### PR TITLE
feat(clawgate-handoff): give resolve's "0 tasks" verdict a positive control, so rc 5 stops being permanently ambiguous

### DIFF
--- a/scripts/lib/clawgate_handoff.sh
+++ b/scripts/lib/clawgate_handoff.sh
@@ -47,7 +47,14 @@
 #      no `tasks` array, a row carrying no usable id, or a counting pass that
 #      produced no usable tally — a broken READ is never reported as an empty
 #      board)
-#   5  the board answered and resolved NOTHING — see the caveat printed with it
+#   5  the board answered and resolved NOTHING — see the caveat printed with it.
+#      🔴 TWO WORDINGS, ONE CODE. `resolve` runs a bounded POSITIVE CONTROL
+#      before printing this verdict (`clawgate_zero_probe`), and when the
+#      control resolves rows the wording narrows from "this cannot distinguish
+#      two mechanisms" to "the board answered; the id under test is still
+#      unproven". THE CODE IS 5 EITHER WAY — `claude/skills/handoff/SKILL.md`
+#      and the resume tooling branch on it to mean "write no field", so it is a
+#      wire contract and only the MESSAGE ever changes.
 #   6  ASK; this command will not pick one. FOUR distinguishable causes, each
 #      named in the output: several WORKED tasks, NO worked task beside one or
 #      more created/read links, a role this tool does not recognise, or (roles
@@ -73,6 +80,14 @@ CLAWGATE_DEFAULT_API_URL="http://192.168.50.250:30302"
 #: Where the hook token and base URL live, RELATIVE to $HOME. Expanded at call
 #: time, never at source time — a caller may set HOME after sourcing.
 CLAWGATE_ENV_REL=".claude/clawgate.env"
+
+#: Seconds ONE control request may take, and it is deliberately a THIRD of the
+#: 10 s the request under test gets. The control can only ever make the rc 5
+#: wording NARROWER — it never changes the code, never resolves a task and never
+#: makes the verdict louder — so it must not be the thing that makes `resolve`
+#: slow or flaky. Two requests, no retries: 6 s is the whole worst case it can
+#: add, and every failure of it falls through to today's wording unchanged.
+CLAWGATE_CONTROL_MAX_TIME=3
 
 #: The front-matter key. One spelling, used by the reader and the writer.
 CLAWGATE_FIELD_KEY="clawgate-task"
@@ -358,6 +373,72 @@ clawgate_usable_id(){
   return 0
 }
 
+# `clawgate_zero_verdict [control-session-id] [control-body-text]` — the ONLY
+# place the "0 tasks for this session" verdict is worded, in either of its two
+# forms. PURE: it takes the control's RESULT as text and does no I/O itself.
+#
+# 🔴 WHY THE CONTROL EXISTS. `GET /api/sessions/{id}/tasks` answers `200
+# {"tasks":[]}` for an id it has never seen — not 404 — so an empty array is the
+# observable that "this session touched no task" and "the id is wrong" SHARE,
+# and it identifies neither (`claude/RULES.md` -> "An EMPTY RESULT cannot
+# distinguish two mechanisms"). Worse, a reassuring zero is also what a dead
+# endpoint, a wrong base URL and a rejected token produce, which is the
+# "positive control" half of the same rules file: a zero is unproven until
+# something has been shown to make the number MOVE.
+#
+# So the caller queries the SAME endpoint with an id KNOWN to be linked. If that
+# comes back with rows, the instrument demonstrably works and the zero under
+# test is a real reading of the board. That hedge was paid for by hand in
+# session 2f969fa6-866b-4ac2-ac11-4c359cbeda7e, whose handoff doc and closing
+# report both had to carry "not a clean bill of health"; this automates the
+# three commands that resolved it.
+#
+# 🔴 IT MUST NOT OVERCLAIM, AND THE OUTPUT SAYS SO IN SO MANY WORDS. A working
+# endpoint proves that a CORRECT id would have resolved. It says NOTHING about
+# whether the id under test is correct — a wrong id still answers 200 with an
+# empty array. The upgraded wording is a NARROWER honest claim, not a clean bill
+# of health, and it still forbids writing a field or minting a task.
+#
+# 🔴 FAIL SAFE, IN EVERY DIRECTION. No control, an unparseable one, one whose
+# `tasks` is not an array, and one that resolved ZERO rows all print today's
+# wording BYTE FOR BYTE. A control that resolved nothing is itself an empty
+# result and cannot license a stronger claim than the one it was meant to check.
+# Called with no arguments at all (which is what `clawgate_rank_rows` does, so
+# the ranking stays pure and serverless) it is exactly the old function.
+clawgate_zero_verdict(){
+  local ctl_sid="${1:-}" ctl_body="${2:-}" ctl_n=""
+  if [ -n "$ctl_sid" ] && [ -n "$ctl_body" ]; then
+    # `empty` rather than `0` for a non-array. ⚠ NOT A GUARD, and measured to be
+    # BEHAVIOURALLY EQUIVALENT to `0` today — both land on the `-gt 0` test and
+    # print the old wording, and the mutant swapping them is an equivalent
+    # mutant this file's suite (correctly) cannot kill. It is spelled this way
+    # because "the schema broke" and "the control answered zero" are different
+    # facts, and the next branch on `$ctl_n` should not have to re-derive that.
+    ctl_n=$(printf '%s' "$ctl_body" | jq -r '
+      if (.tasks | type) == "array" then (.tasks | length) else empty end' 2>/dev/null)
+  fi
+  # Anything that is not ONE bare non-negative integer — empty, text, several
+  # lines from a filter that lost its wrapper — is no control. Same discipline
+  # as the tally guard in `clawgate_rank_rows`: a broken read is never a count.
+  case "$ctl_n" in
+    ''|*[!0-9]*) ctl_n=0 ;;
+  esac
+
+  echo "clawgate: NOTHING RESOLVED — 0 tasks for this session."
+  if [ "$ctl_n" -gt 0 ]; then
+    echo "  POSITIVE CONTROL: the SAME endpoint answered $ctl_n link(s) for session $ctl_sid,"
+    echo "  so the board is reachable, the base URL is right and the token is accepted —"
+    echo "  this 0 is a REAL READING of the board, not an instrument wired to nothing."
+    echo "  🔴 IT DOES NOT PROVE THE SESSION ID UNDER TEST IS RIGHT. A wrong id ALSO answers"
+    echo "  200 with an EMPTY ARRAY; the control shows only that a CORRECT id WOULD have"
+    echo "  resolved. That is a NARROWER claim, NOT a clean bill of health."
+  else
+    echo "  An unknown session id answers 200 with an EMPTY ARRAY, so this cannot"
+    echo "  distinguish 'this session touched no task' from 'the id is wrong'."
+  fi
+  echo "  Write NO clawgate-task: field, say so in the report, and never create a task."
+}
+
 # `clawgate_rank_rows <response-body-text>` — the whole verdict, from text alone.
 # Prints the candidate rows (role-ANNOTATED and role-ORDERED, worked first) and
 # then one verdict line, and returns `resolve`'s 0/4/5/6 (see the header).
