### PR TITLE
fix(nolaunch): stamp every recorded launch with its xdist worker id — the KNOWN RACE closed without touching the runner's ledger

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2889,8 +2889,22 @@ _count_of() { # $1 = alternation regex, $2 = summary line
 # ⚠ What loadfile does NOT buy, stated so nobody reads more into it: it pins
 # INTRA-file co-location only. State shared ACROSS files — the run-wide launch
 # log, the spool ledger, the nogit guard config — is still touched by every
-# worker concurrently. See the KNOWN RACE note in scripts/tests/
-# test_no_real_launchers.py.
+# worker concurrently.
+#
+# For the LAUNCH LOG that is now handled rather than merely known: every line it
+# records carries the writing worker's id as its SECOND field
+# (`systemctl(blocked) [gw2] …`), and `testlib.nolaunch`'s readers filter on it,
+# so a test's `before + 1` is a claim about its OWN worker again. Read
+# `scripts/testlib/nolaunch.py`'s module docstring before changing the log
+# format — in particular, the tag may NOT move to line start, because the GUARD
+# 7 evaluation block below classifies this file with ^-anchored greps on the
+# FIRST token. NOTHING IN THIS SCRIPT NEEDED TO CHANGE for that fix, and the
+# reason is `NOLAUNCH_SEEN`: it brackets a whole pytest invocation by line
+# offset and all N workers run inside that bracket for the SAME target, so an
+# interleaved sibling-worker line already belongs to the right target.
+#
+# The spool ledger and the nogit guard config are NOT covered by that and remain
+# as described above.
 #
 # 🔴 NESTED RUNS MUST BE SERIAL, and the signal is PYTEST_CURRENT_TEST.
 # Tests in scripts/tests SPAWN THIS SCRIPT (test_run_tests_floors.py and the .sh

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2891,10 +2891,13 @@ _count_of() { # $1 = alternation regex, $2 = summary line
 # log, the spool ledger, the nogit guard config — is still touched by every
 # worker concurrently.
 #
-# For the LAUNCH LOG that is now handled rather than merely known: every line it
-# records carries the writing worker's id as its SECOND field
+# For the LAUNCH LOG that is now handled rather than merely known: every
+# INTERCEPT line it records carries the writing worker's id as its SECOND field
 # (`systemctl(blocked) [gw2] …`), and `testlib.nolaunch`'s readers filter on it,
-# so a test's `before + 1` is a claim about its OWN worker again. Read
+# so a test's `before + 1` is a claim about its OWN worker again. ⚠ The one
+# exception, because `recorded()`'s contract is careful about it and this
+# comment must be too: the `nolaunch(session)` MARKER is deliberately UNTAGGED —
+# its attribution is owned right here, by the per-target count below. Read
 # `scripts/testlib/nolaunch.py`'s module docstring before changing the log
 # format — in particular, the tag may NOT move to line start, because the GUARD
 # 7 evaluation block below classifies this file with ^-anchored greps on the

--- a/scripts/testlib/nolaunch.py
+++ b/scripts/testlib/nolaunch.py
@@ -209,9 +209,27 @@ SERIAL_WORKER = "main"
 THIS_WORKER = "<this>"
 ALL_WORKERS = "<all>"
 
-# `<classifier> [<tag>] <argv…>`. Anchored, and the tag may not contain a space
-# or a `]`, so an argv that happens to contain a bracketed word cannot be read
-# as the tag.
+# `<classifier> [<tag>] <argv…>` — the tag is the SECOND field and nothing else
+# is. What each piece actually does, stated at the width it is pinned to (see
+# `test_the_readers_default_to_this_worker_and_can_still_see_everything`):
+#
+#   `^\S+ `      the classifier token, then exactly one space. This is what
+#                stops a bracketed word LATER in the argv from being read as the
+#                tag — `notify-send [gw1] -t 2500 [not-a-tag]` yields `gw1`.
+#   `[^\]\s]+`   the tag itself: no `]` (it would swallow the delimiter) and no
+#                whitespace. The `\s` half is the conservative parse of a
+#                MALFORMED field, not a live case: pytest-xdist ids are `gw<N>`
+#                and `SERIAL_WORKER` is a literal, so neither can contain a
+#                space. ⚠ THE BOUNDED CONSEQUENCE, stated because it is a silent
+#                zero and not obvious: if somebody exports
+#                `PYTEST_XDIST_WORKER="gw 1"`, the stub writes `[gw 1]` and this
+#                reads the line as UNTAGGED, so a filtered `recorded()` will not
+#                return it even though `worker_tag()` would say `gw 1`. That
+#                asymmetry is pinned rather than fixed — normalising here would
+#                have to be mirrored in the sh stub, and two spellings of one
+#                rule is the bug this module already exists to avoid.
+#   trailing ` ` the delimiter must be followed by the argv separator, so
+#                `notify-send [gw1]nospace` is not a tagged line.
 _TAGGED = re.compile(r"^\S+ \[([^\]\s]+)\] ")
 
 # The POSIX-sh expression the stubs expand to get their own tag. Assembled from
@@ -232,6 +250,14 @@ def worker_tag() -> str:
     Read at call time, never cached: `nolaunch` is imported once per pytest
     worker but the value is a property of the process, and a cached module-level
     constant would be captured before a nested session could change it.
+
+    🔴 `or`, NOT `os.environ.get(WORKER_ENV, SERIAL_WORKER)`. The two differ on
+    exactly one input — the variable SET TO EMPTY — and `or` is the one that
+    agrees with the sh stub's `${PYTEST_XDIST_WORKER:-main}`, which also falls
+    back on empty. `get(..., default)` would make Python read `""` while the
+    stub wrote `[main]`, so every filtered read would return nothing while the
+    log looked perfectly well-formed. Pinned by
+    `test_the_stub_takes_its_tag_from_the_xdist_worker_variable`.
     """
     return os.environ.get(WORKER_ENV) or SERIAL_WORKER
 

--- a/scripts/testlib/nolaunch.py
+++ b/scripts/testlib/nolaunch.py
@@ -99,9 +99,55 @@ The principle is NOT "never install a stub where no real binary exists" — it i
 (or one with only flags) has no verb, so it is recorded and swallowed with exit
 0 and no output, where the real binary would list units. Every call site in
 this tree passes a verb.
+
+🔴 EVERY LINE CARRIES THE WRITER'S pytest-xdist WORKER ID — AND WHY
+-------------------------------------------------------------------
+There is ONE run-wide log, shared by every target and, since #841, by every
+xdist worker inside a target. `run-tests.sh` runs each pytest target
+`-n N --dist loadfile`. `loadfile` keeps one FILE's tests on one worker, so a
+file does not race itself — but the ~8 sibling files in `scripts/tests` that
+also invoke `systemctl`/`openrgb`/`systemd-run`/`notify-send` run on SIBLING
+workers and append to this same file. Measured composition of the log for a
+9-file subset at `-n 4`: 23 `systemctl(blocked)`, 9 `openrgb`, 8 `systemd-run`,
+8 `notify-send` foreign lines per run.
+
+That breaks the shape every assertion here uses:
+
+    before = len(blocked_systemctl(stub_dir))   # sample
+    ...do the thing...                          # <- a sibling worker appends
+    assert len(blocked_systemctl(stub_dir)) == before + 1
+
+`before + 1` is a claim about THIS worker's launches, measured against a
+counter every worker increments. A few-ms window on a REQUIRED gate, and it
+presents as an unrelated test failing for no reason.
+
+So the stub stamps the tag INTO the line and the readers filter on it. Two
+things that look arbitrary are not:
+
+  * THE TAG IS THE SECOND FIELD, NEVER THE FIRST. `run-tests.sh` classifies
+    this log with THREE `^`-anchored greps on the FIRST token — one counting
+    `nolaunch(session)` markers, one counting `systemctl(read)` passthroughs,
+    and one selecting everything that is neither as a launcher HIT — and
+    `blocked_systemctl` below uses `startswith("systemctl(blocked)")`. A tag at
+    line start would silently reclassify the marker and every read as a real
+    launcher reach and fail the run. The patterns themselves are not restated
+    here: `test_the_runners_anchored_classifiers_still_match_the_tagged_format`
+    reads them OUT of run-tests.sh and runs them against a log this tree wrote.
+  * THE RUNNER'S LEDGER NEEDS NO CHANGE. `NOLAUNCH_SEEN` brackets a WHOLE
+    pytest invocation by line offset (`nl_before+1 .. nl_after`), and all N
+    workers run inside that bracket for the SAME target, so an interleaved
+    sibling-worker line already belongs to the correct target. That is why
+    this is a tag in one shared log rather than per-worker log FILES — those
+    WOULD need the ledger model changed.
+
+Serial runs (`DEVRC_TEST_JOBS=1`, a bare `pytest`, and every NON-pytest target
+the runner starts) have no `PYTEST_XDIST_WORKER`, so they tag `main` — one
+namespace, and the filter is a no-op there rather than a special case.
 """
 from __future__ import annotations
 
+import os
+import re
 import shutil
 from pathlib import Path
 
@@ -145,10 +191,60 @@ SYSTEMCTL_READ_FLAGS = ("--version", "--help", "-h")
 
 LOG_NAME = "launches.log"
 
+# pytest-xdist exports this into each WORKER process, and a child shell inherits
+# it. MEASURED (6 files, `-n 4 --dist loadfile`): four distinct ids `gw0`..`gw3`
+# reached a `sh -c` child; the same suite run serially left it UNSET there.
+WORKER_ENV = "PYTEST_XDIST_WORKER"
+
+# The tag used when `WORKER_ENV` is absent: a serial pytest run, or one of the
+# NON-pytest targets (`HOOK_TESTS`, `SHELL_TESTS`) that reach the stubs through
+# PATH with no plugin at all. A name, not an empty string, so every line has a
+# tag in the same position and the parser never has to special-case one.
+SERIAL_WORKER = "main"
+
+# `worker=` sentinels for the readers below. Neither can collide with a real tag
+# — pytest-xdist ids are `gw<N>` and `SERIAL_WORKER` is a bare word — so passing
+# one can never be confused with asking for a worker that happens to be called
+# that.
+THIS_WORKER = "<this>"
+ALL_WORKERS = "<all>"
+
+# `<classifier> [<tag>] <argv…>`. Anchored, and the tag may not contain a space
+# or a `]`, so an argv that happens to contain a bracketed word cannot be read
+# as the tag.
+_TAGGED = re.compile(r"^\S+ \[([^\]\s]+)\] ")
+
+# The POSIX-sh expression the stubs expand to get their own tag. Assembled from
+# the constants above so the shell and the Python reader cannot drift apart on
+# the variable name or the fallback — the one thing a copy would get wrong
+# silently, because a stub tagged `main` under xdist still LOOKS well-formed.
+_WORKER_SH = '"${' + WORKER_ENV + ':-' + SERIAL_WORKER + '}"'
+
 
 def log_path(stub_dir: Path) -> Path:
     """Where `install(stub_dir)` records intercepted argv, one line per launch."""
     return Path(stub_dir) / LOG_NAME
+
+
+def worker_tag() -> str:
+    """The tag THIS process's launches are stamped with.
+
+    Read at call time, never cached: `nolaunch` is imported once per pytest
+    worker but the value is a property of the process, and a cached module-level
+    constant would be captured before a nested session could change it.
+    """
+    return os.environ.get(WORKER_ENV) or SERIAL_WORKER
+
+
+def line_worker(line: str) -> str | None:
+    """The worker tag a recorded line carries, or None if it carries none.
+
+    None is the honest answer for the plugin's `nolaunch(session)` marker, which
+    is deliberately NOT tagged: `run-tests.sh` counts it per TARGET (one per
+    worker that ran a test) and owns that accounting.
+    """
+    m = _TAGGED.match(line)
+    return m.group(1) if m else None
 
 
 def launcher_body(name: str, log: Path) -> str:
@@ -161,10 +257,19 @@ def launcher_body(name: str, log: Path) -> str:
 
     🔴 And RECORDING IS ALL IT DOES. The guard test pins this text against a
     literal copy of itself, because a stub that records correctly AND has a side
-    effect passes every behavioural assertion in the suite.
+    effect passes every behavioural assertion in the suite. That pin lives in
+    `scripts/tests/test_no_real_launchers.py::test_a_stub_does_nothing_but_record`
+    and spells the expectation out by hand — deriving it from here would make a
+    mutation of this function invisible to it.
+
+    🔴 The `[$worker]` field is the second one, never the first: `run-tests.sh`
+    classifies this log with `^`-anchored greps on the FIRST token. See the
+    module docstring.
     """
-    return 'printf \'%s %s\\n\' "{name}" "$*" >> "{log}"\nexit 0\n'.format(
-        name=name, log=log)
+    return (
+        "printf '%s [%s] %s\\n' \"{name}\" {worker} \"$*\" >> \"{log}\"\n"
+        "exit 0\n"
+    ).format(name=name, worker=_WORKER_SH, log=log)
 
 
 def systemctl_body(real: str, log: Path) -> str:
@@ -195,13 +300,14 @@ def systemctl_body(real: str, log: Path) -> str:
     """
     verbs = "|".join(SYSTEMCTL_READ_VERBS)
     flags = "|".join(SYSTEMCTL_READ_FLAGS)
+    w = _WORKER_SH
     return (
         # Position-independent read flags first: they print and exit whatever
         # else is on the line.
         'for a in "$@"; do\n'
         '  case "$a" in\n'
         f'    {flags})\n'
-        f'      printf \'%s %s\\n\' "systemctl(read)" "$*" >> "{log}"\n'
+        f'      printf \'%s [%s] %s\\n\' "systemctl(read)" {w} "$*" >> "{log}"\n'
         f'      exec "{real}" "$@" ;;\n'
         '  esac\n'
         'done\n'
@@ -218,10 +324,10 @@ def systemctl_body(real: str, log: Path) -> str:
         'done\n'
         'case "$verb" in\n'
         f'  {verbs})\n'
-        f'    printf \'%s %s\\n\' "systemctl(read)" "$*" >> "{log}"\n'
+        f'    printf \'%s [%s] %s\\n\' "systemctl(read)" {w} "$*" >> "{log}"\n'
         f'    exec "{real}" "$@" ;;\n'
         'esac\n'
-        f'printf \'%s %s\\n\' "systemctl(blocked)" "$*" >> "{log}"\n'
+        f'printf \'%s [%s] %s\\n\' "systemctl(blocked)" {w} "$*" >> "{log}"\n'
         'exit 0\n'
     )
 
@@ -252,17 +358,42 @@ def install(stub_dir: Path) -> Path:
     return log
 
 
-def recorded(stub_dir: Path) -> list[str]:
-    """Every intercepted launch so far, as `<name> <argv…>` lines."""
+def recorded(stub_dir: Path, worker: str = THIS_WORKER) -> list[str]:
+    """Intercepted launches, as `<name> [<worker>] <argv…>` lines.
+
+    🔴 THE DEFAULT IS THIS WORKER'S LINES ONLY, AND THAT IS THE SAFE DIRECTION.
+    Every caller in the tree uses the `before = len(recorded(...)) / … / ==
+    before + 1` shape, which is a claim about launches THIS test made; against
+    the unfiltered log that claim is measured on a counter three sibling xdist
+    workers also increment (see the module docstring). Defaulting to unfiltered
+    would leave the race armed for the next test somebody writes, which is the
+    same shape as the bug this exists to close.
+
+    Pass `worker=ALL_WORKERS` for the whole log — the report/inspection view,
+    and the only honest answer to "did anything at all get intercepted". Pass a
+    literal tag (`"gw2"`) to ask about one specific worker.
+
+    Untagged lines — today only the plugin's `nolaunch(session)` marker — belong
+    to no worker and appear ONLY under `ALL_WORKERS`.
+    """
     log = log_path(stub_dir)
     if not log.exists():
         return []
-    return [ln for ln in log.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    lines = [ln for ln in log.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    if worker == ALL_WORKERS:
+        return lines
+    want = worker_tag() if worker == THIS_WORKER else worker
+    return [ln for ln in lines if line_worker(ln) == want]
 
 
-def blocked_systemctl(stub_dir: Path) -> list[str]:
-    """The recorded systemctl calls that were SWALLOWED rather than executed."""
-    return [ln for ln in recorded(stub_dir) if ln.startswith("systemctl(blocked)")]
+def blocked_systemctl(stub_dir: Path, worker: str = THIS_WORKER) -> list[str]:
+    """The recorded systemctl calls that were SWALLOWED rather than executed.
+
+    Same `worker=` contract as `recorded()`, and for the same reason: every
+    caller counts these before and after an action.
+    """
+    return [ln for ln in recorded(stub_dir, worker)
+            if ln.startswith("systemctl(blocked)")]
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/testlib/nolaunch_plugin.py
+++ b/scripts/testlib/nolaunch_plugin.py
@@ -78,6 +78,12 @@ SESSION_MARKER = "nolaunch(session)"
 
 
 def _log_marker(stub_dir: Path, note: str) -> None:
+    # 🔴 DELIBERATELY NOT `[<worker>]`-TAGGED, unlike every launch line. This
+    # marker is `run-tests.sh`'s per-TARGET positive control — it counts one per
+    # xdist worker that ran a test and compares against `-n N` — so the runner
+    # already owns its attribution and a tag would buy nothing. The consequence,
+    # stated rather than implied: `nolaunch.recorded()` filtered to a worker does
+    # NOT return these; `worker=ALL_WORKERS` does.
     log = nolaunch.log_path(stub_dir)
     log.parent.mkdir(parents=True, exist_ok=True)
     with log.open("a", encoding="utf-8") as fh:
@@ -151,9 +157,16 @@ def _patch_subprocess(stub_dir: Path):
             redirected = _redirect_argv(args, stub_dir)
             if redirected is not None:
                 log = nolaunch.log_path(stub_dir)
+                # 🔴 SAME `[<worker>]` SECOND FIELD as the L1 stubs write. Both
+                # write paths must be tagged or `recorded()`'s per-worker filter
+                # would silently drop the L2 line — an absolute-path reach that
+                # WAS intercepted reading as one that was never seen, which is
+                # the reassuring-zero failure this whole guard exists to avoid.
                 with log.open("a", encoding="utf-8") as fh:
-                    fh.write("%s(abs) %s\n" % (os.path.basename(str(args[0])),
-                                               " ".join(str(x) for x in args[1:])))
+                    fh.write("%s(abs) [%s] %s\n" % (
+                        os.path.basename(str(args[0])),
+                        nolaunch.worker_tag(),
+                        " ".join(str(x) for x in args[1:])))
                 args = redirected
             super().__init__(args, *a, **kw)
 

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -543,6 +543,9 @@ def _private_stubs(tmp_path) -> Path:
     if real is None:
         # What `install()` would have written on a PATH with no stub dir on it:
         # nothing. Never fabricate an answer — the module's own rule.
+        # ⚠ DEFENSIVE, AND UNREACHABLE IN BOTH TIERS TODAY — do not count it as
+        # exercised: on the dev host a real systemctl exists, and in the sandbox
+        # `install()` never wrote a systemctl stub for this branch to remove.
         (stubs / "systemctl").unlink(missing_ok=True)
     else:
         write_exec(stubs / "systemctl",
@@ -728,8 +731,15 @@ def test_the_readers_default_to_this_worker_and_can_still_see_everything(tmp_pat
     # 🔴 `line_worker`'s PARSE, pinned at the width its comment claims — each
     # case below is a piece of the regex that SURVIVES deletion without it.
     # An argv containing a bracketed word must not be mistaken for the tag
-    # (this one is carried by the `^\S+ ` anchor, not by the tag class):
-    assert nolaunch.line_worker("notify-send [gw1] -t 2500 [not-a-tag]") == "gw1"
+    # (this one is carried by the `^\S+ ` anchor, not by the tag class).
+    # 🔴 THE TRAILING ` --urgency low` IS LOAD-BEARING. With the bracketed word
+    # at END of string, `^\S+ ` widened to `^.* ` behaves IDENTICALLY — the
+    # greedy match has to backtrack to the only `] ` there is — so the fixture
+    # could not see the mutant its own comment describes. MEASURED: with the
+    # word at the end, `\S+` → `.*` SURVIVES; with something after it, the
+    # widened form yields `not-a-tag` and this goes red.
+    assert nolaunch.line_worker(
+        "notify-send [gw1] -t 2500 [not-a-tag] --urgency low") == "gw1"
     # The tag class excludes whitespace — a malformed field is NOT a tag, and
     # the module comment names the bounded silent-zero this implies:
     assert nolaunch.line_worker("notify-send [gw 1] hello") is None
@@ -745,13 +755,6 @@ def test_the_readers_default_to_this_worker_and_can_still_see_everything(tmp_pat
     assert nolaunch.line_worker("[gw1] notify-send hello") is None
 
 
-# ⚠ INVARIANT GUARD, not regression coverage: this passes at origin/main too,
-# because there the tag does not exist and the classifiers match trivially. It
-# pins the constraint the tag's PLACEMENT had to satisfy — `run-tests.sh` reads
-# this log with `^`-anchored greps on the FIRST token, so a tag at line START
-# would stop the session marker and every `systemctl(read)` passthrough from
-# matching and report both as real launcher reaches, failing the whole run.
-# Nothing in Python covered those greps before; they are the log's real consumer.
 def _guard7_grep_patterns() -> tuple[str, str, str]:
     """PARSE the three log classifiers out of run-tests.sh's GUARD 7 block.
 
@@ -759,8 +762,15 @@ def _guard7_grep_patterns() -> tuple[str, str, str]:
     `<literal> in runner` substrings and its docstring claimed it "read the
     patterns out of the runner". That was false in the way that matters: a
     substring check cannot notice a FOURTH classifier appearing, and it cannot
-    tell you which pattern the runner actually applies to what. This returns
-    what the runner will run.
+    tell you which pattern the runner actually applies to what.
+
+    🔴 AND THE PARSE ITSELF WAS THEN TOO NARROW — the same shape as the finding
+    it was written to fix, one layer down. It matched only `grep -c '…'` and
+    `grep -vE '…'`, so MEASURED, inserting `grep -cE '^brandnew\\(kind\\)'` into
+    the block left this GREEN. Two things now stand in for "what the runner will
+    run": the quote-and-flag-agnostic pattern extraction below, AND a pin on the
+    SET OF `grep` INVOCATIONS in the block, which catches a new classifier
+    whatever its flags or quoting — including one with no quoted pattern at all.
 
     Scoped to the GUARD 7 evaluation block by its own section banners, so a
     `grep -c` belonging to GUARD 8 or 10 cannot be mistaken for one of these.
@@ -773,17 +783,36 @@ def _guard7_grep_patterns() -> tuple[str, str, str]:
         "banners this parse anchors on — it cannot say what the runner runs, "
         "and a pass here would mean nothing")
     block = runner[start:end]
-    counts = re.findall(r"grep -c '([^']+)'", block)
-    selects = re.findall(r"grep -vE '([^']+)'", block)
-    # Both directions: a classifier added or removed changes what "unclassified
-    # = a real launcher reach" means, which is the whole verdict GUARD 7 emits.
-    assert counts == ["^nolaunch(session)", "^systemctl(read)"], (
-        f"GUARD 7's ^-anchored COUNT classifiers changed: {counts}")
-    assert selects == [r"^(nolaunch\(session\)|systemctl\(read\)|$)"], (
-        f"GUARD 7's HIT selector changed: {selects}")
-    return counts[0], counts[1], selects[0]
+
+    # EVERY grep in the block, by flag, in source order. The fourth is the
+    # unquoted `grep -c .` that counts the hit lines — it takes no classifier
+    # pattern, which is exactly why a pin on quoted patterns alone cannot see a
+    # grep appear or disappear.
+    invocations = re.findall(r"\bgrep\s+(-[\w-]+)", block)
+    assert invocations == ["-c", "-c", "-vE", "-c"], (
+        "GUARD 7 no longer runs exactly these four greps over the launch log. "
+        "A classifier added or removed changes what 'unclassified = a real "
+        f"launcher reach' means, which is the whole verdict it emits: {invocations}")
+
+    # Flag- and quote-agnostic, so `-cE` or a double-quoted pattern is seen.
+    quoted = [(flag, pat) for flag, _q, pat
+              in re.findall(r"\bgrep\s+(-[\w-]+)\s+(['\"])(.+?)\2", block)]
+    assert quoted == [
+        ("-c", "^nolaunch(session)"),
+        ("-c", "^systemctl(read)"),
+        ("-vE", r"^(nolaunch\(session\)|systemctl\(read\)|$)"),
+    ], f"GUARD 7's classifier patterns changed: {quoted}"
+    return quoted[0][1], quoted[1][1], quoted[2][1]
 
 
+# ⚠ INVARIANT GUARD, not regression coverage — THIS TEST, not the helper above.
+# It passes at origin/main too, because there the tag does not exist and the
+# classifiers match trivially. It pins the constraint the tag's PLACEMENT had to
+# satisfy — `run-tests.sh` reads this log with `^`-anchored greps on the FIRST
+# token, so a tag at line START would stop the session marker and every
+# `systemctl(read)` passthrough from matching and report both as real launcher
+# reaches, failing the whole run. Nothing in Python covered those greps before;
+# they are the log's real consumer.
 def test_the_runners_anchored_classifiers_still_match_the_tagged_format(tmp_path):
     """Run `run-tests.sh`'s OWN grep patterns against a log this tree produced.
 
@@ -804,12 +833,27 @@ def test_the_runners_anchored_classifiers_still_match_the_tagged_format(tmp_path
     # classifies by their first token, so a hand-written copy stays in the old
     # format under the very mutation this test exists to catch — MEASURED, an
     # earlier draft of this test stayed green under a tag-at-line-start mutant.
+    #
+    # 🔴 AND EVERY STUB IS DRIVEN UNDER A PROBE TAG, NOT THE AMBIENT ONE. This
+    # is the fixture trap from claude/RULES.md, measured here: comparing against
+    # `worker_tag()` collapses to the literal `main` in ANY serial run, which is
+    # the same constant the sh stub falls back to — so `w = _WORKER_SH` mutated
+    # to `w = '"main"'` in `systemctl_body` SURVIVED the whole suite serially
+    # (90 passed) and died only under `-n 2`. A fixture that can only ever
+    # produce the constant's own value cannot see a mutant that hardcodes the
+    # literal. `gwSYSPROBE` is a value `SERIAL_WORKER` CANNOT equal, so this
+    # test now measures the same thing whichever way the suite is invoked.
+    # (`launcher_body` has the equivalent control via `gw7` plus a literal-text
+    # pin, and the L2 layer via `gwABSPROBE`; this was the branch without one.)
+    probe = "gwSYSPROBE"
+    assert probe != nolaunch.SERIAL_WORKER
     stubs = _private_stubs(tmp_path)
     log = nolaunch.log_path(stubs)
     from testlib import nolaunch_plugin
     nolaunch_plugin._log_marker(stubs, "scripts/tests -q")
     for cmd in ("notify-send a-toast", "systemd-run --user --unit=u true"):
-        assert _through_a_shell(stubs, cmd).returncode == 0
+        assert _through_a_shell(
+            stubs, cmd, PYTEST_XDIST_WORKER=probe).returncode == 0
     # The systemctl stub, generated by `systemctl_body` and pointed at a
     # passthrough target of our own — so ALL THREE of its branches run in BOTH
     # tiers, where `install()` writes no systemctl stub at all when the host has
@@ -820,9 +864,11 @@ def test_the_runners_anchored_classifiers_still_match_the_tagged_format(tmp_path
     write_exec(passthrough, "exit 0\n")
     write_exec(stubs / "systemctl",
                nolaunch.systemctl_body(str(passthrough), log))
-    assert _through_a_shell(stubs, "systemctl --user status u").returncode == 0
-    assert _through_a_shell(stubs, "systemctl --user stop u").returncode == 0
-    assert _through_a_shell(stubs, "systemctl --version").returncode == 0
+    for cmd in ("systemctl --user status u",      # VERB read
+                "systemctl --user stop u",        # mutating -> blocked
+                "systemctl --version"):           # position-independent FLAG read
+        assert _through_a_shell(
+            stubs, cmd, PYTEST_XDIST_WORKER=probe).returncode == 0
 
     def _grep(args):
         p = subprocess.run([grep, *args, str(log)], stdout=subprocess.PIPE,
@@ -846,11 +892,10 @@ def test_the_runners_anchored_classifiers_still_match_the_tagged_format(tmp_path
     # identical mutation of its `systemctl(blocked)` sibling was killed. Both
     # read branches are covered: `--user status u` is the VERB one and
     # `--version` is the position-independent FLAG one.
-    assert [nolaunch.line_worker(ln) for ln in reads] == [
-        nolaunch.worker_tag(), nolaunch.worker_tag()], (
-        "a `systemctl(read)` line lost its [worker] tag. It still classifies "
-        "correctly for the runner, so nothing in run-tests.sh notices — but "
-        f"every per-worker read drops it silently: {reads}")
+    assert [nolaunch.line_worker(ln) for ln in reads] == [probe, probe], (
+        "a `systemctl(read)` line did not carry the worker id its stub was RUN "
+        "under. It still classifies correctly for the runner, so nothing in "
+        f"run-tests.sh notices — but every per-worker read drops it: {reads}")
 
     hits = _grep(["-vE", hit_pat])
     assert len(hits) == 3, (
@@ -860,7 +905,9 @@ def test_the_runners_anchored_classifiers_still_match_the_tagged_format(tmp_path
         f"that:\n{hits}")
     assert sorted(ln.split(" [", 1)[0] for ln in hits) == [
         "notify-send", "systemctl(blocked)", "systemd-run"], hits
-    assert all(nolaunch.line_worker(ln) == nolaunch.worker_tag() for ln in hits), hits
+    # Same probe tag, same reason: `systemctl(blocked)` and the two record-only
+    # launchers each have their own printf, so each is its own mutation site.
+    assert [nolaunch.line_worker(ln) for ln in hits] == [probe] * 3, hits
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -525,9 +525,35 @@ def _private_stubs(tmp_path) -> Path:
     `run-tests.sh`'s GUARD 7 accounting as a real launcher reach, and would move
     the `before` sample of every other test in this file. (2) They all assert an
     EXACT total, which the shared log can never offer.
+
+    🔴 AND THE `systemctl` STUB IS RE-POINTED, not left as `install()` wrote it.
+    `install()` resolves "the real systemctl" through `shutil.which`, and by the
+    time any test runs, PATH[0] is the SESSION stub dir — so a plain `install()`
+    here writes a systemctl stub whose read branch execs the SESSION stub, which
+    records into the SESSION log. `install()`'s own self-exec assertion cannot
+    catch that: it only compares against the dir being installed into, and these
+    are two different dirs. Inert today (only the classifier test invokes
+    systemctl, and it overwrites this file first) — closed anyway, because the
+    next test to call `systemctl` through this helper would silently measure the
+    wrong file and read as a passing test.
     """
     stubs = tmp_path / "own-stubs"
     nolaunch.install(stubs)
+    real = _real_binary("systemctl")
+    if real is None:
+        # What `install()` would have written on a PATH with no stub dir on it:
+        # nothing. Never fabricate an answer — the module's own rule.
+        (stubs / "systemctl").unlink(missing_ok=True)
+    else:
+        write_exec(stubs / "systemctl",
+                   nolaunch.systemctl_body(real, nolaunch.log_path(stubs)))
+    sysctl = stubs / "systemctl"
+    if sysctl.exists():
+        body = sysctl.read_text(encoding="utf-8")
+        assert str(_stub_dir_from_env()) not in body, (
+            "this private stub dir's systemctl still chains into the SESSION "
+            "stub dir, so a read verb through it would exec the session stub "
+            f"and be recorded in the wrong log:\n{body}")
     return stubs
 
 
@@ -628,10 +654,32 @@ def test_the_stub_takes_its_tag_from_the_xdist_worker_variable(tmp_path):
                        text=True, timeout=15, env=env)
     assert q.returncode == 0, f"{q.stdout}{q.stderr}"
 
+    # 🔴 Point 3, THE BOUNDARY BETWEEN THEM: set-but-EMPTY. Neither of the two
+    # points above can see it, and it is where the shell and Python spellings
+    # can silently disagree — `${PYTEST_XDIST_WORKER:-main}` falls back on
+    # empty, and so must `worker_tag()`. MEASURED: rewriting that `or` as
+    # `os.environ.get(WORKER_ENV, SERIAL_WORKER)` SURVIVES a set/unset-only
+    # test, and would then have Python looking for `""` while the stub wrote
+    # `[main]` — every filtered read empty, every line well-formed.
+    r = _through_a_shell(stubs, "openrgb --empty-worker", PYTEST_XDIST_WORKER="")
+    assert r.returncode == 0, f"{r.stdout}{r.stderr}"
+    prev = os.environ.get("PYTEST_XDIST_WORKER")
+    os.environ["PYTEST_XDIST_WORKER"] = ""
+    try:
+        assert nolaunch.worker_tag() == nolaunch.SERIAL_WORKER, (
+            "an EMPTY PYTEST_XDIST_WORKER made Python disagree with the stub: "
+            "the sh `:-` fallback wrote the serial tag and this did not")
+    finally:
+        if prev is None:
+            os.environ.pop("PYTEST_XDIST_WORKER", None)
+        else:
+            os.environ["PYTEST_XDIST_WORKER"] = prev
+
     every = nolaunch.recorded(stubs, worker=nolaunch.ALL_WORKERS)
     assert every == [
         "openrgb [gw7] --under-a-worker",
         f"openrgb [{nolaunch.SERIAL_WORKER}] --serial",
+        f"openrgb [{nolaunch.SERIAL_WORKER}] --empty-worker",
     ], every
     assert nolaunch.recorded(stubs, worker="gw7") == [
         "openrgb [gw7] --under-a-worker"], every
@@ -677,8 +725,24 @@ def test_the_readers_default_to_this_worker_and_can_still_see_everything(tmp_pat
     ]
     assert nolaunch.line_worker("nolaunch(session) scripts/tests -q") is None
     assert nolaunch.line_worker("i3-msg(abs) [gwZ] workspace 9") == "gwZ"
-    # An argv containing a bracketed word must not be mistaken for the tag.
+    # 🔴 `line_worker`'s PARSE, pinned at the width its comment claims — each
+    # case below is a piece of the regex that SURVIVES deletion without it.
+    # An argv containing a bracketed word must not be mistaken for the tag
+    # (this one is carried by the `^\S+ ` anchor, not by the tag class):
     assert nolaunch.line_worker("notify-send [gw1] -t 2500 [not-a-tag]") == "gw1"
+    # The tag class excludes whitespace — a malformed field is NOT a tag, and
+    # the module comment names the bounded silent-zero this implies:
+    assert nolaunch.line_worker("notify-send [gw 1] hello") is None
+    # …and excludes `]`, so the tag cannot swallow its own delimiter and keep
+    # hunting for a later one. Without that exclusion this yields `gw]x`:
+    assert nolaunch.line_worker("notify-send [gw]x] hello") is None
+    # The ordinary well-formed shape still parses, so the case above is a
+    # rejection of malformed input and not the class being broken outright:
+    assert nolaunch.line_worker("notify-send [gw] hello") == "gw"
+    # The delimiter must be followed by the argv separator:
+    assert nolaunch.line_worker("notify-send [gw1]nospace") is None
+    # A missing classifier token is not a tagged line either:
+    assert nolaunch.line_worker("[gw1] notify-send hello") is None
 
 
 # ⚠ INVARIANT GUARD, not regression coverage: this passes at origin/main too,
@@ -688,25 +752,46 @@ def test_the_readers_default_to_this_worker_and_can_still_see_everything(tmp_pat
 # would stop the session marker and every `systemctl(read)` passthrough from
 # matching and report both as real launcher reaches, failing the whole run.
 # Nothing in Python covered those greps before; they are the log's real consumer.
+def _guard7_grep_patterns() -> tuple[str, str, str]:
+    """PARSE the three log classifiers out of run-tests.sh's GUARD 7 block.
+
+    🔴 EXTRACTED, not copied — an earlier version of this helper asserted three
+    `<literal> in runner` substrings and its docstring claimed it "read the
+    patterns out of the runner". That was false in the way that matters: a
+    substring check cannot notice a FOURTH classifier appearing, and it cannot
+    tell you which pattern the runner actually applies to what. This returns
+    what the runner will run.
+
+    Scoped to the GUARD 7 evaluation block by its own section banners, so a
+    `grep -c` belonging to GUARD 8 or 10 cannot be mistaken for one of these.
+    """
+    runner = (SCRIPTS / "run-tests.sh").read_text(encoding="utf-8")
+    start = runner.find("# --- GUARD 7 (evaluation)")
+    end = runner.find("# --- GUARD 8 (evaluation)", start + 1)
+    assert start != -1 and end > start, (
+        "run-tests.sh's GUARD 7 evaluation block is no longer delimited by the "
+        "banners this parse anchors on — it cannot say what the runner runs, "
+        "and a pass here would mean nothing")
+    block = runner[start:end]
+    counts = re.findall(r"grep -c '([^']+)'", block)
+    selects = re.findall(r"grep -vE '([^']+)'", block)
+    # Both directions: a classifier added or removed changes what "unclassified
+    # = a real launcher reach" means, which is the whole verdict GUARD 7 emits.
+    assert counts == ["^nolaunch(session)", "^systemctl(read)"], (
+        f"GUARD 7's ^-anchored COUNT classifiers changed: {counts}")
+    assert selects == [r"^(nolaunch\(session\)|systemctl\(read\)|$)"], (
+        f"GUARD 7's HIT selector changed: {selects}")
+    return counts[0], counts[1], selects[0]
+
+
 def test_the_runners_anchored_classifiers_still_match_the_tagged_format(tmp_path):
     """Run `run-tests.sh`'s OWN grep patterns against a log this tree produced.
 
-    The patterns are read out of the runner rather than copied, so a change on
-    that side is visible here; and they are executed by real `grep`, not
-    re-implemented in `re`, because the claim is about what the runner does.
+    The patterns are PARSED out of the runner (see `_guard7_grep_patterns`), and
+    executed by real `grep` rather than re-implemented in `re`, because the
+    claim is about what the runner does to this file.
     """
-    runner = (SCRIPTS / "run-tests.sh").read_text(encoding="utf-8")
-    marker_pat = r"^nolaunch(session)"
-    read_pat = r"^systemctl(read)"
-    hit_pat = r"^(nolaunch\(session\)|systemctl\(read\)|$)"
-    assert "grep -c '^nolaunch(session)'" in runner, (
-        "run-tests.sh no longer classifies the session marker with this "
-        "pattern — the placement constraint this test pins has moved")
-    assert "grep -c '^systemctl(read)'" in runner, (
-        "run-tests.sh no longer counts systemctl READS with this pattern")
-    assert ("grep -vE '^(nolaunch\\(session\\)|systemctl\\(read\\)|$)'"
-            in runner), (
-        "run-tests.sh no longer selects launcher HITS with this pattern")
+    marker_pat, read_pat, hit_pat = _guard7_grep_patterns()
 
     grep = shutil.which("grep")
     assert grep is not None, (
@@ -717,7 +802,7 @@ def test_the_runners_anchored_classifiers_still_match_the_tagged_format(tmp_path
     # here. Hand-writing the `systemctl(read)` and `nolaunch(session)` lines is
     # what makes this guard vacuous: those two are the ONLY ones the runner
     # classifies by their first token, so a hand-written copy stays in the old
-    # format under the very mutation this test exists to catch — MEASURED, the
+    # format under the very mutation this test exists to catch — MEASURED, an
     # earlier draft of this test stayed green under a tag-at-line-start mutant.
     stubs = _private_stubs(tmp_path)
     log = nolaunch.log_path(stubs)
@@ -726,14 +811,18 @@ def test_the_runners_anchored_classifiers_still_match_the_tagged_format(tmp_path
     for cmd in ("notify-send a-toast", "systemd-run --user --unit=u true"):
         assert _through_a_shell(stubs, cmd).returncode == 0
     # The systemctl stub, generated by `systemctl_body` and pointed at a
-    # passthrough target of our own — so BOTH its branches run in BOTH tiers,
-    # where `install()` writes no systemctl stub at all when the host has none.
+    # passthrough target of our own — so ALL THREE of its branches run in BOTH
+    # tiers, where `install()` writes no systemctl stub at all when the host has
+    # none: the VERB read, the mutating block, and the position-independent
+    # `--version`/`--help` flag read, which no test in this tree exercised at
+    # all before (it has its own printf, so it is its own mutation site).
     passthrough = tmp_path / "passthrough-systemctl"
     write_exec(passthrough, "exit 0\n")
     write_exec(stubs / "systemctl",
                nolaunch.systemctl_body(str(passthrough), log))
     assert _through_a_shell(stubs, "systemctl --user status u").returncode == 0
     assert _through_a_shell(stubs, "systemctl --user stop u").returncode == 0
+    assert _through_a_shell(stubs, "systemctl --version").returncode == 0
 
     def _grep(args):
         p = subprocess.run([grep, *args, str(log)], stdout=subprocess.PIPE,
@@ -743,13 +832,30 @@ def test_the_runners_anchored_classifiers_still_match_the_tagged_format(tmp_path
     assert _grep(["-c", marker_pat]) == ["1"], (
         "the session marker stopped matching the runner's ^-anchored count — "
         "GUARD 7 would report the plugin as never loaded in this target")
-    assert _grep(["-c", read_pat]) == ["1"], (
+    reads = _grep([read_pat])
+    assert len(reads) == 2, (
         "a systemctl READ stopped matching the runner's ^-anchored count and "
-        "would now be reported as a real launcher reach")
+        f"would now be reported as a real launcher reach: {reads}")
+    # 🔴 THE READ LINES CARRY THE TAG TOO — asserted here because NOTHING ELSE
+    # CAN SEE IT. A read is by construction not a `hit`, so the hits assertion
+    # below never inspects it, and in the nix sandbox tier (no real systemctl)
+    # `install()` writes no systemctl stub, so no other test in the file
+    # produces a read line at all. MEASURED: with this assertion absent,
+    # deleting `[%s]` from ONLY the `systemctl(read)` branch of
+    # `systemctl_body` survived that tier at 74 passed / exit 0, while the
+    # identical mutation of its `systemctl(blocked)` sibling was killed. Both
+    # read branches are covered: `--user status u` is the VERB one and
+    # `--version` is the position-independent FLAG one.
+    assert [nolaunch.line_worker(ln) for ln in reads] == [
+        nolaunch.worker_tag(), nolaunch.worker_tag()], (
+        "a `systemctl(read)` line lost its [worker] tag. It still classifies "
+        "correctly for the runner, so nothing in run-tests.sh notices — but "
+        f"every per-worker read drops it silently: {reads}")
+
     hits = _grep(["-vE", hit_pat])
     assert len(hits) == 3, (
         "the runner's HIT selector no longer classifies the log the way this "
-        "tree writes it — the marker and the systemctl READ must be excluded "
+        "tree writes it — the marker and both systemctl READS must be excluded "
         f"and the three launcher lines kept; a tag at line START breaks exactly "
         f"that:\n{hits}")
     assert sorted(ln.split(" [", 1)[0] for ln in hits) == [

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -40,6 +40,13 @@ What is asserted, and why each is not enough alone:
   * THE LEDGER  — pinned against the TREE (`testlib.launcher_scan`), not only
     against itself. `dunstctl`, `rofi` and `yad` were all reachable while the
     self-pinned list said the set was complete.
+  * THE TAG     — every recorded line carries the writing pytest-xdist worker's
+    id as its SECOND field, and the readers filter on it. Without that, the
+    `before = len(...)` / `== before + 1` shape used throughout this file is a
+    claim about THIS worker measured on a counter every sibling worker
+    increments — a few-ms flake on a REQUIRED gate. Pinned deterministically
+    (an injected foreign line), never raced for, plus the placement constraint
+    `run-tests.sh`'s `^`-anchored greps impose on where the tag may sit.
 """
 from __future__ import annotations
 
@@ -431,7 +438,11 @@ def test_invoking_a_launcher_records_and_launches_nothing(launcher, no_real_laun
     lines = nolaunch.recorded(no_real_launchers)
     assert len(lines) == before + 1, (
         f"expected exactly one new recorded launch, got {lines[before:]}")
-    assert lines[-1] == f"{launcher} {marker}", lines[-1]
+    # The `[<worker>]` field is pinned HERE, by exact equality, because the
+    # per-worker filter that makes `before + 1` sound under xdist reads exactly
+    # this position. A stub that stopped emitting it would still record, still
+    # exit 0, and quietly make every filtered read return nothing.
+    assert lines[-1] == f"{launcher} [{nolaunch.worker_tag()}] {marker}", lines[-1]
 
 
 def test_the_stubs_exit_zero_because_a_failing_stub_would_change_the_script(
@@ -474,14 +485,276 @@ def test_a_stub_does_nothing_but_record(launcher, no_real_launchers):
     # keeps the expectation a LITERAL (deriving it from `mockbin.SHEBANG` would
     # make a mutation of that constant invisible here) while staying out of the
     # scanner's needles.
+    # 🔴 The `[%s]` worker field and its `${PYTEST_XDIST_WORKER:-main}` source
+    # are spelled out HERE as literals, not built from `nolaunch.WORKER_ENV` /
+    # `SERIAL_WORKER`, for the same reason as the shebang below: a mutation of
+    # those constants would change the expectation and this pin with it. Under
+    # xdist a stub that read the WRONG variable would tag every line `main` and
+    # still look perfectly well-formed in the log.
     expected = (
         "#" + "!/bin/sh\n"
-        "printf '%s %s\\n' \"" + launcher + "\" \"$*\" >> \"" + str(log) + "\"\n"
+        "printf '%s [%s] %s\\n' \"" + launcher + "\" "
+        "\"${PYTEST_XDIST_WORKER:-main}\" \"$*\" >> \"" + str(log) + "\"\n"
         "exit 0\n"
     )
     actual = (no_real_launchers / launcher).read_text(encoding="utf-8")
     assert actual == expected, (
         f"the {launcher} stub is not a pure recorder any more:\n{actual!r}")
+
+
+# --------------------------------------------------------------------------- #
+# THE PER-WORKER TAG — the xdist cross-worker race, closed deterministically
+# --------------------------------------------------------------------------- #
+# 🔴 The bug these pin: ONE run-wide `launches.log`, and since #841 every pytest
+# target runs `-n N --dist loadfile`. `loadfile` keeps THIS file's tests on one
+# worker, so this file does not race itself — but ~8 sibling files in
+# `scripts/tests` also invoke `systemctl`/`openrgb`/`systemd-run`/`notify-send`,
+# run on SIBLING workers, and append to the same file. Every assertion here is
+# `before = len(...)` → act → `== before + 1`, i.e. a claim about THIS worker's
+# launches measured on a counter four workers increment.
+#
+# The window is a few ms and the original report got NOT REPRODUCED in 2/2 runs,
+# so none of these races for it. The foreign line is INJECTED between the sample
+# and the assertion, which is the same state the race produces and is reached
+# every single run.
+def _private_stubs(tmp_path) -> Path:
+    """A stub dir of this test's OWN, never the session's run-wide one.
+
+    🔴 Load-bearing, twice over. (1) One of these tests APPENDS a fabricated
+    foreign line to the log; in the run-wide log that line would be counted by
+    `run-tests.sh`'s GUARD 7 accounting as a real launcher reach, and would move
+    the `before` sample of every other test in this file. (2) They all assert an
+    EXACT total, which the shared log can never offer.
+    """
+    stubs = tmp_path / "own-stubs"
+    nolaunch.install(stubs)
+    return stubs
+
+
+def _through_a_shell(stubs: Path, command: str, **envextra):
+    """Invoke a stub the way a script under test does: a PATH lookup in a child.
+
+    Deliberately NOT `subprocess.run([str(stubs / name)])`: an absolute path to a
+    ledgered basename is exactly what the plugin's L2 layer rewrites, and it
+    would rewrite it to the SESSION stub dir — so the launch would be recorded in
+    the wrong log and this test would measure nothing.
+    """
+    env = dict(os.environ)
+    env["PATH"] = str(stubs) + os.pathsep + env["PATH"]
+    env.update(envextra)
+    return subprocess.run([_SH, "-c", command],
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                          text=True, timeout=15, env=env)
+
+
+def test_a_sibling_workers_line_does_not_count_as_this_workers_launch(tmp_path):
+    """🔴 REGRESSION for the xdist cross-worker race — deterministic, not raced.
+
+    RED AT origin/main, but say how: there the module has no per-worker concept
+    at all, so this test cannot even be expressed and dies on `AttributeError`.
+    The meaningful red is the mutant that restores origin/main's SEMANTICS while
+    keeping the API — `recorded()` accepting `worker=` and ignoring it. MEASURED
+    against that mutant, this test fails on the assertion below with its own
+    message: the injected sibling lines land inside `before + 1` and the count
+    is 3.
+    """
+    stubs = _private_stubs(tmp_path)
+    log = nolaunch.log_path(stubs)
+    mine = nolaunch.worker_tag()
+    sibling = f"{mine}-sibling"
+    assert sibling != mine
+
+    before = len(nolaunch.recorded(stubs))
+
+    # THE RACE. A sibling xdist worker appending between the sample and the
+    # assertion — two lines, because both readers are exposed.
+    with log.open("a", encoding="utf-8") as fh:
+        fh.write(f"notify-send [{sibling}] --a-sibling-workers-toast\n")
+        fh.write(f"systemctl(blocked) [{sibling}] --user stop sibling.timer\n")
+
+    marker = "--own-launch-probe"
+    p = _through_a_shell(stubs, f"notify-send {marker}")
+    assert p.returncode == 0, f"{p.stdout}{p.stderr}"
+
+    lines = nolaunch.recorded(stubs)
+    assert len(lines) == before + 1, (
+        "a SIBLING xdist worker's launches were counted as this worker's. That "
+        "is the race: `before + 1` is a claim about what THIS test launched, "
+        f"and it was measured against every worker's lines:\n{lines}")
+    assert lines[-1] == f"notify-send [{mine}] {marker}", lines[-1]
+
+    assert nolaunch.blocked_systemctl(stubs) == [], (
+        "the sibling worker's blocked systemctl call was attributed to this "
+        "worker — `blocked_systemctl` is exposed to the same race")
+
+    # 🔴 POSITIVE CONTROL. Everything above is equally satisfied by an injection
+    # that never happened, or by a `recorded()` pointed at the wrong file. The
+    # unfiltered view must SEE the foreign lines for the filtered view's silence
+    # to mean anything.
+    every = nolaunch.recorded(stubs, worker=nolaunch.ALL_WORKERS)
+    assert len(every) == before + 3, (
+        f"the foreign lines are not in the log at all, so filtering them out "
+        f"proves nothing:\n{every}")
+    assert [ln for ln in every if nolaunch.line_worker(ln) == sibling] == [
+        f"notify-send [{sibling}] --a-sibling-workers-toast",
+        f"systemctl(blocked) [{sibling}] --user stop sibling.timer",
+    ], every
+    assert len(nolaunch.blocked_systemctl(stubs, worker=nolaunch.ALL_WORKERS)) == 1
+
+
+def test_the_stub_takes_its_tag_from_the_xdist_worker_variable(tmp_path):
+    """The MECHANISM, measured at both ends of the dimension it depends on.
+
+    MEASURED on the workbench before this was written (6 files, `-n 4 --dist
+    loadfile`): four distinct ids `gw0`..`gw3` reached a `sh -c` child; the same
+    files run serially left `PYTEST_XDIST_WORKER` UNSET there. Both points are
+    pinned here rather than raced for, because a stub that read the variable but
+    had no fallback would tag serial runs with an empty field and a stub that
+    ignored the variable would tag every xdist worker `main` — and BOTH still
+    produce a well-formed-looking log.
+    """
+    stubs = _private_stubs(tmp_path)
+
+    # Point 1: a worker id in the environment is the tag.
+    p = _through_a_shell(stubs, "openrgb --under-a-worker",
+                         PYTEST_XDIST_WORKER="gw7")
+    assert p.returncode == 0, f"{p.stdout}{p.stderr}"
+
+    # Point 2: no worker id — the serial fallback, one namespace with no gap.
+    env = {k: v for k, v in os.environ.items() if k != "PYTEST_XDIST_WORKER"}
+    env["PATH"] = str(stubs) + os.pathsep + os.environ["PATH"]
+    q = subprocess.run([_SH, "-c", "openrgb --serial"],
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                       text=True, timeout=15, env=env)
+    assert q.returncode == 0, f"{q.stdout}{q.stderr}"
+
+    every = nolaunch.recorded(stubs, worker=nolaunch.ALL_WORKERS)
+    assert every == [
+        "openrgb [gw7] --under-a-worker",
+        f"openrgb [{nolaunch.SERIAL_WORKER}] --serial",
+    ], every
+    assert nolaunch.recorded(stubs, worker="gw7") == [
+        "openrgb [gw7] --under-a-worker"], every
+
+
+def test_the_readers_default_to_this_worker_and_can_still_see_everything(tmp_path):
+    """The `worker=` contract, pinned against a hand-written log.
+
+    🔴 THE DEFAULT IS THE POINT. A `recorded()` that defaulted to the whole log
+    would leave the race armed for the next test somebody writes — the shape of
+    the bug, not a variant of it — so "the default filters" is asserted, not
+    left to be inferred from the call sites that happen to exist today.
+
+    The `nolaunch(session)` marker is here on purpose: it is deliberately
+    untagged (`run-tests.sh` owns its per-target accounting), so it belongs to
+    no worker and must appear under ALL_WORKERS and nowhere else.
+    """
+    stubs = tmp_path / "hand-written"
+    stubs.mkdir()
+    mine = nolaunch.worker_tag()
+    log = nolaunch.log_path(stubs)
+    log.write_text(
+        "nolaunch(session) scripts/tests -q\n"
+        f"systemd-run [{mine}] --user --unit=ours --on-active=2h true\n"
+        "systemctl(blocked) [gwZ] --user stop theirs.timer\n"
+        f"systemctl(blocked) [{mine}] --user stop ours.timer\n"
+        "systemctl(read) [gwZ] --user is-active theirs.timer\n"
+        "i3-msg(abs) [gwZ] workspace 9\n",
+        encoding="utf-8")
+
+    assert nolaunch.recorded(stubs) == [
+        f"systemd-run [{mine}] --user --unit=ours --on-active=2h true",
+        f"systemctl(blocked) [{mine}] --user stop ours.timer",
+    ], nolaunch.recorded(stubs)
+    assert nolaunch.blocked_systemctl(stubs) == [
+        f"systemctl(blocked) [{mine}] --user stop ours.timer"]
+
+    assert len(nolaunch.recorded(stubs, worker=nolaunch.ALL_WORKERS)) == 6
+    assert nolaunch.recorded(stubs, worker="gwZ") == [
+        "systemctl(blocked) [gwZ] --user stop theirs.timer",
+        "systemctl(read) [gwZ] --user is-active theirs.timer",
+        "i3-msg(abs) [gwZ] workspace 9",
+    ]
+    assert nolaunch.line_worker("nolaunch(session) scripts/tests -q") is None
+    assert nolaunch.line_worker("i3-msg(abs) [gwZ] workspace 9") == "gwZ"
+    # An argv containing a bracketed word must not be mistaken for the tag.
+    assert nolaunch.line_worker("notify-send [gw1] -t 2500 [not-a-tag]") == "gw1"
+
+
+# ⚠ INVARIANT GUARD, not regression coverage: this passes at origin/main too,
+# because there the tag does not exist and the classifiers match trivially. It
+# pins the constraint the tag's PLACEMENT had to satisfy — `run-tests.sh` reads
+# this log with `^`-anchored greps on the FIRST token, so a tag at line START
+# would stop the session marker and every `systemctl(read)` passthrough from
+# matching and report both as real launcher reaches, failing the whole run.
+# Nothing in Python covered those greps before; they are the log's real consumer.
+def test_the_runners_anchored_classifiers_still_match_the_tagged_format(tmp_path):
+    """Run `run-tests.sh`'s OWN grep patterns against a log this tree produced.
+
+    The patterns are read out of the runner rather than copied, so a change on
+    that side is visible here; and they are executed by real `grep`, not
+    re-implemented in `re`, because the claim is about what the runner does.
+    """
+    runner = (SCRIPTS / "run-tests.sh").read_text(encoding="utf-8")
+    marker_pat = r"^nolaunch(session)"
+    read_pat = r"^systemctl(read)"
+    hit_pat = r"^(nolaunch\(session\)|systemctl\(read\)|$)"
+    assert "grep -c '^nolaunch(session)'" in runner, (
+        "run-tests.sh no longer classifies the session marker with this "
+        "pattern — the placement constraint this test pins has moved")
+    assert "grep -c '^systemctl(read)'" in runner, (
+        "run-tests.sh no longer counts systemctl READS with this pattern")
+    assert ("grep -vE '^(nolaunch\\(session\\)|systemctl\\(read\\)|$)'"
+            in runner), (
+        "run-tests.sh no longer selects launcher HITS with this pattern")
+
+    grep = shutil.which("grep")
+    assert grep is not None, (
+        "no grep on PATH — run-tests.sh cannot classify its own launch log "
+        "without one, so this environment cannot run the gate either")
+
+    # 🔴 EVERY LINE BELOW IS PRODUCED BY THIS TREE'S OWN CODE, none typed out
+    # here. Hand-writing the `systemctl(read)` and `nolaunch(session)` lines is
+    # what makes this guard vacuous: those two are the ONLY ones the runner
+    # classifies by their first token, so a hand-written copy stays in the old
+    # format under the very mutation this test exists to catch — MEASURED, the
+    # earlier draft of this test stayed green under a tag-at-line-start mutant.
+    stubs = _private_stubs(tmp_path)
+    log = nolaunch.log_path(stubs)
+    from testlib import nolaunch_plugin
+    nolaunch_plugin._log_marker(stubs, "scripts/tests -q")
+    for cmd in ("notify-send a-toast", "systemd-run --user --unit=u true"):
+        assert _through_a_shell(stubs, cmd).returncode == 0
+    # The systemctl stub, generated by `systemctl_body` and pointed at a
+    # passthrough target of our own — so BOTH its branches run in BOTH tiers,
+    # where `install()` writes no systemctl stub at all when the host has none.
+    passthrough = tmp_path / "passthrough-systemctl"
+    write_exec(passthrough, "exit 0\n")
+    write_exec(stubs / "systemctl",
+               nolaunch.systemctl_body(str(passthrough), log))
+    assert _through_a_shell(stubs, "systemctl --user status u").returncode == 0
+    assert _through_a_shell(stubs, "systemctl --user stop u").returncode == 0
+
+    def _grep(args):
+        p = subprocess.run([grep, *args, str(log)], stdout=subprocess.PIPE,
+                           text=True, timeout=15)
+        return [ln for ln in p.stdout.splitlines() if ln]
+
+    assert _grep(["-c", marker_pat]) == ["1"], (
+        "the session marker stopped matching the runner's ^-anchored count — "
+        "GUARD 7 would report the plugin as never loaded in this target")
+    assert _grep(["-c", read_pat]) == ["1"], (
+        "a systemctl READ stopped matching the runner's ^-anchored count and "
+        "would now be reported as a real launcher reach")
+    hits = _grep(["-vE", hit_pat])
+    assert len(hits) == 3, (
+        "the runner's HIT selector no longer classifies the log the way this "
+        "tree writes it — the marker and the systemctl READ must be excluded "
+        f"and the three launcher lines kept; a tag at line START breaks exactly "
+        f"that:\n{hits}")
+    assert sorted(ln.split(" [", 1)[0] for ln in hits) == [
+        "notify-send", "systemctl(blocked)", "systemd-run"], hits
+    assert all(nolaunch.line_worker(ln) == nolaunch.worker_tag() for ln in hits), hits
 
 
 # --------------------------------------------------------------------------- #
@@ -532,28 +805,23 @@ def test_a_mutating_systemctl_verb_is_recorded_and_swallowed(no_real_launchers):
     assert p.stderr == "", (
         f"the real systemctl appears to have run: {p.stderr!r}")
     blocked = nolaunch.blocked_systemctl(no_real_launchers)
-    # 🔴 KNOWN RACE, OPEN — this comment used to say "sound only because pytest
-    # runs this suite sequentially in one process". That premise is FALSE as of
-    # the xdist change: run-tests.sh runs each target `-n N --dist loadfile`.
-    #
-    # loadfile keeps THIS file's tests on one worker, so they do not race each
-    # other. What does race is the other eight files in this tree that invoke
-    # `systemctl` — they run on sibling workers and append to the SAME run-wide
+    # 🔴 THE CROSS-WORKER RACE THIS USED TO CARRY IS CLOSED — read the note, it
+    # is what makes `before + 1` sound again. This comment previously said the
+    # assertion was "sound only because pytest runs this suite sequentially in
+    # one process", which the xdist change (`-n N --dist loadfile`) made false:
+    # loadfile keeps THIS file on one worker, but ~8 sibling files in this tree
+    # also invoke `systemctl` and append to the SAME run-wide
     # `$DEVRC_TEST_LAUNCH_STUB_DIR/launches.log` that `before` was sampled from.
-    # Measured composition of that log for a 9-file subset at -n 4: 23
-    # `systemctl(blocked)`, 9 `openrgb`, 8 `systemd-run`, 8 `notify-send` foreign
-    # lines per run, interleaving with these assertions.
     #
-    # NOT REPRODUCED in 2/2 subset runs — the window is a few ms — so this is a
-    # small-probability flake on a REQUIRED gate, which is worse than a loud one:
-    # it will present as an unrelated test failing for no reason.
-    #
-    # The fix is the one the original comment named — a per-worker stub dir — and
-    # it is deliberately NOT done here: the stub log path is baked into the stub
-    # script bodies at install() time, and the runner attributes intercepts to
-    # targets by LINE OFFSET into that single file, so per-worker logs need the
-    # runner's ledger model changed too. That is a design change, not a patch.
-    # Until then: `DEVRC_TEST_JOBS=1` makes this deterministic.
+    # It is not fixed by per-worker LOG FILES — that WOULD need the runner's
+    # ledger model changed, since it attributes intercepts to targets by line
+    # offset into one file. It is fixed by a per-worker TAG inside that one log:
+    # `blocked_systemctl()` now returns only THIS worker's lines by default, so
+    # a sibling worker's `systemctl(blocked)` can no longer land inside the
+    # window. See `testlib/nolaunch.py`'s docstring, and the deterministic pins
+    # under "THE PER-WORKER TAG" above — the race is injected there rather than
+    # raced for, because the window is a few ms and it was NOT REPRODUCED in 2/2
+    # runs when it was open.
     assert len(blocked) == before + 1, blocked[before:]
     assert unit in blocked[-1] and "stop" in blocked[-1], blocked[-1]
 

--- a/scripts/tests/test_no_real_launchers_all_targets.py
+++ b/scripts/tests/test_no_real_launchers_all_targets.py
@@ -397,6 +397,46 @@ def test_the_absolute_path_reach_is_intercepted_in_process(tmp_path,
         f"nothing was recorded for the absolute-path reach: {lines}")
 
 
+def test_the_in_process_layer_tags_the_line_with_THIS_worker(tmp_path,
+                                                             no_real_launchers,
+                                                             monkeypatch):
+    """🔴 The L2 tag must come from the ENVIRONMENT, not from a constant.
+
+    The test above already fails if L2 writes NO tag — its `recorded()` is
+    filtered, so an untagged line vanishes. What it cannot see is L2 writing the
+    WRONG tag: hardcode `nolaunch.SERIAL_WORKER` there and a serial run
+    (`DEVRC_TEST_JOBS=1`, or any bare `pytest`) agrees with it by coincidence,
+    because `worker_tag()` is `main` too. The whole point of this PR is the
+    xdist case, and that is the case a serial gate is structurally blind to.
+
+    So this forces the dimension instead of waiting for the harness to supply
+    it: a worker id no serial fallback can produce, set for the duration of one
+    in-process launch. Under `-n 4` the ambient value would be `gw<N>`; under
+    `DEVRC_TEST_JOBS=1` there is none. Either way the assertion is the same, so
+    the guard is not a hostage to how the suite happens to be invoked.
+    """
+    probe_tag = "gwABSPROBE"
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", probe_tag)
+    assert nolaunch.worker_tag() == probe_tag
+
+    fake_dir = tmp_path / "elsewhere"
+    fake_dir.mkdir()
+    witness = tmp_path / "IT-RAN-TAGGED"
+    write_exec(fake_dir / "i3-msg", f'printf ran > "{witness}"\nexit 0\n')
+
+    before = len(nolaunch.recorded(no_real_launchers, worker=probe_tag))
+    subprocess.run([str(fake_dir / "i3-msg"), "workspace", "8"], check=False,
+                   capture_output=True)
+    assert not witness.exists(), "the absolute-path launcher RAN"
+
+    mine = nolaunch.recorded(no_real_launchers, worker=probe_tag)[before:]
+    assert [ln for ln in mine if ln.startswith("i3-msg(abs)")] == [
+        f"i3-msg(abs) [{probe_tag}] workspace 8"], (
+        "the in-process layer did not stamp THIS process's worker id on the "
+        f"line it wrote — a hardcoded tag reads as correct in a serial run "
+        f"and mis-attributes every launch under xdist: {mine}")
+
+
 def test_the_absolute_path_sites_are_pinned():
     """The set of ABSOLUTE launcher paths in the tree, pinned both ways.
 

--- a/scripts/tests/test_no_real_launchers_all_targets.py
+++ b/scripts/tests/test_no_real_launchers_all_targets.py
@@ -236,7 +236,16 @@ def test_a_target_that_reaches_a_launcher_is_named_and_red(tmp_path):
     assert "GUARD 7 problem" in out, (
         f"the run failed, but not for the launcher reason:\n{out}")
     assert str(target) in out, f"the failure did not NAME the target:\n{out}"
-    assert "notify-send NOLAUNCH-PROBE planted reach" in out, (
+    # 🔴 The `[<worker>]` tag is matched as a PATTERN, not a literal, and that is
+    # not laziness: it is whatever `PYTEST_XDIST_WORKER` the nested runner
+    # inherited from THIS session's worker, so it is `gw2` under the gate and
+    # `main` under a bare serial `pytest` — a literal would pin the harness's
+    # own parallelism rather than the guard's report. What IS pinned is that the
+    # tag is present and sits between the launcher name and the argv, because
+    # that placement is what keeps `run-tests.sh`'s ^-anchored classifiers from
+    # reading the line as something else entirely.
+    assert re.search(
+        r"notify-send \[[^\]\s]+\] NOLAUNCH-PROBE planted reach", out), (
         f"the guard reported a reach it never actually recorded:\n{out}")
 
 


### PR DESCRIPTION
## The bug

`scripts/tests/test_no_real_launchers.py:535` carried a `🔴 KNOWN RACE, OPEN` comment. Since #841, `run-tests.sh` runs each pytest target `-n N --dist loadfile`. `loadfile` keeps **one file's** tests on one worker, so that file does not race itself — but ~8 sibling files in `scripts/tests` also invoke `systemctl`/`openrgb`/`systemd-run`/`notify-send`, run on **sibling** workers, and append to the **same** run-wide `$DEVRC_TEST_LAUNCH_STUB_DIR/launches.log`.

Every assertion in that file is

```python
before = len(nolaunch.blocked_systemctl(stub_dir))
...do the thing...
assert len(nolaunch.blocked_systemctl(stub_dir)) == before + 1
```

— a claim about **this worker's** launches, measured on a counter four workers increment. A few-ms window on a REQUIRED gate: it presents as an unrelated test failing for no reason. The workaround on file was `DEVRC_TEST_JOBS=1`; that still works, and is now a no-op rather than a special case.

## The fix

Both write paths stamp the writing worker's id into the line, as its **second** field:

```
systemctl(blocked) [gw2] --user stop foo
notify-send [main] -t 2500 rig-control …
i3-msg(abs) [gw0] workspace 9
```

* **L1**, the PATH stubs (`launcher_body`, `systemctl_body`) — `"${PYTEST_XDIST_WORKER:-main}"`. A serial run, and every NON-pytest target the runner starts, tag `main`: one namespace, no special case.
* **L2**, the in-process `subprocess.Popen` patch in `nolaunch_plugin.py` — `nolaunch.worker_tag()`. Left untagged, an absolute-path reach that *was* intercepted would read as one nobody ever saw.
* `_log_marker` is **deliberately left untagged** — `run-tests.sh` owns its per-target accounting (one marker per worker that ran a test). Consequence stated in the code: a filtered `recorded()` does not return markers; `ALL_WORKERS` does.

### `recorded()` / `blocked_systemctl()` — `worker=`, and why the default filters

Both now take `worker=`, defaulting to `THIS_WORKER`; `worker=ALL_WORKERS` returns the whole log, `worker="gw2"` asks about one worker.

The default filters on purpose. Every caller in the tree is the before/after shape above, so defaulting to unfiltered would leave the race armed for the next test somebody writes — the same shape as the bug. `ALL_WORKERS` keeps the unfiltered/report view available and is exercised by a test rather than left theoretical.

### Why a tag and not per-worker logs

The KNOWN RACE comment said the fix "needs the runner's ledger model changed too". **That is true of per-worker log FILES and false of a tag** — and it was checked, not assumed: `NOLAUNCH_SEEN+=("$d|$((nl_before+1))|$nl_after")` brackets a **whole** pytest invocation by line offset, and all N workers run inside that bracket for the **same** target `$d`, so an interleaved sibling-worker line already belongs to the correct target.

**`scripts/run-tests.sh` is BEHAVIOURALLY unchanged** — no ledger change, no classifier change, no new state; the gate runs green through it untouched. It does carry a **comment-only** edit: its xdist section pointed at "the KNOWN RACE note in `scripts/tests/test_no_real_launchers.py`", and that string no longer exists there, which would have left the runner as the only place in the repo still describing this race as open. (`test_doc_path_rot.py` cannot catch that — the path still resolves.) The rewritten comment says what is now true, why the tag may not move to line start, and why `NOLAUNCH_SEEN` needed no change.

The tag may not go at line **start**: the runner classifies this log with three `^`-anchored greps on the first token (`grep -c '^nolaunch(session)'`, `grep -c '^systemctl(read)'`, `grep -vE '^(nolaunch\(session\)|systemctl\(read\)|$)'`). A tag in front would reclassify the session marker and every read passthrough as a real launcher reach and fail the run.

## Call sites touched (and the ones deliberately left)

`git grep` for `nolaunch.recorded` / `nolaunch.blocked_systemctl` finds callers in exactly **two** files. (A wider grep for the bare word `recorded(` hits six more files — `test_subsystem_resolver.py`, `test_resume_state_clawgate.py`, `test_resume_state_handoff_resolution.py`, `browser-bridge/tests/test_server.py`, `dl-router/tests/test_learning.py`, `session-analysis/tests/test_insights.py` — all false positives: they are *test names* containing the word, and `test_resume_state_clawgate.py` defines its own local `recorded(stdout)` helper. None of them imports `nolaunch`.)

**Changed (behaviour follows the new default — all are before/after counts made by THIS worker):**

| site | why |
|---|---|
| `test_no_real_launchers.py:421,431` `test_invoking_a_launcher_records_and_launches_nothing` | before/after count; the exact-line assertion now pins `[worker]` too |
| `:524,534` `test_a_mutating_systemctl_verb_is_recorded_and_swallowed` | **the site the KNOWN RACE comment was attached to** |
| `:585,593` `test_an_argument_that_spells_a_read_verb_does_not_promote_a_mutation` | same shape, same exposure — 10 parametrised cases |
| `:637,665` the two `any(ln.startswith("systemctl(read)"))` reads | this worker made the read; filtering is the more precise claim |
| `:711,721 / :750,767 / :781,789 / :844,862` the four seam tests | `[before:]` slices plus `len(...) == 1` filters on `systemd-run ` — measured, 8 foreign `systemd-run` lines per run at `-n 4` |

**Behaviour changed, source line NOT edited — `test_no_real_launchers_all_targets.py:379,386`.** Listing these under both headings was a contradiction in an earlier draft of this body; this is the accurate statement. Both calls now return this worker's lines because the *default* changed; nothing at the call site moved. They are **not** cross-worker reads: they sit in `test_the_absolute_path_reach_is_intercepted_in_process`, which launches `<tmp>/i3-msg` from the pytest process itself and reads back the L2 `i3-msg(abs)` line it just caused — same worker, same process — so the filter does not narrow them. Mutant **M4** (L2 write path untagged) kills exactly that test, which is the proof it still sees what it is supposed to. The rest of that file is about the *runner* covering all targets: those tests drive a nested `run-tests.sh` and assert on its **stdout**, not on `recorded()`.

**Left as-is:**

* **`_log_marker`** — see above.
* **`scripts/run-tests.sh`'s ledger and classifiers** — no change needed; see the argument above. (A **comment-only** edit did land in that file — same section.)

One assertion in `test_no_real_launchers_all_targets.py` did need updating: `assert "notify-send NOLAUNCH-PROBE planted reach" in out` reads the *runner's echo of the log line*. It is now a regex (`notify-send \[[^\]\s]+\] NOLAUNCH-PROBE planted reach`) because the tag there is whatever `PYTEST_XDIST_WORKER` the nested runner inherited — `gw1` under the gate, `main` under a bare serial `pytest`. A literal would pin the harness's own parallelism instead of the guard's report.

## Coverage

The window is a few ms and the original author got NOT REPRODUCED in 2/2 runs, so nothing here races for it: the foreign line is **injected** between the sample and the assertion, which is the same state the race produces and is reached every run.

* **`test_a_sibling_workers_line_does_not_count_as_this_workers_launch`** — REGRESSION. Injects a sibling worker's `notify-send` **and** `systemctl(blocked)` into the log between `before` and the assertion, in a private stub dir (fabricating a line in the run-wide log would be counted by GUARD 7 as a real reach and would move every other test's `before`). Carries a positive control: the `ALL_WORKERS` view must **see** the foreign lines, or filtering them out proves nothing.
* **`test_the_stub_takes_its_tag_from_the_xdist_worker_variable`** — the mechanism at both ends of the dimension it depends on: `PYTEST_XDIST_WORKER` set → that id; unset → `main`.
* **`test_the_readers_default_to_this_worker_and_can_still_see_everything`** — the `worker=` contract against a hand-written log, including that the untagged session marker belongs to no worker and that an argv containing a bracketed word is not mistaken for the tag.
* **`test_the_in_process_layer_tags_the_line_with_THIS_worker`** — forces a worker id no serial fallback can produce, so a hardcoded L2 tag cannot pass by coincidence under `DEVRC_TEST_JOBS=1`.
* ⚠ **`test_the_runners_anchored_classifiers_still_match_the_tagged_format` is an INVARIANT GUARD, not regression coverage** — it is green at `origin/main` too, where the tag does not exist and the classifiers match trivially. It pins the constraint the tag's *placement* had to satisfy. It **parses** the three grep patterns out of `run-tests.sh`'s GUARD 7 block (pinning the set both ways, so a classifier appearing *or* disappearing is red) and runs **real `grep`** against a log written entirely by this tree's own code — including the `systemctl(read)`/`systemctl(blocked)` lines, generated through `systemctl_body` pointed at a passthrough binary of our own so all three of its branches run in **both** tiers. Nothing in Python covered the runner's classifiers before this.

  This guard has been wrong twice, both times in the same direction — **its description wider than its pin** — and both are worth reading before trusting it:

  1. An early draft hand-wrote the `systemctl(read)` and `nolaunch(session)` lines. It **stayed green under a tag-at-line-start mutant**: those two are the only lines the runner classifies by their first token, so a hand-written copy stays in the old format under the very mutation the test exists to catch.
  2. A blind audit then found it *still* narrower than its docstring: it asserted the tag over `hits` only, and a read is by construction **not** a hit — so deleting `[%s]` from the read branch survived the **gating** tier at 74 passed / exit 0 while the identical mutation of its `systemctl(blocked)` sibling was killed. It now asserts the tag on the read lines directly, and drives the `--version`/`--help` flag branch too, which no test in this tree exercised at all.

  Both are pinned by mutants (M3c, M7, M7b) rather than by the wording.

## Verification

See the PR discussion for the full red/green matrix, both tiers, both `DEVRC_TEST_JOBS` settings, and the 15-mutant battery.
