### PR TITLE
fix(tests): make the parametrize VALUES deterministic too — #855 pinned only the id

### DIFF
--- a/scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py
+++ b/scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py
@@ -155,38 +155,54 @@ def q(s):
 # need it at import time.
 SCRATCH = tempfile.mkdtemp(prefix="ghccg-test-")
 
+# 🔴 …AND THAT RANDOM NAME MUST NOT REACH A `parametrize` VALUE EITHER — which is
+# a strictly stronger claim than "must not reach an id", and #855 deliberately
+# left it open. That PR unbroke a hard-blocked required gate under time pressure
+# by REDACTING `SCRATCH` out of the ids (`stable_id`, now retired below); pinning
+# the label was the right call for that job and it worked. What it left behind is
+# the other half: the VALUES still interpolated the per-process directory, so
+# every xdist worker executed a different byte string under one shared id.
+# Measured on `main` at 1d67f5e8: 10 of 379 parametrize values.
+#
+# An id-level fix cannot see that, by construction — `SAME_LINE_HEREDOC_CASES`
+# pins its own labels, so a per-process path in ITS values collides with nothing
+# and no id-level check can ever notice. So the directory NAME stays out of the
+# tables entirely: they spell it as a stable placeholder and the two drivers
+# substitute the real one at call time. Id AND executed bytes are then identical
+# in every worker, and `stable_id` has nothing left to redact.
+#
+# The random directory itself stays, for the reason above it: several cases
+# assert a verdict that depends on a body-file path NOT existing, and a fixed
+# name makes those a claim about this machine's `/tmp` — and would collide
+# between the concurrent gate runs this box hosts.
+#
+# `scratch()` — the spelling anyone adding a table will reach for — is the SAFE
+# one. Only a test that touches the file on disk needs `scratch_on_disk()`, and
+# that is a deliberate minority of five.
+SCRATCH_TOKEN = "/ghccg-scratch"
+
 
 def scratch(name):
+    """A path in the per-run scratch dir, spelled as a stable placeholder.
+
+    Safe in a `parametrize` table. `ev()` / `verdict()` resolve it to `SCRATCH`
+    before the command reaches the gate, so what runs is the real path.
+    """
+    return SCRATCH_TOKEN + "/" + name
+
+
+def scratch_on_disk(name):
+    """The REAL path — for the handful of tests that open or stat the file."""
     return os.path.join(SCRATCH, name)
 
 
-def stable_id(cmd):
-    """A parametrize id for `cmd` with the per-run scratch path REDACTED.
+def resolved(cmd):
+    """Substitute the real per-run scratch dir for the placeholder.
 
-    🔴 A PARAMETRIZE ID MUST NOT CARRY `SCRATCH`, OR THE WHOLE GATE STOPS —
-    and it is the id, not the test, that breaks. pytest derives an id from the
-    parameter VALUE, so a command string holding this module's `mkdtemp` path
-    puts that random path in the id. Every xdist worker imports this module
-    fresh and gets a DIFFERENT `SCRATCH`, so the workers collect different ids
-    and xdist aborts the whole run:
-
-        ERROR gw1 - Different tests were collected between gw0 and gw1
-
-    Measured on this file at 200e6383: `-n 4` → 3 errors, 0 tests; serial →
-    474 passed. Since #841 the gate runs every pytest target 4-way, so that is
-    a red gate blocking every open PR in the repo — from a test id, with no
-    test having failed.
-
-    Redaction rather than a fixed path: several cases below depend on the
-    FILESYSTEM path being fresh and per-run (see the `SCRATCH` comment), and a
-    fixed shared name would collide between the concurrent gate runs this box
-    hosts. So the path stays random and only the id is pinned — the id becomes
-    a pure function of the table.
-
-    `test_control_no_parametrize_id_can_carry_the_scratch_path` pins that this
-    is actually applied everywhere it must be.
+    A no-op on a command built with `scratch_on_disk()`, so the drivers can apply
+    it unconditionally.
     """
-    return cmd.replace(SCRATCH, "<scratch>")
+    return cmd.replace(SCRATCH_TOKEN, SCRATCH)
 
 
 # --------------------------------------------------------------------------- #
@@ -210,7 +226,7 @@ def verdict(cmd, env=None, tool_name="Bash", raw=None, hook=None):
         e.update(env)
     payload = raw if raw is not None else json.dumps(
         {"tool_name": tool_name, "hook_event_name": "PreToolUse",
-         "cwd": str(ROOT), "tool_input": {"command": cmd}})
+         "cwd": str(ROOT), "tool_input": {"command": resolved(cmd)}})
     p = subprocess.run([sys.executable, hook or HOOK], input=payload,
                        capture_output=True, text=True, env=e)
     assert p.returncode == 0, (
@@ -244,7 +260,7 @@ def assert_allowed(cmd, env=None):
 # would make the suite slow. The subprocess driver above covers the process
 # contract; this covers volume.
 def ev(cmd, env=None):
-    return guard.evaluate(cmd, env or {}, guard_core)
+    return guard.evaluate(resolved(cmd), env or {}, guard_core)
 
 
 # =========================================================================== #
@@ -682,8 +698,7 @@ UNRELATED_HEREDOC_CASES = [
 ]
 
 
-@pytest.mark.parametrize("tail,mark", UNRELATED_HEREDOC_CASES,
-                         ids=[stable_id(c[0]) for c in UNRELATED_HEREDOC_CASES])
+@pytest.mark.parametrize("tail,mark", UNRELATED_HEREDOC_CASES)
 def test_an_unrelated_heredoc_does_not_satisfy_a_create(tail, mark):
     """🔴 A well-specified heredoc written earlier on the line, for a DIFFERENT
     command, must not answer for a create — whatever the reason the create's own
