### PR TITLE
fix(escrow-verify): --decrypt-check spent the master password before discovering it could not finish

### DIFF
--- a/SECRETS.md
+++ b/SECRETS.md
@@ -175,14 +175,31 @@ backups`); `scripts/analyze-service-index/escrow-verify.py` is what re-checks
 that copy, so the escrow does not quietly rot into a second thing that only
 looks intact.
 
+🔴 **RUN IT ONCE BEFORE YOU UNLOCK.** The order below is deliberate and was
+learned twice: `--decrypt-check` reaches MinIO through a LAZY `minio` import, so
+a shell without that package unlocked the vault and died afterwards — the master
+password spent on a run that was never going to finish. A locked first pass costs
+a second and proves the shell, the argv and the host label; `escrow-verify.py`
+cannot prompt for a password itself (every `bw` call runs with stdin on
+`/dev/null`), so the only spend is your own `bw unlock`.
+
+⚠ The `python3.withPackages(...)` argument is **required** for `--decrypt-check`.
+Without it `python3` resolves from the ambient profile, which does not carry
+`minio`, and the run refuses with exit 34 naming the interpreter.
+
 ```sh
 # `bw` is deliberately NOT installed on either host.
-nix-shell -p bitwarden-cli jq --run '
-  export BW_SESSION="$(bw unlock --raw)"          # the ONE step nothing can automate
-  python3 scripts/analyze-service-index/escrow-verify.py
+nix-shell -p bitwarden-cli jq 'python3.withPackages(p:[p.minio])' --run '
+  # 1. locked dry pass: exits 12 VAULT-LOCKED, or 34 if THIS shell is wrong.
+  #    Either way no password has been spent.
+  python3 scripts/analyze-service-index/escrow-verify.py --decrypt-check --host <host label>
+  # 2. only now — the ONE step nothing can automate
+  export BW_SESSION="$(bw unlock --raw)"
+  # 3. the claim that matters
+  python3 scripts/analyze-service-index/escrow-verify.py --decrypt-check --host <host label>
 '
-… escrow-verify.py --decrypt-check --host <host label>   # the claim that matters
-… escrow-verify.py --print-plan                          # no bw, no network, no key
+… escrow-verify.py --print-plan   # no bw, no network, no key — and it names
+                                  # which file the comparison will actually use
 ```
 
 Two levels, and they are **different claims**. The default compares the note to
@@ -201,12 +218,13 @@ materially. It reports **byte counts and a classification only, never the
 differing content**, and it reads the server from `bw config server` at run time
 rather than carrying an endpoint into a public repo.
 
-🔴 **Under `--decrypt-check` the eight outcomes mean different things, and only
+🔴 **Under `--decrypt-check` the nine outcomes mean different things, and only
 one of them is about the KEY.** Reading these wrong is how a working
 disaster-recovery key gets rotated, or a tampered backup gets waved through:
 
 | code | meaning | what to do |
 |---|---|---|
+| `34` `DECRYPT-DEPS-MISSING` | this interpreter cannot import what the decrypt path needs — raised BEFORE any `bw` call | re-run under the shell above; nothing was tested and the vault was not contacted |
 | `27` `STORE-UNREACHABLE` | could not open the bucket at all | cluster/route fault; nothing was tested |
 | `28` `NO-ARTIFACT` | zero objects under the prefix | wrong `--host`/prefix, or the backups are gone — `restore-verify.py` diagnoses which |
 | `29` `AGE-MISSING` | `age` is not on PATH | environment fault; says nothing about the escrow |

--- a/claudedocs/handoff-analyze-service-index-backup.md
+++ b/claudedocs/handoff-analyze-service-index-backup.md
@@ -372,6 +372,25 @@ a mismatch now names *what chose* the on-disk path — refusing to call the mism
 when an env var did. `--print-plan` discloses a redirect before any password is spent.
 Matrix: both red at `a8089a51`, green at HEAD, demonstrated by execution.
 
+🔴 **A run from the WRONG SHELL now refuses BEFORE the vault, exit 34.** Measured
+2026-08-25, twice: `--decrypt-check` unlocked the vault and *then* died on a missing
+`minio` — after the master password had been typed. The first fix corrected which shell is
+advertised; it did not change *when* the run discovers it is in the wrong one, so it
+happened again. `preflight_decrypt_imports()` now runs before any `bw` call and names the
+interpreter that came up short:
+
+```
+DECRYPT-DEPS-MISSING: --decrypt-check needs minio, which <the profile python3>
+cannot import. NOTHING HAS BEEN CHECKED and the vault was NOT contacted ...
+```
+
+Only the `python3.withPackages(p:[p.minio])` shape resolves a `python3` that has it — the
+bare shell and `-p bitwarden-cli jq` both resolve the ambient profile's, which does not.
+The old failure surfaced as `scripts/mail-actions/_minio.py`'s own `SystemExit`, which
+names a different program (`extract.py archive-invoices`) and a different package set;
+accurate for its original caller, misleading here. That shim is unchanged — escrow-verify
+simply no longer reaches it.
+
 It also settles two assumptions **never measured against the real vault item**: that a
 Secure Note has `type == 2`, and that `notes` is present in `bw list items` output. A wrong
 guess is loud, not silent — exit 19 prints the observed type. Locked/unauthenticated exit

--- a/claudedocs/handoff-analyze-service-index-backup.md
+++ b/claudedocs/handoff-analyze-service-index-backup.md
@@ -51,11 +51,10 @@ and close the one failure mode in it that is unrecoverable (no off-machine backu
    escrowed key still there, still byte-identical, and does it still *work*". Byte equality
    and working are different claims: `--decrypt-check` writes the **escrowed** bytes to a
    throwaway 0600 identity and decrypts a real artifact with them.
-   🔴 **Its unlocked path ran once (2026-08-25) and did NOT settle the question** — it
-   compared against a client key an env var had redirected it to. The escrow's agreement
-   with the real `age.key` is **still unconfirmed since the 08-23 `cmp`**, and that older
-   claim is neither confirmed nor refuted by the 08-25 run. See "The one link still
-   untested" — and do not re-escrow on that run's advice.
+   🔴 **CLOSED 2026-08-25: rc=0, byte-IDENTICAL and DECRYPT-CHECKED.** The escrowed
+   bytes opened a real timer-produced artifact and restored 40 commits. An earlier attempt
+   that day did NOT settle it — it compared against a client key an env var had redirected
+   it to — so the run that counts is the one with `--identity` pinned. See "The one link".
 
 ### Verified live, end to end
 10 scopes, 201 commits compared, restored from the bucket → `age -d` → `git clone` →
@@ -303,10 +302,56 @@ pgrep -f 'run-tests.sh|gate.sh' | while read -r p; do
 done   # none may equal ~/workspace/devrc/.git
 ```
 
-## The one link still untested — 🔴 STILL THE ONLY THING BLOCKED ON A HUMAN
+## The one link — 🔴 CLOSED 2026-08-25, rc=0
 
