### PR TITLE
fix(browser): a new site-notes entry needed a bridge RESTART to exist — and said nothing

### DIFF
--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -1101,11 +1101,37 @@ _SITES_DIR = Path(
 # The doc path a consumer is told to read is REPO-RELATIVE, matching how every
 # other reference file is named in SKILL.md's table.
 _SITES_REL_PREFIX = "reference/sites"
-# (resolved_dir, {host_suffix: filename}) — parsed at most once per directory.
-# Keyed on the directory so a test that repoints BROWSER_BRIDGE_SITES_DIR gets a
-# fresh load without needing a reset hook, while a normal run reads the file once
-# for the life of the process.
+# (resolved_dir, stamp, {host_suffix: filename}) — re-parsed only when the file
+# CHANGES. Keyed on the directory so a test that repoints BROWSER_BRIDGE_SITES_DIR
+# gets a fresh load without needing a reset hook.
+#
+# 🔴 THE STAMP IS THE WHOLE POINT — keyed on the directory ALONE, this cache made
+# every registry addition INVISIBLE to a running bridge until it restarted, and
+# invisible SILENTLY. Measured 2026-08-27: `civit.ai` was registered, merged, and
+# present on disk, while a bridge started two days earlier kept answering from a
+# mapping that predated it. Nothing reports this. The failure reads as "my new
+# entry does not work", so the natural response is to go looking for a bug in the
+# entry — a false negative about your OWN change, which is what makes it
+# expensive rather than merely stale. A registry that is only ever added to is
+# exactly the shape that hides it: the entries already cached keep resolving, so
+# the feature looks alive while the new half is dead.
 _site_index_cache = None
+
+
+def _site_index_stamp():
+    """A cheap change-stamp for `_index.json`: (mtime_ns, size), or None.
+
+    One `stat` per lookup — not a re-parse, and not a re-read. None means the
+    stat itself failed (absent/unreadable), and the caller deliberately KEEPS
+    whatever it already had rather than discarding it: this whole path is
+    best-effort, and a registry that momentarily cannot be stat'd is not a
+    reason to start answering "no site notes" to every command.
+    """
+    try:
+        st = (_SITES_DIR / "_index.json").stat()
+        return (st.st_mtime_ns, st.st_size)
+    except Exception:  # noqa: BLE001 — an unreadable registry is not an error.
+        return None
 
 
 def _load_site_index() -> dict:
@@ -1125,8 +1151,13 @@ def _load_site_index() -> dict:
     """
     global _site_index_cache
     cached = _site_index_cache
+    stamp = _site_index_stamp()
     if cached is not None and cached[0] == _SITES_DIR:
-        return cached[1]
+        # A None stamp (the file cannot be stat'd right now) REUSES the cache
+        # rather than re-reading — see _site_index_stamp. Only an observed,
+        # DIFFERENT stamp forces the re-parse.
+        if stamp is None or cached[1] == stamp:
+            return cached[2]
     mapping = {}
     try:
         raw = json.loads((_SITES_DIR / "_index.json").read_text("utf-8"))
@@ -1146,7 +1177,7 @@ def _load_site_index() -> dict:
                 mapping[host] = name
     except Exception:  # noqa: BLE001 — an absent/broken registry is not an error.
         mapping = {}
-    _site_index_cache = (_SITES_DIR, mapping)
+    _site_index_cache = (_SITES_DIR, stamp, mapping)
     return mapping
 
 

--- a/scripts/browser-bridge/tests/test_site_notes.py
+++ b/scripts/browser-bridge/tests/test_site_notes.py
@@ -378,6 +378,50 @@ def test_the_index_is_parsed_once_per_directory(tmp_path, monkeypatch):
     assert S._site_notes_path("cached.test") == "reference/sites/cached.test.md"
 
 
+def test_a_CHANGED_index_is_re_read_in_the_SAME_process(tmp_path, monkeypatch):
+    """🔴 THE REGRESSION TEST. A NEW ENTRY MUST NOT NEED A RESTART.
+
+    Cached on the directory ALONE, this answered from a mapping parsed once for
+    the life of the process — so a registry entry that was added, merged and
+    present on disk stayed INVISIBLE to a running bridge, and silently. Measured
+    2026-08-27: `civit.ai` was registered while a bridge started two days earlier
+    kept resolving the OLD key set. The entries already cached keep working, so
+    the feature looks alive while the new half is dead, and the failure presents
+    as "my new entry is broken" — a false negative about your own change.
+
+    🔴 THE TEST MUST MUTATE THE FILE BETWEEN TWO LOOKUPS IN ONE PROCESS. Nothing
+    weaker can see this: re-running with an UNCHANGED file is a no-op either way,
+    and clearing the cache via `_point_at` tests the parser rather than the
+    invalidation. This is the same shape as the base-clone refresh hook that
+    "worked exactly once per file" — an idempotence test cannot detect a cache
+    that never invalidates, because the second run has nothing new to miss.
+
+    The two payloads differ in LENGTH as well as content, so the (mtime_ns, size)
+    stamp changes even on a filesystem whose mtime granularity is coarse enough
+    to place both writes in the same tick. That is deliberate: a same-length edit
+    inside one timestamp tick is exactly how a coarse-stamped cache goes on
+    serving stale bytes, and the test must not be the thing that depends on luck.
+    """
+    d = _write_index(tmp_path / "mutating", json.dumps(
+        {"sites": {"before.test": "before.test.md"}}))
+    _point_at(monkeypatch, d)
+    assert S._site_notes_path("before.test") == "reference/sites/before.test.md"
+
+    # Rewrite in place — NO cache clear, NO repoint. This is the running bridge.
+    (d / "_index.json").write_text(json.dumps(
+        {"sites": {"after.test": "a-considerably-longer-name.after.test.md"}}),
+        encoding="utf-8")
+
+    assert S._site_notes_path("after.test") == (
+        "reference/sites/a-considerably-longer-name.after.test.md"), (
+        "a registry entry added while the process was running stayed invisible — "
+        "the index cache did not notice the file had changed")
+    assert S._site_notes_path("before.test") == "", (
+        "the re-read merged into the old mapping instead of replacing it; a key "
+        "REMOVED from the registry must stop resolving too"
+    )
+
+
 # --------------------------------------------------------------------------- #
 # THE LEDGER — the registry's key set and the directory's *.md set are identical
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
fix(browser): a new site-notes entry needed a bridge RESTART to exist — and said nothing

`_load_site_index` cached on the sites DIRECTORY alone, and the comment said the
quiet part: "reads the file once for the life of the process". So a registry entry
that was added, reviewed, merged and sitting on disk stayed INVISIBLE to any
already-running bridge, with nothing anywhere reporting it.

Measured 2026-08-27, on the change that exposed it: `civit.ai` was registered
(#925) and present in the base clone, while the bridge — pid 1022164, started two
days earlier — kept answering from the mapping it parsed at boot. `civitai.com`
resolved; `model-benchmarking.civit.ai` returned no `site_notes` at all.

🔴 WHY THIS IS WORSE THAN ORDINARY STALENESS. The entries already cached keep
resolving, so the feature looks alive while only the NEW half is dead. And the
symptom lands on the wrong suspect: it presents as "the entry I just added does
not work", so the natural next move is to go hunting for a bug in the entry. It
cost exactly that today — a positive control "failed" and the change under test
was correct. A registry that is only ever appended to is the ideal shape for
hiding this, because the regression is invisible to everyone who is not adding a
key at that moment.

THE FIX: key the cache on (dir, stamp) where stamp is (mtime_ns, size). One
`stat` per lookup — not a re-read, not a re-parse. A re-parse happens only on an
observed, DIFFERENT stamp.

🔴 A FAILED STAT REUSES THE CACHE rather than discarding it, and that is a
deliberate choice, not an oversight. This path is best-effort by contract — a
browser command must never start failing because a doc registry is momentarily
unreadable — so "cannot stat right now" must not become "no site notes for every
command". That choice is also what keeps
`test_the_index_is_parsed_once_per_directory` passing UNMODIFIED: it proves
cheapness by DELETING the file and requiring a second lookup to still answer,
which is precisely the None-stamp branch. The cheapness guarantee is intact; only
the staleness case changed.

THE TEST IS THE POINT, because its absence is what let this ship:
`test_a_CHANGED_index_is_re_read_in_the_SAME_process` mutates `_index.json`
BETWEEN TWO LOOKUPS IN ONE PROCESS. Nothing weaker can see the defect — re-running
against an unchanged file is a no-op either way, and clearing the cache through
`_point_at` tests the parser instead of the invalidation. Same shape as the
base-clone refresh hook that "worked exactly once per file": an idempotence test
is structurally blind to a cache that never invalidates, because the second run
has nothing new to miss.

It also asserts the old key STOPS resolving, so a re-read that merged into the
previous mapping instead of replacing it would fail — a removal has to take
effect too, not only an addition.

The two payloads differ in LENGTH as well as content, so the stamp moves even
where mtime granularity is coarse enough to put both writes in one tick. A
same-length edit inside a single timestamp tick is exactly how a coarse-stamped
cache goes on serving stale bytes; the regression test must not be the part that
relies on luck.

Verified:
  tests/test_site_notes.py    71 passed (was 70)
  tests/ (full python suite)  792 passed (was 791)


**Follow-up to #925**, which is what exposed this: the entry merged, sat on disk, and the running bridge never saw it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5yPJ1haNA2t9x2PxjrHr6
