### PR TITLE
fix(githooks): the push audit was grading pytest fixture repos — 4 runs, 167,977 output tokens, none about real code

### DIFF
--- a/githooks/README.md
+++ b/githooks/README.md
@@ -14,7 +14,7 @@ Version-controlled, global git hooks. Two features, in order on every push:
 |---|---|
 | `pre-push` | Global dispatcher. Chains to any repo-local pre-push first (never clobbers it), runs the **blocking test gate**, then fires the audit **backgrounded** so the push is never delayed. |
 | `tests-on-push.sh` | SYNCHRONOUS worker: self-detects devrc, filters on changed files, runs `scripts/run-tests.sh --set all` in the repo's **own devShell** (`nix develop`, so a venv owned by the caller's cwd cannot shadow the interpreter), and (mode `on`) **blocks on a test failure (exit 1) or a repo-content guard (exit 2)**. An ENVIRONMENT precondition (exit 3) → warn + allow. No-op for non-devrc repos. |
-| `audit-on-push.sh` | The backgrounded worker: branch + diff-size + flag gates, then headless `claude -p "/audit-pr current"`, then routes 🔴/🟡 to clawgate. |
+| `audit-on-push.sh` | The backgrounded worker: fixture-tree + branch + synthetic-ref + diff-size + flag gates, then headless `claude -p "/audit-pr current"`, then routes 🔴/🟡 to clawgate. |
 | `install.sh` | Sets `git config --global core.hooksPath` to this dir. `--uninstall` reverts. |
 | `audit-on-push.env.example` | Config template → copy to `~/.claude/audit-on-push.env`. |
 
@@ -128,13 +128,40 @@ Other knobs in that file: `AUDIT_MIN_LINES` (default 40 — skip trivial diffs),
 ## Trigger gates (all must pass, else it exits silently)
 
 1. `AUDIT_ON_PUSH != off`
-2. Branch is a **feature branch** — `zach/*`, `feat*`, `fix*`, `feature/*`,
+2. **The repository being graded is not a pytest temp fixture tree** — the
+   REPO ROOT (not cwd) is not under `pytest-of-*` / `/tmp/pytest-*` /
+   `*/pytest[-_]basetemp/*`, and no `PYTEST_CURRENT_TEST` / `PYTEST_VERSION`
+   is in the environment. Both halves are kept: `--basetemp=<dir>` defeats
+   every path pattern, and the env is absent when a stale fixture path is
+   pushed from a plain shell after the run.
+3. Branch is a **feature branch** — `zach/*`, `feat*`, `fix*`, `feature/*`,
    `hotfix/*`, `chore/*`, `refactor/*`, `wip/*`, or any `*/*`.
    **Never** `trunk` / `main` / `master` / `develop`.
-3. Diff (HEAD vs merge-base with upstream/default) ≥ `AUDIT_MIN_LINES` lines.
+4. **The push is not at a throwaway remote, and the branch is not a synthetic
+   local test ref** — the destination URL is not a `/tmp`-ish filesystem path,
+   and a `test/*`-namespace branch with no upstream whose remote sha is
+   all-zero (git's own "the remote does not have this ref") is skipped.
+   🔴 "no upstream" **alone** is deliberately NOT a trigger: the first
+   `git push -u origin fix/…` of a real feature branch also lacks one, and
+   that is the single most valuable push to audit.
+5. Diff (HEAD vs merge-base with upstream/default) ≥ `AUDIT_MIN_LINES` lines.
 
 Only then does the single LLM call (the audit) run. Everything before it is
 deterministic + cheap. Clean / 🟢-only audits are suppressed → no notification.
+
+Gates 2 and 4 are the **2026-08-25 fixture-audit fix**: a 14-day session audit
+found 5 hook-fired audit runs, **3 of them launched from inside
+`/tmp/.../pytest-of-zach/pytest-0/test_…/`**, one of which graded the branch
+`test/prepush-pc-r3` — a ref that has never existed upstream. The four
+non-productive runs cost **167,977 output tokens**. Pinned by
+`scripts/tests/test_audit_on_push_fixture_guard.py`. 🔴 That file re-measures
+the guard's own mutation score every run instead of asserting it in prose: the
+worker carries `# >>> GUARD:x` / `# <<< GUARD:x` sentinels, the test deletes
+exactly those lines and requires the result to audit all five cases the shipped
+worker skips. **If you edit either guard, keep the sentinels on their own lines
+and keep the helper functions OUTSIDE them** — a mutant that removes a guard
+together with the machinery it calls dies of `command not found`, which is a
+kill the test has not earned.
 
 ## Notification surface
 

--- a/githooks/audit-on-push.sh
+++ b/githooks/audit-on-push.sh
@@ -26,7 +26,9 @@
 #
 # Trigger gates (ALL must pass or it exits 0 silently):
 #   - flag != off
+#   - the repository being graded is NOT a pytest temp fixture tree
 #   - branch is a FEATURE branch (NEVER trunk/main/master)
+#   - the branch is not a synthetic local test ref pushed at a throwaway remote
 #   - diff (HEAD vs merge-base with upstream/default) >= AUDIT_MIN_LINES changed
 #
 set -uo pipefail
@@ -59,15 +61,78 @@ case "$AUDIT_ON_PUSH" in
   *) log "unknown AUDIT_ON_PUSH=$AUDIT_ON_PUSH; treating as off"; exit 0 ;;
 esac
 