@@ -527,11 +608,14 @@ clawgate_rank_rows(){
   n_read="${fields[3]}"; n_created="${fields[4]}"
   n_unknown="${fields[5]}"; n_absent="${fields[6]}"
 
+  # 🔴 THE WORDING IS DELEGATED, THE CODE IS NOT. `clawgate_zero_verdict` owns
+  # both forms of this verdict in ONE place (`claude/RULES.md` -> "One rule, one
+  # place"); called with no arguments it prints exactly the un-upgraded text, so
+  # this function stays PURE and drivable from a fixture string with no server.
+  # `clawgate_resolve` is the only caller that has a control to hand it, and it
+  # re-renders through this same function rather than wording it a second time.
   if [ "$n" -eq 0 ]; then
-    echo "clawgate: NOTHING RESOLVED — 0 tasks for this session."
-    echo "  An unknown session id answers 200 with an EMPTY ARRAY, so this cannot"
-    echo "  distinguish 'this session touched no task' from 'the id is wrong'."
-    echo "  Write NO clawgate-task: field, say so in the report, and never create a task."
+    clawgate_zero_verdict
     return 5
   fi
 
@@ -646,6 +730,79 @@ clawgate_env_get(){
   return 1
 }
 
+# `clawgate_zero_probe <base> <curl-config> <out-file> <session-id-under-test>`
+# — the POSITIVE CONTROL behind rc 5's upgraded wording. Prints the control
+# session id on stdout and leaves that session's response body in <out-file>;
+# prints NOTHING and returns non-zero on any failure whatsoever.
+#
+# TWO bounded requests, in this order:
+#   1. `GET /api/tasks?limit=1` — the cheapest read on the board that names a
+#      session. A task's `sourceSessionId` is BY CONSTRUCTION linked to that
+#      task with `role=created` (see the role table in this file's header), so
+#      it is an id that MUST resolve if the endpoint works. Nothing is invented:
+#      the control id comes from the server's own data, not from a constant that
+#      could go stale.
+#   2. `GET /api/sessions/<that id>/tasks` — THE SAME ENDPOINT UNDER TEST. That
+#      identity is the whole point. A control that exercised a different route
+#      would share none of the steps in doubt and could not tell a dead endpoint
+#      from an empty board.
+#
+# 🔴 NON-FATAL BY CONSTRUCTION. Every branch here is `return 1`, never an echo
+# and never a code the caller propagates: the caller's verdict and exit code are
+# identical whether this succeeds or dies. `--max-time` is
+# `$CLAWGATE_CONTROL_MAX_TIME` on both requests and there are no retries, so the
+# worst case it can add is two short timeouts. It runs ONLY on the rc 5 path — a
+# resolve that resolved anything never issues these requests at all.
+#
+# 🔴 IT REUSES THE CALLER'S CURL CONFIG, so the token is written once, into one
+# 0600 file, under one trap. A second auth path here would be a second place to
+# leak it from, and `claude/RULES.md` -> "One rule, one place" applies to the
+# credential exactly as it does to a predicate. It also reuses <out-file> for
+# BOTH requests: request 2 overwrites request 1's body, and the caller reads that
+# file only when this returns 0 — so a failed request 2 can never hand the task
+# LIST back as if it were a session's links.
+#
+# 🔴 A CONTROL ID EQUAL TO THE ID UNDER TEST IS REFUSED. It would be a second
+# sample of the same unknown rather than a control (`claude/RULES.md` -> "A
+# control that SHARES the step you doubt is not a control"). Unreachable while
+# the board is consistent — that session resolving rows here and zero rows in
+# the request under test is a contradiction — but a task filed by this very
+# session BETWEEN the two requests would produce exactly that race, and the
+# refusal costs one `case`.
+clawgate_zero_probe(){
+  local base="$1" cfg="$2" out="$3" under_test="$4" code rc sid
+  code=$(curl -sS --max-time "$CLAWGATE_CONTROL_MAX_TIME" --config "$cfg" \
+         -o "$out" -w '%{http_code}' "$base/api/tasks?limit=1" 2>/dev/null)
+  rc=$?
+  [ "$rc" -eq 0 ] || return 1
+  [ "$code" = "200" ] || return 1
+
+  # `.[0]` on an empty array is null, and `select(type == "string")` drops it —
+  # so an empty board, an error object that happens to parse, and a schema that
+  # renamed the field are all the same "no control", never a bare word that
+  # would then be pasted into a URL path.
+  sid=$(jq -r 'if type == "array" then .[0] else . end
+               | if type == "object" then (.sourceSessionId // empty) else empty end
+               | select(type == "string")' < "$out" 2>/dev/null)
+
+  # The SAME refusal `clawgate_resolve` applies to the id under test: this is
+  # interpolated into a URL PATH, so anything that could steer it — a slash, a
+  # `..`, a query string — and anything that is not exactly ONE id (a newline is
+  # not in the class, so a filter that matched several rows is rejected too) is
+  # no control rather than a request sent blind.
+  case "$sid" in
+    ''|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  [ "$sid" != "$under_test" ] || return 1
+
+  code=$(curl -sS --max-time "$CLAWGATE_CONTROL_MAX_TIME" --config "$cfg" \
+         -o "$out" -w '%{http_code}' "$base/api/sessions/$sid/tasks" 2>/dev/null)
+  rc=$?
+  [ "$rc" -eq 0 ] || return 1
+  [ "$code" = "200" ] || return 1
+  printf '%s\n' "$sid"
+}
+
 # `clawgate_resolve` — which clawgate task(s) does THIS session own?
 #
 # 🔴 THE SESSION ID COMES FROM `CLAUDE_CODE_SESSION_ID` — there is no `CLAUDE_SESSION_ID`.
@@ -738,29 +895,60 @@ clawgate_resolve(){
   code=$(curl -sS --max-time 10 --config "$cfg" -o "$body" -w '%{http_code}' \
          "$base/api/sessions/$sid/tasks" 2>/dev/null)
   rc=$?
-  rm -f "$cfg"
+  # 🔴 THE CONFIG OUTLIVES THIS REQUEST NOW, and the trap is why that is safe.
+  # The control below reuses it rather than writing the token a second time, so
+  # the unlink moves to every exit path instead of sitting here — and `^C`
+  # anywhere in between is still covered by the EXIT/INT/TERM trap installed
+  # above. Each path unlinks BOTH files explicitly and then clears the trap.
 
   if [ "$rc" -ne 0 ]; then
-    rm -f "$body"; trap - EXIT INT TERM
+    rm -f "$cfg" "$body"; trap - EXIT INT TERM
     echo "clawgate: DID NOT ANSWER (curl exit $rc — unreachable, TLS, or timed out). UNKNOWN, not empty."
     return 4
   fi
   if [ "$code" != "200" ]; then
-    rm -f "$body"; trap - EXIT INT TERM
+    rm -f "$cfg" "$body"; trap - EXIT INT TERM
     echo "clawgate: DID NOT ANSWER (HTTP $code). UNKNOWN, not empty."
     return 4
   fi
 
   # 🔴 THE DECIDING HAPPENS ABOVE THE I/O LINE. Everything from here is handing
   # the response TEXT to `clawgate_rank_rows` — `$(< "$body")` is a bash
-  # redirection, not a `cat`, so this does not grow the preflight ledger. The
-  # body is read and the temp file unlinked BEFORE any verdict runs, so no exit
-  # path can leave it behind.
-  local body_text
+  # redirection, not a `cat`, so this does not grow the preflight ledger.
+  local body_text verdict vrc
   body_text=$(< "$body")
-  rm -f "$body"; trap - EXIT INT TERM
 
-  clawgate_rank_rows "$body_text"
+  verdict=$(clawgate_rank_rows "$body_text")
+  vrc=$?
+
+  # 🔴 rc 5 IS THE ONLY CODE THE ZERO BRANCH RETURNS, and that is what makes it
+  # usable as the trigger here without re-asking "was it empty?" in a second
+  # place. Anything else resolved, asked or failed — none of which a control
+  # could inform — so the buffered verdict goes straight out and NO extra
+  # request is issued. A resolve that resolves is exactly as fast as before.
+  if [ "$vrc" -ne 5 ]; then
+    rm -f "$cfg" "$body"; trap - EXIT INT TERM
+    printf '%s\n' "$verdict"
+    return "$vrc"
+  fi
+
+  # The zero path, and the ONLY path that pays for the control. `$verdict` is
+  # discarded and re-rendered through the same function, because that function
+  # is where both wordings live; a probe that fails reproduces `$verdict` byte
+  # for byte.
+  #
+  # 🔴 THE EXIT CODE IS 5 IN BOTH DIRECTIONS. It is a wire contract —
+  # `claude/skills/handoff/SKILL.md` and the resume tooling read it as "write no
+  # `clawgate-task:` field" — so the control may narrow the WORDING and may
+  # never move the code. `$body` is reused as the probe's scratch file: it has
+  # already been read into `$body_text`, and it is unlinked below on every path.
+  local ctl_sid="" ctl_body=""
+  if ctl_sid=$(clawgate_zero_probe "$base" "$cfg" "$body" "$sid"); then
+    ctl_body=$(< "$body")
+  fi
+  rm -f "$cfg" "$body"; trap - EXIT INT TERM
+  clawgate_zero_verdict "$ctl_sid" "$ctl_body"
+  return 5
 }
 
 clawgate_handoff_usage(){

--- a/scripts/tests/test_resume_state_clawgate.py
+++ b/scripts/tests/test_resume_state_clawgate.py
@@ -1285,8 +1285,20 @@ def resolver(tmp_path):
     # the suite could say about the token is that it is not in argv — and the
     # file it IS in, its escaping, and whether it is unlinked afterwards were
     # all unmeasured.
+    # 🔴 THE STUB DISPATCHES ON THE URL, because `resolve` can now issue THREE
+    # different requests and they are not interchangeable: the session under
+    # test, the task-list read that names a control session, and that control
+    # session's own links. A stub that served one body to all of them could not
+    # express "the control answered while the session under test did not" —
+    # which is the entire behaviour under test — and would have made the
+    # upgraded-wording test pass for the wrong reason.
+    #
+    # Unset control bodies mean "this request returns an EMPTY file", which is
+    # what every pre-existing test gets: the probe then finds no session id and
+    # falls through to the old wording, so none of them changes meaning.
     write_exec(binp / "curl", (
         'out=""\n'
+        'url=""\n'
         'while [ $# -gt 0 ]; do\n'
         '  case "$1" in\n'
         '    -o) out="$2"; shift 2 ;;\n'
@@ -1296,12 +1308,34 @@ def resolver(tmp_path):
         # drop it from the trap) left the suite green with a real token file
         # persisting while the fixture's TMPDIR sat empty.
         '    --config) printf "%s\\n" "$2" >> "$STUB_CFG_PATHS"; cp "$2" "$STUB_CFG_COPY"; shift 2 ;;\n'
+        '    http://*|https://*)\n'
+        '      url="$1"; printf "%s\\n" "$1" >> "$STUB_URLS"\n'
+        '      printf "%s\\n" "$1" >> "$STUB_ARGV"; shift ;;\n'
         '    *) printf "%s\\n" "$1" >> "$STUB_ARGV"; shift ;;\n'
         '  esac\n'
         'done\n'
-        '[ -n "$out" ] && [ -n "${STUB_BODY:-}" ] && cp "$STUB_BODY" "$out"\n'
-        'printf "%s" "${STUB_CODE:-200}"\n'
-        'exit "${STUB_RC:-0}"\n'
+        'body="${STUB_BODY:-}"\n'
+        'code="${STUB_CODE:-200}"\n'
+        'rc="${STUB_RC:-0}"\n'
+        'case "$url" in\n'
+        # the request under test — keeps STUB_BODY/STUB_CODE/STUB_RC verbatim
+        '  */api/sessions/"$STUB_MAIN_SID"/tasks) : ;;\n'
+        '  */api/tasks*)\n'
+        '     body="${STUB_BODY_TASKLIST:-}"\n'
+        '     code="${STUB_CTL_CODE:-200}"; rc="${STUB_CTL_RC:-0}" ;;\n'
+        # 🔴 THE CONTROL'S TWO REQUESTS GET SEPARATE CODES, and they had to.
+        # Sharing one knob made request 1 fail first, so request 2's own
+        # status check NEVER EXECUTED — a mutant deleting it survived the whole
+        # class (`claude/RULES.md` -> "a mutation test still passes when an
+        # earlier check always wins so the guard never executes").
+        '  */api/sessions/*/tasks)\n'
+        '     body="${STUB_BODY_CONTROL:-}"\n'
+        '     code="${STUB_CTL2_CODE:-200}"; rc="${STUB_CTL2_RC:-0}" ;;\n'
+        'esac\n'
+        '[ -n "$out" ] && : > "$out"\n'
+        '[ -n "$out" ] && [ -n "$body" ] && cp "$body" "$out"\n'
+        'printf "%s" "$code"\n'
+        'exit "$rc"\n'
     ))
 
     # 🔴 A PASS-THROUGH `jq` THAT CAN BE MADE TO DIE ON ONE SPECIFIC CALL.
@@ -1326,13 +1360,33 @@ def resolver(tmp_path):
         f'exec {real_jq} "$@"\n'
     ))
 
+    url_log = tmp_path / "curl-urls.log"
+
     def go(payload=None, *, session=SESSION_VAR, session_id="sess-abc-123",
            code="200", rc="0", env_file: str | None = None,
-           jq_fail_on: int | None = None, jq_fail_out: str = ""):
+           jq_fail_on: int | None = None, jq_fail_out: str = "",
+           tasklist=None, control=None, ctl_code="200", ctl_rc="0",
+           ctl2_code="200", ctl2_rc="0"):
         env = _base_env()
         env["HOME"] = str(home)
         env["PATH"] = f"{binp}{os.pathsep}{env['PATH']}"
         env["STUB_ARGV"] = str(argv_log)
+        env["STUB_URLS"] = str(url_log)
+        env["STUB_MAIN_SID"] = session_id or ""
+        env["STUB_CTL_CODE"] = ctl_code
+        env["STUB_CTL_RC"] = ctl_rc
+        env["STUB_CTL2_CODE"] = ctl2_code
+        env["STUB_CTL2_RC"] = ctl2_rc
+        if url_log.exists():
+            url_log.unlink()           # the URL log is PER CALL, not per fixture
+        if tasklist is not None:
+            p = tmp_path / "tasklist.json"
+            p.write_text(tasklist if isinstance(tasklist, str) else json.dumps(tasklist))
+            env["STUB_BODY_TASKLIST"] = str(p)
+        if control is not None:
+            p = tmp_path / "control.json"
+            p.write_text(control if isinstance(control, str) else json.dumps(control))
+            env["STUB_BODY_CONTROL"] = str(p)
         env["STUB_CFG_COPY"] = str(cfg_copy)
         env["STUB_CFG_PATHS"] = str(cfg_paths)
         # 🔴 LOAD-BEARING, AND IT WAS MISSING. `mktemp` honours TMPDIR, so
@@ -1360,6 +1414,7 @@ def resolver(tmp_path):
                               text=True, timeout=30, env=env)
 
     go.argv_log = argv_log  # type: ignore[attr-defined]
