### PR TITLE
feat(run-tests): per-target timing census — the runner reported counts and a verdict and no durations

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2904,6 +2904,37 @@ TOT_PASSED=0
 TOT_SKIPPED=0
 TOT_FAILED=0
 
+# --- PER-TARGET TIMING CENSUS --------------------------------------------------
+# 🔴 WHY THIS EXISTS. This runner reported COUNTS and a VERDICT and no durations
+# at all, so the only time signal anywhere was the gate's whole-run wall clock.
+# Measured 2026-08-27 over the twelve most recent completed `devrc-ci` runs:
+# 805s–1293s against the gate's 45m deadline. That is 30–48% of budget with a
+# 1.6x run-to-run spread, and NOTHING in the output could attribute either the
+# spread or a future overrun to a target. The first signal of a target that
+# doubles is a hard kill at 45m carrying no evidence about which one did it.
+#
+# The per-target shape IS known — the xdist header above records `scripts/tests`
+# at 677s of 1194 (57%), browser-bridge 234s, dl-router 126s — but it was
+# hand-measured once, on 2026-08-25, on the SERIAL runner that #841 then
+# replaced. A number in a comment ages; a number the run prints does not.
+#
+# 🔴 THE RECORD IS TAKEN BY A WRAPPER, NOT BY CALLS SPRINKLED THROUGH THE BODY.
+# `run_pytest` has FIVE terminal paths, three of which `return 1` before pytest
+# is ever invoked (missing target, non-file/dir target, unparseable summary).
+# Recording at each one is exactly the mistake GUARD 7/8/10 each had to grow a
+# "never accounted" check for. Wrapping makes the record structurally
+# unmissable instead: every path out of the body passes through one place.
+# `TIMING_CALLS` is kept anyway as a positive control on that claim — if it ever
+# exceeds the number of records, the census is a SUBSET, and a cost ranking
+# built from a subset reads exactly like a complete one.
+#
+# 🔴 FAIL-OPEN, DELIBERATELY. A census is an OBSERVER; an observer that can
+# abort the thing it observes is worse than no census. Every read here defaults
+# (`${VAR:-0}`) rather than tripping `set -u`, and nothing in this block can set
+# `fail`. The timing summary is DIAGNOSTIC — it never changes the verdict.
+TIMINGS=()        # "<elapsed_seconds>\t<rc>\t<target>"
+TIMING_CALLS=0    # dispatches; compared against ${#TIMINGS[@]} at the summary
+
 # Pull "<N> <word>" out of a pytest summary line; 0 when the word is absent.
 _count_of() { # $1 = alternation regex, $2 = summary line
   local n
@@ -2923,6 +2954,21 @@ _count_of() { # $1 = alternation regex, $2 = summary line
 # TARGET loop: running all 27 targets concurrently cannot finish sooner than its
 # longest single target, i.e. 677s — a 1.75x ceiling that -P2 already reaches and
 # -P8 does not improve on. The parallelism has to be INSIDE the big target.
+#
+# ⚠ THOSE FOUR NUMBERS ARE THE **SERIAL** SHAPE, and they are kept because they
+# are what justified the choice above — not because they still describe the run.
+# Do not quote them as current. The run now PRINTS its own per-target ranking
+# every time (see PER-TARGET TIMING CENSUS below), which exists precisely so a
+# figure in a comment stops being the only per-target number anyone has.
+#
+# First measurement off that census, the authoritative gate at this commit:
+# 527s accounted over 31 targets — `scripts/tests` 209s (40%), browser-bridge
+# 143s (27%), dl-router 99s (19%). 🔴 xdist did NOT scale the targets evenly:
+# scripts/tests fell 677→209 (3.2x), browser-bridge 234→143 (1.6x), dl-router
+# 126→99 (1.3x). So the concentration this comment describes has FLATTENED —
+# the biggest target is no longer 57% but 40%, and browser-bridge + dl-router
+# are now 46% between them. Anyone looking for the next devrc CI lever should
+# start there, not here.
 #
 # 🔴 `--dist loadfile`, not the `load` default: a file's tests stay on ONE
 # worker. Several suites here share module-level state (marker files, per-session
@@ -3093,7 +3139,25 @@ _markers_expected() {
   fi
 }
 
+# The timing wrapper. See the PER-TARGET TIMING CENSUS header above for why the
+# record is taken HERE rather than at each of the body's five terminal paths.
+#
+# 🔴 NOT a subshell. `_run_pytest_body` mutates globals the rest of the run
+# depends on — `fail`, `RESULTS`, `SKIP_LINES`, `NOLAUNCH_SEEN`, `TOT_*` — and
+# `fail` in particular is global by design (set at the top of the run, never
+# `local` in the body). Calling it in a subshell would discard every one of
+# those and turn a red target green, which is the whole verdict.
 run_pytest() {
+  local _t_target="$1" _t_t0 _t_rc
+  TIMING_CALLS=$(( ${TIMING_CALLS:-0} + 1 ))
+  _t_t0="$(date +%s)"
+  _run_pytest_body "$@"
+  _t_rc=$?
+  TIMINGS+=("$(( $(date +%s) - _t_t0 ))"$'\t'"$_t_rc"$'\t'"$_t_target")
+  return "$_t_rc"
+}
+
+_run_pytest_body() {
   local d="$1"
   echo "=== pytest $d ==="
 
@@ -3368,12 +3432,19 @@ SHELL_TESTS=(
   "scripts/tests/test_resume_state.sh"
   "scripts/tests/test_base_clone_staleness.sh"
 )
-for SHELL_TEST in "${SHELL_TESTS[@]}"; do
+# 🔴 THE SHELL TESTS ARE IN THE TIMING CENSUS TOO, and the reason is the census's
+# own honesty: it is presented as an accounting of the run, so a population it
+# silently omits would make every percentage in it wrong in the same direction.
+# Same wrapper shape as `run_pytest` above, for the same reason — the body has
+# two terminal paths (the missing-file `return` and falling off the end) and a
+# record at each is the pattern GUARD 7/8/10 each had to grow a check for.
+_run_shell_test_body() {
+  local SHELL_TEST="$1" nl_before
   if [ ! -f "$SHELL_TEST" ]; then
     echo "run-tests: ERROR — shell test '$SHELL_TEST' does not exist (typo, or moved?)." >&2
     RESULTS+=("FAIL  $SHELL_TEST (missing)")
     fail=1
-    continue
+    return 1
   fi
   echo "=== script $SHELL_TEST ==="
   nl_before="$(_nolaunch_lines)"
@@ -3389,12 +3460,75 @@ for SHELL_TEST in "${SHELL_TESTS[@]}"; do
   _spool_account "$SHELL_TEST"
   _nogit_account "$SHELL_TEST"
   echo
+}
+
+for SHELL_TEST in "${SHELL_TESTS[@]}"; do
+  _st_t0="$(date +%s)"
+  TIMING_CALLS=$(( ${TIMING_CALLS:-0} + 1 ))
+  _run_shell_test_body "$SHELL_TEST"
+  _st_rc=$?
+  TIMINGS+=("$(( $(date +%s) - _st_t0 ))"$'\t'"$_st_rc"$'\t'"$SHELL_TEST")
 done
 
 echo "======================== SUMMARY ($SET set) ========================"
 for r in "${RESULTS[@]}"; do echo "  $r"; done
 echo "  ----"
 echo "  TOTAL collected=$TOT_COLLECTED  passed=$TOT_PASSED  skipped=$TOT_SKIPPED  failed=$TOT_FAILED  (floor: $MIN_TESTS = sum of ${#TARGETS[@]} per-target floors)"
+
+# --- PER-TARGET TIMING (diagnostic; never changes the verdict) -----------------
+# Read the PER-TARGET TIMING CENSUS header for why this exists. Three properties
+# this block is written to hold, each of which a plainer version would violate:
+#
+#   1. It reports what it ACCOUNTED FOR and what the RUN COST, separately. Setup,
+#      the flake evaluation and the GUARD evaluation blocks below are outside
+#      both loops, so the target times do NOT sum to the run. Printing only the
+#      targets would imply they do, and every percentage would silently be a
+#      share of the wrong denominator. The `unaccounted` line is the difference,
+#      stated rather than left for the reader to derive.
+#   2. Percentages are of the ACCOUNTED total, and the line says so. This is the
+#      denominator a cost ranking actually wants ("which target should I attack")
+#      and it is not the same number as the run's wall clock.
+#   3. It is fail-open and cannot change `fail`. `${VAR:-0}` on every read, no
+#      `exit`, no assignment to the verdict.
+_t_accounted=0
+for _rec in ${TIMINGS[@]+"${TIMINGS[@]}"}; do
+  _t_accounted=$(( _t_accounted + ${_rec%%$'\t'*} ))
+done
+_t_run="${SECONDS:-0}"
+echo "  ----"
+echo "  TIMING accounted=${_t_accounted}s over ${#TIMINGS[@]} target(s)  run=${_t_run}s  unaccounted=$(( _t_run - _t_accounted ))s (setup + guard evaluation)"
+
+# 🔴 POSITIVE CONTROL ON THIS CENSUS'S OWN COMPLETENESS. The wrapper above is
+# meant to make a missed record structurally impossible; this is what turns that
+# from a claim into a checked one. If a dispatch ever fails to leave a record,
+# the ranking below is built from a SUBSET and reads exactly like a complete one.
+# Reported, never fatal — see property 3.
+if [ "${TIMING_CALLS:-0}" -ne "${#TIMINGS[@]}" ]; then
+  echo "  TIMING ⚠ INCOMPLETE — ${TIMING_CALLS:-0} dispatch(es) but ${#TIMINGS[@]} record(s)."
+  echo "          The ranking below is a SUBSET of what ran; do not read it as a total."
+fi
+
+# 🔴 THE ROW LOOP IS GUARDED ON HAVING RECORDS, NOT ON THE TOTAL BEING NON-ZERO.
+# An earlier revision required `_t_accounted > 0` so the percentage could divide
+# — which silently printed NO ranking at all for any run whose targets each
+# rounded to 0s. That is not a hypothetical: it is every fixture-sized run, i.e.
+# exactly the runs this block's own tests perform, so the tests would have been
+# asserting against a block that never executed. The division is what needs the
+# guard; the rows do not.
+if [ "${#TIMINGS[@]}" -gt 0 ]; then
+  printf '%s\n' ${TIMINGS[@]+"${TIMINGS[@]}"} \
+    | sort -t"$(printf '\t')" -k1,1nr \
+    | while IFS="$(printf '\t')" read -r _secs _rc _tgt; do
+        if [ "${_t_accounted:-0}" -gt 0 ]; then
+          _pct="$(( ( ${_secs:-0} * 1000 / _t_accounted + 5 ) / 10 ))"
+        else
+          _pct=0
+        fi
+        printf '    %6ss  %5s%%  %s%s\n' \
+          "$_secs" "$_pct" "$_tgt" \
+          "$([ "${_rc:-0}" -ne 0 ] && printf '  (rc=%s)' "$_rc" || true)"
+      done
+fi
 
 # --- GUARD 3 (global): collected-test floor ------------------------------------
 # The per-target floors above are the load-bearing check; this total is their

--- a/scripts/tests/test_run_tests_timing.py
+++ b/scripts/tests/test_run_tests_timing.py
@@ -281,7 +281,13 @@ def test_shell_tests_are_in_the_census(tmp_path):
     d = tmp_path / "t_one"
     write_pytest_suite(d, 3)
     script = tmp_path / "a_shell_test.sh"
-    script.write_text("#!/usr/bin/env bash\nexit 0\n")
+    # 🔴 DELIBERATELY NO SHEBANG. `test_no_test_writes_a_usr_bin_env_shebang_at_runtime`
+    # forbids a test writing its own `#!/usr/bin/env …` line, and the first draft
+    # of this fixture did exactly that and failed the gate. A shebang is not
+    # needed anyway: the runner invokes `bash "$SHELL_TEST"` explicitly, so the
+    # file is never executed on its own. Do not "fix" this by adding one back or
+    # by allowlisting it.
+    script.write_text("exit 0\n")
     proc = _run(_runner(tmp_path, [str(d)], shell_tests=[str(script)]))
     s = _summary(proc)
 

--- a/scripts/tests/test_run_tests_timing.py
+++ b/scripts/tests/test_run_tests_timing.py
@@ -1,0 +1,296 @@
+"""Guards for `scripts/run-tests.sh`'s PER-TARGET TIMING CENSUS.
+
+WHY THIS EXISTS
+---------------
+The runner reported COUNTS (``TOTAL collected=… passed=…``) and a VERDICT
+(``RESULT: PASS (exit=0)``) and no durations at all. The only time signal
+anywhere was the Tekton gate's whole-run wall clock against its 45m deadline.
+
+Measured 2026-08-27 over the twelve most recent completed ``devrc-ci`` runs:
+805s-1293s, i.e. 30-48% of that deadline with a 1.6x run-to-run spread, and
+nothing in the output could attribute either the spread or a future overrun to a
+target. The first signal of a target that doubles would be a hard kill at 45m
+carrying no evidence about which one did it.
+
+The per-target shape WAS known -- the xdist header in the runner records
+``scripts/tests`` at 677s of 1194 (57%), browser-bridge 234s, dl-router 126s --
+but hand-measured once, on 2026-08-25, against the SERIAL runner that devrc#841
+then replaced. A number in a comment ages silently; a number the run prints does
+not.
+
+WHAT IS REGRESSION COVERAGE HERE AND WHAT IS NOT
+------------------------------------------------
+Per `claude/RULES.md` ("a guard that pins an invariant the bug never violated is
+an INVARIANT GUARD -- label it as one"):
+
+  * ``test_the_census_prints_a_row_per_target`` is the POSITIVE CONTROL. Every
+    other test here reads content out of this block, so prove it can produce
+    content at all before reading any absence from it.
+
+  * ``test_a_target_that_returns_before_pytest_is_still_counted`` is the one
+    test the WRAPPER DESIGN exists for, and the only one that is red against the
+    obvious implementation. ``run_pytest`` has five terminal paths, three of
+    which return before pytest is invoked. A census that records where the
+    counts are computed misses all three and still looks complete.
+
+  * ``test_a_dropped_record_is_reported_as_incomplete`` is the MUTATION test for
+    the completeness control, run in BOTH arms: it asserts the warning is absent
+    from an unmutated run and present in a mutated one. The absent half is what
+    stops "the warning is in the output" being satisfied by a block that always
+    prints it.
+
+  * ``test_the_census_does_not_change_the_verdict`` is the FAIL-OPEN property,
+    measured rather than asserted, using the same mutation. A census is an
+    observer; an observer that can turn a green run red is worse than none.
+
+  * ``test_shell_tests_are_in_the_census`` is an INVARIANT GUARD. No bug ever
+    omitted them -- the census was written including them. It exists because the
+    block presents itself as an accounting of the run, and a population it
+    silently dropped would make every percentage in it wrong in one direction.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from testlib.runner_patch import (  # noqa: E402
+    patch_runner_source,
+    write_pytest_suite,
+)
+
+RUN_TESTS = REPO_ROOT / "scripts" / "run-tests.sh"
+
+# The exact record line in the pytest wrapper. Mutating it is how the
+# completeness control is exercised; naming it as a constant means a rename in
+# the runner fails the assertion below LOUDLY rather than making the mutation a
+# silent no-op that scores as SURVIVED.
+PYTEST_RECORD = 'TIMINGS+=("$(( $(date +%s) - _t_t0 ))"$\'\\t\'"$_t_rc"$\'\\t\'"$_t_target")'
+
+TIMING_LINE = re.compile(
+    r"^  TIMING accounted=(\d+)s over (\d+) target\(s\)  run=(\d+)s  unaccounted=(-?\d+)s",
+    re.M,
+)
+ROW = re.compile(r"^ {4}\s*(\d+)s\s+(\d+)%\s+(\S+)(  \(rc=(\d+)\))?$", re.M)
+
+
+def _runner(tmp_path: Path, targets: list[str], *, shell_tests: list[str],
+            mutate=None) -> Path:
+    """A patched copy of the runner. `mutate` gets the source and returns it."""
+    src = patch_runner_source(
+        RUN_TESTS.read_text(),
+        targets,
+        {t: 1 for t in targets},
+        shell_tests=shell_tests,
+        hook_tests=[],
+    )
+    if mutate is not None:
+        src = mutate(src)
+    dst = tmp_path / "run-tests.sh"
+    dst.write_text(src)
+    return dst
+
+
+def _run(runner: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(runner), str(REPO_ROOT)],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=900,
+        env={**os.environ, "MIN_TESTS": "1"},
+    )
+
+
+def _summary(proc: subprocess.CompletedProcess) -> str:
+    out = proc.stdout + proc.stderr
+    i = out.find("======================== SUMMARY")
+    assert i >= 0, f"the run never reached its SUMMARY, so there is nothing to read.\n{out[-3000:]}"
+    return out[i:]
+
+
+# --------------------------------------------------------------------------
+# POSITIVE CONTROL
+# --------------------------------------------------------------------------
+
+def test_the_census_prints_a_row_per_target(tmp_path):
+    """Two targets in, two rows out, and the header's own total agrees with them.
+
+    Reading the accounted total back out of the ROWS is the point: a header that
+    printed a number the rows did not sum to would be a self-contradicting
+    census, which is worse than none.
+    """
+    a, b = tmp_path / "t_a", tmp_path / "t_b"
+    write_pytest_suite(a, 3, prefix="test_a")
+    write_pytest_suite(b, 4, prefix="test_b")
+    proc = _run(_runner(tmp_path, [str(a), str(b)], shell_tests=[]))
+    s = _summary(proc)
+
+    m = TIMING_LINE.search(s)
+    assert m, f"no TIMING header -- the census produced nothing to test.\n{s[:2000]}"
+    accounted, n_targets, run, unaccounted = (int(g) for g in m.groups())
+    assert n_targets == 2, f"expected 2 recorded targets, got {n_targets}\n{s[:2000]}"
+
+    rows = ROW.findall(s)
+    assert len(rows) == 2, f"expected 2 ranking rows, got {len(rows)}: {rows}\n{s[:2000]}"
+    assert sum(int(r[0]) for r in rows) == accounted, (
+        "the header's accounted total is not the sum of the rows it printed.\n"
+        f"header={accounted} rows={[r[0] for r in rows]}"
+    )
+    assert {r[2] for r in rows} == {str(a), str(b)}, rows
+    assert unaccounted == run - accounted, (
+        f"unaccounted is not run-accounted: {unaccounted} != {run}-{accounted}"
+    )
+    assert unaccounted >= 0, (
+        "accounted MORE time than the run took, which means the two clocks are "
+        f"not measuring the same thing.\nrun={run} accounted={accounted}"
+    )
+
+
+# --------------------------------------------------------------------------
+# REGRESSION -- the property the wrapper exists for
+# --------------------------------------------------------------------------
+
+def test_a_target_that_returns_before_the_counts_is_still_counted(tmp_path):
+    """A target whose pytest summary is unparseable takes `run_pytest`'s
+    unparseable-summary early return -- BEFORE `TOT_COLLECTED` and friends are
+    touched -- and must still appear in the census.
+
+    This is the whole reason the record is taken by a wrapper. The obvious
+    implementation, recording next to where the counts are accumulated, is GREEN
+    on every other test in this file and RED here.
+
+    🔴 WHY THIS BRANCH AND NOT THE OBVIOUS ONE. The first draft used a MISSING
+    target, which is `run_pytest`'s first early return and reads far better in a
+    test name. It is UNREACHABLE: a precondition block validates the whole
+    hermetic target list and exits 2 with "unusable entr(ies) in the hermetic
+    target list" long before the loop starts, so the run never reaches SUMMARY
+    and the guard under test never executes. That is the "an earlier check
+    always wins so the guard never runs" case in `claude/RULES.md`, and it was
+    caught only by running the test rather than by reading the branch. The
+    unparseable-summary path has no such gatekeeper: the target EXISTS, so the
+    precondition passes, and pytest is what fails.
+
+    A broken `conftest.py` is the forcing function -- pytest aborts during
+    collection and prints no summary line at all.
+    """
+    ok = tmp_path / "t_ok"
+    write_pytest_suite(ok, 3)
+    bad = tmp_path / "t_unparseable"
+    bad.mkdir()
+    (bad / "conftest.py").write_text("raise RuntimeError('conftest explodes on import')\n")
+    (bad / "test_x.py").write_text("def test_x():\n    assert True\n")
+
+    proc = _run(_runner(tmp_path, [str(ok), str(bad)], shell_tests=[]))
+    s = _summary(proc)
+    assert "(unparseable summary)" in s, (
+        "the fixture did not reach the branch this test exists for, so a pass "
+        "here would prove nothing.\n" + s[:2000]
+    )
+
+    m = TIMING_LINE.search(s)
+    assert m, f"no TIMING header.\n{s[:2000]}"
+    assert int(m.group(2)) == 2, (
+        "the target that returned early is MISSING from the census, so the "
+        "ranking is a subset that reads as a total.\n" + s[:2000]
+    )
+    rows = {r[2]: r for r in ROW.findall(s)}
+    assert str(bad) in rows, f"no row for the early-return target.\n{rows}"
+    assert rows[str(bad)][4] == "1", (
+        "the early-return target is recorded with rc=0, so a failed dispatch is "
+        f"indistinguishable from an instant one.\nrow={rows[str(bad)]}"
+    )
+    assert "TIMING ⚠ INCOMPLETE" not in s, (
+        "the completeness control fired on a run where every dispatch DID leave "
+        "a record -- it is counting something other than records.\n" + s[:2000]
+    )
+
+
+# --------------------------------------------------------------------------
+# MUTATION -- both arms
+# --------------------------------------------------------------------------
+
+def _drop_pytest_record(src: str) -> str:
+    assert src.count(PYTEST_RECORD) == 1, (
+        "the pytest wrapper's record line is not where this test thinks it is, "
+        "so the mutation below would be a silent no-op and score as SURVIVED. "
+        "Update PYTEST_RECORD to match the runner."
+    )
+    return src.replace(PYTEST_RECORD, ": # record dropped by the mutation test")
+
+
+def test_a_dropped_record_is_reported_as_incomplete(tmp_path):
+    """Break the record and the census must SAY it is a subset.
+
+    Both arms are asserted. Without the clean arm, "the warning appears" would
+    also be satisfied by a block that prints it unconditionally, which is a
+    control that cannot fail.
+    """
+    d = tmp_path / "t_one"
+    write_pytest_suite(d, 3)
+
+    clean = _summary(_run(_runner(tmp_path, [str(d)], shell_tests=[])))
+    assert "TIMING ⚠ INCOMPLETE" not in clean, (
+        "the incomplete warning is present on an UNMUTATED run, so it says "
+        "nothing about completeness.\n" + clean[:2000]
+    )
+
+    broken_dir = tmp_path / "broken"
+    broken_dir.mkdir()
+    mutated = _summary(_run(_runner(
+        broken_dir, [str(d)], shell_tests=[], mutate=_drop_pytest_record)))
+    assert "TIMING ⚠ INCOMPLETE" in mutated, (
+        "a dispatch left no record and the census still presented itself as "
+        "complete -- the control is inert.\n" + mutated[:2000]
+    )
+    assert "1 dispatch(es) but 0 record(s)" in mutated, (
+        "the warning fired but does not name the mismatch it found.\n" + mutated[:2000]
+    )
+
+
+def test_the_census_does_not_change_the_verdict(tmp_path):
+    """FAIL-OPEN. The same mutation, checked for the property that matters more
+    than the warning: a broken census must not fail a green run."""
+    d = tmp_path / "t_one"
+    write_pytest_suite(d, 3)
+    proc = _run(_runner(tmp_path, [str(d)], shell_tests=[], mutate=_drop_pytest_record))
+    out = proc.stdout + proc.stderr
+    assert "RESULT: PASS (exit=0)" in out, (
+        "a broken TIMING census turned an otherwise-green run red. It is an "
+        f"observer; it may never do this.\nrc={proc.returncode}\n{out[-3000:]}"
+    )
+    assert proc.returncode == 0, f"rc={proc.returncode}\n{out[-3000:]}"
+
+
+# --------------------------------------------------------------------------
+# INVARIANT GUARD
+# --------------------------------------------------------------------------
+
+def test_shell_tests_are_in_the_census(tmp_path):
+    """The census covers the SHELL_TESTS loop too, not just pytest targets.
+
+    Not regression coverage -- it was written this way. It is pinned because the
+    block claims to account for the run: a silently-omitted population would
+    make every percentage a share of the wrong denominator, in the direction
+    that overstates whatever remains.
+    """
+    d = tmp_path / "t_one"
+    write_pytest_suite(d, 3)
+    script = tmp_path / "a_shell_test.sh"
+    script.write_text("#!/usr/bin/env bash\nexit 0\n")
+    proc = _run(_runner(tmp_path, [str(d)], shell_tests=[str(script)]))
+    s = _summary(proc)
+
+    m = TIMING_LINE.search(s)
+    assert m, f"no TIMING header.\n{s[:2000]}"
+    assert int(m.group(2)) == 2, (
+        "the shell test is not in the census, so the accounting excludes a "
+        "population it presents itself as covering.\n" + s[:2000]
+    )
+    assert str(script) in {r[2] for r in ROW.findall(s)}, (
+        "no ranking row for the shell test.\n" + s[:2000]
+    )


### PR DESCRIPTION
`scripts/run-tests.sh` reported counts (`TOTAL collected=… passed=…`) and a verdict (`RESULT: PASS (exit=0)`) and **no durations at all**. The only time signal anywhere was the Tekton gate's whole-run wall clock against its 45m deadline.

Measured over the twelve most recent completed `devrc-ci` runs: **805s–1293s**, i.e. 30–48% of that deadline with a **1.6× run-to-run spread** — and nothing in the output could attribute either the spread or a future overrun to a target. The first signal of a target that doubles would be a hard kill at 45m carrying no evidence about which one did it.

The per-target shape *was* known — the xdist header records `scripts/tests` at 677s of 1194 (57%) — but it was hand-measured once, on 2026-08-25, against the **serial** runner that #841 then replaced.

## What it prints

From the authoritative gate at this commit:

```
  TIMING accounted=527s over 31 target(s)  run=533s  unaccounted=6s (setup + guard evaluation)
       209s     40%  scripts/tests
       143s     27%  scripts/browser-bridge/tests
        99s     19%  scripts/dl-router/tests
        17s      3%  scripts/initiatives/tests
        … 27 more
```

**That is already a finding.** xdist did not scale the targets evenly:

| target | serial | now | speedup |
|---|---|---|---|
| `scripts/tests` | 677s (57%) | **209s (40%)** | 3.2× |
| `scripts/browser-bridge/tests` | 234s | **143s (27%)** | 1.6× |
| `scripts/dl-router/tests` | 126s | **99s (19%)** | 1.3× |

The concentration the xdist comment describes has **flattened**. The biggest target is no longer 57% but 40%, and browser-bridge + dl-router are now **46% between them** — so the next devrc CI lever is those two, not `scripts/tests`. The stale prose is relabelled as the serial shape rather than left reading as current.

## Three design points

1. **The record is taken by a wrapper, not sprinkled through the body.** `run_pytest` has five terminal paths, three of which return before the counts are computed. Recording where the counts are accumulated misses all three and still looks complete — the mistake GUARD 7/8/10 each had to grow a "never accounted" check for. `TIMING_CALLS` remains as a positive control on that claim.
2. **The `SHELL_TESTS` loop is in the census too.** The block presents itself as an accounting of the run; a silently-omitted population would make every percentage wrong in one direction.
3. **`accounted` and `run` are reported separately, with `unaccounted` stated.** Setup and the guard-evaluation blocks sit outside both loops, so target times do not sum to the run (measured: 6s of 533s). Printing only the targets would imply they do.

Fail-open throughout — every read defaults, nothing here can set `fail`, and the census cannot change the verdict. That last one is asserted, not merely intended.

## Tests

`scripts/tests/test_run_tests_timing.py` — five, each labelled per `claude/RULES.md`: a positive control, one **regression** (the wrapper property), a two-armed **mutation** test for the completeness control, a **fail-open** property test, and one **invariant guard** for the shell-test population.

Two defects the tests caught that reading did not:

- **The first version of the regression test targeted an unreachable branch.** It used a *missing* target — the natural early return. A precondition validates the whole target list and exits 2 before the loop starts, so the guard never executes. That is the "an earlier check always wins" case, and only running it revealed it. It now forces the unparseable-summary path with a broken `conftest.py`, and asserts the branch was reached before reading anything from it.
- **The first version of the row loop printed nothing.** It required `accounted > 0` so the percentage could divide — which emits no ranking for any run whose targets each round to 0s, i.e. every fixture-sized run, i.e. exactly the runs its own tests perform.

### Mutation result

Built the naive alternative (record at the counts instead of the wrapper) and ran the suite against it. `test_a_target_that_returns_before_the_counts_is_still_counted` failed with **its own message** — *"MISSING from the census, so the ranking is a subset that reads as a total"* — not a generic red. The other two tests **refused to score**, because the `PYTEST_RECORD` anti-vacuity guard detected its mutation target had moved and said so rather than reporting SURVIVED.

## Deliberately not included

**No time budget or stop-line.** A budget is a gate, not an observer, and a sibling harness elsewhere has its own history of reddening 13 gates the day its envelope guard landed. This census is what makes a later budget settable from data rather than guessed.

## Verified

`nix build .#checks.x86_64-linux.pytests` → `RESULT: PASS (exit=0)`, `TOTAL collected=17634 passed=17632 skipped=2 failed=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9VFYjPYAcY5BuePKFvBw8
