### PR TITLE
fix(gate): a random tmpdir in a parametrize ID took the pytest tier red — pin the ID, keep the path random

### DIFF
--- a/scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py
+++ b/scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py
@@ -160,6 +160,35 @@ def scratch(name):
     return os.path.join(SCRATCH, name)
 
 
+def stable_id(cmd):
+    """A parametrize id for `cmd` with the per-run scratch path REDACTED.
+
+    🔴 A PARAMETRIZE ID MUST NOT CARRY `SCRATCH`, OR THE WHOLE GATE STOPS —
+    and it is the id, not the test, that breaks. pytest derives an id from the
+    parameter VALUE, so a command string holding this module's `mkdtemp` path
+    puts that random path in the id. Every xdist worker imports this module
+    fresh and gets a DIFFERENT `SCRATCH`, so the workers collect different ids
+    and xdist aborts the whole run:
+
+        ERROR gw1 - Different tests were collected between gw0 and gw1
+
+    Measured on this file at 200e6383: `-n 4` → 3 errors, 0 tests; serial →
+    474 passed. Since #841 the gate runs every pytest target 4-way, so that is
+    a red gate blocking every open PR in the repo — from a test id, with no
+    test having failed.
+
+    Redaction rather than a fixed path: several cases below depend on the
+    FILESYSTEM path being fresh and per-run (see the `SCRATCH` comment), and a
+    fixed shared name would collide between the concurrent gate runs this box
+    hosts. So the path stays random and only the id is pinned — the id becomes
+    a pure function of the table.
+
+    `test_control_no_parametrize_id_can_carry_the_scratch_path` pins that this
+    is actually applied everywhere it must be.
+    """
+    return cmd.replace(SCRATCH, "<scratch>")
+
+
 # --------------------------------------------------------------------------- #
 # drivers
 # --------------------------------------------------------------------------- #
@@ -653,7 +682,8 @@ UNRELATED_HEREDOC_CASES = [
 ]
 
 
