### PR TITLE
fix(search-tool-nudge): it demanded Grep/Glob — 0 of 133 sessions that reached for them had them

### DIFF
--- a/scripts/claude-hooks/search-tool-nudge.py
+++ b/scripts/claude-hooks/search-tool-nudge.py
@@ -1,159 +1,167 @@
 #!/usr/bin/env python3
-"""PostToolUse nudge: when a Bash call does a SEARCH that the native Grep/Glob tools
-already do (`grep -r`, bare `rg`, `find <path> -name …`, `ls -R`, `find | xargs grep`),
-inject context pointing at the native tool.
+"""PostToolUse nudge: when a Bash call runs a RECURSIVE tree content-search
+(`grep -r`, bare `rg`), warn that the search is .gitignore-BLIND and can return a
+confident zero.
 
-Why this exists: measured over a 30-day window of activity telemetry, Bash is 71% of all
-Claude tool calls (workbench 31,355 / laptop 6,164) while Grep+Glob together were used
-50 times — and ZERO times on the laptop. RULES.md's "Tool Optimization" section said
-"Grep over bash grep, Glob over find"; that prose rule demonstrably did not work.
-Per RULES.md "Deterministic Over Prose" the replacement has to be structural, so this
-fires at the moment the search-shaped command runs.
+--------------------------------------------------------------------------- #
+WHAT THIS HOOK USED TO SAY, AND WHY IT WAS WRONG  (retargeted 2026-08-25)
+--------------------------------------------------------------------------- #
+It used to point the same detector at the native Grep/Glob tools, quoting
+"Bash 37.5k calls vs Grep+Glob 50" as proof of an agent-discipline failure.
 
-🔴 As of 2026-08-10 that prose section is GONE — retired from claude/RULES.md after a
-paired revert-and-rerun audit reproduced the telemetry finding (the control arm, WITH
-the rule loaded, reached for bash `grep` in 4 of 4 runs and never once used the Grep
-tool). See `claude/RULES-ARCHIVE.md#retired-tool-optimization`. So this hook is now the
-ONLY thing carrying "prefer the native search tools" — there is no prose fallback behind
-it. Weakening or disabling the detector removes the guidance entirely rather than
-downgrading it to a written rule.
+🔴 That statistic counted ATTEMPTS, and essentially every attempt FAILED. Measured
+across the 2,460 session transcripts under ~/.claude/projects with an mtime inside
+14 days:
+
+    Grep: 128 sessions reached for it — 0 used it without an error,
+          128 got "No such tool available: Grep".
+    Glob:   5 sessions reached for it — 0 used it,  5 got the same error.
+
+Grep and Glob are not underused on this fleet; they are ABSENT from it. The old
+message did not describe a discipline gap, it described a tool roster — and a
+nudge toward a tool that cannot be called can never once be correct, which is the
+"permanently-red gate" shape from RULES.md: it trains the reader to ignore the hook.
+
+It was also actively harmful, not merely inert. In the same corpus the nudge fired
+in 319 sessions, and in 61 of them it came BEFORE a failed `Grep` call — the hook
+talked the agent into a tool call that could only error, costing tokens twice.
+
+Ruled out before retargeting, so this is a root-cause fix and not a workaround: the
+absence is NOT local configuration. `~/.claude/settings.json` has an empty
+`permissions.deny`, no `disallowedTools`, and no Grep/Glob entry; the roster is
+decided server-side.
+
+🔴 AVAILABILITY IS NOT KNOWABLE FROM ANYTHING THIS HOOK RECEIVES. Measured, not
+assumed, at claude-code 2.1.232:
+  * the PostToolUse payload carries exactly 12 keys and none is a tool roster —
+    captured live via a stdin-dumping hook: session_id, transcript_path, cwd,
+    prompt_id, permission_mode, effort, hook_event_name, tool_name, tool_input,
+    tool_response, tool_use_id, duration_ms;
+  * a freshly captured transcript has no `"tools"` key, no `availableTools`, and
+    zero occurrences of the names of the tools the session was not given.
+The previous revision inferred absence from the transcript's
+`Error: No such tool available: <Tool>` record. That worked, but only AFTER the
+model had already attempted the tool and eaten the failure — the one cost worth
+avoiding. It is removed rather than left in place, because a guard that cannot act
+before the damage reads as coverage while providing none.
+
+--------------------------------------------------------------------------- #
+WHAT IT WARNS ABOUT NOW, AND WHY THAT IS WORTH A NUDGE
+--------------------------------------------------------------------------- #
+The same commands, but for a hazard that needs no tool at all — and a CORRECTNESS
+hazard rather than a token-cost nag.
+
+In the Bash tool's shell, `grep` is not GNU grep. Claude Code's shell snapshot
+installs a function that execs `ugrep -G --ignore-files --hidden -I …`, and
+`--ignore-files` makes it honour `.gitignore`. `rg` honours `.gitignore` by
+default too. So a recursive search SKIPS ignored and generated paths — caches,
+venvs, build output, `__pycache__` — and reports a confident 0 or an undercount
+with no indication anything was skipped.
+
+Reproduced live on this host (a token planted in both a tracked and a gitignored
+file), with the controls that make the number mean something:
+
+    positive control, tracked file : shadowed `grep -rn` 1  |  GNU grep 1
+    explicit path into ignored dir : shadowed `grep -rn` 1  |  GNU grep 1
+    🔴 WHOLE TREE (`grep -rn … .`) : shadowed `grep -rn` 1  |  GNU grep 2
+    bare `rg`                      : 1   |   `rg --no-ignore` 2
+
+This is already a written rule — `claude/RULES.md` "Shell & Tooling Gotchas"
+("`grep` here is a FUNCTION wrapping ugrep, and `-r` HONOURS `.gitignore` … Never
+quote a `-r` zero about an ignored or generated path", → archive:
+grep-gitignore-blind). That rule was READ IN-SESSION and the trap was hit anyway,
+which is the same "prose did not work" evidence that motivated the original hook.
+Per RULES.md "Deterministic Over Prose" the enforcement has to be structural, so
+this fires at the moment the blind search runs. The rule text stays — unlike the
+retired "Tool Optimization" section, this one is TRUE and still worth reading;
+the hook is its in-the-moment reminder, not its replacement.
+
+WHAT DELIBERATELY NO LONGER FIRES, because the same controls show it is SAFE:
+  * `find … | xargs grep` and `find … -exec grep` — the paths are explicit, so
+    `--ignore-files` never applies (measured: 2, the correct answer);
+  * `find -name` / `ls -R` — `find` is shadowed to `bfs`, which is NOT passed an
+    ignore-files flag and does see gitignored files (measured: it found the
+    generated file);
+  * non-recursive `grep`, and `cmd | rg` as a stdin filter — no tree walk.
+This is why the old FILES ("Glob") kind is gone entirely rather than reworded:
+there is no hazard on that side to warn about.
 
 Design constraints, in priority order:
   1. NEVER blocks. It is a PostToolUse nudge — it only ever adds context, and always
      exits 0. (bash-guard.py is the only hook here that denies; this is not that.)
   2. False positives are expensive. This runs on EVERY Bash call, and a hook that cries
      wolf trains the operator to ignore it. So the detector is deliberately conservative:
