### PR TITLE
feat(audit-pr): a round that changes no PRODUCTION code is auditing the LADDER, not the PR

### DIFF
--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -7,6 +7,9 @@ allowed-tools: Bash, Read, Grep, Glob, Agent
 
 # /audit-pr — adversarial PR audit
 
+Every case history and number below is sourced in
+`~/.claude/skills/audit-pr/reference/round-ladder-evidence.md`.
+
 Target: `$ARGUMENTS`. Resolve it:
 - A number → that GitHub PR (`gh pr diff <n>`, `gh pr view <n>`).
 - `current` / empty → the current branch's diff vs its base/trunk.
@@ -16,16 +19,15 @@ Target: `$ARGUMENTS`. Resolve it:
 
 Dispatch a subagent (read-only — it must NOT modify files or merge) to audit the change against this checklist. Have it read the diff and the code it touches, not just the PR description.
 
-**Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, and anything security/auth/path-gating. These reliably hide real, deploy-blocking bugs (shutdown data-loss, trash-path overwrite, scanner match-path scope-creep, an unauthenticated arbitrary-path scan and a git `core.fsmonitor` RCE all surfaced this way). If the branch has a **private Go module dep**, the auditor may need `GOPRIVATE` (e.g. `GOPRIVATE=github.com/civitai/*`) — a sum-db `500` there is env, not a code defect.
+**Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, and anything security/auth/path-gating. These reliably hide real, deploy-blocking bugs (shutdown data-loss, trash-path overwrite, scanner scope-creep, an unauthenticated arbitrary-path scan and a git `core.fsmonitor` RCE all surfaced this way). If the branch has a **private Go module dep**, the auditor may need `GOPRIVATE` — a sum-db `500` there is env, not a code defect.
 
-**Brief the auditor on the environment, or it will report false findings.** A fresh worktree is not a
-working checkout, and an auditor that hits this cold reports it as a defect in the PR. Tell it, up
+**Brief the auditor on the environment, or it will report false findings.** A fresh worktree is not
+a working checkout, and an auditor that hits this cold reports it as a defect in the PR. Tell it, up
 front, whichever apply: **git submodules are unpopulated** in a new worktree (one made 4 test files
-"fail to collect" — pure environment); **monorepo/workspace
-`node_modules`** may need linking per package, not just at the root; **whether the base branch is
-already red** on typecheck/lint/tests, and *at which file*, so a baseline error is not attributed to
-the PR; and that **zsh does not word-split unquoted parameters**, so `eslint $FILES` silently checks
-**zero** files and prints a confident PASS. Also tell it to work in a `cp -a` copy if it wants to
+"fail to collect" — pure environment); **monorepo `node_modules`** may need linking per package, not
+just at the root; **whether the base branch is already red** on typecheck/lint/tests and *at which
+file*, so a baseline error is not attributed to the PR; and that **zsh does not word-split unquoted
+parameters**, so `eslint $FILES` silently checks **zero** files and prints a confident PASS. Also tell it to work in a `cp -a` copy if it wants to
 mutate code, leave your worktree untouched, and verify it clean at the end.
 
 **Audit for:**
@@ -58,9 +60,9 @@ Ask the re-auditor to:
   only where the defect would let a real behaviour regression through;
 - treat "the author says it's fixed" as a claim to verify against the diff.
 
