### PR TITLE
fix(load-test-harness): the flake reproducer reported a verdict about itself — fixed, generalised, and used

### DIFF
--- a/scripts/dl-router/tests/load_test_store.sh
+++ b/scripts/dl-router/tests/load_test_store.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+#
+# load_test_store.sh — a FLAKE REPRODUCER. Runs one or more pytest targets in a
+# loop under synthetic CPU pressure (and optionally under pytest-xdist) and
+# reports how often they go red.
+#
+# 🔴 THIS IS A SCRIPT, NOT A TEST — never run it as part of the gate.
+#    It spawns (nproc/2) busy-loop CPU burners and takes minutes. It is safe
+#    from `scripts/run-tests.sh` by construction: that runner hands each target
+#    DIRECTORY to `python -m pytest`, and pytest's default `python_files` is
+#    `test_*.py` / `*_test.py`, so a `.sh` file in a tests dir is never
+#    collected. `scripts/tests/test_load_test_harness.py` pins that (the repo
+#    must keep having no pytest config that widens `python_files`), and the
+#    same convention already covers `scripts/tests/mutants-*.sh` and
+#    `scripts/tests/test_*.sh` — shell scripts that live beside tests and are
+#    invoked by hand, never collected.
+#
+# 🔴 WHY THIS FILE HAS A GUARD IN IT. Until 2026-08-25 the pytest nodeid was
+#    split across a line continuation:
+#
+#        python -m pytest "$FLAKE_DIR/.../test_store.py" \
+#          ::test_concurrent_writers_do_not_lose_rows \
+#
+#    so `::test_concurrent_writers_do_not_lose_rows` arrived as its OWN argv
+#    element instead of a suffix on the file path. pytest answers that with
+#    `ERROR: directory argument cannot contain :: selection parts` and
+#    `no tests ran in 0.01s`, exit 4 — so EVERY run "failed" and the script
+#    exited `failures == RUNS` no matter what the code under test did. It was
+#    an instrument reporting a verdict about ITSELF.
+#
+#    Two things stop that coming back:
+#      1. the targets live in an ARRAY and are expanded `"${RESOLVED[@]}"`, so
+#         one target is one argv element and there is no continuation to split;
+#      2. a PREFLIGHT `--collect-only` runs BEFORE any burner is spawned. If the
+#         targets collect zero tests, this script prints `COULD NOT RUN` and
+#         exits 91 — it never reports a failure COUNT it cannot vouch for.
+#         Exit 91 can never collide with a failure count because RUNS > 90 is
+#         rejected up front.
+#
+# Usage:
+#   load_test_store.sh [RUNS] [FLAKE_DIR] [TARGET ...]
+#
+#     RUNS       how many times to run the targets (default 6, max 90).
+#     FLAKE_DIR  the flake/repo to run inside (default: this script's own repo
+#                root — the old default was a `/tmp` path that did not exist, so
+#                the script could not be run without arg 2).
+#     TARGET...  one or more pytest targets. A relative target is resolved
+#                against FLAKE_DIR; an absolute one is used as-is. Default is
+#                the dl-router concurrent-writers test, so existing muscle
+#                memory (`load_test_store.sh 10`) still does what it did.
+#
+#   Env:
+#     PER_RUN_TIMEOUT  seconds per run (default 120).
+#     BURNERS          number of CPU burners (default nproc/2; 0 disables them,
+#                      which is how you test xdist contention WITHOUT CPU load).
+#     XDIST            pytest-xdist width, e.g. 4 (default 0 = no xdist).
+#     DIST             xdist distribution mode when XDIST > 0 (default loadfile,
+#                      matching scripts/run-tests.sh).
+#     PYTEST_EXTRA     extra pytest args, space-separated.
+#     LOG_DIR          where per-run logs go (default /tmp).
+#
+# Exit status:
+#     0..RUNS   the number of runs that FAILED (0 = the target never went red).
+#     91        COULD NOT RUN — the targets collect nothing, or a run collected
+#               nothing. This is NOT "the tests failed"; read the log.
+#     2         bad usage.
+#
+# Examples:
+#   ./load_test_store.sh 10
+#   ./load_test_store.sh 10 "$PWD" scripts/tests/test_git_repo_isolation.py::test_live_cotenants_sees_another_process_in_the_repo
+#   XDIST=4 BURNERS=0 ./load_test_store.sh 10 "$PWD" scripts/tests/test_subsystem_store_api.py
+#
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+DEFAULT_FLAKE_DIR=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
+DEFAULT_TARGET='scripts/dl-router/tests/test_store.py::test_concurrent_writers_do_not_lose_rows'
+
+# 91 is the COULD-NOT-RUN status. It is only unambiguous while a failure count
+# cannot reach it, so the run count is capped here rather than clamped later.
+COULD_NOT_RUN=91
+MAX_RUNS=90
+
+RUNS=${1:-6}
+FLAKE_DIR=${2:-$DEFAULT_FLAKE_DIR}
+if [ "$#" -gt 2 ]; then
+  shift 2
+  TARGETS=("$@")
+else
+  TARGETS=("$DEFAULT_TARGET")
+fi
+
+case "$RUNS" in
+  ''|*[!0-9]*) echo "usage: $(basename "$0") [RUNS] [FLAKE_DIR] [TARGET ...]" >&2
+               echo "  RUNS must be a positive integer, got: $RUNS" >&2; exit 2 ;;
+esac
+if [ "$RUNS" -lt 1 ] || [ "$RUNS" -gt "$MAX_RUNS" ]; then
+  echo "RUNS must be between 1 and $MAX_RUNS (got $RUNS) — $COULD_NOT_RUN is reserved" >&2
+  exit 2
+fi
+if [ ! -e "$FLAKE_DIR/flake.nix" ]; then
+  echo "COULD NOT RUN: no flake.nix in FLAKE_DIR=$FLAKE_DIR" >&2
+  exit "$COULD_NOT_RUN"
+fi
+
+# 🔴 ONE TARGET = ONE ARGV ELEMENT. Never build a nodeid across a line
+# continuation, and never interpolate this array into a single string — that is
+# exactly the defect this file exists to have fixed.
+RESOLVED=()
+for t in "${TARGETS[@]}"; do
+  case "$t" in
+    /*) RESOLVED+=("$t") ;;
+    *)  RESOLVED+=("$FLAKE_DIR/$t") ;;
+  esac
+done
+
+PER_RUN_TIMEOUT=${PER_RUN_TIMEOUT:-120}
+CORES=$(nproc 2>/dev/null || echo 4)
+NUM_BURNERS=${BURNERS:-$(( CORES / 2 ))}
+XDIST=${XDIST:-0}
+DIST=${DIST:-loadfile}
+LOG_DIR=${LOG_DIR:-/tmp}
+mkdir -p "$LOG_DIR"
+
+PYTEST_OPTS=(-q --tb=short)
+if [ "$XDIST" -gt 0 ]; then
+  PYTEST_OPTS+=(-n "$XDIST" --dist "$DIST")
+fi
+# Word-splitting is WANTED here: PYTEST_EXTRA is a space-separated arg list.
+# shellcheck disable=SC2206
+EXTRA=(${PYTEST_EXTRA:-})
+
+Burners=()
+cleanup() {
+  # Reap by RESOLVED PID only — never a `pkill -f` pattern, which would match
+  # this script's own command line and sibling agents' processes.
+  for pid in ${Burners[@]+"${Burners[@]}"}; do
+    kill "$pid" 2>/dev/null || true
+  done
+  wait 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "flake-dir=$FLAKE_DIR"
+echo "targets=${#RESOLVED[@]}"
+for t in "${RESOLVED[@]}"; do echo "  target: $t"; done
+echo "cores=$CORES burners=$NUM_BURNERS runs=$RUNS xdist=$XDIST timeout=${PER_RUN_TIMEOUT}s"
+
+# --- PREFLIGHT: prove the targets COLLECT before burning a single cycle -------
+# A harness that cannot reach its subject must say so, not report a count.
+preflight="$LOG_DIR/load-test-$$.preflight.log"
+set +e
+timeout "$PER_RUN_TIMEOUT" nix develop "$FLAKE_DIR" --command \
+  python -m pytest "${RESOLVED[@]}" --collect-only -q >"$preflight" 2>&1
+preflight_rc=$?
+set -e
+collected=$(grep -Eo '^[0-9]+(/[0-9]+)? tests? collected' "$preflight" 2>/dev/null \
+            | tail -1 | grep -Eo '^[0-9]+' || true)
+if [ "$preflight_rc" -ne 0 ] || [ -z "$collected" ] || [ "$collected" -eq 0 ]; then
+  echo "---"
+  echo "COULD NOT RUN: the targets collect no tests (pytest --collect-only rc=$preflight_rc, collected=${collected:-none})"
+  echo "  this is NOT a test failure — the harness could not reach its subject."
+  echo "  see $preflight"
+  # 🔴 The DIAGNOSTIC must never be able to change the VERDICT. Measured while
+  # building this: a missing LOG_DIR made `sed` exit 2, `set -e` killed the
+  # script mid-report, and the run exited 2 while printing COULD NOT RUN — the
+  # same class of self-referential lie this file was written to remove.
+  sed -n '1,20p' "$preflight" 2>/dev/null | sed 's/^/  | /' || true
+  exit "$COULD_NOT_RUN"
+fi
+echo "preflight: $collected test(s) collected — the harness can reach its subject"
+
+for (( i=0; i<NUM_BURNERS; i++ )); do
+  ( while :; do :; done ) &>/dev/null &
+  Burners+=($!)
+done
+echo "spawned ${#Burners[@]} burners, load: $(uptime | sed 's/.*load average: //')"
+
+failures=0
+for (( run=1; run<=RUNS; run++ )); do
+  log="$LOG_DIR/load-test-$$.run$run.log"
+  set +e
+  timeout "$PER_RUN_TIMEOUT" nix develop "$FLAKE_DIR" --command \
+    python -m pytest "${RESOLVED[@]}" "${PYTEST_OPTS[@]}" ${EXTRA[@]+"${EXTRA[@]}"} \
+    >"$log" 2>&1
+  run_rc=$?
+  set -e
+  summary=$(grep -Ev '^[[:space:]]*$' "$log" | tail -1)
+  # A run that collected nothing is the ORIGINAL defect wearing a different
+  # hat: it must not be scored as a failure of the code under test.
+  if grep -qE '^no tests (ran|collected) in ' "$log"; then
+    echo "  run $run: COULD NOT RUN — collected nothing (rc=$run_rc) — $log"
+    echo "---"
+    echo "COULD NOT RUN after $((run-1)) clean run(s); see $log"
+    exit "$COULD_NOT_RUN"
+  fi
+  if [ "$run_rc" -eq 0 ]; then
+    echo "  run $run: PASS  | $summary"
+  else
+    echo "  run $run: FAIL (rc=$run_rc, see $log) | $summary"
+    failures=$((failures+1))
+  fi
+done
+
+echo "---"
+echo "failures: $failures / $RUNS"
+echo "final load: $(uptime | sed 's/.*load average: //')"
+exit "$failures"

--- a/scripts/dl-router/tests/load_test_store.sh
+++ b/scripts/dl-router/tests/load_test_store.sh
@@ -185,7 +185,9 @@ for (( run=1; run<=RUNS; run++ )); do
     >"$log" 2>&1
   run_rc=$?
   set -e
-  summary=$(grep -Ev '^[[:space:]]*$' "$log" | tail -1)
+  # `|| true`: `set -o pipefail` is on, and grep exits 1 on an EMPTY log — which
+  # would kill the script here, mid-measurement, over a cosmetic line.
+  summary=$(grep -Ev '^[[:space:]]*$' "$log" | tail -1 || true)
   # A run that collected nothing is the ORIGINAL defect wearing a different
   # hat: it must not be scored as a failure of the code under test.
   if grep -qE '^no tests (ran|collected) in ' "$log"; then

--- a/scripts/tests/test_load_test_harness.py
+++ b/scripts/tests/test_load_test_harness.py
@@ -322,6 +322,20 @@ def test_a_clean_sweep_reports_zero_and_exits_zero(tmp_path: Path) -> None:
     assert "failures: 0 / 3" in proc.stdout
 
 
+def test_an_empty_run_log_does_not_kill_the_harness(tmp_path: Path) -> None:
+    """`set -o pipefail` + a `grep` over an EMPTY log exits 1.
+
+    The summary line is cosmetic; it must never be able to abort the
+    measurement. Without the guard the harness dies after run 1 and never
+    prints a `failures:` line at all.
+    """
+    proc, _ = run_harness(tmp_path, runs=3, run_out="", run_rc="0")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "failures: 0 / 3" in proc.stdout, (
+        "the harness stopped early on an empty log instead of finishing its "
+        f"runs:\n{proc.stdout}")
+
+
 def test_runs_above_the_cap_are_refused_so_91_stays_unambiguous(
         tmp_path: Path) -> None:
     """91 is only a distinguishable status while a failure count cannot reach it."""

--- a/scripts/tests/test_load_test_harness.py
+++ b/scripts/tests/test_load_test_harness.py
@@ -463,13 +463,20 @@ def test_the_harness_cannot_be_collected_by_the_gate() -> None:
     assert name.endswith(".sh"), name
     assert not name.startswith("test_"), name
     assert not name.endswith("_test.py"), name
-    configs = [REPO_ROOT / n for n in
-               ("pytest.ini", "setup.cfg", "pyproject.toml", "tox.ini")]
-    present = [c.name for c in configs if c.exists()]
-    assert not present, (
-        f"a pytest config appeared ({present}) — re-check that it does not set "
-        "`python_files`, which is the only thing that could make "
-        f"{name} collectable by scripts/run-tests.sh")
+    # `python_files` is the ONE setting that could change what that name means.
+    # Check the CONTENT of whatever config exists rather than forbidding configs
+    # outright — a `pyproject.toml` added for an unrelated reason must not fail
+    # this with a message about pytest collection.
+    widened = []
+    for cfg in ("pytest.ini", "setup.cfg", "pyproject.toml", "tox.ini"):
+        path = REPO_ROOT / cfg
+        if path.exists() and "python_files" in path.read_text(
+                encoding="utf-8", errors="replace"):
+            widened.append(cfg)
+    assert not widened, (
+        f"{widened} set `python_files` — re-check that the pattern still "
+        f"excludes {name}, or scripts/run-tests.sh will collect a script that "
+        "spawns CPU burners and takes minutes")
 
 
 def deploy_carries(repo: Path, path: Path) -> tuple[bool, str]:

--- a/scripts/tests/test_load_test_harness.py
+++ b/scripts/tests/test_load_test_harness.py
@@ -1,0 +1,407 @@
+"""Guards for `scripts/dl-router/tests/load_test_store.sh` — the FLAKE REPRODUCER.
+
+WHY THIS FILE EXISTS
+--------------------
+The harness is an INSTRUMENT: you point it at a pytest target, it runs that
+target in a loop under CPU pressure, and its exit status is the number of runs
+that went red. An instrument that cannot reach its subject and reports a
+failure count anyway is worse than no instrument, because the count reads as a
+measurement of the code under test.
+
+That is exactly what it did. Until 2026-08-25 the nodeid was split across a
+line continuation::
+
+    python -m pytest "$FLAKE_DIR/scripts/dl-router/tests/test_store.py" \\
+      ::test_concurrent_writers_do_not_lose_rows \\
+      -q --tb=short
+
+so `::test_concurrent_writers_do_not_lose_rows` reached pytest as its OWN argv
+element rather than as a suffix on the file path. pytest answers a bare `::name`
+with `ERROR: directory argument cannot contain :: selection parts` and
+`no tests ran in 0.01s`, exit 4. Measured on this tree at
+1f3d854c: the original script reported `failures: 3 / 3` and exited 3 with the
+subject never once executed; the fixed script reports `failures: 0 / 3` on the
+same target with `1 passed in 9.83s` per run.
+
+WHAT IS REGRESSION COVERAGE HERE AND WHAT IS NOT (RULES.md asks for the label)
+------------------------------------------------------------------------------
+  * `test_the_nodeid_reaches_pytest_as_one_argv_element` and
+    `test_no_argv_element_is_a_bare_selection_part` are REGRESSION coverage.
+    Both are RED against the original file (measured: the first fails because
+    the nodeid is two elements, the second because `::test_concurrent_...`
+    appears alone) and GREEN against the fixed one.
+  * `test_a_target_that_collects_nothing_is_could_not_run` and
+    `test_a_run_that_collects_nothing_mid_loop_is_could_not_run` are REGRESSION
+    coverage for the CONSEQUENCE — the original scored an unreachable subject as
+    `failures == RUNS`. They are RED against the original (it prints a failure
+    count, exit 3) and GREEN here (exit 91, `COULD NOT RUN`).
+  * `test_the_failure_count_is_the_exit_status` and
+    `test_burners_are_reaped_when_the_run_ends` are INVARIANT GUARDS. The bug
+    never violated either; they exist so a fix cannot quietly drop the two
+    properties the original got right.
+  * `test_the_harness_cannot_be_collected_by_the_gate` and
+    `test_the_harness_is_tracked_by_git` are INVARIANT GUARDS on the deploy and
+    the gate: `scripts/dl-router/` is a `home.file` source, so an untracked file
+    there is silently absent from the built artifact, and a harness that spawns
+    CPU burners must never be picked up by `scripts/run-tests.sh`.
+
+HOW THE BEHAVIOURAL TESTS WORK
+------------------------------
+The harness shells out to `nix develop <dir> --command python -m pytest …`.
+These tests put a STUB `nix` first on PATH that (a) appends its whole argv to a
+log, one element per line, and (b) prints a canned pytest summary line and exits
+with a canned status. So the argv the harness BUILDS is observable exactly, in
+both tiers, with no nix, no network and no CPU burn (`BURNERS=0`).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from testlib.mockbin import write_exec  # noqa: E402
+
+HARNESS = SCRIPTS / "dl-router" / "tests" / "load_test_store.sh"
+
+DEFAULT_TARGET_SUFFIX = (
+    "scripts/dl-router/tests/test_store.py"
+    "::test_concurrent_writers_do_not_lose_rows"
+)
+
+# The argv log uses a record marker so one invocation's elements cannot be
+# confused with the next one's — the harness calls `nix` at least twice (the
+# preflight and each run).
+RECORD = "=== INVOCATION ==="
+
+# 🔴 The stub is POSIX sh via `write_exec`, never `#!/usr/bin/env` — the nix
+# build sandbox has no /usr/bin/env, and a stub that cannot exec fails in a way
+# that reads as "the harness is broken". See scripts/testlib/mockbin.py.
+NIX_STUB_BODY = """
+{
+  echo "%(record)s"
+  for a in "$@"; do printf '%%s\\n' "$a"; done
+} >> "$ARGV_LOG"
+
+for a in "$@"; do
+  if [ "$a" = "--collect-only" ]; then
+    printf '%%s\\n' "$STUB_COLLECT_OUT"
+    exit "$STUB_COLLECT_RC"
+  fi
+done
+printf '%%s\\n' "$STUB_RUN_OUT"
+exit "$STUB_RUN_RC"
+""" % {"record": RECORD}
+
+
+def _install_nix_stub(tmp_path: Path) -> tuple[Path, Path]:
+    stub_dir = tmp_path / "stubbin"
+    stub_dir.mkdir()
+    argv_log = tmp_path / "argv.log"
+    argv_log.write_text("", encoding="utf-8")
+    write_exec(stub_dir / "nix", NIX_STUB_BODY)
+    return stub_dir, argv_log
+
+
+def run_harness(
+    tmp_path: Path,
+    *,
+    script: Path | None = None,
+    runs: int = 2,
+    targets: tuple[str, ...] = (),
+    collect_out: str = "1 test collected in 0.05s",
+    collect_rc: str = "0",
+    run_out: str = "1 passed in 0.10s",
+    run_rc: str = "0",
+    extra_env: dict[str, str] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    """Run the harness with a stubbed `nix`, returning (proc, argv_log)."""
+    stub_dir, argv_log = _install_nix_stub(tmp_path)
+    env = dict(os.environ)
+    env["PATH"] = f"{stub_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["ARGV_LOG"] = str(argv_log)
+    env["STUB_COLLECT_OUT"] = collect_out
+    env["STUB_COLLECT_RC"] = collect_rc
+    env["STUB_RUN_OUT"] = run_out
+    env["STUB_RUN_RC"] = run_rc
+    # 🔴 BURNERS=0: a test must never spawn (nproc/2) busy loops on the gate host.
+    env["BURNERS"] = "0"
+    env["LOG_DIR"] = str(tmp_path / "logs")
+    env["PER_RUN_TIMEOUT"] = "30"
+    if extra_env:
+        env.update(extra_env)
+    argv = ["bash", str(script or HARNESS), str(runs), str(REPO_ROOT), *targets]
+    proc = subprocess.run(
+        argv, capture_output=True, text=True, env=env, timeout=120,
+        cwd=str(tmp_path),
+    )
+    return proc, argv_log
+
+
+def invocations(argv_log: Path) -> list[list[str]]:
+    """Split the stub's argv log into one list per `nix` invocation."""
+    records: list[list[str]] = []
+    for line in argv_log.read_text(encoding="utf-8").splitlines():
+        if line == RECORD:
+            records.append([])
+        elif records:
+            records[-1].append(line)
+    return records
+
+
+# --------------------------------------------------------------------------
+# REGRESSION: the nodeid must reach pytest as ONE argv element
+# --------------------------------------------------------------------------
+
+def test_the_nodeid_reaches_pytest_as_one_argv_element(tmp_path: Path) -> None:
+    """RED against the original file, GREEN here.
+
+    The original built the nodeid across a line continuation, so pytest saw
+    `<path>/test_store.py` and `::test_concurrent_writers_do_not_lose_rows` as
+    two separate arguments. This asserts the STATE — one element that ends with
+    the full nodeid — not the absence of a spelling.
+    """
+    proc, argv_log = run_harness(tmp_path, runs=1)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    records = invocations(argv_log)
+    assert records, "the stub `nix` was never invoked — the harness did not run"
+    for argv in records:
+        whole = [a for a in argv if a.endswith(DEFAULT_TARGET_SUFFIX)]
+        assert len(whole) == 1, (
+            "the default target must reach pytest as exactly ONE argv element "
+            f"ending in {DEFAULT_TARGET_SUFFIX!r}; got argv={argv!r}")
+
+
+def test_no_argv_element_is_a_bare_selection_part(tmp_path: Path) -> None:
+    """RED against the original file, GREEN here.
+
+    pytest rejects a bare `::name` outright (`directory argument cannot contain
+    :: selection parts`). No argv element the harness builds may ever start with
+    `::`, for any target.
+    """
+    proc, argv_log = run_harness(
+        tmp_path, runs=1,
+        targets=("scripts/tests/test_git_repo_isolation.py::test_live_cotenants"
+                 "_sees_another_process_in_the_repo",))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    for argv in invocations(argv_log):
+        offenders = [a for a in argv if a.startswith("::")]
+        assert not offenders, (
+            f"argv element(s) {offenders!r} are bare pytest selection parts — "
+            "the nodeid was split across arguments again")
+
+
+def test_a_relative_target_is_resolved_against_the_flake_dir(
+        tmp_path: Path) -> None:
+    proc, argv_log = run_harness(
+        tmp_path, runs=1, targets=("scripts/tests/test_x.py::test_y",))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    wanted = f"{REPO_ROOT}/scripts/tests/test_x.py::test_y"
+    for argv in invocations(argv_log):
+        assert wanted in argv, f"expected {wanted!r} in argv={argv!r}"
+
+
+def test_an_absolute_target_is_passed_through_unchanged(
+        tmp_path: Path) -> None:
+    absolute = "/somewhere/else/test_thing.py::test_case"
+    proc, argv_log = run_harness(tmp_path, runs=1, targets=(absolute,))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    for argv in invocations(argv_log):
+        assert absolute in argv, f"expected {absolute!r} in argv={argv!r}"
+
+
+def test_several_targets_each_stay_one_argv_element(tmp_path: Path) -> None:
+    proc, argv_log = run_harness(
+        tmp_path, runs=1,
+        targets=("scripts/tests/test_a.py::test_one",
+                 "scripts/tests/test_b.py::TestC::test_two"))
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    for argv in invocations(argv_log):
+        assert f"{REPO_ROOT}/scripts/tests/test_a.py::test_one" in argv
+        assert f"{REPO_ROOT}/scripts/tests/test_b.py::TestC::test_two" in argv
+
+
+# --------------------------------------------------------------------------
+# REGRESSION: an unreachable subject is COULD NOT RUN, never a failure count
+# --------------------------------------------------------------------------
+
+def test_a_target_that_collects_nothing_is_could_not_run(
+        tmp_path: Path) -> None:
+    """The preflight guard. RED against the original (it had none).
+
+    Asserted on THIS guard's own message and status, not merely on "non-zero":
+    a neighbouring failure would also be non-zero, and the whole point is that
+    91 means "the harness could not measure", not "the code is broken".
+    """
+    proc, _ = run_harness(
+        tmp_path, runs=3,
+        collect_out="no tests collected in 0.00s", collect_rc="4")
+    assert proc.returncode == 91, (
+        f"expected 91 (COULD NOT RUN), got {proc.returncode}\n"
+        f"{proc.stdout}{proc.stderr}")
+    assert "COULD NOT RUN: the targets collect no tests" in proc.stdout
+    assert "failures:" not in proc.stdout, (
+        "a harness that cannot reach its subject must not print a failure "
+        "COUNT — that is the exact lie this file exists to prevent")
+
+
+def test_the_preflight_runs_before_any_burner_is_spawned(
+        tmp_path: Path) -> None:
+    """Reachability: the guard must fire on the cheap path, not after the burn."""
+    proc, _ = run_harness(
+        tmp_path, runs=3,
+        collect_out="no tests collected in 0.00s", collect_rc="4")
+    assert proc.returncode == 91
+    assert "spawned" not in proc.stdout, (
+        "burners were spawned before the preflight decided the target was "
+        "unreachable")
+
+
+def test_a_run_that_collects_nothing_mid_loop_is_could_not_run(
+        tmp_path: Path) -> None:
+    """Preflight green, then a run collects nothing — still not a failure count.
+
+    Its message is deliberately DIFFERENT from the preflight's, so a test that
+    passes here cannot be passing on the preflight guard's error instead.
+    """
+    proc, _ = run_harness(
+        tmp_path, runs=3,
+        collect_out="1 test collected in 0.05s", collect_rc="0",
+        run_out="no tests ran in 0.01s", run_rc="4")
+    assert proc.returncode == 91, (
+        f"expected 91, got {proc.returncode}\n{proc.stdout}{proc.stderr}")
+    assert "COULD NOT RUN after" in proc.stdout
+    assert "COULD NOT RUN: the targets collect no tests" not in proc.stdout, (
+        "this must be the mid-loop guard's message, not the preflight's — "
+        "otherwise the test is green for the wrong reason")
+    assert "failures:" not in proc.stdout
+
+
+def test_a_missing_flake_dir_is_could_not_run(tmp_path: Path) -> None:
+    stub_dir, argv_log = _install_nix_stub(tmp_path)
+    env = dict(os.environ)
+    env["PATH"] = f"{stub_dir}{os.pathsep}{env.get('PATH', '')}"
+    env.update({"ARGV_LOG": str(argv_log), "STUB_COLLECT_OUT": "",
+                "STUB_COLLECT_RC": "0", "STUB_RUN_OUT": "", "STUB_RUN_RC": "0",
+                "BURNERS": "0", "LOG_DIR": str(tmp_path / "logs")})
+    nowhere = tmp_path / "not-a-flake"
+    nowhere.mkdir()
+    proc = subprocess.run(
+        ["bash", str(HARNESS), "2", str(nowhere)],
+        capture_output=True, text=True, env=env, timeout=60)
+    assert proc.returncode == 91, proc.stdout + proc.stderr
+    assert "COULD NOT RUN: no flake.nix" in proc.stderr
+
+
+# --------------------------------------------------------------------------
+# INVARIANT GUARDS — properties the original got right, pinned so a fix
+# cannot silently drop them
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("runs", [1, 3])
+def test_the_failure_count_is_the_exit_status(
+        tmp_path: Path, runs: int) -> None:
+    """Two points, not one — a hardcoded 1 or a boolean would pass at runs=1."""
+    proc, _ = run_harness(
+        tmp_path, runs=runs, run_out="1 failed in 0.10s", run_rc="1")
+    assert proc.returncode == runs, (
+        f"expected exit {runs} (one per failing run), got {proc.returncode}\n"
+        f"{proc.stdout}")
+    assert f"failures: {runs} / {runs}" in proc.stdout
+
+
+def test_a_clean_sweep_reports_zero_and_exits_zero(tmp_path: Path) -> None:
+    proc, _ = run_harness(tmp_path, runs=3)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "failures: 0 / 3" in proc.stdout
+
+
+def test_runs_above_the_cap_are_refused_so_91_stays_unambiguous(
+        tmp_path: Path) -> None:
+    """91 is only a distinguishable status while a failure count cannot reach it."""
+    proc, _ = run_harness(tmp_path, runs=91)
+    assert proc.returncode == 2, proc.stdout + proc.stderr
+    assert "91 is reserved" in proc.stderr
+
+
+def test_burners_are_reaped_when_the_run_ends(tmp_path: Path) -> None:
+    """The EXIT trap must leave no busy loop behind.
+
+    Checked by PROCESS GROUP, never by a `pkill -f` pattern: a pattern would
+    match this test's own command line and a sibling agent's processes.
+    """
+    stub_dir, argv_log = _install_nix_stub(tmp_path)
+    env = dict(os.environ)
+    env["PATH"] = f"{stub_dir}{os.pathsep}{env.get('PATH', '')}"
+    env.update({"ARGV_LOG": str(argv_log),
+                "STUB_COLLECT_OUT": "1 test collected in 0.05s",
+                "STUB_COLLECT_RC": "0", "STUB_RUN_OUT": "1 passed in 0.10s",
+                "STUB_RUN_RC": "0",
+                "BURNERS": "2", "LOG_DIR": str(tmp_path / "logs"),
+                "PER_RUN_TIMEOUT": "30"})
+    proc = subprocess.Popen(
+        ["bash", str(HARNESS), "1", str(REPO_ROOT)],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        env=env, start_new_session=True)
+    pgid = os.getpgid(proc.pid)
+    out, _ = proc.communicate(timeout=120)
+    assert proc.returncode == 0, out
+    assert "spawned 2 burners" in out, out
+    # The group must be empty once the harness has exited. If a burner survived
+    # it would still be in this group and killpg(0) would succeed.
+    with pytest.raises(ProcessLookupError):
+        os.killpg(pgid, 0)
+
+
+# --------------------------------------------------------------------------
+# INVARIANT GUARDS — the gate must never collect it, the deploy must carry it
+# --------------------------------------------------------------------------
+
+def test_the_harness_cannot_be_collected_by_the_gate() -> None:
+    """It spawns CPU burners and takes minutes — the gate must never run it.
+
+    pytest's default `python_files` is `test_*.py` / `*_test.py`, so a `.sh`
+    file is uncollectable UNLESS a config widens the pattern. Both halves are
+    asserted: the name, and the absence of any pytest config that could change
+    what the name means.
+    """
+    name = HARNESS.name
+    assert name.endswith(".sh"), name
+    assert not name.startswith("test_"), name
+    assert not name.endswith("_test.py"), name
+    configs = [REPO_ROOT / n for n in
+               ("pytest.ini", "setup.cfg", "pyproject.toml", "tox.ini")]
+    present = [c.name for c in configs if c.exists()]
+    assert not present, (
+        f"a pytest config appeared ({present}) — re-check that it does not set "
+        "`python_files`, which is the only thing that could make "
+        f"{name} collectable by scripts/run-tests.sh")
+
+
+def test_the_harness_is_tracked_by_git() -> None:
+    """🔴 `scripts/dl-router/` is a `home.file` source.
+
+    An untracked file there is silently ABSENT from the deployed artifact — the
+    switch succeeds and the file simply is not present. This harness lived
+    untracked in one host's checkout for a day for exactly that reason.
+    """
+    rel = HARNESS.relative_to(REPO_ROOT).as_posix()
+    proc = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-files", "--error-unmatch", rel],
+        capture_output=True, text=True)
+    if proc.returncode != 0 and "not a git repository" in proc.stderr.lower():
+        pytest.skip("no git checkout here (nix build sandbox copies without .git)")
+    assert proc.returncode == 0, (
+        f"{rel} is NOT tracked by git — the nix flake copies "
+        "scripts/dl-router/ into the store from the git tree, so an untracked "
+        "file is omitted from the deploy with no error")
+
+
+def test_the_harness_is_executable() -> None:
+    assert os.access(HARNESS, os.X_OK), f"{HARNESS} lost its +x bit"

--- a/scripts/tests/test_load_test_harness.py
+++ b/scripts/tests/test_load_test_harness.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -66,6 +67,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS = REPO_ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
+from testlib.hermetic_git import hermetic_git_env  # noqa: E402
 from testlib.mockbin import write_exec  # noqa: E402
 
 HARNESS = SCRIPTS / "dl-router" / "tests" / "load_test_store.sh"
@@ -142,6 +144,47 @@ def run_harness(
         cwd=str(tmp_path),
     )
     return proc, argv_log
+
+
+def state_and_pgrp(stat_text: str) -> tuple[str, int] | None:
+    """Parse `state` and `pgrp` out of one /proc/<pid>/stat line.
+
+    Split AFTER the last `)`: the `comm` field is the process name in
+    parentheses and may itself contain spaces and parentheses, so a plain
+    `.split()` on the whole line mis-indexes every field after it.
+    """
+    close = stat_text.rfind(")")
+    if close == -1:
+        return None
+    fields = stat_text[close + 2:].split()
+    if len(fields) < 3 or not fields[2].lstrip("-").isdigit():
+        return None
+    return fields[0], int(fields[2])
+
+
+def live_pids_in_group(pgid: int) -> list[int]:
+    """PIDs in `pgid` that are NOT zombies.
+
+    🔴 `os.kill(pid, 0)` / `os.killpg(pgid, 0)` SUCCEED on a zombie. That exact
+    mistake made `devrc-ci` red on its first 5 of 5 runs, in a reap check green
+    on every dev host — a CI step container's PID 1 does not reap, so the dead
+    child lingered as `Z` and the "is it gone" probe said no. Read the STATE.
+    """
+    live: list[int] = []
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            stat = (entry / "stat").read_text(encoding="utf-8", errors="replace")
+        except (FileNotFoundError, ProcessLookupError, PermissionError, OSError):
+            continue  # the process exited between listdir and read
+        parsed = state_and_pgrp(stat)
+        if parsed is None:
+            continue
+        state, pgrp = parsed
+        if state != "Z" and pgrp == pgid:
+            live.append(int(entry.name))
+    return live
 
 
 def invocations(argv_log: Path) -> list[list[str]]:
@@ -344,6 +387,33 @@ def test_runs_above_the_cap_are_refused_so_91_stays_unambiguous(
     assert "91 is reserved" in proc.stderr
 
 
+def test_the_reap_probe_sees_a_live_process_and_ignores_a_zombie() -> None:
+    """Validate the INSTRUMENT before reading its verdict.
+
+    A `live_pids_in_group` that returned `[]` unconditionally would make the
+    reap test below green forever. Positive control: a real live process in its
+    own group MUST be seen. Then the parser is driven directly over a zombie
+    line and over a `comm` carrying spaces and parentheses — the two shapes a
+    naive `.split()` gets wrong.
+    """
+    # POSITIVE CONTROL — the probe must be able to return a NON-EMPTY answer.
+    sleeper = subprocess.Popen(["sleep", "30"], start_new_session=True)
+    try:
+        seen = live_pids_in_group(os.getpgid(sleeper.pid))
+        assert sleeper.pid in seen, (
+            f"the probe cannot see a live process — it is wired to nothing "
+            f"(pid {sleeper.pid}, group answer {seen})")
+    finally:
+        sleeper.kill()
+        sleeper.wait()
+
+    assert state_and_pgrp("42 (python3.12) S 1 4242 4242 0 -1 …") == ("S", 4242)
+    assert state_and_pgrp("42 (bash) Z 1 4242 4242 0 -1 …") == ("Z", 4242)
+    # A comm with spaces AND parentheses — `.split()` on the whole line would
+    # read "weird)" as the state here.
+    assert state_and_pgrp("42 (my (weird) proc) R 1 99 99 0 -1 …") == ("R", 99)
+
+
 def test_burners_are_reaped_when_the_run_ends(tmp_path: Path) -> None:
     """The EXIT trap must leave no busy loop behind.
 
@@ -367,10 +437,14 @@ def test_burners_are_reaped_when_the_run_ends(tmp_path: Path) -> None:
     out, _ = proc.communicate(timeout=120)
     assert proc.returncode == 0, out
     assert "spawned 2 burners" in out, out
-    # The group must be empty once the harness has exited. If a burner survived
-    # it would still be in this group and killpg(0) would succeed.
-    with pytest.raises(ProcessLookupError):
-        os.killpg(pgid, 0)
+    deadline = time.monotonic() + 10
+    live = live_pids_in_group(pgid)
+    while live and time.monotonic() < deadline:
+        time.sleep(0.1)
+        live = live_pids_in_group(pgid)
+    assert not live, (
+        f"burners survived the EXIT trap: pids {live} are still in process "
+        f"group {pgid}")
 
 
 # --------------------------------------------------------------------------
@@ -398,23 +472,81 @@ def test_the_harness_cannot_be_collected_by_the_gate() -> None:
         f"{name} collectable by scripts/run-tests.sh")
 
 
-def test_the_harness_is_tracked_by_git() -> None:
+def deploy_carries(repo: Path, path: Path) -> tuple[bool, str]:
+    """Would the nix deploy carry `path`? Answered in BOTH tiers, never skipped.
+
+    * dev host — the flake's source is the GIT TREE, so an untracked file under
+      `scripts/dl-router/` is copied into the store by nothing and is silently
+      absent from the deployed artifact. `git ls-files` is the question.
+    * nix build sandbox — there is no `.git` at all (`cp -r ${./.}`, and a
+      flake's `./.` is the tracked tree). But the directory being read there IS
+      that store copy, so PRESENCE is the same claim, already answered.
+
+    🔴 Deliberately not a `pytest.skip`: `scripts/run-tests.sh` GUARD 2 pins the
+    expected-skip SET and its TOTAL, so a new skip fails the gate — and a
+    deploy-completeness check that evaporates in the tier the merge is gated on
+    would be reading as coverage while providing none.
+    """
+    if (repo / ".git").exists():
+        rel = path.relative_to(repo).as_posix()
+        proc = subprocess.run(
+            ["git", "-C", str(repo), "ls-files", "--error-unmatch", rel],
+            capture_output=True, text=True,
+            env=hermetic_git_env())
+        return proc.returncode == 0, (
+            f"git ls-files --error-unmatch {rel}: rc={proc.returncode} "
+            f"{proc.stderr.strip()}")
+    return path.exists(), (
+        f"no .git under {repo} (sandbox tier) — presence of {path} in the "
+        "store copy is the proof the flake carried it")
+
+
+def test_the_harness_is_carried_by_the_deploy() -> None:
     """🔴 `scripts/dl-router/` is a `home.file` source.
 
     An untracked file there is silently ABSENT from the deployed artifact — the
     switch succeeds and the file simply is not present. This harness lived
     untracked in one host's checkout for a day for exactly that reason.
     """
-    rel = HARNESS.relative_to(REPO_ROOT).as_posix()
-    proc = subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "ls-files", "--error-unmatch", rel],
-        capture_output=True, text=True)
-    if proc.returncode != 0 and "not a git repository" in proc.stderr.lower():
-        pytest.skip("no git checkout here (nix build sandbox copies without .git)")
-    assert proc.returncode == 0, (
-        f"{rel} is NOT tracked by git — the nix flake copies "
-        "scripts/dl-router/ into the store from the git tree, so an untracked "
-        "file is omitted from the deploy with no error")
+    carried, why = deploy_carries(REPO_ROOT, HARNESS)
+    assert carried, (
+        f"{HARNESS.relative_to(REPO_ROOT).as_posix()} would NOT reach the "
+        f"deployed artifact — {why}")
+
+
+def test_the_deploy_check_can_say_no_on_both_branches(tmp_path: Path) -> None:
+    """Negative + positive control for `deploy_carries`, on BOTH its branches.
+
+    Without this, the sandbox branch never executes on a dev host and the
+    checkout branch never executes in the sandbox — so each tier would be
+    trusting a branch it cannot observe.
+    """
+    # --- sandbox-shaped: no .git, so presence is the answer -----------------
+    sandbox = tmp_path / "storecopy"
+    sandbox.mkdir()
+    absent = sandbox / "nope.sh"
+    carried, why = deploy_carries(sandbox, absent)
+    assert carried is False, why
+    present = sandbox / "here.sh"
+    present.write_text("", encoding="utf-8")
+    carried, why = deploy_carries(sandbox, present)
+    assert carried is True, why
+
+    # --- checkout-shaped: a real repo, file untracked then tracked ----------
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = hermetic_git_env()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True, env=env)
+    tracked_later = repo / "sub" / "thing.sh"
+    tracked_later.parent.mkdir()
+    tracked_later.write_text("", encoding="utf-8")
+    carried, why = deploy_carries(repo, tracked_later)
+    assert carried is False, (
+        f"an UNTRACKED file must not read as carried — {why}")
+    subprocess.run(["git", "-C", str(repo), "add", "sub/thing.sh"],
+                   check=True, env=env)
+    carried, why = deploy_carries(repo, tracked_later)
+    assert carried is True, why
 
 
 def test_the_harness_is_executable() -> None:


### PR DESCRIPTION
## The diagnosis

`scripts/dl-router/tests/load_test_store.sh` is a **flake reproducer** — it runs a
pytest target in a loop under synthetic CPU load and exits with the number of runs
that went red. It has been **untracked** in the workbench checkout since 2026-08-24,
in a directory (`scripts/dl-router/`) that is a `home.file` deploy source — so it was
also absent from the built artifact entirely.

It also **could not work**. Lines 33-36 split the pytest nodeid across a line
continuation:

```bash
  if timeout "$PER_RUN_TIMEOUT" nix develop "$FLAKE_DIR" --command \
    python -m pytest "$FLAKE_DIR/scripts/dl-router/tests/test_store.py" \
      ::test_concurrent_writers_do_not_lose_rows \
      -q --tb=short >"$log" 2>&1; then
```

so `::test_concurrent_writers_do_not_lose_rows` reached pytest as its **own argv
element** rather than a suffix on the file path. Measured, from the original's own
run log:

```
ERROR: directory argument cannot contain :: selection parts: ::test_concurrent_writers_do_not_lose_rows
no tests ran in 0.01s
```

pytest exits 4, so **every run "failed"** and the script exited `failures == RUNS`
regardless of the code under test. It was an instrument reporting a verdict about
itself.

## Old vs new, side by side

Same repo (`1f3d854c`), same target, same 12 burners, `PER_RUN_TIMEOUT=300`:

| | runs | reported | exit | what the run logs actually say |
|---|---|---|---|---|
| **OLD** | 3 | `failures: 3 / 3` | 3 | `no tests ran in 0.01s` ×3 — the subject never executed |
| **NEW** | 3 | `failures: 0 / 3` | 0 | `1 passed in 9.83s`, `1 passed in 6.42s`, `1 passed in 10.62s` |

The old script's per-run wall time (0.01s) is the tell: it never reached the test.

## Instrument validation — the control pair

The harness was pointed at two synthetic tests written for the purpose (kept out of
the repo — they test nothing in devrc), 3 runs each, 2 burners:

| control | target | reported | exit | log content |
|---|---|---|---|---|
| **negative** (must go red) | `test_must_fail` (`assert 1 + 1 == 3`) | `failures: 3 / 3` | 3 | `AssertionError: negative control: this assertion is designed to fail` / `1 failed in 0.01s` |
| **positive** (must report zero) | `test_must_pass` | `failures: 0 / 3` | 0 | `1 passed in 0.00s` |

Reported as a **pair**: a zero on its own is indistinguishable from a harness wired
to nothing. The negative control fails for a *real assertion*, not a collection
error — checked by reading the log, not the exit code.

**Third control — the new preflight.** Pointed at a nodeid that does not exist:

```
COULD NOT RUN: the targets collect no tests (pytest --collect-only rc=4, collected=none)
  this is NOT a test failure — the harness could not reach its subject.
  | ERROR: not found: …/test_store.py::test_this_name_does_not_exist
exit 91
```

No burners were spawned — the guard fires before the burn, and `spawned` never
appears in the output.

That guard is not hypothetical. **Flake #3's briefed nodeid is wrong**:
`scripts/tests/test_subsystem_touch.py::test_kills_the_LENGTH_guard` does not
resolve — the test is inside `class TestCommitMutationKillMatrix`, so the nodeid
needs the class. The old harness shape would have scored that as `failures: N / N`.
The fixed one says `COULD NOT RUN`, exit 91, and names the reason.

## What changed

1. **The nodeid reaches pytest as one argv element.** Targets live in an array and
   are expanded `"${RESOLVED[@]}"` — there is no continuation left to split.
2. **Generalised to any target.** `load_test_store.sh [RUNS] [FLAKE_DIR] [TARGET ...]`;
   a relative target is resolved against `FLAKE_DIR`, an absolute one passed through.
   The old hardcoded nodeid is the **default**, so `./load_test_store.sh 10` still does
   what it did. New env knobs: `BURNERS` (0 disables them), `XDIST` / `DIST`
   (pytest-xdist width and dist mode), `PYTEST_EXTRA`, `LOG_DIR`, `PER_RUN_TIMEOUT`.
3. **A preflight `--collect-only` before any burner is spawned**, plus a mid-loop
   check: a run that collects nothing is `COULD NOT RUN` (exit 91), never a failure
   count. `RUNS > 90` is refused so 91 can never collide with a count.
4. **`FLAKE_DIR` defaults to the script's own repo root.** The old default was
   `/tmp/flake-load-test`, which does not exist — the script could not be run without
   arg 2.
5. **The diagnostic can no longer change the verdict.** Found while building this: a
   missing `LOG_DIR` made `sed` exit 2, `set -e` killed the script mid-report, and the
   run exited **2** while printing `COULD NOT RUN`. Same for the cosmetic summary line,
   where `set -o pipefail` + `grep` over an empty log aborted the measurement after
   run 1.

Kept: `set -euo pipefail`, the EXIT trap that reaps burners **by resolved PID** (never
a `pkill -f` pattern), and the failure count as exit status.

**It cannot be collected by the gate.** `scripts/run-tests.sh` hands target
*directories* to `python -m pytest`, whose default `python_files` is `test_*.py` /
`*_test.py` — a `.sh` file is never collected. The same convention already covers
`scripts/tests/mutants-*.sh` and `scripts/tests/test_*.sh`. Pinned by
`test_the_harness_cannot_be_collected_by_the_gate`, which also asserts no pytest
config has appeared that could widen `python_files`.

## Regression coverage — the red/green matrix

`scripts/tests/test_load_test_harness.py` drives the harness with a **stub `nix`** first
on PATH that records its whole argv one element per line and prints a canned pytest
summary. So the argv the harness *builds* is observable exactly, in both tiers, with no
nix, no network and `BURNERS=0`.

| | against the ORIGINAL file | against the FIXED file |
|---|---|---|
| the 11 behavioural guards | **RED** | GREEN |
| the invariant guards | GREEN | GREEN |
| **total** | **11 failed, 6 passed** | **20 passed, 0 skipped** |

The primary guard fails with **its own message**, naming the offending element — not a
neighbour's error:

```
AssertionError: argv element(s) ['::test_concurrent_writers_do_not_lose_rows'] are
bare pytest selection parts — the nodeid was split across arguments again
```

Labels are in the module docstring: `test_the_nodeid_reaches_pytest_as_one_argv_element`,
`test_no_argv_element_is_a_bare_selection_part` and the two `COULD NOT RUN` tests are
**regression coverage**; `test_the_failure_count_is_the_exit_status` (parametrised at
two run counts, so a hardcoded `1` cannot pass) and the reap/deploy checks are
**invariant guards** and are not counted as regression coverage.

Two hazards this repo has already paid for were closed before they could fire:

* **No new `pytest.skip`.** GUARD 2 in `run-tests.sh` pins the expected-skip set *and*
  its total, so a new skip fails the gate — and a deploy-completeness check that
  evaporates in the sandbox tier would read as coverage while providing none.
  `deploy_carries()` answers in both tiers and is driven over **both** its branches by
  its own negative control.
* **The reap probe is zombie-proof.** `os.killpg(pgid, 0)` succeeds on a zombie — the
  exact probe that made `devrc-ci` red on its first 5 of 5 runs. It now reads the state
  character from `/proc/<pid>/stat`, with a **positive control** proving the probe can
  return a non-empty answer at all.

## Did load reproduce flake #1?

**The briefed nodeid did not go red once in 40 runs. Two of its siblings, in the same
file and on the same mechanism, went red 3 times in 10 — but only under the gate's own
concurrency shape.**

Three conditions, all on this branch's tree, on the workbench (24 cores; baseline load
17-27 from other agents throughout):

| | target | burners | xdist | runs | red |
|---|---|---|---|---|---|
| **A** | the flake-#1 nodeid alone | 12 (load 24 → 28) | none | 20 | **0 / 20** |
| **B** | the whole `test_subsystem_store_api.py` | 0 | `-n 4 --dist load` | 10 | **0 / 10** (272 passed every run) |
| **D** | the whole `scripts/tests` — the gate's own shape | 6 | `-n 4 --dist loadfile` | 10 | **3 / 10** |

So: **CPU load alone does not reproduce it** (A, 0/20 at load ~28), and **xdist over the
single file does not either** (B, 0/10). What reproduces is condition D — 4 xdist workers
running *different files* concurrently, which is what `--dist loadfile` over the whole
directory produces, and which is exactly how `scripts/run-tests.sh` runs.

All three red runs were in `test_subsystem_store_api.py`, all on worker `gw3`, and all on
the **same mechanism flake #1 was diagnosed with** — a positional index into an audit log
written asynchronously by a server subprocess:

* runs 3 and 7 — `TestLockoutOverHTTP::test_five_failures_lock_out_a_VALID_token_from_the_same_client`

  ```
  assert "status=lockout-triggered" in audit[4]
  AssertionError: assert 'status=lockout-triggered' in 'store-api audit … auth=fail result=401 status=unauthorized'
  ```

* run 5 — `TestLockoutOverHTTP::test_a_SUCCESS_does_NOT_buy_more_GUESSES`

  ```
  assert "status=lockout-triggered" in audit[5]
  AssertionError: assert 'status=lockout-triggered' in 'store-api audit … auth=ok result=200 status=recalled'
  ```

In both, the record sitting at that index was an **earlier** one — the expected record had
not arrived yet. Neither of these two tests is among the three flakes named in the brief,
so this is new for **#863**, which owns the file. The reproducer for it is:

```bash
XDIST=4 DIST=loadfile BURNERS=6 PER_RUN_TIMEOUT=1200 \
  ./scripts/dl-router/tests/load_test_store.sh 10 . scripts/tests
```

Not fixed here — #863 owns that file.

⚠ **Condition D applied CPU load and gate-shape xdist together, so it does not separate
them.** A and B show that neither factor *alone* is sufficient at those run counts; a
`BURNERS=0` run of condition D was not made.

The other two briefed flakes also never went red: `test_git_repo_isolation.py::test_live_cotenants_sees_another_process_in_the_repo`
passed in all 10 condition-D runs, and **flake #3's briefed nodeid does not exist** —
`test_kills_the_LENGTH_guard` is inside `class TestCommitMutationKillMatrix`, so the
nodeid needs the class. The fixed harness reports that as `COULD NOT RUN` / exit 91;
the old one would have reported it as `failures: N / N`.

## Gate — both tiers

Base sha **`1f3d854c`** (`origin/main` when this branch was cut); branch head
**`465f8ce1`**. `origin/main` has since moved to `6509702b` — these runs are a claim
about this branch at `465f8ce1`, on that base, not about the merged tree.

**Dev-host tier** — `nix develop . --command bash scripts/gate.sh --tier both --set hermetic`

```
  PASS  pytest  exit=0  verdict='RESULT: PASS (exit=0)'
  PASS  node    exit=0  verdict='RESULT: PASS (exit=0)'
GATE: RESULT=PASS exit=0
```

`scripts/tests collected=8556 passed=8556 skipped=0 floor=8036`; node
`TOTAL suites=5 files=39 tests=1292 pass=1292 fail=0 skipped=0`.

**Sandbox tier** — the one Tekton runs and the merge is gated on:

```
nix build .#checks.x86_64-linux.pytests    -> RESULT: PASS (exit=0), BUILD_RC=0
    TOTAL collected=17008 passed=17006 skipped=2 failed=0 (floor: 15789 = sum of 28 per-target floors)
    grep -c "building '" = 1     # it genuinely built; 0 would be a cached zero

nix build .#checks.x86_64-linux.nodetests  -> RESULT: PASS (exit=0), BUILD_RC=0
    TOTAL suites=5 files=39 tests=1292 pass=1292 fail=0 skipped=0 (floor: 1239)
    grep -c "building '" = 1
```

`skipped=2` is the pinned `EXPECTED_SKIPS` set unchanged — this branch adds **no** skip,
which is why `deploy_carries()` answers in both tiers instead of skipping in one.

## Not verified

Stated plainly rather than rounded up.

* **Which factor drives the reproduction.** Condition D applied CPU load *and* gate-shape
  xdist at once. A and B rule out each *alone* at 20 and 10 runs; D does not separate
  them. A `BURNERS=0` run of condition D would.
* **The briefed flake #1 nodeid never went red** in 40 runs across three conditions. That
  is a negative result at those run counts, not proof it cannot reproduce.
* **`--rebuild` was not run.** Both sandbox checks were built plain and each was confirmed
  to have genuinely built (`grep -c "building '"` = 1, not a cached zero). I did not
  additionally force a rebuild for determinism.
* **Merged-tree gating is not done.** `strict` is false on `main` and `origin/main` moved
  from `1f3d854c` to `6509702b` while this was in flight.
* **Not deployed.** No `home-manager switch` / `ship.sh` was run. `scripts/dl-router/` is a
  `home.file` source, so the harness only reaches the deployed artifact after a switch —
  being tracked (this PR) is necessary, not sufficient.
* **Condition B's stdout lost its final `failures:` line** because I edited the running
  script mid-run — bash re-reads a script by byte offset, so the tail was truncated. The
  0/10 there is read from the ten per-run pytest logs (`272 passed` in each), not from
  that stdout.
* **`shellcheck` was not run** on the harness; it is not in `gateTools` and no gate runs
  it. `bash -n` passes.