-     it fires only on the shapes that are unambiguously a tree search, and stays silent
-     on every narrow/legitimate use (single-file `grep`, `git log | grep`, `find -exec`
-     doing non-search work).
-  3. Once per KIND per session (two kinds: content-search, file-search), so a session
-     sees at most two of these ever.
-  4. NEVER recommend a tool this session does not have. Grep/Glob are not present in
-     every session — the harness answers a call to a missing one with
-     `Error: No such tool available: Grep. …`. A nudge pointing at a tool that cannot
-     be called is pure token cost AND trains the operator to ignore the hook, which
-     degrades it for the sessions where it IS actionable. See "Availability" below.
+     it fires only on the shapes that are unambiguously a gitignore-honouring tree walk.
+  3. Once per KIND per session, so a session sees at most one of these ever.
+
+The FILENAME is deliberately unchanged. `search-tool-nudge.py` is registered by path
+in register-nudge-hook.py, nix/home.nix, run-tests.sh and three test files, and — the
+reason that matters — a rename would leave the OLD file in place at
+~/.claude/hooks/search-tool-nudge.py on every host that has already deployed it, still
+firing the retired Grep/Glob message with nothing to supersede it. Renaming has to be
+sequenced with a removal; it is not a free cleanup.
 
 Fail-open: any error -> exit 0 silently; it must never break the Bash tool.
 """
-import sys, json, os, re, shlex, glob
+import sys, json, os, re, shlex
 
 HOME = os.path.expanduser("~")
 CACHE_DIR = f"{HOME}/.cache/claude-search-tool-nudge"
 
-# Content-search binaries: they read file *contents*, so the native answer is Grep.
-GREP_BINS = {"grep", "egrep", "fgrep", "rgrep", "ggrep"}
+# 🔴 EXACTLY ONE name, and it is not a stylistic choice. Claude Code's shell snapshot
+# defines precisely three functions — `find`, `grep`, `pkill` — so ONLY the spelling
+# `grep` is redirected to `ugrep --ignore-files`. `egrep`/`fgrep`/`rgrep`/`ggrep` reach
+# the real GNU binaries and are NOT gitignore-blind.
+#
+# MEASURED against the same planted-token fixture, which is how this was caught after
+# being written the other way round (all five names) first:
+#     grep -rn  -> 1   (blind: the gitignored copy is invisible)
+#     egrep -rn -> 2   (correct)
+#     fgrep -rn -> 2   (correct)
+# Widening this set back out would make the hook fire on commands that have no hazard.
+GREP_BINS = {"grep"}
+# Unshadowed grep spellings, kept NAMED rather than merely absent so the next reader
+# sees they were considered and excluded on evidence, not overlooked.
+UNSHADOWED_GREP = {"egrep", "fgrep", "rgrep", "ggrep"}
+# Searchers that walk the tree from cwd AND honour .gitignore by default.
 RG_BINS = {"rg", "ag", "ack", "ack-grep"}
-# Leading words that wrap a real command without changing what it is.
-WRAPPERS = {"sudo", "time", "nice", "ionice", "command", "builtin", "stdbuf", "env", "\\"}
+# `command grep` / `\grep` / an absolute path BYPASS the shadowing function, so they
+# are GNU grep and carry no hazard. 🔴 `command` is therefore NOT a transparent
+# wrapper here the way `sudo`/`time` are — it changes which binary runs, which is
+# exactly the fix this hook recommends. Keeping it in WRAPPERS would make the hook
+# fire on its own advice.
+WRAPPERS = {"sudo", "time", "nice", "ionice", "builtin", "stdbuf", "env"}
+BYPASS_WRAPPERS = {"command", "\\"}
 SEPARATORS = {"|", "|&", "||", "&&", ";", ";;", "&", "\n"}
-# `find` actions that mean the find is doing WORK, not searching for Claude to read.
-FIND_ACTIONS = {"-exec", "-execdir", "-ok", "-okdir"}
-FIND_NAME_PREDS = {"-name", "-iname", "-path", "-ipath", "-regex", "-iregex", "-wholename"}
 
 CONTENT = "content"
-FILES = "files"
 
 HINTS = {
     CONTENT: (
-        "Grep tool",
-        "Grep(pattern=\"…\", path=\"…\", glob=\"*.py\", output_mode=\"content\")",
-    ),
-    FILES: (
-        "Glob tool",
-        "Glob(pattern=\"**/*.py\", path=\"…\")",
+        "before quoting a zero, re-run with `command grep -r` or `rg --no-ignore`",
+        "or enumerate: `find … -print0 | xargs -0 grep <pat>`",
     ),
 }
 
-# The native tool each kind points at. Suppression is per-TOOL, not per-session-wide:
-# a session that has only ever PROVEN Grep missing still gets its one Glob nudge, which
-# then proves Glob too if it is also gone. Costs at most one extra nudge and keeps the
-# claim scoped to what was actually observed.
-NATIVE_TOOL = {CONTENT: "Grep", FILES: "Glob"}
-
-# --------------------------------------------------------------------------- #
-# Availability
-#
-# The PostToolUse payload does NOT enumerate the session's tools, and the wording of
-# the unavailability error is NOT in the claude-code bundle (checked: 2.1.220 contains
-# neither "Grep is not available" nor "via the Bash tool instead") — the tool set is
-# decided server-side, so there is no local config file to consult. The only observable
-# is the transcript: when the model calls a tool the session lacks, the harness writes
-#
-#   {"type":"user","message":{"role":"user","content":[{"type":"tool_result",
-#     "content":"<tool_use_error>Error: No such tool available: Grep. Grep is not
-#      available in this session — search file contents with `grep` via the Bash tool
-#      instead.</tool_use_error>",
-#     "is_error":true,"tool_use_id":"…"}]}, …}
-#
-# So availability is INFERRED, and only ever in the safe direction: silence a tool once
-# this session has proven it missing. Known gap, stated rather than papered over — the
-# signal only exists once the model has ATTEMPTED the tool. A session that never reaches
-# for Grep (because it can see Grep is not in its tool list) produces no signal and keeps
-# getting the nudge. Nothing else the hook receives distinguishes that case.
-#
-# 🔴 The match is STRUCTURAL, not spelled: only a tool_result block with `is_error` true
-# whose text STARTS with the marker counts. That matters — this very error text also
-# appears in the parent transcript as ordinary prose (quoted inside an Agent tool_use
-# prompt, and inside a subagent's final report, both `is_error` false). A substring grep
-# over the raw transcript would match those and silence a session whose tools work fine.
-# --------------------------------------------------------------------------- #
-UNAVAILABLE_MARKER = b"No such tool available: "
-# NO `^` in the pattern: `.match()` already anchors at the start, so a `^` here would be
-# a second, redundant anchor — and a redundant guard is one a mutation sweep can delete
-# without any test noticing. One anchor, and it is `.match` (NOT `.search`): an is_error
-# tool_result that merely CONTAINS the marker — a failed Bash call whose stderr quotes it
-# — must not suppress. Pinned by "marker mid-text in a real error does NOT suppress".
-_UNAVAILABLE_RE = re.compile(r"Error: No such tool available: ([A-Za-z][A-Za-z0-9_]*)")
-
-# Scan cost bound. The scan is O(bytes) and runs at most once per KIND per session (see
-# the claim protocol below), so the cap exists only to bound a pathological or corrupt
-# transcript, NOT the normal case.
-#
-# Why 1 GiB and not something snug: the previous value (64 MiB) was chosen just above the
-# largest transcript then on this host (63.4 MiB = 99.1% of it) — i.e. one long session
-# away from silently truncating, which would have looked exactly like "no signal". A cap
-# whose whole job is to catch the pathological case must not sit inside the normal range.
-# Throughput measured on that 63.4 MiB file, 5 runs: 52-102 ms, i.e. 0.8-1.6 ms/MiB with
-# a WARM page cache. That is a FLOOR, not a bound — caches could not be dropped on this
-# host, so a cold read is slower by an unmeasured factor. Even at 10x the floor, 1 GiB is
-# a few seconds, once per kind per session, and truncation fails OPEN: nudge delivered.
-# Overridable so the truncation boundary itself is testable rather than assumed.
-#
-# 🔴 The override is parsed DEFENSIVELY, because this runs at import time — outside
-# main()'s try — so an exception here escapes as a non-zero exit with a traceback on
-# EVERY Bash call in that session, which is exactly what the module docstring promises
-# never happens. A bare int() on the raw value made a single typo in a shell profile
-# (`...=abc`) enough to do that. Anything unparseable or non-positive falls back to the
-# default. Known and accepted: Python's int() also accepts underscore separators, so
-# "1_0" parses as 10 rather than being rejected — harmless, because a too-SMALL cap only
-# truncates the scan, which fails open and delivers the nudge.
-def _scan_cap(default):
-    try:
-        raw = os.environ.get("SEARCH_TOOL_NUDGE_MAX_SCAN_BYTES")
-        value = int(raw) if raw else default
-        return value if value > 0 else default
-    except Exception:
-        return default
-
-
-MAX_SCAN_BYTES = _scan_cap(1024 * 1024 * 1024)
 
 # --------------------------------------------------------------------------- #
 # Per-session state, and the claim protocol
 #
 # 🔴 Concurrency is the normal case here, not an edge: parallel subagents share one
 # session, so several hook processes run at once. The old layout — one state FILE per
-# session, read-modify-write — raced, and this hook's transcript scan sits between the
-# read and the write, which widens the window from microseconds to tens of milliseconds.
-# MEASURED, 12 truly-concurrent invocations against a 66.5 MB transcript: 10-11 duplicate
-# nudges (base hook, no scan: 0-2). N copies of the nudge in one turn is precisely the
+# session, read-modify-write — raced. MEASURED, 12 truly-concurrent invocations:
+# 10-11 duplicate nudges. N copies of the nudge in one turn is precisely the
 # "trains the operator to ignore it" failure this hook exists to avoid.
+#
+# (The race USED to be much wider, because a transcript scan for tool availability sat
+# between the read and the write. That scan is gone — see the header — so the window is
+# back to microseconds. The atomic claim is kept regardless: it is what makes the
+# once-per-kind guarantee hold, and it was never the scan that made it necessary.)
 #
 # So state is a DIRECTORY per session and each token is an empty marker FILE created with
 # O_CREAT|O_EXCL — an atomic test-and-set, no lock, so nothing can block the Bash call.
-# The kind is claimed BEFORE the transcript is scanned, which means exactly one process
-# per kind scans and exactly one can emit; the losers exit silently and pay nothing.
+# The kind is claimed BEFORE anything is emitted, so exactly one process per kind can
+# emit; the losers exit silently and pay nothing.
 #
 # What is actually guaranteed, stated precisely because the old comment overclaimed:
 #   * at most ONE nudge per kind per session, including under concurrency, as long as
@@ -163,9 +171,11 @@ MAX_SCAN_BYTES = _scan_cap(1024 * 1024 * 1024)
 #   * a process that claims a kind and then dies burns that kind's nudge for the session.
 #     Deliberate: one lost nudge is far cheaper than N duplicates.
 #
-# Tokens: a KIND ("content"/"files") = nudge handled; "no:<Tool>" = that tool proven
-# unavailable. They are stored VERBATIM as filenames — ":" is a legal filename byte on
-# Linux, so no encoding step is involved (see _token_file).
+# Tokens: a KIND ("content") = that nudge is spent for this session. Stored VERBATIM as
+# a filename. The retired revision also wrote "no:<Tool>" markers recording a tool proven
+# unavailable; nothing writes those any more, but an already-deployed host still has them
+# on disk. They are inert — _read_state only ever compares against a KIND — so no
+# migration is needed and the stale files simply age out with the cache directory.
 # --------------------------------------------------------------------------- #
 STATE_ROOT = f"{CACHE_DIR}/s"
 
@@ -275,14 +285,33 @@ def _tokenize(cmd):
 def _strip_wrappers(tokens):
     """Drop leading `VAR=val` assignments and no-op wrappers (`sudo`, `time`, `xargs`…).
 
