### PR TITLE
fix(present): --sanitize WITHHOLDS harvested prose instead of pretending to scrub it

### DIFF
--- a/claudedocs/handoff-cairn.md
+++ b/claudedocs/handoff-cairn.md
@@ -56,27 +56,54 @@ team instance, each measured rather than assumed.
 
 ## Open investigations — live diagnosis state
 
-### The sanitized export leaks three scope names
-- **Symptom + exact repro:** `python3 -m scripts.present.generate --sanitize -o <path>` prints
-  two `🔴 SANITIZE DEGRADED` lines — *"hostname indistinguishable from a word"* and *"scope
-  matched in its exact form only"* — and the output retains real scope names.
-- **Observed (with values):** counts in sanitized vs full output —
-  `naida 2 vs 2` (**wholly unsanitized**), `vetr 3 vs 4`, `auditloop 3 vs 4`.
-  Positive control on the same run proves the mechanism works: `civitai 0 vs 5`,
-  `datapacket 0 vs 2`, `kubeclaw 0 vs 2`, `zacx.dev 0 vs 3`.
-- **Ruled out:** the sanitizer being broken generally — four identifier classes go to zero.
-  Ruled out an operator-identity leak: username, email and FQDNs all sanitize to 0.
-- **Leading hypothesis:** short, word-like scope names (`naida`, `vetr`, `auditloop`) fall below
-  the length ladder / exact-form rule in `scripts/present/sanitize.py`, which was deliberately
-  narrowed so that rewriting the English acronym `CLI` (a real scope) stopped corrupting prose.
-  The fix is likely a scope allowlist keyed on the store's own scope set rather than a length
-  heuristic.
-- **Why it matters beyond tidiness:** "the portable export serves the off-workbench reader" is
-  the argument that justified deferring LAN/nebula reach. If the export is not clean, that
-  argument is weaker than stated. With a **team instance** it stops being cosmetic entirely and
-  becomes an entitlement boundary.
-- **Next probe:** `sed -n '/def .*scope/,/^def /p' scripts/present/sanitize.py` and read the
-  length ladder; then check whether `measure`'s scope set can drive substitution directly.
+### ~~The sanitized export leaks three scope names~~ — DIAGNOSED AND FIXED
+🔴 **The leading hypothesis in the previous handoff was WRONG, and acting on it would not
+have fixed the leak.** It read: *short, word-like scope names fall below the length ladder;
+the fix is a scope allowlist keyed on the store's own scope set.* Measured 2026-08-26:
+
+- **They were not scopes at all.** The store's scope set is `civitai`, `civitai-*`,
+  `claude-pool`, `cli`, `datapacket-talos`, `devrc`, `flipt-state`, `homelab-infra`,
+  `homelab-talos`, `kubeclaw`, `storage-resolver`. `naida`, `vetr` and `auditloop` are absent,
+  so the scope class removed **zero** of the leaked occurrences — the one that *did* vanish in
+  each pair (`vetr.com`, `auditloop.zacx.dev`) went via the **host** rule.
+- **The length ladder was a red herring.** `auditloop` is 9 chars and would have been matched
+  aggressively *if it had been a scope*.
+- **The store's scope set was already the substitution source** (`sanitize.build()` →
+  `measurements.by_key("index.store")`). It is a curated index, not an inventory of names that
+  must not leak.
+- **The real class:** all three survivors sat in the `skills.inventory` row — human-authored
+  prose harvested out of `claude/skills/*/SKILL.md`. Substitution redacts identifier CLASSES it
+  has been shown; a harvested sentence has no class at all.
+
+🔴 **Widening the name list was tried and REJECTED ON MEASUREMENT, not on taste.** Sourcing
+names from the index store + the skill directories + all 149 directories under `~/workspace`
+still left `naida` **fully intact** — the directory is `naida-ai` and the leak was a bare
+`naida` in a sentence — while corrupting ordinary English: `"run the test suite from a scratch
+dir"` → `"run the scope-108 suite from a scope-104 dir"`. **A name list is fail-OPEN by
+construction**; it closes exactly the names something happened to be called after, and an
+entitlement boundary may not be.
+
+**The fix (this PR):** a measurer DECLARES what each column holds
+(`Measurement.column_kinds`): `""` ordinary, `"name"` a local identifier substituted *inside
+that cell only*, `"prose"` **withheld** in a sanitized build. Withholding is driven by the
+declaration, never by a name list, so it still happens on a host where every name source is
+empty. An unknown kind is withheld too — the fail-closed direction.
+
+- **Verified** — every client name to 0, with the mechanism proven live, not a bare zero:
+  `naida 2→0`, `vetr 4→0`, `auditloop 4→0`; controls `civitai 5→0`, `datapacket 2→0`,
+  `kubeclaw 2→0`, `zacx.dev 3→0`; page still renders **37 rows, 37 withheld cells, 77 name
+  stand-ins**; ordinary prose uncorrupted (`test` 23 in both builds).
+- **Residual, stated honestly:** devrc's *own* subsystem names still appear — in file paths
+  (`scripts/repo-cos/tests`), systemd unit names (`repo-cos.timer`) and `content.py`'s static
+  narrative, none of which pass through a declared column. That is correct: the page is *about*
+  devrc. It would become a leak if a script were ever named after a client.
+- 🔴 **Two `SANITIZE DEGRADED` lines still print, and both are honest.**
+  *"hostname indistinguishable from a word"* is the nodename; *"scope matched in its exact form
+  only"* is the 3-char scope `cli`. Both are deliberate declines, counted in the legend. They
+  are **not** the leak and were never related to it.
+- **Separately worth a decision (not fixed here):** `claude/skills/*/SKILL.md` is tracked in
+  this **public** repo, so those client names are already published in git. The sanitizer is now
+  correct; the repo-level exposure is a different question.
 
 ### Tekton silently did not fire for one push
 - **Symptom + exact repro:** pushed `4b9e692a` to a PR branch; both required checks sat
@@ -108,11 +135,9 @@ team instance, each measured rather than assumed.
   trade.
 
 ## Next steps (ranked)
-1. **Fix the sanitizer leak** — `scripts/present/sanitize.py`. Drive substitution from the
-   store's own scope set (which `measure` already resolves) instead of a length/word heuristic.
-   Verify with the control pair, never a bare zero. Repo: `devrc`. **Do this before the team
-   instance** — the heuristic *becomes* the entitlement boundary the moment someone who is not
-   Zach reads a page.
+1. ~~**Fix the sanitizer leak**~~ — **DONE**, see the diagnosis above. The proposed fix was
+   measured not to work and was replaced: declaration-driven **withholding** of harvested
+   prose, plus name substitution confined to declared identifier cells.
 2. **Build `cairn who <task>`** — the task→session→window→transcript resolver. Every hop exists;
    only the join is missing (see the Gotchas block below for the exact chain). Repo: `devrc`.
    This is the first capability that is *about* Cairn rather than inherited from devrc.
@@ -207,8 +232,12 @@ curl -s http://192.168.50.250:8900/ | grep -c 'Where the three touch'   # expect
 ssh zach@10.42.0.100 '(echo >/dev/tcp/192.168.50.250/8900) 2>/dev/null && echo OPEN || echo CLOSED'
 #   expect: CLOSED   (and 22/443 OPEN, proving the probe works)
 
-# the sanitizer leak, with its positive control
-python3 -m scripts.present.generate --sanitize -o /tmp/san.html   # prints 2 DEGRADED lines
-grep -oic naida /tmp/san.html      # expect 2  — leaked
-grep -oic civitai /tmp/san.html    # expect 0  — control: the mechanism works
+# the sanitizer, with BOTH controls — a bare zero cannot tell a working
+# sanitizer from one wired to nothing, so check the page still has content
+python3 -m scripts.present.generate --sanitize -o /tmp/san.html   # 2 DEGRADED lines, both honest
+grep -oic naida /tmp/san.html        # expect 0  — was 2 before the fix
+grep -oic civitai /tmp/san.html      # expect 0  — control: substitution works
+grep -oc 'WITHHELD' /tmp/san.html    # expect 37 — positive control: the page is NOT empty
+grep -oc 'name-[0-9][0-9]' /tmp/san.html   # expect 77 — identifiers renamed, not dropped
+grep -oic ' test ' /tmp/san.html     # expect 23 — control: ordinary prose NOT corrupted
 ```

--- a/claudedocs/handoff-cairn.md
+++ b/claudedocs/handoff-cairn.md
@@ -234,10 +234,18 @@ ssh zach@10.42.0.100 '(echo >/dev/tcp/192.168.50.250/8900) 2>/dev/null && echo O
 
 # the sanitizer, with BOTH controls — a bare zero cannot tell a working
 # sanitizer from one wired to nothing, so check the page still has content
+# 🔴 `grep -o | wc -l`, NEVER `grep -oc`. With GNU grep, `-c` counts matching
+# LINES and overrides `-o`, so the positive controls below return 1 instead of
+# 37/77 and the fix reads as failed. This host's `grep` is a ugrep WRAPPER where
+# `-oc` does count occurrences — which is exactly why the wrong form looked fine
+# when it was written. The piped form is right under both.
 python3 -m scripts.present.generate --sanitize -o /tmp/san.html   # 2 DEGRADED lines, both honest
-grep -oic naida /tmp/san.html        # expect 0  — was 2 before the fix
-grep -oic civitai /tmp/san.html      # expect 0  — control: substitution works
-grep -oc 'WITHHELD' /tmp/san.html    # expect 37 — positive control: the page is NOT empty
-grep -oc 'name-[0-9][0-9]' /tmp/san.html   # expect 77 — identifiers renamed, not dropped
-grep -oic ' test ' /tmp/san.html     # expect 23 — control: ordinary prose NOT corrupted
+grep -o -i naida /tmp/san.html   | wc -l   # expect 0  — was 2 before the fix
+grep -o -i civitai /tmp/san.html | wc -l   # expect 0  — control: substitution works
+grep -o WITHHELD /tmp/san.html   | wc -l   # >0 — positive control: the page is NOT empty
+grep -o 'name-[0-9][0-9]' /tmp/san.html | wc -l   # >0 — identifiers renamed, not dropped
+grep -o -i ' test ' /tmp/san.html | wc -l  # equal in BOTH builds — prose NOT corrupted
 ```
+🔴 **Do not pin the last four to a literal count here.** They move whenever a skill or an rc
+code is added, and a stale number in a doc reads as a failed fix. Compare the sanitized build
+against the full one from the same commit instead.

--- a/scripts/present/__init__.py
+++ b/scripts/present/__init__.py
@@ -4,7 +4,9 @@ Four modules, one direction of dependency:
 
     measure.py   takes every number at build time; owns `UNMEASURED`
     content.py   the prose and the hand-authored inline SVG; owns NO numbers
-    sanitize.py  swaps real identifiers for synthetic stand-ins (`--sanitize`)
+    sanitize.py  `--sanitize`: swaps real identifiers for synthetic stand-ins,
+                 and WITHHOLDS columns a measurer declared to hold harvested
+                 human prose — substitution cannot redact a sentence
     render.py    assembles one self-contained HTML file
     generate.py  the CLI, and the only place that decides a build has failed
 

