### PR TITLE
feat(opencode): opencode briefs must carry their sources (rc 6) — ~0.9% of the brief surface, and NOT the part the evidence came from

### DIFF
--- a/scripts/opencode/SKILL.md
+++ b/scripts/opencode/SKILL.md
@@ -11,11 +11,19 @@ context window. The point is *your* context budget: seven weeks of opencode cost
 
 ## The whole invocation
 
-```bash
+````bash
 opencode-dispatch run --dir <PROJECT-DIR> --title "<short title>" -m flash <<'BRIEF'
 <the complete task specification>
-BRIEF
+
+```claims
+[]
 ```
+BRIEF
+````
+
+🔴 **The `claims` block is REQUIRED — a brief without one is refused (rc 6).**
+See "Every brief carries its sources" below; `[]` is the honest declaration when
+the brief genuinely asserts no premise the agent would act on.
 
 That is it. Do **not** re-derive the CLI — `opencode --version`, `--help`,
 `run --help` and `models` were re-run from scratch in **nine** separate sessions
@@ -56,7 +64,76 @@ as well, so you can check them without dispatching.
 opencode-dispatch preflight --dir <PROJECT-DIR> --brief <FILE>   # or stdin
 ```
 
-`--json` for a machine-readable report. Exit **3** means the brief was refused.
+`--json` for a machine-readable report. Exit **3** (a path escape) or **6** (an
+uncited claim) means the brief was refused — see "When preflight refuses".
+
+## Every brief carries its sources
+
+🔴 **A brief with no `claims` block is REFUSED — rc 6, nothing written, nothing
+dispatched.** Declare each load-bearing claim: a fact the brief states that the
+agent will *act on*, and that would change the work if it were wrong.
+
+````markdown
+```claims
+[
+  {"claim":   "the preview DB is a clone, not production",
+   "source":  "https://pr-4260.example.com/api/health",
+   "read_at": "2026-08-21",
+   "basis":   "measurement"},
+  {"claim":   "the avatar refresh is driven by the localStorage roster",
+   "source":  "src/components/AccountSwitcher.tsx:42",
+   "read_at": "2026-08-21",
+   "basis":   "inference"}
+]
+```
+````
+
+All four fields are required on every entry. `basis` is a **closed enum** —
+`measurement` (you ran it, read it, saw the output) or `inference` (you concluded
+it). Nothing else; a misspelling is refused rather than read as a measurement.
+Extra fields are kept and warned about, never rejected.
+
+**`[]` is a valid, honest declaration** — "this brief asserts no load-bearing
+claim". It is an assertion on the record rather than a silence, and the report
+prints it as `NONE DECLARED`.
+
+### 🔴 What this covers — ~0.9% of the briefs this machine produces
+
+| surface | rate | covered? |
+|---|---|---|
+| opencode dispatch (this tool) | ~1.2/day | ✅ |
+| Claude `Agent`-tool subagent brief | ~137/day | ❌ no chokepoint exists |
+| clawgate `build_task_body()` | uncounted | ❌ |
+
+Basis: 6 briefs on disk across 3 project dirs over Aug 21–25 (a **floor** — the
+dirs are deleted with their projects) vs 1,921 `Agent` calls in the audit's
+14-day window. Different windows; treat it as an order of magnitude.
+
+🔴 **Every measured instance below came from the UNCOVERED surface** — the wrong
+root cause reached three *subagent* briefs; the three subagents correcting a
+stale brief were Agent-tool subagents. **Do not cite this guard as evidence that
+premise-propagation is handled.** It is a bridgehead on a real dispatch path, and
+the schema a wider guard would reuse.
+
+### Why it refuses instead of reminding
+
+A 14-day audit of 443 sessions found **wrong premises propagating into subagent
+briefs in four of six audit slices** — the highest-cost error class found, and
+one the adversarial audit ladder is structurally blind to. A session built an
+entire storage layer on a belief lifted from a stale comment and a stale README;
+**four audit rounds read past it**. A wrong root-cause diagnosis was pushed into
+**three** subagent briefs before being retracted. A homelab session *inferred* an
+auth constraint from a token prefix, reported it as fact, and it propagated into
+a downstream session's opening brief — "my inference presented as fact".
+
+A prose instruction is the mechanism that already failed there four times. So
+this is a schema, checked in code, that refuses.
+
+🔴 **What it cannot see, stated plainly:** it checks that *declared* claims carry
+sources. It cannot know your prose asserts a fifth premise you never declared —
+detecting a claim in free text needs a heuristic, a heuristic over-matches, and a
+permanently-red gate is worse than no gate. What the mandatory block buys is
+narrower and real: you cannot dispatch without having been asked the question.
 
 ## Reading the result
 
@@ -68,7 +145,7 @@ dependency is worth taking only once this skill is proven to get used. For now:
 tail -n 60 <the log path printed on dispatch>
 ```
 
-## Why this exists — four measured failure modes, three success-shaped
+## Why this exists — five measured failure modes, three success-shaped
 
 1. 🔴 **`external_directory: "ask"` → headless auto-reject → exit 0, no work.**
    The brief named a path outside `--dir`. `opencode run` **auto-rejects** an
@@ -86,12 +163,25 @@ tail -n 60 <the log path printed on dispatch>
 4. **20% of opencode sessions exceed the Bash tool's hard 600,000 ms ceiling**
    (p90 2508s, p95 9119s); one died at exactly 600s with `Exit code 143`. Hence
    detached-always.
+5. 🔴 **A wrong premise, stated as fact, propagating into the brief.** Found in
+   **four of six** slices of a 14-day audit over 443 sessions — the highest-cost
+   error class, and the one the adversarial audit ladder is blind to. Preflight
+   **refuses (rc 6)** a brief that declares no citations. See "Every brief
+   carries its sources".
 
 ## When preflight refuses
 
-It refused because a path — in the brief, or a `--file` attachment — does not
-resolve under `--dir`. The offender is printed as written *and* resolved, tagged
-`[brief]` or `[attachment]`. Fix the **brief or the `--dir`**, never the check —
+**Read the exit code — the two refusals are fixed by different edits.**
+
+| rc | meaning | fix |
+|---|---|---|
+| 3 | a path in the brief or a `--file` resolves outside `--dir` | move/widen/inline (below) |
+| 6 | a load-bearing claim carries no citation | add or complete the `claims` block |
+
+### rc 3 — a path escape
+
+The offender is printed as written *and* resolved, tagged `[brief]` or
+`[attachment]`. Fix the **brief or the `--dir`**, never the check —
 three options, in order of preference:
 
 1. move the file under `--dir`;
@@ -108,6 +198,15 @@ Read the three verdict lines literally — they are different claims:
   attachments` — **not** an all-clear. Nothing was there to check.
 - `UNMEASURED paths : N` — variable-built paths that cannot be decided
   statically. Neither blocked nor cleared; check them yourself.
+- `claim citations : N claim(s) cited — X measurement, Y inference` — the brief
+  declared them and every one is well-formed.
+- `claim citations : NONE DECLARED — …` — the brief **asserts** it carries no
+  load-bearing claim. That is a claim about the brief, not an all-clear about
+  its prose.
+
+The report then lists each **inference** individually with its source and date.
+🔴 Those are the ones to **re-verify before acting on**, not to treat as facts —
+an inference reported as established fact is the measured failure.
 
 A `⚠ WARN` line is different — it is advisory and the dispatch proceeds. It goes
 through a parser that deliberately over-matches, so blocking on it would build a

