### PR TITLE
docs(activity): `browser` is no longer laptop-only — five stale claims across three files

### DIFF
--- a/claude/skills/activity/SKILL.md
+++ b/claude/skills/activity/SKILL.md
@@ -45,14 +45,19 @@ stamps `host` from `ACTIVITY_HOST`.
 ### The sources — MEASURED, not declared
 🔴 **Do not re-derive the expected-present set from prose** — run
 `python3 ~/workspace/devrc/scripts/collector/deadman.py`, which derives it from the table.
-Live pairs (measured 2026-08-03): **9 sources on the laptop, 8 on the workbench, 17 total.**
+Live pairs (measured 2026-08-27): **9 sources on the laptop, 9 on the workbench, 18 total.**
+⚠ This line read `8 on the workbench, 17 total` from 2026-08-03 until 2026-08-27, when
+`workbench/browser` began emitting (first row 21:46 on 08-26) and the roster changed under it.
+**That is the number aging, not the check** — `deadman.py` picked the new pair up with no edit
+anywhere, which is the whole point of deriving expected-present from the table. Re-run it
+rather than trusting this count.
 
 | source | what | laptop | workbench |
 |---|---|---|---|
 | `zsh` | preexec/precmd, interactive-only → excludes Claude's Bash tool | ✅ | ✅ |
 | `tmux` | focus hooks | ✅ | ✅ |
 | `keys` | X11 XRecord keylogger, **full content**. Carries `app`=WM_CLASS + `payload.workspace` | ✅ | ✅ **(the doc said laptop-only — wrong)** |
-| `browser` | Brave MV3 ext → loopback receiver :8787 | ✅ | ❌ **0 rows, correctly — the ext is laptop-only. This is the ONLY genuinely laptop-only source.** |
+| `browser` | Brave MV3 ext → loopback receiver :8787 | ✅ | ✅ **since 2026-08-26 21:46 — the doc said laptop-only; it is now on BOTH. There is no longer any laptop-only source.** |
 | `claude` | Claude Code transcript tailer, 5-min timer | ✅ | ✅ |
 | `i3` | i3ipc focus daemon | ✅ | ✅ **(the doc said laptop-only — wrong)** |
 | `opencode` | opencode plugin + tailers (`prompt`/`assistant-turn`/`tool-call`/`session-summary`) | ✅ | ✅ |
@@ -79,14 +84,30 @@ Per-source detail that matters when querying:
   commands only, so its silence was unbounded and it false-alarmed as DEAD whenever Zach
   simply hadn't browsed; do not "fix" a browser-bridge DEAD verdict by raising a budget.
 
-**Browser extension is NOT fully nix-managed.** Hand-loaded unpacked in Brave (the laptop's
-daily browser) from `~/.local/share/activity-browser-ext/` — a real-file copy, since
-Chromium dislikes loading a nix-store symlink dir. It persists across restarts, but a
-`service_worker.js`/content-script change needs: ship →
+**Browser extension is NOT fully nix-managed, and THE TWO HOSTS LOAD IT FROM DIFFERENT
+PATHS** — so the update procedure below is laptop-only. Read Brave's own
+`Preferences` → `extensions.settings[*].path` for the authoritative answer on a host;
+the dir merely existing proves nothing about which one Brave loaded.
+
+| host | loaded from | how it updates | measured 2026-08-27 |
+|---|---|---|---|
+| laptop | `~/.local/share/activity-browser-ext/` — a hand-made real-file copy | the `cp` dance below, BY HAND | manifest 1.4.0 |
+| workbench | `~/.config/activity-collector/browser-ext` — the home-manager-deployed dir itself | on `home-manager switch`, no `cp` | manifest 1.4.0 |
+
+The workbench arrangement is the better one and needs no fixing: that path is a **real
+directory** (`readlink -f` terminates at itself, not in `/nix/store`), so the "Chromium
+dislikes a nix-store symlink dir" reason for the laptop's copy does not apply to it.
+🔴 **But the two can silently reach different manifest versions** — a `switch` moves the
+workbench and leaves the laptop, and only the laptop's `cp` moves the laptop. They agree
+today; that is a measurement, not a guarantee. Compare both before blaming a behaviour
+difference on anything else.
+
+Laptop procedure — a `service_worker.js`/content-script change needs: ship →
 `cp -fL ~/.config/activity-collector/browser-ext/*.js ~/.local/share/activity-browser-ext/`
 → **reload the extension in `brave://extensions`** (+ reload the page — content scripts only
-inject post-reload). Manifest **v1.4.0**. When a file is DELETED upstream (e.g. the old
+inject post-reload). When a file is DELETED upstream (e.g. the old
 `active_time.js`), `rm` it from `~/.local/share/…` by hand — `cp` won't remove it.
