### PR TITLE
docs(handoff): bridge-unbounded-waits — talos-infra #1306 merged, and the doc's own "machinery is INERT" gotcha is REFUTED

### DIFF
--- a/claudedocs/handoff-bridge-unbounded-waits.md
+++ b/claudedocs/handoff-bridge-unbounded-waits.md
@@ -17,8 +17,9 @@ defect class — a wait whose only backstop is someone else's timeout** — foun
 the browser-bridge and fixed at the source each time.
 
 ## State now
-- **All three fixes MERGED and live.** Verified by CONTENT on `origin/main` (squash merges,
-  so ancestry proves nothing) and by `browser ping` on both Brave profiles:
+- **The bridge-unbounded-waits arc is CLOSED.** All three fixes merged and verified
+  earlier; nothing further was needed on them. Carried forward because the shas and
+  constants are the durable record:
 
   | PR | defect | constant | merge |
   |---|---|---|---|
@@ -26,15 +27,26 @@ the browser-bridge and fixed at the source each time.
   | #814 | `open`'s `chrome.tabs.get` — same shape, the audit's predicted regeneration | `REUSE_TAB_BUDGET_MS = 2000` | `b242fc2df` |
   | #820 | test safety-nets TIGHTER than the CLI's own `curl -m 60`, at 31 sites | `CLI_TIMEOUT_S = 300` | `366de0912` |
 
-- **Both profiles run the new build**: `buildMarker = e1ee86a50a811d40`, `stale=False` on
-  `work` and `personal - other`. 🔴 `buildMarker` is the ONLY field describing running code;
-  `extensionVersion` read `0.8.1` on both throughout, including while one was stale.
-- **clawgate task 358** filed (the meta-class: dead guard branches + a detector). Already
-  picked up by a DIFFERENT session (`f23b37ec-…`), status `in_progress`. Not ours to work.
-- **talos-infra**: app-capture SKILL.md pruned 25,817 → 13,418 B (−48%); the occlusion
-  premise retracted in `SKILL.md` + `reference/foreground-and-spend.md`; the host→fixture
-  map consolidated from three copies to one. Issues #1288, #1289, #1293, #1297 filed.
-- **IN FLIGHT: nothing of ours.** No open PR, no half-written branch.
+- **talos-infra issues filed by the earlier session and still on record:** #1288
+  (`app-requests` list semantics), #1289 (the dropped `SHARED_LIST_RESULT`, see the
+  open investigation below), #1293, #1297 (the crop/render work — items 2 and 3 now
+  closed, item 1 open; see Next steps 1).
+- **NEW this session: talos-infra #1306 MERGED** as squash `0e4fc872a` (2026-08-26).
+  It removed two RETRACTED claims that were still being PRINTED at runtime by
+  `app-capture`, fixed the gate that was keeping one of them alive, and closed
+  items 2 and 3 of talos-infra **#1297**.
+  - Verified on `origin/trunk` **by content** (a squash merge never makes the branch
+    head an ancestor, so ancestry proves nothing): `5/5 deadlock` = **0** occurrences,
+    `STALE BRIDGE BUILD` present, `M112d` present, `TWO CAUSES` present.
+  - Gate `tekton / gitops-ci` = success on the exact head SHA, `total_count: 1`.
+  - Branch deleted; worktree removed.
+- **Four adversarial audit rounds ran on that PR, and every round found real defects —
+  each one introduced by the round before it.** The mutation battery caught none of
+  them. Details in Gotchas below; this is the most transferable output of the session.
+- **IN FLIGHT: nothing of ours.** No open PR, no half-written branch, no worktree.
+- 🔴 **`--repo devrc` primary clone is on `main`, clean** apart from two pre-existing
+  untracked files that are not ours (`nix/system/apply-nebula-443.sh.LOCAL-preserved-2026-08-02`,
+  `scripts/dl-router/tests/load_test_store.sh`).
 
 ## Open investigations — live diagnosis state
 
@@ -87,33 +99,71 @@ the browser-bridge and fixed at the source each time.
   change may just be to log the first failing FIELD. Otherwise: compare the block's bundled
   SDK version against the shape the host sends. Full write-up: talos-infra issue **#1289**.
 