-    Returns (command_name, args, via_xargs). `via_xargs` matters because
-    `find … | xargs grep` is a tree content-search even though the grep has no -r.
+    Returns (command_name, args, via_xargs, bypassed).
+
+    `via_xargs` means the searcher is fed EXPLICIT paths from a pipe, which is the
+    shape the live control showed is SAFE (`--ignore-files` never applies to an
+    explicitly named file), so it now suppresses instead of firing.
+
+    `bypassed` means this invocation does NOT reach the shell-snapshot `grep`
+    function — `command grep`, or any name containing a slash (`/usr/bin/grep`,
+    `./grep`). Those are the real GNU grep, carry no gitignore blindness, and are
+    literally what this hook tells you to do; firing on them would make the hook
+    nag its own advice.
+
+    🔴 Honest scope: `\\grep` ALSO bypasses the function in a real shell, but
+    shlex(posix=True) consumes the backslash, so `\\grep` is indistinguishable from
+    `grep` by the time we see tokens. That is a known false-positive shape, not a
+    covered one — it costs one spurious nudge per session and nothing else.
     """
     i = 0
     via_xargs = False
+    bypassed = False
     while i < len(tokens):
         t = tokens[i]
         if re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", t) or t in WRAPPERS:
+            i += 1
+            continue
+        if t in BYPASS_WRAPPERS:
+            bypassed = True
             i += 1
             continue
         if os.path.basename(t) == "xargs":
@@ -296,8 +325,10 @@ def _strip_wrappers(tokens):
             continue
         break
     if i >= len(tokens):
-        return None, [], via_xargs
-    return os.path.basename(tokens[i]), tokens[i + 1:], via_xargs
+        return None, [], via_xargs, bypassed
+    if "/" in tokens[i]:
+        bypassed = True
+    return os.path.basename(tokens[i]), tokens[i + 1:], via_xargs, bypassed
 
 
 def _has_short_flag(args, letters):
@@ -311,193 +342,67 @@ def _has_short_flag(args, letters):
     return False
 
 
-def _classify_segment(cmd_name, args, piped_in, via_xargs):
-    """Return CONTENT / FILES / None for one already-unwrapped command."""
-    if cmd_name is None:
+def _classify_segment(cmd_name, args, piped_in, via_xargs, bypassed):
+    """Return CONTENT / None for one already-unwrapped command.
+
+    CONTENT means: this invocation WALKS A TREE ITSELF and the walker honours
+    .gitignore, so its result can silently omit ignored/generated paths.
+    """
+    if cmd_name is None or bypassed:
+        return None
+    # Fed explicit paths from a pipe -> `--ignore-files` cannot skip them. Measured
+    # SAFE (`find … | xargs grep` returned the correct 2 where a tree walk returned 1).
+    if via_xargs:
         return None
 
     # --- grep family -----------------------------------------------------------
-    # Fires ONLY when recursive (or fed by xargs from a find). A non-recursive grep is
-    # either a single-file read or a pipeline filter (`git log | grep push`) — both
-    # legitimate, neither expressible as the Grep tool, so both stay silent.
+    # Fires ONLY when recursive, because only a recursive invocation makes the
+    # shadowing ugrep function WALK, which is when `--ignore-files` starts pruning.
+    # A non-recursive grep is a named-file read or a pipeline filter
+    # (`git log | grep push`) — it sees exactly the bytes it was handed.
     if cmd_name in GREP_BINS:
         recursive = _has_short_flag(args, "rR") or any(
             a.split("=", 1)[0] in ("--recursive", "--dereference-recursive") for a in args
         )
-        if recursive:
-            return CONTENT
-        if via_xargs:
-            return CONTENT
-        return None
+        return CONTENT if recursive else None
 
     # --- ripgrep / ag / ack ----------------------------------------------------
-    # These default to recursive-from-cwd, so a bare invocation IS a tree search. But
-    # `cmd | rg foo` is a stdin filter — same legitimate case as grep — so skip when
-    # the segment receives a pipe.
+    # These default to recursive-from-cwd AND to honouring .gitignore, so a bare
+    # invocation IS a blind tree search. `cmd | rg foo` is a stdin filter — no walk.
+    # An explicit --no-ignore / -u is the fix, so it must not fire on itself.
     if cmd_name in RG_BINS:
         if piped_in:
             return None
-        return FILES if "--files" in args else CONTENT
+        if any(a.split("=", 1)[0] in ("--no-ignore", "--no-ignore-vcs", "--unrestricted")
+               for a in args):
+            return None
+        if _has_short_flag(args, "u"):
+            return None
+        return CONTENT
 
-    # --- find ------------------------------------------------------------------
-    if cmd_name == "find":
-        if "-delete" in args:
-            return None  # a deletion, not a search
-        for i, a in enumerate(args):
-            if a in FIND_ACTIONS:
-                child = args[i + 1] if i + 1 < len(args) else ""
-                # `find … -exec grep …` is a tree content-search; `-exec rm/chmod/…`
-                # is real work and must stay silent.
-                return CONTENT if os.path.basename(child) in GREP_BINS else None
-        if any(a in FIND_NAME_PREDS for a in args):
-            return FILES
-        return None
-
-    # --- ls -R -----------------------------------------------------------------
-    if cmd_name == "ls" and _has_short_flag(args, "R"):
-        return FILES
-
+    # 🔴 `find` and `ls -R` deliberately absent: `find` is shadowed to `bfs`, which is
+    # NOT passed an ignore-files flag and DOES see gitignored paths (measured). There
+    # is no hazard on that side, so warning about it would be a pure false positive.
     return None
 
 
 def analyze(cmd):
-    """Pure: return the ordered, de-duplicated list of kinds (CONTENT/FILES) `cmd` earns.
+    """Pure: return the de-duplicated list of kinds `cmd` earns — [] or [CONTENT].
 
-    Ordered so output is deterministic; de-duplicated so one command yields at most one
-    nudge per kind.
+    A list (rather than a bool) so the once-per-KIND state protocol and the IO
+    contract stay identical to the shape they had when this hook carried two kinds.
     """
     segments = _tokenize(cmd)
     if not segments:
         return []
 
     kinds = []
-    # Pipeline-level pass first: `find … | xargs grep …` / `find … | grep …` is a tree
-    # content-search that neither segment alone reveals.
-    by_pipeline = {}
-    for tokens, piped_in, pid in segments:
-        by_pipeline.setdefault(pid, []).append((tokens, piped_in))
-    find_to_grep = set()
-    for pid, members in by_pipeline.items():
-        names = [_strip_wrappers(t)[0] for t, _ in members]
-        if "find" in names and any(n in GREP_BINS for n in names[names.index("find") + 1:]):
-            find_to_grep.add(pid)
-            if CONTENT not in kinds:
-                kinds.append(CONTENT)
-
-    for tokens, piped_in, pid in segments:
-        name, args, via_xargs = _strip_wrappers(tokens)
-        # In a `find … | xargs grep` pipeline the find is the *plumbing* for a content
-        # search, not a file search — one CONTENT nudge is the right answer, so don't
-        # also emit FILES for the find half.
-        if pid in find_to_grep and name == "find":
-            continue
-        k = _classify_segment(name, args, piped_in, via_xargs)
+    for tokens, piped_in, _pid in segments:
+        name, args, via_xargs, bypassed = _strip_wrappers(tokens)
+        k = _classify_segment(name, args, piped_in, via_xargs, bypassed)
         if k and k not in kinds:
             kinds.append(k)
     return kinds
-
-
-def _error_texts(rec):
-    """Yield the text of every tool_result block in `rec` that the harness marked as an
-    ERROR. Anything else — assistant tool_use inputs, ordinary tool output, a subagent's
-    report — is deliberately not a witness (see the Availability note above)."""
-    msg = rec.get("message")
-    content = msg.get("content") if isinstance(msg, dict) else None
-    if not isinstance(content, list):
-        return
-    for block in content:
-        if not isinstance(block, dict) or not block.get("is_error"):
-            continue
-        c = block.get("content")
-        if isinstance(c, list):  # some versions wrap it as [{"type":"text","text":…}]
-            c = "".join(b.get("text", "") for b in c if isinstance(b, dict))
-        if not isinstance(c, str):
-            continue
-        yield c.replace("<tool_use_error>", "").replace("</tool_use_error>", "").strip()
-
-
-def _scan_transcript(path, wanted, budget):
-    """Names from `wanted` that `path` records as unavailable. Byte-prefiltered so all
-    but a handful of lines are rejected without a JSON parse.
-
-    Honest scope note, same convention as _newlines_to_separators above: the prefilter
-    is a pure performance optimisation and a mutation sweep confirms it SURVIVES
-    deletion — semantics are identical either way, only the cost changes (json.loads on
-    every line of a multi-MB transcript vs a substring test). Kept for the cost.
-    """
-    found = set()
-    with open(path, "rb") as fh:
-        for raw in fh:
-            budget[0] -= len(raw)
-            if budget[0] < 0:
-                break
-            if UNAVAILABLE_MARKER not in raw:
-                continue
-            try:
-                rec = json.loads(raw)
-            except Exception:
-                continue
-            if not isinstance(rec, dict):
-                continue
-            for text in _error_texts(rec):
-                m = _UNAVAILABLE_RE.match(text)
-                if m and m.group(1) in wanted:
-                    found.add(m.group(1))
-                    if found >= wanted:
-                        return found
-    return found
-
-
-def _transcript_paths(data):
-    """Transcripts that can witness THIS agent's tool errors, most specific first.
-
-    `transcript_path` is derived from the SESSION id, which a subagent shares with its
-    parent — so a subagent's own tool errors are NOT in it. They live in the per-agent
-    transcript, whose layout is (verified on disk, and in the claude-code 2.1.220
-    bundle's `K0()`):
-        <project>/<session>.jsonl                        <- transcript_path
-        <project>/<session>/subagents/[<nested>/]agent-<agent_id>.jsonl
-    """
-    tp = data.get("transcript_path")
-    if not isinstance(tp, str) or not tp.endswith(".jsonl"):
-        return []
-    paths = []
-    agent = data.get("agent_id")
-    if isinstance(agent, str) and re.fullmatch(r"[A-Za-z0-9_.-]{1,64}", agent):
-        base = os.path.join(tp[: -len(".jsonl")], "subagents")
-        direct = os.path.join(base, "agent-%s.jsonl" % agent)
-        if os.path.isfile(direct):
-            paths.append(direct)
-        else:  # nested agent-spawned-agent case
-            paths.extend(sorted(glob.glob(os.path.join(base, "**", "agent-%s.jsonl" % agent),
-                                          recursive=True))[:2])
-    if os.path.isfile(tp):
-        paths.append(tp)
-    return paths
-
-
-def _unavailable_native_tools(data, wanted):
-    """Which of `wanted` this session has PROVEN unavailable.
-
-    Fail-open, in exactly two places — both individually reachable, so neither is an
-    unkillable belt-and-braces guard: a malformed payload that breaks path resolution,
-    and a transcript that cannot be read. Either yields no signal, i.e. the nudge is
-    delivered exactly as it was before this hook learned about availability.
-    """
-    found = set()
-    budget = [MAX_SCAN_BYTES]
-    try:
-        paths = _transcript_paths(data)
-    except Exception:
-        return found
-    for p in paths:
-        try:
-            found |= _scan_transcript(p, wanted - found, budget)
-        except Exception:
-            continue
-        if found >= wanted or budget[0] < 0:
-            break
-    return found
 
 
 def _sanitize(part):
@@ -611,35 +516,19 @@ def main():
         if not fresh:
             sys.exit(0)
 
-        # 🔴 CLAIM BEFORE SCANNING. Everything past this point is done by exactly one
-        # process per kind, so concurrent invocations cannot each emit a nudge AND
-        # cannot each read the whole transcript. The losers exit silently, paying nothing.
+        # 🔴 CLAIM BEFORE EMITTING. Everything past this point is done by exactly one
+        # process per kind, so concurrent invocations cannot each emit a nudge. The
+        # losers exit silently, paying nothing.
         fresh = [k for k in fresh if _claim(state_dir, k)]
         if not fresh:
             sys.exit(0)
 
