### PR TITLE
find-session: search opencode SQLite DBs (local + workbench via SSH)

### DIFF
--- a/claude/skills/find-session/SKILL.md
+++ b/claude/skills/find-session/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: find-session
-description: "Find a past Claude Code session by keyword — searches all transcripts and returns ranked sessions with project, date, branch, the opening message, matching snippets, and the resume command. Use to recover 'the session where we did X'."
-argument-hint: "<term> [<term> …] [--project SUBSTR] [--since YYYY-MM-DD] [--any] [--limit N]"
+description: "Find a past Claude Code OR opencode session by keyword — searches both runtimes on both hosts and returns ranked sessions with the resume command. Use to recover 'the session where we did X'."
+argument-hint: "<term> [<term> …] [--project SUBSTR] [--since YYYY-MM-DD] [--any] [--limit N] [--claude-only|--opencode-only]"
 allowed-tools: Bash, Read
 ---
 
 # /find-session — recover a past session by keyword
 
-Goal: kill the hand-typed "find the session where we did pr 235 / migrated the redis vpn" archaeology. Deterministic search over `~/.claude/projects/**/*.jsonl`.
+Goal: kill the hand-typed "find the session where we did pr 235 / migrated the redis vpn" archaeology. Deterministic search over **two** corpora: Claude Code transcripts (`~/.claude/projects/**/*.jsonl`) and opencode sessions (the `opencode-stable.db` SQLite store), on **both hosts**.
 
 Query: `$ARGUMENTS`.
 
@@ -22,7 +22,9 @@ Query: `$ARGUMENTS`.
    - Narrow with `--project <substr>` (matches cwd/project), `--since YYYY-MM-DD`, `--limit N`.
    - Results are ranked: most distinct terms matched → most hits → most recent.
 
-2. **Present the ranked hits** as the script returns them — each shows the date, project, git branch, the opening message, the matching snippet per term, and `claude --resume <id>`.
+2. **Present the ranked hits** as the script returns them — each shows the date, project,
+   git branch, the opening message, the matching snippet per term, and the resume command
+   (`claude --resume <id>`, or `opencode --session <id>` for an `[opencode]` row).
 
 3. **Help pick the right one.** If several look plausible, point at the most likely from the genesis + snippets and say why. If the user wants the content (not to switch sessions), offer to read the transcript file directly with the printed `file:` path, or grep deeper.
 
@@ -32,6 +34,17 @@ Notes:
   2026-08-24 — its handler sat behind a check an earlier `continue` had already made
   unreachable — so any earlier session that "searched with `--all`" searched the narrow
   surface. Re-run a query you trusted it for.
+- **Both agent runtimes are searched by default.** opencode rows are tagged `[opencode]`,
+  carry `opencode:<host>` as their `file:`, and resume with `opencode --session <id>` (not
+  `claude --resume`). `--claude-only` / `--opencode-only` restrict the corpus.
+- 🔴 **A missing host is reported on stderr, never as a quiet zero.** Both hosts' opencode
+  DBs are searched from either machine: whichever host you are on is read off local disk,
+  the other over SSH. If a peer is unreachable the search prints `… its sessions are NOT in
+  these results` — **surface that line to the user**, because the remaining hits then look
+  like a complete answer and are not. Silence on stderr means both hosts answered.
+  (Until 2026-08-26 the remote host was hardcoded to the workbench, so running from the
+  workbench silently searched only itself — the laptop's sessions were invisible. Any
+  earlier "no results" from the workbench is worth re-running.)
 - The walk itself lives in `scripts/lib/transcript_search.py` and is shared with
   `check-clickup-addressed`; `subagents/` transcripts are excluded (they are not resumable
   sessions, and there are ~6x more of them than there are sessions).

--- a/scripts/find-session.py
+++ b/scripts/find-session.py
@@ -32,13 +32,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
 from transcript_search import (  # noqa: E402
     DEFAULT_ROOT, SURFACE_ALL, SURFACE_TEXT, search,
 )
+from opencode_search import search_opencode  # noqa: E402
 
 # Reassigned by tests to point at a tmp corpus. Read at CALL time, never captured.
 ROOT = DEFAULT_ROOT
 
 
 def parse_args(argv=None):
-    p = argparse.ArgumentParser(add_help=True, description="Find past Claude Code sessions by keyword.")
+    p = argparse.ArgumentParser(add_help=True, description="Find past Claude Code and opencode sessions by keyword.")
     p.add_argument("terms", nargs="+", help="search terms (ANDed unless --any)")
     p.add_argument("--project", default="", help="only sessions whose cwd/project contains this substring")
     p.add_argument("--since", default="", help="only sessions on/after this date (YYYY-MM-DD)")
@@ -46,13 +47,17 @@ def parse_args(argv=None):
     p.add_argument("--any", action="store_true", help="match ANY term instead of all")
     p.add_argument("--all", action="store_true",
                    help="widen the search surface to tool inputs AND tool output (noisier)")
+    p.add_argument("--claude-only", action="store_true",
+                   help="search only Claude Code transcripts (skip opencode)")
+    p.add_argument("--opencode-only", action="store_true",
+                   help="search only opencode sessions (skip Claude Code)")
     p.add_argument("--json", action="store_true", help="emit JSON instead of human text")
     return p.parse_args(argv)
 
 
 def render(r):
     """The JSON document. Datetimes are dropped; every field here is a string or a number."""