+    go.url_log = url_log  # type: ignore[attr-defined]
     go.cfg_copy = cfg_copy  # type: ignore[attr-defined]
     go.cfg_paths = cfg_paths  # type: ignore[attr-defined]
     go.tmpdir = tmpdir  # type: ignore[attr-defined]
@@ -2120,6 +2175,384 @@ class TestResolve:
         assert out.returncode == 4, out.stdout + out.stderr
         assert "is not on PATH" in out.stdout
         assert "UNKNOWN, not empty" in out.stdout
+
+
+# --------------------------------------------------------------------------- #
+# §5b rc 5's POSITIVE CONTROL
+#
+# `GET /api/sessions/{id}/tasks` answers `200 {"tasks":[]}` for an id it has
+# never seen, so the zero it returns is the observable shared by "this session
+# touched no task", "the id is wrong", "the endpoint is dead", "the base URL is
+# wrong" and "the token was rejected". `resolve` therefore asks the SAME
+# endpoint with an id it knows IS linked — a task's own `sourceSessionId` — and
+# narrows the wording only when that comes back with rows.
+#
+# 🔴 THE EXIT CODE NEVER MOVES. rc 5 is a wire contract read by
+# `claude/skills/handoff/SKILL.md` and the resume tooling as "write no
+# `clawgate-task:` field"; every test in this section asserts it explicitly, in
+# BOTH directions, so an upgrade of the wording can never become an upgrade of
+# the verdict.
+# --------------------------------------------------------------------------- #
+
+#: 🔴 SPELLED HERE, NEVER READ FROM THE SUBJECT, and pinned as a WHOLE
+#: NORMALISED STRING rather than by keyword. The artifact under test is PROSE,
+#: and `claude/RULES.md` -> "a guard on WORDS is walkable by REWORDING" — a
+#: keyword check would let the control's caveat be softened, dropped or
+#: contradicted while staying green. A cosmetic reword now costs a test edit;
+#: that is the price of a machine-readable claim.
+OLD_ZERO_WORDING = (
+    "clawgate: NOTHING RESOLVED — 0 tasks for this session.\n"
+    "  An unknown session id answers 200 with an EMPTY ARRAY, so this cannot\n"
+    "  distinguish 'this session touched no task' from 'the id is wrong'.\n"
+    "  Write NO clawgate-task: field, say so in the report, and never create a task."
+)
+
+#: 🔴 CHOSEN SO NO ASSERTION CAN PASS ON A CONSTANT. The control session id is
+#: nothing like the id under test (`sess-abc-123`), and the control resolves
+#: THREE links — not one, and not the same number as any other quantity the
+#: verdict prints — so a mutant that hardcodes `1`, echoes the session under
+#: test, or counts the wrong array cannot produce this string.
+CTL_SID = "ctl-7d41e9f0-known-linked"
+CTL_TASK_ID = 946
+CTL_LINKS = 3
+
+
+def upgraded_zero_wording(sid: str = CTL_SID, n: int = CTL_LINKS) -> str:
+    """The wording rc 5 carries when the control resolved rows.
+
+    Built from the two values the control actually produced, so the assertion
+    is sensitive to BOTH of them: a subject that printed a fixed id or a fixed
+    count would satisfy a keyword check and fails this.
+    """
+    return (
+        "clawgate: NOTHING RESOLVED — 0 tasks for this session.\n"
+        f"  POSITIVE CONTROL: the SAME endpoint answered {n} link(s) for session {sid},\n"
+        "  so the board is reachable, the base URL is right and the token is accepted —\n"
+        "  this 0 is a REAL READING of the board, not an instrument wired to nothing.\n"
+        "  🔴 IT DOES NOT PROVE THE SESSION ID UNDER TEST IS RIGHT. A wrong id ALSO answers\n"
+        "  200 with an EMPTY ARRAY; the control shows only that a CORRECT id WOULD have\n"
+        "  resolved. That is a NARROWER claim, NOT a clean bill of health.\n"
+        "  Write NO clawgate-task: field, say so in the report, and never create a task."
+    )
+
+
+def norm(text: str) -> str:
+    """Trailing whitespace stripped per line, and the trailing blank lines gone.
+
+    Deliberately the ONLY normalisation: the words, their order, the indentation
+    and the line breaks are all under test.
+    """
+    return "\n".join(ln.rstrip() for ln in text.splitlines()).rstrip("\n")
+
+
+def tasklist_naming(sid: str, task_id: int = CTL_TASK_ID) -> list:
+    """What `GET /api/tasks?limit=1` returns: a JSON ARRAY of task objects, each
+    carrying the `sourceSessionId` that filed it.
+
+    🔴 THE SHAPE IS THE LIVE SERVER'S, verified against clawgate 0.8.0 on
+    2026-08-25 (`/api/tasks?limit=1` -> `[{"id":358, …,
+    "sourceSessionId":"e0242f58-…"}]`) — a bare array, NOT the `{"tasks":[…]}`
+    envelope the sessions endpoint uses. A fixture built from the wrong
+    envelope would exercise the fallback rather than the feature.
+    """
+    return [{"id": task_id, "title": "a task somebody filed", "status": "open",
+             "sourceSessionId": sid}]
+
+
+def control_links(sid: str = CTL_SID, n: int = CTL_LINKS) -> dict:
+    """What the control session's own `GET /api/sessions/{sid}/tasks` returns."""
+    return {"sessionId": sid,
+            "tasks": [{"id": CTL_TASK_ID + i, "role": "created", "status": "open",
+                       "title": f"link {i}"} for i in range(n)]}
+
+
+def urls(resolver) -> list[str]:
+    log = resolver.url_log  # type: ignore[attr-defined]
+    return log.read_text().split() if log.exists() else []
+
+
+class TestZeroPositiveControl:
+    # --------------------------------------------------- the upgraded wording
+    def test_a_control_that_RESOLVES_ROWS_upgrades_the_zero_verdict(self, resolver):
+        """🔴 THE REGRESSION TEST. Watched RED at a2dc76be (origin/main), where
+        `resolve` prints the un-upgraded hedge for this exact fixture because no
+        control exists at all; green at HEAD.
+
+        The whole stdout is pinned, so this also asserts that NOTHING ELSE is
+        printed on the zero path — a stray line from the probe would fail it."""
+        r = resolver(NONE, tasklist=tasklist_naming(CTL_SID), control=control_links())
+        assert r.returncode == 5, r.stdout + r.stderr
+        assert norm(r.stdout) == upgraded_zero_wording(), r.stdout
+
+    def test_the_upgraded_verdict_REFUSES_to_bless_the_id_under_test(self, resolver):
+        """🔴 THE OVERCLAIM THIS FEATURE COULD EASILY HAVE SHIPPED. A working
+        endpoint proves a CORRECT id would have resolved; it proves nothing
+        about whether the id under test IS correct, because a wrong id answers
+        200 with an empty array too. Named separately from the whole-string pin
+        above so a future reword cannot quietly drop the caveat and be recorded
+        as a cosmetic test edit."""
+        r = resolver(NONE, tasklist=tasklist_naming(CTL_SID), control=control_links())
+        assert "DOES NOT PROVE THE SESSION ID UNDER TEST IS RIGHT" in r.stdout
+        assert "NOT a clean bill of health" in r.stdout
+        assert "EMPTY ARRAY" in r.stdout, "the ambiguity it does NOT resolve is still named"
+        # and it still forbids the two things rc 5 exists to forbid
+        assert "Write NO clawgate-task: field" in r.stdout
+        assert "never create a task" in r.stdout
+        assert recorded(r.stdout) == [], r.stdout
+
+    def test_the_upgraded_verdict_NAMES_the_control_it_used(self, resolver):
+        """The claim carries its own scope: which id resolved, and how many
+        links. Driven at a SECOND (sid, count) pair so neither can be a constant
+        the subject happens to print — `claude/RULES.md` -> "One measurement is
+        not a general claim"."""
+        other_sid, other_n = "ctl-0b5c22ae-second-probe", 7
+        r = resolver(NONE,
+                     tasklist=tasklist_naming(other_sid),
+                     control=control_links(other_sid, other_n))
+        assert r.returncode == 5, r.stdout + r.stderr
+        assert norm(r.stdout) == upgraded_zero_wording(other_sid, other_n), r.stdout
+
+    # ------------------------------------------------ the fail-safe direction
+    #: Every way the control can fail to be a control. Each must reproduce the
+    #: OLD wording byte for byte: a control that did not answer may not make the
+    #: verdict louder, and may not make it quieter either.
+    DEAD_CONTROLS: list[tuple[str, dict]] = [
+        ("no task list at all", {}),
+        ("an empty task list", {"tasklist": []}),
+        ("a task list that is not JSON", {"tasklist": "<html>502</html>"}),
+        ("a task list naming no session",
+         {"tasklist": [{"id": CTL_TASK_ID, "title": "t"}]}),
+        ("a sourceSessionId that is not a string",
+         {"tasklist": [{"id": CTL_TASK_ID, "sourceSessionId": 17}]}),
+        ("a sourceSessionId that could steer the URL",
+         {"tasklist": [{"id": CTL_TASK_ID, "sourceSessionId": "../../api/tasks"}]}),
+        ("a control session that resolves NOTHING",
+         {"tasklist": tasklist_naming(CTL_SID), "control": {"tasks": []}}),
+        ("a control whose tasks is not an array",
+         {"tasklist": tasklist_naming(CTL_SID), "control": {"tasks": {"id": 1}}}),
+        ("a control that is not JSON",
+         {"tasklist": tasklist_naming(CTL_SID), "control": "gateway timed out"}),
+        ("a task list the server refuses",
+         {"tasklist": tasklist_naming(CTL_SID), "control": control_links(),
+          "ctl_code": "500"}),
+        ("a task list curl could not reach",
+         {"tasklist": tasklist_naming(CTL_SID), "control": control_links(),
+          "ctl_rc": "7"}),
+        # 🔴 THE TWO CASES THAT REACH REQUEST 2's OWN CHECKS. The four above all
+        # die in request 1, so request 2's status/rc guards never execute and a
+        # mutant deleting them SURVIVED. These let request 1 succeed and fail
+        # only the control query — the body is still served, exactly as a real
+        # 5xx or a proxy error page would be, so a subject that ignored the
+        # status would read it as three resolved links.
+        ("a control session the server refuses",
+         {"tasklist": tasklist_naming(CTL_SID), "control": control_links(),
+          "ctl2_code": "500"}),
+        ("a control session curl could not reach",
+         {"tasklist": tasklist_naming(CTL_SID), "control": control_links(),
+          "ctl2_rc": "7"}),
+    ]
+
+    @pytest.mark.parametrize("why,kw", DEAD_CONTROLS, ids=[w for w, _ in DEAD_CONTROLS])
+    def test_a_control_that_did_not_answer_keeps_the_OLD_wording_byte_for_byte(
+        self, resolver, why, kw
+    ):
+        """🔴 FAIL SAFE. The control is a nicety; its failure must be invisible.
+        Byte-for-byte, because "roughly the same message" is how a hedge gets
+        softened by accident — and because a control that failed has told us
+        NOTHING, which is exactly what the old wording says."""
+        r = resolver(NONE, **kw)
+        assert r.returncode == 5, r.stdout + r.stderr
+        assert norm(r.stdout) == OLD_ZERO_WORDING, r.stdout
+
+    #: Every `sourceSessionId` shape that must never reach a URL path. The
+    #: middle one is what an error page or a renamed field leaves behind.
+    UNSENDABLE_IDS = ["../../api/tasks", "", "sess abc", "x/../../etc", "a?b=c"]
+
+    @pytest.mark.parametrize("bad", UNSENDABLE_IDS)
+    def test_a_control_id_that_could_steer_the_URL_is_never_SENT(self, resolver, bad):
+        """🔴 ASSERTED ON THE REQUEST, NOT ON THE WORDING — and it had to be.
+        Deleting this refusal left the whole class GREEN: the steered URL
+        `…/api/sessions/../../api/tasks/tasks` still contains `/api/tasks`, so
+        the fixture served it the task LIST, whose shape carries no `tasks`
+        array, so the verdict fell back to the old wording anyway. The output
+        was identical while a hand-built path had been sent to the server. Only
+        counting the requests can see that (`claude/RULES.md` -> "A guard can be
+        SPELLED rather than STRUCTURAL")."""
+        r = resolver(NONE, tasklist=[{"id": CTL_TASK_ID, "sourceSessionId": bad}])
+        assert r.returncode == 5, r.stdout + r.stderr
+        assert norm(r.stdout) == OLD_ZERO_WORDING, r.stdout
+        seen = urls(resolver)
+        assert seen == [
+            "http://clawgate.invalid:1/api/sessions/sess-abc-123/tasks",
+            "http://clawgate.invalid:1/api/tasks?limit=1",
+        ], f"a third request was issued with a refused control id {bad!r}: {seen}"
+
+    def test_a_control_id_EQUAL_to_the_session_under_test_is_not_a_control(self, resolver):
+        """🔴 `claude/RULES.md` -> "A control that SHARES the step you doubt is a
+        second sample of the same unknown, not a control". Reachable only as a
+        race (a task filed by this very session between the two requests), and
+        refused rather than reasoned about."""
+        r = resolver(NONE, session_id="sess-abc-123",
+                     tasklist=tasklist_naming("sess-abc-123"),
+                     control=control_links("sess-abc-123"))
+        assert r.returncode == 5, r.stdout + r.stderr
+        assert norm(r.stdout) == OLD_ZERO_WORDING, r.stdout
+        # and it never issued the second control request at all
+        assert urls(resolver) == [
+            "http://clawgate.invalid:1/api/sessions/sess-abc-123/tasks",
+            "http://clawgate.invalid:1/api/tasks?limit=1",
+        ], urls(resolver)
+
+    # ------------------------------------------------------ the exit contract
+    def test_the_exit_code_is_5_in_BOTH_directions(self, resolver):
+        """🔴 THE WIRE CONTRACT, asserted as a PAIR in one test so the two halves
+        cannot drift apart. `claude/skills/handoff/SKILL.md` branches on rc 5 to
+        mean "write no `clawgate-task:` field"; a control that moved the code
+        would silently change what every caller does."""
+        up = resolver(NONE, tasklist=tasklist_naming(CTL_SID), control=control_links())
+        old = resolver(NONE)
+        assert (up.returncode, old.returncode) == (5, 5), (up.stdout, old.stdout)
+        # …and the two really did take different branches, or the pair is vacuous
+        assert norm(up.stdout) != norm(old.stdout)
+
+    # ------------------------------------------- the requests actually happen
+    def test_the_probe_issues_the_two_control_requests_it_claims_to(self, resolver):
+        """🔴 POSITIVE CONTROL ON THE HARNESS. Every fail-safe assertion above is
+        of the form "the output is unchanged", which a probe wired to nothing
+        satisfies for free. This is the case that must produce a non-zero count:
+        three URLs, the last of them the SAME endpoint as the first, with the id
+        the task list named."""
+        r = resolver(NONE, tasklist=tasklist_naming(CTL_SID), control=control_links())
+        assert r.returncode == 5
+        seen = urls(resolver)
+        assert len(seen) == 3, seen
+        assert seen[0].endswith("/api/sessions/sess-abc-123/tasks"), seen
+        assert "/api/tasks?limit=1" in seen[1], seen
+        assert seen[2].endswith(f"/api/sessions/{CTL_SID}/tasks"), seen
+
+    def test_NO_control_request_is_issued_when_anything_RESOLVES(self, resolver):
+        """🔴 THE COST BOUND. `resolve` must not get slower for the runs that
+        work. Driven across every non-5 outcome the ranking can reach — one
+        resolution, an ASK, and a broken read — because the trigger is the exit
+        code and a mutant moving the probe above that check would still look
+        right on the empty payload."""
+        for payload, want_rc in ((ONE, 0), (TWO, 6), ({"tasks": "nope"}, 4)):
+            r = resolver(payload, tasklist=tasklist_naming(CTL_SID),
+                         control=control_links())
+            assert r.returncode == want_rc, r.stdout
+            assert urls(resolver) == [
+                "http://clawgate.invalid:1/api/sessions/sess-abc-123/tasks"
+            ], (payload, urls(resolver))
+
+    def test_the_TOKEN_FILE_is_still_gone_after_the_control_runs(self, resolver):
+        """🔴 THE ONE THING THIS CHANGE MADE RISKIER. The curl config holds a
+        live bearer token and used to be unlinked immediately after the request
+        under test; it now OUTLIVES that request so the control can reuse it
+        rather than writing the credential a second time. So the deletion has to
+        be re-proven on the longest path — and on exactly ONE file, since a
+        second auth path would show up here as a second leftover."""
+        tmpdir = resolver.tmpdir  # type: ignore[attr-defined]
+        assert not list(tmpdir.iterdir()), "the fixture TMPDIR did not start empty"
+        r = resolver(NONE, tasklist=tasklist_naming(CTL_SID), control=control_links())
+        assert r.returncode == 5
+        assert list(tmpdir.iterdir()) == [], [p.name for p in tmpdir.iterdir()]
+        # ONE config, handed to all three requests — not one per request
+        paths = set(resolver.cfg_paths.read_text().split())  # type: ignore[attr-defined]
+        assert len(paths) == 1, f"the token was written to {len(paths)} files: {paths}"
+        assert SENTINEL_TOKEN not in r.stdout + r.stderr
+
+    def test_the_stub_serves_DIFFERENT_bodies_per_URL(self, resolver):
+        """🔴 NEGATIVE CONTROL ON THE HARNESS ITSELF. If the stub served one body
+        to every request, the upgraded-wording test would pass whenever the
+        session under test resolved rows — i.e. for the wrong reason entirely.
+        Here the session under test is EMPTY while the control is not, and the
+        subject must report both facts at once."""
+        r = resolver(NONE, tasklist=tasklist_naming(CTL_SID), control=control_links())
+        assert "0 tasks for this session" in r.stdout
+        assert f"{CTL_LINKS} link(s) for session {CTL_SID}" in r.stdout
+
+    # ---------------------------------------------------- structure and cost
+    def test_the_control_is_TIME_BOUNDED_and_never_retries(self):
+        """🔴 STRUCTURAL, because the behavioural version would have to be slow
+        to be real. Every curl inside the probe must carry the shared timeout
+        constant, that constant must be SHORTER than the request under test's,
+        and no retry flag may appear — a stacking retry is how a nicety becomes
+        the reason `resolve` hangs."""
+        src = LIB.read_text(encoding="utf-8")
+        probe = _decommented(shell_fn_body(src, "clawgate_zero_probe"))
+        calls = re.findall(r"\bcurl\b", probe)
+        assert len(calls) == 2, f"the probe issues {len(calls)} curl call(s), not 2"
+        bounded = re.findall(r'--max-time\s+"\$CLAWGATE_CONTROL_MAX_TIME"', probe)
+        assert len(bounded) == len(calls), (
+            "a curl in the probe is not bounded by $CLAWGATE_CONTROL_MAX_TIME:\n" + probe
+        )
+        assert "--retry" not in probe, "the control must not retry"
+        m = re.search(r"^CLAWGATE_CONTROL_MAX_TIME=(\d+)\s*$", src, re.M)
+        assert m, "CLAWGATE_CONTROL_MAX_TIME is no longer a plain integer constant"
+        # Exactly ONE literal `--max-time N`: a second would make "the request
+        # under test's timeout" ambiguous and this comparison arbitrary.
+        literals = re.findall(r"--max-time\s+(\d+)\b", src)
+        assert len(literals) == 1, f"expected one literal --max-time, found {literals}"
+        assert int(m.group(1)) < int(literals[0]), (
+            f"the control's timeout ({m.group(1)}s) is not shorter than the "
+            f"request under test's ({literals[0]}s)"
+        )
+
+    def test_the_zero_wording_lives_in_exactly_ONE_function(self):
+        """🔴 `claude/RULES.md` -> "One rule, one place". Two copies of this
+        verdict — one in the ranking, one in the resolver — is how the upgraded
+        branch and the fail-safe branch drift apart, and only one of them is
+        ever exercised by a run against a live board."""
+        src = LIB.read_text(encoding="utf-8")
+        sentinel = "NOTHING RESOLVED — 0 tasks for this session."
+        assert src.count(sentinel) == 1, "the zero verdict is worded in more than one place"
+        assert sentinel in shell_fn_body(src, "clawgate_zero_verdict")
+        rank = shell_fn_body(src, "clawgate_rank_rows")
+        assert "clawgate_zero_verdict" in rank, "the ranking no longer delegates the wording"
+        assert sentinel not in rank
+
+    def test_the_verdict_is_PURE_and_the_probe_is_NOT(self):
+        """🔴 THE FILE'S OWN PURE/IO CONTRACT, extended to the two new functions.
+        The wording is drivable from a fixture with no server; the requests are
+        not, and putting them on the wrong side of that line is how the last
+        untestable 50-line block got there."""
+        src = LIB.read_text(encoding="utf-8")
+        io_line = src.index("# I/O — everything below this line")
+        assert src.index("clawgate_zero_verdict(){") < io_line
+        assert src.index("clawgate_zero_probe(){") > io_line
+        probe = _decommented(shell_fn_body(src, "clawgate_zero_probe"))
+        assert "echo" not in probe, (
+            "the probe prints a diagnostic — its failure must be invisible to the "
+            "verdict, which is the caller's to word"
+        )
+
+    # ---------------------------------------- the wording, driven PURELY
+    def test_the_renderer_answers_from_TEXT_ALONE(self):
+        """No server, no stub, no PATH games: the two wordings are a pure
+        function of (control id, control body). This is what makes every case
+        above reproducible from a string."""
+        up = call_fn("clawgate_zero_verdict", CTL_SID, json.dumps(control_links()))
+        assert up.returncode == 0, up.stdout + up.stderr
+        assert norm(up.stdout) == upgraded_zero_wording(), up.stdout
+        old = call_fn("clawgate_zero_verdict")
+        assert norm(old.stdout) == OLD_ZERO_WORDING, old.stdout
+
+    @pytest.mark.parametrize("body", [
+        "", "not json", "{}", '{"tasks": []}', '{"tasks": null}',
+        '{"tasks": {"id": 1}}', '{"tasks": "3"}', "[]",
+    ])
+    def test_no_shape_of_dead_control_body_can_upgrade_the_wording(self, body):
+        """🔴 A CONTROL THAT RESOLVED ZERO IS ITSELF AN EMPTY RESULT and cannot
+        license a stronger claim. Driven at the renderer because no live server
+        produces all of these, and the branch must be right for each."""
+        r = call_fn("clawgate_zero_verdict", CTL_SID, body)
+        assert norm(r.stdout) == OLD_ZERO_WORDING, (body, r.stdout)
+
+    def test_a_control_id_with_no_body_is_not_a_control(self):
+        """Both halves are required — an id alone names a session nothing was
+        read from."""
+        r = call_fn("clawgate_zero_verdict", CTL_SID)
+        assert norm(r.stdout) == OLD_ZERO_WORDING, r.stdout
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## The problem

