### PR TITLE
feat(worktree-prune): re-derive the 593-worktree classification with signals a SQUASH merge cannot hide from

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -75,6 +75,7 @@ Click actions for those blocks:
 | `playwright-nixos` | drive Playwright with the nixpkgs Chromium matching *this project's* pin (`--list` / `--select`) |
 | `dogfood-cycle` | automate the civitai App Block "dogfood test cycle" |
 | `run3` | run a command with stdout and stderr captured to **separate** files (never merged), reporting each stream's byte count, path and the command's own exit code. Use it whenever the question is *which stream produced this* — in zsh, `cmd 2>&1 >/dev/null \| consumer` hands the consumer **stdout**, so redirection order cannot answer it |
+| `worktree-prune` | classify git worktrees across many repos as `dead` / `orphan` / `live` / `cannot-tell`, recording the EVIDENCE each verdict rests on. **Dry-run by default**; `--execute` additionally requires `--confirm N` matching the exact removal count, only ever touches `dead` rows, re-checks dirtiness immediately before each removal and never passes `--force`. 🔴 It does **not** decide "did this land" by ancestry: `git merge-base --is-ancestor` is false for every **squash**-merged branch forever, so containment is answered by four independent signals (`ancestor`, `pr-merged` via `gh`, `content-identical` over the branch's changed paths, `patch-equivalent` via `git cherry`) and anything none of them can answer is a loud `cannot-tell`, never a `dead` |
 
 ## Network / VPN
 

--- a/scripts/tests/test_worktree_prune.py
+++ b/scripts/tests/test_worktree_prune.py
@@ -1,0 +1,1082 @@
+"""`scripts/worktree-prune` — the worktree classifier, and the controls that make
+its verdicts worth reading.
+
+WHAT IS UNDER TEST
+------------------
+A tool that will eventually be pointed at ~750 real worktrees and asked which of
+them can be deleted. The prior attempt at that classification reported 245
+"orphans" using a containment checker that called a `git diff
+--pathspec-from-file` which does not exist, exited 129, and therefore scored
+EVERY branch unmerged. So the interesting question is not "does the tool run" —
+it ran — but "can its verdicts distinguish the cases that matter".
+
+🔴 THE HEADLINE TRAP, AND THE FIXTURE THAT PINS IT
+---------------------------------------------------
+A SQUASH merge never makes the branch head an ancestor of the base.
+`git merge-base --is-ancestor` is FALSE for every squash-merged branch, forever.
+An ancestry-only classifier therefore reports merged work as orphaned — the
+exact failure that gets real work deleted.
+
+`test_squash_merged_branch_is_dead_not_orphan` builds a REAL squash merge with
+real git and asserts `dead`. And
+`test_an_ancestry_only_classifier_calls_the_squash_an_orphan` is its MUTATION
+CONTROL: it swaps in the broken, ancestry-only checker and watches the SAME
+fixture flip to `orphan`. Without that control, `dead` could be produced by any
+signal at all — including one that says `dead` unconditionally. With it, the
+fixture is proven to be a genuine squash (not an ancestor in disguise) AND the
+content check is proven to be the thing carrying the verdict.
+
+THE TWO CONTROLS THE BRIEF ASKS FOR, NAMED
+-------------------------------------------
+  POSITIVE control (it MUST say dead): `test_squash_merged_branch_is_dead_not_orphan`
+      and `test_true_merge_is_dead_by_ancestry`.
+  NEGATIVE control (it MUST say orphan): `test_genuinely_unmerged_branch_is_an_orphan`.
+  Neither is a general claim on its own — a classifier hardwired to one verdict
+  passes exactly one of them. Both together, plus the mutation control, are what
+  make the pair mean something.
+
+🔴 AND THE LOUD-UNKNOWN CONTROL. `test_without_gh_the_orphan_becomes_cannot_tell`
+feeds the SAME unmerged fixture with the PR lookup removed and requires the
+verdict to degrade to `cannot-tell` rather than stay `orphan`. "No PR found" and
+"we could not ask" are the same observable — an empty result — and they license
+opposite verdicts.
+
+HERMETIC BY CONSTRUCTION
+------------------------
+Every repository is created under `tmp_path` with real git. The only remote is a
+NAME with a github.com URL that is never contacted (it exists so `gh --repo`
+gets a slug), and every `gh` invocation goes to a stub script in the test's own
+`tmp_path`. No network, no real gh, no `.git` read out of the source tree except
+the tool FILE itself.
+"""
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from testlib import hermetic_git, mockbin  # noqa: E402
+
+TOOL = REPO_ROOT / "scripts" / "worktree-prune"
+
+
+def _load():
+    loader = importlib.machinery.SourceFileLoader("_worktree_prune", str(TOOL))
+    spec = importlib.util.spec_from_loader("_worktree_prune", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+wp = _load()
+
+
+# ── hermetic environment ──────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _hermetic_env(monkeypatch):
+    """The tool shells out to git with the AMBIENT environment, so the pins have
+    to live in `os.environ` for the duration of each test rather than in a dict
+    passed to one helper."""
+    for k, v in hermetic_git.HERMETIC.items():
+        monkeypatch.setenv(k, v)
+
+
+def git(repo: Path, *args: str) -> str:
+    r = subprocess.run(["git", "-C", str(repo), *args], capture_output=True,
+                       text=True, check=False, timeout=120)
+    if r.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} in {repo} failed rc={r.returncode}\n"
+                             f"stdout={r.stdout}\nstderr={r.stderr}")
+    return r.stdout.strip()
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def publish(repo: Path) -> None:
+    """Point the remote-tracking refs at the current `main`.
+
+    There is no real remote — `refs/remotes/origin/main` is written directly, so
+    the tool resolves the default branch through the `origin-head-symref` path
+    it will use in production without any network.
+    """
+    sha = git(repo, "rev-parse", "main")
+    git(repo, "update-ref", "refs/remotes/origin/main", sha)
+    git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+
+
+def new_repo(tmp_path: Path, name: str = "repo") -> Path:
+    repo = tmp_path / name
+    repo.mkdir(parents=True)
+    git(repo, "init", "-q", "-b", "main")
+    write(repo / "README.md", "base\n")
+    git(repo, "add", "README.md")
+    git(repo, "commit", "-qm", "base")
+    git(repo, "remote", "add", "origin", "https://github.com/fixture/repo.git")
+    publish(repo)
+    return repo
+
+
+def commit_on_branch(repo: Path, branch: str, rel: str, text: str, msg: str) -> None:
+    git(repo, "checkout", "-q", "-b", branch)
+    write(repo / rel, text)
+    git(repo, "add", rel)
+    git(repo, "commit", "-qm", msg)
+    git(repo, "checkout", "-q", "main")
+
+
+def squash_merge(repo: Path, branch: str, rel: str, msg: str) -> None:
+    """A REAL squash: the branch's file content lands on main as ONE new commit
+    with different parents, so the branch head is not an ancestor of main."""
+    git(repo, "checkout", "-q", "main")
+    git(repo, "checkout", branch, "--", rel)
+    git(repo, "add", rel)
+    git(repo, "commit", "-qm", msg)
+    publish(repo)
+
+
+def add_worktree(repo: Path, path: Path, *args: str) -> Path:
+    git(repo, "worktree", "add", "-q", str(path), *args)
+    return path
+
+
+# ── gh stubs ──────────────────────────────────────────────────────────────────
+
+def gh_stub(tmp_path: Path, bulk: list, name: str = "gh") -> str:
+    """A `gh` that answers `pr list` from a JSON file and nothing else."""
+    payload = tmp_path / f"{name}-bulk.json"
+    payload.write_text(json.dumps(bulk), encoding="utf-8")
+    head = tmp_path / f"{name}-head.json"
+    head.write_text("[]", encoding="utf-8")
+    stub = tmp_path / name
+    mockbin.write_exec(stub, f"""
+prev=""
+head_query=0
+for a in "$@"; do
+  if [ "$prev" = "--head" ]; then head_query=1; fi
+  prev="$a"
+done
+if [ "$head_query" = "1" ]; then
+  cat "{head}"
+else
+  cat "{payload}"
+fi
+exit 0
+""")
+    return str(stub)
+
+
+def gh_broken(tmp_path: Path, name: str = "gh-broken") -> str:
+    stub = tmp_path / name
+    mockbin.write_exec(stub, """
+echo "gh: To get started with GitHub CLI, please run: gh auth login" >&2
+exit 4
+""")
+    return str(stub)
+
+
+def scan(repo: Path, gh_cmd: str = "gh", use_gh: bool = True, pr_limit: int = 2000) -> dict:
+    rows = wp.scan_repo(repo, gh_cmd, use_gh, pr_limit, jobs=1)
+    return {r["path"]: r for r in rows}
+
+
+def row_for(repo: Path, path: Path, **kw) -> dict:
+    return scan(repo, **kw)[str(path)]
+
+
+# ── the four required fixtures, one repo ──────────────────────────────────────
+
+@pytest.fixture()
+def universe(tmp_path: Path):
+    """One repo carrying every scenario the brief names, plus the awkward ones.
+
+    Returns (repo, {label: worktree_path}, gh_cmd).
+    """
+    repo = new_repo(tmp_path)
+    wts = tmp_path / "wts"
+    wts.mkdir()
+
+    # (1) squash-merged — the headline trap. Two commits on the branch, ONE
+    #     squash commit on main, so ancestry is false and content is identical.
+    git(repo, "checkout", "-q", "-b", "feat/squashed")
+    write(repo / "squashed.txt", "first\n")
+    git(repo, "add", "squashed.txt")
+    git(repo, "commit", "-qm", "squashed: part 1")
+    write(repo / "squashed.txt", "first\nsecond\n")
+    git(repo, "add", "squashed.txt")
+    git(repo, "commit", "-qm", "squashed: part 2")
+    git(repo, "checkout", "-q", "main")
+    squash_merge(repo, "feat/squashed", "squashed.txt", "squash the branch (#42)")
+
+    # (2) a genuinely unmerged branch with unique commits.
+    commit_on_branch(repo, "feat/unmerged", "unmerged.txt", "unique work\n", "unmerged work")
+
+    # (3) merged-and-clean, by a real merge commit (ancestry holds).
+    commit_on_branch(repo, "feat/merged", "merged.txt", "merged\n", "mergeable work")
+    git(repo, "merge", "-q", "--no-ff", "-m", "merge feat/merged", "feat/merged")
+    publish(repo)
+
+    # (4) dirty — its content IS merged, so only the dirt keeps it alive.
+    commit_on_branch(repo, "feat/dirty", "dirty.txt", "dirty branch\n", "dirty branch work")
+    git(repo, "merge", "-q", "--no-ff", "-m", "merge feat/dirty", "feat/dirty")
+    publish(repo)
+
+    paths = {
+        "squashed": add_worktree(repo, wts / "squashed", "feat/squashed"),
+        "unmerged": add_worktree(repo, wts / "unmerged", "feat/unmerged"),
+        "merged": add_worktree(repo, wts / "merged", "feat/merged"),
+        "dirty": add_worktree(repo, wts / "dirty", "feat/dirty"),
+    }
+    write(paths["dirty"] / "SCRATCH.md", "notes nobody committed\n")
+
+    return repo, paths, gh_stub(tmp_path, [])
+
+
+# ── POSITIVE CONTROL: the squash must be dead ─────────────────────────────────
+
+def test_squash_merged_branch_is_dead_not_orphan(universe):
+    repo, paths, gh = universe
+    r = row_for(repo, paths["squashed"], gh_cmd=gh)
+    assert r["verdict"] == "dead", r["verdict_reason"]
+
+
+def test_the_squash_fixture_really_is_a_squash_and_not_an_ancestor(universe):
+    """If ancestry held, the headline test above would be vacuous."""
+    repo, paths, gh = universe
+    head = git(repo, "rev-parse", "feat/squashed")
+    rc = subprocess.run(["git", "-C", str(repo), "merge-base", "--is-ancestor",
+                         head, "refs/remotes/origin/main"], check=False).returncode
+    assert rc == 1, "the fixture is not a squash — the branch IS an ancestor of main"
+
+
+def test_the_squash_verdict_rests_on_content_not_ancestry(universe):
+    repo, paths, gh = universe
+    r = row_for(repo, paths["squashed"], gh_cmd=gh)
+    assert r["landed_signals"] == ["content-identical"], r["landed_signals"]
+    assert "ancestor" in r["checks_run"], r["checks_run"]
+
+
+def test_the_squash_row_is_removable(universe):
+    repo, paths, gh = universe
+    assert row_for(repo, paths["squashed"], gh_cmd=gh)["removable"] is True
+
+
+def test_true_merge_is_dead_by_ancestry(universe):
+    repo, paths, gh = universe
+    r = row_for(repo, paths["merged"], gh_cmd=gh)
+    assert r["verdict"] == "dead"
+    assert "ancestor" in r["landed_signals"], r["landed_signals"]
+
+
+# ── NEGATIVE CONTROL: the unmerged branch must be an orphan ───────────────────
+
+def test_genuinely_unmerged_branch_is_an_orphan(universe):
+    repo, paths, gh = universe
+    r = row_for(repo, paths["unmerged"], gh_cmd=gh)
+    assert r["verdict"] == "orphan", r["verdict_reason"]
+
+
+def test_the_orphan_is_never_removable(universe):
+    repo, paths, gh = universe
+    r = row_for(repo, paths["unmerged"], gh_cmd=gh)
+    assert r["removable"] is False
+    assert r["blockers"] == []  # orphan is blocked by its VERDICT, not by a flag
+
+
+def test_the_orphan_has_no_landing_signal(universe):
+    repo, paths, gh = universe
+    assert row_for(repo, paths["unmerged"], gh_cmd=gh)["landed_signals"] == []
+
+
+def test_the_orphan_actually_carries_unique_commits(universe):
+    """A branch with no unique commits would be an ancestor, making the negative
+    control vacuous for the opposite reason to the positive one."""
+    repo, paths, gh = universe
+    ahead = git(repo, "rev-list", "--count", "refs/remotes/origin/main..feat/unmerged")
+    assert int(ahead) >= 1
+
+
+# ── the dirty worktree ────────────────────────────────────────────────────────
+
+def test_dirty_worktree_is_live(universe):
+    repo, paths, gh = universe
+    r = row_for(repo, paths["dirty"], gh_cmd=gh)
+    assert r["verdict"] == "live"
+    assert r["dirty"] is True
+
+
+def test_dirty_worktree_is_not_removable_even_though_its_content_landed(universe):
+    repo, paths, gh = universe
+    r = row_for(repo, paths["dirty"], gh_cmd=gh)
+    assert r["removable"] is False
+    assert any("uncommitted" in b or "untracked" in b for b in r["blockers"]), r["blockers"]
+
+
+def test_an_untracked_file_alone_counts_as_dirty(tmp_path):
+    """The case a tracked-only status check would silently discard."""
+    repo = new_repo(tmp_path)
+    commit_on_branch(repo, "feat/x", "x.txt", "x\n", "x")
+    git(repo, "merge", "-q", "--no-ff", "-m", "merge", "feat/x")
+    publish(repo)
+    wt = add_worktree(repo, tmp_path / "wt", "feat/x")
+    clean = row_for(repo, wt, gh_cmd=gh_stub(tmp_path, []))
+    assert clean["verdict"] == "dead"
+    write(wt / "untracked.md", "notes\n")
+    after = row_for(repo, wt, gh_cmd=gh_stub(tmp_path, []))
+    assert after["dirty"] is True
+    assert after["verdict"] == "live"
+
+
+def test_the_main_worktree_is_always_live_and_never_removable(universe):
+    repo, paths, gh = universe
+    r = scan(repo, gh_cmd=gh)[str(repo)]
+    assert r["is_main"] is True
+    assert r["verdict"] == "live"
+    assert r["removable"] is False
+
+
+# ── 🔴 THE MUTATION CONTROL ───────────────────────────────────────────────────
+
+def test_an_ancestry_only_classifier_calls_the_squash_an_orphan(universe, monkeypatch):
+    """Watch the SAME fixture go wrong under the broken classifier.
+
+    This is the red half of the headline test. It replaces `landing_signals`
+    with the ancestry-only version — the shape of the checker that produced the
+    245-orphan figure — and requires the squash-merged worktree to be
+    misclassified as `orphan`. If this test ever passes with the real
+    classifier in place, the `dead` verdict above is not being carried by the
+    content check.
+    """
+    repo, paths, gh = universe
+
+    def ancestry_only(repo_path, head, default_ref):
+        rc = subprocess.run(["git", "-C", str(repo_path), "merge-base", "--is-ancestor",
+                             head, default_ref], check=False).returncode
+        return {"fired": ["ancestor"] if rc == 0 else [],
+                "checked": ["ancestor"], "notes": ["ancestry only"]}
+
+    monkeypatch.setattr(wp, "landing_signals", ancestry_only)
+    r = row_for(repo, paths["squashed"], gh_cmd=gh)
+    assert r["verdict"] == "orphan", (
+        "the ancestry-only mutant did NOT misclassify the squash — the fixture "
+        "is not exercising the squash path, so the headline test proves nothing")
+
+
+def test_a_classifier_that_ignores_dirtiness_would_call_the_dirty_tree_dead(universe, monkeypatch):
+    """The second mutation: drop the dirty check and watch the dirty worktree —
+    whose content DID land — become removable. That is the shape of the bug this
+    tool exists to not have."""
+    repo, paths, gh = universe
+    real = wp.worktree_dirty
+    monkeypatch.setattr(wp, "worktree_dirty", lambda p: (False, 0, []))
+    r = row_for(repo, paths["dirty"], gh_cmd=gh)
+    assert r["verdict"] == "dead" and r["removable"] is True, (
+        "the dirty fixture is not otherwise-dead, so the real test's `live` "
+        "verdict could be coming from something other than the dirty check")
+    monkeypatch.setattr(wp, "worktree_dirty", real)
+
+
+# ── the loud unknown ──────────────────────────────────────────────────────────
+
+def test_without_gh_the_orphan_becomes_cannot_tell(universe):
+    repo, paths, gh = universe
+    r = row_for(repo, paths["unmerged"], use_gh=False)
+    assert r["verdict"] == "cannot-tell", r["verdict_reason"]
+    assert "UNKNOWN" in r["verdict_reason"]
+
+
+def test_without_gh_the_squash_is_still_dead(universe):
+    """The content signal is git-only, so removing gh must not cost us the
+    verdict that matters — only the orphan/cannot-tell distinction."""
+    repo, paths, gh = universe
+    assert row_for(repo, paths["squashed"], use_gh=False)["verdict"] == "dead"
+
+
+def test_a_broken_gh_yields_cannot_tell_not_orphan(universe, tmp_path):
+    repo, paths, gh = universe
+    r = row_for(repo, paths["unmerged"], gh_cmd=gh_broken(tmp_path))
+    assert r["verdict"] == "cannot-tell"
+    assert r["pr"]["answered"] is False
+
+
+def test_a_missing_gh_binary_yields_cannot_tell_not_orphan(universe, tmp_path):
+    repo, paths, gh = universe
+    r = row_for(repo, paths["unmerged"], gh_cmd=str(tmp_path / "no-such-gh"))
+    assert r["verdict"] == "cannot-tell"
+
+
+def test_cannot_tell_is_never_removable(universe):
+    repo, paths, gh = universe
+    r = row_for(repo, paths["unmerged"], use_gh=False)
+    assert r["removable"] is False
+
+
+def test_a_detached_worktree_with_unmerged_work_is_cannot_tell(universe, tmp_path):
+    repo, paths, gh = universe
+    sha = git(repo, "rev-parse", "feat/unmerged")
+    wt = add_worktree(repo, tmp_path / "detached", "--detach", sha)
+    r = row_for(repo, wt, gh_cmd=gh)
+    assert r["detached"] is True
+    assert r["branch"] is None
+    assert r["verdict"] == "cannot-tell"
+    assert "detached" in r["pr"]["why"]
+
+
+def test_a_detached_worktree_whose_content_landed_is_still_dead(universe, tmp_path):
+    """`cannot-tell` for a detached HEAD is about the PR lookup, not about
+    containment — the git signals work without a branch name."""
+    repo, paths, gh = universe
+    sha = git(repo, "rev-parse", "feat/squashed")
+    wt = add_worktree(repo, tmp_path / "detached-landed", "--detach", sha)
+    assert row_for(repo, wt, gh_cmd=gh)["verdict"] == "dead"
+
+
+def test_an_unresolvable_default_branch_is_cannot_tell(tmp_path):
+    repo = tmp_path / "odd"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "wip-only")
+    write(repo / "a.txt", "a\n")
+    git(repo, "add", "a.txt")
+    git(repo, "commit", "-qm", "a")
+    git(repo, "checkout", "-q", "-b", "side")
+    write(repo / "b.txt", "b\n")
+    git(repo, "add", "b.txt")
+    git(repo, "commit", "-qm", "b")
+    git(repo, "checkout", "-q", "wip-only")
+    wt = add_worktree(repo, tmp_path / "wt-odd", "side")
+    r = row_for(repo, wt, use_gh=False)
+    assert r["default_ref"] is None
+    assert r["default_how"] == "unresolved"
+    assert r["verdict"] == "cannot-tell"
+
+
+def test_a_prunable_worktree_is_cannot_tell_not_dead(universe, tmp_path):
+    """The directory is gone. `git worktree prune` is the answer, not `remove`,
+    and guessing `dead` here is how a tool starts removing things it cannot see."""
+    repo, paths, gh = universe
+    wt = add_worktree(repo, tmp_path / "vanishing", "-b", "feat/vanishing")
+    for p in sorted(wt.rglob("*"), reverse=True):
+        p.unlink() if p.is_file() or p.is_symlink() else p.rmdir()
+    wt.rmdir()
+    r = row_for(repo, wt, gh_cmd=gh)
+    assert r["verdict"] == "cannot-tell"
+    assert r["removable"] is False
+
+
+def test_a_locked_worktree_is_live(universe, tmp_path):
+    repo, paths, gh = universe
+    git(repo, "worktree", "lock", "--reason", "kept on purpose", str(paths["merged"]))
+    try:
+        r = row_for(repo, paths["merged"], gh_cmd=gh)
+        assert r["locked"] is True
+        assert r["verdict"] == "live"
+        assert r["removable"] is False
+    finally:
+        git(repo, "worktree", "unlock", str(paths["merged"]))
+
+
+# ── pull-request signals ──────────────────────────────────────────────────────
+
+def test_an_open_pr_keeps_an_unmerged_branch_live(universe, tmp_path):
+    repo, paths, _ = universe
+    gh = gh_stub(tmp_path, [{"number": 7, "state": "OPEN", "headRefName": "feat/unmerged",
+                             "mergedAt": None, "url": "u"}], name="gh-open")
+    r = row_for(repo, paths["unmerged"], gh_cmd=gh)
+    assert r["verdict"] == "live"
+    assert "#7" in r["verdict_reason"]
+
+
+def test_a_closed_unmerged_pr_leaves_the_branch_an_orphan(universe, tmp_path):
+    repo, paths, _ = universe
+    gh = gh_stub(tmp_path, [{"number": 8, "state": "CLOSED", "headRefName": "feat/unmerged",
+                             "mergedAt": None, "url": "u"}], name="gh-closed")
+    r = row_for(repo, paths["unmerged"], gh_cmd=gh)
+    assert r["verdict"] == "orphan"
+    assert "#8" in r["verdict_reason"]
+
+
+def test_a_merged_pr_rescues_a_branch_no_git_signal_can_see(tmp_path):
+    """The known false negative of `content-identical`, stated in the tool's own
+    docstring: a squash that the default branch has since built on top of. Only
+    the PR answer can see it, so this is the row that proves gh is load-bearing
+    and not decoration."""
+    repo = new_repo(tmp_path)
+    git(repo, "checkout", "-q", "-b", "feat/overwritten")
+    write(repo / "f.txt", "branch version\n")
+    git(repo, "add", "f.txt")
+    git(repo, "commit", "-qm", "branch work part 1")
+    # 🔴 TWO commits, deliberately. A ONE-commit branch squashes to a commit
+    # with the SAME patch-id, so `git cherry` sees it and the tool is not blind
+    # after all — measured: this test passed for the wrong reason until the
+    # second commit was added.
+    write(repo / "f.txt", "branch version\nmore branch work\n")
+    git(repo, "add", "f.txt")
+    git(repo, "commit", "-qm", "branch work part 2")
+    git(repo, "checkout", "-q", "main")
+    squash_merge(repo, "feat/overwritten", "f.txt", "squash (#9)")
+    write(repo / "f.txt", "and then main changed it again\n")
+    git(repo, "add", "f.txt")
+    git(repo, "commit", "-qm", "later work on the same path")
+    publish(repo)
+    wt = add_worktree(repo, tmp_path / "wt", "feat/overwritten")
+
+    blind = row_for(repo, wt, gh_cmd=gh_stub(tmp_path, [], name="gh-empty"))
+    assert blind["verdict"] == "orphan", (
+        "the git signals were supposed to be blind here; if they see it, this "
+        "test is not exercising the false negative it claims to")
+
+    gh = gh_stub(tmp_path, [{"number": 9, "state": "MERGED", "headRefName": "feat/overwritten",
+                             "mergedAt": "2026-01-01T00:00:00Z", "url": "u"}], name="gh-merged")
+    seeing = row_for(repo, wt, gh_cmd=gh)
+    assert seeing["verdict"] == "dead"
+    assert "pr-merged" in seeing["landed_signals"]
+
+
+def test_a_cherry_picked_branch_is_dead_by_patch_equivalence_alone(tmp_path):
+    """The third signal, exercised where it is the ONLY one that can fire.
+
+    🔴 This test exists because a mutation sweep deleted the `patch-equivalent`
+    signal and the whole suite stayed GREEN — every other landing case was
+    already covered by `ancestor` or `content-identical`, so the signal was
+    decorative as far as the tests could see. The fixture cherry-picks the
+    branch's commit onto main and then changes the same path AGAIN, which puts
+    `content-identical` out of reach and leaves patch-equivalence carrying the
+    verdict on its own.
+    """
+    repo = new_repo(tmp_path)
+    write(repo / "p.txt", "orig\n")
+    git(repo, "add", "p.txt")
+    git(repo, "commit", "-qm", "add p")
+    publish(repo)
+
+    git(repo, "checkout", "-q", "-b", "feat/picked")
+    write(repo / "p.txt", "orig\npicked\n")
+    git(repo, "add", "p.txt")
+    git(repo, "commit", "-qm", "the work")
+    picked = git(repo, "rev-parse", "HEAD")
+
+    git(repo, "checkout", "-q", "main")
+    # 🔴 Main must DIVERGE before the pick. Cherry-picking straight onto the
+    # branch's own parent reproduces the identical commit — same tree, same
+    # parent, same identity, same second — so git hands back the SAME sha and
+    # the branch becomes a genuine ancestor. Measured: this fixture asserted
+    # `patch-equivalent` and got `ancestor` until this commit was added.
+    write(repo / "unrelated.txt", "main did something else first\n")
+    git(repo, "add", "unrelated.txt")
+    git(repo, "commit", "-qm", "unrelated main work")
+    git(repo, "cherry-pick", picked)
+    write(repo / "p.txt", "orig\npicked\nlater\n")
+    git(repo, "add", "p.txt")
+    git(repo, "commit", "-qm", "main moves on over the same path")
+    publish(repo)
+
+    wt = add_worktree(repo, tmp_path / "wt", "feat/picked")
+    r = row_for(repo, wt, use_gh=False)
+    assert r["landed_signals"] == ["patch-equivalent"], r["evidence"]
+    assert r["verdict"] == "dead"
+    assert r["removable"] is True
+
+
+def test_a_truncated_pr_index_falls_back_to_a_per_branch_query(universe, tmp_path):
+    """An absence in a TRUNCATED list proves nothing. With `--pr-limit 1` the
+    bulk index is at its limit, so the tool must ask directly rather than read
+    the gap as 'no PR'."""
+    repo, paths, _ = universe
+    gh = gh_stub(tmp_path, [{"number": 1, "state": "MERGED", "headRefName": "unrelated",
+                             "mergedAt": "2026-01-01T00:00:00Z", "url": "u"}], name="gh-trunc")
+    r = row_for(repo, paths["unmerged"], gh_cmd=gh, pr_limit=1)
+    assert r["pr"]["answered"] is True
+    assert "direct query" in r["pr"]["why"]
+    assert r["verdict"] == "orphan"
+
+
+def test_a_complete_index_says_so_in_the_evidence(universe):
+    repo, paths, gh = universe
+    r = row_for(repo, paths["unmerged"], gh_cmd=gh)
+    assert "COMPLETE index" in r["pr"]["why"]
+
+
+def test_a_merged_state_outranks_a_stale_open_record_for_the_same_branch(universe, tmp_path):
+    repo, paths, _ = universe
+    gh = gh_stub(tmp_path, [
+        {"number": 3, "state": "OPEN", "headRefName": "feat/unmerged", "mergedAt": None, "url": "u"},
+        {"number": 4, "state": "MERGED", "headRefName": "feat/unmerged",
+         "mergedAt": "2026-01-01T00:00:00Z", "url": "u"},
+    ], name="gh-rank")
+    r = row_for(repo, paths["unmerged"], gh_cmd=gh)
+    assert r["verdict"] == "dead"
+    assert r["pr"]["number"] == 4
+
+
+# ── the empty-pathspec hazard ─────────────────────────────────────────────────
+
+def test_paths_differ_refuses_an_empty_pathspec(tmp_path):
+    """A pathspec-less `git diff` compares the WHOLE trees. That is the mirror
+    image of the `--pathspec-from-file` bug: it answers a question nobody asked,
+    reassuringly."""
+    repo = new_repo(tmp_path)
+    with pytest.raises(AssertionError, match="EMPTY pathspec"):
+        wp._paths_differ(repo, "main", "refs/remotes/origin/main", [])
+
+
+def test_a_branch_with_no_unique_content_is_landed_by_the_short_circuit(tmp_path):
+    """A branch whose commits net out to no change must take the
+    `no-content-change` path, NOT a whole-tree diff."""
+    repo = new_repo(tmp_path)
+    git(repo, "checkout", "-q", "-b", "feat/noop")
+    write(repo / "tmp.txt", "temporary\n")
+    git(repo, "add", "tmp.txt")
+    git(repo, "commit", "-qm", "add")
+    (repo / "tmp.txt").unlink()
+    git(repo, "add", "-A", "tmp.txt")
+    git(repo, "commit", "-qm", "and remove it again")
+    git(repo, "checkout", "-q", "main")
+    write(repo / "elsewhere.txt", "main moved on\n")
+    git(repo, "add", "elsewhere.txt")
+    git(repo, "commit", "-qm", "main moves")
+    publish(repo)
+    wt = add_worktree(repo, tmp_path / "wt", "feat/noop")
+    r = row_for(repo, wt, use_gh=False)
+    assert r["landed_signals"] == ["no-content-change"], r["evidence"]
+    assert r["verdict"] == "dead"
+
+
+def test_pathspec_batching_survives_more_paths_than_one_argv_can_hold(tmp_path, monkeypatch):
+    """`PATHSPEC_BATCH_BYTES` exists because a truncated argv would show up as
+    'no differing paths' — a confident, wrong `dead`. Shrinking the batch size
+    forces many batches over a real repo and the answer must not move."""
+    repo = new_repo(tmp_path)
+    git(repo, "checkout", "-q", "-b", "feat/many")
+    for i in range(40):
+        write(repo / f"dir{i}" / f"file-with-a-long-name-{i}.txt", f"content {i}\n")
+    git(repo, "add", "-A", ".")
+    git(repo, "commit", "-qm", "many files")
+    git(repo, "checkout", "-q", "main")
+    base = git(repo, "rev-parse", "main")
+    changed = subprocess.run(["git", "-C", str(repo), "diff", "--name-only", base, "feat/many"],
+                             capture_output=True, text=True, check=True).stdout.split()
+    assert len(changed) == 40
+    monkeypatch.setattr(wp, "PATHSPEC_BATCH_BYTES", 30)
+    assert wp._paths_differ(repo, "feat/many", "main", changed) is True
+    assert wp._paths_differ(repo, "feat/many", "feat/many", changed) is False
+
+
+# ── porcelain parsing ─────────────────────────────────────────────────────────
+
+PORCELAIN = """worktree /home/z/repo
+HEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+branch refs/heads/main
+
+worktree /home/z/wt-detached
+HEAD bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+detached
+
+worktree /home/z/wt-locked
+HEAD cccccccccccccccccccccccccccccccccccccccc
+branch refs/heads/feat/keep
+locked kept on purpose
+
+worktree /home/z/wt-gone
+HEAD dddddddddddddddddddddddddddddddddddddddd
+branch refs/heads/feat/gone
+prunable gitdir file points to non-existent location
+"""
+
+
+def test_porcelain_parser_reads_every_attribute():
+    rows = wp.parse_worktree_porcelain(PORCELAIN)
+    assert [r["path"] for r in rows] == [
+        "/home/z/repo", "/home/z/wt-detached", "/home/z/wt-locked", "/home/z/wt-gone"]
+    assert rows[0]["is_main"] is True and rows[0]["branch"] == "main"
+    assert rows[1]["detached"] is True and rows[1]["branch"] is None
+    assert rows[2]["locked"] is True and rows[2]["lock_reason"] == "kept on purpose"
+    assert rows[3]["prunable"] is True
+    assert rows[3]["prune_reason"] == "gitdir file points to non-existent location"
+    assert [r["is_main"] for r in rows[1:]] == [False, False, False]
+
+
+def test_porcelain_parser_handles_a_missing_trailing_blank_line():
+    rows = wp.parse_worktree_porcelain("worktree /a\nHEAD " + "e" * 40 + "\nbranch refs/heads/x")
+    assert len(rows) == 1 and rows[0]["branch"] == "x"
+
+
+def test_porcelain_parser_marks_only_the_first_block_as_main():
+    rows = wp.parse_worktree_porcelain(PORCELAIN)
+    assert sum(1 for r in rows if r["is_main"]) == 1
+
+
+# ── classify() as a pure function ─────────────────────────────────────────────
+
+def base_row(**kw) -> dict:
+    row = {"is_main": False, "bare": False, "prunable": False, "path_exists": True,
+           "locked": False, "dirty": False, "dirty_count": 0,
+           "default_ref": "refs/remotes/origin/main", "landed_signals": [],
+           "signal_error": False, "evidence": [],
+           "pr": {"answered": True, "state": None, "number": None, "merged_at": None,
+                  "why": "complete index"}}
+    row.update(kw)
+    return row
+
+
+@pytest.mark.parametrize("kw,expected", [
+    ({"is_main": True}, "live"),
+    ({"bare": True}, "live"),
+    ({"prunable": True}, "cannot-tell"),
+    ({"path_exists": False}, "cannot-tell"),
+    ({"locked": True}, "live"),
+    ({"dirty": None}, "cannot-tell"),
+    ({"dirty": True, "dirty_count": 3}, "live"),
+    ({"default_ref": None}, "cannot-tell"),
+    ({"landed_signals": ["ancestor"]}, "dead"),
+    ({"landed_signals": ["content-identical"]}, "dead"),
+    ({"landed_signals": ["patch-equivalent"]}, "dead"),
+    ({"landed_signals": ["no-content-change"]}, "dead"),
+    ({"signal_error": True}, "cannot-tell"),
+    ({}, "orphan"),
+])
+def test_classify_covers_every_branch(kw, expected):
+    assert wp.classify(base_row(**kw))["verdict"] == expected
+
+
+@pytest.mark.parametrize("state,expected", [
+    ("OPEN", "live"), ("MERGED", "dead"), ("CLOSED", "orphan"), (None, "orphan"),
+])
+def test_classify_pull_request_states(state, expected):
+    row = base_row(pr={"answered": True, "state": state, "number": 5,
+                       "merged_at": None, "why": "complete index"})
+    assert wp.classify(row)["verdict"] == expected
+
+
+def test_classify_never_returns_a_verdict_outside_the_vocabulary():
+    for kw in ({}, {"is_main": True}, {"dirty": True}, {"prunable": True},
+               {"landed_signals": ["ancestor"]}, {"pr": {"answered": False, "state": None,
+                                                         "number": None, "merged_at": None,
+                                                         "why": "x"}}):
+        assert wp.classify(base_row(**kw))["verdict"] in wp.VERDICTS
+
+
+def test_only_dead_rows_are_ever_removable():
+    for kw in ({}, {"is_main": True}, {"dirty": True}, {"prunable": True},
+               {"path_exists": False}, {"locked": True}, {"signal_error": True},
+               {"default_ref": None}):
+        r = wp.classify(base_row(**kw))
+        assert r["removable"] is False, (kw, r["verdict"])
+
+
+def test_an_open_pr_beats_a_landing_signal():
+    """A branch can be both merged and have a newer open PR reusing the name.
+    Live wins — the tool must not remove a tree someone is iterating in."""
+    row = base_row(landed_signals=["ancestor"],
+                   pr={"answered": True, "state": "OPEN", "number": 11,
+                       "merged_at": None, "why": "complete index"})
+    assert wp.classify(row)["verdict"] == "live"
+
+
+# ── the safety contract ───────────────────────────────────────────────────────
+
+def _executable_string_literals(path: Path) -> "list[str]":
+    """Every string constant in the module EXCEPT docstrings and comments.
+
+    A `--force` that reaches git has to be a string literal in executable code,
+    so this is the exact surface — and it does not go red merely because the
+    module's prose explains why `--force` is never passed.
+    """
+    import ast
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    docstrings = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            body = getattr(node, "body", None)
+            if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant) \
+                    and isinstance(body[0].value.value, str):
+                docstrings.add(id(body[0].value))
+    return [n.value for n in ast.walk(tree)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str)
+            and id(n) not in docstrings]
+
+
+def test_the_tool_never_passes_force_to_worktree_remove():
+    """Structural, and deliberately blunt. A verdict-level test cannot see a
+    `--force` added to the removal call, because the fixture would be removed
+    either way and the test would stay green."""
+    literals = _executable_string_literals(TOOL)
+    offenders = [s for s in literals if "--force" in s or s == "-f"]
+    assert offenders == [], f"a force flag reached executable code: {offenders}"
+    assert "worktree" in literals and "remove" in literals, (
+        "the removal call is not where this test thinks it is — the scan above "
+        "would then be looking at the wrong file")
+
+
+def test_the_force_scanner_can_go_red(tmp_path):
+    """🔴 Negative control on the scanner above. A check that cannot fail is
+    indistinguishable from no check, and this one is a grep in disguise."""
+    mutant = tmp_path / "mutant.py"
+    mutant.write_text(
+        '"""A docstring that says --force and must NOT trip the scanner."""\n'
+        'def f():\n'
+        '    """Also mentions --force."""\n'
+        '    return _git(repo, "worktree", "remove", "--force", str(path))\n',
+        encoding="utf-8")
+    assert [s for s in _executable_string_literals(mutant) if "--force" in s] == ["--force"]
+
+
+def test_dry_run_is_the_default_and_removes_nothing(universe, tmp_path, capsys):
+    repo, paths, gh = universe
+    before = set(git(repo, "worktree", "list", "--porcelain").splitlines())
+    rc = wp.main(["--repo", str(repo), "--gh-cmd", gh, "--jobs", "1"])
+    assert rc == wp.RC_OK
+    assert set(git(repo, "worktree", "list", "--porcelain").splitlines()) == before
+    err = capsys.readouterr().err
+    assert "DRY RUN" in err
+
+
+def test_execute_without_confirm_refuses_and_removes_nothing(universe, tmp_path, capsys):
+    repo, paths, gh = universe
+    rc = wp.main(["--repo", str(repo), "--gh-cmd", gh, "--jobs", "1", "--execute"])
+    assert rc == wp.RC_EXECUTE_REFUSED
+    assert paths["squashed"].is_dir()
+    err = capsys.readouterr().err
+    assert "REFUSED" in err
+    # The message must name the number, or the operator's next move is a guess.
+    assert "--confirm 2" in err, err
+
+
+def test_execute_with_a_wrong_confirm_refuses_and_removes_nothing(universe, capsys):
+    repo, paths, gh = universe
+    rc = wp.main(["--repo", str(repo), "--gh-cmd", gh, "--jobs", "1",
+                  "--execute", "--confirm", "99"])
+    assert rc == wp.RC_EXECUTE_REFUSED
+    assert paths["squashed"].is_dir() and paths["merged"].is_dir()
+    assert "does not match" in capsys.readouterr().err
+
+
+def test_execute_removes_only_the_dead_rows(universe, capsys):
+    repo, paths, gh = universe
+    rows = wp.scan_repo(repo, gh, True, 2000, jobs=1)
+    n = sum(1 for r in rows if r["removable"])
+    assert n == 2, [r["path"] for r in rows if r["removable"]]
+    assert wp.execute_removals(rows, n) == wp.RC_OK
+    assert not paths["squashed"].exists()
+    assert not paths["merged"].exists()
+    assert paths["unmerged"].is_dir(), "an orphan was removed"
+    assert paths["dirty"].is_dir(), "a dirty worktree was removed"
+
+
+def test_execute_rechecks_dirtiness_at_the_moment_of_removal(universe, capsys):
+    """🔴 The scan is a claim about the PAST. A concurrent session can start
+    editing between the survey and the delete, so the check runs immediately
+    before the destructive step — not in the survey that motivated it."""
+    repo, paths, gh = universe
+    rows = [r for r in wp.scan_repo(repo, gh, True, 2000, jobs=1)
+            if r["path"] == str(paths["squashed"])]
+    assert rows[0]["removable"] is True
+    write(paths["squashed"] / "SOMEONE_STARTED_WORKING.md", "in flight\n")
+    assert wp.execute_removals(rows, 1) == wp.RC_OK
+    assert paths["squashed"].is_dir(), "a worktree that went dirty after the scan was removed"
+    assert "SKIP" in capsys.readouterr().err
+
+
+def test_execute_refuses_a_row_whose_verdict_is_not_dead_even_if_removable_is_set(universe, capsys):
+    """Defence in depth: `removable` is derived from the verdict, but the
+    executor re-asserts the verdict rather than trusting the flag it was handed."""
+    repo, paths, gh = universe
+    rows = wp.scan_repo(repo, gh, True, 2000, jobs=1)
+    victim = [r for r in rows if r["path"] == str(paths["unmerged"])]
+    assert victim[0]["verdict"] == "orphan"
+    victim[0]["removable"] = True
+    assert wp.execute_removals(victim, 1) == wp.RC_OK
+    assert paths["unmerged"].is_dir()
+    assert "not dead" in capsys.readouterr().err
+
+
+def test_execute_skips_a_worktree_git_no_longer_lists(universe, capsys):
+    repo, paths, gh = universe
+    rows = [r for r in wp.scan_repo(repo, gh, True, 2000, jobs=1)
+            if r["path"] == str(paths["merged"])]
+    git(repo, "worktree", "remove", str(paths["merged"]))
+    assert wp.execute_removals(rows, 1) == wp.RC_OK
+    assert "no longer lists" in capsys.readouterr().err
+
+
+# ── cli surface ───────────────────────────────────────────────────────────────
+
+def test_json_output_carries_the_evidence_for_every_row(universe, tmp_path, capsys):
+    repo, paths, gh = universe
+    out = tmp_path / "report.json"
+    rc = wp.main(["--repo", str(repo), "--gh-cmd", gh, "--jobs", "1",
+                  "--format", "json", "--out", str(out)])
+    assert rc == wp.RC_OK
+    capsys.readouterr()
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert set(payload) == {"summary", "rows"}
+    assert payload["summary"]["counts"]["dead"] == 2
+    assert payload["summary"]["counts"]["orphan"] == 1
+    for row in payload["rows"]:
+        assert row["evidence"], row["path"]
+        assert row["verdict_reason"]
+        assert "default branch" in row["evidence"][0]
+
+
+def test_the_text_report_shouts_about_cannot_tell(universe, capsys):
+    repo, paths, gh = universe
+    wp.main(["--repo", str(repo), "--jobs", "1", "--no-gh"])
+    out = capsys.readouterr().out
+    assert "cannot-tell" in out
+    assert "NOT dead" in out
+
+
+def test_a_clean_run_with_no_unknowns_does_not_shout(universe, capsys):
+    repo, paths, gh = universe
+    wp.main(["--repo", str(repo), "--gh-cmd", gh, "--jobs", "1"])
+    out = capsys.readouterr().out
+    assert "NOT dead" not in out
+
+
+def test_no_repos_named_is_an_error_not_an_empty_success(capsys):
+    assert wp.main([]) == wp.RC_NOTHING_TO_SCAN
+    assert "nothing to scan" in capsys.readouterr().err
+
+
+def test_dry_run_and_execute_together_are_a_usage_error(universe):
+    repo, paths, gh = universe
+    assert wp.main(["--repo", str(repo), "--dry-run", "--execute"]) == wp.RC_USAGE
+
+
+def test_confirm_without_execute_is_a_usage_error(universe):
+    repo, paths, gh = universe
+    assert wp.main(["--repo", str(repo), "--confirm", "1"]) == wp.RC_USAGE
+
+
+def test_repos_from_file_reads_paths_and_ignores_comments(universe, tmp_path):
+    repo, paths, gh = universe
+    listing = tmp_path / "repos.txt"
+    listing.write_text(f"# a comment\n\n{repo}  # trailing\n", encoding="utf-8")
+
+    class A:
+        repo = []
+        repos_from = str(listing)
+        scan_root = []
+        scan_depth = 2
+    assert wp.collect_repos(A()) == [Path(str(repo))]
+
+
+def test_the_tool_runs_as_a_subprocess_and_exits_zero(universe, tmp_path):
+    repo, paths, gh = universe
+    r = subprocess.run([sys.executable, str(TOOL), "--repo", str(repo),
+                        "--gh-cmd", gh, "--jobs", "1", "--format", "json"],
+                       capture_output=True, text=True, check=False, timeout=180)
+    assert r.returncode == 0, r.stderr
+    payload = json.loads(r.stdout)
+    assert payload["summary"]["worktrees"] == 5
+
+
+# ── discovery ─────────────────────────────────────────────────────────────────
+
+def test_discovery_finds_main_checkouts_and_not_their_worktrees(universe, tmp_path):
+    repo, paths, gh = universe
+    found = wp.discover_repos([tmp_path], depth=3)
+    assert repo.resolve() in found
+    for p in paths.values():
+        assert p.resolve() not in found, f"{p} is a linked worktree, not a checkout"
+
+
+def test_discovery_accepts_a_root_that_is_itself_a_repo(universe, tmp_path):
+    repo, paths, gh = universe
+    assert wp.discover_repos([repo], depth=1) == [repo.resolve()]
+
+
+def test_discovery_respects_the_depth_limit(universe, tmp_path):
+    repo, paths, gh = universe
+    deep = tmp_path / "a" / "b" / "c"
+    deep.mkdir(parents=True)
+    nested = new_repo(deep, "nested")
+    assert nested.resolve() not in wp.discover_repos([tmp_path], depth=2)
+    assert nested.resolve() in wp.discover_repos([tmp_path], depth=5)
+
+
+def test_discovery_survives_a_directory_it_cannot_read(universe, tmp_path):
+    """🔴 Found by the FIRST real run, not by a fixture. `Path.is_dir()` raises
+    on EACCES — it swallows only ENOENT/ENOTDIR/EBADF/ELOOP — so a `lost+found`
+    inside a scan root took the entire scan down with a traceback before one row
+    was printed. An unreadable directory holds no worktrees we can classify; it
+    is not a reason to abandon the other 750.
+    """
+    walled = tmp_path / "walled"
+    walled.mkdir()
+    (walled / "inner").mkdir()
+    walled.chmod(0o000)
+    try:
+        found = wp.discover_repos([tmp_path], depth=3)
+    finally:
+        walled.chmod(0o755)
+    repo, _, _ = universe
+    assert repo.resolve() in found, "the readable repo was lost to the unreadable sibling"
+
+
+@pytest.mark.parametrize("depth", [1, 3])
+def test_discovery_survives_an_unreadable_root_itself(tmp_path, depth):
+    walled = tmp_path / "root"
+    walled.mkdir()
+    walled.chmod(0o000)
+    try:
+        assert wp.discover_repos([walled], depth=depth) == []
+    finally:
+        walled.chmod(0o755)
+
+
+def test_repo_slug_reads_the_github_owner_and_name(tmp_path):
+    repo = new_repo(tmp_path)
+    assert wp.repo_slug(repo) == "fixture/repo"
+    git(repo, "remote", "set-url", "origin", "git@github.com:owner/name.git")
+    assert wp.repo_slug(repo) == "owner/name"
+    git(repo, "remote", "set-url", "origin", "https://gitlab.com/owner/name.git")
+    assert wp.repo_slug(repo) is None
+
+
+def test_default_branch_resolution_records_how_it_was_resolved(tmp_path):
+    repo = new_repo(tmp_path)
+    ref, how = wp.resolve_default_ref(repo)
+    assert (ref, how) == ("refs/remotes/origin/main", "origin-head-symref")
+    git(repo, "symbolic-ref", "-d", "refs/remotes/origin/HEAD")
+    assert wp.resolve_default_ref(repo) == ("refs/remotes/origin/main", "remote-candidate:main")
+    git(repo, "update-ref", "-d", "refs/remotes/origin/main")
+    assert wp.resolve_default_ref(repo) == ("refs/heads/main", "local-candidate:main")
+
+
+# ── the instrument's own controls ─────────────────────────────────────────────
+
+def test_the_gh_stub_can_be_observed_to_answer(tmp_path):
+    """A positive control on the harness. A stub wired to nothing produces the
+    same empty PR index as a real gh with no PRs, and every orphan verdict in
+    this file rests on telling those apart."""
+    gh = gh_stub(tmp_path, [{"number": 1, "state": "OPEN", "headRefName": "b",
+                             "mergedAt": None, "url": "u"}], name="gh-probe")
+    r = subprocess.run([gh, "pr", "list", "--repo", "x/y", "--state", "all",
+                        "--json", "number"], capture_output=True, text=True, check=False)
+    assert r.returncode == 0
+    assert json.loads(r.stdout)[0]["number"] == 1
+
+
+def test_the_broken_gh_stub_really_fails(tmp_path):
+    r = subprocess.run([gh_broken(tmp_path, "gh-probe-broken")], capture_output=True,
+                       text=True, check=False)
+    assert r.returncode != 0
+
+
+def test_the_stub_interpreter_exists(tmp_path):
+    assert mockbin.interpreter_is_executable(), (
+        "the stub shebang interpreter is missing — every gh stub in this file "
+        "would fail to exec and the tests that depend on one must go red, not "
+        "silently empty")

