### PR TITLE
fix(gate): pin #841's xdist-only positive control, conditionally — DEVRC_TEST_JOBS=1 was permanently red

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2807,9 +2807,9 @@ EXPECTED_SKIPS=(
   "scripts/signal/tests|needs a real Postgres|unset:SIGNAL_PG_DSN"
   # GUARD 9's positive control for `_own_xdist_run_id()`
   # (test_gitenv_sibling_exclusion.py::test_a_real_worker_reports_a_run_id).
-  # 🔴 IT CANNOT BE MADE TO RUN SERIALLY, and the alternative was checked before
-  # pinning — the skill_audit note below is the standing reminder that
-  # re-pointing beats pinning whenever the test can be made to RUN.
+  # 🔴 IT CANNOT BE FAKED INTO RUNNING IN-PROCESS, and the alternative was
+  # checked before pinning — the skill_audit note below is the standing reminder
+  # that re-pointing beats pinning whenever the test can be made to RUN.
   # `_own_xdist_run_id()` answers non-None only when the run id is in
   # `os.environ` and ABSENT from `/proc/self/environ`, i.e. assigned at RUNTIME
   # by xdist inside an already-exec'd worker. Exporting PYTEST_XDIST_WORKER by
@@ -2817,21 +2817,36 @@ EXPECTED_SKIPS=(
   # no run id; and exporting PYTEST_XDIST_TESTRUNUID too puts it in
   # `/proc/self/environ`, which the function correctly reads as INHERITED and
   # rejects (that is `test_an_INHERITED_run_id_does_not_make_us_a_worker`, in
-  # the same file). A serial arrangement that made this control pass would be
-  # asserting against a faked condition — a vacuous positive control, which is
-  # strictly worse than a pinned skip.
+  # the same file). Any env-forged arrangement asserts against a faked
+  # condition — a vacuous positive control, strictly worse than a pinned skip.
+  # ⚠ NARROWER THAN IT FIRST READ, and MEASURED: `-n 1 --dist loadfile` DOES
+  # spawn a real `gw0`, so the control runs and passes there (6 passed). What
+  # that arrangement is not is SERIAL — it is one worker, in a separate process.
+  # Adopting it would delete the in-process mode `DEVRC_TEST_JOBS=1` exists to
+  # provide (a bisect, a flake hunt, a debugger), which is the mode this entry
+  # is unbreaking. So the judgment stands on the trade, not on impossibility.
   # CONDITIONAL on DEVRC_XDIST_ACTIVE, NOT on PYTEST_XDIST_WORKER: this ledger
   # is evaluated in the RUNNER's shell, where xdist's variable is never set.
   # See the flag's definition next to PYTEST_PARALLEL_ARGS for why. (It is set
   # far below this array; only the evaluation order matters, and that happens in
   # GUARD 2 long after both.)
   # 🔴 CONSEQUENCE, stated so it is not a surprise: in the DEFAULT parallel mode
-  # — which is what both gate tiers run — this test RUNS, so the pin costs no
-  # coverage where merges are gated. It forgives the skip only in the explicitly
-  # serial mode (`DEVRC_TEST_JOBS=1`, or a nested run), which is the mode this
-  # file itself recommends for a bisect or a flake hunt. Before this entry that
-  # mode exited 1 on GUARD 2 alone: #841 introduced both the test and the
-  # parallelism, so it shipped a race whose documented workaround it had broken.
+  # this test RUNS, so the pin costs no coverage in the mode the gate tiers
+  # normally take. It forgives the skip only where the run is serial —
+  # `DEVRC_TEST_JOBS=1`, or a nested run — which is the mode this file itself
+  # recommends for a bisect or a flake hunt. Before this entry that mode exited
+  # 1 on GUARD 2 alone: #841 introduced both the test and the parallelism, so it
+  # shipped a race whose documented workaround it had broken.
+  # ⚠ "the gate tiers run parallel" is NPROC-DERIVED, NOT structural, so say the
+  # conditional part out loud: `_devrc_default_jobs` is `min(nproc, 4)`, and the
+  # comment beside it anticipates 1–2-core CI nodes. Measured 2026-08-26 on
+  # THIS host: `nix build .#checks.x86_64-linux.pytests` logged
+  # `parallelism =4 (-n 4 --dist loadfile)`, so the sandbox saw >= 4 cores and
+  # the control ran. On a genuinely 1-core builder the gating tier is SERIAL, this
+  # pin applies, and GUARD 9's positive control does not run behind a green
+  # gate. That trade is accepted; it must not be silent. If a builder ever
+  # lands on one core, the fix is to make the CONTROL independent of the
+  # runner's mode, not to delete this entry.
   "scripts/tests|only meaningful inside a real xdist worker|unset:DEVRC_XDIST_ACTIVE"
 )
 # ⚠ REMOVED, deliberately — do not re-add. `scripts/tests/test_skill_audit.py`
@@ -3007,11 +3022,24 @@ PYTEST_PARALLEL_ARGS=()
 # while PYTEST_XDIST_WORKER is INHERITED and set, i.e. exactly inverted.
 # This flag is the same fact read at the end that owns it — we are the process
 # that decides whether xdist workers exist at all — so it tracks the `-n` in
-# `PYTEST_PARALLEL_ARGS` by construction. Assigned unconditionally first, so an
-# exported value from the ambient environment cannot forge it.
-# Deliberately a plain shell variable, NOT exported: nothing downstream of
-# pytest may branch on it, and `${!_v-}` reads shell variables just fine.
+# `PYTEST_PARALLEL_ARGS` by construction.
+#
+# 🔴 THE `=""` RESET IS LOAD-BEARING, NOT TIDINESS. Without it an ambient
+# `DEVRC_XDIST_ACTIVE=1` in the caller's environment forges "we are parallel",
+# the pin stops applying, and a SERIAL run goes `fail=1 unexpected=1` — the
+# exact permanently-red gate this ledger entry exists to remove. Pinned by
+# `test_an_ambient_value_cannot_forge_the_flag`; deleting this line used to
+# survive the whole suite, because every other case drives the variable through
+# an environment the harness has already scrubbed.
+#
+# 🔴 `export -n` because the attribute SURVIVES re-assignment. A plain
+# assignment does not un-export a name the ambient environment already
+# exported, so without this the flag would reach pytest and its workers on some
+# invocations and not others — an inconsistently-exported flag is worse than an
+# exported one. Nothing downstream may branch on it; `${!_v-}` reads a plain
+# shell variable just fine.
 DEVRC_XDIST_ACTIVE=""
+export -n DEVRC_XDIST_ACTIVE
 if [ "$PYTEST_JOBS" -gt 1 ]; then
   PYTEST_PARALLEL_ARGS=(-n "$PYTEST_JOBS" --dist loadfile)
   DEVRC_XDIST_ACTIVE=1

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2805,6 +2805,34 @@ EXPECTED_SKIPS=(
   # SIGNAL_PG_DSN — the test then RUNS, the skip total drops to 1, and the flat
   # entry count still said 2.
   "scripts/signal/tests|needs a real Postgres|unset:SIGNAL_PG_DSN"
+  # GUARD 9's positive control for `_own_xdist_run_id()`
+  # (test_gitenv_sibling_exclusion.py::test_a_real_worker_reports_a_run_id).
+  # 🔴 IT CANNOT BE MADE TO RUN SERIALLY, and the alternative was checked before
+  # pinning — the skill_audit note below is the standing reminder that
+  # re-pointing beats pinning whenever the test can be made to RUN.
+  # `_own_xdist_run_id()` answers non-None only when the run id is in
+  # `os.environ` and ABSENT from `/proc/self/environ`, i.e. assigned at RUNTIME
+  # by xdist inside an already-exec'd worker. Exporting PYTEST_XDIST_WORKER by
+  # hand only defeats the `skipif` — the assertion then fails, because there is
+  # no run id; and exporting PYTEST_XDIST_TESTRUNUID too puts it in
+  # `/proc/self/environ`, which the function correctly reads as INHERITED and
+  # rejects (that is `test_an_INHERITED_run_id_does_not_make_us_a_worker`, in
+  # the same file). A serial arrangement that made this control pass would be
+  # asserting against a faked condition — a vacuous positive control, which is
+  # strictly worse than a pinned skip.
+  # CONDITIONAL on DEVRC_XDIST_ACTIVE, NOT on PYTEST_XDIST_WORKER: this ledger
+  # is evaluated in the RUNNER's shell, where xdist's variable is never set.
+  # See the flag's definition next to PYTEST_PARALLEL_ARGS for why. (It is set
+  # far below this array; only the evaluation order matters, and that happens in
+  # GUARD 2 long after both.)
+  # 🔴 CONSEQUENCE, stated so it is not a surprise: in the DEFAULT parallel mode
+  # — which is what both gate tiers run — this test RUNS, so the pin costs no
+  # coverage where merges are gated. It forgives the skip only in the explicitly
+  # serial mode (`DEVRC_TEST_JOBS=1`, or a nested run), which is the mode this
+  # file itself recommends for a bisect or a flake hunt. Before this entry that
+  # mode exited 1 on GUARD 2 alone: #841 introduced both the test and the
+  # parallelism, so it shipped a race whose documented workaround it had broken.
+  "scripts/tests|only meaningful inside a real xdist worker|unset:DEVRC_XDIST_ACTIVE"
 )
 # ⚠ REMOVED, deliberately — do not re-add. `scripts/tests/test_skill_audit.py`
 # carried two regression pins against the LIVE datapacket-talos skill corpus, a
@@ -2969,8 +2997,24 @@ if [ -n "${PYTEST_CURRENT_TEST:-}" ]; then
   PYTEST_JOBS=1
 fi
 PYTEST_PARALLEL_ARGS=()
+# 🔴 DEVRC_XDIST_ACTIVE is READ BY GUARD 2, and it exists because the obvious
+# variable cannot work. A conditional EXPECTED_SKIPS entry is evaluated by
+# `_skip_entry_applies` in THIS shell; xdist's own PYTEST_XDIST_WORKER is set
+# only inside the worker PROCESSES pytest spawns, so it is unset HERE in BOTH
+# modes — a pin written against it would be a flat pin wearing a conditional's
+# clothes, and would red the gate in the parallel mode instead of the serial
+# one. Worse in a nested run (`PYTEST_CURRENT_TEST` set): we are then serial
+# while PYTEST_XDIST_WORKER is INHERITED and set, i.e. exactly inverted.
+# This flag is the same fact read at the end that owns it — we are the process
+# that decides whether xdist workers exist at all — so it tracks the `-n` in
+# `PYTEST_PARALLEL_ARGS` by construction. Assigned unconditionally first, so an
+# exported value from the ambient environment cannot forge it.
+# Deliberately a plain shell variable, NOT exported: nothing downstream of
+# pytest may branch on it, and `${!_v-}` reads shell variables just fine.
+DEVRC_XDIST_ACTIVE=""
 if [ "$PYTEST_JOBS" -gt 1 ]; then
   PYTEST_PARALLEL_ARGS=(-n "$PYTEST_JOBS" --dist loadfile)
+  DEVRC_XDIST_ACTIVE=1
 fi
 # Every other lever in this file announces itself. A run whose log cannot say
 # whether it was parallel cannot be compared against another run's timing, and

--- a/scripts/tests/test_conditional_skip_pins.py
+++ b/scripts/tests/test_conditional_skip_pins.py
@@ -482,3 +482,45 @@ def test_the_runner_SETS_that_flag_exactly_when_it_passes_dash_n():
         f"parallel: {var} must be set alongside the -n argv, got "
         f"{parallel.stdout!r}. If the argv moved but the flag did not, the "
         f"pin's condition no longer tracks the mode it names.")