`clawgate_handoff.sh resolve`'s rc 5 printed the same permanent hedge on every zero:

```
clawgate: NOTHING RESOLVED — 0 tasks for this session.
  An unknown session id answers 200 with an EMPTY ARRAY, so this cannot
  distinguish 'this session touched no task' from 'the id is wrong'.
  Write NO clawgate-task: field, say so in the report, and never create a task.
```

True — and also the reassuring shape of a **dead endpoint, a wrong base URL and a rejected token**. Every `/handoff` run paid for it. Session `2f969fa6-866b-4ac2-ac11-4c359cbeda7e` paid in full: its handoff doc *and* its closing report both had to carry "not a clean bill of health". The ambiguity was then resolved **by hand, in three commands** — query the same endpoint with a session id known to be linked, and watch rows come back.

This automates those three commands.

## What it does

On the **zero path only**, `clawgate_zero_probe` issues two bounded requests:

1. `GET /api/tasks?limit=1` — a task's `sourceSessionId` is *by construction* linked to that task with `role=created`, so it is an id that MUST resolve. The control id comes from the server's own data, never from a constant that can go stale.
2. `GET /api/sessions/<that id>/tasks` — **the same endpoint under test**. That identity is the point; a control on a different route shares none of the steps in doubt.

Rows back ⇒ the wording narrows:

```
clawgate: NOTHING RESOLVED — 0 tasks for this session.
  POSITIVE CONTROL: the SAME endpoint answered 1 link(s) for session e0242f58-9d11-4fb3-b61e-da147a499305,
  so the board is reachable, the base URL is right and the token is accepted —
  this 0 is a REAL READING of the board, not an instrument wired to nothing.
  🔴 IT DOES NOT PROVE THE SESSION ID UNDER TEST IS RIGHT. A wrong id ALSO answers
  200 with an EMPTY ARRAY; the control shows only that a CORRECT id WOULD have
  resolved. That is a NARROWER claim, NOT a clean bill of health.
  Write NO clawgate-task: field, say so in the report, and never create a task.
```

(that block is **real output**, captured against live clawgate 0.8.0)

## 🔴 It does not overclaim

A working endpoint proves only that a *correct* id would have resolved. It says nothing about whether the id under test is correct. The output says so in so many words, and still forbids writing a field or minting a task.

## 🔴 The exit code never moves

rc 5 is a **wire contract** — `claude/skills/handoff/SKILL.md` and the resume tooling read it as "write no `clawgate-task:` field". Only the MESSAGE changes. Asserted as a pair in one test so the halves cannot drift.

## Fail-safe and cheap

Any control failure — no task list, unparseable, no `sourceSessionId`, an id that could steer a URL, an id equal to the one under test, non-200, curl error, a control resolving zero rows — reproduces today's wording **byte for byte**. Both requests carry `--max-time 3` (a third of the request under test's 10 s), no retries, and none is issued unless the ranking already returned 5: **a resolve that resolves is exactly as fast as before**. Measured live: 53 ms for all three requests.

