### PR TITLE
fix(restore-verify): a run that cross-checked NOTHING gets its OWN code (40), not rc=0 and not a bare 1

### DIFF
--- a/SECRETS.md
+++ b/SECRETS.md
@@ -161,19 +161,38 @@ them would raise a false data-loss alarm), or this machine's id could not be
 read, which makes "another host's" an assumption rather than a measurement.
 
 🔴 **A run of THIS host's artifacts in which NOT ONE scope could be compared
-FAILS.** Measured 2026-08-26: `--host <this host> --store <an empty directory>`
-printed every scope as `NOT CROSS-CHECKED … self-consistency only` and exited
-**0** — an exit code is all a systemd timer reads, so a wrong or absent
-`--store` silently downgraded the whole run to "the object decrypts and is
-internally consistent", which says nothing about whether it still matches the
-history it is a backup of. It now exits non-zero and names the store it looked
-at, distinguishing a store that **does not exist** from one that exists and is
-**empty** from one that holds scopes but not this one. Two zero-cross-check
-runs are deliberately still rc=0: **another host's** artifacts (suppressing the
-comparison there is correct), and a **partial** run where at least one scope did
-compare. So on a disaster-recovery machine with no store yet, expect a non-zero
-exit — read the per-artifact lines, which still say each artifact restored and
-passed `fsck`.
+exits `40`, and `40` IS NOT A VERDICT AGAINST YOUR BACKUPS.** Every cause has
+its own exit code here for the same reason `escrow-verify.py` gives below — so a
+timer can act on the number, and so an operator mid-recovery is not told the
+wrong thing:
+
+| code | meaning | what to do |
+|---|---|---|
+| `0` | verified, and cross-checked against the live store | nothing |
+| `40` `NOTHING-CROSS-CHECKED` | every artifact **decrypted, restored and passed `git fsck`** — and **none** was compared to a live store | **not an alarm about the backups.** `--print-plan` shows the store path this run used: if it is not the one you meant, re-run pointing at the right one; if it *is*, the live store is gone and this is the **expected** code during a recovery — the per-artifact lines are your evidence the backups are intact |
+| `1` | a check **FAILED** — an artifact did not decrypt, did not restore, failed `fsck`, is stale, or a scope has no artifact at all | this one *is* about the backups; read the first failure |
+
+Measured 2026-08-26: `--host <this host> --store <an empty directory>` printed
+every scope as `NOT CROSS-CHECKED … self-consistency only` and exited **0** — an
+exit code is all a systemd timer reads, so a wrong or absent `--store` silently
+downgraded the whole run to "the object decrypts and is internally consistent",
+which says nothing about whether it still matches the history it is a backup of.
+
+🔴 **`40`'s message names BOTH mechanisms and asserts NEITHER.** "You pointed at
+the wrong store" and "the store is genuinely gone" are the *same observation*,
+and nothing in the run separates them — so it says so, and its remedy works
+under either reading. It does name which of three store states it saw: the
+directory **does not exist**, it exists and holds **no scope repositories**, or
+it holds scopes but **not this one** (that third case gets a different mechanism
+pair — a store that is plainly there cannot be blamed on `--store` naming
+nothing). A real failure **outranks** `40`: a corrupt artifact beside an absent
+store exits `1`, because the louder finding must not be filed as a store
+problem.
+
+Two zero-cross-check runs are deliberately still `0`: **another host's**
+artifacts (suppressing the comparison there is correct — see the three
+`NOT CROSS-CHECKED` reasons above), and a **partial** run where at least one
+scope did compare.
 
 🔴 **It never runs `git bundle verify`, and neither should you.** Measured: a
 bundle with one byte flipped mid-packfile passes it at **rc=0** printing *"The

--- a/SECRETS.md
+++ b/SECRETS.md
@@ -169,7 +169,7 @@ wrong thing:
 | code | meaning | what to do |
 |---|---|---|
 | `0` | verified, and cross-checked against the live store | nothing |
-| `40` `NOTHING-CROSS-CHECKED` | every artifact **decrypted, restored and passed `git fsck`** — and **none** was compared to a live store | **not an alarm about the backups.** `--print-plan` shows the store path this run used: if it is not the one you meant, re-run pointing at the right one; if it *is*, the live store is gone and this is the **expected** code during a recovery — the per-artifact lines are your evidence the backups are intact |
+| `40` `NOTHING-CROSS-CHECKED` | every artifact **this run verified** (all scopes, or just the `--scope` one) **decrypted, restored and passed `git fsck`** — and **none** was compared to a live store | **not an alarm about the backups.** The message names the store path it looked at: if that is not the one you meant, re-run with `--store` pointing at the one you did; if it *is*, something on the live side is missing or unreachable and this is the **expected** code during a recovery — the per-artifact lines are your evidence the backups are intact |
 | `1` | a check **FAILED** — an artifact did not decrypt, did not restore, failed `fsck`, is stale, or a scope has no artifact at all | this one *is* about the backups; read the first failure |
 
 Measured 2026-08-26: `--host <this host> --store <an empty directory>` printed
@@ -178,16 +178,19 @@ exit code is all a systemd timer reads, so a wrong or absent `--store` silently
 downgraded the whole run to "the object decrypts and is internally consistent",
 which says nothing about whether it still matches the history it is a backup of.
 
-🔴 **`40`'s message names BOTH mechanisms and asserts NEITHER.** "You pointed at
-the wrong store" and "the store is genuinely gone" are the *same observation*,
-and nothing in the run separates them — so it says so, and its remedy works
-under either reading. It does name which of three store states it saw: the
-directory **does not exist**, it exists and holds **no scope repositories**, or
-it holds scopes but **not this one** (that third case gets a different mechanism
-pair — a store that is plainly there cannot be blamed on `--store` naming
-nothing). A real failure **outranks** `40`: a corrupt artifact beside an absent
-store exits `1`, because the louder finding must not be filed as a store
-problem.
+🔴 **`40`'s message lists every mechanism consistent with what it saw, says the
+list is NOT closed, and asserts none of them.** "You pointed at the wrong store"
+and "the store is genuinely gone" are the *same observation*, and nothing in the
+run separates them. It names which of **five** states it observed, per scope —
+the store directory **does not exist**; it exists and holds **no scope
+repositories**; it holds scopes but **not this one**; the scope path is a
+**symlink** (never followed, so the repository may be perfectly intact); the
+scope path has **no `.git`**. The last two matter because a closed
+"wrong `--store` *or* store GONE" pair is false for both: the repository is
+right there and `--store` is correct. A real failure **outranks** `40`: a
+corrupt artifact beside an absent store exits `1`, because the louder finding
+must not be filed as a store problem — the `40` finding is still printed, as
+`ALSO:`.
 
 Two zero-cross-check runs are deliberately still `0`: **another host's**
 artifacts (suppressing the comparison there is correct — see the three

--- a/SECRETS.md
+++ b/SECRETS.md
@@ -160,6 +160,21 @@ two stores are divergent content that merely share scope names, so comparing
 them would raise a false data-loss alarm), or this machine's id could not be
 read, which makes "another host's" an assumption rather than a measurement.
 
+🔴 **A run of THIS host's artifacts in which NOT ONE scope could be compared
+FAILS.** Measured 2026-08-26: `--host <this host> --store <an empty directory>`
+printed every scope as `NOT CROSS-CHECKED … self-consistency only` and exited
+**0** — an exit code is all a systemd timer reads, so a wrong or absent
+`--store` silently downgraded the whole run to "the object decrypts and is
+internally consistent", which says nothing about whether it still matches the
+history it is a backup of. It now exits non-zero and names the store it looked
+at, distinguishing a store that **does not exist** from one that exists and is
+**empty** from one that holds scopes but not this one. Two zero-cross-check
+runs are deliberately still rc=0: **another host's** artifacts (suppressing the
+comparison there is correct), and a **partial** run where at least one scope did
+compare. So on a disaster-recovery machine with no store yet, expect a non-zero
+exit — read the per-artifact lines, which still say each artifact restored and
+passed `fsck`.
+
 🔴 **It never runs `git bundle verify`, and neither should you.** Measured: a
 bundle with one byte flipped mid-packfile passes it at **rc=0** printing *"The
 bundle records a complete history."*, while a clone of the same bundle dies at