+
+
+def test_an_ambient_value_cannot_forge_the_flag():
+    """🔴 THE `=""` RESET, WHICH NOTHING ELSE HERE CAN SEE.
+
+    Every other case drives the condition variable through `_bash`, and `_bash`
+    POPS every ledger condition var from the environment before each run — so
+    no other case can ever observe an ambient value, and deleting the reset
+    line survived the entire suite. Measured consequence of that deletion: a
+    SERIAL run with the flag exported gave `fail=1 pin_expected=2
+    unexpected=1`, i.e. precisely the permanently-red gate this ledger entry
+    exists to remove, reached from a caller's environment rather than a code
+    change.
+
+    So this case deliberately puts the value BACK, via `env_extra` (applied
+    after the pop), and requires the block to clear it.
+
+    It also pins the second half of that line's promise — the flag must not be
+    EXPORTED. Bash keeps the export attribute across re-assignment, so a name
+    the ambient environment already exported stays exported through a plain
+    `VAR=""`; without `export -n` the flag would reach pytest and its workers
+    on exactly the invocations where a caller happens to export it, and not
+    otherwise. Nothing branches on it today, which is the whole reason to fix
+    it now rather than after something does.
+    """
+    _, var = _xdist_pin()
+    block = _extract("PYTEST_PARALLEL_ARGS=()", "\n# Every other lever")
+    probe = (f'\nprintf "flag=[%s] exported=%s\\n" "${{{var}-}}" '
+             f'"$(env | grep -c \'^{var}=\' || true)"\n')
+
+    forged = _bash(f"PYTEST_JOBS=1\n{block}{probe}", {var: "1"})
+    assert forged.returncode == 0, forged.stderr
+    flag, exported = forged.stdout.strip().split()
+    assert flag == "flag=[]", (
+        f"an ambient {var}=1 survived into a SERIAL run ({flag}): the pin then "
+        f"does not apply, the skip is unforgiven, and the gate is red again — "
+        f"the `{var}=\"\"` reset is gone or no longer unconditional")
+    assert exported == "exported=0", (
+        f"{var} is EXPORTED ({exported}) — bash keeps the export attribute "
+        f"across re-assignment, so `export -n` is what makes the "
+        f"'plain shell variable, NOT exported' comment true when a caller "
+        f"already exported the name")