-## Next steps (ranked)
-1. **`--render` the three new app-capture recipes** — `civitai/talos-infra`, files
-   `.claude/skills/app-capture/scripts/recipes/{app-requests,gen-matrix,playable-collections}.json`.
-   BLOCKED on a design call, not on tooling: all three refuse (`app-requests` exit 5
-   `full_frame` 46.9%×98.3%; `gen-matrix` exit 6 `too_few_states` — 1 state, the identical-box
-   check needs ≥2; `playable-collections` exit 5, 63.9%×**100.0%**). The floors are NOT wrong —
-   these apps scroll, so content legitimately fills the band. Decide declared `crop.rect`
-   (as `sensei.json` already does) vs detection, and give `gen-matrix` a 2nd state. **#1297.**
-2. **`plan.py`'s step text still prints two RETRACTED claims on every run** —
-   `civitai/talos-infra`, `.claude/skills/app-capture/scripts/plan.py`: "an App Block does not
-   boot in a hidden tab" and the occlusion story. Docs were corrected; these are code strings.
-   Also `capture.sh`'s exit-12 message names OCCLUSION as the cause. **#1297.**
-3. **Fix the `test_browser_cli_backs_off_on_429` stall at its source** — `devrc`,
-   `scripts/browser-bridge/tests/test_server.py`. See the investigation above; #820 only
-   stopped the test preempting the CLI's own timeout.
-4. **`open`'s fallthrough shares the suspected failure mode** — `devrc`,
-   `scripts/browser-bridge/extension/service_worker.js`. `chrome.tabs.create` is *another*
-   unbounded browser-process IPC, so a browser-wide stall leaks one tab per `open` while
-   returning success. Needs a live measurement of a hung `tabs.get` that nobody has.
-5. **Removing app-capture's inert raise** — `civitai/talos-infra`. Optional cleanup, NOT a
-   fix: `activate` without `--focus` answers `i3: "withheld"` and raises nothing. Touches
-   `ACTIVATE_REASONS`, gate G11, mutants M59–M64; mutation sweeps run to HOURS.
-6. 🔴 **clawgate #358 — IN FLIGHT, another session.** Do not start it.
+### Does `chrome.windows.update({focused:true})` actually take the operator's screen?
+- **Why it is open:** `browser activate` does THREE things and the consent gate covers
+  only one. Measured by reading `<devrc>/scripts/browser-bridge/extension/service_worker.js`:
+  `activate` unconditionally runs `chrome.tabs.update(tab.id,{active:true})` **and**
+  `chrome.windows.update(tab.windowId,{focused:true})`. The `--focus` gate governs the
+  host-side `i3-msg` ONLY.
+- **Observed (with values):** `<devrc>/scripts/browser-bridge/server.py` carries the
+  retraction verbatim — *"⚠ `takes nothing` (an earlier wording here) OVERSTATED it …
+  the extension also calls windows.update{focused:true}, which this gate does NOT
+  cover. Under i3's default `smart` … a focus request from a window on an ACTIVE
+  workspace `will receive the focus`."* The bridge README goes further:
+  *"whether `chrome.windows.update({focused:true})` actually emits that X11 activation
+  request … nobody has measured it … unknown, not zero and not proven non-zero."*
+- **Ruled out:** "activate is inert without --focus" — FALSE, and it was written into
+  nine places in talos-infra before an audit caught it. The tab-activation half always
+  happens, and it is what routes a capture onto the `captureVisibleTab` fast path.
+- **Leading hypothesis:** the residual is real but bounded to the case where Brave is
+  ALREADY on the visible workspace (cross-workspace, i3 `smart` refuses). Magnitude
+  unknown in both directions.
+- **Next probe:** with Brave on the CURRENTLY VISIBLE workspace and focus on another
+  window, record `xdotool getactivewindow`, run `browser --instance work activate`
+  (no `--focus`), re-read `xdotool getactivewindow`, and restore. 🔴 Assert the
+  workspace state INSIDE the arm and abort if it does not hold — the 2026-08-24
+  occlusion probe gave a confident WRONG answer twice for exactly that reason.
+- 🔴 **Consequence nobody has measured, and it is the one that matters:** on the
+  `--trusted` spend path `plan_spend` emits `activate` with **empty args** — no
+  `--focus` — so whether the subsequent `xdotool key --clearmodifiers` reliably lands
+  on Brave rests on this same residual. `plan.py` now says so instead of claiming the
+  step "STEALS THE OPERATOR'S SCREEN". Behaviour deliberately unchanged.
 