--- a/scripts/present/content.py
+++ b/scripts/present/content.py
@@ -664,6 +664,13 @@ SECTIONS: tuple[Section, ...] = (
                 "tier had simply never been run.")),
             ("measure", "gate.tiers"),
             ("p", (
+                "The gate reports its own inability to answer as a distinct code. "
+                "<b>90 is not &ldquo;the tests failed&rdquo;</b> &mdash; it means the runner's "
+                "verdict and its exit status disagreed, or the run was truncated, so the "
+                "gate cannot vouch for it. Debugging a diff against a 90 is debugging the "
+                "wrong thing.")),
+            ("measure", "gate.exit_codes"),
+            ("p", (
                 "Whether a check <i>runs</i> and whether it <i>blocks</i> are different "
                 "facts, and the repo's machine-checked marker sees only the first. One day "
                 "here exactly one of the two required contexts was listed, and it collected "

--- a/scripts/present/generate.py
+++ b/scripts/present/generate.py
@@ -96,7 +96,9 @@ def main(argv=None) -> int:
                     help="output HTML path (default: present.html)")
     ap.add_argument("--repo", default=None, help="repo root to measure (default: this checkout)")
     ap.add_argument("--sanitize", action="store_true",
-                    help="swap real identifiers for synthetic stand-ins, for a shareable copy")
+                    help="shareable copy: swap real identifiers for synthetic "
+                         "stand-ins, and WITHHOLD harvested prose (which no "
+                         "substitution can redact) rather than pretend to clean it")
     ap.add_argument("--no-systemd", action="store_true",
                     help="skip systemd probing (that row then renders UNMEASURED, with the reason)")
     ap.add_argument("--no-network", action="store_true",

--- a/scripts/present/measure.py
+++ b/scripts/present/measure.py
@@ -776,7 +776,7 @@ def m_gate_tiers(env: Env) -> dict:
 
 
 def m_gate_exit_codes(env: Env) -> dict:
-    """`gate.sh`'s exit-code legend, parsed out of its own header comment.
+    """`gate.sh`'s exit-code legend, parsed out of its `# Exit:` comment block.
 
     Split out of `m_gate_tiers` deliberately — see the note there. This is the
     HARVESTED half: whoever edits `scripts/gate.sh` writes these sentences, so
@@ -806,8 +806,8 @@ def m_gate_exit_codes(env: Env) -> dict:
     #: `{"0","1","2","90"}` allowlist as "dead code". It was dead as a
     #: REACHABILITY matter and load-bearing as a VALUE bound: it was the only
     #: thing confining the harvest to real exit codes. With it gone and the
-    #: pattern anchored on nothing but `^#`, any of `gate.sh`'s 99 comment lines
-    #: that happens to read `# N = …` became an exit code on the page. Measured:
+    #: pattern anchored on nothing but `^#`, ANY comment line in `gate.sh` that
+    #: happens to read `# N = …` became an exit code on the page. Measured:
     #: one ordinary body comment (`#   7 = the number of retries …`) rendered a
     #: fifth code, with the suite green.
     #:
@@ -838,7 +838,7 @@ def m_gate_exit_codes(env: Env) -> dict:
             "no `# Exit: N = …` legend block was found in scripts/gate.sh — an "
             "empty parse is a broken read, not a script without exit codes")
     return dict(
-        value=f"{len(rows)} exit codes documented in gate.sh's header",
+        value=f"{len(rows)} exit codes in gate.sh's `# Exit:` legend block",
         detail=(
             "🔴 90 is the one to understand: it means the runner's own verdict "
             "and its exit status DISAGREED, or a run was truncated. That is "

--- a/scripts/present/measure.py
+++ b/scripts/present/measure.py
@@ -728,8 +728,6 @@ def m_gate_tiers(env: Env) -> dict:
     # The derivation NAME is the reliable token: `checks.${system} = { … }` is
     # an interpolated attrset, so the attribute path is not literally in the file.
     checks = sorted(set(re.findall(r'runCommandLocal\s+"devrc-([a-z0-9-]+)"', ftext)))
-    gtext = gate.read_text(encoding="utf-8", errors="replace")
-    exits = sorted(set(re.findall(r"^#\s+(\d+)\s*=\s*(.+)$", gtext, re.M)))
     #: 🔴 THE TIERS ARE A STRUCTURE, SO THE COUNT IS DERIVED FROM IT. This layer's
     #: charter is that no quantity is TYPED — a literal `2` here would be the
     #: first hand-maintained number on a page built to have none, and it would
@@ -742,7 +740,6 @@ def m_gate_tiers(env: Env) -> dict:
         ("sandbox source", "a `cp -r ${./.}` store copy with NO .git — repo-local git facts evaluate differently"),
         ("gate.sh could-not-vouch code", "90 — status/content disagreement or a truncated run; NOT 'the tests failed'"),
     ]
-    rows += [(f"gate.sh exit {code}", desc.strip()) for code, desc in exits if code in {"0", "1", "2", "90"}]
     return dict(
         value=(f"{len(tiers)} tiers, {len(checks)} flake checks" if checks
                else f"{len(tiers)} tiers"),
@@ -757,12 +754,49 @@ def m_gate_tiers(env: Env) -> dict:
         ),
         source="scripts/gate.sh header + flake.nix checks",
         columns=("tier / fact", "what it is"),
-        #: The tail of this column is `desc.strip()` lifted out of `gate.sh`'s
-        #: exit-code comments — a sentence a human edits freely, in a file this
-        #: module does not own. Same class as the skill descriptions, so it gets
-        #: the same treatment. It names no third party TODAY; that is a property
-        #: of the current contents, not of the column, and the contents change
-        #: without a commit here.
+        #: 🔴 NO DECLARATION, AND THE SPLIT BELOW IS WHY. Every cell here is a
+        #: literal written in THIS module and reviewed with it, so none of it is
+        #: harvested prose. The harvested half — `gate.sh`'s exit-code comments —
+        #: used to share this column, which forced the whole column to be
+        #: declared `prose`; that withheld the two tier COMMANDS as well, and
+        #: those commands are the entire argument of the section this table sits
+        #: in. Withholding was correct and the granularity was not: `column_kinds`
+        #: is per COLUMN, so mixing authored and harvested text in one column
+        #: makes the safe half pay for the unsafe half. Separated into
+        #: `m_gate_exit_codes` instead.
+        rows=tuple(rows),
+    )
+
+
+def m_gate_exit_codes(env: Env) -> dict:
+    """`gate.sh`'s exit-code legend, parsed out of its own header comment.
+
+    Split out of `m_gate_tiers` deliberately — see the note there. This is the
+    HARVESTED half: whoever edits `scripts/gate.sh` writes these sentences, so
+    the column is `prose` and a sanitized build withholds it. The CODES stay
+    visible, which is the part a reader needs to look one up.
+    """
+    gate = env.repo / "scripts" / "gate.sh"
+    if not gate.is_file():
+        raise Unmeasurable(f"{gate} does not exist")
+    gtext = gate.read_text(encoding="utf-8", errors="replace")
+    exits = sorted(set(re.findall(r"^#\s+(\d+)\s*=\s*(.+)$", gtext, re.M)))
+    rows = [(code, desc.strip()) for code, desc in exits if code in {"0", "1", "2", "90"}]
+    if not rows:
+        raise Unmeasurable(
+            "no `# N = …` exit-code lines were found in scripts/gate.sh — an "
+            "empty parse is a broken read, not a script without exit codes")
+    return dict(
+        value=f"{len(rows)} exit codes documented in gate.sh's header",
+        detail=(
+            "🔴 90 is the one to understand: it means the runner's own verdict "
+            "and its exit status DISAGREED, or a run was truncated. That is "
+            "'this gate cannot vouch for the run', which is not the same claim "
+            "as 'the tests failed' — read the log rather than debugging a diff "
+            "against it."
+        ),
+        source="scripts/gate.sh header comment",
+        columns=("exit", "meaning"),
         column_kinds=("", "prose"),
         rows=tuple(rows),
     )
@@ -1579,6 +1613,8 @@ REGISTRY: tuple[tuple[str, str, str, object, str], ...] = (
      "python -c \"import sys;sys.path.insert(0,'scripts');from present.measure import WORK_INTAKE;print(*WORK_INTAKE,sep=chr(10))\""),
     ("gate.tiers", "constraints", "The two gate tiers", m_gate_tiers,
      "nix develop --impure --command bash scripts/gate.sh --tier both"),
