### PR TITLE
rig-control: time-of-day RGB color schedule

### DIFF
--- a/scripts/rig-control.sh
+++ b/scripts/rig-control.sh
@@ -3,6 +3,10 @@
 # subsystems:
 #   * chassis RGB on/off  (MSI motherboard headers, OpenRGB device 2 — scoped so
 #                          the keyboard/mouse are never touched)
+#                          Colors shift by time of day:
+#                            10am amber → 11am golden → noon turquoise → 2pm blue
+#                            → 4pm violet → 5pm pink → 6pm tomato → 8pm orange-red
+#                            → 10pm red → midnight dark-red → 3am blackout
 #   * monitor blackout / restore  (DDC-CI backlight; delegates to monitor-blackout.sh)
 #
 # GUI: a single dark-themed yad button that toggles between sleep and wake.
@@ -29,7 +33,6 @@ DIR="$(dirname "$SELF")"
 # --- config ------------------------------------------------------------------
 RGB_DEVICE="${RIG_RGB_DEVICE:-2}"
 RGB_ON_MODE="${RIG_RGB_ON_MODE:-static}"
-RGB_ON_COLOR="${RIG_RGB_ON_COLOR:-FFFFFF}"
 STATE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/rig-control"
 STATE_FILE="$STATE_DIR/state"
 
@@ -43,8 +46,28 @@ notify() {
 is_asleep() { [[ -f "$STATE_FILE" ]] && read -r _state < "$STATE_FILE" && [[ "$_state" == "sleeping" ]]; }
 
 # --- chassis RGB (OpenRGB device 2 only) ------------------------------------
+# Time-of-day color: amber morning → bright/fun day → warm sunset → red late-night.
+# Sleep mode always uses black (000000) regardless of time.
+time_color() {
+  local h
+  h=$(date +%H)
+  case "$h" in
+    10)        echo "FFA500" ;;  # 10am  — amber (just woke)
+    11)        echo "FFBF00" ;;  # 11am  — golden
+    12|13)     echo "00CED1" ;;  # noon  — dark turquoise
+    14|15)     echo "1E90FF" ;;  # 2-3pm — dodger blue
+    16)        echo "9400D3" ;;  # 4pm   — violet
+    17)        echo "FF69B4" ;;  # 5pm   — hot pink
+    18|19)     echo "FF6347" ;;  # 6-7pm — tomato (sunset)
+    20|21)     echo "FF4500" ;;  # 8-9pm — orange red
+    22|23)     echo "FF0000" ;;  # 10-11pm — red
+    0|1|2)     echo "8B0000" ;;  # midnight-2am — dark red
+    *)         echo "FFA500" ;;  # 3am-9am (sleeping) — amber fallback
+  esac
+}
+
 rgb_on() {
-  openrgb --device "$RGB_DEVICE" --mode "$RGB_ON_MODE" --color "$RGB_ON_COLOR" >/dev/null 2>&1
+  openrgb --device "$RGB_DEVICE" --mode "$RGB_ON_MODE" --color "$(time_color)" >/dev/null 2>&1
 }
 
 rgb_off() {


### PR DESCRIPTION
Time-of-day RGB color schedule for chassis headers:

| Time | Color | Hex |
|---|---|---|
| 10am | Amber | FFA500 |
| 11am | Golden | FFBF00 |
| 12-1pm | Dark turquoise | 00CED1 |
| 2-3pm | Dodger blue | 1E90FF |
| 4pm | Violet | 9400D3 |
| 5pm | Hot pink | FF69B4 |
| 6-7pm | Tomato (sunset) | FF6347 |
| 8-9pm | Orange red | FF4500 |
| 10-11pm | Red | FF0000 |
| Midnight-2am | Dark red | 8B0000 |
| 3am-9am | Off (sleep mode) | 000000 |

Colors update on every wake/rgb-on call — bar toggle, scheduled timer, or CLI.