--- a/scripts/tests/test_conditional_skip_pins.py
+++ b/scripts/tests/test_conditional_skip_pins.py
@@ -35,6 +35,10 @@ import pytest
 
 REPO = Path(__file__).resolve().parents[2]
 RUNNER = REPO / "scripts" / "run-tests.sh"
+# The one test in this repo that can only run inside a real xdist worker. Its
+# pin is a SEAM between two files, so the cases below read both — still no
+# `git`, so the hermetic tier is unaffected.
+XDIST_ONLY_TEST = REPO / "scripts" / "tests" / "test_gitenv_sibling_exclusion.py"
 
 
 def _runner_text() -> str:
@@ -314,3 +318,167 @@ def test_a_malformed_unset_tail_is_a_hard_error_and_does_NOT_abort_the_loop():
             f"{bad!r} aborted the loop — the entry after it was never counted. "
             f"stdout={r.stdout!r} stderr={r.stderr!r}")
         assert "invalid variable" in r.stderr.lower(), r.stderr
+
+
+# --------------------------------------------------------------------------
+# THE XDIST-ONLY POSITIVE CONTROL, and why its pin needs the third field.
+#
+# 🔴 WHAT WENT WRONG. #841 introduced BOTH the `-n` parallelism and
+# `test_gitenv_sibling_exclusion.py::test_a_real_worker_reports_a_run_id`, which
+# is `skipif`-ed outside a real xdist worker. The ledger got no entry, so
+# `DEVRC_TEST_JOBS=1` — the serial mode this runner itself recommends for a
+# bisect or a flake hunt, and the documented workaround for #841's own race —
+# exited 1 on GUARD 2 alone: one UNPINNED skip group plus `3 skipped vs 2
+# pinned`. A permanently-red gate is worse than no gate.
+#
+# 🔴 WHY A FLAT PIN IS NOT THE FIX, and why the condition variable is NOT
+# `PYTEST_XDIST_WORKER`. The ledger is evaluated in the RUNNER's shell. xdist
+# sets PYTEST_XDIST_WORKER inside the worker PROCESSES it spawns, never in the
+# process that spawned pytest — so that variable is unset there in BOTH modes,
+# and a pin keyed to it applies always, i.e. a flat pin in disguise. Either
+# shape reds the PARALLEL mode instead, where the test legitimately RUNS. The
+# runner therefore publishes `DEVRC_XDIST_ACTIVE` beside `PYTEST_PARALLEL_ARGS`,
+# and the last case below pins that flag to the `-n` it is supposed to track —
+# without it, every case here would be satisfied by a condition naming a
+# variable nothing ever sets.
+# --------------------------------------------------------------------------
+
+def _ledger_entries() -> list[str]:
+    block = _extract("EXPECTED_SKIPS=(", "\n)")
+    entries = re.findall(r'^\s*"([^"]+)"', block, re.M)
+    assert len(entries) >= 2, f"parsed {len(entries)} ledger entries — extraction is broken"
+    return entries
+
+
+def _xdist_only_skip_reason() -> str:
+    """The literal `reason=` of the xdist-only skip, read from the TEST FILE.
+
+    Read rather than restated, so a reword there cannot silently un-pin the
+    skip: the ledger's regex is exercised against the real string below.
+    """
+    src = XDIST_ONLY_TEST.read_text(encoding="utf8")
+    reasons = re.findall(r'reason="([^"]+)"', src)
+    assert len(reasons) == 1, (
+        f"expected exactly one skipif reason in {XDIST_ONLY_TEST.name}, "
+        f"found {len(reasons)}: {reasons!r} — this fixture no longer knows "
+        f"which skip it is pinning")
+    return reasons[0]
+
+
+def _xdist_only_skip_line() -> str:
+    """A `-rs` line in pytest's exact shape for that skip."""
+    rel = XDIST_ONLY_TEST.relative_to(REPO).as_posix()
+    return f"SKIPPED [1] {rel}:1: {_xdist_only_skip_reason()}"
+
+
+def _xdist_pin() -> tuple[str, str]:
+    """`(entry, condition-variable)` for the ledger pin that covers that skip.
+
+    Everything is DERIVED — the owning directory from the test's own path, the
+    entry by actually running the ledger's regex against the test's own reason,
+    and the variable out of the entry. Renaming the flag or moving the file
+    keeps these cases honest; losing the pin, or its third field, fails here
+    with a named reason instead of somewhere downstream.
+    """
+    rel = XDIST_ONLY_TEST.relative_to(REPO).as_posix()
+    owning_dir = rel.rsplit("/", 1)[0]
+    reason = _xdist_only_skip_reason()
+
+    hits = []
+    for entry in _ledger_entries():
+        fields = entry.split("|")
+        if fields[0] != owning_dir:
+            continue
+        if re.search(fields[1], reason):
+            hits.append(entry)
+    assert len(hits) == 1, (
+        f"expected exactly ONE EXPECTED_SKIPS entry matching {owning_dir!r} + "
+        f"{reason!r}, found {len(hits)}: {hits!r}. With none, "
+        f"`DEVRC_TEST_JOBS=1 scripts/run-tests.sh` exits 1 on GUARD 2's "
+        f"unpinned-skip guard — the permanently-red serial gate.")
+
+    fields = hits[0].split("|")
+    assert len(fields) == 3, (
+        f"the xdist-only pin {hits[0]!r} is FLAT. It must be conditional "
+        f"(`|unset:VAR`): under `-n` the test RUNS, the skip total drops, and a "
+        f"flat entry count reds the default parallel mode instead — the same "
+        f"defect the SIGNAL_PG_DSN pin was given a third field to fix.")
+    assert fields[2].startswith("unset:"), f"unsupported condition {fields[2]!r}"
+    var = fields[2][len("unset:"):]
+    assert var != "PYTEST_XDIST_WORKER", (
+        "the pin is conditional on xdist's OWN variable, which is set only "
+        "inside worker processes and never in the runner's shell — so it "
+        "applies in both modes and is a flat pin in disguise")
+    return hits[0], var
+
+
+def test_the_xdist_only_control_is_forgiven_SERIAL_and_not_forgiven_PARALLEL():
+    """🔴 The behaviour, both arms, through the REAL ledger.
+
+    The forgiving arm alone would be satisfied by a flat pin, and the flat pin
+    is the version that reds the mode the merge gate actually runs.
+    """
+    entries = _ledger_entries()
+    _, var = _xdist_pin()
+    lines = [_xdist_only_skip_line()]
+
+    serial = _bash(_verdict_harness(entries, 1, lines))
+    assert serial.returncode == 0, serial.stderr
+    assert "unexpected=0" in serial.stdout, (
+        "the serial-mode skip is UNPINNED — this is the red gate. "
+        f"stdout={serial.stdout!r} stderr={serial.stderr!r}")
+
+    parallel = _bash(_verdict_harness(entries, 1, lines), {var: "1"})
+    assert "unexpected=1" in parallel.stdout, (
+        f"with {var} set the test RUNS, so nothing may forgive that skip line; "
+        f"the pin is behaving as a flat pin. stdout={parallel.stdout!r}")
+
+
+def test_going_parallel_drops_exactly_one_expected_pin():
+    """The counting half of the same claim, on the shipped entries.
+
+    Mirrors `test_the_real_ledger_behaves_the_same_way` for the other
+    conditional pin: the number of applicable pins must FALL by one when the
+    runner goes parallel, because the xdist-only control then runs.
+    """
+    entries = _ledger_entries()
+    _, var = _xdist_pin()
+    harness = _count_harness(entries)
+
+    serial = _bash(harness)
+    parallel = _bash(harness, {var: "1"})
+    assert serial.returncode == 0 and parallel.returncode == 0, \
+        (serial.stderr, parallel.stderr)
+    n_serial = int(serial.stdout.split()[0])
+    n_parallel = int(parallel.stdout.split()[0])
+    assert n_parallel == n_serial - 1, (
+        f"setting {var} must drop exactly one expected pin (got {n_serial} -> "
+        f"{n_parallel}); equal counts mean the pin is flat and the PARALLEL "
+        f"gate goes red")
+
+
+def test_the_runner_SETS_that_flag_exactly_when_it_passes_dash_n():
+    """🔴 REACHABILITY. Every case above drives the condition variable by hand,
+    so all of them stay green if the runner never sets it — the pin would then
+    apply in both modes and the parallel gate would be red, unobserved.
+
+    So this drives the shipped parallelism block itself and pins the
+    RELATIONSHIP: the flag is non-empty exactly when `-n` is in the pytest
+    argv. Both arms, because either alone is satisfiable by a constant.
+    """
+    _, var = _xdist_pin()
+    block = _extract("PYTEST_PARALLEL_ARGS=()", "\n# Every other lever")
+    probe = (f'\nprintf "flag=[%s] args=[%s]\\n" "${{{var}-}}" '
+             f'"${{PYTEST_PARALLEL_ARGS[*]-}}"\n')
+
+    serial = _bash(f"PYTEST_JOBS=1\n{block}{probe}")
+    assert serial.returncode == 0, serial.stderr
+    assert serial.stdout.strip() == "flag=[] args=[]", (
+        f"serial: {var} must be empty and no -n passed, got {serial.stdout!r}")
+
+    parallel = _bash(f"PYTEST_JOBS=4\n{block}{probe}")
+    assert parallel.returncode == 0, parallel.stderr
+    assert parallel.stdout.strip() == "flag=[1] args=[-n 4 --dist loadfile]", (
+        f"parallel: {var} must be set alongside the -n argv, got "
+        f"{parallel.stdout!r}. If the argv moved but the flag did not, the "
+        f"pin's condition no longer tracks the mode it names.")


