### PR TITLE
test(guards): plant positive controls for 5 never-executed guard FIRING paths

### DIFF
--- a/scripts/tests/test_clawgate_predicate_single_source.py
+++ b/scripts/tests/test_clawgate_predicate_single_source.py
@@ -240,18 +240,118 @@ def test_the_scanner_actually_walks_the_repo():
 
 
 # =========================================================================== #
-# THE GUARD
+# THE CHECKS, as pure functions over a root
 # =========================================================================== #
-def test_the_pending_state_set_is_defined_exactly_once():
+# 🔴 Each of the three loops below used to live inline inside its test, walking
+# the LIVE repo. That made every one of them structurally undriveable: they fire
+# only on a dirty corpus, and the corpus is clean, so the FIRING half of each
+# guard had never been executed by any test. Extracted verbatim (same
+# comparisons, same message strings) so a synthetic tree can drive them — the
+# live tests below call these with REPO and assert exactly what they did before.
+def scan_for_unallowlisted_literals(root: Path, allowlist=ALLOWLIST) -> dict:
+    """`{relpath: [line, ...]}` for every file holding TARGET outside `allowlist`."""
     offenders = {}
-    for p in python_files(REPO):
-        rel = p.relative_to(REPO).as_posix()
+    for p in python_files(root):
+        rel = p.relative_to(root).as_posix()
         try:
             hits = find_state_set_literals(p.read_text(encoding="utf-8"))
         except (SyntaxError, UnicodeDecodeError):
             continue  # pragma: no cover - not raised over the tracked corpus