@@ -1628,14 +1643,12 @@ REALISTIC_ALLOWS = [
 ]
 
 
-@pytest.mark.parametrize("cmd", REALISTIC_ALLOWS,
-                         ids=[stable_id(c) for c in REALISTIC_ALLOWS])
+@pytest.mark.parametrize("cmd", REALISTIC_ALLOWS)
 def test_a_realistic_correct_call_is_allowed(cmd):
     assert ev(cmd) is None, cmd
 
 
-@pytest.mark.parametrize("cmd", REALISTIC_ALLOWS[:12],
-                         ids=[stable_id(c) for c in REALISTIC_ALLOWS[:12]])
+@pytest.mark.parametrize("cmd", REALISTIC_ALLOWS[:12])
 def test_a_realistic_correct_call_is_allowed_through_the_real_process(cmd):
     assert_allowed(cmd)
 
@@ -1909,27 +1922,27 @@ def test_control_no_parametrize_id_can_carry_the_scratch_path(tmp_path):
 
     NOT fixed by pinning `SCRATCH` to a constant path: several cases here need
     a directory no leftover file can answer for, and a shared name collides
-    between the concurrent gate runs this box hosts. The id is pinned; the
-    path stays random.
+    between the concurrent gate runs this box hosts. The path stays random; it
+    is its NAME that is kept out of the tables (`SCRATCH_TOKEN`).
     """
     a = _collect_ids_in_a_fresh_process(tmp_path / "tmp-a")
     b = _collect_ids_in_a_fresh_process(tmp_path / "tmp-b")
 
     # --- THE CLAIM, FIRST --------------------------------------------------- #
     # 🔴 ORDER IS LOAD-BEARING, and the first draft of this test had it wrong.
-    # With the coverage controls above the claim, removing an `ids=` DROPS the
-    # redaction count, so the control tripped first and the claim below never
-    # executed — the guard went red for a reason that named neither the
-    # offending table nor xdist. A mutant must be killed by the assertion that
-    # OWNS it. The controls still run; they just cannot pre-empt it, and a
-    # vacuous collection (0 ids, no offenders) still fails on them below.
+    # A coverage control placed ABOVE the claim tripped first, so the guard went
+    # red for a reason that named neither the offending table nor xdist. A mutant
+    # must be killed by the assertion that OWNS it. The control still runs; it
+    # just cannot pre-empt this, and a vacuous collection (0 ids, no offenders)
+    # still fails on it below.
     offenders = [i for i in a + b if "ghccg-test-" in i]
     assert not offenders, (
         f"{len(offenders)} collected id(s) embed the per-process scratch dir. "
         "Under xdist every worker gets a different one and the ENTIRE RUN "
         "aborts with a collection mismatch — every open PR in the repo blocked, "
-        "with no test having failed. Give that parametrize an explicit "
-        "`ids=[stable_id(...) ...]`.\n  " + "\n  ".join(o[:200] for o in offenders[:5]))
+        "with no test having failed. Build that path with `scratch(...)`, which "
+        "spells it as `SCRATCH_TOKEN` and is resolved by the drivers.\n  "
+        + "\n  ".join(o[:200] for o in offenders[:5]))
 
     assert a == b, (
         "two processes collected different node ids, so xdist will abort this "
@@ -1938,19 +1951,86 @@ def test_control_no_parametrize_id_can_carry_the_scratch_path(tmp_path):
         "uuid). Differing ids:\n  " +
         "\n  ".join(x[:200] for x in (set(a) ^ set(b)))[:2000])
 
-    # --- COVERAGE CONTROLS, AFTER --------------------------------------------- #
+    # --- COVERAGE CONTROL, AFTER ---------------------------------------------- #
     # A guard that read an empty id list would report a reassuring zero above.
-    # These say the collection happened AND that it reached the at-risk tables.
     assert len(a) >= 400, (
         f"only {len(a)} ids collected — too few for this file; the offender "
         "search above was scanning almost nothing")
-    redacted = [i for i in a if "<scratch>" in i]
-    assert len(redacted) >= 3, (
-        "fewer than 3 collected ids carry the '<scratch>' redaction token, so "
-        "the offender search above is watching less than it was written for. "
-        "Either `stable_id` stopped being applied to a table that needs it, or "
-        "the tables stopped using `scratch(...)` — check which before relaxing "
-        f"this number. ids carrying the token: {redacted}")
+
+    # 🔴 THE `<scratch>` REDACTION CONTROL THAT USED TO SIT HERE IS RETIRED, AND
+    # NOT AS DEAD CODE — it was INCOMPATIBLE with fixing the values. It asserted
+    # `len([i for i in a if "<scratch>" in i]) >= 3`, i.e. that at least three ids
+    # had needed redacting, which is an assertion that the per-process path IS
+    # still in the tables. Any later value-level fix therefore had to turn it red
+    # to land. Its coverage is not lost: what it was really watching — that the
+    # at-risk tables are still reached — is now pinned positively by
+    # `test_no_parametrize_VALUE_carries_the_per_run_scratch_PATH`, which walks
+    # the values themselves and carries its own `> 300` positive control.
+
+
+# =========================================================================== #
+# 🔴 THE VALUE HALF — what an id-level check CANNOT see, by construction.
+#
+# The guard above compares collected IDs, which is the right shape for the
+# failure that took the gate down: workers disagreeing about which tests exist.
+# But an id is only as informative as the label, and a table is free to pin its
+# own (`SAME_LINE_HEREDOC_CASES` passes `ids=[c[0] for c in ...]`). Put a
+# per-process path in THAT table's values and every worker collects an identical
+# id list while executing a different byte string under each name — green, and
+# wrong. That is not hypothetical: it is the state `main` was in at 1d67f5e8,
+# where 10 of 379 parametrize values still interpolated `SCRATCH`.
+#
+# So this pins the VALUES. Together the two guards pin id-level and value-level
+# determinism independently, and neither subsumes the other: mutating a value
+# behind an explicit `ids=` kills only this one.
+# =========================================================================== #
+PARAM_DRIFT_MARK = "PER-RUN SCRATCH PATH IN A parametrize VALUE"
+
+
+def _every_parametrize_value():
+    """(test name, value) for every entry of every `parametrize` table here.
+
+    Read off the decorated functions' own `pytestmark`, NOT off
+    `request.session.items`: `items` holds only what the current invocation
+    SELECTED, so a `-k` or `-x` run would hand this two items and fail its
+    positive control on a tree that is perfectly fine. A guard that goes red on a
+    filtered run is a guard people learn to ignore. (Measured: the first draft
+    read `session.items` and did exactly that under `-k`.)
+    """
+    out = []
+    for name, obj in sorted(globals().items()):
+        if not (name.startswith("test_") and callable(obj)):
+            continue
+        for mark in getattr(obj, "pytestmark", []):
+            if mark.name != "parametrize":
+                continue
+            values = mark.args[1] if len(mark.args) > 1 else mark.kwargs.get(
+                "argvalues", [])
+            out.extend((name, v) for v in values)
+    return out
+
+
+def test_no_parametrize_VALUE_carries_the_per_run_scratch_PATH():
+    """🔴 EVERY WORKER MUST RUN THE SAME BYTES, not merely agree on the names.
+
+    A stable id over a per-process value is the same cross-worker inconsistency
+    with the alarm switched off. This walks the parameters rather than their
+    labels, so an explicit `ids=` cannot hide anything from it."""
+    values = _every_parametrize_value()
+    # POSITIVE CONTROL: an empty walk must not read as a pass. Anchored well
+    # below the real count (379) so an ordinary edit need not touch it.
+    assert len(values) > 300, (
+        f"the parametrize walk found only {len(values)} values in this module — "
+        f"it is measuring nothing")
+    offenders = [(t, v) for t, v in values if SCRATCH in repr(v)]
+    assert not offenders, (
+        f"{PARAM_DRIFT_MARK}: {len(offenders)} parametrize value(s) interpolate "
+        f"the per-run scratch directory {SCRATCH!r}, which differs in every "
+        f"process. Each xdist worker would run DIFFERENT bytes under one id — "
+        f"an id-level check cannot see this. Use `scratch()` (the stable "
+        f"placeholder, resolved by `ev()`/`verdict()`), never "
+        f"`scratch_on_disk()`, in a table.\n"
+        + "\n".join(f"  {t} -> {v!r:.200}" for t, v in offenders[:5]))
 
 
 # =========================================================================== #
@@ -2012,8 +2092,8 @@ def test_the_LAST_body_flag_being_correct_still_passes(cmd):
 def test_a_body_file_beats_a_body_flag_whatever_the_order():
     """`create.go` assigns `opts.Body = string(b)` after `--body` is bound, so the
     FILE is what GitHub renders even when `--body` was written second."""
-    good = scratch("bfile-good.md")
-    bad = scratch("bfile-bad.md")
+    good = scratch_on_disk("bfile-good.md")
+    bad = scratch_on_disk("bfile-bad.md")
     with open(good, "w") as f:
         f.write(CC + "\n")
     with open(bad, "w") as f:
@@ -2039,7 +2119,7 @@ def test_a_correct_body_beside_an_UNREADABLE_body_file_cannot_see_the_body():
     nothing either way; reading the `--body` gh discards is the bypass. The
     verdict must be the CANNOT-SEE one, not "no closing condition" — they are
     different facts."""