+    ("gate.exit_codes", "constraints", "gate.sh's exit-code legend", m_gate_exit_codes,
+     "grep -E '^#\\s+[0-9]+\\s*=' scripts/gate.sh"),
     ("gate.protection", "constraints", "What actually BLOCKS a merge", m_branch_protection,
      "gh api /repos/<owner>/<repo>/branches/main/protection --jq .required_status_checks"),
     ("tests.pytest", "constraints", "Per-target collected-test floors", m_pytest_floors,

--- a/scripts/present/measure.py
+++ b/scripts/present/measure.py
@@ -115,10 +115,21 @@ class Measurement:
     #:             enumerate what a sentence might name.
     #:
     #: `PROSE_LEDGER` in `scripts/tests/test_present_sanitize.py` pins the
-    #: declarations two-way — a registry key that gains or loses one fails the
-    #: suite — because a measurer that starts harvesting prose without saying so
-    #: is precisely the leak this field was added to stop, and it is invisible
-    #: in a diff that only adds a `rows.append`.
+    #: declarations two-way — a registry key that gains, loses or CHANGES one
+    #: fails the suite.
+    #:
+    #: 🔴 READ WHAT THAT DOES AND DOES NOT COVER, because the first version of
+    #: this comment claimed more than the test delivers. The ledger compares
+    #: DECLARATIONS against declarations. A brand-new column that harvests prose
+    #: and declares NOTHING produces no ledger entry, so the comparison still
+    #: holds and the suite stays green — the ledger cannot catch a declaration
+    #: that was never written. It catches one that is deleted, truncated,
+    #: mistyped or demoted, which is the likelier regression once the field
+    #: exists. The never-declared case is caught by a human asking the question
+    #: below, and by nothing else.
+    #:
+    #: So, when adding a measurer: can a cell in that column contain a sentence
+    #: somebody WROTE, in a file this module does not own? If yes it is `prose`.
     column_kinds: tuple[str, ...] = ()
 
     @property
@@ -126,15 +137,30 @@ class Measurement:
         return self.status == MEASURED
 
     def kind_of(self, index: int) -> str:
-        """The declared kind of column `index` — `""` when nothing is declared.
+        """The declared kind of column `index`.
 
-        Out-of-range is `""` and not an error on purpose: a row that is shorter
-        or longer than `columns` is a measurer bug, and turning it into an
-        exception here would take down a whole build over one ragged row.
+        Two different absences, and they must not answer the same way:
+
+          * NOTHING is declared on this measurement (`column_kinds` empty) —
+            every column is ordinary, which is the pre-existing behaviour for
+            the twenty-one rows that declare nothing.
+          * SOMETHING is declared but this index is past the end — the row is
+            RAGGED, i.e. it has more cells than the declaration covers.
+
+        🔴 THE RAGGED CASE FAILS CLOSED, and returning `""` for it was a hole.
+        Demonstrated: a measurement declaring `("name", "prose")` with a
+        three-cell row emitted the third cell VERBATIM into a sanitized page,
+        because the position past the end read as "ordinary". A declaration
+        that does not reach a cell is exactly the state where this module knows
+        least about that cell, so it withholds rather than publishes. Raising
+        instead would take down a whole build over one ragged row — a page with
+        one withheld cell is the better failure.
         """
+        if not self.column_kinds:
+            return ""
         if index < len(self.column_kinds):
             return self.column_kinds[index]
-        return ""
+        return "prose"
 
 
 @dataclass
@@ -731,6 +757,13 @@ def m_gate_tiers(env: Env) -> dict:
         ),
         source="scripts/gate.sh header + flake.nix checks",
         columns=("tier / fact", "what it is"),
+        #: The tail of this column is `desc.strip()` lifted out of `gate.sh`'s
+        #: exit-code comments — a sentence a human edits freely, in a file this
+        #: module does not own. Same class as the skill descriptions, so it gets
+        #: the same treatment. It names no third party TODAY; that is a property
+        #: of the current contents, not of the column, and the contents change
+        #: without a commit here.
+        column_kinds=("", "prose"),
         rows=tuple(rows),
     )
 
@@ -1109,6 +1142,13 @@ def m_drift_ladder(env: Env) -> dict:
         ),
         source="the EXIT CODES block in scripts/drift-check.sh (pinned against ship.sh by test_drift_check.py)",
         columns=("rc", "meaning"),
+        #: `meaning` is parsed straight out of `drift-check.sh`'s EXIT CODES
+        #: banner — up to ~420 chars of free prose per cell, authored by whoever
+        #: last edited that script. Declared `prose` for the same reason as the
+        #: skill descriptions: this module cannot enumerate what a sentence in
+        #: another file might name, and "it looks fine today" is the reasoning
+        #: this whole field exists to stop being load-bearing.
+        column_kinds=("", "prose"),
         rows=tuple(rows),
     )
 

--- a/scripts/present/measure.py
+++ b/scripts/present/measure.py
@@ -84,10 +84,57 @@ class Measurement:
     settle: str | None = None        # the command that would settle it
     columns: tuple[str, ...] = ()
     rows: tuple[tuple[str, ...], ...] = ()
+    #: What KIND of text each column holds, parallel to `columns`. Empty means
+    #: "every column is ordinary", which is the pre-existing behaviour.
+    #:
+    #: 🔴 THIS EXISTS BECAUSE SUBSTITUTION CANNOT REDACT PROSE, AND THE PAGE
+    #: SHIPPED CLAIMING OTHERWISE. `--sanitize` rewrites identifier CLASSES it
+    #: has been shown; a measurer that harvests a human-written sentence out of
+    #: a file hands it text with no class at all. Measured 2026-08-26: three
+    #: third-party project names rode out of `claude/skills/*/SKILL.md`
+    #: descriptions into a page stamped SANITIZED, while the same run took four
+    #: other identifier classes to zero — so the banner looked clean.
+    #:
+    #: Widening the name list was tried and REJECTED ON MEASUREMENT: sourcing
+    #: names from the index store, the skill directories AND every directory
+    #: under the operator's workspace (149 names) still left one project name
+    #: untouched — its directory is `<name>-ai` and the leak was a bare `<name>`
+    #: in a sentence — while rewriting `test`, `fast` and `scratch` wherever
+    #: they appeared as English words. A name list is fail-OPEN by construction:
+    #: it closes exactly the names something happened to be called after.
+    #:
+    #: So the kinds split the problem where it actually splits:
+    #:
+    #:   `""`      ordinary — sanitized by the identifier classes, as before.
+    #:   `"name"`  a LOCAL IDENTIFIER in a structured cell. Known local names
+    #:             are substituted inside it. Confined to the cell, so a skill
+    #:             called `bar` cannot rewrite the word "bar" in prose — the
+    #:             corruption that forced the length ladder in the first place.
+    #:   `"prose"` HUMAN-AUTHORED PROSE harvested from a file. WITHHELD in a
+    #:             sanitized build, never scrubbed, because no rule can
+    #:             enumerate what a sentence might name.
+    #:
+    #: `PROSE_LEDGER` in `scripts/tests/test_present_sanitize.py` pins the
+    #: declarations two-way — a registry key that gains or loses one fails the
+    #: suite — because a measurer that starts harvesting prose without saying so
+    #: is precisely the leak this field was added to stop, and it is invisible
+    #: in a diff that only adds a `rows.append`.
+    column_kinds: tuple[str, ...] = ()
 
     @property
     def measured(self) -> bool:
         return self.status == MEASURED
+
+    def kind_of(self, index: int) -> str:
+        """The declared kind of column `index` — `""` when nothing is declared.
+
+        Out-of-range is `""` and not an error on purpose: a row that is shorter
+        or longer than `columns` is a measurer bug, and turning it into an
+        exception here would take down a whole build over one ragged row.
+        """
+        if index < len(self.column_kinds):
+            return self.column_kinds[index]
+        return ""
 
 
 @dataclass
@@ -422,6 +469,15 @@ def m_skill_listing(env: Env) -> dict:
         ),
         source="scripts/lib/skill_tiers.py (the ledger's own parser), ratchet from scripts/tests/test_skill_tiers.py",
         columns=("what", "measured"),
+        #: 🔴 THE `what` COLUMN IS `name` FOR THREE ROWS OUT OF TEN, AND WHICH
+        #: THREE IS NOT FIXED. `costliest tier-A entry: <skill>` interpolates a
+        #: skill name into an otherwise-static label, so this column leaks
+        #: whenever the costliest entries happen to be the client-named skills.
+        #: Today they are not — measured `clickup`, `session-manager`,
+        #: `window-triage` — which is exactly why declaring it only when the
+        #: leak is visible would be wrong: the cell contents are a ranking that
+        #: moves on its own, with no commit to notice it.
+        column_kinds=("name", ""),
         rows=tuple(rows),
     )
 
@@ -465,6 +521,19 @@ def m_skill_inventory(env: Env) -> dict:
         ),
         source="claude/skills/*/SKILL.md front-matter + claude/skill-tiers.json",
         columns=("skill", "tier", "what it is (its own words)", "path"),
+        #: The description is the skill AUTHOR's sentence, not this module's, so
+        #: it can name anything — a client, a product, a hostname this module has
+        #: never been shown. It is `prose`, and a sanitized build withholds it.
+        #: The skill name is a local identifier and appears twice (bare, and
+        #: inside the path), so both of those cells are `name`.
+        #:
+        #: 🔴 EVERY name IS SUBSTITUTED, NOT JUST THE ONES THAT LOOK LIKE
+        #: CLIENTS — and that is the entitlement argument, not over-caution.
+        #: Redacting only the names judged sensitive would publish the judgement:
+        #: a reader seeing 35 real names and 2 stand-ins learns exactly which
+        #: two are the clients. Uniform substitution leaks neither the names nor
+        #: the boundary.
+        column_kinds=("name", "", "prose", "name"),
         rows=tuple(rows),
     )
 

--- a/scripts/present/measure.py
+++ b/scripts/present/measure.py
@@ -752,7 +752,14 @@ def m_gate_tiers(env: Env) -> dict:
             "#773. Name the tier AND the base sha in any claim that a merge is safe."
             + (f" flake checks discovered: {', '.join(checks)}." if checks else "")
         ),
-        source="scripts/gate.sh header + flake.nix checks",
+        #: 🔴 THIS USED TO SAY "scripts/gate.sh header + flake.nix checks" AND
+        #: WAS STALE THE MOMENT THE HARVEST MOVED OUT. This measurer no longer
+        #: reads a byte of `gate.sh`'s text — it only checks the file EXISTS —
+        #: so the old provenance contradicted the note below it inside one
+        #: function. Provenance is this page's core promise; a `source` that
+        #: names a file the code stopped reading is the page lying about itself.
+        source="flake.nix `checks` + literals in scripts/present/measure.py "
+               "(scripts/gate.sh is checked for existence only)",
         columns=("tier / fact", "what it is"),
         #: 🔴 NO DECLARATION, AND THE SPLIT BELOW IS WHY. Every cell here is a
         #: literal written in THIS module and reviewed with it, so none of it is
@@ -780,12 +787,28 @@ def m_gate_exit_codes(env: Env) -> dict:
     if not gate.is_file():
         raise Unmeasurable(f"{gate} does not exist")
     gtext = gate.read_text(encoding="utf-8", errors="replace")
-    exits = sorted(set(re.findall(r"^#\s+(\d+)\s*=\s*(.+)$", gtext, re.M)))
-    rows = [(code, desc.strip()) for code, desc in exits if code in {"0", "1", "2", "90"}]
+    #: 🔴 THE `Exit:` PREFIX IS PART OF THE GRAMMAR, AND MISSING IT DROPPED THE
+    #: SUCCESS CODE. `gate.sh` writes its legend as a hanging indent —
+    #: `# Exit: 0 = …` on the first line, `#       1 = …` after it — so a
+    #: pattern anchored on `^#\s+(\d+)` matches every code EXCEPT 0, and the row
+    #: rendered "3 exit codes documented in gate.sh's header" while the header
+    #: documents four. A reader looking up a code would have found the legend
+    #: missing the one that means everything passed.
+    #:
+    #: This is the SAME defect `m_drift_ladder` already carries a 🔴 note about
+    #: ("a count of one thing wearing the name of another"), reintroduced 370
+    #: lines away by a new parser. Pinned now by
+    #: `test_the_gate_exit_code_legend_matches_gate_sh`, because the count is a
+    #: `value` string and NOTHING in this suite pinned any `value` string —
+    #: hardcoding it to the right number was measured to pass.
+    exits = set(re.findall(r"^#\s*(?:Exit:)?\s*(\d+)\s*=\s*(.+)$", gtext, re.M))
+    #: Numeric, not lexical: a two-digit code must not sort before a one-digit
+    #: one, and `sorted()` on the string puts `10` ahead of `2`.
+    rows = [(code, desc.strip()) for code, desc in sorted(exits, key=lambda kv: int(kv[0]))]
     if not rows:
         raise Unmeasurable(
-            "no `# N = …` exit-code lines were found in scripts/gate.sh — an "
-            "empty parse is a broken read, not a script without exit codes")
+            "no `# [Exit:] N = …` exit-code lines were found in scripts/gate.sh "
+            "— an empty parse is a broken read, not a script without exit codes")
     return dict(
         value=f"{len(rows)} exit codes documented in gate.sh's header",
         detail=(

--- a/scripts/present/measure.py
+++ b/scripts/present/measure.py
@@ -838,7 +838,7 @@ def m_gate_exit_codes(env: Env) -> dict:
             "no `# Exit: N = …` legend block was found in scripts/gate.sh — an "
             "empty parse is a broken read, not a script without exit codes")
     return dict(
-        value=f"{len(rows)} exit codes in gate.sh's `# Exit:` legend block",
+        value=f"{len(rows)} exit codes in gate.sh's Exit: legend block",
         detail=(
             "🔴 90 is the one to understand: it means the runner's own verdict "
             "and its exit status DISAGREED, or a run was truncated. That is "
@@ -1665,7 +1665,7 @@ REGISTRY: tuple[tuple[str, str, str, object, str], ...] = (
     ("gate.tiers", "constraints", "The two gate tiers", m_gate_tiers,
      "nix develop --impure --command bash scripts/gate.sh --tier both"),
     ("gate.exit_codes", "constraints", "gate.sh's exit-code legend", m_gate_exit_codes,
-     "grep -E '^#\\s+[0-9]+\\s*=' scripts/gate.sh"),
+     "grep -E '^#[[:space:]]*(Exit:)?[[:space:]]*[0-9]+[[:space:]]*=' scripts/gate.sh"),
     ("gate.protection", "constraints", "What actually BLOCKS a merge", m_branch_protection,
      "gh api /repos/<owner>/<repo>/branches/main/protection --jq .required_status_checks"),
     ("tests.pytest", "constraints", "Per-target collected-test floors", m_pytest_floors,

--- a/scripts/present/measure.py
+++ b/scripts/present/measure.py
@@ -801,14 +801,42 @@ def m_gate_exit_codes(env: Env) -> dict:
     #: `test_the_gate_exit_code_legend_matches_gate_sh`, because the count is a
     #: `value` string and NOTHING in this suite pinned any `value` string —
     #: hardcoding it to the right number was measured to pass.
-    exits = set(re.findall(r"^#\s*(?:Exit:)?\s*(\d+)\s*=\s*(.+)$", gtext, re.M))
+    #: 🔴 THE BLOCK IS THE UNIT, NOT THE LINE — AND WIDENING THE PATTERN WITHOUT
+    #: RE-BOUNDING IT PUBLISHED FICTION. The previous round dropped a
+    #: `{"0","1","2","90"}` allowlist as "dead code". It was dead as a
+    #: REACHABILITY matter and load-bearing as a VALUE bound: it was the only
+    #: thing confining the harvest to real exit codes. With it gone and the
+    #: pattern anchored on nothing but `^#`, any of `gate.sh`'s 99 comment lines
+    #: that happens to read `# N = …` became an exit code on the page. Measured:
+    #: one ordinary body comment (`#   7 = the number of retries …`) rendered a
+    #: fifth code, with the suite green.
+    #:
+    #: Restoring a literal allowlist would only re-freeze the answer this page
+    #: exists to MEASURE. So the bound is structural instead: the legend is the
+    #: CONTIGUOUS run of comment lines beginning at the `# Exit:` anchor, and it
+    #: ends at the first line that is not a continuation. A code documented
+    #: outside that block is not in the legend, which is exactly what `source`
+    #: and the row label claim.
+    exits: list[tuple[str, str]] = []
+    started = False
+    for line in gtext.splitlines():
+        head = re.match(r"^#\s*Exit:\s*(\d+)\s*=\s*(.+)$", line)
+        cont = re.match(r"^#\s*(\d+)\s*=\s*(.+)$", line)
+        if head:
+            started = True
+            exits.append((head.group(1), head.group(2)))
+        elif started and cont:
+            exits.append((cont.group(1), cont.group(2)))
+        elif started:
+            break
     #: Numeric, not lexical: a two-digit code must not sort before a one-digit
     #: one, and `sorted()` on the string puts `10` ahead of `2`.
-    rows = [(code, desc.strip()) for code, desc in sorted(exits, key=lambda kv: int(kv[0]))]
+    rows = [(code, desc.strip())
+            for code, desc in sorted(set(exits), key=lambda kv: int(kv[0]))]
     if not rows:
         raise Unmeasurable(
-            "no `# [Exit:] N = …` exit-code lines were found in scripts/gate.sh "
-            "— an empty parse is a broken read, not a script without exit codes")
+            "no `# Exit: N = …` legend block was found in scripts/gate.sh — an "
+            "empty parse is a broken read, not a script without exit codes")
     return dict(
         value=f"{len(rows)} exit codes documented in gate.sh's header",
         detail=(
@@ -818,7 +846,7 @@ def m_gate_exit_codes(env: Env) -> dict:
             "as 'the tests failed' — read the log rather than debugging a diff "
             "against it."
         ),
-        source="scripts/gate.sh header comment",
+        source="scripts/gate.sh — the contiguous `# Exit:` legend block only",
         columns=("exit", "meaning"),
         column_kinds=("", "prose"),
         rows=tuple(rows),

--- a/scripts/present/sanitize.py
+++ b/scripts/present/sanitize.py
@@ -21,6 +21,27 @@ a security boundary and it must never be described as one:
     class of identifier walks straight through, silently, and the only defence
     is reading the output.
 
+🔴 PROSE IS NOT SUBSTITUTED, IT IS WITHHELD — AND THAT IS THE ONLY HONEST
+ANSWER. Substitution rewrites identifiers it has been SHOWN. A measurer that
+harvests a human-written sentence out of a file hands this module text with no
+class at all, and the sentence can name anything. Measured 2026-08-26: three
+third-party project names rode out of `claude/skills/*/SKILL.md` descriptions
+into a page stamped SANITIZED, while four other identifier classes on the SAME
+run went to zero — so nothing looked wrong.
+
+Widening the name list was tried and rejected on measurement, not on taste:
+sourcing names from the index store, the skill directories AND all 149
+directories under the operator's workspace still left one project name fully
+intact — its directory is `<name>-ai` and the leak was a bare `<name>` in a
+sentence — while rewriting `test`, `fast` and `scratch` wherever they occurred
+as English words. A name list closes exactly the names something happened to be
+named after, which is fail-OPEN, and an entitlement boundary may not be.
+
+So a measurer DECLARES what each column holds (`Measurement.column_kinds`) and
+this module withholds the prose instead of pretending to clean it. Withholding
+is driven by that declaration, never by the name list, so it still happens on a
+host where every name source is empty.
+
 🔴 EVERY CLASS BELOW IS CASE-INSENSITIVE AND HYPHEN-BLIND, AND THAT IS A FIX,
 NOT A STYLE CHOICE. Both asymmetries shipped and both leaked, into a page whose
 whole purpose is being handed to an outsider:
@@ -193,6 +214,13 @@ NOT_SUBSTITUTED = frozenset({"devrc"})
 #: of a short scope walks through, and the legend says so.
 SCOPE_AGGRESSIVE_MIN = 5
 
+#: What a withheld prose cell renders as.
+#:
+#: 🔴 IT SAYS WITHHELD, NOT BLANK. An empty cell is the silent zero this whole
+#: page is built against — the reader cannot tell "the skill has no description"
+#: from "the description was removed", and only one of those is true.
+WITHHELD = "[WITHHELD — prose, not redactable]"
+
 
 def _word(literal: str) -> str:
     """A boundary that treats a HYPHEN as a separator, not as part of the word.
@@ -229,6 +257,13 @@ class Sanitizer:
     #: Dotless machine names read from local state. See `_hosts` for why only
     #: some of them can safely be substituted.
     hostnames: tuple[str, ...] = ()
+    #: LOCAL IDENTIFIERS substituted ONLY inside a cell a measurer declared
+    #: `name`. They are deliberately NOT part of `text()`: this set contains
+    #: names like `bar`, `i3`, `signal` and `resume`, and letting them loose on
+    #: the whole page would rewrite ordinary English — the corruption that
+    #: forced `SCOPE_AGGRESSIVE_MIN` to exist. Confining them to a structured
+    #: cell is what makes substituting ALL of them safe.
+    local_names: tuple[str, ...] = ()
     keep: frozenset[str] = NOT_SUBSTITUTED
     #: Why a class is weaker than it claims on THIS build. Set by `build()`.
     degraded: tuple[str, ...] = ()
@@ -236,6 +271,9 @@ class Sanitizer:
     _counters: dict[str, int] = field(default_factory=dict)
     #: kind -> how many real values this run declined to substitute.
     _skipped: dict[str, int] = field(default_factory=dict)
+    #: How many prose cells this run withheld. Counted separately from
+    #: `_skipped` because it is the redaction WORKING, not a hole in it.
+    _withheld: int = 0
 
     def _next(self, kind: str) -> int:
         self._counters[kind] = self._counters.get(kind, 0) + 1
@@ -384,6 +422,45 @@ class Sanitizer:
         out = self._hosts(out)
         return out
 
+    def _names(self, text: str) -> str:
+        """Substitute LOCAL IDENTIFIERS — only ever called on a `name` cell.
+
+        No length ladder and no exact-form fallback: a `name` cell is a
+        structured identifier slot, so a short name there is a name, not an
+        English word that happens to collide. That is precisely the assumption
+        `text()` may NOT make, which is why this is a separate method rather
+        than another class inside it.
+        """
+        for real in sorted(self.local_names, key=len, reverse=True):
+            if not real or real.lower() in self.keep:
+                continue
+            stand = self._stand_in("name", real.lower(), lambda n: f"name-{n:02d}")
+            text = re.sub(_word(real), stand, text, flags=re.I)
+        return text
+
+    def cell(self, value: str | None, kind: str) -> str | None:
+        """Sanitize one table cell according to its DECLARED kind.
+
+        🔴 AN UNKNOWN KIND IS TREATED AS `prose`, NOT AS ORDINARY. This is the
+        fail-closed direction and it is the whole point of the field: a typo, a
+        kind added by a newer measurer than this module knows about, or a
+        half-finished declaration must lose the text, never publish it. The
+        ordinary path is the one spelled `""`, and it has to be spelled.
+        """
+        if value is None or not self.enabled:
+            return value
+        if kind == "":
+            return self.text(value)
+        if kind == "name":
+            return self._names(self.text(value) or "")
+        self._withheld += 1
+        return WITHHELD
+
+    @property
+    def withheld(self) -> int:
+        """How many prose cells this run removed rather than scrubbed."""
+        return self._withheld
+
     @property
     def substitutions(self) -> int:
         return len(self._map)
@@ -404,6 +481,8 @@ class Sanitizer:
             for key in source:
                 kind = key.split(":", 1)[0]
                 counts[kind] = counts.get(kind, 0) + 1
+        if self._withheld:
+            counts["prose-withheld"] = self._withheld
         if self.degraded:
             counts["NOT-SUBSTITUTED-see-build-log"] = len(self.degraded)
         return tuple(sorted(counts.items()))
@@ -449,6 +528,32 @@ def build(enabled: bool, env, measurements=None) -> Sanitizer:
                 degraded.append(
                     "the index store measured ZERO scopes, so no scope name is "
                     "substituted — an empty scope list is not a clean one")
+    #: LOCAL IDENTIFIERS for `name` cells, read from the skill inventory the
+    #: same way scopes are read from the index store — local state, never a
+    #: committed literal.
+    #:
+    #: 🔴 AN EMPTY SET HERE IS NOT A CLEAN RUN, AND IT DOES NOT REOPEN THE
+    #: PROSE HOLE. Withholding is driven by the DECLARATION, not by this list,
+    #: so a build with no inventory still removes every prose cell — it just
+    #: cannot rename the identifiers around them, and says so.
+    local_names: list[str] = []
+    if measurements is not None:
+        inv = measurements.by_key("skills.inventory")
+        if inv is None:
+            degraded.append(
+                "no `skills.inventory` row is registered, so NO local identifier "
+                "is renamed in a `name` cell — the prose is still withheld")
+        elif not inv.measured:
+            degraded.append(
+                "the skill inventory came back UNMEASURED "
+                f"({inv.reason or 'no reason given'}), so NO local identifier is "
+                "renamed in a `name` cell — the prose is still withheld")
+        else:
+            local_names = [row[0].lstrip("/") for row in inv.rows if row and row[0]]
+            if not local_names:
+                degraded.append(
+                    "the skill inventory measured ZERO skills, so no local "
+                    "identifier is renamed — an empty name list is not a clean one")
     home = str(env.home).rstrip("/")
     try:
         node = socket.gethostname()
@@ -461,6 +566,7 @@ def build(enabled: bool, env, measurements=None) -> Sanitizer:
         user=os.path.basename(home),
         scopes=tuple(scopes),
         hostnames=hostnames,
+        local_names=tuple(sorted(set(local_names))),
         degraded=tuple(degraded),
     )
 
