### PR TITLE
docs: repoint AGENTIC_LEVERAGE.md instead of deleting it; keep the measured /next-lever count

### DIFF
--- a/claudedocs/close-the-loop/STATE.md
+++ b/claudedocs/close-the-loop/STATE.md
@@ -205,8 +205,10 @@ LIVE 2026-06-15, each with its own staleness rule). Parked: the context-capturin
   path — they cannot guess it.**
 - **Civit fleet** (in `datapacket-talos`): capacity-sweep, reliability-sweep P1–P4,
   dependency-pr-auditor, classifier-tuner, pr-reviewer, alert-diagnose-svc, standup-triage…
-  Check before building anything civit-side (the `next-lever` skill + `AGENTIC_LEVERAGE.md` are
-  the catalog).
+  Check before building anything civit-side — the catalog is
+  `datapacket-talos:clusters/production/apps/AGENTIC_LEVERAGE.md` (VERIFIED present
+  2026-08-26). The `next-lever` skill that used to front it is RETIRED — gone from
+  `origin/main` and deployed on neither host — so reach the catalog by path, not by skill.
 - **Existing artifacts:** `perf-deep-dive` runbook + `homelab-observability-read` profile
   (perf-deep-dive is a **manual tool**, not a loop).
 

--- a/claudedocs/the-algorithm-applied-2026-06-17.md
+++ b/claudedocs/the-algorithm-applied-2026-06-17.md
@@ -12,7 +12,7 @@ Pipeline: `devrc/scripts/session-analysis/{extract_user_msgs,extract_genesis}.py
 
 **Where the work is (last 14 days, 147 sessions):** civitai prod infra dominates — `datapacket-talos` **100**, `civitai` 12, `homelab-talos` 11, `devrc` 7, the rest scattered (vetr, gpu-fleet, naida). This is overwhelmingly **prod ops on one system**, not greenfield.
 
-**How sessions open:** 45% with a slash command, 55% typed. Top openers: `/investigate-alert` (35), `/check-app` (26), `/kubeclaw-agents` (16), `/investigate-network` (11), `/app-blocks` (10), `/manage-postgres` (10), `/next-lever` (8). Typed openers are dominated by **"read X (load context)" (59)** and **"analyze/recon X" (32)** — i.e. re-loading state and re-deriving subsystem maps.
+**How sessions open:** 45% with a slash command, 55% typed. Top openers: `/investigate-alert` (35), `/check-app` (26), `/kubeclaw-agents` (16), `/investigate-network` (11), `/app-blocks` (10), `/manage-postgres` (10), `/next-lever` (8 — skill RETIRED since, count kept: this is a measurement of 2026-06-17, not a live inventory). Typed openers are dominated by **"read X (load context)" (59)** and **"analyze/recon X" (32)** — i.e. re-loading state and re-deriving subsystem maps.
 
 **~40 distinct slash commands/skills** are in active use. The work is heavily tooled already.
 
@@ -79,7 +79,7 @@ If after cutting you've kept more than ~120 lines, you didn't cut enough.
 ### 3. Simplify & optimize (only what survived deletion)
 
 - The surviving rules are already terse — collapse the duplicate "use best tool/parallel" rules into **one** Tool-Optimization rule.
-- **Do NOT over-consolidate the command fleet.** The `investigate-*` (4) and `manage-*` (8) families look like duplication but `AGENTIC_LEVERAGE.md`'s skill-granularity rule already governs this deliberately (runbook depth ⇒ own skill). Respect it; this is a case where apparent duplication is correct.
+- **Do NOT over-consolidate the command fleet.** The `investigate-*` (4) and `manage-*` (8) families look like duplication but the skill-granularity rule in `datapacket-talos:clusters/production/apps/AGENTIC_LEVERAGE.md` already governs this deliberately (runbook depth ⇒ own skill). Respect it; this is a case where apparent duplication is correct.
 - Simplify continuity: 59 "read X" + 13 "read handoff" openers mean **context-reload is the single most repeated act.** `/resume` now collapses it — but it's unproven (see §5).
 
 ### 4. Accelerate cycle time (only now)


### PR DESCRIPTION
## What

Rescues two edits that were sitting **uncommitted** in the workbench checkout — a tree shared with ~60 worktrees and other sessions, where one routine `git checkout` loses them silently — and corrects them.

The edits scrubbed references to the `next-lever` skill and `AGENTIC_LEVERAGE.md`. Measured 2026-08-26, they were **half right**:

| reference | reality |
|---|---|
| `next-lever` | **RETIRED** — absent from `origin/main`, deployed on neither host. Removing it is correct. |
| `AGENTIC_LEVERAGE.md` | **Still exists**, in another repo: `datapacket-talos:clusters/production/apps/AGENTIC_LEVERAGE.md` |

So the pointer was *deleted* rather than *repointed* — leaving "Check before building anything civit-side" with no destination, and a governance claim with no source.

## Changes

- **`STATE.md`** — repoint to the `datapacket-talos` path; note that `next-lever` is retired so the catalog is reached **by path, not by skill**.
- **`the-algorithm-applied-2026-06-17.md`** — **restore `/next-lever` (8)** to the top-openers list, annotated as since-retired. That line is a *measurement* of 2026-06-17 across 147 sessions; dropping an entry because the tool was later retired makes the list irreconcilable with the run that produced it. The retirement is a fact about **today**, the count a fact about **then**. Same repoint for its `AGENTIC_LEVERAGE.md` mention.

## Verification — stated at its real scope

🔴 **`test_doc_path_rot` does not cover these files, so its green means nothing here.** `CORPUS_DIRS = ("claude", "CLAUDE.md")` excludes `claudedocs/` deliberately (it is the handoff/scratch tree), and the corpus is built from `git ls-files`, so an uncommitted edit is invisible twice over.

I found this by control, not by reading: I planted a dead `claudedocs/…` reference and the test stayed **green**; planted an in-scope `scripts/…` one and it stayed **green** again. That second green is what proved the gate *blind* on this corpus rather than *clean*.

331 tests pass (`test_doc_path_rot`, `test_skills_mapping_guard`, `test_no_public_ips`, `test_no_client_hostnames`, `test_no_captured_text`, `test_no_captured_markup`) — but none of them examine this change.

**The cross-repo reference is therefore UNGUARDED.** Verified by hand only:
```
git -C $DATAPACKET ls-tree -r --name-only HEAD | grep AGENTIC_LEVERAGE
→ clusters/production/apps/AGENTIC_LEVERAGE.md
```
Nothing will tell us if that file moves.

## Note for merging

`claudedocs/close-the-loop/STATE.md` is a **live mutable deploy target** (`mkOutOfStoreSymlink` → `~/.claude/skills/close-the-loop/STATE.md`), and the workbench's working copy is currently the pre-amendment version. Its local modification must be discarded after merge or `ship.sh`'s `merge --ff-only` will refuse and **skip the host**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)