### PR DESCRIPTION
## The defect

`#841` (`955603f4`) introduced **both** the `-n` xdist parallelism **and**
`scripts/tests/test_gitenv_sibling_exclusion.py::test_a_real_worker_reports_a_run_id`,
which `skipif`s outside a real xdist worker. It got no `EXPECTED_SKIPS` entry, so **the
serial mode — the mode `run-tests.sh` itself recommends for a bisect or a flake hunt, and
the documented workaround for the very race `#841` was closing — exited 1 on GUARD 2
alone**:

```
ERROR: 1 UNPINNED skip group(s) — coverage silently collapsed:
       SKIPPED [1] scripts/tests/test_gitenv_sibling_exclusion.py:92: only meaningful inside a real xdist worker
ERROR: 3 test(s) skipped, but 2 of 2 pinned entries apply here.
```

`RULES.md`: *a permanently-red gate is worse than no gate — it trains everyone to click
through.*

## Judgment: pin, not re-point — and what was rejected

The `EXPECTED_SKIPS` header's two `⚠ REMOVED, deliberately` notes establish that pinning is
the **second** choice: `test_skill_audit.py`'s entry went away because the right fix was
re-pointing at tracked fixtures *so the test RUNS*. So the first question was whether this
test can be made to run without a real worker.

