### PR TITLE
test(skill-size): plant positive controls for 8 guards nobody had watched fire

### DIFF
--- a/scripts/tests/test_handoff_skill_size.py
+++ b/scripts/tests/test_handoff_skill_size.py
@@ -206,17 +206,25 @@ MAX_BYTES = 24_000
 MIN_HEADROOM_BYTES = 900
 
 
-def _existing_topics() -> str:
+def existing_topics_text(reference_dir: Path) -> str:
     """The reference topics that exist RIGHT NOW, read off the filesystem.
 
     Globbed rather than hard-coded for the reason test_skill_size.py gives: a
     hand-maintained list drifts, and a drifted list steers a maintainer into
     creating a duplicate topic for content that already has a home.
+
+    Takes the directory as an argument so the empty-glob branch -- the one that
+    tells a maintainer `reference/` moved -- can be driven by a planted control
+    against a tmp dir instead of waiting for the real tree to lose its sidecars.
     """
-    topics = sorted(p.stem for p in REFERENCE_DIR.glob("*.md"))
+    topics = sorted(p.stem for p in reference_dir.glob("*.md"))
     if not topics:
-        return f"(none found under {REFERENCE_DIR} -- did reference/ move?)"  # pragma: no cover - the guard's own FIRING path: it fires only when the corpus is dirty, and no planted positive control drives it. Adding one is the real remedy
+        return f"(none found under {reference_dir} -- did reference/ move?)"
     return ", ".join(topics)
+
+
+def _existing_topics() -> str:
+    return existing_topics_text(REFERENCE_DIR)
 
 
 def _pin_lists() -> dict[str, int]:
@@ -259,10 +267,16 @@ def _pin_lists() -> dict[str, int]:
     return counts
 
 
-def _pin_counts() -> str:
-    counts = _pin_lists()
+def pin_counts_text(counts: dict[str, int]) -> str:
+    """Render the pin-count block from an already-parsed count mapping.
+
+    Split from `_pin_lists()` so the unparseable-corpus branch below is
+    reachable from a planted control: it fires only when NEITHER pin module can
+    be parsed, which never happens on a healthy tree, so it was recorded as a
+    guard nobody has watched execute.
+    """
     if not counts:
-        return (  # pragma: no cover - the guard's own FIRING path: it fires only when the corpus is dirty, and no planted positive control drives it. Adding one is the real remedy
+        return (
             "The skill's prose is pinned verbatim by HANDOFF_SENTENCES "
             "(scripts/tests/test_subsystem_touch.py) and SKILL_PINS "
             "(scripts/tests/test_handoff_doc.py) -- neither could be parsed "
@@ -278,6 +292,10 @@ def _pin_counts() -> str:
         f"SKILL_PINS entries and the seam test in test_subsystem_touch.py. Read "
         f"the step cold — the pin count is not your safety net here."
     )
+
+
+def _pin_counts() -> str:
+    return pin_counts_text(_pin_lists())
 
 
 def _eviction_playbook() -> str:
@@ -350,6 +368,47 @@ def test_eviction_playbook_lists_every_reference_topic():
         "maintainer following it would create a duplicate topic. The list must "
         "stay derived from the filesystem, never hard-coded."
     )