-**`escrow-verify.py`'s unlocked path has RUN ONCE, on 2026-08-25, and it did not settle
-the question** — it compared the escrow against the wrong file. Details in "The env
+**MEASURED, rc=0.** The escrow is intact AND it works:
+
+```
+escrow OK — the Secure Note matches ~/workspace/homelab-talos/.secrets/age.key
+IDENTICAL (189 escrowed bytes vs 189 on disk); session cross-check RAN;
+DECRYPT-CHECKED: the ESCROWED bytes decrypted
+<host>/civitai/20260825T094001Z.bundle.age (scope civitai) and restored
+40 commit(s) over 1 ref(s)
+```
+
+🔴 **Two separate claims, and the second is the one that matters.** Byte equality says the
+two copies agree; the decrypt says the copy *in the vault* — not the one on disk — opens a
+real artifact. The artifact was the TIMER's own output from that morning, not a hand-made
+fixture. Disk loss no longer takes the key with the store, and that is now measured rather
+than assumed.
+
+It also settled the two assumptions **never previously measured against the real vault
+item**: the note is `type == 2`, and `notes` is present in `bw list items` output. A wrong
+guess on either exits 19 or 20 long before the decrypt, so reaching rc=0 proves both.
+
+⚠ **Still soft:** `server NOT PINNED` — `--expect-server` / `ASIB_ESCROW_SERVER` were
+unset, so the run trusted whatever `bw config server` said. The session cross-check DID
+run and matched, which is a weaker but real check. Pin the server to close it.
+
+⚠ **Still untested, and unchanged:** the disaster path that actually matters — reading the
+note from the **web vault on another device** and pasting it into a file. That path can
+mangle whitespace and no run here exercises it. And the laptop's `bw` is still not logged
+in (`rc=13` when measured), so recovering from that host needs a fresh `bw login` first.
+
+**How it was run — use this, not a hand-typed one-liner:**
+
+```bash
+scripts/analyze-service-index/check-escrow.sh          # locked dry pass, then unlock
+scripts/analyze-service-index/check-escrow.sh --plan   # no bw, no network, no key
+```
+
+🔴 **The one-liner form is retired because it failed three times in a row, each time
+costing a master-password entry** — once by omitting the `python3.withPackages(...)`
+argument, once by losing the script-path token (which lands the operator in a Python
+REPL), and once by losing the identity-path token (`--identity: expected one argument`).
+All three are quoting/paste failures, not mistakes about the task. A ~300-character line
+carrying a nix expression, a `--run` string and three nested command substitutions is not
+something to hand a person to paste; the quoting now lives in a file.
+
+### The earlier run, kept because its lesson is durable
+
+**An earlier attempt on 2026-08-25 did NOT settle the question** — it compared the escrow
+against the wrong file. Details in "The env
 redirect" below. So the claim below is unchanged: everything above the vault boundary is
 still synthetic — the real note fetch, the real byte comparison against the real `age.key`,
 and `--decrypt-check` against MinIO are covered only by an injected fake.