**It cannot be faked into running in-process**, and the mechanism says so rather than the
intent. `_own_xdist_run_id()` returns non-`None` only when the run id is in `os.environ`
**and absent from `/proc/self/environ`** — i.e. assigned at *runtime* by xdist inside an
already-exec'd worker. So exporting `PYTEST_XDIST_WORKER` by hand only defeats the
`skipif` and the assertion then **fails**; exporting `PYTEST_XDIST_TESTRUNUID` too makes
the function read it as **INHERITED** and reject it (that is
`test_an_INHERITED_run_id_does_not_make_us_a_worker`, in the same file). Any env-forged
arrangement asserts against a **faked** condition.

> **Correction after review — this was first stated wider than proved.** `pytest -n 1
> --dist loadfile` **does** spawn a real `gw0`, and the control runs and passes there
> (measured: 6 passed, no skip). What that arrangement is not is *serial* — it is one
> worker in a separate process. Adopting it would delete the in-process mode
> `DEVRC_TEST_JOBS=1` exists to provide (a bisect, a flake hunt, a debugger), which is the
> mode this PR is unbreaking. **The judgment stands on the trade, not on impossibility**,
> and the source comment now says exactly that.

**Also rejected: re-pointing at a nested `pytest -n 2` subprocess.** It would run in both
modes, but trades a control live inside the workers whose sibling-exclusion behaviour is at
stake for a synthetic one, adds a multi-second nested pytest to every run, and buys **no
coverage in the mode that gates merges**.

