### PR TITLE
fix(subsystem-store): every image built since 2026-08-21 could not import — the Dockerfile's file list rotted silently

### DIFF
--- a/scripts/subsystem-store-api/Dockerfile
+++ b/scripts/subsystem-store-api/Dockerfile
@@ -30,6 +30,7 @@ FROM python:3.12-slim
 COPY scripts/lib/subsystem_recall.py   /app/scripts/lib/
 COPY scripts/lib/subsystem_resolver.py /app/scripts/lib/
 COPY scripts/lib/subsystem_touch.py    /app/scripts/lib/
+COPY scripts/lib/git_mainline.py       /app/scripts/lib/
 COPY scripts/subsystem-store-api/server.py /app/scripts/subsystem-store-api/
 
 # `subsystem_touch` evaluates `DEFAULT_STORE_ROOT = Path.home() / ".claude" / …`

--- a/scripts/subsystem-store-api/Dockerfile.dockerignore
+++ b/scripts/subsystem-store-api/Dockerfile.dockerignore
@@ -2,4 +2,5 @@
 !scripts/lib/subsystem_recall.py
 !scripts/lib/subsystem_resolver.py
 !scripts/lib/subsystem_touch.py
+!scripts/lib/git_mainline.py
 !scripts/subsystem-store-api/server.py

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2322,6 +2322,67 @@ class TestPhaseOneScope:
                 assert headers["Allow"] == "GET, HEAD"
                 assert body == b"read-only\n"
 
+    def test_the_image_copies_every_module_it_needs(self):
+        """🔴 THE DOCKERFILE ENUMERATES ITS `COPY`s, AND THE LIST ROTTED SILENTLY.
+
+        `subsystem_touch` gained `from git_mainline import …` in #677
+        (2026-08-21). The Dockerfile's hand-written list was not updated, so
+        every image built after that commit contained code that could not
+        import — while the RUNNING pod stayed healthy, because its image
+        predates the change. The defect was therefore invisible from production
+        and invisible from CI, and surfaced only when somebody next rebuilt:
+        `ModuleNotFoundError: No module named 'git_mainline'`, caught by
+        `build-push.sh`'s own import control at deploy time.
+
+        This computes the TRANSITIVE closure of local `scripts/lib` imports from
+        the entrypoints and asserts the Dockerfile covers it, so the next added
+        import fails here — in CI, on the commit that adds it — rather than at
+        the next deploy, which may be months later and someone else's problem.
+        """
+        lib = ROOT / "scripts" / "lib"
+        dockerfile = (API_DIR / "Dockerfile").read_text()
+
+        def local_imports(path: Path) -> set[str]:
+            found = set()
+            for node in ast.walk(ast.parse(path.read_text())):
+                if isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                    found.add(node.module.split(".")[0])
+                elif isinstance(node, ast.Import):
+                    for alias in node.names:
+                        found.add(alias.name.split(".")[0])
+            return {m for m in found if (lib / f"{m}.py").exists()}
+
+        # Entrypoints: what the server imports directly.
+        needed, queue = set(), ["subsystem_recall"]
+        while queue:
+            mod = queue.pop()
+            if mod in needed:
+                continue
+            needed.add(mod)
+            queue.extend(local_imports(lib / f"{mod}.py"))
+
+        # 🔴 TWO LISTS, AND CHECKING ONLY ONE IS A GUARD NARROWER THAN THE
+        # HAZARD. The first version of this test checked only the COPY lines —
+        # and would have passed while the build still failed, because
+        # `Dockerfile.dockerignore` is an ALLOWLIST (`**` then explicit `!`
+        # unignores) and an un-listed file never reaches the build context at
+        # all. Measured: with the COPY added but the ignore-file untouched,
+        # `docker build` fails with `"/scripts/lib/git_mainline.py": not found`.
+        # Both lists must cover the closure, so both are asserted.
+        ignorefile = (API_DIR / "Dockerfile.dockerignore").read_text()
+        copied = set(re.findall(r"COPY scripts/lib/(\w+)\.py", dockerfile))
+        unignored = set(re.findall(r"!scripts/lib/(\w+)\.py", ignorefile))
+
+        assert not (needed - copied), (
+            f"Dockerfile does not COPY {sorted(needed - copied)} — the image "
+            f"would build and then fail to import at runtime."
+        )
+        assert not (needed - unignored), (
+            f"Dockerfile.dockerignore does not un-ignore "
+            f"{sorted(needed - unignored)} — it is an allowlist, so the file "
+            f"never reaches the build context and COPY fails outright."
+        )
+
     def test_nothing_in_this_directory_writes_to_the_store(self):
         for path in sorted(API_DIR.iterdir()):
             if not path.is_file():


### PR DESCRIPTION
Found while building `0.4.0` for the task **360** deploy. Blocks that deploy.

## What happened

`build-push.sh`'s own import control refused the image:

```
ModuleNotFoundError: No module named 'git_mainline'
  subsystem_recall.py:283 → subsystem_touch.py:296 → git_mainline
```

`subsystem_touch` gained that import in **#677 (2026-08-21)**. Neither the Dockerfile's `COPY` list nor `Dockerfile.dockerignore`'s allowlist was updated.

## 🔴 Why nobody noticed for five days

The failure was invisible from **both** directions:

- **Production was healthy** — the running pod serves `0.3.0`, whose image predates the import. Nothing was broken to observe.
- **CI never builds the image** — so nothing was red.

It could only surface at the next rebuild. That happened to be today, for a feature deploy. Had it been an **incident** rebuild, the image would have failed at the moment somebody most needed it.

## Two lists, both wrong — and fixing the first hid the second

Adding the `COPY` alone **still failed**:

```
ERROR: failed to compute cache key: "/scripts/lib/git_mainline.py": not found
```

`Dockerfile.dockerignore` is an **allowlist** (`**`, then explicit `!` unignores). An un-listed file never reaches the build context, so `COPY` cannot succeed no matter what it says.

## The guard

`test_the_image_copies_every_module_it_needs` computes the **transitive closure** of local `scripts/lib` imports from the server's entrypoint and asserts **both** lists cover it. Closure today is exactly `{subsystem_recall, subsystem_resolver, subsystem_touch, git_mainline}`.

🔴 **Its first version checked only the `COPY` lines** — a guard narrower than the hazard, which would have passed while the build still failed. That is the same "description wider than the implementation" shape this file's other tests keep catching, committed in the guard written to stop it. Both lists are now asserted, each with a message naming which file and which list.

## Verification

| check | result |
|---|---|
| guard with `COPY` removed | fails, naming `['git_mainline']` |
| guard with `COPY` restored | passes |
| `build-push.sh` control 1 | `/data in the image holds 0 files (must be 0) — OK` |
| `build-push.sh` control 2 | `subsystem_recall imported, 3 modes` |
| suite | **358 passed** |

The two build controls are the real proof — the guard is a CI-time early warning for the same property.

## Blast radius

**Reversible.** Two build-config lines and one test. No runtime code, no manifest. Nothing deploys by merging; the image is pushed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7CtMW371evXEXDkjgTNbz