--- a/scripts/analyze-service-index/check-escrow.sh
+++ b/scripts/analyze-service-index/check-escrow.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Check the escrowed age key — the whole workflow, in one short command.
+#
+# 🔴 WHY THIS EXISTS. The documented way to run `--decrypt-check` was a ~300
+# character one-liner with nested quoting: a `nix-shell -p …` carrying a
+# `python3.withPackages(…)` expression, a `--run` string holding a command
+# substitution for the master password, and two more substitutions inside that.
+# Measured over three attempts by the operator it went wrong three different
+# ways — a Python REPL (the script path token lost), `--identity: expected one
+# argument` (the path token lost), and a run in a shell without `minio` (the
+# package argument omitted). Every one of those is a QUOTING or PASTE failure,
+# not a mistake about the task, and each cost a master-password entry.
+#
+# So the quoting lives here, once, in a file — where it is version-controlled,
+# reviewed, and cannot be damaged in transit. The operator types one word.
+#
+# 🔴 THE ORDER IS THE POINT, and it is the fix from the #851 audit: this runs a
+# LOCKED dry pass FIRST. That pass costs a second and proves the shell, the
+# interpreter, the argv and the host label — and it cannot spend a password,
+# because `escrow-verify.py` never prompts (every `bw` call runs with stdin on
+# /dev/null). Only once it has failed with VAULT-LOCKED — the expected outcome
+# — do we ask for the password. A wrong shell therefore costs a second, not a
+# credential.
+#
+# Usage:
+#   check-escrow.sh              # byte check + decrypt check against the bucket
+#   check-escrow.sh --plan       # no bw, no network, no key: what WOULD run
+#   check-escrow.sh -- <args>    # anything after `--` goes to escrow-verify.py
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+VERIFY="$HERE/escrow-verify.py"
+# The identity this subsystem encrypts to. NOT read from the environment on
+# purpose: `SOPS_AGE_KEY_FILE` is exported by unrelated work and once pointed
+# this comparison at an unrelated third party's key, whose mismatch read as a
+# damaged escrow and whose remedy would have overwritten a good one.
+IDENTITY="${HOME}/workspace/homelab-talos/.secrets/age.key"
+HOST_LABEL="workbench-$(cat /etc/machine-id)"
+
+# The one place the shell expression lives. `bitwarden-cli` for `bw`, `jq`
+# because the documented pipeline uses it, and the python env because
+# `--decrypt-check` reaches MinIO through a LAZY `minio` import — a shell
+# without it resolves `python3` from the ambient profile, which lacks it.
+NIX_PKGS=(-p bitwarden-cli jq 'python3.withPackages(p:[p.minio])')
+
+EXTRA=()
+PLAN_ONLY=0
+case "${1:-}" in
+  --plan) PLAN_ONLY=1 ;;
+  --)     shift; EXTRA=("$@") ;;
+  "")     ;;
+  *)      EXTRA=("$@") ;;
+esac
+
+if [ "$PLAN_ONLY" = 1 ]; then
+  exec nix-shell "${NIX_PKGS[@]}" --run \
+    "python3 '$VERIFY' --print-plan --identity '$IDENTITY' --host '$HOST_LABEL'"
+fi
+
+# `${EXTRA[@]+"${EXTRA[@]}"}` — an empty array under `set -u` is an unbound
+# variable on bash < 4.4; this form expands to nothing rather than erroring.
+printf '=== 1/2  locked dry pass — proves the shell and argv, spends nothing\n'
+set +e
+nix-shell "${NIX_PKGS[@]}" --run \
+  "python3 '$VERIFY' --decrypt-check --identity '$IDENTITY' --host '$HOST_LABEL' ${EXTRA[*]-}"
+dry=$?
+set -e
+
+# 12 == VAULT-LOCKED, which is exactly what an un-unlocked vault must produce.
+# Anything else means the run failed for a reason a password will not fix, so
+# stop BEFORE asking for one — that is this script's whole job.
+if [ "$dry" -ne 12 ]; then
+  printf '\n=== dry pass exited %s, not 12 (VAULT-LOCKED).\n' "$dry"
+  printf '=== NOT asking for the master password: this run failed for a reason\n'
+  printf '===   unlocking will not fix. Read the message above.\n'
+  exit "$dry"
+fi
+
+printf '\n=== 2/2  vault is locked as expected — unlocking now\n'
+# 🔴 `&&` IS NOT ENOUGH: MEASURED, `bw unlock --raw` can exit ZERO having
+# printed NOTHING (it does so when it cannot read a password — no TTY, EOF, or
+# a cancelled prompt). The session is then the empty string, `export` succeeds,
+# and the verifier runs against a vault it cannot open and reports
+# VAULT-LOCKED — which reads as "the vault is locked" when what actually
+# happened is "your unlock produced no session". Two different problems, one
+# message. So the emptiness is checked explicitly and named.
+exec nix-shell "${NIX_PKGS[@]}" --run \
+  "BW_SESSION=\$(bw unlock --raw) || exit 12
+   if [ -z \"\$BW_SESSION\" ]; then
+     printf '=== bw unlock produced an EMPTY session (it exited 0 but printed nothing).\n' >&2
+     printf '===   Wrong password, a cancelled prompt, or no terminal to read one.\n' >&2
+     printf '===   NOT running the check: it would report VAULT-LOCKED and look\n' >&2
+     printf '===   like a vault problem rather than an unlock that never happened.\n' >&2
+     exit 12
+   fi
+   export BW_SESSION
+   exec python3 '$VERIFY' --decrypt-check --identity '$IDENTITY' --host '$HOST_LABEL' ${EXTRA[*]-}"

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -294,6 +294,11 @@ EXIT_CODES: dict[str, int] = {
     "AGE-MISSING": 29,          # precondition: the tool is not installed
     "ARTIFACT-UNREADABLE": 30,  # the pipeline failed BEFORE decrypt was reached
     "DECRYPT-FAILED": 25,       # age wrote NOTHING: wrong key OR damaged header
+    # 🔴 RAISED BEFORE ANY `bw` CALL — see `preflight_decrypt_imports`. Its own
+    # code because the remedy is unlike every other one here: nothing is wrong
+    # with the escrow, the artifact or the vault; the INTERPRETER is missing a
+    # package, and the fix is to re-run under a different shell.
+    "DECRYPT-DEPS-MISSING": 34,
     "ARTIFACT-CORRUPT": 33,     # age authenticated the HEADER then failed the
                                 #   payload: the key WORKED, the bytes are bad
     "ARTIFACT-EMPTY": 31,       # age exited ZERO on nothing: the key is FINE
@@ -1286,6 +1291,58 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
 NON_DEFAULT_NOTE = "  <- NOT the default identity"
 
 
+def preflight_decrypt_imports(*, modules: tuple[str, ...] = None,
+                              find_spec=None) -> None:
+    """Refuse a `--decrypt-check` the interpreter CANNOT complete — BEFORE the
+    vault is touched.
+
+    🔴 THIS RUNS BEFORE ANY `bw` CALL, AND THAT ORDERING IS THE WHOLE POINT.
+    MEASURED 2026-08-25, twice, in the same shape:
+
+      * the advertised shell omitted `minio`, so `--decrypt-check` unlocked the
+        vault and THEN died `ModuleNotFoundError` — after the master password
+        had been typed. The hint was fixed; the ORDERING was not, so the same
+        thing happened again from a shell that simply lacked the package.
+      * the failure surfaced as `scripts/mail-actions/_minio.py`'s own
+        `SystemExit`, which names a DIFFERENT program (`extract.py
+        archive-invoices`) and a DIFFERENT package set (`psycopg2`,
+        `requests`). Accurate for its original caller, actively misleading
+        here, and it never says WHICH interpreter came up short.
+
+    `importlib.util.find_spec` is used rather than a real import: it answers
+    "can this be imported" without executing `_minio.py`, whose import guard is
+    the `SystemExit` above — so probing by import would trade one confusing
+    message for another.
+
+    Only the modules the DECRYPT path needs are checked, and only when the run
+    will actually build the real downloader; a caller that injects a fake needs
+    none of them and must not be refused.
+    """
+    modules = DECRYPT_PYTHON_MODULES if modules is None else modules
+    find_spec = importlib.util.find_spec if find_spec is None else find_spec
+    missing = []
+    for mod in modules:
+        try:
+            if find_spec(mod) is None:
+                missing.append(mod)
+        except (ImportError, ValueError):
+            # A parent package that is itself absent raises rather than
+            # returning None. Same conclusion: not importable here.
+            missing.append(mod)
+    if not missing:
+        return
+    raise EscrowError(
+        "DECRYPT-DEPS-MISSING",
+        f"--decrypt-check needs {', '.join(missing)}, which "
+        f"{sys.executable} cannot import. NOTHING HAS BEEN CHECKED and the "
+        f"vault was NOT contacted — this refusal is raised before any `bw` "
+        f"call precisely so a master password is not spent on a run that "
+        f"cannot finish. Re-run under a shell that provides it: "
+        f"{NIX_SHELL_HINT}. (A shell WITHOUT the "
+        f"`python3.withPackages(...)` argument resolves `python3` from the "
+        f"ambient profile, which does not carry these packages.)")
+
+
 def _undo_advice(identity_source: str) -> str:
     """How to re-run against the default, phrased for THIS kind of source.
 
@@ -1394,6 +1451,12 @@ def run(*, bw: BitwardenCLI, identity: Path, item_name: str,
     # the run should end there rather than after unlocking, listing and reading
     # a note it then has nothing to compare against.
     disk = read_identity(identity)
+
+    # 🔴 BEFORE THE VAULT. Only when this run will build the REAL downloader:
+    # an injected factory needs none of these modules, and refusing it would
+    # make the seam untestable without the package installed.
+    if decrypt and downloader_factory is None and from_dir is None:
+        preflight_decrypt_imports()
 
     bw.require_available()
     status = check_vault_state(bw)

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -1291,7 +1291,36 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
 NON_DEFAULT_NOTE = "  <- NOT the default identity"
 
 
-def preflight_decrypt_imports(*, modules: tuple[str, ...] = None,
+def preflight_decrypt_tools(*, which=None) -> None:
+    """Refuse a `--decrypt-check` whose TOOLS are absent — before the vault.
+
+    🔴 `age` is needed by EVERY decrypt path, including `--from-dir` and an
+    injected downloader, so its scope is wider than the `minio` check below.
+    It was already checked — but deep inside `decrypt_check`, i.e. AFTER the
+    vault round-trip. That is the same "right check, wrong moment" shape this
+    module is being repaired for: on the documented workflow the operator has
+    already typed a master password by then.
+
+    🔴 THIS DOES NOT CLOSE THE CLASS. `kubectl`, `git`, a route to the tenant
+    and a readable `--store` can all still fail late, and the advertised
+    nix-shell provisions none of them — they resolve only because `nix-shell
+    -p` is impure. `age` is fixed here because it is the one precondition
+    testable with a single PATH lookup and no network.
+    """
+    which = shutil.which if which is None else which
+    if which("age") is not None:
+        return
+    raise EscrowError(
+        "AGE-MISSING",
+        "`age` is not on PATH, so the escrowed key cannot be tested against "
+        "anything. NOTHING HAS BEEN CHECKED and the vault was NOT contacted — "
+        "this refusal is raised before any `bw` call. It is an ENVIRONMENT "
+        "fault and says NOTHING about the escrow: do not read it as a verdict "
+        "on the key or on the artifacts. age is declared in "
+        "nix/pkgs/default.nix and in flake.nix `gateTools`.")
+
+
+def preflight_decrypt_imports(*, modules: tuple[str, ...] | None = None,
                               find_spec=None) -> None:
     """Refuse a `--decrypt-check` the interpreter CANNOT complete — BEFORE the
     vault is touched.
@@ -1450,13 +1479,22 @@ def run(*, bw: BitwardenCLI, identity: Path, item_name: str,
     # an absent or empty on-disk identity makes the comparison meaningless — so
     # the run should end there rather than after unlocking, listing and reading
     # a note it then has nothing to compare against.
-    disk = read_identity(identity)
+    # 🔴 FIRST, BEFORE EVEN THE LOCAL IDENTITY READ. Two orderings are pinned
+    # here as decisions, both by tests:
+    #   * ahead of `read_identity`, because IDENTITY-MISSING's remedy (point
+    #     ASIB_AGE_IDENTITY / SOPS_AGE_KEY_FILE somewhere real) is DISJOINT
+    #     from the shell fix, so reporting it first buys the operator a second
+    #     trip — the exact thing this preflight exists to prevent;
+    #   * ahead of `require_available`, because DECRYPT-DEPS-MISSING's remedy
+    #     is one nix-shell that provides `bw` too.
+    # Tools are checked before modules: `age` is needed by every decrypt path,
+    # `minio` only by the one that reaches the real bucket.
+    if decrypt:
+        preflight_decrypt_tools()
+        if downloader_factory is None and from_dir is None:
+            preflight_decrypt_imports()
 
-    # 🔴 BEFORE THE VAULT. Only when this run will build the REAL downloader:
-    # an injected factory needs none of these modules, and refusing it would
-    # make the seam untestable without the package installed.
-    if decrypt and downloader_factory is None and from_dir is None:
-        preflight_decrypt_imports()
+    disk = read_identity(identity)
 
     bw.require_available()
     status = check_vault_state(bw)
@@ -1709,6 +1747,15 @@ def main(argv: list[str] | None = None) -> int:
         if not args.decrypt:
             verdict = _go(None)
         elif args.work_dir is not None:
+            # 🔴 PREFLIGHT BEFORE THE DIRECTORY IS TOUCHED. `_private_dir`
+            # creates the whole parent chain and chmods an EXISTING directory
+            # to 0700; doing that and then refusing left a filesystem change
+            # behind a message that says nothing happened. The refusal must be
+            # the first thing that acts, not merely the first thing reported.
+            if args.decrypt:
+                preflight_decrypt_tools()
+                if args.from_dir is None:
+                    preflight_decrypt_imports()
             verdict = _go(B._private_dir(args.work_dir))
         else:
             with tempfile.TemporaryDirectory(prefix="asi-escrow-verify.") as td:

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -1410,13 +1410,46 @@ def test_age_ABSENT_is_an_ENVIRONMENT_fault_not_a_verdict_on_the_escrow(
     assert ei.value.exit_code == 29
     # The owned sentence, WHOLE — a substring here would pass on a reworded
     # message that had stopped saying the thing that matters.
+    #
+    # 🔴 THIS IS NOW THE *PREFLIGHT* SENTENCE, and the difference is the point:
+    # the check moved ahead of the vault, so it can truthfully add that nothing
+    # was checked and no `bw` call was made. The LATE site keeps its own
+    # wording — see the test below — because "the vault was NOT contacted"
+    # would be FALSE there, and one shared string would make one of the two
+    # sites lie.
     assert ei.value.verdict == (
         "`age` is not on PATH, so the escrowed key cannot be tested against "
-        "anything. This is an ENVIRONMENT fault and says NOTHING about the "
-        "escrow — do not read it as a verdict on the key or on the artifacts. "
-        "age is declared in nix/pkgs/default.nix and in flake.nix `gateTools`; "
-        "add it there, or run this whole command under nix.")
+        "anything. NOTHING HAS BEEN CHECKED and the vault was NOT contacted — "
+        "this refusal is raised before any `bw` call. It is an ENVIRONMENT "
+        "fault and says NOTHING about the escrow: do not read it as a verdict "
+        "on the key or on the artifacts. age is declared in "
+        "nix/pkgs/default.nix and in flake.nix `gateTools`.")
     assert ei.value.detail is None
+
+
+def test_the_LATE_age_check_is_still_REACHABLE_and_says_something_TRUE(
+        escrow_world, monkeypatch):
+    """🔴 A LAYER NOBODY CAN OBSERVE FAILING IS A LAYER NOBODY KNOWS IS GONE.
+
+    Hoisting the `age` check into the preflight makes the original one
+    unreachable through `run()` — so it is exercised HERE, by driving
+    `decrypt_check` directly, which is also the real path if `age` vanishes
+    between the preflight and the decrypt. Its wording must stay its own: it
+    runs after the vault, so it must NOT claim the vault was not contacted.
+    """
+    monkeypatch.setattr(EV.shutil, "which",
+                        lambda name: None if name == "age" else "/usr/bin/" + name)
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.decrypt_check(escrow_bytes=escrow_world["note"].encode(),
+                         work_dir=escrow_world["work"], bucket="b",
+                         prefix=PREFIX, store=escrow_world["store"],
+                         scope_filter=None, from_dir=None, now=NOW,
+                         downloader_factory=lambda: FakeDownloader(
+                             escrow_world["objects"]))
+    assert ei.value.token == "AGE-MISSING"
+    assert "vault was NOT contacted" not in ei.value.verdict, (
+        "the late check copied the preflight's sentence, which is false there")
+    assert "ENVIRONMENT fault" in ei.value.verdict
 
 
 def test_the_age_precondition_runs_BEFORE_the_store_is_opened(escrow_world,
@@ -3120,3 +3153,186 @@ def test_a_missing_bw_STILL_reports_itself_when_the_deps_are_fine(escrow_world):
                decrypt=True, prefix=PREFIX, store=escrow_world["store"],
                work_dir=escrow_world["work"], now=NOW)
     assert ei.value.token == "BW-MISSING"
+
+
+# --------------------------------------------------------------------------- #
+# 16b. findings from the #851 audit — each one a guard that was NOT there
+# --------------------------------------------------------------------------- #
+def test_the_preflight_refusal_is_pinned_as_a_WHOLE_STRING():
+    """🔴 THE CLAUSE THAT MATTERS MOST WAS THE ONE NOT ASSERTED.
+
+    The first version asserted three substrings and never touched
+    "the vault was NOT contacted" — so flipping it to "the vault WAS
+    contacted", a straight falsehood about whether the operator's credential
+    had been used, left the entire suite green. This module's own section
+    header says a substring cannot tell a true message from a confident wrong
+    one; that standard applies here more than anywhere.
+    """
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.preflight_decrypt_imports(modules=("definitely_not_installed_xyz",))
+    assert ei.value.verdict == (
+        f"--decrypt-check needs definitely_not_installed_xyz, which "
+        f"{sys.executable} cannot import. NOTHING HAS BEEN CHECKED and the "
+        f"vault was NOT contacted — this refusal is raised before any `bw` "
+        f"call precisely so a master password is not spent on a run that "
+        f"cannot finish. Re-run under a shell that provides it: "
+        f"{EV.NIX_SHELL_HINT}. (A shell WITHOUT the "
+        f"`python3.withPackages(...)` argument resolves `python3` from the "
+        f"ambient profile, which does not carry these packages.)")
+
+
+def test_EVERY_module_in_the_ledger_is_checked_not_just_the_first():
+    """🔴 A ONE-TUPLE FIXTURE CANNOT SEE `modules[:1]`.
+
+    Every fixture here — and the real ledger — had exactly one entry, so a
+    mutant that checks only the first module survived, and the multi-module
+    `', '.join(missing)` rendering was never exercised. A two-element fixture
+    whose FIRST entry resolves is the control that can see it.
+    """
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.preflight_decrypt_imports(modules=("os", "definitely_not_installed_xyz"))
+    assert "definitely_not_installed_xyz" in ei.value.verdict
+    # both missing -> both named, comma-joined
+    with pytest.raises(EV.EscrowError) as ei2:
+        EV.preflight_decrypt_imports(modules=("no_such_a_xyz", "no_such_b_xyz"))
+    assert "no_such_a_xyz, no_such_b_xyz" in ei2.value.verdict
+
+
+def test_a_find_spec_raising_ValueError_is_treated_as_missing():
+    """The `ValueError` arm of the except tuple was untested — dropping it
+    survived, while dropping `ImportError` was caught. Both arms now observable."""
+    def boom(_mod):
+        raise ValueError("simulated embedded null")
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.preflight_decrypt_imports(modules=("anything",), find_spec=boom)
+    assert ei.value.token == "DECRYPT-DEPS-MISSING"
+
+
+def test_FROM_DIR_is_never_refused_for_a_missing_bucket_package(escrow_world,
+                                                                 monkeypatch,
+                                                                 tmp_path):
+    """🔴 THE NEGATIVE CONTROL THE `from_dir` ARM LACKED.
+
+    Deleting `and from_dir is None` from the scope condition survived the whole
+    suite, because every `--from-dir` test ran with the real ledger and `minio`
+    present. `--from-dir` is the ONLY decrypt path exercisable without a
+    cluster — so it is exactly the one most likely to be run from a shell with
+    no `minio`, and wrongly refusing it with rc 34 would be a permanently-red
+    gate on the cheap path.
+    """
+    monkeypatch.setattr(EV, "DECRYPT_PYTHON_MODULES",
+                        ("definitely_not_installed_xyz",))
+    root = tmp_path / "fetched"
+    for k, blob in escrow_world["objects"].items():
+        obj = root / k
+        obj.parent.mkdir(parents=True, exist_ok=True)
+        obj.write_bytes(blob)
+    v = EV.run(bw=_cli(FakeBw(items=[_item(notes=escrow_world["note"])])),
+               identity=escrow_world["identity"], item_name=ITEM, decrypt=True,
+               bucket=str(root), prefix=PREFIX, store=escrow_world["store"],
+               from_dir=root, work_dir=escrow_world["work"], now=NOW)
+    assert v.decrypt_checked is True
+
+
+def test_the_preflight_OUTRANKS_a_missing_identity(escrow_world, monkeypatch,
+                                                   tmp_path):
+    """🔴 A SECOND ORDERING PINNED AS A DECISION.
+
+    With no `minio` AND an unreadable identity, DECRYPT-DEPS-MISSING must win.
+    IDENTITY-MISSING's remedy (point ASIB_AGE_IDENTITY / SOPS_AGE_KEY_FILE at a
+    real file) is DISJOINT from the shell fix, so reporting it first buys the
+    operator a second trip — the exact thing this preflight exists to prevent.
+    Moving the preflight below `read_identity` is otherwise invisible.
+    """
+    monkeypatch.setattr(EV, "DECRYPT_PYTHON_MODULES",
+                        ("definitely_not_installed_xyz",))
+    fake = FakeBw(items=[_item(notes=escrow_world["note"])])
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=_cli(fake), identity=tmp_path / "does-not-exist.key",
+               item_name=ITEM, decrypt=True, prefix=PREFIX,
+               store=escrow_world["store"], work_dir=escrow_world["work"],
+               now=NOW)
+    assert ei.value.token == "DECRYPT-DEPS-MISSING", (
+        "IDENTITY-MISSING won: the preflight no longer runs before read_identity")
+    assert fake.calls == []
+
+
+def test_a_missing_identity_STILL_reports_itself_when_the_deps_are_fine(
+        escrow_world, tmp_path):
+    """Negative control for the ordering above — the preflight must OUTRANK
+    IDENTITY-MISSING, not MASK it."""
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=_cli(FakeBw(items=[_item(notes=escrow_world["note"])])),
+               identity=tmp_path / "does-not-exist.key", item_name=ITEM,
+               decrypt=True, prefix=PREFIX, store=escrow_world["store"],
+               work_dir=escrow_world["work"], now=NOW)
+    assert ei.value.token == "IDENTITY-MISSING"
+
+
+def test_SECRETS_md_exit_codes_agree_with_the_module():
+    """🔴 THE TABLE A HUMAN READS UNDER PRESSURE, BOUND TO THE CODE.
+
+    `--print-plan` renders `EXIT_CODES` dynamically and is covered — but
+    SECRETS.md's `--decrypt-check` table is hand-written, and nothing tied the
+    two together. It silently went stale the moment code 34 was added: the doc
+    still said "eight outcomes" and omitted the one an operator is now most
+    likely to hit.
+
+    Scope, stated so this is not read as more than it is: this pins every
+    (code, token) pair the doc DOES list against the module, and requires the
+    preflight code to appear. It cannot know which subset of codes the doc
+    *ought* to list, so a future code omitted entirely is still invisible here.
+    """
+    import re
+    doc = (ROOT / "SECRETS.md").read_text(encoding="utf-8")
+    pairs = re.findall(r"\|\s*`(\d+)`\s*`([A-Z][A-Z-]+)`\s*\|", doc)
+    assert pairs, "no exit-code rows found — the table moved or changed shape"
+    for code, token in pairs:
+        assert token in EV.EXIT_CODES, (
+            f"SECRETS.md documents {token!r}, which the module does not define")
+        assert EV.EXIT_CODES[token] == int(code), (
+            f"SECRETS.md says {token}={code}, module says "
+            f"{EV.EXIT_CODES[token]}")
+    documented = {t for _, t in pairs}
+    assert "DECRYPT-DEPS-MISSING" in documented, (
+        "the preflight's code is undocumented — it is the one an operator in "
+        "the wrong shell will actually hit")
+
+
+def test_a_REFUSED_run_leaves_no_work_dir_behind(monkeypatch, tmp_path):
+    """🔴 THE REFUSAL MUST BE THE FIRST THING THAT ACTS, not merely the first
+    thing reported.
+
+    `main()` built the work dir before calling `run()`, so a refusal that says
+    "NOTHING HAS BEEN CHECKED" had already created the whole parent chain —
+    and, on a pre-existing directory, chmodded it to 0700. The message stayed
+    literally true (nothing was *checked*), which is exactly why this needed a
+    test rather than a reading: removing the fix leaves the suite green.
+    """
+    monkeypatch.setattr(EV, "DECRYPT_PYTHON_MODULES",
+                        ("definitely_not_installed_xyz",))
+    work = tmp_path / "deep" / "nested" / "work"
+    rc = EV.main(["--decrypt-check", "--work-dir", str(work),
+                  "--identity", str(tmp_path / "any.key"),
+                  "--host", "synthetic-host"])
+    assert rc == EV.EXIT_CODES["DECRYPT-DEPS-MISSING"]
+    assert not work.exists(), "the work dir was created before the refusal"
+    assert not work.parent.exists(), "the parent chain was created too"
+
+
+def test_a_REFUSED_run_does_not_CHMOD_an_existing_dir(monkeypatch, tmp_path):
+    """The second half of the same fix, and the one with a real blast radius:
+    `_private_dir` chmods an EXISTING directory to 0700. Refusing afterwards
+    left an operator-supplied directory's mode silently changed."""
+    monkeypatch.setattr(EV, "DECRYPT_PYTHON_MODULES",
+                        ("definitely_not_installed_xyz",))
+    work = tmp_path / "mine"
+    work.mkdir(mode=0o755)
+    work.chmod(0o755)
+    before = stat.S_IMODE(work.stat().st_mode)
+    rc = EV.main(["--decrypt-check", "--work-dir", str(work),
+                  "--identity", str(tmp_path / "any.key"),
+                  "--host", "synthetic-host"])
+    assert rc == EV.EXIT_CODES["DECRYPT-DEPS-MISSING"]
+    assert stat.S_IMODE(work.stat().st_mode) == before, (
+        "the refused run changed the mode of a directory it did not create")

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -308,6 +308,9 @@ def test_the_exit_code_table_is_pinned_EXACTLY_both_ways():
         "ARTIFACT-EMPTY": 31,
         "NOTE-MISSING": 32,
         "ARTIFACT-CORRUPT": 33,
+        # raised BEFORE any `bw` call — the interpreter cannot finish the run,
+        # so no master password is spent on one that was never going to
+        "DECRYPT-DEPS-MISSING": 34,
     }
 
 