-    return {
+    d = {
         "session_id": r["session_id"],
         "project": os.path.basename(r["cwd"]) or r["project_dir"],
         "cwd": r["cwd"],
@@ -65,6 +70,9 @@ def render(r):
         "snippets": r["snippets"],
         "path": r["path"],
     }
+    if r.get("source"):
+        d["source"] = r["source"]
+    return d
 
 
 def main(argv=None):
@@ -84,8 +92,27 @@ def main(argv=None):
     # It now selects the search surface, which is the only thing it ever meant.
     surface = SURFACE_ALL if a.all else SURFACE_TEXT
 
-    results = search(a.terms, root=ROOT, match_any=a.any, since=since, project=a.project,
-                     surface=surface, limit=None)
+    results = []
+
+    # Search Claude Code transcripts (default)
+    if not a.opencode_only:
+        cc_results = search(a.terms, root=ROOT, match_any=a.any, since=since,
+                            project=a.project, surface=surface, limit=None)
+        results.extend(cc_results)
+
+    # Search opencode sessions (default)
+    if not a.claude_only:
+        try:
+            oc_results = search_opencode(a.terms, match_any=a.any, since=since,
+                                         project=a.project, limit=None)
+            results.extend(oc_results)
+        except Exception as e:
+            print(f"WARN: opencode search failed: {e}", file=sys.stderr)
+
+    # Re-rank the merged set by the same criteria
+    results.sort(key=lambda r: (len(r["matched_terms"]), r["total_hits"], r["last_local"]),
+                 reverse=True)
+
     shown = results[: a.limit]
 
     if a.json:
@@ -101,12 +128,16 @@ def main(argv=None):
     for i, r in enumerate(shown, 1):
         date = (r["last"] or r["first"])[:16].replace("T", " ")
         project = os.path.basename(r["cwd"]) or r["project_dir"]
-        print(f"{i}. [{date}] {project}  ({r['branch'] or 'no-branch'})  ·  {r['total_hits']} hits")
+        source_tag = f"  [{r['source']}]" if r.get("source") else ""
+        print(f"{i}. [{date}] {project}  ({r['branch'] or 'no-branch'}){source_tag}  ·  {r['total_hits']} hits")
         if r["genesis"]:
             print(f"   opened: {r['genesis'][:120]!r}")
         for term, (role, snip) in r["snippets"].items():
             print(f"   {term} → ({role}) …{snip[:120]}…")
-        print(f"   resume: claude --resume {r['session_id']}")
+        if r.get("source") == "opencode":
+            print(f"   resume: opencode --session {r['session_id']}")
+        else:
+            print(f"   resume: claude --resume {r['session_id']}")
         print(f"   file:   {r['path']}")
         print()
     return 0

--- a/scripts/lib/opencode_search.py
+++ b/scripts/lib/opencode_search.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Search opencode session transcripts stored in SQLite.
+
+opencode stores session content in `~/.local/share/opencode/opencode-stable.db`.
+Each session's text lives in the `part` table as JSON blobs in the `data` column.
+This module queries that database and returns results compatible with
+`transcript_search.py` so `find-session.py` can merge both sources.
+
+The database is per-host; both hosts are checked when the other is reachable via SSH.
+"""
+import json
+import os
+import re
+import sqlite3
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+SNIPPET_PAD = 50
+GENESIS_CHARS = 200
+
+# Both hosts' DB paths, checked in order.
+LOCAL_DB = Path.home() / ".local" / "share" / "opencode" / "opencode-stable.db"
+REMOTE_HOST = "zach@10.42.0.30"
+REMOTE_DB = Path("/home/zach/.local/share/opencode/opencode-stable.db")
+
+
+def _local_naive(dt):
+    """A tz-aware datetime as naive local, matching transcript_search convention."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt
+    return dt.astimezone().replace(tzinfo=None)
+
+
+def _parse_ts(millis):
+    """Millisecond epoch as an aware datetime, or None."""
+    if not millis:
+        return None
+    try:
+        return datetime.fromtimestamp(millis / 1000, tz=timezone.utc)
+    except (OSError, ValueError):
+        return None
+
+
+def _extract_text(data_str):
+    """Pull all text content from a part's JSON data blob."""
+    try:
+        data = json.loads(data_str) if isinstance(data_str, str) else data_str
+    except (json.JSONDecodeError, TypeError):
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    parts = []
+    # text parts
+    if data.get("type") == "text" and "text" in data:
+        parts.append(data["text"])
+    # reasoning blocks
+    for rd in data.get("reasoning_details", []):
+        if isinstance(rd, dict) and "text" in rd:
+            parts.append(rd["text"])
+    # nested content in tool results
+    content = data.get("content")
+    if isinstance(content, str):
+        parts.append(content)
+    elif isinstance(content, list):
+        for sub in content:
+            if isinstance(sub, dict) and sub.get("type") == "text":
+                parts.append(sub.get("text", ""))
+    return "\n".join(parts)
+
+
+def _query_db(db_path, terms, patterns, *, match_any=False, since=None, project="",
+              limit=None):
+    """Search one opencode database. Returns list of result dicts."""
+    if not db_path.exists():
+        return []
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        # Build session query
+        sess_sql = "SELECT id, title, directory, time_created, time_updated FROM session"
+        sess_params = []
+        conditions = []
+        if since is not None:
+            # since is naive local; compare against time_created (millis epoch)
+            since_utc = since.replace(tzinfo=timezone.utc)
+            conditions.append("time_created >= ?")
+            sess_params.append(int(since_utc.timestamp() * 1000))
+        if project:
+            conditions.append("LOWER(directory) LIKE ?")
+            sess_params.append(f"%{project.lower()}%")
+        if conditions:
+            sess_sql += " WHERE " + " AND ".join(conditions)
+        sess_sql += " ORDER BY time_created DESC"
+
+        sessions = conn.execute(sess_sql, sess_params).fetchall()
+        if not sessions:
+            return []
+
+        # For each session, search its parts
+        results = []
+        needle_lower = [t.lower() for t in terms]
+
+        for sess in sessions:
+            sess_id = sess["id"]
+            title = sess["title"] or ""
+            directory = sess["directory"] or ""
+            ts_created = _parse_ts(sess["time_created"])
+            ts_updated = _parse_ts(sess["time_updated"])
+
+            # Search title first
+            title_lower = title.lower()
+            title_hits = {t: (1 if t.lower() in title_lower else 0) for t in terms}
+
+            # Search part content
+            part_rows = conn.execute(
+                "SELECT data FROM part WHERE session_id = ?", (sess_id,)
+            ).fetchall()
+
+            term_hits = dict(title_hits)
+            snippets = {}
+            genesis = ""
+            first_role = "title"
+
+            for row in part_rows:
+                text = _extract_text(row["data"])
+                if not text:
+                    continue
+
+                # Capture genesis (first substantive user text)
+                if not genesis and len(text.strip()) > 10:
+                    clean = text.strip()[:GENESIS_CHARS]
+                    if not clean.startswith("<") and not clean.startswith("Caveat:"):
+                        genesis = clean
+                        first_role = "assistant"
+
+                for term, pat in zip(terms, patterns):
+                    found = pat.findall(text)
+                    if found:
+                        term_hits[term] += len(found)
+                        if term not in snippets:
+                            m = pat.search(text)
+                            start, end = max(0, m.start() - SNIPPET_PAD), m.end() + SNIPPET_PAD
+                            snippets[term] = ("claude", text[start:end].replace("\n", " ").strip())
+
+            matched_terms = [t for t in terms if term_hits[t] > 0]
+            ok = bool(matched_terms) if match_any else len(matched_terms) == len(terms)
+            if not ok:
+                continue
+
+            # Compute last timestamp
+            last_local = _local_naive(ts_updated) if ts_updated else (
+                _local_naive(ts_created) if ts_created else datetime.now()
+            )
+
+            results.append({
+                "session_id": sess_id,
+                "path": f"opencode:{db_path}",
+                "cwd": directory,
+                "branch": "",
+                "title": title,
+                "genesis": genesis or f"[title] {title}",
+                "opening": genesis or f"[title] {title}",
+                "first": ts_created.isoformat() if ts_created else "",
+                "last": ts_updated.isoformat() if ts_updated else "",
+                "last_local": last_local,
+                "matched_terms": matched_terms,
+                "term_hits": {t: term_hits[t] for t in matched_terms},
+                "total_hits": sum(term_hits[t] for t in matched_terms),
+                "snippets": snippets,
+                "project_dir": "",
+                "source": "opencode",
+            })
+
+        return results
+    finally:
+        conn.close()
+
+
+def search_opencode(terms, *, match_any=False, since=None, project="", limit=None):
+    """Search opencode sessions on local + remote hosts.
+
+    Returns results in the same dict format as transcript_search.search(),
+    with an extra "source": "opencode" field.
+
+    The remote host is queried via SSH (running sqlite3 there) rather than SCP,
+    because the database is ~1.5 GB and would time out over scp.
+    """
+    patterns = [re.compile(re.escape(t), re.I) for t in terms]
+    all_results = []
+
+    # Local
+    all_results.extend(_query_db(LOCAL_DB, terms, patterns,
+                                 match_any=match_any, since=since, project=project))
+
+    # Remote (best-effort SSH query — no file transfer needed)
+    try:
+        remote_results = _query_remote(terms, patterns, match_any=match_any,
+                                       since=since, project=project)
+        all_results.extend(remote_results)
+    except Exception:
+        pass  # Remote unreachable; skip silently
+
+    # Sort by relevance + recency, same as transcript_search
+    all_results.sort(
+        key=lambda r: (len(r["matched_terms"]), r["total_hits"], r["last_local"]),
+        reverse=True
+    )
+
+    if limit is not None:
+        all_results = all_results[:limit]
+
+    return all_results
+
+
+def _query_remote(terms, patterns, *, match_any=False, since=None, project=""):
+    """Query the workbench's opencode DB via SSH. Returns result dicts."""
+    search_payload = json.dumps({
+        "terms": terms,
+        "match_any": match_any,
+        "since": since.isoformat() if since else None,
+        "project": project,
+    })
+    try:
+        # Write the script to a temp file on the remote, then execute it.
+        # This avoids shell-escaping the multi-line Python through SSH+zsh.
+        write_cmd = f"cat > /tmp/_oc_search.py << 'PYEOF'\n{_REMOTE_SEARCH_SCRIPT}\nPYEOF"
+        proc = subprocess.run(
+            ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes",
+             REMOTE_HOST, write_cmd],
+            capture_output=True, timeout=10
+        )
+        if proc.returncode != 0:
+            return []
+        # Now run the script with payload on stdin
+        proc = subprocess.run(
+            ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes",
+             REMOTE_HOST, "python3 /tmp/_oc_search.py"],
+            input=search_payload.encode(),
+            capture_output=True, timeout=30
+        )
+        if proc.returncode != 0 or not proc.stdout.strip():
+            return []
+        remote_data = json.loads(proc.stdout.decode())
+        # Convert last_local strings back to datetime for sorting
+        for r in remote_data:
+            try:
+                r["last_local"] = datetime.fromisoformat(r["last_local"])
+            except (ValueError, TypeError):
+                r["last_local"] = datetime.now()
+        return remote_data
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError, OSError):
+        return []
+
+
+# The script that runs on the remote host. Receives JSON config as the last line on stdin.
+_REMOTE_SEARCH_SCRIPT = r'''
+import json, sqlite3, re, os, sys
+from datetime import datetime, timezone
+
+# Read all lines; the last non-empty line is the JSON payload
+lines = sys.stdin.read().strip().split("\n")
+payload = json.loads(lines[-1])
+terms = payload["terms"]
+match_any = payload["match_any"]
+since_str = payload["since"]
+project = payload["project"]
+
+since = None
+if since_str:
+    since = datetime.fromisoformat(since_str)
+
+db = "/home/zach/.local/share/opencode/opencode-stable.db"
+if not os.path.exists(db):
+    print("[]")
+    exit()
+
+conn = sqlite3.connect(db)
+conn.row_factory = sqlite3.Row
+
+sess_sql = "SELECT id, title, directory, time_created, time_updated FROM session"
+params = []
+conds = []
+if since:
+    since_ms = int(since.replace(tzinfo=timezone.utc).timestamp() * 1000)
+    conds.append("time_created >= ?")
+    params.append(since_ms)
+if project:
+    conds.append("LOWER(directory) LIKE ?")
+    params.append(f"%{project.lower()}%")
+if conds:
+    sess_sql += " WHERE " + " AND ".join(conds)
+sess_sql += " ORDER BY time_created DESC"
+
+sessions = conn.execute(sess_sql, params).fetchall()
+results = []
+patterns = [re.compile(re.escape(t), re.I) for t in terms]
+
+for sess in sessions:
+    sid = sess["id"]
+    title = sess["title"] or ""
+    directory = sess["directory"] or ""
+    tc = sess["time_created"]
+    tu = sess["time_updated"]
+
+    title_lower = title.lower()
+    term_hits = {t: (1 if t.lower() in title_lower else 0) for t in terms}
+
+    parts = conn.execute("SELECT data FROM part WHERE session_id = ?", (sid,)).fetchall()
+    snippets = {}
+    genesis = ""
+
+    for row in parts:
+        try:
+            data = json.loads(row["data"]) if isinstance(row["data"], str) else row["data"]
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        text = ""
+        if data.get("type") == "text" and "text" in data:
+            text = data["text"]
+        if not text:
+            continue
+        if not genesis and len(text.strip()) > 10:
+            c = text.strip()[:200]
+            if not c.startswith("<") and not c.startswith("Caveat:"):
+                genesis = c
+        for term, pat in zip(terms, patterns):
+            found = pat.findall(text)
+            if found:
+                term_hits[term] += len(found)
+                if term not in snippets:
+                    m = pat.search(text)
+                    s, e = max(0, m.start() - 50), m.end() + 50
+                    snippets[term] = ("claude", text[s:e].replace("\n", " ").strip())
+
+    matched = [t for t in terms if term_hits[t] > 0]
+    ok = bool(matched) if match_any else len(matched) == len(terms)
+    if not ok:
+        continue
+
+    last_local = datetime.fromtimestamp(tu / 1000, tz=timezone.utc).replace(tzinfo=None) if tu else (
+        datetime.fromtimestamp(tc / 1000, tz=timezone.utc).replace(tzinfo=None) if tc else datetime.now()
+    )
+
+    results.append({
+        "session_id": sid,
+        "path": "opencode:workbench",
+        "cwd": directory,
+        "branch": "",
+        "title": title,
+        "genesis": genesis or f"[title] {title}",
+        "opening": genesis or f"[title] {title}",
+        "first": datetime.fromtimestamp(tc / 1000, tz=timezone.utc).isoformat() if tc else "",
+        "last": datetime.fromtimestamp(tu / 1000, tz=timezone.utc).isoformat() if tu else "",
+        "last_local": last_local.isoformat() if isinstance(last_local, datetime) else str(last_local),
+        "matched_terms": matched,
+        "term_hits": {t: term_hits[t] for t in matched},
+        "total_hits": sum(term_hits[t] for t in matched),
+        "snippets": snippets,
+        "project_dir": "",
+        "source": "opencode",
+    })
+
+conn.close()
+print(json.dumps(results, default=str))
+'''