## Structure

`clawgate_zero_verdict` is PURE and is the only place either wording lives — `clawgate_rank_rows` calls it with no arguments, so the ranking stays serverless and drivable from a fixture string. `clawgate_zero_probe` sits below the I/O line, prints nothing, and **reuses the caller's 0600 curl config** so the token is still written exactly once, under one trap (re-proven by a new test on the now-longer path).

## Test matrix

| claim | evidence |
|---|---|
| regression, not an invariant guard | `test_a_control_that_RESOLVES_ROWS_upgrades_the_zero_verdict` and `test_the_exit_code_is_5_in_BOTH_directions`: **RED at `a2dc76be` (origin/main)**, each on its OWN assertion; **green at HEAD** |
| the prose can't be reworded around | whole normalised stdout pinned for both wordings, spelled in the test file, never read from the subject |
| fail-safe | 13 shapes assert the old text byte for byte |
| exit code | asserted 5 explicitly in both directions |
| live | exercised against clawgate 0.8.0 on the LAN NodePort — the genuinely-zero session, a nonexistent id, and a linked session (rc 6, so no control issued) |
| suite | 232 passed in `test_resume_state_clawgate.py`; full `bash scripts/run-tests.sh .` → `RESULT: PASS (exit=0)` |

### Mutation battery — 13 mutants, 12 KILLED

Including the known-caught positive control (`return 5` → `return 0`, killed by 23 tests). The one survivor, `else empty` → `else 0` in the count filter, was **measured equivalent** — identical output for every non-array shape, verified by md5 rather than argued — and is documented as such in the source.

**Two harness gaps the battery found, both fixed in this PR:**

- the control's two requests shared one status knob, so **request 2's own checks never executed** and a mutant deleting them survived the whole class (`claude/RULES.md` → "a mutation test still passes when an earlier check always wins"). The stub now has separate codes per request; the mutant is killed.
- the URL-steering refusal was asserted on the **wording**, which a steered `…/api/sessions/../../api/tasks/tasks` happens to reproduce (it still contains `/api/tasks`, so the fixture served it the task list and the verdict fell back anyway). Deleting the guard left the class **green** while a hand-built path went to the server. Now asserted on the **requests actually issued**; the mutant is killed 5×.

## Not verified

- The fail-safe branches were driven against the **mock**, not against a live board — reaching them live needs a server that answers the session request but not `/api/tasks`, which I did not construct.
- `claude/skills/handoff/SKILL.md` is unchanged: its rc-5 text ("write no field… not a clean bill of health") stays accurate under both wordings, and `resume-state.sh` sources this lib but never calls `resolve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