@@ -2974,3 +2977,146 @@ def test_the_undo_advice_matches_the_KIND_of_source():
         advice = EV._undo_advice(src)
         assert "env -u" not in advice, advice
         assert str(B.DEFAULT_IDENTITY) in advice
+
+
+# --------------------------------------------------------------------------- #
+# 16. 🔴 --decrypt-check REFUSES BEFORE THE VAULT WHEN IT CANNOT FINISH
+#
+# Measured twice on 2026-08-25, the second time AFTER the hint was fixed:
+# `--decrypt-check` unlocked the vault and then died on a missing `minio`,
+# i.e. after the master password had been typed. Fixing WHICH shell is
+# advertised did not fix WHEN the run discovers it is in the wrong one.
+# --------------------------------------------------------------------------- #
+def test_the_preflight_token_and_code_are_pinned():
+    assert EV.EXIT_CODES["DECRYPT-DEPS-MISSING"] == 34
+    # distinct from every other code, or the operator is sent to the wrong place
+    codes = list(EV.EXIT_CODES.values())
+    assert len(codes) == len(set(codes))
+
+
+def test_the_preflight_PASSES_when_every_module_resolves():
+    """The positive control. Without it a preflight wired to nothing — or one
+    that always raised — would be indistinguishable from a working one."""
+    EV.preflight_decrypt_imports(modules=("os", "sys"))
+    # and the real ledger resolves in this environment too
+    EV.preflight_decrypt_imports()
+
+
+def test_the_preflight_NAMES_the_module_the_interpreter_and_the_shell():
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.preflight_decrypt_imports(modules=("definitely_not_installed_xyz",))
+    assert ei.value.token == "DECRYPT-DEPS-MISSING"
+    assert ei.value.exit_code == 34
+    msg = ei.value.verdict
+    assert "definitely_not_installed_xyz" in msg
+    # 🔴 WHICH interpreter — the whole confusion was not knowing which python ran
+    assert sys.executable in msg
+    # ...and the shell that would work, rendered from the ledger
+    assert EV.NIX_SHELL_HINT in msg
+    # ...and that nothing was checked, so this is not read as a verdict
+    assert "NOTHING HAS BEEN CHECKED" in msg
+
+
+def test_a_module_whose_PARENT_is_absent_counts_as_missing():
+    """`find_spec` RAISES rather than returning None when a parent package is
+    itself absent. Treating that as 'present' would let the run proceed to the
+    exact failure the preflight exists to prevent."""
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.preflight_decrypt_imports(modules=("no_such_parent_pkg.child",))
+    assert ei.value.token == "DECRYPT-DEPS-MISSING"
+
+
+def test_a_find_spec_that_RAISES_ImportError_is_treated_as_missing():
+    def boom(_mod):
+        raise ImportError("simulated")
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.preflight_decrypt_imports(modules=("anything",), find_spec=boom)
+    assert ei.value.token == "DECRYPT-DEPS-MISSING"
+
+
+def test_the_refusal_happens_BEFORE_A_SINGLE_bw_CALL(escrow_world, monkeypatch):
+    """🔴 THE POINT OF THE WHOLE CHANGE, asserted as a COUNT.
+
+    A message that merely mentions the vault was not contacted is a claim; the
+    fake `bw` recording ZERO invocations is the evidence. If this ever regresses
+    the operator spends a master password on a run that cannot finish.
+    """
+    monkeypatch.setattr(EV, "DECRYPT_PYTHON_MODULES",
+                        ("definitely_not_installed_xyz",))
+    fake = FakeBw(items=[_item(notes=escrow_world["note"])])
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=_cli(fake), identity=escrow_world["identity"], item_name=ITEM,
+               decrypt=True, prefix=PREFIX, store=escrow_world["store"],
+               work_dir=escrow_world["work"], now=NOW)
+    assert ei.value.token == "DECRYPT-DEPS-MISSING"
+    assert fake.calls == [], (
+        f"the vault was contacted before the preflight refused: {fake.calls}")
+
+
+def test_an_INJECTED_downloader_is_never_refused(escrow_world, monkeypatch):
+    """The negative control for the guard's SCOPE. A caller supplying a fake
+    needs none of these modules; refusing it would make the seam untestable
+    wherever the package is absent, which is its own failure mode."""
+    monkeypatch.setattr(EV, "DECRYPT_PYTHON_MODULES",
+                        ("definitely_not_installed_xyz",))
+    d = FakeDownloader(escrow_world["objects"])
+    v = EV.run(bw=_cli(FakeBw(items=[_item(notes=escrow_world["note"])])),
+               identity=escrow_world["identity"], item_name=ITEM, decrypt=True,
+               prefix=PREFIX, store=escrow_world["store"],
+               work_dir=escrow_world["work"], now=NOW,
+               downloader_factory=lambda: d)
+    assert v.decrypt_checked is True
+
+
+def test_a_run_WITHOUT_decrypt_check_is_never_refused(escrow_world, monkeypatch):
+    """A byte-comparison run reaches no bucket, so the modules are irrelevant.
+    Refusing it would be a permanently-red gate on the cheap check."""
+    monkeypatch.setattr(EV, "DECRYPT_PYTHON_MODULES",
+                        ("definitely_not_installed_xyz",))
+    v = EV.run(bw=_cli(FakeBw(items=[_item(notes=escrow_world["note"])])),
+               identity=escrow_world["identity"], item_name=ITEM,
+               store=escrow_world["store"], now=NOW)
+    assert v.decrypt_checked is False
+
+
+def test_the_preflight_OUTRANKS_a_missing_bw(escrow_world, monkeypatch):
+    """🔴 A DELIBERATE ORDERING, pinned — not an accident of line order.
+
+    Both can be wrong at once: no `bw` on PATH AND an interpreter without the
+    decrypt deps. The deps refusal is the more useful of the two, because its
+    remedy is ONE nix-shell that provides `bw` as well. Reporting BW-MISSING
+    first sends the operator to solve half the problem and hit the other half
+    on the next run — the second trip being exactly what this change exists to
+    prevent.
+
+    Without this test, moving the preflight below `require_available()` is an
+    invisible change: that method is a PATH lookup with no subprocess, so the
+    zero-bw-calls guard cannot see the swap.
+    """
+    monkeypatch.setattr(EV, "DECRYPT_PYTHON_MODULES",
+                        ("definitely_not_installed_xyz",))
+    fake = FakeBw(items=[_item(notes=escrow_world["note"])])
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=_cli(fake, locator=lambda name: None),
+               identity=escrow_world["identity"], item_name=ITEM,
+               decrypt=True, prefix=PREFIX, store=escrow_world["store"],
+               work_dir=escrow_world["work"], now=NOW)
+    assert ei.value.token == "DECRYPT-DEPS-MISSING", (
+        "BW-MISSING won: the preflight no longer runs before require_available")
+    assert fake.calls == []
+    # and the remedy it prints must cover BOTH faults, or the ordering is wrong
+    assert "bitwarden-cli" in ei.value.verdict
+    assert "p.minio" in ei.value.verdict
+
+
+def test_a_missing_bw_STILL_reports_itself_when_the_deps_are_fine(escrow_world):
+    """The negative control for the ordering above: with the deps present, a
+    missing `bw` must still produce BW-MISSING. Otherwise the preflight could
+    be masking that failure rather than outranking it."""
+    fake = FakeBw(items=[_item(notes=escrow_world["note"])])
+    with pytest.raises(EV.EscrowError) as ei:
+        EV.run(bw=_cli(fake, locator=lambda name: None),
+               identity=escrow_world["identity"], item_name=ITEM,
+               decrypt=True, prefix=PREFIX, store=escrow_world["store"],
+               work_dir=escrow_world["work"], now=NOW)
+    assert ei.value.token == "BW-MISSING"


