### PR TITLE
docs(clawgate/deploy): bump buildVersion WITH the pin — the step that reddens every PR

### DIFF
--- a/claude/skills/clawgate/reference/deploy.md
+++ b/claude/skills/clawgate/reference/deploy.md
@@ -61,8 +61,25 @@ docker push harbor.homelab.lan/library/clawgate:$VER && docker push harbor.homel
 
 # 3. bump the pin, stage explicit paths, commit, rebase (clean tree → no autostash), push
 cd /home/zach/workspace/homelab-trunk
+# 🔴 BUMP BOTH. The version lives in TWO files and `version_pin_test.go` asserts
+# they are equal, so moving the pin alone turns `go test ./...` RED — which is
+# `tekton/clawgate-ci FAILED: go` on EVERY PR that touches containers/clawgate,
+# not just yours. It has shipped twice: #408 ("the deploy pin moved without it")
+# and again at 0.8.2, where the fix had to land as its own PR (#427, "trunk was
+# red for every PR"). The tell you will see FIRST is clawgatectl printing
+# `note: server <new>, clawgatectl built for <old>` on every command — if you
+# see that after a deploy, this step is what you missed.
 sed -i "s#clawgate:[0-9.]\+#clawgate:$VER#" clusters/workbench/apps/clawgate/deployment.yaml
-git add <your changed clawgate paths> clusters/workbench/apps/clawgate/deployment.yaml containers/clawgate/HANDOFF.md
+sed -i "s#^var buildVersion = \".*\"#var buildVersion = \"$VER\"#" containers/clawgate/cmd/clawgatectl/client.go
+# CONFIRM both moved before committing — a sed that matched nothing exits 0.
+grep -m1 -oE "clawgate:[0-9.]+" clusters/workbench/apps/clawgate/deployment.yaml
+grep -nE '^var buildVersion' containers/clawgate/cmd/clawgatectl/client.go
+# The guard that fails the whole fleet if these drift. ⚠ COUNT the result line —
+# a `-run` filter that matches nothing prints "ok ... [no tests to run]" and
+# exits 0, so a typo'd test name reads exactly like a pass.
+go test . -run TestDeployPinMatchesClientBuildVersion -v | grep -E '^(=== RUN|--- (PASS|FAIL)|ok|FAIL)'
+git add <your changed clawgate paths> clusters/workbench/apps/clawgate/deployment.yaml \
+        containers/clawgate/cmd/clawgatectl/client.go containers/clawgate/HANDOFF.md
 git commit -m "..." -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 git fetch origin trunk && git rebase origin/trunk && git push origin HEAD:trunk
 


### PR DESCRIPTION
## Why

clawgate's version lives in **two** files, and `version_pin_test.go` asserts they are equal:

- `clusters/workbench/apps/clawgate/deployment.yaml` — the image tag
- `containers/clawgate/cmd/clawgatectl/client.go` — `var buildVersion`

The deploy runbook's step 3 only ever bumped the first. Moving the pin alone turns `go test ./...` red, which surfaces as **`tekton/clawgate-ci FAILED: go` on every PR that touches `containers/clawgate`** — not just the deployer's.

## This has shipped twice

| | |
|---|---|
| 0.8.0 | fixed by #408 — *"the deploy pin moved without it"* |
| 0.8.2 | happened again; the fix had to land as its own PR, #427, whose title says trunk was red for every PR |

Both times the runbook was followed faithfully and the gate still broke. That makes it a defect in the runbook, not in anyone's care — which is why the fix belongs here rather than in a reminder.

## What changed

Step 3 now bumps **both** files, reads both back to confirm (a `sed` that matches nothing exits 0), and runs the guard.

The guard invocation is spelled out with its real name, `TestDeployPinMatchesClientBuildVersion`, and greps the **result lines** rather than trusting the exit code. Measured while writing this — a plausible-looking wrong name is silently a no-op:

```
filter correct -> === RUN TestDeployPinMatchesClientBuildVersion
                  --- PASS  /  ok
filter typo'd  -> ok  github.com/zacxdev/clawgate  [no tests to run]
```

Both controls were run against a synced trunk. The typo'd form exits **0**, so an operator who mistypes the test name gets something indistinguishable from a pass.

It also names the symptom seen first: `clawgatectl` printing `note: server <new>, clawgatectl built for <old>` on every command. That note's value depends on being rare — when the literal falls behind it fires forever and trains everyone to ignore the one signal that does that job.

## Disclosure

I caused the 0.8.2 instance. My commit bumped the pin and not the literal, following this runbook as written.