That last clause is the decisive difference from the two removed entries. Those tests were
skipping in **every** tier of the gate — structurally unobservable where merges are
decided. This one **runs in the default parallel mode, in both tiers**.

## Why the condition is `DEVRC_XDIST_ACTIVE` and not `PYTEST_XDIST_WORKER`

A flat pin would move the red from the serial mode into the **parallel** one — exactly the
failure the header documents for the `SIGNAL_PG_DSN` entry. So the entry takes the
conditional third field. But **`unset:PYTEST_XDIST_WORKER` would have been a flat pin
wearing a conditional's clothes**: `_skip_entry_applies` evaluates `${!VAR-}` **in the
runner's own shell**, and xdist sets that variable only inside the worker *processes* it
spawns. In a nested run it is worse than useless — `PYTEST_CURRENT_TEST` forces
`PYTEST_JOBS=1` (serial) while `PYTEST_XDIST_WORKER` is inherited and *set*, i.e. exactly
inverted.

So `run-tests.sh` publishes `DEVRC_XDIST_ACTIVE` next to `PYTEST_PARALLEL_ARGS`, set from
the same `if` that adds `-n`, so it tracks the argv by construction. Reset to `""`
unconditionally first and `export -n`'d — both load-bearing, see the audit round below.

## Audit round (`b81622e1`) — three findings, all folded in