### PR DESCRIPTION
Follow-up to #822, from the same failure happening a second time — and then a third and a fourth.

> ✅ **The escrow is now VERIFIED.** Using the wrapper this PR adds: `rc=0`, byte-`IDENTICAL` (189 vs 189, identity pinned), and `DECRYPT-CHECKED` — the bytes read back **out of the vault** decrypted that morning's timer-produced artifact and restored 40 commits over 1 ref. That also settled two assumptions never measured against the real vault item: the note is `type == 2` and `notes` is present in `bw list items`, since a wrong guess on either exits 19 or 20 long before the decrypt. Disk loss no longer takes the key with the store, and that is measured rather than assumed.

## What #822 fixed, and what it left

#822 corrected **which shell** `escrow-verify.py` advertises, so `--decrypt-check` would stop dying on a missing `minio`. It did not change **when** the run discovers it is in the wrong shell. So a run from any shell lacking the package still did this:

1. the operator's own `bw unlock` consumes the **master password** — this script never prompts; every `bw` call runs with stdin on `/dev/null`
2. escrow-verify unlocks the vault, fetches the note, compares bytes
3. reaches MinIO
4. dies

> ⚠️ **Corrected after audit.** An earlier version of this body said step 1 was the *script* prompting for the password. It does not and cannot — which turns out to matter, because the spend happens in the **preceding command**, and that is where the real fix had to go (see "Where the password is actually spent" below).

