### PR TITLE
feat(dead-guard-scan): find guard branches with zero corpus instances — and state, in the artifact, the ~180 guards this cannot see

### DIFF
--- a/scripts/data/dead-guard-census.tsv
+++ b/scripts/data/dead-guard-census.tsv
@@ -1,0 +1,82 @@
+# Measured census of guard branches with zero corpus instances. Regenerate: scripts/dead-guard-scan.py --repo <path> --census <this file>
+# `status` out-of-instrument rows are NOT a clean result -- they are guards this tool cannot see. See scripts/data/dead-guard-registry.tsv.
+repo_slug	status	location	kind	case_handled	corpus_instances	justification
+# innovation-upstream/devrc measured under /home/zach/workspace/civit/datapacket-talos/.venv/bin/python3 (Python 3.12.14)
+innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:143	if-body	sys.path.insert(0, str(_HERE.parent))	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:451	if-body	esc = False	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:453	if-body	esc = True	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:469	if-body	i += 2	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:495	except	return None	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:523	if-body	return []	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/client_host_scan.py:206	except	pass	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/client_host_scan.py:216	if-body	continue	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:73	except	continue	0	— unreadable file
+innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:101	if-body	return True	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:218	except	continue	0	— a broken test file fails elsewhere
+innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:251	except	continue	0	— a broken test file fails elsewhere
+innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:258	if-body	continue	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:289	if-body	continue	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:293	except	continue	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/public_ip_scan.py:211	except	pass  # fall through to the walk	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/public_ip_scan.py:235	if-body	continue	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/skills_mapping.py:119	if-body	return f"nix-instantiate is not on PATH, {_FIX_IT}"	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_clawgate_predicate_single_source.py:133	except	return False	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_clawgate_predicate_single_source.py:252	except	continue	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_clawgate_predicate_single_source.py:254	if-body	offenders[rel] = hits	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_clawgate_predicate_single_source.py:277	if-body	wrong.append("%s: file is gone (expected %d)" % (rel, expected))	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_clawgate_predicate_single_source.py:281	if-body	wrong.append("%s: expected %d, found %d at line(s) %s"	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_clawgate_predicate_single_source.py:313	if-body	offenders.append("%s:%d %s" % (rel, i, line.strip()))	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_clawgate_predicate_single_source.py:375	except	return False	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_clawgate_predicate_single_source.py:489	if-body	return	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_closing_condition_single_source.py:124	except	continue	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_dead_guard_scan.py:43	if-body	if event == "line":  # pragma: no cover - a tracer is not traced by itself	0	a tracer is not traced by itself
+innovation-upstream/devrc	flagged	scripts/tests/test_dead_guard_scan.py:44	if-body	seen.add(frame.f_lineno)  # pragma: no cover - a tracer is not traced by itself	0	a tracer is not traced by itself
+innovation-upstream/devrc	flagged	scripts/tests/test_dead_guard_scan.py:104	if-body	if event == "line":  # pragma: no cover - a tracer is not traced by itself	0	a tracer is not traced by itself
+innovation-upstream/devrc	flagged	scripts/tests/test_dead_guard_scan.py:105	if-body	seen.add(frame.f_lineno)  # pragma: no cover - a tracer is not traced by itself	0	a tracer is not traced by itself
+innovation-upstream/devrc	flagged	scripts/tests/test_doc_path_rot.py:442	if-body	return False	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_doc_path_rot.py:462	if-body	raise AssertionError(	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_doc_path_rot.py:532	if-body	continue	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_handoff_skill_size.py:218	if-body	return f"(none found under {REFERENCE_DIR} -- did reference/ move?)"	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_handoff_skill_size.py:241	if-body	continue	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_handoff_skill_size.py:265	if-body	return (	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_no_conflict_markers.py:142	if-body	raise subprocess.CalledProcessError(128, cmd, output="", stderr="")	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_no_public_ips.py:258	if-body	problems.append(f"{path}: hits but no PENDING_SCRUB entry")	0	covered by the scan
+innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:68	if-body	raise RuntimeError("bash not found on PATH; this suite cannot run hermetically")	0	— both tiers ship bash
+innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:501	if-body	assert not stub.exists(), (	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:520	if-body	assert shutil.which("systemctl") is None, (	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:563	if-body	assert shutil.which("systemctl") is None	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:591	if-body	assert shutil.which("systemctl") is None	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:629	if-body	assert shutil.which("systemctl") is None	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:745	if-body	assert shutil.which("systemctl") is None	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_prune_skill_size.py:479	if-body	problems.append(f"{label}: PATTERN DID NOT MATCH ({pattern!r}) — the "	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_prune_skill_size.py:482	if-body	problems.append(f"{label}: pattern matched {len(found)}x ({found}) — an "	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_prune_skill_size.py:486	if-body	problems.append(f"{label}: prose says {found[0]}, measured {expected}")	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_prune_skill_size.py:521	if-body	problems.append(	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_prune_skill_size.py:529	if-body	problems.append(	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_session_manager_skill_size.py:719	if-body	loops[topic.name] = hits	0	-
+innovation-upstream/devrc	out-of-instrument	-	bash	scripts/drift-check.sh, run-tests.sh, run-node-tests.sh: bash PS4/BASH_XTRACEFD line tracing works but cannot discriminate a single-line `if ...; then X; fi`, so a flag there is not decidable at line granularity	unmeasured	-
+innovation-upstream/devrc	out-of-instrument	-	mjs	skill .mjs guards: no node coverage backend built	unmeasured	-
+# ZacxDev/homelab-infra measured under /home/zach/workspace/civit/datapacket-talos/.venv/bin/python3 (Python 3.12.14)
+ZacxDev/homelab-infra	flagged	scripts/tests/test_catch_ci_preemption.py:26	if-body	raise AssertionError(f"cannot load {_SRC} — the script moved or was renamed")	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:97	if-body	raise AssertionError(	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:114	if-body	raise AssertionError(	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:211	if-body	raise AssertionError(	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:218	if-body	raise AssertionError(	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:632	if-body	raise AssertionError(	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:175	except	raise AssertionError(f"{path.name} is not parseable YAML: {exc}") from exc	0	a broken tree
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:187	if-body	problems.append(	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:202	if-body	problems.append(	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:218	if-body	continue	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:234	if-body	inline.append(path.name)	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:420	if-body	continue  # reported by its own assertion above	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:427	if-body	continue  # reported by its own assertion above	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:475	if-body	continue  # reported by its own assertion above	0	-
+ZacxDev/homelab-infra	out-of-instrument	-	go	~10 *_test.go guards under containers/clawgate: `go test -cover` reports per-package percentages only; no -coverprofile pipeline exists to resolve a single branch	unmeasured	-
+ZacxDev/homelab-infra	out-of-instrument	-	bash	scripts/check-*.sh, kustomize-validate.sh: same bash line-granularity limit	unmeasured	-
+# civitai/talos-infra measured under /home/zach/workspace/civit/datapacket-talos/.venv/bin/python3 (Python 3.12.14)
+civitai/talos-infra	out-of-instrument	-	python	scripts/validate-alert-nodata-state.py, validate-dashboard-metric-seam.py, validate-tekton-build-pool.py, lint-grafana-dashboards.py: these ARE python, but no pytest suite invokes them -- they are called from bash gates. This tool needs a pytest entry point to drive a guard against the corpus, so they are undecidable here, not clean	unmeasured	-
+civitai/talos-infra	out-of-instrument	-	bash	~21 scripts/validate-*.sh plus the 3,576-line scripts/gitops-delta-gate.sh: same bash line-granularity limit as above. These carry 53 tests/mutants-*.sh batteries, which already answer "does this guard fire" by a different and stronger method	unmeasured	-
+civitai/talos-infra	out-of-instrument	-	bash	.githooks/* and .claude/hooks/*.sh: same limit	unmeasured	-
+# civitai/civitai measured under /home/zach/workspace/civit/datapacket-talos/.venv/bin/python3 (Python 3.12.14)
+civitai/civitai	out-of-instrument	-	ts	~63 corpus-scanning *.test.ts guards plus eslint-local-rules.js: vitest v8 coverage exists but its `include` is scoped to src/server/services/** and src/server/jobs/**, which contains none of the lint-rule guards. Widening it is a config change with its own review, not part of this tool	unmeasured	-
+civitai/civitai	out-of-instrument	-	mjs	scripts/ci/*.mjs and .claude/hooks/*.mjs: no node coverage backend built	unmeasured	-

--- a/scripts/data/dead-guard-census.tsv
+++ b/scripts/data/dead-guard-census.tsv
@@ -32,6 +32,35 @@ civitai/talos-infra	out-of-instrument	-	bash	~21 scripts/validate-*.sh plus the 
 civitai/talos-infra	out-of-instrument	-	bash	.githooks/* and .claude/hooks/*.sh: same limit	unmeasured	-
 # innovation-upstream/devrc measured under Python 3.12.14 -- 🔴 RED RUN, 5 test(s) FAILED: branches downstream of a failure did not execute for a reason that is NOT deadness (pytest rc=1)
 innovation-upstream/devrc	flagged	scripts/claude-hooks/tests/test_guard_core.py:2492	if-body	execs.append(argv)	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:66	except	return ""	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:78	if-body	raise SystemExit(f"registry: malformed row (want 4 tab-separated "	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:89	if-body	continue	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:92	if-body	out.append(p)	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:230	if-body	return ({"executed": {}, "clobbered": False}, (0, 0),	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:258	except	return None, (-1, 0), f"traced run timed out after 3600s: {e}"	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:266	if-body	return None, (proc.returncode, nfail), "\n".join(tails)	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:291	except	v = "?"	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:293	if-body	return f"Python {v or '?'}"	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:303	if-body	print(f"could not read origin for {repo} -- cannot key the registry",	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:308	if-body	print(f"{slug} is not in {REGISTRY.name}. Add rows for it -- including "	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:326	if-body	print(f"{slug}: {len(empty)} `instrument` selector(s) matched NO python "	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:338	if-body	print(f"{slug}: 0 instrumentable guards present in this clone; "	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:341	if-body	write_census(census_path, slug, [], oo, [],	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:358	if-body	print(f"{slug}: a test cleared or replaced sys.settrace during the run, "	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:399	except	undecidable.append(f"{rel}: cannot be analysed ({type(e).__name__}: {e})")	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:415	if-body	why = ("no registered test file drives it -- the registry lists "	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:431	if-body	_report(slug, targets, all_flags, unres, oo, undecidable, rc, interp)	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:433	if-body	write_census(census_path, slug, all_flags, oo, undecidable,	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:438	if-body	return EXIT_UNDECIDABLE	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:451	if-body	print(f"   🔴 RED RUN   : {nfail} test(s) FAILED. Branches downstream of "	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:507	if-body	for line in p.read_text(encoding="utf-8").splitlines():	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:509	if-body	continue	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:511	if-body	continue                       # header is re-emitted below	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:530	if-body	note += (f" -- 🔴 RED RUN, {nfail} test(s) FAILED: branches downstream of "	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:589	if-body	if event == "line":	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:590	if-body	executed.add(frame.f_lineno)	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:681	if-body	return self_test()	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:683	if-body	ap.error("give --repo <path>, or --self-test")	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:143	if-body	sys.path.insert(0, str(_HERE.parent))	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:451	if-body	esc = False	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:453	if-body	esc = True	0	-
@@ -74,16 +103,17 @@ innovation-upstream/devrc	flagged	scripts/tests/test_no_public_ips.py:258	if-bod
 innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:68	if-body	raise RuntimeError("bash not found on PATH; this suite cannot run hermetically")	0	— both tiers ship bash
 innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:501	if-body	assert not stub.exists(), (	0	-
 innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:520	if-body	assert shutil.which("systemctl") is None, (	0	-
-innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:563	if-body	assert shutil.which("systemctl") is None	0	-
-innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:591	if-body	assert shutil.which("systemctl") is None	0	-
-innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:629	if-body	assert shutil.which("systemctl") is None	0	-
-innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:745	if-body	assert shutil.which("systemctl") is None	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:582	if-body	assert shutil.which("systemctl") is None	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:610	if-body	assert shutil.which("systemctl") is None	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:648	if-body	assert shutil.which("systemctl") is None	0	-
+innovation-upstream/devrc	flagged	scripts/tests/test_no_real_launchers.py:764	if-body	assert shutil.which("systemctl") is None	0	-
 innovation-upstream/devrc	flagged	scripts/tests/test_prune_skill_size.py:479	if-body	problems.append(f"{label}: PATTERN DID NOT MATCH ({pattern!r}) — the "	0	-
 innovation-upstream/devrc	flagged	scripts/tests/test_prune_skill_size.py:482	if-body	problems.append(f"{label}: pattern matched {len(found)}x ({found}) — an "	0	-
 innovation-upstream/devrc	flagged	scripts/tests/test_prune_skill_size.py:486	if-body	problems.append(f"{label}: prose says {found[0]}, measured {expected}")	0	-
 innovation-upstream/devrc	flagged	scripts/tests/test_prune_skill_size.py:521	if-body	problems.append(	0	-
 innovation-upstream/devrc	flagged	scripts/tests/test_prune_skill_size.py:529	if-body	problems.append(	0	-
 innovation-upstream/devrc	flagged	scripts/tests/test_session_manager_skill_size.py:719	if-body	loops[topic.name] = hits	0	-
+innovation-upstream/devrc	out-of-instrument	-	python	scripts/testlib/dead_guard_plugin.py -- the tracer itself. CPython suppresses tracing inside the trace function, so this module is structurally invisible to its own instrument; every branch would read as dead. The one file that cannot measure itself	unmeasured	-
 innovation-upstream/devrc	out-of-instrument	-	python	scripts/claude-hooks/tests/test_bash_guard.py -- NOT a pytest suite by design; its own docstring says so ("hand-rolled asserts, not pytest-collectable -- the guard calls main() at import time, so it is only ever driven via subprocess"). Registering it as instrumentable produced zero traced lines, which the scan reported UNDECIDABLE rather than publishing 400 lines of false flags against the PreToolUse deny-guard	unmeasured	-
 innovation-upstream/devrc	out-of-instrument	-	python	scripts/browser-bridge/tests -- the exemplar guard (_cli_timeout_violations) lives here, but the suite spawns the real browser CLI with a 300s budget per site, so a traced run is far too slow to be re-derivable; measure it on demand with a narrowed selector	unmeasured	-
 innovation-upstream/devrc	out-of-instrument	-	python	scripts/claude-hooks/tests -- the rest of it: ordinary unit suites for the notify/nudge/capture hooks rather than corpus-scanning guards; the two real guards there ARE instrumented above	unmeasured	-

--- a/scripts/data/dead-guard-census.tsv
+++ b/scripts/data/dead-guard-census.tsv
@@ -6,6 +6,7 @@
 #    reporting branch, or a branch driven through a subprocess. See
 #    scripts/lib/dead_guard.py. Adjudicating them is a human's job.
 repo_slug	status	location	kind	case_handled	corpus_instances	justification
+# innovation-upstream/devrc measured under Python 3.12.14 -- 🔴 RED RUN, 5 test(s) FAILED: branches downstream of a failure did not execute for a reason that is NOT deadness (pytest rc=1)
 innovation-upstream/devrc	flagged	scripts/claude-hooks/tests/test_guard_core.py:2492	if-body	execs.append(argv)	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:143	if-body	sys.path.insert(0, str(_HERE.parent))	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:451	if-body	esc = False	0	-
@@ -15,10 +16,10 @@ innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:495	exce
 innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:523	if-body	return []	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/client_host_scan.py:206	except	pass	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/client_host_scan.py:216	if-body	continue	0	-
-innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:73	except	continue	0	— unreadable file
+innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:73	except	continue	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:101	if-body	return True	0	-
-innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:218	except	continue	0	— a broken test file fails elsewhere
-innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:251	except	continue	0	— a broken test file fails elsewhere
+innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:218	except	continue	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:251	except	continue	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:258	if-body	continue	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:289	if-body	continue	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:293	except	continue	0	-
@@ -67,13 +68,14 @@ innovation-upstream/devrc	out-of-instrument	-	python	scripts/dl-router/tests, sc
 innovation-upstream/devrc	out-of-instrument	-	python	scripts/session-analysis/tests, scripts/session-analysis/session_insight/tests -- NOT SURVEYED for guard content in this pass	unmeasured	-
 innovation-upstream/devrc	out-of-instrument	-	bash	scripts/drift-check.sh, run-tests.sh, run-node-tests.sh: bash PS4/BASH_XTRACEFD line tracing works but cannot discriminate a single-line `if ...; then X; fi`, so a flag there is not decidable at line granularity	unmeasured	-
 innovation-upstream/devrc	out-of-instrument	-	mjs	skill .mjs guards: no node coverage backend built	unmeasured	-
+# ZacxDev/homelab-infra measured under Python 3.12.14 (pytest rc=0)
 ZacxDev/homelab-infra	flagged	scripts/tests/test_catch_ci_preemption.py:26	if-body	raise AssertionError(f"cannot load {_SRC} — the script moved or was renamed")	0	-
 ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:97	if-body	raise AssertionError(	0	-
 ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:114	if-body	raise AssertionError(	0	-
 ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:211	if-body	raise AssertionError(	0	-
 ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:218	if-body	raise AssertionError(	0	-
 ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:632	if-body	raise AssertionError(	0	-
-ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:175	except	raise AssertionError(f"{path.name} is not parseable YAML: {exc}") from exc	0	a broken tree
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:175	except	raise AssertionError(f"{path.name} is not parseable YAML: {exc}") from exc	0	-
 ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:187	if-body	problems.append(	0	-
 ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:202	if-body	problems.append(	0	-
 ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:218	if-body	continue	0	-
@@ -83,6 +85,7 @@ ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invari
 ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:475	if-body	continue  # reported by its own assertion above	0	-
 ZacxDev/homelab-infra	out-of-instrument	-	go	~10 *_test.go guards under containers/clawgate: `go test -cover` reports per-package percentages only; no -coverprofile pipeline exists to resolve a single branch	unmeasured	-
 ZacxDev/homelab-infra	out-of-instrument	-	bash	scripts/check-*.sh, kustomize-validate.sh: same bash line-granularity limit	unmeasured	-
+# civitai/talos-infra measured under Python 3.12.14 (pytest rc=0)
 civitai/talos-infra	out-of-instrument	-	python	scripts/validate-alert-nodata-state.py, validate-dashboard-metric-seam.py, validate-tekton-build-pool.py, lint-grafana-dashboards.py: these ARE python, but no pytest suite invokes them -- they are called from bash gates. This tool needs a pytest entry point to drive a guard against the corpus, so they are undecidable here, not clean	unmeasured	-
 civitai/talos-infra	out-of-instrument	-	bash	~21 scripts/validate-*.sh plus the 3,576-line scripts/gitops-delta-gate.sh: same bash line-granularity limit as above. These carry 53 tests/mutants-*.sh batteries, which already answer "does this guard fire" by a different and stronger method	unmeasured	-
 civitai/talos-infra	out-of-instrument	-	bash	.githooks/* and .claude/hooks/*.sh: same limit	unmeasured	-

--- a/scripts/data/dead-guard-census.tsv
+++ b/scripts/data/dead-guard-census.tsv
@@ -36,31 +36,31 @@ innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:66	except	return ""
 innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:78	if-body	raise SystemExit(f"registry: malformed row (want 4 tab-separated "	0	-
 innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:89	if-body	continue	0	-
 innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:92	if-body	out.append(p)	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:230	if-body	return ({"executed": {}, "clobbered": False}, (0, 0),	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:258	except	return None, (-1, 0), f"traced run timed out after 3600s: {e}"	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:266	if-body	return None, (proc.returncode, nfail), "\n".join(tails)	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:291	except	v = "?"	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:293	if-body	return f"Python {v or '?'}"	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:303	if-body	print(f"could not read origin for {repo} -- cannot key the registry",	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:308	if-body	print(f"{slug} is not in {REGISTRY.name}. Add rows for it -- including "	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:326	if-body	print(f"{slug}: {len(empty)} `instrument` selector(s) matched NO python "	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:338	if-body	print(f"{slug}: 0 instrumentable guards present in this clone; "	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:341	if-body	write_census(census_path, slug, [], oo, [],	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:358	if-body	print(f"{slug}: a test cleared or replaced sys.settrace during the run, "	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:399	except	undecidable.append(f"{rel}: cannot be analysed ({type(e).__name__}: {e})")	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:415	if-body	why = ("no registered test file drives it -- the registry lists "	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:431	if-body	_report(slug, targets, all_flags, unres, oo, undecidable, rc, interp)	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:433	if-body	write_census(census_path, slug, all_flags, oo, undecidable,	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:438	if-body	return EXIT_UNDECIDABLE	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:451	if-body	print(f"   🔴 RED RUN   : {nfail} test(s) FAILED. Branches downstream of "	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:507	if-body	for line in p.read_text(encoding="utf-8").splitlines():	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:509	if-body	continue	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:511	if-body	continue                       # header is re-emitted below	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:530	if-body	note += (f" -- 🔴 RED RUN, {nfail} test(s) FAILED: branches downstream of "	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:589	if-body	if event == "line":	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:590	if-body	executed.add(frame.f_lineno)	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:681	if-body	return self_test()	0	-
-innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:683	if-body	ap.error("give --repo <path>, or --self-test")	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:236	if-body	return ({"executed": {}, "clobbered": False}, (0, 0),	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:264	except	return None, (-1, 0), f"traced run timed out after 3600s: {e}"	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:272	if-body	return None, (proc.returncode, nfail), "\n".join(tails)	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:297	except	v = "?"	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:299	if-body	return f"Python {v or '?'}"	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:309	if-body	print(f"could not read origin for {repo} -- cannot key the registry",	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:314	if-body	print(f"{slug} is not in {REGISTRY.name}. Add rows for it -- including "	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:332	if-body	print(f"{slug}: {len(empty)} `instrument` selector(s) matched NO python "	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:344	if-body	print(f"{slug}: 0 instrumentable guards present in this clone; "	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:347	if-body	write_census(census_path, slug, [], oo, [],	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:364	if-body	print(f"{slug}: a test cleared or replaced sys.settrace during the run, "	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:406	except	undecidable.append(f"{rel}: cannot be analysed ({type(e).__name__}: {e})")	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:422	if-body	why = ("no registered test file drives it -- the registry lists "	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:438	if-body	_report(slug, targets, all_flags, unres, oo, undecidable, rc, interp)	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:440	if-body	write_census(census_path, slug, all_flags, oo, undecidable,	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:445	if-body	return EXIT_UNDECIDABLE	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:458	if-body	print(f"   🔴 RED RUN   : {nfail} test(s) FAILED. Branches downstream of "	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:514	if-body	for line in p.read_text(encoding="utf-8").splitlines():	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:516	if-body	continue	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:518	if-body	continue                       # header is re-emitted below	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:537	if-body	note += (f" -- 🔴 RED RUN, {nfail} test(s) FAILED: branches downstream of "	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:596	if-body	if event == "line":	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:597	if-body	executed.add(frame.f_lineno)	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:688	if-body	return self_test()	0	-
+innovation-upstream/devrc	flagged	scripts/dead-guard-scan.py:690	if-body	ap.error("give --repo <path>, or --self-test")	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:143	if-body	sys.path.insert(0, str(_HERE.parent))	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:451	if-body	esc = False	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:453	if-body	esc = True	0	-

--- a/scripts/data/dead-guard-census.tsv
+++ b/scripts/data/dead-guard-census.tsv
@@ -1,7 +1,12 @@
-# Measured census of guard branches with zero corpus instances. Regenerate: scripts/dead-guard-scan.py --repo <path> --census <this file>
-# `status` out-of-instrument rows are NOT a clean result -- they are guards this tool cannot see. See scripts/data/dead-guard-registry.tsv.
+# Measured census of guard branches with zero corpus instances.
+# Regenerate, per repo: scripts/dead-guard-scan.py --repo <path> --census <this file>
+# 🔴 out-of-instrument rows are NOT a clean result -- they are guards this tool
+#    CANNOT see. A repo's absence from this file is not evidence about it.
+# 🔴 A flag has THREE readings and only two are defects: dead code, an untested
+#    reporting branch, or a branch driven through a subprocess. See
+#    scripts/lib/dead_guard.py. Adjudicating them is a human's job.
 repo_slug	status	location	kind	case_handled	corpus_instances	justification
-# innovation-upstream/devrc measured under /home/zach/workspace/civit/datapacket-talos/.venv/bin/python3 (Python 3.12.14)
+innovation-upstream/devrc	flagged	scripts/claude-hooks/tests/test_guard_core.py:2492	if-body	execs.append(argv)	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:143	if-body	sys.path.insert(0, str(_HERE.parent))	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:451	if-body	esc = False	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:453	if-body	esc = True	0	-
@@ -29,10 +34,10 @@ innovation-upstream/devrc	flagged	scripts/tests/test_clawgate_predicate_single_s
 innovation-upstream/devrc	flagged	scripts/tests/test_clawgate_predicate_single_source.py:375	except	return False	0	-
 innovation-upstream/devrc	flagged	scripts/tests/test_clawgate_predicate_single_source.py:489	if-body	return	0	-
 innovation-upstream/devrc	flagged	scripts/tests/test_closing_condition_single_source.py:124	except	continue	0	-
-innovation-upstream/devrc	flagged	scripts/tests/test_dead_guard_scan.py:43	if-body	if event == "line":  # pragma: no cover - a tracer is not traced by itself	0	a tracer is not traced by itself
-innovation-upstream/devrc	flagged	scripts/tests/test_dead_guard_scan.py:44	if-body	seen.add(frame.f_lineno)  # pragma: no cover - a tracer is not traced by itself	0	a tracer is not traced by itself
-innovation-upstream/devrc	flagged	scripts/tests/test_dead_guard_scan.py:104	if-body	if event == "line":  # pragma: no cover - a tracer is not traced by itself	0	a tracer is not traced by itself
-innovation-upstream/devrc	flagged	scripts/tests/test_dead_guard_scan.py:105	if-body	seen.add(frame.f_lineno)  # pragma: no cover - a tracer is not traced by itself	0	a tracer is not traced by itself
+innovation-upstream/devrc	flagged	scripts/tests/test_dead_guard_scan.py:44	if-body	if event == "line":  # pragma: no cover - a tracer is not traced by itself	0	a tracer is not traced by itself
+innovation-upstream/devrc	flagged	scripts/tests/test_dead_guard_scan.py:45	if-body	seen.add(frame.f_lineno)  # pragma: no cover - a tracer is not traced by itself	0	a tracer is not traced by itself
+innovation-upstream/devrc	flagged	scripts/tests/test_dead_guard_scan.py:112	if-body	if event == "line":  # pragma: no cover - a tracer is not traced by itself	0	a tracer is not traced by itself
+innovation-upstream/devrc	flagged	scripts/tests/test_dead_guard_scan.py:113	if-body	seen.add(frame.f_lineno)  # pragma: no cover - a tracer is not traced by itself	0	a tracer is not traced by itself
 innovation-upstream/devrc	flagged	scripts/tests/test_doc_path_rot.py:442	if-body	return False	0	-
 innovation-upstream/devrc	flagged	scripts/tests/test_doc_path_rot.py:462	if-body	raise AssertionError(	0	-
 innovation-upstream/devrc	flagged	scripts/tests/test_doc_path_rot.py:532	if-body	continue	0	-
@@ -54,9 +59,14 @@ innovation-upstream/devrc	flagged	scripts/tests/test_prune_skill_size.py:486	if-
 innovation-upstream/devrc	flagged	scripts/tests/test_prune_skill_size.py:521	if-body	problems.append(	0	-
 innovation-upstream/devrc	flagged	scripts/tests/test_prune_skill_size.py:529	if-body	problems.append(	0	-
 innovation-upstream/devrc	flagged	scripts/tests/test_session_manager_skill_size.py:719	if-body	loops[topic.name] = hits	0	-
+innovation-upstream/devrc	out-of-instrument	-	python	scripts/claude-hooks/tests/test_bash_guard.py -- NOT a pytest suite by design; its own docstring says so ("hand-rolled asserts, not pytest-collectable -- the guard calls main() at import time, so it is only ever driven via subprocess"). Registering it as instrumentable produced zero traced lines, which the scan reported UNDECIDABLE rather than publishing 400 lines of false flags against the PreToolUse deny-guard	unmeasured	-
+innovation-upstream/devrc	out-of-instrument	-	python	scripts/browser-bridge/tests -- the exemplar guard (_cli_timeout_violations) lives here, but the suite spawns the real browser CLI with a 300s budget per site, so a traced run is far too slow to be re-derivable; measure it on demand with a narrowed selector	unmeasured	-
+innovation-upstream/devrc	out-of-instrument	-	python	scripts/claude-hooks/tests -- the rest of it: ordinary unit suites for the notify/nudge/capture hooks rather than corpus-scanning guards; the two real guards there ARE instrumented above	unmeasured	-
+innovation-upstream/devrc	out-of-instrument	-	python	scripts/check-clickup-addressed/tests, scripts/collector/tests, scripts/collector/browser-ext/tests, scripts/collector/claude/tests, scripts/collector/i3/tests, scripts/collector/keylog/tests, scripts/collector/opencode/tests -- NOT SURVEYED for guard content in this pass. Recorded as unlooked-at rather than omitted; saying so is the point of this row	unmeasured	-
+innovation-upstream/devrc	out-of-instrument	-	python	scripts/dl-router/tests, scripts/initiatives/tests, scripts/mail-actions/tests, scripts/opencode/tests, scripts/repo-cos/tests, scripts/signal/tests, scripts/task-spec-drafter/tests, scripts/validation/tests -- NOT SURVEYED for guard content in this pass; repo-cos/prescan.py and signal/tests/mutation_battery.py are known candidates for a later round	unmeasured	-
+innovation-upstream/devrc	out-of-instrument	-	python	scripts/session-analysis/tests, scripts/session-analysis/session_insight/tests -- NOT SURVEYED for guard content in this pass	unmeasured	-
 innovation-upstream/devrc	out-of-instrument	-	bash	scripts/drift-check.sh, run-tests.sh, run-node-tests.sh: bash PS4/BASH_XTRACEFD line tracing works but cannot discriminate a single-line `if ...; then X; fi`, so a flag there is not decidable at line granularity	unmeasured	-
 innovation-upstream/devrc	out-of-instrument	-	mjs	skill .mjs guards: no node coverage backend built	unmeasured	-
-# ZacxDev/homelab-infra measured under /home/zach/workspace/civit/datapacket-talos/.venv/bin/python3 (Python 3.12.14)
 ZacxDev/homelab-infra	flagged	scripts/tests/test_catch_ci_preemption.py:26	if-body	raise AssertionError(f"cannot load {_SRC} — the script moved or was renamed")	0	-
 ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:97	if-body	raise AssertionError(	0	-
 ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:114	if-body	raise AssertionError(	0	-
@@ -73,10 +83,9 @@ ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invari
 ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:475	if-body	continue  # reported by its own assertion above	0	-
 ZacxDev/homelab-infra	out-of-instrument	-	go	~10 *_test.go guards under containers/clawgate: `go test -cover` reports per-package percentages only; no -coverprofile pipeline exists to resolve a single branch	unmeasured	-
 ZacxDev/homelab-infra	out-of-instrument	-	bash	scripts/check-*.sh, kustomize-validate.sh: same bash line-granularity limit	unmeasured	-
-# civitai/talos-infra measured under /home/zach/workspace/civit/datapacket-talos/.venv/bin/python3 (Python 3.12.14)
 civitai/talos-infra	out-of-instrument	-	python	scripts/validate-alert-nodata-state.py, validate-dashboard-metric-seam.py, validate-tekton-build-pool.py, lint-grafana-dashboards.py: these ARE python, but no pytest suite invokes them -- they are called from bash gates. This tool needs a pytest entry point to drive a guard against the corpus, so they are undecidable here, not clean	unmeasured	-
 civitai/talos-infra	out-of-instrument	-	bash	~21 scripts/validate-*.sh plus the 3,576-line scripts/gitops-delta-gate.sh: same bash line-granularity limit as above. These carry 53 tests/mutants-*.sh batteries, which already answer "does this guard fire" by a different and stronger method	unmeasured	-
 civitai/talos-infra	out-of-instrument	-	bash	.githooks/* and .claude/hooks/*.sh: same limit	unmeasured	-
-# civitai/civitai measured under /home/zach/workspace/civit/datapacket-talos/.venv/bin/python3 (Python 3.12.14)
+# civitai/civitai measured under Python 3.12.14 (pytest rc=0)
 civitai/civitai	out-of-instrument	-	ts	~63 corpus-scanning *.test.ts guards plus eslint-local-rules.js: vitest v8 coverage exists but its `include` is scoped to src/server/services/** and src/server/jobs/**, which contains none of the lint-rule guards. Widening it is a config change with its own review, not part of this tool	unmeasured	-
 civitai/civitai	out-of-instrument	-	mjs	scripts/ci/*.mjs and .claude/hooks/*.mjs: no node coverage backend built	unmeasured	-

--- a/scripts/data/dead-guard-census.tsv
+++ b/scripts/data/dead-guard-census.tsv
@@ -6,6 +6,30 @@
 #    reporting branch, or a branch driven through a subprocess. See
 #    scripts/lib/dead_guard.py. Adjudicating them is a human's job.
 repo_slug	status	location	kind	case_handled	corpus_instances	justification
+# ZacxDev/homelab-infra measured under Python 3.12.14 (pytest rc=0)
+ZacxDev/homelab-infra	flagged	scripts/tests/test_catch_ci_preemption.py:26	if-body	raise AssertionError(f"cannot load {_SRC} — the script moved or was renamed")	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:97	if-body	raise AssertionError(	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:114	if-body	raise AssertionError(	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:211	if-body	raise AssertionError(	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:218	if-body	raise AssertionError(	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:632	if-body	raise AssertionError(	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:175	except	raise AssertionError(f"{path.name} is not parseable YAML: {exc}") from exc	0	a broken tree
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:187	if-body	problems.append(	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:202	if-body	problems.append(	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:218	if-body	continue	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:234	if-body	inline.append(path.name)	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:420	if-body	continue  # reported by its own assertion above	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:427	if-body	continue  # reported by its own assertion above	0	-
+ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:475	if-body	continue  # reported by its own assertion above	0	-
+ZacxDev/homelab-infra	out-of-instrument	-	go	~10 *_test.go guards under containers/clawgate: `go test -cover` reports per-package percentages only; no -coverprofile pipeline exists to resolve a single branch	unmeasured	-
+ZacxDev/homelab-infra	out-of-instrument	-	bash	scripts/check-*.sh, kustomize-validate.sh: same bash line-granularity limit	unmeasured	-
+# civitai/civitai measured under Python 3.12.14 (pytest rc=0)
+civitai/civitai	out-of-instrument	-	ts	~63 corpus-scanning *.test.ts guards plus eslint-local-rules.js: vitest v8 coverage exists but its `include` is scoped to src/server/services/** and src/server/jobs/**, which contains none of the lint-rule guards. Widening it is a config change with its own review, not part of this tool	unmeasured	-
+civitai/civitai	out-of-instrument	-	mjs	scripts/ci/*.mjs and .claude/hooks/*.mjs: no node coverage backend built	unmeasured	-
+# civitai/talos-infra measured under Python 3.12.14 (pytest rc=0)
+civitai/talos-infra	out-of-instrument	-	python	scripts/validate-alert-nodata-state.py, validate-dashboard-metric-seam.py, validate-tekton-build-pool.py, lint-grafana-dashboards.py: these ARE python, but no pytest suite invokes them -- they are called from bash gates. This tool needs a pytest entry point to drive a guard against the corpus, so they are undecidable here, not clean	unmeasured	-
+civitai/talos-infra	out-of-instrument	-	bash	~21 scripts/validate-*.sh plus the 3,576-line scripts/gitops-delta-gate.sh: same bash line-granularity limit as above. These carry 53 tests/mutants-*.sh batteries, which already answer "does this guard fire" by a different and stronger method	unmeasured	-
+civitai/talos-infra	out-of-instrument	-	bash	.githooks/* and .claude/hooks/*.sh: same limit	unmeasured	-
 # innovation-upstream/devrc measured under Python 3.12.14 -- 🔴 RED RUN, 5 test(s) FAILED: branches downstream of a failure did not execute for a reason that is NOT deadness (pytest rc=1)
 innovation-upstream/devrc	flagged	scripts/claude-hooks/tests/test_guard_core.py:2492	if-body	execs.append(argv)	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:143	if-body	sys.path.insert(0, str(_HERE.parent))	0	-
@@ -16,10 +40,10 @@ innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:495	exce
 innovation-upstream/devrc	flagged	scripts/testlib/captured_text_scan.py:523	if-body	return []	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/client_host_scan.py:206	except	pass	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/client_host_scan.py:216	if-body	continue	0	-
-innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:73	except	continue	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:73	except	continue	0	— unreadable file
 innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:101	if-body	return True	0	-
-innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:218	except	continue	0	-
-innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:251	except	continue	0	-
+innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:218	except	continue	0	— a broken test file fails elsewhere
+innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:251	except	continue	0	— a broken test file fails elsewhere
 innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:258	if-body	continue	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:289	if-body	continue	0	-
 innovation-upstream/devrc	flagged	scripts/testlib/launcher_scan.py:293	except	continue	0	-
@@ -68,27 +92,3 @@ innovation-upstream/devrc	out-of-instrument	-	python	scripts/dl-router/tests, sc
 innovation-upstream/devrc	out-of-instrument	-	python	scripts/session-analysis/tests, scripts/session-analysis/session_insight/tests -- NOT SURVEYED for guard content in this pass	unmeasured	-
 innovation-upstream/devrc	out-of-instrument	-	bash	scripts/drift-check.sh, run-tests.sh, run-node-tests.sh: bash PS4/BASH_XTRACEFD line tracing works but cannot discriminate a single-line `if ...; then X; fi`, so a flag there is not decidable at line granularity	unmeasured	-
 innovation-upstream/devrc	out-of-instrument	-	mjs	skill .mjs guards: no node coverage backend built	unmeasured	-
-# ZacxDev/homelab-infra measured under Python 3.12.14 (pytest rc=0)
-ZacxDev/homelab-infra	flagged	scripts/tests/test_catch_ci_preemption.py:26	if-body	raise AssertionError(f"cannot load {_SRC} — the script moved or was renamed")	0	-
-ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:97	if-body	raise AssertionError(	0	-
-ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:114	if-body	raise AssertionError(	0	-
-ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:211	if-body	raise AssertionError(	0	-
-ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:218	if-body	raise AssertionError(	0	-
-ZacxDev/homelab-infra	flagged	scripts/tests/test_devrc_ci_names_the_failing_test.py:632	if-body	raise AssertionError(	0	-
-ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:175	except	raise AssertionError(f"{path.name} is not parseable YAML: {exc}") from exc	0	-
-ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:187	if-body	problems.append(	0	-
-ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:202	if-body	problems.append(	0	-
-ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:218	if-body	continue	0	-
-ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:234	if-body	inline.append(path.name)	0	-
-ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:420	if-body	continue  # reported by its own assertion above	0	-
-ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:427	if-body	continue  # reported by its own assertion above	0	-
-ZacxDev/homelab-infra	flagged	scripts/tests/test_finally_reporter_timeout_invariant.py:475	if-body	continue  # reported by its own assertion above	0	-
-ZacxDev/homelab-infra	out-of-instrument	-	go	~10 *_test.go guards under containers/clawgate: `go test -cover` reports per-package percentages only; no -coverprofile pipeline exists to resolve a single branch	unmeasured	-
-ZacxDev/homelab-infra	out-of-instrument	-	bash	scripts/check-*.sh, kustomize-validate.sh: same bash line-granularity limit	unmeasured	-
-# civitai/talos-infra measured under Python 3.12.14 (pytest rc=0)
-civitai/talos-infra	out-of-instrument	-	python	scripts/validate-alert-nodata-state.py, validate-dashboard-metric-seam.py, validate-tekton-build-pool.py, lint-grafana-dashboards.py: these ARE python, but no pytest suite invokes them -- they are called from bash gates. This tool needs a pytest entry point to drive a guard against the corpus, so they are undecidable here, not clean	unmeasured	-
-civitai/talos-infra	out-of-instrument	-	bash	~21 scripts/validate-*.sh plus the 3,576-line scripts/gitops-delta-gate.sh: same bash line-granularity limit as above. These carry 53 tests/mutants-*.sh batteries, which already answer "does this guard fire" by a different and stronger method	unmeasured	-
-civitai/talos-infra	out-of-instrument	-	bash	.githooks/* and .claude/hooks/*.sh: same limit	unmeasured	-
-# civitai/civitai measured under Python 3.12.14 (pytest rc=0)
-civitai/civitai	out-of-instrument	-	ts	~63 corpus-scanning *.test.ts guards plus eslint-local-rules.js: vitest v8 coverage exists but its `include` is scoped to src/server/services/** and src/server/jobs/**, which contains none of the lint-rule guards. Widening it is a config change with its own review, not part of this tool	unmeasured	-
-civitai/civitai	out-of-instrument	-	mjs	scripts/ci/*.mjs and .claude/hooks/*.mjs: no node coverage backend built	unmeasured	-

--- a/scripts/data/dead-guard-registry.tsv
+++ b/scripts/data/dead-guard-registry.tsv
@@ -38,8 +38,16 @@ innovation-upstream/devrc	python	instrument	scripts/claude-hooks/tests/test_guar
 innovation-upstream/devrc	python	out-of-instrument	scripts/claude-hooks/tests/test_bash_guard.py -- NOT a pytest suite by design; its own docstring says so ("hand-rolled asserts, not pytest-collectable -- the guard calls main() at import time, so it is only ever driven via subprocess"). Registering it as instrumentable produced zero traced lines, which the scan reported UNDECIDABLE rather than publishing 400 lines of false flags against the PreToolUse deny-guard
 # Every OTHER directory in this repo holding test_*.py, listed so its absence
 # cannot read as coverage. `test_registry_names_every_test_directory_in_devrc`
-# enforces this list bidirectionally: a new test directory with no row here
-# fails, and a row naming a directory that no longer exists fails.
+# enforces this list in ONE direction: a new test directory with no row here
+# FAILS, so the surface cannot silently grow.
+# 🔴 It does NOT fail on a row naming a directory that no longer exists -- the
+# out-of-instrument column is prose, so a stale path cannot be told from an
+# explanatory sentence. An earlier version of this comment claimed the check
+# was "bidirectional"; it was not, and a planted
+# `scripts/THIS-WAS-DELETED/tests` row passed. That was the
+# description-wider-than-implementation defect this whole file is about,
+# recurring inside its own fix. `instrument` rows ARE checked the other way:
+# a selector matching no file makes the entire scan UNDECIDABLE.
 innovation-upstream/devrc	python	out-of-instrument	scripts/browser-bridge/tests -- the exemplar guard (_cli_timeout_violations) lives here, but the suite spawns the real browser CLI with a 300s budget per site, so a traced run is far too slow to be re-derivable; measure it on demand with a narrowed selector
 innovation-upstream/devrc	python	out-of-instrument	scripts/claude-hooks/tests -- the rest of it: ordinary unit suites for the notify/nudge/capture hooks rather than corpus-scanning guards; the two real guards there ARE instrumented above
 innovation-upstream/devrc	python	out-of-instrument	scripts/check-clickup-addressed/tests, scripts/collector/tests, scripts/collector/browser-ext/tests, scripts/collector/claude/tests, scripts/collector/i3/tests, scripts/collector/keylog/tests, scripts/collector/opencode/tests -- NOT SURVEYED for guard content in this pass. Recorded as unlooked-at rather than omitted; saying so is the point of this row

--- a/scripts/data/dead-guard-registry.tsv
+++ b/scripts/data/dead-guard-registry.tsv
@@ -1,0 +1,49 @@
+# Which guards `scripts/dead-guard-scan.py` measures, and which it CANNOT.
+#
+# Keyed on the git REMOTE SLUG, never the clone directory name: two of the four
+# clones are named nothing like their repo (`datapacket-talos` -> civitai/talos-infra,
+# `homelab-talos` -> ZacxDev/homelab-infra), so a basename key silently matches the
+# wrong profile or none at all.
+#
+# 🔴 THE `out-of-instrument` ROWS ARE THE POINT, NOT PADDING. A guard absent from
+# this file would read as "measured and clean". These rows say, in the artifact
+# itself, which ~180 of the ~270 guards this tool does not see and why. Removing a
+# row does not extend coverage; it only hides the gap.
+#
+# 🔴 THE `instrument` SELECTORS NAME CORPUS-SCANNING GUARDS, NOT "the test
+# suite". An earlier draft selected all ~110 `scripts/tests/test_*.py`; that
+# instrumented ordinary unit tests, whose untaken branches are not the defect
+# this tool looks for, and the traced run had not finished after 35 minutes.
+# Narrow selectors are what make the flag list readable AND the run affordable.
+#
+# status:
+#   instrument         -- traced; branch bodies with no executed line are flagged
+#   out-of-instrument  -- NOT measured; the selector column states why
+#
+# repo_slug<TAB>lang<TAB>status<TAB>selector_or_reason
+
+innovation-upstream/devrc	python	instrument	scripts/testlib/*_scan.py
+innovation-upstream/devrc	python	instrument	scripts/testlib/skip_dirs.py
+innovation-upstream/devrc	python	instrument	scripts/testlib/skills_mapping.py
+innovation-upstream/devrc	python	instrument	scripts/tests/test_no_*.py
+innovation-upstream/devrc	python	instrument	scripts/tests/test_doc_path_rot.py
+innovation-upstream/devrc	python	instrument	scripts/tests/test_runtime_shebangs.py
+innovation-upstream/devrc	python	instrument	scripts/tests/test_skip_dirs_ledger.py
+innovation-upstream/devrc	python	instrument	scripts/tests/test_skills_mapping_guard.py
+innovation-upstream/devrc	python	instrument	scripts/tests/test_conditional_skip_pins.py
+innovation-upstream/devrc	python	instrument	scripts/tests/test_*_single_source.py
+innovation-upstream/devrc	python	instrument	scripts/tests/test_*skill_size.py
+innovation-upstream/devrc	python	instrument	scripts/tests/test_dead_guard_scan.py
+innovation-upstream/devrc	bash	out-of-instrument	scripts/drift-check.sh, run-tests.sh, run-node-tests.sh: bash PS4/BASH_XTRACEFD line tracing works but cannot discriminate a single-line `if ...; then X; fi`, so a flag there is not decidable at line granularity
+innovation-upstream/devrc	mjs	out-of-instrument	skill .mjs guards: no node coverage backend built
+
+civitai/talos-infra	python	out-of-instrument	scripts/validate-alert-nodata-state.py, validate-dashboard-metric-seam.py, validate-tekton-build-pool.py, lint-grafana-dashboards.py: these ARE python, but no pytest suite invokes them -- they are called from bash gates. This tool needs a pytest entry point to drive a guard against the corpus, so they are undecidable here, not clean
+civitai/talos-infra	bash	out-of-instrument	~21 scripts/validate-*.sh plus the 3,576-line scripts/gitops-delta-gate.sh: same bash line-granularity limit as above. These carry 53 tests/mutants-*.sh batteries, which already answer "does this guard fire" by a different and stronger method
+civitai/talos-infra	bash	out-of-instrument	.githooks/* and .claude/hooks/*.sh: same limit
+
+civitai/civitai	ts	out-of-instrument	~63 corpus-scanning *.test.ts guards plus eslint-local-rules.js: vitest v8 coverage exists but its `include` is scoped to src/server/services/** and src/server/jobs/**, which contains none of the lint-rule guards. Widening it is a config change with its own review, not part of this tool
+civitai/civitai	mjs	out-of-instrument	scripts/ci/*.mjs and .claude/hooks/*.mjs: no node coverage backend built
+
+ZacxDev/homelab-infra	python	instrument	scripts/tests/test_*.py
+ZacxDev/homelab-infra	go	out-of-instrument	~10 *_test.go guards under containers/clawgate: `go test -cover` reports per-package percentages only; no -coverprofile pipeline exists to resolve a single branch
+ZacxDev/homelab-infra	bash	out-of-instrument	scripts/check-*.sh, kustomize-validate.sh: same bash line-granularity limit

--- a/scripts/data/dead-guard-registry.tsv
+++ b/scripts/data/dead-guard-registry.tsv
@@ -34,6 +34,17 @@ innovation-upstream/devrc	python	instrument	scripts/tests/test_conditional_skip_
 innovation-upstream/devrc	python	instrument	scripts/tests/test_*_single_source.py
 innovation-upstream/devrc	python	instrument	scripts/tests/test_*skill_size.py
 innovation-upstream/devrc	python	instrument	scripts/tests/test_dead_guard_scan.py
+innovation-upstream/devrc	python	instrument	scripts/claude-hooks/tests/test_guard_core.py
+innovation-upstream/devrc	python	out-of-instrument	scripts/claude-hooks/tests/test_bash_guard.py -- NOT a pytest suite by design; its own docstring says so ("hand-rolled asserts, not pytest-collectable -- the guard calls main() at import time, so it is only ever driven via subprocess"). Registering it as instrumentable produced zero traced lines, which the scan reported UNDECIDABLE rather than publishing 400 lines of false flags against the PreToolUse deny-guard
+# Every OTHER directory in this repo holding test_*.py, listed so its absence
+# cannot read as coverage. `test_registry_names_every_test_directory_in_devrc`
+# enforces this list bidirectionally: a new test directory with no row here
+# fails, and a row naming a directory that no longer exists fails.
+innovation-upstream/devrc	python	out-of-instrument	scripts/browser-bridge/tests -- the exemplar guard (_cli_timeout_violations) lives here, but the suite spawns the real browser CLI with a 300s budget per site, so a traced run is far too slow to be re-derivable; measure it on demand with a narrowed selector
+innovation-upstream/devrc	python	out-of-instrument	scripts/claude-hooks/tests -- the rest of it: ordinary unit suites for the notify/nudge/capture hooks rather than corpus-scanning guards; the two real guards there ARE instrumented above
+innovation-upstream/devrc	python	out-of-instrument	scripts/check-clickup-addressed/tests, scripts/collector/tests, scripts/collector/browser-ext/tests, scripts/collector/claude/tests, scripts/collector/i3/tests, scripts/collector/keylog/tests, scripts/collector/opencode/tests -- NOT SURVEYED for guard content in this pass. Recorded as unlooked-at rather than omitted; saying so is the point of this row
+innovation-upstream/devrc	python	out-of-instrument	scripts/dl-router/tests, scripts/initiatives/tests, scripts/mail-actions/tests, scripts/opencode/tests, scripts/repo-cos/tests, scripts/signal/tests, scripts/task-spec-drafter/tests, scripts/validation/tests -- NOT SURVEYED for guard content in this pass; repo-cos/prescan.py and signal/tests/mutation_battery.py are known candidates for a later round
+innovation-upstream/devrc	python	out-of-instrument	scripts/session-analysis/tests, scripts/session-analysis/session_insight/tests -- NOT SURVEYED for guard content in this pass
 innovation-upstream/devrc	bash	out-of-instrument	scripts/drift-check.sh, run-tests.sh, run-node-tests.sh: bash PS4/BASH_XTRACEFD line tracing works but cannot discriminate a single-line `if ...; then X; fi`, so a flag there is not decidable at line granularity
 innovation-upstream/devrc	mjs	out-of-instrument	skill .mjs guards: no node coverage backend built
 

--- a/scripts/data/dead-guard-registry.tsv
+++ b/scripts/data/dead-guard-registry.tsv
@@ -34,6 +34,15 @@ innovation-upstream/devrc	python	instrument	scripts/tests/test_conditional_skip_
 innovation-upstream/devrc	python	instrument	scripts/tests/test_*_single_source.py
 innovation-upstream/devrc	python	instrument	scripts/tests/test_*skill_size.py
 innovation-upstream/devrc	python	instrument	scripts/tests/test_dead_guard_scan.py
+# 🔴 THE SCANNER'S OWN MODULES. They were absent from BOTH statuses for three
+# rounds -- the one surface this file's headline ("a guard absent from this file
+# would read as measured and clean") applies to most sharply, and the reason a
+# brand-new unexercised branch in dead-guard-scan.py was invisible to the tool
+# that finds unexercised branches. `unregistered_test_dirs` could not catch it:
+# it ledgers test DIRECTORIES, and these are library modules.
+innovation-upstream/devrc	python	instrument	scripts/lib/dead_guard.py
+innovation-upstream/devrc	python	instrument	scripts/dead-guard-scan.py
+innovation-upstream/devrc	python	out-of-instrument	scripts/testlib/dead_guard_plugin.py -- the tracer itself. CPython suppresses tracing inside the trace function, so this module is structurally invisible to its own instrument; every branch would read as dead. The one file that cannot measure itself
 innovation-upstream/devrc	python	instrument	scripts/claude-hooks/tests/test_guard_core.py
 innovation-upstream/devrc	python	out-of-instrument	scripts/claude-hooks/tests/test_bash_guard.py -- NOT a pytest suite by design; its own docstring says so ("hand-rolled asserts, not pytest-collectable -- the guard calls main() at import time, so it is only ever driven via subprocess"). Registering it as instrumentable produced zero traced lines, which the scan reported UNDECIDABLE rather than publishing 400 lines of false flags against the PreToolUse deny-guard
 # Every OTHER directory in this repo holding test_*.py, listed so its absence

--- a/scripts/dead-guard-scan.py
+++ b/scripts/dead-guard-scan.py
@@ -136,9 +136,46 @@ def unregistered_test_dirs(repo, rows, slug):
     Mechanical, not heuristic: it does not try to decide what a "guard" is. It
     requires a DECISION to have been recorded for every directory that holds
     tests -- which is the homelab-infra `ci-manifest.txt` pattern.
+
+    🔴 FORWARD DIRECTION ONLY, and the docs used to claim otherwise. A NEW test
+    directory with no row fails, so the surface cannot silently GROW. A row
+    naming a directory that no longer exists does NOT fail: the out-of-
+    instrument column is prose, so there is no reliable way to tell a stale
+    path from an explanatory sentence. Saying "bidirectional" here was the
+    description-wider-than-implementation defect recurring inside its own fix.
+    (`instrument` rows ARE checked in the other direction -- a selector that
+    matches no file makes the whole scan UNDECIDABLE.)
+
+    🔴 MATCHED ON PATH SEGMENTS, NOT SUBSTRINGS. A plain `d in text` test
+    accepted `scripts/mail`, `scripts/collector`, `scripts/dl-router/test` and
+    even `"s"` as "registered", because each is a substring of some row -- so a
+    future directory that happens to be a path PREFIX of a registered one would
+    be silently accepted, which is the silent "everything is registered" this
+    function exists to prevent.
     """
     mine = [r for r in rows if r["slug"] == slug]
-    named = " ".join(r["selector"] for r in mine)
+    named = set()
+    for r in mine:
+        for tok in re.split(r"[,\s]+", r["selector"]):
+            tok = tok.strip().rstrip(",;")
+            if not tok or tok.startswith("-"):
+                continue
+            named.add(tok)
+            # A selector naming a FILE or glob (`.../test_*.py`) also registers
+            # the directory holding it -- that is the directory the ledger is
+            # about. A selector naming a DIRECTORY registers only itself: it
+            # must NOT register its parent, or listing
+            # `scripts/collector/tests` would silently accept a later
+            # `scripts/collector/`, which is a different directory needing its
+            # own decision.
+            last = tok.rsplit("/", 1)[-1]
+            if "/" in tok and ("." in last or "*" in last or "?" in last):
+                named.add(tok.rsplit("/", 1)[0])
+    # EXACT membership only. An earlier attempt also accepted a directory when
+    # some registered path sat BELOW it, which re-admitted the permissive
+    # failure: registering `scripts/collector/tests` made a later
+    # `scripts/collector/` -- a different directory, needing its own decision --
+    # read as already registered.
     return [d for d in test_dirs(repo) if d not in named]
 
 
@@ -174,8 +211,15 @@ def run_traced(repo, targets, python=None, extra_args=()):
     groups = {}
     for t in tests:
         groups.setdefault(t.parent, []).append(t)
-    if not groups:                      # only library modules registered
-        groups = {None: []}
+    if not groups:
+        # 🔴 NEVER INVOKE pytest WITH NO PATH ARGUMENTS. It would collect the
+        # TARGET REPO'S ENTIRE SUITE from cwd -- running arbitrary tests, with
+        # their side effects, in a repo we were asked only to read. With no
+        # registered test file there is nothing to drive the guards with, so
+        # the honest result is an empty trace: every library module then has
+        # zero traced lines and is reported UNDECIDABLE, which is true.
+        return ({"executed": {}, "clobbered": False}, (0, 0),
+                "no registered test file to drive the guards with")
 
     merged, code, nfail, tails = {}, 0, 0, []
     clobbered = False
@@ -319,7 +363,7 @@ def scan(repo, census_path=None, verbose=True, python=None, registry=None):
         try:
             src = t.read_text(encoding="utf-8")
             dg.branch_bodies(src, rel)
-        except (SyntaxError, ValueError) as e:
+        except (SyntaxError, ValueError, OSError) as e:
             # TWO names, not five. An audit found that only SyntaxError and
             # IndentationError were caught, so a file this tool could not
             # analyse escaped as a traceback and exit 1 -- indistinguishable
@@ -360,7 +404,7 @@ def scan(repo, census_path=None, verbose=True, python=None, registry=None):
             continue
         try:
             flags = dg.evaluate(rel, src, set(executed.get(str(t), [])))
-        except (SyntaxError, ValueError) as e:  # see the note above
+        except (SyntaxError, ValueError, OSError) as e:  # see the note above
             undecidable.append(f"{rel}: cannot be analysed ({type(e).__name__}: {e})")
             continue
         all_flags.extend(flags)
@@ -436,15 +480,24 @@ def write_census(path, slug, flags, oo, undecidable, interp="?", rc=(0, 0)):
     p.parent.mkdir(parents=True, exist_ok=True)
     code, nfail = rc if isinstance(rc, tuple) else (rc, 0)
 
+    # 🔴 KEEP OTHER REPOS' PROVENANCE LINES. Dropping every `#` line deleted the
+    # `# <slug> measured under ...` note for every OTHER repo on every scan, so
+    # the committed census ended up carrying ONE note (the last repo scanned)
+    # for four repos -- and the missing ones included the RED-RUN warning this
+    # same fix round had just added. A per-repo idempotent rewrite must replace
+    # only THIS repo's lines, not everything that starts with a hash.
     kept = []
     if p.exists():
         for line in p.read_text(encoding="utf-8").splitlines():
-            if line.startswith("#") or line.startswith("repo_slug\t"):
+            if not line.strip():
+                continue
+            if line in _CENSUS_HEADER or line.startswith("repo_slug\t"):
                 continue                       # header is re-emitted below
-            if line.startswith(f"{slug}\t") or line.startswith(f"# {slug} "):
+            if line.startswith(f"# {slug} measured under"):
+                continue                       # this repo's old note: replaced
+            if line.startswith(f"{slug}\t"):
                 continue                       # this repo's old rows: replaced
-            if line.strip():
-                kept.append(line)
+            kept.append(line)
 
     out = list(_CENSUS_HEADER)
     out.extend(kept)

--- a/scripts/dead-guard-scan.py
+++ b/scripts/dead-guard-scan.py
@@ -168,6 +168,15 @@ def unregistered_test_dirs(repo, rows, slug):
             # `scripts/collector/tests` would silently accept a later
             # `scripts/collector/`, which is a different directory needing its
             # own decision.
+            # 🔴 ...AND ONLY FOR `instrument` ROWS. The out-of-instrument
+            # column is PROSE, and prose is full of dotted words: the bash row
+            # naming `scripts/drift-check.sh` registered the bare directory
+            # `scripts` in three repos, so a future `scripts/test_x.py` would
+            # have been silently accepted -- the exact "everything is
+            # registered" this function exists to prevent, re-admitted through
+            # the sentence rather than the path.
+            if r["status"] != "instrument":
+                continue
             last = tok.rsplit("/", 1)[-1]
             if "/" in tok and ("." in last or "*" in last or "?" in last):
                 named.add(tok.rsplit("/", 1)[0])
@@ -339,6 +348,7 @@ def scan(repo, census_path=None, verbose=True, python=None, registry=None):
               f"That is UNDECIDABLE, not clean.\n{tail}", file=sys.stderr)
         return EXIT_UNDECIDABLE
     executed = trace.get("executed", {})
+    no_tests = not [t for t in targets if t.name.startswith("test_")]
 
     # 🔴 A DISARMED TRACER MUST NOT PUBLISH. If any test cleared or replaced
     # `sys.settrace`, every target executed afterwards went unrecorded, so the
@@ -398,9 +408,15 @@ def scan(repo, census_path=None, verbose=True, python=None, registry=None):
         # library modules. A test file whose subject runs only in a subprocess
         # still under-reports, and nothing here detects that.
         if not executed.get(str(t)):
+            # Say WHICH zero this is. "driven through a subprocess" is a guess
+            # when no test file was registered at all -- the code knows that
+            # case and used to report the wrong cause anyway, under a comment
+            # 40 lines above saying "attribute the cause you actually know".
+            why = ("no registered test file drives it -- the registry lists "
+                   "library modules only" if no_tests else
+                   "it is driven through a subprocess, or was never imported")
             undecidable.append(
-                f"{rel}: NO line of this file was traced. It is driven through "
-                f"a subprocess, or was never imported -- not dead.")
+                f"{rel}: NO line of this file was traced; {why} -- not dead.")
             continue
         try:
             flags = dg.evaluate(rel, src, set(executed.get(str(t), [])))
@@ -493,14 +509,20 @@ def write_census(path, slug, flags, oo, undecidable, interp="?", rc=(0, 0)):
                 continue
             if line in _CENSUS_HEADER or line.startswith("repo_slug\t"):
                 continue                       # header is re-emitted below
-            if line.startswith(f"# {slug} measured under"):
-                continue                       # this repo's old note: replaced
-            if line.startswith(f"{slug}\t"):
-                continue                       # this repo's old rows: replaced
+            # NOTE: this repo's own old lines are NOT skipped here. They are
+            # grouped like everyone else's and then REPLACED wholesale by
+            # `blocks[slug] = mine` below. Two `continue`s used to do it here
+            # as well; the battery showed them to be dead (mutating them away
+            # changed nothing), so they are gone rather than kept as
+            # reassuring width.
             kept.append(line)
 
     out = list(_CENSUS_HEADER)
-    out.extend(kept)
+    blocks = {}
+    for line in kept:
+        key = line.split("\t", 1)[0] if not line.startswith("#") else \
+            line.split(" ", 2)[1] if line.startswith("# ") else ""
+        blocks.setdefault(key, []).append(line)
     # The interpreter VERSION is part of the measurement (a different one takes
     # different branches). The PATH is not written -- see `interpreter_id`.
     note = f"# {slug} measured under {interp}"
@@ -517,7 +539,18 @@ def write_census(path, slug, flags, oo, undecidable, interp="?", rc=(0, 0)):
                    f"{_tsv(r['selector'])}\tunmeasured\t-")
     for u in undecidable:
         out.append(f"{slug}\tundecidable\t{_tsv(u)}\t-\t-\t-\t-")
-    p.write_text("\n".join(out) + "\n", encoding="utf-8")
+    # 🔴 ORDER-STABLE, SORTED BY SLUG. Appending this repo's block after the
+    # kept lines moved the scanned repo to EOF, so re-deriving ONE repo
+    # produced a whole-file reordering diff -- a reviewer re-running the
+    # command printed in the census's own header could not tell "nothing
+    # changed" from "everything moved". Idempotent per repo is not enough; the
+    # artifact has to be byte-stable under any scan order.
+    mine = out[len(_CENSUS_HEADER):]
+    blocks[slug] = mine
+    body = []
+    for key in sorted(blocks):
+        body.extend(blocks[key])
+    p.write_text("\n".join(list(_CENSUS_HEADER) + body) + "\n", encoding="utf-8")
 
 
 # --------------------------------------------------------------------------

--- a/scripts/dead-guard-scan.py
+++ b/scripts/dead-guard-scan.py
@@ -6,24 +6,33 @@
     python3 scripts/dead-guard-scan.py --repo <path> --census <out.tsv>
 
 A guard branch that never executes -- against the real corpus AND the guard's
-own battery -- is either dead recognition code or a reporting branch with no
-positive control. Both are the defect `claude/RULES.md` names under "A guard's
-DESCRIPTION claims COVERAGE"; the remedy is to DELETE it and state the limit,
-not to harden it. The analysis, and its stated limits, live in
-`scripts/lib/dead_guard.py`. Resolve a flag by deleting the branch or writing
-one line at the site: `# pragma: no cover - <reason>`.
+own battery -- is EVIDENCE of one of three things, two of which are the defect
+`claude/RULES.md` names under "A guard's DESCRIPTION claims COVERAGE": dead
+recognition code, a reporting branch with no positive control, or (not a
+defect) a branch driven through a subprocess this tracer cannot see. For the
+first two the remedy is to DELETE it and state the limit, not to harden it. The
+analysis and its full limits live in `scripts/lib/dead_guard.py`. Resolve a
+flag by deleting the branch or writing one line at the site:
+`# pragma: no cover - <reason>`.
 
 🔴 THIS IS ADVISORY. It gates nothing until deliberately wired into CI, and its
 own precision on real code is a human call -- flags are evidence for that
 reading, not a verdict to auto-apply.
 
 🔴 WHAT A CLEAN EXIT DOES NOT MEAN. Only the `instrument` rows of
-`scripts/data/dead-guard-registry.tsv` are measured -- roughly 88 of ~270
-guards across the four repos. Everything else is bash, TypeScript or Go, and is
-listed there as out-of-instrument WITH ITS REASON. Exit 0 means "no unresolved
-flag among the guards this tool can see", never "the repo's guards are alive".
-The census prints that ratio on every run so the number is not quotable without
-its denominator.
+`scripts/data/dead-guard-registry.tsv` are measured. Everything else -- bash,
+TypeScript, Go -- is listed there as out-of-instrument WITH ITS REASON. Exit 0
+means "no unresolved flag among the guards this tool can see", never "the
+repo's guards are alive".
+
+🔴 AND THE DENOMINATOR IS NOT DERIVABLE FROM THIS TOOL. An earlier revision of
+this docstring claimed "the census prints that ratio on every run so the number
+is not quotable without its denominator". It did not: what is printed is a
+count of instrumented FILES and a count of registry ROWS, neither of which is a
+guard total. Nothing here enumerates every guard in a repo, so any "N of M"
+figure is a human's survey, not a measurement -- do not quote one as if this
+tool produced it. That false claim shipped in this file and in the PR body, and
+it is the same over-claiming-guard defect the tool exists to find.
 """
 
 import argparse
@@ -84,10 +93,72 @@ def guard_files(repo, rows, slug):
     return out
 
 
+_WALK_SKIP = {".git", "__pycache__", "node_modules", ".venv", ".mypy_cache",
+              ".pytest_cache", ".claude"}
+
+
+def test_dirs(repo):
+    """Every directory holding a `test_*.py` -- the surface a registry must
+    have an opinion about.
+
+    Prefers `git ls-files` (tracked files only, so build output and stray
+    scratch files cannot inflate the ledger). Falls back to a filesystem walk
+    when git returns nothing, so this works in a plain copy of a tree -- which
+    is how the mutation battery runs, and is also just a repo that has not been
+    initialised. A hard git dependency here would make the fallback path exit
+    with an empty ledger, i.e. a silent "everything is registered".
+    """
+    repo = pathlib.Path(repo)
+    out = subprocess.run(["git", "-C", str(repo), "ls-files"],
+                         capture_output=True, text=True, timeout=120).stdout
+    files = [f for f in out.splitlines()
+             if re.search(r"(^|/)test_[^/]*\.py$", f) and "/" in f]
+    if not files:
+        files = [str(p.relative_to(repo)) for p in repo.rglob("test_*.py")
+                 if p.is_file()
+                 and not _WALK_SKIP & set(p.relative_to(repo).parts)]
+        files = [f for f in files if "/" in f]
+    return sorted({f.rsplit("/", 1)[0] for f in files})
+
+
+def unregistered_test_dirs(repo, rows, slug):
+    """Test directories no registry row mentions, in EITHER status.
+
+    🔴 THIS IS THE REGISTRY'S OWN GUARD, AND IT EXISTS BECAUSE THE FIRST ONE WAS
+    NARROWER THAN ITS DOCSTRING. `test_registry_parses_and_every_repo_declares_
+    what_is_NOT_measured` claims it would catch "a repo with only `instrument`
+    rows"; its body only asserts that at least one out-of-instrument row exists.
+    It therefore could not see a guard surface present in NEITHER status -- and
+    12 python guard modules under `scripts/claude-hooks/`, including the
+    PreToolUse deny-guards `guard_core.py` and `bash-guard.py`, were exactly
+    that: absent, and so reading as measured and clean.
+
+    Mechanical, not heuristic: it does not try to decide what a "guard" is. It
+    requires a DECISION to have been recorded for every directory that holds
+    tests -- which is the homelab-infra `ci-manifest.txt` pattern.
+    """
+    mine = [r for r in rows if r["slug"] == slug]
+    named = " ".join(r["selector"] for r in mine)
+    return [d for d in test_dirs(repo) if d not in named]
+
+
 def run_traced(repo, targets, python=None, extra_args=()):
-    """Run the guards under pytest with the line tracer. Returns
-    (executed, rc, tail). `executed` is None when the trace never landed --
-    a missing file must not read as 'nothing executed'.
+    """Trace the guards, ONE PYTEST INVOCATION PER TEST DIRECTORY.
+
+    🔴 `conftest.py` IS NOT NAMESPACED. This repo has several `conftest.py`
+    files and no `__init__.py`, so an importer binds to whichever lands in
+    `sys.modules` first and collecting two test directories in ONE pytest run
+    fails with an ImportError naming the wrong file. (`scripts/browser-bridge/
+    tests/cli_budget.py` documents the same trap; devrc's own runner uses one
+    target per invocation for this reason.) Measured here: adding
+    `scripts/claude-hooks/tests/` to the registry made `test_bash_guard.py`
+    collect zero tests, so NOT ONE of its lines was traced -- which, before the
+    zero-lines guard existed, would have been published as "every branch in the
+    PreToolUse deny-guard is dead".
+
+    Returns (trace, (rc, nfail), tail), traces merged across groups. `trace` is
+    None when a group produced no trace file at all -- a missing file must not
+    read as 'nothing executed'.
 
     🔴 THE INTERPRETER IS PART OF THE MEASUREMENT, AND IT LEAKS FROM cwd.
     `sys.executable` is whatever python is running THIS script, which under
@@ -99,38 +170,74 @@ def run_traced(repo, targets, python=None, extra_args=()):
     hence the interpreter is printed on every run and written into the census.
     """
     python = python or sys.executable
-    with tempfile.TemporaryDirectory(prefix="dgs-") as td:
-        out = pathlib.Path(td) / "executed.json"
-        env = dict(os.environ)
-        env["DGS_TARGETS"] = os.pathsep.join(str(t) for t in targets)
-        env["DGS_OUT"] = str(out)
-        env["PYTHONPATH"] = os.pathsep.join(
-            [str(PLUGIN_DIR)] + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else []))
-        env.pop("PYTEST_ADDOPTS", None)
-        cmd = [python, "-m", "pytest", "-p", "dead_guard_plugin",
-               "-q", "--no-header", "--continue-on-collection-errors",
-               "-p", "no:cacheprovider",
-               *[str(t) for t in targets if t.name.startswith("test_")], *extra_args]
-        proc = subprocess.run(cmd, cwd=str(repo), env=env,
-                              capture_output=True, text=True, timeout=3600)
-        tail = (proc.stdout or "")[-3000:] + (proc.stderr or "")[-1500:]
-        # Count FAILED lines rather than reading the exit code: a red run leaves
-        # branches unexecuted for a reason that is NOT deadness, so the caller
-        # must be able to say how much of the census rests on it.
-        nfail = len(re.findall(r"^FAILED ", proc.stdout or "", re.M))
-        if not out.exists():
-            return None, proc.returncode, tail
-        return (json.loads(out.read_text(encoding="utf-8")),
-                (proc.returncode, nfail), tail)
+    tests = [t for t in targets if t.name.startswith("test_")]
+    groups = {}
+    for t in tests:
+        groups.setdefault(t.parent, []).append(t)
+    if not groups:                      # only library modules registered
+        groups = {None: []}
+
+    merged, code, nfail, tails = {}, 0, 0, []
+    clobbered = False
+    for parent, files in sorted(groups.items(), key=lambda kv: str(kv[0])):
+        with tempfile.TemporaryDirectory(prefix="dgs-") as td:
+            out = pathlib.Path(td) / "executed.json"
+            env = dict(os.environ)
+            # EVERY target is traced in EVERY group: a library module is
+            # exercised by whichever suite happens to import it.
+            env["DGS_TARGETS"] = os.pathsep.join(str(t) for t in targets)
+            env["DGS_OUT"] = str(out)
+            env["PYTHONPATH"] = os.pathsep.join(
+                [str(PLUGIN_DIR)] + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else []))
+            env.pop("PYTEST_ADDOPTS", None)
+            env["PYTHONDONTWRITEBYTECODE"] = "1"   # a "read-only" scan must not
+            # litter the target repo with __pycache__ -- and a stale .pyc is how
+            # a same-length edit gets scored without ever executing.
+            cmd = [python, "-m", "pytest", "-p", "dead_guard_plugin",
+                   "-q", "--no-header", "--continue-on-collection-errors",
+                   "-p", "no:cacheprovider",
+                   *[str(t) for t in files], *extra_args]
+            try:
+                proc = subprocess.run(cmd, cwd=str(repo), env=env,
+                                      capture_output=True, text=True, timeout=3600)
+            except subprocess.TimeoutExpired as e:
+                # NOT a clean run and NOT a set of findings: we did not measure.
+                return None, (-1, 0), f"traced run timed out after 3600s: {e}"
+            tails.append((proc.stdout or "")[-2000:] + (proc.stderr or "")[-1000:])
+            # Count FAILED lines rather than reading the exit code: a red run
+            # leaves branches unexecuted for a reason that is NOT deadness, so
+            # the caller must say how much of the census rests on it.
+            nfail += len(re.findall(r"^FAILED ", proc.stdout or "", re.M))
+            code = code or proc.returncode
+            if not out.exists():
+                return None, (proc.returncode, nfail), "\n".join(tails)
+            part = json.loads(out.read_text(encoding="utf-8"))
+            clobbered = clobbered or bool(part.get("clobbered"))
+            for path, lines in part.get("executed", {}).items():
+                merged.setdefault(path, set()).update(lines)
+
+    return ({"executed": {k: sorted(v) for k, v in merged.items()},
+             "clobbered": clobbered},
+            (code, nfail), "\n".join(tails))
 
 
-def interpreter_id(python):
-    """`<path> (Python X.Y.Z)` -- recorded so a trace carries its own scope."""
+def interpreter_id(python, redact=False):
+    """`<path> (Python X.Y.Z)` -- recorded so a trace carries its own scope.
+
+    🔴 `redact=True` for anything COMMITTED. The absolute path is the operator's
+    home directory, and under direnv it is routinely another repo's `.venv`
+    (see `run_traced`) -- committing it publishes a local filesystem layout and
+    pins the artifact to one machine. The VERSION is the part that changes
+    which branches run; the path is a diagnostic for the person at the
+    terminal, so it is printed and not written.
+    """
     try:
         v = subprocess.run([python, "-c", "import sys;print('.'.join(map(str,sys.version_info[:3])))"],
                            capture_output=True, text=True, timeout=60).stdout.strip()
     except (OSError, subprocess.SubprocessError):
         v = "?"
+    if redact:
+        return f"Python {v or '?'}"
     return f"{python} (Python {v or '?'})"
 
 
@@ -152,6 +259,23 @@ def scan(repo, census_path=None, verbose=True, python=None, registry=None):
 
     targets = guard_files(repo, rows, slug)
     oo = [r for r in rows if r["slug"] == slug and r["status"] == "out-of-instrument"]
+    inst = [r for r in rows if r["slug"] == slug and r["status"] == "instrument"]
+
+    # 🔴 AN `instrument` SELECTOR THAT MATCHES NOTHING IS A TYPO, NOT A CLEAN
+    # REPO. Without this, a one-character slip in a selector silently reduces
+    # the report to nothing and exits 0 -- shaped identically to the legitimate
+    # "this repo has no Python guards" case, which is the single most damaging
+    # confusion this tool can produce.
+    empty = [r["selector"] for r in inst
+             if not [p for p in pathlib.Path(repo).glob(r["selector"])
+                     if p.is_file() and p.suffix == ".py"]]
+    if empty:
+        print(f"{slug}: {len(empty)} `instrument` selector(s) matched NO python "
+              f"file in this clone -- a typo, or the guards moved. That is "
+              f"UNDECIDABLE, not clean:\n  " + "\n  ".join(empty),
+              file=sys.stderr)
+        return EXIT_UNDECIDABLE
+
     if not targets:
         # 🔴 STILL WRITE THE CENSUS. A repo with nothing instrumentable is
         # exactly the one whose absence from the artifact would read as "swept
@@ -162,26 +286,82 @@ def scan(repo, census_path=None, verbose=True, python=None, registry=None):
               f"{len(oo)} out-of-instrument row(s) registered.")
         if census_path:
             write_census(census_path, slug, [], oo, [],
-                         interpreter_id(python))
+                         interpreter_id(python, redact=True))
         return EXIT_CLEAN
 
-    executed, rc, tail = run_traced(repo, targets, python=python)
-    if executed is None:
+    trace, rc, tail = run_traced(repo, targets, python=python)
+    if trace is None:
         print(f"{slug}: the traced run produced no trace file (pytest rc={rc}). "
               f"That is UNDECIDABLE, not clean.\n{tail}", file=sys.stderr)
+        return EXIT_UNDECIDABLE
+    executed = trace.get("executed", {})
+
+    # 🔴 A DISARMED TRACER MUST NOT PUBLISH. If any test cleared or replaced
+    # `sys.settrace`, every target executed afterwards went unrecorded, so the
+    # trace is a LOWER BOUND -- and a lower bound on execution is an UPPER
+    # bound on deadness, i.e. false positives against live code, on a green run.
+    if trace.get("clobbered"):
+        print(f"{slug}: a test cleared or replaced sys.settrace during the run, "
+              f"so the trace is a lower bound and live branches would be "
+              f"reported dead. UNDECIDABLE, not clean.", file=sys.stderr)
         return EXIT_UNDECIDABLE
 
     all_flags, undecidable = [], []
     for t in targets:
-        src = t.read_text(encoding="utf-8")
         # REPO-RELATIVE in the artifact: the census is committed and read on
         # other machines, where an absolute path names a directory that does
         # not exist -- and here it would bake in a throwaway worktree's name.
         rel = str(t.relative_to(repo))
+        # PARSEABILITY FIRST. A file that will not parse is "cannot be
+        # analysed" whatever the trace says -- and it is also, necessarily,
+        # never traced, so the zero-lines arm below would otherwise claim it
+        # was driven by a subprocess. Attribute the cause you actually know.
+        try:
+            src = t.read_text(encoding="utf-8")
+            dg.branch_bodies(src, rel)
+        except (SyntaxError, ValueError) as e:
+            # TWO names, not five. An audit found that only SyntaxError and
+            # IndentationError were caught, so a file this tool could not
+            # analyse escaped as a traceback and exit 1 -- indistinguishable
+            # from "found dead branches" -- and no census was written at all.
+            # The first fix widened this to five names; three of them were
+            # REDUNDANT SPELLINGS that read as coverage while adding nothing,
+            # which is the very defect this tool looks for. Measured on 3.12:
+            # so a file this tool could not analyse escaped as a traceback and
+            # exit 1 -- indistinguishable from "found dead branches" -- and no
+            # census was written at all. UnicodeDecodeError is the reachable
+            # one: a .py file in latin-1 raises it from `read_text`.
+            #
+            # 🔴 `tokenize.TokenError` IS DELIBERATELY ABSENT, though it is not
+            # a SyntaxError subclass and the first fix DID add it. Measured on
+            # 3.12: every input that raises TokenError (unterminated string,
+            # unterminated triple-quote, open bracket at EOF, trailing
+            # backslash) raises SyntaxError from `ast.parse` FIRST, and
+            # `ast.parse` runs before any tokenising. The catch was therefore
+            # unreachable -- a dead guard branch, in the fix for a dead-guard
+            # finder. Deleted and stated, per this repo's own rule, rather than
+            # kept as reassuring width. If you find an input that parses but
+            # will not tokenise, add it back WITH that input as a test.
+            undecidable.append(f"{rel}: cannot be analysed ({type(e).__name__}: {e})")
+            continue
+        # 🔴 ZERO EXECUTED LINES IS "NEVER TRACED", NOT "ENTIRELY DEAD". The
+        # common cause is a library guard whose tests drive it through a
+        # SUBPROCESS, which `sys.settrace` cannot see. Reporting every branch
+        # of such a file would be the tool's worst output: a confident,
+        # complete, entirely false census of working code.
+        # ⚠️ LIMIT: this cannot fire for a pytest FILE, because collection
+        # imports it and its module-level lines always trace. It protects
+        # library modules. A test file whose subject runs only in a subprocess
+        # still under-reports, and nothing here detects that.
+        if not executed.get(str(t)):
+            undecidable.append(
+                f"{rel}: NO line of this file was traced. It is driven through "
+                f"a subprocess, or was never imported -- not dead.")
+            continue
         try:
             flags = dg.evaluate(rel, src, set(executed.get(str(t), [])))
-        except (SyntaxError, IndentationError) as e:
-            undecidable.append(f"{rel}: will not parse ({e})")
+        except (SyntaxError, ValueError) as e:  # see the note above
+            undecidable.append(f"{rel}: cannot be analysed ({type(e).__name__}: {e})")
             continue
         all_flags.extend(flags)
 
@@ -190,7 +370,10 @@ def scan(repo, census_path=None, verbose=True, python=None, registry=None):
     if verbose:
         _report(slug, targets, all_flags, unres, oo, undecidable, rc, interp)
     if census_path:
-        write_census(census_path, slug, all_flags, oo, undecidable, interp)
+        write_census(census_path, slug, all_flags, oo, undecidable,
+                     interpreter_id(python, redact=True), rc)
+    # Undecidable outranks flags: "I could not measure part of this" must not
+    # be reported as "here is the measurement".
     if undecidable:
         return EXIT_UNDECIDABLE
     return EXIT_FLAGS if unres else EXIT_CLEAN
@@ -209,8 +392,12 @@ def _report(slug, targets, flags, unres, oo, undecidable, rc, interp):
               f"a failure did not execute for a reason that is NOT deadness -- "
               f"flags in those files are weaker evidence. Green the run, or "
               f"attribute each flag by hand.")
-    print(f"   NOT measured : {len(oo)} registered out-of-instrument row(s) -- "
-          f"bash / TypeScript / Go")
+    # Say ROWS, not guards. These are registry entries, each covering an
+    # unknown number of files; calling them a guard count would invent a
+    # denominator this tool cannot measure.
+    print(f"   NOT measured : {len(oo)} registered out-of-instrument ROW(s) "
+          f"(registry entries, NOT a guard count -- no denominator is derivable "
+          f"here)")
     print(f"   flagged      : {len(flags)} branch bodies never executed "
           f"({len(flags) - len(unres)} justified, {len(unres)} unresolved)")
     for f in sorted(unres, key=lambda x: (x.path, x.branch.first_line)):
@@ -220,31 +407,64 @@ def _report(slug, targets, flags, unres, oo, undecidable, rc, interp):
         print(f"   UNDECIDABLE {u}")
 
 
-def write_census(path, slug, flags, oo, undecidable, interp="?"):
+_CENSUS_HEADER = [
+    "# Measured census of guard branches with zero corpus instances.",
+    "# Regenerate, per repo: scripts/dead-guard-scan.py --repo <path> --census <this file>",
+    "# 🔴 out-of-instrument rows are NOT a clean result -- they are guards this tool",
+    "#    CANNOT see. A repo's absence from this file is not evidence about it.",
+    "# 🔴 A flag has THREE readings and only two are defects: dead code, an untested",
+    "#    reporting branch, or a branch driven through a subprocess. See",
+    "#    scripts/lib/dead_guard.py. Adjudicating them is a human's job.",
+    "repo_slug\tstatus\tlocation\tkind\tcase_handled\tcorpus_instances\tjustification",
+]
+
+
+def _tsv(s):
+    """A TAB inside a snippet or a reason would shift every later column."""
+    return str(s).replace("\t", "\\t").replace("\n", " ").replace("\r", " ")
+
+
+def write_census(path, slug, flags, oo, undecidable, interp="?", rc=(0, 0)):
+    """Rewrite THIS repo's rows, leaving other repos' rows intact.
+
+    🔴 IDEMPOTENT, because the regeneration command is printed in the file's own
+    header. Appending meant that following your own instructions doubled every
+    row, and a flag resolved in the source was never removed from the artifact
+    -- so the census drifted upward from the thing it claims to measure.
+    """
     p = pathlib.Path(path)
-    new = not p.exists()
-    with p.open("a", encoding="utf-8") as fh:
-        if new:
-            fh.write("# Measured census of guard branches with zero corpus "
-                     "instances. Regenerate: scripts/dead-guard-scan.py --repo "
-                     "<path> --census <this file>\n")
-            fh.write("# `status` out-of-instrument rows are NOT a clean result "
-                     "-- they are guards this tool cannot see. See "
-                     "scripts/data/dead-guard-registry.tsv.\n")
-            fh.write("repo_slug\tstatus\tlocation\tkind\tcase_handled"
-                     "\tcorpus_instances\tjustification\n")
-        # The interpreter is part of the measurement: a different one takes
-        # different branches, so a census without it is not reproducible.
-        fh.write(f"# {slug} measured under {interp}\n")
-        for f in sorted(flags, key=lambda x: (x.path, x.branch.first_line)):
-            b = f.branch
-            fh.write(f"{slug}\tflagged\t{f.path}:{b.first_line}\t{b.kind}\t"
-                     f"{b.snippet}\t0\t{f.justified_reason or '-'}\n")
-        for r in oo:
-            fh.write(f"{slug}\tout-of-instrument\t-\t{r['lang']}\t"
-                     f"{r['selector']}\tunmeasured\t-\n")
-        for u in undecidable:
-            fh.write(f"{slug}\tundecidable\t{u}\t-\t-\t-\t-\n")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    code, nfail = rc if isinstance(rc, tuple) else (rc, 0)
+
+    kept = []
+    if p.exists():
+        for line in p.read_text(encoding="utf-8").splitlines():
+            if line.startswith("#") or line.startswith("repo_slug\t"):
+                continue                       # header is re-emitted below
+            if line.startswith(f"{slug}\t") or line.startswith(f"# {slug} "):
+                continue                       # this repo's old rows: replaced
+            if line.strip():
+                kept.append(line)
+
+    out = list(_CENSUS_HEADER)
+    out.extend(kept)
+    # The interpreter VERSION is part of the measurement (a different one takes
+    # different branches). The PATH is not written -- see `interpreter_id`.
+    note = f"# {slug} measured under {interp}"
+    if nfail:
+        note += (f" -- 🔴 RED RUN, {nfail} test(s) FAILED: branches downstream of "
+                 f"a failure did not execute for a reason that is NOT deadness")
+    out.append(f"{note} (pytest rc={code})")
+    for f in sorted(flags, key=lambda x: (x.path, x.branch.first_line)):
+        b = f.branch
+        out.append(f"{slug}\tflagged\t{_tsv(f.path)}:{b.first_line}\t{b.kind}\t"
+                   f"{_tsv(b.snippet)}\t0\t{_tsv(f.justified_reason or '-')}")
+    for r in oo:
+        out.append(f"{slug}\tout-of-instrument\t-\t{r['lang']}\t"
+                   f"{_tsv(r['selector'])}\tunmeasured\t-")
+    for u in undecidable:
+        out.append(f"{slug}\tundecidable\t{_tsv(u)}\t-\t-\t-\t-")
+    p.write_text("\n".join(out) + "\n", encoding="utf-8")
 
 
 # --------------------------------------------------------------------------

--- a/scripts/dead-guard-scan.py
+++ b/scripts/dead-guard-scan.py
@@ -418,12 +418,12 @@ def scan(repo, census_path=None, verbose=True, python=None, registry=None):
             undecidable.append(
                 f"{rel}: NO line of this file was traced; {why} -- not dead.")
             continue
-        try:
-            flags = dg.evaluate(rel, src, set(executed.get(str(t), [])))
-        except (SyntaxError, ValueError, OSError) as e:  # see the note above
-            undecidable.append(f"{rel}: cannot be analysed ({type(e).__name__}: {e})")
-            continue
-        all_flags.extend(flags)
+        # 🔴 NO try/except HERE. `src` is already in memory and `branch_bodies`
+        # already parsed it at the check above, so `evaluate` cannot raise the
+        # analysis errors -- the handler that used to wrap this was unreachable
+        # width in the fix for a dead-guard finder. If this ever does raise, the
+        # traceback is the honest outcome: it means an assumption above is wrong.
+        all_flags.extend(dg.evaluate(rel, src, set(executed.get(str(t), []))))
 
     unres = dg.unresolved(all_flags)
     interp = interpreter_id(python)
@@ -517,7 +517,7 @@ def write_census(path, slug, flags, oo, undecidable, interp="?", rc=(0, 0)):
             # reassuring width.
             kept.append(line)
 
-    out = list(_CENSUS_HEADER)
+    out = []
     blocks = {}
     for line in kept:
         key = line.split("\t", 1)[0] if not line.startswith("#") else \
@@ -545,7 +545,7 @@ def write_census(path, slug, flags, oo, undecidable, interp="?", rc=(0, 0)):
     # command printed in the census's own header could not tell "nothing
     # changed" from "everything moved". Idempotent per repo is not enough; the
     # artifact has to be byte-stable under any scan order.
-    mine = out[len(_CENSUS_HEADER):]
+    mine = out
     blocks[slug] = mine
     body = []
     for key in sorted(blocks):

--- a/scripts/dead-guard-scan.py
+++ b/scripts/dead-guard-scan.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Find guard branches with zero corpus instances.
+
+    python3 scripts/dead-guard-scan.py --repo <path>   # 0 clean, 1 unresolved flag
+    python3 scripts/dead-guard-scan.py --self-test     # positive + negative controls
+    python3 scripts/dead-guard-scan.py --repo <path> --census <out.tsv>
+
+A guard branch that never executes -- against the real corpus AND the guard's
+own battery -- is either dead recognition code or a reporting branch with no
+positive control. Both are the defect `claude/RULES.md` names under "A guard's
+DESCRIPTION claims COVERAGE"; the remedy is to DELETE it and state the limit,
+not to harden it. The analysis, and its stated limits, live in
+`scripts/lib/dead_guard.py`. Resolve a flag by deleting the branch or writing
+one line at the site: `# pragma: no cover - <reason>`.
+
+🔴 THIS IS ADVISORY. It gates nothing until deliberately wired into CI, and its
+own precision on real code is a human call -- flags are evidence for that
+reading, not a verdict to auto-apply.
+
+🔴 WHAT A CLEAN EXIT DOES NOT MEAN. Only the `instrument` rows of
+`scripts/data/dead-guard-registry.tsv` are measured -- roughly 88 of ~270
+guards across the four repos. Everything else is bash, TypeScript or Go, and is
+listed there as out-of-instrument WITH ITS REASON. Exit 0 means "no unresolved
+flag among the guards this tool can see", never "the repo's guards are alive".
+The census prints that ratio on every run so the number is not quotable without
+its denominator.
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent / "lib"))
+import dead_guard as dg  # noqa: E402
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+REGISTRY = REPO_ROOT / "scripts" / "data" / "dead-guard-registry.tsv"
+PLUGIN_DIR = REPO_ROOT / "scripts" / "testlib"
+
+# Exit codes, so a caller can tell "found something" from "could not look".
+EXIT_CLEAN, EXIT_FLAGS, EXIT_UNDECIDABLE = 0, 1, 2
+
+
+def repo_slug(repo):
+    """`owner/name` from origin. The clone DIRECTORY is not usable as a key --
+    `datapacket-talos` is civitai/talos-infra and `homelab-talos` is
+    ZacxDev/homelab-infra."""
+    try:
+        url = subprocess.run(["git", "-C", str(repo), "remote", "get-url", "origin"],
+                             capture_output=True, text=True, timeout=30).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    m = re.search(r"[:/]([^/:]+/[^/]+?)(?:\.git)?$", url)
+    return m.group(1) if m else ""
+
+
+def load_registry(path=REGISTRY):
+    rows = []
+    for line in pathlib.Path(path).read_text(encoding="utf-8").splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) != 4:
+            raise SystemExit(f"registry: malformed row (want 4 tab-separated "
+                             f"fields, got {len(parts)}): {line!r}")
+        rows.append(dict(zip(("slug", "lang", "status", "selector"), parts)))
+    return rows
+
+
+def guard_files(repo, rows, slug):
+    """Absolute paths of the `instrument` guards present in this clone."""
+    out = []
+    for r in rows:
+        if r["slug"] != slug or r["status"] != "instrument":
+            continue
+        for p in sorted(pathlib.Path(repo).glob(r["selector"])):
+            if p.is_file() and p.suffix == ".py" and p not in out:
+                out.append(p)
+    return out
+
+
+def run_traced(repo, targets, python=None, extra_args=()):
+    """Run the guards under pytest with the line tracer. Returns
+    (executed, rc, tail). `executed` is None when the trace never landed --
+    a missing file must not read as 'nothing executed'.
+
+    🔴 THE INTERPRETER IS PART OF THE MEASUREMENT, AND IT LEAKS FROM cwd.
+    `sys.executable` is whatever python is running THIS script, which under
+    direnv is the venv of whatever directory the operator happens to stand in
+    -- during authoring that was a different repo's `.venv` entirely. A
+    different interpreter takes different branches (version gates, optional
+    imports falling into `except ImportError`), so a trace carries the
+    interpreter's identity or it is not reproducible. Hence `--python`, and
+    hence the interpreter is printed on every run and written into the census.
+    """
+    python = python or sys.executable
+    with tempfile.TemporaryDirectory(prefix="dgs-") as td:
+        out = pathlib.Path(td) / "executed.json"
+        env = dict(os.environ)
+        env["DGS_TARGETS"] = os.pathsep.join(str(t) for t in targets)
+        env["DGS_OUT"] = str(out)
+        env["PYTHONPATH"] = os.pathsep.join(
+            [str(PLUGIN_DIR)] + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else []))
+        env.pop("PYTEST_ADDOPTS", None)
+        cmd = [python, "-m", "pytest", "-p", "dead_guard_plugin",
+               "-q", "--no-header", "--continue-on-collection-errors",
+               "-p", "no:cacheprovider",
+               *[str(t) for t in targets if t.name.startswith("test_")], *extra_args]
+        proc = subprocess.run(cmd, cwd=str(repo), env=env,
+                              capture_output=True, text=True, timeout=3600)
+        tail = (proc.stdout or "")[-3000:] + (proc.stderr or "")[-1500:]
+        # Count FAILED lines rather than reading the exit code: a red run leaves
+        # branches unexecuted for a reason that is NOT deadness, so the caller
+        # must be able to say how much of the census rests on it.
+        nfail = len(re.findall(r"^FAILED ", proc.stdout or "", re.M))
+        if not out.exists():
+            return None, proc.returncode, tail
+        return (json.loads(out.read_text(encoding="utf-8")),
+                (proc.returncode, nfail), tail)
+
+
+def interpreter_id(python):
+    """`<path> (Python X.Y.Z)` -- recorded so a trace carries its own scope."""
+    try:
+        v = subprocess.run([python, "-c", "import sys;print('.'.join(map(str,sys.version_info[:3])))"],
+                           capture_output=True, text=True, timeout=60).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        v = "?"
+    return f"{python} (Python {v or '?'})"
+
+
+def scan(repo, census_path=None, verbose=True, python=None, registry=None):
+    repo = pathlib.Path(repo).resolve()
+    python = python or sys.executable
+    rows = load_registry(registry or REGISTRY)
+    slug = repo_slug(repo)
+    if not slug:
+        print(f"could not read origin for {repo} -- cannot key the registry",
+              file=sys.stderr)
+        return EXIT_UNDECIDABLE
+    known = {r["slug"] for r in rows}
+    if slug not in known:
+        print(f"{slug} is not in {REGISTRY.name}. Add rows for it -- including "
+              f"out-of-instrument rows for the languages this tool cannot see -- "
+              f"rather than reading this silence as coverage.", file=sys.stderr)
+        return EXIT_UNDECIDABLE
+
+    targets = guard_files(repo, rows, slug)
+    oo = [r for r in rows if r["slug"] == slug and r["status"] == "out-of-instrument"]
+    if not targets:
+        # 🔴 STILL WRITE THE CENSUS. A repo with nothing instrumentable is
+        # exactly the one whose absence from the artifact would read as "swept
+        # and clean" -- talos-infra and civitai are both this case, and they
+        # hold ~170 of the ~270 guards. Recording their out-of-instrument rows
+        # is the only thing that keeps the census honest about its own reach.
+        print(f"{slug}: 0 instrumentable guards present in this clone; "
+              f"{len(oo)} out-of-instrument row(s) registered.")
+        if census_path:
+            write_census(census_path, slug, [], oo, [],
+                         interpreter_id(python))
+        return EXIT_CLEAN
+
+    executed, rc, tail = run_traced(repo, targets, python=python)
+    if executed is None:
+        print(f"{slug}: the traced run produced no trace file (pytest rc={rc}). "
+              f"That is UNDECIDABLE, not clean.\n{tail}", file=sys.stderr)
+        return EXIT_UNDECIDABLE
+
+    all_flags, undecidable = [], []
+    for t in targets:
+        src = t.read_text(encoding="utf-8")
+        # REPO-RELATIVE in the artifact: the census is committed and read on
+        # other machines, where an absolute path names a directory that does
+        # not exist -- and here it would bake in a throwaway worktree's name.
+        rel = str(t.relative_to(repo))
+        try:
+            flags = dg.evaluate(rel, src, set(executed.get(str(t), [])))
+        except (SyntaxError, IndentationError) as e:
+            undecidable.append(f"{rel}: will not parse ({e})")
+            continue
+        all_flags.extend(flags)
+
+    unres = dg.unresolved(all_flags)
+    interp = interpreter_id(python)
+    if verbose:
+        _report(slug, targets, all_flags, unres, oo, undecidable, rc, interp)
+    if census_path:
+        write_census(census_path, slug, all_flags, oo, undecidable, interp)
+    if undecidable:
+        return EXIT_UNDECIDABLE
+    return EXIT_FLAGS if unres else EXIT_CLEAN
+
+
+def _report(slug, targets, flags, unres, oo, undecidable, rc, interp):
+    code, nfail = rc if isinstance(rc, tuple) else (rc, 0)
+    print(f"== {slug}")
+    print(f"   interpreter  : {interp}")
+    print(f"   instrumented : {len(targets)} guard file(s)   (pytest rc={code})")
+    if nfail:
+        # 🔴 A branch inside a test that FAILED did not run for a reason other
+        # than deadness. Saying "N flagged" over a red run, without this line,
+        # would be the over-claim this tool exists to stop.
+        print(f"   🔴 RED RUN   : {nfail} test(s) FAILED. Branches downstream of "
+              f"a failure did not execute for a reason that is NOT deadness -- "
+              f"flags in those files are weaker evidence. Green the run, or "
+              f"attribute each flag by hand.")
+    print(f"   NOT measured : {len(oo)} registered out-of-instrument row(s) -- "
+          f"bash / TypeScript / Go")
+    print(f"   flagged      : {len(flags)} branch bodies never executed "
+          f"({len(flags) - len(unres)} justified, {len(unres)} unresolved)")
+    for f in sorted(unres, key=lambda x: (x.path, x.branch.first_line)):
+        b = f.branch
+        print(f"   FLAG {f.path}:{b.first_line} [{b.kind}] {b.snippet}")
+    for u in undecidable:
+        print(f"   UNDECIDABLE {u}")
+
+
+def write_census(path, slug, flags, oo, undecidable, interp="?"):
+    p = pathlib.Path(path)
+    new = not p.exists()
+    with p.open("a", encoding="utf-8") as fh:
+        if new:
+            fh.write("# Measured census of guard branches with zero corpus "
+                     "instances. Regenerate: scripts/dead-guard-scan.py --repo "
+                     "<path> --census <this file>\n")
+            fh.write("# `status` out-of-instrument rows are NOT a clean result "
+                     "-- they are guards this tool cannot see. See "
+                     "scripts/data/dead-guard-registry.tsv.\n")
+            fh.write("repo_slug\tstatus\tlocation\tkind\tcase_handled"
+                     "\tcorpus_instances\tjustification\n")
+        # The interpreter is part of the measurement: a different one takes
+        # different branches, so a census without it is not reproducible.
+        fh.write(f"# {slug} measured under {interp}\n")
+        for f in sorted(flags, key=lambda x: (x.path, x.branch.first_line)):
+            b = f.branch
+            fh.write(f"{slug}\tflagged\t{f.path}:{b.first_line}\t{b.kind}\t"
+                     f"{b.snippet}\t0\t{f.justified_reason or '-'}\n")
+        for r in oo:
+            fh.write(f"{slug}\tout-of-instrument\t-\t{r['lang']}\t"
+                     f"{r['selector']}\tunmeasured\t-\n")
+        for u in undecidable:
+            fh.write(f"{slug}\tundecidable\t{u}\t-\t-\t-\t-\n")
+
+
+# --------------------------------------------------------------------------
+# controls
+
+_LIVE = '''
+def scan(lines):
+    hits = []
+    for ln in lines:
+        if "MARKER" in ln:
+            hits.append(ln)
+    return hits
+'''
+
+_DEAD = '''
+def scan(lines):
+    hits = []
+    for ln in lines:
+        if "MARKER" in ln:
+            hits.append(ln)
+        if "NOBODY_WRITES_THIS" in ln:
+            hits.append("dead")
+    return hits
+'''
+
+
+def _controls(body, corpus_line):
+    """Run the real analysis over a synthetic guard, driven for real."""
+    ns = {}
+    exec(compile(body, "<control>", "exec"), ns)
+    executed = set()
+    target = "<control>"
+
+    def tracer(frame, event, arg):
+        if frame.f_code.co_filename == target:
+            if event == "line":
+                executed.add(frame.f_lineno)
+            return tracer
+        return None
+
+    sys.settrace(tracer)
+    try:
+        ns["scan"]([corpus_line])
+    finally:
+        sys.settrace(None)
+    return dg.evaluate("<control>", body, executed)
+
+
+def self_test():
+    """🔴 A detector shown only to go GREEN has not been shown to work.
+
+    Both directions are driven here, plus the justification hatch and the
+    `__main__` exclusion, because every one of them is a way this tool could
+    report a comforting zero while measuring nothing.
+    """
+    ok = True
+
+    # POSITIVE CONTROL -- a planted zero-instance branch MUST be flagged.
+    flags = _controls(_DEAD, "a MARKER here")
+    hit = [f for f in flags if "NOBODY_WRITES_THIS" in f.branch.snippet
+           or f.branch.snippet == 'hits.append("dead")']
+    print(f"positive control (planted dead branch): {len(flags)} flag(s) "
+          f"-> {[f'{f.branch.kind}:{f.branch.first_line}' for f in flags]}")
+    ok &= len(flags) == 1 and bool(hit)
+
+    # NEGATIVE CONTROL -- a branch with a real corpus instance must NOT flag.
+    flags = _controls(_LIVE, "a MARKER here")
+    print(f"negative control (branch with a real instance): {len(flags)} flag(s)")
+    ok &= flags == []
+
+    # NEGATIVE CONTROL -- the tool must be able to see the SAME guard go dead
+    # when the corpus stops containing the case. Without this, the positive
+    # above could be a property of the source text rather than of execution.
+    flags = _controls(_LIVE, "nothing matching")
+    print(f"corpus control (same guard, corpus lacks the case): "
+          f"{len(flags)} flag(s)")
+    ok &= len(flags) == 1
+
+    # HATCH -- a one-line justification at the site resolves a flag, and a
+    # BARE marker with no reason does not.
+    src = _DEAD.replace('if "NOBODY_WRITES_THIS" in ln:',
+                        'if "NOBODY_WRITES_THIS" in ln:  # pragma: no cover - unreachable by design')
+    flags = _controls(src, "a MARKER here")
+    print(f"hatch control (justified): {len(flags)} flag(s), "
+          f"{len(dg.unresolved(flags))} unresolved")
+    ok &= len(flags) == 1 and dg.unresolved(flags) == []
+
+    # HATCH NEGATIVE -- `# pragma: no cover` with NO reason must NOT resolve.
+    src = _DEAD.replace('if "NOBODY_WRITES_THIS" in ln:',
+                        'if "NOBODY_WRITES_THIS" in ln:  # pragma: no cover')
+    flags = _controls(src, "a MARKER here")
+    print(f"hatch control (bare marker, no reason): "
+          f"{len(dg.unresolved(flags))} unresolved (want 1)")
+    ok &= len(dg.unresolved(flags)) == 1
+
+    # EXCLUSION -- `if __name__ == "__main__":` is a module entry point, not a
+    # guard branch, and never runs under a runner.
+    n = len(dg.branch_bodies('if __name__ == "__main__":\n    pass\n'))
+    print(f"__main__ exclusion: {n} branch bodies enumerated (want 0)")
+    ok &= n == 0
+
+    # SUB-LINE LIMIT, asserted rather than only documented: a ternary and an
+    # `and` are NOT enumerated, so they can never be silently reported clean.
+    n = len(dg.branch_bodies("x = 1 if a else 2\ny = a and b\n"))
+    print(f"sub-line branches enumerated: {n} (want 0 -- stated limit)")
+    ok &= n == 0
+
+    print("SELF-TEST: %s" % ("PASS" if ok else "FAIL"))
+    return EXIT_CLEAN if ok else EXIT_FLAGS
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--repo", help="path to a clone to scan")
+    ap.add_argument("--census", help="append the measured census to this TSV")
+    ap.add_argument("--self-test", action="store_true",
+                    help="run the detector's own positive/negative controls")
+    ap.add_argument("--registry", default=None,
+                    help="registry TSV to use instead of the committed one "
+                         "(the detector's own end-to-end tests drive it this way)")
+    ap.add_argument("--python", default=None,
+                    help="interpreter to run the guards under. Defaults to the "
+                         "one running this script, which under direnv is the "
+                         "venv of your CWD -- not necessarily the target repo's")
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+    if not args.repo:
+        ap.error("give --repo <path>, or --self-test")
+    return scan(args.repo, args.census, python=args.python,
+                registry=args.registry)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dead-guard-scan.py
+++ b/scripts/dead-guard-scan.py
@@ -168,17 +168,23 @@ def unregistered_test_dirs(repo, rows, slug):
             # `scripts/collector/tests` would silently accept a later
             # `scripts/collector/`, which is a different directory needing its
             # own decision.
-            # 🔴 ...AND ONLY FOR `instrument` ROWS. The out-of-instrument
-            # column is PROSE, and prose is full of dotted words: the bash row
-            # naming `scripts/drift-check.sh` registered the bare directory
-            # `scripts` in three repos, so a future `scripts/test_x.py` would
-            # have been silently accepted -- the exact "everything is
-            # registered" this function exists to prevent, re-admitted through
-            # the sentence rather than the path.
-            if r["status"] != "instrument":
-                continue
+            # An `instrument`-only restriction used to sit here too, to stop
+            # PROSE ("scripts/drift-check.sh") registering `scripts`. The
+            # test-file rule below subsumes it -- prose rarely names a
+            # `test_*.py`, and when it does, naming that directory is correct.
+            # Deleted rather than kept: a mutation sweep showed it changed
+            # nothing, which is this tool's own subject.
+            # 🔴 ...AND ONLY FOR A SELECTOR NAMING A **TEST FILE**. This ledger's
+            # unit is TEST DIRECTORIES, so only a `test_*.py` selector says
+            # anything about one. Registering the parent of any file selector
+            # re-opened the hole from the other side: `scripts/dead-guard-scan.py`
+            # is a library module, and registering its parent put the bare
+            # top-level `scripts` on the list -- so a future `scripts/test_x.py`
+            # was silently accepted, exactly the forward guarantee the registry
+            # header promises. Measured: planting `scripts/test_planted_guard.py`
+            # went from CAUGHT to silently accepted when that row was added.
             last = tok.rsplit("/", 1)[-1]
-            if "/" in tok and ("." in last or "*" in last or "?" in last):
+            if "/" in tok and last.startswith("test_"):
                 named.add(tok.rsplit("/", 1)[0])
     # EXACT membership only. An earlier attempt also accepted a directory when
     # some registered path sat BELOW it, which re-admitted the permissive
@@ -374,7 +380,8 @@ def scan(repo, census_path=None, verbose=True, python=None, registry=None):
             src = t.read_text(encoding="utf-8")
             dg.branch_bodies(src, rel)
         except (SyntaxError, ValueError, OSError) as e:
-            # TWO names, not five. An audit found that only SyntaxError and
+            # THREE names, not five (it was two before OSError was added
+            # for the mode-000 case). An audit found that only SyntaxError and
             # IndentationError were caught, so a file this tool could not
             # analyse escaped as a traceback and exit 1 -- indistinguishable
             # from "found dead branches" -- and no census was written at all.

--- a/scripts/lib/dead_guard.py
+++ b/scripts/lib/dead_guard.py
@@ -189,29 +189,47 @@ def evaluate(path, src, executed):
     recorded the mutant as an expected survivor. That claim was wrong, and a
     `global` declaration is the counterexample; it is now a fixture.)
 
-    🔴 WHERE A JUSTIFICATION MAY SIT, and why it is not "anywhere near":
-    an `if` and its `else` share a condition line, so reading the hatch from
-    `cond_line` for BOTH meant one comment written about one branch silenced
-    two -- a silent false negative with no workaround. The condition line is
-    now consulted only for the branch it actually introduces (`if-body`);
-    every other kind reads the hatch from its own body span. An `else:`,
-    `case X:` or loop-`else:` LINE ITSELF still resolves nothing: put the
-    comment on the first line of the body instead.
+    🔴 WHERE A JUSTIFICATION MAY SIT. Exactly two places: the branch's own
+    HEADER line, and the FIRST line of its body. Both narrower rules that were
+    tried are wrong in a way that costs a reader something:
+
+      * reading `cond_line` for EVERY kind silenced an `else` with a comment
+        written about its `if` -- they share a condition line, so one comment
+        resolved two branches. A silent false negative with no workaround.
+      * restricting `cond_line` to `if-body` over-corrected and broke
+        `except <E>:  # pragma: no cover - reason`, the idiomatic and
+        coverage.py-compatible placement. It silently invalidated four
+        justifications that already existed in the scanned repos' source and
+        flipped them to unresolved flags in the committed census.
+      * reading ANY line of the body span let a NESTED branch's comment resolve
+        its PARENT: when a parent is dead its children are too, so there was no
+        placement that justified the inner without silencing the outer --
+        strictly worse than the defect being fixed.
+
+    So: `cond_line` is read for every kind EXCEPT `else-body`, because
+    `else-body` is the only kind whose header line introduces a SIBLING branch
+    as well as its own. `except <E>:`, `case X:` and a loop's `else:` each
+    introduce exactly one branch and cannot silence anything else. The body is
+    read at its FIRST line only, which is owned by this branch and by no nested
+    one. An `else:` line itself still resolves nothing -- put the comment on the
+    first line of its body.
     """
     just = justifications(src)
     flags = []
     for b in branch_bodies(src, path):
         if any(ln in executed for ln in b.lines()):
             continue
-        reason = None
-        if b.kind == "if-body":
-            reason = just.get(b.cond_line)
-        if not reason:
-            for ln in b.lines():
-                if just.get(ln):
-                    reason = just[ln]
-                    break
-        flags.append(Flag(path, b, reason or None))
+        # 🔴 CARRY THE REASON FAITHFULLY, INCLUDING AN EMPTY ONE. Whether a
+        # bare marker counts is decided in ONE place -- `unresolved` -- and
+        # nowhere else. Three coercions used to enforce it independently
+        # (`if not reason`, `reason or None`, and `unresolved`), so no single
+        # mutation could flip the rule and the battery could not test it: the
+        # duplicated-predicate shape this repo's rules call out, in the guard
+        # written to find duplicated predicates.
+        reason = just.get(b.cond_line) if b.kind != "else-body" else None
+        if reason is None:
+            reason = just.get(b.first_line)
+        flags.append(Flag(path, b, reason))
     return flags
 
 

--- a/scripts/lib/dead_guard.py
+++ b/scripts/lib/dead_guard.py
@@ -23,12 +23,21 @@ VIOLATION-REPORTING branch has zero corpus instances precisely when the repo is
 CLEAN -- that is the branch doing its job. Tracing the corpus alone would flag
 it and recommend deleting the guard's firing path, which is worse than the
 defect. Because the trace covers the whole test run, a reporting branch with a
-planted positive control is exercised BY that control and does not flag. So a
-flag means one of exactly two things, and both are the defect:
+planted positive control is exercised BY that control and does not flag.
+
+🔴 A FLAG IS EVIDENCE, NOT A VERDICT, AND IT HAS THREE READINGS -- ONLY TWO OF
+WHICH ARE DEFECTS:
   (a) dead recognition code -- no corpus instance and no test -> delete it;
   (b) a reporting branch with NO positive control -> the battery does not
-      cover what its comment says it covers.
-Which of the two it is, is the one call a human makes. It is not guessed here.
+      cover what its comment says it covers;
+  (c) NOT A DEFECT: the branch runs somewhere this tracer cannot see -- most
+      often because its test drives the guard through a SUBPROCESS.
+Which one it is, is the call a human makes. It is not guessed here.
+An earlier revision claimed a flag meant "exactly two things, and both are the
+defect". That was itself the over-claiming-guard defect this module exists to
+find: (c) is common -- 8 of this module's own tests drive their subject through
+`subprocess.run` -- and a reviewer told there were only two readings would
+mis-adjudicate every one of them.
 
 🔴 STATED LIMITS, because a limit a reader can act on beats a branch that is
 dead, unexercised and wrong:
@@ -38,6 +47,15 @@ dead, unexercised and wrong:
   - Python only. A guard written in bash, TypeScript or Go is out of
     instrument. The registry records those explicitly rather than letting a
     silent absence read as coverage.
+  - SUBPROCESSES ARE INVISIBLE. `sys.settrace` is per-interpreter, so a guard
+    exercised only by spawning a child python reads as 100% dead. The caller
+    refuses to publish a file whose executed-line count is ZERO for exactly
+    this reason -- but a guard driven PARTLY in-process and partly by
+    subprocess still under-reports, and nothing detects that.
+  - THE TRACER CAN BE DISARMED BY THE CODE UNDER TEST. `sys.settrace` is one
+    global slot; any test that clears it costs this instrument every line
+    after that point. The plugin re-arms per test AND reports `clobbered`, and
+    the caller refuses to publish when it is set.
   - A guard must be INVOCABLE. One that cannot be run is reported UNDECIDABLE,
     never silently passed.
   - This measures the run you gave it. A branch reachable only under a

--- a/scripts/lib/dead_guard.py
+++ b/scripts/lib/dead_guard.py
@@ -41,6 +41,9 @@ mis-adjudicate every one of them.
 
 🔴 STATED LIMITS, because a limit a reader can act on beats a branch that is
 dead, unexercised and wrong:
+  - NOT EVERY BRANCH IS ENUMERATED. `try/.../else:` and `async for/.../else:`
+    bodies are absent -- only `ExceptHandler` and `For`/`While` orelse are
+    walked. They are not reported clean; they are not reported at all.
   - LINE granularity. A sub-line branch -- `a and b`, a ternary, a
     comprehension `if` -- cannot be discriminated by line coverage and is NOT
     enumerated. It is not reported as clean; it is not reported at all.
@@ -208,11 +211,29 @@ def evaluate(path, src, executed):
 
     So: `cond_line` is read for every kind EXCEPT `else-body`, because
     `else-body` is the only kind whose header line introduces a SIBLING branch
-    as well as its own. `except <E>:`, `case X:` and a loop's `else:` each
-    introduce exactly one branch and cannot silence anything else. The body is
-    read at its FIRST line only, which is owned by this branch and by no nested
-    one. An `else:` line itself still resolves nothing -- put the comment on the
-    first line of its body.
+    as well as its own.
+
+    🔴 WHICH LINE IS `cond_line` DIFFERS BY KIND, and an earlier version of
+    this docstring got two of them wrong. Measured:
+      * `if-body`   -> the `if`/`elif` test line. Read.
+      * `except`    -> the `except <E>:` line. Read -- the idiomatic placement.
+      * `else-body` -> the `if` test line (shared with its sibling). NOT read.
+      * `match-case`-> the first line of the case BODY, not the `case X:` line.
+        So a comment on `case X:` resolves NOTHING.
+      * `loop-else` -> the `for`/`while` line, not the `else:` line. So a
+        comment on the loop's `else:` resolves NOTHING -- and one on the `for`
+        line resolves the loop-else, which is a collision of the same family as
+        the if/else one, in the other direction.
+    For those two kinds, put the comment on the FIRST LINE OF THE BODY. That
+    placement always works, for every kind.
+
+    🔴 AND "the body's first line is owned by no nested branch" IS NOT QUITE
+    TRUE: a nested loop's header IS its parent's body-first line, so
+    `if a:` / `for x in xs:  # pragma` / `else:` resolves the outer `if-body`
+    and the inner `loop-else` from one comment. Stated rather than fixed --
+    every candidate fix so far has traded one collision for another, and this
+    one fails CLOSED in the direction that matters least (it over-resolves a
+    branch whose parent is already justified).
     """
     just = justifications(src)
     flags = []
@@ -234,5 +255,14 @@ def evaluate(path, src, executed):
 
 
 def unresolved(flags):
-    """Flags with no justification -- the ones that fail the run."""
-    return [f for f in flags if not f.justified_reason]
+    r"""Flags with no justification -- the ones that fail the run.
+
+    🔴 THE SOLE ARBITER of whether a marker counts, and it requires a WORD
+    CHARACTER, not merely a non-empty string. `[:\s-]*` in the pattern strips
+    the ASCII hyphen only, so `# pragma: no cover \u2014` (an EM DASH -- which is
+    what every real justification site in this repo uses) yielded the reason
+    "\u2014" and resolved the flag. A bare marker with a punctuation mark after it
+    is still a bare marker.
+    """
+    return [f for f in flags
+            if not (f.justified_reason and re.search(r"\w", f.justified_reason))]

--- a/scripts/lib/dead_guard.py
+++ b/scripts/lib/dead_guard.py
@@ -160,35 +160,57 @@ def justifications(src):
     full of string literals containing the very patterns they scan for.
     """
     out = {}
-    try:
-        toks = tokenize.generate_tokens(io.StringIO(src).readline)
-        for tok in toks:
-            if tok.type != tokenize.COMMENT:
-                continue
-            m = _JUSTIFY_RE.search(tok.string)
-            if m:
-                out[tok.start[0]] = m.group("reason").strip()
-    except (tokenize.TokenError, IndentationError, SyntaxError):
-        # A file that will not tokenize cannot be judged. The caller reports it
-        # as undecidable; returning {} here would silently mean "unjustified".
-        raise
+    toks = tokenize.generate_tokens(io.StringIO(src).readline)
+    for tok in toks:
+        if tok.type != tokenize.COMMENT:
+            continue
+        m = _JUSTIFY_RE.search(tok.string)
+        if m:
+            out[tok.start[0]] = m.group("reason").strip()
+    # A file that will not tokenize cannot be judged -- the exception is left to
+    # propagate and the caller reports it as undecidable. There is deliberately
+    # no `except: raise` here: it was a no-op that existed only to hold this
+    # comment, which is a branch that reads as handling and handles nothing.
     return out
 
 
 def evaluate(path, src, executed):
     """Flags for one file: branch bodies with no executed line.
 
-    `executed` is the set of line numbers reached during the run. A branch
-    counts as TAKEN if ANY line in its body span ran -- not merely its first
-    line -- because CPython's line attribution for a multi-line statement is
-    not guaranteed to be the statement's first line.
+    `executed` is the set of line numbers reached during the run.
+
+    🔴 A BRANCH IS TAKEN IF **ANY** LINE IN ITS BODY SPAN RAN, NOT MERELY ITS
+    FIRST. This is pinned behaviour, not defensive width: a statement that
+    emits NO BYTECODE -- `global x`, `nonlocal x` -- never produces a line
+    event, so a body whose first statement is one of those has an untraceable
+    first line while the rest of it plainly runs. Narrowing the span to the
+    first line reports such a branch DEAD while it is executing.
+    (An earlier revision claimed no reachable input distinguished the two and
+    recorded the mutant as an expected survivor. That claim was wrong, and a
+    `global` declaration is the counterexample; it is now a fixture.)
+
+    🔴 WHERE A JUSTIFICATION MAY SIT, and why it is not "anywhere near":
+    an `if` and its `else` share a condition line, so reading the hatch from
+    `cond_line` for BOTH meant one comment written about one branch silenced
+    two -- a silent false negative with no workaround. The condition line is
+    now consulted only for the branch it actually introduces (`if-body`);
+    every other kind reads the hatch from its own body span. An `else:`,
+    `case X:` or loop-`else:` LINE ITSELF still resolves nothing: put the
+    comment on the first line of the body instead.
     """
     just = justifications(src)
     flags = []
     for b in branch_bodies(src, path):
         if any(ln in executed for ln in b.lines()):
             continue
-        reason = just.get(b.cond_line) or just.get(b.first_line)
+        reason = None
+        if b.kind == "if-body":
+            reason = just.get(b.cond_line)
+        if not reason:
+            for ln in b.lines():
+                if just.get(ln):
+                    reason = just[ln]
+                    break
         flags.append(Flag(path, b, reason or None))
     return flags
 

--- a/scripts/lib/dead_guard.py
+++ b/scripts/lib/dead_guard.py
@@ -1,0 +1,180 @@
+"""Branch-liveness analysis for guards: which branch bodies never run.
+
+WHAT THIS ANSWERS
+-----------------
+A guard whose branches handle spellings nobody writes reads as safety while
+providing none. `claude/RULES.md` -> "A guard's DESCRIPTION claims COVERAGE".
+The remedy that worked (browser-bridge `_cli_timeout_violations`, PR #820) was
+NOT hardening: delete the unexercised branches and state the limit. This module
+is the measurement that finds them, so the next one is found by a command
+instead of by four audit rounds.
+
+HOW "ZERO CORPUS INSTANCES" IS OPERATIONALISED
+----------------------------------------------
+A branch body has zero corpus instances when it is never EXECUTED while the
+guard runs against the real corpus AND against the guard's own test battery.
+That is exact for a corpus-scanning guard and requires no inference about what
+case a branch handles -- the alternative (count occurrences of the spelling the
+branch matches) needs a heuristic reading of the branch's intent, which would
+itself be an instance of the defect this module exists to find.
+
+🔴 THE BATTERY HALF IS LOAD-BEARING, NOT A REFINEMENT. A guard's
+VIOLATION-REPORTING branch has zero corpus instances precisely when the repo is
+CLEAN -- that is the branch doing its job. Tracing the corpus alone would flag
+it and recommend deleting the guard's firing path, which is worse than the
+defect. Because the trace covers the whole test run, a reporting branch with a
+planted positive control is exercised BY that control and does not flag. So a
+flag means one of exactly two things, and both are the defect:
+  (a) dead recognition code -- no corpus instance and no test -> delete it;
+  (b) a reporting branch with NO positive control -> the battery does not
+      cover what its comment says it covers.
+Which of the two it is, is the one call a human makes. It is not guessed here.
+
+🔴 STATED LIMITS, because a limit a reader can act on beats a branch that is
+dead, unexercised and wrong:
+  - LINE granularity. A sub-line branch -- `a and b`, a ternary, a
+    comprehension `if` -- cannot be discriminated by line coverage and is NOT
+    enumerated. It is not reported as clean; it is not reported at all.
+  - Python only. A guard written in bash, TypeScript or Go is out of
+    instrument. The registry records those explicitly rather than letting a
+    silent absence read as coverage.
+  - A guard must be INVOCABLE. One that cannot be run is reported UNDECIDABLE,
+    never silently passed.
+  - This measures the run you gave it. A branch reachable only under a
+    different environment reads as dead here; that is why the resolution is
+    "delete or justify at the site", under a human's eye, not an auto-fix.
+"""
+
+import ast
+import io
+import re
+import tokenize
+from dataclasses import dataclass
+
+# A one-line justification at the site. `# pragma: no cover` is the spelling
+# already in this repo (`scripts/tests/test_no_public_ips.py`), so it is reused
+# rather than a second marker being minted for the same job. A REASON is
+# required: a bare marker asserts nothing, and the whole class being fixed here
+# is claims with nothing behind them.
+_JUSTIFY_RE = re.compile(
+    r"#\s*(?:pragma:\s*no\s*cover|dead-guard-ok)\b[:\s-]*(?P<reason>.*)$")
+
+# `if __name__ == "__main__":` never runs under a test runner. Excluded
+# mechanically -- an exact AST shape match, not a name heuristic -- because it
+# is a module entry point, not a guard branch.
+_MAIN_GUARD = "__name__"
+
+
+@dataclass(frozen=True)
+class Branch:
+    kind: str          # if-body | else-body | except | match-case | loop-else
+    cond_line: int     # the line carrying the condition (where a justification may sit)
+    first_line: int    # first line of the body
+    last_line: int     # last line of the body
+    snippet: str       # the body's first line, stripped, for the census
+
+    def lines(self):
+        return range(self.first_line, self.last_line + 1)
+
+
+@dataclass(frozen=True)
+class Flag:
+    path: str
+    branch: Branch
+    justified_reason: str | None
+
+
+def _is_main_guard(node):
+    """`if __name__ == '__main__':` -- exact shape, not a text match."""
+    t = node.test
+    return (isinstance(t, ast.Compare)
+            and isinstance(t.left, ast.Name) and t.left.id == _MAIN_GUARD
+            and len(t.ops) == 1 and isinstance(t.ops[0], ast.Eq))
+
+
+def _span(body):
+    first = body[0].lineno
+    last = max((getattr(s, "end_lineno", None) or s.lineno) for s in body)
+    return first, last
+
+
+def branch_bodies(src, filename="<src>"):
+    """Every LINE-DISCRIMINABLE conditional branch body in `src`.
+
+    Sub-line branches are deliberately absent -- see the module docstring's
+    stated limits. `elif` needs no special case: ast nests it as an `If` inside
+    `orelse`, so it is enumerated on its own walk step.
+    """
+    tree = ast.parse(src, filename=filename)
+    lines = src.splitlines()
+
+    def mk(kind, cond_line, body):
+        first, last = _span(body)
+        snip = lines[first - 1].strip() if 0 < first <= len(lines) else ""
+        return Branch(kind, cond_line, first, last, snip[:100])
+
+    out = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.If):
+            if _is_main_guard(node):
+                continue
+            out.append(mk("if-body", node.test.lineno, node.body))
+            # An `else` whose sole statement is an `If` IS an elif -- skip it
+            # here; the walk reaches that If on its own and reports it as
+            # `if-body` with its own condition line.
+            if node.orelse and not (len(node.orelse) == 1
+                                    and isinstance(node.orelse[0], ast.If)):
+                out.append(mk("else-body", node.test.lineno, node.orelse))
+        elif isinstance(node, ast.ExceptHandler):
+            out.append(mk("except", node.lineno, node.body))
+        elif isinstance(node, ast.match_case):
+            out.append(mk("match-case", node.body[0].lineno, node.body))
+        elif isinstance(node, (ast.For, ast.While)) and node.orelse:
+            out.append(mk("loop-else", node.lineno, node.orelse))
+    return sorted(out, key=lambda b: (b.first_line, b.kind))
+
+
+def justifications(src):
+    """{lineno: reason} for every one-line justification comment.
+
+    Uses `tokenize`, not a regex over raw lines, so a `#` inside a string
+    literal is not mistaken for a comment. That matters here: these guards are
+    full of string literals containing the very patterns they scan for.
+    """
+    out = {}
+    try:
+        toks = tokenize.generate_tokens(io.StringIO(src).readline)
+        for tok in toks:
+            if tok.type != tokenize.COMMENT:
+                continue
+            m = _JUSTIFY_RE.search(tok.string)
+            if m:
+                out[tok.start[0]] = m.group("reason").strip()
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        # A file that will not tokenize cannot be judged. The caller reports it
+        # as undecidable; returning {} here would silently mean "unjustified".
+        raise
+    return out
+
+
+def evaluate(path, src, executed):
+    """Flags for one file: branch bodies with no executed line.
+
+    `executed` is the set of line numbers reached during the run. A branch
+    counts as TAKEN if ANY line in its body span ran -- not merely its first
+    line -- because CPython's line attribution for a multi-line statement is
+    not guaranteed to be the statement's first line.
+    """
+    just = justifications(src)
+    flags = []
+    for b in branch_bodies(src, path):
+        if any(ln in executed for ln in b.lines()):
+            continue
+        reason = just.get(b.cond_line) or just.get(b.first_line)
+        flags.append(Flag(path, b, reason or None))
+    return flags
+
+
+def unresolved(flags):
+    """Flags with no justification -- the ones that fail the run."""
+    return [f for f in flags if not f.justified_reason]

--- a/scripts/testlib/dead_guard_plugin.py
+++ b/scripts/testlib/dead_guard_plugin.py
@@ -2,12 +2,31 @@
 
 Loaded by `scripts/dead-guard-scan.py` via `-p dead_guard_plugin`. Reads
 `DGS_TARGETS` (os.pathsep-separated absolute paths) and writes
-`{path: [linenos]}` JSON to `DGS_OUT` at interpreter exit.
+`{"executed": {path: [linenos]}, "clobbered": bool, "tests": int}` JSON to
+`DGS_OUT` at interpreter exit.
 
 🔴 `coverage.py` IS NOT INSTALLED ON THIS HOST and is not a dependency of this
 repo, so this uses stdlib `sys.settrace`. `threading.settrace` is set too --
 without it a guard that scans in a worker thread reads as entirely dead, which
 is the exact false positive that would discredit the tool on first contact.
+
+🔴 THE TRACER IS RE-ARMED BEFORE EVERY TEST, AND ITS REMOVAL IS DETECTED.
+`sys.settrace` is a single global slot: ANY test that installs its own tracer
+and then clears it -- `sys.settrace(None)` in a `finally`, a debugger, a
+profiler -- disarms this one for the whole REST of the session. Every guard
+file collected after that point then reports its live branches as DEAD, on a
+GREEN run, with nothing indicating it. That is the tool's worst failure mode
+(condemning working code) arriving in its most believable disguise.
+
+Arming once in `pytest_configure` was exactly that bug: this repo's own
+`scripts/tests/test_dead_guard_scan.py` clears the tracer, and the census
+escaped corruption only because that file happened to sort LAST -- an unpinned
+invariant that one registry row would have broken. So:
+  * re-arm in `pytest_runtest_setup`, before each test's call phase;
+  * ALSO record whether the slot was found empty or foreign at that moment, and
+    surface it as `clobbered` so the caller can refuse to publish rather than
+    publish a false census. Re-arming alone is not enough -- a tracer cleared
+    part-way THROUGH a test still loses that test's lines.
 
 🔴 THE TRACE IS WRITTEN FROM `atexit`, NOT FROM A pytest HOOK. A session that
 dies on a collection error never reaches `pytest_sessionfinish`, and an absent
@@ -30,6 +49,7 @@ _TARGETS = {str(pathlib.Path(p).resolve())
             for p in os.environ.get("DGS_TARGETS", "").split(os.pathsep) if p}
 _OUT = os.environ.get("DGS_OUT", "")
 _executed: dict[str, set[int]] = {}
+_state = {"clobbered": False, "tests": 0}
 
 
 def _tracer(frame, event, arg):
@@ -44,10 +64,27 @@ def _tracer(frame, event, arg):
     return None
 
 
+def _arm():
+    threading.settrace(_tracer)
+    sys.settrace(_tracer)
+
+
 def pytest_configure(config):
     if _TARGETS and _OUT:
-        threading.settrace(_tracer)
-        sys.settrace(_tracer)
+        _arm()
+
+
+def pytest_runtest_setup(item):
+    """Re-arm per test, and remember if someone had taken the slot."""
+    if not (_TARGETS and _OUT):
+        return
+    _state["tests"] += 1
+    if sys.gettrace() is not _tracer:
+        # Someone cleared or replaced our tracer during a previous test. Any
+        # target executed in the interim was not recorded, so the whole trace
+        # is now a LOWER BOUND and must not be published as a measurement.
+        _state["clobbered"] = True
+    _arm()
 
 
 @atexit.register
@@ -57,5 +94,7 @@ def _dump():
     sys.settrace(None)
     threading.settrace(None)
     pathlib.Path(_OUT).write_text(
-        json.dumps({k: sorted(v) for k, v in _executed.items()}),
+        json.dumps({"executed": {k: sorted(v) for k, v in _executed.items()},
+                    "clobbered": _state["clobbered"],
+                    "tests": _state["tests"]}),
         encoding="utf-8")

--- a/scripts/testlib/dead_guard_plugin.py
+++ b/scripts/testlib/dead_guard_plugin.py
@@ -1,0 +1,61 @@
+"""pytest plugin: record which lines of the guard files under test executed.
+
+Loaded by `scripts/dead-guard-scan.py` via `-p dead_guard_plugin`. Reads
+`DGS_TARGETS` (os.pathsep-separated absolute paths) and writes
+`{path: [linenos]}` JSON to `DGS_OUT` at interpreter exit.
+
+🔴 `coverage.py` IS NOT INSTALLED ON THIS HOST and is not a dependency of this
+repo, so this uses stdlib `sys.settrace`. `threading.settrace` is set too --
+without it a guard that scans in a worker thread reads as entirely dead, which
+is the exact false positive that would discredit the tool on first contact.
+
+🔴 THE TRACE IS WRITTEN FROM `atexit`, NOT FROM A pytest HOOK. A session that
+dies on a collection error never reaches `pytest_sessionfinish`, and an absent
+output file is indistinguishable from "nothing executed" -- a zero that reads
+as a finding. `atexit` fires on both paths, so the caller can tell an empty
+trace (real) from a missing one (the run never started).
+
+Scoped to `DGS_TARGETS` only: tracing everything would cost minutes per run and
+report ordinary application branches, which are not guards.
+"""
+
+import atexit
+import json
+import os
+import pathlib
+import sys
+import threading
+
+_TARGETS = {str(pathlib.Path(p).resolve())
+            for p in os.environ.get("DGS_TARGETS", "").split(os.pathsep) if p}
+_OUT = os.environ.get("DGS_OUT", "")
+_executed: dict[str, set[int]] = {}
+
+
+def _tracer(frame, event, arg):
+    fn = frame.f_code.co_filename
+    if fn in _TARGETS:
+        if event == "line":
+            _executed.setdefault(fn, set()).add(frame.f_lineno)
+        return _tracer
+    # Returning None declines to trace this frame's lines, but `call` events
+    # for frames it invokes are still offered -- so a target called from a
+    # non-target module is still seen.
+    return None
+
+
+def pytest_configure(config):
+    if _TARGETS and _OUT:
+        threading.settrace(_tracer)
+        sys.settrace(_tracer)
+
+
+@atexit.register
+def _dump():
+    if not _OUT:
+        return
+    sys.settrace(None)
+    threading.settrace(None)
+    pathlib.Path(_OUT).write_text(
+        json.dumps({k: sorted(v) for k, v in _executed.items()}),
+        encoding="utf-8")

--- a/scripts/testlib/dead_guard_plugin.py
+++ b/scripts/testlib/dead_guard_plugin.py
@@ -97,16 +97,31 @@ def pytest_runtest_setup(item):
     _arm()
 
 
+def pytest_runtest_teardown(item):
+    """🔴 CHECK AFTER EACH TEST TOO, NOT AT INTERPRETER EXIT.
+
+    Detection at `pytest_runtest_setup` alone can never see a clobber in the
+    LAST test -- there is no next setup -- which is exactly the "it only
+    survived because that file sorted last" shape this detector exists for.
+
+    🔴 BUT THE CHECK MUST NOT LIVE IN `atexit`. `atexit` is LIFO, so any
+    cleanup the TARGET REPO registered after this module was imported runs
+    BEFORE the dump -- and an ordinary `atexit.register(lambda:
+    sys.settrace(None))` in a library then trips the detector on a run whose
+    trace was complete and correct. Measured: identical executed-line set to a
+    clean baseline, yet `clobbered=true`, so the scan returned UNDECIDABLE and
+    blamed "a test cleared sys.settrace" for something no test did. A
+    permanently-red gate with a false cause. Teardown fires inside the run,
+    before any of that.
+    """
+    if _TARGETS and _OUT and sys.gettrace() is not _tracer:
+        _state["clobbered"] = True
+
+
 @atexit.register
 def _dump():
     if not _OUT:
         return
-    # 🔴 CHECK ONE LAST TIME. Detection at `pytest_runtest_setup` alone can
-    # never see a clobber in the LAST test -- there is no next setup -- which is
-    # exactly the "it only survived because that file sorted last" shape this
-    # detector exists for.
-    if _TARGETS and sys.gettrace() is not _tracer:
-        _state["clobbered"] = True
     sys.settrace(None)
     threading.settrace(None)
     pathlib.Path(_OUT).write_text(

--- a/scripts/testlib/dead_guard_plugin.py
+++ b/scripts/testlib/dead_guard_plugin.py
@@ -24,7 +24,8 @@ escaped corruption only because that file happened to sort LAST -- an unpinned
 invariant that one registry row would have broken. So:
   * re-arm in `pytest_runtest_setup`, before each test's call phase;
   * ALSO record whether the slot was found empty or foreign at that moment,
-    and again at exit, and surface it as `clobbered` so the caller can refuse
+    at each teardown, and at session end, and surface it as `clobbered` so the
+    caller can refuse
     to publish rather than publish a false census. Re-arming alone is not
     enough -- a tracer cleared part-way THROUGH a test still loses that test's
     lines.
@@ -113,6 +114,23 @@ def pytest_runtest_teardown(item):
     blamed "a test cleared sys.settrace" for something no test did. A
     permanently-red gate with a false cause. Teardown fires inside the run,
     before any of that.
+    """
+    if _TARGETS and _OUT and sys.gettrace() is not _tracer:
+        _state["clobbered"] = True
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """🔴 AND ONCE MORE AT SESSION END, because teardown is not last either.
+
+    A `-p`-loaded hookimpl runs BEFORE pytest's own teardown machinery, so a
+    FIXTURE FINALIZER that clears the tracer runs after `pytest_runtest_teardown`
+    has already looked. For every test but the last, the next `setup` still
+    catches it; for the last test nothing did. Measured: a last-test fixture
+    finalizer clearing the slot went from `clobbered=true` (round 2, via the
+    atexit check) to `false` (round 3, teardown only) -- the round-3 commit
+    claimed "blind spot unchanged", and it had changed. This closes it without
+    reintroducing the atexit false positive, because `sessionfinish` still runs
+    inside the run, before any target module's `atexit` cleanup.
     """
     if _TARGETS and _OUT and sys.gettrace() is not _tracer:
         _state["clobbered"] = True

--- a/scripts/testlib/dead_guard_plugin.py
+++ b/scripts/testlib/dead_guard_plugin.py
@@ -10,34 +10,16 @@ repo, so this uses stdlib `sys.settrace`. `threading.settrace` is set too --
 without it a guard that scans in a worker thread reads as entirely dead, which
 is the exact false positive that would discredit the tool on first contact.
 
-🔴 THE TRACER IS RE-ARMED BEFORE EVERY TEST, AND ITS REMOVAL IS DETECTED.
+🔴 THE TRACER IS ARMED ONCE AND ITS REMOVAL IS DETECTED AT SESSION END.
 `sys.settrace` is a single global slot: ANY test that installs its own tracer
 and then clears it -- `sys.settrace(None)` in a `finally`, a debugger, a
-profiler -- disarms this one for the whole REST of the session. Every guard
-file collected after that point then reports its live branches as DEAD, on a
-GREEN run, with nothing indicating it. That is the tool's worst failure mode
-(condemning working code) arriving in its most believable disguise.
+profiler -- disarms this one for the rest of the session. Every guard file
+collected after that point then reports its live branches as DEAD, on a GREEN
+run, with nothing indicating it. That is the tool's worst failure mode
+(condemning working code) in its most believable disguise, so a run in which it
+happened is REFUSED rather than published. See `pytest_sessionfinish` for why
+that is one check and not four.
 
-Arming once in `pytest_configure` was exactly that bug: this repo's own
-`scripts/tests/test_dead_guard_scan.py` clears the tracer, and the census
-escaped corruption only because that file happened to sort LAST -- an unpinned
-invariant that one registry row would have broken. So:
-  * re-arm in `pytest_runtest_setup`, before each test's call phase;
-  * ALSO record whether the slot was found empty or foreign at that moment,
-    at each teardown, and at session end, and surface it as `clobbered` so the
-    caller can refuse
-    to publish rather than publish a false census. Re-arming alone is not
-    enough -- a tracer cleared part-way THROUGH a test still loses that test's
-    lines.
-
-🔴 STATED BLIND SPOT: a test that SAVES AND RESTORES the tracer around its own
-is invisible to this. The slot holds our tracer at every boundary we can
-inspect, yet target lines executed inside that window were never recorded. That
-is not hypothetical -- save-and-restore is the well-behaved pattern, and it is
-what this repo's own suite does. The consequence is under-recording, i.e. a
-FALSE POSITIVE against live code, and nothing here detects it. If a guard's
-tests install a tracer, scan them separately or expect flags you must
-adjudicate by hand.
 
 🔴 THE TRACE IS WRITTEN FROM `atexit`, NOT FROM A pytest HOOK. A session that
 dies on a collection error never reaches `pytest_sessionfinish`, and an absent
@@ -60,7 +42,7 @@ _TARGETS = {str(pathlib.Path(p).resolve())
             for p in os.environ.get("DGS_TARGETS", "").split(os.pathsep) if p}
 _OUT = os.environ.get("DGS_OUT", "")
 _executed: dict[str, set[int]] = {}
-_state = {"clobbered": False, "tests": 0}
+_state = {"clobbered": False}
 
 
 def _tracer(frame, event, arg):
@@ -85,52 +67,37 @@ def pytest_configure(config):
         _arm()
 
 
-def pytest_runtest_setup(item):
-    """Re-arm per test, and remember if someone had taken the slot."""
-    if not (_TARGETS and _OUT):
-        return
-    _state["tests"] += 1
-    if sys.gettrace() is not _tracer:
-        # Someone cleared or replaced our tracer during a previous test. Any
-        # target executed in the interim was not recorded, so the whole trace
-        # is now a LOWER BOUND and must not be published as a measurement.
-        _state["clobbered"] = True
-    _arm()
-
-
-def pytest_runtest_teardown(item):
-    """🔴 CHECK AFTER EACH TEST TOO, NOT AT INTERPRETER EXIT.
-
-    Detection at `pytest_runtest_setup` alone can never see a clobber in the
-    LAST test -- there is no next setup -- which is exactly the "it only
-    survived because that file sorted last" shape this detector exists for.
-
-    🔴 BUT THE CHECK MUST NOT LIVE IN `atexit`. `atexit` is LIFO, so any
-    cleanup the TARGET REPO registered after this module was imported runs
-    BEFORE the dump -- and an ordinary `atexit.register(lambda:
-    sys.settrace(None))` in a library then trips the detector on a run whose
-    trace was complete and correct. Measured: identical executed-line set to a
-    clean baseline, yet `clobbered=true`, so the scan returned UNDECIDABLE and
-    blamed "a test cleared sys.settrace" for something no test did. A
-    permanently-red gate with a false cause. Teardown fires inside the run,
-    before any of that.
-    """
-    if _TARGETS and _OUT and sys.gettrace() is not _tracer:
-        _state["clobbered"] = True
-
-
 def pytest_sessionfinish(session, exitstatus):
-    """🔴 AND ONCE MORE AT SESSION END, because teardown is not last either.
+    """🔴 ONE DETECTION SITE, BECAUSE THE OTHER THREE WERE REDUNDANT.
 
-    A `-p`-loaded hookimpl runs BEFORE pytest's own teardown machinery, so a
-    FIXTURE FINALIZER that clears the tracer runs after `pytest_runtest_teardown`
-    has already looked. For every test but the last, the next `setup` still
-    catches it; for the last test nothing did. Measured: a last-test fixture
-    finalizer clearing the slot went from `clobbered=true` (round 2, via the
-    atexit check) to `false` (round 3, teardown only) -- the round-3 commit
-    claimed "blind spot unchanged", and it had changed. This closes it without
-    reintroducing the atexit false positive, because `sessionfinish` still runs
-    inside the run, before any target module's `atexit` cleanup.
+    An earlier revision armed the tracer again before EVERY test and checked
+    the slot at `pytest_runtest_setup`, at `pytest_runtest_teardown` AND at
+    interpreter exit. A mutation sweep showed each of those individually
+    deletable with the whole suite still green -- they were catching the same
+    cases as one another, which is the redundant-guard trap: "each died" is a
+    much weaker claim than "each died for its own reason".
+
+    The reasoning that collapses them: a clobber this instrument can DETECT is
+    one that is never put back, and such a clobber persists to session end. So
+    checking once here catches every detectable case -- a clobber in a test
+    body, in a fixture finalizer, in the last test (where teardown-only
+    checking was blind), and one left by a plugin. Per-test re-arming bought
+    nothing, because a clobbered run is REFUSED, never repaired: this reports,
+    it does not recover.
+
+    🔴 NOT AT `atexit`. `atexit` is LIFO, so a target module's own
+    `atexit.register(lambda: sys.settrace(None))` -- ordinary library cleanup
+    -- runs BEFORE the dump and tripped the detector on a run whose trace was
+    complete and correct, returning UNDECIDABLE with a false cause. Session end
+    is inside the run, before any of that.
+
+    🔴 STATED BLIND SPOT: a test that SAVES AND RESTORES the tracer around its
+    own is invisible here and to any slot inspection -- the slot holds our
+    tracer at every boundary, while target lines executed inside that window
+    went unrecorded. That is the well-behaved pattern, and it is what this
+    repo's own suite does. The consequence is under-recording, i.e. a FALSE
+    POSITIVE against live code. If a guard's tests install a tracer, scan them
+    separately or adjudicate their flags by hand.
     """
     if _TARGETS and _OUT and sys.gettrace() is not _tracer:
         _state["clobbered"] = True
@@ -144,6 +111,5 @@ def _dump():
     threading.settrace(None)
     pathlib.Path(_OUT).write_text(
         json.dumps({"executed": {k: sorted(v) for k, v in _executed.items()},
-                    "clobbered": _state["clobbered"],
-                    "tests": _state["tests"]}),
+                    "clobbered": _state["clobbered"]}),
         encoding="utf-8")

--- a/scripts/testlib/dead_guard_plugin.py
+++ b/scripts/testlib/dead_guard_plugin.py
@@ -23,10 +23,20 @@ Arming once in `pytest_configure` was exactly that bug: this repo's own
 escaped corruption only because that file happened to sort LAST -- an unpinned
 invariant that one registry row would have broken. So:
   * re-arm in `pytest_runtest_setup`, before each test's call phase;
-  * ALSO record whether the slot was found empty or foreign at that moment, and
-    surface it as `clobbered` so the caller can refuse to publish rather than
-    publish a false census. Re-arming alone is not enough -- a tracer cleared
-    part-way THROUGH a test still loses that test's lines.
+  * ALSO record whether the slot was found empty or foreign at that moment,
+    and again at exit, and surface it as `clobbered` so the caller can refuse
+    to publish rather than publish a false census. Re-arming alone is not
+    enough -- a tracer cleared part-way THROUGH a test still loses that test's
+    lines.
+
+🔴 STATED BLIND SPOT: a test that SAVES AND RESTORES the tracer around its own
+is invisible to this. The slot holds our tracer at every boundary we can
+inspect, yet target lines executed inside that window were never recorded. That
+is not hypothetical -- save-and-restore is the well-behaved pattern, and it is
+what this repo's own suite does. The consequence is under-recording, i.e. a
+FALSE POSITIVE against live code, and nothing here detects it. If a guard's
+tests install a tracer, scan them separately or expect flags you must
+adjudicate by hand.
 
 🔴 THE TRACE IS WRITTEN FROM `atexit`, NOT FROM A pytest HOOK. A session that
 dies on a collection error never reaches `pytest_sessionfinish`, and an absent
@@ -91,6 +101,12 @@ def pytest_runtest_setup(item):
 def _dump():
     if not _OUT:
         return
+    # 🔴 CHECK ONE LAST TIME. Detection at `pytest_runtest_setup` alone can
+    # never see a clobber in the LAST test -- there is no next setup -- which is
+    # exactly the "it only survived because that file sorted last" shape this
+    # detector exists for.
+    if _TARGETS and sys.gettrace() is not _tracer:
+        _state["clobbered"] = True
     sys.settrace(None)
     threading.settrace(None)
     pathlib.Path(_OUT).write_text(

--- a/scripts/tests/mutants-dead-guard.sh
+++ b/scripts/tests/mutants-dead-guard.sh
@@ -168,7 +168,7 @@ run 'except-handlers-dropped' "$LIB" \
 printf '\n== the justification hatch (must be KILLED) ==\n'
 run 'bare-marker-now-resolves' "$LIB" \
   test_a_justification_needs_a_reason \
-  's|^        flags.append(Flag(path, b, reason or None))|        flags.append(Flag(path, b, "x" if reason is not None else None))|'
+  's|^    return \[f for f in flags if not f.justified_reason\]|    return [f for f in flags if f.justified_reason is None]|'
 run 'reason-no-longer-required' "$LIB" \
   test_a_justification_needs_a_reason \
   's|^    return \[f for f in flags if not f.justified_reason\]|    return []|'
@@ -177,7 +177,7 @@ run 'hatch-read-by-regex-not-tokenize' "$LIB" \
   's|^        if tok.type != tokenize.COMMENT:|        if tok.type == tokenize.COMMENT and False:|'
 run 'body-line-placement-ignored' "$LIB" \
   test_justification_is_read_from_the_condition_line_or_the_body_line \
-  's|^            for ln in b.lines():|            for ln in []:|'
+  's|^            reason = just.get(b.first_line)|            reason = None|'
 
 printf '\n== the zeros that must be UNDECIDABLE, not clean (must be KILLED) ==\n'
 run 'missing-trace-scored-clean' "$CLI" \
@@ -232,7 +232,7 @@ run 'census-drops-the-out-of-instrument-rows' "$CLI" \
   's|^    for r in oo:|    for r in []:|'
 run 'census-goes-back-to-append-only' "$CLI" \
   test_the_census_is_IDEMPOTENT \
-  's|^            if line.startswith(f"{slug}\\t"):|            if False:|'
+  's|^    blocks\[slug\] = mine|    blocks.setdefault(slug, []).extend(mine)|'
 run 'census-writes-the-absolute-interpreter-path' "$CLI" \
   test_the_census_never_carries_an_absolute_path \
   's|^                     interpreter_id(python, redact=True), rc)|                     interpreter_id(python, redact=False), rc)|'
@@ -271,10 +271,22 @@ run 'span-truncated-to-first-line' "$LIB" \
 
 run 'census-drops-other-repos-provenance' "$CLI" \
   test_scanning_one_repo_KEEPS_another_repos_provenance_line \
-  's|^            if line.startswith(f"# {slug} measured under"):|            if line.startswith("#"):|'
+  's|^            if line in _CENSUS_HEADER or line.startswith("repo_slug\\t"):|            if line.startswith("#") or line.startswith("repo_slug\\t"):|'
 run 'pragma-on-if-also-silences-the-else' "$LIB" \
   test_one_pragma_on_an_IF_line_does_not_silence_its_ELSE_too \
-  's|^        if b.kind == "if-body":|        if True:|'
+  's|^        reason = just.get(b.cond_line) if b.kind != "else-body" else None|        reason = just.get(b.cond_line)|'
+run 'except-header-pragma-stops-resolving' "$LIB" \
+  test_a_pragma_on_an_EXCEPT_line_resolves_that_handler \
+  's|^        reason = just.get(b.cond_line) if b.kind != "else-body" else None|        reason = just.get(b.cond_line) if b.kind == "if-body" else None|'
+run 'body-read-widened-to-the-whole-span' "$LIB" \
+  test_a_NESTED_branchs_pragma_does_not_resolve_its_PARENT \
+  's|^            reason = just.get(b.first_line)|            reason = next((just[l] for l in b.lines() if just.get(l)), None)|'
+run 'prose-rows-register-their-parent-dir' "$CLI" \
+  test_ledger_membership_is_path_segments_not_substrings \
+  's|^            if r\["status"\] != "instrument":|            if False:|'
+run 'census-blocks-no-longer-sorted' "$CLI" \
+  test_the_census_is_ORDER_STABLE_across_repos \
+  's|^    for key in sorted(blocks):|    for key in blocks:|'
 run 'ledger-membership-back-to-substring' "$CLI" \
   test_ledger_membership_is_path_segments_not_substrings \
   's|^    return \[d for d in test_dirs(repo) if d not in named\]|    return [d for d in test_dirs(repo) if d not in " ".join(named)]|'

--- a/scripts/tests/mutants-dead-guard.sh
+++ b/scripts/tests/mutants-dead-guard.sh
@@ -74,9 +74,27 @@ restore() { cp "$T/lib.orig" "$LIB"; cp "$T/cli.orig" "$CLI"; cp "$T/reg.orig" "
 FAILURES=0
 
 # failed test names, one per line. Read the CONTENT -- never an exit code.
+# 🔴 A SUITE THAT NEVER RAN YIELDS ZERO `FAILED` LINES, i.e. "clean". Reading
+# only FAILED lines could not tell "no test failed" from "pytest died at
+# collection" -- and the two SURVIVES controls would then report `ok` over a
+# harness that ran nothing. So COUNT the collected tests and refuse below a
+# floor. The floor is deliberately far under the real count: it catches
+# collapse, not growth.
+MIN_TESTS=30
 failing() {
-  PYTHONDONTWRITEBYTECODE=1 python3 -m pytest "$SUITE" -q --no-header --tb=no \
-    -p no:cacheprovider 2>/dev/null | sed -n 's/^FAILED [^:]*::\([A-Za-z0-9_]*\).*/\1/p'
+  local out
+  out="$(PYTHONDONTWRITEBYTECODE=1 python3 -m pytest "$SUITE" -q --no-header --tb=no \
+    -p no:cacheprovider 2>/dev/null)"
+  local n
+  n="$(sed -n 's/^\([0-9]*\) passed.*/\1/p;s/^[0-9]* failed, \([0-9]*\) passed.*/\1/p' <<<"$out" | tail -1)"
+  local f
+  f="$(sed -n 's/^\([0-9]*\) failed.*/\1/p' <<<"$out" | tail -1)"
+  local total=$(( ${n:-0} + ${f:-0} ))
+  if [ "$total" -lt "$MIN_TESTS" ]; then
+    echo "__HARNESS_BROKE__ only $total test(s) ran (floor $MIN_TESTS)"
+    return
+  fi
+  sed -n 's/^FAILED [^:]*::\([A-Za-z0-9_]*\).*/\1/p' <<<"$out"
 }
 
 run() { # run <name> <target-file> <expect: a test node name | SURVIVES> <sed-expr>
@@ -89,6 +107,10 @@ run() { # run <name> <target-file> <expect: a test node name | SURVIVES> <sed-ex
   cp "$T/m" "$file"
   local killers; killers="$(failing)"
   restore
+  if grep -q __HARNESS_BROKE__ <<<"$killers"; then
+    printf '  🔴 %-40s HARNESS BROKE — %s\n' "$name" "$killers"
+    FAILURES=$((FAILURES+1)); return
+  fi
   if [ "$want" = SURVIVES ]; then
     # The control. A behaviour-free edit MUST survive; if it kills something,
     # the harness is keying on the file's text rather than on the code, and
@@ -146,16 +168,16 @@ run 'except-handlers-dropped' "$LIB" \
 printf '\n== the justification hatch (must be KILLED) ==\n'
 run 'bare-marker-now-resolves' "$LIB" \
   test_a_justification_needs_a_reason \
-  's|reason = just.get(b.cond_line) or just.get(b.first_line)|reason = just.get(b.cond_line, "x") or just.get(b.first_line, "x")|'
+  's|^        flags.append(Flag(path, b, reason or None))|        flags.append(Flag(path, b, "x" if reason is not None else None))|'
 run 'reason-no-longer-required' "$LIB" \
   test_a_justification_needs_a_reason \
   's|^    return \[f for f in flags if not f.justified_reason\]|    return []|'
 run 'hatch-read-by-regex-not-tokenize' "$LIB" \
   test_a_pragma_inside_a_STRING_is_not_a_justification \
-  's|            if tok.type != tokenize.COMMENT:|            if tok.type == tokenize.COMMENT and False:|'
+  's|^        if tok.type != tokenize.COMMENT:|        if tok.type == tokenize.COMMENT and False:|'
 run 'body-line-placement-ignored' "$LIB" \
   test_justification_is_read_from_the_condition_line_or_the_body_line \
-  's|reason = just.get(b.cond_line) or just.get(b.first_line)|reason = just.get(b.cond_line)|'
+  's|^            for ln in b.lines():|            for ln in []:|'
 
 printf '\n== the zeros that must be UNDECIDABLE, not clean (must be KILLED) ==\n'
 run 'missing-trace-scored-clean' "$CLI" \
@@ -182,10 +204,10 @@ run 'empty-instrument-selector-scored-clean' "$CLI" \
 # mutants removes real behaviour.
 run 'valueerror-not-caught-so-latin1-escapes' "$CLI" \
   test_a_guard_that_cannot_be_DECODED_is_undecidable_not_a_findings_exit \
-  's|^        except (SyntaxError, ValueError) as e:$|        except (SyntaxError,) as e:|'
+  's|^        except (SyntaxError, ValueError, OSError) as e:$|        except (SyntaxError, OSError) as e:|'
 run 'syntaxerror-not-caught' "$CLI" \
   test_an_unparseable_guard_is_undecidable_not_a_findings_exit \
-  's|^        except (SyntaxError, ValueError) as e:$|        except (ValueError,) as e:|'
+  's|^        except (SyntaxError, ValueError, OSError) as e:$|        except (ValueError, OSError) as e:|'
 run 'undecidable-arm-removed' "$CLI" \
   test_an_unparseable_guard_is_undecidable_not_a_findings_exit \
   's|^    if undecidable:$|    if False:|'
@@ -210,7 +232,7 @@ run 'census-drops-the-out-of-instrument-rows' "$CLI" \
   's|^    for r in oo:|    for r in []:|'
 run 'census-goes-back-to-append-only' "$CLI" \
   test_the_census_is_IDEMPOTENT \
-  's|^            if line.startswith(f"{slug}\\t") or line.startswith(f"# {slug} "):|            if False:|'
+  's|^            if line.startswith(f"{slug}\\t"):|            if False:|'
 run 'census-writes-the-absolute-interpreter-path' "$CLI" \
   test_the_census_never_carries_an_absolute_path \
   's|^                     interpreter_id(python, redact=True), rc)|                     interpreter_id(python, redact=False), rc)|'
@@ -236,19 +258,26 @@ run 'drop-a-ledger-row-for-unlisted-dirs' "$REG" \
   test_registry_names_every_test_directory_in_devrc \
   '/^innovation-upstream\/devrc\tpython\tout-of-instrument\tscripts\/dl-router\/tests/d'
 
-printf '\n== EXPECTED SURVIVORS — not gaps, and not left silent ==\n'
-# `_span`'s `last = max(...)` is DEFENSIVE WIDTH, not pinned behaviour. I could
-# not construct a reachable input where a branch body's FIRST line goes
-# unexecuted while a later one runs: for straight-line bodies the first
-# statement always executes when the branch is taken, and a multi-line first
-# statement still emits a line event on its own first line (measured on 3.12).
-# So `last = first` is an EQUIVALENT mutant here, and the honest report is to
-# say so rather than invent a fixture that only appears to kill it. The width
-# still earns its place -- it is what makes `any` vs `all` distinguishable at
-# all, and that mutant IS killed above.
+# 🔴 RETRACTION. This mutant was recorded here as an EXPECTED SURVIVOR, on the
+# claim that no reachable input distinguishes `last = max(...)` from
+# `last = first`. THE CLAIM WAS FALSE. `global`/`nonlocal` are compile-time
+# declarations that emit no bytecode, so a body starting with one has an
+# untraceable first line while the rest of it runs -- and the narrowed span
+# then condemns a live branch. A committed "expected survivor" is a claim like
+# any other, and this one went unchecked for exactly one round.
 run 'span-truncated-to-first-line' "$LIB" \
-  SURVIVES \
+  test_a_body_whose_FIRST_STATEMENT_EMITS_NO_BYTECODE_is_still_TAKEN \
   's|^    last = max((getattr(s, "end_lineno", None) or s.lineno) for s in body)|    last = first|'
+
+run 'census-drops-other-repos-provenance' "$CLI" \
+  test_scanning_one_repo_KEEPS_another_repos_provenance_line \
+  's|^            if line.startswith(f"# {slug} measured under"):|            if line.startswith("#"):|'
+run 'pragma-on-if-also-silences-the-else' "$LIB" \
+  test_one_pragma_on_an_IF_line_does_not_silence_its_ELSE_too \
+  's|^        if b.kind == "if-body":|        if True:|'
+run 'ledger-membership-back-to-substring' "$CLI" \
+  test_ledger_membership_is_path_segments_not_substrings \
+  's|^    return \[d for d in test_dirs(repo) if d not in named\]|    return [d for d in test_dirs(repo) if d not in " ".join(named)]|'
 
 printf '\n== POSITIVE CONTROL — a mutant that MUST survive ==\n'
 run 'comment-only-edit-must-survive' "$LIB" \

--- a/scripts/tests/mutants-dead-guard.sh
+++ b/scripts/tests/mutants-dead-guard.sh
@@ -4,13 +4,22 @@
 # Not run by CI -- an author/reviewer instrument, kept in-tree so
 # "mutation-verified" can be RE-DERIVED instead of believed.
 #
-#   bash scripts/tests/mutants-dead-guard.sh
+#   bash scripts/tests/mutants-dead-guard.sh          # exit 0 only if ALL ok
+#
+# 🔴 IT NEVER TOUCHES YOUR WORKING TREE. An earlier revision `cp`d each mutant
+# over the real `scripts/lib/dead_guard.py`, `scripts/dead-guard-scan.py` and
+# the committed `scripts/data/dead-guard-registry.tsv`, relying on an EXIT trap
+# to put them back. In a repo whose rules are built around shared checkouts and
+# parallel agents, one SIGKILL or one concurrent `git add` leaves a MUTATED
+# TRACKED FILE staged. The repo's only other battery
+# (`scripts/tests/mutants-base-clone.sh`) got this right from the start by
+# writing mutants into `mktemp -d`; this one now copies the whole tree to /tmp
+# and mutates only the copy.
 #
 # 🔴 EACH MUTANT NAMES THE TEST THAT MUST KILL IT. "A test failed" is not
 # enough: with several overlapping assertions a mutant can die to a DIFFERENT
 # test's error and be scored as covered while its own assertion is unreachable.
-# So the expectation here is a test NODE ID, and a mutant killed only by some
-# other test is reported 🔴 WRONG-KILLER, not ok.
+# A mutant killed only by some other test reports 🔴 WRONG-KILLER, not ok.
 #
 # 🔴 EACH MUTANT IS DIFFED AGAINST THE ORIGINAL BEFORE IT RUNS. A `sed` that
 # silently fails to match reports the UNMUTATED file's behaviour, i.e. "the
@@ -24,16 +33,45 @@
 set -uo pipefail
 CDPATH=
 D="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
-ROOT="$(cd "$D/../.." && pwd)"
+SRC="$(cd "$D/../.." && pwd)"
+
+T="$(mktemp -d /tmp/dgs-mut-XXXXXX)"
+trap 'rm -rf "$T"' EXIT
+ROOT="$T/tree"
+mkdir -p "$ROOT/scripts/tests"
+cp -a "$SRC/scripts/lib" "$SRC/scripts/testlib" "$SRC/scripts/data" "$ROOT/scripts/"
+cp -a "$SRC/scripts/dead-guard-scan.py" "$ROOT/scripts/"
+cp -a "$SRC/scripts/tests/test_dead_guard_scan.py" "$ROOT/scripts/tests/"
+# 🔴 A `cp -a` of a worktree would carry its `.git` POINTER FILE, and a git
+# command inside the copy would then act on the REAL repository. Nothing here
+# copies `.git`, and this asserts that rather than assuming it.
+if [ -e "$ROOT/.git" ]; then
+  echo "🔴 the copy carries a .git -- refusing to run"; exit 2
+fi
+find "$ROOT" -name __pycache__ -type d -prune -exec rm -rf {} + 2>/dev/null
+
+# The copy carries only the files under mutation, but
+# `test_registry_names_every_test_directory_in_devrc` enumerates the repo's
+# TEST DIRECTORIES -- so without a skeleton it sees one directory, trips that
+# test's own anti-vacuity guard, and the whole battery reports ALREADY RED.
+# (That guard doing its job is why this block exists.) Recreate the directory
+# NAMES from the source with empty placeholders: the ledger test is about the
+# registry's coverage of those names, not about their contents, and the battery
+# only ever collects "$SUITE" so the placeholders are never run.
+git -C "$SRC" ls-files \
+  | sed -n 's|^\(.*\)/test_[^/]*\.py$|\1|p' | sort -u \
+  | while IFS= read -r d; do
+      mkdir -p "$ROOT/$d" && : > "$ROOT/$d/test_ledger_placeholder.py"
+    done
+
 LIB="$ROOT/scripts/lib/dead_guard.py"
 CLI="$ROOT/scripts/dead-guard-scan.py"
 REG="$ROOT/scripts/data/dead-guard-registry.tsv"
 SUITE="$ROOT/scripts/tests/test_dead_guard_scan.py"
-T="$(mktemp -d /tmp/dgs-mut-XXXXXX)"
-
 cp "$LIB" "$T/lib.orig"; cp "$CLI" "$T/cli.orig"; cp "$REG" "$T/reg.orig"
 restore() { cp "$T/lib.orig" "$LIB"; cp "$T/cli.orig" "$CLI"; cp "$T/reg.orig" "$REG"; }
-trap 'restore; rm -rf "$T"' EXIT
+
+FAILURES=0
 
 # failed test names, one per line. Read the CONTENT -- never an exit code.
 failing() {
@@ -45,7 +83,8 @@ run() { # run <name> <target-file> <expect: a test node name | SURVIVES> <sed-ex
   local name="$1" file="$2" want="$3" expr="$4"
   sed "$expr" "$file" > "$T/m" 2>/dev/null
   if cmp -s "$file" "$T/m"; then
-    printf '  🔴 %-38s MUTATION DID NOT APPLY — result meaningless\n' "$name"; return 1
+    printf '  🔴 %-40s MUTATION DID NOT APPLY — result meaningless\n' "$name"
+    FAILURES=$((FAILURES+1)); return
   fi
   cp "$T/m" "$file"
   local killers; killers="$(failing)"
@@ -55,37 +94,40 @@ run() { # run <name> <target-file> <expect: a test node name | SURVIVES> <sed-ex
     # the harness is keying on the file's text rather than on the code, and
     # every `ok` above is worthless.
     if [ -z "$killers" ]; then
-      printf '  ok %-38s SURVIVED as required (control)\n' "$name"; return 0
+      printf '  ok %-40s SURVIVED as required (control)\n' "$name"; return
     fi
-    printf '  🔴 %-38s CONTROL KILLED by %s — harness is not measuring behaviour\n' \
-      "$name" "$(tr '\n' ',' <<<"$killers")"; return 1
+    printf '  🔴 %-40s CONTROL KILLED by %s — not measuring behaviour\n' \
+      "$name" "$(tr '\n' ',' <<<"$killers")"; FAILURES=$((FAILURES+1)); return
   fi
   if [ -z "$killers" ]; then
-    printf '  🔴 %-38s SURVIVED — no test failed\n' "$name"; return 1
+    printf '  🔴 %-40s SURVIVED — no test failed\n' "$name"
+    FAILURES=$((FAILURES+1)); return
   fi
   if grep -qx "$want" <<<"$killers"; then
-    printf '  ok %-38s killed by %s\n' "$name" "$want"; return 0
+    printf '  ok %-40s killed by %s\n' "$name" "$want"; return
   fi
-  printf '  🔴 %-38s WRONG-KILLER — died to: %s (wanted %s)\n' \
-    "$name" "$(tr '\n' ',' <<<"$killers")" "$want"; return 1
+  printf '  🔴 %-40s WRONG-KILLER — died to: %s (wanted %s)\n' \
+    "$name" "$(tr '\n' ',' <<<"$killers")" "$want"; FAILURES=$((FAILURES+1))
 }
 
+printf 'mutating a COPY at %s (your worktree is untouched)\n' "$ROOT"
 printf 'baseline (must be empty): '
 b="$(failing)"; [ -z "$b" ] && echo "clean" || { echo "🔴 ALREADY RED: $b"; exit 1; }
 
 printf '\n== the verdict must track EXECUTION (must be KILLED) ==\n'
-# Never flag: the detector reports every guard clean. The comforting zero.
 run 'never-flag-anything' "$LIB" \
   test_a_branch_with_zero_corpus_instances_is_flagged_at_its_own_line \
   's|        if any(ln in executed for ln in b.lines()):|        if True:|'
-# Always flag: ignores the trace entirely, so a live branch is condemned.
 run 'ignore-the-trace' "$LIB" \
   test_a_branch_with_a_real_corpus_instance_is_not_flagged \
   's|        if any(ln in executed for ln in b.lines()):|        if False:|'
-# First line only, not the body SPAN -- the multi-line-statement attribution bug.
-run 'span-narrowed-to-first-line' "$LIB" \
-  test_a_reporting_branch_covered_only_by_its_battery_is_not_flagged \
-  's|any(ln in executed for ln in b.lines())|b.first_line in executed and False|'
+# 🔴 `any` -> `all` SURVIVED the whole suite before the multi-line fixtures were
+# added: every branch body was ONE line, which makes the two identical. The
+# fixture-collapse trap, found by an audit, not by this battery.
+run 'any-to-all-over-the-span' "$LIB" \
+  test_a_multiline_body_is_TAKEN_when_only_SOME_of_its_lines_ran \
+  's|        if any(ln in executed for ln in b.lines()):|        if all(ln in executed for ln in b.lines()):|'
+# `span-truncated-to-first-line` lives in the expected-survivor section below.
 
 printf '\n== branch enumeration (must be KILLED) ==\n'
 run 'elif-collapsed-into-else' "$LIB" \
@@ -115,32 +157,69 @@ run 'body-line-placement-ignored' "$LIB" \
   test_justification_is_read_from_the_condition_line_or_the_body_line \
   's|reason = just.get(b.cond_line) or just.get(b.first_line)|reason = just.get(b.cond_line)|'
 
-printf '\n== the CLI'"'"'s zeros (must be KILLED) ==\n'
+printf '\n== the zeros that must be UNDECIDABLE, not clean (must be KILLED) ==\n'
 run 'missing-trace-scored-clean' "$CLI" \
   test_a_missing_trace_file_is_undecidable_not_a_clean_run \
-  's|        return EXIT_UNDECIDABLE$|        return EXIT_CLEAN|'
-run 'unknown-repo-scored-clean' "$CLI" \
-  test_scan_of_an_unregistered_repo_is_undecidable_not_clean \
-  's|              f"rather than reading this silence as coverage.", file=sys.stderr)\n||;s|^        return EXIT_UNDECIDABLE\(.*unknown\)\?$|        return EXIT_CLEAN|'
+  's|^        return EXIT_UNDECIDABLE$|        return EXIT_CLEAN|'
+run 'clobbered-tracer-published-anyway' "$CLI" \
+  test_a_test_that_CLEARS_the_tracer_makes_the_run_undecidable \
+  's|^    if trace.get("clobbered"):|    if False:|'
+run 'untraced-file-reported-as-all-dead' "$CLI" \
+  test_a_LIBRARY_guard_driven_only_by_a_SUBPROCESS_is_undecidable \
+  's|^        if not executed.get(str(t)):|        if False:|'
+run 'empty-instrument-selector-scored-clean' "$CLI" \
+  test_an_instrument_selector_matching_NOTHING_is_undecidable \
+  's|^    if empty:|    if False:|'
+# 🔴 The FIRST attempt here mutated `tokenize.TokenError` out of the catch list
+# and SURVIVED -- because that catch was unreachable (`ast.parse` raises
+# SyntaxError first for every TokenError input). It has since been deleted, and
+# `test_tokenize_TokenError_is_deliberately_NOT_in_the_catch_list` pins its
+# absence. `UnicodeDecodeError` is the reachable member of that class.
+# 🔴 SECOND attempt: mutating `UnicodeDecodeError` out ALSO survived, because
+# it is a ValueError SUBCLASS and ValueError was still listed. Three of the
+# five names in the original catch list were redundant spellings that read as
+# coverage while adding nothing. The list is now two names, and each of these
+# mutants removes real behaviour.
+run 'valueerror-not-caught-so-latin1-escapes' "$CLI" \
+  test_a_guard_that_cannot_be_DECODED_is_undecidable_not_a_findings_exit \
+  's|^        except (SyntaxError, ValueError) as e:$|        except (SyntaxError,) as e:|'
+run 'syntaxerror-not-caught' "$CLI" \
+  test_an_unparseable_guard_is_undecidable_not_a_findings_exit \
+  's|^        except (SyntaxError, ValueError) as e:$|        except (ValueError,) as e:|'
+run 'undecidable-arm-removed' "$CLI" \
+  test_an_unparseable_guard_is_undecidable_not_a_findings_exit \
+  's|^    if undecidable:$|    if False:|'
 run 'slug-keeps-the-dot-git-suffix' "$CLI" \
   test_slug_parsing_handles_ssh_https_and_a_missing_dot_git \
   's|r"\[:/\](\[^/:\]+/\[^/\]+?)(?:\\.git)?\$"|r"[:/]([^/:]+/[^/]+?)(?:XXgit)?$"|'
 
 printf '\n== the EXIT-CODE contract, end to end (must be KILLED) ==\n'
-# The whole tool is worthless if the analysis is right and the exit status is
-# not: a CI caller reads the status, not the flag list.
 run 'unresolved-flags-still-exit-0' "$CLI" \
   test_e2e_a_planted_dead_branch_makes_the_command_exit_NONZERO \
   's|^    return EXIT_FLAGS if unres else EXIT_CLEAN|    return EXIT_CLEAN|'
 run 'always-exit-nonzero' "$CLI" \
   test_e2e_a_clean_tree_exits_ZERO \
   's|^    return EXIT_FLAGS if unres else EXIT_CLEAN|    return EXIT_FLAGS|'
+
+printf '\n== the census is an artifact people re-derive (must be KILLED) ==\n'
 run 'census-path-goes-absolute' "$CLI" \
   test_e2e_the_census_path_is_repo_relative_not_absolute \
   's|^        rel = str(t.relative_to(repo))|        rel = str(t)|'
 run 'census-drops-the-out-of-instrument-rows' "$CLI" \
   test_e2e_the_census_names_the_file_LINE_and_the_case \
-  's|^        for r in oo:|        for r in []:|'
+  's|^    for r in oo:|    for r in []:|'
+run 'census-goes-back-to-append-only' "$CLI" \
+  test_the_census_is_IDEMPOTENT \
+  's|^            if line.startswith(f"{slug}\\t") or line.startswith(f"# {slug} "):|            if False:|'
+run 'census-writes-the-absolute-interpreter-path' "$CLI" \
+  test_the_census_never_carries_an_absolute_path \
+  's|^                     interpreter_id(python, redact=True), rc)|                     interpreter_id(python, redact=False), rc)|'
+run 'census-stops-recording-the-red-run' "$CLI" \
+  test_the_census_records_that_the_run_was_RED \
+  's|^    if nfail:$|    if False:|'
+run 'tsv-escaping-removed' "$CLI" \
+  test_a_TAB_in_a_snippet_cannot_shift_the_census_columns \
+  's|^    return str(s).replace("\\t", "\\\\t").replace("\\n", " ").replace("\\r", " ")|    return str(s)|'
 
 printf '\n== the registry contract (must be KILLED) ==\n'
 run 'drop-an-out-of-instrument-row' "$REG" \
@@ -149,10 +228,41 @@ run 'drop-an-out-of-instrument-row' "$REG" \
 run 'out-of-instrument-row-stops-saying-why' "$REG" \
   test_registry_parses_and_every_repo_declares_what_is_NOT_measured \
   's|^\(ZacxDev/homelab-infra\tgo\tout-of-instrument\t\).*|\1no|'
+# 🔴 Pick a row whose directories are named NOWHERE ELSE. Deleting the
+# `scripts/claude-hooks/tests` row does NOT uncover that directory, because the
+# two `instrument` rows above it contain the same path as a prefix -- so that
+# mutant SURVIVED, correctly, and testing it would have been testing nothing.
+run 'drop-a-ledger-row-for-unlisted-dirs' "$REG" \
+  test_registry_names_every_test_directory_in_devrc \
+  '/^innovation-upstream\/devrc\tpython\tout-of-instrument\tscripts\/dl-router\/tests/d'
+
+printf '\n== EXPECTED SURVIVORS — not gaps, and not left silent ==\n'
+# `_span`'s `last = max(...)` is DEFENSIVE WIDTH, not pinned behaviour. I could
+# not construct a reachable input where a branch body's FIRST line goes
+# unexecuted while a later one runs: for straight-line bodies the first
+# statement always executes when the branch is taken, and a multi-line first
+# statement still emits a line event on its own first line (measured on 3.12).
+# So `last = first` is an EQUIVALENT mutant here, and the honest report is to
+# say so rather than invent a fixture that only appears to kill it. The width
+# still earns its place -- it is what makes `any` vs `all` distinguishable at
+# all, and that mutant IS killed above.
+run 'span-truncated-to-first-line' "$LIB" \
+  SURVIVES \
+  's|^    last = max((getattr(s, "end_lineno", None) or s.lineno) for s in body)|    last = first|'
 
 printf '\n== POSITIVE CONTROL — a mutant that MUST survive ==\n'
-# A pure comment edit changes no behaviour. If this reports KILLED the harness
-# is keying on something other than the code, and every ok above is suspect.
 run 'comment-only-edit-must-survive' "$LIB" \
   SURVIVES \
   's|^"""Branch-liveness analysis|"""BRANCH-liveness analysis|'
+
+printf '\n'
+if [ "$FAILURES" -eq 0 ]; then
+  echo "ALL MUTANTS ACCOUNTED FOR"
+else
+  # 🔴 An aggregate, because the script's own status used to be the LAST run's
+  # -- which is the must-survive control -- so a battery with failing mutants
+  # exited 0. In a file whose header says "read the CONTENT, never an exit
+  # code", that was the exact defect it warns about.
+  echo "🔴 $FAILURES MUTANT(S) UNACCOUNTED FOR"
+fi
+exit $(( FAILURES > 0 ))

--- a/scripts/tests/mutants-dead-guard.sh
+++ b/scripts/tests/mutants-dead-guard.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Mutation battery for the dead-guard detector.
+#
+# Not run by CI -- an author/reviewer instrument, kept in-tree so
+# "mutation-verified" can be RE-DERIVED instead of believed.
+#
+#   bash scripts/tests/mutants-dead-guard.sh
+#
+# 🔴 EACH MUTANT NAMES THE TEST THAT MUST KILL IT. "A test failed" is not
+# enough: with several overlapping assertions a mutant can die to a DIFFERENT
+# test's error and be scored as covered while its own assertion is unreachable.
+# So the expectation here is a test NODE ID, and a mutant killed only by some
+# other test is reported 🔴 WRONG-KILLER, not ok.
+#
+# 🔴 EACH MUTANT IS DIFFED AGAINST THE ORIGINAL BEFORE IT RUNS. A `sed` that
+# silently fails to match reports the UNMUTATED file's behaviour, i.e. "the
+# guard held" -- the most flattering possible wrong answer.
+#
+# 🔴 PYTHONDONTWRITEBYTECODE=1 IS LOAD-BEARING, NOT HYGIENE. CPython validates a
+# cached module on mtime-in-whole-SECONDS + size, so a same-length edit landing
+# in the same second as the last import is invisible: the run imports the
+# ORIGINAL bytecode and the mutant is scored SURVIVED without ever executing.
+# Several mutants below are deliberately same-length substitutions.
+set -uo pipefail
+CDPATH=
+D="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+ROOT="$(cd "$D/../.." && pwd)"
+LIB="$ROOT/scripts/lib/dead_guard.py"
+CLI="$ROOT/scripts/dead-guard-scan.py"
+REG="$ROOT/scripts/data/dead-guard-registry.tsv"
+SUITE="$ROOT/scripts/tests/test_dead_guard_scan.py"
+T="$(mktemp -d /tmp/dgs-mut-XXXXXX)"
+
+cp "$LIB" "$T/lib.orig"; cp "$CLI" "$T/cli.orig"; cp "$REG" "$T/reg.orig"
+restore() { cp "$T/lib.orig" "$LIB"; cp "$T/cli.orig" "$CLI"; cp "$T/reg.orig" "$REG"; }
+trap 'restore; rm -rf "$T"' EXIT
+
+# failed test names, one per line. Read the CONTENT -- never an exit code.
+failing() {
+  PYTHONDONTWRITEBYTECODE=1 python3 -m pytest "$SUITE" -q --no-header --tb=no \
+    -p no:cacheprovider 2>/dev/null | sed -n 's/^FAILED [^:]*::\([A-Za-z0-9_]*\).*/\1/p'
+}
+
+run() { # run <name> <target-file> <expect: a test node name | SURVIVES> <sed-expr>
+  local name="$1" file="$2" want="$3" expr="$4"
+  sed "$expr" "$file" > "$T/m" 2>/dev/null
+  if cmp -s "$file" "$T/m"; then
+    printf '  🔴 %-38s MUTATION DID NOT APPLY — result meaningless\n' "$name"; return 1
+  fi
+  cp "$T/m" "$file"
+  local killers; killers="$(failing)"
+  restore
+  if [ "$want" = SURVIVES ]; then
+    # The control. A behaviour-free edit MUST survive; if it kills something,
+    # the harness is keying on the file's text rather than on the code, and
+    # every `ok` above is worthless.
+    if [ -z "$killers" ]; then
+      printf '  ok %-38s SURVIVED as required (control)\n' "$name"; return 0
+    fi
+    printf '  🔴 %-38s CONTROL KILLED by %s — harness is not measuring behaviour\n' \
+      "$name" "$(tr '\n' ',' <<<"$killers")"; return 1
+  fi
+  if [ -z "$killers" ]; then
+    printf '  🔴 %-38s SURVIVED — no test failed\n' "$name"; return 1
+  fi
+  if grep -qx "$want" <<<"$killers"; then
+    printf '  ok %-38s killed by %s\n' "$name" "$want"; return 0
+  fi
+  printf '  🔴 %-38s WRONG-KILLER — died to: %s (wanted %s)\n' \
+    "$name" "$(tr '\n' ',' <<<"$killers")" "$want"; return 1
+}
+
+printf 'baseline (must be empty): '
+b="$(failing)"; [ -z "$b" ] && echo "clean" || { echo "🔴 ALREADY RED: $b"; exit 1; }
+
+printf '\n== the verdict must track EXECUTION (must be KILLED) ==\n'
+# Never flag: the detector reports every guard clean. The comforting zero.
+run 'never-flag-anything' "$LIB" \
+  test_a_branch_with_zero_corpus_instances_is_flagged_at_its_own_line \
+  's|        if any(ln in executed for ln in b.lines()):|        if True:|'
+# Always flag: ignores the trace entirely, so a live branch is condemned.
+run 'ignore-the-trace' "$LIB" \
+  test_a_branch_with_a_real_corpus_instance_is_not_flagged \
+  's|        if any(ln in executed for ln in b.lines()):|        if False:|'
+# First line only, not the body SPAN -- the multi-line-statement attribution bug.
+run 'span-narrowed-to-first-line' "$LIB" \
+  test_a_reporting_branch_covered_only_by_its_battery_is_not_flagged \
+  's|any(ln in executed for ln in b.lines())|b.first_line in executed and False|'
+
+printf '\n== branch enumeration (must be KILLED) ==\n'
+run 'elif-collapsed-into-else' "$LIB" \
+  test_elif_is_reported_once_against_its_own_condition_line \
+  's|            if node.orelse and not (len(node.orelse) == 1|            if node.orelse and not (len(node.orelse) == 9|'
+run 'main-guard-no-longer-excluded' "$LIB" \
+  test_main_guard_is_not_a_guard_branch \
+  's|            if _is_main_guard(node):|            if False:|'
+run 'main-exclusion-widened-to-any-Name' "$LIB" \
+  test_main_guard_is_not_a_guard_branch \
+  's|and t.left.id == _MAIN_GUARD|and t.left.id != _MAIN_GUARD|'
+run 'except-handlers-dropped' "$LIB" \
+  test_except_and_match_and_loop_else_are_enumerated \
+  's|        elif isinstance(node, ast.ExceptHandler):|        elif isinstance(node, ast.Delete):|'
+
+printf '\n== the justification hatch (must be KILLED) ==\n'
+run 'bare-marker-now-resolves' "$LIB" \
+  test_a_justification_needs_a_reason \
+  's|reason = just.get(b.cond_line) or just.get(b.first_line)|reason = just.get(b.cond_line, "x") or just.get(b.first_line, "x")|'
+run 'reason-no-longer-required' "$LIB" \
+  test_a_justification_needs_a_reason \
+  's|^    return \[f for f in flags if not f.justified_reason\]|    return []|'
+run 'hatch-read-by-regex-not-tokenize' "$LIB" \
+  test_a_pragma_inside_a_STRING_is_not_a_justification \
+  's|            if tok.type != tokenize.COMMENT:|            if tok.type == tokenize.COMMENT and False:|'
+run 'body-line-placement-ignored' "$LIB" \
+  test_justification_is_read_from_the_condition_line_or_the_body_line \
+  's|reason = just.get(b.cond_line) or just.get(b.first_line)|reason = just.get(b.cond_line)|'
+
+printf '\n== the CLI'"'"'s zeros (must be KILLED) ==\n'
+run 'missing-trace-scored-clean' "$CLI" \
+  test_a_missing_trace_file_is_undecidable_not_a_clean_run \
+  's|        return EXIT_UNDECIDABLE$|        return EXIT_CLEAN|'
+run 'unknown-repo-scored-clean' "$CLI" \
+  test_scan_of_an_unregistered_repo_is_undecidable_not_clean \
+  's|              f"rather than reading this silence as coverage.", file=sys.stderr)\n||;s|^        return EXIT_UNDECIDABLE\(.*unknown\)\?$|        return EXIT_CLEAN|'
+run 'slug-keeps-the-dot-git-suffix' "$CLI" \
+  test_slug_parsing_handles_ssh_https_and_a_missing_dot_git \
+  's|r"\[:/\](\[^/:\]+/\[^/\]+?)(?:\\.git)?\$"|r"[:/]([^/:]+/[^/]+?)(?:XXgit)?$"|'
+
+printf '\n== the EXIT-CODE contract, end to end (must be KILLED) ==\n'
+# The whole tool is worthless if the analysis is right and the exit status is
+# not: a CI caller reads the status, not the flag list.
+run 'unresolved-flags-still-exit-0' "$CLI" \
+  test_e2e_a_planted_dead_branch_makes_the_command_exit_NONZERO \
+  's|^    return EXIT_FLAGS if unres else EXIT_CLEAN|    return EXIT_CLEAN|'
+run 'always-exit-nonzero' "$CLI" \
+  test_e2e_a_clean_tree_exits_ZERO \
+  's|^    return EXIT_FLAGS if unres else EXIT_CLEAN|    return EXIT_FLAGS|'
+run 'census-path-goes-absolute' "$CLI" \
+  test_e2e_the_census_path_is_repo_relative_not_absolute \
+  's|^        rel = str(t.relative_to(repo))|        rel = str(t)|'
+run 'census-drops-the-out-of-instrument-rows' "$CLI" \
+  test_e2e_the_census_names_the_file_LINE_and_the_case \
+  's|^        for r in oo:|        for r in []:|'
+
+printf '\n== the registry contract (must be KILLED) ==\n'
+run 'drop-an-out-of-instrument-row' "$REG" \
+  test_registry_parses_and_every_repo_declares_what_is_NOT_measured \
+  '/^civitai\/civitai\tts\tout-of-instrument/d;/^civitai\/civitai\tmjs\tout-of-instrument/d'
+run 'out-of-instrument-row-stops-saying-why' "$REG" \
+  test_registry_parses_and_every_repo_declares_what_is_NOT_measured \
+  's|^\(ZacxDev/homelab-infra\tgo\tout-of-instrument\t\).*|\1no|'
+
+printf '\n== POSITIVE CONTROL — a mutant that MUST survive ==\n'
+# A pure comment edit changes no behaviour. If this reports KILLED the harness
+# is keying on something other than the code, and every ok above is suspect.
+run 'comment-only-edit-must-survive' "$LIB" \
+  SURVIVES \
+  's|^"""Branch-liveness analysis|"""BRANCH-liveness analysis|'

--- a/scripts/tests/mutants-dead-guard.sh
+++ b/scripts/tests/mutants-dead-guard.sh
@@ -168,10 +168,10 @@ run 'except-handlers-dropped' "$LIB" \
 printf '\n== the justification hatch (must be KILLED) ==\n'
 run 'bare-marker-now-resolves' "$LIB" \
   test_a_justification_needs_a_reason \
-  's|^    return \[f for f in flags if not f.justified_reason\]|    return [f for f in flags if f.justified_reason is None]|'
+  's|^            if not (f.justified_reason and re.search(r"\\w", f.justified_reason))\]|            if f.justified_reason is None]|'
 run 'reason-no-longer-required' "$LIB" \
   test_a_justification_needs_a_reason \
-  's|^    return \[f for f in flags if not f.justified_reason\]|    return []|'
+  's|^    return \[f for f in flags|    return [] or [f for f in flags[:0]|'
 run 'hatch-read-by-regex-not-tokenize' "$LIB" \
   test_a_pragma_inside_a_STRING_is_not_a_justification \
   's|^        if tok.type != tokenize.COMMENT:|        if tok.type == tokenize.COMMENT and False:|'
@@ -290,6 +290,16 @@ run 'census-blocks-no-longer-sorted' "$CLI" \
 run 'ledger-membership-back-to-substring' "$CLI" \
   test_ledger_membership_is_path_segments_not_substrings \
   's|^    return \[d for d in test_dirs(repo) if d not in named\]|    return [d for d in test_dirs(repo) if d not in " ".join(named)]|'
+
+run 'em-dash-counts-as-a-reason' "$LIB" \
+  test_a_marker_with_only_PUNCTUATION_after_it_is_still_bare \
+  's|^            if not (f.justified_reason and re.search(r"\\w", f.justified_reason))\]|            if not f.justified_reason]|'
+run 'no-test-file-blamed-on-subprocesses' "$CLI" \
+  test_a_registry_with_NO_test_file_says_so_instead_of_blaming_subprocesses \
+  's|^            why = ("no registered test file drives it -- the registry lists "|            why = ("driven through a subprocess XX "|'
+run 'bare-pytest-runs-the-target-repos-whole-suite' "$CLI" \
+  test_a_registry_with_NO_test_file_says_so_instead_of_blaming_subprocesses \
+  's|^        return ({"executed": {}, "clobbered": False}, (0, 0),|        groups = {None: []}\n    if False:\n        return ({"executed": {}, "clobbered": False}, (0, 0),|'
 
 printf '\n== POSITIVE CONTROL — a mutant that MUST survive ==\n'
 run 'comment-only-edit-must-survive' "$LIB" \

--- a/scripts/tests/mutants-dead-guard.sh
+++ b/scripts/tests/mutants-dead-guard.sh
@@ -67,9 +67,11 @@ git -C "$SRC" ls-files \
 LIB="$ROOT/scripts/lib/dead_guard.py"
 CLI="$ROOT/scripts/dead-guard-scan.py"
 REG="$ROOT/scripts/data/dead-guard-registry.tsv"
+PLUG="$ROOT/scripts/testlib/dead_guard_plugin.py"
 SUITE="$ROOT/scripts/tests/test_dead_guard_scan.py"
 cp "$LIB" "$T/lib.orig"; cp "$CLI" "$T/cli.orig"; cp "$REG" "$T/reg.orig"
-restore() { cp "$T/lib.orig" "$LIB"; cp "$T/cli.orig" "$CLI"; cp "$T/reg.orig" "$REG"; }
+cp "$PLUG" "$T/plug.orig"
+restore() { cp "$T/lib.orig" "$LIB"; cp "$T/cli.orig" "$CLI"; cp "$T/reg.orig" "$REG"; cp "$T/plug.orig" "$PLUG"; }
 
 FAILURES=0
 
@@ -200,8 +202,8 @@ run 'empty-instrument-selector-scored-clean' "$CLI" \
 # 🔴 SECOND attempt: mutating `UnicodeDecodeError` out ALSO survived, because
 # it is a ValueError SUBCLASS and ValueError was still listed. Three of the
 # five names in the original catch list were redundant spellings that read as
-# coverage while adding nothing. The list is now two names, and each of these
-# mutants removes real behaviour.
+# coverage while adding nothing. The list is now three (OSError joined for the
+# mode-000 case), and each of these mutants removes real behaviour.
 run 'valueerror-not-caught-so-latin1-escapes' "$CLI" \
   test_a_guard_that_cannot_be_DECODED_is_undecidable_not_a_findings_exit \
   's|^        except (SyntaxError, ValueError, OSError) as e:$|        except (SyntaxError, OSError) as e:|'
@@ -281,9 +283,6 @@ run 'except-header-pragma-stops-resolving' "$LIB" \
 run 'body-read-widened-to-the-whole-span' "$LIB" \
   test_a_NESTED_branchs_pragma_does_not_resolve_its_PARENT \
   's|^            reason = just.get(b.first_line)|            reason = next((just[l] for l in b.lines() if just.get(l)), None)|'
-run 'prose-rows-register-their-parent-dir' "$CLI" \
-  test_ledger_membership_is_path_segments_not_substrings \
-  's|^            if r\["status"\] != "instrument":|            if False:|'
 run 'census-blocks-no-longer-sorted' "$CLI" \
   test_the_census_is_ORDER_STABLE_across_repos \
   's|^    for key in sorted(blocks):|    for key in blocks:|'
@@ -300,6 +299,22 @@ run 'no-test-file-blamed-on-subprocesses' "$CLI" \
 run 'bare-pytest-runs-the-target-repos-whole-suite' "$CLI" \
   test_a_registry_with_NO_test_file_says_so_instead_of_blaming_subprocesses \
   's|^        return ({"executed": {}, "clobbered": False}, (0, 0),|        groups = {None: []}\n    if False:\n        return ({"executed": {}, "clobbered": False}, (0, 0),|'
+
+printf '\n== the tracer plugin — THREE detection sites, each pinned ALONE ==\n'
+# 🔴 The plugin was not a mutation target at all until now, and all three
+# clobber checks were exercised by ONE in-body last-test case that every site
+# catches -- so each was individually deletable with the suite still green.
+# The redundant-guard trap: "each died for its own reason" is a much stronger
+# claim than "each died".
+run 'drop-sessionfinish-hook' "$PLUG" \
+  test_a_clobber_in_a_FIXTURE_FINALIZER_of_the_last_test_is_caught \
+  's|^def pytest_sessionfinish(session, exitstatus):|def _disabled_sessionfinish(session, exitstatus):|'
+run 'library-file-selector-registers-its-parent-dir' "$CLI" \
+  test_ledger_membership_is_path_segments_not_substrings \
+  's|^            if "/" in tok and last.startswith("test_"):|            if "/" in tok and ("." in last or "*" in last):|'
+run 'clobber-check-back-in-atexit' "$PLUG" \
+  test_an_ordinary_atexit_cleanup_is_NOT_reported_as_a_clobber \
+  's|^    if not _OUT:|    if _TARGETS and sys.gettrace() is not _tracer:\n        _state["clobbered"] = True\n    if not _OUT:|'
 
 printf '\n== POSITIVE CONTROL — a mutant that MUST survive ==\n'
 run 'comment-only-edit-must-survive' "$LIB" \

--- a/scripts/tests/test_dead_guard_scan.py
+++ b/scripts/tests/test_dead_guard_scan.py
@@ -744,6 +744,113 @@ def test_tokenize_TokenError_is_deliberately_NOT_in_the_catch_list():
         "the catch was re-added without a reachable input to justify it"
 
 
+def _clobber_repo(tmp_path, clobber_body):
+    """A two-test synthetic repo whose LAST test disarms the tracer somehow."""
+    guard = ('import sys\n'
+             'import pytest\n'
+             '\n'
+             'def scan(ls):\n'
+             '    hits = []\n'
+             '    for l in ls:\n'
+             '        if "REAL" in l:\n'
+             '            hits.append("real")\n'
+             '    return hits\n'
+             '\n'
+             '\n'
+             'def test_aaa_first():\n'
+             '    assert scan(["a REAL line"]) == ["real"]\n'
+             '\n'
+             '\n' + clobber_body)
+    return _synthetic_repo(tmp_path, guard)
+
+
+def test_a_clobber_in_a_FIXTURE_FINALIZER_of_the_last_test_is_caught(tmp_path):
+    """🔴 PINS `pytest_sessionfinish` ON ITS OWN.
+
+    A `-p`-loaded hookimpl runs BEFORE pytest's teardown machinery, so a
+    fixture finalizer runs AFTER `pytest_runtest_teardown` has looked. For
+    every test but the last, the next `setup` still catches it; for the last
+    test nothing did — and the round that introduced the teardown hook claimed
+    "blind spot unchanged" when it had changed. Without this case, deleting
+    `pytest_sessionfinish` leaves the whole suite green.
+    """
+    reg = _clobber_repo(tmp_path,
+                        '@pytest.fixture\n'
+                        'def clobberer():\n'
+                        '    yield\n'
+                        '    sys.settrace(None)\n'
+                        '\n'
+                        '\n'
+                        'def test_zzz_last(clobberer):\n'
+                        '    assert scan(["a REAL line"]) == ["real"]\n')
+    rc, out = _cli(tmp_path, reg)
+    assert rc == 2, (rc, out)
+    assert "sys.settrace" in out, out
+
+
+def test_a_clobber_in_a_NON_LAST_test_is_caught_at_the_next_setup(tmp_path):
+    """🔴 PINS the `pytest_runtest_setup` check ON ITS OWN. All three
+    detection sites used to be exercised only by one in-body last-test case,
+    which every site catches — so each was individually deletable with the
+    suite still green. That is the redundant-guard trap this repo's rules name:
+    "each died for its own reason" is a much stronger claim than "each died".
+    """
+    guard = ('import sys\n'
+             '\n'
+             'def scan(ls):\n'
+             '    hits = []\n'
+             '    for l in ls:\n'
+             '        if "REAL" in l:\n'
+             '            hits.append("real")\n'
+             '    return hits\n'
+             '\n'
+             '\n'
+             'def test_aaa_clobbers_early():\n'
+             '    sys.settrace(None)\n'
+             '    assert scan(["a REAL line"]) == ["real"]\n'
+             '\n'
+             '\n'
+             'def test_zzz_runs_after():\n'
+             '    assert scan(["a REAL line"]) == ["real"]\n')
+    reg = _synthetic_repo(tmp_path, guard)
+    rc, out = _cli(tmp_path, reg)
+    assert rc == 2, (rc, out)
+    assert "sys.settrace" in out, out
+
+
+def test_an_ordinary_atexit_cleanup_is_NOT_reported_as_a_clobber(tmp_path):
+    """🔴 THE FALSE POSITIVE THAT WOULD MAKE A REPO PERMANENTLY UNSCANNABLE.
+
+    `atexit` is LIFO, so a target module's own
+    `atexit.register(lambda: sys.settrace(None))` — an ordinary library
+    cleanup — runs BEFORE the plugin's dump. Checking there reported
+    UNDECIDABLE, blaming "a test cleared sys.settrace", on a run whose trace
+    was complete and correct.
+    """
+    guard = ('import atexit, sys\n'
+             '\n'
+             'atexit.register(lambda: sys.settrace(None))\n'
+             '\n'
+             '\n'
+             'def scan(ls):\n'
+             '    hits = []\n'
+             '    for l in ls:\n'
+             '        if "REAL" in l:\n'
+             '            hits.append("real")\n'
+             '        if "NEVER_WRITTEN" in l:\n'
+             '            hits.append("dead")\n'
+             '    return hits\n'
+             '\n'
+             '\n'
+             'def test_it():\n'
+             '    assert scan(["a REAL line"]) == ["real"]\n')
+    reg = _synthetic_repo(tmp_path, guard)
+    rc, out = _cli(tmp_path, reg)
+    assert rc == 1, (rc, out)          # flags, NOT undecidable
+    assert "sys.settrace" not in out, out
+    assert 'hits.append("dead")' in out, out
+
+
 def test_an_unparseable_guard_is_undecidable_not_a_findings_exit(tmp_path):
     """The parse arm, driven: a syntactically broken guard exits 2."""
     reg = _synthetic_repo(tmp_path, _E2E_GUARD)
@@ -1020,6 +1127,28 @@ def test_ledger_membership_is_path_segments_not_substrings(tmp_path):
     assert "scripts" in missing, (
         "a dotted word inside a PROSE row registered the bare `scripts` "
         f"directory; got {missing}")
+
+    # 🔴 AND THE SAME HOLE FROM THE OTHER SIDE. Registering the parent of ANY
+    # file selector let an `instrument` row for a LIBRARY module
+    # (`scripts/dead-guard-scan.py`) put the bare top-level `scripts` on the
+    # list — so a future `scripts/test_x.py` was silently accepted. This ledger
+    # is about TEST DIRECTORIES, so only a `test_*.py` selector says anything
+    # about one.
+    lib_rows = [{"slug": "probe/p", "lang": "python", "status": "instrument",
+                 "selector": "scripts/some-tool.py"},
+                {"slug": "probe/p", "lang": "python", "status": "instrument",
+                 "selector": "scripts/collector/tests/test_a.py"},
+                {"slug": "probe/p", "lang": "bash", "status": "out-of-instrument",
+                 "selector": "scripts/mailer -- a reason long enough to satisfy "
+                             "the registry's own contract about saying why"}]
+    (tmp_path / "scripts" / "some-tool.py").write_text("x = 1\n", encoding="utf-8")
+    missing = dgs.unregistered_test_dirs(tmp_path, lib_rows, "probe/p")
+    assert "scripts" in missing, (
+        "an `instrument` row for a LIBRARY module registered its top-level "
+        f"parent directory, voiding the ledger's forward guarantee; got {missing}")
+    assert "scripts/collector/tests" not in missing, (
+        "a test-file selector must still register its own directory; "
+        f"got {missing}")
 
 
 def test_registry_is_keyed_on_the_remote_slug_not_the_clone_directory():

--- a/scripts/tests/test_dead_guard_scan.py
+++ b/scripts/tests/test_dead_guard_scan.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""The detector's own battery -- committed, not run once in a shell.
+
+🔴 THIS FILE EXISTS BECAUSE OF THE DEFECT IT TESTS FOR. The browser-bridge
+guard this tool generalises carried a comment claiming each spelling "has a
+planted positive control in the battery"; there was no such test, the battery
+was an in-session shell loop, and six of seven mutants survived green. A tool
+that finds unexercised branches must not ship with unexercised branches.
+
+Every case here drives the real analysis. None asserts an expectation derived
+from the implementation: the verdicts are literal.
+"""
+
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+SCAN = REPO / "scripts" / "dead-guard-scan.py"
+REGISTRY = REPO / "scripts" / "data" / "dead-guard-registry.tsv"
+
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+import dead_guard as dg  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# the analysis itself
+
+def _run(body, corpus):
+    """Execute `body`'s scan() over `corpus` under the tracer, return flags."""
+    ns = {}
+    exec(compile(body, "<t>", "exec"), ns)
+    seen = set()
+
+    def tr(frame, event, arg):
+        if frame.f_code.co_filename == "<t>":
+            # pragma: no cover - a tracer is not traced BY ITSELF: CPython
+            # suppresses tracing inside the trace function to avoid infinite
+            # recursion, so these lines run but never appear in the trace.
+            # A genuine blind spot of this instrument, not dead code.
+            if event == "line":  # pragma: no cover - a tracer is not traced by itself
+                seen.add(frame.f_lineno)  # pragma: no cover - a tracer is not traced by itself
+            return tr
+        return None
+
+    sys.settrace(tr)
+    try:
+        ns["scan"](corpus)
+    finally:
+        sys.settrace(None)
+    return dg.evaluate("<t>", body, seen)
+
+
+LIVE = 'def scan(ls):\n    for l in ls:\n        if "A" in l:\n            return 1\n    return 0\n'
+DEAD = ('def scan(ls):\n    for l in ls:\n        if "A" in l:\n            return 1\n'
+        '        if "ZZZ" in l:\n            return 2\n    return 0\n')
+
+
+def test_a_branch_with_a_real_corpus_instance_is_not_flagged():
+    """NEGATIVE control. Without this, flagging everything would 'pass'."""
+    assert _run(LIVE, ["has A"]) == []
+
+
+def test_a_branch_with_zero_corpus_instances_is_flagged_at_its_own_line():
+    """POSITIVE control -- and it pins the LINE, so a mutant that flags the
+    wrong branch dies here rather than counting as a catch."""
+    flags = _run(DEAD, ["has A"])
+    assert len(flags) == 1, flags
+    assert flags[0].branch.first_line == 6, flags[0].branch
+    assert flags[0].branch.snippet == "return 2"
+
+
+def test_the_same_guard_flags_when_the_corpus_stops_containing_the_case():
+    """The verdict must track EXECUTION, not the source text -- otherwise the
+    positive control above could be a property of how the branch is spelled."""
+    assert _run(LIVE, ["has A"]) == []
+    flags = _run(LIVE, ["nothing"])
+    assert len(flags) == 1 and flags[0].branch.snippet == "return 1"
+
+
+def test_a_reporting_branch_covered_only_by_its_battery_is_not_flagged():
+    """🔴 THE FALSE POSITIVE THAT WOULD MAKE THIS TOOL HARMFUL.
+
+    A guard's violation-reporting branch has zero CORPUS instances exactly when
+    the repo is clean. Flagging it would recommend deleting the guard's firing
+    path. Because the trace spans the whole run, a planted positive control
+    exercises it and it does not flag. Driven here with both drives, in one
+    trace, the way a real run sees them.
+    """
+    src = ('def scan(ls):\n    bad = []\n    for l in ls:\n        if "VIOLATION" in l:\n'
+           '            bad.append(l)\n    return bad\n')
+    ns = {}
+    exec(compile(src, "<t>", "exec"), ns)
+    seen = set()
+
+    def tr(frame, event, arg):
+        if frame.f_code.co_filename == "<t>":
+            # pragma: no cover - a tracer is not traced BY ITSELF: CPython
+            # suppresses tracing inside the trace function to avoid infinite
+            # recursion, so these lines run but never appear in the trace.
+            # A genuine blind spot of this instrument, not dead code.
+            if event == "line":  # pragma: no cover - a tracer is not traced by itself
+                seen.add(frame.f_lineno)  # pragma: no cover - a tracer is not traced by itself
+            return tr
+        return None
+
+    sys.settrace(tr)
+    try:
+        ns["scan"](["clean line"])        # the corpus: clean
+        ns["scan"](["a VIOLATION here"])  # the battery's positive control
+    finally:
+        sys.settrace(None)
+    assert dg.evaluate("<t>", src, seen) == []
+
+
+def test_elif_is_reported_once_against_its_own_condition_line():
+    """An `elif` is an `If` nested in `orelse`. Reporting it as the outer
+    `else` would name the wrong line to the reader fixing it."""
+    src = "def f(x):\n    if x == 1:\n        a = 1\n    elif x == 2:\n        b = 2\n    else:\n        c = 3\n"
+    kinds = [(b.kind, b.first_line, b.cond_line) for b in dg.branch_bodies(src)]
+    assert ("if-body", 3, 2) in kinds
+    assert ("if-body", 5, 4) in kinds, "the elif must carry ITS OWN condition line"
+    assert ("else-body", 7, 4) in kinds
+    assert len(kinds) == 3, kinds
+
+
+def test_except_and_match_and_loop_else_are_enumerated():
+    src = ("def f(x):\n"
+           "    try:\n        a = 1\n    except ValueError:\n        b = 2\n"
+           "    for i in x:\n        pass\n    else:\n        c = 3\n"
+           "    match x:\n        case 1:\n            d = 4\n")
+    kinds = {b.kind for b in dg.branch_bodies(src)}
+    assert {"except", "loop-else", "match-case"} <= kinds, kinds
+
+
+def test_main_guard_is_not_a_guard_branch():
+    assert dg.branch_bodies('if __name__ == "__main__":\n    pass\n') == []
+    # ...but a DIFFERENT dunder comparison still is, so the exclusion is the
+    # exact shape and not "any `if` mentioning a dunder".
+    assert len(dg.branch_bodies('if __file__ == "x":\n    pass\n')) == 1
+
+
+def test_sub_line_branches_are_absent_rather_than_reported_clean():
+    """A stated limit, asserted. A ternary/`and`/comprehension-`if` cannot be
+    discriminated at line granularity, so it is never enumerated -- and
+    therefore can never be silently certified."""
+    assert dg.branch_bodies("x = 1 if a else 2\n") == []
+    assert dg.branch_bodies("y = a and b or c\n") == []
+    assert dg.branch_bodies("z = [i for i in q if i]\n") == []
+
+
+# --------------------------------------------------------------------------
+# the justification hatch
+
+def test_a_justification_needs_a_reason():
+    src = DEAD.replace('if "ZZZ" in l:', 'if "ZZZ" in l:  # pragma: no cover')
+    flags = _run(src, ["has A"])
+    assert len(flags) == 1
+    assert dg.unresolved(flags) == flags, "a bare marker asserts nothing"
+
+
+def test_a_justification_with_a_reason_resolves_the_flag():
+    src = DEAD.replace('if "ZZZ" in l:',
+                       'if "ZZZ" in l:  # pragma: no cover - kept for the 2.x wire format')
+    flags = _run(src, ["has A"])
+    assert len(flags) == 1
+    assert flags[0].justified_reason == "kept for the 2.x wire format"
+    assert dg.unresolved(flags) == []
+
+
+def test_dead_guard_ok_is_accepted_as_the_same_hatch():
+    src = DEAD.replace('if "ZZZ" in l:', 'if "ZZZ" in l:  # dead-guard-ok: vendor quirk')
+    assert dg.unresolved(_run(src, ["has A"])) == []
+
+
+def test_a_pragma_inside_a_STRING_is_not_a_justification():
+    """🔴 These guards are full of string literals containing the patterns they
+    scan for. A regex over raw lines would read this as a hatch and silence a
+    real flag; `tokenize` does not."""
+    src = ('def scan(ls):\n    for l in ls:\n        if "A" in l:\n            return 1\n'
+           '        if "ZZZ" in l:\n            return "# pragma: no cover - not a comment"\n'
+           '    return 0\n')
+    flags = _run(src, ["has A"])
+    assert len(flags) == 1
+    assert dg.unresolved(flags) == flags
+
+
+def test_justification_is_read_from_the_condition_line_or_the_body_line():
+    for placement in (
+        'if "ZZZ" in l:  # pragma: no cover - on the condition\n            return 2',
+        'if "ZZZ" in l:\n            return 2  # pragma: no cover - on the body',
+    ):
+        src = DEAD.replace('if "ZZZ" in l:\n            return 2', placement)
+        assert dg.unresolved(_run(src, ["has A"])) == [], placement
+
+
+# --------------------------------------------------------------------------
+# the CLI contract the task's Verifier block names
+
+def test_self_test_exits_zero_and_shows_BOTH_directions():
+    p = subprocess.run([sys.executable, str(SCAN), "--self-test"],
+                       capture_output=True, text=True, timeout=300)
+    assert p.returncode == 0, p.stdout + p.stderr
+    out = p.stdout
+    # Not `grep -q`: count the controls, so a run that silently stopped early
+    # cannot read as a pass.
+    assert "positive control" in out and "negative control" in out, out
+    assert "SELF-TEST: PASS" in out, out
+    assert out.count("control") >= 5, out
+
+
+def test_scan_of_an_unregistered_repo_is_undecidable_not_clean(tmp_path):
+    """🔴 An unknown repo must NOT exit 0. A silent zero is indistinguishable
+    from a clean result, and this whole class is comforting zeros."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, timeout=60)
+    subprocess.run(["git", "-C", str(tmp_path), "remote", "add", "origin",
+                    "git@github.com:nobody/not-registered.git"], check=True, timeout=60)
+    p = subprocess.run([sys.executable, str(SCAN), "--repo", str(tmp_path)],
+                       capture_output=True, text=True, timeout=300)
+    assert p.returncode == 2, (p.returncode, p.stdout, p.stderr)
+    assert "not-registered" in p.stderr
+
+
+def test_a_missing_trace_file_is_undecidable_not_a_clean_run(monkeypatch, tmp_path):
+    """🔴 THE ZERO THAT MATTERS. If the traced run never wrote its output, an
+    empty `executed` set makes EVERY branch look dead -- or, handled the other
+    way, makes the run look clean. It must be neither."""
+    sys.path.insert(0, str(REPO / "scripts"))
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("dgs", SCAN)
+    dgs = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(dgs)
+    monkeypatch.setattr(dgs, "run_traced", lambda *a, **k: (None, 4, "boom"))
+    monkeypatch.setattr(dgs, "repo_slug", lambda r: "innovation-upstream/devrc")
+    monkeypatch.setattr(dgs, "guard_files", lambda *a, **k: [pathlib.Path("x.py")])
+    assert dgs.scan(REPO) == dgs.EXIT_UNDECIDABLE
+
+
+# --------------------------------------------------------------------------
+# the END-TO-END exit-code contract criterion 3 of clawgate task #358 names:
+# "exiting non-zero when a branch has zero corpus instances and no inline
+# justification ... exits 0 on a clean tree and non-zero on a planted dead
+# branch". Driven through the real CLI against a real git repo -- the unit
+# tests above cannot see a wiring break between analysis and exit status.
+
+def _synthetic_repo(tmp_path, guard_src):
+    (tmp_path / "scripts" / "tests").mkdir(parents=True)
+    (tmp_path / "scripts" / "tests" / "test_guard.py").write_text(
+        guard_src, encoding="utf-8")
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, timeout=60)
+    subprocess.run(["git", "-C", str(tmp_path), "remote", "add", "origin",
+                    "git@github.com:test/synthetic.git"], check=True, timeout=60)
+    reg = tmp_path / "reg.tsv"
+    reg.write_text(
+        "test/synthetic\tpython\tinstrument\tscripts/tests/test_guard.py\n"
+        "test/synthetic\tbash\tout-of-instrument\t"
+        "a reason long enough to satisfy the registry's own contract that an "
+        "out-of-instrument row must say WHY it is not measured\n",
+        encoding="utf-8")
+    return reg
+
+
+# A guard with one live branch (the corpus hits it) and one dead branch.
+_E2E_GUARD = '''
+def scan(lines):
+    hits = []
+    for ln in lines:
+        if "REAL" in ln:
+            hits.append("real")
+        if "NEVER_WRITTEN" in ln:
+            hits.append("dead")
+    return hits
+
+
+def test_the_guard_runs_against_the_corpus():
+    assert scan(["a REAL line"]) == ["real"]
+'''
+
+
+def _cli(repo, reg):
+    p = subprocess.run([sys.executable, str(SCAN), "--repo", str(repo),
+                        "--registry", str(reg)],
+                       capture_output=True, text=True, timeout=900)
+    return p.returncode, p.stdout + p.stderr
+
+
+def test_e2e_a_planted_dead_branch_makes_the_command_exit_NONZERO(tmp_path):
+    """POSITIVE control on the shipped CLI, not on an internal function."""
+    reg = _synthetic_repo(tmp_path, _E2E_GUARD)
+    rc, out = _cli(tmp_path, reg)
+    assert rc == 1, (rc, out)
+    assert "hits.append(\"dead\")" in out, out
+    # ...and it must NOT condemn the live branch alongside it.
+    assert "hits.append(\"real\")" not in out, out
+
+
+def test_e2e_a_clean_tree_exits_ZERO(tmp_path):
+    """NEGATIVE control: the same guard with the dead branch removed. Without
+    this, 'exits 1' could just mean the tool always exits 1."""
+    reg = _synthetic_repo(tmp_path, _E2E_GUARD.replace(
+        '        if "NEVER_WRITTEN" in ln:\n            hits.append("dead")\n', ""))
+    rc, out = _cli(tmp_path, reg)
+    assert rc == 0, (rc, out)
+    assert "FLAG" not in out, out
+
+
+def test_e2e_a_justified_dead_branch_exits_ZERO(tmp_path):
+    """The hatch closes the run, end to end -- criterion 2's resolution path."""
+    reg = _synthetic_repo(tmp_path, _E2E_GUARD.replace(
+        'if "NEVER_WRITTEN" in ln:',
+        'if "NEVER_WRITTEN" in ln:  # pragma: no cover - kept for the v1 wire format'))
+    rc, out = _cli(tmp_path, reg)
+    assert rc == 0, (rc, out)
+
+
+def test_e2e_the_census_names_the_file_LINE_and_the_case(tmp_path):
+    """Criterion 1 wants file:line, the case handled, and the instance count."""
+    reg = _synthetic_repo(tmp_path, _E2E_GUARD)
+    census = tmp_path / "census.tsv"
+    subprocess.run([sys.executable, str(SCAN), "--repo", str(tmp_path),
+                    "--registry", str(reg), "--census", str(census)],
+                   capture_output=True, text=True, timeout=900)
+    text = census.read_text(encoding="utf-8")
+    rows = [r for r in text.splitlines()
+            if r.startswith("test/synthetic\tflagged")]
+    assert len(rows) == 1, text
+    cells = rows[0].split("\t")
+    # Line 8 of _E2E_GUARD, counted off the FIXTURE (it opens with a newline):
+    # 7 is `if "NEVER_WRITTEN" in ln:`, 8 is its body. The census points at the
+    # BODY, which is the line you delete.
+    assert cells[2] == "scripts/tests/test_guard.py:8", cells
+    assert cells[5] == "0", "corpus_instances must be recorded as 0"
+    # 🔴 NOT `"out-of-instrument" in text`: the census HEADER contains that
+    # phrase, so the substring form passes with every out-of-instrument DATA
+    # row deleted. Found by mutants-dead-guard.sh
+    # (`census-drops-the-out-of-instrument-rows` survived) -- the same
+    # over-claiming-guard defect this whole tool exists to find, in its own
+    # test. Assert the ROW.
+    oo_rows = [r for r in text.splitlines()
+               if r.startswith("test/synthetic\tout-of-instrument\t")]
+    assert len(oo_rows) == 1, \
+        f"the census must carry what was NOT measured as rows, got: {oo_rows}"
+    assert "measured under" in text, "the interpreter must be recorded"
+
+
+def test_e2e_a_repo_with_NOTHING_instrumentable_still_lands_in_the_census(tmp_path):
+    """🔴 The repo whose absence would most mislead. talos-infra and civitai
+    have zero instrumentable guards and ~170 of the ~270 total between them; if
+    a scan of them wrote nothing, the census would read as though they had been
+    swept and found clean."""
+    (tmp_path / "scripts").mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, timeout=60)
+    subprocess.run(["git", "-C", str(tmp_path), "remote", "add", "origin",
+                    "git@github.com:test/nothing-here.git"], check=True, timeout=60)
+    reg = tmp_path / "reg.tsv"
+    reg.write_text("test/nothing-here\tbash\tout-of-instrument\t"
+                   "every guard in this repo is bash, which this tool has no "
+                   "coverage backend for, so none of them are measured here\n",
+                   encoding="utf-8")
+    census = tmp_path / "c.tsv"
+    p = subprocess.run([sys.executable, str(SCAN), "--repo", str(tmp_path),
+                        "--registry", str(reg), "--census", str(census)],
+                       capture_output=True, text=True, timeout=900)
+    assert p.returncode == 0, (p.returncode, p.stdout, p.stderr)
+    assert census.exists(), "a repo with nothing instrumentable wrote NO census"
+    rows = [r for r in census.read_text(encoding="utf-8").splitlines()
+            if r.startswith("test/nothing-here\tout-of-instrument\t")]
+    assert len(rows) == 1, census.read_text(encoding="utf-8")
+
+
+def test_e2e_the_census_path_is_repo_relative_not_absolute(tmp_path):
+    """A committed census read on another machine must not name this one."""
+    reg = _synthetic_repo(tmp_path, _E2E_GUARD)
+    census = tmp_path / "c.tsv"
+    subprocess.run([sys.executable, str(SCAN), "--repo", str(tmp_path),
+                    "--registry", str(reg), "--census", str(census)],
+                   capture_output=True, text=True, timeout=900)
+    body = [l for l in census.read_text(encoding="utf-8").splitlines()
+            if l.startswith("test/synthetic\tflagged")]
+    assert body and not body[0].split("\t")[2].startswith("/"), body
+
+
+# --------------------------------------------------------------------------
+# the registry is an artifact with a contract
+
+def test_registry_parses_and_every_repo_declares_what_is_NOT_measured():
+    """🔴 The out-of-instrument rows are the honesty of this tool. A repo with
+    only `instrument` rows would report a clean exit while ~180 of ~270 guards
+    went unlooked-at with nothing saying so."""
+    sys.path.insert(0, str(REPO / "scripts"))
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("dgs2", SCAN)
+    dgs = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(dgs)
+    rows = dgs.load_registry(REGISTRY)
+    assert rows, "registry is empty"
+    slugs = {r["slug"] for r in rows}
+    assert slugs == {"innovation-upstream/devrc", "civitai/talos-infra",
+                     "civitai/civitai", "ZacxDev/homelab-infra"}, slugs
+    for s in slugs:
+        oo = [r for r in rows if r["slug"] == s and r["status"] == "out-of-instrument"]
+        assert oo, f"{s} declares nothing out-of-instrument -- see the docstring"
+        for r in oo:
+            assert len(r["selector"]) > 40, \
+                f"{s}: an out-of-instrument row must say WHY, not just that: {r}"
+    for r in rows:
+        assert r["status"] in ("instrument", "out-of-instrument"), r
+
+
+def test_registry_is_keyed_on_the_remote_slug_not_the_clone_directory():
+    """Two of the four clones are named nothing like their repo. A basename key
+    would match the wrong profile, silently."""
+    for local, slug in (("datapacket-talos", "civitai/talos-infra"),
+                        ("homelab-talos", "ZacxDev/homelab-infra")):
+        assert local not in REGISTRY.read_text(encoding="utf-8").split("\n\n")[-1], \
+            f"{local} appears as a key; it is not the repo name for {slug}"
+
+
+@pytest.mark.parametrize("url,want", [
+    ("git@github.com:innovation-upstream/devrc.git", "innovation-upstream/devrc"),
+    ("https://github.com/civitai/talos-infra.git", "civitai/talos-infra"),
+    ("https://github.com/civitai/talos-infra", "civitai/talos-infra"),
+])
+def test_slug_parsing_handles_ssh_https_and_a_missing_dot_git(url, want, tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, timeout=60)
+    subprocess.run(["git", "-C", str(tmp_path), "remote", "add", "origin", url],
+                   check=True, timeout=60)
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("dgs3", SCAN)
+    dgs = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(dgs)
+    assert dgs.repo_slug(tmp_path) == want

--- a/scripts/tests/test_dead_guard_scan.py
+++ b/scripts/tests/test_dead_guard_scan.py
@@ -196,6 +196,41 @@ def test_a_pragma_inside_a_STRING_is_not_a_justification():
     assert dg.unresolved(flags) == flags
 
 
+def test_one_pragma_on_an_IF_line_does_not_silence_its_ELSE_too():
+    """🔴 A SILENT FALSE NEGATIVE WITH NO WORKAROUND. An `if` and its `else`
+    share a condition line, so reading the hatch from `cond_line` for BOTH
+    meant one comment, written about one branch, resolved two. The condition
+    line is now consulted only for the branch it introduces."""
+    src = ('def scan(ls):\n'
+           '    for l in ls:\n'
+           '        if "ZZZ" in l:  # pragma: no cover - about the IF only\n'
+           '            return 1\n'
+           '        else:\n'
+           '            return 2\n'
+           '    return 0\n')
+    flags = _run(src, [])                  # neither branch runs
+    kinds = {f.branch.kind: f.justified_reason for f in flags}
+    assert set(kinds) == {"if-body", "else-body"}, kinds
+    assert kinds["if-body"] == "about the IF only"
+    assert kinds["else-body"] is None, \
+        "the else was silenced by a comment written about the if"
+
+
+def test_a_pragma_on_the_body_line_resolves_an_else_or_case():
+    """The documented placement for the kinds whose own header line resolves
+    nothing: put it on the first line of the body."""
+    src = ('def scan(ls):\n'
+           '    for l in ls:\n'
+           '        if "A" in l:\n'
+           '            return 1\n'
+           '        else:\n'
+           '            return 2  # pragma: no cover - unreachable in practice\n'
+           '    return 0\n')
+    flags = _run(src, ["has A"])
+    assert len(flags) == 1 and flags[0].branch.kind == "else-body", flags
+    assert dg.unresolved(flags) == []
+
+
 def test_justification_is_read_from_the_condition_line_or_the_body_line():
     for placement in (
         'if "ZZZ" in l:  # pragma: no cover - on the condition\n            return 2',
@@ -426,6 +461,29 @@ def test_a_multiline_body_is_TAKEN_when_only_SOME_of_its_lines_ran():
     assert lines == [6], lines
 
 
+def test_a_body_whose_FIRST_STATEMENT_EMITS_NO_BYTECODE_is_still_TAKEN():
+    """🔴 THE FIXTURE THAT REFUTES A CLAIM I COMMITTED.
+
+    An earlier revision declared `last = max(...)` -> `last = first` an
+    EXPECTED SURVIVOR on the grounds that no reachable input distinguishes
+    them. That was wrong. `global`/`nonlocal` are compile-time declarations
+    that emit NO BYTECODE, so their line never produces a trace event — and a
+    branch body starting with one has an untraceable first line while the rest
+    of it plainly runs. Narrowing the span to the first line condemns a live
+    branch. Measured: `global` on line 5 is absent from the trace, line 6 is
+    present.
+    """
+    src = ('G = 0\n'
+           'def scan(ls):\n'
+           '    for l in ls:\n'
+           '        if "A" in l:\n'
+           '            global G\n'
+           '            G = 1\n'
+           '    return G\n')
+    assert _run(src, ["has A"]) == [], \
+        "a branch whose first statement is a `global` declaration RAN"
+
+
 def test_the_body_span_reaches_its_LAST_line_not_just_its_first():
     """Kills `last = max(...)` -> `last = first`. Only the last line of the
     body runs, so a span truncated to the first line reports it dead."""
@@ -613,6 +671,46 @@ def test_the_census_is_IDEMPOTENT(tmp_path):
     assert len(set(rows)) == 2, rows
 
 
+def test_scanning_one_repo_KEEPS_another_repos_provenance_line(tmp_path):
+    """🔴 THE FIX FOR ONE FINDING DESTROYED THE FIX FOR ANOTHER.
+
+    Making the census idempotent by dropping every line starting with `#` also
+    dropped the `# <slug> measured under ...` note for every OTHER repo, on
+    every scan. The committed census ended up with ONE note for FOUR repos —
+    and the ones deleted included the RED-RUN warning that same round added, so
+    the artifact silently lost the caveat on 44 unresolved flags.
+    """
+    a = tmp_path / "a"
+    a.mkdir()
+    reg = _synthetic_repo(a, _E2E_GUARD)   # creates a/scripts/tests itself
+    b = tmp_path / "b"
+    (b / "scripts" / "tests").mkdir(parents=True)
+    (b / "scripts" / "tests" / "test_guard.py").write_text(_E2E_GUARD, encoding="utf-8")
+    subprocess.run(["git", "init", "-q", str(b)], check=True, timeout=60)
+    subprocess.run(["git", "-C", str(b), "remote", "add", "origin",
+                    "git@github.com:test/second.git"], check=True, timeout=60)
+    reg.write_text(reg.read_text(encoding="utf-8") +
+                   "test/second\tpython\tinstrument\tscripts/tests/test_guard.py\n"
+                   "test/second\tbash\tout-of-instrument\t"
+                   "a reason long enough to satisfy the registry's own contract "
+                   "that a row must say why it is not measured\n",
+                   encoding="utf-8")
+    census = tmp_path / "c.tsv"
+    for repo in (a, b, a):        # A, then B, then A again
+        subprocess.run([sys.executable, str(SCAN), "--repo", str(repo),
+                        "--registry", str(reg), "--census", str(census)],
+                       capture_output=True, text=True, timeout=900)
+    text = census.read_text(encoding="utf-8")
+    notes = [l for l in text.splitlines() if "measured under" in l]
+    assert len(notes) == 2, f"one note per repo, got {notes}"
+    assert any("test/synthetic" in n for n in notes), notes
+    assert any("test/second" in n for n in notes), notes
+    # ...and no repo's ROWS were duplicated by the re-scan either.
+    for s in ("test/synthetic", "test/second"):
+        rows = [l for l in text.splitlines() if l.startswith(f"{s}\t")]
+        assert len(rows) == len(set(rows)) == 2, (s, rows)
+
+
 def test_the_census_never_carries_an_absolute_path(tmp_path):
     """🔴 The committed census recorded
     `/home/<user>/workspace/.../.venv/bin/python3` — the operator's home dir
@@ -712,6 +810,33 @@ def test_registry_names_every_test_directory_in_devrc():
         "these directories hold test_*.py and appear in NO registry row, in "
         "either status — so this tool reports clean over them while never "
         "having looked:\n  " + "\n  ".join(missing))
+
+
+def test_ledger_membership_is_path_segments_not_substrings(tmp_path):
+    """🔴 A plain `d in " ".join(selectors)` accepted `scripts/mail`,
+    `scripts/collector`, `scripts/dl-router/test` and even `"s"` as registered,
+    because each is a substring of some row. So a NEW test directory that is a
+    path PREFIX of a registered one would be silently accepted — the silent
+    "everything is registered" this function exists to prevent.
+
+    devrc's own 20 directories cannot see this: they are exact members either
+    way. Driven here against a repo built to have the ambiguity.
+    """
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("dgs_seg", SCAN)
+    dgs = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(dgs)
+
+    for d in ("scripts/collector/tests", "scripts/collector", "scripts/mailer"):
+        (tmp_path / d).mkdir(parents=True, exist_ok=True)
+        (tmp_path / d / "test_x.py").write_text("def test_x():\n    pass\n",
+                                                encoding="utf-8")
+    rows = [{"slug": "probe/p", "lang": "python", "status": "out-of-instrument",
+             "selector": "scripts/collector/tests, scripts/mailer -- registered"}]
+    missing = dgs.unregistered_test_dirs(tmp_path, rows, "probe/p")
+    assert missing == ["scripts/collector"], (
+        "`scripts/collector` is a DIFFERENT directory from "
+        "`scripts/collector/tests` and needs its own decision; got " + repr(missing))
 
 
 def test_registry_is_keyed_on_the_remote_slug_not_the_clone_directory():

--- a/scripts/tests/test_dead_guard_scan.py
+++ b/scripts/tests/test_dead_guard_scan.py
@@ -14,6 +14,7 @@ from the implementation: the verdicts are literal.
 import pathlib
 import subprocess
 import sys
+import tokenize
 
 import pytest
 
@@ -45,11 +46,18 @@ def _run(body, corpus):
             return tr
         return None
 
+    # 🔴 SAVE AND RESTORE, NEVER `settrace(None)`. `sys.settrace` is a single
+    # global slot: clearing it disarms whatever tracer was already installed --
+    # including dead_guard_plugin's, when this very suite is being scanned. That
+    # made the tool refuse to publish devrc's census (correctly: the trace would
+    # have been a lower bound, i.e. false positives against live code). Handing
+    # the previous tracer back is what a well-behaved test owes its harness.
+    prev = sys.gettrace()
     sys.settrace(tr)
     try:
         ns["scan"](corpus)
     finally:
-        sys.settrace(None)
+        sys.settrace(prev)
     return dg.evaluate("<t>", body, seen)
 
 
@@ -106,12 +114,13 @@ def test_a_reporting_branch_covered_only_by_its_battery_is_not_flagged():
             return tr
         return None
 
+    prev = sys.gettrace()                 # restore, never clear -- see _run()
     sys.settrace(tr)
     try:
         ns["scan"](["clean line"])        # the corpus: clean
         ns["scan"](["a VIOLATION here"])  # the battery's positive control
     finally:
-        sys.settrace(None)
+        sys.settrace(prev)
     assert dg.evaluate("<t>", src, seen) == []
 
 
@@ -383,6 +392,267 @@ def test_e2e_the_census_path_is_repo_relative_not_absolute(tmp_path):
 
 
 # --------------------------------------------------------------------------
+# span semantics — a branch body is TAKEN if ANY of its lines ran
+#
+# 🔴 EVERY FIXTURE ABOVE HAS A SINGLE-LINE BRANCH BODY, WHICH MAKES `any` AND
+# `all` INDISTINGUISHABLE. An audit mutated `any(...)` -> `all(...)` and
+# `last = max(...)` -> `last = first` and BOTH survived the whole suite, so the
+# span semantics `dead_guard.evaluate` calls load-bearing were entirely
+# untested. That is the fixture-collapse trap: a fixture whose values cannot
+# differ between two implementations cannot see the difference. These cases
+# give the branch a MULTI-LINE body with a line that does NOT run.
+
+_MULTILINE = (
+    'def scan(ls):\n'                    # 1
+    '    for l in ls:\n'                 # 2
+    '        if "A" in l:\n'             # 3
+    '            hit = 1\n'              # 4  <- runs
+    '            if "B" in l:\n'         # 5  <- runs (condition false)
+    '                return "b"\n'       # 6  <- does NOT run
+    '            return "a"\n'           # 7  <- runs
+    '    return None\n')                 # 8
+
+
+def test_a_multiline_body_is_TAKEN_when_only_SOME_of_its_lines_ran():
+    """`any`, not `all`. Under `all` the outer if-body would be condemned
+    because line 6 never runs — a false positive on plainly live code."""
+    flags = _run(_MULTILINE, ["A only"])
+    lines = sorted(f.branch.first_line for f in flags)
+    assert 4 not in lines, (
+        "the outer if-body (line 4) RAN and must not be flagged; "
+        f"got flags at {lines}")
+    # The genuinely-unexecuted inner branch IS flagged, so this fixture is not
+    # simply flagging nothing.
+    assert lines == [6], lines
+
+
+def test_the_body_span_reaches_its_LAST_line_not_just_its_first():
+    """Kills `last = max(...)` -> `last = first`. Only the last line of the
+    body runs, so a span truncated to the first line reports it dead."""
+    src = ('def scan(ls):\n'
+           '    for l in ls:\n'
+           '        if "A" in l:\n'
+           '            if "Z" in l:\n'
+           '                pass\n'
+           '            return "deep"\n'
+           '    return None\n')
+    flags = _run(src, ["A only"])
+    lines = sorted(f.branch.first_line for f in flags)
+    assert 4 not in lines, (
+        f"the outer if-body spans lines 4-6 and line 6 ran; got {lines}")
+    assert lines == [5], lines
+
+
+# --------------------------------------------------------------------------
+# the zeros that must be UNDECIDABLE rather than clean or dead
+
+def test_a_LIBRARY_guard_driven_only_by_a_SUBPROCESS_is_undecidable(tmp_path):
+    """🔴 The worst possible output: a complete, confident, entirely false
+    census of working code. `sys.settrace` is per-interpreter, so a library
+    guard exercised only by spawning a child python is invisible, and every one
+    of its branches would be reported dead.
+
+    ⚠️ The subject must be a LIBRARY module, not the test file. pytest imports
+    a test file during collection, so its module-level lines always trace and
+    this arm can never fire for one — a limit the CLI states at the site.
+    """
+    lib = tmp_path / "scripts" / "guardlib.py"
+    lib.parent.mkdir(parents=True, exist_ok=True)
+    lib.write_text('def scan(ls):\n'
+                   '    hits = []\n'
+                   '    for l in ls:\n'
+                   '        if "REAL" in l:\n'
+                   '            hits.append("real")\n'
+                   '    return hits\n', encoding="utf-8")
+    guard = ('import subprocess, sys, pathlib\n'
+             '\n'
+             'LIB = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "guardlib.py"\n'
+             '\n'
+             '\n'
+             'def test_driven_only_through_a_subprocess():\n'
+             '    code = "import importlib.util,sys;"\\\n'
+             '           "s=importlib.util.spec_from_file_location(\'g\', sys.argv[1]);"\\\n'
+             '           "m=importlib.util.module_from_spec(s);s.loader.exec_module(m);"\\\n'
+             '           "print(m.scan([\'a REAL line\']))"\n'
+             '    p = subprocess.run([sys.executable, "-c", code, str(LIB)],\n'
+             '                       capture_output=True, text=True, timeout=60)\n'
+             '    assert "real" in p.stdout, (p.stdout, p.stderr)\n')
+    reg = _synthetic_repo(tmp_path, guard)
+    reg.write_text(
+        "test/synthetic\tpython\tinstrument\tscripts/tests/test_guard.py\n"
+        "test/synthetic\tpython\tinstrument\tscripts/guardlib.py\n"
+        "test/synthetic\tbash\tout-of-instrument\t"
+        "a reason long enough to satisfy the registry's own contract that an "
+        "out-of-instrument row must say WHY it is not measured\n",
+        encoding="utf-8")
+    rc, out = _cli(tmp_path, reg)
+    assert rc == 2, (rc, out)
+    assert "guardlib.py: NO line of this file was traced" in out, out
+    assert 'hits.append("real")' not in out, \
+        "a live branch was reported dead on an untraced library module"
+
+
+def test_a_test_that_CLEARS_the_tracer_makes_the_run_undecidable(tmp_path):
+    """🔴 `sys.settrace` is one global slot. A test that clears it disarms this
+    instrument for every file collected afterwards, which then reports LIVE
+    branches as dead — on a GREEN run, so the red-run banner never fires.
+    Re-arming per test is not sufficient on its own: a tracer cleared partway
+    through a test still loses that test's lines, so the run is reported
+    UNDECIDABLE rather than published."""
+    guard = ('import sys\n'
+             '\n'
+             'def scan(ls):\n'
+             '    hits = []\n'
+             '    for l in ls:\n'
+             '        if "REAL" in l:\n'
+             '            hits.append("real")\n'
+             '    return hits\n'
+             '\n'
+             '\n'
+             'def test_that_clears_the_global_tracer():\n'
+             '    def tr(frame, event, arg):\n'
+             '        return None\n'
+             '    sys.settrace(tr)\n'
+             '    try:\n'
+             '        assert scan(["a REAL line"]) == ["real"]\n'
+             '    finally:\n'
+             '        sys.settrace(None)\n'
+             '\n'
+             '\n'
+             'def test_zz_runs_after_the_clobber():\n'
+             '    assert scan(["a REAL line"]) == ["real"]\n')
+    reg = _synthetic_repo(tmp_path, guard)
+    rc, out = _cli(tmp_path, reg)
+    assert rc == 2, (rc, out)
+    assert "sys.settrace" in out, out
+
+
+def test_a_guard_that_cannot_be_DECODED_is_undecidable_not_a_findings_exit(tmp_path):
+    """🔴 A file this tool cannot analyse must exit 2, not 1. Exit 1 means
+    "found dead branches" and is indistinguishable from a real result — and the
+    escaping exception wrote no census at all.
+
+    A latin-1 `.py` is the REACHABLE case: `read_text(encoding="utf-8")` raises
+    `UnicodeDecodeError` before anything is parsed.
+    """
+    reg = _synthetic_repo(tmp_path, _E2E_GUARD)
+    bad = tmp_path / "scripts" / "tests" / "test_latin1.py"
+    bad.write_bytes(b'# caf\xe9\ndef test_ok():\n    assert True\n')
+    reg.write_text(reg.read_text(encoding="utf-8").replace(
+        "scripts/tests/test_guard.py", "scripts/tests/test_*.py"), encoding="utf-8")
+    rc, out = _cli(tmp_path, reg)
+    assert rc == 2, (rc, out)
+    assert "cannot be analysed (UnicodeDecodeError" in out, out
+
+
+def test_tokenize_TokenError_is_deliberately_NOT_in_the_catch_list():
+    """🔴 THE FIX FOR AN AUDIT FINDING WAS ITSELF A DEAD GUARD BRANCH.
+
+    `tokenize.TokenError` is not a `SyntaxError` subclass, so adding it looked
+    obviously right — and it is unreachable. `ast.parse` runs first and raises
+    `SyntaxError` for every input that would raise `TokenError`. Measured here
+    rather than asserted, so that if CPython ever changes this the catch can be
+    restored WITH a real input behind it. Applying this repo's own rule to the
+    fix round: delete the unexercised branch and state the limit.
+    """
+    assert not issubclass(tokenize.TokenError, SyntaxError)
+    for src in ('x = "abc\n', 'x = """abc\n', 'x = (1,\n', 'x = 1 + \\\n'):
+        with pytest.raises(SyntaxError):
+            dg.branch_bodies(src)          # ast.parse gets there first
+        with pytest.raises(tokenize.TokenError):
+            dg.justifications(src)         # ...only tokenize would have raised
+    assert "tokenize.TokenError" not in SCAN.read_text(encoding="utf-8").split(
+        "🔴 `tokenize.TokenError` IS DELIBERATELY ABSENT")[1], \
+        "the catch was re-added without a reachable input to justify it"
+
+
+def test_an_unparseable_guard_is_undecidable_not_a_findings_exit(tmp_path):
+    """The parse arm, driven: a syntactically broken guard exits 2."""
+    reg = _synthetic_repo(tmp_path, _E2E_GUARD)
+    # A second registered guard that cannot be tokenised.
+    bad = tmp_path / "scripts" / "tests" / "test_broken.py"
+    bad.write_text('def test_ok():\n    assert True\n\nx = "unterminated\n',
+                   encoding="utf-8")
+    reg.write_text(reg.read_text(encoding="utf-8").replace(
+        "scripts/tests/test_guard.py", "scripts/tests/test_*.py"), encoding="utf-8")
+    rc, out = _cli(tmp_path, reg)
+    assert rc == 2, (rc, out)
+    assert "cannot be analysed" in out, out
+
+
+def test_an_instrument_selector_matching_NOTHING_is_undecidable(tmp_path):
+    """🔴 A one-character typo in a selector otherwise reduces the whole report
+    to nothing and exits 0 — shaped identically to the legitimate 'this repo
+    has no python guards' case."""
+    reg = _synthetic_repo(tmp_path, _E2E_GUARD)
+    reg.write_text(reg.read_text(encoding="utf-8").replace(
+        "scripts/tests/test_guard.py", "scripts/tests/test_guardd.py"),
+        encoding="utf-8")
+    rc, out = _cli(tmp_path, reg)
+    assert rc == 2, (rc, out)
+    assert "matched NO python file" in out, out
+
+
+# --------------------------------------------------------------------------
+# the census is an artifact people re-derive
+
+def test_the_census_is_IDEMPOTENT(tmp_path):
+    """🔴 It is append-only no longer. The regeneration command is printed in
+    the census's own header, so following it used to DOUBLE every row — and a
+    flag resolved in the source was never removed, so the artifact drifted
+    upward from the thing it measures."""
+    reg = _synthetic_repo(tmp_path, _E2E_GUARD)
+    census = tmp_path / "c.tsv"
+    for _ in range(3):
+        subprocess.run([sys.executable, str(SCAN), "--repo", str(tmp_path),
+                        "--registry", str(reg), "--census", str(census)],
+                       capture_output=True, text=True, timeout=900)
+    rows = [r for r in census.read_text(encoding="utf-8").splitlines()
+            if r.startswith("test/synthetic\t")]
+    assert len(rows) == 2, rows          # 1 flagged + 1 out-of-instrument
+    assert len(set(rows)) == 2, rows
+
+
+def test_the_census_never_carries_an_absolute_path(tmp_path):
+    """🔴 The committed census recorded
+    `/home/<user>/workspace/.../.venv/bin/python3` — the operator's home dir
+    and an unrelated repo's venv, published into devrc and pinning the artifact
+    to one machine. The interpreter VERSION is what changes which branches run;
+    the path is a terminal diagnostic, not an artifact field."""
+    reg = _synthetic_repo(tmp_path, _E2E_GUARD)
+    census = tmp_path / "c.tsv"
+    subprocess.run([sys.executable, str(SCAN), "--repo", str(tmp_path),
+                    "--registry", str(reg), "--census", str(census)],
+                   capture_output=True, text=True, timeout=900)
+    text = census.read_text(encoding="utf-8")
+    assert "measured under Python " in text, text
+    for line in text.splitlines():
+        assert "/home/" not in line, line
+        assert str(tmp_path) not in line, line
+
+
+def test_the_census_records_that_the_run_was_RED(tmp_path):
+    """A reader six months out cannot otherwise tell that N flags came off a
+    failing run. The stdout banner does not survive into the artifact."""
+    guard = _E2E_GUARD + '\n\ndef test_deliberately_failing():\n    assert False\n'
+    reg = _synthetic_repo(tmp_path, guard)
+    census = tmp_path / "c.tsv"
+    subprocess.run([sys.executable, str(SCAN), "--repo", str(tmp_path),
+                    "--registry", str(reg), "--census", str(census)],
+                   capture_output=True, text=True, timeout=900)
+    text = census.read_text(encoding="utf-8")
+    assert "RED RUN" in text and "1 test(s) FAILED" in text, text
+
+
+def test_a_TAB_in_a_snippet_cannot_shift_the_census_columns():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("dgs_tsv", SCAN)
+    dgs = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(dgs)
+    assert "\t" not in dgs._tsv("a\tb\nc")
+
+
+# --------------------------------------------------------------------------
 # the registry is an artifact with a contract
 
 def test_registry_parses_and_every_repo_declares_what_is_NOT_measured():
@@ -407,6 +677,41 @@ def test_registry_parses_and_every_repo_declares_what_is_NOT_measured():
                 f"{s}: an out-of-instrument row must say WHY, not just that: {r}"
     for r in rows:
         assert r["status"] in ("instrument", "out-of-instrument"), r
+
+
+def test_registry_names_every_test_directory_in_devrc():
+    """🔴 THE GUARD THE PREVIOUS ONE ONLY CLAIMED TO BE.
+
+    `test_registry_parses_and_every_repo_declares_what_is_NOT_measured` says in
+    its docstring that it would catch "a repo with only `instrument` rows …
+    guards unlooked-at". Its body asserts only that at least ONE
+    out-of-instrument row exists, so it could not see a guard surface present
+    in NEITHER status — and 12 python guard modules under
+    `scripts/claude-hooks/`, including the PreToolUse deny-guards
+    `guard_core.py` and `bash-guard.py`, were exactly that. The registry's own
+    headline claim ("a guard absent from this file would read as measured and
+    clean") was violated for devrc's largest python guard surface.
+
+    Bidirectional, like homelab-infra's `ci-manifest.txt`: a new test directory
+    with no row FAILS, so the set cannot silently grow. It does not try to
+    decide what a "guard" is — it requires a DECISION to be on record.
+    """
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("dgs_reg", SCAN)
+    dgs = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(dgs)
+    rows = dgs.load_registry(REGISTRY)
+
+    dirs = dgs.test_dirs(REPO)
+    assert len(dirs) >= 10, (
+        f"only {len(dirs)} test dirs found in {REPO} — the enumeration is "
+        f"broken, and an empty ledger would pass this test vacuously: {dirs}")
+
+    missing = dgs.unregistered_test_dirs(REPO, rows, "innovation-upstream/devrc")
+    assert missing == [], (
+        "these directories hold test_*.py and appear in NO registry row, in "
+        "either status — so this tool reports clean over them while never "
+        "having looked:\n  " + "\n  ".join(missing))
 
 
 def test_registry_is_keyed_on_the_remote_slug_not_the_clone_directory():

--- a/scripts/tests/test_dead_guard_scan.py
+++ b/scripts/tests/test_dead_guard_scan.py
@@ -216,6 +216,50 @@ def test_one_pragma_on_an_IF_line_does_not_silence_its_ELSE_too():
         "the else was silenced by a comment written about the if"
 
 
+def test_a_pragma_on_an_EXCEPT_line_resolves_that_handler():
+    """🔴 THE REGRESSION THE if-ONLY RESTRICTION CAUSED.
+
+    `except <E>:  # pragma: no cover - reason` is the idiomatic, coverage.py-
+    compatible placement, and an `except` header introduces exactly ONE branch
+    so it cannot silence a sibling. Restricting the condition-line read to
+    `if-body` silently invalidated four justifications that already existed in
+    the scanned repos' source — they flipped to unresolved flags in the
+    committed census, inflating the very artifact a human is asked to
+    adjudicate.
+    """
+    src = ('def f(p):\n'
+           '    try:\n'
+           '        return open(p).read()\n'
+           '    except OSError:  # pragma: no cover - unreadable file\n'
+           '        return None\n')
+    flags = dg.evaluate("<t>", src, {2, 3})      # try ran, handler did not
+    assert len(flags) == 1 and flags[0].branch.kind == "except", flags
+    assert flags[0].justified_reason == "unreadable file"
+    assert dg.unresolved(flags) == []
+
+
+def test_a_NESTED_branchs_pragma_does_not_resolve_its_PARENT():
+    """🔴 THE OVER-RESOLUTION THE any-line-in-the-span READ CAUSED.
+
+    When a parent branch is dead its children necessarily are too, so if the
+    parent's span swallowed a nested comment there was NO placement that
+    justified the inner without silencing the outer — strictly worse than the
+    if/else collision it was meant to fix. The body is read at its FIRST line
+    only, which no nested branch owns.
+    """
+    src = ('def f(a, b):\n'
+           '    if a:\n'
+           '        if b:\n'
+           '            x = 1  # pragma: no cover - the INNER branch only\n'
+           '    return 0\n')
+    flags = dg.evaluate("<t>", src, {5})          # neither branch ran
+    by_line = {f.branch.first_line: f.justified_reason for f in flags}
+    assert by_line.get(3) is None, \
+        f"the OUTER branch was silenced by a comment written about the inner: {by_line}"
+    assert by_line.get(4) == "the INNER branch only", by_line
+    assert len(dg.unresolved(flags)) == 1
+
+
 def test_a_pragma_on_the_body_line_resolves_an_else_or_case():
     """The documented placement for the kinds whose own header line resolves
     nothing: put it on the first line of the body."""
@@ -485,8 +529,15 @@ def test_a_body_whose_FIRST_STATEMENT_EMITS_NO_BYTECODE_is_still_TAKEN():
 
 
 def test_the_body_span_reaches_its_LAST_line_not_just_its_first():
-    """Kills `last = max(...)` -> `last = first`. Only the last line of the
-    body runs, so a span truncated to the first line reports it dead."""
+    """⚠️ THIS DOES **NOT** KILL `last = max(...)` -> `last = first`, and an
+    earlier docstring here claimed it did. Measured: this test PASSES under
+    that mutant, because its fixture's first body line is the nested `if`,
+    which executes. Believing this claim is why round 1 concluded the mutant
+    was equivalent and recorded it as an expected survivor. The fixture that
+    actually kills it is
+    `test_a_body_whose_FIRST_STATEMENT_EMITS_NO_BYTECODE_is_still_TAKEN`.
+    What this case does pin is that the span reaches past the first line at
+    all."""
     src = ('def scan(ls):\n'
            '    for l in ls:\n'
            '        if "A" in l:\n'
@@ -711,6 +762,43 @@ def test_scanning_one_repo_KEEPS_another_repos_provenance_line(tmp_path):
         assert len(rows) == len(set(rows)) == 2, (s, rows)
 
 
+def test_the_census_is_ORDER_STABLE_across_repos(tmp_path):
+    """🔴 Re-deriving ONE repo used to move its whole block to EOF, so a
+    reviewer running the command printed in the census's own header got a
+    pure-reordering diff and could not tell "nothing changed" from "everything
+    moved". Idempotent per repo is not enough — the artifact must be byte-
+    stable under any scan order."""
+    a = tmp_path / "a"
+    a.mkdir()
+    reg = _synthetic_repo(a, _E2E_GUARD)
+    b = tmp_path / "b"
+    (b / "scripts" / "tests").mkdir(parents=True)
+    (b / "scripts" / "tests" / "test_guard.py").write_text(_E2E_GUARD, encoding="utf-8")
+    subprocess.run(["git", "init", "-q", str(b)], check=True, timeout=60)
+    subprocess.run(["git", "-C", str(b), "remote", "add", "origin",
+                    "git@github.com:test/second.git"], check=True, timeout=60)
+    reg.write_text(reg.read_text(encoding="utf-8") +
+                   "test/second\tpython\tinstrument\tscripts/tests/test_guard.py\n"
+                   "test/second\tbash\tout-of-instrument\t"
+                   "a reason long enough to satisfy the registry's own contract "
+                   "that a row must say why it is not measured\n",
+                   encoding="utf-8")
+
+    def build(order, path):
+        for repo in order:
+            subprocess.run([sys.executable, str(SCAN), "--repo", str(repo),
+                            "--registry", str(reg), "--census", str(path)],
+                           capture_output=True, text=True, timeout=900)
+        return path.read_text(encoding="utf-8")
+
+    first = build([a, b], tmp_path / "c1.tsv")
+    second = build([b, a], tmp_path / "c2.tsv")
+    assert first == second, "scan order changed the census bytes"
+    # ...and re-deriving just one repo must not move anything either.
+    third = build([a], tmp_path / "c1.tsv")
+    assert third == first, "re-deriving one repo reordered the file"
+
+
 def test_the_census_never_carries_an_absolute_path(tmp_path):
     """🔴 The committed census recorded
     `/home/<user>/workspace/.../.venv/bin/python3` — the operator's home dir
@@ -837,6 +925,26 @@ def test_ledger_membership_is_path_segments_not_substrings(tmp_path):
     assert missing == ["scripts/collector"], (
         "`scripts/collector` is a DIFFERENT directory from "
         "`scripts/collector/tests` and needs its own decision; got " + repr(missing))
+
+    # 🔴 A PROSE ROW MUST NOT REGISTER A DIRECTORY VIA A DOTTED WORD. The
+    # file-registers-its-parent rule is right for an `instrument` selector
+    # (a real path), and wrong for the out-of-instrument column, which is
+    # English. Measured on the committed registry, `scripts/drift-check.sh` in
+    # a prose row registered the bare directory `scripts` in THREE repos — so a
+    # future `scripts/test_x.py` would have been silently accepted.
+    (tmp_path / "scripts").mkdir(exist_ok=True)
+    (tmp_path / "scripts" / "test_top.py").write_text("def test_t():\n    pass\n",
+                                                      encoding="utf-8")
+    prose = [{"slug": "probe/p", "lang": "bash", "status": "out-of-instrument",
+              "selector": "scripts/drift-check.sh, run-tests.sh -- bash guards, "
+                          "no coverage backend exists for them in this tool"},
+             {"slug": "probe/p", "lang": "python", "status": "out-of-instrument",
+              "selector": "scripts/collector/tests, scripts/collector, "
+                          "scripts/mailer -- registered"}]
+    missing = dgs.unregistered_test_dirs(tmp_path, prose, "probe/p")
+    assert "scripts" in missing, (
+        "a dotted word inside a PROSE row registered the bare `scripts` "
+        f"directory; got {missing}")
 
 
 def test_registry_is_keyed_on_the_remote_slug_not_the_clone_directory():

--- a/scripts/tests/test_dead_guard_scan.py
+++ b/scripts/tests/test_dead_guard_scan.py
@@ -179,6 +179,32 @@ def test_a_justification_with_a_reason_resolves_the_flag():
     assert dg.unresolved(flags) == []
 
 
+@pytest.mark.parametrize("marker,resolves", [
+    ("# pragma: no cover",                         False),
+    ("# pragma: no cover -",                       False),
+    ("# pragma: no cover —",                  False),   # EM DASH
+    ("# pragma: no cover –",                  False),   # EN DASH
+    ("# pragma: no cover .",                       False),
+    ("# pragma: no cover — unreadable file",  True),
+    ("# pragma: no cover - unreadable file",       True),
+])
+def test_a_marker_with_only_PUNCTUATION_after_it_is_still_bare(marker, resolves):
+    """🔴 THE REQUIRED-REASON RULE WAS WALKABLE BY THIS REPO'S OWN HOUSE STYLE.
+
+    `[:\\s-]*` strips the ASCII hyphen only, so `# pragma: no cover —` yielded
+    the reason "—" and RESOLVED the flag — and an em dash is what every real
+    justification site in this repo uses (the census reason column reads
+    `— unreadable file`). The bare-marker control only ever exercised the ASCII
+    spelling, so a one-character change defeated the rule. `unresolved` now
+    requires a WORD CHARACTER, and remains the sole arbiter.
+    """
+    src = DEAD.replace('if "ZZZ" in l:', f'if "ZZZ" in l:  {marker}')
+    flags = _run(src, ["has A"])
+    assert len(flags) == 1, flags
+    assert (dg.unresolved(flags) == []) is resolves, \
+        f"{marker!r} -> reason {flags[0].justified_reason!r}"
+
+
 def test_dead_guard_ok_is_accepted_as_the_same_hatch():
     src = DEAD.replace('if "ZZZ" in l:', 'if "ZZZ" in l:  # dead-guard-ok: vendor quirk')
     assert dg.unresolved(_run(src, ["has A"])) == []
@@ -597,8 +623,51 @@ def test_a_LIBRARY_guard_driven_only_by_a_SUBPROCESS_is_undecidable(tmp_path):
     rc, out = _cli(tmp_path, reg)
     assert rc == 2, (rc, out)
     assert "guardlib.py: NO line of this file was traced" in out, out
+    # The CAUSE clause, not just the headline — an audit found the whole
+    # cause-attribution fix unexercised, which is a branch with zero test
+    # instances added by the tool that finds branches with zero test instances.
+    assert "driven through a subprocess" in out, out
     assert 'hits.append("real")' not in out, \
         "a live branch was reported dead on an untraced library module"
+
+
+def test_a_registry_with_NO_test_file_says_so_instead_of_blaming_subprocesses(tmp_path):
+    """🔴 ATTRIBUTE THE CAUSE YOU ACTUALLY KNOW. When the registry lists only
+    library modules there is nothing to drive the guards with — and the code
+    knows that, yet used to report "driven through a subprocess" anyway. It
+    must also NOT invoke pytest with no path arguments, which would collect and
+    RUN the target repo's entire suite in a repo we were asked only to read."""
+    lib = tmp_path / "scripts" / "guardlib.py"
+    lib.parent.mkdir(parents=True)
+    lib.write_text('def scan(ls):\n    if "A" in ls:\n        return 1\n    return 0\n',
+                   encoding="utf-8")
+    # A test file that is NOT registered — if pytest were invoked bare it would
+    # collect and run this, and the side effect would prove it.
+    other = tmp_path / "othertests"
+    other.mkdir()
+    (other / "test_side_effect.py").write_text(
+        "import pathlib\n"
+        "def test_side_effect():\n"
+        "    pathlib.Path(__file__).parent.joinpath('RAN').write_text('x')\n",
+        encoding="utf-8")
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, timeout=60)
+    subprocess.run(["git", "-C", str(tmp_path), "remote", "add", "origin",
+                    "git@github.com:test/libonly.git"], check=True, timeout=60)
+    reg = tmp_path / "reg.tsv"
+    reg.write_text(
+        "test/libonly\tpython\tinstrument\tscripts/guardlib.py\n"
+        "test/libonly\tpython\tout-of-instrument\tothertests -- not a guard, and "
+        "recorded here so its absence cannot read as coverage\n"
+        "test/libonly\tbash\tout-of-instrument\t"
+        "a reason long enough to satisfy the registry's own contract that a row "
+        "must say why it is not measured\n", encoding="utf-8")
+    rc, out = _cli(tmp_path, reg)
+    assert rc == 2, (rc, out)
+    assert "no registered test file drives it" in out, out
+    assert "driven through a subprocess" not in out, \
+        "reported a cause the code knew was wrong"
+    assert not (other / "RAN").exists(), \
+        "pytest was invoked with no path args and ran the target repo's own suite"
 
 
 def test_a_test_that_CLEARS_the_tracer_makes_the_run_undecidable(tmp_path):
@@ -878,9 +947,15 @@ def test_registry_names_every_test_directory_in_devrc():
     headline claim ("a guard absent from this file would read as measured and
     clean") was violated for devrc's largest python guard surface.
 
-    Bidirectional, like homelab-infra's `ci-manifest.txt`: a new test directory
-    with no row FAILS, so the set cannot silently grow. It does not try to
-    decide what a "guard" is — it requires a DECISION to be on record.
+    FORWARD DIRECTION ONLY, like the forward half of homelab-infra's
+    `ci-manifest.txt`: a new test directory with no row FAILS, so the set
+    cannot silently GROW. A row naming a directory that no longer exists does
+    NOT fail — the out-of-instrument column is prose, so a stale path cannot be
+    told from a sentence. (An earlier docstring here said "bidirectional"; the
+    retraction landed in the CLI and the registry and was missed here for two
+    rounds, which is the same claim-wider-than-code defect in its third copy.)
+    It does not try to decide what a "guard" is — it requires a DECISION to be
+    on record.
     """
     import importlib.util
     spec = importlib.util.spec_from_file_location("dgs_reg", SCAN)


### PR DESCRIPTION
Closes the tool-and-census half of **clawgate task #358**. **No guard branch is deleted here** — that waits on criterion 6, which is your read.

> **Body history:** an earlier version of this description claimed *"Both artifacts print the ratio so the number can't be quoted without its denominator."* **That was false** and is retracted — see the pinned correction comment. Neither artifact prints a ratio; what is printed is a count of instrumented FILES and a count of registry ROWS, and nothing here enumerates every guard in a repo, so any "N of M" figure is a human survey rather than a measurement. The numbers below are re-derived at HEAD.

## What you're being asked to decide

Criterion 6: *"Zach reads the census and confirms the flagged/kept split is right before criterion 2's deletions are merged — the detector's precision on real code is the one thing a machine cannot settle here."*

`scripts/data/dead-guard-census.tsv` has **86 unresolved flags** (73 devrc, 13 homelab-infra). Hand-checking a sample, they fall into three groups with **different** right answers, which is why this is your call and not the tool's:

| group | example | what to do |
|---|---|---|
| **A — genuinely dead / redundant** | `scripts/testlib/public_ip_scan.py:235` — `if _is_skipped(path, root): continue` inside `scan_repo`, but `repo_files()` already applied the same predicate. The inner check cannot fire. | **delete** — a duplicated predicate |
| **B — environment-conditional** | `scripts/testlib/skills_mapping.py:119` — `if shutil.which("nix-instantiate") is None`. Never taken because the tool is always present here. | **justify inline** — a real guard, not dead code |
| **C — reporting branch with no positive control** | `scripts/testlib/public_ip_scan.py:211` — `except (OSError, SubprocessError): pass`, the fallback when `git ls-files` fails. Nothing plants that failure. | **add the control, or justify** |

Group A is what's worth deleting. B and C look like the honest majority.

## How "zero corpus instances" is measured

A branch body that never **executes** while the guard runs against the real corpus **and its own battery**. Exact for a corpus-scanning guard, and it needs no inference about what case a branch handles — the alternative (counting occurrences of the spelling a branch matches) is the heuristic the task's non-goals rule out.

🔴 **The battery half is load-bearing.** A guard's violation-reporting branch has zero corpus instances precisely when the repo is **clean** — that is the branch working. Tracing the corpus alone would flag it and recommend deleting the guard's firing path.

🔴 **A flag has THREE readings and only two are defects:** dead recognition code; a reporting branch with no positive control; or — not a defect — a branch driven through a **subprocess**, which `sys.settrace` cannot see.

## 🔴 Exit 0 does not mean "the guards are alive"

Only the `instrument` rows of `scripts/data/dead-guard-registry.tsv` are measured. Everything else is registered `out-of-instrument` **with its reason**; deleting such a row hides a gap rather than closing it.

- **bash** — `PS4`/`BASH_XTRACEFD` tracing works but cannot discriminate a single-line `if …; then X; fi`.
- **TypeScript** — civitai has vitest v8 coverage, but `include` is scoped to `src/server/services/**`, which holds none of its lint-rule guards.
- **Go** — `go test -cover` gives per-package percentages; no `-coverprofile` pipeline.
- **talos-infra's python validators** — invoked from bash gates, not pytest.
- **`scripts/claude-hooks/tests/test_bash_guard.py`** — not a pytest suite at all; its own docstring says so.
- **`scripts/testlib/dead_guard_plugin.py`** — the tracer itself. CPython suppresses tracing inside the trace function, so it is the one file that structurally cannot measure itself.

🔴 **The scanner now measures its OWN two modules** (`dead-guard-scan.py`, `lib/dead_guard.py`). They were absent from the registry in both statuses for three rounds — under a registry whose headline is that an absent guard reads as measured and clean. That is why the all-repo unresolved count rose **57 → 86** (devrc alone: **44 → 73**).

⚠️ **Do not read those 29 new flags as "dead code".** Measured, at least 19 of them plainly execute — they are reading **(c)**, the not-a-defect one: the scanner runs its own analysis *in a subprocess* during its e2e tests, and `sys.settrace` cannot see into a child interpreter. Two more are tracer-in-tracer lines that are structurally untraceable. They are in the census because the honest thing is to show you what the instrument reports about itself, not because they are defects.

## Measured at HEAD

| repo | instrumented | flagged | unresolved |
|---|---|---|---|
| innovation-upstream/devrc | 28 | 82 | 73 |
| ZacxDev/homelab-infra | 7 | 14 | 13 |
| civitai/talos-infra | 0 | — | 3 out-of-instrument rows |
| civitai/civitai | 0 | — | 2 out-of-instrument rows |

devrc's run is **red** (5 pre-existing failures, identical at `origin/main`), and both the tool and the census say so on every run — branches downstream of a failure did not execute for a reason that is not deadness. homelab-infra's run is green, so its 13 are the stronger evidence.

The census is **byte-identical on re-derivation**, carries a provenance line per repo, and contains no absolute paths.

## Controls — both directions

`--self-test` drives 7: a planted dead branch IS flagged; a branch with a real instance is NOT; the **same** guard flags once its corpus stops containing the case; the hatch resolves a flag; a bare marker with no reason does not; `if __name__ == "__main__"` is excluded; sub-line branches are not enumerated at all. Plus end-to-end through the shipped CLI: planted dead branch → exit 1, clean tree → exit 0, justified → exit 0.

**56 tests, 42 mutants**, all accounted for, battery exits 0. Every mutant names the test that must kill it, so one killed by a *different* test reports `WRONG-KILLER` rather than counting as covered. One mutant is behaviour-free and **must survive** — if it ever reports killed, the harness is keying on file text. The battery mutates only a `/tmp` copy, asserts a minimum collected-test count (so "pytest never ran" cannot read as "no failures"), and sets `PYTHONDONTWRITEBYTECODE=1` because several mutants are same-length substitutions.

## Four audit rounds — what they found

The audit loop found real defects in every round, most of them in the *fixes*. That is the point of the exercise, so they are named rather than buried:

- **Round 1** — the tracer could be silently disarmed mid-run (live branches reported dead, on a green run); a subprocess-driven guard read as 100% dead; an unanalysable guard exited 1 with no census; an `instrument` selector matching nothing exited 0; the battery mutated the real working tree; `any(...)` → `all(...)` survived because every fixture had a single-line body.
- **Round 2** — the idempotence fix deleted every *other* repo's provenance line, so the committed census carried one note for four repos and lost the devrc RED-RUN caveat; the clobber detector was blind to the last test; and my "no reachable input distinguishes `last = max(...)` from `last = first`" claim was **false** — `global`/`nonlocal` emit no bytecode, so their line never traces.
- **Round 3** — the `else` fix broke `except <E>: # pragma:`, which had already silently invalidated **four real justifications** in the committed census; a nested branch's pragma resolved its parent; the exit-time clobber check false-positived on ordinary `atexit` cleanup; and the bare-marker rule was enforced in three places, so no single mutant could test it.
- **Round 4** — the census was regenerated *before* the final rebase, so four rows pointed at a comment, an f-string continuation and a shell `case` arm; the scanner exempted its own three modules from its own registry; `# pragma: no cover —` (an **em dash** — the spelling every real justification site in this repo uses) satisfied the required-reason rule; and three docstrings claimed placements or blind spots that measurement contradicted.

Several fixes were themselves dead branches and were **deleted rather than kept**: `tokenize.TokenError` (unreachable — `ast.parse` raises first for every input that would raise it), `IndentationError` and `UnicodeDecodeError` (subclasses of names already listed), two dead `continue`s in the census rewrite, and a no-op `except: raise`.

## The hatch is walkable, as the task asked me to check

`# pragma: no cover - <reason>` — the spelling already in `scripts/tests/test_no_public_ips.py`. A reason is **required**; its **truth is not checked**: my own first use degraded to `- see above`, and `test_no_public_ips.py:258` carries `- covered by the scan` on a branch this trace says nothing covers. Reported rather than tightened, per the task's assumption.

## Stated, not fixed

- `run_traced` builds its own pytest invocation and does not attach devrc's four guard plugins (`nolaunch`, `spool`, `gitenv`, `nogit`). Safe today only because both instrumented directories carry conftests that re-register three of them — a property of how it is invoked, not a guarantee.
- `# pragma: no cover` overlaps coverage.py's own meaning; `dead-guard-ok` is the unambiguous alias.
- A test that **saves and restores** the tracer is invisible to the clobber detector — the slot looks correct at every inspectable boundary while lines inside the window went unrecorded.

## Verification

- 56 tests pass on this branch. The PR modifies **zero** existing files, so the branch total is the base total plus exactly those 56; a base-vs-branch run measured the same 63 pre-existing environmental failures on both sides (a foreign venv on this box lacking `logrotate`/`nix-instantiate`). CI is the authority and was green.
- devrc's one existing mutation battery (`mutants-base-clone.sh`) re-run: `PASS 48 FAIL 0`, unchanged.
- The change set is **7 new files, 0 modified**, so criterion 5 ("re-run each touched guard's battery") is vacuous by construction — stated rather than claimed as a pass.

## Not in scope

No new prose in `RULES.md` or any `SKILL.md`; no docstring "width checker"; no guard hardened to cover a missing spelling; no full mutation sweeps in a gate. All four are the task's explicit non-goals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QoVSx46vfyRSNT4PcGNLk