-        if hits and rel not in ALLOWLIST:
-            offenders[rel] = hits  # pragma: no cover - the guard's own FIRING path: it fires only when the corpus is dirty, and no planted positive control drives it. Adding one is the real remedy
+        if hits and rel not in allowlist:
+            offenders[rel] = hits
+    return offenders
+
+
+def check_allowlist_counts(root: Path, allowlist=ALLOWLIST) -> list:
+    """Messages for every allowlist entry whose file is gone or miscounted."""
+    wrong = []
+    for rel, expected in sorted(allowlist.items()):
+        p = root / rel
+        if not p.exists():
+            wrong.append("%s: file is gone (expected %d)" % (rel, expected))
+            continue
+        hits = find_state_set_literals(p.read_text(encoding="utf-8"))
+        if len(hits) != expected:
+            wrong.append("%s: expected %d, found %d at line(s) %s"
+                         % (rel, expected, len(hits), hits))
+    return wrong
+
+
+def scan_for_threshold_respellings(root: Path, skip=()) -> list:
+    """`["rel:lineno text", ...]` for every re-spelling of the shared constant."""
+    offenders = []
+    for p in python_files(root):
+        rel = p.relative_to(root).as_posix()
+        if rel in skip:
+            continue
+        text = p.read_text(encoding="utf-8", errors="replace")
+        for i, line in enumerate(text.splitlines(), 1):
+            if "THRESHOLD_SECS" in line and "=" in line and "CG." not in line \
+                    and "clawgate_tasks" not in line:
+                offenders.append("%s:%d %s" % (rel, i, line.strip()))
+    return offenders
+
+
+# =========================================================================== #
+# 🔴 POSITIVE CONTROLS on the three FIRING paths above. Each feeds a synthetic
+# tree that MUST make one guard fire, and asserts THAT guard's own message —
+# never merely "the list is non-empty". Counts are pairwise distinct so the two
+# arms of the allowlist comparison cannot be confused for each other.
+# =========================================================================== #
+def test_positive_control_an_unallowlisted_copy_IS_reported(tmp_path):
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "rogue.py").write_text(
+        "# a fourth surface re-spelling the predicate\n"
+        'STATES = frozenset({"ready_for_review", "open"})\n')
+    # …and a file that IS pardoned must stay out of the report.
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "lib").mkdir()
+    (tmp_path / "scripts" / "lib" / "clawgate_tasks.py").write_text(
+        'PENDING_TASK_STATES = frozenset({"open", "ready_for_review"})\n')
+
+    offenders = scan_for_unallowlisted_literals(tmp_path)
+    assert offenders == {"pkg/rogue.py": [2]}, offenders
+
+
+def test_positive_control_a_pardoned_file_that_VANISHED_is_reported(tmp_path):
+    # Only the "file is gone" arm: nothing on disk at all. 7 is unique to this
+    # test, so a mutant that leaks into the other arm's message is visible.
+    wrong = check_allowlist_counts(tmp_path, {"scripts/vanished.py": 7})
+    assert wrong == ["scripts/vanished.py: file is gone (expected 7)"], wrong
+
+
+def test_positive_control_a_pardoned_file_with_the_WRONG_COUNT_is_reported(tmp_path):
+    # Only the count arm: the file exists and holds exactly 2 literals while the
+    # pardon was issued for 3. Both numbers differ from each other and from the
+    # 7 above, so this cannot pass by coincidence with the other arm.
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "pardoned.py").write_text(
+        'A = frozenset({"open", "ready_for_review"})\n'
+        'B = ["ready_for_review", "open", "blocked"]\n')
+    wrong = check_allowlist_counts(tmp_path, {"scripts/pardoned.py": 3})
+    assert wrong == [
+        "scripts/pardoned.py: expected 3, found 2 at line(s) [1, 2]"], wrong
+    # The same file pinned at its true count is silent — the guard is not simply
+    # rejecting everything.
+    assert check_allowlist_counts(tmp_path, {"scripts/pardoned.py": 2}) == []
+
+
+def test_positive_control_a_respelled_threshold_constant_is_reported(tmp_path):
+    (tmp_path / "consumer.py").write_text(
+        "import os\n"
+        "STUCK_THRESHOLD_SECS = 900\n"
+        "threshold = CG.STUCK_THRESHOLD_SECS\n")
+    (tmp_path / "skipped.py").write_text("OTHER_THRESHOLD_SECS = 42\n")
+
+    offenders = scan_for_threshold_respellings(tmp_path, skip=("skipped.py",))
+    assert offenders == ["consumer.py:2 STUCK_THRESHOLD_SECS = 900"], offenders
+
+
+# =========================================================================== #
+# THE GUARD
+# =========================================================================== #
+def test_the_pending_state_set_is_defined_exactly_once():
+    offenders = scan_for_unallowlisted_literals(REPO)
     assert not offenders, (
         "a second copy of the clawgate operator-pending state set appeared:\n"
         + "\n".join("  %s: line(s) %s" % (k, v) for k, v in offenders.items())
@@ -270,16 +370,7 @@ def test_every_allowlist_entry_carries_EXACTLY_the_pinned_number_of_literals():
     to an already-listed file, which is the regrowth the whole guard exists to
     catch, wearing a pardon it was never granted.
     """
-    wrong = []
-    for rel, expected in sorted(ALLOWLIST.items()):
-        p = REPO / rel
-        if not p.exists():
-            wrong.append("%s: file is gone (expected %d)" % (rel, expected))  # pragma: no cover - the guard's own FIRING path: it fires only when the corpus is dirty, and no planted positive control drives it. Adding one is the real remedy
-            continue
-        hits = find_state_set_literals(p.read_text(encoding="utf-8"))
-        if len(hits) != expected:
-            wrong.append("%s: expected %d, found %d at line(s) %s"  # pragma: no cover - the guard's own FIRING path: it fires only when the corpus is dirty, and no planted positive control drives it. Adding one is the real remedy
-                         % (rel, expected, len(hits), hits))
+    wrong = check_allowlist_counts(REPO)
     assert not wrong, (
         "the ALLOWLIST no longer accounts for the literals in these files:\n  "
         + "\n  ".join(wrong)
@@ -300,17 +391,9 @@ def test_the_threshold_constant_is_also_defined_exactly_once():
     # vacuous the moment it was renamed — a guard that stops matching is
     # indistinguishable from a guard that finds nothing. `_SECS` is what keeps it
     # off unrelated thresholds like session-manager's DEFAULT_STALE_THRESHOLD.
-    offenders = []
-    for p in python_files(REPO):
-        rel = p.relative_to(REPO).as_posix()
-        if rel in (LIB_REL, "scripts/tests/test_clawgate_tasks.py",
-                   "scripts/tests/test_clawgate_predicate_single_source.py"):
-            continue
-        text = p.read_text(encoding="utf-8", errors="replace")
-        for i, line in enumerate(text.splitlines(), 1):
-            if "THRESHOLD_SECS" in line and "=" in line and "CG." not in line \
-                    and "clawgate_tasks" not in line:
-                offenders.append("%s:%d %s" % (rel, i, line.strip()))  # pragma: no cover - the guard's own FIRING path: it fires only when the corpus is dirty, and no planted positive control drives it. Adding one is the real remedy
+    offenders = scan_for_threshold_respellings(
+        REPO, skip=(LIB_REL, "scripts/tests/test_clawgate_tasks.py",
+                    "scripts/tests/test_clawgate_predicate_single_source.py"))
     assert not offenders, (
         "a stuck-threshold constant was re-spelled outside the shared module:\n  "
         + "\n  ".join(offenders)

--- a/scripts/tests/test_doc_path_rot.py
+++ b/scripts/tests/test_doc_path_rot.py
@@ -459,7 +459,7 @@ def _read_list(path: Path) -> list[str]:
         # every known-dead one as NEW. That is exactly how the reference
         # implementation's repo produced a confident false alarm -- the script
         # was pulled into a clone without its sidecar.
-        raise AssertionError(  # pragma: no cover - the guard's own FIRING path: it fires only when the corpus is dirty, and no planted positive control drives it. Adding one is the real remedy
+        raise AssertionError(
             f"{path} is missing. This gate's verdict is meaningless without it; "
             "restore it from git rather than letting the run continue."
         )
@@ -1215,6 +1215,30 @@ def test_ignore_matcher_handles_both_forms():
     assert not _ignored("claude/skills/gone/SKILL.md.bak", ignores)
     assert not _ignored("claudedocs/other/deep.md", ignores)
     assert not _ignored("claude/skills/gone/SKILL.md", [])
+
+
+def test_a_missing_data_file_raises_LOUDLY_rather_than_reading_as_empty(tmp_path):
+    """POSITIVE CONTROL on `_read_list`'s missing-file guard.
+
+    Both sidecars exist in every real checkout, so on a healthy tree that guard
+    is never executed — indistinguishable from a guard wired to nothing. The
+    hazard it covers is silent: without it `path.read_text()` raises
+    `FileNotFoundError`, which reads as "the run crashed" rather than "the
+    gate's verdict is meaningless", and an earlier `.is_file()`-less version
+    would have returned an EMPTY list — reclassifying every exempt reference as
+    dead, or every known-dead one as NEW.
+
+    🔴 Pin the TYPE and the MESSAGE, not merely "something raised": deleting the
+    guard still raises, just a different exception with a different meaning.
+    """
+    missing = tmp_path / "doc-path-ignore.list"
+    with pytest.raises(AssertionError, match=r"is missing\. This gate's verdict"):
+        _read_list(missing)
+    # …and the happy path still returns the parsed list, so the guard is not
+    # simply refusing everything (comments and blanks stripped).
+    present = tmp_path / "present.list"
+    present.write_text("# a comment\n\nclaude/skills/gone/SKILL.md  # why\n")
+    assert _read_list(present) == ["claude/skills/gone/SKILL.md"]
 
 
 # --- stated limits -----------------------------------------------------------


### PR DESCRIPTION
## What

`scripts/dead-guard-scan.py` found 27 guard FIRING paths in this repo that no test has ever been watched to execute. Five of them live in these two files, each annotated in-place with *"no planted positive control drives it. Adding one is the real remedy"*. This is that remedy for those five.

Four of the five sat **inline inside a test body that walks the LIVE repo**. They fire only when the corpus is dirty, and the corpus is clean — so nothing short of breaking the repo could reach them. The reporting half of each guard, the half that decides what the failure message *says*, had never run.

## How

**`scripts/tests/test_clawgate_predicate_single_source.py`** — the three inline scan loops are extracted **verbatim** into pure module-level helpers over a `root`: `scan_for_unallowlisted_literals`, `check_allowlist_counts`, `scan_for_threshold_respellings`. Same comparisons, same message strings; the live tests call them with `REPO` and keep their existing assertion text unchanged. Pure refactor — no existing assertion weakened.

Four new positive controls feed synthetic trees that MUST make each guard fire, and assert **that guard's exact message** rather than "the list is non-empty". The two arms of the allowlist comparison (file-gone vs wrong-count) are driven **separately** with pairwise-distinct fixture counts (`7` / `3`-vs-`2`), so neither can pass on the other's behalf. Each control also pins a silent case, so a guard that fires on *everything* would be caught too.

**`scripts/tests/test_doc_path_rot.py`** — `_read_list`'s missing-data-file guard now has a direct control. It pins the exception **TYPE and the message**, because with the guard removed `path.read_text()` still raises — `FileNotFoundError`, which reads as "the run crashed" rather than "this gate's verdict is meaningless".

Every control is driven **in-process** (direct call), never via `subprocess`: the scanner traces with `sys.settrace`, which is per-interpreter, so a subprocess-driven control would leave the branch recorded as never-executed.

The five now-obsolete `# pragma: no cover` annotations are deleted. **No data file, no scanner, and neither of the registry/census TSVs was touched.**

## Mutation matrix — every control watched to go red for its OWN reason

Each mutant neuters the **narrowest** expression (the reporting statement itself, never its enclosing condition), run with `PYTHONDONTWRITEBYTECODE=1`. In every case **exactly one** control failed and the other three passed — no cross-talk between the two allowlist arms.

| # | Site | Control test | Mutation | Observed failure |
|---|---|---|---|---|
| 1 | `offenders[rel] = hits` | `test_positive_control_an_unallowlisted_copy_IS_reported` | statement → `pass` | `AssertionError: {}` — `assert {} == {'pkg/rogue.py': [2]}` |
| 2 | `wrong.append("… file is gone …")` | `test_positive_control_a_pardoned_file_that_VANISHED_is_reported` | statement → `pass` | `assert [] == ['scripts/vanished.py: file is gone (expected 7)']` |
| 3 | `wrong.append("… expected %d, found %d …")` | `test_positive_control_a_pardoned_file_with_the_WRONG_COUNT_is_reported` | statement → `pass` | `assert [] == ['scripts/pardoned.py: expected 3, found 2 at line(s) [1, 2]']` |
| 4 | `offenders.append("%s:%d %s")` | `test_positive_control_a_respelled_threshold_constant_is_reported` | statement → `pass` | `assert [] == ['consumer.py:2 STUCK_THRESHOLD_SECS = 900']` |
| 5 | `raise AssertionError(f"{path} is missing…")` (`_read_list`) | `test_a_missing_data_file_raises_LOUDLY_rather_than_reading_as_empty` | statement → `pass` | `FileNotFoundError` escapes `pytest.raises(AssertionError, …)` — i.e. the **type pin** is what catches it |

Both files were restored **byte-exactly** (sha256 verified against a pre-sweep `cp -a`) after the sweep, and re-run green.

## Verification

- `dead-guard-scan.py --repo <wt>`: **the five sites no longer appear**. Remaining unresolved flags are 2 in `scripts/tests/test_no_real_launchers.py` — a different subset, untouched here.
- `pytest scripts/tests/test_clawgate_predicate_single_source.py scripts/tests/test_doc_path_rot.py -q` → **116 passed** (91 before this change).
- `run-tests.sh --check-floors` → **PASS (exit 0)** at both `origin/main` and this branch, identical floor tables, `GLOBAL floor = 15789` on both.
- `run-tests.sh --set all` → **exit 3 at BOTH refs**, identically: a missing-tool ENVIRONMENT precondition on this dev box (`nix develop` not entered), not a code failure and not a delta. Tekton CI is the authority.
