### PR TITLE
fix(audit-pr): the two worktree hazards the ladder deliberately left open, and the counts round 10 filed

### DIFF
--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -13,7 +13,9 @@ Case histories and the measurements behind the ladder rules:
 Target: `$ARGUMENTS`:
 - A number → that GitHub PR (`gh pr diff <n>`, `gh pr view <n>`).
 - `current` / empty → the current branch's diff vs its base/trunk.
-- Several numbers → audit each, one subagent per PR **with `isolation: "worktree"`** so they don't collide.
+- Several numbers → audit each, one subagent per PR so they don't collide. 🔴 `isolation:
+  "worktree"` worktrees the **cwd's** repo, not the PR's — for a PR in another repo have the
+  agent run `git -C <that-repo> worktree add …` itself.
 
 ## What to do
 
@@ -27,7 +29,9 @@ not a working checkout, and an auditor hitting this cold blames the PR. Whicheve
 **monorepo `node_modules`** may need linking per package, not just at the root; **whether the base
 branch is already red** and *at which file*; and that **zsh does not word-split unquoted
 parameters**, so `eslint $FILES` checks **zero** files and prints a confident PASS. Have it mutate
-only in a `cp -a` copy, and verify your worktree clean yourself at the end.
+only in a `cp -a` copy — **`rm -f <copy>/.git` first**, since a worktree's is a FILE pointing at the
+real git dir, so a commit in the copy lands on your branch — and verify your worktree clean
+yourself at the end.
 
 **Audit for:**
 1. **Risks** — what breaks in production.
@@ -43,8 +47,8 @@ only in a `cp -a` copy, and verify your worktree clean yourself at the end.
 ## After the fixes: RE-AUDIT THE DELTA (don't assume closure)
 
 **A fix round frequently introduces the next finding** — one feature took **five rounds**, each
-caused by the previous fix, none caught by the mechanical gate. Once they are fixed, dispatch a
-**delta re-audit** against the **previously-audited tip**, not the whole PR again.
+caused by the previous fix, none caught by the mechanical gate. Then dispatch a **delta re-audit**
+against the **previously-audited tip**, not the whole PR again.
 
 Ask the re-auditor to:
 - state **per prior finding**: actually fixed / partially / not / **made worse**;
@@ -58,7 +62,7 @@ Ask the re-auditor to:
 
 **Carry the ledger in every round's summary**: `round N · payload lines changed THIS round: X (since
 round 1: Y) · elapsed: Z`. X is what the gate below reads; without it the flattening shows only in
-hindsight — on #498 the plateau was diagnosed at round 9, six rounds late.
+hindsight — on #498 the plateau was diagnosed six rounds late.
 
 ### 🔴 A clean round ENDS the ladder. Never run another round to confirm a clean round.
 
@@ -68,12 +72,12 @@ not on the author saying it's done.
 
 🔴 **A "safe to merge" VERDICT is not the stop signal — the FINDINGS are.** #804's rounds **5, 6 and
 7 each returned "safe to merge" and each still reported real defects** that were then fixed — the
-last a latch that read as pinned and was vacuous in both directions. A ladder keyed to the verdict
-stops at round 5 and ships it.
+last a latch that read as pinned and was vacuous both ways. A verdict-keyed ladder stops at round 5
+and ships it.
 
 ⚠ **#804 is NOT an example of a wasted round, and neither is any other PR cited here.** Every one of
-its eight rounds produced findings that needed fixing. This is a forward rule with a demonstrated
-near-miss — do not cite it as a fix for measured waste.
+its eight rounds produced findings that needed fixing. A forward rule with a demonstrated
+near-miss — not a fix for measured waste.
 
 🔴 **This is NOT a round cap, and a cap was rejected.** The count is set by
 FINDINGS, never by a number, and #505 is why: its round 2 opens *"Round 1 fixed six findings and
@@ -85,25 +89,25 @@ both. Keep going while rounds keep finding things — `claude/RULES.md` still sa
 several — and stop the moment one does not.
 
 **When a round's fix is mostly renumbering your own prose, fix the FORM, not the number** — number
-the list and tell the reader to count it; a total kept beside what it counts drifts.
+the list and tell the reader to count it; a total kept beside what it counts will drift.
 
 **Say the stop rule to the re-auditor** ("a clean round is the stop condition; do not invent
 findings") — otherwise late rounds manufacture nits.
 
 🔴 **A FRAMED AUDIT VERIFIES THE FRAME. When a PR has already been audited, dispatch the next one
-BLIND** — the diff and the checklist, *not* your conclusions or the prior findings' answers. Three
-framed audits **confirmed** a claim; one blind audit refuted it in a pass. A delta re-audit must
-name the prior findings, so frame it as *what was claimed fixed* — never *why it is correct*.
+BLIND** — the diff and the checklist, *not* your conclusions or the prior findings' answers. Three framed
+audits **confirmed** a claim; one blind audit refuted it in a pass. A delta re-audit must name the
+prior findings — frame it as *what was claimed fixed*, never *why it is correct*.
 
 ### 🔴 ATTRIBUTION: a round that changes no PAYLOAD is auditing the LADDER, not the PR
 
 A fix round writes new guards and the next delta round diffs them, so **the ladder manufactures its
 own next round's findings** and the stop rule above, keyed to findings, cannot fire. Measured on
-`civitai/cli` #498: **ten rounds, 5 h 32 m, 77% of the session's output tokens; rounds 4–10 changed
-1,051 test lines and ZERO payload lines.** No round was clean.
+`civitai/cli` #498: **ten rounds, 5 h 32 m, 77% of the session's output; rounds 4–10 changed 1,051
+test lines and ZERO payload lines.** No round was clean.
 
-So gate on what each round CHANGES, not what it finds. After a round's fixes land, count the
-payload lines **that round** changed:
+Gate on what each round CHANGES, not what it finds. After a round's fixes land, count the payload
+lines **that round** changed:
 
 ```
 git log --numstat --format= --remerge-diff <the sha you audited THAT round>..HEAD --not <base>