-**Carry the ledger in every round's summary**: `round N · production lines changed since round 1: X
-· elapsed: Y`. Without it the flattening is visible only in hindsight — on #498 the session
-diagnosed its own plateau at round 9, six rounds after X stopped moving.
+**Carry the ledger in every round's summary**: `round N · payload lines changed THIS round: X (since
+round 1: Y) · elapsed: Z`. X is what the gate below reads; without it the flattening is visible only
+in hindsight — on #498 the session diagnosed its own plateau at round 9, six rounds late.
 
 ### 🔴 A clean round ENDS the ladder. Never run another round to confirm a clean round.
 
@@ -101,31 +103,39 @@ For a delta re-audit you must name the prior findings (that is the point), so ke
 
 ### 🔴 ATTRIBUTION: a round that changes no PRODUCTION code is auditing the LADDER, not the PR
 
-A fix round writes new guards. The next delta round diffs `<audited-sha>..HEAD`, so **those guards
-are its audit surface** — the ladder manufactures its own next round's findings, and the stop rule
-above, keyed to findings, can never fire. Measured on `civitai/cli` #498 (2026-08-26): **ten rounds,
-5 h 32 m, 77% of the session's output tokens; the fix commits for rounds 4–10 changed 1,002 lines of
-test code and ZERO lines of production code.** No round was ever clean. Full numbers and method:
-`~/.claude/skills/audit-pr/reference/round-ladder-evidence.md`.
+A fix round writes new guards and the next delta round diffs them, so **the ladder manufactures its
+own next round's findings** and the stop rule above, keyed to findings, can never fire. Measured on
+`civitai/cli` #498 (2026-08-26): **ten rounds, 5 h 32 m, 77% of the session's output tokens; rounds
+4–10 changed 1,051 lines of test code and ZERO lines of the thing the PR shipped.** No round was
+ever clean.
 
 So gate on what each round CHANGES, not on what it finds. After a round's fixes land, count the
-production lines **that round** changed: `git diff --numstat <the sha you audited THAT round>..HEAD`.
+payload lines **that round** changed:
 
-🔴 **Per-round, never cumulative.** A range anchored at round 1 stays non-zero forever once any
-early round touched production — on #498 the cumulative form prints the same number for rounds 4
-through 10 and the gate never fires. Equivalently: the ledger's cumulative X **unchanged across two
-rounds** is the same condition, and that is what makes it visible in the summaries.
+```
+git log --numstat --format= --no-merges --first-parent <the sha you audited THAT round>..HEAD
+```
 
-🔴 **Do not classify with a pathspec.** `':!*test*'` swallows `attestation/`, `latest/` and
-`inspector/` as "tests" while missing `FooTest.java` and `*.cy.ts` — wrong in both directions on
-ordinary names (measured). A round's fix touches a handful of files: read the `--numstat` list and
-judge by this repo's convention. **Tests, fixtures and docs are not production.** Ambiguous is not
-zero — the gate does not fire, and the ladder continues.
+🔴 **The unit is THIS PR's PAYLOAD, never a file extension.** Payload = what the PR exists to ship;
+scaffolding = the tests, fixtures and notes a round wrote to guard it. For a code change the payload
+is source and a `.md` is not — but **for a docs or skill PR the payload IS the `.md`**, and 24 of
+devrc's last 40 merged PRs ship no source at all, so a rule keyed to file type reads every round of
+those as zero and stops a ladder that is working. Nor will a pathspec do it: `':!*test*'` swallows
+`attestation/` and `latest/`, `':!*spec*'` swallows `inspector/`, and both keep `FooTest.java` and
+`*.cy.ts` (measured). A round's fix touches a handful of files — read the list and name each one
+payload or scaffolding. **Ambiguous is not zero**: the gate does not fire, and the ladder continues.
 
-**Two consecutive rounds whose fixes changed zero production lines ⇒ the ladder has left the PR.
-Stop.** File the remaining guard findings as one follow-up task naming the test file, closed when
-its PR merges or a named reader dismisses it in writing; do not spend a round on them. A round that
-touches production code never trips this, however deep the ladder is.
+🔴 **Per-round and the round's OWN commits.** Anchored at round 1 the count stays non-zero forever
+once an early round touched payload — on #498 that prints the same number for rounds 4 through 10
+and never fires. A plain two-dot `git diff` breaks the other way: after a `merge main` or a rebase
+it sweeps upstream lines in as payload, so a scaffolding-only round scores non-zero and the counter
+resets. Hence `--first-parent --no-merges` above; if the branch was rebased mid-round, re-anchor on
+the new sha rather than trusting the old one.
+
+**Two consecutive rounds whose fixes changed zero payload lines ⇒ the ladder has left the PR.
+Stop.** File the remaining scaffolding findings as one follow-up task naming the file, closed when
+its PR merges or a named reader dismisses it in writing. A round that touches payload never trips
+this, however deep the ladder is.
 
 ⚠ **This does not retract the two rules above, and is not a cap in disguise.** #498's rounds were
 not wasted in the sense those rules deny — every one found something real. The waste is on a
@@ -137,26 +147,19 @@ measures the fixes; it never counts the rounds.
 When a PR claims a guard is "mutation-verified", check **what kind**. Deleting the guard is the
 obvious mutant and the weakest: four variants that delete NOTHING — swapped operands, inverted
 branches, the guard commented out, a stale value re-bound — once passed a suite its author had just
-"mutation-verified" (each one, and how to enumerate your own, in the reference file). The two that
-decide most cases:
-
-- **When you can only assert on TEXT** (raw SQL, a generated config, a serialised query), **pin the
-  WHOLE normalised statement**, not features of it — a partial regex is satisfied by semantically
-  inverted code, and `--` / `/* */` make "the token is present" and "the clause is live" different
-  facts. A cosmetic reformat then fails the test; that is the trade.
-- **A fixture of empty or default values collapses distinct implementations into identical output.**
-  One mutant survived *only* because the fixture was `{}`. Give fixtures non-default sibling values.
-
-**A review fix RESETS the gate** (`claude/RULES.md`): re-run the FULL battery after each fix round
-*and* after any reformat, not just the mutant for what you changed.
+"mutation-verified". The two rules that decide most cases: **when you can only assert on TEXT, pin
+the WHOLE normalised statement** (a partial regex is satisfied by inverted code, and `--` / `/* */`
+make "the token is present" and "the clause is live" different facts — a cosmetic reformat then
+fails the test, which is the trade); and **a fixture of empty or default values collapses distinct
+implementations into identical output**, so give fixtures non-default sibling values. **A review fix
+RESETS the gate** (`claude/RULES.md`): re-run the FULL battery after every round and reformat.
 
 ## Price a defect from the CONSUMING code, not the producing site
 
-Before repeating any consequence an audit asserts — especially one with a cost attached — read the
-code that **consumes** the value, not just the code that writes it. **Verifying that a value is USED
-is not verifying what its ABSENCE costs**: one audit priced a lost watermark at "re-judges the whole
-backlog at LLM cost" when a `NOT EXISTS` dedupe in the same `WHERE` clause made it zero LLM calls.
-Sanity-check the frequency side too — "routine" and "rare" are asserted far more often than measured.
+**Verifying that a value is USED is not verifying what its ABSENCE costs.** Read the code that
+consumes it before repeating any consequence an audit asserts, especially a costed one (worked
+example in the reference file). Sanity-check the frequency side too — "routine" and "rare" are
+asserted far more often than measured.
 
 **A finding about the PR *description* gets corrected PUBLICLY.** If the audit shows the PR body
 misstates what the change does, post a **PR comment** saying so rather than silently editing the

--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -14,12 +14,9 @@ Target: `$ARGUMENTS`. Resolve it:
 
 ## What to do
 
-Dispatch a subagent (read-only — it must NOT modify files or merge) to audit the change against this checklist. Have it actually read the diff and the surrounding code it touches, not just the PR description.
+Dispatch a subagent (read-only — it must NOT modify files or merge) to audit the change against this checklist. Have it read the diff and the code it touches, not just the PR description.
 
-**Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, and anything security/auth/path-gating. These reliably hide real, deploy-blocking bugs (shutdown data-loss, trash-path overwrite, an unauthenticated arbitrary-path scan and a git `core.fsmonitor` RCE all surfaced this way). If the branch has a **private Go module dep**, the auditor may need `GOPRIVATE` (e.g. `GOPRIVATE=github.com/civitai/*`) — a sum-db `500` there is env, not a code defect.
-
-Case histories: `~/.claude/skills/audit-pr/reference/round-ladder-evidence.md` (source
-`devrc/claude/skills/audit-pr/`).
+**Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, and anything security/auth/path-gating. These reliably hide real, deploy-blocking bugs (shutdown data-loss, trash-path overwrite, scanner match-path scope-creep, an unauthenticated arbitrary-path scan and a git `core.fsmonitor` RCE all surfaced this way). If the branch has a **private Go module dep**, the auditor may need `GOPRIVATE` (e.g. `GOPRIVATE=github.com/civitai/*`) — a sum-db `500` there is env, not a code defect.
 
 **Brief the auditor on the environment, or it will report false findings.** A fresh worktree is not a
 working checkout, and an auditor that hits this cold reports it as a defect in the PR. Tell it, up
@@ -63,7 +60,7 @@ Ask the re-auditor to:
 
 **Carry the ledger in every round's summary**: `round N · production lines changed since round 1: X
 · elapsed: Y`. Without it the flattening is visible only in hindsight — on #498 the session
-diagnosed its own plateau at round 9, six rounds after that number stopped moving.
+diagnosed its own plateau at round 9, six rounds after X stopped moving.
 
 ### 🔴 A clean round ENDS the ladder. Never run another round to confirm a clean round.
 
@@ -72,10 +69,9 @@ round that returns no findings is the last one — stop there, and do not re-con
 not on the author saying it's done.
 
 🔴 **A "safe to merge" VERDICT is not the stop signal — the FINDINGS are.** #804's rounds **5, 6 and
-7 each returned "safe to merge" and each still reported real defects** that were then fixed — among
-them a `didDrag` latch pinned on its SET but not its RELEASE, where deleting the reset, deleting the
-clear, and deleting **both** were all green. A ladder keyed to the verdict stops at round 5 and
-ships that latch.
+7 each returned "safe to merge" and each still reported real defects** that were then fixed — the
+last a latch that read as pinned and was vacuous in both directions (all three in the reference
+file). A ladder keyed to the verdict stops at round 5 and ships it.
 
 ⚠ **#804 is NOT an example of a wasted round, and neither is any other PR cited here.** Every one of
 its eight rounds produced findings that needed fixing, round 8 included. This is a forward rule with
@@ -90,26 +86,6 @@ detector exists to prevent, reintroduced by the fix for the previous one"*. A ca
 both. Keep going while rounds keep finding things — `claude/RULES.md` still says to budget for
 several — and stop the moment one does not.
 
-### 🔴 ATTRIBUTION: a round that changes no PRODUCTION code is auditing the LADDER, not the PR
-
-A fix round writes new guards. The next delta round diffs `<audited-sha>..HEAD`, so **those guards
-are its audit surface** — the ladder manufactures its own next round's findings, and the stop rule
-above, keyed to findings, can never fire. Measured on `civitai/cli` #498 (2026-08-26): **ten
-rounds, 5 h 32 m, 77% of the session's output tokens; the fix commits for rounds 4–10 changed 1,002
-lines of test code and ZERO lines of production code.** No round was ever clean.
-
-So gate on what the rounds CHANGE, not on what they find. Before dispatching round N+1, run
-`git diff --numstat <first-audited-sha>..HEAD -- ':!*_test.*' ':!*test*' ':!*spec*'`.
-
-**Two consecutive rounds whose fixes changed zero production lines ⇒ the ladder has left the PR.
-Stop.** File the remaining guard findings as a follow-up task against the test file; do not spend a
-round on them. A round that touches production code never trips this, however deep the ladder is.
-
-⚠ **This does not retract the two rules above, and is not a cap in disguise.** #498's rounds were
-not wasted in the sense those rules deny — every one found something real. The waste is on a
-different axis: real findings *about scaffolding the ladder itself had just written*. The gate
-measures the fixes; it never counts the rounds.
-
 **When a round's fix is mostly renumbering your own prose, fix the FORM, not the number.** Number
 the list and tell the reader to count it; a total maintained in parallel with the thing it counts
 will drift.
@@ -123,42 +99,64 @@ Three successive framed audits **confirmed** a claim; one blind audit refuted it
 For a delta re-audit you must name the prior findings (that is the point), so keep the framing to
 *what was claimed fixed* — never *why it is correct*.
 
+### 🔴 ATTRIBUTION: a round that changes no PRODUCTION code is auditing the LADDER, not the PR
+
+A fix round writes new guards. The next delta round diffs `<audited-sha>..HEAD`, so **those guards
+are its audit surface** — the ladder manufactures its own next round's findings, and the stop rule
+above, keyed to findings, can never fire. Measured on `civitai/cli` #498 (2026-08-26): **ten rounds,
+5 h 32 m, 77% of the session's output tokens; the fix commits for rounds 4–10 changed 1,002 lines of
+test code and ZERO lines of production code.** No round was ever clean. Full numbers and method:
+`~/.claude/skills/audit-pr/reference/round-ladder-evidence.md`.
+
+So gate on what each round CHANGES, not on what it finds. After a round's fixes land, count the
+production lines **that round** changed: `git diff --numstat <the sha you audited THAT round>..HEAD`.
+
+🔴 **Per-round, never cumulative.** A range anchored at round 1 stays non-zero forever once any
+early round touched production — on #498 the cumulative form prints the same number for rounds 4
+through 10 and the gate never fires. Equivalently: the ledger's cumulative X **unchanged across two
+rounds** is the same condition, and that is what makes it visible in the summaries.
+
+🔴 **Do not classify with a pathspec.** `':!*test*'` swallows `attestation/`, `latest/` and
+`inspector/` as "tests" while missing `FooTest.java` and `*.cy.ts` — wrong in both directions on
+ordinary names (measured). A round's fix touches a handful of files: read the `--numstat` list and
+judge by this repo's convention. **Tests, fixtures and docs are not production.** Ambiguous is not
+zero — the gate does not fire, and the ladder continues.
+
+**Two consecutive rounds whose fixes changed zero production lines ⇒ the ladder has left the PR.
+Stop.** File the remaining guard findings as one follow-up task naming the test file, closed when
+its PR merges or a named reader dismisses it in writing; do not spend a round on them. A round that
+touches production code never trips this, however deep the ladder is.
+
+⚠ **This does not retract the two rules above, and is not a cap in disguise.** #498's rounds were
+not wasted in the sense those rules deny — every one found something real. The waste is on a
+different axis: real findings *about scaffolding the ladder itself had just written*. The gate
+measures the fixes; it never counts the rounds.
+
 ## Mutation testing: deletion-mutants are the EASY half
 
-When a PR claims a guard is "mutation-verified", check **what kind** of mutation was run. Breaking a
-guard by *deleting* it is the obvious test and the weakest one. Four semantically broken variants
-that delete nothing once passed a suite its author had just "mutation-verified":
-
-- **swap the operands** of a merge/concat — inverts which side wins;
-- **invert the branches** of a CASE/ternary — here it turned a merge into an unconditional WIPE,
-  strictly worse than the bug being fixed;
-- **comment the guard out** — the clause is dead but the TEXT is still present, so every regex
-  looking for it still matches;
-- **re-bind a stale value** — literally the original defect, reintroduced.
-
-Generalisations, as auditor **and** as author:
+When a PR claims a guard is "mutation-verified", check **what kind**. Deleting the guard is the
+obvious mutant and the weakest: four variants that delete NOTHING — swapped operands, inverted
+branches, the guard commented out, a stale value re-bound — once passed a suite its author had just
+"mutation-verified" (each one, and how to enumerate your own, in the reference file). The two that
+decide most cases:
 
 - **When you can only assert on TEXT** (raw SQL, a generated config, a serialised query), **pin the
-  WHOLE normalised statement**, not features of it. A partial regex is satisfied by semantically
+  WHOLE normalised statement**, not features of it — a partial regex is satisfied by semantically
   inverted code, and `--` / `/* */` make "the token is present" and "the clause is live" different
-  facts. Accept that a cosmetic reformat then fails the test — that is the trade.
+  facts. A cosmetic reformat then fails the test; that is the trade.
 - **A fixture of empty or default values collapses distinct implementations into identical output.**
-  One mutant survived *only* because the fixture was `{}`, which made "bind just the patch" and
-  "rebind the whole stale snapshot" byte-identical. Give fixtures non-default sibling values.
-- **Enumerate mutants from the expression's semantic failure modes** — operand order, branch order,
-  comment-out, wrong bind, off-by-one — not from "delete the thing I was already thinking about".
-- **A review fix RESETS the gate.** Re-run the FULL mutant battery after each fix round *and* after
-  any reformat, not just the mutant for the thing you changed.
+  One mutant survived *only* because the fixture was `{}`. Give fixtures non-default sibling values.
+
+**A review fix RESETS the gate** (`claude/RULES.md`): re-run the FULL battery after each fix round
+*and* after any reformat, not just the mutant for what you changed.
 
 ## Price a defect from the CONSUMING code, not the producing site
 
 Before repeating any consequence an audit asserts — especially one with a cost attached — read the
-code that **consumes** the value, not just the code that writes it. One audit priced a lost
-watermark at "re-judges the whole backlog at LLM cost"; a `NOT EXISTS` dedupe in the same `WHERE`
-clause made the true cost a wider index scan and **zero** LLM calls, two public claims too late.
-
-**Verifying that a value is USED is not verifying what its ABSENCE costs.** Also sanity-check the
-frequency side of any risk claim — "routine" and "rare" are asserted far more often than measured.
+code that **consumes** the value, not just the code that writes it. **Verifying that a value is USED
+is not verifying what its ABSENCE costs**: one audit priced a lost watermark at "re-judges the whole
+backlog at LLM cost" when a `NOT EXISTS` dedupe in the same `WHERE` clause made it zero LLM calls.
+Sanity-check the frequency side too — "routine" and "rare" are asserted far more often than measured.
 
 **A finding about the PR *description* gets corrected PUBLICLY.** If the audit shows the PR body
 misstates what the change does, post a **PR comment** saying so rather than silently editing the

--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -16,12 +16,15 @@ Target: `$ARGUMENTS`. Resolve it:
 
 Dispatch a subagent (read-only — it must NOT modify files or merge) to audit the change against this checklist. Have it actually read the diff and the surrounding code it touches, not just the PR description.
 
-**Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, and anything security/auth/path-gating. These reliably hide real, deploy-blocking bugs (shutdown data-loss, trash-path overwrite, scanner match-path scope-creep, unauthenticated arbitrary-path scan, a git `core.fsmonitor` RCE all surfaced this way). If the branch has a **private Go module dep**, the auditor may need `GOPRIVATE` set (e.g. `GOPRIVATE=github.com/civitai/*`) to build/inspect it — a sum-db `500` there is env, not a code defect.
+**Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, and anything security/auth/path-gating. These reliably hide real, deploy-blocking bugs (shutdown data-loss, trash-path overwrite, an unauthenticated arbitrary-path scan and a git `core.fsmonitor` RCE all surfaced this way). If the branch has a **private Go module dep**, the auditor may need `GOPRIVATE` (e.g. `GOPRIVATE=github.com/civitai/*`) — a sum-db `500` there is env, not a code defect.
+
+Case histories: `~/.claude/skills/audit-pr/reference/round-ladder-evidence.md` (source
+`devrc/claude/skills/audit-pr/`).
 
 **Brief the auditor on the environment, or it will report false findings.** A fresh worktree is not a
 working checkout, and an auditor that hits this cold reports it as a defect in the PR. Tell it, up
-front, whichever apply: **git submodules are unpopulated** in a new worktree (one unpopulated
-submodule made 4 test files "fail to collect" — pure environment); **monorepo/workspace
+front, whichever apply: **git submodules are unpopulated** in a new worktree (one made 4 test files
+"fail to collect" — pure environment); **monorepo/workspace
 `node_modules`** may need linking per package, not just at the root; **whether the base branch is
 already red** on typecheck/lint/tests, and *at which file*, so a baseline error is not attributed to
 the PR; and that **zsh does not word-split unquoted parameters**, so `eslint $FILES` silently checks
@@ -41,22 +44,26 @@ mutate code, leave your worktree untouched, and verify it clean at the end.
 
 ## After the fixes: RE-AUDIT THE DELTA (don't assume closure)
 
-**A fix round frequently introduces the next finding.** One `civitai-manager`
-feature took **five rounds**: a dead button → fixing it exposed a silent
-wrong-file install → fixing *that* introduced a type-check regression that refused
-legitimate LoCon installs. Every one was caught pre-merge, and **none of them by
-the mechanical gate**.
+**A fix round frequently introduces the next finding.** One `civitai-manager` feature took **five
+rounds**, each caused by the previous fix, and **none of them caught by the mechanical gate**.
 
-So once an audit's findings are fixed, dispatch a **delta re-audit** — diff the fix
-commits against the **previously-audited tip** (`git diff <audited-sha>..HEAD`),
-not the whole PR again. Especially when the fix touched the same code path.
+So once an audit's findings are fixed, dispatch a **delta re-audit** — diff the fix commits against
+the **previously-audited tip** (`git diff <audited-sha>..HEAD`), not the whole PR again. Especially
+when the fix touched the same code path.
 
 Ask the re-auditor to:
 - state **per prior finding**: actually fixed / partially / not / **made worse**;
-- hunt specifically for **regressions the fix round itself introduced** (the new
-  guard that's too strict, the new branch that's unreachable, the narrowed type
-  check that now rejects a legitimate case);
+- hunt specifically for **regressions the fix round itself introduced** (the new guard that's too
+  strict, the new branch that's unreachable, the narrowed type check that now rejects a legitimate
+  case);
+- **label every finding `behaviour` or `guard`, and separate shipped behaviour from scaffolding.**
+  Tests an earlier round of this same ladder wrote are in its diff *by construction*; report on them
+  only where the defect would let a real behaviour regression through;
 - treat "the author says it's fixed" as a claim to verify against the diff.
+
+**Carry the ledger in every round's summary**: `round N · production lines changed since round 1: X
+· elapsed: Y`. Without it the flattening is visible only in hindsight — on #498 the session
+diagnosed its own plateau at round 9, six rounds after that number stopped moving.
 
 ### 🔴 A clean round ENDS the ladder. Never run another round to confirm a clean round.
 
@@ -65,49 +72,62 @@ round that returns no findings is the last one — stop there, and do not re-con
 not on the author saying it's done.
 
 🔴 **A "safe to merge" VERDICT is not the stop signal — the FINDINGS are.** #804's rounds **5, 6 and
-7 each returned "safe to merge" and each still reported real defects** that were then fixed: a
-module-scope `installAutoStart` whose deletion left the entire lightbox inert in Brave with the
-suite 99/99 green; four checked-in numbers that disagreed with each other about one measurement; and
-a `didDrag` latch pinned on its SET but not its RELEASE, where deleting the reset, deleting the
+7 each returned "safe to merge" and each still reported real defects** that were then fixed — among
+them a `didDrag` latch pinned on its SET but not its RELEASE, where deleting the reset, deleting the
 clear, and deleting **both** were all green. A ladder keyed to the verdict stops at round 5 and
-ships that latch — a guard that reads as pinned and is vacuous in both directions.
+ships that latch.
 
 ⚠ **#804 is NOT an example of a wasted round, and neither is any other PR cited here.** Every one of
-its eight rounds produced findings that needed fixing, round 8 included (three 🟢, two of them
-shipped features that could be unwired with the suite green). The ladder ran to 8 legitimately and
-the stop rule was never exercised on it. This is a forward rule with a demonstrated near-miss — do
-not cite it as a fix for measured waste.
+its eight rounds produced findings that needed fixing, round 8 included. This is a forward rule with
+a demonstrated near-miss — do not cite it as a fix for measured waste.
 
-🔴 **This is NOT a round cap, and a cap was rejected.** The count is set by FINDINGS, never by a
-number, and #505 is why: its round 2 opens *"Round 1 fixed six findings and introduced two of its
-own"*, and its round 4 caught a **ReDoS that round 3's own fix introduced** — three 40-char shas did
-not return in 30 s, hanging `/handoff` with no output — plus a terminator requirement that round 3
-had added and that silently dropped ten marker shapes, *"the failure this detector exists to
-prevent, reintroduced by the fix for the previous one"*. A cap at 2 or 3 ships both. Keep going
-while rounds keep finding things — `claude/RULES.md` still says to budget for several — and stop the
-moment one does not.
+🔴 **This is NOT a round cap, and a cap was rejected.** The count is set by
+FINDINGS, never by a number, and #505 is why: its round 2 opens *"Round 1 fixed six findings and
+introduced two of its own"*, and its round 4 caught a **ReDoS that round 3's own fix introduced** —
+three 40-char shas did not return in 30 s, hanging `/handoff` with no output — plus a terminator
+requirement that round 3 had added and that silently dropped ten marker shapes, *"the failure this
+detector exists to prevent, reintroduced by the fix for the previous one"*. A cap at 2 or 3 ships
+both. Keep going while rounds keep finding things — `claude/RULES.md` still says to budget for
+several — and stop the moment one does not.
 
-**When a round's fix is mostly renumbering your own prose, fix the FORM, not the number.** #804 hit
-this three times: round 5 found "four `.toLowerCase()` guards" was seven, round 6 found four
-checked-in numbers for one measurement, and round 8's own message records the count regrowing wrong
-*twice in the paragraph about counts*. Number the list and tell the reader to count it; a total
-maintained in parallel with the thing it counts will drift.
+### 🔴 ATTRIBUTION: a round that changes no PRODUCTION code is auditing the LADDER, not the PR
+
+A fix round writes new guards. The next delta round diffs `<audited-sha>..HEAD`, so **those guards
+are its audit surface** — the ladder manufactures its own next round's findings, and the stop rule
+above, keyed to findings, can never fire. Measured on `civitai/cli` #498 (2026-08-26): **ten
+rounds, 5 h 32 m, 77% of the session's output tokens; the fix commits for rounds 4–10 changed 1,002
+lines of test code and ZERO lines of production code.** No round was ever clean.
+
+So gate on what the rounds CHANGE, not on what they find. Before dispatching round N+1, run
+`git diff --numstat <first-audited-sha>..HEAD -- ':!*_test.*' ':!*test*' ':!*spec*'`.
+
+**Two consecutive rounds whose fixes changed zero production lines ⇒ the ladder has left the PR.
+Stop.** File the remaining guard findings as a follow-up task against the test file; do not spend a
+round on them. A round that touches production code never trips this, however deep the ladder is.
+
+⚠ **This does not retract the two rules above, and is not a cap in disguise.** #498's rounds were
+not wasted in the sense those rules deny — every one found something real. The waste is on a
+different axis: real findings *about scaffolding the ladder itself had just written*. The gate
+measures the fixes; it never counts the rounds.
+
+**When a round's fix is mostly renumbering your own prose, fix the FORM, not the number.** Number
+the list and tell the reader to count it; a total maintained in parallel with the thing it counts
+will drift.
 
 **Say the stop rule to the re-auditor explicitly** ("a clean round is the stop condition; do not
 invent findings to justify the round") — otherwise late rounds manufacture nits to look productive.
 
 🔴 **A FRAMED AUDIT VERIFIES THE FRAME. When a PR has already been audited, dispatch the next one
 BLIND** — give it the diff and the checklist, *not* your conclusions or the prior findings' answers.
-Three successive audits **confirmed** a claim purely because the prompt handed them the thing to
-check; a single blind audit refuted it in one pass by finding a second reader nobody had mentioned.
+Three successive framed audits **confirmed** a claim; one blind audit refuted it in a single pass.
 For a delta re-audit you must name the prior findings (that is the point), so keep the framing to
 *what was claimed fixed* — never *why it is correct*.
 
 ## Mutation testing: deletion-mutants are the EASY half
 
 When a PR claims a guard is "mutation-verified", check **what kind** of mutation was run. Breaking a
-guard by *deleting* it is the obvious test and the weakest one. Across one PR, four semantically
-broken variants that delete nothing all passed a suite its author had just "mutation-verified":
+guard by *deleting* it is the obvious test and the weakest one. Four semantically broken variants
+that delete nothing once passed a suite its author had just "mutation-verified":
 
 - **swap the operands** of a merge/concat — inverts which side wins;
 - **invert the branches** of a CASE/ternary — here it turned a merge into an unconditional WIPE,
@@ -116,7 +136,7 @@ broken variants that delete nothing all passed a suite its author had just "muta
   looking for it still matches;
 - **re-bind a stale value** — literally the original defect, reintroduced.
 
-Generalisations worth applying as an auditor **and** as an author:
+Generalisations, as auditor **and** as author:
 
 - **When you can only assert on TEXT** (raw SQL, a generated config, a serialised query), **pin the
   WHOLE normalised statement**, not features of it. A partial regex is satisfied by semantically
@@ -133,22 +153,20 @@ Generalisations worth applying as an auditor **and** as an author:
 ## Price a defect from the CONSUMING code, not the producing site
 
 Before repeating any consequence an audit asserts — especially one with a cost attached — read the
-code that **consumes** the value, not just the code that writes it. An audit correctly established
-that a watermark was written, that losing it reset the watermark, and that a query read it; it then
-priced the loss as "re-judges the whole backlog at LLM cost". The same `WHERE` clause carried an
-independent `NOT EXISTS` dedupe that excluded every already-processed row regardless of the
-watermark, so the true cost was a wider index scan and zero LLM calls. The wrong figure propagated
-into a PR body, a public comment and two code notes before anyone read the full clause.
+code that **consumes** the value, not just the code that writes it. One audit priced a lost
+watermark at "re-judges the whole backlog at LLM cost"; a `NOT EXISTS` dedupe in the same `WHERE`
+clause made the true cost a wider index scan and **zero** LLM calls, two public claims too late.
 
 **Verifying that a value is USED is not verifying what its ABSENCE costs.** Also sanity-check the
-frequency side of any risk claim (how often can the two writers actually collide?) — "routine" and
-"rare" get asserted far more often than they get measured.
+frequency side of any risk claim — "routine" and "rare" are asserted far more often than measured.
 
-**A finding about the PR *description* gets corrected PUBLICLY.** If the audit
-shows the PR body misstates what the change does, post a **PR comment** saying so
-rather than silently editing the body — a reviewer may already have read (and
-believed) the wrong version.
+**A finding about the PR *description* gets corrected PUBLICLY.** If the audit shows the PR body
+misstates what the change does, post a **PR comment** saying so rather than silently editing the
+body — a reviewer may already have read (and believed) the wrong version.
 
 ## Output
 
-Findings grouped by severity (🔴 deploy-blocking / 🟡 should-fix / 🟢 nit), each with file:line and a one-line "why it matters". End with a clear **verdict**: safe to merge / merge after fixing 🔴 / needs rework. No marketing language; flag uncertainty honestly. Do not merge — report only.
+Findings grouped by severity (🔴 deploy-blocking / 🟡 should-fix / 🟢 nit), each with file:line, a
+`behaviour`/`guard` label, and a one-line "why it matters". Then the round ledger, then a clear
+**verdict**: safe to merge / merge after fixing 🔴 / needs rework — advisory for the human, never
+the ladder's stop signal. No marketing language; flag uncertainty. Do not merge — report only.

--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Grep, Glob, Agent
 
 # /audit-pr — adversarial PR audit
 
-Every measurement below is dated and sourced in
+Case histories and the measurements behind the ladder rules:
 `~/.claude/skills/audit-pr/reference/round-ladder-evidence.md`.
 
 Target: `$ARGUMENTS`. Resolve it:
@@ -19,16 +19,16 @@ Target: `$ARGUMENTS`. Resolve it:
 
 Dispatch a subagent (read-only — it must NOT modify files or merge) to audit the change against this checklist. Have it read the diff and the code it touches, not just the PR description.
 
-**Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, and anything security/auth/path-gating. These reliably hide real, deploy-blocking bugs (shutdown data-loss, trash-path overwrite, scanner scope-creep, an unauthenticated arbitrary-path scan and a git `core.fsmonitor` RCE all surfaced this way). If the branch has a **private Go module dep**, the auditor may need `GOPRIVATE` — a sum-db `500` there is env, not a code defect.
+**Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, anything security/auth/path-gating. These reliably hide deploy-blocking bugs (shutdown data-loss, trash-path overwrite, scanner scope-creep, an unauthenticated arbitrary-path scan and a git `core.fsmonitor` RCE all surfaced this way). If the branch has a **private Go module dep**, the auditor may need `GOPRIVATE` — a sum-db `500` there is env, not a code defect.
 
 **Brief the auditor on the environment, or it will report false findings.** A fresh worktree is not
-a working checkout, and an auditor that hits this cold reports it as a defect in the PR. Tell it, up
-front, whichever apply: **git submodules are unpopulated** in a new worktree (one made 4 test files
+a working checkout, and an auditor hitting this cold reports it as a defect in the PR. Tell it,
+whichever apply: **git submodules are unpopulated** in a new worktree (one made 4 test files
 "fail to collect" — pure environment); **monorepo `node_modules`** may need linking per package, not
 just at the root; **whether the base branch is already red** on typecheck/lint/tests and *at which
 file*, so a baseline error is not attributed to the PR; and that **zsh does not word-split unquoted
-parameters**, so `eslint $FILES` silently checks **zero** files and prints a confident PASS. Also tell it to work in a `cp -a` copy if it wants to
-mutate code, leave your worktree untouched, and verify it clean at the end.
+parameters**, so `eslint $FILES` silently checks **zero** files and prints a confident PASS. Also tell it to mutate code only in a `cp -a` copy, and
+to verify your worktree clean at the end.
 
 **Audit for:**
 1. **Risks** — what could break in production from this change.
@@ -44,11 +44,9 @@ mutate code, leave your worktree untouched, and verify it clean at the end.
 ## After the fixes: RE-AUDIT THE DELTA (don't assume closure)
 
 **A fix round frequently introduces the next finding** — one feature took **five rounds**, each
-caused by the previous fix, none caught by the mechanical gate.
-
-So once an audit's findings are fixed, dispatch a **delta re-audit** — diff the fix commits against
-the **previously-audited tip** (`git diff <audited-sha>..HEAD`), not the whole PR again. Especially
-when the fix touched the same code path.
+caused by the previous fix, none caught by the mechanical gate. So once the findings are fixed,
+dispatch a **delta re-audit**: diff the fix commits against the **previously-audited tip**, not the
+whole PR again, especially when the fix touched the same code path.
 
 Ask the re-auditor to:
 - state **per prior finding**: actually fixed / partially / not / **made worse**;
@@ -57,12 +55,12 @@ Ask the re-auditor to:
   case);
 - **label every finding `behaviour` or `guard`, and separate shipped behaviour from scaffolding.**
   Tests an earlier round wrote are in its diff *by construction*; report on them only where the
-  defect would let a real regression through;
-- treat "the author says it's fixed" as a claim to verify against the diff.
+  defect lets a real regression through;
+- treat "the author says it's fixed" as a claim to check against the diff.
 
 **Carry the ledger in every round's summary**: `round N · payload lines changed THIS round: X (since
-round 1: Y) · elapsed: Z`. X is what the gate below reads; without it the flattening is visible only
-in hindsight — on #498 the session diagnosed its own plateau at round 9, six rounds late.
+round 1: Y) · elapsed: Z`. X is what the gate below reads; without it the flattening shows only in
+hindsight — on #498 the session diagnosed its own plateau at round 9, six rounds late.
 
 ### 🔴 A clean round ENDS the ladder. Never run another round to confirm a clean round.
 
@@ -88,22 +86,22 @@ detector exists to prevent, reintroduced by the fix for the previous one"*. A ca
 both. Keep going while rounds keep finding things — `claude/RULES.md` still says to budget for
 several — and stop the moment one does not.
 
-**When a round's fix is mostly renumbering your own prose, fix the FORM, not the number.** Number
+**When a round's fix is mostly renumbering your own prose, fix the FORM, not the number** — number
 the list and tell the reader to count it; a total kept in parallel with what it counts will drift.
 
 **Say the stop rule to the re-auditor explicitly** ("a clean round is the stop condition; do not
 invent findings to justify the round") — otherwise late rounds manufacture nits.
 
 🔴 **A FRAMED AUDIT VERIFIES THE FRAME. When a PR has already been audited, dispatch the next one
-BLIND** — give it the diff and the checklist, *not* your conclusions or the prior findings' answers.
-Three successive framed audits **confirmed** a claim; one blind audit refuted it in a single pass.
-For a delta re-audit you must name the prior findings (that is the point), so keep the framing to
-*what was claimed fixed* — never *why it is correct*.
+BLIND** — the diff and the checklist, *not* your conclusions or the prior findings' answers. Three
+successive framed audits **confirmed** a claim; one blind audit refuted it in a pass. A delta
+re-audit must name the prior findings, so frame it as *what was claimed fixed* — never *why it is
+correct*.
 
 ### 🔴 ATTRIBUTION: a round that changes no PAYLOAD is auditing the LADDER, not the PR
 
 A fix round writes new guards and the next delta round diffs them, so **the ladder manufactures its
-own next round's findings** and the stop rule above, keyed to findings, can never fire. Measured on
+own next round's findings** and the stop rule above, keyed to findings, cannot fire. Measured on
 `civitai/cli` #498: **ten rounds, 5 h 32 m, 77% of the session's output tokens; rounds 4–10 changed
 1,051 test lines and ZERO payload lines.** No round was ever clean.
 
@@ -111,31 +109,32 @@ So gate on what each round CHANGES, not on what it finds. After a round's fixes 
 payload lines **that round** changed:
 
 ```
-git log --numstat --format= --no-merges --first-parent <the sha you audited THAT round>..HEAD
+git log --numstat --format= --remerge-diff <the sha you audited THAT round>..HEAD --not <base>
 ```
 
 🔴 **The unit is THIS PR's PAYLOAD, never a file extension.** Payload = what the PR exists to ship;
 scaffolding = the tests, fixtures and notes a round wrote to guard it. For a code change the payload
-is source and a `.md` is not — but **for a docs or skill PR the payload IS the `.md`**, and on 2026-08-26 **25 of
-devrc's 40 most recently merged PRs shipped no source at all**, so a rule keyed to file type reads
-every round of those as zero and stops a ladder that is working. Nor will a pathspec do it: `':!*test*'` swallows
+is source and a `.md` is not — but **for a docs or skill PR the payload IS the `.md`**, and **most of this repo's
+merged PRs ship no source file at all** (measured; the reference file dates it), so a rule keyed to
+file type reads every round of those as zero and stops a ladder that is working. Nor will a pathspec do it: `':!*test*'` swallows
 `attestation/` and `latest/`, `':!*spec*'` swallows `inspector/`, and both keep `FooTest.java` and
 `*.cy.ts` (measured). A round's fix touches a handful of files — read the list and name each one
 payload or scaffolding. **Ambiguous is not zero**: the gate does not fire, and the ladder continues.
 
-🔴 **Per-round and the round's OWN commits.** Anchored at round 1 the count stays non-zero forever
-once an early round touched payload — on #498 that prints the same number for rounds 4 through 10
-and never fires. A plain two-dot `git diff` breaks the other way: after a `merge main` or a rebase
-it sweeps upstream lines in as payload, so a scaffolding-only round scores non-zero and the counter
-resets. Hence `--first-parent --no-merges` above; if the branch was rebased mid-round, re-anchor on the
-new sha. **`--no-merges` has one cost**: payload hand-written into a merge *conflict resolution* is
-invisible to it (measured: 0 where the old form read 340), so if a round's fix landed that way,
-count that merge explicitly with `git show --numstat <merge>`.
+🔴 **Per-round, and every commit the round actually made.** Anchored at round 1 the count stays
+non-zero forever once an early round touched payload — on #498 that prints the same number for
+rounds 4 through 10 and never fires. Each part of the command above earns its place, measured across
+four ladder shapes (table in the reference file): `--not <base>` is what keeps a `merge main` from
+being counted as this round's work — a plain two-dot `git diff` read **201** where the truth was one
+test line; `--remerge-diff` is what makes payload hand-written into a **merge-conflict resolution**
+visible. Do **not** reach for `--no-merges --first-parent`: it looks equivalent and hides payload in
+BOTH of those shapes — **0** for a fix committed on a side branch and merged `--no-ff`, which is the
+shape agent worktrees produce. If the branch was rebased mid-round, re-anchor on the new sha.
 
 **Two consecutive rounds whose fixes changed zero payload lines ⇒ the ladder has left the PR.
 Stop.** File the remaining scaffolding findings as one follow-up task naming the file, closed when
 its PR merges or a named reader dismisses it in writing. A round that touches payload never trips
-this, however deep the ladder is.
+this, however deep.
 
 ⚠ **This does not retract the two rules above, and is not a cap in disguise.** #498's rounds were
 not wasted in the sense those rules deny — every one found something real. The waste is on a

--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read, Grep, Glob, Agent
 
 # /audit-pr — adversarial PR audit
 
-Every case history and number below is sourced in
+Every measurement below is dated and sourced in
 `~/.claude/skills/audit-pr/reference/round-ladder-evidence.md`.
 
 Target: `$ARGUMENTS`. Resolve it:
@@ -43,8 +43,8 @@ mutate code, leave your worktree untouched, and verify it clean at the end.
 
 ## After the fixes: RE-AUDIT THE DELTA (don't assume closure)
 
-**A fix round frequently introduces the next finding.** One `civitai-manager` feature took **five
-rounds**, each caused by the previous fix, and **none of them caught by the mechanical gate**.
+**A fix round frequently introduces the next finding** — one feature took **five rounds**, each
+caused by the previous fix, none caught by the mechanical gate.
 
 So once an audit's findings are fixed, dispatch a **delta re-audit** — diff the fix commits against
 the **previously-audited tip** (`git diff <audited-sha>..HEAD`), not the whole PR again. Especially
@@ -56,8 +56,8 @@ Ask the re-auditor to:
   strict, the new branch that's unreachable, the narrowed type check that now rejects a legitimate
   case);
 - **label every finding `behaviour` or `guard`, and separate shipped behaviour from scaffolding.**
-  Tests an earlier round of this same ladder wrote are in its diff *by construction*; report on them
-  only where the defect would let a real behaviour regression through;
+  Tests an earlier round wrote are in its diff *by construction*; report on them only where the
+  defect would let a real regression through;
 - treat "the author says it's fixed" as a claim to verify against the diff.
 
 **Carry the ledger in every round's summary**: `round N · payload lines changed THIS round: X (since
@@ -89,11 +89,10 @@ both. Keep going while rounds keep finding things — `claude/RULES.md` still sa
 several — and stop the moment one does not.
 
 **When a round's fix is mostly renumbering your own prose, fix the FORM, not the number.** Number
-the list and tell the reader to count it; a total maintained in parallel with the thing it counts
-will drift.
+the list and tell the reader to count it; a total kept in parallel with what it counts will drift.
 
 **Say the stop rule to the re-auditor explicitly** ("a clean round is the stop condition; do not
-invent findings to justify the round") — otherwise late rounds manufacture nits to look productive.
+invent findings to justify the round") — otherwise late rounds manufacture nits.
 
 🔴 **A FRAMED AUDIT VERIFIES THE FRAME. When a PR has already been audited, dispatch the next one
 BLIND** — give it the diff and the checklist, *not* your conclusions or the prior findings' answers.
@@ -101,13 +100,12 @@ Three successive framed audits **confirmed** a claim; one blind audit refuted it
 For a delta re-audit you must name the prior findings (that is the point), so keep the framing to
 *what was claimed fixed* — never *why it is correct*.
 
-### 🔴 ATTRIBUTION: a round that changes no PRODUCTION code is auditing the LADDER, not the PR
+### 🔴 ATTRIBUTION: a round that changes no PAYLOAD is auditing the LADDER, not the PR
 
 A fix round writes new guards and the next delta round diffs them, so **the ladder manufactures its
 own next round's findings** and the stop rule above, keyed to findings, can never fire. Measured on
-`civitai/cli` #498 (2026-08-26): **ten rounds, 5 h 32 m, 77% of the session's output tokens; rounds
-4–10 changed 1,051 lines of test code and ZERO lines of the thing the PR shipped.** No round was
-ever clean.
+`civitai/cli` #498: **ten rounds, 5 h 32 m, 77% of the session's output tokens; rounds 4–10 changed
+1,051 test lines and ZERO payload lines.** No round was ever clean.
 
 So gate on what each round CHANGES, not on what it finds. After a round's fixes land, count the
 payload lines **that round** changed:
@@ -118,9 +116,9 @@ git log --numstat --format= --no-merges --first-parent <the sha you audited THAT
 
 🔴 **The unit is THIS PR's PAYLOAD, never a file extension.** Payload = what the PR exists to ship;
 scaffolding = the tests, fixtures and notes a round wrote to guard it. For a code change the payload
-is source and a `.md` is not — but **for a docs or skill PR the payload IS the `.md`**, and 24 of
-devrc's last 40 merged PRs ship no source at all, so a rule keyed to file type reads every round of
-those as zero and stops a ladder that is working. Nor will a pathspec do it: `':!*test*'` swallows
+is source and a `.md` is not — but **for a docs or skill PR the payload IS the `.md`**, and on 2026-08-26 **25 of
+devrc's 40 most recently merged PRs shipped no source at all**, so a rule keyed to file type reads
+every round of those as zero and stops a ladder that is working. Nor will a pathspec do it: `':!*test*'` swallows
 `attestation/` and `latest/`, `':!*spec*'` swallows `inspector/`, and both keep `FooTest.java` and
 `*.cy.ts` (measured). A round's fix touches a handful of files — read the list and name each one
 payload or scaffolding. **Ambiguous is not zero**: the gate does not fire, and the ladder continues.
@@ -129,8 +127,10 @@ payload or scaffolding. **Ambiguous is not zero**: the gate does not fire, and t
 once an early round touched payload — on #498 that prints the same number for rounds 4 through 10
 and never fires. A plain two-dot `git diff` breaks the other way: after a `merge main` or a rebase
 it sweeps upstream lines in as payload, so a scaffolding-only round scores non-zero and the counter
-resets. Hence `--first-parent --no-merges` above; if the branch was rebased mid-round, re-anchor on
-the new sha rather than trusting the old one.
+resets. Hence `--first-parent --no-merges` above; if the branch was rebased mid-round, re-anchor on the
+new sha. **`--no-merges` has one cost**: payload hand-written into a merge *conflict resolution* is
+invisible to it (measured: 0 where the old form read 340), so if a round's fix landed that way,
+count that merge explicitly with `git show --numstat <merge>`.
 
 **Two consecutive rounds whose fixes changed zero payload lines ⇒ the ladder has left the PR.
 Stop.** File the remaining scaffolding findings as one follow-up task naming the file, closed when
@@ -156,10 +156,9 @@ RESETS the gate** (`claude/RULES.md`): re-run the FULL battery after every round
 
 ## Price a defect from the CONSUMING code, not the producing site
 
-**Verifying that a value is USED is not verifying what its ABSENCE costs.** Read the code that
-consumes it before repeating any consequence an audit asserts, especially a costed one (worked
-example in the reference file). Sanity-check the frequency side too — "routine" and "rare" are
-asserted far more often than measured.
+**Verifying that a value is USED is not verifying what its ABSENCE costs.** Read the consuming
+code before repeating any costed consequence an audit asserts. Sanity-check the frequency side too —
+"routine" and "rare" are asserted far more often than measured.
 
 **A finding about the PR *description* gets corrected PUBLICLY.** If the audit shows the PR body
 misstates what the change does, post a **PR comment** saying so rather than silently editing the
@@ -167,7 +166,7 @@ body — a reviewer may already have read (and believed) the wrong version.
 
 ## Output
 
-Findings grouped by severity (🔴 deploy-blocking / 🟡 should-fix / 🟢 nit), each with file:line, a
-`behaviour`/`guard` label, and a one-line "why it matters". Then the round ledger, then a clear
+Findings by severity (🔴 deploy-blocking / 🟡 should-fix / 🟢 nit), each with file:line, a
+`behaviour`/`guard` label and a one-line "why it matters". Then the round ledger, then a clear
 **verdict**: safe to merge / merge after fixing 🔴 / needs rework — advisory for the human, never
-the ladder's stop signal. No marketing language; flag uncertainty. Do not merge — report only.
+the ladder's stop signal. Flag uncertainty. Do not merge — report only.

--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -21,37 +21,36 @@ Dispatch a subagent (read-only — it must NOT modify files or merge) to audit t
 
 **Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, anything security/auth/path-gating. These hide deploy-blocking bugs (shutdown data-loss, trash-path overwrite, an unauthenticated arbitrary-path scan and a git `core.fsmonitor` RCE all surfaced this way). A branch with a **private Go module dep** may need `GOPRIVATE` — a sum-db `500` there is env, not a defect.
 
-**Brief the auditor on the environment, or it will report false findings.** A fresh worktree is not
-a working checkout, and an auditor hitting this cold reports it as a defect in the PR. Tell it,
-whichever apply: **submodules are unpopulated** in a new worktree (one made 4 test files "fail to
-collect" — pure environment); **monorepo `node_modules`** may need linking per package, not just at
-the root; **whether the base branch is already red** and *at which file*, so a baseline error is not
-blamed on the PR; and that **zsh does not word-split unquoted parameters**, so `eslint $FILES`
-checks **zero** files and prints a confident PASS. Have it mutate only in a `cp -a` copy and verify
-your worktree clean at the end.
+**Brief the auditor on the environment, or it will report false findings** — a fresh worktree is
+not a working checkout, and an auditor hitting this cold blames the PR. Whichever apply:
+**submodules are unpopulated** in a new worktree (one made 4 test files "fail to collect");
+**monorepo `node_modules`** may need linking per package, not just at the root; **whether the base
+branch is already red** and *at which file*; and that **zsh does not word-split unquoted
+parameters**, so `eslint $FILES` checks **zero** files and prints a confident PASS. Have it mutate
+only in a `cp -a` copy and leave your worktree clean.
 
 **Audit for:**
-1. **Risks** — what could break in production.
-2. **Regressions** — existing behaviour this silently alters or removes.
-3. **Assumptions** — unstated preconditions the code relies on that may not hold.
-4. **Gaps** — error handling, edge cases, tests, migrations, rollback.
+1. **Risks** — what breaks in production.
+2. **Regressions** — behaviour this silently alters or removes.
+3. **Assumptions** — unstated preconditions that may not hold.
+4. **Gaps** — error handling, edge cases, tests, migrations.
 5. **Bugs** — logic/correctness defects, with file:line.
-6. **Issues** — code quality, maintainability, conventions.
-7. **Behaviour changes** — observable changes in output/API/UX, intended or not. If the PR claims to revert prior behaviour, confirm it restores the pre-change state.
+6. **Issues** — quality, maintainability, conventions.
+7. **Behaviour changes** — observable changes in output/API/UX, intended or not. If the PR claims to revert behaviour, confirm it restores the pre-change state.
 8. **Leaks** — secrets, PII, resource/handle/memory, over-broad permissions.
-9. **Second-order consequences** — ripple effects on other services, callers, data, cost.
+9. **Second-order consequences** — ripple effects on services, callers, data, cost.
 
 ## After the fixes: RE-AUDIT THE DELTA (don't assume closure)
 
 **A fix round frequently introduces the next finding** — one feature took **five rounds**, each
-caused by the previous fix, none caught by the mechanical gate. So once the findings are fixed,
-dispatch a **delta re-audit** against the **previously-audited tip**, not the whole PR again.
+caused by the previous fix, none caught by the mechanical gate. Once they are fixed, dispatch a
+**delta re-audit** against the **previously-audited tip**, not the whole PR again.
 
 Ask the re-auditor to:
 - state **per prior finding**: actually fixed / partially / not / **made worse**;
-- hunt specifically for **regressions the fix round itself introduced** (the new guard that's too
-  strict, the new branch that's unreachable, the narrowed type check that now rejects a legitimate
-  case);
+- hunt for **regressions the fix round itself introduced** — the guard that's too strict, the branch
+  that's unreachable, the narrowed check that now rejects a legitimate case, **the rule reworded
+  wider on one axis and narrower on another**;
 - **label every finding `behaviour` or `guard`, and separate shipped behaviour from scaffolding.**
   Tests an earlier round wrote are in its diff *by construction*; report them only where the defect
   lets a real regression through;
@@ -59,7 +58,7 @@ Ask the re-auditor to:
 
 **Carry the ledger in every round's summary**: `round N · payload lines changed THIS round: X (since
 round 1: Y) · elapsed: Z`. X is what the gate below reads; without it the flattening shows only in
-hindsight — on #498 the session diagnosed its own plateau at round 9, six rounds late.
+hindsight — on #498 the plateau was diagnosed at round 9, six rounds late.
 
 ### 🔴 A clean round ENDS the ladder. Never run another round to confirm a clean round.
 
@@ -88,23 +87,22 @@ several — and stop the moment one does not.
 **When a round's fix is mostly renumbering your own prose, fix the FORM, not the number** — number
 the list and tell the reader to count it; a total kept beside what it counts drifts.
 
-**Say the stop rule to the re-auditor explicitly** ("a clean round is the stop condition; do not
-invent findings") — otherwise late rounds manufacture nits.
+**Say the stop rule to the re-auditor** ("a clean round is the stop condition; do not invent
+findings") — otherwise late rounds manufacture nits.
 
 🔴 **A FRAMED AUDIT VERIFIES THE FRAME. When a PR has already been audited, dispatch the next one
 BLIND** — the diff and the checklist, *not* your conclusions or the prior findings' answers. Three
-successive framed audits **confirmed** a claim; one blind audit refuted it in a pass. A delta
-re-audit must name the prior findings, so frame it as *what was claimed fixed* — never *why it is
-correct*.
+framed audits **confirmed** a claim; one blind audit refuted it in a pass. A delta re-audit must
+name the prior findings, so frame it as *what was claimed fixed* — never *why it is correct*.
 
 ### 🔴 ATTRIBUTION: a round that changes no PAYLOAD is auditing the LADDER, not the PR
 
 A fix round writes new guards and the next delta round diffs them, so **the ladder manufactures its
 own next round's findings** and the stop rule above, keyed to findings, cannot fire. Measured on
-`civitai/cli` #498: **ten rounds, 5 h 32 m, 77% of the session's output; rounds 4–10 changed 1,051
-test lines and ZERO payload lines.** No round was ever clean.
+`civitai/cli` #498: **ten rounds, 5 h 32 m, 77% of the session's output tokens; rounds 4–10 changed
+1,051 test lines and ZERO payload lines.** No round was clean.
 
-So gate on what each round CHANGES, not on what it finds. After a round's fixes land, count the
+So gate on what each round CHANGES, not what it finds. After a round's fixes land, count the
 payload lines **that round** changed:
 
 ```
@@ -122,24 +120,27 @@ payload or scaffolding. **Ambiguous is not zero**: the gate does not fire, and t
 
 🔴 **Per-round, and every commit the round actually made.** Anchored at round 1 the count stays
 non-zero forever once an early round touched payload — on #498 that prints the same number for
-rounds 4 through 10 and never fires. Every flag above earns its place, measured across four ladder
-shapes (table in the reference file): `--not <base>` excludes the bring-in a `merge main` drags
-along; `--remerge-diff` makes payload hand-written into a **merge-conflict resolution** visible. Do
+rounds 4 through 10 and never fires. Every flag earns its place, measured across four ladder shapes
+(table in the reference file): `--not <base>` excludes the bring-in a `merge main` drags along;
+`--remerge-diff` makes payload hand-written into a **merge-conflict resolution** visible. Do
 **not** reach for `--no-merges --first-parent`: it looks equivalent and reads **0** for a fix
 committed on a side branch and merged `--no-ff` — the shape agent worktrees produce.
 
 🔴 **`<base>` is the CURRENT tip you would merge into — `git fetch` it first.** A local
-`origin/main` is exactly as current as your last fetch, and a stale one re-reports upstream work as
-this round's payload: at the fork point the entire bring-in (201 where the truth was 1), one commit
-behind, its tail. Re-anchor on the new sha after a mid-round rebase. And **a failed command is not
-zero — require rc 0 AND silent stderr.** A missing ref or a git without `--remerge-diff` exits 128
-with empty output; an unwritable object store is worse, because `--remerge-diff` then under-counts,
-**exits 0 and prints a plausible number**, saying so only on stderr.
+`origin/main` is only as current as your last fetch, and a stale one re-reports upstream work as
+this round's payload: the whole bring-in from the fork point (201 where the truth was 1), its tail
+from one commit behind. Re-anchor on the new sha after a mid-round rebase. And **a zero you did not
+watch the command EARN is not a zero — require rc 0, silent stderr, and a non-empty range.** A
+missing ref or a git without `--remerge-diff` exits 128 with empty output; an unwritable object
+store is worse, because `--remerge-diff` then under-counts, **exits 0 and prints a plausible
+number**, saying so only on stderr; and a range whose commits are simply not in this checkout yet
+prints nothing, silently, with rc 0. Keep stderr on the terminal — folding it into the sum with
+`2>&1` makes the one loud failure invisible.
 
 **Two consecutive rounds whose fixes changed zero payload lines ⇒ the ladder has left the PR.
 Stop.** File the remaining scaffolding findings as one follow-up task naming the file, closed when
 its PR merges or a named reader dismisses it in writing. A round that touches payload never trips
-this, however deep.
+this.
 
 ⚠ **This does not retract the two rules above, and is not a cap in disguise.** #498's rounds were
 not wasted in the sense those rules deny — every one found something real. The waste is on a
@@ -149,19 +150,17 @@ measures the fixes; it never counts the rounds.
 ## Mutation testing: deletion-mutants are the EASY half
 
 When a PR claims a guard is "mutation-verified", check **what kind**. Deletion is the obvious
-mutant and the weakest: four variants that delete NOTHING — swapped operands, inverted branches, the
-guard commented out, a stale value re-bound — once passed a suite its author had just
-"mutation-verified" (all four in the reference file). The two rules that decide most cases: **when
-you can only assert on TEXT, pin the WHOLE normalised statement** — a partial regex is satisfied by
-inverted code, and `--` / `/* */` make "the token is present" and "the clause is live" different
-facts; and **a fixture of empty or default values collapses distinct implementations into identical
-output**, so give fixtures non-default sibling values. **A review fix RESETS the gate**
+mutant and the weakest: four variants that delete NOTHING once passed a suite its author had just
+"mutation-verified" (named in the reference file). The two rules that decide most cases: **when you
+can only assert on TEXT, pin the WHOLE normalised statement** — a partial regex is satisfied by
+inverted code, and a pin that stops mid-sentence leaves the tail free to argue the opposite; and
+**a fixture of empty or default values collapses distinct implementations into identical output**,
+so give fixtures non-default sibling values. **A review fix RESETS the gate**
 (`claude/RULES.md`): re-run the FULL battery after every round and reformat.
 
-**Price a defect from the CONSUMING code, not the producing site: verifying that a value is USED is
-not verifying what its ABSENCE costs.** Read the consuming code before repeating any costed
-consequence an audit asserts. Sanity-check frequency too — "routine" and "rare" are asserted far
-more often than they are measured.
+**Price a defect from the CONSUMING code: verifying that a value is USED is not verifying what its
+ABSENCE costs.** Read the consuming code before repeating any costed consequence an audit asserts,
+and sanity-check frequency — "routine" and "rare" are asserted far more often than measured.
 
 **A finding about the PR *description* gets corrected PUBLICLY.** If the audit shows the PR body
 misstates what the change does, post a **PR comment** saying so rather than silently editing the
@@ -170,6 +169,6 @@ body — a reviewer may already have read (and believed) the wrong version.
 ## Output
 
 Findings by severity (🔴 deploy-blocking / 🟡 should-fix / 🟢 nit), each with file:line, a
-`behaviour`/`guard` label and one line on why it matters. Then the round ledger, then a **verdict**:
-safe to merge / merge after fixing 🔴 / needs rework — advisory for the human, never the ladder's
-stop signal. Flag uncertainty. Do not merge — report only.
+`behaviour`/`guard` label and one line on why it matters. Then the ledger, then a **verdict**: safe
+to merge / merge after fixing 🔴 / needs rework — advisory for the human, never the ladder's stop
+signal. Flag uncertainty. Do not merge — report only.

--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -38,7 +38,7 @@ your worktree clean at the end.
 5. **Bugs** — logic/correctness defects, with file:line.
 6. **Issues** — code quality, maintainability, conventions.
 7. **Behaviour changes** — observable changes in output/API/UX, intended or not. If the PR claims to revert prior behaviour, confirm it restores the pre-change state.
-8. **Leaks** — secrets, PII, resource/handle/memory leaks, over-broad permissions.
+8. **Leaks** — secrets, PII, resource/handle/memory, over-broad permissions.
 9. **Second-order consequences** — ripple effects on other services, callers, data, cost.
 
 ## After the fixes: RE-AUDIT THE DELTA (don't assume closure)

--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -27,13 +27,13 @@ not a working checkout, and an auditor hitting this cold blames the PR. Whicheve
 **monorepo `node_modules`** may need linking per package, not just at the root; **whether the base
 branch is already red** and *at which file*; and that **zsh does not word-split unquoted
 parameters**, so `eslint $FILES` checks **zero** files and prints a confident PASS. Have it mutate
-only in a `cp -a` copy and leave your worktree clean.
+only in a `cp -a` copy, and verify your worktree clean yourself at the end.
 
 **Audit for:**
 1. **Risks** — what breaks in production.
 2. **Regressions** — behaviour this silently alters or removes.
 3. **Assumptions** — unstated preconditions that may not hold.
-4. **Gaps** — error handling, edge cases, tests, migrations.
+4. **Gaps** — error handling, edge cases, tests, migrations, rollback.
 5. **Bugs** — logic/correctness defects, with file:line.
 6. **Issues** — quality, maintainability, conventions.
 7. **Behaviour changes** — observable changes in output/API/UX, intended or not. If the PR claims to revert behaviour, confirm it restores the pre-change state.

--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -10,32 +10,32 @@ allowed-tools: Bash, Read, Grep, Glob, Agent
 Case histories and the measurements behind the ladder rules:
 `~/.claude/skills/audit-pr/reference/round-ladder-evidence.md`.
 
-Target: `$ARGUMENTS`. Resolve it:
+Target: `$ARGUMENTS`:
 - A number → that GitHub PR (`gh pr diff <n>`, `gh pr view <n>`).
 - `current` / empty → the current branch's diff vs its base/trunk.
-- Multiple numbers → audit each; if several, dispatch one subagent per PR **with `isolation: "worktree"`** so they don't collide.
+- Several numbers → audit each, one subagent per PR **with `isolation: "worktree"`** so they don't collide.
 
 ## What to do
 
 Dispatch a subagent (read-only — it must NOT modify files or merge) to audit the change against this checklist. Have it read the diff and the code it touches, not just the PR description.
 
-**Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, anything security/auth/path-gating. These reliably hide deploy-blocking bugs (shutdown data-loss, trash-path overwrite, an unauthenticated arbitrary-path scan and a git `core.fsmonitor` RCE all surfaced this way). A branch with a **private Go module dep** may need `GOPRIVATE` — a sum-db `500` there is env, not a defect.
+**Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, anything security/auth/path-gating. These hide deploy-blocking bugs (shutdown data-loss, trash-path overwrite, an unauthenticated arbitrary-path scan and a git `core.fsmonitor` RCE all surfaced this way). A branch with a **private Go module dep** may need `GOPRIVATE` — a sum-db `500` there is env, not a defect.
 
 **Brief the auditor on the environment, or it will report false findings.** A fresh worktree is not
 a working checkout, and an auditor hitting this cold reports it as a defect in the PR. Tell it,
-whichever apply: **git submodules are unpopulated** in a new worktree (one made 4 test files
-"fail to collect" — pure environment); **monorepo `node_modules`** may need linking per package, not
-just at the root; **whether the base branch is already red** on typecheck/lint/tests and *at which
-file*, so a baseline error is not attributed to the PR; and that **zsh does not word-split unquoted
-parameters**, so `eslint $FILES` silently checks **zero** files and prints a confident PASS. Also tell it to mutate code only in a `cp -a` copy, and
-to verify your worktree clean at the end.
+whichever apply: **submodules are unpopulated** in a new worktree (one made 4 test files "fail to
+collect" — pure environment); **monorepo `node_modules`** may need linking per package, not just at
+the root; **whether the base branch is already red** and *at which file*, so a baseline error is not
+blamed on the PR; and that **zsh does not word-split unquoted parameters**, so `eslint $FILES`
+checks **zero** files and prints a confident PASS. Have it mutate only in a `cp -a` copy and verify
+your worktree clean at the end.
 
 **Audit for:**
 1. **Risks** — what could break in production.
 2. **Regressions** — existing behaviour this silently alters or removes.
 3. **Assumptions** — unstated preconditions the code relies on that may not hold.
 4. **Gaps** — error handling, edge cases, tests, migrations, rollback.
-5. **Bugs** — concrete logic/correctness defects, with file:line.
+5. **Bugs** — logic/correctness defects, with file:line.
 6. **Issues** — code quality, maintainability, conventions.
 7. **Behaviour changes** — observable changes in output/API/UX, intended or not. If the PR claims to revert prior behaviour, confirm it restores the pre-change state.
 8. **Leaks** — secrets, PII, resource/handle/memory leaks, over-broad permissions.
@@ -45,8 +45,7 @@ to verify your worktree clean at the end.
 
 **A fix round frequently introduces the next finding** — one feature took **five rounds**, each
 caused by the previous fix, none caught by the mechanical gate. So once the findings are fixed,
-dispatch a **delta re-audit**: diff the fix commits against the **previously-audited tip**, not the
-whole PR again.
+dispatch a **delta re-audit** against the **previously-audited tip**, not the whole PR again.
 
 Ask the re-auditor to:
 - state **per prior finding**: actually fixed / partially / not / **made worse**;
@@ -54,8 +53,8 @@ Ask the re-auditor to:
   strict, the new branch that's unreachable, the narrowed type check that now rejects a legitimate
   case);
 - **label every finding `behaviour` or `guard`, and separate shipped behaviour from scaffolding.**
-  Tests an earlier round wrote are in its diff *by construction*; report on them only where the
-  defect lets a real regression through;
+  Tests an earlier round wrote are in its diff *by construction*; report them only where the defect
+  lets a real regression through;
 - treat "the author says it's fixed" as a claim to check against the diff.
 
 **Carry the ledger in every round's summary**: `round N · payload lines changed THIS round: X (since
@@ -87,7 +86,7 @@ both. Keep going while rounds keep finding things — `claude/RULES.md` still sa
 several — and stop the moment one does not.
 
 **When a round's fix is mostly renumbering your own prose, fix the FORM, not the number** — number
-the list and tell the reader to count it; a total kept in parallel with what it counts will drift.
+the list and tell the reader to count it; a total kept beside what it counts drifts.
 
 **Say the stop rule to the re-auditor explicitly** ("a clean round is the stop condition; do not
 invent findings") — otherwise late rounds manufacture nits.
@@ -102,8 +101,8 @@ correct*.
 
 A fix round writes new guards and the next delta round diffs them, so **the ladder manufactures its
 own next round's findings** and the stop rule above, keyed to findings, cannot fire. Measured on
-`civitai/cli` #498: **ten rounds, 5 h 32 m, 77% of the session's output tokens; rounds 4–10 changed
-1,051 test lines and ZERO payload lines.** No round was ever clean.
+`civitai/cli` #498: **ten rounds, 5 h 32 m, 77% of the session's output; rounds 4–10 changed 1,051
+test lines and ZERO payload lines.** No round was ever clean.
 
 So gate on what each round CHANGES, not on what it finds. After a round's fixes land, count the
 payload lines **that round** changed:
@@ -129,11 +128,13 @@ along; `--remerge-diff` makes payload hand-written into a **merge-conflict resol
 **not** reach for `--no-merges --first-parent`: it looks equivalent and reads **0** for a fix
 committed on a side branch and merged `--no-ff` — the shape agent worktrees produce.
 
-🔴 **`<base>` is the CURRENT tip you would merge into** (`origin/main`), never the fork point: one
-commit stale and the whole bring-in is re-reported as this round's payload (201 where the truth was
-1, measured). Re-anchor on the new sha after a mid-round rebase. And **a failed command is not
-zero** — a missing ref exits 128 with empty output, and `--remerge-diff` under-counts and still
-exits 0 when the object store is unwritable. Confirm it printed something before believing a zero.
+🔴 **`<base>` is the CURRENT tip you would merge into — `git fetch` it first.** A local
+`origin/main` is exactly as current as your last fetch, and a stale one re-reports upstream work as
+this round's payload: at the fork point the entire bring-in (201 where the truth was 1), one commit
+behind, its tail. Re-anchor on the new sha after a mid-round rebase. And **a failed command is not
+zero — require rc 0 AND silent stderr.** A missing ref or a git without `--remerge-diff` exits 128
+with empty output; an unwritable object store is worse, because `--remerge-diff` then under-counts,
+**exits 0 and prints a plausible number**, saying so only on stderr.
 
 **Two consecutive rounds whose fixes changed zero payload lines ⇒ the ladder has left the PR.
 Stop.** File the remaining scaffolding findings as one follow-up task naming the file, closed when
@@ -169,6 +170,6 @@ body — a reviewer may already have read (and believed) the wrong version.
 ## Output
 
 Findings by severity (🔴 deploy-blocking / 🟡 should-fix / 🟢 nit), each with file:line, a
-`behaviour`/`guard` label and a one-line "why it matters". Then the round ledger, then a clear
-**verdict**: safe to merge / merge after fixing 🔴 / needs rework — advisory for the human, never
-the ladder's stop signal. Flag uncertainty. Do not merge — report only.
+`behaviour`/`guard` label and one line on why it matters. Then the round ledger, then a **verdict**:
+safe to merge / merge after fixing 🔴 / needs rework — advisory for the human, never the ladder's
+stop signal. Flag uncertainty. Do not merge — report only.

--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -19,7 +19,7 @@ Target: `$ARGUMENTS`. Resolve it:
 
 Dispatch a subagent (read-only — it must NOT modify files or merge) to audit the change against this checklist. Have it read the diff and the code it touches, not just the PR description.
 
-**Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, anything security/auth/path-gating. These reliably hide deploy-blocking bugs (shutdown data-loss, trash-path overwrite, scanner scope-creep, an unauthenticated arbitrary-path scan and a git `core.fsmonitor` RCE all surfaced this way). If the branch has a **private Go module dep**, the auditor may need `GOPRIVATE` — a sum-db `500` there is env, not a code defect.
+**Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, anything security/auth/path-gating. These reliably hide deploy-blocking bugs (shutdown data-loss, trash-path overwrite, an unauthenticated arbitrary-path scan and a git `core.fsmonitor` RCE all surfaced this way). A branch with a **private Go module dep** may need `GOPRIVATE` — a sum-db `500` there is env, not a defect.
 
 **Brief the auditor on the environment, or it will report false findings.** A fresh worktree is not
 a working checkout, and an auditor hitting this cold reports it as a defect in the PR. Tell it,
@@ -31,22 +31,22 @@ parameters**, so `eslint $FILES` silently checks **zero** files and prints a con
 to verify your worktree clean at the end.
 
 **Audit for:**
-1. **Risks** — what could break in production from this change.
+1. **Risks** — what could break in production.
 2. **Regressions** — existing behaviour this silently alters or removes.
 3. **Assumptions** — unstated preconditions the code relies on that may not hold.
-4. **Gaps** — missing error handling, edge cases, tests, migrations, rollback.
+4. **Gaps** — error handling, edge cases, tests, migrations, rollback.
 5. **Bugs** — concrete logic/correctness defects, with file:line.
-6. **Issues** — code quality, maintainability, convention violations.
-7. **Behaviour changes** — observable changes in output/API/UX, intended or not. If the PR claims to revert prior behaviour, confirm it actually restores the pre-change state.
+6. **Issues** — code quality, maintainability, conventions.
+7. **Behaviour changes** — observable changes in output/API/UX, intended or not. If the PR claims to revert prior behaviour, confirm it restores the pre-change state.
 8. **Leaks** — secrets, PII, resource/handle/memory leaks, over-broad permissions.
-9. **Second-order consequences** — ripple effects on other services, callers, data, cost, load.
+9. **Second-order consequences** — ripple effects on other services, callers, data, cost.
 
 ## After the fixes: RE-AUDIT THE DELTA (don't assume closure)
 
 **A fix round frequently introduces the next finding** — one feature took **five rounds**, each
 caused by the previous fix, none caught by the mechanical gate. So once the findings are fixed,
 dispatch a **delta re-audit**: diff the fix commits against the **previously-audited tip**, not the
-whole PR again, especially when the fix touched the same code path.
+whole PR again.
 
 Ask the re-auditor to:
 - state **per prior finding**: actually fixed / partially / not / **made worse**;
@@ -70,12 +70,12 @@ not on the author saying it's done.
 
 🔴 **A "safe to merge" VERDICT is not the stop signal — the FINDINGS are.** #804's rounds **5, 6 and
 7 each returned "safe to merge" and each still reported real defects** that were then fixed — the
-last a latch that read as pinned and was vacuous in both directions (all three in the reference
-file). A ladder keyed to the verdict stops at round 5 and ships it.
+last a latch that read as pinned and was vacuous in both directions. A ladder keyed to the verdict
+stops at round 5 and ships it.
 
 ⚠ **#804 is NOT an example of a wasted round, and neither is any other PR cited here.** Every one of
-its eight rounds produced findings that needed fixing, round 8 included. This is a forward rule with
-a demonstrated near-miss — do not cite it as a fix for measured waste.
+its eight rounds produced findings that needed fixing. This is a forward rule with a demonstrated
+near-miss — do not cite it as a fix for measured waste.
 
 🔴 **This is NOT a round cap, and a cap was rejected.** The count is set by
 FINDINGS, never by a number, and #505 is why: its round 2 opens *"Round 1 fixed six findings and
@@ -90,7 +90,7 @@ several — and stop the moment one does not.
 the list and tell the reader to count it; a total kept in parallel with what it counts will drift.
 
 **Say the stop rule to the re-auditor explicitly** ("a clean round is the stop condition; do not
-invent findings to justify the round") — otherwise late rounds manufacture nits.
+invent findings") — otherwise late rounds manufacture nits.
 
 🔴 **A FRAMED AUDIT VERIFIES THE FRAME. When a PR has already been audited, dispatch the next one
 BLIND** — the diff and the checklist, *not* your conclusions or the prior findings' answers. Three
@@ -123,13 +123,17 @@ payload or scaffolding. **Ambiguous is not zero**: the gate does not fire, and t
 
 🔴 **Per-round, and every commit the round actually made.** Anchored at round 1 the count stays
 non-zero forever once an early round touched payload — on #498 that prints the same number for
-rounds 4 through 10 and never fires. Each part of the command above earns its place, measured across
-four ladder shapes (table in the reference file): `--not <base>` is what keeps a `merge main` from
-being counted as this round's work — a plain two-dot `git diff` read **201** where the truth was one
-test line; `--remerge-diff` is what makes payload hand-written into a **merge-conflict resolution**
-visible. Do **not** reach for `--no-merges --first-parent`: it looks equivalent and hides payload in
-BOTH of those shapes — **0** for a fix committed on a side branch and merged `--no-ff`, which is the
-shape agent worktrees produce. If the branch was rebased mid-round, re-anchor on the new sha.
+rounds 4 through 10 and never fires. Every flag above earns its place, measured across four ladder
+shapes (table in the reference file): `--not <base>` excludes the bring-in a `merge main` drags
+along; `--remerge-diff` makes payload hand-written into a **merge-conflict resolution** visible. Do
+**not** reach for `--no-merges --first-parent`: it looks equivalent and reads **0** for a fix
+committed on a side branch and merged `--no-ff` — the shape agent worktrees produce.
+
+🔴 **`<base>` is the CURRENT tip you would merge into** (`origin/main`), never the fork point: one
+commit stale and the whole bring-in is re-reported as this round's payload (201 where the truth was
+1, measured). Re-anchor on the new sha after a mid-round rebase. And **a failed command is not
+zero** — a missing ref exits 128 with empty output, and `--remerge-diff` under-counts and still
+exits 0 when the object store is unwritable. Confirm it printed something before believing a zero.
 
 **Two consecutive rounds whose fixes changed zero payload lines ⇒ the ladder has left the PR.
 Stop.** File the remaining scaffolding findings as one follow-up task naming the file, closed when
@@ -143,21 +147,20 @@ measures the fixes; it never counts the rounds.
 
 ## Mutation testing: deletion-mutants are the EASY half
 
-When a PR claims a guard is "mutation-verified", check **what kind**. Deleting the guard is the
-obvious mutant and the weakest: four variants that delete NOTHING — swapped operands, inverted
-branches, the guard commented out, a stale value re-bound — once passed a suite its author had just
-"mutation-verified". The two rules that decide most cases: **when you can only assert on TEXT, pin
-the WHOLE normalised statement** (a partial regex is satisfied by inverted code, and `--` / `/* */`
-make "the token is present" and "the clause is live" different facts — a cosmetic reformat then
-fails the test, which is the trade); and **a fixture of empty or default values collapses distinct
-implementations into identical output**, so give fixtures non-default sibling values. **A review fix
-RESETS the gate** (`claude/RULES.md`): re-run the FULL battery after every round and reformat.
+When a PR claims a guard is "mutation-verified", check **what kind**. Deletion is the obvious
+mutant and the weakest: four variants that delete NOTHING — swapped operands, inverted branches, the
+guard commented out, a stale value re-bound — once passed a suite its author had just
+"mutation-verified" (all four in the reference file). The two rules that decide most cases: **when
+you can only assert on TEXT, pin the WHOLE normalised statement** — a partial regex is satisfied by
+inverted code, and `--` / `/* */` make "the token is present" and "the clause is live" different
+facts; and **a fixture of empty or default values collapses distinct implementations into identical
+output**, so give fixtures non-default sibling values. **A review fix RESETS the gate**
+(`claude/RULES.md`): re-run the FULL battery after every round and reformat.
 
-## Price a defect from the CONSUMING code, not the producing site
-
-**Verifying that a value is USED is not verifying what its ABSENCE costs.** Read the consuming
-code before repeating any costed consequence an audit asserts. Sanity-check the frequency side too —
-"routine" and "rare" are asserted far more often than measured.
+**Price a defect from the CONSUMING code, not the producing site: verifying that a value is USED is
+not verifying what its ABSENCE costs.** Read the consuming code before repeating any costed
+consequence an audit asserts. Sanity-check frequency too — "routine" and "rare" are asserted far
+more often than they are measured.
 
 **A finding about the PR *description* gets corrected PUBLICLY.** If the audit shows the PR body
 misstates what the change does, post a **PR comment** saying so rather than silently editing the

--- a/claude/skills/audit-pr/reference/round-ladder-evidence.md
+++ b/claude/skills/audit-pr/reference/round-ladder-evidence.md
@@ -8,8 +8,8 @@ and nothing here decides whether one applies. Dated, because each is a measureme
 
 ## 2026-08-26 · `civitai/cli` #498 — ten rounds, and the axis the stop rule cannot see
 
-The measurement behind **ATTRIBUTION: a round that changes no PRODUCTION code is auditing the
-LADDER, not the PR**. Session `4719a2f0`, `feat/whoami-json-profile-fields`.
+The measurement behind **ATTRIBUTION: a round that changes no PAYLOAD is auditing the LADDER, not
+the PR**. Session `4719a2f0`, `feat/whoami-json-profile-fields`.
 
 | | |
 |---|---|
@@ -17,14 +17,14 @@ LADDER, not the PR**. Session `4719a2f0`, `feat/whoami-json-profile-fields`.
 | elapsed | 5 h 32 m |
 | share of session | 1,312 of 1,756 transcript rows (75%) |
 | main-thread output tokens | 321k of 419k (77%); 100M of 115M cache reads |
-| after the last production change | 171k output tokens, 4 h 10 m |
+| after the last source change | 171k output tokens, 4 h 10 m |
 | rounds that returned CLEAN | **zero** |
 
 Churn attribution, from the branch's own fix commits. **Method, because the classifier decides the
 answer**: `git show --numstat <sha>`, summing `additions + deletions`, each path classed by an
 explicit rule — TEST if a path component is `test(s)`/`spec(s)`/`e2e`/`testdata`/`__tests__`/
 `cypress` or the filename matches `*_test.*` / `*.{test,spec,cy}.*` / `*Test.*`; DOC if `*.md`/
-`*.txt`/`*.rst` or under `doc(s)/`; PRODUCTION otherwise.
+`*.txt`/`*.rst` or under `doc(s)/`; SOURCE otherwise.
 
 | rounds | test | doc | source |
 |---|---|---|---|
@@ -39,7 +39,7 @@ test lines) landed after the first snapshot and was never re-counted. **The less
 a number re-derived from a moving branch is a measurement with a timestamp, not a constant, and
 "which column does a `.md` belong in" is the same question the gate itself turns on.
 