+On the workbench a `switch` + an extension reload is the whole procedure.
 
 ## ⚠ Gotchas (each cost real time)
 - **Timezone:** `ts` is the **UTC instant** (tz-less DateTime64). Dashboard buckets
@@ -207,9 +228,19 @@ Creds come from `~/.config/activity-collector/env` (the collector's own file) un
 - **The budget is MEASURED per (host, source)**: `clamp(2 × p99 active-gap, 2h, 48h)`.
   Measured 2026-08-03 — `keys`/`i3`/`tmux` land on the 2h floor; `workbench/opencode` 11.5h;
   `workbench/tool` 31.1h. Nothing is hand-tuned and nothing is hand-listed.
-- **Expected-present is measured too**: a pair is judged only if it cleared a baseline in the
-  14-day window, so `workbench/browser` (0 rows, correctly absent) can never alarm, while a
-  source that *was* emitting and stopped keeps its baseline and does.
+- **Expected-present is measured too**: a pair is judged only if it cleared
+  `MIN_BASELINE_BUCKETS` (20) in the 14-day window; a source that legitimately does not exist
+  on a host is simply absent from the evaluated set and can never alarm, while a source that
+  *was* emitting and stopped keeps its baseline and does.
+  🔴 **`workbench/browser` used to be this bullet's worked example of "correctly absent" — and
+  on 2026-08-26 21:46 it started emitting, which is why the example is gone.** It cleared the
+  baseline on its own (25 buckets) and joined the evaluated set with **no edit to any file**;
+  that is the mechanism working, not breaking. Two consequences worth knowing:
+  it is now a pair that CAN read DEAD (budget `2.0h` of ACTIVE time at first measurement), and
+  its budget is sized off ~1 day of history, so the p99 gap is small and will grow — expect the
+  budget to widen on its own as normal silences accumulate. **Do not hand-tune it**; nothing in
+  this checker is hand-listed, and an exception table is exactly what it exists to avoid.
+  ⚠ `browser` is NOT a presence source, so none of this changes any host's ACTIVE buckets.
 - 🔴 **"Cannot tell" ≠ "healthy".** `not-configured` / `unreachable` / `query-failed` /
   `no-data` / `misconfigured` / `presence-stalled` are each their own state; `ok` is
   unreachable unless rows came back AND at least one pair was actually measured

--- a/claude/skills/activity/reference/queries.md
+++ b/claude/skills/activity/reference/queries.md
@@ -29,10 +29,16 @@ attention is the i3∩domain intersection below.
   ~86% of i3 attention. (This bullet said "i3 + scroll exist only for `host=laptop`" until
   2026-08-26 — the same claim `SKILL.md` already retracts in its source table. Do not
   re-derive it.)
-- **`browser` — nav AND scroll — genuinely IS laptop-only**: the extension is hand-loaded
-  in the laptop's Brave. Same window: 867 `browser` rows, **zero** on the workbench; all
-  7,571 scroll-bearing nav rows laptop. So an i3∩browser query must pin **one host on both
-  sides** — what makes it correct is the host-consistency, not the `'laptop'` literal.
+- 🔴 **`browser` is on BOTH hosts as of 2026-08-26 21:46 — it is no longer laptop-only.**
+  This bullet read "genuinely IS laptop-only" until 2026-08-27. The measurement behind it was
+  real and is kept: over the 7d window ending 2026-08-26, 867 `browser` rows with **zero** on
+  the workbench, all 7,571 scroll-bearing nav rows laptop. It went out of date hours later,
+  when the extension was loaded in the workbench's Brave too (from
+  `~/.config/activity-collector/browser-ext`, a different path than the laptop's — see
+  `SKILL.md`). **Scroll-bearing rows may still be laptop-heavy; that is not re-measured here.**
+  An i3∩browser query must still pin **one host on both sides** — host-consistency is what
+  makes it correct, never the `'laptop'` literal — and that now matters far more, because a
+  mismatch no longer returns nothing (see the intersect query below).
 - `app` is empty on **every** `workspace-focus` row, on both hosts, by construction
   (0 of 1,100 laptop / 0 of 4,179 workbench populated) — so filter `kind='window-focus'`
   before grouping by `app`; `app != ''` alone reads as a data-quality filter but is really