--- a/scripts/worktree-prune
+++ b/scripts/worktree-prune
@@ -1,0 +1,835 @@
+#!/usr/bin/env python3
+"""Classify git worktrees across many repos as dead / orphan / live / cannot-tell.
+
+WHY THIS EXISTS
+---------------
+A 14-day audit counted 593 worktrees across these repos and reported 217 dead
+and 245 orphans. That classification is NOT usable as a delete list, for a
+reason that has nothing to do with the count: the containment checker that
+produced it called a `git diff --pathspec-from-file` that does not exist, exited
+129, and therefore scored EVERY branch as unmerged. It was rebuilt and spot-
+checked 7/7 against PR ground truth afterwards — but 7 confirmations is thin
+support for 245 irreversible deletions, and "unmerged, no PR" is also the exact
+profile of work in progress.
+
+So this tool re-derives the classification from scratch, records the EVIDENCE
+each verdict rests on, and refuses to guess.
+
+🔴 THE TRAP THIS TOOL IS BUILT AROUND: A SQUASH MERGE IS NOT AN ANCESTOR
+------------------------------------------------------------------------
+`git merge-base --is-ancestor <branch> <default>` returns FALSE for every
+squash-merged branch, forever — the squash is a new commit with different
+parents, so the branch's own commits genuinely are not in the default branch's
+history. A classifier that asks only that question reports merged work as
+orphaned, which is the failure mode that gets real work deleted.
+
+"Did this land" is therefore answered by FOUR independent signals, and the row
+records which ones fired:
+
+  ancestor          `git merge-base --is-ancestor` — definitive when true,
+                    worthless when false (see above).
+  pr-merged         `gh pr list --head <branch> --state all` reports MERGED.
+                    Definitive, and the only signal that survives a squash the
+                    default branch has since built on top of.
+  content-identical every path the branch changed since its merge-base has the
+                    SAME content in the default branch. This is the signal that
+                    catches a squash merge with no git-level ancestry.
+  patch-equivalent  `git cherry <default> <head>` finds an equivalent commit
+                    upstream for every commit on the branch. Catches rebases
+                    and cherry-picks.
+
+🔴 `content-identical` HAS A KNOWN FALSE NEGATIVE, stated rather than implied:
+if the branch squash-merged and the default branch has since CHANGED one of
+those paths again, the contents no longer match and this signal goes quiet. That
+is why `pr-merged` exists, and why a row with no signal at all and no
+authoritative PR answer is `cannot-tell`, never `dead`.
+
+🔴 AND A GUARD AGAINST THE MIRROR-IMAGE BUG: a comparison against an ABSENT
+operand reports SAME, not MISSING. If the branch changed nothing since its
+merge-base the changed-path set is EMPTY, and a pathspec-less `git diff` would
+then compare the WHOLE TREES and answer a question nobody asked. That case is
+short-circuited explicitly (`no-content-change`) and never reaches the diff.
+
+THE VERDICTS
+------------
+  live         the main checkout, or locked, or DIRTY (any uncommitted or
+               untracked file), or carrying an OPEN pull request.
+  dead         clean, and at least one landing signal fired.
+  orphan       clean, no landing signal, AND an authoritative PR answer says
+               there is no open PR. Informational — NEVER removable.
+  cannot-tell  everything else, loudly: gh unavailable or unauthenticated, a
+               truncated PR index, a detached HEAD with no branch to look up, an
+               unresolvable default branch, a git command that failed, a
+               worktree whose path is gone. It is never silently folded into
+               `dead`.
+
+🔴 WHAT THIS TOOL WILL NOT DO
+-----------------------------
+  * `--dry-run` is the DEFAULT. Nothing is removed without `--execute`.
+  * `--execute` additionally requires `--confirm N` where N is EXACTLY the
+     number of rows the run would remove. A scope that moved under you (a
+     branch merged, a worktree went dirty) changes N and the run refuses.
+  * Only rows whose verdict is `dead` are ever removable. `orphan` and
+    `cannot-tell` are not, by construction.
+  * `git worktree remove` is called WITHOUT `--force`, ever. Git's own refusal
+    on a dirty tree is a second, independent floor under the dirty check this
+    tool already ran — and it is re-run immediately BEFORE each removal, not
+    inherited from the scan that motivated it.
+
+USAGE
+  worktree-prune --scan-root ~/workspace --scan-depth 2 [--out report.json]
+  worktree-prune --repo ~/workspace/devrc --format json
+  worktree-prune --repos-from repos.txt --no-gh
+  worktree-prune --scan-root ~/workspace --execute --confirm 12   # fires
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+# ── exit codes ────────────────────────────────────────────────────────────────
+RC_OK = 0
+RC_USAGE = 2
+RC_EXECUTE_REFUSED = 3
+RC_NOTHING_TO_SCAN = 4
+
+# Verdict vocabulary. Spelled as literals so a test can pin them without reading
+# them back out of the classifier that produces them.
+DEAD = "dead"
+ORPHAN = "orphan"
+LIVE = "live"
+CANNOT_TELL = "cannot-tell"
+VERDICTS = (DEAD, ORPHAN, LIVE, CANNOT_TELL)
+
+# 🔴 argv on Linux is capped (~128 KiB for a single argument list, and a
+# civitai branch can touch thousands of paths). Pathspecs are therefore batched
+# well under that rather than passed in one go — a truncated-argv failure would
+# show up as "no differing paths", i.e. as a confident, wrong `dead`.
+PATHSPEC_BATCH_BYTES = 40_000
+
+GIT_TIMEOUT = 180
+GH_TIMEOUT = 120
+
+DEFAULT_BRANCH_CANDIDATES = ("main", "master", "trunk", "develop")
+
+
+def _log(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+# ── git plumbing ──────────────────────────────────────────────────────────────
+
+def _git(cwd: Path, *args: str, timeout: int = GIT_TIMEOUT) -> subprocess.CompletedProcess:
+    """One git invocation. `--no-optional-locks` so a read cannot race a
+    concurrent session by refreshing the index of a repo it does not own."""
+    return subprocess.run(
+        ["git", "--no-optional-locks", "-C", str(cwd), *args],
+        capture_output=True, text=True, timeout=timeout, check=False,
+    )
+
+
+def _git_ok(cwd: Path, *args: str) -> "str | None":
+    r = _git(cwd, *args)
+    return r.stdout.strip() if r.returncode == 0 else None
+
+
+def is_dir(p: Path) -> bool:
+    """`Path.is_dir()` that cannot raise.
+
+    🔴 `Path.is_dir()` RAISES on EACCES — it swallows only ENOENT/ENOTDIR/EBADF/
+    ELOOP. Measured on this tool's FIRST real run: a `lost+found` inside a scan
+    root took the whole scan down with a PermissionError traceback before one
+    row was printed. A directory we cannot read holds no worktrees we can
+    classify; that is a row we cannot tell about, not a reason to abandon the
+    other 750. One helper, used at every such test, because the same
+    `Path.is_dir()` sits behind `path_exists` and the dirty check too.
+    """
+    try:
+        return p.is_dir()
+    except OSError:
+        return False
+
+
+def discover_repos(roots: "list[Path]", depth: int) -> "list[Path]":
+    """Directories under `roots` (to `depth` levels) whose `.git` is a DIRECTORY.
+
+    🔴 The `.git`-is-a-directory test is what separates a MAIN checkout from a
+    linked worktree: a linked worktree's `.git` is a FILE holding `gitdir: …`.
+    Enumerating worktrees from a linked worktree would report the same set N
+    times and make every count wrong.
+    """
+    found: dict[str, Path] = {}
+
+    def walk(d: Path, level: int) -> None:
+        if level > depth:
+            return
+        try:
+            entries = sorted(p for p in d.iterdir() if is_dir(p) and not p.is_symlink())
+        except OSError:
+            return
+        for p in entries:
+            if p.name == ".git":
+                continue
+            if is_dir(p / ".git"):
+                found[str(p.resolve())] = p.resolve()
+                continue  # a main checkout; do not descend into its worktrees
+            walk(p, level + 1)
+
+    for root in roots:
+        root = root.expanduser()
+        if is_dir(root / ".git"):
+            found[str(root.resolve())] = root.resolve()
+            continue
+        walk(root, 1)
+    return sorted(found.values(), key=str)
+
+
+def parse_worktree_porcelain(text: str) -> "list[dict]":
+    """Parse `git worktree list --porcelain` into one dict per worktree.
+
+    Blocks are blank-line separated; the FIRST block is the main worktree.
+    Attribute lines are `key` or `key value`.
+    """
+    rows: list[dict] = []
+    cur: "dict | None" = None
+    for raw in text.splitlines():
+        line = raw.rstrip("\n")
+        if not line.strip():
+            if cur is not None:
+                rows.append(cur)
+                cur = None
+            continue
+        key, _, value = line.partition(" ")
+        if key == "worktree":
+            if cur is not None:
+                rows.append(cur)
+            cur = {"path": value, "head": None, "branch": None, "detached": False,
+                   "bare": False, "locked": False, "lock_reason": None,
+                   "prunable": False, "prune_reason": None}
+        elif cur is None:
+            continue
+        elif key == "HEAD":
+            cur["head"] = value
+        elif key == "branch":
+            cur["branch"] = value[len("refs/heads/"):] if value.startswith("refs/heads/") else value
+        elif key == "detached":
+            cur["detached"] = True
+        elif key == "bare":
+            cur["bare"] = True
+        elif key == "locked":
+            cur["locked"] = True
+            cur["lock_reason"] = value or None
+        elif key == "prunable":
+            cur["prunable"] = True
+            cur["prune_reason"] = value or None
+    if cur is not None:
+        rows.append(cur)
+    for i, r in enumerate(rows):
+        r["is_main"] = (i == 0)
+    return rows
+
+
+def list_worktrees(repo: Path) -> "list[dict]":
+    r = _git(repo, "worktree", "list", "--porcelain")
+    if r.returncode != 0:
+        return []
+    return parse_worktree_porcelain(r.stdout)
+
+
+def resolve_default_ref(repo: Path) -> "tuple[str | None, str]":
+    """The repo's default branch, plus HOW it was resolved.
+
+    The `how` string is carried into every row's evidence: a verdict computed
+    against the wrong default branch is wrong in the dangerous direction, and
+    "we guessed `main` because origin/HEAD was unset" must be visible.
+    """
+    sym = _git_ok(repo, "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD")
+    if sym:
+        return sym, "origin-head-symref"
+    for name in DEFAULT_BRANCH_CANDIDATES:
+        ref = f"refs/remotes/origin/{name}"
+        if _git(repo, "rev-parse", "--verify", "--quiet", ref).returncode == 0:
+            return ref, f"remote-candidate:{name}"
+    for name in DEFAULT_BRANCH_CANDIDATES:
+        ref = f"refs/heads/{name}"
+        if _git(repo, "rev-parse", "--verify", "--quiet", ref).returncode == 0:
+            return ref, f"local-candidate:{name}"
+    return None, "unresolved"
+
+
+def repo_slug(repo: Path) -> "str | None":
+    """`owner/name` from origin's URL, for `gh --repo`. None if not GitHub."""
+    url = _git_ok(repo, "remote", "get-url", "origin")
+    if not url:
+        return None
+    u = url.strip()
+    if u.endswith(".git"):
+        u = u[:-4]
+    if "github.com" not in u:
+        return None
+    if u.startswith("git@") or u.startswith("ssh://"):
+        _, _, tail = u.partition("github.com")
+        tail = tail.lstrip(":/")
+    else:
+        _, _, tail = u.partition("github.com")
+        tail = tail.lstrip("/")
+    parts = [p for p in tail.split("/") if p]
+    return "/".join(parts[:2]) if len(parts) >= 2 else None
+
+
+def worktree_dirty(path: Path) -> "tuple[bool | None, int, list[str]]":
+    """(dirty, count, sample). `None` means UNKNOWABLE — never False.
+
+    Untracked files count as dirty on purpose: an unstaged new file is exactly
+    the "docs written into a working tree are unsaved work" case, and it is the
+    one a tracked-only check would silently discard.
+    """
+    if not is_dir(path):
+        return None, 0, []
+    r = _git(path, "status", "--porcelain=v1", "--untracked-files=normal")
+    if r.returncode != 0:
+        return None, 0, [f"git status failed rc={r.returncode}: {r.stderr.strip()[:200]}"]
+    lines = [ln for ln in r.stdout.splitlines() if ln.strip()]
+    return (len(lines) > 0), len(lines), lines[:10]
+
+
+def _paths_differ(repo: Path, rev_a: str, rev_b: str, paths: "list[str]") -> "bool | None":
+    """Do any of `paths` differ between the two revs? None on a git failure.
+
+    🔴 `paths` MUST be non-empty. A pathspec-less `git diff` compares the whole
+    trees, which would answer a different question and — for a branch with no
+    unique content — answer it wrongly. The caller short-circuits that case; the
+    assertion here is the second floor under it.
+    """
+    if not paths:
+        raise AssertionError(
+            "_paths_differ called with an EMPTY pathspec — that silently widens "
+            "the comparison to the whole tree. The no-content-change case is "
+            "the caller's to handle.")
+    batch: list[str] = []
+    size = 0
+    batches: list[list[str]] = []
+    for p in paths:
+        if batch and size + len(p) + 1 > PATHSPEC_BATCH_BYTES:
+            batches.append(batch)
+            batch, size = [], 0
+        batch.append(p)
+        size += len(p) + 1
+    if batch:
+        batches.append(batch)
+    for b in batches:
+        r = _git(repo, "diff", "--name-only", rev_a, rev_b, "--", *b)
+        if r.returncode != 0:
+            return None
+        if r.stdout.strip():
+            return True
+    return False
+
+
+def landing_signals(repo: Path, head: str, default_ref: str) -> "dict":
+    """Which of the git-side landing signals fired, and what was checked.
+
+    Returns {"fired": [...], "checked": [...], "notes": [...]}.
+    """
+    fired: list[str] = []
+    checked: list[str] = []
+    notes: list[str] = []
+
+    checked.append("ancestor")
+    anc = _git(repo, "merge-base", "--is-ancestor", head, default_ref)
+    if anc.returncode == 0:
+        fired.append("ancestor")
+        notes.append(f"{head[:12]} is an ancestor of {default_ref}")
+        return {"fired": fired, "checked": checked, "notes": notes}
+    if anc.returncode not in (0, 1):
+        notes.append(f"ancestor check failed rc={anc.returncode}: {anc.stderr.strip()[:160]}")
+        return {"fired": fired, "checked": checked, "notes": notes, "error": True}
+
+    base = _git_ok(repo, "merge-base", head, default_ref)
+    if not base:
+        notes.append(f"no merge-base between {head[:12]} and {default_ref}")
+        return {"fired": fired, "checked": checked, "notes": notes, "error": True}
+
+    checked.append("content-identical")
+    r = _git(repo, "diff", "--name-only", base, head)
+    if r.returncode != 0:
+        notes.append(f"changed-path listing failed rc={r.returncode}")
+        return {"fired": fired, "checked": checked, "notes": notes, "error": True}
+    changed = [p for p in r.stdout.splitlines() if p.strip()]
+    if not changed:
+        # 🔴 The empty-operand case, handled here and NOT by a pathspec-less
+        # diff. The branch introduced no content relative to its merge-base, so
+        # there is nothing that could fail to be present upstream.
+        fired.append("no-content-change")
+        notes.append(f"branch changes no path relative to merge-base {base[:12]}")
+        return {"fired": fired, "checked": checked, "notes": notes}
+    differ = _paths_differ(repo, head, default_ref, changed)
+    if differ is None:
+        notes.append("content comparison failed")
+        return {"fired": fired, "checked": checked, "notes": notes, "error": True}
+    if not differ:
+        fired.append("content-identical")
+        notes.append(f"all {len(changed)} changed path(s) have identical content in {default_ref}")
+    else:
+        notes.append(f"at least one of {len(changed)} changed path(s) differs from {default_ref}")
+
+    checked.append("patch-equivalent")
+    cherry = _git(repo, "cherry", default_ref, head)
+    if cherry.returncode == 0:
+        lines = [ln for ln in cherry.stdout.splitlines() if ln.strip()]
+        if lines and all(ln.startswith("-") for ln in lines):
+            fired.append("patch-equivalent")
+            notes.append(f"git cherry: all {len(lines)} commit(s) have an equivalent upstream")
+        elif lines:
+            unmatched = sum(1 for ln in lines if ln.startswith("+"))
+            notes.append(f"git cherry: {unmatched}/{len(lines)} commit(s) have no upstream equivalent")
+    else:
+        notes.append(f"git cherry failed rc={cherry.returncode}")
+
+    return {"fired": fired, "checked": checked, "notes": notes}
+
+
+# ── gh / pull requests ────────────────────────────────────────────────────────
+
+class PullRequestIndex:
+    """Per-repo branch -> pull request state, with an explicit ANSWERED flag.
+
+    🔴 `answered` is the whole point. "No PR found" and "we could not ask" are
+    the same OBSERVABLE — an empty result — and they license opposite verdicts:
+    the first supports `orphan`, the second supports only `cannot-tell`. A
+    truncated PR listing collapses them too, so truncation is detected and the
+    per-branch fallback query is used for anything the bulk index missed.
+    """
+
+    def __init__(self, slug: "str | None", gh_cmd: str, enabled: bool, limit: int = 2000):
+        self.slug = slug
+        self.gh_cmd = gh_cmd
+        self.enabled = enabled
+        self.limit = limit
+        self.by_branch: "dict[str, dict]" = {}
+        self.truncated = False
+        self.available = False
+        self.reason = "gh disabled by --no-gh" if not enabled else "not fetched"
+
+    def fetch(self) -> None:
+        if not self.enabled:
+            return
+        if not self.slug:
+            self.reason = "no github origin remote — cannot ask gh"
+            return
+        r = self._gh("pr", "list", "--repo", self.slug, "--state", "all",
+                     "--limit", str(self.limit),
+                     "--json", "number,state,headRefName,mergedAt,url")
+        if r is None or r.returncode != 0:
+            err = "gh not runnable" if r is None else (r.stderr.strip()[:200] or f"rc={r.returncode}")
+            self.reason = f"gh pr list failed: {err}"
+            return
+        try:
+            data = json.loads(r.stdout or "[]")
+        except json.JSONDecodeError:
+            self.reason = "gh pr list returned unparseable JSON"
+            return
+        for pr in data:
+            branch = pr.get("headRefName")
+            if not branch:
+                continue
+            prev = self.by_branch.get(branch)
+            # Prefer MERGED > OPEN > CLOSED, then the highest number.
+            rank = {"MERGED": 3, "OPEN": 2, "CLOSED": 1}
+            if prev is None or (rank.get(pr.get("state"), 0), pr.get("number", 0)) > \
+                    (rank.get(prev.get("state"), 0), prev.get("number", 0)):
+                self.by_branch[branch] = pr
+        self.truncated = len(data) >= self.limit
+        self.available = True
+        self.reason = (f"gh pr list returned {len(data)} PR(s)"
+                       + (f" — AT THE {self.limit} LIMIT, index may be truncated" if self.truncated else ""))
+
+    def lookup(self, branch: "str | None") -> "dict":
+        """{'answered': bool, 'state': str|None, 'number': int|None, 'why': str}"""
+        if branch is None:
+            return {"answered": False, "state": None, "number": None, "merged_at": None,
+                    "why": "detached HEAD — no branch to look a pull request up by"}
+        if not self.enabled:
+            return {"answered": False, "state": None, "number": None, "merged_at": None,
+                    "why": "gh disabled (--no-gh)"}
+        if not self.available:
+            return {"answered": False, "state": None, "number": None, "merged_at": None,
+                    "why": self.reason}
+        hit = self.by_branch.get(branch)
+        if hit is not None:
+            return {"answered": True, "state": hit.get("state"), "number": hit.get("number"),
+                    "merged_at": hit.get("mergedAt"), "why": "found in the repo's PR index"}
+        if not self.truncated:
+            return {"answered": True, "state": None, "number": None, "merged_at": None,
+                    "why": f"absent from a COMPLETE index of {len(self.by_branch)} branch(es)"}
+        # Truncated index: an absence proves nothing. Ask directly.
+        r = self._gh("pr", "list", "--repo", self.slug, "--head", branch, "--state", "all",
+                     "--limit", "10", "--json", "number,state,headRefName,mergedAt,url")
+        if r is None or r.returncode != 0:
+            return {"answered": False, "state": None, "number": None, "merged_at": None,
+                    "why": "PR index truncated and the per-branch query failed"}
+        try:
+            data = json.loads(r.stdout or "[]")
+        except json.JSONDecodeError:
+            return {"answered": False, "state": None, "number": None, "merged_at": None,
+                    "why": "PR index truncated and the per-branch query returned bad JSON"}
+        if not data:
+            return {"answered": True, "state": None, "number": None, "merged_at": None,
+                    "why": "no pull request for this branch (direct query)"}
+        rank = {"MERGED": 3, "OPEN": 2, "CLOSED": 1}
+        best = max(data, key=lambda p: (rank.get(p.get("state"), 0), p.get("number", 0)))
+        return {"answered": True, "state": best.get("state"), "number": best.get("number"),
+                "merged_at": best.get("mergedAt"), "why": "direct per-branch query"}
+
+    def _gh(self, *args: str) -> "subprocess.CompletedProcess | None":
+        try:
+            return subprocess.run([self.gh_cmd, *args], capture_output=True, text=True,
+                                  timeout=GH_TIMEOUT, check=False)
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+
+
+# ── classification ────────────────────────────────────────────────────────────
+
+def classify(row: "dict") -> "dict":
+    """Decide the verdict from the already-gathered evidence on `row`.
+
+    Pure: it runs no subprocess, so a test can drive every branch from a dict.
+    """
+    ev: list[str] = list(row.get("evidence", []))
+    blockers: list[str] = []
+
+    def out(verdict: str, reason: str) -> dict:
+        row["verdict"] = verdict
+        row["verdict_reason"] = reason
+        row["evidence"] = ev
+        removable = verdict == DEAD and not blockers
+        row["removable"] = removable
+        row["blockers"] = blockers
+        return row
+
+    if row.get("is_main"):
+        blockers.append("main checkout — never a removal candidate")
+        return out(LIVE, "the repository's main worktree")
+    if row.get("bare"):
+        blockers.append("bare worktree")
+        return out(LIVE, "bare worktree")
+
+    if row.get("prunable"):
+        blockers.append("git reports this worktree as prunable (stale admin entry)")
+        return out(CANNOT_TELL,
+                   "git reports the worktree prunable: "
+                   f"{row.get('prune_reason') or 'no reason given'} — "
+                   "`git worktree prune` is the right tool, not `remove`")
+    if not row.get("path_exists"):
+        blockers.append("worktree path does not exist on disk")
+        return out(CANNOT_TELL, "the worktree directory is gone but git still lists it")
+
+    if row.get("locked"):
+        blockers.append("worktree is locked")
+        return out(LIVE, f"locked: {row.get('lock_reason') or 'no reason given'}")
+
+    dirty = row.get("dirty")
+    if dirty is None:
+        blockers.append("could not determine whether the worktree is dirty")
+        return out(CANNOT_TELL, "`git status` did not answer — dirtiness unknown")
+    if dirty:
+        blockers.append(f"{row.get('dirty_count', 0)} uncommitted/untracked path(s)")
+        return out(LIVE, f"uncommitted work: {row.get('dirty_count', 0)} dirty path(s)")
+
+    if row.get("default_ref") is None:
+        blockers.append("default branch could not be resolved")
+        return out(CANNOT_TELL, "no default branch to compare against")
+
+    pr = row.get("pr") or {}
+    if pr.get("state") == "OPEN":
+        blockers.append(f"open pull request #{pr.get('number')}")
+        return out(LIVE, f"open pull request #{pr.get('number')}")
+
+    fired = list(row.get("landed_signals") or [])
+    if pr.get("state") == "MERGED":
+        if "pr-merged" not in fired:
+            fired.append("pr-merged")
+            row["landed_signals"] = fired
+        ev.append(f"pr-merged: #{pr.get('number')} merged at {pr.get('merged_at')}")
+    if fired:
+        return out(DEAD, "landed — signals: " + ", ".join(fired))
+
+    if row.get("signal_error"):
+        blockers.append("a git containment check failed")
+        return out(CANNOT_TELL, "a containment check errored; landing is undetermined")
+
+    if pr.get("answered"):
+        state = pr.get("state")
+        detail = f"closed-unmerged PR #{pr.get('number')}" if state == "CLOSED" else "no pull request"
+        return out(ORPHAN,
+                   f"no landing signal fired and {detail} ({pr.get('why')}) — "
+                   "unmerged work with nothing tracking it")
+
+    blockers.append("no authoritative pull-request answer")
+    return out(CANNOT_TELL,
+               "no landing signal fired, and the pull-request state is UNKNOWN "
+               f"({pr.get('why')}) — an absence of evidence, not evidence of absence")
+
+
+# ── scanning ──────────────────────────────────────────────────────────────────
+
+def scan_repo(repo: Path, gh_cmd: str, use_gh: bool, pr_limit: int, jobs: int) -> "list[dict]":
+    wts = list_worktrees(repo)
+    if not wts:
+        return []
+    default_ref, default_how = resolve_default_ref(repo)
+    slug = repo_slug(repo)
+    index = PullRequestIndex(slug, gh_cmd, use_gh, pr_limit)
+    index.fetch()
+
+    def build(wt: dict) -> dict:
+        path = Path(wt["path"])
+        row: dict = {
+            "repo": str(repo),
+            "repo_slug": slug,
+            "path": str(path),
+            "path_exists": is_dir(path),
+            "is_main": wt["is_main"],
+            "bare": wt["bare"],
+            "detached": wt["detached"],
+            "branch": wt["branch"],
+            "head": wt["head"],
+            "locked": wt["locked"],
+            "lock_reason": wt["lock_reason"],
+            "prunable": wt["prunable"],
+            "prune_reason": wt["prune_reason"],
+            "default_ref": default_ref,
+            "default_how": default_how,
+            "evidence": [f"default branch {default_ref} resolved by {default_how}"],
+        }
+        dirty, count, sample = worktree_dirty(path)
+        row["dirty"] = dirty
+        row["dirty_count"] = count
+        row["dirty_sample"] = sample
+        row["evidence"].append(
+            "dirty=UNKNOWN" if dirty is None else f"dirty={dirty} ({count} path(s))")
+
+        row["pr"] = index.lookup(wt["branch"])
+        row["evidence"].append(
+            f"pr: answered={row['pr']['answered']} state={row['pr']['state']} ({row['pr']['why']})")
+
+        row["landed_signals"] = []
+        row["checks_run"] = []
+        row["signal_error"] = False
+        if (not wt["is_main"] and not wt["bare"] and default_ref and wt["head"]
+                and dirty is False and row["pr"].get("state") != "OPEN"):
+            sig = landing_signals(repo, wt["head"], default_ref)
+            row["landed_signals"] = sig["fired"]
+            row["checks_run"] = sig["checked"]
+            row["signal_error"] = bool(sig.get("error"))
+            row["evidence"].extend(sig["notes"])
+        return classify(row)
+
+    if jobs > 1:
+        with ThreadPoolExecutor(max_workers=jobs) as pool:
+            return list(pool.map(build, wts))
+    return [build(w) for w in wts]
+
+
+# ── reporting ─────────────────────────────────────────────────────────────────
+
+def summarize(rows: "list[dict]") -> "dict":
+    counts = {v: 0 for v in VERDICTS}
+    for r in rows:
+        counts[r["verdict"]] = counts.get(r["verdict"], 0) + 1
+    return {
+        "worktrees": len(rows),
+        "repos": len({r["repo"] for r in rows}),
+        "counts": counts,
+        "removable": sum(1 for r in rows if r.get("removable")),
+    }
+
+
+def render_text(rows: "list[dict]", summary: dict, verbose: bool) -> str:
+    lines: list[str] = []
+    per_repo: dict[str, dict] = {}
+    for r in rows:
+        d = per_repo.setdefault(r["repo"], {v: 0 for v in VERDICTS})
+        d[r["verdict"]] += 1
+    lines.append(f"{'repo':<58} {'dead':>5} {'orphan':>7} {'live':>5} {'cannot-tell':>12}")
+    for repo in sorted(per_repo):
+        d = per_repo[repo]
+        lines.append(f"{repo[-58:]:<58} {d[DEAD]:>5} {d[ORPHAN]:>7} {d[LIVE]:>5} {d[CANNOT_TELL]:>12}")
+    c = summary["counts"]
+    lines.append("")
+    lines.append(f"{summary['worktrees']} worktree(s) across {summary['repos']} repo(s): "
+                 f"{c[DEAD]} dead, {c[ORPHAN]} orphan, {c[LIVE]} live, {c[CANNOT_TELL]} cannot-tell")
+    lines.append(f"{summary['removable']} row(s) would be removed by --execute "
+                 f"(dead + clean + unlocked only)")
+    if c[CANNOT_TELL]:
+        lines.append(f"🔴 {c[CANNOT_TELL]} row(s) are cannot-tell — they are NOT dead and are "
+                     "NOT removable. Read their verdict_reason before believing any count above.")
+    if verbose:
+        lines.append("")
+        for r in sorted(rows, key=lambda x: (x["verdict"], x["path"])):
+            if r["verdict"] == LIVE and not verbose:
+                continue
+            lines.append(f"[{r['verdict']}] {r['path']}  branch={r['branch']}")
+            lines.append(f"    {r['verdict_reason']}")
+            for e in r["evidence"]:
+                lines.append(f"      · {e}")
+    return "\n".join(lines)
+
+
+# ── execute ───────────────────────────────────────────────────────────────────
+
+def execute_removals(rows: "list[dict]", confirm: "int | None") -> int:
+    """Remove ONLY `removable` rows, re-verifying each immediately beforehand.
+
+    🔴 The re-verification is not belt-and-braces. The scan that produced these
+    rows is a claim about the PAST; a concurrent session can have started
+    editing in one of those worktrees since. The check therefore runs at the
+    moment of the destructive step, not in the survey that motivated it.
+
+    🔴 `git worktree remove` is called WITHOUT `--force`. Git refuses on a dirty
+    or locked tree, which is an INDEPENDENT floor under our own dirty check —
+    two mechanisms, so a bug in ours is not the only thing standing there.
+    """
+    targets = [r for r in rows if r.get("removable")]
+    if confirm is None:
+        _log(f"REFUSED: --execute requires --confirm N. This run would remove {len(targets)} "
+             f"worktree(s); pass --confirm {len(targets)} if that is what you intend.")
+        return RC_EXECUTE_REFUSED
+    if confirm != len(targets):
+        _log(f"REFUSED: --confirm {confirm} does not match the {len(targets)} row(s) this run "
+             "would remove. The scope moved under you — re-read the report. Nothing removed.")
+        return RC_EXECUTE_REFUSED
+
+    removed = skipped = failed = 0
+    for r in targets:
+        path = Path(r["path"])
+        repo = Path(r["repo"])
+        if r.get("verdict") != DEAD:
+            _log(f"SKIP {path}: verdict is {r.get('verdict')}, not {DEAD}")
+            skipped += 1
+            continue
+        live = [w for w in list_worktrees(repo) if Path(w["path"]) == path]
+        if not live:
+            _log(f"SKIP {path}: git no longer lists this worktree")
+            skipped += 1
+            continue
+        if live[0]["locked"]:
+            _log(f"SKIP {path}: locked since the scan")
+            skipped += 1
+            continue
+        # 🔴 LAST, so it is the check immediately before the destructive step
+        # rather than one buried in the survey that motivated it.
+        dirty, count, _ = worktree_dirty(path)
+        if dirty is not False:
+            _log(f"SKIP {path}: re-check says dirty={dirty} ({count} path(s)) — "
+                 "it changed since the scan, or was never knowable")
+            skipped += 1
+            continue
+        res = _git(repo, "worktree", "remove", str(path))
+        if res.returncode == 0:
+            _log(f"REMOVED {path}")
+            removed += 1
+        else:
+            _log(f"FAILED  {path}: rc={res.returncode} {res.stderr.strip()[:300]}")
+            failed += 1
+    _log(f"execute: removed={removed} skipped={skipped} failed={failed}")
+    return RC_OK if failed == 0 else 1
+
+
+# ── cli ───────────────────────────────────────────────────────────────────────
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="worktree-prune",
+        description="Classify git worktrees as dead / orphan / live / cannot-tell. "
+                    "DRY-RUN BY DEFAULT — nothing is removed without --execute.")
+    p.add_argument("--repo", action="append", default=[], metavar="DIR",
+                   help="a repository to scan (repeatable)")
+    p.add_argument("--scan-root", action="append", default=[], metavar="DIR",
+                   help="discover main checkouts under DIR (repeatable)")
+    p.add_argument("--repos-from", metavar="FILE",
+                   help="file of repository paths, one per line; # comments allowed")
+    p.add_argument("--scan-depth", type=int, default=2,
+                   help="how deep --scan-root descends looking for checkouts (default 2)")
+    p.add_argument("--jobs", type=int, default=8, help="parallel worktree probes (default 8)")
+    p.add_argument("--no-gh", action="store_true",
+                   help="do not consult gh. Every unlanded row then becomes cannot-tell, "
+                        "because 'no PR found' and 'we could not ask' stop being distinguishable.")
+    p.add_argument("--gh-cmd", default="gh", help="the gh executable to use (default: gh)")
+    p.add_argument("--pr-limit", type=int, default=2000,
+                   help="how many PRs to pull per repo before falling back to per-branch queries")
+    p.add_argument("--format", choices=("text", "json"), default="text")
+    p.add_argument("--out", metavar="FILE", help="write the machine-readable row list here")
+    p.add_argument("--verbose", action="store_true", help="print every row with its evidence")
+    p.add_argument("--dry-run", action="store_true",
+                   help="explicit no-op: dry-run is already the default")
+    p.add_argument("--execute", action="store_true",
+                   help="actually remove the `dead` rows. Requires --confirm N.")
+    p.add_argument("--confirm", type=int, metavar="N",
+                   help="the exact number of worktrees --execute may remove")
+    return p
+
+
+def collect_repos(args) -> "list[Path]":
+    repos: list[Path] = [Path(r).expanduser() for r in args.repo]
+    if args.repos_from:
+        for line in Path(args.repos_from).expanduser().read_text(encoding="utf-8").splitlines():
+            line = line.split("#", 1)[0].strip()
+            if line:
+                repos.append(Path(line).expanduser())
+    if args.scan_root:
+        repos.extend(discover_repos([Path(r) for r in args.scan_root], args.scan_depth))
+    seen: dict[str, Path] = {}
+    for r in repos:
+        try:
+            key = str(r.resolve())
+        except OSError:
+            key = str(r)
+        seen.setdefault(key, r)
+    return list(seen.values())
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.dry_run and args.execute:
+        _log("--dry-run and --execute are contradictory. Pick one.")
+        return RC_USAGE
+    if args.confirm is not None and not args.execute:
+        _log("--confirm is only meaningful with --execute.")
+        return RC_USAGE
+
+    repos = collect_repos(args)
+    if not repos:
+        _log("nothing to scan: pass --repo, --repos-from or --scan-root.")
+        return RC_NOTHING_TO_SCAN
+
+    rows: list[dict] = []
+    for repo in repos:
+        rows.extend(scan_repo(repo, args.gh_cmd, not args.no_gh, args.pr_limit, args.jobs))
+
+    summary = summarize(rows)
+    payload = {"summary": summary, "rows": rows}
+
+    if args.out:
+        Path(args.out).expanduser().write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(render_text(rows, summary, args.verbose))
+
+    if not args.execute:
+        _log("DRY RUN — nothing was removed. Pass --execute --confirm N to act.")
+        return RC_OK
+    return execute_removals(rows, args.confirm)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this is

