### PR TITLE
feat(subsystem-store): a scope you may NOT see enumerated every scope you may not see — four channels, closed at the index (cairn phase 3, criteria 1-3)

### DIFF
--- a/scripts/lib/subsystem_recall.py
+++ b/scripts/lib/subsystem_recall.py
@@ -1297,7 +1297,12 @@ class RecallReport:
         return caveat_text(f"{self.scope}/", badges_present(self.listing))
 
 
-def load_store(store_root: str | Path, *, verb: str) -> tuple[Path, SubsystemIndex]:
+def load_store(
+    store_root: str | Path,
+    *,
+    verb: str,
+    visible_scopes: Sequence[str] | None = None,
+) -> tuple[Path, SubsystemIndex]:
     """Resolve the store root and load its index, or raise with a sentinel.
 
     🔴 ONE PLACE, because `recall` and `search` open the SAME store for the same
@@ -1306,6 +1311,29 @@ def load_store(store_root: str | Path, *, verb: str) -> tuple[Path, SubsystemInd
     did NOT happen ("nothing was recalled" / "nothing was searched") or it reads
     as the ordinary nothing-recorded-yet case, which is the confident zero this
     module exists to prevent.
+
+    🔴 `visible_scopes` IS A NARROWING OF THE WHOLE INDEX, AND IT IS APPLIED HERE
+    FOR EXACTLY THE REASON ABOVE — this is the single site both readers get their
+    index from, so a caller that may only see some scopes cannot be given a wider
+    one by a route that forgot to filter. `None` means UNRESTRICTED (every local
+    CLI caller); a sequence means "these normalized scopes and nothing else".
+
+    Filtering the INDEX rather than each answer is what closes four leaks at
+    once, and every one of them was measured on the deployed API before this
+    change:
+
+      * `known_scopes` — a `scope-absent` report ends with "scopes the store does
+        hold: …", so asking for a scope you do not have enumerated every scope
+        you do not have either.
+      * `malformed_elsewhere` — the "(+N further malformed entries in OTHER
+        scopes …)" block names those scopes on EVERY status, not only on a miss.
+      * `search?all_scopes=1` — it names no scope at all, so a per-scope refusal
+        check cannot see it; it searched the CONTENT of every scope in the store.
+      * the entries themselves.
+
+    An empty sequence therefore means "no scope is visible", NOT "unrestricted".
+    That direction is deliberate: a caller that forgot to resolve an allowlist
+    gets an empty store, not the whole one.
 
     🔴 IT LOADS WITH `ON_MALFORMED_COLLECT`, AND THAT IS THIS MODULE'S POLICY
     DECISION, NOT THE LOADER'S. A malformed entry no longer raises here: it comes
@@ -1328,12 +1356,26 @@ def load_store(store_root: str | Path, *, verb: str) -> tuple[Path, SubsystemInd
             f"store. Nothing was {verb}; this is NOT 'nothing recorded yet'"
         )
     try:
-        return store, load_index(store, on_malformed=ON_MALFORMED_COLLECT)
+        index = load_index(store, on_malformed=ON_MALFORMED_COLLECT)
     except OSError as exc:
         raise EntryUnreadableError(
             f"index entry unreadable: under {store} ({type(exc).__name__}: {exc}) — the "
             f"store was not fully read, so this report would be INCOMPLETE"
         ) from exc
+    if visible_scopes is None:
+        return store, index
+    # 🔴 REBUILT FROM THE TWO PUBLIC FIELDS, not by mutating a frozen dataclass
+    # and not by adding a third field. `scopes`, `malformed_in`,
+    # `malformed_outside`, `entries` and `__len__` are ALL derived from
+    # `by_scope` + `malformed`, so narrowing exactly those two narrows every
+    # derived answer at once — including the ones a future accessor adds. A
+    # per-answer filter would have to be repeated at every one of them, which is
+    # the shape that is wrong at all but one site.
+    allowed = {normalize_ref(s) for s in visible_scopes}
+    return store, SubsystemIndex(
+        by_scope={k: v for k, v in index.by_scope.items() if k in allowed},
+        malformed=tuple(m for m in index.malformed if m.scope in allowed),
+    )
 
 
 def recall(
@@ -1346,6 +1388,7 @@ def recall(
     page: int = 1,
     focus_paths: Sequence[str] = (),
     focus_source: str | None = None,
+    visible_scopes: Sequence[str] | None = None,
 ) -> RecallReport:
     """Surface an entry's `## What it is` + `## Pointers` + `## Nuance / work-history`.
 
@@ -1386,7 +1429,14 @@ def recall(
     if mode not in RECALL_MODES:
         raise ValueError(f"mode must be one of {RECALL_MODES}, got {mode!r}")
 
-    store, index = load_store(store_root, verb="recalled")
+    # 🔴 `visible_scopes` IS PASSED, NEVER RE-DERIVED. A scope the caller may not
+    # see must be absent from the INDEX, not filtered out of each answer — see
+    # `load_store`. Once it is absent, `scope-absent` (and its `known_scopes`
+    # list) is what a refused scope produces, which is byte-for-byte what a scope
+    # that never existed produces.
+    store, index = load_store(
+        store_root, verb="recalled", visible_scopes=visible_scopes
+    )
     # Computed ONCE, before any status branch, and passed to every one of them —
     # the block renders on all of them (`render_malformed`), so deriving it per
     # branch would be the same predicate at six sites, wrong at five.
@@ -2538,6 +2588,7 @@ def search(
     threshold: float = DEFAULT_SEARCH_THRESHOLD,
     max_hits: int = DEFAULT_MAX_HITS,
     all_scopes: bool = False,
+    visible_scopes: Sequence[str] | None = None,
 ) -> SearchReport:
     """Find HUNKS matching `query`. READ-ONLY, stdlib only, nothing is spawned.
 
@@ -2564,7 +2615,16 @@ def search(
     if not isinstance(context, int) or isinstance(context, bool) or context < CONTEXT_BULLET:
         raise ValueError(f"context must be an int >= 0, got {context!r}")
 
-    store, index = load_store(store_root, verb="searched")
+    # 🔴 THE `all_scopes` PATH IS THE REASON THIS IS AN INDEX FILTER AND NOT A
+    # PER-SCOPE REFUSAL CHECK. `?all_scopes=1` names NO scope, so there is
+    # nothing for such a check to refuse — it would search the CONTENT of every
+    # scope in the store and report hits from scopes the caller cannot name.
+    # Narrowing the index instead makes `index.scopes` below already the
+    # caller's own set, so the store-wide search is store-wide over what the
+    # caller may see and nothing else.
+    store, index = load_store(
+        store_root, verb="searched", visible_scopes=visible_scopes
+    )
     bad = index.malformed_in(scope)
     bad_elsewhere = index.malformed_outside((scope,))
 

--- a/scripts/lib/subsystem_recall.py
+++ b/scripts/lib/subsystem_recall.py
@@ -278,6 +278,7 @@ from subsystem_resolver import (  # noqa: E402
     parse_front_matter,
     parse_journal_bullets,
     resolve_ref_tiered,
+    visible_scope_set,
 )
 from subsystem_resolver import extract_sections as _extract_sections  # noqa: E402
 from subsystem_touch import (  # noqa: E402
@@ -329,6 +330,7 @@ __all__ = [
     "discarded_sensitivity",
     "sensitivity_label",
     "load_store",
+    "visible_scope_set",
     "listing_order",
     "listing_page",
     "tokenize",
@@ -1356,7 +1358,16 @@ def load_store(
             f"store. Nothing was {verb}; this is NOT 'nothing recorded yet'"
         )
     try:
-        index = load_index(store, on_malformed=ON_MALFORMED_COLLECT)
+        # 🔴 THE ALLOWLIST GOES DOWN INTO THE LOADER, NOT ONLY ONTO ITS RESULT.
+        # Narrowing afterwards still opened every file in every scope, so one
+        # unreadable entry in a scope the caller may NOT see put that file's full
+        # path into a 503 body, broke recall for everyone, and — for a FIFO named
+        # `*.md` — hung the request thread outright. See `load_index`.
+        index = load_index(
+            store,
+            on_malformed=ON_MALFORMED_COLLECT,
+            visible_scopes=visible_scopes,
+        )
     except OSError as exc:
         raise EntryUnreadableError(
             f"index entry unreadable: under {store} ({type(exc).__name__}: {exc}) — the "
@@ -1371,7 +1382,18 @@ def load_store(
     # derived answer at once — including the ones a future accessor adds. A
     # per-answer filter would have to be repeated at every one of them, which is
     # the shape that is wrong at all but one site.
-    allowed = {normalize_ref(s) for s in visible_scopes}
+    #
+    # ⚠ REDUNDANT WITH THE LOADER'S OWN FILTER TODAY, AND KEPT DELIBERATELY.
+    # `load_index` now skips a denied scope dir entirely, so this rebuild has
+    # nothing left to drop — a mutation sweep will score it as an equivalent
+    # mutant. It stays because the two filters answer different questions: the
+    # loader's decides what is OPENED, this one decides what the RESULT SHAPE is,
+    # and a future caller that hands this function an already-loaded index, or a
+    # loader that learns a reason to register a scope it did not read, must not
+    # silently widen the answer. Both derive the set from `visible_scope_set`, so
+    # they cannot come to disagree about what an allowlist means.
+    allowed = visible_scope_set(visible_scopes)
+    assert allowed is not None  # `visible_scopes is None` returned above
     return store, SubsystemIndex(
         by_scope={k: v for k, v in index.by_scope.items() if k in allowed},
         malformed=tuple(m for m in index.malformed if m.scope in allowed),

--- a/scripts/lib/subsystem_resolver.py
+++ b/scripts/lib/subsystem_resolver.py
@@ -1741,13 +1741,23 @@ def entry_mapping(text: str, *, filename: str, scope: str) -> dict[str, object]:
 # 🔴 THE TOTAL CLASSIFIER — why this exists instead of a fourth `if` arm.
 #
 # ⚠ IT LIVED IN `subsystem-store-api/server.py` UNTIL `load_index` NEEDED IT.
-# It moved here rather than being copied: "what IS this path" open-coded at two
-# sites is the predicate-at-N-sites shape that is wrong at N-1 of them, and the
-# two sites in question are `/snapshot` and the index loader — disagreeing about
-# a FIFO named `*.md` is exactly what costs a request thread. What did NOT move
-# is the ACTION TABLES: each context maps every kind explicitly, and the loader's
-# table (`_LOADER_ENTRY_ACTIONS`, below) is deliberately NARROWER than the
-# server's `_ENTRY_ACTIONS`. `server.py` imports these names.
+# It moved here rather than being copied: "what IS this path" open-coded at N
+# sites is wrong at N-1 of them, and disagreeing about a FIFO named `*.md` is
+# exactly what costs a request thread. What did NOT move is the ACTION TABLES:
+# each context maps every kind explicitly, and the loader's table
+# (`_LOADER_ENTRY_ACTIONS`, below) is deliberately NARROWER than the server's
+# `_ENTRY_ACTIONS`. `server.py` imports these names.
+#
+# 🔴 THE TWO GUARDED SITES ARE `/snapshot` AND THIS INDEX LOADER — AND THEY ARE
+# NOT ALL THE SITES. An earlier wording here said they were, and that claim was
+# false: `subsystem_touch.census()` (`glob("*.md")` then `read_text`) is a THIRD
+# glob-and-read site with NO kind check at all, so it still hangs on a fifo and
+# still 503-equivalents on a directory. It is left that way ON PURPOSE, by
+# ruling: `census()` is CLI-only, no server path imports `subsystem_touch`, and
+# the operator declined to widen the guard to it. `validate_scope` also globs,
+# but only for NAMES — it reads nothing itself and defers to `load_index`, so it
+# inherits this guard rather than needing one. Said here so the next reader does
+# not have to rediscover it, and so "two sites" stops reading as "all of them".
 #
 # Four consecutive audit rounds found the same shape of defect in `_snapshot`,
 # and every fix added one more predicate to a sequence:
@@ -1927,10 +1937,13 @@ def visible_scope_set(visible_scopes: Sequence[str] | None) -> set[str] | None:
 # 🔴 THE LOADER'S OWN TABLE, AND IT IS DELIBERATELY NARROWER THAN THE SERVER'S.
 #
 # The broad form — mirroring `server.py`'s `_ENTRY_ACTIONS` wholesale — was
-# written, reviewed and REJECTED: it also refuses `link-to-file`, `directory`,
-# `link-to-dir` and `indeterminate`, every one of which this loader reads (or
-# fails on) today, so it is a behaviour change for every local CLI caller and
-# for the writer's probe. What was decided instead is exactly two cells:
+# written, reviewed and REJECTED, because it also refuses `link-to-file` and
+# `indeterminate`, which this loader READS (or honestly fails on) today: that is
+# a behaviour change for every local CLI caller and for the writer's probe, and
+# those two cells are still `TAKE` for exactly that reason. The cells that HAVE
+# been decided, one ruling at a time, each on the same criterion — "this loader
+# has never successfully read one, so refusing it changes no legitimate caller"
+# — are the five below. The first ruling decided two:
 #
 #   `broken-link`  a dangling symlink. `Path.glob("*.md")` MATCHES A LEADING
 #                  DOT — measured, not assumed — so an Emacs lock file
@@ -1962,30 +1975,63 @@ def visible_scope_set(visible_scopes: Sequence[str] | None) -> set[str] | None:
 #                  one, and on a `replicas: 1` / `strategy: Recreate` service a
 #                  wedged thread is the worst outcome in this file. Refused.
 #
-# None of the three is ever a legitimate entry, so no legitimate caller changes
+# 🔴 AND NOW A FOURTH AND FIFTH, ON THE SAME CRITERION THE NARROW RULING USED:
+#
+#   `directory`    a DIRECTORY named `*.md`. `read_text` on one raises
+#   `link-to-dir`  `IsADirectoryError`, and because an OSError fails closed in
+#                  BOTH policies that was a store-wide `503 index entry
+#                  unreadable` for EVERY caller — `/recall` AND `/search` — off
+#                  one stray `mkdir <scope>/<slug>.md` or an rsync/restore
+#                  artefact. Measured on the tip that carried them, with a
+#                  paired control:
+#
+#                      store/beta/notes.md created as a DIRECTORY
+#                      GET /api/v1/recall/alpha, UNRESTRICTED legacy token
+#                      -> 503 "index entry unreadable: … (IsADirectoryError:
+#                         … /beta/notes.md)"
+#                      CONTROL, same shape but a dangling `.#lock.md` -> 200
+#
+#                  A symlink to a directory measured identically. 🔴 THE
+#                  CRITERION IS UNCHANGED, WHICH IS WHY THIS IS NOT A WIDENING
+#                  OF THE RULING: this loader has NEVER successfully read a
+#                  directory — it has only ever raised on one — so refusing it
+#                  changes no legitimate caller's behaviour, exactly as with
+#                  `broken-link`, `other` and `link-to-other`. It also makes the
+#                  loader AGREE with `/snapshot`'s `_ENTRY_ACTIONS`, which
+#                  already refused both kinds; two readers of one store
+#                  disagreeing about what a directory named `*.md` is was the
+#                  divergence, not the fix.
+#
+# None of the five is ever a legitimate entry, so no legitimate caller changes
 # behaviour.
 #
 # 🔴 `link-to-file` IS `TAKE`, AND THAT IS THE POINT OF THE NARROW FORM — it is
 # the cell the narrow-vs-broad ruling was actually about, and closing
-# `link-to-other` did not touch it. A symlink to a regular `*.md` is read today
-# and keeps being read. A mutant that flips this cell to REFUSE is the exact
-# over-broad regression the narrow ruling exists to prevent, and
-# `test_a_SYMLINKED_entry_is_STILL_READ_the_guard_is_NOT_the_broad_one` kills
-# it.
+# `link-to-other`, `directory` and `link-to-dir` did not touch it. A symlink to
+# a regular `*.md` is read today and keeps being read. A mutant that flips this
+# cell to REFUSE is the exact over-broad regression the narrow ruling exists to
+# prevent, and `test_a_SYMLINKED_entry_is_STILL_READ_the_guard_is_NOT_the_broad_one`
+# kills it.
 #
-# ⚠ `indeterminate`, `directory`, `link-to-dir` and `absent` are `TAKE` for the
-# same conservatism: `read_text` raises on each (EACCES, IsADirectoryError,
-# FileNotFoundError) and that raise is the four-state rule's "the store was not
-# fully READ", which is a DIFFERENT fact from "this entry is malformed" and must
-# not be quietly folded into it.
+# ⚠ `indeterminate` and `absent` are `TAKE`, and for a DIFFERENT reason from the
+# two cells that just left this list — one this round was told explicitly not to
+# fold in. `indeterminate` means "the `lstat` failed and I could not look",
+# which is not "this kind can never be an entry"; `absent` is a file that
+# vanished between `glob()` and `classify_path`. `read_text` raises on each
+# (EACCES, FileNotFoundError) and that raise is the four-state rule's "the store
+# was not fully READ" — a DIFFERENT fact from "this entry is malformed", which
+# must not be quietly folded into it. `regular-file` and `link-to-file` are
+# `TAKE` because they are what an entry IS; the residuals they carry are
+# enumerated in `load_index`'s RESIDUAL LEDGER and pinned by
+# `test_the_LOADER_RESIDUAL_SET_is_pinned`.
 _LOADER_ENTRY_ACTIONS: dict[str, str] = {
     KIND_BROKEN_LINK: REFUSE,
     KIND_OTHER: REFUSE,
     KIND_LINK_TO_OTHER: REFUSE,
+    KIND_DIRECTORY: REFUSE,
+    KIND_LINK_TO_DIR: REFUSE,
     KIND_REGULAR_FILE: TAKE,
     KIND_LINK_TO_FILE: TAKE,
-    KIND_DIRECTORY: TAKE,
-    KIND_LINK_TO_DIR: TAKE,
     KIND_INDETERMINATE: TAKE,
     KIND_ABSENT: TAKE,
 }
@@ -2012,6 +2058,19 @@ _LOADER_REFUSAL_REASON: dict[str, str] = {
         "device) — refused before `open()`, which blocks on a fifo whether it "
         "is named directly or reached through a link. Measured wedging a "
         "`/recall` request thread for 25s while the process stayed healthy"
+    ),
+    KIND_DIRECTORY: (
+        "a directory named `*.md` — refused before `open()`, which on a "
+        "directory raises `IsADirectoryError`; that OSError fails closed, so "
+        "one stray `mkdir <scope>/<slug>.md` (or an rsync/restore artefact) "
+        "answered `/recall` and `/search` with a store-wide 503 for every "
+        "caller. Delete the directory, or move its contents into a `*.md` file"
+    ),
+    KIND_LINK_TO_DIR: (
+        "a symlink to a directory — refused before `open()`, which raises "
+        "`IsADirectoryError` whether the directory is named directly or "
+        "reached through a link, and that OSError fails closed into the same "
+        "store-wide 503"
     ),
 }
 
@@ -2093,27 +2152,48 @@ def load_index(
     🔴 SO THE CANDIDATE'S KIND IS NOW CHECKED BEFORE `open()`, FOR EVERY CALLER
     — `_LOADER_ENTRY_ACTIONS`, above, which reuses `classify_path` rather than
     asking the question a second way. It is NARROW on purpose: a dangling
-    symlink, a fifo/socket/device, and a symlink POINTING AT one are refused,
-    and everything this loader reads today — regular files AND symlinks to
+    symlink, a fifo/socket/device, a symlink POINTING AT one, a directory named
+    `*.md` and a symlink pointing at a directory are refused, and everything
+    this loader has ever successfully READ — regular files AND symlinks to
     regular files — is still read, so no legitimate caller changes behaviour.
-    (The `link-to-other` cell shipped one round later than the other two, after
-    the shape was measured wedging an unrestricted `/recall` thread for 25s;
-    `open()` blocks the same through a link as directly.) A refusal is reported the way
+    (Cells 3-5 shipped in later rounds than the first two, each after the shape
+    was measured: `link-to-other` wedging an unrestricted `/recall` thread for
+    25s, and `directory`/`link-to-dir` 503ing the whole store on an
+    `IsADirectoryError` off one stray `mkdir`.) A refusal is reported the way
     every other unusable entry is, through `on_malformed`: a `MalformedEntry` on
     the index under `COLLECT`, a `MalformedEntryError` under `RAISE`. One
     hostile file therefore costs that ONE entry, and is NAMED, instead of
     costing the whole store.
 
-    ⚠ WHAT IT DOES **NOT** COVER, said rather than left to be found: a
-    `chmod 000` REGULAR file still raises `EntryUnreadableError` for an
-    unrestricted caller, and still names its path in the message. That is
-    deliberate — it is the four-state rule below ("the store was not fully
-    READ", which is not "this entry is malformed") — so on a HOSTILE store the
-    unrestricted reading is unchanged for that shape and changed for the other
-    three. ⚠ THAT LIST USED TO NAME A SECOND UNCOVERED SHAPE — a symlink
-    pointing AT a fifo — and it no longer does, because that cell is now
-    REFUSE. `chmod 000` is the only residual left here, and it is a 503, not a
-    hang.
+    ⚠ THE RESIDUAL LEDGER — what this guard does **NOT** cover, enumerated
+    rather than left to be found, and machine-checked so it cannot silently go
+    stale the way it twice did. It is exactly the kinds `_LOADER_ENTRY_ACTIONS`
+    still maps to `TAKE`, because `TAKE` means `read_text` runs and any `OSError`
+    it raises fails closed into a store-wide `EntryUnreadableError` — a 503, and
+    for an unrestricted caller one that names the path:
+
+      * `regular-file` — a `chmod 000` entry. `PermissionError`. This is the
+        four-state rule working as designed: "the store was not fully READ" is
+        a different fact from "this entry is malformed", and only the second has
+        an honest degraded form.
+      * `link-to-file` — the SAME shape reached through a symlink, when the
+        TARGET is unreadable. Measured, not assumed: a link to a `chmod 000`
+        regular file 503s identically. Listed separately because the kind is
+        separate and the ledger must not read shorter than it is.
+      * `indeterminate` — the `lstat` itself failed (EACCES on the parent,
+        ESTALE, EIO…). Deliberately NOT refused: "I could not look" is a
+        different premise from "this kind can never be an entry", which is the
+        criterion every REFUSE cell above rests on.
+      * `absent` — the candidate vanished between `glob()` and `classify_path`.
+        A TOCTOU race, `FileNotFoundError`, unreproduced here rather than
+        measured.
+
+    `test_the_LOADER_RESIDUAL_SET_is_pinned` pins that set, and
+    `test_the_RESIDUAL_LEDGER_names_every_TAKE_kind_and_no_REFUSE_one` pins THIS
+    PARAGRAPH against the table in both directions — so a cell that becomes
+    REFUSE cannot stay listed here (the drift that left a closed hang recorded
+    as open for a whole round), and a new `TAKE` cell cannot go unlisted.
+    (END OF RESIDUAL LEDGER)
 
     ⚠ `Path.glob("*.md")` DOES match a leading dot — measured, not assumed — so
     an Emacs lock file (`.#entry.md`, a dangling symlink) is a candidate and had

--- a/scripts/lib/subsystem_resolver.py
+++ b/scripts/lib/subsystem_resolver.py
@@ -2151,11 +2151,18 @@ def load_index(
 
     🔴 SO THE CANDIDATE'S KIND IS NOW CHECKED BEFORE `open()`, FOR EVERY CALLER
     — `_LOADER_ENTRY_ACTIONS`, above, which reuses `classify_path` rather than
-    asking the question a second way. It is NARROW on purpose: a dangling
-    symlink, a fifo/socket/device, a symlink POINTING AT one, a directory named
-    `*.md` and a symlink pointing at a directory are refused, and everything
-    this loader has ever successfully READ — regular files AND symlinks to
-    regular files — is still read, so no legitimate caller changes behaviour.
+    asking the question a second way. It is NARROW on purpose. THE REFUSED SET,
+    named by KIND so this sentence is machine-readable and cannot drift the way
+    the ledger below twice did: a dangling symlink (`broken-link`), a
+    fifo/socket/device (`other`), a symlink POINTING AT one (`link-to-other`), a
+    directory named `*.md` (`directory`) and a symlink pointing at a directory
+    (`link-to-dir`) are refused. (END OF REFUSED SET.) Everything this loader has
+    ever successfully READ — regular files AND symlinks to regular files — is
+    still read, so no legitimate caller changes behaviour.
+    `test_the_DOCSTRING_REFUSED_SET_names_every_REFUSE_kind_and_no_other` pins
+    the marked span above against the table in both directions — it was PROSE
+    for a round, naming none of the kinds, and nothing read it: dropping three
+    of the five refusals from it left the whole suite green.
     (Cells 3-5 shipped in later rounds than the first two, each after the shape
     was measured: `link-to-other` wedging an unrestricted `/recall` thread for
     25s, and `directory`/`link-to-dir` 503ing the whole store on an

--- a/scripts/lib/subsystem_resolver.py
+++ b/scripts/lib/subsystem_resolver.py
@@ -59,8 +59,19 @@ CONTRACT SUMMARY
                                          loader would build; the shared step a
                                          validator and the loader must not spell
                                          twice)
-    load_index(root, *, on_malformed=RAISE)
-                                      -> SubsystemIndex (the thin disk loader)
+    load_index(root, *, on_malformed=RAISE, visible_scopes=None)
+                                      -> SubsystemIndex (the thin disk loader;
+                                         `visible_scopes=None` is UNRESTRICTED and
+                                         an EMPTY sequence is its opposite — see
+                                         `visible_scope_set`)
+    visible_scope_set(visible_scopes) -> set[str]|None (the one allowlist folding,
+                                         shared with `subsystem_recall.load_store`
+                                         and the API's `/snapshot`)
+    classify_path(path)               -> str  (one of `ALL_KINDS`; the ONE answer
+                                         to "what IS this path", shared with
+                                         `subsystem-store-api/server.py`)
+    action_for(kind, actions)         -> SKIP|TAKE|REFUSE (raises AssertionError on
+                                         an unmapped kind — never a default)
 
 Every raise carries a distinct sentinel phrase so a caller — or a mutation test —
 can tell WHICH guard fired, not merely that something did:
@@ -81,7 +92,9 @@ wrong reason and stays green with the guard deleted (`claude/RULES.md` →
 
 from __future__ import annotations
 
+import errno
 import re
+import stat
 from collections.abc import Sequence as _AbcSequence
 from dataclasses import dataclass
 from datetime import date as _date
@@ -128,6 +141,22 @@ __all__ = [
     "parse_front_matter",
     "entry_mapping",
     "load_index",
+    "visible_scope_set",
+    "KIND_BROKEN_LINK",
+    "KIND_LINK_TO_DIR",
+    "KIND_LINK_TO_FILE",
+    "KIND_LINK_TO_OTHER",
+    "KIND_DIRECTORY",
+    "KIND_REGULAR_FILE",
+    "KIND_OTHER",
+    "KIND_INDETERMINATE",
+    "KIND_ABSENT",
+    "ALL_KINDS",
+    "SKIP",
+    "TAKE",
+    "REFUSE",
+    "classify_path",
+    "action_for",
 ]
 
 # The kind enum from `analyze-service.md`: "kind ∈ `service` | `process` | `org`
@@ -601,6 +630,22 @@ def _rejection(
     )
 
 
+def _check_on_malformed(on_malformed: str) -> str:
+    """Validate the policy name and return it. ONE place, TWO callers.
+
+    `load_index` has to branch on this policy BEFORE `build_index` ever sees it
+    (its entry-kind guard decides raise-vs-collect for itself), so without this
+    the predicate would be spelled at two sites — and the site that got it wrong
+    would answer a bogus policy string with a `MalformedEntryError` about the
+    first hostile file instead of "you passed a policy that does not exist".
+    """
+    if on_malformed not in ON_MALFORMED:
+        raise ValueError(
+            f"on_malformed must be one of {ON_MALFORMED}, got {on_malformed!r}"
+        )
+    return on_malformed
+
+
 def build_index(
     mappings: Iterable[Mapping[str, object]],
     *,
@@ -631,11 +676,7 @@ def build_index(
     first site would have left `COLLECT` able to raise, which is the shape a
     caller cannot defend against because it looks handled.
     """
-    if on_malformed not in ON_MALFORMED:
-        raise ValueError(
-            f"on_malformed must be one of {ON_MALFORMED}, got {on_malformed!r}"
-        )
-    collecting = on_malformed == ON_MALFORMED_COLLECT
+    collecting = _check_on_malformed(on_malformed) == ON_MALFORMED_COLLECT
     by_scope: dict[str, list[SubsystemEntry]] = {}
     malformed: list[MalformedEntry] = []
     seen: dict[tuple[str, str, str | None], str] = {}
@@ -1696,6 +1737,173 @@ def entry_mapping(text: str, *, filename: str, scope: str) -> dict[str, object]:
     return fm
 
 
+# =============================================================================
+# 🔴 THE TOTAL CLASSIFIER — why this exists instead of a fourth `if` arm.
+#
+# ⚠ IT LIVED IN `subsystem-store-api/server.py` UNTIL `load_index` NEEDED IT.
+# It moved here rather than being copied: "what IS this path" open-coded at two
+# sites is the predicate-at-N-sites shape that is wrong at N-1 of them, and the
+# two sites in question are `/snapshot` and the index loader — disagreeing about
+# a FIFO named `*.md` is exactly what costs a request thread. What did NOT move
+# is the ACTION TABLES: each context maps every kind explicitly, and the loader's
+# table (`_LOADER_ENTRY_ACTIONS`, below) is deliberately NARROWER than the
+# server's `_ENTRY_ACTIONS`. `server.py` imports these names.
+#
+# Four consecutive audit rounds found the same shape of defect in `_snapshot`,
+# and every fix added one more predicate to a sequence:
+#
+#   r1  entry symlinks followed          -> refuse symlinked ENTRIES
+#   r2  symlinked SCOPE dirs filtered    -> silently omitted, read as scope-empty
+#   r3  `is_symlink()` before `is_dir()` -> a symlinked README 503'd everything
+#   r4  `is_dir()` first                 -> a DANGLING scope link vanished,
+#                                           read as scope-empty at exit 0
+#
+# Each round the stated predicate ("refuse a thing that IS a scope but cannot be
+# served safely; skip a thing that is not one") failed to DECIDE the next input
+# class, because a broken pointer is neither. Adding an arm fixes the instance;
+# it does not make the rule total, so the next class falls through the same gap.
+#
+# So: classify the path's TYPE exhaustively, in one place, and have each context
+# map EVERY kind to an action explicitly. `_ROOT_ACTIONS`, `_ENTRY_ACTIONS` and
+# `_LOADER_ENTRY_ACTIONS` are asserted complete by `TestClassifierIsTotal`, and
+# an unmapped kind raises rather than defaulting — a fallthrough is a test
+# failure, not a silent skip. Name-based rules (dotfiles, the `.md` suffix) stay
+# SEPARATE from type, because conflating them is what made the dotfile and
+# symlink rules interfere.
+# =============================================================================
+
+KIND_BROKEN_LINK = "broken-link"      # dangling target, or a symlink loop
+KIND_LINK_TO_DIR = "link-to-dir"
+KIND_LINK_TO_FILE = "link-to-file"
+KIND_LINK_TO_OTHER = "link-to-other"  # link to a fifo/socket/device
+KIND_DIRECTORY = "directory"
+KIND_REGULAR_FILE = "regular-file"
+KIND_OTHER = "other"                  # fifo, socket, device, door…
+# 🔴 THE LAST CELL OF THE LOOP: the first version of this classifier was total
+# over KIND STRINGS but not over KNOWLEDGE. "I could not determine what this is"
+# is its own answer and must never share a bucket with "I know exactly what this
+# is".
+#
+# ⚠ CORRECTED — AND THE CORRECTION IS THE INTERESTING PART. This comment used to
+# say "every pathlib predicate returns False when the stat itself fails, so an
+# EACCES fell into KIND_OTHER and was skipped", and cited a measurement of
+# `/snapshot` answering 200 / exit 0 / entries=0. BOTH WERE WRONG, and the
+# second was inherited from an audit report and written up here as first-hand.
+# ⚠ And the raise did NOT come from `classify_path` — that function is INTRODUCED
+# by this fix. In the failing version it came from `candidate.is_dir()` in
+# `_snapshot`, which this commit deletes. Corrected after an audit caught the
+# anachronism; the docstring below was already accurate.
+# Measured on the pinned interpreter:
+#     pathlib._IGNORED_ERRNOS == (ENOENT, ENOTDIR, EBADF, ELOOP)
+#     child of a 0o600 dir: is_symlink/is_dir/is_file/exists each RAISE
+#                           PermissionError — none returns False
+# So the old failure was not a silent empty store; it was an UNCAUGHT
+# PermissionError out of `classify_path`, crashing the handler with no response
+# and no audit line. Loud, not quiet.
+#
+# The fix stands — a crashed handler becoming a typed 503 is strictly better —
+# but the reasoning had to be corrected, because "pathlib returns False on stat
+# failure" is exactly the kind of false premise that gets a guard deleted
+# somewhere else in this file on the strength of a comment.
+KIND_INDETERMINATE = "indeterminate"
+# Vanished between `readdir` and the stat — a benign race, not a hazard, and
+# distinct from INDETERMINATE because the right action differs.
+KIND_ABSENT = "absent"
+
+ALL_KINDS: frozenset[str] = frozenset(
+    {
+        KIND_BROKEN_LINK,
+        KIND_LINK_TO_DIR,
+        KIND_LINK_TO_FILE,
+        KIND_LINK_TO_OTHER,
+        KIND_DIRECTORY,
+        KIND_REGULAR_FILE,
+        KIND_OTHER,
+        KIND_INDETERMINATE,
+        KIND_ABSENT,
+    }
+)
+
+# What a context does with each kind. `SKIP` = not the thing we are looking for,
+# so its absence is not a fact worth reporting. `TAKE` = use it. `REFUSE` = it
+# IS (or claims to be) the thing, and we cannot serve it — which must be
+# REPORTED, never skipped, because a skip renders as "nothing recorded".
+SKIP, TAKE, REFUSE = "skip", "take", "refuse"
+
+
+def classify_path(path: Path) -> str:
+    """The path's type, as exactly one of `ALL_KINDS`. Total by construction.
+
+    🔴 ONE `lstat`, THEN THE MODE BITS — not a sequence of pathlib predicates.
+    Those predicates fail in TWO different ways and neither is usable here:
+    they return False for the errnos in `pathlib._IGNORED_ERRNOS` (ENOENT,
+    ENOTDIR, EBADF, ELOOP), so "not a directory" and "no such path" are
+    indistinguishable; and they RAISE for every other errno (EACCES, ESTALE,
+    EIO), so a sequence built from them can abort mid-classification and take
+    the handler with it. The previous version did exactly that on an
+    unstat-able child.
+
+    Reading the mode bits from one explicit `lstat` makes both cases answerable:
+    a failure is an exception we must classify, not a False we might miss or a
+    raise we did not expect. It also halves the syscalls, which narrows the
+    TOCTOU window between them.
+    """
+    try:
+        st = path.lstat()
+    except FileNotFoundError:
+        return KIND_ABSENT
+    except OSError:
+        # EACCES on the parent, ESTALE, EIO… We do not know what this is, and
+        # saying so is the point — see KIND_INDETERMINATE.
+        return KIND_INDETERMINATE
+
+    if not stat.S_ISLNK(st.st_mode):
+        if stat.S_ISDIR(st.st_mode):
+            return KIND_DIRECTORY
+        if stat.S_ISREG(st.st_mode):
+            return KIND_REGULAR_FILE
+        return KIND_OTHER
+
+    try:
+        target = path.stat()  # follows the link
+    except OSError as exc:
+        # ENOENT = dangling, ELOOP = a cycle (measured: self-loop, mutual loop
+        # and a 45-link chain all give ELOOP). Both are broken POINTERS, which
+        # is a fact we know; anything else means the stat failed for a reason we
+        # cannot interpret, which is not.
+        #
+        # ⚠ NO ACTION DEPENDS ON THIS BRANCH IN THE SERVER'S TWO TABLES, and
+        # saying so is honest rather than leaving it to read as coverage:
+        # BROKEN_LINK and INDETERMINATE map to the SAME action in both of them,
+        # so there the split only changes the word in the 503 body. ⚠ THAT IS NO
+        # LONGER TRUE OF EVERY TABLE: `_LOADER_ENTRY_ACTIONS` REFUSES
+        # `broken-link` and TAKES `indeterminate`, so a mutant collapsing this
+        # branch is now killable through the loader (it turns the Emacs lock file
+        # back into a store-wide `EntryUnreadableError`). Errnos measured to land
+        # in `indeterminate` rather than `broken-link`: ENOTDIR (`/etc/hosts/x`),
+        # ENAMETOOLONG (300-char target), EACCES (link into an unsearchable dir).
+        if exc.errno in (errno.ENOENT, errno.ELOOP):
+            return KIND_BROKEN_LINK
+        return KIND_INDETERMINATE
+    if stat.S_ISDIR(target.st_mode):
+        return KIND_LINK_TO_DIR
+    if stat.S_ISREG(target.st_mode):
+        return KIND_LINK_TO_FILE
+    return KIND_LINK_TO_OTHER
+
+
+def action_for(kind: str, actions: Mapping[str, str]) -> str:
+    """Look up the action, refusing to guess. An unmapped kind is a BUG."""
+    try:
+        return actions[kind]
+    except KeyError:  # pragma: no cover - pinned by TestClassifierIsTotal
+        raise AssertionError(
+            f"unclassified path kind {kind!r}: every kind must be mapped "
+            f"explicitly, because a default is how the last four rounds of this "
+            f"defect happened"
+        ) from None
+
+
 def visible_scope_set(visible_scopes: Sequence[str] | None) -> set[str] | None:
     """One allowlist -> the normalized set every narrowing site compares against.
 
@@ -1714,6 +1922,76 @@ def visible_scope_set(visible_scopes: Sequence[str] | None) -> set[str] | None:
     if visible_scopes is None:
         return None
     return {normalize_ref(s) for s in visible_scopes}
+
+
+# 🔴 THE LOADER'S OWN TABLE, AND IT IS DELIBERATELY NARROWER THAN THE SERVER'S.
+#
+# The broad form — mirroring `server.py`'s `_ENTRY_ACTIONS` wholesale — was
+# written, reviewed and REJECTED: it also refuses `link-to-file`, `directory`,
+# `link-to-dir` and `indeterminate`, every one of which this loader reads (or
+# fails on) today, so it is a behaviour change for every local CLI caller and
+# for the writer's probe. What was decided instead is exactly two cells:
+#
+#   `broken-link`  a dangling symlink. `Path.glob("*.md")` MATCHES A LEADING
+#                  DOT — measured, not assumed — so an Emacs lock file
+#                  (`.#entry.md`, a dangling link to `user@host.pid:boot`) is a
+#                  candidate entry. Opening it raised, and because an OSError
+#                  fails closed in BOTH policies that took `/recall` down for
+#                  EVERY caller, naming the file and its scope in the 503.
+#   `other`        fifo, socket, device. `read_text` on a FIFO BLOCKS until
+#                  somebody writes to it: on a `replicas: 1` Deployment the
+#                  request thread never returns. This is the cell that is not a
+#                  degradation but a hang.
+#
+# Neither is ever a legitimate entry, so no legitimate caller changes behaviour.
+#
+# 🔴 `link-to-file` IS `TAKE`, AND THAT IS THE POINT OF THE NARROW FORM. A
+# symlink to a regular `*.md` is read today and keeps being read. A mutant that
+# flips this cell to REFUSE is the exact over-broad regression the narrow ruling
+# exists to prevent, and `test_a_SYMLINKED_entry_is_still_READ_the_narrow_guard_
+# is_not_the_broad_one` kills it.
+#
+# ⚠ NAMED RESIDUAL, NOT AN OVERSIGHT: `link-to-other` — a symlink POINTING AT a
+# fifo/socket/device — is the SAME hang in a different shape and is left `TAKE`,
+# because the decision on this PR named `other` and `broken-link` and nothing
+# else. Closing it is this one cell; it is called out here so the next reader
+# does not have to rediscover it from a wedged pod.
+#
+# ⚠ `indeterminate`, `directory`, `link-to-dir` and `absent` are `TAKE` for the
+# same conservatism: `read_text` raises on each (EACCES, IsADirectoryError,
+# FileNotFoundError) and that raise is the four-state rule's "the store was not
+# fully READ", which is a DIFFERENT fact from "this entry is malformed" and must
+# not be quietly folded into it.
+_LOADER_ENTRY_ACTIONS: dict[str, str] = {
+    KIND_BROKEN_LINK: REFUSE,
+    KIND_OTHER: REFUSE,
+    KIND_REGULAR_FILE: TAKE,
+    KIND_LINK_TO_FILE: TAKE,
+    KIND_LINK_TO_OTHER: TAKE,
+    KIND_DIRECTORY: TAKE,
+    KIND_LINK_TO_DIR: TAKE,
+    KIND_INDETERMINATE: TAKE,
+    KIND_ABSENT: TAKE,
+}
+
+# The `why` clause each refused kind carries — the sentence after the sentinel,
+# so a refused entry reads exactly like every other unusable one. It names the
+# SHAPE and never invents a fix, because the operator's fix differs per shape
+# (delete the lock file; delete the fifo).
+_LOADER_REFUSAL_REASON: dict[str, str] = {
+    KIND_BROKEN_LINK: (
+        "broken symlink (a dangling target, or a link loop) — not an entry, and "
+        "refused before `open()`. `glob('*.md')` matches a leading dot, so an "
+        "editor lock file such as `.#<entry>.md` lands here; reading it raised "
+        "`index entry unreadable`, which took the whole store down for every "
+        "caller and named this file in the error"
+    ),
+    KIND_OTHER: (
+        "not a regular file (a fifo, socket or device) — refused before "
+        "`open()`, which on a fifo blocks until somebody writes to it and never "
+        "returns, wedging the reader"
+    ),
+}
 
 
 def load_index(
@@ -1778,42 +2056,57 @@ def load_index(
     four-state rule and it is unchanged. The local CLI passes no allowlist at
     all (`None`), so its behaviour is byte-identical to before.
 
-    🔴 AND THAT LAST SENTENCE IS ALSO THE LIMIT OF THIS FIX — SAID HERE RATHER
-    THAN LEFT TO BE DISCOVERED. `visible_scopes=None` skips nothing, so for an
-    UNRESTRICTED caller all three failures above are exactly as open as they
-    were. That includes the credential the pod is deployed with today: a bare
-    legacy row is unrestricted, so **the live API is not protected by this
-    change**; only a scoped token whose allowlist excludes the bad scope is.
-    Measured on this tree, `load_store` over a store whose `quartz-mine` scope
-    holds one hostile file:
+    🔴 AND THE ALLOWLIST ALONE WAS NOT THE WHOLE FIX — `visible_scopes=None`
+    SKIPS NOTHING. For an UNRESTRICTED caller the narrowing above does exactly
+    nothing, and a bare legacy row is unrestricted, which is what the pod is
+    deployed with today. Measured on this tree BEFORE the entry-kind guard
+    below, `load_store` over a store whose `quartz-mine` scope holds one hostile
+    file:
 
         visible_scopes=None        FIFO `hang.md`     -> HUNG (>6s, killed)
         visible_scopes=None        `.#locked.md`      -> EntryUnreadableError
         visible_scopes=('kelp-forest',)  both         -> loads, scopes=(kelp-forest,)
         visible_scopes=('quartz-mine',)  FIFO         -> HUNG (its own scope)
 
-    Closing it for everybody needs a KIND check on the candidate before `open()`
-    — `server.py`'s `_ENTRY_ACTIONS` already classifies exactly these cases
-    (`KIND_OTHER: REFUSE`, "a FIFO named `*.md` blocked `open()` forever") for
-    `/snapshot`, and that classifier lives in the API rather than here. Left
-    OUT OF THIS CHANGE on purpose: it also refuses a symlink-to-regular-file
-    entry, which this loader accepts today, so it is a behaviour change for
-    every local CLI caller and wants its own review. **Closing condition: an
-    entry-kind guard in this module, or a decision on this PR that the residual
-    is accepted.**
+    🔴 SO THE CANDIDATE'S KIND IS NOW CHECKED BEFORE `open()`, FOR EVERY CALLER
+    — `_LOADER_ENTRY_ACTIONS`, above, which reuses `classify_path` rather than
+    asking the question a second way. It is NARROW on purpose: a dangling
+    symlink and a fifo/socket/device are refused, and everything this loader
+    reads today — regular files AND symlinks to regular files — is still read,
+    so no legitimate caller changes behaviour. A refusal is reported the way
+    every other unusable entry is, through `on_malformed`: a `MalformedEntry` on
+    the index under `COLLECT`, a `MalformedEntryError` under `RAISE`. One
+    hostile file therefore costs that ONE entry, and is NAMED, instead of
+    costing the whole store.
+
+    ⚠ WHAT IT DOES **NOT** COVER, said rather than left to be found: a
+    `chmod 000` REGULAR file still raises `EntryUnreadableError` for an
+    unrestricted caller, and still names its path in the message. That is
+    deliberate — it is the four-state rule below ("the store was not fully
+    READ", which is not "this entry is malformed") — so on a HOSTILE store the
+    unrestricted reading is unchanged for that shape and changed for the other
+    two. A symlink pointing AT a fifo (`link-to-other`) is likewise still
+    `TAKE`; see the table's note.
 
     ⚠ `Path.glob("*.md")` DOES match a leading dot — measured, not assumed — so
-    an Emacs lock file (`.#entry.md`, a dangling symlink) is a candidate and has
-    been observed 503ing `/api/v1/recall/<scope>` in practice.
+    an Emacs lock file (`.#entry.md`, a dangling symlink) is a candidate and had
+    been observed 503ing `/api/v1/recall/<scope>` in practice. That is the
+    `broken-link` cell's whole reason for existing, and the `.md` half of the
+    shape needs no separate check because the glob has already applied it.
 
     ⚠ NOT A SUBSTITUTE FOR THE RESULT NARROWING in `load_store`. That one is
     still authoritative for the shape of the answer; this one exists so the
     denied scope is never TOUCHED. Both call `visible_scope_set`, so they cannot
     come to disagree about what an allowlist means.
     """
+    collecting = _check_on_malformed(on_malformed) == ON_MALFORMED_COLLECT
     allowed = visible_scope_set(visible_scopes)
     mappings: list[Mapping[str, object]] = []
     scopes: list[str] = []
+    # Entries REFUSED by kind before `open()`. Kept separate from `mappings`
+    # because they never become one — `build_index` never sees them, so nothing
+    # downstream has to learn a second rejection shape.
+    refused: list[MalformedEntry] = []
     # Both `sorted()` calls here are DETERMINISM guards: they fix which entry a
     # malformed-index error names, so the same store always produces the same
     # message. ⚠ The scope-level one is not observable from a test — no test can
@@ -1846,6 +2139,31 @@ def load_index(
         for md in sorted(scope_dir.glob("*.md")):
             if md.name == "README.md":
                 continue
+            # 🔴 WHAT IS THIS PATH — ASKED BEFORE IT IS OPENED, AND ASKED ONCE.
+            # `classify_path` is the same function `/snapshot` uses; only the
+            # action table differs, because the action is a property of the
+            # context. The narrow-vs-broad argument is on the table itself.
+            kind = classify_path(md)
+            if action_for(kind, _LOADER_ENTRY_ACTIONS) == REFUSE:
+                reason = _LOADER_REFUSAL_REASON[kind]
+                if not collecting:
+                    # 🔴 THE SAME POLICY, NOT A NEW ONE. Under `RAISE` this is
+                    # indistinguishable from any other rejection — the writer's
+                    # probe must not act on a store it read only part of, and
+                    # that is as true of a fifo as of a bad `aliases:` line.
+                    raise MalformedEntryError(
+                        f"malformed index entry {md.name!r}: {reason}",
+                        source=md.name,
+                        why=reason,
+                    )
+                refused.append(
+                    MalformedEntry(
+                        scope=normalize_ref(scope_dir.name),
+                        filename=md.name,
+                        reason=reason,
+                    )
+                )
+                continue
             mappings.append(
                 entry_mapping(
                     md.read_text(encoding="utf-8", errors="replace"),
@@ -1853,4 +2171,15 @@ def load_index(
                     scope=scope_dir.name,
                 )
             )
-    return build_index(mappings, extra_scopes=scopes, on_malformed=on_malformed)
+    index = build_index(mappings, extra_scopes=scopes, on_malformed=on_malformed)
+    if not refused:
+        return index
+    # 🔴 MERGED HERE RATHER THAN PASSED INTO `build_index`. These rows have
+    # ALREADY been through the `on_malformed` policy above (a non-collecting
+    # caller never reaches this line), so handing them to a function whose whole
+    # job is to APPLY that policy would be a second, silent policy site. The
+    # scope is already registered by `extra_scopes`, so the empty-scope rule
+    # `build_index` implements for its own rejects needs nothing here.
+    return SubsystemIndex(
+        by_scope=index.by_scope, malformed=index.malformed + tuple(refused)
+    )

--- a/scripts/lib/subsystem_resolver.py
+++ b/scripts/lib/subsystem_resolver.py
@@ -1821,11 +1821,26 @@ def load_index(
     # mutation sweep cannot kill. Stated rather than left to look covered.
     for scope_dir in sorted(p for p in Path(root).iterdir() if p.is_dir()):
         if allowed is not None and normalize_ref(scope_dir.name) not in allowed:
-            # 🔴 `continue` BEFORE `scopes.append`, not after: registering the
-            # name here would put a denied scope on `index.scopes` — the
-            # `known_scopes` enumeration channel, reopened one line above the
-            # filter that closes it. Nothing about this directory is read,
-            # listed, classified or named.
+            # 🔴 `continue` BEFORE `scopes.append`, not after. Appending first
+            # still skips the READ, so it looks equivalent — and THROUGH
+            # `load_store` it is, because that function's result narrowing drops
+            # the key again on the way out. Measured: the swap survives a sweep
+            # driven entirely through `load_store`. It is NOT equivalent for a
+            # caller that uses this function directly (`subsystem_touch`, and
+            # `TestTheLoaderItselfTakesTheAllowlist`), which gets a denied
+            # scope's NAME on `index.scopes` — the `known_scopes` enumeration
+            # channel — for a directory nothing ever opened.
+            #
+            # 🔴 `is not None`, NEVER truthiness: an EMPTY allowlist means
+            # nothing is visible, and `if allowed and …` would read it as
+            # unrestricted. Same asymmetry, same fail-closed direction, same
+            # invisibility through `load_store`.
+            #
+            # 🔴 The DIRECTORY NAME is folded before comparing, because the index
+            # key `build_index` derives from it is folded (`extra_scopes` →
+            # `normalize_ref`). A raw comparison drops a scope dir spelled
+            # `Kelp_Forest` out of an allowlist that names `kelp-forest` — the
+            # caller's OWN scope, silently emptied.
             continue
         scopes.append(scope_dir.name)
         for md in sorted(scope_dir.glob("*.md")):

--- a/scripts/lib/subsystem_resolver.py
+++ b/scripts/lib/subsystem_resolver.py
@@ -1943,19 +1943,35 @@ def visible_scope_set(visible_scopes: Sequence[str] | None) -> set[str] | None:
 #                  request thread never returns. This is the cell that is not a
 #                  degradation but a hang.
 #
-# Neither is ever a legitimate entry, so no legitimate caller changes behaviour.
+# 🔴 AND NOW A THIRD, WHICH IS THE SECOND ONE IN A DIFFERENT SHAPE:
 #
-# 🔴 `link-to-file` IS `TAKE`, AND THAT IS THE POINT OF THE NARROW FORM. A
-# symlink to a regular `*.md` is read today and keeps being read. A mutant that
-# flips this cell to REFUSE is the exact over-broad regression the narrow ruling
-# exists to prevent, and `test_a_SYMLINKED_entry_is_still_READ_the_narrow_guard_
-# is_not_the_broad_one` kills it.
+#   `link-to-other`  a symlink POINTING AT a fifo/socket/device. It shipped
+#                  `TAKE` for one round and was written up here as a NAMED
+#                  RESIDUAL — the decision that created this table named `other`
+#                  and `broken-link` and nothing else. It was then MEASURED
+#                  rather than argued about, on the tip that carried it:
 #
-# ⚠ NAMED RESIDUAL, NOT AN OVERSIGHT: `link-to-other` — a symlink POINTING AT a
-# fifo/socket/device — is the SAME hang in a different shape and is left `TAKE`,
-# because the decision on this PR named `other` and `broken-link` and nothing
-# else. Closing it is this one cell; it is called out here so the next reader
-# does not have to rediscover it from a wedged pod.
+#                      store/bravo/link-to-fifo.md -> /tmp/thefifo (a real fifo)
+#                      GET /api/v1/recall/alpha, UNRESTRICTED legacy token
+#                      -> no response at 25s, request thread WEDGED (curl 124)
+#                      -> /healthz 200 throughout, so the process was UP and the
+#                         worker was gone — the positive control for the probe
+#
+#                  `open()` does not care which path shape reached the fifo, so
+#                  this was never a lesser defect than `other`; it was the same
+#                  one, and on a `replicas: 1` / `strategy: Recreate` service a
+#                  wedged thread is the worst outcome in this file. Refused.
+#
+# None of the three is ever a legitimate entry, so no legitimate caller changes
+# behaviour.
+#
+# 🔴 `link-to-file` IS `TAKE`, AND THAT IS THE POINT OF THE NARROW FORM — it is
+# the cell the narrow-vs-broad ruling was actually about, and closing
+# `link-to-other` did not touch it. A symlink to a regular `*.md` is read today
+# and keeps being read. A mutant that flips this cell to REFUSE is the exact
+# over-broad regression the narrow ruling exists to prevent, and
+# `test_a_SYMLINKED_entry_is_STILL_READ_the_guard_is_NOT_the_broad_one` kills
+# it.
 #
 # ⚠ `indeterminate`, `directory`, `link-to-dir` and `absent` are `TAKE` for the
 # same conservatism: `read_text` raises on each (EACCES, IsADirectoryError,
@@ -1965,9 +1981,9 @@ def visible_scope_set(visible_scopes: Sequence[str] | None) -> set[str] | None:
 _LOADER_ENTRY_ACTIONS: dict[str, str] = {
     KIND_BROKEN_LINK: REFUSE,
     KIND_OTHER: REFUSE,
+    KIND_LINK_TO_OTHER: REFUSE,
     KIND_REGULAR_FILE: TAKE,
     KIND_LINK_TO_FILE: TAKE,
-    KIND_LINK_TO_OTHER: TAKE,
     KIND_DIRECTORY: TAKE,
     KIND_LINK_TO_DIR: TAKE,
     KIND_INDETERMINATE: TAKE,
@@ -1990,6 +2006,12 @@ _LOADER_REFUSAL_REASON: dict[str, str] = {
         "not a regular file (a fifo, socket or device) — refused before "
         "`open()`, which on a fifo blocks until somebody writes to it and never "
         "returns, wedging the reader"
+    ),
+    KIND_LINK_TO_OTHER: (
+        "a symlink to something that is not a regular file (a fifo, socket or "
+        "device) — refused before `open()`, which blocks on a fifo whether it "
+        "is named directly or reached through a link. Measured wedging a "
+        "`/recall` request thread for 25s while the process stayed healthy"
     ),
 }
 
@@ -2071,9 +2093,12 @@ def load_index(
     🔴 SO THE CANDIDATE'S KIND IS NOW CHECKED BEFORE `open()`, FOR EVERY CALLER
     — `_LOADER_ENTRY_ACTIONS`, above, which reuses `classify_path` rather than
     asking the question a second way. It is NARROW on purpose: a dangling
-    symlink and a fifo/socket/device are refused, and everything this loader
-    reads today — regular files AND symlinks to regular files — is still read,
-    so no legitimate caller changes behaviour. A refusal is reported the way
+    symlink, a fifo/socket/device, and a symlink POINTING AT one are refused,
+    and everything this loader reads today — regular files AND symlinks to
+    regular files — is still read, so no legitimate caller changes behaviour.
+    (The `link-to-other` cell shipped one round later than the other two, after
+    the shape was measured wedging an unrestricted `/recall` thread for 25s;
+    `open()` blocks the same through a link as directly.) A refusal is reported the way
     every other unusable entry is, through `on_malformed`: a `MalformedEntry` on
     the index under `COLLECT`, a `MalformedEntryError` under `RAISE`. One
     hostile file therefore costs that ONE entry, and is NAMED, instead of
@@ -2085,8 +2110,10 @@ def load_index(
     deliberate — it is the four-state rule below ("the store was not fully
     READ", which is not "this entry is malformed") — so on a HOSTILE store the
     unrestricted reading is unchanged for that shape and changed for the other
-    two. A symlink pointing AT a fifo (`link-to-other`) is likewise still
-    `TAKE`; see the table's note.
+    three. ⚠ THAT LIST USED TO NAME A SECOND UNCOVERED SHAPE — a symlink
+    pointing AT a fifo — and it no longer does, because that cell is now
+    REFUSE. `chmod 000` is the only residual left here, and it is a 503, not a
+    hang.
 
     ⚠ `Path.glob("*.md")` DOES match a leading dot — measured, not assumed — so
     an Emacs lock file (`.#entry.md`, a dangling symlink) is a candidate and had

--- a/scripts/lib/subsystem_resolver.py
+++ b/scripts/lib/subsystem_resolver.py
@@ -1696,7 +1696,32 @@ def entry_mapping(text: str, *, filename: str, scope: str) -> dict[str, object]:
     return fm
 
 
-def load_index(root: Path, *, on_malformed: str = ON_MALFORMED_RAISE) -> SubsystemIndex:
+def visible_scope_set(visible_scopes: Sequence[str] | None) -> set[str] | None:
+    """One allowlist -> the normalized set every narrowing site compares against.
+
+    🔴 ONE PLACE, because this predicate is now spelled at three of them — the
+    index loader below, `subsystem_recall.load_store`, and the API's `/snapshot`
+    candidate list, which walks the store root directly and so cannot use the
+    index at all. Open-coded at three sites it would be wrong at two of them in
+    the same direction, and the direction that matters here is "wider than the
+    caller's allowlist".
+
+    🔴 `None` IN, `None` OUT — UNRESTRICTED. An EMPTY sequence returns an EMPTY
+    SET, which is its opposite: nothing is visible. Both are falsy, so every
+    caller must test `is None`, never truthiness; that asymmetry is the whole
+    fail-closed direction of the scoped-token design.
+    """
+    if visible_scopes is None:
+        return None
+    return {normalize_ref(s) for s in visible_scopes}
+
+
+def load_index(
+    root: Path,
+    *,
+    on_malformed: str = ON_MALFORMED_RAISE,
+    visible_scopes: Sequence[str] | None = None,
+) -> SubsystemIndex:
     """Read `<root>/<scope>/*.md` into a `SubsystemIndex`. READ-ONLY.
 
     `README.md` is skipped in every scope — each scope dir carries one as its
@@ -1730,7 +1755,63 @@ def load_index(root: Path, *, on_malformed: str = ON_MALFORMED_RAISE) -> Subsyst
     interpret, while an unreadable one means the store was not fully READ — the
     set of entries is then unknown, so there is nothing honest to degrade to.
     `load_store`/`build_report` name it `index entry unreadable`.
+
+    🔴 `visible_scopes` IS APPLIED BEFORE ANY FILE IS OPENED, AND THAT IS THE
+    POINT OF IT BEING HERE RATHER THAN ON THE RESULT. Narrowing the index
+    afterwards still WALKS and READS every scope, which with a scoped API caller
+    in front of it is three separate defects, all measured:
+
+      * DISCLOSURE. One unreadable entry made `/recall` and `/search` answer
+        `503 index entry unreadable: under <store> (PermissionError: …
+        '<store>/<denied-scope>/locked-entry.md')` — the full path of a file in
+        a scope that caller is not allowed to know exists. A scoped reader had
+        no other way to learn that name.
+      * DENIAL OF SERVICE. One unreadable file anywhere in the store broke
+        recall for EVERY caller, including the ones whose own scopes were fine.
+      * A HUNG THREAD. `read_text` on a FIFO named `*.md` blocks until somebody
+        writes to it. On a `replicas: 1` service that is worse than the 503: the
+        request never returns and the worker is gone. `/snapshot` already
+        refuses non-regular files by kind; this path had no such guard, and now
+        does not need one for a scope the caller cannot name.
+
+    An unreadable file in a scope the caller CAN see still raises — that is the
+    four-state rule and it is unchanged. The local CLI passes no allowlist at
+    all (`None`), so its behaviour is byte-identical to before.
+
+    🔴 AND THAT LAST SENTENCE IS ALSO THE LIMIT OF THIS FIX — SAID HERE RATHER
+    THAN LEFT TO BE DISCOVERED. `visible_scopes=None` skips nothing, so for an
+    UNRESTRICTED caller all three failures above are exactly as open as they
+    were. That includes the credential the pod is deployed with today: a bare
+    legacy row is unrestricted, so **the live API is not protected by this
+    change**; only a scoped token whose allowlist excludes the bad scope is.
+    Measured on this tree, `load_store` over a store whose `quartz-mine` scope
+    holds one hostile file:
+
+        visible_scopes=None        FIFO `hang.md`     -> HUNG (>6s, killed)
+        visible_scopes=None        `.#locked.md`      -> EntryUnreadableError
+        visible_scopes=('kelp-forest',)  both         -> loads, scopes=(kelp-forest,)
+        visible_scopes=('quartz-mine',)  FIFO         -> HUNG (its own scope)
+
+    Closing it for everybody needs a KIND check on the candidate before `open()`
+    — `server.py`'s `_ENTRY_ACTIONS` already classifies exactly these cases
+    (`KIND_OTHER: REFUSE`, "a FIFO named `*.md` blocked `open()` forever") for
+    `/snapshot`, and that classifier lives in the API rather than here. Left
+    OUT OF THIS CHANGE on purpose: it also refuses a symlink-to-regular-file
+    entry, which this loader accepts today, so it is a behaviour change for
+    every local CLI caller and wants its own review. **Closing condition: an
+    entry-kind guard in this module, or a decision on this PR that the residual
+    is accepted.**
+
+    ⚠ `Path.glob("*.md")` DOES match a leading dot — measured, not assumed — so
+    an Emacs lock file (`.#entry.md`, a dangling symlink) is a candidate and has
+    been observed 503ing `/api/v1/recall/<scope>` in practice.
+
+    ⚠ NOT A SUBSTITUTE FOR THE RESULT NARROWING in `load_store`. That one is
+    still authoritative for the shape of the answer; this one exists so the
+    denied scope is never TOUCHED. Both call `visible_scope_set`, so they cannot
+    come to disagree about what an allowlist means.
     """
+    allowed = visible_scope_set(visible_scopes)
     mappings: list[Mapping[str, object]] = []
     scopes: list[str] = []
     # Both `sorted()` calls here are DETERMINISM guards: they fix which entry a
@@ -1739,6 +1820,13 @@ def load_index(root: Path, *, on_malformed: str = ON_MALFORMED_RAISE) -> Subsyst
     # control `iterdir()` order — so it is the one guard in this module a
     # mutation sweep cannot kill. Stated rather than left to look covered.
     for scope_dir in sorted(p for p in Path(root).iterdir() if p.is_dir()):
+        if allowed is not None and normalize_ref(scope_dir.name) not in allowed:
+            # 🔴 `continue` BEFORE `scopes.append`, not after: registering the
+            # name here would put a denied scope on `index.scopes` — the
+            # `known_scopes` enumeration channel, reopened one line above the
+            # filter that closes it. Nothing about this directory is read,
+            # listed, classified or named.
+            continue
         scopes.append(scope_dir.name)
         for md in sorted(scope_dir.glob("*.md")):
             if md.name == "README.md":

--- a/scripts/lib/subsystem_touch.py
+++ b/scripts/lib/subsystem_touch.py
@@ -4745,6 +4745,16 @@ def census(store_root: str | Path, now: float | None = None) -> Census:
         scope = scope_dir.name
         by_scope.setdefault(scope, 0)
         nested.setdefault(scope, {})
+        # ⚠ THE THIRD `glob("*.md")` + `read_text` SITE, AND THE ONE WITH NO
+        # ENTRY-KIND GUARD. `subsystem_resolver.load_index` and the API's
+        # `/snapshot` both classify a candidate before opening it; this one does
+        # not, so a fifo named `*.md` still blocks `read_text` here forever and a
+        # directory named `*.md` still raises `IsADirectoryError` out of
+        # `census()`. Left that way by ruling, not oversight: `census` is CLI
+        # only — nothing in `subsystem-store-api/server.py` imports
+        # `subsystem_touch` — so no request thread can reach it, and widening the
+        # guard here was considered and declined. If that import ever appears,
+        # this line becomes a hung worker.
         for md in sorted(scope_dir.glob("*.md")):
             if md.name == "README.md":
                 continue

--- a/scripts/subsystem-store-api/README.md
+++ b/scripts/subsystem-store-api/README.md
@@ -131,9 +131,19 @@ are the store-root line — `2` and `2` for pod-vs-workbench.
 ## The token is a SET, and rotation is by overlap
 
 The token file holds **one ROW per line, current first**. Blank lines are
-ignored; duplicate tokens collapse, order preserved. Up to `MAX_TOKENS` (4) —
-every line is a live credential, so an uncapped set is an accumulation nobody
-has retired, and the server refuses to start rather than serve one.
+ignored. Up to `MAX_TOKENS` (4) — every line is a live credential, so an
+uncapped set is an accumulation nobody has retired, and the server refuses to
+start rather than serve one.
+
+🔴 **Two rows holding the same token collapse only if they are IDENTICAL** —
+same token, same identity, same folded scope list. If they disagree the server
+refuses to start with `duplicate token in rows N and M`, naming both
+authorities. This is not pedantry: dropping the second row before parsing it
+made `<tok>` followed by `<tok> zach kelp-forest` — "scope a credential its
+holder already has", the migration's own first step — load as ONE unrestricted
+`legacy` row, with no error and a banner that said `1 of 1 token rows are bare`
+over a two-line file. **To scope an existing token, EDIT its bare row**; adding
+a second row below it is refused.
 
 A row is one of two shapes:
 

--- a/scripts/subsystem-store-api/README.md
+++ b/scripts/subsystem-store-api/README.md
@@ -86,6 +86,26 @@ all → `503` + `X-Store-Status: store-unreachable`, carrying the reader's own
 "this is NOT 'nothing recorded yet'" sentence. A `200` is a claim the store was
 read, and only the first of those can make it.
 
+🔴 **One hostile FILE no longer costs the whole store.** The index loader
+classifies each `*.md` candidate BEFORE opening it and refuses two kinds:
+
+| on disk | why it is refused |
+|---|---|
+| a dangling symlink — e.g. an Emacs lock file `.#entry.md`, which `glob("*.md")` really does match | opening it raised, and an `OSError` fails closed, so `/recall` and `/search` answered **503** for EVERY caller and named the file and its scope in the body |
+| a fifo / socket / device named `*.md` | `read_text` on a fifo blocks until somebody writes; on `replicas: 1` the request thread never returned |
+
+A refused entry becomes an ordinary **malformed** row — counted, named, and
+rendered like every other unusable entry — so the scope's good entries still
+serve. It is refused, never silently skipped: a dropped entry is
+indistinguishable from one nobody ever wrote.
+
+⚠ **What still 503s, deliberately:** an unreadable REGULAR file (`chmod 000`).
+"The store was not fully READ" is a different fact from "this entry is
+malformed", and only the second has an honest degraded form. A symlink pointing
+*at* a fifo is also still opened — the same hang in a different shape, left open
+by the narrow scope of this change and recorded at
+`subsystem_resolver._LOADER_ENTRY_ACTIONS`.
+
 ## Operating it
 
 ```bash
@@ -131,13 +151,21 @@ are the store-root line — `2` and `2` for pod-vs-workbench.
 ## The token is a SET, and rotation is by overlap
 
 The token file holds **one ROW per line, current first**. Blank lines are
-ignored. Up to `MAX_TOKENS` (4) — every line is a live credential, so an
-uncapped set is an accumulation nobody has retired, and the server refuses to
-start rather than serve one.
+ignored. Up to `MAX_TOKENS` (4) **distinct tokens** — every distinct token is a
+live credential, so an uncapped set is an accumulation nobody has retired, and
+the server refuses to start rather than serve one. The cap counts CREDENTIALS,
+not lines: a row written twice is one credential (see the collapse below), and
+counting it twice would have refused a four-credential file.
 
-🔴 **Two rows holding the same token collapse only if they are IDENTICAL** —
-same token, same identity, same folded scope list. If they disagree the server
-refuses to start with `duplicate token in rows N and M`, naming both
+Every guard that names a position names the **physical line number**, so it is
+countable in an editor — `token on line 6 of 6`, `duplicate token on lines 2
+and 6` — including across a collapse and across blank lines.
+
+🔴 **Two rows holding the same token collapse only if they grant the SAME
+THING** — same identity and the same folded scope SET. Case, `_` vs `-`, a
+repeated scope and the ORDER of the list are all spellings of one grant, so
+`zach alpha,beta` and `zach beta,alpha` collapse. If they genuinely disagree the
+server refuses to start with `duplicate token on lines N and M`, naming both
 authorities. This is not pedantry: dropping the second row before parsing it
 made `<tok>` followed by `<tok> zach kelp-forest` — "scope a credential its
 holder already has", the migration's own first step — load as ONE unrestricted
@@ -155,7 +183,7 @@ A row is one of two shapes:
 🔴 **Whitespace now separates the three FIELDS of one row, not two tokens.**
 Before phase 3 the file was split on any whitespace, so `<tokenA> <tokenB>` on
 one line was two credentials. It is now a row with a token in the identity
-field — refused at startup with `malformed token row N of M`, never
+field — refused at startup with `malformed token row on line N of M`, never
 reinterpreted. Put one row per line.
 
 Generate a token:

--- a/scripts/subsystem-store-api/README.md
+++ b/scripts/subsystem-store-api/README.md
@@ -12,8 +12,9 @@ usable is phase 2. Add the pointer when there is something to point at.
 | in | out, until |
 |---|---|
 | the pod, seeded from the local store | — |
-| read-only `GET` API, bearer token **SET** | writes / append endpoints → **phase 3** |
-| per-client rate limit + lockout, `CF-Connecting-IP` keying | separate read/write tokens → **phase 3** |
+| read-only `GET` API, bearer token **SET** | writes / append endpoints → **phase 3, criteria 4-10** |
+| per-client rate limit + lockout, `CF-Connecting-IP` keying | a WRITE-scoped token → **phase 3, criteria 4-10** |
+| per-token identity + **scope allowlist** on every read route (phase 3, criteria 1-3) | — |
 | cluster-internal `ClusterIP` | 🔴 IngressRoute + DNS → **an UNMERGED PR** |
 | byte-identity verified against local | the CLI wrapper + read-through cache → **phase 2** |
 
@@ -129,17 +130,62 @@ are the store-root line — `2` and `2` for pod-vs-workbench.
 
 ## The token is a SET, and rotation is by overlap
 
-The token file holds **one token per line, current first**. Whitespace-separated
-is also accepted; blank lines are ignored; duplicates collapse. Up to
-`MAX_TOKENS` (4) — every line is a live credential, so an uncapped set is an
-accumulation nobody has retired, and the server refuses to start rather than
-serve one.
+The token file holds **one ROW per line, current first**. Blank lines are
+ignored; duplicate tokens collapse, order preserved. Up to `MAX_TOKENS` (4) —
+every line is a live credential, so an uncapped set is an accumulation nobody
+has retired, and the server refuses to start rather than serve one.
 
-Generate one:
+A row is one of two shapes:
+
+```
+<token>                                    # LEGACY: identity `legacy`, ALL scopes
+<token>   <identity>   <scope>,<scope>     # MAPPED: named holder, scoped
+```
+
+🔴 **Whitespace now separates the three FIELDS of one row, not two tokens.**
+Before phase 3 the file was split on any whitespace, so `<tokenA> <tokenB>` on
+one line was two credentials. It is now a row with a token in the identity
+field — refused at startup with `malformed token row N of M`, never
+reinterpreted. Put one row per line.
+
+Generate a token:
 
 ```bash
 python3 -c 'import secrets; print(secrets.token_urlsafe(43))'   # 58 chars
 ```
+
+### Identities and scope allowlists (phase 3, criteria 1-3)
+
+A **mapped** row names who holds the token and which scopes it may read. The
+identity is lowercase `[a-z0-9-]`, at most 32 characters — deliberately BELOW
+the 43-character token floor, so a token can never be misread as an identity.
+Scopes are comma-separated, each matching `[A-Za-z0-9_-]+`, folded by the
+reader's own `normalize_ref` so `Kelp_Forest` and `kelp-forest` are one scope.
+
+A scope outside the allowlist answers **exactly what a scope that never existed
+answers** — `200`, `X-Store-Status: scope-absent`, and a body byte-identical to
+the genuinely-absent one. There is no "forbidden" response, because a response
+that discriminates is an enumeration API. What the caller sees narrows with it:
+`known_scopes`, the cross-scope malformed block, `?all_scopes=1` search results,
+the `/snapshot` tar members and `X-Store-Revision` are all the caller's own.
+
+⚠ **`X-Store-Snapshot` (and the freshness prose) stays STORE-WIDE.** It carries
+a total `entry-files=` count across scopes the caller cannot name. That is
+deliberate — it is the staleness guarantee the snapshot design rests on, and
+scoping it would make "how old is this copy" a function of your allowlist — but
+it is a residual count leak, recorded here rather than left to be discovered.
+
+`identity=<name>` is an **additional** audit field; `token=<fingerprint>` is
+unchanged and is still the only thing that can tell one holder's current
+credential from its previous one.
+
+🔴 **A bare legacy row is still valid, and any file containing one makes the
+process shout on stderr at startup**, naming the count and the legacy
+fingerprints. That is the migration (mapped rows land beside the old shared
+token) and the rollback (put the one line back — no code change). Rotating a
+MAPPED credential uses a second identity (`zach-prev`), not a second row naming
+the same one: two rows claiming one identity with disagreeing allowlists have no
+defined precedence, so they are refused.
 
 ### Rotating, and how you know it is safe to finish
 
@@ -154,8 +200,8 @@ store-api audit ts=… ip=203.0.113.7 peer=trusted method=GET path=/api/v1/recal
 
 1. `sops clusters/homelab/apps/subsystem-store/secrets.enc.yaml` — put the NEW
    token on the first line, keep the old one below it. Commit; Flux applies.
-2. Restart the pod. Its startup line prints every fingerprint in file order:
-   `token-ids=<new>,<old>`.
+2. Restart the pod. Its startup line prints every fingerprint in file order,
+   each with its identity: `token-ids=<new>:legacy,<old>:legacy`.
 3. Roll clients onto the new token. Watch the audit stream until the OLD
    fingerprint stops appearing:
    `kubectl -n subsystem-store logs deploy/subsystem-store-api | grep 'token=<old>'`
@@ -340,8 +386,11 @@ layers' job; this layer is the only one that can see a wrong credential.
 
 ## Deferred, and why (not oversights)
 
-- **Separate read/write tokens** — there is no write path until phase 3, so a
-  write-scoped token today is a label on a capability that does not exist.
+- **Separate read/write tokens** — the READ half landed with phase 3 criteria
+  1-3 (identity + scope allowlist above). A WRITE-scoped token is still deferred
+  for the original reason: criteria 4-10 add no verb yet, so it would be a label
+  on a capability that does not exist. `do_POST = do_PUT = do_PATCH = do_DELETE
+  = _reject_write` is untouched and every write verb is still a 405.
 - **Backup CronJob, daily-commit CronJob** — the workbench copy is authoritative
   until phase 3, so the PVC is a second copy, not the only one.
 - **A `rotate-token` script** — the procedure above is four steps across a SOPS

--- a/scripts/subsystem-store-api/README.md
+++ b/scripts/subsystem-store-api/README.md
@@ -87,24 +87,41 @@ all → `503` + `X-Store-Status: store-unreachable`, carrying the reader's own
 read, and only the first of those can make it.
 
 🔴 **One hostile FILE no longer costs the whole store.** The index loader
-classifies each `*.md` candidate BEFORE opening it and refuses two kinds:
+classifies each `*.md` candidate BEFORE opening it, and REFUSES these kinds —
+the list is `subsystem_resolver._LOADER_ENTRY_ACTIONS`, and a test asserts this
+table against it in both directions, so neither can drift ahead of the other:
 
-| on disk | why it is refused |
-|---|---|
-| a dangling symlink — e.g. an Emacs lock file `.#entry.md`, which `glob("*.md")` really does match | opening it raised, and an `OSError` fails closed, so `/recall` and `/search` answered **503** for EVERY caller and named the file and its scope in the body |
-| a fifo / socket / device named `*.md` | `read_text` on a fifo blocks until somebody writes; on `replicas: 1` the request thread never returned |
+| kind | on disk | why it is refused |
+|---|---|---|
+| `broken-link` | a dangling symlink — e.g. an Emacs lock file `.#entry.md`, which `glob("*.md")` really does match | opening it raised, and an `OSError` fails closed, so `/recall` and `/search` answered **503** for EVERY caller and named the file and its scope in the body |
+| `other` | a fifo / socket / device named `*.md` | `read_text` on a fifo blocks until somebody writes; on `replicas: 1` the request thread never returned |
+| `link-to-other` | a symlink pointing *at* a fifo / socket / device | the same hang in a different shape — `open()` does not care which path shape reached the fifo. Measured wedging an unrestricted `/recall` for **25s** while `/healthz` stayed 200 |
+| `directory` | a directory named `*.md` — one stray `mkdir <scope>/<slug>.md`, an rsync or a restore artefact | `read_text` raises `IsADirectoryError`, and that `OSError` fails closed: **503** on `/recall` and `/search` for every caller. Measured, with a dangling-lock-file control returning 200 on the same shape |
+| `link-to-dir` | a symlink pointing at a directory | identical, through a link |
 
 A refused entry becomes an ordinary **malformed** row — counted, named, and
 rendered like every other unusable entry — so the scope's good entries still
 serve. It is refused, never silently skipped: a dropped entry is
 indistinguishable from one nobody ever wrote.
 
-⚠ **What still 503s, deliberately:** an unreadable REGULAR file (`chmod 000`).
-"The store was not fully READ" is a different fact from "this entry is
-malformed", and only the second has an honest degraded form. A symlink pointing
-*at* a fifo is also still opened — the same hang in a different shape, left open
-by the narrow scope of this change and recorded at
-`subsystem_resolver._LOADER_ENTRY_ACTIONS`.
+⚠ **THE RESIDUAL LEDGER — what still 503s, deliberately.** This is exactly the
+set of kinds the loader still `TAKE`s, and the same test pins it, because this
+paragraph has twice gone stale while the table moved underneath it:
+
+| kind | the shape | why it is still read |
+|---|---|---|
+| `regular-file` | an unreadable entry (`chmod 000`) | "the store was not fully READ" is a different fact from "this entry is malformed", and only the second has an honest degraded form |
+| `link-to-file` | a symlink whose TARGET is unreadable | the same shape through a link — measured, and listed on its own so the ledger does not read shorter than it is |
+| `indeterminate` | the `lstat` itself failed (EACCES on the parent, ESTALE, EIO) | "I could not look" is a different premise from "this kind can never be an entry", which is the criterion every REFUSE row above rests on |
+| `absent` | the candidate vanished between `glob()` and the classify | a TOCTOU race. Reasoned from the table, not reproduced |
+
+Everything else this loader has ever successfully read — regular files and
+symlinks to regular files — is still read, so no legitimate caller changed
+behaviour. **END OF RESIDUAL LEDGER.**
+
+⚠ `subsystem_touch.census()` is a THIRD `glob("*.md")` + `read_text` site and has
+**no** kind check, so it still hangs on a fifo. Unguarded by ruling, not by
+oversight: it is CLI-only and nothing in `server.py` imports `subsystem_touch`.
 
 ## Operating it
 

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -214,11 +214,18 @@ import subsystem_recall as rc  # noqa: E402
 
 # 🔴 THE PATH CLASSIFIER IS IMPORTED, NOT DEFINED HERE — it moved into
 # `subsystem_resolver` when `load_index` grew an entry-kind guard of its own.
-# "What IS this path" spelled at two sites is wrong at one of them, and the two
-# sites are `/snapshot` and the index loader: disagreeing about a FIFO named
-# `*.md` is what costs a request thread. The three ACTION tables stay with their
-# contexts (`_ROOT_ACTIONS`/`_ENTRY_ACTIONS` below, `_LOADER_ENTRY_ACTIONS`
-# there), because an action is a property of the context and not of the path.
+# "What IS this path" spelled at N sites is wrong at N-1 of them, and the two
+# sites GUARDED BY THIS CLASSIFIER are `/snapshot` and the index loader:
+# disagreeing about a FIFO named `*.md` is what costs a request thread. The
+# three ACTION tables stay with their contexts (`_ROOT_ACTIONS`/`_ENTRY_ACTIONS`
+# below, `_LOADER_ENTRY_ACTIONS` there), because an action is a property of the
+# context and not of the path.
+#
+# ⚠ TWO GUARDED SITES IS NOT TWO SITES — this comment used to say it was, and
+# was wrong. `subsystem_touch.census()` globs `*.md` and `read_text`s the result
+# with no kind check, so it still hangs on a fifo. It is unguarded BY RULING,
+# not by oversight: it is CLI-only and NOTHING in this server imports
+# `subsystem_touch`, so no request thread can reach it.
 #
 # Re-exported deliberately (hence the `F401`): `KIND_*`, `SKIP/TAKE/REFUSE`,
 # `ALL_KINDS`, `classify_path` and `action_for` are read off THIS module by

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -423,11 +423,24 @@ def as_token_record(item: "str | TokenRecord") -> TokenRecord:
     return TokenRecord(token=item, identity=LEGACY_IDENTITY, scopes=None)
 
 
+def _authority_of(record: TokenRecord) -> str:
+    """How a record's AUTHORITY reads in an error message. Never the token.
+
+    Used only by the duplicate-token guard, whose whole job is to say that two
+    rows disagree — so it has to be able to say what they disagree ABOUT, and
+    the identity and the scope list are the two facts that are not secrets.
+    """
+    if record.scopes is None:
+        return f"{record.identity} (UNRESTRICTED)"
+    return f"{record.identity} ({','.join(record.scopes)})"
+
+
 def _parse_token_row(fields: list[str], index: int, total: int) -> TokenRecord:
     """One non-empty line of the token file -> one record, or raise naming why.
 
-    Guards 6-11 of `load_tokens`' ladder live here; the numbering and the
-    reachability argument are in that function's docstring.
+    Guards 6-10 of `load_tokens`' ladder live here; the numbering and the
+    reachability argument are in that function's docstring. Guards 11 and 12 are
+    cross-row and cannot live here — see `load_tokens`.
     """
     if len(fields) not in (1, 3):
         # 🔴 REFUSED, NOT REINTERPRETED, and this is where the format changed.
@@ -552,15 +565,41 @@ def load_tokens(
       8.  identity is not taken   -> "reserved identity in token row N of M"
       9.  the allowlist is real   -> "empty scope allowlist in token row N of M"
       10. every scope is namable  -> "invalid scope in token row N of M"
-      11. one row per identity    -> "duplicate identity"
+      11. one authority per token -> "duplicate token in rows N and M"
+      12. one row per identity    -> "duplicate identity"
 
     Guards 1-5 are UNCHANGED in wording and in order, deliberately: they are the
     ones an operator has already met, and 5 in particular is reached by a file
     whose second line an editor truncated. Guard 5 names the POSITION, never the
     token — saying "one of them is short" would leave the operator grepping a
-    secret by hand — and 6-10 keep that property for the same reason.
+    secret by hand — and 6-12 keep that property for the same reason.
 
-    🔴 GUARD 11 EXEMPTS `legacy`, AND THAT IS NOT AN OVERSIGHT. Two legacy rows
+    🔴 EVERY ROW REACHES THE LADDER, AND THAT IS A FIX, NOT A STYLE CHOICE.
+    This loop used to drop a line whose FIRST FIELD had already been seen —
+    before parsing it, before validating it, silently. Two failures were
+    measured, and both are fail-OPEN:
+
+      * `<tok>` on one line and `<tok> zach alpha` on the next — the exact
+        migration this format exists for, "scope a credential its holder
+        already has" — loaded as ONE row, `identity=legacy scopes=None`, i.e.
+        UNRESTRICTED. The mapped row simply did not exist. The only signal was
+        a banner saying "1 of 1 token rows are bare" over a two-line file.
+      * `<tok> zach alpha` then `<tok> Za_CH_BAD !!!!` loaded clean. The second
+        row carried an invalid identity AND an invalid scope and was never
+        validated, because it was dropped before guards 6-10 ran.
+
+    That is guard 10's own defect class — a grant that reads as working and does
+    nothing — one level up and in the unsafe direction, and it contradicted
+    guard 12, which refuses two rows claiming one IDENTITY for having "no
+    defined precedence" while two rows claiming one TOKEN silently picked one.
+    So: parse first, collapse after, and only rows that are IDENTICAL collapse.
+
+    🔴 GUARD 11 RUNS BEFORE GUARD 12, AND THE ORDER IS LOAD-BEARING. A file
+    holding one row twice, verbatim, must collapse to one record — otherwise
+    guard 12 would see two rows claiming one identity and refuse the ordinary
+    "I pasted the line twice" file. Collapse first, then count identities.
+
+    🔴 GUARD 12 EXEMPTS `legacy`, AND THAT IS NOT AN OVERSIGHT. Two legacy rows
     are an overlap rotation of the old shared token, which is the exact thing
     guards 1-5 were built to support. Two rows naming ONE mapped identity are
     different: if their allowlists disagree there is no defined answer, and if
@@ -588,15 +627,16 @@ def load_tokens(
     # Line-based now, because a row has internal structure. `.split()` per line
     # still absorbs a trailing newline, CRLF and any run of spaces or tabs
     # BETWEEN fields; a blank line is skipped rather than being an empty row.
+    #
+    # 🔴 NOTHING IS DROPPED HERE. See the docstring: a de-duplication that ran
+    # before the parse made two fail-open readings possible. Rows 4, 5 and every
+    # index in guards 6-12 therefore count PHYSICAL LINES, which is also what the
+    # operator is looking at when they read the message.
     rows: list[list[str]] = []
-    seen_tokens: set[str] = set()
     for line in raw.splitlines():
         fields = line.split()
         if not fields:
             continue
-        if fields[0] in seen_tokens:  # de-duplicated BY TOKEN, ORDER PRESERVED
-            continue
-        seen_tokens.add(fields[0])
         rows.append(fields)
 
     if not rows:
@@ -619,8 +659,48 @@ def load_tokens(
         for index, fields in enumerate(rows, start=1)
     ]
 
-    by_identity: dict[str, int] = {}
+    # GUARD 11 — one token, one authority. Runs on PARSED records, so a row that
+    # would be collapsed has already been through guards 6-10, and two rows that
+    # merely SPELL one grant differently (`Kelp_Forest` vs `kelp-forest`) are
+    # recognised as the same grant rather than as a disagreement.
+    #
+    # 🔴 COLLAPSE ONLY WHAT IS IDENTICAL. `TokenRecord` is a frozen dataclass, so
+    # `==` compares the token, the identity AND the scope tuple — all three facts
+    # the rest of this file resolves off one match. Anything less than all three
+    # agreeing is two authorities for one credential, and picking one of them is
+    # what made the migration path fail open.
+    first_seen: dict[str, tuple[int, TokenRecord]] = {}
+    collapsed: list[tuple[int, TokenRecord]] = []
     for index, record in enumerate(records, start=1):
+        seen = first_seen.get(record.token)
+        if seen is None:
+            first_seen[record.token] = (index, record)
+            collapsed.append((index, record))
+            continue
+        first_index, first_record = seen
+        if record == first_record:
+            # The rotation shape, and it is legitimate: one row written twice.
+            # Order is kept because the FIRST occurrence is the one retained.
+            continue
+        raise ValueError(
+            f"duplicate token in rows {first_index} and {index}: one credential "
+            f"is given two different authorities — {_authority_of(first_record)} "
+            f"and {_authority_of(record)} — and there is no defined precedence "
+            f"between them. Scoping a token its holder already has means EDITING "
+            f"the bare row, not adding a second one below it; a second holder "
+            f"needs a second token"
+        )
+    # 🔴 REBOUND HERE, ONCE, so everything below — guard 12, the legacy banner's
+    # "N of M", and the returned SET — reads the collapsed list. A second name
+    # kept alongside `records` is how a later edit ends up counting one list and
+    # returning the other.
+    records = [record for _row, record in collapsed]
+
+    # GUARD 12 — one row per mapped identity. Indexed by PHYSICAL row, carried
+    # through the collapse above, so "rows 1 and 3" names the lines the operator
+    # can see rather than positions in a list they cannot.
+    by_identity: dict[str, int] = {}
+    for index, record in collapsed:
         if record.is_legacy:
             continue
         first = by_identity.get(record.identity)
@@ -2404,10 +2484,11 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         # opened, and can never reach the `unreadable` list either — a refused
         # scope must not be able to 503 somebody else's snapshot, which is both
         # a leak and a denial of service.
-        visible = self._visible_scopes
-        allowed = (
-            None if visible is None else {rc.normalize_ref(s) for s in visible}
-        )
+        # 🔴 THE SAME PREDICATE THE INDEX LOADER USES, from the same function.
+        # Three sites now narrow by allowlist — here, `load_index` (what is
+        # OPENED) and `load_store` (the result shape) — and open-coding the fold
+        # at each of them is how they come to disagree about `Kelp_Forest`.
+        allowed = rc.visible_scope_set(self._visible_scopes)
         try:
             candidates = sorted(
                 p

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -189,7 +189,6 @@ criteria 4-10.
 from __future__ import annotations
 
 import argparse
-import errno
 import hashlib
 import hmac
 import io
@@ -197,7 +196,6 @@ import ipaddress
 import math
 import os
 import re
-import stat
 import sys
 import tarfile
 import threading
@@ -213,6 +211,35 @@ _LIB = Path(__file__).resolve().parents[1] / "lib"
 sys.path.insert(0, str(_LIB))
 
 import subsystem_recall as rc  # noqa: E402
+
+# 🔴 THE PATH CLASSIFIER IS IMPORTED, NOT DEFINED HERE — it moved into
+# `subsystem_resolver` when `load_index` grew an entry-kind guard of its own.
+# "What IS this path" spelled at two sites is wrong at one of them, and the two
+# sites are `/snapshot` and the index loader: disagreeing about a FIFO named
+# `*.md` is what costs a request thread. The three ACTION tables stay with their
+# contexts (`_ROOT_ACTIONS`/`_ENTRY_ACTIONS` below, `_LOADER_ENTRY_ACTIONS`
+# there), because an action is a property of the context and not of the path.
+#
+# Re-exported deliberately (hence the `F401`): `KIND_*`, `SKIP/TAKE/REFUSE`,
+# `ALL_KINDS`, `classify_path` and `action_for` are read off THIS module by
+# `TestClassifierIsTotal`, and the tables below are written in terms of them.
+from subsystem_resolver import (  # noqa: E402,F401
+    ALL_KINDS,
+    KIND_ABSENT,
+    KIND_BROKEN_LINK,
+    KIND_DIRECTORY,
+    KIND_INDETERMINATE,
+    KIND_LINK_TO_DIR,
+    KIND_LINK_TO_FILE,
+    KIND_LINK_TO_OTHER,
+    KIND_OTHER,
+    KIND_REGULAR_FILE,
+    REFUSE,
+    SKIP,
+    TAKE,
+    action_for,
+    classify_path,
+)
 
 # --- Constants that the tests pin LITERALLY -------------------------------------
 #
@@ -435,12 +462,53 @@ def _authority_of(record: TokenRecord) -> str:
     return f"{record.identity} ({','.join(record.scopes)})"
 
 
-def _parse_token_row(fields: list[str], index: int, total: int) -> TokenRecord:
+def _authority_key(record: TokenRecord) -> tuple[str, frozenset[str] | None]:
+    """What two rows must AGREE ON to be one grant rather than two authorities.
+
+    🔴 A **SET** OF SCOPES, NOT THE TUPLE, and that is a fix. `TokenRecord` is a
+    frozen dataclass, so `record == record` compares `scopes` positionally —
+    which made `<tok> zach alpha,beta` and `<tok> zach beta,alpha` a refusal
+    reading "two different authorities — zach (alpha,beta) and zach
+    (beta,alpha)". Both grant the same set; there is a defined answer, so guard
+    11 must not claim there is none. Guard 11's own comment already promised
+    this ("rows that merely SPELL one grant differently are recognised as the
+    same grant") and delivered it for case/`_`-folding only.
+
+    The TOKEN is not in the key: the collapse is already keyed on it, so every
+    pair this compares shares one by construction.
+
+    `None` (unrestricted) is kept as `None` rather than folded to an empty
+    frozenset, because an empty allowlist is its OPPOSITE everywhere else in
+    this file — the same asymmetry as `visible_scope_set`.
+
+    ⚠ EQUIVALENT MUTANT, MEASURED, RECORDED RATHER THAN LEFT TO READ AS PINNED.
+    `frozenset(record.scopes or ())` — which collapses `None` into the empty set
+    — SURVIVES the whole suite (56/56 in the token classes, 0 failures). It is
+    unreachable, and by construction rather than by luck: two rows only reach
+    this comparison sharing a token, `legacy` is the ONLY identity a bare row
+    gets and guard 8 refuses a mapped row that claims it, so a `None` is only
+    ever compared with another `None`; and guard 9 refuses a mapped row with an
+    empty allowlist, so no non-None empty set exists to confuse it. The spelling
+    stays because it is the same asymmetry as every other allowlist site and a
+    future guard-9 relaxation would make it load-bearing — but no test
+    distinguishes the two today, and saying so is the honest form.
+    """
+    return (
+        record.identity,
+        None if record.scopes is None else frozenset(record.scopes),
+    )
+
+
+def _parse_token_row(fields: list[str], line: int, total: int) -> TokenRecord:
     """One non-empty line of the token file -> one record, or raise naming why.
 
     Guards 6-10 of `load_tokens`' ladder live here; the numbering and the
     reachability argument are in that function's docstring. Guards 11 and 12 are
     cross-row and cannot live here — see `load_tokens`.
+
+    `line` is the PHYSICAL line number and `total` the file's physical line
+    count, so "line 6 of 6" is something the operator can count to in an editor.
+    Both are passed in rather than derived, because this function sees one row.
     """
     if len(fields) not in (1, 3):
         # 🔴 REFUSED, NOT REINTERPRETED, and this is where the format changed.
@@ -469,7 +537,7 @@ def _parse_token_row(fields: list[str], index: int, total: int) -> TokenRecord:
                 "three fields, so `alpha, beta` is two of them"
             )
         raise ValueError(
-            f"malformed token row {index} of {total}: {len(fields)} fields, "
+            f"malformed token row on line {line} of {total}: {len(fields)} fields, "
             f"expected 1 (a bare legacy token) or 3 (token, identity, "
             f"comma-separated scopes). Whitespace separates the three FIELDS, "
             f"so two tokens on one line is no longer two tokens{hint}"
@@ -484,7 +552,7 @@ def _parse_token_row(fields: list[str], index: int, total: int) -> TokenRecord:
         or not IDENTITY_COMPONENT.fullmatch(identity)
     ):
         raise ValueError(
-            f"invalid identity in token row {index} of {total}: {identity!r} — "
+            f"invalid identity in token row on line {line} of {total}: {identity!r} — "
             f"expected lowercase letters, digits and dashes, starting on an "
             f"alphanumeric, at most {MAX_IDENTITY_CHARS} characters. The "
             f"identity is quoted into the audit log, so it must be one spelling"
@@ -495,7 +563,7 @@ def _parse_token_row(fields: list[str], index: int, total: int) -> TokenRecord:
         # old shared credential, which can see everything" — or the one line the
         # operator greps to know the migration is finished is ambiguous.
         raise ValueError(
-            f"reserved identity in token row {index} of {total}: "
+            f"reserved identity in token row on line {line} of {total}: "
             f"{LEGACY_IDENTITY!r} is what a BARE token line is given, and it "
             f"means unrestricted scope. Name this row's holder instead"
         )
@@ -505,7 +573,7 @@ def _parse_token_row(fields: list[str], index: int, total: int) -> TokenRecord:
         # Reachable with a bare `,`: three fields, a valid identity, and no
         # scope name anywhere in the third.
         raise ValueError(
-            f"empty scope allowlist in token row {index} of {total} "
+            f"empty scope allowlist in token row on line {line} of {total} "
             f"({identity!r}): a credential that may see NO scope can never be "
             f"used. Remove the row, or name the scopes it may read"
         )
@@ -528,7 +596,7 @@ def _parse_token_row(fields: list[str], index: int, total: int) -> TokenRecord:
         folded = rc.normalize_ref(raw)
         if not SAFE_PATH_COMPONENT.fullmatch(raw) or not folded:
             raise ValueError(
-                f"invalid scope in token row {index} of {total} ({identity!r}): "
+                f"invalid scope in token row on line {line} of {total} ({identity!r}): "
                 f"{raw!r} — a scope must match {SAFE_PATH_COMPONENT.pattern} AND "
                 f"still name something once folded the way the reader folds a "
                 f"scope. An entry that no request could name, or that folds away "
@@ -571,25 +639,36 @@ def load_tokens(
     LOUD startup warning, because "unrestricted" is a state somebody has to be
     able to see from the pod log.
 
-    Guard order — each reachable by an input no earlier guard rejects:
+    Guard order — each reachable by an input no earlier guard rejects. `L` is a
+    PHYSICAL LINE NUMBER and `T` the file's physical line count:
       1.  some source at all      -> "no token source"
       2.  the file is readable    -> "token file unreadable"
       3.  at least one token      -> "token is empty"
       4.  not an accumulation     -> "too many tokens"
-      5.  every token long enough -> "token N of M is too short"
-      6.  every row parses        -> "malformed token row N of M"
-      7.  identity is well-formed -> "invalid identity in token row N of M"
-      8.  identity is not taken   -> "reserved identity in token row N of M"
-      9.  the allowlist is real   -> "empty scope allowlist in token row N of M"
-      10. every scope is namable  -> "invalid scope in token row N of M"
-      11. one authority per token -> "duplicate token in rows N and M"
+      5.  every token long enough -> "token on line L of T is too short"
+      6.  every row parses        -> "malformed token row on line L of T"
+      7.  identity is well-formed -> "invalid identity in token row on line L of T"
+      8.  identity is not taken   -> "reserved identity in token row on line L of T"
+      9.  the allowlist is real   -> "empty scope allowlist in token row on line L of T"
+      10. every scope is namable  -> "invalid scope in token row on line L of T"
+      11. one authority per token -> "duplicate token on lines L and M"
       12. one row per identity    -> "duplicate identity"
 
-    Guards 1-5 are UNCHANGED in wording and in order, deliberately: they are the
-    ones an operator has already met, and 5 in particular is reached by a file
-    whose second line an editor truncated. Guard 5 names the POSITION, never the
-    token — saying "one of them is short" would leave the operator grepping a
-    secret by hand — and 6-12 keep that property for the same reason.
+    Guards 1-4 are unchanged in ORDER, and 1-3 in wording too: they are the ones
+    an operator has already met, and 5 in particular is reached by a file whose
+    second line an editor truncated.
+
+    ⚠ 4 AND 5 DID CHANGE WORDING ON THIS BRANCH, and both were defects rather
+    than polish. 4 counted physical ROWS, so a legitimately duplicated line
+    counted twice against `MAX_TOKENS`; it counts DISTINCT tokens now. 5-12 said
+    "N of M" over NON-BLANK rows while the comment beside them claimed physical
+    lines — measurably false on any file with a blank line in it, and "the
+    operator can find the line" is the whole reason an index is carried at all.
+    Every one of them names a real line number now.
+
+    Guard 5 names the POSITION, never the token — saying "one of them is short"
+    would leave the operator grepping a secret by hand — and 6-12 keep that
+    property for the same reason.
 
     🔴 EVERY ROW REACHES THE LADDER, AND THAT IS A FIX, NOT A STYLE CHOICE.
     This loop used to drop a line whose FIRST FIELD had already been seen —
@@ -615,6 +694,11 @@ def load_tokens(
     holding one row twice, verbatim, must collapse to one record — otherwise
     guard 12 would see two rows claiming one identity and refuse the ordinary
     "I pasted the line twice" file. Collapse first, then count identities.
+
+    🔴 AND "TWICE" MEANS THE SAME GRANT, NOT THE SAME TEXT. Two rows collapse
+    when their identity and their scope SET agree; case, `_` vs `-`, a repeated
+    scope and the ORDER of the list are all spellings of one grant. See
+    `_authority_key`.
 
     🔴 GUARD 12 EXEMPTS `legacy`, AND THAT IS NOT AN OVERSIGHT. Two legacy rows
     are an overlap rotation of the old shared token, which is the exact thing
@@ -646,61 +730,91 @@ def load_tokens(
     # BETWEEN fields; a blank line is skipped rather than being an empty row.
     #
     # 🔴 NOTHING IS DROPPED HERE. See the docstring: a de-duplication that ran
-    # before the parse made two fail-open readings possible. Rows 4, 5 and every
-    # index in guards 6-12 therefore count PHYSICAL LINES, which is also what the
-    # operator is looking at when they read the message.
-    rows: list[list[str]] = []
-    for line in raw.splitlines():
-        fields = line.split()
+    # before the parse made two fail-open readings possible.
+    #
+    # 🔴 AND THE INDEX CARRIED FORWARD IS THE PHYSICAL LINE NUMBER, MEASURED, NOT
+    # THE ROW'S POSITION IN THIS LIST. The comment here used to CLAIM the two
+    # were the same thing; the loop skips blank lines, so they are not, and the
+    # claim was measurably false the moment a file had one. Reproduced on a
+    # six-line file whose rows sat on lines 2, 4 and 6: guard 12 said "token rows
+    # 1 and 3 both claim it" for a clash on lines 2 and 6 — and "the operator can
+    # find the line" is the ENTIRE justification for carrying a pre-collapse
+    # index through guard 12 at all. `total` is the physical line COUNT for the
+    # same reason, so "line 6 of 6" is countable in an editor.
+    lines = raw.splitlines()
+    total = len(lines)
+    rows: list[tuple[int, list[str]]] = []
+    for lineno, text in enumerate(lines, start=1):
+        fields = text.split()
         if not fields:
             continue
-        rows.append(fields)
+        rows.append((lineno, fields))
 
     if not rows:
         raise ValueError("token is empty: the source resolved to whitespace only")
-    if len(rows) > MAX_TOKENS:
+    # 🔴 GUARD 4 COUNTS CREDENTIALS, NOT ROWS. Removing the pre-parse dedup left
+    # this counting physical rows, and measured: 4 distinct tokens plus ONE
+    # verbatim duplicate line answered "too many tokens: 5, max 4" for a file
+    # holding 4 credentials that loaded fine before this branch — and five copies
+    # of one token said the same for ONE. That contradicts guard 11, whose own
+    # comment calls a duplicated row "the rotation shape, and it is legitimate".
+    #
+    # DISTINCT FIRST FIELDS is exactly the post-collapse count and needs no
+    # parse: guard 11 collapses on `record.token`, which IS `fields[0]`, and
+    # refuses outright any pair that shares one without agreeing. So for every
+    # file that loads at all, this number and `len(collapsed)` are the same
+    # number — computed here only because guard 4 must stay ahead of the parse.
+    credentials = {fields[0] for _lineno, fields in rows}
+    if len(credentials) > MAX_TOKENS:
         raise ValueError(
-            f"too many tokens: {len(rows)}, max {MAX_TOKENS}. Every line is a "
-            f"live credential; retire the old ones instead of accumulating them"
+            f"too many tokens: {len(credentials)}, max {MAX_TOKENS}. Every "
+            f"DISTINCT token is a live credential; retire the old ones instead "
+            f"of accumulating them"
         )
-    for index, fields in enumerate(rows, start=1):
+    for lineno, fields in rows:
         if len(fields[0]) < MIN_TOKEN_CHARS:
             raise ValueError(
-                f"token {index} of {len(rows)} is too short: {len(fields[0])} chars, "
-                f"need >= {MIN_TOKEN_CHARS} (256 bits base64url). A short token is "
-                f"a guessable one"
+                f"token on line {lineno} of {total} is too short: "
+                f"{len(fields[0])} chars, need >= {MIN_TOKEN_CHARS} (256 bits "
+                f"base64url). A short token is a guessable one"
             )
 
-    records = [
-        _parse_token_row(fields, index, len(rows))
-        for index, fields in enumerate(rows, start=1)
-    ]
+    records = [_parse_token_row(fields, lineno, total) for lineno, fields in rows]
 
     # GUARD 11 — one token, one authority. Runs on PARSED records, so a row that
     # would be collapsed has already been through guards 6-10, and two rows that
-    # merely SPELL one grant differently (`Kelp_Forest` vs `kelp-forest`) are
-    # recognised as the same grant rather than as a disagreement.
+    # merely SPELL one grant differently are recognised as the same grant rather
+    # than as a disagreement. Three spellings are folded, and each was a measured
+    # false refusal or would have been one:
+    #   * case and `_` vs `-`  (`Kelp_Forest` == `kelp-forest`) — by the parser
+    #   * a repeated scope     (`alpha,alpha` == `alpha`)       — by the parser
+    #   * scope-list ORDER     (`alpha,beta` == `beta,alpha`)   — by
+    #     `_authority_key`, which compares the SET. Measured before that: the two
+    #     rows were refused as "two different authorities — zach (alpha,beta) and
+    #     zach (beta,alpha)", which is one grant written twice.
     #
-    # 🔴 COLLAPSE ONLY WHAT IS IDENTICAL. `TokenRecord` is a frozen dataclass, so
-    # `==` compares the token, the identity AND the scope tuple — all three facts
-    # the rest of this file resolves off one match. Anything less than all three
-    # agreeing is two authorities for one credential, and picking one of them is
-    # what made the migration path fail open.
+    # 🔴 COLLAPSE ONLY WHAT GRANTS THE SAME THING. Anything less than the
+    # identity AND the scope SET agreeing is two authorities for one credential,
+    # and picking one of them is what made the migration path fail open.
     first_seen: dict[str, tuple[int, TokenRecord]] = {}
     collapsed: list[tuple[int, TokenRecord]] = []
-    for index, record in enumerate(records, start=1):
+    # `strict=True`: `records` is built one-for-one from `rows` directly above,
+    # and if a later edit ever makes it not, a SHORTER zip would silently drop
+    # the tail — the rows nobody then checks for a duplicate token.
+    for (lineno, _fields), record in zip(rows, records, strict=True):
         seen = first_seen.get(record.token)
         if seen is None:
-            first_seen[record.token] = (index, record)
-            collapsed.append((index, record))
+            first_seen[record.token] = (lineno, record)
+            collapsed.append((lineno, record))
             continue
-        first_index, first_record = seen
-        if record == first_record:
+        first_line, first_record = seen
+        if _authority_key(record) == _authority_key(first_record):
             # The rotation shape, and it is legitimate: one row written twice.
-            # Order is kept because the FIRST occurrence is the one retained.
+            # Order is kept because the FIRST occurrence is the one retained —
+            # which also decides which SPELLING of the scope list survives.
             continue
         raise ValueError(
-            f"duplicate token in rows {first_index} and {index}: one credential "
+            f"duplicate token on lines {first_line} and {lineno}: one credential "
             f"is given two different authorities — {_authority_of(first_record)} "
             f"and {_authority_of(record)} — and there is no defined precedence "
             f"between them. Scoping a token its holder already has means EDITING "
@@ -711,24 +825,26 @@ def load_tokens(
     # "N of M", and the returned SET — reads the collapsed list. A second name
     # kept alongside `records` is how a later edit ends up counting one list and
     # returning the other.
-    records = [record for _row, record in collapsed]
+    records = [record for _line, record in collapsed]
 
-    # GUARD 12 — one row per mapped identity. Indexed by PHYSICAL row, carried
-    # through the collapse above, so "rows 1 and 3" names the lines the operator
-    # can see rather than positions in a list they cannot.
+    # GUARD 12 — one row per mapped identity. Indexed by PHYSICAL LINE, carried
+    # through the collapse above, so "lines 2 and 6" names what the operator can
+    # see rather than positions in a list they cannot — and, since this branch,
+    # rather than an ordinal over non-blank rows that a single blank line makes
+    # wrong.
     by_identity: dict[str, int] = {}
-    for index, record in collapsed:
+    for lineno, record in collapsed:
         if record.is_legacy:
             continue
         first = by_identity.get(record.identity)
         if first is not None:
             raise ValueError(
-                f"duplicate identity {record.identity!r}: token rows {first} and "
-                f"{index} both claim it, and their scope allowlists have no "
-                f"defined precedence. Rotate a mapped credential under a second "
-                f"identity ({record.identity}-prev), not a second row"
+                f"duplicate identity {record.identity!r}: token rows on lines "
+                f"{first} and {lineno} both claim it, and their scope allowlists "
+                f"have no defined precedence. Rotate a mapped credential under a "
+                f"second identity ({record.identity}-prev), not a second row"
             )
-        by_identity[record.identity] = index
+        by_identity[record.identity] = lineno
 
     legacy = [r for r in records if r.is_legacy]
     if legacy:
@@ -1381,7 +1497,7 @@ SEED_STAMP_NAME = ".seed-stamp"
 
 
 # =============================================================================
-# 🔴 THE TOTAL CLASSIFIER — why this exists instead of a fourth `if` arm.
+# 🔴 THE ACTION TABLES. The CLASSIFIER they read moved to `subsystem_resolver`.
 #
 # Four consecutive audit rounds found the same shape of defect in `_snapshot`,
 # and every fix added one more predicate to a sequence:
@@ -1397,71 +1513,22 @@ SEED_STAMP_NAME = ".seed-stamp"
 # class, because a broken pointer is neither. Adding an arm fixes the instance;
 # it does not make the rule total, so the next class falls through the same gap.
 #
-# So: classify the path's TYPE exhaustively, in one place, and have each context
-# map EVERY kind to an action explicitly. `_ROOT_ACTIONS` and `_ENTRY_ACTIONS`
-# are asserted complete by `TestClassifierIsTotal`, and an unmapped kind raises
-# rather than defaulting — a fallthrough is a test failure, not a silent skip.
-# Name-based rules (dotfiles, the `.md` suffix) stay SEPARATE from type, because
-# conflating them is what made the dotfile and symlink rules interfere.
+# So: classify the path's TYPE exhaustively, in ONE place — now
+# `subsystem_resolver.classify_path`, because the index loader needs the same
+# answer and a second copy of it would be the predicate-at-two-sites shape — and
+# have each context map EVERY kind to an action explicitly.
+#
+# 🔴 THE TABLES DID **NOT** MOVE WITH IT, AND THAT IS THE DESIGN. A kind's
+# action is a property of the CONTEXT, not of the path: the loader's own table
+# (`subsystem_resolver._LOADER_ENTRY_ACTIONS`) is deliberately NARROWER than
+# `_ENTRY_ACTIONS` below — it TAKES a symlink-to-regular-file that `/snapshot`
+# refuses, because the loader has always read one and refusing it would be a
+# behaviour change for every local CLI caller. All three tables are asserted
+# complete by `TestClassifierIsTotal`, and an unmapped kind raises rather than
+# defaulting — a fallthrough is a test failure, not a silent skip. Name-based
+# rules (dotfiles, the `.md` suffix) stay SEPARATE from type, because conflating
+# them is what made the dotfile and symlink rules interfere.
 # =============================================================================
-
-KIND_BROKEN_LINK = "broken-link"      # dangling target, or a symlink loop
-KIND_LINK_TO_DIR = "link-to-dir"
-KIND_LINK_TO_FILE = "link-to-file"
-KIND_LINK_TO_OTHER = "link-to-other"  # link to a fifo/socket/device
-KIND_DIRECTORY = "directory"
-KIND_REGULAR_FILE = "regular-file"
-KIND_OTHER = "other"                  # fifo, socket, device, door…
-# 🔴 THE LAST CELL OF THE LOOP: the first version of this classifier was total
-# over KIND STRINGS but not over KNOWLEDGE. "I could not determine what this is"
-# is its own answer and must never share a bucket with "I know exactly what this
-# is".
-#
-# ⚠ CORRECTED — AND THE CORRECTION IS THE INTERESTING PART. This comment used to
-# say "every pathlib predicate returns False when the stat itself fails, so an
-# EACCES fell into KIND_OTHER and was skipped", and cited a measurement of
-# `/snapshot` answering 200 / exit 0 / entries=0. BOTH WERE WRONG, and the
-# second was inherited from an audit report and written up here as first-hand.
-# ⚠ And the raise did NOT come from `classify_path` — that function is INTRODUCED
-# by this fix. In the failing version it came from `candidate.is_dir()` in
-# `_snapshot`, which this commit deletes. Corrected after an audit caught the
-# anachronism; the docstring below was already accurate.
-# Measured on the pinned interpreter:
-#     pathlib._IGNORED_ERRNOS == (ENOENT, ENOTDIR, EBADF, ELOOP)
-#     child of a 0o600 dir: is_symlink/is_dir/is_file/exists each RAISE
-#                           PermissionError — none returns False
-# So the old failure was not a silent empty store; it was an UNCAUGHT
-# PermissionError out of `classify_path`, crashing the handler with no response
-# and no audit line. Loud, not quiet.
-#
-# The fix stands — a crashed handler becoming a typed 503 is strictly better —
-# but the reasoning had to be corrected, because "pathlib returns False on stat
-# failure" is exactly the kind of false premise that gets a guard deleted
-# somewhere else in this file on the strength of a comment.
-KIND_INDETERMINATE = "indeterminate"
-# Vanished between `readdir` and the stat — a benign race, not a hazard, and
-# distinct from INDETERMINATE because the right action differs.
-KIND_ABSENT = "absent"
-
-ALL_KINDS: frozenset[str] = frozenset(
-    {
-        KIND_BROKEN_LINK,
-        KIND_LINK_TO_DIR,
-        KIND_LINK_TO_FILE,
-        KIND_LINK_TO_OTHER,
-        KIND_DIRECTORY,
-        KIND_REGULAR_FILE,
-        KIND_OTHER,
-        KIND_INDETERMINATE,
-        KIND_ABSENT,
-    }
-)
-
-# What a context does with each kind. `SKIP` = not the thing we are looking for,
-# so its absence is not a fact worth reporting. `TAKE` = use it. `REFUSE` = it
-# IS (or claims to be) the thing, and we cannot serve it — which must be
-# REPORTED, never skipped, because a skip renders as "nothing recorded".
-SKIP, TAKE, REFUSE = "skip", "take", "refuse"
 
 _ROOT_ACTIONS: dict[str, str] = {
     # 🔴 A BROKEN POINTER IS A SCOPE THAT SHOULD BE THERE AND IS NOT. Skipping
@@ -1494,77 +1561,6 @@ _ENTRY_ACTIONS: dict[str, str] = {
     KIND_ABSENT: SKIP,
 }
 
-
-def classify_path(path: Path) -> str:
-    """The path's type, as exactly one of `ALL_KINDS`. Total by construction.
-
-    🔴 ONE `lstat`, THEN THE MODE BITS — not a sequence of pathlib predicates.
-    Those predicates fail in TWO different ways and neither is usable here:
-    they return False for the errnos in `pathlib._IGNORED_ERRNOS` (ENOENT,
-    ENOTDIR, EBADF, ELOOP), so "not a directory" and "no such path" are
-    indistinguishable; and they RAISE for every other errno (EACCES, ESTALE,
-    EIO), so a sequence built from them can abort mid-classification and take
-    the handler with it. The previous version did exactly that on an
-    unstat-able child.
-
-    Reading the mode bits from one explicit `lstat` makes both cases answerable:
-    a failure is an exception we must classify, not a False we might miss or a
-    raise we did not expect. It also halves the syscalls, which narrows the
-    TOCTOU window between them.
-    """
-    try:
-        st = path.lstat()
-    except FileNotFoundError:
-        return KIND_ABSENT
-    except OSError:
-        # EACCES on the parent, ESTALE, EIO… We do not know what this is, and
-        # saying so is the point — see KIND_INDETERMINATE.
-        return KIND_INDETERMINATE
-
-    if not stat.S_ISLNK(st.st_mode):
-        if stat.S_ISDIR(st.st_mode):
-            return KIND_DIRECTORY
-        if stat.S_ISREG(st.st_mode):
-            return KIND_REGULAR_FILE
-        return KIND_OTHER
-
-    try:
-        target = path.stat()  # follows the link
-    except OSError as exc:
-        # ENOENT = dangling, ELOOP = a cycle (measured: self-loop, mutual loop
-        # and a 45-link chain all give ELOOP). Both are broken POINTERS, which
-        # is a fact we know; anything else means the stat failed for a reason we
-        # cannot interpret, which is not.
-        #
-        # ⚠ NO ACTION DEPENDS ON THIS BRANCH, and saying so is honest rather
-        # than leaving it to read as coverage: BROKEN_LINK and INDETERMINATE map
-        # to the SAME action in BOTH tables, so the split only changes the word
-        # in the 503 body. A mutant collapsing it survives the suite, and that
-        # is correct — there is no behaviour to catch. It is kept because the
-        # two words mean different things to whoever reads the 503, and because
-        # the tables could diverge later. Errnos measured to land in
-        # `indeterminate` rather than `broken-link`: ENOTDIR (`/etc/hosts/x`),
-        # ENAMETOOLONG (300-char target), EACCES (link into an unsearchable dir).
-        if exc.errno in (errno.ENOENT, errno.ELOOP):
-            return KIND_BROKEN_LINK
-        return KIND_INDETERMINATE
-    if stat.S_ISDIR(target.st_mode):
-        return KIND_LINK_TO_DIR
-    if stat.S_ISREG(target.st_mode):
-        return KIND_LINK_TO_FILE
-    return KIND_LINK_TO_OTHER
-
-
-def action_for(kind: str, actions: dict[str, str]) -> str:
-    """Look up the action, refusing to guess. An unmapped kind is a BUG."""
-    try:
-        return actions[kind]
-    except KeyError:  # pragma: no cover - pinned by TestClassifierIsTotal
-        raise AssertionError(
-            f"unclassified path kind {kind!r}: every kind must be mapped "
-            f"explicitly, because a default is how the last four rounds of this "
-            f"defect happened"
-        ) from None
 
 # 🔴 THE ROUTE TABLE, AND THE DISPATCHER READS IT. `name -> (handler, arity)`,
 # where arity counts the path components including the route name itself, so

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -451,11 +451,28 @@ def _parse_token_row(fields: list[str], index: int, total: int) -> TokenRecord:
         # impossible, so it would land here — and landing here is the point: a
         # line this parser cannot read is a startup failure, never a guess about
         # which of two readings the operator meant.
+        #
+        # ⚠ AND THE MESSAGE NAMES THE LIKELY TYPO WITHOUT ADMITTING IT. `<tok>
+        # zach a, b` is FOUR fields, because the space after the comma splits
+        # the scope list in two — a diagnostic of "4 fields, expected 1 or 3"
+        # is correct and useless, and the operator's next move is to stare at a
+        # line that looks like it has three of them. The hint is appended, never
+        # substituted for the refusal, and it is CONDITIONAL on evidence in the
+        # row (a comma past the identity field) rather than being guessed: the
+        # `<tokenA> <tokenB>` case has no comma and still gets the sentence
+        # about two tokens, which is ITS likely cause.
+        hint = ""
+        if len(fields) > 3 and any("," in f for f in fields[2:]):
+            hint = (
+                ". Field 3 is a comma-separated list with NO SPACES — write "
+                "`alpha,beta`, not `alpha, beta`: a space is what separates the "
+                "three fields, so `alpha, beta` is two of them"
+            )
         raise ValueError(
             f"malformed token row {index} of {total}: {len(fields)} fields, "
             f"expected 1 (a bare legacy token) or 3 (token, identity, "
             f"comma-separated scopes). Whitespace separates the three FIELDS, "
-            f"so two tokens on one line is no longer two tokens"
+            f"so two tokens on one line is no longer two tokens{hint}"
         )
     token = fields[0]
     if len(fields) == 1:
@@ -1764,6 +1781,32 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
     # would then see the whole store. An empty tuple is the fail-closed
     # direction: nothing is visible until a matched record says otherwise, and a
     # legacy record is the ONLY thing that can put `None` here.
+    #
+    # ⚠ ALL FIVE `= ()` SITES ARE EQUIVALENT MUTANTS TODAY, RECORDED RATHER THAN
+    # LEFT AS UNEXPLAINED SURVIVORS — the same treatment `send_error`'s
+    # `close_connection` and its reset already get, and for the same reason: an
+    # unexplained survivor reads either as a missing test or as a guard somebody
+    # may delete. MEASURED, one site at a time, each against the FULL
+    # `test_subsystem_store_api.py` suite: substituting `= None` at this
+    # declaration or at any of the four resets (`_reject_write`, `send_error`,
+    # `_request_path`'s `ValueError` branch, `_handle`) leaves 375/375 passing.
+    #
+    # WHY, precisely — and it is a REACHABILITY fact, not a coverage gap: every
+    # entry point into this handler assigns this field before any route can read
+    # it. `_handle` and `_reject_write` reset then either `authorize` (which
+    # overwrites it from the matched record) or refuse and return; `send_error`
+    # and the `_request_path` branch answer 401 and never reach a read route.
+    # There is no path on which the RESET VALUE is what a route observes, so no
+    # test can distinguish the two — writing one would mean inventing a caller
+    # that does not exist.
+    #
+    # 🔴 SO THE COMMENTS BELOW DESCRIBE A DIRECTION, NOT A LIVE GUARD. They are
+    # kept because the direction is the whole design — the day a refactor adds a
+    # route that runs before `authorize`, `()` serves nothing and `None` serves
+    # the entire store — but nobody should read them as "this is pinned by a
+    # test". It is not, it cannot be while the resets are unreachable, and
+    # saying so here is cheaper than a future reader re-deriving it from a
+    # green sweep.
     _visible_scopes: "tuple[str, ...] | None" = ()
     # The matched credential's name, for the audit line. `-` until one matches.
     _identity: str | None = None
@@ -1986,7 +2029,9 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         # 🔴 RESET TO `()` — nothing visible — NOT to the unrestricted `None`.
         # See the class-level declaration: this is the fail-closed direction,
         # and it is the reset value precisely because a reset runs on paths
-        # that never reach `authorize`.
+        # that never reach `authorize`. ⚠ EQUIVALENT MUTANT — `= None` here
+        # passes the full suite, because nothing reads the field before it is
+        # reassigned. Recorded at the declaration; not pinned by any test.
         self._visible_scopes = ()
         self._identity = None
         path = self._request_path()
@@ -2052,7 +2097,9 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         # 🔴 RESET TO `()` — nothing visible — NOT to the unrestricted `None`.
         # See the class-level declaration: this is the fail-closed direction,
         # and it is the reset value precisely because a reset runs on paths
-        # that never reach `authorize`.
+        # that never reach `authorize`. ⚠ EQUIVALENT MUTANT — `= None` here
+        # passes the full suite, because nothing reads the field before it is
+        # reassigned. Recorded at the declaration; not pinned by any test.
         self._visible_scopes = ()
         self._identity = None
         # ⚠ THAT RESET IS AN EQUIVALENT MUTANT ON THIS PATH, RECORDED RATHER
@@ -2155,7 +2202,9 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             # 🔴 RESET TO `()` — nothing visible — NOT to the unrestricted `None`.
             # See the class-level declaration: this is the fail-closed direction,
             # and it is the reset value precisely because a reset runs on paths
-            # that never reach `authorize`.
+            # that never reach `authorize`. ⚠ EQUIVALENT MUTANT — `= None` here
+            # passes the full suite, because nothing reads the field before it is
+            # reassigned. Recorded at the declaration; not pinned by any test.
             self._visible_scopes = ()
             self._identity = None
             self._unauthorized()
@@ -2198,7 +2247,9 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         # 🔴 RESET TO `()` — nothing visible — NOT to the unrestricted `None`.
         # See the class-level declaration: this is the fail-closed direction,
         # and it is the reset value precisely because a reset runs on paths
-        # that never reach `authorize`.
+        # that never reach `authorize`. ⚠ EQUIVALENT MUTANT — `= None` here
+        # passes the full suite, because nothing reads the field before it is
+        # reassigned. Recorded at the declaration; not pinned by any test.
         self._visible_scopes = ()
         self._identity = None
         path = self._request_path()

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -138,9 +138,52 @@ it is the second layer, not this one.
     all three are tunable by env. Cloudflare's WAF and the Traefik middleware
     are the outer two layers, not the only ones.
 
-Still NOT here, and still tracked forward: separate read/write tokens (there is
-no write path until phase 3, so a write-scoped token would today be a label on
-a capability that does not exist).
+PHASE 3, CRITERIA 1-3 — TWO-TOKEN AUTHORIZATION ON THE **READ** PATH
+---------------------------------------------------------------------
+🔴 THE READ PATH ONLY. There is still NO write verb, no append endpoint and no
+`PUT`; `do_POST = do_PUT = do_PATCH = do_DELETE = _reject_write` is untouched
+and `TestPhaseOneScope`'s write guard is still the thing that has to be broken
+on purpose when the write path lands. What changed is WHO a token is and WHAT
+it may see.
+
+  * **A token file row maps token -> identity -> scope allowlist**
+    (`load_tokens`, `TokenRecord`). A BARE token line is still valid and means
+    identity `legacy` with UNRESTRICTED scope — that is the migration and the
+    rollback, not a courtesy — and any legacy row makes the process shout on
+    stderr at startup.
+  * **Every read route refuses a scope outside the caller's allowlist**, and it
+    does so by narrowing the INDEX at `subsystem_recall.load_store`, the one
+    site both readers load from.
+  * **A refused scope is byte-identical to a nonexistent one.**
+
+🔴 THE ABSENT PATH WAS ALREADY AN ENUMERATION ORACLE, WHICH IS WHY A PER-ROUTE
+"is this scope yours" CHECK WOULD NOT HAVE BEEN ENOUGH. Measured on the
+deployed pod: `GET /api/v1/recall/<never-existed>` answers **200**, status
+`scope-absent`, and the body ends `scopes the store does hold: <every scope>`.
+Four distinct channels carried it:
+
+    1. `known_scopes`        rendered on every `scope-absent` report
+    2. `malformed_elsewhere` names OTHER scopes on EVERY status, not just a miss
+    3. `search?all_scopes=1` searches the CONTENT of every scope and NAMES NONE,
+                             so a per-scope refusal check has nothing to refuse
+    4. the `/snapshot` tar   ships the entry files themselves
+
+1-3 all derive from the single `SubsystemIndex` that `load_store` returns, so
+filtering THAT closes all three at once and cannot be forgotten by a route.
+4 does not go through the index at all — `_snapshot` walks the store root — so
+it is filtered separately, at the candidate list.
+
+⚠ WHAT IS STILL SHARED, STATED RATHER THAN LEFT TO BE FOUND: `X-Store-Snapshot`
+(and the freshness prose that opens every body) is STORE-WIDE. It carries a
+total `entry-files=` count over scopes the caller cannot name. That is a
+deliberate carry-over — it is the freshness guarantee the whole snapshot design
+rests on, and scoping it would make a caller's view of staleness a function of
+its own allowlist — but it IS a residual count leak, and it is the reason the
+byte-identity claim below is about a REFUSED scope versus an ABSENT one, never
+about two different stores.
+
+Still NOT here, and still tracked forward: the write path itself (§2c) —
+criteria 4-10.
 """
 
 from __future__ import annotations
@@ -159,6 +202,7 @@ import sys
 import tarfile
 import threading
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -200,6 +244,33 @@ MIN_TOKEN_CHARS = 43
 # and every one of them is a live credential — so the file is refused rather
 # than served, at STARTUP, for the same reason a short token is.
 MAX_TOKENS = 4
+
+# 🔴 THE IDENTITY OF A LEGACY ROW, AND IT MEANS UNRESTRICTED SCOPE.
+#
+# A bare token line — no identity, no allowlist — is the shape the file had
+# before this change, and it MUST keep loading: the migration puts the mapped
+# rows in beside the old shared token, and the rollback is re-adding that one
+# line. A format that refused it would make the rollback a code change.
+#
+# It is spelled here as a constant because three different things have to agree
+# on it: the parser that assigns it, the guard that refuses a MAPPED row from
+# claiming it, and the startup warning that names it.
+LEGACY_IDENTITY = "legacy"
+
+# 🔴 32, AND THE NUMBER IS LOAD-BEARING RATHER THAN TIDY: it is BELOW
+# `MIN_TOKEN_CHARS`, so a token can never be a well-formed identity. That makes
+# "the operator put three tokens on one line" structurally impossible to read as
+# "token, identity, scopes" — the second field would be at least 43 characters
+# and this cap refuses it. A cap ABOVE the token floor would have made that
+# misreading silent, and a silent misreading of a credential file is exactly the
+# failure the guard ladder below exists for.
+MAX_IDENTITY_CHARS = 32
+
+# Lowercase, digits and dashes, starting on an alphanumeric. Deliberately
+# NARROWER than the scope class below (no `_`, no uppercase): an identity is
+# quoted into the audit log and compared for duplicates, so two spellings of one
+# name would be two identities to the parser and one to the operator.
+IDENTITY_COMPONENT = re.compile(r"[a-z0-9][a-z0-9-]*")
 
 # 🔴 THE ONLY HEADER THIS SERVER WILL ACCEPT AS A CLIENT IDENTITY, and it is
 # trustworthy for exactly one reason: Cloudflare is the sole public ingress and
@@ -307,26 +378,195 @@ def token_id(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()[:12]
 
 
-def load_tokens(token_file: str | None, env: dict[str, str]) -> list[str]:
+@dataclass(frozen=True)
+class TokenRecord:
+    """One credential, and what it is allowed to SEE. Phase 3, criterion 1.
+
+    🔴 THE TOKEN AND ITS AUTHORITY ARE ONE OBJECT ON PURPOSE. The alternative —
+    a token list beside a `dict[token, scopes]` — is two structures that a route
+    can consult one of. Every consumer here is handed the record `authorize`
+    matched, so "which token was this" and "what may it see" cannot be answered
+    from different places and disagree.
+
+    `scopes is None` means UNRESTRICTED, and it is reachable ONLY from a legacy
+    bare-token row. An EMPTY tuple is its opposite — nothing is visible — and
+    that asymmetry is why the handler's per-request default is `()` rather than
+    `None`: a route that failed to set the field must see nothing, not
+    everything.
+    """
+
+    token: str
+    identity: str
+    scopes: tuple[str, ...] | None
+
+    @property
+    def fingerprint(self) -> str:
+        """What the audit log carries. Never the token — see `token_id`."""
+        return token_id(self.token)
+
+    @property
+    def is_legacy(self) -> bool:
+        return self.scopes is None
+
+
+def as_token_record(item: "str | TokenRecord") -> TokenRecord:
+    """Normalize one configured credential. ONE PLACE, and it is the same rule.
+
+    A bare `str` becomes the legacy record — identity `legacy`, unrestricted —
+    because that IS what a bare token line means (see `LEGACY_IDENTITY`). It is
+    not a compatibility shim bolted onto the callers: `load_tokens`,
+    `build_server` and `authorize` all route through here, so the meaning of a
+    bare token cannot come to differ between the parser and the checker.
+    """
+    if isinstance(item, TokenRecord):
+        return item
+    return TokenRecord(token=item, identity=LEGACY_IDENTITY, scopes=None)
+
+
+def _parse_token_row(fields: list[str], index: int, total: int) -> TokenRecord:
+    """One non-empty line of the token file -> one record, or raise naming why.
+
+    Guards 6-11 of `load_tokens`' ladder live here; the numbering and the
+    reachability argument are in that function's docstring.
+    """
+    if len(fields) not in (1, 3):
+        # 🔴 REFUSED, NOT REINTERPRETED, and this is where the format changed.
+        # The previous parser was `raw.split()` over the WHOLE file, so two
+        # tokens separated by a space were two credentials. Under the row format
+        # that same line would read as `token identity scopes` with a token in
+        # the identity field. `MAX_IDENTITY_CHARS` already makes that
+        # impossible, so it would land here — and landing here is the point: a
+        # line this parser cannot read is a startup failure, never a guess about
+        # which of two readings the operator meant.
+        raise ValueError(
+            f"malformed token row {index} of {total}: {len(fields)} fields, "
+            f"expected 1 (a bare legacy token) or 3 (token, identity, "
+            f"comma-separated scopes). Whitespace separates the three FIELDS, "
+            f"so two tokens on one line is no longer two tokens"
+        )
+    token = fields[0]
+    if len(fields) == 1:
+        return as_token_record(token)
+
+    identity = fields[1]
+    if (
+        len(identity) > MAX_IDENTITY_CHARS
+        or not IDENTITY_COMPONENT.fullmatch(identity)
+    ):
+        raise ValueError(
+            f"invalid identity in token row {index} of {total}: {identity!r} — "
+            f"expected lowercase letters, digits and dashes, starting on an "
+            f"alphanumeric, at most {MAX_IDENTITY_CHARS} characters. The "
+            f"identity is quoted into the audit log, so it must be one spelling"
+        )
+    if identity == LEGACY_IDENTITY:
+        # 🔴 A MAPPED ROW MAY NOT CLAIM THE UNRESTRICTED NAME. `legacy` in the
+        # audit log has to mean exactly one thing — "this request came in on the
+        # old shared credential, which can see everything" — or the one line the
+        # operator greps to know the migration is finished is ambiguous.
+        raise ValueError(
+            f"reserved identity in token row {index} of {total}: "
+            f"{LEGACY_IDENTITY!r} is what a BARE token line is given, and it "
+            f"means unrestricted scope. Name this row's holder instead"
+        )
+
+    raw_scopes = [part.strip() for part in fields[2].split(",")]
+    if not any(raw_scopes):
+        # Reachable with a bare `,`: three fields, a valid identity, and no
+        # scope name anywhere in the third.
+        raise ValueError(
+            f"empty scope allowlist in token row {index} of {total} "
+            f"({identity!r}): a credential that may see NO scope can never be "
+            f"used. Remove the row, or name the scopes it may read"
+        )
+    # Normalized with the reader's OWN folding rule, so an allowlist entry and
+    # the index key it must match cannot disagree about case or `_` vs `-`.
+    scopes: list[str] = []
+    for raw in raw_scopes:
+        # 🔴 BOTH HALVES, AND THE SECOND IS NOT REDUNDANT — the guard has to be
+        # as wide as its own sentence. The class alone accepts `-` and `___`,
+        # which `normalize_ref` folds to the EMPTY STRING: an entry that is
+        # perfectly namable in a URL and yet matches no index key, i.e. a grant
+        # that reads as working and does nothing. That is the precise failure
+        # this message claims to prevent, so it is checked on the value that
+        # actually reaches the comparison, not on the text the operator typed.
+        #
+        # (The class alone DOES cover the empty string — `[A-Za-z0-9_-]+` needs
+        # one character, so `fullmatch("")` is None. A `not raw or` in front was
+        # provably redundant and was removed; this second clause is a different
+        # claim and is reachable by an input the first accepts.)
+        folded = rc.normalize_ref(raw)
+        if not SAFE_PATH_COMPONENT.fullmatch(raw) or not folded:
+            raise ValueError(
+                f"invalid scope in token row {index} of {total} ({identity!r}): "
+                f"{raw!r} — a scope must match {SAFE_PATH_COMPONENT.pattern} AND "
+                f"still name something once folded the way the reader folds a "
+                f"scope. An entry that no request could name, or that folds away "
+                f"to nothing, is refused here rather than sitting inert"
+            )
+        scopes.append(folded)
+    return TokenRecord(
+        token=token,
+        identity=identity,
+        scopes=tuple(dict.fromkeys(scopes)),
+    )
+
+
+def load_tokens(
+    token_file: str | None,
+    env: dict[str, str],
+    *,
+    warn: Callable[[str], None] | None = None,
+) -> list[TokenRecord]:
     """Resolve the bearer token SET. FILE FIRST, env only as a fallback.
 
     🔴 A SET, NOT A TOKEN, and that is the whole of rotation (§2b: "token
-    rotation must be a one-command operation"). One token per line — the CURRENT
-    one first, the PREVIOUS one below it. Rotation is then: add the new line,
-    watch the audit log until every client's `token=` fingerprint has moved,
-    then delete the old line. There is no window in which a client is broken,
-    which is the reason single-token rotations never actually get performed.
+    rotation must be a one-command operation"). ONE ROW PER LINE — the CURRENT
+    credential first, the PREVIOUS one below it. Rotation is then: add the new
+    line, watch the audit log until every client's `token=` fingerprint has
+    moved, then delete the old line. There is no window in which a client is
+    broken, which is the reason single-token rotations never actually get
+    performed.
+
+    THE ROW FORMAT (phase 3, criterion 1)::
+
+        <token>                                   # legacy: identity `legacy`,
+                                                  # UNRESTRICTED scope
+        <token>   <identity>   <scope>,<scope>    # mapped: named, scoped
+
+    Both shapes may appear in one file, and that is not a concession — it is the
+    migration and the rollback. The old shared token stays on its bare line
+    while clients move onto mapped rows, and putting that line back is how the
+    change is undone without a deploy. A file holding any legacy row emits a
+    LOUD startup warning, because "unrestricted" is a state somebody has to be
+    able to see from the pod log.
 
     Guard order — each reachable by an input no earlier guard rejects:
-      1. some source at all      -> "no token source"
-      2. the file is readable    -> "token file unreadable"
-      3. at least one token      -> "token is empty"
-      4. not an accumulation     -> "too many tokens"
-      5. every token long enough -> "token N of M is too short"
+      1.  some source at all      -> "no token source"
+      2.  the file is readable    -> "token file unreadable"
+      3.  at least one token      -> "token is empty"
+      4.  not an accumulation     -> "too many tokens"
+      5.  every token long enough -> "token N of M is too short"
+      6.  every row parses        -> "malformed token row N of M"
+      7.  identity is well-formed -> "invalid identity in token row N of M"
+      8.  identity is not taken   -> "reserved identity in token row N of M"
+      9.  the allowlist is real   -> "empty scope allowlist in token row N of M"
+      10. every scope is namable  -> "invalid scope in token row N of M"
+      11. one row per identity    -> "duplicate identity"
 
-    Guard 5 names the POSITION, never the token. A file whose second line was
-    truncated by an editor passes 1-4 and is exactly what 5 is for; saying
-    "one of them is short" would leave the operator grepping a secret by hand.
+    Guards 1-5 are UNCHANGED in wording and in order, deliberately: they are the
+    ones an operator has already met, and 5 in particular is reached by a file
+    whose second line an editor truncated. Guard 5 names the POSITION, never the
+    token — saying "one of them is short" would leave the operator grepping a
+    secret by hand — and 6-10 keep that property for the same reason.
+
+    🔴 GUARD 11 EXEMPTS `legacy`, AND THAT IS NOT AN OVERSIGHT. Two legacy rows
+    are an overlap rotation of the old shared token, which is the exact thing
+    guards 1-5 were built to support. Two rows naming ONE mapped identity are
+    different: if their allowlists disagree there is no defined answer, and if
+    they agree the operator wanted `<identity>-prev`. Rotating a mapped
+    credential therefore uses a second identity, which is also what makes the
+    audit log able to say which of the two a client is still on.
     """
     raw: str | None = None
     if token_file:
@@ -345,29 +585,70 @@ def load_tokens(token_file: str | None, env: dict[str, str]) -> list[str]:
             "The API is not served without one"
         )
 
-    # `.split()` on any whitespace: a base64url token contains none, so this
-    # accepts one-per-line (the documented shape) and survives a trailing
-    # newline, CRLF, or an operator who used spaces.
-    tokens: list[str] = []
-    for candidate in raw.split():
-        if candidate not in tokens:  # de-duplicated, ORDER PRESERVED
-            tokens.append(candidate)
+    # Line-based now, because a row has internal structure. `.split()` per line
+    # still absorbs a trailing newline, CRLF and any run of spaces or tabs
+    # BETWEEN fields; a blank line is skipped rather than being an empty row.
+    rows: list[list[str]] = []
+    seen_tokens: set[str] = set()
+    for line in raw.splitlines():
+        fields = line.split()
+        if not fields:
+            continue
+        if fields[0] in seen_tokens:  # de-duplicated BY TOKEN, ORDER PRESERVED
+            continue
+        seen_tokens.add(fields[0])
+        rows.append(fields)
 
-    if not tokens:
+    if not rows:
         raise ValueError("token is empty: the source resolved to whitespace only")
-    if len(tokens) > MAX_TOKENS:
+    if len(rows) > MAX_TOKENS:
         raise ValueError(
-            f"too many tokens: {len(tokens)}, max {MAX_TOKENS}. Every line is a "
+            f"too many tokens: {len(rows)}, max {MAX_TOKENS}. Every line is a "
             f"live credential; retire the old ones instead of accumulating them"
         )
-    for index, token in enumerate(tokens, start=1):
-        if len(token) < MIN_TOKEN_CHARS:
+    for index, fields in enumerate(rows, start=1):
+        if len(fields[0]) < MIN_TOKEN_CHARS:
             raise ValueError(
-                f"token {index} of {len(tokens)} is too short: {len(token)} chars, "
+                f"token {index} of {len(rows)} is too short: {len(fields[0])} chars, "
                 f"need >= {MIN_TOKEN_CHARS} (256 bits base64url). A short token is "
                 f"a guessable one"
             )
-    return tokens
+
+    records = [
+        _parse_token_row(fields, index, len(rows))
+        for index, fields in enumerate(rows, start=1)
+    ]
+
+    by_identity: dict[str, int] = {}
+    for index, record in enumerate(records, start=1):
+        if record.is_legacy:
+            continue
+        first = by_identity.get(record.identity)
+        if first is not None:
+            raise ValueError(
+                f"duplicate identity {record.identity!r}: token rows {first} and "
+                f"{index} both claim it, and their scope allowlists have no "
+                f"defined precedence. Rotate a mapped credential under a second "
+                f"identity ({record.identity}-prev), not a second row"
+            )
+        by_identity[record.identity] = index
+
+    legacy = [r for r in records if r.is_legacy]
+    if legacy:
+        # 🔴 ONE LOUD LINE, EMITTED HERE RATHER THAN BY `main`. This is the only
+        # place that knows a row was bare, and a caller obliged to re-derive it
+        # is a caller that can forget to. Printed to stderr so it lands in the
+        # pod log beside the startup banner.
+        emit = warn if warn is not None else (lambda line: print(line, file=sys.stderr))
+        emit(
+            f"subsystem-store-api: 🔴 UNRESTRICTED-SCOPE LEGACY MODE — "
+            f"{len(legacy)} of {len(records)} token rows are bare tokens with no "
+            f"identity and NO scope allowlist (identity={LEGACY_IDENTITY!r}); "
+            f"they can read EVERY scope in the store. Fingerprints: "
+            f"{','.join(r.fingerprint for r in legacy)}. Give each holder its own "
+            f"`<token> <identity> <scopes>` row and delete these lines"
+        )
+    return records
 
 
 def presented_token(header: str | None) -> str:
@@ -384,9 +665,18 @@ def presented_token(header: str | None) -> str:
     return parts[1].strip()
 
 
-def authorize(header: str | None, expected: Sequence[str]) -> str:
-    """Constant-time bearer check against a token SET. Returns the fingerprint
-    of the token that matched; raises `_Rejected` and never returns a reason.
+def authorize(
+    header: str | None, expected: "Sequence[str | TokenRecord]"
+) -> TokenRecord:
+    """Constant-time bearer check against a token SET. Returns the RECORD that
+    matched; raises `_Rejected` and never returns a reason.
+
+    🔴 THE RECORD, NOT THE FINGERPRINT, and the change is the point of phase 3.
+    The caller needs two facts about a request — who it is, for the audit line,
+    and what it may SEE, for every read route — and they must come out of the
+    SAME match. Returning only a fingerprint forced the scope lookup to be a
+    second search keyed on something else, which is the shape that ends up
+    consulting a stale or wider table than the one that authenticated.
 
     🔴 `hmac.compare_digest`, NOT `==`. A public endpoint makes a byte-at-a-time
     timing oracle practically exploitable, and the difference is invisible in
@@ -410,13 +700,17 @@ def authorize(header: str | None, expected: Sequence[str]) -> str:
             "str yields characters, and a one-character token would authorize"
         )
     got = presented_token(header).encode("utf-8")
-    matched: str | None = None
-    for token in expected:
-        if hmac.compare_digest(got, token.encode("utf-8")):
-            matched = token
+    matched: TokenRecord | None = None
+    for item in expected:
+        # Normalized INSIDE the loop rather than in a comprehension above it, so
+        # the loop still performs exactly one `compare_digest` per configured
+        # credential and the no-early-exit property below is unchanged.
+        record = as_token_record(item)
+        if hmac.compare_digest(got, record.token.encode("utf-8")):
+            matched = record
     if matched is None:
         raise _Rejected()
-    return token_id(matched)
+    return matched
 
 
 def sole_header(headers: Any, name: str) -> str | None:
@@ -929,7 +1223,12 @@ class RateLimiter:
             del self._failures[key]
 
 
-def scope_revision(store_root: str | Path, scope: str) -> str:
+def scope_revision(
+    store_root: str | Path,
+    scope: str,
+    *,
+    visible_scopes: Sequence[str] | None = None,
+) -> str:
     """The scope's git HEAD, read from the filesystem — `git` is never spawned.
 
     §3 (Determinism): "have every response carry a `store-revision:` line (the
@@ -941,7 +1240,21 @@ def scope_revision(store_root: str | Path, scope: str) -> str:
     Returns "unknown" for every failure — an absent repo, a detached or
     unresolvable ref, an unreadable file. 🔴 "unknown" is honest; a fabricated
     sha would be quoted into a report and believed.
+
+    🔴 IT IS ALSO A HEADER-LEVEL DISCRIMINATOR, SO IT IS GATED — and it is gated
+    BY CONSTRUCTION rather than by the fact that it currently cannot leak.
+    `X-Store-Revision` is computed from `<store>/<scope>/.git/HEAD`, a path
+    outside the index entirely, so narrowing the INDEX (`load_store`'s
+    `visible_scopes`) does not reach it. Today no scope in the served copy is a
+    git repo, so it answers "unknown" for everything and the leak is LATENT —
+    which is exactly the state in which a guard gets left out and the day a
+    scope becomes a repo the header starts telling a caller which refused scopes
+    exist. `visible_scopes=None` is unrestricted, matching every other seam here.
     """
+    if visible_scopes is not None and rc.normalize_ref(scope) not in {
+        rc.normalize_ref(s) for s in visible_scopes
+    }:
+        return "unknown"
     git = Path(store_root) / scope / ".git"
     try:
         head = (git / "HEAD").read_text(encoding="utf-8").strip()
@@ -1343,7 +1656,7 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
 
     # Injected by `build_server`.
     store_root: str = DEFAULT_STORE
-    expected_tokens: tuple[str, ...] = ()
+    expected_tokens: "tuple[TokenRecord, ...]" = ()
     # 🔴 EMPTY MEANS BELIEVE NOBODY'S HEADER, not "believe everybody's". A
     # subclass that never reaches `build_server` (and `build_server` refuses an
     # empty set) inherits a server that ignores `CF-Connecting-IP` from every
@@ -1362,6 +1675,18 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
     # `None` = not established yet (a request line too malformed to get that
     # far). Rendered as `peer=-`, never silently as "trusted".
     _peer_trusted: bool | None = None
+    # 🔴 THE PER-REQUEST SCOPE ALLOWLIST, AND ITS RESET VALUE IS `()`, NOT `None`.
+    #
+    # `None` is the UNRESTRICTED sentinel everywhere else in this file
+    # (`load_store`, `scope_revision`, `TokenRecord.scopes`), which makes it the
+    # one value this field must never default to: a route reached without a
+    # successful `authorize` — today impossible, tomorrow one refactor away —
+    # would then see the whole store. An empty tuple is the fail-closed
+    # direction: nothing is visible until a matched record says otherwise, and a
+    # legacy record is the ONLY thing that can put `None` here.
+    _visible_scopes: "tuple[str, ...] | None" = ()
+    # The matched credential's name, for the audit line. `-` until one matches.
+    _identity: str | None = None
 
     # --- plumbing ---------------------------------------------------------------
 
@@ -1450,6 +1775,13 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             f"method={audit_field(self.command, limit=16)} "
             f"path={audit_field(path)} "
             f"token={audit_field(self._token_fp or '-', limit=16)} "
+            # 🔴 ADDITIVE, AND `token=` IS UNTOUCHED. The fingerprint is what
+            # makes an overlap rotation checkable and nothing may be derived
+            # from the identity instead: two rows can hold one identity's
+            # current and previous credential, and only `token=` tells them
+            # apart. `identity=` answers the different question phase 3 adds —
+            # WHOSE request this was, and therefore which allowlist applied.
+            f"identity={audit_field(self._identity or '-', limit=MAX_IDENTITY_CHARS)} "
             f"auth={'ok' if self._token_fp else 'fail'} "
             f"result={int(result)} status={audit_field(status, limit=32)}"
         )
@@ -1571,6 +1903,12 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         self._client_ip = None
         self._token_fp = None
         self._peer_trusted = None
+        # 🔴 RESET TO `()` — nothing visible — NOT to the unrestricted `None`.
+        # See the class-level declaration: this is the fail-closed direction,
+        # and it is the reset value precisely because a reset runs on paths
+        # that never reach `authorize`.
+        self._visible_scopes = ()
+        self._identity = None
         path = self._request_path()
         if path is None:
             return
@@ -1583,9 +1921,16 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             # counted — 405 after 405 with nothing charged. A write attempt
             # with no valid credential is not a "wrong method", it is an
             # unauthorised request, and it is answered and charged as one.
-            self._token_fp = authorize(
+            # 🔴 ONE MATCH, THREE FACTS. The fingerprint, the identity and the
+            # scope allowlist all come off the SAME record `authorize` returned,
+            # so no route can be authenticated against one credential and
+            # authorised against another.
+            record = authorize(
                 self.headers.get("Authorization"), self.expected_tokens
             )
+            self._token_fp = record.fingerprint
+            self._identity = record.identity
+            self._visible_scopes = record.scopes
         except _Rejected:
             self._refuse(path, self._count_failure(self.limiter, self._client_ip))
             return
@@ -1624,6 +1969,12 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         self._client_ip = None
         self._token_fp = None
         self._peer_trusted = None
+        # 🔴 RESET TO `()` — nothing visible — NOT to the unrestricted `None`.
+        # See the class-level declaration: this is the fail-closed direction,
+        # and it is the reset value precisely because a reset runs on paths
+        # that never reach `authorize`.
+        self._visible_scopes = ()
+        self._identity = None
         # ⚠ THAT RESET IS AN EQUIVALENT MUTANT ON THIS PATH, RECORDED RATHER
         # THAN LEFT AS AN UNEXPLAINED SURVIVOR. A no-selector sweep showed
         # deleting it changes nothing observable, and the reason is worth
@@ -1721,6 +2072,12 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             self._client_ip = None
             self._token_fp = None
             self._peer_trusted = None
+            # 🔴 RESET TO `()` — nothing visible — NOT to the unrestricted `None`.
+            # See the class-level declaration: this is the fail-closed direction,
+            # and it is the reset value precisely because a reset runs on paths
+            # that never reach `authorize`.
+            self._visible_scopes = ()
+            self._identity = None
             self._unauthorized()
             self._audit(self._raw_path(), 401, "malformed-target")
             return None
@@ -1758,6 +2115,12 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         self._client_ip = None
         self._token_fp = None
         self._peer_trusted = None
+        # 🔴 RESET TO `()` — nothing visible — NOT to the unrestricted `None`.
+        # See the class-level declaration: this is the fail-closed direction,
+        # and it is the reset value precisely because a reset runs on paths
+        # that never reach `authorize`.
+        self._visible_scopes = ()
+        self._identity = None
         path = self._request_path()
         if path is None:
             return
@@ -1800,9 +2163,16 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             return
 
         try:
-            self._token_fp = authorize(
+            # 🔴 ONE MATCH, THREE FACTS. The fingerprint, the identity and the
+            # scope allowlist all come off the SAME record `authorize` returned,
+            # so no route can be authenticated against one credential and
+            # authorised against another.
+            record = authorize(
                 self.headers.get("Authorization"), self.expected_tokens
             )
+            self._token_fp = record.fingerprint
+            self._identity = record.identity
+            self._visible_scopes = record.scopes
         except _Rejected:
             self._refuse(path, self._count_failure(limiter, ip))
             return
@@ -1906,7 +2276,14 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             headers={
                 "X-Store-Status": status,
                 "X-Store-Exit": str(code),
-                "X-Store-Revision": scope_revision(self.store_root, scope),
+                # 🔴 GATED ON THE CALLER'S ALLOWLIST. This one header does NOT
+                # come from the narrowed index — it is read off
+                # `<store>/<scope>/.git/HEAD` — so it is the one place a refused
+                # scope could still be told apart from an absent one. See
+                # `scope_revision`.
+                "X-Store-Revision": scope_revision(
+                    self.store_root, scope, visible_scopes=self._visible_scopes
+                ),
                 "X-Store-Snapshot": fresh_header,
             },
         )
@@ -1925,6 +2302,7 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             limit=limit if limit is not None else rc.DEFAULT_ENTRY_LIMIT,
             mode=mode,
             page=page if page is not None else 1,
+            visible_scopes=self._visible_scopes,
         )
         self._serve_report(
             urlsplit(self.path).path,
@@ -1952,6 +2330,11 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             ),
             max_hits=max_hits if max_hits is not None else rc.DEFAULT_MAX_HITS,
             all_scopes=params.get("all_scopes", ["0"])[-1] not in ("0", "", "false"),
+            # 🔴 AND THIS IS WHAT MAKES `?all_scopes=1` SAFE. That flag names no
+            # scope, so a per-scope refusal check has nothing to refuse — it
+            # would search the CONTENT of every scope in the store. Narrowing
+            # the index makes "all scopes" mean "all the caller's scopes".
+            visible_scopes=self._visible_scopes,
         )
         self._serve_report(
             urlsplit(self.path).path,
@@ -2009,12 +2392,29 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             self._audit(urlsplit(self.path).path, 400, "bad-request")
             return
 
+        # 🔴 THE FOURTH ENUMERATION CHANNEL, AND THE ONLY ONE `load_store` CANNOT
+        # CLOSE. This route never builds an index — it walks the store root
+        # directly — so the narrowing that covers `/recall` and `/search` does
+        # not reach here at all. Without this line a caller allowed one scope
+        # could download every scope's entry FILES, which is a wider leak than
+        # any of the three channels the index filter closes.
+        #
+        # Applied as a filter on the CANDIDATE list rather than on the tar
+        # members, so an out-of-allowlist scope is never classified, never
+        # opened, and can never reach the `unreadable` list either — a refused
+        # scope must not be able to 503 somebody else's snapshot, which is both
+        # a leak and a denial of service.
+        visible = self._visible_scopes
+        allowed = (
+            None if visible is None else {rc.normalize_ref(s) for s in visible}
+        )
         try:
             candidates = sorted(
                 p
                 for p in root.iterdir()
                 if not p.name.startswith(".")
                 and (scope_filter is None or p.name == scope_filter)
+                and (allowed is None or rc.normalize_ref(p.name) in allowed)
             )
         except OSError as exc:
             # 🔴 The store was NOT read. Same state, same code and the same
@@ -2169,7 +2569,7 @@ def build_server(
     host: str,
     port: int,
     store_root: str,
-    tokens: Sequence[str],
+    tokens: "Sequence[str | TokenRecord]",
     trusted_proxies: Sequence[Any],
     limiter: RateLimiter | None = None,
     audit: Callable[[str], None] | None = None,
@@ -2181,6 +2581,12 @@ def build_server(
     still passing the old name now fails loudly at the call, instead of silently
     configuring the empty default set and rejecting every request — or, worse,
     being iterated character-by-character somewhere downstream.
+
+    An item may be a `TokenRecord` or a bare `str`; a bare one is the LEGACY
+    record (unrestricted scope) by the same rule the token file uses, resolved
+    through the one `as_token_record`. Normalizing here rather than in the
+    handler means `expected_tokens` is a homogeneous tuple of records, so no
+    request-path code has to ask what shape it was configured with.
     """
     if isinstance(tokens, (str, bytes)):
         raise TypeError("tokens must be a SEQUENCE of tokens, not one string")
@@ -2213,7 +2619,7 @@ def build_server(
         pass
 
     _Handler.store_root = store_root
-    _Handler.expected_tokens = tuple(tokens)
+    _Handler.expected_tokens = tuple(as_token_record(t) for t in tokens)
     _Handler.trusted_proxies = networks
     _Handler.limiter = limiter if limiter is not None else RateLimiter()
     if audit is not None:
@@ -2237,9 +2643,10 @@ def main(argv: list[str] | None = None) -> int:
         "--token-file",
         default=os.environ.get("SUBSYSTEM_STORE_TOKEN_FILE", DEFAULT_TOKEN_FILE),
         help=(
-            "file holding the bearer token SET, ONE PER LINE, current first "
-            "(mode 0600). FILE FIRST: the agent exec sandbox strips env vars, so "
-            "$SUBSYSTEM_STORE_TOKEN is the fallback"
+            "file holding the bearer token SET, ONE ROW PER LINE, current first "
+            "(mode 0600). A row is `<token>` (legacy: unrestricted scope) or "
+            "`<token> <identity> <scope>,<scope>`. FILE FIRST: the agent exec "
+            "sandbox strips env vars, so $SUBSYSTEM_STORE_TOKEN is the fallback"
         ),
     )
     args = p.parse_args(argv)
@@ -2283,7 +2690,13 @@ def main(argv: list[str] | None = None) -> int:
     # should have stopped appearing before deleting its line from the secret.
     print(
         f"subsystem-store-api: listening on {args.host}:{args.port} "
-        f"store={args.store} token-ids={','.join(token_id(t) for t in tokens)} "
+        # 🔴 `<fingerprint>:<identity>` — the fingerprint FIRST and unchanged in
+        # form, because the rotation procedure in the README greps for it. The
+        # identity is appended, not substituted: two rows can hold one holder's
+        # current and previous credential, so the identity alone cannot tell an
+        # operator which line to delete.
+        f"store={args.store} "
+        f"token-ids={','.join(f'{t.fingerprint}:{t.identity}' for t in tokens)} "
         f"lockout={max_failures}/{window_s:g}s->{lockout_s:g}s "
         # 🔴 PRINTED, so "which peers may set CF-Connecting-IP" is a fact in the
         # pod log rather than a value nobody can read back out of a running

--- a/scripts/tests/test_cairn_cli.py
+++ b/scripts/tests/test_cairn_cli.py
@@ -44,10 +44,28 @@ LOOPBACK = ipaddress.ip_network("127.0.0.1/32")
 
 
 def _load_api():
+    """Import `server.py` by path — its directory name has a hyphen in it.
+
+    🔴 `sys.modules[spec.name] = module` BEFORE `exec_module`, and it is not
+    bookkeeping. A module executed while absent from `sys.modules` is only
+    MOSTLY imported, and CPython dereferences that entry without a `None` guard
+    in places you do not go looking: `dataclasses._is_type` does
+    `sys.modules.get(cls.__module__).__dict__` to decide whether a STRING
+    annotation names `ClassVar`/`KW_ONLY`, so under `from __future__ import
+    annotations` the first `@dataclass` in the file raised
+
+        AttributeError: 'NoneType' object has no attribute '__dict__'
+
+    at import — 43 collection errors in this file, none of them near the change
+    that triggered them. `test_subsystem_store_api._load_server` has always
+    registered; this loader is the second copy of that predicate and was the
+    one that was wrong, which is the shape a duplicated predicate always takes.
+    """
     sys.path.insert(0, str(REPO / "scripts" / "lib"))
     spec = importlib.util.spec_from_file_location("srv", SERVER_PY)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
 

--- a/scripts/tests/test_subsystem_recall.py
+++ b/scripts/tests/test_subsystem_recall.py
@@ -5172,9 +5172,14 @@ class TestDegradationMutationKills:
             tmp_path,
             "m_collect",
             [
+                # The anchor moved when `load_store` grew its `visible_scopes`
+                # narrowing: the load is now bound to a name so the index can be
+                # filtered before it is returned. The MUTATION is unchanged —
+                # drop `on_malformed=ON_MALFORMED_COLLECT` and nothing else — and
+                # it is still the narrowest expression that can be wrong.
                 (
-                    "        return store, load_index(store, on_malformed=ON_MALFORMED_COLLECT)",
-                    "        return store, load_index(store)",
+                    "        index = load_index(store, on_malformed=ON_MALFORMED_COLLECT)",
+                    "        index = load_index(store)",
                 )
             ],
         )

--- a/scripts/tests/test_subsystem_recall.py
+++ b/scripts/tests/test_subsystem_recall.py
@@ -5172,14 +5172,22 @@ class TestDegradationMutationKills:
             tmp_path,
             "m_collect",
             [
-                # The anchor moved when `load_store` grew its `visible_scopes`
-                # narrowing: the load is now bound to a name so the index can be
-                # filtered before it is returned. The MUTATION is unchanged —
-                # drop `on_malformed=ON_MALFORMED_COLLECT` and nothing else — and
-                # it is still the narrowest expression that can be wrong.
+                # The anchor has moved TWICE now. First when `load_store` grew
+                # its `visible_scopes` narrowing (the load became a bound name so
+                # the index could be filtered before being returned), and again
+                # when that allowlist was pushed DOWN into `load_index` so a
+                # denied scope is never opened — which wrapped the call across
+                # four lines.
+                #
+                # 🔴 THE MUTATION IS STILL THE SAME ONE, AND STILL THE NARROWEST
+                # EXPRESSION THAT CAN BE WRONG: drop `on_malformed=` and NOTHING
+                # else. `visible_scopes=` is deliberately KEPT in the mutant, so
+                # this test measures the COLLECT policy and cannot be satisfied
+                # (or broken) by the scope filter — a mutant that removed both
+                # would die for whichever reason fired first.
                 (
-                    "        index = load_index(store, on_malformed=ON_MALFORMED_COLLECT)",
-                    "        index = load_index(store)",
+                    "            on_malformed=ON_MALFORMED_COLLECT,\n",
+                    "",
                 )
             ],
         )

--- a/scripts/tests/test_subsystem_recall.py
+++ b/scripts/tests/test_subsystem_recall.py
@@ -43,6 +43,7 @@ import collections
 import hashlib
 import importlib.util
 import json
+import os
 from testlib import hermetic_git  # noqa: E402
 import subprocess
 import sys
@@ -159,6 +160,49 @@ def _make_store(root: Path) -> Path:
 @pytest.fixture()
 def store(tmp_path: Path) -> Path:
     return _make_store(tmp_path)
+
+
+BLOCKER_NAME = ".not-a-directory"
+
+
+def _plant_unreadable(store: Path, scope: str, name: str = "broken.md") -> Path:
+    """Plant a candidate entry the loader still TAKEs and then CANNOT read.
+
+    🔴 IT USED TO BE `(scope / "broken.md").mkdir()`, AND THAT STOPPED BEING AN
+    UNREADABLE ENTRY FOR A GOOD REASON. `subsystem_resolver._LOADER_ENTRY_ACTIONS`
+    now REFUSES `directory` and `link-to-dir` before `open()` — measured: one
+    stray `mkdir <scope>/<slug>.md` (or an rsync/restore artefact) answered
+    `/recall` and `/search` with a store-wide 503 for EVERY caller. A directory
+    is therefore a NAMED MALFORMED ROW now, not an `EntryUnreadableError`, and
+    every control that used one to provoke an OSError had silently gone vacuous:
+    it was asserting a raise that no longer happens.
+
+    🔴 THE REPLACEMENT IS PERMISSION-FREE ON PURPOSE. Every OTHER surviving
+    residual (`regular-file`, `link-to-file`) is a `chmod 000`, which a root-run
+    sandbox ignores — that is exactly the vacuum the original fixture comment
+    said it was avoiding, so swapping to one would have traded a dead control
+    for a conditionally dead one. This is a symlink whose target resolution
+    fails with ENOTDIR (a path "under" a regular file): `classify_path` calls it
+    `indeterminate` — "I could not look" — which the loader deliberately still
+    TAKEs, so `read_text` runs and raises `NotADirectoryError`. Measured on this
+    tree as euid 1000, and it does not depend on being non-root.
+
+    Returns the planted path; `_unplant_unreadable` removes both files it made.
+    """
+    scope_dir = store / scope
+    blocker = scope_dir / BLOCKER_NAME
+    if not blocker.exists():
+        blocker.write_text("a regular file, so paths UNDER it are ENOTDIR\n",
+                           encoding="utf-8")
+    target = scope_dir / name
+    os.symlink(blocker / "child", target)
+    return target
+
+
+def _unplant_unreadable(store: Path, scope: str, name: str = "broken.md") -> None:
+    """Undo `_plant_unreadable`, both files, so a tree hash can be compared."""
+    (store / scope / name).unlink()
+    (store / scope / BLOCKER_NAME).unlink()
 
 
 def _tree_hash(root: Path) -> str:
@@ -359,10 +403,12 @@ class TestNegativeControls:
         assert "none omitted" not in text, "a completeness claim over an incomplete index"
 
     def test_an_unreadable_entry_RAISES_its_own_sentinel(self, store: Path) -> None:
-        """Reached with a DIRECTORY sitting where a `.md` is expected — an
-        OSError any user hits, rather than a mode change that a root-run sandbox
-        would silently bypass and make this control vacuous."""
-        (store / SCOPE / "broken.md").mkdir()
+        """Reached with a candidate the loader TAKEs and cannot read — an
+        OSError any user hits, and still not a mode change a root-run sandbox
+        would silently bypass. See `_plant_unreadable` for why it is no longer
+        a directory: that shape is REFUSED before `open()` now, so it degrades
+        into a named malformed row and this control had gone vacuous."""
+        _plant_unreadable(store, SCOPE)
         with pytest.raises(rc.EntryUnreadableError) as exc:
             rc.recall(store, SCOPE)
         assert "index entry unreadable" in str(exc.value)
@@ -393,7 +439,7 @@ class TestNegativeControls:
         with pytest.raises(rc.StoreMissingError) as e1:
             rc.recall(tmp_path / "absent", SCOPE)
         msgs.append(str(e1.value))
-        (store / SCOPE / "broken.md").mkdir()
+        _plant_unreadable(store, SCOPE)
         with pytest.raises(rc.EntryUnreadableError) as e2:
             rc.recall(store, SCOPE)
         msgs.append(str(e2.value))
@@ -2907,10 +2953,11 @@ class TestRecallNeverWrites:
         rc.render_text(rep)
         json.dumps(rc.report_json(rep))
         with pytest.raises(rc.EntryUnreadableError):
-            # …and the raising arm is kept, on the condition that still raises.
-            (store / SCOPE / "broken.md").mkdir()
+            # …and the raising arm is kept, on a condition that still raises —
+            # a directory no longer does, it is REFUSED before `open()` now.
+            _plant_unreadable(store, SCOPE)
             rc.recall(store, SCOPE)
-        (store / SCOPE / "broken.md").rmdir()
+        _unplant_unreadable(store, SCOPE)
         assert _tree_hash(store) == after_fixture
         assert after_fixture != before  # the fixture moved it; the module did not
 
@@ -4054,7 +4101,7 @@ class TestMutationKillMatrix:
             ],
         )
         store = _make_store(tmp_path / "s")
-        (store / SCOPE / "broken.md").mkdir()
+        _plant_unreadable(store, SCOPE)
         with pytest.raises(Exception) as exc:
             mod.recall(store, SCOPE)
         assert not isinstance(exc.value, mod.EntryUnreadableError)

--- a/scripts/tests/test_subsystem_resolver.py
+++ b/scripts/tests/test_subsystem_resolver.py
@@ -68,6 +68,7 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -2712,11 +2713,29 @@ class TestCollectDegrades:
         """🔴 THE LINE THE DEGRADATION STOPS AT, stated as a test. A malformed
         entry is a file we READ and could not interpret; an unreadable one means
         the store was not fully read, so the entry SET is unknown and there is
-        nothing honest to degrade to. Reached with a directory where a `.md`
-        belongs — an OSError any user hits, not a mode change a root-run sandbox
-        would silently bypass."""
+        nothing honest to degrade to.
+
+        🔴 IT USED TO BE A DIRECTORY, AND THAT SHAPE NO LONGER REACHES THIS
+        LINE. `_LOADER_ENTRY_ACTIONS` now REFUSES `directory` and `link-to-dir`
+        before `open()` — one stray `mkdir <scope>/<slug>.md` was measured 503ing
+        the whole store for every caller — so a directory DEGRADES into a named
+        malformed row and this control had gone vacuous, asserting a raise that
+        no longer happens.
+
+        The replacement is still not a mode change a root-run sandbox would
+        bypass: a symlink whose target resolution fails with ENOTDIR (a path
+        under a regular file). `classify_path` calls that `indeterminate` — "I
+        could not look" — which the loader deliberately still TAKEs, so
+        `read_text` runs and raises `NotADirectoryError`."""
         store = _synth_store(tmp_path, {"alpha-unit.md": GOOD_A})
-        (store / "synth-scope" / "broken.md").mkdir()
+        scope_dir = store / "synth-scope"
+        blocker = scope_dir / ".not-a-directory"
+        blocker.write_text("a regular file, so paths UNDER it are ENOTDIR\n")
+        os.symlink(blocker / "child", scope_dir / "broken.md")
+        assert sr.classify_path(scope_dir / "broken.md") == sr.KIND_INDETERMINATE, (
+            "the fixture is not a kind the loader still TAKEs, so it would be "
+            "refused rather than read and this control would prove nothing"
+        )
         with pytest.raises(OSError):
             sr.load_index(store, on_malformed=sr.ON_MALFORMED_COLLECT)
 

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -1009,18 +1009,28 @@ class TestReadOnlyPhase1:
 # scan, and — since the entry-kind guard landed — `subsystem_resolver`'s INDEX
 # LOADER, which is a different context and therefore a different column.
 #
-# 🔴 THE LOADER COLUMN IS THE NARROW RULING, CELL BY CELL. It refuses exactly
-# `broken-link` (the Emacs `.#entry.md` lock file, which used to 503 the whole
-# store) and the two shapes of "an `open()` on this never returns" — `other`
-# (the fifo itself) and `link-to-other` (a symlink pointing at one), each of
-# which was measured HANGING the request thread. It TAKES everything else —
-# most pointedly `link-to-file`, which the loader has always read. Copying the
-# `_ENTRY_ACTIONS` column wholesale is the over-broad form that was explicitly
-# rejected, and flipping any remaining TAKE here to REFUSE is a behaviour change
-# for ordinary callers; every one of those flips is a mutant this column kills.
+# 🔴 THE LOADER COLUMN IS THE NARROW RULING, CELL BY CELL. Every REFUSE in it
+# rests on ONE criterion, applied over three rulings and never widened: this
+# loader has never successfully READ that kind — it has only ever raised or
+# blocked on one — so refusing it changes no legitimate caller. That covers
+# `broken-link` (the Emacs `.#entry.md` lock file, which 503'd the whole store),
+# the two shapes of "an `open()` on this never returns" — `other` (the fifo) and
+# `link-to-other` (a symlink pointing at one), each measured HANGING the request
+# thread — and the two shapes of `IsADirectoryError`, `directory` and
+# `link-to-dir`, measured 503ing the whole store off one stray `mkdir`.
+#
+# It TAKES everything else — most pointedly `link-to-file`, which the loader has
+# always read. Copying the `_ENTRY_ACTIONS` column wholesale is the over-broad
+# form that was explicitly rejected, and flipping any remaining TAKE here to
+# REFUSE is a behaviour change for ordinary callers; every one of those flips is
+# a mutant this column kills.
 DECISION_TABLE = [
     ("KIND_BROKEN_LINK", "REFUSE", "REFUSE", "REFUSE"),
-    ("KIND_LINK_TO_DIR", "REFUSE", "REFUSE", "TAKE"),
+    # 🔴 CLOSED IN THE SAME ROUND AS `KIND_DIRECTORY`, AND FOR ITS REASON —
+    # `read_text` raises `IsADirectoryError` whether the directory is named
+    # directly or reached through a link, and that OSError fails closed into a
+    # store-wide 503 for every caller.
+    ("KIND_LINK_TO_DIR", "REFUSE", "REFUSE", "REFUSE"),
     ("KIND_LINK_TO_FILE", "SKIP", "REFUSE", "TAKE"),
     # 🔴 CLOSED, AND IT WAS THE SAME DEFECT — NOT A LESSER ONE. This cell was
     # `TAKE` for one round, pinned as a named residual because the ruling that
@@ -1033,16 +1043,47 @@ DECISION_TABLE = [
     # column now refuses BOTH shapes of it. `link-to-file` stays `TAKE` — that
     # is still the upper bound, and still the point of the narrow form.
     ("KIND_LINK_TO_OTHER", "SKIP", "REFUSE", "REFUSE"),
-    ("KIND_DIRECTORY", "TAKE", "REFUSE", "TAKE"),
+    # 🔴 CLOSED, AND IT WAS NEVER A LESSER DEFECT EITHER. The loader TOOK this
+    # cell for three rounds while its own ledger called `chmod 000` "the only
+    # residual left" — which was measured false: `store/beta/notes.md` created
+    # as a DIRECTORY answered `GET /api/v1/recall/alpha` (a scope the caller
+    # never asked about, unrestricted legacy token) with `503 index entry
+    # unreadable … IsADirectoryError`, while the same store carrying a dangling
+    # `.#lock.md` instead answered 200. One accidental `mkdir <scope>/notes.md`
+    # or one rsync/restore artefact took `/recall` and `/search` down for EVERY
+    # caller. `read_text` has never once succeeded on a directory, so refusing
+    # it changes no legitimate caller — the criterion the narrow ruling itself
+    # used — and it makes the loader agree with `/snapshot`, which already
+    # refused it.
+    ("KIND_DIRECTORY", "TAKE", "REFUSE", "REFUSE"),
     ("KIND_REGULAR_FILE", "SKIP", "TAKE", "TAKE"),
     ("KIND_OTHER", "SKIP", "REFUSE", "REFUSE"),
     # 🔴 "I could not look" must never share a cell with "nothing is there".
     # In the LOADER it is TAKE, so `read_text` raises and the four-state rule's
     # "the store was not fully READ" is preserved — a DIFFERENT fact from "this
-    # entry is malformed", which is what REFUSE would report it as.
+    # entry is malformed", which is what REFUSE would report it as. ⚠ This is
+    # the cell the `directory` ruling deliberately did NOT sweep up with it:
+    # "the lstat failed" is a different premise from "this kind can never be an
+    # entry", and only the second justifies a REFUSE.
     ("KIND_INDETERMINATE", "REFUSE", "REFUSE", "TAKE"),
     ("KIND_ABSENT", "SKIP", "SKIP", "TAKE"),
 ]
+
+# 🔴 THE LOADER'S RESIDUAL SET, PINNED AS A LITERAL — the set of kinds
+# `_LOADER_ENTRY_ACTIONS` still maps to TAKE, which is exactly the set of shapes
+# whose `read_text` can still fail closed into a store-wide 503.
+#
+# It is spelled here, by hand, and NOT derived from the table, because the whole
+# defect this pins is a LEDGER that drifted: two documents claimed `chmod 000`
+# was "the only residual" while the table had four TAKE cells that could raise,
+# one of which (`directory`) took the store down for every caller. A derived set
+# would have agreed with the table forever and said nothing.
+LOADER_RESIDUAL_KINDS = {
+    "regular-file",   # chmod 000 -> PermissionError
+    "link-to-file",   # a link whose TARGET is chmod 000 -> PermissionError
+    "indeterminate",  # the lstat itself failed -> OSError on read
+    "absent",         # vanished between glob() and classify -> FileNotFoundError
+}
 
 # The LEDGER of every action table that exists, so "all three contexts" is a
 # claim something checks rather than a number in a test name.
@@ -1090,16 +1131,164 @@ class TestClassifierIsTotal:
         three contexts" would keep passing while the fourth defaulted. This
         asserts the LEDGER against what the two modules actually define, so the
         set GROWING or SHRINKING is a failure either way.
+
+        🔴 SELECTED BY WHAT THE DICT CONTAINS, NEVER BY WHAT IT IS CALLED. This
+        guard used to match `name.endswith("_ACTIONS")`, which made it a SPELLED
+        guard while its docstring claimed a structural one — and the difference
+        was measured with paired controls: a fourth table named
+        `_FOURTH_TABLE_ACTIONS` was KILLED, the byte-identical table renamed
+        `_SNAPSHOT_KIND_POLICY` SURVIVED (19 passed, 0 failed). A new context
+        does not have to adopt the old suffix, and the one that does not is
+        exactly the one nobody notices.
+
+        So the question asked is what the dict IS, not what it is called: KEYS
+        that are kinds, VALUES that are actions. Both halves are load-bearing —
+        keys alone also matches `_LOADER_REFUSAL_REASON`, which is kind-keyed
+        but maps to English sentences and decides nothing. Naming is then free.
         """
         found = {
             f"{mod.__name__}.{name}"
             for mod in (api, resolver)
             for name, value in vars(mod).items()
-            if name.endswith("_ACTIONS") and isinstance(value, dict)
+            if isinstance(value, dict)
+            and set(value) & api.ALL_KINDS
+            and set(value.values()) <= {api.SKIP, api.TAKE, api.REFUSE}
         }
         assert found == {name for name, _t in ALL_ACTION_TABLES}, (
             f"the action-table ledger is out of date: {sorted(found)}"
         )
+
+    def test_the_LOADER_RESIDUAL_SET_is_pinned(self):
+        """🔴 THE LEDGER THAT KEPT GOING STALE, MADE MACHINE-READABLE.
+
+        `load_index`'s docstring and the API README each asserted, for three
+        rounds, that a `chmod 000` regular file was "the only residual left" —
+        while the table held FOUR `TAKE` cells whose `read_text` fails closed
+        into a store-wide 503, one of them (`directory`) reachable from a single
+        accidental `mkdir <scope>/notes.md` and measured taking `/recall` down
+        for every caller.
+
+        ⚠ AN INVARIANT GUARD, NOT A REGRESSION TEST — nothing was ever
+        structurally wrong with the TABLE this asserts; the defect was in the
+        two documents describing it, and the two guards below are the ones that
+        pin those. This exists so that whatever is ruled next about a cell has
+        to move a literal a reviewer can see, in the same diff.
+        """
+        taken = {
+            k for k, a in resolver._LOADER_ENTRY_ACTIONS.items() if a == api.TAKE
+        }
+        assert taken == LOADER_RESIDUAL_KINDS, (
+            "the loader's TAKE set moved. Every kind here is a shape whose "
+            "`read_text` can still 503 the whole store, so this set IS the "
+            "residual ledger — update `load_index`'s docstring and "
+            f"subsystem-store-api/README.md in the same diff. now={sorted(taken)}"
+        )
+
+    @staticmethod
+    def _residual_ledger(label: str) -> str:
+        """The document's RESIDUAL LEDGER region, by its literal markers.
+
+        An absent or unterminated marker ASSERTS rather than returning an empty
+        slice — an empty region would satisfy every "is not in" below and turn
+        this guard into the reassuring zero it exists to prevent.
+        """
+        text = (
+            resolver.load_index.__doc__
+            if "load_index" in label
+            else (API_DIR / label).read_text(encoding="utf-8")
+        )
+        start = text.find("RESIDUAL LEDGER")
+        assert start > 0, f"{label}: no RESIDUAL LEDGER section at all"
+        end = text.find("END OF RESIDUAL LEDGER", start + 1)
+        assert end > start, f"{label}: the RESIDUAL LEDGER is not terminated"
+        region = text[start:end]
+        assert len(region) > 200, f"{label}: the ledger region is suspiciously short"
+        return region
+
+    @pytest.mark.parametrize(
+        "label", ["subsystem_resolver.load_index", "README.md"]
+    )
+    def test_the_RESIDUAL_LEDGER_names_every_TAKE_kind_and_no_REFUSE_one(
+        self, label
+    ):
+        """🔴 THE GUARD THAT WOULD HAVE CAUGHT THE STALE LEDGER, IN BOTH
+        DIRECTIONS AND IN BOTH DOCUMENTS.
+
+        The previous round flipped `link-to-other` to REFUSE and its commit
+        message claimed "comments and docstrings updated wherever they still
+        recorded the hang as open". The docstring and two test docstrings were;
+        the README was NOT, and went on telling operators the hang was "left
+        open" for a whole round after it was closed. Nothing could see that,
+        because no test read the README.
+
+        So both directions are asserted, and a document that fails either is
+        wrong in a way a reader would act on:
+          * a kind the table still `TAKE`s and the ledger omits -> the ledger
+            reads SHORTER than the hazard actually is;
+          * a kind the table now REFUSEs and the ledger still lists -> a closed
+            hazard recorded as open, which is what happened.
+        And symmetrically for the REFUSED table above the ledger.
+
+        ⚠ THIS PINS TOKENS, NOT PROSE. A backticked kind name is a
+        machine-readable claim; the sentences around it are free to be
+        rewritten. That is the deliberate trade — pinning the whole normalised
+        string would fail on every cosmetic edit and get deleted.
+        """
+        ledger = self._residual_ledger(label)
+        taken = {
+            k for k, a in resolver._LOADER_ENTRY_ACTIONS.items() if a == api.TAKE
+        }
+        refused = {
+            k for k, a in resolver._LOADER_ENTRY_ACTIONS.items() if a == api.REFUSE
+        }
+        assert taken and refused, "the loader table is degenerate"
+
+        for kind in sorted(taken):
+            assert f"`{kind}`" in ledger, (
+                f"{label}: the residual ledger does not name `{kind}`, which "
+                f"the loader still TAKEs — the ledger reads SHORTER than the "
+                f"hazard is"
+            )
+        for kind in sorted(refused):
+            assert f"`{kind}`" not in ledger, (
+                f"{label}: `{kind}` is still described as a residual, but the "
+                f"loader now REFUSEs it — a closed hazard recorded as open is "
+                f"the exact drift this guard exists for"
+            )
+
+    def test_the_README_REFUSED_TABLE_names_every_REFUSE_kind_and_no_other(self):
+        """The other half of the same seam, and the half an operator reads
+        first: the README's refusal table is what tells them which shapes are
+        already handled. A kind missing from it reads as an open hazard that is
+        closed; a kind listed in it that the loader actually TAKEs reads as a
+        guard that does not exist.
+
+        Scoped to the README because it is the document with an explicit table.
+        `load_index`'s docstring prose is covered by the ledger half above.
+        """
+        text = (API_DIR / "README.md").read_text(encoding="utf-8")
+        cut = text.find("RESIDUAL LEDGER")
+        # 🔴 NOT `text[:cut]` UNGUARDED: `find` returns -1 when the marker is
+        # gone, and `text[:-1]` is the WHOLE file — which would silently fold
+        # the residual ledger's own rows into the refusal table and fail with a
+        # message about the wrong thing. Measured: deleting the marker produced
+        # "README refusal table lists `absent`", which sends the reader nowhere
+        # near the actual edit.
+        assert cut > 0, "the README has no RESIDUAL LEDGER marker to split on"
+        head = text[:cut]
+        assert "| kind |" in head, "the README's refusal table has moved"
+        for kind, action in sorted(resolver._LOADER_ENTRY_ACTIONS.items()):
+            present = f"| `{kind}` |" in head
+            if action == api.REFUSE:
+                assert present, (
+                    f"README refusal table does not list `{kind}`, which the "
+                    f"loader refuses"
+                )
+            else:
+                assert not present, (
+                    f"README refusal table lists `{kind}`, which the loader "
+                    f"TAKEs — it claims a guard that is not there"
+                )
 
     def test_the_pinned_table_covers_EVERY_kind(self):
         """🔴 Two-way pin on the parametrize list itself.
@@ -1199,7 +1388,13 @@ class TestClassifierIsTotal:
         assert refused == set(resolver._LOADER_REFUSAL_REASON), (
             "the loader's REFUSE cells and its refusal sentences have drifted"
         )
-        assert refused == {api.KIND_BROKEN_LINK, api.KIND_OTHER, api.KIND_LINK_TO_OTHER}
+        assert refused == {
+            api.KIND_BROKEN_LINK,
+            api.KIND_OTHER,
+            api.KIND_LINK_TO_OTHER,
+            api.KIND_DIRECTORY,
+            api.KIND_LINK_TO_DIR,
+        }
 
     def test_classify_returns_the_right_kind_for_each_REAL_path(self, tmp_path: Path):
         """🔴 The table above is only meaningful if `classify_path` actually
@@ -2631,14 +2826,27 @@ class TestTokenSetAndOverlapRotation:
         self, tmp_path: Path
     ):
         """🔴 THE UPPER BOUND: counting credentials must not become counting
-        nothing. Five DISTINCT tokens with one of them repeated is still five
+        nothing. SEVEN distinct tokens with one of them repeated is still seven
         credentials, and the number in the message is the credential count — not
-        the row count (6) it would have been, and not a constant.
+        the row count (8) it would have been, and not a constant.
+
+        🔴 SEVEN, NOT FIVE, AND THAT IS THE WHOLE POINT OF THE FIXTURE. This
+        test used to build five tokens and assert `too many tokens: 5, max 4` —
+        five being one past a cap of four, so the printed number could only ever
+        BE five, and the other test that reaches this message uses five too. It
+        was a fixture that can only produce the constant's own value:
+        `claude/RULES.md` calls that shape out by name, and it was measured — a
+        mutant hardcoding `5` in place of the credential count SURVIVED the full
+        93-test subset with 0 failures.
+
+        Seven separates every number in the sentence: 7 credentials, 8 rows,
+        cap 4. A hardcoded 5, a row count, or the cap itself each print
+        something this assertion rejects.
         """
-        five = [chr(ord("a") + i) * 48 for i in range(5)]
-        path = self._write(tmp_path, *five, five[2])
+        seven = [chr(ord("a") + i) * 48 for i in range(7)]
+        path = self._write(tmp_path, *seven, seven[2])
         message = str(exc_of(lambda: api.load_tokens(path, {})))
-        assert "too many tokens: 5, max 4" in message, message
+        assert "too many tokens: 7, max 4" in message, message
 
     def test_a_SHORT_SECOND_token_names_its_POSITION_and_never_the_token(
         self, tmp_path: Path
@@ -7057,12 +7265,17 @@ LOCKED_ENTRY = "sealed-adit.md"
 EMACS_LOCK = ".#sealed-adit.md"
 
 
-def _make_unreadable(store: Path, scope: str, kind: str) -> Path:
+def _make_unreadable(
+    store: Path, scope: str, kind: str, *, outside: Path | None = None
+) -> Path:
     """Put ONE hostile candidate entry into `<store>/<scope>/`.
 
     `kind` is `perm` (a mode-000 regular file), `emacs` (the dangling lock-file
-    symlink) or `fifo` (a named pipe, which blocks `open()` until somebody
-    writes). All three are real shapes seen on a real store, not contrivances.
+    symlink), `fifo` (a named pipe, which blocks `open()` until somebody
+    writes), `dir` (a DIRECTORY named `*.md` — one stray `mkdir`, or an
+    rsync/restore artefact) or `linkdir` (a symlink pointing at one, which needs
+    `outside` to hold the real directory). All five are real shapes seen on a
+    real store, not contrivances.
     """
     target = store / scope / (EMACS_LOCK if kind == "emacs" else LOCKED_ENTRY)
     if kind == "perm":
@@ -7072,9 +7285,101 @@ def _make_unreadable(store: Path, scope: str, kind: str) -> Path:
         os.symlink("zach@host.4242:1767225600", target)
     elif kind == "fifo":
         os.mkfifo(target)
+    elif kind == "dir":
+        target.mkdir()
+    elif kind == "linkdir":
+        assert outside is not None, "`linkdir` needs somewhere to put the target"
+        real = outside / "a-real-directory"
+        real.mkdir(parents=True, exist_ok=True)
+        os.symlink(real, target)
     else:  # pragma: no cover - a typo in a test argument is a test bug
         raise AssertionError(kind)
     return target
+
+
+def under_deadline(source: str, seconds: float, *args: str):
+    """Run `source` in a CHILD process. The completed process, or `None` meaning
+    it blew the wall-clock deadline.
+
+    🔴 EVERY TEST THAT READS A STORE HOLDING A FIFO MUST GO THROUGH HERE, AND
+    THE REASON IS THAT THE ALTERNATIVE HAS NO FAILURE MODE. `read_text` on a
+    fifo blocks forever: in-process there is no exception and no value to assert
+    on, so the test does not fail — the RUNNER wedges. Measured on this file
+    with `_LOADER_ENTRY_ACTIONS[KIND_OTHER]` reverted to `TAKE`:
+    `test_the_REFUSED_entries_are_SURFACED_not_silently_dropped` ran **>600s**
+    with no error and no failure (isolated, `rc=124` at 60s). No
+    `pytest-timeout` plugin is installed — only `xdist` — so nothing above the
+    test would have cut it off either.
+
+    A test that hangs instead of failing is worse than no test: CI stops, and
+    nobody gets a red to act on. `claude/RULES.md`: "a permanently-red gate is
+    worse than no gate" — a permanently-HUNG one is worse still, because it does
+    not even report.
+
+    ⚠ ONE SPELLING, DELIBERATELY. This was a nested closure in two separate
+    tests before, and a third test simply did without; the predicate-at-N-sites
+    shape is how the third one came to be missing.
+    """
+    try:
+        return subprocess.run(
+            [sys.executable, "-c", source, *args],
+            capture_output=True,
+            text=True,
+            timeout=seconds,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+
+
+def _load_store_probe(store: Path, *, expr: str = "None") -> str:
+    """A child-process program that loads `store` and prints what it found.
+
+    `expr` is evaluated in the child to produce `visible_scopes`, so the scoped
+    and unrestricted arms share one program instead of two that could drift.
+    """
+    return (
+        "import sys;"
+        f"sys.path.insert(0, {str(RECALL_PATH.parent)!r});"
+        "import subsystem_recall as rc;"
+        f"vs = {expr};"
+        f"_s, i = rc.load_store({str(store)!r}, verb='recalled', visible_scopes=vs);"
+        "print('SCOPES=' + ','.join(i.scopes));"
+        "print('MALFORMED=' + ','.join(m.label for m in i.malformed));"
+        "print('REASONS=' + '|'.join(m.reason for m in i.malformed));"
+        "print('PERSCOPE=' + ','.join("
+        "    '%s:%d' % (s, len(i.entries(s))) for s in i.scopes))"
+    )
+
+
+def _load_index_raise_probe(store: Path) -> str:
+    """A child-process program that loads `store` under `RAISE` and prints the
+    exception class, its `source` and its message — the facts the in-process
+    `pytest.raises` used to assert, in a form a wall-clock deadline can bound.
+    """
+    return (
+        "import sys;"
+        f"sys.path.insert(0, {str(RECALL_PATH.parent)!r});"
+        "import subsystem_recall as rc;"
+        "\ntry:\n"
+        f"    rc.load_index({str(store)!r})\n"
+        "except BaseException as exc:\n"
+        "    print('CLASS=' + type(exc).__name__)\n"
+        "    print('SOURCE=' + str(getattr(exc, 'source', None)))\n"
+        "    print('MESSAGE=' + str(exc).replace(chr(10), ' '))\n"
+        "else:\n"
+        "    print('CLASS=NOTHING-RAISED')\n"
+    )
+
+
+def _probe_field(stdout: str, key: str) -> str:
+    """The one `KEY=value` line a probe printed, or an assertion naming what it
+    printed instead — never a silent empty string, which would satisfy most of
+    the comparisons it feeds.
+    """
+    for line in stdout.splitlines():
+        if line.startswith(f"{key}="):
+            return line[len(key) + 1 :]
+    raise AssertionError(f"the probe printed no {key}= line: {stdout[:600]!r}")
 
 
 class TestTheLoaderItselfTakesTheAllowlist:
@@ -7201,7 +7506,11 @@ class TestUnreadableEntriesInDeniedScopes:
     🔴 AND THE LIMIT OF (2) IS TESTED TOO, not just stated: it is NARROW. A
     `chmod 000` regular file still raises for an unrestricted caller —
     `test_an_UNREADABLE_REGULAR_FILE_still_RAISES_and_THAT_is_the_residual` is
-    the honest record of what did NOT close.
+    the honest record of ONE thing that did not close. ⚠ It is not the only one
+    and must not be read as such: the full list is the module-level
+    `LOADER_RESIDUAL_KINDS`, pinned against the table by
+    `test_the_LOADER_RESIDUAL_SET_is_pinned` and against both documents that
+    describe it by the two `RESIDUAL LEDGER` guards beside it.
     """
 
     def _store(self, tmp_path: Path, kind: str) -> Path:
@@ -7405,25 +7714,12 @@ class TestUnreadableEntriesInDeniedScopes:
         than a proxy for it.
         """
         store = self._store(tmp_path, "fifo")
-        probe = (
-            "import sys;"
-            f"sys.path.insert(0, {str(RECALL_PATH.parent)!r});"
-            "import subsystem_recall as rc;"
-            f"vs = None if sys.argv[1] == 'unrestricted' else ({ALLOW_SCOPE!r},);"
-            f"_s, i = rc.load_store({str(store)!r}, verb='recalled', visible_scopes=vs);"
-            "print('SCOPES=' + ','.join(i.scopes));"
-            "print('MALFORMED=' + ','.join(m.label for m in i.malformed))"
+        probe = _load_store_probe(
+            store, expr=f"None if sys.argv[1] == 'unrestricted' else ({ALLOW_SCOPE!r},)"
         )
 
         def run(arg: str, deadline: float):
-            """The completed process, or `None` meaning it blew the deadline."""
-            try:
-                return subprocess.run(
-                    [sys.executable, "-c", probe, arg],
-                    capture_output=True, text=True, timeout=deadline,
-                )
-            except subprocess.TimeoutExpired:
-                return None
+            return under_deadline(probe, deadline, arg)
 
         scoped = run("scoped", 30.0)
         assert scoped is not None, (
@@ -7491,16 +7787,6 @@ class TestUnreadableEntriesInDeniedScopes:
             "the fixture is not the kind this test is about"
         )
 
-        def under_deadline(source: str, seconds: float):
-            """The completed process, or `None` meaning it blew the deadline."""
-            try:
-                return subprocess.run(
-                    [sys.executable, "-c", source],
-                    capture_output=True, text=True, timeout=seconds,
-                )
-            except subprocess.TimeoutExpired:
-                return None
-
         # 🔴 THE POSITIVE CONTROL FIRST, so a runner that cannot observe a block
         # fails before the assertion that depends on it means anything. A bare
         # `open()` of the fifo — no store, no loader — is the syscall the guard
@@ -7548,23 +7834,44 @@ class TestTheLoaderRefusesHostileEntriesByKind:
 
     🔴 AND THE GUARD IS NARROW BY DECISION, NOT BY ACCIDENT. Mirroring
     `/snapshot`'s `_ENTRY_ACTIONS` wholesale also refuses a symlink to a regular
-    file, a directory and an unstat-able path — all of which this loader reads or
-    fails on TODAY, so the broad form is a behaviour change for every local CLI
-    caller. `test_a_SYMLINKED_entry_is_STILL_READ…` is the test that kills the
-    broad form; without it "refuse hostile kinds" has no upper bound.
+    file and an unstat-able path — which this loader READS and honestly fails on
+    respectively, so the broad form is still a behaviour change for every local
+    CLI caller. `test_a_SYMLINKED_entry_is_STILL_READ…` is the test that kills
+    the broad form; without it "refuse hostile kinds" has no upper bound.
 
-    ⚠ NARROW IS NOT FROZEN. The guard has THREE cells, not the two it shipped
-    with: `link-to-other` (a symlink pointing at a fifo/socket/device) was left
-    TAKE for one round as a named residual, then measured wedging an
-    unrestricted `/recall` for 25s and closed. That widening is still inside the
-    upper bound — it refuses a shape no legitimate entry has, and
-    `link-to-file`, the cell the narrow ruling was actually about, is untouched.
+    ⚠ NARROW IS NOT FROZEN. The guard has FIVE cells, not the two it shipped
+    with, added over three rulings and each on the SAME criterion — this loader
+    has never successfully read that kind, so refusing it changes no legitimate
+    caller. `link-to-other` (a symlink pointing at a fifo/socket/device) was
+    left TAKE for one round as a named residual, then measured wedging an
+    unrestricted `/recall` for 25s. `directory` and `link-to-dir` were TAKE for
+    three, while the ledger called `chmod 000` "the only residual left" — then
+    measured 503ing the whole store on an `IsADirectoryError`, off one stray
+    `mkdir <scope>/notes.md`. Every one of those widenings is still inside the
+    upper bound, and `link-to-file`, the cell the narrow ruling was actually
+    about, is untouched.
+
+    🔴 THE UPPER BOUND IS NOW ALSO A LEDGER SOMETHING READS.
+    `TestClassifierIsTotal.test_the_LOADER_RESIDUAL_SET_is_pinned` and the two
+    `RESIDUAL LEDGER` guards beside it assert the surviving TAKE set against
+    both documents that describe it, in both directions — because the drift that
+    let `directory` sit open for three rounds was a DOCUMENT going stale, not a
+    table being wrong, and no test read the documents.
     """
 
     def _hostile(self, tmp_path: Path) -> Path:
         """One store, BOTH refused shapes, in a scope that is not the one asked
         for — the arrangement the operator reproduced: unrestricted token, a
         dangling `.#lock.md` in `bravo`, and a recall for `alpha`.
+
+        🔴 THIS FIXTURE PLANTS A REAL FIFO, SO NOTHING MAY READ IT IN-PROCESS.
+        Three tests in this class used to: `load_store` / `load_index` directly,
+        and an in-process server. With `_LOADER_ENTRY_ACTIONS[KIND_OTHER]`
+        reverted to `TAKE` the first of them ran >600s with no error and no
+        failure — the guard's own regression test WEDGED the suite instead of
+        failing it, and with no `pytest-timeout` plugin loaded nothing would have
+        cut it off. Every read of this store now goes through `under_deadline`,
+        which turns that hang back into a red.
         """
         store = _build_store(
             tmp_path / "store",
@@ -7584,12 +7891,30 @@ class TestTheLoaderRefusesHostileEntriesByKind:
         `GOOD_TOKEN` is a BARE row, so the record is `legacy`/unrestricted —
         the pod's own configuration, not a scoped token that would be protected
         by the allowlist pushdown instead.
+
+        🔴 THE SERVER IS A REAL SPAWNED PROCESS, NOT AN IN-PROCESS ONE, AND
+        THAT IS A TEST-SAFETY REQUIREMENT RATHER THAN A FIDELITY PREFERENCE.
+        This fixture plants a FIFO; a wedged handler thread inside the pytest
+        process cannot be reclaimed, and `running()`'s teardown would leave it
+        parked for the rest of the run. `running_subprocess` puts the load in a
+        child that is `terminate()`d in its own `finally`, and turns a wedge into
+        a socket timeout — which this test converts into a NAMED failure below,
+        because "the worker never came back" is the whole claim.
         """
         store = self._hostile(tmp_path)
-        with running(store, tokens=(GOOD_TOKEN,)) as (base, _):
-            code, headers, body = fetch(
-                f"{base}/api/v1/recall/{ALLOW_SCOPE}", token=GOOD_TOKEN
-            )
+        token_file = tmp_path / "token"
+        token_file.write_text(GOOD_TOKEN + "\n")
+        with running_subprocess(store, token_file) as (base, _proc):
+            try:
+                code, headers, body = fetch(
+                    f"{base}/api/v1/recall/{ALLOW_SCOPE}", token=GOOD_TOKEN
+                )
+            except (urllib.error.URLError, TimeoutError) as exc:  # no response
+                raise AssertionError(
+                    "the request thread WEDGED on the hostile store — a REFUSE "
+                    "cell is not reaching `load_index`. On a `replicas: 1` "
+                    f"Deployment that is a worker that never comes back ({exc})"
+                ) from None
         text = body.decode()
         assert code == 200, f"{code}: {text[:400]}"
         assert headers["X-Store-Status"] == "recalled"
@@ -7605,16 +7930,124 @@ class TestTheLoaderRefusesHostileEntriesByKind:
         Asserted on the index rather than on the rendered body, because the body
         deliberately reports cross-scope defects as a COUNT with scopes named and
         never a filename; the per-file facts live here.
+
+        🔴 IN A CHILD PROCESS, BECAUSE THIS IS THE TEST THAT WEDGED. Measured:
+        reverting `_LOADER_ENTRY_ACTIONS[KIND_OTHER]` to `TAKE` made this exact
+        test run >600s with no error and no failure — it called `load_store` on a
+        store holding a real fifo, in-process, and `read_text` never returned.
+        The deadline is what converts that back into a `None`, i.e. a red.
         """
         store = self._hostile(tmp_path)
-        _s, index = api.rc.load_store(store, verb="recalled")
-        labels = sorted(m.label for m in index.malformed)
+        done = under_deadline(_load_store_probe(store), 30.0)
+        assert done is not None, (
+            "an UNRESTRICTED `load_store` of the hostile store HUNG — a "
+            "REFUSE cell is not reaching `load_index`"
+        )
+        assert done.returncode == 0, done.stderr[-800:]
+        labels = sorted(
+            _probe_field(done.stdout, "MALFORMED").split(",")
+        )
         assert labels == sorted(
             [f"{DENY_SCOPE}/{EMACS_LOCK}", f"{DENY_SCOPE}/{LOCKED_ENTRY}"]
+        ), done.stdout
+        reasons = _probe_field(done.stdout, "REASONS")
+        assert "broken symlink" in reasons, reasons
+        assert "not a regular file" in reasons, reasons
+        # …and the good entry in that same scope is still served.
+        assert f"{DENY_SCOPE}:1" in _probe_field(done.stdout, "PERSCOPE"), done.stdout
+
+    def _recall_over_http(self, tmp_path: Path, name: str, kind: str):
+        """Build a store carrying ONE hostile `kind`, then recall a DIFFERENT
+        scope over the wire on the pod's own credential shape (a bare legacy
+        row, i.e. unrestricted). Returns `(code, headers, text)`.
+        """
+        root = tmp_path / name
+        store = _build_store(
+            root / "store",
+            {ALLOW_SCOPE: KELP_NUANCE, DENY_SCOPE: QUARTZ_NUANCE},
         )
-        reasons = " ".join(m.reason for m in index.malformed)
-        assert "broken symlink" in reasons
-        assert "not a regular file" in reasons
+        _make_unreadable(store, DENY_SCOPE, kind, outside=root / "outside")
+        with running(store, tokens=(GOOD_TOKEN,)) as (base, _):
+            code, headers, body = fetch(
+                f"{base}/api/v1/recall/{ALLOW_SCOPE}", token=GOOD_TOKEN
+            )
+        return code, headers, body.decode()
+
+    @pytest.mark.parametrize("kind", ["dir", "linkdir"])
+    def test_a_DIRECTORY_named_md_no_longer_503s_the_WHOLE_store(
+        self, tmp_path: Path, kind: str
+    ):
+        """🔴 THE MEASURED SYMPTOM, AND THE ONE THE LEDGER DENIED EXISTED.
+
+        For three rounds `load_index`'s docstring and the API README both said a
+        `chmod 000` regular file was "the only residual left". Measured on that
+        tip, with a paired control:
+
+            store/beta/notes.md created as a DIRECTORY
+              GET /api/v1/recall/alpha, unrestricted legacy token
+              -> 503 "index entry unreadable: … (IsADirectoryError: …)"
+            CONTROL, same shape but a dangling `.#lock.md`
+              -> 200
+
+        So one accidental `mkdir <scope>/notes.md`, or one rsync or restore
+        artefact, took `/recall` AND `/search` down for EVERY caller — including
+        callers whose own scopes were untouched, and for a scope this request
+        never even asked about. A symlink to a directory behaved identically,
+        which is why both are parametrized here rather than one standing in for
+        the other.
+
+        🔴 THE POSITIVE CONTROL IS IN THIS TEST, NOT NEXT TO IT. Every assertion
+        here is "it did NOT 503", which is the reassuring zero that a harness
+        wired to nothing also produces. The `chmod 000` arm at the end drives the
+        SAME helper at the one shape that is still, deliberately, a residual —
+        so a fixture that plants nothing, or a `running()` that never reaches the
+        loader, fails there before the 200 above means anything.
+        """
+        code, headers, text = self._recall_over_http(tmp_path, f"probe-{kind}", kind)
+        assert code == 200, f"{code}: {text[:400]}"
+        assert headers["X-Store-Status"] == "recalled"
+        assert KELP_NUANCE in text, "the caller's own content vanished"
+
+        code, headers, text = self._recall_over_http(
+            tmp_path, f"control-{kind}", "perm"
+        )
+        assert code == 503, (
+            "an unreadable REGULAR file did NOT 503 — this harness cannot "
+            f"observe the failure the assertions above deny, so they are "
+            f"vacuous. got {code}: {text[:300]}"
+        )
+        assert headers["X-Store-Status"] == "store-unreachable"
+
+    @pytest.mark.parametrize("kind", ["dir", "linkdir"])
+    def test_the_REFUSED_DIRECTORY_is_a_NAMED_row_not_a_silent_skip(
+        self, tmp_path: Path, kind: str
+    ):
+        """A 200 is only correct if the refused path is still ACCOUNTED FOR — a
+        dropped entry is indistinguishable from one nobody ever wrote, which is
+        the conflation this whole store exists to avoid.
+
+        The REASON is asserted too, and the two kinds carry DIFFERENT sentences,
+        so a refusal filed under the wrong cell's reason fails here rather than
+        passing on the word "directory" appearing anywhere at all.
+        """
+        root = tmp_path / kind
+        store = _build_store(
+            root / "store",
+            {ALLOW_SCOPE: KELP_NUANCE, DENY_SCOPE: QUARTZ_NUANCE},
+        )
+        planted = _make_unreadable(
+            store, DENY_SCOPE, kind, outside=root / "outside"
+        )
+        expected_kind = api.KIND_DIRECTORY if kind == "dir" else api.KIND_LINK_TO_DIR
+        assert api.classify_path(planted) == expected_kind, (
+            "the fixture is not the kind this test is about"
+        )
+
+        _s, index = api.rc.load_store(store, verb="recalled")
+        assert [m.label for m in index.malformed] == [f"{DENY_SCOPE}/{LOCKED_ENTRY}"]
+        assert index.malformed[0].reason == resolver._LOADER_REFUSAL_REASON[
+            expected_kind
+        ], "the refusal was filed under another cell's sentence"
         # …and the good entry in that same scope is still served.
         assert len(index.entries(DENY_SCOPE)) == 1
 
@@ -7663,12 +8096,22 @@ class TestTheLoaderRefusesHostileEntriesByKind:
         only part of, and that is as true of a fifo as of a wrapped `aliases:`
         line. A guard that collected unconditionally would silently hand the
         writer a partial index.
+
+        🔴 UNDER THE DEADLINE TOO. Whether the fifo is even REACHED here depends
+        on `sorted()` order inside the scope directory — so "it raised before the
+        fifo, therefore it cannot hang" is a property of two filenames, not of
+        the code. That is not a guarantee worth resting the suite's liveness on.
         """
         store = self._hostile(tmp_path)
-        with pytest.raises(api.rc.MalformedEntryError) as exc:
-            api.rc.load_index(store)
-        assert "malformed index entry" in str(exc.value)
-        assert exc.value.source in (EMACS_LOCK, LOCKED_ENTRY)
+        done = under_deadline(_load_index_raise_probe(store), 30.0)
+        assert done is not None, (
+            "`load_index` under RAISE HUNG on the hostile store — a REFUSE cell "
+            "is not reaching the loader"
+        )
+        assert done.returncode == 0, done.stderr[-800:]
+        assert _probe_field(done.stdout, "CLASS") == "MalformedEntryError", done.stdout
+        assert "malformed index entry" in _probe_field(done.stdout, "MESSAGE")
+        assert _probe_field(done.stdout, "SOURCE") in (EMACS_LOCK, LOCKED_ENTRY)
 
     def test_a_BOGUS_policy_is_still_a_ValueError_not_a_refusal(
         self, tmp_path: Path
@@ -7678,6 +8121,13 @@ class TestTheLoaderRefusesHostileEntriesByKind:
         spelled twice. Spelled twice, a bogus policy on a hostile store would be
         answered with a complaint about the first fifo instead of about the
         policy — a message that sends the operator to the wrong file.
+
+        ⚠ THE ONE TEST IN THIS CLASS THAT STAYS IN-PROCESS ON THE HOSTILE STORE,
+        and it is safe for a STRUCTURAL reason, not a lucky one:
+        `_check_on_malformed` is the FIRST statement of `load_index`, so this
+        call raises before `iterdir()` — no candidate is ever classified, let
+        alone opened. If that ordering ever changes, this test becomes a hang and
+        must move to `under_deadline` with the others.
         """
         store = self._hostile(tmp_path)
         with pytest.raises(ValueError, match="on_malformed must be one of"):

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -5811,6 +5811,38 @@ class TestScopedTokenRowGuards:
             api.load_tokens(path, {}, warn=lambda _l: None)
         assert "malformed token row 1 of 1" in str(exc.value)
         assert "4 fields" in str(exc.value)
+        # 🔴 THE NEGATIVE HALF OF THE TYPO HINT, and it is what stops the hint
+        # becoming noise. There is no comma anywhere in this row, so a
+        # comma-spacing explanation would be a wrong guess printed with the same
+        # confidence as the count. A hint that fires unconditionally is a hint
+        # nobody reads.
+        assert "NO SPACES" not in str(exc.value)
+
+    def test_GUARD_6_a_SPACE_AFTER_A_COMMA_is_told_what_it_actually_did(
+        self, tmp_path: Path
+    ):
+        """🔴 FAIL-CLOSED IS NOT THE SAME AS DIAGNOSTIC. `<tok> zach a, b` is a
+        four-field row because the space after the comma split the scope list,
+        and the row is correctly refused — but "4 fields, expected 1 or 3" sends
+        the operator to count fields on a line that looks like it has three.
+
+        The refusal is unchanged: same guard, same prefix, same count. Only the
+        sentence after it is new, and it is conditional on a comma actually
+        being present past the identity, so it cannot be printed as a guess.
+        """
+        path = self._write(
+            tmp_path, f"{ZACH_TOKEN} zach {ALLOW_SCOPE}, {DENY_SCOPE}"
+        )
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {}, warn=lambda _l: None)
+        message = str(exc.value)
+        # The guard is NOT weakened — it still refuses, still by field count.
+        assert "malformed token row 1 of 1" in message
+        assert "4 fields" in message
+        # …and now says what to do about it.
+        assert "NO SPACES" in message
+        assert "`alpha,beta`, not `alpha, beta`" in message
+        assert ZACH_TOKEN not in message
 
     def test_GUARD_7_an_identity_outside_the_charset_is_refused(self, tmp_path: Path):
         # Passes guard 6: three fields. Fails only on the identity's spelling.
@@ -6191,8 +6223,16 @@ class TestEnumerationChannelsAreClosed:
         text = body.decode()
         assert KELP_NUANCE in text, "the caller's own content vanished"
         assert DENY_SCOPE not in text
-        assert "broken-shard" not in text
-
+        # ⚠ `assert "broken-shard" not in text` WAS HERE AND HAS BEEN DELETED AS
+        # VACUOUS, not moved. `render_malformed` emits `elsewhere` as a COUNT
+        # with its scopes named and DELIBERATELY never a filename ("naming the
+        # scopes makes it actionable without putting another scope's filenames,
+        # which are client-identifying, on this screen"). So no filename from
+        # another scope is rendered at base OR at HEAD, for ANY token — the
+        # assertion could not have failed and was reading as coverage while
+        # providing none. The line above is the real guard for this channel; the
+        # filename half is pinned where it CAN fail, in the positive control
+        # below, which drives the reading that does render the block.
     def test_CHANNEL_2_POSITIVE_CONTROL_a_legacy_token_DOES_see_it(
         self, scoped_store: Path
     ):
@@ -6205,10 +6245,20 @@ class TestEnumerationChannelsAreClosed:
             _c, _h, body = fetch(
                 f"{base}/api/v1/recall/{ALLOW_SCOPE}", token=GOOD_TOKEN
             )
-        assert DENY_SCOPE in body.decode(), (
+        text = body.decode()
+        assert DENY_SCOPE in text, (
             "the fixture produced no cross-scope malformed block, so the "
             "negative assertion above proves nothing"
         )
+        # 🔴 AND THE BLOCK IS A COUNT, NOT A ROW — pinned HERE because this is
+        # the only reading in which the block is rendered at all, so it is the
+        # only place the claim can fail. `render_malformed`'s contract is that a
+        # scope OUTSIDE the one being recalled contributes its name and a number
+        # and never a filename, because filenames are client-identifying. An
+        # unrestricted caller is the widest reading there is: if `broken-shard`
+        # is absent from THIS body, no narrower caller can see it either.
+        assert "broken-shard" not in text
+        assert "1 further malformed entry in OTHER scopes" in text
 
     def test_CHANNEL_3_all_scopes_search_narrows_to_the_callers_own(
         self, scoped_store: Path
@@ -6228,6 +6278,18 @@ class TestEnumerationChannelsAreClosed:
         assert QUARTZ_NUANCE not in text
         assert DENY_SCOPE not in text
         assert THIRD_SCOPE not in text
+        # 🔴 NARROWED IS NOT EMPTIED, AND WITHOUT THESE THREE THE TEST ABOVE IS
+        # SATISFIED BY A SEARCH THAT LOOKED AT NOTHING. Measured: with
+        # `scopes_searched` forced to `()` the body renders "searched 0 entries
+        # in (none)" — which contains no denied scope name and no denied content,
+        # so every assertion above passes while the feature is entirely inert.
+        #
+        # The caller's OWN scope must be named, the placeholder must be absent,
+        # and the COUNT must have moved off zero. Three independent facts,
+        # because a renderer could satisfy any one of them by accident.
+        assert ALLOW_SCOPE in text, "the caller's own scope was not searched"
+        assert "(none)" not in text
+        assert "searched 1 entry" in text
 
     def test_CHANNEL_3_POSITIVE_CONTROL_a_legacy_token_DOES_find_it(
         self, scoped_store: Path
@@ -6282,6 +6344,15 @@ class TestEnumerationChannelsAreClosed:
         """`?scope=` reaches the filesystem directly, so it is its own door into
         the same store — and it must answer for a denied scope exactly what it
         answers for one that never existed.
+
+        🔴 COMPARED AS BYTES AND AS A HEADER SET, the way
+        `TestRefusedIsIndistinguishableFromAbsent` compares its pair. This test
+        used to check three NAMED facts — the code, one header and the member
+        list — which is a claim about the three things somebody thought of. The
+        docstring promises "exactly what it answers", and exactly is a byte
+        comparison: a fourth `X-Store-*` header, or a differing tar footer, would
+        discriminate a refused scope from an absent one while every named
+        assertion stayed green.
         """
         with running(scoped_store, tokens=(ZACH,)) as (base, _):
             denied = fetch(
@@ -6290,8 +6361,27 @@ class TestEnumerationChannelsAreClosed:
             phantom = fetch(
                 f"{base}/api/v1/snapshot?scope={PHANTOM_SCOPE}", token=ZACH_TOKEN
             )
+
+        def store_headers(headers: dict) -> tuple:
+            return tuple(
+                sorted(
+                    (k, v) for k, v in headers.items() if k.lower().startswith("x-store")
+                )
+            )
+
         assert denied[0] == phantom[0] == 200
-        assert denied[1]["X-Store-Entries"] == phantom[1]["X-Store-Entries"] == "0"
+        assert store_headers(denied[1]) == store_headers(phantom[1]), (
+            f"X-Store-* headers differ:\n denied ={store_headers(denied[1])}\n"
+            f" phantom={store_headers(phantom[1])}"
+        )
+        assert denied[2] == phantom[2], (
+            "the tar BYTES differ — a refused scope is distinguishable from an "
+            f"absent one:\n denied ={denied[2]!r}\n phantom={phantom[2]!r}"
+        )
+        # 🔴 AND THE SHARED ANSWER IS THE EMPTY ARCHIVE, not two identical
+        # errors: byte-identity between two 503s would satisfy everything above
+        # while serving nothing. Same reasoning as the recall/search pair.
+        assert denied[1]["X-Store-Entries"] == "0"
         for body in (denied[2], phantom[2]):
             with tarfile.open(fileobj=io.BytesIO(body), mode="r") as tar:
                 assert tar.getnames() == []
@@ -6416,25 +6506,26 @@ class TestRefusedIsIndistinguishableFromAbsent:
         assert b"NOTHING RECORDED YET" in refused[2].upper()
         assert QUARTZ_NUANCE.encode() not in refused[2]
 
+    SEARCH_QUERY = f"/api/v1/search/{DENY_SCOPE}?q=drill+head+overheats"
+
     def test_SEARCH_a_refused_scope_is_BYTE_IDENTICAL_to_one_that_never_existed(
         self, tmp_path: Path
     ):
         root, present, absent = self._phases(tmp_path)
-        query = f"/api/v1/search/{DENY_SCOPE}?q=drill+head+overheats"
         present()
-        refused = self._ask(root, ZACH, query)
+        refused = self._ask(root, ZACH, self.SEARCH_QUERY)
         absent()
-        never = self._ask(root, ZACH, query)
+        never = self._ask(root, ZACH, self.SEARCH_QUERY)
 
         assert refused[0] == never[0] == 200
         assert refused[1] == never[1], f"{refused[1]} != {never[1]}"
         assert refused[2] == never[2]
         assert dict(refused[1])["X-Store-Status"] == "scope-absent"
 
-    def test_POSITIVE_CONTROL_the_comparison_CAN_see_the_difference(
+    def test_POSITIVE_CONTROL_the_RECALL_comparison_CAN_see_the_difference(
         self, tmp_path: Path
     ):
-        """🔴 WITHOUT THIS, BOTH TESTS ABOVE ARE SATISFIED BY A SERVER THAT
+        """🔴 WITHOUT THIS, THE RECALL TEST ABOVE IS SATISFIED BY A SERVER THAT
         ANSWERS THE SAME BYTES TO EVERYTHING.
 
         The same two phases, driven by an UNRESTRICTED legacy token: present ->
@@ -6452,6 +6543,36 @@ class TestRefusedIsIndistinguishableFromAbsent:
         assert dict(gone[1])["X-Store-Status"] == "scope-absent"
         assert seen[2] != gone[2]
         assert QUARTZ_NUANCE.encode() in seen[2]
+
+    def test_POSITIVE_CONTROL_the_SEARCH_comparison_CAN_see_the_difference(
+        self, tmp_path: Path
+    ):
+        """🔴 THE SEARCH PATH HAD NO POSITIVE CONTROL AT ALL, and the recall one
+        does not cover it: they are different routes, different renderers and
+        different statuses.
+
+        An equality between two responses is only evidence if the pair CAN
+        differ. This server fail-closes to an EMPTY body without
+        `SUBSYSTEM_STORE_TRUSTED_PROXIES` and a `CF-Connecting-IP` header, and
+        two empty bodies compare identical — so "byte-identical" is exactly the
+        assertion a broken harness satisfies best. Same two phases, same query,
+        an UNRESTRICTED token: present -> `search-hit` carrying the matched
+        nuance, absent -> `scope-absent`. Both non-empty, and different.
+        """
+        root, present, absent = self._phases(tmp_path)
+        present()
+        found = self._ask(root, GOOD_TOKEN, self.SEARCH_QUERY)
+        absent()
+        gone = self._ask(root, GOOD_TOKEN, self.SEARCH_QUERY)
+
+        assert found[0] == gone[0] == 200
+        assert dict(found[1])["X-Store-Status"] == "search-hit"
+        assert dict(gone[1])["X-Store-Status"] == "scope-absent"
+        assert found[2] != gone[2]
+        assert QUARTZ_NUANCE.encode() in found[2]
+        # …and neither body is the empty string, which is what a fail-closed
+        # server returns and what would make the equality above vacuous.
+        assert found[2] and gone[2]
 
 
 class TestScopeRevisionIsGatedByConstruction:
@@ -6663,6 +6784,100 @@ def _make_unreadable(store: Path, scope: str, kind: str) -> Path:
     else:  # pragma: no cover - a typo in a test argument is a test bug
         raise AssertionError(kind)
     return target
+
+
+class TestTheLoaderItselfTakesTheAllowlist:
+    """🔴 `load_index` DIRECTLY — the surface `load_store` hides.
+
+    `load_store` narrows its RESULT as well, so through that door three separate
+    mutations of the loader's own filter are invisible: an empty allowlist read
+    as unrestricted, a denied scope's NAME registered before the skip, and a
+    directory name compared unfolded. Each was measured SURVIVING a sweep that
+    only drove `load_store`, and each is a real defect for the OTHER callers of
+    this function — `subsystem_touch`, and anything that hands the result
+    somewhere the post-filter is not.
+
+    The seam guard is the pair: these tests plus the `load_store` ones above.
+    Neither half alone pins the loader.
+    """
+
+    def _store(self, tmp_path: Path, *scope_dirs: str) -> Path:
+        """A store whose scope DIRECTORY NAMES are exactly as given.
+
+        Spelled by hand rather than through `_build_store`, because one test
+        below needs a directory whose name does NOT equal its own folded form
+        and that fixture is the whole point of it.
+        """
+        root = tmp_path / "store"
+        for name in scope_dirs:
+            (root / name).mkdir(parents=True)
+            (root / name / f"{name}-entry.md").write_text(
+                _entry(f"{name}-entry", name, nuance=f"- 2026-03-04: {name} drifts.")
+            )
+        return root
+
+    def test_POSITIVE_CONTROL_no_allowlist_loads_every_scope(self, tmp_path: Path):
+        """Without this the three tests below are satisfied by a loader that
+        returns an empty index for everything.
+        """
+        root = self._store(tmp_path, ALLOW_SCOPE, DENY_SCOPE)
+        index = api.rc.load_index(root, on_malformed="collect")
+        assert set(index.scopes) == {ALLOW_SCOPE, DENY_SCOPE}
+
+    def test_an_EMPTY_allowlist_registers_NO_scope_not_EVERY_scope(
+        self, tmp_path: Path
+    ):
+        """🔴 THE ASYMMETRY, PINNED AT THE LOADER TOO. `None` and `()` are both
+        falsy, so a filter written `if allowed and …` treats "you may see
+        nothing" as "you may see everything" — a total bypass, and one that every
+        test with a POPULATED allowlist passes.
+
+        `load_store` re-narrows its result, which is why this mutation survives
+        entirely when measured through that door. Here there is nothing in the
+        way.
+        """
+        root = self._store(tmp_path, ALLOW_SCOPE, DENY_SCOPE)
+        index = api.rc.load_index(root, on_malformed="collect", visible_scopes=())
+        assert index.scopes == ()
+        assert len(index) == 0
+
+    def test_a_denied_scopes_NAME_is_not_registered_either(self, tmp_path: Path):
+        """🔴 SKIPPING THE READ IS NOT SKIPPING THE SCOPE. A filter placed one
+        line too late still appends the directory name to `extra_scopes`, so the
+        denied scope arrives on `index.scopes` — the `known_scopes` enumeration
+        channel — having never been opened. It reads as fixed and leaks the one
+        fact the channel was about: that the scope EXISTS.
+
+        Invisible through `load_store`, which drops the key again on the way out.
+        """
+        root = self._store(tmp_path, ALLOW_SCOPE, DENY_SCOPE)
+        index = api.rc.load_index(
+            root, on_malformed="collect", visible_scopes=(ALLOW_SCOPE,)
+        )
+        assert index.scopes == (ALLOW_SCOPE,)
+
+    def test_the_DIRECTORY_NAME_is_FOLDED_before_it_is_compared(
+        self, tmp_path: Path
+    ):
+        """🔴 OVER-FILTERING, AND THE FIXTURE HAS TO REACH IT. Every other store
+        in this file has directory names that are already their own folded form,
+        so a filter comparing the RAW `scope_dir.name` behaves identically and
+        the mutation survives. Here the directory really is spelled
+        `Kelp_Forest`: the index key it produces is `kelp-forest`, so an
+        allowlist naming `kelp-forest` must still match it, and an unfolded
+        comparison silently empties the caller's OWN scope.
+        """
+        raw_dir = "Kelp_Forest"
+        assert api.rc.normalize_ref(raw_dir) == ALLOW_SCOPE != raw_dir, (
+            "the fixture directory must NOT already equal its folded form, or "
+            "this test measures nothing"
+        )
+        root = self._store(tmp_path, raw_dir, DENY_SCOPE)
+        index = api.rc.load_index(
+            root, on_malformed="collect", visible_scopes=(ALLOW_SCOPE,)
+        )
+        assert index.scopes == (ALLOW_SCOPE,)
+        assert len(index) == 1
 
 
 class TestUnreadableEntriesInDeniedScopes:
@@ -6881,18 +7096,39 @@ class TestScopeFilteringIsNotAWriteVerb:
     def test_the_route_set_did_NOT_grow(self):
         assert set(api.API_ROUTES) == {"recall", "search", "snapshot"}
 
-    def test_every_write_verb_is_STILL_405_with_a_valid_SCOPED_token(
+    def test_every_write_verb_is_STILL_405_on_EVERY_ROUTE_with_a_SCOPED_token(
         self, scoped_store: Path
     ):
+        """🔴 EVERY ROUTE, ENUMERATED FROM `API_ROUTES` ITSELF — not `/recall`
+        alone, which is what this used to probe.
+
+        The two guards in this class were jointly walkable. A `do_POST` added on
+        `/snapshot` passed BOTH: the route SET is unchanged, so
+        `test_the_route_set_did_NOT_grow` is green, and the only path this test
+        exercised was `/recall`. Driving the table means a route added to
+        `API_ROUTES` is automatically probed, and a verb added to one existing
+        route is caught by the route it was added to.
+        """
+        # A path per route, so the request reaches the route rather than the
+        # `bad request: invalid path component` branch. Keyed on the ledger, and
+        # asserted TOTAL below, so a new route cannot be silently unprobed.
+        paths = {
+            "recall": f"/api/v1/recall/{ALLOW_SCOPE}",
+            "search": f"/api/v1/search/{ALLOW_SCOPE}?q=tide",
+            "snapshot": "/api/v1/snapshot",
+        }
+        assert set(paths) == set(api.API_ROUTES), (
+            "a route exists that this test has no path for, so it would go "
+            f"unprobed: {sorted(set(api.API_ROUTES) ^ set(paths))}"
+        )
         with running(scoped_store, tokens=(ZACH,)) as (base, _):
-            for method in ("POST", "PUT", "PATCH", "DELETE"):
-                code, _h, body = fetch(
-                    f"{base}/api/v1/recall/{ALLOW_SCOPE}",
-                    token=ZACH_TOKEN,
-                    method=method,
-                )
-                assert code == 405, f"{method} answered {code}"
-                assert body == b"read-only\n"
+            for route, path in sorted(paths.items()):
+                for method in ("POST", "PUT", "PATCH", "DELETE"):
+                    code, _h, body = fetch(
+                        f"{base}{path}", token=ZACH_TOKEN, method=method
+                    )
+                    assert code == 405, f"{method} {route} answered {code}"
+                    assert body == b"read-only\n", f"{method} {route}: {body!r}"
 
     def test_a_full_scoped_read_workload_leaves_the_store_BYTE_IDENTICAL(
         self, scoped_store: Path

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -52,6 +52,7 @@ from testlib import hermetic_git  # noqa: E402
 import io
 import os
 import re
+import shutil
 import tarfile
 import secrets
 import subprocess
@@ -480,6 +481,23 @@ def tree_hash(root: Path) -> str:
 # =============================================================================
 
 
+def loaded(token_file, env, **kwargs) -> list[tuple]:
+    """`load_tokens` as PLAIN TUPLES — `(token, identity, scopes)` per row.
+
+    🔴 A tuple, not the `TokenRecord` itself, and deliberately: importing the
+    dataclass and asserting `== TokenRecord(...)` would re-derive the expected
+    value from the implementation under test, and a field renamed on both sides
+    would stay green. Spelling the three facts out here means the assertion
+    breaks when the SHAPE changes, which is when someone should look.
+
+    `warn=` is swallowed by default so the legacy-mode banner does not spray
+    stderr across every guard test; the tests that are ABOUT that banner pass
+    their own sink and read it.
+    """
+    kwargs.setdefault("warn", lambda _line: None)
+    return [(r.token, r.identity, r.scopes) for r in api.load_tokens(token_file, env, **kwargs)]
+
+
 class TestTokenLoadingGuards:
     """`load_tokens` refuses to serve on a token that is absent, empty or weak.
 
@@ -532,7 +550,11 @@ class TestTokenLoadingGuards:
     def test_a_token_of_exactly_the_floor_is_accepted(self, tmp_path: Path):
         path = tmp_path / "tok"
         path.write_text("z" * 43 + "\n")
-        assert api.load_tokens(str(path), {}) == ["z" * 43]
+        # 🔴 A BARE ROW IS THE LEGACY RECORD: identity `legacy`, `scopes=None`
+        # meaning UNRESTRICTED. Pinned here rather than only in the phase-3
+        # section, because this is the shape criterion 10's rollback re-adds and
+        # the whole migration rests on it still loading.
+        assert loaded(str(path), {}) == [("z" * 43, "legacy", None)]
 
     def test_env_is_the_FALLBACK_not_the_primary(self, tmp_path: Path):
         # Both sources present: the FILE wins. The agent exec sandbox strips env
@@ -540,12 +562,14 @@ class TestTokenLoadingGuards:
         # mounted secret would make the deployed token unknowable.
         path = tmp_path / "tok"
         path.write_text("f" * 50)
-        assert api.load_tokens(str(path), {"SUBSYSTEM_STORE_TOKEN": "e" * 50}) == [
-            "f" * 50
+        assert loaded(str(path), {"SUBSYSTEM_STORE_TOKEN": "e" * 50}) == [
+            ("f" * 50, "legacy", None)
         ]
 
     def test_env_is_used_when_no_file_is_named(self):
-        assert api.load_tokens(None, {"SUBSYSTEM_STORE_TOKEN": "e" * 50}) == ["e" * 50]
+        assert loaded(None, {"SUBSYSTEM_STORE_TOKEN": "e" * 50}) == [
+            ("e" * 50, "legacy", None)
+        ]
 
 
 # =============================================================================
@@ -2423,11 +2447,27 @@ class TestTokenSetAndOverlapRotation:
 
     def test_two_tokens_load_as_a_set_IN_FILE_ORDER(self, tmp_path: Path):
         path = self._write(tmp_path, GOOD_TOKEN, SECOND_TOKEN)
-        assert api.load_tokens(path, {}) == [GOOD_TOKEN, SECOND_TOKEN]
+        assert [r[0] for r in loaded(path, {})] == [GOOD_TOKEN, SECOND_TOKEN]
 
     def test_a_duplicated_line_collapses_and_order_is_kept(self, tmp_path: Path):
         path = self._write(tmp_path, SECOND_TOKEN, GOOD_TOKEN, SECOND_TOKEN)
-        assert api.load_tokens(path, {}) == [SECOND_TOKEN, GOOD_TOKEN]
+        assert [r[0] for r in loaded(path, {})] == [SECOND_TOKEN, GOOD_TOKEN]
+
+    def test_TWO_LEGACY_ROWS_do_NOT_trip_the_duplicate_identity_guard(
+        self, tmp_path: Path
+    ):
+        """🔴 THE EXEMPTION, EXERCISED — it is what keeps rotation working.
+
+        Both bare rows carry identity `legacy`, so a duplicate-identity check
+        written without the exemption refuses the ordinary current+previous
+        overlap file: the very shape guards 1-5 exist to support, and the shape
+        criterion 10's rollback restores. Distinct tokens, one identity, and it
+        must LOAD.
+        """
+        path = self._write(tmp_path, GOOD_TOKEN, SECOND_TOKEN)
+        rows = loaded(path, {})
+        assert [r[1] for r in rows] == ["legacy", "legacy"]
+        assert [r[2] for r in rows] == [None, None]
 
     def test_the_cap_is_FOUR(self):
         # Literal, not `api.MAX_TOKENS` — importing it would assert x == x.
@@ -2449,7 +2489,7 @@ class TestTokenSetAndOverlapRotation:
     ):
         four = [chr(ord("a") + i) * 48 for i in range(4)]
         path = self._write(tmp_path, *four)
-        assert api.load_tokens(path, {}) == four
+        assert [r[0] for r in loaded(path, {})] == four
 
     def test_a_SHORT_SECOND_token_names_its_POSITION_and_never_the_token(
         self, tmp_path: Path
@@ -2518,7 +2558,11 @@ class TestTokenSetAndOverlapRotation:
         got = api.authorize(
             f"Bearer {GOOD_TOKEN}", (GOOD_TOKEN, SECOND_TOKEN, THIRD_TOKEN)
         )
-        assert got == api.token_id(GOOD_TOKEN)
+        # 🔴 The RECORD, and the fingerprint is read off it — `authorize`
+        # returns identity and allowlist alongside the match now, so the audit
+        # line and the scope filter come from one decision.
+        assert got.fingerprint == api.token_id(GOOD_TOKEN)
+        assert got.token == GOOD_TOKEN
         assert len(seen) == 3, f"short-circuited after {len(seen)} comparisons"
 
     def test_authorize_REFUSES_a_bare_string_rather_than_iterating_CHARACTERS(self):
@@ -2599,7 +2643,7 @@ class TestTokenSetAndOverlapRotation:
         assert api.token_id(GOOD_TOKEN) in out
         assert api.token_id(SECOND_TOKEN) in out
         assert GOOD_TOKEN not in out and SECOND_TOKEN not in out
-        assert started["tokens"] == [GOOD_TOKEN, SECOND_TOKEN]
+        assert [r.token for r in started["tokens"]] == [GOOD_TOKEN, SECOND_TOKEN]
 
 
 class TestClientIpIsCloudflareOnly:
@@ -5619,3 +5663,885 @@ class TestResolveClientIsTheWholeRule:
         )
         assert key == "2001:db8:1:2::/64"
         assert trusted is False
+
+
+# =============================================================================
+# 16. PHASE 3, CRITERIA 1-3 — two-token authorization on the READ path.
+#
+# 🔴 WHICH OF THESE ARE REGRESSION TESTS, HONESTLY. `server.py` and the absent
+# path both EXIST at the base ref, and the leak is real there, so the tests in
+# `TestEnumerationChannelsAreClosed` and `TestRefusedIsIndistinguishableFromAbsent`
+# are genuine regressions: they go red at base for the RIGHT reason (the body
+# names scopes the caller may not see) rather than by API error. The GUARD tests
+# in `TestScopedTokenRowGuards` are NOT: they call a parser that does not accept
+# a three-field row at base, so their red is a shape error and proves nothing —
+# the mutation matrix in the PR body is their evidence.
+#
+# 🔴 AND THE WRITE PATH IS NOT HERE. Criteria 4-10 add no verb in this branch;
+# `TestPhaseOneScope.test_the_server_declares_no_write_handler` is untouched and
+# still the thing that has to be broken on purpose when the write path lands.
+# =============================================================================
+
+
+# Pairwise-distinct, and distinct from every scope constant already in this
+# file AND from every literal any assertion below names. Invented for this
+# section so a renderer that surfaced the wrong scope cannot pass by
+# coincidence.
+ALLOW_SCOPE = "kelp-forest"     # zach may read it
+DENY_SCOPE = "quartz-mine"      # dana may read it; zach may not
+THIRD_SCOPE = "lantern-bay"     # nobody in these tests may read it
+PHANTOM_SCOPE = "never-quarried"  # never exists on disk, at any point
+
+# One distinctive sentence per scope, sharing no substring, so "did content from
+# a scope I cannot see reach me" is answerable by a single `in` on the body.
+KELP_NUANCE = "- 2026-03-04: the tide gauge drifts 3cm after a spring flood."
+QUARTZ_NUANCE = "- 2026-03-05: the drill head overheats past 900 revolutions."
+LANTERN_NUANCE = "- 2026-03-06: the beacon lamp browns out on a westerly gale."
+
+ZACH_TOKEN = "k" * 20 + "L" * 20 + "m" * 8   # 48 chars
+DANA_TOKEN = "p" * 20 + "Q" * 20 + "r" * 8   # 48 chars, disjoint
+# 🔴 TOKEN-LENGTH AND ALL-LOWERCASE, so it PASSES the identity charset check and
+# can be rejected ONLY by the length cap. That is what lets the "a token can
+# never be an identity" test measure the arithmetic it claims to measure rather
+# than an incidental uppercase letter. `secrets.token_urlsafe` really can emit
+# an all-lowercase string, so this is a shape, not a contrivance.
+LOWER_TOKEN = "s" * 24 + "t" * 24            # 48 chars, [a-z] only
+
+# The identity class, spelled again here BY HAND. Importing
+# `api.IDENTITY_COMPONENT` would make the fixture's precondition and the code
+# under test the same expression, so a wrong class would satisfy both.
+IDENTITY_CHARSET = re.compile(r"[a-z0-9][a-z0-9-]*")
+
+# A fixed instant, applied to every entry file, so two stores built from
+# different scope NAMES still date identically. `snapshot_freshness` reports the
+# newest entry mtime and the entry-file COUNT store-wide, and both are shared
+# across an allowlist — see the module docstring's residual-leak note. Holding
+# them constant is what lets the byte-identity claim below be about scope
+# EXISTENCE and nothing else.
+FIXED_MTIME = 1_767_225_600.0  # 2026-01-01T00:00:00Z, an arbitrary round instant
+
+
+def _scoped_record(token: str, identity: str, *scopes: str):
+    return api.TokenRecord(token=token, identity=identity, scopes=tuple(scopes))
+
+
+ZACH = _scoped_record(ZACH_TOKEN, "zach", ALLOW_SCOPE)
+DANA = _scoped_record(DANA_TOKEN, "dana", DENY_SCOPE)
+
+
+def _build_store(root: Path, scopes: "dict[str, str]", *, malformed: str = "") -> Path:
+    """A store holding one entry per named scope, every mtime pinned.
+
+    `scopes` maps scope name -> the nuance line that scope's single entry
+    carries. `malformed` optionally names a scope that also gets a front-matter-
+    less file, which is what puts a row on `index.malformed`.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    for scope, nuance in scopes.items():
+        (root / scope).mkdir(parents=True, exist_ok=True)
+        entry = root / scope / f"{scope}-entry.md"
+        entry.write_text(_entry(f"{scope}-entry", scope, nuance=nuance))
+    if malformed:
+        (root / malformed / "broken-shard.md").write_text("no front matter here\n")
+    for path in sorted(root.rglob("*.md")):
+        os.utime(path, (FIXED_MTIME, FIXED_MTIME))
+    return root
+
+
+@pytest.fixture
+def scoped_store(tmp_path: Path) -> Path:
+    """Three populated scopes, and the malformed row lives in a DENIED one.
+
+    The malformed placement is the point: `malformed_elsewhere` is rendered on
+    EVERY status, so a reject sitting in a scope the caller cannot name is the
+    channel that leaks without any miss ever happening.
+    """
+    return _build_store(
+        tmp_path / "store",
+        {
+            ALLOW_SCOPE: KELP_NUANCE,
+            DENY_SCOPE: QUARTZ_NUANCE,
+            THIRD_SCOPE: LANTERN_NUANCE,
+        },
+        malformed=DENY_SCOPE,
+    )
+
+
+class TestScopedTokenRowGuards:
+    """🔴 SIX NEW GUARDS, AND EACH INPUT PASSES EVERY EARLIER ONE.
+
+    Guards 1-5 (no source / unreadable / empty / too many / too short) are
+    unchanged and covered by `TestTokenLoadingGuards` and
+    `TestTokenSetAndOverlapRotation` above. Every file below therefore uses
+    tokens of 48 characters and at most four rows, so the only guard that can
+    reject it is the one the test names — a test that went red because a
+    DIFFERENT guard fired would be green with the guard it names deleted, which
+    is the failure mode this class is shaped against.
+
+    Each assertion pins the guard's OWN sentence, not merely `ValueError`.
+    """
+
+    def _write(self, tmp_path: Path, *rows: str) -> str:
+        path = tmp_path / "tokens"
+        path.write_text("\n".join(rows) + "\n")
+        return str(path)
+
+    def test_GUARD_6_a_row_with_two_fields_is_MALFORMED_not_two_tokens(
+        self, tmp_path: Path
+    ):
+        """🔴 THE FORMAT CHANGE, MADE LOUD. Under the old whole-file `.split()`
+        this line was TWO credentials. Under the row format it is one row with a
+        field count that means nothing, and the process refuses to start rather
+        than pick a reading.
+        """
+        path = self._write(tmp_path, f"{ZACH_TOKEN} zach")
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {}, warn=lambda _l: None)
+        assert "malformed token row 1 of 1" in str(exc.value)
+        assert "2 fields" in str(exc.value)
+        # And never the credential itself, on the one file whose whole content
+        # is credentials.
+        assert ZACH_TOKEN not in str(exc.value)
+
+    def test_GUARD_6_is_reached_by_a_FOUR_field_row_too(self, tmp_path: Path):
+        # The other side of the `not in (1, 3)` boundary. A guard tested only
+        # from below is a guard tested on one side of its condition.
+        path = self._write(tmp_path, f"{ZACH_TOKEN} zach {ALLOW_SCOPE} extra")
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {}, warn=lambda _l: None)
+        assert "malformed token row 1 of 1" in str(exc.value)
+        assert "4 fields" in str(exc.value)
+
+    def test_GUARD_7_an_identity_outside_the_charset_is_refused(self, tmp_path: Path):
+        # Passes guard 6: three fields. Fails only on the identity's spelling.
+        path = self._write(tmp_path, f"{ZACH_TOKEN} Za_ch {ALLOW_SCOPE}")
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {}, warn=lambda _l: None)
+        assert "invalid identity in token row 1 of 1" in str(exc.value)
+        assert "Za_ch" in str(exc.value)
+
+    def test_GUARD_7_a_TOKEN_can_never_be_read_as_an_identity(self, tmp_path: Path):
+        """🔴 THE STRUCTURAL HALF OF THE FORMAT CHANGE, AND THE FIXTURE HAS TO
+        REACH IT. Three tokens on one line used to be three credentials; now it
+        is a three-field row, and what stops the second one being read as an
+        identity is ARITHMETIC — the cap is below the token floor, 48 > 32.
+
+        So the identity here is `LOWER_TOKEN`, which is token-SHAPED and passes
+        the charset check outright: only the LENGTH cap can reject it. An
+        earlier version used a token containing uppercase, which meant the
+        charset half did all the work and the length cap — the half the
+        docstring is about — was never exercised at all.
+        """
+        path = self._write(tmp_path, f"{ZACH_TOKEN} {LOWER_TOKEN} {ALLOW_SCOPE}")
+        assert IDENTITY_CHARSET.fullmatch(LOWER_TOKEN), (
+            "the fixture must pass the CHARSET check, or this test measures the "
+            "charset half and not the length cap it claims to"
+        )
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {}, warn=lambda _l: None)
+        assert "invalid identity in token row 1 of 1" in str(exc.value)
+        # 32 and 43, pinned LITERALLY — the cap must stay under the floor or
+        # this whole property evaporates silently.
+        assert api.MAX_IDENTITY_CHARS == 32
+        assert api.MIN_TOKEN_CHARS == 43
+        assert api.MAX_IDENTITY_CHARS < api.MIN_TOKEN_CHARS
+        assert len(LOWER_TOKEN) > api.MAX_IDENTITY_CHARS
+
+    def test_GUARD_8_a_mapped_row_may_not_claim_the_legacy_identity(
+        self, tmp_path: Path
+    ):
+        # Passes 6 (three fields) and 7 (`legacy` is a well-formed identity).
+        # Only the reservation can reject it.
+        path = self._write(tmp_path, f"{ZACH_TOKEN} legacy {ALLOW_SCOPE}")
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {}, warn=lambda _l: None)
+        assert "reserved identity in token row 1 of 1" in str(exc.value)
+        assert "'legacy'" in str(exc.value)
+
+    def test_GUARD_9_an_explicitly_empty_allowlist_is_refused(self, tmp_path: Path):
+        # Three fields, a valid non-reserved identity, and a third field holding
+        # no scope name at all. Every earlier guard passes.
+        path = self._write(tmp_path, f"{ZACH_TOKEN} zach ,")
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {}, warn=lambda _l: None)
+        assert "empty scope allowlist in token row 1 of 1" in str(exc.value)
+        assert "'zach'" in str(exc.value)
+
+    def test_GUARD_10_a_scope_no_URL_could_name_is_refused(self, tmp_path: Path):
+        # A dot is outside the path-component class, so `kelp.forest` could
+        # never be requested — an allowlist entry that would sit inert forever.
+        # Passes 9: the list is non-empty.
+        path = self._write(tmp_path, f"{ZACH_TOKEN} zach kelp.forest")
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {}, warn=lambda _l: None)
+        assert "invalid scope in token row 1 of 1" in str(exc.value)
+        assert "kelp.forest" in str(exc.value)
+
+    def test_GUARD_10_also_catches_an_EMPTY_entry_inside_a_real_list(
+        self, tmp_path: Path
+    ):
+        """The reachable case guard 9 cannot see: the list is not empty, so
+        `any(...)` is satisfied, and one entry still names nothing.
+        """
+        path = self._write(
+            tmp_path, f"{ZACH_TOKEN} zach {ALLOW_SCOPE},,{DENY_SCOPE}"
+        )
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {}, warn=lambda _l: None)
+        assert "invalid scope in token row 1 of 1" in str(exc.value)
+
+    def test_GUARD_10_also_catches_an_entry_that_FOLDS_AWAY_to_nothing(
+        self, tmp_path: Path
+    ):
+        """🔴 THE HALF THE CHARACTER CLASS CANNOT SEE, and the reason the guard
+        checks the FOLDED value rather than the typed one.
+
+        `-` and `___` are inside `[A-Za-z0-9_-]+`, so they are perfectly namable
+        in a URL — and `normalize_ref` folds both to the EMPTY STRING, which
+        matches no index key. Such an entry is a grant that reads as working and
+        does nothing, which is exactly what this guard's sentence promises to
+        prevent. A guard narrower than its own description is worse than none,
+        because it stops anyone looking.
+        """
+        for typo in ("-", "___", "--"):
+            path = self._write(tmp_path, f"{ZACH_TOKEN} zach {typo}")
+            with pytest.raises(ValueError) as exc:
+                api.load_tokens(path, {}, warn=lambda _l: None)
+            assert "invalid scope in token row 1 of 1" in str(exc.value), typo
+            assert "folds away" in str(exc.value), typo
+
+    def test_GUARD_11_two_rows_naming_ONE_identity_are_refused(self, tmp_path: Path):
+        # Two rows, both well-formed, both with real allowlists — every earlier
+        # guard passes on every row. Only the cross-row check can see this.
+        path = self._write(
+            tmp_path,
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE}",
+            f"{DANA_TOKEN} zach {DENY_SCOPE}",
+        )
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {}, warn=lambda _l: None)
+        assert "duplicate identity 'zach'" in str(exc.value)
+        assert "rows 1 and 2" in str(exc.value)
+
+    def test_a_WELL_FORMED_mapped_file_loads_with_its_allowlist(self, tmp_path: Path):
+        """The positive control for all six guards above. Without it, a parser
+        that rejected EVERYTHING would pass every test in this class.
+        """
+        path = self._write(
+            tmp_path,
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE},{DENY_SCOPE}",
+            f"{DANA_TOKEN} dana {DENY_SCOPE}",
+        )
+        assert loaded(path, {}) == [
+            (ZACH_TOKEN, "zach", (ALLOW_SCOPE, DENY_SCOPE)),
+            (DANA_TOKEN, "dana", (DENY_SCOPE,)),
+        ]
+
+    def test_an_allowlist_entry_is_FOLDED_the_way_the_reader_folds_a_scope(
+        self, tmp_path: Path
+    ):
+        """🔴 An allowlist entry and the index key it must match cannot be
+        allowed to disagree about case or `_` vs `-`: an entry that never
+        matched would be a silently inert grant, which reads as a working one.
+        """
+        path = self._write(tmp_path, f"{ZACH_TOKEN} zach Kelp_Forest")
+        assert loaded(path, {}) == [(ZACH_TOKEN, "zach", (ALLOW_SCOPE,))]
+
+
+class TestLegacyRowsSurviveTheMigration:
+    """🔴 CRITERION 10's REQUIREMENT, WHICH IS WHY THIS IS NOT A PREFERENCE.
+
+    The old shared token has to keep working while clients move onto mapped
+    rows, and the rollback is putting that one line back — a rollback that
+    needed a code change would not be one.
+    """
+
+    def _write(self, tmp_path: Path, *rows: str) -> str:
+        path = tmp_path / "tokens"
+        path.write_text("\n".join(rows) + "\n")
+        return str(path)
+
+    def test_a_MIXED_file_of_legacy_and_mapped_rows_loads(self, tmp_path: Path):
+        path = self._write(
+            tmp_path,
+            GOOD_TOKEN,                            # legacy, unrestricted
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE}",    # mapped
+        )
+        assert loaded(path, {}) == [
+            (GOOD_TOKEN, "legacy", None),
+            (ZACH_TOKEN, "zach", (ALLOW_SCOPE,)),
+        ]
+
+    def test_a_LEGACY_row_reads_EVERY_scope_over_HTTP(self, scoped_store: Path):
+        """The unrestricted half, exercised rather than asserted from the shape:
+        a bare token is served content from a scope no mapped row names.
+        """
+        with running(scoped_store, tokens=(GOOD_TOKEN,)) as (base, _):
+            for scope, nuance in (
+                (ALLOW_SCOPE, KELP_NUANCE),
+                (DENY_SCOPE, QUARTZ_NUANCE),
+                (THIRD_SCOPE, LANTERN_NUANCE),
+            ):
+                code, _h, body = fetch(f"{base}/api/v1/recall/{scope}", token=GOOD_TOKEN)
+                assert code == 200, scope
+                assert nuance.encode() in body, scope
+
+    def test_the_startup_warning_NAMES_legacy_mode_and_its_fingerprints(
+        self, tmp_path: Path
+    ):
+        """🔴 A one-line, loud, greppable statement that the store is running
+        with an unrestricted credential. Without it "the migration is finished"
+        is a guess, which is the same failure the `token=` fingerprint exists to
+        stop for rotation.
+        """
+        path = self._write(
+            tmp_path, GOOD_TOKEN, f"{ZACH_TOKEN} zach {ALLOW_SCOPE}"
+        )
+        warnings: list[str] = []
+        api.load_tokens(path, {}, warn=warnings.append)
+        assert len(warnings) == 1, warnings
+        line = warnings[0]
+        assert "LEGACY MODE" in line
+        assert "1 of 2" in line
+        assert api.token_id(GOOD_TOKEN) in line
+        # NEGATIVE CONTROL on the same line: the mapped row is not legacy, so
+        # its fingerprint must NOT be named as unrestricted.
+        assert api.token_id(ZACH_TOKEN) not in line
+        # …and never a credential.
+        assert GOOD_TOKEN not in line and ZACH_TOKEN not in line
+
+    def test_NO_warning_when_EVERY_row_is_mapped(self, tmp_path: Path):
+        """🔴 THE POSITIVE CONTROL'S PARTNER. A warner that fires unconditionally
+        would pass the test above and teach the operator to ignore the line.
+        """
+        path = self._write(
+            tmp_path,
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE}",
+            f"{DANA_TOKEN} dana {DENY_SCOPE}",
+        )
+        warnings: list[str] = []
+        api.load_tokens(path, {}, warn=warnings.append)
+        assert warnings == []
+
+
+class TestEnumerationChannelsAreClosed:
+    """🔴 FOUR CHANNELS, MEASURED ON THE DEPLOYED POD, EACH WITH ITS OWN TEST.
+
+    A per-route "is this scope yours" check would close NONE of the first three:
+    they all fire on requests for a scope the caller IS allowed, or on a request
+    that names no scope at all. Every test here drives `zach`, whose allowlist
+    is `ALLOW_SCOPE` alone, and asserts on the names and CONTENT of the two
+    scopes he may not see.
+    """
+
+    def test_CHANNEL_1_known_scopes_names_only_the_callers_own(
+        self, scoped_store: Path
+    ):
+        """`scope-absent` renders "scopes the store does hold: …". At base that
+        sentence enumerated the whole store to anybody holding any token.
+        """
+        with running(scoped_store, tokens=(ZACH,)) as (base, _):
+            code, headers, body = fetch(
+                f"{base}/api/v1/recall/{PHANTOM_SCOPE}", token=ZACH_TOKEN
+            )
+        assert code == 200
+        assert headers["X-Store-Status"] == "scope-absent"
+        text = body.decode()
+        assert ALLOW_SCOPE in text, "the caller's own scope vanished — over-filtered"
+        assert DENY_SCOPE not in text
+        assert THIRD_SCOPE not in text
+
+    def test_CHANNEL_2_malformed_elsewhere_names_no_denied_scope(
+        self, scoped_store: Path
+    ):
+        """🔴 THE CHANNEL THAT FIRES ON A SUCCESSFUL READ. The "(+N further
+        malformed entries in OTHER scopes …)" block is rendered on EVERY status,
+        so this leaks on a perfectly ordinary 200 for a scope the caller owns —
+        no miss, nothing refused, nothing to notice.
+        """
+        with running(scoped_store, tokens=(ZACH,)) as (base, _):
+            code, headers, body = fetch(
+                f"{base}/api/v1/recall/{ALLOW_SCOPE}", token=ZACH_TOKEN
+            )
+        assert code == 200
+        assert headers["X-Store-Status"] == "recalled"
+        text = body.decode()
+        assert KELP_NUANCE in text, "the caller's own content vanished"
+        assert DENY_SCOPE not in text
+        assert "broken-shard" not in text
+
+    def test_CHANNEL_2_POSITIVE_CONTROL_a_legacy_token_DOES_see_it(
+        self, scoped_store: Path
+    ):
+        """🔴 WITHOUT THIS THE TEST ABOVE IS A ZERO FROM A CHECK THAT MIGHT SEE
+        NOTHING. The fixture must actually PRODUCE a `malformed_elsewhere` block
+        naming the denied scope, or "the name is absent" is satisfied by a
+        renderer that never emits the block at all.
+        """
+        with running(scoped_store, tokens=(GOOD_TOKEN,)) as (base, _):
+            _c, _h, body = fetch(
+                f"{base}/api/v1/recall/{ALLOW_SCOPE}", token=GOOD_TOKEN
+            )
+        assert DENY_SCOPE in body.decode(), (
+            "the fixture produced no cross-scope malformed block, so the "
+            "negative assertion above proves nothing"
+        )
+
+    def test_CHANNEL_3_all_scopes_search_narrows_to_the_callers_own(
+        self, scoped_store: Path
+    ):
+        """🔴 THE ONE A PER-SCOPE CHECK STRUCTURALLY CANNOT COVER. `?all_scopes=1`
+        NAMES NO SCOPE, so there is nothing for such a check to refuse — it
+        searches the CONTENT of every scope in the store.
+        """
+        with running(scoped_store, tokens=(ZACH,)) as (base, _):
+            code, _h, body = fetch(
+                f"{base}/api/v1/search/{ALLOW_SCOPE}?q=drill+head+overheats"
+                f"&all_scopes=1",
+                token=ZACH_TOKEN,
+            )
+        assert code == 200
+        text = body.decode()
+        assert QUARTZ_NUANCE not in text
+        assert DENY_SCOPE not in text
+        assert THIRD_SCOPE not in text
+
+    def test_CHANNEL_3_POSITIVE_CONTROL_a_legacy_token_DOES_find_it(
+        self, scoped_store: Path
+    ):
+        """The query has to be one that HITS, or the narrowed search is
+        indistinguishable from a query nothing matches.
+        """
+        with running(scoped_store, tokens=(GOOD_TOKEN,)) as (base, _):
+            code, headers, body = fetch(
+                f"{base}/api/v1/search/{ALLOW_SCOPE}?q=drill+head+overheats"
+                f"&all_scopes=1",
+                token=GOOD_TOKEN,
+            )
+        assert code == 200
+        assert headers["X-Store-Status"] == "search-hit"
+        assert QUARTZ_NUANCE in body.decode()
+
+    def test_CHANNEL_4_the_snapshot_tar_carries_only_allowed_members(
+        self, scoped_store: Path
+    ):
+        """🔴 ASSERTED OVER EXTRACTED MEMBER NAMES, NOT A STATUS CODE. This route
+        never builds an index, so the filter that closes channels 1-3 does not
+        reach it; a 200 here says nothing about what is inside the archive.
+        """
+        with running(scoped_store, tokens=(ZACH,)) as (base, _):
+            code, headers, body = fetch(f"{base}/api/v1/snapshot", token=ZACH_TOKEN)
+        assert code == 200
+        with tarfile.open(fileobj=io.BytesIO(body), mode="r") as tar:
+            names = sorted(tar.getnames())
+        assert names == [f"{ALLOW_SCOPE}/{ALLOW_SCOPE}-entry.md"], names
+        # The server's own count must describe the same filtered set, or
+        # `cairn::install_snapshot`'s mismatch check refuses every scoped pull.
+        assert headers["X-Store-Entries"] == "1"
+
+    def test_CHANNEL_4_POSITIVE_CONTROL_a_legacy_token_gets_every_member(
+        self, scoped_store: Path
+    ):
+        with running(scoped_store, tokens=(GOOD_TOKEN,)) as (base, _):
+            code, headers, body = fetch(f"{base}/api/v1/snapshot", token=GOOD_TOKEN)
+        assert code == 200
+        with tarfile.open(fileobj=io.BytesIO(body), mode="r") as tar:
+            names = sorted(tar.getnames())
+        assert names == sorted(
+            [f"{s}/{s}-entry.md" for s in (ALLOW_SCOPE, DENY_SCOPE, THIRD_SCOPE)]
+            + [f"{DENY_SCOPE}/broken-shard.md"]
+        ), names
+        assert headers["X-Store-Entries"] == "4"
+
+    def test_a_scope_FILTERED_snapshot_of_a_denied_scope_ships_nothing(
+        self, scoped_store: Path
+    ):
+        """`?scope=` reaches the filesystem directly, so it is its own door into
+        the same store — and it must answer for a denied scope exactly what it
+        answers for one that never existed.
+        """
+        with running(scoped_store, tokens=(ZACH,)) as (base, _):
+            denied = fetch(
+                f"{base}/api/v1/snapshot?scope={DENY_SCOPE}", token=ZACH_TOKEN
+            )
+            phantom = fetch(
+                f"{base}/api/v1/snapshot?scope={PHANTOM_SCOPE}", token=ZACH_TOKEN
+            )
+        assert denied[0] == phantom[0] == 200
+        assert denied[1]["X-Store-Entries"] == phantom[1]["X-Store-Entries"] == "0"
+        for body in (denied[2], phantom[2]):
+            with tarfile.open(fileobj=io.BytesIO(body), mode="r") as tar:
+                assert tar.getnames() == []
+
+    def test_TWO_TOKENS_ON_ONE_SERVER_each_see_only_their_own(
+        self, scoped_store: Path
+    ):
+        """🔴 THE SEAM, NOT THE COMPONENT. Both records are configured on ONE
+        server, so this fails if the allowlist is resolved from anything other
+        than the record that authenticated THIS request — a module-level cache,
+        the first configured row, or a value left on the handler by the previous
+        request on a keep-alive connection.
+        """
+        with running(scoped_store, tokens=(ZACH, DANA)) as (base, audit):
+            zach_own = fetch(f"{base}/api/v1/recall/{ALLOW_SCOPE}", token=ZACH_TOKEN)
+            zach_other = fetch(f"{base}/api/v1/recall/{DENY_SCOPE}", token=ZACH_TOKEN)
+            dana_own = fetch(f"{base}/api/v1/recall/{DENY_SCOPE}", token=DANA_TOKEN)
+            dana_other = fetch(f"{base}/api/v1/recall/{ALLOW_SCOPE}", token=DANA_TOKEN)
+
+        assert zach_own[1]["X-Store-Status"] == "recalled"
+        assert KELP_NUANCE.encode() in zach_own[2]
+        assert dana_own[1]["X-Store-Status"] == "recalled"
+        assert QUARTZ_NUANCE.encode() in dana_own[2]
+        # …and each is told the OTHER's scope does not exist.
+        assert zach_other[1]["X-Store-Status"] == "scope-absent"
+        assert dana_other[1]["X-Store-Status"] == "scope-absent"
+        assert QUARTZ_NUANCE.encode() not in zach_other[2]
+        assert KELP_NUANCE.encode() not in dana_other[2]
+        # The audit line says WHOSE request each was, which is the only record
+        # that can answer "who read what" after the fact.
+        assert "identity=zach" in audit[0] and "identity=zach" in audit[1]
+        assert "identity=dana" in audit[2] and "identity=dana" in audit[3]
+
+    def test_the_audit_line_still_carries_the_FINGERPRINT_not_only_the_identity(
+        self, scoped_store: Path
+    ):
+        """🔴 `identity=` is ADDITIVE. Overlap rotation is checkable only through
+        `token=`: two rows can hold one holder's current and previous credential,
+        and the identity cannot tell them apart.
+        """
+        with running(scoped_store, tokens=(ZACH,)) as (base, audit):
+            fetch(f"{base}/api/v1/recall/{ALLOW_SCOPE}", token=ZACH_TOKEN)
+        assert f"token={api.token_id(ZACH_TOKEN)}" in audit[0]
+        assert "identity=zach" in audit[0]
+        assert "auth=ok" in audit[0]
+        assert ZACH_TOKEN not in audit[0]
+
+    def test_a_REJECTED_request_names_no_identity(self, scoped_store: Path):
+        with running(scoped_store, tokens=(ZACH,)) as (base, audit):
+            fetch(f"{base}/api/v1/recall/{ALLOW_SCOPE}", token="w" * 48)
+        assert "identity=-" in audit[0]
+        assert "auth=fail" in audit[0]
+
+
+class TestRefusedIsIndistinguishableFromAbsent:
+    """🔴 CRITERION 3, PROVEN RATHER THAN ASSUMED — and the comparison is built
+    so that scope EXISTENCE is the only thing that varies.
+
+    Two responses to `recall/<DENY_SCOPE>` from the SAME token at the SAME store
+    path: once when that scope holds an entry, once when it never existed. The
+    entry-file COUNT and the newest mtime are held constant across the two (the
+    scope is rebuilt under a different name), because `X-Store-Snapshot` is
+    store-wide and would otherwise differ for a reason that is not the one under
+    test. See the module docstring's residual-leak note.
+    """
+
+    def _phases(self, tmp_path: Path):
+        """Yields a builder for phase A (denied scope present) and phase B (it
+        never existed), both at ONE path so `  store: <root>` cannot differ."""
+        root = tmp_path / "store"
+
+        def present():
+            if root.exists():
+                shutil.rmtree(root)
+            return _build_store(
+                root, {ALLOW_SCOPE: KELP_NUANCE, DENY_SCOPE: QUARTZ_NUANCE}
+            )
+
+        def absent():
+            shutil.rmtree(root)
+            # Same file COUNT, same mtimes, different scope name — so the only
+            # fact that moved is whether DENY_SCOPE is on disk.
+            return _build_store(
+                root, {ALLOW_SCOPE: KELP_NUANCE, THIRD_SCOPE: LANTERN_NUANCE}
+            )
+
+        return root, present, absent
+
+    def _ask(self, root: Path, token, path: str):
+        with running(root, tokens=(token,)) as (base, _):
+            code, headers, body = fetch(
+                f"{base}{path}",
+                token=token.token if hasattr(token, "token") else token,
+            )
+        store_headers = tuple(
+            sorted((k, v) for k, v in headers.items() if k.lower().startswith("x-store"))
+        )
+        return code, store_headers, body
+
+    def test_RECALL_a_refused_scope_is_BYTE_IDENTICAL_to_one_that_never_existed(
+        self, tmp_path: Path
+    ):
+        root, present, absent = self._phases(tmp_path)
+        present()
+        refused = self._ask(root, ZACH, f"/api/v1/recall/{DENY_SCOPE}")
+        absent()
+        never = self._ask(root, ZACH, f"/api/v1/recall/{DENY_SCOPE}")
+
+        assert refused[0] == never[0] == 200
+        assert refused[1] == never[1], (
+            f"X-Store-* headers differ:\n refused={refused[1]}\n absent ={never[1]}"
+        )
+        assert refused[2] == never[2], (
+            "response bodies differ — a refused scope is distinguishable from an "
+            "absent one:\n"
+            f"refused: {refused[2]!r}\nabsent : {never[2]!r}"
+        )
+        # 🔴 And the shared answer is the ABSENT report, not two identical
+        # errors: byte-identity between two 401s or two 503s would satisfy
+        # everything above while serving nothing.
+        assert dict(refused[1])["X-Store-Status"] == "scope-absent"
+        assert b"NOTHING RECORDED YET" in refused[2].upper()
+        assert QUARTZ_NUANCE.encode() not in refused[2]
+
+    def test_SEARCH_a_refused_scope_is_BYTE_IDENTICAL_to_one_that_never_existed(
+        self, tmp_path: Path
+    ):
+        root, present, absent = self._phases(tmp_path)
+        query = f"/api/v1/search/{DENY_SCOPE}?q=drill+head+overheats"
+        present()
+        refused = self._ask(root, ZACH, query)
+        absent()
+        never = self._ask(root, ZACH, query)
+
+        assert refused[0] == never[0] == 200
+        assert refused[1] == never[1], f"{refused[1]} != {never[1]}"
+        assert refused[2] == never[2]
+        assert dict(refused[1])["X-Store-Status"] == "scope-absent"
+
+    def test_POSITIVE_CONTROL_the_comparison_CAN_see_the_difference(
+        self, tmp_path: Path
+    ):
+        """🔴 WITHOUT THIS, BOTH TESTS ABOVE ARE SATISFIED BY A SERVER THAT
+        ANSWERS THE SAME BYTES TO EVERYTHING.
+
+        The same two phases, driven by an UNRESTRICTED legacy token: present ->
+        `recalled` with the entry's content, absent -> `scope-absent`. If this
+        pair did not differ, the equality above would be measuring the harness
+        rather than the fix.
+        """
+        root, present, absent = self._phases(tmp_path)
+        present()
+        seen = self._ask(root, GOOD_TOKEN, f"/api/v1/recall/{DENY_SCOPE}")
+        absent()
+        gone = self._ask(root, GOOD_TOKEN, f"/api/v1/recall/{DENY_SCOPE}")
+
+        assert dict(seen[1])["X-Store-Status"] == "recalled"
+        assert dict(gone[1])["X-Store-Status"] == "scope-absent"
+        assert seen[2] != gone[2]
+        assert QUARTZ_NUANCE.encode() in seen[2]
+
+
+class TestScopeRevisionIsGatedByConstruction:
+    """🔴 THE ONE HEADER THE INDEX FILTER CANNOT REACH.
+
+    `X-Store-Revision` is read off `<store>/<scope>/.git/HEAD`, a path the index
+    knows nothing about. Today no scope in the served copy is a git repo, so it
+    answers "unknown" for everything and the leak is LATENT — which is exactly
+    the state in which a guard gets skipped. So the fixture MAKES a denied scope
+    a real repo and asserts the header still cannot tell it from an absent one.
+    """
+
+    def _git(self, path: Path, *args: str):
+        subprocess.run(
+            ["git", "-C", str(path), *args],
+            check=True,
+            capture_output=True,
+            env={**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "HOME": str(path),
+                 **hermetic_git.MAINTENANCE_OFF},
+        )
+
+    def _repo(self, store: Path, scope: str) -> str:
+        scope_dir = store / scope
+        self._git(scope_dir, "init", "-q", "-b", "main")
+        self._git(scope_dir, "config", "user.email", "t@example.invalid")
+        self._git(scope_dir, "config", "user.name", "T")
+        self._git(scope_dir, "add", f"{scope}-entry.md")
+        self._git(scope_dir, "commit", "-qm", "seed")
+        return subprocess.run(
+            ["git", "-C", str(scope_dir), "rev-parse", "HEAD"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+    def test_POSITIVE_CONTROL_the_fixture_really_is_a_repo_and_the_header_shows_it(
+        self, scoped_store: Path
+    ):
+        """A "the header said unknown" assertion is worthless against a fixture
+        that could never have produced a sha. This proves it could.
+        """
+        head = self._repo(scoped_store, DENY_SCOPE)
+        assert len(head) == 40
+        assert api.scope_revision(scoped_store, DENY_SCOPE) == head
+        with running(scoped_store, tokens=(GOOD_TOKEN,)) as (base, _):
+            _c, headers, _b = fetch(
+                f"{base}/api/v1/recall/{DENY_SCOPE}", token=GOOD_TOKEN
+            )
+        assert headers["X-Store-Revision"] == head
+
+    def test_a_DENIED_scopes_revision_is_unknown_even_though_it_HAS_one(
+        self, scoped_store: Path
+    ):
+        head = self._repo(scoped_store, DENY_SCOPE)
+        assert api.scope_revision(
+            scoped_store, DENY_SCOPE, visible_scopes=(ALLOW_SCOPE,)
+        ) == "unknown"
+        with running(scoped_store, tokens=(ZACH,)) as (base, _):
+            _c, denied, _b = fetch(
+                f"{base}/api/v1/recall/{DENY_SCOPE}", token=ZACH_TOKEN
+            )
+            _c2, phantom, _b2 = fetch(
+                f"{base}/api/v1/recall/{PHANTOM_SCOPE}", token=ZACH_TOKEN
+            )
+        assert denied["X-Store-Revision"] == "unknown"
+        assert denied["X-Store-Revision"] == phantom["X-Store-Revision"]
+        assert head not in denied["X-Store-Revision"]
+
+    def test_the_callers_OWN_scope_still_reports_its_sha(self, scoped_store: Path):
+        """🔴 OVER-FILTERING IS ALSO A FAILURE. A gate that answered "unknown"
+        for everything would pass the test above and silently delete the
+        determinism guarantee `scope@sha` exists for.
+        """
+        head = self._repo(scoped_store, ALLOW_SCOPE)
+        with running(scoped_store, tokens=(ZACH,)) as (base, _):
+            _c, headers, _b = fetch(
+                f"{base}/api/v1/recall/{ALLOW_SCOPE}", token=ZACH_TOKEN
+            )
+        assert headers["X-Store-Revision"] == head
+
+    def test_visible_scopes_None_is_UNRESTRICTED_matching_every_other_seam(
+        self, scoped_store: Path
+    ):
+        head = self._repo(scoped_store, DENY_SCOPE)
+        assert api.scope_revision(scoped_store, DENY_SCOPE, visible_scopes=None) == head
+        # …and an EMPTY sequence is the opposite, not a synonym for None.
+        assert api.scope_revision(
+            scoped_store, DENY_SCOPE, visible_scopes=()
+        ) == "unknown"
+
+
+class TestTheReaderNarrowingItself:
+    """`load_store`'s `visible_scopes`, unit-level — the one site both readers
+    take their index from, so this is where over- and under-filtering show up
+    without an HTTP layer in the way.
+    """
+
+    def test_None_is_unrestricted_and_an_EMPTY_SEQUENCE_is_the_opposite(
+        self, scoped_store: Path
+    ):
+        """🔴 THE ASYMMETRY, PINNED. `None` and `()` are both falsy, so a guard
+        written `if visible_scopes:` would treat an empty allowlist as
+        unrestricted — a total bypass that every functional test with a
+        populated allowlist would pass.
+        """
+        _s, wide = api.rc.load_store(scoped_store, verb="recalled")
+        assert set(wide.scopes) == {ALLOW_SCOPE, DENY_SCOPE, THIRD_SCOPE}
+        _s, none_visible = api.rc.load_store(
+            scoped_store, verb="recalled", visible_scopes=()
+        )
+        assert none_visible.scopes == ()
+        assert len(none_visible) == 0
+        assert none_visible.malformed == ()
+
+    def test_the_MALFORMED_tuple_is_narrowed_beside_by_scope(
+        self, scoped_store: Path
+    ):
+        """Both public fields, or `malformed_outside` still names a denied scope
+        while `scopes` does not — the half-fix that reads as a whole one.
+        """
+        _s, wide = api.rc.load_store(scoped_store, verb="recalled")
+        assert [m.scope for m in wide.malformed] == [DENY_SCOPE]
+        _s, narrow = api.rc.load_store(
+            scoped_store, verb="recalled", visible_scopes=(ALLOW_SCOPE,)
+        )
+        assert narrow.scopes == (ALLOW_SCOPE,)
+        assert narrow.malformed == ()
+        assert narrow.malformed_outside((ALLOW_SCOPE,)) == ()
+
+    def test_an_allowlist_entry_is_normalised_against_the_index_key(
+        self, scoped_store: Path
+    ):
+        _s, narrow = api.rc.load_store(
+            scoped_store, verb="recalled", visible_scopes=("Kelp_Forest",)
+        )
+        assert narrow.scopes == (ALLOW_SCOPE,)
+
+    def test_an_UNREADABLE_store_still_RAISES_rather_than_narrowing_to_empty(
+        self, tmp_path: Path
+    ):
+        """🔴 THE FOUR-STATE RULE SURVIVES THE FILTER. `store-unreachable` and
+        "you may see nothing" both produce an empty index; only the first may be
+        a raise, and collapsing them is the exact conflation this whole module
+        exists to prevent. A filter applied BEFORE the load would have done it.
+        """
+        with pytest.raises(api.rc.StoreMissingError):
+            api.rc.load_store(
+                tmp_path / "absent", verb="recalled", visible_scopes=(ALLOW_SCOPE,)
+            )
+
+    def test_recall_and_search_BOTH_take_the_narrowing(self, scoped_store: Path):
+        """One kwarg, two callers — and a threading bug that reached only one of
+        them would leave `/search` wide open while `/recall` looked fixed.
+        """
+        rep = api.rc.recall(
+            scoped_store, DENY_SCOPE, visible_scopes=(ALLOW_SCOPE,)
+        )
+        assert rep.status == "scope-absent"
+        assert rep.known_scopes == (ALLOW_SCOPE,)
+        sea = api.rc.search(
+            scoped_store, ALLOW_SCOPE, "drill head overheats",
+            all_scopes=True, visible_scopes=(ALLOW_SCOPE,),
+        )
+        assert sea.scopes_searched == (ALLOW_SCOPE,)
+        assert sea.known_scopes == (ALLOW_SCOPE,)
+        assert sea.total_hits == 0
+
+    def test_the_CLI_DEFAULT_is_still_unrestricted(self, scoped_store: Path):
+        """The local reader must not have acquired an allowlist by accident:
+        `cairn` and `/resume` call these with no such argument and read the whole
+        store, and a default of `()` here would empty every local recall.
+        """
+        assert api.rc.recall(scoped_store, DENY_SCOPE).status == "recalled"
+        assert set(api.rc.recall(scoped_store, ALLOW_SCOPE).known_scopes) == {
+            ALLOW_SCOPE, DENY_SCOPE, THIRD_SCOPE
+        }
+
+
+class TestScopeFilteringIsNotAWriteVerb:
+    """🔴 CRITERIA 4-10 ARE NOT IN THIS BRANCH, AND THAT IS ASSERTED, NOT SAID.
+
+    `TestPhaseOneScope` already pins the write guard and the route ledger; this
+    is the same claim restated for the change that landed here, so a future
+    branch that adds a verb "while it is touching auth anyway" fails a test in
+    the section that added scoping.
+    """
+
+    def test_the_route_set_did_NOT_grow(self):
+        assert set(api.API_ROUTES) == {"recall", "search", "snapshot"}
+
+    def test_every_write_verb_is_STILL_405_with_a_valid_SCOPED_token(
+        self, scoped_store: Path
+    ):
+        with running(scoped_store, tokens=(ZACH,)) as (base, _):
+            for method in ("POST", "PUT", "PATCH", "DELETE"):
+                code, _h, body = fetch(
+                    f"{base}/api/v1/recall/{ALLOW_SCOPE}",
+                    token=ZACH_TOKEN,
+                    method=method,
+                )
+                assert code == 405, f"{method} answered {code}"
+                assert body == b"read-only\n"
+
+    def test_a_full_scoped_read_workload_leaves_the_store_BYTE_IDENTICAL(
+        self, scoped_store: Path
+    ):
+        before = tree_hash(scoped_store)
+        with running(scoped_store, tokens=(ZACH, DANA)) as (base, _):
+            for token in (ZACH_TOKEN, DANA_TOKEN):
+                for path in (
+                    f"/api/v1/recall/{ALLOW_SCOPE}",
+                    f"/api/v1/recall/{DENY_SCOPE}",
+                    f"/api/v1/recall/{PHANTOM_SCOPE}",
+                    f"/api/v1/search/{ALLOW_SCOPE}?q=tide&all_scopes=1",
+                    "/api/v1/snapshot",
+                ):
+                    fetch(f"{base}{path}", token=token)
+        assert tree_hash(scoped_store) == before

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -1011,20 +1011,28 @@ class TestReadOnlyPhase1:
 #
 # 🔴 THE LOADER COLUMN IS THE NARROW RULING, CELL BY CELL. It refuses exactly
 # `broken-link` (the Emacs `.#entry.md` lock file, which used to 503 the whole
-# store) and `other` (the fifo, which used to HANG the request thread), and
-# TAKES everything else — most pointedly `link-to-file`, which the loader has
-# always read. Copying the `_ENTRY_ACTIONS` column wholesale is the over-broad
-# form that was explicitly rejected, and flipping any TAKE here to REFUSE is a
-# behaviour change for ordinary callers; every one of those flips is a mutant
-# this column kills.
+# store) and the two shapes of "an `open()` on this never returns" — `other`
+# (the fifo itself) and `link-to-other` (a symlink pointing at one), each of
+# which was measured HANGING the request thread. It TAKES everything else —
+# most pointedly `link-to-file`, which the loader has always read. Copying the
+# `_ENTRY_ACTIONS` column wholesale is the over-broad form that was explicitly
+# rejected, and flipping any remaining TAKE here to REFUSE is a behaviour change
+# for ordinary callers; every one of those flips is a mutant this column kills.
 DECISION_TABLE = [
     ("KIND_BROKEN_LINK", "REFUSE", "REFUSE", "REFUSE"),
     ("KIND_LINK_TO_DIR", "REFUSE", "REFUSE", "TAKE"),
     ("KIND_LINK_TO_FILE", "SKIP", "REFUSE", "TAKE"),
-    # ⚠ A symlink POINTING AT a fifo is the same hang in a different shape, and
-    # is left TAKE by the narrow ruling. Pinned as the residual it is, so a
-    # future decision to close it is a deliberate edit here.
-    ("KIND_LINK_TO_OTHER", "SKIP", "REFUSE", "TAKE"),
+    # 🔴 CLOSED, AND IT WAS THE SAME DEFECT — NOT A LESSER ONE. This cell was
+    # `TAKE` for one round, pinned as a named residual because the ruling that
+    # created the loader column named `other` and `broken-link` and nothing
+    # else. Then it was MEASURED on that tip: a `link-to-fifo.md` symlink in a
+    # scope the caller never asked for wedged `GET /api/v1/recall/<other-scope>`
+    # for 25s under an UNRESTRICTED legacy token — the request thread gone, on a
+    # `replicas: 1` / `strategy: Recreate` service. `open()` blocks identically
+    # whether the fifo is reached directly or through a link, so the loader
+    # column now refuses BOTH shapes of it. `link-to-file` stays `TAKE` — that
+    # is still the upper bound, and still the point of the narrow form.
+    ("KIND_LINK_TO_OTHER", "SKIP", "REFUSE", "REFUSE"),
     ("KIND_DIRECTORY", "TAKE", "REFUSE", "TAKE"),
     ("KIND_REGULAR_FILE", "SKIP", "TAKE", "TAKE"),
     ("KIND_OTHER", "SKIP", "REFUSE", "REFUSE"),
@@ -1168,6 +1176,30 @@ class TestClassifierIsTotal:
         assert api._ROOT_ACTIONS[k] == getattr(api, expected_root)
         assert api._ENTRY_ACTIONS[k] == getattr(api, expected_entry)
         assert resolver._LOADER_ENTRY_ACTIONS[k] == getattr(api, expected_loader)
+
+    def test_every_REFUSED_loader_kind_HAS_a_reason_and_no_other_kind_does(self):
+        """🔴 THE SEAM BETWEEN THE TWO DICTS, which nothing else reads together.
+
+        `load_index` looks the reason up by `_LOADER_REFUSAL_REASON[kind]` —
+        an unguarded subscript — so flipping a cell to REFUSE without writing
+        its sentence turns a hostile entry into a `KeyError` out of the loader:
+        a 500 with no `X-Store-Status`, for a shape whose whole fix was to make
+        it a NAMED malformed row. That is how the `link-to-other` cell would
+        have landed, and reviewing the table alone cannot see it.
+
+        Asserted as SET EQUALITY, not containment, so it fails when the ledger
+        GROWS as well as when it shrinks — a reason left behind for a kind that
+        went back to TAKE is dead prose claiming a guard that is gone.
+        """
+        refused = {
+            k
+            for k, action in resolver._LOADER_ENTRY_ACTIONS.items()
+            if action == api.REFUSE
+        }
+        assert refused == set(resolver._LOADER_REFUSAL_REASON), (
+            "the loader's REFUSE cells and its refusal sentences have drifted"
+        )
+        assert refused == {api.KIND_BROKEN_LINK, api.KIND_OTHER, api.KIND_LINK_TO_OTHER}
 
     def test_classify_returns_the_right_kind_for_each_REAL_path(self, tmp_path: Path):
         """🔴 The table above is only meaningful if `classify_path` actually
@@ -7364,8 +7396,13 @@ class TestUnreadableEntriesInDeniedScopes:
         or it becomes a test pinning the bug.
 
         What keeps the timeout meaningful instead is
-        `test_a_TAKEN_kind_still_HANGS_which_is_why_the_REFUSE_cells_exist`
-        below: the same machinery, aimed at a kind the loader still TAKES.
+        `test_a_SYMLINK_to_a_FIFO_no_longer_HANGS_and_the_DEADLINE_still_SEES_one`
+        below. ⚠ That test's control had to be re-aimed too: it used to point at
+        `link-to-other`, a kind the loader still TAKES — and it does not any
+        more, because that shape was measured wedging a live request thread for
+        25s. No remaining TAKE cell blocks, so the control is now a bare
+        `open()` of the fifo itself, which is the syscall in question rather
+        than a proxy for it.
         """
         store = self._store(tmp_path, "fifo")
         probe = (
@@ -7409,25 +7446,38 @@ class TestUnreadableEntriesInDeniedScopes:
         assert f"SCOPES={ALLOW_SCOPE},{DENY_SCOPE}\n" in unrestricted.stdout
         assert f"MALFORMED={DENY_SCOPE}/{LOCKED_ENTRY}\n" in unrestricted.stdout
 
-    def test_a_TAKEN_kind_still_HANGS_which_is_why_the_REFUSE_cells_exist(
+    def test_a_SYMLINK_to_a_FIFO_no_longer_HANGS_and_the_DEADLINE_still_SEES_one(
         self, tmp_path: Path
     ):
-        """🔴 THE POSITIVE CONTROL FOR THE PROBE ITSELF, and the honest record of
-        the `link-to-other` residual in one test.
+        """🔴 THE SECOND INVERSION, AND THE PROBE'S OWN POSITIVE CONTROL, in one
+        test — because the two have to move together.
 
-        Every assertion in the test above is now "it did NOT hang", which is
-        exactly the reassuring zero `claude/RULES.md` calls indistinguishable
-        from a harness wired to nothing: a probe that crashed on import, or a
-        fixture that made no FIFO, would satisfy all of them. So this drives the
-        SAME probe at a store whose hostile entry is a SYMLINK POINTING AT a
-        fifo — `link-to-other`, which the narrow ruling leaves `TAKE` — and
-        watches it block.
+        This test used to be
+        `test_a_TAKEN_kind_still_HANGS_which_is_why_the_REFUSE_cells_exist`, and
+        asserted that a symlink POINTING AT a fifo blocks the reader forever. It
+        was the honest record of the `link-to-other` residual the narrow ruling
+        left open, and simultaneously the positive control proving the deadline
+        machinery can observe a hang at all.
 
-        It therefore asserts two things at once: the deadline machinery can
-        still observe a hang, and the one shape the narrow guard does not cover
-        is genuinely uncovered. Closing that residual means flipping ONE cell of
-        `_LOADER_ENTRY_ACTIONS`, and this test is what will go red and tell
-        whoever does it to update the table pin.
+        The residual was then MEASURED rather than reasoned about: on the tip
+        that carried it, an unrestricted (bare legacy) `GET
+        /api/v1/recall/<scope>` against a store holding one `link-to-fifo.md` in
+        a DIFFERENT scope wedged for 25s and the request thread never came back,
+        while `/healthz` answered 200 throughout — so the process was up and the
+        worker was gone. `open()` blocks the same whether the fifo is reached
+        directly or through a link. The cell is now REFUSE, so the same input
+        must assert the opposite: complete, load both scopes, and REPORT the
+        link as a malformed entry.
+
+        🔴 AND THAT LEAVES A HOLE THIS TEST MUST FILL ITSELF. Every timing
+        assertion in the class is now "it did NOT hang", which is the reassuring
+        zero `claude/RULES.md` calls indistinguishable from a harness wired to
+        nothing — and no kind the loader still TAKES blocks, so the old control
+        cannot simply be re-aimed at another cell. The control below therefore
+        drives the SAME deadline machinery at a bare `open()` of the SAME fifo,
+        which must blow it. A fixture that made no real fifo, or a subprocess
+        runner that never blocks, fails there and takes the vacuous green with
+        it.
         """
         store = _build_store(
             tmp_path / "store",
@@ -7435,32 +7485,56 @@ class TestUnreadableEntriesInDeniedScopes:
         )
         real_fifo = tmp_path / "a-real-fifo"
         os.mkfifo(real_fifo)
-        os.symlink(real_fifo, store / DENY_SCOPE / LOCKED_ENTRY)
-        assert api.classify_path(store / DENY_SCOPE / LOCKED_ENTRY) == (
-            api.KIND_LINK_TO_OTHER
-        ), "the fixture is not the kind this test is about"
+        link = store / DENY_SCOPE / LOCKED_ENTRY
+        os.symlink(real_fifo, link)
+        assert api.classify_path(link) == api.KIND_LINK_TO_OTHER, (
+            "the fixture is not the kind this test is about"
+        )
+
+        def under_deadline(source: str, seconds: float):
+            """The completed process, or `None` meaning it blew the deadline."""
+            try:
+                return subprocess.run(
+                    [sys.executable, "-c", source],
+                    capture_output=True, text=True, timeout=seconds,
+                )
+            except subprocess.TimeoutExpired:
+                return None
+
+        # 🔴 THE POSITIVE CONTROL FIRST, so a runner that cannot observe a block
+        # fails before the assertion that depends on it means anything. A bare
+        # `open()` of the fifo — no store, no loader — is the syscall the guard
+        # exists to keep the request thread out of.
+        blocked = under_deadline(
+            f"open({str(real_fifo)!r}); print('OPENED')", 10.0
+        )
+        assert blocked is None, (
+            "a bare `open()` of the fifo RETURNED, so this fixture is not a "
+            "blocking fifo and the deadline below measures nothing — every "
+            "'it did not hang' assertion in this class would be vacuous. "
+            f"stdout={None if blocked is None else blocked.stdout!r}"
+        )
 
         probe = (
             "import sys;"
             f"sys.path.insert(0, {str(RECALL_PATH.parent)!r});"
             "import subsystem_recall as rc;"
-            f"rc.load_store({str(store)!r}, verb='recalled');"
-            "print('LOADED')"
+            f"_s, i = rc.load_store({str(store)!r}, verb='recalled');"
+            "print('SCOPES=' + ','.join(i.scopes));"
+            "print('MALFORMED=' + ','.join(m.label for m in i.malformed))"
         )
-        try:
-            done = subprocess.run(
-                [sys.executable, "-c", probe],
-                capture_output=True, text=True, timeout=15.0,
-            )
-        except subprocess.TimeoutExpired:
-            done = None
-        assert done is None, (
-            "a symlink-to-FIFO entry did NOT block the reader. Either the guard "
-            "was widened to cover `link-to-other` — in which case flip that cell "
-            "in DECISION_TABLE and re-aim this test — or this probe is no longer "
-            "measuring anything, which would make every 'it did not hang' "
-            f"assertion above vacuous. stdout={None if done is None else done.stdout!r}"
+        done = under_deadline(probe, 30.0)
+        assert done is not None, (
+            "an UNRESTRICTED read of a store holding a SYMLINK-to-FIFO entry "
+            "HUNG — `_LOADER_ENTRY_ACTIONS[KIND_LINK_TO_OTHER]` is not REFUSE, "
+            "or the guard is not reaching `load_index`. On a `replicas: 1` "
+            "Deployment that is a worker that never comes back"
         )
+        assert done.returncode == 0, done.stderr[-600:]
+        assert f"SCOPES={ALLOW_SCOPE},{DENY_SCOPE}\n" in done.stdout, done.stdout
+        # REPORTED, not skipped — a dropped entry is indistinguishable from one
+        # nobody ever wrote, which is the conflation this store exists to avoid.
+        assert f"MALFORMED={DENY_SCOPE}/{LOCKED_ENTRY}\n" in done.stdout, done.stdout
 
 
 class TestTheLoaderRefusesHostileEntriesByKind:
@@ -7478,6 +7552,13 @@ class TestTheLoaderRefusesHostileEntriesByKind:
     fails on TODAY, so the broad form is a behaviour change for every local CLI
     caller. `test_a_SYMLINKED_entry_is_STILL_READ…` is the test that kills the
     broad form; without it "refuse hostile kinds" has no upper bound.
+
+    ⚠ NARROW IS NOT FROZEN. The guard has THREE cells, not the two it shipped
+    with: `link-to-other` (a symlink pointing at a fifo/socket/device) was left
+    TAKE for one round as a named residual, then measured wedging an
+    unrestricted `/recall` for 25s and closed. That widening is still inside the
+    upper bound — it refuses a shape no legitimate entry has, and
+    `link-to-file`, the cell the narrow ruling was actually about, is untouched.
     """
 
     def _hostile(self, tmp_path: Path) -> Path:

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -5910,9 +5910,114 @@ class TestScopedTokenRowGuards:
             assert "invalid scope in token row 1 of 1" in str(exc.value), typo
             assert "folds away" in str(exc.value), typo
 
-    def test_GUARD_11_two_rows_naming_ONE_identity_are_refused(self, tmp_path: Path):
-        # Two rows, both well-formed, both with real allowlists — every earlier
-        # guard passes on every row. Only the cross-row check can see this.
+    def test_GUARD_11_the_MIGRATION_SHAPE_is_refused_not_silently_collapsed(
+        self, tmp_path: Path
+    ):
+        """🔴 THE FAIL-OPEN THIS GUARD EXISTS FOR, AND IT WAS LIVE.
+
+        "Scope a credential its holder already has" is the migration's own first
+        step, and the natural way to write it is to leave the bare line and add a
+        mapped one below. The loader used to drop the second row BEFORE parsing
+        it — keyed on the token, order preserved — so this file loaded as ONE
+        record, `identity='legacy' scopes=None`: UNRESTRICTED. No error. The
+        mapped row did not exist, and the only signal was a banner reading
+        "1 of 1 token rows are bare" over a two-line file.
+
+        The two authorities are named in the message because the whole content
+        of the complaint is that they DISAGREE — and neither an identity nor a
+        scope name is a credential, so naming them keeps guard 5's property.
+        """
+        path = self._write(
+            tmp_path, ZACH_TOKEN, f"{ZACH_TOKEN} zach {ALLOW_SCOPE}"
+        )
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {}, warn=lambda _l: None)
+        message = str(exc.value)
+        assert "duplicate token in rows 1 and 2" in message
+        # Both authorities, spelled out — the unrestricted one by name, so an
+        # operator reading the pod log can see WHICH reading they nearly got.
+        assert "legacy (UNRESTRICTED)" in message
+        assert f"zach ({ALLOW_SCOPE})" in message
+        # …and never the credential itself, on the one file whose whole content
+        # is credentials.
+        assert ZACH_TOKEN not in message
+
+    def test_GUARD_11_a_DUPLICATE_TOKEN_ROW_no_longer_bypasses_guards_6_to_10(
+        self, tmp_path: Path
+    ):
+        """🔴 THE SECOND HALF OF THE SAME DEFECT: a dropped row was never
+        VALIDATED either.
+
+        This second row carries an invalid identity AND an invalid scope. Under
+        the pre-fix loader the whole row vanished before guard 6 ran and the file
+        loaded clean as `zach/{ALLOW_SCOPE}`. Every row must reach the ladder, so
+        the row's OWN first failure — guard 7 — is what must fire, and the
+        assertion names guard 7's sentence rather than merely `ValueError`: a
+        test satisfied by any raise would be green with guard 7 deleted.
+        """
+        path = self._write(
+            tmp_path,
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE}",
+            f"{ZACH_TOKEN} Za_CH_BAD !!!!",
+        )
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {}, warn=lambda _l: None)
+        message = str(exc.value)
+        assert "invalid identity in token row 2 of 2" in message
+        assert "Za_CH_BAD" in message
+
+    def test_GUARD_11_collapses_ONE_GRANT_SPELLED_TWO_WAYS(self, tmp_path: Path):
+        """🔴 THE OTHER DIRECTION — OVER-REFUSING IS ALSO A FAILURE, and this is
+        the case a purely TEXTUAL collapse gets wrong.
+
+        `Kelp_Forest` and `kelp-forest` are the same grant: the parser folds both
+        to one scope. The rows are not identical as text and ARE identical as
+        records, and it is the record that decides. A guard comparing raw lines
+        would refuse a file that says one unambiguous thing.
+        """
+        path = self._write(
+            tmp_path,
+            f"{ZACH_TOKEN} zach Kelp_Forest",
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE}",
+        )
+        assert loaded(path, {}) == [(ZACH_TOKEN, "zach", (ALLOW_SCOPE,))]
+
+    def test_GUARD_11_fires_even_when_the_IDENTITY_agrees(self, tmp_path: Path):
+        """One token, one identity, two DIFFERENT allowlists. Guard 12 would also
+        see this pair — and would tell the operator to invent `zach-prev`, which
+        is the wrong advice for what is one credential written twice. Guard 11
+        runs first precisely so the more specific complaint wins.
+        """
+        path = self._write(
+            tmp_path,
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE}",
+            f"{ZACH_TOKEN} zach {DENY_SCOPE}",
+        )
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {}, warn=lambda _l: None)
+        assert "duplicate token in rows 1 and 2" in str(exc.value)
+        assert "duplicate identity" not in str(exc.value)
+
+    def test_GUARD_11_runs_BEFORE_12_so_an_IDENTICAL_MAPPED_ROW_still_loads(
+        self, tmp_path: Path
+    ):
+        """🔴 THE ORDER IS LOAD-BEARING, AND THIS IS WHAT BREAKS IF IT INVERTS.
+
+        One mapped row pasted twice, verbatim. Guard 11 collapses it to a single
+        record; if guard 12 ran first it would see two rows claiming `zach` and
+        refuse the file. Nothing about this input is ambiguous, so it must load.
+        """
+        path = self._write(
+            tmp_path,
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE}",
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE}",
+        )
+        assert loaded(path, {}) == [(ZACH_TOKEN, "zach", (ALLOW_SCOPE,))]
+
+    def test_GUARD_12_two_rows_naming_ONE_identity_are_refused(self, tmp_path: Path):
+        # Two rows, both well-formed, both with real allowlists, and two DISTINCT
+        # tokens so guard 11 cannot be what fires — every earlier guard passes on
+        # every row. Only the cross-row identity check can see this.
         path = self._write(
             tmp_path,
             f"{ZACH_TOKEN} zach {ALLOW_SCOPE}",
@@ -5922,6 +6027,24 @@ class TestScopedTokenRowGuards:
             api.load_tokens(path, {}, warn=lambda _l: None)
         assert "duplicate identity 'zach'" in str(exc.value)
         assert "rows 1 and 2" in str(exc.value)
+
+    def test_GUARD_12_names_the_PHYSICAL_rows_across_a_collapse(
+        self, tmp_path: Path
+    ):
+        """The index an operator is told to look at must be the LINE they can
+        see. Row 2 collapses into row 1, so the clash is between rows 1 and 3 —
+        a position in the post-collapse list would call it "rows 1 and 2" and
+        send them to the wrong line.
+        """
+        path = self._write(
+            tmp_path,
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE}",
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE}",
+            f"{DANA_TOKEN} zach {DENY_SCOPE}",
+        )
+        with pytest.raises(ValueError) as exc:
+            api.load_tokens(path, {}, warn=lambda _l: None)
+        assert "token rows 1 and 3 both claim it" in str(exc.value)
 
     def test_a_WELL_FORMED_mapped_file_loads_with_its_allowlist(self, tmp_path: Path):
         """The positive control for all six guards above. Without it, a parser
@@ -6464,13 +6587,19 @@ class TestTheReaderNarrowingItself:
         )
         assert narrow.scopes == (ALLOW_SCOPE,)
 
-    def test_an_UNREADABLE_store_still_RAISES_rather_than_narrowing_to_empty(
+    def test_a_MISSING_store_still_RAISES_rather_than_narrowing_to_empty(
         self, tmp_path: Path
     ):
         """🔴 THE FOUR-STATE RULE SURVIVES THE FILTER. `store-unreachable` and
         "you may see nothing" both produce an empty index; only the first may be
         a raise, and collapsing them is the exact conflation this whole module
         exists to prevent. A filter applied BEFORE the load would have done it.
+
+        ⚠ RENAMED. This used to be called `test_an_UNREADABLE_store_still_RAISES…`
+        and passes a store root that does not EXIST — a different condition, a
+        different error type and a different line of `load_store`. The
+        genuinely-unreadable path is `TestUnreadableEntriesInDeniedScopes` below,
+        which is where the interesting behaviour is.
         """
         with pytest.raises(api.rc.StoreMissingError):
             api.rc.load_store(
@@ -6503,6 +6632,241 @@ class TestTheReaderNarrowingItself:
         assert set(api.rc.recall(scoped_store, ALLOW_SCOPE).known_scopes) == {
             ALLOW_SCOPE, DENY_SCOPE, THIRD_SCOPE
         }
+
+
+# The name in the 503 body an unreadable entry used to produce. Distinct from
+# every other literal in this file, so "did this filename reach the caller" is a
+# single `in` and cannot be satisfied by coincidence.
+LOCKED_ENTRY = "sealed-adit.md"
+# An Emacs lock file: a DANGLING symlink whose name starts with a dot and ends
+# `.md`. `Path.glob("*.md")` matches a leading dot — measured, not assumed, and
+# pinned by a test below — so it IS a candidate entry, and this exact shape has
+# been observed 503ing `/api/v1/recall/<scope>` in practice.
+EMACS_LOCK = ".#sealed-adit.md"
+
+
+def _make_unreadable(store: Path, scope: str, kind: str) -> Path:
+    """Put ONE hostile candidate entry into `<store>/<scope>/`.
+
+    `kind` is `perm` (a mode-000 regular file), `emacs` (the dangling lock-file
+    symlink) or `fifo` (a named pipe, which blocks `open()` until somebody
+    writes). All three are real shapes seen on a real store, not contrivances.
+    """
+    target = store / scope / (EMACS_LOCK if kind == "emacs" else LOCKED_ENTRY)
+    if kind == "perm":
+        target.write_text(_entry("sealed-adit", scope, nuance="- sealed."))
+        os.chmod(target, 0o000)
+    elif kind == "emacs":
+        os.symlink("zach@host.4242:1767225600", target)
+    elif kind == "fifo":
+        os.mkfifo(target)
+    else:  # pragma: no cover - a typo in a test argument is a test bug
+        raise AssertionError(kind)
+    return target
+
+
+class TestUnreadableEntriesInDeniedScopes:
+    """🔴 THE INDEX LOADER USED TO OPEN EVERY FILE IN THE STORE BEFORE THE
+    ALLOWLIST WAS APPLIED, AND SCOPED CALLERS MADE THAT THREE DEFECTS AT ONCE.
+
+    `load_store` narrowed the index it got BACK; `load_index` had already walked
+    and read the whole store to build it. So one unreadable entry in a scope a
+    caller may not see:
+
+      * put that file's FULL PATH — and therefore the denied scope's name — into
+        a 503 body that caller could read. A scoped reader had no other way to
+        learn the name existed, which is the exact enumeration surface the rest
+        of this section closes;
+      * broke `/recall` and `/search` for EVERY caller, including the ones whose
+        own scopes were perfectly readable;
+      * and for a FIFO named `*.md`, blocked the request thread on `open()`
+        indefinitely. `/snapshot` already refuses that by kind
+        (`_ENTRY_ACTIONS[KIND_OTHER] == REFUSE`); the index path did not.
+
+    Fixed by pushing `visible_scopes` DOWN into `load_index`, so a denied scope
+    dir is never descended into at all.
+
+    🔴 AND THE LIMIT IS TESTED TOO, not just stated: an UNRESTRICTED caller —
+    which is what a bare legacy token is, and what the pod is deployed with
+    today — is exactly as exposed as before. `test_the_UNRESTRICTED_reading_is_
+    UNCHANGED_and_that_is_the_residual` is the honest record of that.
+    """
+
+    def _store(self, tmp_path: Path, kind: str) -> Path:
+        store = _build_store(
+            tmp_path / "store",
+            {ALLOW_SCOPE: KELP_NUANCE, DENY_SCOPE: QUARTZ_NUANCE},
+        )
+        _make_unreadable(store, DENY_SCOPE, kind)
+        return store
+
+    def test_the_FIXTURE_really_is_a_candidate_entry_glob_matches_a_dotfile(
+        self, tmp_path: Path
+    ):
+        """🔴 THE POSITIVE CONTROL FOR THE EMACS SHAPE. If `glob("*.md")` did not
+        match a leading dot, `.#sealed-adit.md` would never be opened, every
+        assertion about it would be vacuous, and the whole case would be a story
+        about a file the loader never sees.
+        """
+        d = tmp_path / "scope"
+        d.mkdir()
+        os.symlink("dangling", d / EMACS_LOCK)
+        assert [p.name for p in d.glob("*.md")] == [EMACS_LOCK]
+
+    @pytest.mark.parametrize("kind", ["perm", "emacs"])
+    def test_a_SCOPED_caller_is_unaffected_by_an_unreadable_DENIED_entry(
+        self, tmp_path: Path, kind: str
+    ):
+        store = self._store(tmp_path, kind)
+        _s, index = api.rc.load_store(
+            store, verb="recalled", visible_scopes=(ALLOW_SCOPE,)
+        )
+        assert index.scopes == (ALLOW_SCOPE,)
+        assert index.malformed == ()
+
+    @pytest.mark.parametrize("kind", ["perm", "emacs"])
+    def test_POSITIVE_CONTROL_the_same_file_in_the_CALLERS_OWN_scope_still_RAISES(
+        self, tmp_path: Path, kind: str
+    ):
+        """🔴 WITHOUT THIS THE TEST ABOVE IS SATISFIED BY A FIXTURE THAT CREATED
+        NOTHING UNREADABLE. It also pins the half that must NOT change: the
+        four-state rule. "I could not read your store" and "you may see nothing"
+        both produce an empty index, and only the first may raise.
+        """
+        store = self._store(tmp_path, kind)
+        with pytest.raises(api.rc.EntryUnreadableError):
+            api.rc.load_store(store, verb="recalled", visible_scopes=(DENY_SCOPE,))
+
+    @pytest.mark.parametrize("kind", ["perm", "emacs"])
+    def test_the_UNRESTRICTED_reading_is_UNCHANGED_and_that_is_the_residual(
+        self, tmp_path: Path, kind: str
+    ):
+        """🔴 THE LIMIT OF THE FIX, ASSERTED RATHER THAN LEFT TO BE DISCOVERED.
+
+        `visible_scopes=None` skips nothing, so an unreadable entry anywhere
+        still takes the whole store down for a local CLI caller — and for a BARE
+        LEGACY TOKEN, which is unrestricted and is what the pod is deployed with
+        today. This test exists so nobody reads the class docstring above and
+        concludes the live API is protected by it. Closing it needs an entry-KIND
+        guard in `load_index`; see that function's own note.
+        """
+        store = self._store(tmp_path, kind)
+        with pytest.raises(api.rc.EntryUnreadableError):
+            api.rc.load_store(store, verb="recalled")
+
+    def test_the_503_body_NAMED_the_denied_scope_and_its_PATH_over_HTTP(
+        self, tmp_path: Path
+    ):
+        """🔴 THE DISCLOSURE ITSELF, DRIVEN THROUGH THE SERVER — the layer where
+        it was a leak rather than an exception type.
+
+        `zach` may see `ALLOW_SCOPE` only. He asks for his OWN scope, which is
+        readable, and used to be answered `503 index entry unreadable: under …
+        (PermissionError: … '<store>/quartz-mine/sealed-adit.md')`. Both halves
+        matter: the status is a denial of service he did not cause, and the body
+        names a scope and a filename he is not allowed to know exist.
+        """
+        store = self._store(tmp_path, "perm")
+        with running(store, tokens=(ZACH,)) as (base, _):
+            code, headers, body = fetch(
+                f"{base}/api/v1/recall/{ALLOW_SCOPE}", token=ZACH_TOKEN
+            )
+        text = body.decode()
+        assert code == 200, f"{code}: {text[:400]}"
+        assert headers["X-Store-Status"] == "recalled"
+        assert KELP_NUANCE in text, "the caller's own content vanished"
+        assert DENY_SCOPE not in text
+        assert LOCKED_ENTRY not in text
+        # …and therefore not the hostile file's path either. Spelled out because
+        # the PATH is what the 503 carried and the two assertions above are only
+        # its components.
+        #
+        # 🔴 NEITHER `"unreadable" not in text` NOR `str(store) not in text` WOULD
+        # DO, and both were tried: the caveat block explains what
+        # `unstamped/unreadable/none` mean on EVERY report, and the store ROOT is
+        # printed on every report as `  store: <root>`. Both are present on a
+        # perfectly healthy 200, so both would be red for a reason that has
+        # nothing to do with this defect. What leaked was the scope name and the
+        # filename UNDER the root, which is what is asserted.
+        assert str(store / DENY_SCOPE / LOCKED_ENTRY) not in text
+
+    def test_POSITIVE_CONTROL_a_LEGACY_token_DOES_still_get_the_503(
+        self, tmp_path: Path
+    ):
+        """🔴 THE FIXTURE MUST ACTUALLY PRODUCE AN UNREADABLE ENTRY. Without this
+        the assertions above are a zero from a check that might see nothing — a
+        `chmod 000` that silently failed (running as root, an exotic filesystem)
+        would leave every one of them green against a perfectly healthy store.
+
+        It is also the honest record of the residual: unrestricted callers still
+        get the 503, and still get the path in it.
+        """
+        store = self._store(tmp_path, "perm")
+        with running(store, tokens=(GOOD_TOKEN,)) as (base, _):
+            code, headers, body = fetch(
+                f"{base}/api/v1/recall/{ALLOW_SCOPE}", token=GOOD_TOKEN
+            )
+        assert code == 503, f"the fixture is readable after all: {code}"
+        assert headers["X-Store-Status"] == "store-unreachable"
+        text = body.decode()
+        assert LOCKED_ENTRY in text and DENY_SCOPE in text
+
+    def test_a_FIFO_named_md_in_a_DENIED_scope_no_longer_HANGS_the_reader(
+        self, tmp_path: Path
+    ):
+        """🔴 THE MOST SERIOUS OF THE THREE, AND THE ONE A NORMAL TEST CANNOT
+        ASSERT: a wedged thread produces no exception and no value, so there is
+        nothing to `pytest.raises` on. It is measured in a CHILD PROCESS under a
+        wall-clock deadline, because a test that can hang is a suite that can
+        hang.
+
+        On a `replicas: 1` Deployment an `open()` that never returns is worse
+        than the 503: the worker is gone and the next request queues behind it.
+
+        The NEGATIVE CONTROL is in the same run and is what makes the timeout
+        meaningful — the unrestricted load of the SAME store must still hang, or
+        this test is measuring a FIFO that somehow opens.
+        """
+        store = self._store(tmp_path, "fifo")
+        probe = (
+            "import sys;"
+            f"sys.path.insert(0, {str(RECALL_PATH.parent)!r});"
+            "import subsystem_recall as rc;"
+            f"vs = None if sys.argv[1] == 'unrestricted' else ({ALLOW_SCOPE!r},);"
+            f"_s, i = rc.load_store({str(store)!r}, verb='recalled', visible_scopes=vs);"
+            "print('SCOPES=' + ','.join(i.scopes))"
+        )
+
+        def run(arg: str, deadline: float):
+            """The completed process, or `None` meaning it blew the deadline."""
+            try:
+                return subprocess.run(
+                    [sys.executable, "-c", probe, arg],
+                    capture_output=True, text=True, timeout=deadline,
+                )
+            except subprocess.TimeoutExpired:
+                return None
+
+        scoped = run("scoped", 30.0)
+        assert scoped is not None, (
+            "the scoped reader HUNG on a FIFO in a scope it may not see — the "
+            "allowlist is not reaching `load_index`"
+        )
+        assert scoped.returncode == 0, scoped.stderr[-600:]
+        assert scoped.stdout.strip() == f"SCOPES={ALLOW_SCOPE}"
+
+        # 🔴 NEGATIVE CONTROL, SAME STORE, SAME PROBE, ONE ARGUMENT DIFFERENT. A
+        # FIFO that opened would make the assertion above pass for the wrong
+        # reason; this proves the hazard is real and still live for the
+        # unrestricted reading, which is the residual documented above. Its
+        # deadline is DELIBERATELY the shorter of the two: the scoped run has
+        # already shown a healthy load of this store finishes well inside it, so
+        # a timeout here is a block, not a slow interpreter.
+        assert run("unrestricted", 15.0) is None, (
+            "the UNRESTRICTED reader did NOT hang on the FIFO — either the "
+            "fixture is not a FIFO, or the residual this suite documents has "
+            "silently been fixed and these comments are now wrong"
+        )
 
 
 class TestScopeFilteringIsNotAWriteVerb:

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -1185,25 +1185,37 @@ class TestClassifierIsTotal:
         )
 
     @staticmethod
-    def _residual_ledger(label: str) -> str:
-        """The document's RESIDUAL LEDGER region, by its literal markers.
+    def _marked_region(
+        text: str, label: str, start: str, end: str, min_len: int
+    ) -> str:
+        """A document region delimited by two literal markers.
 
         An absent or unterminated marker ASSERTS rather than returning an empty
         slice — an empty region would satisfy every "is not in" below and turn
-        this guard into the reassuring zero it exists to prevent.
+        the guard using it into the reassuring zero it exists to prevent. So
+        does a region that came back implausibly short.
         """
+        lo = text.find(start)
+        assert lo > 0, f"{label}: no {start} section at all"
+        hi = text.find(end, lo + len(start))
+        assert hi > lo, f"{label}: the {start} region is not terminated by {end!r}"
+        region = text[lo:hi]
+        assert len(region) > min_len, (
+            f"{label}: the {start} region is suspiciously short ({len(region)}b)"
+        )
+        return region
+
+    @classmethod
+    def _residual_ledger(cls, label: str) -> str:
+        """The document's RESIDUAL LEDGER region, by its literal markers."""
         text = (
             resolver.load_index.__doc__
             if "load_index" in label
             else (API_DIR / label).read_text(encoding="utf-8")
         )
-        start = text.find("RESIDUAL LEDGER")
-        assert start > 0, f"{label}: no RESIDUAL LEDGER section at all"
-        end = text.find("END OF RESIDUAL LEDGER", start + 1)
-        assert end > start, f"{label}: the RESIDUAL LEDGER is not terminated"
-        region = text[start:end]
-        assert len(region) > 200, f"{label}: the ledger region is suspiciously short"
-        return region
+        return cls._marked_region(
+            text, label, "RESIDUAL LEDGER", "END OF RESIDUAL LEDGER", min_len=200
+        )
 
     @pytest.mark.parametrize(
         "label", ["subsystem_resolver.load_index", "README.md"]
@@ -1256,6 +1268,66 @@ class TestClassifierIsTotal:
                 f"the exact drift this guard exists for"
             )
 
+    def test_the_DOCSTRING_REFUSED_SET_names_every_REFUSE_kind_and_no_other(self):
+        """🔴 THE HALF THE GUARD BELOW CLAIMED AND DID NOT COVER — a docstring
+        whose SENTENCE promised more coverage than its BODY delivered.
+
+        `test_the_README_REFUSED_TABLE_…` used to say "`load_index`'s docstring
+        prose is covered by the ledger half above". It was not. The ledger guard
+        reads only the span between `RESIDUAL LEDGER` and its END marker, and
+        the docstring's REFUSAL sentence lives well above that span — so nothing
+        in the tree read it. `resolver.load_index.__doc__` appeared exactly once
+        in the whole test suite, inside `_residual_ledger`.
+
+        Measured, on the state this fix replaced: dropping `link-to-other`,
+        `directory` and `link-to-dir` from that sentence — leaving the docstring
+        asserting a TWO-cell guard against a FIVE-cell table, verbatim the shape
+        of the README drift the ledger guard exists for — left the suite at
+        **407 passed**.
+
+        So the sentence now names its kinds as backticked TOKENS inside literal
+        markers, and this pins the marked span against the table in both
+        directions, exactly as the two guards around it do:
+          * a kind the loader REFUSEs and the sentence omits -> the docstring
+            claims a NARROWER guard than the code has, which is what a reader
+            deletes a "redundant" cell on the strength of;
+          * a kind the sentence names that the loader TAKEs -> a guard claimed
+            where none exists, which is the README failure one document over.
+
+        ⚠ TOKENS, NOT PROSE — same trade as the ledger guard. The explanatory
+        clause beside each kind is free to be rewritten; the backticked name is
+        the machine-readable claim. And the span is delimited tightly on
+        purpose: the paragraph BELOW it names `link-to-other`, `directory` and
+        `link-to-dir` while recounting which round each shipped in, so a guard
+        scoped to the whole docstring would have passed on all three while the
+        refusal sentence itself said nothing about them.
+        """
+        refused = {
+            k for k, a in resolver._LOADER_ENTRY_ACTIONS.items() if a == api.REFUSE
+        }
+        assert refused, "the loader refuses nothing — the table is degenerate"
+        region = self._marked_region(
+            resolver.load_index.__doc__ or "",
+            "subsystem_resolver.load_index",
+            "REFUSED SET",
+            "END OF REFUSED SET",
+            min_len=120,
+        )
+        for kind, action in sorted(resolver._LOADER_ENTRY_ACTIONS.items()):
+            present = f"`{kind}`" in region
+            if action == api.REFUSE:
+                assert present, (
+                    f"`load_index`'s REFUSED SET does not name `{kind}`, which "
+                    f"the loader refuses — the docstring claims a narrower "
+                    f"guard than the code has"
+                )
+            else:
+                assert not present, (
+                    f"`load_index`'s REFUSED SET names `{kind}`, which the "
+                    f"loader does not REFUSE (it is {action!r}) — it claims a "
+                    f"guard that is not there"
+                )
+
     def test_the_README_REFUSED_TABLE_names_every_REFUSE_kind_and_no_other(self):
         """The other half of the same seam, and the half an operator reads
         first: the README's refusal table is what tells them which shapes are
@@ -1263,20 +1335,22 @@ class TestClassifierIsTotal:
         closed; a kind listed in it that the loader actually TAKEs reads as a
         guard that does not exist.
 
-        Scoped to the README because it is the document with an explicit table.
-        `load_index`'s docstring prose is covered by the ledger half above.
+        Scoped to the README's refusal TABLE — not to everything above the
+        ledger marker, which is what it used to be. `text[:cut]` swept in every
+        line of the document before the ledger, so an unrelated future table
+        with a `regular-file` row would have failed here with a message
+        pointing at the refusal table, which is not where the edit is. The
+        docstring's own refusal sentence is pinned by the guard ABOVE, not by
+        this one — it is a different document and it says it differently.
         """
         text = (API_DIR / "README.md").read_text(encoding="utf-8")
-        cut = text.find("RESIDUAL LEDGER")
-        # 🔴 NOT `text[:cut]` UNGUARDED: `find` returns -1 when the marker is
-        # gone, and `text[:-1]` is the WHOLE file — which would silently fold
-        # the residual ledger's own rows into the refusal table and fail with a
-        # message about the wrong thing. Measured: deleting the marker produced
-        # "README refusal table lists `absent`", which sends the reader nowhere
-        # near the actual edit.
-        assert cut > 0, "the README has no RESIDUAL LEDGER marker to split on"
-        head = text[:cut]
-        assert "| kind |" in head, "the README's refusal table has moved"
+        # The table's own header line is the anchor, and a blank line ends it —
+        # the narrowest span that can be wrong. An absent header ASSERTS rather
+        # than yielding a slice: `find` returns -1 on a miss, and `text[-1:]`
+        # is a one-character region that satisfies every "is not in" below.
+        head = self._marked_region(
+            text, "README.md", "| kind | on disk | why it is refused |", "\n\n", min_len=200
+        )
         for kind, action in sorted(resolver._LOADER_ENTRY_ACTIONS.items()):
             present = f"| `{kind}` |" in head
             if action == api.REFUSE:

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -87,6 +87,17 @@ def _load_server():
 
 api = _load_server()
 
+# 🔴 THE SAME MODULE OBJECT THE SERVER IMPORTED FROM, not a second load.
+# `server.py` puts `scripts/lib` on `sys.path` and imports `subsystem_resolver`,
+# so by the line above it is in `sys.modules`; re-loading it by path would give a
+# SECOND module whose `_LOADER_ENTRY_ACTIONS` is a different dict, and a mutation
+# aimed at the one the loader actually reads would survive against it.
+resolver = sys.modules["subsystem_resolver"]
+assert resolver.classify_path is api.classify_path, (
+    "the server no longer shares the resolver's classifier — two copies of "
+    "'what IS this path' is the defect the move was made to prevent"
+)
+
 
 # =============================================================================
 # Synthetic fixtures — realistic SHAPES, invented names, pairwise-distinct text.
@@ -498,6 +509,18 @@ def loaded(token_file, env, **kwargs) -> list[tuple]:
     return [(r.token, r.identity, r.scopes) for r in api.load_tokens(token_file, env, **kwargs)]
 
 
+def exc_of(call) -> ValueError:
+    """The `ValueError` `call()` raises, so a MESSAGE assertion is one line.
+
+    Only for tests whose subject is the wording; `pytest.raises` stays inline
+    wherever the fact under test is that it raised AT ALL, because that is a
+    different claim and reads better spelled out.
+    """
+    with pytest.raises(ValueError) as exc:
+        call()
+    return exc.value
+
+
 class TestTokenLoadingGuards:
     """`load_tokens` refuses to serve on a token that is absent, empty or weak.
 
@@ -539,7 +562,7 @@ class TestTokenLoadingGuards:
         assert "is too short" in str(exc.value)
         # The position is named even when there is only one — a message that
         # said "the token" would have to change shape the day a second appears.
-        assert "token 1 of 1" in str(exc.value)
+        assert "token on line 1 of 1" in str(exc.value)
         # 43 chars = 256 bits base64url, pinned LITERALLY (§2b).
         assert "43" in str(exc.value)
 
@@ -981,17 +1004,44 @@ class TestReadOnlyPhase1:
 # 🔴 THE PINNED DECISION TABLE, as a named constant so the completeness guard
 # and the per-cell guard read the SAME list. Introspecting the parametrize mark
 # to get it was clever and wrong; two literals would drift.
+#
+# THREE contexts now: the `/snapshot` scope-root scan, the `/snapshot` entry
+# scan, and — since the entry-kind guard landed — `subsystem_resolver`'s INDEX
+# LOADER, which is a different context and therefore a different column.
+#
+# 🔴 THE LOADER COLUMN IS THE NARROW RULING, CELL BY CELL. It refuses exactly
+# `broken-link` (the Emacs `.#entry.md` lock file, which used to 503 the whole
+# store) and `other` (the fifo, which used to HANG the request thread), and
+# TAKES everything else — most pointedly `link-to-file`, which the loader has
+# always read. Copying the `_ENTRY_ACTIONS` column wholesale is the over-broad
+# form that was explicitly rejected, and flipping any TAKE here to REFUSE is a
+# behaviour change for ordinary callers; every one of those flips is a mutant
+# this column kills.
 DECISION_TABLE = [
-    ("KIND_BROKEN_LINK", "REFUSE", "REFUSE"),
-    ("KIND_LINK_TO_DIR", "REFUSE", "REFUSE"),
-    ("KIND_LINK_TO_FILE", "SKIP", "REFUSE"),
-    ("KIND_LINK_TO_OTHER", "SKIP", "REFUSE"),
-    ("KIND_DIRECTORY", "TAKE", "REFUSE"),
-    ("KIND_REGULAR_FILE", "SKIP", "TAKE"),
-    ("KIND_OTHER", "SKIP", "REFUSE"),
+    ("KIND_BROKEN_LINK", "REFUSE", "REFUSE", "REFUSE"),
+    ("KIND_LINK_TO_DIR", "REFUSE", "REFUSE", "TAKE"),
+    ("KIND_LINK_TO_FILE", "SKIP", "REFUSE", "TAKE"),
+    # ⚠ A symlink POINTING AT a fifo is the same hang in a different shape, and
+    # is left TAKE by the narrow ruling. Pinned as the residual it is, so a
+    # future decision to close it is a deliberate edit here.
+    ("KIND_LINK_TO_OTHER", "SKIP", "REFUSE", "TAKE"),
+    ("KIND_DIRECTORY", "TAKE", "REFUSE", "TAKE"),
+    ("KIND_REGULAR_FILE", "SKIP", "TAKE", "TAKE"),
+    ("KIND_OTHER", "SKIP", "REFUSE", "REFUSE"),
     # 🔴 "I could not look" must never share a cell with "nothing is there".
-    ("KIND_INDETERMINATE", "REFUSE", "REFUSE"),
-    ("KIND_ABSENT", "SKIP", "SKIP"),
+    # In the LOADER it is TAKE, so `read_text` raises and the four-state rule's
+    # "the store was not fully READ" is preserved — a DIFFERENT fact from "this
+    # entry is malformed", which is what REFUSE would report it as.
+    ("KIND_INDETERMINATE", "REFUSE", "REFUSE", "TAKE"),
+    ("KIND_ABSENT", "SKIP", "SKIP", "TAKE"),
+]
+
+# The LEDGER of every action table that exists, so "all three contexts" is a
+# claim something checks rather than a number in a test name.
+ALL_ACTION_TABLES = [
+    ("subsystem_store_server._ROOT_ACTIONS", api._ROOT_ACTIONS),
+    ("subsystem_store_server._ENTRY_ACTIONS", api._ENTRY_ACTIONS),
+    ("subsystem_resolver._LOADER_ENTRY_ACTIONS", resolver._LOADER_ENTRY_ACTIONS),
 ]
 
 
@@ -1015,15 +1065,33 @@ class TestClassifierIsTotal:
     rounds each made implicitly, by omission, and got wrong.
     """
 
-    def test_every_kind_is_mapped_in_BOTH_contexts(self):
-        for name, actions in (
-            ("_ROOT_ACTIONS", api._ROOT_ACTIONS),
-            ("_ENTRY_ACTIONS", api._ENTRY_ACTIONS),
-        ):
+    def test_every_kind_is_mapped_in_ALL_THREE_contexts(self):
+        for name, actions in ALL_ACTION_TABLES:
             missing = api.ALL_KINDS - set(actions)
             extra = set(actions) - api.ALL_KINDS
             assert not missing, f"{name} does not decide: {sorted(missing)}"
             assert not extra, f"{name} maps unknown kinds: {sorted(extra)}"
+
+    def test_the_TABLE_LEDGER_names_every_action_table_that_exists(self):
+        """🔴 A SEAM GUARD, NOT A TOTALITY ONE — the test above is only as wide
+        as the list it iterates.
+
+        A fourth context that maps kinds would be structurally invisible to
+        every assertion in this class: nothing here reads the modules, so a new
+        table simply would not be checked, and "every kind is mapped in all
+        three contexts" would keep passing while the fourth defaulted. This
+        asserts the LEDGER against what the two modules actually define, so the
+        set GROWING or SHRINKING is a failure either way.
+        """
+        found = {
+            f"{mod.__name__}.{name}"
+            for mod in (api, resolver)
+            for name, value in vars(mod).items()
+            if name.endswith("_ACTIONS") and isinstance(value, dict)
+        }
+        assert found == {name for name, _t in ALL_ACTION_TABLES}, (
+            f"the action-table ledger is out of date: {sorted(found)}"
+        )
 
     def test_the_pinned_table_covers_EVERY_kind(self):
         """🔴 Two-way pin on the parametrize list itself.
@@ -1034,7 +1102,7 @@ class TestClassifierIsTotal:
         would have an UNPINNED cell while the docstring claimed otherwise. Same
         idiom as `test_waiting_windows.py`'s `set(KIND_BAND) == set(ALL_KINDS)`.
         """
-        pinned = {getattr(api, name) for name, _r, _e in DECISION_TABLE}
+        pinned = {getattr(api, name) for name, _r, _e, _l in DECISION_TABLE}
         assert pinned == api.ALL_KINDS, (
             f"unpinned cells: {sorted(api.ALL_KINDS - pinned)}"
         )
@@ -1067,9 +1135,9 @@ class TestClassifierIsTotal:
         assert b"indeterminate refused" in body, body[:300]
 
     def test_every_mapped_action_is_a_known_action(self):
-        for actions in (api._ROOT_ACTIONS, api._ENTRY_ACTIONS):
+        for name, actions in ALL_ACTION_TABLES:
             for kind, action in actions.items():
-                assert action in (api.SKIP, api.TAKE, api.REFUSE), (kind, action)
+                assert action in (api.SKIP, api.TAKE, api.REFUSE), (name, kind, action)
 
     def test_an_unmapped_kind_RAISES_rather_than_defaulting(self):
         """🔴 The fallthrough is the whole mechanism. If `action_for` returned a
@@ -1078,17 +1146,28 @@ class TestClassifierIsTotal:
         with pytest.raises(AssertionError, match="unclassified path kind"):
             api.action_for("a-kind-nobody-mapped", api._ROOT_ACTIONS)
 
-    @pytest.mark.parametrize("kind,expected_root,expected_entry", DECISION_TABLE)
-    def test_the_decision_table_is_pinned(self, kind, expected_root, expected_entry):
+    @pytest.mark.parametrize(
+        "kind,expected_root,expected_entry,expected_loader", DECISION_TABLE
+    )
+    def test_the_decision_table_is_pinned(
+        self, kind, expected_root, expected_entry, expected_loader
+    ):
         """Pins the table itself, so a silent flip of any single cell fails.
 
         Every previous round's bug was one cell of this table being wrong or
         absent; asserting the table makes each cell a named, reviewable decision
         instead of an emergent property of statement order.
+
+        ⚠ A CONSTANTS PIN IS NOT A BEHAVIOUR TEST, and this class's own history
+        says so — three ENTRY cells needed behavioural tests before they were
+        believed. The two loader cells that DO something have them below
+        (`TestTheLoaderRefusesHostileEntriesByKind`); this asserts the decision
+        is written down, not that it fires.
         """
         k = getattr(api, kind)
         assert api._ROOT_ACTIONS[k] == getattr(api, expected_root)
         assert api._ENTRY_ACTIONS[k] == getattr(api, expected_entry)
+        assert resolver._LOADER_ENTRY_ACTIONS[k] == getattr(api, expected_loader)
 
     def test_classify_returns_the_right_kind_for_each_REAL_path(self, tmp_path: Path):
         """🔴 The table above is only meaningful if `classify_path` actually
@@ -2491,6 +2570,44 @@ class TestTokenSetAndOverlapRotation:
         path = self._write(tmp_path, *four)
         assert [r[0] for r in loaded(path, {})] == four
 
+    def test_the_CAP_counts_CREDENTIALS_not_ROWS(self, tmp_path: Path):
+        """🔴 A REGRESSION THIS BRANCH INTRODUCED, MEASURED. Removing the
+        pre-parse dedup left guard 4 counting physical rows, so four distinct
+        tokens plus ONE verbatim duplicate line answered `too many tokens: 5,
+        max 4` — for a file holding four credentials that loaded fine before.
+
+        It also contradicted guard 11, whose own comment calls a duplicated row
+        "the rotation shape, and it is legitimate": the file guard 11 accepts is
+        the file guard 4 was refusing.
+
+        FIVE rows, FOUR credentials. It must load, and the collapse must leave
+        exactly the four.
+        """
+        four = [chr(ord("a") + i) * 48 for i in range(4)]
+        path = self._write(tmp_path, *four, four[0])
+        assert [r[0] for r in loaded(path, {})] == four
+
+    def test_FIVE_COPIES_of_ONE_token_is_ONE_credential(self, tmp_path: Path):
+        """The far end of the same claim, and the one that made the old wording
+        plainly wrong: five identical lines are one credential, and "too many
+        tokens: 5" was a sentence about a file with one token in it.
+        """
+        path = self._write(tmp_path, *([GOOD_TOKEN] * 5))
+        assert [r[0] for r in loaded(path, {})] == [GOOD_TOKEN]
+
+    def test_the_CAP_still_counts_the_DISTINCT_ones_and_says_so(
+        self, tmp_path: Path
+    ):
+        """🔴 THE UPPER BOUND: counting credentials must not become counting
+        nothing. Five DISTINCT tokens with one of them repeated is still five
+        credentials, and the number in the message is the credential count — not
+        the row count (6) it would have been, and not a constant.
+        """
+        five = [chr(ord("a") + i) * 48 for i in range(5)]
+        path = self._write(tmp_path, *five, five[2])
+        message = str(exc_of(lambda: api.load_tokens(path, {})))
+        assert "too many tokens: 5, max 4" in message, message
+
     def test_a_SHORT_SECOND_token_names_its_POSITION_and_never_the_token(
         self, tmp_path: Path
     ):
@@ -2501,7 +2618,7 @@ class TestTokenSetAndOverlapRotation:
         with pytest.raises(ValueError) as exc:
             api.load_tokens(path, {})
         message = str(exc.value)
-        assert "token 2 of 2 is too short" in message
+        assert "token on line 2 of 2 is too short" in message
         assert "hunter2" not in message, "the secret was echoed into the error"
         assert "43" in message
 
@@ -5797,7 +5914,7 @@ class TestScopedTokenRowGuards:
         path = self._write(tmp_path, f"{ZACH_TOKEN} zach")
         with pytest.raises(ValueError) as exc:
             api.load_tokens(path, {}, warn=lambda _l: None)
-        assert "malformed token row 1 of 1" in str(exc.value)
+        assert "malformed token row on line 1 of 1" in str(exc.value)
         assert "2 fields" in str(exc.value)
         # And never the credential itself, on the one file whose whole content
         # is credentials.
@@ -5809,7 +5926,7 @@ class TestScopedTokenRowGuards:
         path = self._write(tmp_path, f"{ZACH_TOKEN} zach {ALLOW_SCOPE} extra")
         with pytest.raises(ValueError) as exc:
             api.load_tokens(path, {}, warn=lambda _l: None)
-        assert "malformed token row 1 of 1" in str(exc.value)
+        assert "malformed token row on line 1 of 1" in str(exc.value)
         assert "4 fields" in str(exc.value)
         # 🔴 THE NEGATIVE HALF OF THE TYPO HINT, and it is what stops the hint
         # becoming noise. There is no comma anywhere in this row, so a
@@ -5837,7 +5954,7 @@ class TestScopedTokenRowGuards:
             api.load_tokens(path, {}, warn=lambda _l: None)
         message = str(exc.value)
         # The guard is NOT weakened — it still refuses, still by field count.
-        assert "malformed token row 1 of 1" in message
+        assert "malformed token row on line 1 of 1" in message
         assert "4 fields" in message
         # …and now says what to do about it.
         assert "NO SPACES" in message
@@ -5849,7 +5966,7 @@ class TestScopedTokenRowGuards:
         path = self._write(tmp_path, f"{ZACH_TOKEN} Za_ch {ALLOW_SCOPE}")
         with pytest.raises(ValueError) as exc:
             api.load_tokens(path, {}, warn=lambda _l: None)
-        assert "invalid identity in token row 1 of 1" in str(exc.value)
+        assert "invalid identity in token row on line 1 of 1" in str(exc.value)
         assert "Za_ch" in str(exc.value)
 
     def test_GUARD_7_a_TOKEN_can_never_be_read_as_an_identity(self, tmp_path: Path):
@@ -5871,7 +5988,7 @@ class TestScopedTokenRowGuards:
         )
         with pytest.raises(ValueError) as exc:
             api.load_tokens(path, {}, warn=lambda _l: None)
-        assert "invalid identity in token row 1 of 1" in str(exc.value)
+        assert "invalid identity in token row on line 1 of 1" in str(exc.value)
         # 32 and 43, pinned LITERALLY — the cap must stay under the floor or
         # this whole property evaporates silently.
         assert api.MAX_IDENTITY_CHARS == 32
@@ -5887,7 +6004,7 @@ class TestScopedTokenRowGuards:
         path = self._write(tmp_path, f"{ZACH_TOKEN} legacy {ALLOW_SCOPE}")
         with pytest.raises(ValueError) as exc:
             api.load_tokens(path, {}, warn=lambda _l: None)
-        assert "reserved identity in token row 1 of 1" in str(exc.value)
+        assert "reserved identity in token row on line 1 of 1" in str(exc.value)
         assert "'legacy'" in str(exc.value)
 
     def test_GUARD_9_an_explicitly_empty_allowlist_is_refused(self, tmp_path: Path):
@@ -5896,7 +6013,7 @@ class TestScopedTokenRowGuards:
         path = self._write(tmp_path, f"{ZACH_TOKEN} zach ,")
         with pytest.raises(ValueError) as exc:
             api.load_tokens(path, {}, warn=lambda _l: None)
-        assert "empty scope allowlist in token row 1 of 1" in str(exc.value)
+        assert "empty scope allowlist in token row on line 1 of 1" in str(exc.value)
         assert "'zach'" in str(exc.value)
 
     def test_GUARD_10_a_scope_no_URL_could_name_is_refused(self, tmp_path: Path):
@@ -5906,7 +6023,7 @@ class TestScopedTokenRowGuards:
         path = self._write(tmp_path, f"{ZACH_TOKEN} zach kelp.forest")
         with pytest.raises(ValueError) as exc:
             api.load_tokens(path, {}, warn=lambda _l: None)
-        assert "invalid scope in token row 1 of 1" in str(exc.value)
+        assert "invalid scope in token row on line 1 of 1" in str(exc.value)
         assert "kelp.forest" in str(exc.value)
 
     def test_GUARD_10_also_catches_an_EMPTY_entry_inside_a_real_list(
@@ -5920,7 +6037,7 @@ class TestScopedTokenRowGuards:
         )
         with pytest.raises(ValueError) as exc:
             api.load_tokens(path, {}, warn=lambda _l: None)
-        assert "invalid scope in token row 1 of 1" in str(exc.value)
+        assert "invalid scope in token row on line 1 of 1" in str(exc.value)
 
     def test_GUARD_10_also_catches_an_entry_that_FOLDS_AWAY_to_nothing(
         self, tmp_path: Path
@@ -5939,7 +6056,7 @@ class TestScopedTokenRowGuards:
             path = self._write(tmp_path, f"{ZACH_TOKEN} zach {typo}")
             with pytest.raises(ValueError) as exc:
                 api.load_tokens(path, {}, warn=lambda _l: None)
-            assert "invalid scope in token row 1 of 1" in str(exc.value), typo
+            assert "invalid scope in token row on line 1 of 1" in str(exc.value), typo
             assert "folds away" in str(exc.value), typo
 
     def test_GUARD_11_the_MIGRATION_SHAPE_is_refused_not_silently_collapsed(
@@ -5965,7 +6082,7 @@ class TestScopedTokenRowGuards:
         with pytest.raises(ValueError) as exc:
             api.load_tokens(path, {}, warn=lambda _l: None)
         message = str(exc.value)
-        assert "duplicate token in rows 1 and 2" in message
+        assert "duplicate token on lines 1 and 2" in message
         # Both authorities, spelled out — the unrestricted one by name, so an
         # operator reading the pod log can see WHICH reading they nearly got.
         assert "legacy (UNRESTRICTED)" in message
@@ -5995,7 +6112,7 @@ class TestScopedTokenRowGuards:
         with pytest.raises(ValueError) as exc:
             api.load_tokens(path, {}, warn=lambda _l: None)
         message = str(exc.value)
-        assert "invalid identity in token row 2 of 2" in message
+        assert "invalid identity in token row on line 2 of 2" in message
         assert "Za_CH_BAD" in message
 
     def test_GUARD_11_collapses_ONE_GRANT_SPELLED_TWO_WAYS(self, tmp_path: Path):
@@ -6027,7 +6144,7 @@ class TestScopedTokenRowGuards:
         )
         with pytest.raises(ValueError) as exc:
             api.load_tokens(path, {}, warn=lambda _l: None)
-        assert "duplicate token in rows 1 and 2" in str(exc.value)
+        assert "duplicate token on lines 1 and 2" in str(exc.value)
         assert "duplicate identity" not in str(exc.value)
 
     def test_GUARD_11_runs_BEFORE_12_so_an_IDENTICAL_MAPPED_ROW_still_loads(
@@ -6058,7 +6175,7 @@ class TestScopedTokenRowGuards:
         with pytest.raises(ValueError) as exc:
             api.load_tokens(path, {}, warn=lambda _l: None)
         assert "duplicate identity 'zach'" in str(exc.value)
-        assert "rows 1 and 2" in str(exc.value)
+        assert "on lines 1 and 2" in str(exc.value)
 
     def test_GUARD_12_names_the_PHYSICAL_rows_across_a_collapse(
         self, tmp_path: Path
@@ -6076,7 +6193,149 @@ class TestScopedTokenRowGuards:
         )
         with pytest.raises(ValueError) as exc:
             api.load_tokens(path, {}, warn=lambda _l: None)
-        assert "token rows 1 and 3 both claim it" in str(exc.value)
+        assert "token rows on lines 1 and 3 both claim it" in str(exc.value)
+
+    def test_GUARD_12_names_the_PHYSICAL_LINE_when_A_BLANK_LINE_SHIFTS_IT(
+        self, tmp_path: Path
+    ):
+        """🔴 THE FIXTURE ABOVE HAS NO BLANK LINE, SO IT PINS THE COLLAPSE
+        DIMENSION AND NOTHING ELSE — while its name and the comment beside the
+        code both claim PHYSICAL LINES. On a file with no blank line the ordinal
+        over non-blank rows and the line number are the same number, so it reads
+        as coverage for a claim it cannot see.
+
+        This is that claim, reproduced: rows on lines 2, 4 and 6. Lines 2 and 4
+        are identical and collapse; the identity clash is between lines 2 and 6.
+        Counting non-blank rows says "1 and 3" — a real message this code emitted
+        — and sends the operator to two lines that hold nothing.
+        """
+        path = self._write(
+            tmp_path,
+            "",
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE}",
+            "",
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE}",
+            "",
+            f"{DANA_TOKEN} zach {DENY_SCOPE}",
+        )
+        message = str(exc_of(lambda: api.load_tokens(path, {}, warn=lambda _l: None)))
+        assert "token rows on lines 2 and 6 both claim it" in message
+        assert "1 and 3" not in message, (
+            "the ordinal over non-blank rows leaked into the message"
+        )
+
+    def test_GUARD_11_names_the_PHYSICAL_LINE_when_A_BLANK_LINE_SHIFTS_IT(
+        self, tmp_path: Path
+    ):
+        """The same claim for guard 11 — "every guard's message must use them
+        consistently" is only true if every guard is measured. Rows on lines 2
+        and 4, disagreeing, so guard 11 fires rather than 12.
+        """
+        path = self._write(
+            tmp_path,
+            "",
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE}",
+            "",
+            f"{ZACH_TOKEN} zach {DENY_SCOPE}",
+        )
+        message = str(exc_of(lambda: api.load_tokens(path, {}, warn=lambda _l: None)))
+        assert "duplicate token on lines 2 and 4" in message
+        assert "1 and 2" not in message
+
+    @pytest.mark.parametrize(
+        "row,sentence",
+        [
+            ("hunter2", "token on line 4 of 4 is too short"),
+            # Two TOKEN-LENGTH fields, so guard 5 passes and guard 6 is what
+            # fires — `aaa bbb` would have been caught by the length floor first
+            # and this row would have measured guard 5 twice.
+            (f"{ZACH_TOKEN} {LOWER_TOKEN}", "malformed token row on line 4 of 4"),
+            (f"{ZACH_TOKEN} Za_ch {ALLOW_SCOPE}", "invalid identity in token row on line 4 of 4"),
+            (f"{ZACH_TOKEN} legacy {ALLOW_SCOPE}", "reserved identity in token row on line 4 of 4"),
+            (f"{ZACH_TOKEN} zach ,", "empty scope allowlist in token row on line 4 of 4"),
+            (f"{ZACH_TOKEN} zach ___", "invalid scope in token row on line 4 of 4"),
+        ],
+    )
+    def test_GUARDS_5_to_10_ALL_name_the_PHYSICAL_LINE(
+        self, tmp_path: Path, row: str, sentence: str
+    ):
+        """🔴 EVERY GUARD IN THE LADDER, NOT THE ONE THAT WAS CONVENIENT. The
+        index was wrong in ALL of them — it is one loop — so a fix measured at
+        one site is a fix that can be half-applied at the others and still look
+        green. The bad row sits on physical line 4 behind two blank lines and a
+        good row, so an ordinal over non-blank rows would say "2".
+        """
+        path = self._write(tmp_path, "", f"{DANA_TOKEN} dana {DENY_SCOPE}", "", row)
+        message = str(exc_of(lambda: api.load_tokens(path, {}, warn=lambda _l: None)))
+        assert sentence in message, message
+        assert "of 2" not in message, (
+            "`total` is still a count of non-blank rows, so 'line 4 of 2' or "
+            f"'line 2 of 2' can be printed for a 4-line file: {message}"
+        )
+
+    def test_GUARD_11_collapses_a_scope_list_written_in_A_DIFFERENT_ORDER(
+        self, tmp_path: Path
+    ):
+        """🔴 ORDER IS A SPELLING, NOT A DISAGREEMENT, and it was measured being
+        refused: `<tok> zach alpha,beta` and `<tok> zach beta,alpha` answered
+        "two different authorities — zach (alpha,beta) and zach (beta,alpha)".
+        Both grant the same SET, so there IS a defined answer and guard 11 may
+        not claim there is none. Guard 11's own comment already promised this
+        ("rows that merely SPELL one grant differently ... are recognised as the
+        same grant") while the code delivered it for case-folding only.
+
+        The FIRST row's spelling is what survives, which is the same rule the
+        rest of the collapse follows.
+        """
+        path = self._write(
+            tmp_path,
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE},{DENY_SCOPE}",
+            f"{ZACH_TOKEN} zach {DENY_SCOPE},{ALLOW_SCOPE}",
+        )
+        assert loaded(path, {}) == [
+            (ZACH_TOKEN, "zach", (ALLOW_SCOPE, DENY_SCOPE))
+        ]
+
+    def test_GUARD_11_a_GENUINE_disagreement_is_STILL_refused(
+        self, tmp_path: Path
+    ):
+        """🔴 THE UPPER BOUND ON THE FIX ABOVE. Comparing SETS must not become
+        comparing nothing: `alpha,beta` and `alpha` are two different grants and
+        one is strictly wider, which is the fail-open direction. Same shape as
+        the collapse above — one token, one identity, two scope lists — so a
+        mutant that returned a constant key, or dropped `scopes` from the key
+        entirely, passes the test above and dies here.
+        """
+        path = self._write(
+            tmp_path,
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE},{DENY_SCOPE}",
+            f"{ZACH_TOKEN} zach {ALLOW_SCOPE}",
+        )
+        message = str(exc_of(lambda: api.load_tokens(path, {}, warn=lambda _l: None)))
+        assert "duplicate token on lines 1 and 2" in message
+        assert f"zach ({ALLOW_SCOPE},{DENY_SCOPE})" in message
+        assert f"zach ({ALLOW_SCOPE})" in message
+
+    def test_GUARD_11_a_BARE_row_never_collapses_into_a_MAPPED_one(
+        self, tmp_path: Path
+    ):
+        """A bare row and a mapped row on ONE token are two authorities, and the
+        refusal names the unrestricted one so the operator can see which reading
+        they nearly got.
+
+        ⚠ WHAT THIS DOES **NOT** PIN, said because the obvious reading of the
+        name is wrong: it is not a test of `_authority_key`'s `None`-vs-empty
+        asymmetry. The two rows differ in IDENTITY (`legacy` vs `zach`), so the
+        identity component alone decides, and a mutant folding `None` into the
+        empty frozenset SURVIVES this — measured. See `_authority_key`'s own
+        note for why that mutant is unreachable rather than uncaught.
+        """
+        path = self._write(
+            tmp_path, ZACH_TOKEN, f"{ZACH_TOKEN} zach {ALLOW_SCOPE}"
+        )
+        message = str(exc_of(lambda: api.load_tokens(path, {}, warn=lambda _l: None)))
+        assert "duplicate token on lines 1 and 2" in message
+        assert "legacy (UNRESTRICTED)" in message
 
     def test_a_WELL_FORMED_mapped_file_loads_with_its_allowlist(self, tmp_path: Path):
         """The positive control for all six guards above. Without it, a parser
@@ -6895,16 +7154,22 @@ class TestUnreadableEntriesInDeniedScopes:
       * broke `/recall` and `/search` for EVERY caller, including the ones whose
         own scopes were perfectly readable;
       * and for a FIFO named `*.md`, blocked the request thread on `open()`
-        indefinitely. `/snapshot` already refuses that by kind
+        indefinitely. `/snapshot` already refused that by kind
         (`_ENTRY_ACTIONS[KIND_OTHER] == REFUSE`); the index path did not.
 
-    Fixed by pushing `visible_scopes` DOWN into `load_index`, so a denied scope
-    dir is never descended into at all.
+    Fixed in TWO steps, and the split matters because they cover different
+    callers:
 
-    🔴 AND THE LIMIT IS TESTED TOO, not just stated: an UNRESTRICTED caller —
-    which is what a bare legacy token is, and what the pod is deployed with
-    today — is exactly as exposed as before. `test_the_UNRESTRICTED_reading_is_
-    UNCHANGED_and_that_is_the_residual` is the honest record of that.
+      1. `visible_scopes` pushed DOWN into `load_index`, so a denied scope dir
+         is never descended into at all. Protects a SCOPED caller only.
+      2. an entry-KIND check before `open()`
+         (`subsystem_resolver._LOADER_ENTRY_ACTIONS`), which protects EVERY
+         caller including the unrestricted bare legacy token the pod runs.
+
+    🔴 AND THE LIMIT OF (2) IS TESTED TOO, not just stated: it is NARROW. A
+    `chmod 000` regular file still raises for an unrestricted caller —
+    `test_an_UNREADABLE_REGULAR_FILE_still_RAISES_and_THAT_is_the_residual` is
+    the honest record of what did NOT close.
     """
 
     def _store(self, tmp_path: Path, kind: str) -> Path:
@@ -6939,33 +7204,85 @@ class TestUnreadableEntriesInDeniedScopes:
         assert index.scopes == (ALLOW_SCOPE,)
         assert index.malformed == ()
 
-    @pytest.mark.parametrize("kind", ["perm", "emacs"])
     def test_POSITIVE_CONTROL_the_same_file_in_the_CALLERS_OWN_scope_still_RAISES(
-        self, tmp_path: Path, kind: str
+        self, tmp_path: Path
     ):
         """🔴 WITHOUT THIS THE TEST ABOVE IS SATISFIED BY A FIXTURE THAT CREATED
         NOTHING UNREADABLE. It also pins the half that must NOT change: the
         four-state rule. "I could not read your store" and "you may see nothing"
         both produce an empty index, and only the first may raise.
+
+        ⚠ `perm` ONLY, and the parametrize over `emacs` that used to be here was
+        DELETED rather than left to fail: the entry-kind guard now refuses a
+        broken link before `open()`, so that shape no longer raises for ANY
+        caller. Its own-scope behaviour is asserted below, as a collected
+        malformed row.
         """
-        store = self._store(tmp_path, kind)
+        store = self._store(tmp_path, "perm")
         with pytest.raises(api.rc.EntryUnreadableError):
             api.rc.load_store(store, verb="recalled", visible_scopes=(DENY_SCOPE,))
 
-    @pytest.mark.parametrize("kind", ["perm", "emacs"])
-    def test_the_UNRESTRICTED_reading_is_UNCHANGED_and_that_is_the_residual(
-        self, tmp_path: Path, kind: str
+    def test_the_BROKEN_LINK_in_the_CALLERS_OWN_scope_is_REPORTED_not_fatal(
+        self, tmp_path: Path
     ):
-        """🔴 THE LIMIT OF THE FIX, ASSERTED RATHER THAN LEFT TO BE DISCOVERED.
-
-        `visible_scopes=None` skips nothing, so an unreadable entry anywhere
-        still takes the whole store down for a local CLI caller — and for a BARE
-        LEGACY TOKEN, which is unrestricted and is what the pod is deployed with
-        today. This test exists so nobody reads the class docstring above and
-        concludes the live API is protected by it. Closing it needs an entry-KIND
-        guard in `load_index`; see that function's own note.
+        """The other side of the guard: refusing an entry must not silently
+        empty the scope that holds it. The caller who OWNS the hostile file
+        still gets their good entry, and still gets told about the bad one.
         """
-        store = self._store(tmp_path, kind)
+        store = self._store(tmp_path, "emacs")
+        _s, index = api.rc.load_store(
+            store, verb="recalled", visible_scopes=(DENY_SCOPE,)
+        )
+        assert index.scopes == (DENY_SCOPE,)
+        assert len(index) == 1
+        assert [m.label for m in index.malformed] == [f"{DENY_SCOPE}/{EMACS_LOCK}"]
+
+    def test_the_UNRESTRICTED_reading_of_a_BROKEN_LINK_no_longer_DIES(
+        self, tmp_path: Path
+    ):
+        """🔴 THE INVERSION. This test used to be
+        `test_the_UNRESTRICTED_reading_is_UNCHANGED_and_that_is_the_residual`
+        and asserted `pytest.raises(EntryUnreadableError)` — the honest record
+        of a residual the allowlist pushdown could not reach. The residual was
+        CLOSED by the entry-kind guard, so the same input must now assert the
+        opposite, and the name has to say which.
+
+        `visible_scopes=None` still skips no SCOPE — that half is unchanged and
+        is why this matters: the pod runs a bare legacy token, which is
+        unrestricted. What changed is that the candidate's KIND is decided
+        before `open()`, so the Emacs lock file costs its own entry and nothing
+        else.
+        """
+        store = self._store(tmp_path, "emacs")
+        _s, index = api.rc.load_store(store, verb="recalled")
+        # The OTHER scope's content survived, which is the DoS half.
+        assert set(index.scopes) == {ALLOW_SCOPE, DENY_SCOPE}
+        assert len(index) == 2, "a good entry was dropped along with the bad one"
+        # …and the bad entry is REPORTED, not silently skipped: a dropped entry
+        # is indistinguishable from one nobody ever wrote, which is the exact
+        # conflation this store guards against everywhere else.
+        assert [m.label for m in index.malformed] == [f"{DENY_SCOPE}/{EMACS_LOCK}"]
+        assert "broken symlink" in index.malformed[0].reason
+
+    def test_an_UNREADABLE_REGULAR_FILE_still_RAISES_and_THAT_is_the_residual(
+        self, tmp_path: Path
+    ):
+        """🔴 THE HALF THAT IS **NOT** CLOSED, kept as its own named test rather
+        than left implied by the parametrize list this used to share.
+
+        A `chmod 000` regular file classifies as `regular-file`, which the
+        loader TAKES — deliberately. `read_text` then raises, and an OSError
+        fails closed in both policies: "the store was not fully READ" is a
+        different fact from "this entry is malformed", and only the second has
+        an honest degraded form. So for THIS shape an unrestricted caller is
+        exactly as exposed as before: 503, and the path in the body
+        (`test_POSITIVE_CONTROL_a_LEGACY_token_DOES_still_get_the_503`).
+
+        It is also the negative control for the test above: if the kind guard
+        were quietly widened to refuse everything it could not read, this would
+        go green-by-collapse and the four-state rule would be gone.
+        """
+        store = self._store(tmp_path, "perm")
         with pytest.raises(api.rc.EntryUnreadableError):
             api.rc.load_store(store, verb="recalled")
 
@@ -7038,9 +7355,17 @@ class TestUnreadableEntriesInDeniedScopes:
         On a `replicas: 1` Deployment an `open()` that never returns is worse
         than the 503: the worker is gone and the next request queues behind it.
 
-        The NEGATIVE CONTROL is in the same run and is what makes the timeout
-        meaningful — the unrestricted load of the SAME store must still hang, or
-        this test is measuring a FIFO that somehow opens.
+        🔴 THE UNRESTRICTED ARM IS AN INVERSION. It used to be the NEGATIVE
+        CONTROL — "the unrestricted load of the SAME store must still hang", the
+        residual the allowlist pushdown could not reach. The entry-kind guard
+        closed it, so the same probe must now COMPLETE, load both scopes, and
+        report the FIFO as a malformed entry. A control that asserts a hazard is
+        still live cannot survive the hazard being fixed; it has to be re-aimed
+        or it becomes a test pinning the bug.
+
+        What keeps the timeout meaningful instead is
+        `test_a_TAKEN_kind_still_HANGS_which_is_why_the_REFUSE_cells_exist`
+        below: the same machinery, aimed at a kind the loader still TAKES.
         """
         store = self._store(tmp_path, "fifo")
         probe = (
@@ -7049,7 +7374,8 @@ class TestUnreadableEntriesInDeniedScopes:
             "import subsystem_recall as rc;"
             f"vs = None if sys.argv[1] == 'unrestricted' else ({ALLOW_SCOPE!r},);"
             f"_s, i = rc.load_store({str(store)!r}, verb='recalled', visible_scopes=vs);"
-            "print('SCOPES=' + ','.join(i.scopes))"
+            "print('SCOPES=' + ','.join(i.scopes));"
+            "print('MALFORMED=' + ','.join(m.label for m in i.malformed))"
         )
 
         def run(arg: str, deadline: float):
@@ -7068,20 +7394,250 @@ class TestUnreadableEntriesInDeniedScopes:
             "allowlist is not reaching `load_index`"
         )
         assert scoped.returncode == 0, scoped.stderr[-600:]
-        assert scoped.stdout.strip() == f"SCOPES={ALLOW_SCOPE}"
+        assert f"SCOPES={ALLOW_SCOPE}\n" in scoped.stdout, scoped.stdout
+        # The denied scope was never descended into, so its FIFO is not even
+        # reported — step 1 still does its own job.
+        assert "MALFORMED=\n" in scoped.stdout, scoped.stdout
 
-        # 🔴 NEGATIVE CONTROL, SAME STORE, SAME PROBE, ONE ARGUMENT DIFFERENT. A
-        # FIFO that opened would make the assertion above pass for the wrong
-        # reason; this proves the hazard is real and still live for the
-        # unrestricted reading, which is the residual documented above. Its
-        # deadline is DELIBERATELY the shorter of the two: the scoped run has
-        # already shown a healthy load of this store finishes well inside it, so
-        # a timeout here is a block, not a slow interpreter.
-        assert run("unrestricted", 15.0) is None, (
-            "the UNRESTRICTED reader did NOT hang on the FIFO — either the "
-            "fixture is not a FIFO, or the residual this suite documents has "
-            "silently been fixed and these comments are now wrong"
+        unrestricted = run("unrestricted", 15.0)
+        assert unrestricted is not None, (
+            "the UNRESTRICTED reader HUNG on the FIFO — the entry-kind guard is "
+            "not reaching `load_index`, and on a `replicas: 1` Deployment that "
+            "is a worker that never comes back"
         )
+        assert unrestricted.returncode == 0, unrestricted.stderr[-600:]
+        assert f"SCOPES={ALLOW_SCOPE},{DENY_SCOPE}\n" in unrestricted.stdout
+        assert f"MALFORMED={DENY_SCOPE}/{LOCKED_ENTRY}\n" in unrestricted.stdout
+
+    def test_a_TAKEN_kind_still_HANGS_which_is_why_the_REFUSE_cells_exist(
+        self, tmp_path: Path
+    ):
+        """🔴 THE POSITIVE CONTROL FOR THE PROBE ITSELF, and the honest record of
+        the `link-to-other` residual in one test.
+
+        Every assertion in the test above is now "it did NOT hang", which is
+        exactly the reassuring zero `claude/RULES.md` calls indistinguishable
+        from a harness wired to nothing: a probe that crashed on import, or a
+        fixture that made no FIFO, would satisfy all of them. So this drives the
+        SAME probe at a store whose hostile entry is a SYMLINK POINTING AT a
+        fifo — `link-to-other`, which the narrow ruling leaves `TAKE` — and
+        watches it block.
+
+        It therefore asserts two things at once: the deadline machinery can
+        still observe a hang, and the one shape the narrow guard does not cover
+        is genuinely uncovered. Closing that residual means flipping ONE cell of
+        `_LOADER_ENTRY_ACTIONS`, and this test is what will go red and tell
+        whoever does it to update the table pin.
+        """
+        store = _build_store(
+            tmp_path / "store",
+            {ALLOW_SCOPE: KELP_NUANCE, DENY_SCOPE: QUARTZ_NUANCE},
+        )
+        real_fifo = tmp_path / "a-real-fifo"
+        os.mkfifo(real_fifo)
+        os.symlink(real_fifo, store / DENY_SCOPE / LOCKED_ENTRY)
+        assert api.classify_path(store / DENY_SCOPE / LOCKED_ENTRY) == (
+            api.KIND_LINK_TO_OTHER
+        ), "the fixture is not the kind this test is about"
+
+        probe = (
+            "import sys;"
+            f"sys.path.insert(0, {str(RECALL_PATH.parent)!r});"
+            "import subsystem_recall as rc;"
+            f"rc.load_store({str(store)!r}, verb='recalled');"
+            "print('LOADED')"
+        )
+        try:
+            done = subprocess.run(
+                [sys.executable, "-c", probe],
+                capture_output=True, text=True, timeout=15.0,
+            )
+        except subprocess.TimeoutExpired:
+            done = None
+        assert done is None, (
+            "a symlink-to-FIFO entry did NOT block the reader. Either the guard "
+            "was widened to cover `link-to-other` — in which case flip that cell "
+            "in DECISION_TABLE and re-aim this test — or this probe is no longer "
+            "measuring anything, which would make every 'it did not hang' "
+            f"assertion above vacuous. stdout={None if done is None else done.stdout!r}"
+        )
+
+
+class TestTheLoaderRefusesHostileEntriesByKind:
+    """🔴 THE NARROW ENTRY-KIND GUARD — what it closes, and what it must not.
+
+    The allowlist pushdown protects a SCOPED caller. `visible_scopes=None` skips
+    nothing, and the live pod runs a BARE LEGACY token, which is unrestricted —
+    so on the deployed configuration a single `.#entry.md` lock file 503'd every
+    recall and a single FIFO wedged the worker. That is the configuration these
+    tests drive.
+
+    🔴 AND THE GUARD IS NARROW BY DECISION, NOT BY ACCIDENT. Mirroring
+    `/snapshot`'s `_ENTRY_ACTIONS` wholesale also refuses a symlink to a regular
+    file, a directory and an unstat-able path — all of which this loader reads or
+    fails on TODAY, so the broad form is a behaviour change for every local CLI
+    caller. `test_a_SYMLINKED_entry_is_STILL_READ…` is the test that kills the
+    broad form; without it "refuse hostile kinds" has no upper bound.
+    """
+
+    def _hostile(self, tmp_path: Path) -> Path:
+        """One store, BOTH refused shapes, in a scope that is not the one asked
+        for — the arrangement the operator reproduced: unrestricted token, a
+        dangling `.#lock.md` in `bravo`, and a recall for `alpha`.
+        """
+        store = _build_store(
+            tmp_path / "store",
+            {ALLOW_SCOPE: KELP_NUANCE, DENY_SCOPE: QUARTZ_NUANCE},
+        )
+        _make_unreadable(store, DENY_SCOPE, "emacs")
+        _make_unreadable(store, DENY_SCOPE, "fifo")
+        return store
+
+    def test_an_UNRESTRICTED_recall_of_ANOTHER_scope_is_200_not_503(
+        self, tmp_path: Path
+    ):
+        """🔴 THE MEASURED SYMPTOM, DRIVEN THROUGH THE SERVER ON THE LIVE
+        CREDENTIAL SHAPE. Before the guard this exact request answered `503
+        index entry unreadable … '<store>/quartz-mine/.#sealed-adit.md'`.
+
+        `GOOD_TOKEN` is a BARE row, so the record is `legacy`/unrestricted —
+        the pod's own configuration, not a scoped token that would be protected
+        by the allowlist pushdown instead.
+        """
+        store = self._hostile(tmp_path)
+        with running(store, tokens=(GOOD_TOKEN,)) as (base, _):
+            code, headers, body = fetch(
+                f"{base}/api/v1/recall/{ALLOW_SCOPE}", token=GOOD_TOKEN
+            )
+        text = body.decode()
+        assert code == 200, f"{code}: {text[:400]}"
+        assert headers["X-Store-Status"] == "recalled"
+        assert KELP_NUANCE in text, "the caller's own content vanished"
+
+    def test_the_REFUSED_entries_are_SURFACED_not_silently_dropped(
+        self, tmp_path: Path
+    ):
+        """🔴 A SKIP RENDERS AS "NOTHING RECORDED", which is the conflation this
+        whole store exists to avoid — so the 200 above is only correct if the
+        two refused files are still ACCOUNTED FOR.
+
+        Asserted on the index rather than on the rendered body, because the body
+        deliberately reports cross-scope defects as a COUNT with scopes named and
+        never a filename; the per-file facts live here.
+        """
+        store = self._hostile(tmp_path)
+        _s, index = api.rc.load_store(store, verb="recalled")
+        labels = sorted(m.label for m in index.malformed)
+        assert labels == sorted(
+            [f"{DENY_SCOPE}/{EMACS_LOCK}", f"{DENY_SCOPE}/{LOCKED_ENTRY}"]
+        )
+        reasons = " ".join(m.reason for m in index.malformed)
+        assert "broken symlink" in reasons
+        assert "not a regular file" in reasons
+        # …and the good entry in that same scope is still served.
+        assert len(index.entries(DENY_SCOPE)) == 1
+
+    def test_a_SYMLINKED_entry_is_STILL_READ_the_guard_is_NOT_the_broad_one(
+        self, tmp_path: Path
+    ):
+        """🔴 THE UPPER BOUND ON THE GUARD, AND THE MUTANT IT EXISTS TO KILL.
+
+        `_ENTRY_ACTIONS[KIND_LINK_TO_FILE]` is REFUSE, because `/snapshot` will
+        not follow a link out of the store. The LOADER has always read one, and
+        a `<scope>/<slug>.md -> ../shared/<slug>.md` symlink is an ordinary way
+        to keep one entry in two places. Copying `/snapshot`'s column here is the
+        over-broad form that was rejected on this PR; flipping that one cell to
+        REFUSE turns this entry into a malformed row and fails here.
+
+        The entry's CONTENT is asserted, not merely its presence: a guard that
+        refused it would still leave the scope registered.
+        """
+        store = _build_store(tmp_path / "store", {ALLOW_SCOPE: KELP_NUANCE})
+        real = tmp_path / "outside" / "linked-entry.md"
+        real.parent.mkdir()
+        real.write_text(
+            _entry("linked-entry", ALLOW_SCOPE, nuance="- 2026-03-06: via a link.")
+        )
+        link = store / ALLOW_SCOPE / "linked-entry.md"
+        os.symlink(real, link)
+        assert api.classify_path(link) == api.KIND_LINK_TO_FILE, (
+            "the fixture is not a symlink-to-regular-file, so this measures "
+            "nothing about the cell it names"
+        )
+
+        _s, index = api.rc.load_store(store, verb="recalled")
+        assert index.malformed == (), (
+            "a symlinked entry was refused — the guard has been widened to the "
+            "broad `_ENTRY_ACTIONS` form the narrow ruling rejected"
+        )
+        assert sorted(e.slug for e in index.entries(ALLOW_SCOPE)) == sorted(
+            ["linked-entry", f"{ALLOW_SCOPE}-entry"]
+        )
+
+    def test_under_RAISE_a_refused_entry_RAISES_the_same_class_as_any_other(
+        self, tmp_path: Path
+    ):
+        """🔴 THE POLICY IS `on_malformed`'s, NOT THE GUARD'S. The WRITER's probe
+        loads with `RAISE` precisely because it must not modify a store it read
+        only part of, and that is as true of a fifo as of a wrapped `aliases:`
+        line. A guard that collected unconditionally would silently hand the
+        writer a partial index.
+        """
+        store = self._hostile(tmp_path)
+        with pytest.raises(api.rc.MalformedEntryError) as exc:
+            api.rc.load_index(store)
+        assert "malformed index entry" in str(exc.value)
+        assert exc.value.source in (EMACS_LOCK, LOCKED_ENTRY)
+
+    def test_a_BOGUS_policy_is_still_a_ValueError_not_a_refusal(
+        self, tmp_path: Path
+    ):
+        """The guard branches on `on_malformed` BEFORE `build_index` validates
+        it, so the predicate is shared (`_check_on_malformed`) rather than
+        spelled twice. Spelled twice, a bogus policy on a hostile store would be
+        answered with a complaint about the first fifo instead of about the
+        policy — a message that sends the operator to the wrong file.
+        """
+        store = self._hostile(tmp_path)
+        with pytest.raises(ValueError, match="on_malformed must be one of"):
+            api.rc.load_index(store, on_malformed="collct")
+
+    def test_the_REFUSED_row_is_filed_under_the_FOLDED_scope(self, tmp_path: Path):
+        """🔴 THE SCOPE ON A `MalformedEntry` IS THE NORMALIZED ONE — that is
+        `MalformedEntry`'s own contract, and `malformed_in` compares against
+        `normalize_ref(scope)`. A refusal filed under the RAW directory name
+        matches no scope, so it vanishes from `malformed_in` and surfaces only
+        through the store-wide count: reported, but not against the scope that
+        holds it, which is where the operator will look.
+
+        The fixture directory really is spelled `Kelp_Forest`. Every other store
+        in this file is already its own folded form, so an unfolded mutant
+        survives them all.
+        """
+        raw_dir = "Kelp_Forest"
+        assert api.rc.normalize_ref(raw_dir) == ALLOW_SCOPE != raw_dir
+        store = _build_store(tmp_path / "store", {raw_dir: KELP_NUANCE})
+        _make_unreadable(store, raw_dir, "emacs")
+
+        _s, index = api.rc.load_store(store, verb="recalled")
+        assert [m.label for m in index.malformed_in(ALLOW_SCOPE)] == [
+            f"{ALLOW_SCOPE}/{EMACS_LOCK}"
+        ]
+        assert index.malformed_outside([ALLOW_SCOPE]) == ()
+
+    def test_a_CLEAN_store_is_UNCHANGED_by_the_guard(self, tmp_path: Path):
+        """The positive control. Every assertion above is about a hostile store;
+        without this, a loader that refused EVERY candidate would satisfy the
+        `.malformed` ones and only fail on content nobody asserted.
+        """
+        store = _build_store(
+            tmp_path / "store",
+            {ALLOW_SCOPE: KELP_NUANCE, DENY_SCOPE: QUARTZ_NUANCE},
+        )
+        _s, index = api.rc.load_store(store, verb="recalled")
+        assert index.malformed == ()
+        assert len(index) == 2
+        assert set(index.scopes) == {ALLOW_SCOPE, DENY_SCOPE}
 
 
 class TestScopeFilteringIsNotAWriteVerb:

--- a/scripts/tests/test_subsystem_touch.py
+++ b/scripts/tests/test_subsystem_touch.py
@@ -7833,8 +7833,34 @@ class TestJournalMutationKillMatrix:
         assert "top 3 of 5" in text, "the cap stopped applying, so this is not the notice's kill"
 
     def test_kills_the_UNREADABLE_wrap_in_build_report(self, tmp_path) -> None:
-        """Without it an `IsADirectoryError` escapes with nothing saying the
-        SUBSYSTEM STORE was what failed."""
+        """Without it a raw `OSError` escapes with nothing saying the SUBSYSTEM
+        STORE was what failed.
+
+        🔴 THE SEVENTH `mkdir` SITE, AND THE ONE THE SWEEP MISSED. This fixture
+        was `(store / SCOPE / "half-written.md").mkdir()` for a round after the
+        six others were migrated — same file, same filename, 276 lines below the
+        sibling at `test_an_UNREADABLE_entry_raises_the_named_error_from_
+        build_report` that WAS migrated. `_LOADER_ENTRY_ACTIONS` now REFUSES
+        `directory` before `open()`, so `load_index` raised `MalformedEntryError`
+        and the `except OSError -> EntryUnreadableError` clause THIS TEST MUTATES
+        was never reached: mutant and pristine module raised the same
+        `MalformedEntryError` and both assertions below passed either way.
+        Measured, not inferred — an IDENTITY replacement (mutant == original) on
+        the old fixture gave `1 passed`, where a sensitive kill must give a
+        FAILURE.
+
+        The replacement is the same ENOTDIR symlink the six siblings use — a
+        path "under" a regular file, which `classify_path` calls `indeterminate`
+        ("I could not look") and the loader deliberately still TAKEs, so
+        `read_text` runs and raises `NotADirectoryError`. Privilege-independent
+        on purpose: a `chmod 000` would be bypassed by a root-run sandbox, which
+        is a conditionally dead control rather than a live one.
+
+        The premise is ASSERTED, not assumed — that is what the old fixture
+        silently lost — and the mutant's OWN symptom is pinned, so a future
+        refusal that moves this shape back onto the malformed path fails here
+        instead of going quietly vacuous again.
+        """
         mod = _load_mutant(
             tmp_path,
             "mj_unreadable",
@@ -7843,13 +7869,30 @@ class TestJournalMutationKillMatrix:
               '        raise RuntimeError(\n            f"neutered: under {store} ')],
         )
         store = _journal_store(tmp_path)
-        (store / SCOPE / "half-written.md").mkdir()
+        blocker = store / SCOPE / ".not-a-directory"
+        blocker.write_text("a regular file, so paths UNDER it are ENOTDIR\n")
+        os.symlink(blocker / "child", store / SCOPE / "half-written.md")
+        assert sr.classify_path(store / SCOPE / "half-written.md") == (
+            sr.KIND_INDETERMINATE
+        ), "the fixture is a kind the loader REFUSES, so it never reaches a read"
         with pytest.raises(Exception) as exc:
             mod.build_report(
                 mod.caller_supplied(_journal_paths("batcher")), store, SCOPE, today=TODAY
             )
         assert not isinstance(exc.value, st.EntryUnreadableError)
         assert "index entry unreadable" not in str(exc.value)
+        # 🔴 THE ANTI-VACUUM HALF. Without this the two assertions above are
+        # satisfied by ANY other exception — including the `MalformedEntryError`
+        # a refused entry raises, which is exactly how this test died the first
+        # time. `MalformedEntryError` is a `ResolverError`, never a
+        # `RuntimeError`, so this names the neutered raise and nothing else.
+        assert isinstance(exc.value, RuntimeError), (
+            f"the mutated clause was never reached — got {type(exc.value).__name__}: "
+            f"{exc.value}"
+        )
+        assert str(exc.value).startswith("neutered: under "), (
+            "the raise that escaped is not the one this mutation planted"
+        )
 
     def test_kills_the_MALFORMED_refusal_wording(self, tmp_path) -> None:
         """🔴 SUPERSEDES `test_the_MALFORMED_reraise_is_UNKILLABLE_and_that_is_the

--- a/scripts/tests/test_subsystem_touch.py
+++ b/scripts/tests/test_subsystem_touch.py
@@ -7559,10 +7559,23 @@ class TestJournalNegativeControls:
         self, tmp_path
     ) -> None:
         """Reachable through the whole flow: the loader reads every `*.md`, so a
-        directory sitting where one is expected fails there — with a NAME, not as
-        a bare `IsADirectoryError`."""
+        candidate it TAKEs and then cannot read fails there — with a NAME, not
+        as a bare `OSError`.
+
+        ⚠ IT USED TO BE A DIRECTORY. That shape is now REFUSED before `open()`
+        (`_LOADER_ENTRY_ACTIONS`, after one stray `mkdir <scope>/<slug>.md` was
+        measured 503ing the whole store), so it takes the MALFORMED path and
+        this control had gone vacuous. The replacement is a symlink whose target
+        resolution fails with ENOTDIR — `indeterminate`, which the loader still
+        TAKEs deliberately — and it is still not a permission change a root-run
+        sandbox would bypass."""
         store = _journal_store(tmp_path)
-        (store / SCOPE / "half-written.md").mkdir()
+        blocker = store / SCOPE / ".not-a-directory"
+        blocker.write_text("a regular file, so paths UNDER it are ENOTDIR\n")
+        os.symlink(blocker / "child", store / SCOPE / "half-written.md")
+        assert sr.classify_path(store / SCOPE / "half-written.md") == (
+            sr.KIND_INDETERMINATE
+        ), "the fixture is a kind the loader REFUSES, so it never reaches a read"
         with pytest.raises(st.EntryUnreadableError) as exc:
             _journal_render(store, "batcher")
         assert "index entry unreadable" in str(exc.value)


### PR DESCRIPTION
Cairn phase 3, **criteria 1, 2 and 3 ONLY** — two-token authorization on the **read** path.

## 🔴 The write path (criteria 4-10) is NOT in this PR

No new verb, no append endpoint, no `PUT`. Asserted, not stated:

- `do_POST = do_PUT = do_PATCH = do_DELETE = _reject_write` is **byte-for-byte untouched**, and `TestPhaseOneScope::test_the_server_declares_no_write_handler` still pins it.
- `API_ROUTES` is still exactly `("recall", "search", "snapshot")`; `TestPhaseOneScope.ROUTES` did not move.
- A new test, `TestScopeFilteringIsNotAWriteVerb`, restates both claims **inside the section that added scoping**, plus a behavioural check that all four write verbs are still `405 read-only` when presented a valid **scoped** token — so a future branch that adds a verb "while it is touching auth anyway" fails a test here.

## The finding that drives it

`GET /api/v1/recall/<never-existed>` answers **200**, `X-Store-Status: scope-absent`, and the body ends `scopes the store does hold: <every scope>`. The absent path was **already** an enumeration oracle. A per-route "is this scope yours" check would have closed almost none of it, because three of the four channels fire on requests that are entirely legitimate.

## The four channels, and how each is closed

| # | channel | fires when | closed by |
|---|---|---|---|
| 1 | `known_scopes` | every `scope-absent` report | index narrowing in `load_store` |
| 2 | `malformed_elsewhere` | **every status** — including an ordinary 200 for a scope the caller DOES own | index narrowing in `load_store` |
| 3 | `search?all_scopes=1` | names **no scope**, so a per-scope check has nothing to refuse; searches every scope's CONTENT | index narrowing in `load_store` |
| 4 | the `/snapshot` tar | ships the entry files themselves; never builds an index | filter on `_snapshot`'s candidate list |

1-3 all derive from the single `SubsystemIndex` returned by `subsystem_recall.load_store` — the one site both readers load from — so a `visible_scopes` narrowing there closes all three at once and **cannot be forgotten by a route**. The filtered index is rebuilt from the two public fields only:

```python
SubsystemIndex(
    by_scope={k: v for k, v in index.by_scope.items() if k in allowed},
    malformed=tuple(m for m in index.malformed if m.scope in allowed),
)
```

`scopes`, `malformed_in`, `malformed_outside`, `entries` and `__len__` are all derived from those two, so every derived answer narrows with them — including accessors added later. `subsystem_resolver.py` is **not touched** (#360's non-goal).

Channel 4 is filtered at the *candidate* list rather than at the tar members, so an out-of-allowlist scope is never classified, never opened, and can never reach the `unreadable` list — a refused scope must not be able to 503 somebody else's snapshot.

### Two seams the index filter cannot reach

- **`X-Store-Revision`** reads `<store>/<scope>/.git/HEAD`, outside the index entirely. No scope in the served copy is a git repo today, so the leak is **latent** — exactly the state in which a guard gets skipped. Gated by construction, and the test **makes** a denied scope a real git repo with a real commit before asserting the header is still `unknown`. It also asserts the caller's *own* scope still reports its sha, because over-filtering would silently delete the `scope@sha` determinism guarantee.
- **The per-request handler reset** is `()` (nothing visible), never the unrestricted `None`. `None` is the unrestricted sentinel everywhere else in the file, which makes it the one value this field must not default to.

## Criterion 1 — the token file row format

```
<token>                                    # LEGACY: identity `legacy`, ALL scopes
<token>   <identity>   <scope>,<scope>     # MAPPED: named holder, scoped
```

🔴 **A bare row stays valid and means unrestricted scope.** That is the migration (mapped rows land beside the old shared token) and the rollback required by criterion 10 (put the one line back — no code change). A file mixing both loads, and any legacy row emits **one loud stderr line** at startup naming the count and the legacy fingerprints.

🔴 **Whitespace now separates the three FIELDS of one row, not two tokens.** The old parser split the whole file on whitespace. A line that used to be two credentials is now refused as `malformed token row N of M` — **never reinterpreted**. `MAX_IDENTITY_CHARS` (32) is deliberately **below** `MIN_TOKEN_CHARS` (43), so a token in the identity field is refused by arithmetic rather than by a spelling.

`identity=` is an **additive** audit field. `token=<fingerprint>` is unchanged and is still the only thing that can tell one holder's current credential from its previous one during an overlap rotation.

### The guard ladder

Guards 1-5 are **unchanged in wording and order**. Six new ones, each with its own sentence, each reachable by an input that passes every earlier guard:

| # | message | reached by |
|---|---|---|
| 1-5 | *(unchanged)* | — |
| 6 | `malformed token row N of M` | `<tok> zach` (2 fields) / `<tok> zach s extra` (4) |
| 7 | `invalid identity in token row N of M` | `<tok> Za_ch s` (charset) / `<tok> <48-char lowercase> s` (length) |
| 8 | `reserved identity in token row N of M` | `<tok> legacy s` |
| 9 | `empty scope allowlist in token row N of M` | `<tok> zach ,` |
| 10 | `invalid scope in token row N of M` | `<tok> zach kelp.forest`, `<tok> zach a,,b`, `<tok> zach -` |
| 11 | `duplicate identity 'X'` | two rows, both well-formed, same identity |

**Guard 11 exempts `legacy`, deliberately** — two bare rows are the ordinary current+previous overlap file that guards 1-5 exist to support, and that criterion 10's rollback restores. Rotating a *mapped* credential uses a second identity (`zach-prev`); two rows claiming one identity with disagreeing allowlists have no defined precedence, so they are refused. Both directions are tested.

**Guard 10 checks the FOLDED value, not the typed one.** `-` and `___` are inside `[A-Za-z0-9_-]+` and perfectly namable in a URL, and `normalize_ref` folds both to the empty string — an allowlist entry that matches no index key, i.e. a grant that reads as working and does nothing. That is precisely what the guard's own sentence promises to prevent, so it is checked where it matters. Found by reading the guard against its description, not by a test.

## Criterion 3 — proven, not assumed

`TestRefusedIsIndistinguishableFromAbsent` asks the **same token** for the **same path** at the **same store root**, once when the scope holds an entry and once when it never existed — with the store-wide `.md` count and every mtime held constant (the scope is rebuilt under a different name). Status line, **full body bytes** and **every** `X-Store-*` header compare equal, for `recall` and for `search`.

**Positive control**: the same two phases driven by an unrestricted legacy token, watched to **differ** (`recalled` + content vs `scope-absent`). Without it the equality above would be measuring the harness.

## ⚠ Residual leak, stated rather than left to be found

`X-Store-Snapshot` and the freshness prose stay **store-wide** and carry a total `entry-files=` count over scopes the caller cannot name. Scoping it would make "how old is this copy" a function of your own allowlist, which is worse — but it is a real count leak, it is documented in the module docstring and the README, and it is why the byte-identity claim is about refused-vs-absent and never about two different stores.

## Red → green matrix

🔴 **Honestly labelled.** `server.py` and the absent path both exist at the base ref and the leak is real there, so the channel and byte-identity tests are genuine **regressions**. The token-guard tests are **invariant guards**: they call a parser that does not accept a three-field row at base, so their red would be a shape error and would prove nothing. The mutation matrix below is their evidence.

Because the guards' red at `origin/main` is vacuous, the meaningful "before" tree is **the fix reverted with the API present**. Each seam reverted independently:

| reverted seam | tests that go RED |
|---|---|
| `load_store` ignores `visible_scopes` | `CHANNEL_1_known_scopes…`, `CHANNEL_2_malformed_elsewhere…`, `CHANNEL_3_all_scopes_search…`, `TWO_TOKENS_ON_ONE_SERVER…`, `RECALL_a_refused_scope_is_BYTE_IDENTICAL…`, `SEARCH_a_refused_scope_is_BYTE_IDENTICAL…`, and 4 in `TestTheReaderNarrowingItself` — **10 red, 10 green** (the 10 green are the positive controls, which use an unrestricted token and correctly do not move) |
| `scope_revision` gate inert | `a_DENIED_scopes_revision_is_unknown_even_though_it_HAS_one`, `visible_scopes_None_is_UNRESTRICTED…` — **2 red** |
| `_snapshot` filter inert | `CHANNEL_4_the_snapshot_tar_carries_only_allowed_members`, `a_scope_FILTERED_snapshot_of_a_denied_scope_ships_nothing` — **2 red** |

All green at HEAD.

## Mutation sweep — 19 mutants, 18 killed, 1 recorded equivalent

Run under `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` purged between mutants (a same-length edit landing in the same whole second is otherwise scored SURVIVED without ever executing). Anchors asserted unique. Originals restored by sha256-verified copy-back, never `git checkout`. A known-caught **positive control** was carried in the batch and reported KILLED, so the harness is demonstrably running the mutated code.

Each kill was checked for **its own** reason, not merely "some test failed":

| mutant | verdict | killed by |
|---|---|---|
| `CONTROL_narrowing_inert` (positive control) | KILLED | 3 channel tests |
| guard 6 → accepts a 2-field row | KILLED | `IndexError` reaching `fields[2]` — i.e. without the guard a 2-field row is a startup **crash**, which is what the guard converts into a clean config error |
| guard 6 → accepts a 4-field row | KILLED | `DID NOT RAISE ValueError` |
| guard 7 charset `fullmatch`→`search` | KILLED | `DID NOT RAISE` |
| guard 7 length cap raised above the token floor | KILLED | `DID NOT RAISE` |
| guard 8 compares the wrong name | KILLED | `DID NOT RAISE` |
| guard 9 tests the LIST not its CONTENTS (`not any(x)` → `not x`) | KILLED | message assertion — the raise came from **guard 10** instead, which is exactly the ladder-ordering property guard 9 exists for |
| guard 10 class `fullmatch`→`search` | KILLED | `DID NOT RAISE` |
| guard 10 skips the empty entry | KILLED | `DID NOT RAISE` |
| guard 10 drops the folds-away half | KILLED | `DID NOT RAISE` |
| guard 11 never records a first sighting | KILLED | `DID NOT RAISE` |
| guard 11 legacy **exemption** removed | KILLED | `ValueError: duplicate identity 'legacy'` — the over-strict direction |
| legacy warning never fires | KILLED | `assert len(warnings) == 1` → `0` |
| legacy warning **always** fires | KILLED | its own negative control |
| `authorize` returns the FIRST configured record | KILLED | `dana` got `scope-absent` for her own scope — the one-match-three-facts seam |
| `_handler` reset `()` → `None` | **SURVIVED** | **recorded equivalent mutant** (below) |

**The survivor, honestly:** `_visible_scopes` is overwritten from the matched record on every path that can reach a route handler (health returns early; unidentified, locked-out, non-API-prefix and bad-token all refuse and return before dispatch). So the reset value is unobservable **today**. It is kept as `()` rather than `None` because a future edit that stops overwriting it must not silently inherit "unrestricted" — the same reasoning the file already records for two other equivalent mutants. Recorded rather than left as an unexplained survivor.

## Test counts and the gate

- `scripts/tests/test_cairn_cli.py` + `scripts/tests/test_subsystem_store_api.py`: **359 → 403** passed (+44).
- Reader-adjacent suites (`test_subsystem_recall`, `test_subsystem_resolver`, `test_subsystem_touch`, `test_service_recon`, `test_subsystem_audit`, `test_store_content_not_copied`, `test_handoff_doc`): **1967 passed**.
- **`scripts/gate.sh --tier pytest` → `GATE: RESULT=PASS exit=0`**, `TOTAL collected=17279 passed=17277 skipped=2 failed=0` across 36 targets, every per-target floor cleared. *(Dev-host tier, at this branch's tip. The sandbox tier `nix build .#checks.x86_64-linux.pytests` — the one Tekton gates on — has **not** been run here; and `strict` is false on branch protection, so this is a claim about this branch, not about the merged tree.)*

## Other callers of the changed signature

`git grep`ed for every `load_store` / `rc.recall(` / `rc.search(` call site. `visible_scopes` defaults to `None` = unrestricted, so the CLI (`cairn`, `/resume`, `subsystem_recall.main`) is unchanged — pinned by `test_the_CLI_DEFAULT_is_still_unrestricted`. One in-repo mutation anchor in `test_subsystem_recall.py::test_kills_the_COLLECT_policy` moved with the refactor and was updated; the mutation it applies is unchanged.

## Incidental fix

`test_cairn_cli._load_api` never registered its module in `sys.modules`. CPython's `dataclasses._is_type` does `sys.modules.get(cls.__module__).__dict__` with **no None guard**, so under `from __future__ import annotations` the first `@dataclass` in `server.py` raised `AttributeError: 'NoneType' object has no attribute '__dict__'` at import — **43 collection errors**, none of them near the change that triggered them. The sibling loader in `test_subsystem_store_api` had always registered; this was the second copy of that predicate and the one that was wrong.

## Deploy note

The live secret is a single bare token, which loads as a legacy row: **unrestricted scope, zero behaviour change on deploy**, plus a loud startup line saying so. Scoping is opt-in per row. Nothing here is deployed and no image version was bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