-🔴 **This list is a WORK QUEUE WITH NO LOCK** — every `/resume` session draws from it, so a
-*better* ranked list produces *more* duplicate work. Items name repo + files; item 6 is
-marked in flight.
+## Next steps (ranked)
+🔴 **Numbering is STABLE and is half a claim's identity — do not re-rank.** Items 2
+and 3 of the original list are DONE and are kept in place rather than renumbered.
+
+1. **Declare crops for `app-requests` + `playable-collections`** — `civitai/talos-infra`,
+   `.claude/skills/app-capture/scripts/{frame.py,recipes/*.json}`. **talos-infra #1297**,
+   still open with a stated closing condition. Design is SETTLED and smaller than it
+   looks: **the rewards-banner shift is purely VERTICAL** — measured on
+   `5-mb-combinations.png` vs the `bannershift.py` cut of the same capture, `x=252`,
+   `w=1200`, `h=312` are byte-identical in both layouts and only `y` moves, 194 → 230
+   (exactly +36). So a declared rect needs only its **y** anchored to the iframe top,
+   and the probe ALREADY reports that (`top`, in `(top, bottom, right, vw, vh)`) — no
+   probe or token change. Work: make `rect` frame-relative when `fromAppFrame` is true
+   (lift the exclusion for THAT FORM ONLY — an absolute rect + `fromAppFrame` must stay
+   refused), gate it by measuring the same declared rect in both banner layouts and
+   asserting the resolved crop is identical, then a LIVE `--render` run to pick crops
+   ending on a clean row boundary rather than mid-row.
+   ⚠ `playable-collections`' `mine` state was last measured populated **2026-08-16** and
+   has NOT been re-measured. If it is empty now, that state shoots an empty screen.
+2. ✅ **DONE (#1306)** — `plan.py`/`capture.sh` no longer print the two retracted claims.
+3. **Fix the `test_browser_cli_backs_off_on_429` stall at its source** — `devrc`,
+   `scripts/browser-bridge/tests/test_server.py`. UNCHANGED this session; see the
+   investigation block already in this doc. #820 only stopped the test preempting the
+   CLI's own timeout — the stall itself is still UNFIXED and UNMEASURED.
+4. **`open`'s fallthrough shares the suspected failure mode** — `devrc`,
+   `scripts/browser-bridge/extension/service_worker.js`. UNCHANGED this session.
+   `chrome.tabs.create` is another unbounded browser-process IPC, so a browser-wide
+   stall leaks one tab per `open` while returning success.
+5. **Removing app-capture's raise** — `civitai/talos-infra`. 🔴 **THIS ITEM'S PREMISE
+   CHANGED: it is no longer "removing an INERT raise".** The raise is not inert (see
+   the open investigation above); only its i3 half is withheld. Removing it would
+   change which capture path is taken. Re-scope before working it.
+6. **clawgate #358** — filed earlier, picked up by a different session. Not ours; its
+   live state was NOT re-checked this session, so treat that as unknown rather than
+   as still-in-flight.
 
 ## Gotchas / decisions / dead-ends
 - 🔴 **`browser ping` → `buildMarker` is the ONLY field describing RUNNING code.** Both
@@ -152,20 +202,73 @@ marked in flight.
   #358's first mechanism and REJECTED — civitai and homelab-talos have ZERO batteries, and a
   full sweep runs for hours so it cannot gate a push.
 
+- 🔴 **RETRACTION OF THIS DOC'S OWN EARLIER GOTCHA. The entry below that says the
+  foregrounding machinery is INERT / "`activate` … raises nothing" is WRONG**, and
+  believing it cost two audit rounds. `browser activate` does three things and the
+  `--focus` gate suppresses ONE: the host-side `i3-msg`. It still makes the tab its
+  window's **active tab** (which is what routes a capture onto the `captureVisibleTab`
+  fast path that hangs), and it still calls the **ungated**
+  `chrome.windows.update({focused:true})`. Read "withheld", never "inert".
+- 🔴 **A TEST WAS WHAT KEPT A RETRACTED CLAIM ALIVE.** talos-infra gate `G14` asserted
+  the exit-12 message literally contain `OCCLUSION failure`. It had been hardened once
+  to stop the message advising FOCUS — and pinned OCCLUSION in its place, i.e. the NEXT
+  wrong variable. Correcting the docs could never have fixed it. **When you retract a
+  mechanism, grep the TEST SUITE for it, not just the prose.**
+- 🔴 **A KEYWORD GUARD ON PROSE GETS WALKED. Three measured escapes, in order:**
+  (a) a negative assert on `un-cover the window` also matched the CORRECT message's
+  "un-covering the window is not the fix" — a guard firing on its own negation;
+  (b) narrowing it to the operative i3 command was walked by the SAME advice written as
+  PROSE with no command, suite green at 138 PASS; (c) pinning the body VERBATIM was
+  walked by appending one line PAST the `sed` range's end anchor, again 138 PASS.
+  Cure: pin the whole normalised string **to end of output**, and keep the
+  position-independent negatives alongside it.
+- 🔴 **A MUTANT THAT ALSO DIES UNDER THE OLD GATE PROVES NOTHING ABOUT THE NEW ONE.**
+  `M112`/`M112b`/`M112c` all replace lines INSIDE the old range, so all three died
+  before the fix too — reverting the range left the battery at 0 survivors and the suite
+  at 138 PASS. `M112d` is the discriminating one and was watched **both ways**: KILLED
+  at HEAD, **SURVIVED** with the range reverted. Ask of any regression mutant: *would
+  this have died before my change?* If yes, it is not guarding the change.
+- 🔴 **PROSE ABOUT "WHAT IS NOT TRUE" IS UNUSUALLY EASY TO GET WRONG IN A NEW
+  DIRECTION.** Four audit rounds, four rounds of real findings, every defect introduced
+  by the round before it: the headline claim not actually delivered (it still printed as
+  line `[f0]` of every run, from the function whose DOCSTRING had been rewritten to
+  disown it); a brand-new falsehood in nine places ("activate is a no-op"); an absolute
+  in the always-loaded SKILL.md that the bridge's own source retracts verbatim; and a
+  mis-attribution on the `--trusted` spend path. **Budget for several rounds and
+  re-audit the DELTA each time** — none of this was caught by a green suite or by the
+  mutation battery.
+- **DECISION: `gen-matrix` gets NO second state, and its `too_few_states` refusal must
+  stay RED.** #1297 proposed adding one. Wrong remedy: the app has exactly one state
+  that does not spend Buzz, so a synthetic second state would either duplicate
+  `configure` (caught by the identical-box gate) or require spending, which the recipe's
+  own `_neverList` forbids. Recorded as a `_noRender` key in the recipe.
+- **Shipped KNOWN-IMPRECISE rather than silently:** whether occlusion CONTRIBUTES to the
+  capture hang (the refutation established only that it is not REQUIRED — a genuinely
+  occluded window was never held); whether `windows.update({focused:true})` reaches X11;
+  the `--trusted` keypress targeting that now visibly rests on it; and `--help`'s
+  hard-coded `sed -n '2,45p'` range, which nothing tests despite the header growing twice.
+- **The primary talos-infra clone shows ~20 dirty `.claude/skills/` files — that is the
+  base-clone sync HOOK, not WIP.** Verified: the working copies hash-match PRIOR
+  `origin/trunk` commits (`aa368b269`, `e3d62238a`). Do not "rescue" them.
+
 ## How to verify
 ```bash
-# 1. all three fixes live, by CONTENT (squash merges — ancestry proves nothing)
-R=~/workspace/devrc; git -C $R fetch origin -q
-git -C $R show origin/main:scripts/browser-bridge/extension/protocol.js | grep -E 'FAST_CAPTURE_BUDGET_MS|REUSE_TAB_BUDGET_MS'
-git -C $R show origin/main:scripts/browser-bridge/tests/cli_budget.py   | grep CLI_TIMEOUT_S
+# 1. #1306 landed, by CONTENT (squash merge — ancestry proves nothing)
+git -C $DATAPACKET fetch origin trunk -q
+git -C $DATAPACKET show origin/trunk:.claude/skills/app-capture/scripts/plan.py   | grep -c '5/5 deadlock)"'   # 0
+git -C $DATAPACKET show origin/trunk:.claude/skills/app-capture/scripts/capture.sh | grep -c 'STALE BRIDGE BUILD' # 1
+git -C $DATAPACKET show origin/trunk:tests/mutants-app-capture.sh                  | grep -c 'M112d'            # 2
 
-# 2. what is actually RUNNING in each profile (not what is deployed)
-BB=~/workspace/devrc/scripts/browser-bridge/browser
-$BB --instance work ping; $BB --instance 'personal - other' ping   # buildMarker on both
-$BB health                                                         # stale=False on both
+# 2. the suite and the gate that was walked three times
+WT=/tmp/wt-verify
+git -C $DATAPACKET worktree add --detach "$WT" origin/trunk
+(cd "$WT" && bash tests/run-tests-app-capture.sh | tail -3)                 # 138 PASS / 0 FAIL
+(cd "$WT" && MUTANTS_ONLY="M112c M112d" bash tests/mutants-app-capture.sh)  # both KILLED, by G14 alone
+# 🔴 at most 2 mutants per run — 3+ exceed a 570s command timeout
+git -C $DATAPACKET worktree remove --force "$WT"
 
-# 3. the guard #820 landed, and that it can still go red
-(cd $R/scripts/browser-bridge && python3 -m pytest tests/test_server.py -q \
-   -k 'test_cli_subprocess_timeouts_outrank_the_cli_own_curl_bound or test_cli_timeout_scan_sees_what_it_claims_and_only_that')
-# then plant a literal timeout at a CLI site in a sibling test file -> must go RED
+# 3. M112d is DISCRIMINATING, not merely passing — the check that matters
+#    revert norm_g14's range to /This is a STALE BRIDGE BUILD/,/FULL Brave restart is the reliable path/p
+#    then MUTANTS_ONLY="M112d" must report SURVIVED. Restore by DIFFING the file,
+#    not by a grep count (a pattern containing $ silently reports 0 on a correct file).
 ```