+# --- gate 0.5: never grade a pytest temp fixture tree ----------------------
+# 🔴 MEASURED over the 14 days to 2026-08-25: FIVE hook-fired audit runs, THREE
+# of them launched from inside cwds shaped like
+#     /tmp/.../pytest-of-zach/pytest-0/test_the_far_side_fixture_woul0/…
+# — a devrc test fixture built a throwaway repo, pushed it at a throwaway bare
+# remote, and this worker graded the FIXTURE's diff with a real headless
+# `claude` call. Four non-productive runs cost 167,977 output tokens (summed
+# from the telemetry `output_tokens` of those runs).
+#
+# 🔴 THE CHECK IS ON THE REPOSITORY ROOT, NOT ON cwd, and the difference is the
+# whole point: this worker is handed REPO_ROOT as $3 by githooks/pre-push and
+# `cd`s to it below, so by the time the audit runs cwd has been overwritten.
+# cwd tells you where the push was typed; REPO_ROOT tells you what is about to
+# be graded, and only the second decides whether the audit is worth a token.
+#
+# TWO HALVES, BOTH KEPT ON PURPOSE:
+#   * PATH — the tmp shapes pytest actually produces by default.
+#   * ENV  — `--basetemp=<dir>` puts the tree at ANY path the caller likes, so
+#     no path pattern can be exhaustive. pytest exports PYTEST_CURRENT_TEST
+#     (during a test) and PYTEST_VERSION (>=8.0, for the whole session) into
+#     every child process, so the env half holds for a basetemp under any name.
+# Neither half subsumes the other: the env is absent when a stale fixture path
+# is pushed from a plain shell after the run, and the path is unrecognisable
+# when basetemp is custom.
+is_pytest_fixture_tree() {
+  case "$1" in
+    */pytest-of-*|*/pytest-of-*/*) return 0 ;;
+    /tmp/pytest-*|/tmp/pytest-*/*) return 0 ;;
+    */pytest-basetemp|*/pytest-basetemp/*) return 0 ;;
+    */pytest_basetemp|*/pytest_basetemp/*) return 0 ;;
+  esac
+  # $TMPDIR is where pytest actually roots `pytest-of-*` when it is set; the
+  # literal `/tmp` arms above do not cover a relocated TMPDIR.
+  case "${TMPDIR:-}" in
+    ""|/|/tmp|/tmp/) : ;;
+    *) case "$1" in "${TMPDIR%/}"/pytest-*) return 0 ;; esac ;;
+  esac
+  return 1
+}
+
+# 🔴 THE SENTINELS ARE LOAD-BEARING, not decoration.
+# `scripts/tests/test_audit_on_push_fixture_guard.py` builds its RED-AT-BASE
+# baseline by deleting exactly the lines between them, so the mutation it scores
+# is THIS guard and nothing else. It deliberately does NOT wrap the helper
+# function above: a mutant that removes a guard together with the machinery it
+# calls dies for the wrong reason. Keep the markers on their own lines, keep the
+# helper OUTSIDE them, and do not put anything between them that the rest of the
+# script depends on.
+# >>> GUARD:fixture-tree
+if is_pytest_fixture_tree "$REPO_ROOT"; then
+  log "repo_root=$REPO_ROOT is a pytest temp fixture tree; skip"
+  exit 0
+fi
+if [ -n "${PYTEST_CURRENT_TEST:-}${PYTEST_VERSION:-}" ]; then
+  log "repo_root=$REPO_ROOT pushed from inside a running pytest (PYTEST_CURRENT_TEST/PYTEST_VERSION set); skip"
+  exit 0
+fi
+# <<< GUARD:fixture-tree
+
 [ -n "$REPO_ROOT" ] && cd "$REPO_ROOT" 2>/dev/null || exit 0
 
 # --- gate 1: feature-branch filter (NEVER trunk/main/master) ---------------
 # Determine the branch being pushed from the ref-update lines on stdin; fall
 # back to the current symbolic HEAD.
+# The ref-update line is `<local ref> <local sha> <remote ref> <remote sha>`;
+# the 4th field is git's OWN answer to "does the remote already have this ref"
+# (all-zero = it does not), which gate 1.5 below reads. It used to be discarded.
 BRANCH=""
-while read -r local_ref _ _ _; do
+REMOTE_SHA=""
+while read -r local_ref _ _ remote_sha; do
   case "$local_ref" in
-    refs/heads/*) BRANCH="${local_ref#refs/heads/}"; break ;;
+    refs/heads/*) BRANCH="${local_ref#refs/heads/}"; REMOTE_SHA="${remote_sha:-}"; break ;;
   esac
 done
 [ -n "$BRANCH" ] || BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
@@ -83,6 +148,66 @@ case "$BRANCH" in
   zach/*|feat/*|feat-*|feature/*|fix/*|fix-*|hotfix/*|bug/*|bugfix/*|chore/*|refactor/*|wip/*|*/*) ;;
   *) log "branch=$BRANCH not a recognized feature branch; skip"; exit 0 ;;
 esac