--- a/scripts/opencode/lib/brief_claims.py
+++ b/scripts/opencode/lib/brief_claims.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""brief_claims — make an OPENCODE dispatch brief carry its sources.
+
+🔴 READ THE SCOPE BEFORE THE RATIONALE. THIS GUARD COVERS ~0.9% OF THE BRIEFS
+THIS MACHINE PRODUCES, AND IT DOES NOT COVER THE ONES THE EVIDENCE CAME FROM.
+--------------------------------------------------------------------------------
+It validates exactly one thing: a brief passed to `opencode-dispatch`, which is
+the only committed code path an opencode brief crosses. Measured rates:
+
+    opencode dispatches  ~1.2 / day   <- COVERED by this module
+    Claude Agent-tool    ~137 / day   <- NOT COVERED. No chokepoint exists.
+    ------------------------------------------------------------------
+    covered share         ~0.9%
+
+Basis, stated so it can be re-checked and argued with: **6 briefs surviving on
+disk across 3 project directories over Aug 21-25 2026** (5 days) — a FLOOR, not
+a total, because `.opencode-dispatch/` is deleted with its project and the local
+telemetry spool had already shipped — against **1,921 `Agent` tool calls in the
+audit's 14-day window**. The two windows differ; treat 0.9% as an order of
+magnitude, not a precise ratio. It is if anything an OVER-estimate of coverage:
+the clawgate `build_task_body()` producers are a third brief surface counted in
+neither number.
+
+🔴 AND THE ASYMMETRY THAT MATTERS MOST: **every measured instance below came
+from the UNCOVERED surface.** The wrong root cause reached three *subagent*
+briefs. The three subagents who opened their reports correcting a stale brief
+were Agent-tool subagents. Not one of the four was an opencode dispatch.
+
+So this module is a bridgehead, not a fix. Do NOT read it — or cite it — as
+evidence that premise-propagation is handled; a guard whose description reads
+wider than its implementation is worse than none, because it stops anyone
+looking. What it genuinely provides: the schema, the vocabulary and the refusal
+semantics that a wider guard would reuse, proven against a real dispatch path.
+
+THE FAILURE CLASS IT IS A BRIDGEHEAD AGAINST (measured, not hypothetical)
+-------------------------------------------------------------------------
+A 14-day audit of 443 sessions found WRONG PREMISES PROPAGATING INTO SUBAGENT
+BRIEFS independently in FOUR OF SIX audit slices — the highest-cost error class
+found, and the one the adversarial audit ladder is structurally blind to.
+The measured instances:
+
+  * A session built an entire storage layer on a belief lifted from a STALE code
+    comment and a STALE README. FOUR adversarial audit rounds read past it.
+  * A wrong root-cause diagnosis was filed as a GitHub issue, endorsed as the
+    session's best finding, and pushed into THREE subagent briefs before being
+    retracted at session end. The recommended fix would have preserved every
+    false pass across a 69-site sweep.
+  * A homelab session INFERRED an auth constraint from a token prefix, reported
+    it as established fact several times, wrote it into a handoff as the ranked
+    next step, and it propagated into a downstream session's opening brief.
+    The session's own words: "my inference presented as fact."
+  * Three independent subagents opened their reports by correcting the brief
+    they were handed: "The brief was stale — the code won."
+
+🔴 WHY THIS IS NOT A PROSE RULE.
+The audit ladder that missed this class four times over IS instruction-based.
+Adding a fifth instruction is the same mechanism that already failed. RULES.md is
+explicit: prefer deterministic/structural fixes over prompt-tuning. So the check
+lives in `opencode-dispatch preflight`, it is schema-validated, and the dispatch
+REFUSES (rc 6) rather than warning.
+
+THE SURFACE — A `claims` FENCE, PARSED AS JSON
+-----------------------------------------------
+A brief declares its load-bearing claims in one fenced block::
+
+    ```claims
+    [
+      {"claim":  "the preview DB is a clone, not production",
+       "source": "https://pr-4260.example.com/api/health",
+       "read_at": "2026-08-21",
+       "basis":  "measurement"},
+      {"claim":  "the avatar refresh is driven by the localStorage roster",
+       "source": "src/components/AccountSwitcher.tsx:42",
+       "read_at": "2026-08-21",
+       "basis":  "inference"}
+    ]
+    ```
+
+JSON, not YAML, and stdlib only: `opencode-dispatch` runs under a bare
+`/usr/bin/env python3` with no guaranteed site-packages, and every other yaml
+user in this repo has to guard the import. A parse error here must name a line,
+not degrade to "no claims found" — an unparseable block and an absent one are
+different facts (the same discipline `preflight` already applies to
+`NOT EXAMINED` vs `none`).
+
+🔴 `basis` IS THE WHOLE POINT, AND IT IS A CLOSED ENUM.
+`measurement` vs `inference` is the exact distinction that failed in the homelab
+instance above: an inference was reported as established fact and propagated. A
+brief that cannot tell its reader which of the two it is hands on a belief with
+its provenance stripped. So `basis` hard-fails on anything outside the set — a
+misspelling must not silently read as a measurement.
+
+TWO TIERS, MATCHING `session_insight/schema.py`
+-----------------------------------------------
+`validate()` returns HARD errors (the dispatch is refused). `key_warnings()`
+returns SOFT warnings that are printed and never reject — so the citation
+vocabulary can grow without breaking every dispatch, which is decision O2 in
+`scripts/session-analysis/session_insight/schema.py`, followed here rather than
+reinvented.
+
+🔴 TWO THINGS THIS STRUCTURALLY CANNOT SEE — stated, not left to be discovered.
+
+  1. THE OTHER 99%. See the scope block at the top. The Agent-tool surface has
+     no committed chokepoint at all, so nothing here reaches it.
+  2. AN UNDECLARED PREMISE IN THE PROSE. Within a brief it does reach, it checks
+     that DECLARED claims carry sources. It cannot know the prose asserts a fifth
+     premise the author never declared, because detecting a "claim" in free prose
+     needs a heuristic, a heuristic over-matches, and a permanently-red gate is
+     worse than no gate (`opencode-dispatch`'s own reasoning for why the glob
+     check warns and the path check blocks).
+
+What the mandatory block buys is narrower than either gap and still real: on the
+path it does cover, the author cannot dispatch WITHOUT having been asked the
+question, and an empty declaration is an explicit on-record assertion rather than
+a silence.
+"""
+from __future__ import annotations
+
+import json
+import re
+
+# --------------------------------------------------------------------------- #
+# The fence
+# --------------------------------------------------------------------------- #
+# Matches ```claims (or ```claims json, or ~~~claims, indented, or a longer
+# fence) ... fence-close.
+#
+# The info string is anchored to the word `claims` so an ordinary ```json block
+# in a brief is NOT mistaken for a declaration — a brief full of JSON examples
+# must still be refused for having declared nothing.
+#
+# 🔴 The close accepts AT LEAST as many fence characters as the open, per
+# CommonMark, via `(?P=fchar)*` after the backreference. Without it a perfectly
+# legal ```…```` pair refused as "no block" — a fail-CLOSED wart, but a confusing
+# one, and every case in `test_the_fence_grammar_is_pinned_in_both_directions`
+# exists because it was probed rather than assumed.
+CLAIMS_FENCE_RE = re.compile(
+    r"^[ \t]*(?P<fence>(?P<fchar>[`~])(?P=fchar){2,})[ \t]*claims\b[^\n]*\n"
+    r"(?P<body>.*?)"
+    r"^[ \t]*(?P=fence)(?P=fchar)*[ \t]*$",
+    re.DOTALL | re.MULTILINE,
+)
+
+# --------------------------------------------------------------------------- #
+# Closed enum (hard-fail on an out-of-set value) — the measurement/inference
+# distinction the audit found being erased.
+# --------------------------------------------------------------------------- #
+BASES = ("measurement", "inference")
+
+# Required on EVERY claim: what was claimed, where it was read, when, and which
+# of the two kinds of knowing it is. Dropping any one of these reproduces one of
+# the four measured instances.
+REQUIRED_FIELDS = ("claim", "source", "read_at", "basis")
+
+# Extensible (soft-fail on unknowns) — a citation may carry more than the four.
+KNOWN_FIELDS = REQUIRED_FIELDS + ("note", "verified_by", "confidence")
+
+# A `read_at` that does not START with a YYYY-MM-DD date is a SOFT warning, not a
+# rejection: "the commit before 6a1f2c3" is a legitimate temporal anchor and
+# rejecting it would push authors toward a fabricated date, which is worse.
+_DATEISH_RE = re.compile(r"^\d{4}-\d{2}-\d{2}")
+
+# The sentinel the report prints when a brief declares an EMPTY list. It is an
+# assertion the author made on the record, not a silence, and it reads that way.
+NO_CLAIMS_DECLARED = (
+    "  claim citations   : NONE DECLARED — the brief asserts it carries no "
+    "load-bearing claim"
+)
+
+# 🔴 The operator-facing refusal. A whole normalised sentence, pinned entire by
+# the tests rather than by substring: a guard on WORDS is walkable by rewording,
+# and this sentence is the tool's central claim about what it refused and why.
+NO_BLOCK_ERROR = (
+    "the brief declares no `claims` block. A dispatch brief must carry its "
+    "sources: add a fenced ```claims block listing each load-bearing claim with "
+    "`claim`, `source`, `read_at` and `basis` (measurement|inference), or "
+    "declare `[]` if the brief genuinely asserts no premise the subagent would "
+    "act on. Measured: wrong premises propagated into subagent briefs in four of "
+    "six audit slices, and four adversarial audit rounds read past one."
+)
+
+
+# --------------------------------------------------------------------------- #
+# Extraction + parse
+# --------------------------------------------------------------------------- #
+def extract_block(text: str) -> str | None:
+    """The FIRST `claims` fence body, or None when the brief declares none.
+
+    Returning None for "absent" is deliberate and is NOT the same value as `[]`
+    for "declared empty" — the caller hard-fails on the first and accepts the
+    second, and collapsing them would turn a refusal into an all-clear.
+    """
+    m = CLAIMS_FENCE_RE.search(text or "")
+    return m.group("body") if m else None
+
+
+def count_blocks(text: str) -> int:
+    """How many `claims` fences the brief carries.
+
+    🔴 More than one is a hard error, not a merge. `extract_block` reads the
+    FIRST; a second block would then be silently unvalidated, which is exactly
+    the shape where an uncited claim survives a green preflight.
+    """
+    return len(CLAIMS_FENCE_RE.findall(text or ""))
+
+
+def parse_claims(text: str):
+    """`(claims, errors)`. `claims` is None whenever `errors` is non-empty.
+
+    🔴 THE PRECISE SCOPE OF "every failure names what went wrong", because the
+    two malformations are NOT alike and an earlier draft of this docstring
+    claimed more than the code does:
+
+      * A malformed BODY — a fence that opened and closed correctly around
+        unparseable JSON — is a NAMED parse error carrying a line and column. It
+        must not degrade into "no claims found", which would report a parse
+        failure as an absence and let the author think the check ran.
+      * A malformed FENCE — unterminated, or closed with FEWER characters than
+        it opened — is genuinely INDISTINGUISHABLE from an absent one to any
+        regex, so it reports `NO_BLOCK_ERROR`. That is a fail-CLOSED outcome
+        (rc 6, refused) and never an accepted empty declaration, which is the
+        direction that matters; `test_the_fence_grammar_is_pinned_in_both_
+        directions` pins all ten cases so the behaviour is deliberate.
+    """
+    n = count_blocks(text)
+    if n == 0:
+        return None, [NO_BLOCK_ERROR]
+    if n > 1:
+        return None, [
+            f"the brief carries {n} `claims` blocks; exactly one is allowed "
+            "(only the first would be validated, so the rest would ship "
+            "unchecked)"
+        ]
+
+    body = extract_block(text)
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError as e:
+        return None, [
+            f"the `claims` block is not valid JSON: {e.msg} (line {e.lineno}, "
+            f"column {e.colno}). It must be a JSON array of claim objects."
+        ]
+    if not isinstance(parsed, list):
+        return None, [
+            "the `claims` block must be a JSON ARRAY of claim objects, got "
+            f"{type(parsed).__name__}"
+        ]
+    return parsed, []
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1 — HARD validation (the dispatch is refused)
+# --------------------------------------------------------------------------- #
+def validate(claims) -> list[str]:
+    """Return a list of HARD-error strings (empty list = valid).
+
+    Hard-fails: a non-object entry, a missing or blank REQUIRED field, a
+    non-string required field, and an out-of-set `basis`. Unknown extra keys are
+    NOT hard errors — see `key_warnings()`.
+    """
+    errs: list[str] = []
+    if not isinstance(claims, list):
+        return ["`claims` must be a list"]
+
+    for i, c in enumerate(claims):
+        where = f"claims[{i}]"
+        if not isinstance(c, dict):
+            errs.append(f"`{where}` must be an object, got {type(c).__name__}")
+            continue
+        for field in REQUIRED_FIELDS:
+            if field not in c:
+                errs.append(
+                    f"`{where}.{field}` is required — an uncited claim is the "
+                    "error class this check exists for"
+                )
+                continue
+            v = c[field]
+            if not isinstance(v, str):
+                errs.append(f"`{where}.{field}` must be a string, got "
+                            f"{type(v).__name__}")
+            elif not v.strip():
+                errs.append(f"`{where}.{field}` is required (non-empty)")
+        # 🔴 The closed enum, checked INDEPENDENTLY of the presence loop above so
+        # a present-but-wrong `basis` is reported by its own error rather than
+        # riding on a missing-field message. A misspelled basis must never be
+        # read as `measurement`.
+        if isinstance(c.get("basis"), str) and c["basis"].strip():
+            if c["basis"] not in BASES:
+                errs.append(
+                    f"`{where}.basis`={c['basis']!r} not in {list(BASES)} — the "
+                    "measurement/inference distinction is the specific thing "
+                    "that failed (an inference was reported as established fact "
+                    "and propagated into a downstream brief)"
+                )
+    return errs
+
+
+# --------------------------------------------------------------------------- #
+# Tier 2 — SOFT warnings (printed, never a rejection)
+# --------------------------------------------------------------------------- #
+def key_warnings(claims) -> list[str]:
+    """Soft warnings for out-of-vocab citation keys and unanchored dates.
+
+    Never a rejection: the citation vocabulary must be able to grow without
+    breaking every dispatch (decision O2 in session_insight/schema.py).
+    """
+    if not isinstance(claims, list):
+        return []
+    warns: list[str] = []
+    for i, c in enumerate(claims):
+        if not isinstance(c, dict):
+            continue
+        for key in c:
+            if key not in KNOWN_FIELDS:
+                warns.append(
+                    f"claims[{i}]: unknown citation field {key!r} — kept, but "
+                    "not part of the known vocabulary"
+                )
+        ra = c.get("read_at")
+        if isinstance(ra, str) and ra.strip() and not _DATEISH_RE.match(ra.strip()):
+            warns.append(
+                f"claims[{i}]: `read_at`={ra!r} does not start with a YYYY-MM-DD "
+                "date — kept, but a reader cannot tell how stale this is"
+            )
+    return warns
+
+
+# --------------------------------------------------------------------------- #
+# Reporting helpers
+# --------------------------------------------------------------------------- #
+def basis_counts(claims) -> dict:
+    """`{basis: count}` over VALID bases only, both keys always present.
+
+    Always emitting both keys is deliberate: a report that omits `inference: 0`
+    cannot be distinguished from one where the field was never computed, and a
+    reassuring zero from a check wired to nothing is the failure RULES.md names.
+    """
+    counts = {b: 0 for b in BASES}
+    if not isinstance(claims, list):
+        return counts
+    for c in claims:
+        if isinstance(c, dict) and c.get("basis") in counts:
+            counts[c["basis"]] += 1
+    return counts
+
+
+def inference_claims(claims) -> list[dict]:
+    """The claims the receiving agent must RE-VERIFY rather than act on.
+
+    Surfaced individually in the report — an inference that reads like a
+    measurement is the whole failure, so the report must not fold them into a
+    count and call it done.
+    """
+    if not isinstance(claims, list):
+        return []
+    return [c for c in claims
+            if isinstance(c, dict) and c.get("basis") == "inference"]

--- a/scripts/opencode/opencode-dispatch
+++ b/scripts/opencode/opencode-dispatch
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 """opencode-dispatch — hand a task to opencode without spending this session's
-context on it, and without the four measured ways a dispatch quietly does
-nothing.
+context on it, and without the five measured ways a dispatch quietly does
+nothing — or does the wrong thing confidently.
 
