### PR TITLE
docs(activity,hooks): the retracted "workbench is headless" claim survived in COMMENTS

### DIFF
--- a/claude/skills/activity/SKILL.md
+++ b/claude/skills/activity/SKILL.md
@@ -165,7 +165,14 @@ On the workbench a `switch` + an extension reload is the whole procedure.
 
 ## status
 ```bash
-# services (run per host; laptop via ssh zach@10.42.0.100). i3-source+keylog laptop-only.
+# services (run per host; laptop via ssh zach@10.42.0.100). All five are LOADED on BOTH
+# hosts — measured 2026-08-27. Four read `active`; `claude-activity-source` reads
+# `inactive` on both because it is a timer-driven oneshot, which is correct, not a fault.
+# 🔴 This line read "i3-source+keylog laptop-only" until 2026-08-27. That was the SAME
+# retracted claim the source table above already corrects (`keys`/`i3` are ✅ on both —
+# the workbench runs a real X/i3 session). It survived every earlier retraction because
+# it lives in a COMMAND COMMENT, and a prose sweep does not read those. Believing it
+# means not checking half the fleet: run this on both hosts, always.
 systemctl --user is-active activity-collector keylog browser-activity-receiver claude-activity-source i3-source
 journalctl --user -u activity-collector -n 20 --no-pager        # ship failures / drops
 ls -la ~/.local/state/activity/spool/                            # backlog = unsent segments (offline buffer)
@@ -182,7 +189,11 @@ curl -s --user "activity_reader:$RPW" --data-binary "SELECT dateDiff('second', m
 ```bash
 # invariants + cross-source reconciliation (always); --replay adds the controlled-replay assertions
 CLICKHOUSE_URL=$CH CLICKHOUSE_USER=activity_reader CLICKHOUSE_PASSWORD=$RPW python3 ~/workspace/devrc/scripts/validation/validate.py
-# keystroke-replay assertions REQUIRE the laptop's X session — run there, not on the headless workbench
+# keystroke-replay assertions need a live X session. Historically this said "run there, not on
+# the headless workbench" — 🔴 the WORKBENCH IS NOT HEADLESS (it runs a real X/i3 session; keylog
+# and i3-source are active on it). That reason was false. Whether the replay actually PASSES on
+# the workbench is UNMEASURED — nobody has run it there. Until someone does, the laptop stays the
+# known-good host; do not read this as "the workbench cannot run it".
 ```
 Current invariant set: `active_ms_capped` + `per_host_hour_active_cap` are **retired**
 (extension `active_ms` no longer emitted), replaced by **`derived_attention_consistent`**

--- a/scripts/claude-hooks/claude-notify.py
+++ b/scripts/claude-hooks/claude-notify.py
@@ -370,8 +370,13 @@ def do_notify(event, cwd, session):
 
     d = notify_desktop(title, body)
     # clawgate (phone push) is a FALLBACK: only when there's no local desktop
-    # toast (i.e. the headless workbench / away-from-laptop). Firing both would
-    # push a redundant phone card while the user is sitting at the laptop.
+    # toast — i.e. whenever notify_desktop() did not deliver one. Firing both
+    # would push a redundant phone card while the user is sitting at the machine.
+    # 🔴 This comment used to name "the headless workbench" as the example case.
+    # The workbench is NOT headless — it runs a real X/i3 session and does get
+    # desktop toasts. The branch is on the RESULT of notify_desktop(), never on
+    # which host this is, so the code was always right; only the example was
+    # wrong, and it would have taught a maintainer to expect no toast there.
     c = notify_clawgate(title, body, host, project, cwd, session) if not d else False
     # `coalesced=` is part of the log CONTRACT: it distinguishes a toast that
     # correctly merged N held turns from one that fired because the gate crashed


### PR DESCRIPTION
## How this was found

A **blind opencode dogfood run** — given tasks whose correct answer depended on the docs being right, told nothing about what had changed, and forbidden from reading git history — reported this unprompted:

> One self-contradiction: `SKILL.md:147` says `"i3-source+keylog laptop-only"` in the status commands block, but this is retracted by the source table … The status block was not updated to match.

It is correct. Three earlier sessions retracted that claim **in prose** and left every comment-borne copy standing, because a prose sweep does not read inside a fenced command block or a code comment. I ran a `laptop-only` grep earlier in this same session, saw the line in my own output, and walked past it.

## The three sites (all comment-only, no behaviour change)

| file | what it said | why it's wrong |
|---|---|---|
| `activity/SKILL.md` `## status` | `i3-source+keylog laptop-only` | both are ✅ on **both** hosts per the source table 100 lines above — believing it means not checking half the fleet |
| `activity/SKILL.md` `## validate` | "run there, not on the headless workbench" | the workbench is **not** headless — it runs a real X/i3 session |
| `claude-hooks/claude-notify.py` | "(i.e. the headless workbench / away-from-laptop)" | same false premise, as the worked example for the no-desktop-toast branch |

## Care taken on each

- **The status line** — measured on both hosts 2026-08-27: all five units `LoadState=loaded`; four `active`, `claude-activity-source` `inactive` on both because it is a timer-driven oneshot (correct, not a fault). Stated explicitly so the fix cannot create a *fresh* false expectation that all five read `active`.
- **The validate line** — the *reason* was false, but whether keystroke-replay actually **passes** on the workbench is **UNMEASURED**; nobody has run it there. So the laptop stays the known-good host and the comment now says that, rather than silently widening an instruction I cannot support.
- **`claude-notify.py`** — the code branches on the **result** of `notify_desktop()`, never on a hostname, so it was always correct. Only the example was wrong — and it would have taught a maintainer to expect no desktop toast on a machine that does get them. Diff is 100% comment lines; the two pyright warnings on this file are pre-existing on `main`.

## Verification

- Both gate tiers run on this branch; results in a follow-up comment.
- Sweep for the same class: `git grep` for host-scope claims **inside comments** across `claude/skills/` and `scripts/`. Remaining hits were checked and are correct in context.

Docs and comments only — no executable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)