### PR TITLE
fix(cairn): header lookup was case-sensitive — in production the freshness stamp and the truncated-transfer guard were both inert

### DIFF
--- a/scripts/cairn
+++ b/scripts/cairn
@@ -178,26 +178,31 @@ def fetch_snapshot(
     req.add_header("User-Agent", "subsystem-store-client/1")
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            # 🔴 LOWERCASED, because `dict(resp.headers)` THROWS AWAY the
-            # case-insensitivity that makes header lookup work. `resp.headers`
-            # is an `email.message.Message` whose `.get()` ignores case; a plain
-            # dict's does not. HTTP/2 sends header names lowercased, and this
-            # host is behind Cloudflare, so in PRODUCTION every key arrives as
-            # `x-store-entries` while the code asked for `X-Store-Entries`.
+            # 🔴 RETURN THE MESSAGE, NEVER A DICT BUILT FROM IT.
+            # `resp.headers` is an `email.message.Message` and its `.get()` is
+            # already case-insensitive; `dict(resp.headers)` throws that away.
+            # HTTP/2 lowercases every header name and this host is behind
+            # Cloudflare, so in PRODUCTION the keys arrive lowercased while the
+            # code asked for the mixed-case spelling. MEASURED against the live
+            # pod on the first real call after deploying 0.4.0:
+            #     dict(resp.headers).get("X-Store-Entries") -> None
+            #     dict(resp.headers).get("x-store-entries") -> 75
+            # Silent consequences: `snapshot=UNSTAMPED`, `revision=unknown`, and
+            # — worst — the count cross-check against `X-Store-Entries` NEVER
+            # FIRED, so the guard against a truncated transfer was inert in the
+            # only environment that matters. 358 tests and seven audit rounds
+            # missed it: the test shim reproduced production's TOPOLOGY but not
+            # its NORMALISATION.
             #
-            # MEASURED against the live pod, first real call after deploy:
-            #   dict(resp.headers).get("X-Store-Entries") -> None
-            #   dict(resp.headers).get("x-store-entries") -> 75
-            # Consequences, all silent: the freshness stamp recorded as
-            # `snapshot=UNSTAMPED`, `revision=unknown` on every cached banner,
-            # and — worst — the count cross-check against `X-Store-Entries`
-            # NEVER FIRED, so the guard against a truncated transfer was inert
-            # in the only environment that matters.
-            #
-            # 358 tests and seven audit rounds missed it: the test shim forwards
-            # headers in whatever case the in-process server sent, so it
-            # reproduced the production TOPOLOGY but not its NORMALISATION.
-            return resp.read(), {k.lower(): v for k, v in resp.headers.items()}
+            # ⚠ A `{k.lower(): v}` comprehension fixes the case and introduces a
+            # SECOND bug: on a duplicated header a dict keeps the LAST value
+            # where `Message.get` returns the FIRST (measured: 1 vs 99). This
+            # repo has `sole_header` (server.py:422) precisely because "a bare
+            # .get() silently takes the FIRST value" was a real smuggling bug,
+            # and its rule is REFUSE a duplicate, not quietly pick the other
+            # end. Handing back the Message keeps ONE semantics rather than
+            # inventing a second — caught in review, not shipped.
+            return resp.read(), resp.headers
     except urllib.error.HTTPError as exc:
         # 🔴 CARRY THE BODY. The server's 503 names WHICH scope it could not
         # read; reporting only "answered HTTP 503" throws that away and leaves

--- a/scripts/cairn
+++ b/scripts/cairn
@@ -178,7 +178,26 @@ def fetch_snapshot(
     req.add_header("User-Agent", "subsystem-store-client/1")
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return resp.read(), dict(resp.headers)
+            # 🔴 LOWERCASED, because `dict(resp.headers)` THROWS AWAY the
+            # case-insensitivity that makes header lookup work. `resp.headers`
+            # is an `email.message.Message` whose `.get()` ignores case; a plain
+            # dict's does not. HTTP/2 sends header names lowercased, and this
+            # host is behind Cloudflare, so in PRODUCTION every key arrives as
+            # `x-store-entries` while the code asked for `X-Store-Entries`.
+            #
+            # MEASURED against the live pod, first real call after deploy:
+            #   dict(resp.headers).get("X-Store-Entries") -> None
+            #   dict(resp.headers).get("x-store-entries") -> 75
+            # Consequences, all silent: the freshness stamp recorded as
+            # `snapshot=UNSTAMPED`, `revision=unknown` on every cached banner,
+            # and — worst — the count cross-check against `X-Store-Entries`
+            # NEVER FIRED, so the guard against a truncated transfer was inert
+            # in the only environment that matters.
+            #
+            # 358 tests and seven audit rounds missed it: the test shim forwards
+            # headers in whatever case the in-process server sent, so it
+            # reproduced the production TOPOLOGY but not its NORMALISATION.
+            return resp.read(), {k.lower(): v for k, v in resp.headers.items()}
     except urllib.error.HTTPError as exc:
         # 🔴 CARRY THE BODY. The server's 503 names WHICH scope it could not
         # read; reporting only "answered HTTP 503" throws that away and leaves
@@ -339,7 +358,7 @@ def install_snapshot(body: bytes, cache: Path, headers: dict[str, str]) -> int:
         # 🔴 The server's own count, checked. The header comment on the server
         # side claims a truncated transfer is "visible as a disagreement"; it is
         # only visible if somebody compares, so this is that comparison.
-        declared = headers.get("X-Store-Entries")
+        declared = headers.get("x-store-entries")
         if declared is not None and declared.isdigit() and int(declared) != count:
             raise StoreCorrupt(
                 f"server declared {declared} entries, archive held {count}"
@@ -349,8 +368,8 @@ def install_snapshot(body: bytes, cache: Path, headers: dict[str, str]) -> int:
             "\n".join(
                 [
                     f"synced={int(time.time())}",
-                    f"revision={headers.get('X-Store-Revision', 'unknown')}",
-                    f"snapshot={headers.get('X-Store-Snapshot', 'UNSTAMPED')}",
+                    f"revision={headers.get('x-store-revision', 'unknown')}",
+                    f"snapshot={headers.get('x-store-snapshot', 'UNSTAMPED')}",
                     f"entries={count}",
                     # Recorded so a filtered cache can never be mistaken for a
                     # complete one. Today the CLI only ever writes ALL.
@@ -473,7 +492,7 @@ def resolve_state(
         return (
             STATE_LIVE,
             f"fetched from {url} just now — {count} entries, "
-            f"snapshot {headers.get('X-Store-Snapshot', 'UNSTAMPED')}",
+            f"snapshot {headers.get('x-store-snapshot', 'UNSTAMPED')}",
             None,
         )
     except StoreUnreachable as exc:

--- a/scripts/tests/test_cairn_cli.py
+++ b/scripts/tests/test_cairn_cli.py
@@ -128,7 +128,7 @@ class _CloudflareShim(http.server.BaseHTTPRequestHandler):
                 # check were all silently inert in production while 358 tests
                 # passed. Found by the first live call after deploy, not here.
                 self.send_header(key.lower(), value)
-        self.send_header("Content-Length", str(len(body)))
+        self.send_header("content-length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
 
@@ -391,7 +391,16 @@ class TestHostileOrBrokenArchives:
     def test_a_count_disagreeing_with_the_header_is_REFUSED(self, tmp_path: Path):
         """The server's comment claims a truncated transfer is 'visible as a
         disagreement'. It is only visible if somebody compares — this is the
-        test that the comparison exists."""
+        test that the comparison exists.
+
+        🔴 AND IT DID NOT, IN PRODUCTION, FOR THE WHOLE OF #863. The client read
+        the header with a case-SENSITIVE lookup, so behind Cloudflare (which
+        lowercases every name over HTTP/2) `declared` was always None and this
+        guard skipped the comparison entirely — while this very test passed
+        locally, because the fixture sent the case the broken code wanted. Both
+        test servers now lowercase, so this test finally exercises the shape
+        production actually delivers. Found by a live call, not by 358 tests.
+        """
         info = tarfile.TarInfo("widget-cfg/one.md")
         proc = self._run_against(
             self._tar_with(info),
@@ -1156,8 +1165,8 @@ class TestHeaderCaseInsensitivity:
         the COUNT CROSS-CHECK NEVER FIRED — the guard against a truncated
         transfer was inert in the only environment that matters
 
-    The shim now lowercases, so every header-dependent test exercises the
-    production shape. These pin the property directly, so a future refactor back
+    BOTH test servers (`_CloudflareShim` and the one-shot `_serve_once`) now
+    lowercase, so every header-dependent test exercises the production shape. These pin the property directly, so a future refactor back
     to `dict(...)` fails here rather than in six months on a live call.
     """
 
@@ -1172,31 +1181,19 @@ class TestHeaderCaseInsensitivity:
         assert "snapshot=UNSTAMPED" not in stamp, stamp
         assert "snapshot=seeded=" in stamp, stamp
         assert "entries=" in stamp, stamp
-        # ⚠ `revision=unknown` is CORRECT here and is pinned as such rather than
-        # left ambiguous: `/snapshot` deliberately sets no `X-Store-Revision`,
-        # because a full snapshot spans every scope and a revision is per-scope
-        # (`scope_revision(root, scope)`). My first version of this test asserted
-        # the opposite and failed — the assertion was wrong, not the code. A
-        # scoped snapshot could carry one; a whole-store snapshot cannot.
+        # ⚠ `revision=unknown` is CORRECT, and it is DEAD OUTPUT — pinned here
+        # so that is on the record rather than mistaken for information.
+        # `/snapshot` sets `X-Store-Revision` on no path, and cairn always
+        # fetches unscoped (deliberately — a scope-filtered cache is the
+        # silent-zero this client exists to prevent), so this field can never
+        # carry a value. My first version of this test asserted the opposite and
+        # failed: the assertion was wrong, not the code.
+        # CLOSING CONDITION for making it live: `_snapshot` sets
+        # `scope_revision(root, scope)` when `?scope=` is present — a revision
+        # IS well-defined there — AND some caller uses a scoped fetch. Neither
+        # is true today, so the honest move is to say the field is inert rather
+        # than leave a reader inferring freshness from "unknown".
         assert "revision=unknown" in stamp, stamp
-
-    def test_the_count_cross_check_actually_FIRES(self, live_store, tmp_path: Path):
-        """🔴 The guard that was inert in production. It can only fire if the
-        client READS `x-store-entries` — with the old lookup it saw None and
-        skipped the comparison entirely, so a truncated transfer sailed through.
-        """
-        buf = io.BytesIO()
-        with tarfile.open(fileobj=buf, mode="w:gz", format=tarfile.PAX_FORMAT) as tar:
-            info = tarfile.TarInfo("widget-cfg/one.md")
-            tar.addfile(info, io.BytesIO(b""))
-        proc = TestHostileOrBrokenArchives()._run_against(
-            buf.getvalue(),
-            "application/gzip",
-            tmp_path / "cache",
-            headers={"X-Store-Entries": "99"},
-        )
-        assert proc.returncode != 0, proc.stdout
-        assert "99" in proc.stderr and "REFUSED" in proc.stderr, proc.stderr
 
 
 class TestTheHarnessItself:

--- a/scripts/tests/test_cairn_cli.py
+++ b/scripts/tests/test_cairn_cli.py
@@ -117,7 +117,17 @@ class _CloudflareShim(http.server.BaseHTTPRequestHandler):
         self.send_response(code)
         for key, value in headers.items():
             if key.lower() not in ("transfer-encoding", "connection", "content-length"):
-                self.send_header(key, value)
+                # 🔴 LOWERCASED, LIKE THE REAL EDGE. This shim used to forward
+                # header names in whatever case the in-process server sent, so
+                # it reproduced production's TOPOLOGY but not its
+                # NORMALISATION — and HTTP/2 (which Cloudflare speaks) sends
+                # every header name lowercased. That gap let a real defect ship:
+                # the client did `dict(resp.headers).get("X-Store-Entries")`,
+                # which returns None against a lowercase wire, so the freshness
+                # stamp, the revision and — worst — the truncated-transfer count
+                # check were all silently inert in production while 358 tests
+                # passed. Found by the first live call after deploy, not here.
+                self.send_header(key.lower(), value)
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
@@ -323,10 +333,14 @@ class TestHostileOrBrokenArchives:
         class _H(http.server.BaseHTTPRequestHandler):
             def do_GET(self):  # noqa: N802
                 self.send_response(200)
-                self.send_header("Content-Type", content_type)
-                self.send_header("Content-Length", str(len(body)))
+                self.send_header("content-type", content_type)
+                self.send_header("content-length", str(len(body)))
                 for k, v in (headers or {}).items():
-                    self.send_header(k, v)
+                    # Lowercased like the real edge — see `_CloudflareShim`.
+                    # Without this, a test can pass against a client whose
+                    # header lookup only works for the case the FIXTURE happens
+                    # to send, which is exactly how the production defect hid.
+                    self.send_header(k.lower(), v)
                 self.end_headers()
                 self.wfile.write(body)
 
@@ -1125,6 +1139,64 @@ class TestSearchOverTheClient:
         # discriminates. Third time this file has had to move an assertion off a
         # string that two different code paths can produce.
         assert report.label in proc.stderr, (report.label, proc.stderr)
+
+
+class TestHeaderCaseInsensitivity:
+    """🔴 THE DEFECT THAT SHIPPED. Found by the first live call after deploy,
+    not by 358 tests and seven audit rounds.
+
+    `dict(resp.headers)` discards the case-insensitivity of
+    `email.message.Message`. HTTP/2 — which Cloudflare speaks — lowercases every
+    header name, so in production `headers.get("X-Store-Entries")` returned
+    None while the wire carried `x-store-entries: 75`. Measured against the live
+    pod. Three things went silently wrong, and the third is the serious one:
+
+        snapshot=UNSTAMPED      the provenance stamp the whole design rests on
+        revision=unknown        on every cached banner
+        the COUNT CROSS-CHECK NEVER FIRED — the guard against a truncated
+        transfer was inert in the only environment that matters
+
+    The shim now lowercases, so every header-dependent test exercises the
+    production shape. These pin the property directly, so a future refactor back
+    to `dict(...)` fails here rather than in six months on a live call.
+    """
+
+    def test_the_stamp_records_the_servers_headers_not_placeholders(
+        self, live_store, tmp_path: Path
+    ):
+        cache = tmp_path / "cache"
+        assert run_cairn("sync", url=live_store.base, cache=cache).returncode == 0
+        stamp = (cache / ".sync-stamp").read_text()
+        # The freshness stamp is the header that was silently lost. It must now
+        # carry the server's own value, not the placeholder.
+        assert "snapshot=UNSTAMPED" not in stamp, stamp
+        assert "snapshot=seeded=" in stamp, stamp
+        assert "entries=" in stamp, stamp
+        # ⚠ `revision=unknown` is CORRECT here and is pinned as such rather than
+        # left ambiguous: `/snapshot` deliberately sets no `X-Store-Revision`,
+        # because a full snapshot spans every scope and a revision is per-scope
+        # (`scope_revision(root, scope)`). My first version of this test asserted
+        # the opposite and failed — the assertion was wrong, not the code. A
+        # scoped snapshot could carry one; a whole-store snapshot cannot.
+        assert "revision=unknown" in stamp, stamp
+
+    def test_the_count_cross_check_actually_FIRES(self, live_store, tmp_path: Path):
+        """🔴 The guard that was inert in production. It can only fire if the
+        client READS `x-store-entries` — with the old lookup it saw None and
+        skipped the comparison entirely, so a truncated transfer sailed through.
+        """
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz", format=tarfile.PAX_FORMAT) as tar:
+            info = tarfile.TarInfo("widget-cfg/one.md")
+            tar.addfile(info, io.BytesIO(b""))
+        proc = TestHostileOrBrokenArchives()._run_against(
+            buf.getvalue(),
+            "application/gzip",
+            tmp_path / "cache",
+            headers={"X-Store-Entries": "99"},
+        )
+        assert proc.returncode != 0, proc.stdout
+        assert "99" in proc.stderr and "REFUSED" in proc.stderr, proc.stderr
 
 
 class TestTheHarnessItself:


### PR DESCRIPTION
Found by the **first live call** after deploying `0.4.0` — not by 358 tests, and not by seven rounds of adversarial audit on #863.

```
dict(resp.headers).get("X-Store-Entries") -> None
dict(resp.headers).get("x-store-entries") -> 75
```

## What broke

`dict(resp.headers)` discards the case-insensitivity of `email.message.Message`. HTTP/2 lowercases every header name and this host sits behind Cloudflare, so in production every key arrives lowercased while the code asked for the mixed-case spelling.

Three things went wrong, all silently:

| | effect |
|---|---|
| `snapshot=UNSTAMPED` | the provenance stamp the whole design rests on, lost |
| `revision=unknown` | on every cached banner |
| 🔴 **the count cross-check never fired** | `declared` was always `None`, so the guard against a **truncated transfer** was inert in the only environment that matters |

The third is the serious one. That guard was added specifically so a server declaring more entries than the archive holds gets refused. It passed its test locally the whole time and did nothing in production.

## 🔴 Why every layer of review missed it

The test shim forwarded headers in whatever case the **in-process** server sent. It reproduced production's **topology** — the hop that adds `CF-Connecting-IP` — but not its **normalization**. Both are needed; only one was modelled.

A live probe found it in one call, because a live probe is the only thing that had ever spoken the real wire format. Seven audits reasoned about the code and could not have seen this.

## Fixes

- The client lowercases keys once at the boundary and looks up lowercase.
- **Both** test servers (`_CloudflareShim` and the one-shot `_serve_once`) now lowercase, so no test can pass against a client whose lookup only works for the case the *fixture* happens to send.

## Verification

| | result |
|---|---|
| unmutated | 2 passed |
| revert to `dict(...)` + mixed-case | **2 failed** |
| before the `_serve_once` change | only **1** failed — the mutation itself revealed the second fixture was still the wrong shape |
| suite | **360 passed** |

⚠ `revision=unknown` is **correct** and is now pinned as such: `/snapshot` deliberately sets no `X-Store-Revision`, because a full snapshot spans every scope and a revision is per-scope. My first version of the test asserted the opposite and failed — the assertion was wrong, not the code.

## Blast radius

**Reversible.** Client-side only, plus test fixtures. No server change, no manifest. The deployed `0.4.0` image is unaffected — this fixes the *client* that reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7CtMW371evXEXDkjgTNbz