@@ -492,6 +598,9 @@ def apply(measurements, san: Sanitizer):
             source=san.text(item.source) or "",
             reason=san.text(item.reason),
             settle=san.text(item.settle),
-            rows=tuple(tuple(san.text(c) or "" for c in row) for row in item.rows),
+            rows=tuple(
+                tuple(san.cell(c, item.kind_of(i)) or "" for i, c in enumerate(row))
+                for row in item.rows
+            ),
         ))
     return out

--- a/scripts/present/sanitize.py
+++ b/scripts/present/sanitize.py
@@ -425,11 +425,22 @@ class Sanitizer:
     def _names(self, text: str) -> str:
         """Substitute LOCAL IDENTIFIERS — only ever called on a `name` cell.
 
-        No length ladder and no exact-form fallback: a `name` cell is a
-        structured identifier slot, so a short name there is a name, not an
-        English word that happens to collide. That is precisely the assumption
-        `text()` may NOT make, which is why this is a separate method rather
-        than another class inside it.
+        No length ladder and no exact-form fallback. The licence for that is
+        CONFINEMENT, not purity: a `name` cell is not guaranteed to be nothing
+        but an identifier — `skills.listing`'s `what` column is declared `name`
+        and holds static English labels alongside `costliest tier-A entry:
+        <skill>`. What makes dropping the ladder safe is that the class never
+        runs over the page at large, plus `_word`'s boundaries. `test_a_static_
+        label_in_a_name_cell_is_not_corrupted` is the guard on that, because the
+        premise "a name cell is a pure identifier slot" is FALSE in one of this
+        module's two uses and should not be relied on again.
+
+        🔴 LONGEST-FIRST IS LOAD-BEARING, NOT TIDINESS. `_word` treats a hyphen
+        as a boundary, so a short name is reachable INSIDE a longer hyphenated
+        one. Substituting shortest-first rewrites the inner name and leaves the
+        outer one half-real: measured on the live set, `reverse=False` published
+        a client name in cleartext as `/<client>-name-10` on a page stamped
+        SANITIZED, with the whole suite green.
         """
         for real in sorted(self.local_names, key=len, reverse=True):
             if not real or real.lower() in self.keep:
@@ -549,11 +560,29 @@ def build(enabled: bool, env, measurements=None) -> Sanitizer:
                 f"({inv.reason or 'no reason given'}), so NO local identifier is "
                 "renamed in a `name` cell — the prose is still withheld")
         else:
-            local_names = [row[0].lstrip("/") for row in inv.rows if row and row[0]]
-            if not local_names:
+            # 🔴 PICK THE COLUMN BY ITS DECLARED KIND, NEVER BY POSITION. Reading
+            # `row[0]` assumed column 0 is the name column — an assumption no
+            # test could see and that a one-line column reorder in the measurer
+            # breaks silently. MEASURED: swapping the first two cells of the
+            # inventory row, without touching `column_kinds`, kept 102 tests
+            # green, kept both DEGRADED lines identical, kept the masthead
+            # reading SANITIZED — and republished all 37 real names in
+            # cleartext, because `local_names` had become {"A","B","?"}.
+            # `kind_of` already knows which column is which; ask it.
+            idx = next((i for i in range(len(inv.columns))
+                        if inv.kind_of(i) == "name"), None)
+            if idx is None:
                 degraded.append(
-                    "the skill inventory measured ZERO skills, so no local "
-                    "identifier is renamed — an empty name list is not a clean one")
+                    "the skill inventory declares NO `name` column, so this "
+                    "build cannot tell which cell holds the identifier and NO "
+                    "local identifier is renamed — the prose is still withheld")
+            else:
+                local_names = [row[idx].lstrip("/") for row in inv.rows
+                               if len(row) > idx and row[idx]]
+                if not local_names:
+                    degraded.append(
+                        "the skill inventory measured ZERO skills, so no local "
+                        "identifier is renamed — an empty name list is not a clean one")
     home = str(env.home).rstrip("/")
     try:
         node = socket.gethostname()

--- a/scripts/present/serve.py
+++ b/scripts/present/serve.py
@@ -28,9 +28,13 @@ it could NOT substitute, and the page's own mode chip carries the same counts.
 REASSURING ONE. It read: a 2026-08-26 build left two client-ish names in the
 sanitized copy, one hostname "indistinguishable from a word" and one scope
 "matched in its exact form only" — i.e. the two DEGRADED lines were the leak.
-They were not, and never had been. Both are deliberate declines (a nodename,
-and the three-character scope `cli`), they are counted in the legend, and they
-leaked nothing. The actual leak was human prose harvested out of another file,
+They were not, and never had been. Both are deliberate declines, counted in the
+legend. ⚠ Careful with the stronger phrasing this line used to carry: "they
+leaked nothing" is wrong as stated, because both declined values DO appear in
+the page — measured, one of them 28 times. The accurate claim is narrower and
+host-dependent: neither declined value is a THIRD-PARTY name on this host
+TODAY, which is a fact about today's contents, not about the rule. The actual
+leak was human prose harvested out of another file,
 which no identifier rule can enumerate and which printed no warning at all.
 Fixed by withholding declared prose rather than substituting it — see
 `sanitize.py`'s header. Kept here because "the page warned me" was exactly the

--- a/scripts/present/serve.py
+++ b/scripts/present/serve.py
@@ -29,12 +29,17 @@ REASSURING ONE. It read: a 2026-08-26 build left two client-ish names in the
 sanitized copy, one hostname "indistinguishable from a word" and one scope
 "matched in its exact form only" — i.e. the two DEGRADED lines were the leak.
 They were not, and never had been. Both are deliberate declines, counted in the
-legend. ⚠ Careful with the stronger phrasing this line used to carry: "they
-leaked nothing" is wrong as stated, because both declined values DO appear in
-the page — measured, one of them 28 times. The accurate claim is narrower and
-host-dependent: neither declined value is a THIRD-PARTY name on this host
-TODAY, which is a fact about today's contents, not about the rule. The actual
-leak was human prose harvested out of another file,
+legend. ⚠ Two phrasings of this line have now been wrong in OPPOSITE
+directions, which is worth more than either correction. It first said the
+declined values "leaked nothing" — too strong, since a declined value is by
+definition left in the page. The fix then said one of them appears "28 times",
+which was a SUBSTRING count read as an appearance count: word-bounded, it
+appears once, and the 28 were other words that merely contain those letters.
+Counting the wrong thing is the failure this whole page argues against, so:
+state the property, not a number. Both declined values are present, both are
+counted in the legend, and neither is a third-party name on this host TODAY —
+a fact about today's contents, not about the rule. The actual leak was human
+prose harvested out of another file,
 which no identifier rule can enumerate and which printed no warning at all.
 Fixed by withholding declared prose rather than substituting it — see
 `sanitize.py`'s header. Kept here because "the page warned me" was exactly the

--- a/scripts/present/serve.py
+++ b/scripts/present/serve.py
@@ -24,11 +24,21 @@ read this page, and not before.
 ⚠ The export is the thing that argument leans on, so check it rather than
 assume it: `generate.py --sanitize` prints a `SANITIZE DEGRADED` line per value
 it could NOT substitute, and the page's own mode chip carries the same counts.
-A 2026-08-26 build left two client-ish names in the sanitized copy (one
-hostname "indistinguishable from a word", one scope matched in its exact form
-only). That is `scripts/present/sanitize.py`'s business, not this server's, but
-it is the reason "the portable export serves the off-workbench reader" is a
-claim to verify per build and not a standing fact.
+🔴 THAT LINE USED TO NAME THE WRONG CAUSE, AND THE WRONG CAUSE WAS THE
+REASSURING ONE. It read: a 2026-08-26 build left two client-ish names in the
+sanitized copy, one hostname "indistinguishable from a word" and one scope
+"matched in its exact form only" — i.e. the two DEGRADED lines were the leak.
+They were not, and never had been. Both are deliberate declines (a nodename,
+and the three-character scope `cli`), they are counted in the legend, and they
+leaked nothing. The actual leak was human prose harvested out of another file,
+which no identifier rule can enumerate and which printed no warning at all.
+Fixed by withholding declared prose rather than substituting it — see
+`sanitize.py`'s header. Kept here because "the page warned me" was exactly the
+wrong lesson: the warnings that DID print were unrelated to the failure, so the
+banner count is not a leak count and never was.
+
+"The portable export serves the off-workbench reader" therefore remains a claim
+to verify per build, not a standing fact.
 
 WHAT THIS IS NOT. It runs no subprocess, holds no credential, has no refresh
 button and no form. It answers exactly two artefact routes out of an explicit

--- a/scripts/tests/test_present_sanitize.py
+++ b/scripts/tests/test_present_sanitize.py
@@ -1083,8 +1083,9 @@ def test_the_exit_code_legend_stops_at_the_BLOCK_and_sorts_NUMERICALLY(tmp_path)
     the `Exit:` anchor optional. The second is the worse one: with a `# N = …`
     line anywhere ABOVE the legend it makes that line the anchor, so the real
     legend is never reached and the page renders ONE FABRICATED CODE AND NO
