### PR TITLE
docs(clawgate skill): it ROUTES, it does not GATE

### DIFF
--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawgate
-description: "Operate clawgate — the self-hosted Claude Code approval UI (plus Tasks/agents/runbooks). Status, send-a-test, push/SSE logs, build and deploy a version, toggle the approval hook, manage credentials/QR. Use for: clawgate, clawgate.zacx.dev, remote approval, the PermissionRequest approval hook, push notifications for permission prompts."
+description: "Operate clawgate — the self-hosted Claude Code permission ROUTER and task board (plus agents/runbooks). Status, send-a-test, push/SSE logs, build and deploy a version, toggle the approval hook, manage credentials/QR. Use for: clawgate, clawgate.zacx.dev, remote approval, the PermissionRequest approval hook, push notifications for permission prompts."
 ---
 
 # clawgate operations
@@ -9,6 +9,19 @@ Self-hosted Go + htmx PWA routing Claude Code permission prompts to Zach's phone
 approve-with-comment / deny), grown into the **agent dispatch loop**: Tasks/Repos/Agents on Postgres,
 agent self-service + privilege profiles + an Operator, runbooks with approval gates, and a machine
 Task API producers post work into for one-tap Dispatch.
+
+🔴 **In practice it ROUTES; it does not GATE — say so rather than calling it an approval gate.**
+Measured in the 2026-08 usage audit, not assumed: **121,740** permission requests routed in 14 days
+against **exactly one** human decision across Prometheus's full 30-day retention (one `approve`,
+2026-07-31). ~99.9% are resolved by the **global auto-approve window**, whose maximum duration is
+**24h** (`handleAutoApproveAll` offers 1h/8h/24h and, unlike the per-project windows, no `forever`) —
+so the ~1 arming/day is one standing decision the UI forces Zach to re-enter, not repeated choices to
+bypass a gate. The operator's call on 2026-08-26 was to accept this and retain decision history
+(`request_history`, migration 0025) so a narrower gate can later be designed from data.
+⚠ Two traps when reasoning about this: `project` is the **cwd basename**, so every git worktree is a
+new project identity and per-project windows go cold exactly when agents write most; and
+`requests` is a working queue the hook `DELETE`s from, so its row count is ~0 and is **not** a usage
+measure. Query `request_history` instead.
 
 🔴 **Point-in-time state: `~/workspace/homelab-talos/containers/clawgate/HANDOFF.md` —
 GREP it for the section you need, never read it whole (~190 KB, lower half superseded).**

--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -1,27 +1,14 @@
 ---
 name: clawgate
-description: "Operate clawgate — the self-hosted Claude Code permission ROUTER and task board (plus agents/runbooks). Status, send-a-test, push/SSE logs, build and deploy a version, toggle the approval hook, manage credentials/QR. Use for: clawgate, clawgate.zacx.dev, remote approval, the PermissionRequest approval hook, push notifications for permission prompts."
+description: "Operate clawgate — the self-hosted Claude Code permission router (plus Tasks/agents/runbooks). Status, send-a-test, push/SSE logs, build and deploy a version, toggle the approval hook, manage credentials/QR. Use for: clawgate, clawgate.zacx.dev, remote approval, the PermissionRequest approval hook, push notifications for permission prompts."
 ---
 
 # clawgate operations
 
-Self-hosted Go + htmx PWA routing Claude Code permission prompts to Zach's phone (approve /
-approve-with-comment / deny), grown into the **agent dispatch loop**: Tasks/Repos/Agents on Postgres,
+Self-hosted Go + htmx PWA routing Claude Code permission prompts to Zach's phone (it ROUTES;
+does NOT gate — `telemetry.md`), grown into the **agent dispatch loop**: Tasks/Repos/Agents on Postgres,
 agent self-service + privilege profiles + an Operator, runbooks with approval gates, and a machine
 Task API producers post work into for one-tap Dispatch.