@@ -113,9 +117,8 @@ git log --numstat --format= --remerge-diff <the sha you audited THAT round>..HEA
 scaffolding = the tests, fixtures and notes a round wrote to guard it. For a code change the payload
 is source and a `.md` is not — but **for a docs or skill PR the payload IS the `.md`**, and **most of this repo's
 merged PRs ship no source file at all** (measured; the reference file dates it), so a rule keyed to
-file type reads every round of those as zero and stops a ladder that is working. Nor will a pathspec do it: `':!*test*'` swallows
-`attestation/` and `latest/`, `':!*spec*'` swallows `inspector/`, and both keep `FooTest.java` and
-`*.cy.ts` (measured). A round's fix touches a handful of files — read the list and name each one
+file type reads every round of those as zero and stops a ladder that is working. Nor will a pathspec do it — measured wrong in both
+directions on ordinary names (reference file). A round's fix touches a handful of files — read the list and name each one
 payload or scaffolding. **Ambiguous is not zero**: the gate does not fire, and the ladder continues.
 
 🔴 **Per-round, and every commit the round actually made.** Anchored at round 1 the count stays
@@ -151,12 +154,10 @@ measures the fixes; it never counts the rounds.
 
 When a PR claims a guard is "mutation-verified", check **what kind**. Deletion is the obvious
 mutant and the weakest: four variants that delete NOTHING once passed a suite its author had just
-"mutation-verified" (named in the reference file). The two rules that decide most cases: **when you
-can only assert on TEXT, pin the WHOLE normalised statement** — a partial regex is satisfied by
-inverted code, and a pin that stops mid-sentence leaves the tail free to argue the opposite; and
-**a fixture of empty or default values collapses distinct implementations into identical output**,
-so give fixtures non-default sibling values. **A review fix RESETS the gate**
-(`claude/RULES.md`): re-run the FULL battery after every round and reformat.
+"mutation-verified" (all four in the reference file). The rule that decides most cases: **when you can
+only assert on TEXT, pin the WHOLE normalised statement** — a partial regex is satisfied by inverted
+code, and a pin that stops mid-sentence leaves the tail free to argue the opposite. Fixture and
+re-run rules: reference file.
 
 **Price a defect from the CONSUMING code: verifying that a value is USED is not verifying what its
 ABSENCE costs.** Read the consuming code before repeating any costed consequence an audit asserts,

--- a/claude/skills/audit-pr/reference/round-ladder-evidence.md
+++ b/claude/skills/audit-pr/reference/round-ladder-evidence.md
@@ -123,6 +123,18 @@ plus the classifier above, and the answer changes with the window.
 
 ---
 