`scripts/worktree-prune` — an instrument that classifies every git worktree across a configurable set of repos as **`dead` / `orphan` / `live` / `cannot-tell`**, recording the evidence each verdict rests on, and writes a machine-readable report.

**🔴 It deletes nothing in this PR, and it fired nothing to produce the numbers below.**

## Why it re-derives rather than trusts

The 14-day audit reported **217 dead / 245 orphans** over 593 worktrees. Its containment checker called a `git diff --pathspec-from-file` that does not exist, exited 129, and therefore scored **every** branch unmerged. It was rebuilt and spot-checked 7/7 — thin support for 245 irreversible deletions, and *"unmerged, no PR"* is also the exact profile of work in progress.

**🔴 The trap the design is built around:** `git merge-base --is-ancestor` returns **false for every squash-merged branch, forever**. So "did this land" is answered by four independent signals, and each row records which fired:

| signal | what it sees | what it misses |
|---|---|---|
| `ancestor` | a true merge | **every squash**, forever |
| `pr-merged` (`gh`) | anything GitHub merged | branches with no PR |
| `content-identical` | a squash with no git ancestry — every changed path has identical content upstream | a squash the default branch has **since built on top of** |
| `patch-equivalent` (`git cherry`) | rebases, cherry-picks | multi-commit squashes |

