### PR TITLE
fix(browser-bridge): reap the tab `open`'s bounded reuse probe orphans — and NOT by bounding tabs.create

### DIFF
--- a/claudedocs/handoff-bridge-unbounded-waits.md
+++ b/claudedocs/handoff-bridge-unbounded-waits.md
@@ -222,7 +222,7 @@ the browser-bridge and fixed at the source each time.
 
 ## Next steps (ranked)
 🔴 **Numbering is STABLE and is half a claim's identity — do not re-rank.** Items 1,
-2, 3 and 7 are DONE and are kept in place rather than renumbered.
+2, 3, 4 and 7 are DONE and are kept in place rather than renumbered.
 
 1. ✅ **DONE (#1316, squash `4379c27cf`, 2026-08-27)** — crops declared for `app-requests`
    and `playable-collections`; talos-infra #1297 closed.
@@ -241,12 +241,34 @@ the browser-bridge and fixed at the source each time.
    from "the CLI hung AFTER the reply". Watched firing in BOTH directions with two fake
    CLIs, not merely reasoned about. **See the new investigation block below — the cause
    may never have been this test at all.**
-4. **`open`'s fallthrough shares the suspected failure mode** — `devrc`,
-   `scripts/browser-bridge/extension/service_worker.js`. UNCHANGED. `chrome.tabs.create`
-   is another unbounded browser-process IPC, so a browser-wide stall leaks one tab per
-   `open` while returning success. 🔴 **THIS IS THE NEXT ITEM, and it is worth more than
-   its rank**: the #797 audit PREDICTED this shape would regenerate and #814 proved it
-   right, so this is the third instance of a class that is 2-for-2.
+4. ✅ **DONE (devrc PR #950)** — and, like item 3, **NOT as this item was framed**. The
+   item said to bound `chrome.tabs.create` as the third instance of the #797/#814
+   unbounded-await class. **Two measurements refused that remedy**, and the refusal is
+   the deliverable:
+   - `execute()`'s own rule forbids it: a local bound is granted only to *"an await
+     inside a `try` whose `catch` implements a RECOVERY (a second, working path) … If a
+     hung step has no alternative to fall through to, the choke point below is already
+     the right and only answer — do NOT add a bound for it."* `chrome.tabs.create` has
+     no second path, so a bound could only relabel `op_timeout:open` and leak the same
+     tab 2 s earlier.
+   - the harm the item NAMES — "leaks one tab per `open` while returning success" — is
+     the **reuse-probe fall-through**, which needs no hang in `create` at all, and
+     `server.py` had already written it down verbatim: *"deterministically ORPHANING
+     the live first tab. Nothing reclaims it; only a human closes it."*
+
+   So: `open` now **reaps** that orphan — timeout arm only, after the replacement
+   exists, fire-and-forget, and **only while the op is still alive**. That last clause
+   was NOT in the first draft; a blind audit found the tail, and it was reproduced
+   before being fixed: `execute()` races the op but cannot cancel it, so a merely SLOW
+   `chrome.tabs.create` resumes `open` after `op_timeout:open` has already been
+   answered — and on that path the server KEEPS ownership of a tab that is still live,
+   so a late reap destroys it and strands the session on a dead id.
+   🔴 **What is still open and deliberately out of scope**: the OTHER orphan. A
+   `chrome.tabs.create` that hangs and never settles is killed at
+   `EXEC_OP_BUDGET_MS` while the abandoned create later produces a tab `open` never
+   sees. Closing it needs the choke point to signal abandonment back into the op, which
+   it has no mechanism for. **If you pick that up, it is a choke-point change, not
+   another budget constant** — re-read `execute()`'s narrow-exception rule first.
 5. **Removing app-capture's raise** — `civitai/talos-infra`. 🔴 **PREMISE CHANGED**: the
    raise is not inert, only its i3 half is withheld. Re-scope before working it.
 6. **clawgate #358** — filed earlier, picked up by a different session. Not ours; live

--- a/claudedocs/handoff-bridge-unbounded-waits.md
+++ b/claudedocs/handoff-bridge-unbounded-waits.md
@@ -256,19 +256,40 @@ the browser-bridge and fixed at the source each time.
      `server.py` had already written it down verbatim: *"deterministically ORPHANING
      the live first tab. Nothing reclaims it; only a human closes it."*
 
-   So: `open` now **reaps** that orphan — timeout arm only, after the replacement
-   exists, fire-and-forget, and **only while the op is still alive**. That last clause
-   was NOT in the first draft; a blind audit found the tail, and it was reproduced
-   before being fixed: `execute()` races the op but cannot cancel it, so a merely SLOW
-   `chrome.tabs.create` resumes `open` after `op_timeout:open` has already been
-   answered — and on that path the server KEEPS ownership of a tab that is still live,
-   so a late reap destroys it and strands the session on a dead id.
+   So the orphan is now **reclaimed** — and 🔴 **WHERE that happens took three
+   rounds and two wrong answers, which is the durable lesson here.** Drafts 1 and 2
+   had the EXTENSION close the tab; both were wrong the same way. **Reclaiming is
+   correct only if the `open` result is DELIVERED** — if it is not, the old tab is not
+   an orphan at all: the ownership record still names it, it is still live, and closing
+   it strands the session on a dead id and then, one op later, on the operator's ACTIVE
+   tab. The extension cannot know, because **TWO parties abandon an op on TWO clocks
+   and neither is visible from inside it**:
+   - `execute()` RACES the op against `EXEC_OP_BUDGET_MS` and cannot cancel it, so a
+     merely SLOW `chrome.tabs.create` resumes `open` after `op_timeout:open` was
+     already answered. Found by a blind audit, **reproduced before fixing** (execMs 80,
+     hung `tabs.get`, create at 300 ms → `tabsRemove []` at return, `[5]` 600 ms later);
+   - the SUBMITTER gives up at its own `cmd_timeout`, which starts at **SUBMIT**, so
+     queue time is structurally invisible extension-side (`server.py`: *"The SUBMITTER
+     giving up … does NOT free the extension"*). Found by the DELTA audit of the fix
+     for the first — an elapsed-time guard in the extension closed one and could not
+     close the other.
+
+   Final shape: the extension **reports** `orphanTabId` and closes nothing; the server
+   closes it in `_record_ownership_locked`, which by construction runs only on a
+   delivered result. That deleted the elapsed guard, its `startedAt` stamp, and a
+   fixture problem along with it — **the party that knows should decide.**
+   🔴 **NEW HAZARD THIS CREATED, and it is disclosed rather than fixed**: parallel
+   agents can derive the SAME session id and share one owned tab (observed
+   2026-07-31, recorded in `scripts/browser-bridge/reference/tabs-instances.md`). A
+   re-`open` by one sibling whose probe times out now closes the tab the OTHER is
+   mid-workflow on. Previously that collision was benign.
    🔴 **What is still open and deliberately out of scope**: the OTHER orphan. A
-   `chrome.tabs.create` that hangs and never settles is killed at
+   `chrome.tabs.create` that hangs and NEVER settles is killed at
    `EXEC_OP_BUDGET_MS` while the abandoned create later produces a tab `open` never
-   sees. Closing it needs the choke point to signal abandonment back into the op, which
-   it has no mechanism for. **If you pick that up, it is a choke-point change, not
-   another budget constant** — re-read `execute()`'s narrow-exception rule first.
+   sees — so there is nothing to report. Closing it needs the choke point to signal
+   abandonment back into the op, which it has no mechanism for. **If you pick that up,
+   it is a choke-point change, not another budget constant** — re-read `execute()`'s
+   narrow-exception rule first.
 5. **Removing app-capture's raise** — `civitai/talos-infra`. 🔴 **PREMISE CHANGED**: the
    raise is not inert, only its i3 half is withheld. Re-scope before working it.
 6. **clawgate #358** — filed earlier, picked up by a different session. Not ours; live

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -232,7 +232,7 @@ has not been exercised against a third-party authenticated API beyond that.)
 | `tabs`       | `chrome.tabs.query({})`                                   | `{tabs:[...],ownedTabId}` |
 | `nav`        | `chrome.tabs.update(tab,{url})`                           | `{tabId,url}` |
 | `screenshot` | **CDP `Page.captureScreenshot`** (png) — works on a BACKGROUND/occluded tab + each profile's own tab; a foreground tab uses the cheap `captureVisibleTab` fast path. `fullpage` grabs the whole document. The CLI decodes `dataUrl` to a **`.png` on disk** and prints a path, never the base64 (see below) | `{url,dataUrl,via}` |
-| `open`       | `chrome.tabs.create({url,active:false})` — **background/HIDDEN** (`visibilityState:"hidden"` → Chromium throttles it → a heavy SPA won't render → reads return a shell). The escape hatch is **`browser wake`** (or a `--wake` read): it un-throttles the tab and moves NO focus. Reads self-announce this via `hidden`/`note` | `{tabId,url}` |
+| `open`       | `chrome.tabs.create({url,active:false})` — **background/HIDDEN** (`visibilityState:"hidden"` → Chromium throttles it → a heavy SPA won't render → reads return a shell). The escape hatch is **`browser wake`** (or a `--wake` read): it un-throttles the tab and moves NO focus. Reads self-announce this via `hidden`/`note`. On a re-`open` whose reuse probe TIMES OUT, it also **closes the orphaned previous tab** and reports `reapAttempted` | `{tabId,url}` (+`reapAttempted` when it reaped) |
 | `close`      | `chrome.tabs.remove(tabId)`                               | `{closed:tabId}` |
 | `emulate`    | **device emulation** — CDP `Emulation.setDeviceMetricsOverride` / `setTouchEmulationEnabled` / `setUserAgentOverride` (**+`userAgentMetadata`**) / `setEmulatedMedia` / `setTimezoneOverride` / `setGeolocationOverride`, from a named preset or raw params. **Sticky per tab** (re-applied inside every later CDP session) and **owned-tab-only**. `--reset` stops re-applying **and restores the viewport** — it sends an arm-then-clear pair, because a bare `clearDeviceMetricsOverride` is a measured no-op (#319). `--reset --recreate` replaces the tab (new tab id) instead, and is the only remedy for a tab the extension cannot reach | `{tabId,url,emulation,applied,note}` or `{tabId,url,reset,wasEmulating,cleared,restored,note}` |
 | `frames`     | **`chrome.webNavigation.getAllFrames`** — the tab's frames INCLUDING cross-origin OUT-OF-PROCESS iframes (OOPIFs) | `{url,title,frames:[{frameId,url,parentFrameId}]}` |
@@ -1945,6 +1945,16 @@ per-session (multi-step **workflow**) isolation did not.
   deliberately restricted to the *timeout* arm; when the probe REJECTS, the tab is
   known absent and a `remove` would only risk a recycled tabId. If the owned
   tab is **gone**, `open` transparently creates a fresh one.
+  🔴 **What this looks like to you, stated because it is the first tab close the
+  extension performs that nobody asked for.** Bridge tabs open `active:false`, but
+  `browser activate` foregrounds them and that is the ordinary workflow — so the
+  page you are *looking at* can vanish mid-session on a re-`open`, taking scroll
+  position, form state and any playing media with it. You get a fresh tab at the
+  requested url in its place. The envelope says so: an `open` that reaped carries
+  **`reapAttempted: <tabId>`** (ATTEMPTED, not closed — nothing awaits the
+  result). An ordinary `open` envelope is unchanged. The reap never fires once the
+  op has already timed out, because on *that* path the old tab is still owned and
+  still usable.
 - **Self-heal on a vanished owned tab.** If the user manually closes an owned
   background tab, the next tab-scoped op dispatches the stale tabId and the
   extension returns `owned_tab_gone` (ok:false). The server then **drops** that

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -1328,14 +1328,21 @@ Two changes close it:
       ⚠ **Cost:** falling through on a merely *slow* `tabs.get` opens a second tab
       while the first is still live and unowned, i.e. the exact tab leak the reuse
       path exists to prevent. A rare orphaned tab is traded for a
-      guaranteed-terminating op — **and that orphan is now reaped**: `open` closes
-      it itself, on the timeout arm only, *after* the replacement exists, and
-      fire-and-forget (awaiting `chrome.tabs.remove` would add a new unbounded
-      `chrome.*` await to the success path — the very class this bound exists to
-      remove). Best-effort, not a guarantee: the browser-wide stall that hung
-      `tabs.get` can hang `tabs.remove` too, and a *different* orphan — one from a
-      hung `chrome.tabs.create`, whose op is killed at `EXEC_OP_BUDGET_MS` while
-      the abandoned create still settles — is still unreclaimed by design.
+      guaranteed-terminating op — **and that orphan is now reclaimed**: `open`
+      REPORTS it as `orphanTabId` and closes nothing; the SERVER issues the
+      `close`, from the one place that knows the `open` result was delivered.
+      (An earlier revision of this paragraph said `open` "closes it itself,
+      fire-and-forget". That was the FIRST design, superseded — the extension
+      calls `chrome.tabs.remove` **never**, pinned by `service_worker.test.mjs`.
+      Recorded rather than quietly rewritten: this same paragraph, in two files,
+      has now been the stale one twice.) Best-effort, not a guarantee: the
+      reclaim is a real op that can fail or be lost; it is withdrawn if the
+      session re-owns that tab before it is dispatched, and dropped rather than
+      dispatched if it is not picked up within `INFLIGHT_STALE_S`. A *different*
+      orphan — one from a `chrome.tabs.create` that hangs and never settles,
+      whose op is killed at `EXEC_OP_BUDGET_MS` while the abandoned create still
+      produces a tab nobody sees — cannot even be reported, and is unreclaimed by
+      design.
       ⚠ **Evidence, honestly:** unlike (1), there is **no live measurement of a
       hung `chrome.tabs.get`** — this is the same mechanism reasoned about from
       the code (the await is unbounded; the catch is structurally blind to a
@@ -1960,14 +1967,17 @@ per-session (multi-step **workflow**) isolation did not.
   sibling whose probe times out therefore closes the tab the OTHER is mid-workflow
   on. That collision was previously benign; it is not any more.
   ⚠ **The reclaim is not guaranteed, and it is bounded on both sides.** It is a
-  real `close` op that can fail or be lost, and nothing counts how often. Three
-  things ARE structural: it never fires when the `open` result was not delivered
+  real `close` op that can fail or be lost, and nothing counts how often. One
+  thing IS structural: it never fires when the `open` result was not delivered
   (on those paths the old tab is still owned and still usable, so closing it would
-  be the worse error); **re-owning a tab withdraws any reclaim queued for it**, so
-  a second `open` that healthily reuses the tab cancels the close; and a reclaim
-  that has not been picked up within `INFLIGHT_STALE_S` is **dropped rather than
-  dispatched**, because after a Brave restart the same tab id names a different
-  tab.
+  be the worse error). Two more bound it, both with a real edge:
+  **re-owning a tab withdraws any reclaim still QUEUED for it** — so a second
+  `open` that healthily reuses the tab cancels the close, *unless the close has
+  already been handed to the extension*, which leaves a window of one poll round
+  trip; and a reclaim not picked up within `INFLIGHT_STALE_S` is **dropped rather
+  than dispatched**, because after a Brave restart the same tab id names a
+  different tab — so that orphan is then never reclaimed at all, which is the
+  trade deliberately taken over closing a stranger's tab.
 - **Self-heal on a vanished owned tab.** If the user manually closes an owned
   background tab, the next tab-scoped op dispatches the stale tabId and the
   extension returns `owned_tab_gone` (ok:false). The server then **drops** that

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -232,7 +232,7 @@ has not been exercised against a third-party authenticated API beyond that.)
 | `tabs`       | `chrome.tabs.query({})`                                   | `{tabs:[...],ownedTabId}` |
 | `nav`        | `chrome.tabs.update(tab,{url})`                           | `{tabId,url}` |
 | `screenshot` | **CDP `Page.captureScreenshot`** (png) — works on a BACKGROUND/occluded tab + each profile's own tab; a foreground tab uses the cheap `captureVisibleTab` fast path. `fullpage` grabs the whole document. The CLI decodes `dataUrl` to a **`.png` on disk** and prints a path, never the base64 (see below) | `{url,dataUrl,via}` |
-| `open`       | `chrome.tabs.create({url,active:false})` — **background/HIDDEN** (`visibilityState:"hidden"` → Chromium throttles it → a heavy SPA won't render → reads return a shell). The escape hatch is **`browser wake`** (or a `--wake` read): it un-throttles the tab and moves NO focus. Reads self-announce this via `hidden`/`note`. On a re-`open` whose reuse probe TIMES OUT, it also **closes the orphaned previous tab** and reports `reapAttempted` | `{tabId,url}` (+`reapAttempted` when it reaped) |
+| `open`       | `chrome.tabs.create({url,active:false})` — **background/HIDDEN** (`visibilityState:"hidden"` → Chromium throttles it → a heavy SPA won't render → reads return a shell). The escape hatch is **`browser wake`** (or a `--wake` read): it un-throttles the tab and moves NO focus. Reads self-announce this via `hidden`/`note`. On a re-`open` whose reuse probe TIMES OUT it **reports the tab it orphaned** as `orphanTabId`, and the SERVER then closes that tab | `{tabId,url}` (+`orphanTabId` when it orphaned one) |
 | `close`      | `chrome.tabs.remove(tabId)`                               | `{closed:tabId}` |
 | `emulate`    | **device emulation** — CDP `Emulation.setDeviceMetricsOverride` / `setTouchEmulationEnabled` / `setUserAgentOverride` (**+`userAgentMetadata`**) / `setEmulatedMedia` / `setTimezoneOverride` / `setGeolocationOverride`, from a named preset or raw params. **Sticky per tab** (re-applied inside every later CDP session) and **owned-tab-only**. `--reset` stops re-applying **and restores the viewport** — it sends an arm-then-clear pair, because a bare `clearDeviceMetricsOverride` is a measured no-op (#319). `--reset --recreate` replaces the tab (new tab id) instead, and is the only remedy for a tab the extension cannot reach | `{tabId,url,emulation,applied,note}` or `{tabId,url,reset,wasEmulating,cleared,restored,note}` |
 | `frames`     | **`chrome.webNavigation.getAllFrames`** — the tab's frames INCLUDING cross-origin OUT-OF-PROCESS iframes (OOPIFs) | `{url,title,frames:[{frameId,url,parentFrameId}]}` |
@@ -1940,21 +1940,29 @@ per-session (multi-step **workflow**) isolation did not.
   tabId as `reuseTabId`; the extension reuses it) instead of creating a second
   real tab — so a double `open` does not orphan the first tab **unless the reuse
   probe exceeds `REUSE_TAB_BUDGET_MS`**, in which case it falls through to a fresh
-  tab and the first one is orphaned — and then **reaped**: the extension closes
-  it, best-effort and fire-and-forget, once the replacement exists. Reaping is
-  deliberately restricted to the *timeout* arm; when the probe REJECTS, the tab is
-  known absent and a `remove` would only risk a recycled tabId. If the owned
-  tab is **gone**, `open` transparently creates a fresh one.
-  🔴 **What this looks like to you, stated because it is the first tab close the
-  extension performs that nobody asked for.** Bridge tabs open `active:false`, but
-  `browser activate` foregrounds them and that is the ordinary workflow — so the
-  page you are *looking at* can vanish mid-session on a re-`open`, taking scroll
-  position, form state and any playing media with it. You get a fresh tab at the
-  requested url in its place. The envelope says so: an `open` that reaped carries
-  **`reapAttempted: <tabId>`** (ATTEMPTED, not closed — nothing awaits the
-  result). An ordinary `open` envelope is unchanged. The reap never fires once the
-  op has already timed out, because on *that* path the old tab is still owned and
-  still usable.
+  tab and the first one is orphaned — and then **reclaimed**. The extension
+  **reports** it as `orphanTabId` and closes nothing; the SERVER issues the
+  `close`, from the one place that knows the `open` result was actually delivered
+  (`_record_ownership_locked`). Reporting is deliberately restricted to the
+  *timeout* arm; when the probe REJECTS, the tab is known absent and a `remove`
+  would only risk a recycled tabId. If the owned tab is **gone**, `open`
+  transparently creates a fresh one.
+  🔴 **What this looks like to you, because it is the one tab close nobody asked
+  for.** Bridge tabs open `active:false`, but `browser activate` foregrounds them
+  and that is the ordinary workflow — so the page you are *looking at* can vanish
+  mid-session on a re-`open`, taking scroll position, form state and any playing
+  media with it. You get a fresh tab at the requested url in its place. The
+  envelope says so: an `open` that orphaned a tab carries
+  **`orphanTabId: <tabId>`**; an ordinary `open` envelope is unchanged.
+  🔴 **And it may not be YOUR tab.** Parallel agents can derive the same session
+  id and therefore share one owned tab (see `reference/tabs-instances.md` — a
+  sibling's tab being handed over was observed 2026-07-31). A re-`open` by one
+  sibling whose probe times out therefore closes the tab the OTHER is mid-workflow
+  on. That collision was previously benign; it is not any more.
+  ⚠ **The reclaim is not guaranteed.** It is a real `close` op that can fail or
+  be lost, and nothing counts how often. What IS structural is that it never fires
+  when the `open` result was not delivered — on those paths the old tab is still
+  owned and still usable, so closing it would be the worse error.
 - **Self-heal on a vanished owned tab.** If the user manually closes an owned
   background tab, the next tab-scoped op dispatches the stale tabId and the
   extension returns `owned_tab_gone` (ok:false). The server then **drops** that

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -1328,7 +1328,14 @@ Two changes close it:
       ⚠ **Cost:** falling through on a merely *slow* `tabs.get` opens a second tab
       while the first is still live and unowned, i.e. the exact tab leak the reuse
       path exists to prevent. A rare orphaned tab is traded for a
-      guaranteed-terminating op.
+      guaranteed-terminating op — **and that orphan is now reaped**: `open` closes
+      it itself, on the timeout arm only, *after* the replacement exists, and
+      fire-and-forget (awaiting `chrome.tabs.remove` would add a new unbounded
+      `chrome.*` await to the success path — the very class this bound exists to
+      remove). Best-effort, not a guarantee: the browser-wide stall that hung
+      `tabs.get` can hang `tabs.remove` too, and a *different* orphan — one from a
+      hung `chrome.tabs.create`, whose op is killed at `EXEC_OP_BUDGET_MS` while
+      the abandoned create still settles — is still unreclaimed by design.
       ⚠ **Evidence, honestly:** unlike (1), there is **no live measurement of a
       hung `chrome.tabs.get`** — this is the same mechanism reasoned about from
       the code (the await is unbounded; the catch is structurally blind to a
@@ -1933,7 +1940,10 @@ per-session (multi-step **workflow**) isolation did not.
   tabId as `reuseTabId`; the extension reuses it) instead of creating a second
   real tab — so a double `open` does not orphan the first tab **unless the reuse
   probe exceeds `REUSE_TAB_BUDGET_MS`**, in which case it falls through to a fresh
-  tab and the first one IS orphaned with nothing to reclaim it. If the owned
+  tab and the first one is orphaned — and then **reaped**: the extension closes
+  it, best-effort and fire-and-forget, once the replacement exists. Reaping is
+  deliberately restricted to the *timeout* arm; when the probe REJECTS, the tab is
+  known absent and a `remove` would only risk a recycled tabId. If the owned
   tab is **gone**, `open` transparently creates a fresh one.
 - **Self-heal on a vanished owned tab.** If the user manually closes an owned
   background tab, the next tab-scoped op dispatches the stale tabId and the

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -1959,10 +1959,15 @@ per-session (multi-step **workflow**) isolation did not.
   sibling's tab being handed over was observed 2026-07-31). A re-`open` by one
   sibling whose probe times out therefore closes the tab the OTHER is mid-workflow
   on. That collision was previously benign; it is not any more.
-  ⚠ **The reclaim is not guaranteed.** It is a real `close` op that can fail or
-  be lost, and nothing counts how often. What IS structural is that it never fires
-  when the `open` result was not delivered — on those paths the old tab is still
-  owned and still usable, so closing it would be the worse error.
+  ⚠ **The reclaim is not guaranteed, and it is bounded on both sides.** It is a
+  real `close` op that can fail or be lost, and nothing counts how often. Three
+  things ARE structural: it never fires when the `open` result was not delivered
+  (on those paths the old tab is still owned and still usable, so closing it would
+  be the worse error); **re-owning a tab withdraws any reclaim queued for it**, so
+  a second `open` that healthily reuses the tab cancels the close; and a reclaim
+  that has not been picked up within `INFLIGHT_STALE_S` is **dropped rather than
+  dispatched**, because after a Brave restart the same tab id names a different
+  tab.
 - **Self-heal on a vanished owned tab.** If the user manually closes an owned
   background tab, the next tab-scoped op dispatches the stale tabId and the
   extension returns `owned_tab_gone` (ok:false). The server then **drops** that

--- a/scripts/browser-bridge/extension/build_id.js
+++ b/scripts/browser-bridge/extension/build_id.js
@@ -24,4 +24,4 @@
 //   * a hash computed in the worker over its own source — same disk read
 // The marker must be a LITERAL in a module the worker imported, so that it was
 // frozen into the loaded module graph at load time and travels with the code.
-export const BUILD_MARKER = "8936861db19e232f";
+export const BUILD_MARKER = "b817ef1e88267a40";

--- a/scripts/browser-bridge/extension/build_id.js
+++ b/scripts/browser-bridge/extension/build_id.js
@@ -24,4 +24,4 @@
 //   * a hash computed in the worker over its own source — same disk read
 // The marker must be a LITERAL in a module the worker imported, so that it was
 // frozen into the loaded module graph at load time and travels with the code.
-export const BUILD_MARKER = "e1ee86a50a811d40";
+export const BUILD_MARKER = "18304ead05a6e386";

--- a/scripts/browser-bridge/extension/build_id.js
+++ b/scripts/browser-bridge/extension/build_id.js
@@ -24,4 +24,4 @@
 //   * a hash computed in the worker over its own source — same disk read
 // The marker must be a LITERAL in a module the worker imported, so that it was
 // frozen into the loaded module graph at load time and travels with the code.
-export const BUILD_MARKER = "9a3c89153f041614";
+export const BUILD_MARKER = "8936861db19e232f";

--- a/scripts/browser-bridge/extension/build_id.js
+++ b/scripts/browser-bridge/extension/build_id.js
@@ -24,4 +24,4 @@
 //   * a hash computed in the worker over its own source — same disk read
 // The marker must be a LITERAL in a module the worker imported, so that it was
 // frozen into the loaded module graph at load time and travels with the code.
-export const BUILD_MARKER = "18304ead05a6e386";
+export const BUILD_MARKER = "9a3c89153f041614";

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -1817,11 +1817,20 @@ export const FAST_CAPTURE_BUDGET_MS = 1500;
 // in the extension and both were wrong the same way.
 //
 // So read the trade as "a rare orphaned tab, reclaimed when the op landed" rather
-// than "a rare orphaned tab, permanent". It does NOT become free: the reclaim is
-// a real op that can fail, nothing counts how often, and the OTHER orphan — a
-// `chrome.tabs.create` that hangs and NEVER settles, whose op dies at
-// EXEC_OP_BUDGET_MS while the abandoned create still produces a tab nobody ever
-// sees — cannot even be reported, and is deliberately out of scope.
+// than "a rare orphaned tab, permanent". It does NOT become free — THREE ways the
+// orphan still survives, and this list is the one `server.py`'s sibling block
+// tells you to extend whenever a bound is added (it was already incomplete once,
+// and this copy was the one missed):
+//   1. the reclaim is a real `close` op that can fail or be lost, and nothing
+//      counts how often;
+//   2. a reclaim not picked up within INFLIGHT_STALE_S is DROPPED rather than
+//      dispatched — deliberately, since after a browser restart that tabId names
+//      a different tab — so that orphan is never reclaimed at all. Note this one
+//      happens AFTER the op landed, which is why (1) alone does not cover it;
+//   3. the OTHER orphan — a `chrome.tabs.create` that hangs and NEVER settles,
+//      whose op dies at EXEC_OP_BUDGET_MS while the abandoned create still
+//      produces a tab nobody ever sees — cannot even be reported, and is
+//      deliberately out of scope.
 //
 // ⚠ LOOP_STALL_MS's worst-legitimate-iteration sum was CHECKED and does NOT move.
 // That comment warns "ADDING A NEW BOUNDED AWAIT TO THE LOOP BODY EATS INTO IT",

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -1803,6 +1803,18 @@ export const FAST_CAPTURE_BUDGET_MS = 1500;
 // is no abort primitive for `chrome.tabs.get`, so the abandoned call still settles
 // in the background — harmlessly, since its result is no longer read.
 //
+// ⚠ THAT COST IS NOW REAPED, AND THE PARAGRAPH ABOVE IS KEPT VERBATIM ON PURPOSE
+// — it is the derivation of the constant, and rewriting it would erase why 2000
+// was chosen. What changed is only the LAST step: `open` now closes the orphaned
+// tab itself, on the timeout arm only, after the replacement exists,
+// fire-and-forget (never awaited — awaiting `chrome.tabs.remove` would put a NEW
+// unbounded chrome.* await on the success path, regenerating this very class).
+// So read the trade as "a rare orphaned tab, best-effort reclaimed" rather than
+// "a rare orphaned tab, permanent". It does NOT become free: a browser-wide stall
+// defeats the reap too, and the OTHER orphan — a hung `chrome.tabs.create`, whose
+// op is killed at EXEC_OP_BUDGET_MS while the abandoned create still settles — is
+// still unreclaimed and deliberately out of scope.
+//
 // ⚠ LOOP_STALL_MS's worst-legitimate-iteration sum was CHECKED and does NOT move.
 // That comment warns "ADDING A NEW BOUNDED AWAIT TO THE LOOP BODY EATS INTO IT",
 // which is about the LOOP BODY's own awaits. This bound sits INSIDE execute(),

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -1803,17 +1803,25 @@ export const FAST_CAPTURE_BUDGET_MS = 1500;
 // is no abort primitive for `chrome.tabs.get`, so the abandoned call still settles
 // in the background — harmlessly, since its result is no longer read.
 //
-// ⚠ THAT COST IS NOW REAPED, AND THE PARAGRAPH ABOVE IS KEPT VERBATIM ON PURPOSE
-// — it is the derivation of the constant, and rewriting it would erase why 2000
-// was chosen. What changed is only the LAST step: `open` now closes the orphaned
-// tab itself, on the timeout arm only, after the replacement exists,
-// fire-and-forget (never awaited — awaiting `chrome.tabs.remove` would put a NEW
-// unbounded chrome.* await on the success path, regenerating this very class).
-// So read the trade as "a rare orphaned tab, best-effort reclaimed" rather than
-// "a rare orphaned tab, permanent". It does NOT become free: a browser-wide stall
-// defeats the reap too, and the OTHER orphan — a hung `chrome.tabs.create`, whose
-// op is killed at EXEC_OP_BUDGET_MS while the abandoned create still settles — is
-// still unreclaimed and deliberately out of scope.
+// ⚠ THAT COST IS NOW RECLAIMED, AND THE PARAGRAPH ABOVE IS KEPT VERBATIM ON
+// PURPOSE — it is the derivation of the constant, and rewriting it would erase
+// why 2000 was chosen. What changed is only the LAST step: `open` REPORTS the
+// orphaned tabId (`orphanTabId`) and the SERVER closes it, in
+// `_record_ownership_locked`, which runs only on a DELIVERED result.
+//
+// 🔴 THE DIVISION MATTERS AND `open`'s COMMENT EXPLAINS IT AT LENGTH: reclaiming
+// is correct only if the result is delivered, and the extension cannot know that
+// — TWO parties abandon an op on TWO clocks (execute()'s EXEC_OP_BUDGET_MS race,
+// which does not cancel; and the submitter's cmd_timeout, which starts at SUBMIT
+// so queue time is invisible extension-side). Two earlier drafts closed the tab
+// in the extension and both were wrong the same way.
+//
+// So read the trade as "a rare orphaned tab, reclaimed when the op landed" rather
+// than "a rare orphaned tab, permanent". It does NOT become free: the reclaim is
+// a real op that can fail, nothing counts how often, and the OTHER orphan — a
+// `chrome.tabs.create` that hangs and NEVER settles, whose op dies at
+// EXEC_OP_BUDGET_MS while the abandoned create still produces a tab nobody ever
+// sees — cannot even be reported, and is deliberately out of scope.
 //
 // ⚠ LOOP_STALL_MS's worst-legitimate-iteration sum was CHECKED and does NOT move.
 // That comment warns "ADDING A NEW BOUNDED AWAIT TO THE LOOP BODY EATS INTO IT",

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -1230,6 +1230,10 @@ const OPS = {
     // The tabId to reclaim after the fall-through succeeds, or null. Set ONLY on
     // the timeout arm — see the catch for why the rejection arm must not reap.
     let orphanTabId = null;
+    // Stamped BEFORE anything is awaited: the reap below must not fire once
+    // execute() has already given up on this op (it races us, it cannot cancel
+    // us). See the elapsed check for what a late reap actually destroys.
+    const startedAt = Date.now();
     if (cmd && cmd.reuseTabId != null) {
       try {
         const existing = await promiseWithTimeout(
@@ -1257,15 +1261,23 @@ const OPS = {
           String((e && e.message) || e).startsWith("reuse_tab_timeout");
         breadcrumb("open", (cmd && cmd.id) || null,
                    timedOut ? "open_reuse_timeout" : "open_reuse_gone");
-        // 🔴 REAP ONLY ON THE TIMEOUT ARM. The two arms carry OPPOSITE evidence
-        // about the tab, and that asymmetry is the whole safety argument:
-        //   * timeout  → we learned NOTHING. The tab is probably still live, and
-        //                the fall-through is about to orphan it. Reap.
-        //   * rejection → `chrome.tabs.get` answered, naming the id as absent.
-        //                Reaping would be a remove against an id we have positive
-        //                evidence is gone — pure exposure (Chromium can recycle a
-        //                tabId, which this file already reasons about in `close`)
-        //                for zero reclaimed tabs. Do not.
+        // 🔴 REAP ONLY ON THE TIMEOUT ARM — and the argument is EXPECTED VALUE,
+        // not a claim that the timeout arm is the safer one. It is not: a
+        // recycled tabId is a hazard on BOTH arms, and the timeout arm's remove
+        // is issued LATER (after an unbounded `chrome.tabs.create`), so its
+        // recycle window is strictly the WIDER of the two. What separates them is
+        // the numerator:
+        //   * rejection → `chrome.tabs.get` ANSWERED, naming the id as absent.
+        //                 Expected tabs reclaimed: ZERO. Any exposure at all,
+        //                 however small, buys nothing. Do not reap.
+        //   * timeout   → the probe answered NOTHING. A live tab is about to be
+        //                 orphaned with no owner, and reclaiming it is the whole
+        //                 point of this change. A non-zero exposure is justified
+        //                 by a non-zero return.
+        // (An earlier draft of this comment argued the rejection arm was refused
+        // because reaping there is "pure exposure" while implying the timeout arm
+        // was not exposed. That reasoning was one-sided and did not carry the
+        // conclusion, even though the conclusion is right.)
         orphanTabId = timedOut ? cmd.reuseTabId : null;
         /* owned tab gone (or hung) → open a fresh one below */
       }
@@ -1278,6 +1290,30 @@ const OPS = {
     // exists — reaping first would close the session's only tab and then, if the
     // create failed, leave it owning a dead id.
     //
+    // 🔴 AND ONLY WHILE THE OP IS STILL ALIVE. execute() RACES this function
+    // against execMs; it does not CANCEL it. So a `chrome.tabs.create` that is
+    // merely slow — settling at, say, 17s — resumes us LONG AFTER execute() has
+    // already answered `op_timeout:open` and moved on. Reaping then is actively
+    // HARMFUL rather than merely useless, and the harm is not the one the
+    // residual list below used to describe:
+    //
+    //   * the server saw `ok:false` with error `op_timeout:open`. That is not a
+    //     tab-gone error, so `_record_ownership_locked` KEEPS the session's
+    //     ownership pointing at the OLD tab (server.py) — which, on that path,
+    //     is still live and still perfectly usable. Pre-change, the next `open`
+    //     simply reused it.
+    //   * a late reap destroys exactly that tab. The session is now left owning
+    //     a dead id; its next op gets `owned_tab_gone`, the server self-heals by
+    //     dropping the mapping, and the op AFTER that falls back to the
+    //     operator's ACTIVE tab — the blast radius the ownership map exists to
+    //     prevent.
+    //
+    // MEASURED, not reasoned: with execMs 80, a hung `tabs.get` and a create
+    // resolving at 300ms, execute() returned `op_timeout:open` with tabsRemove
+    // [] — and 600ms later tabsRemove was [5]. The elapsed check below is what
+    // turns that into a no-op. `>=` deliberately: at exactly execMs the race has
+    // fired, and a tie must skip.
+    //
     // 🔴 FIRE-AND-FORGET, NEVER AWAITED, AND THAT IS LOAD-BEARING. `tabs.remove`
     // is one more unbounded browser-process IPC; awaiting it would put a NEW
     // unbounded await on `open`'s success path — re-creating, at the last line of
@@ -1287,23 +1323,42 @@ const OPS = {
     // ⚠ WHAT THIS DOES **NOT** FIX, stated rather than discovered later:
     //   (a) A browser-wide stall defeats the reap too — the same stall that hung
     //       `tabs.get` can hang `tabs.remove`, and nothing here waits to find
-    //       out. It is best-effort by construction, not a guarantee.
-    //   (b) The OTHER orphan is untouched: if `chrome.tabs.create` itself hangs,
-    //       execute() kills the op at EXEC_OP_BUDGET_MS while the abandoned
-    //       create still settles in the background, producing a tab this function
-    //       never sees and therefore cannot reap. Closing that one needs the
-    //       choke point to signal abandonment back into the op, which it has no
-    //       mechanism for today. Deliberately out of scope.
-    //   (c) No new exposure class: this is the SAME `chrome.tabs.remove(<the
-    //       session's owned tabId>)` that the `close` op already performs
-    //       unconditionally, on an id the server vouched for moments earlier.
-    if (orphanTabId != null) {
+    //       out. It is best-effort by construction, not a guarantee. And because
+    //       nothing waits, THE FAILURE IS UNOBSERVABLE: `reapAttempted` below
+    //       reports that the call was ISSUED, never that a tab was closed. There
+    //       is no production counter for how often either happens, deliberately
+    //       — the breadcrumb slot execute() clobbers could not carry one.
+    //   (b) The OTHER orphan is untouched: if `chrome.tabs.create` hangs and
+    //       NEVER settles, execute() kills the op at EXEC_OP_BUDGET_MS and the
+    //       abandoned create later produces a tab this function never sees and
+    //       therefore cannot reap. (The SLOW-but-settling variant is the case
+    //       the elapsed check above handles: there we do resume, and we
+    //       deliberately do nothing.) Closing (b) needs the choke point to
+    //       signal abandonment back into the op, which it cannot do today.
+    //   (c) No new CAPABILITY: `chrome.tabs.remove(<the session's owned tabId>)`
+    //       is what the `close` op already performs unconditionally, on an id
+    //       the server vouched for moments earlier. Two honest differences,
+    //       though — `close` calls `forgetTab` FIRST and for a stated reason
+    //       (onRemoved's timing is not ours to control, and a stale entry is
+    //       inheritable by a recycled tabId), so the reap does the same below;
+    //       and unlike `close` this remove is issued WITHOUT the caller asking
+    //       for it, so `reapAttempted` exists to leave a trace in the envelope.
+    let reapAttempted = null;
+    if (orphanTabId != null && (Date.now() - startedAt) < loopTiming().execMs) {
+      forgetTab(orphanTabId);
       try {
         const p = chrome.tabs.remove(orphanTabId);
         if (p && typeof p.catch === "function") p.catch(() => {});
+        reapAttempted = orphanTabId;
       } catch (e) { /* a reap must never break the op it is cleaning up after */ }
     }
-    return { tabId: tab.id, url: tab.url || (cmd && cmd.url) || "about:blank" };
+    const out = { tabId: tab.id,
+                  url: tab.url || (cmd && cmd.url) || "about:blank" };
+    // Additive, and ATTEMPTED is the honest word — the remove is not awaited, so
+    // this can never mean "closed". Present only on the path that reaps, so an
+    // ordinary `open` envelope is byte-identical to before.
+    if (reapAttempted != null) out.reapAttempted = reapAttempted;
+    return out;
   },
 
   // Close the session's owned tab (the server injects its tabId). The server

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -1211,14 +1211,32 @@ const OPS = {
   // choice — and, importantly, for why `screenshot`'s CDP attach-hang arithmetic
   // does NOT apply here (`open` never attaches the debugger).
   //
-  // 🔴 AND THE BOUND'S DISCLOSED COST IS NOW REAPED RATHER THAN ONLY DISCLOSED.
-  // REUSE_TAB_BUDGET_MS states it, and server.py's `reuse_tab_id` block states it
-  // harder — a probe that exceeds the budget falls through to a FRESH tab, the
-  // server overwrites the ownership record, and the live first tab is
-  // "deterministically ORPHAN[ed] … Nothing reclaims it; only a human closes it."
-  // That sentence is what the reap below deletes. `open` returns SUCCESS on that
-  // path, so no error surfaces and nothing else in the system ever revisits it:
-  // one leaked tab per timed-out re-open, accumulating until a human notices.
+  // 🔴 AND THE BOUND'S DISCLOSED COST IS REPORTED SO THE SERVER CAN RECLAIM IT.
+  // REUSE_TAB_BUDGET_MS states the cost, and server.py's `reuse_tab_id` block
+  // states it harder — a probe that exceeds the budget falls through to a FRESH
+  // tab, the server overwrites the ownership record, and the live first tab is
+  // orphaned. `open` returns SUCCESS on that path, so no error surfaces: one
+  // leaked tab per timed-out re-open, accumulating until a human notices.
+  //
+  // 🔴 THIS FUNCTION REPORTS THE ORPHAN. IT DOES NOT CLOSE IT — and that
+  // division is the whole design, arrived at by getting it wrong twice.
+  // Reclaiming is only correct when the op's RESULT IS DELIVERED: if nobody
+  // records the fresh tab as owned, the OLD tab is not an orphan at all — the
+  // server still owns it, it is still live, and closing it strands the session
+  // on a dead id (then, one op later, on the operator's ACTIVE tab). This
+  // function cannot know whether delivery happened. TWO independent parties
+  // abandon an op and NEITHER is visible from here:
+  //   * execute() races this op against execMs and cannot cancel it, so a merely
+  //     SLOW `chrome.tabs.create` resumes us after `op_timeout:open` was already
+  //     answered;
+  //   * the SUBMITTER gives up at its own `cmd_timeout`, on a different clock
+  //     that starts at SUBMIT rather than at dequeue — so queue time is
+  //     structurally invisible here (server.py: "The SUBMITTER giving up … does
+  //     NOT free the extension"). An elapsed-time guard in this file closed the
+  //     first and could not close the second.
+  // The server knows both, because `_record_ownership_locked` runs ONLY on a
+  // delivered result. So it decides, and it enqueues the `close`. One rule, one
+  // place — and the place is the one holding the ownership map.
   //
   // NOT a bound on `chrome.tabs.create` — that was considered and rejected. This
   // choke-point file's own rule (see execute()) grants a local bound only to "an
@@ -1227,13 +1245,10 @@ const OPS = {
   // relabel `op_timeout:open` as a create-specific timeout while leaking exactly
   // the same tab. The leak, not the label, is the defect.
   async open(cmd) {
-    // The tabId to reclaim after the fall-through succeeds, or null. Set ONLY on
-    // the timeout arm — see the catch for why the rejection arm must not reap.
+    // The tabId the fall-through is about to orphan, or null. Set ONLY on the
+    // timeout arm — see the catch for why the rejection arm reports nothing.
+    // REPORTED in the envelope; never acted on here.
     let orphanTabId = null;
-    // Stamped BEFORE anything is awaited: the reap below must not fire once
-    // execute() has already given up on this op (it races us, it cannot cancel
-    // us). See the elapsed check for what a late reap actually destroys.
-    const startedAt = Date.now();
     if (cmd && cmd.reuseTabId != null) {
       try {
         const existing = await promiseWithTimeout(
@@ -1261,21 +1276,21 @@ const OPS = {
           String((e && e.message) || e).startsWith("reuse_tab_timeout");
         breadcrumb("open", (cmd && cmd.id) || null,
                    timedOut ? "open_reuse_timeout" : "open_reuse_gone");
-        // 🔴 REAP ONLY ON THE TIMEOUT ARM — and the argument is EXPECTED VALUE,
-        // not a claim that the timeout arm is the safer one. It is not: a
-        // recycled tabId is a hazard on BOTH arms, and the timeout arm's remove
-        // is issued LATER (after an unbounded `chrome.tabs.create`), so its
-        // recycle window is strictly the WIDER of the two. What separates them is
-        // the numerator:
+        // 🔴 REPORT AN ORPHAN ONLY ON THE TIMEOUT ARM — and the argument is
+        // EXPECTED VALUE, not a claim that the timeout arm is the safer one. It
+        // is not: a recycled tabId is a hazard on BOTH arms, and the timeout
+        // arm's close is issued LATER (after an unbounded `chrome.tabs.create`,
+        // plus a server round-trip), so its recycle window is strictly the WIDER
+        // of the two. What separates them is the numerator:
         //   * rejection → `chrome.tabs.get` ANSWERED, naming the id as absent.
         //                 Expected tabs reclaimed: ZERO. Any exposure at all,
-        //                 however small, buys nothing. Do not reap.
+        //                 however small, buys nothing. Report nothing.
         //   * timeout   → the probe answered NOTHING. A live tab is about to be
         //                 orphaned with no owner, and reclaiming it is the whole
         //                 point of this change. A non-zero exposure is justified
         //                 by a non-zero return.
         // (An earlier draft of this comment argued the rejection arm was refused
-        // because reaping there is "pure exposure" while implying the timeout arm
+        // because acting there is "pure exposure" while implying the timeout arm
         // was not exposed. That reasoning was one-sided and did not carry the
         // conclusion, even though the conclusion is right.)
         orphanTabId = timedOut ? cmd.reuseTabId : null;
@@ -1286,78 +1301,39 @@ const OPS = {
       url: (cmd && cmd.url) ? cmd.url : "about:blank",
       active: false,
     });
-    // Reclaim the tab the timed-out probe just orphaned, AFTER the replacement
-    // exists — reaping first would close the session's only tab and then, if the
-    // create failed, leave it owning a dead id.
+    // 🔴 REPORT the orphan; the SERVER closes it. Two earlier drafts closed it
+    // here and both were wrong in the same direction, so state the rule rather
+    // than the fix: RECLAIMING IS CORRECT ONLY IF THIS RESULT IS DELIVERED. If
+    // nobody records the fresh tab as owned, the old tab is not an orphan — it
+    // is still owned, still live, and closing it strands the session on a dead
+    // id. Two independent parties abandon an op, and NEITHER is observable from
+    // inside this function: execute()'s execMs race (which cannot cancel us, so
+    // a merely SLOW create resumes here after `op_timeout:open` was answered),
+    // and the SUBMITTER's own cmd_timeout — a different clock, started at
+    // SUBMIT, so queue time is structurally invisible here. An elapsed-time
+    // guard in this file closed the first and could not close the second.
     //
-    // 🔴 AND ONLY WHILE THE OP IS STILL ALIVE. execute() RACES this function
-    // against execMs; it does not CANCEL it. So a `chrome.tabs.create` that is
-    // merely slow — settling at, say, 17s — resumes us LONG AFTER execute() has
-    // already answered `op_timeout:open` and moved on. Reaping then is actively
-    // HARMFUL rather than merely useless, and the harm is not the one the
-    // residual list below used to describe:
-    //
-    //   * the server saw `ok:false` with error `op_timeout:open`. That is not a
-    //     tab-gone error, so `_record_ownership_locked` KEEPS the session's
-    //     ownership pointing at the OLD tab (server.py) — which, on that path,
-    //     is still live and still perfectly usable. Pre-change, the next `open`
-    //     simply reused it.
-    //   * a late reap destroys exactly that tab. The session is now left owning
-    //     a dead id; its next op gets `owned_tab_gone`, the server self-heals by
-    //     dropping the mapping, and the op AFTER that falls back to the
-    //     operator's ACTIVE tab — the blast radius the ownership map exists to
-    //     prevent.
-    //
-    // MEASURED, not reasoned: with execMs 80, a hung `tabs.get` and a create
-    // resolving at 300ms, execute() returned `op_timeout:open` with tabsRemove
-    // [] — and 600ms later tabsRemove was [5]. The elapsed check below is what
-    // turns that into a no-op. `>=` deliberately: at exactly execMs the race has
-    // fired, and a tie must skip.
-    //
-    // 🔴 FIRE-AND-FORGET, NEVER AWAITED, AND THAT IS LOAD-BEARING. `tabs.remove`
-    // is one more unbounded browser-process IPC; awaiting it would put a NEW
-    // unbounded await on `open`'s success path — re-creating, at the last line of
-    // the op, the exact class this whole arc exists to remove. Not awaiting it
-    // means the reap cannot delay, fail, or wedge the op under any circumstances.
+    // `_record_ownership_locked` runs ONLY on a delivered result, so the server
+    // has exactly the fact this function lacks. It enqueues the `close`.
     //
     // ⚠ WHAT THIS DOES **NOT** FIX, stated rather than discovered later:
-    //   (a) A browser-wide stall defeats the reap too — the same stall that hung
-    //       `tabs.get` can hang `tabs.remove`, and nothing here waits to find
-    //       out. It is best-effort by construction, not a guarantee. And because
-    //       nothing waits, THE FAILURE IS UNOBSERVABLE: `reapAttempted` below
-    //       reports that the call was ISSUED, never that a tab was closed. There
-    //       is no production counter for how often either happens, deliberately
-    //       — the breadcrumb slot execute() clobbers could not carry one.
+    //   (a) It is still best-effort. The server-issued `close` is a real op that
+    //       can itself fail or be lost, and no counter tracks how often. What is
+    //       gone is the case where the reclaim was WRONG, not the case where it
+    //       silently does not happen.
     //   (b) The OTHER orphan is untouched: if `chrome.tabs.create` hangs and
     //       NEVER settles, execute() kills the op at EXEC_OP_BUDGET_MS and the
-    //       abandoned create later produces a tab this function never sees and
-    //       therefore cannot reap. (The SLOW-but-settling variant is the case
-    //       the elapsed check above handles: there we do resume, and we
-    //       deliberately do nothing.) Closing (b) needs the choke point to
+    //       abandoned create later produces a tab this function never sees, so
+    //       there is nothing to report. Closing (b) needs the choke point to
     //       signal abandonment back into the op, which it cannot do today.
-    //   (c) No new CAPABILITY: `chrome.tabs.remove(<the session's owned tabId>)`
-    //       is what the `close` op already performs unconditionally, on an id
-    //       the server vouched for moments earlier. Two honest differences,
-    //       though — `close` calls `forgetTab` FIRST and for a stated reason
-    //       (onRemoved's timing is not ours to control, and a stale entry is
-    //       inheritable by a recycled tabId), so the reap does the same below;
-    //       and unlike `close` this remove is issued WITHOUT the caller asking
-    //       for it, so `reapAttempted` exists to leave a trace in the envelope.
-    let reapAttempted = null;
-    if (orphanTabId != null && (Date.now() - startedAt) < loopTiming().execMs) {
-      forgetTab(orphanTabId);
-      try {
-        const p = chrome.tabs.remove(orphanTabId);
-        if (p && typeof p.catch === "function") p.catch(() => {});
-        reapAttempted = orphanTabId;
-      } catch (e) { /* a reap must never break the op it is cleaning up after */ }
-    }
+    //   (c) `orphanTabId` is a REPORT, not an instruction, and the server treats
+    //       it as one — it closes the tab only when it also just recorded the
+    //       session's NEW tab, and never when the two ids are equal.
     const out = { tabId: tab.id,
                   url: tab.url || (cmd && cmd.url) || "about:blank" };
-    // Additive, and ATTEMPTED is the honest word — the remove is not awaited, so
-    // this can never mean "closed". Present only on the path that reaps, so an
-    // ordinary `open` envelope is byte-identical to before.
-    if (reapAttempted != null) out.reapAttempted = reapAttempted;
+    // Additive, and present only on the path that orphans, so an ordinary `open`
+    // envelope is byte-identical to before.
+    if (orphanTabId != null) out.orphanTabId = orphanTabId;
     return out;
   },
 

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -1210,7 +1210,26 @@ const OPS = {
   // ONLY shape this catch can act on. See REUSE_TAB_BUDGET_MS for the 2000ms
   // choice — and, importantly, for why `screenshot`'s CDP attach-hang arithmetic
   // does NOT apply here (`open` never attaches the debugger).
+  //
+  // 🔴 AND THE BOUND'S DISCLOSED COST IS NOW REAPED RATHER THAN ONLY DISCLOSED.
+  // REUSE_TAB_BUDGET_MS states it, and server.py's `reuse_tab_id` block states it
+  // harder — a probe that exceeds the budget falls through to a FRESH tab, the
+  // server overwrites the ownership record, and the live first tab is
+  // "deterministically ORPHAN[ed] … Nothing reclaims it; only a human closes it."
+  // That sentence is what the reap below deletes. `open` returns SUCCESS on that
+  // path, so no error surfaces and nothing else in the system ever revisits it:
+  // one leaked tab per timed-out re-open, accumulating until a human notices.
+  //
+  // NOT a bound on `chrome.tabs.create` — that was considered and rejected. This
+  // choke-point file's own rule (see execute()) grants a local bound only to "an
+  // await inside a `try` whose `catch` implements a RECOVERY (a second, working
+  // path)". `chrome.tabs.create` has no second path, so a bound there could only
+  // relabel `op_timeout:open` as a create-specific timeout while leaking exactly
+  // the same tab. The leak, not the label, is the defect.
   async open(cmd) {
+    // The tabId to reclaim after the fall-through succeeds, or null. Set ONLY on
+    // the timeout arm — see the catch for why the rejection arm must not reap.
+    let orphanTabId = null;
     if (cmd && cmd.reuseTabId != null) {
       try {
         const existing = await promiseWithTimeout(
@@ -1234,9 +1253,20 @@ const OPS = {
         // mid-open. It is NOT a counter and NOT an answer to "how often does the
         // probe time out in production" — that needs a key execute() does not
         // clobber, deliberately not added here.
+        const timedOut =
+          String((e && e.message) || e).startsWith("reuse_tab_timeout");
         breadcrumb("open", (cmd && cmd.id) || null,
-                   String((e && e.message) || e).startsWith("reuse_tab_timeout")
-                     ? "open_reuse_timeout" : "open_reuse_gone");
+                   timedOut ? "open_reuse_timeout" : "open_reuse_gone");
+        // 🔴 REAP ONLY ON THE TIMEOUT ARM. The two arms carry OPPOSITE evidence
+        // about the tab, and that asymmetry is the whole safety argument:
+        //   * timeout  → we learned NOTHING. The tab is probably still live, and
+        //                the fall-through is about to orphan it. Reap.
+        //   * rejection → `chrome.tabs.get` answered, naming the id as absent.
+        //                Reaping would be a remove against an id we have positive
+        //                evidence is gone — pure exposure (Chromium can recycle a
+        //                tabId, which this file already reasons about in `close`)
+        //                for zero reclaimed tabs. Do not.
+        orphanTabId = timedOut ? cmd.reuseTabId : null;
         /* owned tab gone (or hung) → open a fresh one below */
       }
     }
@@ -1244,6 +1274,35 @@ const OPS = {
       url: (cmd && cmd.url) ? cmd.url : "about:blank",
       active: false,
     });
+    // Reclaim the tab the timed-out probe just orphaned, AFTER the replacement
+    // exists — reaping first would close the session's only tab and then, if the
+    // create failed, leave it owning a dead id.
+    //
+    // 🔴 FIRE-AND-FORGET, NEVER AWAITED, AND THAT IS LOAD-BEARING. `tabs.remove`
+    // is one more unbounded browser-process IPC; awaiting it would put a NEW
+    // unbounded await on `open`'s success path — re-creating, at the last line of
+    // the op, the exact class this whole arc exists to remove. Not awaiting it
+    // means the reap cannot delay, fail, or wedge the op under any circumstances.
+    //
+    // ⚠ WHAT THIS DOES **NOT** FIX, stated rather than discovered later:
+    //   (a) A browser-wide stall defeats the reap too — the same stall that hung
+    //       `tabs.get` can hang `tabs.remove`, and nothing here waits to find
+    //       out. It is best-effort by construction, not a guarantee.
+    //   (b) The OTHER orphan is untouched: if `chrome.tabs.create` itself hangs,
+    //       execute() kills the op at EXEC_OP_BUDGET_MS while the abandoned
+    //       create still settles in the background, producing a tab this function
+    //       never sees and therefore cannot reap. Closing that one needs the
+    //       choke point to signal abandonment back into the op, which it has no
+    //       mechanism for today. Deliberately out of scope.
+    //   (c) No new exposure class: this is the SAME `chrome.tabs.remove(<the
+    //       session's owned tabId>)` that the `close` op already performs
+    //       unconditionally, on an id the server vouched for moments earlier.
+    if (orphanTabId != null) {
+      try {
+        const p = chrome.tabs.remove(orphanTabId);
+        if (p && typeof p.catch === "function") p.catch(() => {});
+      } catch (e) { /* a reap must never break the op it is cleaning up after */ }
+    }
     return { tabId: tab.id, url: tab.url || (cmd && cmd.url) || "about:blank" };
   },
 

--- a/scripts/browser-bridge/reference/tabs-instances.md
+++ b/scripts/browser-bridge/reference/tabs-instances.md
@@ -29,15 +29,21 @@ Now each session can own its own tab:
   DISCARDS your url.** Calling `browser open <url>` again in a session that already
   owns a **live** tab returns that SAME tabId (it does not leak a second tab —
   EXCEPT when the reuse probe exceeds `REUSE_TAB_BUDGET_MS`, which falls through to
-  a fresh tab and orphans the first — the extension then **reaps** that orphan,
-  best-effort and fire-and-forget, once the replacement exists; only on the
-  TIMEOUT arm, since a REJECTING probe has already named the tab as absent) — and
+  a fresh tab and orphans the first — the extension then **reports** that orphan
+  as `orphanTabId` and the SERVER closes it, from the one place that knows the
+  result was delivered; only on the TIMEOUT arm, since a REJECTING probe has
+  already named the tab as absent) — and
   drops the url on the floor.
-  🔴 **The reap CLOSES a real tab you did not ask it to close.** If you had
+  🔴 **That reclaim CLOSES a real tab you did not ask it to close.** If you had
   `activate`d that tab you were looking at it, and it disappears mid-session
   (scroll position, form state, playing media) with a fresh tab at the requested
-  url in its place. The tell is **`reapAttempted: <tabId>`** in the `open`
-  envelope — ATTEMPTED, never "closed", because nothing awaits the remove. In `extension/service_worker.js`'s `open`, a live
+  url in its place. The tell is **`orphanTabId: <tabId>`** in the `open` envelope.
+  🔴 **AND IT MAY NOT BE YOUR TAB.** Two parallel agents can derive the SAME
+  session id and share one owned tab — see the shared-session bullet below, where
+  `open` handing over a sibling's tab was observed for real. A re-`open` by one
+  sibling whose probe times out therefore closes the tab the OTHER sibling is
+  mid-workflow on. That collision used to be benign; it is not any more.
+  In `extension/service_worker.js`'s `open`, a live
   `reuseTabId` returns `chrome.tabs.get(reuseTabId)` as `{tabId, url, reused: true}`
   and **never calls `chrome.tabs.update`**, so `cmd.url` is never applied and the
   `url` handed back is the tab's **CURRENT** address, not the one you asked for.

--- a/scripts/browser-bridge/reference/tabs-instances.md
+++ b/scripts/browser-bridge/reference/tabs-instances.md
@@ -43,10 +43,13 @@ Now each session can own its own tab:
   `open` handing over a sibling's tab was observed for real. A re-`open` by one
   sibling whose probe times out therefore closes the tab the OTHER sibling is
   mid-workflow on. That collision used to be benign; it is not any more. Two
-  things bound it: **re-owning a tab withdraws any reclaim queued for it** (so a
-  sibling's own next `open`, if it reuses that tab, cancels the close), and a
+  things bound it, and neither is absolute: **re-owning a tab withdraws any
+  reclaim still QUEUED for it** (so a sibling's own next `open`, if it reuses that
+  tab, cancels the close — but *not* once the close has been handed to the
+  extension, which leaves one poll round trip in which it still lands), and a
   reclaim not picked up within `INFLIGHT_STALE_S` is **dropped rather than
-  dispatched** — after a Brave restart the same tab id names a different tab.
+  dispatched** — after a Brave restart the same tab id names a different tab, so
+  that orphan is then never reclaimed at all.
   In `extension/service_worker.js`'s `open`, a live
   `reuseTabId` returns `chrome.tabs.get(reuseTabId)` as `{tabId, url, reused: true}`
   and **never calls `chrome.tabs.update`**, so `cmd.url` is never applied and the

--- a/scripts/browser-bridge/reference/tabs-instances.md
+++ b/scripts/browser-bridge/reference/tabs-instances.md
@@ -42,7 +42,11 @@ Now each session can own its own tab:
   session id and share one owned tab — see the shared-session bullet below, where
   `open` handing over a sibling's tab was observed for real. A re-`open` by one
   sibling whose probe times out therefore closes the tab the OTHER sibling is
-  mid-workflow on. That collision used to be benign; it is not any more.
+  mid-workflow on. That collision used to be benign; it is not any more. Two
+  things bound it: **re-owning a tab withdraws any reclaim queued for it** (so a
+  sibling's own next `open`, if it reuses that tab, cancels the close), and a
+  reclaim not picked up within `INFLIGHT_STALE_S` is **dropped rather than
+  dispatched** — after a Brave restart the same tab id names a different tab.
   In `extension/service_worker.js`'s `open`, a live
   `reuseTabId` returns `chrome.tabs.get(reuseTabId)` as `{tabId, url, reused: true}`
   and **never calls `chrome.tabs.update`**, so `cmd.url` is never applied and the

--- a/scripts/browser-bridge/reference/tabs-instances.md
+++ b/scripts/browser-bridge/reference/tabs-instances.md
@@ -32,7 +32,12 @@ Now each session can own its own tab:
   a fresh tab and orphans the first — the extension then **reaps** that orphan,
   best-effort and fire-and-forget, once the replacement exists; only on the
   TIMEOUT arm, since a REJECTING probe has already named the tab as absent) — and
-  drops the url on the floor. In `extension/service_worker.js`'s `open`, a live
+  drops the url on the floor.
+  🔴 **The reap CLOSES a real tab you did not ask it to close.** If you had
+  `activate`d that tab you were looking at it, and it disappears mid-session
+  (scroll position, form state, playing media) with a fresh tab at the requested
+  url in its place. The tell is **`reapAttempted: <tabId>`** in the `open`
+  envelope — ATTEMPTED, never "closed", because nothing awaits the remove. In `extension/service_worker.js`'s `open`, a live
   `reuseTabId` returns `chrome.tabs.get(reuseTabId)` as `{tabId, url, reused: true}`
   and **never calls `chrome.tabs.update`**, so `cmd.url` is never applied and the
   `url` handed back is the tab's **CURRENT** address, not the one you asked for.

--- a/scripts/browser-bridge/reference/tabs-instances.md
+++ b/scripts/browser-bridge/reference/tabs-instances.md
@@ -29,7 +29,9 @@ Now each session can own its own tab:
   DISCARDS your url.** Calling `browser open <url>` again in a session that already
   owns a **live** tab returns that SAME tabId (it does not leak a second tab —
   EXCEPT when the reuse probe exceeds `REUSE_TAB_BUDGET_MS`, which falls through to
-  a fresh tab and orphans the first) — and
+  a fresh tab and orphans the first — the extension then **reaps** that orphan,
+  best-effort and fire-and-forget, once the replacement exists; only on the
+  TIMEOUT arm, since a REJECTING probe has already named the tab as absent) — and
   drops the url on the floor. In `extension/service_worker.js`'s `open`, a live
   `reuseTabId` returns `chrome.tabs.get(reuseTabId)` as `{tabId, url, reused: true}`
   and **never calls `chrome.tabs.update`**, so `cmd.url` is never applied and the

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -2262,7 +2262,12 @@ class Registry:
             # What survives is a WEAKER residual, stated so nobody re-derives the
             # stronger claim from this block. ⚠ THIS LIST IS LOAD-BEARING AND HAS
             # BEEN INCOMPLETE ONCE — it is where the "what is still broken"
-            # answer is supposed to live, so add to it when you add a bound:
+            # answer is supposed to live, so add to it when you add a bound.
+            # 🔴 AND THERE IS A SECOND COPY: `REUSE_TAB_BUDGET_MS` in
+            # extension/protocol.js carries a narrower list (ways the ORPHAN
+            # survives; this one also covers over-closes). It was the copy missed
+            # last time precisely because nothing here said it existed — update
+            # both, or say why only one applies.
             #   * the reclaim is best-effort — a real `close` op that can fail or
             #     be lost, with no counter for how often;
             #   * a DIFFERENT orphan is still unreclaimed: if `chrome.tabs.create`

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -2347,6 +2347,44 @@ class Registry:
                 self._owners[okey] = {
                     "tab_id": tid, "last_seen": self._clock()}
                 log("owner_open", key=inst.key, session=session_id, tab=tid)
+                # 🔴 RECLAIM THE ORPHAN — HERE, AND NOWHERE ELSE.
+                #
+                # When the extension's reuse probe exceeds REUSE_TAB_BUDGET_MS it
+                # falls through to a FRESH tab and reports the tabId it thereby
+                # orphaned. The line above has just overwritten the ownership
+                # record, so that old tab now has NO owner and nothing else in the
+                # system will ever revisit it — the leak this block's sibling
+                # comment (see `reuse_tab_id` in submit) used to describe as
+                # "Nothing reclaims it; only a human closes it."
+                #
+                # 🔴 WHY THE CLOSE LIVES ON THIS SIDE. Two earlier attempts had
+                # the EXTENSION close it directly, and both were wrong the same
+                # way: reclaiming is correct only if this result is DELIVERED.
+                # If it is not, the old tab is not an orphan at all — the ownership
+                # record still names it, it is still live, and closing it strands
+                # the session on a dead id (then, one op later, on the operator's
+                # ACTIVE tab). The extension cannot know: TWO parties abandon an
+                # op on TWO clocks, and neither is visible from inside the op —
+                # execute()'s EXEC_OP_BUDGET_MS race, which does not cancel the op
+                # so a merely SLOW `chrome.tabs.create` resumes it afterwards; and
+                # the submitter's own cmd_timeout, which starts at SUBMIT, so
+                # queue time is invisible to any extension-side elapsed check.
+                #
+                # This method is reached ONLY from the delivered-result path in
+                # submit() (after `inst.results.pop(cid)`). A submitter that gave
+                # up raised BridgeTimeout long before here, and a result arriving
+                # after that goes down deliver_result's `result_after_abandon`
+                # branch instead. So "we got here" IS the fact the extension
+                # lacked, and it is structural rather than a check that could
+                # drift.
+                orphan = data.get("orphanTabId") if isinstance(data, dict) else None
+                # `!= tid` is not paranoia: closing the tab we just recorded as
+                # owned would destroy the session's only tab. A report is data,
+                # never an instruction. (`isinstance(orphan, int)` also rejects
+                # the bool a hand-crafted envelope could carry — `True == 1`.)
+                if (isinstance(orphan, int) and not isinstance(orphan, bool)
+                        and orphan != tid):
+                    self._enqueue_reap_close_locked(inst, orphan, session_id)
         elif op == "tabs":
             # Annotate the listing with which tab (if any) THIS session owns, so
             # `browser tabs` can flag it. Metadata only (a tabId, never content).
@@ -2354,6 +2392,43 @@ class Registry:
             if isinstance(data, dict):
                 data["ownedTabId"] = self._owned_tab_locked(
                     inst.key, session_id, touch=False)
+
+    def _enqueue_reap_close_locked(self, inst, tab_id: int, session_id) -> None:
+        """Queue a fire-and-forget `close` for a tab the extension just orphaned.
+
+        🔴 NO WAITER, DELIBERATELY. Every other command in this file is enqueued
+        by a submitter that then blocks on `inst.results[cid]`; this one has no
+        submitter, because the caller it would belong to has already been handed
+        its `open` result. So `cid` is NOT added to `inst.waiters`, and when the
+        reply arrives `deliver_result` finds no waiter, falls to its
+        `result_after_abandon` branch, pops the inflight entry and logs. That is
+        an existing, exercised path — not a new one — and it is why this cannot
+        strand a waiter or a `pending` slot: it takes neither.
+
+        🔴 BUT IT DOES TAKE AN `inflight` ENTRY, and that is the point of the
+        line. `inflight` is what `_effective_timeout_locked` reads to tell a BUSY
+        extension from an idle one; without an entry, a `ping` landing while this
+        close executes would fast-fail against a perfectly healthy extension.
+        The entry is released by the same `deliver_result` branch above, or
+        expires on INFLIGHT_STALE_S if the reply never comes.
+
+        Ordering: appended to the same FIFO outbox as everything else, so it runs
+        before any command submitted after it and cannot overtake one submitted
+        before. It targets a tab NOBODY owns any more, so it cannot race a
+        tab-scoped op for the session's current tab.
+
+        Idempotent by construction: the extension's `close` treats an
+        already-gone tab as success, so a tab that really had died during the
+        probe costs one no-op round trip and nothing else.
+        """
+        cid = secrets.token_hex(8)
+        inst.outbox.append({"id": cid, "op": "close", "tabId": tab_id})
+        _now = self._clock()
+        self._prune_inflight_locked(inst, _now)
+        inst.inflight[cid] = _now
+        log("owner_orphan_reap", key=inst.key, session=session_id, tab=tab_id,
+            id=cid)
+        self._cond.notify_all()   # wake this instance's waiting poller
 
     # --- resolution / introspection --------------------------------------- #
     def _live_instances_locked(self):

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -2109,6 +2109,15 @@ class Registry:
                  if now - t > INFLIGHT_STALE_S and c not in inst.waiters]
         for c in stale:
             del inst.inflight[c]
+        # A reap's `reaps` entry is only ever meaningful while its `inflight`
+        # entry lives: it is created with one and dropped with one on every
+        # normal exit (reply, cancel, expiry-at-pickup). The one path that leaves
+        # it behind is a reap whose reply is LOST — the residual this feature
+        # already discloses. Without this sweep that entry would outlive the
+        # Instance's usefulness (`instance_id` is stable across a browser
+        # restart), so tie its lifetime to the one that is already bounded.
+        for c in [c for c in inst.reaps if c not in inst.inflight]:
+            del inst.reaps[c]
 
     # --- concurrency backstop (per-instance rate limit + queue-depth cap) --- #
     def _admit_locked(self, inst: Instance):
@@ -2222,14 +2231,24 @@ class Registry:
             # the same inversion is easy to reintroduce from either direction.
             #
             # What survives is a WEAKER residual, stated so nobody re-derives the
-            # stronger claim from this block:
+            # stronger claim from this block. ⚠ THIS LIST IS LOAD-BEARING AND HAS
+            # BEEN INCOMPLETE ONCE — it is where the "what is still broken"
+            # answer is supposed to live, so add to it when you add a bound:
             #   * the reclaim is best-effort — a real `close` op that can fail or
             #     be lost, with no counter for how often;
             #   * a DIFFERENT orphan is still unreclaimed: if `chrome.tabs.create`
             #     hangs and NEVER settles, the op is killed at EXEC_OP_BUDGET_MS
             #     and the abandoned create later produces a tab the extension
             #     never sees, so there is nothing to report. Neither side can
-            #     close that one.
+            #     close that one;
+            #   * CANCELLATION IS PRE-DISPATCH ONLY. Re-owning a tab withdraws a
+            #     reclaim still in the outbox, but once the extension has taken
+            #     it there is nothing to withdraw — one poll round trip in which
+            #     a re-owned tab can still be closed (was unbounded before);
+            #   * AN EXPIRED RECLAIM IS DROPPED, so that orphan is never
+            #     reclaimed at all. A leaked tab, taken deliberately over
+            #     dispatching a stale tabId that a browser restart has reassigned
+            #     to somebody else's tab.
             reuse_tab_id = None
             if op == "open" and session_id is not None and tab is None:
                 reuse_tab_id = self._owned_tab_locked(inst.key, session_id,
@@ -2518,25 +2537,49 @@ class Registry:
         at enqueue time, and a concurrent `open` can hand the same tab back to a
         session before the close is dispatched.
 
-        Only removes entries still sitting in the outbox — once dispatched there
+        Only removes entries still sitting in the OUTBOX — once dispatched there
         is nothing to withdraw, which is a real (much narrower) residual: the
         window is one poll round trip rather than unbounded.
+
+        🔴 AND THAT SCOPE MUST GOVERN THE BOOKKEEPING TOO, WHICH AN EARLIER DRAFT
+        GOT WRONG IN EXACTLY THE WAY THIS DOCSTRING HID. `inst.reaps` holds reaps
+        the extension has ALREADY PICKED UP as well as queued ones. The first
+        version selected from `reaps` and then popped `reaps` + `inflight` for
+        every match, while removing only the queued ones from the outbox — so a
+        cancel landing one poll round trip later erased the bookkeeping of a reap
+        that was still genuinely executing. Two measured harms, both re-opening
+        something this feature had just closed:
+          * the `inflight` entry is what `_effective_timeout_locked` reads to
+            tell a BUSY extension from a wedged one. Dropping it collapsed a
+            `ping`'s deadline from 20.0s to 2.0s while the close was really
+            running — the false wedge `_enqueue_reap_close_locked` adds that line
+            to prevent, and whose documented remedy is restarting the operator's
+            live browser.
+          * the reap's own reply then matched nothing, so `deliver_result`
+            returned False and the reply was logged `result_unknown_id` — the
+            lost-reply tell that branch exists to stop emitting.
+        It also contradicted the sibling path: the EXPIRY drop pops only the one
+        entry it removed, and its test asserts exactly that ("the reap already in
+        flight is still outstanding"). Same invariant, two call sites.
+
+        So the pops below are keyed on what was ACTUALLY REMOVED from the outbox,
+        never on what merely matched the tab.
         """
-        stale = [c for c in inst.reaps
-                 if inst.reaps[c].get("tab_id") == tab_id]
-        if not stale:
+        match = {c for c in inst.reaps
+                 if inst.reaps[c].get("tab_id") == tab_id}
+        if not match:
             return 0
-        drop = set(stale)
-        kept = deque(c for c in inst.outbox if c.get("id") not in drop)
-        removed = len(inst.outbox) - len(kept)
-        inst.outbox = kept
-        for c in stale:
+        withdrawn = {c.get("id") for c in inst.outbox if c.get("id") in match}
+        if not withdrawn:
+            return 0          # all matches are already in flight — leave them be
+        inst.outbox = deque(c for c in inst.outbox
+                            if c.get("id") not in withdrawn)
+        for c in withdrawn:
             inst.reaps.pop(c, None)
             inst.inflight.pop(c, None)
-        if removed:
-            log("owner_orphan_reap_cancel", key=inst.key, tab=tab_id,
-                n=removed)
-        return removed
+        log("owner_orphan_reap_cancel", key=inst.key, tab=tab_id,
+            n=len(withdrawn))
+        return len(withdrawn)
 
     # --- resolution / introspection --------------------------------------- #
     def _live_instances_locked(self):

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -1659,7 +1659,7 @@ class Instance:
                  "pending", "rl_tokens", "rl_last", "extension_version",
                  "extension_id", "extension_build", "last_poll_wall",
                  "lost_logged",
-                 "last_dispatch", "inflight")
+                 "last_dispatch", "inflight", "reaps")
 
     def __init__(self, key, instance_id, label, now, burst=0.0,
                  extension_version=None, extension_id=None,
@@ -1716,6 +1716,11 @@ class Instance:
         # one — which is what tells a legitimately BUSY extension apart from a
         # WEDGED one (see Registry.submit's `fast_timeout`).
         self.inflight: dict[str, float] = {}
+        # cid -> {"tab_id", "expires_at"} for FIRE-AND-FORGET orphan reaps only
+        # (see _enqueue_reap_close_locked). Every OTHER outbox entry belongs to a
+        # submitter that removes it on abandonment; a reap has no submitter, so
+        # this is what gives it a lifetime and lets it be cancelled.
+        self.reaps: dict[str, dict] = {}
 
 
 class Registry:
@@ -1928,7 +1933,23 @@ class Registry:
                     if inst.superseded:
                         return SUPERSEDED
                     if inst.outbox:
-                        return inst.outbox.popleft()
+                        cmd = inst.outbox.popleft()
+                        # A fire-and-forget orphan reap is the ONE outbox entry
+                        # with no submitter to withdraw it, so it carries its own
+                        # expiry — see _enqueue_reap_close_locked. Past it, the
+                        # tabId can no longer be trusted to name the same tab
+                        # (a Brave restart reuses this Instance and restarts tab
+                        # ids at 1), so DROP it rather than dispatch it.
+                        r = inst.reaps.get(cmd.get("id"))
+                        if r is not None:
+                            if self._clock() >= r["expires_at"]:
+                                inst.reaps.pop(cmd["id"], None)
+                                inst.inflight.pop(cmd["id"], None)
+                                log("owner_orphan_reap_expired",
+                                    key=inst.key, tab=r.get("tab_id"),
+                                    id=cmd["id"])
+                                continue      # look for the next command
+                        return cmd
                     remaining = deadline - self._clock()
                     if remaining <= 0:
                         return None
@@ -1956,7 +1977,26 @@ class Registry:
                     inst.results[cid] = payload
                     self._cond.notify_all()
                     return True
-            # No live submitter — but this may be the ABANDONED command whose
+            # A fire-and-forget orphan reap: no waiter by design, but very much a
+            # command WE issued and are expecting. Recognised here so a perfectly
+            # normal reap does not fall through to the abandoned-command branch
+            # below and get logged as `result_unknown_id` — a line whose whole
+            # meaning is "a reply for a command nobody knows about", i.e. a
+            # lost-reply tell. Emitting it on every successful reap would retire
+            # that signal.
+            for inst in candidates:
+                r = inst.reaps.pop(cid, None)
+                if r is not None:
+                    inst.inflight.pop(cid, None)
+                    if (inst.last_dispatch or {}).get("id") == cid:
+                        inst.last_dispatch = None
+                    log("owner_orphan_reap_done", key=inst.key,
+                        tab=r.get("tab_id"), id=cid,
+                        ok=bool(isinstance(payload, dict)
+                                and payload.get("ok")))
+                    return True
+            # No live submitter, and not a reap either — so this may be the
+            # ABANDONED command whose
             # inflight entry we deliberately kept (see INFLIGHT_STALE_S). The reply
             # proves the extension is free again, so release it NOW instead of
             # waiting out the staleness window: that is the difference between the
@@ -2166,20 +2206,30 @@ class Registry:
             # record below is overwritten, orphaning the live first tab.
             #
             # ⚠ THIS COMMENT USED TO END "Nothing reclaims it; only a human
-            # closes it." THAT IS NO LONGER TRUE and the correction is the point:
-            # the extension now REAPS that tab — on the timeout arm only, after
-            # the replacement exists, fire-and-forget (see `open` in
-            # service_worker.js). What survives is a WEAKER residual, stated so
-            # nobody re-derives the stronger claim from this block:
-            #   * the reap is best-effort. A browser-wide stall that hung
-            #     `tabs.get` can hang `tabs.remove` too, and nothing waits.
+            # closes it." THAT IS NO LONGER TRUE: the extension REPORTS the
+            # orphaned tabId in its `open` result and THIS SERVER closes it, in
+            # `_record_ownership_locked` → `_enqueue_reap_close_locked`. Read
+            # those two for the full argument; the short version is that
+            # reclaiming is only correct when the `open` result was DELIVERED, and
+            # this side is the only side that knows.
+            #
+            # 🔴 AN EARLIER REVISION OF THIS PARAGRAPH SAID THE OPPOSITE — "the
+            # reclaim is entirely the extension's, so nothing below depends on
+            # it" — and it survived one whole audit round. It was written when the
+            # extension did the closing, and it is exactly the sentence that would
+            # tell a maintainer reading submit() that the server does nothing
+            # here. It does. Left recorded rather than silently replaced, because
+            # the same inversion is easy to reintroduce from either direction.
+            #
+            # What survives is a WEAKER residual, stated so nobody re-derives the
+            # stronger claim from this block:
+            #   * the reclaim is best-effort — a real `close` op that can fail or
+            #     be lost, with no counter for how often;
             #   * a DIFFERENT orphan is still unreclaimed: if `chrome.tabs.create`
-            #     itself hangs, the op is killed at EXEC_OP_BUDGET_MS while the
-            #     abandoned create still settles, producing a tab the extension
-            #     never sees. Nothing here or there can close that one.
-            # Either way the SERVER's behaviour is unchanged — it overwrites the
-            # ownership record exactly as before; the reclaim is entirely the
-            # extension's, so nothing below depends on it.
+            #     hangs and NEVER settles, the op is killed at EXEC_OP_BUDGET_MS
+            #     and the abandoned create later produces a tab the extension
+            #     never sees, so there is nothing to report. Neither side can
+            #     close that one.
             reuse_tab_id = None
             if op == "open" and session_id is not None and tab is None:
                 reuse_tab_id = self._owned_tab_locked(inst.key, session_id,
@@ -2347,6 +2397,12 @@ class Registry:
                 self._owners[okey] = {
                     "tab_id": tid, "last_seen": self._clock()}
                 log("owner_open", key=inst.key, session=session_id, tab=tid)
+                # 🔴 RE-OWNING A TAB WITHDRAWS ANY REAP AIMED AT IT. `open` is
+                # not in TAB_SCOPED_OPS, so two concurrent opens from one session
+                # take no turnstile and a later one can healthily REUSE the tab an
+                # earlier one queued for reaping. Without this the server closes a
+                # tab it currently owns. Reproduced before it was fixed.
+                self._cancel_queued_reaps_locked(inst, tid)
                 # 🔴 RECLAIM THE ORPHAN — HERE, AND NOWHERE ELSE.
                 #
                 # When the extension's reuse probe exceeds REUSE_TAB_BUDGET_MS it
@@ -2399,36 +2455,88 @@ class Registry:
         🔴 NO WAITER, DELIBERATELY. Every other command in this file is enqueued
         by a submitter that then blocks on `inst.results[cid]`; this one has no
         submitter, because the caller it would belong to has already been handed
-        its `open` result. So `cid` is NOT added to `inst.waiters`, and when the
-        reply arrives `deliver_result` finds no waiter, falls to its
-        `result_after_abandon` branch, pops the inflight entry and logs. That is
-        an existing, exercised path — not a new one — and it is why this cannot
-        strand a waiter or a `pending` slot: it takes neither.
+        its `open` result. So `cid` is NOT added to `inst.waiters`, and it cannot
+        strand a waiter or a `pending` slot: it takes neither. Its reply is
+        recognised by `deliver_result` via `inst.reaps` and answered normally.
 
         🔴 BUT IT DOES TAKE AN `inflight` ENTRY, and that is the point of the
         line. `inflight` is what `_effective_timeout_locked` reads to tell a BUSY
         extension from an idle one; without an entry, a `ping` landing while this
         close executes would fast-fail against a perfectly healthy extension.
-        The entry is released by the same `deliver_result` branch above, or
-        expires on INFLIGHT_STALE_S if the reply never comes.
 
-        Ordering: appended to the same FIFO outbox as everything else, so it runs
-        before any command submitted after it and cannot overtake one submitted
-        before. It targets a tab NOBODY owns any more, so it cannot race a
-        tab-scoped op for the session's current tab.
+        🔴 AND IT IS THE ONLY OUTBOX ENTRY THAT NEEDS ITS OWN LIFETIME, because
+        it is the only one with no submitter to withdraw it. Every other command
+        is dropped from the outbox by its abandoning submitter at `cmd_timeout`
+        (see the filter in submit's finally). Left unbounded this one survives a
+        wedged extension indefinitely — and `instance_id` is stable per profile,
+        so a Brave RESTART returns the SAME `Instance` while Chromium's tab ids
+        restart at 1. The queued `close` would then name a different, real tab.
+        That correlation is adverse: a browser-wide stall is what PRODUCES a
+        reap, and a full restart is the documented remedy for a stall. Hence
+        `expires_at`, checked at pickup in `poll()`, matched to the same
+        INFLIGHT_STALE_S window the inflight entry already ages out on.
 
-        Idempotent by construction: the extension's `close` treats an
-        already-gone tab as success, so a tab that really had died during the
-        probe costs one no-op round trip and nothing else.
+        🔴 AND IT MUST BE CANCELLABLE, because the guard that made it safe is
+        POINT-IN-TIME. `orphan != tid` was true when the reap was enqueued; the
+        close executes later, and `open` is NOT in TAB_SCOPED_OPS, so two
+        concurrent `open`s from one session (which parallel agents sharing a
+        session id really do produce) take no turnstile: a later `open` can
+        healthily REUSE the very tab this reap is queued to close. Then the
+        server would close a tab it CURRENTLY OWNS — the session is left on a
+        dead id and, one op later, on the operator's ACTIVE tab. That is why
+        `_record_ownership_locked` calls `_cancel_queued_reaps_locked` for every
+        tab it records: re-owning a tab withdraws any reap aimed at it.
+
+        Ordering: appended to the same FIFO outbox as everything else, so it is
+        dispatched before any command appended after it. ⚠ NOT "before any
+        command SUBMITTED after it" — a submit blocked in `_tab_queues` has not
+        appended yet, so it can still land ahead. Harmless (the reap targets a
+        different tab), but the stronger sentence was wrong.
+
+        Idempotent WHILE THE ID STILL NAMES THE SAME TAB: the extension's `close`
+        treats an already-gone tab as success, so a tab that really had died
+        during the probe costs one no-op round trip. The expiry above is what
+        keeps that qualifier true.
         """
         cid = secrets.token_hex(8)
         inst.outbox.append({"id": cid, "op": "close", "tabId": tab_id})
         _now = self._clock()
         self._prune_inflight_locked(inst, _now)
         inst.inflight[cid] = _now
+        inst.reaps[cid] = {"tab_id": tab_id,
+                           "expires_at": _now + INFLIGHT_STALE_S}
         log("owner_orphan_reap", key=inst.key, session=session_id, tab=tab_id,
             id=cid)
         self._cond.notify_all()   # wake this instance's waiting poller
+
+    @staticmethod
+    def _cancel_queued_reaps_locked(inst, tab_id: int) -> int:
+        """Withdraw any not-yet-dispatched reap aimed at `tab_id`.
+
+        Called whenever a session RE-OWNS a tab. See the cancellation paragraph
+        in `_enqueue_reap_close_locked`: the `orphan != tid` guard is true only
+        at enqueue time, and a concurrent `open` can hand the same tab back to a
+        session before the close is dispatched.
+
+        Only removes entries still sitting in the outbox — once dispatched there
+        is nothing to withdraw, which is a real (much narrower) residual: the
+        window is one poll round trip rather than unbounded.
+        """
+        stale = [c for c in inst.reaps
+                 if inst.reaps[c].get("tab_id") == tab_id]
+        if not stale:
+            return 0
+        drop = set(stale)
+        kept = deque(c for c in inst.outbox if c.get("id") not in drop)
+        removed = len(inst.outbox) - len(kept)
+        inst.outbox = kept
+        for c in stale:
+            inst.reaps.pop(c, None)
+            inst.inflight.pop(c, None)
+        if removed:
+            log("owner_orphan_reap_cancel", key=inst.key, tab=tab_id,
+                n=removed)
+        return removed
 
     # --- resolution / introspection --------------------------------------- #
     def _live_instances_locked(self):

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -2077,9 +2077,19 @@ class Registry:
 
     @staticmethod
     def _prune_inflight_locked(inst, now):
-        """Drop `inflight` entries that can no longer describe current business.
+        """Drop `inflight` entries that can no longer describe current business,
+        AND sweep the `reaps` index of entries nothing can reach any more.
 
-        TWO conditions, and the second is not optional:
+        🔴 THE SECOND JOB IS IN THE NAME'S BLIND SPOT, WHICH IS HOW A REGRESSION
+        GOT IN. This used to say "Drop `inflight` entries" and nothing else, so a
+        function whose contract read "inflight only" was quietly given authority
+        over the reap-expiry index — and the first draft of that sweep used an
+        inflight-only predicate, deleting the metadata of reaps still queued in
+        the outbox and thereby removing BOTH of a reap's bounds. The sweep's own
+        comment below carries the measurement; this line exists so the contract
+        at the top is as wide as the body.
+
+        TWO conditions for the inflight half, and the second is not optional:
 
         (a) older than INFLIGHT_STALE_S, AND
         (b) NO live submitter is still blocked on it (`cid not in inst.waiters`).
@@ -2109,14 +2119,33 @@ class Registry:
                  if now - t > INFLIGHT_STALE_S and c not in inst.waiters]
         for c in stale:
             del inst.inflight[c]
-        # A reap's `reaps` entry is only ever meaningful while its `inflight`
-        # entry lives: it is created with one and dropped with one on every
-        # normal exit (reply, cancel, expiry-at-pickup). The one path that leaves
-        # it behind is a reap whose reply is LOST — the residual this feature
-        # already discloses. Without this sweep that entry would outlive the
-        # Instance's usefulness (`instance_id` is stable across a browser
-        # restart), so tie its lifetime to the one that is already bounded.
-        for c in [c for c in inst.reaps if c not in inst.inflight]:
+        # Sweep the `reaps` index for entries nothing can reach any more. The one
+        # path that strands one is a reap whose reply is LOST — the residual this
+        # feature discloses — after which it would outlive the Instance's
+        # usefulness, since `instance_id` is stable across a browser restart.
+        #
+        # 🔴 A REAP IS REACHABLE FROM TWO PLACES, AND AN EARLIER DRAFT SWEPT ON
+        # ONLY ONE OF THEM. `inst.reaps[cid]` is the ONLY index from an outbox
+        # entry to its `expires_at`, and it is also what `_cancel_queued_reaps_
+        # locked` matches on. A reap's inflight stamp and its expiry are both set
+        # from the same instant, so the age-prune above fires at EXACTLY the
+        # moment the reap expires — and a reap is never in `waiters`
+        # (deliberately: "NO WAITER"), so condition (b) never shields it. An
+        # inflight-only predicate therefore deleted the metadata of a reap STILL
+        # SITTING IN THE OUTBOX. Measured, red at that draft and green before it:
+        #   * `poll()` found no entry, skipped the expiry branch, and DISPATCHED
+        #     the stale close — removing the exact bound `expires_at` exists to
+        #     provide, in the wedged-extension case it was written for;
+        #   * `_cancel_queued_reaps_locked` could no longer see it, so re-owning
+        #     the tab stopped withdrawing the close — the other bound, gone too.
+        # Neither needs a rare event: `_prune_inflight_locked` runs on EVERY
+        # submit and every ping, and two ordinary ops ahead of the reap in the
+        # serial FIFO can exceed INFLIGHT_STALE_S without any wedge at all.
+        #
+        # So sweep only what BOTH bounded lifetimes have finished with.
+        queued = {c.get("id") for c in inst.outbox}
+        for c in [c for c in inst.reaps
+                  if c not in inst.inflight and c not in queued]:
             del inst.reaps[c]
 
     # --- concurrency backstop (per-instance rate limit + queue-depth cap) --- #

--- a/scripts/browser-bridge/server.py
+++ b/scripts/browser-bridge/server.py
@@ -2163,8 +2163,23 @@ class Registry:
             # is gone (owned_tab_gone). 🔴 NO LONGER UNCONDITIONAL: since the
             # extension bounds that probe (REUSE_TAB_BUDGET_MS), a probe that
             # exceeds the budget falls through to a FRESH tab and the ownership
-            # record below is overwritten, deterministically ORPHANING the live
-            # first tab. Nothing reclaims it; only a human closes it.
+            # record below is overwritten, orphaning the live first tab.
+            #
+            # ⚠ THIS COMMENT USED TO END "Nothing reclaims it; only a human
+            # closes it." THAT IS NO LONGER TRUE and the correction is the point:
+            # the extension now REAPS that tab — on the timeout arm only, after
+            # the replacement exists, fire-and-forget (see `open` in
+            # service_worker.js). What survives is a WEAKER residual, stated so
+            # nobody re-derives the stronger claim from this block:
+            #   * the reap is best-effort. A browser-wide stall that hung
+            #     `tabs.get` can hang `tabs.remove` too, and nothing waits.
+            #   * a DIFFERENT orphan is still unreclaimed: if `chrome.tabs.create`
+            #     itself hangs, the op is killed at EXEC_OP_BUDGET_MS while the
+            #     abandoned create still settles, producing a tab the extension
+            #     never sees. Nothing here or there can close that one.
+            # Either way the SERVER's behaviour is unchanged — it overwrites the
+            # ownership record exactly as before; the reclaim is entirely the
+            # extension's, so nothing below depends on it.
             reuse_tab_id = None
             if op == "open" and session_id is not None and tab is None:
                 reuse_tab_id = self._owned_tab_locked(inst.key, session_id,

--- a/scripts/browser-bridge/tests/cdp_protocol.test.mjs
+++ b/scripts/browser-bridge/tests/cdp_protocol.test.mjs
@@ -333,15 +333,15 @@ test("open's reuse-probe bound is ordered against the work it wraps (the op-ceil
   // a LOW-side failure — a merely slow probe falls through to a fresh tab and
   // ORPHANS the live one.
   //
-  // ⚠ `open` now REAPS that orphan (service_worker.js), so an earlier wording here
-  // — "with nothing to reclaim it" — no longer holds. THE FLOOR IS NOT WEAKENED BY
-  // THAT, and the reason is worth stating so nobody lowers it on the strength of
-  // the reap: the reap is best-effort and fire-and-forget, so it converts a
-  // guaranteed leak into a probable reclaim, not into a no-op. Every low-side
-  // fall-through still costs a real tab close plus a real tab create — visible
-  // churn in the operator's window — and under the browser-wide stall that would
-  // cause a slow probe in the first place, the reap is exactly the thing least
-  // likely to land.
+  // ⚠ `open` now REPORTS that orphan and the SERVER closes it, so an earlier
+  // wording here — "with nothing to reclaim it" — no longer holds. THE FLOOR IS
+  // NOT WEAKENED BY THAT, and the reason is worth stating so nobody lowers it on
+  // the strength of the reclaim: it turns a guaranteed leak into a reclaim that
+  // happens only when the `open` result was DELIVERED, which is a narrowing, not
+  // a no-op. Every low-side fall-through still costs a real tab close plus a real
+  // tab create — visible churn in the operator's window, and possibly a SIBLING
+  // agent's tab (parallel agents can share one owned tab). Under the very stall
+  // that causes a slow probe, the reclaim is the part least likely to land.
   //
   // ⚠️ BE HONEST ABOUT WHAT THIS FLOOR IS: there is NO measurement of a healthy
   // `chrome.tabs.get` anywhere in this repo, so unlike #797's `> 1365` (anchored to
@@ -354,9 +354,10 @@ test("open's reuse-probe bound is ordered against the work it wraps (the op-ceil
   assert.ok(REUSE_TAB_BUDGET_MS >= 1000,
             `reuse probe (${REUSE_TAB_BUDGET_MS}ms) is below the 1000ms floor. Going `
             + `LOW orphans live tabs: a slow-but-healthy probe falls through to a `
-            + `fresh tab, and the reap that reclaims the old one is best-effort and `
-            + `fire-and-forget — least likely to land under exactly the stall that `
-            + `caused the slow probe, and it costs a real close+create either way. `
+            + `fresh tab, and the server-side reclaim of the old one fires ONLY `
+            + `when that open result was delivered — so it narrows the leak, it `
+            + `does not remove it, and every fall-through still costs a real `
+            + `close+create (possibly of a SIBLING agent's tab). `
             + `The floor is conservative `
             + `(2x activate's measured ~350-500ms round trip), not calibrated — if `
             + `you have measured chrome.tabs.get, replace it with the real band`);

--- a/scripts/browser-bridge/tests/cdp_protocol.test.mjs
+++ b/scripts/browser-bridge/tests/cdp_protocol.test.mjs
@@ -354,7 +354,10 @@ test("open's reuse-probe bound is ordered against the work it wraps (the op-ceil
   assert.ok(REUSE_TAB_BUDGET_MS >= 1000,
             `reuse probe (${REUSE_TAB_BUDGET_MS}ms) is below the 1000ms floor. Going `
             + `LOW orphans live tabs: a slow-but-healthy probe falls through to a `
-            + `fresh tab and nothing reclaims the old one. The floor is conservative `
+            + `fresh tab, and the reap that reclaims the old one is best-effort and `
+            + `fire-and-forget — least likely to land under exactly the stall that `
+            + `caused the slow probe, and it costs a real close+create either way. `
+            + `The floor is conservative `
             + `(2x activate's measured ~350-500ms round trip), not calibrated — if `
             + `you have measured chrome.tabs.get, replace it with the real band`);
 });

--- a/scripts/browser-bridge/tests/cdp_protocol.test.mjs
+++ b/scripts/browser-bridge/tests/cdp_protocol.test.mjs
@@ -331,7 +331,17 @@ test("open's reuse-probe bound is ordered against the work it wraps (the op-ceil
   // measured, `REUSE_TAB_BUDGET_MS = 100` passed the entire 507-test suite. That is
   // the wrong direction to be unguarded, because the bound's whole disclosed cost is
   // a LOW-side failure — a merely slow probe falls through to a fresh tab and
-  // ORPHANS the live one, with nothing to reclaim it.
+  // ORPHANS the live one.
+  //
+  // ⚠ `open` now REAPS that orphan (service_worker.js), so an earlier wording here
+  // — "with nothing to reclaim it" — no longer holds. THE FLOOR IS NOT WEAKENED BY
+  // THAT, and the reason is worth stating so nobody lowers it on the strength of
+  // the reap: the reap is best-effort and fire-and-forget, so it converts a
+  // guaranteed leak into a probable reclaim, not into a no-op. Every low-side
+  // fall-through still costs a real tab close plus a real tab create — visible
+  // churn in the operator's window — and under the browser-wide stall that would
+  // cause a slow probe in the first place, the reap is exactly the thing least
+  // likely to land.
   //
   // ⚠️ BE HONEST ABOUT WHAT THIS FLOOR IS: there is NO measurement of a healthy
   // `chrome.tabs.get` anywhere in this repo, so unlike #797's `> 1365` (anchored to

--- a/scripts/browser-bridge/tests/service_worker.test.mjs
+++ b/scripts/browser-bridge/tests/service_worker.test.mjs
@@ -31,14 +31,15 @@ const state = {
   tab: { id: TAB_ID, url: "https://civitai.com/apps/run/model-benchmarking",
          title: "Model Benchmarking", active: false, status: "complete", windowId: 1 },
   calls: { getAllFrames: [], executeScript: [], debugger: [], tabsGet: [],
-           tabsUpdate: [], windowsUpdate: [], tabsCreate: [] },
+           tabsUpdate: [], windowsUpdate: [], tabsCreate: [], tabsRemove: [] },
   crumbs: [],
 };
 function resetCalls() {
   state.calls = { getAllFrames: [], executeScript: [], debugger: [], tabsGet: [],
-                  tabsUpdate: [], windowsUpdate: [], tabsCreate: [] };
+                  tabsUpdate: [], windowsUpdate: [], tabsCreate: [], tabsRemove: [] };
   state.crumbs = [];
   state.execResult = { ok: true };
+  state.tabsRemoveThrows = false;
 }
 // Keep the `activate` wait fast + deterministic in these wiring tests (the wait
 // LOGIC itself is unit-tested in protocol.test.mjs): no paint settle, 1ms polls.
@@ -62,6 +63,10 @@ globalThis.chrome = {
     async create(props) {
       state.calls.tabsCreate.push(props);
       return { id: FRESH_TAB_ID, url: (props && props.url) || "about:blank" };
+    },
+    async remove(id) {
+      state.calls.tabsRemove.push(id);
+      if (state.tabsRemoveThrows) throw new Error(`No tab with id: ${id}.`);
     },
     async update(id, props) {
       state.calls.tabsUpdate.push({ id, props });
@@ -468,7 +473,10 @@ test("open reuse probe: a HUNG chrome.tabs.get falls through to a fresh tab",
 // reuse into a fresh tab. A healthy `tabs.get` must still reuse — otherwise the
 // test above would pass just as well with the reuse path deleted outright, and
 // would be recording coverage it does not have. (Tab reuse is not cosmetic: a
-// missed reuse orphans the previous tab, which nothing owns and nothing closes.)
+// missed reuse orphans the previous tab, which nothing OWNS — the reap added
+// later in this file closes it best-effort, but reuse is still strictly cheaper
+// than close-plus-create, and the reap is the least likely thing to land under
+// the stall that caused the missed reuse.)
 test("open reuse probe: a HEALTHY chrome.tabs.get still reuses the owned tab", async () => {
   resetCalls();
   const out = await OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" });
@@ -546,6 +554,179 @@ test("open reuse probe: the breadcrumb distinguishes a HANG from a genuinely-gon
   // distinct literals above, so such an assertion is strictly IMPLIED and cannot fail
   // for any mutant — coverage-shaped and empty, the same defect this PR removed once
   // already. The distinctness that matters is enforced by the two equals.)
+});
+
+// --------------------------------------------------------------------------- //
+// 🔴 THE BOUND'S ORPHAN IS REAPED, NOT ONLY DISCLOSED.
+//
+// #814 bounded the reuse probe and DISCLOSED its cost in two places — the
+// REUSE_TAB_BUDGET_MS comment, and server.py's `reuse_tab_id` block, which spells
+// it out: a probe that exceeds the budget falls through to a FRESH tab, the server
+// overwrites the ownership record, and the live first tab is "deterministically
+// ORPHAN[ed] … Nothing reclaims it; only a human closes it." `open` returns
+// SUCCESS on that path, so nothing ever revisits it — one leaked tab per
+// timed-out re-open. These tests pin the reclaim.
+//
+// WHY THE ASYMMETRY IS THE SUBJECT AND NOT AN IMPLEMENTATION DETAIL: the two arms
+// of the catch carry OPPOSITE evidence. A timeout learned nothing (reap); a
+// rejection is `chrome.tabs.get` naming the id as absent (do not reap — a remove
+// against an id we have positive evidence is gone is pure exposure, since a tabId
+// can be recycled). A test that only asserted "the timeout arm reaps" would pass
+// just as well with an UNCONDITIONAL reap, which is a strictly worse program. So
+// both arms are asserted, side by side, and the negative is the discriminating one.
+// --------------------------------------------------------------------------- //
+
+// Race an `open` against a 1s deadline so a REGRESSION IS AN ASSERTION FAILURE,
+// not a hang: node scores a timed-out test `cancelled` and leaves `fail` at 0, so
+// a gate that greps the fail count would read a live regression as clean. The
+// per-test `{ timeout }` stays only as a backstop for anything outside the race.
+function openWithin(promise, why) {
+  let hangTimer;
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      hangTimer = setTimeout(() => reject(new Error(why)), 1000);
+    }),
+  ]).finally(() => clearTimeout(hangTimer));
+}
+
+test("open reuse probe: a TIMED-OUT probe reaps the tab it just orphaned",
+     { timeout: 2000 }, async (t) => {
+  resetCalls();
+  const realGet = chrome.tabs.get;
+  const realTiming = globalThis.BROWSER_BRIDGE_LOOP_TIMING;
+  t.after(() => {
+    chrome.tabs.get = realGet;
+    globalThis.BROWSER_BRIDGE_LOOP_TIMING = realTiming;
+  });
+  globalThis.BROWSER_BRIDGE_LOOP_TIMING = { ...(realTiming || {}), reuseTabMs: 20 };
+  chrome.tabs.get = () => new Promise(() => {});   // never settles
+
+  const out = await openWithin(
+    OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" }),
+    "open did not settle within 1s");
+
+  assert.equal(out.tabId, FRESH_TAB_ID, "the fall-through still yields the fresh tab");
+  assert.equal(state.calls.tabsCreate.length, 1, "exactly one replacement tab");
+  assert.deepEqual(state.calls.tabsRemove, [TAB_ID],
+                   "the orphaned tab must be reclaimed — server.py's "
+                   + "\"Nothing reclaims it; only a human closes it\" is what this "
+                   + "assertion deletes");
+
+  // 🔴 ORDERING, WHICH THE ASSERTION ABOVE CANNOT SEE: the reap must run only
+  // AFTER the replacement exists. Reaping first would close the session's ONLY
+  // tab and then, when the create fails, leave it owning a dead id — strictly
+  // worse than the leak. A failing create is the one probe that separates the two
+  // orderings, because both produce an identical `tabsRemove` when create works.
+  resetCalls();
+  const realCreate = chrome.tabs.create;
+  t.after(() => { chrome.tabs.create = realCreate; });
+  chrome.tabs.create = async () => { throw new Error("Tab creation failed."); };
+  await assert.rejects(
+    () => openWithin(OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" }),
+                     "open did not settle within 1s on a failing create"),
+    /Tab creation failed\./,
+    "a failed create must still surface as the op's error");
+  assert.deepEqual(state.calls.tabsRemove, [],
+                   "nothing may be reaped when there is no replacement tab — the "
+                   + "reap belongs AFTER chrome.tabs.create, not before it");
+});
+
+// 🔴 THE DISCRIMINATING NEGATIVE. Without this, an unconditional reap passes the
+// test above — and an unconditional reap fires a `tabs.remove` at an id
+// `chrome.tabs.get` has just reported absent, which buys nothing and can land on a
+// recycled tabId.
+test("open reuse probe: a REJECTING probe must NOT reap — the id is known absent",
+     async (t) => {
+  resetCalls();
+  const realGet = chrome.tabs.get;
+  t.after(() => { chrome.tabs.get = realGet; });
+  chrome.tabs.get = async () => { throw new Error("No tab with id: 5."); };
+
+  const out = await OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" });
+  assert.equal(out.tabId, FRESH_TAB_ID, "the gone path still yields a fresh tab");
+  assert.equal(state.calls.tabsCreate.length, 1);
+  assert.deepEqual(state.calls.tabsRemove, [],
+                   "a tab the probe REPORTED gone must not be removed: nothing to "
+                   + "reclaim, and a recycled tabId would be someone else's tab");
+});
+
+// The other two paths that reach `chrome.tabs.create`, both of which must stay
+// reap-free. Together with the two arms above these enumerate every route through
+// `open`, so "the reap fires on exactly one of them" is a closed claim rather than
+// a sampled one.
+test("open: neither a healthy reuse nor a first open ever reaps", async () => {
+  resetCalls();
+  const reused = await OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" });
+  assert.equal(reused.reused, true, "healthy probe reuses (attribution control)");
+  assert.deepEqual(state.calls.tabsRemove, [], "a reused tab is not an orphan");
+
+  resetCalls();
+  const fresh = await OPS.open({ url: "https://civitai.com/" });   // no reuseTabId
+  assert.equal(fresh.tabId, FRESH_TAB_ID);
+  assert.equal(state.calls.tabsCreate.length, 1);
+  assert.deepEqual(state.calls.tabsRemove, [],
+                   "a session's FIRST open has no predecessor to reclaim");
+});
+
+// 🔴 THE REAP IS FIRE-AND-FORGET, AND THAT IS LOAD-BEARING RATHER THAN TIDY.
+// `chrome.tabs.remove` is one more unbounded browser-process IPC. Awaiting it
+// would put a NEW unbounded await on `open`'s SUCCESS path — regenerating, at the
+// last line of the op, the exact defect class #797/#814 exist to remove. So the
+// property under test is not "the reap works" but "the reap cannot hurt": a
+// remove that HANGS FOREVER, one that REJECTS, and one that throws SYNCHRONOUSLY
+// must each leave `open`'s result and latency untouched.
+//
+// The hang arm needs the race + `{ timeout }` for the reason stated above the
+// probe tests: node scores a timed-out test `cancelled`, leaving `fail` at 0, so a
+// regression here would read as clean to a gate that greps the fail count.
+test("open reuse probe: a HANGING / REJECTING / THROWING reap cannot delay or fail open",
+     { timeout: 2000 }, async (t) => {
+  const realGet = chrome.tabs.get;
+  const realRemove = chrome.tabs.remove;
+  const realTiming = globalThis.BROWSER_BRIDGE_LOOP_TIMING;
+  t.after(() => {
+    chrome.tabs.get = realGet;
+    chrome.tabs.remove = realRemove;
+    globalThis.BROWSER_BRIDGE_LOOP_TIMING = realTiming;
+  });
+  globalThis.BROWSER_BRIDGE_LOOP_TIMING = { ...(realTiming || {}), reuseTabMs: 20 };
+  chrome.tabs.get = () => new Promise(() => {});   // force the timeout arm
+
+  const openOrDie = (why) =>
+    openWithin(OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" }), why);
+
+  // (a) HANG. The one that would catch an `await` being added to the reap.
+  resetCalls();
+  let removeCalls = 0;
+  chrome.tabs.remove = () => { removeCalls += 1; return new Promise(() => {}); };
+  let out = await openOrDie(
+    "open did not settle within 1s: the reap is being AWAITED, so a hung "
+    + "chrome.tabs.remove now wedges the op it was added to clean up after");
+  assert.equal(out.tabId, FRESH_TAB_ID, "a hung reap must not change the result");
+  assert.equal(removeCalls, 1, "…and the reap must still have been ATTEMPTED");
+
+  // (b) REJECT — the ordinary case when the orphan really had gone after all.
+  resetCalls();
+  chrome.tabs.remove = async (id) => {
+    state.calls.tabsRemove.push(id);
+    throw new Error("No tab with id: 5.");
+  };
+  out = await openOrDie("open did not settle within 1s on a REJECTING reap");
+  assert.equal(out.tabId, FRESH_TAB_ID, "a rejected reap must not fail the op");
+  assert.deepEqual(state.calls.tabsRemove, [TAB_ID]);
+
+  // (c) SYNCHRONOUS throw — an older/stubbed chrome.* surface. This is the arm
+  // that makes the `try` around the reap non-vacuous; without it, deleting that
+  // try/catch passes the whole suite.
+  resetCalls();
+  chrome.tabs.remove = (id) => {
+    state.calls.tabsRemove.push(id);
+    throw new Error("chrome.tabs.remove is not a function");
+  };
+  out = await openOrDie("open did not settle within 1s on a SYNC-THROWING reap");
+  assert.equal(out.tabId, FRESH_TAB_ID, "a synchronously throwing reap must not fail the op");
+  assert.deepEqual(state.calls.tabsRemove, [TAB_ID]);
 });
 
 // --------------------------------------------------------------------------- //

--- a/scripts/browser-bridge/tests/service_worker.test.mjs
+++ b/scripts/browser-bridge/tests/service_worker.test.mjs
@@ -39,7 +39,6 @@ function resetCalls() {
                   tabsUpdate: [], windowsUpdate: [], tabsCreate: [], tabsRemove: [] };
   state.crumbs = [];
   state.execResult = { ok: true };
-  state.tabsRemoveThrows = false;
 }
 // Keep the `activate` wait fast + deterministic in these wiring tests (the wait
 // LOGIC itself is unit-tested in protocol.test.mjs): no paint settle, 1ms polls.
@@ -64,10 +63,10 @@ globalThis.chrome = {
       state.calls.tabsCreate.push(props);
       return { id: FRESH_TAB_ID, url: (props && props.url) || "about:blank" };
     },
-    async remove(id) {
-      state.calls.tabsRemove.push(id);
-      if (state.tabsRemoveThrows) throw new Error(`No tab with id: ${id}.`);
-    },
+    // Present ONLY so that a regression which puts a tab close back into `open`
+    // is RECORDED rather than crashing on an undefined stub — every `open`
+    // assertion below requires this list to stay EMPTY.
+    async remove(id) { state.calls.tabsRemove.push(id); },
     async update(id, props) {
       state.calls.tabsUpdate.push({ id, props });
       if (props) Object.assign(state.tab, props);   // e.g. {active:true}
@@ -98,7 +97,7 @@ globalThis.chrome = {
   alarms: { create() {}, onAlarm: { addListener() {} } },
 };
 
-const { OPS, loopTiming, execute, emulationState, documentEmulation } =
+const { OPS, loopTiming, execute } =
   await import("../extension/service_worker.js");
 const { FAST_CAPTURE_BUDGET_MS, EXEC_OP_BUDGET_MS, POLL_BUDGET_MS,
         RESULT_BUDGET_MS, LOOP_STALL_MS, STORAGE_BUDGET_MS, REUSE_TAB_BUDGET_MS }
@@ -556,25 +555,32 @@ test("open reuse probe: the breadcrumb distinguishes a HANG from a genuinely-gon
   // for any mutant — coverage-shaped and empty, the same defect this PR removed once
   // already. The distinctness that matters is enforced by the two equals.)
 });
-
 // --------------------------------------------------------------------------- //
-// 🔴 THE BOUND'S ORPHAN IS REAPED, NOT ONLY DISCLOSED.
+// 🔴 THE BOUND'S ORPHAN IS REPORTED SO THE SERVER CAN RECLAIM IT — AND THE
+// EXTENSION CLOSES NOTHING.
 //
 // #814 bounded the reuse probe and DISCLOSED its cost in two places — the
 // REUSE_TAB_BUDGET_MS comment, and server.py's `reuse_tab_id` block, which spells
 // it out: a probe that exceeds the budget falls through to a FRESH tab, the server
-// overwrites the ownership record, and the live first tab is "deterministically
-// ORPHAN[ed] … Nothing reclaims it; only a human closes it." `open` returns
-// SUCCESS on that path, so nothing ever revisits it — one leaked tab per
-// timed-out re-open. These tests pin the reclaim.
+// overwrites the ownership record, and the live first tab is orphaned with nothing
+// to reclaim it. `open` returns SUCCESS on that path, so nothing ever revisits it
+// — one leaked tab per timed-out re-open.
 //
-// WHY THE ASYMMETRY IS THE SUBJECT AND NOT AN IMPLEMENTATION DETAIL: the two arms
-// of the catch carry OPPOSITE evidence. A timeout learned nothing (reap); a
-// rejection is `chrome.tabs.get` naming the id as absent (do not reap — a remove
-// against an id we have positive evidence is gone is pure exposure, since a tabId
-// can be recycled). A test that only asserted "the timeout arm reaps" would pass
-// just as well with an UNCONDITIONAL reap, which is a strictly worse program. So
-// both arms are asserted, side by side, and the negative is the discriminating one.
+// 🔴 WHY THE DIVISION OF LABOUR IS THE SUBJECT OF THESE TESTS. Two earlier drafts
+// had the extension close the tab itself. Both were wrong the same way:
+// reclaiming is correct ONLY IF THE RESULT IS DELIVERED — otherwise the old tab is
+// not an orphan at all (the ownership record still names it, it is still live) and
+// closing it strands the session on a dead id, then on the operator's ACTIVE tab.
+// TWO parties abandon an op on TWO clocks and neither is visible from inside the
+// op: execute()'s execMs race (which cannot cancel, so a merely SLOW create
+// resumes afterwards) and the submitter's cmd_timeout (which starts at SUBMIT, so
+// queue time is invisible). An extension-side elapsed guard closed the first and
+// structurally could not close the second. So the assertion that matters most
+// below is the NEGATIVE one, repeated on every path: `tabsRemove` stays empty.
+//
+// The server half — that a DELIVERED `open` result carrying `orphanTabId` enqueues
+// a `close`, and an abandoned one does not — is pinned in test_server.py, because
+// the fact "we got here" lives only there.
 // --------------------------------------------------------------------------- //
 
 // Race an `open` against a 1s deadline so a REGRESSION IS AN ASSERTION FAILURE,
@@ -591,7 +597,7 @@ function openWithin(promise, why) {
   ]).finally(() => clearTimeout(hangTimer));
 }
 
-test("open reuse probe: a TIMED-OUT probe reaps the tab it just orphaned",
+test("open reuse probe: a TIMED-OUT probe REPORTS the orphan and closes nothing",
      { timeout: 2000 }, async (t) => {
   resetCalls();
   const realGet = chrome.tabs.get;
@@ -603,63 +609,28 @@ test("open reuse probe: a TIMED-OUT probe reaps the tab it just orphaned",
   globalThis.BROWSER_BRIDGE_LOOP_TIMING = { ...(realTiming || {}), reuseTabMs: 20 };
   chrome.tabs.get = () => new Promise(() => {});   // never settles
 
-  // SEED both per-tab maps, or the `has(...) === false` assertions below are
-  // vacuous — they would hold just as well on a build that never forgets
-  // anything. t.after clears them so a leak here cannot colour a later test.
-  emulationState.set(TAB_ID, { preset: "iphone-15" });
-  documentEmulation.set(TAB_ID, { at: 1 });
-  t.after(() => { emulationState.delete(TAB_ID); documentEmulation.delete(TAB_ID); });
-  assert.equal(emulationState.has(TAB_ID), true, "control: the seed took");
-  assert.equal(documentEmulation.has(TAB_ID), true, "control: the seed took");
-
   const out = await openWithin(
     OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" }),
     "open did not settle within 1s");
 
   assert.equal(out.tabId, FRESH_TAB_ID, "the fall-through still yields the fresh tab");
   assert.equal(state.calls.tabsCreate.length, 1, "exactly one replacement tab");
-  assert.deepEqual(state.calls.tabsRemove, [TAB_ID],
-                   "the orphaned tab must be reclaimed — server.py's "
-                   + "\"Nothing reclaims it; only a human closes it\" is what this "
-                   + "assertion deletes");
-  assert.equal(out.reapAttempted, TAB_ID,
-               "the envelope must carry the trace: this remove is issued WITHOUT "
-               + "the caller asking for it, so `open` is the only place it can be "
-               + "recorded (nothing awaits the result, hence ATTEMPTED)");
-
-  // 🔴 PARITY WITH `close`, WHICH DOES THIS FIRST AND SAYS WHY: onRemoved's
-  // timing is not ours to control and it does not fire at all on the
-  // already-gone path, so a stale entry is inheritable by a RECYCLED tabId.
-  // Without this the claim "the same thing `close` does" is not literally true.
-  assert.equal(emulationState.has(TAB_ID), false,
-               "the reap must forget the tab's emulation state, as `close` does");
-  assert.equal(documentEmulation.has(TAB_ID), false,
-               "…and its document record, for the same recycled-tabId reason");
-
-  // 🔴 ORDERING, WHICH THE ASSERTION ABOVE CANNOT SEE: the reap must run only
-  // AFTER the replacement exists. Reaping first would close the session's ONLY
-  // tab and then, when the create fails, leave it owning a dead id — strictly
-  // worse than the leak. A failing create is the one probe that separates the two
-  // orderings, because both produce an identical `tabsRemove` when create works.
-  resetCalls();
-  const realCreate = chrome.tabs.create;
-  t.after(() => { chrome.tabs.create = realCreate; });
-  chrome.tabs.create = async () => { throw new Error("Tab creation failed."); };
-  await assert.rejects(
-    () => openWithin(OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" }),
-                     "open did not settle within 1s on a failing create"),
-    /Tab creation failed\./,
-    "a failed create must still surface as the op's error");
+  assert.equal(out.orphanTabId, TAB_ID,
+               "the tab the fall-through orphaned must be REPORTED — it is the "
+               + "only way the server can ever learn of it, and server.py's "
+               + "\"Nothing reclaims it; only a human closes it\" is what this "
+               + "report exists to delete");
   assert.deepEqual(state.calls.tabsRemove, [],
-                   "nothing may be reaped when there is no replacement tab — the "
-                   + "reap belongs AFTER chrome.tabs.create, not before it");
+                   "🔴 the EXTENSION must not close it. It cannot know whether "
+                   + "this result will be delivered, and on the paths where it is "
+                   + "not, the old tab is still OWNED and still live");
 });
 
-// 🔴 THE DISCRIMINATING NEGATIVE. Without this, an unconditional reap passes the
-// test above — and an unconditional reap fires a `tabs.remove` at an id
-// `chrome.tabs.get` has just reported absent, which buys nothing and can land on a
-// recycled tabId.
-test("open reuse probe: a REJECTING probe must NOT reap — the id is known absent",
+// 🔴 THE DISCRIMINATING NEGATIVE for the report. Without it, an unconditional
+// `orphanTabId` passes the test above — and an unconditional report makes the
+// server close a tab `chrome.tabs.get` has just named as absent: nothing to
+// reclaim, and a recycled tabId would be someone else's tab.
+test("open reuse probe: a REJECTING probe reports NO orphan — the id is known absent",
      async (t) => {
   resetCalls();
   const realGet = chrome.tabs.get;
@@ -669,54 +640,49 @@ test("open reuse probe: a REJECTING probe must NOT reap — the id is known abse
   const out = await OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" });
   assert.equal(out.tabId, FRESH_TAB_ID, "the gone path still yields a fresh tab");
   assert.equal(state.calls.tabsCreate.length, 1);
-  assert.deepEqual(state.calls.tabsRemove, [],
-                   "a tab the probe REPORTED gone must not be removed: nothing to "
-                   + "reclaim, and a recycled tabId would be someone else's tab");
+  assert.equal("orphanTabId" in out, false,
+               "a tab the probe REPORTED gone must not be reported as an orphan: "
+               + "nothing to reclaim, and a recycled tabId would be someone "
+               + "else's tab");
+  assert.deepEqual(state.calls.tabsRemove, []);
 });
 
-// ⚠ ONE KNOWN EQUIVALENT MUTANT, recorded so nobody re-derives it as a coverage
-// gap: changing `orphanTabId != null` to a truthiness test SURVIVES this file.
-// It is equivalent, not uncovered — Chromium never issues tab id 0
-// (chrome.tabs.TAB_ID_NONE is -1 and real ids start at 1), so the two predicates
-// cannot disagree on any value this code can hold. `!= null` is kept anyway
-// because it says what is meant.
-//
-// The other two paths that reach `chrome.tabs.create`, both of which must stay
-// reap-free. Together with the two arms above these enumerate every route through
-// `open`, so "the reap fires on exactly one of them" is a closed claim rather than
-// a sampled one.
-test("open: neither a healthy reuse nor a first open ever reaps", async () => {
+// The other two paths that reach `chrome.tabs.create`. Together with the two arms
+// above these enumerate every route through `open`, so "exactly one of them
+// reports an orphan" is a closed claim rather than a sampled one.
+test("open: neither a healthy reuse nor a first open reports an orphan", async () => {
   resetCalls();
   const reused = await OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" });
   assert.equal(reused.reused, true, "healthy probe reuses (attribution control)");
-  assert.deepEqual(state.calls.tabsRemove, [], "a reused tab is not an orphan");
+  assert.equal("orphanTabId" in reused, false, "a reused tab is not an orphan");
+  assert.deepEqual(state.calls.tabsRemove, []);
 
   resetCalls();
   const fresh = await OPS.open({ url: "https://civitai.com/" });   // no reuseTabId
   assert.equal(fresh.tabId, FRESH_TAB_ID);
   assert.equal(state.calls.tabsCreate.length, 1);
-  assert.deepEqual(state.calls.tabsRemove, [],
-                   "a session's FIRST open has no predecessor to reclaim");
+  assert.equal("orphanTabId" in fresh, false,
+               "a session's FIRST open has no predecessor to reclaim");
+  assert.deepEqual(state.calls.tabsRemove, []);
 });
 
-// 🔴 A REAP THAT ARRIVES AFTER execute() HAS GIVEN UP IS WORSE THAN NO REAP.
+// 🔴 THE REGRESSION GUARD FOR THE WHOLE DESIGN DECISION, and the one case that
+// makes it concrete: an op execute() has ALREADY ABANDONED.
 //
 // execute() RACES the op against execMs; it does not CANCEL it. So a
-// `chrome.tabs.create` that is merely SLOW — not hung — resumes `open` long after
-// the op has already answered `op_timeout:open`. And on that path the old tab is
-// NOT an orphan: the server saw a non-tab-gone error, so it KEPT the session's
-// ownership pointing at a tab that is still live and still usable. Pre-change the
-// next `open` simply reused it. A late reap destroys it, leaving the session
-// owning a dead id → `owned_tab_gone` → the mapping is dropped → the op after
-// that falls back to the OPERATOR'S ACTIVE TAB, which is the blast radius the
-// ownership map exists to prevent.
+// `chrome.tabs.create` that is merely SLOW resumes `open` long after the op
+// answered `op_timeout:open`. On that path the old tab is NOT an orphan — the
+// server saw a non-tab-gone error and KEPT ownership of a tab that is still live
+// and still usable; pre-change the next `open` simply reused it. Anything closing
+// it here would strand the session on a dead id → `owned_tab_gone` → the mapping
+// is dropped → the op AFTER that falls back to the OPERATOR'S ACTIVE TAB.
 //
-// This test drives the whole op through execute(), not OPS.open, because the
-// race that defines "given up" lives in execute() and nowhere else. The reap is
-// asserted absent BOTH at return and after the slow create settles — checking
-// only the former would pass with the guard deleted, since the harm is
-// exclusively in the tail.
-test("open: a reap must NOT fire once execute() has already abandoned the op",
+// This is now impossible BY CONSTRUCTION rather than by a guard: the extension
+// never closes, and the server acts only on a delivered result. This test pins
+// that construction — put a `chrome.tabs.remove` back into `open` and it goes red.
+// It is driven through execute(), not OPS.open, because the race that defines
+// "given up" lives there and nowhere else.
+test("open: the extension closes NO tab even when execute() has abandoned the op",
      { timeout: 4000 }, async (t) => {
   resetCalls();
   const realGet = chrome.tabs.get;
@@ -727,113 +693,65 @@ test("open: a reap must NOT fire once execute() has already abandoned the op",
     chrome.tabs.create = realCreate;
     globalThis.BROWSER_BRIDGE_LOOP_TIMING = realTiming;
   });
-  // reuse probe 20ms (fall through), WHOLE OP 80ms, create settles at 300ms —
-  // so the create outlives the op by ~220ms. The three values are pairwise
-  // distinct and none is a multiple of another, so a mutant that swaps one
-  // budget for another cannot land on an equivalent schedule.
+  // reuse probe 90ms (falls through), WHOLE OP 310ms, create settling at 260ms.
+  // 🔴 THESE NUMBERS ARE CHOSEN SO THE CREATE ALONE FITS INSIDE execMs (260 <
+  // 310) WHILE THE WHOLE OP DOES NOT (~350 > 310). A fixture where the create by
+  // itself already exceeds execMs cannot tell "elapsed since op start" from
+  // "elapsed since create start", so it would pass against an implementation
+  // that re-anchored its clock — measured: that mutant survived the earlier
+  // 20/80/300 fixture. Keep the create INSIDE the budget and the op OUTSIDE it.
   globalThis.BROWSER_BRIDGE_LOOP_TIMING = {
-    ...(realTiming || {}), reuseTabMs: 20, execMs: 80 };
+    ...(realTiming || {}), reuseTabMs: 90, execMs: 310 };
   chrome.tabs.get = () => new Promise(() => {});          // force the timeout arm
+  let createSettled = false;
   chrome.tabs.create = async (props) => {
     state.calls.tabsCreate.push(props);
-    await new Promise((r) => setTimeout(r, 300));
+    await new Promise((r) => setTimeout(r, 260));
+    createSettled = true;
     return { id: FRESH_TAB_ID, url: (props && props.url) || "about:blank" };
   };
 
   const env = await execute({ op: "open", id: "late", reuseTabId: TAB_ID,
                               url: "https://civitai.com/" });
-  assert.equal(env.ok, false, "the op must still time out (control: the slow "
-                              + "create really did outlive execute's budget)");
+  assert.equal(env.ok, false, "control: the slow create really did outlive "
+                              + "execute's budget, so this IS the abandoned case");
   assert.equal(env.error, "op_timeout:open");
-  assert.deepEqual(state.calls.tabsRemove, [],
-                   "nothing may be reaped before the create settles");
+  assert.deepEqual(state.calls.tabsRemove, []);
 
   // Let the abandoned create resume and run `open`'s tail.
-  await new Promise((r) => setTimeout(r, 600));
-  assert.equal(state.calls.tabsCreate.length, 1,
-               "control: the create really did run and settle");
+  await new Promise((r) => setTimeout(r, 400));
+  assert.equal(createSettled, true,
+               "control: the create really did SETTLE (not merely start — the "
+               + "push above happens before its await, so tabsCreate.length "
+               + "cannot witness settlement)");
   assert.deepEqual(state.calls.tabsRemove, [],
-                   "a reap arriving after execute() gave up destroys a tab the "
-                   + "SERVER STILL OWNS and that is still live — the session is "
-                   + "left owning a dead id, and two ops later it falls back to "
-                   + "the operator's active tab");
+                   "🔴 nothing may close a tab from inside `open`. On this path "
+                   + "the SERVER STILL OWNS the old tab and it is still live; a "
+                   + "close here leaves the session on a dead id and, two ops "
+                   + "later, on the operator's active tab");
 });
 
-// 🔴 THE REAP IS FIRE-AND-FORGET, AND THAT IS LOAD-BEARING RATHER THAN TIDY.
-// `chrome.tabs.remove` is one more unbounded browser-process IPC. Awaiting it
-// would put a NEW unbounded await on `open`'s SUCCESS path — regenerating, at the
-// last line of the op, the exact defect class #797/#814 exist to remove. So the
-// property under test is not "the reap works" but "the reap cannot hurt": a
-// remove that HANGS FOREVER, one that REJECTS, and one that throws SYNCHRONOUSLY
-// must each leave `open`'s result and latency untouched.
-//
-// The hang arm needs the race + `{ timeout }` for the reason stated above the
-// probe tests: node scores a timed-out test `cancelled`, leaving `fail` at 0, so a
-// regression here would read as clean to a gate that greps the fail count.
-test("open reuse probe: a HANGING / REJECTING / THROWING reap cannot delay or fail open",
-     { timeout: 2000 }, async (t) => {
+// The op DOES still report the orphan on that abandoned path — harmlessly, since
+// the envelope is dropped. Asserted so nobody "tidies" the report into the same
+// abandonment check the close used to need: the report is inert without a
+// delivered result, which is exactly why it is safe to make unconditionally.
+test("open: the orphan is still REPORTED on the abandoned path (inert, not guarded)",
+     { timeout: 4000 }, async (t) => {
+  resetCalls();
   const realGet = chrome.tabs.get;
-  const realRemove = chrome.tabs.remove;
   const realTiming = globalThis.BROWSER_BRIDGE_LOOP_TIMING;
   t.after(() => {
     chrome.tabs.get = realGet;
-    chrome.tabs.remove = realRemove;
     globalThis.BROWSER_BRIDGE_LOOP_TIMING = realTiming;
   });
   globalThis.BROWSER_BRIDGE_LOOP_TIMING = { ...(realTiming || {}), reuseTabMs: 20 };
-  chrome.tabs.get = () => new Promise(() => {});   // force the timeout arm
-
-  const openOrDie = (why) =>
-    openWithin(OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" }), why);
-
-  // (a) HANG. The one that would catch an `await` being added to the reap.
-  // Recorded through `state.calls.tabsRemove`, not a local counter: a counter
-  // cannot see a reap issued against the WRONG id, and this arm would then be
-  // the one place in the file blind to it.
-  resetCalls();
-  chrome.tabs.remove = (id) => {
-    state.calls.tabsRemove.push(id);
-    return new Promise(() => {});                 // never settles
-  };
-  let out = await openOrDie(
-    "open did not settle within 1s: the reap is being AWAITED, so a hung "
-    + "chrome.tabs.remove now wedges the op it was added to clean up after");
-  assert.equal(out.tabId, FRESH_TAB_ID, "a hung reap must not change the result");
-  assert.deepEqual(state.calls.tabsRemove, [TAB_ID],
-                   "…and the reap must still have been ATTEMPTED, against the "
-                   + "ORPHAN's id and not the replacement's");
-
-  // (b) REJECT — the ordinary case when the orphan really had gone after all.
-  resetCalls();
-  chrome.tabs.remove = async (id) => {
-    state.calls.tabsRemove.push(id);
-    throw new Error("No tab with id: 5.");
-  };
-  out = await openOrDie("open did not settle within 1s on a REJECTING reap");
-  assert.equal(out.tabId, FRESH_TAB_ID, "a rejected reap must not fail the op");
-  assert.deepEqual(state.calls.tabsRemove, [TAB_ID]);
-
-  // (c) SYNCHRONOUS throw — an older/stubbed chrome.* surface. This is the arm
-  // that makes the `try` around the reap non-vacuous; without it, deleting that
-  // try/catch passes the whole suite.
-  resetCalls();
-  chrome.tabs.remove = (id) => {
-    state.calls.tabsRemove.push(id);
-    throw new Error("chrome.tabs.remove is not a function");
-  };
-  out = await openOrDie("open did not settle within 1s on a SYNC-THROWING reap");
-  assert.equal(out.tabId, FRESH_TAB_ID, "a synchronously throwing reap must not fail the op");
-  assert.deepEqual(state.calls.tabsRemove, [TAB_ID]);
-  // 🔴 …and the trace must NOT claim an attempt that never left the building.
-  // `reapAttempted` is assigned AFTER the call precisely so a synchronous throw
-  // skips it; moving that line one statement earlier is invisible to every other
-  // assertion in this file.
-  assert.equal("reapAttempted" in out, false,
-               "a reap that threw before dispatching must leave no trace saying "
-               + "it was attempted — the field is the only record anyone gets");
+  chrome.tabs.get = () => new Promise(() => {});
+  const out = await openWithin(
+    OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" }),
+    "open did not settle within 1s");
+  assert.equal(out.orphanTabId, TAB_ID);
+  assert.deepEqual(state.calls.tabsRemove, []);
 });
-
-// --------------------------------------------------------------------------- //
 // `activate` op: foreground the tab (tabs.update{active} + windows.update{focused})
 // then bounded wait-for-load. Wiring only — the wait LOGIC is unit-tested in
 // protocol.test.mjs. No CDP/debugger, no executeScript, no new permission.

--- a/scripts/browser-bridge/tests/service_worker.test.mjs
+++ b/scripts/browser-bridge/tests/service_worker.test.mjs
@@ -98,7 +98,8 @@ globalThis.chrome = {
   alarms: { create() {}, onAlarm: { addListener() {} } },
 };
 
-const { OPS, loopTiming } = await import("../extension/service_worker.js");
+const { OPS, loopTiming, execute, emulationState, documentEmulation } =
+  await import("../extension/service_worker.js");
 const { FAST_CAPTURE_BUDGET_MS, EXEC_OP_BUDGET_MS, POLL_BUDGET_MS,
         RESULT_BUDGET_MS, LOOP_STALL_MS, STORAGE_BUDGET_MS, REUSE_TAB_BUDGET_MS }
   = await import("../extension/protocol.js");
@@ -602,6 +603,15 @@ test("open reuse probe: a TIMED-OUT probe reaps the tab it just orphaned",
   globalThis.BROWSER_BRIDGE_LOOP_TIMING = { ...(realTiming || {}), reuseTabMs: 20 };
   chrome.tabs.get = () => new Promise(() => {});   // never settles
 
+  // SEED both per-tab maps, or the `has(...) === false` assertions below are
+  // vacuous — they would hold just as well on a build that never forgets
+  // anything. t.after clears them so a leak here cannot colour a later test.
+  emulationState.set(TAB_ID, { preset: "iphone-15" });
+  documentEmulation.set(TAB_ID, { at: 1 });
+  t.after(() => { emulationState.delete(TAB_ID); documentEmulation.delete(TAB_ID); });
+  assert.equal(emulationState.has(TAB_ID), true, "control: the seed took");
+  assert.equal(documentEmulation.has(TAB_ID), true, "control: the seed took");
+
   const out = await openWithin(
     OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" }),
     "open did not settle within 1s");
@@ -612,6 +622,19 @@ test("open reuse probe: a TIMED-OUT probe reaps the tab it just orphaned",
                    "the orphaned tab must be reclaimed — server.py's "
                    + "\"Nothing reclaims it; only a human closes it\" is what this "
                    + "assertion deletes");
+  assert.equal(out.reapAttempted, TAB_ID,
+               "the envelope must carry the trace: this remove is issued WITHOUT "
+               + "the caller asking for it, so `open` is the only place it can be "
+               + "recorded (nothing awaits the result, hence ATTEMPTED)");
+
+  // 🔴 PARITY WITH `close`, WHICH DOES THIS FIRST AND SAYS WHY: onRemoved's
+  // timing is not ours to control and it does not fire at all on the
+  // already-gone path, so a stale entry is inheritable by a RECYCLED tabId.
+  // Without this the claim "the same thing `close` does" is not literally true.
+  assert.equal(emulationState.has(TAB_ID), false,
+               "the reap must forget the tab's emulation state, as `close` does");
+  assert.equal(documentEmulation.has(TAB_ID), false,
+               "…and its document record, for the same recycled-tabId reason");
 
   // 🔴 ORDERING, WHICH THE ASSERTION ABOVE CANNOT SEE: the reap must run only
   // AFTER the replacement exists. Reaping first would close the session's ONLY
@@ -651,6 +674,13 @@ test("open reuse probe: a REJECTING probe must NOT reap — the id is known abse
                    + "reclaim, and a recycled tabId would be someone else's tab");
 });
 
+// ⚠ ONE KNOWN EQUIVALENT MUTANT, recorded so nobody re-derives it as a coverage
+// gap: changing `orphanTabId != null` to a truthiness test SURVIVES this file.
+// It is equivalent, not uncovered — Chromium never issues tab id 0
+// (chrome.tabs.TAB_ID_NONE is -1 and real ids start at 1), so the two predicates
+// cannot disagree on any value this code can hold. `!= null` is kept anyway
+// because it says what is meant.
+//
 // The other two paths that reach `chrome.tabs.create`, both of which must stay
 // reap-free. Together with the two arms above these enumerate every route through
 // `open`, so "the reap fires on exactly one of them" is a closed claim rather than
@@ -667,6 +697,66 @@ test("open: neither a healthy reuse nor a first open ever reaps", async () => {
   assert.equal(state.calls.tabsCreate.length, 1);
   assert.deepEqual(state.calls.tabsRemove, [],
                    "a session's FIRST open has no predecessor to reclaim");
+});
+
+// 🔴 A REAP THAT ARRIVES AFTER execute() HAS GIVEN UP IS WORSE THAN NO REAP.
+//
+// execute() RACES the op against execMs; it does not CANCEL it. So a
+// `chrome.tabs.create` that is merely SLOW — not hung — resumes `open` long after
+// the op has already answered `op_timeout:open`. And on that path the old tab is
+// NOT an orphan: the server saw a non-tab-gone error, so it KEPT the session's
+// ownership pointing at a tab that is still live and still usable. Pre-change the
+// next `open` simply reused it. A late reap destroys it, leaving the session
+// owning a dead id → `owned_tab_gone` → the mapping is dropped → the op after
+// that falls back to the OPERATOR'S ACTIVE TAB, which is the blast radius the
+// ownership map exists to prevent.
+//
+// This test drives the whole op through execute(), not OPS.open, because the
+// race that defines "given up" lives in execute() and nowhere else. The reap is
+// asserted absent BOTH at return and after the slow create settles — checking
+// only the former would pass with the guard deleted, since the harm is
+// exclusively in the tail.
+test("open: a reap must NOT fire once execute() has already abandoned the op",
+     { timeout: 4000 }, async (t) => {
+  resetCalls();
+  const realGet = chrome.tabs.get;
+  const realCreate = chrome.tabs.create;
+  const realTiming = globalThis.BROWSER_BRIDGE_LOOP_TIMING;
+  t.after(() => {
+    chrome.tabs.get = realGet;
+    chrome.tabs.create = realCreate;
+    globalThis.BROWSER_BRIDGE_LOOP_TIMING = realTiming;
+  });
+  // reuse probe 20ms (fall through), WHOLE OP 80ms, create settles at 300ms —
+  // so the create outlives the op by ~220ms. The three values are pairwise
+  // distinct and none is a multiple of another, so a mutant that swaps one
+  // budget for another cannot land on an equivalent schedule.
+  globalThis.BROWSER_BRIDGE_LOOP_TIMING = {
+    ...(realTiming || {}), reuseTabMs: 20, execMs: 80 };
+  chrome.tabs.get = () => new Promise(() => {});          // force the timeout arm
+  chrome.tabs.create = async (props) => {
+    state.calls.tabsCreate.push(props);
+    await new Promise((r) => setTimeout(r, 300));
+    return { id: FRESH_TAB_ID, url: (props && props.url) || "about:blank" };
+  };
+
+  const env = await execute({ op: "open", id: "late", reuseTabId: TAB_ID,
+                              url: "https://civitai.com/" });
+  assert.equal(env.ok, false, "the op must still time out (control: the slow "
+                              + "create really did outlive execute's budget)");
+  assert.equal(env.error, "op_timeout:open");
+  assert.deepEqual(state.calls.tabsRemove, [],
+                   "nothing may be reaped before the create settles");
+
+  // Let the abandoned create resume and run `open`'s tail.
+  await new Promise((r) => setTimeout(r, 600));
+  assert.equal(state.calls.tabsCreate.length, 1,
+               "control: the create really did run and settle");
+  assert.deepEqual(state.calls.tabsRemove, [],
+                   "a reap arriving after execute() gave up destroys a tab the "
+                   + "SERVER STILL OWNS and that is still live — the session is "
+                   + "left owning a dead id, and two ops later it falls back to "
+                   + "the operator's active tab");
 });
 
 // 🔴 THE REAP IS FIRE-AND-FORGET, AND THAT IS LOAD-BEARING RATHER THAN TIDY.
@@ -697,14 +787,21 @@ test("open reuse probe: a HANGING / REJECTING / THROWING reap cannot delay or fa
     openWithin(OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" }), why);
 
   // (a) HANG. The one that would catch an `await` being added to the reap.
+  // Recorded through `state.calls.tabsRemove`, not a local counter: a counter
+  // cannot see a reap issued against the WRONG id, and this arm would then be
+  // the one place in the file blind to it.
   resetCalls();
-  let removeCalls = 0;
-  chrome.tabs.remove = () => { removeCalls += 1; return new Promise(() => {}); };
+  chrome.tabs.remove = (id) => {
+    state.calls.tabsRemove.push(id);
+    return new Promise(() => {});                 // never settles
+  };
   let out = await openOrDie(
     "open did not settle within 1s: the reap is being AWAITED, so a hung "
     + "chrome.tabs.remove now wedges the op it was added to clean up after");
   assert.equal(out.tabId, FRESH_TAB_ID, "a hung reap must not change the result");
-  assert.equal(removeCalls, 1, "…and the reap must still have been ATTEMPTED");
+  assert.deepEqual(state.calls.tabsRemove, [TAB_ID],
+                   "…and the reap must still have been ATTEMPTED, against the "
+                   + "ORPHAN's id and not the replacement's");
 
   // (b) REJECT — the ordinary case when the orphan really had gone after all.
   resetCalls();
@@ -727,6 +824,13 @@ test("open reuse probe: a HANGING / REJECTING / THROWING reap cannot delay or fa
   out = await openOrDie("open did not settle within 1s on a SYNC-THROWING reap");
   assert.equal(out.tabId, FRESH_TAB_ID, "a synchronously throwing reap must not fail the op");
   assert.deepEqual(state.calls.tabsRemove, [TAB_ID]);
+  // 🔴 …and the trace must NOT claim an attempt that never left the building.
+  // `reapAttempted` is assigned AFTER the call precisely so a synchronous throw
+  // skips it; moving that line one statement earlier is invisible to every other
+  // assertion in this file.
+  assert.equal("reapAttempted" in out, false,
+               "a reap that threw before dispatching must leave no trace saying "
+               + "it was attempted — the field is the only record anyone gets");
 });
 
 // --------------------------------------------------------------------------- //

--- a/scripts/browser-bridge/tests/service_worker.test.mjs
+++ b/scripts/browser-bridge/tests/service_worker.test.mjs
@@ -647,9 +647,16 @@ test("open reuse probe: a REJECTING probe reports NO orphan — the id is known 
   assert.deepEqual(state.calls.tabsRemove, []);
 });
 
-// The other two paths that reach `chrome.tabs.create`. Together with the two arms
-// above these enumerate every route through `open`, so "exactly one of them
-// reports an orphan" is a closed claim rather than a sampled one.
+// The other two routes through `open`. Together with the two arms above, these
+// four enumerate every route — reuse-hit, reuse-reject, reuse-timeout, and no
+// `reuseTabId` at all — so "exactly one of them reports an orphan" is a CLOSED
+// claim rather than a sampled one.
+//
+// ⚠ An earlier wording called these "the other two paths that reach
+// `chrome.tabs.create`". Only ONE of them does: a healthy reuse RETURNS before
+// the create (which is what `reused.reused === true` below asserts). The
+// load-bearing claim — that the four cases are exhaustive — was right; the
+// description of them was not.
 test("open: neither a healthy reuse nor a first open reports an orphan", async () => {
   resetCalls();
   const reused = await OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" });

--- a/scripts/browser-bridge/tests/service_worker.test.mjs
+++ b/scripts/browser-bridge/tests/service_worker.test.mjs
@@ -731,26 +731,61 @@ test("open: the extension closes NO tab even when execute() has abandoned the op
                    + "later, on the operator's active tab");
 });
 
-// The op DOES still report the orphan on that abandoned path — harmlessly, since
-// the envelope is dropped. Asserted so nobody "tidies" the report into the same
-// abandonment check the close used to need: the report is inert without a
-// delivered result, which is exactly why it is safe to make unconditionally.
-test("open: the orphan is still REPORTED on the abandoned path (inert, not guarded)",
+// The op DOES still report the orphan on a GENUINELY ABANDONED op — harmlessly,
+// since the envelope is dropped. Asserted so nobody "tidies" the report behind
+// the same abandonment check the close used to need: the report is inert without
+// a delivered result, which is exactly why it is safe to emit unconditionally.
+//
+// 🔴 THIS TEST WAS VACUOUS IN ITS FIRST FORM AND AN AUDIT MEASURED IT. It called
+// `OPS.open()` directly, with the default `execMs` and no `execute()` wrapper, so
+// the op finished in ~20ms and NOTHING was abandoned — a duplicate of the
+// timeout-arm test above, under a name claiming coverage it did not have. The
+// mutant its own comment names (re-guard the emit with
+// `(Date.now() - startedAt) < loopTiming().execMs`) SURVIVED the whole file. It
+// must therefore observe the report on the far side of a real abandonment, which
+// means reading `open`'s return value AFTER execute() has already given up on it.
+test("open: the orphan is still REPORTED on a genuinely ABANDONED op (inert, not guarded)",
      { timeout: 4000 }, async (t) => {
   resetCalls();
   const realGet = chrome.tabs.get;
+  const realCreate = chrome.tabs.create;
   const realTiming = globalThis.BROWSER_BRIDGE_LOOP_TIMING;
   t.after(() => {
     chrome.tabs.get = realGet;
+    chrome.tabs.create = realCreate;
     globalThis.BROWSER_BRIDGE_LOOP_TIMING = realTiming;
   });
-  globalThis.BROWSER_BRIDGE_LOOP_TIMING = { ...(realTiming || {}), reuseTabMs: 20 };
+  // Same 90/310/260 shape as the test above — create INSIDE execMs, whole op
+  // OUTSIDE it — so a re-anchored clock cannot pass by accident.
+  globalThis.BROWSER_BRIDGE_LOOP_TIMING = {
+    ...(realTiming || {}), reuseTabMs: 90, execMs: 310 };
   chrome.tabs.get = () => new Promise(() => {});
-  const out = await openWithin(
-    OPS.open({ reuseTabId: TAB_ID, url: "https://civitai.com/" }),
-    "open did not settle within 1s");
-  assert.equal(out.orphanTabId, TAB_ID);
-  assert.deepEqual(state.calls.tabsRemove, []);
+  // Hold onto the op's OWN promise so its resolved value is readable after
+  // execute() has abandoned it. execute() races the op; it does not cancel it, so
+  // this promise still settles — with whatever `open` decided to report.
+  let opPromise = null;
+  chrome.tabs.create = async (props) => {
+    state.calls.tabsCreate.push(props);
+    await new Promise((r) => setTimeout(r, 260));
+    return { id: FRESH_TAB_ID, url: (props && props.url) || "about:blank" };
+  };
+  const realOpen = OPS.open;
+  t.after(() => { OPS.open = realOpen; });
+  OPS.open = (cmd) => { opPromise = realOpen.call(OPS, cmd); return opPromise; };
+
+  const env = await execute({ op: "open", id: "inert", reuseTabId: TAB_ID,
+                             url: "https://civitai.com/" });
+  assert.equal(env.error, "op_timeout:open",
+               "control: this really IS the abandoned case");
+
+  const out = await opPromise;   // resolves ~260ms after execute() gave up
+  assert.equal(out.orphanTabId, TAB_ID,
+               "the report must be emitted UNCONDITIONALLY — putting it behind an "
+               + "abandonment check buys nothing (a dropped envelope is already "
+               + "inert) and would re-introduce a clock this file no longer needs");
+  assert.equal(out.tabId, FRESH_TAB_ID);
+  assert.deepEqual(state.calls.tabsRemove, [],
+                   "and still nothing is closed from inside `open`");
 });
 // `activate` op: foreground the tab (tabs.update{active} + windows.update{focused})
 // then bounded wait-for-load. Wiring only — the wait LOGIC is unit-tested in

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -617,6 +617,14 @@ class FakeExtension(threading.Thread):
                 envelope = {"id": cmd["id"], "ok": False,
                             "error": data["__error__"],
                             "instanceId": self.instance_id}
+                # A real extension can attach a payload to a FAILURE envelope, and
+                # a test needs to model that to prove the server ignores it: any
+                # OTHER key alongside `__error__` becomes `data`. Without this the
+                # "a failed op must not act on data" mutants are unreachable —
+                # `data` is simply absent, so they pass for the wrong reason.
+                extra = {k: v for k, v in data.items() if k != "__error__"}
+                if extra:
+                    envelope["data"] = extra
             else:
                 envelope = {"id": cmd["id"], "ok": True, "data": data,
                             "instanceId": self.instance_id}
@@ -9497,3 +9505,273 @@ def test_net_outranks_is_strict_at_the_boundary():
     assert _net_outranks(181, 180)
     assert not _net_outranks(180, 180), "a tie must not count as outranking"
     assert not _net_outranks(179, 180)
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE ORPHAN REAP IS THE SERVER'S JOB, AND "WE GOT HERE" IS THE WHOLE REASON.
+#
+# When the extension's reuse probe exceeds REUSE_TAB_BUDGET_MS it falls through to
+# a FRESH tab and REPORTS the tabId it thereby orphaned (`orphanTabId`). It does
+# not close it. `_record_ownership_locked` does — and it can, because it runs ONLY
+# on a delivered result.
+#
+# Why that structural fact is load-bearing rather than incidental: reclaiming is
+# correct only if the result IS delivered. If it is not, the old tab is not an
+# orphan at all — the ownership record still names it, it is still live — and
+# closing it strands the session on a dead id, then (one op later) on the
+# OPERATOR'S ACTIVE tab. Two parties abandon an op on two different clocks and
+# NEITHER is visible from inside the extension: execute()'s EXEC_OP_BUDGET_MS race
+# (which cannot cancel the op, so a merely SLOW `chrome.tabs.create` resumes it
+# afterwards) and this server's own `cmd_timeout` (which starts at SUBMIT, so
+# queue time is invisible to any extension-side elapsed check). An extension-side
+# guard closed the first and structurally could not close the second.
+#
+# So the tests below come in pairs: the reclaim HAPPENS on a delivered result, and
+# it DOES NOT on an abandoned one. The negative is the one that pins the design.
+# --------------------------------------------------------------------------- #
+def _orphan_exec(new_ids, live, orphan_of=None, delay=0.0):
+    """Model the SW `open` FALL-THROUGH: always create a fresh tab, and report
+    `orphanTabId` for it when `orphan_of` says to. `close` removes from `live`.
+
+    `delay` sleeps before answering an `open`, so a test can drive the submitter
+    past its own cmd_timeout while the command still completes here — the exact
+    abandonment shape an extension-side elapsed check cannot see.
+    """
+    it = iter(new_ids)
+
+    def _exec(cmd):
+        if cmd["op"] == "open":
+            if delay:
+                time.sleep(delay)
+            tid = next(it)
+            live.add(tid)
+            out = {"tabId": tid, "url": cmd.get("url")}
+            if orphan_of is not None:
+                out["orphanTabId"] = orphan_of(tid, cmd)
+            return out
+        if cmd["op"] == "close":
+            live.discard(cmd.get("tabId"))
+            return {"closed": cmd.get("tabId")}
+        return {"tabId": cmd.get("tabId"), "op": cmd["op"]}
+    return _exec
+
+
+def _wait_closed(ext, tab_id, timeout=3.0):
+    """The reap `close` is enqueued with NO waiter, so nothing in the request path
+    blocks on it — poll the fake's dispatch log instead of sleeping a guess."""
+    end = time.monotonic() + timeout
+    while time.monotonic() < end:
+        if any(c["op"] == "close" and c.get("tabId") == tab_id
+               for c in ext.dispatched):
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def test_reported_orphan_is_reaped_by_the_server():
+    """A DELIVERED `open` result carrying `orphanTabId` makes the server enqueue a
+    `close` for that tab — the leak `reuse_tab_id`'s comment used to describe as
+    "Nothing reclaims it; only a human closes it"."""
+    srv, reg = _serve()
+    live = {101}
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_orphan_exec([202], live,
+                                              orphan_of=lambda tid, cmd: 101))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _cmd(srv, {"op": "open"}, session="A")
+        assert st == 200
+        assert body["result"]["data"]["tabId"] == 202
+        # Ownership moves to the FRESH tab (this is what orphans 101).
+        assert reg.owners_snapshot() == {("only", "A"): 202}
+        assert _wait_closed(ext, 101), "the reported orphan was never reaped"
+        assert live == {202}, "the orphaned tab is still open"
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_an_abandoned_open_never_reaps_the_orphan():
+    """🔴 THE NEGATIVE THAT PINS THE DESIGN. The submitter gives up at
+    `cmd_timeout` (0.3s here) while the extension answers late (0.8s). The result
+    therefore lands with no waiter, `_record_ownership_locked` is never reached,
+    and the ownership record STILL NAMES 101 — a tab that is live and usable. A
+    reap here would strand the session on a dead id.
+
+    This is the case an extension-side elapsed check could not see: the
+    extension's own budget is untouched, and the clock that expired is this
+    server's, started at SUBMIT.
+    """
+    srv, reg = _serve(cmd_timeout=0.3)
+    live = {101}
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_orphan_exec([202], live, delay=0.8,
+                                              orphan_of=lambda tid, cmd: 101))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _cmd(srv, {"op": "open"}, session="A")
+        assert st == 504, f"expected the submitter to give up, got {st} {body}"
+        # The extension DID complete the open — the control that makes the
+        # assertion below about ABANDONMENT rather than about nothing happening.
+        end = time.monotonic() + 3.0
+        while time.monotonic() < end and 202 not in live:
+            time.sleep(0.01)
+        assert 202 in live, "control: the extension never actually ran the open"
+        # Now the real assertion: no reap, ever.
+        assert not _wait_closed(ext, 101, timeout=0.6), (
+            "an abandoned open must NOT reap: nothing recorded the fresh tab as "
+            "owned, so 101 is still this session's OWNED, LIVE tab")
+        assert live == {101, 202}
+        assert reg.owners_snapshot() == {}, (
+            "an abandoned open records no ownership at all — which is exactly why "
+            "the old tab must not be treated as an orphan")
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_a_failed_open_never_reaps_the_orphan():
+    """`ok:false` returns before the `open` branch, so a failing open that somehow
+    carried an orphan report reclaims nothing."""
+    srv, reg = _serve()
+    live = {101}
+
+    def _boom(cmd):
+        if cmd["op"] == "open":
+            # The harness's documented way to model an op-level failure — an
+            # ok:false envelope from the extension, NOT a crashed fake.
+            # 🔴 IT CARRIES AN ORPHAN REPORT ON PURPOSE. Without a payload this
+            # test cannot discriminate: a mutant that moves the reap above the
+            # `if failed: return` finds no `data` and passes for the wrong
+            # reason. Measured — that mutant SURVIVED the first draft.
+            return {"__error__": "open_exploded", "orphanTabId": 101}
+        if cmd["op"] == "close":
+            live.discard(cmd.get("tabId"))
+            return {"closed": cmd.get("tabId")}
+        return {}
+    ext = FakeExtension(srv, instance_id="solo", label="only", executor=_boom)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _cmd(srv, {"op": "open"}, session="A")
+        assert body["result"]["ok"] is False
+        assert body["result"]["data"]["orphanTabId"] == 101, (
+            "control: the failure envelope really did carry the report the server "
+            "must ignore")
+        assert not _wait_closed(ext, 101, timeout=0.4)
+        assert [c for c in ext.dispatched if c["op"] == "close"] == []
+        assert live == {101}
+        assert reg.owners_snapshot() == {}, (
+            "a failed open records no ownership — so nothing was orphaned")
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+@pytest.mark.parametrize("reported", [
+    pytest.param(lambda tid, cmd: tid, id="equal-to-the-new-tab"),
+    pytest.param(lambda tid, cmd: True, id="a-bool-not-an-int"),
+    pytest.param(lambda tid, cmd: "101", id="a-string"),
+    pytest.param(lambda tid, cmd: None, id="null"),
+    pytest.param(lambda tid, cmd: 101.0, id="a-float"),
+])
+def test_a_malformed_or_self_referential_orphan_report_is_refused(reported):
+    """A report is DATA, never an instruction.
+
+    `== tid` is the one that matters most: closing the tab just recorded as owned
+    would destroy the session's ONLY tab. The bool case is not pedantry — Python
+    makes `isinstance(True, int)` true and `True == 1`, so a hand-crafted envelope
+    could otherwise reap tab 1.
+    """
+    srv, reg = _serve()
+    live = {101}
+    ext = FakeExtension(srv, instance_id="solo", label="only",
+                        executor=_orphan_exec([202], live, orphan_of=reported))
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        st, body = _cmd(srv, {"op": "open"}, session="A")
+        assert st == 200
+        assert body["result"]["data"]["tabId"] == 202
+        # 🔴 ASSERT NO `close` OF **ANY** TAB, AND SNAPSHOT AFTER THE WAIT.
+        # The first draft did neither and the bool mutant SURVIVED because of it:
+        # it enqueues `close` for tabId `True`, so waiting on a specific id never
+        # sees it — and the dispatch list was snapshotted before the extension had
+        # even polled, so it was empty either way. Two independent reasons the
+        # test could not fail. Wait for a plausible round trip, then look at the
+        # WHOLE list.
+        assert not _wait_closed(ext, 202, timeout=0.4)
+        closes = [c for c in ext.dispatched if c["op"] == "close"]
+        assert closes == [], f"a refused report still enqueued {closes}"
+        assert live == {101, 202}
+    finally:
+        ext.stop(); srv.shutdown(); srv.server_close()
+
+
+def test_the_reap_close_is_inflight_while_it_runs_then_fully_released():
+    """The reap takes an `inflight` entry and NO waiter, and both halves matter.
+
+    `inflight` is what `_effective_timeout_locked` reads to tell a BUSY extension
+    from an idle one, so WITHOUT the entry a `ping` landing mid-reap fast-fails a
+    perfectly healthy extension. WITH it but without release, the instance reads
+    busy until INFLIGHT_STALE_S.
+
+    🔴 ASSERTING ONLY THE END STATE IS VACUOUS — `inflight == {}` is equally true
+    of a build that never adds the entry, and measured: that mutant SURVIVED the
+    first draft of this test. So the entry must be caught WHILE the reap is in
+    flight, which is what the slow `close` below buys.
+    """
+    srv, reg = _serve()
+    live = {101}
+    gate = threading.Event()
+
+    def _exec(cmd):
+        if cmd["op"] == "open":
+            live.add(202)
+            return {"tabId": 202, "url": cmd.get("url"), "orphanTabId": 101}
+        if cmd["op"] == "close":
+            # Hold the reap OPEN so its inflight entry is observable. Released by
+            # the test once it has seen the entry.
+            gate.wait(3.0)
+            live.discard(cmd.get("tabId"))
+            return {"closed": cmd.get("tabId")}
+        return {"tabId": cmd.get("tabId"), "op": cmd["op"]}
+
+    ext = FakeExtension(srv, instance_id="solo", label="only", executor=_exec)
+    ext.start()
+    try:
+        assert _wait_connected(srv, want=True)
+        _cmd(srv, {"op": "open"}, session="A")
+        assert _wait_closed(ext, 101), "the reap was never dispatched"
+        inst = list(reg._instances.values())[0]
+
+        # (1) IN FLIGHT: exactly one entry, and NO waiter for it.
+        end = time.monotonic() + 3.0
+        seen = None
+        while time.monotonic() < end:
+            snap = dict(inst.inflight)
+            if snap:
+                seen = snap
+                break
+            time.sleep(0.005)
+        assert seen, ("the reap took no `inflight` entry — a ping landing here "
+                      "would fast-fail a healthy extension")
+        assert len(seen) == 1, f"expected exactly the reap in flight, got {seen}"
+        cid = next(iter(seen))
+        assert cid not in inst.waiters, (
+            "the reap must take NO waiter — nobody will ever pop its result")
+        assert inst.pending == 0, "the reap must not consume a concurrency slot"
+
+        # (2) RELEASED by its own reply, not by INFLIGHT_STALE_S.
+        gate.set()
+        end = time.monotonic() + 3.0
+        while time.monotonic() < end and inst.inflight:
+            time.sleep(0.01)
+        assert inst.inflight == {}, (
+            "the reap's inflight entry must be released by its reply")
+        assert inst.waiters == set()
+        assert live == {202}
+        # And the extension is usable immediately afterwards.
+        st, body = _cmd(srv, {"op": "text"}, session="A")
+        assert st == 200 and body["result"]["ok"] is True
+    finally:
+        gate.set(); ext.stop(); srv.shutdown(); srv.server_close()

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -10050,11 +10050,18 @@ def test_cancelling_does_not_disturb_a_reap_ALREADY_IN_FLIGHT():
 
 
 def test_a_reap_whose_reply_is_lost_does_not_strand_its_bookkeeping():
-    """A `reaps` entry is only meaningful while its `inflight` entry lives.
+    """A DISPATCHED reap whose reply never arrives must not strand its entry.
 
-    The one path that leaves it behind is a reap whose reply never arrives — the
-    residual this feature already discloses. `instance_id` is stable across a
-    browser restart, so the same `Instance` would carry it forever.
+    That is the residual this feature discloses, and `instance_id` is stable
+    across a browser restart, so the same `Instance` would carry it forever.
+
+    ⚠ SCOPE, STATED BECAUSE READING THIS AS COVERAGE OF THE SWEEP IS WHAT
+    STOPPED ANYONE LOOKING AT THE OTHER ARM: this test dispatches before
+    advancing the clock, so `outbox` is empty and it exercises the DISPATCHED
+    case only. The sweep also sees QUEUED reaps, and an earlier predicate got
+    that arm wrong — pinned separately by
+    `test_a_prune_must_not_starve_a_reap_STILL_IN_THE_OUTBOX` and
+    `test_a_prune_must_not_make_a_queued_reap_UNCANCELLABLE`.
     """
     t = {"now": 1000.0}
     reg = S.Registry(clock=lambda: t["now"])
@@ -10085,3 +10092,125 @@ def test_a_reap_whose_reply_is_lost_does_not_strand_its_bookkeeping():
     assert inst.reaps == {}, (
         "the reaps entry must age out with it — otherwise a lost reply strands it "
         "on an Instance that survives a browser restart")
+
+
+def test_a_prune_must_not_starve_a_reap_STILL_IN_THE_OUTBOX():
+    """🔴 THE SWEEP MUST RESPECT BOTH LIFETIMES, NOT JUST `inflight`.
+
+    `inst.reaps[cid]` is the ONLY index from an outbox entry to its `expires_at`,
+    and it is also what `_cancel_queued_reaps_locked` matches on. A reap's
+    inflight stamp and its expiry come from the same instant, so the age-prune
+    fires at exactly the moment the reap expires — and a reap is never in
+    `waiters` (deliberately), so the prune's second condition never shields it.
+
+    An inflight-only sweep therefore deleted the metadata of a reap STILL SITTING
+    IN THE OUTBOX, removing BOTH bounds at once. This test pins both, because
+    they fail together and each alone reads as a smaller bug than it is.
+
+    Not exotic: `_prune_inflight_locked` runs on every submit and every ping, and
+    two ordinary ops ahead of the reap in the serial FIFO can exceed
+    INFLIGHT_STALE_S with no wedge at all.
+    """
+    t = {"now": 1000.0}
+    reg = S.Registry(clock=lambda: t["now"])
+    reg.poll("solo", "only", 0)
+    inst = list(reg._instances.values())[0]
+    with reg._cond:
+        reg._record_ownership_locked(
+            inst, "open", "A", None, {"ok": True, "data": {"tabId": 101}})
+        reg._record_ownership_locked(
+            inst, "open", "A", None,
+            {"ok": True, "data": {"tabId": 202, "orphanTabId": 101}})
+    assert len(inst.reaps) == 1 and len(inst.outbox) == 1, "control: queued"
+
+    # An ordinary prune — what every submit and every ping does — while the reap
+    # is STILL QUEUED and now past its window.
+    t["now"] += S.INFLIGHT_STALE_S + 1
+    with reg._cond:
+        S.Registry._prune_inflight_locked(inst, t["now"])
+    assert len(inst.reaps) == 1, (
+        "a QUEUED reap's metadata must survive the prune — it is the only index "
+        "to its expires_at and the only thing cancellation can match on")
+
+    # (a) EXPIRY still fires: the stale close is dropped, not handed over.
+    got = reg.poll("solo", "only", 0)
+    assert got is None, (
+        f"an expired reap was DISPATCHED ({got}) — after a browser restart the "
+        f"same tab id names a stranger's tab")
+    assert list(inst.outbox) == []
+    assert inst.reaps == {}, "…and dropping it does clean up after itself"
+
+
+def test_a_prune_must_not_make_a_queued_reap_UNCANCELLABLE():
+    """The other half of the same defect, asserted separately because the two
+    have different consequences: this one closes a tab the session CURRENTLY
+    OWNS, which is what `_cancel_queued_reaps_locked` exists to prevent."""
+    t = {"now": 1000.0}
+    reg = S.Registry(clock=lambda: t["now"])
+    reg.poll("solo", "only", 0)
+    inst = list(reg._instances.values())[0]
+    with reg._cond:
+        reg._record_ownership_locked(
+            inst, "open", "A", None, {"ok": True, "data": {"tabId": 101}})
+        reg._record_ownership_locked(
+            inst, "open", "A", None,
+            {"ok": True, "data": {"tabId": 202, "orphanTabId": 101}})
+
+    t["now"] += S.INFLIGHT_STALE_S + 1
+    with reg._cond:
+        S.Registry._prune_inflight_locked(inst, t["now"])
+        n = reg._cancel_queued_reaps_locked(inst, 101)
+    assert n == 1, (
+        f"a re-owned tab must still withdraw its QUEUED reap after a prune "
+        f"(got {n}) — otherwise the server closes a tab it currently owns")
+    assert list(inst.outbox) == []
+
+
+def test_cancelling_nothing_does_not_log_a_cancellation():
+    """The early return's ONLY observable, so without this it has no killing
+    mutation — measured: deleting it survived the whole reap selection.
+
+    `owner_orphan_reap_cancel` means "a queued close was withdrawn". Emitting it
+    with n=0 on every re-`open` that happens to match an already-dispatched reap
+    would make the line mean nothing, which is the same defect as the
+    `result_unknown_id` one this feature already fixed.
+    """
+    reg = S.Registry()
+    reg.poll("solo", "only", 0)
+    inst = list(reg._instances.values())[0]
+    with reg._cond:
+        reg._record_ownership_locked(
+            inst, "open", "A", None, {"ok": True, "data": {"tabId": 101}})
+        reg._record_ownership_locked(
+            inst, "open", "A", None,
+            {"ok": True, "data": {"tabId": 202, "orphanTabId": 101}})
+    reg.poll("solo", "only", 0)          # dispatch it → nothing left to withdraw
+    assert list(inst.outbox) == [] and len(inst.reaps) == 1, "control"
+
+    lines = []
+    real_log = S.log
+    try:
+        S.log = lambda ev, **kw: lines.append((ev, kw))
+        with reg._cond:
+            n = reg._cancel_queued_reaps_locked(inst, 101)
+    finally:
+        S.log = real_log
+    assert n == 0
+    assert [e for e, _ in lines if e == "owner_orphan_reap_cancel"] == [], (
+        f"nothing was withdrawn, so no cancellation may be logged; got {lines}")
+    # Positive control for the capture itself — otherwise an empty `lines` would
+    # prove only that the patch missed.
+    lines.clear()
+    with reg._cond:
+        reg._record_ownership_locked(
+            inst, "open", "A", None,
+            {"ok": True, "data": {"tabId": 303, "orphanTabId": 101}})
+    try:
+        S.log = lambda ev, **kw: lines.append((ev, kw))
+        with reg._cond:
+            n2 = reg._cancel_queued_reaps_locked(inst, 101)
+    finally:
+        S.log = real_log
+    assert n2 == 1
+    assert [e for e, _ in lines if e == "owner_orphan_reap_cancel"], (
+        "control: a REAL withdrawal must log, or the assertion above is vacuous")

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -9935,3 +9935,153 @@ def test_a_reap_reply_is_recognised_not_logged_as_an_unknown_id():
     # A genuinely unknown id still reads as unknown — the control that proves the
     # branch above did not simply make deliver_result answer True to everything.
     assert reg.deliver_result("deadbeefdeadbeef", {"ok": True}) is False
+
+
+def test_cancelling_does_not_disturb_a_reap_ALREADY_IN_FLIGHT():
+    """🔴 CANCELLATION IS SCOPED TO THE OUTBOX, AND THE BOOKKEEPING MUST AGREE.
+
+    `inst.reaps` holds reaps the extension has ALREADY PICKED UP as well as
+    queued ones. An earlier draft selected from `reaps` and then popped
+    `reaps` + `inflight` for every match while removing only the QUEUED ones from
+    the outbox — so a re-`open` landing one poll round trip late erased the
+    bookkeeping of a close that was still genuinely executing.
+
+    Both harms are asserted here, because both re-open something this feature had
+    just closed, and neither is visible from the outbox alone:
+      * `inflight` is what `_effective_timeout_locked` reads to tell a BUSY
+        extension from a wedged one. Dropping it collapses a `ping`'s deadline
+        while the close is really running — the false wedge whose documented
+        remedy is restarting the operator's live browser.
+      * `deliver_result` recognises a reap through `reaps`. Dropping the entry
+        sends its reply down the abandoned-command branch, which logs
+        `result_unknown_id` — the lost-reply tell that branch exists to stop
+        emitting.
+
+    Same invariant the EXPIRY path already asserts ("the reap already in flight
+    is still outstanding"), at the other call site.
+    """
+    # FROZEN clock, so the two deadline reads below are exactly comparable. With
+    # the real monotonic clock they differ by microseconds of elapsed `age` and an
+    # equality assertion fails for a reason that has nothing to do with the bug
+    # (measured: 19.99997930 vs 19.99996640 — while the DEFECT collapses it to
+    # 2.0, i.e. the signal is ~18s and the noise ~1e-5s).
+    t = {"now": 5000.0}
+    reg = S.Registry(clock=lambda: t["now"])
+    reg.poll("solo", "only", 0)
+    inst = list(reg._instances.values())[0]
+
+    with reg._cond:
+        reg._record_ownership_locked(
+            inst, "open", "A", None, {"ok": True, "data": {"tabId": 101}})
+        reg._record_ownership_locked(
+            inst, "open", "A", None,
+            {"ok": True, "data": {"tabId": 202, "orphanTabId": 101}})
+    cid = next(iter(inst.reaps))
+
+    # DISPATCH it — this is the whole difference from the queued-cancel test.
+    got = reg.poll("solo", "only", 0)
+    assert got is not None and got["id"] == cid and got["tabId"] == 101
+    assert list(inst.outbox) == [], "control: it really is out of the outbox now"
+    with reg._cond:
+        busy = reg._effective_timeout_locked(inst, 20.0, 2.0)
+    assert busy > 2.0, (
+        f"control: an in-flight reap must read BUSY (got {busy})")
+
+    # …and now the session re-owns 101 while that close is still executing.
+    with reg._cond:
+        reg._record_ownership_locked(
+            inst, "open", "A", None,
+            {"ok": True, "data": {"tabId": 101, "reused": True}})
+
+    assert cid in inst.inflight, (
+        "an ALREADY-DISPATCHED reap must keep its inflight entry — without it a "
+        "ping landing here fast-fails a perfectly healthy extension")
+    with reg._cond:
+        still_busy = reg._effective_timeout_locked(inst, 20.0, 2.0)
+    assert still_busy == busy > 2.0, (
+        f"the ping deadline moved {busy} -> {still_busy}: the false wedge is back "
+        f"(the defect collapses it to the 2.0 fast deadline)")
+    assert cid in inst.reaps, "…and its reaps entry, or its reply is unrecognised"
+    assert reg.deliver_result(cid, {"id": cid, "ok": True,
+                                    "data": {"closed": 101}}) is True, (
+        "the in-flight reap's reply must still be RECOGNISED — otherwise it is "
+        "logged result_unknown_id, retiring the lost-reply signal")
+
+    # 🔴 THE DISCRIMINATING FIXTURE: ONE DISPATCHED **AND** ONE QUEUED REAP FOR
+    # THE SAME TAB, WHICH IS THE ONLY SHAPE THAT SEPARATES THE TWO SCOPES.
+    #
+    # Everything above is guarded by the early return ("all matches are already
+    # in flight — leave them be"), so a mutant that widens ONLY the pop loops is
+    # unreachable and survives: measured, two of them did. With a withdrawable
+    # reap present the early return does not fire, the loops run, and the
+    # difference between `for c in withdrawn` and `for c in match` becomes
+    # observable — which is the whole content of this fix.
+    #
+    # Reachable, not contrived: reap A for tab 101 is dispatched; the session
+    # later re-owns 101 and orphans it again, queuing reap B for the same tab;
+    # then a third open reuses 101 and cancels. B must go, A must not.
+    with reg._cond:
+        reg._record_ownership_locked(
+            inst, "open", "A", None, {"ok": True, "data": {"tabId": 101}})
+        reg._record_ownership_locked(
+            inst, "open", "A", None,
+            {"ok": True, "data": {"tabId": 303, "orphanTabId": 101}})
+    a_cid = next(iter(inst.reaps))                 # queued reap for 101
+    reg.poll("solo", "only", 0)                    # dispatch it
+    with reg._cond:
+        reg._record_ownership_locked(
+            inst, "open", "A", None,
+            {"ok": True, "data": {"tabId": 404, "orphanTabId": 101}})
+    b_cid = [c for c in inst.reaps if c != a_cid][0]   # queued reap for 101
+    assert [c["id"] for c in inst.outbox] == [b_cid], "control: A out, B queued"
+    assert a_cid in inst.inflight and b_cid in inst.inflight
+
+    with reg._cond:
+        n = reg._cancel_queued_reaps_locked(inst, 101)
+    assert n == 1, f"exactly the QUEUED reap may be withdrawn, not {n}"
+    assert list(inst.outbox) == [], "B leaves the outbox"
+    assert b_cid not in inst.reaps and b_cid not in inst.inflight, (
+        "B's bookkeeping goes with it")
+    assert a_cid in inst.inflight, (
+        "🔴 A IS STILL EXECUTING. Popping its inflight entry here is the false "
+        "wedge — a ping landing now fast-fails a healthy extension")
+    assert a_cid in inst.reaps, (
+        "🔴 …and popping its reaps entry sends its reply to result_unknown_id")
+
+
+def test_a_reap_whose_reply_is_lost_does_not_strand_its_bookkeeping():
+    """A `reaps` entry is only meaningful while its `inflight` entry lives.
+
+    The one path that leaves it behind is a reap whose reply never arrives — the
+    residual this feature already discloses. `instance_id` is stable across a
+    browser restart, so the same `Instance` would carry it forever.
+    """
+    t = {"now": 1000.0}
+    reg = S.Registry(clock=lambda: t["now"])
+    reg.poll("solo", "only", 0)
+    inst = list(reg._instances.values())[0]
+
+    with reg._cond:
+        reg._record_ownership_locked(
+            inst, "open", "A", None, {"ok": True, "data": {"tabId": 101}})
+        reg._record_ownership_locked(
+            inst, "open", "A", None,
+            {"ok": True, "data": {"tabId": 202, "orphanTabId": 101}})
+    cid = next(iter(inst.reaps))
+    got = reg.poll("solo", "only", 0)
+    assert got is not None and got["id"] == cid   # dispatched; reply never comes
+
+    # Before the window closes both entries are legitimately outstanding — the
+    # control that makes the assertion below about PRUNING rather than about the
+    # entries never existing.
+    with reg._cond:
+        S.Registry._prune_inflight_locked(inst, t["now"])
+    assert cid in inst.inflight and cid in inst.reaps
+
+    t["now"] += S.INFLIGHT_STALE_S + 1
+    with reg._cond:
+        S.Registry._prune_inflight_locked(inst, t["now"])
+    assert cid not in inst.inflight, "control: inflight ages out as designed"
+    assert inst.reaps == {}, (
+        "the reaps entry must age out with it — otherwise a lost reply strands it "
+        "on an Instance that survives a browser restart")

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -9568,6 +9568,26 @@ def _wait_closed(ext, tab_id, timeout=3.0):
     return False
 
 
+def _drain(srv, session="A"):
+    """🔴 PROVE THE OUTBOX WAS DRAINED PAST WHERE A REAP WOULD SIT.
+
+    Every "no reap happened" assertion below is a ZERO, and a zero is
+    indistinguishable from "the test looked too early" — the exact class this PR
+    has already tripped over four times. A wall-clock window does not fix it; it
+    just makes the vacuous pass load-dependent.
+
+    The outbox is FIFO. So dispatch a sentinel op through the same instance and
+    wait for its RESULT: if the sentinel came back, everything queued before it
+    has already been handed to the extension. A subsequent "no `close` was
+    dispatched" then means the reap was never enqueued, rather than not yet
+    picked up.
+    """
+    st, body = _cmd(srv, {"op": "text"}, session=session)
+    assert st == 200 and body["result"]["ok"] is True, (
+        f"drain sentinel failed ({st} {body}) — the negative assertions after it "
+        f"would be vacuous")
+
+
 def test_reported_orphan_is_reaped_by_the_server():
     """A DELIVERED `open` result carrying `orphanTabId` makes the server enqueue a
     `close` for that tab — the leak `reuse_tab_id`'s comment used to describe as
@@ -9618,7 +9638,9 @@ def test_an_abandoned_open_never_reaps_the_orphan():
         while time.monotonic() < end and 202 not in live:
             time.sleep(0.01)
         assert 202 in live, "control: the extension never actually ran the open"
-        # Now the real assertion: no reap, ever.
+        # Now the real assertion: no reap, ever. Drained first, so the zero is
+        # a fact about the server rather than about our timing.
+        _drain(srv)
         assert not _wait_closed(ext, 101, timeout=0.6), (
             "an abandoned open must NOT reap: nothing recorded the fresh tab as "
             "owned, so 101 is still this session's OWNED, LIVE tab")
@@ -9658,6 +9680,7 @@ def test_a_failed_open_never_reaps_the_orphan():
         assert body["result"]["data"]["orphanTabId"] == 101, (
             "control: the failure envelope really did carry the report the server "
             "must ignore")
+        _drain(srv)
         assert not _wait_closed(ext, 101, timeout=0.4)
         assert [c for c in ext.dispatched if c["op"] == "close"] == []
         assert live == {101}
@@ -9699,6 +9722,7 @@ def test_a_malformed_or_self_referential_orphan_report_is_refused(reported):
         # even polled, so it was empty either way. Two independent reasons the
         # test could not fail. Wait for a plausible round trip, then look at the
         # WHOLE list.
+        _drain(srv)
         assert not _wait_closed(ext, 202, timeout=0.4)
         closes = [c for c in ext.dispatched if c["op"] == "close"]
         assert closes == [], f"a refused report still enqueued {closes}"
@@ -9775,3 +9799,139 @@ def test_the_reap_close_is_inflight_while_it_runs_then_fully_released():
         assert st == 200 and body["result"]["ok"] is True
     finally:
         gate.set(); ext.stop(); srv.shutdown(); srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE REAP'S OWN LIFETIME AND CANCELLATION.
+#
+# A reap is the ONLY outbox entry with no submitter. Every other command is
+# withdrawn from the outbox by its abandoning submitter at `cmd_timeout`; this one
+# has nobody to do that. Two consequences, both reproduced before being fixed:
+#
+#   * it must EXPIRE. `instance_id` is stable per profile, so a Brave restart
+#     returns the SAME `Instance` while Chromium's tab ids restart at 1 — a
+#     long-queued `close` would then name a different, REAL tab. The correlation
+#     is adverse: a browser-wide stall is what produces a reap, and a full restart
+#     is the documented remedy for a stall.
+#   * it must be CANCELLABLE. `orphan != tid` is true only at ENQUEUE time, and
+#     `open` is not in TAB_SCOPED_OPS, so two concurrent opens from one session
+#     (which parallel agents sharing a session id really do produce) take no
+#     turnstile: a later `open` can healthily REUSE the tab an earlier one queued
+#     for reaping. The server would then close a tab it CURRENTLY OWNS.
+# --------------------------------------------------------------------------- #
+def test_re_owning_a_tab_cancels_the_reap_queued_for_it():
+    """🔴 The guard that made the reap safe is POINT-IN-TIME; the close runs later.
+
+    Driven at the registry, because the race needs the reap to sit in the outbox
+    across a second ownership record — which an HTTP-level test cannot pin
+    deterministically. The instance never polls, so nothing is dispatched and the
+    outbox itself is the observable.
+    """
+    reg = S.Registry()
+    # Register through the public path (one poll that times out immediately).
+    reg.poll("solo", "only", 0)
+    inst = list(reg._instances.values())[0]
+    okey = (inst.key, "A")
+
+    # open #1 owns 101; open #2 falls through to 202 and orphans 101.
+    with reg._cond:                       # `_locked` in the name is literal
+        reg._record_ownership_locked(
+            inst, "open", "A", None, {"ok": True, "data": {"tabId": 101}})
+        reg._record_ownership_locked(
+            inst, "open", "A", None,
+            {"ok": True, "data": {"tabId": 202, "orphanTabId": 101}})
+    queued = [c for c in inst.outbox if c["op"] == "close"]
+    assert [c["tabId"] for c in queued] == [101], (
+        "control: the reap really was queued")
+    assert reg.owners_snapshot()[okey] == 202
+
+    # …and now a CONCURRENT open healthily reuses 101 before the reap is picked up.
+    with reg._cond:
+        reg._record_ownership_locked(
+            inst, "open", "A", None, {"ok": True, "data": {"tabId": 101,
+                                                           "reused": True}})
+    assert reg.owners_snapshot()[okey] == 101
+    assert [c for c in inst.outbox if c["op"] == "close"] == [], (
+        "the queued reap must be WITHDRAWN — the session owns 101 again, and "
+        "closing it would strand the session on a dead id and, one op later, on "
+        "the operator's ACTIVE tab")
+    assert inst.reaps == {}, "the reap bookkeeping must be dropped with it"
+    assert inst.inflight == {}, "…including its inflight entry"
+
+
+def test_a_reap_that_outlives_its_window_is_dropped_not_dispatched():
+    """🔴 An EXPIRED reap must never reach the extension.
+
+    Past the window the tabId can no longer be trusted to name the same tab. The
+    injected clock jumps far past INFLIGHT_STALE_S between enqueue and pickup —
+    exactly the wedged-extension-then-Brave-restart shape.
+    """
+    t = {"now": 1000.0}
+    reg = S.Registry(clock=lambda: t["now"])
+    reg.poll("solo", "only", 0)
+    inst = list(reg._instances.values())[0]
+
+    with reg._cond:                       # `_locked` in the name is literal
+        reg._record_ownership_locked(
+            inst, "open", "A", None, {"ok": True, "data": {"tabId": 101}})
+        reg._record_ownership_locked(
+            inst, "open", "A", None,
+            {"ok": True, "data": {"tabId": 202, "orphanTabId": 101}})
+    assert [c["tabId"] for c in inst.outbox if c["op"] == "close"] == [101]
+
+    # A poll BEFORE the window closes still gets it — the control that makes the
+    # assertion below about EXPIRY rather than about the reap never existing.
+    t["now"] += S.INFLIGHT_STALE_S / 2
+    got = reg.poll("solo", "only", 0)
+    assert got is not None and got["op"] == "close" and got["tabId"] == 101
+
+    # Now the same again, but the extension is gone past the window.
+    with reg._cond:
+        reg._record_ownership_locked(
+            inst, "open", "A", None,
+            {"ok": True, "data": {"tabId": 303, "orphanTabId": 202}})
+    assert [c["tabId"] for c in inst.outbox if c["op"] == "close"] == [202]
+    t["now"] += S.INFLIGHT_STALE_S + 1
+    got = reg.poll("solo", "only", 0)
+    assert got is None, f"an expired reap was dispatched anyway: {got}"
+    assert list(inst.outbox) == [], "…and it must be removed, not left to retry"
+    # 🔴 THE DISPATCHED REAP IS STILL OUTSTANDING, AND THAT ASYMMETRY IS THE
+    # ASSERTION. An earlier draft here demanded `reaps == {}` and failed — which
+    # was the TEST being wrong, not the code: the 101 reap was handed to the
+    # extension and is legitimately awaiting its reply, so dropping its
+    # bookkeeping would lose the very entry that keeps the instance reading BUSY.
+    # Only the never-dispatched 202 entry may disappear.
+    assert [r["tab_id"] for r in inst.reaps.values()] == [101], (
+        "expiry must drop ONLY the entry it dropped from the outbox — the reap "
+        "already in flight is still outstanding")
+    assert len(inst.inflight) == 1, "…and keeps its inflight entry until it replies"
+
+
+def test_a_reap_reply_is_recognised_not_logged_as_an_unknown_id():
+    """`result_unknown_id` means "a reply for a command nobody knows about" — a
+    LOST-REPLY tell. A reap has no waiter by design, so before this it fell to
+    that branch and fired on every SUCCESSFUL reap, retiring the signal.
+
+    Asserted on the RETURN VALUE of deliver_result (True = we know this command),
+    which is what `_handle_result` branches on to choose between an ok response
+    and the `unknown_id` error.
+    """
+    reg = S.Registry()
+    reg.poll("solo", "only", 0)
+    inst = list(reg._instances.values())[0]
+    with reg._cond:                       # `_locked` in the name is literal
+        reg._record_ownership_locked(
+            inst, "open", "A", None, {"ok": True, "data": {"tabId": 101}})
+        reg._record_ownership_locked(
+            inst, "open", "A", None,
+            {"ok": True, "data": {"tabId": 202, "orphanTabId": 101}})
+    cid = next(iter(inst.reaps))
+
+    assert reg.deliver_result(cid, {"id": cid, "ok": True,
+                                    "data": {"closed": 101}}) is True, (
+        "a reap's own reply must be RECOGNISED — falling through to the "
+        "abandoned-command branch logs result_unknown_id on correct operation")
+    assert inst.reaps == {} and inst.inflight == {}
+    # A genuinely unknown id still reads as unknown — the control that proves the
+    # branch above did not simply make deliver_result answer True to everything.
+    assert reg.deliver_result("deadbeefdeadbeef", {"ok": True}) is False

--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -10104,8 +10104,14 @@ def test_a_prune_must_not_starve_a_reap_STILL_IN_THE_OUTBOX():
     `waiters` (deliberately), so the prune's second condition never shields it.
 
     An inflight-only sweep therefore deleted the metadata of a reap STILL SITTING
-    IN THE OUTBOX, removing BOTH bounds at once. This test pins both, because
-    they fail together and each alone reads as a smaller bug than it is.
+    IN THE OUTBOX, removing BOTH bounds at once. ⚠ THIS TEST PINS THE **EXPIRY**
+    HALF ONLY — the cancellation half is
+    `test_a_prune_must_not_make_a_queued_reap_UNCANCELLABLE`, deliberately a
+    separate test because the two have different consequences. (An earlier
+    docstring here said "this test pins both", which is the
+    description-claims-coverage-the-body-lacks shape this very round exists to
+    remove; corrected rather than quietly reworded.) They fail together, and each
+    alone reads as a smaller bug than it is, which is why the pair matters.
 
     Not exotic: `_prune_inflight_locked` runs on every submit and every ping, and
     two ordinary ops ahead of the reap in the serial FIFO can exceed


### PR DESCRIPTION
Queue item 4 of `claudedocs/handoff-bridge-unbounded-waits.md` — **built as the opposite of what the item asked for, and that is the finding.**

## What the item asked for, and why it was refused

> "`chrome.tabs.create` is another unbounded browser-process IPC, so a browser-wide stall leaks one tab per `open` while returning success. Worth more than its rank: the #797 audit PREDICTED this shape would regenerate and #814 proved it right, so this is the third instance of a class that is 2-for-2."

The class is real. The remedy is not:

* **`execute()`'s own rule forbids a bound here.** "A local bound is granted only to *an await inside a `try` whose `catch` implements a RECOVERY (a second, working path)* … If a hung step has no alternative to fall through to, the choke point below is already the right and only answer — **do NOT add a bound for it.**" `chrome.tabs.create` has no second path.
* **A bound would not fix the harm the item names.** It relabels `op_timeout:open` as a create-specific timeout and leaks *exactly the same tab*, 2 s earlier. And the named harm — "leaks one tab per `open` **while returning success**" — is the reuse-probe fall-through, which needs no hang in `create` at all.

`server.py` had already written the real defect down:

> a probe that exceeds the budget falls through to a FRESH tab and the ownership record below is overwritten, deterministically **ORPHANING the live first tab. Nothing reclaims it; only a human closes it.**

That sentence is what this PR deletes. **The leak, not the label, was the defect.**

## The change

~10 lines of production code. `open` now closes the orphan itself — on the **timeout arm only**, **after** the replacement tab exists, **fire-and-forget**.

Three decisions, each pinned by a mutant:

| decision | why | mutant |
|---|---|---|
| timeout arm **only** | a rejection is `tabs.get` naming the id absent — a remove reclaims nothing and only risks a recycled tabId | M1 unconditional reap |
| **after** the create | reaping first closes the session's only tab, then on a failed create leaves it owning a dead id | M5 reap-before-create |
| **never awaited** | `tabs.remove` is one more unbounded IPC — awaiting it puts a new unbounded await on `open`'s SUCCESS path, regenerating this class at the last line of the op | M3 awaited-reap |

## What it does NOT fix — stated, not discovered later

1. **Best-effort only.** The browser-wide stall that hung `tabs.get` can hang `tabs.remove`, and nothing waits to find out.
2. **The other orphan is untouched.** A hung `chrome.tabs.create` is killed at `EXEC_OP_BUDGET_MS` while the abandoned create still settles, producing a tab `open` never sees. Closing it needs the choke point to signal abandonment back into the op — no mechanism today. Deliberately out of scope.
3. **No new exposure class.** This is the same `chrome.tabs.remove(<the session's owned tabId>)` that `close` already performs unconditionally, on an id the server vouched for moments earlier.

## Evidence

**Watched RED at the base.** Reverting only the production change (tests unchanged) → **30 pass / 2 fail**, both as ordinary assertion failures naming their own cause — not `cancelled`, which is how a hang scores and how a fail-count gate reads a live regression as clean:

```
not ok 19 - a TIMED-OUT probe reaps the tab it just orphaned
            actual [] / expected [5]
not ok 22 - a HANGING / REJECTING / THROWING reap cannot delay or fail open
            "…and the reap must still have been ATTEMPTED"  0 !== 1
```

The other two new tests **pass at the base by construction** — they are invariant guards / discriminating negatives (the rejection arm must not reap; healthy reuse and a first open must not reap), **not** regression coverage. Labelled as such rather than counted.

**Mutation battery — 7 mutants, all KILLED, each by the assertion naming its own decision.** Control: unmutated tree, 0 failures.

```
M1 unconditional reap       KILLED  "must not be removed"          (the negative arm)
M2 inverted arm             KILLED  "Nothing reclaims it"
M3 awaited reap             KILLED  "the reap is being AWAITED"
M4 try/catch deleted        KILLED  sync-throw arm, at service_worker.js:1301 —
                                    raw "chrome.tabs.remove is not a function",
                                    not an assertion message (stack verified)
M5 reap before create       KILLED  "reap belongs AFTER chrome.tabs.create"
M6 .catch() dropped         KILLED  unhandledRejection on the reject arm
M7 reap the wrong id        KILLED  fixture-distinctness control (TAB_ID != FRESH_TAB_ID)
```

**Suites.** node `511 pass / 0 fail` across all 15 `.test.mjs`; browser-bridge pytest `792 pass / 0 fail`.

The two **build-marker gates went red first and were right** — the extension source changed, so `build_id.js` is regenerated here (`e1ee86a50a811d40` → `18304ead05a6e386`).

## Prose describing this hazard as open is corrected

A comment is a claim. Every site that said the orphan is unreclaimable now says what is actually true, with the residual stated: `server.py`'s "Nothing reclaims it" block; `REUSE_TAB_BUDGET_MS`'s cost paragraph in `protocol.js` (**kept verbatim** — it is the derivation of 2000 — with the change appended); the reuse-probe floor rationale in `cdp_protocol.test.mjs`; the attribution-control comment in `service_worker.test.mjs`; and the operator-facing claims in `README.md` and `reference/tabs-instances.md`.

## Separate finding, NOT fixed here

`validateCommand` does not whitelist fields and `_handle_cmd` pops only `target`/`tab`/`focus`, so a client-supplied `reuseTabId` survives into the command whenever the session owns no tab — after which `open` returns that tab and `_record_ownership_locked` records ownership of it, bypassing `_resolve_tab`'s `not_owned_tab` guard. **Read from the code, not executed** (a live probe would take over the operator's tab). Pre-existing and independent of this PR; this change does not widen it (the reap fires only on a hang the caller cannot induce, against a tab the hole already lets them own and `close`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