+## 2026-08-26 · why the classifier is a JUDGEMENT, not a pathspec
+
+Behind **"the unit is THIS PR's PAYLOAD, never a file extension"**. Measured on a scratch repo
+(git 2.55.0), `git ls-files -- ':!*_test.*' ':!*test*' ':!*spec*'` counts as PRODUCTION only
+`cypress/e2e/login.cy.ts`, `src/main/java/FooTest.java` and `main.go` — so `':!*test*'` swallows
+`pkg/attestation/verify.go` and `api/latest/handler.go`, `':!*spec*'` swallows
+`internal/inspector/scan.go`, and the two genuine tests survive as "production". Wrong in both
+directions, on directory names any repo might have. `':!*_test.*'` is entirely subsumed by
+`':!*test*'`, and docs are excluded by none of them.
+
+---
+
 ## 2026-08-26 · which range form counts a ROUND's payload — measured across four shapes
 
 The measurement behind the gate's command. Each shape is a throwaway repo (git 2.55.0); the numbers
@@ -166,6 +178,15 @@ that delete nothing all passed a suite its author had just "mutation-verified":
 - **comment the guard out** — the clause is dead but the TEXT is still present (`--`, `/* */`), so
   every regex looking for it still matches;
 - **re-bind a stale value** — literally the original defect, reintroduced.
+
+Two rules the skill body points here for, because they bind the AUTHOR of a guard more than the
+reader of a PR:
+
+- **A fixture of empty or default values collapses distinct implementations into identical output.**
+  One mutant survived *only* because the fixture was `{}`, which made "bind just the patch" and
+  "rebind the whole stale snapshot" byte-identical. Give fixtures non-default sibling values.
+- **A review fix RESETS the gate** (`claude/RULES.md`): re-run the FULL mutant battery after every
+  fix round *and* after any reformat — not just the mutant for the thing you changed.
 
 What would have caught all four: enumerating mutants from the expression's own semantic failure
 modes — operand order, branch order, comment-out, wrong bind, off-by-one — rather than from "delete

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -311,8 +311,8 @@ recorded as SURVIVED off an 11-passed run.
        into the sum so nothing escapes") ..... 1 failed
   S4   reworded-rule regression shape deleted   1 failed
 
-  added after the ninth audit -- two pins that certified PRESENCE without
-  certifying the instruction around them:
+  added after the ninth audit -- one pin that certified PRESENCE without
+  certifying the instruction around it, and one block with no pin at all:
   N1   delta-bullet HEAD inverted to "do NOT
        hunt", pinned phrase byte-identical ... 1 failed
   N2   the other regression shapes deleted,
@@ -560,14 +560,15 @@ SKILL_CLASSIFIER_METHOD = (
     "payload or scaffolding. **Ambiguous is not zero**: the gate does not fire, "
     "and the ladder continues."
 )
-# The pathspec facts, kept because they are the reason the method is a judgement
-# and not a pattern. `inspector` is dropped by `*spec*`, NOT by `*test*` -- an
-# earlier version of this sentence attributed all three to `*test*` and was
-# wrong on its own third example.
+# The pathspec prohibition. The MEASUREMENT behind it moved to the reference
+# file (pinned there as EVIDENCE_PATHSPEC_MEASUREMENT) when the body needed the
+# bytes for two worktree hazards; what stays here is the rule a reader acts on.
+# Keep both: an earlier version of the measurement attributed all three
+# directory names to `*test*` and was wrong on its own third example, which is
+# why the numbers are pinned rather than paraphrased.
 SKILL_GATE_NO_PATHSPEC = (
-    "Nor will a pathspec do it: `':!*test*'` swallows `attestation/` and "
-    "`latest/`, `':!*spec*'` swallows `inspector/`, and both keep "
-    "`FooTest.java` and `*.cy.ts` (measured)."
+    "Nor will a pathspec do it — measured wrong in both directions on ordinary "
+    "names (reference file)."
 )
 
 # The operator instructions this rule ships -- count them below rather than