The worst property of the original defect — *the password is spent on a run that was never going to finish* — survived the fix, four adversarial audit rounds, and both gate tiers. Every round asked whether the hint was **correct**; none asked whether the failure still came **too late**.

## What the operator actually saw

```
minio is required. On NixOS run under:
  nix-shell -p "python3.withPackages(p:[p.minio p.psycopg2 p.requests])" --run 'python scripts/mail-actions/extract.py archive-invoices ...'
```

That is `scripts/mail-actions/_minio.py`'s own import guard. It names a **different program** and a **different package set**, and never says which interpreter came up short. The message is not wrong — it is accurate for `extract.py`, its original caller. It only became misleading when a second program started reaching it. **The shim is unchanged here**; escrow-verify simply no longer gets there.

## The fix

`preflight_decrypt_imports()` runs **before any `bw` call** and exits `34 DECRYPT-DEPS-MISSING`:

```
DECRYPT-DEPS-MISSING: --decrypt-check needs minio, which /home/…/.nix-profile/bin/python3
cannot import. NOTHING HAS BEEN CHECKED and the vault was NOT contacted — this refusal is
raised before any `bw` call precisely so a master password is not spent on a run that
cannot finish. Re-run under a shell that provides it: nix-shell -p bitwarden-cli jq
'python3.withPackages(p:[p.minio])' --run '<command>'. (A shell WITHOUT the
`python3.withPackages(...)` argument resolves `python3` from the ambient profile, which
does not carry these packages.)
```

