### PR TITLE
fix(writeback-guard): a card this session FILED is not a card it WORKED — check the role

### DIFF
--- a/scripts/claude-hooks/clawgate-writeback-guard.py
+++ b/scripts/claude-hooks/clawgate-writeback-guard.py
@@ -1209,9 +1209,37 @@ def has_live_agent(task):
     return agent.get("status") in LIVE_AGENT_STATUSES
 
 
+def session_role(task, session_id):
+    """This session's ROLE on the card — "worked" | "created" | "read" — or None.
+
+    Costs nothing extra, exactly like `has_live_agent`: `sessions` already rides along
+    in the `/api/tasks/{id}` payload `live_task` fetches, so this reads a field that
+    was paid for either way. Measured on the live board 2026-08-27: each entry carries
+    `sessionId`, `role`, `project`, `cwd`, `host`, `firstSeenAt`, `lastSeenAt`.
+
+    🔴 None is the LOUD direction. An absent `sessions` array, a shape this hook does
+    not recognise, an empty session id, or simply no row for this session all resolve
+    to None, which leaves the verdict wherever it already was — a guard that went
+    QUIET on a payload it could not parse would be walkable by any board change.
+    """
+    if not isinstance(task, dict) or not session_id:
+        return None
+    rows = task.get("sessions")
+    if not isinstance(rows, list):
+        return None
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        if r.get("sessionId") != session_id:
+            continue
+        role = r.get("role")
+        return role if isinstance(role, str) else None
+    return None
+
+
 def writeback_state(task, first_read_ts, skew=CLOCK_SKEW_ALLOWANCE_SECS,
-                    work_ts=None):
-    """"closed" | "written" | "delegated" | "missing" | "unknown" for one live task.
+                    work_ts=None, session_id=None):
+    """"closed" | "written" | "delegated" | "authored" | "missing" | "unknown".
 
     🔴 "delegated" is checked LAST, after the comment scan — never before it. A card
     can have both a live agent AND a real write-back, and that is "written"; ordering
@@ -1256,6 +1284,26 @@ def writeback_state(task, first_read_ts, skew=CLOCK_SKEW_ALLOWANCE_SECS,
             return "written"
     if has_live_agent(task):
         return "delegated"
+    # 🔴 CHECKED LAST, and additively — every branch above keeps its exact prior
+    # meaning. A card this session FILED is not a card this session WORKED: the body
+    # describes work to be done later, so there is nothing to write back yet.
+    #
+    # Measured 2026-08-27, and it is the reason this exists: authoring a task makes
+    # the guard fire on it TWICE OVER. `flows/task-authoring.md` Phase 0 mandates
+    # checking the board for an existing task, so reading the hits arms the guard on
+    # each; then `task create` returns only `{"id":N}` with no echo, so verifying the
+    # create means reading the new card, which arms it again. The session then does
+    # unrelated work and Stop blocks on a card nobody has started. The block asked for
+    # `ready_for_review`, which on task #390 would have pushed the operator a
+    # notification claiming a CONTROL-PLANE REBOOT task was ready for review.
+    #
+    # 🔴 ONLY "created" — never "read". A genuine pickup is a `read` too (read the
+    # card, work, then owe the comment), so suppressing `read` would disable the
+    # guard's entire purpose rather than narrow it. The duplicate-check read of an
+    # OTHER task during authoring therefore still fires, and that is deliberate: no
+    # field distinguishes it from a pickup that has not written back yet.
+    if session_role(task, session_id) == "created":
+        return "authored"
     return "missing"
 
 
@@ -1314,6 +1362,36 @@ def missing_text(task_id, first_read_ts, session_id=""):
            "dismiss": dismiss_cmd(task_id, session_id),
            "flow": FLOW_DEPLOYED, "flow_repo": FLOW_REPO}
     )