-    REAL ONES, labelled "1 exit codes documented in …". So the fixture brackets
-    the legend — a decoy on each side.
+    REAL ONES, under a label asserting that is the whole legend. So the fixture
+    brackets the legend — a decoy on each side, and BOTH are load-bearing:
+    deleting either one lets a different mutant back through.
     """
     repo = tmp_path / "repo"
     (repo / "scripts").mkdir(parents=True)
@@ -1109,7 +1110,15 @@ def test_the_exit_code_legend_stops_at_the_BLOCK_and_sorts_NUMERICALLY(tmp_path)
     env = measure.Env(repo=repo, home=tmp_path / "h", claude_dir=tmp_path / "c",
                       index_store=tmp_path / "s", allow_systemd=False,
                       allow_network=False)
-    got = [code for code, _ in measure.m_gate_exit_codes(env)["rows"]]
+    fields = measure.m_gate_exit_codes(env)
+    got = [code for code, _ in fields["rows"]]
+
+    # The count in the headline, read off a legend whose size differs from the
+    # real file's. Without this a hardcoded `value` survives: the sibling guard
+    # checks the count against the REAL gate.sh, where the literal happens to be
+    # right, and nothing else reads `value` at all.
+    assert fields["value"].startswith("3 "), (
+        f"the headline count does not match this 3-code legend: {fields['value']!r}")
 
     assert "7" not in got, (
         f"a comment BELOW the legend block was published as an exit code: {got}")

--- a/scripts/tests/test_present_sanitize.py
+++ b/scripts/tests/test_present_sanitize.py
@@ -19,11 +19,18 @@ and that the mapping is STABLE. They cannot prove an unknown class is caught —
 `test_the_sanitizer_cannot_see_an_unknown_identifier_class` pins that limitation
 as a property, so nobody reads this suite as a guarantee it does not make.
 
-WHAT COUNTS AS COVERAGE. All INVARIANT GUARDS: `scripts/present/` is new in this
-commit, so nothing here can be shown red on pre-change code. Each substitution
-test carries its own control — the un-sanitized path must leave the value ALONE —
-because a `Sanitizer` that rewrote everything unconditionally would pass a
-one-sided assertion and destroy the private build.
+WHAT COUNTS AS COVERAGE. Most of this file is INVARIANT GUARDS: `scripts/present/`
+was new in the commit that added them, so they cannot be shown red on pre-change
+code. Each substitution test carries its own control — the un-sanitized path must
+leave the value ALONE — because a `Sanitizer` that rewrote everything
+unconditionally would pass a one-sided assertion and destroy the private build.
+
+🔴 THE `column_kinds` TESTS ARE REGRESSION COVERAGE, NOT INVARIANT GUARDS, and
+the difference is load-bearing. They pin a leak that SHIPPED: harvested prose
+naming a third party rode into a page stamped SANITIZED while four other
+identifier classes on the same run went to zero. `test_a_declared_PROSE_cell_is_
+withheld_whole_not_scrubbed` is red on the pre-change tree — verify it there
+before trusting it, since a guard nobody has watched fail proves nothing.
 
 Every value below is INVENTED. Real identifiers are read at run time from local
 state and appear in no fixture, which is the arrival path this repo's captured-
@@ -64,10 +71,24 @@ FAKE_STORE = "/nix/store/abcdefghijklmnopqrstuvwxyz012345-python3-3.12.14"
 #: other half of this class, which is the one that cannot be substituted safely.
 FAKE_NODE = "workbench-prod"
 
+#: Local identifiers for a `name` cell. Deliberately mixed:
+#:
+#:   * `quartzsight` and `pelagic-mail` are shaped like the leak that motivated
+#:     the class — a third party's name used as a local identifier;
+#:   * `bar` and `resume` are shaped like the CORRUPTION risk — ordinary English
+#:     words that are also real local identifiers. They are what proves the
+#:     substitution stays inside the cell it was declared on.
+FAKE_NAMES = ("quartzsight", "pelagic-mail", "bar", "resume")
+#: A sentence of the kind a measurer HARVESTS rather than authors. It names a
+#: third party that appears in NO name list — which is the whole point: this is
+#: the value substitution structurally cannot reach.
+FAKE_PROSE = "Walk the Northwind Dental funnel and screenshot every view"
+
 
 def _san(enabled=True, **kw) -> sanitize.Sanitizer:
     base = dict(enabled=enabled, home=FAKE_HOME, user="jrandom",
-                scopes=FAKE_SCOPES, hostnames=(FAKE_NODE,))
+                scopes=FAKE_SCOPES, hostnames=(FAKE_NODE,),
+                local_names=FAKE_NAMES)
     base.update(kw)
     return sanitize.Sanitizer(**base)
 
@@ -491,6 +512,254 @@ def test_apply_sanitizes_every_string_field_including_an_absence():
     assert out.by_key("b").status == measure.UNMEASURED, "apply() changed a status"
 
 
+# --------------------------------------------------------------------------- #
+# Prose is WITHHELD, not scrubbed — the class substitution cannot reach
+# --------------------------------------------------------------------------- #
+
+
+def test_a_declared_PROSE_cell_is_withheld_whole_not_scrubbed():
+    """REGRESSION GUARD — red before `column_kinds` existed.
+
+    The shipped bug: a measurer harvested a human sentence out of a file, the
+    sentence named a third party no identifier list contained, and it rode into
+    a page stamped SANITIZED. Substituting harder cannot fix this — the name is
+    not in any list to substitute — so the cell has to go.
+    """
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("skills.inventory",
+                         columns=("skill", "what it is"),
+                         column_kinds=("name", "prose"),
+                         rows=(("/quartzsight", FAKE_PROSE),)))
+    out = sanitize.apply(ms, _san())
+    cell = out.by_key("skills.inventory").rows[0][1]
+    assert "Northwind" not in cell, f"harvested prose survived: {cell!r}"
+    assert cell == sanitize.WITHHELD, f"prose was scrubbed, not withheld: {cell!r}"
+
+
+def test_withholding_says_WITHHELD_and_never_leaves_a_BLANK():
+    """A blank cell cannot be told from a skill that has no description.
+
+    Same silent-zero failure the UNMEASURED state exists to prevent, arriving
+    one layer down.
+    """
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("k", columns=("c",), column_kinds=("prose",),
+                         rows=((FAKE_PROSE,),)))
+    cell = sanitize.apply(ms, _san()).by_key("k").rows[0][0]
+    assert cell.strip(), "a withheld cell rendered as whitespace"
+    assert "WITHHELD" in cell
+
+
+def test_withholding_still_happens_when_EVERY_name_source_is_empty():
+    """FAIL-CLOSED GUARD, and the one that separates this fix from the old one.
+
+    A name-list fix is only as good as the list. Withholding is driven by the
+    DECLARATION, so a host with no index store and no skill inventory — where
+    every name list is empty and the old approach degraded to doing nothing —
+    still removes the prose.
+    """
+    bare = sanitize.Sanitizer(enabled=True, home="", user="", scopes=(),
+                              hostnames=(), local_names=())
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("k", columns=("c",), column_kinds=("prose",),
+                         rows=((FAKE_PROSE,),)))
+    cell = sanitize.apply(ms, bare).by_key("k").rows[0][0]
+    assert cell == sanitize.WITHHELD, f"empty name sources reopened the hole: {cell!r}"
+
+
+def test_an_UNKNOWN_column_kind_is_withheld_and_not_waved_through():
+    """FAIL-CLOSED GUARD on the declaration itself.
+
+    A typo, or a kind a newer measurer knows and this module does not, must
+    lose the text rather than publish it. The ordinary path is spelled `""` and
+    has to be spelled — silence is not the safe default here.
+    """
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("k", columns=("c",), column_kinds=("prosee",),
+                         rows=((FAKE_PROSE,),)))
+    cell = sanitize.apply(ms, _san()).by_key("k").rows[0][0]
+    assert cell == sanitize.WITHHELD, f"an unknown kind was treated as ordinary: {cell!r}"
+
+
+def test_a_NAME_cell_substitutes_every_local_identifier_including_short_ones():
+    """A `name` cell is a structured slot, so the length ladder does not apply.
+
+    `bar` is 3 characters and `text()` would decline it — correctly, since it
+    is an English word. Here it is unambiguously an identifier.
+    """
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("k", columns=("skill", "path"),
+                         column_kinds=("name", "name"),
+                         rows=(("/bar", "claude/skills/bar/SKILL.md"),
+                               ("/quartzsight", "claude/skills/quartzsight/SKILL.md"))))
+    rows = sanitize.apply(ms, _san()).by_key("k").rows
+    blob = repr(rows)
+    for real in ("bar", "quartzsight"):
+        assert f"/{real}" not in blob, f"{real!r} survived a name cell: {blob!r}"
+    assert "claude/skills/" in blob, "the path SHAPE was destroyed, not just the name"
+
+
+def test_the_same_name_gets_the_same_stand_in_in_both_of_its_cells():
+    """Otherwise the row stops being readable as one row.
+
+    A skill whose name and path disagreed would read as two different skills,
+    which is a worse artefact than the one this replaced.
+    """
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("k", columns=("skill", "path"),
+                         column_kinds=("name", "name"),
+                         rows=(("/quartzsight", "claude/skills/quartzsight/SKILL.md"),)))
+    name_cell, path_cell = sanitize.apply(ms, _san()).by_key("k").rows[0]
+    stand = name_cell.lstrip("/")
+    assert stand.startswith("name-"), f"unexpected stand-in {name_cell!r}"
+    assert f"claude/skills/{stand}/SKILL.md" == path_cell, \
+        f"name and path disagree: {name_cell!r} vs {path_cell!r}"
+
+
+def test_a_local_name_that_is_an_ENGLISH_WORD_is_not_rewritten_OUTSIDE_its_cell():
+    """CORRUPTION CONTROL — the failure that killed the name-list approach.
+
+    Sourcing names widely and substituting them everywhere rewrote `test`,
+    `fast` and `scratch` as they occurred in ordinary English. Confining the
+    class to a declared cell is what makes substituting ALL names safe, so this
+    is the assertion that licenses the aggressive half of the fix.
+    """
+    prose = "resume the run from the status bar and read the bar chart"
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("k", detail=prose,
+                         columns=("ordinary",), column_kinds=("",),
+                         rows=((prose,),)))
+    out = sanitize.apply(ms, _san()).by_key("k")
+    assert out.rows[0][0] == prose, f"an ordinary cell was name-substituted: {out.rows[0][0]!r}"
+    assert out.detail == prose, f"`detail` was name-substituted: {out.detail!r}"
+
+
+def test_a_row_with_NO_declared_kinds_behaves_exactly_as_before():
+    """BACKWARD-COMPATIBILITY GUARD. An empty `column_kinds` is not `prose`.
+
+    Twenty-one registered rows declare nothing. If the default drifted to
+    withholding, the page would empty itself and the tests that count rows
+    would still pass.
+    """
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("k", columns=("c",), rows=((f"at {FAKE_HOME}/x",),)))
+    cell = sanitize.apply(ms, _san()).by_key("k").rows[0][0]
+    assert "WITHHELD" not in cell, "an undeclared column was withheld"
+    assert FAKE_HOME not in cell, "an undeclared column stopped being sanitized"
+
+
+def test_the_legend_counts_withheld_cells_and_warnings_does_NOT_call_it_a_hole():
+    """Withholding is the redaction WORKING; a declined substitution is not.
+
+    Filing them together would make a clean build print degradation warnings
+    forever, which is how a warning stops being read.
+    """
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("k", columns=("c",), column_kinds=("prose",),
+                         rows=((FAKE_PROSE,), (FAKE_PROSE,))))
+    san = _san()
+    sanitize.apply(ms, san)
+    assert san.withheld == 2
+    assert dict(san.legend())["prose-withheld"] == 2
+    assert not [w for w in san.warnings() if "withheld" in w.lower()], \
+        f"withholding was reported as a degradation: {san.warnings()!r}"
+
+
+def test_the_disabled_sanitizer_withholds_NOTHING():
+    """The private build must be the identity transform on prose too."""
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("k", columns=("c",), column_kinds=("prose",),
+                         rows=((FAKE_PROSE,),)))
+    out = sanitize.apply(ms, _san(enabled=False))
+    assert out.by_key("k").rows[0][0] == FAKE_PROSE
+
+
+# --------------------------------------------------------------------------- #
+# The declaration ledger — pinned two-way
+# --------------------------------------------------------------------------- #
+
+#: Every registry key that declares a non-ordinary column, and what it declares.
+#:
+#: 🔴 PINNED TWO-WAY ON PURPOSE. A measurer that starts harvesting prose without
+#: declaring it is EXACTLY the leak `column_kinds` was added to stop, and it is
+#: invisible in review — the diff is one more `rows.append`. So a key that gains
+#: a declaration, loses one, or changes one fails this test until someone edits
+#: the ledger and, in doing so, states what the new column holds.
+#:
+#: Adding a key here is not a formality. Ask: can a cell in that column contain
+#: a sentence somebody WROTE? If yes it is `prose` — no matter how safe today's
+#: contents look, because the contents change without a commit here.
+PROSE_LEDGER = {
+    "skills.listing": ("name", ""),
+    "skills.inventory": ("name", "", "prose", "name"),
+}
+
+
+def _ledger_env(tmp_path):
+    """The REAL repo — the ledger is a claim about the real measurers.
+
+    Home, claude dir and index store point at `tmp_path` so nothing reads the
+    operator's machine, and `allow_network=False` keeps `m_branch_protection`
+    from shelling `gh` (see `Env.allow_network`).
+    """
+    return measure.Env(repo=REPO_ROOT, home=tmp_path,
+                       claude_dir=tmp_path / ".claude",
+                       index_store=tmp_path / "index-store",
+                       allow_systemd=False, allow_network=False)
+
+
+def _declared_kinds(env) -> dict:
+    out = {}
+    for item in measure.take(env):
+        if item.column_kinds:
+            out[item.key] = tuple(item.column_kinds)
+    return out
+
+
+def test_the_column_kind_ledger_is_pinned_two_way(tmp_path):
+    """SEAM GUARD over the whole registry, not over one measurer.
+
+    Runs the real registry and compares the declarations it PRODUCES against
+    the ledger. Both directions matter: a new prose column that nobody declared
+    never appears here (so the ledger is checked against reality, not against
+    itself), and a declaration deleted from a measurer fails rather than
+    silently reopening the hole.
+    """
+    env = _ledger_env(tmp_path)
+    live = _declared_kinds(env)
+    assert live == PROSE_LEDGER, (
+        "the declared column kinds moved.\n"
+        f"  registry says: {live}\n"
+        f"  ledger says:   {PROSE_LEDGER}\n"
+        "If a measurer now harvests human-written text out of a file, declare "
+        "that column `prose` and add it here. If a column stopped being "
+        "harvested, remove it here in the same commit."
+    )
+
+
+def test_every_ledger_KEY_is_a_real_registry_key():
+    """The other direction: a ledger entry naming nothing pins nothing."""
+    keys = {entry[0] for entry in measure.REGISTRY}
+    unknown = set(PROSE_LEDGER) - keys
+    assert not unknown, f"the ledger names keys the registry does not have: {unknown}"
+
+
+def test_every_declaration_is_as_long_as_its_own_columns(tmp_path):
+    """A short `column_kinds` silently leaves the tail columns ordinary.
+
+    That is the shape where a declaration READS as coverage and provides none —
+    the prose column sits past the end of the tuple and is waved through.
+    """
+    env = _ledger_env(tmp_path)
+    for item in measure.take(env):
+        if not item.column_kinds:
+            continue
+        assert len(item.column_kinds) == len(item.columns), (
+            f"{item.key}: {len(item.column_kinds)} kinds for "
+            f"{len(item.columns)} columns — the tail is undeclared"
+        )
+
+
 def test_apply_preserves_the_measured_unmeasured_split():
     """INVARIANT GUARD. Sanitizing must not turn an absence into a value."""
     ms = measure.MeasurementSet()
@@ -555,14 +824,52 @@ def test_scope_substitution_degrading_to_ZERO_is_LOUD(tmp_path):
         assert san.warnings(), f"{label}: nothing would be printed"
         assert any("NOT-SUBSTITUTED" in k for k, _ in san.legend()), (
             f"{label}: the page's own legend would not show it: {san.legend()}")
+        # 🔴 It must degrade for the SCOPE reason specifically. `build()` now has
+        # a second name source (the skill inventory) whose absence ALSO degrades,
+        # and a bare `san.degraded` would go green on that one alone — this test
+        # would then pass with scope degradation deleted entirely.
+        assert any("scope" in reason for reason in san.degraded), (
+            f"{label}: degraded, but not about scopes: {san.degraded!r}")
 
-    # CONTROL: a store that measured real scopes degrades NOTHING, so the flag
+    # CONTROL: with BOTH name sources measured, nothing degrades — so the flag
     # above cannot be a constant.
     fine = measure.MeasurementSet()
     fine.items.append(_row("index.store", columns=("scope",), rows=(("borealis",),)))
+    fine.items.append(_row("skills.inventory", columns=("skill",),
+                           column_kinds=("name",), rows=(("/pelagic-mail",),)))
     ok = sanitize.build(True, env, fine)
-    assert not ok.degraded and ok.scopes == ("borealis",)
+    assert not ok.degraded, f"a fully-measured build degraded: {ok.degraded!r}"
+    assert ok.scopes == ("borealis",)
+    assert ok.local_names == ("pelagic-mail",), (
+        f"the name source did not load: {ok.local_names!r}")
     assert not any("NOT-SUBSTITUTED" in k for k, _ in ok.legend())
+
+
+def test_the_NAME_source_degrading_is_LOUD_but_does_NOT_reopen_the_prose_hole(tmp_path):
+    """The two halves of the fix must fail INDEPENDENTLY.
+
+    A missing skill inventory means identifiers around the prose keep their real
+    names — worth a warning. It must NOT mean the prose comes back, because the
+    withholding is driven by the DECLARATION, not by any name list. Coupling
+    them would rebuild the fail-open behaviour this change removed, one layer up.
+    """
+    env = measure.Env(repo=tmp_path, home=tmp_path / "h", claude_dir=tmp_path / "c",
+                      index_store=tmp_path / "s", allow_systemd=False,
+                      allow_network=False)
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("index.store", columns=("scope",), rows=(("borealis",),)))
+    san = sanitize.build(True, env, ms)
+
+    assert any("skills.inventory" in r for r in san.degraded), (
+        f"a missing name source degraded silently: {san.degraded!r}")
+    assert san.local_names == ()
+
+    page = measure.MeasurementSet()
+    page.items.append(_row("k", columns=("c",), column_kinds=("prose",),
+                           rows=((FAKE_PROSE,),)))
+    cell = sanitize.apply(page, san).by_key("k").rows[0][0]
+    assert cell == sanitize.WITHHELD, (
+        f"a degraded name source reopened the prose hole: {cell!r}")
 
 
 def test_the_legend_never_prints_the_real_side():

--- a/scripts/tests/test_present_sanitize.py
+++ b/scripts/tests/test_present_sanitize.py
@@ -680,11 +680,14 @@ def test_a_STATIC_LABEL_in_a_name_cell_is_not_corrupted():
         "quartzsighted about the ceiling",               # `quartzsight` inside a longer word
         "pelagic-mailboxes archive nightly",             # the whole hyphenated name, extended
     )
-    # 🔴 CHECKED AGAINST `FAKE_NAMES` ITSELF, NOT A THIRD HARDCODED TUPLE. The
-    # first version listed the names again here, so it could not see the drift
-    # it names: deleting one from `FAKE_NAMES` left this test green, and only a
-    # sibling caught it. Every name the sanitizer is given must be exercised by
-    # some label, or this guard is partly vacuous again.
+    # 🔴 CHECKED AGAINST `FAKE_NAMES` ITSELF, NOT A THIRD HARDCODED TUPLE, so
+    # that ADDING a name to the sanitizer without giving it a label fails here
+    # rather than silently narrowing this guard. ⚠ It cannot see a DELETION —
+    # iterating `FAKE_NAMES` structurally cannot notice a shorter `FAKE_NAMES` —
+    # and that direction is covered by
+    # `test_a_local_name_that_PREFIXES_another_is_not_eaten` instead. Stated
+    # because an earlier version of this comment claimed the deletion direction,
+    # which is the "description wider than the implementation" shape.
     unexercised = [n for n in FAKE_NAMES if not any(n in label for label in labels)]
     assert not unexercised, (
         f"fixture drifted: {unexercised} are in FAKE_NAMES but appear in no label, "
@@ -1015,9 +1018,27 @@ def test_the_gate_exit_code_legend_matches_gate_sh(tmp_path):
         f"{row.reason if row else 'row absent'}")
 
     gate = (REPO_ROOT / "scripts" / "gate.sh").read_text(encoding="utf-8")
-    # Independent read: every commented `<digits> = <text>` in the header block,
-    # without assuming where on the line the digits sit.
-    expected = {m.group(1) for m in re.finditer(r"^#[^\n]*?\b(\d+)\s*=\s*\S", gate, re.M)}
+    # Independent read of the SAME block. Deliberately a different grammar —
+    # it does not care where on the line the digits sit — but the same SCOPE,
+    # because scope is a property of the claim ("the legend"), not of the
+    # parser. Reading the whole file here instead would make the guard disagree
+    # with a correct page the moment `gate.sh` gains an unrelated `# N = …`.
+    #
+    # ⚠ WHAT NEITHER PARSER CAN SEE: a code documented with a different
+    # SEPARATOR (`#  3 : …`) is invisible to both, so the page under-reports and
+    # this guard confirms it. That is inherent to cross-checking one file with
+    # two readers; it is recorded rather than fixed because the alternative —
+    # a third grammar — has the same property one level up.
+    block: list[str] = []
+    started = False
+    for line in gate.splitlines():
+        if re.match(r"^#[^\n]*?\bExit:\s*\d+\s*=", line):
+            started = True
+        elif started and not re.match(r"^#[^\n]*?\b\d+\s*=\s*\S", line):
+            break
+        if started:
+            block.append(line)
+    expected = {m.group(1) for m in re.finditer(r"\b(\d+)\s*=\s*\S", "\n".join(block))}
     assert expected, "no exit codes found in gate.sh at all — the control is broken"
 
     got = {code for code, _ in row.rows}
@@ -1030,6 +1051,49 @@ def test_the_gate_exit_code_legend_matches_gate_sh(tmp_path):
     )
     assert row.value.startswith(f"{len(expected)} "), (
         f"the count in the value label disagrees with the rows: {row.value!r}")
+
+
+def test_the_exit_code_legend_stops_at_the_BLOCK_and_sorts_NUMERICALLY(tmp_path):
+    """🔴 REGRESSION GUARD on two claims the REAL `gate.sh` cannot distinguish.
+
+    Both were unguarded because today's file makes the right and wrong answers
+    identical — the reason a synthetic fixture is the only instrument here:
+
+      * SCOPE. A previous round dropped a `{"0","1","2","90"}` allowlist as
+        "dead code". It was dead as reachability and load-bearing as a VALUE
+        bound. Without it, any of `gate.sh`'s 99 comment lines reading
+        `# N = …` became an exit code on the page — measured, one ordinary body
+        comment rendered a fifth code with the suite green. The real file
+        contains no such comment, so nothing failed.
+      * ORDER. `sorted()` on the code STRING puts `10` before `2`. The real
+        codes are `0,1,2,90`, where lexical and numeric order coincide, so
+        reverting the numeric key changes nothing there.
+
+    The fixture therefore carries a decoy comment far below the legend AND a
+    two-digit code that sorts differently under the two orderings.
+    """
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    (repo / "flake.nix").write_text('runCommandLocal "devrc-pytests" {}\n')
+    (repo / "scripts" / "gate.sh").write_text(
+        "#!/usr/bin/env bash\n"
+        "# Exit: 0 = everything passed.\n"
+        "#      10 = a two-digit code, which must not sort before 2.\n"
+        "#       2 = a usage problem.\n"
+        "\n"
+        "echo hello\n"
+        "#   7 = a retry budget, NOT an exit code, far below the legend\n"
+    )
+    env = measure.Env(repo=repo, home=tmp_path / "h", claude_dir=tmp_path / "c",
+                      index_store=tmp_path / "s", allow_systemd=False,
+                      allow_network=False)
+    got = [code for code, _ in measure.m_gate_exit_codes(env)["rows"]]
+
+    assert "7" not in got, (
+        f"a comment outside the legend block was published as an exit code: {got}")
+    assert got == ["0", "2", "10"], (
+        f"expected numeric order 0,2,10 — got {got}. Lexical sorting puts '10' "
+        "before '2', which the real gate.sh cannot reveal.")
 
 
 def test_every_ledger_KEY_is_a_real_registry_key():

--- a/scripts/tests/test_present_sanitize.py
+++ b/scripts/tests/test_present_sanitize.py
@@ -1024,11 +1024,18 @@ def test_the_gate_exit_code_legend_matches_gate_sh(tmp_path):
     # parser. Reading the whole file here instead would make the guard disagree
     # with a correct page the moment `gate.sh` gains an unrelated `# N = …`.
     #
-    # ⚠ WHAT NEITHER PARSER CAN SEE: a code documented with a different
-    # SEPARATOR (`#  3 : …`) is invisible to both, so the page under-reports and
-    # this guard confirms it. That is inherent to cross-checking one file with
-    # two readers; it is recorded rather than fixed because the alternative —
-    # a third grammar — has the same property one level up.
+    # ⚠ WHAT NEITHER PARSER CAN SEE, AND IT IS WORSE THAN "ONE CODE MISSING".
+    # An earlier version of this note said a code written with a different
+    # SEPARATOR (`#  3 : …`) is merely invisible. Measured, it is not: such a
+    # line is a NON-CONTINUATION, so it TERMINATES the block and every code
+    # after it is lost too — a legend of `0, 3(colon), 2` yields `['0']`. The
+    # same holds for a bare `#` used to group codes mid-legend: `0, #, 1` yields
+    # `['0']`. Both parsers agree, so this guard stays green while the page
+    # under-reports.
+    #
+    # Recorded rather than fixed: the fix is a third grammar, which has the same
+    # property one level up. The mitigation that does work is a maintainer of
+    # `gate.sh` knowing the legend must be an unbroken run of `# N = …` lines.
     block: list[str] = []
     started = False
     for line in gate.splitlines():
@@ -1061,7 +1068,7 @@ def test_the_exit_code_legend_stops_at_the_BLOCK_and_sorts_NUMERICALLY(tmp_path)
 
       * SCOPE. A previous round dropped a `{"0","1","2","90"}` allowlist as
         "dead code". It was dead as reachability and load-bearing as a VALUE
-        bound. Without it, any of `gate.sh`'s 99 comment lines reading
+        bound. Without it, ANY comment line in `gate.sh` reading
         `# N = …` became an exit code on the page — measured, one ordinary body
         comment rendered a fifth code with the suite green. The real file
         contains no such comment, so nothing failed.
@@ -1069,14 +1076,25 @@ def test_the_exit_code_legend_stops_at_the_BLOCK_and_sorts_NUMERICALLY(tmp_path)
         codes are `0,1,2,90`, where lexical and numeric order coincide, so
         reverting the numeric key changes nothing there.
 
-    The fixture therefore carries a decoy comment far below the legend AND a
-    two-digit code that sorts differently under the two orderings.
+    🔴 THE BLOCK HAS TWO BOUNDARIES AND A DECOY BELOW IT ONLY PINS ONE. The
+    first version of this fixture placed its decoy after the legend, so the
+    END boundary was pinned and the START was not — and two mutants survived a
+    green suite: dropping `started` from the continuation branch, and making
+    the `Exit:` anchor optional. The second is the worse one: with a `# N = …`
+    line anywhere ABOVE the legend it makes that line the anchor, so the real
+    legend is never reached and the page renders ONE FABRICATED CODE AND NO
+    REAL ONES, labelled "1 exit codes documented in …". So the fixture brackets
+    the legend — a decoy on each side.
     """
     repo = tmp_path / "repo"
     (repo / "scripts").mkdir(parents=True)