-    missing = scratch("bfile-does-not-exist.md")
+    missing = scratch_on_disk("bfile-does-not-exist.md")
     assert not os.path.exists(missing)
     reason = ev(CREATE + " -t t --body " + q(CC) + " --body-file " + missing) or ""
     assert UNSEEABLE_MARK in reason
@@ -2173,8 +2253,8 @@ def test_a_single_curl_data_argument_is_unaffected(cmd):
 def test_only_the_LAST_gh_api_input_answers():
     """`--input` is a pflag `StringVar` in gh api, so a repeat is last-wins for
     exactly the reason `--body` is."""
-    good = scratch("input-good.json")
-    bad = scratch("input-bad.json")
+    good = scratch_on_disk("input-good.json")
+    bad = scratch_on_disk("input-bad.json")
     with open(good, "w") as f:
         json.dump({"title": "t", "body": CC}, f)
     with open(bad, "w") as f:


### PR DESCRIPTION
**Follow-on to #855, not a correction of it.** #855 unbroke a hard-blocked required gate under
time pressure — with both tiers red nothing in the repo could merge — and redacting `SCRATCH`
out of the test IDs was the right call for that job. It worked; `main` has been green since
`1d67f5e8`. This PR closes the residual it deliberately left, and **keeps #855's id-stability
guard**, which is still correct and still worth having.