**🟡 1 — the `DEVRC_XDIST_ACTIVE=""` reset was load-bearing with no guard.** Deleting it
**survived all 16 tests**, because `_bash` pops every ledger condition var from the
environment before each case, so no case could ever observe an ambient value. Measured
consequence: a serial run with the flag exported leaves the pin inapplicable and the skip
unforgiven — the permanently-red gate this PR exists to remove, reached from a *caller's
environment* rather than a code change. `test_an_ambient_value_cannot_forge_the_flag` now
puts the value back via `env_extra` (applied after the pop) and requires the block to clear
it. Watched to fail with the line deleted (M7 below).

**🟢 2 — "a plain shell variable, NOT exported" was conditionally false.** Bash keeps the
export attribute across re-assignment, so a name the ambient environment already exported
stays exported through `VAR=""` — pytest and its workers *would* receive it. Measured
`exported=1` without the fix. Now `export -n`, with the second half of the same new case
asserting `exported=0` (M8).

**🟢 3 — "which is what both gate tiers run" was nproc-derived, not structural.**
`_devrc_default_jobs` is `min(nproc, 4)`, and the runner's own comment anticipates 1–2-core
CI nodes. On a genuinely 1-core builder the gating tier is **serial**, the pin applies, and
GUARD 9's positive control silently does not run behind a green gate. The trade is
accepted; it is now stated in the comment rather than left silent, with what was actually
measured here (`nix build …pytests` logged `parallelism =4`, so that sandbox saw ≥ 4 cores).

## Coverage

Four cases in the existing harness `scripts/tests/test_conditional_skip_pins.py` (no new
file). All drive **shipped code**, and everything is **derived** rather than spelled: the
skip reason is read out of `test_gitenv_sibling_exclusion.py`, the ledger entry is found by
running the ledger's own regex against that reason, and the condition variable is taken
from the entry it found.

| case | pins |
|---|---|
| `test_the_xdist_only_control_is_forgiven_SERIAL_and_not_forgiven_PARALLEL` | behaviour, both arms, through the real ledger |
| `test_going_parallel_drops_exactly_one_expected_pin` | the counting half — equal counts mean a flat pin |
| `test_the_runner_SETS_that_flag_exactly_when_it_passes_dash_n` | **reachability**: the flag ⇔ the `-n` |
| `test_an_ambient_value_cannot_forge_the_flag` | the `=""` reset **and** the non-export claim |

The third exists because the first two drive the variable *by hand*: without it, a condition
naming a variable nothing ever sets leaves both green while the parallel gate goes red
(M2 survives the first two). The fourth exists for the mirror-image blind spot: the harness
*scrubs* the environment, so nothing else here can see the reset at all.

### Red-at-base / green-at-HEAD