+
+
+def test_control_existing_topics_reports_an_empty_reference_dir(tmp_path):
+    """Positive control for the `reference/ moved` arm of the topic renderer.
+
+    On a healthy tree the glob is never empty, so this branch was recorded by
+    `scripts/dead-guard-scan.py` as never executed -- asserted to work, never
+    watched to. Driven IN-PROCESS against an empty tmp dir; a subprocess would
+    leave the branch just as unobserved.
+    """
+    empty = tmp_path / "reference"
+    empty.mkdir()
+    assert existing_topics_text(empty) == (
+        f"(none found under {empty} -- did reference/ move?)"
+    )
+    # Negative control: the same helper does NOT say "none found" when a topic
+    # exists, so the message above is a fact about the empty dir, not the code.
+    (empty / "some-topic.md").write_text("x", encoding="utf-8")
+    (empty / "another-topic.md").write_text("y", encoding="utf-8")
+    assert existing_topics_text(empty) == "another-topic, some-topic"
+
+
+def test_control_pin_counts_reports_an_unparseable_pin_corpus():
+    """Positive control for the `neither could be parsed` arm of the pin block.
+
+    It fires only when BOTH pin modules are missing or hold no list literal --
+    never true on a healthy tree. Driven by handing the renderer an empty
+    mapping directly, which is exactly what `_pin_lists()` returns in that case.
+    """
+    assert pin_counts_text({}) == (
+        "The skill's prose is pinned verbatim by HANDOFF_SENTENCES "
+        "(scripts/tests/test_subsystem_touch.py) and SKILL_PINS "
+        "(scripts/tests/test_handoff_doc.py) -- neither could be parsed "
+        "from here, so re-count them by hand before editing."
+    )
+    # Negative control: a populated mapping renders the OTHER arm, so the branch
+    # above is selected by the emptiness and nothing else. The counts are
+    # deliberately not the live ones -- a mutant hardcoding a real figure dies.
+    populated = pin_counts_text({"HANDOFF_SENTENCES": 41, "SKILL_PINS": 7})
+    assert "neither could be parsed" not in populated
+    assert "41 in HANDOFF_SENTENCES, 7 in SKILL_PINS" in populated
 
 
 def test_handoff_skill_under_hard_ceiling():

--- a/scripts/tests/test_prune_skill_size.py
+++ b/scripts/tests/test_prune_skill_size.py
@@ -361,6 +361,62 @@ def _registry_block(body: str) -> str:
     return body[start:] if end == -1 else body[start:end]
 
 