Anything none of them answers is a **loud `cannot-tell`**, never a `dead`.

## 🔴 The dry-run classification of the real worktrees

`./scripts/worktree-prune --scan-root ~/workspace --scan-depth 2 --jobs 8` — **883 entries across 128 repos**, of which 128 are main checkouts. Of the **755 linked worktrees**:

| verdict | count | removable by `--execute` |
|---|---|---|
| **dead** | **249** | 249 |
| **orphan** | **40** | 0 — never, by construction |
| **live** | **413** | 0 |
| **cannot-tell** | **53** | 0 |

**The 245-orphan figure does not reproduce. This instrument finds 40.** Where the other ~200 went, measured:

- **385 of the 755 are DIRTY** — uncommitted or untracked files (78 of them with >50 dirty paths). Those are `live` and are never removable. A classifier without a dirtiness gate reads them as unmerged-with-no-PR, i.e. as orphans.
- **214 of the 249 `dead` rows fired NO ancestry signal (86%)** — they would read as unmerged to an ancestry-only checker. **107 of them rest on `pr-merged` alone**, with no git-visible evidence whatsoever: squashes the default branch has since built over.

`dead` by signal set: `pr-merged` 107 · `patch-equivalent+pr-merged` 56 · `ancestor` 33 · `patch-equivalent` 17 · `content-identical+patch-equivalent+pr-merged` 13 · `content-identical+pr-merged` 10 · `content-identical+patch-equivalent` 8 · `content-identical` 3 · `ancestor+pr-merged` 2.