Rebased onto **`1d67f5e8`** (re-fetched at the moment of rebasing, not taken from a note).

## What was left open

#855 kept `SCRATCH = tempfile.mkdtemp(...)` interpolated into the parametrize tables and pinned
only the labels. Probe: import the module, walk every `parametrize` mark's `argvalues` off the
decorated functions' `pytestmark`, count values whose `repr` contains the module's own `SCRATCH`.

| tree | parametrize values examined | carrying the per-process path |
|---|---|---|
| `200e6383` (before #855) | 379 | 10 |
| **`1d67f5e8` (`main`, with #855)** | 379 | **10 — unchanged** |
| this branch `3f4d0224` | 379 | **0** |

The ids agree, so xdist collects consistently and the gate is green — but **every worker executes
a different byte string under one shared id**, and a node id no longer names what ran, so
re-running a failing id reproduces something else.

**An id-level guard cannot see this, by construction.** `SAME_LINE_HEREDOC_CASES` passes
`ids=[c[0] for c in ...]`, so a per-process path in *its* values collides with nothing and no
id-level check can ever notice. **Seven of the ten offenders are in that table.**

## The fix

Keep the random directory — several cases assert a verdict that depends on a body-file path
**not** existing, so a fixed name makes those a claim about this machine's `/tmp` and would
collide between the concurrent gate runs this box hosts. Keep its **name** out of the tables
instead:

- `scratch()` returns a stable placeholder (`SCRATCH_TOKEN`); `ev()` and `verdict()` substitute
  the real directory at call time. Id **and** executed bytes are then identical in every worker.
- `scratch_on_disk()` is the real path — 5 call sites, the tests that `open()` or
  `os.path.exists()` the file.
- `scratch()`, the spelling anyone adding a table reaches for, is the safe one by default.
- `stable_id()` retired: with deterministic values it has nothing to redact, and the three
  `ids=[stable_id(...)]` lists go with it.

### 🔴 Why the `<scratch>` redaction control had to go — incompatible, not merely redundant

This is the part worth reading. #855's control asserted:

```python
redacted = [i for i in a if "<scratch>" in i]
assert len(redacted) >= 3
```

That asserts **at least three ids still needed redacting** — i.e. that the per-process path *is*
still present in the tables. It pins the randomness as a required property. **Any later
value-level fix had to turn it red in order to land.** It was not dead code left behind; it was a
latch holding the residual open.

Its real subject — *are the at-risk tables still being reached?* — is now pinned **positively**
by the new guard's own `> 300` positive control, which fails if the walk sees nothing.

## The two guards, and why neither subsumes the other

| guard | owner | pins |
|---|---|---|
| `test_control_no_parametrize_id_can_carry_the_scratch_path` | #855, **kept** | id-level determinism — two fresh processes with different `TMPDIR`s must collect identical id lists |
| `test_no_parametrize_VALUE_carries_the_per_run_scratch_PATH` | this PR | value-level determinism — no `parametrize` value may interpolate the per-run directory |

The value guard reads `pytestmark`, not `request.session.items`, deliberately: `items` holds only
what the invocation *selected*, so a `-k` or `-x` run would trip its positive control on a healthy
tree. (Measured — the first draft did exactly that.) A guard that goes red on a filtered run is one
people learn to ignore.

## Control pair — on the rebased branch

Target file. `run-tests.sh` uses `-n <nproc, capped 4> --dist loadfile`.

| | base `1d67f5e8` | this branch `3f4d0224` |
|---|---|---|
| serial | **475 passed** | **476 passed** |
| `-n 4 --dist loadfile` | **475 passed** | **476 passed** |

**+1 is exactly the new value guard.** No case added, removed, renamed or weakened — the three
`ids=` removals change how ids are *spelled*, not which cases exist. (474 at `200e6383`, +1 from
#855's guard = 475, +1 here = 476.)

## Red at base, green at HEAD

The new guard grafted onto `1d67f5e8` — i.e. **with #855's id fix already in** — and watched fail:

```
1 failed, 475 passed
PER-RUN SCRATCH PATH IN A parametrize VALUE: 10 parametrize value(s) interpolate the
  per-run scratch directory '/tmp/nix-shell.gEGikD/ghccg-test-4h_2us99'
```

That is the matrix that matters: **#855's id guard passes among those 475 while the value hazard
is still fully present.** The two are measuring different things.

## Mutation results — on the rebased HEAD, both guards present

Isolated `git archive HEAD` sandbox, `PYTHONDONTWRITEBYTECODE=1` **and** `__pycache__` wiped
between mutants (CPython validates cached bytecode on whole-second mtime + size, so a same-length
edit inside one second is scored SURVIVED without executing). Each mutant flips one table entry
from `scratch(...)` to `scratch_on_disk(...)` — the narrowest expression that can be wrong.

| mutant | result |
|---|---|
| **control** (unmutated) | `476 passed` — neither guard fires spuriously |
| **M1** `REALISTIC_ALLOWS` `allow.md` — reaches an id | `2 failed, 474 passed` — **both** guards, each with its own message: `4 collected id(s) embed the per-process scratch dir` and `PER-RUN SCRATCH PATH IN A parametrize VALUE: 2 parametrize value(s)` |
| **M2** `SAME_LINE_HEREDOC_CASES` `sl-and.md` — hidden behind an explicit `ids=` | `1 failed, 475 passed` — **only** the value guard: `PER-RUN SCRATCH PATH IN A parametrize VALUE: 1 parametrize value(s)` |
| **restored** | `476 passed` |

M1 is the known-caught positive control. **M2 is the load-bearing one:** #855's id guard *passes*
there, so the two guards demonstrably do not subsume each other, and nothing earlier
short-circuits the value guard — it executes and fails on its own assertion.

## Sweep for the same class elsewhere

Measured, not a grep count of declarations: `pytest --collect-only -q scripts` twice, diffed.
**16,329 tests across `scripts/`; 284 test modules on disk; 28 matched the crude
`mkdtemp|NamedTemporaryFile|gettempdir|TemporaryDirectory|uuid4|getpid|random.` grep.** The only
ids that differed between collections were the 3 in this module. No other module bakes a
per-process value into a parametrize id, so there is no follow-on to file.

## Gates — both tiers, base `1d67f5e8`

**Tier 1 — dev host, `scripts/gate.sh`** (base `1d67f5e8`) — `GATE: RESULT=PASS exit=0`

```
PASS  pytest  exit=0  verdict='RESULT: PASS (exit=0)'
PASS  node    exit=0  verdict='RESULT: PASS (exit=0)'
TOTAL collected=16646  passed=16644  skipped=2  failed=0  (floor: 15789 = sum of 28 per-target floors)
TOTAL suites=5 files=39 tests=1292 pass=1292 fail=0 skipped=0  (floor: 1239)
```

⚠️ The first attempt exited **3** with `run-tests: FATAL — required tool(s) missing from PATH:
logrotate`. That is run-tests.sh's **environment** code (2 is the repo-content code), and it was a
fact about my invocation — I ran it from the plain login shell instead of the devShell that carries
`gateTools`. Re-run under `nix develop`, it passes. Recorded rather than quietly re-run, because an
exit 3 reads like a broken change at a glance.

**Tier 2 — the sandbox tier Tekton gates on** (base `1d67f5e8`) — both `RESULT: PASS (exit=0)`

```
nix build .#checks.x86_64-linux.pytests
  parallelism =4 pytest worker(s) (-n 4 --dist loadfile)
  PASS  scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py
        (collected=476 passed=476 skipped=0 floor=451)
  TOTAL collected=16646  passed=16644  skipped=2  failed=0
  RESULT: PASS (exit=0)

nix build .#checks.x86_64-linux.nodetests
  TOTAL suites=5 files=39 tests=1292 pass=1292 fail=0 skipped=0
  RESULT: PASS (exit=0)
```

Read from `nix log` **content**, never exit codes: the base build earlier in this investigation
reported `RC=0` through a `| tail` wrapper over a genuinely failed derivation, which is the exact
trap `CLAUDE.md` documents.

## What I did NOT verify

- **`main` moved to `1d613e1c` after the tiers ran.** Both tiers were run on this branch based on
  `1d67f5e8`. The intervening commit (#856) is docs-only — one file,
  `claudedocs/proposal-subsystem-store-homelab.md` — with no overlap with this diff, and it passed
  both required checks itself. `git merge-tree --write-tree HEAD origin/main` exits **0**, so the
  merge is clean. But I did not re-run either tier on the merged tree after `main` advanced;
  `strict: false` means a green check here is a claim about this branch, not about that tree.
- Pre-PR sweep was done **by file touched**, not by branch name — that is how #855 slipped past the
  claim ref, since the lock is per-slug and two sessions naming the same work differently never
  collide. All open PRs were enumerated and their file lists checked: **no other open PR touches
  `test_gh_issue_closing_condition_guard.py`.** This diff is 1 file, and touches none of
  `scripts/lib/nix_read_paths.sh`, `scripts/ship.sh`, `scripts/drift-check.sh` (#857's files).