@@ -612,7 +613,7 @@ SKILL_STDERR_CAPTURE = (
 # not that the instruction around it still tells the re-auditor to hunt.
 # Measured with only the phrase pinned -- inverting the bullet head to "do NOT
 # spend the round hunting regressions the fix round itself introduced", and
-# deleting the other two regression shapes, were both GREEN with the phrase
+# deleting the other three regression shapes, were both GREEN with the phrase
 # byte-identical. Same lesson as EVIDENCE_LESSON_BC, one file over.
 SKILL_REWORD_REGRESSION = (
     "- hunt for **regressions the fix round itself introduced** — the guard "
@@ -621,12 +622,25 @@ SKILL_REWORD_REGRESSION = (
     "narrower on another**;"
 )
 # 🔴 THE ENVIRONMENT BRIEF, pinned whole. It is payload -- what the operator is
-# told to put in front of the auditor -- and it was reworded in FOUR of this
-# PR's nine commits, every time under byte pressure. Measured unpinned: gutting
+# told to put in front of the auditor -- and it was reworded in SIX of #900's
+# eleven commits (four of the eight FIX commits), every one a shave until the
+# last, which restored what a shave had taken. Measured unpinned: gutting
 # its lead to "do not bother briefing the auditor", deleting the zsh word-split
 # warning, and re-applying the exact worktree-duty regression round 8 diagnosed
 # (shifting "verify your worktree clean YOURSELF" back to "leave your worktree
 # clean", i.e. from the operator to the auditee) were ALL green.
+# 🔴 The two worktree hazards, pinned because each is a rule whose DELETION is
+# silent and whose inversion reads plausible. `isolation: "worktree"` builds
+# from the CWD's repo, so dispatching it for a PR in another repo worktrees the
+# wrong one -- and the failure is quiet: the agent either reports a briefed file
+# missing, or silently audits the wrong tree. Measured: with the caveat
+# unpinned, replacing it with "use `isolation: \"worktree\"` for any repo" was
+# green.
+SKILL_CROSS_REPO_WORKTREE = (
+    "🔴 `isolation: \"worktree\"` worktrees the **cwd's** repo, not the PR's — "
+    "for a PR in another repo have the agent run `git -C <that-repo> worktree "
+    "add …` itself."
+)
 SKILL_ENVIRONMENT_BRIEF = (
     "**Brief the auditor on the environment, or it will report false findings** "
     "— a fresh worktree is not a working checkout, and an auditor hitting this "
@@ -636,7 +650,9 @@ SKILL_ENVIRONMENT_BRIEF = (
     "**whether the base branch is already red** and *at which file*; and that "
     "**zsh does not word-split unquoted parameters**, so `eslint $FILES` checks "
     "**zero** files and prints a confident PASS. Have it mutate only in a `cp "
-    "-a` copy, and verify your worktree clean yourself at the end."
+    "-a` copy — **`rm -f <copy>/.git` first**, since a worktree's is a FILE "
+    "pointing at the real git dir, so a commit in the copy lands on your branch "
+    "— and verify your worktree clean yourself at the end."
 )
 SKILL_LEDGER = (
     "**Carry the ledger in every round's summary**: `round N · payload lines "
@@ -680,6 +696,15 @@ EVIDENCE_SHAPE_C_ROW = (
 EVIDENCE_PR_POPULATION_ROW = (
     "| `gh pr list --state merged --limit 40` (sorts by CREATED) | 24 | 16 | 7 "
     "| 1 |"
+)
+# 🔴 The pathspec measurement, demoted from the body in the worktree-hazards
+# follow-up. The body now carries only the prohibition, so this file is where a
+# reader checks WHY -- and an unpinned measurement in this file has already
+# drifted twice (Z8, and shape A before U1).
+EVIDENCE_PATHSPEC_MEASUREMENT = (
+    "so `':!*test*'` swallows `pkg/attestation/verify.go` and "
+    "`api/latest/handler.go`, `':!*spec*'` swallows `internal/inspector/"
+    "scan.go`, and the two genuine tests survive as \"production\""
 )
 EVIDENCE_SHAPE_A_ROW = (
     "| A. clean `merge main` brings 200 upstream lines; the round's own fix is "
@@ -977,6 +1002,11 @@ def test_the_attribution_measurement_survives_where_the_skill_routes_to_it():
     _assert_pinned_once(
         EVIDENCE_MD, EVIDENCE_SHAPE_A_ROW, "the shape-A range measurement"
     )
+    _assert_pinned_once(
+        EVIDENCE_MD,
+        EVIDENCE_PATHSPEC_MEASUREMENT,
+        "the pathspec counter-measurement",
+    )
     _assert_pinned_once(EVIDENCE_MD, EVIDENCE_LESSON_A, "the shape-A lesson")
     _assert_pinned_once(EVIDENCE_MD, EVIDENCE_LESSON_BC, "the shape-B/C lesson")
     _assert_pinned_once(
@@ -1034,7 +1064,9 @@ def test_the_gate_pins_its_MECHANISM_not_only_its_decision():
 
 
 def test_the_operator_instructions_the_gate_depends_on_are_pinned():
-    """The instructions a reader ACTS on, each of which survived deletion.
+    """The instructions a reader ACTS on -- count the asserts, not this sentence.
+
+    Each was added after a mutant deleted or inverted it with the suite green.
 
     Neither is decorative. The ledger's X IS the number the gate reads -- it
     carries the per-round count into the summary a human actually sees, which is
@@ -1058,6 +1090,9 @@ def test_the_operator_instructions_the_gate_depends_on_are_pinned():
     )
     _assert_pinned_once(
         SKILL_MD, SKILL_ENVIRONMENT_BRIEF, "the environment brief"
+    )
+    _assert_pinned_once(
+        SKILL_MD, SKILL_CROSS_REPO_WORKTREE, "the cross-repo worktree hazard"
     )
 
 


### PR DESCRIPTION
Follow-up to #900. That PR disclosed two 🔴 in this skill and deliberately scoped them out so the ladder could stay on the attribution gate; round 10 then filed three comment counts rather than spending a round on them, which is what the gate it added instructs. This closes all five, and does the structural fix #900 kept deferring.

## The two hazards, both silent

**1. `isolation: "worktree"` worktrees the CWD's repo, not the PR's.** The skill's primary target is a bare PR number, which is very often a PR in *another* repo — and then every fan-out auditor gets a worktree of whatever repo the operator happened to be sitting in. One failure half is loud (the agent reports a briefed file missing); the other is silent (it audits the wrong tree and says nothing). Now: for a PR in another repo, have the agent run `git -C <that-repo> worktree add …` itself.

**2. A `cp -a` of a worktree shares the ORIGINAL's git dir.** The skill tells the auditor to mutate only in a `cp -a` copy — and a worktree's `.git` is a *file* holding `gitdir: …`, so a commit in that copy lands on the real branch. Now: `rm -f <copy>/.git` first.

Both pinned. **G2 was green until it was pinned** — inverting the caveat to "use `isolation: "worktree"` for any repo" passed the suite.

## The three counts round 10 filed

- the env-brief comment said "four of this PR's nine commits"; measured **six of eleven**, or four of the eight *fix* commits — the denominator the neighbouring comment uses. Stated both ways now, so neither reading is wrong.
- "the other two regression shapes" is **three**.
- the matrix header said "two pins that certified presence"; it was **one pin plus one block with no pin at all** — different lessons, so the header says so.
- and the renamed test's docstring still said "neither"/"either" for a body asserting six constants.

## The structural fix

#900's last four rounds each paid for a new rule by shaving words out of the checklist, and one of those shaves deleted `rollback` under a commit message claiming a restore. This one **stops shaving and re-homes**: the pathspec counter-evidence (a measurement) and the two mutation rules that bind a guard's *author* rather than a PR's *reader* move to the reference file, which is not budgeted.

**Body 11,985 → 11,902 B — the first commit in this thread to add two rules and come out smaller.** The moved measurement is pinned at its new home; the prohibition it supports stays pinned in the body.

## Coverage

```
POS  unmutated .............................. 11 passed
PREV origin/main (pre-change payload) ....... 3 failed, 8 passed
G1   cp -a .git hazard deleted ............... 1 failed
G2   cross-repo worktree caveat inverted ..... 1 failed   <- green until pinned
G3   pathspec measurement inverted at its new home  1 failed
G4   pathspec prohibition -> endorsement ..... 1 failed
```

Each on its own scratch tree, `PYTHONDONTWRITEBYTECODE=1`, cache disabled, assert-before-edit. Two pins were re-pointed here because their sentences changed deliberately — the module's documented path, and the moment the suite made me notice I was rewriting a rule rather than reformatting a paragraph.

Gate: `scripts/gate.sh --tier both` → `GATE: RESULT=PASS exit=0`, on a branch cut from `6d6bf84d`.

## Still open, deliberately

The **dispatch template** — the skill still has no executable procedure, so a caller reassembles the auditor brief from prose each time. That is the largest remaining usability gap and it is a different change from this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