-
-🔴 **In practice it ROUTES; it does not GATE — say so rather than calling it an approval gate.**
-Measured in the 2026-08 usage audit, not assumed: **121,740** permission requests routed in 14 days
-against **exactly one** human decision across Prometheus's full 30-day retention (one `approve`,
-2026-07-31). ~99.9% are resolved by the **global auto-approve window**, whose maximum duration is
-**24h** (`handleAutoApproveAll` offers 1h/8h/24h and, unlike the per-project windows, no `forever`) —
-so the ~1 arming/day is one standing decision the UI forces Zach to re-enter, not repeated choices to
-bypass a gate. The operator's call on 2026-08-26 was to accept this and retain decision history
-(`request_history`, migration 0025) so a narrower gate can later be designed from data.
-⚠ Two traps when reasoning about this: `project` is the **cwd basename**, so every git worktree is a
-new project identity and per-project windows go cold exactly when agents write most; and
-`requests` is a working queue the hook `DELETE`s from, so its row count is ~0 and is **not** a usage
-measure. Query `request_history` instead.
 
 🔴 **Point-in-time state: `~/workspace/homelab-talos/containers/clawgate/HANDOFF.md` —
 GREP it for the section you need, never read it whole (~190 KB, lower half superseded).**

--- a/claude/skills/clawgate/reference/telemetry.md
+++ b/claude/skills/clawgate/reference/telemetry.md
@@ -3,6 +3,44 @@
 Read when: metrics/logs are missing, you're adding an event or a dashboard panel, or you're about
 to debug a red CI check.
 
+## 🔴 It ROUTES; it does not GATE — measured, not asserted (2026-08 usage audit)
+
+SKILL.md's one-liner points here. Do not describe clawgate as an approval gate.
+
+| | |
+|---|---|
+| permission requests routed, 14d | **121,740** (~11.3k/day) |
+| human decisions, full 30d Prometheus retention | **1** — one `approve`, 2026-07-31 |
+| resolved by the **global** auto-approve window | ~**99.9%** |
+| global window max duration | **24h** (`handleAutoApproveAll`: 1h/8h/24h, no `forever`) |
+
+The 24h cap is the point: ~1 arming/day is **one standing decision the UI forces the operator to
+re-enter daily**, not repeated choices to bypass a gate. The operator's call on 2026-08-26 was to
+accept this and retain decision history so a narrower gate can later be designed from data.
+
+**Four traps when reasoning about this — each cost a wrong claim in review:**
+
+- 🔴 **`requests` row count is NOT a usage measure.** It is a working queue the hook `DELETE`s from,
+  so it sits at ~0. Query **`request_history`** (migration `0025`, live in 0.8.1) instead —
+  `decided_by` is `human` / `auto` / `expired`, and it is a **column**, never inferred from the
+  comment text (the auto path happens to write `"auto-approved"`, which any path could spell).
+- 🔴 **`project` is the cwd BASENAME** (`devrc` vs `devrc-wt-nudge`). Every git worktree mints a new
+  project identity, so per-project auto-approve windows go cold exactly when worktree isolation is
+  mandated — i.e. when agents write most.
+- 🔴 **Expiries land in `Delete`, not `Sweep`.** The hook's EXIT trap DELETEs at a **170s** deadline
+  and the DEPLOYED `CLAWGATE_REQUEST_TTL` is **5m**, so Delete normally fires ~130s before Sweep's
+  cutoff. ⚠ Take that TTL from `deployment.yaml`, never from `main.go`'s 1h **default** — using the
+  default produced a "~35 minutes" claim that was wrong by an order of magnitude.
+- 🔴 **`clawgatectl` cannot mint a permission request** — it only reaches `/health`, `/api/agents`
+  and `/api/tasks*`, never `POST /api/send`. The genuinely hook-less producer is the agent
+  **checkpoint**, which runs on the 24h `checkpointSweepGrace`, not the 5m TTL.
+
+⚠ **`pushResolved` is a SILENT control message, not a buzz.** `sw.js` maps `type:"resolved"` to
+`closeByTag(...)` and *"Render nothing."* Auto-approved requests never reach `pushNewRequest` at all
+(the auto-approve branch returns first), so the ~26k/day deliveries are no-op closes of
+notifications that were never shown — a minor efficiency item, **not** notification spam. Do not
+repeat the "your phone buzzes 26k times" framing; it was checked and is false.
+
 ## CI — 🔑 IT MOVED (2026-07-30)
 **GitHub Actions is BILLING-BLOCKED repo-wide**: every workflow run fails in seconds with
 `steps: 0` and the annotation *"recent account payments have failed or your spending limit needs to

