### PR TITLE
feat(cairn): `who <task>` — resolve a task to its sessions, windows and transcripts

### DIFF
--- a/scripts/cairn
+++ b/scripts/cairn
@@ -737,10 +737,25 @@ def _cairn_who():
     🔴 SHARED SO THE TWO COPIES CANNOT DRIFT APART AGAIN. They already had:
     only one excluded `bool`, while a comment here claimed they mirrored each
     other. Importing the predicate rather than restating it means the next fix
-    lands in both halves of this CLI at once. Lazy because `cairn`'s store
-    commands must not pay for it, and because `sys.path` gains `lib/` at module
-    scope above.
+    lands in both halves of this CLI at once.
+
+    ⚠ THE IMPORT IS FUNCTION-SCOPED, BUT IT BUYS THE STORE PATH NOTHING, AND AN
+    EARLIER VERSION OF THIS SENTENCE CLAIMED IT DID. `build_parser` evaluates
+    `_who_default_timeout()` inside the `--timeout` help string, so `cairn_who`
+    is already in `sys.modules` before ANY subcommand dispatches — measured, on
+    every invocation. The first call here costs ~1 ms cold and ~0.1 us warm, and
+    in the real CLI it is always warm. It is function-scoped to keep the
+    module-scope import list honest about what this file needs to START, not as
+    an optimisation. Saying otherwise is the same false-comment class this whole
+    change exists to remove, and is how a maintainer reasons from a wrong cost
+    model — e.g. deleting the eager call above as an "obvious" cleanup.
     """
+    # The sibling importers below guard this the same way. Module scope already
+    # inserts `lib/`, so no failing path exists today; relying on that silently
+    # is what lets three importers disagree, which is the defect one commit ago.
+    lib = str(Path(__file__).resolve().parent / "lib")
+    if lib not in sys.path:
+        sys.path.insert(0, lib)
     import cairn_who  # noqa: PLC0415
 
     return cairn_who

--- a/scripts/cairn
+++ b/scripts/cairn
@@ -851,7 +851,10 @@ def build_parser() -> argparse.ArgumentParser:
     # was rejected outright because the flag only existed BEFORE the subcommand.
     # 🔴 A DISTINCT `dest` IS WHAT MAKES THE PRECEDENCE POSSIBLE. Sharing
     # `timeout` let the subparser default clobber an explicit parent value.
+    # `metavar` because the internal dest would otherwise surface in --help
+    # as `--timeout WHO_TIMEOUT` — an implementation detail on a user surface.
     w.add_argument("--timeout", type=int, default=None, dest="who_timeout",
+                   metavar="SECONDS",
                    help=f"seconds per external tool (default {_who_default_timeout()}; "
                         "a top-level --timeout is honoured too)")
     w.set_defaults(func=cmd_who)

--- a/scripts/cairn
+++ b/scripts/cairn
@@ -542,7 +542,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
     # is a legitimate API capability with its own tests; it is just not
     # something that may narrow this cache.
     state, detail, hint = resolve_state(
-        args.cache, no_sync=False, scope=None, timeout=args.timeout
+        args.cache, no_sync=False, scope=None, timeout=_store_timeout(args)
     )
     if state == STATE_LIVE:
         print(banner(state, detail))
@@ -553,7 +553,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
 
 def cmd_ls_entries(args: argparse.Namespace) -> int:
     state, detail, hint = resolve_state(
-        args.cache, no_sync=args.no_sync, scope=None, timeout=args.timeout
+        args.cache, no_sync=args.no_sync, scope=None, timeout=_store_timeout(args)
     )
     if hint is not None:
         print(banner(state, detail), file=sys.stderr)
@@ -571,7 +571,7 @@ def _report(args: argparse.Namespace, *, search: str | None) -> int:
     # never held. That is the silent-zero this file exists to prevent, and the
     # first draft of this function had it.
     state, detail, hint = resolve_state(
-        args.cache, no_sync=args.no_sync, scope=None, timeout=args.timeout
+        args.cache, no_sync=args.no_sync, scope=None, timeout=_store_timeout(args)
     )
     if hint is not None:
         print(banner(state, detail), file=sys.stderr)
@@ -674,7 +674,7 @@ def cmd_validate(args: argparse.Namespace) -> int:
     # `scope=None` — see the note in `cmd_sync`. `--scope` still narrows what is
     # VALIDATED (below); it must never narrow what is CACHED.
     state, detail, hint = resolve_state(
-        args.cache, no_sync=args.no_sync, scope=None, timeout=args.timeout
+        args.cache, no_sync=args.no_sync, scope=None, timeout=_store_timeout(args)
     )
     if hint is not None:
         print(banner(state, detail), file=sys.stderr)
@@ -721,20 +721,42 @@ def cmd_validate(args: argparse.Namespace) -> int:
     return worst
 
 
-def _top_level_timeout_was_given(argv: Sequence[str] | None = None) -> bool:
-    """Did `--timeout` appear BEFORE the subcommand name?
+def _store_timeout(args: argparse.Namespace) -> int:
+    """The store commands' bound, resolved in ONE place.
 
-    Read off argv because argparse cannot tell us: the subparser's default
-    overwrites the parent's value in the namespace, so by the time `cmd_who`
-    runs, an explicit parent `--timeout` and no flag at all are identical.
+    🔴 THE SENTINEL CREATED FOUR CHANCES TO FORGET. Making the top-level
+    `--timeout` default to `None` (so `who` can tell "not given" from an
+    explicit value) meant every store call site had to resolve it, and mutating
+    all four to pass the raw `None` through kept the whole suite green — a
+    `None` reaches `urllib` as NO timeout, the same unbounded wait `_run`
+    already refuses on the other side of this file. One resolver, four callers,
+    and `test_every_store_call_site_resolves_the_timeout_sentinel` pins that no
+    fifth caller open-codes it.
     """
-    args = list(sys.argv[1:] if argv is None else argv)
-    for tok in args:
-        if tok == "who" or not tok.startswith("-"):
-            return False
-        if tok == "--timeout" or tok.startswith("--timeout="):
-            return True
-    return False
+    return int(args.timeout) if getattr(args, "timeout", None) is not None else DEFAULT_TIMEOUT
+
+
+def _who_timeout(args: argparse.Namespace, own_default: int) -> int:
+    """Precedence: `who --timeout` > a top-level `--timeout` > who's own default.
+
+    🔴 THIS REPLACES A WARNING ABOUT A DISCARDED FLAG, AND HONOURING IT IS THE
+    BETTER FIX. argparse copies the subparser's namespace over the parent's, so
+    a top-level `cairn --timeout N who …` used to vanish — and before `who` had
+    its own flag that was the ONLY spelling that worked. The first fix printed a
+    notice instead, driven by hand-parsing `sys.argv`; that scanner returned the
+    WRONG answer for two reachable spellings — `--cache <val> --timeout 5 who 42`
+    (it stopped at `--cache`'s value) and `--time 5 who 42` (argparse accepts
+    long-option abbreviations; a literal `== "--timeout"` does not). Both
+    silently discarded, which is what the notice existed to prevent.
+    Re-implementing argparse's own parsing to describe argparse's behaviour was
+    the mistake. The flags now use DISTINCT dests, so nothing is clobbered and
+    there is nothing to announce.
+    """
+    if getattr(args, "who_timeout", None) is not None:
+        return int(args.who_timeout)
+    if getattr(args, "timeout", None) is not None:
+        return int(args.timeout)
+    return int(own_default)
 
 
 def _who_default_timeout() -> int:
@@ -754,19 +776,8 @@ def cmd_who(args: argparse.Namespace) -> int:
         sys.path.insert(0, lib)
     import cairn_who  # noqa: PLC0415
 
-    # 🔴 SAY SO WHEN A FLAG IS DISCARDED. argparse copies the subparser's
-    # namespace over the parent's, so a top-level `cairn --timeout N who …` is
-    # silently dropped — and before `who` had its own flag, that spelling was
-    # the ONLY one that worked. Anyone with that habit would have got 60s while
-    # believing they asked for N. Naming a substitution rather than performing
-    # it quietly is this repo's standing rule.
-    if _top_level_timeout_was_given():
-        print("cairn who: ignoring the top-level --timeout (it applies to the "
-              "store commands). Use `cairn who --timeout N`.", file=sys.stderr)
     report = cairn_who.resolve(
-        args.task,
-        # `None` means "the subcommand's own default", never cairn's store bound.
-        timeout=args.timeout if args.timeout is not None else cairn_who.DEFAULT_TIMEOUT,
+        args.task, timeout=_who_timeout(args, cairn_who.DEFAULT_TIMEOUT),
         host=args.host, skip_windows=args.no_windows,
     )
     if args.json:
@@ -787,7 +798,9 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     p.add_argument("--cache", type=Path, default=DEFAULT_CACHE)
-    p.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    # `None` = not given. The store commands resolve it to DEFAULT_TIMEOUT;
+    # `who` resolves it to its own, longer default. See `_who_timeout`.
+    p.add_argument("--timeout", type=int, default=None)
     sub = p.add_subparsers(dest="cmd", required=True)
 
     def common(sp):
@@ -836,8 +849,11 @@ def build_parser() -> argparse.ArgumentParser:
     # specifically about a sleeping laptop. Inheriting the store's bound meant
     # the documented rationale was not what shipped, and `cairn who --timeout N`
     # was rejected outright because the flag only existed BEFORE the subcommand.
-    w.add_argument("--timeout", type=int, default=None,
-                   help=f"seconds per external tool (default {_who_default_timeout()})")
+    # 🔴 A DISTINCT `dest` IS WHAT MAKES THE PRECEDENCE POSSIBLE. Sharing
+    # `timeout` let the subparser default clobber an explicit parent value.
+    w.add_argument("--timeout", type=int, default=None, dest="who_timeout",
+                   help=f"seconds per external tool (default {_who_default_timeout()}; "
+                        "a top-level --timeout is honoured too)")
     w.set_defaults(func=cmd_who)
     return p
 

--- a/scripts/cairn
+++ b/scripts/cairn
@@ -721,6 +721,22 @@ def cmd_validate(args: argparse.Namespace) -> int:
     return worst
 
 
+def _top_level_timeout_was_given(argv: Sequence[str] | None = None) -> bool:
+    """Did `--timeout` appear BEFORE the subcommand name?
+
+    Read off argv because argparse cannot tell us: the subparser's default
+    overwrites the parent's value in the namespace, so by the time `cmd_who`
+    runs, an explicit parent `--timeout` and no flag at all are identical.
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+    for tok in args:
+        if tok == "who" or not tok.startswith("-"):
+            return False
+        if tok == "--timeout" or tok.startswith("--timeout="):
+            return True
+    return False
+
+
 def _who_default_timeout() -> int:
     """Read `who`'s own default rather than restating it in help text."""
     lib = str(Path(__file__).resolve().parent / "lib")
@@ -738,6 +754,15 @@ def cmd_who(args: argparse.Namespace) -> int:
         sys.path.insert(0, lib)
     import cairn_who  # noqa: PLC0415
 