`cannot-tell` (53): 38 detached HEAD (no branch to look a PR up by) · 12 prunable — the directory is gone, so `git worktree prune` is the tool, not `remove` · 3 where `git status` did not answer.

Largest repos (linked worktrees only): `civitai` 322 (258 live/dirty, 59 dead, 4 cannot-tell, 1 orphan) · `datapacket-talos` 199 (123 dead, 28 cannot-tell, 25 orphan, 23 live) · `devrc` 61 (30 live, 22 dead, 6 orphan, 3 cannot-tell).

Default branch resolved via `origin/HEAD` symref for 750 rows, a local `main` fallback for 5 — recorded per row, because a verdict computed against the wrong default branch is wrong in the dangerous direction.

### Ground-truth spot checks against GitHub (not self-reported)

- `feat/remix-sfw-blur-mode` → `dead` on **`pr-merged` alone**. `gh pr view 347` = `MERGED 2026-08-19`; `git merge-base --is-ancestor` = **rc 1, not an ancestor**. The squash case, live in the corpus.
- Three `orphan` rows (`splice-presets-fixes`, `tmp/signal-cred`, `zach/725-r5`) → `gh pr list --head <branch> --state all` returns `[]` for each.

## The safety contract

- `--dry-run` is the **default**; `--execute` is required to remove anything.
- `--execute` **additionally** requires `--confirm N` matching the exact removal count. Scope moved under you ⇒ N changes ⇒ the run refuses and removes nothing (rc 3).
- Only `dead` rows are ever removable, and the executor **re-asserts the verdict** rather than trusting the `removable` flag it was handed.
- Dirtiness is re-checked **immediately before each removal**, not inherited from the scan that motivated it (a worktree that goes dirty in between is skipped).
- `git worktree remove` is called **without `--force`**, ever — git's own refusal on a dirty tree is a second, independent floor under our own check.
- `--no-gh` degrades every unlanded row from `orphan` to `cannot-tell` **on purpose**: "no PR found" and "we could not ask" are the same observable and license opposite verdicts.