-    opencode-dispatch preflight --dir DIR [--brief FILE|-] [--json]
+    opencode-dispatch preflight --dir DIR [--brief FILE|-] [--json]   # rc 3 / rc 6
     opencode-dispatch run       --dir DIR [--brief FILE|-] [--title T]
                                 [-m flash|mimo|pro|<full/model/id>]
                                 [--auto] [-c] [--file F]...
 
 WHY A WRAPPER AND NOT JUST `opencode run`
 -----------------------------------------
-Four failure modes, all measured over 17 days of real dispatches, and THREE of
-them success-shaped — the dispatch exits 0 and nothing happened:
+Five failure modes, all measured, and FOUR of them success-shaped — the dispatch
+exits 0 and the result looks fine:
 
   1. 🔴 `external_directory: "ask"` -> headless AUTO-REJECT -> exit 0, no work.
      The brief named a path outside `--dir`. `opencode run` auto-rejects an
@@ -37,6 +37,21 @@ them success-shaped — the dispatch exits 0 and nothing happened:
      `Exit code 143`. So this tool NEVER runs opencode in the foreground and
      offers no flag to. It detaches into its own session, tees to a log file
      inside `--dir`, and returns immediately.
+
+  5. 🔴 A WRONG PREMISE, STATED AS FACT, PROPAGATING INTO THE BRIEF — and this
+     one is success-shaped in the worst way: the dispatch runs, produces work,
+     and the work is built on a belief nobody sourced.
+     A 14-day audit of 443 sessions found this in FOUR OF SIX slices — the
+     highest-cost error class found — and the adversarial audit ladder is
+     structurally blind to it (four rounds read past one instance). See
+     `lib/brief_claims.py` for the four measured cases.
+     NARROWED, NOT CLOSED, and the distinction is the point. `preflight` refuses
+     — rc 6 — an opencode brief that declares no citations, and `run` refuses
+     BEFORE installing the brief so nothing is written either. But an opencode
+     dispatch is ~1.2/day against ~137/day of Claude `Agent`-tool briefs, which
+     have NO committed chokepoint: **~0.9% of the surface, and all four measured
+     instances came from the 99% this does not reach.** Read the scope block at
+     the top of `lib/brief_claims.py` before citing this as handled.
 
 🔴 WHY THE PATH CHECK BLOCKS AND THE GLOB CHECK ONLY WARNS.
 The path check is EXACT — a path is under `--dir` or it is not — and the failure
@@ -68,6 +83,7 @@ for _p in (_HERE / "lib", _HERE.parent / "collector"):
     if str(_p) not in sys.path:
         sys.path.insert(0, str(_p))
 
+import brief_claims  # noqa: E402
 import brief_scan  # noqa: E402
 import oc_permissions  # noqa: E402
 
@@ -77,7 +93,8 @@ TOOL = "opencode-dispatch"
 # tests/test_dispatch.py: against the literals at the `emit(` call sites,
 # against adoption-scan's REGISTRY row, and against a check that no call site
 # passes a COMPUTED outcome (which the call-site grep could not see).
-OUTCOMES = ("dispatched", "preflight-ok", "preflight-blocked", "error")
+OUTCOMES = ("dispatched", "preflight-ok", "preflight-blocked",
+            "preflight-uncited", "error")
 
 # --------------------------------------------------------------------------- #
 # Exit codes. Each failure gets its OWN code so a caller can branch, and rc 3 in
@@ -89,6 +106,21 @@ RC_USAGE = 2
 RC_PATH_ESCAPE = 3      # 🔴 failure 1: the brief names a path outside --dir
 RC_DIR = 4              # --dir missing / not a directory
 RC_LAUNCH = 5           # opencode could not be started
+RC_UNCITED = 6          # 🔴 failure 5: a load-bearing claim with no citation
+
+# 🔴 rc 6 IS ITS OWN CODE, not a second meaning for rc 3.
+#
+# rc 3 means "the brief points somewhere I cannot reach"; rc 6 means "the brief
+# asserts something and will not say where it came from". A caller that retries
+# rc 3 by widening --dir would do exactly the wrong thing with rc 6, and the two
+# are fixed by different edits. Same reasoning that gave RC_DIR and RC_LAUNCH
+# their own codes rather than folding them into a generic failure.
+#
+# 🔴 AND THE ORDER MATTERS. The path check runs FIRST and returns FIRST, so a
+# brief that trips both reports rc 3. That is deliberate — a path escape makes
+# the dispatch a silent no-op regardless of its citations — but it means any test
+# of the citation guard MUST use a brief with NO external path, or the guard
+# never executes and the test passes for the wrong reason.
 
 # --------------------------------------------------------------------------- #
 # Model aliases — ONLY the three that actually get retyped. No router, no
@@ -285,9 +317,34 @@ def preflight(text: str, directory: Path, attachments=()) -> dict:
                  + brief_scan.scan_attachments(attachments, directory))
     warnings = brief_scan.scan_commands(text, directory)
     unresolved = brief_scan.extract_unresolved_paths(text)