+
+
+def authored_text(task_id, session_id=""):
+    """A NOTICE, never a block: this session FILED task N rather than working it.
+
+    🔴 It is not silent, and that is the whole design of this rung. Upstream, `created`
+    is TERMINAL and outranks `worked` — so a session that files a card and then goes on
+    to DO it keeps the `created` role, and going silent here would lose exactly the
+    write-back this hook exists to protect. A notice ends the turn (it cannot force a
+    continuation) while still putting the one case that needs a human decision on
+    screen. Nothing here is owed unless that second sentence applies.
+    """
+    lines = [
+        "clawgate: task %d was FILED by this session, not worked — no write-back is "
+        "owed." % task_id,
+        "This is a NOTICE and nothing is blocked; the turn may end.",
+        "",
+        "🔴 UNLESS this session also DID the work on %d. Upstream, the `created` role "
+        "is terminal and outranks `worked`, so a file-then-work session still reads as "
+        "`created` and this hook cannot tell the two apart. If you worked it, write it "
+        "back yourself:" % task_id,
+        '  clawgatectl task comment %d --body "<what shipped, evidence per acceptance '
+        'criterion, and an explicit NOT-verified list>"' % task_id,
+        "",
+        "Do NOT flip the status just to quiet this line — `ready_for_review` pushes a "
+        "notification to Zach, and on a task nobody has started that is a false claim.",
+    ]
+    if session_id:
+        lines.append("session: %s" % session_id)
+    return "\n".join(lines)
 
 
 def unknown_text(task_id, first_read_ts, error, session_id=""):
