### PR TITLE
feat(audit-pr): check in the two instruments #900 ran only in a scratchpad — and one of its published numbers was the wrong metric

### DIFF
--- a/claude/skills/audit-pr/reference/round-ladder-evidence.md
+++ b/claude/skills/audit-pr/reference/round-ladder-evidence.md
@@ -69,7 +69,10 @@ rounds a walk matches) and rounds *implied* (each session's deepest round summed
 that a ladder reaching round 8 ran eight). Re-run 2026-08-27 with the checked-in instrument: 127
 sessions, **306 observed / 541 implied**, mean deepest 4.26, 39% ≥5 — and that reading includes the
 ten-round ladder this file documents, which is what "the window moves" means in practice. Quote one
-count, name which, and date it.
+count, name which, and date it. 🔴 **That reading was stale within hours of being written** — an
+independent re-run the same day gave 319 observed / 556 implied / mean 4.38, because the corpus
+includes the very session dispatching the ladder this file describes. A figure from this instrument
+is a reading, not a fact about the world.
 
 **Re-derive rather than quote**: `scripts/ladder-depth-sweep.py` is the instrument, it prints both
 counts with the run date, and it REFUSES to report a zero it cannot distinguish from a broken

--- a/claude/skills/audit-pr/reference/round-ladder-evidence.md
+++ b/claude/skills/audit-pr/reference/round-ladder-evidence.md
@@ -58,10 +58,22 @@ Two things this case establishes, and one it does not:
   nothing, so it is not an instance of the waste that retraction denies. Different axis.
 
 Ladder depth across all sessions, measured the same day over `~/.claude/projects/**/*.jsonl`
-(numbered delta re-audit dispatches, `subagents/` excluded): **110 sessions, 440 rounds, 84 of those
-sessions in the preceding 14 days**; mean deepest round 4.0; 34% ran ≥5 rounds; distribution
-3→38, 4→22, 5→21, 6→9, 7→4, 8→2, 10→1. The ladder is a dominant workflow, not an occasional one —
-which is what makes a per-round gate worth its bytes.
+(numbered delta re-audit dispatches, `subagents/` excluded): **110 sessions, 84 of them in the
+preceding 14 days**; mean deepest round 4.0; 34% ran ≥5 rounds; distribution 3→38, 4→22, 5→21, 6→9,
+7→4, 8→2, 10→1. The ladder is a dominant workflow, not an occasional one — which is what makes a
+per-round gate worth its bytes.
+
+🔴 **The "440 rounds" this paragraph used to quote was the SUM OF DEPTHS, and it did not say so.**
+Two different counts are available and they are far apart: rounds *observed* (the distinct numbered
+rounds a walk matches) and rounds *implied* (each session's deepest round summed, on the reasoning
+that a ladder reaching round 8 ran eight). Re-run 2026-08-27 with the checked-in instrument: 127
+sessions, **306 observed / 541 implied**, mean deepest 4.26, 39% ≥5 — and that reading includes the
+ten-round ladder this file documents, which is what "the window moves" means in practice. Quote one
+count, name which, and date it.
+
+**Re-derive rather than quote**: `scripts/ladder-depth-sweep.py` is the instrument, it prints both
+counts with the run date, and it REFUSES to report a zero it cannot distinguish from a broken
+filter — which is what its first version returned, having filtered on the wrong tool name.
 
 ---
 