-    (repo / "flake.nix").write_text('runCommandLocal "devrc-pytests" {}\n')
+    # No `flake.nix` stub: `m_gate_exit_codes` reads ONLY `scripts/gate.sh`.
+    # The sibling `m_gate_tiers` is the one that reads the flake, and a stub
+    # here would imply a dependency this measurer does not have.
     (repo / "scripts" / "gate.sh").write_text(
         "#!/usr/bin/env bash\n"
+        "#   5 = a tunable, ABOVE the legend and not part of it\n"
+        "\n"
         "# Exit: 0 = everything passed.\n"
         "#      10 = a two-digit code, which must not sort before 2.\n"
         "#       2 = a usage problem.\n"
@@ -1090,7 +1108,10 @@ def test_the_exit_code_legend_stops_at_the_BLOCK_and_sorts_NUMERICALLY(tmp_path)
     got = [code for code, _ in measure.m_gate_exit_codes(env)["rows"]]
 
     assert "7" not in got, (
-        f"a comment outside the legend block was published as an exit code: {got}")
+        f"a comment BELOW the legend block was published as an exit code: {got}")
+    assert "5" not in got, (
+        f"a comment ABOVE the legend block was published as an exit code, or "
+        f"became the anchor and displaced the real legend: {got}")
     assert got == ["0", "2", "10"], (
         f"expected numeric order 0,2,10 — got {got}. Lexical sorting puts '10' "
         "before '2', which the real gate.sh cannot reveal.")

--- a/scripts/tests/test_present_sanitize.py
+++ b/scripts/tests/test_present_sanitize.py
@@ -78,7 +78,12 @@ FAKE_NODE = "workbench-prod"
 #:   * `bar` and `resume` are shaped like the CORRUPTION risk — ordinary English
 #:     words that are also real local identifiers. They are what proves the
 #:     substitution stays inside the cell it was declared on.
-FAKE_NAMES = ("quartzsight", "pelagic-mail", "bar", "resume")
+#:   * `mailbox` and `pelagic-mailbox` are a PREFIX PAIR reachable through
+#:     `_word`'s hyphen boundary. Without a pair like this in the fixture, the
+#:     longest-first ordering in `_names` is untestable — and reversing it was
+#:     measured to keep the whole suite green while publishing a real client
+#:     name in cleartext.
+FAKE_NAMES = ("quartzsight", "pelagic-mailbox", "mailbox", "bar", "resume")
 #: A sentence of the kind a measurer HARVESTS rather than authors. It names a
 #: third party that appears in NO name list — which is the whole point: this is
 #: the value substitution structurally cannot reach.
@@ -616,6 +621,113 @@ def test_the_same_name_gets_the_same_stand_in_in_both_of_its_cells():
         f"name and path disagree: {name_cell!r} vs {path_cell!r}"
 
 