-The last production change was round 3's `d2ec92d` — **18 lines of `internal/appapi/appblocks.go`**
+The last source change was round 3's `d2ec92d` — **18 lines of `internal/appapi/appblocks.go`**
 (a fifth render path, structurally unreachable from the golden table: a real find). Rounds 4–10 each
 found something real too; all of it concerned guards that an earlier round of the same ladder had
 written.
@@ -98,6 +98,22 @@ counts*.
 
 ---
 
+## 2026-08-26 · what a devrc PR actually ships — why the unit is PAYLOAD, not file type
+
+The measurement behind **"the unit is THIS PR's PAYLOAD, never a file extension"**. Same classifier
+as the table above, applied to each PR's file list from `gh pr view <n> --json files`:
+
+> Of the **40 most recently merged** `innovation-upstream/devrc` PRs, **25 shipped no SOURCE file at
+> all** — 17 of those were docs-only, the rest docs plus tests.
+
+So a gate keyed to "docs are not production" reads zero payload for every round of well over half
+this repo's PRs and stops a ladder that is working. 🔴 **The list moves as PRs merge** — this figure
+is dated for that reason, and an earlier version of it (`24`) was carried over from a subagent's
+report without being re-derived, which is the same mistake the churn table above records three
+times. Re-derive before quoting; the script is six lines of `gh` plus the classifier.
+
+---
+
 ## Mutation variants that delete NOTHING
 
 Behind **"deletion-mutants are the EASY half"**. Across one PR, four semantically broken variants