+def figure_problems_in(src: str, checks) -> list[str]:
+    """Cross-check every `(label, pattern, expected)` figure against `src`.
+
+    Extracted from the test body so each of the three FIRING arms -- no match,
+    more than one match, and a captured value that differs from the measured one
+    -- can be driven by a planted positive control instead of waiting for the
+    live corpus to go dirty. The live gate below calls this with the module's own
+    source; the controls call it with synthetic text. Pure: no filesystem, no
+    globals, so a control's input is exactly what the caller passes.
+    """
+    problems = []
+    for label, pattern, expected in checks:
+        found = re.findall(pattern, src)
+        if not found:
+            problems.append(f"{label}: PATTERN DID NOT MATCH ({pattern!r}) — the "
+                            f"sentence was reworded, so this figure is now unchecked")
+        elif len(found) > 1:
+            problems.append(f"{label}: pattern matched {len(found)}x ({found}) — an "
+                            "added sentence can shadow the live figure; make the "
+                            "pattern name exactly one sentence")
+        elif found[0] != expected:
+            problems.append(f"{label}: prose says {found[0]}, measured {expected}")
+    return problems
+
+
+def bb_claim_problems_in(src: str, bb: int, target: int, bb_claim: str) -> list[str]:
+    """The browser-bridge pair: the sentence is present verbatim, and it is TRUE.
+
+    Two separate guards, deliberately kept together because they are two halves
+    of one claim -- the wording pin cannot see a false sentence, and the
+    `bb > target` measurement cannot see a reworded one. Extracted for the same
+    reason as `figure_problems_in`: both arms are otherwise only reachable by
+    dirtying the real corpus.
+    """
+    problems = []
+    if " ".join(src.split()).count(bb_claim) != 1:
+        problems.append(
+            "browser-bridge claim: the sentence asserting that browser-bridge "
+            f"meets the target is not present exactly once as written.\n    "
+            f"Expected verbatim (whitespace-normalised):\n      {bb_claim}\n    "
+            "A reword makes this figure unchecked, so restore the wording or "
+            "re-point this pin deliberately."
+        )
+    if bb > target:
+        problems.append(
+            f"browser-bridge claim: prose says browser-bridge MEETS the "
+            f"{target:,} B target, but it measures {bb:,} B -- over by "
+            f"{bb - target:,} B. The sentence is now FALSE, and this module's "
+            "whole 'the target is achievable and is not in dispute' argument "
+            "rests on it. Fix browser-bridge or rewrite the argument -- do NOT "
+            "restate the new number, which is how the literal form of this "
+            "check certified the same falsehood."
+        )
+    return problems
+
+
 def test_this_modules_own_stated_figures_are_re_measured():
     """🔴 THE DOCSTRING IS A CLAIM, AND PROSE COULD NOT HOLD IT.
 
@@ -472,18 +528,7 @@ def test_this_modules_own_stated_figures_are_re_measured():
         ("routing mean, restated",   r"at the real ([\d,]+) B/row",               f"{row_bytes // len(rows):,}"),
         ("two mean routing rows",    r"two rows are ([\d,]+) B > ",               f"{2 * (row_bytes // len(rows)):,}"),
     ]
-    problems = []
-    for label, pattern, expected in checks:
-        found = re.findall(pattern, src)
-        if not found:
-            problems.append(f"{label}: PATTERN DID NOT MATCH ({pattern!r}) — the "  # pragma: no cover - the guard's own FIRING path: it fires only when the corpus is dirty, and no planted positive control drives it. Adding one is the real remedy
-                            f"sentence was reworded, so this figure is now unchecked")
-        elif len(found) > 1:
-            problems.append(f"{label}: pattern matched {len(found)}x ({found}) — an "  # pragma: no cover - the guard's own FIRING path: it fires only when the corpus is dirty, and no planted positive control drives it. Adding one is the real remedy
-                            "added sentence can shadow the live figure; make the "
-                            "pattern name exactly one sentence")
-        elif found[0] != expected:
-            problems.append(f"{label}: prose says {found[0]}, measured {expected}")  # pragma: no cover - the guard's own FIRING path: it fires only when the corpus is dirty, and no planted positive control drives it. Adding one is the real remedy
+    problems = figure_problems_in(src, checks)
 
     # ── The one figure this module does NOT own ──────────────────────────────
     # Every other gated figure derives from something this module's own change
@@ -517,24 +562,7 @@ def test_this_modules_own_stated_figures_are_re_measured():
         "while routing ~11x its own weight, so the target is achievable and is "
         "not in dispute."
     )
-    if " ".join(src.split()).count(BB_CLAIM) != 1:
-        problems.append(  # pragma: no cover - the guard's own FIRING path: it fires only when the corpus is dirty, and no planted positive control drives it. Adding one is the real remedy
-            "browser-bridge claim: the sentence asserting that browser-bridge "
-            f"meets the target is not present exactly once as written.\n    "
-            f"Expected verbatim (whitespace-normalised):\n      {BB_CLAIM}\n    "
-            "A reword makes this figure unchecked, so restore the wording or "
-            "re-point this pin deliberately."
-        )
-    if bb > target:
-        problems.append(  # pragma: no cover - the guard's own FIRING path: it fires only when the corpus is dirty, and no planted positive control drives it. Adding one is the real remedy
-            f"browser-bridge claim: prose says browser-bridge MEETS the "
-            f"{target:,} B target, but it measures {bb:,} B -- over by "
-            f"{bb - target:,} B. The sentence is now FALSE, and this module's "
-            "whole 'the target is achievable and is not in dispute' argument "
-            "rests on it. Fix browser-bridge or rewrite the argument -- do NOT "
-            "restate the new number, which is how the literal form of this "
-            "check certified the same falsehood."
-        )
+    problems += bb_claim_problems_in(src, bb, target, BB_CLAIM)
 
     assert not problems, (
         "this module's own figures no longer describe what they measure:\n  "
@@ -547,6 +575,128 @@ def test_this_modules_own_stated_figures_are_re_measured():
         f"Deliberately ungated: {list(UNGATED)}\n"
         "Re-measure and update the prose; do NOT relax this test."
     )
+
+
+# ── Positive controls for the five guard arms above ─────────────────────────
+#
+# The gate above only ever runs against a CLEAN corpus, so every one of its
+# `problems.append` branches was recorded by `scripts/dead-guard-scan.py` as
+# never executed: the guards were asserted to work, never watched to. These
+# controls feed synthetic inputs that MUST make one specific arm fire, and each
+# asserts that arm's WHOLE message, so a mutant cannot be scored dead by a
+# neighbouring arm's wording.
+#
+# The three `figure_problems_in` arms are mutually exclusive branches of one
+# loop, so each fixture is built to leave the other two silent:
+#   * no-match   -- the pattern is absent, so neither count nor value is reached;
+#   * multi-match -- `expected` EQUALS the first capture, so disabling this arm
+#     falls through to a value comparison that is TRUE and yields nothing, never
+#     a second message that could be mistaken for this one;
+#   * value-mismatch -- exactly one capture, so only the value arm can fire.
+# Fixture figures are pairwise distinct and share no value with any figure the
+# live corpus measures, so a mutant hardcoding a real constant survives none of
+# them. They are deliberately NOT restated from the gated docstring either --
+# this module's own rule is that a second hand-copy of a live number is how the
+# drift regrows, and these controls must not become such a copy.
+
+
+def test_control_figure_pattern_that_matches_nothing_reports_it_unchecked():
+    """Arm 1: a reworded sentence means the figure is silently unchecked."""
+    src = "the ledger sits at 4,441 B today"
+    pattern = r"no sentence in this fixture says ([\d,]+) B"
+    problems = figure_problems_in(src, [("absent figure", pattern, "9,173")])
+    assert problems == [
+        f"absent figure: PATTERN DID NOT MATCH ({pattern!r}) — the "
+        "sentence was reworded, so this figure is now unchecked"
+    ]
+
+
+def test_control_figure_pattern_that_matches_twice_reports_the_shadowing():
+    """Arm 2: a second sentence can shadow the live figure.
+
+    `expected` is the FIRST capture on purpose: with this arm neutered the loop
+    falls through to a value comparison that passes, so the control goes empty
+    rather than red-for-the-wrong-arm.
+    """
+    src = "row A is 2,207 B and row B is 6,619 B"
+    problems = figure_problems_in(src, [("doubled figure", r"is ([\d,]+) B", "2,207")])
+    assert problems == [
+        "doubled figure: pattern matched 2x (['2,207', '6,619']) — an "
+        "added sentence can shadow the live figure; make the "
+        "pattern name exactly one sentence"
+    ]
+
+
+def test_control_figure_whose_prose_value_drifted_reports_both_numbers():
+    """Arm 3: one clean match whose captured value is no longer the measurement."""
+    src = "the tally reads 5,003 B in prose"
+    problems = figure_problems_in(
+        src, [("stale figure", r"tally reads ([\d,]+) B", "8,761")])
+    assert problems == ["stale figure: prose says 5,003, measured 8,761"]
+
+
+def test_control_all_three_figure_arms_fire_together_with_distinct_wording():
+    """The three arms are distinguishable, not one message wearing three hats."""
+    src = "row A is 2,207 B and row B is 6,619 B. the tally reads 5,003 B in prose"
+    absent = r"no sentence in this fixture says ([\d,]+) B"
+    problems = figure_problems_in(src, [
+        ("absent figure", absent, "9,173"),
+        ("doubled figure", r"is ([\d,]+) B", "2,207"),
+        ("stale figure", r"tally reads ([\d,]+) B", "8,761"),
+    ])
+    assert problems == [
+        f"absent figure: PATTERN DID NOT MATCH ({absent!r}) — the "
+        "sentence was reworded, so this figure is now unchecked",
+        "doubled figure: pattern matched 2x (['2,207', '6,619']) — an "
+        "added sentence can shadow the live figure; make the "
+        "pattern name exactly one sentence",
+        "stale figure: prose says 5,003, measured 8,761",
+    ]
+
+
+_CONTROL_CLAIM = "PINNED FIXTURE SENTENCE about a target being met."
+
+
+@pytest.mark.parametrize("occurrences", [0, 2])
+def test_control_bb_claim_not_present_exactly_once_is_reported(occurrences):
+    """BB arm 1: the wording pin. `bb <= target`, so the value arm stays silent."""
+    src = "prelude\n" + "\n".join([_CONTROL_CLAIM] * occurrences) + "\ncoda"
+    problems = bb_claim_problems_in(src, 7_331, 10_247, _CONTROL_CLAIM)
+    assert problems == [
+        "browser-bridge claim: the sentence asserting that browser-bridge "
+        "meets the target is not present exactly once as written.\n    "
+        f"Expected verbatim (whitespace-normalised):\n      {_CONTROL_CLAIM}\n    "
+        "A reword makes this figure unchecked, so restore the wording or "
+        "re-point this pin deliberately."
+    ]
+
+
+def test_control_bb_over_target_reports_the_sentence_as_false():
+    """BB arm 2: the sentence is present verbatim and is nonetheless FALSE.
+
+    This is the walk the module's own comment describes -- the prose still says
+    browser-bridge MEETS the target while the file measures over it. The claim
+    is planted exactly once so the wording arm cannot fire and steal the kill.
+    """
+    src = f"prelude\n{_CONTROL_CLAIM}\ncoda"
+    problems = bb_claim_problems_in(src, 13_701, 11_453, _CONTROL_CLAIM)
+    assert problems == [
+        "browser-bridge claim: prose says browser-bridge MEETS the "
+        "11,453 B target, but it measures 13,701 B -- over by "
+        "2,248 B. The sentence is now FALSE, and this module's "
+        "whole 'the target is achievable and is not in dispute' argument "
+        "rests on it. Fix browser-bridge or rewrite the argument -- do NOT "
+        "restate the new number, which is how the literal form of this "
+        "check certified the same falsehood."
+    ]
+
+
+def test_control_clean_input_produces_no_problems_at_all():
+    """Negative control: neither helper invents a problem on a clean corpus."""
+    src = f"the tally reads 8,761 B in prose\n{_CONTROL_CLAIM}"
+    assert figure_problems_in(
+        src, [("stale figure", r"tally reads ([\d,]+) B", "8,761")]) == []
+    assert bb_claim_problems_in(src, 7_331, 10_247, _CONTROL_CLAIM) == []
 
 
 def test_every_reference_topic_is_routed_from_the_core():

--- a/scripts/tests/test_session_manager_skill_size.py
+++ b/scripts/tests/test_session_manager_skill_size.py
@@ -700,6 +700,70 @@ def test_a_NEW_orphan_sidecar_reaches_the_unrouted_verdict():
     )
 
 
+def self_routing_loops_in(topics, resolve) -> dict[str, list[str]]:
+    """Which of `topics` hold a routing path that resolves back to themselves.
+
+    Extracted from the gate below so the RECORDING branch -- the one that files
+    a loop -- can be driven by a planted control. On a healthy tree no topic
+    self-routes, so that branch was scored by `scripts/dead-guard-scan.py` as
+    never executed: the gate's red had been argued, never watched.
+
+    Pure in its inputs: `topics` are the paths to read and `resolve` decides
+    where a written token lands, so a control can supply both.
+    """
+    loops: dict[str, list[str]] = {}
+    for topic in topics:
+        hits = [t for t in _routing_paths(topic.read_text(encoding="utf-8"))
+                if resolve(t) == topic]
+        if hits:
+            loops[topic.name] = hits
+    return loops
+
+
+def test_control_a_planted_self_route_is_recorded_as_a_loop(tmp_path):
+    """Positive control for the loop-recording branch of the self-route gate.
+
+    Two topics are planted side by side and only ONE of them points at itself,
+    so a mutant that records unconditionally is caught by the other's absence
+    from the verdict -- equality on the whole mapping, not `loops` being truthy.
+    The forward pointer is the exact shape the 2026-08-21 prune produced when it
+    sliced text verbatim out of the core: correct in the core, a loop once it
+    landed inside its own target.
+    """
+    looper = tmp_path / "loops-onto-itself.md"
+    looper.write_text(
+        "See `reference/loops-onto-itself.md` for the detail.\n", encoding="utf-8")
+    forward = tmp_path / "points-elsewhere.md"
+    forward.write_text(
+        "See `reference/loops-onto-itself.md` for the detail.\n", encoding="utf-8")
+
+    def resolve(token: str) -> Path:
+        return tmp_path / Path(token).name
+
+    assert self_routing_loops_in([looper, forward], resolve) == {
+        "loops-onto-itself.md": ["reference/loops-onto-itself.md"]
+    }
+
+
+def test_control_forward_pointers_alone_record_no_loop(tmp_path):
+    """Negative control: the branch above is selected by the self-pointer only.
+
+    Without it the positive control cannot tell "the guard fired" from "the
+    guard fires on everything", which is the mutant that survives a truthiness
+    assertion.
+    """
+    forward = tmp_path / "points-elsewhere.md"
+    forward.write_text(
+        "See `reference/some-other-topic.md` for the detail.\n", encoding="utf-8")
+    bare = tmp_path / "routes-nothing.md"
+    bare.write_text("Prose with no routing path at all.\n", encoding="utf-8")
+
+    def resolve(token: str) -> Path:
+        return tmp_path / Path(token).name
+
+    assert self_routing_loops_in([forward, bare], resolve) == {}
+
+
 def test_no_reference_topic_ROUTES_TO_ITSELF():
     """🔴 THE BLIND SPOT OF THE ROUTING GATE ABOVE: it reads SKILL.md only.
 