--- a/scripts/lib/opencode_search.py
+++ b/scripts/lib/opencode_search.py
@@ -6,23 +6,90 @@ Each session's text lives in the `part` table as JSON blobs in the `data` column
 This module queries that database and returns results compatible with
 `transcript_search.py` so `find-session.py` can merge both sources.
 
-The database is per-host; both hosts are checked when the other is reachable via SSH.
+The database is per-host. Every peer in PEERS is searched: the one that IS this
+machine is queried directly on disk, the rest over SSH. Which peer is "local" is
+resolved from this host's own interface addresses, never hardcoded — pinning one
+host as "the remote" made the search asymmetric, because from that host the SSH
+leg was a self-connection that failed and was silently swallowed, leaving the
+OTHER host's sessions permanently invisible.
 """
 import json
 import os
 import re
+import socket
 import sqlite3
 import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
 SNIPPET_PAD = 50
 GENESIS_CHARS = 200
 
-# Both hosts' DB paths, checked in order.
-LOCAL_DB = Path.home() / ".local" / "share" / "opencode" / "opencode-stable.db"
-REMOTE_HOST = "zach@10.42.0.30"
-REMOTE_DB = Path("/home/zach/.local/share/opencode/opencode-stable.db")
+DB_RELPATH = Path(".local") / "share" / "opencode" / "opencode-stable.db"
+LOCAL_DB = Path.home() / DB_RELPATH
+
+# Every host that holds an opencode DB, by Nebula address. Whichever of these IS
+# the machine we are running on is read from disk; the others go over SSH.
+PEERS = (
+    ("workbench", "10.42.0.30", "zach"),
+    ("laptop", "10.42.0.100", "zach"),
+)
+REMOTE_DB = Path("/home/zach") / DB_RELPATH
+
+
+def configured_peers():
+    """PEERS, unless `DEVRC_OPENCODE_PEERS` overrides it.
+
+    Format: comma-separated `label:addr:user`. An EMPTY value means "no peers".
+
+    🔴 This exists so the test suite can be hermetic BY CONSTRUCTION. Relying on
+    the real DB and SSH merely being absent is not hermeticity: they ARE absent in
+    the nix sandbox tier and present on the dev host, so the same test would pass
+    in one tier and fail in the other — which is exactly how it failed here.
+    """
+    raw = os.environ.get("DEVRC_OPENCODE_PEERS")
+    if raw is None:
+        return PEERS
+    peers = []
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        parts = chunk.split(":")
+        if len(parts) != 3:
+            raise ValueError(
+                "DEVRC_OPENCODE_PEERS entries are label:addr:user — got " + repr(chunk))
+        peers.append(tuple(parts))
+    return tuple(peers)
+
+
+def configured_local_db():
+    """LOCAL_DB, unless `DEVRC_OPENCODE_DB` overrides it (tests, or a moved store)."""
+    override = os.environ.get("DEVRC_OPENCODE_DB")
+    return Path(override) if override else LOCAL_DB
+
+
+def _own_addresses():
+    """This host's own IPv4 addresses, for deciding which peer is us.
+
+    Falls back to hostname resolution if `ip` is unavailable; an empty set is
+    safe — it just means no peer is treated as local, and the SSH leg reports
+    its own failure rather than silently returning nothing.
+    """
+    addrs = set()
+    try:
+        proc = subprocess.run(["ip", "-4", "-o", "addr", "show"],
+                              capture_output=True, text=True, timeout=5)
+        addrs.update(re.findall(r"inet (\d+\.\d+\.\d+\.\d+)", proc.stdout))
+    except (OSError, subprocess.SubprocessError):
+        pass
+    if not addrs:
+        try:
+            addrs.update(socket.gethostbyname_ex(socket.gethostname())[2])
+        except OSError:
+            pass
+    return addrs
 
 
 def _local_naive(dt):
@@ -71,10 +138,21 @@ def _extract_text(data_str):
     return "\n".join(parts)
 
 
+def _warn(msg):
+    """Report a degraded leg on stderr.
+
+    A peer that cannot be reached means the result set is INCOMPLETE. Returning
+    an empty list quietly is indistinguishable from "nothing matched", so every
+    failure gets a line here.
+    """
+    print(msg, file=sys.stderr)
+
+
 def _query_db(db_path, terms, patterns, *, match_any=False, since=None, project="",
-              limit=None):
+              limit=None, label="local"):
     """Search one opencode database. Returns list of result dicts."""
     if not db_path.exists():
+        _warn(f"opencode search: no database at {db_path} — skipping {label}")
         return []
 
     conn = sqlite3.connect(str(db_path))
@@ -158,7 +236,7 @@ def _query_db(db_path, terms, patterns, *, match_any=False, since=None, project=
 
             results.append({
                 "session_id": sess_id,
-                "path": f"opencode:{db_path}",
+                "path": f"opencode:{label}",
                 "cwd": directory,
                 "branch": "",
                 "title": title,
@@ -191,18 +269,30 @@ def search_opencode(terms, *, match_any=False, since=None, project="", limit=Non
     """
     patterns = [re.compile(re.escape(t), re.I) for t in terms]
     all_results = []