It uses `find_spec` rather than a real import, because importing `_minio` **is** the confusing `SystemExit` above.

Measured, and it discriminates:

| shell | result |
|---|---|
| without `withPackages` | `rc=34` in **1s**, vault not contacted |
| with it | gets **past** the preflight to `rc=12 VAULT-LOCKED` |

Which matters, because only one shape resolves an interpreter that has the package:

| shell | `python3` |
|---|---|
| bare | ambient profile — **no `minio`** |
| `-p bitwarden-cli jq` | ambient profile — **no `minio`** |
| `+ 'python3.withPackages(p:[p.minio])'` | store env — has it |

## Scope, deliberately narrow

Skipped when a downloader is injected or `--from-dir` is used (neither reaches a bucket), and for any run without `--decrypt-check`. Otherwise the cheap byte-comparison check becomes a permanently-red gate wherever the package is absent — which is its own failure mode.

## 🔴 One ordering pinned as a decision

With **both** `bw` and `minio` missing, `DECRYPT-DEPS-MISSING` wins over `BW-MISSING`. Its remedy is one `nix-shell` that provides `bw` too; the reverse order sends the operator to fix half the problem and hit the other half on the next run — a second trip being exactly what this change exists to prevent.

That needed its own test. `require_available()` is a PATH lookup with **no subprocess**, so the zero-`bw`-calls guard could not see the swap: moving the preflight below it **survived the entire suite** until `test_the_preflight_OUTRANKS_a_missing_bw` was added. It came out of the mutation sweep as an apparent survivor that turned out to be equivalent — and chasing it surfaced a question nobody had decided.