--- a/scripts/ladder-depth-sweep.py
+++ b/scripts/ladder-depth-sweep.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""How deep do adversarial-audit ladders actually run? — the measurement behind
+the attribution gate in `claude/skills/audit-pr/SKILL.md`.
+
+WHY THIS EXISTS
+---------------
+That skill's stop rule is keyed to FINDINGS, and its attribution gate is keyed
+to whether a round's FIXES changed payload. `scripts/tests/test_audit_ladder_
+stop_rule.py` pins the instructions but says plainly that it cannot observe
+BEHAVIOUR: nothing in the suite proves any session actually stopped. This script
+is the other half — the only thing that can tell you whether the rule changed
+what sessions do.
+
+It answers one question: over the sessions on this host, how deep did numbered
+delta re-audit ladders run? Run it before and after a change to the rule (or on
+two date windows) and compare the distributions.
+
+    scripts/ladder-depth-sweep.py                     # all sessions
+    scripts/ladder-depth-sweep.py --since 2026-08-27  # one window
+    scripts/ladder-depth-sweep.py --detail            # one line per session
+
+🔴 A ZERO HERE IS REFUSED, NOT REPORTED. The first run of this sweep during
+devrc #900 returned a confident **0 sessions** because it filtered on tool name
+`Task` while the harness emits `Agent`. A count of zero is exactly what a
+correct sweep of a quiet host and a sweep wired to nothing both produce, so this
+exits non-zero and says so rather than letting a zero be quoted. Same reason the
+skill it serves says "a failed command is not zero".
+
+🔴 THE WINDOW MOVES. Sessions accumulate, so this is a measurement with a
+timestamp and not a constant — a figure from it read 25 and then 24 two hours
+later during #900, which is why the skill body carries the qualitative claim and
+the reference file carries the dated numbers. The header prints the run date;
+quote it with the date or not at all.
+
+WHAT IT COUNTS
+--------------
+A "round" is a subagent dispatch whose description or prompt names a numbered
+delta re-audit — `Delta re-audit round 4 of PR 900`, `round 3 delta re-audit`,
+and so on. A session's DEPTH is the highest round number it dispatched. First
+audits (unnumbered) are not counted as rounds, so depth 3 means at least four
+audits ran. `subagents/` transcripts are excluded — by
+`scripts/lib/transcript_search.py`, which owns that rule; this script does not
+walk the corpus itself.
+
+Blind spots, so the number is not read wider than it is: a ladder whose rounds
+were never NUMBERED is invisible here, and so is one run by a different runtime.
+Both make this an UNDER-count of ladder work, never an over-count.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from datetime import date
+from pathlib import Path
+
+# 🔴 THE CORPUS WALK IS NOT HAND-ROLLED HERE, and the first version of this
+# script got that wrong. `scripts/lib/transcript_search.py` is the one
+# enumerator, `scripts/tests/test_transcript_search.py` pins the full set of
+# walk sites repo-wide, and a new `**/*.jsonl` walk fails that suite BY DEFAULT
+# -- which is exactly what happened, and is the guard working. Going through the
+# shared lib also inherits two decisions this script would otherwise have had to
+# re-make and could have re-made wrongly: which files are corpus members
+# (`subagents/` excluded), and skipping a MALFORMED LINE rather than the whole
+# file, since a truncated tail is the normal shape of a transcript still being
+# written.
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+import transcript_search as ts  # noqa: E402
+
+# Both spellings, because the tool name is `Agent` in some transcripts and
+# `Task` in others -- filtering on one of them is the bug that produced the
+# refused zero this script now guards against.
+DISPATCH_TOOLS = {"Agent", "Task"}
+
+ROUND = re.compile(
+    r"(?:delta\s+)?re-?audit(?:ing)?[^.\n]{0,40}?round\s*(\d+)"
+    r"|round\s*(\d+)[^.\n]{0,30}(?:delta\s+)?re-?audit",
+    re.I,
+)
+
+
+def dispatch_texts(row: dict) -> list[str]:
+    """Description + prompt of every subagent dispatch in one transcript row."""
+    content = (row.get("message") or {}).get("content")
+    if not isinstance(content, list):
+        return []
+    out = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "tool_use" or block.get("name") not in DISPATCH_TOOLS:
+            continue
+        inp = block.get("input") or {}
+        out.append(f"{inp.get('description', '')} {str(inp.get('prompt', ''))[:400]}")
+    return out
+
+
+def sweep(since: str | None) -> tuple[dict, int]:
+    """-> ({(project, session): {rounds, last_date}}, dispatches_seen)"""
+    sessions: dict[tuple[str, str], dict] = defaultdict(
+        lambda: {"rounds": set(), "date": ""}
+    )
+    dispatches = 0
+    for path in ts.iter_transcripts():
+        key = (path.parent.name, path.stem)
+        for row in ts.load_records(path):
+            stamp = (row.get("timestamp") or "")[:10]
+            if since and stamp and stamp < since:
+                continue
+            for text in dispatch_texts(row):
+                dispatches += 1
+                hit = ROUND.search(text)
+                if not hit:
+                    continue
+                rec = sessions[key]
+                rec["rounds"].add(int(hit.group(1) or hit.group(2)))
+                rec["date"] = max(rec["date"], stamp)
+    return sessions, dispatches
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=(__doc__ or "").split("\n")[0])
+    ap.add_argument("--since", help="only rows on/after this ISO date")
+    ap.add_argument("--detail", action="store_true", help="one line per session")
+    args = ap.parse_args()
+
+    sessions, dispatches = sweep(args.since)
+
+    # 🔴 The positive control. `dispatches` counts EVERY subagent dispatch the
+    # walk saw, matched or not: if that is zero the walk itself found nothing,
+    # which is a broken filter or an empty projects dir -- not a quiet host.
+    if dispatches == 0:
+        print(
+            "🔴 REFUSING TO REPORT: the walk saw ZERO subagent dispatches under\n"
+            f"   {ts.DEFAULT_ROOT}. That is indistinguishable from a wrong tool-name\n"
+            "   filter or a wrong path, so it is not reported as a result.\n"
+            "   Check DISPATCH_TOOLS and the projects directory before trusting\n"
+            "   any number from this script.",
+            file=sys.stderr,
+        )
+        return 2
+
+    ladders = {k: v for k, v in sessions.items() if v["rounds"]}
+    print(f"# ladder-depth sweep — run {date.today().isoformat()}"
+          + (f", window from {args.since}" if args.since else ", all sessions"))
+    print(f"# {dispatches:,} subagent dispatch(es) walked (the positive control)")
+    if not ladders:
+        print("\n0 sessions ran a NUMBERED re-audit ladder in this window.")
+        print("(The walk found dispatches, so this zero is a measurement, not a "
+              "broken filter.)")
+        return 0
+
+    depths = sorted(max(v["rounds"]) for v in ladders.values())
+    observed = sum(len(v["rounds"]) for v in ladders.values())
+    implied = sum(depths)
+    deep = sum(1 for d in depths if d >= 5)
+    # 🔴 TWO ROUND COUNTS, BOTH PRINTED, BECAUSE THEY ARE NOT THE SAME NUMBER
+    # and one of them was published without saying which it was. OBSERVED counts
+    # the distinct numbered rounds this walk actually matched; IMPLIED sums each
+    # session's deepest round, on the reasoning that a ladder that reached round
+    # 8 ran eight of them. Implied is always the larger. Quote one, name it.
+    print(f"\nsessions with a numbered ladder : {len(ladders):,}")
+    print(f"rounds OBSERVED (matched)       : {observed:,}")
+    print(f"rounds IMPLIED (sum of depths)  : {implied:,}")
+    print(f"mean deepest round              : {sum(depths)/len(depths):.2f}")
+    print(f"ran 5 or more rounds            : {deep} ({100*deep/len(depths):.0f}%)")
+    print("\ndepth  sessions")
+    hist: dict[int, int] = defaultdict(int)
+    for d in depths:
+        hist[d] += 1
+    for d in sorted(hist):
+        print(f"{d:>5}  {'#' * hist[d]} {hist[d]}")
+
+    if args.detail:
+        print("\ndate        depth  project / session")
+        for (project, session), rec in sorted(
+            ladders.items(), key=lambda kv: (kv[1]["date"], max(kv[1]["rounds"])),
+            reverse=True,
+        ):
+            proj = project.replace("-home-zach-workspace-", "")
+            print(f"{rec['date']}  {max(rec['rounds']):>5}  {proj} {session[:8]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ladder-depth-sweep.py
+++ b/scripts/ladder-depth-sweep.py
@@ -42,9 +42,19 @@ audits ran. `subagents/` transcripts are excluded — by
 `scripts/lib/transcript_search.py`, which owns that rule; this script does not
 walk the corpus itself.
 
-Blind spots, so the number is not read wider than it is: a ladder whose rounds
-were never NUMBERED is invisible here, and so is one run by a different runtime.
-Both make this an UNDER-count of ladder work, never an over-count.
+Blind spots, so the number is not read wider than it is:
+
+* A ladder whose rounds were never NUMBERED is invisible, and so is one run by a
+  different runtime. Both make this an UNDER-count of ladder work.
+* IMPLIED is an UPPER BOUND. It assumes a ladder that reached round N ran N
+  rounds; where numbering skips (measured: 3 sessions, 8 round-numbers, ~2% of
+  the corpus-wide gap) it over-counts. The rest of that gap is the unnumbered
+  first audit, which is by design.
+* 🔴 COMPARING TWO WINDOWS OF DIFFERENT LENGTH IS BIASED. Depth is computed from
+  in-window rounds only, so a narrower window truncates ladders that started
+  before it and mechanically RAISES mean depth. Measured on one unchanged
+  corpus: 4.38 all-time, 4.42 since 08-01, 4.97 since 08-20, 6.47 since 08-27.
+  Compare equal-length windows, or the artifact reads as an effect.
 """
 from __future__ import annotations
 
@@ -106,10 +116,17 @@ def sweep(since: str | None) -> tuple[dict, int]:
         key = (path.parent.name, path.stem)
         for row in ts.load_records(path):
             stamp = (row.get("timestamp") or "")[:10]
+            texts = dispatch_texts(row)
+            # 🔴 The positive control counts dispatches BEFORE the window filter.
+            # Counting after it made an legitimately EMPTY window exit 2 with
+            # "indistinguishable from a wrong tool-name filter" -- naming a cause
+            # that was not the real one, and making the honest "this zero is a
+            # measurement" branch unreachable for the commonest way to get a
+            # zero.
+            dispatches += len(texts)
             if since and stamp and stamp < since:
                 continue
-            for text in dispatch_texts(row):
-                dispatches += 1
+            for text in texts:
                 hit = ROUND.search(text)
                 if not hit:
                     continue

--- a/scripts/ladder-depth-sweep.py
+++ b/scripts/ladder-depth-sweep.py
@@ -47,9 +47,16 @@ Blind spots, so the number is not read wider than it is:
 * A ladder whose rounds were never NUMBERED is invisible, and so is one run by a
   different runtime. Both make this an UNDER-count of ladder work.
 * IMPLIED is an UPPER BOUND. It assumes a ladder that reached round N ran N
-  rounds; where numbering skips (measured: 3 sessions, 8 round-numbers, ~2% of
-  the corpus-wide gap) it over-counts. The rest of that gap is the unnumbered
-  first audit, which is by design.
+  rounds; where numbering skips it over-counts — measured 2026-08-27: 3 sessions,
+  8 round-numbers, 3.3% of the corpus-wide OBSERVED/IMPLIED gap.
+* 🔴 THE OTHER 97% OF THAT GAP IS NOT THE UNNUMBERED FIRST AUDIT, and an earlier
+  version of this comment said it was. Measured: 231 of 239 missing round-numbers
+  are LEADING absences — 1.79 per session across 129 sessions, and exactly ONE
+  session in the corpus ever dispatched a "round 1". A single unnumbered first
+  audit can account for at most one per session, so most of them are UNNUMBERED
+  DELTA ROUNDS: a real round that was dispatched without a number in its label.
+  That is blind spot #1 above, and it means the true ladder depth is HIGHER than
+  IMPLIED, not lower. Do not read "depth 3" as "exactly four audits ran".
 * 🔴 COMPARING TWO WINDOWS OF DIFFERENT LENGTH IS BIASED. Depth is computed from
   in-window rounds only, so a narrower window truncates ladders that started
   before it and mechanically RAISES mean depth. Measured on one unchanged
@@ -106,19 +113,27 @@ def dispatch_texts(row: dict) -> list[str]:
     return out
 
 
-def sweep(since: str | None) -> tuple[dict, int]:
-    """-> ({(project, session): {rounds, last_date}}, dispatches_seen)"""
+def sweep(since: str | None) -> tuple[dict, int, int]:
+    """-> (sessions, dispatches_corpus_wide, dispatches_in_window)
+
+    The two counts are separate because the first is the POSITIVE CONTROL and
+    must not be narrowed by `--since` (a filtered zero is a measurement, not a
+    broken filter), while the second is what a reader comparing two windows
+    actually wants. Printing only the first under a window label was off by 21x
+    on one measured pair.
+    """
     sessions: dict[tuple[str, str], dict] = defaultdict(
         lambda: {"rounds": set(), "date": ""}
     )
     dispatches = 0
+    in_window = 0
     for path in ts.iter_transcripts():
         key = (path.parent.name, path.stem)
         for row in ts.load_records(path):
             stamp = (row.get("timestamp") or "")[:10]
             texts = dispatch_texts(row)
             # 🔴 The positive control counts dispatches BEFORE the window filter.
-            # Counting after it made an legitimately EMPTY window exit 2 with
+            # Counting after it made a legitimately EMPTY window exit 2 with
             # "indistinguishable from a wrong tool-name filter" -- naming a cause
             # that was not the real one, and making the honest "this zero is a
             # measurement" branch unreachable for the commonest way to get a
@@ -126,6 +141,7 @@ def sweep(since: str | None) -> tuple[dict, int]:
             dispatches += len(texts)
             if since and stamp and stamp < since:
                 continue
+            in_window += len(texts)
             for text in texts:
                 hit = ROUND.search(text)
                 if not hit:
@@ -133,7 +149,7 @@ def sweep(since: str | None) -> tuple[dict, int]:
                 rec = sessions[key]
                 rec["rounds"].add(int(hit.group(1) or hit.group(2)))
                 rec["date"] = max(rec["date"], stamp)
-    return sessions, dispatches
+    return sessions, dispatches, in_window
 
 
 def main() -> int:
@@ -142,7 +158,7 @@ def main() -> int:
     ap.add_argument("--detail", action="store_true", help="one line per session")
     args = ap.parse_args()
 
-    sessions, dispatches = sweep(args.since)
+    sessions, dispatches, in_window = sweep(args.since)
 
     # 🔴 The positive control. `dispatches` counts EVERY subagent dispatch the
     # walk saw, matched or not: if that is zero the walk itself found nothing,
@@ -161,7 +177,8 @@ def main() -> int:
     ladders = {k: v for k, v in sessions.items() if v["rounds"]}
     print(f"# ladder-depth sweep — run {date.today().isoformat()}"
           + (f", window from {args.since}" if args.since else ", all sessions"))
-    print(f"# {dispatches:,} subagent dispatch(es) walked (the positive control)")
+    print(f"# {dispatches:,} dispatch(es) walked corpus-wide (the positive "
+          f"control) · {in_window:,} inside the window")
     if not ladders:
         print("\n0 sessions ran a NUMBERED re-audit ladder in this window.")
         print("(The walk found dispatches, so this zero is a measurement, not a "

--- a/scripts/ladder-depth-sweep.py
+++ b/scripts/ladder-depth-sweep.py
@@ -49,14 +49,16 @@ Blind spots, so the number is not read wider than it is:
 * IMPLIED is an UPPER BOUND. It assumes a ladder that reached round N ran N
   rounds; where numbering skips it over-counts — measured 2026-08-27: 3 sessions,
   8 round-numbers, 3.3% of the corpus-wide OBSERVED/IMPLIED gap.
-* 🔴 THE OTHER 97% OF THAT GAP IS NOT THE UNNUMBERED FIRST AUDIT, and an earlier
-  version of this comment said it was. Measured: 231 of 239 missing round-numbers
-  are LEADING absences — 1.79 per session across 129 sessions, and exactly ONE
-  session in the corpus ever dispatched a "round 1". A single unnumbered first
-  audit can account for at most one per session, so most of them are UNNUMBERED
-  DELTA ROUNDS: a real round that was dispatched without a number in its label.
-  That is blind spot #1 above, and it means the true ladder depth is HIGHER than
-  IMPLIED, not lower. Do not read "depth 3" as "exactly four audits ran".
+* 🔴 MUCH OF THE REST IS NOT THE UNNUMBERED FIRST AUDIT EITHER, though an
+  earlier version of this comment said all of it was. Measured 2026-08-27: 231 of
+  239 missing round-numbers are LEADING absences, 128 sessions have a minimum
+  round of 2 or more, and exactly ONE session in the corpus ever dispatched a
+  "round 1". One unnumbered first audit accounts for at most one missing number
+  per session, so **at least 103 of the 231 (45%)** must be UNNUMBERED DELTA
+  ROUNDS — real rounds dispatched without a number in the label. 45% is the floor
+  the measurement supports, not a share; an earlier "97% / most" over-stated it.
+  Either way it is blind spot #1 above, and it means true ladder depth is HIGHER
+  than IMPLIED, not lower. Do not read "depth 3" as "exactly four audits ran".
 * 🔴 COMPARING TWO WINDOWS OF DIFFERENT LENGTH IS BIASED. Depth is computed from
   in-window rounds only, so a narrower window truncates ladders that started
   before it and mechanically RAISES mean depth. Measured on one unchanged

--- a/scripts/tests/mutants-audit-ladder.sh
+++ b/scripts/tests/mutants-audit-ladder.sh
@@ -185,18 +185,29 @@ run_move() { # run_move <name> <expect> <file> <python-expr>
     printf '  🔴 %-46s SURVIVED — no test failed\n' "$name"
     FAILURES=$((FAILURES+1)); return
   fi
-  # 🔴 EXCLUSIVE, not "among". These rows exist to show that ONE assertion --
-  # the relationship one -- executes; the docstring quotes them as "relationship
-  # pin ONLY". `grep -qx` would print ok for a mutant killed by the named test
-  # AND a neighbour, which is precisely the day the claim stops being true.
-  # Measured: with a co-failing test added to the module, the `among` form
-  # printed ok and the sweep still said "all as expected".
-  if [ "$killers" = "$want" ]; then
-    printf '  ok %-46s killed by %s ALONE\n' "$name" "$want"; return
+  # 🔴 EXCLUSIVE, not "among" -- but in TWO steps, because one comparison
+  # collapses two states that need opposite responses. These rows exist to show
+  # that ONE assertion (the relationship one) executes; the docstring quotes
+  # them as "relationship pin ONLY".
+  #   * named test ABSENT      -> WRONG-KILLER: your relationship pin is DEAD,
+  #                               something else killed the mutant.
+  #   * named test PLUS others -> NOT EXCLUSIVE: the pin fired, but the probe no
+  #                               longer isolates it; re-scope the mutant.
+  # A single equality test reports the first as the second, which routes the
+  # operator away from the exact failure these rows exist to catch. Measured:
+  # `grep -qx` alone printed ok for named-plus-neighbour (the round-2 bug);
+  # equality alone printed NOT EXCLUSIVE for named-absent (the round-3 bug).
+  if ! grep -qx "$want" <<<"$killers"; then
+    printf '  🔴 %-46s WRONG-KILLER: %s (wanted %s)\n' \
+      "$name" "$(tr '\n' ',' <<<"$killers" | sed 's/,$//')" "$want"
+    FAILURES=$((FAILURES+1)); return
   fi
-  printf '  🔴 %-46s NOT EXCLUSIVE: %s (wanted %s alone)\n' \
-    "$name" "$(tr '\n' ',' <<<"$killers")" "$want"
-  FAILURES=$((FAILURES+1))
+  if [ "$killers" != "$want" ]; then
+    printf '  🔴 %-46s NOT EXCLUSIVE: %s (wanted %s alone)\n' \
+      "$name" "$(tr '\n' ',' <<<"$killers" | sed 's/,$//')" "$want"
+    FAILURES=$((FAILURES+1)); return
+  fi
+  printf '  ok %-46s killed by %s ALONE\n' "$name" "$want"
 }
 
 run() { # run <name> <expect: test node name | SURVIVES> <file> <old> <new>
@@ -235,7 +246,7 @@ run() { # run <name> <expect: test node name | SURVIVES> <file> <old> <new>
     return
   fi
   printf '  🔴 %-46s WRONG-KILLER: %s (wanted %s)\n' \
-    "$name" "$(tr '\n' ',' <<<"$killers")" "$want"
+    "$name" "$(tr '\n' ',' <<<"$killers" | sed 's/,$//')" "$want"
   FAILURES=$((FAILURES+1))
 }
 

--- a/scripts/tests/mutants-audit-ladder.sh
+++ b/scripts/tests/mutants-audit-ladder.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# Mutation battery for the audit-ladder PROSE guards —
+# `claude/skills/audit-pr/SKILL.md`, its `reference/round-ladder-evidence.md`,
+# and the pins in `scripts/tests/test_audit_ladder_stop_rule.py`.
+#
+# Not run by CI. An author/reviewer instrument, kept IN THE TREE so
+# "mutation-verified" can be RE-DERIVED instead of believed.
+#
+#   bash scripts/tests/mutants-audit-ladder.sh          # exit 0 only if ALL ok
+#
+# 🔴 IT EXISTS BECAUSE THE SWEEPS IT REPLACES WERE NOT COMMITTED. devrc #900 ran
+# ten audit rounds and recorded ~30 mutants in the module's docstring; every one
+# of those runs happened in a session scratchpad that no longer exists, so not a
+# single row could be re-checked by anyone else — including the rows that
+# justified adding a pin. `mutants-claim-work.sh` had already recorded exactly
+# that lesson for a different file. This follows its conventions.
+#
+# 🔴 THE ARTIFACT UNDER MUTATION IS PROSE, so the mutants are rewordings and
+# deletions rather than operator swaps. That is the point: `claude/RULES.md`
+# says a guard on WORDS is walkable by REWORDING, and each row below is a
+# rewording that a reader would accept and that must nevertheless go red.
+#
+# 🔴 IT NEVER TOUCHES YOUR WORKING TREE. Everything is mutated inside a
+# `mktemp -d` copy, and the copy is asserted to carry no `.git` — a `cp -a` of a
+# worktree would carry its `.git` POINTER FILE and a git command inside the copy
+# would then act on the real repository. (That hazard is one of the things the
+# skill under test now warns about.)
+#
+# 🔴 EACH MUTANT NAMES THE TEST THAT MUST KILL IT. "A test failed" is not
+# enough: these pins overlap by design — the same sentence can be covered by a
+# whole-block constant and by a narrower one — so a mutant can die to a
+# DIFFERENT test's error and be scored as covered while its own assertion is
+# unreachable. A mutant killed only by some other test reports 🔴 WRONG-KILLER.
+#
+# 🔴 EACH MUTATION IS COMPARED AGAINST THE ORIGINAL BEFORE IT RUNS. A target
+# string that no longer matches — line re-wrapped, a word changed — would leave
+# the file UNMUTATED and report "the guard held", the most flattering possible
+# wrong answer. That is not hypothetical here: during #900 five mutants silently
+# failed to apply for exactly that reason across three rounds, and were caught
+# only because the driver asserted first.
+#
+# 🔴 TWO CONTROLS, BOTH MANDATORY:
+#   * the unmutated BASELINE must be green (else every row is meaningless);
+#   * two SURVIVES rows — a re-wrap of a pinned sentence and an edit to prose
+#     nobody pinned — which must kill NOTHING. `_norm` collapses whitespace on
+#     purpose, so a re-wrap that goes red would mean the pins are keyed to line
+#     breaks rather than to words.
+#
+# 🔴 PYTHONDONTWRITEBYTECODE=1: a stale `.pyc` keyed on mtime-in-whole-seconds
+# plus size is how a same-length edit gets scored SURVIVED without executing.
+#
+# COVERAGE IS DELIBERATELY PARTIAL, AND HERE IS WHAT IS NOT COVERED. The rows
+# below are the ones whose SURVIVAL was measured during #900 — i.e. each was
+# green until a pin was added for it. Rows that only ever confirmed an existing
+# pin (the M-series against `claude/RULES.md`, the evidence-file truncation
+# ladder) are not repeated here; run them from the module's docstring matrix if
+# you are changing those guards.
+set -uo pipefail
+CDPATH=
+D="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+SRC="$(cd "$D/../.." && pwd)"
+
+T="$(mktemp -d /tmp/audit-ladder-mut-XXXXXX)"
+trap 'rm -rf "$T"' EXIT
+ROOT="$T/tree"
+
+mkdir -p "$ROOT/scripts/tests" \
+         "$ROOT/claude/skills/audit-pr/reference"
+cp -a "$SRC/scripts/tests/test_audit_ladder_stop_rule.py" "$ROOT/scripts/tests/"
+cp -a "$SRC/claude/RULES.md"          "$ROOT/claude/"
+cp -a "$SRC/claude/RULES-ARCHIVE.md"  "$ROOT/claude/"
+cp -a "$SRC/claude/skills/audit-pr/SKILL.md" "$ROOT/claude/skills/audit-pr/"
+cp -a "$SRC/claude/skills/audit-pr/reference/round-ladder-evidence.md" \
+      "$ROOT/claude/skills/audit-pr/reference/"
+
+if [ -e "$ROOT/.git" ]; then
+  echo "🔴 the copy carries a .git — refusing to run"; exit 2
+fi
+find "$ROOT" -name __pycache__ -type d -prune -exec rm -rf {} + 2>/dev/null
+
+SUITE="$ROOT/scripts/tests/test_audit_ladder_stop_rule.py"
+SKILL="$ROOT/claude/skills/audit-pr/SKILL.md"
+EVID="$ROOT/claude/skills/audit-pr/reference/round-ladder-evidence.md"
+cp -a "$SKILL" "$T/skill.orig"
+cp -a "$EVID"  "$T/evid.orig"
+restore() { cp -a "$T/skill.orig" "$SKILL"; cp -a "$T/evid.orig" "$EVID"; }
+
+FAILURES=0
+ROWS=0
+
+# 🔴 Read the CONTENT, never an exit code. A suite that never ran yields zero
+# FAILED lines — i.e. "clean" — so a harness wired to nothing would score every
+# mutant SURVIVED and every control ok. The floor catches COLLAPSE, not growth.
+MIN_TESTS=8
+failing() {
+  local out n f total
+  out="$(cd "$ROOT" && PYTHONDONTWRITEBYTECODE=1 python3 -m pytest "$SUITE" \
+    -q --no-header --tb=no -p no:cacheprovider 2>/dev/null)"
+  n="$(sed -n 's/^\([0-9]*\) passed.*/\1/p;s/^[0-9]* failed, \([0-9]*\) passed.*/\1/p' <<<"$out" | tail -1)"
+  f="$(sed -n 's/^\([0-9]*\) failed.*/\1/p' <<<"$out" | tail -1)"
+  total=$(( ${n:-0} + ${f:-0} ))
+  if [ "$total" -lt "$MIN_TESTS" ]; then
+    echo "__HARNESS_BROKE__ only $total test(s) ran (floor $MIN_TESTS)"
+    return
+  fi
+  sed -n 's/^FAILED [^:]*::\([A-Za-z0-9_]*\).*/\1/p' <<<"$out" | sort -u
+}
+
+# apply <file> <old-literal> <new-literal> — literal, multi-line safe, and it
+# refuses rather than no-ops when the target is absent.
+apply() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import pathlib, sys
+p = pathlib.Path(sys.argv[1]); t = p.read_text()
+old, new = sys.argv[2], sys.argv[3]
+if old not in t:
+    sys.exit(3)
+p.write_text(t.replace(old, new, 1))
+PY
+}
+
+run() { # run <name> <expect: test node name | SURVIVES> <file> <old> <new>
+  local name="$1" want="$2" file="$3" old="$4" new="$5"
+  ROWS=$((ROWS+1))
+  if ! apply "$file" "$old" "$new"; then
+    printf '  🔴 %-46s MUTATION DID NOT APPLY — result meaningless\n' "$name"
+    FAILURES=$((FAILURES+1)); restore; return
+  fi
+  local killers; killers="$(failing)"
+  restore
+  if grep -q __HARNESS_BROKE__ <<<"$killers"; then
+    printf '  🔴 %-46s HARNESS BROKE — %s\n' "$name" "$killers"
+    FAILURES=$((FAILURES+1)); return
+  fi
+  if [ "$want" = SURVIVES ]; then
+    if [ -z "$killers" ]; then
+      printf '  ok %-46s SURVIVED as required (control)\n' "$name"; return
+    fi
+    printf '  🔴 %-46s CONTROL KILLED by %s — keyed on text, not words\n' \
+      "$name" "$(tr '\n' ',' <<<"$killers")"; FAILURES=$((FAILURES+1)); return
+  fi
+  if [ -z "$killers" ]; then
+    printf '  🔴 %-46s SURVIVED — no test failed\n' "$name"
+    FAILURES=$((FAILURES+1)); return
+  fi
+  if grep -qx "$want" <<<"$killers"; then
+    printf '  ok %-46s killed by %s\n' "$name" "$want"; return
+  fi
+  printf '  🔴 %-46s WRONG-KILLER: %s (wanted %s)\n' \
+    "$name" "$(tr '\n' ',' <<<"$killers")" "$want"
+  FAILURES=$((FAILURES+1))
+}
+
+echo "== baseline =="
+base="$(failing)"
+if [ -n "$base" ]; then
+  echo "  🔴 the UNMUTATED tree is already failing: $(tr '\n' ',' <<<"$base")"
+  echo "     every row below would be meaningless. Fix that first."
+  exit 2
+fi
+echo "  ok unmutated tree is green"
+
+echo
+echo "== the gate's MECHANISM =="
+run "gate command -> echo 0" \
+    test_the_gate_pins_its_MECHANISM_not_only_its_decision "$SKILL" \
+    'git log --numstat --format= --remerge-diff <the sha you audited THAT round>..HEAD --not <base>' \
+    'echo 0'
+run "range reverted to the cumulative two-dot" \
+    test_the_gate_pins_its_MECHANISM_not_only_its_decision "$SKILL" \
+    'git log --numstat --format= --remerge-diff <the sha you audited THAT round>..HEAD --not <base>' \
+    'git diff --numstat <first-audited-sha>..HEAD'
+run "classifier method -> just use the pathspec" \
+    test_the_gate_pins_its_MECHANISM_not_only_its_decision "$SKILL" \
+    'read the list and name each one
+payload or scaffolding' \
+    'just run the pathspec and trust it'
+run "fail-safe inverted (ambiguous counts as zero)" \
+    test_the_gate_pins_its_MECHANISM_not_only_its_decision "$SKILL" \
+    '**Ambiguous is not zero**: the gate does not fire, and the ladder continues.' \
+    '**Ambiguous counts as zero**: the gate fires, and the ladder stops.'
+run "decision reworded TWO -> THREE" \
+    test_the_attribution_gate_is_stated_with_its_not_a_cap_qualifier "$SKILL" \
+    '**Two consecutive rounds whose fixes' \
+    '**Three consecutive rounds whose fixes'
+
+echo
+echo "== what an operator ACTS on =="
+run "'rollback' shaved out of the Gaps item" \
+    test_the_operator_instructions_the_gate_depends_on_are_pinned "$SKILL" \
+    'migrations, rollback.' 'migrations.'
+run "whole 9-item checklist gutted" \
+    test_the_operator_instructions_the_gate_depends_on_are_pinned "$SKILL" \
+    '**Audit for:**' '**Audit for:** whatever seems off. ORIGINAL FOLLOWS:'
+run "cp -a .git hazard deleted" \
+    test_the_operator_instructions_the_gate_depends_on_are_pinned "$SKILL" \
+    ' — **`rm -f <copy>/.git` first**, since a worktree'"'"'s is a FILE pointing at the
+real git dir, so a commit in the copy lands on your branch —' ','
+run "cross-repo worktree caveat inverted" \
+    test_the_operator_instructions_the_gate_depends_on_are_pinned "$SKILL" \
+    '🔴 `isolation:
+  "worktree"` worktrees the **cwd'"'"'s** repo, not the PR'"'"'s' \
+    'Use `isolation: "worktree"` for any repo'
+run "stderr-capture rule inverted" \
+    test_the_operator_instructions_the_gate_depends_on_are_pinned "$SKILL" \
+    'Keep stderr on the terminal — folding it into the sum with
+`2>&1` makes the one loud failure invisible.' \
+    'Fold stderr into the sum with `2>&1` so no failure escapes the count.'
+
+echo
+echo "== the EVIDENCE the rules rest on =="
+run "shape-A row inverted (argues for the banned flag)" \
+    test_the_attribution_measurement_survives_where_the_skill_routes_to_it "$EVID" \
+    '| 1 line, and it is a TEST ⇒ 0 payload | **201** | 1 | 1 |' \
+    '| 1 line, and it is a TEST ⇒ 0 payload | 1 | 1 | **201** |'
+run "shape-B/C lesson tail inverted" \
+    test_the_attribution_measurement_survives_where_the_skill_routes_to_it "$EVID" \
+    '`git show --numstat <merge>` is not the remedy either' \
+    '`git show --numstat <merge>` is the remedy'
+run "churn row reverted to the stale 1,002" \
+    test_the_attribution_measurement_survives_where_the_skill_routes_to_it "$EVID" \
+    '**1,051**' '**1,002**'
+
+echo
+echo "== controls (must kill NOTHING) =="
+run "re-wrap a pinned sentence across new line breaks" SURVIVES "$SKILL" \
+    'Rounds continue **only** while the previous round produced a finding that required a fix. The first' \
+    'Rounds continue **only** while the previous round
+produced a finding that required a fix. The first'
+run "edit prose nobody pinned" SURVIVES "$SKILL" \
+    '## What to do' '## What to do (read this first)'
+
+echo
+if [ "$FAILURES" -eq 0 ]; then
+  echo "✅ $ROWS row(s), all as expected"
+  exit 0
+fi
+echo "🔴 $FAILURES of $ROWS row(s) not as expected"
+exit 1

--- a/scripts/tests/mutants-audit-ladder.sh
+++ b/scripts/tests/mutants-audit-ladder.sh
@@ -6,7 +6,11 @@
 # Not run by CI. An author/reviewer instrument, kept IN THE TREE so
 # "mutation-verified" can be RE-DERIVED instead of believed.
 #
-#   bash scripts/tests/mutants-audit-ladder.sh          # exit 0 only if ALL ok
+#   nix develop ~/workspace/devrc -c bash scripts/tests/mutants-audit-ladder.sh
+#
+#   (a bare `bash …` works only where pytest is already on PATH; this host's
+#   `.envrc` is `use opencode`, which does not put it there.) Exit 0 only if
+#   every row is as expected.
 #
 # 🔴 IT EXISTS BECAUSE THE SWEEPS IT REPLACES WERE NOT COMMITTED. devrc #900 ran
 # ten audit rounds and recorded ~30 mutants in the module's docstring; every one
@@ -21,10 +25,14 @@
 # rewording that a reader would accept and that must nevertheless go red.
 #
 # 🔴 IT NEVER TOUCHES YOUR WORKING TREE. Everything is mutated inside a
-# `mktemp -d` copy, and the copy is asserted to carry no `.git` — a `cp -a` of a
-# worktree would carry its `.git` POINTER FILE and a git command inside the copy
-# would then act on the real repository. (That hazard is one of the things the
-# skill under test now warns about.)
+# `mktemp -d` copy built by naming FIVE INDIVIDUAL FILES — that selective copy,
+# not the assertion below it, is what keeps a `.git` out. The assertion is an
+# INVARIANT GUARD and is labelled as one rather than counted as coverage: it
+# cannot fire today and has never been watched to. It earns its two lines only
+# against the future refactor that replaces the file list with `cp -a "$SRC"`,
+# which would carry a worktree's `.git` POINTER FILE and let a git command
+# inside the copy act on the real repository — a hazard the skill under test
+# now warns about, and the reason to leave a tripwire on the road not taken.
 #
 # 🔴 EACH MUTANT NAMES THE TEST THAT MUST KILL IT. "A test failed" is not
 # enough: these pins overlap by design — the same sentence can be covered by a
@@ -81,9 +89,15 @@ find "$ROOT" -name __pycache__ -type d -prune -exec rm -rf {} + 2>/dev/null
 SUITE="$ROOT/scripts/tests/test_audit_ladder_stop_rule.py"
 SKILL="$ROOT/claude/skills/audit-pr/SKILL.md"
 EVID="$ROOT/claude/skills/audit-pr/reference/round-ladder-evidence.md"
+RULES="$ROOT/claude/RULES.md"
 cp -a "$SKILL" "$T/skill.orig"
 cp -a "$EVID"  "$T/evid.orig"
-restore() { cp -a "$T/skill.orig" "$SKILL"; cp -a "$T/evid.orig" "$EVID"; }
+cp -a "$RULES" "$T/rules.orig"
+restore() {
+  cp -a "$T/skill.orig" "$SKILL"
+  cp -a "$T/evid.orig"  "$EVID"
+  cp -a "$T/rules.orig" "$RULES"
+}
 
 FAILURES=0
 ROWS=0
@@ -91,11 +105,22 @@ ROWS=0
 # 🔴 Read the CONTENT, never an exit code. A suite that never ran yields zero
 # FAILED lines — i.e. "clean" — so a harness wired to nothing would score every
 # mutant SURVIVED and every control ok. The floor catches COLLAPSE, not growth.
-MIN_TESTS=8
+# `run-tests.sh`'s convention for a floor is `m - min(50, max(1, m/20))`; at
+# m=11 that is 10. Catches COLLAPSE, not growth.
+MIN_TESTS=10
 failing() {
   local out n f total
+  # stderr is CAPTURED, not discarded: the commonest way to get "0 tests ran" on
+  # this host is running outside `nix develop` (`.envrc` is `use opencode`, so a
+  # loaded direnv has no pytest), and discarding stderr turns that one-line
+  # diagnosis into a headline that blames the TREE. Checked before the count.
   out="$(cd "$ROOT" && PYTHONDONTWRITEBYTECODE=1 python3 -m pytest "$SUITE" \
-    -q --no-header --tb=no -p no:cacheprovider 2>/dev/null)"
+    -q --no-header --tb=no -p no:cacheprovider 2>&1)"
+  if grep -q "No module named pytest" <<<"$out"; then
+    echo "__HARNESS_BROKE__ pytest is not on PATH — run this under" \
+         "\`nix develop ~/workspace/devrc -c bash \$0\`, not a bare shell"
+    return
+  fi
   n="$(sed -n 's/^\([0-9]*\) passed.*/\1/p;s/^[0-9]* failed, \([0-9]*\) passed.*/\1/p' <<<"$out" | tail -1)"
   f="$(sed -n 's/^\([0-9]*\) failed.*/\1/p' <<<"$out" | tail -1)"
   total=$(( ${n:-0} + ${f:-0} ))
@@ -117,6 +142,46 @@ if old not in t:
     sys.exit(3)
 p.write_text(t.replace(old, new, 1))
 PY
+}
+
+# move <file> <python-expr-on-t> — for mutants that RELOCATE a block with its
+# text byte-identical. Those are the reachability controls: every whole-string
+# pin stays green, so only an assertion that actually EXECUTES can see them.
+move() {
+  python3 - "$1" "$2" <<'PYEOF'
+import pathlib, sys
+p = pathlib.Path(sys.argv[1]); t = p.read_text()
+ns = {"t": t}
+exec("out = " + sys.argv[2], ns)          # noqa: S102 — harness, not product
+if ns["out"] == t:
+    sys.exit(3)
+p.write_text(ns["out"])
+PYEOF
+}
+
+run_move() { # run_move <name> <expect> <file> <python-expr>
+  local name="$1" want="$2" file="$3" expr="$4"
+  ROWS=$((ROWS+1))
+  if ! move "$file" "$expr"; then
+    printf '  🔴 %-46s MUTATION DID NOT APPLY — result meaningless\n' "$name"
+    FAILURES=$((FAILURES+1)); restore; return
+  fi
+  local killers; killers="$(failing)"
+  restore
+  if grep -q __HARNESS_BROKE__ <<<"$killers"; then
+    printf '  🔴 %-46s HARNESS BROKE — %s\n' "$name" "$killers"
+    FAILURES=$((FAILURES+1)); return
+  fi
+  if [ -z "$killers" ]; then
+    printf '  🔴 %-46s SURVIVED — no test failed\n' "$name"
+    FAILURES=$((FAILURES+1)); return
+  fi
+  if grep -qx "$want" <<<"$killers"; then
+    printf '  ok %-46s killed by %s\n' "$name" "$want"; return
+  fi
+  printf '  🔴 %-46s WRONG-KILLER: %s (wanted %s)\n' \
+    "$name" "$(tr '\n' ',' <<<"$killers")" "$want"
+  FAILURES=$((FAILURES+1))
 }
 
 run() { # run <name> <expect: test node name | SURVIVES> <file> <old> <new>
@@ -153,6 +218,14 @@ run() { # run <name> <expect: test node name | SURVIVES> <file> <old> <new>
 
 echo "== baseline =="
 base="$(failing)"
+if grep -q __HARNESS_BROKE__ <<<"$base"; then
+  # Not the tree's fault — say which, because the previous version printed
+  # "the UNMUTATED tree is already failing" at somebody whose only mistake was
+  # the shell they ran in.
+  echo "  🔴 THE HARNESS could not run: ${base#__HARNESS_BROKE__ }"
+  echo "     Nothing was measured. This says nothing about the tree."
+  exit 2
+fi
 if [ -n "$base" ]; then
   echo "  🔴 the UNMUTATED tree is already failing: $(tr '\n' ',' <<<"$base")"
   echo "     every row below would be meaningless. Fix that first."
@@ -220,6 +293,19 @@ run "shape-B/C lesson tail inverted" \
 run "churn row reverted to the stale 1,002" \
     test_the_attribution_measurement_survives_where_the_skill_routes_to_it "$EVID" \
     '**1,051**' '**1,002**'
+
+echo
+echo "== REACHABILITY: relocations that leave every string pin byte-identical =="
+# 🔴 These two are the rows the module's docstring marks as the reachability
+# controls, and they were the gap this harness shipped with: without them the
+# two RELATIONSHIP assertions -- the ones that check WHERE a rule sits, not that
+# its words exist -- had no re-derivable evidence that they execute at all.
+run_move "stop clause moved to its OWN bullet in RULES.md" \
+    test_the_stop_rule_shares_a_bullet_with_the_rule_it_bounds "$RULES" \
+    't.replace("🔴 **A CLEAN round ENDS the ladder", "\n- 🔴 **A CLEAN round ENDS the ladder", 1)'
+run_move "ATTRIBUTION section moved ABOVE the stop rule" \
+    test_the_attribution_gate_comes_after_the_rule_it_bounds "$SKILL" \
+    't[:t.index("### 🔴 A clean round ENDS the ladder.")] + t[t.index("### 🔴 ATTRIBUTION: a round that changes no PAYLOAD"):t.index("## Mutation testing:")] + t[t.index("### 🔴 A clean round ENDS the ladder."):t.index("### 🔴 ATTRIBUTION: a round that changes no PAYLOAD")] + t[t.index("## Mutation testing:"):]'
 
 echo
 echo "== controls (must kill NOTHING) =="

--- a/scripts/tests/mutants-audit-ladder.sh
+++ b/scripts/tests/mutants-audit-ladder.sh
@@ -57,12 +57,19 @@
 # 🔴 PYTHONDONTWRITEBYTECODE=1: a stale `.pyc` keyed on mtime-in-whole-seconds
 # plus size is how a same-length edit gets scored SURVIVED without executing.
 #
-# COVERAGE IS DELIBERATELY PARTIAL, AND HERE IS WHAT IS NOT COVERED. The rows
-# below are the ones whose SURVIVAL was measured during #900 — i.e. each was
-# green until a pin was added for it. Rows that only ever confirmed an existing
-# pin (the M-series against `claude/RULES.md`, the evidence-file truncation
-# ladder) are not repeated here; run them from the module's docstring matrix if
-# you are changing those guards.
+# COVERAGE IS DELIBERATELY PARTIAL, AND HERE IS WHAT IS NOT COVERED. Two kinds
+# of row are here: the ones whose SURVIVAL was measured during #900 — each green
+# until a pin was added for it — and the two RELOCATIONS at the end, which never
+# survived anything and are here for the opposite reason: they are the only rows
+# that can show the RELATIONSHIP assertions execute at all, since a relocation
+# leaves every whole-string pin byte-identical. (An earlier version of this
+# paragraph excluded "the M-series against `claude/RULES.md`" by name while the
+# harness ran M4 two hundred lines below. Fixed; the rows are the authority.)
+#
+# NOT here: rows that only ever CONFIRMED an existing pin, and the evidence-file
+# truncation ladder. Run those from the module's docstring matrix if you are
+# changing those guards. This list is the executable one — count it here rather
+# than trusting a total written anywhere else, including in that docstring.
 set -uo pipefail
 CDPATH=
 D="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
@@ -105,8 +112,9 @@ ROWS=0
 # 🔴 Read the CONTENT, never an exit code. A suite that never ran yields zero
 # FAILED lines — i.e. "clean" — so a harness wired to nothing would score every
 # mutant SURVIVED and every control ok. The floor catches COLLAPSE, not growth.
-# `run-tests.sh`'s convention for a floor is `m - min(50, max(1, m/20))`; at
-# m=11 that is 10. Catches COLLAPSE, not growth.
+# `run-tests.sh`'s own floor formula is `m - min(50, max(1, m/20))`; at m=11
+# that is 10. It catches COLLAPSE, not growth — losing one test still clears it,
+# losing two reports HARNESS BROKE.
 MIN_TESTS=10
 failing() {
   local out n f total
@@ -117,8 +125,9 @@ failing() {
   out="$(cd "$ROOT" && PYTHONDONTWRITEBYTECODE=1 python3 -m pytest "$SUITE" \
     -q --no-header --tb=no -p no:cacheprovider 2>&1)"
   if grep -q "No module named pytest" <<<"$out"; then
-    echo "__HARNESS_BROKE__ pytest is not on PATH — run this under" \
-         "\`nix develop ~/workspace/devrc -c bash \$0\`, not a bare shell"
+    echo "__HARNESS_BROKE__ pytest is not on PATH — run it as" \
+         "\`nix develop ~/workspace/devrc -c bash" \
+         "scripts/tests/mutants-audit-ladder.sh\`, not in a bare shell"
     return
   fi
   n="$(sed -n 's/^\([0-9]*\) passed.*/\1/p;s/^[0-9]* failed, \([0-9]*\) passed.*/\1/p' <<<"$out" | tail -1)"
@@ -176,15 +185,23 @@ run_move() { # run_move <name> <expect> <file> <python-expr>
     printf '  🔴 %-46s SURVIVED — no test failed\n' "$name"
     FAILURES=$((FAILURES+1)); return
   fi
-  if grep -qx "$want" <<<"$killers"; then
-    printf '  ok %-46s killed by %s\n' "$name" "$want"; return
+  # 🔴 EXCLUSIVE, not "among". These rows exist to show that ONE assertion --
+  # the relationship one -- executes; the docstring quotes them as "relationship
+  # pin ONLY". `grep -qx` would print ok for a mutant killed by the named test
+  # AND a neighbour, which is precisely the day the claim stops being true.
+  # Measured: with a co-failing test added to the module, the `among` form
+  # printed ok and the sweep still said "all as expected".
+  if [ "$killers" = "$want" ]; then
+    printf '  ok %-46s killed by %s ALONE\n' "$name" "$want"; return
   fi
-  printf '  🔴 %-46s WRONG-KILLER: %s (wanted %s)\n' \
+  printf '  🔴 %-46s NOT EXCLUSIVE: %s (wanted %s alone)\n' \
     "$name" "$(tr '\n' ',' <<<"$killers")" "$want"
   FAILURES=$((FAILURES+1))
 }
 
 run() { # run <name> <expect: test node name | SURVIVES> <file> <old> <new>
+        # scores on "the named test is AMONG the killers" and PRINTS any extras,
+        # because these rows do not claim exclusivity -- only `run_move` does.
   local name="$1" want="$2" file="$3" old="$4" new="$5"
   ROWS=$((ROWS+1))
   if ! apply "$file" "$old" "$new"; then
@@ -209,7 +226,13 @@ run() { # run <name> <expect: test node name | SURVIVES> <file> <old> <new>
     FAILURES=$((FAILURES+1)); return
   fi
   if grep -qx "$want" <<<"$killers"; then
-    printf '  ok %-46s killed by %s\n' "$name" "$want"; return
+    local extra; extra="$(grep -vx "$want" <<<"$killers" | tr '\n' ',' | sed 's/,$//')"
+    if [ -n "$extra" ]; then
+      printf '  ok %-46s killed by %s (also: %s)\n' "$name" "$want" "$extra"
+    else
+      printf '  ok %-46s killed by %s\n' "$name" "$want"
+    fi
+    return
   fi
   printf '  🔴 %-46s WRONG-KILLER: %s (wanted %s)\n' \
     "$name" "$(tr '\n' ',' <<<"$killers")" "$want"

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -146,9 +146,13 @@ rule rather than reformatting a paragraph.
    ladder that stopped. The behavioural claim needs transcript measurement over
    future ladders -- `scripts/ladder-depth-sweep.py` is that instrument, and it
    prints both round counts with the date because the two differ -- and is NOT
-   made here. The mutation rows quoted in this module are re-derivable with
-   `bash scripts/tests/mutants-audit-ladder.sh`; before that harness was checked
-   in, every matrix here was a claim nobody else could re-run.
+   made here. The SURVIVOR rows quoted in this module -- the ones that were green
+   until a pin was added for them -- plus both reachability controls (M4, M10)
+   are re-derivable with `nix develop ~/workspace/devrc -c bash
+   scripts/tests/mutants-audit-ladder.sh`: 15 of the 45 rows quoted across the
+   two matrices below. The rest only ever CONFIRMED an existing pin and are not
+   repeated there. Before that harness was checked in, every matrix here was a
+   claim nobody else could re-run at all.
 6. **The CLASSIFIER is a human judgement, deliberately -- and only its WORDING
    is pinned.** The rule tells the reader to name each changed file payload or
    scaffolding rather than run a pathspec, because a pathspec is wrong in both

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -144,8 +144,11 @@ rule rather than reformatting a paragraph.
    and it bites harder for this one: the gate is a `git log --numstat` an
    operator has to issue between rounds, so the only evidence it fired is a
    ladder that stopped. The behavioural claim needs transcript measurement over
-   future ladders -- re-run the sweep in the docstring above -- and is NOT made
-   here.
+   future ladders -- `scripts/ladder-depth-sweep.py` is that instrument, and it
+   prints both round counts with the date because the two differ -- and is NOT
+   made here. The mutation rows quoted in this module are re-derivable with
+   `bash scripts/tests/mutants-audit-ladder.sh`; before that harness was checked
+   in, every matrix here was a claim nobody else could re-run.
 6. **The CLASSIFIER is a human judgement, deliberately -- and only its WORDING
    is pinned.** The rule tells the reader to name each changed file payload or
    scaffolding rather than run a pathspec, because a pathspec is wrong in both

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -146,13 +146,17 @@ rule rather than reformatting a paragraph.
    ladder that stopped. The behavioural claim needs transcript measurement over
    future ladders -- `scripts/ladder-depth-sweep.py` is that instrument, and it
    prints both round counts with the date because the two differ -- and is NOT
-   made here. The SURVIVOR rows quoted in this module -- the ones that were green
-   until a pin was added for them -- plus both reachability controls (M4, M10)
-   are re-derivable with `nix develop ~/workspace/devrc -c bash
-   scripts/tests/mutants-audit-ladder.sh`: 15 of the 45 rows quoted across the
-   two matrices below. The rest only ever CONFIRMED an existing pin and are not
-   repeated there. Before that harness was checked in, every matrix here was a
-   claim nobody else could re-run at all.
+   made here. SOME of the rows quoted below are re-derivable with `nix develop
+   ~/workspace/devrc -c bash scripts/tests/mutants-audit-ladder.sh` -- and that
+   harness, not this sentence, is the authority on WHICH: it names every row it
+   runs, and it runs some rows (the worktree hazards from #922) that appear in
+   no matrix here at all. 🔴 NO COUNT IS QUOTED HERE ON PURPOSE. Two independent
+   counts of these same two matrices disagreed -- 44 and 48 -- because "a row"
+   is ambiguous between labelled lines, distinct labels, and mutants-excluding-
+   controls. A total kept beside what it counts drifts, which is this file's own
+   rule; count them in the harness, where they are the executable list.
+   Before that harness was checked in, every matrix here was a claim nobody else
+   could re-run at all.
 6. **The CLASSIFIER is a human judgement, deliberately -- and only its WORDING
    is pinned.** The rule tells the reader to name each changed file payload or
    scaffolding rather than run a pathspec, because a pathspec is wrong in both


### PR DESCRIPTION
Third and last follow-up to #900. That PR recorded ~30 mutation rows in `test_audit_ladder_stop_rule.py` and a 110-session transcript sweep in the skill's reference file — and **every one of those runs happened in a session scratchpad that no longer exists**, so not a single row could be re-checked by anyone else, including the rows that justified adding a pin. `scripts/tests/mutants-claim-work.sh` had already written that lesson down for a different file, in a comment saying its predecessor "was never committed — so nobody could re-check a single row". Same mistake, one skill over.

## Two instruments, both run, both in the tree

**`scripts/tests/mutants-audit-ladder.sh`** — 13 mutants + 2 controls over the prose guards, built to the conventions `mutants-claim-work.sh` established:

- mutates only inside a `mktemp -d` copy, and **asserts the copy carries no `.git`** — a `cp -a` of a worktree would carry its gitdir pointer and a git command inside the copy would act on the real repo, which is a hazard this very skill now warns about;
- **every mutant names the test that must kill it**, and one killed only by some *other* test reports 🔴 WRONG-KILLER rather than ok — these pins overlap by design, so "a test failed" is not evidence the intended assert ran;
- **refuses to score a mutation that did not apply** — five silently failed to apply across three of #900's rounds, caught only because the driver asserted first;
- reads the suite's *content* with a collected-test floor, never an exit code;
- **two SURVIVES controls that must kill nothing** — a re-wrap of a pinned sentence and an edit to unpinned prose. The re-wrap is the one that matters: `_norm` collapses whitespace on purpose, so a red there would mean the pins key on line breaks rather than words.

Measured: **15 rows, all as expected** — 13 killed by their named test, 0 wrong-killers, both controls survived.

**`scripts/ladder-depth-sweep.py`** — the behavioural half. The test module states plainly that it pins instructions and *cannot* observe whether any session actually stopped; this is the only thing that can answer that, by comparing ladder-depth distributions across date windows. 🔴 **It refuses to report a zero**: its first version during #900 returned a confident `0` because it filtered on tool name `Task` while the harness emits `Agent`, and a zero from a broken filter is indistinguishable from a quiet host. It now counts every dispatch it walks as a positive control and exits 2 if that is zero.

## The repo's own ledger caught my first draft

The sweep's first version hand-rolled an `os.walk`, and `test_transcript_search.py` went red — that module enumerates every `*.jsonl` walk site in the tree and treats an unlisted one as **a violation by default**, because "a walk nobody enumerated is the one that goes unnoticed."

The right answer wasn't to add myself to the ledger but to **stop being a fifth walk**. The script now goes through `scripts/lib/transcript_search.py`, which also hands it two decisions it would otherwise have re-made and could have re-made wrongly: corpus membership (`subagents/` excluded) and skipping a malformed *line* rather than the whole file. Running it then surfaced a second defect the ledger couldn't see — the lib path was `parents[1]` where it needed `parent`, so the script exited on import. Both fixed, and measured after rather than asserted.

## And running it found a published number was the wrong metric

The reference file said "110 sessions, **440 rounds**". Two counts are available and they're far apart:

| | |
|---|---|
| rounds **observed** | the distinct numbered rounds a walk matches |
| rounds **implied** | each session's deepest round summed — a ladder reaching round 8 ran eight |

**440 was implied, and the paragraph didn't say so.** Re-run with the checked-in instrument: **127 sessions, 306 observed / 541 implied**, mean deepest 4.26, 39% ≥5 — a reading that includes the ten-round ladder the file documents, which is what "the window moves" means in practice. The script now prints both, labelled, with the run date; the reference file names the metric, carries the re-measurement, and tells the reader to re-derive rather than quote.

The qualitative claim the skill body rests on is unaffected in direction or magnitude — the ladder is a dominant workflow either way.

## Gate

`scripts/gate.sh --tier both` → `GATE: RESULT=PASS exit=0`, on a branch cut from `648f08c2`. The first run of this branch was **red** (`test_transcript_search.py`), which is how the walk-site ledger did its job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