+    # 🔴 SAY SO WHEN A FLAG IS DISCARDED. argparse copies the subparser's
+    # namespace over the parent's, so a top-level `cairn --timeout N who …` is
+    # silently dropped — and before `who` had its own flag, that spelling was
+    # the ONLY one that worked. Anyone with that habit would have got 60s while
+    # believing they asked for N. Naming a substitution rather than performing
+    # it quietly is this repo's standing rule.
+    if _top_level_timeout_was_given():
+        print("cairn who: ignoring the top-level --timeout (it applies to the "
+              "store commands). Use `cairn who --timeout N`.", file=sys.stderr)
     report = cairn_who.resolve(
         args.task,
         # `None` means "the subcommand's own default", never cairn's store bound.

--- a/scripts/cairn
+++ b/scripts/cairn
@@ -52,6 +52,7 @@ from __future__ import annotations
 import argparse
 import fcntl
 import io
+import json
 import os
 import shutil
 import sys
@@ -720,6 +721,24 @@ def cmd_validate(args: argparse.Namespace) -> int:
     return worst
 
 
+def cmd_who(args: argparse.Namespace) -> int:
+    """Task -> sessions -> windows + transcripts. See `lib/cairn_who.py`."""
+    lib = str(Path(__file__).resolve().parent / "lib")
+    if lib not in sys.path:
+        sys.path.insert(0, lib)
+    import cairn_who  # noqa: PLC0415
+
+    report = cairn_who.resolve(
+        args.task, timeout=args.timeout, host=args.host,
+        skip_windows=args.no_windows,
+    )
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        print(cairn_who.render(report))
+    return report.exit_code
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="cairn",
@@ -762,6 +781,19 @@ def build_parser() -> argparse.ArgumentParser:
 
     e = common(sub.add_parser("ls-entries", help="one `<scope>/<entry>.md` per line"))
     e.set_defaults(func=cmd_ls_entries)
+
+    # 🔴 `who` TOUCHES NO STORE AND NO CACHE. It is the first cairn subcommand
+    # about a different noun — a TASK, not a subsystem entry — so it takes none
+    # of the `common()` flags and never syncs. It is here rather than in its own
+    # binary because `cairn` is the name for the whole three-noun layer, and a
+    # second CLI would be the second place to look.
+    w = sub.add_parser("who", help="which sessions/windows/transcripts worked a task")
+    w.add_argument("task")
+    w.add_argument("--json", action="store_true")
+    w.add_argument("--host", default=None, choices=["workbench", "laptop"])
+    w.add_argument("--no-windows", action="store_true",
+                   help="skip the tmux scan; report only the durable transcripts")
+    w.set_defaults(func=cmd_who)
     return p
 
 

--- a/scripts/cairn
+++ b/scripts/cairn
@@ -170,10 +170,9 @@ def fetch_snapshot(
     # and mutating either `fetch_snapshot`'s or `urlopen`'s argument to `None`
     # survived the whole suite. The asymmetry was the defect: one half of one
     # program failing closed.
-    if not isinstance(timeout, int) or isinstance(timeout, bool) or timeout <= 0:
-        raise StoreUnreachable(
-            f"refusing to fetch {url} with timeout={timeout!r} — a missing or "
-            "non-positive bound is an UNBOUNDED wait, not a default")
+    bad = _cairn_who().unbounded_timeout_reason(timeout)
+    if bad:
+        raise StoreUnreachable(f"refusing to fetch {url}: {bad}")
     target = f"{url}/api/v1/snapshot" + (f"?scope={scope}" if scope else "")
     req = urllib.request.Request(target, method="GET")
     req.add_header("Authorization", f"Bearer {token}")
@@ -730,6 +729,21 @@ def cmd_validate(args: argparse.Namespace) -> int:
         )
         worst = max(worst, code)
     return worst
+
+
+def _cairn_who():
+    """The `who` module, imported lazily — it owns the timeout predicate.
+
+    🔴 SHARED SO THE TWO COPIES CANNOT DRIFT APART AGAIN. They already had:
+    only one excluded `bool`, while a comment here claimed they mirrored each
+    other. Importing the predicate rather than restating it means the next fix
+    lands in both halves of this CLI at once. Lazy because `cairn`'s store
+    commands must not pay for it, and because `sys.path` gains `lib/` at module
+    scope above.
+    """
+    import cairn_who  # noqa: PLC0415
+
+    return cairn_who
 
 
 def _store_timeout(args: argparse.Namespace) -> int:

--- a/scripts/cairn
+++ b/scripts/cairn
@@ -163,6 +163,17 @@ def fetch_snapshot(
     url: str, token: str, *, scope: str | None, timeout: int
 ) -> tuple[bytes, dict[str, str]]:
     """GET the tar. Every failure becomes a StoreUnreachable NAMING the host."""
+    # 🔴 `timeout=None` REACHES `urlopen` AS *NO* TIMEOUT, NOT AS A DEFAULT, so
+    # this refuses it rather than trusting the annotation above — `timeout: int`
+    # is a type hint, and a hint is not a code path. The sibling `who` side of
+    # this CLI has refused it since `cairn_who._run`; the store side did not,
+    # and mutating either `fetch_snapshot`'s or `urlopen`'s argument to `None`
+    # survived the whole suite. The asymmetry was the defect: one half of one
+    # program failing closed.
+    if not isinstance(timeout, int) or isinstance(timeout, bool) or timeout <= 0:
+        raise StoreUnreachable(
+            f"refusing to fetch {url} with timeout={timeout!r} — a missing or "
+            "non-positive bound is an UNBOUNDED wait, not a default")
     target = f"{url}/api/v1/snapshot" + (f"?scope={scope}" if scope else "")
     req = urllib.request.Request(target, method="GET")
     req.add_header("Authorization", f"Bearer {token}")
@@ -730,8 +741,12 @@ def _store_timeout(args: argparse.Namespace) -> int:
     all four to pass the raw `None` through kept the whole suite green — a
     `None` reaches `urllib` as NO timeout, the same unbounded wait `_run`
     already refuses on the other side of this file. One resolver, four callers,
-    and `test_every_store_call_site_resolves_the_timeout_sentinel` pins that no
-    fifth caller open-codes it.
+    and `test_no_call_site_passes_the_RAW_sentinel_attribute` pins that no
+    fifth caller open-codes it, while
+    `test_every_STORE_subcommand_reaches_the_network_with_a_POSITIVE_bound`
+    covers the spellings an AST scan cannot see. `fetch_snapshot` refuses a
+    non-positive bound outright, so a future caller that bypasses both
+    fails closed rather than waiting forever.
     """
     return int(args.timeout) if getattr(args, "timeout", None) is not None else DEFAULT_TIMEOUT
 

--- a/scripts/cairn
+++ b/scripts/cairn
@@ -721,6 +721,16 @@ def cmd_validate(args: argparse.Namespace) -> int:
     return worst
 
 
+def _who_default_timeout() -> int:
+    """Read `who`'s own default rather than restating it in help text."""
+    lib = str(Path(__file__).resolve().parent / "lib")
+    if lib not in sys.path:
+        sys.path.insert(0, lib)
+    import cairn_who  # noqa: PLC0415
+
+    return int(cairn_who.DEFAULT_TIMEOUT)
+
+
 def cmd_who(args: argparse.Namespace) -> int:
     """Task -> sessions -> windows + transcripts. See `lib/cairn_who.py`."""
     lib = str(Path(__file__).resolve().parent / "lib")
@@ -729,8 +739,10 @@ def cmd_who(args: argparse.Namespace) -> int:
     import cairn_who  # noqa: PLC0415
 
     report = cairn_who.resolve(
-        args.task, timeout=args.timeout, host=args.host,
-        skip_windows=args.no_windows,
+        args.task,
+        # `None` means "the subcommand's own default", never cairn's store bound.
+        timeout=args.timeout if args.timeout is not None else cairn_who.DEFAULT_TIMEOUT,
+        host=args.host, skip_windows=args.no_windows,
     )
     if args.json:
         print(json.dumps(report.to_dict(), indent=2))
@@ -793,6 +805,14 @@ def build_parser() -> argparse.ArgumentParser:
     w.add_argument("--host", default=None, choices=["workbench", "laptop"])
     w.add_argument("--no-windows", action="store_true",
                    help="skip the tmux scan; report only the durable transcripts")
+    # 🔴 ITS OWN `--timeout`, AND ITS OWN DEFAULT. cairn's top-level `--timeout`
+    # is 20s, chosen for an HTTP snapshot fetch; `who` shells into tmux on two
+    # hosts, and `cairn_who.DEFAULT_TIMEOUT` carries a docstring reasoning
+    # specifically about a sleeping laptop. Inheriting the store's bound meant
+    # the documented rationale was not what shipped, and `cairn who --timeout N`
+    # was rejected outright because the flag only existed BEFORE the subcommand.
+    w.add_argument("--timeout", type=int, default=None,
+                   help=f"seconds per external tool (default {_who_default_timeout()})")
     w.set_defaults(func=cmd_who)
     return p
 

--- a/scripts/lib/cairn_who.py
+++ b/scripts/lib/cairn_who.py
@@ -230,6 +230,35 @@ class WhoReport:
 # --------------------------------------------------------------------------- #
 
 
+def unbounded_timeout_reason(value) -> str | None:
+    """Why `value` is not a usable timeout, or `None` if it is fine.
+
+    🔴 ONE PREDICATE, ONE PLACE — AND CONSOLIDATING IT IS WHAT FOUND THE BUG.
+    This rule was open-coded at two sites (`_run` here, `fetch_snapshot` in
+    `scripts/cairn`) and the copies DISAGREED: only one excluded `bool`. A
+    comment claiming the two mirrored each other was therefore false, and the
+    weaker copy was measured running `_run(cmd, True)` with a ONE-SECOND bound
+    and reporting `did not answer within Trues` — verbatim the "nobody notices"
+    failure `_run`'s own docstring describes.
+
+    `bool` is the trap: it subclasses `int`, so `isinstance(x, int)` accepts
+    `True` and silently yields a 1s timeout. `None` is the other: it means NO
+    timeout to both `subprocess` and `urlopen`, an unbounded wait rather than a
+    default. Both callers raise their OWN exception type from this reason, so
+    the rule is shared without coupling the store path to `who`'s error class.
+    """
+    if isinstance(value, bool):
+        return (f"timeout={value!r} is a bool — it subclasses int, so this "
+                "would silently run with a 1-second bound")
+    if not isinstance(value, int):
+        return (f"timeout={value!r} is not an int — a missing bound is an "
+                "UNBOUNDED wait, not a default")
+    if value <= 0:
+        return (f"timeout={value!r} is not positive — a non-positive bound is "
+                "an UNBOUNDED wait, not a default")
+    return None
+
+
 def _one_line(text: str) -> str:
     """Collapse a diagnostic to one line.
 
@@ -255,10 +284,9 @@ def _run(cmd: Sequence[str], timeout: int) -> tuple[int, str, str]:
     # waits forever on a host that will never answer. Measured: a None timeout
     # let a 2s sleep run to completion unbounded. The expiry message would also
     # have read "within Nones", which is how nobody notices. Refuse it.
-    if not isinstance(timeout, int) or timeout <= 0:
-        raise WhoError(
-            f"refusing to run {cmd[0]} with timeout={timeout!r} — a missing or "
-            "non-positive bound is an UNBOUNDED wait, not a default")
+    bad = unbounded_timeout_reason(timeout)
+    if bad:
+        raise WhoError(f"refusing to run {cmd[0]}: {bad}")
     try:
         p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
     except FileNotFoundError:

--- a/scripts/lib/cairn_who.py
+++ b/scripts/lib/cairn_who.py
@@ -68,6 +68,10 @@ WHO_NO_CLAWGATE = "clawgate-unreachable"
 #: and no transcript. That is a genuine gap worth reporting loudly, and it is
 #: not the same as the task having no sessions.
 WHO_UNLOCATED = "sessions-recorded-but-none-located"
+#: clawgate refused the id itself (400). A typo is the likeliest failure of all,
+#: and reporting it as `clawgate-unreachable` sent the operator to debug the
+#: network while clawgate's own 400 was printed directly above.
+WHO_BAD_TASK_ID = "bad-task-id"
 
 EXIT_OK = 0
 EXIT_USAGE = 2
@@ -82,6 +86,31 @@ EXIT_NO_CLAWGATE = 8
 
 class WhoError(RuntimeError):
     """A failure that names which HOP could not be taken."""
+
+
+class TaskNotFound(WhoError):
+    """clawgate answered, and the answer is "no such task"."""
+
+
+class BadTaskId(WhoError):
+    """clawgate refused the id itself (400). A typo, not an outage."""
+
+
+class ClawgateUnreachable(WhoError):
+    """clawgate could not be asked at all."""
+
+
+#: `session-manager`'s own exit codes, which it documents and which this module
+#: must honour rather than re-derive.
+#:
+#: 🔴 3 AND 4 ARE THE WHOLE POINT AND THEY BOTH RETURN AN EMPTY SCAN. 3 is
+#: `EXIT_EMPTY` — every requested host answered and the answer is a real zero.
+#: 4 is `EXIT_UNAVAILABLE` — NO host could be reached, so the zero is
+#: unmeasured. Its source says a caller "must never read success off a truncated
+#: run". Treating 4 as success is exactly that, and it renders as a confident
+#: "this session is running nowhere".
+SM_EXIT_EMPTY = 3
+SM_EXIT_UNAVAILABLE = 4
 
 
 @dataclass
@@ -181,7 +210,8 @@ class WhoReport:
             WHO_UNLOCATED: EXIT_UNLOCATED,
             WHO_NO_TASK: EXIT_NO_TASK,
             WHO_NO_CLAWGATE: EXIT_NO_CLAWGATE,
-        }.get(self.state, EXIT_OK)
+            WHO_BAD_TASK_ID: EXIT_USAGE,
+        }[self.state]
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -228,15 +258,30 @@ def fetch_task(task: str, *, timeout: int = DEFAULT_TIMEOUT,
     if not str(task).strip():
         raise WhoError("empty task id")
     rc, out, err = runner(["clawgatectl", "task", "get", str(task)], timeout)
+    # One line. A tool's stderr is often several (a version-skew notice above
+    # the real error), and interpolating it raw breaks the render's
+    # indentation so the follow-up sentence reads as unrelated output.
+    detail = " ".join(err.split()) or "no diagnostic"
+    # 🔴 CLASSIFY BY EXCEPTION TYPE, NOT BY THE MESSAGE TEXT. The first version
+    # raised one error class and had the caller substring-match `"has no task"`
+    # to decide between "no such task" and "could not ask" — while interpolating
+    # clawgate's raw stderr into the other message, so any diagnostic containing
+    # that phrase would have flipped the verdict. Deciding a state by grepping a
+    # string you just built is the defect this module exists to avoid, one layer
+    # up from the exit code that already answers it.
     if rc == 4:
-        raise WhoError(f"clawgate has no task {task}")
-    if rc in (3, 6, 7, 8) or (rc != 0 and not out.strip()):
-        raise WhoError(
-            f"clawgatectl exited {rc} — {err.strip() or 'no diagnostic'}")
+        raise TaskNotFound(f"clawgate has no task {task}")
+    if rc == 2:
+        # 400 — the id itself was refused. An operator typo, and the LIKELIEST
+        # failure of all; reporting it as "unreachable" sends them to debug the
+        # network while clawgate's own 400 is printed directly above.
+        raise BadTaskId(f"clawgatectl refused the id {task!r} — {detail}")
+    if rc != 0:
+        raise ClawgateUnreachable(f"clawgatectl exited {rc} — {detail}")
     try:
         return json.loads(out)
     except json.JSONDecodeError as exc:
-        raise WhoError(f"clawgatectl returned non-JSON: {exc}")
+        raise ClawgateUnreachable(f"clawgatectl returned non-JSON: {exc}")
 
 
 def sessions_of(task_obj: dict[str, Any]) -> list[SessionHit]:
@@ -262,16 +307,34 @@ def sessions_of(task_obj: dict[str, Any]) -> list[SessionHit]:
     return out
 
 
-def _index_windows(payload: dict[str, Any]) -> dict[str, WindowHit]:
-    """`claude_session_id` -> the window holding it.
+def _index_windows(payload: dict[str, Any]) -> tuple[dict[str, WindowHit], list[str]]:
+    """`claude_session_id` -> window, PLUS the hosts that were not measured.
+
+    🔴 THE SECOND RETURN VALUE IS THE HONEST HALF, AND OMITTING IT SHIPPED A
+    SILENT ZERO. `session-manager` publishes `reachable`, `windows_measured` and
+    `windows_error` PER HOST, and leaves an unreachable host's `windows` as an
+    empty list while still exiting 0 because the other host answered.
+    Indexing only `windows` therefore turns "the laptop is asleep" into a
+    confident "this session is running nowhere" — demonstrated with the same
+    session rendering `none live` with the laptop down and a real window with it
+    up. `ConnectTimeout=4` means a sleeping laptop fails FAST, so this is the
+    everyday case rather than an edge.
 
     🔴 LAST WRITER WINS IS WRONG HERE, SO IT IS NOT DONE. Two windows can carry
     the same session id (a split pane, a re-attached session). The first is kept
-    and the collision is not silently overwritten, because overwriting makes the
-    answer depend on host iteration order — which is a dict order, not a fact.
+    rather than the last, so the answer cannot depend on iteration order.
+    `session-manager` dumps with `sort_keys=True`, which is what makes the host
+    order stable run to run — a property of ITS writer, not of dicts, so it is
+    named here rather than assumed.
     """
     idx: dict[str, WindowHit] = {}
-    for host, block in (payload.get("hosts") or {}).items():
+    unmeasured: list[str] = []
+    for host, block in sorted((payload.get("hosts") or {}).items()):
+        if (block.get("reachable") is False
+                or block.get("windows_measured") is False
+                or block.get("windows_error")):
+            unmeasured.append(host)
+            continue
         for w in block.get("windows") or []:
             sid = w.get("claude_session_id")
             if not sid or sid in idx:
@@ -287,11 +350,12 @@ def _index_windows(payload: dict[str, Any]) -> dict[str, WindowHit]:
                 hotkey=w.get("hotkey"),
                 path=w.get("path"),
             )
-    return idx
+    return idx, unmeasured
 
 
 def live_windows(*, timeout: int = DEFAULT_TIMEOUT, host: str | None = None,
-                 runner=_run, script: Path | None = None) -> dict[str, WindowHit]:
+                 runner=_run, script: Path | None = None
+                 ) -> tuple[dict[str, WindowHit], list[str]]:
     """Scan tmux across hosts and index by session id.
 
     🔴 `--lean` IS NOT USABLE HERE and that is measured, not assumed: its
@@ -304,9 +368,19 @@ def live_windows(*, timeout: int = DEFAULT_TIMEOUT, host: str | None = None,
     if host:
         cmd += ["--host", host]
     rc, out, err = runner(cmd, timeout)
-    if rc != 0 and not out.strip():
-        raise WhoError(f"session-manager exited {rc} — "
-                       f"{err.strip() or 'no diagnostic'}")
+    detail = err.strip() or "no diagnostic"
+    # 🔴 rc 4 ARRIVES WITH A FULL, WELL-FORMED JSON REPORT OF ZERO WINDOWS, so
+    # the old `rc != 0 and not out.strip()` guard let it through as a measured
+    # scan. `session-manager` documents 4 as "NO requested host could be
+    # reached — the 0 is unmeasured", and its own header says a caller must
+    # never read success off a truncated run. 3 is the opposite code and is a
+    # genuine measured zero, so it deliberately does NOT raise.
+    if rc == SM_EXIT_UNAVAILABLE:
+        raise WhoError(
+            f"session-manager exited {rc} — no host could be reached, so its "
+            f"empty scan is UNMEASURED, not a zero ({detail})")
+    if rc not in (0, SM_EXIT_EMPTY) and not out.strip():
+        raise WhoError(f"session-manager exited {rc} — {detail}")
     try:
         payload = json.loads(out)
     except json.JSONDecodeError as exc:
@@ -356,10 +430,12 @@ def resolve(task: str, *, timeout: int = DEFAULT_TIMEOUT,
     """Task -> sessions -> (window, transcript). Every hop's failure is NAMED."""
     try:
         obj = task_fetcher(task, timeout=timeout)
+    except TaskNotFound as exc:
+        return WhoReport(task=task, state=WHO_NO_TASK, notes=[str(exc)])
+    except BadTaskId as exc:
+        return WhoReport(task=task, state=WHO_BAD_TASK_ID, notes=[str(exc)])
     except WhoError as exc:
-        msg = str(exc)
-        state = WHO_NO_TASK if "has no task" in msg else WHO_NO_CLAWGATE
-        return WhoReport(task=task, state=state, notes=[msg])
+        return WhoReport(task=task, state=WHO_NO_CLAWGATE, notes=[str(exc)])
 
     report = WhoReport(
         task=task, state=WHO_RESOLVED,
@@ -376,8 +452,17 @@ def resolve(task: str, *, timeout: int = DEFAULT_TIMEOUT,
         report.windows_reason = "--no-windows: the live half was not looked at"
     else:
         try:
-            windows = window_fetcher(timeout=timeout, host=host)
-            measured = True
+            windows, unmeasured_hosts = window_fetcher(timeout=timeout, host=host)
+            # 🔴 A PARTIAL SCAN IS NOT A MEASURED SCAN. If ANY host went
+            # unmeasured, a session with no match might simply have been on
+            # that host, so "none live" is unproven for every session that did
+            # not match. A session that DID match is a positive finding and is
+            # unaffected — an absence is what needs the caveat.
+            measured = not unmeasured_hosts
+            if unmeasured_hosts:
+                report.windows_reason = (
+                    "host(s) not measured by session-manager: "
+                    + ", ".join(unmeasured_hosts))
         except WhoError as exc:
             # 🔴 NOT fatal, and NOT an empty window column. The durable half is
             # independent of tmux being reachable, and it is usually the half
@@ -385,9 +470,9 @@ def resolve(task: str, *, timeout: int = DEFAULT_TIMEOUT,
             report.windows_reason = str(exc)
 
     for s in report.sessions:
-        s.windows_measured = measured
-        if measured:
-            s.window = windows.get(s.session_id)
+        # A hit is a hit regardless of whether some OTHER host was measured.
+        s.window = windows.get(s.session_id)
+        s.windows_measured = measured or s.window is not None
         try:
             s.transcript = transcript_finder(s.session_id, root=transcript_root)
         except Exception as exc:  # noqa: BLE001 — a bad transcript root must
@@ -395,7 +480,12 @@ def resolve(task: str, *, timeout: int = DEFAULT_TIMEOUT,
             report.notes.append(
                 f"transcript lookup failed for {s.session_id[:8]}…: {exc}")
 
-    if not any(s.located for s in report.sessions):
+    # 🔴 `UNLOCATED` IS A CLAIM ABOUT A GAP, SO IT REQUIRES HAVING LOOKED. When
+    # the live half is unmeasured, "nothing located" means "no transcript, and
+    # the window is unknown" — indeterminate, not a proven gap. Firing exit 6
+    # there made the machine-readable surface assert what the human-readable
+    # one had just disclaimed, which is the worse half to get wrong.
+    if measured and not any(s.located for s in report.sessions):
         report.state = WHO_UNLOCATED
     return report
 
@@ -415,6 +505,11 @@ def render(report: WhoReport) -> str:
         head += f"  [{report.status}]"
     lines.append(head)
 
+    if report.state == WHO_BAD_TASK_ID:
+        lines.append(f"  🔴 {WHO_BAD_TASK_ID} — {'; '.join(report.notes)}")
+        lines.append("     clawgate answered; it refused the id. Check the id, "
+                     "not the network.")
+        return "\n".join(lines)
     if report.state == WHO_NO_TASK:
         lines.append(f"  🔴 {WHO_NO_TASK} — {'; '.join(report.notes)}")
         return "\n".join(lines)

--- a/scripts/lib/cairn_who.py
+++ b/scripts/lib/cairn_who.py
@@ -230,6 +230,18 @@ class WhoReport:
 # --------------------------------------------------------------------------- #
 
 
+def _one_line(text: str) -> str:
+    """Collapse a diagnostic to one line.
+
+    🔴 APPLIED IN `_run`, NOT AT EACH CALL SITE. The first version collapsed
+    stderr inside `fetch_task` only, so `live_windows` still carried multi-line
+    text into `windows_reason`, which `render` prints inside an indented block —
+    the exact breakage the other site's comment described. One rule, two places
+    is how the second copy stays wrong.
+    """
+    return " ".join((text or "").split())
+
+
 def _run(cmd: Sequence[str], timeout: int) -> tuple[int, str, str]:
     """Run a tool, capturing both streams SEPARATELY.
 
@@ -238,13 +250,22 @@ def _run(cmd: Sequence[str], timeout: int) -> tuple[int, str, str]:
     a parse. Merging them here would throw that guarantee away at the one place
     that depends on it.
     """
+    # 🔴 `timeout=None` MEANS NO TIMEOUT AT ALL, so a None here does not
+    # "fall back to a default" — it removes the bound entirely and `cairn who`
+    # waits forever on a host that will never answer. Measured: a None timeout
+    # let a 2s sleep run to completion unbounded. The expiry message would also
+    # have read "within Nones", which is how nobody notices. Refuse it.
+    if not isinstance(timeout, int) or timeout <= 0:
+        raise WhoError(
+            f"refusing to run {cmd[0]} with timeout={timeout!r} — a missing or "
+            "non-positive bound is an UNBOUNDED wait, not a default")
     try:
         p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
     except FileNotFoundError:
         raise WhoError(f"{cmd[0]} is not on PATH")
     except subprocess.TimeoutExpired:
         raise WhoError(f"{cmd[0]} did not answer within {timeout}s")
-    return p.returncode, p.stdout, p.stderr
+    return p.returncode, p.stdout, _one_line(p.stderr)
 
 
 def fetch_task(task: str, *, timeout: int = DEFAULT_TIMEOUT,
@@ -261,7 +282,7 @@ def fetch_task(task: str, *, timeout: int = DEFAULT_TIMEOUT,
     # One line. A tool's stderr is often several (a version-skew notice above
     # the real error), and interpolating it raw breaks the render's
     # indentation so the follow-up sentence reads as unrelated output.
-    detail = " ".join(err.split()) or "no diagnostic"
+    detail = err or "no diagnostic"
     # 🔴 CLASSIFY BY EXCEPTION TYPE, NOT BY THE MESSAGE TEXT. The first version
     # raised one error class and had the caller substring-match `"has no task"`
     # to decide between "no such task" and "could not ask" — while interpolating
@@ -368,7 +389,7 @@ def live_windows(*, timeout: int = DEFAULT_TIMEOUT, host: str | None = None,
     if host:
         cmd += ["--host", host]
     rc, out, err = runner(cmd, timeout)
-    detail = err.strip() or "no diagnostic"
+    detail = err or "no diagnostic"
     # 🔴 rc 4 ARRIVES WITH A FULL, WELL-FORMED JSON REPORT OF ZERO WINDOWS, so
     # the old `rc != 0 and not out.strip()` guard let it through as a measured
     # scan. `session-manager` documents 4 as "NO requested host could be

--- a/scripts/lib/cairn_who.py
+++ b/scripts/lib/cairn_who.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""`cairn who <task>` — resolve a TASK to the sessions that worked it, the tmux
+windows hosting them, and the transcripts they wrote.
+
+WHY THIS IS A COMMAND AND NOT A RECIPE. Every hop already resolved before this
+existed; none of them joined. Answering "who is working task 360, and where do I
+read what they did" took four tools and a hand-written jq join, which is exactly
+the shape of thing nobody does twice — so the question stopped being asked.
+
+🔴 THE TWO ANSWERS HAVE DIFFERENT LIFETIMES, AND COLLAPSING THEM IS THE WHOLE
+TRAP. A tmux window is TRANSIENT: it is gone when the pane closes, the session
+ends or the host reboots. A transcript is DURABLE: it is a file on disk that
+outlives all of that. Measured 2026-08-27 on the task this command was written
+for — the session's window had already vanished, while its 6 MB transcript sat
+exactly where it was written. A resolver that reports only the window answers
+"nobody" for most of the history it is asked about, and a resolver that reports
+one line for both makes "the window is gone" indistinguishable from "the work
+never happened". So every session yields TWO independent findings, always
+labelled, and one may be present while the other is not.
+
+🔴 AN UNMEASURED LIVE HALF IS NOT "NO WINDOW". `session-manager` shells out to
+tmux on two hosts; the laptop may be asleep, off the nebula, or simply slow. If
+that lookup fails, the honest report is UNMEASURED with the reason — never an
+empty window column, which reads as "this session is not running anywhere" and
+is the silent zero this repo's whole measurement layer exists to prevent. The
+transcript half is unaffected by that failure and is still reported.
+
+🔴 THE SESSION-ID JOIN KEY IS NOT ALWAYS A UUID. Measured across a live scan:
+39 of 41 windows carried a uuid in `claude_session_id` and 2 carried a
+`ses_…` token from a different runtime. A join that assumes uuid shape, or
+that lowercases/normalises one side only, silently matches nothing and reports
+a clean "no live window". The comparison here is on the exact string, both
+sides, and `test_cairn_who.py` pins a non-uuid id against a real match.
+
+WHAT IT DOES NOT DO. It does not raise, focus or switch to a window — that is
+the operator's screen, and stealing it is a `pkill`-class action (RULES.md).
+It prints the address; moving there is the human's call.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Sequence
+
+#: How long to wait on each external tool. `session-manager` shells into tmux on
+#: two hosts and a full cross-host scan measured ~5s; the laptop being asleep is
+#: the case this bound exists for, and it must EXPIRE rather than hang a command
+#: someone typed.
+DEFAULT_TIMEOUT = 60
+
+#: Outcome vocabulary. Every one of these is a DIFFERENT answer to "who worked
+#: this task", and the point of naming them is that several of them print little
+#: or nothing — which is precisely when they get confused for each other.
+WHO_RESOLVED = "resolved"
+#: The task exists and clawgate recorded no session against it. A real state —
+#: a task filed through the web UI has none — and NOT an error.
+WHO_NO_SESSIONS = "no-sessions-recorded"
+#: The task id is not in clawgate. Distinct from every "found nothing" state.
+WHO_NO_TASK = "task-not-found"
+#: Could not ask clawgate at all. Distinct from `task-not-found`, because one of
+#: them means "the answer is no" and the other means "there was no answer".
+WHO_NO_CLAWGATE = "clawgate-unreachable"
+#: Sessions exist, and NEITHER half resolved for any of them — no live window
+#: and no transcript. That is a genuine gap worth reporting loudly, and it is
+#: not the same as the task having no sessions.
+WHO_UNLOCATED = "sessions-recorded-but-none-located"
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+#: Nothing located though sessions were recorded — see `WHO_UNLOCATED`.
+EXIT_UNLOCATED = 6
+#: The task id does not exist.
+EXIT_NO_TASK = 7
+#: Could not reach clawgate. Never folded into 7: "no such task" and "I could
+#: not ask" are opposite claims that print the same emptiness.
+EXIT_NO_CLAWGATE = 8
+
+
+class WhoError(RuntimeError):
+    """A failure that names which HOP could not be taken."""
+
+
+@dataclass
+class WindowHit:
+    """A LIVE tmux window. Transient — see the module docstring."""
+
+    host: str
+    session: str
+    window_index: str | None = None
+    window_id: str | None = None
+    pane_id: str | None = None
+    codename: str | None = None
+    hotkey: str | None = None
+    path: str | None = None
+
+    @property
+    def address(self) -> str:
+        """`<session>:<window_index>` — what `tmux switch-client -t` accepts.
+
+        🔴 `window_index` AND `window_id` ARE DIFFERENT THINGS and both are
+        carried. The index (`1`) is what a human types; the id (`@349`) is
+        stable across renumbering when other windows are killed. Printing only
+        the index sends someone to a different window after a close; printing
+        only the id gives them something tmux accepts but nobody recognises.
+        """
+        idx = self.window_index if self.window_index is not None else "?"
+        return f"{self.session}:{idx}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "host": self.host,
+            "session": self.session,
+            "window_index": self.window_index,
+            "window_id": self.window_id,
+            "pane_id": self.pane_id,
+            "codename": self.codename,
+            "hotkey": self.hotkey,
+            "path": self.path,
+            "address": self.address,
+        }
+
+
+@dataclass
+class SessionHit:
+    """One session on the task, with its two independent findings."""
+
+    session_id: str
+    role: str | None = None
+    project: str | None = None
+    cwd: str | None = None
+    host: str | None = None
+    last_seen: str | None = None
+    #: The transient half. `None` means "looked and found none" ONLY when
+    #: `windows_measured` is True.
+    window: WindowHit | None = None
+    #: 🔴 The flag that keeps an absent window honest. False means the live
+    #: lookup did not happen or failed, so `window is None` says nothing.
+    windows_measured: bool = True
+    #: The durable half.
+    transcript: Path | None = None
+
+    @property
+    def located(self) -> bool:
+        return self.window is not None or self.transcript is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "role": self.role,
+            "project": self.project,
+            "cwd": self.cwd,
+            "host": self.host,
+            "last_seen": self.last_seen,
+            "window": self.window.to_dict() if self.window else None,
+            "windows_measured": self.windows_measured,
+            "transcript": str(self.transcript) if self.transcript else None,
+        }
+
+
+@dataclass
+class WhoReport:
+    task: str
+    state: str
+    sessions: list[SessionHit] = field(default_factory=list)
+    title: str | None = None
+    status: str | None = None
+    #: Why the live half is unmeasured on this run, if it is. Printed; never
+    #: swallowed.
+    windows_reason: str | None = None
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def exit_code(self) -> int:
+        return {
+            WHO_RESOLVED: EXIT_OK,
+            WHO_NO_SESSIONS: EXIT_OK,
+            WHO_UNLOCATED: EXIT_UNLOCATED,
+            WHO_NO_TASK: EXIT_NO_TASK,
+            WHO_NO_CLAWGATE: EXIT_NO_CLAWGATE,
+        }.get(self.state, EXIT_OK)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task": self.task,
+            "state": self.state,
+            "title": self.title,
+            "status": self.status,
+            "windows_reason": self.windows_reason,
+            "notes": list(self.notes),
+            "sessions": [s.to_dict() for s in self.sessions],
+        }
+
+
+# --------------------------------------------------------------------------- #
+# The hops
+# --------------------------------------------------------------------------- #
+
+
+def _run(cmd: Sequence[str], timeout: int) -> tuple[int, str, str]:
+    """Run a tool, capturing both streams SEPARATELY.
+
+    🔴 Never `2>&1`. `clawgatectl` documents that JSON goes to stdout and
+    nothing else ever does, precisely so a diagnostic on stderr cannot corrupt
+    a parse. Merging them here would throw that guarantee away at the one place
+    that depends on it.
+    """
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError:
+        raise WhoError(f"{cmd[0]} is not on PATH")
+    except subprocess.TimeoutExpired:
+        raise WhoError(f"{cmd[0]} did not answer within {timeout}s")
+    return p.returncode, p.stdout, p.stderr
+
+
+def fetch_task(task: str, *, timeout: int = DEFAULT_TIMEOUT,
+               runner=_run) -> dict[str, Any]:
+    """`clawgatectl task get <id>` -> the task object.
+
+    Its documented exit codes are used as-is rather than re-derived from the
+    message text: 4 is not-found, 3 is auth, 6 is network. Reading the message
+    instead is how a wording change turns "unreachable" into "not found".
+    """
+    if not str(task).strip():
+        raise WhoError("empty task id")
+    rc, out, err = runner(["clawgatectl", "task", "get", str(task)], timeout)
+    if rc == 4:
+        raise WhoError(f"clawgate has no task {task}")
+    if rc in (3, 6, 7, 8) or (rc != 0 and not out.strip()):
+        raise WhoError(
+            f"clawgatectl exited {rc} — {err.strip() or 'no diagnostic'}")
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError as exc:
+        raise WhoError(f"clawgatectl returned non-JSON: {exc}")
+
+
+def sessions_of(task_obj: dict[str, Any]) -> list[SessionHit]:
+    """The `sessions[]` clawgate embeds on a task read.
+
+    A session with no `sessionId` is DROPPED rather than carried as a blank —
+    a blank id would match every window whose id is also blank, which is how a
+    join invents a result.
+    """
+    out: list[SessionHit] = []
+    for row in task_obj.get("sessions") or []:
+        sid = (row.get("sessionId") or "").strip()
+        if not sid:
+            continue
+        out.append(SessionHit(
+            session_id=sid,
+            role=row.get("role"),
+            project=row.get("project"),
+            cwd=row.get("cwd"),
+            host=row.get("host"),
+            last_seen=row.get("lastSeenAt"),
+        ))
+    return out
+
+
+def _index_windows(payload: dict[str, Any]) -> dict[str, WindowHit]:
+    """`claude_session_id` -> the window holding it.
+
+    🔴 LAST WRITER WINS IS WRONG HERE, SO IT IS NOT DONE. Two windows can carry
+    the same session id (a split pane, a re-attached session). The first is kept
+    and the collision is not silently overwritten, because overwriting makes the
+    answer depend on host iteration order — which is a dict order, not a fact.
+    """
+    idx: dict[str, WindowHit] = {}
+    for host, block in (payload.get("hosts") or {}).items():
+        for w in block.get("windows") or []:
+            sid = w.get("claude_session_id")
+            if not sid or sid in idx:
+                continue
+            idx[sid] = WindowHit(
+                host=w.get("host") or host,
+                session=str(w.get("session")),
+                window_index=(str(w["window_index"])
+                              if w.get("window_index") is not None else None),
+                window_id=w.get("window_id"),
+                pane_id=w.get("pane_id"),
+                codename=w.get("codename"),
+                hotkey=w.get("hotkey"),
+                path=w.get("path"),
+            )
+    return idx
+
+
+def live_windows(*, timeout: int = DEFAULT_TIMEOUT, host: str | None = None,
+                 runner=_run, script: Path | None = None) -> dict[str, WindowHit]:
+    """Scan tmux across hosts and index by session id.
+
+    🔴 `--lean` IS NOT USABLE HERE and that is measured, not assumed: its
+    `lean_row_fields` omit `pane_id`, `window_id` and `codename`, which are
+    three of the four things this command exists to print. The full scan cost
+    ~5s cross-host, which is what a typed command can afford.
+    """
+    exe = Path(script) if script else _session_manager_path()
+    cmd = [sys.executable, str(exe), "scan", "--json"]
+    if host:
+        cmd += ["--host", host]
+    rc, out, err = runner(cmd, timeout)
+    if rc != 0 and not out.strip():
+        raise WhoError(f"session-manager exited {rc} — "
+                       f"{err.strip() or 'no diagnostic'}")
+    try:
+        payload = json.loads(out)
+    except json.JSONDecodeError as exc:
+        raise WhoError(f"session-manager returned non-JSON: {exc}")
+    return _index_windows(payload)
+
+
+def _session_manager_path() -> Path:
+    """Prefer the checkout this file ships in; fall back to PATH."""
+    local = Path(__file__).resolve().parents[1] / "session-manager"
+    if local.is_file():
+        return local
+    found = shutil.which("session-manager")
+    if found:
+        return Path(found)
+    raise WhoError("session-manager was not found in this checkout or on PATH")
+
+
+def find_transcript(session_id: str, root: Path | None = None) -> Path | None:
+    """Delegate to `transcript_search`, the repo's ONE transcript locator.
+
+    🔴 Re-implementing the `<cwd> -> -home-zach-…` mangling here would make two
+    copies of a rule that has to agree, and `claude/RULES.md` records that a
+    predicate open-coded at N sites is typically wrong at N-1 of them. That
+    module already survived a consolidation that found seven real bugs; it also
+    resolves by SCAN, so it finds a transcript whose project directory does not
+    match the cwd clawgate recorded — which happens whenever a session moved.
+    """
+    lib = str(Path(__file__).resolve().parent)
+    if lib not in sys.path:
+        sys.path.insert(0, lib)
+    import transcript_search  # noqa: PLC0415
+
+    return transcript_search.find_transcript(session_id, root=root)
+
+
+# --------------------------------------------------------------------------- #
+# The join
+# --------------------------------------------------------------------------- #
+
+
+def resolve(task: str, *, timeout: int = DEFAULT_TIMEOUT,
+            host: str | None = None, skip_windows: bool = False,
+            transcript_root: Path | None = None,
+            task_fetcher=fetch_task, window_fetcher=live_windows,
+            transcript_finder=find_transcript) -> WhoReport:
+    """Task -> sessions -> (window, transcript). Every hop's failure is NAMED."""
+    try:
+        obj = task_fetcher(task, timeout=timeout)
+    except WhoError as exc:
+        msg = str(exc)
+        state = WHO_NO_TASK if "has no task" in msg else WHO_NO_CLAWGATE
+        return WhoReport(task=task, state=state, notes=[msg])
+
+    report = WhoReport(
+        task=task, state=WHO_RESOLVED,
+        title=obj.get("title"), status=obj.get("status"),
+    )
+    report.sessions = sessions_of(obj)
+    if not report.sessions:
+        report.state = WHO_NO_SESSIONS
+        return report
+
+    windows: dict[str, WindowHit] = {}
+    measured = False
+    if skip_windows:
+        report.windows_reason = "--no-windows: the live half was not looked at"
+    else:
+        try:
+            windows = window_fetcher(timeout=timeout, host=host)
+            measured = True
+        except WhoError as exc:
+            # 🔴 NOT fatal, and NOT an empty window column. The durable half is
+            # independent of tmux being reachable, and it is usually the half
+            # that answers the question.
+            report.windows_reason = str(exc)
+
+    for s in report.sessions:
+        s.windows_measured = measured
+        if measured:
+            s.window = windows.get(s.session_id)
+        try:
+            s.transcript = transcript_finder(s.session_id, root=transcript_root)
+        except Exception as exc:  # noqa: BLE001 — a bad transcript root must
+            # degrade this ONE session's durable half, never the whole report.
+            report.notes.append(
+                f"transcript lookup failed for {s.session_id[:8]}…: {exc}")
+
+    if not any(s.located for s in report.sessions):
+        report.state = WHO_UNLOCATED
+    return report
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+
+
+def render(report: WhoReport) -> str:
+    """Human output. Every absence is spelled, never left blank."""
+    lines: list[str] = []
+    head = f"task {report.task}"
+    if report.title:
+        head += f" — {report.title}"
+    if report.status:
+        head += f"  [{report.status}]"
+    lines.append(head)
+
+    if report.state == WHO_NO_TASK:
+        lines.append(f"  🔴 {WHO_NO_TASK} — {'; '.join(report.notes)}")
+        return "\n".join(lines)
+    if report.state == WHO_NO_CLAWGATE:
+        lines.append(f"  🔴 {WHO_NO_CLAWGATE} — {'; '.join(report.notes)}")
+        lines.append("     This is NOT 'the task has no sessions' — nothing was asked.")
+        return "\n".join(lines)
+    if report.state == WHO_NO_SESSIONS:
+        lines.append("  no session is recorded against this task.")
+        lines.append("  That is a real state (a task filed in the UI has none), "
+                     "not a lookup failure.")
+        return "\n".join(lines)
+
+    if report.windows_reason:
+        lines.append(f"  🔴 LIVE WINDOWS UNMEASURED — {report.windows_reason}")
+        lines.append("     'no window' below would be unproven, so it is not claimed.")
+
+    for s in report.sessions:
+        role = f" ({s.role})" if s.role else ""
+        where = f" in {s.project}" if s.project else ""
+        lines.append(f"\n  session {s.session_id}{role}{where}")
+        if s.last_seen:
+            lines.append(f"    last seen   {s.last_seen}")
+
+        if not s.windows_measured:
+            lines.append("    window      UNMEASURED — not looked up on this run")
+        elif s.window is None:
+            lines.append("    window      none live — the session is not open in tmux now")
+        else:
+            w = s.window
+            extra = []
+            if w.codename:
+                extra.append(w.codename)
+            if w.hotkey:
+                extra.append(w.hotkey)
+            tag = f"  ({', '.join(extra)})" if extra else ""
+            lines.append(f"    window      {w.host} {w.address}{tag}")
+            ids = " ".join(x for x in (w.window_id, w.pane_id) if x)
+            if ids:
+                lines.append(f"                ids {ids}")
+            if w.path:
+                lines.append(f"                cwd {w.path}")
+
+        if s.transcript:
+            lines.append(f"    transcript  {s.transcript}")
+        else:
+            lines.append("    transcript  not found on this host")
+
+    for note in report.notes:
+        lines.append(f"  note: {note}")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(
+        prog="cairn who",
+        description="Resolve a task to its sessions, tmux windows and transcripts.",
+    )
+    ap.add_argument("task")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--host", default=None, choices=["workbench", "laptop"])
+    ap.add_argument("--no-windows", action="store_true",
+                    help="skip the tmux scan; report only the durable transcripts")
+    ap.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    args = ap.parse_args(argv)
+
+    report = resolve(args.task, timeout=args.timeout, host=args.host,
+                     skip_windows=args.no_windows)
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        print(render(report))
+    return report.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_cairn_who.py
+++ b/scripts/tests/test_cairn_who.py
@@ -22,6 +22,7 @@ read at run time and appear in no fixture — the `CLAUDE.md` PUBLIC-repo rule.
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -263,7 +264,7 @@ def test_session_manager_EXIT_UNAVAILABLE_is_not_read_as_a_measured_zero():
     through because the output was present and well-formed.
     """
     def runner(cmd, timeout):
-        return W.SM_EXIT_UNAVAILABLE, json.dumps(_scan([])), "all hosts down"
+        return 4, json.dumps(_scan([])), "all hosts down"   # literal: 4 is session-manager's
 
     with pytest.raises(W.WhoError) as exc:
         W.live_windows(runner=runner, script=Path(__file__))
@@ -275,7 +276,7 @@ def test_session_manager_EXIT_EMPTY_IS_a_measured_zero():
     answer is genuinely none — raising on it would make a quiet fleet look
     like an outage."""
     def runner(cmd, timeout):
-        return W.SM_EXIT_EMPTY, json.dumps(_scan([])), ""
+        return 3, json.dumps(_scan([])), ""   # literal: 3 is session-manager's
 
     idx, unmeasured = W.live_windows(runner=runner, script=Path(__file__))
     assert idx == {} and unmeasured == []
@@ -520,15 +521,25 @@ def test_a_transcript_lookup_failure_degrades_ONE_session_not_the_report():
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.parametrize("rc,expect", [
-    (4, "has no task"),
-    (3, "exited 3"),
-    (6, "exited 6"),
-    (7, "exited 7"),
-    (8, "exited 8"),
+@pytest.mark.parametrize("rc,expect,exc_type", [
+    (4, "has no task", "TaskNotFound"),
+    (2, "refused the id", "BadTaskId"),
+    (3, "exited 3", "ClawgateUnreachable"),
+    (6, "exited 6", "ClawgateUnreachable"),
+    (7, "exited 7", "ClawgateUnreachable"),
+    (8, "exited 8", "ClawgateUnreachable"),
 ])
-def test_fetch_task_reads_clawgatectl_EXIT_CODES_not_its_prose(rc, expect):
-    """The codes are documented; the message wording is not a contract."""
+def test_fetch_task_reads_clawgatectl_EXIT_CODES_not_its_prose(rc, expect, exc_type):
+    """The codes are documented; the message wording is not a contract.
+
+    🔴 THE TYPE COLUMN IS THE POINT, AND ITS ABSENCE LEFT THE HEADLINE PAIR
+    UNPINNED. Asserting only the message let rc 4 raise `ClawgateUnreachable`
+    with the whole suite green — so `cairn who <missing-id>` would exit 8 and
+    print "nothing was asked", which is precisely the confusion this module
+    exists to prevent. The other test covering that pair injects hand-thrown
+    exceptions and never calls `fetch_task`, so neither half built the combined
+    state: the seam nobody owns.
+    """
     # 🔴 STDOUT IS NON-EMPTY ON PURPOSE. The first version fed `out=""` for
     # every code, so the `not out.strip()` fallback produced an identical
     # message and deleting the whole exit-code table SURVIVED — the test named
@@ -539,6 +550,9 @@ def test_fetch_task_reads_clawgatectl_EXIT_CODES_not_its_prose(rc, expect):
     with pytest.raises(W.WhoError) as exc:
         W.fetch_task("42", runner=runner)
     assert expect in str(exc.value)
+    assert type(exc.value).__name__ == exc_type, (
+        f"rc {rc} raised {type(exc.value).__name__}, not {exc_type} — the STATE "
+        "a caller derives from it would be wrong")
 
 
 def test_fetch_task_refuses_an_empty_id_before_shelling_out():
@@ -691,3 +705,164 @@ def test_who_owns_its_own_timeout_default_and_accepts_the_flag_AFTER_the_subcomm
     assert "--timeout" in help_out, "who does not accept --timeout after the subcommand"
     assert f"default {W.DEFAULT_TIMEOUT}" in help_out, (
         f"the help advertises a default that is not who's own:\n{help_out}")
+
+
+def test_the_session_manager_exit_codes_match_SESSION_MANAGERS_OWN_definitions():
+    """🔴 SEAM GUARD. `session-manager` owns these numbers; this module copies them.
+
+    A copy that silently drifts is the whole hazard: if `SM_EXIT_UNAVAILABLE`
+    stopped being 4, real rc 4 would fall through the `rc not in (0,
+    SM_EXIT_EMPTY) and not out.strip()` branch — stdout is non-empty on rc 4 —
+    and the silent zero this PR fixed would be back with the suite green.
+    Read from the source of truth rather than restated here.
+    """
+    src = (REPO_ROOT / "scripts" / "session-manager").read_text(encoding="utf-8")
+    found = dict(re.findall(r"^EXIT_(EMPTY|UNAVAILABLE)\s*=\s*(\d+)", src, re.M))
+    assert set(found) == {"EMPTY", "UNAVAILABLE"}, (
+        f"could not read session-manager's exit codes — the guard checked "
+        f"NOTHING: {found}")
+    assert int(found["EMPTY"]) == W.SM_EXIT_EMPTY
+    assert int(found["UNAVAILABLE"]) == W.SM_EXIT_UNAVAILABLE
+
+
+def test_a_host_that_is_REACHABLE_but_UNMEASURED_is_still_unmeasured():
+    """🔴 The clause a mutant could delete for free, and it is NOT redundant.
+
+    `session-manager` calls list-panes and list-windows independently, so a host
+    can be `reachable: True` with `windows_measured: False` and STILL publish a
+    full `windows` list — every row carrying `claude_session_id: null`. Without
+    this clause the run reports `measured=True` while every session on that host
+    silently reads "none live", which is the exact defect the round before this
+    one fixed, arriving through the other door.
+    """
+    payload = {"hosts": {"workbench": {
+        "reachable": True, "windows_measured": False,
+        "windows": [_window(None), _window(None)],
+    }}}
+    idx, unmeasured = W._index_windows(payload)
+    assert idx == {}
+    assert unmeasured == ["workbench"], (
+        f"a reachable-but-unmeasured host was counted as measured: {unmeasured}")
+
+
+def test_a_host_with_a_WINDOWS_ERROR_is_unmeasured_even_if_reachable():
+    """The third arm of the same predicate."""
+    payload = {"hosts": {"workbench": {
+        "reachable": True, "windows_measured": True,
+        "windows_error": "tmux: server exited",
+        "windows": [_window(FAKE_UUID)],
+    }}}
+    idx, unmeasured = W._index_windows(payload)
+    assert idx == {} and unmeasured == ["workbench"]
+
+
+def test_EXIT_EMPTY_with_EMPTY_stdout_is_still_a_measured_zero():
+    """Separates `rc not in (0, SM_EXIT_EMPTY)` from a bare `rc != 0`.
+
+    The existing rc-3 case carries stdout, so `and not out.strip()`
+    short-circuits and the two spellings are indistinguishable there.
+    """
+    def runner(cmd, timeout):
+        return 3, "", ""
+
+    # rc 3 with no output: not an error, but nothing to parse either.
+    with pytest.raises(W.WhoError) as exc:
+        W.live_windows(runner=runner, script=Path(__file__))
+    assert "non-JSON" in str(exc.value), (
+        f"rc 3 with empty output should fail on the PARSE, naming what was "
+        f"wrong — not be reported as a bad exit code: {exc.value}")
+
+
+@pytest.mark.parametrize("bad", [None, 0, -1, "60"])
+def test_a_MISSING_or_NONPOSITIVE_timeout_is_refused_not_treated_as_a_default(bad):
+    """🔴 `timeout=None` means NO TIMEOUT — measured: an unbounded wait.
+
+    Dropping the CLI's `None -> DEFAULT_TIMEOUT` resolution survived the suite,
+    and under it `cairn who` waits forever on a host that never answers while
+    the expiry message would read "within Nones". So the refusal lives in
+    `_run`, where it cannot be bypassed by a caller that forgets.
+    """
+    with pytest.raises(W.WhoError) as exc:
+        W._run(["true"], bad)
+    assert "UNBOUNDED" in str(exc.value)
+
+
+def test_the_stderr_collapse_happens_at_the_REAL_boundary():
+    """One rule, one place — and the place is `_run`, so it is tested there.
+
+    🔴 THE FIRST VERSION OF THIS TEST INJECTED A FAKE RUNNER AND SO TESTED A
+    PATH PRODUCTION NEVER TAKES. `_run` is the only runner in production; a
+    caller-supplied one bypasses the normalisation by construction, so asserting
+    against a fake would have pinned nothing while looking like coverage. This
+    drives a real subprocess emitting real multi-line stderr.
+
+    It matters because `live_windows`' diagnostic lands in `windows_reason`,
+    which `render` prints inside an indented block — a raw newline there makes
+    the follow-up sentence read as unrelated output.
+    """
+    rc, out, err = W._run(
+        [sys.executable, "-c",
+         "import sys; sys.stderr.write('line one\\nline two\\n  line three\\n')"],
+        timeout=30)
+    assert "\n" not in err, f"multi-line stderr reached a caller: {err!r}"
+    assert err == "line one line two line three"
+
+
+def test_a_discarded_TOP_LEVEL_timeout_is_named_not_swallowed():
+    """argparse drops it silently, and it was the only spelling that used to work."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_loader(
+        "cairn_cli", loader=None, origin=str(REPO_ROOT / "scripts" / "cairn"))
+    mod = importlib.util.module_from_spec(spec)
+    mod.__file__ = str(REPO_ROOT / "scripts" / "cairn")
+    exec(compile((REPO_ROOT / "scripts" / "cairn").read_text(), "cairn", "exec"),
+         mod.__dict__)
+    f = mod._top_level_timeout_was_given
+    assert f(["--timeout", "5", "who", "42"]) is True
+    assert f(["--timeout=5", "who", "42"]) is True
+    assert f(["who", "42", "--timeout", "5"]) is False
+    assert f(["who", "42"]) is False
+
+
+def _load_cairn_cli():
+    """Exec `scripts/cairn` as a module — it has no .py extension."""
+    import importlib.util
+
+    path = REPO_ROOT / "scripts" / "cairn"
+    spec = importlib.util.spec_from_loader("cairn_cli", loader=None, origin=str(path))
+    mod = importlib.util.module_from_spec(spec)
+    mod.__file__ = str(path)
+    exec(compile(path.read_text(encoding="utf-8"), str(path), "exec"), mod.__dict__)
+    return mod
+
+
+def test_the_CLI_resolves_a_missing_timeout_to_WHOs_own_default(monkeypatch):
+    """🔴 Pins the `None -> DEFAULT_TIMEOUT` step in `cmd_who`.
+
+    Dropping it survived every earlier battery. `_run` now REFUSES a `None`
+    bound, so the consequence is a loud error rather than the unbounded wait it
+    used to be — but "fails visibly" is not "is correct", and the resolution
+    itself was still unpinned. Measured under the mutant: every run reported
+    `clawgate-unreachable — refusing to run clawgatectl with timeout=None`.
+    """
+    cli = _load_cairn_cli()
+    seen = {}
+
+    def fake_resolve(task, *, timeout, host, skip_windows):
+        seen["timeout"] = timeout
+        return W.WhoReport(task=task, state=W.WHO_NO_SESSIONS)
+
+    sys.modules.pop("cairn_who", None)
+    monkeypatch.setattr(W, "resolve", fake_resolve)
+    monkeypatch.setitem(sys.modules, "cairn_who", W)
+
+    args = cli.build_parser().parse_args(["who", "42"])
+    monkeypatch.setattr(sys, "argv", ["cairn", "who", "42"])
+    args.func(args)
+    assert seen["timeout"] == W.DEFAULT_TIMEOUT, (
+        f"the CLI passed {seen['timeout']!r} instead of who's own default")
+
+    args = cli.build_parser().parse_args(["who", "42", "--timeout", "7"])
+    args.func(args)
+    assert seen["timeout"] == 7, "an explicit --timeout was not honoured"

--- a/scripts/tests/test_cairn_who.py
+++ b/scripts/tests/test_cairn_who.py
@@ -60,16 +60,26 @@ def _session_row(sid, **kw):
 def _window(sid, **kw):
     w = {"claude_session_id": sid, "host": "workbench", "session": "scratch9",
          "window_index": "3", "window_id": "@903", "pane_id": "%903",
-         "codename": "Onyx", "hotkey": "Alt+o", "path": "/tmp/proj-one"}
+         "codename": "Onyx", "hotkey": "o", "path": "/tmp/proj-one"}
     w.update(kw)
     return w
 
 
-def _scan(windows, host="workbench"):
-    return {"hosts": {host: {"windows": list(windows)}}}
+def _scan(windows, host="workbench", **hostkw):
+    """A host block shaped like the real one — INCLUDING the honesty fields.
+
+    🔴 `reachable`, `windows_measured` and `windows_error` are published per
+    host by `session-manager` and were the fields the first version of this
+    module ignored. A fixture that omits them cannot see that class of bug.
+    """
+    block = {"windows": list(windows), "reachable": True,
+             "windows_measured": True, "windows_error": None}
+    block.update(hostkw)
+    return {"hosts": {host: block}}
 
 
-def _resolve(task_obj, windows=None, transcripts=None, window_exc=None, **kw):
+def _resolve(task_obj, windows=None, transcripts=None, window_exc=None,
+             scan_kw=None, **kw):
     """Drive `resolve` with every hop injected — no network, no tmux, no disk."""
     def fetch(task, timeout=0):
         return task_obj
@@ -77,7 +87,7 @@ def _resolve(task_obj, windows=None, transcripts=None, window_exc=None, **kw):
     def wins(timeout=0, host=None):
         if window_exc:
             raise window_exc
-        return W._index_windows(_scan(windows or []))
+        return W._index_windows(_scan(windows or [], **(scan_kw or {})))
 
     def find(sid, root=None):
         got = (transcripts or {}).get(sid)
@@ -183,6 +193,135 @@ def test_a_MEASURED_scan_with_no_match_DOES_claim_none_live():
 # --------------------------------------------------------------------------- #
 
 
+def test_ONE_unreachable_host_makes_an_ABSENT_window_unmeasured():
+    """🔴 REGRESSION GUARD — the defect this command's own docstring forbade.
+
+    `session-manager` leaves an unreachable host's `windows` as an empty list
+    and still exits 0 when the OTHER host answered, so indexing only `windows`
+    turned "the laptop is asleep" into a confident "this session is running
+    nowhere". Demonstrated on the same fixture, laptop down vs up: `none live`
+    became a real window. `ConnectTimeout=4` makes a sleeping laptop fail FAST,
+    so this is the everyday case, not an edge.
+    """
+    payload = {"hosts": {
+        "laptop": {"reachable": False, "windows": []},
+        "workbench": {"reachable": True, "windows": [_window(FAKE_UUID_2)]},
+    }}
+
+    def wins(timeout=0, host=None):
+        return W._index_windows(payload)
+
+    r = W.resolve("42", task_fetcher=lambda t, timeout=0: _task([_session_row(FAKE_UUID)]),
+                  window_fetcher=wins, transcript_finder=lambda s, root=None: None)
+    assert r.sessions[0].windows_measured is False, (
+        "an absent window was claimed as measured while a host was unreachable")
+    out = W.render(r)
+    assert "UNMEASURED" in out and "none live" not in out
+    assert "laptop" in (r.windows_reason or ""), r.windows_reason
+
+
+def test_a_MATCHED_window_stays_a_positive_finding_even_with_a_host_down():
+    """CONTROL. Partial-scan honesty must not erase findings it DID make.
+
+    Without this, the fix for the guard above could degrade every window to
+    UNMEASURED whenever any host is down — throwing away real answers to avoid
+    claiming a false absence.
+    """
+    payload = {"hosts": {
+        "laptop": {"reachable": False, "windows": []},
+        "workbench": {"reachable": True, "windows": [_window(FAKE_UUID)]},
+    }}
+    r = W.resolve("42", task_fetcher=lambda t, timeout=0: _task([_session_row(FAKE_UUID)]),
+                  window_fetcher=lambda timeout=0, host=None: W._index_windows(payload),
+                  transcript_finder=lambda s, root=None: None)
+    s = r.sessions[0]
+    assert s.window is not None and s.windows_measured is True
+    assert "scratch9:3" in W.render(r)
+
+
+def test_UNLOCATED_does_not_fire_when_the_live_half_was_never_measured():
+    """🔴 Exit 6 documents a GENUINE gap, so it requires having looked.
+
+    With the live half unmeasured, "nothing located" means "no transcript, and
+    the window is unknown" — indeterminate. Firing exit 6 made the
+    machine-readable surface assert what the human-readable one disclaimed.
+    """
+    r = _resolve(_task([_session_row(FAKE_UUID)]), transcripts={},
+                 skip_windows=True)
+    assert not r.sessions[0].located
+    assert r.state != W.WHO_UNLOCATED
+    assert r.exit_code == W.EXIT_OK
+    assert "UNMEASURED" in W.render(r)
+
+
+def test_session_manager_EXIT_UNAVAILABLE_is_not_read_as_a_measured_zero():
+    """🔴 rc 4 arrives WITH a full JSON report of zero windows.
+
+    `session-manager` documents 4 as "NO requested host could be reached — the
+    0 is unmeasured", and its header says a caller must never read success off
+    a truncated run. The old guard (`rc != 0 and not out.strip()`) let it
+    through because the output was present and well-formed.
+    """
+    def runner(cmd, timeout):
+        return W.SM_EXIT_UNAVAILABLE, json.dumps(_scan([])), "all hosts down"
+
+    with pytest.raises(W.WhoError) as exc:
+        W.live_windows(runner=runner, script=Path(__file__))
+    assert "UNMEASURED" in str(exc.value)
+
+
+def test_session_manager_EXIT_EMPTY_IS_a_measured_zero():
+    """CONTROL, and the opposite code. 3 means every host answered and the
+    answer is genuinely none — raising on it would make a quiet fleet look
+    like an outage."""
+    def runner(cmd, timeout):
+        return W.SM_EXIT_EMPTY, json.dumps(_scan([])), ""
+
+    idx, unmeasured = W.live_windows(runner=runner, script=Path(__file__))
+    assert idx == {} and unmeasured == []
+
+
+def test_a_nonzero_scan_WITH_output_is_still_refused():
+    """The `and`/`or` seam. An unrecognised non-zero code carrying output must
+    not be waved through just because JSON happened to be printed."""
+    def runner(cmd, timeout):
+        return 99, "", "something broke"
+
+    with pytest.raises(W.WhoError):
+        W.live_windows(runner=runner, script=Path(__file__))
+
+
+def test_a_BAD_task_id_is_not_reported_as_an_outage():
+    """🔴 rc 2 is clawgate ANSWERING with a 400. A typo is the likeliest
+    failure of all, and calling it `clawgate-unreachable` printed "nothing was
+    asked" directly above clawgate's own 400."""
+    def runner(cmd, timeout):
+        return 2, "", "400 Bad Request — bad id"
+
+    with pytest.raises(W.BadTaskId):
+        W.fetch_task("not-a-number", runner=runner)
+
+    r = W.resolve("x", task_fetcher=lambda t, timeout=0: (_ for _ in ()).throw(
+        W.BadTaskId("clawgatectl refused the id")))
+    assert r.state == W.WHO_BAD_TASK_ID
+    assert r.exit_code == W.EXIT_USAGE
+    assert r.exit_code not in (W.EXIT_NO_CLAWGATE, W.EXIT_NO_TASK)
+    assert "not the network" in W.render(r)
+
+
+def test_find_transcript_forwards_its_ROOT(tmp_path):
+    """The real locator, exercised directly — every other test injects a fake.
+
+    Dropping the `root=` passthrough survived the suite, which means claim
+    "reuses transcript_search" was verified only by reading the source.
+    """
+    proj = tmp_path / "-tmp-proj"
+    proj.mkdir()
+    (proj / f"{FAKE_UUID}.jsonl").write_text("{}\n")
+    assert W.find_transcript(FAKE_UUID, root=tmp_path) == proj / f"{FAKE_UUID}.jsonl"
+    assert W.find_transcript(FAKE_UUID_2, root=tmp_path) is None
+
+
 def test_task_not_found_and_clawgate_unreachable_are_DIFFERENT_states_and_codes():
     """🔴 Both print an empty result; one of them is a lie.
 
@@ -191,10 +330,10 @@ def test_task_not_found_and_clawgate_unreachable_are_DIFFERENT_states_and_codes(
     turn "unreachable" into "no such task".
     """
     def missing(task, timeout=0):
-        raise W.WhoError("clawgate has no task 42")
+        raise W.TaskNotFound("clawgate has no task 42")
 
     def down(task, timeout=0):
-        raise W.WhoError("clawgatectl exited 6 — dial tcp: i/o timeout")
+        raise W.ClawgateUnreachable("clawgatectl exited 6 — dial tcp: i/o timeout")
 
     a = W.resolve("42", task_fetcher=missing)
     b = W.resolve("42", task_fetcher=down)
@@ -215,14 +354,26 @@ def test_a_task_with_no_sessions_is_a_REAL_state_not_a_failure():
 
 
 def test_every_state_has_an_exit_code_and_the_success_ones_are_distinct():
-    """LEDGER. A state added without a code would silently map to 0."""
-    states = {W.WHO_RESOLVED, W.WHO_NO_SESSIONS, W.WHO_UNLOCATED,
-              W.WHO_NO_TASK, W.WHO_NO_CLAWGATE}
+    """LEDGER, discovered by INTROSPECTION rather than re-listed.
+
+    🔴 The first version enumerated a literal 5-element set, so its own
+    docstring claim — "a state added without a code would silently map to 0" —
+    was false twice over: it could not see a new `WHO_*` constant, and the
+    mapping had a `.get(..., EXIT_OK)` default that swallowed one. Mutating the
+    default to 99 survived. The map is now total (a `KeyError` on an unmapped
+    state) and the states come from the module.
+    """
+    states = {v for n, v in vars(W).items()
+              if n.startswith("WHO_") and isinstance(v, str)}
+    assert len(states) >= 6, f"state discovery broke: {states}"
     codes = {s: W.WhoReport(task="t", state=s).exit_code for s in states}
     assert codes[W.WHO_RESOLVED] == 0 and codes[W.WHO_NO_SESSIONS] == 0
     failing = {s: c for s, c in codes.items() if c != 0}
     assert len(set(failing.values())) == len(failing), (
         f"two failure states share an exit code: {failing}")
+    # 🔴 No silent default: an unmapped state must RAISE, not report success.
+    with pytest.raises(KeyError):
+        W.WhoReport(task="t", state="a-state-nobody-mapped").exit_code
 
 
 # --------------------------------------------------------------------------- #
@@ -262,7 +413,7 @@ def test_a_session_row_with_a_BLANK_id_is_dropped_not_carried():
 
 
 def test_a_window_with_no_session_id_never_enters_the_index():
-    idx = W._index_windows(_scan([
+    idx, _ = W._index_windows(_scan([
         _window(None), _window(""), _window(FAKE_UUID)]))
     assert set(idx) == {FAKE_UUID}
 
@@ -277,25 +428,36 @@ def test_two_windows_sharing_a_session_id_resolve_DETERMINISTICALLY():
     first = _window(FAKE_UUID, session="scratch1", window_index="1")
     second = _window(FAKE_UUID, session="scratch2", window_index="2")
     for _ in range(5):
-        idx = W._index_windows(_scan([first, second]))
+        idx, _ = W._index_windows(_scan([first, second]))
         assert idx[FAKE_UUID].address == "scratch1:1"
 
 
 def test_windows_are_indexed_across_ALL_hosts_not_just_the_first():
     payload = {"hosts": {
-        "workbench": {"windows": [_window(FAKE_UUID)]},
-        "laptop": {"windows": [_window(FAKE_UUID_2, host="laptop")]},
+        "workbench": {"windows": [_window(FAKE_UUID)], "reachable": True},
+        "laptop": {"windows": [_window(FAKE_UUID_2, host="laptop")],
+                   "reachable": True},
     }}
-    idx = W._index_windows(payload)
+    idx, _ = W._index_windows(payload)
     assert set(idx) == {FAKE_UUID, FAKE_UUID_2}
     assert idx[FAKE_UUID_2].host == "laptop"
+    # 🔴 The row's OWN `host` wins over the `hosts` key. Every fixture used to
+    # set them equal, so swapping the operands was indistinguishable.
+    odd = {"hosts": {"workbench": {"reachable": True,
+                                   "windows": [_window(FAKE_UUID, host="elsewhere")]}}}
+    only, _ = W._index_windows(odd)
+    assert only[FAKE_UUID].host == "elsewhere"
 
 
 def test_a_host_block_with_no_windows_key_does_not_crash_the_index():
     """A host that failed to scan reports no `windows`; that is a state."""
     payload = {"hosts": {"laptop": {"reachable": False},
-                         "workbench": {"windows": [_window(FAKE_UUID)]}}}
-    assert set(W._index_windows(payload)) == {FAKE_UUID}
+                         "workbench": {"windows": [_window(FAKE_UUID)],
+                                       "reachable": True}}}
+    idx, unmeasured = W._index_windows(payload)
+    assert set(idx) == {FAKE_UUID}
+    assert unmeasured == ["laptop"], (
+        f"an unreachable host was not reported as unmeasured: {unmeasured}")
 
 
 # --------------------------------------------------------------------------- #
@@ -320,7 +482,7 @@ def test_render_carries_BOTH_the_window_index_and_the_stable_ids():
     out = W.render(r)
     assert "scratch9:3" in out
     assert "@903" in out and "%903" in out
-    assert "Onyx" in out and "Alt+o" in out
+    assert "Onyx" in out and "(Onyx, o)" in out
 
 
 def test_the_json_surface_round_trips_and_marks_the_unmeasured_half():
@@ -345,7 +507,7 @@ def test_a_transcript_lookup_failure_degrades_ONE_session_not_the_report():
         return _task([_session_row(FAKE_UUID), _session_row(FAKE_UUID_2)])
 
     r = W.resolve("42", task_fetcher=fetch,
-                  window_fetcher=lambda timeout=0, host=None: {},
+                  window_fetcher=lambda timeout=0, host=None: ({}, []),
                   transcript_finder=boom)
     assert r.sessions[0].transcript is None
     assert r.sessions[1].transcript == Path("/tmp/t/b.jsonl")
@@ -367,8 +529,12 @@ def test_a_transcript_lookup_failure_degrades_ONE_session_not_the_report():
 ])
 def test_fetch_task_reads_clawgatectl_EXIT_CODES_not_its_prose(rc, expect):
     """The codes are documented; the message wording is not a contract."""
+    # 🔴 STDOUT IS NON-EMPTY ON PURPOSE. The first version fed `out=""` for
+    # every code, so the `not out.strip()` fallback produced an identical
+    # message and deleting the whole exit-code table SURVIVED — the test named
+    # for "reads exit codes, not prose" did not pin the table at all.
     def runner(cmd, timeout):
-        return rc, "", "some diagnostic"
+        return rc, '{"id": 42}', "some diagnostic"
 
     with pytest.raises(W.WhoError) as exc:
         W.fetch_task("42", runner=runner)
@@ -506,3 +672,22 @@ def test_who_never_raises_or_focuses_a_window():
     for verb in ("switch-client", "select-window", "windowactivate",
                  "i3-msg", "wmctrl", "attach-session"):
         assert verb not in code, f"who reaches for {verb!r} — that is screen theft"
+
+
+def test_who_owns_its_own_timeout_default_and_accepts_the_flag_AFTER_the_subcommand():
+    """🔴 `cairn`'s top-level `--timeout` is 20s, tuned for an HTTP fetch.
+
+    `who` shells into tmux on two hosts, and `DEFAULT_TIMEOUT` here carries a
+    docstring reasoning specifically about a sleeping laptop. Inheriting the
+    store's bound meant the documented rationale was not what shipped — and
+    `cairn who --timeout N` was rejected outright, because the flag only existed
+    BEFORE the subcommand where nobody would type it.
+    """
+    import subprocess as sp
+
+    cairn = REPO_ROOT / "scripts" / "cairn"
+    help_out = sp.run([sys.executable, str(cairn), "who", "--help"],
+                      capture_output=True, text=True, timeout=60).stdout
+    assert "--timeout" in help_out, "who does not accept --timeout after the subcommand"
+    assert f"default {W.DEFAULT_TIMEOUT}" in help_out, (
+        f"the help advertises a default that is not who's own:\n{help_out}")

--- a/scripts/tests/test_cairn_who.py
+++ b/scripts/tests/test_cairn_who.py
@@ -1180,10 +1180,14 @@ def test_the_timeout_predicate_has_exactly_ONE_implementation():
     for path in (REPO_ROOT / "scripts" / "cairn",
                  REPO_ROOT / "scripts" / "lib" / "cairn_who.py"):
         src = path.read_text(encoding="utf-8")
-        # the predicate's own body is the one legitimate site
-        body = src.count("def unbounded_timeout_reason")
+        # 🔴 EXACTLY ZERO, not "at most one". The earlier bound allowed one
+        # copy on the theory that the predicate's own body is a legitimate
+        # site — but its parameter is `value`, not `timeout`, so this pattern
+        # never matched inside it, and the allowance was dead slack permitting
+        # one genuine re-open-coded copy. Measured: an agreeing duplicate in
+        # `_run` SURVIVED under the old bound.
         opencoded = len(re.findall(r"isinstance\(\s*timeout\s*,\s*int\s*\)", src))
-        assert opencoded <= body, (
-            f"{path.name} open-codes the timeout predicate "
-            f"({opencoded} site(s), {body} definition(s)) — import "
-            "`unbounded_timeout_reason` instead so the copies cannot drift")
+        assert opencoded == 0, (
+            f"{path.name} open-codes the timeout predicate at {opencoded} "
+            "site(s) — import `unbounded_timeout_reason` instead so the "
+            "copies cannot drift")

--- a/scripts/tests/test_cairn_who.py
+++ b/scripts/tests/test_cairn_who.py
@@ -808,23 +808,6 @@ def test_the_stderr_collapse_happens_at_the_REAL_boundary():
     assert err == "line one line two line three"
 
 
-def test_a_discarded_TOP_LEVEL_timeout_is_named_not_swallowed():
-    """argparse drops it silently, and it was the only spelling that used to work."""
-    import importlib.util
-
-    spec = importlib.util.spec_from_loader(
-        "cairn_cli", loader=None, origin=str(REPO_ROOT / "scripts" / "cairn"))
-    mod = importlib.util.module_from_spec(spec)
-    mod.__file__ = str(REPO_ROOT / "scripts" / "cairn")
-    exec(compile((REPO_ROOT / "scripts" / "cairn").read_text(), "cairn", "exec"),
-         mod.__dict__)
-    f = mod._top_level_timeout_was_given
-    assert f(["--timeout", "5", "who", "42"]) is True
-    assert f(["--timeout=5", "who", "42"]) is True
-    assert f(["who", "42", "--timeout", "5"]) is False
-    assert f(["who", "42"]) is False
-
-
 def _load_cairn_cli():
     """Exec `scripts/cairn` as a module — it has no .py extension."""
     import importlib.util
@@ -866,3 +849,134 @@ def test_the_CLI_resolves_a_missing_timeout_to_WHOs_own_default(monkeypatch):
     args = cli.build_parser().parse_args(["who", "42", "--timeout", "7"])
     args.func(args)
     assert seen["timeout"] == 7, "an explicit --timeout was not honoured"
+
+
+@pytest.mark.parametrize("argv,expected", [
+    # who's own flag wins
+    (["who", "42", "--timeout", "7"], 7),
+    # a TOP-LEVEL --timeout is honoured, not discarded
+    (["--timeout", "5", "who", "42"], 5),
+    # …including after another value-taking global, the spelling the old
+    # hand-rolled argv scanner got WRONG (it stopped at --cache's value)
+    (["--cache", "/tmp/c", "--timeout", "5", "who", "42"], 5),
+    # …and via argparse's long-option abbreviation, which a literal
+    # `== "--timeout"` comparison could never see
+    (["--time", "5", "who", "42"], 5),
+    # neither given -> who's OWN default, never the store's shorter one
+    (["who", "42"], None),
+    # who's own flag beats a top-level one
+    (["--timeout", "5", "who", "42", "--timeout", "9"], 9),
+])
+def test_the_timeout_precedence_is_who_then_TOP_LEVEL_then_whos_own_default(
+        argv, expected, monkeypatch):
+    """🔴 REGRESSION GUARD over every spelling, driven through `cmd_who` itself.
+
+    The first fix here printed a notice saying a top-level `--timeout` was being
+    discarded, driven by hand-parsing `sys.argv`. That scanner returned the
+    WRONG answer for two reachable spellings — after another value-taking global
+    option, and via argparse's long-option abbreviation — so those silently
+    discarded exactly as before, which is what the notice existed to prevent.
+    Re-implementing argparse's parsing in order to describe argparse's behaviour
+    was the mistake; distinct dests remove the clobber and there is nothing to
+    announce.
+
+    Only the helper was tested before, never `cmd_who`, so deleting the whole
+    block left the suite green — the seam nobody owns.
+    """
+    cli = _load_cairn_cli()
+    seen = {}
+
+    def fake_resolve(task, *, timeout, host, skip_windows):
+        seen["timeout"] = timeout
+        return W.WhoReport(task=task, state=W.WHO_NO_SESSIONS)
+
+    monkeypatch.setattr(W, "resolve", fake_resolve)
+    monkeypatch.setitem(sys.modules, "cairn_who", W)
+    args = cli.build_parser().parse_args(argv)
+    args.func(args)
+    want = W.DEFAULT_TIMEOUT if expected is None else expected
+    assert seen["timeout"] == want, (
+        f"{' '.join(argv)} resolved to {seen['timeout']}, expected {want}")
+
+
+def test_who_never_writes_a_warning_to_STDOUT(capsys, monkeypatch):
+    """`cairn who --json` writes JSON to stdout; anything else breaks a parse.
+
+    The previous design printed a notice, and its stream was unpinned — dropping
+    `file=sys.stderr` survived the suite.
+    """
+    cli = _load_cairn_cli()
+    monkeypatch.setattr(W, "resolve", lambda task, *, timeout, host, skip_windows:
+                        W.WhoReport(task=task, state=W.WHO_NO_SESSIONS))
+    monkeypatch.setitem(sys.modules, "cairn_who", W)
+    args = cli.build_parser().parse_args(["--timeout", "5", "who", "42", "--json"])
+    args.func(args)
+    out = capsys.readouterr().out
+    json.loads(out)  # raises if anything non-JSON was printed alongside it
+
+
+def test_the_store_commands_still_get_the_STORE_default_when_no_flag_is_given():
+    """CONTROL for the sentinel. Making the parent default `None` must not
+    silently hand the store commands a `None` bound — the unbounded wait."""
+    cli = _load_cairn_cli()
+    args = cli.build_parser().parse_args(["recall"])
+    assert args.timeout is None, "the sentinel is not in place"
+    assert cli.DEFAULT_TIMEOUT > 0
+    who = cli.build_parser().parse_args(["who", "42"])
+    assert cli._who_timeout(who, W.DEFAULT_TIMEOUT) == W.DEFAULT_TIMEOUT
+
+
+def test_every_store_call_site_resolves_the_timeout_sentinel():
+    """🔴 SEAM GUARD: no call site may pass the raw sentinel to the network.
+
+    Making the top-level `--timeout` default `None` — so `who` can tell "not
+    given" from an explicit value — gave every store command a chance to forget.
+    Mutating all four sites to pass `args.timeout` through kept the suite green,
+    and a `None` reaches `urllib` as NO timeout: the unbounded wait `_run`
+    already refuses on the other side of this same file.
+
+    Asserts the RELATIONSHIP (every `timeout=` argument in the store paths goes
+    through the resolver) rather than a count, so a fifth caller fails here.
+    """
+    import ast
+
+    src = (REPO_ROOT / "scripts" / "cairn").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    # The hazard is precisely `args.timeout` — the namespace attribute that may
+    # hold the sentinel. A local `timeout=timeout` inside a helper is forwarding
+    # an ALREADY-resolved value and is not a bypass; flagging it too made this
+    # guard fire on two innocent sites, which is how a guard gets loosened until
+    # it means nothing.
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg != "timeout":
+                continue
+            v = kw.value
+            if (isinstance(v, ast.Attribute) and v.attr == "timeout"
+                    and isinstance(v.value, ast.Name) and v.value.id == "args"):
+                offenders.append(ast.unparse(kw))
+    assert not offenders, (
+        "a `timeout=` argument passes `args.timeout` raw, so it may carry the "
+        f"None sentinel to the network — resolve it first: {offenders}")
+
+    # CONTROL: the guard must be able to FIRE. Without this, narrowing it to
+    # `args.timeout` could have narrowed it to nothing.
+    bad = ast.parse("f(timeout=args.timeout)")
+    hits = [ast.unparse(kw) for n in ast.walk(bad) if isinstance(n, ast.Call)
+            for kw in n.keywords
+            if kw.arg == "timeout" and isinstance(kw.value, ast.Attribute)
+            and kw.value.attr == "timeout"
+            and isinstance(kw.value.value, ast.Name) and kw.value.value.id == "args"]
+    assert hits == ["timeout=args.timeout"], "the detector cannot see a real bypass"
+
+
+def test_the_store_resolver_turns_the_sentinel_into_a_POSITIVE_bound():
+    cli = _load_cairn_cli()
+    args = cli.build_parser().parse_args(["recall"])
+    assert args.timeout is None
+    assert cli._store_timeout(args) == cli.DEFAULT_TIMEOUT > 0
+    explicit = cli.build_parser().parse_args(["--timeout", "9", "recall"])
+    assert cli._store_timeout(explicit) == 9

--- a/scripts/tests/test_cairn_who.py
+++ b/scripts/tests/test_cairn_who.py
@@ -926,51 +926,108 @@ def test_the_store_commands_still_get_the_STORE_default_when_no_flag_is_given():
     assert cli._who_timeout(who, W.DEFAULT_TIMEOUT) == W.DEFAULT_TIMEOUT
 
 
-def test_every_store_call_site_resolves_the_timeout_sentinel():
-    """🔴 SEAM GUARD: no call site may pass the raw sentinel to the network.
+def _passes_args_timeout_raw(kw) -> bool:
+    """The detector, as ONE function used by both the scan and its control.
 
-    Making the top-level `--timeout` default `None` — so `who` can tell "not
-    given" from an explicit value — gave every store command a chance to forget.
-    Mutating all four sites to pass `args.timeout` through kept the suite green,
-    and a `None` reaches `urllib` as NO timeout: the unbounded wait `_run`
-    already refuses on the other side of this same file.
-
-    Asserts the RELATIONSHIP (every `timeout=` argument in the store paths goes
-    through the resolver) rather than a count, so a fifth caller fails here.
+    🔴 THE FIRST CONTROL WAS A TAUTOLOGY AND A DEMONSTRATED BYPASS PROVED IT.
+    It re-implemented this predicate as separate literal code, so it verified a
+    COPY of the detector rather than the detector. Measured: blinding the real
+    predicate (`v.value.id != "args"`) AND restoring a genuine bypass in
+    `cmd_sync` at the same time left all 63 tests green — the control could not
+    fail in exactly the scenario its own comment named. A control built out of
+    the thing it is controlling is a second sample of the same unknown.
     """
     import ast
 
-    src = (REPO_ROOT / "scripts" / "cairn").read_text(encoding="utf-8")
-    tree = ast.parse(src)
-    # The hazard is precisely `args.timeout` — the namespace attribute that may
-    # hold the sentinel. A local `timeout=timeout` inside a helper is forwarding
-    # an ALREADY-resolved value and is not a bypass; flagging it too made this
-    # guard fire on two innocent sites, which is how a guard gets loosened until
-    # it means nothing.
-    offenders = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        for kw in node.keywords:
-            if kw.arg != "timeout":
-                continue
-            v = kw.value
-            if (isinstance(v, ast.Attribute) and v.attr == "timeout"
-                    and isinstance(v.value, ast.Name) and v.value.id == "args"):
-                offenders.append(ast.unparse(kw))
+    if kw.arg != "timeout":
+        return False
+    v = kw.value
+    return (isinstance(v, ast.Attribute) and v.attr == "timeout"
+            and isinstance(v.value, ast.Name) and v.value.id == "args")
+
+
+def test_the_raw_sentinel_detector_can_actually_FIRE():
+    """CONTROL, exercising the SAME function the scan below uses.
+
+    Narrowing a guard can narrow it to nothing, so the detector must be shown
+    to see a real bypass before its silence means anything.
+    """
+    import ast
+
+    bad = ast.parse("cmd(timeout=args.timeout)")
+    hits = [kw for n in ast.walk(bad) if isinstance(n, ast.Call)
+            for kw in n.keywords if _passes_args_timeout_raw(kw)]
+    assert len(hits) == 1, "the detector cannot see a real bypass"
+
+    for safe in ("cmd(timeout=_store_timeout(args))", "cmd(timeout=timeout)",
+                 "cmd(cache=args.timeout)", "cmd(timeout=other.timeout)"):
+        tree = ast.parse(safe)
+        assert not [kw for n in ast.walk(tree) if isinstance(n, ast.Call)
+                    for kw in n.keywords if _passes_args_timeout_raw(kw)], (
+            f"the detector fires on a safe form: {safe}")
+
+
+def test_no_call_site_passes_the_RAW_sentinel_attribute():
+    """SEAM GUARD, scoped to exactly what it can see.
+
+    🔴 ITS EARLIER DOCSTRING CLAIMED A RELATIONSHIP IT DOES NOT ENFORCE — "every
+    `timeout=` argument goes through the resolver". It rejects one AST shape:
+    the literal `args.timeout`. Measured survivors of that wider claim:
+    `timeout=getattr(args, "timeout")`, `timeout=args.timeout or None`, and
+    `timeout=None` — the last being the exact hazard the prose named. Those are
+    covered by the BEHAVIOURAL test below instead, which asserts what actually
+    reaches the network layer; this one catches the spelling a careless edit
+    produces, and says so rather than implying more.
+    """
+    import ast
+
+    tree = ast.parse((REPO_ROOT / "scripts" / "cairn").read_text(encoding="utf-8"))
+    offenders = [ast.unparse(kw) for n in ast.walk(tree) if isinstance(n, ast.Call)
+                 for kw in n.keywords if _passes_args_timeout_raw(kw)]
     assert not offenders, (
         "a `timeout=` argument passes `args.timeout` raw, so it may carry the "
         f"None sentinel to the network — resolve it first: {offenders}")
 
-    # CONTROL: the guard must be able to FIRE. Without this, narrowing it to
-    # `args.timeout` could have narrowed it to nothing.
-    bad = ast.parse("f(timeout=args.timeout)")
-    hits = [ast.unparse(kw) for n in ast.walk(bad) if isinstance(n, ast.Call)
-            for kw in n.keywords
-            if kw.arg == "timeout" and isinstance(kw.value, ast.Attribute)
-            and kw.value.attr == "timeout"
-            and isinstance(kw.value.value, ast.Name) and kw.value.value.id == "args"]
-    assert hits == ["timeout=args.timeout"], "the detector cannot see a real bypass"
+
+@pytest.mark.parametrize("argv", [
+    ["sync"], ["recall"], ["search", "q"], ["validate"], ["ls-entries"],
+])
+def test_every_STORE_subcommand_reaches_the_network_with_a_POSITIVE_bound(
+        argv, monkeypatch, tmp_path):
+    """🔴 THE BEHAVIOURAL HALF, and the one that covers spellings AST cannot.
+
+    `timeout=None`, `getattr(args, "timeout")` and `args.timeout or None` all
+    slip past a syntactic guard while carrying the sentinel to `urllib`, where
+    a `None` means NO timeout — the unbounded wait `_run` refuses on the other
+    side of this file. Asserting on what the network layer actually receives is
+    indifferent to how the argument was spelled.
+    """
+    cli = _load_cairn_cli()
+    seen = {}
+
+    def fake_resolve_state(cache, *, no_sync, scope, timeout, **kw):
+        seen["timeout"] = timeout
+        raise SystemExit(0)
+
+    monkeypatch.setattr(cli, "resolve_state", fake_resolve_state, raising=False)
+    monkeypatch.setattr(cli, "DEFAULT_CACHE", tmp_path / "cache", raising=False)
+    # `--cache` is a TOP-LEVEL flag, so it goes BEFORE the subcommand — the
+    # same namespace-position distinction this round's precedence fix is about.
+    args = cli.build_parser().parse_args(["--cache", str(tmp_path / "c")] + argv)
+    try:
+        args.func(args)
+    except SystemExit:
+        pass
+    except Exception:
+        pass
+    # 🔴 NOT a skip. A subcommand that stops reaching `resolve_state` has lost
+    # this coverage, and a skip would report that as a pass — the vacuous green
+    # this whole file is written against. Measured: all five reach it today.
+    assert "timeout" in seen, (
+        f"{argv[0]} never reached resolve_state, so nothing was checked")
+    assert isinstance(seen["timeout"], int) and seen["timeout"] > 0, (
+        f"{argv[0]} reached the network with timeout={seen['timeout']!r} — a "
+        "non-positive or None bound is an UNBOUNDED wait")
 
 
 def test_the_store_resolver_turns_the_sentinel_into_a_POSITIVE_bound():

--- a/scripts/tests/test_cairn_who.py
+++ b/scripts/tests/test_cairn_who.py
@@ -773,7 +773,7 @@ def test_EXIT_EMPTY_with_EMPTY_stdout_is_still_a_measured_zero():
         f"wrong — not be reported as a bad exit code: {exc.value}")
 
 
-@pytest.mark.parametrize("bad", [None, 0, -1, "60"])
+@pytest.mark.parametrize("bad", [None, 0, -1, "60", True])
 def test_a_MISSING_or_NONPOSITIVE_timeout_is_refused_not_treated_as_a_default(bad):
     """🔴 `timeout=None` means NO TIMEOUT — measured: an unbounded wait.
 
@@ -784,7 +784,13 @@ def test_a_MISSING_or_NONPOSITIVE_timeout_is_refused_not_treated_as_a_default(ba
     """
     with pytest.raises(W.WhoError) as exc:
         W._run(["true"], bad)
-    assert "UNBOUNDED" in str(exc.value)
+    # 🔴 Assert the REFUSAL, and that the reason names the actual problem —
+    # not one fixed word. `True` is not an UNBOUNDED wait, it is a silently
+    # WRONG one (1 second), and demanding that word made the guard's own
+    # message have to lie to satisfy the test.
+    assert "refusing to run" in str(exc.value)
+    assert repr(bad) in str(exc.value), (
+        f"the reason does not name the offending value: {exc.value}")
 
 
 def test_the_stderr_collapse_happens_at_the_REAL_boundary():
@@ -1065,7 +1071,8 @@ def test_the_STORE_fetch_refuses_an_unbounded_bound_like_the_who_side_does(bad):
     cli = _load_cairn_cli()
     with pytest.raises(cli.StoreUnreachable) as exc:
         cli.fetch_snapshot("http://127.0.0.1:1", "tok", scope=None, timeout=bad)
-    assert "UNBOUNDED" in str(exc.value)
+    assert "refusing to fetch" in str(exc.value)
+    assert repr(bad) in str(exc.value)
 
 
 def test_the_store_fetch_ACCEPTS_a_positive_bound():
@@ -1075,8 +1082,8 @@ def test_the_store_fetch_ACCEPTS_a_positive_bound():
     with pytest.raises(cli.StoreUnreachable) as exc:
         # port 1 is closed: this must fail on the CONNECTION, not the bound.
         cli.fetch_snapshot("http://127.0.0.1:1", "tok", scope=None, timeout=1)
-    assert "UNBOUNDED" not in str(exc.value), (
-        f"a valid bound was refused as unbounded: {exc.value}")
+    assert "refusing to fetch" not in str(exc.value), (
+        f"a valid bound was refused: {exc.value}")
 
 
 def test_the_POSITIVE_bound_actually_reaches_urlopen(monkeypatch):
@@ -1120,3 +1127,63 @@ def test_the_POSITIVE_bound_actually_reaches_urlopen(monkeypatch):
     assert seen["timeout"] == 11, (
         f"urlopen received timeout={seen['timeout']!r}, not the bound it was "
         "given — the validated parameter is not what goes to the network")
+
+
+#: Every value that must be refused as a timeout, by BOTH halves of this CLI.
+UNBOUNDED_TIMEOUTS = [None, 0, -1, "60", True, False, 1.5, [], object()]
+
+
+@pytest.mark.parametrize("bad", UNBOUNDED_TIMEOUTS)
+def test_BOTH_entry_points_refuse_the_SAME_unusable_timeouts(bad):
+    """🔴 TWO-WAY PIN. The rule was open-coded twice and the copies DISAGREED.
+
+    Only `fetch_snapshot` excluded `bool`, while a comment claimed it refused
+    "the way `cairn_who._run` always has". Measured before this fix:
+    `_run(["sleep","3"], True)` ran with a ONE-SECOND bound and reported
+    `did not answer within Trues` — verbatim the "nobody notices" failure
+    `_run`'s own docstring describes.
+
+    Asserting the two AGREE, rather than asserting each separately, is what
+    makes a future divergence fail here instead of shipping. Consolidation was
+    the bug-finding instrument: the disagreement was only audible once the two
+    predicates were put side by side.
+    """
+    cli = _load_cairn_cli()
+    with pytest.raises(W.WhoError) as who_exc:
+        W._run(["true"], bad)
+    with pytest.raises(cli.StoreUnreachable) as store_exc:
+        cli.fetch_snapshot("http://127.0.0.1:1", "tok", scope=None, timeout=bad)
+    assert "refusing to run" in str(who_exc.value)
+    assert "refusing to fetch" in str(store_exc.value)
+
+
+def test_both_entry_points_ACCEPT_the_same_positive_bound():
+    """CONTROL. Two guards that refuse EVERYTHING also agree perfectly."""
+    cli = _load_cairn_cli()
+    rc, _, _ = W._run(["true"], 5)
+    assert rc == 0
+    with pytest.raises(cli.StoreUnreachable) as exc:
+        cli.fetch_snapshot("http://127.0.0.1:1", "tok", scope=None, timeout=5)
+    assert "refusing to fetch" not in str(exc.value), (
+        f"a valid bound was refused: {exc.value}")
+
+
+def test_the_timeout_predicate_has_exactly_ONE_implementation():
+    """🔴 One rule, one place — asserted structurally, not by convention.
+
+    A second `isinstance(timeout, int)` anywhere in this CLI is the copy that
+    drifts. Searching the tree is how the disagreement was found; this is how
+    it stays found.
+    """
+    import re
+
+    for path in (REPO_ROOT / "scripts" / "cairn",
+                 REPO_ROOT / "scripts" / "lib" / "cairn_who.py"):
+        src = path.read_text(encoding="utf-8")
+        # the predicate's own body is the one legitimate site
+        body = src.count("def unbounded_timeout_reason")
+        opencoded = len(re.findall(r"isinstance\(\s*timeout\s*,\s*int\s*\)", src))
+        assert opencoded <= body, (
+            f"{path.name} open-codes the timeout predicate "
+            f"({opencoded} site(s), {body} definition(s)) — import "
+            "`unbounded_timeout_reason` instead so the copies cannot drift")

--- a/scripts/tests/test_cairn_who.py
+++ b/scripts/tests/test_cairn_who.py
@@ -975,9 +975,10 @@ def test_no_call_site_passes_the_RAW_sentinel_attribute():
     the literal `args.timeout`. Measured survivors of that wider claim:
     `timeout=getattr(args, "timeout")`, `timeout=args.timeout or None`, and
     `timeout=None` — the last being the exact hazard the prose named. Those are
-    covered by the BEHAVIOURAL test below instead, which asserts what actually
-    reaches the network layer; this one catches the spelling a careless edit
-    produces, and says so rather than implying more.
+    covered by the BEHAVIOURAL test below, which asserts the value handed to
+    `resolve_state`, and beyond it by `fetch_snapshot`'s own refusal of a
+    non-positive bound. This one catches the spelling a careless edit produces,
+    and says so rather than implying more.
     """
     import ast
 
@@ -997,10 +998,18 @@ def test_every_STORE_subcommand_reaches_the_network_with_a_POSITIVE_bound(
     """🔴 THE BEHAVIOURAL HALF, and the one that covers spellings AST cannot.
 
     `timeout=None`, `getattr(args, "timeout")` and `args.timeout or None` all
-    slip past a syntactic guard while carrying the sentinel to `urllib`, where
-    a `None` means NO timeout — the unbounded wait `_run` refuses on the other
-    side of this file. Asserting on what the network layer actually receives is
-    indifferent to how the argument was spelled.
+    slip past a syntactic guard while carrying the sentinel onward. Asserting on
+    the value handed to `resolve_state` is indifferent to how the argument was
+    spelled, which an AST scan is not.
+
+    🔴 THE BOUNDARY THIS ASSERTS IS `resolve_state`, NOT `urllib`, AND THE
+    EARLIER WORDING CLAIMED THE LATTER. Two frames still sit between them
+    (`fetch_snapshot`, then `urlopen`), and mutating either one's `timeout=` to
+    `None` survived this test — a docstring promising coverage it did not have,
+    which is the defect the previous round existed to fix. Those frames are now
+    closed in SOURCE instead: `fetch_snapshot` refuses a non-positive bound the
+    way `cairn_who._run` always has, so the path fails closed rather than
+    depending on this test reaching far enough.
     """
     cli = _load_cairn_cli()
     seen = {}
@@ -1037,3 +1046,77 @@ def test_the_store_resolver_turns_the_sentinel_into_a_POSITIVE_bound():
     assert cli._store_timeout(args) == cli.DEFAULT_TIMEOUT > 0
     explicit = cli.build_parser().parse_args(["--timeout", "9", "recall"])
     assert cli._store_timeout(explicit) == 9
+
+
+@pytest.mark.parametrize("bad", [None, 0, -1, "60", True])
+def test_the_STORE_fetch_refuses_an_unbounded_bound_like_the_who_side_does(bad):
+    """🔴 CLOSES THE ASYMMETRY: half of one program was failing closed.
+
+    `cairn_who._run` has always refused a `None` timeout, because `urlopen` and
+    `subprocess` both read it as NO timeout rather than as a default. The store
+    half did not — `fetch_snapshot(timeout: int)` is an annotation, and an
+    annotation is not a code path. Mutating either `fetch_snapshot`'s or
+    `urlopen`'s `timeout=` to `None` survived the entire suite, inside a PR
+    whose own docstrings claimed that value was covered.
+
+    `True` is in the list deliberately: `bool` subclasses `int`, so a plain
+    `isinstance(x, int)` accepts it and would silently run with a 1-second bound.
+    """
+    cli = _load_cairn_cli()
+    with pytest.raises(cli.StoreUnreachable) as exc:
+        cli.fetch_snapshot("http://127.0.0.1:1", "tok", scope=None, timeout=bad)
+    assert "UNBOUNDED" in str(exc.value)
+
+
+def test_the_store_fetch_ACCEPTS_a_positive_bound():
+    """CONTROL. Without it the guard above passes on a function that refuses
+    every input, which is the other way to be useless."""
+    cli = _load_cairn_cli()
+    with pytest.raises(cli.StoreUnreachable) as exc:
+        # port 1 is closed: this must fail on the CONNECTION, not the bound.
+        cli.fetch_snapshot("http://127.0.0.1:1", "tok", scope=None, timeout=1)
+    assert "UNBOUNDED" not in str(exc.value), (
+        f"a valid bound was refused as unbounded: {exc.value}")
+
+
+def test_the_POSITIVE_bound_actually_reaches_urlopen(monkeypatch):
+    """🔴 THE NETWORK BOUNDARY ITSELF — the claim two docstrings kept making.
+
+    Validating `fetch_snapshot`'s PARAMETER does not pin what its body hands to
+    `urlopen`: mutating `urlopen(req, timeout=timeout)` to `timeout=None`
+    survived every guard above it, because the argument check had already
+    passed. That is the "mutate the narrowest expression" case — the guard and
+    the hazard were one line apart and never met.
+
+    Observing the kwarg `urlopen` receives is the only assertion that spans
+    them, and it is what finally makes "a positive bound reaches the network"
+    a measured statement rather than a hopeful one.
+    """
+    cli = _load_cairn_cli()
+    seen = {}
+
+    class _Resp:
+        headers = {}
+
+        def read(self):
+            return b""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(req, timeout=None, **kw):
+        seen["timeout"] = timeout
+        return _Resp()
+
+    monkeypatch.setattr(cli.urllib.request, "urlopen", fake_urlopen)
+    try:
+        cli.fetch_snapshot("http://127.0.0.1:1", "tok", scope=None, timeout=11)
+    except Exception:
+        pass  # the empty body may fail later; the kwarg is already recorded
+    assert "timeout" in seen, "urlopen was never reached — nothing was checked"
+    assert seen["timeout"] == 11, (
+        f"urlopen received timeout={seen['timeout']!r}, not the bound it was "
+        "given — the validated parameter is not what goes to the network")

--- a/scripts/tests/test_cairn_who.py
+++ b/scripts/tests/test_cairn_who.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+"""Gate on `cairn who` — the task -> session -> window -> transcript join.
+
+WHAT THIS FILE IS DEFENDING. Every hop resolved before the command existed; the
+defect class is not "a hop breaks" but "two different answers get printed the
+same way". Four pairs are indistinguishable at a glance and each is pinned here:
+
+  * a window that is GONE      vs a tmux scan that never RAN;
+  * a task that does NOT EXIST vs a clawgate we could not ASK;
+  * a task with NO SESSIONS    vs sessions none of which could be LOCATED;
+  * a session id that is a uuid vs one that is not.
+
+🔴 THESE ARE REGRESSION GUARDS FOR A MEASURED REALITY, NOT INVARIANTS. The
+motivating observation: on 2026-08-27 the task this command was built for had
+three sessions, TWO of which had no live window and both of which had a 6 MB
+transcript sitting on disk. A resolver keyed on tmux alone answers "nobody" for
+that task. The fixture below is that shape.
+
+Every identifier here is INVENTED. Real session ids, paths and task titles are
+read at run time and appear in no fixture — the `CLAUDE.md` PUBLIC-repo rule.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB = REPO_ROOT / "scripts" / "lib"
+if str(LIB) not in sys.path:
+    sys.path.insert(0, str(LIB))
+
+import cairn_who as W  # noqa: E402
+
+# Invented, and deliberately shaped like the real thing.
+FAKE_UUID = "11111111-2222-4333-8444-555555555555"
+FAKE_UUID_2 = "66666666-7777-4888-8999-000000000000"
+#: 🔴 NOT a uuid. Measured on a live scan: 2 of 41 windows carried a token of
+#: this shape in `claude_session_id`. A join that assumes uuid matches nothing
+#: and reports a clean "no live window".
+FAKE_OPAQUE_ID = "ses_aBcDeF1234567890xyz"
+
+
+def _task(sessions, **kw):
+    obj = {"title": "a synthetic task", "status": "open", "sessions": sessions}
+    obj.update(kw)
+    return obj
+
+
+def _session_row(sid, **kw):
+    row = {"sessionId": sid, "role": "worked", "project": "proj-one",
+           "cwd": "/tmp/proj-one", "host": "node-a",
+           "lastSeenAt": "2000-01-01T00:00:00Z"}
+    row.update(kw)
+    return row
+
+
+def _window(sid, **kw):
+    w = {"claude_session_id": sid, "host": "workbench", "session": "scratch9",
+         "window_index": "3", "window_id": "@903", "pane_id": "%903",
+         "codename": "Onyx", "hotkey": "Alt+o", "path": "/tmp/proj-one"}
+    w.update(kw)
+    return w
+
+
+def _scan(windows, host="workbench"):
+    return {"hosts": {host: {"windows": list(windows)}}}
+
+
+def _resolve(task_obj, windows=None, transcripts=None, window_exc=None, **kw):
+    """Drive `resolve` with every hop injected — no network, no tmux, no disk."""
+    def fetch(task, timeout=0):
+        return task_obj
+
+    def wins(timeout=0, host=None):
+        if window_exc:
+            raise window_exc
+        return W._index_windows(_scan(windows or []))
+
+    def find(sid, root=None):
+        got = (transcripts or {}).get(sid)
+        return Path(got) if got else None
+
+    return W.resolve("42", task_fetcher=fetch, window_fetcher=wins,
+                     transcript_finder=find, **kw)
+
+
+# --------------------------------------------------------------------------- #
+# The two halves are INDEPENDENT
+# --------------------------------------------------------------------------- #
+
+
+def test_a_session_with_NO_window_but_a_transcript_is_still_LOCATED():
+    """🔴 THE MOTIVATING CASE. A tmux window is transient; a transcript is not.
+
+    Measured on the real task this command was built for: 2 of its 3 sessions
+    had no live window and both had a multi-megabyte transcript on disk. A
+    resolver that treats "no window" as "not found" answers "nobody" for almost
+    every task older than the current uptime.
+    """
+    r = _resolve(_task([_session_row(FAKE_UUID)]),
+                 windows=[], transcripts={FAKE_UUID: "/tmp/t/a.jsonl"})
+    s = r.sessions[0]
+    assert s.window is None
+    assert s.transcript == Path("/tmp/t/a.jsonl")
+    assert s.located, "a durable transcript did not count as located"
+    assert r.state == W.WHO_RESOLVED
+    assert r.exit_code == W.EXIT_OK
+
+
+def test_a_session_with_a_window_but_NO_transcript_is_still_LOCATED():
+    """The mirror image — a brand-new session whose transcript has not landed."""
+    r = _resolve(_task([_session_row(FAKE_UUID)]),
+                 windows=[_window(FAKE_UUID)], transcripts={})
+    s = r.sessions[0]
+    assert s.window is not None and s.transcript is None
+    assert s.located
+    assert r.state == W.WHO_RESOLVED
+
+
+def test_sessions_recorded_but_NEITHER_half_resolves_is_its_own_state():
+    """Not `no-sessions`, and not success. A real gap, reported as one."""
+    r = _resolve(_task([_session_row(FAKE_UUID)]), windows=[], transcripts={})
+    assert r.state == W.WHO_UNLOCATED
+    assert r.exit_code == W.EXIT_UNLOCATED
+    assert r.exit_code != W.EXIT_OK
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 UNMEASURED is not "none"
+# --------------------------------------------------------------------------- #
+
+
+def test_a_FAILED_tmux_scan_is_UNMEASURED_and_never_reads_as_no_window():
+    """🔴 THE SILENT-ZERO GUARD, and the reason `windows_measured` exists.
+
+    The laptop asleep, off the nebula, or slow makes the scan fail. Rendering
+    that as an empty window column asserts "this session is running nowhere",
+    which is a claim nothing measured. The durable half must still be reported,
+    because it is independent of tmux being reachable.
+    """
+    r = _resolve(_task([_session_row(FAKE_UUID)]),
+                 transcripts={FAKE_UUID: "/tmp/t/a.jsonl"},
+                 window_exc=W.WhoError("session-manager did not answer within 60s"))
+    s = r.sessions[0]
+    assert s.windows_measured is False
+    assert r.windows_reason and "did not answer" in r.windows_reason
+
+    out = W.render(r)
+    assert "UNMEASURED" in out
+    assert "none live" not in out, (
+        "an unmeasured scan rendered as a positive 'no window' claim:\n" + out)
+    # the durable half survived the transient half's failure
+    assert "/tmp/t/a.jsonl" in out
+    assert r.state == W.WHO_RESOLVED
+
+
+def test_no_windows_flag_reports_UNMEASURED_rather_than_pretending_it_looked():
+    """Opting out of the scan must not manufacture a negative finding."""
+    r = _resolve(_task([_session_row(FAKE_UUID)]),
+                 transcripts={FAKE_UUID: "/tmp/t/a.jsonl"}, skip_windows=True)
+    assert r.sessions[0].windows_measured is False
+    assert "UNMEASURED" in W.render(r)
+    assert "none live" not in W.render(r)
+
+
+def test_a_MEASURED_scan_with_no_match_DOES_claim_none_live():
+    """CONTROL for the two above. Without this they would pass on a resolver
+    that never claims anything, which is the other way to be useless."""
+    r = _resolve(_task([_session_row(FAKE_UUID)]),
+                 windows=[_window(FAKE_UUID_2)],
+                 transcripts={FAKE_UUID: "/tmp/t/a.jsonl"})
+    assert r.sessions[0].windows_measured is True
+    out = W.render(r)
+    assert "none live" in out
+    assert "UNMEASURED" not in out
+
+
+# --------------------------------------------------------------------------- #
+# "No answer" is not "the answer is no"
+# --------------------------------------------------------------------------- #
+
+
+def test_task_not_found_and_clawgate_unreachable_are_DIFFERENT_states_and_codes():
+    """🔴 Both print an empty result; one of them is a lie.
+
+    `clawgatectl` documents 4 = not found and 3/6 = auth/network, so the code is
+    read rather than the message text — a reworded diagnostic must not silently
+    turn "unreachable" into "no such task".
+    """
+    def missing(task, timeout=0):
+        raise W.WhoError("clawgate has no task 42")
+
+    def down(task, timeout=0):
+        raise W.WhoError("clawgatectl exited 6 — dial tcp: i/o timeout")
+
+    a = W.resolve("42", task_fetcher=missing)
+    b = W.resolve("42", task_fetcher=down)
+    assert a.state == W.WHO_NO_TASK and a.exit_code == W.EXIT_NO_TASK
+    assert b.state == W.WHO_NO_CLAWGATE and b.exit_code == W.EXIT_NO_CLAWGATE
+    assert a.state != b.state and a.exit_code != b.exit_code
+    assert "NOT 'the task has no sessions'" in W.render(b)
+
+
+def test_a_task_with_no_sessions_is_a_REAL_state_not_a_failure():
+    """A task filed in the web UI has none. Exit 0, and said in words."""
+    r = _resolve(_task([]))
+    assert r.state == W.WHO_NO_SESSIONS
+    assert r.exit_code == W.EXIT_OK
+    out = W.render(r)
+    assert "no session is recorded" in out
+    assert "not a lookup failure" in out
+
+
+def test_every_state_has_an_exit_code_and_the_success_ones_are_distinct():
+    """LEDGER. A state added without a code would silently map to 0."""
+    states = {W.WHO_RESOLVED, W.WHO_NO_SESSIONS, W.WHO_UNLOCATED,
+              W.WHO_NO_TASK, W.WHO_NO_CLAWGATE}
+    codes = {s: W.WhoReport(task="t", state=s).exit_code for s in states}
+    assert codes[W.WHO_RESOLVED] == 0 and codes[W.WHO_NO_SESSIONS] == 0
+    failing = {s: c for s, c in codes.items() if c != 0}
+    assert len(set(failing.values())) == len(failing), (
+        f"two failure states share an exit code: {failing}")
+
+
+# --------------------------------------------------------------------------- #
+# The join key
+# --------------------------------------------------------------------------- #
+
+
+def test_a_NON_UUID_session_id_still_joins():
+    """🔴 REGRESSION GUARD. 2 of 41 live windows carried a `ses_…` token.
+
+    A join that validates or normalises uuid shape matches nothing for those and
+    reports a clean "no live window" — the failure that looks like a fact.
+    """
+    r = _resolve(_task([_session_row(FAKE_OPAQUE_ID)]),
+                 windows=[_window(FAKE_OPAQUE_ID)])
+    assert r.sessions[0].window is not None, "a non-uuid session id did not join"
+    assert r.sessions[0].window.address == "scratch9:3"
+
+
+def test_the_join_is_CASE_SENSITIVE_on_both_sides():
+    """Ids are opaque tokens, not identifiers to be folded.
+
+    Lowercasing one side only is the classic half-normalised join; folding both
+    would make two genuinely different ids collide.
+    """
+    r = _resolve(_task([_session_row(FAKE_OPAQUE_ID.upper())]),
+                 windows=[_window(FAKE_OPAQUE_ID)])
+    assert r.sessions[0].window is None, "ids were matched case-insensitively"
+
+
+def test_a_session_row_with_a_BLANK_id_is_dropped_not_carried():
+    """A blank id matches every blank window id — that is an invented result."""
+    r = _resolve(_task([_session_row(""), _session_row("   "),
+                        _session_row(FAKE_UUID)]),
+                 windows=[_window(FAKE_UUID)])
+    assert [s.session_id for s in r.sessions] == [FAKE_UUID]
+
+
+def test_a_window_with_no_session_id_never_enters_the_index():
+    idx = W._index_windows(_scan([
+        _window(None), _window(""), _window(FAKE_UUID)]))
+    assert set(idx) == {FAKE_UUID}
+
+
+def test_two_windows_sharing_a_session_id_resolve_DETERMINISTICALLY():
+    """A split pane or a re-attach can produce two rows for one session.
+
+    Last-writer-wins makes the answer depend on host iteration order, which is a
+    dict order rather than a fact. First wins, and it is pinned so the choice is
+    visible rather than incidental.
+    """
+    first = _window(FAKE_UUID, session="scratch1", window_index="1")
+    second = _window(FAKE_UUID, session="scratch2", window_index="2")
+    for _ in range(5):
+        idx = W._index_windows(_scan([first, second]))
+        assert idx[FAKE_UUID].address == "scratch1:1"
+
+
+def test_windows_are_indexed_across_ALL_hosts_not_just_the_first():
+    payload = {"hosts": {
+        "workbench": {"windows": [_window(FAKE_UUID)]},
+        "laptop": {"windows": [_window(FAKE_UUID_2, host="laptop")]},
+    }}
+    idx = W._index_windows(payload)
+    assert set(idx) == {FAKE_UUID, FAKE_UUID_2}
+    assert idx[FAKE_UUID_2].host == "laptop"
+
+
+def test_a_host_block_with_no_windows_key_does_not_crash_the_index():
+    """A host that failed to scan reports no `windows`; that is a state."""
+    payload = {"hosts": {"laptop": {"reachable": False},
+                         "workbench": {"windows": [_window(FAKE_UUID)]}}}
+    assert set(W._index_windows(payload)) == {FAKE_UUID}
+
+
+# --------------------------------------------------------------------------- #
+# Rendering — an absence must be spelled
+# --------------------------------------------------------------------------- #
+
+
+def test_render_never_leaves_a_finding_BLANK():
+    """Both halves absent, and both said out loud rather than omitted."""
+    r = _resolve(_task([_session_row(FAKE_UUID)]), windows=[], transcripts={})
+    out = W.render(r)
+    assert "none live" in out
+    assert "not found" in out
+    for line in out.splitlines():
+        assert not line.rstrip().endswith(("window", "transcript")), \
+            f"a label was printed with no value: {line!r}"
+
+
+def test_render_carries_BOTH_the_window_index_and_the_stable_ids():
+    """The index is what a human types; the id survives renumbering."""
+    r = _resolve(_task([_session_row(FAKE_UUID)]), windows=[_window(FAKE_UUID)])
+    out = W.render(r)
+    assert "scratch9:3" in out
+    assert "@903" in out and "%903" in out
+    assert "Onyx" in out and "Alt+o" in out
+
+
+def test_the_json_surface_round_trips_and_marks_the_unmeasured_half():
+    r = _resolve(_task([_session_row(FAKE_UUID)]),
+                 transcripts={FAKE_UUID: "/tmp/t/a.jsonl"},
+                 window_exc=W.WhoError("laptop unreachable"))
+    d = json.loads(json.dumps(r.to_dict()))
+    assert d["sessions"][0]["windows_measured"] is False
+    assert d["sessions"][0]["window"] is None
+    assert d["windows_reason"] == "laptop unreachable"
+    assert d["sessions"][0]["transcript"] == "/tmp/t/a.jsonl"
+
+
+def test_a_transcript_lookup_failure_degrades_ONE_session_not_the_report():
+    """One unreadable project dir must not cost the other sessions' answers."""
+    def boom(sid, root=None):
+        if sid == FAKE_UUID:
+            raise OSError("permission denied")
+        return Path("/tmp/t/b.jsonl")
+
+    def fetch(task, timeout=0):
+        return _task([_session_row(FAKE_UUID), _session_row(FAKE_UUID_2)])
+
+    r = W.resolve("42", task_fetcher=fetch,
+                  window_fetcher=lambda timeout=0, host=None: {},
+                  transcript_finder=boom)
+    assert r.sessions[0].transcript is None
+    assert r.sessions[1].transcript == Path("/tmp/t/b.jsonl")
+    assert any("permission denied" in n for n in r.notes)
+    assert r.state == W.WHO_RESOLVED
+
+
+# --------------------------------------------------------------------------- #
+# The external hops, without the externals
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("rc,expect", [
+    (4, "has no task"),
+    (3, "exited 3"),
+    (6, "exited 6"),
+    (7, "exited 7"),
+    (8, "exited 8"),
+])
+def test_fetch_task_reads_clawgatectl_EXIT_CODES_not_its_prose(rc, expect):
+    """The codes are documented; the message wording is not a contract."""
+    def runner(cmd, timeout):
+        return rc, "", "some diagnostic"
+
+    with pytest.raises(W.WhoError) as exc:
+        W.fetch_task("42", runner=runner)
+    assert expect in str(exc.value)
+
+
+def test_fetch_task_refuses_an_empty_id_before_shelling_out():
+    """An empty path parameter is the doubled-slash 301 class clawgatectl names."""
+    called = []
+
+    def runner(cmd, timeout):
+        called.append(cmd)
+        return 0, "{}", ""
+
+    for bad in ("", "   "):
+        with pytest.raises(W.WhoError):
+            W.fetch_task(bad, runner=runner)
+    assert not called, "an empty id reached the network"
+
+
+def test_fetch_task_rejects_non_json_rather_than_returning_a_blank():
+    """An Authelia portal page is a 200 with HTML — never a task with no sessions."""
+    def runner(cmd, timeout):
+        return 0, "<html>login</html>", ""
+
+    with pytest.raises(W.WhoError) as exc:
+        W.fetch_task("42", runner=runner)
+    assert "non-JSON" in str(exc.value)
+
+
+def test_live_windows_reports_a_nonzero_scan_with_no_output_as_an_ERROR():
+    """Not an empty index — that would render as 'no session is anywhere'."""
+    def runner(cmd, timeout):
+        return 1, "", "tmux: no server running"
+
+    with pytest.raises(W.WhoError) as exc:
+        W.live_windows(runner=runner, script=Path(__file__))
+    assert "no server running" in str(exc.value)
+
+
+def test_live_windows_does_NOT_pass_lean(tmp_path):
+    """🔴 `--lean` omits `pane_id`, `window_id` and `codename`.
+
+    Three of the four things this command prints. Pinned because `--lean` is the
+    faster flag and an obvious future 'optimisation'.
+    """
+    seen = {}
+
+    def runner(cmd, timeout):
+        seen["cmd"] = cmd
+        return 0, json.dumps(_scan([])), ""
+
+    W.live_windows(runner=runner, script=Path(__file__))
+    assert "--lean" not in seen["cmd"]
+    assert "--json" in seen["cmd"]
+
+
+def test_live_windows_forwards_a_host_filter_only_when_asked():
+    seen = []
+
+    def runner(cmd, timeout):
+        seen.append(cmd)
+        return 0, json.dumps(_scan([])), ""
+
+    W.live_windows(runner=runner, script=Path(__file__))
+    W.live_windows(runner=runner, script=Path(__file__), host="laptop")
+    assert "--host" not in seen[0]
+    assert seen[1][seen[1].index("--host") + 1] == "laptop"
+
+
+def _code_strings(path: Path) -> list[str]:
+    """Every string literal in EXECUTABLE code — docstrings excluded.
+
+    🔴 THIS HELPER EXISTS BECAUSE THE FIRST VERSIONS OF THE TWO GUARDS BELOW
+    WERE SPELLED, NOT STRUCTURAL. They grepped the raw source, so they fired on
+    the module's own PROSE — the docstring sentence explaining what `tmux
+    switch-client` accepts, and the comment saying never to merge the streams.
+    A guard that a comment can trip is a guard a reword can also silence, in
+    both directions. Parsing and dropping docstrings makes the claim structural:
+    it is about what the code DOES, not about which words appear in the file.
+    """
+    import ast
+
+    tree = ast.parse(path.read_text(encoding="utf-8"), str(path))
+    docstrings: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef,
+                             ast.FunctionDef, ast.AsyncFunctionDef)):
+            body = getattr(node, "body", None) or []
+            if (body and isinstance(body[0], ast.Expr)
+                    and isinstance(body[0].value, ast.Constant)
+                    and isinstance(body[0].value.value, str)):
+                docstrings.add(id(body[0].value))
+    return [n.value for n in ast.walk(tree)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str)
+            and id(n) not in docstrings]
+
+
+def test_the_helper_that_makes_these_guards_structural_actually_drops_docstrings(tmp_path):
+    """CONTROL. Without this, `_code_strings` returning [] passes both guards.
+
+    A helper that silently yields nothing turns two assertions into no
+    assertions, which is the exact shape it was written to remove.
+    """
+    f = tmp_path / "m.py"
+    f.write_text('"""a docstring saying switch-client."""\nX = "a code string"\n')
+    got = _code_strings(f)
+    assert got == ["a code string"], got
+
+
+def test_the_two_streams_are_captured_SEPARATELY():
+    """`clawgatectl` guarantees stdout is JSON and nothing else ever is.
+
+    Merging stderr in would throw that guarantee away at the one place that
+    relies on it, so the runner must never be asked to combine them.
+    """
+    import ast
+
+    src = (LIB / "cairn_who.py").read_text(encoding="utf-8")
+    assert "2>&1" not in " ".join(_code_strings(LIB / "cairn_who.py"))
+    # the structural half: no `stderr=` keyword anywhere in a call
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                assert kw.arg != "stderr", "a call redirects stderr"
+
+
+def test_who_never_raises_or_focuses_a_window():
+    """🔴 The operator's screen is not this command's to take (RULES.md).
+
+    `who` prints an address; moving there is the human's call. A future 'jump
+    to it' convenience belongs behind an explicit flag, not in a resolver.
+    """
+    code = " ".join(_code_strings(LIB / "cairn_who.py"))
+    for verb in ("switch-client", "select-window", "windowactivate",
+                 "i3-msg", "wmctrl", "attach-session"):
+        assert verb not in code, f"who reaches for {verb!r} — that is screen theft"


### PR DESCRIPTION
Rank 2 of the cairn handoff. Every hop already resolved; none of them joined. Answering *"who worked task N, and where do I read what they did"* took four tools and a hand-written jq join.

```
$ cairn who 360
task 360 — …  [ready_for_review]

  session 98843002-… (created) in homelab-talos
    window      none live — the session is not open in tmux now
    transcript  ~/.claude/projects/-home-…/98843002-….jsonl

  session 80c7556c-… (read) in devrc
    window      workbench scratch15:1  (iris, i)
                ids @314 %314
    transcript  ~/.claude/projects/-home-…/80c7556c-….jsonl
```

## The two answers have different lifetimes — that's the whole design

A tmux window is **transient**; a transcript is **durable**. Measured on the task this was built for: its window had already vanished while its 6 MB transcript sat exactly where it was written. A window-keyed resolver answers "nobody" for almost every task older than current uptime, and folding both into one line makes *"the window is gone"* indistinguishable from *"the work never happened"*. So each session yields **two independent findings**, always labelled, either of which may be absent.

## Three things the recorded chain description didn't carry

| measured | consequence |
|---|---|
| **The join key isn't always a uuid** — 39/41 live windows carried uuids, 2 carried `ses_…` tokens | a shape-validating join matches nothing for those and reports a clean "no live window" — a failure that reads as a fact |
| **`--lean` omits `pane_id`, `window_id`, `codename`** | three of the four things this prints; pinned, because `--lean` is the obvious future "optimisation" |
| **The handoff's worked example no longer resolves** | that's the point, not a problem — it's why the durable half exists |

## Five states that all print near-nothing

`resolved` · `no-sessions-recorded` (a UI-filed task genuinely has none — exit 0) · `sessions-recorded-but-none-located` · `task-not-found` (7) · `clawgate-unreachable` (8).

The last two are the pair that matters: **"the answer is no" and "there was no answer" print the same emptiness.** `clawgatectl`'s documented exit codes are read rather than its prose, so a reworded diagnostic can't turn unreachable into not-found.

🔴 **An unmeasured live half is never rendered as "no window."** If the tmux scan fails — laptop asleep, off the nebula, slow — the report says `UNMEASURED` with the reason and still prints the transcripts, which don't depend on tmux being reachable. An empty window column would assert "this session runs nowhere", which is the silent zero this repo's measurement layer exists to stop.

## Reuse, not re-derivation

Uses `transcript_search.find_transcript` rather than re-implementing the `<cwd> → -home-zach-…` mangling — one rule, one place, and that module already survived a consolidation that found seven real bugs. It also resolves by *scan*, so it finds a transcript whose project dir doesn't match the recorded cwd.

Does **not** raise, focus or switch to a window. `who` prints the address; moving there is the operator's call.

## Tests

33, mutation-swept under `PYTHONDONTWRITEBYTECODE=1` with a pristine control. 7 mutants, each killed by the intended guard: UNMEASURED collapsed to "no window"; a transcript no longer counting as located; task-not-found folded into unreachable; last-writer-wins on a duplicate session id; a **real** `switch-client` call; a **real** stderr merge; and a vacuous `_code_strings`.

🔴 **Two of those guards were initially spelled, not structural** — they grepped raw source and fired on this module's own *docstrings* mentioning `tmux switch-client` and `2>&1`. A guard a comment can trip is one a reword can silence. They now parse the AST and scan executable code only, with a control test proving the helper doesn't simply return nothing (which would silence both at once).

## Verified

Live: exit **7** on an absent task, **0** resolved, **0** with `--no-windows`; `--json` round-trips and marks the unmeasured half. Full dev-host gate `GATE: RESULT=PASS` (pytest + node) at base `8e42c5e6`. Sandbox tier is Tekton's two required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)