+def test_a_local_name_that_PREFIXES_another_is_not_eaten():
+    """🔴 REGRESSION GUARD on `_names`' longest-first ordering.
+
+    `_word` treats a hyphen as a boundary, so a short name is reachable INSIDE a
+    longer hyphenated one. Shortest-first therefore rewrites the inner name and
+    leaves the outer one HALF-REAL — which reads as sanitized and is not.
+
+    Measured before this test existed: flipping `reverse=True` to `reverse=False`
+    kept all 75 tests green and published a real client name in cleartext on a
+    page stamped SANITIZED. The sibling guard for `_scopes` (see
+    `test_a_scope_name_that_prefixes_another_is_not_eaten`) had existed all
+    along; the parallel one for `_names` had not, and the fixture carried no
+    pair that could have seen it.
+    """
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("k", columns=("skill",), column_kinds=("name",),
+                         rows=(("/pelagic-mailbox",), ("/mailbox",))))
+    rows = sanitize.apply(ms, _san()).by_key("k").rows
+    blob = repr(rows)
+    assert "mailbox" not in blob, f"a name survived, whole or in part: {blob!r}"
+    stand_ins = re.findall(r"name-\d+", blob)
+    assert len(set(stand_ins)) == 2, f"the two distinct names collapsed: {blob!r}"
+
+
+def test_a_STATIC_LABEL_in_a_name_cell_is_not_corrupted():
+    """The `name` kind drops the length ladder, so prove it cannot eat prose.
+
+    🔴 A `name` cell is NOT a pure identifier slot — `skills.listing`'s `what`
+    column is declared `name` and holds static English labels beside
+    `costliest tier-A entry: <skill>`. The licence for dropping the ladder is
+    CONFINEMENT plus `_word`'s boundaries, not purity, so the labels that
+    actually ship are the thing to assert on.
+    """
+    labels = ("skills shipped (in-tree + mkOutOfStoreSymlink)",
+              "tier A — full description in the always-on listing",
+              "tier B — `name-only`, still /name-invocable",
+              "per-entry cap (upstream, not devrc's)")
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("k", columns=("what",), column_kinds=("name",),
+                         rows=tuple((label,) for label in labels)))
+    out = sanitize.apply(ms, _san()).by_key("k").rows
+    for label, (got,) in zip(labels, out):
+        assert got == label, f"a static label was corrupted: {label!r} -> {got!r}"
+
+
+def test_the_NAME_column_is_found_by_its_KIND_not_by_its_POSITION(tmp_path):
+    """🔴 REGRESSION GUARD. `build()` used to read `row[0]` and assume.
+
+    Measured: swapping the first two cells of the inventory row, WITHOUT
+    touching `column_kinds`, kept 102 tests green, kept both DEGRADED lines
+    byte-identical, kept the masthead reading SANITIZED — and republished every
+    real skill name, because the name list had become the tier letters.
+
+    A column reorder is a one-line refactor nobody would think to re-audit, so
+    the declaration has to be what selects the column.
+    """
+    env = measure.Env(repo=tmp_path, home=tmp_path / "h", claude_dir=tmp_path / "c",
+                      index_store=tmp_path / "s", allow_systemd=False,
+                      allow_network=False)
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("index.store", columns=("scope",), rows=(("borealis",),)))
+    # the name column is SECOND here, exactly as a reorder would leave it
+    ms.items.append(_row("skills.inventory", columns=("tier", "skill"),
+                         column_kinds=("", "name"),
+                         rows=(("A", "/quartzsight"), ("B", "/bar"))))
+    san = sanitize.build(True, env, ms)
+    assert san.local_names == ("bar", "quartzsight"), (
+        f"the name column was read positionally: {san.local_names!r}")
+    assert not san.degraded, f"a well-formed build degraded: {san.degraded!r}"
+
+
+def test_an_inventory_with_NO_name_column_degrades_LOUDLY(tmp_path):
+    """CONTROL for the above: the selector must be able to come back empty.
+
+    Without this, `test_..._by_its_KIND_not_by_its_POSITION` cannot tell a
+    working selector from one that silently falls back to position 0.
+    """
+    env = measure.Env(repo=tmp_path, home=tmp_path / "h", claude_dir=tmp_path / "c",
+                      index_store=tmp_path / "s", allow_systemd=False,
+                      allow_network=False)
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("index.store", columns=("scope",), rows=(("borealis",),)))
+    ms.items.append(_row("skills.inventory", columns=("tier", "skill"),
+                         rows=(("A", "/quartzsight"),)))
+    san = sanitize.build(True, env, ms)
+    assert san.local_names == ()
+    assert any("no `name` column" in r.lower() or "NO `name` column" in r
+               for r in san.degraded), (
+        f"an inventory with no name column degraded silently: {san.degraded!r}")
+
+
+def test_a_RAGGED_row_withholds_the_cells_past_its_DECLARATION():
+    """🔴 FAIL-CLOSED GUARD. A position past the end used to read as ordinary.
+
+    Demonstrated: a measurement declaring `("name", "prose")` with a three-cell
+    row emitted the third cell VERBATIM into a sanitized page. A declaration
+    that does not reach a cell is where this module knows LEAST about it.
+    """
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("k", columns=("skill", "what it is"),
+                         column_kinds=("name", "prose"),
+                         rows=(("/quartzsight", FAKE_PROSE, FAKE_PROSE),)))
+    row = sanitize.apply(ms, _san()).by_key("k").rows[0]
+    assert "Northwind" not in repr(row), f"a ragged cell was published: {row!r}"
+    assert row[2] == sanitize.WITHHELD
+
+
 def test_a_local_name_that_is_an_ENGLISH_WORD_is_not_rewritten_OUTSIDE_its_cell():
     """CORRUPTION CONTROL — the failure that killed the name-list approach.
 
@@ -689,9 +801,18 @@ def test_the_disabled_sanitizer_withholds_NOTHING():
 #: Adding a key here is not a formality. Ask: can a cell in that column contain
 #: a sentence somebody WROTE? If yes it is `prose` — no matter how safe today's
 #: contents look, because the contents change without a commit here.
+#: 🔴 WHAT THIS LEDGER CANNOT SEE. It compares DECLARATIONS to declarations. A
+#: brand-new column that harvests prose and declares NOTHING produces no entry
+#: here, so the comparison still holds and the suite stays green. It catches a
+#: declaration that is deleted, truncated, mistyped or demoted — the likelier
+#: regression now the field exists — and nothing more. An audit found two
+#: undeclared prose columns (`gate.tiers`, `drift.ladder`) while this test was
+#: green, which is the worked proof of that limit.
 PROSE_LEDGER = {
     "skills.listing": ("name", ""),
     "skills.inventory": ("name", "", "prose", "name"),
+    "gate.tiers": ("", "prose"),
+    "drift.ladder": ("", "prose"),
 }
 
 
@@ -734,6 +855,52 @@ def test_the_column_kind_ledger_is_pinned_two_way(tmp_path):
         "If a measurer now harvests human-written text out of a file, declare "
         "that column `prose` and add it here. If a column stopped being "
         "harvested, remove it here in the same commit."
+    )
+
+
+def test_the_inventory_NAME_COLUMN_really_holds_the_skill_names(tmp_path):
+    """🔴 SEAM GUARD pinning a RELATIONSHIP: rows vs the columns describing them.
+
+    `sanitize.build()` sources every local identifier from the column
+    `skills.inventory` declares `name`. Selecting that column BY ITS KIND (which
+    it now does) is necessary and not sufficient: if the measurer's row tuple is
+    reordered while `columns`/`column_kinds` stay put, the declaration points at
+    the wrong cell and the data itself lies. No declaration can catch that —
+    only checking the cells against the source can.
+
+    Measured: reordering the row tuple alone kept 102 tests green, kept both
+    DEGRADED lines byte-identical, kept the masthead reading SANITIZED, and
+    republished every real skill name — because the name list had silently
+    become the set of tier letters {"A", "B", "?"}.
+
+    Read through `skill_tiers`, the measurer's OWN source, so this compares the
+    rendered table against the thing it claims to render rather than against
+    itself.
+    """
+    env = _ledger_env(tmp_path)
+    inv = measure.take(env).by_key("skills.inventory")
+    assert inv is not None and inv.measured, (
+        f"the inventory did not measure, so this guard checked NOTHING: "
+        f"{inv.reason if inv else 'row absent'}")
+
+    idx = next((i for i in range(len(inv.columns)) if inv.kind_of(i) == "name"), None)
+    assert idx is not None, "skills.inventory declares no `name` column"
+
+    sys.path.insert(0, str(SCRIPTS / "lib"))
+    try:
+        import skill_tiers  # noqa: PLC0415
+        expected = {f"/{name}" for name in skill_tiers.shipped_skills()}
+    finally:
+        if sys.path and sys.path[0] == str(SCRIPTS / "lib"):
+            sys.path.pop(0)
+
+    got = {row[idx] for row in inv.rows}
+    assert got == expected, (
+        "the cells in the declared `name` column are not the skill names.\n"
+        f"  column index {idx} holds: {sorted(got)[:5]}...\n"
+        f"  shipped skills are:      {sorted(expected)[:5]}...\n"
+        "If the row tuple was reordered, move `column_kinds` with it — otherwise "
+        "sanitize.build() harvests the wrong cell and every real name ships."
     )
 
 

--- a/scripts/tests/test_present_sanitize.py
+++ b/scripts/tests/test_present_sanitize.py
@@ -660,8 +660,7 @@ def test_a_STATIC_LABEL_in_a_name_cell_is_not_corrupted():
     🔴 A `name` cell is NOT a pure identifier slot — `skills.listing`'s `what`
     column is declared `name` and holds static English labels beside
     `costliest tier-A entry: <skill>`. The licence for dropping the ladder is
-    CONFINEMENT plus `_word`'s boundaries, not purity, so the labels that
-    actually ship are the thing to assert on.
+    CONFINEMENT plus `_word`'s boundaries, not purity.
 
     🔴 EVERY LABEL BELOW CONTAINS A FIXTURE NAME AS A SUBSTRING, AND THAT IS
     THE ENTIRE POINT. The first version asserted on four real labels from
@@ -679,10 +678,17 @@ def test_a_STATIC_LABEL_in_a_name_cell_is_not_corrupted():
         "pinned to the toolbar, not the status area",    # `bar` inside `toolbar`
         "mailboxes are counted, not read",               # `mailbox` inside `mailboxes`
         "quartzsighted about the ceiling",               # `quartzsight` inside a longer word
+        "pelagic-mailboxes archive nightly",             # the whole hyphenated name, extended
     )
-    for name in ("resume", "bar", "mailbox", "quartzsight"):
-        assert any(name in label for label in labels), \
-            f"fixture drifted: {name!r} is no longer exercised, so this guard is vacuous"
+    # 🔴 CHECKED AGAINST `FAKE_NAMES` ITSELF, NOT A THIRD HARDCODED TUPLE. The
+    # first version listed the names again here, so it could not see the drift
+    # it names: deleting one from `FAKE_NAMES` left this test green, and only a
+    # sibling caught it. Every name the sanitizer is given must be exercised by
+    # some label, or this guard is partly vacuous again.
+    unexercised = [n for n in FAKE_NAMES if not any(n in label for label in labels)]
+    assert not unexercised, (
+        f"fixture drifted: {unexercised} are in FAKE_NAMES but appear in no label, "
+        "so this guard does not cover them")
 
     ms = measure.MeasurementSet()
     ms.items.append(_row("k", columns=("what",), column_kinds=("name",),
@@ -978,10 +984,52 @@ def test_the_inventory_NAME_COLUMN_really_holds_the_skill_names(tmp_path):
         f"  declared `name` columns: {name_cols}\n"
         f"  a row reads: {sorted(got)[:1]}\n"
         f"  source says: {sorted(expected)[:1]}\n"
-        "If the row tuple was reordered, move `columns` and `column_kinds` with "
-        "it — otherwise sanitize.build() harvests the wrong cell, or a declared "
-        "`name` cell carries prose, and either way real values ship."
+        "This pins POSITIONS 0/2/3 against the source, so moving `columns` and "
+        "`column_kinds` alongside a row reorder will NOT satisfy it — update the "
+        "indices here in the same commit, deliberately. Until they agree, "
+        "sanitize.build() harvests the wrong cell or a declared `name` cell "
+        "carries prose, and either way real values ship."
     )
+
+
+def test_the_gate_exit_code_legend_matches_gate_sh(tmp_path):
+    """🔴 REGRESSION GUARD. The parser silently dropped `gate.sh`'s SUCCESS code.
+
+    `gate.sh` writes its legend as a hanging indent — `# Exit: 0 = …` first,
+    `#       1 = …` after — so a pattern anchored on `^#\\s+(\\d+)` matches every
+    code EXCEPT 0. The row then rendered "3 exit codes documented in gate.sh's
+    header" for a header documenting four, and the filter's own `"0"` entry was
+    dead code that made the intent look satisfied.
+
+    It shipped green because NOTHING in this suite pinned any `value` string:
+    hardcoding the count to the right number was measured to pass. So this reads
+    the codes out of `gate.sh` INDEPENDENTLY — a different pattern, deliberately
+    — and compares. It is the same defect `m_drift_ladder` already carries a 🔴
+    note about, reintroduced by a new parser 370 lines away, which is why it is
+    pinned rather than merely commented.
+    """
+    env = _ledger_env(tmp_path)
+    row = measure.take(env).by_key("gate.exit_codes")
+    assert row is not None and row.measured, (
+        f"gate.exit_codes did not measure, so this guard checked NOTHING: "
+        f"{row.reason if row else 'row absent'}")
+
+    gate = (REPO_ROOT / "scripts" / "gate.sh").read_text(encoding="utf-8")
+    # Independent read: every commented `<digits> = <text>` in the header block,
+    # without assuming where on the line the digits sit.
+    expected = {m.group(1) for m in re.finditer(r"^#[^\n]*?\b(\d+)\s*=\s*\S", gate, re.M)}
+    assert expected, "no exit codes found in gate.sh at all — the control is broken"
+
+    got = {code for code, _ in row.rows}
+    assert got == expected, (
+        f"the rendered legend does not match gate.sh's header.\n"
+        f"  rendered: {sorted(got, key=int)}\n"
+        f"  gate.sh:  {sorted(expected, key=int)}\n"
+        "A code documented in the script and missing from the page sends a "
+        "reader looking for their exit status in a set that does not contain it."
+    )
+    assert row.value.startswith(f"{len(expected)} "), (
+        f"the count in the value label disagrees with the rows: {row.value!r}")
 
 
 def test_every_ledger_KEY_is_a_real_registry_key():

--- a/scripts/tests/test_present_sanitize.py
+++ b/scripts/tests/test_present_sanitize.py
@@ -73,8 +73,8 @@ FAKE_NODE = "workbench-prod"
 
 #: Local identifiers for a `name` cell. Deliberately mixed:
 #:
-#:   * `quartzsight` and `pelagic-mail` are shaped like the leak that motivated
-#:     the class — a third party's name used as a local identifier;
+#:   * `quartzsight` and `pelagic-mailbox` are shaped like the leak that
+#:     motivated the class — a third party's name used as a local identifier;
 #:   * `bar` and `resume` are shaped like the CORRUPTION risk — ordinary English
 #:     words that are also real local identifiers. They are what proves the
 #:     substitution stays inside the cell it was declared on.
@@ -83,7 +83,16 @@ FAKE_NODE = "workbench-prod"
 #:     longest-first ordering in `_names` is untestable — and reversing it was
 #:     measured to keep the whole suite green while publishing a real client
 #:     name in cleartext.
-FAKE_NAMES = ("quartzsight", "pelagic-mailbox", "mailbox", "bar", "resume")
+#:
+#: 🔴 KEPT IN THE ORDER `build()` ACTUALLY PRODUCES — `tuple(sorted(set(...)))`,
+#: i.e. ALPHABETICAL, which puts `mailbox` BEFORE `pelagic-mailbox`. The first
+#: version of this tuple listed the longer name first, and that accident rescued
+#: a mutant: deleting the `sorted(..., key=len, reverse=True)` in `_names`
+#: entirely left the suite green, because iteration order happened to be
+#: longest-first anyway. Production never sees that order. A fixture whose
+#: incidental layout does the work of the code under test is not a fixture, it
+#: is a second bug.
+FAKE_NAMES = ("bar", "mailbox", "pelagic-mailbox", "quartzsight", "resume")
 #: A sentence of the kind a measurer HARVESTS rather than authors. It names a
 #: third party that appears in NO name list — which is the whole point: this is
 #: the value substitution structurally cannot reach.
@@ -653,17 +662,44 @@ def test_a_STATIC_LABEL_in_a_name_cell_is_not_corrupted():
     `costliest tier-A entry: <skill>`. The licence for dropping the ladder is
     CONFINEMENT plus `_word`'s boundaries, not purity, so the labels that
     actually ship are the thing to assert on.
+
+    🔴 EVERY LABEL BELOW CONTAINS A FIXTURE NAME AS A SUBSTRING, AND THAT IS
+    THE ENTIRE POINT. The first version asserted on four real labels from
+    `m_skill_listing` in which no fixture name appeared at all — so it compared
+    two constants and could not fail under ANY mutation of `_names`, `_word` or
+    the sort order, while its docstring claimed it proved corruption impossible.
+    A guard that reads as coverage and provides none is worse than none, because
+    it stops anyone looking. What actually defends these is `_word`'s
+    non-word-character boundaries, so the fixtures must exercise exactly that.
     """