## Test matrix

**87 tests, on real git fixture repos** — a real squash merge, a genuinely unmerged branch, a cherry-pick, a dirty worktree, a merged-and-clean one, a detached HEAD, a prunable entry, a locked tree, and a squash the default branch later overwrote. Hermetic: `tmp_path` repos, a stubbed `gh`, no network.

**Named controls (reported as a pair, per RULES):**

| control | test | requires |
|---|---|---|
| positive | `test_squash_merged_branch_is_dead_not_orphan` | **dead** |
| positive | `test_true_merge_is_dead_by_ancestry` | **dead** |
| negative | `test_genuinely_unmerged_branch_is_an_orphan` | **orphan** |
| loud-unknown | `test_without_gh_the_orphan_becomes_cannot_tell` | **cannot-tell**, not orphan |
| fixture validity | `test_the_squash_fixture_really_is_a_squash_and_not_an_ancestor` | `is-ancestor` rc **1** |
| harness | `test_the_gh_stub_can_be_observed_to_answer` / `test_the_broken_gh_stub_really_fails` | the stub can produce a non-zero count **and** can fail |

**18-mutant sweep — 18/18 KILLED, unmutated control GREEN.** (Swept at the 84-test revision; the 3 tests added afterwards are the EACCES regression below, red-proven separately. Adding tests cannot turn a KILLED mutant into a SURVIVED one, so 18/18 is a lower bound that still holds at 87.) Every mutant ran the FULL file (no `-k` filter — a filter that excludes the killing test reports SURVIVED), restored from a pristine copy each time, under `PYTHONDONTWRITEBYTECODE=1`.

