### PR TITLE
feat(browser): register civit.ai — App Blocks had no site notes, and the iframe is where every op lands

### DIFF
--- a/scripts/browser-bridge/reference/sites/_index.json
+++ b/scripts/browser-bridge/reference/sites/_index.json
@@ -12,6 +12,7 @@
     "file degrades to no site_notes and never breaks a browser op."
   ],
   "sites": {
+    "civit.ai": "civit.ai.md",
     "civitai.com": "civitai.com.md"
   }
 }

--- a/scripts/browser-bridge/reference/sites/civit.ai.md
+++ b/scripts/browser-bridge/reference/sites/civit.ai.md
@@ -1,0 +1,78 @@
+# civit.ai — Civitai App Blocks: the iframe, the boot, and the 404 that looks like an app
+
+**Load this when:** a result envelope named this file in `site_notes` · you are
+driving anything at `<slug>.civit.ai` · a selector or injected JS on an App Block
+returned `null` and you are about to call the bridge broken · you are about to
+report an App Block control as missing or a component as defective.
+
+Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`.
+Mechanism files stay authoritative for mechanism: frames and OOPIFs →
+`reference/frames-cdp.md`; throttling and `wake` → `reference/spa-wake.md`;
+stripped `data-testid` and hit-testing → `reference/css-hit-test.md`; proving a
+read is the live authenticated session → `reference/auth-pages.md`. The parent
+site's identity and `/apps` reads → `reference/sites/civitai.com.md`.
+This file is only what is true of **an App Block**.
+
+🔴 **Before driving a block by hand, check whether a recipe already exists.** The
+`app-capture` skill in `civitai/talos-infra` encodes every fact below as a
+*refusal* in `plan.py`, and ships recipes for the first-party blocks. Driving one
+deterministically is `capture.sh <recipe>`; only recipe **authoring** needs the
+by-hand flow this file describes.
+
+---
+
+## 🔴 A block renders in a CROSS-ORIGIN IFRAME — every DOM op needs `--frame`
+
+`<slug>.civit.ai` is embedded in `civitai.com/apps/run/<slug>`. Top-frame
+selectors find nothing and injected JS returns `null`, which reads exactly like a
+broken bridge. It is not: you are addressing the wrong document.
+
+🔴 **This is a SAFETY boundary, not only a correctness one.** A `--frame` op is
+dispatched synthetically (`trusted:false`). A **top-frame** `click`/`type`/`key`
+takes CDP `Input.dispatch*Event` and arrives `trusted:true`. So dropping `--frame`
+does not merely miss the element — it upgrades the event's trust, and that is the
+second route to a trusted event, one that spells no `xdotool` anywhere.
+
+**Corollary, and the reason a "broken" money button is usually not broken:** the
+spend path *rejects untrusted events*, so a synthetic in-frame click does nothing
+at all on a billing control. That is the platform working as designed, not a
+defect — do not report it as one, and do not "fix" it by dropping `--frame`.
+
+## 🔴 The frame id changes on EVERY load — re-poll `frames` after any nav
+
+Five distinct ids in one session (819, 821, 828, 830, 832). A frame id captured
+before a `nav` is dead after it. Re-poll `frames` and take the new id; never
+carry one across a navigation.
+
+## Blocks boot slowly — the frame does not exist right after `open`
+
+Poll for it. A missing frame this early means *not yet*, not *absent*. Never let
+a miss fall back to the top frame: that silently gives you the host page's DOM
+under a name that says otherwise.
+
+## 🔴 Gate on an APP-READY ANCHOR before the first action
+
+Wait for something only the **booted** app renders — not merely the frame's
+existence.
+
+Without that gate the failure is actively misleading: a click fired into a
+still-booting app is **discarded**, and it is the *next* wait that times out,
+naming a control that is perfectly fine. The resulting defect report is about the
+wrong component. This is the single most expensive mistake available here.
+
+## Tabs are created hidden and throttled — `wake` after every view change
+
+A throttled capture is a blank page. `wake --wait 4000` un-throttles *rendering*.
+
+🔴 **But do NOT infer that a block needs a foreground tab to boot.** It does not —
+measured 4/4 booting hidden, one with no `activate` at all. An earlier "5/5
+`BLOCK_INIT` deadlock in a hidden tab" is **retracted** and unexplained; do not
+re-derive a foregrounding requirement from it. The `wake` is for throttling, and
+that is all it is for.
+
+## 🔴 Logged out, `/apps/run/<slug>` is a plain 404 — byte-identical to a bad slug
+
+The 404 renders, screenshots, crops and frames just as well as a real app, so
+nothing downstream will tell you. **Check auth first**, before any read you intend
+to draw a conclusion from — an unauthenticated session makes a working block and a
+nonexistent one indistinguishable.


### PR DESCRIPTION
feat(browser): register civit.ai — App Blocks had no site notes, and the iframe is where every op lands

Civitai App Blocks render at `<slug>.civit.ai` inside `civitai.com/apps/run/<slug>`.
The registry held one key, `civitai.com`, and the match is on label boundaries —
different apex, so no App Block host has ever resolved to site notes.

That gap sat exactly where it hurts. `_domain_from_result` reads the envelope's
`url`, and a `--frame` op reports the FRAME's own url (reference/read-envelopes.md
line 92, reference/frames-cdp.md line 51). Every DOM op against a block is
frame-scoped, so every one of them carried a `civit.ai` host and got nothing —
while the top-level page, which almost nothing addresses, was the half that
resolved.

ONE APEX KEY, NOT SEVEN PER-APP FILES. Suffix matching on label boundaries covers
every current and future `<slug>.civit.ai` at zero per-app cost, and longest-match
-wins leaves room for a specific block to override later if one ever earns it.
Seven files would also collide with test_every_registered_file_is_non_trivial:
most blocks have nothing site-specific to say and would be padded to pass.

WHAT THE FILE CARRIES is platform facts only — true of every block, none of them
decaying:
  * the cross-origin iframe, and that dropping `--frame` does not merely miss the
    element, it UPGRADES the event to trusted:true via CDP Input — the second
    route to a trusted event, the one that spells no xdotool
  * the corollary that makes a "broken" money button usually not broken: the spend
    path rejects untrusted events, so a synthetic in-frame click does nothing
  * the frame id changing on every load (five ids in one session)
  * blocks booting slowly, and never letting a missing frame fall back to the top
  * the app-ready anchor, whose absence is actively misleading rather than merely
    flaky: the click is DISCARDED and the NEXT wait times out naming a control
    that is fine, so the defect report is about the wrong component
  * hidden+throttled tabs needing wake — with the retraction attached, because
    blocks DO boot hidden (4/4) and the old "5/5 BLOCK_INIT deadlock" is
    unexplained and must not be re-derived into a foregrounding requirement
  * logged out, /apps/run/<slug> is a plain 404 that screenshots, crops and frames
    exactly like a real app

Per-app verdicts deliberately stay in talos-infra's app-capture skill. They decay
and are re-measured there; copying them here would rot them in a second repo.

The file also points at app-capture first, so an agent does not hand-roll a flow
that already ships as a recipe. Only recipe AUTHORING needs the by-hand path.

SKILL.md is untouched — test_skill_md_names_the_directory_and_no_individual_site
pins that the registry, not the skill body, is where a site appears.

Verified:
  tests/test_site_notes.py    70 passed
  tests/ (full python suite)  791 passed
  host resolution, called directly under BROWSER_BRIDGE_SITES_DIR:
    custom-generators/sensei/gen-matrix/apex civit.ai -> civit.ai.md
    civitai.com + www.civitai.com                     -> civitai.com.md (unchanged)
    notcivit.ai / xcivit.ai / civit.ai.evil.invalid    -> "" (label boundaries hold)
  a simulated frame envelope (data.url = https://sensei.civit.ai/x) comes back
  carrying site_notes; an unregistered host has no such key at all.

Instrument validated, not trusted: moving civit.ai.md aside turns the suite RED at
test_index_and_files_are_the_same_set AND test_every_registered_file_is_non_trivial,
green again when restored — so the pass is a pass on THIS file.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5yPJ1haNA2t9x2PxjrHr6