@@ -110,10 +126,10 @@ that delete nothing all passed a suite its author had just "mutation-verified":
   looking for it still matches;
 - **re-bind a stale value** — literally the original defect, reintroduced.
 
-**Enumerate mutants from the expression's semantic failure modes** — operand order, branch order,
-comment-out, wrong bind, off-by-one — not from "delete the thing I was already thinking about". The
-`{}` fixture that hid one of these made "bind just the patch" and "rebind the whole stale snapshot"
-byte-identical.
+What would have caught all four: enumerating mutants from the expression's own semantic failure
+modes — operand order, branch order, comment-out, wrong bind, off-by-one — rather than from "delete
+the thing I was already thinking about". The `{}` fixture that hid one of them made "bind just the
+patch" and "rebind the whole stale snapshot" byte-identical.
 
 ---
 

--- a/claude/skills/audit-pr/reference/round-ladder-evidence.md
+++ b/claude/skills/audit-pr/reference/round-ladder-evidence.md
@@ -167,6 +167,10 @@ that delete nothing all passed a suite its author had just "mutation-verified":
   looking for it still matches;
 - **re-bind a stale value** — literally the original defect, reintroduced.
 
+Why a text assertion needs the WHOLE statement: `--` and `/* */` make "the token is present" and
+"the clause is live" different facts, so a guard commented out still satisfies every regex looking
+for it.
+
 What would have caught all four: enumerating mutants from the expression's own semantic failure
 modes — operand order, branch order, comment-out, wrong bind, off-by-one — rather than from "delete
 the thing I was already thinking about". The `{}` fixture that hid one of them made "bind just the

--- a/claude/skills/audit-pr/reference/round-ladder-evidence.md
+++ b/claude/skills/audit-pr/reference/round-ladder-evidence.md
@@ -100,17 +100,50 @@ counts*.
 
 ## 2026-08-26 · what a devrc PR actually ships — why the unit is PAYLOAD, not file type
 
-The measurement behind **"the unit is THIS PR's PAYLOAD, never a file extension"**. Same classifier
-as the table above, applied to each PR's file list from `gh pr view <n> --json files`:
+The measurement behind **"the unit is THIS PR's PAYLOAD, never a file extension"**. Classifier as
+above, applied to each PR's file list from `gh pr view <n> --json files`:
 
-> Of the **40 most recently merged** `innovation-upstream/devrc` PRs, **25 shipped no SOURCE file at
-> all** — 17 of those were docs-only, the rest docs plus tests.
+| selection | no SOURCE at all | docs-only | tests-only | both |
+|---|---|---|---|---|
+| `gh pr list --state merged --limit 40` (sorts by CREATED) | 24 | 16 | 7 | 1 |
+| the 40 most recently MERGED (`--json mergedAt`, sorted) | 24 | 16 | 6 | 2 |
 
-So a gate keyed to "docs are not production" reads zero payload for every round of well over half
-this repo's PRs and stops a ladder that is working. 🔴 **The list moves as PRs merge** — this figure
-is dated for that reason, and an earlier version of it (`24`) was carried over from a subagent's
-report without being re-derived, which is the same mistake the churn table above records three
-times. Re-derive before quoting; the script is six lines of `gh` plus the classifier.
+🔴 **This is a moving window, and it moved while this PR was open**: the same two commands read
+**25** two hours earlier, because PRs merged in between — including this one's siblings. That is why
+the skill body carries the qualitative claim (*most of this repo's merged PRs ship no source file at
+all*) and the number lives here with its date, its selection command and its classifier. An earlier
+version of the body pinned `24` taken from a subagent's report without re-derivation; the next
+pinned `25` measured correctly but decaying by the hour. **A number that changes with the clock does
+not belong in a rule** — only in a dated measurement beside it.
+
+Either selection supports the point: **well over half** of what this repo merges ships no source
+file, so a gate keyed to "docs are not production" reads zero payload for every round of those PRs
+and stops a ladder that is working.
+
+---
+
+## 2026-08-26 · which range form counts a ROUND's payload — measured across four shapes
+
+The measurement behind the gate's command. Each shape is a throwaway repo (git 2.55.0); the numbers
+are `additions + deletions` summed over the numstat output.
+
+| shape | truth | `git diff A..HEAD` | `--no-merges --first-parent` | `--remerge-diff … --not <base>` |
+|---|---|---|---|---|
+| A. clean `merge main` brings 200 upstream lines; the round's own fix is 1 test line | 0 payload | **201** | 1 | 1 |
+| B. payload hand-written into a merge-CONFLICT resolution | >0 | 30 | **1** | 37 |
+| C. the round's fix is 50 payload lines on a side branch, merged `--no-ff` | ~50 | 51 | **0** | 51 |
+| D. control: 12 payload lines, linear, no merges | 13 | 13 | 13 | 13 |
+
+Bold is wrong. Three lessons, and every one of them was shipped as a rule before it was measured:
+
+- **A** is why the range needs `--not <base>` — a two-dot diff attributes the whole upstream
+  bring-in to this round, the gate never fires, and the ladder runs forever.
+- **B and C** are why `--no-merges --first-parent` is NOT the fix, though it looks like one and
+  shipped as one for a round: it reads **0** for a fix committed on a side branch and merged
+  `--no-ff` — the shape agent worktrees produce — so the gate fires and stops a ladder whose payload
+  is still moving. `git show --numstat <merge>` is not the remedy either: it prints the first-parent
+  diff, so on shape A it reports every upstream line as this round's work.
+- **D** is the positive control. A form that gets D wrong is not measuring churn at all.
 
 ---
 

--- a/claude/skills/audit-pr/reference/round-ladder-evidence.md
+++ b/claude/skills/audit-pr/reference/round-ladder-evidence.md
@@ -163,13 +163,9 @@ that delete nothing all passed a suite its author had just "mutation-verified":
 - **swap the operands** of a merge/concat — inverts which side wins;
 - **invert the branches** of a CASE/ternary — here it turned a merge into an unconditional WIPE,
   strictly worse than the bug being fixed;
-- **comment the guard out** — the clause is dead but the TEXT is still present, so every regex
-  looking for it still matches;
+- **comment the guard out** — the clause is dead but the TEXT is still present (`--`, `/* */`), so
+  every regex looking for it still matches;
 - **re-bind a stale value** — literally the original defect, reintroduced.
-
-Why a text assertion needs the WHOLE statement: `--` and `/* */` make "the token is present" and
-"the clause is live" different facts, so a guard commented out still satisfies every regex looking
-for it.
 
 What would have caught all four: enumerating mutants from the expression's own semantic failure
 modes — operand order, branch order, comment-out, wrong bind, off-by-one — rather than from "delete

--- a/claude/skills/audit-pr/reference/round-ladder-evidence.md
+++ b/claude/skills/audit-pr/reference/round-ladder-evidence.md
@@ -118,7 +118,8 @@ not belong in a rule** — only in a dated measurement beside it.
 
 Either selection supports the point: **well over half** of what this repo merges ships no source
 file, so a gate keyed to "docs are not production" reads zero payload for every round of those PRs
-and stops a ladder that is working.
+and stops a ladder that is working. **Re-derive before quoting** — the selection is one `gh pr list`
+plus the classifier above, and the answer changes with the window.
 
 ---
 
@@ -127,12 +128,19 @@ and stops a ladder that is working.
 The measurement behind the gate's command. Each shape is a throwaway repo (git 2.55.0); the numbers
 are `additions + deletions` summed over the numstat output.
 
-| shape | truth | `git diff A..HEAD` | `--no-merges --first-parent` | `--remerge-diff … --not <base>` |
+| shape | what the round actually wrote | `git diff A..HEAD` | `--no-merges --first-parent` | `--remerge-diff … --not <base>` |
 |---|---|---|---|---|
-| A. clean `merge main` brings 200 upstream lines; the round's own fix is 1 test line | 0 payload | **201** | 1 | 1 |
-| B. payload hand-written into a merge-CONFLICT resolution | >0 | 30 | **1** | 37 |
+| A. clean `merge main` brings 200 upstream lines; the round's own fix is 1 test line | 1 line, and it is a TEST ⇒ 0 payload | **201** | 1 | 1 |
+| B. one branch-side commit (1 line), then 30 payload lines hand-written into the merge-CONFLICT resolution | 31 | 30 | **1** ⇐ the branch commit only; the resolution is invisible | 37 |
 | C. the round's fix is 50 payload lines on a side branch, merged `--no-ff` | ~50 | 51 | **0** | 51 |
 | D. control: 12 payload lines, linear, no merges | 13 | 13 | 13 | 13 |
+
+Fixtures: four throwaway repos, each `main` + a `feat` branch off one base commit, built by
+`scratchpad/ranges.sh` in the authoring session — A merges 200 upstream lines into a branch whose
+only commit edits `app_test.go`; B makes both sides edit `app.go` and hand-writes 30 lines while
+resolving; C commits the fix on a `side` branch and merges `--no-ff`; D commits 12 lines directly.
+Re-derive rather than quote: the numbers are small enough to rebuild in a minute, and B's `1` is
+only legible next to what the branch-side commit contributed.
 
 Bold is wrong. Three lessons, and every one of them was shipped as a rule before it was measured:
 

--- a/claude/skills/audit-pr/reference/round-ladder-evidence.md
+++ b/claude/skills/audit-pr/reference/round-ladder-evidence.md
@@ -1,0 +1,94 @@
+# Round-ladder evidence
+
+Case histories behind the ladder rules in `../SKILL.md`. Facts only — the RULES live in the skill
+body, and nothing here decides whether one applies. Dated because each is a measurement, not a
+principle.
+
+---
+
+## 2026-08-26 · `civitai/cli` #498 — ten rounds, and the axis the stop rule cannot see
+
+The measurement behind **ATTRIBUTION: a round that changes no PRODUCTION code is auditing the
+LADDER, not the PR**. Session `4719a2f0`, `feat/whoami-json-profile-fields`.
+
+| | |
+|---|---|
+| rounds | 10 (first audit 17:50 → round 10 dispatched 23:22) |
+| elapsed | 5 h 32 m |
+| share of session | 1,312 of 1,756 transcript rows (75%) |
+| main-thread output tokens | 321k of 419k (77%); 100M of 115M cache reads |
+| after the last production change | 171k output tokens, 4 h 10 m |
+| rounds that returned CLEAN | **zero** |
+
+Churn attribution, from the branch's own fix commits (`git show --numstat`, test files vs the rest):
+
+| rounds | test/guard lines | production lines |
+|---|---|---|
+| feature + rounds 1–3 | 1,061 | 332 |
+| **rounds 4–10** | **1,002** | **0** |
+
+The last production change was round 3's `d2ec92d` (32 lines — a fifth render path that was
+structurally unreachable from the golden table, a real find). Rounds 4–10 each found something real
+too; all of it concerned guards that an earlier round of the same ladder had written.
+
+Two things this case establishes, and one it does not:
+
+- **The ladder manufactures its own audit surface.** A delta round diffs `<audited-sha>..HEAD` and
+  each fix round added ~130 lines of new guard code, so there is always new un-audited material.
+  A stop condition keyed to *findings* therefore has no exit in the guard-hardening regime.
+- **The session already knew.** At round 9 it wrote: *"the shipped behaviour has been stable,
+  gate-green and live-verified since round 2. Rounds 3–10 have all been about the guards, not the
+  feature… the returns are now in test quality, not in what ships"* — and asked the operator whether
+  to stop. The judgement was available five hours before it was acted on; what was missing was a
+  measurement that surfaces it at round 4.
+- **It does NOT contradict the "not a wasted round" retraction.** No #498 round ran and found
+  nothing, so it is not an instance of the waste that retraction denies. Different axis.
+
+Ladder depth across all sessions, measured the same day over `~/.claude/projects/**/*.jsonl`
+(numbered delta re-audit dispatches, `subagents/` excluded): **110 sessions, 440 rounds, 84 of those
+sessions in the preceding 14 days**; mean deepest round 4.0; 34% ran ≥5 rounds; distribution
+3→38, 4→22, 5→21, 6→9, 7→4, 8→2, 10→1. The ladder is a dominant workflow, not an occasional one —
+which is what makes a per-round gate worth its bytes.
+
+---
+
+## `civitai-manager` — the five-round chain, each round caused by the last
+
+Behind **"a fix round frequently introduces the next finding"**. A dead button → fixing it exposed a
+silent wrong-file install → fixing *that* introduced a type-check regression that refused legitimate
+LoCon installs. Five rounds, every one caught pre-merge, and **none of them by the mechanical
+gate** — which is the whole argument for re-auditing the delta rather than trusting a green suite.
+
+---
+
+## devrc #804 — the verdict is not the stop signal
+
+Behind **"a 'safe to merge' VERDICT is not the stop signal"**. Rounds 5, 6 and 7 each returned "safe
+to merge" and each still reported a real defect that was then fixed:
+
+1. a module-scope `installAutoStart` whose deletion left the entire lightbox inert in Brave, with
+   the suite 99/99 green;
+2. four checked-in numbers that disagreed with each other about one measurement;
+3. a `didDrag` latch pinned on its SET but not its RELEASE — deleting the reset, deleting the clear,
+   and deleting **both** were all green.
+
+A ladder keyed to the verdict stops at round 5 and ships (3).
+
+**#804 is not an example of a wasted round.** All eight rounds produced findings that needed fixing,
+round 8 included (three 🟢, two of them shipped features that could be unwired with the suite
+green). The stop rule was never exercised on it.
+
+It is also where **"fix the FORM, not the number"** comes from: round 5 found that "four
+`.toLowerCase()` guards" was seven, round 6 found four checked-in numbers for one measurement, and
+round 8's own commit message records the count regrowing wrong twice *in the paragraph about
+counts*.
+
+---
+
+## Where the rest lives
+
+- The **rejected numeric cap** and devrc #505's ReDoS-introduced-by-the-fix evidence: stated inline
+  in `../SKILL.md` (it is load-bearing there) and in `claude/RULES-ARCHIVE.md` →
+  `audit-fix-resets-gate`.
+- The retraction of the original "measured waste" justification: `claude/RULES-ARCHIVE.md` →
+  `audit-fix-resets-gate`, and pinned by `scripts/tests/test_audit_ladder_stop_rule.py`.

--- a/claude/skills/audit-pr/reference/round-ladder-evidence.md
+++ b/claude/skills/audit-pr/reference/round-ladder-evidence.md
@@ -20,16 +20,27 @@ LADDER, not the PR**. Session `4719a2f0`, `feat/whoami-json-profile-fields`.
 | after the last production change | 171k output tokens, 4 h 10 m |
 | rounds that returned CLEAN | **zero** |
 
-Churn attribution, from the branch's own fix commits (`git show --numstat`, test files vs the rest):
+Churn attribution, from the branch's own fix commits. **Method, because the classifier decides the
+answer**: `git show --numstat <sha>`, summing `additions + deletions`, each path classed by an
+explicit rule — TEST if a path component is `test(s)`/`spec(s)`/`e2e`/`testdata`/`__tests__`/
+`cypress` or the filename matches `*_test.*` / `*.{test,spec,cy}.*` / `*Test.*`; DOC if `*.md`/
+`*.txt`/`*.rst` or under `doc(s)/`; PRODUCTION otherwise.
 
-| rounds | test/guard lines | production lines |
-|---|---|---|
-| feature + rounds 1–3 | 1,061 | 332 |
-| **rounds 4–10** | **1,002** | **0** |
+| rounds | test | doc | production |
+|---|---|---|---|
+| feature + rounds 1–3 | 961 | 110 | 222 |
+| **rounds 4–10** | **1,002** | **0** | **0** |
 
-The last production change was round 3's `d2ec92d` (32 lines — a fifth render path that was
-structurally unreachable from the golden table, a real find). Rounds 4–10 each found something real
-too; all of it concerned guards that an earlier round of the same ladder had written.
+🔴 An earlier version of this table read `1,061 / 332` and was wrong twice, both times in the
+direction that flatters the argument: the test column was mis-added, and the production column
+folded 110 lines of release-notes markdown into "production". Docs are not production — that is the
+same classifier question the gate itself turns on, which is why the rule in the body says to read
+the file list rather than trust a pathspec.
+
+The last production change was round 3's `d2ec92d` — **18 lines of `internal/appapi/appblocks.go`**
+(a fifth render path, structurally unreachable from the golden table: a real find). Rounds 4–10 each
+found something real too; all of it concerned guards that an earlier round of the same ladder had
+written.
 
 Two things this case establishes, and one it does not:
 
@@ -85,10 +96,31 @@ counts*.
 
 ---
 
+---
+
+## Mutation variants that delete NOTHING
+
+Behind **"deletion-mutants are the EASY half"**. Across one PR, four semantically broken variants
+that delete nothing all passed a suite its author had just "mutation-verified":
+
+- **swap the operands** of a merge/concat — inverts which side wins;
+- **invert the branches** of a CASE/ternary — here it turned a merge into an unconditional WIPE,
+  strictly worse than the bug being fixed;
+- **comment the guard out** — the clause is dead but the TEXT is still present, so every regex
+  looking for it still matches;
+- **re-bind a stale value** — literally the original defect, reintroduced.
+
+**Enumerate mutants from the expression's semantic failure modes** — operand order, branch order,
+comment-out, wrong bind, off-by-one — not from "delete the thing I was already thinking about". The
+`{}` fixture that hid one of these made "bind just the patch" and "rebind the whole stale snapshot"
+byte-identical.
+
+---
+
 ## Where the rest lives
 
 - The **rejected numeric cap** and devrc #505's ReDoS-introduced-by-the-fix evidence: stated inline
-  in `../SKILL.md` (it is load-bearing there) and in `claude/RULES-ARCHIVE.md` →
+  in the skill body (it is load-bearing there) and in `~/.claude/RULES-ARCHIVE.md` →
   `audit-fix-resets-gate`.
-- The retraction of the original "measured waste" justification: `claude/RULES-ARCHIVE.md` →
-  `audit-fix-resets-gate`, and pinned by `scripts/tests/test_audit_ladder_stop_rule.py`.
+- The retraction of the original "measured waste" justification: `~/.claude/RULES-ARCHIVE.md` →
+  `audit-fix-resets-gate`, and pinned by `devrc/scripts/tests/test_audit_ladder_stop_rule.py`.

--- a/claude/skills/audit-pr/reference/round-ladder-evidence.md
+++ b/claude/skills/audit-pr/reference/round-ladder-evidence.md
@@ -1,8 +1,8 @@
 # Round-ladder evidence
 
-Case histories behind the ladder rules in `../SKILL.md`. Facts only — the RULES live in the skill
-body, and nothing here decides whether one applies. Dated because each is a measurement, not a
-principle.
+Case histories behind the ladder rules in `~/.claude/skills/audit-pr/SKILL.md` (source:
+`devrc/claude/skills/audit-pr/`). Evidence and worked examples — the RULES live in the skill body,
+and nothing here decides whether one applies. Dated, because each is a measurement, not a principle.
 
 ---
 
@@ -26,16 +26,18 @@ explicit rule — TEST if a path component is `test(s)`/`spec(s)`/`e2e`/`testdat
 `cypress` or the filename matches `*_test.*` / `*.{test,spec,cy}.*` / `*Test.*`; DOC if `*.md`/
 `*.txt`/`*.rst` or under `doc(s)/`; PRODUCTION otherwise.
 
-| rounds | test | doc | production |
+| rounds | test | doc | source |
 |---|---|---|---|
-| feature + rounds 1–3 | 961 | 110 | 222 |
-| **rounds 4–10** | **1,002** | **0** | **0** |
+| feature + rounds 1–3 (`bce0c0c`…`d2ec92d`) | 961 | 110 | 222 |
+| **rounds 4–10** (`a82718b`…`7541bc1`) | **1,051** | **0** | **0** |
 
-🔴 An earlier version of this table read `1,061 / 332` and was wrong twice, both times in the
-direction that flatters the argument: the test column was mis-added, and the production column
-folded 110 lines of release-notes markdown into "production". Docs are not production — that is the
-same classifier question the gate itself turns on, which is why the rule in the body says to read
-the file list rather than trust a pathspec.
+🔴 This table has been wrong **three times**, each time in the direction that flatters the argument,
+which is why it now carries its shas and its classifier. `1,061 / 332`: the test column was
+mis-added, and the source column folded 110 lines of markdown (68 of a release-notes draft, 42 of
+`README.md`) into "production". Then `1,002`: that is rounds 4–**9**; round 10's fix `7541bc1` (49
+test lines) landed after the first snapshot and was never re-counted. **The lesson is the rule** —
+a number re-derived from a moving branch is a measurement with a timestamp, not a constant, and
+"which column does a `.md` belong in" is the same question the gate itself turns on.
 
 The last production change was round 3's `d2ec92d` — **18 lines of `internal/appapi/appblocks.go`**
 (a fifth render path, structurally unreachable from the golden table: a real find). Rounds 4–10 each
@@ -96,8 +98,6 @@ counts*.
 
 ---
 
----
-
 ## Mutation variants that delete NOTHING
 
 Behind **"deletion-mutants are the EASY half"**. Across one PR, four semantically broken variants
@@ -114,6 +114,18 @@ that delete nothing all passed a suite its author had just "mutation-verified":
 comment-out, wrong bind, off-by-one — not from "delete the thing I was already thinking about". The
 `{}` fixture that hid one of these made "bind just the patch" and "rebind the whole stale snapshot"
 byte-identical.
+
+---
+
+## Pricing a defect from the CONSUMING code — the worked example
+
+Behind **"verifying that a value is USED is not verifying what its ABSENCE costs"**. An audit
+correctly established that a watermark was written, that losing it reset the watermark, and that a
+query read it — then priced the loss as "re-judges the whole backlog at LLM cost". The same `WHERE`
+clause carried an independent `NOT EXISTS` dedupe that excluded every already-processed row
+regardless of the watermark, so the true cost was a wider index scan and **zero** LLM calls. The
+wrong figure reached a PR body, a public comment and two code notes before anyone read the full
+clause.
 
 ---
 

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -56,7 +56,10 @@ re-audit dispatches, `subagents/` excluded): **110 sessions, 440 rounds, 84 of
 them in the preceding 14 days**; mean deepest round 4.0; 34% ran >= 5 rounds.
 
 So the gate is: two consecutive rounds whose FIXES changed zero production lines
-=> the ladder has left the PR, stop. It is not a cap (it counts production lines,
+=> the ladder has left the PR, stop. **Per-round, never cumulative** -- a range
+anchored at round 1 is non-zero forever once any early round touched production,
+and the first version of this rule shipped exactly that, which on #498 prints
+the same number for rounds 4-10 and never fires. It is not a cap (it counts production lines,
 never rounds; a round that touches production code never trips it however deep
 the ladder is) and it does not retract the retraction below -- #498 contains no
 round that ran and found nothing, which is the waste that retraction denies.
@@ -115,7 +118,14 @@ rule rather than reformatting a paragraph.
    ladder that stopped. The behavioural claim needs transcript measurement over
    future ladders -- re-run the sweep in the docstring above -- and is NOT made
    here.
-6. **The THRESHOLD is pinned, not justified.** "Two consecutive rounds" comes
+6. **The CLASSIFIER is a human judgement, deliberately.** The rule tells the
+   reader to read the `--numstat` file list rather than run a pathspec, because
+   a pathspec is wrong in both directions on ordinary names (`':!*test*'`
+   excludes `pkg/attestation/`, `api/latest/`, `internal/inspector/`; misses
+   `FooTest.java`, `login.cy.ts` -- measured). Nothing here can check that a
+   given round's lines were classified correctly; the pins only ensure the
+   instruction still says to judge rather than to pattern-match.
+7. **The THRESHOLD is pinned, not justified.** "Two consecutive rounds" comes
    from one measured ladder (#498, n=1), where the plateau began at round 4 and
    ran to 10. One round is knowingly too tight: a round may legitimately fix only
    a guard. Whether two is right is a judgement, and this module cannot tell a
@@ -126,8 +136,16 @@ WATCHED TO FAIL -- the matrix, so this module is not taken on trust
 -------------------------------------------------------------------
 Red at `origin/main` (the three guarded documents restored via `git show
 origin/main:<path>` into a scratch tree, this module copied in unchanged):
-**4 failed, 1 passed** -- every stop-rule assertion red, the invariant guard
-green, as its label above predicts. Green at HEAD: **5 passed**.
+every stop-rule assertion red, the invariant guard green, as its label above
+predicts.
+
+🔴 The counts originally recorded here -- "4 failed, 1 passed" red and "5 passed"
+green -- were WRONG when written: the module shipped in that same commit with
+**6** tests, so no run of it can produce a 5-test total. Re-measured 2026-08-26
+at `6509702b`: **6 passed**. Corrected rather than left, because this file's own
+thesis is that a total maintained in parallel with the thing it counts drifts --
+and an unverified self-reported matrix inside the module that pins other
+people's claims is the worst place for it to happen.
 
 Mutation controls, each run on a copy of the HEAD tree, under
 `PYTHONDONTWRITEBYTECODE=1` with the pytest cache disabled. The unmutated copy
@@ -157,31 +175,43 @@ every whole-string pin stays GREEN and only
 what proves that assertion executes and is not a second spelling of the string
 pin it sits beside.
 
-THE ATTRIBUTION-GATE PINS -- their own matrix (2026-08-26, 3 tests added)
-------------------------------------------------------------------------
+THE ATTRIBUTION-GATE PINS -- their own matrix (2026-08-26, 5 tests added, 6 -> 11)
+---------------------------------------------------------------------------------
 Same method: each run on its OWN scratch tree built from HEAD, never the
 worktree, under `PYTHONDONTWRITEBYTECODE=1` with the pytest cache disabled, and
-every mutant script asserts its target string is present before editing (so a
-missed mutant fails loudly instead of scoring SURVIVED). Script preserved at
-`scratchpad/controls.sh` in the authoring session; it is 6 `cp`s and a `pytest`.
+every mutant asserts its target string is present before editing (so a missed
+mutant fails loudly instead of scoring SURVIVED).
 
-  POS  unmutated copy .......................... 9 passed  <- harness control
+  POS  unmutated copy ......................... 11 passed  <- harness control
   BASE origin/main's SKILL.md, reference file
-       absent (i.e. pre-change) ................ 3 failed, 6 passed
-                                                 -- exactly the three new tests
-                                                 red, all six pre-existing ones
-                                                 green: regression coverage, not
-                                                 an invariant guard
-  M7   attribution heading deleted .............. 2 failed -- heading pin, plus
-                                                 the order test's both-present
-                                                 precondition
-  M8   gate threshold reworded TWO -> THREE ..... 1 failed -- the gate pin ONLY,
-                                                 which is what separates a
-                                                 whole-string pin from a keyword
-                                                 guard
-  M9   evidence file deleted .................... 1 failed -- evidence pin
-  M11  different-axis paragraph dropped from
-       the evidence file ....................... 1 failed -- evidence pin
+       absent (i.e. pre-change) ............... 6 failed, 5 passed  -- exactly
+                                                the five new tests plus the
+                                                widened floor guard: regression
+                                                coverage, not invariant guards
+  M7   attribution heading deleted ............. 2 failed -- heading pin, plus
+                                                the order test's both-present
+                                                precondition
+  M8   decision reworded TWO -> THREE .......... 1 failed -- the decision pin
+                                                ONLY, which separates a
+                                                whole-string pin from a keyword
+                                                guard
+  M9   evidence file deleted ................... 2 failed
+  M11  different-axis paragraph dropped ........ 1 failed
+  X3   gate COMMAND replaced with `echo 0` ..... 1 failed
+  X4   ledger instruction deleted .............. 1 failed
+  X5   behaviour/guard labelling bullet
+       deleted ................................ 1 failed
+  X6   evidence file truncated to 0 B .......... 2 failed -- the floor guard
+                                                fires with its own message
+  X7   no-pathspec rule deleted ................ 1 failed
+  X8   range reverted to CUMULATIVE ............ 1 failed
+
+🔴 X3, X4 and X5 all SURVIVED a fully green 9-test run in review -- the gate's
+decision was pinned while the command producing its input, the ledger and the
+finding labels were not. X8 is the defect that shipped in the first version of
+this rule and was caught by review, not by this module: `<first-audited-sha>..`
+is cumulative, so it prints the same non-zero number for #498's rounds 4-10 and
+the gate never fires. Both are why the pins now cover the MECHANISM.
 
 🔴 M10 is this half's reachability control, and the analogue of M4. The
 attribution section is MOVED above the stop rule with its text byte-identical:
@@ -315,10 +345,51 @@ SKILL_ATTRIBUTION_NOT_A_CAP = (
     "measures the fixes; it never counts the rounds."
 )
 
+# 🔴 THE MECHANISM, not just the decision. Pinning only the gate sentence leaves
+# the command that produces its input free to be replaced with one that computes
+# a different quantity -- which is not hypothetical: the first version of this
+# gate shipped a CUMULATIVE range (`<first-audited-sha>..HEAD`) that a per-round
+# condition cannot consume, and on the very ladder that motivated the rule it
+# printed the same non-zero number for rounds 4 through 10 and never fired.
+# Caught in review; these three pins are what stop it coming back.
+SKILL_GATE_COMMAND = (
+    "After a round's fixes land, count the production lines **that round** "
+    "changed: `git diff --numstat <the sha you audited THAT round>..HEAD`."
+)
+SKILL_GATE_PER_ROUND = (
+    "🔴 **Per-round, never cumulative.** A range anchored at round 1 stays "
+    "non-zero forever once any early round touched production"
+)
+# The classifier decides the gate's answer, so it is part of the mechanism. A
+# pathspec looks precise and is wrong in BOTH directions on ordinary names --
+# measured: `':!*test*'` excludes `pkg/attestation/`, `api/latest/` and
+# `internal/inspector/` while `FooTest.java` and `login.cy.ts` survive it.
+SKILL_GATE_NO_PATHSPEC = (
+    "🔴 **Do not classify with a pathspec.** `':!*test*'` swallows "
+    "`attestation/`, `latest/` and `inspector/` as \"tests\" while missing "
+    "`FooTest.java` and `*.cy.ts`"
+)
+
+# The other two operator instructions this rule ships. Both survived a mutant
+# that deleted them outright before these pins existed.
+SKILL_LEDGER = (
+    "**Carry the ledger in every round's summary**: `round N · production lines "
+    "changed since round 1: X · elapsed: Y`."
+)
+SKILL_FINDING_LABELS = (
+    "**label every finding `behaviour` or `guard`, and separate shipped "
+    "behaviour from scaffolding.**"
+)
+
 # The deployed path, not a repo-relative one: a devrc skill is READ from
 # ~/.claude/skills/<name>/ by an agent whose cwd is some unrelated project, so a
 # bare `reference/x.md` resolves against that cwd. Same rule as
 # scripts/tests/test_doc_path_rot.py (1c).