```
GREEN   M0-control-unmutated                        passed=84 failed=0
KILLED  M1-ancestry-only (the 245-orphan bug)       failed=9  first: test_a_detached_worktree_whose_content_landed_is_still_dead
KILLED  M1b-drop-patch-equivalent                   failed=1  test_a_cherry_picked_branch_is_dead_by_patch_equivalence_alone
KILLED  M2-ignore-dirtiness                         failed=5  test_an_untracked_file_alone_counts_as_dirty
KILLED  M3-cannot-tell-becomes-dead                 failed=5  test_a_broken_gh_yields_cannot_tell_not_orphan
KILLED  M4-force-the-removal                        failed=1  test_the_tool_never_passes_force_to_worktree_remove
KILLED  M5-drop-the-confirm-gate                    failed=1  test_execute_with_a_wrong_confirm_refuses_and_removes_nothing
KILLED  M5b-confirm-optional                        failed=1  test_execute_without_confirm_refuses_and_removes_nothing
KILLED  M6-allow-empty-pathspec                     failed=1  test_paths_differ_refuses_an_empty_pathspec
KILLED  M7-unanswered-pr-counts-as-answered         failed=5  test_a_broken_gh_yields_cannot_tell_not_orphan
KILLED  M8-drop-the-pre-removal-dirty-recheck       failed=1  test_execute_rechecks_dirtiness_at_the_moment_of_removal
KILLED  M9-broken-gh-reports-answered               failed=2  test_a_broken_gh_yields_cannot_tell_not_orphan
KILLED  M10-open-pr-does-not-protect                failed=3  test_an_open_pr_beats_a_landing_signal
KILLED  M11-orphan-is-removable                     failed=4  test_only_dead_rows_are_ever_removable
KILLED  M12-executor-trusts-the-removable-flag      failed=1  test_execute_refuses_a_row_whose_verdict_is_not_dead_even_if_removable_is_set
KILLED  M13-main-worktree-not-special               failed=3  test_the_main_worktree_is_always_live_and_never_removable
KILLED  M14-prunable-treated-as-dead                failed=1  test_classify_covers_every_branch[kw2-cannot-tell]
KILLED  M15-no-content-change-short-circuit-removed failed=1  test_a_branch_with_no_unique_content_is_landed_by_the_short_circuit
KILLED  M16-default-branch-guess-main               failed=1  test_an_unresolvable_default_branch_is_cannot_tell
```

