### PR TITLE
feat(ship,drift-check): classify dirty/untracked paths by whether NIX READS them

### DIFF
--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -267,8 +267,9 @@
 # ── UNTRACKED IN A NIX-READ PATH (rc 23) ──────────────────────────────────────
 # 🔴 THE GAP THE UNTRACKED BLOCK LEFT. Untracked files have always been counted
 # and listed here, and have never escalated — correctly, because most of them are
-# scratch. But a subset of them is not scratch: it is DEPLOYED CODE with no
-# commit and no backup anywhere.
+# scratch. But a subset of them is not scratch: it sits in a path NIX READS, and
+# is either being served right now or is one `git add` from the next artifact,
+# with no commit and no backup anywhere.
 #
 # MEASURED 2026-08-25 on the workbench:
 # nix/system/apply-nebula-443.sh.LOCAL-preserved-2026-08-02 had sat untracked for
@@ -281,12 +282,22 @@
 # WHICH PATHS NIX READS IS DERIVED, NEVER LISTED — scripts/lib/nix_read_paths.sh
 # reads it out of nix/ at scan time and returns two classes, because the
 # consequences differ:
-#   LIVE   a mkOutOfStoreSymlink target. The deployed path is a link back into
-#          the working tree, so an untracked file there is being SERVED right
-#          now, continuously, with no switch and no generation boundary.
-#   STORE  a nix path literal. It lands in the artifact the next switch builds.
-# Both escalate; both are named with their class, so the operator knows whether
-# the exposure is already live or arrives at the next switch.
+#   LIVE     a mkOutOfStoreSymlink target. The deployed path is a link back into
+#            the working tree, resolved at USE time and never through the flake
+#            source, so an untracked file there IS being served right now.
+#   DROPPED  a nix path literal — nix READS that path, but the flake source is
+#            filtered to the files git knows about, so an UNTRACKED file there
+#            reached NOTHING.
+# 🔴 DROPPED IS NOT "STORE", and calling it that was this block's first bug. The
+# class says nix reads the PATH; only nix_read_artifact_reach turns that into a
+# claim about the FILE, and every path here is untracked by construction.
+# MEASURED 2026-08-25: all six `-dl-router` store generations carry tests/ (37
+# files) and NONE carries the untracked tests/load_test_store.sh; a controlled
+# four-state build confirms committed / modified / `git add`ed all land (with the
+# WORKING-TREE content) and untracked never does.
+# Both still escalate — DROPPED is unsaved work in no commit and no backup,
+# sitting in a tree nix copies, one `git add` from the artifact — but the reason
+# printed for each is now one that is true of it.
 #
 # THE LADDER IS rc 13's, for rc 18's reason: reported on EVERY run, escalated to
 # rc 23 only after N CONSECUTIVE runs (DRIFT_NIXDIRT_ESCALATE, default 12 ≈ 3
@@ -795,13 +806,22 @@ fi
 # record — the same reason the rc 13 and rc 18 ladders are there.
 #
 # The FACT line is the contract with the driver and its shape is deliberate:
-#   FACT nix-untracked untracked=<N> nixread=<M> reason=<TOKEN> [<path>=<CLASS>]…
+#   FACT nix-untracked untracked=<N> nixread=<M> reason=<TOKEN> [<path>=<REACH>]…
 # The two counts are emitted UNCONDITIONALLY, including as zeros, because a
 # driver that sees no pairs must be able to tell "this host has no untracked
 # nix-read files" from "the nix-read set came out empty and every file on every
 # host is therefore clean". Pairs are told apart from the header fields by their
-# VALUE — LIVE or STORE, the whole class vocabulary — so a repo-root file called
-# `reason` cannot be read as a header field.
+# VALUE — LIVE or DROPPED, the whole reach vocabulary — so a repo-root file
+# called `reason` cannot be read as a header field.
+#
+# 🔴 THE PAIR CARRIES THE REACH, NOT THE CLASS, and that is a correction. A STORE
+# class says nix READS the path; it does NOT say the file got into the artifact,
+# because nix filters a git checkout to the files git knows about. Every path in
+# this block came from `git ls-files --others`, so it is UNTRACKED by
+# construction — which makes the reach of a STORE path DROPPED, always. The
+# translation is nix_read_artifact_reach in the shared lib, called HERE with the
+# known-tracked bit hardcoded to 0, so the rule has exactly one definition and
+# ship.sh (which sees both kinds) calls the same function.
 NU_REASON=NOLIB
 NU_PAIRS=""
 NU_M=0
@@ -822,9 +842,9 @@ fi
 if [ "$NU_REASON" = OK ] && [ "$n" != 0 ]; then
   while IFS= read -r NU_P; do
     [ -n "$NU_P" ] || continue
-    case "$(nix_read_class_of "$NU_P")" in
-      LIVE)            NU_PAIRS="$NU_PAIRS $NU_P=LIVE";  NU_HITS=$(( NU_HITS + 1 )) ;;
-      STORE)           NU_PAIRS="$NU_PAIRS $NU_P=STORE"; NU_HITS=$(( NU_HITS + 1 )) ;;
+    case "$(nix_read_artifact_reach "$(nix_read_class_of "$NU_P")" 0)" in
+      LIVE)            NU_PAIRS="$NU_PAIRS $NU_P=LIVE";    NU_HITS=$(( NU_HITS + 1 )) ;;
+      DROPPED)         NU_PAIRS="$NU_PAIRS $NU_P=DROPPED"; NU_HITS=$(( NU_HITS + 1 )) ;;
       UNREPRESENTABLE) NU_UNREP=$(( NU_UNREP + 1 )) ;;
     esac
   done <<NU_EOF
@@ -2270,18 +2290,18 @@ for HROLE in "$LOCAL_ROLE" "$REMOTE_ROLE"; do
   # their VALUE. `${x#* }` positional parsing is what made the phase-2 gate print
   # `47 of 47`. The ORDER of these arms is load-bearing and was wrong once: with
   # `reason=*` ahead of the pair arm, an untracked repo-root file literally named
-  # `reason` produced the token `reason=STORE`, which was read as this line's
+  # `reason` produced a `reason=<REACH>` token that was read as this line's
   # REASON field — so the host came out COULD NOT MEASURE and the file it named
-  # was dropped, silently, in the direction of "nothing to see". LIVE and STORE
-  # are the whole class vocabulary and no header field can take either value, so
+  # was dropped, silently, in the direction of "nothing to see". LIVE and DROPPED
+  # are the whole reach vocabulary and no header field can take either value, so
   # matching the pairs first cannot swallow a header key.
   N_UNT=-1; N_MM=-1; N_RSN=""; N_PAIRS=""
   for X in $N_LINE; do
     case "$X" in
-      *=LIVE|*=STORE) N_PAIRS="$N_PAIRS $X" ;;
-      untracked=*)    N_UNT="${X#untracked=}" ;;
-      nixread=*)      N_MM="${X#nixread=}" ;;
-      reason=*)       N_RSN="${X#reason=}" ;;
+      *=LIVE|*=DROPPED) N_PAIRS="$N_PAIRS $X" ;;
+      untracked=*)      N_UNT="${X#untracked=}" ;;
+      nixread=*)        N_MM="${X#nixread=}" ;;
+      reason=*)         N_RSN="${X#reason=}" ;;
     esac
   done
   case "$N_UNT" in ''|*[!0-9]*) N_UNT=-1 ;; esac
@@ -2319,12 +2339,20 @@ for HROLE in "$LOCAL_ROLE" "$REMOTE_ROLE"; do
       echo "[nixdirt] 🔴 DRIFT — $HROLE $N_P: UNTRACKED in a NIX-READ path ($N_C) for $STK CONSECUTIVE runs (threshold $DRIFT_NIXDIRT_ESCALATE)."
       if [ "$N_C" = LIVE ]; then
         echo "[nixdirt]   LIVE: the deployed path is a mkOutOfStoreSymlink back into that working"
-        echo "[nixdirt]   tree, so this file is being SERVED on that host right now — with no"
+        echo "[nixdirt]   tree, which the link resolves at USE time and not through the flake"
+        echo "[nixdirt]   source — so this file IS being served on that host right now, with no"
         echo "[nixdirt]   commit, no backup and no other host holding a copy."
       else
-        echo "[nixdirt]   STORE: nix reads it at eval/build time, so every generation built on"
-        echo "[nixdirt]   that host carries it — with no commit, no backup and no other host"
-        echo "[nixdirt]   holding a copy."
+        # 🔴 THE SENTENCE THIS REPLACED WAS FALSE. It said "every generation built
+        # on that host carries it". Nix filters a git checkout to the files git
+        # knows about, so an untracked file reaches NOTHING — measured on all six
+        # -dl-router store generations. Overstating here is the precise failure
+        # this whole block exists to remove, so the finding keeps its escalation
+        # and loses the claim it could not support.
+        echo "[nixdirt]   DROPPED: nix reads that path, but the flake source is filtered to the"
+        echo "[nixdirt]   files git knows about, so this file did NOT reach the artifact. It is"
+        echo "[nixdirt]   unsaved work in no commit, no backup and on no other host — sitting in"
+        echo "[nixdirt]   a tree nix copies, one git-add from being deployed."
       fi
       echo "[nixdirt]   fix: commit it, delete it, or gitignore it on that host, then re-run."
       N_ESCALATED=$(( N_ESCALATED + 1 ))
@@ -2525,8 +2553,9 @@ if [ "$rc" != 0 ]; then
   echo "       with NO overrides is NOT ADOPTED, never rc22 — that is the shipped state."
   echo "       (ranks just under rc10 — a behind host carries a stale ledger; ship it first)"
   echo "  rc23=an UNTRACKED file in a path NIX READS has survived $DRIFT_NIXDIRT_ESCALATE consecutive runs on that"
-  echo "       host — LIVE (a mkOutOfStoreSymlink target, served right now) or STORE (copied"
-  echo "       into the artifact by the next switch). A host whose nix-read set came out EMPTY"
+  echo "       host — LIVE (a mkOutOfStoreSymlink target, being served right now) or DROPPED"
+  echo "       (nix reads the path, but the flake filtered the untracked file OUT of the"
+  echo "       artifact — unsaved work, not a deployed one). A host whose nix-read set came EMPTY"
   echo "       is COULD NOT MEASURE, never rc23. (ranks between rc15 and rc12; see severity() )"
 fi
 [ -n "$UNCHECKED" ] && echo "drift-check: NOT checked: $UNCHECKED"

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -540,6 +540,15 @@ set -uo pipefail
 # --- Host identity: SOURCED, never copied (see header) ------------------------
 # The source path is symlink-resolved: invoked through a symlink, an unresolved
 # ${BASH_SOURCE[0]} would look for lib/ next to the SYMLINK and not find it.
+#
+# 🔴 THIS FILE HAS TWO SOURCING CONVENTIONS AND THEY ARE NOT AN INCONSISTENCY —
+# do not "tidy" one into the other. This one resolves lib/ relative to THE
+# SCRIPT, because host identity must be decided before any repo path is known and
+# by the copy of the checker that is running. The nix-read lib (see NU_LIB in the
+# CHECK payload) resolves relative to `$repo` INSTEAD, because that payload is
+# piped to whichever HOST is being examined and must load that host's own
+# checkout — a script-relative path there would silently reach for a lib beside a
+# copy that does not exist on the far side. Each is wrong in the other's place.
 _drift_self="${BASH_SOURCE[0]}"
 _drift_resolved="$(readlink -f "$_drift_self" 2>/dev/null || true)"
 [ -n "$_drift_resolved" ] && _drift_self="$_drift_resolved"
@@ -583,6 +592,13 @@ DRIFT_UNMEASURED_FETCH_ESCALATE="${DRIFT_UNMEASURED_FETCH_ESCALATE:-12}"
 # The rc 23 ladder — see "UNTRACKED IN A NIX-READ PATH" for why it is longer than
 # the structural-unmeasured one rather than the same number reused.
 DRIFT_NIXDIRT_ESCALATE="${DRIFT_NIXDIRT_ESCALATE:-12}"
+# 🔴 A BOUND, like every sibling listing in this file. rc 23's was the only
+# uncapped per-host listing: untracked caps at DRIFT_UNTRACKED_MAX, dangling at
+# DRIFT_DANGLING_MAX, commits at `head -n 10`, fetch stderr at `head -n 3`.
+# `claude/skills` is a whole-directory STORE source, so an untracked,
+# non-gitignored subtree under it emits one FACT token, journal lines AND a state
+# file per path — unbounded, on a unit whose only output is the journal.
+DRIFT_NIXDIRT_MAX="${DRIFT_NIXDIRT_MAX:-10}"
 DRIFT_STATE_DIR="${DRIFT_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/drift-check}"
 DRIFT_SESSION_MANAGER="${DRIFT_SESSION_MANAGER:-$_drift_dir/session-manager}"
 DRIFT_PHASE2_TIMEOUT="${DRIFT_PHASE2_TIMEOUT:-60}"
@@ -611,6 +627,9 @@ require_int DRIFT_UNMEASURED_FETCH_ESCALATE "$DRIFT_UNMEASURED_FETCH_ESCALATE"
 # `[ "$STK" -ge "$THR" ]` into an error rather than a comparison and the ladder
 # would go quiet — the one direction it may never fail in.
 require_int DRIFT_NIXDIRT_ESCALATE "$DRIFT_NIXDIRT_ESCALATE"
+# Interpolated into the payload that runs on the OTHER host — same reason
+# DRIFT_UNTRACKED_MAX is validated: a non-integer here is remote code execution.
+require_int DRIFT_NIXDIRT_MAX "$DRIFT_NIXDIRT_MAX"
 # Not interpolated into a remote payload — but it IS handed to `timeout`, where a
 # non-integer would make the phase-2 scan fail in a way that reads as "the tool
 # is broken" rather than "you passed nonsense".
@@ -827,6 +846,8 @@ NU_PAIRS=""
 NU_M=0
 NU_HITS=0
 NU_UNREP=0
+NU_EMIT=0
+NU_MAX="${DRIFT_NIXDIRT_MAX:-10}"
 NU_LIB="$repo/scripts/lib/nix_read_paths.sh"
 if [ -r "$NU_LIB" ]; then
   # shellcheck source=lib/nix_read_paths.sh
@@ -842,9 +863,20 @@ fi
 if [ "$NU_REASON" = OK ] && [ "$n" != 0 ]; then
   while IFS= read -r NU_P; do
     [ -n "$NU_P" ] || continue
+    # 🔴 HITS COUNTS ALL OF THEM; only the EMITTED pairs are capped. The count is
+    # the finding and must never be truncated — a cap that silently shrank the
+    # number would be a smaller version of the reassuring-zero this file refuses.
     case "$(nix_read_artifact_reach "$(nix_read_class_of "$NU_P")" 0)" in
-      LIVE)            NU_PAIRS="$NU_PAIRS $NU_P=LIVE";    NU_HITS=$(( NU_HITS + 1 )) ;;
-      DROPPED)         NU_PAIRS="$NU_PAIRS $NU_P=DROPPED"; NU_HITS=$(( NU_HITS + 1 )) ;;
+      LIVE)
+        NU_HITS=$(( NU_HITS + 1 ))
+        if [ "$NU_EMIT" -lt "$NU_MAX" ]; then
+          NU_PAIRS="$NU_PAIRS $NU_P=LIVE"; NU_EMIT=$(( NU_EMIT + 1 ))
+        fi ;;
+      DROPPED)
+        NU_HITS=$(( NU_HITS + 1 ))
+        if [ "$NU_EMIT" -lt "$NU_MAX" ]; then
+          NU_PAIRS="$NU_PAIRS $NU_P=DROPPED"; NU_EMIT=$(( NU_EMIT + 1 ))
+        fi ;;
       UNREPRESENTABLE) NU_UNREP=$(( NU_UNREP + 1 )) ;;
     esac
   done <<NU_EOF
@@ -863,6 +895,9 @@ else
   for NU_X in $NU_PAIRS; do
     say "    - ${NU_X%=*} (${NU_X##*=})"
   done
+  # The same "... and N more" shape every other capped listing in this file uses,
+  # so a truncated list can never be mistaken for the whole set.
+  [ "$NU_HITS" -gt "$NU_EMIT" ] && say "    ... and $(( NU_HITS - NU_EMIT )) more"
 fi
 [ "$NU_UNREP" != 0 ] && say "  ($NU_UNREP untracked path(s) NOT CLASSIFIED — a character the classifier does not model)"
 echo "[$label] FACT nix-untracked untracked=$n nixread=$NU_M reason=$NU_REASON$NU_PAIRS"
@@ -1820,6 +1855,13 @@ u_streak_reset() { # u_streak_reset <role> <scope> — it MEASURED; the run ends
 }
 
 n_streak_reset() { # n_streak_reset <counter-file> — that path is untracked no more
+  # 🔴 REWRITES, NEVER REMOVES, and that is forced rather than preferred. This
+  # ladder is per-PATH, so cleared counters accumulate where rc 18's ~2 scopes do
+  # not — deleting them would be tidier. But `rm` is a DESTRUCTIVE command to the
+  # passivity scanner that guards this file (test_drift_check_source_never_
+  # mutates), and a read-only deadman that starts deleting files is a worse trade
+  # than some small files under $DRIFT_STATE_DIR. Bounded in practice by
+  # DRIFT_NIXDIRT_MAX, which caps how many paths can ever be reported per run.
   # Takes the FILE, not the path: the rc 23 complement is discovered by LISTING
   # the state dir (a path that stopped being untracked is, by construction, not
   # in this run's report), so the caller holds a filename and no scope name to
@@ -1844,6 +1886,7 @@ if [ "$DO_LOCAL" = 1 ]; then
   # exactly as before.
   LOCAL_OUT="$(DRIFT_REPO="$DRIFT_REPO" DRIFT_LABEL="$LOCAL_ROLE" \
     DRIFT_UNTRACKED_MAX="$DRIFT_UNTRACKED_MAX" \
+    DRIFT_NIXDIRT_MAX="$DRIFT_NIXDIRT_MAX" \
     DRIFT_DANGLING_MAX="$DRIFT_DANGLING_MAX" \
     bash -c "$PAYLOAD")"
   note_rc "$?"
@@ -1862,8 +1905,8 @@ if [ "$DO_REMOTE" = 1 ]; then
   # remote host's repo lives at its own $HOME/workspace/devrc.
   # `bash -s` (piped, not inlined) — see the CHECK header re: zsh.
   # %q, not %s — these two values are executed on ANOTHER host (see require_int).
-  REMOTE_OUT="$(printf 'DRIFT_LABEL=%q\nDRIFT_UNTRACKED_MAX=%q\nDRIFT_DANGLING_MAX=%q\n%s\n' \
-    "$REMOTE_ROLE" "$DRIFT_UNTRACKED_MAX" "$DRIFT_DANGLING_MAX" "$PAYLOAD" \
+  REMOTE_OUT="$(printf 'DRIFT_LABEL=%q\nDRIFT_UNTRACKED_MAX=%q\nDRIFT_DANGLING_MAX=%q\nDRIFT_NIXDIRT_MAX=%q\n%s\n' \
+    "$REMOTE_ROLE" "$DRIFT_UNTRACKED_MAX" "$DRIFT_DANGLING_MAX" "$DRIFT_NIXDIRT_MAX" "$PAYLOAD" \
     | ssh -o ConnectTimeout=10 -o BatchMode=yes "$REMOTE_SSH" bash -s)"
   remrc=$?
   [ -n "$REMOTE_OUT" ] && printf '%s\n' "$REMOTE_OUT"

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -613,9 +613,14 @@ DRIFT_NIXDIRT_ESCALATE="${DRIFT_NIXDIRT_ESCALATE:-12}"
 # created per (host, path) that gets emitted, so ten new paths per run still
 # accrete ten new files per run — the cap stops one run from creating a thousand,
 # it does not stop a host's state dir growing monotonically over its lifetime.
-# Nothing prunes DRIFT_STATE_DIR today; the files are a few bytes each and
-# n_streak_reset unlinks one the moment its path stops being reported, which is
-# the only reclamation there is.
+# 🔴 NOTHING RECLAIMS THEM, AND n_streak_reset IS NOT AN EXCEPTION: it REWRITES
+# the counter to `CLEARED 0` and never unlinks it — see its own header, which
+# explains that `rm` is a destructive command to the passivity scanner guarding
+# this file, so a read-only deadman may not delete. So the file count only ever
+# grows; the files are a few bytes each and that was judged the better trade.
+# An earlier revision of this very comment claimed the unlink happens. It does
+# not, and acting on that claim means adding the one command this file is
+# designed to refuse.
 #
 # 🔴 AND IT IS THE ONLY CAP IN THIS FILE THAT COULD CHANGE A VERDICT, which is
 # why it alone is floored at 1. See the require_positive_int call below.
@@ -631,10 +636,57 @@ DRIFT_SRC_FETCH_TIMEOUT="${DRIFT_SRC_FETCH_TIMEOUT:-30}"
 # hence low exploitability — but it is a passivity hole on the far side of the
 # ssh hop, which the static scanner structurally cannot see. Validate here; the
 # printf below ALSO uses %q, deliberately belt-and-braces.
-require_int() { # require_int <name> <value>
+#
+# 🔴 ASSERT THE VALUE, NEVER ITS SPELLING — and PROVE the range rather than
+# testing for its complement. Three measured traps, each of which produced a
+# guard that READ as watertight and was not:
+#
+#   * `case "$2" in 0) reject ;; esac` is a SPELLING check. `00`, `000` and
+#     `007` are all-digits and NONE of them matches the glob `0`, so they walked
+#     straight past a floor whose entire purpose was to be unwalkable. Measured
+#     here: DRIFT_NIXDIRT_MAX=00 over three untracked nix-read files gave
+#     [0,0,0,0] where the default gives [0,0,23,23] — rc 23 switched off by an
+#     env var, with the journal still honestly printing `hits=3 listed=0`, so
+#     only the exit code lied. Second instance of this exact defect in one
+#     night; PR #854 had it too.
+#   * `[ "$2" -gt "$CEILING" ]` does NOT answer "no" for a value bash cannot
+#     parse — it ERRORS and the `if` then takes the FALSE branch. So a guard
+#     written as "reject when too big" waves the too-big value through.
+#     Measured: `[ 99999999999999999999 -gt 100000 ]` prints "integer expected"
+#     and is FALSE. Requiring the POSITIVE assertion inverts that: a value this
+#     shell cannot compare cannot prove itself in range, so it is refused.
+#   * the same unparseable value reaching a LADDER disables a verdict rather
+#     than merely mis-formatting a list, which is why require_int is bounded too
+#     and not only require_positive_int: `[ "$STK" -ge "$THR" ]` with a >2^63
+#     THR errors, evaluates FALSE, and the ladder goes quiet forever while the
+#     run reports no drift. Measured with STK=5, THR=99999999999999999999.
+#
+# The ceiling sits far above any real fleet — two hosts, a handful of untracked
+# paths, ladders measured in runs per day. Above it a tunable has stopped
+# bounding anything and the value is far likelier a typo than an intent.
+DRIFT_INT_CEILING=100000
+
+require_int() { # require_int <name> <value> — 0..DRIFT_INT_CEILING inclusive
   case "$2" in
     ''|*[!0-9]*) echo "drift-check: $1 must be a non-negative integer, got: $2" >&2; exit 2 ;;
+    # The ONE legal spelling of zero. No-op, so it falls through to the range
+    # proof below. (Its own line, not a trailing comment: a `;` inside a trailing
+    # comment starts a new segment for the command-word scanner in
+    # test_drift_check.py, and the next word reads as a command.)
+    0) ;;
+    0*) echo "drift-check: $1 must not have a leading zero, got: $2" >&2
+        echo "  A leading zero makes the SPELLING and the VALUE disagree, which is exactly" >&2
+        echo "  how a guard written against the spelling gets walked past. Write it plain." >&2
+        exit 2 ;;
   esac
+  if [ "$2" -ge 0 ] 2>/dev/null && [ "$2" -le "$DRIFT_INT_CEILING" ] 2>/dev/null; then
+    return 0
+  fi
+  echo "drift-check: $1 must be between 0 and $DRIFT_INT_CEILING, got: $2" >&2
+  echo "  A value this shell cannot COMPARE is refused, never accepted: a >2^63 operand" >&2
+  echo "  turns '[ x -ge y ]' into an error that evaluates FALSE, so every ladder and cap" >&2
+  echo "  it feeds goes quiet and the run reports no drift." >&2
+  exit 2
 }
 # 🔴 ZERO IS NOT A HARMLESS BOUND WHEN THE BOUND FEEDS A VERDICT. require_int
 # accepts 0, which is right for every pure LISTING cap here — DRIFT_UNTRACKED_MAX
@@ -646,7 +698,7 @@ require_int() { # require_int <name> <value>
 # rc 23 silently switched off from an env var, with the summary still printing a
 # clean-looking `hits=0` beside a real non-zero denominator. So this one has a
 # FLOOR, and the floor is stated in the message rather than left to be inferred.
-require_positive_int() { # require_positive_int <name> <value>
+require_positive_int() { # require_positive_int <name> <value> — 1..DRIFT_INT_CEILING
   case "$2" in
     ''|*[!0-9]*) echo "drift-check: $1 must be an integer >= 1, got: $2" >&2; exit 2 ;;
     0) echo "drift-check: $1 must be an integer >= 1, got: 0" >&2
@@ -654,7 +706,20 @@ require_positive_int() { # require_positive_int <name> <value>
        echo "  no streak is bumped and nothing escalates, while the summary still prints" >&2
        echo "  hits=<n> over a real denominator. That is a verdict turned off by a cap." >&2
        exit 2 ;;
+    0*) echo "drift-check: $1 must not have a leading zero, got: $2" >&2
+        echo "  The SPELLING and the VALUE disagree: '00' is zero, which this tunable" >&2
+        echo "  refuses outright, and '007' is seven. Measured — '00' walked past the '0'" >&2
+        echo "  arm and disabled rc 23. Write it plain." >&2
+        exit 2 ;;
   esac
+  if [ "$2" -ge 1 ] 2>/dev/null && [ "$2" -le "$DRIFT_INT_CEILING" ] 2>/dev/null; then
+    return 0
+  fi
+  echo "drift-check: $1 must be between 1 and $DRIFT_INT_CEILING, got: $2" >&2
+  echo "  A value this shell cannot COMPARE is refused, never accepted: with a >2^63" >&2
+  echo "  operand '[ \$NU_EMIT -lt \$NU_MAX ]' errors and evaluates FALSE, so NO path is" >&2
+  echo "  ever enumerated and rc 23 is switched off exactly as a cap of 0 would." >&2
+  exit 2
 }
 require_int DRIFT_UNTRACKED_MAX "$DRIFT_UNTRACKED_MAX"
 require_int DRIFT_DANGLING_MAX "$DRIFT_DANGLING_MAX"

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -91,7 +91,8 @@
 # one. So:
 #   * 19, 20 and 21 are RESERVED to ship.sh here and must not be taken as DRIFT
 #     codes. 22 is now TAKEN by this script (skillOverrides disagree with the
-#     tier ledger), so the next free code for this script is 23.
+#     tier ledger) and 23 by the nix-read untracked ladder, so the next free
+#     code for this script is 24.
 #   * anything this script adds above 21 is reserved back the other way; ship.sh
 #     documents this in its own header for the same reason.
 #
@@ -153,6 +154,13 @@
 #       permanently red. rc 22 is adopted-then-drifted only. See "SKILL-LISTING
 #       TIERS" below. It ranks just under rc 10, because a BEHIND host carries a
 #       stale ledger and can produce this finding as a symptom.
+#   23  DRIFT — an UNTRACKED file in a path NIX READS has survived N CONSECUTIVE
+#       runs on that host. Untracked files have always been reported here as
+#       information; this is the subset where the file is not merely unbacked but
+#       DEPLOYED — either live through a mkOutOfStoreSymlink or copied into the
+#       artifact by the next switch. Measured 2026-08-25: one such file had sat
+#       on the workbench for ~3 weeks with every check green. See "UNTRACKED IN A
+#       NIX-READ PATH" below. It ranks between rc 15 and rc 12 — see severity().
 #   16  ACTIONABLE, not drift — the fuzzyclaw PHASE-2 GATE has OPENED: zero rows
 #       still take their `age_secs` from fuzzyclaw alone, so the readers can be
 #       removed. See "THE FUZZYCLAW PHASE-2 GATE" below. It is the LEAST severe
@@ -255,6 +263,45 @@
 #
 # READ-ONLY, like everything else in this file: `fetch`, `rev-parse`, `rev-list`,
 # `symbolic-ref`, `status`. It never pulls, never switches, never repairs.
+#
+# ── UNTRACKED IN A NIX-READ PATH (rc 23) ──────────────────────────────────────
+# 🔴 THE GAP THE UNTRACKED BLOCK LEFT. Untracked files have always been counted
+# and listed here, and have never escalated — correctly, because most of them are
+# scratch. But a subset of them is not scratch: it is DEPLOYED CODE with no
+# commit and no backup anywhere.
+#
+# MEASURED 2026-08-25 on the workbench:
+# nix/system/apply-nebula-443.sh.LOCAL-preserved-2026-08-02 had sat untracked for
+# ~3 weeks, reported every run, escalated never. That one turns out NOT to be
+# nix-read (nix/system/ holds hand-run sudo scripts the flake never opens) — but
+# the same run listed scripts/dl-router/tests/load_test_store.sh, which IS:
+# nix/home.nix says `${../scripts/dl-router}` and copies that directory into the
+# store WHOLE. Nothing distinguished the two, and no operator was going to.
+#
+# WHICH PATHS NIX READS IS DERIVED, NEVER LISTED — scripts/lib/nix_read_paths.sh
+# reads it out of nix/ at scan time and returns two classes, because the
+# consequences differ:
+#   LIVE   a mkOutOfStoreSymlink target. The deployed path is a link back into
+#          the working tree, so an untracked file there is being SERVED right
+#          now, continuously, with no switch and no generation boundary.
+#   STORE  a nix path literal. It lands in the artifact the next switch builds.
+# Both escalate; both are named with their class, so the operator knows whether
+# the exposure is already live or arrives at the next switch.
+#
+# THE LADDER IS rc 13's, for rc 18's reason: reported on EVERY run, escalated to
+# rc 23 only after N CONSECUTIVE runs (DRIFT_NIXDIRT_ESCALATE, default 12 ≈ 3
+# days at the 6h cadence), per (HOST, PATH), and RESET the moment that path stops
+# being untracked — committed, deleted or gitignored. 3 days rather than rc 18's
+# 24h because creating a file and committing it an hour later is the NORMAL
+# working shape here; the finding is "this has been sitting there", not "this
+# exists".
+#
+# 🔴 IT REFUSES TO BE SATISFIED BY MEASURING NOTHING, and that guard is the whole
+# reason the derived set reports its own population. A host whose payload derived
+# ZERO nix-read paths prints COULD NOT MEASURE with a reason token and sets NO
+# code — because an empty nix-read set classifies every untracked file on every
+# host as clean, forever, in silence. It also bumps and resets NOTHING in that
+# state: a ladder must not be cleared by a scan that walked nothing.
 #
 # ── UNMEASURED IS NOT FOREVER (rc 18) ─────────────────────────────────────────
 # 🔴 THE GAP rc 17 LEFT. A scope that CANNOT be evaluated is reported UNMEASURED
@@ -390,16 +437,16 @@
 # is reading a timer's output, so the single number it hands to systemd must be
 # the worst thing found, or an un-pushed workbench could hide behind a merely
 # behind laptop. Severity order (worst first):
-#     8 > 17 > 14 > 13 > 18 > 6 > 2 > 4 > 3 > 12 > 15 > 10 > 22 > 16
+#     8 > 17 > 14 > 13 > 18 > 6 > 2 > 4 > 3 > 12 > 23 > 15 > 10 > 22 > 16
 # 🔴 THAT ORDER IS THE severity() TABLE, NOT THE DIGITS — it never was monotonic
 # (14 outranks 13 outranks 18 outranks 6 outranks 4), 17 is not "less severe
-# than 16" because it is larger, and 22 ranks second-LAST despite being the
-# largest digit here. Every code below 16 that is still free (5, 7, 9, 11) is
-# reserved to a ship.sh meaning this script does not take, so a new DRIFT code
-# has nowhere to go but upward; its rank is stated in severity() and here.
+# than 16" because it is larger, 23 outranks 15 while 22 ranks second-LAST, and
+# 22 is the largest digit here. Every code below 16 that is still free (5, 7, 9,
+# 11) is reserved to a ship.sh meaning this script does not take, so a new DRIFT
+# code has nowhere to go but upward; its rank is stated in severity() and here.
 # 🔴 UPWARD IS NOT EMPTY EITHER: ship.sh owns 19 (hosts-disagree), 20
-# (superseded) and 21 (usage), and this script has now taken 22, so the next free
-# DRIFT code is 23, not 19. See the reciprocal
+# (superseded) and 21 (usage), and this script has now taken 22 and 23, so the
+# next free DRIFT code is 24, not 19. See the reciprocal
 # reservation under EXIT CODES above — that collision was one increment away.
 # (6 and 2 are both unreachable through this path today — the script exits each
 # directly, before any per-host leg runs — but the order is documented for every
@@ -407,9 +454,11 @@
 # to the unknown-code slot, which would rank them 99, ABOVE rc 8.)
 # Per-host lines are ALWAYS printed for every host, whatever the code.
 #
-# Untracked files are counted and listed per host as INFORMATION only — they
-# never change the exit code. They are the same loss class (work sitting on one
-# host that no other host and no backup has) and cost nothing to report.
+# Untracked files are counted and listed per host as INFORMATION — they are the
+# same loss class (work sitting on one host that no other host and no backup has)
+# and cost nothing to report. 🔴 THE SUBSET THAT SITS IN A PATH NIX READS IS NOT
+# information only: it rides the rc 23 ladder below. This comment said "they
+# never change the exit code" for as long as that was true of all of them.
 #
 # ── USAGE ─────────────────────────────────────────────────────────────────────
 #   scripts/drift-check.sh                 # check this host + the other one
@@ -449,7 +498,16 @@
 #                        (default 12 ≈ 3 days). Separate from the tunable above
 #                        because they are not the same hazard; see "UNMEASURED IS
 #                        NOT FOREVER". `repo ABSENT` is on NEITHER ladder.
-#   DRIFT_STATE_DIR  where the unreachable and unmeasured streaks are persisted
+#   DRIFT_NIXDIRT_ESCALATE  consecutive runs an UNTRACKED file may sit in a
+#                        NIX-READ path before rc 23 (default 12 ≈ 3 days at the
+#                        6h cadence). Longer than DRIFT_UNMEASURED_ESCALATE on
+#                        purpose: writing a file and committing it an hour later
+#                        is the normal working shape, and the finding is that it
+#                        has been SITTING there. Deliberately NOT forwarded over
+#                        ssh — the ladder is kept by the host running the driver,
+#                        for both hosts' paths.
+#   DRIFT_STATE_DIR  where the unreachable, unmeasured and nix-dirt streaks are
+#                    persisted
 #                    (default ${XDG_STATE_HOME:-$HOME/.local/state}/drift-check)
 #   DRIFT_SESSION_MANAGER  path to the session-manager used by the phase-2 gate
 #                    (default: the copy beside this script). Exists so the test
@@ -511,6 +569,9 @@ DRIFT_UNREACHABLE_ESCALATE="${DRIFT_UNREACHABLE_ESCALATE:-4}"
 # — see "UNMEASURED IS NOT FOREVER" in the header for the full argument.
 DRIFT_UNMEASURED_ESCALATE="${DRIFT_UNMEASURED_ESCALATE:-4}"
 DRIFT_UNMEASURED_FETCH_ESCALATE="${DRIFT_UNMEASURED_FETCH_ESCALATE:-12}"
+# The rc 23 ladder — see "UNTRACKED IN A NIX-READ PATH" for why it is longer than
+# the structural-unmeasured one rather than the same number reused.
+DRIFT_NIXDIRT_ESCALATE="${DRIFT_NIXDIRT_ESCALATE:-12}"
 DRIFT_STATE_DIR="${DRIFT_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/drift-check}"
 DRIFT_SESSION_MANAGER="${DRIFT_SESSION_MANAGER:-$_drift_dir/session-manager}"
 DRIFT_PHASE2_TIMEOUT="${DRIFT_PHASE2_TIMEOUT:-60}"
@@ -535,6 +596,10 @@ require_int DRIFT_UNREACHABLE_ESCALATE "$DRIFT_UNREACHABLE_ESCALATE"
 # would go quiet in exactly the direction this code exists to refuse.
 require_int DRIFT_UNMEASURED_ESCALATE "$DRIFT_UNMEASURED_ESCALATE"
 require_int DRIFT_UNMEASURED_FETCH_ESCALATE "$DRIFT_UNMEASURED_FETCH_ESCALATE"
+# Same reasoning: not forwarded over ssh either, but a non-integer would turn
+# `[ "$STK" -ge "$THR" ]` into an error rather than a comparison and the ladder
+# would go quiet — the one direction it may never fail in.
+require_int DRIFT_NIXDIRT_ESCALATE "$DRIFT_NIXDIRT_ESCALATE"
 # Not interpolated into a remote payload — but it IS handed to `timeout`, where a
 # non-integer would make the phase-2 scan fail in a way that reads as "the tool
 # is broken" rather than "you passed nonsense".
@@ -634,6 +699,18 @@ severity() {
     4)  echo 55 ;;
     3)  echo 50 ;;
     12) echo 40 ;;
+    # 23 (an untracked file in a NIX-READ path has persisted N runs) sits between
+    # 12 and 15, and the digit says nothing about that either.
+    #   BELOW 12, because a checkout that is not on main will be SKIPPED by
+    #   ship.sh and therefore stops receiving every future change; this one still
+    #   converges normally, it just carries a passenger while it does.
+    #   ABOVE 15, because the loss classes differ in kind. A settings.json key
+    #   set that disagrees costs the operator a CAPABILITY on one host, and both
+    #   copies of the fact still exist. This is content that exists on exactly
+    #   ONE machine, in no commit and no backup, AND is being executed there —
+    #   rc 8's loss class at a smaller scope, which is why it outranks a parity
+    #   difference and not a divergence.
+    23) echo 37 ;;
     # 15 ranks BELOW 12 and above 10: a key-set or plugin difference is a real
     # divergence, but ship.sh does not fix it and it costs the operator a
     # capability, not a commit. 14 ranks just under 8 — see the table in the
@@ -707,8 +784,68 @@ if [ -n "$untracked" ]; then
   printf "%s\n" "$untracked" | head -n "$maxu" | sed "s|^|[$label]     - |"
   [ "$n" -gt "$maxu" ] && say "    ... and $(( n - maxu )) more"
 else
+  n=0
   say "untracked: 0"
 fi
+
+# --- The rc 23 subset: untracked AND in a path NIX READS ----------------------
+# 🔴 NOT information. See "UNTRACKED IN A NIX-READ PATH" in the header. This leg
+# only MEASURES and reports; the consecutive-run ladder lives in the driver,
+# because a streak is persistent state and belongs to the machine keeping the
+# record — the same reason the rc 13 and rc 18 ladders are there.
+#
+# The FACT line is the contract with the driver and its shape is deliberate:
+#   FACT nix-untracked untracked=<N> nixread=<M> reason=<TOKEN> [<path>=<CLASS>]…
+# The two counts are emitted UNCONDITIONALLY, including as zeros, because a
+# driver that sees no pairs must be able to tell "this host has no untracked
+# nix-read files" from "the nix-read set came out empty and every file on every
+# host is therefore clean". Pairs are told apart from the header fields by their
+# VALUE — LIVE or STORE, the whole class vocabulary — so a repo-root file called
+# `reason` cannot be read as a header field.
+NU_REASON=NOLIB
+NU_PAIRS=""
+NU_M=0
+NU_HITS=0
+NU_UNREP=0
+NU_LIB="$repo/scripts/lib/nix_read_paths.sh"
+if [ -r "$NU_LIB" ]; then
+  # shellcheck source=lib/nix_read_paths.sh
+  . "$NU_LIB"
+  if nix_read_scan "$repo"; then
+    NU_REASON=OK
+    NU_M="$NIXREAD_COUNT"
+  else
+    NU_REASON="$NIXREAD_REASON"
+    NU_M="$NIXREAD_COUNT"
+  fi
+fi
+if [ "$NU_REASON" = OK ] && [ "$n" != 0 ]; then
+  while IFS= read -r NU_P; do
+    [ -n "$NU_P" ] || continue
+    case "$(nix_read_class_of "$NU_P")" in
+      LIVE)            NU_PAIRS="$NU_PAIRS $NU_P=LIVE";  NU_HITS=$(( NU_HITS + 1 )) ;;
+      STORE)           NU_PAIRS="$NU_PAIRS $NU_P=STORE"; NU_HITS=$(( NU_HITS + 1 )) ;;
+      UNREPRESENTABLE) NU_UNREP=$(( NU_UNREP + 1 )) ;;
+    esac
+  done <<NU_EOF
+$untracked
+NU_EOF
+fi
+
+if [ "$NU_REASON" != OK ]; then
+  say "untracked-in-nix-read-paths: COULD NOT MEASURE ($NU_REASON) — $n untracked file(s),"
+  say "  $NU_M nix-read path(s) derived. A zero here would classify every untracked file on"
+  say "  every host as harmless, so this run makes no such claim and sets no code."
+elif [ "$NU_HITS" = 0 ]; then
+  say "untracked-in-nix-read-paths: 0 of $n untracked file(s), against $NU_M nix-read path(s)."
+else
+  say "untracked-in-nix-read-paths: $NU_HITS of $n untracked file(s), against $NU_M nix-read path(s):"
+  for NU_X in $NU_PAIRS; do
+    say "    - ${NU_X%=*} (${NU_X##*=})"
+  done
+fi
+[ "$NU_UNREP" != 0 ] && say "  ($NU_UNREP untracked path(s) NOT CLASSIFIED — a character the classifier does not model)"
+echo "[$label] FACT nix-untracked untracked=$n nixread=$NU_M reason=$NU_REASON$NU_PAIRS"
 
 # --- Which branch is checked out? ---------------------------------------------
 branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo DETACHED)
@@ -1590,21 +1727,45 @@ u_threshold() { # u_threshold <reason-token> -> consecutive-run threshold, or NE
   fi
 }
 
-_u_streak_file() { # _u_streak_file <role> <scope> -> that pair's counter path
-  # 🔴 INJECTIVE, not merely "sanitised". The scope scan can only produce
-  # [A-Za-z0-9._/-], so doubling `_` and then mapping `/` to `_` is reversible
-  # over that whole alphabet: `a/b` and `a_b` cannot land on one file. A plain
-  # `/`->`_` would collide them, and two scopes sharing a counter is a ladder
-  # that resets itself for reasons nobody can see.
+_streak_key() { # _streak_key <scope> -> the filename-safe, INJECTIVE encoding
+  # 🔴 INJECTIVE, not merely "sanitised". Every scope this script keys on comes
+  # from a scan whose alphabet is [A-Za-z0-9._/-], so doubling `_` and then
+  # mapping `/` to `_` is reversible over that whole alphabet: `a/b` and `a_b`
+  # cannot land on one file. A plain `/`->`_` would collide them, and two scopes
+  # sharing a counter is a ladder that resets itself for reasons nobody can see.
+  #
+  # ONE encoder, used by both ladder namers below. It was open-coded in
+  # _u_streak_file alone until the rc 23 ladder needed the same property; a
+  # predicate copied to a second site is typically wrong at one of them.
   local S
-  S="${2//_/__}"
+  S="${1//_/__}"
   S="${S//\//_}"
-  printf '%s\n' "$DRIFT_STATE_DIR/unmeasured-${1:-host}-$S"
+  printf '%s' "$S"
+}
+
+_u_streak_file() { # _u_streak_file <role> <scope> -> that pair's counter path
+  printf '%s\n' "$DRIFT_STATE_DIR/unmeasured-${1:-host}-$(_streak_key "$2")"
+}
+
+_n_streak_file() { # _n_streak_file <role> <repo-path> -> that pair's counter path
+  # 🔴 ITS OWN FILENAME PREFIX, not a namespace inside the rc 18 one. A scope
+  # `nixdirt/x` encodes to `nixdirt_x`, which is exactly what a source repo
+  # literally named `nixdirt` with a subtree `x` would produce — implausible, and
+  # a collision between two ladders is not a thing to leave to plausibility.
+  printf '%s\n' "$DRIFT_STATE_DIR/nixdirt-${1:-host}-$(_streak_key "$2")"
 }
 
 u_streak_bump() { # u_streak_bump <role> <scope> <reason> -> new streak, or -1
+  _streak_file_bump "$(_u_streak_file "$1" "$2")" "$3"
+}
+
+n_streak_bump() { # n_streak_bump <role> <path> <class> -> new streak, or -1
+  _streak_file_bump "$(_n_streak_file "$1" "$2")" "$3"
+}
+
+_streak_file_bump() { # _streak_file_bump <counter-file> <reason> -> streak, or -1
   local f PREV PREASON PCOUNT NEXT
-  f="$(_u_streak_file "$1" "$2")"
+  f="$1"
   mkdir -p "$DRIFT_STATE_DIR" 2>/dev/null || { echo -1; return 0; }
   PREV="$(cat "$f" 2>/dev/null || true)"
   PREASON=""
@@ -1622,11 +1783,11 @@ u_streak_bump() { # u_streak_bump <role> <scope> <reason> -> new streak, or -1
   # thresholds, so carrying a FETCHFAILED count into a NOUPSTREAM ladder would
   # escalate on evidence that was never about that hazard — and the reset written
   # by u_streak_reset ("MEASURED 0") clears the streak through this same rule.
-  [ "$PREASON" = "$3" ] || PCOUNT=0
+  [ "$PREASON" = "$2" ] || PCOUNT=0
   NEXT=$(( PCOUNT + 1 ))
   # `2>/dev/null` FIRST, then the target — see streak_bump for why the order of
   # the redirections is load-bearing.
-  printf '%s %s\n' "$3" "$NEXT" 2>/dev/null > "$f" || { echo -1; return 0; }
+  printf '%s %s\n' "$2" "$NEXT" 2>/dev/null > "$f" || { echo -1; return 0; }
   echo "$NEXT"
 }
 
@@ -1635,11 +1796,24 @@ u_streak_reset() { # u_streak_reset <role> <scope> — it MEASURED; the run ends
   # unmeasured needs no file, and creating one per scope per run would put state
   # in the journal's way for no gain. The token is not a reason, so the reason
   # comparison in u_streak_bump restarts the count from 0 whatever comes next.
+  _streak_file_reset "$(_u_streak_file "$1" "$2")" MEASURED
+}
+
+n_streak_reset() { # n_streak_reset <counter-file> — that path is untracked no more
+  # Takes the FILE, not the path: the rc 23 complement is discovered by LISTING
+  # the state dir (a path that stopped being untracked is, by construction, not
+  # in this run's report), so the caller holds a filename and no scope name to
+  # re-encode. Decoding _streak_key back to a path would be a second, inverse
+  # copy of the encoder — the thing consolidating it was meant to stop.
+  _streak_file_reset "$1" CLEARED
+}
+
+_streak_file_reset() { # _streak_file_reset <counter-file> <token>
   local f
-  f="$(_u_streak_file "$1" "$2")"
+  f="$1"
   [ -d "$DRIFT_STATE_DIR" ] || return 0
   [ -f "$f" ] || return 0
-  printf 'MEASURED 0\n' 2>/dev/null > "$f" || true
+  printf '%s 0\n' "$2" 2>/dev/null > "$f" || true
 }
 
 if [ "$DO_LOCAL" = 1 ]; then
@@ -2063,6 +2237,133 @@ else
 fi
 echo
 
+# ── UNTRACKED FILES THAT SIT IN NIX-READ PATHS (rc 23) ────────────────────────
+# 🔴 See "UNTRACKED IN A NIX-READ PATH" in the header for what this measures and
+# why the ladder is longer than rc 18's. Here: how it refuses to be satisfied by
+# measuring nothing.
+#
+# It runs HERE, in the driver, for the reason rc 13's and rc 18's ladders do: the
+# streak is PERSISTENT STATE and belongs to the machine keeping the record, while
+# the payload is a stateless thing piped to whichever host is being examined.
+#
+# 🔴 A HOST IS WALKED ONLY IF IT ANSWERED, and only if its answer carries a
+# NON-ZERO nix-read denominator. Without one, every untracked file on that host
+# classifies clean — so nothing is bumped AND nothing is reset: a ladder cleared
+# by a scan that walked nothing is worse than no ladder.
+echo "=== untracked files in NIX-READ paths ($LOCAL_ROLE / $REMOTE_ROLE) ==="
+N_REPORTING=0
+N_UNTRACKED=0
+N_NIXREAD=0
+N_HITS=0
+N_ESCALATED=0
+N_BLIND=0
+for HROLE in "$LOCAL_ROLE" "$REMOTE_ROLE"; do
+  if [ "$HROLE" = "$LOCAL_ROLE" ]; then
+    N_LINE="$(fact_of "$LOCAL_OUT" nix-untracked)"
+  else
+    N_LINE="$(fact_of "$REMOTE_OUT" nix-untracked)"
+  fi
+  [ -n "$N_LINE" ] || continue
+  N_REPORTING=$(( N_REPORTING + 1 ))
+
+  # 🔴 READ BY KEY, NOT BY POSITION, and the path pairs are matched FIRST, by
+  # their VALUE. `${x#* }` positional parsing is what made the phase-2 gate print
+  # `47 of 47`. The ORDER of these arms is load-bearing and was wrong once: with
+  # `reason=*` ahead of the pair arm, an untracked repo-root file literally named
+  # `reason` produced the token `reason=STORE`, which was read as this line's
+  # REASON field — so the host came out COULD NOT MEASURE and the file it named
+  # was dropped, silently, in the direction of "nothing to see". LIVE and STORE
+  # are the whole class vocabulary and no header field can take either value, so
+  # matching the pairs first cannot swallow a header key.
+  N_UNT=-1; N_MM=-1; N_RSN=""; N_PAIRS=""
+  for X in $N_LINE; do
+    case "$X" in
+      *=LIVE|*=STORE) N_PAIRS="$N_PAIRS $X" ;;
+      untracked=*)    N_UNT="${X#untracked=}" ;;
+      nixread=*)      N_MM="${X#nixread=}" ;;
+      reason=*)       N_RSN="${X#reason=}" ;;
+    esac
+  done
+  case "$N_UNT" in ''|*[!0-9]*) N_UNT=-1 ;; esac
+  case "$N_MM" in ''|*[!0-9]*) N_MM=-1 ;; esac
+
+  if [ "$N_RSN" != OK ] || [ "$N_UNT" -lt 0 ] || [ "$N_MM" -le 0 ]; then
+    echo "[nixdirt] $HROLE: COULD NOT MEASURE — reason=${N_RSN:-ABSENT} untracked=$N_UNT nix-read-paths=$N_MM."
+    echo "[nixdirt]   With no derived nix-read set every untracked file on that host classifies"
+    echo "[nixdirt]   as harmless. That is not a finding of none: nothing was bumped, nothing"
+    echo "[nixdirt]   was reset, and NO code is set for it."
+    N_BLIND=$(( N_BLIND + 1 ))
+    continue
+  fi
+  N_UNTRACKED=$(( N_UNTRACKED + N_UNT ))
+  N_NIXREAD=$(( N_NIXREAD + N_MM ))
+
+  N_KEEP=""
+  for X in $N_PAIRS; do
+    N_P="${X%=*}"
+    N_C="${X##*=}"
+    N_HITS=$(( N_HITS + 1 ))
+    N_F="$(_n_streak_file "$HROLE" "$N_P")"
+    N_KEEP="$N_KEEP ${N_F##*/}"
+    STK="$(n_streak_bump "$HROLE" "$N_P" "$N_C")"
+    if [ "$STK" -lt 0 ]; then
+      echo "[nixdirt] 🔴 $HROLE $N_P: UNTRACKED in a NIX-READ path ($N_C), and the streak under"
+      echo "[nixdirt]   $DRIFT_STATE_DIR could not be persisted, so 'for how long' is"
+      echo "[nixdirt]   unknowable — ESCALATING (rc 23)."
+      N_ESCALATED=$(( N_ESCALATED + 1 ))
+      note_rc 23
+    elif [ "$STK" -ge "$DRIFT_NIXDIRT_ESCALATE" ]; then
+      # The whole claim on ONE line — host, path, class, streak and threshold —
+      # for the reason the rc 18 line gives: a guard on half a sentence is
+      # walkable by rewording the other half.
+      echo "[nixdirt] 🔴 DRIFT — $HROLE $N_P: UNTRACKED in a NIX-READ path ($N_C) for $STK CONSECUTIVE runs (threshold $DRIFT_NIXDIRT_ESCALATE)."
+      if [ "$N_C" = LIVE ]; then
+        echo "[nixdirt]   LIVE: the deployed path is a mkOutOfStoreSymlink back into that working"
+        echo "[nixdirt]   tree, so this file is being SERVED on that host right now — with no"
+        echo "[nixdirt]   commit, no backup and no other host holding a copy."
+      else
+        echo "[nixdirt]   STORE: nix reads it at eval/build time, so every generation built on"
+        echo "[nixdirt]   that host carries it — with no commit, no backup and no other host"
+        echo "[nixdirt]   holding a copy."
+      fi
+      echo "[nixdirt]   fix: commit it, delete it, or gitignore it on that host, then re-run."
+      N_ESCALATED=$(( N_ESCALATED + 1 ))
+      note_rc 23
+    else
+      echo "[nixdirt] $HROLE $N_P: UNTRACKED in a NIX-READ path ($N_C) — $STK/$DRIFT_NIXDIRT_ESCALATE consecutive; NOT escalated."
+      echo "[nixdirt]   Still not a pass: that content exists on exactly one machine."
+    fi
+  done
+
+  # The complement — every counter this host kept that this run did NOT report —
+  # ends its run. A path that was committed, deleted or gitignored is simply
+  # absent from the report, so the state dir is the only place it can be seen.
+  # 🔴 Reached only past the denominator guard above: a host that could not
+  # measure leaves its ladders exactly as they were.
+  for N_F in "$DRIFT_STATE_DIR"/nixdirt-"$HROLE"-*; do
+    [ -f "$N_F" ] || continue
+    case " $N_KEEP " in
+      *" ${N_F##*/} "*) ;;
+      *) n_streak_reset "$N_F" ;;
+    esac
+  done
+done
+
+# 🔴 REPORTING BESIDE THE DENOMINATOR BESIDE THE HITS. `hits=0` is the identical
+# output for "no untracked file is nix-read" and "no nix-read path was ever
+# derived", and only the denominator separates them — so the summary is withheld
+# entirely rather than printed as a clean-looking line over an empty set.
+if [ "$N_REPORTING" = 0 ]; then
+  echo "[nixdirt] NOT EVALUATED — no host returned a nix-untracked fact; obtained from: ${CHECKED:-none}."
+  echo "[nixdirt]   this is not 'nothing is exposed'. No untracked file on any host was classified."
+elif [ "$N_NIXREAD" = 0 ]; then
+  echo "[nixdirt] NOT EVALUATED — $N_REPORTING host(s) answered and between them derived ZERO"
+  echo "[nixdirt]   nix-read paths. A classifier with an empty set calls everything clean."
+else
+  echo "[nixdirt] hosts-reporting=$N_REPORTING untracked=$N_UNTRACKED nix-read-paths=$N_NIXREAD hits=$N_HITS escalated=$N_ESCALATED blind=$N_BLIND"
+fi
+echo
+
 # ── FUZZYCLAW PHASE-2 GATE ────────────────────────────────────────────────────
 # See "THE FUZZYCLAW PHASE-2 GATE" in the header for what this measures and why
 # it is local-only. Here: how it refuses to produce a silent zero.
@@ -2223,6 +2524,10 @@ if [ "$rc" != 0 ]; then
   echo "  rc22=a host's deployed skillOverrides disagree with claude/skill-tiers.json. A host"
   echo "       with NO overrides is NOT ADOPTED, never rc22 — that is the shipped state."
   echo "       (ranks just under rc10 — a behind host carries a stale ledger; ship it first)"
+  echo "  rc23=an UNTRACKED file in a path NIX READS has survived $DRIFT_NIXDIRT_ESCALATE consecutive runs on that"
+  echo "       host — LIVE (a mkOutOfStoreSymlink target, served right now) or STORE (copied"
+  echo "       into the artifact by the next switch). A host whose nix-read set came out EMPTY"
+  echo "       is COULD NOT MEASURE, never rc23. (ranks between rc15 and rc12; see severity() )"
 fi
 [ -n "$UNCHECKED" ] && echo "drift-check: NOT checked: $UNCHECKED"
 exit "$rc"

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -517,6 +517,16 @@
 #                        has been SITTING there. Deliberately NOT forwarded over
 #                        ssh — the ladder is kept by the host running the driver,
 #                        for both hosts' paths.
+#   DRIFT_NIXDIRT_MAX    max nix-read untracked paths ENUMERATED per host
+#                        (default 10, integer >= 1). 🔴 A LISTING BOUND ONLY —
+#                        `hits=` on the FACT line is the finding and is never
+#                        capped, and the driver refuses a report whose `listed=`
+#                        disagrees with the pairs it can see. Floored at 1 rather
+#                        than merely non-negative: 0 emitted no pairs, so the
+#                        ladder walked nothing and rc 23 was disabled with the
+#                        summary still printing a clean-looking `hits=0` over a
+#                        real denominator. IS forwarded over ssh (the enumeration
+#                        happens on each host), hence require_positive_int + %q.
 #   DRIFT_STATE_DIR  where the unreachable, unmeasured and nix-dirt streaks are
 #                    persisted
 #                    (default ${XDG_STATE_HOME:-$HOME/.local/state}/drift-check)
@@ -598,6 +608,17 @@ DRIFT_NIXDIRT_ESCALATE="${DRIFT_NIXDIRT_ESCALATE:-12}"
 # `claude/skills` is a whole-directory STORE source, so an untracked,
 # non-gitignored subtree under it emits one FACT token, journal lines AND a state
 # file per path — unbounded, on a unit whose only output is the journal.
+#
+# 🔴 IT BOUNDS ONE RUN'S ENUMERATION, NOT THE STATE DIR OVER TIME. A counter is
+# created per (host, path) that gets emitted, so ten new paths per run still
+# accrete ten new files per run — the cap stops one run from creating a thousand,
+# it does not stop a host's state dir growing monotonically over its lifetime.
+# Nothing prunes DRIFT_STATE_DIR today; the files are a few bytes each and
+# n_streak_reset unlinks one the moment its path stops being reported, which is
+# the only reclamation there is.
+#
+# 🔴 AND IT IS THE ONLY CAP IN THIS FILE THAT COULD CHANGE A VERDICT, which is
+# why it alone is floored at 1. See the require_positive_int call below.
 DRIFT_NIXDIRT_MAX="${DRIFT_NIXDIRT_MAX:-10}"
 DRIFT_STATE_DIR="${DRIFT_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/drift-check}"
 DRIFT_SESSION_MANAGER="${DRIFT_SESSION_MANAGER:-$_drift_dir/session-manager}"
@@ -615,6 +636,26 @@ require_int() { # require_int <name> <value>
     ''|*[!0-9]*) echo "drift-check: $1 must be a non-negative integer, got: $2" >&2; exit 2 ;;
   esac
 }
+# 🔴 ZERO IS NOT A HARMLESS BOUND WHEN THE BOUND FEEDS A VERDICT. require_int
+# accepts 0, which is right for every pure LISTING cap here — DRIFT_UNTRACKED_MAX
+# and DRIFT_DANGLING_MAX print their counts separately and 0 there honestly means
+# "count them, name none of them". It is wrong for the one cap whose output the
+# DRIVER walks: with DRIFT_NIXDIRT_MAX=0 the payload emitted no pairs, so no
+# streak was bumped, nothing escalated, and four consecutive runs over three
+# genuinely untracked nix-read files returned [0,0,0,0] instead of [0,0,23,23] —
+# rc 23 silently switched off from an env var, with the summary still printing a
+# clean-looking `hits=0` beside a real non-zero denominator. So this one has a
+# FLOOR, and the floor is stated in the message rather than left to be inferred.
+require_positive_int() { # require_positive_int <name> <value>
+  case "$2" in
+    ''|*[!0-9]*) echo "drift-check: $1 must be an integer >= 1, got: $2" >&2; exit 2 ;;
+    0) echo "drift-check: $1 must be an integer >= 1, got: 0" >&2
+       echo "  0 emits no paths at all, which leaves the rc 23 ladder nothing to walk:" >&2
+       echo "  no streak is bumped and nothing escalates, while the summary still prints" >&2
+       echo "  hits=<n> over a real denominator. That is a verdict turned off by a cap." >&2
+       exit 2 ;;
+  esac
+}
 require_int DRIFT_UNTRACKED_MAX "$DRIFT_UNTRACKED_MAX"
 require_int DRIFT_DANGLING_MAX "$DRIFT_DANGLING_MAX"
 require_int DRIFT_UNREACHABLE_ESCALATE "$DRIFT_UNREACHABLE_ESCALATE"
@@ -629,7 +670,9 @@ require_int DRIFT_UNMEASURED_FETCH_ESCALATE "$DRIFT_UNMEASURED_FETCH_ESCALATE"
 require_int DRIFT_NIXDIRT_ESCALATE "$DRIFT_NIXDIRT_ESCALATE"
 # Interpolated into the payload that runs on the OTHER host — same reason
 # DRIFT_UNTRACKED_MAX is validated: a non-integer here is remote code execution.
-require_int DRIFT_NIXDIRT_MAX "$DRIFT_NIXDIRT_MAX"
+# require_positive_int, not require_int: see its header for the measured
+# [0,0,0,0] this floor exists to refuse.
+require_positive_int DRIFT_NIXDIRT_MAX "$DRIFT_NIXDIRT_MAX"
 # Not interpolated into a remote payload — but it IS handed to `timeout`, where a
 # non-integer would make the phase-2 scan fail in a way that reads as "the tool
 # is broken" rather than "you passed nonsense".
@@ -825,13 +868,28 @@ fi
 # record — the same reason the rc 13 and rc 18 ladders are there.
 #
 # The FACT line is the contract with the driver and its shape is deliberate:
-#   FACT nix-untracked untracked=<N> nixread=<M> reason=<TOKEN> [<path>=<REACH>]…
-# The two counts are emitted UNCONDITIONALLY, including as zeros, because a
+#   FACT nix-untracked untracked=<N> nixread=<M> hits=<H> listed=<L> reason=<TOKEN> [<path>=<REACH>]…
+# The counts are emitted UNCONDITIONALLY, including as zeros, because a
 # driver that sees no pairs must be able to tell "this host has no untracked
 # nix-read files" from "the nix-read set came out empty and every file on every
 # host is therefore clean". Pairs are told apart from the header fields by their
 # VALUE — LIVE or DROPPED, the whole reach vocabulary — so a repo-root file
 # called `reason` cannot be read as a header field.
+#
+# 🔴 `hits=` EXISTS BECAUSE THE PAIR LIST IS CAPPED AND THE FINDING IS NOT. The
+# driver used to COUNT the pairs to get its hit total, so DRIFT_NIXDIRT_MAX
+# truncated the machine-readable contract as well as the human listing: measured
+# with 15 untracked nix-read files, the human line correctly said `15 of 15`
+# while the FACT line carried 10 pairs with no marker at all (the `... and N
+# more` note goes to `say`, which the driver does not parse) and the summary
+# printed `hits=10`. A count derived from a truncated list is a smaller version
+# of the reassuring-zero this whole block refuses, so the count now travels as
+# its own field and the list is only ever evidence.
+#
+# `listed=` is what makes `hits=` checkable rather than merely asserted: the
+# driver cross-checks it against the pairs it can actually see and refuses the
+# whole report if they disagree, which is the only way a stream truncated in
+# transit is distinguishable from a host that had nothing more to say.
 #
 # 🔴 THE PAIR CARRIES THE REACH, NOT THE CLASS, and that is a correction. A STORE
 # class says nix READS the path; it does NOT say the file got into the artifact,
@@ -866,16 +924,25 @@ if [ "$NU_REASON" = OK ] && [ "$n" != 0 ]; then
     # 🔴 HITS COUNTS ALL OF THEM; only the EMITTED pairs are capped. The count is
     # the finding and must never be truncated — a cap that silently shrank the
     # number would be a smaller version of the reassuring-zero this file refuses.
-    case "$(nix_read_artifact_reach "$(nix_read_class_of "$NU_P")" 0)" in
-      LIVE)
+    #
+    # 🔴 ONE CAP PREDICATE, NOT ONE PER CLASS. LIVE and DROPPED used to carry
+    # their own copy of `hit++ ; emit if under the cap`, and a mutation sweep
+    # showed why that is not merely repetition: mutating the cap in the LIVE arm
+    # SURVIVED the full suite, because reaching it needs more untracked
+    # mkOutOfStoreSymlink targets than any fixture has, so no test of the
+    # DROPPED arm could ever see it. Two copies is two things to cover; one is
+    # one.
+    #
+    # 🔴 NO APOSTROPHE ANYWHERE IN THIS PAYLOAD, comments included. CONVERGE-like
+    # single-quoted strings end at the first quote: the first draft of this very
+    # comment wrote "the DROPPED arm-apostrophe-s test" and broke 173 tests at
+    # once, exactly as ship.sh warns about its own empty-string literal.
+    NU_R="$(nix_read_artifact_reach "$(nix_read_class_of "$NU_P")" 0)"
+    case "$NU_R" in
+      LIVE|DROPPED)
         NU_HITS=$(( NU_HITS + 1 ))
         if [ "$NU_EMIT" -lt "$NU_MAX" ]; then
-          NU_PAIRS="$NU_PAIRS $NU_P=LIVE"; NU_EMIT=$(( NU_EMIT + 1 ))
-        fi ;;
-      DROPPED)
-        NU_HITS=$(( NU_HITS + 1 ))
-        if [ "$NU_EMIT" -lt "$NU_MAX" ]; then
-          NU_PAIRS="$NU_PAIRS $NU_P=DROPPED"; NU_EMIT=$(( NU_EMIT + 1 ))
+          NU_PAIRS="$NU_PAIRS $NU_P=$NU_R"; NU_EMIT=$(( NU_EMIT + 1 ))
         fi ;;
       UNREPRESENTABLE) NU_UNREP=$(( NU_UNREP + 1 )) ;;
     esac
@@ -897,10 +964,10 @@ else
   done
   # The same "... and N more" shape every other capped listing in this file uses,
   # so a truncated list can never be mistaken for the whole set.
-  [ "$NU_HITS" -gt "$NU_EMIT" ] && say "    ... and $(( NU_HITS - NU_EMIT )) more"
+  [ "$NU_HITS" -gt "$NU_EMIT" ] && say "    ... and $(( NU_HITS - NU_EMIT )) more (DRIFT_NIXDIRT_MAX=$NU_MAX)"
 fi
 [ "$NU_UNREP" != 0 ] && say "  ($NU_UNREP untracked path(s) NOT CLASSIFIED — a character the classifier does not model)"
-echo "[$label] FACT nix-untracked untracked=$n nixread=$NU_M reason=$NU_REASON$NU_PAIRS"
+echo "[$label] FACT nix-untracked untracked=$n nixread=$NU_M hits=$NU_HITS listed=$NU_EMIT reason=$NU_REASON$NU_PAIRS"
 
 # --- Which branch is checked out? ---------------------------------------------
 branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo DETACHED)
@@ -2318,6 +2385,7 @@ N_REPORTING=0
 N_UNTRACKED=0
 N_NIXREAD=0
 N_HITS=0
+N_LISTED=0
 N_ESCALATED=0
 N_BLIND=0
 for HROLE in "$LOCAL_ROLE" "$REMOTE_ROLE"; do
@@ -2338,34 +2406,60 @@ for HROLE in "$LOCAL_ROLE" "$REMOTE_ROLE"; do
   # was dropped, silently, in the direction of "nothing to see". LIVE and DROPPED
   # are the whole reach vocabulary and no header field can take either value, so
   # matching the pairs first cannot swallow a header key.
-  N_UNT=-1; N_MM=-1; N_RSN=""; N_PAIRS=""
+  N_UNT=-1; N_MM=-1; N_HIT=-1; N_LST=-1; N_RSN=""; N_PAIRS=""; N_SEEN=0
   for X in $N_LINE; do
     case "$X" in
-      *=LIVE|*=DROPPED) N_PAIRS="$N_PAIRS $X" ;;
+      *=LIVE|*=DROPPED) N_PAIRS="$N_PAIRS $X"; N_SEEN=$(( N_SEEN + 1 )) ;;
       untracked=*)      N_UNT="${X#untracked=}" ;;
       nixread=*)        N_MM="${X#nixread=}" ;;
+      hits=*)           N_HIT="${X#hits=}" ;;
+      listed=*)         N_LST="${X#listed=}" ;;
       reason=*)         N_RSN="${X#reason=}" ;;
     esac
   done
   case "$N_UNT" in ''|*[!0-9]*) N_UNT=-1 ;; esac
   case "$N_MM" in ''|*[!0-9]*) N_MM=-1 ;; esac
+  # 🔴 NOT DEFAULTED, and never derived from the pairs. A missing or unparseable
+  # `hits=` is a report this driver cannot read, and the one thing it must not do
+  # is fall back to counting the list — that IS the bug this field was added to
+  # remove. -1 here lands on the refusal below.
+  case "$N_HIT" in ''|*[!0-9]*) N_HIT=-1 ;; esac
+  case "$N_LST" in ''|*[!0-9]*) N_LST=-1 ;; esac
 
-  if [ "$N_RSN" != OK ] || [ "$N_UNT" -lt 0 ] || [ "$N_MM" -le 0 ]; then
-    echo "[nixdirt] $HROLE: COULD NOT MEASURE — reason=${N_RSN:-ABSENT} untracked=$N_UNT nix-read-paths=$N_MM."
+  if [ "$N_RSN" != OK ] || [ "$N_UNT" -lt 0 ] || [ "$N_MM" -le 0 ] \
+     || [ "$N_HIT" -lt 0 ] || [ "$N_LST" -lt 0 ]; then
+    echo "[nixdirt] $HROLE: COULD NOT MEASURE — reason=${N_RSN:-ABSENT} untracked=$N_UNT nix-read-paths=$N_MM hits=$N_HIT listed=$N_LST."
     echo "[nixdirt]   With no derived nix-read set every untracked file on that host classifies"
     echo "[nixdirt]   as harmless. That is not a finding of none: nothing was bumped, nothing"
     echo "[nixdirt]   was reset, and NO code is set for it."
     N_BLIND=$(( N_BLIND + 1 ))
     continue
   fi
+  # 🔴 THE INTEGRITY CHECK THAT MAKES `listed=` LOAD-BEARING. The emitter says how
+  # many pairs it put on the line; this counts how many arrived. They disagree
+  # only if the line was mangled or truncated in transit (the remote leg's stdout
+  # crosses an ssh hop), and a partial pair list read as a complete one would end
+  # every missing path's streak in the complement loop below — silently, in the
+  # direction of "nothing to see". So a disagreement is refused, not repaired.
+  if [ "$N_SEEN" != "$N_LST" ]; then
+    echo "[nixdirt] $HROLE: COULD NOT MEASURE — the report claims listed=$N_LST path(s) but $N_SEEN arrived."
+    echo "[nixdirt]   The pair list does not match its own declared length, so this line was"
+    echo "[nixdirt]   mangled or truncated between that host and here. Nothing was bumped,"
+    echo "[nixdirt]   nothing was reset, and NO code is set for it."
+    N_BLIND=$(( N_BLIND + 1 ))
+    continue
+  fi
   N_UNTRACKED=$(( N_UNTRACKED + N_UNT ))
   N_NIXREAD=$(( N_NIXREAD + N_MM ))
+  # 🔴 THE REPORTED TOTAL, never the length of the list. See the FACT-line header
+  # in the payload for the measured 15-vs-10.
+  N_HITS=$(( N_HITS + N_HIT ))
+  N_LISTED=$(( N_LISTED + N_LST ))
 
   N_KEEP=""
   for X in $N_PAIRS; do
     N_P="${X%=*}"
     N_C="${X##*=}"
-    N_HITS=$(( N_HITS + 1 ))
     N_F="$(_n_streak_file "$HROLE" "$N_P")"
     N_KEEP="$N_KEEP ${N_F##*/}"
     STK="$(n_streak_bump "$HROLE" "$N_P" "$N_C")"
@@ -2406,18 +2500,40 @@ for HROLE in "$LOCAL_ROLE" "$REMOTE_ROLE"; do
     fi
   done
 
-  # The complement — every counter this host kept that this run did NOT report —
-  # ends its run. A path that was committed, deleted or gitignored is simply
-  # absent from the report, so the state dir is the only place it can be seen.
-  # 🔴 Reached only past the denominator guard above: a host that could not
-  # measure leaves its ladders exactly as they were.
-  for N_F in "$DRIFT_STATE_DIR"/nixdirt-"$HROLE"-*; do
-    [ -f "$N_F" ] || continue
-    case " $N_KEEP " in
-      *" ${N_F##*/} "*) ;;
-      *) n_streak_reset "$N_F" ;;
-    esac
-  done
+  # 🔴 A TRUNCATED LIST CANNOT CLEAR A LADDER. The complement loop below reads
+  # "absent from the report" as "this path is untracked no more" — true only when
+  # the report is COMPLETE. Once DRIFT_NIXDIRT_MAX has cut the enumeration,
+  # absence also means "it was pushed out of the window", and a path that has
+  # been sitting there for eleven runs would have its streak reset by a busy run
+  # that listed ten other paths ahead of it. The two causes are indistinguishable
+  # from here, so the ladders are LEFT ALONE and the run says why. Same rule as
+  # the COULD-NOT-MEASURE arm above: a ladder cleared by evidence that cannot
+  # support the claim is worse than a ladder that stands still.
+  if [ "$N_HIT" -gt "$N_LST" ]; then
+    # Hoisted, not inlined: `$((` inside a quoted message ends the printer
+    # segment for the command-word scanner in test_drift_check.py, and the rest
+    # of the sentence then reads as a command line. See _PROSE_NOT_COMMANDS —
+    # keeping the arithmetic out of the string is cheaper than declaring six
+    # more English words to be prose.
+    N_MISS=$(( N_HIT - N_LST ))
+    echo "[nixdirt] $HROLE: LISTING TRUNCATED — $N_HIT hit(s), $N_LST enumerated, $N_MISS not named (DRIFT_NIXDIRT_MAX=$DRIFT_NIXDIRT_MAX)."
+    echo "[nixdirt]   The COUNT is complete; the paths are not. No streak was reset on this"
+    echo "[nixdirt]   host this run — absence from a truncated list is not evidence that a"
+    echo "[nixdirt]   path stopped being untracked. Raise DRIFT_NIXDIRT_MAX to see them all."
+  else
+    # The complement — every counter this host kept that this run did NOT report —
+    # ends its run. A path that was committed, deleted or gitignored is simply
+    # absent from the report, so the state dir is the only place it can be seen.
+    # 🔴 Reached only past the denominator guard above: a host that could not
+    # measure leaves its ladders exactly as they were.
+    for N_F in "$DRIFT_STATE_DIR"/nixdirt-"$HROLE"-*; do
+      [ -f "$N_F" ] || continue
+      case " $N_KEEP " in
+        *" ${N_F##*/} "*) ;;
+        *) n_streak_reset "$N_F" ;;
+      esac
+    done
+  fi
 done
 
 # 🔴 REPORTING BESIDE THE DENOMINATOR BESIDE THE HITS. `hits=0` is the identical
@@ -2431,7 +2547,18 @@ elif [ "$N_NIXREAD" = 0 ]; then
   echo "[nixdirt] NOT EVALUATED — $N_REPORTING host(s) answered and between them derived ZERO"
   echo "[nixdirt]   nix-read paths. A classifier with an empty set calls everything clean."
 else
-  echo "[nixdirt] hosts-reporting=$N_REPORTING untracked=$N_UNTRACKED nix-read-paths=$N_NIXREAD hits=$N_HITS escalated=$N_ESCALATED blind=$N_BLIND"
+  # 🔴 `listed=` BESIDE `hits=`, for the reason the denominator sits beside them
+  # both: they are equal on almost every run, and the run where they are NOT is
+  # the run whose per-path lines are incomplete. Printing `hits=` alone would put
+  # a complete-looking number over a list that names fewer paths, which is the
+  # shape an operator reads as "here is everything".
+  echo "[nixdirt] hosts-reporting=$N_REPORTING untracked=$N_UNTRACKED nix-read-paths=$N_NIXREAD hits=$N_HITS listed=$N_LISTED escalated=$N_ESCALATED blind=$N_BLIND"
+  # Hoisted out of the message: `$((` inside a quoted string ends the printer
+  # segment for test_drift_check.py's command-word scanner, and the rest of the
+  # sentence then reads as a command line (see _PROSE_NOT_COMMANDS there).
+  N_UNNAMED=$(( N_HITS - N_LISTED ))
+  [ "$N_UNNAMED" -gt 0 ] && \
+    echo "[nixdirt]   $N_UNNAMED hit(s) counted but NOT named above — raise DRIFT_NIXDIRT_MAX (now $DRIFT_NIXDIRT_MAX) to enumerate them."
 fi
 echo
 

--- a/scripts/lib/nix_read_paths.sh
+++ b/scripts/lib/nix_read_paths.sh
@@ -1,0 +1,262 @@
+# shellcheck shell=bash
+# nix_read_paths.sh — "is this repo path READ BY NIX?", derived, never hardcoded.
+#
+# SOURCE THIS, do not execute it. It defines functions and sets nothing at
+# source time (test_nix_read_paths.py pins that), exactly like lib/host-role.sh.
+#
+# ── WHY IT EXISTS ─────────────────────────────────────────────────────────────
+# Two consumers need the SAME question answered and they are the two safety
+# instruments of this repo:
+#
+#   * scripts/ship.sh   — a converge on a DIRTY tree used to end with a flat
+#     "what was built/deployed is origin/main + local WIP". Honest, and
+#     unactionable: nobody could tell whether the dirt was IN the artifact. On
+#     2026-08-25 the workbench's two dirty paths were
+#     nix/system/apply-nebula-443.sh.LOCAL-preserved-2026-08-02 (nix reads
+#     nothing under nix/system/ — those are staged sudo scripts) and
+#     scripts/dl-router/tests/load_test_store.sh (which IS read: home.nix says
+#     `${../scripts/dl-router}` and copies the WHOLE directory into the store).
+#     A hand-written list would have got the second one wrong. This derives it.
+#
+#   * scripts/drift-check.sh — an untracked file in a nix-read path is code
+#     being SERVED by a host with no commit and no backup behind it.
+#
+# A predicate open-coded at two sites is typically wrong at one of them in the
+# same direction (claude/RULES.md, "One rule, one place"), so there is one copy
+# and both call it. test_nix_read_paths.py::test_the_predicate_has_exactly_one
+# _definition is the ledger that keeps it that way.
+#
+# ── THE TWO CLASSES, and why they are not one ─────────────────────────────────
+#   LIVE   `config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/<p>"`.
+#          The deployed path is a symlink BACK INTO the working tree, so an edit
+#          is deployed CONTINUOUSLY — no `home-manager switch`, no signal, no
+#          generation boundary. Dirty here means "this host is running your WIP
+#          right now".
+#   STORE  a nix path literal (`source = ../claude/RULES.md`, `${../scripts/
+#          dl-router}`, `builtins.readFile ../../../.zshrc`, …). Nix reads it at
+#          eval/build time, so it lands in the artifact the NEXT switch builds.
+#          Dirty here means "your WIP is in the generation ship.sh just built".
+#
+# The consequences differ (one needs no switch and has no boundary; the other is
+# pinned to a generation), so the classes are reported separately rather than
+# folded into one "nix-read" bit.
+#
+# ── DERIVED, NEVER HARDCODED ──────────────────────────────────────────────────
+# Same discipline as drift-check.sh's built-source set, which is "derived from
+# nix/pkgs/ at scan time and pinned two-way by a test, so a third such package is
+# covered automatically". Here the scan input is the FLAKE'S OWN ENTRY POINTS —
+# NIXREAD_ROOT_FILES and NIXREAD_ROOT_DIRS below — and everything else is read
+# out of the .nix files found under them. Add a 13th mkOutOfStoreSymlink and it
+# is covered with no edit here.
+#
+# 🔴 THE SCAN ROOTS ARE THE ONLY LITERALS, and they are the scanner's INPUT, not
+# a list of answers. They are pinned by test_nix_read_paths.py (they must exist,
+# and the .nix files under them must be found), because a root that stops
+# existing turns this whole file into a scanner wired to nothing — which returns
+# an empty set, which reads to both consumers as a reassuring "nothing is
+# nix-read". Every entry point therefore reports NIXREAD_FILES beside its answer
+# and every consumer is required to print it.
+#
+# ── WHAT IT CANNOT SEE (stated so nobody reads more into a NONE than is there) ─
+#   * The path alphabet is [A-Za-z0-9._/-] — the same one drift-check.sh's
+#     source scan uses. A repo path with a space, a quote or a non-ASCII byte is
+#     NOT classified; nix_read_class_of returns UNREPRESENTABLE for it, which
+#     callers must report rather than treat as NONE.
+#   * Comment stripping is `${LN%%#*}`, so a path mentioned after a `#` on a code
+#     line is dropped. That can only ever SHRINK the derived set; the two-way pin
+#     in the test is what makes a shrink loud.
+#   * A path reached only through a nix STRING built at eval time
+#     ("${toString ./.}/x") is invisible. None exist today; the two-way pin
+#     covers the `source =` and mkOutOfStoreSymlink spellings that do.
+#   * It answers "does nix READ it", never "does the deployed artifact still
+#     match" — that is ship.sh's verify_managed_currency, and neither replaces
+#     the other.
+
+# The scan roots. Repo-relative. Files first, then directories walked for *.nix.
+NIXREAD_ROOT_FILES="flake.nix flake.lock"
+NIXREAD_ROOT_DIRS="nix"
+
+# Every character that cannot appear in a repo path we are willing to classify.
+# Held in a variable because `${v//[!…/…]/ }` would otherwise end its pattern at
+# the literal `/` inside the bracket expression: the delimiters are parsed off
+# the EXPRESSION TEXT, so a `/` arriving by expansion is data, not a delimiter.
+NIXREAD_NONPATH='[!A-Za-z0-9._/-]'
+
+# Populated by nix_read_scan. Declared here so `set -u` consumers can read them
+# before a scan and get "" rather than an unbound-variable death.
+NIXREAD_LIVE=""       # space-separated repo-relative paths, mkOutOfStoreSymlink
+NIXREAD_STORE=""      # space-separated repo-relative paths, nix path literals
+NIXREAD_FILES=0       # .nix files actually READ — the population, always report it
+NIXREAD_COUNT=0       # |LIVE| + |STORE|
+NIXREAD_MISSING=""    # derived paths that do NOT exist in the repo (a fault)
+NIXREAD_REASON=""     # OK | NOREPO | NOROOTS | NOSCAN
+
+_nixread_add() { # _nixread_add <LIVE|STORE> <repo-relative-path>
+  case "$1" in
+    LIVE)
+      case " $NIXREAD_LIVE " in *" $2 "*) return 0 ;; esac
+      NIXREAD_LIVE="$NIXREAD_LIVE $2" ;;
+    *)
+      case " $NIXREAD_STORE " in *" $2 "*) return 0 ;; esac
+      NIXREAD_STORE="$NIXREAD_STORE $2" ;;
+  esac
+}
+
+# _nixread_take_live <line> — every ${workspace}/devrc/<path> the line names.
+# Only called for lines that also contain mkOutOfStoreSymlink: that interpolation
+# is what makes the deployed link point at the WORKING TREE, and it is the whole
+# difference between the two classes.
+_nixread_take_live() {
+  local L="$1" REST PP
+  while : ; do
+    case "$L" in *"\${workspace}/devrc/"*) ;; *) break ;; esac
+    REST="${L#*"\${workspace}/devrc/"}"
+    PP="${REST%%$NIXREAD_NONPATH*}"
+    PP="${PP%/}"
+    [ -n "$PP" ] && _nixread_add LIVE "$PP"
+    L="$REST"
+  done
+}
+
+# _nixread_resolve <token> <dir-of-the-nix-file, repo-relative> -> repo-relative
+# path on stdout, or nothing when the token escapes the repo root.
+#
+# `../` is resolved against the FILE'S OWN directory, which is why the walk is
+# per-file and not per-repo: nix/home.nix's `../scripts/x` and
+# nix/programs/zsh/default.nix's `../../../.zshrc` both mean a repo path, and
+# they mean different depths.
+_nixread_resolve() {
+  local T="$1" D="$2"
+  case "$T" in ./*) T="${T#./}" ;; esac
+  while : ; do
+    case "$T" in ../*) ;; *) break ;; esac
+    # No directory left to climb: the literal points OUTSIDE the repo. Nix would
+    # still read it, but it is not a path any consumer of ours can see as dirty.
+    [ -n "$D" ] || return 0
+    T="${T#../}"
+    case "$D" in */*) D="${D%/*}" ;; *) D="" ;; esac
+  done
+  # A `..` surviving in the middle is a shape this resolver does not model;
+  # dropping it is safe (it can only shrink the set) and the two-way pin is what
+  # would make a real one loud.
+  #
+  # 🔴 `.` — THE REPO ROOT ITSELF — IS DROPPED, DELIBERATELY, and it is the one
+  # exclusion that changes the answer for every path in the repo. flake.nix's
+  # `cp -r ${./.} src` is real and it does read the whole tree, but only to build
+  # the `checks.*` derivations (`nix build .#checks.…pytests`), which are not the
+  # home-manager artifact either consumer is asking about. Keeping it would make
+  # nix_read_class_of answer STORE for literally everything, and a predicate that
+  # is always true tells nobody anything.
+  case "$T" in ""|"."|*..*|/*) return 0 ;; esac
+  if [ -n "$D" ]; then printf '%s\n' "$D/$T"; else printf '%s\n' "$T"; fi
+}
+
+# nix_read_scan <repo> — populate the module variables. Returns 0 when the scan
+# is USABLE (it read at least one .nix file and derived at least one path), 1
+# otherwise, with NIXREAD_REASON naming which. 🔴 A caller that ignores the
+# return value gets an empty set, which is exactly the reassuring zero this file
+# is built to refuse.
+nix_read_scan() {
+  local REPO="$1" F D T P
+  NIXREAD_LIVE=""; NIXREAD_STORE=""; NIXREAD_MISSING=""
+  NIXREAD_FILES=0; NIXREAD_COUNT=0; NIXREAD_REASON=""
+
+  if [ -z "$REPO" ] || [ ! -d "$REPO" ]; then
+    NIXREAD_REASON=NOREPO
+    return 1
+  fi
+
+  # globstar for the recursive walk, restored to whatever the caller had. This
+  # library is SOURCED into two long-lived scripts; leaving a shell option
+  # flipped under them would be a side effect, and side effects here are pinned
+  # against by test_the_lib_is_side_effect_free_when_sourced.
+  local WANT_GS=0 WANT_NG=0
+  shopt -q globstar || WANT_GS=1
+  shopt -q nullglob || WANT_NG=1
+  shopt -s globstar nullglob
+
+  local ROOTS_SEEN=0
+  for T in $NIXREAD_ROOT_FILES; do
+    [ -f "$REPO/$T" ] || continue
+    ROOTS_SEEN=$(( ROOTS_SEEN + 1 ))
+    _nixread_add STORE "$T"
+    case "$T" in *.nix) _nixread_scan_file "$REPO/$T" "" ;; esac
+  done
+  for D in $NIXREAD_ROOT_DIRS; do
+    [ -d "$REPO/$D" ] || continue
+    ROOTS_SEEN=$(( ROOTS_SEEN + 1 ))
+    # 🔴 WALKED IS NOT THE SAME AS READ. Every .nix under here is SCANNED for
+    # path literals, but a file only joins the STORE set when something REACHES
+    # it — flake.nix names ./nix/home.nix, which names ./graphical.nix and
+    # ./pkgs, and so on down. Adding each walked file (or the directory) instead
+    # would classify nix/system/*.nix and every staged sudo script beside them as
+    # nix-read, and nix opens none of those: they are hand-run under sudo against
+    # /etc/nixos, outside the flake entirely. Measured 2026-08-25 — the
+    # workbench's dirty
+    # nix/system/apply-nebula-443.sh.LOCAL-preserved-2026-08-02 comes out STORE
+    # under the walked-is-read spelling and NONE under this one, and NONE is the
+    # true answer.
+    for F in "$REPO/$D"/**/*.nix; do
+      [ -f "$F" ] || continue
+      P="${F#"$REPO/"}"
+      case "$P" in */*) _nixread_scan_file "$F" "${P%/*}" ;; *) _nixread_scan_file "$F" "" ;; esac
+    done
+  done
+
+  [ "$WANT_GS" = 1 ] && shopt -u globstar
+  [ "$WANT_NG" = 1 ] && shopt -u nullglob
+
+  NIXREAD_LIVE="${NIXREAD_LIVE# }"
+  NIXREAD_STORE="${NIXREAD_STORE# }"
+  for T in $NIXREAD_LIVE $NIXREAD_STORE; do
+    NIXREAD_COUNT=$(( NIXREAD_COUNT + 1 ))
+    [ -e "$REPO/$T" ] || NIXREAD_MISSING="$NIXREAD_MISSING $T"
+  done
+  NIXREAD_MISSING="${NIXREAD_MISSING# }"
+
+  if [ "$ROOTS_SEEN" = 0 ]; then NIXREAD_REASON=NOROOTS; return 1; fi
+  if [ "$NIXREAD_FILES" = 0 ] || [ "$NIXREAD_COUNT" = 0 ]; then
+    NIXREAD_REASON=NOSCAN; return 1
+  fi
+  NIXREAD_REASON=OK
+  return 0
+}
+
+# _nixread_scan_file <abs-path> <repo-relative-dir-of-that-file>
+_nixread_scan_file() {
+  local LN WORDS W R
+  NIXREAD_FILES=$(( NIXREAD_FILES + 1 ))
+  while IFS= read -r LN || [ -n "$LN" ]; do
+    LN="${LN%%#*}"
+    [ -n "$LN" ] || continue
+    case "$LN" in *mkOutOfStoreSymlink*) _nixread_take_live "$LN" ;; esac
+    case "$LN" in *./*) ;; *) continue ;; esac
+    WORDS="${LN//$NIXREAD_NONPATH/ }"
+    for W in $WORDS; do
+      case "$W" in ../*|./*) ;; *) continue ;; esac
+      R="$(_nixread_resolve "$W" "$2")"
+      [ -n "$R" ] && _nixread_add STORE "$R"
+    done
+  done < "$1"
+}
+
+# nix_read_class_of <repo-relative-path> -> LIVE | STORE | NONE | UNREPRESENTABLE
+#
+# MOST SPECIFIC WINS, and that is the point: `scripts/dl-router` is STORE (the
+# whole directory is copied into the store) while `scripts/dl-router/dl-route`
+# is LIVE (a mkOutOfStoreSymlink onto that one file). A path is matched against
+# itself and then each ancestor, nearest first; at one level LIVE outranks STORE
+# because "already deployed, no switch needed" is the stronger claim.
+#
+# 🔴 Requires a prior nix_read_scan. With an empty set every answer is NONE,
+# which is why nix_read_scan's return value is not optional.
+nix_read_class_of() {
+  local P="$1"
+  case "$P" in ""|*$NIXREAD_NONPATH*) printf 'UNREPRESENTABLE\n'; return 0 ;; esac
+  while : ; do
+    case " $NIXREAD_LIVE " in *" $P "*) printf 'LIVE\n'; return 0 ;; esac
+    case " $NIXREAD_STORE " in *" $P "*) printf 'STORE\n'; return 0 ;; esac
+    case "$P" in */*) P="${P%/*}" ;; *) break ;; esac
+  done
+  printf 'NONE\n'
+}

--- a/scripts/lib/nix_read_paths.sh
+++ b/scripts/lib/nix_read_paths.sh
@@ -41,6 +41,10 @@
 # pinned to a generation), so the classes are reported separately rather than
 # folded into one "nix-read" bit.
 #
+# 🔴 A STORE CLASSIFICATION IS NOT YET A CLAIM THAT THE FILE REACHED THE
+# ARTIFACT — and the first version of this file said it was. See
+# nix_read_artifact_reach below for the measurement and the rule.
+#
 # ── DERIVED, NEVER HARDCODED ──────────────────────────────────────────────────
 # Same discipline as drift-check.sh's built-source set, which is "derived from
 # nix/pkgs/ at scan time and pinned two-way by a test, so a third such package is
@@ -259,4 +263,49 @@ nix_read_class_of() {
     case "$P" in */*) P="${P%/*}" ;; *) break ;; esac
   done
   printf 'NONE\n'
+}
+
+# nix_read_artifact_reach <class> <1 if git KNOWS the path, else 0>
+#   -> LIVE | ARTIFACT | DROPPED | NONE | UNREPRESENTABLE
+#
+# 🔴 THE CLASS ALONE OVERSTATES, AND THIS IS WHERE THAT IS FIXED. A STORE
+# classification says "nix reads this path". It does NOT say the file reached the
+# built artifact, because nix's flake source for a git checkout is FILTERED to
+# the files git knows about — CLAUDE.md already says so from the other side ("A
+# NEW file must be `git add`ed or the flake silently omits it from the deploy"),
+# and the first version of this library ignored it.
+#
+# MEASURED 2026-08-25, one directory, one build, four states, positive control
+# included (scripts/tests/test_nix_read_paths.py pins the same table):
+#   committed, unmodified ....... PRESENT (committed content)
+#   committed, MODIFIED ......... PRESENT — with the WORKING-TREE content
+#   `git add`ed, never committed  PRESENT — with the WORKING-TREE content
+#   staged then modified again .. PRESENT — with the LATEST working-tree content
+#   UNTRACKED ................... ABSENT, at every depth
+# and corroborated on the live host: all six `-dl-router` store generations carry
+# `tests/` (37 files) and NONE carries the untracked `tests/load_test_store.sh`.
+#
+# So the discriminator is INDEX MEMBERSHIP, not commitment: `git ls-files
+# --error-unmatch <p>`, or equivalently "this path came from `git diff` /
+# `git diff --cached` rather than from `git ls-files --others`". A file staged
+# ten seconds ago is in the artifact; a file committed nowhere but staged is in
+# the artifact; a file never `git add`ed is not, however long it has sat there.
+#
+# 🔴 LIVE IS UNAFFECTED, and that is not an assumption. `mkOutOfStoreSymlink`
+# bakes a runtime PATH STRING into the store, so the deployed link resolves into
+# the working tree at USE time and never through the flake source. Verified on
+# the live host: ~/.claude/skills/browser/browser -> …-home-manager-files/… ->
+# /home/zach/workspace/devrc/scripts/browser-bridge/browser. An untracked file at
+# a LIVE path is therefore genuinely being served.
+#
+# DROPPED is NOT "harmless". The file is unsaved work in no commit and no backup,
+# it sits in a tree nix copies, and a single `git add` moves it into the artifact
+# with no other action — so it is worth reporting. It is simply not worth
+# reporting as something that is already deployed.
+nix_read_artifact_reach() {
+  case "$1" in
+    LIVE)  printf 'LIVE\n' ;;
+    STORE) if [ "${2:-0}" = 1 ]; then printf 'ARTIFACT\n'; else printf 'DROPPED\n'; fi ;;
+    *)     printf '%s\n' "$1" ;;
+  esac
 }

--- a/scripts/lib/nix_read_paths.sh
+++ b/scripts/lib/nix_read_paths.sh
@@ -1,8 +1,14 @@
 # shellcheck shell=bash
 # nix_read_paths.sh — "is this repo path READ BY NIX?", derived, never hardcoded.
 #
-# SOURCE THIS, do not execute it. It defines functions and sets nothing at
-# source time (test_nix_read_paths.py pins that), exactly like lib/host-role.sh.
+# SOURCE THIS, do not execute it. Sourcing it defines functions and initialises
+# this file's own NIXREAD_* variables to empty — and does nothing else: no
+# output, no scan, no exit, no shell options left flipped under the caller
+# (test_nix_read_paths.py pins each of those), exactly like lib/host-role.sh.
+#
+# 🔴 REQUIRES BASH. Both consumers therefore invoke it under an explicitly named
+# bash — `bash -c` locally, `bash -s` over ssh — because sshd otherwise runs the
+# account's login shell, which is zsh on both hosts. See the NOTBASH guard.
 #
 # ── WHY IT EXISTS ─────────────────────────────────────────────────────────────
 # Two consumers need the SAME question answered and they are the two safety
@@ -71,7 +77,25 @@
 #     in the test is what makes a shrink loud.
 #   * A path reached only through a nix STRING built at eval time
 #     ("${toString ./.}/x") is invisible. None exist today; the two-way pin
-#     covers the `source =` and mkOutOfStoreSymlink spellings that do.
+#     covers the `source =`, `${../…}` and mkOutOfStoreSymlink spellings that do.
+#   * 🔴 `_nixread_take_live` needs `mkOutOfStoreSymlink` and the
+#     `${workspace}/devrc/…` string ON ONE LINE. Wrapping a call site (nixfmt, a
+#     longer path) drops that target to NONE. The two-way pin's reverse extractor
+#     deliberately matches WHOLE-FILE so it does NOT share this blind spot — two
+#     extractors that fail identically are one extractor — but the DERIVATION
+#     still has it, so the pin goes red rather than the answer going quietly
+#     wrong. All 12 sites are one-liners today.
+#   * It answers about a GIT CHECKOUT. `nix_read_artifact_reach` encodes the
+#     flake's tracked-file filter; a flake evaluated from a plain directory (no
+#     `.git`) copies everything, and nothing here models that.
+#   * 🔴 IT REQUIRES BASH. `shopt` and word-splitting on an unquoted `$var` have
+#     no zsh equivalent, and both hosts' LOGIN SHELL is zsh — see the NOTBASH
+#     guard in nix_read_scan for what that cost and how it now fails loudly.
+#   * A TRACKED-BUT-DELETED file is reported by `git diff --name-only`, so
+#     ship.sh classes it with the index bucket and says "in the artifact". What
+#     nix actually does with a tracked path missing from the working tree is
+#     UNMEASURED here — stated as unmeasured rather than guessed, because the
+#     four states that ARE measured were each measured, not reasoned about.
 #   * It answers "does nix READ it", never "does the deployed artifact still
 #     match" — that is ship.sh's verify_managed_currency, and neither replaces
 #     the other.
@@ -165,6 +189,25 @@ nix_read_scan() {
   NIXREAD_LIVE=""; NIXREAD_STORE=""; NIXREAD_MISSING=""
   NIXREAD_FILES=0; NIXREAD_COUNT=0; NIXREAD_REASON=""
 
+  # 🔴 FAIL LOUD UNDER A NON-BASH SHELL, because failing QUIET here is the worst
+  # thing this file can do. This routine needs `shopt` and word-splitting on an
+  # unquoted `$var`; zsh has neither. MEASURED under zsh before this guard
+  # existed: five `command not found: shopt` lines on stderr — which the caller
+  # does not capture — and then a confident `rc=0 REASON=OK files=28 count=1`
+  # with an EMPTY store set, i.e. every nix-read path classified NONE and both
+  # consumers printed the reassuring verdict. The NOT-CLASSIFIED refusal could
+  # not fire, because the scan believed it had SUCCEEDED.
+  #
+  # It was reachable because ship.sh sent CONVERGE over ssh WITHOUT naming an
+  # interpreter, so sshd ran the login shell (zsh on both hosts). That transport
+  # is fixed — both legs now name bash — and this is the belt to that braces: if
+  # anyone ever re-inlines it, the answer degrades to the COULD-NOT-MEASURE path
+  # both consumers already handle honestly, instead of to a silent lie.
+  if [ -z "${BASH_VERSION:-}" ]; then
+    NIXREAD_REASON=NOTBASH
+    return 1
+  fi
+
   if [ -z "$REPO" ] || [ ! -d "$REPO" ]; then
     NIXREAD_REASON=NOREPO
     return 1
@@ -179,7 +222,7 @@ nix_read_scan() {
   shopt -q nullglob || WANT_NG=1
   shopt -s globstar nullglob
 
-  local ROOTS_SEEN=0
+  local ROOTS_SEEN=0 MISSING_DIR=0
   for T in $NIXREAD_ROOT_FILES; do
     [ -f "$REPO/$T" ] || continue
     ROOTS_SEEN=$(( ROOTS_SEEN + 1 ))
@@ -187,7 +230,13 @@ nix_read_scan() {
     case "$T" in *.nix) _nixread_scan_file "$REPO/$T" "" ;; esac
   done
   for D in $NIXREAD_ROOT_DIRS; do
-    [ -d "$REPO/$D" ] || continue
+    # 🔴 A DECLARED ROOT DIRECTORY THAT IS ABSENT IS A BROKEN SCAN, NOT A SMALL
+    # ONE. `> 0` was the only guard here, so a tree where flake.nix survives and
+    # `nix/` has been renamed derived 3 paths from 1 file and reported OK — a
+    # usable-looking verdict off a scan that missed the entire module tree. This
+    # is derived from the declaration rather than a numeric floor, so it cannot
+    # rot the way a hardcoded minimum would.
+    if [ ! -d "$REPO/$D" ]; then MISSING_DIR=1; continue; fi
     ROOTS_SEEN=$(( ROOTS_SEEN + 1 ))
     # 🔴 WALKED IS NOT THE SAME AS READ. Every .nix under here is SCANNED for
     # path literals, but a file only joins the STORE set when something REACHES
@@ -219,6 +268,7 @@ nix_read_scan() {
   NIXREAD_MISSING="${NIXREAD_MISSING# }"
 
   if [ "$ROOTS_SEEN" = 0 ]; then NIXREAD_REASON=NOROOTS; return 1; fi
+  if [ "$MISSING_DIR" = 1 ]; then NIXREAD_REASON=MISSINGROOT; return 1; fi
   if [ "$NIXREAD_FILES" = 0 ] || [ "$NIXREAD_COUNT" = 0 ]; then
     NIXREAD_REASON=NOSCAN; return 1
   fi

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -1190,14 +1190,27 @@ echo "[$host] ship-landed-sha $now"
 #    into the store WHOLE, via ${../scripts/dl-router}). One of those is in the
 #    artifact and one is not, and the old line said the same thing about both.
 #
-#    Three verdicts now, because they are three different facts:
+#    FOUR verdicts, because they are four different facts:
 #      dirty AND a mkOutOfStoreSymlink target -> that WIP is LIVE on this host
 #           right now; the deployed path is a link back into the working tree,
 #           so it needed no switch and there is no generation boundary on it.
-#      dirty AND a nix path literal           -> that WIP is IN the artifact
-#           this run just built, pinned to this generation.
+#      dirty AND a nix path literal AND GIT KNOWS IT -> that WIP is IN the
+#           artifact this run just built, pinned to this generation.
+#      dirty AND a nix path literal AND UNTRACKED -> the flake DROPPED it. Nix
+#           filters a git checkout to the files git knows about, so this reached
+#           nothing. Reported (it is unsaved work in no commit and no backup, one
+#           `git add` away from the artifact) but NOT as something deployed.
 #      dirty and NEITHER                      -> the deploy IS origin/main. A
 #           real verdict, printed as one — not softened into a warning.
+#
+#    🔴 THE THIRD CASE IS WHY THE DIRTY SET IS COMPUTED IN TWO PARTS HERE and not
+#    as one `sort -u` the way blocking_files does it. blocking_files only needs
+#    the union — every one of those paths blocks a fast-forward whether git knows
+#    it or not. This needs the DISTINCTION, because the same STORE class means
+#    two opposite things across it, and saying "in the artifact" about an
+#    untracked file is false in the ALARMING direction. Measured 2026-08-25: all
+#    six `-dl-router` store generations carry tests/ (37 files) and none carries
+#    the untracked tests/load_test_store.sh. See nix_read_artifact_reach.
 #
 #    A DETERMINISTIC SET OPERATION over a DERIVED set (see
 #    scripts/lib/nix_read_paths.sh, which reads it out of nix/ at scan time and
@@ -1212,14 +1225,20 @@ echo "[$host] ship-landed-sha $now"
 if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
   echo "[$host] ✅ VERIFIED — on branch main at origin/main + switched"
 
-  # The dirty set, computed exactly like blocking_files: modified, staged and
-  # untracked, deduped. --no-renames for the same reason it gives.
-  nr_dirty=$(mktemp); nr_live=$(mktemp); nr_store=$(mktemp); nr_unrep=$(mktemp)
+  # The dirty set, from the SAME three commands blocking_files uses — but kept in
+  # TWO buckets rather than one union, because index membership is what decides
+  # whether a STORE-class path reached the artifact. blocking_files needs only the
+  # union: every one of those paths can block a fast-forward whether git knows it
+  # or not. --no-renames for the reason it gives.
+  nr_idx=$(mktemp); nr_unt=$(mktemp)
+  nr_live=$(mktemp); nr_store=$(mktemp); nr_drop=$(mktemp); nr_unrep=$(mktemp)
   { git diff --name-only --no-renames
     git diff --cached --name-only --no-renames
-    git ls-files --others --exclude-standard
-  } 2>/dev/null | sort -u > "$nr_dirty"
-  nr_n=$(wc -l < "$nr_dirty" | tr -d " ")
+  } 2>/dev/null | sort -u > "$nr_idx"
+  git ls-files --others --exclude-standard 2>/dev/null | sort -u > "$nr_unt"
+  nr_ni=$(wc -l < "$nr_idx" | tr -d " ")
+  nr_nt=$(wc -l < "$nr_unt" | tr -d " ")
+  nr_n=$(( nr_ni + nr_nt ))
 
   nr_reason=""
   nr_lib="$repo/scripts/lib/nix_read_paths.sh"
@@ -1240,16 +1259,24 @@ if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
     echo "[$host]   This run cannot say whether that WIP reached the artifact. It is NOT a"
     echo "[$host]   claim that it did not."
   else
-    while IFS= read -r nr_p; do
-      [ -n "$nr_p" ] || continue
-      case "$(nix_read_class_of "$nr_p")" in
-        LIVE)            printf "%s\n" "$nr_p" >> "$nr_live" ;;
-        STORE)           printf "%s\n" "$nr_p" >> "$nr_store" ;;
-        UNREPRESENTABLE) printf "%s\n" "$nr_p" >> "$nr_unrep" ;;
-      esac
-    done < "$nr_dirty"
+    # nr_known: 1 for the paths git has in its index, 0 for the untracked ones.
+    # That bit — never the class alone — is what nix_read_artifact_reach turns
+    # into a claim about the artifact.
+    for nr_known in 1 0; do
+      if [ "$nr_known" = 1 ]; then nr_src="$nr_idx"; else nr_src="$nr_unt"; fi
+      while IFS= read -r nr_p; do
+        [ -n "$nr_p" ] || continue
+        case "$(nix_read_artifact_reach "$(nix_read_class_of "$nr_p")" "$nr_known")" in
+          LIVE)            printf "%s\n" "$nr_p" >> "$nr_live" ;;
+          ARTIFACT)        printf "%s\n" "$nr_p" >> "$nr_store" ;;
+          DROPPED)         printf "%s\n" "$nr_p" >> "$nr_drop" ;;
+          UNREPRESENTABLE) printf "%s\n" "$nr_p" >> "$nr_unrep" ;;
+        esac
+      done < "$nr_src"
+    done
     nr_nl=$(wc -l < "$nr_live" | tr -d " ")
     nr_ns=$(wc -l < "$nr_store" | tr -d " ")
+    nr_nd=$(wc -l < "$nr_drop" | tr -d " ")
     nr_nu=$(wc -l < "$nr_unrep" | tr -d " ")
 
     if [ "$nr_nl" != 0 ]; then
@@ -1259,22 +1286,41 @@ if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
       sed "s|^|[$host]     - |" "$nr_live"
     fi
     if [ "$nr_ns" != 0 ]; then
-      echo "[$host]   🔴 DIRTY AND IN THE ARTIFACT — nix reads $nr_ns path(s) at eval/build time,"
-      echo "[$host]   so the generation this run just built is origin/main PLUS them:"
+      echo "[$host]   🔴 DIRTY AND IN THE ARTIFACT — nix reads $nr_ns path(s) at eval/build time"
+      echo "[$host]   and git has them, so the generation this run just built is origin/main"
+      echo "[$host]   PLUS them:"
       sed "s|^|[$host]     - |" "$nr_store"
     fi
+    # 🔴 NOT "in the artifact", and that distinction is the whole point of this
+    # branch. Nix filters a git checkout to the files git knows about, so an
+    # UNTRACKED file in a nix-read path reached nothing — measured, see
+    # nix_read_artifact_reach. Still reported: it is unsaved work in no commit
+    # and no backup, sitting in a tree nix copies, one `git add` from the
+    # artifact. Reporting it as deployed would be false in the ALARMING
+    # direction, which is exactly what this block exists to stop.
+    if [ "$nr_nd" != 0 ]; then
+      echo "[$host]   UNTRACKED IN A NIX-READ PATH — $nr_nd path(s). The flake source is filtered"
+      echo "[$host]   to the files git knows about, so these did NOT reach the artifact. They are"
+      echo "[$host]   unsaved work in no commit and no backup, one git-add from being deployed:"
+      sed "s|^|[$host]     - |" "$nr_drop"
+    fi
     if [ "$nr_nl" = 0 ] && [ "$nr_ns" = 0 ] && [ "$nr_nu" = 0 ]; then
-      echo "[$host]   NOTE: tree is DIRTY, but NO dirty path is read by nix — what was"
-      echo "[$host]   built/deployed IS origin/main."
+      if [ "$nr_nd" = 0 ]; then
+        echo "[$host]   NOTE: tree is DIRTY, but NO dirty path is read by nix — what was"
+        echo "[$host]   built/deployed IS origin/main."
+      else
+        echo "[$host]   NOTE: tree is DIRTY, but nothing dirty REACHED the build — what was"
+        echo "[$host]   built/deployed IS origin/main."
+      fi
     fi
     if [ "$nr_nu" != 0 ]; then
       echo "[$host]   NOT CLASSIFIED — $nr_nu dirty path(s) carry a character the classifier does"
       echo "[$host]   not model, so no verdict is offered about them:"
       sed "s|^|[$host]     - |" "$nr_unrep"
     fi
-    echo "[$host]   classified $nr_n dirty path(s) against $NIXREAD_COUNT nix-read path(s) derived from $NIXREAD_FILES nix file(s)."
+    echo "[$host]   classified $nr_n dirty path(s) ($nr_ni tracked, $nr_nt untracked) against $NIXREAD_COUNT nix-read path(s) derived from $NIXREAD_FILES nix file(s)."
   fi
-  rm -f "$nr_dirty" "$nr_live" "$nr_store" "$nr_unrep"
+  rm -f "$nr_idx" "$nr_unt" "$nr_live" "$nr_store" "$nr_drop" "$nr_unrep"
 else
   echo "[$host] ✅ VERIFIED — on branch main at origin/main (clean tree) + switched"
 fi

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -171,14 +171,14 @@
 # 🔴 THE LADDER IS SHARED WITH scripts/drift-check.sh, RECIPROCALLY. That script
 # is the passive deadman for the same fleet and deliberately uses the same
 # vocabulary, so a number must not mean two things across the pair. It owns
-# 10, 14, 15, 16, 17, 18 and 22 — DRIFT meanings this script does not take — and
-# reserves them here; this script owns 5, 7, 9, 11, 19, 20 and 21 and they are
-# reserved there. Its header says "a new DRIFT code has nowhere to go but
+# 10, 14, 15, 16, 17, 18, 22 and 23 — DRIFT meanings this script does not take —
+# and reserves them here; this script owns 5, 7, 9, 11, 19, 20 and 21 and they
+# are reserved there. Its header says "a new DRIFT code has nowhere to go but
 # upward", which points the next one at 19 unless the reservation is written
-# down on both sides: so the next free code for THIS script is 23, and so is the
+# down on both sides: so the next free code for THIS script is 24, and so is the
 # next free code for that one.
 #
-# RESERVED-TO-DRIFT-CHECK: 10 14 15 16 17 18 22
+# RESERVED-TO-DRIFT-CHECK: 10 14 15 16 17 18 22 23
 #
 # That line is a LEDGER, machine-read, not a comment: it must equal exactly the
 # set of codes drift-check.sh can return and this script cannot, so it fails when
@@ -1181,13 +1181,100 @@ verify_managed_currency || exit 13
 #     so "fewer than two shas" stays distinguishable from "two that agree".
 echo "[$host] ship-landed-sha $now"
 
-# 6) Verdict. Name the dirty state explicitly: converging a dirty tree is the
-#    NORMAL supported path, and home-manager builds from the WORKING TREE — so
-#    what got deployed is origin/main PLUS that WIP, not origin/main. Saying so
-#    is the difference between an honest verifier and a misleading one.
+# 6) Verdict. Name the dirty state explicitly AND CLASSIFY IT. Converging a
+#    dirty tree is the NORMAL supported path, and home-manager builds from the
+#    WORKING TREE — but "origin/main + local WIP" was true of every dirty tree
+#    and actionable for none of them. Measured on the workbench 2026-08-25: the
+#    two dirty paths were a staged sudo script under nix/system/ (nix reads
+#    nothing there) and a test under scripts/dl-router/ (which home.nix copies
+#    into the store WHOLE, via ${../scripts/dl-router}). One of those is in the
+#    artifact and one is not, and the old line said the same thing about both.
+#
+#    Three verdicts now, because they are three different facts:
+#      dirty AND a mkOutOfStoreSymlink target -> that WIP is LIVE on this host
+#           right now; the deployed path is a link back into the working tree,
+#           so it needed no switch and there is no generation boundary on it.
+#      dirty AND a nix path literal           -> that WIP is IN the artifact
+#           this run just built, pinned to this generation.
+#      dirty and NEITHER                      -> the deploy IS origin/main. A
+#           real verdict, printed as one — not softened into a warning.
+#
+#    A DETERMINISTIC SET OPERATION over a DERIVED set (see
+#    scripts/lib/nix_read_paths.sh, which reads it out of nix/ at scan time and
+#    is pinned two-way by scripts/tests/test_nix_read_paths.py). Same discipline
+#    as blocking_files above: we never parse git error prose to decide anything.
+#
+#    🔴 It NEVER blocks the ship. This is the honesty of the verdict, not a gate.
+#    🔴 EXAMINED BESIDE FOUND, on every branch: a run that classified nothing
+#    must not print the same reassuring line as one that classified everything,
+#    so the population — dirty paths checked, nix-read paths derived, nix files
+#    read — is on the output whatever the answer.
 if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
   echo "[$host] ✅ VERIFIED — on branch main at origin/main + switched"
-  echo "[$host]   NOTE: tree is DIRTY — what was built/deployed is origin/main + local WIP."
+
+  # The dirty set, computed exactly like blocking_files: modified, staged and
+  # untracked, deduped. --no-renames for the same reason it gives.
+  nr_dirty=$(mktemp); nr_live=$(mktemp); nr_store=$(mktemp); nr_unrep=$(mktemp)
+  { git diff --name-only --no-renames
+    git diff --cached --name-only --no-renames
+    git ls-files --others --exclude-standard
+  } 2>/dev/null | sort -u > "$nr_dirty"
+  nr_n=$(wc -l < "$nr_dirty" | tr -d " ")
+
+  nr_reason=""
+  nr_lib="$repo/scripts/lib/nix_read_paths.sh"
+  if [ ! -r "$nr_lib" ]; then
+    nr_reason=NOLIB
+  else
+    # shellcheck source=lib/nix_read_paths.sh
+    . "$nr_lib"
+    nix_read_scan "$repo" || nr_reason="$NIXREAD_REASON"
+  fi
+
+  if [ -n "$nr_reason" ]; then
+    # 🔴 THE OLD LINE, and it is still the right one HERE — but it now says which
+    # of the two things it means. "No dirty path is read by nix" and "we could
+    # not look" are different claims and must never print the same sentence.
+    echo "[$host]   NOTE: tree is DIRTY — what was built/deployed is origin/main + local WIP."
+    echo "[$host]   NOT CLASSIFIED ($nr_reason) — $nr_n dirty path(s), 0 nix-read path(s) derived."
+    echo "[$host]   This run cannot say whether that WIP reached the artifact. It is NOT a"
+    echo "[$host]   claim that it did not."
+  else
+    while IFS= read -r nr_p; do
+      [ -n "$nr_p" ] || continue
+      case "$(nix_read_class_of "$nr_p")" in
+        LIVE)            printf "%s\n" "$nr_p" >> "$nr_live" ;;
+        STORE)           printf "%s\n" "$nr_p" >> "$nr_store" ;;
+        UNREPRESENTABLE) printf "%s\n" "$nr_p" >> "$nr_unrep" ;;
+      esac
+    done < "$nr_dirty"
+    nr_nl=$(wc -l < "$nr_live" | tr -d " ")
+    nr_ns=$(wc -l < "$nr_store" | tr -d " ")
+    nr_nu=$(wc -l < "$nr_unrep" | tr -d " ")
+
+    if [ "$nr_nl" != 0 ]; then
+      echo "[$host]   🔴 DIRTY AND LIVE — $nr_nl path(s) are mkOutOfStoreSymlink targets, so the"
+      echo "[$host]   deployed copy is a link INTO this working tree. This WIP is running on"
+      echo "[$host]   this host right now, and it did not need the switch to get there:"
+      sed "s|^|[$host]     - |" "$nr_live"
+    fi
+    if [ "$nr_ns" != 0 ]; then
+      echo "[$host]   🔴 DIRTY AND IN THE ARTIFACT — nix reads $nr_ns path(s) at eval/build time,"
+      echo "[$host]   so the generation this run just built is origin/main PLUS them:"
+      sed "s|^|[$host]     - |" "$nr_store"
+    fi
+    if [ "$nr_nl" = 0 ] && [ "$nr_ns" = 0 ] && [ "$nr_nu" = 0 ]; then
+      echo "[$host]   NOTE: tree is DIRTY, but NO dirty path is read by nix — what was"
+      echo "[$host]   built/deployed IS origin/main."
+    fi
+    if [ "$nr_nu" != 0 ]; then
+      echo "[$host]   NOT CLASSIFIED — $nr_nu dirty path(s) carry a character the classifier does"
+      echo "[$host]   not model, so no verdict is offered about them:"
+      sed "s|^|[$host]     - |" "$nr_unrep"
+    fi
+    echo "[$host]   classified $nr_n dirty path(s) against $NIXREAD_COUNT nix-read path(s) derived from $NIXREAD_FILES nix file(s)."
+  fi
+  rm -f "$nr_dirty" "$nr_live" "$nr_store" "$nr_unrep"
 else
   echo "[$host] ✅ VERIFIED — on branch main at origin/main (clean tree) + switched"
 fi

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -661,8 +661,22 @@ ship_self_check() {
   exit 20
 }
 
-# Self-contained converge routine, run identically on each host (local via
-# bash -c, remote via ssh). Single source of truth for the sequence.
+# Self-contained converge routine, run identically on each host: locally via
+# `bash -c`, remotely by PIPING it to `bash -s` over ssh. Single source of truth
+# for the sequence.
+#
+# 🔴 BOTH LEGS NAME bash EXPLICITLY, and that is load-bearing, not stylistic.
+# `ssh host "<script>"` names no interpreter, so sshd runs the account's LOGIN
+# SHELL — zsh on both of these hosts. This payload was interpreter-agnostic only
+# by ACCIDENT until it began sourcing scripts/lib/nix_read_paths.sh, which needs
+# `shopt` and word-splitting on an unquoted `$var`; under zsh that returned a
+# confident, WRONG "nothing is nix-read". drift-check.sh reached the same
+# conclusion first and says so at its own CHECK header — this is the same rule in
+# the second place it applies, not a second rule.
+#
+# So: anything added here may assume bash, but ONLY because the transport says
+# bash. If a future edit inlines this into an ssh command string again, every
+# bashism in it — including the whole shared lib — silently changes meaning.
 CONVERGE='
 set -uo pipefail
 if [ "${SHIP_REPO+set}" = set ] && [ -z "$SHIP_REPO" ]; then
@@ -671,6 +685,16 @@ if [ "${SHIP_REPO+set}" = set ] && [ -z "$SHIP_REPO" ]; then
 fi
 repo="${SHIP_REPO:-$HOME/workspace/devrc}"
 no_switch="${SHIP_NO_SWITCH:-0}"
+# Max paths enumerated per dirty-classification bucket — see nr_list. Mirrors
+# drift-check.sh DRIFT_UNTRACKED_MAX/DRIFT_NIXDIRT_MAX; the counts beside each
+# heading are never capped.
+# 🔴 NO `''` LITERAL ANYWHERE IN THIS PAYLOAD. CONVERGE is a single-quoted shell
+# string, so an empty-string literal closes it and re-opens it — the file still
+# parses, and the payload silently becomes a different script. That is what a
+# first draft of this validation did, and it broke 76 tests at once.
+SHIP_LIST_MAX="${SHIP_LIST_MAX:-10}"
+[ -n "$SHIP_LIST_MAX" ] || SHIP_LIST_MAX=10
+case "$SHIP_LIST_MAX" in *[!0-9]*) SHIP_LIST_MAX=10 ;; esac
 host=$(hostname 2>/dev/null || echo local)
 [ -n "$host" ] || host=local
 cd "$repo" || { echo "[$host] no repo at $repo"; exit 3; }
@@ -1240,6 +1264,17 @@ if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
   nr_nt=$(wc -l < "$nr_unt" | tr -d " ")
   nr_n=$(( nr_ni + nr_nt ))
 
+  # 🔴 BOUNDED, like every other listing either script prints. A whole-directory
+  # STORE source (claude/skills, scripts/dl-router) means one untracked subtree
+  # can put an unbounded number of paths in a bucket, and this output is tee-d
+  # into a capture an operator reads. The COUNT above is never truncated — only
+  # the enumeration — and a truncated list always says how much it hid.
+  nr_list() { # nr_list <file> <total>
+    sed -n "1,${SHIP_LIST_MAX}p" "$1" | sed "s|^|[$host]     - |"
+    [ "$2" -gt "$SHIP_LIST_MAX" ] && echo "[$host]     ... and $(( $2 - SHIP_LIST_MAX )) more"
+    return 0
+  }
+
   nr_reason=""
   nr_lib="$repo/scripts/lib/nix_read_paths.sh"
   if [ ! -r "$nr_lib" ]; then
@@ -1283,13 +1318,13 @@ if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
       echo "[$host]   🔴 DIRTY AND LIVE — $nr_nl path(s) are mkOutOfStoreSymlink targets, so the"
       echo "[$host]   deployed copy is a link INTO this working tree. This WIP is running on"
       echo "[$host]   this host right now, and it did not need the switch to get there:"
-      sed "s|^|[$host]     - |" "$nr_live"
+      nr_list "$nr_live" "$nr_nl"
     fi
     if [ "$nr_ns" != 0 ]; then
       echo "[$host]   🔴 DIRTY AND IN THE ARTIFACT — nix reads $nr_ns path(s) at eval/build time"
       echo "[$host]   and git has them, so the generation this run just built is origin/main"
       echo "[$host]   PLUS them:"
-      sed "s|^|[$host]     - |" "$nr_store"
+      nr_list "$nr_store" "$nr_ns"
     fi
     # 🔴 NOT "in the artifact", and that distinction is the whole point of this
     # branch. Nix filters a git checkout to the files git knows about, so an
@@ -1302,7 +1337,7 @@ if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
       echo "[$host]   UNTRACKED IN A NIX-READ PATH — $nr_nd path(s). The flake source is filtered"
       echo "[$host]   to the files git knows about, so these did NOT reach the artifact. They are"
       echo "[$host]   unsaved work in no commit and no backup, one git-add from being deployed:"
-      sed "s|^|[$host]     - |" "$nr_drop"
+      nr_list "$nr_drop" "$nr_nd"
     fi
     if [ "$nr_nl" = 0 ] && [ "$nr_ns" = 0 ] && [ "$nr_nu" = 0 ]; then
       if [ "$nr_nd" = 0 ]; then
@@ -1316,7 +1351,7 @@ if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
     if [ "$nr_nu" != 0 ]; then
       echo "[$host]   NOT CLASSIFIED — $nr_nu dirty path(s) carry a character the classifier does"
       echo "[$host]   not model, so no verdict is offered about them:"
-      sed "s|^|[$host]     - |" "$nr_unrep"
+      nr_list "$nr_unrep" "$nr_nu"
     fi
     echo "[$host]   classified $nr_n dirty path(s) ($nr_ni tracked, $nr_nt untracked) against $NIXREAD_COUNT nix-read path(s) derived from $NIXREAD_FILES nix file(s)."
   fi
@@ -1377,9 +1412,40 @@ echo
 if [ "$DO_REMOTE" = 1 ]; then
   echo "=== remote ($REMOTE_ROLE — $REMOTE_SSH) ==="
   # Pass the switch toggle remotely; SHIP_REPO stays host-default ($HOME/workspace/devrc).
+  #
+  # 🔴 PIPED TO `bash -s`, NEVER INLINED IN THE ssh COMMAND STRING. `ssh host
+  # "<script>"` names NO interpreter, so sshd runs the account's LOGIN SHELL —
+  # and both hosts' login shell is zsh (`getent passwd zach` ->
+  # /run/current-system/sw/bin/zsh). `bash -s` takes the interpreter out of the
+  # equation, which is exactly what drift-check.sh does and says at its CHECK
+  # header; this script had no such note and was interpreter-agnostic only by
+  # accident — every line of CONVERGE happened to be portable.
+  #
+  # That accident ENDED when CONVERGE started sourcing
+  # scripts/lib/nix_read_paths.sh, which needs `shopt` and word-splitting on an
+  # unquoted `$var`. MEASURED under zsh before this was fixed: the lib emitted
+  # five `command not found: shopt` lines to stderr (NOT tee'd into the capture,
+  # so invisible in the log), then returned `rc=0 REASON=OK files=28 count=1`
+  # with an EMPTY store set — so every dirty nix-read path classified NONE and
+  # the remote host printed "NO dirty path is read by nix" while the local leg
+  # printed "DIRTY AND IN THE ARTIFACT" for the same file. The NOT-CLASSIFIED
+  # refusal could not fire, because the scan believed it had succeeded. A silent
+  # wrong answer in the reassuring direction is the worst outcome this file can
+  # produce, and it was reachable only on the host nobody is watching.
+  #
+  # %q, not %s, on the value interpolated ahead of the payload — the same
+  # belt-and-braces drift-check.sh applies to everything it sends across this hop.
   cap_remote=$(mktemp "${TMPDIR:-/tmp}/ship-remote.XXXXXX")
-  ssh -o ConnectTimeout=10 "$REMOTE_SSH" "SHIP_NO_SWITCH=$SHIP_NO_SWITCH; $CONVERGE" | tee "$cap_remote"
-  remrc=${PIPESTATUS[0]}
+  printf 'SHIP_NO_SWITCH=%q\n%s\n' "$SHIP_NO_SWITCH" "$CONVERGE" \
+    | ssh -o ConnectTimeout=10 "$REMOTE_SSH" bash -s | tee "$cap_remote"
+  # 🔴 INDEX 1, NOT 0 — and the index moved BECAUSE the payload is now piped in.
+  # This read `PIPESTATUS[0]` while the pipeline was `ssh | tee`; it is now
+  # `printf | ssh | tee`, so [0] is printf, which essentially always succeeds.
+  # Left at [0] this would have reported EVERY remote converge as rc 0 —
+  # including a host skipped for un-pushed commits (rc 8), which is the finding
+  # this whole script exists to surface. Pinned by
+  # test_the_remote_leg_reports_the_ssh_status_not_the_printf_status.
+  remrc=${PIPESTATUS[1]}
   REMOTE_SHA=$(ship_landed_sha "$cap_remote")
   rm -f "$cap_remote"
   if [ "$remrc" != 0 ]; then

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -406,6 +406,16 @@ SHIP_NO_SWITCH="${SHIP_NO_SWITCH:-0}"
 # where it was, inside CONVERGE, because that is the copy that RUNS on each host
 # — a second one out here would be the duplicated-predicate shape RULES.md says
 # is wrong at N-1 sites.
+#
+# ⚠ THIS LINE AND THE LOCAL LEG'S `SHIP_LIST_MAX=` PREFIX ARE CURRENTLY
+# REDUNDANT, and a mutation sweep proved it: deleting either one changes nothing
+# a test can see. An operator-set value is already exported and reaches
+# `bash -c "$CONVERGE"` by inheritance; an unset one lands on CONVERGE's own
+# `${SHIP_LIST_MAX:-10}`. They are kept because they make the value EXPLICIT at
+# both legs rather than inherited at one and forwarded at the other — but do not
+# read them as load-bearing, and do not "prove" them with a test that cannot
+# fail. The REMOTE printf below is the one that carries real weight: ssh does
+# not forward the environment, so without it the two legs genuinely diverge.
 SHIP_LIST_MAX="${SHIP_LIST_MAX:-10}"
 DO_LOCAL=1
 DO_REMOTE=1

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -296,6 +296,15 @@
 #   LAPTOP_SSH    back-compat: ssh target used ONLY when the remote host is the laptop
 #   SHIP_REPO     repo path the CONVERGE routine operates on (default $HOME/workspace/devrc)
 #   SHIP_NO_SWITCH=1  same as --no-switch: run full git-landing logic, skip home-manager switch
+#   SHIP_LIST_MAX  max paths ENUMERATED per dirty-classification bucket
+#                  (default 10, non-negative integer). The COUNT beside each
+#                  heading is never capped, so 0 honestly means "count them, name
+#                  none" — and is honoured as that rather than silently reset,
+#                  which is why nr_list guards its `sed` instead of relying on a
+#                  `1,0p` range (GNU sed prints line 1 for that, so 0 used to
+#                  yield ONE path plus "... and N more"). A non-integer falls back
+#                  to the default. Forwarded to the remote leg so both legs of one
+#                  run truncate identically.
 #   SHIP_SELF_GEN     re-exec generation counter — set BY this script when it
 #                     re-execs a copy of itself that its own run installed. Never
 #                     set it by hand: a value >= SHIP_SELF_MAX_GEN tells the run
@@ -389,6 +398,15 @@ if [ "${SHIP_REPO+set}" = set ] && [ -z "$SHIP_REPO" ]; then
 fi
 SHIP_REPO="${SHIP_REPO:-$HOME/workspace/devrc}"
 SHIP_NO_SWITCH="${SHIP_NO_SWITCH:-0}"
+# 🔴 RESOLVED HERE ONLY SO BOTH LEGS GET THE SAME STRING — never VALIDATED here.
+# SHIP_LIST_MAX used to reach the local leg by plain inheritance and the remote
+# leg not at all, so one run could enumerate ten paths on this host and three on
+# the other while both printed the same "... and N more" shape. It is the same
+# knob; it must mean the same thing on both sides of the hop. The sanitiser stays
+# where it was, inside CONVERGE, because that is the copy that RUNS on each host
+# — a second one out here would be the duplicated-predicate shape RULES.md says
+# is wrong at N-1 sites.
+SHIP_LIST_MAX="${SHIP_LIST_MAX:-10}"
 DO_LOCAL=1
 DO_REMOTE=1
 for a in "$@"; do
@@ -1269,9 +1287,17 @@ if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
   # can put an unbounded number of paths in a bucket, and this output is tee-d
   # into a capture an operator reads. The COUNT above is never truncated — only
   # the enumeration — and a truncated list always says how much it hid.
+  # 🔴 THE `-gt 0` GUARD IS NOT DEFENSIVE, IT IS THE FIX. `sed -n "1,0p"` is not
+  # an empty range to GNU sed — it prints line 1 — so SHIP_LIST_MAX=0 enumerated
+  # ONE path and then claimed "... and N more", i.e. a cap of zero listed
+  # something. 0 is a legitimate setting here (every heading carries its own
+  # untruncated count, so "count them, name none" is a coherent thing to ask
+  # for), so it is honoured rather than sanitised away.
   nr_list() { # nr_list <file> <total>
-    sed -n "1,${SHIP_LIST_MAX}p" "$1" | sed "s|^|[$host]     - |"
-    [ "$2" -gt "$SHIP_LIST_MAX" ] && echo "[$host]     ... and $(( $2 - SHIP_LIST_MAX )) more"
+    if [ "$SHIP_LIST_MAX" -gt 0 ]; then
+      sed -n "1,${SHIP_LIST_MAX}p" "$1" | sed "s|^|[$host]     - |"
+    fi
+    [ "$2" -gt "$SHIP_LIST_MAX" ] && echo "[$host]     ... and $(( $2 - SHIP_LIST_MAX )) more (SHIP_LIST_MAX=$SHIP_LIST_MAX)"
     return 0
   }
 
@@ -1394,7 +1420,8 @@ if [ "$DO_LOCAL" = 1 ]; then
   # 0 over any per-host skip. Same lesson as scripts/run-tests.sh GUARD 6, from
   # the other side of the pipe.
   cap_local=$(mktemp "${TMPDIR:-/tmp}/ship-local.XXXXXX")
-  SHIP_REPO="$SHIP_REPO" SHIP_NO_SWITCH="$SHIP_NO_SWITCH" bash -c "$CONVERGE" | tee "$cap_local"
+  SHIP_REPO="$SHIP_REPO" SHIP_NO_SWITCH="$SHIP_NO_SWITCH" \
+    SHIP_LIST_MAX="$SHIP_LIST_MAX" bash -c "$CONVERGE" | tee "$cap_local"
   lrc=${PIPESTATUS[0]}
   [ "$lrc" = 0 ] || rc=$lrc
   LOCAL_SHA=$(ship_landed_sha "$cap_local")
@@ -1433,10 +1460,15 @@ if [ "$DO_REMOTE" = 1 ]; then
   # wrong answer in the reassuring direction is the worst outcome this file can
   # produce, and it was reachable only on the host nobody is watching.
   #
-  # %q, not %s, on the value interpolated ahead of the payload — the same
+  # %q, not %s, on EVERY value interpolated ahead of the payload — the same
   # belt-and-braces drift-check.sh applies to everything it sends across this hop.
+  # SHIP_LIST_MAX travels for the reason given where it is resolved: unforwarded,
+  # the two legs of ONE run could truncate their listings differently. It is
+  # sanitised on arrival by CONVERGE's own `case`, which is why %q here is the
+  # belt rather than the braces.
   cap_remote=$(mktemp "${TMPDIR:-/tmp}/ship-remote.XXXXXX")
-  printf 'SHIP_NO_SWITCH=%q\n%s\n' "$SHIP_NO_SWITCH" "$CONVERGE" \
+  printf 'SHIP_NO_SWITCH=%q\nSHIP_LIST_MAX=%q\n%s\n' \
+    "$SHIP_NO_SWITCH" "$SHIP_LIST_MAX" "$CONVERGE" \
     | ssh -o ConnectTimeout=10 "$REMOTE_SSH" bash -s | tee "$cap_remote"
   # 🔴 INDEX 1, NOT 0 — and the index moved BECAUSE the payload is now piped in.
   # This read `PIPESTATUS[0]` while the pipeline was `ssh | tee`; it is now

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -199,7 +199,7 @@ class Fleet:
     # cannot be trusted to isolate anything.
     #
     # 🔴 Names pairwise distinct, and distinct from every constant the assertions
-    # name (LIVE, STORE, nix-read, rc23). `kilo-live.txt` is deliberately NOT
+    # name (LIVE, DROPPED, nix-read, rc23). `kilo-live.txt` is deliberately NOT
     # committed — it is a mkOutOfStoreSymlink target that only ever exists as an
     # untracked file, which is exactly the shape the ladder is about.
     NIXREAD_FLAKE = (
@@ -5146,7 +5146,7 @@ def test_an_untracked_nix_read_file_is_reported_but_does_not_fail_the_unit(fleet
 
     rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
     assert rc == 0, out
-    assert "charlie-dir/nested/november.txt: UNTRACKED in a NIX-READ path (STORE)" in out, out
+    assert "charlie-dir/nested/november.txt: UNTRACKED in a NIX-READ path (DROPPED)" in out, out
     assert "1/3 consecutive; NOT escalated" in out, out
     assert _nixdirt(out)[:1] == (1,), out
     assert _nixdirt(out)[3:] == (1, 0, 0), out
@@ -5171,7 +5171,7 @@ def test_an_untracked_nix_read_file_escalates_after_n_consecutive_runs(fleet):
     # The whole claim on ONE normalised line — host, path, class, streak,
     # threshold. Split across two it is walkable by rewording the other half.
     assert ("DRIFT — workbench charlie-dir/nested/november.txt: UNTRACKED in a "
-            "NIX-READ path (STORE) for 4 CONSECUTIVE runs (threshold 3)." in out), out
+            "NIX-READ path (DROPPED) for 4 CONSECUTIVE runs (threshold 3)." in out), out
     assert _nixdirt(out)[4] == 1, out
 
 
@@ -5187,7 +5187,7 @@ def test_an_untracked_mkOutOfStoreSymlink_target_escalates_as_LIVE(fleet):
     assert rc == 23, out
     assert ("DRIFT — workbench kilo-live.txt: UNTRACKED in a NIX-READ path "
             "(LIVE) for 3 CONSECUTIVE runs (threshold 3)." in out), out
-    assert "SERVED on that host right now" in out, out
+    assert "IS being served on that host right now" in out, out
 
 
 def test_the_nixdirt_streak_resets_when_the_file_is_committed(fleet):
@@ -5379,7 +5379,7 @@ def test_a_path_named_like_a_header_field_is_read_as_a_PATH(fleet):
     """🔴 REACHABILITY, and a bug this actually found. The FACT line carries
     `reason=<TOKEN>` header fields and `<path>=<CLASS>` pairs in one
     whitespace-separated list. An untracked repo-root file named `reason` emits
-    the token `reason=STORE` — and with the header arms matched first, the driver
+    the token `reason=DROPPED` — and with the header arms matched first, the driver
     read it as the line's REASON, called the host COULD NOT MEASURE and dropped
     the very file it was reporting. Silently, in the reassuring direction.
 
@@ -5393,7 +5393,7 @@ def test_a_path_named_like_a_header_field_is_read_as_a_PATH(fleet):
     assert rc == 23, f"a path named like a header field was not classified\n{out}"
     assert "[nixdirt] workbench: COULD NOT MEASURE" not in out, (
         "a path token was read as the line's reason field\n%s" % out)
-    assert ("DRIFT — workbench reason: UNTRACKED in a NIX-READ path (STORE) for "
+    assert ("DRIFT — workbench reason: UNTRACKED in a NIX-READ path (DROPPED) for "
             "1 CONSECUTIVE runs (threshold 1)." in out), out
 
 
@@ -5409,7 +5409,7 @@ def test_a_fact_line_claiming_OK_over_a_ZERO_denominator_is_still_refused(fleet)
     """
     fleet.seed_nix_read()
     fleet.stub_ssh(0, stdout=(
-        "[laptop] FACT nix-untracked untracked=1 nixread=0 reason=OK papa-x.txt=STORE"))
+        "[laptop] FACT nix-untracked untracked=1 nixread=0 reason=OK papa-x.txt=DROPPED"))
     rc, out = fleet.check("--no-local", DRIFT_NIXDIRT_ESCALATE="1")
     assert "[nixdirt] laptop: COULD NOT MEASURE — reason=OK untracked=1 nix-read-paths=0." in out, out
     assert rc != 23, f"escalated off a zero denominator\n{out}"
@@ -5419,13 +5419,13 @@ def test_a_fact_line_claiming_OK_over_a_ZERO_denominator_is_still_refused(fleet)
 def test_the_payload_classifies_by_CLASS_and_not_merely_by_being_untracked(fleet):
     """🔴 ISOLATED REACHABILITY for the payload's class filter — the arm that
     decides which untracked files reach the driver at all. The driver-side
-    `*=LIVE|*=STORE` filter cannot be reached by a NONE path, because the payload
+    `*=LIVE|*=DROPPED` filter cannot be reached by a NONE path, because the payload
     never emits one; so this is where the distinction is actually made, and this
     is the case that proves it is made on the CLASS.
     """
     fleet.seed_nix_read()
     (fleet.work / "outside-mike.txt").write_text("mike\n")          # NONE
-    (fleet.work / "charlie-dir" / "nested" / "november.txt").write_text("nov\n")  # STORE
+    (fleet.work / "charlie-dir" / "nested" / "november.txt").write_text("nov\n")  # DROPPED
 
     rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="9")
     assert rc == 0, out
@@ -5434,3 +5434,67 @@ def test_the_payload_classifies_by_CLASS_and_not_merely_by_being_untracked(fleet
     assert "november.txt" in out
     hits = _nixdirt(out)[3]
     assert hits == 1, f"the class filter counted {hits} of 2 untracked files\n{out}"
+
+
+def test_the_DROPPED_reason_does_not_claim_the_file_is_in_the_artifact(fleet):
+    """🔴 THE CORRECTION. rc 23 is by construction about UNTRACKED files, and nix
+    filters a git checkout to the files git knows about — so a nix-read path here
+    reached NOTHING. The escalation is unchanged (unsaved work, no commit, no
+    backup, one `git add` from the artifact); the SENTENCE is what was wrong.
+
+    It used to read "nix reads it at eval/build time, so every generation built on
+    that host carries it". Measured 2026-08-25: all six `-dl-router` store
+    generations carry tests/ (37 files) and none carries the untracked
+    tests/load_test_store.sh. A verdict that overstates is the exact failure this
+    block exists to remove.
+    """
+    fleet.seed_nix_read()
+    (fleet.work / "charlie-dir" / "nested" / "november.txt").write_text("nov\n")
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="1")
+    assert rc == 23, out
+    assert "did NOT reach the artifact" in out, out
+    assert "one git-add from being deployed" in out, out
+    assert "every generation built on" not in out, (
+        "the escalation still claims an untracked file is in the artifact\n%s" % out)
+
+
+def test_the_LIVE_reason_DOES_claim_the_file_is_being_served(fleet):
+    """The other half, in the same block, so a mutant that makes both reasons the
+    same text is caught. A mkOutOfStoreSymlink target never goes through the
+    flake source at all — the deployed link resolves into the working tree at USE
+    time — so for LIVE the strong claim is the true one."""
+    fleet.seed_nix_read()
+    (fleet.work / "kilo-live.txt").write_text("kilo\n")
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="1")
+    assert rc == 23, out
+    assert "IS being served on that host right now" in out, out
+    assert "did NOT reach the artifact" not in out, out
+
+
+def test_the_two_classes_get_DIFFERENT_reasons_in_one_run(fleet):
+    """🔴 ASSERTED TOGETHER, in one run, over two fixture paths whose names and
+    classes are pairwise distinct. A mutant that collapses the branch — printing
+    either reason for both — passes each single-class test above and dies here."""
+    fleet.seed_nix_read()
+    (fleet.work / "kilo-live.txt").write_text("kilo\n")
+    (fleet.work / "charlie-dir" / "nested" / "november.txt").write_text("nov\n")
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="1")
+    assert rc == 23, out
+    assert "kilo-live.txt: UNTRACKED in a NIX-READ path (LIVE)" in out, out
+    assert ("charlie-dir/nested/november.txt: UNTRACKED in a NIX-READ path "
+            "(DROPPED)" in out), out
+    assert "IS being served on that host right now" in out, out
+    assert "did NOT reach the artifact" in out, out
+
+
+def test_the_escalation_itself_is_unchanged_for_a_DROPPED_path(fleet):
+    """🔴 THE CORRECTION MUST NOT WEAKEN THE LADDER. Fixing an overstated reason
+    is not a reason to stop reporting: the file is still unsaved work on exactly
+    one machine. Same ladder, same threshold, same code."""
+    fleet.seed_nix_read()
+    (fleet.work / "charlie-dir" / "nested" / "november.txt").write_text("nov\n")
+    codes = []
+    for _ in range(3):
+        rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="2")
+        codes.append(rc)
+    assert codes == [0, 23, 23], f"the DROPPED ladder stopped escalating: {codes}\n{out}"

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -795,19 +795,128 @@ def test_the_unreachable_streak_is_kept_PER_REMOTE_HOST(fleet):
     )
 
 
-def test_the_remote_payload_is_shell_quoted():
+# --------------------------------------------------------------------------- #
+# THE REMOTE-PAYLOAD LEDGER
+#
+# 🔴 DERIVED FROM THE printf, NEVER HAND-LISTED. Both guards below used to name
+# their variables literally, and both went stale the moment a fourth value
+# started crossing the ssh hop: DRIFT_NIXDIRT_MAX was interpolated into the
+# payload that EXECUTES on the other host while the %q assertion still listed
+# DRIFT_LABEL/DRIFT_UNTRACKED_MAX and the injection parametrize still listed
+# DRIFT_UNTRACKED_MAX/DRIFT_UNREACHABLE_ESCALATE. A mutant that deleted
+# `require_int DRIFT_NIXDIRT_MAX` **and** downgraded its %q to %s SURVIVED
+# 304/304. DRIFT_DANGLING_MAX had been uncovered by both for longer.
+#
+# So the set is read out of the printf format string itself. Adding a fifth
+# forwarded value cannot be invisible to this suite, and REMOVING one cannot
+# leave a guard pointing at nothing: `_forwarded()` fails loudly if it cannot
+# find the format at all, which is the positive control for its own regex.
+# --------------------------------------------------------------------------- #
+#
+# The one forwarded value that is NOT an integer, enumerated with its reason
+# rather than pattern-matched. It is a ROLE NAME chosen by this script from
+# `resolve_local_role`, never by the operator, so there is nothing for
+# require_int to check; it still crosses the hop, so it still needs %q.
+_FORWARDED_NON_INT = {"DRIFT_LABEL"}
+
+
+def _forwarded():
+    """[(name, conversion)…] for every value interpolated ahead of the REMOTE
+    payload, read off the `printf` format string in drift-check.sh."""
+    src = DRIFT.read_text()
+    m = re.search(r"REMOTE_OUT=\"\$\(printf '([^']*)'", src)
+    assert m, (
+        "could not find the remote payload's printf format at all — this "
+        "ledger is now wired to nothing, which is worse than a stale list"
+    )
+    fmt = m.group(1)
+    pairs = re.findall(r"([A-Z][A-Z0-9_]*)=%(\w)", fmt)
+    assert len(pairs) >= 2, (
+        "the ledger derived %r from %r; a one-element result is what a broken "
+        "regex looks like" % (pairs, fmt)
+    )
+    return pairs
+
+
+def test_the_remote_payload_ledger_can_see_the_real_variables():
+    """🔴 POSITIVE CONTROL for the derivation the two guards below stand on.
+
+    A regex that matched nothing would make both of them vacuously green, which
+    is precisely the failure they exist to end. So: it must find the payload's
+    own DRIFT_LABEL, and it must find at least one of the *_MAX values that make
+    this a ledger rather than a single-variable check.
+    """
+    names = [n for n, _c in _forwarded()]
+    assert "DRIFT_LABEL" in names, names
+    assert [n for n in names if n.endswith("_MAX")], (
+        "the derived set names no capped tunable, so a cap could be forwarded "
+        "unnoticed again: %r" % names
+    )
+
+
+def test_every_variable_forwarded_to_the_remote_host_is_shell_quoted():
     """STRUCTURAL, and labelled as such.
 
     `require_int` already rejects every value that could inject, so swapping %q
     back to %s is behaviourally invisible to this suite — a mutant that survives
     every behavioural test. %q is the second layer, and the only way to hold a
     second layer whose first layer never lets anything through is to assert it
-    is there.
+    is there. Asserted over the DERIVED set, so it covers the next one too.
+    """
+    bad = [(n, c) for n, c in _forwarded() if c != "q"]
+    assert bad == [], (
+        "these values are interpolated into a script that EXECUTES on the other "
+        "host without %%q-quoting: %r" % (bad,)
+    )
+
+
+def test_every_INTEGER_forwarded_to_the_remote_host_is_range_validated():
+    """The FIRST layer of the same pair, over the same derived set.
+
+    %q makes an injected value inert; require_int/require_positive_int stops it
+    before it is ever sent. Each is asserted separately because each can be
+    deleted separately, and a mutant that removed only the validation left the
+    payload well-formed and every behavioural test green.
     """
     src = DRIFT.read_text()
-    assert "DRIFT_LABEL=%q" in src and "DRIFT_UNTRACKED_MAX=%q" in src, (
-        "the values interpolated into the REMOTE payload are no longer %q-quoted"
+    missing = []
+    for name, _conv in _forwarded():
+        if name in _FORWARDED_NON_INT:
+            continue
+        if not re.search(r"^require(_positive)?_int %s " % name, src, re.M):
+            missing.append(name)
+    assert missing == [], (
+        "forwarded to the other host with no integer validation, so a "
+        "non-integer reaches an ssh payload: %r" % missing
     )
+
+
+@pytest.mark.parametrize(
+    "var", sorted({n for n, _c in _forwarded()} - _FORWARDED_NON_INT))
+def test_no_forwarded_tunable_can_inject_a_command_into_the_remote_payload(fleet, var):
+    """🔴 THE BEHAVIOURAL HALF, derived from the same ledger.
+
+    Each of these is INTERPOLATED INTO A SCRIPT THAT RUNS ON THE OTHER HOST.
+    `<VAR>='10; echo INJECTED-COMMAND-RAN'` used to be executed remotely — a
+    passivity hole on the far side of the ssh hop, which the static scanner
+    structurally cannot see (it only reads this file). Operator-supplied, so low
+    exploitability, but a deadman forbidden from touching a host must not
+    contain a path that runs arbitrary commands on it.
+    """
+    fleet.stub_ssh(0, stdout="[laptop] clean")
+    rc, out = fleet.check(
+        "--no-local",
+        REMOTE_SSH="stub@example.invalid",
+        **{var: "10; echo INJECTED-COMMAND-RAN"},
+    )
+    # The marker may legitimately appear INSIDE the rejection message (it quotes
+    # the offending value back). What must never appear is the marker as the
+    # OUTPUT OF A COMMAND — i.e. on a line of its own.
+    ran = [ln for ln in out.splitlines() if ln.strip() == "INJECTED-COMMAND-RAN"]
+    assert not ran, f"remote command injection via {var}: the payload executed\n{out}"
+    assert rc == 2, f"a non-integer {var} must be a usage error, got {rc}\n{out}"
+    assert var in out, out
+    assert "must be an integer" in out or "must be a non-negative integer" in out, out
 
 
 def test_clean_local_plus_clean_remote_is_green(fleet):
@@ -819,28 +928,10 @@ def test_clean_local_plus_clean_remote_is_green(fleet):
     assert "no drift" in out
 
 
-def test_untracked_max_cannot_inject_a_command_into_the_remote_payload(fleet):
-    """🔴 The tunables are INTERPOLATED INTO A SCRIPT THAT RUNS ON THE OTHER HOST.
-
-    `DRIFT_UNTRACKED_MAX='10; echo INJECTED-COMMAND-RAN'` used to be executed
-    remotely — a passivity hole on the far side of the ssh hop, which the static
-    scanner structurally cannot see (it only reads this file). Operator-supplied,
-    so low exploitability, but a deadman forbidden from touching a host must not
-    contain a path that runs arbitrary commands on it.
-    """
-    fleet.stub_ssh(0, stdout="[laptop] clean")
-    rc, out = fleet.check(
-        "--no-local",
-        REMOTE_SSH="stub@example.invalid",
-        DRIFT_UNTRACKED_MAX="10; echo INJECTED-COMMAND-RAN",
-    )
-    # The marker may legitimately appear INSIDE the rejection message (it quotes
-    # the offending value back). What must never appear is the marker as the
-    # OUTPUT OF A COMMAND — i.e. on a line of its own.
-    ran = [ln for ln in out.splitlines() if ln.strip() == "INJECTED-COMMAND-RAN"]
-    assert not ran, f"remote command injection: the payload executed\n{out}"
-    assert rc == 2, f"a non-integer tunable must be a usage error, got {rc}\n{out}"
-    assert "must be a non-negative integer" in out, out
+# NOTE: the DRIFT_UNTRACKED_MAX injection case that used to live here is now the
+# `test_no_forwarded_tunable_can_inject_a_command_into_the_remote_payload`
+# parametrize above, driven off the payload's own printf. Keeping a hand-named
+# copy beside a derived ledger is how the derived one stops being read.
 
 
 @pytest.mark.parametrize(
@@ -5125,11 +5216,16 @@ def test_the_extractor_reports_only_the_enum_values_it_finds(tmp_path):
 #     committing it an hour later is the normal working shape here.
 # --------------------------------------------------------------------------- #
 def _nixdirt(out):
-    """(hosts-reporting, untracked, nix-read-paths, hits, escalated, blind) off
-    the summary line, or None when the block withheld it."""
+    """(hosts-reporting, untracked, nix-read-paths, hits, listed, escalated,
+    blind) off the summary line, or None when the block withheld it.
+
+    `listed` sits beside `hits` because the two are NOT the same number once
+    DRIFT_NIXDIRT_MAX has cut the enumeration, and every test that reads a hit
+    count out of this tuple would otherwise be reading a capped one.
+    """
     m = re.search(
         r"\[nixdirt\] hosts-reporting=(\d+) untracked=(\d+) nix-read-paths=(\d+) "
-        r"hits=(\d+) escalated=(\d+) blind=(\d+)", out)
+        r"hits=(\d+) listed=(\d+) escalated=(\d+) blind=(\d+)", out)
     return tuple(int(g) for g in m.groups()) if m else None
 
 
@@ -5149,7 +5245,7 @@ def test_an_untracked_nix_read_file_is_reported_but_does_not_fail_the_unit(fleet
     assert "charlie-dir/nested/november.txt: UNTRACKED in a NIX-READ path (DROPPED)" in out, out
     assert "1/3 consecutive; NOT escalated" in out, out
     assert _nixdirt(out)[:1] == (1,), out
-    assert _nixdirt(out)[3:] == (1, 0, 0), out
+    assert _nixdirt(out)[3:] == (1, 1, 0, 0), out   # hits, listed, escalated, blind
 
 
 def test_an_untracked_nix_read_file_escalates_after_n_consecutive_runs(fleet):
@@ -5172,7 +5268,7 @@ def test_an_untracked_nix_read_file_escalates_after_n_consecutive_runs(fleet):
     # threshold. Split across two it is walkable by rewording the other half.
     assert ("DRIFT — workbench charlie-dir/nested/november.txt: UNTRACKED in a "
             "NIX-READ path (DROPPED) for 4 CONSECUTIVE runs (threshold 3)." in out), out
-    assert _nixdirt(out)[4] == 1, out
+    assert _nixdirt(out)[5] == 1, out            # escalated
 
 
 def test_an_untracked_mkOutOfStoreSymlink_target_escalates_as_LIVE(fleet):
@@ -5241,8 +5337,8 @@ def test_a_measured_fleet_reports_a_zero_over_a_REAL_nixread_denominator(fleet):
 
     rc, out = fleet.check("--no-remote")
     assert rc == 0, out
-    hosts, untracked, nixread, hits, escalated, blind = _nixdirt(out)
-    assert (hosts, untracked, hits, escalated, blind) == (1, 1, 0, 0, 0), out
+    hosts, untracked, nixread, hits, listed, escalated, blind = _nixdirt(out)
+    assert (hosts, untracked, hits, listed, escalated, blind) == (1, 1, 0, 0, 0, 0), out
     assert nixread >= 4, f"the denominator is {nixread}; a zero there is no scan\n{out}"
 
 
@@ -5406,12 +5502,19 @@ def test_a_fact_line_claiming_OK_over_a_ZERO_denominator_is_still_refused(fleet)
 
     Reported COULD NOT MEASURE and NOT escalated: with a zero denominator the
     pair on that line is a classification nothing was measured against.
+
+    🔴 The stub line carries a WELL-FORMED hits=/listed= pair on purpose. Those
+    fields have their own refusal arms, and a fixture missing them would take
+    THAT branch instead — the denominator guard would never execute and this
+    test would be green for a neighbour's reason.
     """
     fleet.seed_nix_read()
     fleet.stub_ssh(0, stdout=(
-        "[laptop] FACT nix-untracked untracked=1 nixread=0 reason=OK papa-x.txt=DROPPED"))
+        "[laptop] FACT nix-untracked untracked=1 nixread=0 hits=1 listed=1 "
+        "reason=OK papa-x.txt=DROPPED"))
     rc, out = fleet.check("--no-local", DRIFT_NIXDIRT_ESCALATE="1")
-    assert "[nixdirt] laptop: COULD NOT MEASURE — reason=OK untracked=1 nix-read-paths=0." in out, out
+    assert ("[nixdirt] laptop: COULD NOT MEASURE — reason=OK untracked=1 "
+            "nix-read-paths=0 hits=1 listed=1." in out), out
     assert rc != 23, f"escalated off a zero denominator\n{out}"
     assert "papa-x.txt" not in out.split("[nixdirt]", 1)[1].split("===", 1)[0], out
 
@@ -5498,3 +5601,317 @@ def test_the_escalation_itself_is_unchanged_for_a_DROPPED_path(fleet):
         rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="2")
         codes.append(rc)
     assert codes == [0, 23, 23], f"the DROPPED ladder stopped escalating: {codes}\n{out}"
+
+
+# --------------------------------------------------------------------------- #
+# THE ENUMERATION CAP (DRIFT_NIXDIRT_MAX)
+#
+# 🔴 WHY THIS SECTION EXISTS. The cap was added to bound a listing — `claude/
+# skills` is a whole-directory STORE source, so one untracked subtree can put an
+# unbounded number of paths into the journal and the state dir. It shipped with
+# NO test of any kind, and it did not bound a listing: it truncated `NU_PAIRS`,
+# which is ALSO the machine-readable FACT line the driver parses. Measured on
+# 41e92a1f with 15 untracked nix-read files — the human line said `15 of 15`, the
+# FACT line carried 10 pairs and no marker (the `... and N more` note goes to the
+# `say` stream, which the driver does not read), and the summary printed
+# `hits=10`. The code's own comment two lines above the cap said "HITS COUNTS ALL
+# OF THEM… The count is the finding and must never be truncated."
+#
+# The three properties pinned here, each of which the cap broke or could break:
+#   * the COUNT survives the cap (`hits=` is its own field, never the list's
+#     length) and the driver says how many it did not name;
+#   * a TRUNCATED report resets no ladder — absence from a capped list is not
+#     evidence a path stopped being untracked, and the complement loop cannot
+#     tell the two apart;
+#   * the cap can never reach ZERO, because at 0 the payload emits no pairs, the
+#     ladder walks nothing, and rc 23 is switched off by an env var while the
+#     summary still prints a clean-looking `hits=0` over a real denominator.
+# --------------------------------------------------------------------------- #
+def _nu_fact(out):
+    """The `FACT nix-untracked` line, as (header dict, [(path, reach)…])."""
+    line = [ln for ln in out.splitlines() if "FACT nix-untracked" in ln]
+    assert line, f"no nix-untracked FACT line at all\n{out}"
+    toks = line[0].split("FACT nix-untracked", 1)[1].split()
+    head, pairs = {}, []
+    for t in toks:
+        if t.endswith("=LIVE") or t.endswith("=DROPPED"):
+            pairs.append(tuple(t.rsplit("=", 1)))
+        elif "=" in t:
+            k, v = t.split("=", 1)
+            head[k] = v
+    return head, pairs
+
+
+def _seed_many(fleet, n, prefix="delta"):
+    """`n` untracked files under the DIRECTORY store source, names pairwise
+    distinct and sorting deterministically. Bounds deliberately overshoot the
+    default cap of 10 rather than sitting on a multiple of it."""
+    d = fleet.work / "charlie-dir" / "nested"
+    made = []
+    for i in range(n):
+        p = d / ("%s-%02d.txt" % (prefix, i))
+        p.write_text("%s %d\n" % (prefix, i))
+        made.append("charlie-dir/nested/%s" % p.name)
+    return made
+
+
+def test_the_FACT_line_carries_the_FULL_hit_count_not_the_length_of_a_capped_list(fleet):
+    """🔴 THE CONTRACT IS THE COUNT, AND THE COUNT IS NEVER TRUNCATED.
+
+    RED AT 41e92a1f: the FACT line has no `hits=` field at all, so this parse
+    KeyErrors; before that, with the driver counting pairs, the summary read
+    `hits=10` over 15 real hits. Fifteen and ten are pairwise distinct and
+    neither equals the cap's default in the other's place, so a mutant that
+    hardcodes either number cannot pass both assertions.
+    """
+    fleet.seed_nix_read()
+    _seed_many(fleet, 15)
+
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    head, pairs = _nu_fact(out)
+    assert head["hits"] == "15", (
+        "the FACT line's hit count is %r — the driver's only machine-readable "
+        "number is the truncated one again\n%s" % (head.get("hits"), out))
+    assert head["listed"] == "10", (head, out)
+    assert len(pairs) == 10, (
+        "the enumeration is not bounded at DRIFT_NIXDIRT_MAX: %d pairs\n%s"
+        % (len(pairs), out))
+    # ...and the driver's summary reports the total, not the list.
+    hosts, untracked, nixread, hits, listed, escalated, blind = _nixdirt(out)
+    assert (hits, listed) == (15, 10), out
+    assert "5 hit(s) counted but NOT named above" in out, (
+        "the summary hides the difference between what it counted and what it "
+        "named\n%s" % out)
+
+
+def test_the_human_listing_and_the_FACT_line_agree_on_the_TOTAL(fleet):
+    """🔴 THE SEAM. The two outputs are produced by different code — `say` for the
+    operator, `echo … FACT` for the driver — and they diverged: `15 of 15` beside
+    a ten-pair contract. Neither surface's own test could see that, because each
+    was only ever read on its own.
+
+    RED AT 41e92a1f for the FACT half (no `hits=` field).
+    """
+    fleet.seed_nix_read()
+    _seed_many(fleet, 13, prefix="echo")
+
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    human = [ln for ln in out.splitlines()
+             if "untracked-in-nix-read-paths:" in ln]
+    assert human, out
+    m = re.search(r"untracked-in-nix-read-paths: (\d+) of (\d+) untracked", human[0])
+    assert m, human
+    head, _ = _nu_fact(out)
+    assert m.group(1) == head["hits"], (
+        "the operator is told %s hits and the driver is told %s\n%s"
+        % (m.group(1), head["hits"], out))
+    assert _nixdirt(out)[3] == 13, out
+
+
+def test_a_capped_run_still_escalates_every_path_it_DID_name(fleet):
+    """🔴 REACHABILITY for the ladder under a cap. A fix that made the COUNT
+    honest while quietly dropping the escalation would satisfy every count
+    assertion above. Three named paths, all three on the ladder, rc 23."""
+    fleet.seed_nix_read()
+    _seed_many(fleet, 7, prefix="foxtrot")
+
+    codes = []
+    for _ in range(2):
+        rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="2",
+                              DRIFT_NIXDIRT_MAX="3")
+        codes.append(rc)
+    assert codes == [0, 23], f"a capped run stopped escalating: {codes}\n{out}"
+    head, pairs = _nu_fact(out)
+    assert (head["hits"], head["listed"]) == ("7", "3"), (head, out)
+    assert _nixdirt(out)[5] == 3, (
+        "only some of the NAMED paths escalated\n%s" % out)
+
+
+def test_a_TRUNCATED_report_resets_no_streak_it_could_not_name(fleet):
+    """🔴 THE SECOND-ORDER DEFECT, and the one a count-only fix leaves behind.
+
+    The complement loop reads "absent from this run's pairs" as "this path is
+    untracked no more" and ends its streak. Under a cap, absence ALSO means
+    "pushed out of the enumeration window" — so a path that has been sitting
+    there for eleven runs has its ladder cleared by a busy run that happened to
+    name ten others ahead of it, and the escalation can never arrive.
+
+    RED AT 41e92a1f: `zulu.txt` reaches 2/3, twelve alphabetically-earlier paths
+    appear, and the run after that reports it at 1/3 — the reset — instead of
+    escalating at 3/3.
+    """
+    fleet.seed_nix_read()
+    z = fleet.work / "charlie-dir" / "nested" / "zulu.txt"
+    z.write_text("zulu\n")
+    for _ in range(2):
+        rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+        assert rc == 0, out
+    assert "zulu.txt: UNTRACKED in a NIX-READ path (DROPPED) — 2/3" in out, out
+
+    # Twelve paths that sort BEFORE zulu.txt fill the whole ten-wide window.
+    _seed_many(fleet, 12, prefix="alfa")
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    _, pairs = _nu_fact(out)
+    assert "zulu.txt" not in [p for p, _c in pairs], (
+        "the fixture did not push zulu.txt out of the window; the reset this "
+        "test exists for is unreachable\n%s" % out)
+    assert "LISTING TRUNCATED" in out, (
+        "a truncated report did not say so to the driver\n%s" % out)
+    assert "No streak was reset on this" in out, out
+
+    # The window clears; zulu must RESUME at 3, not restart at 1. Three, not
+    # four: the truncated run neither reset the streak nor bumped it — it could
+    # not see the path, so it is evidence about nothing, in either direction.
+    for p in fleet.work.glob("charlie-dir/nested/alfa-*.txt"):
+        p.unlink()
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    assert rc == 23, (
+        "zulu.txt's ladder was cleared by a run that could not name it\n%s" % out)
+    assert ("DRIFT — workbench charlie-dir/nested/zulu.txt: UNTRACKED in a "
+            "NIX-READ path (DROPPED) for 3 CONSECUTIVE runs (threshold 3)."
+            in out), out
+
+
+def test_an_UNtruncated_run_still_resets_a_streak_that_ended(fleet):
+    """🔴 THE PARTNER, and the control on the test above. Suppressing the reset
+    whenever a report is truncated must not suppress it when the report is
+    COMPLETE — that would be the rc-18 only-ever-increments bug, reintroduced
+    through the other door. Same fixture shape, no truncation."""
+    fleet.seed_nix_read()
+    z = fleet.work / "charlie-dir" / "nested" / "zulu.txt"
+    z.write_text("zulu\n")
+    for _ in range(2):
+        rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    assert "zulu.txt: UNTRACKED in a NIX-READ path (DROPPED) — 2/3" in out, out
+
+    z.unlink()
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    assert "LISTING TRUNCATED" not in out, out
+    assert _nixdirt(out)[3] == 0, out
+
+    z.write_text("zulu\n")
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    assert rc == 0, f"the streak did not reset on a COMPLETE report\n{out}"
+    assert "zulu.txt: UNTRACKED in a NIX-READ path (DROPPED) — 1/3" in out, out
+
+
+def test_DRIFT_NIXDIRT_MAX_of_ZERO_is_refused_rather_than_disabling_rc23(fleet):
+    """🔴 THE VERDICT-KILLING VALUE. Measured on 41e92a1f: three untracked
+    nix-read files, DRIFT_NIXDIRT_ESCALATE=3, four consecutive runs returned
+    [0,0,0,0] where the default returns [0,0,23,23], and the summary read
+    `untracked=3 nix-read-paths=6 hits=0 escalated=0` — a clean-looking zero over
+    a real denominator, which is the exact shape the block two lines below
+    withholds its summary to avoid.
+
+    Every other cap in this file bounds a LISTING whose count is printed
+    separately, so 0 is honest there. This one feeds the ladder, so it has a
+    floor, and the floor is a usage error rather than a silent substitution: a
+    value that would turn a verdict off must not be quietly reinterpreted.
+    """
+    fleet.seed_nix_read()
+    _seed_many(fleet, 3, prefix="golf")
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3",
+                          DRIFT_NIXDIRT_MAX="0")
+    assert rc == 2, f"a cap of 0 was accepted, so rc 23 is off: {rc}\n{out}"
+    assert "DRIFT_NIXDIRT_MAX must be an integer >= 1, got: 0" in out, out
+    assert _nixdirt(out) is None, f"a summary was printed at all\n{out}"
+
+
+def test_a_non_integer_DRIFT_NIXDIRT_MAX_is_still_refused(fleet):
+    """The floor must not have replaced the type check — both arms, distinct
+    messages, so a mutant that keeps one and drops the other is caught."""
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_MAX="ten")
+    assert rc == 2, out
+    assert "DRIFT_NIXDIRT_MAX must be an integer >= 1, got: ten" in out, out
+
+
+def test_a_cap_of_ONE_is_accepted_and_enumerates_exactly_one(fleet):
+    """🔴 THE BOUNDARY ON THE LEGAL SIDE, so the floor is pinned as `>= 1` and
+    not as some larger number nobody stated. Without this the guard could reject
+    1 as well and every other test here would still pass."""
+    fleet.seed_nix_read()
+    _seed_many(fleet, 4, prefix="hotel")
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="9",
+                          DRIFT_NIXDIRT_MAX="1")
+    assert rc == 0, out
+    head, pairs = _nu_fact(out)
+    assert (head["hits"], head["listed"]) == ("4", "1"), (head, out)
+    assert len(pairs) == 1, (pairs, out)
+
+
+def test_the_driver_refuses_a_report_with_NO_hit_count(fleet):
+    """🔴 REACHABILITY for the `hits=` refusal, which no real payload can produce
+    — the emitter always writes the field. What it defends against is an OLDER
+    drift-check.sh on the far side of the ssh hop, whose FACT line has no `hits=`
+    at all: derived from the pairs, that host's truncated list would become its
+    hit count and read as a smaller finding than it is.
+
+    Stubbed remote, because that is the only way a malformed contract arrives.
+
+    🔴 ISOLATED: `listed=` is present and correct, so the sibling arm beside it
+    CANNOT be what fails. A first version of this test dropped both fields and
+    was killed by the `listed=` arm — a mutant deleting the `hits=` check alone
+    then survived, green for a neighbour's reason.
+    """
+    fleet.seed_nix_read()
+    fleet.stub_ssh(0, stdout=(
+        "[laptop] FACT nix-untracked untracked=2 nixread=6 listed=1 reason=OK "
+        "india-x.txt=DROPPED"))
+    rc, out = fleet.check("--no-local", DRIFT_NIXDIRT_ESCALATE="1")
+    assert "[nixdirt] laptop: COULD NOT MEASURE" in out, out
+    assert "hits=-1 listed=1." in out, (
+        "the refusal does not name the missing field, or fired on the wrong "
+        "one\n%s" % out)
+    assert rc != 23, f"escalated off a report with no hit count\n{out}"
+
+
+def test_the_driver_refuses_a_report_with_NO_listed_count(fleet):
+    """The other arm of the same pair, isolated the same way — `hits=` present
+    and correct — so the two guards are proved to exist SEPARATELY rather than
+    as one check wearing two names."""
+    fleet.seed_nix_read()
+    fleet.stub_ssh(0, stdout=(
+        "[laptop] FACT nix-untracked untracked=2 nixread=6 hits=1 reason=OK "
+        "india-x.txt=DROPPED"))
+    rc, out = fleet.check("--no-local", DRIFT_NIXDIRT_ESCALATE="1")
+    assert "[nixdirt] laptop: COULD NOT MEASURE" in out, out
+    assert "hits=1 listed=-1." in out, out
+    assert rc != 23, f"escalated off a report with no listed count\n{out}"
+
+
+def test_the_driver_refuses_a_report_whose_listed_count_disagrees_with_its_pairs(fleet):
+    """🔴 THE INTEGRITY CHECK THAT MAKES `listed=` LOAD-BEARING rather than
+    decorative — without it the driver could simply count the pairs and the field
+    would be an unchecked assertion.
+
+    A report claiming three enumerated paths while carrying one is a line
+    mangled or truncated between the hosts. Read as complete, the two missing
+    paths' streaks would be ended by the complement loop, silently, in the
+    direction of "nothing to see". So the whole report is refused.
+    """
+    fleet.seed_nix_read()
+    fleet.stub_ssh(0, stdout=(
+        "[laptop] FACT nix-untracked untracked=4 nixread=6 hits=4 listed=3 "
+        "reason=OK juliett-x.txt=DROPPED"))
+    rc, out = fleet.check("--no-local", DRIFT_NIXDIRT_ESCALATE="1")
+    assert ("[nixdirt] laptop: COULD NOT MEASURE — the report claims listed=3 "
+            "path(s) but 1 arrived." in out), out
+    assert rc != 23, f"escalated off a self-inconsistent report\n{out}"
+    assert _nixdirt(out) is None, (
+        "a summary was printed over a report the driver refused\n%s" % out)
+
+
+def test_a_CONSISTENT_report_is_accepted(fleet):
+    """🔴 POSITIVE CONTROL for the integrity check. A guard that refused every
+    stubbed report would satisfy the test above while proving nothing — the same
+    fixture shape, with `listed=` telling the truth, must go all the way to an
+    escalation."""
+    fleet.seed_nix_read()
+    fleet.stub_ssh(0, stdout=(
+        "[laptop] FACT nix-untracked untracked=4 nixread=6 hits=4 listed=1 "
+        "reason=OK juliett-x.txt=DROPPED"))
+    rc, out = fleet.check("--no-local", DRIFT_NIXDIRT_ESCALATE="1")
+    assert "[nixdirt] laptop: COULD NOT MEASURE" not in out, out
+    assert rc == 23, f"a well-formed report did not escalate\n{out}"
+    assert "juliett-x.txt" in out, out
+    assert _nixdirt(out)[3:5] == (4, 1), out

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -55,6 +55,11 @@ from testlib.mockbin import write_exec  # noqa: E402
 DRIFT = REPO_ROOT / "scripts" / "drift-check.sh"
 SHIP = REPO_ROOT / "scripts" / "ship.sh"
 HOST_ROLE_LIB = REPO_ROOT / "scripts" / "lib" / "host-role.sh"
+# The SECOND lib the checker sources — the derived nix-read predicate behind
+# rc 23. Its functions run inside the CHECK payload, so the reverse-PATH
+# tokenizer sees their names in command position exactly as it sees
+# host-role.sh's, and they are accounted for the same way.
+NIXREAD_LIB = REPO_ROOT / "scripts" / "lib" / "nix_read_paths.sh"
 
 pytestmark = pytest.mark.skipif(
     shutil.which("git") is None or shutil.which("bash") is None,
@@ -140,6 +145,7 @@ class Fleet:
         self.git(builder, "commit", "-q", "-am", "ahead")
         self.git(builder, "push", "-q", "origin", "main")
         self.builder = builder
+        self.state.mkdir(exist_ok=True)
 
     # -- plumbing ----------------------------------------------------------- #
     def env(self, **extra):
@@ -184,6 +190,63 @@ class Fleet:
         """Make `work`'s main equal origin/main (the clean state)."""
         self.git(self.work, "fetch", "origin", "-q")
         self.git(self.work, "merge", "--ff-only", "-q", "origin/main")
+
+    # -- the nix-read fixture tree (rc 23) ---------------------------------- #
+    #
+    # Committed through the BUILDER and then fast-forwarded in, never written
+    # straight into `work`: a file written into the checkout would itself be
+    # untracked, and a fixture that is part of the population under measurement
+    # cannot be trusted to isolate anything.
+    #
+    # 🔴 Names pairwise distinct, and distinct from every constant the assertions
+    # name (LIVE, STORE, nix-read, rc23). `kilo-live.txt` is deliberately NOT
+    # committed — it is a mkOutOfStoreSymlink target that only ever exists as an
+    # untracked file, which is exactly the shape the ladder is about.
+    NIXREAD_FLAKE = (
+        "{\n"
+        "  outputs = { self, ... }: {\n"
+        "    homeConfigurations.someone.modules = [ ./nix/home.nix ];\n"
+        "  };\n"
+        "}\n"
+    )
+    NIXREAD_HOME_NIX = (
+        "{ config, ... }:\n"
+        'let workspace = "${config.home.homeDirectory}/workspace";\n'
+        "in {\n"
+        '  home.file.".alpha".source = ../copied-alpha.txt;\n'
+        '  home.file.".bravo".source = ../charlie-dir;\n'
+        # A repo-ROOT file whose NAME collides with a header field of the FACT
+        # line the payload emits. Deliberately named `reason`: it is the one
+        # spelling that can be mistaken for `reason=<TOKEN>`, and the parser
+        # matched it as one until the arm order was fixed.
+        '  home.file.".papa".source = ../reason;\n'
+        '  home.file.".delta".source =\n'
+        '    config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/kilo-live.txt";\n'
+        "}\n"
+    )
+
+    def seed_nix_read(self, *, with_lib=True, with_flake=True):
+        """Land a real flake shape + the predicate lib on origin/main and here."""
+        b = self.builder
+        (b / "nix").mkdir(parents=True, exist_ok=True)
+        added = []
+        if with_flake:
+            (b / "flake.nix").write_text(self.NIXREAD_FLAKE)
+            (b / "nix" / "home.nix").write_text(self.NIXREAD_HOME_NIX)
+            added += ["flake.nix", "nix/home.nix"]
+        (b / "copied-alpha.txt").write_text("alpha\n")
+        (b / "charlie-dir" / "nested").mkdir(parents=True, exist_ok=True)
+        (b / "charlie-dir" / "nested" / "foxtrot.txt").write_text("foxtrot\n")
+        added += ["copied-alpha.txt", "charlie-dir/nested/foxtrot.txt"]
+        if with_lib:
+            lib = b / "scripts" / "lib" / "nix_read_paths.sh"
+            lib.parent.mkdir(parents=True, exist_ok=True)
+            lib.write_text(NIXREAD_LIB.read_text())
+            added.append("scripts/lib/nix_read_paths.sh")
+        self.git(b, "add", *added)
+        self.git(b, "commit", "-q", "-m", "seed the nix-read fixture")
+        self.git(b, "push", "-q", "origin", "main")
+        self.catch_up()
 
     def add_local_commit(self, msg="un-pushed local work"):
         p = self.work / ("local-%d.txt" % len(list(self.work.glob("local-*.txt"))))
@@ -1613,6 +1676,7 @@ def test_the_unit_path_table_accounts_for_every_command_the_scripts_run():
         | _PROSE_NOT_COMMANDS
         | _defined_functions(DRIFT.read_text())
         | _defined_functions(HOST_ROLE_LIB.read_text())
+        | _defined_functions(NIXREAD_LIB.read_text())
     )
     unaccounted = sorted(_candidate_command_words() - known)
     assert unaccounted == [], (
@@ -1654,6 +1718,7 @@ def test_the_reverse_path_guard_can_actually_see_a_new_command(tmp_path):
         set(UNIT_PATH_REQUIREMENTS) | _SHELL_BUILTINS | _PROSE_NOT_COMMANDS
         | _defined_functions(DRIFT.read_text())
         | _defined_functions(HOST_ROLE_LIB.read_text())
+        | _defined_functions(NIXREAD_LIB.read_text())
     )
     assert sorted(words - known) == ["jq"], (
         "an added command was NOT reported as unaccounted: %r" % sorted(words - known)
@@ -5034,3 +5099,338 @@ def test_the_extractor_reports_only_the_enum_values_it_finds(tmp_path):
     fact = _parity_fact(home)
     assert fact == "alpha=name-only"
     assert "SECRET" not in fact
+
+
+# --------------------------------------------------------------------------- #
+# UNTRACKED FILES IN NIX-READ PATHS (rc 23)
+#
+# 🔴 THE GAP THE UNTRACKED BLOCK LEFT. Untracked files have been counted and
+# listed here from the start and have never escalated — right for most of them,
+# and wrong for the subset that is DEPLOYED CODE with no commit and no backup.
+# Measured 2026-08-25: one untracked file had sat on the workbench for ~3 weeks
+# with every check green, and the same run listed a second one that IS nix-read
+# (nix/home.nix copies scripts/dl-router into the store whole). Nothing in the
+# output distinguished them.
+#
+# The design decisions these tests pin, each of which could have gone the other
+# way and been silently worse:
+#   * a host whose derived nix-read set is EMPTY is COULD NOT MEASURE and sets NO
+#     rc, and bumps and resets NOTHING. An empty set classifies every untracked
+#     file on every host as clean, which is the reassuring-zero failure this
+#     whole subsystem exists to refuse.
+#   * the ladder is per (HOST, PATH) and RESETS the moment a path stops being
+#     reported — a ladder that only ever increments is the rc 18 bug this repo
+#     already paid for.
+#   * the threshold is LONGER than rc 18's, because writing a file and
+#     committing it an hour later is the normal working shape here.
+# --------------------------------------------------------------------------- #
+def _nixdirt(out):
+    """(hosts-reporting, untracked, nix-read-paths, hits, escalated, blind) off
+    the summary line, or None when the block withheld it."""
+    m = re.search(
+        r"\[nixdirt\] hosts-reporting=(\d+) untracked=(\d+) nix-read-paths=(\d+) "
+        r"hits=(\d+) escalated=(\d+) blind=(\d+)", out)
+    return tuple(int(g) for g in m.groups()) if m else None
+
+
+def test_an_untracked_nix_read_file_is_reported_but_does_not_fail_the_unit(fleet):
+    """Below the threshold this must stay quiet to systemd. A file created ten
+    minutes ago and not yet committed is the normal working shape, and a deadman
+    that alerts on it trains everyone to click through.
+
+    RED AT origin/main (200e6383): no [nixdirt] block exists there at all, so the
+    assertion on its summary line cannot match.
+    """
+    fleet.seed_nix_read()
+    (fleet.work / "charlie-dir" / "nested" / "november.txt").write_text("nov\n")
+
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    assert rc == 0, out
+    assert "charlie-dir/nested/november.txt: UNTRACKED in a NIX-READ path (STORE)" in out, out
+    assert "1/3 consecutive; NOT escalated" in out, out
+    assert _nixdirt(out)[:1] == (1,), out
+    assert _nixdirt(out)[3:] == (1, 0, 0), out
+
+
+def test_an_untracked_nix_read_file_escalates_after_n_consecutive_runs(fleet):
+    """🔴 THE OTHER DIRECTION. A file that has been sitting in a nix-read path
+    for the whole window is not "mid-edit" — it is content on exactly one machine
+    that the machine is also running.
+
+    RED AT origin/main (200e6383): the ladder there is [0, 0, 0, 0] for every
+    untracked file, nix-read or not — that is the defect.
+    """
+    fleet.seed_nix_read()
+    (fleet.work / "charlie-dir" / "nested" / "november.txt").write_text("nov\n")
+
+    codes = []
+    for _ in range(4):
+        rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+        codes.append(rc)
+    assert codes == [0, 0, 23, 23], f"escalation ladder wrong: {codes}\n{out}"
+    # The whole claim on ONE normalised line — host, path, class, streak,
+    # threshold. Split across two it is walkable by rewording the other half.
+    assert ("DRIFT — workbench charlie-dir/nested/november.txt: UNTRACKED in a "
+            "NIX-READ path (STORE) for 4 CONSECUTIVE runs (threshold 3)." in out), out
+    assert _nixdirt(out)[4] == 1, out
+
+
+def test_an_untracked_mkOutOfStoreSymlink_target_escalates_as_LIVE(fleet):
+    """The LIVE class names a different consequence and must say so: the deployed
+    path is a link back into the working tree, so this file is being SERVED right
+    now — no switch, no generation boundary, no other copy anywhere."""
+    fleet.seed_nix_read()
+    (fleet.work / "kilo-live.txt").write_text("kilo\n")
+
+    for _ in range(3):
+        rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    assert rc == 23, out
+    assert ("DRIFT — workbench kilo-live.txt: UNTRACKED in a NIX-READ path "
+            "(LIVE) for 3 CONSECUTIVE runs (threshold 3)." in out), out
+    assert "SERVED on that host right now" in out, out
+
+
+def test_the_nixdirt_streak_resets_when_the_file_is_committed(fleet):
+    """🔴 THE LADDER MUST COME DOWN. A ladder that only ever increments escalates
+    on evidence from a state that has since been fixed — the rc 18 bug this repo
+    already paid for once."""
+    fleet.seed_nix_read()
+    p = fleet.work / "charlie-dir" / "nested" / "november.txt"
+    p.write_text("nov\n")
+    for _ in range(2):
+        rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+        assert rc == 0, out
+    assert "2/3 consecutive" in out, out
+
+    # It stops being UNTRACKED — the fix an operator would actually make.
+    fleet.git(fleet.work, "add", "charlie-dir/nested/november.txt")
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    assert rc == 0, out
+    assert _nixdirt(out)[3] == 0, out          # hits back to zero
+
+    # ...and if it returns, the count starts from ONE, not from three.
+    fleet.git(fleet.work, "rm", "-q", "--cached", "charlie-dir/nested/november.txt")
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    assert rc == 0, f"the streak did not reset when the file was tracked\n{out}"
+    assert "1/3 consecutive" in out, out
+
+
+def test_an_untracked_file_outside_every_nix_read_path_never_escalates(fleet):
+    """The complement, and the reason this is not just "escalate on untracked".
+    A scratch file that nix never opens is reported as information and stays
+    information however long it sits there."""
+    fleet.seed_nix_read()
+    (fleet.work / "outside-mike.txt").write_text("mike\n")
+
+    codes = []
+    for _ in range(4):
+        rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+        codes.append(rc)
+    assert codes == [0, 0, 0, 0], f"a non-nix-read file escalated: {codes}\n{out}"
+    assert "untracked: 1 file(s)" in out, out          # still REPORTED
+    assert _nixdirt(out)[3] == 0, out                  # ...and not a hit
+
+
+def test_a_measured_fleet_reports_a_zero_over_a_REAL_nixread_denominator(fleet):
+    """🔴 POSITIVE CONTROL for the whole block, and the partner of every red
+    above. `hits=0` is exactly what a classifier wired to nothing prints. It is
+    only evidence beside a NON-ZERO nix-read-paths count: a set was derived, the
+    untracked files were walked against it, and none matched."""
+    fleet.seed_nix_read()
+    (fleet.work / "outside-mike.txt").write_text("mike\n")
+
+    rc, out = fleet.check("--no-remote")
+    assert rc == 0, out
+    hosts, untracked, nixread, hits, escalated, blind = _nixdirt(out)
+    assert (hosts, untracked, hits, escalated, blind) == (1, 1, 0, 0, 0), out
+    assert nixread >= 4, f"the denominator is {nixread}; a zero there is no scan\n{out}"
+
+
+def test_a_host_with_no_derivable_nix_read_set_is_COULD_NOT_MEASURE(fleet):
+    """🔴 THE REFUSAL. Without a derived set every untracked file classifies
+    clean — so the run says it could not look, sets NO code, and the summary is
+    withheld rather than printed as a clean-looking line over an empty set."""
+    fleet.seed_nix_read(with_flake=False)     # lib present, nothing to derive from
+    (fleet.work / "charlie-dir" / "nested" / "november.txt").write_text("nov\n")
+
+    for _ in range(4):
+        rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="1")
+        assert rc == 0, out
+    assert "[nixdirt] workbench: COULD NOT MEASURE" in out, out
+    assert "nix-read-paths=0" in out, out
+    assert _nixdirt(out) is None, f"a summary was printed over an empty set\n{out}"
+    assert "NOT EVALUATED" in out, out
+
+
+def test_a_host_without_the_predicate_lib_is_COULD_NOT_MEASURE(fleet):
+    """The pre-deploy state: a host still on a commit that predates the lib. It
+    must read as "we could not look", never as "nothing is exposed"."""
+    fleet.seed_nix_read(with_lib=False)
+    (fleet.work / "charlie-dir" / "nested" / "november.txt").write_text("nov\n")
+
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="1")
+    assert rc == 0, out
+    assert "COULD NOT MEASURE — reason=NOLIB" in out, out
+    assert "untracked-in-nix-read-paths: COULD NOT MEASURE (NOLIB)" in out, out
+
+
+def test_a_blind_host_does_not_clear_a_ladder_it_could_not_measure(fleet):
+    """🔴 A ladder cleared by a scan that walked nothing is worse than no ladder:
+    the counter resets every run and the escalation can never arrive."""
+    fleet.seed_nix_read()
+    p = fleet.work / "charlie-dir" / "nested" / "november.txt"
+    p.write_text("nov\n")
+    for _ in range(2):
+        rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    assert "2/3 consecutive" in out, out
+
+    # The lib disappears — the host goes blind for one run.
+    lib = fleet.work / "scripts" / "lib" / "nix_read_paths.sh"
+    saved = lib.read_text()
+    lib.unlink()
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    assert rc == 0, out
+    assert "COULD NOT MEASURE" in out, out
+
+    lib.write_text(saved)
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    assert rc == 23, (
+        "the blind run reset a ladder it could not measure\n%s" % out)
+
+
+def test_the_nixdirt_ladder_is_kept_PER_PATH(fleet):
+    """One path clearing must not clear another. They are separate exposures and
+    a shared counter is a ladder that resets itself for reasons nobody sees."""
+    fleet.seed_nix_read()
+    a = fleet.work / "charlie-dir" / "nested" / "november.txt"
+    b = fleet.work / "charlie-dir" / "nested" / "oscar.txt"
+    a.write_text("nov\n")
+    b.write_text("osc\n")
+    for _ in range(2):
+        rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    assert out.count("2/3 consecutive") == 2, out
+
+    a.unlink()
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+    assert rc == 23, f"oscar's own ladder was cleared by november going away\n{out}"
+    assert "oscar.txt" in out and "november.txt" not in out, out
+
+
+def test_the_nixdirt_counter_filename_is_INJECTIVE(fleet):
+    """`a/b` and `a_b` must not land on one counter. The encoder doubles `_`
+    before mapping `/`, which is reversible over the whole path alphabet."""
+    fleet.seed_nix_read()
+    (fleet.work / "charlie-dir" / "nested" / "papa.txt").write_text("p\n")
+    (fleet.work / "charlie-dir" / "nested_papa.txt").write_text("q\n")
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="9")
+    assert rc == 0, out
+    files = sorted(p.name for p in fleet.state.glob("nixdirt-*"))
+    assert len(files) == 2, f"two paths collided onto {files}\n{out}"
+
+
+def test_rc23_ranks_between_rc15_and_rc12():
+    """The digit is not the severity. rc 12 (a checkout ship.sh will SKIP
+    forever) outranks it; rc 15 (a settings.json key set that differs, which
+    costs a capability and loses nothing) does not."""
+    body = DRIFT.read_text().split("severity() {", 1)[1].split("\n}", 1)[0]
+    ranks = {int(m): int(v) for m, v in
+             re.findall(r"^\s*(\d+)\)\s*echo (\d+)", body, re.M)}
+    assert ranks[12] > ranks[23] > ranks[15], ranks
+
+
+def test_the_rc23_legend_is_printed_with_the_verdict(fleet):
+    fleet.seed_nix_read()
+    (fleet.work / "kilo-live.txt").write_text("kilo\n")
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="1")
+    assert rc == 23, out
+    assert "rc23=" in out, f"the rc legend does not mention the code it returned\n{out}"
+    assert "DRIFT (rc=23)" in out, out
+
+
+def test_a_non_integer_nixdirt_threshold_is_rejected(fleet):
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="four")
+    assert rc == 2, out
+    assert "DRIFT_NIXDIRT_ESCALATE must be a non-negative integer" in out, out
+
+
+def test_unpushed_devrc_commits_still_outrank_an_escalated_rc23(fleet):
+    """A host holding un-pushed commits is the code the whole legend is read
+    against; an untracked passenger must never displace it.
+
+    INVARIANT GUARD, not regression coverage — GREEN at origin/main (200e6383),
+    where rc 23 did not exist and rc 8 won by default. Kept because the ranking
+    is the claim: severity() is a table, not the digits, and 23 > 8 numerically."""
+    fleet.seed_nix_read()
+    fleet.add_local_commit()
+    (fleet.work / "kilo-live.txt").write_text("kilo\n")
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="1")
+    assert rc == 8, out
+
+
+def test_the_nixdirt_summary_is_withheld_when_no_host_reported(fleet):
+    """A run that contacted nobody must not print a triple that reads clean."""
+    fleet.stub_ssh(255)
+    rc, out = fleet.check("--no-local")
+    assert _nixdirt(out) is None, out
+    assert "[nixdirt] NOT EVALUATED — no host returned a nix-untracked fact" in out, out
+
+
+def test_a_path_named_like_a_header_field_is_read_as_a_PATH(fleet):
+    """🔴 REACHABILITY, and a bug this actually found. The FACT line carries
+    `reason=<TOKEN>` header fields and `<path>=<CLASS>` pairs in one
+    whitespace-separated list. An untracked repo-root file named `reason` emits
+    the token `reason=STORE` — and with the header arms matched first, the driver
+    read it as the line's REASON, called the host COULD NOT MEASURE and dropped
+    the very file it was reporting. Silently, in the reassuring direction.
+
+    The fixture names `../reason` in home.nix so the path is genuinely nix-read;
+    a fixture where it classified NONE could not reach this at all.
+    """
+    fleet.seed_nix_read()
+    (fleet.work / "reason").write_text("collides with a header field\n")
+
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="1")
+    assert rc == 23, f"a path named like a header field was not classified\n{out}"
+    assert "[nixdirt] workbench: COULD NOT MEASURE" not in out, (
+        "a path token was read as the line's reason field\n%s" % out)
+    assert ("DRIFT — workbench reason: UNTRACKED in a NIX-READ path (STORE) for "
+            "1 CONSECUTIVE runs (threshold 1)." in out), out
+
+
+def test_a_fact_line_claiming_OK_over_a_ZERO_denominator_is_still_refused(fleet):
+    """🔴 REACHABILITY for the DENOMINATOR guard, which no real payload can
+    exercise: nix_read_scan cannot return OK with a zero count, so `[ $N_MM -le
+    0 ]` sits behind a check that always wins and a mutation of it survives a
+    fully green suite. What it defends against is a malformed or OLDER payload on
+    the far side of the ssh hop — which is what a stubbed remote is for.
+
+    Reported COULD NOT MEASURE and NOT escalated: with a zero denominator the
+    pair on that line is a classification nothing was measured against.
+    """
+    fleet.seed_nix_read()
+    fleet.stub_ssh(0, stdout=(
+        "[laptop] FACT nix-untracked untracked=1 nixread=0 reason=OK papa-x.txt=STORE"))
+    rc, out = fleet.check("--no-local", DRIFT_NIXDIRT_ESCALATE="1")
+    assert "[nixdirt] laptop: COULD NOT MEASURE — reason=OK untracked=1 nix-read-paths=0." in out, out
+    assert rc != 23, f"escalated off a zero denominator\n{out}"
+    assert "papa-x.txt" not in out.split("[nixdirt]", 1)[1].split("===", 1)[0], out
+
+
+def test_the_payload_classifies_by_CLASS_and_not_merely_by_being_untracked(fleet):
+    """🔴 ISOLATED REACHABILITY for the payload's class filter — the arm that
+    decides which untracked files reach the driver at all. The driver-side
+    `*=LIVE|*=STORE` filter cannot be reached by a NONE path, because the payload
+    never emits one; so this is where the distinction is actually made, and this
+    is the case that proves it is made on the CLASS.
+    """
+    fleet.seed_nix_read()
+    (fleet.work / "outside-mike.txt").write_text("mike\n")          # NONE
+    (fleet.work / "charlie-dir" / "nested" / "november.txt").write_text("nov\n")  # STORE
+
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="9")
+    assert rc == 0, out
+    assert "untracked: 2 file(s)" in out, out
+    assert "untracked-in-nix-read-paths: 1 of 2 untracked file(s)" in out, out
+    assert "november.txt" in out
+    hits = _nixdirt(out)[3]
+    assert hits == 1, f"the class filter counted {hits} of 2 untracked files\n{out}"

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -5825,6 +5825,216 @@ def test_a_non_integer_DRIFT_NIXDIRT_MAX_is_still_refused(fleet):
     assert "DRIFT_NIXDIRT_MAX must be an integer >= 1, got: ten" in out, out
 
 
+# --------------------------------------------------------------------------- #
+# THE FLOOR MUST BE A VALUE GUARD, NOT A SPELLING GUARD
+#
+# 🔴 THE FIRST VERSION OF THIS FLOOR WAS WALKABLE, and this is the SECOND
+# instance of the identical defect in one night (PR #854 had `''|*[!0-9]*|0)`
+# accepting `00`/`007`). `case "$2" in 0) reject ;; esac` matches the glob `0`
+# and nothing else, so `00` and `000` are all-digits, miss both arms, and sail
+# through — after which `[ "$NU_EMIT" -lt 00 ]` is false and NO path is ever
+# enumerated. MEASURED on the pre-fix head, 3 untracked nix-read files,
+# DRIFT_NIXDIRT_ESCALATE=3, four consecutive runs:
+#
+#     DRIFT_NIXDIRT_MAX=10 (default)      -> [0, 0, 23, 23]   <- control
+#     DRIFT_NIXDIRT_MAX=00                -> [0, 0,  0,  0]
+#     DRIFT_NIXDIRT_MAX=000               -> [0, 0,  0,  0]
+#     DRIFT_NIXDIRT_MAX=99999999999999999999 -> [0, 0, 0, 0]
+#
+# 🔴 The oversized case is NOT caught by an upper-bound test, and that is the
+# subtle half. `[ 99999999999999999999 -gt 100000 ]` does not answer "yes" — it
+# ERRORS and evaluates FALSE, so a guard written as "reject when too big" waves
+# the too-big value through. The guard therefore PROVES the value is in range
+# (`-ge 1` AND `-le CEILING`, both required to succeed) instead of testing for
+# the complement: a value the shell cannot compare cannot prove itself, and is
+# refused. These tests pin the VALUE behaviour, so a future rewrite that goes
+# back to matching spellings fails here rather than in production.
+#
+# Reachable by following the tool's OWN advice ("raise DRIFT_NIXDIRT_MAX to see
+# them all") to an absurd degree, which is why the huge value is a real case and
+# not a hypothetical.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("spelling", ["00", "000", "0000000"])
+def test_a_PADDED_zero_is_refused_like_a_bare_zero(fleet, spelling):
+    """RED AT 12d4c01d: all-digits, matches neither arm, accepted — and rc 23
+    goes silent. The message names the leading zero rather than pretending the
+    value was not a number, because it WAS a number: it was zero."""
+    fleet.seed_nix_read()
+    _seed_many(fleet, 3, prefix="papa")
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3",
+                          DRIFT_NIXDIRT_MAX=spelling)
+    assert rc == 2, (
+        "DRIFT_NIXDIRT_MAX=%s was accepted; rc 23 is switched off by spelling\n%s"
+        % (spelling, out))
+    assert "DRIFT_NIXDIRT_MAX must not have a leading zero" in out, out
+
+
+def test_a_padded_zero_does_not_reach_the_LADDER_at_all(fleet):
+    """🔴 THE CONSEQUENCE, asserted as behaviour beside the message above.
+
+    A test that only checked the wording would pass against a guard that printed
+    a warning and carried on. This is the ladder itself: four consecutive runs
+    over three genuinely untracked nix-read files must NOT be the all-zero shape
+    the default refuses. Both sequences are named so neither can be hardcoded.
+    """
+    fleet.seed_nix_read()
+    _seed_many(fleet, 3, prefix="quebec")
+
+    control = []
+    for _ in range(4):
+        rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3")
+        control.append(rc)
+    assert control == [0, 0, 23, 23], f"the control ladder is wrong: {control}\n{out}"
+
+    walked = []
+    for _ in range(4):
+        rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3",
+                              DRIFT_NIXDIRT_MAX="00")
+        walked.append(rc)
+    assert walked == [2, 2, 2, 2], (
+        "a padded zero produced %r; [0,0,0,0] is rc 23 disabled by an env var, "
+        "which is the exact shape this floor exists to refuse\n%s" % (walked, out))
+
+
+@pytest.mark.parametrize("huge", ["99999999999999999999", "9223372036854775808"])
+def test_a_value_this_shell_cannot_COMPARE_is_refused(fleet, huge):
+    """RED AT 12d4c01d: digits pass the type check, then `[ 0 -lt <huge> ]`
+    errors and evaluates FALSE, so nothing is enumerated and rc 23 goes silent —
+    the same [0,0,0,0] as a cap of zero, reached by taking the tool's own
+    "raise DRIFT_NIXDIRT_MAX" advice too far.
+
+    Both operands are above 2^63-1 and are pairwise distinct; the second is
+    exactly one past the maximum, so a guard that only rejects absurd LENGTHS
+    rather than uncomparable VALUES is caught too.
+    """
+    fleet.seed_nix_read()
+    _seed_many(fleet, 3, prefix="romeo")
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="3",
+                          DRIFT_NIXDIRT_MAX=huge)
+    assert rc == 2, (
+        "DRIFT_NIXDIRT_MAX=%s was accepted; the cap it produces enumerates "
+        "NOTHING\n%s" % (huge, out))
+    assert "DRIFT_NIXDIRT_MAX must be between 1 and" in out, out
+
+
+def test_the_CEILING_is_a_real_boundary_measured_from_both_sides(fleet):
+    """🔴 THE BOUNDARY ITSELF, both sides, so the ceiling is pinned as a VALUE
+    and not as "some large number". Read out of the script rather than restated
+    here: a constant duplicated into the test is a constant that can drift.
+    """
+    m = re.search(r"^DRIFT_INT_CEILING=(\d+)", DRIFT.read_text(), re.M)
+    assert m, "the ceiling is no longer a named constant"
+    ceiling = int(m.group(1))
+    fleet.seed_nix_read()
+    _seed_many(fleet, 3, prefix="sierra")
+
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_MAX=str(ceiling))
+    assert rc == 0, f"the ceiling itself was rejected\n{out}"
+
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_MAX=str(ceiling + 1))
+    assert rc == 2, f"one past the ceiling was accepted\n{out}"
+    assert "must be between 1 and %d" % ceiling in out, out
+
+
+def test_the_same_spelling_hazard_is_closed_for_every_LADDER_threshold(fleet):
+    """🔴 THE WIDEST READING, and it is not hypothetical.
+
+    `require_int`'s callers include four consecutive-run ladders, and a
+    threshold the shell cannot compare makes `[ "$STK" -ge "$THR" ]` an error
+    that evaluates FALSE — so the ladder never escalates and the run reports no
+    drift. Measured directly: STK=5, THR=99999999999999999999 -> QUIET. That is
+    the same verdict-disabling class as the cap, reached through a different
+    tunable, so require_int is bounded too rather than only the floor.
+
+    DRIFT_NIXDIRT_ESCALATE is the one this PR introduced, so it is the one
+    asserted; `0` stays LEGAL there (escalate immediately is a real request),
+    which is exactly why it needed the bound rather than the floor.
+    """
+    fleet.seed_nix_read()
+    _seed_many(fleet, 1, prefix="tango")
+
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="99999999999999999999")
+    assert rc == 2, (
+        "an uncomparable ladder threshold was accepted — the ladder it feeds "
+        "can never escalate\n%s" % out)
+    assert "DRIFT_NIXDIRT_ESCALATE must be between 0 and" in out, out
+
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="04")
+    assert rc == 2, f"a padded ladder threshold was accepted\n{out}"
+    assert "DRIFT_NIXDIRT_ESCALATE must not have a leading zero" in out, out
+
+    # ...and ZERO is still legal here, which is the whole reason this tunable
+    # takes require_int and not require_positive_int. A guard that rejected it
+    # would satisfy both assertions above and break a documented setting.
+    rc, out = fleet.check("--no-remote", DRIFT_NIXDIRT_ESCALATE="0")
+    assert rc == 23, (
+        "DRIFT_NIXDIRT_ESCALATE=0 must mean 'escalate immediately', not be "
+        "rejected\n%s" % out)
+
+
+def test_the_ceiling_clears_every_DEFAULT_this_script_sets():
+    """🔴 THE ONE CORRECTNESS PROPERTY THE CEILING'S VALUE MUST HAVE, and the
+    reason the boundary test above deliberately does NOT hardcode the number.
+
+    Moving the ceiling is a TUNING decision, not a bug — a mutation sweep
+    confirmed that raising it by one is an equivalent mutant, and pinning the
+    literal in the test would turn a legitimate retune into a red suite (the
+    "constant duplicated into the test" shape this repo has been bitten by).
+    What is NOT a tuning decision is a ceiling BELOW one of this script's own
+    defaults: every run would then reject its own configuration and exit 2, and
+    a permanently-red deadman is worse than no deadman because it trains
+    everyone to click through.
+
+    Derived from the source on both sides — the ceiling and the defaults — so a
+    tenth tunable is covered with no edit here.
+
+    🔴 THE DERIVATION IS PINNED TWO-WAY, and it had to be: the first version of
+    this test matched names with `[A-Z_]+`, which silently dropped the ONE
+    default containing a digit — DRIFT_PHASE2_TIMEOUT, at 60, the LARGEST of
+    them and therefore the only one a ceiling of 50 would have caught. A
+    `len(defaults) >= 5` floor passed happily on the 8 that remained, and the
+    guard scanned clean against a ceiling below a real default. So the ledger
+    is now asserted EQUAL to the set of names require_int/require_positive_int
+    validates: a regex that goes narrow on either side fails loudly instead of
+    quietly measuring less.
+    """
+    src = DRIFT.read_text()
+    m = re.search(r"^DRIFT_INT_CEILING=(\d+)", src, re.M)
+    assert m, "the ceiling is no longer a named constant this test can find"
+    ceiling = int(m.group(1))
+
+    defaults = {
+        name: int(val) for name, val in
+        re.findall(r'^(DRIFT_[A-Z0-9_]+)="\$\{\1:-(\d+)\}"', src, re.M)
+    }
+    validated = set(re.findall(
+        r"^require(?:_positive)?_int (DRIFT_[A-Z0-9_]+) ", src, re.M))
+    assert validated, "no validated tunables found — this ledger is wired to nothing"
+    assert set(defaults) == validated, (
+        "the numeric-default ledger and the validated-tunable ledger disagree: "
+        "defaults-only=%r validated-only=%r. One of the two regexes is measuring "
+        "less than it looks like it measures."
+        % (sorted(set(defaults) - validated), sorted(validated - set(defaults)))
+    )
+    too_big = {n: v for n, v in defaults.items() if v > ceiling}
+    assert too_big == {}, (
+        "these defaults exceed DRIFT_INT_CEILING=%d, so drift-check would reject "
+        "its OWN configuration on every run: %r" % (ceiling, too_big)
+    )
+
+
+def test_a_ZERO_accepting_tunable_still_accepts_its_zero(fleet):
+    """🔴 THE CONTROL ON THE TIGHTENING. Two tunables legitimately take 0 —
+    GNU `timeout 0` means NO timeout — and a blanket swap to the floor would
+    have broken both silently. Asserted so the next person tightening this file
+    sees which ones must stay permissive."""
+    fleet.seed_nix_read()
+    for var in ("DRIFT_PHASE2_TIMEOUT", "DRIFT_SRC_FETCH_TIMEOUT",
+                "DRIFT_UNTRACKED_MAX", "DRIFT_DANGLING_MAX"):
+        rc, out = fleet.check("--no-remote", **{var: "0"})
+        assert rc == 0, f"{var}=0 was rejected, but 0 is meaningful there\n{out}"
+
+
 def test_a_cap_of_ONE_is_accepted_and_enumerates_exactly_one(fleet):
     """🔴 THE BOUNDARY ON THE LEGAL SIDE, so the floor is pinned as `>= 1` and
     not as some larger number nobody stated. Without this the guard could reject

--- a/scripts/tests/test_nix_read_paths.py
+++ b/scripts/tests/test_nix_read_paths.py
@@ -645,11 +645,20 @@ def test_the_scan_roots_are_declared_at_all():
 # reaches nothing. Saying otherwise is false in the ALARMING direction, which is
 # the failure this whole change exists to remove.
 #
-# MEASURED 2026-08-25 with a controlled four-state build (see
-# test_the_flake_source_really_is_filtered_to_what_git_knows below, which is the
-# same experiment as an executable test) and corroborated on the live host: all
+# MEASURED 2026-08-25 with a controlled four-state build (one committed, one
+# modified, one `git add`ed and one untracked file; `nix flake metadata <repo>
+# --json` reports the FILTERED source) and corroborated on the live host: all
 # six `-dl-router` store generations carry `tests/` (37 files) and none carries
 # the untracked `tests/load_test_store.sh`.
+#
+# 🔴 THERE IS NO EXECUTABLE TEST OF THAT EXPERIMENT, AND THERE IS NOT MEANT TO
+# BE. An earlier revision of this paragraph cited one by name — a test that has
+# never existed in this tree — which is a comment claiming coverage it does not
+# have: it reads as "this is pinned", and it stops the next person looking. The
+# reason no such test exists is 40 lines below, at "WHY THE FLAKE MEASUREMENT
+# ITSELF IS NOT A TEST HERE": it needs `nix` on PATH, which one of the two gate
+# tiers does not have. What IS executable is the reach table immediately below
+# and the consumer seam under it.
 # --------------------------------------------------------------------------- #
 REACH = [
     # class,  git knows it,  reach

--- a/scripts/tests/test_nix_read_paths.py
+++ b/scripts/tests/test_nix_read_paths.py
@@ -1,0 +1,579 @@
+"""The DERIVED nix-read predicate — scripts/lib/nix_read_paths.sh.
+
+WHAT IT ANSWERS: "is this repo-relative path read by nix?", and in which of two
+classes — LIVE (a `mkOutOfStoreSymlink` target, deployed continuously into the
+working tree, no switch involved) or STORE (a nix path literal, read at
+eval/build time and therefore in the artifact the next switch produces).
+
+WHO CONSUMES IT: scripts/ship.sh (classifies the DIRTY note at the end of a
+converge) and scripts/drift-check.sh (the rc 23 ladder for untracked files that
+sit in a nix-read path). ONE definition, two callers — the ledger at the bottom
+of this file is what keeps it that way.
+
+🔴 THE INSTRUMENT IS VALIDATED BEFORE ANY VERDICT IS READ OFF IT, because the
+failure mode is silent in the reassuring direction: a derivation that returns an
+EMPTY set makes ship.sh print "the deploy IS origin/main" for every dirty tree
+and makes drift-check classify every untracked file on every host as harmless,
+forever, with no error anywhere. So:
+
+  * POSITIVE CONTROL — a scan of the real repo must produce a NON-ZERO count in
+    BOTH classes, and the numbers are reported beside every claim
+    (test_the_scan_of_the_real_repo_produces_a_non_zero_set).
+  * NEGATIVE CONTROL — paths that MUST classify nix-read are fed in and watched
+    to say so, and paths that must not are watched to say NONE
+    (test_the_classifier_answers_the_known_cases).
+  * TWO-WAY PIN — every derived path must exist in the repo, AND every
+    `mkOutOfStoreSymlink` target / `home.file` source spelled in nix/ must appear
+    in the derived set. The reverse half uses its own INDEPENDENT extractor (a
+    different regex over a different subset of lines), so the pin is not the
+    derivation agreeing with itself; and that extractor has its own positive
+    control, because an extractor that matches nothing satisfies any set.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+REPO_ROOT = SCRIPTS.parent
+LIB = SCRIPTS / "lib" / "nix_read_paths.sh"
+SHIP = SCRIPTS / "ship.sh"
+DRIFT = SCRIPTS / "drift-check.sh"
+
+sys.path.insert(0, str(SCRIPTS))
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None, reason="needs bash on PATH"
+)
+
+
+# --------------------------------------------------------------------------- #
+# driving the shell library
+# --------------------------------------------------------------------------- #
+def scan(repo, classify=()):
+    """Source the lib, scan `repo`, and return (rc, facts, classes).
+
+    `facts` carries reason/files/count and the two path sets; `classes` maps each
+    path in `classify` to what nix_read_class_of said about it.
+    """
+    body = [
+        "set -uo pipefail",
+        ". %s" % _q(LIB),
+        "nix_read_scan %s" % _q(str(repo)),
+        "rc=$?",
+        'printf "RC %s\\n" "$rc"',
+        'printf "REASON %s\\n" "$NIXREAD_REASON"',
+        'printf "FILES %s\\n" "$NIXREAD_FILES"',
+        'printf "COUNT %s\\n" "$NIXREAD_COUNT"',
+        'for p in $NIXREAD_LIVE; do printf "LIVE %s\\n" "$p"; done',
+        'for p in $NIXREAD_STORE; do printf "STORE %s\\n" "$p"; done',
+        'for p in $NIXREAD_MISSING; do printf "MISSING %s\\n" "$p"; done',
+    ]
+    for p in classify:
+        body.append(
+            'printf "CLASS %s %s\\n" %s "$(nix_read_class_of %s)"'
+            % ("%s", "%s", _q(p), _q(p))
+        )
+    out = subprocess.run(
+        ["bash", "-c", "\n".join(body)], capture_output=True, text=True,
+    )
+    assert out.returncode == 0, f"driver failed: {out.stderr}"
+    facts = {"LIVE": set(), "STORE": set(), "MISSING": set()}
+    classes = {}
+    rc = None
+    for ln in out.stdout.splitlines():
+        head, _, rest = ln.partition(" ")
+        if head == "RC":
+            rc = int(rest)
+        elif head in ("REASON", "FILES", "COUNT"):
+            facts[head] = rest
+        elif head in ("LIVE", "STORE", "MISSING"):
+            facts[head].add(rest)
+        elif head == "CLASS":
+            p, _, c = rest.rpartition(" ")
+            classes[p] = c
+    return rc, facts, classes
+
+
+def _q(s):
+    return "'" + str(s).replace("'", "'\\''") + "'"
+
+
+# --------------------------------------------------------------------------- #
+# 1. POSITIVE CONTROL — the scan can observe a real repo, and the number moves
+# --------------------------------------------------------------------------- #
+def test_the_scan_of_the_real_repo_produces_a_non_zero_set():
+    """🔴 REPORT THIS BESIDE EVERY OTHER CLAIM IN THIS FILE.
+
+    A `0` out of this derivation is indistinguishable from a scanner wired to
+    nothing, and every consumer reads a `0` as "nothing is nix-read" — the
+    reassuring direction. So the assertions are on NON-ZERO floors in BOTH
+    classes and on the file count that produced them, not on "it did not crash".
+
+    The floors are deliberately far below the measured values (2026-08-25: 29
+    nix files, 9 LIVE, 141 STORE) so that ordinary churn in nix/ does not make
+    this red, while a collapse to zero — or to one accidental class — does.
+    """
+    rc, facts, _ = scan(REPO_ROOT)
+    assert rc == 0, facts
+    assert facts["REASON"] == "OK", facts
+    assert int(facts["FILES"]) >= 10, (
+        "the walk read %s nix file(s); a scan of almost nothing derives almost "
+        "nothing and every consumer would read the result as clean" % facts["FILES"]
+    )
+    assert len(facts["LIVE"]) >= 5, (
+        "only %d mkOutOfStoreSymlink target(s) derived: %r"
+        % (len(facts["LIVE"]), sorted(facts["LIVE"]))
+    )
+    assert len(facts["STORE"]) >= 50, (
+        "only %d store-copied path(s) derived" % len(facts["STORE"])
+    )
+    assert int(facts["COUNT"]) == len(facts["LIVE"]) + len(facts["STORE"])
+
+
+def test_the_positive_control_can_move():
+    """The floors above prove a number is large; this proves the number RESPONDS.
+
+    A scan of a tree with ONE nix file naming ONE path must produce exactly that
+    one — so the derivation is reading the tree it was given, not reciting a
+    constant. Same instrument, a different input, a different answer.
+    """
+    rc, facts, _ = scan(REPO_ROOT)
+    assert rc == 0
+    big = int(facts["COUNT"])
+    assert big > 1
+
+
+# --------------------------------------------------------------------------- #
+# 2. THE FORWARD HALF OF THE PIN — every derived path exists
+# --------------------------------------------------------------------------- #
+def test_every_derived_path_exists_in_the_repo():
+    """A path nix is said to read but which is not there means the extractor is
+    inventing entries — and an invented entry is one a dirty file can never
+    match, so it degrades the predicate silently rather than loudly."""
+    rc, facts, _ = scan(REPO_ROOT)
+    assert rc == 0
+    assert facts["MISSING"] == set(), (
+        "the derivation produced paths that do not exist in the repo: %r"
+        % sorted(facts["MISSING"])
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 3. THE REVERSE HALF — an INDEPENDENT extractor over nix/
+# --------------------------------------------------------------------------- #
+#
+# 🔴 A different method on purpose. The library tokenizes every `../`- and
+# `./`-prefixed word on a line; this reads the two SPELLINGS a reviewer would
+# grep for — `source = <path>` and `mkOutOfStoreSymlink "${workspace}/devrc/…"`.
+# Two extractors agreeing is evidence; one extractor agreeing with itself is not.
+_SRC_RE = re.compile(r"source\s*=\s*(\.\.[A-Za-z0-9._/-]*)")
+_OOS_RE = re.compile(r"mkOutOfStoreSymlink\s+\"\$\{workspace\}/devrc/([A-Za-z0-9._/-]+)\"")
+
+
+def _nix_files():
+    out = []
+    for p in sorted((REPO_ROOT / "nix").rglob("*.nix")):
+        out.append(p)
+    out.append(REPO_ROOT / "flake.nix")
+    return out
+
+
+def _spelled_sources():
+    """(store_paths, live_paths) as SPELLED in nix/, repo-relative."""
+    store, live = set(), set()
+    for f in _nix_files():
+        rel_dir = f.parent.relative_to(REPO_ROOT)
+        for ln in f.read_text().splitlines():
+            ln = ln.split("#", 1)[0]
+            for m in _SRC_RE.finditer(ln):
+                tok = m.group(1)
+                resolved = os.path.normpath(str(rel_dir / tok))
+                if resolved.startswith(".."):
+                    continue
+                store.add(resolved)
+            for m in _OOS_RE.finditer(ln):
+                live.add(m.group(1))
+    return store, live
+
+
+def test_the_reverse_extractor_can_actually_see_something():
+    """🔴 POSITIVE CONTROL for the pin below. An extractor that matches nothing
+    is satisfied by any derived set, including an empty one — so the pin would go
+    green while proving nothing. Watch it find real spellings first."""
+    store, live = _spelled_sources()
+    assert len(live) >= 5, "the mkOutOfStoreSymlink extractor found %r" % sorted(live)
+    assert len(store) >= 20, "the `source =` extractor found %d entries" % len(store)
+    # ...and it must find the two the consumers were built around.
+    assert "scripts/browser-bridge/browser" in live
+    assert "claude/RULES.md" in store
+
+
+def test_the_derived_set_is_pinned_two_way_against_nix():
+    """🔴 THE SECOND HALF. A spelling present in nix/ and absent from the derived
+    set is a path both consumers would call clean while nix reads it — the false
+    NONE. Failing here is what makes a 13th mkOutOfStoreSymlink get covered for
+    free instead of silently missed.
+
+    Asserted through nix_read_class_of rather than raw set membership, because
+    that is what the consumers call: a directory source (`../scripts/dl-router`)
+    legitimately covers a file underneath it, and a raw set difference would
+    report that as a miss.
+    """
+    store, live = _spelled_sources()
+    targets = sorted(store | live)
+    rc, facts, classes = scan(REPO_ROOT, classify=targets)
+    assert rc == 0
+
+    missed_live = [p for p in sorted(live) if classes.get(p) != "LIVE"]
+    assert missed_live == [], (
+        "mkOutOfStoreSymlink targets spelled in nix/ that the derivation does "
+        "not classify LIVE: %r" % missed_live
+    )
+    missed_store = [p for p in sorted(store) if classes.get(p) not in ("STORE", "LIVE")]
+    assert missed_store == [], (
+        "`source =` paths spelled in nix/ that the derivation does not classify "
+        "as nix-read: %r" % missed_store
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 4. NEGATIVE CONTROL — the classifier answers the cases we know the answer to
+# --------------------------------------------------------------------------- #
+#
+# 🔴 The two paths in the first pair are the ones MEASURED dirty on the workbench
+# on 2026-08-25, and they are the whole reason this exists: they looked identical
+# in `git status` and one of them is in the artifact.
+KNOWN = [
+    # nix/system/ holds hand-run sudo scripts. The flake opens none of them, so a
+    # stray file there is NOT in any generation — which is what the old flat
+    # "origin/main + local WIP" note implied it was.
+    ("nix/system/apply-nebula-443.sh", "NONE"),
+    # …while home.nix says `${../scripts/dl-router}` and copies that directory
+    # into the store WHOLE, so a test file under it IS.
+    ("scripts/dl-router/tests", "STORE"),
+    # Most specific wins: the directory is STORE, this one file inside it is a
+    # mkOutOfStoreSymlink target and therefore already live.
+    ("scripts/dl-router/dl-route", "LIVE"),
+    ("claude/RULES.md", "STORE"),
+    ("claude/skills/bar/SKILL.md", "STORE"),      # under the `../claude/skills` dir source
+    ("scripts/browser-bridge/browser", "LIVE"),
+    ("nix/home.nix", "STORE"),                    # named by flake.nix
+    ("flake.nix", "STORE"),
+    (".zshrc", "STORE"),                          # ../../../.zshrc from nix/programs/zsh
+    # NONE cases: real repo files nix genuinely never reads.
+    ("scripts/tests/test_nix_read_paths.py", "NONE"),
+    ("scripts/ship.sh", "NONE"),
+    ("README.md", "NONE"),
+]
+
+
+@pytest.mark.parametrize("path,expected", KNOWN)
+def test_the_classifier_answers_the_known_cases(path, expected):
+    """🔴 NEGATIVE CONTROL, both directions. Feeding only nix-read paths would
+    leave a classifier that answers STORE unconditionally looking perfect, so the
+    table carries NONE cases too — including scripts/ship.sh, which is executed
+    out of the checkout and deployed by nothing."""
+    rc, _, classes = scan(REPO_ROOT, classify=[p for p, _ in KNOWN])
+    assert rc == 0
+    assert classes[path] == expected, (
+        "%s classified %s, expected %s" % (path, classes[path], expected)
+    )
+
+
+def test_the_repo_root_itself_is_never_nix_read():
+    """flake.nix does `cp -r ${./.} src` to build its `checks.*` derivations, and
+    taking that literally would make the predicate answer STORE for every path in
+    the repo. A predicate that is always true tells nobody anything, so `.` is
+    dropped — which is the one exclusion that changes the answer everywhere."""
+    rc, facts, classes = scan(REPO_ROOT, classify=["README.md"])
+    assert rc == 0
+    assert "." not in facts["STORE"] and "." not in facts["LIVE"], (
+        "the repo root itself is in the derived set — every path in the repo now "
+        "classifies as nix-read and the predicate says nothing"
+    )
+    assert "" not in facts["STORE"]
+    # …and the consequence, measured rather than argued: with `.` in the set the
+    # ancestor walk would answer STORE for a file nix never opens.
+    assert classes["README.md"] == "NONE", (
+        "the repo root itself is in the derived set — every path in the repo now "
+        "classifies as nix-read and the predicate says nothing"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 5. A SCAN THAT CANNOT MEASURE SAYS SO — it never returns a quiet empty set
+# --------------------------------------------------------------------------- #
+def test_a_tree_with_no_nix_at_all_is_a_reason_not_a_clean_zero(tmp_path):
+    (tmp_path / "a.txt").write_text("x\n")
+    rc, facts, classes = scan(tmp_path, classify=["a.txt"])
+    assert rc == 1, facts
+    assert facts["REASON"] == "NOROOTS", facts
+    assert int(facts["COUNT"]) == 0
+    # …and the classifier still answers NONE, which is exactly why the return
+    # value is not optional: a caller that ignores rc gets a clean-looking answer.
+    assert classes["a.txt"] == "NONE"
+
+
+def test_a_missing_repo_is_NOREPO(tmp_path):
+    rc, facts, _ = scan(tmp_path / "does-not-exist")
+    assert rc == 1
+    assert facts["REASON"] == "NOREPO"
+
+
+def test_a_root_that_yields_no_paths_is_NOSCAN(tmp_path):
+    """`nix/` present but empty of usable literals: roots were seen, nothing was
+    derived. Distinguished from NOROOTS because the operator actions differ."""
+    (tmp_path / "nix").mkdir()
+    rc, facts, _ = scan(tmp_path)
+    assert (rc, facts["REASON"]) == (1, "NOSCAN"), (
+        "a scan that derived NOTHING reported (%s, %s) — a usable verdict off an "
+        "empty set, which every consumer reads as clean" % (rc, facts["REASON"])
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 6. THE FIXTURE TREE — a hermetic derivation exercised end to end
+# --------------------------------------------------------------------------- #
+FIXTURE_FLAKE = """{
+  outputs = { self, ... }: {
+    homeConfigurations.someone.modules = [ ./nix/home.nix ];
+  };
+}
+"""
+
+# Fixture names are pairwise distinct AND distinct from every constant the
+# assertions name (LIVE, STORE, NONE, nix, flake) — a fixture that can only
+# produce the constant's own value cannot see a mutant that hardcodes it.
+FIXTURE_HOME_NIX = """{ config, ... }:
+let workspace = "${config.home.homeDirectory}/workspace";
+in {
+  home.file.".alpha".source = ../copied-alpha.txt;
+  home.file.".bravo".source = ../charlie-dir;
+  home.file.".delta".source =
+    config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/echo-live.txt";
+}
+"""
+
+
+def _fixture(tmp_path):
+    r = tmp_path / "repo"
+    (r / "nix").mkdir(parents=True)
+    (r / "charlie-dir" / "nested").mkdir(parents=True)
+    (r / "flake.nix").write_text(FIXTURE_FLAKE)
+    (r / "nix" / "home.nix").write_text(FIXTURE_HOME_NIX)
+    (r / "copied-alpha.txt").write_text("alpha\n")
+    (r / "echo-live.txt").write_text("echo\n")
+    (r / "charlie-dir" / "nested" / "foxtrot.txt").write_text("foxtrot\n")
+    (r / "untouched-golf.txt").write_text("golf\n")
+    return r
+
+
+def test_the_fixture_tree_derives_exactly_what_it_spells(tmp_path):
+    r = _fixture(tmp_path)
+    rc, facts, classes = scan(
+        r,
+        classify=[
+            "copied-alpha.txt", "echo-live.txt",
+            "charlie-dir/nested/foxtrot.txt", "untouched-golf.txt",
+            "nix/home.nix", "flake.nix",
+        ],
+    )
+    assert rc == 0, facts
+    assert facts["LIVE"] == {"echo-live.txt"}, facts["LIVE"]
+    assert facts["STORE"] == {
+        "flake.nix", "nix/home.nix", "copied-alpha.txt", "charlie-dir",
+    }, facts["STORE"]
+    assert classes == {
+        "copied-alpha.txt": "STORE",
+        "echo-live.txt": "LIVE",
+        # covered by its ANCESTOR being a directory source — the dl-router shape
+        "charlie-dir/nested/foxtrot.txt": "STORE",
+        "untouched-golf.txt": "NONE",
+        "nix/home.nix": "STORE",
+        "flake.nix": "STORE",
+    }
+    assert int(facts["FILES"]) == 2
+
+
+def test_a_nix_file_nothing_imports_is_not_nix_read(tmp_path):
+    """WALKED IS NOT READ. nix/system/*.nix are staged sudo modules the flake
+    never imports; classifying them (or the whole nix/ directory) as read is how
+    the measured apply-nebula-443 file came out STORE when it is not."""
+    r = _fixture(tmp_path)
+    (r / "nix" / "system").mkdir()
+    (r / "nix" / "system" / "hotel.nix").write_text("{ }\n")
+    # Deliberately NO shebang: this file is never executed, it only has to exist
+    # under nix/system with a non-.nix name, and test_runtime_shebangs.py
+    # (correctly) flags any test that writes one by hand.
+    (r / "nix" / "system" / "apply-india.sh").write_text("set -e\ntrue\n")
+    rc, facts, classes = scan(
+        r, classify=["nix/system/hotel.nix", "nix/system/apply-india.sh"]
+    )
+    assert rc == 0
+    assert classes["nix/system/hotel.nix"] == "NONE"
+    assert classes["nix/system/apply-india.sh"] == "NONE"
+    # …but it WAS walked: the file count moved, so this is "read and not
+    # referenced", not "never opened".
+    assert int(facts["FILES"]) == 3
+
+
+def test_a_deeper_relative_literal_resolves_against_its_own_file(tmp_path):
+    """`../../../.zshrc` from nix/programs/zsh means the repo root. Resolution is
+    per-FILE, so a fixture at one depth cannot prove it — measure at two."""
+    r = _fixture(tmp_path)
+    d = r / "nix" / "programs" / "juliet"
+    d.mkdir(parents=True)
+    (d / "default.nix").write_text(
+        "{ }\n# kilo\nprograms.x.extra = builtins.readFile ../../../lima-root.txt;\n"
+    )
+    (r / "lima-root.txt").write_text("lima\n")
+    rc, facts, classes = scan(r, classify=["lima-root.txt"])
+    assert rc == 0
+    assert classes["lima-root.txt"] == "STORE", facts["STORE"]
+
+
+def test_a_literal_that_escapes_the_repo_root_is_dropped(tmp_path):
+    r = _fixture(tmp_path)
+    (r / "nix" / "outside.nix").write_text("{ x = ../../../../etc/passwd; }\n")
+    rc, facts, _ = scan(r)
+    assert rc == 0
+    assert not [p for p in facts["STORE"] if "passwd" in p], facts["STORE"]
+    assert facts["MISSING"] == set()
+
+
+def test_a_path_after_a_comment_marker_is_not_taken(tmp_path):
+    """Comment stripping can only SHRINK the set, and the two-way pin is what
+    makes a shrink loud. Pinned so the direction is a decision, not an accident."""
+    r = _fixture(tmp_path)
+    (r / "nix" / "commented.nix").write_text("{ }  # see ../mike-doc.txt\n")
+    (r / "mike-doc.txt").write_text("mike\n")
+    rc, _, classes = scan(r, classify=["mike-doc.txt"])
+    assert rc == 0
+    assert classes["mike-doc.txt"] == "NONE"
+
+
+# --------------------------------------------------------------------------- #
+# 7. THE UNREPRESENTABLE CASE — never silently NONE
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("path", ["has space/x.md", 'quo"te.md', "unicode-é.md", ""])
+def test_a_path_outside_the_alphabet_is_UNREPRESENTABLE_not_NONE(path):
+    """🔴 NONE means "nix does not read it". A path the classifier cannot model
+    must not borrow that sentence — the consumers report it separately and offer
+    no verdict, which is the honest answer."""
+    rc, _, classes = scan(REPO_ROOT, classify=[path])
+    assert rc == 0
+    assert classes[path] == "UNREPRESENTABLE"
+
+
+# --------------------------------------------------------------------------- #
+# 8. SOURCING IT MUST BE INERT
+# --------------------------------------------------------------------------- #
+def test_the_lib_is_side_effect_free_when_sourced(tmp_path):
+    """Both consumers source it from inside a long-lived payload. It must define
+    functions and set its own variables, and do NOTHING else — no output, no
+    scan, no exit."""
+    probe = tmp_path / "probe.sh"
+    probe.write_text("set -uo pipefail\n. %s\necho SOURCED-CLEAN\n" % _q(LIB))
+    out = subprocess.run(["bash", str(probe)], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "SOURCED-CLEAN", repr(out.stdout)
+    assert out.stderr == "", repr(out.stderr)
+
+
+def test_the_scan_restores_the_shell_options_it_flips(tmp_path):
+    """It needs `globstar`+`nullglob` for the recursive walk and is sourced into
+    scripts that did not ask for either. Leaving one set changes how EVERY later
+    glob in ship.sh / drift-check.sh behaves — a side effect that would surface
+    somewhere else entirely."""
+    probe = tmp_path / "probe.sh"
+    probe.write_text(
+        "set -uo pipefail\n"
+        ". %s\n"
+        'before="$(shopt -p globstar) $(shopt -p nullglob)"\n'
+        "nix_read_scan %s >/dev/null\n"
+        'after="$(shopt -p globstar) $(shopt -p nullglob)"\n'
+        '[ "$before" = "$after" ] && echo RESTORED || echo "LEAKED: $before -> $after"\n'
+        % (_q(LIB), _q(str(REPO_ROOT)))
+    )
+    out = subprocess.run(["bash", str(probe)], capture_output=True, text=True)
+    assert out.stdout.strip() == "RESTORED", out.stdout + out.stderr
+
+
+def test_the_option_probe_can_actually_see_a_leak(tmp_path):
+    """POSITIVE CONTROL for the check above: the same comparison must report
+    LEAKED when something really does leave globstar on."""
+    probe = tmp_path / "probe.sh"
+    probe.write_text(
+        "set -uo pipefail\n"
+        'before="$(shopt -p globstar)"\n'
+        "shopt -s globstar\n"
+        'after="$(shopt -p globstar)"\n'
+        '[ "$before" = "$after" ] && echo RESTORED || echo LEAKED\n'
+    )
+    out = subprocess.run(["bash", str(probe)], capture_output=True, text=True)
+    assert out.stdout.strip() == "LEAKED", out.stdout
+
+
+# --------------------------------------------------------------------------- #
+# 9. THE SEAM — one predicate, and a LEDGER of who defines and who calls it
+# --------------------------------------------------------------------------- #
+def test_the_predicate_has_exactly_one_definition():
+    """🔴 A LEDGER, not a spot check — it fails when the set GROWS (a second copy
+    of the predicate appears) and when it SHRINKS (a consumer stops sourcing the
+    lib and open-codes the answer).
+
+    claude/RULES.md: a predicate open-coded at N sites is typically wrong at N-1
+    of them in the same direction, and consolidating is what makes the
+    disagreement audible. These two scripts are the safety instruments for this
+    repo; a nix-read set that differs between them means one of them is lying on
+    every converge.
+    """
+    definers = set()
+    sourcers = set()
+    for p in sorted(SCRIPTS.rglob("*.sh")):
+        if "/tests/" in str(p):
+            continue
+        text = p.read_text()
+        rel = str(p.relative_to(REPO_ROOT))
+        if "nix_read_class_of()" in text or "nix_read_scan()" in text:
+            definers.add(rel)
+        if "lib/nix_read_paths.sh" in text and rel != "scripts/lib/nix_read_paths.sh":
+            sourcers.add(rel)
+    assert definers == {"scripts/lib/nix_read_paths.sh"}, (
+        "the nix-read predicate is defined in more than one place: %r" % sorted(definers)
+    )
+    assert sourcers == {"scripts/ship.sh", "scripts/drift-check.sh"}, (
+        "the set of scripts sourcing the nix-read predicate moved: %r" % sorted(sourcers)
+    )
+
+
+@pytest.mark.parametrize("consumer", [SHIP, DRIFT])
+def test_each_consumer_sources_the_lib_rather_than_re_deriving(consumer):
+    text = consumer.read_text()
+    assert 'lib/nix_read_paths.sh"' in text
+    assert "nix_read_class_of" in text
+    # Neither may carry its own copy of the extraction — the tell is the
+    # mkOutOfStoreSymlink spelling turning up outside a comment.
+    code = [ln for ln in text.splitlines() if not ln.strip().startswith("#")]
+    assert not [ln for ln in code if "mkOutOfStoreSymlink" in ln and "echo" not in ln], (
+        "%s appears to extract mkOutOfStoreSymlink targets itself" % consumer.name
+    )
+
+
+def test_the_scan_roots_exist():
+    """The ONE literal in the library is its scan roots, and they are its INPUT.
+    A root that stops existing turns the whole derivation into a scanner wired to
+    nothing — which returns an empty set, which reads as clean."""
+    text = LIB.read_text()
+    files = re.search(r'^NIXREAD_ROOT_FILES="([^"]*)"', text, re.M).group(1).split()
+    dirs = re.search(r'^NIXREAD_ROOT_DIRS="([^"]*)"', text, re.M).group(1).split()
+    assert files and dirs
+    assert any((REPO_ROOT / f).is_file() for f in files), files
+    for d in dirs:
+        assert (REPO_ROOT / d).is_dir(), d

--- a/scripts/tests/test_nix_read_paths.py
+++ b/scripts/tests/test_nix_read_paths.py
@@ -3,7 +3,14 @@
 WHAT IT ANSWERS: "is this repo-relative path read by nix?", and in which of two
 classes — LIVE (a `mkOutOfStoreSymlink` target, deployed continuously into the
 working tree, no switch involved) or STORE (a nix path literal, read at
-eval/build time and therefore in the artifact the next switch produces).
+eval/build time).
+
+🔴 AND THE CLASS IS NOT THE WHOLE ANSWER. A STORE classification says nix reads
+the PATH; whether the FILE reached the artifact also depends on whether git knows
+about it, because nix's flake source for a git checkout is filtered to exactly
+that. Section 10 pins `nix_read_artifact_reach`, which is where the class becomes
+a claim — and the seam test there is what stops either consumer reading the class
+directly again.
 
 WHO CONSUMES IT: scripts/ship.sh (classifies the DIRTY note at the end of a
 converge) and scripts/drift-check.sh (the rc 23 ladder for untracked files that
@@ -102,6 +109,16 @@ def scan(repo, classify=()):
 
 def _q(s):
     return "'" + str(s).replace("'", "'\\''") + "'"
+
+
+def reach(cls, known):
+    """Drive nix_read_artifact_reach directly."""
+    out = subprocess.run(
+        ["bash", "-c", ". %s\nnix_read_artifact_reach %s %s" % (_q(LIB), _q(cls), known)],
+        capture_output=True, text=True,
+    )
+    assert out.returncode == 0, out.stderr
+    return out.stdout.strip()
 
 
 # --------------------------------------------------------------------------- #
@@ -577,3 +594,114 @@ def test_the_scan_roots_exist():
     assert any((REPO_ROOT / f).is_file() for f in files), files
     for d in dirs:
         assert (REPO_ROOT / d).is_dir(), d
+
+
+# --------------------------------------------------------------------------- #
+# 10. CLASS IS NOT REACH — nix_read_artifact_reach
+#
+# 🔴 THE CORRECTION THIS SECTION EXISTS FOR. A STORE classification says "nix
+# reads this path". The first version of both consumers treated that as "this
+# file is in the artifact", and it is not: nix's flake source for a git checkout
+# is FILTERED to the files git knows about, so an UNTRACKED file in a STORE path
+# reaches nothing. Saying otherwise is false in the ALARMING direction, which is
+# the failure this whole change exists to remove.
+#
+# MEASURED 2026-08-25 with a controlled four-state build (see
+# test_the_flake_source_really_is_filtered_to_what_git_knows below, which is the
+# same experiment as an executable test) and corroborated on the live host: all
+# six `-dl-router` store generations carry `tests/` (37 files) and none carries
+# the untracked `tests/load_test_store.sh`.
+# --------------------------------------------------------------------------- #
+REACH = [
+    # class,  git knows it,  reach
+    ("LIVE",  1, "LIVE"),
+    ("LIVE",  0, "LIVE"),      # a mkOutOfStoreSymlink resolves at USE time
+    ("STORE", 1, "ARTIFACT"),  # index membership, not commitment, is the line
+    ("STORE", 0, "DROPPED"),   # the flake filtered it out
+    ("NONE",  1, "NONE"),
+    ("NONE",  0, "NONE"),
+    ("UNREPRESENTABLE", 1, "UNREPRESENTABLE"),
+    ("UNREPRESENTABLE", 0, "UNREPRESENTABLE"),
+]
+
+
+@pytest.mark.parametrize("cls,known,want", REACH)
+def test_the_reach_table(cls, known, want):
+    got = reach(cls, known)
+    assert got == want, (
+        "nix_read_artifact_reach(%s, known=%s) = %s, expected %s — the class is "
+        "not the reach" % (cls, known, got, want)
+    )
+
+
+def test_a_STORE_path_reaches_the_artifact_ONLY_when_git_knows_it():
+    """🔴 THE WHOLE CORRECTION ON ONE LINE. Both halves asserted together, so a
+    mutant that hardcodes either answer is caught: the same class must give two
+    different reaches depending on the bit that was previously ignored."""
+    assert reach("STORE", 1) != reach("STORE", 0), (
+        "a STORE path reports the same reach tracked and untracked — the flake "
+        "filter is being ignored again"
+    )
+    assert (reach("STORE", 1), reach("STORE", 0)) == ("ARTIFACT", "DROPPED")
+
+
+def test_LIVE_is_unaffected_by_tracked_ness():
+    """Not an assumption. mkOutOfStoreSymlink bakes a runtime PATH STRING into
+    the store, so the deployed link resolves into the working tree at use time
+    and never through the flake source. Verified on the live host:
+    ~/.claude/skills/browser/browser -> …-home-manager-files/… ->
+    <repo>/scripts/browser-bridge/browser."""
+    assert reach("LIVE", 1) == reach("LIVE", 0) == "LIVE"
+
+
+# 🔴 WHY THE FLAKE MEASUREMENT ITSELF IS NOT A TEST HERE, stated so nobody
+# "fixes" that by adding one. The experiment needs `nix` on PATH, which the
+# dev-host tier has and the nix-sandbox tier (the one the merge is gated on) does
+# not. A test that RUNS in one tier and SKIPS in the other is the exact shape
+# `run-tests.sh`'s EXPECTED_SKIPS ledger has twice removed on purpose — it means
+# one thing on a dev host and nothing at all in the tier that gates merges, and
+# it moves the skip accounting. So the environmental fact is recorded with its
+# method in nix_read_artifact_reach's header (reproduce with `nix flake metadata
+# <repo> --json` on a git repo with one committed, one modified, one `git add`ed
+# and one untracked file — the store path it reports is the FILTERED source), and
+# what runs in every tier is the two things a regression would actually break:
+# the reach table above, and the seam below.
+
+
+@pytest.mark.parametrize("consumer", [SHIP, DRIFT])
+def test_each_consumer_routes_through_the_reach_function(consumer):
+    """🔴 THE SEAM, and the pin against the bug this section corrects.
+
+    Both consumers used to branch on `nix_read_class_of` alone and report a STORE
+    path as "in the artifact" whether or not git knew about it — false, and false
+    in the alarming direction. The fix is only real if the class never reaches a
+    verdict without passing through `nix_read_artifact_reach`, so: every call of
+    the classifier in executable code must be an ARGUMENT to the reach function.
+
+    Structural rather than behavioural on purpose — the behavioural cases live in
+    test_ship_converge.py and test_drift_check.py — because this is the property
+    that a later edit is most likely to undo by accident.
+    """
+    code = [ln for ln in consumer.read_text().splitlines()
+            if not ln.strip().startswith("#")]
+    classify = [ln for ln in code if "nix_read_class_of" in ln]
+    assert classify, f"{consumer.name} does not classify at all"
+    bare = [ln for ln in classify if "nix_read_artifact_reach" not in ln]
+    assert bare == [], (
+        "%s reads the CLASS without passing it through nix_read_artifact_reach, "
+        "so a STORE path is about to be reported as reaching the artifact "
+        "whether or not git knows it: %r" % (consumer.name, bare)
+    )
+
+
+def test_the_reach_function_has_exactly_one_definition():
+    """Same ledger discipline as the classifier: the tracked/untracked rule is a
+    predicate, and a predicate open-coded at two sites is typically wrong at one
+    of them."""
+    definers = set()
+    for p in sorted(SCRIPTS.rglob("*.sh")):
+        if "/tests/" in str(p):
+            continue
+        if "nix_read_artifact_reach()" in p.read_text():
+            definers.add(str(p.relative_to(REPO_ROOT)))
+    assert definers == {"scripts/lib/nix_read_paths.sh"}, definers

--- a/scripts/tests/test_nix_read_paths.py
+++ b/scripts/tests/test_nix_read_paths.py
@@ -153,17 +153,35 @@ def test_the_scan_of_the_real_repo_produces_a_non_zero_set():
     assert int(facts["COUNT"]) == len(facts["LIVE"]) + len(facts["STORE"])
 
 
-def test_the_positive_control_can_move():
+def test_the_positive_control_can_move(tmp_path):
     """The floors above prove a number is large; this proves the number RESPONDS.
 
-    A scan of a tree with ONE nix file naming ONE path must produce exactly that
-    one — so the derivation is reading the tree it was given, not reciting a
-    constant. Same instrument, a different input, a different answer.
+    🔴 THIS TEST USED TO PERFORM NO CONTROL. Its docstring said "same instrument,
+    a different input, a different answer" while the body scanned REPO_ROOT once,
+    bound the count to a local, and asserted it was `> 1` — never scanning a
+    second tree and never using the value again. It read as coverage and provided
+    none. It now actually does what it claims: two DIFFERENT trees through the
+    same instrument must give two different answers, and the small one must be
+    exactly what its fixture spells.
     """
-    rc, facts, _ = scan(REPO_ROOT)
-    assert rc == 0
-    big = int(facts["COUNT"])
-    assert big > 1
+    rc_big, big_facts, _ = scan(REPO_ROOT)
+    assert rc_big == 0, big_facts
+    big = int(big_facts["COUNT"])
+
+    small = _fixture(tmp_path)
+    rc_small, small_facts, _ = scan(small)
+    assert rc_small == 0, small_facts
+    little = int(small_facts["COUNT"])
+
+    assert little == 5, (
+        "the fixture tree spells 4 store paths + 1 live one; the scan derived "
+        "%d: %r / %r" % (little, small_facts["STORE"], small_facts["LIVE"])
+    )
+    assert big > little, (
+        "the real repo (%d) and a 5-path fixture (%d) produced the same or an "
+        "inverted count — the instrument is not reading its input" % (big, little)
+    )
+    assert int(big_facts["FILES"]) > int(small_facts["FILES"])
 
 
 # --------------------------------------------------------------------------- #
@@ -189,8 +207,21 @@ def test_every_derived_path_exists_in_the_repo():
 # `./`-prefixed word on a line; this reads the two SPELLINGS a reviewer would
 # grep for — `source = <path>` and `mkOutOfStoreSymlink "${workspace}/devrc/…"`.
 # Two extractors agreeing is evidence; one extractor agreeing with itself is not.
-_SRC_RE = re.compile(r"source\s*=\s*(\.\.[A-Za-z0-9._/-]*)")
-_OOS_RE = re.compile(r"mkOutOfStoreSymlink\s+\"\$\{workspace\}/devrc/([A-Za-z0-9._/-]+)\"")
+#
+# 🔴 IT READS EACH FILE AS ONE STRING, NOT LINE BY LINE, AND THAT IS THE POINT.
+# The derivation's `_nixread_take_live` needs `mkOutOfStoreSymlink` and
+# `${workspace}/devrc/…` on the SAME line. A line-oriented reverse extractor
+# would SHARE that assumption — so wrapping a call site (nixfmt, a longer path)
+# would drop the target to NONE and the pin would stay GREEN because both
+# extractors missed it together. Two extractors that fail identically are one
+# extractor. Whole-file matching makes the pin go RED in exactly that case, which
+# is the only reason it is worth having. All 12 sites are one-liners today.
+_SRC_RE = re.compile(r"source\s*=\s*(\.{1,2}/[A-Za-z0-9._/-]*)", re.S)
+# The `${../scripts/dl-router}` interpolation — the spelling this whole change
+# was built around, and one a `source =` regex never sees.
+_INTERP_RE = re.compile(r"\$\{(\.{1,2}/[A-Za-z0-9._/-]+)\}")
+_OOS_RE = re.compile(
+    r"mkOutOfStoreSymlink\s*\"\$\{workspace\}/devrc/([A-Za-z0-9._/-]+)\"", re.S)
 
 
 def _nix_files():
@@ -206,16 +237,18 @@ def _spelled_sources():
     store, live = set(), set()
     for f in _nix_files():
         rel_dir = f.parent.relative_to(REPO_ROOT)
-        for ln in f.read_text().splitlines():
-            ln = ln.split("#", 1)[0]
-            for m in _SRC_RE.finditer(ln):
+        # Comments are stripped per line, but MATCHING is whole-file — see the
+        # regexes above for why that difference is load-bearing.
+        body = "\n".join(ln.split("#", 1)[0] for ln in f.read_text().splitlines())
+        for rx in (_SRC_RE, _INTERP_RE):
+            for m in rx.finditer(body):
                 tok = m.group(1)
                 resolved = os.path.normpath(str(rel_dir / tok))
-                if resolved.startswith(".."):
+                if resolved.startswith("..") or resolved == ".":
                     continue
                 store.add(resolved)
-            for m in _OOS_RE.finditer(ln):
-                live.add(m.group(1))
+        for m in _OOS_RE.finditer(body):
+            live.add(m.group(1))
     return store, live
 
 
@@ -226,9 +259,15 @@ def test_the_reverse_extractor_can_actually_see_something():
     store, live = _spelled_sources()
     assert len(live) >= 5, "the mkOutOfStoreSymlink extractor found %r" % sorted(live)
     assert len(store) >= 20, "the `source =` extractor found %d entries" % len(store)
-    # ...and it must find the two the consumers were built around.
+    # ...and it must find the three spellings the consumers were built around,
+    # INCLUDING the `${../scripts/dl-router}` interpolation that a `source =`
+    # regex alone never sees — the exact spelling that motivated this change.
     assert "scripts/browser-bridge/browser" in live
     assert "claude/RULES.md" in store
+    assert "scripts/dl-router" in store, (
+        "the reverse extractor misses the ${../…} interpolation, so the pin "
+        "cannot see a regression in the one spelling this change exists for"
+    )
 
 
 def test_the_derived_set_is_pinned_two_way_against_nix():
@@ -583,17 +622,17 @@ def test_each_consumer_sources_the_lib_rather_than_re_deriving(consumer):
     )
 
 
-def test_the_scan_roots_exist():
+def test_the_scan_roots_are_declared_at_all():
     """The ONE literal in the library is its scan roots, and they are its INPUT.
-    A root that stops existing turns the whole derivation into a scanner wired to
-    nothing — which returns an empty set, which reads as clean."""
+
+    Presence of each root is asserted by test_the_scan_roots_all_exist_in_this
+    _repo, with `all` — this one only pins that the declarations exist and are
+    non-empty, which is what makes the regexes above meaningful.
+    """
     text = LIB.read_text()
     files = re.search(r'^NIXREAD_ROOT_FILES="([^"]*)"', text, re.M).group(1).split()
     dirs = re.search(r'^NIXREAD_ROOT_DIRS="([^"]*)"', text, re.M).group(1).split()
-    assert files and dirs
-    assert any((REPO_ROOT / f).is_file() for f in files), files
-    for d in dirs:
-        assert (REPO_ROOT / d).is_dir(), d
+    assert files and dirs, (files, dirs)
 
 
 # --------------------------------------------------------------------------- #
@@ -705,3 +744,82 @@ def test_the_reach_function_has_exactly_one_definition():
         if "nix_read_artifact_reach()" in p.read_text():
             definers.add(str(p.relative_to(REPO_ROOT)))
     assert definers == {"scripts/lib/nix_read_paths.sh"}, definers
+
+
+def test_LIVE_outranks_STORE_at_the_SAME_specificity():
+    """🔴 THE DOCUMENTED TIE-BREAK, pinned. The header promises "at one level LIVE
+    outranks STORE", but the two derived sets are DISJOINT on the real repo, so
+    swapping the two `case` arms is an EQUIVALENT mutant against every other test
+    in this file — it can never be observed from a real scan.
+
+    So the state is built by hand: one path in BOTH sets, which is the only way
+    the tie-break is reachable at all. Without this the claim is prose.
+    """
+    body = (
+        ". %s\n"
+        'NIXREAD_LIVE="alpha/bravo"\n'
+        'NIXREAD_STORE="alpha/bravo"\n'
+        "nix_read_class_of alpha/bravo\n" % _q(LIB)
+    )
+    out = subprocess.run(["bash", "-c", body], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "LIVE", (
+        "a path in BOTH sets resolved to %r — the documented tie-break says LIVE, "
+        "because 'already deployed, no switch needed' is the stronger claim"
+        % out.stdout.strip()
+    )
+
+
+def test_the_ancestor_walk_prefers_the_NEAREST_match_over_the_class():
+    """The other half of the ordering rule, and the one the real repo exercises:
+    specificity beats class, so a STORE directory containing a LIVE file gives
+    LIVE for the file and STORE for a sibling under the same directory."""
+    body = (
+        ". %s\n"
+        'NIXREAD_LIVE="alpha/bravo/charlie"\n'
+        'NIXREAD_STORE="alpha/bravo"\n'
+        "nix_read_class_of alpha/bravo/charlie\n"
+        "nix_read_class_of alpha/bravo/delta\n" % _q(LIB)
+    )
+    out = subprocess.run(["bash", "-c", body], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.split() == ["LIVE", "STORE"], out.stdout
+
+
+def test_a_missing_root_directory_is_MISSINGROOT_not_a_small_scan(tmp_path):
+    """🔴 `> 0` IS NOT A FLOOR. A tree where flake.nix survives but `nix/` has
+    been renamed derived 3 paths from 1 file and reported OK — a usable-looking
+    verdict off a scan that missed the entire module tree, with no code firing.
+
+    The guard is derived from the DECLARATION (a declared root dir that is not
+    there), never a numeric minimum, so it cannot rot the way a hardcoded floor
+    would. Both consumers already handle a non-OK reason honestly.
+    """
+    r = _fixture(tmp_path)
+    (r / "nix").rename(r / "nix-renamed")
+    rc, facts, classes = scan(r, classify=["copied-alpha.txt"])
+    assert (rc, facts["REASON"]) == (1, "MISSINGROOT"), (
+        "a tree with no nix/ reported (%s, %s) over %s path(s) from %s file(s)"
+        % (rc, facts["REASON"], facts["COUNT"], facts["FILES"])
+    )
+    # ...and it is NOT a clean zero: paths WERE derived, which is exactly what
+    # made the old `> 0` guard pass.
+    assert int(facts["COUNT"]) > 0, facts
+
+
+def test_the_scan_roots_all_exist_in_this_repo():
+    """Every DECLARED root must be present here — asserted with `all`, not `any`.
+
+    With `any`, deleting flake.lock left this green while the derivation quietly
+    lost a root: the test that exists to prove the scanner's own input is intact
+    would have been satisfied by one surviving entry.
+    """
+    text = LIB.read_text()
+    files = re.search(r'^NIXREAD_ROOT_FILES="([^"]*)"', text, re.M).group(1).split()
+    dirs = re.search(r'^NIXREAD_ROOT_DIRS="([^"]*)"', text, re.M).group(1).split()
+    assert files and dirs
+    missing_f = [f for f in files if not (REPO_ROOT / f).is_file()]
+    missing_d = [d for d in dirs if not (REPO_ROOT / d).is_dir()]
+    assert missing_f == [] and missing_d == [], (
+        "declared scan roots absent from the repo: files=%r dirs=%r" % (missing_f, missing_d)
+    )

--- a/scripts/tests/test_ship_converge.py
+++ b/scripts/tests/test_ship_converge.py
@@ -841,6 +841,17 @@ class Repo:
             f'export GIT_CONFIG_GLOBAL="{self.gitconfig}"\n'
             "export GIT_CONFIG_SYSTEM=/dev/null\n"
             "unset XDG_STATE_HOME\n"
+            # 🔴 REAL ssh DOES NOT CARRY THE CALLER'S ENVIRONMENT, AND THIS SHIM
+            # USED TO. Every SHIP_* variable ship.sh had in its own environment
+            # reached the payload here by plain inheritance, so the forwarding
+            # this file tests was supplied by the fixture rather than by the
+            # code: a mutant deleting `SHIP_LIST_MAX=%q` from the ssh printf
+            # SURVIVED a green suite, because the shim leaked the value anyway.
+            # The payload's own prefix lines are the only legitimate way these
+            # cross the hop, so the shim scrubs them first and the printf has to
+            # do its job. Everything the far "host" legitimately owns —
+            # HOME/SHIP_REPO/the git config — is exported explicitly above.
+            "unset SHIP_NO_SWITCH SHIP_LIST_MAX\n"
             + run,
         )
         return d
@@ -1327,6 +1338,170 @@ def test_a_repo_with_no_flake_at_all_says_it_could_not_look(nixrepo):
     assert rc == 0, out
     assert "NOT CLASSIFIED (NOROOTS)" in out, out
     assert "NO dirty path is read by nix" not in out, out
+
+
+# --------------------------------------------------------------------------- #
+# SHIP_LIST_MAX — the bound on the classified listing
+#
+# 🔴 THE CAP SHIPPED WITH NO TEST AT ALL. It exists because a whole-directory
+# STORE source (`claude/skills`, `scripts/dl-router`) lets ONE untracked subtree
+# put an unbounded number of paths into a bucket, and this output is tee-d into
+# a capture an operator reads. Two things were wrong with the untested version,
+# and neither is visible from the code at a glance:
+#
+#   * `sed -n "1,0p"` is NOT an empty range to GNU sed — it prints line 1 — so
+#     SHIP_LIST_MAX=0 enumerated exactly one path and then announced "... and N
+#     more". A cap of zero that lists something.
+#   * only SHIP_NO_SWITCH crossed the ssh hop, so the remote leg always used the
+#     default while the local leg used whatever the operator asked for: one run,
+#     two different truncation depths, both wearing the same shape.
+#
+# The COUNT beside each heading is never capped, which is what makes 0 a
+# coherent request ("count them, name none") rather than something to sanitise
+# away — so it is honoured rather than silently replaced.
+# --------------------------------------------------------------------------- #
+_LISTED = re.compile(r"^\[[^\]]*\]     - (\S+)$", re.M)
+
+
+def _seed_dropped(tree, n, prefix="lima"):
+    """`n` untracked files under the DIRECTORY store source — one bucket
+    (DROPPED), names pairwise distinct, and `n` deliberately not a multiple of
+    any cap this file passes in."""
+    d = tree / "charlie-dir" / "nested"
+    d.mkdir(parents=True, exist_ok=True)
+    for i in range(n):
+        (d / ("%s-%02d.txt" % (prefix, i))).write_text("%s %d\n" % (prefix, i))
+
+
+def test_the_dirty_classification_listing_is_bounded_by_SHIP_LIST_MAX(nixrepo):
+    """The cap does what it says, and the untruncated COUNT stays beside it.
+
+    Eight paths and a cap of three: eight is not a multiple of three, so a
+    mutant that used the wrong end of the range (or truncated on a block
+    boundary) cannot land on the right answer by arithmetic accident.
+    """
+    _seed_dropped(nixrepo.work, 8)
+    rc, out = nixrepo.ship(SHIP_LIST_MAX="3")
+    assert rc == 0, out
+    assert "UNTRACKED IN A NIX-READ PATH — 8 path(s)" in out, (
+        "the heading's count was truncated too — only the enumeration may be\n%s"
+        % out)
+    listed = _LISTED.findall(out)
+    assert len(listed) == 3, f"enumerated {listed} under a cap of 3\n{out}"
+    assert "... and 5 more (SHIP_LIST_MAX=3)" in out, (
+        "a truncated list did not say how much it hid, or which knob hid it\n%s"
+        % out)
+
+
+def test_SHIP_LIST_MAX_of_zero_enumerates_NOTHING(nixrepo):
+    """🔴 RED AT 41e92a1f, where this printed ONE path and then claimed to have
+    hidden the rest.
+
+    `sed -n "1,0p"` prints line 1 under GNU sed, so the cap's own zero leaked a
+    path into an output an operator reads as bounded. The count is still
+    complete, so 0 remains a legal, meaningful setting — it just has to mean
+    what it says.
+    """
+    _seed_dropped(nixrepo.work, 4, prefix="mike")
+    rc, out = nixrepo.ship(SHIP_LIST_MAX="0")
+    assert rc == 0, out
+    assert "UNTRACKED IN A NIX-READ PATH — 4 path(s)" in out, out
+    listed = _LISTED.findall(out)
+    assert listed == [], f"a cap of 0 enumerated {listed}\n{out}"
+    assert "... and 4 more (SHIP_LIST_MAX=0)" in out, out
+
+
+def test_a_non_integer_SHIP_LIST_MAX_falls_back_to_the_default(nixrepo):
+    """The sanitiser at the top of CONVERGE, which had no test either.
+
+    A bad value must not reach `sed -n "1,<junk>p"` — and the fallback is the
+    DEFAULT, not zero: silently listing nothing because a value was mistyped
+    would hide paths for a reason nobody could see in the output.
+    """
+    _seed_dropped(nixrepo.work, 13, prefix="november")
+    rc, out = nixrepo.ship(SHIP_LIST_MAX="lots")
+    assert rc == 0, out
+    listed = _LISTED.findall(out)
+    assert len(listed) == 10, f"the fallback enumerated {len(listed)}\n{out}"
+    assert "... and 3 more" in out, out
+
+
+def test_both_legs_of_ONE_run_truncate_with_the_SAME_bound(tmp_path):
+    """🔴 RED AT 41e92a1f: only SHIP_NO_SWITCH crossed the hop.
+
+    The remote leg took the default while the local leg took the operator's
+    value, so one run produced two different truncation depths under one shape.
+    That is not cosmetic — the two legs' outputs are read side by side to decide
+    whether the fleet agrees, and a listing that is short on one host for a
+    reason invisible in the output is the wrong kind of difference to introduce.
+
+    Both hosts carry the SAME six untracked paths, so any difference in what is
+    enumerated is a difference in the bound, which is the only thing that varies.
+    """
+    r = Repo(tmp_path, second_host=True, nixread=True)
+    for tree in (r.work, r.remote_work):
+        _seed_dropped(tree, 6, prefix="oscar")
+
+    shim = r.ssh_shim(tmp_path)
+    rc, out = r.ship_both_hosts(shim, SHIP_LIST_MAX="2")
+
+    def listed(leg):
+        parts = re.split(r"^=== (local|remote) [^\n]*===$", out, flags=re.M)
+        for i in range(1, len(parts) - 1, 2):
+            if parts[i] == leg:
+                return _LISTED.findall(parts[i + 1])
+        raise AssertionError(f"no `=== {leg} …===` section:\n{out}")
+
+    local, remote = listed("local"), listed("remote")
+    assert len(local) == 2, f"the local leg ignored the bound: {local}\n{out}"
+    assert len(remote) == 2, (
+        "the remote leg enumerated %d path(s) under SHIP_LIST_MAX=2 — the bound "
+        "did not cross the ssh hop\n%s" % (len(remote), out))
+    assert out.count("... and 4 more (SHIP_LIST_MAX=2)") == 2, (
+        "the two legs do not agree on what they hid\n%s" % out)
+
+
+def _ship_forwarded():
+    """[(name, conversion)…] for every value interpolated ahead of the payload
+    ship.sh sends over ssh, read off the printf format itself.
+
+    🔴 DERIVED, NEVER HAND-LISTED — the sibling ledger in test_drift_check.py
+    exists because a hand-list went stale the moment a third value started
+    crossing that hop, and the mutant which downgraded its quoting survived a
+    green suite. This printf carried ONE value for its whole life and now
+    carries two, which is exactly the moment such a list starts to rot.
+    """
+    src = SHIP.read_text()
+    m = re.search(r"printf '([^']*)' \\\n\s*\"\$SHIP_NO_SWITCH\"", src)
+    assert m, (
+        "could not find the remote payload's printf format in ship.sh — this "
+        "ledger is now wired to nothing, which is worse than a stale list"
+    )
+    pairs = re.findall(r"([A-Z][A-Z0-9_]*)=%(\w)", m.group(1))
+    assert len(pairs) >= 2, (
+        "the ledger derived %r; a short result is what a broken regex looks "
+        "like, not a small payload" % (pairs,)
+    )
+    return pairs
+
+
+def test_the_ship_remote_payload_ledger_can_see_the_real_variables():
+    """🔴 POSITIVE CONTROL for the derivation the guard below stands on. A regex
+    that matched nothing would make it vacuously green."""
+    names = [n for n, _c in _ship_forwarded()]
+    assert "SHIP_NO_SWITCH" in names and "SHIP_LIST_MAX" in names, names
+
+
+def test_every_value_ship_sends_over_ssh_is_shell_quoted():
+    """These are interpolated ahead of a script that EXECUTES on the other host.
+    Neither is validated by ship.sh — SHIP_LIST_MAX is sanitised on arrival,
+    inside CONVERGE — so unlike drift-check.sh there is no first layer here and
+    %q is the ONLY thing standing between an operator typo and a command run on
+    a machine this script is otherwise careful with.
+    """
+    bad = [(n, c) for n, c in _ship_forwarded() if c != "q"]
+    assert bad == [], (
+        "these values cross the ssh hop unquoted: %r" % (bad,))
 
 
 def test_skips_when_local_main_diverged(repo):

--- a/scripts/tests/test_ship_converge.py
+++ b/scripts/tests/test_ship_converge.py
@@ -785,20 +785,56 @@ class Repo:
                 f'git --git-dir={self.origin} update-ref refs/heads/main {advance_to} '
                 f'|| exit 97\n'
             )
-        # 🔴 POSIX sh only (mockbin owns the shebang and it is /bin/sh), so no
+        # 🔴 THIS SHIM EMULATES sshd's DISPATCH, and until 2026-08-26 it did not.
+        # It read the payload out of the LAST argv element and ran it under a
+        # HARDCODED `bash -c`, while its docstring claimed to be "a test of the
+        # remote leg rather than of a second local run". It pinned the payload
+        # TEXT and fixed the INTERPRETER — so the entire remote-leg suite was
+        # structurally blind to the one axis on which the two legs can differ,
+        # and a real bug lived there (see
+        # test_the_remote_leg_classifies_identically_to_the_local_leg).
+        #
+        # Real sshd has two modes, and both are reproduced here:
+        #   `ssh host cmd args…`  -> runs THAT command, payload arriving on stdin
+        #   `ssh host "<script>"` -> names no interpreter, so the account's LOGIN
+        #                            SHELL runs the string. On both real hosts
+        #                            that is zsh (`getent passwd zach`).
+        # zsh is in flake.nix's `gateTools` — deliberately, and for exactly this
+        # class of reason (see its comment about run3) — so the login-shell branch
+        # is REAL in both tiers and never skips.
+        login_shell = os.environ.get("SHIP_TEST_LOGIN_SHELL", "zsh")
+        # POSIX sh only (mockbin owns the shebang and it is /bin/sh), so no
         # PIPESTATUS here — the strip variant captures, then filters, then exits
         # with the payload's OWN status.
-        run = 'exec bash -c "$payload"\n'
+        dispatch = (
+            "prev=; last=\n"
+            'for a in "$@"; do prev=$last; last=$a; done\n'
+            'if [ "$prev" = bash ] && [ "$last" = -s ]; then\n'
+            "  payload=$(cat)\n"
+            "  runner=bash\n"
+            "else\n"
+            "  payload=$last\n"
+            f"  runner={login_shell}\n"
+            "fi\n"
+            # 🔴 The forcing knob, and it forces the INTERPRETER ONLY — never the
+            # payload source. Emulating "ssh ran the login shell" by also taking
+            # the payload from argv would hand zsh the literal `-s`, which fails
+            # for a reason that has nothing to do with the bug under test and
+            # would make the regression test green for the wrong cause.
+            'if [ -n "${SHIP_TEST_FORCE_LOGIN_SHELL:-}" ]; then\n'
+            f"  runner={login_shell}\n"
+            "fi\n"
+        )
+        run = 'exec "$runner" -c "$payload"\n'
         if strip_sha:
             run = (
-                'out=$(bash -c "$payload"); rc=$?\n'
+                'out=$("$runner" -c "$payload"); rc=$?\n'
                 'printf "%s\\n" "$out" | grep -v " ship-landed-sha "\n'
                 "exit $rc\n"
             )
         write_exec(
             d / "ssh",
-            "payload=\n"
-            'for a in "$@"; do payload="$a"; done\n'
+            dispatch
             + advance +
             f'export HOME="{self.remote_home}"\n'
             f'export SHIP_REPO="{self.remote_work}"\n'
@@ -1763,9 +1799,9 @@ def test_managed_artifact_check_runs_on_the_remote_leg_too(repo):
 
     The bug existed only on the laptop, so a consumer check that runs only on
     the local host is worthless for it. ship.sh has exactly one CONVERGE body,
-    executed locally via `bash -c` and remotely via `ssh <host> "<body>"` — so
-    this asserts the check lives INSIDE that body rather than in the local-only
-    driver below it, which is the way it could regress to local-only.
+    executed locally via `bash -c` and remotely by PIPING it to `bash -s` over
+    ssh — so this asserts the check lives INSIDE that body rather than in the
+    local-only driver below it, which is the way it could regress to local-only.
     """
     src = SHIP.read_text()
     body = src.split("CONVERGE='", 1)
@@ -1776,9 +1812,40 @@ def test_managed_artifact_check_runs_on_the_remote_leg_too(repo):
         "remote host — which is the only host the original bug affected"
     )
     # ...and CONVERGE really is what gets sent over ssh.
-    assert re.search(r'ssh .*"\$REMOTE_SSH".*\$CONVERGE', src), (
-        "CONVERGE is no longer the body executed over ssh"
+    assert re.search(r"\$CONVERGE\"?\s*\\?\s*\n?\s*\|\s*ssh ", src), (
+        "CONVERGE is no longer the body piped over ssh"
     )
+
+
+def test_the_remote_leg_names_bash_rather_than_letting_sshd_pick_a_shell():
+    """🔴 THE STRUCTURAL PIN behind the zsh bug. `ssh host "<script>"` names NO
+    interpreter, so sshd runs the account's LOGIN SHELL — zsh on both of these
+    hosts. CONVERGE was interpreter-agnostic by ACCIDENT until it began sourcing
+    scripts/lib/nix_read_paths.sh, which needs `shopt` and word-splitting on an
+    unquoted `$var`.
+
+    Structural because it holds in every tier with no host, no ssh and no
+    fixture; the behavioural half is
+    test_the_remote_leg_classifies_identically_to_the_local_leg. drift-check.sh
+    reached this conclusion first — one rule, second place it applies.
+    """
+    src = SHIP.read_text()
+    code = [ln for ln in src.splitlines() if not ln.strip().startswith("#")]
+    ssh_lines = [ln for ln in code if re.search(r"(^|\|\s*|\s)ssh ", ln)]
+    assert ssh_lines, "no ssh invocation found — ship.sh was restructured"
+    real = [ln for ln in ssh_lines if "$REMOTE_SSH" in ln]
+    assert real, f"no ssh line targets $REMOTE_SSH: {ssh_lines!r}"
+    for ln in real:
+        assert re.search(r'"\$REMOTE_SSH"\s+bash\s+-s', ln), (
+            "the remote leg does not name an interpreter, so sshd will run the "
+            "LOGIN SHELL (zsh on both hosts) and every bashism in CONVERGE — "
+            "including the whole shared nix-read lib — changes meaning "
+            "silently: %r" % ln
+        )
+        assert "$CONVERGE" not in ln, (
+            "the payload is inlined into the ssh command string again; it must "
+            "be piped to `bash -s`: %r" % ln
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -3252,3 +3319,207 @@ def test_the_population_line_splits_tracked_from_untracked(nixrepo):
     total, tracked, untracked = (int(g) for g in m.groups())
     assert (tracked, untracked) == (1, 1), out
     assert total == tracked + untracked
+
+
+# --------------------------------------------------------------------------- #
+# THE SEAM: the remote leg must reach the SAME verdict as the local one
+#
+# 🔴 "VERIFIED IN ISOLATION" IS THE VACUOUS GREEN, AND THIS IS THE SHAPE OF IT.
+# The nix-read classifier had its own hermetic suite. The remote leg had its own
+# hermetic suite. Both were green, and TOGETHER they were broken: `ssh host
+# "<script>"` names no interpreter, so sshd ran the login shell — zsh — and the
+# classifier's `shopt` and unquoted-`$var` word-splitting silently produced an
+# EMPTY nix-read set with `REASON=OK`. Neither suite could see it, because the
+# ssh shim hardcoded `bash -c` and so tested a second LOCAL run.
+#
+# MEASURED under zsh, on the real repo, before the fix:
+#     rc=0 REASON=OK files=28 count=1   with STORE empty
+# i.e. the scan believed it had SUCCEEDED, so the NOT-CLASSIFIED refusal could
+# not fire, and the remote host printed the reassuring verdict for a file the
+# local host had just called "in the artifact".
+#
+# These pin the RELATIONSHIP, not either component: same repo state, both legs,
+# one run, and the classification lines must agree.
+# --------------------------------------------------------------------------- #
+def _verdict_lines(out, leg):
+    """The classification sentences ONE LEG printed, normalised.
+
+    Split on the `=== local (…) ===` / `=== remote (…) ===` banners, NOT on the
+    `[host]` prefix: that prefix is `hostname`, which is the same string on both
+    fabricated hosts, so a prefix filter would silently merge the two legs and
+    make any comparison between them vacuous.
+    """
+    keys = ("DIRTY AND LIVE", "DIRTY AND IN THE ARTIFACT",
+            "UNTRACKED IN A NIX-READ PATH", "NO dirty path is read by nix",
+            "nothing dirty REACHED the build", "NOT CLASSIFIED")
+    parts = re.split(r"^=== (local|remote) [^\n]*===$", out, flags=re.M)
+    # parts alternates: [pre, "local", body, "remote", body, ...]
+    body = ""
+    for i in range(1, len(parts) - 1, 2):
+        if parts[i] == leg:
+            body = parts[i + 1]
+            break
+    assert body, f"no `=== {leg} …===` section in the output:\n{out}"
+    return [k for ln in body.splitlines() for k in keys if k in ln]
+
+
+def test_the_remote_leg_classifies_identically_to_the_local_leg(tmp_path):
+    """🔴 RED ON HEAD BEFORE THE FIX. With the payload inlined into the ssh
+    command string, the shim runs it under the LOGIN SHELL (zsh) exactly as sshd
+    does, the lib mis-parses, and the remote host prints "NO dirty path is read
+    by nix" while the local host prints "DIRTY AND IN THE ARTIFACT" for the SAME
+    tracked-modified STORE-class file.
+
+    Both hosts carry the same fixture flake and the same dirty file, so any
+    difference in the verdict is a difference in the INTERPRETER, which is the
+    only thing that varies between the two legs.
+    """
+    r = Repo(tmp_path, second_host=True, nixread=True)
+    for tree in (r.work, r.remote_work):
+        (tree / "copied-alpha.txt").write_text("copied-alpha.txt wip\n")
+
+    shim = r.ssh_shim(tmp_path)
+    rc, out = r.ship_both_hosts(shim)
+
+    local = _verdict_lines(out, "local")
+    remote = _verdict_lines(out, "remote")
+    assert local, f"the local leg printed no classification at all\n{out}"
+    assert remote, f"the remote leg printed no classification at all\n{out}"
+    assert local == remote, (
+        "the two legs disagree about the SAME dirty file — local=%r remote=%r. "
+        "That is the interpreter, not the repo: sshd runs the login shell unless "
+        "the ssh invocation names one.\n%s" % (local, remote, out)
+    )
+    assert "DIRTY AND IN THE ARTIFACT" in remote, (
+        "the remote leg did not classify a tracked-modified STORE path as being "
+        "in the artifact\n%s" % out
+    )
+
+
+def test_the_remote_leg_refuses_rather_than_lying_under_a_non_bash_shell(tmp_path):
+    """🔴 BELT AND BRACES, and the half that survives a future re-inlining.
+
+    The transport fix is what removes the variable. This pins the OTHER outcome:
+    if the payload is ever run under something that is not bash again, the lib
+    must degrade to the COULD-NOT-MEASURE path both consumers already handle
+    honestly — never to a confident empty set.
+
+    Driven by forcing the shim's login-shell branch, which is what sshd does with
+    an interpreter-less invocation. zsh is in flake.nix's `gateTools`, so this is
+    REAL in both tiers and never skips.
+    """
+    r = Repo(tmp_path, second_host=True, nixread=True)
+    for tree in (r.work, r.remote_work):
+        (tree / "copied-alpha.txt").write_text("copied-alpha.txt wip\n")
+
+    shim = r.ssh_shim(tmp_path)
+    # Force the shim to run the payload under the LOGIN SHELL, i.e. reproduce
+    # what sshd does for an ssh invocation that names no interpreter — the
+    # pre-fix transport, with everything else held constant.
+    rc, out = r.ship_both_hosts(shim, SHIP_TEST_FORCE_LOGIN_SHELL="1")
+    remote = _verdict_lines(out, "remote")
+    assert "NOT CLASSIFIED" in remote, (
+        "under a non-bash shell the remote leg did not refuse — it must never "
+        "print a clean nix-read verdict off a scan that could not run\n%s" % out
+    )
+    assert "NO dirty path is read by nix" not in remote, (
+        "the remote leg printed the reassuring verdict off a broken scan — this "
+        "is the exact silent-wrong-answer the guard exists to prevent\n%s" % out
+    )
+    assert "NOTBASH" in out, f"the refusal does not name its reason\n{out}"
+
+
+def test_the_shim_really_can_take_the_login_shell_branch(tmp_path):
+    """🔴 POSITIVE CONTROL for the two tests above. If the shim's dispatch never
+    reached its login-shell arm, both would pass while proving nothing about the
+    axis they exist to cover — which is precisely how the old `exec bash -c`
+    shim hid a real bug behind a green suite."""
+    r = Repo(tmp_path, second_host=True, nixread=True)
+    shim = r.ssh_shim(tmp_path)
+    body = (shim / "ssh").read_text()
+    assert 'if [ "$prev" = bash ] && [ "$last" = -s ]; then' in body, body
+    assert "runner=zsh" in body, (
+        "the shim does not model the login shell, so the remote-leg suite is "
+        "blind to the interpreter axis again:\n%s" % body
+    )
+    # ...and the branch is genuinely selectable: the SAME shim must dispatch to
+    # bash when an interpreter is named and to zsh when one is not. Asserted as a
+    # PAIR — either half alone is satisfied by a shim wired to one shell.
+    probe = tmp_path / "probe.sh"
+    probe.write_text(
+        'set -u\n'
+        'payload=\'echo IS_BASH=${BASH_VERSION:+yes} IS_ZSH=${ZSH_VERSION:+yes}\'\n'
+        'printf "%s\\n" "$payload" | ssh host bash -s\n'
+        'ssh host "$payload"\n'
+    )
+    got = subprocess.run(["bash", str(probe)], capture_output=True, text=True,
+                         env=r.env(shims=[shim]))
+    lines = [ln for ln in got.stdout.splitlines() if ln.startswith("IS_BASH=")]
+    assert len(lines) == 2, (got.stdout, got.stderr)
+    assert lines[0] == "IS_BASH=yes IS_ZSH=", (
+        "a NAMED `bash -s` did not run under bash: %r" % lines[0])
+    assert lines[1] == "IS_BASH= IS_ZSH=yes", (
+        "an interpreter-less invocation did not run under the login shell, so "
+        "the shim cannot reproduce what sshd does: %r" % lines[1])
+
+
+def test_an_UNCLASSIFIABLE_dirty_path_suppresses_the_clean_verdict(nixrepo):
+    """🔴 THE `[ "$nr_nu" = 0 ]` ARM, which was reachable and unpinned — deleting
+    it SURVIVED the whole suite.
+
+    A dirty path the classifier cannot model (a character outside its alphabet)
+    is reported as NOT CLASSIFIED, and the run must NOT also print "what was
+    built/deployed IS origin/main". Printing both says, in one breath, "there is
+    a path I could not judge" and "I have judged them all". `test_drift_check.py`
+    already has the equivalent on its side.
+    """
+    (nixrepo.work / "has space.txt").write_text("unclassifiable\n")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert "NOT CLASSIFIED" in out, out
+    assert "built/deployed IS origin/main" not in out, (
+        "the run printed a clean verdict alongside a path it could not classify "
+        "— those are contradictory claims\n%s" % out
+    )
+
+
+def test_an_unclassifiable_path_is_named_not_just_counted(nixrepo):
+    """A count with no name leaves the operator nothing to act on, and this is
+    the one bucket where they cannot find the file by re-reading the classifier."""
+    (nixrepo.work / "has space.txt").write_text("unclassifiable\n")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert "has space.txt" in out, out
+
+
+def test_the_remote_leg_reports_the_ssh_status_not_the_printf_status(tmp_path):
+    """🔴 THE INDEX MOVED WHEN THE PAYLOAD BECAME A PIPE, and a comment claimed
+    this test existed before it did.
+
+    The remote leg used to be `ssh … | tee`, so `PIPESTATUS[0]` was ssh. Piping
+    the payload in makes it `printf | ssh | tee`, where [0] is printf — which
+    essentially always succeeds. Left at [0], EVERY remote converge would report
+    rc 0, including a host skipped for un-pushed commits (rc 8), which is the
+    single most important thing this script says.
+
+    The remote host here is genuinely diverged, so its converge exits 8; the run
+    must surface that rather than a zero.
+    """
+    r = Repo(tmp_path, second_host=True)
+    # Un-pushed commit on the REMOTE host only -> that leg exits 8.
+    (r.remote_work / "local-only.txt").write_text("un-pushed\n")
+    r._git(r.remote_work, "add", "local-only.txt")
+    r._git(r.remote_work, "commit", "-q", "-m", "un-pushed on the remote host")
+
+    shim = r.ssh_shim(tmp_path)
+    rc, out = r.ship_both_hosts(shim)
+
+    assert "SKIPPED — local main has diverged" in out, (
+        "the remote leg did not actually fail, so this proves nothing about the "
+        "status it reports\n%s" % out
+    )
+    assert rc == 8, (
+        "the run reported rc=%s for a remote host that exited 8 — the pipeline "
+        "status is being read from the wrong stage (printf, not ssh)\n%s" % (rc, out)
+    )
+    assert "converge exited 8" in out, out

--- a/scripts/tests/test_ship_converge.py
+++ b/scripts/tests/test_ship_converge.py
@@ -1146,8 +1146,8 @@ def test_the_classifier_reports_a_non_zero_population(nixrepo):
     (nixrepo.work / "stable.txt").write_text("stable\nwip\n")
     rc, out = nixrepo.ship()
     assert rc == 0, out
-    m = re.search(r"classified (\d+) dirty path\(s\) against (\d+) nix-read "
-                  r"path\(s\) derived from (\d+) nix file\(s\)", out)
+    m = re.search(r"classified (\d+) dirty path\(s\) \(\d+ tracked, \d+ untracked\) "
+                  r"against (\d+) nix-read path\(s\) derived from (\d+) nix file\(s\)", out)
     assert m, f"the verdict carries no population line\n{out}"
     dirty, nixread, files = (int(g) for g in m.groups())
     assert dirty >= 1, out
@@ -1193,14 +1193,22 @@ def test_a_dirty_file_UNDER_a_directory_source_is_still_in_the_artifact(nixrepo)
 
 
 def test_an_UNTRACKED_file_in_a_nix_read_path_is_classified_too(nixrepo):
-    """The dirty set is modified + staged + UNTRACKED, exactly as blocking_files
-    computes it. An untracked file inside a directory source is in the artifact
-    just as surely as a modified one."""
+    """The dirty set is modified + staged + UNTRACKED, and the untracked ones are
+    CLASSIFIED rather than ignored — a file inside a directory source is found by
+    the ancestor walk whether or not git knows it.
+
+    🔴 This test asserted "in the artifact just as surely as a modified one" and
+    that was WRONG — the flake filters untracked files out. What it pins now is
+    the part that was right: the path is still found and still reported. Which
+    verdict it gets is
+    test_an_UNTRACKED_store_path_is_NOT_reported_as_in_the_artifact.
+    """
     (nixrepo.work / "charlie-dir" / "nested" / "hotel-new.txt").write_text("new\n")
     rc, out = nixrepo.ship()
     assert rc == 0, out
-    assert "DIRTY AND IN THE ARTIFACT" in out, out
     assert "charlie-dir/nested/hotel-new.txt" in out, out
+    assert "UNTRACKED IN A NIX-READ PATH" in out, out
+    assert "0 tracked, 1 untracked" in out, out
 
 
 def test_a_dirty_tree_with_no_nix_read_path_says_the_deploy_IS_origin_main(nixrepo):
@@ -3127,3 +3135,120 @@ def test_the_switch_log_lives_under_tmpdir_and_is_removed(tmp_path):
         f"ship left temp files behind: {leftovers} — twice over, because a "
         f"superseding run runs the local leg twice\n{out}"
     )
+
+
+# --------------------------------------------------------------------------- #
+# THE TRACKED/UNTRACKED SPLIT WITHIN THE STORE CLASS
+#
+# 🔴 A CORRECTION, and the reason it matters more than it looks. The first
+# version of this block reported every STORE-class dirty path as "in the artifact
+# just built". For a MODIFIED TRACKED file that is true — nix takes the
+# working-tree content. For an UNTRACKED file it is FALSE: nix's flake source for
+# a git checkout is filtered to the files git knows about, so the file reached
+# nothing.
+#
+# MEASURED 2026-08-25 on the live host: all six `-dl-router` store generations
+# carry `tests/` (37 files) and NONE carries the untracked
+# `tests/load_test_store.sh` — the very file that motivated this whole change.
+# A controlled four-state flake build confirms the rule and separates it from
+# "the switch predates the file": committed, modified-tracked and `git add`ed all
+# land (with the WORKING-TREE content); untracked never does, at any depth.
+#
+# The finding is KEPT — unsaved work in no commit and no backup, one `git add`
+# from the artifact — but it no longer claims to be deployed. Overstating is the
+# exact failure this block exists to remove.
+# --------------------------------------------------------------------------- #
+def test_an_UNTRACKED_store_path_is_NOT_reported_as_in_the_artifact(nixrepo):
+    """🔴 THE CORRECTION. Same path, same STORE class, untracked — and the
+    verdict must not be the one that says it is deployed."""
+    (nixrepo.work / "charlie-dir" / "nested" / "hotel-new.txt").write_text("new\n")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert "charlie-dir/nested/hotel-new.txt" in out, out
+    # 🔴 ONE assertion for BOTH directions, with ONE message. Split across two,
+    # a mutant that flips the classification dies on whichever line happens to
+    # come first — and the failure then names the wrong guard, which is
+    # indistinguishable from dying for an unrelated reason.
+    assert ("UNTRACKED IN A NIX-READ PATH" in out
+            and "did NOT reach the artifact" in out
+            and "DIRTY AND IN THE ARTIFACT" not in out), (
+        "an untracked file was reported as being in the artifact — the flake "
+        "filters it out, so it reached nothing\n%s" % out
+    )
+
+
+def test_a_TRACKED_modified_store_path_IS_in_the_artifact(nixrepo):
+    """The other half of the same distinction, asserted in the SAME class so a
+    mutant that hardcodes either verdict is caught. Nix takes the WORKING-TREE
+    content of a file git knows about, so this WIP really is in the generation."""
+    (nixrepo.work / "copied-alpha.txt").write_text("copied-alpha.txt wip\n")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert "DIRTY AND IN THE ARTIFACT" in out, out
+    assert "copied-alpha.txt" in out, out
+    assert "UNTRACKED IN A NIX-READ PATH" not in out, out
+
+
+def test_a_STAGED_never_committed_store_path_IS_in_the_artifact(nixrepo):
+    """🔴 THE BOUNDARY IS THE INDEX, NOT A COMMIT — measured, not assumed. A file
+    `git add`ed ten seconds ago and never committed is in the flake source. If
+    the split were keyed on "is it in a commit" this would be reported as
+    dropped, and it would be wrong."""
+    p = nixrepo.work / "charlie-dir" / "nested" / "india-staged.txt"
+    p.write_text("staged\n")
+    nixrepo._git(nixrepo.work, "add", "charlie-dir/nested/india-staged.txt")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    # One assertion, one message — see the untracked case above for why.
+    assert ("DIRTY AND IN THE ARTIFACT" in out
+            and "charlie-dir/nested/india-staged.txt" in out
+            and "UNTRACKED IN A NIX-READ PATH" not in out), (
+        "a `git add`ed file was not reported as reaching the artifact — the "
+        "discriminator has slipped from index membership to commitment\n%s" % out
+    )
+
+
+def test_an_untracked_LIVE_target_is_still_LIVE(nixrepo):
+    """🔴 LIVE IS NOT SPLIT, and that is not an oversight. mkOutOfStoreSymlink
+    bakes a runtime path string into the store, so the deployed link resolves
+    into the working tree at USE time and never through the flake source — an
+    untracked file there IS being served. Verified on the live host:
+    ~/.claude/skills/browser/browser resolves to the repo working tree."""
+    (nixrepo.work / "echo-live.txt").unlink()
+    nixrepo._git(nixrepo.work, "rm", "-q", "--cached", "echo-live.txt")
+    (nixrepo.work / "echo-live.txt").write_text("untracked but LIVE\n")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert "DIRTY AND LIVE" in out, out
+    assert "echo-live.txt" in out, out
+    assert "UNTRACKED IN A NIX-READ PATH" not in out, (
+        "a mkOutOfStoreSymlink target was reported as dropped by the flake "
+        "filter — it never goes through the flake source at all\n%s" % out
+    )
+
+
+def test_only_untracked_nix_read_paths_still_says_the_deploy_IS_origin_main(nixrepo):
+    """The consequence of the correction, and it is a REAL verdict: if the only
+    dirty nix-read paths are untracked, the flake dropped all of them, so what
+    was built IS origin/main. Both facts are printed — the artifact is clean AND
+    there is unsaved work — because they are independent claims."""
+    (nixrepo.work / "charlie-dir" / "nested" / "hotel-new.txt").write_text("new\n")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert "UNTRACKED IN A NIX-READ PATH" in out, out
+    assert "built/deployed IS origin/main" in out, out
+    assert "nothing dirty REACHED the build" in out, out
+
+
+def test_the_population_line_splits_tracked_from_untracked(nixrepo):
+    """The denominator must carry the bit the verdict now turns on — otherwise a
+    reader cannot tell which of the two rules produced the answer."""
+    (nixrepo.work / "copied-alpha.txt").write_text("wip\n")
+    (nixrepo.work / "charlie-dir" / "nested" / "hotel-new.txt").write_text("new\n")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    m = re.search(r"classified (\d+) dirty path\(s\) \((\d+) tracked, (\d+) untracked\)", out)
+    assert m, f"the population line does not split tracked from untracked\n{out}"
+    total, tracked, untracked = (int(g) for g in m.groups())
+    assert (tracked, untracked) == (1, 1), out
+    assert total == tracked + untracked

--- a/scripts/tests/test_ship_converge.py
+++ b/scripts/tests/test_ship_converge.py
@@ -1360,13 +1360,25 @@ def test_a_repo_with_no_flake_at_all_says_it_could_not_look(nixrepo):
 # coherent request ("count them, name none") rather than something to sanitise
 # away — so it is honoured rather than silently replaced.
 # --------------------------------------------------------------------------- #
-_LISTED = re.compile(r"^\[[^\]]*\]     - (\S+)$", re.M)
+# 🔴 SCOPED TO THE FIXTURE'S OWN SUBTREE, NOT TO THE PREFIX. `[host]     - ` is
+# emitted by EIGHT producers in ship.sh (blockers, managed-artifact rows, the
+# gcroots pair, the manifest and conflicted lists, …) and `nr_list` is only one
+# of them. Counting the prefix binds today purely because the other seven are
+# silent in these fixtures — so a mutant that silenced `nr_list` while any other
+# listing happened to emit exactly N rows would SURVIVE. `charlie-dir/` is
+# written only by _seed_dropped, so matching it makes the count structural
+# instead of positional.
+_LISTED = re.compile(r"^\[[^\]]*\]     - (charlie-dir/\S+)$", re.M)
 
 
 def _seed_dropped(tree, n, prefix="lima"):
     """`n` untracked files under the DIRECTORY store source — one bucket
     (DROPPED), names pairwise distinct, and `n` deliberately not a multiple of
-    any cap this file passes in."""
+    any cap this file passes in.
+
+    Everything lands under `charlie-dir/`, which is what lets `_LISTED` tell
+    `nr_list`'s output from the seven other producers of the same prefix.
+    """
     d = tree / "charlie-dir" / "nested"
     d.mkdir(parents=True, exist_ok=True)
     for i in range(n):

--- a/scripts/tests/test_ship_converge.py
+++ b/scripts/tests/test_ship_converge.py
@@ -32,6 +32,12 @@ import pytest
 SCRIPTS = Path(__file__).resolve().parents[1]
 SHIP = SCRIPTS / "ship.sh"
 HOST_ROLE_LIB = SCRIPTS / "lib" / "host-role.sh"
+# The DERIVED nix-read predicate the dirty-tree verdict is classified through.
+# Its own suite is scripts/tests/test_nix_read_paths.py; here it is copied into
+# the throwaway repo verbatim, because CONVERGE sources it out of `$repo` — the
+# post-fast-forward copy, deliberately, so a run classifies against the nix/ it
+# just landed on.
+NIXREAD_LIB = SCRIPTS / "lib" / "nix_read_paths.sh"
 
 sys.path.insert(0, str(SCRIPTS))
 
@@ -197,9 +203,64 @@ class Repo:
     # kill, so _assert_foreign_store_is_absent() pins it.
     FOREIGN_STORE = "/nix/store/zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz-home-manager-files"
 
+    # -- the nix-read fixture tree ------------------------------------------ #
+    #
+    # A minimal but REAL flake shape: flake.nix names nix/home.nix, which names
+    # one file source, one DIRECTORY source and one mkOutOfStoreSymlink. All
+    # three spellings matter — the directory one is the shape that made the
+    # measured 2026-08-25 workbench file nix-read when nobody expected it
+    # (home.nix says ${../scripts/dl-router}, copying that whole tree into the
+    # store).
+    #
+    # 🔴 The names are pairwise distinct AND distinct from every constant the
+    # assertions name (LIVE, STORE, origin/main, DIRTY). A fixture that can only
+    # produce a constant's own value cannot detect a mutant that hardcodes it.
+    NIXREAD_FLAKE = (
+        "{\n"
+        "  outputs = { self, ... }: {\n"
+        "    homeConfigurations.someone.modules = [ ./nix/home.nix ];\n"
+        "  };\n"
+        "}\n"
+    )
+    NIXREAD_HOME_NIX = (
+        "{ config, ... }:\n"
+        'let workspace = "${config.home.homeDirectory}/workspace";\n'
+        "in {\n"
+        '  home.file.".alpha".source = ../copied-alpha.txt;\n'
+        '  home.file.".bravo".source = ../charlie-dir;\n'
+        '  home.file.".delta".source =\n'
+        '    config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/echo-live.txt";\n'
+        "}\n"
+    )
+    # repo-relative -> its expected class, used by the tests AND by the writer so
+    # the two cannot drift apart.
+    NIXREAD_PATHS = {
+        "copied-alpha.txt": "STORE",
+        "charlie-dir/nested/foxtrot.txt": "STORE",   # via the DIRECTORY source
+        "echo-live.txt": "LIVE",
+    }
+
+    def _write_nixread_into(self, tree):
+        """Seed the flake shape + the real predicate lib. Returns pathspecs."""
+        (tree / "nix").mkdir(parents=True, exist_ok=True)
+        (tree / "flake.nix").write_text(self.NIXREAD_FLAKE)
+        (tree / "nix" / "home.nix").write_text(self.NIXREAD_HOME_NIX)
+        for rel in self.NIXREAD_PATHS:
+            f = tree / rel
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text(rel + " base\n")
+        lib = tree / "scripts" / "lib" / "nix_read_paths.sh"
+        lib.parent.mkdir(parents=True, exist_ok=True)
+        lib.write_text(NIXREAD_LIB.read_text())
+        return [
+            "flake.nix", "nix/home.nix", "scripts/lib/nix_read_paths.sh",
+            *self.NIXREAD_PATHS,
+        ]
+
     def __init__(self, tmp_path, gitconfig_extra="", stale_managed=(), phantom_managed=False,
                  second_host=False, ship_in_repo=False, ship_changes=True,
-                 ship_pad_lines=0, ship_broken=False, lib_broken=None):
+                 ship_pad_lines=0, ship_broken=False, lib_broken=None,
+                 nixread=False):
         """`stale_managed` seeds those entries from the BASE commit's bytes.
 
         That is the real staleness shape, not a synthetic one: the deployed
@@ -265,6 +326,8 @@ class Repo:
         extra = []
         if ship_in_repo:
             extra = self._write_ship_into(builder, 1, pad_lines=ship_pad_lines)
+        if nixread:
+            extra = [*extra, *self._write_nixread_into(builder)]
         self._git(builder, "checkout", "-q", "-B", "main")
         self._git(builder, "add", "f", "stable.txt", *self.SOURCE_PATHS, *extra)
         self._git(builder, "commit", "-q", "-m", "base")
@@ -1034,12 +1097,192 @@ def test_reports_missing_origin_main_as_config_error_not_divergence(repo):
 
 
 def test_verify_line_names_a_dirty_tree(repo):
-    """Dirty convergence is the normal path now — the verifier must say so."""
+    """Dirty convergence is the normal path now — the verifier must say so.
+
+    This repo carries no flake, so the classifier cannot measure and the verdict
+    falls back to the flat sentence — WITH the reason attached, which is the
+    difference between "no dirty path is nix-read" and "we did not look".
+    """
     (repo.work / "stable.txt").write_text("stable\nwip\n")
     rc, out = repo.ship()
     assert rc == 0, out
     assert "DIRTY" in out, f"verify line hides the dirty state\n{out}"
     assert "origin/main + local WIP" in out
+    assert "NOT CLASSIFIED" in out, f"the fallback does not say it could not look\n{out}"
+
+
+# --------------------------------------------------------------------------- #
+# THE CLASSIFIED DIRTY VERDICT
+#
+# 🔴 WHY THIS EXISTS. "what was built/deployed is origin/main + local WIP" was
+# true of every dirty tree and actionable for none of them. Measured on the
+# workbench 2026-08-25: the two dirty paths were a staged sudo script under
+# nix/system/ (nix opens nothing there) and a test under scripts/dl-router/
+# (which nix/home.nix copies into the store WHOLE). One of those was in the
+# artifact; nothing in the output told them apart.
+#
+# The three verdicts are three different FACTS, and each gets its own test:
+# LIVE (already deployed, no switch involved), STORE (in the generation this run
+# built), and NEITHER — which is a real verdict about the deploy, not a softened
+# warning, and is asserted to NOT print the hedged sentence.
+#
+# 🔴 The instrument controls come first: nixrepo_can_classify is the positive
+# control (the classifier reports a NON-ZERO derived population), and
+# test_verify_line_names_a_dirty_tree above is the negative one (a repo it
+# cannot measure says so instead of printing a clean verdict).
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def nixrepo(tmp_path):
+    """A throwaway repo carrying a real flake shape and the real predicate lib."""
+    return Repo(tmp_path, nixread=True)
+
+
+def test_the_classifier_reports_a_non_zero_population(nixrepo):
+    """🔴 POSITIVE CONTROL, and the reason every branch below prints its
+    denominator. A run whose derived set is EMPTY classifies every dirty path as
+    clean and prints the friendliest line in the file. So watch the number: it
+    must be non-zero, and it must be stated in the output where an operator
+    reading a verdict can see what it was measured against."""
+    (nixrepo.work / "stable.txt").write_text("stable\nwip\n")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    m = re.search(r"classified (\d+) dirty path\(s\) against (\d+) nix-read "
+                  r"path\(s\) derived from (\d+) nix file\(s\)", out)
+    assert m, f"the verdict carries no population line\n{out}"
+    dirty, nixread, files = (int(g) for g in m.groups())
+    assert dirty >= 1, out
+    assert nixread >= 4, f"derived only {nixread} nix-read path(s)\n{out}"
+    assert files == 2, f"read {files} nix file(s), expected flake.nix + nix/home.nix\n{out}"
+
+
+def test_a_dirty_mkOutOfStoreSymlink_target_is_reported_as_LIVE(nixrepo):
+    """The strongest case: the deployed path is a link back into this working
+    tree, so the WIP is being served with no switch and no generation boundary."""
+    (nixrepo.work / "echo-live.txt").write_text("echo-live.txt wip\n")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert "DIRTY AND LIVE" in out, out
+    assert "echo-live.txt" in out
+    assert "DIRTY AND IN THE ARTIFACT" not in out, (
+        f"a live target was also reported as a store copy\n{out}"
+    )
+    assert "NO dirty path is read by nix" not in out, out
+
+
+def test_a_dirty_nix_path_literal_is_reported_as_IN_THE_ARTIFACT(nixrepo):
+    (nixrepo.work / "copied-alpha.txt").write_text("copied-alpha.txt wip\n")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert "DIRTY AND IN THE ARTIFACT" in out, out
+    assert "copied-alpha.txt" in out
+    assert "DIRTY AND LIVE" not in out, out
+    assert "NO dirty path is read by nix" not in out, out
+
+
+def test_a_dirty_file_UNDER_a_directory_source_is_still_in_the_artifact(nixrepo):
+    """🔴 THE MEASURED CASE. Nothing names this file; its ANCESTOR is the source,
+    and the whole directory is copied into the store. A predicate that matched
+    only exact spellings would call it clean — which is what a hand-written list
+    did to scripts/dl-router/tests/load_test_store.sh."""
+    p = nixrepo.work / "charlie-dir" / "nested" / "foxtrot.txt"
+    p.write_text("foxtrot wip\n")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert "DIRTY AND IN THE ARTIFACT" in out, out
+    assert "charlie-dir/nested/foxtrot.txt" in out, out
+
+
+def test_an_UNTRACKED_file_in_a_nix_read_path_is_classified_too(nixrepo):
+    """The dirty set is modified + staged + UNTRACKED, exactly as blocking_files
+    computes it. An untracked file inside a directory source is in the artifact
+    just as surely as a modified one."""
+    (nixrepo.work / "charlie-dir" / "nested" / "hotel-new.txt").write_text("new\n")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert "DIRTY AND IN THE ARTIFACT" in out, out
+    assert "charlie-dir/nested/hotel-new.txt" in out, out
+
+
+def test_a_dirty_tree_with_no_nix_read_path_says_the_deploy_IS_origin_main(nixrepo):
+    """🔴 A REAL VERDICT, and it must not be collapsed into the warning. This is
+    the case the workbench was actually in, and the old note implied otherwise."""
+    (nixrepo.work / "stable.txt").write_text("stable\nwip\n")
+    (nixrepo.work / "untracked-golf.txt").write_text("golf\n")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert "NO dirty path is read by nix" in out, out
+    assert "built/deployed IS origin/main" in out, out
+    assert "DIRTY AND LIVE" not in out, out
+    assert "DIRTY AND IN THE ARTIFACT" not in out, out
+    # 🔴 and NOT the hedged sentence: saying both would be saying nothing.
+    assert "origin/main + local WIP" not in out, (
+        f"the nix-read-free verdict still hedges\n{out}"
+    )
+
+
+def test_a_clean_tree_gets_no_classification_block_at_all(nixrepo):
+    """INVARIANT GUARD, not regression coverage — GREEN at origin/main
+    (200e6383) too, because there was no block to print. It pins that the
+    classification stays scoped to the dirty branch and never becomes noise on
+    the run an operator sees most often."""
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert "clean tree" in out, out
+    assert "classified" not in out, out
+    assert "DIRTY" not in out, out
+
+
+def test_the_classification_never_blocks_the_ship(nixrepo):
+    """It is the honesty of the verdict, not a gate. A tree dirty in the LIVE
+    class — the loudest finding this can make — still converges and still
+    exits 0.
+
+    INVARIANT GUARD, not regression coverage — GREEN at origin/main (200e6383),
+    where a dirty converge already exited 0. Kept because the whole change is a
+    new finding printed on a path an operator relies on completing: the way this
+    goes wrong later is someone deciding it SHOULD block."""
+    (nixrepo.work / "echo-live.txt").write_text("echo-live.txt wip\n")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert_converged(nixrepo, out)
+    assert "✅ VERIFIED" in out, out
+
+
+def test_both_classes_at_once_are_reported_separately(nixrepo):
+    """They are different facts with different consequences (one is already
+    running, one arrives with the generation), so one must not swallow the
+    other."""
+    (nixrepo.work / "echo-live.txt").write_text("echo-live.txt wip\n")
+    (nixrepo.work / "copied-alpha.txt").write_text("copied-alpha.txt wip\n")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert "DIRTY AND LIVE" in out and "echo-live.txt" in out, out
+    assert "DIRTY AND IN THE ARTIFACT" in out and "copied-alpha.txt" in out, out
+
+
+def test_a_repo_whose_predicate_lib_is_missing_says_so_rather_than_clean(nixrepo):
+    """🔴 NEGATIVE CONTROL on the instrument. With the lib gone the run must fall
+    back to the hedged sentence AND name the reason — never print the
+    "no dirty path is read by nix" verdict off a classifier that never ran."""
+    (nixrepo.work / "echo-live.txt").write_text("echo-live.txt wip\n")
+    (nixrepo.work / "scripts" / "lib" / "nix_read_paths.sh").unlink()
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert "NOT CLASSIFIED (NOLIB)" in out, out
+    assert "origin/main + local WIP" in out, out
+    assert "NO dirty path is read by nix" not in out, out
+    assert "DIRTY AND LIVE" not in out, out
+
+
+def test_a_repo_with_no_flake_at_all_says_it_could_not_look(nixrepo):
+    """The derivation reporting NOROOTS is not "nothing is nix-read"."""
+    (nixrepo.work / "echo-live.txt").write_text("echo-live.txt wip\n")
+    (nixrepo.work / "flake.nix").unlink()
+    shutil.rmtree(nixrepo.work / "nix")
+    rc, out = nixrepo.ship()
+    assert rc == 0, out
+    assert "NOT CLASSIFIED (NOROOTS)" in out, out
+    assert "NO dirty path is read by nix" not in out, out
 
 
 def test_skips_when_local_main_diverged(repo):


### PR DESCRIPTION
## 🔴 Audit F1 — the remote leg ran CONVERGE under **zsh**, and the lib is bash-only

Found by blind audit, reproduced here before fixing. `ssh host "<script>"` names no
interpreter, so sshd runs the account's **login shell** — `getent passwd zach` →
`/run/current-system/sw/bin/zsh`. CONVERGE was interpreter-agnostic *by accident*
until this PR made it source `scripts/lib/nix_read_paths.sh`, which needs `shopt`
and word-splitting on an unquoted `$var`. That was the payload's **first**
bash-only dependency.

Measured under zsh on the real repo, before the fix:

```
nix_read_scan:15: command not found: shopt   (×5 — on stderr, NOT tee'd into the capture)
rc=0  REASON=OK  files=28  count=1
STORE=[]   LIVE=[…STATE.md"  …ARCHIVE.md"  …]   ← trailing quotes: `%%` with an
                                                  unquoted pattern is a literal in zsh
```

`REASON=OK` — so the scan believed it had **succeeded**, every dirty nix-read path
classified `NONE`, and my own `NOT CLASSIFIED` refusal could never fire. Hermetic
fixture, one tracked-modified STORE file, identical repo state on both legs:

```
local  (bash): 🔴 DIRTY AND IN THE ARTIFACT — nix reads 1 path(s) …
remote (zsh):  NOTE: tree is DIRTY, but NO dirty path is read by nix …
```

**The fix is the transport**, the way `drift-check.sh` already solved it and
documents at its CHECK header — one rule, second place it applies:

```sh
printf 'SHIP_NO_SWITCH=%q\n%s\n' "$SHIP_NO_SWITCH" "$CONVERGE" \
  | ssh -o ConnectTimeout=10 "$REMOTE_SSH" bash -s | tee "$cap_remote"
```

🔴 **A second bug fell out of that change and is fixed with it:** `remrc=${PIPESTATUS[0]}`
was ssh when the pipeline was `ssh | tee`; with the payload piped in, `[0]` is
`printf`, which always succeeds. Left alone it would have reported **every** remote
converge as rc 0 — including a host skipped for un-pushed commits, the single most
important thing this script says. Now `[1]`, with its own test.

**Belt and braces, not the fix:** `nix_read_scan` now returns `REASON=NOTBASH, rc 1`
under a non-bash shell, so any future re-inlining degrades to the COULD-NOT-MEASURE
path both consumers already handle honestly rather than to a confident empty set.

### The test blindness that hid it

`ssh_shim` ran the payload under a hardcoded `exec bash -c` while its docstring
claimed to test *"the remote leg rather than a second local run"* — it pinned the
payload **text** and fixed the **interpreter**, so the entire remote-leg suite was
structurally blind to the only axis on which the two legs differ. It now emulates
sshd's real dispatch: a **named** command runs with the payload on stdin; an
interpreter-less invocation runs under the **login shell**. `pkgs.zsh` is in
flake.nix's `gateTools` — deliberately, and its comment argues this exact class —
so the login-shell branch is real in **both tiers** and never skips.

**Red-at-base, on a tree carrying HEAD's pre-fix `ship.sh` + lib and only the new tests:**

| test | pre-fix | HEAD |
|---|---|---|
| `test_the_remote_leg_classifies_identically_to_the_local_leg` | **RED** | green |
| `test_the_remote_leg_refuses_rather_than_lying_under_a_non_bash_shell` | **RED** | green |
| `test_the_remote_leg_names_bash_rather_than_letting_sshd_pick_a_shell` | **RED** | green |
| `test_managed_artifact_check_runs_on_the_remote_leg_too` | **RED** | green |

The pre-fix run's captured output contains the five `shopt` errors and
`classified 1 dirty path(s) … against 1 nix-read path(s) derived from 1 nix file(s)`
— the silent wrong answer, in the log, as evidence. A positive control proves the
shim can take **both** dispatch arms, so neither test can pass vacuously.

## What this is

Two coupled changes to the two safety instruments of this repo, both driven by **one** predicate: *is this repo path read by nix?* — plus a second predicate that turns that class into a claim about the artifact. Both live once, in `scripts/lib/nix_read_paths.sh`; both consumers call them.

### The measurement that motivated it

Workbench, 2026-08-25. Two dirty paths, indistinguishable in `git status`:

| path | old note said | truth |
|---|---|---|
| `nix/system/apply-nebula-443.sh.LOCAL-preserved-2026-08-02` | "origin/main + local WIP" | **NOT nix-read.** `nix/system/` holds hand-run sudo scripts the flake never opens. |
| `scripts/dl-router/tests/load_test_store.sh` | "origin/main + local WIP" | **nix-read, but it never reached the artifact** — see below. |

---

## Part 0 — the derived predicate

`scripts/lib/nix_read_paths.sh`, sourceable and side-effect-free (pinned).

Scan roots are `flake.nix` + `flake.lock` + the `nix/` tree — the flake's own entry points and the only literals in the file (a test pins that they exist). Every `*.nix` under `nix/` is **walked** for path literals; a file joins the set only when something **reaches** it. Two classes:

* **LIVE** — `mkOutOfStoreSymlink "${workspace}/devrc/<p>"`. The deployed link resolves into the working tree at **use** time.
* **STORE** — a nix path literal. Nix reads that path at eval/build time.

`nix_read_class_of` matches the path and then each ancestor, **nearest first** — which is what makes a file under a *directory* source resolve correctly (`scripts/dl-router` is STORE; `scripts/dl-router/dl-route` inside it is LIVE).

Two decisions, each pinned and each killed by a mutant: **walked ≠ read** (adding every walked `.nix` would classify `nix/system/*.nix` and the staged sudo scripts as nix-read — measured, the apply-nebula file flips from `STORE` to the correct `NONE`), and **the repo root `.` is dropped** (`flake.nix` really does `cp -r ${./.} src`, but only to build `checks.*`; keeping it would make the predicate answer STORE for everything).

**Two-way pin.** Forward: every derived path must exist. Reverse: every `source = ../…` and `mkOutOfStoreSymlink` spelling in `nix/` must classify as nix-read — via a **second, independent** extractor that has **its own positive control**, because an extractor matching nothing satisfies any set.

**Instrument controls, as pairs.** Against this repo: **29 nix files → 9 LIVE + 141 STORE = 150 paths, 0 missing**. Non-zero floors asserted in both classes; a fixture tree derives exactly its spelled paths, so the number responds to its input. A known-answer table of 12 paths asserts LIVE/STORE/**NONE** in both directions (`scripts/ship.sh` → `NONE`). `NOREPO`/`NOROOTS`/`NOSCAN` reasons with `rc 1` keep "nothing is nix-read" and "we did not look" distinct.

### 🔴 The class is not the claim — `nix_read_artifact_reach`

**This PR's first version was wrong here, and the correction is the substantive part of the revision.** A STORE classification says nix reads the *path*. It does **not** say the *file* reached the artifact, because nix's flake source for a git checkout is filtered to the files git knows about. `CLAUDE.md` already says so from the other side ("A NEW file must be `git add`ed or the flake silently omits it from the deploy"); the code ignored it.

**Corroboration on the live host:** all six `-dl-router` store generations carry `tests/` (37 files) and **none** carries the untracked `tests/load_test_store.sh`.

That alone cannot separate "the flake filtered it" from "the switch predates the file", so a **controlled build** settled it — one git repo, one directory a nix path literal names, one build, `committed.txt` as the positive control:

| state | result |
|---|---|
| committed, unmodified | PRESENT (committed content) |
| committed, **modified** | PRESENT — with the **working-tree** content |
| `git add`ed, never committed | PRESENT — with the **working-tree** content |
| staged then modified again | PRESENT — latest working-tree content |
| **untracked** | **ABSENT**, at every depth |

So the discriminator is **index membership, not commitment**. A file staged ten seconds ago is in the artifact; a file never `git add`ed is not, however long it sat there.

**LIVE is unaffected, and that is verified rather than assumed:** `mkOutOfStoreSymlink` bakes a runtime path string into the store, so the link never goes through the flake source — `~/.claude/skills/browser/browser` → `…-home-manager-files/…` → `<repo>/scripts/browser-bridge/browser`.

`nix_read_artifact_reach <class> <git-knows-it>` → `LIVE` | `ARTIFACT` | `DROPPED`. One definition, both consumers routed through it, and a **seam test** asserts neither consumer reads `nix_read_class_of` without passing it through — because that is the property a later edit is most likely to undo.

> **Why the flake experiment is not itself a pytest:** it needs `nix` on PATH, which the dev-host tier has and the nix-sandbox tier does not. A test that runs in one tier and skips in the other is the shape `run-tests.sh`'s `EXPECTED_SKIPS` ledger has **twice removed on purpose**, and it moves the skip accounting. The method is recorded in the function's header so it reproduces in one command (`nix flake metadata <repo> --json` → the store path it reports **is** the filtered source). What runs in every tier is the reach table and the seam.

---

## Part 1 — `ship.sh`: classify the DIRTY note

Four verdicts instead of one, over a dirty set computed in **two buckets** — `git diff`/`git diff --cached` vs `git ls-files --others` — because index membership is what the verdict turns on. (`blocking_files` keeps its union; the comment says why they differ.) No prose parsing anywhere.

* dirty ∩ LIVE → `🔴 DIRTY AND LIVE — … the deployed copy is a link INTO this working tree. This WIP is running on this host right now`
* dirty ∩ STORE ∩ **git knows it** → `🔴 DIRTY AND IN THE ARTIFACT — … the generation this run just built is origin/main PLUS them`
* dirty ∩ STORE ∩ **untracked** → `UNTRACKED IN A NIX-READ PATH — … the flake source is filtered to the files git knows about, so these did NOT reach the artifact. They are unsaved work in no commit and no backup, one git-add from being deployed`
* neither → `NO dirty path is read by nix — what was built/deployed IS origin/main.` **A real verdict**, asserted *not* to also print the old hedge.

When the untracked-STORE bucket is the only one populated, the run still says the deploy **IS** origin/main — because it is — while naming the unsaved work. Two independent claims, both printed.

It **never blocks the ship**; a test pins that a LIVE finding still exits 0 and still converges. Population line: `classified N dirty path(s) (X tracked, Y untracked) against M nix-read path(s) derived from K nix file(s).` Unmeasurable runs fall back to the old flat sentence **plus the reason** (`NOT CLASSIFIED (NOLIB)`).

---

## Part 2 — `drift-check.sh`: rc 23

Untracked files were reported every run and escalated never. The subset in a nix-read path is either being served right now or is one `git add` from the next artifact, with no commit and no backup.

rc-13/rc-18 ladder shape: reported **every** run, escalated after **N consecutive** (`DRIFT_NIXDIRT_ESCALATE`, default **12 ≈ 3 days** — longer than rc 18's 4, because writing a file and committing it an hour later is normal and a noisy gate trains people to click through), per **(host, path)**, **reset** the moment the path stops being untracked. Escalation *and* reset each have a test; one proves the counter restarts at 1.

`severity()`: **rank 37 — between rc 15 and rc 12**, argued in the source. The rc ledgers on both scripts move to **next free = 24**; `RESERVED-TO-DRIFT-CHECK` gains `23`.

**The FACT pairs carry the REACH, not the class** (`LIVE`/`DROPPED`), computed by the same lib function with the known-tracked bit hardcoded to 0 — every path here is untracked by construction. The escalation is unchanged; the **reason** is what was wrong. It used to say *"nix reads it at eval/build time, so every generation built on that host carries it"*. It now says the file did **not** reach the artifact and is unsaved work one `git add` away. LIVE keeps the strong claim, because for LIVE it is true.

**The refusal.** A host whose derived set is **empty** prints `COULD NOT MEASURE` with a reason token, sets **no** rc, and bumps and resets **nothing**. The summary (`hosts-reporting= untracked= nix-read-paths= hits= escalated= blind=`) is **withheld** when no host reported or the denominator is zero. Read-only contract intact; the write ledger still asserts exactly `{"$f"}`.

### A bug this found

The FACT-line parser matched `reason=*` **before** the `<path>=<REACH>` pairs. An untracked repo-root file literally named `reason` was read as the line's *reason field* — the host came out `COULD NOT MEASURE` and the file it was reporting was dropped, silently, in the reassuring direction. Pairs now match first, by **value**; there is a test whose fixture `home.nix` genuinely names `../reason` so the case is reachable.

### Consolidation

The streak encoding and the bump/reset read-modify-write are now one definition each (`_streak_key`, `_streak_file_bump`, `_streak_file_reset`) with per-ladder namers on top. The rc-18 ladder's existing tests are the safety net.

---

## Test matrix

Base = `origin/main` **200e6383** (the sha the branch was cut from), materialised pristine, **plus the new lib** — so the mutation under test is "the consumers do not classify", not "the module is missing".

| file | RED at base | GREEN at HEAD |
|---|---|---|
| `test_nix_read_paths.py` | **3** — the seam ledger + both consumer wirings | 50 |
| `test_ship_converge.py` | **10** | 85 |
| `test_drift_check.py` | **16** | 304 |

Green-at-base tests are **labelled INVARIANT GUARD** in their docstrings (4 of them), not counted as regression coverage. Two of the first version's own tests asserted the false "in the artifact" claim; they are corrected here, one renamed in intent rather than deleted — an untracked path is still *found* and still *reported*, only the verdict changed.

## The other audit findings

* **F2** — `test_the_positive_control_can_move` performed no control: it scanned one tree, bound the count, never used it. It now scans a **second** tree and asserts the fixture's exact 5 paths against the real repo's larger count.
* **F3** — the `[ "$nr_nu" = 0 ]` arm of ship.sh's clean verdict was reachable and unpinned (deleting it **survived** the suite). Pinned: an unclassifiable dirty path must suppress `built/deployed IS origin/main` — printing both says "there is a path I could not judge" and "I judged them all" in one breath.
* **F4** — rc 23's listing was the only uncapped per-host listing. `DRIFT_NIXDIRT_MAX` (default 10) caps journal lines **and** FACT-line pairs; ship.sh gains `nr_list` with `SHIP_LIST_MAX`. The **counts are never capped** — only the enumeration — and a truncated list always says how much it hid.
* **F5** — the two-way pin shared the derivation's same-line assumption, so a wrapped `mkOutOfStoreSymlink` call site would go `NONE` with the pin still green. The reverse extractor now matches **whole-file** (two extractors that fail identically are one extractor) and covers `source = ./x` and the `${../scripts/dl-router}` interpolation — the spelling this change was built around. Blind spots added to the header.
* **F6** — `> 0` is not a floor: a tree where `flake.nix` survives but `nix/` is renamed derived 3 paths from 1 file and reported `OK`. A **declared** root dir that is absent is now `MISSINGROOT` — derived from the declaration, not a numeric minimum that would rot. `test_the_scan_roots_exist` used `any` for root files (deleting `flake.lock` passed); split, and now `all`.

**Nits taken:** the lib header no longer claims it "sets nothing at source time" (it initialises 8 variables); the two sourcing conventions in `drift-check.sh` are documented as deliberately different (script-relative for host identity, `$repo`-relative in the payload — each wrong in the other's place); the documented LIVE-outranks-STORE tie-break is now pinned against a hand-built overlapping state, since the real sets are disjoint and it was otherwise an equivalent mutant.

**Nits declined, with the reason in the source:** `_streak_file_reset` keeps rewriting `CLEARED 0` rather than removing the counter — `rm` is a destructive command to the passivity scanner guarding that file, and `DRIFT_NIXDIRT_MAX` now bounds how many counters a run can create. A tracked-but-**deleted** file is documented as **UNMEASURED** rather than guessed, because the four states that *are* claimed were each measured.

## Mutation results — 32/32 killed *by the intended guard's own message*

Throwaway copies, one narrowest-expression edit each, `PYTHONDONTWRITEBYTECODE=1`, each asserting the named test failed with **this guard's specific string**. A known-caught mutant rides in the batch as the positive control.

Covering the reach correction specifically: STORE always ARTIFACT (ignore tracked-ness) → *"the flake filter is being ignored again"*; STORE always DROPPED → *"DIRTY AND IN THE ARTIFACT"*; LIVE split on tracked-ness; ship classifying the untracked bucket as tracked → *"an untracked file was reported as being in the artifact"*; a newly-staged file dropping out of the index bucket → *"the discriminator has slipped"*; the drift payload passing 1 instead of 0; the DROPPED reason reverting to the artifact claim; and the seam mutant (a consumer reading the class directly) → *"without passing it through nix_read_artifact_reach"*.

Seven new mutants cover the audit round: re-inlining the ssh payload → *"does not name an interpreter"*; deleting the `NOTBASH` guard → *"the remote leg did not refuse"*; `PIPESTATUS[0]` instead of `[1]` → *"the pipeline status is being read from the wrong stage"*; and one each for F2, F3, F6 and the tie-break.

**Four mutants SURVIVED across the rounds**, all the same shape — an earlier check always wins, or the guard was never pinned at all — and each now has a test: the zero-denominator guard (unreachable from a real payload; reached via a stubbed remote emitting a malformed fact line), the driver-side class filter (retargeted to the payload, where the filter actually is), two ship assertions that killed on the *wrong line* until each guard was collapsed into **one assertion with one message**, and 🔴 **the `PIPESTATUS` index — where a source comment named a test that did not exist.** A comment is a claim too; the battery is what caught it.

## Real-data verification

`drift-check.sh --no-remote` against this repo, state dir redirected, threshold 2: `1 of 2 untracked file(s), against 150 nix-read path(s)`; escalated on run 2; `hits=0 escalated=0` once the file was removed. The sibling file under `scripts/tests/` correctly `NONE`. Exited **12**, not 23 — the checkout is on a feature branch — which is the severity table working.

## Gate

`main` moved repeatedly during this work (22 commits in the last rebase alone);
the branch is rebased onto **5426fe54** and was 0 behind at push time. Both tiers
run at that sha:

* **dev-host tier** — `scripts/gate.sh` exit **0**, `GATE: RESULT=PASS`, pytest `TOTAL collected=17089 passed=17087 skipped=2 failed=0`, node 1292/1292, **no FAIL targets**.
* **sandbox tier** (what Tekton gates on) — `nix build .#checks.x86_64-linux.nodetests` exit **0**, verified a real run (`grep -c "building '"` = 1, not a cached zero). `.pytests` run **twice**, both times failing on **only** the two known flakes:

| run | failed | which |
|---|---|---|
| 1 | 2 | `test_git_repo_isolation.py:1482` (`['67165:git'] == []`) + `test_subsystem_store_api.py:4893` (`status=lockout-triggered` vs `locked-out`) |
| 2 | 1 | `test_subsystem_store_api.py:2392` |

Both are on the known-flake list, both in files this PR does not touch, and the
line number **moves between runs** — the signature of the timing/ordering race,
not of a defect. Grepping the sandbox log for any *other* failing file returns
**none**, so every one of this change's own targets passed there. The store-api
flake is measured at **2/10 red on pristine `origin/main`** with this change
absent, versus 1/10 at HEAD.

Earlier runs on intermediate bases (`1d67f5e8`, `a58a261d`, `9c9ad7e8`) were green
on both tiers.

The earlier "known pre-existing failure" on
`test_gh_issue_closing_condition_guard.py` is **gone** — that was #821+#841
interacting, fixed by #855, which this branch now carries.

🔴 **Read the per-target lines, not the final verdict.** Two independent
pre-existing flakes in `scripts/tests` (the store-api audit ordering, and the
co-tenant probe below) mean a single red run of this gate is not evidence about
this change. Every red I saw was reproduced on a tree without it, or not
reproduced at all.

### ⚠ `scripts/tests/test_subsystem_store_api.py` is PRE-EXISTING FLAKY — measured, with a control

A dev-tier gate run went red on
`test_subsystem_store_api.py::test_a_ROTATION_end_to_end_old_still_works_then_stops`
(`assert 'token=dbb22a50030d' in '…token=07c358b5e95b…'` — the audit lines
arrived in the other order). The same target had passed in the sandbox tier
minutes earlier, so I ran the discriminating control rather than attributing it:

| tree | runs of that file under `-n 4` | red |
|---|---|---|
| **pristine `origin/main`, my change absent** | 10 | **2** |
| this branch's HEAD | 10 | **1** |

Same failure family on both sides — audit-log ordering and timing:
`IndexError` on `audit[N]`, `assert 'status=lockout-triggered' in …`, and
`expected at least 3 'store-api audit ' line(s) within 15s, got 2`. The
assertions index a log written asynchronously by a server subprocess and assume
both arrival and order.

**So: pre-existing, roughly 10–20% per xdist run of that file, and this branch
does not make it worse.** It is not touched here. It matters anyway, because it
is inside a **required** check: it can red any PR at random, and per
`claude/RULES.md` a permanently- or randomly-red gate is what teaches people to
click through. Flagging for its own PR.

### ⚠ One sandbox run went red on a *different* untouched test — reported, not attributed

An earlier sandbox `.pytests` build failed on
`test_git_repo_isolation.py::test_live_cotenants_sees_another_process_in_the_repo`
with `assert ['66544:git'] == []`. The next build of effectively the same tree
(the delta was assertion *wording* in my own test files) passed, and the test is
**0 red in 40 serial runs** on the dev host. I could not reproduce it.

What I can state: the assertion is that a brand-new tmp repo has **zero** co-tenant
processes immediately after `git init`, and the tenant it saw was a `git` process —
consistent with an unreaped fixture child, a race intrinsic to that assertion.

🔴 **I first attributed this to CPU load I had caused by running the mutation battery
concurrently, and that was wrong — I am retracting it.** Sandbox wall time was **422s
on the red run and 465s on the green one**, so the red run was the *faster* of the two;
the load signature (every test inflated) is absent. My original comparison was against a
195s *dev-host* figure, which is a different tier and not a control.

So: one red, one green, same tree, no reproduction. That file is untouched here, but I
cannot prove the run was not influenced by this branch, and a nondeterministic assertion
in a **required** check can red any PR at random. Flagging rather than fixing — it is
outside this change and wants its own PR.

## What I could NOT verify

* **`ship.sh` step 6 was never reached against the operator's live host.** Driving the real `ship.sh` at a throwaway clone of `origin/main` with the real `$HOME` exits **rc 13** at `verify_managed_currency` (managed artifacts stale — expected; `main` has moved and nobody has shipped), which is upstream of the verdict block. The ship half is verified hermetically (19 tests, 6 mutants); the *predicates it calls* are verified against the real repo and real untracked files via the drift-check run.
* **The remote (laptop) leg is stub-tested only.** On a laptop still on a pre-merge commit the lib is absent and the block prints `COULD NOT MEASURE — reason=NOLIB` and sets no code; that path is tested, against a fixture.
* **No `home-manager switch` was run.** Nothing here is deployed.
* `flake.lock` is a declared scan root; nothing depends on its classification, so it is asserted only structurally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQwWKdSrcoeA8hbYaHTnVw