+
+    # 🔴 failure 5 — a load-bearing claim with no citation. Parse errors and
+    # schema errors are the SAME tier (both refuse) but are kept as one list so
+    # the report prints whichever actually happened rather than a generic
+    # "citations invalid". `claims` is None on a parse failure, and every
+    # downstream reader below is written to tolerate that rather than assume a
+    # list — an unparseable block must not read as an empty one.
+    claims, claim_errs = brief_claims.parse_claims(text)
+    if claims is not None:
+        claim_errs = brief_claims.validate(claims)
+    claim_warns = brief_claims.key_warnings(claims)
+
     return {
         "dir": str(directory),
         "blocked": bool(offenders),
+        "uncited": bool(claim_errs),
+        "citation_errors": claim_errs,
+        "citation_warnings": claim_warns,
+        # 🔴 Always present, both bases, even when the block is absent — a
+        # missing key and a zero are different facts and the JSON consumer must
+        # not have to guess which it got.
+        "claims_declared": len(claims) if isinstance(claims, list) else None,
+        "claims_by_basis": brief_claims.basis_counts(claims),
+        "inference_claims": [
+            {"claim": c.get("claim", ""), "source": c.get("source", ""),
+             "read_at": c.get("read_at", "")}
+            for c in brief_claims.inference_claims(claims)
+        ],
         "external_paths": [
             {"as_written": o.text, "resolved": o.resolved, "kind": o.kind}
             for o in offenders
@@ -370,6 +427,59 @@ def skill_reference_verdict(config: dict | None = None) -> str:
     return VERDICT_SKILL_REFS_BLOCKED.format(action=action, dir=SKILLS_DIR)
 
 
+# 🔴 THE CITATION VERDICT SENTENCES, AS WHOLE NORMALISED STRINGS — same
+# treatment, for the same reason, as VERDICT_CLEAN above. These are the tool's
+# central claim about what a brief's premises are backed by; the tests pin them
+# entire so a cosmetic reword cannot quietly widen what they appear to promise.
+VERDICT_CITED = ("  claim citations   : {n} claim(s) cited — "
+                 "{measurement} measurement, {inference} inference")
+
+
+def _print_citation_section(rep: dict) -> None:
+    """The citation half of the report.
+
+    🔴 It prints the INFERENCE claims individually rather than only counting
+    them. The measured failure was an inference reported as established fact and
+    propagated into a downstream brief — a count of "1 inference" folded into a
+    summary line reproduces exactly the erasure this check exists to prevent.
+    """
+    if rep["citation_errors"]:
+        print()
+        print("🔴 BLOCKED — the brief does not carry its sources.")
+        print("   Wrong premises propagated into subagent briefs in FOUR OF SIX")
+        print("   audit slices over 443 sessions; four adversarial audit rounds")
+        print("   read past one of them. A brief is where a bad premise gets")
+        print("   laundered into a fact, so this is checked here and refused.")
+        for e in rep["citation_errors"]:
+            print(f"     {e}")
+        return
+
+    declared = rep["claims_declared"]
+    if declared == 0:
+        print(brief_claims.NO_CLAIMS_DECLARED)
+    else:
+        print(VERDICT_CITED.format(n=declared, **rep["claims_by_basis"]))
+
+    # UNVERIFIED is its own category — never folded into the cited count, the
+    # same discipline the UNMEASURED-paths block above applies.
+    if rep["inference_claims"]:
+        print()
+        print(f"  ⚠ {len(rep['inference_claims'])} claim(s) are INFERENCES, not "
+              "measurements. The receiving")
+        print("    agent must RE-VERIFY these before acting on them, not treat "
+              "them as facts:")
+        for c in rep["inference_claims"]:
+            print(f"     [inference] {c['claim']}")
+            print(f"                 read {c['read_at']} from {c['source']}")
+
+    if rep["citation_warnings"]:
+        print()
+        print("  ⚠ citation warnings  : not blocking — the citation vocabulary "
+              "is allowed to grow")
+        for w in rep["citation_warnings"]:
+            print(f"     {w}")
+
+
 def print_report(rep: dict) -> None:
     # 🔴 Always print what was EXAMINED beside what was found. A bare "0
     # external paths" from a scan that walked nothing is the failure, not the
@@ -411,6 +521,8 @@ def print_report(rep: dict) -> None:
               "these yourself:")
         for tok in rep["unresolved_paths"]:
             print(f"     {tok}")
+
+    _print_citation_section(rep)
 
     if rep["command_warnings"]:
         rows = rep["command_warnings"]
@@ -465,14 +577,19 @@ def cmd_preflight(args) -> int:
             "command_warnings": len(rep["command_warnings"]),
             "paths_examined": rep["paths_examined"],
             "attachments_examined": rep["attachments_examined"],
-            "commands_examined": rep["commands_examined"]}
-    # 🔴 Two literal call sites, not one ternary. The outcome ledger in
+            "commands_examined": rep["commands_examined"],
+            "citation_errors": len(rep["citation_errors"]),
+            "inference_claims": len(rep["inference_claims"])}
+    # 🔴 Three literal call sites, not one ternary. The outcome ledger in
     # tests/test_dispatch.py is a GREP over these call sites — a computed
     # argument is invisible to it, and an outcome the ledger cannot see is one
     # adoption-scan silently buckets as "unknown".
     if rep["blocked"]:
         emit("preflight-blocked", dims, exit_code=RC_PATH_ESCAPE)
         return RC_PATH_ESCAPE
+    if rep["uncited"]:
+        emit("preflight-uncited", dims, exit_code=RC_UNCITED)
+        return RC_UNCITED
     emit("preflight-ok", dims, exit_code=RC_OK)
     return RC_OK
 
@@ -513,6 +630,22 @@ def cmd_run(args) -> int:
               "model_alias": args.model or "default"},
              exit_code=RC_PATH_ESCAPE)
         return RC_PATH_ESCAPE
+
+    # 🔴 REFUSED BEFORE `install_brief`, exactly like the path check above: an
+    # uncited brief must not be left sitting in the target directory where a
+    # later `-c` continuation could pick it up. "Not dispatched" has to mean
+    # nothing was written, not merely that opencode was not started.
+    if rep["uncited"]:
+        print()
+        print("NOT DISPATCHED.")
+        emit("preflight-uncited",
+             {"stage": "run", "citation_errors": len(rep["citation_errors"]),
+              "inference_claims": len(rep["inference_claims"]),
+              "external_paths": len(rep["external_paths"]),
+              "command_warnings": len(rep["command_warnings"]),
+              "model_alias": args.model or "default"},
+             exit_code=RC_UNCITED)
+        return RC_UNCITED
 
     brief_path, log_path = install_brief(
         directory, text, slugify(args.title or "", "brief"))