+#
+# 🔴 Asserted PRESENT, not present-exactly-once. Every other pin here is a
+# once-pin because a duplicated RULE is a rule that can drift; a duplicated
+# POINTER is just a second door to the same file, and once-pinning it would turn
+# "route to the evidence from the section that needs it" into a test failure.
 SKILL_ROUTES_TO_EVIDENCE = (
     "`~/.claude/skills/audit-pr/reference/round-ladder-evidence.md`"
 )
@@ -326,7 +397,17 @@ SKILL_ROUTES_TO_EVIDENCE = (
 # The measurement the gate rests on, pinned in the evidence file so an eviction
 # cannot leave the rule standing on an anecdote. The churn row IS the argument:
 # rounds 4-10 changed 1,002 test lines and 0 production lines.
-EVIDENCE_CHURN_ROW = "| **rounds 4–10** | **1,002** | **0** |"
+EVIDENCE_CHURN_ROW = "| **rounds 4–10** | **1,002** | **0** | **0** |"
+
+# 🔴 The classifier is stated in the evidence file because it DECIDES the numbers
+# above -- and because the first version of that table was wrong twice in the
+# direction that flattered the argument (a mis-added test column, and 110 lines
+# of release-notes markdown counted as production). Pinning the correction keeps
+# the honest version from being tidied away into a clean-looking table.
+EVIDENCE_TABLE_CORRECTION = (
+    "🔴 An earlier version of this table read `1,061 / 332` and was wrong twice, "
+    "both times in the direction that flatters the argument"
+)
 
 # 🔴 The half a reader will want to delete as "redundant with the retraction it
 # does not contradict". #498 is NOT evidence of a round that found nothing; it is
@@ -386,7 +467,16 @@ def test_the_guarded_files_exist_and_are_substantial():
     are deliberately crude -- they only have to separate "the document" from
     "a stub".
     """
-    for path, floor in ((RULES_MD, 20_000), (ARCHIVE_MD, 20_000), (SKILL_MD, 3_000)):
+    for path, floor in (
+        (RULES_MD, 20_000),
+        (ARCHIVE_MD, 20_000),
+        (SKILL_MD, 3_000),
+        # Added with the attribution gate. Measured without it: truncating the
+        # evidence file to 0 B reported "the #498 churn row ... is not present
+        # exactly once as written (found 0)" and told the reader they had
+        # REWORDED a sentence in a file that was empty.
+        (EVIDENCE_MD, 1_000),
+    ):
         assert path.is_file(), (
             f"{path} not found -- every pin in this module would fail with a "
             "misleading 'reworded' message. If the file MOVED, re-point the "
@@ -527,11 +617,58 @@ def test_the_attribution_measurement_survives_where_the_skill_routes_to_it():
         "it in one line. Restore it, or move the measurement back into the "
         "body and re-point this test."
     )
-    _assert_pinned_once(SKILL_MD, SKILL_ROUTES_TO_EVIDENCE, "the evidence route")
+    body = _norm(_read(SKILL_MD))
+    assert body.count(_norm(SKILL_ROUTES_TO_EVIDENCE)) >= 1, (
+        "\n\nclaude/skills/audit-pr/SKILL.md no longer routes to "
+        f"{EVIDENCE_MD.name} by its DEPLOYED path.\n"
+        "  The body summarises the measurement in one line; without a path a "
+        "reader cannot reach the rest. It must be the ~/.claude/skills/... "
+        "form -- this skill is read with the cwd in some unrelated project, "
+        "where a bare `reference/x.md` opens nothing.\n"
+        "  More than one route is fine and is why this is not a once-pin."
+    )
     _assert_pinned_once(EVIDENCE_MD, EVIDENCE_CHURN_ROW, "the #498 churn row")
+    _assert_pinned_once(
+        EVIDENCE_MD, EVIDENCE_TABLE_CORRECTION, "the churn-table correction"
+    )
     _assert_pinned_once(
         EVIDENCE_MD, EVIDENCE_DIFFERENT_AXIS, "the different-axis distinction"
     )
+
+
+def test_the_gate_pins_its_MECHANISM_not_only_its_decision():
+    """🔴 A decision pin does not protect the command that feeds it.
+
+    Measured on this module before these three pins existed: replacing the whole
+    `git diff --numstat ...` instruction with `echo 0` left all 9 tests GREEN.
+    The gate's verdict sentence was pinned; the quantity it consumes was not, so
+    the instruction could be swapped for one that never fires and the suite
+    would say the rule was intact.
+
+    That is not a hypothetical. The first version of this gate shipped a
+    CUMULATIVE range, which a per-round condition cannot consume -- on #498 it
+    prints the same non-zero number for rounds 4 through 10. Three pins, because
+    the mechanism has three parts that can each be wrong on their own: WHICH
+    RANGE, HOW LINES ARE CLASSIFIED, and the DECISION over the result.
+    """
+    _assert_pinned_once(SKILL_MD, SKILL_GATE_COMMAND, "the gate's command")
+    _assert_pinned_once(SKILL_MD, SKILL_GATE_PER_ROUND, "the per-round rule")
+    _assert_pinned_once(
+        SKILL_MD, SKILL_GATE_NO_PATHSPEC, "the do-not-use-a-pathspec rule"
+    )
+
+
+def test_the_two_operator_instructions_the_gate_depends_on_are_pinned():
+    """The ledger and the finding labels, each of which survived deletion.
+
+    Neither is decorative. The ledger is what makes the gate's answer VISIBLE in
+    a summary (its cumulative X unchanged across two rounds is the same
+    condition the gate tests); the `behaviour`/`guard` labels are what let a
+    reader see that a round's findings were all about scaffolding. Measured:
+    deleting either left all 9 tests green before these pins.
+    """
+    _assert_pinned_once(SKILL_MD, SKILL_LEDGER, "the per-round ledger")
+    _assert_pinned_once(SKILL_MD, SKILL_FINDING_LABELS, "the finding labels")
 
 
 def test_the_stop_rule_shares_a_bullet_with_the_rule_it_bounds():

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -48,8 +48,9 @@ Measured on `civitai/cli` #498 (session 4719a2f0, 2026-08-26): **10 rounds over
 output tokens**. The fix commits for **rounds 4-10 changed 1,051 lines of test
 code and ZERO lines of what the PR SHIPPED** -- the last such change was round
 3's `d2ec92d` (18 lines of `internal/appapi/appblocks.go`). **No round was ever
-clean**, so the stop rule was never once eligible to fire, and the session escalated to the operator at round 9 with its
-own diagnosis ("rounds 3-10 have all been about the guards, not the feature").
+clean**, so the stop rule was never once eligible to fire, and the session
+escalated to the operator at round 9 with its own diagnosis ("rounds 3-10 have
+all been about the guards, not the feature").
 
 Scale, measured the same day over `~/.claude/projects/**/*.jsonl` (numbered delta
 re-audit dispatches, `subagents/` excluded): **110 sessions, 440 rounds, 84 of
@@ -58,20 +59,29 @@ them in the preceding 14 days**; mean deepest round 4.0; 34% ran >= 5 rounds.
 So the gate is: two consecutive rounds whose FIXES changed zero PAYLOAD lines
 => the ladder has left the PR, stop. Payload = what the PR exists to ship, never
 a file type: keyed to "docs are not production" the gate reads zero for every
-round of a docs or skill PR and stops a working ladder (measured: 24 of devrc's
-last 40 merged PRs, this one included).
+round of a docs or skill PR and stops a working ladder. Measured 2026-08-26: of
+the 40 most recently merged devrc PRs, **25 shipped no source file at all** (17
+of those docs-only) -- this PR among them. That figure is dated because the list
+moves; an earlier `24` here came from a subagent's report and was written in
+without being re-derived.
 
 **Per-round, and the round's OWN commits** -- anchored at round 1 the count is
 non-zero forever once an early round touched payload (the first version of this
 rule shipped exactly that: on #498 it prints the same number for rounds 4-10 and
 never fires), while a plain two-dot `git diff` sweeps in whatever a `merge main`
 or a rebase brought with it and reads 200 upstream lines as this round's payload.
-Hence `git log --numstat --format= --no-merges --first-parent <sha>..HEAD`:
-measured, 1 line where the two-dot form reported 201.
+Hence `git log --numstat --format= --no-merges --first-parent <sha>..HEAD`.
+Measured on a purpose-built scratch repo -- one round whose only fix was a single
+line of `app_test.go`, then `git merge main` bringing 200 upstream lines of
+`other.go`: the two-dot form reports `1 + 200`, this form reports `1`. The flag
+has a cost of its own, stated in the skill: payload written INTO a merge conflict
+resolution is invisible to `--no-merges` (measured 0 where the two-dot form read
+340), so a round whose fix landed that way must count that merge explicitly.
 
 It is not a cap (it counts payload lines, never rounds; a round that touches
-payload never trips it however deep the ladder is) and it does not retract the retraction below -- #498 contains no
-round that ran and found nothing, which is the waste that retraction denies.
+payload never trips it however deep the ladder is) and it does not retract the
+retraction below -- #498 contains no round that ran and found nothing, which is
+the waste that retraction denies.
 Different axis: real findings about scaffolding the ladder itself had written.
 
 🔴 WHY THIS MODULE ALSO GUARDS THE COUNTER-EVIDENCE
@@ -133,9 +143,12 @@ rule rather than reformatting a paragraph.
    directions on ordinary names (`':!*test*'` excludes `pkg/attestation/` and
    `api/latest/`, `':!*spec*'` excludes `internal/inspector/`; both keep
    `FooTest.java` and `login.cy.ts` -- measured). Three constants now pin the
-   definition, the method and that counter-evidence, after five mutants that
+   definition, the method and that counter-evidence, after FOUR mutants that
    rewrote the method -- including one flipping "Ambiguous is not zero" to its
-   opposite -- passed a green 11-test suite with only the prohibition pinned.
+   opposite, and one reinstating the pathspec as the method with the 🔴 warning
+   left intact -- passed a green 11-test suite with only the prohibition pinned.
+   (A fifth survivor of that same run, Z8, belongs to the evidence family and is
+   caught by `EVIDENCE_BASELINE_ROW`, not by these three.)
    What remains unenforceable: whether a given round's files were named
    CORRECTLY. Nothing mechanical can answer that, which is why the residual
    error is aimed at the safe side (ambiguous => the gate does not fire).
@@ -205,7 +218,7 @@ recorded as SURVIVED off an 11-passed run.
   POS  unmutated copy ......................... 11 passed  <- harness control
   BASE origin/main's SKILL.md, reference file
        absent (i.e. pre-change) ............... 6 failed, 5 passed
-  PREV the round-1 tip `ed38490b` ............. 4 failed, 7 passed  <- the tree
+  PREV the round-1 tip `ed38490b` ............. 5 failed, 6 passed  <- the tree
                                                 the second audit read; these are
                                                 the pins added after it
 
@@ -225,6 +238,23 @@ recorded as SURVIVED off an 11-passed run.
   Y4   evidence truncated to 1,400 B (passed
        under the old 1,000 B floor) ........... 2 failed
   Z9   churn row reverted to the stale 1,002 .. 1 failed
+
+  added after the third audit:
+  W1   heading reverted to "no PRODUCTION code" .. 2 failed  <- the heading was
+                                                  the one sentence the payload
+                                                  fix missed, and it was PINNED,
+                                                  so the pin held the
+                                                  contradiction in place
+  W2   dated measurement -> vague "many" ....... 1 failed
+  W3   "`--no-merges` has one cost" -> "has no
+       cost" .................................. 1 failed  <- SURVIVED until the
+                                                  blind spot was pinned
+  W4   evidence truncated to exactly the
+       1,500 B floor .......................... 1 failed  <- the FLOOR passes;
+                                                  the pin's message now names
+                                                  the file size, which is what
+                                                  separates truncated from
+                                                  reworded at any size
 
   the round-1 set, re-run against current strings:
   X3   gate command -> `echo 0` ............... 1 failed
@@ -343,13 +373,13 @@ ARCHIVE_RETRACTION = (
 # --------------------------------------------------------------------------- #
 
 SKILL_ATTRIBUTION_HEADING = (
-    "### 🔴 ATTRIBUTION: a round that changes no PRODUCTION code is auditing "
-    "the LADDER, not the PR"
+    "### 🔴 ATTRIBUTION: a round that changes no PAYLOAD is auditing the "
+    "LADDER, not the PR"
 )
 
 # The gate itself. Pinned whole because every number in it is load-bearing: TWO
 # consecutive rounds (one is noise -- a round can legitimately fix only a guard),
-# ZERO production lines (not "few"), and the action is STOP rather than "consider
+# ZERO payload lines (not "few"), and the action is STOP rather than "consider
 # stopping".
 SKILL_ATTRIBUTION_GATE = (
     "**Two consecutive rounds whose fixes changed zero payload lines ⇒ the "
@@ -402,6 +432,27 @@ SKILL_PAYLOAD_DEFINITION = (
     "what the PR exists to ship; scaffolding = the tests, fixtures and notes a "
     "round wrote to guard it. For a code change the payload is source and a "
     "`.md` is not — but **for a docs or skill PR the payload IS the `.md`**"
+)
+# 🔴 The measurement the payload definition rests on, pinned WITH its date --
+# the PR list moves as PRs merge, so this is a timestamped measurement and not a
+# constant. It was `24` for one commit, carried over from a subagent's report
+# without being re-derived; re-measured here at 25/40 on 2026-08-26. Method in
+# the reference file.
+# 🔴 The flag's OWN blind spot, pinned because disclaiming it is the cheap edit.
+# `--no-merges` is what keeps a `merge main` from being counted as this round's
+# payload -- and it also makes payload hand-written INTO a merge conflict
+# resolution invisible (measured: 0, where the two-dot form read 340). That is
+# the UNSAFE direction: the gate reads zero on a round that did change payload.
+# Measured: rewriting "has one cost" to "has no cost" left the suite green.
+SKILL_NO_MERGES_COST = (
+    "**`--no-merges` has one cost**: payload hand-written into a merge "
+    "*conflict resolution* is invisible to it (measured: 0 where the old form "
+    "read 340), so if a round's fix landed that way, count that merge "
+    "explicitly with `git show --numstat <merge>`."
+)
+SKILL_PAYLOAD_MEASUREMENT = (
+    "on 2026-08-26 **25 of devrc's 40 most recently merged PRs shipped no "
+    "source at all**"
 )
 SKILL_CLASSIFIER_METHOD = (
     "A round's fix touches a handful of files — read the list and name each one "
@@ -489,9 +540,17 @@ def _read(path: Path) -> str:
 def _assert_pinned_once(path: Path, claim: str, what: str) -> None:
     body = _norm(_read(path))
     count = body.count(_norm(claim))
+    # 🔴 The size goes in the MESSAGE, not only in a floor. A byte floor can
+    # only ever sit below the LAST string it guards -- measured: a 1,500 B floor
+    # passed a truncation that had already eaten the first pinned row at byte
+    # 1,433, and any floor under 3,532 leaves a hole -- so the floor cannot be
+    # the thing that distinguishes "reworded" from "truncated". Reporting the
+    # file's actual size here does distinguish them, at every size, forever.
+    size = len(path.read_bytes())
     assert count == 1, (
         f"\n\n{path.relative_to(REPO_ROOT)}: {what} is not present exactly once "
-        f"as written (found {count}).\n"
+        f"as written (found {count}). The file is {size:,} B -- if that is far "
+        "short of what it should hold, this is a TRUNCATION, not a reword.\n"
         f"  Expected verbatim (whitespace-normalised):\n    {_norm(claim)}\n\n"
         "  This is a WHOLE-STRING pin because the artifact is prose and a "
         "keyword guard is walkable by rewording (claude/RULES.md, "
@@ -533,11 +592,15 @@ def test_the_guarded_files_exist_and_are_substantial():
         # exactly once as written (found 0)" and told the reader they had
         # REWORDED a sentence in a file that was empty.
         #
-        # 🔴 1,500, not 1,000: the first pinned string in this file starts at
-        # byte ~1,400, so a 1,000 B floor PASSES on a truncation that already
-        # ate it -- the misleading message the floor exists to prevent, from
-        # the guard meant to prevent it. A floor below the first thing it
-        # guards is not a floor.
+        # 🔴 The floor is a SANITY check, not the truncation guard. Measured:
+        # this file's first pinned string spans bytes 1,433-1,501 and its last
+        # ends at 3,532, so a 1,500 B floor still passes a truncation that ate
+        # the first one, and every floor under 3,532 leaves some hole -- chasing
+        # the number is the wrong fix, because the floor can never sit above a
+        # string that has not been written yet. `_assert_pinned_once` now
+        # reports the file's size in its own failure message, which separates
+        # "reworded" from "truncated" at any size. This floor only has to
+        # separate "the document" from "a stub".
         (EVIDENCE_MD, 1_500),
     ):
         assert path.is_file(), (
@@ -634,7 +697,7 @@ def test_the_attribution_gate_comes_after_the_rule_it_bounds():
 
     Order carries meaning here: the attribution gate BOUNDS the findings-keyed
     stop rule, it does not replace it. A reader who meets it first meets "stop
-    when the fixes stop touching production code" with no "keep going while
+    when the fixes stop touching payload" with no "keep going while
     rounds keep finding things" in view -- which is the one-audit-is-enough
     failure `audit-fix-resets-gate` exists to prevent.
 
@@ -654,7 +717,7 @@ def test_the_attribution_gate_comes_after_the_rule_it_bounds():
         "\n\nclaude/skills/audit-pr/SKILL.md: the ATTRIBUTION gate now precedes "
         "the clean-round stop rule.\n"
         "  The gate bounds that rule; it does not replace it. Read first, it "
-        "says 'stop when the fixes stop touching production code' with no "
+        "says 'stop when the fixes stop touching payload' with no "
         "'keep going while rounds keep finding things' in view -- and a single "
         "audit round is how a completely inert feature shipped past 428 green "
         "tests (claude/RULES-ARCHIVE.md, audit-fix-resets-gate).\n"
@@ -726,6 +789,12 @@ def test_the_gate_pins_its_MECHANISM_not_only_its_decision():
         SKILL_MD, SKILL_CLASSIFIER_METHOD, "the classifier METHOD"
     )
     _assert_pinned_once(
+        SKILL_MD, SKILL_PAYLOAD_MEASUREMENT, "the dated payload measurement"
+    )
+    _assert_pinned_once(
+        SKILL_MD, SKILL_NO_MERGES_COST, "the --no-merges blind spot"
+    )
+    _assert_pinned_once(
         SKILL_MD, SKILL_GATE_NO_PATHSPEC, "the pathspec counter-evidence"
     )
 
@@ -733,11 +802,14 @@ def test_the_gate_pins_its_MECHANISM_not_only_its_decision():
 def test_the_two_operator_instructions_the_gate_depends_on_are_pinned():
     """The ledger and the finding labels, each of which survived deletion.
 
-    Neither is decorative. The ledger is what makes the gate's answer VISIBLE in
-    a summary (its cumulative X unchanged across two rounds is the same
-    condition the gate tests); the `behaviour`/`guard` labels are what let a
-    reader see that a round's findings were all about scaffolding. Measured:
-    deleting either left all 9 tests green before these pins.
+    Neither is decorative. The ledger's X IS the number the gate reads -- it
+    carries the per-round count into the summary a human actually sees, which is
+    what turns the gate from a command someone must remember to run into a field
+    they would notice missing. (An earlier format carried only the cumulative
+    figure; that is the quantity the gate cannot consume.) The `behaviour`/
+    `guard` labels are what let a reader see that a round's findings were all
+    about scaffolding. Measured: deleting either left all 9 tests green before
+    these pins.
     """
     _assert_pinned_once(SKILL_MD, SKILL_LEDGER, "the per-round ledger")
     _assert_pinned_once(SKILL_MD, SKILL_FINDING_LABELS, "the finding labels")

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -45,23 +45,32 @@ ladder manufactures its own next round's findings.
 
 Measured on `civitai/cli` #498 (session 4719a2f0, 2026-08-26): **10 rounds over
 5 h 32 m**, 75% of the session's transcript rows, **321k of 419k main-thread
-output tokens**. The fix commits for **rounds 4-10 changed 1,002 lines of test
-code and ZERO lines of production code** -- the last production change was round
-3's `d2ec92d`. **No round was ever clean**, so the stop rule was never once
-eligible to fire, and the session escalated to the operator at round 9 with its
+output tokens**. The fix commits for **rounds 4-10 changed 1,051 lines of test
+code and ZERO lines of what the PR SHIPPED** -- the last such change was round
+3's `d2ec92d` (18 lines of `internal/appapi/appblocks.go`). **No round was ever
+clean**, so the stop rule was never once eligible to fire, and the session escalated to the operator at round 9 with its
 own diagnosis ("rounds 3-10 have all been about the guards, not the feature").
 
 Scale, measured the same day over `~/.claude/projects/**/*.jsonl` (numbered delta
 re-audit dispatches, `subagents/` excluded): **110 sessions, 440 rounds, 84 of
 them in the preceding 14 days**; mean deepest round 4.0; 34% ran >= 5 rounds.
 
-So the gate is: two consecutive rounds whose FIXES changed zero production lines
-=> the ladder has left the PR, stop. **Per-round, never cumulative** -- a range
-anchored at round 1 is non-zero forever once any early round touched production,
-and the first version of this rule shipped exactly that, which on #498 prints
-the same number for rounds 4-10 and never fires. It is not a cap (it counts production lines,
-never rounds; a round that touches production code never trips it however deep
-the ladder is) and it does not retract the retraction below -- #498 contains no
+So the gate is: two consecutive rounds whose FIXES changed zero PAYLOAD lines
+=> the ladder has left the PR, stop. Payload = what the PR exists to ship, never
+a file type: keyed to "docs are not production" the gate reads zero for every
+round of a docs or skill PR and stops a working ladder (measured: 24 of devrc's
+last 40 merged PRs, this one included).
+
+**Per-round, and the round's OWN commits** -- anchored at round 1 the count is
+non-zero forever once an early round touched payload (the first version of this
+rule shipped exactly that: on #498 it prints the same number for rounds 4-10 and
+never fires), while a plain two-dot `git diff` sweeps in whatever a `merge main`
+or a rebase brought with it and reads 200 upstream lines as this round's payload.
+Hence `git log --numstat --format= --no-merges --first-parent <sha>..HEAD`:
+measured, 1 line where the two-dot form reported 201.
+
+It is not a cap (it counts payload lines, never rounds; a round that touches
+payload never trips it however deep the ladder is) and it does not retract the retraction below -- #498 contains no
 round that ran and found nothing, which is the waste that retraction denies.
 Different axis: real findings about scaffolding the ladder itself had written.
 
@@ -113,18 +122,23 @@ rule rather than reformatting a paragraph.
    it never caught the bug this module is about. It is labelled here rather than
    counted as a catch. It IS reachable: watched to fail by stubbing SKILL.md.
 5. **Nothing here proves the attribution gate is RUN.** Same blind spot as (2),
-   and it bites harder for this one: the gate is a `git diff --numstat` an
+   and it bites harder for this one: the gate is a `git log --numstat` an
    operator has to issue between rounds, so the only evidence it fired is a
    ladder that stopped. The behavioural claim needs transcript measurement over
    future ladders -- re-run the sweep in the docstring above -- and is NOT made
    here.
-6. **The CLASSIFIER is a human judgement, deliberately.** The rule tells the
-   reader to read the `--numstat` file list rather than run a pathspec, because
-   a pathspec is wrong in both directions on ordinary names (`':!*test*'`
-   excludes `pkg/attestation/`, `api/latest/`, `internal/inspector/`; misses
-   `FooTest.java`, `login.cy.ts` -- measured). Nothing here can check that a
-   given round's lines were classified correctly; the pins only ensure the
-   instruction still says to judge rather than to pattern-match.
+6. **The CLASSIFIER is a human judgement, deliberately -- and only its WORDING
+   is pinned.** The rule tells the reader to name each changed file payload or
+   scaffolding rather than run a pathspec, because a pathspec is wrong in both
+   directions on ordinary names (`':!*test*'` excludes `pkg/attestation/` and
+   `api/latest/`, `':!*spec*'` excludes `internal/inspector/`; both keep
+   `FooTest.java` and `login.cy.ts` -- measured). Three constants now pin the
+   definition, the method and that counter-evidence, after five mutants that
+   rewrote the method -- including one flipping "Ambiguous is not zero" to its
+   opposite -- passed a green 11-test suite with only the prohibition pinned.
+   What remains unenforceable: whether a given round's files were named
+   CORRECTLY. Nothing mechanical can answer that, which is why the residual
+   error is aimed at the safe side (ambiguous => the gate does not fire).
 7. **The THRESHOLD is pinned, not justified.** "Two consecutive rounds" comes
    from one measured ladder (#498, n=1), where the plateau began at round 4 and
    ran to 10. One round is knowingly too tight: a round may legitimately fix only
@@ -149,25 +163,29 @@ people's claims is the worst place for it to happen.
 
 Mutation controls, each run on a copy of the HEAD tree, under
 `PYTHONDONTWRITEBYTECODE=1` with the pytest cache disabled. The unmutated copy
-is the positive control (5 passed), so a red below is the mutant and not the
-harness:
+is the positive control, so a red below is the mutant and not the harness.
+**Re-measured 2026-08-26 against the current 11-test module** -- the counts
+first recorded here were taken against a 5-test module that never existed, and
+M2/M5 have since gained assertions that also fire:
 
-  POS  unmutated copy .......................... 5 passed
+  POS  unmutated copy ......................... 11 passed
   M1   cosmetic reword of the RULES clause
        ("FINDINGS, never by a number" -> "findings,
-       not by a number") ........................ 2 failed -- the string pin AND
-                                                  the relationship pin
-  M2   delete the SKILL heading .................. 1 failed -- heading pin
+       not by a number") ....................... 2 failed -- the string pin AND
+                                                 the relationship pin
+  M2   delete the SKILL heading ................ 2 failed -- heading pin, plus
+                                                 the order test's both-present
+                                                 precondition
   M3   replace the not-a-cap paragraph with an
        actual cap ("Cap the ladder at three
-       rounds") ................................. 1 failed -- not-a-cap pin
+       rounds") ................................ 1 failed -- not-a-cap pin
   M4   move the stop clause into its OWN bullet,
-       text byte-identical ...................... 1 failed -- relationship pin
-                                                  ONLY
-  M5   truncate SKILL.md to a stub .............. 3 failed -- the invariant guard
-                                                  fires with its own message
+       text byte-identical ..................... 1 failed -- relationship pin
+                                                 ONLY
+  M5   truncate SKILL.md to a stub ............. 9 failed -- the invariant guard
+                                                 fires with its own message
   M6   drop the rejected-cap evidence from the
-       archive .................................. 1 failed -- archive pin
+       archive ................................. 1 failed -- archive pin
 
 🔴 M4 is the one that matters for reachability. The clause survives verbatim, so
 every whole-string pin stays GREEN and only
@@ -179,39 +197,44 @@ THE ATTRIBUTION-GATE PINS -- their own matrix (2026-08-26, 5 tests added, 6 -> 1
 ---------------------------------------------------------------------------------
 Same method: each run on its OWN scratch tree built from HEAD, never the
 worktree, under `PYTHONDONTWRITEBYTECODE=1` with the pytest cache disabled, and
-every mutant asserts its target string is present before editing (so a missed
-mutant fails loudly instead of scoring SURVIVED).
+every mutant asserts its target string is present before editing. That assert is
+not ceremony -- two mutants below silently failed to apply on a first pass
+because their target had been re-wrapped, and without it both would have been
+recorded as SURVIVED off an 11-passed run.
 
   POS  unmutated copy ......................... 11 passed  <- harness control
   BASE origin/main's SKILL.md, reference file
-       absent (i.e. pre-change) ............... 6 failed, 5 passed  -- exactly
-                                                the five new tests plus the
-                                                widened floor guard: regression
-                                                coverage, not invariant guards
-  M7   attribution heading deleted ............. 2 failed -- heading pin, plus
-                                                the order test's both-present
-                                                precondition
-  M8   decision reworded TWO -> THREE .......... 1 failed -- the decision pin
-                                                ONLY, which separates a
-                                                whole-string pin from a keyword
-                                                guard
-  M9   evidence file deleted ................... 2 failed
-  M11  different-axis paragraph dropped ........ 1 failed
-  X3   gate COMMAND replaced with `echo 0` ..... 1 failed
-  X4   ledger instruction deleted .............. 1 failed
+       absent (i.e. pre-change) ............... 6 failed, 5 passed
+  PREV the round-1 tip `ed38490b` ............. 4 failed, 7 passed  <- the tree
+                                                the second audit read; these are
+                                                the pins added after it
+
+  the five that SURVIVED a green 11-test suite until the classifier was pinned:
+  Z1   classifier METHOD sentence deleted ..... 1 failed
+  Z3   "the payload IS the `.md`" -> "docs are
+       never payload" ......................... 1 failed
+  Z4   fail-safe inverted ("Ambiguous counts as
+       zero: the gate fires") ................. 1 failed
+  Y9   method replaced by the pathspec, the 🔴
+       warning left intact .................... 1 failed
+  Z8   corrected baseline row -> 9999s ........ 1 failed
+
+  the regressions earlier rounds shipped:
+  X8   command reverted to the cumulative
+       two-dot diff ........................... 1 failed
+  Y4   evidence truncated to 1,400 B (passed
+       under the old 1,000 B floor) ........... 2 failed
+  Z9   churn row reverted to the stale 1,002 .. 1 failed
+
+  the round-1 set, re-run against current strings:
+  X3   gate command -> `echo 0` ............... 1 failed
+  X4   ledger instruction deleted ............. 1 failed
   X5   behaviour/guard labelling bullet
        deleted ................................ 1 failed
-  X6   evidence file truncated to 0 B .......... 2 failed -- the floor guard
-                                                fires with its own message
-  X7   no-pathspec rule deleted ................ 1 failed
-  X8   range reverted to CUMULATIVE ............ 1 failed
-
-🔴 X3, X4 and X5 all SURVIVED a fully green 9-test run in review -- the gate's
-decision was pinned while the command producing its input, the ledger and the
-finding labels were not. X8 is the defect that shipped in the first version of
-this rule and was caught by review, not by this module: `<first-audited-sha>..`
-is cumulative, so it prints the same non-zero number for #498's rounds 4-10 and
-the gate never fires. Both are why the pins now cover the MECHANISM.
+  M8   decision reworded TWO -> THREE ......... 1 failed  (decision pin only)
+  X6   evidence file truncated to 0 B ......... 2 failed
+  M10  section moved ABOVE the stop rule,
+       text byte-identical .................... 1 failed  (order pin only)
 
 🔴 M10 is this half's reachability control, and the analogue of M4. The
 attribution section is MOVED above the stop rule with its text byte-identical:
@@ -329,7 +352,7 @@ SKILL_ATTRIBUTION_HEADING = (
 # ZERO production lines (not "few"), and the action is STOP rather than "consider
 # stopping".
 SKILL_ATTRIBUTION_GATE = (
-    "**Two consecutive rounds whose fixes changed zero production lines ⇒ the "
+    "**Two consecutive rounds whose fixes changed zero payload lines ⇒ the "
     "ladder has left the PR. Stop.**"
 )
 
@@ -353,28 +376,53 @@ SKILL_ATTRIBUTION_NOT_A_CAP = (
 # printed the same non-zero number for rounds 4 through 10 and never fired.
 # Caught in review; these three pins are what stop it coming back.
 SKILL_GATE_COMMAND = (
-    "After a round's fixes land, count the production lines **that round** "
-    "changed: `git diff --numstat <the sha you audited THAT round>..HEAD`."
+    "git log --numstat --format= --no-merges --first-parent "
+    "<the sha you audited THAT round>..HEAD"
 )
 SKILL_GATE_PER_ROUND = (
-    "🔴 **Per-round, never cumulative.** A range anchored at round 1 stays "
-    "non-zero forever once any early round touched production"
+    "🔴 **Per-round and the round's OWN commits.** Anchored at round 1 the "
+    "count stays non-zero forever once an early round touched payload"
 )
-# The classifier decides the gate's answer, so it is part of the mechanism. A
-# pathspec looks precise and is wrong in BOTH directions on ordinary names --
-# measured: `':!*test*'` excludes `pkg/attestation/`, `api/latest/` and
-# `internal/inspector/` while `FooTest.java` and `login.cy.ts` survive it.
+
+# 🔴 THE CLASSIFIER, pinned as the INSTRUCTION it is -- not as the prohibition
+# beside it. Measured: with only the "do not use a pathspec" sentence pinned,
+# FIVE mutants passed a green 11-test suite, including one that deleted "read
+# the list and name each one payload or scaffolding", one that flipped
+# "Ambiguous is not zero" to its opposite (reversing the fail-safe direction),
+# and one that reinstated the pathspec as the method while leaving the warning
+# in place. A prohibition is not a method.
+#
+# The DEFINITION is the half that decides: keyed to file TYPE ("docs are not
+# production") the gate reads zero for every round of a docs or skill PR and
+# stops a working ladder -- measured at 24 of devrc's last 40 merged PRs, this
+# one included. Keyed to PAYLOAD it asks the question that matters: did this
+# round change what the PR ships, or only the guards the ladder wrote?
+SKILL_PAYLOAD_DEFINITION = (
+    "🔴 **The unit is THIS PR's PAYLOAD, never a file extension.** Payload = "
+    "what the PR exists to ship; scaffolding = the tests, fixtures and notes a "
+    "round wrote to guard it. For a code change the payload is source and a "
+    "`.md` is not — but **for a docs or skill PR the payload IS the `.md`**"
+)
+SKILL_CLASSIFIER_METHOD = (
+    "A round's fix touches a handful of files — read the list and name each one "
+    "payload or scaffolding. **Ambiguous is not zero**: the gate does not fire, "
+    "and the ladder continues."
+)
+# The pathspec facts, kept because they are the reason the method is a judgement
+# and not a pattern. `inspector` is dropped by `*spec*`, NOT by `*test*` -- an
+# earlier version of this sentence attributed all three to `*test*` and was
+# wrong on its own third example.
 SKILL_GATE_NO_PATHSPEC = (
-    "🔴 **Do not classify with a pathspec.** `':!*test*'` swallows "
-    "`attestation/`, `latest/` and `inspector/` as \"tests\" while missing "
-    "`FooTest.java` and `*.cy.ts`"
+    "Nor will a pathspec do it: `':!*test*'` swallows `attestation/` and "
+    "`latest/`, `':!*spec*'` swallows `inspector/`, and both keep "
+    "`FooTest.java` and `*.cy.ts` (measured)."
 )
 
 # The other two operator instructions this rule ships. Both survived a mutant
 # that deleted them outright before these pins existed.
 SKILL_LEDGER = (
-    "**Carry the ledger in every round's summary**: `round N · production lines "
-    "changed since round 1: X · elapsed: Y`."
+    "**Carry the ledger in every round's summary**: `round N · payload lines "
+    "changed THIS round: X (since round 1: Y) · elapsed: Z`."
 )
 SKILL_FINDING_LABELS = (
     "**label every finding `behaviour` or `guard`, and separate shipped "
@@ -396,8 +444,16 @@ SKILL_ROUTES_TO_EVIDENCE = (
 
 # The measurement the gate rests on, pinned in the evidence file so an eviction
 # cannot leave the rule standing on an anecdote. The churn row IS the argument:
-# rounds 4-10 changed 1,002 test lines and 0 production lines.
-EVIDENCE_CHURN_ROW = "| **rounds 4–10** | **1,002** | **0** | **0** |"
+# rounds 4-10 changed 1,051 test lines and 0 payload lines.
+EVIDENCE_CHURN_ROW = (
+    "| **rounds 4–10** (`a82718b`…`7541bc1`) | **1,051** | **0** | **0** |"
+)
+# 🔴 The row the corrections were ABOUT, pinned too. Without it the numbers can
+# drift back while the correction sentence below still narrates having fixed
+# them -- measured: rewriting this row to 9999s left the suite green.
+EVIDENCE_BASELINE_ROW = (
+    "| feature + rounds 1–3 (`bce0c0c`…`d2ec92d`) | 961 | 110 | 222 |"
+)
 
 # 🔴 The classifier is stated in the evidence file because it DECIDES the numbers
 # above -- and because the first version of that table was wrong twice in the
@@ -405,8 +461,9 @@ EVIDENCE_CHURN_ROW = "| **rounds 4–10** | **1,002** | **0** | **0** |"
 # of release-notes markdown counted as production). Pinning the correction keeps
 # the honest version from being tidied away into a clean-looking table.
 EVIDENCE_TABLE_CORRECTION = (
-    "🔴 An earlier version of this table read `1,061 / 332` and was wrong twice, "
-    "both times in the direction that flatters the argument"
+    "🔴 This table has been wrong **three times**, each time in the direction "
+    "that flatters the argument, which is why it now carries its shas and its "
+    "classifier."
 )
 
 # 🔴 The half a reader will want to delete as "redundant with the retraction it
@@ -475,7 +532,13 @@ def test_the_guarded_files_exist_and_are_substantial():
         # evidence file to 0 B reported "the #498 churn row ... is not present
         # exactly once as written (found 0)" and told the reader they had
         # REWORDED a sentence in a file that was empty.
-        (EVIDENCE_MD, 1_000),
+        #
+        # 🔴 1,500, not 1,000: the first pinned string in this file starts at
+        # byte ~1,400, so a 1,000 B floor PASSES on a truncation that already
+        # ate it -- the misleading message the floor exists to prevent, from
+        # the guard meant to prevent it. A floor below the first thing it
+        # guards is not a floor.
+        (EVIDENCE_MD, 1_500),
     ):
         assert path.is_file(), (
             f"{path} not found -- every pin in this module would fail with a "
@@ -546,8 +609,8 @@ def test_the_attribution_gate_is_stated_with_its_not_a_cap_qualifier():
     INTO that range -- so the ladder manufactures its own next round's findings
     and a stop condition keyed to findings has no exit. Measured on `civitai/cli`
     #498 (2026-08-26): ten rounds, 5 h 32 m, 77% of the session's output tokens,
-    and the fix commits for rounds 4-10 changed 1,002 lines of test code and ZERO
-    lines of production code. No round was ever clean, so the rule above was
+    and the fix commits for rounds 4-10 changed 1,051 lines of test code and ZERO
+    lines of payload. No round was ever clean, so the rule above was
     never once eligible to fire.
 
     All three constants are pinned together on purpose. The gate without its
@@ -629,6 +692,9 @@ def test_the_attribution_measurement_survives_where_the_skill_routes_to_it():
     )
     _assert_pinned_once(EVIDENCE_MD, EVIDENCE_CHURN_ROW, "the #498 churn row")
     _assert_pinned_once(
+        EVIDENCE_MD, EVIDENCE_BASELINE_ROW, "the #498 baseline churn row"
+    )
+    _assert_pinned_once(
         EVIDENCE_MD, EVIDENCE_TABLE_CORRECTION, "the churn-table correction"
     )
     _assert_pinned_once(
@@ -654,7 +720,13 @@ def test_the_gate_pins_its_MECHANISM_not_only_its_decision():
     _assert_pinned_once(SKILL_MD, SKILL_GATE_COMMAND, "the gate's command")
     _assert_pinned_once(SKILL_MD, SKILL_GATE_PER_ROUND, "the per-round rule")
     _assert_pinned_once(
-        SKILL_MD, SKILL_GATE_NO_PATHSPEC, "the do-not-use-a-pathspec rule"
+        SKILL_MD, SKILL_PAYLOAD_DEFINITION, "the payload definition"
+    )
+    _assert_pinned_once(
+        SKILL_MD, SKILL_CLASSIFIER_METHOD, "the classifier METHOD"
+    )
+    _assert_pinned_once(
+        SKILL_MD, SKILL_GATE_NO_PATHSPEC, "the pathspec counter-evidence"
     )
 
 

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -36,6 +36,32 @@ on it.
 So the rule is FORWARD-LOOKING with a demonstrated near-miss. It is not a remedy
 for observed waste, and must not be cited as one.
 
+🔴 THE ATTRIBUTION GATE -- THE AXIS THE FINDINGS-KEYED RULE CANNOT SEE
+----------------------------------------------------------------------
+Added 2026-08-26. The stop rule above is keyed to findings, and there is a whole
+regime in which it can never fire: a fix round WRITES new guards, the next delta
+round diffs `<audited-sha>..HEAD`, so those guards are its audit surface. The
+ladder manufactures its own next round's findings.
+
+Measured on `civitai/cli` #498 (session 4719a2f0, 2026-08-26): **10 rounds over
+5 h 32 m**, 75% of the session's transcript rows, **321k of 419k main-thread
+output tokens**. The fix commits for **rounds 4-10 changed 1,002 lines of test
+code and ZERO lines of production code** -- the last production change was round
+3's `d2ec92d`. **No round was ever clean**, so the stop rule was never once
+eligible to fire, and the session escalated to the operator at round 9 with its
+own diagnosis ("rounds 3-10 have all been about the guards, not the feature").
+
+Scale, measured the same day over `~/.claude/projects/**/*.jsonl` (numbered delta
+re-audit dispatches, `subagents/` excluded): **110 sessions, 440 rounds, 84 of
+them in the preceding 14 days**; mean deepest round 4.0; 34% ran >= 5 rounds.
+
+So the gate is: two consecutive rounds whose FIXES changed zero production lines
+=> the ladder has left the PR, stop. It is not a cap (it counts production lines,
+never rounds; a round that touches production code never trips it however deep
+the ladder is) and it does not retract the retraction below -- #498 contains no
+round that ran and found nothing, which is the waste that retraction denies.
+Different axis: real findings about scaffolding the ladder itself had written.
+
 🔴 WHY THIS MODULE ALSO GUARDS THE COUNTER-EVIDENCE
 ---------------------------------------------------
 The obvious fix -- cap the rounds at N -- was written first and REJECTED, on this
@@ -83,6 +109,18 @@ rule rather than reformatting a paragraph.
    not regression coverage.** It was green at `origin/main` and green at HEAD --
    it never caught the bug this module is about. It is labelled here rather than
    counted as a catch. It IS reachable: watched to fail by stubbing SKILL.md.
+5. **Nothing here proves the attribution gate is RUN.** Same blind spot as (2),
+   and it bites harder for this one: the gate is a `git diff --numstat` an
+   operator has to issue between rounds, so the only evidence it fired is a
+   ladder that stopped. The behavioural claim needs transcript measurement over
+   future ladders -- re-run the sweep in the docstring above -- and is NOT made
+   here.
+6. **The THRESHOLD is pinned, not justified.** "Two consecutive rounds" comes
+   from one measured ladder (#498, n=1), where the plateau began at round 4 and
+   ran to 10. One round is knowingly too tight: a round may legitimately fix only
+   a guard. Whether two is right is a judgement, and this module cannot tell a
+   deliberate re-tune from a quiet weakening -- it only makes the change visible
+   in the diff, which is the point of pinning a number in prose at all.
 
 WATCHED TO FAIL -- the matrix, so this module is not taken on trust
 -------------------------------------------------------------------
@@ -118,6 +156,38 @@ every whole-string pin stays GREEN and only
 `test_the_stop_rule_shares_a_bullet_with_the_rule_it_bounds` goes red -- which is
 what proves that assertion executes and is not a second spelling of the string
 pin it sits beside.
+
+THE ATTRIBUTION-GATE PINS -- their own matrix (2026-08-26, 3 tests added)
+------------------------------------------------------------------------
+Same method: each run on its OWN scratch tree built from HEAD, never the
+worktree, under `PYTHONDONTWRITEBYTECODE=1` with the pytest cache disabled, and
+every mutant script asserts its target string is present before editing (so a
+missed mutant fails loudly instead of scoring SURVIVED). Script preserved at
+`scratchpad/controls.sh` in the authoring session; it is 6 `cp`s and a `pytest`.
+
+  POS  unmutated copy .......................... 9 passed  <- harness control
+  BASE origin/main's SKILL.md, reference file
+       absent (i.e. pre-change) ................ 3 failed, 6 passed
+                                                 -- exactly the three new tests
+                                                 red, all six pre-existing ones
+                                                 green: regression coverage, not
+                                                 an invariant guard
+  M7   attribution heading deleted .............. 2 failed -- heading pin, plus
+                                                 the order test's both-present
+                                                 precondition
+  M8   gate threshold reworded TWO -> THREE ..... 1 failed -- the gate pin ONLY,
+                                                 which is what separates a
+                                                 whole-string pin from a keyword
+                                                 guard
+  M9   evidence file deleted .................... 1 failed -- evidence pin
+  M11  different-axis paragraph dropped from
+       the evidence file ....................... 1 failed -- evidence pin
+
+🔴 M10 is this half's reachability control, and the analogue of M4. The
+attribution section is MOVED above the stop rule with its text byte-identical:
+every whole-string pin stays GREEN and only
+`test_the_attribution_gate_comes_after_the_rule_it_bounds` goes red (1 failed) --
+which proves that assertion executes rather than restating the pins beside it.
 """
 
 from pathlib import Path
@@ -127,6 +197,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 RULES_MD = REPO_ROOT / "claude" / "RULES.md"
 ARCHIVE_MD = REPO_ROOT / "claude" / "RULES-ARCHIVE.md"
 SKILL_MD = REPO_ROOT / "claude" / "skills" / "audit-pr" / "SKILL.md"
+EVIDENCE_MD = (
+    REPO_ROOT / "claude" / "skills" / "audit-pr" / "reference"
+    / "round-ladder-evidence.md"
+)
 
 # --------------------------------------------------------------------------- #
 # THE PINS -- whole normalised strings, never keywords.
@@ -209,6 +283,59 @@ ARCHIVE_RETRACTION = (
     "**Every load-bearing part of that is false**, and it was checked against "
     "`gh pr view <n> --json commits` only after it had been written into five "
     "places."
+)
+
+# --------------------------------------------------------------------------- #
+# THE ATTRIBUTION GATE -- the axis the findings-keyed stop rule cannot see.
+# --------------------------------------------------------------------------- #
+
+SKILL_ATTRIBUTION_HEADING = (
+    "### 🔴 ATTRIBUTION: a round that changes no PRODUCTION code is auditing "
+    "the LADDER, not the PR"
+)
+
+# The gate itself. Pinned whole because every number in it is load-bearing: TWO
+# consecutive rounds (one is noise -- a round can legitimately fix only a guard),
+# ZERO production lines (not "few"), and the action is STOP rather than "consider
+# stopping".
+SKILL_ATTRIBUTION_GATE = (
+    "**Two consecutive rounds whose fixes changed zero production lines ⇒ the "
+    "ladder has left the PR. Stop.**"
+)
+
+# 🔴 The clause that keeps this from being read as the rejected cap, or as a
+# retraction of the two rules it sits under. Without it the next reader has three
+# stop rules and no idea how they compose -- and the cheapest way to "simplify"
+# that is to collapse them into a count, which is the rejected fix.
+SKILL_ATTRIBUTION_NOT_A_CAP = (
+    "⚠ **This does not retract the two rules above, and is not a cap in "
+    "disguise.** #498's rounds were not wasted in the sense those rules deny — "
+    "every one found something real. The waste is on a different axis: real "
+    "findings *about scaffolding the ladder itself had just written*. The gate "
+    "measures the fixes; it never counts the rounds."
+)
+
+# The deployed path, not a repo-relative one: a devrc skill is READ from
+# ~/.claude/skills/<name>/ by an agent whose cwd is some unrelated project, so a
+# bare `reference/x.md` resolves against that cwd. Same rule as
+# scripts/tests/test_doc_path_rot.py (1c).
+SKILL_ROUTES_TO_EVIDENCE = (
+    "`~/.claude/skills/audit-pr/reference/round-ladder-evidence.md`"
+)
+
+# The measurement the gate rests on, pinned in the evidence file so an eviction
+# cannot leave the rule standing on an anecdote. The churn row IS the argument:
+# rounds 4-10 changed 1,002 test lines and 0 production lines.
+EVIDENCE_CHURN_ROW = "| **rounds 4–10** | **1,002** | **0** |"
+
+# 🔴 The half a reader will want to delete as "redundant with the retraction it
+# does not contradict". #498 is NOT evidence of a round that found nothing; it is
+# evidence of rounds that found real things about the ladder's own scaffolding.
+# Losing this distinction re-opens the retracted "measured waste" story.
+EVIDENCE_DIFFERENT_AXIS = (
+    "**It does NOT contradict the \"not a wasted round\" retraction.** No #498 "
+    "round ran and found nothing, so it is not an instance of the waste that "
+    "retraction denies. Different axis."
 )
 
 
@@ -320,6 +447,91 @@ def test_the_rule_is_justified_by_the_verdict_gap_not_by_claimed_waste():
     )
     _assert_pinned_once(SKILL_MD, SKILL_NOT_WASTE, "the not-a-wasted-round retraction")
     _assert_pinned_once(ARCHIVE_MD, ARCHIVE_RETRACTION, "the archive's retraction")
