### PR TITLE
docs(handoff): the preemption fix is SETTLED (0/65, p=9e-9) — and neither "flaky test" was ever a flake

### DIFF
--- a/claudedocs/handoff-ci-flakes-and-misattribution.md
+++ b/claudedocs/handoff-ci-flakes-and-misattribution.md
@@ -210,26 +210,74 @@ read the root cause first; the design is what failed, not the code.
    count a run as KILLED if ANY step's `terminated.exitCode` is `255` or `137`, GENUINE if
    `verdict` exits non-zero without one. **Reproduce `30/121` on the pre-`06:00Z 2026-08-25`
    window first** — that is the instrument's positive control, and it matches to the digit.
-2. **Two flaky tests still UNDIAGNOSED**, both `devrc`, `scripts/tests/`:
-   `test_no_unallowlisted_public_ip_literal_is_committed` and
-   `test_the_module_root_is_load_bearing`. Neither has a wall-clock dependency in the sandbox
-   tier; either could have been a *correct* red on some branch. Logs were unrecoverable (pods
-   GC'd; commit statuses cap at 140 chars) — **but `broken-gate-tail` now exists**, so a
-   recurrence is readable.
-3. **Re-check `test_an_absent_origin_header_is_not_the_same_as_an_empty_one`** —
+2. ✅ **DONE 2026-08-25 — NEITHER OF THE "TWO FLAKY TESTS" WAS EVER A FLAKE.** Both were
+   already diagnosed AND closed, and — 🔴 the part worth carrying — **both were recorded as
+   closed in THIS DOC'S OWN LINEAGE and then carried forward as "UNDIAGNOSED" anyway.** The
+   hedge that was right (*"either could have been a correct red on some branch"*) sat next to
+   the answer for two days because nobody re-read the predecessor. Same misattribution class
+   this thread exists to fix, committed by the thread's own notes.
+   - **`test_the_module_root_is_load_bearing` — a DETERMINISTIC two-tier failure, fixed by
+     #732 (`5a2a7b21`, 2026-08-22).** It asserted `gitenv.py` sits inside a git checkout; the
+     authoritative runner's source is a `/nix/store` path with **no `.git`**, so it died on
+     its own precondition — green on a dev host, red in the only tier that gates a merge, **on
+     every open PR, for reasons no PR had touched.** Recorded ✅ DONE in `cdcc61f8`.
+     **Re-verified live here, both arms, in `.git`-less trees exported with `git archive`:**
+
+     | tree | result |
+     |---|---|
+     | `5a2a7b21^` (pre-#732) | **1 failed** — `AssertionError: gitenv.py is not inside a git checkout`, the verbatim CI assertion |
+     | `origin/main` | **2 passed** |
+
+     The red arm is the **negative control**: the harness was shown to go red before its
+     green was believed. A regression guard also exists —
+     `test_the_module_root_pin_does_not_depend_on_this_tree_being_a_checkout`.
+   - **`test_no_unallowlisted_public_ip_literal_is_committed` — a CORRECT RED, not a flake.**
+     It failed #762's first revision, which committed
+     `nix/system/apply-nebula-443.sh.LOCAL-preserved-2026-08-02` — carrying a real prod
+     lighthouse IP **6 times** — into a **PUBLIC** repo. Recorded in `6d959016`. The test has
+     no wall-clock, no concurrency and no process scan; it is a pure function of the tree, so
+     it *cannot* flake. **Re-verified live, with both controls:** the file is **absent from
+     `origin/main`** (`git cat-file -e` → never committed, so the gate did its job); under
+     test the committed tree gives **0 unpinned**; feeding the same assertion path the leak
+     file gives **6**, all from that one path. Instrument proven able to go red; the zero is real.
+3. 🔴 **`broken-gate-tail` CANNOT name a failing test — do not reach for it expecting one.**
+   Measured over every `devrc-ci-*-report` TaskRun: **24 of 139 populated**, but only **1 of
+   the 24 genuine failures**. It is the *broken-gate* instrument (kills), and its content is
+   the last 1200B of a log captured mid-suite, so it ends in a wall of dots. **The instrument
+   that names the test is the commit status** (`FAILING: <test> | TOTAL collected=…`).
+   ⚠ **That naming only starts at `a9337827` (2026-08-24T20:34Z)** — every failure before it
+   carries counts and no name, which is why the two tests above were unattributable rather
+   than unexplained. 17 of the window's 24 genuine failures are named; all 17 are read and
+   **neither test above appears**.
+4. 🔴 **UNEXPLAINED, found while doing the above: a leg reported `FAILED` with `failed=0`.**
+   Commit `1ca46a80` (`devrc-ci-jqx65`, 2026-08-25T20:44Z):
+   `FAILED: pytests — TOTAL collected=16062 passed=16060 skipped=2 failed=0`. The arithmetic
+   closes (16060+2=16062), so no test failed and the leg still failed the PR. Either a target
+   died without producing a test failure (collection error, non-pytest target, non-zero exit)
+   or the verdict logic mis-attributes. **This is a misattribution of exactly this thread's
+   kind and it is LIVE** — it was not chased here.
+5. **Re-check `test_an_absent_origin_header_is_not_the_same_as_an_empty_one`** —
    `scripts/browser-bridge/tests/`. It shares #802's dropped-emit mechanism and **#802 has
    merged (`d09038d8`)**; the prior agent said verify rather than assume it is covered.
-4. **A ninth flake, UNCONFIRMED:** `test_live_cotenants_does_not_count_this_process`
+   **Now the top open flake item**, since 1 and 2 are closed.
+6. **A ninth flake, UNCONFIRMED:** `test_live_cotenants_does_not_count_this_process`
    (`scripts/tests/test_git_repo_isolation.py:1479`). Leading suspect `git commit`'s detached
    `run_auto_maintenance`. 0/25 reproductions across three load conditions, **and the /proc
    watcher used failed its own positive control — so those zeros are not evidence.**
-5. **#810's two remaining cosmetic nits:** `scripts/lib/agent_ledger.py:261` still says "a 2s
+7. **#810's two remaining cosmetic nits:** `scripts/lib/agent_ledger.py:261` still says "a 2s
    timeout under load" (a second spelling of the budget), and the narrow arm's failure message
    in `test_agent_ledger.py` names the wrong cause. Neither merits its own PR.
-6. **Housekeeping, none urgent:** `homelab-talos` has **53 stash entries** and a repo-local
+8. **Housekeeping, none urgent:** `homelab-talos` has **53 stash entries** and a repo-local
    `core.hooksPath` nobody set deliberately; `devrc` has **46 worktrees**, many on merged
    branches. And `ecc4332e` references the capacity question as `#1205`, which is **not** a
    homelab-infra number (issues stop at #316, PRs at #394) — tracker unknown.
+   ⚠ **New, and it is a LEAK sitting in a working tree, not a tidiness item:**
+   `nix/system/apply-nebula-443.sh.LOCAL-preserved-2026-08-02` is **still untracked in the
+   workbench `devrc` checkout**, 23 days on, carrying a prod IP 6×, in a repo where
+   `git add -A` is banned for exactly this reason. `6d959016` established its entire delta IS
+   the leak (the tracked `apply-nebula-443.sh` takes the IP at runtime), so it is not stranded
+   work and deleting it loses nothing. **Left in place — removing an operator's untracked file
+   is their call, not an agent's.**
 
 ## Gotchas / decisions / dead-ends
 - 🔴 **`scripts/gate.sh` runs the DEV-HOST tier only** — `run-tests.sh` + `run-node-tests.sh`.

--- a/claudedocs/handoff-ci-flakes-and-misattribution.md
+++ b/claudedocs/handoff-ci-flakes-and-misattribution.md
@@ -46,11 +46,33 @@ spool row. Both are now fixed; the flake family underneath is only half closed.
     2026-08-25 05:32Z — **46 minutes AFTER** the burst capture that "confirmed" it. Not our work.
   - **~27 were genuine per-test flakes**, ~1 test in ~15,500, varying run to run. #810/#833/#840
     address the tmux-deadline class; the rest are listed under Next steps.
-- **Post-fix measurement (the one `ci-priority-classes.yaml` explicitly asks for):**
-  before #396 `30/121 killed (24.8%)`; after (≥06:00Z 2026-08-25) **`0/9`, 100% passed**,
-  with `devrc-ci` on `talos-xr6-r7p` and `gitops-validate` on `talos-uvh-gtj`.
-  ⚠ **n=9 is suggestive, NOT conclusive** — ~2 kills expected at the old rate, so a clean 9
-  arises by luck ~1 in 12. **Re-run it** (next-step 1).
+- ✅ **Post-fix measurement — RE-RUN 2026-08-25 ~23:50Z at n=65. THE PREEMPTION FIX IS SETTLED.**
+  Before #396 `30/121 killed (24.8%)`; after (created ≥06:00Z 2026-08-25) **`0/65` killed,
+  57 passed / 8 genuine `verdict exit=1` / 3 still running.**
+  P(0 kills in 65 | rate unchanged at 24.8%) = **9e-9**; 95% upper bound on any residual
+  kill rate **4.5%**, down from 24.8%. The earlier `0/9` was ~1-in-13 by luck; this is not.
+  - 🔴 **Instrument validated by EXACT RECONSTRUCTION, not by plausibility.** The same
+    classifier over the same window boundary reproduces the prior session's figure to the
+    digit — `30/121 = 24.8%` — numerator *and* denominator. (`121` = all gate TaskRuns
+    created before `06:00Z`, incompletes included; a `complete`-only denominator gives
+    `30/116 = 25.9%`. Both are stated so the number carries its own definition.)
+  - **TWO independent discriminators agree.** Kills counted as any step exiting `255`/`137`;
+    separately, `verdict exit=2` is the killed-step signature. Pre: 30 and 30. Post: **0 and 0.**
+    Zero `255`/`137` on ANY step (`clone`/`pytests`/`nodetests`/…), not just the test legs.
+  - 🔴 **The rival mechanism — "the post window was just quiet" — is REFUTED by measurement,
+    not assumed away.** Post is *busier*: median concurrent TaskRuns 14 vs 12, max **74 vs 44**;
+    max overlapping `gitops-validate` TaskRuns **38 vs 30**; max overlapping `devrc-ci` gates
+    **14 vs 9**; runs overlapping ≥10 `gitops-validate` TaskRuns **15 vs 12**. Equal-or-higher
+    contention, zero kills.
+  - **No pruning confound:** 68 `devrc-ci` PipelineRuns and 68 gate TaskRuns in the post
+    window — nothing GC'd out of the denominator.
+  - **The mechanism is live:** 212 pods checked, `devrc-ci` **entirely** on `talos-xr6-r7p`,
+    `gitops-validate` **entirely** on `talos-uvh-gtj`, zero cross-over.
+  - **Preemption did not MOVE — it stopped:** `gitops-validate` shows `0` killed in *both*
+    windows (0/238 pre, 0/107 post); it was the preemptor, never the victim.
+  - **The genuine-flake class is UNCHANGED, exactly as expected:** `verdict exit=1` at
+    14/116 (12.1%) pre vs 8/65 (12.3%) post. #396 closed preemption and touched nothing
+    else — the per-test flakes under Next steps 2–4 are still open and still real.
 - **Deploy: NOT done this session.** Nothing was shipped to either host; all seven PRs are
   merged only. `DEFAULT_TMUX_TIMEOUT_S` is untouched at `2.0`, so no production behaviour changed.
 
@@ -179,11 +201,15 @@ read the root cause first; the design is what failed, not the code.
   under-diagnosis this thread spent the evening correcting.
 
 ## Next steps (ranked)
-1. **Re-run the post-#396 kill-rate measurement** — the only open question with a deadline
-   attached, because it decides whether the preemption fix is actually settled. Compare
-   against `30/121 (24.8%)` before and `0/9` after. Repo: `homelab-infra`. One command,
-   `KUBECONFIG=$KC_HOMELAB`, classify `devrc-ci` gate TaskRuns by whether any step exited
-   `255`/`137` (killed, no test result) vs `verdict exit=1` (genuine).
+1. ✅ **DONE 2026-08-25 — the post-#396 kill-rate measurement re-ran at n=65 and came back
+   `0/65`.** Full result, controls and refuted rival mechanism under `State now`. **The
+   preemption arm of this thread is CLOSED**; do not re-derive it. What remains below is the
+   genuine per-test flake class only, which the same measurement shows is untouched (12.1% →
+   12.3%, i.e. unchanged). Method, if it is ever needed again: dump
+   `kubectl -n tekton-ci get taskruns -o json`, take names matching `devrc-ci-*-gate`,
+   count a run as KILLED if ANY step's `terminated.exitCode` is `255` or `137`, GENUINE if
+   `verdict` exits non-zero without one. **Reproduce `30/121` on the pre-`06:00Z 2026-08-25`
+   window first** — that is the instrument's positive control, and it matches to the digit.
 2. **Two flaky tests still UNDIAGNOSED**, both `devrc`, `scripts/tests/`:
    `test_no_unallowlisted_public_ip_literal_is_committed` and
    `test_the_module_root_is_load_bearing`. Neither has a wall-clock dependency in the sandbox


### PR DESCRIPTION
Records the re-run of the post-#396 devrc-ci kill-rate measurement — next-step 1 of `claudedocs/handoff-ci-flakes-and-misattribution.md`, and the only open question in that thread with a deadline attached, because it decides whether the scheduler-preemption fix is settled.

## The result

| window | killed | rate |
|---|---|---|
| pre-#396 (created < `2026-08-25T06:00Z`) | **30 / 121** | 24.8% |
| post-#396 (created ≥ `2026-08-25T06:00Z`) | **0 / 65** | **0.0%** |

P(0 kills in 65 | rate unchanged at 24.8%) = **9e-9**. 95% upper bound on any residual kill rate: **4.5%**, down from 24.8%.

The prior session measured `0/9` and correctly refused to call it — a clean 9 arises by luck ~1 in 13. At n=65 it does not.

## Why this is a measurement and not a hopeful zero

- **The instrument is validated by exact reconstruction, not plausibility.** The same classifier over the same window boundary reproduces the prior session's figure to the digit — `30/121 = 24.8%`, numerator *and* denominator. A zero from an instrument that has not been shown to reproduce a known non-zero is indistinguishable from an instrument wired to nothing.
- **Two independent discriminators agree.** Kills counted as any step exiting `255`/`137`; separately, `verdict exit=2` is the killed-step signature. Pre: 30 and 30. Post: **0 and 0**. Zero `255`/`137` on *any* step, not just the test legs.
- **The rival mechanism is refuted by measurement, not assumed away.** "0 kills because the post window was quiet" predicts lower contention. Measured: post is *busier* — median concurrent TaskRuns 14 vs 12, max **74 vs 44**; max overlapping `gitops-validate` TaskRuns **38 vs 30**; max overlapping `devrc-ci` gates **14 vs 9**; runs overlapping ≥10 `gitops-validate` TaskRuns **15 vs 12**. Equal-or-higher contention, zero kills.
- **No pruning confound.** 68 `devrc-ci` PipelineRuns and 68 gate TaskRuns in the post window — nothing GC'd out of the denominator.
- **The mechanism is live.** 212 pods checked: `devrc-ci` entirely on one node, `gitops-validate` entirely on another, zero cross-over.
- **Preemption did not move, it stopped.** `gitops-validate` is 0 killed in *both* windows (0/238 pre, 0/107 post) — it was the preemptor, never the victim.

## What this does NOT close

The genuine per-test flake class is **unchanged**: `verdict exit=1` at 14/116 (12.1%) pre vs 8/65 (12.3%) post. #396 closed preemption and touched nothing else, so next-steps 2–4 of the handoff stay open and stay real. The doc says so explicitly rather than letting a headline zero read as "CI is fixed".

## Verification

Docs-only. `test_doc_path_rot.py` (76 passed) and the four content gates — `test_no_captured_markup`, `test_no_captured_text`, `test_no_client_hostnames`, `test_no_public_ips` (227 passed) — run on the **dev-host tier** at base `79d83f1c`. The sandbox tier (`nix build .#checks…`) is what Tekton gates on and is not claimed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