--- a/scripts/opencode/tests/test_brief_claims.py
+++ b/scripts/opencode/tests/test_brief_claims.py
@@ -1,0 +1,520 @@
+r"""Tests for `brief_claims` — the dispatch-brief citation guard.
+
+WHAT IS UNDER TEST, and why. Every claim below is a MEASURED failure from a
+14-day audit of 443 sessions, not a hypothetical:
+
+  1. THE HARD FAIL. A brief with a load-bearing claim and no citation must be
+     REFUSED (rc 6), not warned about. Wrong premises propagated into subagent
+     briefs independently in FOUR OF SIX audit slices — the highest-cost error
+     class found — and the adversarial audit ladder is structurally blind to it
+     (four rounds read past one instance). A prose rule is the same mechanism
+     that already failed, so the check has to refuse.
+
+  2. THE POSITIVE CONTROL. A well-formed citation must PASS. A refuser that
+     refuses everything is not a gate, and it is the shape that trains people to
+     click through — which RULES.md says is worse than no gate.
+
+  3. MEASUREMENT vs INFERENCE. The specific thing that failed: a homelab session
+     INFERRED an auth constraint from a token prefix, reported it as established
+     fact, wrote it into a handoff, and it propagated into a downstream session's
+     opening brief ("my inference presented as fact"). So the distinction must be
+     REPRESENTABLE, PRESERVED through the report, and SURFACED per-claim — not
+     folded into a count, which reproduces the erasure.
+
+  4. THE SOFT TIER. Unknown citation fields WARN and never reject, matching
+     `session_insight/schema.py`'s decision O2 (closed enums hard-fail;
+     extensible vocabularies soft-fail) rather than inventing a second idiom.
+
+  5. 🔴 THE ORDERING TRAP. `opencode-dispatch` runs the PATH check before the
+     citation check and returns on the first. So every CLI test here uses a
+     brief with NO external path — otherwise the citation guard would never
+     execute and the test would go green without reaching the code it names.
+     `test_the_citation_guard_is_reachable_past_the_path_check` pins that
+     reachability explicitly rather than leaving it to each fixture's care.
+
+    run:  python -m pytest scripts/opencode/tests/test_brief_claims.py -q
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+OC_DIR = ROOT / "scripts" / "opencode"
+CLI_PATH = OC_DIR / "opencode-dispatch"
+
+sys.path.insert(0, str(OC_DIR / "lib"))
+
+import brief_claims as BC  # noqa: E402
+
+
+def _load_cli():
+    spec = importlib.util.spec_from_loader(
+        "opencode_dispatch_claims",
+        importlib.machinery.SourceFileLoader(
+            "opencode_dispatch_claims", str(CLI_PATH)),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+D = _load_cli()
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures — REALISTIC, taken from a brief that was actually dispatched.
+#
+# 🔴 Not a textbook fixture. RULES.md: a scanner allowlists its own canonical
+# examples and scans clean, so the negative control has to be built from real
+# data. This text is the opening of `20260821-185821-verify-pr-4260-switcher-
+# avatar-refresh.md`, a brief that really ran — and its parenthetical "(dev
+# database clone — safe to mutate; it is NOT production data)" is exactly the
+# uncited load-bearing claim this guard exists for: acted on, never sourced,
+# and catastrophic if stale.
+# --------------------------------------------------------------------------- #
+REAL_UNCITED_BRIEF = """\
+# Verify the account-switcher avatar refresh on the PR-4260 preview
+
+Goal: determine, by driving a real browser, whether the account-switcher avatar
+updates WITHOUT a full page reload when the signed-in user's profile picture
+changes. Preview URL: https://pr-4260.example.com (dev database clone — safe to
+mutate; it is NOT production data).
+
+## Steps
+
+1. Read the session endpoint and record `user.image`.
+2. Change the profile picture through the real UI.
+3. Re-read both values without reloading.
+"""
+
+
+def _cited(*entries: dict) -> str:
+    return "\n```claims\n" + json.dumps(list(entries), indent=2) + "\n```\n"
+
+
+MEASURED = {
+    "claim": "the preview DB is a clone, not production",
+    "source": "https://pr-4260.example.com/api/health",
+    "read_at": "2026-08-21",
+    "basis": "measurement",
+}
+INFERRED = {
+    "claim": "the avatar refresh is driven by the localStorage roster",
+    "source": "src/components/AccountSwitcher.tsx:42",
+    "read_at": "2026-08-21",
+    "basis": "inference",
+}
+
+
+def _run_cli(args, stdin_text):
+    return subprocess.run(
+        [sys.executable, str(CLI_PATH), *args],
+        input=stdin_text, capture_output=True, text=True, timeout=120,
+    )
+
+
+# 🔴 THE REFUSAL SENTENCE, WRITTEN OUT HERE — deliberately NOT imported from
+# `brief_claims`.
+#
+# MEASURED, in this file's own mutation sweep: the first version asserted
+# `errs == [BC.NO_BLOCK_ERROR]`, and the control mutant that REWORDED the
+# constant SURVIVED a fully green suite — mutating the constant mutated the
+# expectation with it, so the test could not see the change. Seven other mutants
+# died; this one walked, and only the positive control revealed it.
+#
+# That is RULES.md's "never derive a test's expectation from the implementation
+# it tests", in the one place where the implementation IS a claim about itself —
+# and `test_dispatch.py` had already recorded the identical finding about
+# `VERDICT_CLEAN`. Reproducing it here is the evidence that the trap is a CLASS,
+# not one file's mistake.
+#
+# A cosmetic reword now fails this file. That is the price of a machine-readable
+# refusal, and it is worth paying.
+LINE_NO_BLOCK = (
+    "the brief declares no `claims` block. A dispatch brief must carry its "
+    "sources: add a fenced ```claims block listing each load-bearing claim with "
+    "`claim`, `source`, `read_at` and `basis` (measurement|inference), or "
+    "declare `[]` if the brief genuinely asserts no premise the subagent would "
+    "act on. Measured: wrong premises propagated into subagent briefs in four of "
+    "six audit slices, and four adversarial audit rounds read past one."
+)
+LINE_NONE_DECLARED = (
+    "  claim citations   : NONE DECLARED — the brief asserts it carries no "
+    "load-bearing claim"
+)
+LINE_CITED_2 = ("  claim citations   : 2 claim(s) cited — "
+                "1 measurement, 1 inference")
+
+
+def test_the_refusal_constants_match_the_sentences_pinned_here():
+    """The two-way pin. The literals above are the source of truth; this asserts
+    the implementation still emits exactly them, so every other test in this file
+    may use either — and a reword can no longer walk past the sweep."""
+    assert BC.NO_BLOCK_ERROR == LINE_NO_BLOCK
+    assert BC.NO_CLAIMS_DECLARED == LINE_NONE_DECLARED
+    assert D.VERDICT_CITED.format(n=2, measurement=1, inference=1) == LINE_CITED_2
+
+
+# --------------------------------------------------------------------------- #
+# 1. THE HARD FAIL — an uncited load-bearing claim is REJECTED
+# --------------------------------------------------------------------------- #
+def test_a_brief_with_no_claims_block_is_rejected():
+    """🔴 The core guard. The brief asserts the preview DB is safe to mutate and
+    cites nothing; the dispatch must refuse rather than launder the premise."""
+    claims, errs = BC.parse_claims(REAL_UNCITED_BRIEF)
+    assert claims is None
+    assert errs == [LINE_NO_BLOCK]
+
+
+def test_a_json_fence_is_not_mistaken_for_a_declaration():
+    """A brief full of JSON examples has still declared NOTHING. If a bare
+    ```json fence satisfied the guard, every brief carrying an example payload
+    would pass uncited — the guard would be walkable by coincidence."""
+    text = 'Send this:\n\n```json\n[{"claim": "x"}]\n```\n'
+    claims, errs = BC.parse_claims(text)
+    assert claims is None and errs == [LINE_NO_BLOCK]
+
+
+@pytest.mark.parametrize("missing", BC.REQUIRED_FIELDS)
+def test_every_required_citation_field_is_individually_required(missing):
+    """Each of the four fields on its own. Dropping `source` reproduces the stale
+    -README instance; dropping `read_at` reproduces the stale-comment one;
+    dropping `basis` reproduces the inference-as-fact one."""
+    entry = {k: v for k, v in MEASURED.items() if k != missing}
+    errs = BC.validate([entry])
+    assert errs, f"a claim missing {missing!r} was accepted"
+    assert any(f"claims[0].{missing}" in e for e in errs), errs
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
+def test_a_blank_citation_field_is_not_a_citation(blank):
+    """🔴 Present-but-empty must fail like absent. Otherwise the cheapest way
+    past the guard is `"source": ""`, which is a citation in shape only."""
+    errs = BC.validate([{**MEASURED, "source": blank}])
+    assert any("claims[0].source" in e for e in errs), errs
+
+
+def test_a_malformed_block_is_a_parse_ERROR_not_an_absence():
+    """An unparseable block and an absent one are different facts. Degrading the
+    first into the second would report a parse failure as "nothing to check"."""
+    claims, errs = BC.parse_claims("```claims\n[{'claim': broken\n```\n")
+    assert claims is None
+    assert len(errs) == 1
+    assert "not valid JSON" in errs[0] and "line" in errs[0]
+    assert errs[0] != LINE_NO_BLOCK
+
+
+def test_a_non_array_block_is_rejected():
+    claims, errs = BC.parse_claims('```claims\n{"claim": "x"}\n```\n')
+    assert claims is None
+    assert "must be a JSON ARRAY" in errs[0]
+
+
+def test_a_second_claims_block_is_rejected_rather_than_silently_unvalidated():
+    """🔴 `extract_block` reads the FIRST fence. A second one would ship
+    unchecked — precisely the shape where an uncited claim survives a green
+    preflight — so two blocks is an error, not a merge."""
+    text = _cited(MEASURED) + _cited({"claim": "uncited"})
+    assert BC.count_blocks(text) == 2
+    claims, errs = BC.parse_claims(text)
+    assert claims is None
+    assert "2 `claims` blocks" in errs[0]
+
+
+@pytest.mark.parametrize("label,text,accepted", [
+    # ACCEPTED — legal CommonMark spellings an author will actually produce.
+    ("backtick", "```claims\n[]\n```\n", True),
+    ("tilde", "~~~claims\n[]\n~~~\n", True),
+    ("info-string", "```claims json\n[]\n```\n", True),
+    ("indented", "  ```claims\n  []\n  ```\n", True),
+    ("longer-fence", "````claims\n[]\n````\n", True),
+    ("close-longer", "```claims\n[]\n````\n", True),
+    # REFUSED — and note the DIRECTION: every malformed fence fails CLOSED, as
+    # "no block declared", never as a silent empty declaration.
+    ("unterminated", "```claims\n[]\n", False),
+    ("close-shorter", "````claims\n[]\n```\n", False),
+    ("wrong-word", "```json\n[]\n```\n", False),
+    ("mixed-chars", "```claims\n[]\n~~~\n", False),
+])
+def test_the_fence_grammar_is_pinned_in_both_directions(label, text, accepted):
+    """🔴 PROBED, not assumed — and pinned so the behaviour is deliberate.
+
+    Two directions, because a fence grammar that accepts everything and one that
+    accepts nothing are both useless. The refusals matter most: a malformed fence
+    must land as "no block" (rc 6), never as an accepted `[]`.
+    """
+    claims, errs = BC.parse_claims(text)
+    if accepted:
+        assert errs == [], f"{label} should be a valid claims fence"
+        assert claims == []
+    else:
+        assert claims is None, f"{label} was accepted as a declaration"
+        assert errs and errs[0] == LINE_NO_BLOCK, errs
+
+
+# --------------------------------------------------------------------------- #
+# 2. THE POSITIVE CONTROL — a well-formed citation PASSES
+# --------------------------------------------------------------------------- #
+def test_a_well_formed_citation_passes():
+    claims, errs = BC.parse_claims(REAL_UNCITED_BRIEF + _cited(MEASURED, INFERRED))
+    assert errs == []
+    assert len(claims) == 2
+    assert BC.validate(claims) == []
+
+
+def test_an_explicitly_empty_declaration_passes():
+    """`[]` is an assertion the author made ON THE RECORD — "this brief carries
+    no load-bearing claim" — as distinct from a silence. The same shape as
+    schema.py's `unreadable=true`: flag it honestly rather than omit it."""
+    claims, errs = BC.parse_claims("Tidy the code up.\n```claims\n[]\n```\n")
+    assert errs == [] and claims == []
+    assert BC.validate(claims) == []
+
+
+# --------------------------------------------------------------------------- #
+# 3. MEASUREMENT vs INFERENCE — represented, preserved, surfaced
+# --------------------------------------------------------------------------- #
+def test_the_basis_enum_is_exactly_the_two_kinds_of_knowing():
+    assert BC.BASES == ("measurement", "inference")
+
+
+@pytest.mark.parametrize("bad", [
+    "measured",      # a plausible misspelling
+    "Measurement",   # case
+    "guess",         # an honest word that is not in the set
+    "assumption",
+])
+def test_an_out_of_set_basis_hard_fails_rather_than_reading_as_a_measurement(bad):
+    """🔴 The closed enum. A misspelled basis must NOT silently default to
+    `measurement` — that is the inference-as-fact failure with extra steps."""
+    errs = BC.validate([{**MEASURED, "basis": bad}])
+    assert any("basis" in e and repr(bad) in e for e in errs), errs
+
+
+def test_the_distinction_is_preserved_through_the_counts():
+    claims, _ = BC.parse_claims(_cited(MEASURED, INFERRED, MEASURED))
+    assert BC.basis_counts(claims) == {"measurement": 2, "inference": 1}
+
+
+def test_both_bases_are_always_keyed_even_at_zero():
+    """A report that omits `inference: 0` cannot be told apart from one where the
+    field was never computed — RULES.md's reassuring-zero failure."""
+    claims, _ = BC.parse_claims(_cited(MEASURED))
+    assert BC.basis_counts(claims) == {"measurement": 1, "inference": 0}
+
+
+def test_inference_claims_are_extracted_individually_not_just_counted():
+    claims, _ = BC.parse_claims(_cited(MEASURED, INFERRED))
+    inf = BC.inference_claims(claims)
+    assert [c["claim"] for c in inf] == [INFERRED["claim"]]
+
+
+def test_the_report_names_each_inference_and_tells_the_agent_to_reverify(tmp_path):
+    """End to end: the receiving agent must be able to SEE which premises are
+    inferences. A count would reproduce the erasure this guard exists to stop."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    p = _run_cli(["preflight", "--dir", str(d)],
+                 "Do the thing." + _cited(MEASURED, INFERRED))
+    assert p.returncode == D.RC_OK, p.stdout + p.stderr
+    assert "[inference] " + INFERRED["claim"] in p.stdout
+    assert "RE-VERIFY" in p.stdout
+    # …and the MEASUREMENT must NOT be listed there — a section that named both
+    # would be a section that distinguishes nothing.
+    assert MEASURED["claim"] not in p.stdout
+
+
+def test_the_json_report_carries_the_distinction_for_a_machine_reader(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    p = _run_cli(["preflight", "--dir", str(d), "--json"],
+                 "Do the thing." + _cited(MEASURED, INFERRED))
+    rep = json.loads(p.stdout)
+    assert rep["claims_declared"] == 2
+    assert rep["claims_by_basis"] == {"measurement": 1, "inference": 1}
+    assert [c["claim"] for c in rep["inference_claims"]] == [INFERRED["claim"]]
+    assert rep["uncited"] is False
+
+
+def test_claims_declared_is_None_not_zero_when_the_block_is_absent(tmp_path):
+    """🔴 "declared nothing" and "declared an empty list" are different facts and
+    must not share a JSON value — a consumer reading 0 for both cannot tell a
+    refusal from an honest empty declaration."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    absent = json.loads(
+        _run_cli(["preflight", "--dir", str(d), "--json"], "no block here").stdout)
+    empty = json.loads(
+        _run_cli(["preflight", "--dir", str(d), "--json"],
+                 "none here\n```claims\n[]\n```\n").stdout)
+    assert absent["claims_declared"] is None
+    assert empty["claims_declared"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# 4. THE SOFT TIER — unknown fields WARN, never reject
+# --------------------------------------------------------------------------- #
+def test_an_unknown_citation_field_warns_and_does_not_reject():
+    """Decision O2, borrowed from session_insight/schema.py: the vocabulary has
+    to be able to grow without breaking every dispatch."""
+    entry = {**MEASURED, "hunch_level": "medium"}
+    assert BC.validate([entry]) == []
+    warns = BC.key_warnings([entry])
+    assert any("hunch_level" in w for w in warns), warns
+
+
+def test_an_unanchored_read_at_warns_and_does_not_reject():
+    """"the commit before 6a1f2c3" is a legitimate temporal anchor. Rejecting it
+    would push authors toward a FABRICATED date, which is strictly worse than an
+    imprecise one."""
+    entry = {**MEASURED, "read_at": "the commit before 6a1f2c3"}
+    assert BC.validate([entry]) == []
+    assert any("read_at" in w for w in BC.key_warnings([entry]))
+
+
+def test_a_known_optional_field_produces_no_warning():
+    """The negative half: a warner that warns about everything is noise, and
+    noise is how a soft tier gets ignored."""
+    assert BC.key_warnings([{**MEASURED, "note": "double-checked"}]) == []
+
+
+def test_an_empty_declaration_READS_as_a_declaration_not_as_a_clean_bill(tmp_path):
+    """🔴 The report must SAY "none declared", not fall silent. A silence beside
+    a clean preflight is indistinguishable from a check that did not run — the
+    same finding that produced `NOT EXAMINED` for the path scanner."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    p = _run_cli(["preflight", "--dir", str(d)],
+                 "Tidy the code up.\n```claims\n[]\n```\n")
+    assert p.returncode == D.RC_OK, p.stdout + p.stderr
+    assert LINE_NONE_DECLARED in [ln.rstrip() for ln in p.stdout.split("\n")]
+    assert "claim(s) cited" not in p.stdout
+
+
+def test_the_cited_verdict_line_reports_the_split_not_just_a_total(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    p = _run_cli(["preflight", "--dir", str(d)],
+                 "Do it." + _cited(MEASURED, INFERRED))
+    assert LINE_CITED_2 in [ln.rstrip() for ln in p.stdout.split("\n")], p.stdout
+
+
+def test_the_soft_tier_survives_the_cli_end_to_end(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    p = _run_cli(["preflight", "--dir", str(d)],
+                 "Do it." + _cited({**MEASURED, "hunch_level": "medium"}))
+    assert p.returncode == D.RC_OK, p.stdout + p.stderr
+    assert "unknown citation field 'hunch_level'" in p.stdout
+    assert "not blocking" in p.stdout
+
+
+# --------------------------------------------------------------------------- #
+# 5. 🔴 REACHABILITY + THE CLI CONTRACT
+# --------------------------------------------------------------------------- #
+def test_the_citation_guard_is_reachable_past_the_path_check(tmp_path):
+    """🔴 THE MUTATION-TEST PRECONDITION, pinned as its own test.
+
+    A guard that never executes still passes a mutation test — an earlier check
+    wins, the mutant dies for the wrong reason, and the sweep reports a kill it
+    did not earn. `opencode-dispatch` checks external paths FIRST and returns on
+    the first failure, so this asserts the two facts that make every other CLI
+    test here meaningful:
+
+      * the uncited fixture trips NO path offender (`paths_examined` 0, so the
+        path check CANNOT have rejected first), and
+      * the rc that comes back is rc 6 specifically, not rc 3.
+    """
+    d = tmp_path / "proj"
+    d.mkdir()
+    p = _run_cli(["preflight", "--dir", str(d), "--json"], REAL_UNCITED_BRIEF)
+    rep = json.loads(p.stdout)
+    assert rep["external_paths"] == [], (
+        "the fixture trips the PATH check, so the citation guard never runs and "
+        "every rc-6 assertion in this file would be green for the wrong reason")
+    assert rep["blocked"] is False
+    assert rep["uncited"] is True
+    assert p.returncode == D.RC_UNCITED == 6, p.stdout + p.stderr
+
+
+def test_preflight_refuses_the_real_uncited_brief_with_the_specific_rc(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    p = _run_cli(["preflight", "--dir", str(d)], REAL_UNCITED_BRIEF)
+    assert p.returncode == D.RC_UNCITED == 6, p.stdout + p.stderr
+    assert LINE_NO_BLOCK in p.stdout
+
+
+def test_rc_6_is_distinct_from_rc_3_so_a_caller_can_branch():
+    """The two failures are fixed by different edits: rc 3 by widening --dir,
+    rc 6 by citing a source. A caller that conflated them would apply the wrong
+    remedy to whichever it met."""
+    assert D.RC_UNCITED != D.RC_PATH_ESCAPE
+    assert len({D.RC_OK, D.RC_USAGE, D.RC_PATH_ESCAPE, D.RC_DIR,
+                D.RC_LAUNCH, D.RC_UNCITED}) == 6
+
+
+def test_run_refuses_an_uncited_brief_and_never_writes_it(tmp_path, monkeypatch):
+    """🔴 "Not dispatched" must mean NOTHING WAS WRITTEN. An uncited brief left
+    in the target directory could be picked up by a later `-c` continuation, so
+    the refusal has to land before `install_brief`."""
+    d = tmp_path / "proj"
+    d.mkdir()
+
+    def boom(*a, **k):
+        raise AssertionError("dispatched despite an uncited brief")
+
+    monkeypatch.setattr(D.subprocess, "Popen", boom)
+    monkeypatch.setattr(D.sys, "stdin", _StdinText(REAL_UNCITED_BRIEF))
+    assert D.main(["run", "--dir", str(d)]) == D.RC_UNCITED
+    assert not (d / D.BRIEF_SUBDIR).exists(), (
+        "an uncited brief was installed into the target directory anyway")
+
+
+def test_run_dispatches_once_the_brief_carries_its_sources(tmp_path, monkeypatch):
+    """The both-directions pin. A gate that only ever refuses is not a gate, and
+    this is the half that proves the citation path can be satisfied."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    seen = {}
+    monkeypatch.setattr(D.subprocess, "Popen",
+                        lambda argv, **kw: seen.update(argv=argv)
+                        or type("P", (), {"pid": 7})())
+    monkeypatch.setattr(D.sys, "stdin",
+                        _StdinText("Do it." + _cited(MEASURED)))
+    assert D.main(["run", "--dir", str(d)]) == D.RC_OK
+    assert seen["argv"][:2] == ["opencode", "run"]
+
+
+def test_the_uncited_outcome_is_in_the_declared_ledger():
+    """The telemetry seam: an outcome the ledger cannot see is one adoption-scan
+    silently buckets as "unknown"."""
+    assert "preflight-uncited" in D.OUTCOMES
+    src = CLI_PATH.read_text()
+    assert src.count('emit("preflight-uncited"') == 2, (
+        "both cmd_preflight and cmd_run must emit it as a LITERAL — the ledger "
+        "test in test_dispatch.py is a grep over call sites and cannot see a "
+        "computed argument")
+
+
+def test_the_uncited_outcome_is_counted_as_impact():
+    """It PREVENTS a bad dispatch, so adoption-scan must be able to report it as
+    a win rather than as unclassified noise."""
+    adoption = (ROOT / "scripts" / "session-analysis" / "adoption-scan.py").read_text()
+    row = adoption.split('"id": "opencode-dispatch"', 1)[1][:900]
+    assert '"preflight-uncited"' in row
+    assert '"impact_outcomes": ["preflight-blocked", "preflight-uncited"]' in row
+
+
+class _StdinText:
+    def __init__(self, text):
+        self._t = text
+
+    def read(self):
+        return self._t

--- a/scripts/opencode/tests/test_dispatch.py
+++ b/scripts/opencode/tests/test_dispatch.py
@@ -337,6 +337,20 @@ def test_tmp_is_deliberately_not_allowlisted(tmp_path):
     assert brief_scan.scan_paths("see /tmp/claude-1000/scratchpad/brief.md", d)
 
 
+# 🔴 THE CITATION DECLARATION every brief below carries.
+#
+# Since the citation guard landed (`brief_claims`), a brief with NO `claims`
+# fence is REFUSED with rc 6 — so every fixture here that expects to reach a
+# LATER verdict has to declare one, or it would never get there and the test
+# would pass or fail for a reason that has nothing to do with what it names.
+#
+# It declares `[]` — "this fixture asserts no load-bearing claim" — which is the
+# honest declaration for a synthetic path-scanner fixture and is exactly the
+# explicit-empty case `brief_claims` accepts. The citation tests that DO care
+# about claim content live in tests/test_brief_claims.py and build their own.
+NO_CLAIMS = "\n```claims\n[]\n```\n"
+
+
 def _run_cli(args, stdin_text):
     """Drive the real CLI end to end, as a subprocess, over stdin."""
     return subprocess.run(
@@ -359,7 +373,7 @@ def test_preflight_accepts_the_in_dir_control(tmp_path):
     d.mkdir()
     (d / "spec.md").write_text("x")
     p = _run_cli(["preflight", "--dir", str(d)],
-                 f"Implement what {d / 'spec.md'} says.")
+                 f"Implement what {d / 'spec.md'} says." + NO_CLAIMS)
     assert p.returncode == D.RC_OK, p.stdout + p.stderr
 
 
@@ -473,7 +487,8 @@ def test_an_empty_scan_says_NOT_EXAMINED_not_an_all_clear(tmp_path):
     find" are different claims."""
     d = tmp_path / "proj"
     d.mkdir()
-    p = _run_cli(["preflight", "--dir", str(d)], "Just tidy the code up.")
+    p = _run_cli(["preflight", "--dir", str(d)],
+                 "Just tidy the code up." + NO_CLAIMS)
     lines = _lines(p.stdout)
     assert LINE_NOT_EXAMINED in lines, p.stdout
     assert "  paths examined       : 0" in lines
@@ -488,7 +503,7 @@ def test_a_real_clean_scan_says_how_many_it_examined(tmp_path):
     d.mkdir()
     (d / "a.md").write_text("x")
     p = _run_cli(["preflight", "--dir", str(d), "--file", str(d / "a.md")],
-                 f"Edit {d / 'src.py'} please.")
+                 f"Edit {d / 'src.py'} please." + NO_CLAIMS)
     lines = _lines(p.stdout)
     assert LINE_CLEAN_2 in lines, p.stdout
     assert LINE_NOT_EXAMINED not in lines