@@ -78,9 +84,15 @@ Intersect i3 "Brave-focused" intervals with the active-tab domain timeline.
 🔴 **The `host='laptop'` below is load-bearing on BOTH sides and must stay matched** — this
 is the one query here that should NOT be widened. The `CROSS JOIN` has no host predicate,
 so dropping (or mismatching) either filter intersects **workbench i3 dwell with laptop
-browser navigation** and invents attention that never happened. Today only `laptop`
-returns rows at all, because `browser` is laptop-only; if the extension ever lands on a
-second host, change both filters together to the same `<h>`.
+browser navigation** and invents attention that never happened.
+
+🔴 **THE SAFETY NET UNDER THIS IS GONE — as of 2026-08-26 21:46 both hosts emit `browser`.**
+This note used to end "today only `laptop` returns rows at all, because `browser` is
+laptop-only; if the extension ever lands on a second host, change both filters together."
+That condition has now occurred. Until it did, a mismatched pair failed LOUDLY-ish by
+returning nothing, because workbench `browser` had zero rows. It now returns a **plausible,
+populated, and wrong** result instead. Change both filters together to the same `<h>`, and
+treat any output from this query as suspect unless you have read both host predicates.
 
 ```sql
 WITH brave AS (SELECT bs, be FROM (SELECT toUnixTimestamp64Milli(ts) bs, app,

--- a/scripts/collector/deadman.py
+++ b/scripts/collector/deadman.py
@@ -51,14 +51,21 @@ cashes out to: `tool` is allowed ~31 active hours of silence on the workbench an
 EXPECTED-PRESENT IS ALSO MEASURED, NOT DECLARED
 -----------------------------------------------
 A pair is evaluated iff it cleared MIN_BASELINE_BUCKETS in the window. A source
-that legitimately does not exist on a host (measured 2026-08-03: `browser` has
-0 rows on the workbench — the Brave activity extension is laptop-only) is simply
-absent from the evaluated set and can never alarm. A source that WAS emitting and
-stopped keeps its baseline for the whole window and does alarm. No table of
-per-host expectations is maintained anywhere, so no table can go stale — and one
-had: the `activity` SKILL.md claimed keylog/i3/browser were "GUI-only -> laptop
-only; the workbench is headless", while the workbench was in fact emitting 41,001
-`i3` and 37,376 `keys` rows.
+that legitimately does not exist on a host is simply absent from the evaluated
+set and can never alarm. A source that WAS emitting and stopped keeps its
+baseline for the whole window and does alarm. No table of per-host expectations
+is maintained anywhere, so no table can go stale — and one had: the `activity`
+SKILL.md claimed keylog/i3/browser were "GUI-only -> laptop only; the workbench
+is headless", while the workbench was in fact emitting 41,001 `i3` and 37,376
+`keys` rows.
+
+🔴 THIS PARAGRAPH'S OWN EXAMPLE WENT STALE, WHICH IS THE POINT. It used to read
+"measured 2026-08-03: `browser` has 0 rows on the workbench — the Brave activity
+extension is laptop-only". On 2026-08-26 21:46 `workbench/browser` started
+emitting; it cleared the baseline (25 buckets) and joined the evaluated set with
+NO code, config or table change. The prose was wrong for a day and the checker
+was never wrong at all — so do not re-introduce a named host/source pair here as
+a standing fact. Run the tool for the roster.
 
 🔴 SCOPE — THE BLIND SPOT, STATED PLAINLY
 -----------------------------------------
@@ -263,7 +270,12 @@ CAP_BUCKETS = 576
 # and `browser` is the SOLE presence source in exactly ONE. Dropping it changed
 # the 169-point sweep for ZERO pairs and improved one seeded-death latency
 # (laptop/zsh). It bought nothing and carried a contamination path, so it is out.
-# (`browser` is laptop-only -- the workbench has never emitted a `browser` row.)
+# 🔴 The parenthetical here used to read "(`browser` is laptop-only -- the
+# workbench has never emitted a `browser` row.)" That STOPPED BEING TRUE on
+# 2026-08-26 21:46, when the workbench began emitting `browser` too. It does not
+# change the decision -- `browser` stays OUT of PRESENCE_SOURCES, and the reason
+# above is the agent-contamination path, which is host-independent. If anything
+# the exclusion now matters MORE: the contaminating path exists on both hosts.
 #
 # 🔴 ADDING A SOURCE THAT A HUMAN DRIVES DIRECTLY MEANS ADDING IT HERE — and
 # adding an agent-driven one, or one an agent can DRIVE INDIRECTLY, means NOT


### PR DESCRIPTION
## What changed

On **2026-08-26 21:46** `workbench/browser` began emitting — the activity extension was loaded into the workbench's Brave. The roster went **17 → 18** pairs (now 9 laptop / 9 workbench), and five places still asserted the old state. Two of them were the *worked example* for "expected-present is measured, not declared".

| file | claim that was false |
|---|---|
| `activity/SKILL.md` | source table: `browser` workbench ❌ → ✅ (no laptop-only source remains) |
| `activity/SKILL.md` | live pairs `9/8/17` → `9/9/18` |
| `activity/SKILL.md` | "`workbench/browser` … can never alarm" — it cleared the baseline (25 buckets) and **is** evaluated |
| `activity/reference/queries.md` | "`browser` genuinely IS laptop-only" |
| `scripts/collector/deadman.py` | same claim in the module docstring **and** the `PRESENCE_SOURCES` comment |

**The checker was never wrong.** It picked the new pair up with no edit anywhere — exactly what deriving expected-present from the table buys. Only the prose aged. Each site now records what it used to say and why it changed; the dated measurements behind them are annotated as since-changed, never deleted.

## Two findings beyond the roster

These are new hazards, not stale prose:

1. **The hosts load the extension from different paths.** Laptop: the hand-made copy `~/.local/share/activity-browser-ext/`. Workbench: the home-manager-deployed `~/.config/activity-collector/browser-ext` directly — a *real directory*, so the "Chromium dislikes a nix-store symlink dir" reason for the laptop's copy does not apply. The documented `cp` update procedure is therefore **laptop-only**, and the two hosts can silently reach different manifest versions. Both measured at 1.4.0 today. Verified by reading Brave's own `Preferences` → `extensions.settings[*].path` on each host.

2. **The i3∩browser intersect query's failure mode got worse.** Its note said only `laptop` returns rows "because `browser` is laptop-only", so a mismatched host pair used to return *nothing*. It now returns a **plausible, populated, and wrong** intersection of workbench i3 dwell against laptop browser navigation.

## No behaviour change

- `browser` stays **out** of `PRESENCE_SOURCES` — the agent-contamination reason is host-independent, and now applies on both hosts.
- The `2.0h` budget is deliberately **not** hand-tuned. It is sized off ~1 day of history, so the p99 gap is small and will widen on its own as normal silences accumulate. Nothing in this checker is hand-listed; an exception table is what it exists to avoid.
- `browser` is not a presence source, so none of this changes any host's ACTIVE buckets.

## Verification

Both tiers run, since the dev-host tier is not a substitute for the sandbox tier the merge is gated on.

- **Sandbox (the gated tier)** — `nix build .#checks.x86_64-linux.{pytests,nodetests}`:
  - `devrc-pytests` → `RESULT: PASS (exit=0)`, `TOTAL collected=17235 passed=17233 skipped=2 failed=0` (floor 15970)
  - `devrc-nodetests` → `RESULT: PASS (exit=0)`, `TOTAL tests=1292 pass=1292 fail=0` (floor 1239)
  - the 2 skips are pre-existing in `signal`/`repo-cos`, untouched here
- **Dev-host tier** — `run-tests.sh` in the flake devShell → `RESULT: PASS (exit=0)`. ⚠ The captured output retained only its tail, so the per-target counts were **not** cross-checked on this tier; the sandbox tier above carries the counts.
- Targeted: deadman 78 passed; doc-rot / skill-listing / skill-tiers / public-IP / captured-text 255 passed.

Docs and comments only — no executable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)