-@pytest.mark.parametrize("tail,mark", UNRELATED_HEREDOC_CASES)
+@pytest.mark.parametrize("tail,mark", UNRELATED_HEREDOC_CASES,
+                         ids=[stable_id(c[0]) for c in UNRELATED_HEREDOC_CASES])
 def test_an_unrelated_heredoc_does_not_satisfy_a_create(tail, mark):
     """🔴 A well-specified heredoc written earlier on the line, for a DIFFERENT
     command, must not answer for a create — whatever the reason the create's own
@@ -1598,12 +1628,14 @@ REALISTIC_ALLOWS = [
 ]
 
 
-@pytest.mark.parametrize("cmd", REALISTIC_ALLOWS)
+@pytest.mark.parametrize("cmd", REALISTIC_ALLOWS,
+                         ids=[stable_id(c) for c in REALISTIC_ALLOWS])
 def test_a_realistic_correct_call_is_allowed(cmd):
     assert ev(cmd) is None, cmd
 
 
-@pytest.mark.parametrize("cmd", REALISTIC_ALLOWS[:12])
+@pytest.mark.parametrize("cmd", REALISTIC_ALLOWS[:12],
+                         ids=[stable_id(c) for c in REALISTIC_ALLOWS[:12]])
 def test_a_realistic_correct_call_is_allowed_through_the_real_process(cmd):
     assert_allowed(cmd)
 
@@ -1835,6 +1867,90 @@ def test_control_the_specified_fixtures_carry_REAL_newlines():
     assert SCRATCH.startswith(tempfile.gettempdir())
     assert os.path.basename(SCRATCH).startswith("ghccg-test-")
     assert len(os.path.basename(SCRATCH)) > len("ghccg-test-")
+
+
+def _collect_ids_in_a_fresh_process(tmpdir):
+    """This file's collected node ids, from a SEPARATE process with its OWN
+    TMPDIR — i.e. its own `SCRATCH`, exactly like an xdist worker."""
+    os.makedirs(tmpdir, exist_ok=True)
+    e = {k: v for k, v in os.environ.items() if not k.startswith("PYTEST_")}
+    e["TMPDIR"] = str(tmpdir)
+    e["PYTHONDONTWRITEBYTECODE"] = "1"
+    p = subprocess.run(
+        [sys.executable, "-m", "pytest", os.path.abspath(__file__),
+         "--collect-only", "-q", "-p", "no:cacheprovider"],
+        capture_output=True, text=True, env=e, cwd=str(ROOT))
+    assert p.returncode == 0, (
+        "the control could not collect this file at all — the assertions below "
+        f"would be vacuous:\n{p.stdout[-2000:]}\n{p.stderr[-2000:]}")
+    return [ln for ln in p.stdout.splitlines() if "::" in ln]
+
+
+def test_control_no_parametrize_id_can_carry_the_scratch_path(tmp_path):
+    """🔴 THE ID IS PART OF THE CONTRACT, AND IT BREAKS THE GATE, NOT THE TEST.
+
+    `SCRATCH` is a fresh `mkdtemp` (deliberately — see its comment), and pytest
+    derives a parametrize id from the parameter VALUE. So any table entry
+    holding a `scratch(...)` path puts a random path in an id. Every xdist
+    worker imports this module fresh and gets a different one, so the workers
+    disagree about WHICH TESTS EXIST and xdist aborts:
+
+        ERROR gw1 - Different tests were collected between gw0 and gw1
+
+    Measured at 200e6383 on this file: `-n 4` → 3 errors, 0 tests collected;
+    serial → 474 passed. The gate has run every pytest target 4-way since #841,
+    so that is a red gate — on both tiers — blocking every open PR, with no
+    test having failed and nothing in the output naming a cause.
+
+    Two real processes with different TMPDIRs, because that is the defect's own
+    definition and the only shape that cannot be satisfied by agreeing with
+    itself: deriving the expectation from this module's own `SCRATCH` would
+    assert only that one process is self-consistent, which it always is.
+
+    NOT fixed by pinning `SCRATCH` to a constant path: several cases here need
+    a directory no leftover file can answer for, and a shared name collides
+    between the concurrent gate runs this box hosts. The id is pinned; the
+    path stays random.
+    """
+    a = _collect_ids_in_a_fresh_process(tmp_path / "tmp-a")
+    b = _collect_ids_in_a_fresh_process(tmp_path / "tmp-b")
+
+    # --- THE CLAIM, FIRST --------------------------------------------------- #
+    # 🔴 ORDER IS LOAD-BEARING, and the first draft of this test had it wrong.
+    # With the coverage controls above the claim, removing an `ids=` DROPS the
+    # redaction count, so the control tripped first and the claim below never
+    # executed — the guard went red for a reason that named neither the
+    # offending table nor xdist. A mutant must be killed by the assertion that
+    # OWNS it. The controls still run; they just cannot pre-empt it, and a
+    # vacuous collection (0 ids, no offenders) still fails on them below.
+    offenders = [i for i in a + b if "ghccg-test-" in i]
+    assert not offenders, (
+        f"{len(offenders)} collected id(s) embed the per-process scratch dir. "
+        "Under xdist every worker gets a different one and the ENTIRE RUN "
+        "aborts with a collection mismatch — every open PR in the repo blocked, "
+        "with no test having failed. Give that parametrize an explicit "
+        "`ids=[stable_id(...) ...]`.\n  " + "\n  ".join(o[:200] for o in offenders[:5]))
+
+    assert a == b, (
+        "two processes collected different node ids, so xdist will abort this "
+        "target with 'Different tests were collected'. Something in a "
+        "parametrize table varies per process (a tmpdir, a pid, a timestamp, a "
+        "uuid). Differing ids:\n  " +
+        "\n  ".join(x[:200] for x in (set(a) ^ set(b)))[:2000])
+
+    # --- COVERAGE CONTROLS, AFTER --------------------------------------------- #
+    # A guard that read an empty id list would report a reassuring zero above.
+    # These say the collection happened AND that it reached the at-risk tables.
+    assert len(a) >= 400, (
+        f"only {len(a)} ids collected — too few for this file; the offender "
+        "search above was scanning almost nothing")
+    redacted = [i for i in a if "<scratch>" in i]
+    assert len(redacted) >= 3, (
+        "fewer than 3 collected ids carry the '<scratch>' redaction token, so "
+        "the offender search above is watching less than it was written for. "
+        "Either `stable_id` stopped being applied to a table that needs it, or "
+        "the tables stopped using `scratch(...)` — check which before relaxing "
+        f"this number. ids carrying the token: {redacted}")
 
 
 # =========================================================================== #


### PR DESCRIPTION
> 🔴 **This blocks every open PR in the repo — it should land before anything else.**
> It is **not a flake.** It is deterministic, and the serial control below proves the code under test was never involved.

## What broke

`scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py` builds its command tables at **module scope**, and those tables need a scratch directory at import time — so `SCRATCH` is a module-scoped `tempfile.mkdtemp()`. That is deliberate ([`:148-156`](https://github.com/innovation-upstream/devrc/blob/200e6383/scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py#L148-L156)): several cases assert a verdict that depends on a body-file path **not existing**, and a hard-coded `/tmp/x.md` makes those a claim about this machine's `/tmp` rather than about the code.

pytest derives a parametrize ID from the **parameter value**. Three table entries hold a `scratch(...)` path, so three IDs carried that random path:

```
…[gh issue create -t t --body-file /build/ghccg-test-mlw98yvv/no-such-file.md-…]
```

**#841** made the gate run each pytest target **4-way under pytest-xdist**. Every worker imports the module fresh, gets a **different** `SCRATCH`, and therefore collects **different test IDs**. xdist treats that as fatal:

```
ERROR gw1 - Different tests were collected between gw0 and gw1
```

Three IDs. No test failed. Both required checks unsatisfiable.

## The fix

`stable_id(cmd)` returns the command with `SCRATCH` replaced by the literal `<scratch>`, and the three at-risk parametrize sites pass explicit `ids=[stable_id(…)]`.

**The filesystem path stays a fresh `mkdtemp` — only the ID is pinned.** The ID becomes a pure function of the table; the directory stays per-run.

Rejected, and why:

| alternative | why not |
|---|---|
| a fixed shared `SCRATCH` path | collides between the concurrent gate runs this box hosts, and re-opens the leftover-file hazard the `mkdtemp` exists to close |
| disabling xdist for this target / `-p no:randomly`-style suppression | silently gives back #841's ~2x win |
| keep tables path-free, substitute in the test body | touches ~5 call sites and moves fixture construction out of the tables the module docstring pins as literal — more change, same result |

This is also the pattern **the file already used**: `SAME_LINE_HEREDOC_CASES` has carried explicit `ids=` since it was written.

## Regression evidence — the matrix

Same file, same command, two refs:

| | `-n 4` | serial |
|---|---|---|
| **`origin/main`** (`200e6383`) | 🔴 **3 errors, 0 tests run** | ✅ 474 passed |
| **HEAD** (`82a155f0`) | ✅ **475 passed** | ✅ 475 passed |

The serial column is the control: it is green at both refs, so the failure is the ID, not the guard under test.

## Repo-wide sweep — **1 instance**, and that is measured

xdist landed recently, so any test whose parametrize IDs embed a per-process value (a tmpdir, a pid, a timestamp, a `uuid4`, a hostname) has the same latent defect and fires the moment that target is touched. Two independent sweeps, both across **all 28 hermetic targets**:

**Static** — 121 files use `parametrize`; **1** evaluates a nondeterministic expression at module scope (this one). The only other grep hit is a comment containing the word "uuid".

**Empirical** — collect each target twice in **separate processes** and diff the sorted ID sets. This catches shapes a grep cannot. Then a second, higher-sensitivity pass under a **different `TMPDIR`**, a **different `HOSTNAME`** and a **>2s clock gap**, so a second-resolution timestamp or a `$TMPDIR`-derived path would also show.

Both passes flagged **exactly this file and nothing else**, across **15,024 collected IDs**. At HEAD all 28 targets are `STABLE`.

The instrument carried its own controls: it flagged the known-bad file (negative control — it can go red) and reported a non-zero ID count for every target (positive control — a target collecting 0 would have been called out, not silently counted clean).

## The guard, and its mutation results

`test_control_no_parametrize_id_can_carry_the_scratch_path` collects this file in **two real processes with different `TMPDIR`s** and asserts the ID sets match. Two processes rather than one, because an expectation derived from this module's own `SCRATCH` would assert only that one process agrees with itself — which it always does.

Three mutants, each **killed by the assertion that owns it**:

| mutant | killed by | message |
|---|---|---|
| `ids=` removed from `REALISTIC_ALLOWS` | offender assertion | names the offending test |
| `ids=` removed from `UNRELATED_HEREDOC_CASES` | offender assertion | names the offending test |
| an `os.getpid()` entry added to a table | the `a == b` assertion | the offender search cannot see a pid — proves the second claim is reachable **on its own**, and that the guard covers the wider class, not just `SCRATCH` |

🔴 **The third mutant is why assertion ORDER is load-bearing here, and the first draft had it wrong.** With the coverage controls *above* the claim, removing an `ids=` **drops the redaction count**, so the control tripped first and the claim below never executed — the guard went red for a reason naming neither the offending table nor xdist. Claim first, controls after; a vacuous collection (0 IDs, no offenders) still fails on the controls.

## Gate — both tiers, both tier-kinds

**Dev-host tier** — `nix develop --impure --command bash scripts/gate.sh --tier both`

```
  PASS  pytest  exit=0  verdict='RESULT: PASS (exit=0)'
  PASS  node    exit=0  verdict='RESULT: PASS (exit=0)'
GATE: RESULT=PASS exit=0

pytest  TOTAL collected=16645  passed=16643  skipped=2  failed=0  (floor: 15789 = sum of 28 per-target floors)
node    TOTAL suites=5 files=39 tests=1292 pass=1292 fail=0 skipped=0  (floor: 1239)
```

**Sandbox tier** — the one Tekton runs and the merge is gated on:

```
nix build .#checks.x86_64-linux.pytests    NIX_BUILD_RC=0
  RESULT: PASS (exit=0)
  TOTAL collected=16645  passed=16643  skipped=2  failed=0  (floor: 15789)

nix build .#checks.x86_64-linux.nodetests  NIX_BUILD_RC=0
  RESULT: PASS (exit=0)
  TOTAL suites=5 files=39 tests=1292 pass=1292 fail=0 skipped=0  (floor: 1239)
```

Read from the runners' own `RESULT:` lines and the per-target counts, with the build's exit status captured separately from any pipeline — never a `| tail` status.

**This target:** `collected=475 passed=475 skipped=0 floor=451` — the count moved 474 → 475 (the new guard) and **no floor drifted**. `collected=475` in the sandbox log is also the proof that tier saw this change, rather than a cached 474.

## Scope note on "both tiers"

The tier I reproduced red and fixed is **pytest**. The **node** tier is green at both refs and was never affected by this defect: `run-node-tests.sh` collects `*.test.mjs` only, and no `.test.mjs` in the repo references this file or `claude-hooks/tests`. Since **both** checks are required, a red `tekton/devrc-pytests` blocks the merge on its own — which is the state `main` was in.

Base: `200e6383`. Gated on this branch; per this repo's `strict: false` protection, gating the **merged** tree is still a manual step before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