--- a/scripts/tests/test_skill_tiers.py
+++ b/scripts/tests/test_skill_tiers.py
@@ -85,12 +85,12 @@ MIN_SKILLS = 30
 # --------------------------------------------------------------------------- #
 MEASURED_ENTRIES = 37
 MEASURED_TIER_A_ENTRIES = 24
-MEASURED_TIER_A_CHARS = 8_961
+MEASURED_TIER_A_CHARS = 8_952
 # devrc's whole listing under the ledger (tier A in full, tier B name-only).
-MEASURED_UNDER_LEDGER_CHARS = 9_153
+MEASURED_UNDER_LEDGER_CHARS = 9_144
 # ...and what the same 37 entries would cost with every skill tier A. The
 # difference is what the ledger buys: 3,907 chars.
-MEASURED_ALL_TIER_A_CHARS = 13_060
+MEASURED_ALL_TIER_A_CHARS = 13_051
 
 # 🔴 THE TIER-A RATCHET, in the REAL formula: the tier-A block cost
 # `sum(len(name) + 4 + min(len(desc), 1536)) + (n - 1)`.

--- a/scripts/tests/test_skill_tiers.py
+++ b/scripts/tests/test_skill_tiers.py
@@ -85,12 +85,12 @@ MIN_SKILLS = 30
 # --------------------------------------------------------------------------- #
 MEASURED_ENTRIES = 37
 MEASURED_TIER_A_ENTRIES = 24
-MEASURED_TIER_A_CHARS = 8_946
+MEASURED_TIER_A_CHARS = 8_961
 # devrc's whole listing under the ledger (tier A in full, tier B name-only).
-MEASURED_UNDER_LEDGER_CHARS = 9_138
+MEASURED_UNDER_LEDGER_CHARS = 9_153
 # ...and what the same 37 entries would cost with every skill tier A. The
 # difference is what the ledger buys: 3,907 chars.
-MEASURED_ALL_TIER_A_CHARS = 13_045
+MEASURED_ALL_TIER_A_CHARS = 13_060
 
 # 🔴 THE TIER-A RATCHET, in the REAL formula: the tier-A block cost
 # `sum(len(name) + 4 + min(len(desc), 1536)) + (n - 1)`.


### PR DESCRIPTION
Companion to homelab-infra #413, which acts on the same two operator decisions from the 2026-08 clawgate usage audit.

The skill description called clawgate "the self-hosted Claude Code **approval UI**". The measurements say that is not what it does:

| | |
|---|---|
| permission requests routed, 14d | **121,740** |
| human decisions, full 30d Prometheus retention | **1** |
| resolved by the global auto-approve window | **~99.9%** |
| global window max duration | **24h** (no `forever`, unlike per-project) |

So ~1 arming/day is *one standing decision the UI forces Zach to re-enter daily*, not repeated choices to bypass a gate.

This lands in the **skill** rather than only a handoff doc because the skill body is what loads into a future session and shapes how it describes the service — a handoff decays, a skill keeps being read.

**Every trigger phrase is preserved** (`remote approval`, `the PermissionRequest approval hook`, `push notifications for permission prompts`) — those are what Zach types, and dropping them would break skill triggering. Only the *claim* changed.

Also records two traps a future session would otherwise re-derive the hard way:
- `project` is the **cwd basename**, so every git worktree mints a new project identity and per-project auto-approve windows go cold exactly when agents write most;
- `requests` is a working queue the hook `DELETE`s from — its ~0 row count is **not** a usage measure. Query `request_history` instead.

Description length 369 chars (well under the ~1024 limit). `test_skill_audit.py`: **89 passed**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)