Two mutation controls are also **inside** the suite, so the red half ships with the green one: `test_an_ancestry_only_classifier_calls_the_squash_an_orphan` swaps in the broken checker and requires the same fixture to flip to `orphan`; `test_a_classifier_that_ignores_dirtiness_would_call_the_dirty_tree_dead` requires the dirty fixture to be otherwise-dead, so its `live` verdict cannot be coming from anything but the dirty check.

### 🔴 Two things that went wrong, reported rather than smoothed over

1. **The sweep's own parser was broken and scored three killed mutants as SURVIVED.** The first `(\d+) failed` in the output belongs to the tool's own `execute: removed=2 skipped=0 failed=0` line, echoed in pytest's captured-stderr block *above* the summary. It now reads the last summary line only and cross-checks against an independent count of `FAILED` lines, refusing to report if they disagree. **One of the three was a real gap**: deleting the `patch-equivalent` signal left the whole suite green, because every other landing case was already covered by `ancestor` or `content-identical`. It now has a dedicated cherry-pick fixture (M1b above).
2. **A defect the fixtures could not reach, found by the first real run.** `Path.is_dir()` **raises** on EACCES — it swallows only ENOENT/ENOTDIR/EBADF/ELOOP — so one unreadable `lost+found` inside a scan root killed the entire scan with a traceback before a single row printed. Fixed with one `is_dir()` helper used at every such test, plus three regression tests **red-proven against the pre-fix code** (`3 failed` with the helper reverted, green with it).

## Gate

`nix develop . --command bash scripts/gate.sh` on the **rebased** tree → **`GATE: RESULT=PASS exit=0`**, both tiers (`RESULT: PASS` for pytest and for node). `scripts/tests` collected **8360 passed=8360** against a floor of **8036** and a drift ceiling of **10045** — inside both bounds, so **no `TARGET_FLOORS` change is needed**. `--check-floors` → PASS.

🔴 **The first gate run was RED, and it was not this change.** `scripts/claude-hooks/tests/test_gh_issue_closing_condition_guard.py` collected 3 with 3 xdist collection errors — the exact defect fixed by `1d67f5e8 fix(gate): a random tmpdir in a parametrize ID took both tiers red (#855)`, which had landed on `main` after this branch was cut. Reported rather than hidden because the branch was **behind main**, and a PR green on its own branch proves nothing about the tree its merge creates. Rebased onto `a58a261d` (4 commits), re-ran the previously-failing target alone (**475 passed**, floor 451), then re-ran the whole gate — the PASS above is the rebased tree.

## 🔴 What I could not determine

- **Whether the 40 orphans are abandoned or in-flight.** A clean tree with unmerged commits and no PR is genuinely ambiguous and the tool says so — `orphan` is informational and is **never** removable. It is not a delete list.
- **The 38 detached-HEAD `cannot-tell` rows.** No branch name means no PR lookup. Matching the head sha against PR merge commits would resolve some; not implemented.
- **Whether the old 593/217/245 counted the same repo set.** This scan finds 128 repos and 755 linked worktrees; I did not reconstruct the prior tool's repo list, so the totals are not directly comparable — only the *shape* of the disagreement (245 → 40) is.
- **`content-identical`'s false negative is only covered where `gh` can answer.** For the 5 rows with no GitHub origin, that backstop is absent and they degrade to `cannot-tell` rather than being silently mis-scored.
- **`--execute` has never been run against the real corpus** — by design. Its behaviour is pinned by fixtures only, and firing it is a separate, human-approved step.