@@ -1485,7 +1563,8 @@ def stop_decision(data, reader=None, budget=STOP_BUDGET_SECS,
         err = "the board returned a task payload this hook could not read"
         try:
             task = reader(tid, timeout=min(PER_TASK_TIMEOUT_SECS, remaining))
-            state = writeback_state(task, first_read_ts, work_ts=worked_at)
+            state = writeback_state(task, first_read_ts, work_ts=worked_at,
+                                    session_id=session_id)
         except LiveReadError as e:
             state, err = "unknown", e
         except Exception as e:            # noqa: BLE001 — a reader that raises anything
@@ -1494,6 +1573,16 @@ def stop_decision(data, reader=None, budget=STOP_BUDGET_SECS,
         # Burning a fire here would let a long agent run climb the ladder and then
         # block on a genuinely missing write-back with its budget already gone.
         if state in ("closed", "written", "delegated"):
+            continue
+        if state == "authored":
+            # 🔴 Appended to `notices`, NEVER to `blocks` — regardless of which rung
+            # `escalate` returns. Same clamp as "unknown" below and for the same
+            # reason: only a MEASURED missing write-back may spend the block budget,
+            # and a card this session merely filed is not one. Its own counter kind
+            # keeps it off the "missing" ladder entirely, so an authoring session
+            # cannot climb toward a block it can never legitimately reach.
+            if escalate(bump_fires(state_dir, tid, "authored")) != "silent":
+                notices.append(authored_text(tid, session_id))
             continue
         if state == "unknown":
             # 🔴 NEVER blocks, and spends its OWN counter. Cannot-measure is reported,

--- a/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
+++ b/scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
@@ -3213,3 +3213,107 @@ def test_positive_control_the_seam_assertions_can_actually_fail():
     # ...and one INSIDE it that names no file resolves to a path that is not there
     assert not _repo_path_for(
         DEPLOYED_SKILLS_PREFIX + "clawgate/flows/no-such-flow.md").is_file()
+
+
+# --------------------------------------------------------------------------- #
+# ROLE — a card this session FILED is not a card this session WORKED
+#
+# Authoring a task arms this guard TWICE: `flows/task-authoring.md` Phase 0 mandates
+# a duplicate check (reading the hits), and `task create` returns only `{"id":N}` so
+# verifying it means reading the new card. Measured 2026-08-27 on tasks #327 and #390.
+# --------------------------------------------------------------------------- #
+def sessioned(role, session=SESSION, **kw):
+    """A live task payload carrying the `sessions` array the board really returns.
+
+    Field set transcribed from `GET /api/tasks/390` on 2026-08-27, not invented: a
+    shape change at the far end surfaces here rather than passing on a fixture built
+    to fit the assertion.
+    """
+    rows = [{"sessionId": session, "role": role, "project": "datapacket-talos",
+             "cwd": "/home/zach/workspace/civit/datapacket-talos", "host": "nixos",
+             "firstSeenAt": READ_TS, "lastSeenAt": READ_TS, "detailAvailable": True}]
+    return dict(task(**kw), sessions=rows)
+
+
+def test_session_role_matches_on_ID_not_on_position():
+    """A second row FIRST, so a fixture cannot pass by reading `sessions[0]`."""
+    t = dict(task(), sessions=[
+        {"sessionId": SESSION_B, "role": "worked"},
+        {"sessionId": SESSION, "role": "created"},
+    ])
+    assert guard.session_role(t, SESSION) == "created"
+    assert guard.session_role(t, SESSION_B) == "worked"
+
+
+@pytest.mark.parametrize("payload_task,sid", [
+    (task(), SESSION),                                    # no `sessions` key at all
+    (dict(task(), sessions=None), SESSION),               # present but null
+    (dict(task(), sessions="created"), SESSION),          # not a list
+    (dict(task(), sessions=[{"sessionId": SESSION}]), SESSION),        # row, no role
+    (dict(task(), sessions=[{"sessionId": SESSION, "role": 7}]), SESSION),  # role not a str
+    (dict(task(), sessions=["created"]), SESSION),        # row not a dict
+    (sessioned("created"), SESSION_B),                    # no row for THIS session
+    (sessioned("created"), ""),                           # empty session id
+])
+def test_session_role_is_None_on_every_unreadable_shape(payload_task, sid):
+    """🔴 None is the LOUD direction — it leaves the verdict at `missing`. A guard that
+    went QUIET on a payload it could not parse would be walkable by any board change."""
+    assert guard.session_role(payload_task, sid) is None
+
+
+def test_a_card_this_session_FILED_reads_as_authored():
+    assert guard.writeback_state(sessioned("created"), READ_TS, work_ts=WORK_TS,
+                                 session_id=SESSION) == "authored"
+
+
+def test_a_REAL_write_back_still_wins_over_authored():
+    """🔴 Ordering. `authored` is checked LAST, so a session that filed a card AND
+    wrote it back reads as `written` — the informative verdict, not the excusing one."""
+    c = [{"author": guard.AGENT_AUTHOR, "createdAt": "2026-08-15T13:00:00.000000Z"}]
+    assert guard.writeback_state(sessioned("created", comments=c), READ_TS,
+                                 work_ts=WORK_TS, session_id=SESSION) == "written"
+
+
+@pytest.mark.parametrize("role", ["read", "worked"])
+def test_only_created_is_excused_never_read(role):
+    """🔴 THE CONTROL THAT MAKES THE FIX NARROW. A genuine pickup is a `read` too —
+    read the card, work, then owe the comment — so excusing `read` would disable the
+    guard's whole purpose instead of narrowing it. Same for a `worked` role with no
+    comment newer than the work."""
+    assert guard.writeback_state(sessioned(role), READ_TS, work_ts=WORK_TS,
+                                 session_id=SESSION) == "missing"
+
+
+def test_an_authored_card_NEVER_BLOCKS_end_to_end(home):
+    """The false positive itself, driven through `stop_decision`.
+
+    🔴 The board IS read, and that is asserted: a mutation reaching non-block by
+    skipping the live read instead of by classifying the role would pass a
+    verdict-only check."""
+    seed()
+    r = Reader(result=sessioned("created"))
+    kind, text = guard.stop_decision(payload("Stop"), reader=r)
+    assert kind == "notice"
+    assert [c[0] for c in r.calls] == [193]
+    assert "FILED by this session" in text
+
+
+def test_the_same_card_read_NOT_created_still_blocks(home):
+    """The positive control for the test above: identical fixture, one field changed,
+    and the guard must still block. Without this, `notice` above could mean the Stop
+    gate stopped working rather than that the role was honoured."""
+    seed()
+    kind, _ = guard.stop_decision(payload("Stop"), reader=Reader(result=sessioned("read")))
+    assert kind == "block"
+
+
+def test_authored_NEVER_climbs_to_a_block_however_many_stops(home):
+    """🔴 Through the LADDER, like the delegated-counter test. Four is strictly more
+    than MAX_BLOCKS (2) and MAX_FIRES (3), and equals neither, so this cannot pass by
+    construction. `authored` rides its own counter kind, so it can neither reach a
+    block nor spend the budget a genuinely missing write-back would need."""
+    seed()
+    kinds = [guard.stop_decision(payload("Stop"),
+                                 reader=Reader(result=sessioned("created")))[0]
+             for _ in range(4)]
+    assert "block" not in kinds


### PR DESCRIPTION
fix(writeback-guard): a card this session FILED is not a card it WORKED — check the role

The guard blocked twice in one session on tasks nobody had started, and the second
one would have been worse than a wasted turn.

## What it did

Authoring a task arms this guard TWICE OVER, and both arms are mandated by the flow
it is supposed to cooperate with:

  * `flows/task-authoring.md` Phase 0 REQUIRES a duplicate check — `task ls`, then
    reading the hits. Every hit is now a tracked read.
  * `task create` returns only `{"id":N}` with no echo, so verifying the create means
    reading the new card. That arms it again, on the card the session just filed.

The session then does unrelated work, Stop fires, and the guard blocks on a card
whose work has not begun. Measured 2026-08-27 on **#327** (read as a duplicate check)
and **#390** (filed by that session). On #390 the block asked for `ready_for_review`,
which would have pushed the operator a notification claiming a **control-plane reboot**
task was ready for review, on a card that is `gate:blocked` and whose blocking
prerequisite (#327, no etcd snapshot exists anywhere) is unmet.

## The fix, and why it costs nothing

`sessions` ALREADY rides along in the `/api/tasks/{id}` payload `live_task` fetches —
verified against the live board: each row carries `sessionId`, `role`, `project`,
`cwd`, `host`, `firstSeenAt`, `lastSeenAt`. So `session_role()` reads a field that was
paid for either way, exactly like `has_live_agent()`. No new request, no new endpoint.

`writeback_state` gains an `"authored"` verdict, checked LAST so every existing branch
keeps its exact prior meaning — a session that filed a card AND wrote it back still
reads `"written"`, which is the informative verdict rather than the excusing one.

## 🔴 ONLY `created`. Never `read`.

A genuine pickup is a `read` too — read the card, work, then owe the comment — so
excusing `read` would disable this guard's entire purpose instead of narrowing it.
The duplicate-check read of ANOTHER task during authoring therefore still fires, and
that is deliberate: no field distinguishes it from a pickup that has not written back
yet. #327's false positive is NOT fixed here, and should not be.

## 🔴 A NOTICE, not silence — because `created` is terminal upstream

`created` outranks `worked`, so a session that files a card and then goes on to DO it
keeps the `created` role. Going silent would lose exactly the write-back this hook
exists to protect. A notice ends the turn (it cannot force a continuation) while still
putting that one case on screen, and the text says plainly what to do if it applies —
and says NOT to flip the status just to quiet the line, because `ready_for_review`
pushes a notification.

It rides its OWN counter kind, appended to `notices` and never to `blocks` regardless
of which rung `escalate` returns — the same clamp as `unknown`, for the same reason:
only a MEASURED missing write-back may spend the block budget.

## Verified

  320 passed at HEAD (was 304 — 16 new).
  15 failed at origin/main with the identical test file.

🔴 The two END-TO-END cases fail at base for the RIGHT reason — a behavioural
assertion, not the new keyword argument:
    assert kind == "notice"     -> AssertionError: assert 'block' == 'notice'
    assert "block" not in kinds -> AssertionError: assert 'block' not in
                                   ['block', 'block', 'notice', 'silent']
That second list is the exact ladder that cost two turns today.

Controls, so a green run means something:
  * `test_the_same_card_read_NOT_created_still_blocks` — identical fixture, ONE field
    changed, must still block. Without it, the notice above could mean the Stop gate
    had stopped working rather than that the role was honoured. It PASSES at base too,
    which is correct: base blocks everything.
  * `test_session_role_matches_on_ID_not_on_position` puts a second row FIRST, so a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5yPJ1haNA2t9x2PxjrHr6