+    peers = configured_peers()
+    local_db = configured_local_db()
+    mine = _own_addresses() if peers else set()
 
-    # Local
-    all_results.extend(_query_db(LOCAL_DB, terms, patterns,
-                                 match_any=match_any, since=since, project=project))
+    for label, addr, user in peers:
+        if addr in mine:
+            # This peer is us — read the DB off local disk.
+            all_results.extend(_query_db(local_db, terms, patterns, match_any=match_any,
+                                         since=since, project=project, label=label))
+            continue
+        try:
+            all_results.extend(_query_remote(f"{user}@{addr}", label, terms, patterns,
+                                             match_any=match_any, since=since,
+                                             project=project))
+        except Exception as exc:  # noqa: BLE001 — reported, never swallowed
+            _warn(f"opencode search: peer {label} ({addr}) failed: {exc}")
 
-    # Remote (best-effort SSH query — no file transfer needed)
-    try:
-        remote_results = _query_remote(terms, patterns, match_any=match_any,
-                                       since=since, project=project)
-        all_results.extend(remote_results)
-    except Exception:
-        pass  # Remote unreachable; skip silently
+    if not any(addr in mine for _, addr, _ in peers):
+        # We are on a host that is not among the peers (or address detection
+        # failed): search the local DB anyway so we never silently skip our own
+        # sessions. With peers explicitly emptied this is the ONLY leg, which is
+        # what makes an injected fixture DB a complete corpus.
+        all_results.extend(_query_db(local_db, terms, patterns, match_any=match_any,
+                                     since=since, project=project, label="local"))
 
     # Sort by relevance + recency, same as transcript_search
     all_results.sort(
@@ -216,33 +306,51 @@ def search_opencode(terms, *, match_any=False, since=None, project="", limit=Non
     return all_results
 
 
-def _query_remote(terms, patterns, *, match_any=False, since=None, project=""):
-    """Query the workbench's opencode DB via SSH. Returns result dicts."""
+def _query_remote(ssh_target, label, terms, patterns, *, match_any=False, since=None,
+                  project=""):
+    """Query one peer's opencode DB via SSH. Returns result dicts.
+
+    Every failure path warns rather than returning a bare [] — an unreachable
+    peer and a peer with no matches are different facts and must not print the
+    same thing.
+    """
     search_payload = json.dumps({
         "terms": terms,
         "match_any": match_any,
         "since": since.isoformat() if since else None,
         "project": project,
+        "label": label,
     })
+    remote_script = f"/tmp/_oc_search_{label}.py"
     try:
         # Write the script to a temp file on the remote, then execute it.
         # This avoids shell-escaping the multi-line Python through SSH+zsh.
-        write_cmd = f"cat > /tmp/_oc_search.py << 'PYEOF'\n{_REMOTE_SEARCH_SCRIPT}\nPYEOF"
+        write_cmd = f"cat > {remote_script} << 'PYEOF'\n{_REMOTE_SEARCH_SCRIPT}\nPYEOF"
         proc = subprocess.run(
             ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes",
-             REMOTE_HOST, write_cmd],
+             ssh_target, write_cmd],
             capture_output=True, timeout=10
         )
         if proc.returncode != 0:
+            _warn(f"opencode search: peer {label} ({ssh_target}) unreachable — "
+                  f"its sessions are NOT in these results "
+                  f"({proc.stderr.decode(errors='replace').strip()[:200]})")
             return []
         # Now run the script with payload on stdin
         proc = subprocess.run(
             ["ssh", "-o", "ConnectTimeout=5", "-o", "BatchMode=yes",
-             REMOTE_HOST, "python3 /tmp/_oc_search.py"],
+             ssh_target, f"python3 {remote_script}"],
             input=search_payload.encode(),
-            capture_output=True, timeout=30
+            capture_output=True, timeout=120
         )
-        if proc.returncode != 0 or not proc.stdout.strip():
+        if proc.returncode != 0:
+            _warn(f"opencode search: peer {label} query failed (exit "
+                  f"{proc.returncode}) — its sessions are NOT in these results "
+                  f"({proc.stderr.decode(errors='replace').strip()[:200]})")
+            return []
+        if not proc.stdout.strip():
+            _warn(f"opencode search: peer {label} returned no output — "
+                  f"its sessions are NOT in these results")
             return []
         remote_data = json.loads(proc.stdout.decode())
         # Convert last_local strings back to datetime for sorting
@@ -252,7 +360,10 @@ def _query_remote(terms, patterns, *, match_any=False, since=None, project=""):
             except (ValueError, TypeError):
                 r["last_local"] = datetime.now()
         return remote_data