@@ -515,7 +530,8 @@ def test_the_report_never_claims_containment_for_an_unchecked_attachment(tmp_pat
 def test_unresolved_paths_are_reported_separately_from_both_verdicts(tmp_path):
     d = tmp_path / "proj"
     d.mkdir()
-    p = _run_cli(["preflight", "--dir", str(d)], "run ${DEVRC}/scripts/tests now")
+    p = _run_cli(["preflight", "--dir", str(d)],
+                 "run ${DEVRC}/scripts/tests now" + NO_CLAIMS)
     lines = _lines(p.stdout)
     assert p.returncode == D.RC_OK
     # Not blocked, not counted as clean, and named.
@@ -689,7 +705,7 @@ def test_the_dispatch_is_detached_into_its_own_session(tmp_path, monkeypatch):
         return FakeProc()
 
     monkeypatch.setattr(D.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(D.sys, "stdin", _Stdin("do the thing"))
+    monkeypatch.setattr(D.sys, "stdin", _Stdin("do the thing" + NO_CLAIMS))
     rc = D.main(["run", "--dir", str(d), "--title", "T", "-m", "flash"])
     assert rc == D.RC_OK
     assert seen["kw"]["start_new_session"] is True, (
@@ -726,12 +742,12 @@ def test_the_brief_is_written_inside_dir_and_self_ignores(tmp_path, monkeypatch)
     d.mkdir()
     monkeypatch.setattr(D.subprocess, "Popen",
                         lambda *a, **k: type("P", (), {"pid": 1})())
-    monkeypatch.setattr(D.sys, "stdin", _Stdin("a clean brief"))
+    monkeypatch.setattr(D.sys, "stdin", _Stdin("a clean brief" + NO_CLAIMS))
     assert D.main(["run", "--dir", str(d)]) == D.RC_OK
     sub = d / D.BRIEF_SUBDIR
     briefs = list(sub.glob("*.md"))
     assert len(briefs) == 1
-    assert briefs[0].read_text() == "a clean brief"
+    assert briefs[0].read_text() == "a clean brief" + NO_CLAIMS
     # 🔴 Never the scratchpad, and never stageable in whatever repo it lands in.
     assert (sub / ".gitignore").read_text().rstrip().endswith("*")
 
@@ -834,7 +850,7 @@ def test_telemetry_never_changes_the_exit_code(monkeypatch, tmp_path):
                         type("M", (), {"emit_invocation": staticmethod(boom)}))
     d = tmp_path / "proj"
     d.mkdir()
-    monkeypatch.setattr(D.sys, "stdin", _Stdin("clean"))
+    monkeypatch.setattr(D.sys, "stdin", _Stdin("clean" + NO_CLAIMS))
     assert D.main(["preflight", "--dir", str(d)]) == D.RC_OK
 
 
@@ -846,7 +862,9 @@ SHIPPED_FILES = [
     "scripts/opencode/opencode-dispatch",
     "scripts/opencode/lib/oc_permissions.py",
     "scripts/opencode/lib/brief_scan.py",
+    "scripts/opencode/lib/brief_claims.py",
     "scripts/opencode/tests/test_dispatch.py",
+    "scripts/opencode/tests/test_brief_claims.py",
 ]
 
 # 🔴 THE TWO TIERS RUN THIS FILE IN DIFFERENT TREES, AND ONLY ONE HAS A `.git`.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1778,7 +1778,25 @@ TARGET_FLOORS=(
   #   run-tests: ERROR — scripts/opencode/tests collected 90 tests but its floor
   #   is only 14. Raise the TARGET_FLOORS entry to "scripts/opencode/tests|86"
   # (which is `_suggested_floor 90` = 90 - min(50, max(1, 90/20 = 4)) = 86.)
-  "scripts/opencode/tests|86"
+  #
+  # 2026-08-25, the brief-citation guard: 90 -> 151 collected. +61 for
+  # scripts/opencode/tests/test_brief_claims.py, a NEW FILE in an existing
+  # directory target — so HERMETIC_TARGETS needs no entry and this line is the
+  # only evidence the gate runs it at all. ZERO new skips, so EXPECTED_SKIPS is
+  # untouched.
+  #
+  # 🔴 THE GATE DID NOT FORCE THIS. 151 is over the old ceiling
+  # (86 + max(60, 86/4) = 146) by 5 — but the run that PASSED read 141, before
+  # the fence-grammar cases landed. Re-pinning is right either way, for the
+  # reason every line above gives: a floor of 86 under a 151-test target carries
+  # **65 tests of SLACK**, which is more than the entire pre-#583 suite.
+  #
+  # The number is the gate's own count put through the gate's own function, NOT
+  # arithmetic across a conflict:
+  #   _suggested_floor 151 = 151 - min(50, max(1, 151/20 = 7)) = 151 - 7 = 144.
+  # If this line conflicts with another branch, re-run the gate on the MERGED
+  # tree and copy what it prints rather than reconciling the two sides.
+  "scripts/opencode/tests|144"
 )
 
 # The allowance rule, in one place, used by BOTH the drift message and anyone

--- a/scripts/session-analysis/adoption-scan.py
+++ b/scripts/session-analysis/adoption-scan.py
@@ -147,10 +147,14 @@ REGISTRY = [
         "id": "opencode-dispatch",
         "label": "opencode-dispatch — preflighted, detached opencode dispatch",
         "via": "tool", "tool": "opencode-dispatch", "opt_in": True,
-        "outcomes": ["dispatched", "preflight-ok", "preflight-blocked", "error"],
-        "impact_outcomes": ["preflight-blocked"],
-        "impact_label": ("silent no-op dispatches prevented (brief named a path "
-                         "outside --dir; `opencode run` auto-rejects and exits 0)"),
+        "outcomes": ["dispatched", "preflight-ok", "preflight-blocked",
+                     "preflight-uncited", "error"],
+        "impact_outcomes": ["preflight-blocked", "preflight-uncited"],
+        "impact_label": ("bad dispatches prevented — a brief naming a path "
+                         "outside --dir (`opencode run` auto-rejects and exits "
+                         "0), or a brief asserting a load-bearing claim with no "
+                         "citation (wrong premises propagated into subagent "
+                         "briefs in 4 of 6 audit slices over 443 sessions)"),
     },
     {
         "id": "browser-bridge",


### PR DESCRIPTION
## 🔴 Read this first: it covers ~0.9% of the surface, and not the part the evidence came from

| brief surface | rate | covered here |
|---|---|---|
| **opencode dispatch** (`opencode-dispatch preflight()`) | **~1.2/day** | ✅ **yes** |
| Claude `Agent`-tool subagent brief | ~137/day | ❌ **no chokepoint exists** |
| clawgate task body (`build_task_body()` ×2) | uncounted | ❌ no |

**Basis, so it can be argued with:** 6 briefs surviving on disk across 3 project directories over **Aug 21–25** (5 days) — explicitly a **FLOOR**, not a total, since `.opencode-dispatch/` is deleted with its project and the local telemetry spool had already shipped — against **1,921 `Agent` calls in the audit's 14-day window**. The two windows differ, so treat **0.9%** as an order of magnitude. If anything it **over**-states coverage: the clawgate producers are a third surface counted in neither number.

🔴 **The asymmetry that matters most: all four measured instances came from the UNCOVERED surface.** The wrong root cause reached three *subagent* briefs. The three subagents who opened their reports correcting a stale brief were Agent-tool subagents. **Not one was an opencode dispatch.**

So this is a **bridgehead, not a fix**, and it is named, documented and merged as one. Please do not cite it as evidence that premise-propagation is handled — a guard reading wider than it implements is worse than none, because it stops anyone looking. What it does provide: the schema, vocabulary and refusal semantics a wider guard would reuse, proven against a real dispatch path.

## What the class is

A 14-day audit of 443 sessions found **wrong premises propagating into subagent briefs** independently in **four of six** audit slices — the highest-cost error class found, and one the adversarial audit ladder is structurally blind to.

| measured instance | what happened |
|---|---|
| stale comment + stale README | a whole storage layer built on it; **four adversarial audit rounds read past it** |
| wrong root-cause diagnosis | filed as a GitHub issue, endorsed as the session's best finding, **pushed into three subagent briefs**, retracted at session end. The recommended fix would have preserved every false pass across a 69-site sweep |
| auth constraint inferred from a token prefix | reported as established fact several times, written into a handoff as the ranked next step, **propagated into a downstream session's opening brief**. Quoted: *"my inference presented as fact."* |
| three `cli` subagents | opened their reports correcting the brief they were handed: *"The brief was stale — the code won."* |

🔴 **This only works structurally.** As a prose instruction it is the same mechanism that already failed — the audit ladder is itself instruction-based and missed this four times over. So it is a schema, in code, at a chokepoint, and it **refuses**.

## The chokepoint I found (and the one I did not)

I swept every committed producer of an agent prompt in this repo. Three surfaces exist; only one is covered here.

| surface | committed chokepoint? | covered by this PR |
|---|---|---|
| **opencode dispatch brief** | ✅ `opencode-dispatch` `preflight()` — both `preflight` and `run` route through it | **yes** |
| clawgate task body (what a devpod agent literally executes) | ✅ two INDEPENDENT producers — `repo-cos/clawgate.py:build_task_body(proposal)` and `initiatives/dispatch.py:build_task_body(view, recommendation)`. Different signatures, so not literal copies; neither validates its body, and both sit outside `clawgate-task-interview-guard.py`, which is interactive-sessions-only by its own docstring | no — see follow-up |
| **Claude `Agent`-tool subagent prompt** | ❌ **none.** Those prompts are composed by the model per prose in `audit-pr/SKILL.md`, `analyze-service/SKILL.md` etc. No committed code sees them | **no — and this is the honest gap** |

`preflight()` was the right host because it already had exactly the two-tier shape this needs: an **exact** check that hard-blocks (path containment, rc 3) beside an **over-matching** one that only warns (command globs). The citation check joins the first tier.

## The design

A brief declares its load-bearing claims in one fenced block:

````markdown
```claims
[
  {"claim":   "the preview DB is a clone, not production",
   "source":  "https://pr-4260.example.com/api/health",
   "read_at": "2026-08-21",
   "basis":   "measurement"},
  {"claim":   "the avatar refresh is driven by the localStorage roster",
   "source":  "src/components/AccountSwitcher.tsx:42",
   "read_at": "2026-08-21",
   "basis":   "inference"}
]
```
````

- **JSON, not YAML** — `opencode-dispatch` runs under a bare `/usr/bin/env python3` with no guaranteed site-packages; every other yaml user in this repo has to guard the import.
- **`basis` is a CLOSED ENUM** (`measurement` | `inference`). This is the specific distinction that failed in the homelab instance, so a misspelling is **refused**, never silently read as a measurement. The report lists each **inference** individually with its source and date and tells the receiving agent to re-verify it — folding them into a count would reproduce the erasure.
- **Two tiers, borrowed from `session_insight/schema.py` rather than reinvented**: `validate()` hard-fails (closed enum, missing/blank required field, parse error, two blocks); `key_warnings()` soft-fails on unknown citation keys and an unanchored `read_at`, so the vocabulary can grow (decision O2).
- **rc 6 `RC_UNCITED`, its own code.** rc 3 is fixed by widening `--dir`, rc 6 by citing a source; a caller conflating them would apply the wrong remedy. `run` refuses **before** `install_brief`, so "not dispatched" means nothing was written either.
- `preflight-uncited` added to `OUTCOMES` + adoption-scan's `REGISTRY` row and its `impact_outcomes` (the ledger test pins those both ways).
- **`[]` is a valid declaration** — an assertion on the record that the brief carries no load-bearing claim, printed as `NONE DECLARED`. Same shape as `schema.py`'s `unreadable=true` + reason.

### 🔴 What it structurally cannot see

It checks that **declared** claims carry sources. It cannot know your prose asserts a fifth premise you never declared — detecting a claim in free text needs a heuristic, a heuristic over-matches, and a permanently-red gate is worse than no gate (this file's own stated reason for why the glob check warns and the path check blocks). What the mandatory block buys is narrower and real: **you cannot dispatch without having been asked the question**, and a silence becomes an explicit `[]`.

## Test matrix

**RED AT BASE — behaviourally, not merely by a missing import.** The new lib was copied into an `origin/main` (`1d67f5e8`) checkout so the failures are about the CLI's behaviour rather than an absent module: **10 failed / 26 passed**.

The bare symptom, on the identical file both ways:

```
BASE_RC=0     # a brief asserting "dev database clone — safe to mutate;
HEAD_RC=6     # it is NOT production data", with zero sources
```

**GREEN AT HEAD:** `scripts/opencode/tests` **151 passed**; authoritative gate `nix build .#checks.x86_64-linux.pytests` → `RESULT: PASS (exit=0)`, `failed=0`.

**MUTATION SWEEP: KILLED 12/12, SURVIVED 0.** Run under `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` deleted between mutants, each scored by the **names** of the tests that killed it, baseline green before and after. Every mutation is the narrowest expression that can be wrong (`if False` on the guard's own condition, never its enclosing branch).

| mutant | killed by |
|---|---|
| absent block fails open | `test_a_brief_with_no_claims_block_is_rejected` + 5 more |
| `basis` closed enum dropped | `test_an_out_of_set_basis_hard_fails_…` ×4 params |
| blank required field accepted | `test_a_blank_citation_field_is_not_a_citation` ×3 |
| soft tier silenced | `test_an_unknown_citation_field_warns_and_does_not_reject` |
| CLI refusal removed (rc 0) | `test_the_citation_guard_is_reachable_past_the_path_check` |
| every claim counted as a measurement | `test_the_distinction_is_preserved_through_the_counts` |
| `run` installs an uncited brief anyway | `test_run_refuses_an_uncited_brief_and_never_writes_it` |
| refusal / verdict sentences reworded (×3) | the literal two-way pins |
| close fence stops requiring the open length | `test_the_fence_grammar_is_pinned_in_both_directions[close-shorter]` |
| any fenced block counts as a declaration | `test_a_json_fence_is_not_mistaken_for_a_declaration` |

### 🔴 The positive control caught a real defect in the first sweep

The known-caught mutant — rewording the pinned refusal sentence — **SURVIVED a fully green suite.** The tests asserted `errs == [BC.NO_BLOCK_ERROR]`, so mutating the constant mutated the expectation with it. Seven other mutants died; that one walked, and only the positive control revealed it.

The sentences are now written out **literally** in the test file with a two-way pin — which is the idiom `test_dispatch.py` had **already** adopted for `VERDICT_CLEAN` after the identical finding. Reproducing it independently is the evidence that this is a **class**, not one file's mistake. It is recorded in the test file.

### Reachability, pinned as its own test

The path check runs **first** and returns first, so a citation-guard test could go green without the guard ever executing. `test_the_citation_guard_is_reachable_past_the_path_check` asserts the fixture trips **no** path offender (`external_paths == []`, `blocked is False`) **and** that the rc is 6 specifically.

The negative-control fixture is the **real text of a brief that was actually dispatched** (`20260821-185821-verify-pr-4260-…`), not a textbook one — its parenthetical *"(dev database clone — safe to mutate; it is NOT production data)"* is precisely the uncited load-bearing claim this exists for.

## Gate

`scripts/opencode/tests` 90 → **151** collected. Re-pinned **86 → 144** = `_suggested_floor 151`: a floor of 86 under a 151-test target carried **65 tests of slack**, more than the entire pre-#583 suite. `--check-floors` passes.

## 🔴 Cost — weighed, and stated

**This adds friction to every opencode dispatch.** Measured volume on this host: **6 briefs surviving on disk across 3 project directories over Aug 21–25** (~1.2/day). That is a **floor, not a total** — `.opencode-dispatch/` dirs are deleted with their projects, and the local telemetry spool had already been shipped. So the friction is roughly **one `claims` block per day**.

🔴 **The 1,921 `Agent`-tool calls in the audit window are NOT covered and NOT slowed.** That is the number that measures the *uncovered surface*, not the friction. Those prompts are composed by the model per prose in the skills, and there is **no committed code chokepoint** for them.

**The honest trade:** this covers a low-volume path well and leaves the high-volume path untouched. It is worth landing anyway — it is the only place a code-level check can exist today, and it establishes the schema and the vocabulary that a wider guard would reuse. But it should not be read as closing the error class.

## Follow-ups (each with a closing condition)

**1. Extend to the clawgate task body — this IS a work item, with a mechanical closing condition.**
Two producers (`repo-cos/clawgate.py:build_task_body(proposal)`, `initiatives/dispatch.py:build_task_body(view, recommendation)`) emit the text a devpod agent literally executes, and neither validates it. Both already have floored gate targets (`scripts/repo-cos/tests`, `scripts/initiatives/tests`), so the work is checkable without new machinery.
- *Closing condition (mechanical):* a merged PR in which **both** call sites produce their body through one shared validator — reusing `brief_claims` — with a ledger test asserting the set of `build_task_body` producers, failing when it **grows or shrinks**, plus one behavioural case per producer. Checked by: the existing `devrc-pytests` gate going green on that PR.

**2. Whether the `Agent`-tool surface gets a chokepoint at all — NOT yet a work item, and I am not minting one.**
Covering ~137 briefs/day means a PreToolUse hook on the Agent tool in `scripts/claude-hooks/`. That is a design decision with real blast radius, not a task someone can pick up, and I can name no mechanical check that would close it. Stating it plainly rather than filing an object nobody can close: **this needs Zach's direction before it is work.** The input he needs is in this PR — the 0.9% figure, its basis, and the fact that the evidence came from the uncovered side.