@@ -711,12 +775,8 @@ def test_no_reference_topic_ROUTES_TO_ITSELF():
     hand-patched with "-- i.e. this file, above"; the other two were not, and
     nothing could have told anyone.
     """
-    loops = {}
-    for topic in sorted(REFERENCE_DIR.glob("*.md")):
-        hits = [t for t in _routing_paths(topic.read_text(encoding="utf-8"))
-                if _resolve_routing_path(t) == topic]
-        if hits:
-            loops[topic.name] = hits  # pragma: no cover - the guard's own FIRING path: it fires only when the corpus is dirty, and no planted positive control drives it. Adding one is the real remedy
+    loops = self_routing_loops_in(sorted(REFERENCE_DIR.glob("*.md")),
+                                  _resolve_routing_path)
     assert not loops, (
         "a reference topic routes to ITSELF -- a reader following the pointer "
         "lands back where they already are:\n"


### PR DESCRIPTION
## What

`scripts/dead-guard-scan.py` scored **8 guard FIRING paths** across the three
skill-size gates as never executed by any test. Each carried the in-place
annotation *"no planted positive control drives it. Adding one is the real
remedy"*. This plants the controls.

| # | Site | Guard |
|---|---|---|
| S1 | `test_prune_skill_size.py` | `checks` loop, arm 1 — pattern matched **zero** times |
| S2 | `test_prune_skill_size.py` | `checks` loop, arm 2 — pattern matched **more than once** |
| S3 | `test_prune_skill_size.py` | `checks` loop, arm 3 — captured value **≠** measured |
| S4 | `test_prune_skill_size.py` | `BB_CLAIM` sentence pin (`count(...) != 1`) |
| S5 | `test_prune_skill_size.py` | `bb > target` — the sentence is present and **FALSE** |
| S6 | `test_handoff_skill_size.py` | `_existing_topics` — `reference/` glob is empty |
| S7 | `test_handoff_skill_size.py` | `_pin_counts` — neither pin module could be parsed |
| S8 | `test_session_manager_skill_size.py` | self-route loop **recorded** |

## How

All eight sat inside long test bodies that walk the LIVE repo, so the only
input that could reach them was a dirty corpus. Each is extracted into a pure
module-level helper; the live gate calls the helper and keeps its assertion text
unchanged. **Pure refactor** — no assertion weakened, relaxed or deleted, every
message string carried over byte-identical, no `SKILL.md` and no prose figure
touched.

New helpers:

- `test_prune_skill_size.figure_problems_in(src, checks)`
- `test_prune_skill_size.bb_claim_problems_in(src, bb, target, bb_claim)`
- `test_handoff_skill_size.existing_topics_text(reference_dir)`
- `test_handoff_skill_size.pin_counts_text(counts)`
- `test_session_manager_skill_size.self_routing_loops_in(topics, resolve)`

Controls are driven **in-process** (direct function call, never `subprocess`) —
the scanner traces with `sys.settrace`, which is per-interpreter, so a
subprocess-driven control would leave the branch recorded as never-executed.

S1–S3 are mutually exclusive branches of ONE loop, so each fixture is built to
leave the other two **silent**: the multi-match fixture sets `expected` to its
own first capture, so neutering that arm falls through to a value comparison
that *passes* rather than to a neighbouring message that could score the mutant
dead for the wrong reason. Fixture figures are pairwise distinct and are not
restated from any live measurement.

## Mutation matrix

Narrowest expression neutered, only that control run, `PYTHONDONTWRITEBYTECODE=1`,
file restored byte-exactly (sha256-verified) between mutants. Every one observed
**RED naming its own arm's message**:

| # | Mutation | Observed failure |
|---|---|---|
| S1 | arm-1 `problems.append(...)` → `pass` | `assert [] == [...]` — missing `absent figure: PATTERN DID NOT MATCH (...) — the sentence was reworded...` |
| S2 | `len(found) > 1` → `len(found) > 99` | missing `doubled figure: pattern matched 2x (['2,207', '6,619']) — an added sentence can shadow...` |
| S3 | `found[0] != expected` → `False` | missing `stale figure: prose says 5,003, measured 8,761` |
| S4 | `" ".join(src.split()).count(bb_claim) != 1` → `False` | missing `browser-bridge claim: ... is not present exactly once as written` (both params, 0 and 2 occurrences) |
| S5 | `bb > target` → `False` | missing `browser-bridge claim: prose says browser-bridge MEETS the 11,453 B target, but it measures 13,701 B -- over by 2,248 B` |
| S6 | `if not topics:` → `if False:` | `assert '' == '(none found under .../reference -- did reference/ move?)'` |
| S7 | `if not counts:` → `if False:` | got the ⚠ pin-count block, expected `The skill's prose is pinned verbatim by HANDOFF_SENTENCES ... neither could be parsed` |
| S8 | `if hits:` → `if False:` | `assert {} == {'loops-onto-itself.md': ['reference/loops-onto-itself.md']}` |

S1 is neutered at its `append` rather than at `if not found:` deliberately:
flipping that condition drops an EMPTY capture list into `found[0]`, so the
control would die of an `IndexError` instead of the absence of its own message —
a mutant dead for the wrong reason.

The prune mutants were re-run a second time against the FINAL file bytes (a
comment-only edit had raced the first pass); all five RED again, same messages.

Negative controls accompany S6/S7/S8 so a mutant that fires unconditionally
cannot pass, plus a clean-input control asserting both prune helpers invent
nothing on a healthy corpus.

## Verification

`scripts/dead-guard-scan.py`, same interpreter, base vs branch:

```
base   (9b5dc48d) : flagged 55 branch bodies never executed (53 justified, 2 unresolved)
branch (this PR)  : flagged 47 branch bodies never executed (45 justified, 2 unresolved)
```

Exactly the eight, and **no new flag**. The 2 unresolved on both sides are the
pre-existing `test_no_real_launchers.py:549 / :679` pair, untouched.

Targeted suite, green:

```
PYTHONDONTWRITEBYTECODE=1 pytest scripts/tests/test_prune_skill_size.py \
  scripts/tests/test_handoff_skill_size.py \
  scripts/tests/test_session_manager_skill_size.py -q
86 passed
```

Full `scripts/tests` is environmentally RED on this box (the default `python3`
resolves to another repo's `.venv`, and `nix develop`'s `gateTools` are absent);
base and branch were run identically and are reported as a pair in the PR
comments. Tekton CI is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