## Verification

Mutation sweep — whole-repo sandbox, `__pycache__` excluded (a copy with valid `.pyc` executes the *original* tree's bytecode, and `PYTHONDONTWRITEBYTECODE=1` does not prevent that — it stops writing, not reading), every mutation asserting it applied exactly once:

```
BASELINE-unmutated                                GREEN            462 passed
preflight-REMOVED-entirely                        KILLED
preflight-runs-AFTER-the-vault-calls              KILLED
preflight-fires-even-with-an-INJECTED-downloader  KILLED
find_spec-exception-NOT-caught                    KILLED
missing-module-reported-as-PRESENT                KILLED
interpreter-NOT-named-in-the-message              KILLED
CONTROL-noop-comment                              SURVIVED   <- harness discriminates
```

Both gate tiers on `d815e899`, read from output rather than exit codes:

| tier | pytest | node |
|---|---|---|
| dev host — `scripts/gate.sh --tier both --set all` | 16,562 / 0 (floor 15,789) | 1,292 / 0 |
| nix sandbox — `nix build .#checks.x86_64-linux.{pytests,nodetests}` | 16,562 / 0 | 1,292 / 0 |

## Where the password is actually spent — the audit's finding

The first revision of this PR put the refusal early **inside the program** and left it too late **in the workflow**. `SECRETS.md` published this order:

```sh
nix-shell -p bitwarden-cli jq --run '
  export BW_SESSION="$(bw unlock --raw)"   # ← password typed HERE
  python3 …/escrow-verify.py
'
… escrow-verify.py --decrypt-check --host <host label>
```

The password is spent one line **before** escrow-verify is invoked, so no preflight inside it can prevent the spend — and that snippet is the shell **without** `python3.withPackages(p:[p.minio])`, so following the docs verbatim now yielded `rc=34` *after* the password. The headline claim was a promise the code could not keep on the documented path.

Fixed where it lives: the recipe now runs a **locked dry pass first** (exits `12`, or `34` if the shell is wrong — nothing spent either way), *then* unlocks, then runs for real; and its shell carries the package. Its outcome table gains code 34 and is now **bound to `EV.EXIT_CODES` by a test** — nothing tied them together, which is how it went stale the moment 34 existed.

Also from that audit, each now killing its mutant:

| finding | why it mattered |
|---|---|
| the refusal was pinned by **substrings** | flipping `vault was NOT contacted` → `vault WAS contacted`, a falsehood about whether the credential had been used, left all 462 green |
| `--from-dir` had no negative control | deleting its arm from the scope condition survived — and it is the only decrypt path runnable without a cluster, so wrongly refusing it would be a permanently-red gate |
| every fixture was a **1-tuple** | `modules[:1]` survived; the multi-module rendering was never exercised |
| `main()` built the work dir **before** refusing | created the parent chain and chmodded an existing dir `0755→0700`, then said nothing had happened — literally true, which is why it needed a test |
| ordering vs `IDENTITY-MISSING` | its remedy is disjoint from the shell fix, so reporting it first buys a second trip. Pinned, with a control proving the preflight **outranks** rather than **masks** it |
| `age` verified after the vault | now preflighted too — it is needed by *every* decrypt path. The late check stays, reachable and separately tested, keeping its own wording, since "the vault was NOT contacted" is false there |

## 🔴 What this does NOT close

`kubectl`, `git`, reachability to the MinIO tenant and `--store` readability can **all still fail after the vault**, and the advertised shell provisions none of them — they resolve only because `nix-shell -p` is impure. Under `--pure` or on a fresh host, an operator following the rc-34 remedy gets past the preflight and dies at `AGE-MISSING`-class faults later. `age` was fixed because it is one PATH lookup with no network; the rest is real design work and is not attempted here.

## 🔴 The one-liner is retired — it failed three times, each costing a password

Getting to that `rc=0` took three attempts, and **every failure was quoting, not the task**:

| attempt | symptom | what was lost |
|---|---|---|
| 1 | `ModuleNotFoundError: minio` | the `python3.withPackages(...)` argument |
| 2 | dropped into a **Python REPL** | the script-path token |
| 3 | `--identity: expected one argument` | the identity-path token |

Responding to each by rewriting the one-liner was the wrong move: the same class of failure three times is a signal about the **form**, not the contents. A ~300-character line carrying a nix expression, a `--run` string and three nested command substitutions is not something to hand a person to paste.

So `scripts/analyze-service-index/check-escrow.sh` holds the quoting once, in a reviewable file:

```sh
check-escrow.sh          # locked dry pass, then unlock, then the real run
check-escrow.sh --plan   # no bw, no network, no key
```

**It runs a LOCKED DRY PASS FIRST** — proving the shell, interpreter, argv and host label for the cost of a second, and spending nothing, because `escrow-verify.py` never prompts. Only once that returns `12 VAULT-LOCKED` (the expected outcome) is the password requested; any other exit stops **before** asking, because a password will not fix it. That is this PR's finding applied at the layer where the spend actually happens.

### A real bug the first successful run surfaced

🔴 **`bw unlock --raw` can exit ZERO having printed NOTHING** — no TTY, EOF, or a cancelled prompt. So `&&` alone let a doomed run through: the empty session exported fine, and the verifier then reported `VAULT-LOCKED`, which reads as *a vault problem* rather than *an unlock that never happened*. Two different faults, one message. The emptiness is now checked and named.

## Still out of scope

Whether the escrowed note matches the real `age.key` remains **unconfirmed** — it needs the master password. What changes here is that attempting it from the wrong shell now costs a second instead of a password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