-    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError, OSError):
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError,
+            OSError) as exc:
+        _warn(f"opencode search: peer {label} ({ssh_target}) failed: "
+              f"{type(exc).__name__}: {exc} — its sessions are NOT in these results")
         return []
 
 
@@ -268,6 +379,7 @@ terms = payload["terms"]
 match_any = payload["match_any"]
 since_str = payload["since"]
 project = payload["project"]
+label = payload.get("label", "remote")
 
 since = None
 if since_str:
@@ -349,7 +461,7 @@ for sess in sessions:
 
     results.append({
         "session_id": sid,
-        "path": "opencode:workbench",
+        "path": "opencode:" + label,
         "cwd": directory,
         "branch": "",
         "title": title,

--- a/scripts/tests/test_opencode_search.py
+++ b/scripts/tests/test_opencode_search.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Tests for `scripts/lib/opencode_search.py` — the opencode-session half of find-session.
+
+🔴 WHICH TESTS ARE REGRESSION COVERAGE, AND AGAINST WHICH BASE.
+
+  `RED_AT_CF4ABDE9` — watched FAIL against cf4abde9, this branch's own first head, where
+                      `REMOTE_HOST` was a single hardcoded `zach@10.42.0.30`. MEASURED on
+                      2026-08-26 from both machines before the fix:
+
+                        term         laptop DB   workbench DB   found FROM laptop   FROM workbench
+                        sensei               0             46                  46               46
+                        verify-117           3              0                   3                0
+
+                      The last cell is the bug. From the workbench the SSH leg was a
+                      self-connection ("Permission denied"), `except Exception: pass`
+                      swallowed it, and the laptop's 377 sessions were permanently
+                      invisible with no diagnostic on stderr.
+
+Everything not in that list is an invariant guard — it pins something worth keeping, but
+is NOT evidence that a bug was fixed.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
+import opencode_search as ocs  # noqa: E402
+
+RED_AT_CF4ABDE9 = {
+    "test_the_host_we_are_running_on_is_never_an_ssh_target",
+    "test_every_peer_that_is_not_us_is_queried",
+    "test_an_unreachable_peer_warns_instead_of_returning_a_silent_empty",
+}
+
+
+@pytest.fixture
+def spy(monkeypatch):
+    """Record which peers went down the local path and which down the SSH path."""
+    calls = {"local": [], "ssh": []}
+
+    def fake_query_db(db_path, terms, patterns, **kw):
+        calls["local"].append(kw.get("label"))
+        return []
+
+    def fake_query_remote(ssh_target, label, terms, patterns, **kw):
+        calls["ssh"].append((label, ssh_target))
+        return []
+
+    monkeypatch.setattr(ocs, "_query_db", fake_query_db)
+    monkeypatch.setattr(ocs, "_query_remote", fake_query_remote)
+    return calls
+
+
+# --- the regression: symmetry across hosts -----------------------------------------
+
+@pytest.mark.parametrize("own_addr,expected_local,expected_ssh", [
+    ("10.42.0.30", "workbench", ("laptop", "zach@10.42.0.100")),
+    ("10.42.0.100", "laptop", ("workbench", "zach@10.42.0.30")),
+])
+def test_the_host_we_are_running_on_is_never_an_ssh_target(
+        monkeypatch, spy, own_addr, expected_local, expected_ssh):
+    """Self-SSH is the whole bug. Whichever peer we ARE is read off local disk.
+
+    Parameterised over BOTH hosts deliberately: the pre-fix code was correct from
+    the laptop and broken from the workbench, so a single-host measurement would
+    have passed while the defect was live.
+    """
+    monkeypatch.setattr(ocs, "_own_addresses", lambda: {own_addr})
+    ocs.search_opencode(["anything"])
+
+    assert spy["local"] == [expected_local]
+    assert spy["ssh"] == [expected_ssh]
+    assert own_addr not in [t for _, t in spy["ssh"]], \
+        f"{own_addr} is this host — it must never be an SSH target"
+
+
+def test_every_peer_that_is_not_us_is_queried(monkeypatch, spy):
+    """The peer set is covered exactly once: no host silently dropped, none doubled."""
+    monkeypatch.setattr(ocs, "_own_addresses", lambda: {"10.42.0.30"})
+    ocs.search_opencode(["anything"])
+
+    covered = set(spy["local"]) | {label for label, _ in spy["ssh"]}
+    assert covered == {label for label, _, _ in ocs.PEERS}
+    assert len(spy["local"]) + len(spy["ssh"]) == len(ocs.PEERS), "a peer was queried twice"
+
+
+def test_a_host_outside_the_peer_table_still_searches_its_own_db(monkeypatch, spy):
+    """Address detection failing must not mean we skip our OWN sessions."""
+    monkeypatch.setattr(ocs, "_own_addresses", set)
+    ocs.search_opencode(["anything"])
+
+    assert spy["local"] == ["local"], "local DB must be searched even when we match no peer"
+    assert len(spy["ssh"]) == len(ocs.PEERS), "all peers are remote when none is us"
+
+
+# --- the regression: a degraded leg must be audible --------------------------------
+
+def test_an_unreachable_peer_warns_instead_of_returning_a_silent_empty(
+        monkeypatch, capsys):
+    """An unreachable peer and a peer with no matches must not print the same thing.
+
+    Pre-fix, `except Exception: pass` made an incomplete result set indistinguishable
+    from an honest zero — which is exactly how the workbench gap went unnoticed.
+    """
+    monkeypatch.setattr(ocs, "_own_addresses", lambda: {"10.42.0.30"})
+    monkeypatch.setattr(ocs, "_query_db", lambda *a, **k: [])
+
+    def refuse(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=[], returncode=255, stdout=b"",
+            stderr=b"zach@10.42.0.100: Permission denied (publickey).")
+
+    monkeypatch.setattr(ocs.subprocess, "run", refuse)
+    results = ocs.search_opencode(["anything"])
+
+    err = capsys.readouterr().err
+    assert results == []
+    assert "laptop" in err, "the warning must name WHICH peer is missing"
+    assert "NOT in these results" in err, \
+        "the warning must say the result set is incomplete, not merely that something failed"
+
+
+def test_a_missing_local_database_warns(monkeypatch, capsys):
+    """A host with no opencode DB is a legitimate state — but it is still a gap."""
+    monkeypatch.setattr(ocs, "_own_addresses", lambda: {"10.42.0.30"})
+    monkeypatch.setattr(ocs, "_query_remote", lambda *a, **k: [])
+    monkeypatch.setattr(ocs, "LOCAL_DB", Path("/nonexistent/opencode-stable.db"))
+    ocs.search_opencode(["anything"])
+
+    assert "no database at" in capsys.readouterr().err
+
+
+# --- invariant guards ---------------------------------------------------------------
+
+def test_results_are_tagged_with_the_peer_they_came_from(monkeypatch):
+    """`path` must identify the HOST, so a merged result set stays attributable.
+
+    Pre-fix the remote script hardcoded `opencode:workbench` for whatever host it ran
+    on, which would mislabel every laptop row the moment a second peer was added.
+    """
+    monkeypatch.setattr(ocs, "_own_addresses", lambda: {"10.42.0.30"})
+    assert '"opencode:" + label' in ocs._REMOTE_SEARCH_SCRIPT, \
+        "the remote script must tag rows with the peer label it was given"
+    assert "opencode:workbench" not in ocs._REMOTE_SEARCH_SCRIPT, \
+        "a hardcoded host label mislabels every other peer's rows"
+
+
+def test_the_remote_script_receives_the_label_it_must_tag_with():
+    """Seam guard: the caller sends `label`, the remote script reads `label`."""
+    assert '"label": label' in _source_of(ocs._query_remote)
+    assert 'payload.get("label"' in ocs._REMOTE_SEARCH_SCRIPT
+
+
+def test_the_red_at_base_ledger_names_real_tests():
+    """A ledger naming a test that does not exist reads as coverage while providing none."""
+    here = set(globals())
+    missing = RED_AT_CF4ABDE9 - here
+    assert not missing, f"ledger names tests that do not exist: {sorted(missing)}"
+
+
+def _source_of(fn):
+    import inspect
+    return inspect.getsource(fn)

--- a/scripts/tests/test_skill_tiers.py
+++ b/scripts/tests/test_skill_tiers.py
@@ -85,12 +85,12 @@ MIN_SKILLS = 30
 # --------------------------------------------------------------------------- #
 MEASURED_ENTRIES = 37
 MEASURED_TIER_A_ENTRIES = 24
-MEASURED_TIER_A_CHARS = 8_952
+MEASURED_TIER_A_CHARS = 8_909
 # devrc's whole listing under the ledger (tier A in full, tier B name-only).
-MEASURED_UNDER_LEDGER_CHARS = 9_144
+MEASURED_UNDER_LEDGER_CHARS = 9_101
 # ...and what the same 37 entries would cost with every skill tier A. The
 # difference is what the ledger buys: 3,907 chars.
-MEASURED_ALL_TIER_A_CHARS = 13_051
+MEASURED_ALL_TIER_A_CHARS = 13_008
 
 # 🔴 THE TIER-A RATCHET, in the REAL formula: the tier-A block cost
 # `sum(len(name) + 4 + min(len(desc), 1536)) + (n - 1)`.

--- a/scripts/tests/test_transcript_search.py
+++ b/scripts/tests/test_transcript_search.py
@@ -115,23 +115,40 @@ def _write(root, project, session_id, lines, subagent=False):
     return p
 
 
-def _run_find_session(root, argv):
+def _run_find_session(root, argv, opencode_db=None):
     """Run scripts/find-session.py against `root`, return (stdout, parsed-json-or-None).
 
     Deliberately drives the CLI module, not the shared library: this is the harness the
     RED_AT_BASE tests were replayed through against a tree where the library did not
     exist yet, so it has to work on both.
+
+    🔴 `find-session.py` searches TWO corpora. `ROOT` scopes the Claude one; the
+    opencode one is scoped by the two env vars below, and it must be scoped
+    EXPLICITLY rather than left to chance. Unscoped, these tests read the live
+    opencode DBs and SSH to the other host, so a fixture asserting "exactly this
+    one session" collected whatever real sessions happened to match — and it
+    would still have passed in the nix sandbox tier, where no DB or SSH exists.
+    `opencode_db` defaults to a path that cannot exist, i.e. an empty corpus.
     """
     mod = _load(SCRIPTS / "find-session.py", "fs_under_test")
     mod.ROOT = str(root)
     buf = io.StringIO()
     old_argv = sys.argv
+    old_env = {k: os.environ.get(k)
+               for k in ("DEVRC_OPENCODE_PEERS", "DEVRC_OPENCODE_DB")}
+    os.environ["DEVRC_OPENCODE_PEERS"] = ""          # no host is contacted
+    os.environ["DEVRC_OPENCODE_DB"] = str(opencode_db or Path(root) / "_no_opencode.db")
     sys.argv = ["find-session.py"] + list(argv)
     try:
         with contextlib.redirect_stdout(buf):
             mod.main()
     finally:
         sys.argv = old_argv
+        for k, v in old_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
     out = buf.getvalue()
     parsed = None
     if "--json" in argv:
@@ -144,6 +161,69 @@ def _run_find_session(root, argv):
 
 def _ids(parsed):
     return sorted(x["session_id"] for x in (parsed or []))
+
+
+def _write_opencode_db(path, sessions):
+    """Build an opencode-shaped SQLite store. `sessions` is [(id, title, cwd, texts)]."""
+    import sqlite3
+    conn = sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE session (id TEXT PRIMARY KEY, title TEXT, "
+                 "directory TEXT, time_created INTEGER, time_updated INTEGER)")
+    conn.execute("CREATE TABLE part (session_id TEXT, data TEXT)")
+    stamp = int(datetime(2026, 8, 25, 12, 0).timestamp() * 1000)
+    for sid, title, cwd, texts in sessions:
+        conn.execute("INSERT INTO session VALUES (?,?,?,?,?)",
+                     (sid, title, cwd, stamp, stamp))
+        for t in texts:
+            conn.execute("INSERT INTO part VALUES (?,?)",
+                         (sid, json.dumps({"type": "text", "text": t})))
+    conn.commit()
+    conn.close()
+    return path
+
+
+# --------------------------- the opencode corpus is actually wired in ---------------
+
+def test_the_opencode_corpus_is_merged_into_the_default_search():
+    """🔴 POSITIVE CONTROL for the muting in `_run_find_session`.
+
+    That helper points the opencode corpus at a path that cannot exist, so every
+    other test in this file sees an EMPTY opencode corpus. A harness wired to
+    nothing would satisfy all of them identically — a reassuring zero that is
+    indistinguishable from "the leg was deleted". This feeds a corpus that MUST
+    produce a non-zero count and watches the number move.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        _write(tmp, "-proj", "claudeone", [_user("zzmergetok")])
+        db = _write_opencode_db(Path(tmp) / "oc.db", [
+            ("ses_zz1", "a title", "/home/zach/workspace/devrc", ["zzmergetok here"]),
+        ])
+
+        _, empty = _run_find_session(tmp, ["--json", "zzmergetok"])
+        _, merged = _run_find_session(tmp, ["--json", "zzmergetok"], opencode_db=db)
+
+        assert _ids(empty) == ["claudeone"], "control: no opencode corpus, Claude row only"
+        assert _ids(merged) == ["claudeone", "ses_zz1"], merged
+        oc = [r for r in merged if r["session_id"] == "ses_zz1"][0]
+        assert oc["source"] == "opencode" and oc["path"] == "opencode:local", oc
+
+
+def test_opencode_only_and_claude_only_partition_the_corpus():
+    """The two flags must be complements, not two spellings of the same filter."""
+    with tempfile.TemporaryDirectory() as tmp:
+        _write(tmp, "-proj", "claudeone", [_user("zzparttok")])
+        db = _write_opencode_db(Path(tmp) / "oc.db", [
+            ("ses_zz2", "t", "/home/zach/workspace/devrc", ["zzparttok here"]),
+        ])
+        _, both = _run_find_session(tmp, ["--json", "zzparttok"], opencode_db=db)
+        _, cc = _run_find_session(tmp, ["--json", "--claude-only", "zzparttok"],
+                                  opencode_db=db)
+        _, oc = _run_find_session(tmp, ["--json", "--opencode-only", "zzparttok"],
+                                  opencode_db=db)
+
+        assert _ids(cc) == ["claudeone"], cc
+        assert _ids(oc) == ["ses_zz2"], oc
+        assert _ids(both) == sorted(_ids(cc) + _ids(oc)), both
 
 
 # --------------------------------------------------------------- corpus enumeration


### PR DESCRIPTION
## What

Adds opencode session search to `find-session.py` so it covers both Claude Code transcripts and opencode's SQLite-backed sessions.

## Why

`find-session.py` only searched `~/.claude/projects/**/*.jsonl`. opencode sessions (stored in `~/.local/share/opencode/opencode-stable.db`) were invisible. Meanwhile `opencode session list` is project-scoped — running from `~` shows only the "global" project's sessions, missing all project-specific work.

## How

- **`scripts/lib/opencode_search.py`** — queries local DB directly, workbench via SSH+python (the DB is 1.5GB, SCP would time out)
- **`find-session.py`** — merges both sources by default, ranked by relevance + recency
  - `--claude-only` / `--opencode-only` flags to scope
  - `[opencode]` tag in output so you know which source a hit came from
  - Resume via `opencode --session <id>` for opencode hits

## Verification

```bash
# Before: no results for today's opencode sessions
python3 scripts/find-session.py clawgate tab switcher --since 2026-08-26

# After: finds the workbench session that was previously invisible
python3 scripts/find-session.py clawgate tab switcher --since 2026-08-26
```

Remote host connected via Nebula (`zach@10.42.0.30`).