+
+
+def test_the_attribution_gate_is_stated_with_its_not_a_cap_qualifier():
+    """🔴 The gate the findings-keyed stop rule cannot supply on its own.
+
+    A delta round diffs `<audited-sha>..HEAD`, and a fix round writes new guards
+    INTO that range -- so the ladder manufactures its own next round's findings
+    and a stop condition keyed to findings has no exit. Measured on `civitai/cli`
+    #498 (2026-08-26): ten rounds, 5 h 32 m, 77% of the session's output tokens,
+    and the fix commits for rounds 4-10 changed 1,002 lines of test code and ZERO
+    lines of production code. No round was ever clean, so the rule above was
+    never once eligible to fire.
+
+    All three constants are pinned together on purpose. The gate without its
+    qualifier reads as a third stop rule of unknown standing next to two others,
+    and the cheapest way to reconcile three is to collapse them into a count --
+    which is the cap this module already rejects.
+    """
+    _assert_pinned_once(
+        SKILL_MD, SKILL_ATTRIBUTION_HEADING, "the attribution-gate heading"
+    )
+    _assert_pinned_once(SKILL_MD, SKILL_ATTRIBUTION_GATE, "the attribution gate")
+    _assert_pinned_once(
+        SKILL_MD,
+        SKILL_ATTRIBUTION_NOT_A_CAP,
+        "the attribution gate's not-a-cap / not-a-retraction qualifier",
+    )
+
+
+def test_the_attribution_gate_comes_after_the_rule_it_bounds():
+    """A RELATIONSHIP pin, and the reachability control for the one above.
+
+    Order carries meaning here: the attribution gate BOUNDS the findings-keyed
+    stop rule, it does not replace it. A reader who meets it first meets "stop
+    when the fixes stop touching production code" with no "keep going while
+    rounds keep finding things" in view -- which is the one-audit-is-enough
+    failure `audit-fix-resets-gate` exists to prevent.
+
+    This assertion is what fails when the section is MOVED with its text
+    byte-identical; every whole-string pin above stays green in that mutant, so a
+    red here proves this test executes rather than restating its neighbour.
+    """
+    body = _norm(_read(SKILL_MD))
+    stop_at = body.find(_norm(SKILL_HEADING))
+    attribution_at = body.find(_norm(SKILL_ATTRIBUTION_HEADING))
+
+    assert stop_at != -1 and attribution_at != -1, (
+        "one of the two headings is missing -- the pins above report which; this "
+        "test only orders them."
+    )
+    assert stop_at < attribution_at, (
+        "\n\nclaude/skills/audit-pr/SKILL.md: the ATTRIBUTION gate now precedes "
+        "the clean-round stop rule.\n"
+        "  The gate bounds that rule; it does not replace it. Read first, it "
+        "says 'stop when the fixes stop touching production code' with no "
+        "'keep going while rounds keep finding things' in view -- and a single "
+        "audit round is how a completely inert feature shipped past 428 green "
+        "tests (claude/RULES-ARCHIVE.md, audit-fix-resets-gate).\n"
+        "  Restore the order, or re-point this test deliberately and say in the "
+        "commit how a reader still meets the bounding rule first."
+    )
+
+
+def test_the_attribution_measurement_survives_where_the_skill_routes_to_it():
+    """🔴 The rule is only as good as the measurement it rests on.
+
+    The skill body carries one line of it; the rest was demoted to the skill's
+    reference/ dir to pay for the rule's bytes. Two ways that goes wrong, both
+    pinned: the evidence file is deleted or emptied (the rule then rests on an
+    anecdote), or the body routes to it with a path that does not RESOLVE for
+    the reader -- a devrc skill is read from ~/.claude/skills/<name>/ by an agent
+    whose cwd is some unrelated project, so a bare `reference/x.md` opens
+    nothing (scripts/tests/test_doc_path_rot.py, rule 1c).
+    """
+    assert EVIDENCE_MD.is_file(), (
+        f"{EVIDENCE_MD.relative_to(REPO_ROOT)} is missing -- the attribution "
+        "gate's measurement lives there and the SKILL.md body only summarises "
+        "it in one line. Restore it, or move the measurement back into the "
+        "body and re-point this test."
+    )
+    _assert_pinned_once(SKILL_MD, SKILL_ROUTES_TO_EVIDENCE, "the evidence route")
+    _assert_pinned_once(EVIDENCE_MD, EVIDENCE_CHURN_ROW, "the #498 churn row")
+    _assert_pinned_once(
+        EVIDENCE_MD, EVIDENCE_DIFFERENT_AXIS, "the different-axis distinction"
+    )
 
 
 def test_the_stop_rule_shares_a_bullet_with_the_rule_it_bounds():

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -302,13 +302,25 @@ recorded as SURVIVED off an 11-passed run.
                                                 lesson was pinned WHOLE
 
   added after the eighth audit -- the first two are the CHECKLIST, unpinned for