--- a/scripts/analyze-service-index/escrow-verify.py
+++ b/scripts/analyze-service-index/escrow-verify.py
@@ -1121,7 +1121,12 @@ def decrypt_check(*, escrow_bytes: bytes, work_dir: Path, bucket: str,
 
         this_host = B.host_label()
         this_machine_id = RV.machine_id()
-        live, no_live_reason = RV.cross_check_target(
+        # The third element is the machine-readable KIND of the block, which
+        # `restore-verify.py`'s whole-run refusal branches on. This script
+        # verifies exactly ONE artifact and asks a different question — does the
+        # ESCROWED KEY open it — so a missing live scope is not a finding here
+        # and the kind is deliberately unused.
+        live, no_live_reason, _no_live_kind = RV.cross_check_target(
             store, scope,
             artifacts_are_foreign=not RV.prefix_belongs_to_this_host(
                 prefix, this_host, this_machine_id),

--- a/scripts/analyze-service-index/restore-verify.py
+++ b/scripts/analyze-service-index/restore-verify.py
@@ -114,7 +114,7 @@ backups is worse than no verifier.
   * zero commits compared against the live scope       -> failure
   * a run that verified zero scopes                    -> failure
   * THIS host's artifacts, and NOT ONE of them cross-checked because the store
-    side gave nothing                                  -> failure
+    side gave nothing                          -> failure, exit 40
 
 The last one is the STORE-side twin of the first, and it was exit-0 until it
 was measured: `--host <this host> --store <an empty directory>` printed 13
@@ -124,6 +124,17 @@ downgraded the whole run to "it decrypts and is internally consistent" and
 called that success. Foreign artifacts and PARTIAL runs (one scope with no live
 repository beside scopes that have one) are outside it by construction — see
 `nothing_cross_checked_message`.
+
+🔴 IT HAS ITS OWN EXIT CODE, AND THE REASON IS THE SAME ONE `escrow-verify.py`
+GIVES: "every cause has its own exit code, so a timer can act on the number".
+`40 NOTHING-CROSS-CHECKED` means *your backups restored perfectly, and nothing
+here compared them to anything* — which is the EXPECTED outcome during a real
+recovery. `1` means a check FAILED. Collapsing the two would tell an operator
+mid-disaster that their backups are broken, and it is the reading that the
+absent-live-scope path was originally left at exit 0 to avoid. A real failure
+OUTRANKS it: 40 is raised only when it is the whole story. The message names
+BOTH mechanisms it cannot separate — a misconfigured `--store` and a store that
+is genuinely gone — and asserts neither.
 
 The single exception is the same one `backup.py` permits: a host that has never
 run the backup at all — no local store AND no objects under its own default
@@ -257,6 +268,48 @@ DECRYPT_CAUSES = frozenset(
     {DECRYPT_AGE_MISSING, DECRYPT_AGE_REFUSED, DECRYPT_EMPTY_PLAINTEXT})
 
 
+# --------------------------------------------------------------------------- #
+# the classified refusals
+# --------------------------------------------------------------------------- #
+# 🔴 ONE TOKEN AND ONE EXIT CODE PER DISTINGUISHABLE CAUSE — the convention
+# `escrow-verify.py` already runs on, in the same directory, for the same
+# reason it states: "Every cause has its own exit code, so a timer can act on
+# the number." SECRETS.md documents both tables side by side, and an operator
+# reading a number during a recovery must not find two answers, so these start
+# at 40 — clear of escrow's classified range.
+#
+# 🔴 WHY THIS TABLE EXISTS AT ALL: `NOTHING-CROSS-CHECKED` is NOT the same fact
+# as a failed verification, and collapsing them into one `1` conflates
+#
+#     "your backups restored perfectly, I just could not compare them"
+#
+# with
+#
+#     "your backups are broken".
+#
+# Those call for opposite reactions, and the first is the EXPECTED outcome
+# during a real recovery — the scenario this whole feature exists for. This
+# module already states the principle one screen down ("An UNKNOWN must not be
+# summarised as a decision"); the exit code is the only part of the output a
+# timer reads, so it is where the principle matters most.
+EXIT_OK = 0
+# 🔴 1 IS DELIBERATELY TWO THINGS: an unclassified verification failure AND an
+# unexpected exception. `escrow-verify.py` gives 1 the same "read the traceback"
+# meaning. Splitting it is a separate change with its own blast radius, and
+# leaving it alone keeps SECRETS.md's existing "exits 1" statements true.
+EXIT_FAILED = 1
+
+NOTHING_CROSS_CHECKED = "NOTHING-CROSS-CHECKED"
+
+EXIT_CODES: dict[str, int] = {
+    # This host's artifacts all verified, and NOT ONE of them was compared
+    # against a live store. The artifacts are NOT implicated — see
+    # `nothing_cross_checked_message`, which is careful to assert neither of the
+    # two mechanisms that share this observation.
+    NOTHING_CROSS_CHECKED: 40,
+}
+
+
 class RestoreVerifyError(B.BackupError):
     """A failure that must make the whole run non-zero.
 
@@ -270,16 +323,31 @@ class RestoreVerifyError(B.BackupError):
     else, so a caller that reads it gets an explicit "this failure carries no
     published cause" rather than a wrong one — never treat None as a default
     cause.
+
+    🔴 `token` IS OPTIONAL AND THE EXIT CODE IS DERIVED FROM IT, NEVER PASSED
+    IN. A constructor taking both could raise a token carrying the wrong code —
+    exactly the conflation the table exists to prevent (`EscrowError` makes the
+    same choice for the same reason). `token is None` means "this refusal is not
+    a distinguishable cause with its own remedy", and it maps to `EXIT_FAILED`.
     """
 
-    def __init__(self, message: str, *, cause: str | None = None):
+    def __init__(self, message: str, *, cause: str | None = None,
+                 token: str | None = None):
         super().__init__(message)
         if cause is not None and cause not in DECRYPT_CAUSES:
             raise KeyError(
                 f"{cause!r} is not a published cause. The set is closed on "
                 f"purpose: a consumer branches on these, so inventing one "
                 f"silently lands in whatever `else` that consumer has.")
+        if token is not None and token not in EXIT_CODES:
+            raise KeyError(
+                f"{token!r} is not in EXIT_CODES. A classified refusal is an "
+                f"ENUMERATED cause with its own exit code and its own remedy; "
+                f"adding one means adding it to the table in the same commit as "
+                f"the test that pins it.")
         self.cause = cause
+        self.token = token
+        self.exit_code = EXIT_FAILED if token is None else EXIT_CODES[token]
 
 
 # --------------------------------------------------------------------------- #
@@ -1272,7 +1340,8 @@ def diagnose_empty_prefix(*, bucket: str, prefix: str, siblings: list[str],
 
 def nothing_cross_checked_message(*, bucket: str, prefix: str, store: Path,
                                   artifacts: int, scopes: list[str]) -> str:
-    """The refusal for a run of THIS host's artifacts that compared NOTHING.
+    """The classified refusal for a run of THIS host's artifacts that compared
+    NOTHING. Raised as `NOTHING-CROSS-CHECKED` (exit 40), never as a bare 1.
 
     🔴 THE EXIT-0 VARIANT IS WORSE THAN THE REFUSAL — the same argument
     `diagnose_empty_prefix` already makes for the BUCKET side, made here for the
@@ -1284,6 +1353,24 @@ def nothing_cross_checked_message(*, bucket: str, prefix: str, store: Path,
     run to "the artifact decrypts and is internally consistent" — which proves
     nothing about whether the backup still matches the history it is a backup
     OF — and reports success while doing it.
+
+    🔴 BUT IT MUST NOT ASSERT *WHY*, AND THE FIRST VERSION DID. It ended
+    "Point --store at the live store, or fix it" — advice that is unfollowable
+    by the one operator who most needs this tool, because in a real disaster
+    THERE IS NO LIVE STORE TO POINT AT; that IS the disaster. "You pointed at
+    the wrong store" and "the store is genuinely gone" are the SAME OBSERVABLE,
+    which is the empty-result trap RULES.md names, and picking the one that
+    happened to be true in testing is a coin flip recorded as a diagnosis. So
+    the message names BOTH mechanisms, says plainly that this run cannot
+    separate them, and gives a remedy that works under either reading.
+
+    🔴 IT ALSO LEADS WITH THE GOOD NEWS, because that is what is actually
+    PROVEN: the artifacts decrypted, restored and passed `git fsck`. The
+    original design note on the absent-live-scope path — "failing here would
+    make the verifier useless at the exact moment it is needed" — is answered by
+    this shape, not overruled by it: the per-artifact evidence is unchanged, the
+    partial run still exits 0, and the disaster case gets its OWN code rather
+    than being folded into "your backups are broken".
 
     🔴 IT FIRES ON THE OBSERVED PROPERTY, NEVER ON "WAS A FLAG TYPED". The
     v1/v2/v3 note in `run()` and `cross_check_target`'s docstring are both about
@@ -1301,27 +1388,48 @@ def nothing_cross_checked_message(*, bucket: str, prefix: str, store: Path,
         zero-objects no-op returns first, with no verdicts).
     """
     state, names = store_state(store)
-    if state == STORE_ABSENT:
-        where = f"the store directory {store} DOES NOT EXIST"
-    elif state == STORE_EMPTY:
-        where = (f"the store directory {store} EXISTS but holds NO scope "
-                 f"repositories")
-    else:
+    # 🔴 TWO RIVAL MECHANISMS PER STATE, NEITHER ASSERTED. Which PAIR is
+    # plausible depends on what was observed; that one of the pair is true does
+    # not. The `--scope` case lands here too — narrowing the question does not
+    # make the answer decidable, and it gets the same code and the same shape.
+    if state == STORE_POPULATED:
         where = (f"the store {store} holds {len(names)} scope "
                  f"repositor{'y' if len(names) == 1 else 'ies'} "
                  f"({sorted(names)}), none of which is one of the artifact "
                  f"scope(s) verified here")
+        mechanisms = (
+            "(1) the scope repositor(y/ies) named below were removed or renamed "
+            "inside this store, or (2) --store names a DIFFERENT store that "
+            "happens to hold other scopes")
+    else:
+        where = (f"the store directory {store} DOES NOT EXIST"
+                 if state == STORE_ABSENT else
+                 f"the store directory {store} EXISTS but holds NO scope "
+                 f"repositories")
+        mechanisms = (
+            "(1) --store names a path that is not this host's store (a typo, a "
+            "different layout, a default that does not apply to this run), or "
+            "(2) the live store is GONE — the disaster these backups exist for")
     return (
-        f"NOTHING WAS CROSS-CHECKED AGAINST THE LIVE STORE. All {artifacts} "
-        f"artifact(s) under {bucket}/{prefix} are THIS machine's, and every one "
-        f"of them was verified for SELF-CONSISTENCY ONLY, because the store "
-        f"side contributed nothing: {where}. Scope(s) with no live repository: "
-        f"{scopes}. Self-consistency proves the object decrypts and restores; "
-        f"it proves NOTHING about whether it still matches the history it is a "
-        f"backup OF, and zero commits were compared on this run. Exiting "
-        f"non-zero because an exit code is all a timer reads. Point --store at "
-        f"the live store, or fix it. Verifying ANOTHER host's artifacts is the "
-        f"one case where zero cross-checks is correct, and this is not it.")
+        f"{NOTHING_CROSS_CHECKED}: {artifacts} artifact(s) under "
+        f"{bucket}/{prefix} DECRYPTED, RESTORED and passed `git fsck`. That "
+        f"much is PROVEN, and it is the good news — these objects are readable "
+        f"backups. What did NOT happen is any comparison against a live store: "
+        f"zero commits were compared, for every one of them. "
+        f"WHY IS NOT DECIDED HERE. The observation is that {where} — and that "
+        f"single observation is shared by two mechanisms: {mechanisms}. "
+        f"Nothing measured on this run separates them, so neither is asserted. "
+        f"Self-consistency proves an object decrypts and restores; it proves "
+        f"NOTHING about whether it still matches the history it is a backup OF, "
+        f"and that is the claim this run could not make. "
+        f"WHAT TO DO, UNDER EITHER READING: `restore-verify.py --print-plan` "
+        f"prints the store path this run used, touching neither the network nor "
+        f"the key. If that is not the store you meant, re-run pointing at the "
+        f"one you did. If it IS the store you meant, then the live side is gone "
+        f"— this code is the EXPECTED outcome during a recovery, not a verdict "
+        f"against the backups, and the per-artifact lines above are the "
+        f"evidence that they are intact. Scope(s) with no live repository: "
+        f"{scopes}.")
 
 
 def run(*, bucket: str, prefix: str, this_host: str,
@@ -1385,6 +1493,9 @@ def run(*, bucket: str, prefix: str, this_host: str,
 
         verdicts: list[ArtifactVerdict] = []
         failures: list[str] = []
+        # The classified NOTHING-CROSS-CHECKED finding, if the run produces one.
+        # Deliberately NOT an entry in `failures` — see where it is set.
+        nothing_cross_checked: str | None = None
 
         # 🔴 ONE NAME for "these artifacts are not this machine's", read by
         # both the coverage check below and `cross_check_target()` in the loop.
@@ -1509,18 +1620,31 @@ def run(*, bucket: str, prefix: str, this_host: str,
         if (verdicts
                 and scopes_with_a_live_target == 0
                 and store_blocked_scopes):
-            msg = nothing_cross_checked_message(
+            # 🔴 KEPT OUT OF `failures` ON PURPOSE. It is a DIFFERENT FACT from
+            # a verification failure — "your backups restored perfectly, I just
+            # could not compare them" versus "your backups are broken" — and it
+            # carries its own exit code so a timer can act on the number.
+            # Mixing it into `failures` would both mis-count the failures and
+            # make it impossible to tell which of the two the run found.
+            nothing_cross_checked = nothing_cross_checked_message(
                 bucket=bucket, prefix=prefix, store=store,
                 artifacts=len(verdicts), scopes=sorted(store_blocked_scopes))
-            failures.append(msg)
-            print(f"{PROG}: FAILED {msg}", file=sys.stderr)
+            print(f"{PROG}: FAILED {nothing_cross_checked}", file=sys.stderr)
     finally:
         ctx.__exit__(None, None, None)
 
+    # 🔴 A REAL FAILURE OUTRANKS "COULD NOT COMPARE". An artifact that did not
+    # restore is the louder finding, and a timer that saw 40 for a corrupt
+    # artifact would read "just a store problem" — the same conflation in the
+    # other direction. So the classified code is raised ONLY when it is the
+    # whole story.
     if failures:
         raise RestoreVerifyError(
             f"{len(failures)} artifact/scope check(s) FAILED; "
             f"{len(verdicts)} verified. First failure: {failures[0]}")
+    if nothing_cross_checked is not None:
+        raise RestoreVerifyError(nothing_cross_checked,
+                                 token=NOTHING_CROSS_CHECKED)
     if not verdicts:
         # 🔴 NOT REACHABLE TODAY, AND LABELLED AS SUCH — a mutation sweep scored
         # its removal SURVIVED, which is the honest answer: `keys` is non-empty
@@ -1598,6 +1722,18 @@ def print_plan(*, bucket: str, prefix: str, store: Path, identity: Path,
     print("           decrypts, never that it still matches the history it backs")
     print("           up. Another host's artifacts are exempt (their comparison")
     print("           is suppressed on purpose), and so is a PARTIAL run.")
+    # 🔴 EVERY CLASSIFIED CAUSE IS LISTED, so an operator can map a number by
+    # eye during a recovery — the same reason `escrow-verify.py --print-plan`
+    # prints its table. `--print-plan` touches neither the network nor the key,
+    # which is exactly why the refusal's remedy sends people here.
+    print(f"exit:      {EXIT_OK}=verified, {EXIT_FAILED}=a check FAILED or an "
+          f"unexpected error, plus one code per classified cause:")
+    for token, code in sorted(EXIT_CODES.items(), key=lambda kv: kv[1]):
+        print(f"           {code}={token}")
+    print(f"           {EXIT_CODES[NOTHING_CROSS_CHECKED]} is NOT a verdict "
+          f"against the backups: every artifact restored and")
+    print("           passed fsck, and NONE could be compared to a live store.")
+    print("           It is the EXPECTED code during a real recovery.")
     print("coverage:  every LOCAL scope must have at least one artifact. A scope")
     print("           that stopped being backed up is invisible to every other")
     print("           check here, because they all iterate the objects that ARE")
@@ -1700,7 +1836,7 @@ def main(argv: list[str] | None = None) -> int:
                        identity_source=identity_source,
                        identity=identity, scope_filter=args.scope,
                        verify_all=args.verify_all, max_lag_days=args.max_lag_days)
-            return 0
+            return EXIT_OK
 
         if args.keep_work_dir and args.work_dir is None:
             # An option that silently does nothing is a lie, and this one would
@@ -1739,12 +1875,20 @@ def main(argv: list[str] | None = None) -> int:
                 verdicts = _go(Path(td))
 
         if not verdicts:
-            return 0        # the documented never-ran-here no-op; reason on stderr
+            return EXIT_OK  # the documented never-ran-here no-op; reason on stderr
         print(summarise(verdicts))
-        return 0
+        return EXIT_OK
+    except RestoreVerifyError as exc:
+        # 🔴 THE CODE COMES OFF THE EXCEPTION, DERIVED FROM ITS TOKEN. A
+        # classified refusal keeps its own number; an unclassified one is
+        # EXIT_FAILED, which is what every raise here used to be. Ordered before
+        # the `BackupError` arm below because this subclasses it — reversed, the
+        # classified codes would be unreachable and 40 would never be seen.
+        print(f"{PROG}: {exc}", file=sys.stderr)
+        return exc.exit_code
     except B.BackupError as exc:
         print(f"{PROG}: {exc}", file=sys.stderr)
-        return 1
+        return EXIT_FAILED
     except Exception as exc:  # noqa: BLE001 — the failure signal, not a swallow
         # 🔴 NOT EVERY FAILURE IS A BackupError, and the ones that are not are the
         # ones nobody wrote a message for: `S3Error`, a urllib3 connection error,
@@ -1756,7 +1900,7 @@ def main(argv: list[str] | None = None) -> int:
               f"Nothing was verified on this run, or only part of it was — "
               f"treat this as NO verification and read the traceback above.",
               file=sys.stderr)
-        return 1
+        return EXIT_FAILED
     finally:
         # EVERY path out: success, BackupError, and an unexpected exception. A
         # failing run is the one most likely to have left a partly-restored

--- a/scripts/analyze-service-index/restore-verify.py
+++ b/scripts/analyze-service-index/restore-verify.py
@@ -1028,33 +1028,59 @@ WHY_KINDS = frozenset({WHY_STORE_ABSENT, WHY_STORE_EMPTY, WHY_SCOPE_SYMLINK,
                        WHY_SCOPE_NOT_A_REPO, WHY_SCOPE_NOT_PRESENT})
 
 
+def _why(kind: str, sentence: str) -> tuple[str, str]:
+    """Every `why_no_live_scope` return goes through here. Closes the set.
+
+    🔴 A SIXTH BRANCH RETURNING AN INLINE LITERAL WOULD `KeyError` INSIDE THE
+    REFUSAL AN OPERATOR IS READING DURING A RECOVERY. `_MECHANISMS` is pinned
+    key-for-key against `WHY_KINDS` by the test suite, but that pin says nothing
+    about what this function actually RETURNS — a branch spelling its kind
+    inline satisfies the ledger test and blows up at the worst possible moment,
+    on the disaster path this whole feature exists to serve. The two halves
+    together (ledger pinned to WHY_KINDS, returns pinned to WHY_KINDS) are what
+    make the `_MECHANISMS[kind]` lookup total.
+
+    It raises rather than degrading: an unknown kind is a programming error with
+    no correct operator-facing text, and inventing one would be the confident
+    wrong answer this module exists to refuse.
+    """
+    if kind not in WHY_KINDS:
+        raise RestoreVerifyError(
+            f"{kind!r} is not in WHY_KINDS. Every store state this verifier can "
+            f"observe is an ENUMERATED value with an entry in _MECHANISMS; "
+            f"adding one means adding it to both, in the same commit as the "
+            f"test that pins them.")
+    return kind, sentence
+
+
 def why_no_live_scope(store: Path, scope: str) -> tuple[str, str]:
     """`(kind, sentence)` for WHICH store state blocked `scope`'s cross-check.
 
     Never "no local store": that spelling was three facts in one, and the two
     scope-level ones below are a fourth and fifth that a store-level answer
-    cannot express at all.
+    cannot express at all. Every return goes through `_why`, which closes the
+    kind set — see its docstring.
     """
     state, names = store_state(store)
     if state == STORE_ABSENT:
-        return WHY_STORE_ABSENT, f"the store directory {store} DOES NOT EXIST"
+        return _why(WHY_STORE_ABSENT, f"the store directory {store} DOES NOT EXIST")
     p = store / scope
     if p.is_symlink():
-        return WHY_SCOPE_SYMLINK, (
+        return _why(WHY_SCOPE_SYMLINK, (
             f"{p} is a SYMLINK, and a symlink is never followed here — "
             f"following one would compare against a repository from "
-            f"OUTSIDE the store")
+            f"OUTSIDE the store"))
     if p.is_dir() and not (p / ".git").exists():
-        return WHY_SCOPE_NOT_A_REPO, (
-            f"{p} exists but is not a git repository (it has no .git)")
+        return _why(WHY_SCOPE_NOT_A_REPO, (
+            f"{p} exists but is not a git repository (it has no .git)"))
     if state == STORE_EMPTY:
-        return WHY_STORE_EMPTY, (
+        return _why(WHY_STORE_EMPTY, (
             f"the store directory {store} EXISTS but holds NO scope "
-            f"repositories")
-    return WHY_SCOPE_NOT_PRESENT, (
+            f"repositories"))
+    return _why(WHY_SCOPE_NOT_PRESENT, (
         f"the store {store} holds {len(names)} scope "
         f"repositor{'y' if len(names) == 1 else 'ies'} but none named "
-        f"{scope!r}")
+        f"{scope!r}"))
 
 
 # Where `%m` comes from. A module-level tuple so the test suite can point the
@@ -1375,9 +1401,15 @@ def diagnose_empty_prefix(*, bucket: str, prefix: str, siblings: list[str],
 # 🔴 ONE MECHANISM PER OBSERVED KIND, AND THE LIST IS OPEN. A CLOSED two-way
 # choice is a claim about what CANNOT be true, and it was wrong for two
 # reachable states (see `WHY_KINDS`). Each entry says what is CONSISTENT with
-# the observation; none says it is THE cause. Read by
-# `nothing_cross_checked_message` and pinned two-way against `WHY_KINDS`, so a
-# sixth state cannot be added without deciding what it means for the operator.
+# the observation; none says it is THE cause.
+#
+# Read by `nothing_cross_checked_message`, and the `_MECHANISMS[kind]` lookup is
+# TOTAL — which takes BOTH halves, not the one this comment used to claim. The
+# test suite pins this table key-for-key against `WHY_KINDS`, AND `_why()`
+# refuses at runtime to return a kind outside `WHY_KINDS`. The ledger pin alone
+# said nothing about what `why_no_live_scope` actually RETURNS: a sixth branch
+# spelling its kind inline satisfied it and would have raised `KeyError` inside
+# the refusal an operator reads during a recovery.
 _MECHANISMS: dict[str, tuple[str, ...]] = {
     WHY_STORE_ABSENT: (
         "--store names a path that is not this host's store (a typo, a "

--- a/scripts/analyze-service-index/restore-verify.py
+++ b/scripts/analyze-service-index/restore-verify.py
@@ -113,6 +113,17 @@ backups is worse than no verifier.
   * a decrypted bundle that restores to zero commits   -> failure
   * zero commits compared against the live scope       -> failure
   * a run that verified zero scopes                    -> failure
+  * THIS host's artifacts, and NOT ONE of them cross-checked because the store
+    side gave nothing                                  -> failure
+
+The last one is the STORE-side twin of the first, and it was exit-0 until it
+was measured: `--host <this host> --store <an empty directory>` printed 13
+`RESTORED … fsck OK … NOT CROSS-CHECKED … self-consistency only` lines and
+rc=0. An exit code is all a timer reads, so a wrong or absent `--store`
+downgraded the whole run to "it decrypts and is internally consistent" and
+called that success. Foreign artifacts and PARTIAL runs (one scope with no live
+repository beside scopes that have one) are outside it by construction — see
+`nothing_cross_checked_message`.
 
 The single exception is the same one `backup.py` permits: a host that has never
 run the backup at all — no local store AND no objects under its own default
@@ -891,6 +902,59 @@ def live_scope_path(store: Path, scope: str) -> Path | None:
     return p
 
 
+# The THREE states a `--store` path can be in, which "no local store" used to
+# spell as one. See `store_state`.
+STORE_ABSENT = "absent"
+STORE_EMPTY = "empty"
+STORE_POPULATED = "populated"
+
+
+def store_state(store: Path) -> tuple[str, list[str]]:
+    """`(state, scope names)` for the live store as a WHOLE.
+
+    🔴 "NO LOCAL STORE" WAS THREE DIFFERENT FACTS SHARING ONE SENTENCE, and
+    they call for three different actions:
+
+      * ABSENT     — the path does not exist. Either the disaster this whole
+        feature exists for, or `--store` points at nothing (a typo, a host where
+        the store lives elsewhere). The operator must find out WHICH.
+      * EMPTY      — the directory is there and holds no scope repository at
+        all. /analyze-service has never run here, or the store was emptied.
+      * POPULATED  — scope repositories are there; the one being compared is
+        simply not among them. That is a per-scope finding, not a store one, and
+        printing "no local store" for it sends the reader to look at the wrong
+        thing entirely.
+
+    An EMPTY RESULT CANNOT DISTINGUISH ITS CAUSES (RULES.md); this is the split
+    that makes it discriminating, and it is read by both the per-artifact reason
+    and the whole-run refusal below.
+    """
+    if not store.is_dir():
+        return STORE_ABSENT, []
+    names = local_scopes(store)
+    return (STORE_POPULATED, names) if names else (STORE_EMPTY, [])
+
+
+def why_no_live_scope(store: Path, scope: str) -> str:
+    """WHICH store state blocked `scope`'s cross-check. Never "no local store"."""
+    state, names = store_state(store)
+    if state == STORE_ABSENT:
+        return f"the store directory {store} DOES NOT EXIST"
+    p = store / scope
+    if p.is_symlink():
+        return (f"{p} is a SYMLINK, and a symlink is never followed here — "
+                f"following one would compare against a repository from "
+                f"OUTSIDE the store")
+    if p.is_dir() and not (p / ".git").exists():
+        return f"{p} exists but is not a git repository (it has no .git)"
+    if state == STORE_EMPTY:
+        return (f"the store directory {store} EXISTS but holds NO scope "
+                f"repositories")
+    return (f"the store {store} holds {len(names)} scope "
+            f"repositor{'y' if len(names) == 1 else 'ies'} but none named "
+            f"{scope!r}")
+
+
 # Where `%m` comes from. A module-level tuple so the test suite can point the
 # reader at synthetic files and exercise the REAL function, rather than
 # re-implementing its shape check in the test — which would only ever prove the
@@ -952,10 +1016,32 @@ def prefix_belongs_to_this_host(prefix: str, this_host: str,
     return bool(this_machine_id) and this_machine_id in prefix
 
 
+# 🔴 THE REASON IN MACHINE-READABLE FORM. The prose reason is for the operator
+# and is free to be reworded; the KIND is what the whole-run refusal branches
+# on, so that predicate can never be a substring match on a sentence. Keyed on
+# WHY the comparison was dropped, because the two answers are not the same
+# finding and only one of them is a gap in verification:
+#
+#   * the artifacts are ANOTHER host's        -> suppressing the compare is
+#     CORRECT (the two stores are divergent content sharing scope names), so a
+#     run with zero cross-checks is a correct run;
+#   * this host's own artifacts, and the LOCAL STORE offered nothing -> the
+#     comparison was silently dropped, and a run with zero of them exits 0
+#     having compared nothing at all. That is the one this refuses.
+NO_CROSS_CHECK_FOREIGN_HOST = "foreign-host"
+NO_CROSS_CHECK_MACHINE_ID_UNREADABLE = "machine-id-unreadable"
+NO_CROSS_CHECK_NO_LIVE_SCOPE = "no-live-scope"
+
+# The kinds that are a fact about THE STORE SIDE — i.e. the artifacts are this
+# machine's and the local half contributed nothing. Membership, not a default:
+# a kind added later is NOT store-side until someone puts it here on purpose.
+STORE_SIDE_BLOCK_KINDS = frozenset({NO_CROSS_CHECK_NO_LIVE_SCOPE})
+
+
 def cross_check_target(store: Path, scope: str, *, artifacts_are_foreign: bool,
                        machine_id_unreadable: bool = False,
-                       ) -> tuple[Path | None, str | None]:
-    """The live repo to compare `scope`'s artifact against, or `(None, reason)`.
+                       ) -> tuple[Path | None, str | None, str | None]:
+    """The live repo to compare `scope`'s artifact against, or `(None, reason, kind)`.
 
     🔴 ONE PLACE OWNS "IS THERE ANYTHING TO COMPARE AGAINST", because the
     predicate used to be open-coded at two sites and was WRONG AT ONE of them —
@@ -1005,15 +1091,17 @@ def cross_check_target(store: Path, scope: str, *, artifacts_are_foreign: bool,
                 "host's label — so whether these artifacts are this machine's "
                 "is UNKNOWN, not decided. Declining to cross-check rather than "
                 "risk a false data-loss alarm; re-run with a matching --host, "
-                "or fix the machine id")
+                "or fix the machine id"), NO_CROSS_CHECK_MACHINE_ID_UNREADABLE
         return None, ("the artifacts belong to ANOTHER host (--host/--prefix) "
                       "and this machine's store is DIVERGENT content that only "
                       "shares scope NAMES — comparing them would report a false "
-                      "data-loss alarm")
+                      "data-loss alarm"), NO_CROSS_CHECK_FOREIGN_HOST
     live = live_scope_path(store, scope)
     if live is None:
-        return None, f"no live scope repository at {store / scope}"
-    return live, None
+        return None, (f"no live scope repository at {store / scope}: "
+                      f"{why_no_live_scope(store, scope)}"
+                      ), NO_CROSS_CHECK_NO_LIVE_SCOPE
+    return live, None, None
 
 
 def uncovered_local_scopes(store: Path, covered: set[str], now: datetime,
@@ -1182,6 +1270,60 @@ def diagnose_empty_prefix(*, bucket: str, prefix: str, siblings: list[str],
                    f"nothing to verify{where}")
 
 
+def nothing_cross_checked_message(*, bucket: str, prefix: str, store: Path,
+                                  artifacts: int, scopes: list[str]) -> str:
+    """The refusal for a run of THIS host's artifacts that compared NOTHING.
+
+    🔴 THE EXIT-0 VARIANT IS WORSE THAN THE REFUSAL — the same argument
+    `diagnose_empty_prefix` already makes for the BUCKET side, made here for the
+    STORE side. MEASURED on this host: `restore-verify.py --host <this host>
+    --store <an empty directory>` printed 13 lines of `RESTORED N commit(s) …,
+    fsck OK … NOT CROSS-CHECKED … self-consistency only`, a summary reading
+    `13 self-consistency only`, and **rc=0**. An exit code is the only thing a
+    systemd timer reads, so a wrong or absent `--store` silently downgrades the
+    run to "the artifact decrypts and is internally consistent" — which proves
+    nothing about whether the backup still matches the history it is a backup
+    OF — and reports success while doing it.
+
+    🔴 IT FIRES ON THE OBSERVED PROPERTY, NEVER ON "WAS A FLAG TYPED". The
+    v1/v2/v3 note in `run()` and `cross_check_target`'s docstring are both about
+    the same mistake made in the other direction; keying this on `--store`
+    having been passed would let the DEFAULT store path — the case actually
+    measured — sail through.
+
+    🔴 AND IT IS NOT A PERMANENTLY-RED GATE. Three legitimate zero-cross-check
+    runs are outside it by construction:
+      * FOREIGN artifacts (`--host`/`--prefix` naming the other machine), where
+        suppressing the compare is correct and its kind is not store-side;
+      * a PARTIAL run — one scope with no live repository beside scopes that
+        have one — because a single live target anywhere clears the guard;
+      * a host that has never run the backup, which never reaches here (the
+        zero-objects no-op returns first, with no verdicts).
+    """
+    state, names = store_state(store)
+    if state == STORE_ABSENT:
+        where = f"the store directory {store} DOES NOT EXIST"
+    elif state == STORE_EMPTY:
+        where = (f"the store directory {store} EXISTS but holds NO scope "
+                 f"repositories")
+    else:
+        where = (f"the store {store} holds {len(names)} scope "
+                 f"repositor{'y' if len(names) == 1 else 'ies'} "
+                 f"({sorted(names)}), none of which is one of the artifact "
+                 f"scope(s) verified here")
+    return (
+        f"NOTHING WAS CROSS-CHECKED AGAINST THE LIVE STORE. All {artifacts} "
+        f"artifact(s) under {bucket}/{prefix} are THIS machine's, and every one "
+        f"of them was verified for SELF-CONSISTENCY ONLY, because the store "
+        f"side contributed nothing: {where}. Scope(s) with no live repository: "
+        f"{scopes}. Self-consistency proves the object decrypts and restores; "
+        f"it proves NOTHING about whether it still matches the history it is a "
+        f"backup OF, and zero commits were compared on this run. Exiting "
+        f"non-zero because an exit code is all a timer reads. Point --store at "
+        f"the live store, or fix it. Verifying ANOTHER host's artifacts is the "
+        f"one case where zero cross-checks is correct, and this is not it.")
+
+
 def run(*, bucket: str, prefix: str, this_host: str,
         this_machine_id: str | None, store: Path, identity: Path,
         scope_filter: str | None, verify_all: bool, max_lag_days: float,
@@ -1281,6 +1423,12 @@ def run(*, bucket: str, prefix: str, this_host: str,
                 failures.append(msg)
                 print(f"{PROG}: FAILED {msg}", file=sys.stderr)
 
+        # Two counters read by the whole-run refusal after the loop. They record
+        # what was OBSERVED per scope — never what was typed — so the refusal
+        # cannot be argued out of firing by a flag.
+        scopes_with_a_live_target = 0
+        store_blocked_scopes: list[str] = []
+
         for scope in sorted(by_scope):
             entries = by_scope[scope]
             # NOTE: no empty-`entries` guard. `group_by_scope` builds each list
@@ -1291,9 +1439,13 @@ def run(*, bucket: str, prefix: str, this_host: str,
             # stamp is fixed-width UTC), so the last entry is the newest.
             newest_stamp = entries[-1][0]
             chosen = entries if verify_all else [entries[-1]]
-            live, no_live_reason = cross_check_target(
+            live, no_live_reason, no_live_kind = cross_check_target(
                 store, scope, artifacts_are_foreign=artifacts_are_foreign,
                 machine_id_unreadable=(this_machine_id is None))
+            if live is not None:
+                scopes_with_a_live_target += 1
+            if no_live_kind in STORE_SIDE_BLOCK_KINDS:
+                store_blocked_scopes.append(scope)
             for stamp, key in chosen:
                 try:
                     v = verify_artifact(
@@ -1329,6 +1481,39 @@ def run(*, bucket: str, prefix: str, this_host: str,
                        f"this one.")
                 failures.append(msg)
                 print(f"{PROG}: FAILED {msg}", file=sys.stderr)
+
+        # 🔴 THE RUN COMPARED NOTHING AGAINST LIVE, AND THE STORE IS WHY.
+        # THREE conjuncts, each excluding a run this must not fire on, and each
+        # able to fail on its own; the whole argument is in
+        # `nothing_cross_checked_message`.
+        #
+        #   verdicts                      a run that verified ZERO artifacts has
+        #                                 its own, louder finding. Saying "all 0
+        #                                 artifacts were self-consistency only"
+        #                                 there blames the STORE for what is
+        #                                 actually a broken artifact.
+        #   scopes_with_a_live_target==0  ONE usable live target anywhere clears
+        #                                 this: a partial run, and equally a run
+        #                                 whose only comparable artifact was
+        #                                 corrupt — the store DID contribute.
+        #   store_blocked_scopes          at least one scope was dropped by the
+        #                                 STORE side rather than because the
+        #                                 artifacts are another host's.
+        #
+        # 🔴 `not any(v.cross_checked ...)` IS DELIBERATELY ABSENT. It reads
+        # like the heart of the check and it is implied by the second conjunct —
+        # a verdict can only be cross-checked against a live target, so zero
+        # targets means zero cross-checks. A mutation sweep scored flipping it
+        # to `not all(...)` SURVIVED, which is the honest answer for a conjunct
+        # that cannot fail: it would have read as coverage while providing none.
+        if (verdicts
+                and scopes_with_a_live_target == 0
+                and store_blocked_scopes):
+            msg = nothing_cross_checked_message(
+                bucket=bucket, prefix=prefix, store=store,
+                artifacts=len(verdicts), scopes=sorted(store_blocked_scopes))
+            failures.append(msg)
+            print(f"{PROG}: FAILED {msg}", file=sys.stderr)
     finally:
         ctx.__exit__(None, None, None)
 
@@ -1408,6 +1593,11 @@ def print_plan(*, bucket: str, prefix: str, store: Path, identity: Path,
     print("           restored tip must be an ANCESTOR of the live tip. Never an")
     print("           equality — the store advances hourly and an equality check")
     print("           would be a permanently-red gate.")
+    print("           A run of THIS host's artifacts in which NOT ONE scope could")
+    print("           be compared FAILS: self-consistency alone says the object")
+    print("           decrypts, never that it still matches the history it backs")
+    print("           up. Another host's artifacts are exempt (their comparison")
+    print("           is suppressed on purpose), and so is a PARTIAL run.")
     print("coverage:  every LOCAL scope must have at least one artifact. A scope")
     print("           that stopped being backed up is invisible to every other")
     print("           check here, because they all iterate the objects that ARE")

--- a/scripts/analyze-service-index/restore-verify.py
+++ b/scripts/analyze-service-index/restore-verify.py
@@ -132,9 +132,15 @@ here compared them to anything* — which is the EXPECTED outcome during a real
 recovery. `1` means a check FAILED. Collapsing the two would tell an operator
 mid-disaster that their backups are broken, and it is the reading that the
 absent-live-scope path was originally left at exit 0 to avoid. A real failure
-OUTRANKS it: 40 is raised only when it is the whole story. The message names
-BOTH mechanisms it cannot separate — a misconfigured `--store` and a store that
-is genuinely gone — and asserts neither.
+OUTRANKS it: 40 is raised only when it is the whole story, and the finding is
+still printed as `ALSO:` when something louder wins. The message lists every
+mechanism CONSISTENT with what was observed, states that the list is NOT closed,
+and asserts none of them.
+
+(This docstring is `--help`, so it is operator-facing prose. The paragraph above
+is whole-string pinned by the test suite for the same reason the refusal itself
+is: it carries the claim that 40 is not a verdict against the backups, and that
+claim is worth nothing if a reword can silently invert it.)
 
 The single exception is the same one `backup.py` permits: a host that has never
 run the backup at all — no local store AND no objects under its own default
@@ -1003,24 +1009,52 @@ def store_state(store: Path) -> tuple[str, list[str]]:
     return (STORE_POPULATED, names) if names else (STORE_EMPTY, [])
 
 
-def why_no_live_scope(store: Path, scope: str) -> str:
-    """WHICH store state blocked `scope`'s cross-check. Never "no local store"."""
+# 🔴 THE FIVE WAYS A SCOPE CAN HAVE NO LIVE REPOSITORY, AS VALUES. The
+# sentences below are for the operator and may be reworded; these are what the
+# refusal BRANCHES on, so its explanation can never be a substring match on
+# prose — and, more importantly, so it cannot offer a two-way choice that
+# EXCLUDES what was actually observed. Measured: a scope that is a SYMLINK, and
+# a scope directory with no `.git`, both reached exit 40 being told the store
+# held "NO scope repositories" and offered only "--store is wrong" or "the store
+# is GONE". Both are false — the repository is right there and `--store` is
+# correct; `live_scope_path` refuses symlinks and `discover_scopes` skips them.
+WHY_STORE_ABSENT = "store-absent"
+WHY_STORE_EMPTY = "store-empty"
+WHY_SCOPE_SYMLINK = "scope-symlink"
+WHY_SCOPE_NOT_A_REPO = "scope-not-a-repo"
+WHY_SCOPE_NOT_PRESENT = "scope-not-present"
+
+WHY_KINDS = frozenset({WHY_STORE_ABSENT, WHY_STORE_EMPTY, WHY_SCOPE_SYMLINK,
+                       WHY_SCOPE_NOT_A_REPO, WHY_SCOPE_NOT_PRESENT})
+
+
+def why_no_live_scope(store: Path, scope: str) -> tuple[str, str]:
+    """`(kind, sentence)` for WHICH store state blocked `scope`'s cross-check.
+
+    Never "no local store": that spelling was three facts in one, and the two
+    scope-level ones below are a fourth and fifth that a store-level answer
+    cannot express at all.
+    """
     state, names = store_state(store)
     if state == STORE_ABSENT:
-        return f"the store directory {store} DOES NOT EXIST"
+        return WHY_STORE_ABSENT, f"the store directory {store} DOES NOT EXIST"
     p = store / scope
     if p.is_symlink():
-        return (f"{p} is a SYMLINK, and a symlink is never followed here — "
-                f"following one would compare against a repository from "
-                f"OUTSIDE the store")
+        return WHY_SCOPE_SYMLINK, (
+            f"{p} is a SYMLINK, and a symlink is never followed here — "
+            f"following one would compare against a repository from "
+            f"OUTSIDE the store")
     if p.is_dir() and not (p / ".git").exists():
-        return f"{p} exists but is not a git repository (it has no .git)"
+        return WHY_SCOPE_NOT_A_REPO, (
+            f"{p} exists but is not a git repository (it has no .git)")
     if state == STORE_EMPTY:
-        return (f"the store directory {store} EXISTS but holds NO scope "
-                f"repositories")
-    return (f"the store {store} holds {len(names)} scope "
-            f"repositor{'y' if len(names) == 1 else 'ies'} but none named "
-            f"{scope!r}")
+        return WHY_STORE_EMPTY, (
+            f"the store directory {store} EXISTS but holds NO scope "
+            f"repositories")
+    return WHY_SCOPE_NOT_PRESENT, (
+        f"the store {store} holds {len(names)} scope "
+        f"repositor{'y' if len(names) == 1 else 'ies'} but none named "
+        f"{scope!r}")
 
 
 # Where `%m` comes from. A module-level tuple so the test suite can point the
@@ -1167,7 +1201,7 @@ def cross_check_target(store: Path, scope: str, *, artifacts_are_foreign: bool,
     live = live_scope_path(store, scope)
     if live is None:
         return None, (f"no live scope repository at {store / scope}: "
-                      f"{why_no_live_scope(store, scope)}"
+                      f"{why_no_live_scope(store, scope)[1]}"
                       ), NO_CROSS_CHECK_NO_LIVE_SCOPE
     return live, None, None
 
@@ -1338,8 +1372,38 @@ def diagnose_empty_prefix(*, bucket: str, prefix: str, siblings: list[str],
                    f"nothing to verify{where}")
 
 
+# 🔴 ONE MECHANISM PER OBSERVED KIND, AND THE LIST IS OPEN. A CLOSED two-way
+# choice is a claim about what CANNOT be true, and it was wrong for two
+# reachable states (see `WHY_KINDS`). Each entry says what is CONSISTENT with
+# the observation; none says it is THE cause. Read by
+# `nothing_cross_checked_message` and pinned two-way against `WHY_KINDS`, so a
+# sixth state cannot be added without deciding what it means for the operator.
+_MECHANISMS: dict[str, tuple[str, ...]] = {
+    WHY_STORE_ABSENT: (
+        "--store names a path that is not this host's store (a typo, a "
+        "different layout, a default that does not apply to this run)",
+        "the live store is GONE — the disaster these backups exist for"),
+    WHY_STORE_EMPTY: (
+        "--store names a path that is not this host's store (a typo, a "
+        "different layout, a default that does not apply to this run)",
+        "the live store is GONE — the disaster these backups exist for"),
+    WHY_SCOPE_SYMLINK: (
+        "the scope path IS present but is a SYMLINK, which is never followed "
+        "here — the repository it points at may be perfectly intact, and "
+        "--store may be exactly right",),
+    WHY_SCOPE_NOT_A_REPO: (
+        "the scope path IS present but carries no .git — an interrupted move, "
+        "or a repository that lost it; --store may be exactly right",),
+    WHY_SCOPE_NOT_PRESENT: (
+        "the scope repositor(y/ies) named below were removed, RENAMED, or "
+        "never created in this store",
+        "--store names a DIFFERENT store that happens to hold other scopes"),
+}
+
+
 def nothing_cross_checked_message(*, bucket: str, prefix: str, store: Path,
-                                  artifacts: int, scopes: list[str]) -> str:
+                                  artifacts: int, scopes: list[str],
+                                  scope_filter: str | None = None) -> str:
     """The classified refusal for a run of THIS host's artifacts that compared
     NOTHING. Raised as `NOTHING-CROSS-CHECKED` (exit 40), never as a bare 1.
 
@@ -1387,49 +1451,53 @@ def nothing_cross_checked_message(*, bucket: str, prefix: str, store: Path,
       * a host that has never run the backup, which never reaches here (the
         zero-objects no-op returns first, with no verdicts).
     """
-    state, names = store_state(store)
-    # 🔴 TWO RIVAL MECHANISMS PER STATE, NEITHER ASSERTED. Which PAIR is
-    # plausible depends on what was observed; that one of the pair is true does
-    # not. The `--scope` case lands here too — narrowing the question does not
-    # make the answer decidable, and it gets the same code and the same shape.
-    if state == STORE_POPULATED:
-        where = (f"the store {store} holds {len(names)} scope "
-                 f"repositor{'y' if len(names) == 1 else 'ies'} "
-                 f"({sorted(names)}), none of which is one of the artifact "
-                 f"scope(s) verified here")
-        mechanisms = (
-            "(1) the scope repositor(y/ies) named below were removed or renamed "
-            "inside this store, or (2) --store names a DIFFERENT store that "
-            "happens to hold other scopes")
-    else:
-        where = (f"the store directory {store} DOES NOT EXIST"
-                 if state == STORE_ABSENT else
-                 f"the store directory {store} EXISTS but holds NO scope "
-                 f"repositories")
-        mechanisms = (
-            "(1) --store names a path that is not this host's store (a typo, a "
-            "different layout, a default that does not apply to this run), or "
-            "(2) the live store is GONE — the disaster these backups exist for")
+    # 🔴 THE OBSERVATIONS AND THE MECHANISMS BOTH COME FROM `why_no_live_scope`,
+    # which already knows the real reason per scope. Deriving them from
+    # `store_state` alone is what produced a two-way choice that EXCLUDED the
+    # truth for a symlinked or non-repository scope.
+    # 🔴 ONE ORDER FOR BOTH LISTS, KEYED ON THE KIND. Sorting the SENTENCES
+    # instead made the order depend on incidental string content — a path
+    # sorting before the word "the" — so the observations and the mechanisms
+    # they explain could appear in unrelated orders. Sorting the (kind,
+    # sentence) PAIRS groups observations by kind in exactly the order the
+    # mechanism list below walks, which is what lets a reader line them up.
+    seen = sorted({why_no_live_scope(store, s) for s in scopes})
+    observed = [sentence for _, sentence in seen]
+    mechanisms: list[str] = []
+    for kind in sorted({k for k, _ in seen}):
+        mechanisms.extend(_MECHANISMS[kind])
+    listed = "; ".join(f"({i}) {m}" for i, m in enumerate(mechanisms, 1))
+
+    # 🔴 THE COUNT IS ATTRIBUTED TO WHAT WAS ACTUALLY VERIFIED, NOT TO THE
+    # PREFIX. Under `--scope` only the selected scope ran, so "N artifact(s)
+    # under <prefix>" over-claimed — and a fixture holding one object cannot
+    # tell the two readings apart, which is why the test now holds several.
+    scanned = (f"scope {scope_filter!r} under {bucket}/{prefix}"
+               if scope_filter is not None
+               else f"every scope under {bucket}/{prefix}")
     return (
-        f"{NOTHING_CROSS_CHECKED}: {artifacts} artifact(s) under "
-        f"{bucket}/{prefix} DECRYPTED, RESTORED and passed `git fsck`. That "
+        f"{NOTHING_CROSS_CHECKED}: all {artifacts} artifact(s) this run "
+        f"verified ({scanned}) DECRYPTED, RESTORED and passed `git fsck`. That "
         f"much is PROVEN, and it is the good news — these objects are readable "
         f"backups. What did NOT happen is any comparison against a live store: "
         f"zero commits were compared, for every one of them. "
-        f"WHY IS NOT DECIDED HERE. The observation is that {where} — and that "
-        f"single observation is shared by two mechanisms: {mechanisms}. "
-        f"Nothing measured on this run separates them, so neither is asserted. "
+        f"WHY IS NOT DECIDED HERE. What was observed is: {'; '.join(observed)}. "
+        f"That is consistent with AT LEAST these mechanisms, and the list is "
+        f"NOT closed: {listed}. Nothing measured on this run separates them, so "
+        f"none of them is asserted. "
         f"Self-consistency proves an object decrypts and restores; it proves "
         f"NOTHING about whether it still matches the history it is a backup OF, "
         f"and that is the claim this run could not make. "
-        f"WHAT TO DO, UNDER EITHER READING: `restore-verify.py --print-plan` "
-        f"prints the store path this run used, touching neither the network nor "
-        f"the key. If that is not the store you meant, re-run pointing at the "
-        f"one you did. If it IS the store you meant, then the live side is gone "
-        f"— this code is the EXPECTED outcome during a recovery, not a verdict "
-        f"against the backups, and the per-artifact lines above are the "
-        f"evidence that they are intact. Scope(s) with no live repository: "
-        f"{scopes}.")
+        f"WHAT TO DO: the store this run looked at is {store} — it is named "
+        f"above, so no second command is needed to find it. If that is not the "
+        f"store you meant, re-run with --store pointing at the one you did. If "
+        f"it IS the store you meant, then something on the LIVE side is missing "
+        f"or unreachable, which is what these backups are for: this code is the "
+        f"EXPECTED outcome during a recovery, not a verdict against the "
+        f"backups, and the per-artifact lines above are the evidence that they "
+        f"are intact. `restore-verify.py --print-plan` WITH THE SAME FLAGS "
+        f"re-prints this run's settings and touches neither the network nor the "
+        f"key. Scope(s) with no live repository: {scopes}.")
 
 
 def run(*, bucket: str, prefix: str, this_host: str,
@@ -1626,10 +1694,15 @@ def run(*, bucket: str, prefix: str, this_host: str,
             # carries its own exit code so a timer can act on the number.
             # Mixing it into `failures` would both mis-count the failures and
             # make it impossible to tell which of the two the run found.
+            # 🔴 NOT PRINTED HERE, AND NOT PREFIXED `FAILED`. It was both, which
+            # cost twice: the 1.4 KB paragraph went to stderr once here and
+            # again from `main()`'s handler, and the first word an operator read
+            # was `FAILED` — the exact claim this message exists to retract. It
+            # is emitted ONCE below, by whichever path actually reports it.
             nothing_cross_checked = nothing_cross_checked_message(
                 bucket=bucket, prefix=prefix, store=store,
-                artifacts=len(verdicts), scopes=sorted(store_blocked_scopes))
-            print(f"{PROG}: FAILED {nothing_cross_checked}", file=sys.stderr)
+                artifacts=len(verdicts), scopes=sorted(store_blocked_scopes),
+                scope_filter=scope_filter)
     finally:
         ctx.__exit__(None, None, None)
 
@@ -1639,10 +1712,16 @@ def run(*, bucket: str, prefix: str, this_host: str,
     # other direction. So the classified code is raised ONLY when it is the
     # whole story.
     if failures:
+        # The outranked finding is still REPORTED — withholding the CODE must
+        # not withhold the fact. `ALSO:`, never `FAILED:`: it is a second
+        # finding beside the failure, not a second failure.
+        if nothing_cross_checked is not None:
+            print(f"{PROG}: ALSO: {nothing_cross_checked}", file=sys.stderr)
         raise RestoreVerifyError(
             f"{len(failures)} artifact/scope check(s) FAILED; "
             f"{len(verdicts)} verified. First failure: {failures[0]}")
     if nothing_cross_checked is not None:
+        # Printed by `main()`'s handler, exactly once. See where it is built.
         raise RestoreVerifyError(nothing_cross_checked,
                                  token=NOTHING_CROSS_CHECKED)
     if not verdicts:
@@ -1717,11 +1796,19 @@ def print_plan(*, bucket: str, prefix: str, store: Path, identity: Path,
     print("           restored tip must be an ANCESTOR of the live tip. Never an")
     print("           equality — the store advances hourly and an equality check")
     print("           would be a permanently-red gate.")
+    # 🔴 THIS PARAGRAPH SAID THE RUN "FAILS", TWELVE LINES ABOVE THE BLOCK
+    # SAYING 40 IS NOT A VERDICT AGAINST THE BACKUPS — and the refusal's own
+    # remedy routes a recovering operator to this screen, so the retracted claim
+    # was the first thing they read. Whole-string pinned by
+    # `test_print_plan_PROSE_never_contradicts_the_FORTY_framing`.
     print("           A run of THIS host's artifacts in which NOT ONE scope could")
-    print("           be compared FAILS: self-consistency alone says the object")
-    print("           decrypts, never that it still matches the history it backs")
-    print("           up. Another host's artifacts are exempt (their comparison")
-    print("           is suppressed on purpose), and so is a PARTIAL run.")
+    print("           be compared exits 40, NOT 0: self-consistency alone says")
+    print("           the object decrypts, never that it still matches the")
+    print("           history it backs up, so 0 would claim what was not")
+    print("           measured. 40 is NOT a verdict against the backups — see")
+    print("           `exit:` below. Another host's artifacts are exempt (their")
+    print("           comparison is suppressed on purpose), and so is a PARTIAL")
+    print("           run: both stay 0.")
     # 🔴 EVERY CLASSIFIED CAUSE IS LISTED, so an operator can map a number by
     # eye during a recovery — the same reason `escrow-verify.py --print-plan`
     # prints its table. `--print-plan` touches neither the network nor the key,

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -2522,14 +2522,27 @@ def test_the_TWO_exit_code_TABLES_never_collide():
     for one code and no way to know which — and each table is individually
     correct, so neither file's own tests can see it. `restore-verify.py` starts
     at 40 for exactly this reason; nothing but this assertion holds it there.
+
+    🔴 KEYS AS WELL AS VALUES, BECAUSE THE DOC PIN MERGES THE TWO TABLES. Only
+    values were asserted at first, while `test_SECRETS_md_exit_codes_agree_with_
+    the_module` resolves a documented token through `{**EV, **RV}` — a dict
+    merge, which silently prefers RV for a SHARED KEY. Its docstring claimed a
+    token "resolves in exactly one of them and `owner` cannot be ambiguous", and
+    nothing checked that half. Unreachable today; asserted rather than argued,
+    because "unreachable" is exactly what the next token added makes wrong.
     """
-    mine = set(EV.EXIT_CODES.values())
-    theirs = set(RV.EXIT_CODES.values())
-    assert mine and theirs, "one of the tables is empty — the pin is vacuous"
-    assert mine.isdisjoint(theirs), (
-        f"these exit codes are claimed by BOTH verifiers: "
-        f"{sorted(mine & theirs)}. SECRETS.md documents both tables; a shared "
-        f"number means an operator reading a code gets two answers.")
+    mine_v, theirs_v = set(EV.EXIT_CODES.values()), set(RV.EXIT_CODES.values())
+    mine_k, theirs_k = set(EV.EXIT_CODES), set(RV.EXIT_CODES)
+    assert mine_v and theirs_v, "one of the tables is empty — the pin is vacuous"
+    assert mine_v.isdisjoint(theirs_v), (
+        f"these exit CODES are claimed by BOTH verifiers: "
+        f"{sorted(mine_v & theirs_v)}. SECRETS.md documents both tables; a "
+        f"shared number means an operator reading a code gets two answers.")
+    assert mine_k.isdisjoint(theirs_k), (
+        f"these TOKENS are defined by BOTH verifiers: "
+        f"{sorted(mine_k & theirs_k)}. The doc pin merges the two tables with "
+        f"`{{**EV, **RV}}`, so a shared token would be resolved by dict-merge "
+        f"order rather than by ownership.")
 
 
 def test_the_module_hardcodes_no_endpoint_and_no_host():
@@ -3307,8 +3320,11 @@ def test_SECRETS_md_exit_codes_agree_with_the_module():
     and the regex reads the whole file. Pinning against `EV.EXIT_CODES` alone
     made a correctly-documented restore-verify code look like a doc error —
     which would have been "fixed" by deleting the row. The two tables are held
-    disjoint by `test_the_TWO_exit_code_TABLES_never_collide`, so a token
-    resolves in exactly one of them and `owner` cannot be ambiguous.
+    disjoint IN BOTH DIRECTIONS by `test_the_TWO_exit_code_TABLES_never_collide`
+    — codes AND tokens — so a token resolves in exactly one of them and `owner`
+    cannot be ambiguous. That second half was asserted only after this docstring
+    already claimed it: the merge below silently prefers RV on a shared key, so
+    the sentence was true of the intent and not of the code.
     """
     import re
     doc = (ROOT / "SECRETS.md").read_text(encoding="utf-8")

--- a/scripts/tests/test_analyze_service_index_escrow_verify.py
+++ b/scripts/tests/test_analyze_service_index_escrow_verify.py
@@ -2513,6 +2513,25 @@ def test_the_escrow_verifier_REUSES_the_restore_pipeline():
     assert "RV.verify_artifact(" in src
 
 
+def test_the_TWO_exit_code_TABLES_never_collide():
+    """🔴 A SEAM GUARD ON A RELATIONSHIP NEITHER FILE OWNS ALONE.
+
+    SECRETS.md documents both tables, a few paragraphs apart, as the thing an
+    operator maps a number through during a recovery. If `restore-verify.py`
+    ever claims a number this script already uses, that reader gets TWO answers
+    for one code and no way to know which — and each table is individually
+    correct, so neither file's own tests can see it. `restore-verify.py` starts
+    at 40 for exactly this reason; nothing but this assertion holds it there.
+    """
+    mine = set(EV.EXIT_CODES.values())
+    theirs = set(RV.EXIT_CODES.values())
+    assert mine and theirs, "one of the tables is empty — the pin is vacuous"
+    assert mine.isdisjoint(theirs), (
+        f"these exit codes are claimed by BOTH verifiers: "
+        f"{sorted(mine & theirs)}. SECRETS.md documents both tables; a shared "
+        f"number means an operator reading a code gets two answers.")
+
+
 def test_the_module_hardcodes_no_endpoint_and_no_host():
     """🔴 devrc is PUBLIC. The server is read from `bw config server` at run
     time; nothing that looks like an endpoint may be committed here."""
@@ -3282,18 +3301,30 @@ def test_SECRETS_md_exit_codes_agree_with_the_module():
     (code, token) pair the doc DOES list against the module, and requires the
     preflight code to appear. It cannot know which subset of codes the doc
     *ought* to list, so a future code omitted entirely is still invisible here.
+
+    🔴 THE DOC CARRIES TWO TABLES, SO THE EXPECTATION IS THE UNION. SECRETS.md
+    documents `restore-verify.py`'s codes a few paragraphs above this script's,
+    and the regex reads the whole file. Pinning against `EV.EXIT_CODES` alone
+    made a correctly-documented restore-verify code look like a doc error —
+    which would have been "fixed" by deleting the row. The two tables are held
+    disjoint by `test_the_TWO_exit_code_TABLES_never_collide`, so a token
+    resolves in exactly one of them and `owner` cannot be ambiguous.
     """
     import re
     doc = (ROOT / "SECRETS.md").read_text(encoding="utf-8")
     pairs = re.findall(r"\|\s*`(\d+)`\s*`([A-Z][A-Z-]+)`\s*\|", doc)
     assert pairs, "no exit-code rows found — the table moved or changed shape"
+    owner = {**EV.EXIT_CODES, **RV.EXIT_CODES}
     for code, token in pairs:
-        assert token in EV.EXIT_CODES, (
-            f"SECRETS.md documents {token!r}, which the module does not define")
-        assert EV.EXIT_CODES[token] == int(code), (
-            f"SECRETS.md says {token}={code}, module says "
-            f"{EV.EXIT_CODES[token]}")
+        assert token in owner, (
+            f"SECRETS.md documents {token!r}, which NEITHER verifier defines")
+        assert owner[token] == int(code), (
+            f"SECRETS.md says {token}={code}, module says {owner[token]}")
     documented = {t for _, t in pairs}
+    assert "NOTHING-CROSS-CHECKED" in documented, (
+        "restore-verify's zero-cross-check code is undocumented — it is the "
+        "one an operator DURING A RECOVERY will hit, and reading it as 'the "
+        "backups failed' is the whole reason it has its own number")
     assert "DECRYPT-DEPS-MISSING" in documented, (
         "the preflight's code is undocumented — it is the one an operator in "
         "the wrong shell will actually hit")

--- a/scripts/tests/test_analyze_service_index_restore_verify.py
+++ b/scripts/tests/test_analyze_service_index_restore_verify.py
@@ -1116,16 +1116,63 @@ def test_a_PARTIAL_cross_check_EXITS_ZERO_through_the_real_CLI(tmp_path, identit
 #   * a PARTIAL run                        -> the two tests in section 5
 #   * a host that never ran the backup     -> the zero-objects no-op, which
 #                                             returns before any verdict exists
+#
+# 🔴 AND IT IS ITS OWN EXIT CODE, NOT A GENERIC 1. "Your backups restored
+# perfectly, I just could not compare them" and "your backups are broken" call
+# for opposite reactions, and the first is the EXPECTED outcome during a real
+# recovery. That is why the absent-live-scope path was originally left at exit
+# 0, in a docstring that said failing there "would make the verifier useless at
+# the exact moment it is needed" -- a concern this answers rather than overrules.
 # --------------------------------------------------------------------------- #
+
+# 🔴 THE INVARIANT HALF OF THE REFUSAL, PINNED ONCE, WHOLE. The clause that
+# matters most is the FIRST one: it asserts the artifacts themselves verified.
+# Pinned by substring it would still pass if flipped to its opposite -- exactly
+# what shipped in #851 and twice in #765 -- so the template is compared by
+# equality after whitespace normalisation, and each store state supplies its own
+# `where`/`mechanisms` literal below. A cosmetic reword costs a test edit; that
+# is the price of a claim a machine can check.
+_NCC = (
+    "NOTHING-CROSS-CHECKED: {n} artifact(s) under {src} DECRYPTED, RESTORED "
+    "and passed `git fsck`. That much is PROVEN, and it is the good news — "
+    "these objects are readable backups. What did NOT happen is any comparison "
+    "against a live store: zero commits were compared, for every one of them. "
+    "WHY IS NOT DECIDED HERE. The observation is that {where} — and that single "
+    "observation is shared by two mechanisms: {mechanisms}. Nothing measured on "
+    "this run separates them, so neither is asserted. Self-consistency proves "
+    "an object decrypts and restores; it proves NOTHING about whether it still "
+    "matches the history it is a backup OF, and that is the claim this run "
+    "could not make. WHAT TO DO, UNDER EITHER READING: `restore-verify.py "
+    "--print-plan` prints the store path this run used, touching neither the "
+    "network nor the key. If that is not the store you meant, re-run pointing "
+    "at the one you did. If it IS the store you meant, then the live side is "
+    "gone — this code is the EXPECTED outcome during a recovery, not a verdict "
+    "against the backups, and the per-artifact lines above are the evidence "
+    "that they are intact. Scope(s) with no live repository: {scopes}.")
+
+# The mechanism PAIR is chosen by what was observed, and neither member of
+# either pair is asserted. Written out here rather than imported so the test
+# does not derive its expectation from the implementation it tests.
+_MECH_STORE_LEVEL = (
+    "(1) --store names a path that is not this host's store (a typo, a "
+    "different layout, a default that does not apply to this run), or (2) the "
+    "live store is GONE — the disaster these backups exist for")
+_MECH_SCOPE_LEVEL = (
+    "(1) the scope repositor(y/ies) named below were removed or renamed inside "
+    "this store, or (2) --store names a DIFFERENT store that happens to hold "
+    "other scopes")
+
+
+def _norm(s: str) -> str:
+    return " ".join(s.split())
+
+
 def test_a_run_that_CROSS_CHECKS_NOTHING_because_of_the_store_REFUSES(
         tmp_path, identity):
     """🔴 THE F5 REGRESSION GUARD. Red before the fix: this run returned two
     verdicts and raised nothing.
 
-    🔴 THE WHOLE MESSAGE IS PINNED, NORMALISED — not a substring. A clause
-    pinned by substring has twice shipped in this repo asserting the OPPOSITE of
-    what the code does and passed the entire suite (#851, #765). A cosmetic
-    reword costs this literal; that price buys a machine-readable claim.
+    Pins the EMPTY-store wording whole, plus the token and the derived code.
     """
     store = tmp_path / "store"          # exists, holds NO scope repository
     store.mkdir()
@@ -1138,49 +1185,186 @@ def test_a_run_that_CROSS_CHECKS_NOTHING_because_of_the_store_REFUSES(
     with pytest.raises(RV.RestoreVerifyError) as ei:
         _verify(store, tmp_path / "work", FakeDownloader(objects), identity)
 
-    expected = (
-        f"1 artifact/scope check(s) FAILED; 2 verified. First failure: "
-        f"NOTHING WAS CROSS-CHECKED AGAINST THE LIVE STORE. All 2 artifact(s) "
-        f"under test-bucket/{PREFIX} are THIS machine's, and every one of them "
-        f"was verified for SELF-CONSISTENCY ONLY, because the store side "
-        f"contributed nothing: the store directory {store} EXISTS but holds NO "
-        f"scope repositories. Scope(s) with no live repository: "
-        f"['scope-alpha', 'scope-beta']. Self-consistency proves the object "
-        f"decrypts and restores; it proves NOTHING about whether it still "
-        f"matches the history it is a backup OF, and zero commits were compared "
-        f"on this run. Exiting non-zero because an exit code is all a timer "
-        f"reads. Point --store at the live store, or fix it. Verifying ANOTHER "
-        f"host's artifacts is the one case where zero cross-checks is correct, "
-        f"and this is not it.")
-    assert " ".join(str(ei.value).split()) == " ".join(expected.split())
+    assert ei.value.token == RV.NOTHING_CROSS_CHECKED, (
+        "the refusal is unclassified, so it exits 1 and is indistinguishable "
+        "from a backup that failed to verify")
+    assert ei.value.exit_code == 40
+    expected = _NCC.format(
+        n=2, src=f"test-bucket/{PREFIX}",
+        where=f"the store directory {store} EXISTS but holds NO scope "
+              f"repositories",
+        mechanisms=_MECH_STORE_LEVEL,
+        scopes="['scope-alpha', 'scope-beta']")
+    assert _norm(str(ei.value)) == _norm(expected)
 
 
-def test_the_STORE_refusal_reaches_the_PROCESS_EXIT_CODE(tmp_path, identity):
-    """The library raising is not the same claim as the PROCESS exiting non-zero,
-    and the exit code is the entire reason this defect matters: it is all a
-    systemd timer ever reads.
+def test_the_STORE_refusal_reaches_the_PROCESS_EXIT_CODE_as_FORTY(
+        tmp_path, identity):
+    """🔴 THE DISASTER CASE — restored from the test this fix originally deleted.
 
-    🔴 `subprocess.run` is read directly. `$?` after a pipe reports the PIPE's
-    status — that is exactly how a real rc=34 read as rc=0 on this host.
+    That test was `test_an_absent_live_scope_verifies_SELF_CONSISTENCY_and_says_
+    so`, and its 🔴 docstring was an explicit design decision:
+
+        "If the store is gone there is nothing to cross-check against — which is
+         the scenario these backups exist for. FAILING HERE WOULD MAKE THE
+         VERIFIER USELESS AT THE EXACT MOMENT IT IS NEEDED."
+
+    That concern is real and is NOT obsolete. What is obsolete is the conclusion
+    that exit 0 is how to honour it: exit 0 is what a timer reads as "the
+    backups are fine", which is a claim this run could not make. The concern is
+    answered instead by a DISTINCT code (40, never the generic 1), a message
+    that leads with what was proven, and per-artifact output that is unchanged.
+
+    🔴 The exit code is read from `subprocess.run` directly. `$?` after a pipe
+    reports the PIPE's status — that is exactly how a real rc=34 read as rc=0
+    on this host.
     """
     scope = _make_scope(tmp_path / "elsewhere", "scope-alpha", {"e.md": "x"},
                         commits=4)
     src = _dir_store(tmp_path / "objects",
                      {_key("scope-alpha"): _make_artifact(scope, identity,
                                                           tmp_path)})
+    gone = tmp_path / "gone"
 
     r = _cli("--from-dir", str(src), "--prefix", HOST,
-             "--store", str(tmp_path / "gone"), "--max-lag-days", "100000",
+             "--store", str(gone), "--max-lag-days", "100000",
              identity=identity)
-    assert r.returncode != 0, (
-        f"the process exited 0 having compared NOTHING against the live "
-        f"store:\n{r.stdout}\n{r.stderr}")
-    assert "NOTHING WAS CROSS-CHECKED AGAINST THE LIVE STORE" in r.stderr, (
-        f"non-zero for some OTHER reason — a control that goes red because a "
-        f"different guard fired is green for the wrong reason:\n{r.stderr}")
-    assert f"the store directory {tmp_path / 'gone'} DOES NOT EXIST" in r.stderr, (
-        f"the refusal does not name the store it looked at, so the operator "
-        f"cannot tell a typo from a disaster:\n{r.stderr}")
+    assert r.returncode == 40, (
+        f"expected the classified NOTHING-CROSS-CHECKED code; a bare 1 tells an "
+        f"operator mid-disaster their backups are broken, and a 0 tells a timer "
+        f"they were verified:\n{r.stdout}\n{r.stderr}")
+
+    expected = _NCC.format(
+        n=1, src=f"{src}/{PREFIX}",
+        where=f"the store directory {gone} DOES NOT EXIST",
+        mechanisms=_MECH_STORE_LEVEL, scopes="['scope-alpha']")
+    assert _norm(expected) in _norm(r.stderr), (
+        f"the refusal's wording changed. Re-read it before updating the "
+        f"literal: it must NAME BOTH mechanisms and assert neither, and it must "
+        f"say the artifacts themselves verified.\n{r.stderr}")
+
+    # The per-artifact evidence the original test protected is still printed —
+    # that is what makes the non-zero exit readable rather than alarming.
+    assert "RESTORED 4 commit(s)" in r.stdout and "fsck OK" in r.stdout, r.stdout
+
+
+def test_a_SCOPE_FILTER_that_compares_NOTHING_gets_the_SAME_code(
+        tmp_path, identity):
+    """🔴 NARROWING THE QUESTION DOES NOT MAKE THE ANSWER DECIDABLE.
+
+    `--scope` selects one scope of THIS host's artifacts; if that scope has no
+    live repository, zero commits were compared and the run must not report
+    success. The store here is POPULATED — it holds a different scope — so the
+    rival mechanisms are the scope-level pair, not the store-level one: a store
+    that is plainly there cannot be blamed on `--store` pointing at nothing.
+    """
+    store = tmp_path / "store"
+    _make_scope(store, "scope-beta", {"e.md": "b"}, commits=2)
+    alpha = _make_scope(tmp_path / "elsewhere", "scope-alpha", {"e.md": "a"},
+                        commits=3)
+    objects = {_key("scope-alpha"): _make_artifact(alpha, identity, tmp_path)}
+
+    with pytest.raises(RV.RestoreVerifyError) as ei:
+        _verify(store, tmp_path / "work", FakeDownloader(objects), identity,
+                scope_filter="scope-alpha")
+
+    assert ei.value.exit_code == 40, ei.value.token
+    expected = _NCC.format(
+        n=1, src=f"test-bucket/{PREFIX}",
+        where=f"the store {store} holds 1 scope repository (['scope-beta']), "
+              f"none of which is one of the artifact scope(s) verified here",
+        mechanisms=_MECH_SCOPE_LEVEL, scopes="['scope-alpha']")
+    assert _norm(str(ei.value)) == _norm(expected)
+
+
+def test_a_REAL_failure_OUTRANKS_the_NOTHING_CROSS_CHECKED_code(
+        tmp_path, identity, capsys):
+    """🔴 40 IS RAISED ONLY WHEN IT IS THE WHOLE STORY.
+
+    A corrupt artifact beside a store that offers nothing satisfies every
+    condition for 40 — and a timer that saw 40 there would read "just a store
+    problem" for a backup that did not restore. That is the same conflation this
+    round is fixing, pointed the other way, so the generic failure wins and 40
+    is withheld.
+
+    Reached with a case no earlier check rejects: `scope-beta` verifies fine, so
+    verdicts is non-empty and the guard's own conditions are all met.
+    """
+    store = tmp_path / "store"
+    store.mkdir()                       # exists, holds NO scope repository
+    elsewhere = tmp_path / "elsewhere"
+    alpha = _make_scope(elsewhere, "scope-alpha", {"e.md": "a"}, commits=3)
+    beta = _make_scope(elsewhere, "scope-beta", {"e.md": "b"}, commits=2)
+    objects = {
+        _key("scope-alpha"): _make_artifact(alpha, identity, tmp_path,
+                                            mangle=_flip_middle_byte),
+        _key("scope-beta"): _make_artifact(beta, identity, tmp_path),
+    }
+
+    with pytest.raises(RV.RestoreVerifyError) as ei:
+        _verify(store, tmp_path / "work", FakeDownloader(objects), identity)
+
+    assert ei.value.token is None, (
+        "a corrupt artifact was reported with the code that means 'the backups "
+        "are fine, I just could not compare them'")
+    assert ei.value.exit_code == 1
+    assert "1 artifact/scope check(s) FAILED" in str(ei.value), str(ei.value)
+    # It is still REPORTED — withholding the code must not withhold the finding.
+    assert "NOTHING-CROSS-CHECKED" in capsys.readouterr().err
+
+
+def test_the_exit_code_table_is_pinned_EXACTLY_both_ways():
+    """🔴 DISTINGUISHABLE CAUSES ARE THE DELIVERABLE, so the token->code map is
+    an EXACT dict of literals — the same pin `escrow-verify.py` carries, for the
+    same reason it gives: "every cause has its own exit code, so a timer can act
+    on the number". Silently reusing a code cannot happen unnoticed.
+    """
+    assert RV.EXIT_CODES == {"NOTHING-CROSS-CHECKED": 40}
+    assert RV.EXIT_OK == 0 and RV.EXIT_FAILED == 1
+    codes = list(RV.EXIT_CODES.values())
+    assert len(set(codes)) == len(codes), "two tokens share an exit code"
+    assert 0 not in codes and 1 not in codes, (
+        "a classified cause collides with success or with the generic failure, "
+        "which is the conflation the table exists to remove")
+
+
+def test_an_unknown_token_CANNOT_be_raised():
+    """The code is DERIVED from the token, so a refusal cannot carry the wrong
+    one — and a token with no table entry is a programming error, loudly.
+
+    🔴 THE MESSAGE IS PINNED, NOT JUST THE EXCEPTION TYPE, and a mutation sweep
+    is why. Deleting the explicit check leaves `EXIT_CODES[token]` on the next
+    line to raise `KeyError` by itself, so `pytest.raises(KeyError)` alone
+    stayed GREEN with the guard removed — green for a DIFFERENT guard's error,
+    which is the failure RULES.md names. The explicit check earns its place by
+    what it SAYS (a bare `KeyError('X')` explains nothing to whoever added the
+    token), so what it says is what gets asserted.
+    """
+    with pytest.raises(KeyError) as ei:
+        RV.RestoreVerifyError("x", token="NOT-A-REAL-TOKEN")
+    assert " ".join(ei.value.args[0].split()) == " ".join((
+        "'NOT-A-REAL-TOKEN' is not in EXIT_CODES. A classified refusal is an "
+        "ENUMERATED cause with its own exit code and its own remedy; adding one "
+        "means adding it to the table in the same commit as the test that pins "
+        "it.").split()), ei.value.args[0]
+    # POSITIVE CONTROL: the real token constructs, and brings its own code.
+    assert RV.RestoreVerifyError("x", token=RV.NOTHING_CROSS_CHECKED
+                                 ).exit_code == 40
+    # An UNCLASSIFIED refusal is the generic code, never a classified one.
+    assert RV.RestoreVerifyError("x").token is None
+    assert RV.RestoreVerifyError("x").exit_code == RV.EXIT_FAILED
+
+
+def test_print_plan_LISTS_every_classified_code(tmp_path, identity):
+    """The refusal's remedy sends the operator to `--print-plan`, so the code
+    they are holding has to be mappable there — escrow-verify's convention, and
+    the reason it prints its own table."""
+    r = _cli("--print-plan", "--store", str(tmp_path / "store"),
+             identity=identity)
+    assert r.returncode == 0, r.stderr
+    for token, code in RV.EXIT_CODES.items():
+        assert token in r.stdout, f"{token} is not listed in --print-plan"
+        assert str(code) in r.stdout, f"{code} is not listed in --print-plan"
 
 
 def test_a_BROKEN_artifact_beside_a_LIVE_target_is_not_blamed_on_the_store(
@@ -1215,7 +1399,11 @@ def test_a_BROKEN_artifact_beside_a_LIVE_target_is_not_blamed_on_the_store(
     assert "FAILED scope-alpha" in err, (
         f"the corrupt artifact was not the recorded failure, so this fixture "
         f"is not exercising what it claims:\n{err}")
-    assert "NOTHING WAS CROSS-CHECKED AGAINST THE LIVE STORE" not in err, (
+    # 🔴 The token, not the sentence. An absence assertion on prose that no
+    # longer exists anywhere passes vacuously; `NOTHING-CROSS-CHECKED` is the
+    # machine-readable name and `test_a_REAL_failure_OUTRANKS_...` is the
+    # positive control proving this string CAN appear on stderr.
+    assert RV.NOTHING_CROSS_CHECKED not in err, (
         f"a corrupt artifact was reported as a STORE problem — the store held "
         f"a live scope-alpha and offered a comparison:\n{err}")
 
@@ -1239,7 +1427,11 @@ def test_a_run_that_verified_ZERO_artifacts_is_not_called_a_store_problem(
 
     err = capsys.readouterr().err
     assert "FAILED scope-alpha" in err, err
-    assert "NOTHING WAS CROSS-CHECKED AGAINST THE LIVE STORE" not in err, (
+    # 🔴 The token, not the sentence. An absence assertion on prose that no
+    # longer exists anywhere passes vacuously; `NOTHING-CROSS-CHECKED` is the
+    # machine-readable name and `test_a_REAL_failure_OUTRANKS_...` is the
+    # positive control proving this string CAN appear on stderr.
+    assert RV.NOTHING_CROSS_CHECKED not in err, (
         f"a run that verified ZERO artifacts announced that all zero of them "
         f"were self-consistency only:\n{err}")
     assert "All 0 artifact(s)" not in err, err
@@ -3345,26 +3537,56 @@ def test_SECRETS_md_documents_the_ZERO_CROSS_CHECK_refusal_WORD_FOR_WORD():
     recipe = doc.split("**Restoring**", 1)[1].split("\n## ", 1)[0]
     expected = (
         "🔴 **A run of THIS host's artifacts in which NOT ONE scope could be "
-        "compared FAILS.** Measured 2026-08-26: `--host <this host> --store <an "
-        "empty directory>` printed every scope as `NOT CROSS-CHECKED … "
-        "self-consistency only` and exited **0** — an exit code is all a systemd "
-        "timer reads, so a wrong or absent `--store` silently downgraded the "
-        "whole run to \"the object decrypts and is internally consistent\", "
-        "which says nothing about whether it still matches the history it is a "
-        "backup of. It now exits non-zero and names the store it looked at, "
-        "distinguishing a store that **does not exist** from one that exists and "
-        "is **empty** from one that holds scopes but not this one. Two "
-        "zero-cross-check runs are deliberately still rc=0: **another host's** "
-        "artifacts (suppressing the comparison there is correct), and a "
-        "**partial** run where at least one scope did compare. So on a "
-        "disaster-recovery machine with no store yet, expect a non-zero exit — "
-        "read the per-artifact lines, which still say each artifact restored and "
-        "passed `fsck`.")
+        "compared exits `40`, and `40` IS NOT A VERDICT AGAINST YOUR BACKUPS.** "
+        "Every cause has its own exit code here for the same reason "
+        "`escrow-verify.py` gives below — so a timer can act on the number, and "
+        "so an operator mid-recovery is not told the wrong thing:\n"
+        "\n"
+        "| code | meaning | what to do |\n"
+        "|---|---|---|\n"
+        "| `0` | verified, and cross-checked against the live store | nothing |\n"
+        "| `40` `NOTHING-CROSS-CHECKED` | every artifact **decrypted, restored "
+        "and passed `git fsck`** — and **none** was compared to a live store | "
+        "**not an alarm about the backups.** `--print-plan` shows the store path "
+        "this run used: if it is not the one you meant, re-run pointing at the "
+        "right one; if it *is*, the live store is gone and this is the "
+        "**expected** code during a recovery — the per-artifact lines are your "
+        "evidence the backups are intact |\n"
+        "| `1` | a check **FAILED** — an artifact did not decrypt, did not "
+        "restore, failed `fsck`, is stale, or a scope has no artifact at all | "
+        "this one *is* about the backups; read the first failure |\n"
+        "\n"
+        "Measured 2026-08-26: `--host <this host> --store <an empty directory>` "
+        "printed every scope as `NOT CROSS-CHECKED … self-consistency only` and "
+        "exited **0** — an exit code is all a systemd timer reads, so a wrong or "
+        "absent `--store` silently downgraded the whole run to \"the object "
+        "decrypts and is internally consistent\", which says nothing about "
+        "whether it still matches the history it is a backup of.\n"
+        "\n"
+        "🔴 **`40`'s message names BOTH mechanisms and asserts NEITHER.** \"You "
+        "pointed at the wrong store\" and \"the store is genuinely gone\" are the "
+        "*same observation*, and nothing in the run separates them — so it says "
+        "so, and its remedy works under either reading. It does name which of "
+        "three store states it saw: the directory **does not exist**, it exists "
+        "and holds **no scope repositories**, or it holds scopes but **not this "
+        "one** (that third case gets a different mechanism pair — a store that "
+        "is plainly there cannot be blamed on `--store` naming nothing). A real "
+        "failure **outranks** `40`: a corrupt artifact beside an absent store "
+        "exits `1`, because the louder finding must not be filed as a store "
+        "problem.\n"
+        "\n"
+        "Two zero-cross-check runs are deliberately still `0`: **another "
+        "host's** artifacts (suppressing the comparison there is correct — see "
+        "the three `NOT CROSS-CHECKED` reasons above), and a **partial** run "
+        "where at least one scope did compare.")
     assert " ".join(expected.split()) in " ".join(recipe.split()), (
         "SECRETS.md's restore recipe no longer carries the zero-cross-check "
-        "paragraph verbatim. If you reworded it deliberately, update this "
-        "literal — but re-read it first: the claim it makes is that the run "
-        "FAILS, and the previous behaviour was exit 0.")
+        "section verbatim. If you reworded it deliberately, update this literal "
+        "— but re-read it first. Two claims in it are the ones a reword flips "
+        "silently: that `40` is NOT an alarm about the backups (it was exit 0 "
+        "until 2026-08-26, and a doc that says so again sends a recovering "
+        "operator to distrust a working tool), and that a real failure OUTRANKS "
+        "it.")
 
 
 def test_the_PRODUCER_points_at_the_verifier_for_the_downstream_half():

--- a/scripts/tests/test_analyze_service_index_restore_verify.py
+++ b/scripts/tests/test_analyze_service_index_restore_verify.py
@@ -46,6 +46,7 @@ wrong reason and stays green with the guard it claims to test deleted.
 """
 from __future__ import annotations
 
+import ast
 import hashlib
 import importlib.util
 from testlib import hermetic_git  # noqa: E402
@@ -1539,7 +1540,11 @@ def test_the_count_is_ARTIFACTS_not_SCOPES(tmp_path, identity):
     """
     store = tmp_path / "store"
     store.mkdir()                                  # exists, holds no repository
-    now = datetime.now(timezone.utc)
+    # The FROZEN clock every other fixture uses, not wall-clock: the run's `now`
+    # is threaded through `_verify`, so this was harmless — but a test whose
+    # inputs move with the wall clock is one whose failures are not reproducible
+    # from the recorded sha, and this file has one convention for that.
+    now = NOW
     alpha = _make_scope(tmp_path / "elsewhere", "scope-alpha", {"e.md": "a"},
                         commits=5)
     objects = {
@@ -1570,7 +1575,7 @@ def test_the_count_is_ARTIFACTS_not_SCOPES(tmp_path, identity):
         "above cannot see the difference")
 
 
-def test_a_kind_OUTSIDE_the_ledger_CANNOT_be_returned(tmp_path):
+def test_a_kind_OUTSIDE_the_ledger_CANNOT_be_returned():
     """🔴 THE LEDGER PIN SAYS NOTHING ABOUT WHAT THE FUNCTION RETURNS.
 
     `_MECHANISMS` is pinned key-for-key against `WHY_KINDS`, and that guard is
@@ -1598,15 +1603,36 @@ def test_a_kind_OUTSIDE_the_ledger_CANNOT_be_returned(tmp_path):
 
     # And the guard is REACHED by the real function on every branch — a check
     # that only the helper enforces would be bypassed by a branch that returns
-    # a bare tuple. Asserted structurally, since a sixth branch is the hazard.
-    body = SCRIPT.read_text(encoding="utf-8").split(
-        "def why_no_live_scope(", 1)[1].split("\ndef ", 1)[0]
-    returns = [ln.strip() for ln in body.splitlines()
-               if ln.strip().startswith("return ")]
-    assert returns, "why_no_live_scope has no returns — this pin is vacuous"
-    assert all(r.startswith("return _why(") for r in returns), (
-        f"a branch of why_no_live_scope returns without going through _why(), "
-        f"so its kind is unchecked: {[r for r in returns if not r.startswith('return _why(')]}")
+    # a bare tuple.
+    #
+    # 🔴 PARSED, NOT SPELLED. This was a line scan for text starting with
+    # `"return "`, and TWO valid, lint-clean bypassing spellings survived a
+    # fully green suite:
+    #
+    #     if scope == "sixth": return "scope-sixth", "x"   # same-line body
+    #     return("scope-sixth", "x")                        # no space
+    #
+    # There is no Python linter anywhere in the gate (zero hits for
+    # ruff/flake8/pylint/pycodestyle in gate.sh, run-tests.sh, flake.nix), so
+    # nothing else refused either spelling. A guard on WORDS is walkable by
+    # REWORDING; this asks the AST what the code IS. It also retires the
+    # `split("\ndef ")` body extraction, which a nested def or a docstring
+    # containing that text would have silently truncated.
+    fn = next((n for n in ast.walk(ast.parse(SCRIPT.read_text(encoding="utf-8")))
+               if isinstance(n, ast.FunctionDef) and n.name == "why_no_live_scope"),
+              None)
+    assert fn is not None, (
+        "why_no_live_scope was not found in the AST — this pin is vacuous")
+    returns = [n for n in ast.walk(fn) if isinstance(n, ast.Return)]
+    assert returns, "why_no_live_scope has no return statements — pin is vacuous"
+    bypassing = [ast.unparse(n) for n in returns
+                 if not (isinstance(n.value, ast.Call)
+                         and isinstance(n.value.func, ast.Name)
+                         and n.value.func.id == "_why")]
+    assert not bypassing, (
+        f"a branch of why_no_live_scope returns WITHOUT going through _why(), "
+        f"so its kind is unchecked and a sixth branch would KeyError inside "
+        f"the refusal an operator reads during a recovery: {bypassing}")
 
 
 def test_the_MECHANISM_ledger_is_pinned_two_way_to_WHY_KINDS():
@@ -1694,45 +1720,20 @@ def test_print_plan_LISTS_every_classified_code(tmp_path, identity):
             f"the number cannot map it:\n{r.stdout}")
 
 
-def test_print_plan_PROSE_never_contradicts_the_FORTY_framing(
-        tmp_path, identity):
-    """🔴 THE #851 TRAP, REPRODUCED INSIDE THE FIX FOR IT.
-
-    A previous round pinned `nothing_cross_checked_message` whole and left
-    `--print-plan`'s prose — added in the SAME commit, carrying the SAME
-    load-bearing claim — unpinned. An auditor rewrote the exit block to "40 IS a
-    verdict against the backups: NO artifact restored and FAILED fsck … It is
-    NEVER the expected code" and the suite stayed FULLY GREEN. The `compare:`
-    tail was worse than unpinned: it still said the run "FAILS", twelve lines
-    above the block saying 40 is not a verdict, and the refusal's own remedy
-    routes a recovering operator to this exact screen.
-
-    🔴 THE WHOLE RENDERED PLAN IS PINNED, NOT THE TWO BLOCKS THAT CARRY THE
-    CLAIM. Pinning the blocks left the obvious hole: a NEW paragraph elsewhere
-    on this screen asserting the opposite ("exit 40 DOES mean your backups are
-    broken") satisfied both `in` checks and survived. An operator reads the
-    screen, not the block, so the screen is the unit.
-
-    Every environment-dependent field is supplied BY THIS TEST (bucket, prefix,
-    store, identity, max-lag) so nothing here is derived from the implementation
-    — except the machine id, which is REDACTED by regex rather than pinned:
-    devrc is a public repo and the real id must never be committed.
-    """
-    store = tmp_path / "store"
-    ident = tmp_path / "ID.key"
-    r = _cli("--print-plan", "--bucket", "test-bucket", "--store", str(store),
-             "--identity", str(ident), "--max-lag-days", "3.0",
-             identity=identity)
-    assert r.returncode == 0, r.stderr
-    got = _norm(re.sub(r"machine-id (?:[0-9a-f]{32}|UNREADABLE)",
-                       "machine-id <redacted>", r.stdout))
-    expected = _norm(f"""
+# 🔴 THE PLAN AS RENDERED, PINNED WHOLE — the SHARED body, with the trailing
+# `local:` line supplied per case. `print_plan` RETURNS EARLY on an empty store
+# (restore-verify.py, `if not scopes: … return`), so a pin taken only against an
+# empty store leaves everything past that line unpinned: appending a
+# contradicting paragraph after the POPULATED `local:` loop survived a fully
+# green suite. Two cases, both by equality, is what closes the healthy-host
+# screen as well as the recovery one.
+_PLAN_BODY = """\
 source:    test-bucket
-prefix:    {PREFIX}
+prefix:    {prefix}
 store:     {store}
 identity:  {ident} (MISSING)
 chosen by: the --identity flag  <- NOT the default identity
-host:      {HOST} (machine-id <redacted>) -> these artifacts are THIS host's: they WILL be cross-checked
+host:      {host} (machine-id <redacted>) -> these artifacts are THIS host's: they WILL be cross-checked
 scope:     (every scope found under the prefix)
 artifacts: newest per scope
 max lag:   3.0 day(s) — older than this is a FAILURE
@@ -1765,16 +1766,96 @@ coverage:  every LOCAL scope must have at least one artifact. A scope
            red gate. Skipped under --scope or an explicit --host.
 writes:    NOTHING to the store, NOTHING to the bucket. The store is
            read through an allowlist of read-only subcommands.
-local:     (no scope repositories under {store})
-""")
+{tail}"""
+
+
+def _rendered_plan(store: Path, ident: Path, identity: Path) -> tuple[str, str]:
+    """`(normalised stdout, raw stdout)` for `--print-plan` over `store`.
+
+    🔴 The machine id is REDACTED, never pinned: devrc is public. It is redacted
+    in the RAW copy too, because that copy is what a failure message prints into
+    the run log — the committed file being clean is not the whole claim.
+    """
+    r = _cli("--print-plan", "--bucket", "test-bucket", "--store", str(store),
+             "--identity", str(ident), "--max-lag-days", "3.0",
+             identity=identity)
+    assert r.returncode == 0, r.stderr
+    safe = re.sub(r"machine-id (?:[0-9a-f]{32}|UNREADABLE)",
+                  "machine-id <redacted>", r.stdout)
+    return _norm(safe), safe
+
+
+_PLAN_WHY = (
+    "Re-read it before updating this literal — TWO claims on this screen invert "
+    "silently under a reword, and this is the screen the refusal sends a "
+    "recovering operator to: that a run comparing nothing exits 40 and NOT 0, "
+    "and that 40 is NOT a verdict against the backups. The WHOLE screen is "
+    "pinned, because pinning only the blocks carrying those claims let a "
+    "CONTRADICTING paragraph be added elsewhere on it.")
+
+
+def test_print_plan_PROSE_never_contradicts_the_FORTY_framing(
+        tmp_path, identity):
+    """🔴 THE #851 TRAP, REPRODUCED INSIDE THE FIX FOR IT — the RECOVERY screen.
+
+    A previous round pinned `nothing_cross_checked_message` whole and left
+    `--print-plan`'s prose — added in the SAME commit, carrying the SAME
+    load-bearing claim — unpinned. An auditor rewrote the exit block to "40 IS a
+    verdict against the backups: NO artifact restored and FAILED fsck … It is
+    NEVER the expected code" and the suite stayed FULLY GREEN. The `compare:`
+    tail was worse than unpinned: it still said the run "FAILS", twelve lines
+    above the block saying 40 is not a verdict.
+
+    Pinning the two BLOCKS was still not enough: a new paragraph ELSEWHERE on
+    the screen asserting the opposite satisfied both `in` checks and survived.
+    An operator reads the screen, not the block, so the screen is the unit.
+
+    This case renders the EMPTY-store screen — the one a recovering operator
+    sees. `test_print_plan_on_a_POPULATED_store_is_pinned_WHOLE_too` covers the
+    rest, which this case structurally cannot reach.
+    """
+    store = tmp_path / "store"
+    ident = tmp_path / "ID.key"
+    got, raw = _rendered_plan(store, ident, identity)
+    expected = _norm(_PLAN_BODY.format(
+        prefix=PREFIX, store=store, ident=ident, host=HOST,
+        tail=f"local:     (no scope repositories under {store})\n"))
     assert got == expected, (
-        f"the rendered --print-plan changed. Re-read it before updating this "
-        f"literal — TWO claims on this screen invert silently under a reword, "
-        f"and this is the screen the refusal sends a recovering operator to: "
-        f"that a run comparing nothing exits 40 and NOT 0, and that 40 is NOT a "
-        f"verdict against the backups. The whole screen is pinned because "
-        f"pinning only the blocks that carry those claims let a CONTRADICTING "
-        f"paragraph be added elsewhere.\n--- got ---\n{r.stdout}")
+        f"the rendered --print-plan (empty store) changed. {_PLAN_WHY}\n"
+        f"--- got ---\n{raw}")
+
+
+def test_print_plan_on_a_POPULATED_store_is_pinned_WHOLE_too(
+        tmp_path, identity):
+    """🔴 THE FIRST WHOLE-PLAN PIN COVERED ONE RENDERING OF TWO.
+
+    `print_plan` RETURNS EARLY when the store holds no scope repositories, and
+    the pin above uses a store that does not exist — so everything the function
+    prints AFTER that early return was unpinned. Measured: appending
+    `print("note: exit 40 DOES mean your backups are broken.")` after the
+    populated `local:` loop SURVIVED a fully green suite. The healthy-host
+    screen was reachable only through `in`-substring assertions, which is the
+    exact pattern this delta exists to retire.
+
+    One scope, one commit, so the `local:` line is deterministic.
+    """
+    store = tmp_path / "store"
+    _make_scope(store, "scope-alpha", {"e.md": "a"}, commits=1)
+    ident = tmp_path / "ID.key"
+    got, raw = _rendered_plan(store, ident, identity)
+    expected = _norm(_PLAN_BODY.format(
+        prefix=PREFIX, store=store, ident=ident, host=HOST,
+        tail=(f"local:     scope-alpha (1 commits) -> would compare against "
+              f"{PREFIX}scope-alpha/<newest>\n")))
+    assert got == expected, (
+        f"the rendered --print-plan (populated store) changed. {_PLAN_WHY}\n"
+        f"--- got ---\n{raw}")
+
+    # POSITIVE CONTROL on the fixture: this case really does render the branch
+    # the other one cannot reach, so it is not a second copy of the same screen.
+    assert "no scope repositories under" not in raw, (
+        "the store is empty, so this case took the early return and covers the "
+        "same rendering as the case above — the populated tail is still unpinned")
 
 
 # `argparse` is constructed with `description=__doc__`, so the module docstring

--- a/scripts/tests/test_analyze_service_index_restore_verify.py
+++ b/scripts/tests/test_analyze_service_index_restore_verify.py
@@ -1133,34 +1133,52 @@ def test_a_PARTIAL_cross_check_EXITS_ZERO_through_the_real_CLI(tmp_path, identit
 # `where`/`mechanisms` literal below. A cosmetic reword costs a test edit; that
 # is the price of a claim a machine can check.
 _NCC = (
-    "NOTHING-CROSS-CHECKED: {n} artifact(s) under {src} DECRYPTED, RESTORED "
-    "and passed `git fsck`. That much is PROVEN, and it is the good news — "
-    "these objects are readable backups. What did NOT happen is any comparison "
-    "against a live store: zero commits were compared, for every one of them. "
-    "WHY IS NOT DECIDED HERE. The observation is that {where} — and that single "
-    "observation is shared by two mechanisms: {mechanisms}. Nothing measured on "
-    "this run separates them, so neither is asserted. Self-consistency proves "
-    "an object decrypts and restores; it proves NOTHING about whether it still "
-    "matches the history it is a backup OF, and that is the claim this run "
-    "could not make. WHAT TO DO, UNDER EITHER READING: `restore-verify.py "
-    "--print-plan` prints the store path this run used, touching neither the "
-    "network nor the key. If that is not the store you meant, re-run pointing "
-    "at the one you did. If it IS the store you meant, then the live side is "
-    "gone — this code is the EXPECTED outcome during a recovery, not a verdict "
-    "against the backups, and the per-artifact lines above are the evidence "
-    "that they are intact. Scope(s) with no live repository: {scopes}.")
+    "NOTHING-CROSS-CHECKED: all {n} artifact(s) this run verified ({scanned}) "
+    "DECRYPTED, RESTORED and passed `git fsck`. That much is PROVEN, and it is "
+    "the good news — these objects are readable backups. What did NOT happen is "
+    "any comparison against a live store: zero commits were compared, for every "
+    "one of them. WHY IS NOT DECIDED HERE. What was observed is: {observed}. "
+    "That is consistent with AT LEAST these mechanisms, and the list is NOT "
+    "closed: {mechanisms}. Nothing measured on this run separates them, so none "
+    "of them is asserted. Self-consistency proves an object decrypts and "
+    "restores; it proves NOTHING about whether it still matches the history it "
+    "is a backup OF, and that is the claim this run could not make. WHAT TO DO: "
+    "the store this run looked at is {store} — it is named above, so no second "
+    "command is needed to find it. If that is not the store you meant, re-run "
+    "with --store pointing at the one you did. If it IS the store you meant, "
+    "then something on the LIVE side is missing or unreachable, which is what "
+    "these backups are for: this code is the EXPECTED outcome during a "
+    "recovery, not a verdict against the backups, and the per-artifact lines "
+    "above are the evidence that they are intact. `restore-verify.py "
+    "--print-plan` WITH THE SAME FLAGS re-prints this run's settings and "
+    "touches neither the network nor the key. Scope(s) with no live "
+    "repository: {scopes}.")
 
-# The mechanism PAIR is chosen by what was observed, and neither member of
-# either pair is asserted. Written out here rather than imported so the test
-# does not derive its expectation from the implementation it tests.
-_MECH_STORE_LEVEL = (
-    "(1) --store names a path that is not this host's store (a typo, a "
-    "different layout, a default that does not apply to this run), or (2) the "
-    "live store is GONE — the disaster these backups exist for")
-_MECH_SCOPE_LEVEL = (
-    "(1) the scope repositor(y/ies) named below were removed or renamed inside "
-    "this store, or (2) --store names a DIFFERENT store that happens to hold "
-    "other scopes")
+# 🔴 THE MECHANISM LIST IS OPEN AND DERIVED FROM WHAT WAS OBSERVED. A CLOSED
+# two-way choice is a claim about what CANNOT be true, and it was FALSE for two
+# reachable states: a scope that is a SYMLINK and a scope directory with no
+# `.git` both reached exit 40 offering only "--store is wrong" or "the store is
+# GONE", when the repository was right there and --store was correct. Written
+# out here rather than imported so the test does not derive its expectation
+# from the implementation it tests.
+_M_STORE_WRONG = ("--store names a path that is not this host's store (a typo, "
+                  "a different layout, a default that does not apply to this "
+                  "run)")
+_M_STORE_GONE = "the live store is GONE — the disaster these backups exist for"
+_M_SYMLINK = ("the scope path IS present but is a SYMLINK, which is never "
+              "followed here — the repository it points at may be perfectly "
+              "intact, and --store may be exactly right")
+_M_NOT_A_REPO = ("the scope path IS present but carries no .git — an "
+                 "interrupted move, or a repository that lost it; --store may "
+                 "be exactly right")
+_M_REMOVED = ("the scope repositor(y/ies) named below were removed, RENAMED, "
+              "or never created in this store")
+_M_DIFFERENT_STORE = ("--store names a DIFFERENT store that happens to hold "
+                      "other scopes")
+
+
+def _numbered(*mechanisms: str) -> str:
+    return "; ".join(f"({i}) {m}" for i, m in enumerate(mechanisms, 1))
 
 
 def _norm(s: str) -> str:
@@ -1190,10 +1208,10 @@ def test_a_run_that_CROSS_CHECKS_NOTHING_because_of_the_store_REFUSES(
         "from a backup that failed to verify")
     assert ei.value.exit_code == 40
     expected = _NCC.format(
-        n=2, src=f"test-bucket/{PREFIX}",
-        where=f"the store directory {store} EXISTS but holds NO scope "
-              f"repositories",
-        mechanisms=_MECH_STORE_LEVEL,
+        n=2, scanned=f"every scope under test-bucket/{PREFIX}",
+        observed=f"the store directory {store} EXISTS but holds NO scope "
+                 f"repositories",
+        mechanisms=_numbered(_M_STORE_WRONG, _M_STORE_GONE), store=store,
         scopes="['scope-alpha', 'scope-beta']")
     assert _norm(str(ei.value)) == _norm(expected)
 
@@ -1235,13 +1253,24 @@ def test_the_STORE_refusal_reaches_the_PROCESS_EXIT_CODE_as_FORTY(
         f"they were verified:\n{r.stdout}\n{r.stderr}")
 
     expected = _NCC.format(
-        n=1, src=f"{src}/{PREFIX}",
-        where=f"the store directory {gone} DOES NOT EXIST",
-        mechanisms=_MECH_STORE_LEVEL, scopes="['scope-alpha']")
+        n=1, scanned=f"every scope under {src}/{PREFIX}",
+        observed=f"the store directory {gone} DOES NOT EXIST",
+        mechanisms=_numbered(_M_STORE_WRONG, _M_STORE_GONE), store=gone,
+        scopes="['scope-alpha']")
     assert _norm(expected) in _norm(r.stderr), (
         f"the refusal's wording changed. Re-read it before updating the "
-        f"literal: it must NAME BOTH mechanisms and assert neither, and it must "
-        f"say the artifacts themselves verified.\n{r.stderr}")
+        f"literal: it must list every mechanism consistent with what was seen, "
+        f"say the list is NOT closed, assert none of them, and say the "
+        f"artifacts themselves verified.\n{r.stderr}")
+
+    # 🔴 EXACTLY ONCE. `run()` printed the 1.4 KB paragraph and `main()`'s
+    # handler printed it again, byte-identically — the reader's eye has to
+    # re-scan it to notice the two are the same text.
+    assert _norm(r.stderr).count("NOTHING-CROSS-CHECKED: all 1 artifact(s)") == 1, (
+        f"the refusal was emitted more than once:\n{r.stderr}")
+    # 🔴 AND NOT UNDER THE WORD `FAILED`. The first word an operator reads must
+    # not be the claim this message exists to retract.
+    assert "FAILED NOTHING-CROSS-CHECKED" not in r.stderr, r.stderr
 
     # The per-artifact evidence the original test protected is still printed —
     # that is what makes the non-zero exit readable rather than alarming.
@@ -1255,14 +1284,25 @@ def test_a_SCOPE_FILTER_that_compares_NOTHING_gets_the_SAME_code(
     `--scope` selects one scope of THIS host's artifacts; if that scope has no
     live repository, zero commits were compared and the run must not report
     success. The store here is POPULATED — it holds a different scope — so the
-    rival mechanisms are the scope-level pair, not the store-level one: a store
-    that is plainly there cannot be blamed on `--store` pointing at nothing.
+    mechanisms are the scope-level ones, not the store-level pair: a store that
+    is plainly there cannot be blamed on `--store` pointing at nothing.
+
+    🔴 THE FIXTURE HOLDS TWO OBJECTS, AND THAT IS THE POINT. With one, "all N
+    artifacts THIS RUN VERIFIED" and "N artifacts under the PREFIX" are the same
+    number, so the test structurally could not see the over-claim it is here to
+    pin — the pairwise-distinct-values rule in RULES.md. `scope-gamma` is in the
+    bucket and NOT selected, so `n` is 1 while the prefix holds 2, and the
+    commit counts (3 / 7 / 2) are distinct from each other and from `n`.
     """
     store = tmp_path / "store"
     _make_scope(store, "scope-beta", {"e.md": "b"}, commits=2)
-    alpha = _make_scope(tmp_path / "elsewhere", "scope-alpha", {"e.md": "a"},
-                        commits=3)
-    objects = {_key("scope-alpha"): _make_artifact(alpha, identity, tmp_path)}
+    elsewhere = tmp_path / "elsewhere"
+    alpha = _make_scope(elsewhere, "scope-alpha", {"e.md": "a"}, commits=3)
+    gamma = _make_scope(elsewhere, "scope-gamma", {"e.md": "g"}, commits=7)
+    objects = {
+        _key("scope-alpha"): _make_artifact(alpha, identity, tmp_path),
+        _key("scope-gamma"): _make_artifact(gamma, identity, tmp_path),
+    }
 
     with pytest.raises(RV.RestoreVerifyError) as ei:
         _verify(store, tmp_path / "work", FakeDownloader(objects), identity,
@@ -1270,10 +1310,11 @@ def test_a_SCOPE_FILTER_that_compares_NOTHING_gets_the_SAME_code(
 
     assert ei.value.exit_code == 40, ei.value.token
     expected = _NCC.format(
-        n=1, src=f"test-bucket/{PREFIX}",
-        where=f"the store {store} holds 1 scope repository (['scope-beta']), "
-              f"none of which is one of the artifact scope(s) verified here",
-        mechanisms=_MECH_SCOPE_LEVEL, scopes="['scope-alpha']")
+        n=1, scanned=f"scope 'scope-alpha' under test-bucket/{PREFIX}",
+        observed=f"the store {store} holds 1 scope repository but none named "
+                 f"'scope-alpha'",
+        mechanisms=_numbered(_M_REMOVED, _M_DIFFERENT_STORE), store=store,
+        scopes="['scope-alpha']")
     assert _norm(str(ei.value)) == _norm(expected)
 
 
@@ -1309,8 +1350,173 @@ def test_a_REAL_failure_OUTRANKS_the_NOTHING_CROSS_CHECKED_code(
         "are fine, I just could not compare them'")
     assert ei.value.exit_code == 1
     assert "1 artifact/scope check(s) FAILED" in str(ei.value), str(ei.value)
-    # It is still REPORTED — withholding the code must not withhold the finding.
-    assert "NOTHING-CROSS-CHECKED" in capsys.readouterr().err
+    # It is still REPORTED — withholding the CODE must not withhold the FINDING.
+    err = capsys.readouterr().err
+    assert f"{RV.PROG}: ALSO: {RV.NOTHING_CROSS_CHECKED}" in err, (
+        f"the outranked finding was dropped, or is no longer labelled ALSO:. "
+        f"It is a second finding beside the failure, not a second failure — "
+        f"and `FAILED` as its first word is the claim it exists to "
+        f"retract:\n{err}")
+    assert "FAILED NOTHING-CROSS-CHECKED" not in err, err
+    # Exactly once here too: this path prints it, and the exception carries the
+    # OTHER finding, so `main()`'s handler cannot double it.
+    assert err.count(RV.NOTHING_CROSS_CHECKED) == 1, err
+
+
+def test_the_per_artifact_reason_COMPOSES_the_store_state_verbatim(
+        tmp_path, identity):
+    """🔴 THE THIRD PLACE THE STORE STATE IS SHOWN, and it is what an operator
+    reads FIRST — one line per scope, above the refusal.
+
+    Found by sweeping the delta for unpinned load-bearing prose rather than
+    fixing only the reported instance. `why_no_live_scope`'s sentences are
+    pinned; the sentence `cross_check_target` WRAPS them in was not, so the
+    per-artifact line could have lost the state entirely with the suite green.
+    """
+    store = tmp_path / "store"
+    beta = _make_scope(store, "scope-beta", {"e.md": "b"}, commits=2)
+    alpha = _make_scope(tmp_path / "elsewhere", "scope-alpha", {"e.md": "a"},
+                        commits=3)
+    objects = {_key("scope-alpha"): _make_artifact(alpha, identity, tmp_path),
+               _key("scope-beta"): _make_artifact(beta, identity, tmp_path)}
+
+    by_scope = {v.scope: v for v in _verify(
+        store, tmp_path / "work", FakeDownloader(objects), identity)}
+    assert by_scope["scope-beta"].cross_checked is True, (
+        "the partial half did not compare — this fixture is not what it claims")
+    assert by_scope["scope-alpha"].no_cross_check_reason == (
+        f"no live scope repository at {store / 'scope-alpha'}: the store "
+        f"{store} holds 1 scope repository but none named 'scope-alpha'")
+
+
+def test_a_SYMLINKED_scope_is_NOT_told_the_store_is_empty_or_gone(
+        tmp_path, identity):
+    """🔴 A CLOSED DISJUNCTION IS A CLAIM ABOUT WHAT CANNOT BE TRUE, AND IT WAS
+    FALSE HERE.
+
+    Measured: a scope that is a SYMLINK reached exit 40 being told the store
+    "EXISTS but holds NO scope repositories", with exactly two mechanisms
+    offered — `--store` is wrong, or the store is GONE. Both false. The
+    repository is right there, `--store` is exactly right, and the only reason
+    nothing was compared is that `live_scope_path` refuses symlinks (following
+    one would compare against a repository from OUTSIDE the store) and
+    `discover_scopes` skips them, which is why the store reads as empty.
+
+    `why_no_live_scope` already knew the real reason; the message did not ask
+    it. This pins that it does, and that the list is declared OPEN.
+    """
+    store = tmp_path / "store"
+    store.mkdir()
+    real = _make_scope(tmp_path / "outside", "scope-alpha", {"e.md": "a"},
+                       commits=3)
+    (store / "scope-alpha").symlink_to(real)
+    objects = {_key("scope-alpha"): _make_artifact(real, identity, tmp_path)}
+
+    with pytest.raises(RV.RestoreVerifyError) as ei:
+        _verify(store, tmp_path / "work", FakeDownloader(objects), identity)
+
+    assert ei.value.exit_code == 40, ei.value.token
+    expected = _NCC.format(
+        n=1, scanned=f"every scope under test-bucket/{PREFIX}",
+        observed=f"{store / 'scope-alpha'} is a SYMLINK, and a symlink is "
+                 f"never followed here — following one would compare against a "
+                 f"repository from OUTSIDE the store",
+        mechanisms=_numbered(_M_SYMLINK), store=store,
+        scopes="['scope-alpha']")
+    assert _norm(str(ei.value)) == _norm(expected)
+    # The two false mechanisms must not be offered at all here.
+    assert _M_STORE_GONE not in str(ei.value), (
+        "a symlinked scope was told the live store is GONE — it is right there")
+    assert "holds NO scope repositories" not in str(ei.value), (
+        "a symlinked scope was told the store holds no repositories")
+
+
+def test_a_scope_directory_with_NO_git_gets_its_OWN_mechanism(
+        tmp_path, identity):
+    """The mirror of the symlink case, and the second state the closed pair
+    excluded. A directory that lost its `.git` is neither a wrong `--store` nor
+    a vanished store."""
+    store = tmp_path / "store"
+    (store / "scope-alpha").mkdir(parents=True)      # present, but not a repo
+    real = _make_scope(tmp_path / "outside", "scope-alpha", {"e.md": "a"},
+                       commits=2)
+    objects = {_key("scope-alpha"): _make_artifact(real, identity, tmp_path)}
+
+    with pytest.raises(RV.RestoreVerifyError) as ei:
+        _verify(store, tmp_path / "work", FakeDownloader(objects), identity)
+
+    assert ei.value.exit_code == 40, ei.value.token
+    expected = _NCC.format(
+        n=1, scanned=f"every scope under test-bucket/{PREFIX}",
+        observed=f"{store / 'scope-alpha'} exists but is not a git repository "
+                 f"(it has no .git)",
+        mechanisms=_numbered(_M_NOT_A_REPO), store=store,
+        scopes="['scope-alpha']")
+    assert _norm(str(ei.value)) == _norm(expected)
+    assert _M_STORE_GONE not in str(ei.value)
+
+
+def test_TWO_DIFFERENT_observations_are_BOTH_reported_with_BOTH_mechanism_sets(
+        tmp_path, identity):
+    """🔴 PAIRWISE-DISTINCT VALUES, APPLIED TO MY OWN AGGREGATION.
+
+    Every other fixture here blocks both scopes for the SAME reason, so the
+    de-duplicated observation set collapses to one entry and the mechanism list
+    to one kind's worth — a mutant reading only `seen[0]` would survive all of
+    them. Here `scope-alpha` is a SYMLINK and `scope-beta` is simply absent, so
+    two distinct sentences and two distinct mechanism sets must BOTH appear, in
+    a deterministic order.
+
+    🔴 THAT ORDER IS BY KIND, FOR BOTH LISTS. Writing this expectation
+    independently is what caught the source sorting SENTENCES instead: the order
+    then fell out of incidental string content (a `/tmp` path sorting before the
+    word "the"), so observations and the mechanisms explaining them could appear
+    in unrelated orders. `scope-symlink` < `store-empty`, in both lists.
+    """
+    store = tmp_path / "store"
+    store.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    alpha = _make_scope(elsewhere, "scope-alpha", {"e.md": "a"}, commits=3)
+    beta = _make_scope(elsewhere, "scope-beta", {"e.md": "b"}, commits=7)
+    (store / "scope-alpha").symlink_to(alpha)     # present, but never followed
+    objects = {_key("scope-alpha"): _make_artifact(alpha, identity, tmp_path),
+               _key("scope-beta"): _make_artifact(beta, identity, tmp_path)}
+
+    with pytest.raises(RV.RestoreVerifyError) as ei:
+        _verify(store, tmp_path / "work", FakeDownloader(objects), identity)
+
+    assert ei.value.exit_code == 40, ei.value.token
+    # Sentences sorted; kinds sorted ("scope-symlink" < "store-empty").
+    expected = _NCC.format(
+        n=2, scanned=f"every scope under test-bucket/{PREFIX}",
+        observed=(f"{store / 'scope-alpha'} is a SYMLINK, and a symlink is "
+                  f"never followed here — following one would compare against "
+                  f"a repository from OUTSIDE the store; the store directory "
+                  f"{store} EXISTS but holds NO scope repositories"),
+        mechanisms=_numbered(_M_SYMLINK, _M_STORE_WRONG, _M_STORE_GONE),
+        store=store, scopes="['scope-alpha', 'scope-beta']")
+    assert _norm(str(ei.value)) == _norm(expected)
+
+
+def test_the_MECHANISM_ledger_is_pinned_two_way_to_WHY_KINDS():
+    """🔴 EVERY OBSERVABLE STATE HAS A MECHANISM, AND EVERY MECHANISM HAS A
+    STATE. A sixth `WHY_*` added without an entry would KeyError at the worst
+    possible moment — inside the refusal an operator is reading during a
+    recovery. An orphan entry is a mechanism offered for a state that can never
+    be observed.
+    """
+    assert set(RV._MECHANISMS) == set(RV.WHY_KINDS), (
+        f"unmapped states: {set(RV.WHY_KINDS) - set(RV._MECHANISMS)}; "
+        f"orphan entries: {set(RV._MECHANISMS) - set(RV.WHY_KINDS)}")
+    assert RV.WHY_KINDS, "the ledger is empty — the pin is vacuous"
+    for kind, entries in RV._MECHANISMS.items():
+        assert entries and all(e.strip() for e in entries), kind
+    # The two scope-level states must NOT offer the store-level mechanisms:
+    # that is the whole finding.
+    for kind in (RV.WHY_SCOPE_SYMLINK, RV.WHY_SCOPE_NOT_A_REPO):
+        joined = " ".join(RV._MECHANISMS[kind])
+        assert "the live store is GONE" not in joined, kind
+        assert "is not this host's store" not in joined, kind
 
 
 def test_the_exit_code_table_is_pinned_EXACTLY_both_ways():
@@ -1358,13 +1564,128 @@ def test_an_unknown_token_CANNOT_be_raised():
 def test_print_plan_LISTS_every_classified_code(tmp_path, identity):
     """The refusal's remedy sends the operator to `--print-plan`, so the code
     they are holding has to be mappable there — escrow-verify's convention, and
-    the reason it prints its own table."""
+    the reason it prints its own table.
+
+    🔴 THE ROW IS ASSERTED AS `code=token`, NOT AS TWO SEPARATE PRESENCE
+    CHECKS. A mutation sweep scored `print(f"{code}={token}")` ->
+    `print(f"{token}")` as SURVIVED: the bare `str(code) in stdout` was
+    satisfied by the adjacent prose line that also contains "40", so the table
+    row could lose its number with the guard fully green. That is a guard
+    reading as coverage while checking one side.
+    """
     r = _cli("--print-plan", "--store", str(tmp_path / "store"),
              identity=identity)
     assert r.returncode == 0, r.stderr
+    assert RV.EXIT_CODES, "the table is empty — this guard is vacuous"
     for token, code in RV.EXIT_CODES.items():
-        assert token in r.stdout, f"{token} is not listed in --print-plan"
-        assert str(code) in r.stdout, f"{code} is not listed in --print-plan"
+        assert f"{code}={token}" in r.stdout, (
+            f"--print-plan has no `{code}={token}` row; an operator holding "
+            f"the number cannot map it:\n{r.stdout}")
+
+
+# The two operator-facing prose blocks `--print-plan` prints about exit 40.
+# Written out as literals here, NOT imported: a test that reads the string from
+# the module it tests only ever proves the module agrees with itself.
+_PLAN_COMPARE_TAIL = (
+    "A run of THIS host's artifacts in which NOT ONE scope could "
+    "be compared exits 40, NOT 0: self-consistency alone says "
+    "the object decrypts, never that it still matches the "
+    "history it backs up, so 0 would claim what was not "
+    "measured. 40 is NOT a verdict against the backups — see "
+    "`exit:` below. Another host's artifacts are exempt (their "
+    "comparison is suppressed on purpose), and so is a PARTIAL "
+    "run: both stay 0.")
+_PLAN_EXIT_BLOCK = (
+    "exit: 0=verified, 1=a check FAILED or an unexpected error, plus one code "
+    "per classified cause: 40=NOTHING-CROSS-CHECKED 40 is NOT a verdict "
+    "against the backups: every artifact restored and passed fsck, and NONE "
+    "could be compared to a live store. It is the EXPECTED code during a real "
+    "recovery.")
+
+
+def test_print_plan_PROSE_never_contradicts_the_FORTY_framing(
+        tmp_path, identity):
+    """🔴 THE #851 TRAP, REPRODUCED INSIDE THE FIX FOR IT.
+
+    The previous round pinned `nothing_cross_checked_message` whole and left
+    `--print-plan`'s prose — added in the SAME commit, carrying the SAME
+    load-bearing claim — unpinned. An auditor rewrote the exit block to "40 IS a
+    verdict against the backups: NO artifact restored and FAILED fsck … It is
+    NEVER the expected code" and the suite stayed FULLY GREEN. The `compare:`
+    tail was worse than unpinned: it still said the run "FAILS", twelve lines
+    above the block saying 40 is not a verdict, and the refusal's own remedy
+    routes a recovering operator to this exact screen.
+
+    Both blocks are now pinned WHOLE and NORMALISED. A cosmetic reword costs a
+    test edit — that is the price of a claim a machine can check.
+    """
+    r = _cli("--print-plan", "--store", str(tmp_path / "store"),
+             identity=identity)
+    assert r.returncode == 0, r.stderr
+    out = _norm(r.stdout)
+    assert _norm(_PLAN_COMPARE_TAIL) in out, (
+        f"--print-plan's `compare:` tail changed. Re-read it: it must NOT say "
+        f"the run 'FAILS' — that is the claim exit 40 exists to retract, and "
+        f"this screen is where the refusal sends a recovering "
+        f"operator.\n{r.stdout}")
+    assert _norm(_PLAN_EXIT_BLOCK) in out, (
+        f"--print-plan's `exit:` block changed. The load-bearing claim is that "
+        f"40 is NOT a verdict against the backups and IS the expected code "
+        f"during a recovery; a reword can invert it silently.\n{r.stdout}")
+
+
+# `argparse` is constructed with `description=__doc__`, so the module docstring
+# IS operator-facing output. This paragraph carries the same load-bearing claim
+# as the refusal and SECRETS.md, and was the third copy of it left unpinned.
+_HELP_FORTY_PARAGRAPH = (
+    "🔴 IT HAS ITS OWN EXIT CODE, AND THE REASON IS THE SAME ONE "
+    "`escrow-verify.py` GIVES: \"every cause has its own exit code, so a timer "
+    "can act on the number\". `40 NOTHING-CROSS-CHECKED` means *your backups "
+    "restored perfectly, and nothing here compared them to anything* — which is "
+    "the EXPECTED outcome during a real recovery. `1` means a check FAILED. "
+    "Collapsing the two would tell an operator mid-disaster that their backups "
+    "are broken, and it is the reading that the absent-live-scope path was "
+    "originally left at exit 0 to avoid. A real failure OUTRANKS it: 40 is "
+    "raised only when it is the whole story, and the finding is still printed "
+    "as `ALSO:` when something louder wins. The message lists every mechanism "
+    "CONSISTENT with what was observed, states that the list is NOT closed, and "
+    "asserts none of them.")
+
+
+def test_the_HELP_output_carries_the_FORTY_paragraph_VERBATIM(identity):
+    """🔴 `--help` IS OPERATOR-FACING PROSE — `argparse(description=__doc__)`.
+
+    Found by sweeping the delta for the class the print-plan finding names,
+    rather than fixing only the instance that was reported. This is the third
+    copy of the "40 is not a verdict against the backups" claim (the refusal and
+    SECRETS.md are the others) and the last one a reword could invert with the
+    suite green.
+
+    🔴 THE PIN IS ON `__doc__`, NOT ON THE RENDERED BYTES, AND THAT IS
+    DELIBERATE — with a POSITIVE CONTROL so it cannot become a pin on dead
+    text. argparse's `HelpFormatter` re-wraps the description and will break a
+    long hyphenated token across lines (measured: `NOTHING-\\nCROSS-CHECKED`),
+    so whitespace-normalising the rendered output yields `NOTHING- CROSS-CHECKED`
+    — a WRAPPING artifact, not a content change. Normalising it away would mean
+    deleting "- " from both sides, which would equally hide a real edit. So:
+    the claim is pinned WHOLE against the docstring, and `--help` is then shown
+    to actually carry that docstring, which is what makes the pin load-bearing.
+    """
+    assert _norm(_HELP_FORTY_PARAGRAPH) in _norm(RV.__doc__ or ""), (
+        "the module docstring no longer carries the exit-40 paragraph "
+        "verbatim. Re-read it before updating this literal: the claim is that "
+        "40 means the backups RESTORED and nothing compared them, that a real "
+        "failure outranks it, and that the mechanism list is not closed.")
+
+    # POSITIVE CONTROL: `--help` really does render this docstring, so the pin
+    # above is a pin on what an operator reads. The fragment is chosen to carry
+    # the claim AND to contain no token long enough for argparse to break.
+    r = _cli("--help", identity=identity)
+    assert r.returncode == 0, r.stderr
+    assert ("means *your backups restored perfectly, and nothing here compared "
+            "them to anything*") in _norm(r.stdout), (
+        f"--help does not render the module docstring, so the pin above is on "
+        f"text no operator sees:\n{r.stdout}")
 
 
 def test_a_BROKEN_artifact_beside_a_LIVE_target_is_not_blamed_on_the_store(
@@ -1495,10 +1816,18 @@ def test_the_THREE_store_states_get_THREE_DIFFERENT_sentences(tmp_path):
     _make_scope(full, "scope-beta", {"e.md": "b"}, commits=1)
 
     said = {
-        "absent": RV.why_no_live_scope(absent, "scope-alpha"),
-        "empty": RV.why_no_live_scope(empty, "scope-alpha"),
-        "full": RV.why_no_live_scope(full, "scope-alpha"),
+        "absent": RV.why_no_live_scope(absent, "scope-alpha")[1],
+        "empty": RV.why_no_live_scope(empty, "scope-alpha")[1],
+        "full": RV.why_no_live_scope(full, "scope-alpha")[1],
     }
+    kinds = {
+        "absent": RV.why_no_live_scope(absent, "scope-alpha")[0],
+        "empty": RV.why_no_live_scope(empty, "scope-alpha")[0],
+        "full": RV.why_no_live_scope(full, "scope-alpha")[0],
+    }
+    assert kinds == {"absent": RV.WHY_STORE_ABSENT,
+                     "empty": RV.WHY_STORE_EMPTY,
+                     "full": RV.WHY_SCOPE_NOT_PRESENT}, kinds
     assert len(set(said.values())) == 3, (
         f"two of the three store states share a sentence, so they are "
         f"indistinguishable in the output: {said}")
@@ -1517,19 +1846,24 @@ def test_the_THREE_store_states_get_THREE_DIFFERENT_sentences(tmp_path):
     real = _make_scope(tmp_path / "outside", "scope-alpha", {"e.md": "x"},
                        commits=1)
     (full / "scope-link").symlink_to(real)
-    link_said = RV.why_no_live_scope(full, "scope-link")
+    link_kind, link_said = RV.why_no_live_scope(full, "scope-link")
+    assert link_kind == RV.WHY_SCOPE_SYMLINK
     assert link_said == (
         f"{full / 'scope-link'} is a SYMLINK, and a symlink is never followed "
         f"here — following one would compare against a repository from OUTSIDE "
         f"the store")
 
     (full / "scope-plain").mkdir()
-    plain_said = RV.why_no_live_scope(full, "scope-plain")
+    plain_kind, plain_said = RV.why_no_live_scope(full, "scope-plain")
+    assert plain_kind == RV.WHY_SCOPE_NOT_A_REPO
     assert plain_said == (
         f"{full / 'scope-plain'} exists but is not a git repository (it has no "
         f".git)")
     assert len({*said.values(), link_said, plain_said}) == 5, (
         "two of the five store-side findings share a sentence")
+    assert len({*kinds.values(), link_kind, plain_kind}) == 5, (
+        "two of the five store-side findings share a KIND, so the refusal "
+        "cannot offer them different mechanisms")
 
 
 def test_the_STORE_SIDE_kind_LEDGER_is_pinned_two_way_to_cross_check_target():
@@ -3545,13 +3879,15 @@ def test_SECRETS_md_documents_the_ZERO_CROSS_CHECK_refusal_WORD_FOR_WORD():
         "| code | meaning | what to do |\n"
         "|---|---|---|\n"
         "| `0` | verified, and cross-checked against the live store | nothing |\n"
-        "| `40` `NOTHING-CROSS-CHECKED` | every artifact **decrypted, restored "
-        "and passed `git fsck`** — and **none** was compared to a live store | "
-        "**not an alarm about the backups.** `--print-plan` shows the store path "
-        "this run used: if it is not the one you meant, re-run pointing at the "
-        "right one; if it *is*, the live store is gone and this is the "
-        "**expected** code during a recovery — the per-artifact lines are your "
-        "evidence the backups are intact |\n"
+        "| `40` `NOTHING-CROSS-CHECKED` | every artifact **this run verified** "
+        "(all scopes, or just the `--scope` one) **decrypted, restored and "
+        "passed `git fsck`** — and **none** was compared to a live store | "
+        "**not an alarm about the backups.** The message names the store path "
+        "it looked at: if that is not the one you meant, re-run with `--store` "
+        "pointing at the one you did; if it *is*, something on the live side is "
+        "missing or unreachable and this is the **expected** code during a "
+        "recovery — the per-artifact lines are your evidence the backups are "
+        "intact |\n"
         "| `1` | a check **FAILED** — an artifact did not decrypt, did not "
         "restore, failed `fsck`, is stale, or a scope has no artifact at all | "
         "this one *is* about the backups; read the first failure |\n"
@@ -3563,17 +3899,20 @@ def test_SECRETS_md_documents_the_ZERO_CROSS_CHECK_refusal_WORD_FOR_WORD():
         "decrypts and is internally consistent\", which says nothing about "
         "whether it still matches the history it is a backup of.\n"
         "\n"
-        "🔴 **`40`'s message names BOTH mechanisms and asserts NEITHER.** \"You "
-        "pointed at the wrong store\" and \"the store is genuinely gone\" are the "
-        "*same observation*, and nothing in the run separates them — so it says "
-        "so, and its remedy works under either reading. It does name which of "
-        "three store states it saw: the directory **does not exist**, it exists "
-        "and holds **no scope repositories**, or it holds scopes but **not this "
-        "one** (that third case gets a different mechanism pair — a store that "
-        "is plainly there cannot be blamed on `--store` naming nothing). A real "
-        "failure **outranks** `40`: a corrupt artifact beside an absent store "
-        "exits `1`, because the louder finding must not be filed as a store "
-        "problem.\n"
+        "🔴 **`40`'s message lists every mechanism consistent with what it saw, "
+        "says the list is NOT closed, and asserts none of them.** \"You pointed "
+        "at the wrong store\" and \"the store is genuinely gone\" are the *same "
+        "observation*, and nothing in the run separates them. It names which of "
+        "**five** states it observed, per scope — the store directory **does "
+        "not exist**; it exists and holds **no scope repositories**; it holds "
+        "scopes but **not this one**; the scope path is a **symlink** (never "
+        "followed, so the repository may be perfectly intact); the scope path "
+        "has **no `.git`**. The last two matter because a closed "
+        "\"wrong `--store` *or* store GONE\" pair is false for both: the "
+        "repository is right there and `--store` is correct. A real failure "
+        "**outranks** `40`: a corrupt artifact beside an absent store exits "
+        "`1`, because the louder finding must not be filed as a store problem "
+        "— the `40` finding is still printed, as `ALSO:`.\n"
         "\n"
         "Two zero-cross-check runs are deliberately still `0`: **another "
         "host's** artifacts (suppressing the comparison there is correct — see "

--- a/scripts/tests/test_analyze_service_index_restore_verify.py
+++ b/scripts/tests/test_analyze_service_index_restore_verify.py
@@ -1463,15 +1463,28 @@ def test_TWO_DIFFERENT_observations_are_BOTH_reported_with_BOTH_mechanism_sets(
     Every other fixture here blocks both scopes for the SAME reason, so the
     de-duplicated observation set collapses to one entry and the mechanism list
     to one kind's worth — a mutant reading only `seen[0]` would survive all of
-    them. Here `scope-alpha` is a SYMLINK and `scope-beta` is simply absent, so
-    two distinct sentences and two distinct mechanism sets must BOTH appear, in
-    a deterministic order.
+    them. Here the two scopes are blocked for two DIFFERENT reasons, so two
+    distinct sentences and two distinct mechanism sets must BOTH appear, in a
+    deterministic order.
 
-    🔴 THAT ORDER IS BY KIND, FOR BOTH LISTS. Writing this expectation
-    independently is what caught the source sorting SENTENCES instead: the order
-    then fell out of incidental string content (a `/tmp` path sorting before the
-    word "the"), so observations and the mechanisms explaining them could appear
-    in unrelated orders. `scope-symlink` < `store-empty`, in both lists.
+    🔴 THAT ORDER IS BY KIND, FOR BOTH LISTS, AND THE FIXTURE IS BUILT SO THE
+    TWO ORDERINGS GENUINELY DIVERGE. The first version of this test used a
+    SYMLINK beside an ABSENT scope, and in that shape kind-order and
+    sentence-order emit a BYTE-IDENTICAL message — `<store>/scope-alpha …`
+    sorts before `the store directory …` under both keys. So mutating the
+    source back to sentence-sorting (the exact pre-fix behaviour this test's
+    docstring claims to have caught) SURVIVED the full suite: the guard was
+    vacuous on the one dimension it names. My own "pairwise-distinct values"
+    rule, failed on my own aggregation, twice in one round.
+
+    The divergent shape, measured: `scope-alpha` a SYMLINK and `scope-beta` a
+    `.git`-less DIRECTORY gives
+
+        kind-order      scope-not-a-repo (beta), scope-symlink (alpha)
+        sentence-order  <store>/scope-alpha …   , <store>/scope-beta …
+
+    — opposite orders, and only kind-order lines each observation up with the
+    numbered mechanism that explains it.
     """
     store = tmp_path / "store"
     store.mkdir()
@@ -1479,6 +1492,7 @@ def test_TWO_DIFFERENT_observations_are_BOTH_reported_with_BOTH_mechanism_sets(
     alpha = _make_scope(elsewhere, "scope-alpha", {"e.md": "a"}, commits=3)
     beta = _make_scope(elsewhere, "scope-beta", {"e.md": "b"}, commits=7)
     (store / "scope-alpha").symlink_to(alpha)     # present, but never followed
+    (store / "scope-beta").mkdir()                # present, but carries no .git
     objects = {_key("scope-alpha"): _make_artifact(alpha, identity, tmp_path),
                _key("scope-beta"): _make_artifact(beta, identity, tmp_path)}
 
@@ -1486,16 +1500,113 @@ def test_TWO_DIFFERENT_observations_are_BOTH_reported_with_BOTH_mechanism_sets(
         _verify(store, tmp_path / "work", FakeDownloader(objects), identity)
 
     assert ei.value.exit_code == 40, ei.value.token
-    # Sentences sorted; kinds sorted ("scope-symlink" < "store-empty").
+    # 🔴 KIND order: "scope-not-a-repo" < "scope-symlink", so BETA's sentence
+    # comes first — the REVERSE of sorting the sentences, where scope-alpha's
+    # path sorts first. That inversion is what makes this guard non-vacuous.
     expected = _NCC.format(
         n=2, scanned=f"every scope under test-bucket/{PREFIX}",
-        observed=(f"{store / 'scope-alpha'} is a SYMLINK, and a symlink is "
-                  f"never followed here — following one would compare against "
-                  f"a repository from OUTSIDE the store; the store directory "
-                  f"{store} EXISTS but holds NO scope repositories"),
-        mechanisms=_numbered(_M_SYMLINK, _M_STORE_WRONG, _M_STORE_GONE),
+        observed=(f"{store / 'scope-beta'} exists but is not a git repository "
+                  f"(it has no .git); {store / 'scope-alpha'} is a SYMLINK, "
+                  f"and a symlink is never followed here — following one would "
+                  f"compare against a repository from OUTSIDE the store"),
+        mechanisms=_numbered(_M_NOT_A_REPO, _M_SYMLINK),
         store=store, scopes="['scope-alpha', 'scope-beta']")
     assert _norm(str(ei.value)) == _norm(expected)
+
+    # POSITIVE CONTROL on the fixture itself: prove the two orderings really do
+    # disagree here, so this test cannot silently go back to being vacuous if
+    # the sentences are ever reworded.
+    pairs = [RV.why_no_live_scope(store, s)
+             for s in ("scope-alpha", "scope-beta")]
+    by_kind = [s for _, s in sorted(pairs)]
+    by_sentence = [s for _, s in sorted(pairs, key=lambda kv: kv[1])]
+    assert by_kind != by_sentence, (
+        "kind-order and sentence-order agree in this fixture, so the ordering "
+        "assertion above cannot see the source revert to sentence-sorting — "
+        "which is exactly how this test was vacuous before")
+
+
+def test_the_count_is_ARTIFACTS_not_SCOPES(tmp_path, identity):
+    """🔴 PAIRWISE-DISTINCT VALUES ON THE COUNT ITSELF.
+
+    Every other exit-40 fixture has exactly ONE artifact per scope, so
+    `len(verdicts)`, `len(by_scope)` and `len(store_blocked_scopes)` are the
+    same number and a mutant binding the wrong one survives. Under `--all` they
+    diverge — that is the flag's whole purpose, every retained artifact per
+    scope — and the message would then UNDER-count what it verified.
+
+    ONE scope, TWO artifacts: n=2 while both scope counts are 1.
+    """
+    store = tmp_path / "store"
+    store.mkdir()                                  # exists, holds no repository
+    now = datetime.now(timezone.utc)
+    alpha = _make_scope(tmp_path / "elsewhere", "scope-alpha", {"e.md": "a"},
+                        commits=5)
+    objects = {
+        _key("scope-alpha", now - timedelta(hours=30)):
+            _make_artifact(alpha, identity, tmp_path),
+        _key("scope-alpha", now - timedelta(hours=2)):
+            _make_artifact(alpha, identity, tmp_path),
+    }
+
+    with pytest.raises(RV.RestoreVerifyError) as ei:
+        _verify(store, tmp_path / "work", FakeDownloader(objects), identity,
+                verify_all=True, max_lag_days=3.0, now=now)
+
+    assert ei.value.exit_code == 40, ei.value.token
+    expected = _NCC.format(
+        n=2, scanned=f"every scope under test-bucket/{PREFIX}",
+        observed=f"the store directory {store} EXISTS but holds NO scope "
+                 f"repositories",
+        mechanisms=_numbered(_M_STORE_WRONG, _M_STORE_GONE), store=store,
+        scopes="['scope-alpha']")
+    assert _norm(str(ei.value)) == _norm(expected)
+
+    # POSITIVE CONTROL on the fixture: the counts really do diverge here, so a
+    # mutant binding a scope count cannot pass by coincidence.
+    assert len(objects) == 2 and len({k.split("/")[1] for k in objects}) == 1, (
+        "this fixture no longer has two artifacts for one scope, so the "
+        "artifact count and the scope count coincide again and the assertion "
+        "above cannot see the difference")
+
+
+def test_a_kind_OUTSIDE_the_ledger_CANNOT_be_returned(tmp_path):
+    """🔴 THE LEDGER PIN SAYS NOTHING ABOUT WHAT THE FUNCTION RETURNS.
+
+    `_MECHANISMS` is pinned key-for-key against `WHY_KINDS`, and that guard is
+    real — but a SIXTH branch in `why_no_live_scope` spelling its kind as an
+    inline literal satisfies it completely, and then `_MECHANISMS[kind]` raises
+    `KeyError` INSIDE the refusal an operator is reading during a recovery. A
+    crash on the disaster path this whole feature exists to serve.
+
+    🔴 THIS TEST IS WHAT MAKES THE GUARD REACHABLE, not merely defensive. Called
+    through `_why` directly, so deleting the check is a mutation that can be
+    watched to fail rather than one that survives for want of a caller.
+    """
+    with pytest.raises(RV.RestoreVerifyError) as ei:
+        RV._why("scope-invented-by-a-sixth-branch", "some sentence")
+    assert " ".join(str(ei.value).split()) == " ".join((
+        "'scope-invented-by-a-sixth-branch' is not in WHY_KINDS. Every store "
+        "state this verifier can observe is an ENUMERATED value with an entry "
+        "in _MECHANISMS; adding one means adding it to both, in the same commit "
+        "as the test that pins them.").split()), str(ei.value)
+
+    # POSITIVE CONTROL: every real kind passes through unchanged, so the guard
+    # is not simply refusing everything.
+    for kind in RV.WHY_KINDS:
+        assert RV._why(kind, "s") == (kind, "s")
+
+    # And the guard is REACHED by the real function on every branch — a check
+    # that only the helper enforces would be bypassed by a branch that returns
+    # a bare tuple. Asserted structurally, since a sixth branch is the hazard.
+    body = SCRIPT.read_text(encoding="utf-8").split(
+        "def why_no_live_scope(", 1)[1].split("\ndef ", 1)[0]
+    returns = [ln.strip() for ln in body.splitlines()
+               if ln.strip().startswith("return ")]
+    assert returns, "why_no_live_scope has no returns — this pin is vacuous"
+    assert all(r.startswith("return _why(") for r in returns), (
+        f"a branch of why_no_live_scope returns without going through _why(), "
+        f"so its kind is unchecked: {[r for r in returns if not r.startswith('return _why(')]}")
 
 
 def test_the_MECHANISM_ledger_is_pinned_two_way_to_WHY_KINDS():
@@ -1583,31 +1694,11 @@ def test_print_plan_LISTS_every_classified_code(tmp_path, identity):
             f"the number cannot map it:\n{r.stdout}")
 
 
-# The two operator-facing prose blocks `--print-plan` prints about exit 40.
-# Written out as literals here, NOT imported: a test that reads the string from
-# the module it tests only ever proves the module agrees with itself.
-_PLAN_COMPARE_TAIL = (
-    "A run of THIS host's artifacts in which NOT ONE scope could "
-    "be compared exits 40, NOT 0: self-consistency alone says "
-    "the object decrypts, never that it still matches the "
-    "history it backs up, so 0 would claim what was not "
-    "measured. 40 is NOT a verdict against the backups — see "
-    "`exit:` below. Another host's artifacts are exempt (their "
-    "comparison is suppressed on purpose), and so is a PARTIAL "
-    "run: both stay 0.")
-_PLAN_EXIT_BLOCK = (
-    "exit: 0=verified, 1=a check FAILED or an unexpected error, plus one code "
-    "per classified cause: 40=NOTHING-CROSS-CHECKED 40 is NOT a verdict "
-    "against the backups: every artifact restored and passed fsck, and NONE "
-    "could be compared to a live store. It is the EXPECTED code during a real "
-    "recovery.")
-
-
 def test_print_plan_PROSE_never_contradicts_the_FORTY_framing(
         tmp_path, identity):
     """🔴 THE #851 TRAP, REPRODUCED INSIDE THE FIX FOR IT.
 
-    The previous round pinned `nothing_cross_checked_message` whole and left
+    A previous round pinned `nothing_cross_checked_message` whole and left
     `--print-plan`'s prose — added in the SAME commit, carrying the SAME
     load-bearing claim — unpinned. An auditor rewrote the exit block to "40 IS a
     verdict against the backups: NO artifact restored and FAILED fsck … It is
@@ -1616,22 +1707,74 @@ def test_print_plan_PROSE_never_contradicts_the_FORTY_framing(
     above the block saying 40 is not a verdict, and the refusal's own remedy
     routes a recovering operator to this exact screen.
 
-    Both blocks are now pinned WHOLE and NORMALISED. A cosmetic reword costs a
-    test edit — that is the price of a claim a machine can check.
+    🔴 THE WHOLE RENDERED PLAN IS PINNED, NOT THE TWO BLOCKS THAT CARRY THE
+    CLAIM. Pinning the blocks left the obvious hole: a NEW paragraph elsewhere
+    on this screen asserting the opposite ("exit 40 DOES mean your backups are
+    broken") satisfied both `in` checks and survived. An operator reads the
+    screen, not the block, so the screen is the unit.
+
+    Every environment-dependent field is supplied BY THIS TEST (bucket, prefix,
+    store, identity, max-lag) so nothing here is derived from the implementation
+    — except the machine id, which is REDACTED by regex rather than pinned:
+    devrc is a public repo and the real id must never be committed.
     """
-    r = _cli("--print-plan", "--store", str(tmp_path / "store"),
+    store = tmp_path / "store"
+    ident = tmp_path / "ID.key"
+    r = _cli("--print-plan", "--bucket", "test-bucket", "--store", str(store),
+             "--identity", str(ident), "--max-lag-days", "3.0",
              identity=identity)
     assert r.returncode == 0, r.stderr
-    out = _norm(r.stdout)
-    assert _norm(_PLAN_COMPARE_TAIL) in out, (
-        f"--print-plan's `compare:` tail changed. Re-read it: it must NOT say "
-        f"the run 'FAILS' — that is the claim exit 40 exists to retract, and "
-        f"this screen is where the refusal sends a recovering "
-        f"operator.\n{r.stdout}")
-    assert _norm(_PLAN_EXIT_BLOCK) in out, (
-        f"--print-plan's `exit:` block changed. The load-bearing claim is that "
-        f"40 is NOT a verdict against the backups and IS the expected code "
-        f"during a recovery; a reword can invert it silently.\n{r.stdout}")
+    got = _norm(re.sub(r"machine-id (?:[0-9a-f]{32}|UNREADABLE)",
+                       "machine-id <redacted>", r.stdout))
+    expected = _norm(f"""
+source:    test-bucket
+prefix:    {PREFIX}
+store:     {store}
+identity:  {ident} (MISSING)
+chosen by: the --identity flag  <- NOT the default identity
+host:      {HOST} (machine-id <redacted>) -> these artifacts are THIS host's: they WILL be cross-checked
+scope:     (every scope found under the prefix)
+artifacts: newest per scope
+max lag:   3.0 day(s) — older than this is a FAILURE
+verify:    download -> age -d -> `git clone --mirror` -> `git fsck`.
+           NEVER `git bundle verify`: it passes a byte-flipped bundle
+           at rc=0 printing 'complete history'. Only a real restore
+           walks the packfile.
+compare:   restored commits must EXIST in the live scope and each
+           restored tip must be an ANCESTOR of the live tip. Never an
+           equality — the store advances hourly and an equality check
+           would be a permanently-red gate.
+           A run of THIS host's artifacts in which NOT ONE scope could
+           be compared exits 40, NOT 0: self-consistency alone says
+           the object decrypts, never that it still matches the
+           history it backs up, so 0 would claim what was not
+           measured. 40 is NOT a verdict against the backups — see
+           `exit:` below. Another host's artifacts are exempt (their
+           comparison is suppressed on purpose), and so is a PARTIAL
+           run: both stay 0.
+exit:      0=verified, 1=a check FAILED or an unexpected error, plus one code per classified cause:
+           40=NOTHING-CROSS-CHECKED
+           40 is NOT a verdict against the backups: every artifact restored and
+           passed fsck, and NONE could be compared to a live store.
+           It is the EXPECTED code during a real recovery.
+coverage:  every LOCAL scope must have at least one artifact. A scope
+           that stopped being backed up is invisible to every other
+           check here, because they all iterate the objects that ARE
+           in the bucket. Gated on the scope's FIRST COMMIT being
+           older than the max lag, so a scope created today is not a
+           red gate. Skipped under --scope or an explicit --host.
+writes:    NOTHING to the store, NOTHING to the bucket. The store is
+           read through an allowlist of read-only subcommands.
+local:     (no scope repositories under {store})
+""")
+    assert got == expected, (
+        f"the rendered --print-plan changed. Re-read it before updating this "
+        f"literal — TWO claims on this screen invert silently under a reword, "
+        f"and this is the screen the refusal sends a recovering operator to: "
+        f"that a run comparing nothing exits 40 and NOT 0, and that 40 is NOT a "
+        f"verdict against the backups. The whole screen is pinned because "
+        f"pinning only the blocks that carry those claims let a CONTRADICTING "
+        f"paragraph be added elsewhere.\n--- got ---\n{r.stdout}")
 
 
 # `argparse` is constructed with `description=__doc__`, so the module docstring

--- a/scripts/tests/test_analyze_service_index_restore_verify.py
+++ b/scripts/tests/test_analyze_service_index_restore_verify.py
@@ -50,6 +50,7 @@ import hashlib
 import importlib.util
 from testlib import hermetic_git  # noqa: E402
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -1023,25 +1024,40 @@ def test_a_NON_BRANCH_ref_round_trips_and_is_cross_checked(tmp_path, identity):
 # --------------------------------------------------------------------------- #
 # 5. 🔴 THE ABSENT LIVE SCOPE — the actual disaster case, and NOT a failure
 # --------------------------------------------------------------------------- #
-def test_an_absent_live_scope_verifies_SELF_CONSISTENCY_and_says_so(
+def test_ONE_absent_live_scope_verifies_SELF_CONSISTENCY_and_says_so(
         tmp_path, identity):
-    """🔴 If the store is gone there is nothing to cross-check against — which is
-    the scenario these backups exist for. Failing here would make the verifier
+    """🔴 A scope whose live repository is gone is NOT a failure — that is the
+    scenario these backups exist for, and failing on it would make the verifier
     useless at the exact moment it is needed.
 
     But it must be DISTINGUISHABLE. `cross_checked` is False, the reason is
     stated, and the printed line says NOT CROSS-CHECKED rather than a word that
     reads like a full verification.
+
+    🔴 THE PARTIAL SHAPE IS THE POINT, and it is what keeps the whole-run
+    refusal below from being a permanently-red gate: `scope-beta` IS live and IS
+    compared, so the run has cross-checked something and stays rc=0 while
+    `scope-alpha` reports honestly that it could not be. A run where NOT ONE
+    scope could be compared is a different finding —
+    `test_a_run_that_CROSS_CHECKS_NOTHING_because_of_the_store_REFUSES`.
     """
     store = tmp_path / "store"
     scope = _make_scope(tmp_path / "elsewhere", "scope-alpha", {"e.md": "x"},
                         commits=5)
     data = _make_artifact(scope, identity, tmp_path)
-    store.mkdir()          # the store exists; THIS SCOPE does not
+    beta = _make_scope(store, "scope-beta", {"e.md": "b"}, commits=2)
+    beta_data = _make_artifact(beta, identity, tmp_path)
+    # the store exists and holds scope-beta; scope-alpha's repository does NOT
 
     verdicts = _verify(store, tmp_path / "work",
-                       FakeDownloader({_key("scope-alpha"): data}), identity)
-    v = verdicts[0]
+                       FakeDownloader({_key("scope-alpha"): data,
+                                       _key("scope-beta"): beta_data}),
+                       identity)
+    by_scope = {v.scope: v for v in verdicts}
+    v = by_scope["scope-alpha"]
+    assert by_scope["scope-beta"].cross_checked is True, (
+        "the control half of this fixture did not cross-check, so 'partial' is "
+        "not what is being measured here")
     assert v.cross_checked is False
     assert v.commits_restored == 5, v.commits_restored
     assert v.commits_compared == 0, "it claims to have compared commits it could not"
@@ -1053,21 +1069,302 @@ def test_an_absent_live_scope_verifies_SELF_CONSISTENCY_and_says_so(
         "one — the two claims are folded into one OK")
 
 
-def test_an_absent_live_scope_EXITS_ZERO_through_the_real_CLI(tmp_path, identity):
-    """The library returning is not the same claim as the PROCESS exiting 0."""
+def test_a_PARTIAL_cross_check_EXITS_ZERO_through_the_real_CLI(tmp_path, identity):
+    """The library returning is not the same claim as the PROCESS exiting 0.
+
+    🔴 AND THIS IS THE ANTI-PERMANENTLY-RED CONTROL for the whole-run refusal,
+    driven end to end: one scope compared, one scope that could not be, rc=0.
+    """
+    store = tmp_path / "store"
     scope = _make_scope(tmp_path / "elsewhere", "scope-alpha", {"e.md": "x"},
                         commits=4)
-    data = _make_artifact(scope, identity, tmp_path)
-    src = _dir_store(tmp_path / "objects", {_key("scope-alpha"): data})
+    beta = _make_scope(store, "scope-beta", {"e.md": "b"}, commits=2)
+    src = _dir_store(tmp_path / "objects", {
+        _key("scope-alpha"): _make_artifact(scope, identity, tmp_path),
+        _key("scope-beta"): _make_artifact(beta, identity, tmp_path),
+    })
 
     r = _cli("--from-dir", str(src), "--prefix", HOST,
-             "--store", str(tmp_path / "gone"), "--max-lag-days", "100000",
+             "--store", str(store), "--max-lag-days", "100000",
              identity=identity)
     assert r.returncode == 0, f"rc={r.returncode}\n{r.stdout}\n{r.stderr}"
     assert "NOT CROSS-CHECKED" in r.stdout, r.stdout
     assert "self-consistency only" in r.stdout, r.stdout
-    assert "1 against the live store" not in r.stdout, (
+    assert "2 against the live store" not in r.stdout, (
         f"the summary claims a live comparison that did not happen:\n{r.stdout}")
+
+
+# --------------------------------------------------------------------------- #
+# 5b. 🔴 A RUN THAT CROSS-CHECKED NOTHING, BECAUSE OF THE STORE
+#
+# REPRODUCED LIVE 2026-08-26 on this host, at the real bucket:
+#
+#     restore-verify.py --host <this host> --store <an empty directory>
+#     -> rc=0, 13 scopes "RESTORED N commit(s) ..., fsck OK ... NOT
+#        CROSS-CHECKED ... self-consistency only",
+#        summary "0 against the live store (0 commit(s) compared), 13
+#        self-consistency only"
+#
+# An exit code is the only thing a systemd timer reads. So a wrong or absent
+# `--store` silently downgraded the entire run to "the artifact decrypts and is
+# internally consistent" — which says nothing about whether the backup still
+# matches the history it is a backup OF — and reported success.
+#
+# The refusal must NOT reach the three legitimate zero-cross-check runs, each of
+# which has its own control below or above:
+#   * FOREIGN artifacts                    -> test_FOREIGN_..._stay_rc_ZERO
+#   * a PARTIAL run                        -> the two tests in section 5
+#   * a host that never ran the backup     -> the zero-objects no-op, which
+#                                             returns before any verdict exists
+# --------------------------------------------------------------------------- #
+def test_a_run_that_CROSS_CHECKS_NOTHING_because_of_the_store_REFUSES(
+        tmp_path, identity):
+    """🔴 THE F5 REGRESSION GUARD. Red before the fix: this run returned two
+    verdicts and raised nothing.
+
+    🔴 THE WHOLE MESSAGE IS PINNED, NORMALISED — not a substring. A clause
+    pinned by substring has twice shipped in this repo asserting the OPPOSITE of
+    what the code does and passed the entire suite (#851, #765). A cosmetic
+    reword costs this literal; that price buys a machine-readable claim.
+    """
+    store = tmp_path / "store"          # exists, holds NO scope repository
+    store.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    objects = {}
+    for name, commits in (("scope-alpha", 5), ("scope-beta", 3)):
+        s = _make_scope(elsewhere, name, {"e.md": name}, commits=commits)
+        objects[_key(name)] = _make_artifact(s, identity, tmp_path)
+
+    with pytest.raises(RV.RestoreVerifyError) as ei:
+        _verify(store, tmp_path / "work", FakeDownloader(objects), identity)
+
+    expected = (
+        f"1 artifact/scope check(s) FAILED; 2 verified. First failure: "
+        f"NOTHING WAS CROSS-CHECKED AGAINST THE LIVE STORE. All 2 artifact(s) "
+        f"under test-bucket/{PREFIX} are THIS machine's, and every one of them "
+        f"was verified for SELF-CONSISTENCY ONLY, because the store side "
+        f"contributed nothing: the store directory {store} EXISTS but holds NO "
+        f"scope repositories. Scope(s) with no live repository: "
+        f"['scope-alpha', 'scope-beta']. Self-consistency proves the object "
+        f"decrypts and restores; it proves NOTHING about whether it still "
+        f"matches the history it is a backup OF, and zero commits were compared "
+        f"on this run. Exiting non-zero because an exit code is all a timer "
+        f"reads. Point --store at the live store, or fix it. Verifying ANOTHER "
+        f"host's artifacts is the one case where zero cross-checks is correct, "
+        f"and this is not it.")
+    assert " ".join(str(ei.value).split()) == " ".join(expected.split())
+
+
+def test_the_STORE_refusal_reaches_the_PROCESS_EXIT_CODE(tmp_path, identity):
+    """The library raising is not the same claim as the PROCESS exiting non-zero,
+    and the exit code is the entire reason this defect matters: it is all a
+    systemd timer ever reads.
+
+    🔴 `subprocess.run` is read directly. `$?` after a pipe reports the PIPE's
+    status — that is exactly how a real rc=34 read as rc=0 on this host.
+    """
+    scope = _make_scope(tmp_path / "elsewhere", "scope-alpha", {"e.md": "x"},
+                        commits=4)
+    src = _dir_store(tmp_path / "objects",
+                     {_key("scope-alpha"): _make_artifact(scope, identity,
+                                                          tmp_path)})
+
+    r = _cli("--from-dir", str(src), "--prefix", HOST,
+             "--store", str(tmp_path / "gone"), "--max-lag-days", "100000",
+             identity=identity)
+    assert r.returncode != 0, (
+        f"the process exited 0 having compared NOTHING against the live "
+        f"store:\n{r.stdout}\n{r.stderr}")
+    assert "NOTHING WAS CROSS-CHECKED AGAINST THE LIVE STORE" in r.stderr, (
+        f"non-zero for some OTHER reason — a control that goes red because a "
+        f"different guard fired is green for the wrong reason:\n{r.stderr}")
+    assert f"the store directory {tmp_path / 'gone'} DOES NOT EXIST" in r.stderr, (
+        f"the refusal does not name the store it looked at, so the operator "
+        f"cannot tell a typo from a disaster:\n{r.stderr}")
+
+
+def test_a_BROKEN_artifact_beside_a_LIVE_target_is_not_blamed_on_the_store(
+        tmp_path, identity, capsys):
+    """🔴 THE STORE DID CONTRIBUTE — the artifact is what broke.
+
+    `scope-alpha` IS live in the store, so a comparison was available; its
+    artifact is corrupt, so no verdict for it exists and NOTHING ended up
+    cross-checked. Blaming that on the store would hand the operator a
+    misdiagnosis ("point --store at the live store") for a bit-rot failure, and
+    it is the only case that separates `scopes_with_a_live_target == 0` from the
+    zero-cross-checks it looks redundant with.
+
+    Reached with a case NO earlier check rejects: the run is already failing on
+    the corrupt artifact, so this asserts WHICH failures were recorded, read off
+    stderr — `str(exc)` carries only `failures[0]`.
+    """
+    store = tmp_path / "store"
+    alpha = _make_scope(store, "scope-alpha", {"e.md": "a"}, commits=3)
+    beta = _make_scope(tmp_path / "elsewhere", "scope-beta", {"e.md": "b"},
+                       commits=2)
+    objects = {
+        _key("scope-alpha"): _make_artifact(alpha, identity, tmp_path,
+                                            mangle=_flip_middle_byte),
+        _key("scope-beta"): _make_artifact(beta, identity, tmp_path),
+    }
+
+    with pytest.raises(RV.RestoreVerifyError):
+        _verify(store, tmp_path / "work", FakeDownloader(objects), identity)
+
+    err = capsys.readouterr().err
+    assert "FAILED scope-alpha" in err, (
+        f"the corrupt artifact was not the recorded failure, so this fixture "
+        f"is not exercising what it claims:\n{err}")
+    assert "NOTHING WAS CROSS-CHECKED AGAINST THE LIVE STORE" not in err, (
+        f"a corrupt artifact was reported as a STORE problem — the store held "
+        f"a live scope-alpha and offered a comparison:\n{err}")
+
+
+def test_a_run_that_verified_ZERO_artifacts_is_not_called_a_store_problem(
+        tmp_path, identity, capsys):
+    """🔴 "ALL 0 ARTIFACTS WERE SELF-CONSISTENCY ONLY" IS A CLAIM ABOUT NOTHING.
+
+    Store absent AND the one artifact corrupt: every other conjunct of the
+    refusal holds, and only `verdicts` keeps it quiet. The run is loudly failing
+    already, on the right thing; adding a store diagnosis on top would send the
+    reader to fix `--store` for a bit-rot failure.
+    """
+    scope = _make_scope(tmp_path / "elsewhere", "scope-alpha", {"e.md": "x"},
+                        commits=3)
+    data = _make_artifact(scope, identity, tmp_path, mangle=_flip_middle_byte)
+
+    with pytest.raises(RV.RestoreVerifyError):
+        _verify(tmp_path / "gone", tmp_path / "work",
+                FakeDownloader({_key("scope-alpha"): data}), identity)
+
+    err = capsys.readouterr().err
+    assert "FAILED scope-alpha" in err, err
+    assert "NOTHING WAS CROSS-CHECKED AGAINST THE LIVE STORE" not in err, (
+        f"a run that verified ZERO artifacts announced that all zero of them "
+        f"were self-consistency only:\n{err}")
+    assert "All 0 artifact(s)" not in err, err
+
+
+def test_FOREIGN_artifacts_with_zero_cross_checks_stay_rc_ZERO(tmp_path, identity):
+    """🔴 THE ANTI-PERMANENTLY-RED CONTROL, and the one that decides WHERE the
+    predicate is keyed.
+
+    Cross-checking another host's artifacts against THIS host's store compares
+    two histories that were never the same one and reports a false data-loss
+    alarm, so suppressing it is CORRECT — which makes zero cross-checks correct
+    too. A guard keyed on "were any cross-checked" alone, rather than on the
+    store-side KIND of the block, goes red on the exact command SECRETS.md tells
+    an operator to run.
+    """
+    now = datetime.now(timezone.utc)
+    elsewhere = _make_scope(tmp_path / "elsewhere", "scope-alpha", {"e.md": "x"},
+                            commits=3)
+    data = _make_artifact(elsewhere, identity, tmp_path)
+    store = tmp_path / "store"          # empty: the store side offers nothing
+    store.mkdir()
+
+    verdicts = _verify(store, tmp_path / "work",
+                       FakeDownloader({_key("scope-alpha",
+                                            now - timedelta(hours=2),
+                                            host="other-host"): data}),
+                       identity, prefix="other-host", this_host=HOST,
+                       this_machine_id=SYNTH_MACHINE_ID, explicit=True,
+                       max_lag_days=3.0, now=now)
+    assert [v.cross_checked for v in verdicts] == [False], verdicts
+    assert "ANOTHER host" in (verdicts[0].no_cross_check_reason or "")
+
+    r = _cli("--from-dir", str(_dir_store(
+                 tmp_path / "objects",
+                 {_key("scope-alpha", host="other-host"): data})),
+             "--prefix", "other-host", "--store", str(store),
+             "--max-lag-days", "100000", identity=identity)
+    assert r.returncode == 0, (
+        f"verifying ANOTHER host's artifacts went red — a permanently-red gate "
+        f"on the documented cross-host command:\n{r.stdout}\n{r.stderr}")
+
+
+# --------------------------------------------------------------------------- #
+# 5c. F6 — "no local store" was THREE facts sharing one sentence
+# --------------------------------------------------------------------------- #
+def test_the_THREE_store_states_get_THREE_DIFFERENT_sentences(tmp_path):
+    """🔴 AN EMPTY RESULT CANNOT DISTINGUISH ITS CAUSES. "no local store" was
+    printed for a store that does not exist, for one that exists and is empty,
+    and for one that is full but does not hold this scope. They call for three
+    different actions — find the store / the store was emptied / this one scope
+    is missing — and the reader was given one sentence for all of them.
+
+    Every sub-case is also asserted to be REACHED, so a state whose branch stops
+    executing cannot pass by matching some other state's sentence.
+    """
+    absent = tmp_path / "gone"
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    full = tmp_path / "full"
+    _make_scope(full, "scope-beta", {"e.md": "b"}, commits=1)
+
+    said = {
+        "absent": RV.why_no_live_scope(absent, "scope-alpha"),
+        "empty": RV.why_no_live_scope(empty, "scope-alpha"),
+        "full": RV.why_no_live_scope(full, "scope-alpha"),
+    }
+    assert len(set(said.values())) == 3, (
+        f"two of the three store states share a sentence, so they are "
+        f"indistinguishable in the output: {said}")
+
+    assert said["absent"] == f"the store directory {absent} DOES NOT EXIST"
+    assert said["empty"] == (
+        f"the store directory {empty} EXISTS but holds NO scope repositories")
+    assert said["full"] == (
+        f"the store {full} holds 1 scope repository but none named "
+        f"'scope-alpha'")
+
+    # The two sub-cases of "the path is there but unusable" — a symlink is never
+    # followed (it would compare against a repository OUTSIDE the store) and a
+    # plain directory is not a repository. Neither may be reported as "the store
+    # holds N scopes, none named X", which reads as "the scope was never here".
+    real = _make_scope(tmp_path / "outside", "scope-alpha", {"e.md": "x"},
+                       commits=1)
+    (full / "scope-link").symlink_to(real)
+    link_said = RV.why_no_live_scope(full, "scope-link")
+    assert link_said == (
+        f"{full / 'scope-link'} is a SYMLINK, and a symlink is never followed "
+        f"here — following one would compare against a repository from OUTSIDE "
+        f"the store")
+
+    (full / "scope-plain").mkdir()
+    plain_said = RV.why_no_live_scope(full, "scope-plain")
+    assert plain_said == (
+        f"{full / 'scope-plain'} exists but is not a git repository (it has no "
+        f".git)")
+    assert len({*said.values(), link_said, plain_said}) == 5, (
+        "two of the five store-side findings share a sentence")
+
+
+def test_the_STORE_SIDE_kind_LEDGER_is_pinned_two_way_to_cross_check_target():
+    """🔴 THE PREDICATE BRANCHES ON A KIND, NOT ON A SENTENCE — and this pins
+    that the ledger and the function cannot drift apart.
+
+    A kind added to `cross_check_target` without a decision about whether it is
+    store-side would silently either widen the refusal (a false alarm) or narrow
+    it (the F5 defect back, one branch over). Two-way: every kind the function
+    can return is a declared constant, and every declared constant is returned.
+    """
+    src = SCRIPT.read_text(encoding="utf-8")
+    declared = set(re.findall(r"^(NO_CROSS_CHECK_[A-Z_]+) = ", src, re.M))
+    assert declared, "no NO_CROSS_CHECK_* constants found — the pin is vacuous"
+
+    body = src.split("def cross_check_target(", 1)[1].split("\ndef ", 1)[0]
+    returned = set(re.findall(r"NO_CROSS_CHECK_[A-Z_]+", body))
+    assert returned == declared, (
+        f"cross_check_target returns {returned - declared} that is not "
+        f"declared, or declares {declared - returned} it never returns")
+
+    assert RV.STORE_SIDE_BLOCK_KINDS <= {getattr(RV, n) for n in declared}, (
+        "STORE_SIDE_BLOCK_KINDS names a kind cross_check_target cannot return, "
+        "so the refusal can never fire for it")
+    assert RV.NO_CROSS_CHECK_FOREIGN_HOST not in RV.STORE_SIDE_BLOCK_KINDS
+    assert RV.NO_CROSS_CHECK_MACHINE_ID_UNREADABLE not in RV.STORE_SIDE_BLOCK_KINDS
+    assert RV.NO_CROSS_CHECK_NO_LIVE_SCOPE in RV.STORE_SIDE_BLOCK_KINDS
 
 
 def test_an_EMPTY_artifact_is_still_a_failure_with_no_live_scope(
@@ -2023,12 +2320,21 @@ def test_the_two_NO_CROSS_CHECK_reasons_are_DISTINGUISHABLE(tmp_path, identity):
     key_own = _key("scope-alpha", now - timedelta(hours=2))
     key_foreign = _key("scope-alpha", now - timedelta(hours=2), host="other-host")
 
-    empty_store = tmp_path / "store"
-    empty_store.mkdir()
-    missing = _verify(empty_store, tmp_path / "w1",
-                      FakeDownloader({key_own: data}), identity,
-                      max_lag_days=3.0, now=now)[0]
-    foreign = _verify(empty_store, tmp_path / "w2",
+    # 🔴 The own-host run is deliberately PARTIAL — `scope-beta` is live, so the
+    # run cross-checks something and the whole-run refusal does not fire. What
+    # is under test here is the per-artifact REASON, not the exit code.
+    store = tmp_path / "store"
+    beta = _make_scope(store, "scope-beta", {"e.md": "b"}, commits=2)
+    beta_data = _make_artifact(beta, identity, tmp_path)
+    own = {v.scope: v for v in _verify(
+        store, tmp_path / "w1",
+        FakeDownloader({key_own: data,
+                        _key("scope-beta", now - timedelta(hours=2)): beta_data}),
+        identity, max_lag_days=3.0, now=now)}
+    missing = own["scope-alpha"]
+    assert own["scope-beta"].cross_checked is True, (
+        "the live half of the fixture did not compare — this run is not partial")
+    foreign = _verify(store, tmp_path / "w2",
                       FakeDownloader({key_foreign: data}), identity,
                       prefix="other-host", this_host=HOST,
                       this_machine_id=SYNTH_MACHINE_ID, explicit=True,
@@ -3022,6 +3328,43 @@ def test_SECRETS_md_points_at_the_verifier_from_the_restore_recipe():
     assert "rc=0" in recipe and "index-pack died" in recipe, (
         "the warning is an assertion with no measurement behind it — state what "
         "was observed, not that a thing is bad")
+
+
+def test_SECRETS_md_documents_the_ZERO_CROSS_CHECK_refusal_WORD_FOR_WORD():
+    """🔴 THE ARTIFACT UNDER TEST IS PROSE, SO THE WHOLE NORMALISED PARAGRAPH IS
+    PINNED, not a phrase in it.
+
+    A guard on WORDS is walkable by REWORDING, and the direction that matters
+    here is the one a reword flips silently: this behaviour was rc=0 until
+    2026-08-26, and a doc that says so again would send a disaster-recovery
+    operator to treat a non-zero exit as a broken tool. Pinning the paragraph
+    means a cosmetic edit costs a test edit — which is the price of a claim a
+    machine can check.
+    """
+    doc = SECRETS_MD.read_text(encoding="utf-8")
+    recipe = doc.split("**Restoring**", 1)[1].split("\n## ", 1)[0]
+    expected = (
+        "🔴 **A run of THIS host's artifacts in which NOT ONE scope could be "
+        "compared FAILS.** Measured 2026-08-26: `--host <this host> --store <an "
+        "empty directory>` printed every scope as `NOT CROSS-CHECKED … "
+        "self-consistency only` and exited **0** — an exit code is all a systemd "
+        "timer reads, so a wrong or absent `--store` silently downgraded the "
+        "whole run to \"the object decrypts and is internally consistent\", "
+        "which says nothing about whether it still matches the history it is a "
+        "backup of. It now exits non-zero and names the store it looked at, "
+        "distinguishing a store that **does not exist** from one that exists and "
+        "is **empty** from one that holds scopes but not this one. Two "
+        "zero-cross-check runs are deliberately still rc=0: **another host's** "
+        "artifacts (suppressing the comparison there is correct), and a "
+        "**partial** run where at least one scope did compare. So on a "
+        "disaster-recovery machine with no store yet, expect a non-zero exit — "
+        "read the per-artifact lines, which still say each artifact restored and "
+        "passed `fsck`.")
+    assert " ".join(expected.split()) in " ".join(recipe.split()), (
+        "SECRETS.md's restore recipe no longer carries the zero-cross-check "
+        "paragraph verbatim. If you reworded it deliberately, update this "
+        "literal — but re-read it first: the claim it makes is that the run "
+        "FAILS, and the previous behaviour was exit 0.")
 
 
 def test_the_PRODUCER_points_at_the_verifier_for_the_downstream_half():


### PR DESCRIPTION
## The defect (F5), reproduced live

Against the **real bucket**, on `origin/main`:

```
restore-verify.py --host <this host> --store <an empty directory>
-> rc=0
   13 x "RESTORED N commit(s) ..., fsck OK ... NOT CROSS-CHECKED
         (no live scope repository at ...) - self-consistency only"
   "verified 13 artifact(s): 0 against the live store (0 commit(s) compared...),
    13 self-consistency only"
```

**An exit code is the only thing a systemd timer reads.** So a wrong or absent
`--store` silently downgraded the whole run to *"the artifact decrypts and is
internally consistent"* — which says nothing about whether the backup still
matches the history it is a backup **of** — and reported success while doing it.

This is the STORE-side twin of the refusal `diagnose_empty_prefix` already makes
for the BUCKET side, whose docstring spells out the argument: *"THE EXIT-0
VARIANT IS WORSE THAN THE REFUSAL."* It also blocked the ranked follow-up of
putting the verifier on a timer at all — shipping the timer first is precisely
the harm F5 describes.

## The fix

### 1. The refusal fires on an observed property (commit 1)

Three conjuncts, each able to fail on its own and each keyed on what was
**observed**, never on "was a flag typed" (the mistake `run()`'s own v1/v2/v3
note records in the opposite direction):

| conjunct | what it excludes |
|---|---|
| `verdicts` | a run that verified ZERO artifacts has its own, louder finding |
| `scopes_with_a_live_target == 0` | ONE usable live target anywhere clears it — a partial run, and a run whose only comparable artifact was corrupt |
| `store_blocked_scopes` | at least one scope was dropped by the STORE side, not because the artifacts are another host's |

`not any(v.cross_checked ...)` is **deliberately absent** — the sweep scored
flipping it to `not all(...)` **SURVIVED**, the honest answer for a conjunct
that cannot fail.

The predicate branches on a **machine-readable kind**, not a sentence.
`cross_check_target()` returns `(live, reason, kind)`; `STORE_SIDE_BLOCK_KINDS`
is a membership ledger pinned two-way against the function's own return paths.

**Not a permanently-red gate** — FOREIGN artifacts, PARTIAL runs, and a host
that never ran the backup are outside it by construction, each with its own
control test.

### 2. `40 NOTHING-CROSS-CHECKED` — its own exit code (commit 2)

`rc=1` conflated **"your backups restored perfectly, I just could not compare
them"** with **"your backups are broken"**. `escrow-verify.py` — same directory
— carries nine codes for exactly this reason, and SECRETS.md documents each with
per-code "do not rotate" guidance: *"Every cause has its own exit code, so a
timer can act on the number."*

- `EXIT_CODES = {"NOTHING-CROSS-CHECKED": 40}`, escrow's convention, pinned as
  an exact dict both ways. **40, not 10–34**, because SECRETS.md documents both
  tables and an operator mapping a number must not find two answers — held by a
  new cross-module seam test pinning the two tables **disjoint**.
- The code is **derived from the token**, never passed in; an unknown token is a
  loud `KeyError`. `token=None` keeps `EXIT_FAILED=1`, so every other raise in
  the file is unchanged.
- **A real failure outranks it.** A corrupt artifact beside an absent store
  exits `1`, not `40` — the same conflation pointed the other way. The finding
  is still printed.
- `--print-plan` renders the table, because that is where the refusal's remedy
  sends the reader.

### 3. The message asserts no mechanism (commit 2)

The first version ended *"Point `--store` at the live store, or fix it"* —
advice the one operator who most needs this tool **cannot follow, because in a
real disaster there is no live store to point at.** "You pointed at the wrong
store" and "the store is genuinely gone" are the **same observable**; that is
the empty-result trap RULES.md names, and the text walked into it. Rewritten to:

1. **lead with what is proven, and it is good news** — N artifacts DECRYPTED,
   RESTORED and passed `git fsck`;
2. **name both rival mechanisms** and say plainly that nothing measured
   separates them, so neither is asserted. The pair is chosen by observed store
   state: a POPULATED store missing one scope cannot be blamed on `--store`
   naming nothing, so it gets the scope-level pair;
3. **a remedy that works under either reading** — `--print-plan` shows the store
   path this run used, touching neither network nor key;
4. keep the true statement that self-consistency proves nothing about matching
   the history it is a backup of.

`--scope X` that compares nothing lands here too, same code and shape: narrowing
the question does not make the answer decidable.

### 4. F6 — "no local store" was three facts sharing one sentence

`store_state()` / `why_no_live_scope()` split them: **DOES NOT EXIST** /
**EXISTS but holds NO scope repositories** / **holds N scopes but none named
X**, plus a symlink (never followed) and a directory with no `.git`.

### 5. The deleted test's intent, restored

`test_an_absent_live_scope_verifies_SELF_CONSISTENCY_and_says_so` carried an
explicit 🔴 decision — *"failing here would make the verifier useless at the
exact moment it is needed"* — and commit 1 reversed it without reconciling it.
That concern is **not obsolete** and is now cited in
`test_the_STORE_refusal_reaches_the_PROCESS_EXIT_CODE_as_FORTY`. What **is**
obsolete is the conclusion that exit 0 honours it: exit 0 is what a timer reads
as "the backups are fine", a claim the run could not make. It is answered by the
distinct code, the good-news-first message, and per-artifact output that is
unchanged — all three asserted in that test.

### 6. The message asserts no mechanism it cannot see (commit 3)

A delta audit found the round-2 message still over-claiming, in three ways that
all land on the disaster path:

- **The remedy was wrong exactly when it mattered.** *"`--print-plan` prints the
  store path this run used"* is **false with no `--store`** — it prints the
  *default*. A run that failed *because* `--store` was wrong sent the operator to
  a command showing a different path, manufacturing the very diagnosis the
  message refuses to assert. It now quotes the path it already has in hand, and
  references `--print-plan` only **with the same flags**.
- **The "both mechanisms" pair was a CLOSED disjunction that excluded the
  truth.** Measured live: a scope that is a **symlink**, and a scope directory
  with **no `.git`**, both reached exit 40 being told the store *"EXISTS but
  holds NO scope repositories"* and offered only *(1) `--store` is wrong* or
  *(2) the store is GONE*. Both false — the repository is right there and
  `--store` is correct. `why_no_live_scope` now **returns** `(kind, sentence)`
  over five `WHY_*` values; `_MECHANISMS` maps kind → what is *consistent* with
  it; the list is declared **"AT LEAST … and the list is NOT closed"**; and the
  tail says *"something on the LIVE side is missing or unreachable"* — true
  under gone, renamed, symlinked and no-`.git` alike.
- **The count over-claimed under `--scope`** ("N artifacts under the prefix"
  when only one scope ran). Fixed to *"all N artifact(s) this run verified
  (scope 'X' under …)"*.

Plus: `--print-plan` no longer says the run "FAILS" twelve lines above the block
saying 40 is not a verdict; the refusal is emitted **once**, not twice; and it is
prefixed `ALSO:`, never `FAILED`.

### 🔴 The #851 trap was reproduced INSIDE the fix for it

Round 2's commit message asserted *"THE #851 CONTROL RAN"* — and it had, against
`nothing_cross_checked_message` **only**, while the `--print-plan` text added in
the **same commit** carried the same load-bearing claim unpinned. An auditor
rewrote it to *"40 IS a verdict against the backups: NO artifact restored and
FAILED fsck … It is NEVER the expected code"* → **342 passed, 0 failed.**

So round 3 swept the delta for the *class* rather than the reported instance,
and found two more copies: the module docstring (which **is** `--help` —
`argparse(description=__doc__)`) and the per-artifact reason `cross_check_target`
composes. All three are now whole-string pinned.

### 7. Four guards that read as coverage while providing none (commit 4)

A delta audit confirmed all nine round-3 fixes but reported four more, all in
this PR's own delta:

- 🟡 **The ordering invariant was not pinned — the fixture could not see it
  break.** Round 3 switched `seen` to (kind, sentence) sorting so observations
  line up with the mechanisms explaining them, and wrote a test whose docstring
  says writing the expectation independently is what caught the old behaviour.
  Mutating it straight back **SURVIVED the full 349-test suite**: in that fixture
  (symlink + *absent* scope) both orderings emit a byte-identical message. The
  round-3 comment even recorded the coincidence — *"Sentences sorted; kinds
  sorted"* — without noticing it made the guard vacuous. **The shipped code was
  correct; this was a fixture defect.** `scope-beta` is now a `.git`-less
  *directory*, which makes the orderings genuinely opposite, plus a positive
  control (`by_kind != by_sentence`) so it cannot silently go vacuous again.
- 🟢 **The ledger pin said nothing about what the function RETURNS.** A sixth
  branch spelling its kind inline satisfied `_MECHANISMS ↔ WHY_KINDS` and would
  then `KeyError` **inside the refusal an operator reads during a recovery**.
  Every return now goes through `_why()`, which refuses a kind outside
  `WHY_KINDS`; a test calls it directly so the guard is **reachable** and its
  deletion is a mutation that can be watched to fail.
- 🟢 **`--print-plan` was pinned in two `in`-blocks, not whole** — a
  contradicting paragraph added *elsewhere* on that screen survived. An operator
  reads the screen, so the screen is the unit: the whole rendered plan is pinned
  by equality, with the machine id **redacted by regex** rather than committed.
- 🟢 **The count was pinned against `len(keys)` but not against a scope count.**
  Every fixture had one artifact per scope, so `len(by_scope)` and
  `len(store_blocked_scopes)` both survived; under `--all` they diverge and the
  message would under-count. New fixture: one scope, two artifacts, `--all`.

### 8. Two guards whose description was wider than their implementation (commit 5)

Test-strength only — **no shipped behaviour changes in this commit**; it touches
the test file alone.

- 🔴 **The "no branch bypasses `_why`" assert was SPELLED, not structural.** It
  collected only lines starting with `"return "`. Two valid, lint-clean
  bypassing spellings **survived a fully green 165-test suite** —
  `if scope == "sixth": return "scope-sixth", "x"` (same-line body) and
  `return("scope-sixth", "x")` (no space) — and there is **no Python linter
  anywhere in the gate** (zero hits for ruff/flake8/pylint/pycodestyle across
  `gate.sh`, `run-tests.sh`, `flake.nix`), so nothing else refused either. That
  assert is the only thing between a future sixth branch and a `KeyError`
  **inside the refusal an operator reads during a recovery**. It now `ast.walk`s
  the `FunctionDef` for `ast.Return` nodes and requires each `n.value` be a
  `Call` to `_why` — which also retires the `split("\ndef ")` body extraction.
- 🟡 **"The whole rendered plan is pinned" held for one rendering of two.**
  `print_plan` returns early on an empty store, and the pin's store never
  existed — so everything after that early return was unpinned. Appending
  `print("note: exit 40 DOES mean your backups are broken.")` after the
  **populated** `local:` loop survived. Now two equality-pinned cases share one
  literal body, and the populated case carries a positive control asserting it
  really took the other branch.

Nits in the same commit: unused `tmp_path` removed; the failure message no
longer interpolates raw stdout (it put the **unredacted machine id** into the
run log — the committed file was always clean, the log path was not); the new
fixture uses the frozen `NOW`.

**Not changed, deliberately:** `scopes=sorted(by_scope)` survives, and the audit
is right that it is an **equivalent mutant** — `foreign-host` and
`machine-id-unreadable` are run-level, so whenever the refusal fires the two
lists are provably identical. A test for an equivalent mutant is coverage
theatre.

## Verification

**Red/green matrix.** Base `0716fede` is this branch's merge-base; `main` is now
`6a145112` (re-measured this round — it moves often).

| control | red | green |
|---|---|---|
| whole PR vs current `main` | **20+** | 0 |
| round-3 delta vs `34131917` | **11** | 0 |
| round-4 delta vs `3124fbbc` | **1** | 0 |
| round-5 delta vs `39d5c3aa` | **0** | — |

🔴 **Round 5 is MUTATION-ONLY: it changes no source behaviour at all**, so a red
count against a base sha would be zero and quoting one would be dishonest.
Rounds 1–4 likewise separate behavioural reds (carrying the defect's own
symptom) from structural ones (the module has no `EXIT_CODES` / `token` /
`WHY_*` at base), which are labelled and not counted as behavioural coverage.

**Mutation-only fixes are demonstrated as the PAIR they have to be** — same
mutant, same source, only the test file differing:

| mutant | old tests | new tests |
|---|---|---|
| sentence-sorting (round 4) | **SURVIVED** at `3124fbbc` | **DIED** — `test_TWO_DIFFERENT_observations_…` |
| sixth branch, **same-line body** (round 5) | **SURVIVED** at `39d5c3aa` | **DIED** — `test_a_kind_OUTSIDE_the_ledger_CANNOT_be_returned` |
| sixth branch, **no space after `return`** (round 5) | **SURVIVED** at `39d5c3aa` | **DIED** — same guard |
| paragraph after the **populated** `local:` loop (round 5) | **SURVIVED** at `39d5c3aa` | **DIED** — `test_print_plan_on_a_POPULATED_store_is_pinned_WHOLE_too` |

Each is killed by the guard that claims to cover it.

**Mutation sweep — 19/19 (round 5), both instrument controls:**

```
dry-run: all 19 anchors match exactly once   <- before spending any wall clock
BASELINE (unmutated): rc=0  352 passed       <- required GREEN first
ok  SURVIVED (want SURVIVE)  noop-control
ok  DIED  B1 sixth branch, SAME-LINE body        <- survived the spelled assert
ok  DIED  B1 sixth branch, NO SPACE after return <- survived the spelled assert
ok  DIED  B1 a real branch swapped to a bare tuple
ok  DIED  B2 contradicting paragraph AFTER the populated local: loop
ok  DIED  B2 the populated local: line loses its commit count
ok  DIED  B2 contradicting paragraph in the SHARED region
ok  DIED  R1/R2/R3/R4 x11  (every earlier mutant re-run)
```

Every sandbox `cp -a` then `rm -f <copy>/.git`, `__pycache__` purged, **zero
`.pyc` asserted**, **every mutant asserts replacement count == 1**. Earlier
rounds ran 24/24, 31/31 and 22/22 on the same controls.

**Both tiers, named separately — and on the MERGED tree** (`6a145112` + this
branch = `abefc05e`; `strict: false`, so a branch green is never a claim about
the merged tree):

| tier | tree | verdict |
|---|---|---|
| nix sandbox `pytests` (**Tekton's tier**) | **merged** | **rc=0** — `scripts/tests` 8,845/8,845; TOTAL 17,298 collected / 17,296 passed / 0 failed |
| nix sandbox `nodetests` | **merged** | **rc=0** — 1,292/1,292 |
| dev-host `gate.sh --tier both` | **merged** | `RESULT=PASS exit=0` |

The merge is clean textually **and** the suite passes on the tree it creates —
`git merge` exiting 0 only says there was no textual conflict.

**Live** (real bucket), exit codes read from `subprocess`, no pipe:

| run | rc | |
|---|---|---|
| `--store <empty dir>` | **40** | emitted **once**, no `FAILED` prefix, *"all 13 artifact(s) this run verified (every scope under …)"*, store path quoted |
| real default store | **0** | 13/13 against the live store, 273 commits compared |
| **symlinked** scope | **40** | names the symlink mechanism; **zero** occurrences of *"the live store is GONE"* |
| `--print-plan` | **0** | lists `40=`; **zero** occurrences of the old *"FAILS"* sentence |

## Also fixed along the way

`test_SECRETS_md_exit_codes_agree_with_the_module` scrapes **every**
`` | `NN` `TOKEN` | `` row in SECRETS.md but checked them against escrow's table
alone — so a correctly-documented restore-verify row read as a doc error, which
would have been "fixed" by deleting the row. It now resolves against the union,
which the disjointness guard makes unambiguous.

Two existing tests encoded the defect as intended behaviour (one was literally
named `..._EXITS_ZERO_through_the_real_CLI`). They are now the **partial-run**
controls, each asserting its live half actually compared.

## Not fixed here

- Putting `restore-verify.py` on a systemd timer is now unblocked but **not
  done**. When it lands, `40` should be treated as an alert distinct from `1`.
- `escrow-verify.py` takes the new 3-tuple and ignores the kind on purpose: it
  verifies one artifact and asks a different question.
- `1` still means both "a check failed" and "an unexpected exception", matching
  escrow's meaning for `1`. Splitting it is a separate change with its own blast
  radius.
- 🔴 **A pre-existing load-sensitive flake in `scripts/tests/test_git_repo_
  isolation.py`** (details under "Both tiers"). It is one line —
  `_GIT_ENV` should merge `hermetic_git.MAINTENANCE_OFF`, as five other test
  modules here already do. Left alone deliberately: it is unrelated to this
  diff, in a file another session may own, and folding it in would widen a PR
  that is under delta audit. **Closing condition, mechanical:** that env merge
  lands, and the test passes in the sandbox tier while a second full gate run is
  loading the box. Checked by whoever picks it up re-running that pair.
  ⚠ It can bite Tekton, which runs this tier on shared hardware.
- 🔴 **A scope directory with mode `000` exits `1` with a traceback instead of
  `40`** — `live_scope_path` raises `PermissionError` *before* `why_no_live_scope`
  runs, so an unreadable store on the **disaster path** reads as "your backups
  failed". Pre-existing; untouched by this diff. **Closing condition:** that
  probe is made permission-safe and a mode-`000` scope reaches the `40` message
  with its own observation, verified by a test that chmods a fixture scope.
- 🟢 **A `--store` that is a regular FILE reports "the store directory DOES NOT
  EXIST"** (`store_state` asks `is_dir()`). Misleading but not false-alarming, and
  pre-existing. **Closing condition:** `store_state` distinguishes "exists but is
  not a directory", pinned like the other five states.
- 🟢 **A scope path that is a regular FILE reports `scope-not-present`.**
  Literally true and inoculated by the "AT LEAST … NOT closed" wording.
  **Deliberately left** — the audit and I agree it needs no change; recorded so
  the next reader does not re-derive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoNKoJzhyPyrrWrS1oMuGh