-        # Don't recommend a tool this session has proven it doesn't have.
-        newly = _unavailable_native_tools(data, {NATIVE_TOOL[k] for k in fresh})
-        if newly:
-            # A DIAGNOSTIC breadcrumb, deliberately not load-bearing: the kind marker
-            # claimed above is what enforces once-per-kind, so nothing reads this back.
-            # It exists so `ls ~/.cache/claude-search-tool-nudge/s/<session>/` answers
-            # "why did the nudge go quiet in this session" without re-deriving it. An
-            # earlier revision DID branch on it; that branch was unreachable once the
-            # claim moved ahead of the scan, and shipping an unreachable branch is how
-            # a guard gets believed. Removed rather than left in as decoration.
-            for t in sorted(newly):
-                _claim(state_dir, "no:" + t)
-            fresh = [k for k in fresh if NATIVE_TOOL[k] not in newly]
-        if not fresh:
-            sys.exit(0)
-
-        lines = "\n".join(f"  • {HINTS[k][0]} → {HINTS[k][1]}" for k in fresh)
+        lines = "\n".join(f"  • {HINTS[k][0]}\n  • {HINTS[k][1]}" for k in fresh)
         nudge = (
-            "search-tool: that Bash call was a tree search. The native tools do the same "
-            "job with structured results, no shell quoting, and far fewer tokens — and "
-            "measured over 30 days they are effectively unused (Bash 37.5k calls vs "
-            "Grep+Glob 50). Prefer them next time:\n"
+            "search-tool: that recursive search is .gitignore-BLIND — here `grep` execs "
+            "`ugrep --ignore-files` and `rg` honours .gitignore, so both silently SKIP "
+            "ignored/generated paths (caches, venvs, build output). Measured on this "
+            "host: whole-tree `grep -rn` found 1 where GNU grep found 2.\n"
             f"{lines}"
         )
         print(json.dumps({

--- a/scripts/claude-hooks/tests/test_search_tool_nudge.py
+++ b/scripts/claude-hooks/tests/test_search_tool_nudge.py
@@ -58,7 +58,7 @@ assert spec and spec.loader
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 analyze = mod.analyze
-CONTENT, FILES = mod.CONTENT, mod.FILES
+CONTENT = mod.CONTENT
 
 fails = []
 
@@ -86,41 +86,52 @@ if len(fails) != 1:
 fails.clear()
 
 # --------------------------------------------------------------------------- #
-# MUST FIRE — tree searches the native tools already do.
+# MUST FIRE — a tree WALK by a searcher that honours .gitignore.
+#
+# 🔴 THE POSITIVE CONTROL for the whole retarget. Without it a silenced hook is
+# indistinguishable from a broken one: every "must not fire" case below would pass
+# just as well against a detector that was wired to nothing.
+#
+# The hazard these share, reproduced live on this host (see the hook's header):
+# whole-tree `grep -rn` found 1 where GNU grep found 2, and bare `rg` found 1 where
+# `rg --no-ignore` found 2.
 # --------------------------------------------------------------------------- #
 MUST_FIRE = [
-    # grep -r / -R across a tree
+    # grep -r / -R across a tree: the shell-snapshot function execs ugrep
+    # --ignore-files, so the walk is gitignore-pruned.
     ("grep -r", "grep -r TODO src/", [CONTENT]),
     ("grep -R", "grep -R 'def main' .", [CONTENT]),
     ("grep clustered flags", "grep -rn --color=never foo lib/", [CONTENT]),
     ("grep --recursive", "grep --recursive pattern .", [CONTENT]),
     ("sudo grep -r", "sudo grep -r secret /etc", [CONTENT]),
-    # ripgrep and friends default to recursive-from-cwd
+    # ripgrep and friends walk from cwd AND honour .gitignore by default
     ("bare rg", "rg 'class Foo'", [CONTENT]),
     ("rg with path", "rg -n TODO scripts/", [CONTENT]),
-    ("rg --files", "rg --files", [FILES]),
     ("ag", "ag pattern src", [CONTENT]),
-    # find by name
-    ("find -name", "find . -name '*.py'", [FILES]),
-    ("find -iname abs path", f"find {HOME}/workspace -iname 'README*'", [FILES]),
-    ("find -path", "find . -path '*/tests/*'", [FILES]),
-    # find piped into grep
-    ("find | xargs grep", "find . -name '*.py' | xargs grep -l TODO", [CONTENT]),
-    ("find -print0 | xargs -0 grep", "find . -name '*.js' -print0 | xargs -0 grep foo", [CONTENT]),
-    ("find -exec grep", "find src -name '*.c' -exec grep -H TODO {} +", [CONTENT]),
-    ("xargs grep from a file list", "cat filelist.txt | xargs grep TODO", [CONTENT]),
-    # ls -R
-    ("ls -R", "ls -R nix/", [FILES]),
-    ("ls -Ral", "ls -Ral scripts", [FILES]),
+    # `rg --files` LISTS files rather than searching contents, so it used to be the
+    # Glob-recommending kind. It stays a firing case under the retarget for a reason
+    # measured on this host: it is gitignore-blind too — `rg --files` listed 1 where
+    # `rg --files --no-ignore` listed 2. The hazard is the walk, not the output mode.
+    ("rg --files", "rg --files", [CONTENT]),
     # multi-command: a search hidden after a &&
     ("chained after &&", "git status && grep -r foo .", [CONTENT]),
     # multi-line: shlex treats \n as plain whitespace, so without an explicit
     # newline->separator pass the whole block lexes as one `cd` command and the
     # search is invisible. Caught by mutant M1.
     ("search on a later LINE", "cd /repo\necho hi\ngrep -r foo src/", [CONTENT]),
-    ("find on a later LINE", "W=/tmp/x\nfind $W -name '*.py'", [FILES]),
-    # both kinds in one call
-    ("both kinds", "grep -r foo . && find . -name '*.md'", [CONTENT, FILES]),
+    # one nudge, not two, when a call carries several blind searches
+    ("two blind searches dedupe to one kind", "grep -r a . && rg b", [CONTENT]),
+    # wrappers that do NOT change which binary runs must stay transparent
+    ("env grep -r", "env grep -r TODO src/", [CONTENT]),
+    ("time grep -r", "time grep -r TODO src/", [CONTENT]),
+    ("nice rg", "nice rg TODO", [CONTENT]),
+    ("VAR=x grep -r", "LC_ALL=C grep -r TODO src/", [CONTENT]),
+    ("grep -r after a semicolon", "cd /repo; grep -r foo .", [CONTENT]),
+    ("grep -r inside a pipeline HEAD", "grep -r foo . | head -20", [CONTENT]),
+    ("grep --dereference-recursive", "grep --dereference-recursive foo .", [CONTENT]),
+    ("ack", "ack pattern", [CONTENT]),
+    # a flag cluster that merely CONTAINS r, and one where r is not first
+    ("grep -inr cluster", "grep -inr TODO src/", [CONTENT]),
 ]
 for name, cmd, want in MUST_FIRE:
     check("FIRE " + name, analyze(cmd), want)
@@ -130,6 +141,62 @@ for name, cmd, want in MUST_FIRE:
 # failure mode here: this runs on EVERY Bash call.
 # --------------------------------------------------------------------------- #
 BENIGN = [
+    # ---------------------------------------------------------------------- #
+    # 🔴 THE RETARGET CASES — shapes this hook used to nudge about and can no
+    # longer justify. Two distinct reasons, both MEASURED, not assumed:
+    #
+    #  (a) the old advice named Grep/Glob, which do not exist on this fleet:
+    #      128 sessions reached for Grep and 0 used it; 5 reached for Glob and
+    #      0 used it. `find -name` / `ls -R` / `rg --files` fired ONLY to
+    #      recommend Glob, so with no tool to name there is nothing to say.
+    #  (b) these shapes are not gitignore-blind anyway, so the NEW warning
+    #      would be false: `find` is shadowed to `bfs`, which is not passed an
+    #      ignore-files flag and DOES see gitignored paths; and a searcher fed
+    #      EXPLICIT paths from xargs/-exec never prunes them.
+    #      Control: `find … | xargs grep` returned the correct 2 where a bare
+    #      tree walk returned 1.
+    # ---------------------------------------------------------------------- #
+    ("find -name (bfs sees gitignored files)", "find . -name '*.py'"),
+    ("find -iname abs path", f"find {HOME}/workspace -iname 'README*'"),
+    ("find -path", "find . -path '*/tests/*'"),
+    ("find on a later LINE", "W=/tmp/x\nfind $W -name '*.py'"),
+    ("ls -R", "ls -R nix/"),
+    ("ls -Ral", "ls -Ral scripts"),
+    ("find | xargs grep (explicit paths)", "find . -name '*.py' | xargs grep -l TODO"),
+    ("find -print0 | xargs -0 grep", "find . -name '*.js' -print0 | xargs -0 grep foo"),
+    ("find -exec grep", "find src -name '*.c' -exec grep -H TODO {} +"),
+    ("xargs grep from a file list", "cat filelist.txt | xargs grep TODO"),
+    # 🔴 The case that actually REACHES the via_xargs guard. Every other xargs shape is
+    # already rejected by the recursion requirement (`xargs grep -l` is not recursive)
+    # or by piped_in (`… | xargs rg`), so without a RECURSIVE grep behind xargs the
+    # guard never executes and a mutation deleting it SURVIVES — measured, then fixed
+    # by adding this case. Behaviour confirmed live: `find . -type f -print0 |
+    # xargs -0 grep -rn` returned the correct 2, i.e. explicit paths are not pruned.
+    ("xargs grep -r (explicit paths, -r is a no-op)",
+     "find . -type f -print0 | xargs -0 grep -rn TODO"),
+    # 🔴 The hook must not nag its own advice. `command grep` / an absolute path
+    # bypass the shadowing function and ARE GNU grep; --no-ignore is the rg fix.
+    ("command grep -r is the FIX", "command grep -r TODO src/"),
+    ("absolute-path grep is GNU grep", "/usr/bin/grep -rn TODO src/"),
+    ("nix-store grep is GNU grep", "/nix/store/abc-gnugrep-3.12/bin/grep -r TODO ."),
+    ("rg --no-ignore is the FIX", "rg --no-ignore TODO"),
+    ("rg --no-ignore-vcs is the FIX", "rg --no-ignore-vcs TODO src/"),
+    ("rg -u is the FIX", "rg -u TODO"),
+    ("rg --unrestricted is the FIX", "rg --unrestricted TODO"),
+    ("rg -uu is the FIX", "rg -uu TODO"),
+    ("rg -nu cluster is the FIX", "rg -nu TODO src/"),
+    ("sudo command grep -r still bypasses", "sudo command grep -r TODO /etc"),
+    ("env command grep -r still bypasses", "env command grep -r TODO src/"),
+    ("relative-path grep bypasses", "./grep -r TODO src/"),
+    # 🔴 Only the spelling `grep` is shadowed by the shell snapshot (it defines exactly
+    # three functions: find, grep, pkill). These reach the real GNU binaries, so they
+    # are NOT gitignore-blind and warning about them would be a false positive.
+    # Measured on the planted-token fixture: `egrep -rn` and `fgrep -rn` both returned
+    # the correct 2, where `grep -rn` returned 1.
+    ("egrep -r is unshadowed GNU egrep", "egrep -r 'a|b' src/"),
+    ("fgrep -R is unshadowed GNU fgrep", "fgrep -R literal ."),
+    ("rgrep is unshadowed", "rgrep -r foo ."),
+    ("ggrep -r is unshadowed", "ggrep -r foo src/"),
     # grep against a single named file
     ("grep single file", "grep TODO README.md"),
     ("grep -n single file", "grep -n 'def main' scripts/foo.py"),
@@ -178,6 +245,30 @@ for name, cmd in BENIGN:
     check("BENIGN " + name, analyze(cmd), [])
 
 # --------------------------------------------------------------------------- #
+# 🔴 THE SHADOWED/UNSHADOWED LEDGER, enforced BOTH ways.
+#
+# The hazard exists only for the ONE spelling the shell snapshot shadows. The hook
+# records that split as two named sets; without this block `UNSHADOWED_GREP` would be
+# unused decoration, and a later "tidy-up" that folded it back into GREP_BINS would
+# reintroduce the false positive with nothing to notice. So: every name in the
+# unshadowed set must classify benign under a RECURSIVE invocation (the only shape
+# that could fire at all), the sets must stay disjoint, and neither may go empty —
+# an empty UNSHADOWED_GREP would make the first loop vacuous.
+# --------------------------------------------------------------------------- #
+check("the shadowed set is exactly {'grep'}", mod.GREP_BINS, {"grep"})
+check("the unshadowed ledger is non-empty (else the loop below is vacuous)",
+      len(mod.UNSHADOWED_GREP) > 0, True)
+check("shadowed and unshadowed sets are disjoint",
+      mod.GREP_BINS & mod.UNSHADOWED_GREP, set())
+for _g in sorted(mod.UNSHADOWED_GREP):
+    check("unshadowed %s -r is benign" % _g, analyze("%s -r foo src/" % _g), [])
+# Positive control for that loop: the SAME call shape on the SHADOWED name must fire,
+# so "all benign" cannot pass by the classifier being wired to nothing.
+for _g in sorted(mod.GREP_BINS):
+    check("shadowed %s -r fires (positive control)" % _g,
+          analyze("%s -r foo src/" % _g), [CONTENT])
+
+# --------------------------------------------------------------------------- #
 # Robustness — a malformed command must be silent, never an exception.
 # --------------------------------------------------------------------------- #
 check("unbalanced quote is silent", analyze("grep -r 'unterminated"), [])
@@ -224,20 +315,41 @@ sid = "test-session-search-nudge-DO-NOT-COLLIDE"
 rc, out = run({"tool_name": "Bash", "session_id": sid,
                "tool_input": {"command": "grep -r TODO src/"}})
 check("io rc", rc, 0)
-check("io first-fire emits", bool(out) and "Grep tool" in out and "additionalContext" in out, True)
+check("io first-fire emits", bool(out) and "additionalContext" in out, True)
 # It is a NUDGE: the payload must carry no deny/block decision of any kind.
 parsed = json.loads(out) if out else {}
 check("io hookEventName", parsed.get("hookSpecificOutput", {}).get("hookEventName"), "PostToolUse")
 check("io never denies", any(k in out for k in ("permissionDecision", "\"deny\"", "block")), False)
 
+# --------------------------------------------------------------------------- #
+# 🔴 THE MESSAGE MUST NOT NAME AN ABSENT TOOL, and must not repeat the retired
+# statistic. This is the assertion that actually pins the bug that prompted the
+# retarget — the detector could be perfect while the text still told the agent to
+# call something the session does not have.
+#
+# Pinned as an ENUMERATED ban rather than one spelling: "Grep tool" alone was
+# walkable by rewording to "the Grep tool" or "Grep(". The old quoted figure is
+# banned too, because it asserted a discipline failure the data does not support
+# (it counted ATTEMPTS, essentially all of which failed).
+# --------------------------------------------------------------------------- #
+_ctx = parsed.get("hookSpecificOutput", {}).get("additionalContext", "")
+for _banned in ("Grep", "Glob", "37.5k", "native tool", "structured results"):
+    check("io message never mentions %r" % _banned, _banned in _ctx, False)
+# Positive control for that ban: the SAME field is asserted to carry the thing it
+# SHOULD say, so a message that went empty (or a field read that returns "") cannot
+# pass the five bans above by vacuity.
+check("io message says what IS actionable (.gitignore)", ".gitignore" in _ctx, True)
+check("io message names the bypass", "command grep" in _ctx, True)
+
 # second search of the same kind in the same session -> deduped, silent
 rc2, out2 = run({"tool_name": "Bash", "session_id": sid,
                  "tool_input": {"command": "grep -r other ."}})
 check("io dedupe silent", out2, "")
-# a DIFFERENT kind still fires once
+# a shape the hook can no longer justify -> silent even though the session is fresh
+# for it. Paired with the fire above, this is the fire/no-fire pair for the IO path.
 rc3, out3 = run({"tool_name": "Bash", "session_id": sid,
                  "tool_input": {"command": "find . -name '*.md'"}})
-check("io other kind fires", "Glob tool" in out3, True)
+check("io retargeted-away kind is silent", (rc3, out3), (0, ""))
 
 # benign command -> silent
 rc4, out4 = run({"tool_name": "Bash", "session_id": sid,
@@ -255,16 +367,18 @@ check("io malformed rc", p.returncode, 0)
 clear_test_state()
 
 # --------------------------------------------------------------------------- #
-# AVAILABILITY SUPPRESSION — never recommend a tool this session does not have.
+# STATE, CONCURRENCY AND FAIL-OPEN scenarios.
 #
-# The hook infers availability from the transcript, because nothing it receives
-# enumerates the session's tools and the unavailability wording is server-side (not in
-# the claude-code bundle). Each scenario below gets its OWN session id so one scenario's
-# cache file cannot decide another's outcome.
+# 🔴 What is NOT here any more, deliberately: the availability-suppression suite that
+# fed the hook a transcript containing `Error: No such tool available: Grep` and asserted
+# the nudge went quiet. That machinery is gone from the hook (see its header — the signal
+# only ever arrived AFTER the model had already eaten the failed tool call), so those
+# tests would have been asserting against deleted code.
 #
-# The pairing that makes these readable: every "suppressed" assertion is preceded by the
-# SAME payload shape against a transcript with no error record, asserted to FIRE. A
-# passing "no nudge" is otherwise indistinguishable from a harness wired to nothing.
+# Each scenario gets its OWN session id so one scenario's state cannot decide another's
+# outcome. `fire()` still accepts a transcript_path because the payload really carries
+# one; the hook now ignores it, and the fail-open cases below pin that a malformed value
+# still cannot change the outcome or crash the hook.
 # --------------------------------------------------------------------------- #
 TMP = tempfile.mkdtemp(prefix="search-tool-nudge-tests-")
 SESSIONS = []
@@ -311,23 +425,6 @@ def session(name):
     return sid
 
 
-def unavailable_record(tool):
-    """The record the harness really writes — shape copied from a live transcript
-    (claude-code 2.1.220), including the <tool_use_error> wrapper and is_error."""
-    return {
-        "type": "user",
-        "isSidechain": False,
-        "message": {"role": "user", "content": [{
-            "type": "tool_result",
-            "content": ("<tool_use_error>Error: No such tool available: %s. %s is not "
-                        "available in this session — search file contents with "
-                        "`grep` via the Bash tool instead.</tool_use_error>" % (tool, tool)),
-            "is_error": True,
-            "tool_use_id": "toolu_01FAKE",
-        }]},
-        "toolUseResult": "Error: No such tool available: %s." % tool,
-    }
-
 
 BENIGN_RECORDS = [
     {"type": "user", "message": {"role": "user", "content": [
@@ -350,16 +447,6 @@ def transcript(name, records):
     return p
 
 
-def agent_transcript(main_path, agent_id, records):
-    d = os.path.join(main_path[: -len(".jsonl")], "subagents")
-    os.makedirs(d, exist_ok=True)
-    p = os.path.join(d, "agent-%s.jsonl" % agent_id)
-    with open(p, "w") as fh:
-        for r in records:
-            fh.write(json.dumps(r) + "\n")
-    return p
-
-
 def fire(sid, cmd, transcript_path=None, agent_id=None):
     """Run the real hook and report whether it emitted a nudge."""
     payload = {"tool_name": "Bash", "session_id": sid, "tool_input": {"command": cmd}}
@@ -368,163 +455,9 @@ def fire(sid, cmd, transcript_path=None, agent_id=None):
     if agent_id is not None:
         payload["agent_id"] = agent_id
     rc, out = run(payload)
-    check("suppression rc 0 (%s)" % sid.split("-")[3], rc, 0)
+    check("hook exits 0 (%s)" % sid.split("-")[3], rc, 0)
     return bool(out)
 
-
-# --- POSITIVE CONTROL: a transcript with no error record must still nudge. -----
-sid = session("clean")
-clean = transcript("clean", BENIGN_RECORDS)
-check("clean transcript still nudges (positive control)", fire(sid, "grep -r TODO src/", clean), True)
-
-# --- NEGATIVE: Grep proven unavailable -> the CONTENT nudge is suppressed. -----
-sid = session("grep-gone")
-gone = transcript("grep-gone", BENIGN_RECORDS + [unavailable_record("Grep")])
-check("Grep unavailable suppresses the content nudge", fire(sid, "grep -r TODO src/", gone), False)
-# Per-TOOL, not session-wide: only Grep was proven missing, so the Glob nudge still
-# fires. Pins the scope of the claim — a session-wide flag would silence this too.
-check("Glob nudge still fires when only Grep was proven gone",
-      fire(sid, "find . -name '*.py'", gone), True)
-# The same distinction inside ONE command that earns BOTH kinds: the Grep half must be
-# dropped and the Glob half still delivered. A session-wide "any tool missing -> stay
-# silent" passes every check above and fails only here.
-sid = session("grep-gone-both")
-gone2 = transcript("grep-gone-both", [unavailable_record("Grep")])
-rc_b, out_b = run({"tool_name": "Bash", "session_id": sid, "transcript_path": gone2,
-                   "tool_input": {"command": "grep -r foo . && find . -name '*.md'"}})
-check("one command, both kinds: only the unavailable half is dropped",
-      ("Glob tool" in out_b, "Grep tool" in out_b), (True, False))
-
-# --- Both proven unavailable -> both suppressed. -------------------------------
-sid = session("both-gone")
-both = transcript("both-gone", [unavailable_record("Grep"), unavailable_record("Glob")])
-check("both tools gone: content suppressed", fire(sid, "grep -r TODO src/", both), False)
-check("both tools gone: files suppressed", fire(sid, "find . -name '*.py'", both), False)
-
-# --- The verdict is CACHED: a later call with no transcript at all stays quiet. -
-# Proves the short-circuit works (and that the scan is not re-run on every call).
-check("suppression persists once recorded", fire(sid, "grep -R other .", None), False)
-# ...and it is cached as a TOOL VERDICT, not merely by spending the nudge budget.
-# Asserted on the state dir because the behavioural check above cannot tell the two
-# apart: a hook that simply emitted both nudges and marked both kinds used would also
-# fall silent here. Pre-change this reads ["content", "files"] with no verdict at all.
-# (The kinds ARE present too — a kind is claimed before the scan, so that the scan runs
-# once and only one process can emit; see the claim protocol.)
-check("suppression records a tool verdict alongside the spent kinds",
-      recorded_tokens(sid), ["content", "files", "no:Glob", "no:Grep"])
-
-# --- STRUCTURAL, not spelled: the same TEXT in a non-error position must not ----
-# suppress. This is the real transcript hazard — the error wording appears verbatim
-# inside an Agent tool_use prompt and inside a subagent's report, both is_error false.
-sid = session("prose")
-_echoed = unavailable_record("Grep")["message"]["content"][0]["content"]
-prose = transcript("prose", [
-    {"type": "assistant", "message": {"role": "assistant", "content": [{
-        "type": "tool_use", "id": "toolu_x", "name": "Agent",
-        "input": {"prompt": "the harness said: Error: No such tool available: Grep. "
-                            "Grep is not available in this session — fix the hook"}}]}},
-    {"type": "user", "message": {"role": "user", "content": [{
-        "type": "tool_result", "is_error": False, "tool_use_id": "toolu_x",
-        "content": "report: Error: No such tool available: Grep. (quoted, not an error)"}]}},
-    # 🔴 The one that actually pins `is_error` as the discriminator: a tool_result whose
-    # text is BYTE-IDENTICAL to the real error record's, differing ONLY in the flag.
-    # This is what a Bash call that prints a transcript record produces — i.e. exactly
-    # what debugging this hook does. Without it, dropping the is_error check survives:
-    # the other two fixtures are rejected by the leading anchor instead, so they exercise
-    # the regex anchor, not the structural guard.
-    {"type": "user", "message": {"role": "user", "content": [{
-        "type": "tool_result", "is_error": False, "tool_use_id": "toolu_y",
-        "content": _echoed}]},
-     "toolUseResult": _echoed},
-])
-check("quoted error prose does NOT suppress", fire(sid, "grep -r TODO src/", prose), True)
-
-# --- ANCHORED: the marker must START the error text, not merely appear in it. --
-# A genuinely failed Bash call whose stderr quotes the marker is an is_error result, so
-# is_error alone does not separate it — only the anchor does. Kills `.match -> .search`;
-# there is deliberately no `^` in the pattern for a mutant to delete for free.
-sid = session("mid-text")
-midtext = transcript("mid-text", [{
-    "type": "user", "message": {"role": "user", "content": [{
-        "type": "tool_result", "is_error": True, "tool_use_id": "toolu_z",
-        "content": "grep: exit 2\nlog line: Error: No such tool available: Grep. "
-                   "Grep is not available in this session"}]}}])
-check("marker mid-text in a real error does NOT suppress",
-      fire(sid, "grep -r TODO src/", midtext), True)
-# 🔴 SAME LINE, no newline before the marker. The fixture above is not enough on its
-# own: `.` does not cross newlines, so a mutant that loosens the pattern to
-# `.*No such tool available: (…)` still fails to match it and survives. This is the
-# realistic shape — a failed command whose own stderr quotes the marker on one line —
-# and under that mutant it is FALSELY SUPPRESSED.
-sid = session("mid-line")
-midline = transcript("mid-line", [{
-    "type": "user", "message": {"role": "user", "content": [{
-        "type": "tool_result", "is_error": True, "tool_use_id": "toolu_z1",
-        "content": "Command failed with exit code 2: hook.py: Error: No such tool "
-                   "available: Grep. (matched 0 files)"}]}}])
-check("marker mid-LINE in a real error does NOT suppress",
-      fire(sid, "grep -r TODO src/", midline), True)
-
-# --- The list-form content branch is real, not speculative. -------------------
-sid = session("list-form")
-listform = transcript("list-form", [{
-    "type": "user", "message": {"role": "user", "content": [{
-        "type": "tool_result", "is_error": True, "tool_use_id": "toolu_l",
-        "content": [{"type": "text",
-                     "text": "Error: No such tool available: Grep. gone."}]}]}}])
-check("list-form error content is understood", fire(sid, "grep -r TODO src/", listform), False)
-
-# --- A DIFFERENT tool being unavailable must not suppress Grep/Glob. -----------
-sid = session("other-tool")
-other = transcript("other-tool", [unavailable_record("WebFetch")])
-check("an unrelated missing tool does not suppress", fire(sid, "grep -r TODO src/", other), True)
-
-# --- SUBAGENT SCOPING ---------------------------------------------------------
-# transcript_path is derived from the SESSION id, which a subagent shares with its
-# parent — so a subagent's own errors are only in its per-agent transcript.
-sid = session("subagent")
-parent = transcript("subagent", BENIGN_RECORDS)
-agent_transcript(parent, "agentX", [unavailable_record("Grep")])
-check("subagent's own transcript is consulted",
-      fire(sid, "grep -r TODO src/", parent, agent_id="agentX"), False)
-# ...and it must NOT leak: the parent session (same session_id, no agent_id) reads only
-# the parent transcript, which is clean, so its nudge is still delivered.
-check("subagent suppression does not leak to the parent session",
-      fire(sid, "grep -r TODO src/", parent), True)
-# ...nor to a SIBLING agent whose own transcript is clean.
-agent_transcript(parent, "agentY", BENIGN_RECORDS)
-check("subagent suppression does not leak to a sibling agent",
-      fire(sid, "grep -r TODO src/", parent, agent_id="agentY"), True)
-
-# A NESTED agent (an agent spawned by an agent) lives one level deeper; the glob
-# fallback is what finds it. Without it this transcript is never consulted.
-sid = session("nested-agent")
-nested_parent = transcript("nested-agent", BENIGN_RECORDS)
-nested_dir = os.path.join(nested_parent[: -len(".jsonl")], "subagents", "outer")
-os.makedirs(nested_dir, exist_ok=True)
-with open(os.path.join(nested_dir, "agent-inner1.jsonl"), "w") as fh:
-    fh.write(json.dumps(unavailable_record("Grep")) + "\n")
-check("nested subagent transcript is found via the glob fallback",
-      fire(sid, "grep -r TODO src/", nested_parent, agent_id="inner1"), False)
-
-# --- agent_id VALIDATION, asserted on the RESOLVED SCAN TARGET. ---------------
-# The outcome alone cannot see this: `_transcript_paths` is called directly so the
-# assertion is about which files would be READ, not about whether a nudge appeared.
-# A glob metacharacter is the realistic leak — unvalidated, "*" makes the fallback
-# glob match a SIBLING agent's transcript and inherit its verdict.
-sid = session("agent-glob")
-sib_parent = transcript("agent-glob", BENIGN_RECORDS)
-agent_transcript(sib_parent, "realsibling", [unavailable_record("Grep")])
-_paths = internal("_transcript_paths")
-check("a glob metacharacter in agent_id resolves to NO extra scan target",
-      _paths({"transcript_path": sib_parent, "agent_id": "*"}) if _paths else None,
-      [sib_parent])
-check("...and a traversal in agent_id resolves to no extra scan target either",
-      _paths({"transcript_path": sib_parent, "agent_id": "../../etc"}) if _paths else None,
-      [sib_parent])
-# Behavioural companion: it must not inherit the sibling's verdict.
-check("agent_id='*' does not inherit a sibling's suppression",
-      fire(sid, "grep -r TODO src/", sib_parent, agent_id="*"), True)
 
 # --- STATE KEY IS INJECTIVE ---------------------------------------------------
 # session="…a" + agent="b" must not share a state dir with session="…a_b" alone.
@@ -560,113 +493,6 @@ check("state key: '@' pair — agent-scoped call nudges",
       fire(Y, "grep -r TODO src/", None, agent_id="b"), True)
 check("state key: '@' pair — the raw '@' session still gets its own nudge",
       fire(Y + "@b", "grep -r TODO src/", None), True)
-
-# --- FAIL OPEN: every detection failure leaves behaviour exactly as before. ----
-sid = session("missing-file")
-check("nonexistent transcript path -> nudge unchanged",
-      fire(sid, "grep -r TODO src/", os.path.join(TMP, "nope", "sess.jsonl")), True)
-
-sid = session("garbage")
-garbage = os.path.join(TMP, "garbage.jsonl")
-with open(garbage, "w") as fh:
-    fh.write("not json\n{\"truncated\": \n\x00\x01binary\n")
-check("unparseable transcript -> nudge unchanged", fire(sid, "grep -r TODO src/", garbage), True)
-
-sid = session("is-a-dir")
-check("transcript path is a directory -> nudge unchanged", fire(sid, "grep -r TODO src/", TMP), True)
-
-sid = session("unreadable")
-unreadable = os.path.join(TMP, "unreadable.jsonl")
-with open(unreadable, "w") as fh:
-    fh.write(json.dumps(unavailable_record("Grep")) + "\n")
-os.chmod(unreadable, 0o000)
-# Skipped under a uid that ignores the mode (root in some CI images) — asserting there
-# would pin the sandbox's uid, not the hook.
-if not os.access(unreadable, os.R_OK):
-    check("unreadable transcript -> nudge unchanged", fire(sid, "grep -r TODO src/", unreadable), True)
-os.chmod(unreadable, 0o644)
-
-sid = session("nul-byte")
-# Reaches the OTHER fail-open branch — the one around path RESOLUTION rather than the
-# one around reading. Getting there needs both an agent_id and a NUL: os.path.isfile()
-# swallows ValueError and returns False (checked — a NUL path alone proves nothing),
-# but the nested-subagent glob does not: `scandir: embedded null character in path`.
-# Without that handler the exception escapes into main()'s catch-all, which exits 0
-# silently — so a detection ERROR would have become a silent SUPPRESSION.
-check("embedded NUL in transcript_path -> nudge unchanged",
-      fire(sid, "grep -r TODO src/", "/tmp/a\x00b.jsonl", agent_id="agentZ"), True)
-
-sid = session("no-transcript-key")
-check("payload without transcript_path -> nudge unchanged (legacy shape)",
-      fire(sid, "grep -r TODO src/", None), True)
-
-# --- SCAN CAP: truncation fails OPEN, and the boundary is pinned at 2 points. --
-# Measured at both ends rather than one: a cap that admits the error line exactly, and
-# one byte less. Without both, an off-by-one on the comparison is invisible.
-cap_records = BENIGN_RECORDS + [unavailable_record("Grep")]
-cap_file = transcript("cap", cap_records)
-with open(cap_file, "rb") as fh:
-    _cap_bytes = fh.read()
-EXACT = len(_cap_bytes)  # budget that admits the final (error) line in full
-
-
-def fire_with_cap_agent(sid, cap, transcript_path, agent_id=None):
-    payload = {"tool_name": "Bash", "session_id": sid, "transcript_path": transcript_path,
-               "tool_input": {"command": "grep -r TODO src/"}}
-    if agent_id is not None:
-        payload["agent_id"] = agent_id
-    p = subprocess.run([sys.executable, HOOK], input=json.dumps(payload),
-                       capture_output=True, text=True,
-                       env=dict(os.environ, SEARCH_TOOL_NUDGE_MAX_SCAN_BYTES=str(cap)))
-    check("cap rc 0", p.returncode, 0)
-    return bool(p.stdout.strip())
-
-
-def fire_with_cap(sid, cap, transcript_path):
-    return fire_with_cap_agent(sid, cap, transcript_path)
-
-
-sid = session("cap-exact")
-check("cap exactly covering the error line still detects it",
-      fire_with_cap(sid, EXACT, cap_file), False)
-sid = session("cap-short")
-check("cap one byte short truncates and fails OPEN (nudge delivered)",
-      fire_with_cap(sid, EXACT - 1, cap_file), True)
-sid = session("cap-tiny")
-check("a tiny cap fails OPEN rather than suppressing",
-      fire_with_cap(sid, 1, cap_file), True)
-
-# 🔴 The override is read at IMPORT time, outside main()'s try. An unparseable value
-# there escapes as a non-zero exit with a traceback on EVERY Bash call in the session —
-# the one thing the module docstring promises never happens, and a typo in a shell
-# profile is enough to trigger it. Every junk shape must exit 0 AND still nudge.
-for _i, _bad in enumerate(("abc", "", "  ", "-1", "0", "1e9", "9" * 400, "12abc", "0x10")):
-    sid = session("cap-junk-%d" % _i)
-    _p = subprocess.run(
-        [sys.executable, HOOK],
-        input=json.dumps({"tool_name": "Bash", "session_id": sid,
-                          "tool_input": {"command": "grep -r TODO src/"}}),
-        capture_output=True, text=True,
-        env=dict(os.environ, SEARCH_TOOL_NUDGE_MAX_SCAN_BYTES=_bad))
-    check("junk scan-cap %r: exit 0, no traceback, nudge delivered" % _bad,
-          (_p.returncode, "Traceback" in _p.stderr, bool(_p.stdout.strip())),
-          (0, False, True))
-
-# ...and a junk value must FALL BACK to the default, not silently disable detection.
-# Asserting "no crash" alone cannot see that: with a non-positive cap accepted verbatim,
-# every scan truncates on its first line, which also fails open and also nudges — the
-# same observable, a completely different reason. Only a transcript that SHOULD suppress
-# separates them.
-for _i, _bad in enumerate(("0", "-1", "abc")):
-    sid = session("cap-fallback-%d" % _i)
-    _p = subprocess.run(
-        [sys.executable, HOOK],
-        input=json.dumps({"tool_name": "Bash", "session_id": sid, "transcript_path": gone,
-                          "tool_input": {"command": "grep -r TODO src/"}}),
-        capture_output=True, text=True,
-        env=dict(os.environ, SEARCH_TOOL_NUDGE_MAX_SCAN_BYTES=_bad))
-    check("junk scan-cap %r falls back to the default (detection still works)" % _bad,
-          (_p.returncode, bool(_p.stdout.strip())), (0, False))
 
 # --- CONCURRENCY: at most ONE nudge per kind per session, under real parallelism.
 # 12 processes released by a shared barrier so their read-modify-write windows overlap.
@@ -792,25 +618,6 @@ if not os.access(_cdir, os.R_OK):
           fire(sid, "grep -r TODO src/", None), False)
 os.chmod(_cdir, 0o700)
 
-# --- Scan ORDER is load-bearing, not cosmetic. --------------------------------
-# Most-specific-first only shows up when the budget cannot cover both files: the
-# subagent's own transcript must be read BEFORE the parent's, or a large parent eats
-# the budget and the agent's own verdict is never seen.
-sid = session("scan-order")
-order_parent = transcript("scan-order", BENIGN_RECORDS * 300)
-agent_transcript(order_parent, "agentO", [unavailable_record("Grep")])
-_agent_len = os.path.getsize(os.path.join(order_parent[: -len(".jsonl")], "subagents",
-                                          "agent-agentO.jsonl"))
-check("agent transcript is scanned before the parent (budget covers only one)",
-      fire_with_cap_agent(sid, _agent_len, order_parent, "agentO"), False)
-
-# --- Only a .jsonl is treated as a transcript. --------------------------------
-sid = session("not-jsonl")
-_notjson = os.path.join(TMP, "notatranscript.txt")
-with open(_notjson, "w") as fh:
-    fh.write(json.dumps(unavailable_record("Grep")) + "\n")
-check("a non-.jsonl transcript_path is not scanned", fire(sid, "grep -r TODO src/", _notjson), True)
-
 # --- State key components are sanitized (no directory escape). ----------------
 _sdir = internal("_state_dir")
 _root = internal("STATE_ROOT")
@@ -818,13 +625,19 @@ check("a traversal in session/agent ids cannot escape the state root",
       os.path.dirname(_sdir({"session_id": "../../escape", "agent_id": "../x"}))
       if (_sdir and _root) else None, _root)
 
+# A well-formed transcript, used below only to prove that a REALISTIC payload shape
+# still behaves — the hook no longer reads the file, so these cases pin that the extra
+# fields cannot change the outcome or crash it.
+clean = transcript("clean", BENIGN_RECORDS)
+
 for i, bad in enumerate((123, [], {"a": 1}, "", "/not/a/jsonl", "/etc")):
-    # A wrong-typed / non-jsonl transcript_path must never crash and never suppress.
+    # A wrong-typed transcript_path must never crash and never change the verdict.
     sid = session("badtype%d" % i)
     check("bad transcript_path %r -> nudge unchanged" % (bad,),
           fire(sid, "grep -r TODO src/", bad), True)
 
-# Same for a wrong-typed agent_id (a `..` traversal must not become a scan target).
+# 🔴 agent_id IS still read — it scopes the state directory — so a wrong-typed or
+# traversal value must neither crash nor escape the state root (asserted above).
 for i, bad_agent in enumerate((123, [], "../../etc", "a/b", "")):
     sid = session("badagent%d" % i)
     payload = {"tool_name": "Bash", "session_id": sid, "agent_id": bad_agent,
@@ -856,7 +669,15 @@ leaked = sorted(os.path.basename(p) for pref in TEST_SID_PREFIXES
 check("no test state leaks into the next run", leaked, [])
 shutil.rmtree(TMP, ignore_errors=True)
 
-MIN_CHECKS = 160  # floor: a suite that silently shrinks is a vacuous green
+# Floor: a suite that silently shrinks is a vacuous green.
+# 🔴 LOWERED 160 -> 130 on 2026-08-25, deliberately and once. The availability-suppression
+# suite (~42 checks: transcript scanning, scan-cap boundaries, subagent transcript
+# resolution, scan order) was removed because the hook code it asserted against was
+# removed — see the hook's header. Those checks did not become flaky or get skipped, they
+# stopped having a subject. The run measures 134, so 130 leaves the same ~4-check margin
+# the old value carried; it is NOT set to the measured number, so a real shrink still
+# trips it.
+MIN_CHECKS = 130
 if fails:
     print("FAIL:")
     for f in fails:
@@ -868,7 +689,7 @@ if len(ran) < MIN_CHECKS:
 print(f"all search-tool-nudge tests passed ({len(ran)} checks: "
       f"{len(MUST_FIRE)} must-fire, {len(BENIGN)} benign, "
       f"1 harness negative control, 1 benign-counter positive control, "
-      f"{len(SESSIONS)} availability-suppression scenarios)")
+      f"{len(SESSIONS)} state/concurrency scenarios)")
 # Machine-readable, and PARSED by the external isolation guard — keep the wording.
 # This half is only the number this file measured itself; the other half of the
 # pair (writes to the INHERITED home, which must be 0) is measured from outside,

--- a/scripts/tests/test_transcript_search.py
+++ b/scripts/tests/test_transcript_search.py
@@ -720,8 +720,12 @@ JSONL_GLOB_SITES = {
         (1, "telemetry reconciler: counts files against ClickHouse rows, opens none"),
     ("scripts/tmux-session-restore.py", "ENUMERATING"):
         (1, "FLAT glob of one already-known project dir; never recurses"),
-    ("scripts/claude-hooks/search-tool-nudge.py", "BY-ID"):
-        (1, "resolves ONE agent-<id>.jsonl in the subagents tier the shared walk excludes"),
+    # 🔴 REMOVED 2026-08-25 with the code it described. search-tool-nudge.py used to
+    # resolve ONE agent-<id>.jsonl to infer whether the session had the Grep/Glob tools.
+    # That inference is gone (the tools are absent fleet-wide and the signal only ever
+    # arrived after the failed call), so the hook reads no transcript at all now and
+    # imports no `glob`. This ledger is pinned BOTH ways, so leaving the entry here
+    # would have failed the gate as a stale reason — which is exactly how it was caught.
     ("scripts/lib/subsystem_touch.py", "BY-ID"):
         (1, "resolves one session id; a second reader of the by-id rule, not of the corpus"),
     ("scripts/claude-hooks/tests/test_bg_command_capture.py", "OS-WALK"):


### PR DESCRIPTION
## The bug

The `PostToolUse[Bash]` search nudge told agents to use the native **Grep/Glob**
tools, quoting *"Bash 37.5k calls vs Grep+Glob 50"* as evidence of an
agent-discipline failure.

**That statistic counted ATTEMPTS, and essentially every attempt failed.** Measured
across the 2,460 session transcripts under `~/.claude/projects` with an mtime inside
14 days:

| tool | sessions that reached for it | used it successfully | got `No such tool available` |
|---|---|---|---|
| `Grep` | 128 | **0** | 128 |
| `Glob` | 5 | **0** | 5 |

Grep and Glob are **absent from this fleet**, not underused. The corrected reading:
the number describes a *tool roster*, not a discipline gap — so the nudge could never
once be correct. That is the permanently-red-gate shape from `RULES.md`: it trains the
reader to ignore the hook.

It was also **actively harmful, not merely inert**. The nudge fired in 319 sessions,
and in **61** of them it came *before* a failed `Grep` call — the hook talked the agent
into a tool call that could only error, costing tokens twice.

Ruled out first, so this is a root-cause fix rather than a workaround: the absence is
**not** local configuration — `permissions.deny` is empty, there is no
`disallowedTools`, and no Grep/Glob entry anywhere. The roster is decided server-side.

## Which path I took, and the evidence that decided it

**Path B — retarget.** Availability is genuinely **not knowable from hook input**, and
I verified that rather than assuming it, at claude-code **2.1.232**:

* A live stdin-dumping `PostToolUse` hook shows the payload carries exactly **12 keys**,
  none of which is a tool roster: `session_id, transcript_path, cwd, prompt_id,
  permission_mode, effort, hook_event_name, tool_name, tool_input, tool_response,
  tool_use_id, duration_ms`. The bundle's own hook docs agree.
* A freshly captured transcript has **no `"tools"` key, no `availableTools`**, and zero
  occurrences of the names of the tools that session was not given.

The previous revision inferred absence from the transcript's
`Error: No such tool available: <Tool>` record. That worked, but only **after** the
model had already attempted the tool and eaten the failure — the one cost worth
avoiding. It is removed rather than left in place, because a guard that cannot act
before the damage reads as coverage while providing none.

## What it warns about now

I did **not** ship the proposed `echo`/`cd`/`export` plumbing nudge. I measured it and
it did not survive inspection — reported in full below. Instead the hook keeps its
existing (well-tested) detector and points it at a hazard that needs no tool at all,
and which is a **correctness** problem rather than a token-cost nag:

> **the same recursive searches are `.gitignore`-BLIND.**

Claude Code's shell snapshot shadows `grep` with a function that execs
`ugrep -G --ignore-files …`, and `rg` honours `.gitignore` by default. A tree walk
therefore silently skips ignored and generated paths — caches, venvs, build output —
and reports a confident `0` or an undercount with no sign anything was pruned.

Reproduced live, with a token planted in **both** a tracked and a gitignored file:

| case | shadowed | real GNU / `--no-ignore` |
|---|---|---|
| positive control, tracked file | 1 | 1 |
| explicit path into the ignored dir | 1 | 1 |
| **whole tree (`grep -rn … .`)** | **1** | **2** |
| bare `rg` | 1 | 2 |
| `rg --files` | 1 | 2 |

This is already `claude/RULES.md` → *"`grep` here is a FUNCTION wrapping ugrep, and
`-r` HONOURS `.gitignore` … Never quote a `-r` zero about an ignored or generated
path"* (archive: `grep-gitignore-blind`). That rule has been read in-session and the
trap hit anyway, so per *Deterministic Over Prose* this is its in-the-moment enforcer.
The rule text stays — unlike the retired *Tool Optimization* section, this one is true.

### The message

```
search-tool: that recursive search is .gitignore-BLIND — here `grep` execs
`ugrep --ignore-files` and `rg` honours .gitignore, so both silently SKIP
ignored/generated paths (caches, venvs, build output). Measured on this host:
whole-tree `grep -rn` found 1 where GNU grep found 2.
  • before quoting a zero, re-run with `command grep -r` or `rg --no-ignore`
  • or enumerate: `find … -print0 | xargs -0 grep <pat>`
```

### What deliberately no longer fires

Each dropped because the **same controls** show there is no hazard:

* `find -name` / `ls -R` — `find` is shadowed to **bfs**, which gets no ignore-files
  flag and *does* see gitignored paths.
* `find | xargs grep`, `find -exec grep` — explicit paths are never pruned (measured:
  the correct **2**, where a bare tree walk gave 1).
* `command grep -r`, an absolute-path `grep`, `rg --no-ignore`, `rg -u` — these **are**
  the recommended fix; firing on them would nag its own advice.
* `egrep` / `fgrep` / `rgrep` / `ggrep` — the snapshot defines exactly three functions
  (`find`, `grep`, `pkill`), so **only** the spelling `grep` is redirected. Measured:
  `egrep -rn` and `fgrep -rn` both returned the correct **2**. I wrote this the other
  way round first and the live control caught it.

## Test matrix — red at base, green at HEAD

Run the **new** suite against the **`origin/main` hook**: **33 failures**, covering every
new behaviour — every retargeted-away shape fires there, `rg --files` returns the old
Glob kind, and the five message assertions catch the retired text verbatim, including
`Grep+Glob 50` and `Glob tool`.

Against **HEAD**: `all search-tool-nudge tests passed (145 checks: 21 must-fire, 50
benign, 1 harness negative control, 1 benign-counter positive control, 17
state/concurrency scenarios)`.

**The fire / no-fire pair is explicit**, because a silenced hook is otherwise
indistinguishable from a broken one:

* **MUST fire** — `grep -r TODO src/`
* **MUST NOT fire** — `find . -name '*.md'`

Both are asserted through the real subprocess IO path, not just `analyze()`.

**Mutation sweep** — 6/6 killed, with a positive control and
`PYTHONDONTWRITEBYTECODE=1` (stale-bytecode trap), hook restored byte-identical after:

| mutant | result |
|---|---|
| M0 make the grep branch never fire (positive control) | KILLED (36) |
| M1 widen `GREP_BINS` back to all five spellings | KILLED (11) |
| M2 drop the `command`/abs-path bypass | KILLED (7) |
| M3 drop the `via_xargs` suppression | **SURVIVED → fixed → KILLED (2)** |
| M4 drop the `rg --no-ignore` exemption | KILLED (4) |
| M5 drop the `rg -u` exemption | KILLED (4) |

M3 is worth reading: every xargs shape was *already* rejected by the recursion
requirement, so the guard never executed and deleting it changed nothing. Fixed by
adding `find … | xargs -0 grep -rn` — the one shape that reaches it — after confirming
live that it returns the correct **2**.

## 🔴 What I measured and did NOT ship

The brief proposed retargeting at shell plumbing (`echo` 11.4%, `export` 5.8%,
`cd` 4.1%). I measured it on **33,856 real Bash calls** from 400 transcripts and
declined, because the premise did not hold:

* **`cd` and `export` are already owned** by `shell-env-nudge.py`, which rewrites repo
  `cd`s and `export KUBECONFIG=` into the pre-exported handles. Adding them here would
  break *one rule, one place*.
* **Decorative `echo` is not scaffolding.** 35.8% of calls carry one and 15.3% carry two
  or more — but inspecting the actual matched arguments, they are almost entirely
  *informative section labels* (`=== ns of gitops-ci pods ===`, `--- any FAIL lines ---`)
  that disambiguate the concatenated output of a batched compound command. Telling the
  agent to drop them would plausibly cost **more** in re-runs than it saves.
* The genuinely contentless variants are too rare to gate on: `>=2` pure separators is
  **1.1%** of calls, and "a call that does no work at all" is **1.06%** — and inspection
  shows those are deliberate `echo idle17` / `echo held` keepalives, not waste.

So the plumbing retarget is reported as **measured and rejected**, not silently skipped.

## Frequency and other honest notes

* Measured on 23,074 real Bash calls from 250 transcripts, the new detector fires on
  **4.9%** of calls — one nudge in ~**75%** of sessions, since it is once-per-kind-per-
  session. Higher than the old hook's rate; the old message is gone, so no session pays
  for both. Flagging it explicitly in case that trade is not wanted.
* **Known false positive, not covered:** `\grep -r` also bypasses the shadowing function
  in a real shell, but `shlex(posix=True)` consumes the backslash, so it is
  indistinguishable from `grep` by the time the hook sees tokens. Costs one spurious
  nudge per session.
* The **filename is deliberately unchanged**. It is registered by path in
  `register-nudge-hook.py`, `nix/home.nix`, `run-tests.sh` and three test files, and a
  rename would strand the OLD file at `~/.claude/hooks/search-tool-nudge.py` on every
  already-deployed host, still emitting the retired message. A rename has to be
  sequenced with a removal.
* Stale `"no:<Tool>"` state files on already-deployed hosts are **inert** — `_read_state`
  only ever compares against a kind — so no migration is needed.
* Removes the now-stale `("scripts/claude-hooks/search-tool-nudge.py","BY-ID")` entry
  from the two-way `JSONL_GLOB_SITES` ledger in `test_transcript_search.py`; the hook no
  longer opens a transcript or imports `glob`. **That ledger is what caught it.**

## Gate

`scripts/run-tests.sh --check-floors` and `--check-targets` both **PASS, unchanged** —
these hook suites are hand-rolled pass/fail scripts excluded from `TARGET_FLOORS` by
construction, so no floor moves and there is no upward drift. The suite's own internal
anti-shrink floor is lowered `160 -> 130` (measured 145): the ~42 removed checks were
the availability-suppression suite, which lost its subject when the code it asserted
against was deleted.

All five `HOOK_TESTS` scripts pass, and
`test_on_disk_artifact_names.py + test_hook_suites_do_not_touch_the_inherited_home.py +
test_transcript_search.py` = **54 passed**.