Base sha **`1a4eb70ae09323c762ba1b58d0fb4dc7ac17a78b`** (`origin/main` at branch point).

| tree | result |
|---|---|
| base `run-tests.sh`, new tests | **4 failed**, 13 passed |
| HEAD `b81622e1` | **17 passed** |

Regression coverage, not invariant guards: the failures at base are the shipped defect,
reported in the guards' own words.

### Mutation sweep — re-run in full at `b81622e1` (a fix round resets the gate)

`PYTHONDONTWRITEBYTECODE=1`, `-p no:cacheprovider`; semantic mutants, each isolated to the
narrowest expression. Positive control: unmutated tree **17 passed**. **Survivors: none.**

| # | mutant | killed by, with its own message |
|---|---|---|
| M1 | drop the third field (flat pin) | `the xdist-only pin '…' is FLAT. It must be conditional…` |
| M2 | condition points at `DEVRC_TEST_JOBS` (never set by the runner) | reachability case: `parallel: DEVRC_TEST_JOBS must be set alongside the -n argv, got 'flag=[] args=[-n 4 --dist loadfile]'` |
| M3 | delete `DEVRC_XDIST_ACTIVE=1` (the `if` intact) | same case, `flag=[]` vs `flag=[1]` |
| M4 | reword the ledger's reason regex | `expected exactly ONE EXPECTED_SKIPS entry … found 0` |
| M5 | initialise the flag to `1` | `serial: DEVRC_XDIST_ACTIVE must be empty and no -n passed, got 'flag=[1] args=[]'` |
| M6 | reword the `skipif` reason in the **test** file (seam mirror) | same entry-matching message, quoting the new reason |
| M7 | delete the `=""` reset (keep `export -n`) | `an ambient DEVRC_XDIST_ACTIVE=1 survived into a SERIAL run (flag=[1])…` |
| M8 | delete `export -n` (keep the reset) | `DEVRC_XDIST_ACTIVE is EXPORTED (exported=1) — bash keeps the export attribute across re-assignment…` |
| M9 | drift: move `DEVRC_XDIST_ACTIVE=1` out of the `if` | `serial: DEVRC_XDIST_ACTIVE must be empty and no -n passed` |

## Behaviour, measured — both tiers, both modes, re-run at `b81622e1`

Every run is a full gate run; the claim is about exit status, so no subset was substituted.

| # | tier | tree | command | result |
|---|---|---|---|---|
| 1 | dev-host, serial | base `1a4eb70a` | `DEVRC_TEST_JOBS=1 nix develop . --command bash scripts/run-tests.sh .` | **`RESULT: FAIL (exit=1)`** — `parallelism =1`, `collected=16922 skipped=3 failed=0`, GUARD 2 the **only** finding (2 `ERROR:` lines, both GUARD 2) |
| 6 | dev-host, serial | `b81622e1` | same | **`RESULT: PASS (exit=0)`** — `parallelism =1`, `collected=16926 skipped=3`, `pinned: 3`, `grep -c ERROR:` = **0** |
| 7 | dev-host, parallel | `b81622e1` | `nix develop . --command bash scripts/gate.sh --tier both` | **`GATE: RESULT=PASS exit=0`** — pytest `parallelism =4`, `collected=16926 skipped=2`; node 1292 tests. The arm a flat pin breaks. |
| 8 | **sandbox (Tekton's tier)** | `b81622e1` | `nix build .#checks.x86_64-linux.pytests` | **`RESULT: PASS (exit=0)`** — `parallelism =4`, `collected=16926 skipped=2 failed=0` |
| 9 | **sandbox** | `b81622e1` | `nix build .#checks.x86_64-linux.nodetests` | **`RESULT: PASS (exit=0)`** — 1292 tests |

`collected` moves 16922 → 16926 (the four new cases). `passed` is 16923 serial vs 16924
parallel: the xdist-only control genuinely runs under `-n`.

## Not verified / caveats

* **A green check here is a claim about this branch, not the merged tree** — `strict` is
  false on `main` by design. The merged-tree run is still yours to do.
* **The 1-core exposure is reasoned, not reproduced.** Every sandbox build measured here
  took `-n 4`; I did not stand up a 1-core builder to watch the gating tier go serial.
* GUARD 10 prints `cannot attribute` for the git-common-dir config in every run here — a
  pre-existing consequence of running in a shared-clone worktree, present identically at
  base, and not a finding of this change.
