### PR TITLE
fix(claim-work): a claim whose WORKTREE was removed was stuck for the full TTL — and the refusal called the owner's own lock somebody else's

### DIFF
--- a/claude/skills/handoff/reference/shared-queue.md
+++ b/claude/skills/handoff/reference/shared-queue.md
@@ -62,6 +62,17 @@ never tell two sessions apart.
 the worktree you claimed from counts as the same owner, at any depth; a SIBLING
 worktree, a different clone, and the other host do not.
 
+⚠ **ONE EXCEPTION, on `--release`/`--steal` only: a claim whose worktree was
+`git worktree remove`d.** Its token is `<clone>/.git/worktrees/<name>`, so after
+the removal NOTHING recomputed it and the slug was stuck for the whole TTL — a
+shape this repo produces routinely, since a worktree per agent is mandated and an
+unchanged one is auto-removed. Since 2026-08-27 the claim also carries a
+`clone-id:`, and the destructive verbs grant when that id is yours AND the claim's
+`owner-id` matches no worktree this clone still has REGISTERED (it warns on stderr
+when it does). The claim/`--check` **verdict is unchanged** — a sibling still reads
+rc 10 STOP either way. Refs published before that date carry no `clone-id:` and
+still need `--force`.
+
 ⚠ **That describes NEW-format refs. LEGACY `cwd:` refs (pre-2026-08-26+1) carry a
 SECOND predicate that differs BY VERB**: strict per-worktree for the claim/check
 verdict (so a subdirectory of the claiming clone reads **rc 10**, not rc 12, even

--- a/claudedocs/design-claim-by-push.md
+++ b/claudedocs/design-claim-by-push.md
@@ -254,18 +254,55 @@ no submodules, so nothing exercises it in anger; it is pinned by
 invariant guard, labelled as one **in the docstring as well as here** — round 5
 found the doc claiming the label and the docstring never using the words.
 
-🔴 **A third residual, found in round 5 and NOT fixed: a claim made in a worktree
-that is later `git worktree remove`d can never be released by anyone without
-`--force`.** The token is `<clone>/.git/worktrees/<name>`; removing the worktree
-deletes that admin directory, so no live directory computes it. Measured: rc 10
-from the clone root *and* from a sibling worktree, for the full TTL, with the
+🔴 **A third residual, found in round 5, FIXED in round 6: a claim made in a
+worktree that is later `git worktree remove`d could not be released by anyone
+without `--force`.** The token is `<clone>/.git/worktrees/<name>`; removing the
+worktree deletes that admin directory, so no live directory computes it. Measured:
+rc 10 from the clone root *and* from a sibling worktree, for the full TTL, with the
 refusal saying the claim "is NOT yours" about the owner's own lock. **This shape
 is produced routinely** — this repo mandates a worktree per file-modifying agent
-and auto-removes one that ends unchanged. It is not fixed because every fix
-widens the token back towards the clone, which is round 3's bug; the escape
-hatches are `--force`, the TTL, or recreating a worktree at the same path with
-the same admin name (measured to restore ownership — the token is the admin
-dir's PATH, not its inode). `git worktree move` is safe.
+and auto-removes one that ends unchanged.
+
+**Round 6's fix, and why it is not round 3 again.** The obvious repair — "if the
+token does not match, fall back to the clone" — is round 3's bug with an extra
+step, and round 4's regression on top of it: a LIVE sibling worktree does not
+match either, and would be handed its peer's lock. So the grant is conditional on
+the owning worktree being **gone**, established positively in two steps:
+
+1. the claim commit now also carries **`clone-id:`** — `hash(machine-id ‖
+   realpath(--git-common-dir))`, hashed for the same public-remote reason
+   `owner-id` is — and it must equal ours. Same clone, same host. Without this
+   step a different clone, or the other machine, would qualify.
+2. the claim's `owner-id` must not be computable by **any worktree this clone
+   still has registered** — the main worktree's git dir plus every admin dir under
+   `<common-dir>/worktrees/`. That set is the complete owner space of this clone on
+   this host (a subdirectory reports its worktree's git dir; a `cp -a` copy points
+   at the original's admin dir), so absence from it means the producing worktree is
+   no longer registered.
+
+`clone-id` is **provenance, not ownership**: it is never compared as a token, and
+the recovery is reached only through `claim_is_mine`'s `clone` scope, i.e. only
+from `require_ownership_or_force`. **The claim/`--check` verdict is untouched** —
+a sibling worktree still reads rc 10 STOP, before and after a removal. The grant
+also warns on stderr, because it is an inference about a directory that is not
+there any more rather than a token match.
+
+⚠ **Two limits, stated.** (a) `clone-id:` is written from round 6 onward, so a
+claim already on the remote with `owner-id:` and no `clone-id:` still needs
+`--force`, the TTL, or recreating a worktree at the same path with the same admin
+name (measured to restore ownership — the token is the admin dir's PATH, not its
+inode). Measured on the canonical remote 2026-08-27: refs in that shape exist
+today, so this is a live gap. (b) The test is "no longer **registered**", not "the
+directory is gone": a worktree `rm -rf`'d without `git worktree prune` keeps its
+admin dir and is still refused — the conservative direction, on purpose.
+`git worktree move` is safe.
+
+Pinned by `test_a_claim_from_a_REMOVED_worktree_is_releasable_by_its_own_clone`
+(red at `648f08c2`), `test_a_live_sibling_worktree_is_not_widened_by_the_removed_
+worktree_recovery` (the round-4 regression guard — every rc 10 paired with the
+same command after the removal, so a recovery wired to nothing cannot pass it),
+`test_the_removed_worktree_recovery_does_not_reach_another_clone_or_host` and
+`test_a_pre_round6_claim_with_no_clone_id_is_still_refused_and_says_force`.
 
 ⚠ **A fourth: a `cp -a` copy of a worktree is the SAME owner as the original**,
 because the copy's `.git` is a file holding `gitdir: <original admin dir>`.
@@ -305,6 +342,14 @@ and a transitional claim's `where:` line says which format it is in rather than
 the matching cwd releases without `--force`, a different cwd is still refused.
 ⚠ Those published claims carry `cwd: /home/zach/workspace/devrc`, a path already
 all over this public repo, so nothing needed redacting.
+
+⚠ **RE-MEASURED 2026-08-27 (round 6): the mix has flipped and the "all legacy"
+sentences above are HISTORY, not the current state.** `owner-id:` now holds the
+large majority of the live refs and a single `cwd:` ref remains. Nothing changes —
+the legacy tier stays because it is not empty — but the **mix moves like the count
+does**, so re-derive both rather than quoting either. This matters for round 6's
+F4 fix in particular: the refs that fall in its `owner-id:`-with-no-`clone-id:` gap
+are the majority today, not a rounding error.
 
 #### 🔴 Round 5: the legacy tier's widening is scoped to the DESTRUCTIVE verbs
 

--- a/scripts/claim-work.sh
+++ b/scripts/claim-work.sh
@@ -698,20 +698,31 @@ ident_mail="$(git_ -C "$IDENT_REPO" config --get user.email 2>/dev/null || true)
 #     "any subdirectory is the same owner" would lead you to expect. devrc has no
 #     submodules, so nothing here exercises it in anger.
 #
-#   R3 — A CLAIM MADE IN A WORKTREE THAT IS LATER `git worktree remove`d CANNOT
-#     BE RELEASED BY ANYONE WITHOUT `--force`, for the whole TTL. The token is
-#     `<clone>/.git/worktrees/<name>`, and removing the worktree deletes that
-#     admin directory, so no live directory computes it any more: measured rc 10
-#     from the clone root AND from a sibling worktree, and the refusal says the
-#     claim "is NOT yours" about the owner's own lock. 🔴 THIS SHAPE IS PRODUCED
-#     ROUTINELY, not hypothetically — this repo mandates a worktree per
-#     file-modifying agent and the harness AUTO-REMOVES one that ends unchanged.
-#     NOT FIXED, and deliberately so: making the token survive its own worktree's
-#     deletion means widening it back towards the clone, which is round 3's bug.
-#     The escape hatches are `--force`, the TTL, or recreating a worktree at the
-#     same path with the same admin name (measured: ownership is restored, since
-#     the token is the PATH of the admin dir and not its inode). `git worktree
-#     move` is safe — it rewrites the working tree's location, not the admin dir.
+#   R3 — A CLAIM MADE IN A WORKTREE THAT IS LATER `git worktree remove`d. The
+#     token is `<clone>/.git/worktrees/<name>`, and removing the worktree deletes
+#     that admin directory, so no live directory computes it any more: measured
+#     rc 10 from the clone root AND from a sibling worktree, for the whole TTL,
+#     with the refusal saying the claim "is NOT yours" about the owner's own lock.
+#     🔴 THIS SHAPE IS PRODUCED ROUTINELY, not hypothetically — this repo mandates
+#     a worktree per file-modifying agent and the harness AUTO-REMOVES one that
+#     ends unchanged.
+#     ✅ CLOSED IN ROUND 6, and NOT by widening the token — that is round 3's bug.
+#     The claim now also publishes a `clone-id:` (hash of machine-id ‖
+#     `--git-common-dir`), and `--release`/`--steal` grant only when that id is
+#     OURS *and* the claim's `owner-id` is not computable by any worktree this
+#     clone still has registered. A sibling that still exists is therefore still
+#     refused, and the claim/`--check` verdict is untouched (strict scope). See
+#     `owner_worktree_is_gone` for the two-step argument and its limits.
+#     ⚠ RESIDUAL OF THE FIX: a claim already on the remote with `owner-id:` and no
+#     `clone-id:` (everything written before round 6) is NOT recoverable — it
+#     still needs `--force`, the TTL, or recreating a worktree at the same path
+#     with the same admin name (measured: ownership is restored, since the token
+#     is the PATH of the admin dir and not its inode). Measured on the canonical
+#     remote 2026-08-27: refs in that shape exist today. `git worktree move` is
+#     safe — it rewrites the working tree's location, not the admin dir.
+#     ⚠ AND THE TEST IS "NO LONGER REGISTERED", NOT "THE DIRECTORY IS GONE": a
+#     worktree `rm -rf`'d without `git worktree prune` keeps its admin dir and is
+#     still refused. Conservative on purpose.
 #
 #   R4 — A `cp -a` COPY OF A WORKTREE IS THE SAME OWNER as the original, because
 #     the copy's `.git` is a FILE holding `gitdir: <original admin dir>`, so
@@ -781,10 +792,22 @@ fi
 # measured it, because other sessions claim and release while you read. Any count
 # written here is stale within hours; the FORMAT is what is durable, and the
 # command that re-derives both is on the line above.
-owner_material="claim-work-owner-v2
+#
+# 🔴 ONE FORMULA, ONE PLACE — and that became load-bearing in round 6. The R3
+# recovery below has to recompute the owner token of every worktree still
+# registered in this clone, i.e. there is now a SECOND caller. A second copy of
+# the three lines would drift from this one silently and the recovery would
+# then refuse (or grant) for a reason nobody could see; `claude/RULES.md` calls
+# an open-coded predicate wrong at N−1 of its N sites. So the derivation lives
+# in exactly one function and both callers go through it.
+owner_id_for() {
+  # <an absolute, realpath'd git DIR> ⇒ the 12-char owner token a session
+  # standing in that worktree computes. Prints nothing if `git` cannot hash.
+  printf '%s' "claim-work-owner-v2
 $OWNER_HOST_PART
-$owner_worktree_part"
-MY_OWNER_ID="$(printf '%s' "$owner_material" | git_ hash-object --stdin 2>/dev/null | cut -c1-12 || true)"
+$1" | git_ hash-object --stdin 2>/dev/null | cut -c1-12 || true
+}
+MY_OWNER_ID="$(owner_id_for "$owner_worktree_part")"
 [ -n "$MY_OWNER_ID" ] || MY_OWNER_ID="unknown"
 
 # 🔴 THE OLD TOKEN, KEPT ONLY TO READ OLD REFS. Refs OUTLIVE a format change, so
@@ -800,13 +823,15 @@ MY_OWNER_ID="$(printf '%s' "$owner_material" | git_ hash-object --stdin 2>/dev/n
 MY_CWD_ID="$(printf '%s' "$IDENT_REPO" | git_ hash-object --stdin 2>/dev/null | cut -c1-12 || true)"
 [ -n "$MY_CWD_ID" ] || MY_CWD_ID="unknown"
 
-# 🔴 AND THE OLDEST TIER GETS A CWD ACCOMMODATION TOO, because it is the one that
-# is ACTUALLY LIVE. Measured 2026-08-26: every claim on the real origin is in the
-# `cwd:` format, each recorded against `/home/zach/workspace/devrc` (the count
-# moves; re-derive it, see the note above). A legacy comparison against `$PWD`
-# alone would leave their holder unable to release them from a worktree or a
-# subdirectory — the same stuck lock, on the refs that exist today rather than on
-# hypothetical future ones.
+# 🔴 AND THE OLDEST TIER GETS A CWD ACCOMMODATION TOO, because it is STILL live.
+# Measured 2026-08-26: EVERY claim on the real origin was in the `cwd:` format,
+# each recorded against `/home/zach/workspace/devrc`. ⚠ RE-MEASURED 2026-08-27:
+# that is no longer true — the `owner-id:` format now holds the large majority and
+# one legacy `cwd:` ref remains. The MIX moves like the count does; re-derive both
+# (see the note above) and do not quote either. The accommodation stays because
+# the tier is not empty: a legacy comparison against `$PWD` alone would leave that
+# holder unable to release from a worktree or a subdirectory — the same stuck
+# lock, on a ref that exists today rather than on a hypothetical future one.
 #
 # So a legacy `cwd:` ALSO matches the CLONE ROOT: the parent of the realpath'd
 # git-common-dir, which is the main worktree's toplevel for any subdirectory and
@@ -874,6 +899,32 @@ esac
 # a second line saying the same thing trains the reader to skip both.
 if [ -z "$MY_CLONE_ROOT" ] && [ "$OWNER_TOKEN_DEGRADED" -eq 0 ]; then
   warn "could not resolve this clone's root (an unreadable --git-common-dir, or a git dir that is not named .git) — a pre-2026-08-26 'cwd:' claim taken at the clone root cannot be recognised as yours from a worktree or a subdirectory. --release/--steal will be refused as 'not yours'; use --force if that happens."
+fi
+
+# ── 🔴 THE CLONE ID — PROVENANCE, NOT OWNERSHIP (round 6, for R3) ─────────────
+# A SECOND published token, and it is deliberately NOT part of the ownership
+# comparison: widening `owner-id` towards the clone is round 3's bug and this
+# must never re-create it. It answers one narrow question that `owner-id` alone
+# cannot — "was this claim made in THIS clone, on THIS host?" — so the R3
+# recovery in `claim_is_mine` can be conditional on the owning worktree being
+# GONE rather than merely unmatched. See `owner_worktree_is_gone`.
+#
+# `--git-common-dir` on purpose (the one other place that reads it is the legacy
+# `cwd:` accept): every worktree of a clone shares it, which is exactly the
+# property that makes it useless as an owner token and correct as a clone id.
+# Hashed, not a path: this trailer is pushed to a PUBLIC remote, same rule as
+# `owner-id` — pinned by
+# `test_the_claim_commit_records_a_hashed_owner_id_not_an_absolute_path`.
+#
+# `unknown` when the probe degraded, and `unknown` never compares equal to
+# anything (see `owner_worktree_is_gone`): a clone that cannot identify itself
+# must get the OLD refusal, not a grant.
+MY_CLONE_ID="unknown"
+if [ -n "$owner_common_part" ] && [ "$OWNER_TOKEN_DEGRADED" -eq 0 ]; then
+  MY_CLONE_ID="$(printf '%s' "claim-work-clone-v1
+$OWNER_HOST_PART
+$owner_common_part" | git_ hash-object --stdin 2>/dev/null | cut -c1-12 || true)"
+  [ -n "$MY_CLONE_ID" ] || MY_CLONE_ID="unknown"
 fi
 
 remote_ref_sha() {
@@ -1057,12 +1108,83 @@ claim_field() {
 # Tiers 1 and 2 (`owner-id:`, `cwd-id:`) ignore the scope entirely — it exists
 # only for the oldest tier, which records a bare path and can be nothing better
 # than a guess about who is standing in it.
+#
+# ── 🔴 R3, AND WHY THE RECOVERY IS A DIFFERENT QUESTION FROM OWNERSHIP ────────
+# A claim made in a worktree that is later `git worktree remove`d used to be
+# unreleasable by ANYONE without `--force` for the whole TTL — the token is
+# `<clone>/.git/worktrees/<name>` and removing the worktree deletes that admin
+# directory, so no live directory computes it. Measured rc 10 from the clone root
+# AND from every sibling, with the refusal telling the owner their own lock "is
+# NOT yours". This repo MANDATES a worktree per file-modifying agent and the
+# harness AUTO-REMOVES one that ends unchanged, so the shape is routine.
+#
+# 🔴 THE FIX IS NOT "FALL BACK TO THE CLONE WHEN THE TOKEN DOES NOT MATCH." That
+# is round 3's bug with an extra step: a LIVE sibling worktree does not match
+# either, and would be handed its peer's lock. The grant is conditional on the
+# owning worktree being GONE, established positively:
+#
+#   1. the claim carries `clone-id:` and it equals OURS — same clone, same host.
+#      Without this, a different clone (or the other machine) would qualify, which
+#      is the blanket fallback above.
+#   2. the claim's `owner-id` is not computable by ANY worktree this clone still
+#      has — the main worktree's git dir plus every REGISTERED linked worktree's
+#      admin dir under `<common-dir>/worktrees/`. That set IS the complete owner
+#      space of this clone on this host (a subdirectory reports its worktree's git
+#      dir; a `cp -a` copy points at the original's admin dir), so absence from it
+#      means the producing worktree is no longer registered.
+#
+# So a sibling that STILL EXISTS is found in step 2 and still refused — the round-4
+# regression, pinned by
+# `test_a_live_sibling_worktree_is_not_widened_by_the_removed_worktree_recovery`.
+#
+# ⚠ THE LIMIT, STATED: `clone-id:` is written from round 6 onward. A claim already
+# on the remote carrying `owner-id:` and no `clone-id:` fails step 1 and still
+# needs `--force`. Measured on the canonical remote 2026-08-27: such refs exist,
+# so this is a live gap and not a hypothetical one.
+#
+# ⚠ AND IT IS "NO LONGER REGISTERED", NOT "THE DIRECTORY IS GONE". A worktree
+# whose checkout was `rm -rf`'d but never `git worktree prune`d still has its admin
+# dir, so it is still in the set and the claim is still refused. That is the
+# conservative direction on purpose.
+owner_worktree_is_gone() {
+  local ref="$1" owner="$2" claim_clone admin
+  claim_clone="$(claim_field "$ref" clone-id)"
+  [ -n "$claim_clone" ] || return 1
+  [ "$claim_clone" != unknown ] || return 1
+  [ "$MY_CLONE_ID" != unknown ] || return 1
+  [ "$claim_clone" = "$MY_CLONE_ID" ] || return 1
+  [ -n "$owner_common_part" ] || return 1
+  # `$owner_common_part` is the main worktree's OWN git dir as well as the common
+  # dir, so it covers a claim taken at the clone root. The glob may not match; the
+  # `-d` test is what handles that (nullglob is not set).
+  for admin in "$owner_common_part" "$owner_common_part"/worktrees/*; do
+    [ -d "$admin" ] || continue
+    admin="$(readlink -f -- "$admin" 2>/dev/null || printf '%s' "$admin")"
+    if [ "$(owner_id_for "$admin")" = "$owner" ]; then
+      return 1
+    fi
+  done
+  # LOUD, because this grant is an INFERENCE about a directory that is not there
+  # any more, not a token match. A silent rc 0 on somebody else's lock is exactly
+  # the shape this gate exists to stop.
+  warn "the worktree that made this claim (owner-id $owner) is no longer registered in this clone — treating it as YOURS to release/steal. If that is wrong, the claim can be re-made."
+  return 0
+}
+
 claim_is_mine() {
   local ref="$1" legacy_scope="${2:-strict}" owner h c legacy
   owner="$(claim_field "$ref" owner-id)"
   if [ -n "$owner" ]; then
-    [ "$owner" = "$MY_OWNER_ID" ] && [ "$MY_OWNER_ID" != "unknown" ]
-    return
+    if [ "$owner" = "$MY_OWNER_ID" ] && [ "$MY_OWNER_ID" != "unknown" ]; then
+      return 0
+    fi
+    # 🔴 R3 recovery, DESTRUCTIVE VERBS ONLY. `report_existing` calls with no
+    # scope, so the claim/`--check` verdict is untouched: a sibling worktree still
+    # reads rc 10 STOP whether or not any worktree was removed.
+    if [ "$legacy_scope" = clone ] && owner_worktree_is_gone "$ref" "$owner"; then
+      return 0
+    fi
+    return 1
   fi
   h="$(claim_field "$ref" host)"
   [ -n "$h" ] && [ "$h" = "$MY_HOST" ] || return 1
@@ -1278,6 +1400,7 @@ $msg
 claimed-by: $ident_name <$ident_mail>
 host: $MY_HOST
 owner-id: $MY_OWNER_ID
+clone-id: $MY_CLONE_ID
 nonce: $$-$(date +%s%N 2>/dev/null || date +%s)
 EOF
 }

--- a/scripts/tests/mutants-claim-work.sh
+++ b/scripts/tests/mutants-claim-work.sh
@@ -169,6 +169,13 @@ b="$(failing)"; [ -z "$b" ] && echo "clean" || { echo "🔴 ALREADY RED: $b"; ex
 printf '\n== the OWNER TOKEN: both directions of the round-2 bug (must be KILLED) ==\n'
 # The too-strict half, reproduced exactly: key the worktree component off the
 # literal ident dir instead of the worktree's git-dir.
+# 🔴 ROUND 6 NEARLY LOST THIS ROW, AND THE SWEEP IS WHY IT DID NOT. The R3
+# recovery gave `--release` a SECOND route to rc 0, and under this mutant the
+# claim's owner-id becomes uncomputable from `sub/` — so the recovery granted and
+# the intended killer went green while the token was exactly as broken as round 2
+# left it. The row reported WRONG-KILLER (it still died, to three other tests).
+# The fix is in the test, not here: it now asserts the release did NOT print the
+# recovery's warning, i.e. that it was a token match.
 run 'worktree-half-is-the-literal-cwd' \
   test_release_from_a_SUBDIRECTORY_is_still_the_owners_own_claim \
   's@^owner_worktree_part="\$(git_ -C "\$IDENT_REPO" rev-parse.*@owner_worktree_part="$IDENT_REPO"@'
@@ -196,9 +203,12 @@ run 'host-half-is-uname-not-machine-id' \
   test_two_hosts_produce_different_owner_tokens \
   's@^  OWNER_HOST_PART="machine-id:\$machine_id"@  OWNER_HOST_PART="hostname:$MY_HOST"@'
 # Drop the worktree component entirely: every session on one host becomes one owner.
+# ⚠ The anchor moved in round 6: the formula lives in `owner_id_for()` now, because
+# the R3 recovery is a SECOND caller of it. The mutation is the same one — replace
+# the variable component of the hashed material with a constant.
 run 'worktree-half-dropped-from-the-token' \
   test_two_different_clones_on_one_host_are_different_owners \
-  's@^\$owner_worktree_part"$@CONSTANT-CLONE"@'
+  's@^\$1" | git_@CONSTANT-CLONE" | git_@'
 # The machine-id read must tolerate an absent file. Without `2>/dev/null || true`
 # the substitution fails and `set -e` aborts the whole run — a tool whose
 # contract is "never block a resume" dying because /etc/machine-id is missing.
@@ -206,14 +216,19 @@ run 'absent-machine-id-file-aborts-the-run' \
   test_a_missing_machine_id_file_degrades_instead_of_collapsing_every_token \
   's@^machine_id=.*$@machine_id="$(head -n1 -- "$MACHINE_ID_FILE")"@'
 # The token must reach the commit. A constant trailer means nobody owns anything.
+# 🔴 SAME ROUND-6 MASKING AS `worktree-half-is-the-literal-cwd` above: a constant
+# owner-id matches nobody, so the OWNER's own release fell through to the R3
+# recovery and returned rc 0. Its killer now also asserts the recovery's warning
+# is ABSENT on the owner's own release.
 run 'owner-id-trailer-is-a-constant' \
   test_release_refuses_another_sessions_live_claim_unless_forced \
   's@^owner-id: \$MY_OWNER_ID$@owner-id: CONSTANT@'
 
 printf '\n== the LEGACY tier, which is the one that is actually LIVE (must be KILLED) ==\n'
-# EVERY claim live on the real origin is `cwd:`-format (the COUNT moves hourly —
-# re-derive it, never quote it). Narrowing the legacy accept back to the literal
-# ident dir locks their holder out from a worktree.
+# The legacy tier is STILL live on the real origin — it was 100% of the refs when
+# round 5 measured it and is one ref of eleven on 2026-08-27. The MIX moves like
+# the count does; re-derive both, never quote either. Narrowing the legacy accept
+# back to the literal ident dir locks that holder out from a worktree.
 run 'legacy-clone-root-accept-removed' \
   test_a_legacy_cwd_claim_is_releasable_from_a_worktree_of_that_clone \
   's@^  \[ -n "\$MY_CLONE_ROOT" \] && \[ "\$legacy" = "\$MY_CLONE_ROOT" \]$@  false@'
@@ -260,6 +275,53 @@ run 'degraded-git-common-dir-probe-goes-quiet' \
 run 'legacy-host-check-removed' \
   test_a_legacy_cwd_claim_from_another_HOST_is_not_yours \
   's@^  \[ -n "\$h" \] && \[ "\$h" = "\$MY_HOST" \] || return 1$@  :@'
+
+printf '\n== ROUND 6 / F4: the REMOVED-WORKTREE recovery (must be KILLED) ==\n'
+# 🔴 THE RECOVERY MUST NOT REACH THE VERDICT. Dropping the scope guard hands
+# `report_existing` the widened answer, which is round 4's regression exactly:
+# after a removal a sibling worktree would be told rc 12 CARRY ON.
+run 'r3-recovery-reaches-the-verdict' \
+  test_a_live_sibling_worktree_is_not_widened_by_the_removed_worktree_recovery \
+  's@^    if \[ "\$legacy_scope" = clone \] && owner_worktree_is_gone "\$ref" "\$owner"; then$@    if owner_worktree_is_gone "$ref" "$owner"; then@'
+# …and the recovery wired to nothing: the F4 lockout comes straight back.
+run 'r3-recovery-never-fires' \
+  test_a_claim_from_a_REMOVED_worktree_is_releasable_by_its_own_clone \
+  's@ && owner_worktree_is_gone "\$ref" "\$owner"; then@ \&\& false; then@'
+# 🔴 THE STEP THAT MAKES IT CONDITIONAL RATHER THAN BLANKET: a claim whose owner
+# token IS computable by a worktree this clone still has registered must be
+# refused. Without it the recovery is "fall back to the clone", i.e. round 3.
+run 'r3-live-worktree-check-removed' \
+  test_a_live_sibling_worktree_is_not_widened_by_the_removed_worktree_recovery \
+  's@^    if \[ "\$(owner_id_for "\$admin")" = "\$owner" \]; then$@    if false; then@'
+# 🔴 PROVENANCE, HALF ONE: without the clone-id equality a removed worktree in
+# ANY clone (or on the other machine) qualifies.
+run 'r3-clone-id-equality-dropped' \
+  test_the_removed_worktree_recovery_does_not_reach_another_clone_or_host \
+  's@^  \[ "\$claim_clone" = "\$MY_CLONE_ID" \] || return 1$@  :@'
+# 🔴 PROVENANCE, HALF TWO — and this is the plausible WRONG fix, not a strawman:
+# "a claim with no clone-id is probably ours". It grants on every pre-round-6
+# `owner-id:` ref, which is the majority of the refs live on the real origin.
+run 'r3-absent-clone-id-treated-as-ours' \
+  test_a_pre_round6_claim_with_no_clone_id_is_still_refused_and_says_force \
+  's@^  \[ -n "\$claim_clone" \] || return 1$@  [ -n "$claim_clone" ] || claim_clone="$MY_CLONE_ID"@'
+# The clone id must reach the commit, and must be the REAL one. A constant that
+# still LOOKS like a hash (so the leak test cannot be the killer) breaks the
+# recovery for everyone.
+run 'clone-id-trailer-is-a-constant' \
+  test_a_claim_from_a_REMOVED_worktree_is_releasable_by_its_own_clone \
+  's@^clone-id: \$MY_CLONE_ID$@clone-id: deadbeefcafe@'
+# 🔴 AND IT MUST COME FROM `--git-common-dir`, NOT the worktree git dir — a
+# per-worktree clone id is uncomputable for exactly the worktree that is gone, so
+# the recovery would never fire while looking implemented.
+run 'clone-id-derived-from-the-worktree-git-dir' \
+  test_a_claim_from_a_REMOVED_worktree_is_releasable_by_its_own_clone \
+  's@^\$owner_common_part" | git_ hash-object@$owner_worktree_part" | git_ hash-object@'
+# 🔴 THE GRANT IS AN INFERENCE, NOT A TOKEN MATCH — same silent-fallback class as
+# the two probe rows above. A quiet rc 0 on somebody else's lock is the shape this
+# gate exists to stop.
+run 'r3-recovery-grant-goes-quiet' \
+  test_a_claim_from_a_REMOVED_worktree_is_releasable_by_its_own_clone \
+  's@^  warn "the worktree that made this claim@  : "@'
 
 printf '\n== the TRAILER READ must not inherit the callers git config (KILLED) ==\n'
 # 🔴 `interpret-trailers` obeys `trailer.*`; the awk line scan it replaced did

--- a/scripts/tests/test_claim_work.py
+++ b/scripts/tests/test_claim_work.py
@@ -1138,9 +1138,20 @@ def test_release_refuses_another_sessions_live_claim_unless_forced(tmp_path):
         "the ref moved despite the refusal")
 
     # …and the owner is still allowed, so the gate is not simply "always refuse".
-    assert _run("--release", "held", repo=a).returncode == RC_OK, (
+    own = _run("--release", "held", repo=a)
+    assert own.returncode == RC_OK, (
         "the OWNER was refused too — the gate is refusing on something other "
         "than ownership")
+    # 🔴 …AND IT WAS A TOKEN MATCH, NOT THE R3 REMOVED-WORKTREE RECOVERY. Round 6
+    # added a second way for `--release` to return 0, and it silently took over
+    # this leg: with a constant `owner-id:` trailer the token matches nobody, the
+    # recovery then finds it uncomputable in this clone and grants — so the
+    # `owner-id-trailer-is-a-constant` mutant passed a green rc 0 for a reason
+    # with nothing to do with ownership. The recovery announces itself; assert it
+    # did not fire, or this leg stops measuring the token at all.
+    assert "no longer registered in this clone" not in own.stderr, (
+        f"the owner's own release went through the R3 removed-worktree recovery "
+        f"instead of matching its token:\n{own.stderr}")
 
 
 def test_release_with_force_overrides_the_ownership_gate(tmp_path):
@@ -1822,6 +1833,12 @@ def test_the_claim_commit_records_a_hashed_owner_id_not_an_absolute_path(tmp_pat
         f"the claim commit published an ABSOLUTE PATH to the remote:\n{body}")
     assert re.search(r"^host: \S+$", body, re.M), body
     assert re.search(r"^nonce: \S+$", body, re.M), body
+    # 🔴 ROUND 6 added a SECOND published token. It goes to the same public
+    # remote under the same rule, so it is pinned here rather than in a test of
+    # its own: a hash, never the clone's path.
+    assert re.search(r"^clone-id: [0-9a-f]{6,}$", body, re.M), (
+        f"the claim commit does not carry a hashed clone-id — the R3 recovery "
+        f"reads it, and an absent one silently disables the recovery:\n{body}")
 
 
 # ── 🔴 refs OUTLIVE a format change ──────────────────────────────────────────
@@ -1930,6 +1947,17 @@ def test_release_from_a_SUBDIRECTORY_is_still_the_owners_own_claim(tmp_path):
             f"literal cwd, so a claim taken at the root is unreleasable from any "
             f"subdirectory and the item is blocked for the whole TTL.\n"
             f"{rel.stdout}\n{rel.stderr}")
+        # 🔴 BY MATCHING THE TOKEN, NOT VIA THE R3 RECOVERY. Round 6 gave
+        # `--release` a second route to rc 0, and it masked this very mutant: a
+        # cwd-keyed token makes the claim's owner-id uncomputable from `sub/`,
+        # the recovery then grants, and "the owner can release from a
+        # subdirectory" reads green while the token is exactly as broken as it
+        # was in round 2. The recovery announces itself on stderr.
+        assert "no longer registered in this clone" not in rel.stderr, (
+            f"the release from {depth} succeeded through the removed-worktree "
+            f"recovery rather than by owning the claim — the owner token is not "
+            f"cwd-invariant and this assertion is the only thing that can see "
+            f"it:\n{rel.stderr}")
         assert f"{CLAIM_NS}subdir-probe" not in _remote_refs(origin)
 
 
@@ -2961,3 +2989,240 @@ def test_a_hostile_init_template_cannot_lock_the_owner_out(tmp_path):
     assert _run("tpltrailer2", cwd=a, env=env).returncode == RC_OK
     assert _run("--release", "tpltrailer2", cwd=b,
                 env=env).returncode == RC_TAKEN
+
+
+# ── 🔴 ROUND 6 / F4: a claim whose WORKTREE was removed was stuck for the TTL ──
+#
+# The owner token is `hash(machine-id ‖ realpath(--git-dir))`, i.e.
+# `<clone>/.git/worktrees/<name>` for a linked worktree. `git worktree remove`
+# deletes that admin directory, so after it NOTHING on the machine recomputes the
+# token: measured rc 10 "is NOT yours" from the clone root and from every sibling,
+# for the whole 7-day TTL, with the refusal telling the owner their own lock
+# belongs to somebody else.
+#
+# 🔴 IT RECURS BY DESIGN. `claude/RULES.md` mandates a worktree per file-modifying
+# agent, and the harness AUTO-REMOVES a worktree that ends unchanged — so
+# "claim in a worktree that then disappears" is a shape this repo produces
+# routinely, not an edge case.
+#
+# The fix is deliberately NOT a clone-level fallback (that is round 3's bug, and
+# round 4's regression, with an extra step). The claim now publishes a `clone-id:`
+# and the grant needs BOTH: same clone + same host, AND the claim's owner-id not
+# computable by any worktree this clone still has registered.
+
+def _remove_worktree(session: Path, path: Path) -> None:
+    _git("-C", str(session), "worktree", "remove", str(path))
+    assert not path.exists(), f"{path} survived `git worktree remove`"
+
+
+def test_a_claim_from_a_REMOVED_worktree_is_releasable_by_its_own_clone(tmp_path):
+    """🔴 F4, THE STUCK LOCK, END TO END. Claim from a linked worktree, remove the
+    worktree, then release — from the clone root AND from a sibling worktree,
+    because the measured symptom was rc 10 from BOTH and one of them is not a
+    general claim.
+
+    Red at the base commit with this message; green at HEAD.
+    """
+    origin = _bare_origin(tmp_path)
+    a = _session(tmp_path, origin, "Same Identity", "a")
+    doomed = _worktree(a, tmp_path / "a-doomed", branch="doomed")
+    sibling = _worktree(a, tmp_path / "a-sibling", branch="sibling")
+    env = _cwd_env(origin)
+
+    assert _run("gone-probe", "--subject", "generic item", cwd=doomed,
+                env=env).returncode == RC_OK
+    assert _run("gone-probe-2", "--subject", "generic item", cwd=doomed,
+                env=env).returncode == RC_OK
+    _remove_worktree(a, doomed)
+
+    # (1) from the CLONE ROOT
+    rel = _run("--release", "gone-probe", cwd=a, env=env)
+    assert rel.returncode == RC_OK, (
+        f"a claim made in a worktree that was later `git worktree remove`d is "
+        f"unreleasable from the clone root (rc={rel.returncode}) — nothing on "
+        f"this machine can recompute `<clone>/.git/worktrees/<name>` any more, so "
+        f"the slug is stuck for the whole TTL and the refusal tells the owner "
+        f"their own lock is somebody else's.\n{rel.stdout}\n{rel.stderr}")
+    assert f"{CLAIM_NS}gone-probe" not in _remote_refs(origin)
+    assert "no longer registered in this clone" in rel.stderr, (
+        f"the grant is an INFERENCE about a directory that is not there any "
+        f"more, not a token match, and it went out silently:\n{rel.stderr}")
+
+    # (2) …and from a SIBLING worktree of the same clone, which measured rc 10 too.
+    rel2 = _run("--release", "gone-probe-2", cwd=sibling, env=env)
+    assert rel2.returncode == RC_OK, (
+        f"a sibling worktree of the same clone still cannot release the claim of "
+        f"a REMOVED worktree (rc={rel2.returncode}) — the measured symptom was "
+        f"rc 10 from the clone root and from every sibling, and only one of the "
+        f"two has been fixed.\n{rel2.stdout}\n{rel2.stderr}")
+    assert f"{CLAIM_NS}gone-probe-2" not in _remote_refs(origin)
+
+
+def test_a_live_sibling_worktree_is_not_widened_by_the_removed_worktree_recovery(
+        tmp_path):
+    """🔴 THE REGRESSION GUARD FOR ROUND 4'S BUG, SAID PLAINLY: round 4 widened the
+    ownership predicate and the widening leaked into the VERDICT, so a sibling
+    worktree claiming a peer's live slug was told rc 12 "✅ THIS IS YOURS — carry
+    on with it". The F4 recovery must not re-create that, in either of its two
+    ways: it must not fire while the owning worktree still EXISTS, and it must not
+    reach `report_existing` at all (which calls `claim_is_mine` with the strict
+    scope and no second argument).
+
+    So, with the owning worktree LIVE, a sibling and the clone root must both get
+    rc 10 on `--check` and on a bare claim, and rc 10 on the destructive verb too.
+
+    🔴 AND THE PAIRING IS THE POINT. Every rc 10 below is followed by the same
+    command after the worktree is removed, which must then behave differently on
+    the release path and IDENTICALLY on the verdict path. Without that, "rc 10"
+    would be satisfied by a recovery wired to nothing.
+    """
+    origin = _bare_origin(tmp_path)
+    a = _session(tmp_path, origin, "Same Identity", "a")
+    holder = _worktree(a, tmp_path / "a-holder", branch="holder")
+    sibling = _worktree(a, tmp_path / "a-sibling2", branch="sibling2")
+    env = _cwd_env(origin)
+
+    assert _run("live-sibling", "--subject", "generic item", cwd=holder,
+                env=env).returncode == RC_OK
+    ref_sha = _remote_refs(origin)[f"{CLAIM_NS}live-sibling"]
+
+    for label, where in (("sibling worktree", sibling), ("clone root", a)):
+        chk = _run("--check", "live-sibling", cwd=where, env=env)
+        assert chk.returncode == RC_TAKEN, (
+            f"--check from the {label} got rc={chk.returncode} about a LIVE "
+            f"peer's claim. rc {RC_MINE} is CARRY ON — round 4's bug "
+            f"verbatim.\n{chk.stdout}")
+        assert "THIS IS YOURS" not in chk.stdout, chk.stdout
+        assert "DO NOT start this item" in chk.stdout, chk.stdout
+
+        dup = _run("live-sibling", "--subject", "the same item", cwd=where, env=env)
+        assert dup.returncode == RC_TAKEN, (
+            f"a bare claim from the {label} got rc={dup.returncode} about a LIVE "
+            f"peer's claim\n{dup.stdout}")
+        assert "THIS IS YOURS" not in dup.stdout, dup.stdout
+
+        rel = _run("--release", "live-sibling", cwd=where, env=env)
+        assert rel.returncode == RC_TAKEN, (
+            f"--release from the {label} deleted a claim whose worktree is still "
+            f"REGISTERED (rc={rel.returncode}) — the F4 recovery is a blanket "
+            f"clone-level fallback, which is round 3's bug.\n{rel.stdout}")
+        assert _remote_refs(origin)[f"{CLAIM_NS}live-sibling"] == ref_sha
+
+    # 🔴 POSITIVE CONTROL — the refusals above are about the worktree being LIVE,
+    # not about a recovery that never runs. Same commands, worktree removed.
+    _remove_worktree(a, holder)
+
+    # the VERDICT is unchanged: strict scope, so still STOP. That is deliberate —
+    # "may I delete this ref?" and "should I start this work?" are not the same
+    # question, and only the first one was widened.
+    chk = _run("--check", "live-sibling", cwd=sibling, env=env)
+    assert chk.returncode == RC_TAKEN, (
+        f"the F4 recovery leaked into the CLAIM/--check verdict (rc="
+        f"{chk.returncode}) — that is exactly round 4's regression\n{chk.stdout}")
+    assert "THIS IS YOURS" not in chk.stdout, chk.stdout
+
+    # the DESTRUCTIVE verb is the one that moves.
+    rel = _run("--release", "live-sibling", cwd=sibling, env=env)
+    assert rel.returncode == RC_OK, (
+        f"removing the owning worktree changed nothing on the release path "
+        f"(rc={rel.returncode}) — every rc 10 asserted above is then vacuous\n"
+        f"{rel.stdout}\n{rel.stderr}")
+    assert f"{CLAIM_NS}live-sibling" not in _remote_refs(origin)
+
+
+def test_the_removed_worktree_recovery_does_not_reach_another_clone_or_host(
+        tmp_path):
+    """🔴 THE RECOVERY IS CONDITIONAL ON PROVENANCE, NOT ON "I COULD NOT MATCH THE
+    TOKEN". A removed worktree's owner-id is uncomputable — but so is a claim from
+    a DIFFERENT clone and so is one from the OTHER MACHINE, and granting those is
+    the blanket fallback this fix exists to avoid.
+
+    Two legs, because the `clone-id` is a hash of BOTH halves and one measurement
+    would not say which half is load-bearing:
+      (1) a different clone on the SAME host, and
+      (2) the SAME clone with a different `/etc/machine-id`.
+    Each is paired with the matching grant, so a `clone-id` comparison wired to
+    nothing cannot pass.
+    """
+    origin = _bare_origin(tmp_path)
+    a = _session(tmp_path, origin, "Same Identity", "a")
+    b = _session(tmp_path, origin, "Same Identity", "b")
+    mid1 = _machine_id(tmp_path, "mid-1", "1111111111111111aaaaaaaaaaaaaaaa")
+    mid2 = _machine_id(tmp_path, "mid-2", "2222222222222222bbbbbbbbbbbbbbbb")
+    env_a = _cwd_env(origin, DEVRC_CLAIM_MACHINE_ID_FILE=str(mid1))
+    env_b = _cwd_env(origin, DEVRC_CLAIM_MACHINE_ID_FILE=str(mid1))
+    env_other_host = _cwd_env(origin, DEVRC_CLAIM_MACHINE_ID_FILE=str(mid2))
+
+    # (1) another CLONE on the same host
+    wt = _worktree(a, tmp_path / "a-cross", branch="cross")
+    assert _run("cross-clone", "--subject", "generic item", cwd=wt,
+                env=env_a).returncode == RC_OK
+    _remove_worktree(a, wt)
+    other = _run("--release", "cross-clone", cwd=b, env=env_b)
+    assert other.returncode == RC_TAKEN, (
+        f"a DIFFERENT clone released a claim made in a removed worktree of "
+        f"another clone (rc={other.returncode}) — the recovery is a blanket "
+        f"'the token did not match' fallback, not a provenance check.\n"
+        f"{other.stdout}\n{other.stderr}")
+    assert f"{CLAIM_NS}cross-clone" in _remote_refs(origin)
+    # …and the clone it WAS made in still gets it, so the refusal above is about
+    # provenance rather than about a recovery that never fires.
+    assert _run("--release", "cross-clone", cwd=a, env=env_a).returncode == RC_OK
+
+    # (2) the same clone, a different machine-id
+    wt2 = _worktree(a, tmp_path / "a-cross2", branch="cross2")
+    assert _run("cross-host", "--subject", "generic item", cwd=wt2,
+                env=env_a).returncode == RC_OK
+    _remove_worktree(a, wt2)
+    xhost = _run("--release", "cross-host", cwd=a, env=env_other_host)
+    assert xhost.returncode == RC_TAKEN, (
+        f"the OTHER machine released a claim made in a removed worktree at the "
+        f"same path (rc={xhost.returncode}) — `/home/zach/workspace/devrc` "
+        f"exists on both hosts, which is the too-loose half of the round-2 bug "
+        f"reappearing in the recovery.\n{xhost.stdout}\n{xhost.stderr}")
+    assert f"{CLAIM_NS}cross-host" in _remote_refs(origin)
+    assert _run("--release", "cross-host", cwd=a, env=env_a).returncode == RC_OK
+
+
+def test_a_pre_round6_claim_with_no_clone_id_is_still_refused_and_says_force(
+        tmp_path):
+    """⚠ THE STATED LIMIT OF THE F4 FIX, PINNED SO IT CANNOT BE MISREAD AS CLOSED.
+
+    `clone-id:` is written from round 6 onward. A claim ALREADY on the remote
+    carrying `owner-id:` and no `clone-id:` fails step 1 of the recovery and still
+    needs `--force` — measured on the canonical remote 2026-08-27, refs in exactly
+    that shape exist today.
+
+    ⚠ LABEL: an INVARIANT GUARD, not regression cover. It passes at the base
+    commit too (nothing there could grant), and its job is to make the
+    `clone-id-requirement-dropped` mutant killable and to stop a later round
+    quietly deleting the requirement.
+    """
+    origin = _bare_origin(tmp_path)
+    a = _session(tmp_path, origin, "Same Identity", "a")
+    env = _cwd_env(origin)
+
+    # A round-5-format claim: owner-id, no clone-id. Built with raw git so it is
+    # genuinely the old shape rather than whatever the current script emits.
+    tree = _git("-C", str(a), "mktree", input="").stdout.strip()
+    body = ("claim(old-format): generic item\n\n"
+            "claimed-by: t <t@localhost>\n"
+            f"host: {os.uname().nodename}\n"
+            "owner-id: deadbeefcafe\n"
+            "nonce: 1-2\n")
+    sha = _git("-C", str(a), "commit-tree", tree, input=body).stdout.strip()
+    _git("-C", str(a), "push", "origin", f"{sha}:{CLAIM_NS}old-format")
+
+    rel = _run("--release", "old-format", cwd=a, env=env)
+    assert rel.returncode == RC_TAKEN, (
+        f"a pre-round-6 `owner-id:` claim with no `clone-id:` was released "
+        f"without --force (rc={rel.returncode}) — the recovery then grants on "
+        f"'the token did not match' alone, which is the blanket fallback\n"
+        f"{rel.stdout}")
+    assert "--force" in rel.stdout, rel.stdout
+    assert _remote_refs(origin)[f"{CLAIM_NS}old-format"] == sha
+
+    # POSITIVE CONTROL: the documented escape hatch works on it.
+    assert _run("--release", "old-format", "--force", cwd=a,
+                env=env).returncode == RC_OK
+    assert f"{CLAIM_NS}old-format" not in _remote_refs(origin)


### PR DESCRIPTION
## The defect (round 6 / F4, the script header's residual **R3**)

Ownership is `hash(/etc/machine-id ‖ realpath(git rev-parse --git-dir))` — i.e.
`<clone>/.git/worktrees/<name>` for a linked worktree. `git worktree remove`
deletes that admin directory, so afterwards **nothing on the machine recomputes
the token**. Measured on `648f08c2`: claim from a linked worktree → remove it →
`--release` returns **rc 10 "is NOT yours"** from the clone root *and* from every
sibling, for the whole 7-day TTL, with the refusal telling the owner their own
lock belongs to somebody else.

It recurs by design: `claude/RULES.md` mandates a worktree per file-modifying
agent and the harness **auto-removes** one that ends unchanged.

## The fix — conditional recovery, not a wider token

"If the token does not match, fall back to the clone" is round 3's bug with an
extra step, and round 4's regression on top: a **live** sibling worktree does not
match either, and would be handed its peer's lock. So the grant is conditional on
the owning worktree being **gone**, established positively in `owner_worktree_is_gone`:

1. the claim now also publishes **`clone-id:`** — `hash(machine-id ‖
   realpath(--git-common-dir))`, hashed for the same public-remote reason
   `owner-id` is — and it must equal ours. **Same clone, same host.**
2. the claim's `owner-id` must not be computable by **any worktree this clone
   still has REGISTERED** (the main worktree's git dir plus every admin dir under
   `<common-dir>/worktrees/`). That set is the complete owner space of this clone
   on this host, so absence from it means the producing worktree is gone.

`clone-id` is **provenance, never an ownership token**. The recovery is reached
only through `claim_is_mine`'s existing `clone` scope (round 5's split), so it is
on `--release`/`--steal` only — **the claim/`--check` verdict is untouched**: a
sibling worktree reads rc 10 STOP before *and* after a removal. The grant warns on
stderr, because it is an inference about a directory that is not there rather than
a token match.

The owner-id derivation moved into `owner_id_for()` because the recovery is a
second caller; a second copy of the formula would drift silently.

### Limits, stated rather than hidden (script header + design doc + shared-queue.md)

* `clone-id:` is written **from here on**. A ref already on the remote with
  `owner-id:` and no `clone-id:` still needs `--force`, the TTL, or recreating a
  worktree at the same path. **Measured on the canonical remote 2026-08-27: those
  are the majority of live refs today.**
* the test is "no longer **registered**", not "the directory is gone" — a worktree
  `rm -rf`'d without `git worktree prune` keeps its admin dir and stays refused.
  Conservative on purpose.

### Also corrected, because it had become measurably false

The script, the mutation battery and the design doc all asserted that **every**
live claim on the real origin is in the legacy `cwd:` format. Re-measured
2026-08-27: `owner-id:` is now the large majority and one `cwd:` ref remains. The
**mix** moves like the count does; all three now say re-derive rather than quote.

## Validation

**Red → green.** New tests fail at `648f08c2` with their own assertion messages
and pass at HEAD (`claim-work.sh` is byte-identical between `2770db2d` — the
sha named in the brief — and `648f08c2`; the only delta between them is the
unrelated ssh-keepalive export):

| leg | at `648f08c2` | at HEAD |
|---|---|---|
| `test_a_claim_from_a_REMOVED_worktree_is_releasable_by_its_own_clone` | FAILED | passed |
| `test_a_live_sibling_worktree_is_not_widened_by_the_removed_worktree_recovery` | FAILED | passed |
| `test_the_removed_worktree_recovery_does_not_reach_another_clone_or_host` | FAILED | passed |
| `test_the_claim_commit_records_a_hashed_owner_id_not_an_absolute_path` (clone-id leg) | FAILED | passed |
| `test_a_pre_round6_claim_with_no_clone_id_is_still_refused_and_says_force` | passed | passed — **labelled an INVARIANT GUARD**, not regression cover |

**The non-widening proof** is its own test and is labelled, in its docstring, a
regression guard for round 4's bug: with the owning worktree **live**, a sibling
worktree *and* the clone root each get **rc 10** on `--check`, on a bare claim and
on `--release` — and every one of those is **paired** with the same command after
the removal, where `--check` must stay rc 10 and only `--release` moves. Without
the pairing, "rc 10" would be satisfied by a recovery wired to nothing.

**Mutation sweep** (`scripts/tests/mutants-claim-work.sh`, `PYTHONDONTWRITEBYTECODE=1`):
**ALL OK for 40 mutants**, 8 of them new for this guard, each killed by its named
test. Both controls in the same run — unmutated baseline `clean`, behaviour-free
`comment-only-edit` **SURVIVED as required**, plus the `already-caught-positive-control`
row. Script restored byte-identical (`sha256 4e47e529…`, mode `100755`).

🔴 **The sweep caught this change masking two existing rows.** The recovery gave
`--release` a second route to rc 0, so `worktree-half-is-the-literal-cwd` and
`owner-id-trailer-is-a-constant` stopped killing their own named tests (both
reported WRONG-KILLER; they still died, to other tests). Fixed in the **tests**,
not by deleting the rows: the owner's own release now asserts the recovery's
warning is **absent**, i.e. that it was a token match.

**Both gate tiers, on both trees.**

| tree | `gate.sh --tier both --set hermetic` | `nix build .#checks…{pytests,nodetests}` |
|---|---|---|
| branch (base `648f08c2`) | `GATE: RESULT=PASS exit=0` — pytest 17656 collected / 0 failed, node 1292 / 0 fail | exit 0 |
| merged (`integ/claim-r6` = `ddbc65f0` + this branch) | `GATE: RESULT=PASS exit=0` — pytest 17657 collected / 0 failed, node 1292 / 0 fail | exit 0 |

**File overlap:** none. The three commits `main` gained since the branch point
(`c577ed0f`, `71db47b0`, `ddbc65f0`) touch `scripts/browser-bridge/**` and two
handoff docs; the merge was clean and no hunk is adjacent to this change. All 26
open PRs were checked for `claim-work` / `design-claim-by-push` / `shared-queue`
paths — zero overlap.

**The canonical remote was not touched.** All development ran against local bare
repos via `DEVRC_CLAIM_REMOTE`. The live `refs/heads/claim/*` set was recorded
before and after: none of the 11 pre-existing refs changed sha or disappeared; two
new ones appeared, both written by other sessions.

## What is NOT fixed / NOT verified

* **Pre-round-6 `owner-id:` refs stay stuck** — they carry no `clone-id:`. That is
  the majority of what is live on origin *today*, so F4 is closed going forward,
  not retroactively. Pinned and labelled rather than papered over.
* **Two sessions in one directory (R1) and the `cp -a` copy case (R4) are
  unchanged** — both still one owner, both still documented.
* **Nothing was deployed.** `home-manager switch` / `ship.sh` have not run, so the
  live `claim-work` on PATH is still the old copy until this merges and ships.
* No measurement was taken against the real origin's *behaviour* — only read-only
  `ls-remote`/`fetch` to establish the ref formats.