-  eight rounds while every round shaved words out of it to stay under budget:
+  eight rounds while every round FROM THE FIFTH ON shaved words out of it to
+  stay under budget (measured: 4 of the 8 pre-fix commits touched the block):
   S1   "rollback" shaved out of the Gaps item  1 failed  <- the actual regression
   S2   the whole 9-item checklist replaced
        with "whatever seems off" ............. 1 failed
   S3   stderr-capture rule INVERTED ("fold it
        into the sum so nothing escapes") ..... 1 failed
   S4   reworded-rule regression shape deleted   1 failed
+
+  added after the ninth audit -- two pins that certified PRESENCE without
+  certifying the instruction around them:
+  N1   delta-bullet HEAD inverted to "do NOT
+       hunt", pinned phrase byte-identical ... 1 failed
+  N2   the other regression shapes deleted,
+       phrase intact ......................... 1 failed
+  P1   worktree duty shifted back to the
+       auditee (round 8's regression, exactly)  1 failed
+  P2   environment-brief lead gutted ......... 1 failed
+  P3   zsh word-split warning deleted ........ 1 failed
 
   the round-1 set, re-run against current strings:
   X3   gate command -> `echo 0` ............... 1 failed
@@ -558,8 +570,9 @@ SKILL_GATE_NO_PATHSPEC = (
     "`FooTest.java` and `*.cy.ts` (measured)."
 )
 
-# The other two operator instructions this rule ships. Both survived a mutant
-# that deleted them outright before these pins existed.
+# The operator instructions this rule ships -- count them below rather than
+# trusting a number here. Every one was added after a mutant deleted or inverted
+# it with the suite green.
 # 🔴 THE CHECKLIST ITSELF. Nine numbered items, pinned as one whole string --
 # this is the operational core of the skill and it was UNPINNED through eight
 # rounds. Measured: replacing the entire block with "**Audit for:** whatever
@@ -594,10 +607,36 @@ SKILL_STDERR_CAPTURE = (
     "Keep stderr on the terminal — folding it into the sum with `2>&1` makes "
     "the one loud failure invisible."
 )
-# The regression shape this PR itself produced twice, added to the re-auditor's
-# checklist and unpinned until now.
+# The regression shape this PR itself produced twice. 🔴 Pinned as the WHOLE
+# bullet, not the phrase: a mid-sentence pin certifies the phrase is PRESENT,
+# not that the instruction around it still tells the re-auditor to hunt.
+# Measured with only the phrase pinned -- inverting the bullet head to "do NOT
+# spend the round hunting regressions the fix round itself introduced", and
+# deleting the other two regression shapes, were both GREEN with the phrase
+# byte-identical. Same lesson as EVIDENCE_LESSON_BC, one file over.
 SKILL_REWORD_REGRESSION = (
-    "**the rule reworded wider on one axis and narrower on another**"
+    "- hunt for **regressions the fix round itself introduced** — the guard "
+    "that's too strict, the branch that's unreachable, the narrowed check that "
+    "now rejects a legitimate case, **the rule reworded wider on one axis and "
+    "narrower on another**;"
+)
+# 🔴 THE ENVIRONMENT BRIEF, pinned whole. It is payload -- what the operator is
+# told to put in front of the auditor -- and it was reworded in FOUR of this
+# PR's nine commits, every time under byte pressure. Measured unpinned: gutting
+# its lead to "do not bother briefing the auditor", deleting the zsh word-split
+# warning, and re-applying the exact worktree-duty regression round 8 diagnosed
+# (shifting "verify your worktree clean YOURSELF" back to "leave your worktree
+# clean", i.e. from the operator to the auditee) were ALL green.
+SKILL_ENVIRONMENT_BRIEF = (
+    "**Brief the auditor on the environment, or it will report false findings** "
+    "— a fresh worktree is not a working checkout, and an auditor hitting this "
+    "cold blames the PR. Whichever apply: **submodules are unpopulated** in a "
+    "new worktree (one made 4 test files \"fail to collect\"); **monorepo "
+    "`node_modules`** may need linking per package, not just at the root; "
+    "**whether the base branch is already red** and *at which file*; and that "
+    "**zsh does not word-split unquoted parameters**, so `eslint $FILES` checks "
+    "**zero** files and prints a confident PASS. Have it mutate only in a `cp "
+    "-a` copy, and verify your worktree clean yourself at the end."
 )
 SKILL_LEDGER = (
     "**Carry the ledger in every round's summary**: `round N · payload lines "
@@ -994,8 +1033,8 @@ def test_the_gate_pins_its_MECHANISM_not_only_its_decision():
     )
 
 
-def test_the_two_operator_instructions_the_gate_depends_on_are_pinned():
-    """The ledger and the finding labels, each of which survived deletion.
+def test_the_operator_instructions_the_gate_depends_on_are_pinned():
+    """The instructions a reader ACTS on, each of which survived deletion.
 
     Neither is decorative. The ledger's X IS the number the gate reads -- it
     carries the per-round count into the summary a human actually sees, which is
@@ -1016,6 +1055,9 @@ def test_the_two_operator_instructions_the_gate_depends_on_are_pinned():
     )
     _assert_pinned_once(
         SKILL_MD, SKILL_REWORD_REGRESSION, "the reworded-rule regression shape"
+    )
+    _assert_pinned_once(
+        SKILL_MD, SKILL_ENVIRONMENT_BRIEF, "the environment brief"
     )
 
 

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -256,9 +256,10 @@ recorded as SURVIVED off an 11-passed run.
                                                   so the pin held the
                                                   contradiction in place
   W2   dated measurement -> vague "many" ....... 1 failed
-  W3   "`--no-merges` has one cost" -> "has no
-       cost" .................................. 1 failed  <- SURVIVED until the
-                                                  blind spot was pinned
+  W3   the wrong-flag prohibition inverted
+       ("do reach for --no-merges
+       --first-parent") ....................... 1 failed  <- SURVIVED until the
+                                                  trap was pinned
   W4   evidence truncated to 1,520 B ......... 1 failed  <- the FLOOR passes;
                                                   the pin's message names the
                                                   file size, which is what
@@ -270,6 +271,14 @@ recorded as SURVIVED off an 11-passed run.
                                                   UnicodeDecodeError traceback,
                                                   which is what `errors=
                                                   "replace"` in `_read` buys
+
+  added after the fifth audit -- every one of these was a rule the previous
+  round shipped UNPINNED, and each mutant below was green before it:
+  V1   `<base>` redefined as the fork point ... 1 failed
+  V2   "a failed command is not zero" inverted  1 failed
+  V3   shape-C row rewritten to erase the
+       argument for the current command ....... 1 failed
+  V4   PR-population row rewritten to 2 of 40 . 1 failed
 
   the round-1 set, re-run against current strings:
   X3   gate command -> `echo 0` ............... 1 failed
@@ -453,22 +462,41 @@ SKILL_PAYLOAD_DEFINITION = (
     "round wrote to guard it. For a code change the payload is source and a "
     "`.md` is not — but **for a docs or skill PR the payload IS the `.md`**"
 )
-# 🔴 The measurement the payload definition rests on, pinned WITH its date --
-# the PR list moves as PRs merge, so this is a timestamped measurement and not a
-# constant. It was `24` for one commit, carried over from a subagent's report
-# without being re-derived; re-measured here at 25/40 on 2026-08-26. Method in
-# the reference file.
-# 🔴 The flag's OWN blind spot, pinned because disclaiming it is the cheap edit.
-# `--no-merges` is what keeps a `merge main` from being counted as this round's
-# payload -- and it also makes payload hand-written INTO a merge conflict
-# resolution invisible (measured: 0, where the two-dot form read 340). That is
-# the UNSAFE direction: the gate reads zero on a round that did change payload.
-# Measured: rewriting "has one cost" to "has no cost" left the suite green.
+# 🔴 The WRONG-FLAG trap, pinned because reaching for it is the natural edit: a
+# reader who wants to exclude a `merge main` reaches for `--no-merges
+# --first-parent`, which looks equivalent and reads ZERO for a fix committed on
+# a side branch and merged `--no-ff` -- the shape agent worktrees produce -- so
+# the gate fires on a ladder whose payload is still moving. It also misses
+# payload hand-written into a merge-conflict resolution. Both measured; the
+# four-shape table is in the reference file. This constant shipped TWICE with
+# wording that credited `--no-merges` with the job `--not <base>` actually does,
+# which is why the sentence pinned here is the prohibition and not a rationale.
 SKILL_WRONG_FLAGS_TRAP = (
     "Do **not** reach for `--no-merges --first-parent`: it looks equivalent and "
-    "hides payload in BOTH of those shapes — **0** for a fix committed on a "
-    "side branch and merged `--no-ff`, which is the shape agent worktrees "
-    "produce."
+    "reads **0** for a fix committed on a side branch and merged `--no-ff` — "
+    "the shape agent worktrees produce."
+)
+# 🔴 QUALITATIVE on purpose. This claim carried a number through two rounds and
+# the number was wrong both times -- first `24` copied from a subagent's report
+# without re-derivation, then a correctly-measured `25` that read `24` again two
+# hours later because PRs kept merging. The dated measurement, both selection
+# commands and the classifier live in the reference file; what is pinned here is
+# the part that does not decay.
+# 🔴 `<base>` and the failed-command rule. Both are new because both were found
+# by measurement, not reasoning: a base ref ONE COMMIT stale re-reports the whole
+# upstream bring-in (201 where the truth was 1), and every way the command can
+# fail -- a missing ref (rc 128, empty stdout), an unwritable object store
+# (`--remerge-diff` under-counts and still exits 0) -- produces a number that
+# sums to ZERO, which is indistinguishable from the gate's own stop verdict.
+SKILL_BASE_DEFINITION = (
+    "🔴 **`<base>` is the CURRENT tip you would merge into** (`origin/main`), "
+    "never the fork point: one commit stale and the whole bring-in is "
+    "re-reported as this round's payload (201 where the truth was 1, measured)."
+)
+SKILL_FAILED_IS_NOT_ZERO = (
+    "And **a failed command is not zero** — a missing ref exits 128 with empty "
+    "output, and `--remerge-diff` under-counts and still exits 0 when the object "
+    "store is unwritable. Confirm it printed something before believing a zero."
 )
 SKILL_PAYLOAD_MEASUREMENT = (
     "**most of this repo's merged PRs ship no source file at all** (measured; "
@@ -522,6 +550,19 @@ EVIDENCE_CHURN_ROW = (
 # 🔴 The row the corrections were ABOUT, pinned too. Without it the numbers can
 # drift back while the correction sentence below still narrates having fixed
 # them -- measured: rewriting this row to 9999s left the suite green.
+# 🔴 The two rows that ARE the argument for the current command. Measured: with
+# only the #498 pins in place, rewriting shape C's `0` to `51` -- which deletes
+# the entire reason the command changed -- left the suite green, as did blanking
+# the four-shape table's first row and rewriting the PR-population count. The
+# body delegates both numbers to this file, so the file has to be pinned too.
+EVIDENCE_SHAPE_C_ROW = (
+    "| C. the round's fix is 50 payload lines on a side branch, merged "
+    "`--no-ff` | ~50 | 51 | **0** | 51 |"
+)
+EVIDENCE_PR_POPULATION_ROW = (
+    "| `gh pr list --state merged --limit 40` (sorts by CREATED) | 24 | 16 | 7 "
+    "| 1 |"
+)
 EVIDENCE_BASELINE_ROW = (
     "| feature + rounds 1–3 (`bce0c0c`…`d2ec92d`) | 961 | 110 | 222 |"
 )
@@ -784,6 +825,12 @@ def test_the_attribution_measurement_survives_where_the_skill_routes_to_it():
         EVIDENCE_MD, EVIDENCE_BASELINE_ROW, "the #498 baseline churn row"
     )
     _assert_pinned_once(
+        EVIDENCE_MD, EVIDENCE_SHAPE_C_ROW, "the shape-C range measurement"
+    )
+    _assert_pinned_once(
+        EVIDENCE_MD, EVIDENCE_PR_POPULATION_ROW, "the PR-population measurement"
+    )
+    _assert_pinned_once(
         EVIDENCE_MD, EVIDENCE_TABLE_CORRECTION, "the churn-table correction"
     )
     _assert_pinned_once(
@@ -802,9 +849,12 @@ def test_the_gate_pins_its_MECHANISM_not_only_its_decision():
 
     That is not a hypothetical. The first version of this gate shipped a
     CUMULATIVE range, which a per-round condition cannot consume -- on #498 it
-    prints the same non-zero number for rounds 4 through 10. Three pins, because
-    the mechanism has three parts that can each be wrong on their own: WHICH
-    RANGE, HOW LINES ARE CLASSIFIED, and the DECISION over the result.
+    prints the same non-zero number for rounds 4 through 10, and the second
+    shipped `--no-merges --first-parent`, which reads ZERO for a fix merged from
+    a side branch. SEVEN pins, because that many parts of the mechanism have
+    each been found wrong on their own: WHICH RANGE, WHAT `<base>` IS, WHAT
+    COUNTS AS PAYLOAD, HOW THE LINES ARE CLASSIFIED, WHICH FLAGS ARE THE TRAP,
+    the measurement under it, and the DECISION over the result.
     """
     _assert_pinned_once(SKILL_MD, SKILL_GATE_COMMAND, "the gate's command")
     _assert_pinned_once(SKILL_MD, SKILL_GATE_PER_ROUND, "the per-round rule")
@@ -822,6 +872,10 @@ def test_the_gate_pins_its_MECHANISM_not_only_its_decision():
     )
     _assert_pinned_once(
         SKILL_MD, SKILL_GATE_NO_PATHSPEC, "the pathspec counter-evidence"
+    )
+    _assert_pinned_once(SKILL_MD, SKILL_BASE_DEFINITION, "what `<base>` is")
+    _assert_pinned_once(
+        SKILL_MD, SKILL_FAILED_IS_NOT_ZERO, "the failed-command-is-not-zero rule"
     )
 
 

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -161,7 +161,13 @@ rule rather than reformatting a paragraph.
    What remains unenforceable: whether a given round's files were named
    CORRECTLY. Nothing mechanical can answer that, which is why the residual
    error is aimed at the safe side (ambiguous => the gate does not fire).
-7. **The THRESHOLD is pinned, not justified.** "Two consecutive rounds" comes
+7. **The evidence file is pinned ROW BY ROW, so a row nobody pinned is
+   unguarded.** Six of its numbers and both of its lessons are pinned; shape D
+   (the positive control) and shape B's row are not, and neither is any prose
+   outside those sentences. A row added later is unguarded until someone pins
+   it, and nothing here notices. The pattern to follow: if the body delegates a
+   number to that file, the row carrying it gets a constant in the same commit.
+8. **The THRESHOLD is pinned, not justified.** "Two consecutive rounds" comes
    from one measured ladder (#498, n=1), where the plateau began at round 4 and
    ran to 10. One round is knowingly too tight: a round may legitimately fix only
    a guard. Whether two is right is a judgement, and this module cannot tell a
@@ -279,6 +285,15 @@ recorded as SURVIVED off an 11-passed run.
   V3   shape-C row rewritten to erase the
        argument for the current command ....... 1 failed
   V4   PR-population row rewritten to 2 of 40 . 1 failed
+
+  added after the sixth audit -- the evidence file was pinned ROW BY ROW, so the
+  rows and lessons nobody had pinned were still rewritable:
+  U1   shape-A row blanked ................... 1 failed
+  U1b  shape-A row INVERTED so the table
+       argues FOR the flag the body
+       prohibits .............................. 1 failed  <- the sharp one
+  U6   shape-A lesson negated ................ 1 failed
+  U7   shape-B/C lesson negated ............... 1 failed
 
   the round-1 set, re-run against current strings:
   X3   gate command -> `echo 0` ............... 1 failed
@@ -482,21 +497,31 @@ SKILL_WRONG_FLAGS_TRAP = (
 # hours later because PRs kept merging. The dated measurement, both selection
 # commands and the classifier live in the reference file; what is pinned here is
 # the part that does not decay.
-# 🔴 `<base>` and the failed-command rule. Both are new because both were found
-# by measurement, not reasoning: a base ref ONE COMMIT stale re-reports the whole
-# upstream bring-in (201 where the truth was 1), and every way the command can
-# fail -- a missing ref (rc 128, empty stdout), an unwritable object store
-# (`--remerge-diff` under-counts and still exits 0) -- produces a number that
-# sums to ZERO, which is indistinguishable from the gate's own stop verdict.
+# 🔴 `<base>` and the failed-command rule. Both were found by measurement, not
+# reasoning, and both were WIDENED by the next round's measurement:
+#   - `origin/main` is only as current as the last fetch, so defining <base> as
+#     that ref without saying to fetch it leaves the same defect one level down.
+#     A base at the FORK POINT re-reports the whole bring-in (201 vs a truth of
+#     1); one commit stale re-reports its tail -- "the whole bring-in" was a
+#     property of the first fixture, not of staleness.
+#   - "confirm it printed something" is NOT sufficient: a missing ref and a git
+#     without `--remerge-diff` do give rc 128 and empty stdout, but an unwritable
+#     object store makes `--remerge-diff` under-count, exit 0 and print a
+#     PLAUSIBLE number, announcing the failure only on stderr. Hence rc 0 AND
+#     silent stderr.
 SKILL_BASE_DEFINITION = (
-    "🔴 **`<base>` is the CURRENT tip you would merge into** (`origin/main`), "
-    "never the fork point: one commit stale and the whole bring-in is "
-    "re-reported as this round's payload (201 where the truth was 1, measured)."
+    "🔴 **`<base>` is the CURRENT tip you would merge into — `git fetch` it "
+    "first.** A local `origin/main` is exactly as current as your last fetch, "
+    "and a stale one re-reports upstream work as this round's payload: at the "
+    "fork point the entire bring-in (201 where the truth was 1), one commit "
+    "behind, its tail."
 )
 SKILL_FAILED_IS_NOT_ZERO = (
-    "And **a failed command is not zero** — a missing ref exits 128 with empty "
-    "output, and `--remerge-diff` under-counts and still exits 0 when the object "
-    "store is unwritable. Confirm it printed something before believing a zero."
+    "And **a failed command is not zero — require rc 0 AND silent stderr.** A "
+    "missing ref or a git without `--remerge-diff` exits 128 with empty output; "
+    "an unwritable object store is worse, because `--remerge-diff` then "
+    "under-counts, **exits 0 and prints a plausible number**, saying so only on "
+    "stderr."
 )
 SKILL_PAYLOAD_MEASUREMENT = (
     "**most of this repo's merged PRs ship no source file at all** (measured; "
@@ -550,11 +575,13 @@ EVIDENCE_CHURN_ROW = (
 # 🔴 The row the corrections were ABOUT, pinned too. Without it the numbers can
 # drift back while the correction sentence below still narrates having fixed
 # them -- measured: rewriting this row to 9999s left the suite green.
-# 🔴 The two rows that ARE the argument for the current command. Measured: with
-# only the #498 pins in place, rewriting shape C's `0` to `51` -- which deletes
-# the entire reason the command changed -- left the suite green, as did blanking
-# the four-shape table's first row and rewriting the PR-population count. The
-# body delegates both numbers to this file, so the file has to be pinned too.
+# 🔴 The rows that ARE the argument for the current command, and the sentences
+# that read them. The body delegates these numbers to this file, so the file has
+# to be pinned too -- measured: with only the #498 pins in place, rewriting shape
+# C's `0` to `51` (which deletes the entire reason the command changed), blanking
+# shape A's row, INVERTING shape A's row so the table argues FOR the flag the
+# body prohibits, rewriting the PR-population count, and negating either lesson
+# bullet were ALL green. The first fix pinned two of those; the rest are here.
 EVIDENCE_SHAPE_C_ROW = (
     "| C. the round's fix is 50 payload lines on a side branch, merged "
     "`--no-ff` | ~50 | 51 | **0** | 51 |"
@@ -563,6 +590,27 @@ EVIDENCE_PR_POPULATION_ROW = (
     "| `gh pr list --state merged --limit 40` (sorts by CREATED) | 24 | 16 | 7 "
     "| 1 |"
 )
+EVIDENCE_SHAPE_A_ROW = (
+    "| A. clean `merge main` brings 200 upstream lines; the round's own fix is "
+    "1 test line | 1 line, and it is a TEST ⇒ 0 payload | **201** | 1 | 1 |"
+)
+# The two sentences that tell a reader what the table MEANS. A table can be
+# correct and useless if the lesson beside it is negated -- both of these were
+# rewritable to the opposite claim with every row pin still green.
+EVIDENCE_LESSON_A = (
+    "**A** is why the range needs `--not <base>` — a two-dot diff attributes the "
+    "whole upstream bring-in to this round, the gate never fires, and the ladder "
+    "runs forever."
+)
+EVIDENCE_LESSON_BC = (
+    "**B and C** are why `--no-merges --first-parent` is NOT the fix, though it "
+    "looks like one and shipped as one for a round: it reads **0** for a fix "
+    "committed on a side branch and merged `--no-ff`"
+)
+# 🔴 Z8's own constant: the corrected #498 baseline row. Pinned because rewriting
+# it to 9999s was green while the correction sentence below still narrated having
+# fixed it. (This comment sat orphaned from its constant for one round, which is
+# the defect it exists to record -- do not insert new constants between them.)
 EVIDENCE_BASELINE_ROW = (
     "| feature + rounds 1–3 (`bce0c0c`…`d2ec92d`) | 961 | 110 | 222 |"
 )
@@ -828,6 +876,11 @@ def test_the_attribution_measurement_survives_where_the_skill_routes_to_it():
         EVIDENCE_MD, EVIDENCE_SHAPE_C_ROW, "the shape-C range measurement"
     )
     _assert_pinned_once(
+        EVIDENCE_MD, EVIDENCE_SHAPE_A_ROW, "the shape-A range measurement"
+    )
+    _assert_pinned_once(EVIDENCE_MD, EVIDENCE_LESSON_A, "the shape-A lesson")
+    _assert_pinned_once(EVIDENCE_MD, EVIDENCE_LESSON_BC, "the shape-B/C lesson")
+    _assert_pinned_once(
         EVIDENCE_MD, EVIDENCE_PR_POPULATION_ROW, "the PR-population measurement"
     )
     _assert_pinned_once(
@@ -851,10 +904,12 @@ def test_the_gate_pins_its_MECHANISM_not_only_its_decision():
     CUMULATIVE range, which a per-round condition cannot consume -- on #498 it
     prints the same non-zero number for rounds 4 through 10, and the second
     shipped `--no-merges --first-parent`, which reads ZERO for a fix merged from
-    a side branch. SEVEN pins, because that many parts of the mechanism have
-    each been found wrong on their own: WHICH RANGE, WHAT `<base>` IS, WHAT
-    COUNTS AS PAYLOAD, HOW THE LINES ARE CLASSIFIED, WHICH FLAGS ARE THE TRAP,
-    the measurement under it, and the DECISION over the result.
+    a side branch. One pin per constant below -- count them rather than trusting
+    a total here, which is this PR's own rule and was violated twice: the number
+    said THREE when the test made seven, was corrected to SEVEN in the same
+    commit that made it nine, and each part it names -- the range, what `<base>`
+    is, what counts as payload, how lines are classified, which flags are the
+    trap, the measurement under it -- has been found wrong on its own.
     """
     _assert_pinned_once(SKILL_MD, SKILL_GATE_COMMAND, "the gate's command")
     _assert_pinned_once(SKILL_MD, SKILL_GATE_PER_ROUND, "the per-round rule")

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -162,9 +162,9 @@ rule rather than reformatting a paragraph.
    CORRECTLY. Nothing mechanical can answer that, which is why the residual
    error is aimed at the safe side (ambiguous => the gate does not fire).
 7. **The evidence file is pinned ROW BY ROW, so a row nobody pinned is
-   unguarded.** Six of its numbers and both of its lessons are pinned; shape D
-   (the positive control) and shape B's row are not, and neither is any prose
-   outside those sentences. A row added later is unguarded until someone pins
+   unguarded.** The `EVIDENCE_*` constants below are the whole of it -- count
+   them; shape D (the positive control) and shape B's row are NOT among them,
+   and neither is any prose outside those sentences. A row added later is unguarded until someone pins
    it, and nothing here notices. The pattern to follow: if the body delegates a
    number to that file, the row carrying it gets a constant in the same commit.
 8. **The THRESHOLD is pinned, not justified.** "Two consecutive rounds" comes
@@ -294,6 +294,12 @@ recorded as SURVIVED off an 11-passed run.
        prohibits .............................. 1 failed  <- the sharp one
   U6   shape-A lesson negated ................ 1 failed
   U7   shape-B/C lesson negated ............... 1 failed
+
+  added after the seventh audit:
+  T1   the empty-range clause deleted ......... 1 failed  <- the check the
+                                                previous rewrite dropped
+  T2   the B/C lesson's TAIL inverted ......... 1 failed  <- green until the
+                                                lesson was pinned WHOLE
 
   the round-1 set, re-run against current strings:
   X3   gate command -> `echo 0` ............... 1 failed
@@ -511,17 +517,18 @@ SKILL_WRONG_FLAGS_TRAP = (
 #     silent stderr.
 SKILL_BASE_DEFINITION = (
     "🔴 **`<base>` is the CURRENT tip you would merge into — `git fetch` it "
-    "first.** A local `origin/main` is exactly as current as your last fetch, "
-    "and a stale one re-reports upstream work as this round's payload: at the "
-    "fork point the entire bring-in (201 where the truth was 1), one commit "
-    "behind, its tail."
+    "first.** A local `origin/main` is only as current as your last fetch, and "
+    "a stale one re-reports upstream work as this round's payload: the whole "
+    "bring-in from the fork point (201 where the truth was 1), its tail from "
+    "one commit behind."
 )
 SKILL_FAILED_IS_NOT_ZERO = (
-    "And **a failed command is not zero — require rc 0 AND silent stderr.** A "
-    "missing ref or a git without `--remerge-diff` exits 128 with empty output; "
-    "an unwritable object store is worse, because `--remerge-diff` then "
-    "under-counts, **exits 0 and prints a plausible number**, saying so only on "
-    "stderr."
+    "And **a zero you did not watch the command EARN is not a zero — require rc "
+    "0, silent stderr, and a non-empty range.** A missing ref or a git without "
+    "`--remerge-diff` exits 128 with empty output; an unwritable object store is "
+    "worse, because `--remerge-diff` then under-counts, **exits 0 and prints a "
+    "plausible number**, saying so only on stderr; and a range whose commits are "
+    "simply not in this checkout yet prints nothing, silently, with rc 0."
 )
 SKILL_PAYLOAD_MEASUREMENT = (
     "**most of this repo's merged PRs ship no source file at all** (measured; "
@@ -572,9 +579,6 @@ SKILL_ROUTES_TO_EVIDENCE = (
 EVIDENCE_CHURN_ROW = (
     "| **rounds 4–10** (`a82718b`…`7541bc1`) | **1,051** | **0** | **0** |"
 )
-# 🔴 The row the corrections were ABOUT, pinned too. Without it the numbers can
-# drift back while the correction sentence below still narrates having fixed
-# them -- measured: rewriting this row to 9999s left the suite green.
 # 🔴 The rows that ARE the argument for the current command, and the sentences
 # that read them. The body delegates these numbers to this file, so the file has
 # to be pinned too -- measured: with only the #498 pins in place, rewriting shape
@@ -602,10 +606,18 @@ EVIDENCE_LESSON_A = (
     "whole upstream bring-in to this round, the gate never fires, and the ladder "
     "runs forever."
 )
+# 🔴 Pinned WHOLE, tail included. The first version stopped at "merged
+# `--no-ff`" -- and the tail could then be rewritten to "a shape that
+# essentially never occurs, so prefer it" with the suite green, which is the
+# same inversion U1b exists to prevent, one clause later in the same bullet.
 EVIDENCE_LESSON_BC = (
     "**B and C** are why `--no-merges --first-parent` is NOT the fix, though it "
     "looks like one and shipped as one for a round: it reads **0** for a fix "
-    "committed on a side branch and merged `--no-ff`"
+    "committed on a side branch and merged `--no-ff` — the shape agent "
+    "worktrees produce — so the gate fires and stops a ladder whose payload is "
+    "still moving. `git show --numstat <merge>` is not the remedy either: it "
+    "prints the first-parent diff, so on shape A it reports every upstream line "
+    "as this round's work."
 )
 # 🔴 Z8's own constant: the corrected #498 baseline row. Pinned because rewriting
 # it to 9999s was green while the correction sentence below still narrated having

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -301,6 +301,15 @@ recorded as SURVIVED off an 11-passed run.
   T2   the B/C lesson's TAIL inverted ......... 1 failed  <- green until the
                                                 lesson was pinned WHOLE
 
+  added after the eighth audit -- the first two are the CHECKLIST, unpinned for
+  eight rounds while every round shaved words out of it to stay under budget:
+  S1   "rollback" shaved out of the Gaps item  1 failed  <- the actual regression
+  S2   the whole 9-item checklist replaced
+       with "whatever seems off" ............. 1 failed
+  S3   stderr-capture rule INVERTED ("fold it
+       into the sum so nothing escapes") ..... 1 failed
+  S4   reworded-rule regression shape deleted   1 failed
+
   the round-1 set, re-run against current strings:
   X3   gate command -> `echo 0` ............... 1 failed
   X4   ledger instruction deleted ............. 1 failed
@@ -551,6 +560,45 @@ SKILL_GATE_NO_PATHSPEC = (
 
 # The other two operator instructions this rule ships. Both survived a mutant
 # that deleted them outright before these pins existed.
+# 🔴 THE CHECKLIST ITSELF. Nine numbered items, pinned as one whole string --
+# this is the operational core of the skill and it was UNPINNED through eight
+# rounds. Measured: replacing the entire block with "**Audit for:** whatever
+# seems off." left the suite green.
+#
+# It is also the MECHANISM behind the worst regression of this PR. Every round
+# paid for new rules by shaving words out of exactly this region to stay under
+# the byte budget, and one of those shaves deleted "rollback" from item 4 while
+# the commit message claimed to have RESTORED it -- a multi-edit script whose
+# later assertion failed before its write, so the restore never landed and the
+# claim was written from intent rather than from the diff. Nothing observed it.
+# A reader of that message would believe the word was there and not look.
+#
+# Pinning the block whole means the next shave fails loudly, in the same commit.
+SKILL_AUDIT_CHECKLIST = (
+    "**Audit for:** 1. **Risks** — what breaks in production. 2. "
+    "**Regressions** — behaviour this silently alters or removes. 3. "
+    "**Assumptions** — unstated preconditions that may not hold. 4. **Gaps** — "
+    "error handling, edge cases, tests, migrations, rollback. 5. **Bugs** — "
+    "logic/correctness defects, with file:line. 6. **Issues** — quality, "
+    "maintainability, conventions. 7. **Behaviour changes** — observable "
+    "changes in output/API/UX, intended or not. If the PR claims to revert "
+    "behaviour, confirm it restores the pre-change state. 8. **Leaks** — "
+    "secrets, PII, resource/handle/memory, over-broad permissions. 9. "
+    "**Second-order consequences** — ripple effects on services, callers, data, "
+    "cost."
+)
+# The stderr-capture rule: deleting it, AND inverting it to "fold stderr into the
+# sum with 2>&1 so a failure cannot escape the count" (which reads plausible and
+# defeats the silent-stderr third of the rule beside it), were both green.
+SKILL_STDERR_CAPTURE = (
+    "Keep stderr on the terminal — folding it into the sum with `2>&1` makes "
+    "the one loud failure invisible."
+)
+# The regression shape this PR itself produced twice, added to the re-auditor's
+# checklist and unpinned until now.
+SKILL_REWORD_REGRESSION = (
+    "**the rule reworded wider on one axis and narrower on another**"
+)
 SKILL_LEDGER = (
     "**Carry the ledger in every round's summary**: `round N · payload lines "
     "changed THIS round: X (since round 1: Y) · elapsed: Z`."
@@ -960,6 +1008,15 @@ def test_the_two_operator_instructions_the_gate_depends_on_are_pinned():
     """
     _assert_pinned_once(SKILL_MD, SKILL_LEDGER, "the per-round ledger")
     _assert_pinned_once(SKILL_MD, SKILL_FINDING_LABELS, "the finding labels")
+    _assert_pinned_once(
+        SKILL_MD, SKILL_AUDIT_CHECKLIST, "the nine-item audit checklist"
+    )
+    _assert_pinned_once(
+        SKILL_MD, SKILL_STDERR_CAPTURE, "the stderr-capture rule"
+    )
+    _assert_pinned_once(
+        SKILL_MD, SKILL_REWORD_REGRESSION, "the reworded-rule regression shape"
+    )
 
 
 def test_the_stop_rule_shares_a_bullet_with_the_rule_it_bounds():

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -59,30 +59,39 @@ them in the preceding 14 days**; mean deepest round 4.0; 34% ran >= 5 rounds.
 So the gate is: two consecutive rounds whose FIXES changed zero PAYLOAD lines
 => the ladder has left the PR, stop. Payload = what the PR exists to ship, never
 a file type: keyed to "docs are not production" the gate reads zero for every
-round of a docs or skill PR and stops a working ladder. Measured 2026-08-26: of
-the 40 most recently merged devrc PRs, **25 shipped no source file at all** (17
-of those docs-only) -- this PR among them. That figure is dated because the list
-moves; an earlier `24` here came from a subagent's report and was written in
-without being re-derived.
+round of a docs or skill PR and stops a working ladder -- and most of what this
+repo merges is exactly that. The measurement is in the reference file with its
+date, its selection command and its classifier, because it MOVES: it read 25 of
+40 and then 24 of 40 within two hours as PRs merged, and an earlier `24` in the
+body had come from a subagent's report without being re-derived. A number that
+changes with the clock does not belong in a rule.
 
-**Per-round, and the round's OWN commits** -- anchored at round 1 the count is
-non-zero forever once an early round touched payload (the first version of this
-rule shipped exactly that: on #498 it prints the same number for rounds 4-10 and
-never fires), while a plain two-dot `git diff` sweeps in whatever a `merge main`
-or a rebase brought with it and reads 200 upstream lines as this round's payload.
-Hence `git log --numstat --format= --no-merges --first-parent <sha>..HEAD`.
-Measured on a purpose-built scratch repo -- one round whose only fix was a single
-line of `app_test.go`, then `git merge main` bringing 200 upstream lines of
-`other.go`: the two-dot form reports `1 + 200`, this form reports `1`. The flag
-has a cost of its own, stated in the skill: payload written INTO a merge conflict
-resolution is invisible to `--no-merges` (measured 0 where the two-dot form read
-340), so a round whose fix landed that way must count that merge explicitly.
+**Per-round, and every commit the round actually made.** Anchored at round 1 the
+count is non-zero forever once an early round touched payload -- the first
+version of this rule shipped exactly that, and on #498 it prints the same number
+for rounds 4-10 and never fires. The second version shipped
+`--no-merges --first-parent`, which is WRONG in the other direction. Measured
+across four shapes (full table in the reference file; git 2.55.0):
+
+  shape                                    truth  two-dot  --no-merges   --remerge-diff
+                                                           --first-parent  --not <base>
+  A clean `merge main`, fix = 1 test line    0      201        1              1
+  B payload in a merge-CONFLICT resolution  >0       30        1 (!)         37
+  C fix on a side branch, merged --no-ff    ~50      51        0 (!)         51
+  D control: 12 payload lines, linear        13      13       13             13
+
+So: `--not <base>` is what excludes the upstream bring-in, `--remerge-diff` is
+what makes conflict-resolution payload visible, and `--no-merges --first-parent`
+reads ZERO for a fix committed on a side branch and merged `--no-ff` -- the shape
+agent worktrees produce -- which fires the gate on a ladder whose payload is
+still moving. `git show --numstat <merge>` is not a remedy either: it prints the
+first-parent diff, so on shape A it reports every upstream line as this round's.
 
 It is not a cap (it counts payload lines, never rounds; a round that touches
 payload never trips it however deep the ladder is) and it does not retract the
 retraction below -- #498 contains no round that ran and found nothing, which is
-the waste that retraction denies.
-Different axis: real findings about scaffolding the ladder itself had written.
+the waste that retraction denies. Different axis: real findings about scaffolding
+the ladder itself had written.
 
 🔴 WHY THIS MODULE ALSO GUARDS THE COUNTER-EVIDENCE
 ---------------------------------------------------
@@ -206,7 +215,8 @@ every whole-string pin stays GREEN and only
 what proves that assertion executes and is not a second spelling of the string
 pin it sits beside.
 
-THE ATTRIBUTION-GATE PINS -- their own matrix (2026-08-26, 5 tests added, 6 -> 11)
+THE ATTRIBUTION-GATE PINS -- their own matrix (2026-08-26, 5 tests added, 6 -> 11;
+22 mutants at the fourth round of review)
 ---------------------------------------------------------------------------------
 Same method: each run on its OWN scratch tree built from HEAD, never the
 worktree, under `PYTHONDONTWRITEBYTECODE=1` with the pytest cache disabled, and
@@ -249,12 +259,17 @@ recorded as SURVIVED off an 11-passed run.
   W3   "`--no-merges` has one cost" -> "has no
        cost" .................................. 1 failed  <- SURVIVED until the
                                                   blind spot was pinned
-  W4   evidence truncated to exactly the
-       1,500 B floor .......................... 1 failed  <- the FLOOR passes;
-                                                  the pin's message now names
-                                                  the file size, which is what
+  W4   evidence truncated to 1,520 B ......... 1 failed  <- the FLOOR passes;
+                                                  the pin's message names the
+                                                  file size, which is what
                                                   separates truncated from
                                                   reworded at any size
+  W5   truncation SPLITTING a multibyte
+       character (1,500 B) .................... 1 failed  <- and it still prints
+                                                  that message rather than a
+                                                  UnicodeDecodeError traceback,
+                                                  which is what `errors=
+                                                  "replace"` in `_read` buys
 
   the round-1 set, re-run against current strings:
   X3   gate command -> `echo 0` ............... 1 failed
@@ -406,17 +421,20 @@ SKILL_ATTRIBUTION_NOT_A_CAP = (
 # printed the same non-zero number for rounds 4 through 10 and never fired.
 # Caught in review; these three pins are what stop it coming back.
 SKILL_GATE_COMMAND = (
-    "git log --numstat --format= --no-merges --first-parent "
-    "<the sha you audited THAT round>..HEAD"
+    "git log --numstat --format= --remerge-diff "
+    "<the sha you audited THAT round>..HEAD --not <base>"
 )
 SKILL_GATE_PER_ROUND = (
-    "🔴 **Per-round and the round's OWN commits.** Anchored at round 1 the "
-    "count stays non-zero forever once an early round touched payload"
+    "🔴 **Per-round, and every commit the round actually made.** Anchored at "
+    "round 1 the count stays non-zero forever once an early round touched "
+    "payload"
 )
 
 # 🔴 THE CLASSIFIER, pinned as the INSTRUCTION it is -- not as the prohibition
 # beside it. Measured: with only the "do not use a pathspec" sentence pinned,
-# FIVE mutants passed a green 11-test suite, including one that deleted "read
+# FOUR mutants rewrote the method and passed a green 11-test suite (a fifth
+# survivor of that run, Z8, is the evidence family, caught by
+# EVIDENCE_BASELINE_ROW) -- including one that deleted "read
 # the list and name each one payload or scaffolding", one that flipped
 # "Ambiguous is not zero" to its opposite (reversing the fail-safe direction),
 # and one that reinstated the pathspec as the method while leaving the warning
@@ -424,8 +442,10 @@ SKILL_GATE_PER_ROUND = (
 #
 # The DEFINITION is the half that decides: keyed to file TYPE ("docs are not
 # production") the gate reads zero for every round of a docs or skill PR and
-# stops a working ladder -- measured at 24 of devrc's last 40 merged PRs, this
-# one included. Keyed to PAYLOAD it asks the question that matters: did this
+# stops a working ladder -- and most of what this repo merges is exactly that
+# (dated measurement, both selections, in the reference file; the figure moved
+# 25 -> 24 within two hours as PRs merged, which is why the body states it
+# qualitatively). Keyed to PAYLOAD it asks the question that matters: did this
 # round change what the PR ships, or only the guards the ladder wrote?
 SKILL_PAYLOAD_DEFINITION = (
     "🔴 **The unit is THIS PR's PAYLOAD, never a file extension.** Payload = "
@@ -444,15 +464,15 @@ SKILL_PAYLOAD_DEFINITION = (
 # resolution invisible (measured: 0, where the two-dot form read 340). That is
 # the UNSAFE direction: the gate reads zero on a round that did change payload.
 # Measured: rewriting "has one cost" to "has no cost" left the suite green.
-SKILL_NO_MERGES_COST = (
-    "**`--no-merges` has one cost**: payload hand-written into a merge "
-    "*conflict resolution* is invisible to it (measured: 0 where the old form "
-    "read 340), so if a round's fix landed that way, count that merge "
-    "explicitly with `git show --numstat <merge>`."
+SKILL_WRONG_FLAGS_TRAP = (
+    "Do **not** reach for `--no-merges --first-parent`: it looks equivalent and "
+    "hides payload in BOTH of those shapes — **0** for a fix committed on a "
+    "side branch and merged `--no-ff`, which is the shape agent worktrees "
+    "produce."
 )
 SKILL_PAYLOAD_MEASUREMENT = (
-    "on 2026-08-26 **25 of devrc's 40 most recently merged PRs shipped no "
-    "source at all**"
+    "**most of this repo's merged PRs ship no source file at all** (measured; "
+    "the reference file dates it)"
 )
 SKILL_CLASSIFIER_METHOD = (
     "A round's fix touches a handful of files — read the list and name each one "
@@ -534,18 +554,24 @@ def _norm(text: str) -> str:
 
 
 def _read(path: Path) -> str:
-    return path.read_text(encoding="utf-8")
+    # errors="replace", not strict: a truncation landing mid-character (likely
+    # in a file full of em-dashes and 🔴) would otherwise raise
+    # UnicodeDecodeError before any assert runs, and the reader gets a traceback
+    # instead of the message saying the file was truncated. Measured: truncating
+    # the evidence file to exactly 1,500 B does this.
+    return path.read_text(encoding="utf-8", errors="replace")
 
 
 def _assert_pinned_once(path: Path, claim: str, what: str) -> None:
     body = _norm(_read(path))
     count = body.count(_norm(claim))
     # 🔴 The size goes in the MESSAGE, not only in a floor. A byte floor can
-    # only ever sit below the LAST string it guards -- measured: a 1,500 B floor
-    # passed a truncation that had already eaten the first pinned row at byte
-    # 1,433, and any floor under 3,532 leaves a hole -- so the floor cannot be
-    # the thing that distinguishes "reworded" from "truncated". Reporting the
-    # file's actual size here does distinguish them, at every size, forever.
+    # only ever sit below the LAST string it guards, and every pin added later
+    # moves that boundary -- so no floor value distinguishes "reworded" from
+    # "truncated" for long. (The previous attempt quoted exact offsets; they
+    # were a commit out of date within one round, and the claim they carried was
+    # false at the tip.) Reporting the file's actual size here distinguishes
+    # them at any size, and needs no maintenance.
     size = len(path.read_bytes())
     assert count == 1, (
         f"\n\n{path.relative_to(REPO_ROOT)}: {what} is not present exactly once "
@@ -592,15 +618,15 @@ def test_the_guarded_files_exist_and_are_substantial():
         # exactly once as written (found 0)" and told the reader they had
         # REWORDED a sentence in a file that was empty.
         #
-        # 🔴 The floor is a SANITY check, not the truncation guard. Measured:
-        # this file's first pinned string spans bytes 1,433-1,501 and its last
-        # ends at 3,532, so a 1,500 B floor still passes a truncation that ate
-        # the first one, and every floor under 3,532 leaves some hole -- chasing
-        # the number is the wrong fix, because the floor can never sit above a
-        # string that has not been written yet. `_assert_pinned_once` now
-        # reports the file's size in its own failure message, which separates
-        # "reworded" from "truncated" at any size. This floor only has to
-        # separate "the document" from "a stub".
+        # 🔴 The floor is a SANITY check, not the truncation guard, and it sits
+        # far below the last string it guards ON PURPOSE. Chasing that offset is
+        # a losing game: every pin added later moves it, and an earlier attempt
+        # to quote exact byte positions here was a commit out of date within one
+        # round -- the numbers it named were the PREVIOUS tip's, and the claim
+        # they carried was false at HEAD. `_assert_pinned_once` reports the
+        # file's size in its own failure message instead, which separates
+        # "reworded" from "truncated" at any size and needs no maintenance. This
+        # floor only has to separate "the document" from "a stub".
         (EVIDENCE_MD, 1_500),
     ):
         assert path.is_file(), (
@@ -792,7 +818,7 @@ def test_the_gate_pins_its_MECHANISM_not_only_its_decision():
         SKILL_MD, SKILL_PAYLOAD_MEASUREMENT, "the dated payload measurement"
     )
     _assert_pinned_once(
-        SKILL_MD, SKILL_NO_MERGES_COST, "the --no-merges blind spot"
+        SKILL_MD, SKILL_WRONG_FLAGS_TRAP, "the --no-merges/--first-parent trap"
     )
     _assert_pinned_once(
         SKILL_MD, SKILL_GATE_NO_PATHSPEC, "the pathspec counter-evidence"


### PR DESCRIPTION
## Why

`/audit-pr` got a stop rule yesterday (#861): **a clean round ends the ladder; rounds continue only while the previous round produced a finding that needed fixing.** It is keyed to FINDINGS — and there is a whole regime in which it cannot fire.

A fix round *writes new guards*. The next delta round diffs `<audited-sha>..HEAD`, so **those guards are its audit surface**. The ladder manufactures its own next round's findings.

## Measured — `civitai/cli` #498, the day after #861 landed

Session `4719a2f0` (2026-08-26). The session even quotes the new rule back at round 3 — *"I'll stop at the first clean one, not at a 'safe to merge' verdict"* — and then runs seven more rounds.

| | |
|---|---|
| rounds | **10** (17:50 → 23:22 = **5 h 32 m**) |
| share of session | 1,312 of 1,756 transcript rows (75%) |
| main-thread output tokens | **321k of 419k (77%)**; 100M of 115M cache reads |
| rounds that returned CLEAN | **zero** — the stop rule was never once eligible |

Churn attribution, from the branch's own fix commits:

| rounds | test/guard lines | production lines |
|---|---|---|
| feature + rounds 1–3 | 1,061 | 332 |
| **rounds 4–10** | **1,002** | **0** |

Every one of rounds 4–10 found something real. All of it concerned guards an earlier round of the same ladder had written. At round 9 the session diagnosed its own plateau — *"rounds 3–10 have all been about the guards, not the feature"* — and asked the operator, five hours after the number stopped moving.

**Not a one-off.** Sweeping `~/.claude/projects/**/*.jsonl` for numbered delta re-audit dispatches: **110 sessions, 440 rounds, 84 of them in the preceding 14 days**; mean deepest round 4.0; 34% ran ≥5. Distribution 3→38, 4→22, 5→21, 6→9, 7→4, 8→2, 10→1.

## What this adds

1. **The attribution gate.** Before dispatching round N+1, `git diff --numstat <first-audited-sha>..HEAD` excluding tests. **Two consecutive rounds whose fixes changed zero production lines ⇒ the ladder has left the PR. Stop.** Remaining guard findings become a follow-up task against the test file, not another round. On #498 this fires after round 5.
2. **A scope brief for delta rounds** — label every finding `behaviour` or `guard`; report on scaffolding only where a defect would let a real behaviour regression through. Tests an earlier round wrote are in the diff *by construction*, and an adversarial auditor handed them will audit them, as instructed.
3. **A per-round ledger** in every summary (`round N · production lines changed since round 1: X · elapsed: Y`), so the plateau is visible at round 4 rather than round 9.

## 🔴 It is neither brake this skill already rejects

Both rejections are left standing, and both stay pinned by the test module.

- **Not the round CAP.** It counts production lines, never rounds. A round that touches production code never trips it, however deep the ladder is — so #505's round-4 ReDoS-introduced-by-round-3 still gets caught.
- **Not a retraction of "#804 is NOT an example of a wasted round."** #498 contains no round that ran and found nothing, which is the waste that retraction denies. Different axis: real findings *about scaffolding the ladder itself had just written*.

## Bytes

Case histories (#804's three defects, the `civitai-manager` five-round chain, the renumbering trio, and the full #498 measurement) move to `claude/skills/audit-pr/reference/round-ladder-evidence.md`, routed by its **deployed** path — a devrc skill is read from `~/.claude/skills/` with the cwd somewhere else entirely.

Body **11,103 → 11,909 B**, inside the 12,038 B budget `scripts/skill-audit.py` enforces (`✓ within budget, references intact`).

## Coverage

`scripts/tests/test_audit_ladder_stop_rule.py`: **+3 tests (6 → 9)**, whole-string pins because the artifact is prose.

```
POS  unmutated copy ......................... 9 passed          <- harness control
BASE origin/main SKILL.md, no reference ..... 3 failed, 6 passed <- exactly the three new
     file (i.e. pre-change)                                        tests red, all six old
                                                                   ones green
M7   attribution heading deleted ............ 2 failed
M8   threshold reworded TWO -> THREE ........ 1 failed  (gate pin ONLY — not a keyword guard)
M9   evidence file deleted .................. 1 failed
M10  section moved ABOVE the stop rule,
     text byte-identical .................... 1 failed  (ORDER pin ONLY — reachability control)
M11  different-axis paragraph dropped ....... 1 failed
```

Each on its own scratch tree, `PYTHONDONTWRITEBYTECODE=1`, pytest cache disabled, and every mutant asserts its target string exists before editing (a missed mutant fails loudly instead of scoring SURVIVED).

**What it does NOT enforce** — recorded in the module docstring, not just here:

- Nothing proves the gate is ever **run**. It is a `git diff --numstat` an operator issues between rounds, so the only evidence it fired is a ladder that stopped. That claim needs a future transcript sweep and is not made.
- **The threshold is pinned, not justified.** "Two consecutive rounds" comes from one measured ladder (n=1). One is knowingly too tight; whether two is right is a judgement.

## Gate

- Dev-host: `scripts/gate.sh --tier both` → `GATE: RESULT=PASS exit=0` (pytest + node).
- Sandbox tier — the one Tekton gates on: `nix build .#checks.x86_64-linux.pytests` and `.nodetests` both built.
- Base `6509702b`. `strict` is false on this repo, so this is a claim about the branch; the merged tree is still worth a re-run if `main` moves first.

## Left out of scope

Two 🔴 hazards found in the same review of this skill, deliberately not bundled: the skill mandates `isolation: "worktree"` for multi-PR fan-out (which worktrees the **cwd's** repo, not the PR's) and separately tells the auditor to `cp -a` a copy to mutate (whose `.git` is a *file* — a commit in the copy lands on the real branch). Happy to file or fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