### PR DESCRIPTION
Updates the canonical handoff after landing talos-infra #1306 (squash `0e4fc872a`).

## Why this matters beyond a status update

🔴 **The doc was actively wrong in a way the next `/resume` would have re-derived.** Its gotchas said the foregrounding machinery is INERT and that `activate` "raises nothing" without `--focus`. That is false: `activate` does three things and the gate suppresses ONE (the host-side `i3-msg`). It still makes the tab its window's **active tab** — which is what routes a capture onto the `captureVisibleTab` fast path that hangs — and still calls the **ungated** `chrome.windows.update({focused:true})`. Believing "inert" cost two audit rounds on #1306.

The Gotchas section appends, so the old claim survives verbatim with the retraction above it — deliberately, per the merge contract: seeing a prior reading was *corrected* is the value.

## What changed

- **State now / Next steps / How to verify** replaced. The three fixes' merge shas and constants are carried forward rather than dropped (the tool warned; the warning was right).
- **Next-step numbering kept STABLE** — item 2 is marked `✅ DONE` in place rather than renumbered, since rank is half a claim's identity.
- **New open investigation appended:** whether `chrome.windows.update({focused:true})` actually takes the screen. Nobody has measured it — the bridge's own README says so. Includes a runnable next probe with the assert-the-state-inside-the-arm warning, because the 2026-08-24 occlusion probe gave a confident wrong answer twice for exactly that reason.
- **New gotchas appended**, the transferable ones: a TEST is what kept a retracted claim alive; a keyword guard on prose gets walked (three measured escapes); and a mutant that also dies under the OLD gate guards nothing.

## Also recorded

`~/.claude/analyze-service-index/datapacket-talos/app-capture.md` gained one dated bullet for the same lessons (validated, exit 0). Not in this repo — the store lives outside every checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)