### PR TITLE
rig-control: instant bar toggle + daily sleep/wake timers

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -337,17 +337,13 @@ let
       { button = "left"; cmd = "yad --calendar --width=200 --height=200 --undecorated --fixed --close-on-unfocus --no-buttons"; }
     ];
   };
-  # rigcontrol: workbench only. Reuses scripts/i3blocks-rigcontrol for the ⚙ render
-  # (plain-text stdout, json defaults false). The click opens the yad panel directly
-  # — i3status-rust custom blocks do NOT set $BLOCK_BUTTON, so the click must live
-  # here, not inside the render script.
+  # rigcontrol: workbench only. Instant toggle on left-click (sleep ↔ wake),
+  # no yad menu. The block script reads the state file and calls rig-control.sh
+  # sleep or wake directly; i3status-rust passes $BLOCK_BUTTON to the command.
   rigcontrolBlock = {
     block = "custom";
     command = "${scriptsDir}/i3blocks-rigcontrol";
     interval = "once";
-    click = [
-      { button = "left"; cmd = "setsid -f ${home}/workspace/devrc/scripts/rig-control.sh gui"; }
-    ];
   };
   # claude-runs: workbench only. LIVE count of Claude-Code-in-tmux runs — renders
   # `󰕮 N` (N>0) / bare `󰕮` (N==0) / `󰕮 ?` (could not measure), always neutral
@@ -665,6 +661,54 @@ lib.mkIf isNixOS {
     Timer = {
       OnStartupSec = "20s";
       OnUnitActiveSec = "45s";
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
+
+  # rig-control scheduled mode switches — workbench only.
+  # 3am → sleep (RGB off + monitor blackout), 10:15am → wake (RGB on + restore).
+  systemd.user.services.rig-control-sleep = lib.mkIf (!isLaptop) {
+    Unit = {
+      Description = "Auto sleep mode: chassis RGB off + monitor blackout";
+      After = [ "graphical-session.target" ];
+    };
+    Service = {
+      Type = "oneshot";
+      ExecStart = "${home}/workspace/devrc/scripts/rig-control.sh sleep";
+    };
+  };
+  systemd.user.timers.rig-control-sleep = lib.mkIf (!isLaptop) {
+    Unit = {
+      Description = "Daily 3am sleep mode";
+    };
+    Timer = {
+      OnCalendar = "03:00:00";
+      Persistent = true;
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
+
+  systemd.user.services.rig-control-wake = lib.mkIf (!isLaptop) {
+    Unit = {
+      Description = "Auto wake mode: chassis RGB on + monitor restore";
+      After = [ "graphical-session.target" ];
+    };
+    Service = {
+      Type = "oneshot";
+      ExecStart = "${home}/workspace/devrc/scripts/rig-control.sh wake";
+    };
+  };
+  systemd.user.timers.rig-control-wake = lib.mkIf (!isLaptop) {
+    Unit = {
+      Description = "Daily 10:15am wake mode";
+    };
+    Timer = {
+      OnCalendar = "10:15:00";
+      Persistent = true;
     };
     Install = {
       WantedBy = [ "timers.target" ];

--- a/scripts/i3blocks-rigcontrol
+++ b/scripts/i3blocks-rigcontrol
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
-# i3blocks launcher block for the rig-control yad panel.
+# i3blocks instant-toggle block for rig-control sleep/wake.
 #   interval=once  -> renders the icon at startup; i3blocks re-runs this on click
 #                     with $BLOCK_BUTTON set (1=left, 2=middle, 3=right).
-# Left-click opens the control panel, detached so it outlives this block run.
+# Left-click toggles between sleep and wake instantly (no yad menu).
 # Icon reflects sleep state: ☀ (awake) or 🌙 (sleeping).
 RIG="$HOME/workspace/devrc/scripts/rig-control.sh"
 STATE_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/rig-control/state"
 
+is_asleep() { [[ -f "$STATE_FILE" ]] && read -r _s < "$STATE_FILE" && [[ "$_s" == "sleeping" ]]; }
+
 case "${BLOCK_BUTTON:-}" in
-  1) setsid -f "$RIG" gui >/dev/null 2>&1 ;;   # left-click -> open panel
+  1) if is_asleep; then "$RIG" wake >/dev/null 2>&1
+     else "$RIG" sleep >/dev/null 2>&1
+     fi ;;
 esac
 
-if [[ -f "$STATE_FILE" ]] && read -r _s < "$STATE_FILE" && [[ "$_s" == "sleeping" ]]; then
-  echo "🌙"
-else
-  echo "☀"
-fi
+if is_asleep; then echo "🌙"; else echo "☀"; fi


### PR DESCRIPTION
## Changes
- **Bar button**: Left-click on ⚙ now instantly toggles sleep/wake (no more yad menu popup)
- **Auto-schedule**: Two systemd user timers (workbench only):
  - `rig-control-sleep`: fires `rig-control.sh sleep` daily at 3:00 AM
  - `rig-control-wake`: fires `rig-control.sh wake` daily at 10:15 AM
  - Both use `Persistent = true` so missed triggers fire on next boot

## Files changed
- `scripts/i3blocks-rigcontrol` — click handler calls sleep/wake directly instead of opening yad
- `nix/graphical.nix` — removed yad click from rigcontrolBlock, added 4 systemd user units