+
+# --- gate 1.5: synthetic local test ref / throwaway fixture remote ----------
+# Second, INDEPENDENT net over the same 2026-08-25 finding. One of the four
+# non-productive runs graded `test/prepush-pc-r3`, and
+# `git ls-remote --heads origin 'test/prepush-pc*'` is EMPTY — that branch has
+# never existed upstream. Gate 1's allowlist waved it through on its trailing
+# `*/*` arm, which matches any slash-bearing name at all.
+#
+# 🔴 WHAT THIS DELIBERATELY DOES NOT DO: skip on "no upstream" ALONE. The FIRST
+# push of a real `fix/…` or `feat/…` branch also has no upstream and also names
+# a ref the remote lacks — and that push is exactly the one the audit exists
+# for. A guard keyed on absence alone would read as "quieter" while silently
+# deleting the feature. So the trigger is absence AND a positive tell:
+#
+#   (a) STRUCTURAL — the push DESTINATION is a filesystem path inside a temp
+#       tree, i.e. a fixture's throwaway bare remote. Nothing in this fleet
+#       legitimately pushes there, and it needs no network call to decide.
+#   (b) NAME-SHAPED BACKSTOP — the branch lives in a `test/`-style namespace
+#       AND git said on stdin that the remote does not have the ref AND no
+#       upstream is configured. This half is walkable by renaming the branch;
+#       it is defence in depth behind (a) and gate 0.5, not the primary.
+is_throwaway_remote() {
+  local _u
+  _u="${1#file://}"
+  [ -n "$_u" ] || return 1
+  case "$_u" in
+    /tmp/*|/var/tmp/*|/dev/shm/*) return 0 ;;
+  esac
+  is_pytest_fixture_tree "$_u" && return 0
+  case "${TMPDIR:-}" in
+    ""|/|/tmp|/tmp/) : ;;
+    *) case "$_u" in "${TMPDIR%/}"/*) return 0 ;; esac ;;
+  esac
+  return 1
+}
+
+# All-zero remote sha (40 hex zeros for sha1, 64 for sha256) = the remote does
+# not have this ref. `tr -d '0'` covers both widths without pinning a length.
+remote_lacks_ref() {
+  [ -z "$REMOTE_SHA" ] && return 0
+  [ -z "$(printf '%s' "$REMOTE_SHA" | tr -d '0')" ] && return 0
+  return 1
+}
+
+# See the sentinel note at gate 0.5 — same contract, same test file.
+# >>> GUARD:synthetic-ref
+if is_throwaway_remote "$URL"; then
+  log "branch=$BRANCH remote=$URL is a throwaway/temp-tree remote; skip"
+  exit 0
+fi
+
+case "$BRANCH" in
+  test/*|tests/*|testing/*)
+    if [ -z "$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)" ] \
+       && remote_lacks_ref; then
+      log "branch=$BRANCH is a synthetic local test ref (no upstream, absent on remote); skip"
+      exit 0
+    fi ;;
+esac
+# <<< GUARD:synthetic-ref
 
 # --- gate 2: non-trivial diff (HEAD vs merge-base with default upstream) ----
 # Find a sensible base: upstream tracking branch, else origin/<default>, else

--- a/scripts/tests/test_audit_on_push_fixture_guard.py
+++ b/scripts/tests/test_audit_on_push_fixture_guard.py
@@ -56,12 +56,17 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from testlib import mockbin  # noqa: E402
+
 AUDIT = ROOT / "githooks" / "audit-on-push.sh"
 
 ZERO_SHA = "0" * 40
@@ -117,18 +122,27 @@ def _make_repo(where: Path, home: Path, branch: str) -> Path:
 
 
 def _stub_claude(bindir: Path) -> Path:
-    """A recording `claude` that answers CLEAN. Its LOG is the positive control."""
+    """A recording `claude` that answers CLEAN. Its LOG is the positive control.
+
+    🔴 `mockbin.write_exec` OWNS THE SHEBANG, and that is not style. This stub is
+    written at RUNTIME and then exec'd by the worker via a PATH lookup, so its
+    interpreter must exist in BOTH tiers. `#!/usr/bin/env bash` — what this
+    function used to write — resolves on a NixOS dev host and does NOT exist in
+    the nix build sandbox, where the authoritative gate runs; `patchShebangs`
+    fixes the source tree and cannot touch a file a test creates while running.
+    That is exactly the two-tier hazard `scripts/tests/test_runtime_shebangs.py`
+    guards, and it took this PR red on `tekton/devrc-pytests` while the dev-host
+    run stayed green. `write_exec` writes `#!/bin/sh` and RAISES if a call site
+    supplies its own shebang, so the body below must stay POSIX sh.
+    """
     bindir.mkdir(parents=True, exist_ok=True)
     calls = bindir / "claude-calls.log"
-    stub = bindir / "claude"
-    stub.write_text(
-        "#!/usr/bin/env bash\n"
-        f'printf "%s\\n" "$*" >> {calls}\n'
+    mockbin.write_exec(
+        bindir / "claude",
+        f'printf "%s\\n" "$*" >> "{calls}"\n'
         'printf "VERDICT:SAFE\\nCLEAN\\n"\n'
         "exit 0\n",
-        encoding="utf-8",
     )
-    stub.chmod(0o755)
     return calls
 
 
@@ -256,6 +270,36 @@ def outside_tmp():
 def test_the_worker_exists_and_is_executable():
     assert AUDIT.is_file(), f"{AUDIT} missing — every test below is vacuous"
     assert os.access(AUDIT, os.X_OK), f"{AUDIT} is not executable"
+
+
+def test_bash_is_on_path_in_this_tier():
+    """🔴 NOT a skipif. Every run below invokes `bash <worker>` explicitly rather
+    than relying on the worker's own shebang, so a missing `bash` would surface
+    as a FileNotFoundError inside an unrelated assertion. `pkgs.bash` is in the
+    pytests check's nativeBuildInputs; if it ever is not, fail here by name."""
+    assert shutil.which("bash") is not None, (
+        "bash is not on PATH in this tier — add it to the pytests check in "
+        "flake.nix rather than skipping these tests")
+
+
+def test_the_stub_this_file_writes_actually_execs_in_this_tier(tmp_path):
+    """🔴 THE TIER CONTROL, and the one this PR earned the hard way.
+
+    A stub whose interpreter does not exist fails at `execve`, and the symptom
+    downstream is "the audit did not run" — indistinguishable from the guard
+    working. `/usr/bin/env` exists on a NixOS dev host and NOT in the nix build
+    sandbox, so the first version of this file was green here and red on the
+    gate. This test asks the direct question in whichever tier it runs in.
+    """
+    calls = _stub_claude(tmp_path / "bin")
+    p = subprocess.run([str(tmp_path / "bin" / "claude"), "-p", "hello"],
+                       capture_output=True, text=True, timeout=30)
+    assert p.returncode == 0, (
+        f"the recording stub could not exec (rc={p.returncode}): {p.stderr!r}. "
+        "If this is ENOENT on the interpreter, the shebang is not valid in this "
+        "tier — see scripts/testlib/mockbin.py")
+    assert "VERDICT:SAFE" in p.stdout, p.stdout
+    assert calls.exists() and "-p hello" in calls.read_text(encoding="utf-8")
 
 
 def test_the_harness_can_observe_an_audit_actually_running(tmp_path, outside_tmp):

--- a/scripts/tests/test_audit_on_push_fixture_guard.py
+++ b/scripts/tests/test_audit_on_push_fixture_guard.py
@@ -1,0 +1,455 @@
+"""githooks/audit-on-push.sh must never spend a headless `claude` call grading a
+pytest fixture repo, or a synthetic test ref pushed at a throwaway remote.
+
+🔴 WHAT THIS IS FOR — measured, not hypothesised. Over the 14 days to
+2026-08-25 the global pre-push hook fired FIVE audit runs. THREE of them were
+launched from inside cwds shaped like
+
+    /tmp/.../pytest-of-zach/pytest-0/test_the_far_side_fixture_woul0/…
+
+— a devrc test fixture built a throwaway repo, pushed it at a throwaway bare
+remote, and the worker graded the FIXTURE's diff for real. One of the runs
+graded the branch `test/prepush-pc-r3`, which has never existed upstream
+(`git ls-remote --heads origin 'test/prepush-pc*'` is empty). The four
+non-productive runs cost 167,977 output tokens, summed from their telemetry
+`output_tokens`.
+
+🔴 THE HARNESS IS THE THING TO DISTRUST HERE, because the reassuring observable
+— "no audit ran" — is exactly what a harness wired to nothing produces. So:
+
+  * POSITIVE CONTROL — `test_the_harness_can_observe_an_audit_actually_running`
+    drives the SAME plumbing on a case with no guard against it and asserts the
+    audit DID run (the `claude` stub was invoked AND `running audit` was
+    logged). If it ever goes quiet, every skip test here is measuring nothing.
+  * NEGATIVE CONTROL / RED-AT-BASE — `test_deleting_the_guard_makes_every_skip_
+    case_audit_again` deletes exactly the lines between the `GUARD:…` sentinels
+    in the shipped script and re-runs the four skip cases against the result.
+    All four must audit. That is the guard's own mutation score, re-taken every
+    run rather than asserted once in prose.
+
+🔴 NO `git`-METADATA READS OF THIS REPO. `nix flake check` builds
+`checks.pytests` from a tracked-file COPY with no `.git`, so `git show
+origin/main:…` exits 128 there while the pre-push tier (which has `.git`) stays
+green — the two-tier blind spot documented in `test_conditional_skip_pins.py`.
+An earlier draft of this file took its baseline from `origin/main` and would
+have SKIPPED in the hermetic tier, which is also an unpinned skip against
+`EXPECTED_SKIPS`. The sentinel-strip baseline runs identically in both tiers and
+adds ZERO skips. (Fixture repos built under `tmp_path` are a different thing and
+are fine — `pkgs.git` is in the check's `nativeBuildInputs` for exactly that.)
+
+🔴 NO REAL `claude` CALL CAN ESCAPE THIS FILE. Every run gets a PATH whose first
+entry holds a recording `claude` stub, and an env built from scratch rather than
+copied from `os.environ` — so `AUDIT_CONF_FILE`/`CLAWGATE_CONF_FILE` point at
+non-existent paths (the operator's `~/.claude/audit-on-push.env` could otherwise
+set `AUDIT_ON_PUSH=on` and make a live POST) and no ambient `PYTEST_*` or
+`TMPDIR` value leaks in to move a guard arm behind the test's back.
+
+MEASURED RED-AT-BASE, by hand, against the real pre-change file
+(`git show origin/main:githooks/audit-on-push.sh` swapped in on disk):
+all SIX skip tests FAILED; the two negative-case tests PASSED. Those two are
+INVARIANT GUARDS — green at base by construction, since the pre-change worker
+audits everything — and are labelled as such below rather than counted as
+regression coverage.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+AUDIT = ROOT / "githooks" / "audit-on-push.sh"
+
+ZERO_SHA = "0" * 40
+REAL_SHA = "1a2b3c4d5e6f70819283a4b5c6d7e8f901234567"
+REAL_URL = "git@github.com:ZacxDev/devrc.git"
+
+# The sentinel pairs the shipped script carries so this file can delete exactly
+# the guard and nothing around it.
+GUARDS = ("GUARD:fixture-tree", "GUARD:synthetic-ref")
+
+# A file big enough to clear AUDIT_MIN_LINES (40) so gate 2 never masks a
+# gate-0.5/1.5 result: if the guard under test does not fire, the run reaches
+# the audit, which is what the positive control reads.
+BIG_BLOB = "".join(f"line {i}\n" for i in range(60))
+
+
+# --------------------------------------------------------------------------- #
+# harness
+# --------------------------------------------------------------------------- #
+def _git_env(home: Path) -> dict[str, str]:
+    """A git environment that cannot reach the operator's config or remotes."""
+    return {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": str(home),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": str(home / "gitconfig"),
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@example.invalid",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@example.invalid",
+    }
+
+
+def _git(repo: Path, home: Path, *args: str) -> str:
+    p = subprocess.run(["git", "-C", str(repo), *args],
+                       capture_output=True, text=True, env=_git_env(home))
+    assert p.returncode == 0, f"git {args}: {p.stderr}"
+    return p.stdout
+
+
+def _make_repo(where: Path, home: Path, branch: str) -> Path:
+    """A real repo with a `main` base commit and `branch` carrying a 60-line diff."""
+    where.mkdir(parents=True, exist_ok=True)
+    home.mkdir(parents=True, exist_ok=True)
+    _git(where, home, "init", "-q", "-b", "main")
+    (where / "base.txt").write_text("base\n", encoding="utf-8")
+    _git(where, home, "add", "base.txt")
+    _git(where, home, "commit", "-q", "-m", "base")
+    _git(where, home, "checkout", "-q", "-b", branch)
+    (where / "feature.txt").write_text(BIG_BLOB, encoding="utf-8")
+    _git(where, home, "add", "feature.txt")
+    _git(where, home, "commit", "-q", "-m", "feature")
+    return where
+
+
+def _stub_claude(bindir: Path) -> Path:
+    """A recording `claude` that answers CLEAN. Its LOG is the positive control."""
+    bindir.mkdir(parents=True, exist_ok=True)
+    calls = bindir / "claude-calls.log"
+    stub = bindir / "claude"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$*" >> {calls}\n'
+        'printf "VERDICT:SAFE\\nCLEAN\\n"\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    return calls
+
+
+class Run:
+    def __init__(self, proc, log_text: str, claude_calls: list[str]):
+        self.proc = proc
+        self.log = log_text
+        self.claude_calls = claude_calls
+
+    @property
+    def audited(self) -> bool:
+        """Did the run actually reach the headless audit? Two independent reads,
+        one from the script's own log and one from the stub it would have to
+        execute — a single read of either could be satisfied by the other
+        failing silently."""
+        return bool(self.claude_calls) and "running audit" in self.log
+
+
+def _run(script: Path, work: Path, *, repo_root: str, branch: str,
+         url: str = REAL_URL, remote_sha: str = REAL_SHA,
+         env_extra: dict[str, str] | None = None) -> Run:
+    work.mkdir(parents=True, exist_ok=True)
+    home = work / "home"
+    home.mkdir(exist_ok=True)
+    bindir = work / "bin"
+    calls = _stub_claude(bindir)
+    log = work / "audit.log"
+
+    env = _git_env(home)
+    env["PATH"] = f"{bindir}{os.pathsep}{env['PATH']}"
+    env["AUDIT_ON_PUSH"] = "shadow"
+    env["AUDIT_LOG_FILE"] = str(log)
+    # Point the two config sources at paths that do not exist, so the operator's
+    # own ~/.claude/*.env can never flip this run to `on` and POST for real.
+    env["AUDIT_CONF_FILE"] = str(work / "no-such-audit.env")
+    env["CLAWGATE_CONF_FILE"] = str(work / "no-such-clawgate.env")
+    # 🔴 TMPDIR is deliberately ABSENT unless a test sets it: it selects one of
+    # gate 0.5's arms, and inheriting the ambient value would make WHICH arm
+    # fires depend on the tier (the nix sandbox relocates TMPDIR).
+    if env_extra:
+        env.update(env_extra)
+
+    stdin = f"refs/heads/{branch} {REAL_SHA} refs/heads/{branch} {remote_sha}\n"
+    proc = subprocess.run(
+        ["bash", str(script), "origin", url, repo_root],
+        input=stdin, capture_output=True, text=True, env=env, timeout=120)
+    log_text = log.read_text(encoding="utf-8") if log.exists() else ""
+    call_lines = (calls.read_text(encoding="utf-8").splitlines()
+                  if calls.exists() else [])
+    return Run(proc, log_text, call_lines)
+
+
+def _strip_guards(text: str) -> str:
+    """Delete exactly the lines between each `>>> GUARD:x` / `<<< GUARD:x` pair.
+
+    This is the guard-removed BASELINE. The helper functions the guards call sit
+    OUTSIDE the sentinels on purpose: a mutant that deletes a guard together
+    with its machinery dies with `command not found` — the wrong reason — and
+    would score a kill this file has not earned.
+    """
+    out, dropped, depth = [], 0, 0
+    for line in text.splitlines(keepends=True):
+        s = line.strip()
+        if depth == 0 and s.startswith("# >>> GUARD:"):
+            depth = 1
+            continue
+        if depth == 1 and s.startswith("# <<< GUARD:"):
+            depth = 0
+            continue
+        if depth:
+            dropped += 1
+            continue
+        out.append(line)
+    assert depth == 0, "unbalanced GUARD sentinels in audit-on-push.sh"
+    assert dropped > 0, "no guard lines were removed — the strip is inert"
+    return "".join(out)
+
+
+@pytest.fixture
+def guard_removed_script(tmp_path) -> Path:
+    """The shipped worker with both guards deleted — the red-at-base baseline."""
+    text = AUDIT.read_text(encoding="utf-8")
+    for name in GUARDS:
+        assert f"# >>> {name}" in text and f"# <<< {name}" in text, (
+            f"{name} sentinels are missing from {AUDIT} — the baseline this "
+            "file builds would silently be the SHIPPED script, and the "
+            "red-at-base test would pass while proving nothing")
+    stripped = _strip_guards(text)
+    # 🔴 Match the CODE, not the words: the same phrases appear in the header
+    # comment ("… is NOT a pytest temp fixture tree"), so a bare substring check
+    # fails on a correctly-stripped file. These are the three `log` calls only
+    # the guards make, and only a CODE line can spell them.
+    for gone in ('log "repo_root=$REPO_ROOT is a pytest temp fixture tree',
+                 'log "repo_root=$REPO_ROOT pushed from inside a running pytest',
+                 'log "branch=$BRANCH remote=$URL is a throwaway/temp-tree remote',
+                 'log "branch=$BRANCH is a synthetic local test ref'):
+        assert gone not in stripped, f"the strip left the guard behind: {gone}"
+    p = tmp_path / "audit-on-push.baseline.sh"
+    p.write_text(stripped, encoding="utf-8")
+    p.chmod(0o755)
+    syn = subprocess.run(["bash", "-n", str(p)], capture_output=True, text=True)
+    assert syn.returncode == 0, f"stripped baseline is not valid bash: {syn.stderr}"
+    return p
+
+
+@pytest.fixture
+def outside_tmp():
+    """A directory whose path does NOT look like a pytest tree.
+
+    `tmp_path` is rooted at `<basetemp>/pytest-of-<user>/…`, which gate 0.5
+    correctly rejects — so the NEGATIVE case cannot be built there without
+    measuring the guard instead of the absence of it.
+    """
+    d = Path(tempfile.mkdtemp(prefix="devrc-auditguard-real-"))
+    assert "pytest-of" not in str(d) and not str(d).startswith("/tmp/pytest-"), d
+    try:
+        yield d
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# 0. harness self-validation — read this before believing anything below
+# --------------------------------------------------------------------------- #
+def test_the_worker_exists_and_is_executable():
+    assert AUDIT.is_file(), f"{AUDIT} missing — every test below is vacuous"
+    assert os.access(AUDIT, os.X_OK), f"{AUDIT} is not executable"
+
+
+def test_the_harness_can_observe_an_audit_actually_running(tmp_path, outside_tmp):
+    """POSITIVE CONTROL for the whole file: a case that MUST reach the audit.
+
+    Without this, every `not run.audited` assertion below is indistinguishable
+    from a harness that never invokes the script at all.
+    """
+    repo = _make_repo(outside_tmp / "repo", tmp_path / "home", "fix/real-thing")
+    run = _run(AUDIT, tmp_path, repo_root=str(repo), branch="fix/real-thing")
+    assert run.audited, (
+        "the harness never reached the audit even on a case with no guard "
+        "against it — the skip assertions in this file are measuring nothing.\n"
+        f"log:\n{run.log}\ncalls: {run.claude_calls}")
+
+
+# --------------------------------------------------------------------------- #
+# 1. GUARD CONDITION 1 — the repository root is a pytest temp fixture tree
+# --------------------------------------------------------------------------- #
+def test_skips_when_the_repo_root_is_under_a_pytest_of_tree(tmp_path):
+    """The measured shape: <basetemp>/pytest-of-<user>/pytest-N/<testname>/…
+
+    The `pytest-of-` component is built explicitly rather than inherited from
+    `tmp_path`, so the test still pins the pattern under `--basetemp=<dir>`,
+    where `tmp_path` carries no such component at all.
+    """
+    root = tmp_path / "pytest-of-zach" / "pytest-0" / "test_the_far_side0"
+    repo = _make_repo(root / "repo", tmp_path / "home", "fix/real-thing")
+    run = _run(AUDIT, tmp_path, repo_root=str(repo), branch="fix/real-thing")
+    assert not run.audited, f"audited a pytest fixture repo:\n{run.log}"
+    assert "pytest temp fixture tree; skip" in run.log, run.log
+
+
+def test_skips_when_the_repo_root_is_under_slash_tmp_slash_pytest(tmp_path):
+    """The literal `/tmp/pytest-*` arm — pytest's default basetemp root.
+
+    No directory is created for it, and that is not a shortcut: gate 0.5 runs
+    BEFORE the worker `cd`s to REPO_ROOT, so a guard that has moved below the
+    `cd` fails this test instead of silently passing on the `cd`'s own exit.
+    """
+    run = _run(AUDIT, tmp_path, repo_root="/tmp/pytest-4242/test_x0/repo",
+               branch="fix/real-thing")
+    assert not run.audited, f"audited a /tmp/pytest-* repo:\n{run.log}"
+    assert "pytest temp fixture tree; skip" in run.log, run.log
+
+
+def test_skips_when_the_repo_root_is_under_a_relocated_TMPDIR(tmp_path, outside_tmp):
+    """The `$TMPDIR/pytest-*` arm — pytest roots its basetemp at $TMPDIR when
+    that is set, and the literal `/tmp` arm above cannot see it. The repo lives
+    at a path NO other arm matches, so this measures the TMPDIR arm alone."""
+    faketmp = outside_tmp / "relocated-tmp"
+    repo = _make_repo(faketmp / "pytest-3" / "repo", tmp_path / "home",
+                      "fix/real-thing")
+    run = _run(AUDIT, tmp_path, repo_root=str(repo), branch="fix/real-thing",
+               env_extra={"TMPDIR": str(faketmp)})
+    assert not run.audited, f"audited a $TMPDIR/pytest-* repo:\n{run.log}"
+    assert "pytest temp fixture tree; skip" in run.log, run.log
+
+
+@pytest.mark.parametrize("var", ["PYTEST_CURRENT_TEST", "PYTEST_VERSION"])
+def test_skips_when_pushed_from_inside_a_running_pytest(tmp_path, outside_tmp, var):
+    """`--basetemp=<dir>` defeats every path pattern, so the env is the half
+    that actually closes the class. The repo here is at a path NO path arm
+    matches — proving the ENV arm, not the path arm."""
+    repo = _make_repo(outside_tmp / "repo", tmp_path / "home", "fix/real-thing")
+    val = ("scripts/tests/test_x.py::test_y (call)"
+           if var == "PYTEST_CURRENT_TEST" else "9.1.1")
+    run = _run(AUDIT, tmp_path, repo_root=str(repo), branch="fix/real-thing",
+               env_extra={var: val})
+    assert not run.audited, f"audited a push made from inside pytest:\n{run.log}"
+    assert "running pytest" in run.log, run.log
+
+
+# --------------------------------------------------------------------------- #
+# 2. GUARD CONDITION 2 — synthetic test ref / throwaway fixture remote
+# --------------------------------------------------------------------------- #
+def test_skips_when_the_push_destination_is_a_temp_tree_remote(tmp_path, outside_tmp):
+    """(a), the STRUCTURAL half: a fixture's throwaway bare remote. The REPO is
+    at a perfectly ordinary path, so only the DESTINATION can be what fires."""
+    repo = _make_repo(outside_tmp / "repo", tmp_path / "home", "fix/real-thing")
+    run = _run(AUDIT, tmp_path, repo_root=str(repo), branch="fix/real-thing",
+               url="/tmp/pytest-of-zach/pytest-0/test_push0/remote.git")
+    assert not run.audited, f"audited a push at a temp-tree remote:\n{run.log}"
+    assert "throwaway/temp-tree remote; skip" in run.log, run.log
+
+
+def test_skips_the_synthetic_test_ref_that_was_actually_graded(tmp_path, outside_tmp):
+    """(b): the exact branch from the incident — `test/prepush-pc-r3`, no
+    upstream, all-zero remote sha (git's own "the remote does not have this
+    ref"). Gate 1's allowlist waves it through on its trailing `*/*` arm, and
+    both the repo path and the destination URL here are ordinary."""
+    repo = _make_repo(outside_tmp / "synth", tmp_path / "home",
+                      "test/prepush-pc-r3")
+    run = _run(AUDIT, tmp_path, repo_root=str(repo), branch="test/prepush-pc-r3",
+               remote_sha=ZERO_SHA)
+    assert not run.audited, f"audited a synthetic test ref:\n{run.log}"
+    assert "synthetic local test ref" in run.log, run.log
+
+
+# --------------------------------------------------------------------------- #
+# 3. THE NEGATIVE CASE — a real repo on a real branch still gets audited
+#    🔴 INVARIANT GUARDS, not regression coverage: both are green at base by
+#    construction (the pre-change script audits everything). They exist to fail
+#    the DAY the guard is widened past its evidence.
+# --------------------------------------------------------------------------- #
+def test_a_real_repo_on_a_real_branch_is_still_audited(tmp_path, outside_tmp):
+    repo = _make_repo(outside_tmp / "repo", tmp_path / "home", "fix/real-thing")
+    run = _run(AUDIT, tmp_path, repo_root=str(repo), branch="fix/real-thing")
+    assert run.audited, (
+        "the guard swallowed a REAL feature-branch push — this is the feature, "
+        f"not the noise.\nlog:\n{run.log}")
+    assert "running audit" in run.log, run.log
+
+
+def test_the_first_push_of_a_real_feature_branch_is_still_audited(tmp_path, outside_tmp):
+    """🔴 THE FAIL-DIRECTION CONTROL, and the reason gate 1.5 is not keyed on
+    "no upstream" alone. A first `git push -u origin fix/…` ALSO has no upstream
+    and ALSO names a ref the remote lacks (all-zero remote sha) — and it is the
+    single most valuable push to audit. A guard keyed on absence alone would
+    read as "quieter" while deleting the feature outright."""
+    repo = _make_repo(outside_tmp / "repo", tmp_path / "home", "fix/brand-new")
+    run = _run(AUDIT, tmp_path, repo_root=str(repo), branch="fix/brand-new",
+               remote_sha=ZERO_SHA)
+    assert run.audited, (
+        "a first push of a real feature branch was skipped — gate 1.5 has been "
+        f"widened past its evidence.\nlog:\n{run.log}")
+
+
+# --------------------------------------------------------------------------- #
+# 4. RED AT BASE — the matrix, re-measured every run rather than written down
+# --------------------------------------------------------------------------- #
+def _skip_cases(tmp_path, outside_tmp) -> dict[str, dict]:
+    real = _make_repo(outside_tmp / "repo", tmp_path / "home", "fix/real-thing")
+    synth = _make_repo(outside_tmp / "synth", tmp_path / "home",
+                       "test/prepush-pc-r3")
+    faketmp = outside_tmp / "relocated-tmp"
+    reloc = _make_repo(faketmp / "pytest-3" / "repo", tmp_path / "home",
+                       "fix/real-thing")
+    fixture = _make_repo(tmp_path / "pytest-of-zach" / "pytest-0" / "t0" / "repo",
+                         tmp_path / "home", "fix/real-thing")
+    return {
+        "pytest-of path": dict(repo_root=str(fixture), branch="fix/real-thing"),
+        "relocated TMPDIR": dict(repo_root=str(reloc), branch="fix/real-thing",
+                                 env_extra={"TMPDIR": str(faketmp)}),
+        "inside a running pytest": dict(
+            repo_root=str(real), branch="fix/real-thing",
+            env_extra={"PYTEST_CURRENT_TEST": "a.py::b (call)"}),
+        "temp-tree remote": dict(
+            repo_root=str(real), branch="fix/real-thing",
+            url="/tmp/pytest-of-zach/pytest-0/remote.git"),
+        "synthetic test ref": dict(
+            repo_root=str(synth), branch="test/prepush-pc-r3",
+            remote_sha=ZERO_SHA),
+    }
+
+
+def test_deleting_the_guard_makes_every_skip_case_audit_again(
+        guard_removed_script, tmp_path, outside_tmp):
+    """🔴 A test never watched to FAIL proves nothing. This deletes exactly the
+    guard (the lines between the `GUARD:…` sentinels) and asserts the resulting
+    worker audits ALL FIVE cases the guard skips — then asserts the SHIPPED
+    worker skips all five. Both halves are required: "the mutant audits them"
+    alone would still hold if the shipped script audited them too."""
+    cases = _skip_cases(tmp_path, outside_tmp)
+    audited_without_guard, audited_with_guard = [], []
+    # 🔴 Work-dir names are INDEXED, not `hash(name)`: PYTHONHASHSEED makes str
+    # hashing nondeterministic per process, and a nondeterministic on-disk name
+    # is the exact defect PR #855 closed elsewhere in this tree.
+    for i, (name, kw) in enumerate(cases.items()):
+        if _run(guard_removed_script, tmp_path / f"nog-{i}", **kw).audited:
+            audited_without_guard.append(name)
+        if _run(AUDIT, tmp_path / f"head-{i}", **kw).audited:
+            audited_with_guard.append(name)
+
+    assert audited_without_guard == list(cases), (
+        "with the guard DELETED the worker did not audit every case — so those "
+        "cases are not regression coverage, they are invariant guards.\n"
+        f"audited without the guard: {audited_without_guard}")
+    assert audited_with_guard == [], (
+        f"the SHIPPED worker still audits: {audited_with_guard}")
+
+
+def test_the_guard_removal_does_not_also_break_the_untouched_paths(
+        guard_removed_script, tmp_path, outside_tmp):
+    """The strip's own control: the baseline must still be a WORKING worker.
+
+    A mutant that is merely broken would make the test above pass for the wrong
+    reason (nothing audits because nothing runs). So the guard-removed copy is
+    also driven on the negative case, where it must behave exactly like the
+    shipped one — audit it.
+    """
+    repo = _make_repo(outside_tmp / "repo", tmp_path / "home", "fix/real-thing")
+    run = _run(guard_removed_script, tmp_path / "ctl",
+               repo_root=str(repo), branch="fix/real-thing")
+    assert run.audited, (
+        "the guard-removed baseline cannot audit anything at all — it is "
+        f"broken, not merely unguarded.\nlog:\n{run.log}\nstderr:{run.proc.stderr}")


### PR DESCRIPTION
## The evidence

A 14-day session audit found the global pre-push hook fired **five** `/audit-pr` runs. **Three** were launched from inside cwds shaped like

```
/tmp/.../pytest-of-zach/pytest-0/test_the_far_side_fixture_woul0/…
```

— a devrc test fixture built a throwaway repo, pushed it at a throwaway bare remote, and `githooks/audit-on-push.sh` graded the **fixture's** diff with a real headless `claude` call.

One run graded the branch `test/prepush-pc-r3`. Independently verified: `git ls-remote --heads origin 'test/prepush-pc*'` returns nothing — **that branch has never existed upstream**.

Cost of the four non-productive runs, summed from telemetry `output_tokens`: **167,977 tokens**.

## The change

Two gates in `githooks/audit-on-push.sh`, which is where all branch/size/flag filtering already lives (`githooks/pre-push` explicitly delegates it there and guarantees only "never slow the push").

**gate 0.5 — the repository being graded is a pytest temp fixture tree.**
Keyed on the **repository root**, not cwd: the worker `cd`s to `REPO_ROOT` before the audit, so cwd says where the push was *typed* while `REPO_ROOT` says what is about to be *graded*. Two halves, and neither subsumes the other:

* **path** — `pytest-of-*`, `/tmp/pytest-*`, `$TMPDIR/pytest-*`, `pytest[-_]basetemp`
* **env** — `PYTEST_CURRENT_TEST` / `PYTEST_VERSION`. `--basetemp=<dir>` puts the tree at *any* path and defeats every pattern; pytest exports these into every child, so the env half holds for a basetemp under any name. Conversely the env is absent when a stale fixture path is pushed from a plain shell after the run.

**gate 1.5 — synthetic local test ref / throwaway remote.**

* *(a), structural* — the push **destination** is a temp-tree filesystem path (a fixture's throwaway bare remote). No network call needed.
* *(b), name-shaped backstop* — the branch is in a `test/`-style namespace **and** git said on stdin the remote lacks the ref **and** no upstream is configured. That fourth stdin field (`<remote sha>`, all-zero when the remote lacks the ref) is git's own answer to the question, and the worker previously discarded it.

Gate 1's existing allowlist waved `test/prepush-pc-r3` through on its trailing `*/*` arm, which matches any slash-bearing name at all.

### 🔴 What this deliberately does NOT do

**Skip on "no upstream" alone.** A first `git push -u origin fix/…` also has no upstream and also names a ref the remote lacks — and it is the single most valuable push to audit. A guard keyed on absence alone would read as "quieter" while deleting the feature outright. Pinned by `test_the_first_push_of_a_real_feature_branch_is_still_audited`.

Skips use the script's existing `log "…; skip"; exit 0` idiom — no new logging channel.

## Test coverage and the red/green matrix

`scripts/tests/test_audit_on_push_fixture_guard.py` — **13 tests, 0 skips**.

Measured by swapping `git show origin/main:githooks/audit-on-push.sh` onto disk and re-running the file, then restoring from a `cp` copy (never `git stash` — the stash stack is repo-global and shared with other agents):

| | at base (`origin/main`) | at HEAD |
|---|---|---|
| 7 skip tests | **FAILED** | passed |
| 2 sentinel-dependent tests | **ERRORED** (sentinels don't exist at base) | passed |
| 2 harness self-validation | passed | passed |
| 2 negative-case tests | passed | passed |
| **total** | **7 failed, 2 errored, 4 passed** | **13 passed** |

The 4 green at base are the harness self-validation pair and two **invariant guards** (a real repo on a real branch, and a real branch's first push, must still audit). They are labelled as such in the file and are **not** counted as regression coverage.

### The matrix is also re-measured in-suite, so it cannot rot into prose

The worker carries `# >>> GUARD:x` / `# <<< GUARD:x` sentinels. `test_deleting_the_guard_makes_every_skip_case_audit_again` deletes exactly those lines and requires the result to audit all five skip cases **while the shipped worker skips all five** — both halves, because "the mutant audits them" alone would still hold if the shipped script audited them too.

Mutation hygiene: the helper functions the guards call sit **outside** the sentinels, so the mutant cannot die of `command not found` — a kill this file has not earned. A separate control (`test_the_guard_removal_does_not_also_break_the_untouched_paths`) asserts the guard-removed baseline still audits the negative case, since a merely-broken baseline would green the mutation test for the wrong reason.

### Harness controls

The reassuring observable here — "no audit ran" — is exactly what a harness wired to nothing produces. So `test_the_harness_can_observe_an_audit_actually_running` drives the same plumbing on a case with no guard against it and asserts the audit **did** run (the `claude` stub was invoked **and** `running audit` was logged — two independent reads). Every run gets a PATH whose first entry holds a recording `claude` stub and an env built from scratch, so `AUDIT_CONF_FILE`/`CLAWGATE_CONF_FILE` point at non-existent paths (the operator's `~/.claude/audit-on-push.env` could otherwise flip a run to `on` and POST for real) and no ambient `PYTEST_*` or `TMPDIR` value leaks in to move a guard arm behind the test's back.

### Two-tier hazard caught during review

An earlier draft took its baseline from `git show origin/main:…`. That would have **skipped** under `nix flake check` (which builds `checks.pytests` from a tracked-file copy with no `.git`) while passing on the dev host — the blind spot `test_conditional_skip_pins.py` documents — and the skip would also have been unpinned against `EXPECTED_SKIPS`. The sentinel strip runs identically in both tiers and adds zero skips.

## End-to-end, not just the worker in isolation

Driven through a real `git push` and the real `githooks/pre-push` dispatcher:

* fixture repo at `pytest-of-*` on `test/prepush-pc-r3` → logged `is a pytest temp fixture tree; skip`, **zero** `claude` calls
* repo outside any temp tree on `fix/really-real` → logged `— running audit` and invoked the stub

## Relationship to #855

No overlap. #855 (merged) touches only `scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py`; this branch is rebased onto it. It fixed a nondeterministic *parametrize ID*; this fixes the hook *firing inside fixture trees*. The one place they rhyme is called out in a comment: this file's work-dir names are indexed rather than `hash(name)`, for exactly the reason #855 gives.

## 🔴 What I could NOT verify

* **The full `scripts/run-tests.sh` suite never completed here.** Five sibling agents were running their own suites on the same box (load ~60 on 24 cores); my run was still inside its first target after ~10 minutes and I terminated it. Its `RESULT: FAIL (exit=143)` is **SIGTERM — my own kill** (`Terminated` on the pytest line, 128+15), not a test failure. No target ever reported, so there is **no load-vs-assertion signature to read from it** either way. This PR's CI gate is the independent check.
* **The push ran no pre-push gate**, and not because it was bypassed — no `--no-verify`, no `DEVRC_SKIP_TESTS`. `core.hooksPath` is **unset in every scope** (worktree, repo, global) on this host and `.git/hooks` holds only `.sample` files, so the hook is not currently installed. Worth a look on its own: `~/.claude/audit-on-push.env` still documents the test gate as enabled "via local `core.hooksPath` on the devrc repo", and that config is gone — meaning the devrc pre-push test gate is presently **inert on this machine**. Filed here rather than fixed, since it is a separate change with its own blast radius.
* **`TARGET_FLOORS` is untouched, by derivation rather than measurement.** I never observed a `collected=` line, so this is reasoning, not a reading: `scripts/tests` has floor `8036`, and the drift ceiling is `floor + max(60, floor/4)` = `10045`. Adding 13 tests cannot approach ~2000 tests of headroom, and a floor is a minimum that added tests can only clear more easily. `scripts/run-tests.sh --check-floors` passes (that validates the two-way pin, not the count). **If CI reports a floor/ceiling failure, that derivation is what was wrong.**