-    labels = ("skills shipped (in-tree + mkOutOfStoreSymlink)",
-              "tier A — full description in the always-on listing",
-              "tier B — `name-only`, still /name-invocable",
-              "per-entry cap (upstream, not devrc's)")
+    #: name -> a label embedding it WITHOUT a word boundary, so only `_word`
+    #: (never a bare `str.replace`) leaves it intact.
+    labels = (
+        "the run resumed after the gate went green",     # `resume` inside `resumed`
+        "pinned to the toolbar, not the status area",    # `bar` inside `toolbar`
+        "mailboxes are counted, not read",               # `mailbox` inside `mailboxes`
+        "quartzsighted about the ceiling",               # `quartzsight` inside a longer word
+    )
+    for name in ("resume", "bar", "mailbox", "quartzsight"):
+        assert any(name in label for label in labels), \
+            f"fixture drifted: {name!r} is no longer exercised, so this guard is vacuous"
+
     ms = measure.MeasurementSet()
     ms.items.append(_row("k", columns=("what",), column_kinds=("name",),
                          rows=tuple((label,) for label in labels)))
     out = sanitize.apply(ms, _san()).by_key("k").rows
     for label, (got,) in zip(labels, out):
         assert got == label, f"a static label was corrupted: {label!r} -> {got!r}"
+
+    # CONTROL: the same cell kind DOES substitute a name that stands alone, so
+    # the assertions above cannot be passing because `_names` is inert.
+    ctl = measure.MeasurementSet()
+    ctl.items.append(_row("c", columns=("what",), column_kinds=("name",),
+                          rows=(("costliest tier-A entry: quartzsight",),)))
+    got = sanitize.apply(ctl, _san()).by_key("c").rows[0][0]
+    assert "quartzsight" not in got, f"the name class is inert: {got!r}"
+    assert got.startswith("costliest tier-A entry: "), \
+        f"the static half of the label was eaten too: {got!r}"
 
 
 def test_the_NAME_column_is_found_by_its_KIND_not_by_its_POSITION(tmp_path):
@@ -690,6 +726,27 @@ def test_the_NAME_column_is_found_by_its_KIND_not_by_its_POSITION(tmp_path):
     assert san.local_names == ("bar", "quartzsight"), (
         f"the name column was read positionally: {san.local_names!r}")
     assert not san.degraded, f"a well-formed build degraded: {san.degraded!r}"
+
+
+def test_a_SHORT_inventory_row_is_skipped_rather_than_raising(tmp_path):
+    """The `len(row) > idx` bound in `build()`, which nothing else reaches.
+
+    A row shorter than the declared name column is a measurer bug, but it must
+    not take the whole build down — and `>=` there turns the skip into an
+    IndexError. No live measurer emits one, so without this the branch is
+    unexercised and the off-by-one is invisible.
+    """
+    env = measure.Env(repo=tmp_path, home=tmp_path / "h", claude_dir=tmp_path / "c",
+                      index_store=tmp_path / "s", allow_systemd=False,
+                      allow_network=False)
+    ms = measure.MeasurementSet()
+    ms.items.append(_row("index.store", columns=("scope",), rows=(("borealis",),)))
+    ms.items.append(_row("skills.inventory", columns=("tier", "skill"),
+                         column_kinds=("", "name"),
+                         rows=(("A",), ("B", "/quartzsight"))))
+    san = sanitize.build(True, env, ms)
+    assert san.local_names == ("quartzsight",), (
+        f"a short row was not skipped cleanly: {san.local_names!r}")
 
 
 def test_an_inventory_with_NO_name_column_degrades_LOUDLY(tmp_path):
@@ -811,7 +868,10 @@ def test_the_disabled_sanitizer_withholds_NOTHING():
 PROSE_LEDGER = {
     "skills.listing": ("name", ""),
     "skills.inventory": ("name", "", "prose", "name"),
-    "gate.tiers": ("", "prose"),
+    # 🔴 `gate.tiers` is deliberately ABSENT: every cell in it is a literal
+    # authored in `measure.py`. Its harvested half lives in `gate.exit_codes`,
+    # split out precisely so the safe half stops paying for the unsafe one.
+    "gate.exit_codes": ("", "prose"),
     "drift.ladder": ("", "prose"),
 }
 
@@ -876,6 +936,13 @@ def test_the_inventory_NAME_COLUMN_really_holds_the_skill_names(tmp_path):
     Read through `skill_tiers`, the measurer's OWN source, so this compares the
     rendered table against the thing it claims to render rather than against
     itself.
+
+    🔴 IT PINS EVERY DECLARED CELL, NOT JUST THE ONE `build()` READS. The first
+    version checked only the first `name` column it found. `skills.inventory`
+    declares TWO (`skill` and `path`), and swapping the description into the
+    OTHER one survived all 145 present tests and republished every harvested
+    description on a page stamped SANITIZED — the same leak class, one column
+    over. A guard scoped to one cell of a row cannot pin a claim about the row.
     """
     env = _ledger_env(tmp_path)
     inv = measure.take(env).by_key("skills.inventory")
@@ -883,24 +950,37 @@ def test_the_inventory_NAME_COLUMN_really_holds_the_skill_names(tmp_path):
         f"the inventory did not measure, so this guard checked NOTHING: "
         f"{inv.reason if inv else 'row absent'}")
 
-    idx = next((i for i in range(len(inv.columns)) if inv.kind_of(i) == "name"), None)
-    assert idx is not None, "skills.inventory declares no `name` column"
+    name_cols = [i for i in range(len(inv.columns)) if inv.kind_of(i) == "name"]
+    assert name_cols, "skills.inventory declares no `name` column"
 
     sys.path.insert(0, str(SCRIPTS / "lib"))
     try:
         import skill_tiers  # noqa: PLC0415
-        expected = {f"/{name}" for name in skill_tiers.shipped_skills()}
+        shipped = skill_tiers.shipped_skills()
     finally:
         if sys.path and sys.path[0] == str(SCRIPTS / "lib"):
             sys.path.pop(0)
+    assert shipped, "shipped_skills() returned nothing — this guard checked NOTHING"
 
-    got = {row[idx] for row in inv.rows}
+    # The WHOLE declared shape, read back against the measurer's own source:
+    # every `name` cell is the skill name (bare or inside its path), and the
+    # `prose` cell is the description — so no pair of cells can be swapped
+    # without this failing.
+    expected = set()
+    for name, (rel, desc) in shipped.items():
+        first = desc.split(". ")[0].strip()
+        if len(first) > 150:
+            first = first[:147].rstrip() + "..."
+        expected.add((f"/{name}", first, rel))
+    got = {(row[0], row[2], row[3]) for row in inv.rows}
     assert got == expected, (
-        "the cells in the declared `name` column are not the skill names.\n"
-        f"  column index {idx} holds: {sorted(got)[:5]}...\n"
-        f"  shipped skills are:      {sorted(expected)[:5]}...\n"
-        "If the row tuple was reordered, move `column_kinds` with it — otherwise "
-        "sanitize.build() harvests the wrong cell and every real name ships."
+        "the inventory's cells do not match what `skill_tiers` says they are.\n"
+        f"  declared `name` columns: {name_cols}\n"
+        f"  a row reads: {sorted(got)[:1]}\n"
+        f"  source says: {sorted(expected)[:1]}\n"
+        "If the row tuple was reordered, move `columns` and `column_kinds` with "
+        "it — otherwise sanitize.build() harvests the wrong cell, or a declared "
+        "`name` cell carries prose, and either way real values ship."
     )
 
 

--- a/scripts/tests/test_present_sanitize.py
+++ b/scripts/tests/test_present_sanitize.py
@@ -1091,8 +1091,12 @@ def test_the_exit_code_legend_stops_at_the_BLOCK_and_sorts_NUMERICALLY(tmp_path)
     # No `flake.nix` stub: `m_gate_exit_codes` reads ONLY `scripts/gate.sh`.
     # The sibling `m_gate_tiers` is the one that reads the flake, and a stub
     # here would imply a dependency this measurer does not have.
+    # 🔴 NO SHEBANG LINE. `test_runtime_shebangs.py` forbids a test writing one
+    # at runtime (use `testlib.mockbin.write_exec` for a file that will be
+    # EXECUTED). This fixture is only ever READ as text by the measurer, so the
+    # shebang was decoration — and it failed the full pytest tier while the six
+    # `test_present_*` files I had been running stayed green.
     (repo / "scripts" / "gate.sh").write_text(
-        "#!/usr/bin/env bash\n"
         "#   5 = a tunable, ABOVE the legend and not part of it\n"
         "\n"
         "# Exit: 0 = everything passed.\n"


### PR DESCRIPTION
## The recorded diagnosis was wrong, and acting on it would not have fixed the leak

The handoff recorded: *short, word-like **scope** names fall below the length ladder; the fix is a scope allowlist keyed on the store's own scope set.* Measured on the live tree:

| | sanitized | full | why |
|---|---|---|---|
| `naida` | 2 | 2 | **not in the scope set** |
| `vetr` | 3 | 4 | not a scope — the 1 removed was `vetr.com`, via the **host** rule |
| `auditloop` | 3 | 4 | not a scope — the 1 removed was `auditloop.zacx.dev`, via the **host** rule |
| `civitai` | 0 | 5 | control: is a scope, mechanism works |
| `datapacket` | 0 | 2 | control |

The scope class removed **zero** of the leaked occurrences. The length ladder was a red herring — `auditloop` is 9 chars and would have been matched aggressively *had it been a scope*. And the store's scope set was **already** the substitution source (`sanitize.build()` → `by_key("index.store")`); it is a curated index, not an inventory of names that must not leak.

All three survivors sat in `skills.inventory` — human prose harvested out of `claude/skills/*/SKILL.md`. Substitution rewrites identifier **classes** it has been shown; a harvested sentence has no class at all.

## Widening the name list was tried and rejected on measurement

| name source | residual |
|---|---|
| index store only | 6 |
| \+ skill dir names | 3 |
| \+ all 149 `~/workspace` dirs | **2 — `naida` still fully intact** |

The directory is `naida-ai`; the leak was a bare `naida` in a sentence. And the widening corrupts the page: `"run the test suite from a scratch dir"` → `"run the scope-108 suite from a scope-104 dir"` — the `CLI` corruption that forced the original narrowing, at 100× scale.

**A name list is fail-OPEN by construction.** It closes exactly the names something happened to be called after. An entitlement boundary may not be.

## The fix

A measurer DECLARES what each column holds (`Measurement.column_kinds`):

- `""` — ordinary, sanitized by the identifier classes as before
- `"name"` — a local identifier, substituted **inside that cell only**, no length ladder. Confinement is what makes substituting *all* names safe: a skill called `bar` cannot rewrite the word "bar" in prose.
- `"prose"` — human-authored text harvested from a file: **WITHHELD**, never scrubbed.

**Withholding is driven by the declaration, never by a name list**, so it still happens on a host where every name source is empty — the property that separates this from the fix it replaces. An unknown kind is withheld too.

Every name is substituted, not only the client-looking ones: redacting selectively *publishes the judgement* — 35 real names beside 2 stand-ins tells the reader exactly which two are the clients.

## Verified — never a bare zero

```
naida 2->0   vetr 4->0   auditloop 4->0
controls: civitai 5->0, datapacket 2->0, kubeclaw 2->0, zacx.dev 3->0
positive controls: 37 rows / 37 withheld cells / 77 name stand-ins
corruption control: ` test ` 23 in BOTH builds
```

Reproduced red on `origin/main`: `Northwind` survives the base `apply()` with `--sanitize` enabled.

**Gates — both tiers, named:** dev-host `scripts/gate.sh --tier both` → `GATE: RESULT=PASS`; sandbox `nix build .#checks.x86_64-linux.{pytests,nodetests}` → `RESULT: PASS (exit=0)` read from the derivation logs, not the exit code. Base sha `6509702b`.

## Tests

13 new, red at base **on their own assertions**, mutation-swept under `PYTHONDONTWRITEBYTECODE=1` with a pristine positive control. 7 mutants, each killed by the intended guard: withholding removed; unknown kind waved through; name substitution removed; `_names` leaked into `text()` globally; the declaration dropped, truncated, and demoted.

`PROSE_LEDGER` is pinned **two-way against the real registry**, so a measurer that starts harvesting prose without declaring it fails the suite — otherwise invisible in review, being one more `rows.append`.

Also fixed: `test_scope_substitution_degrading_to_ZERO_is_LOUD` would have gone green on the *wrong* degradation once `build()` gained a second name source; it now asserts the scope reason specifically.

## Residual, stated honestly

devrc's **own** subsystem names still appear — in file paths (`scripts/repo-cos/tests`), unit names (`repo-cos.timer`) and `content.py`'s static narrative, none of which pass through a declared column. Correct: the page is *about* devrc. It would become a leak if a script were ever named after a client.

The two remaining `SANITIZE DEGRADED` lines are honest and unrelated to this leak: a nodename indistinguishable from a word, and the 3-char scope `cli`.

**Separately worth a decision (not fixed here):** `claude/skills/*/SKILL.md` is tracked in this **public** repo, so those client names are already published in git. The sanitizer is now correct; the repo-level exposure is a different question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)