### PR TITLE
test(flakes): three real-process races — a row is not yours because it is FIRST, and a decoy repo runs git maintenance

### DIFF
--- a/scripts/testlib/hermetic_git.py
+++ b/scripts/testlib/hermetic_git.py
@@ -28,6 +28,26 @@ modules define such a helper (`tree_hash` / `_tree_hash` / `_manifest` /
 of them in the same direction, and unifying them is what makes the disagreement
 audible." Unifying them is this module.
 
+🔴 RE-MEASURED 2026-08-26: NINE modules, and the last unpinned one had already
+fired. `test_hermetic_git.py::EXPECTED_MEMBERS` is the live ledger — read the
+count THERE, not the sentence above, which is a dated observation and not a
+claim about today. The ninth hole was `test_analyze_service_index_commit.py`'s
+`_decoy_repo_with_worktree`, which built its decoy from a bare `dict(os.environ)`
+while `_run` in the same module pinned maintenance off with a comment naming
+this exact hazard: git spawned `git maintenance run --auto --quiet --detach`
+against the decoy, and that DETACHED process created and removed
+`<decoy>/.git/objects/maintenance.lock` inside the window between the test's two
+fingerprints of that tree. 4/180 red under CPU load; 0/180 once pinned.
+
+⚠ AND THE LEDGER'S DETECTOR IS NARROWER THAN THE HAZARD, stated so the count is
+not read as coverage. It keys on four helper NAMES and globs
+`scripts/tests/test_*.py` only. `scripts/tests/test_git_repo_isolation.py`
+creates repo fixtures with no maintenance pin and snapshots their `.git` dirs;
+it is safe TODAY only because `gitenv.snapshot` reads a fixed three-file set and
+never walks `objects/` — widen its `extra_files` the way
+`test_analyze_service_index_commit.py::_objects_files` does and that module joins
+the class with nothing to notice.
+
 🔴 THE STAKES CHANGED, WHICH IS WHY THIS IS NOT COSMETIC. Both Tekton tiers
 (`devrc-pytests` AND `devrc-nodetests`) are required on `main` with
 `enforce_admins: true`. A flake in any one of these modules therefore blocks

--- a/scripts/tests/test_analyze_service_index_commit.py
+++ b/scripts/tests/test_analyze_service_index_commit.py
@@ -2520,12 +2520,25 @@ def _decoy_repo_with_worktree(tmp_path):
     (MEASURED, git 2.55.0 — a push from the MAIN checkout exports no GIT_DIR),
     which is how the variable reaches a suite, and from there anything the suite
     runs.
+
+    🔴 BUILT WITH THE HERMETIC ENV, AND THAT IS LOAD-BEARING, NOT TIDINESS. With
+    maintenance left at its default, `git` here spawns
+    `git maintenance run --auto --quiet --detach` against THIS repo — a
+    DETACHED process that outlives the command and creates, then removes,
+    `<decoy>/.git/objects/maintenance.lock` on its own schedule. `_fingerprint`
+    walks `objects/`, so that lock is a file appearing and disappearing inside
+    the very tree the assertion below is about. Measured on the unmodified tree
+    under CPU load: 4/180 red, every one of them
+    `DELETED .../objects/maintenance.lock` — the lock was caught by the `before`
+    snapshot and gone by the `after` one. The identity/`decoy` overrides are
+    kept because a committer named `decoy` is what distinguishes this repo's
+    commits from the ones the script under test writes.
     """
     work = tmp_path / "decoy" / "work"
     work.mkdir(parents=True)
-    env = dict(os.environ)
-    env.update({"GIT_AUTHOR_NAME": "decoy", "GIT_AUTHOR_EMAIL": "d@example.invalid",
-                "GIT_COMMITTER_NAME": "decoy", "GIT_COMMITTER_EMAIL": "d@example.invalid"})
+    env = hermetic_git.hermetic_git_env(
+        GIT_AUTHOR_NAME="decoy", GIT_AUTHOR_EMAIL="d@example.invalid",
+        GIT_COMMITTER_NAME="decoy", GIT_COMMITTER_EMAIL="d@example.invalid")
     subprocess.run(["git", "init", "-q", "-b", "decoy/base", str(work)],
                    check=True, capture_output=True, env=env)
     (work / "real-file.txt").write_text("real\n", encoding="utf-8")

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -180,8 +180,13 @@ def running(
     Deliberately not a handler-level unit test: the response CODE, the header
     set and the exact bytes on the wire are what every claim in this file is
     about, and an in-process call to a handler method cannot observe them.
+
+    🔴 THE YIELDED `audit` IS AN `AuditLog`, NOT A BARE LIST, so `await_audit`
+    works on it. The response-does-not-imply-the-line race `drain_output`
+    documents is NOT a property of the subprocess pipe — it is a property of
+    `ThreadingHTTPServer`, and this in-process server has exactly the same one.
     """
-    audit: list[str] = []
+    audit = AuditLog()
     httpd = api.build_server(
         host="127.0.0.1",
         port=0,
@@ -289,6 +294,55 @@ def _comparable(headers: dict) -> tuple:
 AUDIT_PREFIX = "store-api audit "
 
 
+def _audit_lines(all_lines: "list[str]") -> "list[str]":
+    """The audit subset of a stream. ONE copy, shared by both record types.
+
+    `Drained` (a subprocess's stdout) and `AuditLog` (an in-process server's
+    sink) differ in where the lines come from and in nothing else that matters
+    here; open-coding the filter twice is how the two drift apart.
+    """
+    return [ln for ln in all_lines if ln.startswith(AUDIT_PREFIX)]
+
+
+class AuditLog(list):
+    """Every line an IN-PROCESS `running()` server has emitted so far.
+
+    🔴 IT IS A REAL `list` BECAUSE FORTY-ODD ASSERTIONS READ IT AS ONE, and it
+    carries `Drained`'s read surface because `await_audit` is the one helper in
+    this file that knows how to wait for a line. The race is NOT a property of
+    the subprocess pipe: `_respond` runs before `_audit` on a
+    `ThreadingHTTPServer`, so an in-process `fetch()` returning proves exactly
+    as little about the audit line as a subprocess one does. Before this class
+    existed the in-process sites had no way to wait at all, and the only thing
+    standing between them and a red run was `shutdown()`'s 0.5s poll interval —
+    a `sleep` nobody wrote down. Measured: with the handler's `_audit` delayed
+    past that interval, the teardown "barrier" vanishes entirely.
+
+    🔴 `closed` IS `None`, NOT AN UNSET `Event`, AND THAT IS THE HONEST VALUE.
+    A `Drained` reaches EOF when the pipe closes, which is a real "no more lines
+    are coming" signal. This stream has none: `ThreadingHTTPServer` runs its
+    handlers as DAEMON threads, which `socketserver._Threads.append` refuses to
+    track, so `server_close()` joins nothing and a handler can still append
+    after teardown returns. Setting a `closed` event there would be a lie that
+    turns "the line is a little late" into a hard failure; `await_audit` reads
+    the sentinel and simply waits out its deadline instead.
+    """
+
+    closed = None
+
+    @property
+    def all(self) -> "list[str]":
+        return list(self)
+
+    @property
+    def audit(self) -> "list[str]":
+        return _audit_lines(list(self))
+
+    @property
+    def text(self) -> str:
+        return "\n".join(self)
+
+
 class Drained:
     """Everything a running store-api process has printed so far.
 
@@ -307,7 +361,7 @@ class Drained:
 
     @property
     def audit(self) -> "list[str]":
-        return [ln for ln in self.all if ln.startswith(AUDIT_PREFIX)]
+        return _audit_lines(self.all)
 
     @property
     def text(self) -> str:
@@ -362,9 +416,16 @@ def drain_output(proc) -> Drained:
     return out
 
 
-def await_audit(out: Drained, n: int, timeout: float = 15.0) -> "list[str]":
+def await_audit(out: "Drained | AuditLog", n: int, timeout: float = 15.0) -> "list[str]":
     """Wait for at least `n` audit lines, then return them. RAISES if they never
     arrive.
+
+    🔴 IT TAKES EITHER RECORD, and that is the whole reason there is only one of
+    these. `Drained` wraps a subprocess's stdout; `AuditLog` is what an
+    in-process `running()` server appends to. The hazard is identical in both —
+    `_respond` runs before `_audit` — so a second waiting helper for the second
+    shape would be the open-coded predicate `claude/RULES.md` warns about, wrong
+    at N-1 sites.
 
     🔴 It raises rather than returning short, so that `[-1]` on the result is
     always safe. Returning whatever had arrived is what produced the CI failure
@@ -384,15 +445,19 @@ def await_audit(out: Drained, n: int, timeout: float = 15.0) -> "list[str]":
     `out.wait_closed()`. `test_the_STDOUT_audit_stream_names_the_matched_
     fingerprint` does both and is the worked example.
     """
+    # `closed` is None for an `AuditLog`: that stream has no EOF to short-circuit
+    # on, so the loop simply runs to its deadline. See `AuditLog`.
+    closed = out.closed
     deadline = time.time() + timeout
     while len(out.audit) < n and time.time() < deadline:
-        if out.closed.is_set() and len(out.audit) < n:
+        if closed is not None and closed.is_set() and len(out.audit) < n:
             break                                   # the pipe is done; no more coming
         time.sleep(0.02)
     lines = out.audit
+    ended = closed is not None and closed.is_set()
     assert len(lines) >= n, (
         f"expected at least {n} `{AUDIT_PREFIX}` line(s) within {timeout:g}s, got "
-        f"{len(lines)}{' (stdout closed early)' if out.closed.is_set() else ''}.\n"
+        f"{len(lines)}{' (stdout closed early)' if ended else ''}.\n"
         f"full stdout:\n{out.text}")
     return lines
 
@@ -2060,8 +2125,14 @@ class TestClientIpIsCloudflareOnly:
             code, _h, body = fetch(
                 f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, client_ip=CLIENT_IP
             )
+            # 🔴 WAIT FOR ALL TWENTY-ONE LINES. `fetch` returning means the
+            # RESPONSE was written; `_audit()` runs after it, on a handler
+            # thread. See `drain_output` — the hazard is the server's, not the
+            # subprocess pipe's, and this site is in-process.
+            lines = await_audit(audit, 21)
         assert code == 200, "an unidentifiable caller locked out an identified one"
         assert POINTER_LINE.encode() in body
+        assert len(lines) == 21, lines
         # 🔴 THE ASSERTION THAT MAKES THIS TEST MEAN ANYTHING, and it was missing.
         # An audit found this test VACUOUS against the very hazard it names:
         # under the mutant `ip = "unknown"` (bucket every unidentified caller
@@ -2070,12 +2141,23 @@ class TestClientIpIsCloudflareOnly:
         # distinguishes fail-closed from a shared bucket is that the twentieth
         # unidentified request is STILL `no-client-ip` and never `locked-out`:
         # nothing was counted, because there was no bucket to count into.
-        statuses = {
-            line.split("status=")[1].split()[0] for line in audit[:20]
-        }
+        #
+        # 🔴 SELECTED BY IDENTITY, NEVER BY POSITION. This used to slice
+        # `audit[:20]`, which assumes the twenty rejections were APPENDED before
+        # the twenty-first request's line. They are not ordered: twenty-one
+        # handler threads each write their response and then race to append, so
+        # the `status=recalled` record can land anywhere in the list. Measured on
+        # an unmodified tree under CPU load: 2/50 red; with the handler's
+        # `_audit` delayed for `no-client-ip` only, 1/1 — `{'no-client-ip',
+        # 'recalled'}`. A row is not yours because it is FIRST.
+        unidentified = [ln for ln in lines if " ip=- " in ln]
+        assert len(unidentified) == 20, (
+            f"expected twenty unidentified records, got {len(unidentified)} — "
+            f"an unidentified caller was given an identity:\n" + "\n".join(lines))
+        statuses = {line.split("status=")[1].split()[0] for line in unidentified}
         assert statuses == {"no-client-ip"}, statuses
-        assert not any("locked-out" in line for line in audit)
-        assert not any("lockout-triggered" in line for line in audit)
+        assert not any("locked-out" in line for line in lines)
+        assert not any("lockout-triggered" in line for line in lines)
 
     def test_the_address_is_NORMALISED_so_one_caller_is_one_bucket(self):
         assert api.client_ip({"CF-Connecting-IP": "::FFFF:203.0.113.7"}) == api.client_ip(
@@ -3906,7 +3988,21 @@ class TestTrustedProxyOverTheRealProcess:
         assert all(f"ip={UNTRUSTED_PEER}" in ln for ln in lines), lines
         assert all("peer=untrusted" in ln for ln in lines), lines
         # …and the forger locks out ITSELF, which is a rate limiter working.
-        assert "status=lockout-triggered" in lines[-1], lines[-1]
+        #
+        # 🔴 READ AS A MULTISET, NEVER AS `lines[-1]`. `await_audit` guarantees
+        # the five lines EXIST; it cannot guarantee the ORDER they were appended
+        # in, and it never could. The five requests are issued sequentially and
+        # the limiter is charged before the response, so the fifth is the one
+        # that trips — but each handler writes its response and only then races
+        # to `_audit()`, so request 5's record can be appended before request
+        # 4's. `lines[-1]` then holds a plain `unauthorized` and the test is red
+        # on a tree with nothing wrong with it. The multiset says exactly what
+        # the sentence above says — five attempts, one of them the lockout — and
+        # says it about all five records instead of one.
+        statuses = sorted(ln.split("status=")[1].split()[0] for ln in lines)
+        assert statuses == ["lockout-triggered"] + ["unauthorized"] * 4, (
+            f"expected four unauthorized and one lockout-triggered, got "
+            f"{statuses}:\n" + "\n".join(lines))
 
     def test_an_untrusted_peer_LOCKING_ITSELF_OUT_does_not_touch_the_victim(
         self, store: Path, token_file: Path


### PR DESCRIPTION
Three real-process flakes, each reproduced on demand before the fix and re-measured after it under the same pressure. No retries, no `sleep`, no `flaky` markers, no widened timeouts.

Two of them turn out to be the **same** defect — reading a list that handler threads append to **by POSITION**. `await_audit()` already existed to close that class for the subprocess server; it could not be called on the in-process one at all, because `running()` yielded a bare `list`. That is now an `AuditLog` carrying `Drained`'s read surface, so there is still exactly one waiting helper.

---

## Flake 1 — `test_unidentified_requests_are_NOT_bucketed_together`

**Mechanism.** Twenty-one requests, twenty-one handler threads. Each writes its response and *then* calls `_audit()`, so the twenty-first request's `status=recalled` record can be appended **before** one of the twenty rejections. `audit[:20]` then contains it and the status set is `{'no-client-ip', 'recalled'}`.

The floor half was masked by an accident: `httpd.shutdown()` polls on a **0.5 s** interval, so teardown burns up to half a second before the assertion runs. That is a `sleep` nobody wrote down, and it does not order anything.

**Before.**
- unmodified tree, 48 CPU burners on a 24-core box: **2/50 red**, then **1/100 red** on a second 100-run measurement at base `2d4b2980`
- with the handler's `_audit` delayed 50 ms for `status=no-client-ip` only (forcing the interleaving): **1/1 red**, `AssertionError: {'no-client-ip', 'recalled'}`

**Fix.** `await_audit(audit, 21)` inside the `with` block for the floor; select the twenty by **identity** (`ip=-`) rather than by index. Under the mutant this test exists to catch (`ip = "unknown"`), the identity selector yields zero rows and the test is still red — coverage is preserved, not traded away.

**After.** 100/100 green under the same CPU load; 1/1 green under the forced interleaving.

**Mutation evidence** (both halves are load-bearing, verified separately):
| mutant | pressure | result |
|---|---|---|
| A: `unidentified = lines[:20]` (positional again, `await_audit` kept) | `_audit` +50 ms on `no-client-ip` | **RED** |
| B: `await_audit` removed, identity selection kept | `_audit` +0.8 s on `no-client-ip` (past the 0.5 s teardown poll) | **RED** |
| HEAD | both of the above | green |

---

## Flake 2 — `TestTrustedProxyOverTheRealProcess.test_THE_DEFECT_the_five_forged_attempts_are_CHARGED_TO_THE_FORGER`

**Mechanism.** Same class, one layer out. This site already used `drain_output` + `await_audit(out, 5)`, which guarantees the five lines **exist** — and never guaranteed the **order they were appended in**. `assert "status=lockout-triggered" in lines[-1]` assumes request 5's record was appended last. The limiter is charged before the response, so the *status* is decided in request order, but the *append* is not: request 5 can beat request 4 to `_audit()` and `lines[-1]` holds a plain `unauthorized`.

**Before.** With the real `server.py` patched to delay `_audit` by 150 ms for `status=unauthorized` only — forcing exactly that interleaving — the pre-fix assertion is **1/1 red**:

```
AssertionError: store-api audit ... result=401 status=unauthorized
assert 'status=lockout-triggered' in '...status=unauthorized'
```

With no forcing, the same mutant passes — which is why this only ever showed up once, in the nix sandbox.

**Fix.** Assert the **multiset**: `sorted(statuses) == ["lockout-triggered"] + ["unauthorized"] * 4`. That is the same sentence the docstring already makes ("five attempts, one of them the lockout") and it says it about all five records instead of one.

**After.** 1/1 green under the same forced interleaving.

---

## Flake 3 — `test_a_leaked_repo_pointer_cannot_aim_the_committer_at_a_foreign_repo` (5 parametrisations)

**Mechanism, named rather than inferred.** `_decoy_repo_with_worktree` built its decoy from a bare `dict(os.environ)`, so git ran with auto-maintenance at its default and spawned:

```
trace: run_command: git maintenance run --auto --quiet --detach
```

`--detach`. That background process creates and removes `<decoy>/.git/objects/maintenance.lock` on its own schedule, and `_fingerprint` walks `objects/` — so a file appears and disappears inside the exact tree the assertion is about. Every observed failure was `DELETED .../objects/maintenance.lock`: the lock was caught by the `before` snapshot and gone by the `after` one.

`_run` in the same module already pinned `hermetic_git.MAINTENANCE_OFF` with a comment naming this hazard. The fixture beside it did not — the open-coded predicate, wrong at N-1 sites, which is the very thing `scripts/testlib/hermetic_git.py` was created to end.

**Before.** 48 burners, 30 repeats × 6 shapes:
- **4/180 red**, all `DELETED …/objects/maintenance.lock`
- instrumented positive control on the racing writer itself: the decoy's `maintenance.lock` was sighted in **43/48** tests (5 of them during the fixture build — the phase that lands it in the `before` snapshot)

**Fix.** Build the decoy with `hermetic_git.hermetic_git_env(...)`, keeping the `decoy` identity overrides.

**After.** **0/180 red** and **0/180 lock sightings** under the same load.

**Mutation evidence.** Reverting only the fixture env, same load, same 180 runs: lock sightings return at **163/180** (25 of them during the build). The instrument is not blind — it is measuring a writer that the fix removes.

---

## Also in here

`scripts/testlib/hermetic_git.py`'s docstring said "EIGHT modules … only THREE pinned maintenance off (2026-08-24)". Re-measured: **nine modules, and after this PR none is unpinned on the create side.** The docstring now points at `test_hermetic_git.py::EXPECTED_MEMBERS` as the live ledger rather than restating a count, and records the detector's own blind spot: it keys on four helper *names* and globs `scripts/tests/test_*.py` only.

---

## Swept, and NOT fixed here — deliberately

`scripts/tests/test_subsystem_store_api.py` has **38** sites that read the in-process audit list; **all 38** read it *after* the `with` block and none waits. Of those, **12** make more than one auditable request, and **7** read positionally across them — flake 1 was one of the 7. The remaining 6 positional sites are the same defect and will flake:

`test_the_audit_line_names_WHICH_fingerprint_matched`, `test_a_ROTATION_end_to_end_old_still_works_then_stops`, `test_five_failures_lock_out_a_VALID_token_from_the_same_client`, `test_a_LOCKED_OUT_response_is_BYTE_IDENTICAL_to_an_ordinary_401`, `test_a_SUCCESS_does_NOT_buy_more_GUESSES`, `test_an_untrusted_peer_IS_charged_to_ITS_OWN_bucket`

Plus 5 count-racy sites (`len(audit) == 2`, `all(...)` which is **vacuously true on an empty list**) and 3 that make no auditable request at all, so their `audit == []` assertion is unconditionally green and guards nothing.

They are left out because each needs its own order-independent reformulation and its own forced-interleaving proof — the exact work this PR did three times — and mis-stating one of them silently is worse than the flake. **Closing condition: a follow-up PR that converts all 11 and shows each one red under a forced `_audit` delay before the fix.**

One structural alternative was measured and rejected: setting `httpd.daemon_threads = False` makes `server_close()` a real barrier (measured: audit len 5 vs 0 with a 1.5 s `_audit` delay) and would fix the *floor* for all 38 sites in one line. It is not in this PR because several tests deliberately leave a request unfinished, and an unbounded join in a required check that already has a permanently-pending failure mode is not a trade worth making blind.

---

## Gate — both tiers, both run, base `2d4b2980`

| tier | command | verdict |
|---|---|---|
| dev host, pytest | `nix develop --impure --command bash scripts/gate.sh --tier both` | `RESULT: PASS (exit=0)` — `TOTAL collected=16917 passed=16915 skipped=2 failed=0 (floor: 15789 = sum of 28 per-target floors)`, 0 FAIL targets |
| dev host, node | same run | `RESULT: PASS (exit=0)` — `TOTAL suites=5 files=39 tests=1292 pass=1292 fail=0 skipped=0 (floor: 1239)` |
| nix sandbox | `nix build .#checks.x86_64-linux.pytests` | `RESULT: PASS (exit=0)` — `PASS 48 FAIL 0`, `TOTAL collected=16917 passed=16915 skipped=2 failed=0` |
| nix sandbox | `nix build .#checks.x86_64-linux.nodetests` | `RESULT: PASS (exit=0)` — `TOTAL suites=5 files=39 tests=1292 pass=1292 fail=0` |

`gate.sh` reported `GATE: RESULT=PASS exit=0`. No floor drifted. Verdict lines and per-target counts were read, not exit codes.

⚠ Scope of that claim: four runs, one tier each, base `2d4b2980`. `strict` is false on branch protection, so a green check is a claim about this branch, not about the tree the merge creates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
