### PR TITLE
feat(audit-pr): assemble the auditor brief in CODE — the invariant clauses stop being retypable

### DIFF
--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -24,6 +24,11 @@ generates the range, the cross-repo worktree directive, checkout state and toolc
 prior round's claims from the fenced `audit-claims` block ONLY, and carries the invariant clauses
 verbatim. **A delta round with no parseable block is REFUSED.**
 
+🔴 **Post the round's block with `--round N --emit-claims --audited <the tip that round's audit
+READ>`.** `--emit-claims` runs after the fixes land, so every sha it can see is a FIX tip; omit
+`--audited` and HEAD is *assumed* — it says so on stderr, because the next round then diffs a range
+that is empty by construction and a finding-free pass over it reads as a clean round.
+
 Dispatch a subagent (read-only — it must NOT modify files or merge) to audit the change against this checklist. Have it read the diff and the code it touches, not just the PR description.
 
 **Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, anything security/auth/path-gating. What each hid, and `GOPRIVATE`: reference file.

--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -19,9 +19,14 @@ Target: `$ARGUMENTS`:
 
 ## What to do
 
+🔴 **Assemble the brief with `~/workspace/devrc/scripts/audit-dispatch.py <pr> [--round N]`** — it
+generates the range, the cross-repo worktree directive, checkout state and toolchain, reads the
+prior round's claims from the fenced `audit-claims` block ONLY, and carries the invariant clauses
+verbatim. **A delta round with no parseable block is REFUSED.**
+
 Dispatch a subagent (read-only — it must NOT modify files or merge) to audit the change against this checklist. Have it read the diff and the code it touches, not just the PR description.
 
-**Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, anything security/auth/path-gating. These hide deploy-blocking bugs (shutdown data-loss, trash-path overwrite, an unauthenticated arbitrary-path scan and a git `core.fsmonitor` RCE all surfaced this way). A branch with a **private Go module dep** may need `GOPRIVATE` — a sum-db `500` there is env, not a defect.
+**Always run this on high-yield change-classes** — web/HTTP endpoints, concurrency reworks, filesystem/quarantine/trash moves, DB migrations, anything security/auth/path-gating. What each hid, and `GOPRIVATE`: reference file.
 
 **Brief the auditor on the environment, or it will report false findings** — a fresh worktree is
 not a working checkout, and an auditor hitting this cold blames the PR. Whichever apply:

--- a/claude/skills/audit-pr/reference/round-ladder-evidence.md
+++ b/claude/skills/audit-pr/reference/round-ladder-evidence.md
@@ -222,6 +222,22 @@ clause.
 
 ---
 
+## High-yield change-classes — what each one actually hid
+
+Demoted from the skill body to pay for the assembler router line; the CLASS LIST stays in the body
+because it is what decides whether to run an audit at all, and only these anecdotes moved.
+
+Deploy-blocking bugs that surfaced from exactly these classes: a **shutdown data-loss** on a
+concurrency rework; a **trash-path overwrite** on a filesystem/quarantine move; an
+**unauthenticated arbitrary-path scan** on an HTTP endpoint; and a git **`core.fsmonitor` RCE**
+reachable from a repo-local config.
+
+The false positive to expect on the same road: a branch with a **private Go module dep** may need
+`GOPRIVATE`, and a sum-db `500` there is an ENVIRONMENT failure, not a defect in the PR. An auditor
+that reports it as a finding has read a broken toolchain as a broken change.
+
+---
+
 ## Where the rest lives
 
 - The **rejected numeric cap** and devrc #505's ReDoS-introduced-by-the-fix evidence: stated inline

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -71,10 +71,26 @@ round has something to read.
    `scripts/ladder-depth-sweep.py`'s refused zero: the failure and the
    legitimate case produce the SAME observable, so neither may be reported.
 2. **A brief missing an invariant clause WARNS and never blocks.** That check
-   exists for a hand-edited `--out` file, and `claude/RULES.md` is explicit that
-   a permanently-red gate trains everyone to click through it. Warn-only is the
+   exists for a hand-edited brief, and `claude/RULES.md` is explicit that a
+   permanently-red gate trains everyone to click through it. Warn-only is the
    right severity for a channel whose failure is cosmetic and whose false
-   positive rate is set by whatever a human typed.
+   positive rate is set by whatever a human typed. It runs over `--check FILE`
+   and over the READ-BACK of `--out` — never over the in-memory string, where
+   it was unreachable by construction and could not have fired for any input.
+
+🔴 EVERY NUMBER HERE IS ABOUT THE PR, NOT ABOUT YOUR CHECKOUT
+-------------------------------------------------------------
+The delta half of a brief — the ledger, the `<prev>..HEAD` range, the `audited=`
+sha `--emit-claims` writes for the NEXT round to anchor on — was resolved
+against `HEAD` in the operator's own SHARED checkout, with nothing checking that
+HEAD was the PR at all. From a clone standing on an unrelated branch that
+produced rc 0, silent stderr, a non-empty range and a confident ledger of the
+wrong branch's files; from `main` it produced the banner "🔴 Zero changed lines
+over a NON-EMPTY range. That is a real measurement, not a failure."
+
+So `git rev-parse HEAD == headRefOid` is a FOURTH read rule beside rc 0, silent
+stderr and a non-empty range, and all three consumers emit COULD NOT MEASURE
+naming that cause when it does not hold.
 
 🔴 WHAT THIS SCRIPT DOES NOT DO
 --------------------------------
@@ -185,11 +201,23 @@ ISOLATION_FORBID = 'Do NOT use `isolation: "worktree"`'
 # the two fields that matter. A block whose header does not parse is reported as
 # MALFORMED rather than skipped: skipping it silently would produce the same
 # observable as "no block at all", and those need different fixes.
-_CLAIMS_FENCE = re.compile(
-    r"^(?P<fence>`{3,})audit-claims(?P<header>[^\n]*)\n"
-    r"(?P<body>.*?)^(?P=fence)\s*$",
-    re.M | re.S,
-)
+#
+# 🔴 THAT COMMENT WAS FALSE FOR FOUR SHAPES, so the parser is line-based rather
+# than one regex. The old `^(?P=fence)\s*$` backreference required the CLOSING
+# fence to be byte-identical to the opener, and anything it could not match was
+# dropped with no report at all:
+#   * an UNCLOSED fence — the refusal then said "no `audit-claims` block in any
+#     of the 1 comment(s) read", which is false and points at the wrong fix;
+#   * a 4-backtick opener closed with 3 — not a close under CommonMark either,
+#     so this really is unclosed and is now named as such;
+#   * a 3-backtick opener closed with 4 — which IS a valid CommonMark close and
+#     renders closed on GitHub, so it is now PARSED rather than dropped;
+#   * a nested fence inside the body, which ends the block early and silently
+#     drops every claim after it.
+# A claim that WRAPS onto a continuation line was silently truncated to its
+# first line, changing the claim; continuation lines are now appended.
+_FENCE_OPEN = re.compile(r"^(?P<fence>`{3,})audit-claims(?P<header>[^\n]*)$")
+_FENCE_BARE = re.compile(r"^(?P<fence>`{3,})\s*$")
 _HEADER_ROUND = re.compile(r"\bround=(\d+)\b")
 _HEADER_AUDITED = re.compile(r"\baudited=(\S+)")
 _CLAIM_ITEM = re.compile(r"^\s*(\d+)[.)]\s+(.+?)\s*$")
@@ -197,16 +225,66 @@ _CLAIM_ITEM = re.compile(r"^\s*(\d+)[.)]\s+(.+?)\s*$")
 ClaimsBlock = namedtuple("ClaimsBlock", "round_no audited_from audited_to items")
 
 
+def _items_from_body(body_lines):
+    """Numbered claim lines, with CONTINUATION lines folded into the item above.
+
+    A claim wrapped over two lines used to lose everything after the first —
+    which does not fail, it changes the claim, and the next round is framed on
+    the truncated text.
+    """
+    items = []
+    for line in body_lines:
+        m = _CLAIM_ITEM.match(line)
+        if m:
+            items.append(m.group(2))
+        elif items and line.strip():
+            items[-1] = f"{items[-1]} {line.strip()}"
+    return items
+
+
 def parse_claims_blocks(texts):
     """-> (blocks, malformed_reasons) over an iterable of comment bodies.
 
     Pure and independently testable: the refusal below is only trustworthy if
     this can be driven with no network and no PR.
+
+    🔴 `malformed` is NOT only populated when the block is unusable. A structural
+    problem that still leaves a parseable block (a nested fence that cut the
+    claims in half) is reported too, and `main` warns about it rather than
+    letting a half-read block pass as a whole one.
     """
     blocks, malformed = [], []
     for text in texts:
-        for m in _CLAIMS_FENCE.finditer(text or ""):
-            header = m.group("header")
+        lines = (text or "").splitlines()
+        i = 0
+        while i < len(lines):
+            om = _FENCE_OPEN.match(lines[i])
+            if om is None:
+                i += 1
+                continue
+            opener, header = om.group("fence"), om.group("header")
+
+            body, close_at, j = [], None, i + 1
+            while j < len(lines):
+                bm = _FENCE_BARE.match(lines[j])
+                # CommonMark: a closing fence must be AT LEAST as long as the
+                # opener. A shorter run of backticks is content, not a close.
+                if bm and len(bm.group("fence")) >= len(opener):
+                    close_at = j
+                    break
+                body.append(lines[j])
+                j += 1
+
+            if close_at is None:
+                malformed.append(
+                    "an `audit-claims` fence that is never CLOSED — no line of "
+                    f"{len(opener)} or more backticks follows it (header was: "
+                    f"`{header.strip() or '<empty>'}`). A shorter closing fence "
+                    "does not close it, under CommonMark or here."
+                )
+                i += 1
+                continue
+
             r = _HEADER_ROUND.search(header)
             a = _HEADER_AUDITED.search(header)
             if not r or not a:
@@ -215,26 +293,54 @@ def parse_claims_blocks(texts):
                     f"`round=<n>` and `audited=<sha>..<sha>` (header was:"
                     f" `{header.strip() or '<empty>'}`)"
                 )
+                i = close_at + 1
                 continue
+
             spec = a.group(1)
             frm, _, to = spec.partition("..")
             if not to:
-                # A bare sha is accepted as the audited TIP; the round-1 anchor
-                # is then simply unknown, which the ledger reports rather than
-                # guesses.
+                # A bare sha is accepted as the audited TIP; for a round-1 block
+                # that tip IS the cumulative anchor (see `round_one_anchor`),
+                # and for any later round the anchor is simply unknown, which
+                # the ledger reports rather than guesses.
                 frm, to = "", frm
-            items = [
-                mm.group(2)
-                for mm in (_CLAIM_ITEM.match(ln) for ln in m.group("body").splitlines())
-                if mm
-            ]
+
+            items = _items_from_body(body)
             if not items:
                 malformed.append(
                     f"an `audit-claims round={r.group(1)}` block with no "
                     "numbered claim lines in its body"
                 )
+                i = close_at + 1
                 continue
+
+            # 🔴 The nested-fence report. A fence inside the body ends the block
+            # early — CommonMark and GitHub agree — so the claims after it are
+            # outside it and were dropped with no signal. The tell is claim
+            # line(s) AND a stray fence in the region after the close, which is
+            # what a cut-in-half block leaves behind. Deliberately a report and
+            # not a rejection: the block that DID parse is still used, and a
+            # comment whose trailing prose merely happens to contain both would
+            # otherwise lose a usable block to a heuristic.
+            k = close_at + 1
+            tail = []
+            while k < len(lines) and _FENCE_OPEN.match(lines[k]) is None:
+                tail.append(lines[k])
+                k += 1
+            if any(_CLAIM_ITEM.match(t) for t in tail) and any(
+                _FENCE_BARE.match(t) for t in tail
+            ):
+                malformed.append(
+                    f"an `audit-claims round={r.group(1)}` block that looks CUT "
+                    "SHORT by a nested fence: numbered claim line(s) and a "
+                    "stray fence follow its closing fence, so claims after the "
+                    f"nested fence were not read (read {len(items)}). Indent "
+                    "any code inside a claim, or open the block with four "
+                    "backticks."
+                )
+
             blocks.append(ClaimsBlock(int(r.group(1)), frm, to, items))
+            i = close_at + 1
     return blocks, malformed
 
 
@@ -248,14 +354,29 @@ def newest_block(blocks):
 
 
 def round_one_anchor(blocks):
-    """The left side of the LOWEST-numbered block's range, or None.
+    """The sha ROUND 1 audited, or None.
 
     That is the only sha in the corpus that can anchor the ledger's cumulative
     "since round 1" figure. When no block carries one, the figure is reported
     NOT MEASURED — never derived from the base, which is a different quantity.
+
+    Two spellings carry it, and both are read:
+      * `round=2 audited=A..B` — A is the tip round 1 audited (the usual case);
+      * `round=1 audited=A`    — the bare form `--emit-claims` writes for a
+        round-1 comment, where the audited TIP is itself that same quantity.
+    A bare sha on any LATER round is NOT an anchor: it says what that round
+    audited, and the round-1 tip is then genuinely unknown.
     """
-    ordered = sorted((b for b in blocks if b.audited_from), key=lambda b: b.round_no)
-    return ordered[0].audited_from if ordered else None
+    candidates = []
+    for b in blocks:
+        if b.audited_from:
+            candidates.append((b.round_no, b.audited_from))
+        elif b.round_no == 1 and b.audited_to:
+            candidates.append((b.round_no, b.audited_to))
+    # Stable sort on the round number alone, so a tie resolves to the block seen
+    # first rather than to whichever sha sorts lower.
+    candidates.sort(key=lambda c: c[0])
+    return candidates[0][1] if candidates else None
 
 
 # --------------------------------------------------------------------------- #
@@ -274,12 +395,18 @@ def real_runner(cmd, cwd=None):
 # Facts gathered per invocation
 # --------------------------------------------------------------------------- #
 
-LedgerReport = namedtuple("LedgerReport", "files added deleted commits reason cumulative")
+LedgerReport = namedtuple(
+    "LedgerReport",
+    "files added deleted commits reason cumulative cumulative_reason",
+)
+# 🔴 `head_check` is the FOURTH read rule, beside rc 0 / silent stderr /
+# non-empty range. See `verify_head_is_the_pr`.
+HeadCheck = namedtuple("HeadCheck", "ok reason local_sha pr_sha")
 Facts = namedtuple(
     "Facts",
-    "pr repo title base_ref url round_no cwd_repo_dir cwd_repo_slug cross_repo "
+    "pr repo title base_ref url round_no cwd_repo_dir cwd_repo_slug repo_relation "
     "branch dirty prev_sha claims claims_round checklist ledger assembled_at "
-    "claims_source",
+    "claims_source head_check",
 )
 
 
@@ -311,9 +438,18 @@ def gather_checkout_state(runner, repo_dir):
 
 
 def gh_pr_facts(runner, pr, repo=None):
-    """PR metadata + comment bodies, via `gh`. -> (dict, [comment bodies])."""
+    """PR metadata + comment bodies, via `gh`. -> (dict, [comment bodies]).
+
+    🔴 `headRefOid` and `isCrossRepository` are read because the two decisions
+    that were WRONG without them are the two most expensive ones this script
+    makes: which tree the ledger measured, and which repository the PR lives in.
+    🔴 There is NO `baseRepository` field on `gh pr view --json` (checked
+    against `gh`'s own field list) — `url` is what carries the base repo, and
+    `pr_slug` reads it.
+    """
     cmd = ["gh", "pr", "view", str(pr), "--json",
-           "title,url,baseRefName,headRepository,headRepositoryOwner,comments"]
+           "title,url,baseRefName,headRefOid,isCrossRepository,"
+           "headRepository,headRepositoryOwner,comments"]
     if repo:
         cmd += ["--repo", repo]
     rc, out, err = runner(cmd)
@@ -330,31 +466,126 @@ def gh_pr_facts(runner, pr, repo=None):
     return data, comments
 
 
+# `https://<host>/<owner>/<name>/pull/<n>` — the PR's own URL, which names the
+# repository the PR LIVES IN. Host-agnostic on purpose (GHES spells the host
+# differently and the path shape is the same).
+_PR_URL = re.compile(r"^https?://[^/]+/([^/]+)/([^/]+)/pull/\d+")
+
+
 def pr_slug(data, override=None):
+    """The repo the PR LIVES IN — NOT the repo its head branch lives in.
+
+    🔴 This read `headRepositoryOwner`/`headRepository` and was therefore wrong
+    for every FORK PR. Verified against real `gh` output for a fork PR against
+    `cli/cli`: `headRepository.nameWithOwner` is `ylfeng250/cli` while `url` is
+    `https://github.com/cli/cli/pull/14280` and `isCrossRepository` is `true`.
+    A fork PR opened against THIS repo therefore computed a slug that differs
+    from the cwd's, took the CROSS-REPO branch, and told the agent to worktree
+    "your local clone of <contributor>/<repo>" — a clone that does not exist,
+    for a repository the PR is not in.
+
+    `gh pr view --json` has no `baseRepository` field, so `url` is the authority
+    and `isCrossRepository` is what says whether the head fields may stand in
+    for it: they are the same repo only when it is false.
+    """
     if override:
         return override
-    owner = (data.get("headRepositoryOwner") or {}).get("login")
-    name = (data.get("headRepository") or {}).get("name")
-    return f"{owner}/{name}" if owner and name else None
+    m = _PR_URL.match((data.get("url") or "").strip())
+    if m:
+        return f"{m.group(1)}/{m.group(2)}"
+    if data.get("isCrossRepository") is False:
+        owner = (data.get("headRepositoryOwner") or {}).get("login")
+        name = (data.get("headRepository") or {}).get("name")
+        if owner and name:
+            return f"{owner}/{name}"
+    # 🔴 None, never a guess. `main` renders a third WHERE-TO-WORK branch for
+    # this, because collapsing "cannot tell" into "same repo" recommends the
+    # flag that is dangerous in exactly the case it cannot rule out.
+    return None
+
+
+def verify_head_is_the_pr(runner, repo_dir, pr_head_sha):
+    """🔴 The FOURTH read rule: is this checkout's HEAD the PR's head commit?
+
+    Everything the delta half of this brief says — the ledger's numbers, the
+    `<prev>..HEAD` range it hands the auditor, and the `audited=` sha
+    `--emit-claims` stamps for the NEXT round to anchor on — is computed against
+    `HEAD` in the operator's own checkout. That checkout is SHARED and moves;
+    nothing here ever checked that it was standing on the PR at all.
+
+    Reproduced from a clone standing on an unrelated feature branch: rc 0,
+    silent stderr, a non-empty range — all three advertised read rules satisfied
+    — and a ledger of that branch's files. Standing on `main` instead produced
+    the confident banner "🔴 Zero changed lines over a NON-EMPTY range. That is
+    a real measurement, not a failure."
+
+    So a failed check returns a `reason` and NO number, exactly like the other
+    three: an unverifiable measurement is not a measurement.
+    """
+    if not pr_head_sha:
+        return HeadCheck(
+            False,
+            "the PR's head sha is not known here (`gh` was not consulted — "
+            "`--claims-file` mode — or reported no `headRefOid`), so nothing "
+            "can confirm this checkout is standing on the PR",
+            None,
+            None,
+        )
+    rc, out, err = runner(["git", "-C", repo_dir, "rev-parse", "HEAD"])
+    local = out.strip()
+    if rc != 0 or not local:
+        return HeadCheck(
+            False,
+            f"`git rev-parse HEAD` in {repo_dir} exited {rc}: "
+            f"{(err or out).strip() or 'no output'}",
+            None,
+            pr_head_sha,
+        )
+    if local != pr_head_sha:
+        return HeadCheck(
+            False,
+            f"this checkout's HEAD is `{local}`, but the PR's head is "
+            f"`{pr_head_sha}` — the two are DIFFERENT COMMITS, so anything "
+            "measured against `HEAD` here is a measurement of another tree",
+            local,
+            pr_head_sha,
+        )
+    return HeadCheck(True, None, local, pr_head_sha)
 
 
 # --------------------------------------------------------------------------- #
 # The ledger — the skill's own command, with the skill's own read rules
 # --------------------------------------------------------------------------- #
 
-def measure_ledger(runner, repo_dir, prev_sha, base):
+def measure_ledger(runner, repo_dir, prev_sha, base, head_check=None):
     """`git log --numstat --format= --remerge-diff <prev>..HEAD --not <base>`.
 
-    🔴 The skill's read rules are enforced here, not assumed: **rc 0, silent
-    stderr, and a non-empty range**. A missing ref or a git without
-    `--remerge-diff` exits 128 with empty output; an unwritable object store
-    makes `--remerge-diff` UNDER-count, exit 0 and print a plausible number,
-    announcing itself only on stderr; and a range whose commits are not in this
-    checkout prints nothing at all, silently, with rc 0. Each of those returns a
-    `reason` and NO number — a failed command is not a zero.
+    🔴 FOUR read rules are enforced here, not assumed: **the checkout's HEAD is
+    the PR's head, rc 0, silent stderr, and a non-empty range**.
+
+    The fourth one came last and is the one that lets the other three pass while
+    the answer is entirely wrong: `HEAD` is resolved in the operator's own
+    SHARED checkout, which is not necessarily standing on the PR. Reproduced
+    from a clone on an unrelated branch — rc 0, silent stderr, a non-empty range
+    and a file list belonging to that branch. `head_check` is
+    `verify_head_is_the_pr`'s verdict; passing None skips it, which is only for
+    a caller that has no PR to compare against.
+
+    A missing ref or a git without `--remerge-diff` exits 128 with empty output;
+    an unwritable object store makes `--remerge-diff` UNDER-count, exit 0 and
+    print a plausible number, announcing itself only on stderr; and a range
+    whose commits are not in this checkout prints nothing at all, silently, with
+    rc 0. Each of those returns a `reason` and NO number — a failed command is
+    not a zero, and neither is a measurement of the wrong tree.
     """
     def fail(reason):
-        return LedgerReport(None, None, None, None, reason, None)
+        return LedgerReport(None, None, None, None, reason, None, None)
+
+    if head_check is not None and not head_check.ok:
+        return fail(
+            "this checkout is not standing on the PR, so `..HEAD` does not "
+            f"mean what this ledger would claim it means: {head_check.reason}"
+        )
 
     rc, out, err = runner(
         ["git", "-C", repo_dir, "rev-list", "--count", f"{prev_sha}..HEAD"]
@@ -401,7 +632,7 @@ def measure_ledger(runner, repo_dir, prev_sha, base):
         files[path] = (cur[0] + na, cur[1] + nd)
         added += na
         deleted += nd
-    return LedgerReport(files, added, deleted, commits, None, None)
+    return LedgerReport(files, added, deleted, commits, None, None, None)
 
 
 # --------------------------------------------------------------------------- #
@@ -425,8 +656,51 @@ def render_worktree_directive(facts):
     repo that is the wrong tree, and the failure is quiet: the agent either
     reports a briefed file missing, or silently audits the wrong repository and
     reports findings about it.
+
+    🔴 THREE states, not two. The decision used to be `bool(cwd_slug and repo
+    and cwd_slug != repo)`, so "could not determine either side" evaluated
+    FALSE and collapsed into the SAME-REPO branch — the one that recommends the
+    flag. With no `origin` remote the output contradicted itself in one
+    paragraph: "The PR lives in `<org>/<other-repo>`, which is this session's
+    own repository (`/home/…/devrc`)", followed by the recommendation. Not
+    knowing is its own answer, and it is the answer that must NOT recommend a
+    flag whose failure mode is silent.
     """
-    if facts.cross_repo:
+    if facts.repo_relation == "unknown":
+        unknown_side = (
+            "this checkout has no `origin` remote to resolve a slug from"
+            if not facts.cwd_repo_slug else
+            "`gh` did not report which repository the PR lives in"
+        )
+        return "\n".join([
+            "## WHERE TO WORK — 🔴 COULD NOT DETERMINE — decide by hand",
+            "",
+            "This script could not establish whether the PR is in THIS "
+            f"session's repository or another one: {unknown_side}.",
+            "",
+            f"    the PR's repo     : {facts.repo}",
+            f"    this checkout     : {facts.cwd_repo_dir}"
+            + (f" (`{facts.cwd_repo_slug}`)" if facts.cwd_repo_slug else
+               " (no `origin` remote)"),
+            "",
+            f"🔴 {ISOLATION_FORBID} until that is answered. The flag builds its "
+            "worktree from the CWD's repo; if that is the wrong repo it fails "
+            "quietly — the agent either reports a briefed file missing or "
+            "silently audits the wrong tree — and this script cannot currently "
+            "rule that out. **Not knowing is not the same as same-repo**, and "
+            "the same-repo branch is the one that recommends the flag.",
+            "",
+            "Answer it, then follow the matching directive:",
+            "",
+            "```",
+            f"gh pr view {facts.pr} --json url          # the repo the PR lives in",
+            f"git -C {facts.cwd_repo_dir} remote get-url origin",
+            "```",
+            "",
+            "Or re-run this script with `--repo owner/name` to state the PR's "
+            "repository outright.",
+        ])
+    if facts.repo_relation == "cross":
         return "\n".join([
             "## WHERE TO WORK — 🔴 CROSS-REPO",
             "",
@@ -496,12 +770,36 @@ def render_range(facts):
             "",
             f"Base branch: `{facts.base_ref}`.",
         ])
+    # 🔴 `..HEAD` is only meaningful once HEAD has been shown to BE the PR's
+    # head. Unverified, the range handed to the auditor points at whatever tree
+    # the shared checkout happens to be standing on — reproduced against an
+    # unrelated feature branch, where it read as an ordinary non-empty range.
+    hc = facts.head_check
+    if hc is not None and hc.ok:
+        tip = "HEAD"
+        note = (
+            f"This checkout's HEAD is `{hc.local_sha}`, verified at assembly "
+            f"time to be PR #{facts.pr}'s head commit — which is what makes "
+            "`..HEAD` mean the PR here."
+        )
+    else:
+        tip = hc.pr_sha if (hc is not None and hc.pr_sha) else "<the PR's head sha>"
+        note = (
+            "🔴 **COULD NOT VERIFY that this checkout is standing on the PR**, "
+            "so `..HEAD` is NOT used above — it would name whatever tree the "
+            "shared checkout is on:\n\n"
+            f"    {hc.reason if hc is not None else 'no check was made'}\n\n"
+            "Resolve the range in a tree that CONTAINS the PR's head before "
+            "trusting any number derived from it."
+        )
     return "\n".join([
         "## THE RANGE",
         "",
         f"A DELTA re-audit, round {facts.round_no}. Diff **`{facts.prev_sha}"
-        "..HEAD`** — the fix commits made since the tip round "
+        f"..{tip}`** — the fix commits made since the tip round "
         f"{facts.claims_round} audited. Do not re-audit the whole PR.",
+        "",
+        note,
         "",
         f"Base branch: `{facts.base_ref}`.",
         "",
@@ -534,9 +832,32 @@ def render_checkout(facts):
 
 
 def render_toolchain(facts):
+    """🔴 The operator's checkout resolves the TOOLCHAIN and nothing else.
+
+    Every command here used to interpolate `facts.cwd_repo_dir`, including the
+    two that name the tree UNDER TEST. `scripts/gate.sh` resolves its own `ROOT`
+    from `BASH_SOURCE`, so `nix develop <shared> -c bash <shared>/scripts/
+    gate.sh` runs the suite in the SHARED CHECKOUT, on whatever branch it is
+    standing on; `nix build <shared>#checks…` builds that flake ref's tree, not
+    the auditor's. Both contradicted WHERE TO WORK three bars above, and the
+    auditor then obeyed the very next sentence — "name the tier and the base
+    sha" — and named the wrong sha.
+
+    `nix develop {r}` is deliberately left pointing at the operator's checkout:
+    that one is only resolving a dev shell (the toolchain), and it is the door
+    the repo's own CLAUDE.md tells everyone to use.
+    """
     r = facts.cwd_repo_dir
     return "\n".join([
         "## TOOLCHAIN — the exact commands, and the two ways they lie",
+        "",
+        "🔴 `<your worktree>` below is **your own copy** — the one WHERE TO WORK "
+        f"told you to make. `{r}` appears ONLY as the argument to `nix develop`, "
+        "where it resolves the dev shell and nothing else. Never point the gate "
+        "or a `nix build` at it: `gate.sh` resolves its root from its own path, "
+        "so running the shared copy runs the suite in the SHARED CHECKOUT on "
+        "whatever branch it is standing on, and a `nix build <ref>#…` builds "
+        "that ref's tree, not yours.",
         "",
         "Run a SUBSET of the suite:",
         "",
@@ -554,7 +875,7 @@ def render_toolchain(facts):
         "read each runner's own `RESULT:` line):",
         "",
         "```",
-        f"nix develop {r} -c bash {r}/scripts/gate.sh --tier both",
+        f"nix develop {r} -c bash <your worktree>/scripts/gate.sh --tier both",
         "```",
         "",
         "🔴 The gate above is the DEV-HOST tier. **The tier the merge actually "
@@ -562,8 +883,8 @@ def render_toolchain(facts):
         "`.git` and is therefore blind to different things:",
         "",
         "```",
-        f"nix build {r}#checks.x86_64-linux.pytests",
-        f"nix build {r}#checks.x86_64-linux.nodetests",
+        "nix build <your worktree>#checks.x86_64-linux.pytests",
+        "nix build <your worktree>#checks.x86_64-linux.nodetests",
         "```",
         "",
         "Name the tier and the base sha in any claim you make about the gate — "
@@ -646,12 +967,32 @@ def render_ledger(facts):
         "check.",
     ]
     if led.cumulative is None:
-        lines += [
-            "",
-            "⚠ The cumulative figure (Y, since round 1) is **NOT MEASURED**: no "
-            "`audit-claims` block carried a round-1 anchor sha. It is not "
-            "derivable from the base, which is a different quantity.",
-        ]
+        # 🔴 TWO mechanisms, and they need opposite fixes: there was no anchor
+        # sha to measure from, or there WAS one and the measurement failed. The
+        # no-anchor sentence used to be printed for both, sending an operator
+        # who already had a round-1 anchor off to add one — reproduced with a
+        # round-1 block whose `audited=` sha makes `rev-list` exit 128. Same
+        # empty-result trap this module refuses everywhere else.
+        if led.cumulative_reason:
+            lines += [
+                "",
+                "⚠ The cumulative figure (Y, since round 1) is **NOT "
+                "MEASURED** — an anchor sha WAS found, and measuring from it "
+                "failed:",
+                "",
+                f"    {led.cumulative_reason}",
+                "",
+                "So this is a broken measurement, not a missing anchor: adding "
+                "another `audit-claims` block will not fix it.",
+            ]
+        else:
+            lines += [
+                "",
+                "⚠ The cumulative figure (Y, since round 1) is **NOT "
+                "MEASURED**: no `audit-claims` block carried a round-1 anchor "
+                "sha. It is not derivable from the base, which is a different "
+                "quantity.",
+            ]
     return "\n".join(lines)
 
 
@@ -729,10 +1070,32 @@ def emit_claims_skeleton(facts, head_sha):
 
     Emitted rather than described, because the next round's assembler reads ONLY
     this shape and a hand-typed near-miss is refused.
+
+    🔴 TWO defects lived in one line here.
+
+    1. With no prior block — a round 1 `--emit-claims`, which is *the remedy the
+       refusal advertises* — `prev_sha` was None and the placeholder
+       `<the sha round 1 audited>` was interpolated INTO the header. The parser
+       then read `audited=<the`, found no `..`, and yielded `audited_from=''`,
+       `audited_to='<the'`; the next round's brief said ``Diff `<the..HEAD` ``
+       with rc 0 and no refusal at all. The parser already accepts a BARE sha as
+       the audited tip, and for round 1 that tip is exactly the quantity the
+       header carries, so the bare form is what is emitted.
+    2. `head_sha` used to be the operator checkout's `git rev-parse --short
+       HEAD` — which is only the PR's head if the shared checkout happens to be
+       standing on it, and is otherwise a record of some other branch's tip
+       going into the field the NEXT round anchors on. The caller now passes the
+       PR's own head sha.
     """
-    frm = facts.prev_sha or "<the sha round 1 audited>"
+    if facts.prev_sha:
+        audited = f"{facts.prev_sha}..{head_sha}"
+    else:
+        # Round 1: no previous tip exists, so the header carries the audited tip
+        # ALONE. `round_one_anchor` reads a round-1 bare sha as the cumulative
+        # anchor, so the ledger stays measurable from here on.
+        audited = head_sha
     return "\n".join([
-        f"```audit-claims round={facts.round_no} audited={frm}..{head_sha}",
+        f"```audit-claims round={facts.round_no} audited={audited}",
         "1. <one line per thing this round's fixes CLAIM to have addressed — "
         "WHAT was claimed, never WHY it is correct>",
         "2. <one line, same rule>",
@@ -744,15 +1107,38 @@ def emit_claims_skeleton(facts, head_sha):
 # The warn-only completeness check
 # --------------------------------------------------------------------------- #
 
-def missing_clauses(brief):
-    """Clause ids whose text is not present verbatim in `brief`.
+def _norm(text):
+    """Whitespace-normalised, so a re-wrap is not a loss but a reword is.
 
-    🔴 WARN-ONLY BY DESIGN. It exists for a `--out` file a human then edits, and
-    `claude/RULES.md` says a permanently-red gate trains everyone to click
-    through it. Blocking here would make the tool refuse to run over an edit
-    that was deliberate.
+    A hand-edited brief gets re-wrapped by editors and by paste; a clause that
+    survived the edit intact should not be reported missing because a line
+    break moved.
     """
-    return [c.id for c in INVARIANT_CLAUSES if c.text not in brief]
+    return " ".join((text or "").split())
+
+
+def missing_clauses(brief):
+    """Clause ids whose text is not present in `brief` (whitespace-normalised).
+
+    🔴 WARN-ONLY BY DESIGN. `claude/RULES.md` says a permanently-red gate trains
+    everyone to click through it, and a brief a human deliberately edited is not
+    a defect. Blocking here would make the tool refuse to run over that edit.
+
+    🔴 IT WAS ALSO UNREACHABLE. The docstring said "it exists for a hand-edited
+    `--out` file" and nothing ever read an `--out` file back: the only caller
+    passed the string `render_brief` had just built out of `INVARIANT_CLAUSES`,
+    so every clause was present BY CONSTRUCTION and the check could not fail for
+    any input a user could supply. The suite reached it only by monkeypatching
+    `render_brief` to a lossy stub — which is the `unreachable-guards` shape in
+    `claude/RULES.md`, and it mattered: the hand-written brief that dispatched
+    the audit of this very script HAD been edited, several clauses shortened and
+    the checklist paraphrased, and the shipped check could not notice.
+
+    Two real inputs now reach it: `--check FILE` (a brief someone edited) and
+    the READ-BACK of `--out` (which also catches a write that lost bytes).
+    """
+    haystack = _norm(brief)
+    return [c.id for c in INVARIANT_CLAUSES if _norm(c.text) not in haystack]
 
 
 # --------------------------------------------------------------------------- #
@@ -787,11 +1173,18 @@ def build_parser():
         prog="audit-dispatch.py",
         description="Assemble an adversarial-audit brief for a PR and print it.",
     )
-    ap.add_argument("pr", type=int, help="the PR number")
+    # `nargs="?"` exists ONLY so `--check FILE` can run with no PR at all — it
+    # inspects a file and consults neither `gh` nor `git`. Every other path
+    # still requires the number, and `main` says so rather than proceeding with
+    # `pr=None`.
+    ap.add_argument("pr", type=int, nargs="?", help="the PR number")
     ap.add_argument("--round", dest="round_no", type=int, default=1,
                     help="round number; >=2 assembles a DELTA re-audit brief")
     ap.add_argument("--repo", help="owner/name, when the PR is not in the cwd's repo")
     ap.add_argument("--out", help="write the brief to this file instead of stdout")
+    ap.add_argument("--check", metavar="FILE",
+                    help="check an EXISTING brief file for missing invariant "
+                         "clauses and exit; consults no PR and no git")
     ap.add_argument("--emit-claims", action="store_true",
                     help="also print an audit-claims block skeleton to paste "
                          "into this round's PR comment")
@@ -801,6 +1194,35 @@ def build_parser():
     return ap
 
 
+def check_brief_file(path, out_stream, err_stream):
+    """`--check FILE` — run the clause check over a brief someone EDITED.
+
+    🔴 This is what makes `missing_clauses` reachable in production. Warn-only,
+    like its in-process sibling: it reports and returns 0, because the operator
+    who edited the brief may have meant to.
+    """
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError as e:
+        print(f"cannot read --check file: {e}", file=err_stream)
+        return 2
+    gone = missing_clauses(text)
+    if gone:
+        print(
+            f"⚠ {path} is missing invariant clause(s): " + ", ".join(gone)
+            + "\n  This is a WARNING, not a refusal. Each is a clause a "
+              "hand-written brief was MEASURED to lose; re-add them, or "
+              "re-generate the brief and edit less.",
+            file=err_stream,
+        )
+    else:
+        print(
+            f"{path}: all {len(INVARIANT_CLAUSES)} invariant clause(s) present.",
+            file=out_stream,
+        )
+    return 0
+
+
 def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
          checklist_reader=None):
     # `checklist_reader` is injected by the test suite so no test depends on
@@ -808,10 +1230,16 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
     # a suite that reads the ambient home is not hermetic, and the sandbox gate
     # tier runs with a different one.
     checklist_reader = checklist_reader or _read_checklist
-    args = build_parser().parse_args(argv)
+    parser = build_parser()
+    args = parser.parse_args(argv)
     out_stream = stdout or sys.stdout
     err_stream = stderr or sys.stderr
     cwd = cwd or os.getcwd()
+
+    if args.check:
+        return check_brief_file(args.check, out_stream, err_stream)
+    if args.pr is None:
+        parser.error("the PR number is required (or use --check FILE)")
 
     repo_dir, cwd_slug = gather_repo_facts(runner, cwd)
     branch, dirty = gather_checkout_state(runner, repo_dir)
@@ -832,7 +1260,17 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
                   file=err_stream)
             return 3
 
-    repo = pr_slug(data, args.repo) or cwd_slug or "UNKNOWN/UNKNOWN"
+    # 🔴 THREE states. `pr_repo` is None when neither `url`, `isCrossRepository`
+    # nor `--repo` could answer it; falling back to `cwd_slug` there (as this
+    # did) makes the comparison compare the cwd with ITSELF and silently yields
+    # "same repo" — the branch that recommends `isolation: "worktree"`.
+    pr_repo = pr_slug(data, args.repo)
+    if pr_repo and cwd_slug:
+        repo_relation = "same" if pr_repo == cwd_slug else "cross"
+    else:
+        repo_relation = "unknown"
+    repo = pr_repo or "UNKNOWN (not reported by `gh`; pass --repo owner/name)"
+
     blocks, malformed = parse_claims_blocks(comment_texts)
     newest = newest_block(blocks)
 
@@ -858,6 +1296,12 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
             f"  looked in : {claims_source}",
             why,
             "",
+            "  ⚠ `gh pr view --json comments` returns ISSUE comments only. A "
+            "block posted as a REVIEW comment, as a reply inside a review "
+            "thread, or in the PR's own DESCRIPTION is invisible to this "
+            "script and is not counted above — check there before concluding "
+            "nobody posted one.",
+            "",
             "  An empty \"what was claimed fixed\" section silently turns a "
             "DELTA re-audit into a blind full audit — a different thing, which "
             "would then read as covered. So this is refused, not emitted.",
@@ -868,6 +1312,20 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
             "first, full audit with no --round.",
         ]), file=err_stream)
         return 2
+
+    # 🔴 A structural problem that still yielded a usable block must not be
+    # silent either. The refusal above only fires when there is NO block, so a
+    # comment holding one readable block and one unreadable fence would
+    # otherwise pass as complete.
+    if malformed and newest is not None:
+        print(
+            "⚠ the claims text held "
+            f"{len(malformed)} thing(s) this script could not read cleanly:\n  "
+            + "\n  ".join(malformed)
+            + "\n  A block WAS found and is used below — but check that the "
+              "claims it carries are all of them.",
+            file=err_stream,
+        )
 
     prev_sha = newest.audited_to if newest else None
     claims = list(newest.items) if newest else []
@@ -880,16 +1338,30 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
             file=err_stream,
         )
 
+    # 🔴 The FOURTH read rule, computed once and used by all three consumers
+    # that were measuring the operator's checkout instead of the PR: the ledger,
+    # the range section, and the `audited=` sha `--emit-claims` stamps.
+    head_check = verify_head_is_the_pr(runner, repo_dir, data.get("headRefOid"))
+
     ledger = None
     base_ref = data.get("baseRefName") or "main"
     base_for_range = f"origin/{base_ref}"
     if args.round_no >= 2 and prev_sha:
-        ledger = measure_ledger(runner, repo_dir, prev_sha, base_for_range)
+        ledger = measure_ledger(
+            runner, repo_dir, prev_sha, base_for_range, head_check
+        )
         anchor = round_one_anchor(blocks)
         if ledger.reason is None and anchor:
-            cum = measure_ledger(runner, repo_dir, anchor, base_for_range)
+            cum = measure_ledger(
+                runner, repo_dir, anchor, base_for_range, head_check
+            )
             if cum.reason is None:
                 ledger = ledger._replace(cumulative=cum.added + cum.deleted)
+            else:
+                # 🔴 Carry the REASON. Dropping it made the brief print one
+                # specific, false cause ("no block carried a round-1 anchor")
+                # for a measurement that failed with an anchor in hand.
+                ledger = ledger._replace(cumulative_reason=cum.reason)
 
     facts = Facts(
         pr=args.pr,
@@ -900,7 +1372,7 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
         round_no=args.round_no,
         cwd_repo_dir=repo_dir,
         cwd_repo_slug=cwd_slug,
-        cross_repo=bool(cwd_slug and repo and cwd_slug != repo),
+        repo_relation=repo_relation,
         branch=branch,
         dirty=dirty,
         prev_sha=prev_sha,
@@ -910,22 +1382,10 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
         ledger=ledger,
         assembled_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%MZ"),
         claims_source=claims_source,
+        head_check=head_check,
     )
 
     brief = render_brief(facts)
-
-    # ------------------------------------------------------------------ #
-    # REFUSAL 2's opposite number: WARN, never block.
-    # ------------------------------------------------------------------ #
-    gone = missing_clauses(brief)
-    if gone:
-        print(
-            "⚠ the assembled brief is missing invariant clause(s): "
-            + ", ".join(gone)
-            + "\n  This is a WARNING, not a refusal — the brief is still "
-              "emitted. Re-add them by hand, or re-run without --out edits.",
-            file=err_stream,
-        )
 
     if args.out:
         Path(args.out).write_text(brief, encoding="utf-8")
@@ -933,9 +1393,57 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
     else:
         print(brief, file=out_stream)
 
+    # ------------------------------------------------------------------ #
+    # REFUSAL 2's opposite number: WARN, never block.
+    # ------------------------------------------------------------------ #
+    # 🔴 Checked against what is ON DISK when there is a disk copy, not against
+    # the string just built. Checking the in-memory brief could only ever pass:
+    # it was rendered FROM `INVARIANT_CLAUSES` a few lines earlier, so every
+    # clause was present by construction and this warning was unreachable for
+    # any input a user could supply. The read-back also catches a write that
+    # lost bytes. `--check FILE` is the other real input.
+    checked_what, checked_text = "the assembled brief", brief
+    if args.out:
+        try:
+            checked_text = Path(args.out).read_text(encoding="utf-8")
+            checked_what = args.out
+        except OSError as e:
+            print(f"⚠ could not re-read {args.out} to check it: {e}",
+                  file=err_stream)
+    gone = missing_clauses(checked_text)
+    if gone:
+        print(
+            f"⚠ {checked_what} is missing invariant clause(s): "
+            + ", ".join(gone)
+            + "\n  This is a WARNING, not a refusal — the brief is still "
+              "emitted. Re-add them by hand, or re-run without --out edits.",
+            file=err_stream,
+        )
+
     if args.emit_claims:
-        rc, head, _ = runner(["git", "-C", repo_dir, "rev-parse", "--short", "HEAD"])
-        head_sha = head.strip() if rc == 0 and head.strip() else "<HEAD sha>"
+        # 🔴 The PR's OWN head, never the shared checkout's. This sha is what
+        # the NEXT round anchors its range and its ledger on, so stamping the
+        # local HEAD here recorded whatever branch this checkout was standing
+        # on — `main`'s tip, in the reproduction — as the sha this round
+        # audited.
+        head_sha = (data.get("headRefOid") or "")[:8]
+        if not head_sha:
+            head_sha = "<the PR's head sha>"
+            print(
+                "⚠ --emit-claims could not read the PR's head sha "
+                "(`headRefOid`), so the block below carries a PLACEHOLDER. "
+                "Replace it with the sha this round actually audited before "
+                "posting — the next round reads this field and refuses on a "
+                "near-miss.",
+                file=err_stream,
+            )
+        elif not head_check.ok:
+            print(
+                "⚠ --emit-claims stamped the PR's head sha, which is correct — "
+                "but this checkout is NOT standing on it, so re-read the claims "
+                f"you are about to write: {head_check.reason}",
+                file=err_stream,
+            )
         print("\n" + _bar(), file=out_stream)
         print("Paste this into the PR comment for this round, so the NEXT "
               "round can read it:\n", file=out_stream)

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -264,9 +264,16 @@ INVARIANTS_HEADING = "## 🔴 NON-NEGOTIABLE — every audit, every round"
 # edit.
 #
 # 🔴 THE MEASURED INVERSIONS, which is a different and checkable claim. Each
-# was applied ALONE against the whole audit-related suite and the result
-# recorded. This list is closed only over what has been MEASURED; it is not a
-# claim that nothing else is invertible.
+# was applied ALONE and the result recorded. This list is closed only over what
+# has been MEASURED; it is not a claim that nothing else is invertible.
+#
+# 🔴 TWO SCOPES, NAMED, because they are not the same measurement. Y1 and Y2
+# were re-measured HERE rather than restated from the audit that found them:
+# each inversion applied alone to `e06461f7`'s script, with `e06461f7`'s test
+# module, leaves that module's own **72 passed** fully green — a claim about
+# THIS module, not about the ~199 audit-related tests the round-4 audit ran,
+# which were not re-run for this line. Y3-Y5 are measured continuously instead,
+# by their `HOLE` rows in the mutation harness, against the CURRENT tree.
 #
 #   Y1  the delta-scope sentence "Do not re-audit the whole PR"   -> green
 #       inverted to "Re-audit the whole PR as well". It defines the round's

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -519,11 +519,29 @@ SECTION_DIRECTIVES = (
     # The first sentence names the CLONE as well as the worktree because that
     # is the tree the recipe actually writes to: `git -C <clone> worktree add`
     # is a write to the clone, before the worktree it grants exists.
+    #
+    # 🔴 ROUND 10 — BUT IT GRANTED FAR MORE THAN THE RECIPE NEEDS, AND IN THE
+    # ONE TREE WITH REAL BLAST RADIUS. Round 8 widened "fetching and checking
+    # out inside IT" to "inside EITHER", i.e. into the clone — while the recipe
+    # three lines above spells that clone `<your local clone of owner/name>`,
+    # which on this host resolves in practice to `~/workspace/<repo>`, a
+    # long-lived tree other sessions are working in. `worktree add` is the only
+    # write the recipe performs there; `fetch` and `checkout` are exactly the
+    # cross-session writes the `no-fetch` clause exists to prevent, and this
+    # directive was authorising them by name.
+    #
+    # "The clone YOU made" arguably excludes those trees already — but nothing
+    # in the brief disambiguated it and the placeholder invites the
+    # substitution, so the grant is stated as the OPERATION it covers rather
+    # than as an adjective on the tree. The forward-reference sentence is
+    # unchanged and still spells `NO_WRITE_SCOPE`.
     Directive(
         "own-worktree-is-writable",
-        "That worktree is YOURS, and so is the clone you made it from: "
-        "fetching and checking out inside either is fine. The no-write rule "
-        "below is about every checkout you did not make.",
+        "That worktree is YOURS: fetching and checking out inside it is fine. "
+        "In the clone you made it from, `git worktree add` is the ONLY write "
+        "this brief asks for — do not `fetch`, `pull` or `checkout` there, "
+        "whoever made it, because other sessions may be standing in it. The "
+        "no-write rule below is about every checkout you did not make.",
     ),
 )
 
@@ -870,8 +888,19 @@ Facts = namedtuple(
     "Facts",
     "pr repo title base_ref url round_no cwd_repo_dir cwd_repo_slug repo_relation "
     "worktree branch dirty prev_sha emit_from claims claims_round checklist "
-    "ledger assembled_at claims_source head_check",
+    "ledger assembled_at claims_source head_check base_assumed",
 )
+# 🔴 `base_assumed` — ROUND 10's SEVENTH INSTANCE, found by the sweep round 9's
+# auditor asked for and not by a finding. `base_ref` is
+# `data.get("baseRefName") or "main"`: a DEFAULT, and every site printing it
+# presented it as a MEASUREMENT. Measured at `706a6b38` with `baseRefName`
+# absent, rc 0 and silent stderr, THE LEDGER's cross-repo hand-over read
+# "…where `origin/main` names THAT repository's base branch and not this
+# checkout's" — an assertion about a repository nothing was asked about.
+# `--claims-file` mode reaches it on EVERY run: it consults no `gh` and
+# hardcodes `baseRefName: "main"`, exactly as it hardcodes no `headRefOid`,
+# and that second omission already carries a reason string while this one did
+# not. Same shape as finding A one field over.
 # 🔴 `prev_sha` and `emit_from` are TWO ANCHORS out of ONE `audited=` field, and
 # they are deliberately separate fields rather than one: `prev_sha` is
 # `range_anchor` (what this round DIFFS FROM) and `emit_from` is `emit_anchor`
@@ -1387,6 +1416,20 @@ def render_claims(facts):
     return "\n".join(lines)
 
 
+# 🔴 THE ONE SPELLING OF "this script never learned the PR's head commit".
+# Written into a rev spec by `range_tip` and into an `audited=` header by
+# `--emit-claims`, and it is NOT a sha: every site that PRINTS it has to say so,
+# which is what `range_tip_is_a_sha` and `unresolved_tip_note` below are for.
+# Open-coded at the two sites it was one reword away from two different
+# placeholders, only one of which any guard could recognise.
+TIP_PLACEHOLDER = "<the PR's head sha>"
+
+# 🔴 `facts.repo` when NOTHING answered which repository the PR lives in. A
+# sentinel and not a slug, so no command may interpolate it: `gh pr view 900
+# --repo UNKNOWN (not reported by ...)` is a shell error, not a lookup.
+REPO_UNKNOWN = "UNKNOWN (not reported by `gh`; pass --repo owner/name)"
+
+
 def range_tip(facts):
     """🔴 The commit the delta range ENDS at — ONE PREDICATE, ONE PLACE.
 
@@ -1413,7 +1456,120 @@ def range_tip(facts):
     hc = facts.head_check
     if hc is not None and hc.ok:
         return hc.local_sha
-    return hc.pr_sha if (hc is not None and hc.pr_sha) else "<the PR's head sha>"
+    return hc.pr_sha if (hc is not None and hc.pr_sha) else TIP_PLACEHOLDER
+
+
+def range_tip_is_a_sha(facts):
+    """Does `range_tip` name a COMMIT, or the literal placeholder?
+
+    🔴 ROUND 10 — THE TIP END OF ROUND 8's REFUSAL 1b, AND IT IS THE SAME
+    DEFECT. `range_tip` answers `TIP_PLACEHOLDER` whenever the PR's head sha was
+    never learned — a state this script MODELS, with its own reason string — and
+    two sites interpolate that answer straight into a git rev spec: THE RANGE's
+    ``Diff `<anchor>..<tip>` `` and THE LEDGER's cross-repo hand-over. Measured
+    at `706a6b38`, cross-repo + no `headRefOid`, rc 0 and silent stderr:
+
+        Diff **`28492af2..<the PR's head sha>`**
+        …
+        So the range above names the PR's head SHA outright — read from
+        `gh pr view --json headRefOid` …
+
+    two sentences after the brief's own explanation that this run never learned
+    that field, and under THE LEDGER's "THE ATTRIBUTION GATE IS YOURS THIS
+    ROUND — it is not optional" the same token appears inside a `git log` the
+    auditor is told to run. `newest is not None` was read as "we have an
+    anchor"; `repo_relation == "cross"` was read as "we have a tip". Both are
+    the same mistake — a WEAKER fact read as a STRONGER one.
+    """
+    return range_tip(facts) != TIP_PLACEHOLDER
+
+
+def unresolved_tip_note(facts, with_reason=True):
+    """The block EVERY site printing `range_tip` must carry when it is no sha.
+
+    🔴 ONE RULE, ONE PLACE, THREE CONSUMERS — THE RANGE's cross-repo branch,
+    THE RANGE's could-not-verify branch, and THE LEDGER's cross-repo hand-over.
+    Open-coded it would be right at the site the finding was filed against and
+    absent at the siblings, which is the shape rounds 3, 5, 7, 8 and 9 each
+    found somewhere else in this module.
+
+    Empty string when the tip IS a sha, so a caller can concatenate it
+    unconditionally and cannot forget the conditional. `with_reason=False` for
+    the callers that have ALREADY printed `hc.reason` a few lines above — both
+    RANGE branches do; the same string twice in a row reads as two different
+    facts. THE LEDGER's hand-over prints it nowhere else, so it takes the
+    default.
+    """
+    if range_tip_is_a_sha(facts):
+        return ""
+    hc = facts.head_check
+    lookup = f"gh pr view {facts.pr} --json headRefOid"
+    if facts.repo != REPO_UNKNOWN:
+        lookup += f" --repo {facts.repo}"
+    reason = (
+        f"\n\n    {hc.reason if hc is not None else 'no check was made'}\n\n"
+        if with_reason else " "
+    )
+    return (
+        "🔴 **THE TIP OF THAT RANGE IS A PLACEHOLDER, NOT A SHA — the range as "
+        "printed CANNOT BE RUN, and neither can any command below that repeats "
+        f"it.** `{TIP_PLACEHOLDER}` is literal text, not a commit: this run "
+        "never learned the PR's head."
+        + reason
+        + f"Resolve it yourself — `{lookup}` — and substitute the sha "
+        "everywhere this brief spells that placeholder before diffing or "
+        "measuring anything. A command carrying it is not a command that "
+        "returned zero; it is one that never ran."
+    )
+
+
+def assumed_base_note(facts):
+    """The block every site printing `base_ref` must carry when it was GUESSED.
+
+    Empty when the PR's base branch was actually read, so a caller concatenates
+    it unconditionally — the same shape as `unresolved_tip_note`, and for the
+    same reason: a conditional a caller has to remember is one a caller forgets
+    at the second site.
+    """
+    if not facts.base_assumed:
+        return ""
+    return (
+        "🔴 **THAT BASE BRANCH WAS ASSUMED, NOT READ.** `gh` reported no "
+        f"`baseRefName` for this PR, so `{facts.base_ref}` is this script's "
+        "DEFAULT and not a fact about the PR. The base is what the PR is "
+        "diffed against and — from round 2 — what `--not <base>` subtracts "
+        "when the payload figure is measured, so a wrong one silently changes "
+        "what you read, at rc 0. Check the PR's real base branch before "
+        "believing any figure derived from it."
+    )
+
+
+def cross_repo_holds_neither_end(facts):
+    """This checkout holds NEITHER end of the range — ONE PREDICATE, ONE PLACE.
+
+    🔴 ROUND 10 — TWO CONSUMERS, AND THE SECOND ONE DID NOT ADOPT THE FIRST'S
+    ORDERING. `render_range`'s cross-repo branch is ordered after the `hc.ok`
+    branch on purpose, and its comment says why: `repo_relation` compares
+    SLUGS, and a clone whose `origin` names a different repository can still
+    hold the PR's head commit (a renamed remote, a mirror). The sha is the
+    ground truth. `render_ledger` asked `repo_relation == "cross"` alone.
+
+    Measured at `706a6b38` in exactly that state (cross-repo PR, the assembly
+    checkout standing on the PR's head, round 3, rc 0, silent stderr): the
+    ledger MEASURED — 4 commits, 13 added, 2 deleted — and threw the numbers
+    away to print "which holds neither end of the range", two bars under THE
+    RANGE's "verified at assembly time to be PR #900's head commit". Every
+    clause of that sentence was false and the two sections contradicted each
+    other inside one document.
+
+    So the question both sites ask is this one, and it asks the head check
+    FIRST: claim the structural impossibility only once the sha comparison has
+    actually failed.
+    """
+    hc = facts.head_check
+    if hc is not None and hc.ok:
+        return False
+    return facts.repo_relation == "cross"
 
 
 def render_range(facts):
@@ -1426,7 +1582,7 @@ def render_range(facts):
             "description.",
             "",
             f"Base branch: `{facts.base_ref}`.",
-        ])
+        ] + (["", assumed_base_note(facts)] if facts.base_assumed else []))
     # 🔴 `..HEAD` is only meaningful once HEAD has been shown to BE the PR's
     # head. Unverified, the range handed to the auditor points at whatever tree
     # the shared checkout happens to be standing on — reproduced against an
@@ -1510,7 +1666,26 @@ def render_range(facts):
     # can still hold the PR's head commit (a clone with a renamed remote, a
     # mirror). The sha is the ground truth; this branch only claims the
     # structural impossibility once the sha comparison has actually failed.
-    elif facts.repo_relation == "cross":
+    #
+    # 🔴 ROUND 10 — AND IT ASKS THAT ORDERING THROUGH A SHARED PREDICATE NOW.
+    # `render_ledger` re-derived the same decision from `repo_relation` alone
+    # and got it wrong for the renamed-remote clone; see
+    # `cross_repo_holds_neither_end`.
+    elif cross_repo_holds_neither_end(facts):
+        # 🔴 ROUND 10 — THE SECOND SENTENCE IS CONDITIONAL, BECAUSE THE FACT IT
+        # ASSERTS IS. "the range above names the PR's head SHA outright" was
+        # unconditional, and `range_tip` hands out a PLACEHOLDER whenever the
+        # head sha was never learned — so the brief said "read from `gh pr view
+        # --json headRefOid`" two sentences after explaining that this run never
+        # read that field.
+        tail = (
+            "So the range above names the PR's head SHA outright — read from "
+            "`gh pr view --json headRefOid`, not resolved in any tree. Both of "
+            "its ends exist in YOUR worktree, the one WHERE TO WORK told you to "
+            "make, and neither exists here."
+            if range_tip_is_a_sha(facts)
+            else unresolved_tip_note(facts, with_reason=False)
+        )
         note = (
             "🔴 **THIS CHECKOUT CANNOT BE STANDING ON THE PR — that is "
             "STRUCTURAL AND PERMANENT, not a checkout that moved.** WHERE TO "
@@ -1521,12 +1696,13 @@ def render_range(facts):
             "not go looking for one, and do not report this as a finding "
             "against the PR:\n\n"
             f"    {hc.reason if hc is not None else 'no check was made'}\n\n"
-            "So the range above names the PR's head SHA outright — read from "
-            "`gh pr view --json headRefOid`, not resolved in any tree. Both of "
-            "its ends exist in YOUR worktree, the one WHERE TO WORK told you to "
-            "make, and neither exists here."
+            + tail
         )
     else:
+        # 🔴 ROUND 10 — THE PLACEHOLDER REACHES THIS BRANCH TOO. It is the
+        # SAME-REPO spelling of the same state (no `headRefOid`), and the
+        # widest reading of the finding is about `range_tip`'s answer, not
+        # about the cross-repo branch that happened to be filed against.
         note = (
             "🔴 **COULD NOT VERIFY that this checkout is standing on the PR**, "
             "so `..HEAD` is NOT used above — it would name whatever tree the "
@@ -1535,6 +1711,12 @@ def render_range(facts):
             "Resolve the range in a tree that CONTAINS the PR's head before "
             "trusting any number derived from it."
         )
+        # `with_reason=False` for the same reason the cross branch passes it:
+        # `hc.reason` is already printed four lines above, and the same string
+        # twice in a row reads as two different facts.
+        tip_note = unresolved_tip_note(facts, with_reason=False)
+        if tip_note:
+            note += "\n\n" + tip_note
     return "\n".join([
         "## THE RANGE",
         "",
@@ -1553,6 +1735,7 @@ def render_range(facts):
         "",
         f"Base branch: `{facts.base_ref}`.",
         "",
+    ] + ([assumed_base_note(facts), ""] if facts.base_assumed else []) + [
         directive("delta-regressions"),
     ])
 
@@ -1714,7 +1897,25 @@ def render_ledger(facts):
     # WHERE it must run, and says out loud that the gate is the auditor's to
     # compute this round. Ordered before every other branch except round 1,
     # which has no ledger for a reason that has nothing to do with repos.
-    if facts.round_no >= 2 and facts.repo_relation == "cross":
+    #
+    # 🔴 ROUND 10 — AND IT NOW ASKS `cross_repo_holds_neither_end`, NOT
+    # `repo_relation` ALONE. `render_range`'s comment already said why the
+    # cross-repo branch must be ordered after the head check: the relation
+    # compares SLUGS, and a renamed remote or a mirror can name a different
+    # repository while holding the PR's head commit. This site did not adopt
+    # that ordering, so in exactly that state it DISCARDED a successful
+    # measurement to print "which holds neither end of the range" — under a
+    # RANGE section that had just said "verified at assembly time". One rule,
+    # two places, wrong at the second.
+    if facts.round_no >= 2 and cross_repo_holds_neither_end(facts):
+        # 🔴 ROUND 10 — THE HAND-OVER IS THE LOUDEST COMMAND IN THE BRIEF ("it
+        # is not optional and nobody else can compute it") and it repeats
+        # `range_tip`, so when that tip is a PLACEHOLDER the auditor is handed a
+        # `git log` that cannot run, under a banner telling them it is
+        # mandatory. The note goes IMMEDIATELY above the fence, not at the end
+        # of the section, because the fence is what gets copied.
+        tip_note = unresolved_tip_note(facts)
+        base_note = assumed_base_note(facts)
         return "\n".join(lines + [
             "🔴 **NOT MEASURABLE FROM HERE — and that is STRUCTURAL, so it is "
             "true of every round of this PR and not a failure of this run.** "
@@ -1732,6 +1933,9 @@ def render_ledger(facts):
             f"of YOUR clone of `{facts.repo}`, where `{facts.base_ref}` names "
             "THAT repository's base branch and not this checkout's:",
             "",
+        ] + ([tip_note, ""] if tip_note else []) + (
+            [base_note, ""] if base_note else []
+        ) + [
             "```",
             "git -C <your worktree> log --numstat --format= --remerge-diff "
             f"{facts.prev_sha}..{range_tip(facts)} --not {facts.base_ref}",
@@ -1830,7 +2034,7 @@ def render_ledger(facts):
         "a checkout it does not own), so a stale base re-reports upstream work "
         "as this round's payload. If the number looks large, that is the first "
         "thing to check.",
-    ]
+    ] + ([""] + [assumed_base_note(facts)] if facts.base_assumed else [])
     if led.cumulative is None:
         # 🔴 TWO mechanisms, and they need opposite fixes: there was no anchor
         # sha to measure from, or there WAS one and the measurement failed. The
@@ -2384,10 +2588,42 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
         repo_relation = "same" if pr_repo == cwd_slug else "cross"
     else:
         repo_relation = "unknown"
-    repo = pr_repo or "UNKNOWN (not reported by `gh`; pass --repo owner/name)"
+    repo = pr_repo or REPO_UNKNOWN
 
     blocks, malformed = parse_claims_blocks(comment_texts)
     newest = newest_block(blocks)
+
+    # 🔴 ROUND 10 — A REFUSAL THAT PRESCRIBES A COMMAND MUST NOT REFUSE THAT
+    # COMMAND. Both refusals below hand the operator a `--emit-claims` re-run as
+    # their mechanical remedy, and both then refused it, byte for byte, because
+    # the refusal is ordered before the emit half and reads the SAME unreadable
+    # block. Measured at `706a6b38`:
+    #
+    #   REFUSAL 1b, over a `round=2` block whose header is `audited=..`
+    #     `… 900 --round 3`                                   -> rc 2
+    #     `… 900 --round 2 --emit-claims --audited abc12345`  -> rc 2, the same
+    #                                                            refusal, empty
+    #                                                            stdout
+    #   REFUSAL 1, at round 3 with no block at all
+    #     `… 900 --round 3`                                   -> rc 2
+    #     `… 900 --round 2 --emit-claims`                     -> rc 2
+    #
+    # (REFUSAL 1's remedy is sound at round 2 — `--round 1 --emit-claims` needs
+    # no block. It is unrunnable from round 3 up, and the operator reads the
+    # repeat as their own typo.)
+    #
+    # The two halves of a run are INDEPENDENT: rendering a DELTA brief needs an
+    # anchor to diff from, and emitting a block needs only a head sha and a
+    # `<from>` the operator supplies. So the refusal keeps its scope — no brief
+    # is emitted and the rc is unchanged — and the run CONTINUES to the emit,
+    # printing the very block the remedy promised. Ordered this way rather than
+    # by rewriting the remedy into prose, for the reason every other refusal
+    # here cites: a mechanical path a machine can run beats a sentence a human
+    # has to interpret.
+    #
+    # `brief_refused` doubles as the return code, so an emit-side refusal
+    # (rc 4) still wins — it is a different failure and needs a different fix.
+    brief_refused = None
 
     # ------------------------------------------------------------------ #
     # 🔴 REFUSAL 1 — a delta round with nothing to be framed on.
@@ -2422,11 +2658,15 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
             "would then read as covered. So this is refused, not emitted.",
             "",
             f"  Fix: run `audit-dispatch.py {args.pr} --round "
-            f"{args.round_no - 1} --emit-claims`, fill the skeleton in, and "
-            "post it as a comment on the PR. Or run this round as an explicit "
-            "first, full audit with no --round.",
+            f"{args.round_no - 1} --emit-claims --audited <the tip that round "
+            "read>`, fill the skeleton in, and post it as a comment on the PR. "
+            "That run refuses its own brief for this same reason and STILL "
+            "prints the block — the two halves are independent. Or run this "
+            "round as an explicit first, full audit with no --round.",
         ]), file=err_stream)
-        return 2
+        if not args.emit_claims:
+            return 2
+        brief_refused = 2
 
     # 🔴 A structural problem that still yielded a usable block must not be
     # silent either. The refusal above only fires when there is NO block, so a
@@ -2501,9 +2741,14 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
             "<from>..<to>`, or re-run "
             f"`audit-dispatch.py {args.pr} --round {newest.round_no} "
             "--emit-claims --audited <the tip that round read>` and post the "
-            "block it prints.",
+            "block it prints. That run refuses its own brief for this same "
+            "reason — it reads the same unreadable header — and STILL prints "
+            "the block, because emitting one needs the sha you just supplied "
+            "and nothing from the comment.",
         ]), file=err_stream)
-        return 2
+        if not args.emit_claims:
+            return 2
+        brief_refused = 2
 
     # 🔴 `--audited` OVERRIDES THE WRITER'S ANCHOR AND NEVER THE READER'S. It
     # states the tip THIS round's audit read — the same quantity `emit_anchor`
@@ -2556,7 +2801,11 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
     )
 
     ledger = None
+    # 🔴 ROUND 10 — THE DEFAULT IS RECORDED, not silently indistinguishable from
+    # a reading. `or "main"` is a guess, and `--not <base>` is what decides which
+    # commits count as this round's payload.
     base_ref = data.get("baseRefName") or "main"
+    base_assumed = not data.get("baseRefName")
     base_for_range = f"origin/{base_ref}"
     if args.round_no >= 2 and prev_sha:
         ledger = measure_ledger(
@@ -2597,42 +2846,50 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
         assembled_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%MZ"),
         claims_source=claims_source,
         head_check=head_check,
+        base_assumed=base_assumed,
     )
 
-    brief = render_brief(facts)
+    # 🔴 THE REFUSAL'S SCOPE IS THE BRIEF, AND ONLY THE BRIEF. A refused run
+    # renders nothing, writes no `--out` file and runs no clause check over a
+    # document that does not exist — it falls straight through to the emit half
+    # below, which is the remedy the refusal just prescribed.
+    if brief_refused is None:
+        brief = render_brief(facts)
 
-    if args.out:
-        Path(args.out).write_text(brief, encoding="utf-8")
-        print(f"wrote {len(brief):,} chars to {args.out}", file=err_stream)
-    else:
-        print(brief, file=out_stream)
+        if args.out:
+            Path(args.out).write_text(brief, encoding="utf-8")
+            print(f"wrote {len(brief):,} chars to {args.out}", file=err_stream)
+        else:
+            print(brief, file=out_stream)
 
-    # ------------------------------------------------------------------ #
-    # REFUSAL 2's opposite number: WARN, never block.
-    # ------------------------------------------------------------------ #
-    # 🔴 Checked against what is ON DISK when there is a disk copy, not against
-    # the string just built. Checking the in-memory brief could only ever pass:
-    # it was rendered FROM `INVARIANT_CLAUSES` a few lines earlier, so every
-    # clause was present by construction and this warning was unreachable for
-    # any input a user could supply. The read-back also catches a write that
-    # lost bytes. `--check FILE` is the other real input.
-    checked_what, checked_text = "the assembled brief", brief
-    if args.out:
-        try:
-            checked_text = Path(args.out).read_text(encoding="utf-8")
-            checked_what = args.out
-        except OSError as e:
-            print(f"⚠ could not re-read {args.out} to check it: {e}",
-                  file=err_stream)
-    gone = missing_clauses(checked_text)
-    if gone:
-        print(
-            f"⚠ {checked_what} is missing invariant clause(s): "
-            + ", ".join(gone)
-            + "\n  This is a WARNING, not a refusal — the brief is still "
-              "emitted. Re-add them by hand, or re-run without --out edits.",
-            file=err_stream,
-        )
+        # -------------------------------------------------------------- #
+        # REFUSAL 2's opposite number: WARN, never block.
+        # -------------------------------------------------------------- #
+        # 🔴 Checked against what is ON DISK when there is a disk copy, not
+        # against the string just built. Checking the in-memory brief could
+        # only ever pass: it was rendered FROM `INVARIANT_CLAUSES` a few lines
+        # earlier, so every clause was present by construction and this warning
+        # was unreachable for any input a user could supply. The read-back also
+        # catches a write that lost bytes. `--check FILE` is the other real
+        # input.
+        checked_what, checked_text = "the assembled brief", brief
+        if args.out:
+            try:
+                checked_text = Path(args.out).read_text(encoding="utf-8")
+                checked_what = args.out
+            except OSError as e:
+                print(f"⚠ could not re-read {args.out} to check it: {e}",
+                      file=err_stream)
+        gone = missing_clauses(checked_text)
+        if gone:
+            print(
+                f"⚠ {checked_what} is missing invariant clause(s): "
+                + ", ".join(gone)
+                + "\n  This is a WARNING, not a refusal — the brief is still "
+                  "emitted. Re-add them by hand, or re-run without --out "
+                  "edits.",
+                file=err_stream,
+            )
 
     if args.emit_claims:
         # 🔴 The PR's OWN head, never the shared checkout's. This sha is what
@@ -2642,7 +2899,7 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
         # audited.
         head_sha = (data.get("headRefOid") or "")[:8]
         if not head_sha:
-            head_sha = "<the PR's head sha>"
+            head_sha = TIP_PLACEHOLDER
             print(
                 "⚠ --emit-claims could not read the PR's head sha "
                 "(`headRefOid`), so the block below carries a PLACEHOLDER. "
@@ -2745,7 +3002,18 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
         print("Paste this into the PR comment for this round, so the NEXT "
               "round can read it:\n", file=out_stream)
         print(skeleton, file=out_stream)
-    return 0
+        if brief_refused is not None:
+            # 🔴 SAID AT THE POINT THE OPERATOR IS LOOKING, not only in the
+            # refusal scrolled off above: this run printed a BLOCK and no
+            # BRIEF, and it exits non-zero for the brief it withheld.
+            print(
+                "⚠ this run emitted the block above and NO BRIEF — the "
+                "refusal printed earlier still stands and it exits "
+                f"{brief_refused}. Post the block, then re-run the round you "
+                "actually wanted.",
+                file=err_stream,
+            )
+    return brief_refused if brief_refused is not None else 0
 
 
 if __name__ == "__main__":

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -194,14 +194,30 @@ INVARIANT_CLAUSES = (
     # switched itself off over a tree that belongs to the dispatching session.
     # The rule that is true in every state is the one about OWNERSHIP: write
     # only to the copy you made.
+    #
+    # 🔴 ROUND 8 — "FOR THIS AUDIT" WAS A SECOND, SMALLER NARROWING, AND IT
+    # FORBADE THE BRIEF'S OWN RECIPE. Round 5 moved this clause off SHAREDNESS
+    # onto ownership and round 7 rewrote the sentence that forward-references it
+    # to say "every checkout you did not make" — a DIFFERENT set, and the
+    # difference lands exactly on the tree WHERE TO WORK tells a cross-repo
+    # auditor to write to: `git -C <your local clone of owner/name> worktree
+    # add …`. That clone is one they made, but not one they made FOR THIS
+    # AUDIT, so the clause forbade the operation the brief had just prescribed
+    # two lines earlier while the forward reference allowed it. Round 6's
+    # finding was a forward reference that narrowed the rule it names; round 7's
+    # fix replaced one narrowing with another on a different axis.
+    #
+    # So both sides now spell ONE set — `NO_WRITE_SCOPE` in the test module
+    # pins that phrase in the clause AND in every forward reference, so a
+    # reword on either side alone fails rather than re-opening the gap.
     Clause(
         "no-fetch",
         "**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to any "
-        "checkout that is not the copy YOU made for this audit — including the "
-        "one THE CHECKOUT section names, which is where this brief was "
-        "assembled and is not yours.** Other sessions are in those trees; a "
-        "fetch there is a write with cross-session blast radius, and every ref "
-        "you need is already resolved for you here.",
+        "checkout you did not make — including the one THE CHECKOUT section "
+        "names, which is where this brief was assembled and is not yours.** "
+        "Other sessions are in those trees; a fetch there is a write with "
+        "cross-session blast radius, and every ref you need is already "
+        "resolved for you here.",
     ),
     Clause(
         "stop-rule",
@@ -487,12 +503,27 @@ SECTION_DIRECTIVES = (
     # 5 deleted, surviving one directive over: the reader can discharge the
     # no-write rule on the grounds that this checkout is not shared.
     #
-    # So the scope is stated the way the clause states it — by OWNERSHIP, which
-    # is true in every checkout state and cannot be discharged by one.
+    # So the scope is stated by OWNERSHIP, which is true in every checkout
+    # state and cannot be discharged by one.
+    #
+    # 🔴 ROUND 8 — AND IT IS NOW THE CLAUSE'S OWN WORDS, NOT MERELY ITS AXIS.
+    # Round 7's comment here read "the scope is stated the way the clause
+    # states it", which was a claim ABOUT THE CLAUSE and was false: the clause
+    # said "the copy YOU made FOR THIS AUDIT" and this sentence said "every
+    # checkout you did not make". Two sets, differing on precisely the clone
+    # the recipe three lines above writes into. `no-fetch` dropped the extra
+    # narrowing, this sentence is unchanged, and both are pinned to the one
+    # phrase `NO_WRITE_SCOPE` — so the guard fails if either side moves alone,
+    # instead of only when a CHECKOUT STATE WORD appears.
+    #
+    # The first sentence names the CLONE as well as the worktree because that
+    # is the tree the recipe actually writes to: `git -C <clone> worktree add`
+    # is a write to the clone, before the worktree it grants exists.
     Directive(
         "own-worktree-is-writable",
-        "That worktree is YOURS: fetching and checking out inside it is fine. "
-        "The no-write rule below is about every checkout you did not make.",
+        "That worktree is YOURS, and so is the clone you made it from: "
+        "fetching and checking out inside either is fine. The no-write rule "
+        "below is about every checkout you did not make.",
     ),
 )
 
@@ -1356,6 +1387,35 @@ def render_claims(facts):
     return "\n".join(lines)
 
 
+def range_tip(facts):
+    """🔴 The commit the delta range ENDS at — ONE PREDICATE, ONE PLACE.
+
+    Read by THE RANGE, which prints it, and by THE LEDGER, which hands it to a
+    cross-repo auditor as part of the command only they can run. Open-coded at
+    both sites it would be wrong at one of them in the same direction, which is
+    `claude/RULES.md` -> consolidation-finds-bugs.
+
+    🔴 IT NEVER RETURNS `HEAD`, and round 8 is where the last caller stopped.
+    Round 7 moved the VERIFIED branch off the token and wrote "Only the
+    VERIFIED branch hardcoded `HEAD`" — while the DEGENERATE branch, four lines
+    above it in the same `if`/`elif`, still handed one out. `HEAD` resolves in
+    the AUDITOR's tree, which is cut after this brief is assembled from a
+    repository other sessions push to; a sha cannot move under them. That
+    argument never depended on which branch produced the range.
+
+    The degenerate case needs no special tip at all: `anchor_is_head` is only
+    true when the head check PASSED, so `local_sha` is the verified PR head and
+    the range renders as `<anchor>..<the commit the anchor abbreviates>` —
+    visibly, and PERMANENTLY, a self-range. That is what makes the banner's
+    "it can never contain anything, whatever the PR looks like" true in the
+    auditor's tree and not merely in this one.
+    """
+    hc = facts.head_check
+    if hc is not None and hc.ok:
+        return hc.local_sha
+    return hc.pr_sha if (hc is not None and hc.pr_sha) else "<the PR's head sha>"
+
+
 def render_range(facts):
     if facts.round_no < 2:
         return "\n".join([
@@ -1379,18 +1439,22 @@ def render_range(facts):
     # "Do not re-audit the whole PR". An auditor obeying that diffs nothing,
     # finds nothing, and the stop-rule clause turns the empty result into "the
     # ladder ENDS". The banner is loud because the failure is silent.
+    tip = range_tip(facts)
     if anchor_is_head(facts.prev_sha, hc):
-        tip = "HEAD"
         note = (
             "🔴 **DEGENERATE RANGE — EMPTY BY CONSTRUCTION. DO NOT AUDIT IT AND "
             "DO NOT REPORT IT CLEAN.**\n\n"
             f"    the anchor `{facts.prev_sha}` IS this checkout's HEAD "
             f"({hc.local_sha})\n\n"
             "Both ends of the range name the same commit, so it can never "
-            "contain anything, whatever the PR looks like. A finding-free pass "
-            "over this range is a fact about the RANGE and is NOT evidence "
-            "about the code — do not let the stop-rule clause below convert it "
-            "into \"the ladder ENDS\".\n\n"
+            "contain anything, whatever the PR looks like — and BOTH ends are "
+            "spelled as shas, so that sentence is true in YOUR tree too. It "
+            "was not while this branch handed out `..HEAD`: that token resolves "
+            "where you are standing, so a commit landing between assembly and "
+            "your audit made the range non-empty and the claim above false. A "
+            "finding-free pass over this range is a fact about the RANGE and is "
+            "NOT evidence about the code — do not let the stop-rule clause "
+            "below convert it into \"the ladder ENDS\".\n\n"
             + directive("degenerate-range-causes")
         )
     # 🔴 ROUND 7 — THE THIRD INSTANCE OF THIS LADDER'S RECURRING CONFUSION, and
@@ -1411,16 +1475,16 @@ def render_range(facts):
     # the brief's own justification asserts the range was verified.
     #
     # Two tells that this is the same inversion and not a new one: the
-    # UNVERIFIED branch three lines down already does the safe thing
-    # (`tip = hc.pr_sha`), and `emit_claims_skeleton` already prefers the
-    # resolved PR head. Only the VERIFIED branch hardcoded `HEAD` — the branch
-    # where being sure was mistaken for the range being stable.
+    # UNVERIFIED branch below already does the safe thing (`tip = hc.pr_sha`),
+    # and `emit_claims_skeleton` already prefers the resolved PR head. Round 7
+    # wrote "Only the VERIFIED branch hardcoded `HEAD`" and round 8 measured
+    # that the DEGENERATE one still did — both now read `range_tip`, which
+    # cannot return the token at all.
     #
     # The ledger below still MEASURES `<anchor>..HEAD`, and correctly: that
     # command runs HERE, now, in the tree just verified. What is handed to
     # ANOTHER process, later, is a sha.
     elif hc is not None and hc.ok:
-        tip = hc.local_sha
         note = (
             f"This checkout's HEAD is `{hc.local_sha}`, verified at assembly "
             f"time to be PR #{facts.pr}'s head commit — so the range above "
@@ -1429,8 +1493,40 @@ def render_range(facts):
             "repository other sessions are pushing to; the sha cannot move "
             "under you."
         )
+    # 🔴 ROUND 8 — THE FOURTH INSTANCE OF THE RECURRING CONFUSION, and this one
+    # is the REPOSITORY axis: the repo `gh` was asked about versus the repo
+    # `git` was run in. Every git command this script issues goes to
+    # `repo_dir` — the assembly checkout — while `gh` was asked about
+    # `facts.repo`. Cross-repo those are different repositories, so the head
+    # check is STRUCTURALLY unable to pass and the unverified branch below fired
+    # every time, phrasing a permanent fact as an operator error: "this
+    # checkout's HEAD is X, but the PR's head is Y", followed by "Resolve the
+    # range in a tree that CONTAINS the PR's head". There is no such tree here
+    # and there never will be, so the instruction is unfollowable and the
+    # diagnosis sends the reader looking for a checkout that moved.
+    #
+    # 🔴 IT IS ORDERED AFTER THE `hc.ok` BRANCH ON PURPOSE. `repo_relation`
+    # compares SLUGS, and a checkout whose `origin` names a different repository
+    # can still hold the PR's head commit (a clone with a renamed remote, a
+    # mirror). The sha is the ground truth; this branch only claims the
+    # structural impossibility once the sha comparison has actually failed.
+    elif facts.repo_relation == "cross":
+        note = (
+            "🔴 **THIS CHECKOUT CANNOT BE STANDING ON THE PR — that is "
+            "STRUCTURAL AND PERMANENT, not a checkout that moved.** WHERE TO "
+            f"WORK above says why: the PR lives in `{facts.repo}` and this "
+            "brief was assembled in "
+            f"`{facts.cwd_repo_slug or facts.cwd_repo_dir}`, a DIFFERENT "
+            "repository. No `git checkout` here can make the two agree, so do "
+            "not go looking for one, and do not report this as a finding "
+            "against the PR:\n\n"
+            f"    {hc.reason if hc is not None else 'no check was made'}\n\n"
+            "So the range above names the PR's head SHA outright — read from "
+            "`gh pr view --json headRefOid`, not resolved in any tree. Both of "
+            "its ends exist in YOUR worktree, the one WHERE TO WORK told you to "
+            "make, and neither exists here."
+        )
     else:
-        tip = hc.pr_sha if (hc is not None and hc.pr_sha) else "<the PR's head sha>"
         note = (
             "🔴 **COULD NOT VERIFY that this checkout is standing on the PR**, "
             "so `..HEAD` is NOT used above — it would name whatever tree the "
@@ -1589,8 +1685,68 @@ def render_toolchain(facts):
     ])
 
 
+def payload_summary_line(facts, cumulative):
+    """🔴 The line the auditor must carry — ONE WRITER, TWO CALLERS.
+
+    The measured branch asks for it and so does the cross-repo hand-over, and
+    round 8 wrote it out twice before the mutation battery objected: the second
+    copy sat at a deeper indentation and made a battery target AMBIGUOUS, so a
+    `replace(…, 1)` mutated the wrong site. Two copies of one sentence are two
+    things to keep in step and, here, a second thing for a pattern to match.
+    """
+    return (f"round {facts.round_no} · payload lines changed THIS round: X "
+            f"(since round 1: {cumulative}) · elapsed: Z")
+
+
 def render_ledger(facts):
     lines = ["## THE LEDGER — payload attribution for this round", ""]
+    # 🔴 ROUND 8 — CROSS-REPO IS "NOT MEASURABLE FROM HERE", NEVER "COULD NOT
+    # MEASURE". The generic banner below describes a command that failed and
+    # tells the reader to re-run it by hand — advice that, cross-repo, points
+    # at the wrong repository. And it fires on EVERY delta round of such a PR,
+    # because `measure_ledger` refuses the moment the head check is not ok and
+    # the head check is structurally unable to pass. A section that is red
+    # every single time is the permanently-red gate `claude/RULES.md` names:
+    # the reader learns to skip it, and the ladder's own two-consecutive-zero
+    # payload-attribution gate silently stops being computed by ANYONE.
+    #
+    # So this states the impossibility, hands over the exact command, says
+    # WHERE it must run, and says out loud that the gate is the auditor's to
+    # compute this round. Ordered before every other branch except round 1,
+    # which has no ledger for a reason that has nothing to do with repos.
+    if facts.round_no >= 2 and facts.repo_relation == "cross":
+        return "\n".join(lines + [
+            "🔴 **NOT MEASURABLE FROM HERE — and that is STRUCTURAL, so it is "
+            "true of every round of this PR and not a failure of this run.** "
+            f"The PR lives in `{facts.repo}`; this brief was assembled in "
+            f"`{facts.cwd_repo_slug or facts.cwd_repo_dir}`, a DIFFERENT "
+            "repository, which holds neither end of the range. A number "
+            "measured here would be a measurement of another project, so none "
+            "is printed.",
+            "",
+            "🔴 **THE ATTRIBUTION GATE IS YOURS THIS ROUND — it is not "
+            "optional and nobody else can compute it.** The ladder ends on two "
+            "consecutive rounds of ZERO payload lines; a gate nobody evaluates "
+            "never fires, and the ladder then runs forever on scaffolding. Run "
+            "this in the worktree WHERE TO WORK told you to make — a worktree "
+            f"of YOUR clone of `{facts.repo}`, where `{facts.base_ref}` names "
+            "THAT repository's base branch and not this checkout's:",
+            "",
+            "```",
+            "git -C <your worktree> log --numstat --format= --remerge-diff "
+            f"{facts.prev_sha}..{range_tip(facts)} --not {facts.base_ref}",
+            "```",
+            "",
+            "Require rc 0, silent stderr and a NON-EMPTY range before believing "
+            "any figure it prints — a failed command is not a zero. Then "
+            "classify the files yourself (payload is what the PR exists to "
+            "ship; scaffolding is the tests, fixtures and notes a round wrote "
+            "to guard it) and carry this line in your summary:",
+            "",
+            "```",
+            payload_summary_line(facts, "Y"),
+            "```",
+        ])
     led = facts.ledger
     if led is None:
         lines += [
@@ -1610,9 +1766,25 @@ def render_ledger(facts):
         ]
         return "\n".join(lines)
 
+    # 🔴 ROUND 8 — PROVENANCE MAY NAME A SHA; IT MAY NOT NAME A TOKEN THE
+    # READER RESOLVES DIFFERENTLY. This line is the only copyable command left
+    # in the brief whose `HEAD` means something else where the auditor stands —
+    # and the paragraph below invites them to re-run it ("if the number looks
+    # large, that is the first thing to check"). Re-run in their worktree,
+    # `<anchor>..HEAD` covers any commit that landed since assembly, so a longer
+    # file list reads as the previous round UNDER-reporting its payload.
+    #
+    # `local_sha` is not a weaker provenance claim than `HEAD`: at the moment
+    # the command ran they were the SAME COMMIT — `measure_ledger` refuses
+    # unless the head check passed — so the sha reports exactly what was
+    # measured AND survives being copied. Only a run with no head check at all
+    # keeps the token, and there `HEAD` is the honest answer, because no sha
+    # was ever established.
+    hc = facts.head_check
+    measured_tip = hc.local_sha if (hc is not None and hc.ok) else "HEAD"
     lines += [
-        f"`git log --numstat --format= --remerge-diff {facts.prev_sha}..HEAD "
-        f"--not {facts.base_ref}` over {led.commits} commit(s):",
+        f"`git log --numstat --format= --remerge-diff {facts.prev_sha}.."
+        f"{measured_tip} --not {facts.base_ref}` over {led.commits} commit(s):",
         "",
         "```",
         f"{'added':>7} {'deleted':>8}  path",
@@ -1647,16 +1819,17 @@ def render_ledger(facts):
         "classification above:",
         "",
         "```",
-        f"round {facts.round_no} · payload lines changed THIS round: X "
-        f"(since round 1: {led.cumulative if led.cumulative is not None else 'Y'}"
-        ") · elapsed: Z",
+        payload_summary_line(
+            facts, led.cumulative if led.cumulative is not None else "Y"),
         "```",
         "",
         "⚠ `<base>` here is `" + facts.base_ref + "` **as it stands in this "
-        "checkout**. This script does not fetch (that would be a write to the "
-        "shared checkout), so a stale base re-reports upstream work as this "
-        "round's payload. If the number looks large, that is the first thing to "
-        "check.",
+        "checkout**, and it is the ONLY end of that command that can mean "
+        "something different where you are standing — both ends of the range "
+        "itself are shas. This script does not fetch (that would be a write to "
+        "a checkout it does not own), so a stale base re-reports upstream work "
+        "as this round's payload. If the number looks large, that is the first "
+        "thing to check.",
     ]
     if led.cumulative is None:
         # 🔴 TWO mechanisms, and they need opposite fixes: there was no anchor
@@ -2274,6 +2447,64 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
     # `--emit-claims` stamps the head the block is posted at into that same
     # field. Reproduced live on devrc #958 and hermetically.
     prev_sha = range_anchor(newest)
+
+    # ------------------------------------------------------------------ #
+    # 🔴 REFUSAL 1b — a block that PARSED but yields no ANCHOR.
+    # ------------------------------------------------------------------ #
+    # 🔴 FOUND IN ROUND 8 BY SWEEPING FOR THE LADDER'S RECURRING SHAPE rather
+    # than from a finding, and it is the FIFTH instance: `newest is not None`
+    # was read as "we have something to diff from". Those are two different
+    # facts. `audited=..` parses cleanly — the regex wants `\S+` and `..`
+    # satisfies it — and yields `audited_from=''`, `audited_to=''`, so
+    # `range_anchor` answers None while `newest` is a perfectly good block with
+    # readable claims.
+    #
+    # Measured at `28492af2`, `--round 3` over such a block, rc 0, silent
+    # stderr:
+    #
+    #     THE RANGE : Diff **`None..1111…5555`** — the fix commits made since
+    #                 the tip round 2 audited.
+    #                 This checkout's HEAD is `1111…5555`, verified at
+    #                 assembly time to be PR #900's head commit
+    #     THE LEDGER: Not measured: a first, full audit has no previous round
+    #                 to attribute against. Start the ledger at your round 2.
+    #
+    # Both halves are wrong in the way this module keeps refusing. The range
+    # hands over a literal Python `None` inside a git rev spec — a command that
+    # cannot run — under the brief's most confident banner; and THE LEDGER
+    # states the ROUND-1 cause ("no previous round") for a round-3 brief that
+    # HAS one, which is the false-cause shape fixed three times already
+    # (`no_sha_reason`, the cumulative reason, the empty-range causes) at the
+    # one site nobody swept.
+    #
+    # Refused rather than banner-ed, for REFUSAL 1's own reason: a delta round
+    # with no anchor is not a delta round, and rendering one anyway produces a
+    # document that reads as covered.
+    if args.round_no >= 2 and newest is not None and not prev_sha:
+        print("\n".join([
+            f"{REFUSAL_HEADER} for round {args.round_no} of PR #{args.pr}.",
+            "",
+            f"  A block WAS found (round={newest.round_no}, "
+            f"{len(newest.items)} claim(s)) and it PARSED — but its `audited=` "
+            "field carries no sha this script can read, so there is nothing to "
+            "diff FROM.",
+            "",
+            "  This is NOT the round-1 case. A first, full audit legitimately "
+            "has no anchor; here a previous round exists and its anchor is "
+            "unreadable, and the two need opposite fixes.",
+            "",
+            "  Without a refusal the brief renders `Diff `None..<the PR's "
+            "head`` — a literal `None` inside a git rev spec, under \"verified "
+            "at assembly time\" — and THE LEDGER reports the round-1 reason.",
+            "",
+            f"  Fix: edit that comment so the header reads `audited="
+            "<from>..<to>`, or re-run "
+            f"`audit-dispatch.py {args.pr} --round {newest.round_no} "
+            "--emit-claims --audited <the tip that round read>` and post the "
+            "block it prints.",
+        ]), file=err_stream)
+        return 2
+
     # 🔴 `--audited` OVERRIDES THE WRITER'S ANCHOR AND NEVER THE READER'S. It
     # states the tip THIS round's audit read — the same quantity `emit_anchor`
     # recovers from the previous block, supplied instead of derived, and for
@@ -2289,6 +2520,31 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
             f"⚠ the newest claims block says round={newest.round_no}, and you "
             f"asked for round {args.round_no}. Using it anyway — but check you "
             "are not re-auditing a round that already ran.",
+            file=err_stream,
+        )
+    # 🔴 THE MIRROR OF THE WARNING ABOVE, and its absence was the asymmetry: a
+    # block from a LATER round warned, a block from a much EARLIER one was
+    # silent. `--round 7` over a `round=2` block puts round 2's claims under
+    # WHAT WAS CLAIMED FIXED, anchors the range on round 2's sha, and frames
+    # the whole audit on them — with nothing anywhere saying that four rounds
+    # are missing.
+    #
+    # A WARNING AND NEVER A REFUSAL, for a reason the refusals above do not
+    # share: skipping a round NUMBER is legitimate (a round can be abandoned,
+    # or numbered by hand), and `gh pr view --json comments` returns ISSUE
+    # comments only — so a block posted as a review comment is invisible here
+    # and would make a refusal wrong. The operator can tell those apart and
+    # this script cannot.
+    elif newest is not None and newest.round_no < args.round_no - 1:
+        gap = args.round_no - 1 - newest.round_no
+        print(
+            f"⚠ the newest claims block says round={newest.round_no}, and you "
+            f"asked for round {args.round_no} — {gap} round(s) in between "
+            "posted no `audit-claims` block this script can see. The claims "
+            "below are that OLDER round's and the range is anchored on its "
+            "sha, so this is a delta over everything since, not since the "
+            "previous round. Check for a later block posted as a REVIEW "
+            "comment, which `gh pr view --json comments` does not return.",
             file=err_stream,
         )
 

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -88,8 +88,8 @@ broken question, not a clean round, and the range section, the ledger and
 auditor who diffs nothing finds nothing, and the `stop-rule` clause then
 converts that into "the ladder ENDS".
 
-🔴 TWO REFUSALS, AND THEY ARE NOT THE SAME KIND
-------------------------------------------------
+🔴 THREE REFUSALS, AND THEY ARE NOT THE SAME KIND
+--------------------------------------------------
 1. **`--round N` for N ≥ 2 with no parseable claims block REFUSES to emit**
    (exit 2), naming what it looked for and where. An empty "what was claimed
    fixed" section silently turns a delta re-audit into a blind full audit — a
@@ -103,6 +103,17 @@ converts that into "the ladder ENDS".
    positive rate is set by whatever a human typed. It runs over `--check FILE`
    and over the READ-BACK of `--out` — never over the in-memory string, where
    it was unreachable by construction and could not have fired for any input.
+3. **`--emit-claims` REFUSES (exit 4) to print a block whose `<from>` this
+   script's OWN parser reads back as something else**, and refuses an empty
+   `--audited` outright. The flag used to accept any string: `abc 123` emitted
+   ``audited=abc 123..<head>``, which parses back as `from=''`, `to='abc'`, so
+   the next round diffed `abc..HEAD`; `e06461f7..dd601793` corrupted `<to>`
+   instead and cascaded into the round after that. A refusal and NOT a warning,
+   because the failure is silent at every downstream station — nothing reports
+   the block malformed, and the self-range guard cannot fire on it. 🔴 A
+   well-formed token that is not a commit round-trips and is NOT caught: this
+   script never resolves a sha, and saying otherwise would be a guard whose
+   description is wider than its implementation.
 
 🔴 EVERY NUMBER HERE IS ABOUT THE PR, NOT ABOUT YOUR CHECKOUT
 -------------------------------------------------------------
@@ -166,11 +177,20 @@ INVARIANT_CLAUSES = (
         "pointing at the real git dir, so a commit inside the copy lands on the "
         "branch you are auditing.",
     ),
+    # 🔴 UNCONDITIONAL, and round 5 put it back that way. Round 4 reworded this
+    # to fire only "to a SHARED checkout — THE CHECKOUT section … says whether
+    # the one it names is shared", which armed it on a STATE this script cannot
+    # know: `gather_worktree_kind` measures the tree the ASSEMBLER stood in, and
+    # in the production configuration it answers `private`, so the prohibition
+    # switched itself off over a tree that belongs to the dispatching session.
+    # The rule that is true in every state is the one about OWNERSHIP: write
+    # only to the copy you made.
     Clause(
         "no-fetch",
-        "**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to a "
-        "SHARED checkout — THE CHECKOUT section of this brief says whether the "
-        "one it names is shared.** Other sessions are in a shared tree; a "
+        "**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to any "
+        "checkout that is not the copy YOU made for this audit — including the "
+        "one THE CHECKOUT section names, which is where this brief was "
+        "assembled and is not yours.** Other sessions are in those trees; a "
         "fetch there is a write with cross-session blast radius, and every ref "
         "you need is already resolved for you here.",
     ),
@@ -345,14 +365,23 @@ SECTION_DIRECTIVES = (
     # rather than to one site" — and which then missed the two sites that same
     # commit was writing. A sweep that does not read the diff it is part of is
     # not a sweep.
+    # 🔴 ROUND 5 SCOPED THE FIRST CAUSE TO ROUND 1. It read "`--emit-claims`
+    # records [the fix tip] when `--audited` is omitted", flat — but from round
+    # 2 on, omitting the flag is CORRECT: `emit_from` falls back to
+    # `emit_anchor(newest)`, which is the previous block's `<to>`, i.e. the tip
+    # this round read. An operator hitting this banner on a round-3 brief was
+    # told their emit was wrong and pushed toward hand-typing a value into
+    # `--audited`, which is how a placeholder reached the header.
     Directive(
         "degenerate-range-causes",
         "Either the `audited=` block was written with the fix tip in its "
-        "`<from>` position — which is what `--emit-claims` records when "
-        "`--audited` is omitted, and what a bare round-1 `audited=<sha>` "
-        "always means; `<from>` is the tip the PREVIOUS round AUDITED, so "
-        "re-emit that block with `--audited <the tip that round actually "
-        "read>` and re-assemble — or nothing has been committed and pushed to "
+        "`<from>` position — which is what a bare round-1 `audited=<sha>` "
+        "always means, and what `--emit-claims` records when `--audited` is "
+        "omitted AT ROUND 1; from round 2 on, omitting it is correct, because "
+        "`<from>` is then recovered from the previous block's `<to>`. "
+        "`<from>` is the tip the PREVIOUS round AUDITED, so "
+        "re-emit that block with `--audited <that round's actual tip sha>` "
+        "and re-assemble — or nothing has been committed and pushed to "
         "the PR since that sha was recorded, in which case there is no delta "
         "to audit yet. 🔴 What is NOT a cause: the round's fix commits being "
         "absent from this checkout. This checkout was VERIFIED at assembly "
@@ -361,13 +390,20 @@ SECTION_DIRECTIVES = (
         "unmeasurable — so fetching or checking out here could not help, and "
         "the `no-fetch` clause forbids it anyway.",
     ),
+    # 🔴 ROUND 5 added the no-write sentence here. It was the ONLY one of the
+    # three checkout states that did not carry it — the `no-fetch` clause was
+    # doing the work from another section — which is what let round 4 reword
+    # that clause into a conditional one and leave the private state with a
+    # write GRANT and no rule anywhere. All three states now state it, and the
+    # test module pins that as a RELATIONSHIP over the `checkout-*` set rather
+    # than as a phrase in one directive.
     Directive(
         "checkout-moves",
         "🔴 **This checkout is SHARED with other sessions and agents. It MOVES "
         "UNDER YOU** — the branch can change, files can appear and vanish, and "
         "commits can land mid-audit. That is expected and is NOT your fault and "
-        "NOT a finding. **Report what you observed moving and carry on; do not "
-        "chase it, and do not try to restore it.**",
+        "NOT a finding. **Write nothing to it**, and report what you observed "
+        "moving and carry on; do not chase it, and do not try to restore it.",
     ),
     # 🔴 THE OTHER TWO THIRDS OF THE CHECKOUT DECISION. `checkout-moves` used to
     # be printed unconditionally under a heading reading THE SHARED CHECKOUT,
@@ -379,16 +415,40 @@ SECTION_DIRECTIVES = (
     # a finding, which suppresses exactly the sibling-agent clobber
     # `claude/RULES.md` ("the SESSION surface") says to report. Git answers it
     # in one read this script never made — see `gather_worktree_kind`.
+    # 🔴 ROUND 5 — THE PREMISE, NOT THE SENTENCE. Round 4 fixed the false SHARED
+    # claim and replaced it with a WRITE GRANT ("yours alone … writing here is
+    # fine") over a tree that is not the auditor's, plus an absolution inverted
+    # the unsafe way ("movement is NOT expected here").
+    #
+    # Both errors have ONE cause: `gather_worktree_kind` measures the cwd of the
+    # ASSEMBLING process, and the consumer is a DIFFERENT process. This script
+    # prints a brief for pasting into an `Agent` dispatch, and WHERE TO WORK
+    # tells that agent to stand somewhere else (`isolation: "worktree"`, or its
+    # own `git worktree add`). So "private" here means private to the session
+    # that BUILT the brief — which is live in that tree, so movement IS
+    # expected — and under the other configuration (no isolation, inherited
+    # cwd) the same tree is shared with the dispatcher and with sibling
+    # auditors. "Yours alone" is wrong either way.
+    #
+    # Observed live: the round-5 brief named this session's own agent worktree,
+    # classified it PRIVATE and printed "Writing here is fine", and the
+    # operator's hand-written dispatch had to CONTRADICT the generated brief in
+    # prose. Retyping a correction over generated text is the failure this
+    # script exists to remove.
+    #
+    # So this states only what the script knows: the path is where the brief was
+    # ASSEMBLED. It grants nothing.
     Directive(
         "checkout-private",
-        "🔴 **This is a PRIVATE worktree — yours alone.** Its `.git` is a link "
-        "into a shared repository, but the WORKING TREE is not shared, so "
-        "files appearing, vanishing or changing under you is **NOT expected "
-        "here and IS worth reporting** — that is the sibling-agent clobber "
-        "`claude/RULES.md` describes, not background noise. **If something "
-        "moves, report it with what moved and when.** Writing here is fine: "
-        "the no-write clause below is about a SHARED checkout, and this is "
-        "not one.",
+        "🔴 **This is the checkout this brief was ASSEMBLED in — not "
+        "necessarily the one you are standing in.** Git reports it as a "
+        "PRIVATE linked worktree: its `.git` is a link into a shared "
+        "repository, and the working tree belongs to the session that BUILT "
+        "this brief, which is not you. That session is live in it, so files "
+        "here can appear, vanish and change. **Write nothing to it** — the "
+        "path is a fact about where the brief was built, never a tree you may "
+        "work in. If you do see something move here, report it with what moved "
+        "and when, and do not try to restore it.",
     ),
     Directive(
         "checkout-unknown",
@@ -623,13 +683,16 @@ def range_anchor(block):
         delta round wants.
       * a BARE `audited=<sha>` (the round-1 spelling) has no `<from>`
         -> fall back to `<to>`. That single sha is only an anchor if it is the
-        tip the round AUDITED, so `--emit-claims --audited <sha>` is how it is
-        supplied. 🔴 WITH `--audited` OMITTED, `--emit-claims` stamps the PR's
-        CURRENT head — which is the head the round's FIXES produced, not the
-        tip it read — and this fallback then makes `<sha>..HEAD` a self-range.
-        That is why `--emit-claims` warns on exactly that spelling instead of
-        emitting it silently: the two bullets are otherwise jointly saying
-        "the common case for the round-1 spelling is a broken range".
+        tip the round AUDITED. 🔴 THE BARE FORM IS WHAT YOU GET WITH `--audited`
+        OMITTED, and the flag is how you AVOID it: passing
+        `--emit-claims --audited <sha>` writes a TWO-SHA `audited=<sha>..<head>`
+        block, which takes the first bullet's path and never this one. Omitted,
+        `--emit-claims` stamps the PR's CURRENT head as that single sha — the
+        head the round's FIXES produced, not the tip it read — and this fallback
+        then makes `<sha>..HEAD` a self-range. That is why `--emit-claims` warns
+        on exactly that spelling instead of emitting it silently: the two
+        bullets are otherwise jointly saying "the common case for the round-1
+        spelling is a broken range".
 
     The WRITER's counterpart is `emit_anchor` — a different quantity, and
     conflating them is what this pair exists to prevent.
@@ -766,17 +829,30 @@ WorktreeKind = namedtuple("WorktreeKind", "kind git_dir common_dir reason")
 def gather_worktree_kind(runner, repo_dir):
     """🔴 SHARED checkout, PRIVATE linked worktree, or COULD NOT DETERMINE.
 
+    🔴 IT MEASURES THE TREE THIS PROCESS IS ASSEMBLING IN, AND NOTHING ELSE.
+    The consumer is a DIFFERENT process: this script prints a brief for pasting
+    into an `Agent` dispatch, and WHERE TO WORK tells that agent to make its own
+    copy (`isolation: "worktree"`, or a hand-rolled `git worktree add`). So a
+    `private` answer means "private to the session that ran THIS script" — never
+    "private to the auditor", and never a licence to write here. Round 4's
+    docstring claimed this is "where a dispatched auditor usually stands"; that
+    was false, and the `checkout-private` directive was written against it,
+    granting write permission over a tree belonging to the dispatching session.
+    Under the other configuration (no isolation, an inherited cwd) the same tree
+    is shared with the dispatcher and with sibling auditors — so no state this
+    function can return makes the tree the auditor's own.
+
     THREE states, the same shape as `render_worktree_directive`'s repo decision
     and for the same reason: collapsing "cannot tell" into either answer picks
     the branch whose failure is silent.
 
     THE BRIEF ASSERTED "SHARED" OF WHATEVER `--show-toplevel` RETURNED. Run
-    from `…/.claude/worktrees/agent-…` — which is where a dispatched auditor
-    usually stands — it printed a heading reading THE SHARED CHECKOUT over "This
-    checkout is SHARED with other sessions and agents. It MOVES UNDER YOU …
-    That is expected and is NOT your fault and NOT a finding." All four claims
-    are false for a private per-agent worktree, and the DIRECTION is what makes
-    it consequential: the auditor is told to disregard exactly the
+    from `…/.claude/worktrees/agent-…` it printed a heading reading THE SHARED
+    CHECKOUT over "This checkout is SHARED with other sessions and agents. It
+    MOVES UNDER YOU … That is expected and is NOT your fault and NOT a finding."
+    Two of those claims are false for a per-agent worktree (it is one session's,
+    not many; movement in it is worth naming), and the DIRECTION is what makes
+    it consequential: the reader is told to disregard exactly the
     sibling-agent clobber `claude/RULES.md` says to report.
 
     Git answers it in one read:
@@ -1327,9 +1403,12 @@ def render_checkout(facts):
         else f"{facts.dirty} uncommitted path(s)"
     )
     wt = facts.worktree
+    # 🔴 "tree is yours" was FALSE and is gone. This is the tree the ASSEMBLER
+    # stood in; the auditor is dispatched elsewhere. See `gather_worktree_kind`.
     kind_line = {
         "shared": "SHARED — other sessions and agents are in this tree",
-        "private": "PRIVATE worktree — linked to a shared repo, tree is yours",
+        "private": "PRIVATE linked worktree — belongs to the session that "
+                   "assembled this brief, not to you",
     }.get(wt.kind, "🔴 COULD NOT DETERMINE")
     lines = [
         "## THE CHECKOUT — state at assembly time",
@@ -1373,6 +1452,18 @@ def render_toolchain(facts):
     `nix develop {r}` is deliberately left pointing at the operator's checkout:
     that one is only resolving a dev shell (the toolchain), and it is the door
     the repo's own CLAUDE.md tells everyone to use.
+
+    🔴 ROUND 5 — THE RATIONALE IS STATE-INDEPENDENT, AND THAT IS DELIBERATE.
+    The round-2 fix moved the COMMANDS off `r` but left the sentence explaining
+    WHY saying "runs the suite in the SHARED CHECKOUT" — a claim about a state
+    THE CHECKOUT section may have just denied. In the private state that
+    sentence is false, the auditor sees the brief refute its own reason two bars
+    apart, and the round-2 finding re-opens in a new state: gate the un-mutated
+    head, then obey the next sentence ("name the tier and the base sha") and
+    name a tree that does not contain what was tested. This section knows
+    nothing about where the auditor stands, so it says only what is true in
+    every state — that copy is not yours and holds none of your mutations.
+    `test_the_toolchain_reason_is_true_in_both_checkout_states` drives both.
     """
     r = facts.cwd_repo_dir
     return "\n".join([
@@ -1382,8 +1473,9 @@ def render_toolchain(facts):
         f"told you to make. `{r}` appears ONLY as the argument to `nix develop`, "
         "where it resolves the dev shell and nothing else. Never point the gate "
         "or a `nix build` at it: `gate.sh` resolves its root from its own path, "
-        "so running the shared copy runs the suite in the SHARED CHECKOUT on "
-        "whatever branch it is standing on, and a `nix build <ref>#…` builds "
+        "so running that copy runs the suite in a checkout that is NOT yours — "
+        "the one this brief was assembled in, on whatever branch it is standing "
+        "on, holding none of your mutations — and a `nix build <ref>#…` builds "
         "that ref's tree, not yours.",
         "",
         "Run a SUBSET of the suite:",
@@ -1640,12 +1732,111 @@ def emit_claims_skeleton(facts, head_sha):
         # about, because it is an assumption and not a measurement.
         audited = head_sha
     return "\n".join([
+        # 🔴 THE LEGEND, added in round 5. The code and the docstrings above
+        # were adjudicated correct and consistent; the failure is at the HUMAN
+        # end, because a person reasons from the emitted block and the block
+        # carried no key to its own two fields. The operator wrote them the
+        # wrong way round in two consecutive briefs and the agent had to
+        # override both. It sits OUTSIDE the fence, so the parser drops it.
+        "  legend: `<from>` = the tip THIS round's audit READ · `<to>` = the "
+        "head THIS round's FIXES produced. Different shas — `<from>` is older.",
+        "",
         f"```audit-claims round={facts.round_no} audited={audited}",
         "1. <one line per thing this round's fixes CLAIM to have addressed — "
         "WHAT was claimed, never WHY it is correct>",
         "2. <one line, same rule>",
         "```",
     ])
+
+
+# 🔴 THE ROUND-TRIP GUARD — round 5. `--audited` accepted ANY string and the
+# emitter's own parser then truncated it, in silence, at both ends of the
+# pipeline. Measured through the real code at `dd601793`:
+#
+#     --audited                emitted header            parses back as
+#     `abc 123`                audited=abc 123..<head>   from='', to='abc'
+#     `<the tip … read>`       audited=<the tip …>..…    from='', to='<the'
+#     `e06461f7..dd601793`     audited=e06461f7..dd6…    from='e06461f7',
+#                                                        to='dd601793..<head>'
+#
+# No warning at emit, none at parse, and the self-range guard cannot fire on any
+# of them. Worse, `degenerate-range-causes` INSTRUCTS the operator to re-emit
+# "with `--audited <the tip that round actually read>`", so pasting the
+# placeholder reproduces it — which is how the round-3 bug re-opened.
+#
+# The check is the pipeline itself: emit the block, feed it back through
+# `parse_claims_blocks`, and require what comes back to RECONSTRUCT the header
+# that was written. Pinned to what is actually PRINTED rather than to a
+# validation regex that could drift from the emitter.
+#
+# 🔴 IT COMPARES THE HEADER WITH ITSELF, NEVER WITH `emit_from` — and that is
+# the whole reason it isolates. The first draft asserted
+# `parsed_from == facts.emit_from`, which turned it into a SECOND assertion
+# about WHICH field the emitter uses; that claim is owned by `emit_anchor` and
+# `test_emit_claims_records_the_tip_this_round_audited_not_the_range_anchor`,
+# and duplicating it made mutants N3 and Y7 cascade into five unrelated tests
+# and would have answered a wrong-field bug in production with a misleading
+# "it does not parse" refusal. Measured by the battery, which reported both as
+# EXTRA-KILLER. This asks only whether the printed field survives the FORMAT.
+#
+# 🔴 NAMED BLIND SPOT: a well-formed token that is not a commit (`zzzzzzzz`)
+# round-trips perfectly and is NOT caught. This script never resolves the sha —
+# it does not `git cat-file` anything in a checkout it refuses to write to — so
+# "is it a real commit" is a question it cannot answer, and pretending otherwise
+# would be a guard whose description is wider than its implementation.
+EMIT_REFUSAL_HEADER = "🔴 REFUSING TO EMIT an `audit-claims` block"
+
+# The RAW text after `audited=`, to end of line — deliberately NOT `\S+`, which
+# is what `_HEADER_AUDITED` uses and is exactly the truncation being detected.
+_EMITTED_AUDITED = re.compile(
+    r"^`{3,}audit-claims[^\n]*?\baudited=([^\n]*)$", re.M
+)
+
+
+def emitted_block_reads_back_as_written(skeleton):
+    """-> None when the block this run would print reads back intact, else why.
+
+    Pure, and driven by the tests directly as well as through `main`: a refusal
+    is only trustworthy if it can be exercised with no PR and no git.
+    """
+    m = _EMITTED_AUDITED.search(skeleton)
+    if not m:
+        return "the block this run would emit carries no `audited=` field at all"
+    raw = m.group(1).rstrip()
+    blocks, malformed = parse_claims_blocks([skeleton])
+    if len(blocks) != 1:
+        why = "; ".join(malformed) or "no reason reported"
+        return (
+            "the block this run would emit does not parse as exactly one "
+            f"`audit-claims` block ({len(blocks)} found: {why})"
+        )
+    b = blocks[0]
+    back = f"{b.audited_from}..{b.audited_to}" if b.audited_from else b.audited_to
+    if back != raw:
+        return (
+            f"the header carries `audited={raw}`, but this script's OWN parser "
+            f"reads it back as `<from>`={b.audited_from!r}, "
+            f"`<to>`={b.audited_to!r} — reconstructing {back!r}. The field is "
+            "read as one whitespace-free token, so anything from the first "
+            "space onward is silently DISCARDED"
+        )
+    for label, field in (("`<from>`", b.audited_from), ("`<to>`", b.audited_to)):
+        if ".." in field:
+            return (
+                f"{label} came back as {field!r}, which carries an embedded "
+                "`..`. The header splits on the FIRST dot-pair, so a range "
+                "written into one half leaves the other half holding a range "
+                "— and that corruption is copied forward into the next round's "
+                "own block"
+            )
+        if "<" in field or ">" in field:
+            return (
+                f"{label} came back as {field!r}, which is a PLACEHOLDER and "
+                "not a sha. The next round would anchor its delta range and "
+                "its whole ledger on it, and nothing downstream reports it "
+                "malformed"
+            )
+    return None
 
 
 # --------------------------------------------------------------------------- #
@@ -1744,7 +1935,10 @@ def build_parser():
                     help="the tip THIS round's audit read — written as the "
                          "`<from>` of the `--emit-claims` block. Round 1 has "
                          "no previous block to derive it from; without this, "
-                         "HEAD is ASSUMED and said so on stderr.")
+                         "HEAD is ASSUMED and said so on stderr. ONE sha: no "
+                         "whitespace, no `..`, no placeholder — the emitted "
+                         "block is fed back through this script's own parser "
+                         "and a value that does not survive is REFUSED.")
     ap.add_argument("--claims-file",
                     help="read claims-block text from this file instead of the "
                          "PR's comments (offline/testing seam)")
@@ -1797,6 +1991,27 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
         return check_brief_file(args.check, out_stream, err_stream)
     if args.pr is None:
         parser.error("the PR number is required (or use --check FILE)")
+
+    # 🔴 An EMPTY `--audited` is the fifth row of round 5's measured table: it
+    # is falsy, so it falls straight through to `emit_anchor(newest)` and the
+    # flag is IGNORED IN SILENCE — including at round 1, where there is no
+    # block to fall back to and the bare `audited=<head>` spelling is written
+    # instead. Refused rather than warned: there is no reading of `--audited ""`
+    # that the operator meant.
+    if args.audited is not None and not args.audited.strip():
+        print("\n".join([
+            f"{EMIT_REFUSAL_HEADER}: `--audited` was given an EMPTY value "
+            f"({args.audited!r}).",
+            "",
+            "  An empty string is falsy, so it is indistinguishable from the "
+            "flag being omitted: the anchor silently falls back to the previous "
+            "block's `<to>`, or — at round 1, where there is no previous block "
+            "— to the bare `audited=<head>` spelling whose next round is EMPTY "
+            "BY CONSTRUCTION.",
+            "",
+            "  Pass the sha this round's audit actually read, or omit the flag.",
+        ]), file=err_stream)
+        return 4
 
     # A flag that silently does nothing is the shape this module refuses
     # everywhere else: `--audited` is written by `--emit-claims` and by nothing
@@ -2092,10 +2307,43 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
                     "anyway.)",
                     file=err_stream,
                 )
+        # 🔴 THE ROUND TRIP, and it is asked of the BLOCK THAT WOULD BE PRINTED
+        # — not of `args.audited` against a validation regex, which is a second
+        # spelling of the emitter that can drift from it. It compares the
+        # header with ITSELF and never with `emit_from`: see
+        # `emitted_block_reads_back_as_written` for why that isolation matters.
+        #
+        # Gated on `facts.emit_from` because the BARE spelling deliberately has
+        # no `<from>`, and its hazard is a different one that already has its
+        # own loud warning six lines above — gating any wider would make the
+        # placeholder `<to>` of a headRefOid-less run a refusal instead of the
+        # warning it already is. Everything the gate does cover comes from a
+        # human: `--audited` typed on the command line, or `emit_anchor`
+        # recovered from a block someone typed into a PR comment.
+        skeleton = emit_claims_skeleton(facts, head_sha)
+        if facts.emit_from:
+            why = emitted_block_reads_back_as_written(skeleton)
+            if why:
+                print("\n".join([
+                    f"{EMIT_REFUSAL_HEADER} for round {args.round_no} of PR "
+                    f"#{args.pr}: it would not survive this script's own "
+                    "parser.",
+                    "",
+                    f"  {why}.",
+                    "",
+                    "  the block that was NOT emitted:",
+                    "",
+                    "      " + "\n      ".join(skeleton.splitlines()),
+                    "",
+                    "  Re-run with `--audited <a single sha, no spaces and no "
+                    "`..`>` — the tip THIS round's audit read. A placeholder "
+                    "in angle brackets is not a sha; neither is a range.",
+                ]), file=err_stream)
+                return 4
         print("\n" + _bar(), file=out_stream)
         print("Paste this into the PR comment for this round, so the NEXT "
               "round can read it:\n", file=out_stream)
-        print(emit_claims_skeleton(facts, head_sha), file=out_stream)
+        print(skeleton, file=out_stream)
     return 0
 
 

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -535,12 +535,29 @@ SECTION_DIRECTIVES = (
     # substitution, so the grant is stated as the OPERATION it covers rather
     # than as an adjective on the tree. The forward-reference sentence is
     # unchanged and still spells `NO_WRITE_SCOPE`.
+    #
+    # 🔴 ROUND 12 — ROUND 10 REFUSED THREE VERBS BY NAME AND NOTHING ELSE, AND
+    # THIS IS THE ONE DIRECTIVE IN THE BRIEF WHOSE FAILURE LANDS OUTSIDE IT.
+    # The `no-fetch` clause below is scoped to "every checkout you did not
+    # make", and round 7 chose that scope precisely so `git -C <clone>
+    # worktree add` stops being forbidden — so the clone is DELIBERATELY
+    # outside that clause and this sentence is the only rule covering it.
+    # A closed verb list is walkable by reaching for a verb nobody listed:
+    # the auditor needs the PR branch present before `worktree add`, `fetch`
+    # is refused by name, and `git -C <clone> remote update` is not — nor are
+    # `switch`, `restore`, `reset`, `branch -f` or `gc`. The preceding
+    # sentence scopes what the brief REQUESTS, never what is PERMITTED.
+    #
+    # So the permission is stated POSITIVELY and everything else is refused by
+    # a universal, not by an enumeration: exactly the "assert the state, never
+    # a word another feature can spell" rule in `claude/RULES.md`.
     Directive(
         "own-worktree-is-writable",
         "That worktree is YOURS: fetching and checking out inside it is fine. "
         "In the clone you made it from, `git worktree add` is the ONLY write "
-        "this brief asks for — do not `fetch`, `pull` or `checkout` there, "
-        "whoever made it, because other sessions may be standing in it. The "
+        "this brief asks for and the ONLY one you may make — every other "
+        "command that writes there is refused, named or not, whoever made "
+        "that clone, because other sessions may be standing in it. The "
         "no-write rule below is about every checkout you did not make.",
     ),
 )

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -888,7 +888,8 @@ Facts = namedtuple(
     "Facts",
     "pr repo title base_ref url round_no cwd_repo_dir cwd_repo_slug repo_relation "
     "worktree branch dirty prev_sha emit_from claims claims_round checklist "
-    "ledger assembled_at claims_source head_check base_assumed",
+    "ledger assembled_at claims_source head_check base_assumed "
+    "base_assumed_reason",
 )
 # 🔴 `base_assumed` — ROUND 10's SEVENTH INSTANCE, found by the sweep round 9's
 # auditor asked for and not by a finding. `base_ref` is
@@ -897,10 +898,17 @@ Facts = namedtuple(
 # absent, rc 0 and silent stderr, THE LEDGER's cross-repo hand-over read
 # "…where `origin/main` names THAT repository's base branch and not this
 # checkout's" — an assertion about a repository nothing was asked about.
-# `--claims-file` mode reaches it on EVERY run: it consults no `gh` and
-# hardcodes `baseRefName: "main"`, exactly as it hardcodes no `headRefOid`,
-# and that second omission already carries a reason string while this one did
-# not. Same shape as finding A one field over.
+# `--claims-file` mode reaches it on EVERY run: it consults no `gh`, so it
+# learns no `baseRefName`, exactly as it learns no `headRefOid`.
+# 🔴 ROUND 12 — AND FOR TWO ROUNDS IT DID NOT REACH IT. Round 10 stated the
+# sentence above and left the mode HARDCODING `baseRefName: "main"`, so
+# `base_assumed` answered False in the one mode this comment, the test
+# module's `delta-assumed-base` comment and the guard's own docstring all
+# call permanently assumed — the banner was suppressed exactly where it is
+# always warranted, at rc 0. The hardcode is gone and the mode now carries a
+# per-cause `base_assumed_reason`, because "gh reported no baseRefName" is
+# itself false in a run that never asked `gh`. Same shape as finding A one
+# field over, and the same remedy.
 # 🔴 `prev_sha` and `emit_from` are TWO ANCHORS out of ONE `audited=` field, and
 # they are deliberately separate fields rather than one: `prev_sha` is
 # `range_anchor` (what this round DIFFS FROM) and `emit_from` is `emit_anchor`
@@ -1530,13 +1538,24 @@ def assumed_base_note(facts):
     it unconditionally — the same shape as `unresolved_tip_note`, and for the
     same reason: a conditional a caller has to remember is one a caller forgets
     at the second site.
+
+    🔴 ROUND 12 — THE CAUSE IS THE CALLER'S TO NAME, exactly as `no_sha_reason`
+    is one field over. This block used to state "`gh` reported no
+    `baseRefName`" unconditionally, which is false in `--claims-file` mode:
+    `gh` is never consulted there, so it reported nothing. The fallback below
+    is for a caller that genuinely cannot say, and it says so rather than
+    picking one of the two causes.
     """
     if not facts.base_assumed:
         return ""
+    why = facts.base_assumed_reason or (
+        "`gh` was not consulted, or reported no `baseRefName` — this caller "
+        "did not say which"
+    )
     return (
-        "🔴 **THAT BASE BRANCH WAS ASSUMED, NOT READ.** `gh` reported no "
-        f"`baseRefName` for this PR, so `{facts.base_ref}` is this script's "
-        "DEFAULT and not a fact about the PR. The base is what the PR is "
+        f"🔴 **THAT BASE BRANCH WAS ASSUMED, NOT READ** ({why}), so "
+        f"`{facts.base_ref}` is this script's DEFAULT and not a fact about "
+        "the PR. The base is what the PR is "
         "diffed against and — from round 2 — what `--not <base>` subtracts "
         "when the payload figure is measured, so a wrong one silently changes "
         "what you read, at rc 0. Check the PR's real base branch before "
@@ -2559,7 +2578,20 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
             print(f"cannot read --claims-file: {e}", file=err_stream)
             return 2
         claims_source = f"`{args.claims_file}`"
-        data = {"title": f"PR #{args.pr}", "url": "", "baseRefName": "main"}
+        # 🔴 ROUND 12 — `baseRefName` WAS HARDCODED `"main"` HERE, AND THAT
+        # SWITCHED THE ASSUMED-BASE BANNER OFF IN THE ONE MODE THAT ALWAYS
+        # ASSUMES. `base_assumed` is `not data.get("baseRefName")`, so the
+        # hardcode answered "the base was READ" for a run that consulted no
+        # `gh` at all — the exact state three comments in this module and its
+        # test module describe as permanent for this mode. Measured at
+        # `88b4105c`: `--round 3 --claims-file <f>` printed "Base branch:
+        # `origin/main`." with no banner, at rc 0 and silent stderr, while the
+        # same run over a `gh` payload with the field deleted printed it.
+        #
+        # This mode does not learn `baseRefName` for the same reason it does
+        # not learn `headRefOid`, so it now omits BOTH and lets `or "main"`
+        # below be the visible default it always was.
+        data = {"title": f"PR #{args.pr}", "url": ""}
         # 🔴 THE CALLER KNOWS WHICH CAUSE IT IS. See `verify_head_is_the_pr`:
         # naming both leaves the reader with a list instead of an answer, and
         # this branch is the one that decided not to consult `gh`.
@@ -2567,12 +2599,24 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
             "this run is `--claims-file` mode, which consults no `gh` and so "
             "never learns the PR's `headRefOid`"
         )
+        # 🔴 THE SAME PER-CAUSE RULE, ONE FIELD OVER. `assumed_base_note` used
+        # to state "`gh` reported no `baseRefName`" unconditionally, which is
+        # itself false here — `gh` was never asked. Following `no_sha_reason`
+        # rather than inventing a second mechanism.
+        base_assumed_reason = (
+            "this run is `--claims-file` mode, which consults no `gh` and so "
+            "never learns the PR's `baseRefName`"
+        )
     else:
         data, comment_texts = gh_pr_facts(runner, args.pr, args.repo)
         claims_source = f"PR #{args.pr}'s comments"
         no_sha_reason = (
             "`gh pr view` was consulted and reported no `headRefOid` for this "
             "PR"
+        )
+        base_assumed_reason = (
+            "`gh pr view` was consulted and reported no `baseRefName` for "
+            "this PR"
         )
         if data.get("_error"):
             print(f"🔴 `gh pr view {args.pr}` failed: {data['_error']}",
@@ -2847,6 +2891,7 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
         claims_source=claims_source,
         head_check=head_check,
         base_assumed=base_assumed,
+        base_assumed_reason=base_assumed_reason,
     )
 
     # 🔴 THE REFUSAL'S SCOPE IS THE BRIEF, AND ONLY THE BRIEF. A refused run

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -3,6 +3,7 @@
 
     scripts/audit-dispatch.py <pr-number> [--round N] [--repo owner/name]
     scripts/audit-dispatch.py <pr-number> --round 3 --emit-claims
+    scripts/audit-dispatch.py <pr-number> --round 1 --emit-claims --audited <sha>
 
 It PRINTS a brief to stdout for pasting into an `Agent` dispatch. It dispatches
 nothing, merges nothing and writes nothing to the repository under audit.
@@ -167,11 +168,11 @@ INVARIANT_CLAUSES = (
     ),
     Clause(
         "no-fetch",
-        "**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to the "
-        "shared checkout named in THE SHARED CHECKOUT section of this brief.** "
-        "Other sessions are in it; a fetch there is a write with cross-session "
-        "blast radius, and every ref you need is already resolved for you "
-        "here.",
+        "**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to a "
+        "SHARED checkout — THE CHECKOUT section of this brief says whether the "
+        "one it names is shared.** Other sessions are in a shared tree; a "
+        "fetch there is a write with cross-session blast radius, and every ref "
+        "you need is already resolved for you here.",
     ),
     Clause(
         "stop-rule",
@@ -216,11 +217,12 @@ INVARIANTS_HEADING = "## 🔴 NON-NEGOTIABLE — every audit, every round"
 # --------------------------------------------------------------------------- #
 # THE SECTION DIRECTIVES — verbatim instruction prose that is NOT a clause.
 # --------------------------------------------------------------------------- #
-# 🔴 WHOLE-STRING PINNING COVERED 7 OF 11 VERBATIM BLOCKS, and three inversions
-# walked straight through a fully green 58-test suite. Round 2 made whole-string
-# pinning the standard for auditor instructions and then applied it to
-# `INVARIANT_CLAUSES` alone; these three blocks are verbatim, non-generated
-# instruction prose that shipped in every delta brief with nothing watching:
+# 🔴 WHOLE-STRING PINNING COVERED THE INVARIANT CLAUSES AND NOTHING ELSE, and
+# three inversions walked straight through a fully green 58-test suite. Round 2
+# made whole-string pinning the standard for auditor instructions and then
+# applied it to `INVARIANT_CLAUSES` alone; these three blocks are verbatim,
+# non-generated instruction prose that shipped in every delta brief with
+# nothing watching:
 #
 #   site             mutation applied alone                       result
 #   render_claims    keep "never WHY IT IS CORRECT", rewrite the  58 passed
@@ -243,15 +245,53 @@ INVARIANTS_HEADING = "## 🔴 NON-NEGOTIABLE — every audit, every round"
 # get their own ledger, pinned WHOLE and two-way by the test module exactly as
 # `INVARIANT_CLAUSES` is.
 #
-# 🔴 WHICH VERBATIM BLOCKS ARE **NOT** PINNED, said plainly rather than left to
-# read as covered: the toolchain section's wrong-shell paragraph and its
-# name-the-tier sentence, the ledger's classify-these-yourself and stale-base
-# paragraphs, the round-1 read-the-whole-diff line, and the OUTPUT contract.
-# Each is guarded by a FRAGMENT assertion aimed at one specific hazard
-# (`test_the_toolchain_*`, `test_the_ledger_*`), which is weaker than a whole
-# string and is not claimed to be more. They are unpinned because pinning every
-# sentence makes the brief unrewordable, and the three above were chosen by a
-# measured inversion, not by inventory.
+# 🔴 WHAT IS PINNED, AND WHAT IS NOT — stated as a RULE, because the previous
+# version of this comment stated a census and the census was both incomplete
+# and arithmetically inconsistent with itself ("WHOLE-STRING PINNING COVERED 7
+# OF 11 VERBATIM BLOCKS" over an enumeration of sixteen). Worse, it asserted
+# that every unpinned block "is guarded by a FRAGMENT assertion aimed at one
+# specific hazard" — a coverage claim that was false for three of the six it
+# listed, which is the failure mode `claude/RULES.md` calls reading as coverage
+# while providing none.
+#
+# THE RULE: exactly two things in this file are pinned WHOLE and two-way —
+# `INVARIANT_CLAUSES` and `SECTION_DIRECTIVES`. **Count them in the ledgers**
+# (`CLAUSE_LEDGER` and `DIRECTIVE_LEDGER` in the test module); no number is
+# restated here, because the last number here was wrong within one round.
+# EVERYTHING ELSE the brief prints is unpinned — some of it fragment-guarded,
+# some of it not guarded at all — and that set is NOT enumerable in a comment:
+# it is every sentence of every renderer, and any census of it rots on the next
+# edit.
+#
+# 🔴 THE MEASURED INVERSIONS, which is a different and checkable claim. Each
+# was applied ALONE against the whole audit-related suite and the result
+# recorded. This list is closed only over what has been MEASURED; it is not a
+# claim that nothing else is invertible.
+#
+#   Y1  the delta-scope sentence "Do not re-audit the whole PR"   -> green
+#       inverted to "Re-audit the whole PR as well". It defines the round's
+#       SCOPE.                              NOW PINNED as `delta-scope`.
+#   Y2  the cross-repo "That worktree is YOURS: fetching … is     -> green
+#       fine" inverted to "do not fetch or check out inside it",
+#       leaving a cross-repo auditor nowhere to work.
+#                                           NOW PINNED as `own-worktree-is-
+#                                           writable`.
+#   Y3  the OUTPUT per-finding format softened to "a one-paragraph
+#       summary is enough".                 -> green. STILL UNPINNED, and
+#       NOTHING asserts it. Named here so it does not read as covered.
+#   Y4  the toolchain's "Name the tier and the base sha" inverted
+#       to "there is no need to".           -> green. STILL UNPINNED, and
+#       NOTHING asserts it.
+#   Y5  the round-1 "read the whole PR diff" replaced with "the PR
+#       description is the fastest way in". -> green. STILL UNPINNED, and
+#       NOTHING asserts it.
+#
+# Y3-Y5 carry rows in `scripts/tests/mutants-audit-dispatch.py` marked as
+# DOCUMENTED HOLES rather than controls, so the gap is re-derivable and a
+# future guard that closes one turns that row red and forces this comment to be
+# updated. They are not pinned because pinning every sentence makes the brief
+# unrewordable; that is a judgement, and it is written down as one rather than
+# dressed up as coverage.
 
 Directive = namedtuple("Directive", "id text")
 
@@ -264,12 +304,55 @@ SECTION_DIRECTIVES = (
         "in a single pass. Verify each item against the diff and state, per "
         "item: **actually fixed / partially / not / made worse**.",
     ),
+    # 🔴 Y1 — THE SENTENCE THAT DEFINES THE DELTA SCOPE, and it shipped
+    # unpinned. Inverting "Do not re-audit the whole PR" into "Re-audit the
+    # whole PR as well" passed all 199 audit-related tests. It was inside a
+    # generated f-string, which is why no whole-string pin could reach it; the
+    # generated line now states the RANGE and this states the INSTRUCTION.
+    Directive(
+        "delta-scope",
+        "**Audit ONLY that range — do NOT re-audit the whole PR.** Everything "
+        "below the range is work a previous round already dispositioned; "
+        "re-reading it re-reports findings that were answered, buries the "
+        "delta this round exists to examine, and makes the round's cost "
+        "indistinguishable from a first full audit.",
+    ),
     Directive(
         "delta-regressions",
         "Also hunt for **regressions this fix round itself introduced** — the "
         "guard that is now too strict, the branch that is now unreachable, the "
         "narrowed check that now rejects a legitimate case, the rule reworded "
         "wider on one axis and narrower on another.",
+    ),
+    # 🔴 ONE WRITER FOR THE DEGENERATE-RANGE CAUSES, because there are TWO
+    # readers (the ledger's COULD NOT MEASURE and THE RANGE's banner) and both
+    # shipped the SAME false cause: "the round's fix commits are not in this
+    # checkout". `anchor_is_head` returns True only when `head_check.ok`, i.e.
+    # only when this checkout has been VERIFIED to be the PR's head commit — so
+    # the predicate that reaches the branch refutes the cause the branch offers,
+    # and the operator is sent to fetch commits into a checkout that already has
+    # them, which the `no-fetch` clause two bars later forbids.
+    #
+    # Identical shape to the empty-range reason and to `verify_head_is_the_pr`'s
+    # `no_sha_reason`, whose commit message said the fix went "to the CLASS
+    # rather than to one site" — and which then missed the two sites that same
+    # commit was writing. A sweep that does not read the diff it is part of is
+    # not a sweep.
+    Directive(
+        "degenerate-range-causes",
+        "Either the `audited=` block was written with the fix tip in its "
+        "`<from>` position — which is what `--emit-claims` records when "
+        "`--audited` is omitted, and what a bare round-1 `audited=<sha>` "
+        "always means; `<from>` is the tip the PREVIOUS round AUDITED, so "
+        "re-emit that block with `--audited <the tip that round actually "
+        "read>` and re-assemble — or nothing has been committed and pushed to "
+        "the PR since that sha was recorded, in which case there is no delta "
+        "to audit yet. 🔴 What is NOT a cause: the round's fix commits being "
+        "absent from this checkout. This checkout was VERIFIED at assembly "
+        "time to be the PR's head commit, and that verification is the very "
+        "thing that makes this range DEGENERATE rather than merely "
+        "unmeasurable — so fetching or checking out here could not help, and "
+        "the `no-fetch` clause forbids it anyway.",
     ),
     Directive(
         "checkout-moves",
@@ -278,6 +361,46 @@ SECTION_DIRECTIVES = (
         "commits can land mid-audit. That is expected and is NOT your fault and "
         "NOT a finding. **Report what you observed moving and carry on; do not "
         "chase it, and do not try to restore it.**",
+    ),
+    # 🔴 THE OTHER TWO THIRDS OF THE CHECKOUT DECISION. `checkout-moves` used to
+    # be printed unconditionally under a heading reading THE SHARED CHECKOUT,
+    # naming whatever `--show-toplevel` returned — INCLUDING a private
+    # per-agent worktree under `.claude/worktrees/agent-…`. Every one of its
+    # four claims is false there (shared / moves under you / expected / NOT a
+    # finding), and the DIRECTION is what makes it consequential: an auditor in
+    # a private worktree who watches files move is told it is expected and not
+    # a finding, which suppresses exactly the sibling-agent clobber
+    # `claude/RULES.md` ("the SESSION surface") says to report. Git answers it
+    # in one read this script never made — see `gather_worktree_kind`.
+    Directive(
+        "checkout-private",
+        "🔴 **This is a PRIVATE worktree — yours alone.** Its `.git` is a link "
+        "into a shared repository, but the WORKING TREE is not shared, so "
+        "files appearing, vanishing or changing under you is **NOT expected "
+        "here and IS worth reporting** — that is the sibling-agent clobber "
+        "`claude/RULES.md` describes, not background noise. **If something "
+        "moves, report it with what moved and when.** Writing here is fine: "
+        "the no-write clause below is about a SHARED checkout, and this is "
+        "not one.",
+    ),
+    Directive(
+        "checkout-unknown",
+        "🔴 **COULD NOT DETERMINE whether this checkout is shared** — the "
+        "`git rev-parse --git-dir --git-common-dir` read that decides it did "
+        "not answer. **Treat it as SHARED and write nothing to it.** But do "
+        "NOT treat anything you see move as expected: that absolution belongs "
+        "to a checkout KNOWN to be shared, and this one is not known to be "
+        "anything. If something moves, report it AND report that its cause "
+        "could not be established here.",
+    ),
+    # 🔴 Y2 — verbatim, operative, and unpinned. Inverting it into "do not
+    # fetch or check out inside it" passed all 199 audit-related tests and
+    # leaves a cross-repo auditor with nowhere to work: the brief has just told
+    # them to build that worktree themselves precisely so they CAN.
+    Directive(
+        "own-worktree-is-writable",
+        "That worktree is YOURS: fetching and checking out inside it is fine. "
+        "The no-write rule below is about the SHARED checkout.",
     ),
 )
 
@@ -486,12 +609,20 @@ def range_anchor(block):
 
     So a delta round reads EVERYTHING SINCE THE PREVIOUSLY-AUDITED TIP:
 
-      * HEAD == `<to>` (the block was posted at the fix tip, the common case)
-        -> the range is exactly that round's fix commits;
-      * more commits landed after the block was posted
-        -> they are included too, which is what a delta round wants;
-      * a round-1 BARE `audited=<sha>` has no `<from>`
-        -> fall back to `<to>`, which for that spelling IS the anchor.
+      * a TWO-SHA `audited=<from>..<to>` -> `<from>`, whatever HEAD is. When
+        the block was posted at the fix tip (the common case) HEAD == `<to>`
+        and the range is exactly that round's fix commits; when more commits
+        landed after it was posted they are included too, which is what a
+        delta round wants.
+      * a BARE `audited=<sha>` (the round-1 spelling) has no `<from>`
+        -> fall back to `<to>`. That single sha is only an anchor if it is the
+        tip the round AUDITED, so `--emit-claims --audited <sha>` is how it is
+        supplied. 🔴 WITH `--audited` OMITTED, `--emit-claims` stamps the PR's
+        CURRENT head — which is the head the round's FIXES produced, not the
+        tip it read — and this fallback then makes `<sha>..HEAD` a self-range.
+        That is why `--emit-claims` warns on exactly that spelling instead of
+        emitting it silently: the two bullets are otherwise jointly saying
+        "the common case for the round-1 spelling is a broken range".
 
     The WRITER's counterpart is `emit_anchor` — a different quantity, and
     conflating them is what this pair exists to prevent.
@@ -514,9 +645,12 @@ def emit_anchor(block):
     not an empty range, which is why it would survive a casual read; the two
     readers are kept separate and named so the next editor has to choose.
 
-    With no prior block (a round-1 `--emit-claims`) there is no `<from>` at all
-    and the bare `audited=<sha>` spelling is emitted instead — see
-    `emit_claims_skeleton`.
+    With no prior block (a round-1 `--emit-claims`) there is no `<from>` to
+    recover, which is what `--audited <sha>` supplies: `main` prefers the flag
+    over this function's answer, because a sha the operator states beats one
+    derived from a block someone typed. With NEITHER, the bare
+    `audited=<sha>` spelling is emitted and warned about — see
+    `emit_claims_skeleton` and the warning in `main`.
     """
     if block is None:
         return None
@@ -539,12 +673,19 @@ def round_one_anchor(blocks):
     audited, and the round-1 tip is then genuinely unknown.
 
     ⚠ NAMED PRECISELY BECAUSE THE OLD WORDING WAS WRONG ("A is the tip round 1
-    audited"). Both spellings resolve to the head AFTER round 1's fixes, so the
-    cumulative figure is "since round 1's fixes landed", not "since round 1
-    read the tree" — round 1's own fix commits are BELOW it. That is a real,
-    pre-existing limit of the quantity, not a defect this function can close,
-    and it is written here so nobody re-derives the stronger claim from the
-    name.
+    audited"), AND THE ANSWER NOW DEPENDS ON HOW THE ROUND-1 BLOCK WAS WRITTEN:
+
+      * `round=2 audited=A..B` — A is the head round 1's FIXES produced, so the
+        figure is "since round 1's fixes landed" and round 1's own fix commits
+        are BELOW it. A real limit of that spelling, not a defect here.
+      * `round=1 audited=A` written WITHOUT `--audited` — the same limit, for
+        the same reason: A is the head, assumed.
+      * `round=1 audited=A..B` written WITH `--audited A` — A really is the tip
+        round 1 READ, and the figure then means "since round 1 read the tree",
+        which is the stronger quantity the name suggests.
+
+    So the caveat is about the SPELLING, not about this function, and it is
+    written out rather than left for someone to re-derive from the name.
     """
     candidates = []
     for b in blocks:
@@ -584,8 +725,8 @@ HeadCheck = namedtuple("HeadCheck", "ok reason local_sha pr_sha")
 Facts = namedtuple(
     "Facts",
     "pr repo title base_ref url round_no cwd_repo_dir cwd_repo_slug repo_relation "
-    "branch dirty prev_sha emit_from claims claims_round checklist ledger "
-    "assembled_at claims_source head_check",
+    "worktree branch dirty prev_sha emit_from claims claims_round checklist "
+    "ledger assembled_at claims_source head_check",
 )
 # 🔴 `prev_sha` and `emit_from` are TWO ANCHORS out of ONE `audited=` field, and
 # they are deliberately separate fields rather than one: `prev_sha` is
@@ -610,6 +751,60 @@ def gather_repo_facts(runner, cwd):
     rc, out, _ = runner(["git", "-C", repo_dir, "remote", "get-url", "origin"])
     slug = _slug_from_remote(out) if rc == 0 else None
     return repo_dir, slug
+
+
+WorktreeKind = namedtuple("WorktreeKind", "kind git_dir common_dir reason")
+
+
+def gather_worktree_kind(runner, repo_dir):
+    """🔴 SHARED checkout, PRIVATE linked worktree, or COULD NOT DETERMINE.
+
+    THREE states, the same shape as `render_worktree_directive`'s repo decision
+    and for the same reason: collapsing "cannot tell" into either answer picks
+    the branch whose failure is silent.
+
+    THE BRIEF ASSERTED "SHARED" OF WHATEVER `--show-toplevel` RETURNED. Run
+    from `…/.claude/worktrees/agent-…` — which is where a dispatched auditor
+    usually stands — it printed a heading reading THE SHARED CHECKOUT over "This
+    checkout is SHARED with other sessions and agents. It MOVES UNDER YOU …
+    That is expected and is NOT your fault and NOT a finding." All four claims
+    are false for a private per-agent worktree, and the DIRECTION is what makes
+    it consequential: the auditor is told to disregard exactly the
+    sibling-agent clobber `claude/RULES.md` says to report.
+
+    Git answers it in one read:
+
+        --git-dir        …/devrc/.git/worktrees/agent-af298…
+        --git-common-dir …/devrc/.git            <- differ => linked worktree
+
+    🔴 COMPARED AS RESOLVED PATHS, NEVER AS STRINGS. Measured at four points:
+    a repo ROOT answers `.git` / `.git`; a repo SUBDIRECTORY answers
+    `/abs/path/.git` / `../.git` — textually different, the same directory. A
+    string compare would call every subdirectory of an ordinary clone a private
+    worktree, i.e. it would be wrong in the direction that drops the no-write
+    instruction. `repo_dir` is normally `--show-toplevel`, but
+    `gather_repo_facts` falls back to the raw cwd when that fails, so the
+    subdirectory case is reachable in production and not a hypothetical.
+    """
+    rc, out, err = runner(
+        ["git", "-C", repo_dir, "rev-parse", "--git-dir", "--git-common-dir"]
+    )
+    lines = [ln.strip() for ln in (out or "").splitlines() if ln.strip()]
+    if rc != 0 or len(lines) != 2:
+        return WorktreeKind(
+            "unknown", None, None,
+            f"`git rev-parse --git-dir --git-common-dir` in {repo_dir} exited "
+            f"{rc} and printed {len(lines)} path(s) where 2 were expected: "
+            f"{((err or out) or '').strip() or 'no output'}",
+        )
+
+    def _resolved(p):
+        # `-C repo_dir` is what git resolved these against, so join there.
+        return os.path.realpath(os.path.join(repo_dir, p))
+
+    git_dir, common_dir = _resolved(lines[0]), _resolved(lines[1])
+    kind = "shared" if git_dir == common_dir else "private"
+    return WorktreeKind(kind, git_dir, common_dir, None)
 
 
 def gather_checkout_state(runner, repo_dir):
@@ -756,8 +951,17 @@ def same_commit(a, b):
     quiet way this whole guard would fail to fire. Empty is never equal to
     anything — `"x".startswith("")` is True, and treating a MISSING anchor as
     "the same commit" would report a self-range for the round-1 case.
+
+    🔴 CASE-FOLDED, and that is not cosmetic either. `git rev-parse` prints
+    lowercase hex, but the `audited=` field is TYPED BY A HUMAN into a PR
+    comment and `ABC41024` is the same commit as `abc41024`. Compared
+    case-sensitively, an upper- or mixed-case anchor answers False here, which
+    silently disables `anchor_is_head` at all three call sites and restores the
+    confident "verified at assembly time to be PR #<n>'s head commit" banner
+    over a range that cannot contain anything — the exact failure the whole
+    degenerate-range guard exists to prevent, re-armed by a shift key.
     """
-    a, b = (a or ""), (b or "")
+    a, b = (a or "").lower(), (b or "").lower()
     if not a or not b:
         return False
     return a.startswith(b) or b.startswith(a)
@@ -854,10 +1058,7 @@ def measure_ledger(runner, repo_dir, prev_sha, base, head_check=None):
                 "same commit and it could not contain anything whatever the "
                 "PR looks like. That is a broken question, NOT a clean round — "
                 "do not read a finding-free audit over it as evidence of "
-                "anything. The round's fix commits are not in this checkout, "
-                "or the `audited=` field was written with the fix tip in the "
-                "`<from>` position; `<from>` is the tip the PREVIOUS round "
-                "audited."
+                "anything. " + directive("degenerate-range-causes")
             )
         if head_check is not None and head_check.ok:
             return fail(
@@ -989,14 +1190,20 @@ def render_worktree_directive(facts):
             f"/tmp/audit-pr{facts.pr}-r{facts.round_no} <the PR's head branch>",
             "```",
             "",
-            "That worktree is YOURS: fetching and checking out inside it is "
-            "fine. The no-write rule below is about the SHARED checkout.",
+            directive("own-worktree-is-writable"),
         ])
+    # 🔴 "this session's own repository (`…/worktrees/agent-…`)" named a
+    # PRIVATE per-agent worktree as if it were the clone. The repo relation is
+    # unaffected — a linked worktree really is the same repository — but the
+    # PATH is not the shared clone, and the brief said it was.
+    here = f"`{facts.cwd_repo_dir}`"
+    if facts.worktree.kind == "private":
+        here += " — a PRIVATE linked worktree of it, not the shared clone"
     return "\n".join([
         "## WHERE TO WORK",
         "",
-        f"The PR lives in `{facts.repo}`, which is this session's own repository "
-        f"(`{facts.cwd_repo_dir}`).",
+        f"The PR lives in `{facts.repo}`, which is the repository this session "
+        f"is standing in ({here}).",
         "",
         f"{ISOLATION_RECOMMEND} — the flag worktrees the CWD's repo, and here "
         "that is the right one.",
@@ -1058,11 +1265,7 @@ def render_range(facts):
             "over this range is a fact about the RANGE and is NOT evidence "
             "about the code — do not let the stop-rule clause below convert it "
             "into \"the ladder ENDS\".\n\n"
-            "Either the round's fix commits are not in this checkout, or the "
-            f"`audited=` block was written with the fix tip in its `<from>` "
-            "position. `<from>` is the tip the PREVIOUS round audited; `<to>` "
-            "is the head that round's fixes produced. Fix that and re-assemble "
-            "before auditing anything."
+            + directive("degenerate-range-causes")
         )
     elif hc is not None and hc.ok:
         tip = "HEAD"
@@ -1086,7 +1289,14 @@ def render_range(facts):
         "",
         f"A DELTA re-audit, round {facts.round_no}. Diff **`{facts.prev_sha}"
         f"..{tip}`** — the fix commits made since the tip round "
-        f"{facts.claims_round} audited. Do not re-audit the whole PR.",
+        f"{facts.claims_round} audited.",
+        "",
+        # 🔴 Y1. The scope instruction used to live INSIDE the generated line
+        # above, where no whole-string pin could reach it — and inverting it to
+        # "Re-audit the whole PR as well" passed the entire suite. The line
+        # above now states the RANGE; this states the INSTRUCTION, and it is
+        # pinned two-way like every other directive.
+        directive("delta-scope"),
         "",
         note,
         "",
@@ -1097,20 +1307,48 @@ def render_range(facts):
 
 
 def render_checkout(facts):
+    """🔴 THREE states — see `gather_worktree_kind`.
+
+    The heading is deliberately state-INDEPENDENT ("THE CHECKOUT"), because the
+    `no-fetch` invariant clause names this section by name and a heading that
+    changes with the state would leave that clause pointing at nothing. Which
+    KIND of checkout it is goes in the block, where it is a fact, and the
+    consequence goes in the directive, where it is pinned.
+    """
     dirty = (
         "could not read (`git status` failed)" if facts.dirty < 0
         else f"{facts.dirty} uncommitted path(s)"
     )
-    return "\n".join([
-        "## THE SHARED CHECKOUT — state at assembly time",
+    wt = facts.worktree
+    kind_line = {
+        "shared": "SHARED — other sessions and agents are in this tree",
+        "private": "PRIVATE worktree — linked to a shared repo, tree is yours",
+    }.get(wt.kind, "🔴 COULD NOT DETERMINE")
+    lines = [
+        "## THE CHECKOUT — state at assembly time",
         "",
         f"    path   : {facts.cwd_repo_dir}",
+        f"    kind   : {kind_line}",
         f"    branch : {facts.branch}",
         f"    dirty  : {dirty}",
         f"    read at: {facts.assembled_at}",
+    ]
+    if wt.kind == "private":
+        lines += [
+            f"    git dir: {wt.git_dir}",
+            f"    common : {wt.common_dir}   <- differs, so this is a linked "
+            "worktree",
+        ]
+    elif wt.kind == "unknown":
+        lines += ["", f"    {wt.reason}"]
+    lines += [
         "",
-        directive("checkout-moves"),
-    ])
+        directive({
+            "shared": "checkout-moves",
+            "private": "checkout-private",
+        }.get(wt.kind, "checkout-unknown")),
+    ]
+    return "\n".join(lines)
 
 
 def render_toolchain(facts):
@@ -1375,13 +1613,24 @@ def emit_claims_skeleton(facts, head_sha):
     from). They are different shas and the single-anchor spelling is wrong on
     one side whichever one you pick: write `prev_sha` here and the next round
     re-audits the previous round's fix commits as well.
+
+    🔴 A FOURTH, from round 4: `emit_from` is ALSO whatever `--audited` said,
+    and for ROUND 1 that flag is the only thing that can supply it. Round 1 has
+    no previous block, so with the flag omitted this falls back to the bare
+    `audited=<head>` spelling — which records the head this round's FIXES
+    produced in the field the next round anchors on, making that round's range
+    empty by construction. The fallback is kept (a bare sha is still readable,
+    and refusing here would break the remedy the delta refusal advertises) and
+    `main` warns LOUDLY on exactly that spelling instead.
     """
     if facts.emit_from:
         audited = f"{facts.emit_from}..{head_sha}"
     else:
-        # Round 1: no previous tip exists, so the header carries the audited tip
-        # ALONE. `round_one_anchor` reads a round-1 bare sha as the cumulative
-        # anchor, so the ledger stays measurable from here on.
+        # Round 1 with no `--audited`: nothing here knows the tip the round
+        # read, so the header carries ONE sha — the head, assumed. The parser
+        # and `round_one_anchor` both read a bare sha as the audited tip, so
+        # the ledger stays measurable; the assumption is what `main` warns
+        # about, because it is an assumption and not a measurement.
         audited = head_sha
     return "\n".join([
         f"```audit-claims round={facts.round_no} audited={audited}",
@@ -1477,6 +1726,18 @@ def build_parser():
     ap.add_argument("--emit-claims", action="store_true",
                     help="also print an audit-claims block skeleton to paste "
                          "into this round's PR comment")
+    # 🔴 THE ONE THING `--emit-claims` CANNOT DERIVE. It runs AFTER this round's
+    # fixes have landed, so every sha it can see locally is a fix tip; the tip
+    # the round's audit READ is only in the operator's head (or in the dispatch
+    # that started the round). For round >= 2 it is recoverable from the
+    # previous block's `<to>`, which is what `emit_anchor` does — for ROUND 1
+    # there is no previous block and nothing to recover it from, which is
+    # exactly the hole this flag closes.
+    ap.add_argument("--audited", metavar="SHA",
+                    help="the tip THIS round's audit read — written as the "
+                         "`<from>` of the `--emit-claims` block. Round 1 has "
+                         "no previous block to derive it from; without this, "
+                         "HEAD is ASSUMED and said so on stderr.")
     ap.add_argument("--claims-file",
                     help="read claims-block text from this file instead of the "
                          "PR's comments (offline/testing seam)")
@@ -1530,7 +1791,21 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
     if args.pr is None:
         parser.error("the PR number is required (or use --check FILE)")
 
+    # A flag that silently does nothing is the shape this module refuses
+    # everywhere else: `--audited` is written by `--emit-claims` and by nothing
+    # else, so passing it to a plain assembly run is a no-op the operator would
+    # otherwise read as "recorded".
+    if args.audited and not args.emit_claims:
+        print(
+            "⚠ --audited names the tip this round's audit read and is only "
+            "ever written by --emit-claims, which this run does not pass. The "
+            "flag changed NOTHING; the range below is anchored on the previous "
+            "round's block as usual.",
+            file=err_stream,
+        )
+
     repo_dir, cwd_slug = gather_repo_facts(runner, cwd)
+    worktree = gather_worktree_kind(runner, repo_dir)
     branch, dirty = gather_checkout_state(runner, repo_dir)
 
     if args.claims_file:
@@ -1632,7 +1907,14 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
     # `--emit-claims` stamps the head the block is posted at into that same
     # field. Reproduced live on devrc #958 and hermetically.
     prev_sha = range_anchor(newest)
-    emit_from = emit_anchor(newest)
+    # 🔴 `--audited` OVERRIDES THE WRITER'S ANCHOR AND NEVER THE READER'S. It
+    # states the tip THIS round's audit read — the same quantity `emit_anchor`
+    # recovers from the previous block, supplied instead of derived, and for
+    # ROUND 1 the only way to have it at all. `prev_sha` (what this run DIFFS
+    # from) is deliberately untouched: assembly runs before the audit and
+    # `--emit-claims` after it, and collapsing the two anchors is the defect
+    # round 3 fixed.
+    emit_from = args.audited or emit_anchor(newest)
     claims = list(newest.items) if newest else []
     claims_round = newest.round_no if newest else None
     if newest is not None and newest.round_no >= args.round_no:
@@ -1680,6 +1962,7 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
         cwd_repo_dir=repo_dir,
         cwd_repo_slug=cwd_slug,
         repo_relation=repo_relation,
+        worktree=worktree,
         branch=branch,
         dirty=dirty,
         prev_sha=prev_sha,
@@ -1752,24 +2035,56 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
                 f"you are about to write: {head_check.reason}",
                 file=err_stream,
             )
-        # 🔴 A SELF-RANGE in the block being WRITTEN. `<from>` is the tip this
-        # round audited and `<to>` is the head its fixes produced; equal means
-        # no fix commits exist yet, so the block claims a round that changed
-        # nothing and the NEXT round will anchor on an empty range. Emitted
-        # silently until round 3: `--round 2 --emit-claims` and `--round 3
-        # --emit-claims` both printed `audited=d9eb36a8..d9eb36a8` with no
-        # warning at all.
-        if same_commit(facts.emit_from, head_sha):
-            print(
-                "🔴 --emit-claims is writing a SELF-RANGE: "
-                f"`audited={head_sha}..{head_sha}`. The two ends are the same "
-                "commit, so the block records a round whose fixes changed "
-                "NOTHING, and the next round's delta range will be EMPTY BY "
-                "CONSTRUCTION — which reads as a clean round. Commit and push "
-                "this round's fixes, then re-run; do not post this block as it "
-                "stands.",
-                file=err_stream,
-            )
+        # 🔴 ASKED OF THE ANCHOR THE NEXT ROUND WILL ACTUALLY USE — not of
+        # `facts.emit_from` directly. Spelled on `emit_from`, this guard was
+        # STRUCTURALLY UNREACHABLE for the one spelling it most needed to
+        # cover: a ROUND-1 `--emit-claims` has no previous block, `emit_from`
+        # is None, `same_commit` answers False for an empty operand — and the
+        # BARE block that then gets written carries the identical hazard,
+        # because `range_anchor` falls back to `<to>` and `<to>` IS the head it
+        # was just stamped at. Round 1 is the remedy the delta refusal
+        # ADVERTISES, so the unreachable case was the advertised one.
+        # Reproduced hermetically and live: this PR's own round-1 block is
+        # `audited=abc41024` (bare, the round-1 FIX tip), and a round-2 brief
+        # assembled from it renders DEGENERATE.
+        next_anchor = range_anchor(
+            ClaimsBlock(args.round_no, facts.emit_from or "", head_sha, [])
+        )
+        if same_commit(next_anchor, head_sha):
+            if facts.emit_from:
+                # `<from>` and `<to>` are both present and name one commit.
+                # Emitted silently until round 3: `--round 2 --emit-claims` and
+                # `--round 3 --emit-claims` both printed
+                # `audited=d9eb36a8..d9eb36a8` with no warning at all.
+                print(
+                    "🔴 --emit-claims is writing a SELF-RANGE: "
+                    f"`audited={head_sha}..{head_sha}`. The two ends are the "
+                    "same commit, so the block records a round whose fixes "
+                    "changed NOTHING, and the next round's delta range will be "
+                    "EMPTY BY CONSTRUCTION — which reads as a clean round. "
+                    "Commit and push this round's fixes, then re-run; do not "
+                    "post this block as it stands.",
+                    file=err_stream,
+                )
+            else:
+                print(
+                    "🔴 --emit-claims is writing a BARE "
+                    f"`audited={head_sha}`, and that sha is the PR's CURRENT "
+                    "head — because --audited was not passed, so HEAD was "
+                    "ASSUMED to be the tip this round's audit read. It is "
+                    "usually not: --emit-claims runs AFTER the round's fixes "
+                    "have landed, so HEAD is the head those fixes PRODUCED. "
+                    "The next round reads a bare sha as its anchor and would "
+                    f"diff `{head_sha}..HEAD` — both ends the same commit, "
+                    "EMPTY BY CONSTRUCTION, which reads as a clean round. "
+                    "Re-run with `--audited <the tip this round's audit "
+                    "actually read>`; the block then carries `<that tip>.."
+                    f"{head_sha}` and the next round sees this round's fix "
+                    "commits. (If nothing has landed since the audit read the "
+                    "tree, the sha is right and there is no delta to assemble "
+                    "anyway.)",
+                    file=err_stream,
+                )
         print("\n" + _bar(), file=out_stream)
         print("Paste this into the PR comment for this round, so the NEXT "
               "round can read it:\n", file=out_stream)

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -1529,8 +1529,21 @@ def unresolved_tip_note(facts, with_reason=True):
         return ""
     hc = facts.head_check
     lookup = f"gh pr view {facts.pr} --json headRefOid"
+    # 🔴 ROUND 12 — `--repo` IS NEVER OMITTED. Dropping it when the PR's
+    # repository is unknown hands over a bare `gh pr view 900 --json
+    # headRefOid`, which resolves against whatever repository the auditor's
+    # CWD is in — and this note renders in briefs whose WHERE TO WORK section
+    # has just told them that is a DIFFERENT repository. It would return a sha
+    # at rc 0, for another project's PR #900. A `<...>` fill-in cannot run
+    # until the operator supplies the answer, which is the honest outcome for
+    # a fact this run never learned.
     if facts.repo != REPO_UNKNOWN:
         lookup += f" --repo {facts.repo}"
+    else:
+        lookup += (
+            " --repo <owner/name — this run never learned which repository "
+            "the PR is in>"
+        )
     reason = (
         f"\n\n    {hc.reason if hc is not None else 'no check was made'}\n\n"
         if with_reason else " "
@@ -1601,6 +1614,14 @@ def cross_repo_holds_neither_end(facts):
     So the question both sites ask is this one, and it asks the head check
     FIRST: claim the structural impossibility only once the sha comparison has
     actually failed.
+
+    🔴 ROUND 12 — WHAT IT ESTABLISHES IS NARROWER THAN ITS NAME, and both
+    consumers now say so. A failed head check means this checkout is not
+    STANDING on the PR's head; it says nothing about whether either commit
+    EXISTS in the object store, and a mirror or a fork remote behind the PR
+    can hold the round's anchor sha perfectly well. So the rendered sentences
+    read "not confirmed to hold either end" rather than "holds neither end" —
+    the measured claim, not the stronger one it was being read as.
     """
     hc = facts.head_check
     if hc is not None and hc.ok:
@@ -1718,7 +1739,7 @@ def render_range(facts):
             "So the range above names the PR's head SHA outright — read from "
             "`gh pr view --json headRefOid`, not resolved in any tree. Both of "
             "its ends exist in YOUR worktree, the one WHERE TO WORK told you to "
-            "make, and neither exists here."
+            "make, and neither is confirmed here."
             if range_tip_is_a_sha(facts)
             else unresolved_tip_note(facts, with_reason=False)
         )
@@ -1957,9 +1978,9 @@ def render_ledger(facts):
             "true of every round of this PR and not a failure of this run.** "
             f"The PR lives in `{facts.repo}`; this brief was assembled in "
             f"`{facts.cwd_repo_slug or facts.cwd_repo_dir}`, a DIFFERENT "
-            "repository, which holds neither end of the range. A number "
-            "measured here would be a measurement of another project, so none "
-            "is printed.",
+            "repository, which is not confirmed to hold either end of the "
+            "range. A number measured here would be a measurement of another "
+            "project, so none is printed.",
             "",
             "🔴 **THE ATTRIBUTION GATE IS YOURS THIS ROUND — it is not "
             "optional and nobody else can compute it.** The ladder ends on two "

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -62,6 +62,31 @@ right — is dropped on the floor. `--emit-claims` prints a correctly-formed
 skeleton for the operator to paste into the round's PR comment, so the NEXT
 round has something to read.
 
+🔴 `audited=<from>..<to>` HAS EXACTLY ONE MEANING, AND TWO READERS
+------------------------------------------------------------------
+    `<from>` is the tip that round's AUDIT read.
+    `<to>`   is the head that round's FIXES produced.
+
+It meant something different to the writer and the reader for two rounds, and
+the range that fell out was EMPTY BY CONSTRUCTION: `--emit-claims` stamps the
+PR's CURRENT head into `<to>`, while the next round diffed `<to>..HEAD` — and
+those coincide, because the block is posted at the fix tip. Reproduced live on
+devrc #958 (`audited=abc41024..d9eb36a8`, and `--round 3` rendered
+``Diff `d9eb36a8..HEAD` `` with HEAD *being* `d9eb36a8`) and hermetically.
+
+So there are two named readers of the one field, and they return DIFFERENT shas:
+
+  * `range_anchor` = `<from>` or, for a bare round-1 `audited=<sha>`, `<to>`.
+    What a delta round DIFFS FROM — everything since the previously-audited tip.
+  * `emit_anchor`  = `<to>`. What `--emit-claims` WRITES as the next block's
+    `<from>`, because the tip THIS round audited is where the last one stopped.
+
+`anchor_is_head` is the third piece: a `<sha>..HEAD` whose `<sha>` IS HEAD is a
+broken question, not a clean round, and the range section, the ledger and
+`--emit-claims` each say so LOUDLY rather than rendering an empty diff — an
+auditor who diffs nothing finds nothing, and the `stop-rule` clause then
+converts that into "the ladder ENDS".
+
 🔴 TWO REFUSALS, AND THEY ARE NOT THE SAME KIND
 ------------------------------------------------
 1. **`--round N` for N ≥ 2 with no parseable claims block REFUSES to emit**
@@ -187,6 +212,88 @@ INVARIANT_CLAUSES = (
 )
 
 INVARIANTS_HEADING = "## 🔴 NON-NEGOTIABLE — every audit, every round"
+
+# --------------------------------------------------------------------------- #
+# THE SECTION DIRECTIVES — verbatim instruction prose that is NOT a clause.
+# --------------------------------------------------------------------------- #
+# 🔴 WHOLE-STRING PINNING COVERED 7 OF 11 VERBATIM BLOCKS, and three inversions
+# walked straight through a fully green 58-test suite. Round 2 made whole-string
+# pinning the standard for auditor instructions and then applied it to
+# `INVARIANT_CLAUSES` alone; these three blocks are verbatim, non-generated
+# instruction prose that shipped in every delta brief with nothing watching:
+#
+#   site             mutation applied alone                       result
+#   render_claims    keep "never WHY IT IS CORRECT", rewrite the  58 passed
+#                    sentence to "the fix round already verified
+#                    each of these, so take them as established"
+#   render_range     delete the whole "Also hunt for regressions" 58 passed
+#   render_checkout  invert "NOT a finding … do not chase it"     58 passed
+#                    into "a finding worth reporting. Restore
+#                    anything you see move."
+#
+# The first inverts this module's own headline 🔴 rule into the exact framed
+# audit it documents; the third tells the auditor to WRITE to the shared
+# checkout, contradicting the `no-fetch` clause two bars later in the same
+# brief. Same shape as W1-W5: the pinned fragment survives, the instruction
+# around it says the opposite.
+#
+# They are NOT invariant clauses — an invariant clause renders in every brief,
+# and two of these are meaningless in a round-1 one ("this fix round" when
+# there has been no fix round). So they stay in the sections that own them and
+# get their own ledger, pinned WHOLE and two-way by the test module exactly as
+# `INVARIANT_CLAUSES` is.
+#
+# 🔴 WHICH VERBATIM BLOCKS ARE **NOT** PINNED, said plainly rather than left to
+# read as covered: the toolchain section's wrong-shell paragraph and its
+# name-the-tier sentence, the ledger's classify-these-yourself and stale-base
+# paragraphs, the round-1 read-the-whole-diff line, and the OUTPUT contract.
+# Each is guarded by a FRAGMENT assertion aimed at one specific hazard
+# (`test_the_toolchain_*`, `test_the_ledger_*`), which is weaker than a whole
+# string and is not claimed to be more. They are unpinned because pinning every
+# sentence makes the brief unrewordable, and the three above were chosen by a
+# measured inversion, not by inventory.
+
+Directive = namedtuple("Directive", "id text")
+
+SECTION_DIRECTIVES = (
+    Directive(
+        "claims-framing",
+        "🔴 This is WHAT WAS CLAIMED, never WHY IT IS CORRECT — nothing here is "
+        "established. Three successive FRAMED audits confirmed a claim purely "
+        "because the prompt handed them the answer; one BLIND audit refuted it "
+        "in a single pass. Verify each item against the diff and state, per "
+        "item: **actually fixed / partially / not / made worse**.",
+    ),
+    Directive(
+        "delta-regressions",
+        "Also hunt for **regressions this fix round itself introduced** — the "
+        "guard that is now too strict, the branch that is now unreachable, the "
+        "narrowed check that now rejects a legitimate case, the rule reworded "
+        "wider on one axis and narrower on another.",
+    ),
+    Directive(
+        "checkout-moves",
+        "🔴 **This checkout is SHARED with other sessions and agents. It MOVES "
+        "UNDER YOU** — the branch can change, files can appear and vanish, and "
+        "commits can land mid-audit. That is expected and is NOT your fault and "
+        "NOT a finding. **Report what you observed moving and carry on; do not "
+        "chase it, and do not try to restore it.**",
+    ),
+)
+
+DIRECTIVE = {d.id: d.text for d in SECTION_DIRECTIVES}
+
+
+def directive(did):
+    """The verbatim block `did` — or a LOUD placeholder if it was deleted.
+
+    Never a `KeyError` and never silence. A deleted directive must leave a mark
+    a human reading the brief can see AND that the rendered-section pin can
+    fail on; raising instead would make every test in the suite error, which
+    scores a deletion as "killed" for the wrong reason and tells the operator
+    nothing.
+    """
+    return DIRECTIVE.get(did) or f"⚠ MISSING VERBATIM BLOCK `{did}`"
 
 # The two mutually exclusive worktree directives. Which one a brief carries is
 # decided by a FACT (the PR's repo vs the cwd's repo), never by the author's
@@ -353,6 +460,69 @@ def newest_block(blocks):
     return best
 
 
+def range_anchor(block):
+    """🔴 What a DELTA round must diff FROM — `audited_from`, not `audited_to`.
+
+    THE FIELD MEANT TWO DIFFERENT THINGS TO THE WRITER AND THE READER, and the
+    range that fell out was EMPTY BY CONSTRUCTION. `--emit-claims` stamps the
+    PR's CURRENT head into `<to>`; this function used to be spelled
+    `newest.audited_to` at the one call site, so the next round diffed
+    `<the head at emit time>..HEAD` — and those coincide, because the block is
+    posted at the fix tip. Reproduced live on devrc #958: the round-2 comment
+    carried `audited=abc41024..d9eb36a8`, and `--round 3` rendered
+    ``Diff `d9eb36a8..HEAD` `` with HEAD *being* `d9eb36a8`.
+
+    That is worse than a wrong number. THE RANGE section does not consult the
+    ledger, so it printed the empty range under "verified at assembly time to be
+    PR #958's head commit" followed by "Do not re-audit the whole PR" — an
+    auditor obeying it diffs nothing, finds nothing, and the `stop-rule` clause
+    then converts that into "the ladder ENDS".
+
+    THE SEMANTICS, stated once so both sides can be checked against it:
+
+        `audited=<from>..<to>` records that the round's fix took the tree from
+        `<from>` — the tip that round's AUDIT read — to `<to>`, the head its
+        fixes produced.
+
+    So a delta round reads EVERYTHING SINCE THE PREVIOUSLY-AUDITED TIP:
+
+      * HEAD == `<to>` (the block was posted at the fix tip, the common case)
+        -> the range is exactly that round's fix commits;
+      * more commits landed after the block was posted
+        -> they are included too, which is what a delta round wants;
+      * a round-1 BARE `audited=<sha>` has no `<from>`
+        -> fall back to `<to>`, which for that spelling IS the anchor.
+
+    The WRITER's counterpart is `emit_anchor` — a different quantity, and
+    conflating them is what this pair exists to prevent.
+    """
+    if block is None:
+        return None
+    return block.audited_from or block.audited_to or None
+
+
+def emit_anchor(block):
+    """🔴 What `--emit-claims` must write as `<from>` — `audited_to`.
+
+    The mirror image of `range_anchor`, and NOT the same sha. A round-N block
+    records the tip round N's AUDIT read; that tip is the head the previous
+    round's block ended at, i.e. the newest block's `audited_to`.
+
+    Spelling this `range_anchor` instead — the obvious "one anchor for
+    everything" simplification — writes the tip round N-1 audited into round N's
+    block, so round N+1 re-audits round N-1's fix commits as well. A superset,
+    not an empty range, which is why it would survive a casual read; the two
+    readers are kept separate and named so the next editor has to choose.
+
+    With no prior block (a round-1 `--emit-claims`) there is no `<from>` at all
+    and the bare `audited=<sha>` spelling is emitted instead — see
+    `emit_claims_skeleton`.
+    """
+    if block is None:
+        return None
+    return block.audited_to or None
+
+
 def round_one_anchor(blocks):
     """The sha ROUND 1 audited, or None.
 
@@ -361,11 +531,20 @@ def round_one_anchor(blocks):
     NOT MEASURED — never derived from the base, which is a different quantity.
 
     Two spellings carry it, and both are read:
-      * `round=2 audited=A..B` — A is the tip round 1 audited (the usual case);
+      * `round=2 audited=A..B` — A is the tip ROUND 2's audit read, which is the
+        head round 1's fixes produced (the usual case);
       * `round=1 audited=A`    — the bare form `--emit-claims` writes for a
-        round-1 comment, where the audited TIP is itself that same quantity.
+        round-1 comment, which is that same head.
     A bare sha on any LATER round is NOT an anchor: it says what that round
     audited, and the round-1 tip is then genuinely unknown.
+
+    ⚠ NAMED PRECISELY BECAUSE THE OLD WORDING WAS WRONG ("A is the tip round 1
+    audited"). Both spellings resolve to the head AFTER round 1's fixes, so the
+    cumulative figure is "since round 1's fixes landed", not "since round 1
+    read the tree" — round 1's own fix commits are BELOW it. That is a real,
+    pre-existing limit of the quantity, not a defect this function can close,
+    and it is written here so nobody re-derives the stronger claim from the
+    name.
     """
     candidates = []
     for b in blocks:
@@ -405,9 +584,14 @@ HeadCheck = namedtuple("HeadCheck", "ok reason local_sha pr_sha")
 Facts = namedtuple(
     "Facts",
     "pr repo title base_ref url round_no cwd_repo_dir cwd_repo_slug repo_relation "
-    "branch dirty prev_sha claims claims_round checklist ledger assembled_at "
-    "claims_source head_check",
+    "branch dirty prev_sha emit_from claims claims_round checklist ledger "
+    "assembled_at claims_source head_check",
 )
+# 🔴 `prev_sha` and `emit_from` are TWO ANCHORS out of ONE `audited=` field, and
+# they are deliberately separate fields rather than one: `prev_sha` is
+# `range_anchor` (what this round DIFFS FROM) and `emit_from` is `emit_anchor`
+# (what `--emit-claims` WRITES as the next block's `<from>`). Collapsing them is
+# the defect this round fixed, in one direction or the other.
 
 
 def _slug_from_remote(url):
@@ -504,7 +688,7 @@ def pr_slug(data, override=None):
     return None
 
 
-def verify_head_is_the_pr(runner, repo_dir, pr_head_sha):
+def verify_head_is_the_pr(runner, repo_dir, pr_head_sha, no_sha_reason=None):
     """🔴 The FOURTH read rule: is this checkout's HEAD the PR's head commit?
 
     Everything the delta half of this brief says — the ledger's numbers, the
@@ -521,13 +705,24 @@ def verify_head_is_the_pr(runner, repo_dir, pr_head_sha):
 
     So a failed check returns a `reason` and NO number, exactly like the other
     three: an unverifiable measurement is not a measurement.
+
+    🔴 `no_sha_reason` IS THE THIRD FALSE-CAUSE SITE, found by sweeping for the
+    class rather than fixing the two the audit named. The message here used to
+    read "`gh` was not consulted — `--claims-file` mode — or reported no
+    `headRefOid`", offering two causes with nothing to choose between them —
+    and the CALLER knows which one it is, because it is the caller that decided
+    whether to consult `gh` at all. So the caller names it, and this function
+    keeps a truthful fallback for a caller that genuinely cannot say.
     """
     if not pr_head_sha:
+        why = no_sha_reason or (
+            "`gh` was not consulted, or reported no `headRefOid` — this caller "
+            "did not say which"
+        )
         return HeadCheck(
             False,
-            "the PR's head sha is not known here (`gh` was not consulted — "
-            "`--claims-file` mode — or reported no `headRefOid`), so nothing "
-            "can confirm this checkout is standing on the PR",
+            f"the PR's head sha is not known here ({why}), so nothing can "
+            "confirm this checkout is standing on the PR",
             None,
             None,
         )
@@ -551,6 +746,49 @@ def verify_head_is_the_pr(runner, repo_dir, pr_head_sha):
             pr_head_sha,
         )
     return HeadCheck(True, None, local, pr_head_sha)
+
+
+def same_commit(a, b):
+    """Do two shas of DIFFERENT LENGTHS name the same commit?
+
+    `audited=` carries an 8-char abbreviation; `git rev-parse HEAD` returns 40.
+    A plain `==` between them is False for every real self-range, which is the
+    quiet way this whole guard would fail to fire. Empty is never equal to
+    anything — `"x".startswith("")` is True, and treating a MISSING anchor as
+    "the same commit" would report a self-range for the round-1 case.
+    """
+    a, b = (a or ""), (b or "")
+    if not a or not b:
+        return False
+    return a.startswith(b) or b.startswith(a)
+
+
+def anchor_is_head(anchor, head_check):
+    """🔴 Is `<anchor>..HEAD` EMPTY BY CONSTRUCTION rather than merely empty?
+
+    ONE PREDICATE, ONE PLACE — the range renderer, the ledger and
+    `--emit-claims` all ask it, and a predicate open-coded at three sites is
+    wrong at two of them in the same direction.
+
+    A range whose two ends are the SAME COMMIT can never contain anything, so
+    "it is empty" says nothing about the PR: it is a fact about the range. That
+    distinction is the whole point. An ordinary empty range is a real
+    measurement ("nothing has landed since"); a self-range is a broken question,
+    and reporting it as the first is how a round with ZERO commits examined gets
+    written up as clean.
+
+    The length mismatch is handled by `same_commit`, not here — and it is not
+    cosmetic: `audited=` carries 8 chars, `rev-parse HEAD` returns 40, so a
+    plain `==` answers False for every real self-range this exists to catch.
+
+    An UNVERIFIED checkout answers False rather than True: when HEAD is not the
+    PR's head, `local_sha` is some other branch's tip and comparing an anchor
+    against it says nothing about the range the auditor will run. That case
+    already has its own COULD NOT VERIFY banner.
+    """
+    if head_check is None or not head_check.ok:
+        return False
+    return same_commit(anchor, head_check.local_sha)
 
 
 # --------------------------------------------------------------------------- #
@@ -600,11 +838,41 @@ def measure_ledger(runner, repo_dir, prev_sha, base, head_check=None):
     except ValueError:
         return fail(f"`git rev-list --count` printed {out.strip()!r}, not a number")
     if commits == 0:
+        # 🔴 THREE causes, and TWO OF THEM ARE REFUTED BY `head_check` — which is
+        # a parameter of this very function, already required `ok` twelve lines
+        # above. The old text named "the fixes are not committed yet, or this
+        # checkout does not have them" unconditionally, so a brief printed
+        # "verified at assembly time to be PR #958's head commit" and "this
+        # checkout does not have them" in one document. Same false-cause shape
+        # as the cumulative reason below, and the reason that fix is now applied
+        # to the CLASS rather than to one site.
+        if anchor_is_head(prev_sha, head_check):
+            return fail(
+                f"the range `{prev_sha}..HEAD` is EMPTY BY CONSTRUCTION, not "
+                f"merely empty: `{prev_sha}` IS this checkout's HEAD "
+                f"({head_check.local_sha}), so both ends of the range are the "
+                "same commit and it could not contain anything whatever the "
+                "PR looks like. That is a broken question, NOT a clean round — "
+                "do not read a finding-free audit over it as evidence of "
+                "anything. The round's fix commits are not in this checkout, "
+                "or the `audited=` field was written with the fix tip in the "
+                "`<from>` position; `<from>` is the tip the PREVIOUS round "
+                "audited."
+            )
+        if head_check is not None and head_check.ok:
+            return fail(
+                f"the range `{prev_sha}..HEAD` is EMPTY — and this checkout's "
+                f"HEAD ({head_check.local_sha}) IS the PR's head, so it is not "
+                "a case of the commits being elsewhere: nothing has landed on "
+                f"the PR itself since `{prev_sha}`. The fixes for this round "
+                "are not committed and pushed yet."
+            )
         return fail(
             f"the range `{prev_sha}..HEAD` is EMPTY — nothing has landed since "
             "the sha that round audited, so there is no delta to audit. Either "
             "the fixes are not committed yet, or this checkout does not have "
-            "them."
+            "them. (No head check was made here, which is why both remain "
+            "live.)"
         )
 
     rc, out, err = runner([
@@ -741,11 +1009,7 @@ def render_claims(facts):
     lines = [
         "## WHAT WAS CLAIMED FIXED",
         "",
-        "🔴 This is WHAT WAS CLAIMED, never WHY IT IS CORRECT — nothing here is "
-        "established. Three successive FRAMED audits confirmed a claim purely "
-        "because the prompt handed them the answer; one BLIND audit refuted it "
-        "in a single pass. Verify each item against the diff and state, per "
-        "item: **actually fixed / partially / not / made worse**.",
+        directive("claims-framing"),
         "",
     ]
     lines += [f"{i}. {c}" for i, c in enumerate(facts.claims, 1)]
@@ -775,7 +1039,32 @@ def render_range(facts):
     # the shared checkout happens to be standing on — reproduced against an
     # unrelated feature branch, where it read as an ordinary non-empty range.
     hc = facts.head_check
-    if hc is not None and hc.ok:
+    # 🔴 AND `..HEAD` is not meaningful when the ANCHOR is HEAD. This section
+    # does not consult the ledger, so a self-range used to be rendered here with
+    # full confidence — "verified at assembly time to be PR #958's head commit"
+    # over ``Diff `d9eb36a8..HEAD` `` with HEAD *being* `d9eb36a8`, followed by
+    # "Do not re-audit the whole PR". An auditor obeying that diffs nothing,
+    # finds nothing, and the stop-rule clause turns the empty result into "the
+    # ladder ENDS". The banner is loud because the failure is silent.
+    if anchor_is_head(facts.prev_sha, hc):
+        tip = "HEAD"
+        note = (
+            "🔴 **DEGENERATE RANGE — EMPTY BY CONSTRUCTION. DO NOT AUDIT IT AND "
+            "DO NOT REPORT IT CLEAN.**\n\n"
+            f"    the anchor `{facts.prev_sha}` IS this checkout's HEAD "
+            f"({hc.local_sha})\n\n"
+            "Both ends of the range name the same commit, so it can never "
+            "contain anything, whatever the PR looks like. A finding-free pass "
+            "over this range is a fact about the RANGE and is NOT evidence "
+            "about the code — do not let the stop-rule clause below convert it "
+            "into \"the ladder ENDS\".\n\n"
+            "Either the round's fix commits are not in this checkout, or the "
+            f"`audited=` block was written with the fix tip in its `<from>` "
+            "position. `<from>` is the tip the PREVIOUS round audited; `<to>` "
+            "is the head that round's fixes produced. Fix that and re-assemble "
+            "before auditing anything."
+        )
+    elif hc is not None and hc.ok:
         tip = "HEAD"
         note = (
             f"This checkout's HEAD is `{hc.local_sha}`, verified at assembly "
@@ -803,10 +1092,7 @@ def render_range(facts):
         "",
         f"Base branch: `{facts.base_ref}`.",
         "",
-        "Also hunt for **regressions this fix round itself introduced** — the "
-        "guard that is now too strict, the branch that is now unreachable, the "
-        "narrowed check that now rejects a legitimate case, the rule reworded "
-        "wider on one axis and narrower on another.",
+        directive("delta-regressions"),
     ])
 
 
@@ -823,11 +1109,7 @@ def render_checkout(facts):
         f"    dirty  : {dirty}",
         f"    read at: {facts.assembled_at}",
         "",
-        "🔴 **This checkout is SHARED with other sessions and agents. It MOVES "
-        "UNDER YOU** — the branch can change, files can appear and vanish, and "
-        "commits can land mid-audit. That is expected and is NOT your fault and "
-        "NOT a finding. **Report what you observed moving and carry on; do not "
-        "chase it, and do not try to restore it.**",
+        directive("checkout-moves"),
     ])
 
 
@@ -1086,9 +1368,16 @@ def emit_claims_skeleton(facts, head_sha):
        standing on it, and is otherwise a record of some other branch's tip
        going into the field the NEXT round anchors on. The caller now passes the
        PR's own head sha.
+
+    🔴 A THIRD, from round 3: the `<from>` written here is `facts.emit_from`
+    (`emit_anchor` — the newest block's `audited_to`, i.e. the tip THIS round's
+    audit read), NOT `facts.prev_sha` (`range_anchor` — what THIS round diffed
+    from). They are different shas and the single-anchor spelling is wrong on
+    one side whichever one you pick: write `prev_sha` here and the next round
+    re-audits the previous round's fix commits as well.
     """
-    if facts.prev_sha:
-        audited = f"{facts.prev_sha}..{head_sha}"
+    if facts.emit_from:
+        audited = f"{facts.emit_from}..{head_sha}"
     else:
         # Round 1: no previous tip exists, so the header carries the audited tip
         # ALONE. `round_one_anchor` reads a round-1 bare sha as the cumulative
@@ -1252,9 +1541,20 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
             return 2
         claims_source = f"`{args.claims_file}`"
         data = {"title": f"PR #{args.pr}", "url": "", "baseRefName": "main"}
+        # 🔴 THE CALLER KNOWS WHICH CAUSE IT IS. See `verify_head_is_the_pr`:
+        # naming both leaves the reader with a list instead of an answer, and
+        # this branch is the one that decided not to consult `gh`.
+        no_sha_reason = (
+            "this run is `--claims-file` mode, which consults no `gh` and so "
+            "never learns the PR's `headRefOid`"
+        )
     else:
         data, comment_texts = gh_pr_facts(runner, args.pr, args.repo)
         claims_source = f"PR #{args.pr}'s comments"
+        no_sha_reason = (
+            "`gh pr view` was consulted and reported no `headRefOid` for this "
+            "PR"
+        )
         if data.get("_error"):
             print(f"🔴 `gh pr view {args.pr}` failed: {data['_error']}",
                   file=err_stream)
@@ -1327,7 +1627,12 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
             file=err_stream,
         )
 
-    prev_sha = newest.audited_to if newest else None
+    # 🔴 TWO anchors, ONE field. See `range_anchor` / `emit_anchor`: reading
+    # `audited_to` here made the delta range EMPTY BY CONSTRUCTION, because
+    # `--emit-claims` stamps the head the block is posted at into that same
+    # field. Reproduced live on devrc #958 and hermetically.
+    prev_sha = range_anchor(newest)
+    emit_from = emit_anchor(newest)
     claims = list(newest.items) if newest else []
     claims_round = newest.round_no if newest else None
     if newest is not None and newest.round_no >= args.round_no:
@@ -1341,7 +1646,9 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
     # 🔴 The FOURTH read rule, computed once and used by all three consumers
     # that were measuring the operator's checkout instead of the PR: the ledger,
     # the range section, and the `audited=` sha `--emit-claims` stamps.
-    head_check = verify_head_is_the_pr(runner, repo_dir, data.get("headRefOid"))
+    head_check = verify_head_is_the_pr(
+        runner, repo_dir, data.get("headRefOid"), no_sha_reason
+    )
 
     ledger = None
     base_ref = data.get("baseRefName") or "main"
@@ -1376,6 +1683,7 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
         branch=branch,
         dirty=dirty,
         prev_sha=prev_sha,
+        emit_from=emit_from,
         claims=claims,
         claims_round=claims_round,
         checklist=checklist_reader(repo_dir),
@@ -1442,6 +1750,24 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
                 "⚠ --emit-claims stamped the PR's head sha, which is correct — "
                 "but this checkout is NOT standing on it, so re-read the claims "
                 f"you are about to write: {head_check.reason}",
+                file=err_stream,
+            )
+        # 🔴 A SELF-RANGE in the block being WRITTEN. `<from>` is the tip this
+        # round audited and `<to>` is the head its fixes produced; equal means
+        # no fix commits exist yet, so the block claims a round that changed
+        # nothing and the NEXT round will anchor on an empty range. Emitted
+        # silently until round 3: `--round 2 --emit-claims` and `--round 3
+        # --emit-claims` both printed `audited=d9eb36a8..d9eb36a8` with no
+        # warning at all.
+        if same_commit(facts.emit_from, head_sha):
+            print(
+                "🔴 --emit-claims is writing a SELF-RANGE: "
+                f"`audited={head_sha}..{head_sha}`. The two ends are the same "
+                "commit, so the block records a round whose fixes changed "
+                "NOTHING, and the next round's delta range will be EMPTY BY "
+                "CONSTRUCTION — which reads as a clean round. Commit and push "
+                "this round's fixes, then re-run; do not post this block as it "
+                "stands.",
                 file=err_stream,
             )
         print("\n" + _bar(), file=out_stream)

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -110,10 +110,19 @@ converts that into "the ladder ENDS".
    the next round diffed `abc..HEAD`; `e06461f7..dd601793` corrupted `<to>`
    instead and cascaded into the round after that. A refusal and NOT a warning,
    because the failure is silent at every downstream station — nothing reports
-   the block malformed, and the self-range guard cannot fire on it. 🔴 A
-   well-formed token that is not a commit round-trips and is NOT caught: this
-   script never resolves a sha, and saying otherwise would be a guard whose
-   description is wider than its implementation.
+   the block malformed, and the self-range guard cannot fire on it. Whitespace
+   is refused on the INPUT rather than by that round trip, which is
+   line-oriented on both sides and therefore blind to a NEWLINE — see the check
+   in `main`. 🔴 A well-formed token that is not a commit round-trips and is
+   NOT caught. THE REASON IS NOT THAT THIS SCRIPT CANNOT RESOLVE A SHA — it
+   runs seven read-only `git -C <that checkout>` commands, two of which
+   (`rev-list --count <anchor>..HEAD`, `log --numstat … <anchor>..HEAD`)
+   resolve exactly that token in exactly that checkout. The reason is that this
+   script deliberately never FETCHES, so the assembly checkout may legitimately
+   lack an object that is perfectly fine on the PR, and a `cat-file` refusal
+   there would be a FALSE POSITIVE on a correct value. The downstream cost is
+   bounded and correctly attributed: `rev-list` exits 128 and the ledger prints
+   COULD NOT MEASURE naming the command, one round later.
 
 🔴 EVERY NUMBER HERE IS ABOUT THE PR, NOT ABOUT YOUR CHECKOUT
 -------------------------------------------------------------
@@ -464,14 +473,48 @@ SECTION_DIRECTIVES = (
     # fetch or check out inside it" passed all 199 audit-related tests and
     # leaves a cross-repo auditor with nowhere to work: the brief has just told
     # them to build that worktree themselves precisely so they CAN.
+    #
+    # 🔴 ROUND 6 — THE SECOND SENTENCE FORWARD-REFERENCES A CLAUSE THAT NO
+    # LONGER SAYS WHAT IT NAMES. It used to read "the no-write rule below is
+    # about the SHARED checkout", which was true while `no-fetch` was scoped to
+    # sharedness. Round 5 rewrote that clause off sharedness and onto OWNERSHIP,
+    # and this sentence was left behind — so in the configuration production
+    # actually produces (a cross-repo PR assembled in a PRIVATE agent worktree)
+    # the brief reads, in order: "the no-write rule below is about the SHARED
+    # checkout" -> "kind : PRIVATE linked worktree" -> "write to no checkout
+    # that is not the copy YOU made, including the one THE CHECKOUT names".
+    # That is the same syllogism round 4 wrote into `checkout-private` and round
+    # 5 deleted, surviving one directive over: the reader can discharge the
+    # no-write rule on the grounds that this checkout is not shared.
+    #
+    # So the scope is stated the way the clause states it — by OWNERSHIP, which
+    # is true in every checkout state and cannot be discharged by one.
     Directive(
         "own-worktree-is-writable",
         "That worktree is YOURS: fetching and checking out inside it is fine. "
-        "The no-write rule below is about the SHARED checkout.",
+        "The no-write rule below is about every checkout you did not make.",
     ),
 )
 
 DIRECTIVE = {d.id: d.text for d in SECTION_DIRECTIVES}
+
+# 🔴 WHICH DIRECTIVE EACH `gather_worktree_kind` STATE RENDERS — ONE PLACE.
+# `render_checkout` used to carry this map inline, which left the RELATIONSHIP
+# ("every state the renderer can select carries the no-write rule") with no
+# machine-readable statement anywhere: round 5's guard over it had to spell the
+# set as ids beginning `checkout-`, and round 6 measured the consequence —
+# RENAMING `checkout-private` to `assembly-private`, DROPPING its no-write
+# sentence and updating the three ledgers left the whole suite green. The rule
+# is the renderer's selection, never a naming convention, so the selection is
+# what a guard now reads. `unknown` is both a state and the fallback for a
+# state this map does not know: not knowing which state you are in is itself
+# the unknown state, and collapsing it into either answer picks the branch
+# whose failure is silent.
+CHECKOUT_STATE_DIRECTIVE = {
+    "shared": "checkout-moves",
+    "private": "checkout-private",
+    "unknown": "checkout-unknown",
+}
 
 
 def directive(did):
@@ -1350,12 +1393,41 @@ def render_range(facts):
             "into \"the ladder ENDS\".\n\n"
             + directive("degenerate-range-causes")
         )
+    # 🔴 ROUND 7 — THE THIRD INSTANCE OF THIS LADDER'S RECURRING CONFUSION, and
+    # it is a TIME axis rather than a place one. Round 3 conflated the
+    # OPERATOR'S CHECKOUT with the tree under audit; round 5 conflated the
+    # ASSEMBLING PROCESS'S CWD with where the auditor stands. This pair: the
+    # HEAD VERIFIED AT ASSEMBLY TIME versus the HEAD THE AUDITOR'S COMMAND WILL
+    # RESOLVE.
+    #
+    # `hc.ok` means `git rev-parse HEAD` in THIS tree, at THIS moment, equalled
+    # the PR's head. It says nothing about the tree the auditor types `..HEAD`
+    # in: this same brief says `Dispatch with isolation: "worktree"` and that
+    # the checkout it names is "not necessarily the one you are standing in",
+    # and the cross-repo recipe hands them a BRANCH, not this sha. That tree is
+    # cut AFTER assembly from a repo the brief itself describes as live under
+    # another session — so a commit landing in between makes
+    # `git diff <from>..HEAD` cover commits no claims block describes, while
+    # the brief's own justification asserts the range was verified.
+    #
+    # Two tells that this is the same inversion and not a new one: the
+    # UNVERIFIED branch three lines down already does the safe thing
+    # (`tip = hc.pr_sha`), and `emit_claims_skeleton` already prefers the
+    # resolved PR head. Only the VERIFIED branch hardcoded `HEAD` — the branch
+    # where being sure was mistaken for the range being stable.
+    #
+    # The ledger below still MEASURES `<anchor>..HEAD`, and correctly: that
+    # command runs HERE, now, in the tree just verified. What is handed to
+    # ANOTHER process, later, is a sha.
     elif hc is not None and hc.ok:
-        tip = "HEAD"
+        tip = hc.local_sha
         note = (
             f"This checkout's HEAD is `{hc.local_sha}`, verified at assembly "
-            f"time to be PR #{facts.pr}'s head commit — which is what makes "
-            "`..HEAD` mean the PR here."
+            f"time to be PR #{facts.pr}'s head commit — so the range above "
+            "names that SHA and not `HEAD`. `HEAD` would resolve in YOUR "
+            "worktree, which is cut after this brief was assembled from a "
+            "repository other sessions are pushing to; the sha cannot move "
+            "under you."
         )
     else:
         tip = hc.pr_sha if (hc is not None and hc.pr_sha) else "<the PR's head sha>"
@@ -1429,10 +1501,8 @@ def render_checkout(facts):
         lines += ["", f"    {wt.reason}"]
     lines += [
         "",
-        directive({
-            "shared": "checkout-moves",
-            "private": "checkout-private",
-        }.get(wt.kind, "checkout-unknown")),
+        directive(CHECKOUT_STATE_DIRECTIVE.get(
+            wt.kind, CHECKOUT_STATE_DIRECTIVE["unknown"])),
     ]
     return "\n".join(lines)
 
@@ -1463,7 +1533,10 @@ def render_toolchain(facts):
     name a tree that does not contain what was tested. This section knows
     nothing about where the auditor stands, so it says only what is true in
     every state — that copy is not yours and holds none of your mutations.
-    `test_the_toolchain_reason_is_true_in_both_checkout_states` drives both.
+    `test_the_toolchain_reason_is_true_in_every_scenario` drives EVERY scenario
+    that module knows and requires this section byte-identical across all of
+    them — round 5 drove two, both same-repo, and round 6 measured that a
+    cross-repo-only reword walked it.
     """
     r = facts.cwd_repo_dir
     return "\n".join([
@@ -1779,11 +1852,34 @@ def emit_claims_skeleton(facts, head_sha):
 # "it does not parse" refusal. Measured by the battery, which reported both as
 # EXTRA-KILLER. This asks only whether the printed field survives the FORMAT.
 #
-# 🔴 NAMED BLIND SPOT: a well-formed token that is not a commit (`zzzzzzzz`)
-# round-trips perfectly and is NOT caught. This script never resolves the sha —
-# it does not `git cat-file` anything in a checkout it refuses to write to — so
-# "is it a real commit" is a question it cannot answer, and pretending otherwise
-# would be a guard whose description is wider than its implementation.
+# 🔴 NAMED BLIND SPOT ONE: a well-formed token that is not a commit
+# (`zzzzzzzz`) round-trips perfectly and is NOT caught.
+#
+# 🔴 AND THE REASON GIVEN HERE FOR THREE ROUNDS WAS FALSE. It asserted that
+# this script performs no sha resolution at all in that checkout, on the
+# grounds that it will not write to one. It does resolve it: `gather_ledger`
+# runs
+# `git -C <that checkout> rev-list --count <anchor>..HEAD` and
+# `git -C <that checkout> log --numstat … <anchor>..HEAD`, both of which resolve
+# exactly this token in exactly that checkout, and READING is not writing. The
+# gap is real; the stated cause was not, and a false cause is what makes the
+# next round close a hole that was never there.
+#
+# THE TRUE REASON, which the code never stated: this script deliberately never
+# FETCHES. So the assembly checkout can legitimately be missing an object that
+# is perfectly present on the PR — a routine state, since it may be an
+# unfetched worktree of a branch someone else pushed — and a `cat-file` refusal
+# there would reject a CORRECT value. The downstream cost of leaving it open is
+# bounded and loud: `rev-list` exits 128 one round later and the ledger prints
+# COULD NOT MEASURE naming the command that failed.
+#
+# 🔴 NAMED BLIND SPOT TWO, and it is why `main` checks the INPUT separately:
+# this function compares the printed header LINE against a parse of that same
+# printed header LINE. `_EMITTED_AUDITED` is `re.M` + `$`; `parse_claims_blocks`
+# reads line by line. Both sides are line-oriented, so a NEWLINE inside the
+# value pushes content onto the next line where NEITHER side can see it and
+# they agree — a control built out of the step it doubts. Do not widen this
+# function to cover it; the input check does, before this runs.
 EMIT_REFUSAL_HEADER = "🔴 REFUSING TO EMIT an `audit-claims` block"
 
 # The RAW text after `audited=`, to end of line — deliberately NOT `\S+`, which
@@ -1935,10 +2031,14 @@ def build_parser():
                     help="the tip THIS round's audit read — written as the "
                          "`<from>` of the `--emit-claims` block. Round 1 has "
                          "no previous block to derive it from; without this, "
-                         "HEAD is ASSUMED and said so on stderr. ONE sha: no "
-                         "whitespace, no `..`, no placeholder — the emitted "
-                         "block is fed back through this script's own parser "
-                         "and a value that does not survive is REFUSED.")
+                         "HEAD is ASSUMED and said so on stderr. ONE sha, and "
+                         "exactly one token: any whitespace at all — a "
+                         "TRAILING NEWLINE included — is refused on the INPUT, "
+                         "because a newline moves content off the header line "
+                         "where the round trip below cannot see it. A value "
+                         "with `..` or a placeholder is refused too: the "
+                         "emitted block is fed back through this script's own "
+                         "parser and one that does not survive is REFUSED.")
     ap.add_argument("--claims-file",
                     help="read claims-block text from this file instead of the "
                          "PR's comments (offline/testing seam)")
@@ -2010,6 +2110,51 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
             "BY CONSTRUCTION.",
             "",
             "  Pass the sha this round's audit actually read, or omit the flag.",
+        ]), file=err_stream)
+        return 4
+
+    # 🔴 ROUND 6 — THE ROUND TRIP IS STRUCTURALLY BLIND TO A NEWLINE, so the
+    # ONE character that moves content off the header LINE gets its own check
+    # on the INPUT, before any of that machinery runs.
+    #
+    # `emitted_block_reads_back_as_written` compares the printed header LINE
+    # against a parse of that same printed header LINE. Both sides are
+    # line-oriented (`_EMITTED_AUDITED` is `re.M` + `$`; `parse_claims_blocks`
+    # reads line by line), so anything pushed onto the NEXT line is invisible
+    # to both and they agree — a control built out of the step it doubts. The
+    # empty check above misses it too: `.strip()` is truthy for `aaaa1111\n`.
+    #
+    # Measured through `main()` at `3619fe68`: `--audited $'aaaa1111\n'` exited
+    # 0 and emitted ``audited=aaaa1111`` — the BARE round-1 spelling, `<to>`
+    # dropped on the floor and a stray `..<head>` line left in the body, with
+    # `parse_claims_blocks` reporting `malformed=[]`. Round 3 then reads
+    # `emit_anchor` = `aaaa1111`, and round 4 re-audits round 2's fixes on top
+    # of round 3's, one round downstream and in silence.
+    #
+    # 🔴 THE PREDICATE IS `split() != [value]`, NOT `len(split()) != 1`. The
+    # obvious spelling does NOT catch this: `'aaaa1111\n'.split()` is
+    # `['aaaa1111']` — length ONE — because `str.split()` with no argument
+    # discards empty fields. It misses a trailing newline, a trailing space and
+    # a trailing `\r` alike. Only comparing against the value ITSELF asks the
+    # question that matters: is this exactly one token with nothing around it?
+    #
+    # Deliberately independent of the round trip: it asks about the INPUT, the
+    # round trip asks about the printed BLOCK, and coupling them is the N3/Y7
+    # cascade round 5 measured and refused.
+    if args.audited is not None and args.audited.split() != [args.audited]:
+        print("\n".join([
+            f"{EMIT_REFUSAL_HEADER}: `--audited` was given a value carrying "
+            f"WHITESPACE ({args.audited!r}).",
+            "",
+            "  It must be exactly ONE whitespace-free token. A NEWLINE is the "
+            "dangerous one: it moves everything after it off the header LINE, "
+            "where neither this script's parser nor the emitted block's own "
+            "round-trip check can see it — the block degrades to the bare "
+            "`audited=<sha>` spelling, `<to>` is lost, and nothing downstream "
+            "reports it malformed.",
+            "",
+            "  Pass a single sha — `--audited abc1234`, not `--audited "
+            "\"$(some command)\"`, whose output ends in a newline.",
         ]), file=err_stream)
         return 4
 

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -1,0 +1,947 @@
+#!/usr/bin/env python3
+"""Assemble an adversarial-audit brief for a PR — the INVARIANT half as CODE.
+
+    scripts/audit-dispatch.py <pr-number> [--round N] [--repo owner/name]
+    scripts/audit-dispatch.py <pr-number> --round 3 --emit-claims
+
+It PRINTS a brief to stdout for pasting into an `Agent` dispatch. It dispatches
+nothing, merges nothing and writes nothing to the repository under audit.
+
+WHY IT EXISTS — the measurement
+-------------------------------
+`claude/skills/audit-pr/SKILL.md` tells an operator to "dispatch a subagent …
+against this checklist" and supplies no procedure, so the brief is reassembled
+from prose every time. Measured over one session that ran 14 audit dispatches:
+**60,100 characters** of hand-written brief, mean 4,292 each; **42%** mean
+similarity between consecutive briefs; **zero** lines longer than 25 chars
+identical across all 14.
+
+Hard-won clauses ACCRETED rather than being present from the start, and three
+were LOST after being learned:
+
+    instruction                      present in dispatch #
+                                     1  2  3  4  5  6  7  8  9 10 11 12 13 14
+    do NOT git fetch            5/14 ·  ·  ·  ·  ·  ·  ·  ·  ✓  ✓  ·  ✓  ✓  ✓
+    shared checkout warning     9/14 ·  ·  ·  ·  ·  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓
+    'ending it is CORRECT'      6/14 ·  ·  ·  ·  ·  ·  ·  ✓  ✓  ✓  ·  ✓  ✓  ✓
+    'a nit is not a finding'    9/14 ·  ·  ·  ·  ✓  ✓  ✓  ✓  ✓  ✓  ·  ✓  ✓  ✓
+    bare pytest = wrong shell  10/14 ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ·  ✓  ·  ·  ·
+    payload/scaffolding label  10/14 ·  ·  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ·  ·  ✓  ✓
+    sandbox tier named         11/14 ·  ·  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ·  ✓  ✓  ✓  ✓
+
+Consequences that actually happened: the auditor at dispatch 8 ran `git fetch`
+in a repo the brief called read-only (the clause first appears at 9); the first
+five auditors reported the shared checkout moving as if it might be their fault;
+the seven rounds before dispatch 8 ran under a stop rule that never said
+stopping was the correct outcome.
+
+So `INVARIANT_CLAUSES` below is the SECTION THAT CANNOT BE FORGOTTEN. It is one
+module-level list, rendered verbatim into every brief this script emits, and
+pinned two-way by `scripts/tests/test_audit_dispatch.py` against that module's
+own independent ledger — so deleting a clause here goes red there, and a bullet
+appearing in the rendered section with no clause behind it goes red too.
+
+🔴 THE FRAMING CONSTRAINT — WHY PROSE IS NEVER PARSED
+-----------------------------------------------------
+A delta round must be framed on WHAT WAS CLAIMED FIXED, never on WHY IT IS
+CORRECT. The skill records that three successive FRAMED audits confirmed a claim
+purely because the prompt handed them the answer, while one BLIND audit refuted
+it in a single pass.
+
+A PR comment contains both — the claims and the reasoning that argues for them.
+So this script reads ONLY the fenced block:
+
+    ```audit-claims round=3 audited=997375ec..9f638fd4
+    1. run_move collapsed WRONG-KILLER into NOT EXCLUSIVE — now two branches
+    2. the "97% / most" quantifier over-stated what the measurement supports
+    ```
+
+and reproduces only its numbered lines. Everything else in the comment —
+including the paragraph directly under the fence explaining why each fix is
+right — is dropped on the floor. `--emit-claims` prints a correctly-formed
+skeleton for the operator to paste into the round's PR comment, so the NEXT
+round has something to read.
+
+🔴 TWO REFUSALS, AND THEY ARE NOT THE SAME KIND
+------------------------------------------------
+1. **`--round N` for N ≥ 2 with no parseable claims block REFUSES to emit**
+   (exit 2), naming what it looked for and where. An empty "what was claimed
+   fixed" section silently turns a delta re-audit into a blind full audit — a
+   different thing, which would then read as covered. Same shape as
+   `scripts/ladder-depth-sweep.py`'s refused zero: the failure and the
+   legitimate case produce the SAME observable, so neither may be reported.
+2. **A brief missing an invariant clause WARNS and never blocks.** That check
+   exists for a hand-edited `--out` file, and `claude/RULES.md` is explicit that
+   a permanently-red gate trains everyone to click through it. Warn-only is the
+   right severity for a channel whose failure is cosmetic and whose false
+   positive rate is set by whatever a human typed.
+
+🔴 WHAT THIS SCRIPT DOES NOT DO
+--------------------------------
+* **It does not classify payload vs scaffolding.** The skill says that is a
+  human judgement, and records that a pathspec is wrong in BOTH directions on
+  ordinary names (`':!*test*'` swallows `attestation/`, `latest/`,
+  `inspector/`; it keeps `FooTest.java` and `login.cy.ts`). So the ledger prints
+  the changed-file list and leaves X blank for a human.
+* **It does not `git fetch`.** The brief it writes forbids the auditor from
+  writing to the shared checkout; doing it here would be the same write. `<base>`
+  is therefore only as current as the operator's last fetch, and the brief SAYS
+  SO rather than quoting a number it cannot vouch for.
+* **It does not dispatch, comment, push or merge.**
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import namedtuple
+from datetime import datetime, timezone
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# THE INVARIANT CLAUSES — the whole point of the script.
+# --------------------------------------------------------------------------- #
+# 🔴 ONE list, rendered verbatim into every brief. Each entry is a single line
+# (no embedded newlines) so the rendered section is trivially parseable as
+# bullets, which is what makes the two-way pin in the test module mechanical
+# rather than a prose comparison.
+#
+# `id` is the stable handle the test module's independent ledger names. Renaming
+# an id is a deliberate act that fails that ledger; rewording `text` is not
+# caught here (see the test module's "what this does NOT enforce" note).
+
+Clause = namedtuple("Clause", "id text")
+
+INVARIANT_CLAUSES = (
+    Clause(
+        "read-only",
+        "**READ-ONLY — you modify nothing in the repository under audit.** If "
+        "you must mutate something to test a theory, do it in a `cp -a` copy "
+        "and run `rm -f <copy>/.git` FIRST: a worktree's `.git` is a FILE "
+        "pointing at the real git dir, so a commit inside the copy lands on the "
+        "branch you are auditing.",
+    ),
+    Clause(
+        "no-fetch",
+        "**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to the "
+        "shared checkout named in THE SHARED CHECKOUT section of this brief.** "
+        "Other sessions are in it; a fetch there is a write with cross-session "
+        "blast radius, and every ref you need is already resolved for you "
+        "here.",
+    ),
+    Clause(
+        "stop-rule",
+        "**A clean round ENDS the ladder — ending it is the CORRECT outcome, "
+        "not a failure.** Rounds continue only while the previous round "
+        "produced a finding that needed fixing. Do not manufacture findings to "
+        "justify the round, and do not run another round to confirm a clean "
+        "one.",
+    ),
+    Clause(
+        "nit-is-not-a-finding",
+        "**A nit that changes nothing a reader does is NOT a finding.** If the "
+        "fix would be a reword with no behavioural, decision or "
+        "correctness consequence, leave it out of the findings and say so in "
+        "one line under the verdict instead.",
+    ),
+    Clause(
+        "reverify-self-reported",
+        "**Re-verify the fix commit's own self-reported numbers rather than "
+        "accepting them.** Counts, byte sizes, mutation-sweep results and "
+        "\"watched red at <sha>\" claims in a commit message or PR body are "
+        "claims to check against the tree, never evidence.",
+    ),
+    Clause(
+        "finding-format",
+        "**Report each finding with `file:line`, a concrete failure scenario "
+        "(the input, the path taken, the wrong output) and a `payload` or "
+        "`scaffolding` label** — payload is what the PR exists to ship; "
+        "scaffolding is the tests, fixtures and notes a round wrote to guard "
+        "it.",
+    ),
+    Clause(
+        "do-not-merge",
+        "**Do not merge — report only.** No pushes, no PR comments, no "
+        "`gh pr merge`. Hand the findings back and let the operator act on "
+        "them.",
+    ),
+)
+
+INVARIANTS_HEADING = "## 🔴 NON-NEGOTIABLE — every audit, every round"
+
+# The two mutually exclusive worktree directives. Which one a brief carries is
+# decided by a FACT (the PR's repo vs the cwd's repo), never by the author's
+# memory — that decision is the single highest-value generated field here.
+ISOLATION_RECOMMEND = 'Dispatch with `isolation: "worktree"`'
+ISOLATION_FORBID = 'Do NOT use `isolation: "worktree"`'
+
+# --------------------------------------------------------------------------- #
+# The claims block — the ONLY thing read out of a PR comment.
+# --------------------------------------------------------------------------- #
+# Tolerant on the header's trailing content and on the fence length, strict on
+# the two fields that matter. A block whose header does not parse is reported as
+# MALFORMED rather than skipped: skipping it silently would produce the same
+# observable as "no block at all", and those need different fixes.
+_CLAIMS_FENCE = re.compile(
+    r"^(?P<fence>`{3,})audit-claims(?P<header>[^\n]*)\n"
+    r"(?P<body>.*?)^(?P=fence)\s*$",
+    re.M | re.S,
+)
+_HEADER_ROUND = re.compile(r"\bround=(\d+)\b")
+_HEADER_AUDITED = re.compile(r"\baudited=(\S+)")
+_CLAIM_ITEM = re.compile(r"^\s*(\d+)[.)]\s+(.+?)\s*$")
+
+ClaimsBlock = namedtuple("ClaimsBlock", "round_no audited_from audited_to items")
+
+
+def parse_claims_blocks(texts):
+    """-> (blocks, malformed_reasons) over an iterable of comment bodies.
+
+    Pure and independently testable: the refusal below is only trustworthy if
+    this can be driven with no network and no PR.
+    """
+    blocks, malformed = [], []
+    for text in texts:
+        for m in _CLAIMS_FENCE.finditer(text or ""):
+            header = m.group("header")
+            r = _HEADER_ROUND.search(header)
+            a = _HEADER_AUDITED.search(header)
+            if not r or not a:
+                malformed.append(
+                    "an `audit-claims` fence whose header does not carry both "
+                    f"`round=<n>` and `audited=<sha>..<sha>` (header was:"
+                    f" `{header.strip() or '<empty>'}`)"
+                )
+                continue
+            spec = a.group(1)
+            frm, _, to = spec.partition("..")
+            if not to:
+                # A bare sha is accepted as the audited TIP; the round-1 anchor
+                # is then simply unknown, which the ledger reports rather than
+                # guesses.
+                frm, to = "", frm
+            items = [
+                mm.group(2)
+                for mm in (_CLAIM_ITEM.match(ln) for ln in m.group("body").splitlines())
+                if mm
+            ]
+            if not items:
+                malformed.append(
+                    f"an `audit-claims round={r.group(1)}` block with no "
+                    "numbered claim lines in its body"
+                )
+                continue
+            blocks.append(ClaimsBlock(int(r.group(1)), frm, to, items))
+    return blocks, malformed
+
+
+def newest_block(blocks):
+    """The highest `round=` present. Ties resolve to the last one seen."""
+    best = None
+    for b in blocks:
+        if best is None or b.round_no >= best.round_no:
+            best = b
+    return best
+
+
+def round_one_anchor(blocks):
+    """The left side of the LOWEST-numbered block's range, or None.
+
+    That is the only sha in the corpus that can anchor the ledger's cumulative
+    "since round 1" figure. When no block carries one, the figure is reported
+    NOT MEASURED — never derived from the base, which is a different quantity.
+    """
+    ordered = sorted((b for b in blocks if b.audited_from), key=lambda b: b.round_no)
+    return ordered[0].audited_from if ordered else None
+
+
+# --------------------------------------------------------------------------- #
+# Process boundary — ONE runner, injected, so every test is hermetic.
+# --------------------------------------------------------------------------- #
+
+def real_runner(cmd, cwd=None):
+    """-> (rc, stdout, stderr). The only place this module spawns anything."""
+    p = subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, check=False
+    )
+    return p.returncode, p.stdout, p.stderr
+
+
+# --------------------------------------------------------------------------- #
+# Facts gathered per invocation
+# --------------------------------------------------------------------------- #
+
+LedgerReport = namedtuple("LedgerReport", "files added deleted commits reason cumulative")
+Facts = namedtuple(
+    "Facts",
+    "pr repo title base_ref url round_no cwd_repo_dir cwd_repo_slug cross_repo "
+    "branch dirty prev_sha claims claims_round checklist ledger assembled_at "
+    "claims_source",
+)
+
+
+def _slug_from_remote(url):
+    """`owner/name` out of any git remote URL spelling, or None."""
+    if not url:
+        return None
+    url = url.strip().removesuffix(".git")
+    m = re.search(r"[:/]([^/:]+)/([^/]+)$", url)
+    return f"{m.group(1)}/{m.group(2)}" if m else None
+
+
+def gather_repo_facts(runner, cwd):
+    """(repo_dir, slug) for the checkout the operator is standing in."""
+    rc, out, _ = runner(["git", "-C", cwd, "rev-parse", "--show-toplevel"])
+    repo_dir = out.strip() if rc == 0 and out.strip() else str(cwd)
+    rc, out, _ = runner(["git", "-C", repo_dir, "remote", "get-url", "origin"])
+    slug = _slug_from_remote(out) if rc == 0 else None
+    return repo_dir, slug
+
+
+def gather_checkout_state(runner, repo_dir):
+    """(branch, dirty-path-count). Both READS; nothing here writes."""
+    rc, out, _ = runner(["git", "-C", repo_dir, "rev-parse", "--abbrev-ref", "HEAD"])
+    branch = out.strip() if rc == 0 else "UNKNOWN"
+    rc, out, _ = runner(["git", "-C", repo_dir, "status", "--porcelain"])
+    dirty = len([ln for ln in out.splitlines() if ln.strip()]) if rc == 0 else -1
+    return branch, dirty
+
+
+def gh_pr_facts(runner, pr, repo=None):
+    """PR metadata + comment bodies, via `gh`. -> (dict, [comment bodies])."""
+    cmd = ["gh", "pr", "view", str(pr), "--json",
+           "title,url,baseRefName,headRepository,headRepositoryOwner,comments"]
+    if repo:
+        cmd += ["--repo", repo]
+    rc, out, err = runner(cmd)
+    if rc != 0:
+        return {"_error": (err or out).strip() or f"gh exited {rc}"}, []
+    try:
+        data = json.loads(out)
+    except ValueError as e:
+        return {"_error": f"gh returned unparseable JSON: {e}"}, []
+    comments = [
+        c.get("body") or "" for c in (data.get("comments") or [])
+        if isinstance(c, dict)
+    ]
+    return data, comments
+
+
+def pr_slug(data, override=None):
+    if override:
+        return override
+    owner = (data.get("headRepositoryOwner") or {}).get("login")
+    name = (data.get("headRepository") or {}).get("name")
+    return f"{owner}/{name}" if owner and name else None
+
+
+# --------------------------------------------------------------------------- #
+# The ledger — the skill's own command, with the skill's own read rules
+# --------------------------------------------------------------------------- #
+
+def measure_ledger(runner, repo_dir, prev_sha, base):
+    """`git log --numstat --format= --remerge-diff <prev>..HEAD --not <base>`.
+
+    🔴 The skill's read rules are enforced here, not assumed: **rc 0, silent
+    stderr, and a non-empty range**. A missing ref or a git without
+    `--remerge-diff` exits 128 with empty output; an unwritable object store
+    makes `--remerge-diff` UNDER-count, exit 0 and print a plausible number,
+    announcing itself only on stderr; and a range whose commits are not in this
+    checkout prints nothing at all, silently, with rc 0. Each of those returns a
+    `reason` and NO number — a failed command is not a zero.
+    """
+    def fail(reason):
+        return LedgerReport(None, None, None, None, reason, None)
+
+    rc, out, err = runner(
+        ["git", "-C", repo_dir, "rev-list", "--count", f"{prev_sha}..HEAD"]
+    )
+    if rc != 0:
+        return fail(f"`git rev-list {prev_sha}..HEAD` exited {rc}: "
+                    f"{(err or out).strip() or 'no output'}")
+    if err.strip():
+        return fail(f"`git rev-list` wrote to stderr: {err.strip()}")
+    try:
+        commits = int(out.strip())
+    except ValueError:
+        return fail(f"`git rev-list --count` printed {out.strip()!r}, not a number")
+    if commits == 0:
+        return fail(
+            f"the range `{prev_sha}..HEAD` is EMPTY — nothing has landed since "
+            "the sha that round audited, so there is no delta to audit. Either "
+            "the fixes are not committed yet, or this checkout does not have "
+            "them."
+        )
+
+    rc, out, err = runner([
+        "git", "-C", repo_dir, "log", "--numstat", "--format=",
+        "--remerge-diff", f"{prev_sha}..HEAD", "--not", base,
+    ])
+    if rc != 0:
+        return fail(f"the numstat command exited {rc}: "
+                    f"{(err or out).strip() or 'no output'}")
+    if err.strip():
+        return fail(
+            "the numstat command exited 0 but wrote to STDERR, so its number is "
+            f"not trustworthy: {err.strip()}"
+        )
+
+    files, added, deleted = {}, 0, 0
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        a, d, path = parts[0], parts[1], parts[-1]
+        na = 0 if a == "-" else int(a) if a.isdigit() else 0
+        nd = 0 if d == "-" else int(d) if d.isdigit() else 0
+        cur = files.get(path, (0, 0))
+        files[path] = (cur[0] + na, cur[1] + nd)
+        added += na
+        deleted += nd
+    return LedgerReport(files, added, deleted, commits, None, None)
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+
+def _bar():
+    return "-" * 76
+
+
+def render_invariants():
+    out = [INVARIANTS_HEADING, ""]
+    out += [f"- {c.text}" for c in INVARIANT_CLAUSES]
+    return "\n".join(out)
+
+
+def render_worktree_directive(facts):
+    """🔴 The generated field that closes the skill's 🔴 cross-repo hazard.
+
+    `isolation: "worktree"` worktrees the CWD's repo. For a PR in a DIFFERENT
+    repo that is the wrong tree, and the failure is quiet: the agent either
+    reports a briefed file missing, or silently audits the wrong repository and
+    reports findings about it.
+    """
+    if facts.cross_repo:
+        return "\n".join([
+            "## WHERE TO WORK — 🔴 CROSS-REPO",
+            "",
+            f"The PR lives in `{facts.repo}`. This session's checkout is "
+            f"`{facts.cwd_repo_dir}`"
+            + (f" (`{facts.cwd_repo_slug}`)" if facts.cwd_repo_slug else "")
+            + " — a DIFFERENT repository.",
+            "",
+            f"🔴 {ISOLATION_FORBID} for this dispatch: that flag builds its "
+            "worktree from the CWD's repo, which is the wrong one here, and it "
+            "fails quietly — the agent either reports a briefed file missing or "
+            "silently audits the wrong tree.",
+            "",
+            "Create the worktree yourself, against the PR's own clone:",
+            "",
+            "```",
+            f"git -C <your local clone of {facts.repo}> worktree add "
+            f"/tmp/audit-pr{facts.pr}-r{facts.round_no} <the PR's head branch>",
+            "```",
+            "",
+            "That worktree is YOURS: fetching and checking out inside it is "
+            "fine. The no-write rule below is about the SHARED checkout.",
+        ])
+    return "\n".join([
+        "## WHERE TO WORK",
+        "",
+        f"The PR lives in `{facts.repo}`, which is this session's own repository "
+        f"(`{facts.cwd_repo_dir}`).",
+        "",
+        f"{ISOLATION_RECOMMEND} — the flag worktrees the CWD's repo, and here "
+        "that is the right one.",
+    ])
+
+
+def render_claims(facts):
+    if facts.round_no < 2:
+        return ""
+    lines = [
+        "## WHAT WAS CLAIMED FIXED",
+        "",
+        "🔴 This is WHAT WAS CLAIMED, never WHY IT IS CORRECT — nothing here is "
+        "established. Three successive FRAMED audits confirmed a claim purely "
+        "because the prompt handed them the answer; one BLIND audit refuted it "
+        "in a single pass. Verify each item against the diff and state, per "
+        "item: **actually fixed / partially / not / made worse**.",
+        "",
+    ]
+    lines += [f"{i}. {c}" for i, c in enumerate(facts.claims, 1)]
+    lines += [
+        "",
+        f"(Read from the `audit-claims round={facts.claims_round}` block in "
+        f"{facts.claims_source}. Nothing else from those comments is reproduced "
+        "here — the reasoning beside a claim is exactly what a framed audit "
+        "goes on to confirm.)",
+    ]
+    return "\n".join(lines)
+
+
+def render_range(facts):
+    if facts.round_no < 2:
+        return "\n".join([
+            "## THE RANGE",
+            "",
+            f"A FIRST, FULL audit: read the whole PR diff (`gh pr diff "
+            f"{facts.pr}`) and the code it touches, not just the PR "
+            "description.",
+            "",
+            f"Base branch: `{facts.base_ref}`.",
+        ])
+    return "\n".join([
+        "## THE RANGE",
+        "",
+        f"A DELTA re-audit, round {facts.round_no}. Diff **`{facts.prev_sha}"
+        "..HEAD`** — the fix commits made since the tip round "
+        f"{facts.claims_round} audited. Do not re-audit the whole PR.",
+        "",
+        f"Base branch: `{facts.base_ref}`.",
+        "",
+        "Also hunt for **regressions this fix round itself introduced** — the "
+        "guard that is now too strict, the branch that is now unreachable, the "
+        "narrowed check that now rejects a legitimate case, the rule reworded "
+        "wider on one axis and narrower on another.",
+    ])
+
+
+def render_checkout(facts):
+    dirty = (
+        "could not read (`git status` failed)" if facts.dirty < 0
+        else f"{facts.dirty} uncommitted path(s)"
+    )
+    return "\n".join([
+        "## THE SHARED CHECKOUT — state at assembly time",
+        "",
+        f"    path   : {facts.cwd_repo_dir}",
+        f"    branch : {facts.branch}",
+        f"    dirty  : {dirty}",
+        f"    read at: {facts.assembled_at}",
+        "",
+        "🔴 **This checkout is SHARED with other sessions and agents. It MOVES "
+        "UNDER YOU** — the branch can change, files can appear and vanish, and "
+        "commits can land mid-audit. That is expected and is NOT your fault and "
+        "NOT a finding. **Report what you observed moving and carry on; do not "
+        "chase it, and do not try to restore it.**",
+    ])
+
+
+def render_toolchain(facts):
+    r = facts.cwd_repo_dir
+    return "\n".join([
+        "## TOOLCHAIN — the exact commands, and the two ways they lie",
+        "",
+        "Run a SUBSET of the suite:",
+        "",
+        "```",
+        f"nix develop {r} -c python3 -m pytest <paths> -q -p no:cacheprovider",
+        "```",
+        "",
+        "🔴 A bare `python3 -m pytest` failing with **`No module named "
+        "pytest`** means you are in the WRONG SHELL, not that the suite is "
+        "broken. This repo's `.envrc` is `use opencode`, which does not put "
+        "pytest on PATH; a loaded direnv is not the dev shell. Do not report "
+        "that as a finding and do not build an ad-hoc `nix-shell` around it.",
+        "",
+        "Run the whole dev-host gate (its EXIT STATUS is authoritative; also "
+        "read each runner's own `RESULT:` line):",
+        "",
+        "```",
+        f"nix develop {r} -c bash {r}/scripts/gate.sh --tier both",
+        "```",
+        "",
+        "🔴 The gate above is the DEV-HOST tier. **The tier the merge actually "
+        "gates on is the sandbox one**, which builds from a store copy with no "
+        "`.git` and is therefore blind to different things:",
+        "",
+        "```",
+        f"nix build {r}#checks.x86_64-linux.pytests",
+        f"nix build {r}#checks.x86_64-linux.nodetests",
+        "```",
+        "",
+        "Name the tier and the base sha in any claim you make about the gate — "
+        "\"the gate passed\" is true of one run, one tier, one base, and reads "
+        "as a property of the change.",
+        "",
+        "`git --version` before you trust a range: `--remerge-diff` needs git "
+        "≥ 2.35, and a git without it exits 128 with EMPTY output, which reads "
+        "exactly like a clean zero.",
+    ])
+
+
+def render_ledger(facts):
+    lines = ["## THE LEDGER — payload attribution for this round", ""]
+    led = facts.ledger
+    if led is None:
+        lines += [
+            "Not measured: a first, full audit has no previous round to "
+            "attribute against. Start the ledger at your round 2.",
+        ]
+        return "\n".join(lines)
+    if led.reason:
+        lines += [
+            "🔴 **COULD NOT MEASURE** — and a failed command is NOT a zero, so "
+            "no number is printed here:",
+            "",
+            f"    {led.reason}",
+            "",
+            "Re-run the command by hand, and require rc 0, silent stderr and a "
+            "non-empty range before believing any figure it prints.",
+        ]
+        return "\n".join(lines)
+
+    lines += [
+        f"`git log --numstat --format= --remerge-diff {facts.prev_sha}..HEAD "
+        f"--not {facts.base_ref}` over {led.commits} commit(s):",
+        "",
+        "```",
+        f"{'added':>7} {'deleted':>8}  path",
+    ]
+    for path, (a, d) in sorted(led.files.items(), key=lambda kv: -sum(kv[1])):
+        lines.append(f"{a:>7} {d:>8}  {path}")
+    lines += [
+        f"{led.added:>7} {led.deleted:>8}  = {len(led.files)} file(s), "
+        f"{led.added + led.deleted} line(s) changed",
+        "```",
+        "",
+    ]
+    if not led.files:
+        lines += [
+            "🔴 Zero changed lines over a NON-EMPTY range. That is a real "
+            "measurement, not a failure — but check that `--not "
+            f"{facts.base_ref}` is not swallowing this round's own commits "
+            "before you act on it.",
+            "",
+        ]
+    lines += [
+        "🔴 **Classify these files yourself — this script deliberately does "
+        "not.** Payload is what the PR exists to ship; scaffolding is the "
+        "tests, fixtures and notes a round wrote to guard it. For a code change "
+        "the payload is source and a `.md` is not; **for a docs or skill PR the "
+        "payload IS the `.md`**. A pathspec cannot do this — `':!*test*'` "
+        "swallows `attestation/`, `latest/` and `inspector/` while keeping "
+        "`FooTest.java` and `login.cy.ts`. **Ambiguous is not zero**: the gate "
+        "does not fire and the ladder continues.",
+        "",
+        "Then carry this line in your summary, with X filled in from the "
+        "classification above:",
+        "",
+        "```",
+        f"round {facts.round_no} · payload lines changed THIS round: X "
+        f"(since round 1: {led.cumulative if led.cumulative is not None else 'Y'}"
+        ") · elapsed: Z",
+        "```",
+        "",
+        "⚠ `<base>` here is `" + facts.base_ref + "` **as it stands in this "
+        "checkout**. This script does not fetch (that would be a write to the "
+        "shared checkout), so a stale base re-reports upstream work as this "
+        "round's payload. If the number looks large, that is the first thing to "
+        "check.",
+    ]
+    if led.cumulative is None:
+        lines += [
+            "",
+            "⚠ The cumulative figure (Y, since round 1) is **NOT MEASURED**: no "
+            "`audit-claims` block carried a round-1 anchor sha. It is not "
+            "derivable from the base, which is a different quantity.",
+        ]
+    return "\n".join(lines)
+
+
+def render_checklist(facts):
+    """The checklist, READ from the skill rather than restated here.
+
+    🔴 One rule, one place. An earlier draft paraphrased the axes inline for
+    delta rounds ("risks, regressions, assumptions, …") — a second copy of a
+    block that is pinned in `scripts/tests/test_audit_ladder_stop_rule.py` and
+    that has already been silently shaved once, with a commit message claiming
+    the opposite. The paraphrase would have drifted with nothing watching.
+    """
+    lines = ["## AUDIT FOR", ""]
+    if facts.round_no >= 2:
+        lines += [
+            "First, per prior claim above: **actually fixed / partially / not "
+            "/ made worse**. Then work the same axes as a full audit, scoped "
+            "to the range:",
+            "",
+        ]
+    lines.append(facts.checklist or (
+        "⚠ COULD NOT INLINE the checklist — "
+        "`~/.claude/skills/audit-pr/SKILL.md` was not readable from here. Read "
+        "its **Audit for:** section and work through every numbered item."
+    ))
+    return "\n".join(lines)
+
+
+def render_output_contract(facts):
+    return "\n".join([
+        "## OUTPUT",
+        "",
+        "Findings by severity (🔴 deploy-blocking / 🟡 should-fix / 🟢 nit), "
+        "each in the format required above. Then the ledger line. Then a "
+        "**verdict** — safe to merge / merge after fixing 🔴 / needs rework — "
+        "which is advisory for the human and is **not** the ladder's stop "
+        "signal: a round can return \"safe to merge\" and still report real "
+        "defects. Flag anything you could not verify, and say so plainly rather "
+        "than reporting it as covered.",
+    ])
+
+
+def render_brief(facts):
+    kind = (
+        "FIRST, FULL adversarial audit" if facts.round_no < 2
+        else f"DELTA re-audit — ROUND {facts.round_no}"
+    )
+    head = "\n".join([
+        f"# {kind} — PR #{facts.pr} in `{facts.repo}`",
+        "",
+        f"**{facts.title}**",
+        f"{facts.url}",
+        "",
+        "Assembled by `scripts/audit-dispatch.py`. The sections below are "
+        "generated from live facts; the NON-NEGOTIABLE block is verbatim and "
+        "identical in every brief this script emits.",
+    ])
+    parts = [
+        head,
+        render_worktree_directive(facts),
+        render_range(facts),
+        render_claims(facts),
+        render_checkout(facts),
+        render_toolchain(facts),
+        render_invariants(),
+        render_checklist(facts),
+        render_ledger(facts),
+        render_output_contract(facts),
+    ]
+    return f"\n\n{_bar()}\n\n".join(p for p in parts if p) + "\n"
+
+
+def emit_claims_skeleton(facts, head_sha):
+    """A correctly-formed block for the operator to paste into the PR comment.
+
+    Emitted rather than described, because the next round's assembler reads ONLY
+    this shape and a hand-typed near-miss is refused.
+    """
+    frm = facts.prev_sha or "<the sha round 1 audited>"
+    return "\n".join([
+        f"```audit-claims round={facts.round_no} audited={frm}..{head_sha}",
+        "1. <one line per thing this round's fixes CLAIM to have addressed — "
+        "WHAT was claimed, never WHY it is correct>",
+        "2. <one line, same rule>",
+        "```",
+    ])
+
+
+# --------------------------------------------------------------------------- #
+# The warn-only completeness check
+# --------------------------------------------------------------------------- #
+
+def missing_clauses(brief):
+    """Clause ids whose text is not present verbatim in `brief`.
+
+    🔴 WARN-ONLY BY DESIGN. It exists for a `--out` file a human then edits, and
+    `claude/RULES.md` says a permanently-red gate trains everyone to click
+    through it. Blocking here would make the tool refuse to run over an edit
+    that was deliberate.
+    """
+    return [c.id for c in INVARIANT_CLAUSES if c.text not in brief]
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+REFUSAL_HEADER = "🔴 REFUSING TO EMIT a delta re-audit brief"
+
+
+def _read_checklist(repo_dir):
+    """The nine-item checklist, read from the skill rather than duplicated.
+
+    One rule, one place: restating the checklist here would give it a second
+    copy to drift from, and the block has already been silently shaved once.
+    """
+    for cand in (
+        Path(repo_dir) / "claude" / "skills" / "audit-pr" / "SKILL.md",
+        Path.home() / ".claude" / "skills" / "audit-pr" / "SKILL.md",
+    ):
+        try:
+            body = cand.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        m = re.search(r"^\*\*Audit for:\*\*\n(.*?)(?=\n## )", body, re.M | re.S)
+        if m:
+            return "**Audit for:**\n" + m.group(1).rstrip()
+    return None
+
+
+def build_parser():
+    ap = argparse.ArgumentParser(
+        prog="audit-dispatch.py",
+        description="Assemble an adversarial-audit brief for a PR and print it.",
+    )
+    ap.add_argument("pr", type=int, help="the PR number")
+    ap.add_argument("--round", dest="round_no", type=int, default=1,
+                    help="round number; >=2 assembles a DELTA re-audit brief")
+    ap.add_argument("--repo", help="owner/name, when the PR is not in the cwd's repo")
+    ap.add_argument("--out", help="write the brief to this file instead of stdout")
+    ap.add_argument("--emit-claims", action="store_true",
+                    help="also print an audit-claims block skeleton to paste "
+                         "into this round's PR comment")
+    ap.add_argument("--claims-file",
+                    help="read claims-block text from this file instead of the "
+                         "PR's comments (offline/testing seam)")
+    return ap
+
+
+def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
+         checklist_reader=None):
+    # `checklist_reader` is injected by the test suite so no test depends on
+    # whether THIS HOST happens to have the skill deployed under ~/.claude —
+    # a suite that reads the ambient home is not hermetic, and the sandbox gate
+    # tier runs with a different one.
+    checklist_reader = checklist_reader or _read_checklist
+    args = build_parser().parse_args(argv)
+    out_stream = stdout or sys.stdout
+    err_stream = stderr or sys.stderr
+    cwd = cwd or os.getcwd()
+
+    repo_dir, cwd_slug = gather_repo_facts(runner, cwd)
+    branch, dirty = gather_checkout_state(runner, repo_dir)
+
+    if args.claims_file:
+        try:
+            comment_texts = [Path(args.claims_file).read_text(encoding="utf-8")]
+        except OSError as e:
+            print(f"cannot read --claims-file: {e}", file=err_stream)
+            return 2
+        claims_source = f"`{args.claims_file}`"
+        data = {"title": f"PR #{args.pr}", "url": "", "baseRefName": "main"}
+    else:
+        data, comment_texts = gh_pr_facts(runner, args.pr, args.repo)
+        claims_source = f"PR #{args.pr}'s comments"
+        if data.get("_error"):
+            print(f"🔴 `gh pr view {args.pr}` failed: {data['_error']}",
+                  file=err_stream)
+            return 3
+
+    repo = pr_slug(data, args.repo) or cwd_slug or "UNKNOWN/UNKNOWN"
+    blocks, malformed = parse_claims_blocks(comment_texts)
+    newest = newest_block(blocks)
+
+    # ------------------------------------------------------------------ #
+    # 🔴 REFUSAL 1 — a delta round with nothing to be framed on.
+    # ------------------------------------------------------------------ #
+    if args.round_no >= 2 and newest is None:
+        why = (
+            "  reason: " + "\n          ".join(malformed)
+            if malformed else
+            f"  reason: no `audit-claims` block in any of the "
+            f"{len(comment_texts)} comment(s) read"
+        )
+        print("\n".join([
+            f"{REFUSAL_HEADER} for round {args.round_no} of PR #{args.pr}.",
+            "",
+            "  looked for: a fenced block of the form",
+            "",
+            "      ```audit-claims round=<n> audited=<sha>..<sha>",
+            "      1. <what was claimed fixed>",
+            "      ```",
+            "",
+            f"  looked in : {claims_source}",
+            why,
+            "",
+            "  An empty \"what was claimed fixed\" section silently turns a "
+            "DELTA re-audit into a blind full audit — a different thing, which "
+            "would then read as covered. So this is refused, not emitted.",
+            "",
+            f"  Fix: run `audit-dispatch.py {args.pr} --round "
+            f"{args.round_no - 1} --emit-claims`, fill the skeleton in, and "
+            "post it as a comment on the PR. Or run this round as an explicit "
+            "first, full audit with no --round.",
+        ]), file=err_stream)
+        return 2
+
+    prev_sha = newest.audited_to if newest else None
+    claims = list(newest.items) if newest else []
+    claims_round = newest.round_no if newest else None
+    if newest is not None and newest.round_no >= args.round_no:
+        print(
+            f"⚠ the newest claims block says round={newest.round_no}, and you "
+            f"asked for round {args.round_no}. Using it anyway — but check you "
+            "are not re-auditing a round that already ran.",
+            file=err_stream,
+        )
+
+    ledger = None
+    base_ref = data.get("baseRefName") or "main"
+    base_for_range = f"origin/{base_ref}"
+    if args.round_no >= 2 and prev_sha:
+        ledger = measure_ledger(runner, repo_dir, prev_sha, base_for_range)
+        anchor = round_one_anchor(blocks)
+        if ledger.reason is None and anchor:
+            cum = measure_ledger(runner, repo_dir, anchor, base_for_range)
+            if cum.reason is None:
+                ledger = ledger._replace(cumulative=cum.added + cum.deleted)
+
+    facts = Facts(
+        pr=args.pr,
+        repo=repo,
+        title=data.get("title") or "(no title)",
+        base_ref=base_ref if args.round_no < 2 else base_for_range,
+        url=data.get("url") or "",
+        round_no=args.round_no,
+        cwd_repo_dir=repo_dir,
+        cwd_repo_slug=cwd_slug,
+        cross_repo=bool(cwd_slug and repo and cwd_slug != repo),
+        branch=branch,
+        dirty=dirty,
+        prev_sha=prev_sha,
+        claims=claims,
+        claims_round=claims_round,
+        checklist=checklist_reader(repo_dir),
+        ledger=ledger,
+        assembled_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%MZ"),
+        claims_source=claims_source,
+    )
+
+    brief = render_brief(facts)
+
+    # ------------------------------------------------------------------ #
+    # REFUSAL 2's opposite number: WARN, never block.
+    # ------------------------------------------------------------------ #
+    gone = missing_clauses(brief)
+    if gone:
+        print(
+            "⚠ the assembled brief is missing invariant clause(s): "
+            + ", ".join(gone)
+            + "\n  This is a WARNING, not a refusal — the brief is still "
+              "emitted. Re-add them by hand, or re-run without --out edits.",
+            file=err_stream,
+        )
+
+    if args.out:
+        Path(args.out).write_text(brief, encoding="utf-8")
+        print(f"wrote {len(brief):,} chars to {args.out}", file=err_stream)
+    else:
+        print(brief, file=out_stream)
+
+    if args.emit_claims:
+        rc, head, _ = runner(["git", "-C", repo_dir, "rev-parse", "--short", "HEAD"])
+        head_sha = head.strip() if rc == 0 and head.strip() else "<HEAD sha>"
+        print("\n" + _bar(), file=out_stream)
+        print("Paste this into the PR comment for this round, so the NEXT "
+              "round can read it:\n", file=out_stream)
+        print(emit_claims_skeleton(facts, head_sha), file=out_stream)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -1176,6 +1176,30 @@ def the_stale_base_caveat_says_it_is_fine(t):
     )
 
 
+def a_third_prescription_site_nothing_drives(t):
+    """🔴 ROUND 12 — THE COVERAGE ARM of the refusal-remedy guard.
+
+    An ADDITION rather than an inversion, and that is the point: the guard
+    calls itself a class guard over "a third refusal that prescribes a command
+    it refuses", so the mutation is a third prescription — planted in the
+    `--audited`-without-`--emit-claims` branch, which neither driven case
+    reaches. Every other assertion in that guard stays green (the two real
+    refusals still prescribe commands that still run); only the site-coverage
+    assertion can see it.
+    """
+    return _swap(
+        t,
+        "    if args.audited and not args.emit_claims:\n        print(\n",
+        "    if args.audited and not args.emit_claims:\n"
+        "        print(\n"
+        '            f"  Fix: run `audit-dispatch.py {args.pr} --round 1 "\n'
+        '            "--emit-claims --audited <sha>`.",\n'
+        "            file=err_stream,\n"
+        "        )\n"
+        "        print(\n",
+    )
+
+
 def the_toolchain_names_the_shared_checkout_cross_repo_only(t):
     """🔴 THE ISOLATING ROW for round 6's 🟢 F4.
 
@@ -2080,6 +2104,9 @@ ROWS = [
      {"test_the_clone_grant_covers_only_the_write_the_recipe_makes",
       "test_each_section_directive_carries_the_instruction_its_ledger_entry_names"},
      the_clone_grant_reverts_to_the_enumeration),
+    ("V29 a THIRD prescription site nothing drives",
+     {"test_every_command_a_refusal_prescribes_actually_runs"},
+     a_third_prescription_site_nothing_drives),
 ]
 
 

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -1093,6 +1093,89 @@ def the_clone_grant_permits_fetching_again(t):
         "below is about every checkout you did not make.")(t)
 
 
+def the_clone_grant_reverts_to_the_enumeration(t):
+    """Round 12's finding: round 10's wording, verbatim.
+
+    The grant is still present, still ledgered, still emitted, and still
+    refuses three verbs BY NAME — so every presence pin stays green and only
+    the enumeration probe plus the whole-string ledger can see it. That is the
+    hole: `remote update`, `switch`, `restore`, `reset`, `branch -f` and `gc`
+    are permitted by omission in the one tree whose blast radius is outside
+    the brief.
+    """
+    return reword_entry(
+        "Directive", "own-worktree-is-writable",
+        "That worktree is YOURS: fetching and checking out inside it is fine. "
+        "In the clone you made it from, `git worktree add` is the ONLY write "
+        "this brief asks for — do not `fetch`, `pull` or `checkout` there, "
+        "whoever made it, because other sessions may be standing in it. The "
+        "no-write rule below is about every checkout you did not make.")(t)
+
+
+def the_claims_file_hardcodes_the_base_ref(t):
+    """Round 12's finding: `--claims-file` mode asserting a base it never read.
+
+    The base's behaviour exactly. `base_assumed` is
+    `not data.get("baseRefName")`, so hardcoding the field switches the
+    assumed-base banner OFF in the one mode that consults no `gh` at all —
+    which is the mode three comments in the script call permanently assumed.
+    """
+    return _swap(
+        t,
+        '        data = {"title": f"PR #{args.pr}", "url": ""}',
+        '        data = {"title": f"PR #{args.pr}", "url": "", '
+        '"baseRefName": "main"}',
+    )
+
+
+# 🔴 THE CAVEAT THE LEDGER PIN HAD NO ROW FOR. Round 10 shrank C3's killer set
+# and `test_the_ledger_says_the_base_was_not_fetched` fell out of the battery
+# entirely — zero occurrences across every row — while sitting in
+# `INVARIANT_GUARDS_AND_LEDGERS`, whose declared evidence IS the battery.
+# TWO rows, because they answer different questions: V26 asks whether anything
+# detects the caveat's ABSENCE, V27 whether anything detects a REWORD that
+# leaves the old fragment pins intact.
+def the_stale_base_caveat_is_deleted(t):
+    """The caveat removed outright; every other ledger sentence untouched."""
+    return _swap(
+        t,
+        '        "⚠ `<base>` here is `" + facts.base_ref + "` **as it stands '
+        'in this "\n'
+        '        "checkout**, and it is the ONLY end of that command that can '
+        'mean "\n'
+        '        "something different where you are standing — both ends of '
+        'the range "\n'
+        '        "itself are shas. This script does not fetch (that would be '
+        'a write to "\n'
+        '        "a checkout it does not own), so a stale base re-reports '
+        'upstream work "\n'
+        '        "as this round\'s payload. If the number looks large, that is '
+        'the first "\n'
+        '        "thing to check.",\n',
+        "",
+    )
+
+
+def the_stale_base_caveat_says_it_is_fine(t):
+    """🔴 THE REACHABILITY CONTROL for the whole-string pin.
+
+    The qualifier the caveat exists for — "as it stands in THIS CHECKOUT" — is
+    replaced by an assurance that it is fine, which is the opposite
+    instruction. Both fragments the guard used to pin ("does not fetch",
+    "stale base") survive downstream untouched, so a fragment pin CANNOT see
+    this. Measured at `88b4105c`: this exact reword left the suite at 109
+    passed.
+    """
+    return _swap(
+        t,
+        '"` **as it stands in this "\n'
+        '        "checkout**, and it is the ONLY end of that command that can '
+        'mean "\n',
+        '"` and it is fine. It is the ONLY end of that command that can '
+        'mean "\n',
+    )
+
+
 def the_toolchain_names_the_shared_checkout_cross_repo_only(t):
     """🔴 THE ISOLATING ROW for round 6's 🟢 F4.
 
@@ -1307,19 +1390,33 @@ ROWS = [
       "test_a_cross_repo_range_states_the_impossibility_not_a_moved_checkout",
       "test_the_ledger_refuses_to_measure_a_checkout_that_is_not_the_pr",
       "test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head",
-      # 🔴 ROUND 10 — SEVEN OF ROUND 8's THIRTEEN LEFT THIS SET, and their
+      # 🔴 ROUND 10 — NINE OF THE NINETEEN NAMES HERE LEFT THIS SET, and their
       # departure is the FIX, measured. Round 8 made THE LEDGER's branch turn
       # on `repo_relation` ALONE, so inverting that decision sent the
       # same-repo `delta` scenario down the hand-over branch and took every
       # ledger assertion with it. The branch now asks
       # `cross_repo_holds_neither_end`, which consults the HEAD CHECK first —
       # and in `delta` that check passes, so the ledger measures whatever the
-      # repo decision says. `..._degenerate_...`, `..._cumulative_...`,
-      # `..._empty_range_...`, `..._refuses_a_failed_command_...`,
-      # `..._says_the_base_was_not_fetched`, `..._shows_the_files_...` and the
-      # fixture seam guard all stopped depending on the repo decision, which
-      # is exactly what round 10's finding B says they should never have.
-      # Re-measured, not reasoned: this set is what the battery reported.
+      # repo decision says. The nine, in full: the two `..._degenerate_...`
+      # guards, the two cumulative ones (`..._a_failed_cumulative_...` and
+      # `..._the_cumulative_figure_...`), `..._an_empty_range_...`,
+      # `..._refuses_a_failed_command_...`,
+      # `..._says_the_base_was_not_fetched`, `..._shows_the_files_...` and
+      # `test_no_cross_repo_brief_claims_its_checkout_was_verified` — all of
+      # which stopped depending on the repo decision, which is exactly what
+      # round 10's finding B says they should never have. Three arrived, so
+      # THIRTEEN distinct names remain (fifteen occurrences: the two directive
+      # guards are listed twice, once for round 4's reason and once for round
+      # 10's).
+      #
+      # 🔴 ROUND 12 CORRECTED THIS PARAGRAPH; IT WAS WRONG IN BOTH NUMBERS. It
+      # read "SEVEN OF ROUND 8's THIRTEEN", and thirteen is what REMAINS at
+      # this head, not what round 8 left. Re-derive by AST-diffing this row's
+      # name set between the two trees — `ast.walk` over the second tuple
+      # element, `set()` the string constants — never by counting the glob
+      # tokens in the sentence above, which was how seven was arrived at while
+      # two of them cover two guards each. Measured 706a6b38 -> 88b4105c: 19
+      # distinct -> 13 distinct, 9 departed, 3 arrived.
       "test_a_cross_repo_ledger_prints_a_measurement_the_head_check_vouched_for",
       "test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha",
       "test_the_clone_grant_covers_only_the_write_the_recipe_makes",
@@ -1960,6 +2057,29 @@ ROWS = [
     ("V24 an ASSUMED base branch is recorded as read",
      {"test_no_brief_states_an_assumed_base_branch_as_a_fact"},
      the_assumed_base_is_recorded_as_read),
+    # 🔴 ROUND 12. V24 mutates the PREDICATE; V25 mutates the INPUT it reads,
+    # and only the second reaches `--claims-file` mode. At `88b4105c` the mode
+    # hardcoded `baseRefName: "main"`, so V24's predicate answered correctly
+    # over a fixture that lied — the whole point of finding 1.
+    ("V25 `--claims-file` hardcodes the base ref again",
+     {"test_no_brief_states_an_assumed_base_branch_as_a_fact"},
+     the_claims_file_hardcodes_the_base_ref),
+    ("V26 THE LEDGER's stale-base caveat deleted",
+     {"test_the_ledger_says_the_base_was_not_fetched"},
+     the_stale_base_caveat_is_deleted),
+    # 🔴 THE REACHABILITY CONTROL for V26's guard, and the row that proves the
+    # whole-string pin is worth its cosmetic cost: the caveat is still present
+    # and still spells both fragments the guard used to look for.
+    ("V27 the stale-base caveat reworded into an assurance",
+     {"test_the_ledger_says_the_base_was_not_fetched"},
+     the_stale_base_caveat_says_it_is_fine),
+    # Same shape as V22: restoring a REWORDED directive necessarily moves the
+    # whole-string directive ledger too. The enumeration probe is the one that
+    # fires for THIS row's reason.
+    ("V28 the clone grant reverts to a closed verb list",
+     {"test_the_clone_grant_covers_only_the_write_the_recipe_makes",
+      "test_each_section_directive_carries_the_instruction_its_ledger_entry_names"},
+     the_clone_grant_reverts_to_the_enumeration),
 ]
 
 

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -73,6 +73,11 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 SCRIPT_REL = "scripts/audit-dispatch.py"
 TEST_REL = "scripts/tests/test_audit_dispatch.py"
+# 🔴 THIS FILE IS A THIRD INPUT TO THE SUITE, not only its driver. Round 4 made
+# the fix matrix's mutants column an evidence claim graded against `ROWS`
+# below, so the test module IMPORTS this file — and a scratch tree without it
+# fails at collection, which reads as "the mutant killed everything".
+HARNESS_REL = "scripts/tests/mutants-audit-dispatch.py"
 
 # 🔴 A COLLAPSE floor, not a growth floor — same rule as
 # `mutants-audit-ladder.sh`. A suite that never ran yields zero FAILED lines,
@@ -83,6 +88,19 @@ MIN_TESTS = 50
 # green. See the module docstring — the clause ledger pins whole normalised
 # strings, and a re-wrap that went red would make every reflow a test failure.
 SURVIVES = "SURVIVES"
+
+# 🔴 A THIRD expectation, and it is NOT a synonym for SURVIVES. `SURVIVES` is a
+# CONTROL: the pin must not be keyed to layout, and a red there is a defect in
+# the pin. `HOLE` is a MEASURED GAP: the mutation survives because nothing
+# guards that sentence, which the script's own ledger comment says out loud
+# rather than letting three unguarded blocks read as covered. The two print
+# differently on purpose — "SURVIVED as required (control)" over a documented
+# hole would be the flattering wrong answer this whole file exists to refuse.
+#
+# A HOLE that starts being KILLED is good news and is reported as an ACTION:
+# promote the row to the killer set that now fires, and delete its line from
+# the ledger comment in `scripts/audit-dispatch.py`.
+HOLE = "HOLE"
 
 
 # --------------------------------------------------------------------------- #
@@ -232,10 +250,14 @@ def reword_clause(cid, new_text):
 # the pins are keyed to layout, and every reflow of the source becomes a
 # failure.
 def rewrap_a_clause(t):
+    # 🔴 RE-TARGETED in round 4 — the `no-fetch` clause was reworded when THE
+    # CHECKOUT section became three-state, and this row immediately reported
+    # MUTATION DID NOT APPLY. Third time an assert-before-editing has caught a
+    # row that would otherwise have scored as "the guard held".
     return _swap(
         t,
-        '"**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to the "',
-        '"**Do NOT  `git fetch`,  `pull`,  `checkout`  or otherwise write to the  "',
+        '"**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to a "',
+        '"**Do NOT  `git fetch`,  `pull`,  `checkout`  or otherwise write to a  "',
     )
 
 
@@ -438,7 +460,11 @@ def the_ledger_ignores_a_self_range(t):
 
 
 def emit_claims_drops_the_self_range_warning(t):
-    return _swap(t, "        if same_commit(facts.emit_from, head_sha):",
+    # 🔴 RE-TARGETED in round 4: the predicate became
+    # `same_commit(next_anchor, head_sha)` when the guard was moved onto the
+    # anchor the NEXT round will use. Disabling it now silences BOTH spellings
+    # of the warning, which is why this row gained a second killer.
+    return _swap(t, "        if same_commit(next_anchor, head_sha):",
                  "        if False:")
 
 
@@ -469,6 +495,123 @@ def add_unledgered_directive(t):
     return _swap(t, marker,
                  '    Directive("unledgered", "**A fourth instruction nobody '
                  'reviewed.**"),\n' + marker)
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 Y1-Y14 — round 4.
+# --------------------------------------------------------------------------- #
+# Y1 and Y2 are the two OPERATIVE verbatim blocks that were still unpinned after
+# round 3's sweep — each inverted alone against all 199 audit-related tests, all
+# green. Y3-Y5 are the three that remain unpinned by choice, and they are
+# recorded as DOCUMENTED HOLES rather than as controls: a hole that survives is
+# not a guard doing its job.
+
+def the_audited_flag_is_ignored(t):
+    return _swap(t,
+                 "    emit_from = args.audited or emit_anchor(newest)",
+                 "    emit_from = emit_anchor(newest)")
+
+
+def the_ignored_audited_flag_is_silent(t):
+    return _swap(t,
+                 "    if args.audited and not args.emit_claims:",
+                 "    if False:")
+
+
+def the_round_one_emit_warning_is_unreachable_again(t):
+    """The round-3 spelling restored: ask `emit_from`, which is None at round 1."""
+    return _swap(
+        t,
+        "        next_anchor = range_anchor(\n"
+        '            ClaimsBlock(args.round_no, facts.emit_from or "", head_sha, [])\n'
+        "        )\n",
+        "        next_anchor = facts.emit_from\n",
+    )
+
+
+def the_ledger_hand_rolls_its_degenerate_causes(t):
+    return _swap(
+        t,
+        '                "anything. " + directive("degenerate-range-causes")\n',
+        '                "anything. The round\'s fix commits are not in this "\n'
+        '                "checkout, or the `audited=` field was written with "\n'
+        '                "the fix tip in the `<from>` position."\n',
+    )
+
+
+def the_range_hand_rolls_its_degenerate_causes(t):
+    return _swap(
+        t,
+        '            + directive("degenerate-range-causes")\n',
+        '            + "Either the round\'s fix commits are not in this "\n'
+        '            "checkout, or the `audited=` block was written with the "\n'
+        '            "fix tip in its `<from>` position."\n',
+    )
+
+
+def same_commit_is_case_sensitive(t):
+    return _swap(t,
+                 '    a, b = (a or "").lower(), (b or "").lower()',
+                 '    a, b = (a or ""), (b or "")')
+
+
+def the_git_dirs_are_compared_as_strings(t):
+    return _swap(
+        t,
+        "    git_dir, common_dir = _resolved(lines[0]), _resolved(lines[1])",
+        "    git_dir, common_dir = lines[0], lines[1]",
+    )
+
+
+def the_unknown_worktree_state_collapses_to_shared(t):
+    return _swap(t,
+                 '        }.get(wt.kind, "checkout-unknown")),',
+                 '        }.get(wt.kind, "checkout-moves")),')
+
+
+def a_private_worktree_is_called_shared(t):
+    return _swap(t,
+                 '            "private": "checkout-private",',
+                 '            "private": "checkout-moves",')
+
+
+def where_to_work_drops_the_private_note(t):
+    return _swap(t,
+                 '    if facts.worktree.kind == "private":',
+                 "    if False:")
+
+
+# 🔴 Y3-Y5 — the DOCUMENTED HOLES. Each inverts an operative sentence that is
+# deliberately NOT pinned, and each must SURVIVE. A row that starts being killed
+# is GOOD NEWS and is reported as an action, not as a pass: promote it to a
+# killer set and delete its line from the ledger comment in the script.
+
+def the_output_contract_drops_the_per_finding_format(t):
+    return _swap(
+        t,
+        '        "Findings by severity (🔴 deploy-blocking / 🟡 should-fix / 🟢 nit), "\n'
+        '        "each in the format required above. ',
+        '        "Findings by severity, a one-paragraph summary is enough. ',
+    )
+
+
+def the_toolchain_drops_name_the_tier(t):
+    return _swap(
+        t,
+        '        "Name the tier and the base sha in any claim you make about the gate — "',
+        '        "There is no need to name the tier or the base sha. "',
+    )
+
+
+def the_round_one_range_points_at_the_pr_description(t):
+    return _swap(
+        t,
+        '            f"A FIRST, FULL audit: read the whole PR diff (`gh pr diff "\n'
+        '            f"{facts.pr}`) and the code it touches, not just the PR "\n'
+        '            "description.",\n',
+        '            "A FIRST, FULL audit: the PR description is the fastest "\n'
+        '            "way in.",\n',
+    )
 
 
 # 🔴 The SURVIVES control for the directive ledger. Whitespace changes; the
@@ -560,7 +703,15 @@ ROWS = [
       # known states flips it to cross as well. Listed because it is the row
       # that PROVES the fork case rides the same decision as the others — the
       # fixture used to encode a model in which it did not.
-      "test_a_fork_pr_against_this_repo_is_not_treated_as_cross_repo"},
+      "test_a_fork_pr_against_this_repo_is_not_treated_as_cross_repo",
+      # 🔴 TWO MORE IN ROUND 4, and both are real couplings rather than a row
+      # gone vague. `own-worktree-is-writable` is rendered ONLY by the
+      # cross-repo branch, so inverting the decision means the cross-repo
+      # scenario brief no longer carries it; and the private-worktree scenario
+      # is a SAME-repo PR, so the inversion sends it down the cross-repo branch
+      # where the WHERE TO WORK section has no private-worktree note at all.
+      "test_every_section_directive_is_emitted_verbatim_in_the_brief_that_owns_it",
+      "test_the_where_to_work_section_does_not_call_a_private_worktree_the_clone"},
      invert_cross_repo),
     ("C4  numstat failure reads as a clean zero",
      {"test_the_ledger_refuses_a_failed_command_rather_than_printing_zero"},
@@ -635,6 +786,15 @@ ROWS = [
      {"test_emit_claims_stamps_the_prs_head_not_the_local_checkouts",
       "test_emit_claims_prints_a_block_this_scripts_own_parser_accepts"},
      emit_claims_uses_the_local_head),
+    # 🔴 H4 BRIEFLY GAINED A KILLER IN ROUND 4 AND GAVE IT BACK, recorded
+    # because the give-back is the evidence. The round-1 assumption test first
+    # asserted `audited_to == <the PR head>`; that made mutant H3 (read the
+    # LOCAL head) kill it for someone else's reason, so the assertion was
+    # weakened to "the block is the BARE spelling". H4 then stopped killing it
+    # — correctly: the placeholder header parses to `audited_from=""`,
+    # `audited_to="<the"`, which IS bare-shaped, and the warning still fires
+    # because it reads `facts.emit_from`, not the emitted text. The row that
+    # owns the round-1 header's parseability is the one below.
     ("H4  round-1 placeholder back in the header",
      {"test_emit_claims_prints_a_block_this_scripts_own_parser_accepts"},
      emit_claims_interpolates_the_placeholder),
@@ -696,30 +856,54 @@ ROWS = [
       "test_the_range_says_head_was_verified_when_it_was",
       "test_a_degenerate_self_range_is_reported_not_rendered_as_a_clean_diff",
       "test_a_degenerate_self_range_is_named_by_the_ledger_too",
-      "test_a_bare_round_one_audited_sha_still_anchors_the_next_round"},
+      "test_a_bare_round_one_audited_sha_still_anchors_the_next_round",
+      # Round 4's four. All four read a range that N1 moves: two assert the
+      # degenerate banner (which no longer fires when the anchor changes) and
+      # two assert the anchor a `--audited` block produces.
+      "test_a_degenerate_range_does_not_blame_a_checkout_it_verified",
+      "test_an_uppercase_audited_sha_still_trips_the_degenerate_guard",
+      "test_audited_supplies_the_tip_a_round_one_emit_cannot_derive",
+      "test_audited_without_emit_claims_says_it_changed_nothing"},
      range_anchor_reads_the_audited_tip),
     # The OTHER wrong fix: `audited_from` alone. A round-1 bare `audited=<sha>`
     # then anchors nothing, and the remedy chain the delta refusal advertises
     # dead-ends.
+    # 🔴 N2 GAINED A KILLER IN ROUND 4, and it is the one that shows the two
+    # fixes are the SAME mechanism: the round-1 assumption warning asks
+    # `range_anchor` what the next round will anchor on, so dropping the bare
+    # fallback makes that anchor None and the warning silent again.
     ("N2  the bare round-1 fallback is dropped",
      {"test_a_bare_round_one_audited_sha_still_anchors_the_next_round",
-      "test_the_cumulative_figure_is_not_measured_without_a_round_one_anchor"},
+      "test_the_cumulative_figure_is_not_measured_without_a_round_one_anchor",
+      "test_a_round_one_emit_claims_says_head_is_an_assumption_not_a_measurement"},
      range_anchor_loses_the_bare_fallback),
     # 🔴 THE MIRROR IMAGE, and the reason the two readers are separate
     # functions: "one anchor everywhere" is wrong on the WRITER's side, and it
     # produces a superset rather than an empty range, so nothing else notices.
+    # `--audited` routes through `emit_from`, so swapping the writer's anchor
+    # to `prev_sha` breaks the flag as well — round 4's addition.
     ("N3  --emit-claims writes the RANGE anchor as `<from>`",
      {"test_emit_claims_records_the_tip_this_round_audited_not_the_range_anchor",
-      "test_emit_claims_prints_a_block_this_scripts_own_parser_accepts"},
+      "test_emit_claims_prints_a_block_this_scripts_own_parser_accepts",
+      "test_audited_supplies_the_tip_a_round_one_emit_cannot_derive"},
      emit_claims_writes_the_range_anchor),
     ("N4  THE RANGE renders a self-range with no banner",
-     {"test_a_degenerate_self_range_is_reported_not_rendered_as_a_clean_diff"},
+     {"test_a_degenerate_self_range_is_reported_not_rendered_as_a_clean_diff",
+      # Round 4: both of these read THE RANGE's degenerate banner — one for
+      # its cause list, one for an uppercase anchor.
+      "test_a_degenerate_range_does_not_blame_a_checkout_it_verified",
+      "test_an_uppercase_audited_sha_still_trips_the_degenerate_guard"},
      the_range_ignores_a_self_range),
     ("N5  the ledger calls a self-range merely empty",
-     {"test_a_degenerate_self_range_is_named_by_the_ledger_too"},
+     {"test_a_degenerate_self_range_is_named_by_the_ledger_too",
+      "test_a_degenerate_range_does_not_blame_a_checkout_it_verified"},
      the_ledger_ignores_a_self_range),
+    # 🔴 N6 now silences BOTH spellings of the warning — see the re-targeting
+    # note on its mutation. Recorded rather than narrowed: one predicate
+    # guards both, and pretending otherwise would mean asserting less.
     ("N6  --emit-claims writes `X..X` in silence",
-     {"test_emit_claims_warns_when_the_block_it_writes_is_a_self_range"},
+     {"test_emit_claims_warns_when_the_block_it_writes_is_a_self_range",
+      "test_a_round_one_emit_claims_says_head_is_an_assumption_not_a_measurement"},
      emit_claims_drops_the_self_range_warning),
     ("N7  the empty-range reason names the refuted causes",
      {"test_an_empty_range_does_not_name_a_cause_the_head_check_refutes"},
@@ -745,7 +929,10 @@ ROWS = [
          "something obvious contradicts one.")),
     ("X2  the delta-regressions instruction deleted outright",
      {"test_the_section_directive_ledger_is_pinned_two_way",
-      "test_each_section_directive_carries_the_instruction_its_ledger_entry_names"},
+      "test_each_section_directive_carries_the_instruction_its_ledger_entry_names",
+      # Round 4: the scenario map and the render check both name it too.
+      "test_the_directive_render_scenario_ledger_is_pinned_two_way",
+      "test_every_section_directive_is_emitted_verbatim_in_the_brief_that_owns_it"},
      drop_entry("Directive", "delta-regressions")),
     # 🔴 X3 KEEPS "MOVES UNDER YOU" and "NOT a finding" — both pinned by
     # `test_the_shared_checkout_state_is_reported_with_the_it_moves_warning` —
@@ -759,17 +946,95 @@ ROWS = [
          "MOVES UNDER YOU** — the branch can change, files can appear and "
          "vanish, and commits can land mid-audit. That is NOT a finding in "
          "itself, but it is worth reporting. Restore anything you see move.")),
+    # 🔴 RE-TARGETED KILLER SET in round 4, and the swap is the interesting
+    # part. The "it reaches no brief" hazard used to be caught by the emitted
+    # test, which iterated the SCRIPT's directives; that test is now driven by
+    # the scenario map, so an unledgered directive is caught one step earlier —
+    # by the scenario pin, which reads `SECTION_DIRECTIVES` and finds an id
+    # nobody said where to render. The hazard is still covered; the guard that
+    # covers it moved, and pretending otherwise would leave a DEAD pin here.
     ("XA  add an unledgered fourth directive",
      {"test_the_section_directive_ledger_is_pinned_two_way",
-      # It ships in the constant and reaches NO brief, which is its own
-      # hazard: an instruction nobody reads is not an instruction.
-      "test_every_section_directive_is_emitted_verbatim_in_the_delta_brief"},
+      "test_the_directive_render_scenario_ledger_is_pinned_two_way"},
      add_unledgered_directive),
     # 🔴 The SURVIVES control for the directive ledger — the sibling of S1. A
     # RED here means the new pin is keyed to layout, and every reflow of the
     # source becomes a test failure.
     ("XS  re-space a directive (instruction identical)",
      SURVIVES, rewrap_a_directive),
+
+    # --------------------------------------------------------------------- #
+    # 🔴 Y1-Y14 — round 4.
+    # --------------------------------------------------------------------- #
+    # 🔴 Y1 INVERTS THE SENTENCE THAT DEFINES THE DELTA SCOPE. It lived inside
+    # a generated f-string, where no whole-string pin could reach it, and the
+    # inversion "Re-audit the whole PR as well" passed every audit-related
+    # test. Killed by the whole-string ledger ALONE — the directive is still
+    # present, still ledgered by id and still emitted, so any other killer
+    # would mean some test is reading this text for something it does not own.
+    ("Y1  delta-scope inverted into 're-audit the whole PR'",
+     {"test_each_section_directive_carries_the_instruction_its_ledger_entry_names"},
+     reword_entry(
+         "Directive", "delta-scope",
+         "**Audit that range, and re-audit the whole PR as well.** A delta "
+         "round is cheap and re-reading everything costs little.")),
+    # 🔴 Y2 leaves a CROSS-REPO auditor with nowhere to work: the brief has
+    # just told them to build that worktree themselves precisely so they can
+    # fetch in it.
+    ("Y2  own-worktree-is-writable inverted into 'do not fetch'",
+     {"test_each_section_directive_carries_the_instruction_its_ledger_entry_names"},
+     reword_entry(
+         "Directive", "own-worktree-is-writable",
+         "Do not fetch or check out inside it either. The no-write rule "
+         "covers every checkout you touch.")),
+    # 🔴 Y3-Y5 — DOCUMENTED HOLES, not controls. See `HOLE` above.
+    ("Y3  OUTPUT drops the per-finding format (NO GUARD)",
+     HOLE, the_output_contract_drops_the_per_finding_format),
+    ("Y4  toolchain drops 'name the tier and base sha' (NO GUARD)",
+     HOLE, the_toolchain_drops_name_the_tier),
+    ("Y5  round-1 range points at the PR description (NO GUARD)",
+     HOLE, the_round_one_range_points_at_the_pr_description),
+    # 🔴 Y5b is the one measurement that makes the three-state worktree read
+    # correct: git answers `/abs/.git` and `../.git` in a repo SUBDIRECTORY —
+    # different strings, the same directory — so a string compare calls every
+    # subdirectory of an ordinary clone a PRIVATE worktree.
+    ("Y5b the two git dirs compared as strings",
+     {"test_gather_worktree_kind_resolves_paths_before_comparing_them"},
+     the_git_dirs_are_compared_as_strings),
+    ("Y6  the UNKNOWN worktree state collapses to SHARED",
+     {"test_an_unreadable_worktree_state_is_its_own_answer_and_keeps_the_no_write",
+      # The `checkout-unknown` directive then reaches no brief at all.
+      "test_every_section_directive_is_emitted_verbatim_in_the_brief_that_owns_it"},
+     the_unknown_worktree_state_collapses_to_shared),
+    ("Y7  --audited is parsed and ignored",
+     {"test_audited_supplies_the_tip_a_round_one_emit_cannot_derive"},
+     the_audited_flag_is_ignored),
+    ("Y8  --audited without --emit-claims is silent again",
+     {"test_audited_without_emit_claims_says_it_changed_nothing"},
+     the_ignored_audited_flag_is_silent),
+    # 🔴 Y9 RESTORES THE UNREACHABLE SPELLING: asked of `emit_from`, which is
+    # None for the round-1 case the warning exists to cover.
+    ("Y9  the round-1 emit warning goes back to `emit_from`",
+     {"test_a_round_one_emit_claims_says_head_is_an_assumption_not_a_measurement"},
+     the_round_one_emit_warning_is_unreachable_again),
+    ("Y10 the LEDGER hand-rolls the refuted cause again",
+     {"test_a_degenerate_range_does_not_blame_a_checkout_it_verified",
+      "test_the_degenerate_range_causes_have_exactly_one_writer_per_consumer"},
+     the_ledger_hand_rolls_its_degenerate_causes),
+    ("Y11 THE RANGE hand-rolls the refuted cause again",
+     {"test_a_degenerate_range_does_not_blame_a_checkout_it_verified",
+      "test_the_degenerate_range_causes_have_exactly_one_writer_per_consumer"},
+     the_range_hand_rolls_its_degenerate_causes),
+    ("Y12 same_commit goes back to case-sensitive",
+     {"test_an_uppercase_audited_sha_still_trips_the_degenerate_guard"},
+     same_commit_is_case_sensitive),
+    ("Y13 WHERE TO WORK drops the private-worktree note",
+     {"test_the_where_to_work_section_does_not_call_a_private_worktree_the_clone"},
+     where_to_work_drops_the_private_note),
+    ("Y14 a PRIVATE worktree is described as SHARED again",
+     {"test_a_private_worktree_is_not_described_as_shared_and_is_not_absolved",
+      "test_every_section_directive_is_emitted_verbatim_in_the_brief_that_owns_it"},
+     a_private_worktree_is_called_shared),
 ]
 
 
@@ -805,6 +1070,7 @@ def main() -> int:
         (root / "scripts" / "tests").mkdir(parents=True)
         shutil.copy(REPO / SCRIPT_REL, root / SCRIPT_REL)
         shutil.copy(REPO / TEST_REL, root / TEST_REL)
+        shutil.copy(REPO / HARNESS_REL, root / HARNESS_REL)
         if (root / ".git").exists():
             print("🔴 the copy carries a .git — refusing to run")
             return 2
@@ -846,6 +1112,20 @@ def main() -> int:
                 continue
             # 🔴 A row that must SURVIVE. Reported through the same code path as
             # everything else, so a control cannot quietly stop being checked.
+            # 🔴 A DOCUMENTED HOLE. Same code path, a different verdict line,
+            # because "SURVIVED as required (control)" printed over an
+            # unguarded sentence is the flattering wrong answer.
+            if want is HOLE:
+                if got:
+                    print(f"  ⚠ {label:44s} NOW KILLED by {sorted(got)} — a "
+                          "guard covers this now. Promote the row to that "
+                          "killer set and delete its line from the ledger "
+                          "comment in scripts/audit-dispatch.py.")
+                    bad += 1
+                else:
+                    print(f"  ok {label:44s} SURVIVED — DOCUMENTED HOLE "
+                          "(nothing guards it; the script's ledger says so)")
+                continue
             if want is SURVIVES:
                 if got:
                     print(f"  🔴 {label:44s} KILLED by {sorted(got)} — this row "

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Mutation battery for `scripts/audit-dispatch.py` — the audit-brief assembler.
+
+    nix develop ~/workspace/devrc -c python3 scripts/tests/mutants-audit-dispatch.py
+
+Not run by CI. An author/reviewer instrument, kept IN THE TREE so
+"mutation-verified" can be RE-DERIVED instead of believed — the same reason
+`scripts/tests/mutants-audit-ladder.sh` exists, and it records the incident:
+devrc #900 ran ten rounds and recorded ~30 mutants in a module docstring, every
+one of them inside a session scratchpad that no longer exists, so not a single
+row could be re-checked by anyone else. This follows its conventions.
+
+🔴 EACH MUTANT NAMES THE EXACT SET OF TESTS THAT MUST KILL IT — not "a test
+failed". These pins overlap by design (a clause deletion trips the id ledger,
+the fragment ledger and the rendered-section comparison), so a mutant can die to
+a DIFFERENT test's error and be scored as covered while its own assertion is
+unreachable. Two distinct failures are reported separately because the responses
+differ:
+  * an expected killer ABSENT   -> 🔴 WRONG-KILLER: that pin is DEAD.
+  * an UNEXPECTED extra killer  -> 🔴 EXTRA-KILLER: something else now fires;
+                                   the row no longer isolates what it names.
+Collapsing them into one comparison routes the operator away from the first,
+which is the failure this battery exists to catch.
+
+🔴 EACH MUTATION IS ASSERTED TO APPLY BEFORE IT RUNS. A target string that no
+longer matches — a line re-wrapped, a word changed — leaves the file UNMUTATED
+and reports "the guard held", the most flattering possible wrong answer.
+
+🔴 IT NEVER TOUCHES YOUR WORKING TREE. Everything happens in a `mktemp` copy
+built by naming TWO INDIVIDUAL FILES. That selective copy, not the assertion
+below it, is what keeps a `.git` out; the assertion is an INVARIANT GUARD
+against the future refactor that replaces the file list with `cp -a`, which
+would carry a worktree's `.git` POINTER FILE and let a git command inside the
+copy act on the real repository.
+
+🔴 PYTHONDONTWRITEBYTECODE=1, and `-p no:cacheprovider`. A stale `.pyc` keyed on
+mtime-in-whole-seconds plus size is how a same-length edit gets scored SURVIVED
+without ever executing.
+
+🔴 THE BASELINE IS THE POSITIVE CONTROL. If the unmutated copy is not green,
+every row below is meaningless and this exits 2 without running any of them —
+and it distinguishes "the tree is red" from "pytest is not on PATH", because the
+second one blames the tree for the shell you are in.
+
+COVERAGE IS DELIBERATELY PARTIAL. What is here: one deletion per invariant
+clause, an addition, one REWORD that leaves the clause present (the reachability
+control for the fragment ledger), one renderer bypass, and one inversion per
+generated decision. What is NOT here: the `gh`/`git` boundary itself (the suite
+injects a runner and says so), and whether a human classifies the ledger's files
+correctly (nothing mechanical can grade that).
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT_REL = "scripts/audit-dispatch.py"
+TEST_REL = "scripts/tests/test_audit_dispatch.py"
+
+# 🔴 A COLLAPSE floor, not a growth floor — same rule as
+# `mutants-audit-ladder.sh`. A suite that never ran yields zero FAILED lines,
+# i.e. "clean", so a harness wired to nothing would score every mutant SURVIVED.
+MIN_TESTS = 30
+
+
+# --------------------------------------------------------------------------- #
+# Mutations. Each takes the script source and returns it changed, or raises.
+# --------------------------------------------------------------------------- #
+
+def drop_clause(cid):
+    def f(t):
+        pat = re.compile(
+            r"    Clause\(\n        \"" + re.escape(cid) + r"\",\n(?:.*?\n)*?    \),\n"
+        )
+        new, n = pat.subn("", t, count=1)
+        if n != 1:
+            raise AssertionError(f"clause {cid!r} not found in its expected shape")
+        return new
+    return f
+
+
+def _swap(t, old, new):
+    if old not in t:
+        raise AssertionError(f"target absent: {old[:70]!r}…")
+    return t.replace(old, new, 1)
+
+
+def add_unledgered_clause(t):
+    marker = ")\n\nINVARIANTS_HEADING"
+    return _swap(t, marker,
+                 '    Clause("unledgered", "**An eighth instruction nobody '
+                 'reviewed.**"),\n' + marker)
+
+
+def reword_stop_rule(t):
+    return _swap(
+        t,
+        '"**A clean round ENDS the ladder — ending it is the CORRECT outcome, "\n'
+        '        "not a failure.** ',
+        '"**A clean round ends the ladder.** ',
+    )
+
+
+def hardcode_bullets(t):
+    return _swap(
+        t,
+        '    out += [f"- {c.text}" for c in INVARIANT_CLAUSES]',
+        '    out += ["- **READ-ONLY.**", "- **Do not merge.**"]',
+    )
+
+
+def remove_the_refusal(t):
+    return _swap(t,
+                 "    if args.round_no >= 2 and newest is None:",
+                 "    if False:")
+
+
+def claims_from_the_whole_comment(t):
+    return _swap(
+        t,
+        "    claims = list(newest.items) if newest else []",
+        '    claims = ([ln for ln in (comment_texts[0] if comment_texts else "")'
+        ".splitlines() if ln.strip()] if newest else [])",
+    )
+
+
+def invert_cross_repo(t):
+    return _swap(t,
+                 "cross_repo=bool(cwd_slug and repo and cwd_slug != repo),",
+                 "cross_repo=bool(cwd_slug and repo and cwd_slug == repo),")
+
+
+def numstat_failure_reads_zero(t):
+    return _swap(
+        t,
+        '    if rc != 0:\n'
+        '        return fail(f"the numstat command exited {rc}: "\n'
+        '                    f"{(err or out).strip() or \'no output\'}")\n',
+        '    if rc != 0:\n        out = ""\n',
+    )
+
+
+def classify_by_pathspec(t):
+    return _swap(
+        t,
+        '        f"round {facts.round_no} · payload lines changed THIS round: X "\n',
+        '        f"round {facts.round_no} · payload lines changed THIS round: "\n'
+        "        f\"{sum(a + d for p, (a, d) in led.files.items() "
+        "if 'test' not in p)} \"\n",
+    )
+
+
+def the_warning_blocks(t):
+    old = ('              "emitted. Re-add them by hand, or re-run without --out edits.",\n'
+           "            file=err_stream,\n"
+           "        )\n")
+    return _swap(t, old, old + "        return 4\n")
+
+
+LEDGER_TRIO = {
+    "test_the_invariant_clause_ledger_is_pinned_two_way",
+    "test_each_clause_carries_the_instruction_its_ledger_entry_names",
+    "test_the_rendered_section_holds_exactly_the_ledgered_clauses",
+}
+DELETION_CONTROL = "test_control_a_clause_deleted_from_the_constant_is_detected"
+
+# (label, expected killer set, mutation)
+ROWS = [
+    ("D1  delete clause read-only",
+     LEDGER_TRIO | {DELETION_CONTROL}, drop_clause("read-only")),
+    # 🔴 D2 is the one asymmetric row, and it is recorded rather than tidied
+    # away: `test_missing_clause_check_warns_and_never_blocks` looks the
+    # `no-fetch` clause up BY ID, so deleting that particular clause makes it
+    # error. A real coupling, and the reason the deleted-clause CONTROL is a
+    # separate test from the warn test.
+    ("D2  delete clause no-fetch",
+     LEDGER_TRIO | {"test_missing_clause_check_warns_and_never_blocks"},
+     drop_clause("no-fetch")),
+    ("D3  delete clause stop-rule",
+     LEDGER_TRIO | {DELETION_CONTROL}, drop_clause("stop-rule")),
+    ("D4  delete clause nit-is-not-a-finding",
+     LEDGER_TRIO | {DELETION_CONTROL}, drop_clause("nit-is-not-a-finding")),
+    ("D5  delete clause reverify-self-reported",
+     LEDGER_TRIO | {DELETION_CONTROL}, drop_clause("reverify-self-reported")),
+    ("D6  delete clause finding-format",
+     LEDGER_TRIO | {DELETION_CONTROL}, drop_clause("finding-format")),
+    ("D7  delete clause do-not-merge",
+     LEDGER_TRIO | {DELETION_CONTROL}, drop_clause("do-not-merge")),
+    ("A1  add an unledgered eighth clause",
+     {"test_the_invariant_clause_ledger_is_pinned_two_way",
+      "test_the_rendered_section_holds_exactly_the_ledgered_clauses",
+      DELETION_CONTROL},
+     add_unledgered_clause),
+    # 🔴 THE REACHABILITY CONTROL. The clause survives and is still emitted, so
+    # every presence pin stays GREEN; only the FRAGMENT ledger can see it. A
+    # WRONG-KILLER here means that ledger is dead code.
+    ("R1  reword stop-rule (clause still present)",
+     {"test_each_clause_carries_the_instruction_its_ledger_entry_names"},
+     reword_stop_rule),
+    ("F1  render bullets from a hardcoded copy",
+     {"test_the_rendered_section_holds_exactly_the_ledgered_clauses",
+      "test_every_clause_is_emitted_verbatim_in_both_kinds_of_brief",
+      DELETION_CONTROL},
+     hardcode_bullets),
+    ("C1  the delta refusal removed",
+     {"test_the_delta_refusal_exits_non_zero_and_emits_no_brief",
+      "test_the_refusal_names_what_it_looked_for_and_where",
+      "test_the_refusal_fires_for_a_malformed_block_and_says_which_way"},
+     remove_the_refusal),
+    ("C2  claims read from the whole comment",
+     {"test_the_brief_carries_the_claims_and_not_the_reasoning_around_them",
+      "test_the_newest_claims_block_wins",
+      "test_emit_claims_prints_a_block_this_scripts_own_parser_accepts"},
+     claims_from_the_whole_comment),
+    ("C3  cross-repo decision inverted",
+     {"test_cross_repo_tells_the_agent_to_worktree_the_prs_repo_itself",
+      "test_same_repo_recommends_the_isolation_flag_and_does_not_hand_roll",
+      "test_the_cross_repo_decision_comes_from_the_repos_not_from_prose"},
+     invert_cross_repo),
+    ("C4  numstat failure reads as a clean zero",
+     {"test_the_ledger_refuses_a_failed_command_rather_than_printing_zero"},
+     numstat_failure_reads_zero),
+    ("C5  the ledger classifies by pathspec",
+     {"test_the_ledger_shows_the_files_and_refuses_to_classify_them"},
+     classify_by_pathspec),
+    ("C6  the missing-clause warning BLOCKS",
+     {"test_missing_clause_check_warns_and_never_blocks"},
+     the_warning_blocks),
+]
+
+
+def failing(root: Path):
+    """-> (killer test names, raw output). Reads the CONTENT, never an exit code."""
+    env = dict(os.environ, PYTHONDONTWRITEBYTECODE="1")
+    p = subprocess.run(
+        [sys.executable, "-m", "pytest", str(root / TEST_REL),
+         "-q", "--no-header", "--tb=no", "-p", "no:cacheprovider"],
+        capture_output=True, text=True, env=env, cwd=str(root), check=False,
+    )
+    # stderr is CAPTURED, not discarded: the commonest way to get "0 tests ran"
+    # on this host is running outside `nix develop` (`.envrc` is `use opencode`,
+    # so a loaded direnv has no pytest), and discarding it turns that one-line
+    # diagnosis into a headline that blames the TREE.
+    out = p.stdout + p.stderr
+    if "No module named pytest" in out:
+        return None, ("pytest is not on PATH — run this as `nix develop "
+                      "~/workspace/devrc -c python3 scripts/tests/"
+                      "mutants-audit-dispatch.py`, not in a bare shell")
+    passed = sum(int(n) for n in re.findall(r"(\d+) passed", out))
+    failed = sum(int(n) for n in re.findall(r"(\d+) failed", out))
+    if passed + failed < MIN_TESTS:
+        return None, (f"only {passed + failed} test(s) ran (floor {MIN_TESTS}) — "
+                      f"the harness, not the tree:\n{out[-800:]}")
+    return set(re.findall(r"^FAILED [^:]*::([A-Za-z0-9_]+)", out, re.M)), out
+
+
+def main() -> int:
+    tmp = Path(tempfile.mkdtemp(prefix="audit-dispatch-mut-"))
+    try:
+        root = tmp / "tree"
+        (root / "scripts" / "tests").mkdir(parents=True)
+        shutil.copy(REPO / SCRIPT_REL, root / SCRIPT_REL)
+        shutil.copy(REPO / TEST_REL, root / TEST_REL)
+        if (root / ".git").exists():
+            print("🔴 the copy carries a .git — refusing to run")
+            return 2
+        original = (root / SCRIPT_REL).read_text(encoding="utf-8")
+
+        killers, raw = failing(root)
+        if killers is None:
+            print(f"🔴 THE HARNESS could not run: {raw}")
+            print("   Nothing was measured. This says nothing about the tree.")
+            return 2
+        if killers:
+            print("🔴 the UNMUTATED tree is already failing: "
+                  + ", ".join(sorted(killers)))
+            print("   every row below would be meaningless. Fix that first.")
+            return 2
+        n = sum(int(x) for x in re.findall(r"(\d+) passed", raw))
+        print(f"POS  unmutated copy .......................... {n} passed")
+        print()
+
+        bad = 0
+        for label, want, mutate in ROWS:
+            try:
+                mutated = mutate(original)
+            except AssertionError as e:
+                print(f"  🔴 {label:44s} MUTATION DID NOT APPLY — {e}")
+                bad += 1
+                continue
+            if mutated == original:
+                print(f"  🔴 {label:44s} MUTATION DID NOT APPLY (no change)")
+                bad += 1
+                continue
+            (root / SCRIPT_REL).write_text(mutated, encoding="utf-8")
+            got, raw2 = failing(root)
+            (root / SCRIPT_REL).write_text(original, encoding="utf-8")
+
+            if got is None:
+                print(f"  🔴 {label:44s} HARNESS BROKE — {raw2}")
+                bad += 1
+                continue
+            if not got:
+                print(f"  🔴 {label:44s} SURVIVED — no test failed")
+                bad += 1
+                continue
+            missing = want - got
+            extra = got - want
+            if missing:
+                print(f"  🔴 {label:44s} WRONG-KILLER: {sorted(missing)} did NOT "
+                      f"fire (got {sorted(got)})")
+                bad += 1
+                continue
+            if extra:
+                print(f"  🔴 {label:44s} EXTRA-KILLER: {sorted(extra)} also fired "
+                      "— the row no longer isolates what it names")
+                bad += 1
+                continue
+            print(f"  ok {label:44s} killed by exactly {len(got)}: "
+                  + ", ".join(sorted(got)))
+
+        print()
+        if bad:
+            print(f"🔴 {bad} of {len(ROWS)} row(s) not as expected")
+            return 1
+        print(f"✅ {len(ROWS)} row(s), all as expected")
+        return 0
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -83,20 +83,28 @@ HARNESS_REL = "scripts/tests/mutants-audit-dispatch.py"
 # `mutants-audit-ladder.sh`. A suite that never ran yields zero FAILED lines,
 # i.e. "clean", so a harness wired to nothing would score every mutant SURVIVED.
 #
-# 🔴 RAISED IN ROUND 8, 50 -> 95, and the drift story is the reason it was 50.
-# It was set when the suite held 58 tests and never moved; against today's 100
-# it would pass a run that collected barely half the module — a state that
+# 🔴 RAISED IN ROUND 8, 50 -> 97, and the drift story is the reason it was 50.
+# It was set when the suite held 58 tests and never moved; against round 8's
+# 102 it would pass a run that collected barely half the module — a state that
 # silently drops whole classes of guard while every remaining row still reports
 # a verdict. Derived from the current measurement the way this repo derives
-# every other floor, `m - min(50, max(1, m // 20))` with m = 102 counted from
-# the harness's own positive-control line, NOT hand-picked.
+# every other floor, `m - min(50, max(1, m // 20))`, with `m` COUNTED from the
+# harness's own positive-control line and NOT hand-picked.
+#
+# 🔴 ROUND 10 RAISED IT AGAIN, 97 -> 104, at m = 109. And round 8's comment
+# here was WRONG IN BOTH ITS NUMBERS — it said "50 -> 95" and "against today's
+# 100" three lines above `MIN_TESTS = 97` and beside its own correct `m = 102`.
+# The stated derivation from the stated `m` gave 97; neither figure in the
+# prose was ever the constant. Exactly the drift this file exists to refuse,
+# in the file whose thesis is that unre-run arithmetic rots. Re-derive by
+# COUNTING, never by adding this round's new tests to the last sentence.
 #
 # 🔴 IT IS A COLLAPSE FLOOR, SO IT COMPARES `passed + failed`, NOT `passed`. A
 # mutant is SUPPOSED to make tests fail; what this refuses is a run that
 # COLLECTED too few. A floor that tracks the suite has to be re-derived when
 # the suite grows — the alternative is the one measured above, a number nobody
 # updated for four rounds while the thing it protects doubled.
-MIN_TESTS = 97
+MIN_TESTS = 104
 
 # A row may name this instead of a killer set: the mutation MUST leave the suite
 # green. See the module docstring — the clause ledger pins whole normalised
@@ -121,28 +129,8 @@ HOLE = "HOLE"
 # Mutations. Each takes the script source and returns it changed, or raises.
 # --------------------------------------------------------------------------- #
 
-def drop_entry(kind, cid):
-    """Delete a whole `Clause(...)` / `Directive(...)` entry from its tuple."""
-    def f(t):
-        pat = re.compile(
-            r"    " + kind + r"\(\n        \"" + re.escape(cid)
-            + r"\",\n(?:.*?\n)*?    \),\n"
-        )
-        new, n = pat.subn("", t, count=1)
-        if n != 1:
-            raise AssertionError(
-                f"{kind.lower()} {cid!r} not found in its expected shape"
-            )
-        return new
-    return f
-
-
-def drop_clause(cid):
-    return drop_entry("Clause", cid)
-
-
-def _swap(t, old, new):
-    """🔴 THE TARGET MUST BE UNIQUE, not merely PRESENT.
+def _require_unique(n, what):
+    """🔴 THE TARGET MUST BE UNIQUE, not merely PRESENT — ONE RULE, ONE PLACE.
 
     Round 8 measured the difference, and it is the same shape as everything
     else this file guards. `C5` targets a line starting with EIGHT spaces;
@@ -159,16 +147,52 @@ def _swap(t, old, new):
     pictured." The assert above it already refuses a target that has MOVED;
     this refuses one that has been DUPLICATED, and the two failures need the
     same response — re-target the row.
+
+    🔴 ROUND 10 — LIFTED OUT OF `_swap`, WHICH WAS ONE OF THREE SITES. Round 8
+    applied the lesson to the string mutator and left both REGEX mutators
+    (`drop_entry`, `reword_entry`) doing `pat.subn(…, count=1)` and testing
+    `n != 1` — a predicate that, WITH `count=1`, can only ever be 0 or 1 and so
+    can detect an ABSENT target and never a DUPLICATED one. Milder than
+    `_swap`'s case (a duplicated entry id would score SURVIVED, which is loud)
+    but the same blind spot, at the sites nobody swept. The rule now has one
+    statement and three callers.
     """
-    n = t.count(old)
     if n == 0:
-        raise AssertionError(f"target absent: {old[:70]!r}…")
+        raise AssertionError(f"target absent: {what}")
     if n > 1:
         raise AssertionError(
-            f"target is AMBIGUOUS — {n} occurrences, so `replace(…, 1)` would "
-            f"mutate whichever comes first and not necessarily the one this "
-            f"row means: {old[:70]!r}…"
+            f"target is AMBIGUOUS — {n} occurrences, so a `count=1` "
+            f"substitution would edit whichever comes first and not "
+            f"necessarily the one this row means: {what}"
         )
+
+
+def _sub_unique(pat, repl, t, what):
+    """`_require_unique` in its REGEX spelling — counts MATCHES, then edits."""
+    _require_unique(len(pat.findall(t)), what)
+    return pat.sub(repl, t, count=1)
+
+
+def drop_entry(kind, cid):
+    """Delete a whole `Clause(...)` / `Directive(...)` entry from its tuple."""
+    def f(t):
+        pat = re.compile(
+            r"    " + kind + r"\(\n        \"" + re.escape(cid)
+            + r"\",\n(?:.*?\n)*?    \),\n"
+        )
+        return _sub_unique(
+            pat, "", t, f"{kind.lower()} {cid!r} in its expected shape"
+        )
+    return f
+
+
+def drop_clause(cid):
+    return drop_entry("Clause", cid)
+
+
+def _swap(t, old, new):
+    """A UNIQUE literal substring, replaced once. See `_require_unique`."""
+    _require_unique(t.count(old), f"{old[:70]!r}…")
     return t.replace(old, new, 1)
 
 
@@ -256,10 +280,17 @@ def classify_by_pathspec(t):
 
 
 def the_warning_blocks(t):
-    old = ('              "emitted. Re-add them by hand, or re-run without --out edits.",\n'
-           "            file=err_stream,\n"
-           "        )\n")
-    return _swap(t, old, old + "        return 4\n")
+    # 🔴 RE-TARGETED IN ROUND 10 — the SIXTH catch by assert-before-editing, and
+    # this one was a pure RE-INDENT: the whole brief-rendering block moved
+    # inside `if brief_refused is None:` so a refused run emits no document to
+    # check. Nothing about the warning changed; the row would have scored "the
+    # guard held" on a file it never edited.
+    old = ('                  "emitted. Re-add them by hand, or re-run without '
+           '--out "\n'
+           '                  "edits.",\n'
+           "                file=err_stream,\n"
+           "            )\n")
+    return _swap(t, old, old + "            return 4\n")
 
 
 # --------------------------------------------------------------------------- #
@@ -283,15 +314,12 @@ def reword_entry(kind, cid, new_text):
             r"(    " + kind + r"\(\n        \"" + re.escape(cid) + r"\",\n)"
             r"(?:.*?\n)*?(    \),\n)"
         )
-        new, n = pat.subn(
+        return _sub_unique(
+            pat,
             lambda m: m.group(1) + f'        "{new_text}",\n' + m.group(2),
-            t, count=1,
+            t,
+            f"{kind.lower()} {cid!r} in its expected shape",
         )
-        if n != 1:
-            raise AssertionError(
-                f"{kind.lower()} {cid!r} not found in its expected shape"
-            )
-        return new
     return f
 
 
@@ -403,11 +431,12 @@ def the_check_command_reports_clean(t):
 
 
 def the_out_file_is_not_read_back(t):
+    # 🔴 RE-TARGETED IN ROUND 10, for the same re-indent as `the_warning_blocks`.
     return _swap(
         t,
-        '            checked_text = Path(args.out).read_text(encoding="utf-8")\n'
-        "            checked_what = args.out\n",
-        "            pass\n",
+        '                checked_text = Path(args.out).read_text(encoding="utf-8")\n'
+        "                checked_what = args.out\n",
+        "                pass\n",
     )
 
 
@@ -887,14 +916,20 @@ def the_head_check_stops_comparing_the_two_shas(t):
     return _swap(t, "    if local != pr_head_sha:", "    if False:")
 
 
+# 🔴 RE-TARGETED IN ROUND 10, both of them: the two branches stopped asking
+# `repo_relation` directly and now ask `cross_repo_holds_neither_end`, the
+# shared predicate round 10's finding B introduced. Same mutation — the branch
+# never fires — at the branch's own condition, so it stays distinct from V19,
+# which mutates the PREDICATE and leaves both branches selectable.
 def the_cross_repo_range_diagnoses_a_moved_checkout_again(t):
-    return _swap(t, '    elif facts.repo_relation == "cross":', "    elif False:")
+    return _swap(t, "    elif cross_repo_holds_neither_end(facts):",
+                 "    elif False:")
 
 
 def the_cross_repo_ledger_reports_a_failed_command_again(t):
     return _swap(
         t,
-        '    if facts.round_no >= 2 and facts.repo_relation == "cross":',
+        "    if facts.round_no >= 2 and cross_repo_holds_neither_end(facts):",
         "    if False:",
     )
 
@@ -945,6 +980,117 @@ def the_ledger_provenance_line_hands_out_head_again(t):
         '    measured_tip = hc.local_sha if (hc is not None and hc.ok) else "HEAD"',
         '    measured_tip = "HEAD"',
     )
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 V18-V23 — round 10. Base `706a6b38`.
+# --------------------------------------------------------------------------- #
+
+def the_tip_is_always_claimed_to_be_a_sha(t):
+    """Round 10's finding A: the placeholder is handed over as a commit.
+
+    The NARROWEST expression that can be wrong — the predicate's own return,
+    not the branch that consults it. Mutating the enclosing `elif` would take
+    the whole cross-repo branch with it and die for someone else's reason.
+    """
+    return _swap(
+        t,
+        "    return range_tip(facts) != TIP_PLACEHOLDER",
+        "    return True",
+    )
+
+
+def the_ledger_asks_the_repo_relation_before_the_head_check(t):
+    """Round 10's finding B, restored at the predicate both sites now share.
+
+    `if False:` on the head-check short-circuit is the base's behaviour
+    exactly: the relation alone decides, so a renamed-remote clone that HOLDS
+    the PR's head is told it holds neither end of the range.
+    """
+    return _swap(
+        t,
+        "    hc = facts.head_check\n"
+        "    if hc is not None and hc.ok:\n"
+        "        return False\n"
+        '    return facts.repo_relation == "cross"',
+        "    hc = facts.head_check\n"
+        "    if False:\n"
+        "        return False\n"
+        '    return facts.repo_relation == "cross"',
+    )
+
+
+def the_anchorless_refusal_blocks_its_own_remedy(t):
+    """Round 10's finding C at REFUSAL 1b — the site the finding named."""
+    return _swap(
+        t,
+        '            "and nothing from the comment.",\n'
+        "        ]), file=err_stream)\n"
+        "        if not args.emit_claims:\n"
+        "            return 2\n"
+        "        brief_refused = 2\n",
+        '            "and nothing from the comment.",\n'
+        "        ]), file=err_stream)\n"
+        "        return 2\n",
+    )
+
+
+def the_no_block_refusal_blocks_its_own_remedy(t):
+    """Round 10's finding C at REFUSAL 1 — the SIBLING site.
+
+    Kept as its own row rather than folded into the one above: the two
+    refusals are independent `return`s, and a fix applied at the site a finding
+    names while the sibling keeps the defect is this ladder's single most
+    repeated shape.
+    """
+    return _swap(
+        t,
+        '            "round as an explicit first, full audit with no --round.",\n'
+        "        ]), file=err_stream)\n"
+        "        if not args.emit_claims:\n"
+        "            return 2\n"
+        "        brief_refused = 2\n",
+        '            "round as an explicit first, full audit with no --round.",\n'
+        "        ]), file=err_stream)\n"
+        "        return 2\n",
+    )
+
+
+def the_two_placeholder_spellings_drift_apart(t):
+    """Round 10's finding A', at the site the constant was extracted FROM.
+
+    `range_tip`'s fallback stops naming `TIP_PLACEHOLDER` and spells its own
+    near-miss, which is exactly the state the constant was introduced to make
+    impossible: the script emits one string and every guard looks for another.
+    """
+    return _swap(
+        t,
+        "    return hc.pr_sha if (hc is not None and hc.pr_sha) else TIP_PLACEHOLDER",
+        "    return hc.pr_sha if (hc is not None and hc.pr_sha) else "
+        "\"<the PR's head sha, unknown>\"",
+    )
+
+
+def the_assumed_base_is_recorded_as_read(t):
+    """Round 10's SEVENTH instance: the default stops announcing itself.
+
+    The narrowest expression again — the flag's own assignment, not the sites
+    that consult it, so the mutant cannot die of a missing name.
+    """
+    return _swap(
+        t,
+        '    base_assumed = not data.get("baseRefName")',
+        "    base_assumed = False",
+    )
+
+
+def the_clone_grant_permits_fetching_again(t):
+    """Round 10's finding D: round 8's wording, verbatim."""
+    return reword_entry(
+        "Directive", "own-worktree-is-writable",
+        "That worktree is YOURS, and so is the clone you made it from: "
+        "fetching and checking out inside either is fine. The no-write rule "
+        "below is about every checkout you did not make.")(t)
 
 
 def the_toolchain_names_the_shared_checkout_cross_repo_only(t):
@@ -1122,7 +1268,10 @@ ROWS = [
       "test_the_refusal_names_what_it_looked_for_and_where",
       "test_the_refusal_fires_for_a_malformed_block_and_says_which_way",
       # Asserts on the refusal MESSAGE, so no refusal means no message.
-      "test_the_refusal_says_which_comment_kinds_it_cannot_see"},
+      "test_the_refusal_says_which_comment_kinds_it_cannot_see",
+      # 🔴 ROUND 10. The remedy guard opens by requiring rc 2 from REFUSAL 1;
+      # with no refusal there is no rc 2 and no prescription to extract.
+      "test_every_command_a_refusal_prescribes_actually_runs"},
      remove_the_refusal),
     ("C2  claims read from the whole comment",
      {"test_the_brief_carries_the_claims_and_not_the_reasoning_around_them",
@@ -1156,17 +1305,26 @@ ROWS = [
       # decision, which is the finding — and NOT a row gone vague.
       "test_a_cross_repo_ledger_hands_the_attribution_gate_to_the_auditor",
       "test_a_cross_repo_range_states_the_impossibility_not_a_moved_checkout",
-      "test_no_cross_repo_brief_claims_its_checkout_was_verified",
-      "test_a_degenerate_range_does_not_blame_a_checkout_it_verified",
-      "test_a_degenerate_self_range_is_named_by_the_ledger_too",
-      "test_a_failed_cumulative_measurement_does_not_print_a_false_cause",
-      "test_an_empty_range_does_not_name_a_cause_the_head_check_refutes",
-      "test_the_cumulative_figure_is_not_measured_without_a_round_one_anchor",
-      "test_the_ledger_refuses_a_failed_command_rather_than_printing_zero",
       "test_the_ledger_refuses_to_measure_a_checkout_that_is_not_the_pr",
-      "test_the_ledger_says_the_base_was_not_fetched",
-      "test_the_ledger_shows_the_files_and_refuses_to_classify_them",
-      "test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head"},
+      "test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head",
+      # 🔴 ROUND 10 — SEVEN OF ROUND 8's THIRTEEN LEFT THIS SET, and their
+      # departure is the FIX, measured. Round 8 made THE LEDGER's branch turn
+      # on `repo_relation` ALONE, so inverting that decision sent the
+      # same-repo `delta` scenario down the hand-over branch and took every
+      # ledger assertion with it. The branch now asks
+      # `cross_repo_holds_neither_end`, which consults the HEAD CHECK first —
+      # and in `delta` that check passes, so the ledger measures whatever the
+      # repo decision says. `..._degenerate_...`, `..._cumulative_...`,
+      # `..._empty_range_...`, `..._refuses_a_failed_command_...`,
+      # `..._says_the_base_was_not_fetched`, `..._shows_the_files_...` and the
+      # fixture seam guard all stopped depending on the repo decision, which
+      # is exactly what round 10's finding B says they should never have.
+      # Re-measured, not reasoned: this set is what the battery reported.
+      "test_a_cross_repo_ledger_prints_a_measurement_the_head_check_vouched_for",
+      "test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha",
+      "test_the_clone_grant_covers_only_the_write_the_recipe_makes",
+      "test_every_section_directive_is_emitted_verbatim_in_the_brief_that_owns_it",
+      "test_the_where_to_work_section_does_not_call_a_private_worktree_the_clone"},
      invert_cross_repo),
     ("C4  numstat failure reads as a clean zero",
      {"test_the_ledger_refuses_a_failed_command_rather_than_printing_zero"},
@@ -1255,7 +1413,12 @@ ROWS = [
      {"test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head",
       "test_the_unknown_head_sha_reason_names_one_cause_not_two",
       "test_a_cross_repo_range_states_the_impossibility_not_a_moved_checkout",
-      "test_no_cross_repo_brief_claims_its_checkout_was_verified"},
+      "test_no_brief_claims_a_verification_its_own_fixture_refutes",
+      # 🔴 ROUND 10. With the verified NOTE forced on, the placeholder-tip
+      # branches never render — the unresolved-tip note lives in the two
+      # branches this mutation makes unreachable — so no scenario spells the
+      # placeholder and that guard's own positive control fires.
+      "test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha"},
      range_ignores_the_head_check),
     ("H3  --emit-claims stamps the LOCAL head",
      {"test_emit_claims_stamps_the_prs_head_not_the_local_checkouts",
@@ -1344,7 +1507,10 @@ ROWS = [
       # fails it), and it stops the degenerate scenario being degenerate at
       # all — which is what that test's own positive control requires.
       "test_a_cross_repo_ledger_hands_the_attribution_gate_to_the_auditor",
-      "test_the_degenerate_range_names_shas_at_both_ends"},
+      "test_the_degenerate_range_names_shas_at_both_ends",
+      # 🔴 ROUND 10's one, and it is the same coupling: the renamed-remote
+      # ledger's provenance line is asserted WHOLE, so a moved anchor fails it.
+      "test_a_cross_repo_ledger_prints_a_measurement_the_head_check_vouched_for"},
      range_anchor_reads_the_audited_tip),
     # The OTHER wrong fix: `audited_from` alone. A round-1 bare `audited=<sha>`
     # then anchors nothing, and the remedy chain the delta refusal advertises
@@ -1484,8 +1650,12 @@ ROWS = [
     # 🔴 Y2 leaves a CROSS-REPO auditor with nowhere to work: the brief has
     # just told them to build that worktree themselves precisely so they can
     # fetch in it.
+    # 🔴 ROUND 10 ADDED THE CLONE-GRANT GUARD to this row and to V4. Any reword
+    # of this directive necessarily moves it: it asserts the two sentences that
+    # scope the grant to `worktree add`, and neither replacement carries them.
     ("Y2  own-worktree-is-writable inverted into 'do not fetch'",
      {"test_each_section_directive_carries_the_instruction_its_ledger_entry_names",
+      "test_the_clone_grant_covers_only_the_write_the_recipe_makes",
       NO_WRITE_SCOPE_GUARD},
      reword_entry(
          "Directive", "own-worktree-is-writable",
@@ -1631,6 +1801,9 @@ ROWS = [
     ("V4  own-worktree scopes the no-write rule to SHARED again",
      {"test_each_section_directive_carries_the_instruction_its_ledger_entry_names",
       "test_no_forward_reference_scopes_the_no_write_rule_to_a_denied_state",
+      # 🔴 ROUND 10 — see Y2: any reword of this directive drops the two
+      # sentences that scope the clone grant to `worktree add`.
+      "test_the_clone_grant_covers_only_the_write_the_recipe_makes",
       NO_WRITE_SCOPE_GUARD},
      the_own_worktree_grant_scopes_the_rule_to_sharedness_again),
     ("V5  the --audited whitespace input check is removed",
@@ -1681,22 +1854,37 @@ ROWS = [
     # seam guard executes at all. Every member listed rather than trimmed to
     # the "main" one, as N1 and V6 are.
     ("V9  the head check stops comparing the two shas",
-     {"test_no_cross_repo_brief_claims_its_checkout_was_verified",
+     {"test_no_brief_claims_a_verification_its_own_fixture_refutes",
       "test_a_cross_repo_ledger_hands_the_attribution_gate_to_the_auditor",
       "test_a_cross_repo_range_states_the_impossibility_not_a_moved_checkout",
       "test_emit_claims_stamps_the_prs_head_not_the_local_checkouts",
       "test_the_ledger_refuses_to_measure_a_checkout_that_is_not_the_pr",
       "test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head",
-      "test_the_range_names_a_sha_and_not_head_when_the_head_is_verified"},
+      "test_the_range_names_a_sha_and_not_head_when_the_head_is_verified",
+      # 🔴 ROUND 10's two, and both are the fourth read rule doing its job:
+      # `cross_repo_holds_neither_end` consults the head check, so disarming it
+      # sends the renamed-remote scenario down the hand-over branch; and
+      # `range_tip` falls back to the placeholder in scenarios that had a
+      # verified sha, so the tip guard's own claim about which scenarios spell
+      # it stops holding.
+      "test_a_cross_repo_ledger_prints_a_measurement_the_head_check_vouched_for",
+      "test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha"},
      the_head_check_stops_comparing_the_two_shas),
     ("V10 the blind-spot rationale hides in a '…' '…' concat",
      {"test_the_blind_spot_rationale_matches_what_the_script_actually_does"},
      the_blind_spot_rationale_hides_in_single_quoted_concat),
+    # 🔴 ROUND 10 GAVE V11 AND V12 ONE KILLER EACH, and in both cases it is the
+    # new guard's OTHER-SIDE positive control: round 10's fixes made two
+    # branches conditional, so each guard also asserts that the branch still
+    # renders its TRUE case. Disable the branch outright and that control
+    # fires — which is the control doing exactly what it is for.
     ("V11 the cross-repo RANGE blames a moved checkout again",
-     {"test_a_cross_repo_range_states_the_impossibility_not_a_moved_checkout"},
+     {"test_a_cross_repo_range_states_the_impossibility_not_a_moved_checkout",
+      "test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha"},
      the_cross_repo_range_diagnoses_a_moved_checkout_again),
     ("V12 the cross-repo LEDGER reports a failed command again",
-     {"test_a_cross_repo_ledger_hands_the_attribution_gate_to_the_auditor"},
+     {"test_a_cross_repo_ledger_hands_the_attribution_gate_to_the_auditor",
+      "test_a_cross_repo_ledger_prints_a_measurement_the_head_check_vouched_for"},
      the_cross_repo_ledger_reports_a_failed_command_again),
     ("V13 the DEGENERATE range hands out `..HEAD` again",
      {"test_the_degenerate_range_names_shas_at_both_ends"},
@@ -1709,15 +1897,69 @@ ROWS = [
      {"test_the_no_write_forward_reference_states_the_clauses_own_scope",
       "test_each_clause_carries_the_instruction_its_ledger_entry_names"},
      the_no_fetch_clause_narrows_to_this_audit_again),
+    # 🔴 ROUND 10 WIDENED THIS ROW BY ONE, and the width is the fix: the
+    # renamed-remote scenario now REACHES the measuring branch, so it reads the
+    # same provenance line and asserts it whole.
     ("V15 THE LEDGER's provenance line hands out `..HEAD` again",
-     {"test_the_ledgers_provenance_line_names_the_sha_it_resolved_not_head"},
+     {"test_the_ledgers_provenance_line_names_the_sha_it_resolved_not_head",
+      "test_a_cross_repo_ledger_prints_a_measurement_the_head_check_vouched_for"},
      the_ledger_provenance_line_hands_out_head_again),
     ("V16 the skipped-round warning is removed",
      {"test_a_claims_block_more_than_one_round_behind_is_warned_about"},
      the_skipped_round_warning_is_removed),
+    # 🔴 ROUND 10 WIDENED THIS ROW BY TWO. The remedy guard requires rc 2 from
+    # REFUSAL 1b before it can read a prescription out of it, and its negative
+    # control is built from the same refusal's text — with the refusal gone
+    # there is nothing to extract on either side. Both are listed rather than
+    # trimmed: a control that stops being able to fail is exactly the thing the
+    # EXTRA-KILLER report exists to surface.
     ("V17 the no-anchor refusal is removed",
-     {"test_a_block_that_parses_but_yields_no_anchor_is_refused"},
+     {"test_a_block_that_parses_but_yields_no_anchor_is_refused",
+      "test_every_command_a_refusal_prescribes_actually_runs",
+      "test_control_the_prescription_extractor_can_see_a_broken_remedy"},
      the_no_anchor_refusal_is_removed),
+
+    # --------------------------------------------------------------------- #
+    # 🔴 V18-V23 — round 10. Base `706a6b38`.
+    # --------------------------------------------------------------------- #
+    # 🔴 TWO killers, and both are the predicate's real consumers: the brief
+    # side (the placeholder is handed over with no warning) and the ledger pin,
+    # whose second assertion drives `unresolved_tip_note` directly and gets ""
+    # back. Listed in full.
+    ("V18 the tip is always claimed to be a sha",
+     {"test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha",
+      "test_the_tip_placeholder_ledger_matches_the_script"},
+     the_tip_is_always_claimed_to_be_a_sha),
+    ("V19 the cross-repo LEDGER asks the relation before the head check",
+     {"test_a_cross_repo_ledger_prints_a_measurement_the_head_check_vouched_for"},
+     the_ledger_asks_the_repo_relation_before_the_head_check),
+    ("V20 REFUSAL 1b blocks the remedy it prescribes",
+     {"test_every_command_a_refusal_prescribes_actually_runs"},
+     the_anchorless_refusal_blocks_its_own_remedy),
+    # 🔴 V21's killer set is TWO, and the width is the coupling itself: the
+    # constant exists so the script's spelling and the guards' literal cannot
+    # drift. Break it and the ledger pin fires (its own assertion) AND the
+    # placeholder guard's positive control fires — no scenario renders the
+    # string it scans for any more. Listed in full rather than trimmed, the
+    # same treatment N1, V6 and V9 get.
+    ("V21 `range_tip`'s placeholder stops naming TIP_PLACEHOLDER",
+     {"test_the_tip_placeholder_ledger_matches_the_script",
+      "test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha"},
+     the_two_placeholder_spellings_drift_apart),
+    # V22 also moves the WHOLE-STRING directive ledger, necessarily: round 10's
+    # fix was a reword, so restoring the old text is a reword the ledger pins.
+    # Both are listed; the clone-grant guard is the one that fires for THIS
+    # row's reason. Same treatment as V14.
+    ("V22 the clone grant permits fetching there again",
+     {"test_the_clone_grant_covers_only_the_write_the_recipe_makes",
+      "test_each_section_directive_carries_the_instruction_its_ledger_entry_names"},
+     the_clone_grant_permits_fetching_again),
+    ("V23 REFUSAL 1 blocks the remedy it prescribes",
+     {"test_every_command_a_refusal_prescribes_actually_runs"},
+     the_no_block_refusal_blocks_its_own_remedy),
+    ("V24 an ASSUMED base branch is recorded as read",
+     {"test_no_brief_states_an_assumed_base_branch_as_a_fact"},
+     the_assumed_base_is_recorded_as_read),
 ]
 
 

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -82,7 +82,21 @@ HARNESS_REL = "scripts/tests/mutants-audit-dispatch.py"
 # 🔴 A COLLAPSE floor, not a growth floor — same rule as
 # `mutants-audit-ladder.sh`. A suite that never ran yields zero FAILED lines,
 # i.e. "clean", so a harness wired to nothing would score every mutant SURVIVED.
-MIN_TESTS = 50
+#
+# 🔴 RAISED IN ROUND 8, 50 -> 95, and the drift story is the reason it was 50.
+# It was set when the suite held 58 tests and never moved; against today's 100
+# it would pass a run that collected barely half the module — a state that
+# silently drops whole classes of guard while every remaining row still reports
+# a verdict. Derived from the current measurement the way this repo derives
+# every other floor, `m - min(50, max(1, m // 20))` with m = 102 counted from
+# the harness's own positive-control line, NOT hand-picked.
+#
+# 🔴 IT IS A COLLAPSE FLOOR, SO IT COMPARES `passed + failed`, NOT `passed`. A
+# mutant is SUPPOSED to make tests fail; what this refuses is a run that
+# COLLECTED too few. A floor that tracks the suite has to be re-derived when
+# the suite grows — the alternative is the one measured above, a number nobody
+# updated for four rounds while the thing it protects doubled.
+MIN_TESTS = 97
 
 # A row may name this instead of a killer set: the mutation MUST leave the suite
 # green. See the module docstring — the clause ledger pins whole normalised
@@ -128,8 +142,33 @@ def drop_clause(cid):
 
 
 def _swap(t, old, new):
-    if old not in t:
+    """🔴 THE TARGET MUST BE UNIQUE, not merely PRESENT.
+
+    Round 8 measured the difference, and it is the same shape as everything
+    else this file guards. `C5` targets a line starting with EIGHT spaces;
+    round 8 added a second copy of that sentence inside a nested list at TWELVE
+    spaces, and eight spaces is a substring of twelve — so `replace(…, 1)` hit
+    the NEW site, which had no `led` in scope, and every scenario-driven test
+    died of a `NameError`. The row reported WRONG-KILLER, which is the lucky
+    outcome: a wrong site that happens to stay runnable scores SURVIVED, or
+    KILLED for a reason belonging to a different mutation, and either reads as
+    a measurement of the row's own target.
+
+    `claude/RULES.md`: "A `count=1` text replace on a pattern that occurs more
+    than once is a live hazard — which occurrence you hit is not the one you
+    pictured." The assert above it already refuses a target that has MOVED;
+    this refuses one that has been DUPLICATED, and the two failures need the
+    same response — re-target the row.
+    """
+    n = t.count(old)
+    if n == 0:
         raise AssertionError(f"target absent: {old[:70]!r}…")
+    if n > 1:
+        raise AssertionError(
+            f"target is AMBIGUOUS — {n} occurrences, so `replace(…, 1)` would "
+            f"mutate whichever comes first and not necessarily the one this "
+            f"row means: {old[:70]!r}…"
+        )
     return t.replace(old, new, 1)
 
 
@@ -192,12 +231,27 @@ def numstat_failure_reads_zero(t):
 
 
 def classify_by_pathspec(t):
+    # 🔴 RE-TARGETED IN ROUND 8, and it is the FIFTH row this file's
+    # assert-before-editing has caught after a refactor nobody thought touched
+    # the battery — this time via the new AMBIGUITY check rather than the
+    # absence one. Round 8 added a second copy of this sentence in the
+    # cross-repo hand-over at a deeper indentation, and the old eight-space
+    # target matched THAT line first (eight spaces are a substring of twelve),
+    # mutating a branch with no `led` in scope. The script now writes the line
+    # from one place, `payload_summary_line`, which is what this targets.
     return _swap(
         t,
-        '        f"round {facts.round_no} · payload lines changed THIS round: X "\n',
-        '        f"round {facts.round_no} · payload lines changed THIS round: "\n'
-        "        f\"{sum(a + d for p, (a, d) in led.files.items() "
-        "if 'test' not in p)} \"\n",
+        '    return (f"round {facts.round_no} · payload lines changed THIS '
+        'round: X "\n',
+        '    return (f"round {facts.round_no} · payload lines changed THIS '
+        'round: "\n'
+        # `files` is None whenever the ledger could not measure (cross-repo,
+        # a failed command), and `payload_summary_line` is now reached in
+        # those states too — so the mutant guards it. A mutant that dies of an
+        # AttributeError is killed by its own crash, not by the guard it is
+        # supposed to be testing.
+        "            f\"{sum(a + d for p, (a, d) in ((facts.ledger.files if "
+        "facts.ledger else None) or dict()).items() if 'test' not in p)} \"\n",
     )
 
 
@@ -759,10 +813,137 @@ def the_whitespace_input_check_is_removed(t):
 
 
 def the_verified_range_hands_out_head_again(t):
+    # 🔴 RE-TARGETED IN ROUND 8. Round 7 wrote the tip inline in
+    # `render_range`'s verified branch; round 8 moved it into `range_tip`
+    # because the DEGENERATE branch of the same `if`/`elif` still handed out
+    # the token. One predicate, one place — so this row now mutates the
+    # predicate, and its killer set GREW to include the degenerate range's own
+    # test. That growth is the consolidation working, not a pin doing new work.
     return _swap(
         t,
-        "    elif hc is not None and hc.ok:\n        tip = hc.local_sha\n",
-        '    elif hc is not None and hc.ok:\n        tip = "HEAD"\n',
+        "    if hc is not None and hc.ok:\n        return hc.local_sha\n",
+        '    if hc is not None and hc.ok:\n        return "HEAD"\n',
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 V8-V15 — round 8 (base `28492af2`).
+# --------------------------------------------------------------------------- #
+# V8 and V10 are V3's plant IN THE TWO SHAPES ROUND 7's NORMALISER COULD NOT
+# SEE, and they exist because V3 planted on ONE line: the guard scored 0 for the
+# same sentence wrapped across two `#` lines and for either single-quoted
+# spelling of an implicit concatenation, while its own prose claimed both. The
+# ladder writes every round's narrative into a wrapped comment block, so the
+# shape the battery never exercised is the shape the defect would arrive in.
+
+_BLIND_SPOT_ANCHOR = (
+    "# 🔴 AND THE REASON GIVEN HERE FOR THREE ROUNDS WAS FALSE. It asserted that"
+)
+
+
+def the_blind_spot_rationale_wraps_across_two_comment_lines(t):
+    """V3's false rationale, with the PHRASE ITSELF split by a line break.
+
+    The break falls INSIDE `never resolves a sha` — between "resolves" and "a
+    sha" — because a plant that keeps the phrase whole on one line is just V3
+    with extra text and proves nothing about the wrap.
+    """
+    return _swap(
+        t,
+        _BLIND_SPOT_ANCHOR,
+        "# This script never resolves\n"
+        "# a sha in that checkout, so whether a well-formed token is a real\n"
+        "# commit is a question it cannot answer.\n" + _BLIND_SPOT_ANCHOR,
+    )
+
+
+def the_blind_spot_rationale_hides_in_single_quoted_concat(t):
+    """The same rationale, split by a SINGLE-QUOTED implicit concatenation.
+
+    Round 7 joined adjacent literals with `re.sub(r'"\\s*"', "", …)`, which sees
+    the double-quoted spelling only — while its docstring said the literals are
+    joined "exactly as the compiler joins them". The compiler does not care
+    which quote character was used.
+    """
+    return _swap(
+        t,
+        _BLIND_SPOT_ANCHOR,
+        "_blind_spot_note = ('This script never resolves '\n"
+        "                    'a sha in that checkout.')\n" + _BLIND_SPOT_ANCHOR,
+    )
+
+
+def the_head_check_stops_comparing_the_two_shas(t):
+    """Round 2's fourth read rule, disarmed — `HEAD` is assumed to be the PR's.
+
+    🔴 THE ISOLATING ROW FOR THE CROSS-REPO SEAM GUARD, from the only side a
+    SCRIPT mutation can reach it. What was actually wrong at `28492af2` was the
+    test module's FIXTURE (`OTHER_REPO_PR` inherited `DEFAULT_PR`'s
+    `headRefOid`, so the assembly checkout was modelled as standing on a commit
+    of another repository), and this battery mutates the script and nothing
+    else. Removing the sha comparison reaches the same rendered state — a brief
+    that says CROSS-REPO and "verified at assembly time" in one document.
+    """
+    return _swap(t, "    if local != pr_head_sha:", "    if False:")
+
+
+def the_cross_repo_range_diagnoses_a_moved_checkout_again(t):
+    return _swap(t, '    elif facts.repo_relation == "cross":', "    elif False:")
+
+
+def the_cross_repo_ledger_reports_a_failed_command_again(t):
+    return _swap(
+        t,
+        '    if facts.round_no >= 2 and facts.repo_relation == "cross":',
+        "    if False:",
+    )
+
+
+def the_degenerate_range_hands_out_head_again(t):
+    """Round 7's half-applied state, restored: the OTHER branch of the if/elif."""
+    return _swap(
+        t,
+        "    if anchor_is_head(facts.prev_sha, hc):\n        note = (",
+        '    if anchor_is_head(facts.prev_sha, hc):\n        tip = "HEAD"\n'
+        "        note = (",
+    )
+
+
+def the_no_fetch_clause_narrows_to_this_audit_again(t):
+    """Round 7's clause scope: the copy you made FOR THIS AUDIT, and no other."""
+    return reword_entry(
+        "Clause", "no-fetch",
+        "**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to any "
+        "checkout that is not the copy YOU made for this audit — including the "
+        "one THE CHECKOUT section names, which is where this brief was "
+        "assembled and is not yours.** Other sessions are in those trees; a "
+        "fetch there is a write with cross-session blast radius, and every ref "
+        "you need is already resolved for you here.")(t)
+
+
+def the_no_anchor_refusal_is_removed(t):
+    """The fifth instance restored: a parsed block is read as an anchor."""
+    return _swap(
+        t,
+        "    if args.round_no >= 2 and newest is not None and not prev_sha:",
+        "    if False:",
+    )
+
+
+def the_skipped_round_warning_is_removed(t):
+    """The asymmetry restored: only a block from a LATER round warns."""
+    return _swap(
+        t,
+        "    elif newest is not None and newest.round_no < args.round_no - 1:",
+        "    elif False:",
+    )
+
+
+def the_ledger_provenance_line_hands_out_head_again(t):
+    return _swap(
+        t,
+        '    measured_tip = hc.local_sha if (hc is not None and hc.ok) else "HEAD"',
+        '    measured_tip = "HEAD"',
     )
 
 
@@ -872,6 +1053,17 @@ LEDGER_TRIO = {
 }
 DELETION_CONTROL = "test_control_a_clause_deleted_from_the_constant_is_detected"
 
+# 🔴 ROUND 8's scope guard reads BOTH SIDES of the no-write rule — the
+# `no-fetch` clause AND every sentence in the rendered brief that
+# forward-references it — because a scope stated in two forms of words is two
+# scopes. So every mutation that touches either text trips it, and FIVE
+# pre-existing rows (D2, W2, Y2, Z3, V4) gained it in the same run. That is the
+# guard's width, measured, not five rows going vague: named once here so the
+# coupling stays legible instead of being spelled out five times.
+NO_WRITE_SCOPE_GUARD = (
+    "test_the_no_write_forward_reference_states_the_clauses_own_scope"
+)
+
 # (label, expected killer set, mutation)
 ROWS = [
     ("D1  delete clause read-only",
@@ -882,7 +1074,8 @@ ROWS = [
     # error. A real coupling, and the reason the deleted-clause CONTROL is a
     # separate test from the warn test.
     ("D2  delete clause no-fetch",
-     LEDGER_TRIO | {"test_missing_clause_check_warns_and_never_blocks"},
+     LEDGER_TRIO | {"test_missing_clause_check_warns_and_never_blocks",
+                    NO_WRITE_SCOPE_GUARD},
      drop_clause("no-fetch")),
     ("D3  delete clause stop-rule",
      LEDGER_TRIO | {DELETION_CONTROL}, drop_clause("stop-rule")),
@@ -952,7 +1145,28 @@ ROWS = [
       # is a SAME-repo PR, so the inversion sends it down the cross-repo branch
       # where the WHERE TO WORK section has no private-worktree note at all.
       "test_every_section_directive_is_emitted_verbatim_in_the_brief_that_owns_it",
-      "test_the_where_to_work_section_does_not_call_a_private_worktree_the_clone"},
+      "test_the_where_to_work_section_does_not_call_a_private_worktree_the_clone",
+      # 🔴 ROUND 8 ADDED NINE MORE, and every one is the same coupling seen
+      # from a new angle: round 8 made THE RANGE and THE LEDGER consult
+      # `repo_relation`, so inverting that decision now moves both sections in
+      # every scenario. The delta scenario becomes CROSS and takes the
+      # hand-over branch (so its ledger prints no numbers and no cause at all);
+      # the cross-repo scenarios become SAME and take the measuring branch. The
+      # width is the fix — those two sections used to be blind to the repo
+      # decision, which is the finding — and NOT a row gone vague.
+      "test_a_cross_repo_ledger_hands_the_attribution_gate_to_the_auditor",
+      "test_a_cross_repo_range_states_the_impossibility_not_a_moved_checkout",
+      "test_no_cross_repo_brief_claims_its_checkout_was_verified",
+      "test_a_degenerate_range_does_not_blame_a_checkout_it_verified",
+      "test_a_degenerate_self_range_is_named_by_the_ledger_too",
+      "test_a_failed_cumulative_measurement_does_not_print_a_false_cause",
+      "test_an_empty_range_does_not_name_a_cause_the_head_check_refutes",
+      "test_the_cumulative_figure_is_not_measured_without_a_round_one_anchor",
+      "test_the_ledger_refuses_a_failed_command_rather_than_printing_zero",
+      "test_the_ledger_refuses_to_measure_a_checkout_that_is_not_the_pr",
+      "test_the_ledger_says_the_base_was_not_fetched",
+      "test_the_ledger_shows_the_files_and_refuses_to_classify_them",
+      "test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head"},
      invert_cross_repo),
     ("C4  numstat failure reads as a clean zero",
      {"test_the_ledger_refuses_a_failed_command_rather_than_printing_zero"},
@@ -980,7 +1194,8 @@ ROWS = [
      reword_clause("read-only",
                    "**Edit the repo under audit freely if it helps.**")),
     ("W2  reword no-fetch into permission",
-     {"test_each_clause_carries_the_instruction_its_ledger_entry_names"},
+     {"test_each_clause_carries_the_instruction_its_ledger_entry_names",
+      NO_WRITE_SCOPE_GUARD},
      reword_clause("no-fetch",
                    "**`pull` and `checkout` in the shared checkout are fine.**")),
     ("W3  finding-format loses file:line + scenario",
@@ -1026,10 +1241,21 @@ ROWS = [
     # rendered token from opposite sides — "not `..HEAD` when the head is
     # unverified" and "not `..HEAD` when it IS verified" — so a mutation that
     # hardcodes the token necessarily trips both. Recorded, not narrowed.
-    ("H2  the range hands out ..HEAD regardless",
+    # 🔴 RELABELLED IN ROUND 8, because what this mutation MEANS changed under
+    # it and the old label would have gone on describing something it no longer
+    # does. The target (`elif hc is not None and hc.ok:` -> `elif True:`) is
+    # unchanged and still applies — but round 8 moved the tip out of that
+    # branch into `range_tip`, so the branch now selects only the NOTE. The
+    # mutant therefore asserts "verified at assembly time" over an UNVERIFIED
+    # checkout instead of handing out `..HEAD`, and
+    # `..._range_names_a_sha_and_not_head_when_the_head_is_verified` correctly
+    # stopped firing: the tip really is still a sha. Handing out the token is
+    # now V6's job (`range_tip`) and V13's (the degenerate branch).
+    ("H2  the range's verified NOTE ignores the head check",
      {"test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head",
       "test_the_unknown_head_sha_reason_names_one_cause_not_two",
-      "test_the_range_names_a_sha_and_not_head_when_the_head_is_verified"},
+      "test_a_cross_repo_range_states_the_impossibility_not_a_moved_checkout",
+      "test_no_cross_repo_brief_claims_its_checkout_was_verified"},
      range_ignores_the_head_check),
     ("H3  --emit-claims stamps the LOCAL head",
      {"test_emit_claims_stamps_the_prs_head_not_the_local_checkouts",
@@ -1112,7 +1338,13 @@ ROWS = [
       "test_a_degenerate_range_does_not_blame_a_checkout_it_verified",
       "test_an_uppercase_audited_sha_still_trips_the_degenerate_guard",
       "test_audited_supplies_the_tip_a_round_one_emit_cannot_derive",
-      "test_audited_without_emit_claims_says_it_changed_nothing"},
+      "test_audited_without_emit_claims_says_it_changed_nothing",
+      # Round 8's two, both real: moving the anchor changes the range the
+      # cross-repo hand-over COMMAND names (asserted whole, so a wrong anchor
+      # fails it), and it stops the degenerate scenario being degenerate at
+      # all — which is what that test's own positive control requires.
+      "test_a_cross_repo_ledger_hands_the_attribution_gate_to_the_auditor",
+      "test_the_degenerate_range_names_shas_at_both_ends"},
      range_anchor_reads_the_audited_tip),
     # The OTHER wrong fix: `audited_from` alone. A round-1 bare `audited=<sha>`
     # then anchors nothing, and the remedy chain the delta refusal advertises
@@ -1152,7 +1384,12 @@ ROWS = [
       # Round 4: both of these read THE RANGE's degenerate banner — one for
       # its cause list, one for an uppercase anchor.
       "test_a_degenerate_range_does_not_blame_a_checkout_it_verified",
-      "test_an_uppercase_audited_sha_still_trips_the_degenerate_guard"},
+      "test_an_uppercase_audited_sha_still_trips_the_degenerate_guard",
+      # Round 8: that test's POSITIVE CONTROL requires the degenerate banner to
+      # be present before it asserts anything about the range, so deleting the
+      # banner kills it on the control rather than on the range spelling. That
+      # is the control doing its job.
+      "test_the_degenerate_range_names_shas_at_both_ends"},
      the_range_ignores_a_self_range),
     ("N5  the ledger calls a self-range merely empty",
      {"test_a_degenerate_self_range_is_named_by_the_ledger_too",
@@ -1248,7 +1485,8 @@ ROWS = [
     # just told them to build that worktree themselves precisely so they can
     # fetch in it.
     ("Y2  own-worktree-is-writable inverted into 'do not fetch'",
-     {"test_each_section_directive_carries_the_instruction_its_ledger_entry_names"},
+     {"test_each_section_directive_carries_the_instruction_its_ledger_entry_names",
+      NO_WRITE_SCOPE_GUARD},
      reword_entry(
          "Directive", "own-worktree-is-writable",
          "Do not fetch or check out inside it either. The no-write rule "
@@ -1346,7 +1584,8 @@ ROWS = [
     # still ledgered by id and still emitted, which is exactly how the reword
     # shipped.
     ("Z3  no-fetch goes back to conditional-on-SHARED",
-     {"test_each_clause_carries_the_instruction_its_ledger_entry_names"},
+     {"test_each_clause_carries_the_instruction_its_ledger_entry_names",
+      NO_WRITE_SCOPE_GUARD},
      the_no_fetch_clause_is_conditional_again),
     ("Z4  TOOLCHAIN's reason names the SHARED CHECKOUT again",
      {"test_the_toolchain_reason_is_true_in_every_scenario"},
@@ -1391,7 +1630,8 @@ ROWS = [
      the_blind_spot_blames_sha_resolution_again),
     ("V4  own-worktree scopes the no-write rule to SHARED again",
      {"test_each_section_directive_carries_the_instruction_its_ledger_entry_names",
-      "test_no_forward_reference_scopes_the_no_write_rule_to_a_denied_state"},
+      "test_no_forward_reference_scopes_the_no_write_rule_to_a_denied_state",
+      NO_WRITE_SCOPE_GUARD},
      the_own_worktree_grant_scopes_the_rule_to_sharedness_again),
     ("V5  the --audited whitespace input check is removed",
      {"test_emit_claims_refuses_an_audited_value_whose_whitespace_leaves_the_line"},
@@ -1407,11 +1647,77 @@ ROWS = [
       "test_the_newest_claims_block_wins",
       "test_a_bare_round_one_audited_sha_still_anchors_the_next_round",
       "test_audited_supplies_the_tip_a_round_one_emit_cannot_derive",
-      "test_audited_without_emit_claims_says_it_changed_nothing"},
+      "test_audited_without_emit_claims_says_it_changed_nothing",
+      # 🔴 ROUND 8 — THE GROWTH IS THE CONSOLIDATION, not a pin doing new work.
+      # `range_tip` is now the single writer for BOTH the verified tip and the
+      # degenerate one (`anchor_is_head` implies the head check passed), so a
+      # mutation of the predicate reaches both. That is the whole point of
+      # having one predicate; V13 is the row that isolates the degenerate
+      # branch's own override.
+      "test_the_degenerate_range_names_shas_at_both_ends"},
      the_verified_range_hands_out_head_again),
     ("V7  TOOLCHAIN names the SHARED CHECKOUT, cross-repo only",
      {"test_the_toolchain_reason_is_true_in_every_scenario"},
      the_toolchain_names_the_shared_checkout_cross_repo_only),
+
+    # --------------------------------------------------------------------- #
+    # 🔴 V8-V15 — round 8. Base `28492af2`.
+    # --------------------------------------------------------------------- #
+    # 🔴 V8 AND V10 ARE V3 IN THE SHAPES THE BATTERY NEVER EXERCISED. V3 plants
+    # its false rationale on ONE line, and round 7's normaliser could see
+    # exactly that: measured at `28492af2`, the same sentence wrapped across two
+    # `#` lines scored 0, and so did both single-quoted spellings of an implicit
+    # concatenation. A battery that only ever plants the shape the guard handles
+    # certifies the guard against itself.
+    ("V8  the blind-spot rationale WRAPS over two `#` lines",
+     {"test_the_blind_spot_rationale_matches_what_the_script_actually_does"},
+     the_blind_spot_rationale_wraps_across_two_comment_lines),
+    # 🔴 V9 IS WIDE, AND THE WIDTH IS THE FINDING'S OWN SHAPE — the same
+    # treatment V1 gets, for the same reason. What was wrong at `28492af2` was
+    # the test module's FIXTURE, which this battery cannot mutate; reaching the
+    # same rendered state from the script means disarming the fourth read rule
+    # itself, and SIX consumers of that rule move with it. The row proves the
+    # rendered state is not free, and it is the only script-side evidence the
+    # seam guard executes at all. Every member listed rather than trimmed to
+    # the "main" one, as N1 and V6 are.
+    ("V9  the head check stops comparing the two shas",
+     {"test_no_cross_repo_brief_claims_its_checkout_was_verified",
+      "test_a_cross_repo_ledger_hands_the_attribution_gate_to_the_auditor",
+      "test_a_cross_repo_range_states_the_impossibility_not_a_moved_checkout",
+      "test_emit_claims_stamps_the_prs_head_not_the_local_checkouts",
+      "test_the_ledger_refuses_to_measure_a_checkout_that_is_not_the_pr",
+      "test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head",
+      "test_the_range_names_a_sha_and_not_head_when_the_head_is_verified"},
+     the_head_check_stops_comparing_the_two_shas),
+    ("V10 the blind-spot rationale hides in a '…' '…' concat",
+     {"test_the_blind_spot_rationale_matches_what_the_script_actually_does"},
+     the_blind_spot_rationale_hides_in_single_quoted_concat),
+    ("V11 the cross-repo RANGE blames a moved checkout again",
+     {"test_a_cross_repo_range_states_the_impossibility_not_a_moved_checkout"},
+     the_cross_repo_range_diagnoses_a_moved_checkout_again),
+    ("V12 the cross-repo LEDGER reports a failed command again",
+     {"test_a_cross_repo_ledger_hands_the_attribution_gate_to_the_auditor"},
+     the_cross_repo_ledger_reports_a_failed_command_again),
+    ("V13 the DEGENERATE range hands out `..HEAD` again",
+     {"test_the_degenerate_range_names_shas_at_both_ends"},
+     the_degenerate_range_hands_out_head_again),
+    # V14 also moves the WHOLE-STRING clause ledger, necessarily: round 8's fix
+    # was a reword of that clause, so restoring the old text is a reword the
+    # ledger pins. Both are listed; the scope guard is the one that fires for
+    # THIS row's reason, and W2/Z3 above show the ledger firing without it.
+    ("V14 `no-fetch` narrows to the copy made FOR THIS AUDIT again",
+     {"test_the_no_write_forward_reference_states_the_clauses_own_scope",
+      "test_each_clause_carries_the_instruction_its_ledger_entry_names"},
+     the_no_fetch_clause_narrows_to_this_audit_again),
+    ("V15 THE LEDGER's provenance line hands out `..HEAD` again",
+     {"test_the_ledgers_provenance_line_names_the_sha_it_resolved_not_head"},
+     the_ledger_provenance_line_hands_out_head_again),
+    ("V16 the skipped-round warning is removed",
+     {"test_a_claims_block_more_than_one_round_behind_is_warned_about"},
+     the_skipped_round_warning_is_removed),
+    ("V17 the no-anchor refusal is removed",
+     {"test_a_block_that_parses_but_yields_no_anchor_is_refused"},
+     the_no_anchor_refusal_is_removed),
 ]
 
 

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -42,12 +42,23 @@ every row below is meaningless and this exits 2 without running any of them —
 and it distinguishes "the tree is red" from "pytest is not on PATH", because the
 second one blames the tree for the shell you are in.
 
+🔴 A ROW MAY EXPECT `SURVIVES`. Same convention as
+`scripts/tests/mutants-audit-ladder.sh`: the clause ledger pins WHOLE
+whitespace-normalised strings, so a pure RE-WRAP must stay green. A re-wrap that
+went red would mean the pins are keyed to line breaks and every reflow of the
+source becomes a test failure — which is the permanently-red gate
+`claude/RULES.md` says trains people to click through. A `SURVIVES` row that
+KILLS something is a finding, reported as such.
+
 COVERAGE IS DELIBERATELY PARTIAL. What is here: one deletion per invariant
 clause, an addition, one REWORD that leaves the clause present (the reachability
-control for the fragment ledger), one renderer bypass, and one inversion per
-generated decision. What is NOT here: the `gh`/`git` boundary itself (the suite
-injects a runner and says so), and whether a human classifies the ledger's files
-correctly (nothing mechanical can grade that).
+control for the clause ledger), five rewords that INVERT their clause, a
+re-wrap control, one renderer bypass, and one inversion per generated decision —
+including the four that shipped and were caught in round 2's audit (the head
+check, the toolchain's tree-under-test, the fork-PR repo read, and the
+three-state repo decision). What is NOT here: the `gh`/`git` boundary itself
+(the suite injects a runner and says so), and whether a human classifies the
+ledger's files correctly (nothing mechanical can grade that).
 """
 from __future__ import annotations
 
@@ -66,7 +77,12 @@ TEST_REL = "scripts/tests/test_audit_dispatch.py"
 # 🔴 A COLLAPSE floor, not a growth floor — same rule as
 # `mutants-audit-ladder.sh`. A suite that never ran yields zero FAILED lines,
 # i.e. "clean", so a harness wired to nothing would score every mutant SURVIVED.
-MIN_TESTS = 30
+MIN_TESTS = 50
+
+# A row may name this instead of a killer set: the mutation MUST leave the suite
+# green. See the module docstring — the clause ledger pins whole normalised
+# strings, and a re-wrap that went red would make every reflow a test failure.
+SURVIVES = "SURVIVES"
 
 
 # --------------------------------------------------------------------------- #
@@ -131,9 +147,12 @@ def claims_from_the_whole_comment(t):
 
 
 def invert_cross_repo(t):
+    # Re-targeted when the two-state `cross_repo` flag became the three-state
+    # `repo_relation`. Same mutation: the two KNOWN states swap, and the
+    # "unknown" state is left alone so this row stays distinct from P2.
     return _swap(t,
-                 "cross_repo=bool(cwd_slug and repo and cwd_slug != repo),",
-                 "cross_repo=bool(cwd_slug and repo and cwd_slug == repo),")
+                 '        repo_relation = "same" if pr_repo == cwd_slug else "cross"',
+                 '        repo_relation = "cross" if pr_repo == cwd_slug else "same"')
 
 
 def numstat_failure_reads_zero(t):
@@ -163,6 +182,194 @@ def the_warning_blocks(t):
     return _swap(t, old, old + "        return 4\n")
 
 
+# --------------------------------------------------------------------------- #
+# 🔴 W1-W5 — the five clause REWORDS that INVERT the instruction.
+# --------------------------------------------------------------------------- #
+# Every one of these passed a fully green 37-test suite while `CLAUSE_LEDGER`
+# pinned a FRAGMENT per clause: the fragment stayed present and the instruction
+# around it said the opposite. W5 is the sharp one — it makes every future brief
+# tell auditors to do what `claude/RULES.md` forbids.
+#
+# Each replaces the whole `Clause(...)` entry, so the clause is still PRESENT,
+# still emitted, and still ledgered by id. Only the whole-string pin can see it.
+
+def reword_clause(cid, new_text):
+    def f(t):
+        pat = re.compile(
+            r"(    Clause\(\n        \"" + re.escape(cid) + r"\",\n)"
+            r"(?:.*?\n)*?(    \),\n)"
+        )
+        new, n = pat.subn(
+            lambda m: m.group(1) + f'        "{new_text}",\n' + m.group(2),
+            t, count=1,
+        )
+        if n != 1:
+            raise AssertionError(f"clause {cid!r} not found in its expected shape")
+        return new
+    return f
+
+
+# 🔴 The SURVIVES control. Whitespace inside a clause changes; the instruction
+# does not. `_norm` on both sides is what must absorb it — so a RED here means
+# the pins are keyed to layout, and every reflow of the source becomes a
+# failure.
+def rewrap_a_clause(t):
+    return _swap(
+        t,
+        '"**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to the "',
+        '"**Do NOT  `git fetch`,  `pull`,  `checkout`  or otherwise write to the  "',
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The four decisions round 2's audit found WRONG, one mutant per site.
+# --------------------------------------------------------------------------- #
+
+def ledger_ignores_the_head_check(t):
+    return _swap(t,
+                 "    if head_check is not None and not head_check.ok:",
+                 "    if False:")
+
+
+def range_ignores_the_head_check(t):
+    return _swap(t, "    if hc is not None and hc.ok:", "    if True:")
+
+
+def emit_claims_uses_the_local_head(t):
+    return _swap(
+        t,
+        '        head_sha = (data.get("headRefOid") or "")[:8]\n',
+        '        _rc, _h, _ = runner(["git", "-C", repo_dir, "rev-parse",\n'
+        '                             "--short", "HEAD"])\n'
+        '        head_sha = _h.strip() if _rc == 0 else ""\n',
+    )
+
+
+def emit_claims_interpolates_the_placeholder(t):
+    return _swap(
+        t,
+        "        audited = head_sha\n",
+        '        audited = f"<the sha round 1 audited>..{head_sha}"\n',
+    )
+
+
+def gate_points_at_the_shared_checkout(t):
+    return _swap(
+        t,
+        'f"nix develop {r} -c bash <your worktree>/scripts/gate.sh --tier both",',
+        'f"nix develop {r} -c bash {r}/scripts/gate.sh --tier both",',
+    )
+
+
+def nix_build_points_at_the_shared_checkout(t):
+    return _swap(
+        t,
+        '        "nix build <your worktree>#checks.x86_64-linux.pytests",\n'
+        '        "nix build <your worktree>#checks.x86_64-linux.nodetests",\n',
+        '        f"nix build {r}#checks.x86_64-linux.pytests",\n'
+        '        f"nix build {r}#checks.x86_64-linux.nodetests",\n',
+    )
+
+
+def pr_slug_reads_the_head_repo(t):
+    return _swap(
+        t,
+        '    m = _PR_URL.match((data.get("url") or "").strip())\n'
+        "    if m:\n"
+        '        return f"{m.group(1)}/{m.group(2)}"\n'
+        '    if data.get("isCrossRepository") is False:\n',
+        "    if True:\n",
+    )
+
+
+def unknown_repo_collapses_to_same(t):
+    return _swap(
+        t,
+        "    if pr_repo and cwd_slug:\n"
+        '        repo_relation = "same" if pr_repo == cwd_slug else "cross"\n'
+        "    else:\n"
+        '        repo_relation = "unknown"\n',
+        '    repo_relation = "cross" if (\n'
+        "        pr_repo and cwd_slug and pr_repo != cwd_slug\n"
+        '    ) else "same"\n',
+    )
+
+
+def the_check_command_reports_clean(t):
+    return _swap(t, "    gone = missing_clauses(text)\n", "    gone = []\n")
+
+
+def the_out_file_is_not_read_back(t):
+    return _swap(
+        t,
+        '            checked_text = Path(args.out).read_text(encoding="utf-8")\n'
+        "            checked_what = args.out\n",
+        "            pass\n",
+    )
+
+
+def missing_clauses_is_not_normalised(t):
+    return _swap(
+        t,
+        "    haystack = _norm(brief)\n"
+        "    return [c.id for c in INVARIANT_CLAUSES if _norm(c.text) not in haystack]",
+        '    return [c.id for c in INVARIANT_CLAUSES if c.text not in (brief or "")]',
+    )
+
+
+def the_cumulative_reason_is_dropped(t):
+    return _swap(
+        t,
+        "                ledger = ledger._replace(cumulative_reason=cum.reason)",
+        "                pass",
+    )
+
+
+def an_unclosed_fence_is_skipped_silently(t):
+    return _swap(
+        t,
+        "            if close_at is None:\n                malformed.append(",
+        "            if close_at is None:\n"
+        "                i += 1\n"
+        "                continue\n"
+        "            if False:\n"
+        "                malformed.append(",
+    )
+
+
+def a_longer_closing_fence_stops_closing(t):
+    return _swap(
+        t,
+        'if bm and len(bm.group("fence")) >= len(opener):',
+        'if bm and len(bm.group("fence")) == len(opener):',
+    )
+
+
+def continuation_lines_are_dropped(t):
+    return _swap(
+        t,
+        "        elif items and line.strip():\n"
+        '            items[-1] = f"{items[-1]} {line.strip()}"\n',
+        "",
+    )
+
+
+def the_nested_fence_report_is_removed(t):
+    return _swap(
+        t,
+        "            if any(_CLAIM_ITEM.match(t) for t in tail) and any(",
+        "            if False and any(",
+    )
+
+
+def the_refusal_drops_the_comment_kinds_note(t):
+    return _swap(
+        t,
+        '            "  ⚠ `gh pr view --json comments` returns ISSUE comments only. A "',
+        '            "  ⚠ A "',
+    )
+
+
 LEDGER_TRIO = {
     "test_the_invariant_clause_ledger_is_pinned_two_way",
     "test_each_clause_carries_the_instruction_its_ledger_entry_names",
@@ -190,8 +397,17 @@ ROWS = [
      LEDGER_TRIO | {DELETION_CONTROL}, drop_clause("reverify-self-reported")),
     ("D6  delete clause finding-format",
      LEDGER_TRIO | {DELETION_CONTROL}, drop_clause("finding-format")),
+    # 🔴 D7 is the SECOND asymmetric row, and the same shape as D2:
+    # `test_the_out_file_is_read_back_and_checked` looks the `do-not-merge`
+    # clause up BY ID to model a lossy write, so deleting that particular clause
+    # makes it error. Recorded rather than tidied away — it is a real coupling,
+    # and by-id lookup is still the right thing there (an INDEX would make the
+    # test's outcome depend on which OTHER clause a mutation deleted, which
+    # shows up in a sweep as dying for the wrong reason).
     ("D7  delete clause do-not-merge",
-     LEDGER_TRIO | {DELETION_CONTROL}, drop_clause("do-not-merge")),
+     LEDGER_TRIO | {DELETION_CONTROL,
+                    "test_the_out_file_is_read_back_and_checked"},
+     drop_clause("do-not-merge")),
     ("A1  add an unledgered eighth clause",
      {"test_the_invariant_clause_ledger_is_pinned_two_way",
       "test_the_rendered_section_holds_exactly_the_ledgered_clauses",
@@ -203,15 +419,22 @@ ROWS = [
     ("R1  reword stop-rule (clause still present)",
      {"test_each_clause_carries_the_instruction_its_ledger_entry_names"},
      reword_stop_rule),
+    # The `--check` round trip fires here too, and correctly: with the bullets
+    # hardcoded, a REAL generated brief written to a REAL file genuinely holds
+    # none of the clauses, which is precisely what that command reports. It is
+    # the only row where the two reach the same conclusion by different routes.
     ("F1  render bullets from a hardcoded copy",
      {"test_the_rendered_section_holds_exactly_the_ledgered_clauses",
       "test_every_clause_is_emitted_verbatim_in_both_kinds_of_brief",
+      "test_the_clause_check_runs_over_a_file_that_can_actually_be_lossy",
       DELETION_CONTROL},
      hardcode_bullets),
     ("C1  the delta refusal removed",
      {"test_the_delta_refusal_exits_non_zero_and_emits_no_brief",
       "test_the_refusal_names_what_it_looked_for_and_where",
-      "test_the_refusal_fires_for_a_malformed_block_and_says_which_way"},
+      "test_the_refusal_fires_for_a_malformed_block_and_says_which_way",
+      # Asserts on the refusal MESSAGE, so no refusal means no message.
+      "test_the_refusal_says_which_comment_kinds_it_cannot_see"},
      remove_the_refusal),
     ("C2  claims read from the whole comment",
      {"test_the_brief_carries_the_claims_and_not_the_reasoning_around_them",
@@ -221,7 +444,12 @@ ROWS = [
     ("C3  cross-repo decision inverted",
      {"test_cross_repo_tells_the_agent_to_worktree_the_prs_repo_itself",
       "test_same_repo_recommends_the_isolation_flag_and_does_not_hand_roll",
-      "test_the_cross_repo_decision_comes_from_the_repos_not_from_prose"},
+      "test_the_cross_repo_decision_comes_from_the_repos_not_from_prose",
+      # A fork PR against THIS repo is a same-repo PR, so inverting the two
+      # known states flips it to cross as well. Listed because it is the row
+      # that PROVES the fork case rides the same decision as the others — the
+      # fixture used to encode a model in which it did not.
+      "test_a_fork_pr_against_this_repo_is_not_treated_as_cross_repo"},
      invert_cross_repo),
     ("C4  numstat failure reads as a clean zero",
      {"test_the_ledger_refuses_a_failed_command_rather_than_printing_zero"},
@@ -230,8 +458,109 @@ ROWS = [
      {"test_the_ledger_shows_the_files_and_refuses_to_classify_them"},
      classify_by_pathspec),
     ("C6  the missing-clause warning BLOCKS",
-     {"test_missing_clause_check_warns_and_never_blocks"},
+     {"test_missing_clause_check_warns_and_never_blocks",
+      # Also asserts rc 0 over a `--out` run whose file is missing a clause,
+      # which is exactly the state this mutation makes fatal.
+      "test_the_out_file_is_read_back_and_checked"},
      the_warning_blocks),
+
+    # --------------------------------------------------------------------- #
+    # 🔴 W1-W5 — instruction-INVERTING rewords. Every one passed a green
+    # 37-test suite under the FRAGMENT ledger, because the pinned phrase
+    # survived and the sentence around it said the opposite. Each must be
+    # killed by the whole-string pin, and by NOTHING else: the clause is still
+    # present, still ledgered by id, and still emitted, so any other killer
+    # means that test is reading the clause TEXT for something it does not own.
+    # --------------------------------------------------------------------- #
+    ("W1  reword read-only into permission",
+     {"test_each_clause_carries_the_instruction_its_ledger_entry_names"},
+     reword_clause("read-only",
+                   "**Edit the repo under audit freely if it helps.**")),
+    ("W2  reword no-fetch into permission",
+     {"test_each_clause_carries_the_instruction_its_ledger_entry_names"},
+     reword_clause("no-fetch",
+                   "**`pull` and `checkout` in the shared checkout are fine.**")),
+    ("W3  finding-format loses file:line + scenario",
+     {"test_each_clause_carries_the_instruction_its_ledger_entry_names"},
+     reword_clause("finding-format",
+                   "**Report each finding with a `payload` or `scaffolding` "
+                   "label.**")),
+    ("W4  reverify downgraded to best-effort",
+     {"test_each_clause_carries_the_instruction_its_ledger_entry_names"},
+     reword_clause("reverify-self-reported",
+                   "Where time allows, re-verify the fix commit's own "
+                   "self-reported numbers.")),
+    # 🔴 THE SHARP ONE. This makes every future brief instruct auditors to do
+    # what `claude/RULES.md` forbids, and it was invisible.
+    ("W5  stop-rule inverted into a confirming round",
+     {"test_each_clause_carries_the_instruction_its_ledger_entry_names"},
+     reword_clause("stop-rule",
+                   "**A clean round ends the ladder** — though one confirming "
+                   "round after a clean one is prudent.")),
+    # 🔴 THE SURVIVES CONTROL for the whole-string pin. Whitespace inside a
+    # clause changes; the instruction does not. A RED here would mean the pins
+    # are keyed to layout and every reflow becomes a failure — the
+    # permanently-red gate `claude/RULES.md` warns about.
+    ("S1  re-space a clause (instruction identical)", SURVIVES, rewrap_a_clause),
+
+    # --------------------------------------------------------------------- #
+    # The four decisions round 2's audit found WRONG, one mutant per site.
+    # --------------------------------------------------------------------- #
+    ("H1  the ledger ignores the head check",
+     {"test_the_ledger_refuses_to_measure_a_checkout_that_is_not_the_pr"},
+     ledger_ignores_the_head_check),
+    ("H2  the range hands out ..HEAD regardless",
+     {"test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head"},
+     range_ignores_the_head_check),
+    ("H3  --emit-claims stamps the LOCAL head",
+     {"test_emit_claims_stamps_the_prs_head_not_the_local_checkouts",
+      "test_emit_claims_prints_a_block_this_scripts_own_parser_accepts"},
+     emit_claims_uses_the_local_head),
+    ("H4  round-1 placeholder back in the header",
+     {"test_emit_claims_prints_a_block_this_scripts_own_parser_accepts"},
+     emit_claims_interpolates_the_placeholder),
+    ("T1  gate.sh points at the shared checkout",
+     {"test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout"},
+     gate_points_at_the_shared_checkout),
+    ("T2  nix build points at the shared checkout",
+     {"test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout",
+      "test_the_toolchain_section_names_the_tier_the_merge_gates_on"},
+     nix_build_points_at_the_shared_checkout),
+    ("P1  pr_slug reads the HEAD repo again",
+     {"test_a_fork_pr_against_this_repo_is_not_treated_as_cross_repo",
+      "test_the_prs_repo_is_read_from_the_url_not_from_the_head_repo"},
+     pr_slug_reads_the_head_repo),
+    ("P2  'cannot determine' collapses to same-repo",
+     {"test_an_undeterminable_repo_gets_its_own_branch_not_the_same_repo_one"},
+     unknown_repo_collapses_to_same),
+    ("K1  --check always reports clean",
+     {"test_the_clause_check_runs_over_a_file_that_can_actually_be_lossy"},
+     the_check_command_reports_clean),
+    ("K2  --out is not read back",
+     {"test_the_out_file_is_read_back_and_checked"},
+     the_out_file_is_not_read_back),
+    ("K3  missing_clauses stops normalising whitespace",
+     {"test_missing_clauses_is_a_pure_function_over_the_text"},
+     missing_clauses_is_not_normalised),
+    ("L1  the cumulative failure reason is dropped",
+     {"test_a_failed_cumulative_measurement_does_not_print_a_false_cause"},
+     the_cumulative_reason_is_dropped),
+    ("B1  an unclosed fence is skipped silently",
+     {"test_a_fence_the_parser_cannot_read_is_reported_not_skipped",
+      "test_a_malformed_fence_beside_a_readable_block_still_warns"},
+     an_unclosed_fence_is_skipped_silently),
+    ("B2  a longer closing fence stops closing",
+     {"test_a_longer_closing_fence_is_a_valid_close_and_is_read"},
+     a_longer_closing_fence_stops_closing),
+    ("B3  continuation lines are dropped",
+     {"test_a_claim_that_wraps_onto_a_continuation_line_keeps_its_tail"},
+     continuation_lines_are_dropped),
+    ("B4  the nested-fence report is removed",
+     {"test_a_block_cut_short_by_a_nested_fence_is_reported"},
+     the_nested_fence_report_is_removed),
+    ("B5  the refusal drops the comment-kinds note",
+     {"test_the_refusal_says_which_comment_kinds_it_cannot_see"},
+     the_refusal_drops_the_comment_kinds_note),
 ]
 
 
@@ -305,6 +634,17 @@ def main() -> int:
             if got is None:
                 print(f"  🔴 {label:44s} HARNESS BROKE — {raw2}")
                 bad += 1
+                continue
+            # 🔴 A row that must SURVIVE. Reported through the same code path as
+            # everything else, so a control cannot quietly stop being checked.
+            if want is SURVIVES:
+                if got:
+                    print(f"  🔴 {label:44s} KILLED by {sorted(got)} — this row "
+                          "must SURVIVE; the pins are keyed to layout, not to "
+                          "the instruction")
+                    bad += 1
+                else:
+                    print(f"  ok {label:44s} SURVIVED as required (control)")
                 continue
             if not got:
                 print(f"  🔴 {label:44s} SURVIVED — no test failed")

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -567,16 +567,22 @@ def the_git_dirs_are_compared_as_strings(t):
     )
 
 
+# 🔴 Y6 AND Y14 WERE RE-TARGETED IN ROUND 7 and the reason is a FIX, not a
+# refactor: `render_checkout`'s inline state->directive dict became the
+# module-level `CHECKOUT_STATE_DIRECTIVE`, so the relationship it encodes can
+# be READ by a guard instead of being spelled as an id prefix. Both mutations
+# still express exactly what they expressed before — the unknown state
+# collapsing into SHARED, and a private worktree being described as shared.
 def the_unknown_worktree_state_collapses_to_shared(t):
     return _swap(t,
-                 '        }.get(wt.kind, "checkout-unknown")),',
-                 '        }.get(wt.kind, "checkout-moves")),')
+                 '    "unknown": "checkout-unknown",\n}',
+                 '    "unknown": "checkout-moves",\n}')
 
 
 def a_private_worktree_is_called_shared(t):
     return _swap(t,
-                 '            "private": "checkout-private",',
-                 '            "private": "checkout-moves",')
+                 '    "private": "checkout-private",',
+                 '    "private": "checkout-moves",')
 
 
 def where_to_work_drops_the_private_note(t):
@@ -655,11 +661,133 @@ def the_shared_state_drops_the_no_write_rule(t):
 
 
 def a_fourth_checkout_state_arrives_with_no_rule(t):
-    """A new `checkout-*` state nobody checked carries the no-write rule."""
+    """A new checkout state nobody checked carries the no-write rule.
+
+    🔴 ROUND 7 EXTENDED IT TO REGISTER THE STATE IN THE RENDERER'S MAP. Round 5
+    added only the `Directive`, which was enough while the guard derived its set
+    from the id PREFIX `checkout-`. The guard now derives it from
+    `CHECKOUT_STATE_DIRECTIVE` — what `render_checkout` can actually SELECT —
+    so a directive nobody selects reaches no brief and, correctly, is no longer
+    that guard's business. Adding the map entry is what keeps this row meaning
+    "a fourth STATE with no rule" rather than "an unledgered directive".
+    """
     marker = ")\n\nDIRECTIVE = {d.id: d.text for d in SECTION_DIRECTIVES}"
-    return _swap(t, marker,
-                 '    Directive("checkout-detached", "🔴 **This checkout is on '
-                 'a DETACHED HEAD.** Nobody wrote a rule for it."),\n' + marker)
+    t = _swap(t, marker,
+              '    Directive("checkout-detached", "🔴 **This checkout is on '
+              'a DETACHED HEAD.** Nobody wrote a rule for it."),\n' + marker)
+    return _swap(t,
+                 '    "unknown": "checkout-unknown",\n}',
+                 '    "unknown": "checkout-unknown",\n'
+                 '    "detached": "checkout-detached",\n}')
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 V1-V7 — round 7 (base `3619fe68`).
+# --------------------------------------------------------------------------- #
+# V1/V2 restore the two halves of the `checkout-*` PREFIX derivation round 6
+# walked; V3 the false blind-spot rationale; V4 the forward reference that
+# narrowed the no-write rule; V5 the whitespace input check; V6 the verified
+# branch's hardcoded `HEAD`; V7 the cross-repo-only toolchain reword that a
+# two-scenario equality could not see.
+
+
+def the_private_state_is_renamed_and_stripped_of_its_rule(t):
+    """Round 6's demonstrated disarm, as far as a SCRIPT-ONLY mutation reaches.
+
+    🔴 AND THE HALF IT CANNOT REACH IS RECORDED RATHER THAN IMPLIED. Round 6's
+    measurement also updated the THREE LEDGERS in the test module — which is
+    what made the suite stay at 89 green — and this battery mutates the script
+    and nothing else. So the ledger pins fire here where they did not fire
+    there, and this row is WIDE for that reason. `V2` is the isolating row for
+    the derivation change; this one exists so the demonstrated disarm has a
+    line in the battery at all.
+    """
+    t = _swap(t, '        "checkout-private",\n', '        "assembly-private",\n')
+    t = _swap(t, '    "private": "checkout-private",',
+              '    "private": "assembly-private",')
+    return reword_entry(
+        "Directive", "assembly-private",
+        "🔴 **This is the checkout this brief was ASSEMBLED in — not "
+        "necessarily the one you are standing in.** Git reports it as a "
+        "PRIVATE linked worktree: its `.git` is a link into a shared "
+        "repository, and the working tree belongs to the session that BUILT "
+        "this brief, which is not you. That session is live in it, so files "
+        "here can appear, vanish and change. If you do see something move "
+        "here, report it with what moved and when.")(t)
+
+
+def a_fourth_state_selects_an_existing_rule_less_directive(t):
+    """🔴 THE ISOLATING ROW for round 6's 🟢 F5.
+
+    Adds a fourth SELECTABLE state pointing at a directive that already exists
+    and is already ledgered — so `SECTION_DIRECTIVES` is untouched, both
+    two-way ledger pins stay green, and the ONLY thing that can see it is a
+    guard that reads the renderer's own selection. Under the round-5 spelling
+    (`ids beginning "checkout-"`) this mutation was invisible.
+    """
+    return _swap(t,
+                 '    "unknown": "checkout-unknown",\n}',
+                 '    "unknown": "checkout-unknown",\n'
+                 '    "detached": "own-worktree-is-writable",\n}')
+
+
+def the_blind_spot_blames_sha_resolution_again(t):
+    """The rationale that was false for three rounds, restored."""
+    return _swap(
+        t,
+        "# 🔴 AND THE REASON GIVEN HERE FOR THREE ROUNDS WAS FALSE. It asserted that",
+        "# This script never resolves a sha, so whether the token is a real\n"
+        "# commit is a question it cannot answer.\n"
+        "# 🔴 AND THE REASON GIVEN HERE FOR THREE ROUNDS WAS FALSE. It asserted that",
+    )
+
+
+def the_own_worktree_grant_scopes_the_rule_to_sharedness_again(t):
+    """Round 5's second sentence, verbatim."""
+    return reword_entry(
+        "Directive", "own-worktree-is-writable",
+        "That worktree is YOURS: fetching and checking out inside it is fine. "
+        "The no-write rule below is about the SHARED checkout.")(t)
+
+
+def the_whitespace_input_check_is_removed(t):
+    return _swap(
+        t,
+        "    if args.audited is not None and args.audited.split() != [args.audited]:",
+        "    if False:",
+    )
+
+
+def the_verified_range_hands_out_head_again(t):
+    return _swap(
+        t,
+        "    elif hc is not None and hc.ok:\n        tip = hc.local_sha\n",
+        '    elif hc is not None and hc.ok:\n        tip = "HEAD"\n',
+    )
+
+
+def the_toolchain_names_the_shared_checkout_cross_repo_only(t):
+    """🔴 THE ISOLATING ROW for round 6's 🟢 F4.
+
+    The forbidden phrase comes back, but ONLY in the cross-repo branch. Round
+    5's guard drove two scenarios, both SAME-REPO, so this reword left the
+    suite at 89 green with no row naming it. Only a guard that drives every
+    scenario — and requires the section byte-identical across them — can see it.
+    """
+    return _swap(
+        t,
+        "    r = facts.cwd_repo_dir\n    return \"\\n\".join([\n"
+        '        "## TOOLCHAIN — the exact commands, and the two ways they lie",',
+        "    r = facts.cwd_repo_dir\n"
+        '    _why = ("so running that copy runs the suite in the SHARED CHECKOUT on "\n'
+        '            "whatever branch it is standing on"\n'
+        '            if facts.repo_relation == "cross" else\n'
+        '            "so running that copy runs the suite in a checkout that is NOT '
+        'yours")\n'
+        "    return \"\\n\".join([\n"
+        '        "## TOOLCHAIN — the exact commands, and the two ways they lie",\n'
+        '        _why,',
+    )
 
 
 def the_no_fetch_clause_is_conditional_again(t):
@@ -891,9 +1019,17 @@ ROWS = [
     # `..._unknown_head_sha_reason_names_one_cause_not_two` reads. Recorded in
     # the same spirit as D2 and D7 — the alternative would be to weaken that
     # test into asserting nothing about the brief.
+    # 🔴 H2 GAINED A THIRD KILLER IN ROUND 7, and it is the tightest coupling
+    # in the file rather than a row gone vague: this mutation makes THE RANGE
+    # hand out the token `HEAD` unconditionally, and round 7's rule is that a
+    # VERIFIED head renders as its SHA. The two claims are about the same
+    # rendered token from opposite sides — "not `..HEAD` when the head is
+    # unverified" and "not `..HEAD` when it IS verified" — so a mutation that
+    # hardcodes the token necessarily trips both. Recorded, not narrowed.
     ("H2  the range hands out ..HEAD regardless",
      {"test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head",
-      "test_the_unknown_head_sha_reason_names_one_cause_not_two"},
+      "test_the_unknown_head_sha_reason_names_one_cause_not_two",
+      "test_the_range_names_a_sha_and_not_head_when_the_head_is_verified"},
      range_ignores_the_head_check),
     ("H3  --emit-claims stamps the LOCAL head",
      {"test_emit_claims_stamps_the_prs_head_not_the_local_checkouts",
@@ -1213,7 +1349,7 @@ ROWS = [
      {"test_each_clause_carries_the_instruction_its_ledger_entry_names"},
      the_no_fetch_clause_is_conditional_again),
     ("Z4  TOOLCHAIN's reason names the SHARED CHECKOUT again",
-     {"test_the_toolchain_reason_is_true_in_both_checkout_states"},
+     {"test_the_toolchain_reason_is_true_in_every_scenario"},
      the_toolchain_reason_names_the_shared_checkout_again),
     ("Z5  the emitted block loses its legend",
      {"test_the_emitted_skeleton_carries_a_legend_for_its_two_fields"},
@@ -1229,6 +1365,53 @@ ROWS = [
       "test_the_degenerate_cause_list_scopes_the_omitted_flag_to_round_one",
       "test_a_degenerate_range_does_not_blame_a_checkout_it_verified"},
      the_degenerate_causes_stop_scoping_the_omission),
+
+    # --------------------------------------------------------------------- #
+    # 🔴 V1-V7 — round 7. Base `3619fe68`.
+    # --------------------------------------------------------------------- #
+    # 🔴 V1 IS WIDE ON PURPOSE and the width is the finding's own shape: round
+    # 6 demonstrated this disarm with the three test-module ledgers UPDATED,
+    # which this battery cannot do. Script-only, the ledger pins catch the
+    # rename — so the row proves the rename is not free, while V2 is what
+    # proves the derivation change bought something.
+    ("V1  checkout-private renamed and stripped of its rule",
+     {"test_the_section_directive_ledger_is_pinned_two_way",
+      "test_the_directive_render_scenario_ledger_is_pinned_two_way",
+      "test_each_section_directive_carries_the_instruction_its_ledger_entry_names",
+      "test_every_section_directive_is_emitted_verbatim_in_the_brief_that_owns_it",
+      "test_every_checkout_state_carries_the_no_write_rule"},
+     the_private_state_is_renamed_and_stripped_of_its_rule),
+    # 🔴 V2 IS THE ISOLATING ROW. Nothing but the renderer's own selection can
+    # see it: `SECTION_DIRECTIVES` is untouched and both ledgers stay green.
+    ("V2  a fourth STATE selects a rule-less directive",
+     {"test_every_checkout_state_carries_the_no_write_rule"},
+     a_fourth_state_selects_an_existing_rule_less_directive),
+    ("V3  the blind-spot note blames sha resolution again",
+     {"test_the_blind_spot_rationale_matches_what_the_script_actually_does"},
+     the_blind_spot_blames_sha_resolution_again),
+    ("V4  own-worktree scopes the no-write rule to SHARED again",
+     {"test_each_section_directive_carries_the_instruction_its_ledger_entry_names",
+      "test_no_forward_reference_scopes_the_no_write_rule_to_a_denied_state"},
+     the_own_worktree_grant_scopes_the_rule_to_sharedness_again),
+    ("V5  the --audited whitespace input check is removed",
+     {"test_emit_claims_refuses_an_audited_value_whose_whitespace_leaves_the_line"},
+     the_whitespace_input_check_is_removed),
+    # 🔴 V6's killer set is WIDE and every member is a real consumer of the
+    # rendered tip: six tests assert a `<anchor>..<sha>` spec, and reverting
+    # the tip to `HEAD` moves all of them. Listed in full rather than trimmed
+    # to the "main" one — the same treatment N1 gets, for the same reason.
+    ("V6  the VERIFIED range hands out `..HEAD` again",
+     {"test_the_range_names_a_sha_and_not_head_when_the_head_is_verified",
+      "test_the_range_is_generated_from_the_previous_rounds_audited_sha",
+      "test_the_range_says_head_was_verified_when_it_was",
+      "test_the_newest_claims_block_wins",
+      "test_a_bare_round_one_audited_sha_still_anchors_the_next_round",
+      "test_audited_supplies_the_tip_a_round_one_emit_cannot_derive",
+      "test_audited_without_emit_claims_says_it_changed_nothing"},
+     the_verified_range_hands_out_head_again),
+    ("V7  TOOLCHAIN names the SHARED CHECKOUT, cross-repo only",
+     {"test_the_toolchain_reason_is_true_in_every_scenario"},
+     the_toolchain_names_the_shared_checkout_cross_repo_only),
 ]
 
 

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -89,16 +89,24 @@ SURVIVES = "SURVIVES"
 # Mutations. Each takes the script source and returns it changed, or raises.
 # --------------------------------------------------------------------------- #
 
-def drop_clause(cid):
+def drop_entry(kind, cid):
+    """Delete a whole `Clause(...)` / `Directive(...)` entry from its tuple."""
     def f(t):
         pat = re.compile(
-            r"    Clause\(\n        \"" + re.escape(cid) + r"\",\n(?:.*?\n)*?    \),\n"
+            r"    " + kind + r"\(\n        \"" + re.escape(cid)
+            + r"\",\n(?:.*?\n)*?    \),\n"
         )
         new, n = pat.subn("", t, count=1)
         if n != 1:
-            raise AssertionError(f"clause {cid!r} not found in its expected shape")
+            raise AssertionError(
+                f"{kind.lower()} {cid!r} not found in its expected shape"
+            )
         return new
     return f
+
+
+def drop_clause(cid):
+    return drop_entry("Clause", cid)
 
 
 def _swap(t, old, new):
@@ -193,10 +201,14 @@ def the_warning_blocks(t):
 # Each replaces the whole `Clause(...)` entry, so the clause is still PRESENT,
 # still emitted, and still ledgered by id. Only the whole-string pin can see it.
 
-def reword_clause(cid, new_text):
+def reword_entry(kind, cid, new_text):
+    """Replace an entry's TEXT, leaving it present, ledgered by id and emitted.
+
+    Only a WHOLE-STRING pin can see this. Every presence check stays green.
+    """
     def f(t):
         pat = re.compile(
-            r"(    Clause\(\n        \"" + re.escape(cid) + r"\",\n)"
+            r"(    " + kind + r"\(\n        \"" + re.escape(cid) + r"\",\n)"
             r"(?:.*?\n)*?(    \),\n)"
         )
         new, n = pat.subn(
@@ -204,9 +216,15 @@ def reword_clause(cid, new_text):
             t, count=1,
         )
         if n != 1:
-            raise AssertionError(f"clause {cid!r} not found in its expected shape")
+            raise AssertionError(
+                f"{kind.lower()} {cid!r} not found in its expected shape"
+            )
         return new
     return f
+
+
+def reword_clause(cid, new_text):
+    return reword_entry("Clause", cid, new_text)
 
 
 # 🔴 The SURVIVES control. Whitespace inside a clause changes; the instruction
@@ -232,7 +250,12 @@ def ledger_ignores_the_head_check(t):
 
 
 def range_ignores_the_head_check(t):
-    return _swap(t, "    if hc is not None and hc.ok:", "    if True:")
+    # 🔴 RE-TARGETED in round 3, and the reason is the one C3 records: the
+    # branch became `elif` when the degenerate-self-range case was inserted
+    # ahead of it, and this row immediately reported MUTATION DID NOT APPLY.
+    # Without that assert it would have scored as "the guard held" — the most
+    # flattering possible wrong answer.
+    return _swap(t, "    elif hc is not None and hc.ok:", "    elif True:")
 
 
 def emit_claims_uses_the_local_head(t):
@@ -367,6 +390,94 @@ def the_refusal_drops_the_comment_kinds_note(t):
         t,
         '            "  ⚠ `gh pr view --json comments` returns ISSUE comments only. A "',
         '            "  ⚠ A "',
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 N1-N7 — the round-3 findings, one mutant per site.
+# --------------------------------------------------------------------------- #
+# N1 restores the shipped defect outright: `audited=` meant `<to>` to the
+# WRITER and `<to>` to the READER, so `<to>..HEAD` had HEAD on both ends and the
+# delta range was EMPTY BY CONSTRUCTION. N3 is its mirror image — the "one
+# anchor for everything" simplification, which is wrong in the other direction
+# and would NOT show up as an empty range, only as a superset.
+
+def range_anchor_reads_the_audited_tip(t):
+    return _swap(
+        t,
+        "    return block.audited_from or block.audited_to or None",
+        "    return block.audited_to or None",
+    )
+
+
+def range_anchor_loses_the_bare_fallback(t):
+    return _swap(
+        t,
+        "    return block.audited_from or block.audited_to or None",
+        "    return block.audited_from or None",
+    )
+
+
+def emit_claims_writes_the_range_anchor(t):
+    return _swap(
+        t,
+        "    if facts.emit_from:\n"
+        '        audited = f"{facts.emit_from}..{head_sha}"\n',
+        "    if facts.prev_sha:\n"
+        '        audited = f"{facts.prev_sha}..{head_sha}"\n',
+    )
+
+
+def the_range_ignores_a_self_range(t):
+    return _swap(t, "    if anchor_is_head(facts.prev_sha, hc):", "    if False:")
+
+
+def the_ledger_ignores_a_self_range(t):
+    return _swap(t, "        if anchor_is_head(prev_sha, head_check):",
+                 "        if False:")
+
+
+def emit_claims_drops_the_self_range_warning(t):
+    return _swap(t, "        if same_commit(facts.emit_from, head_sha):",
+                 "        if False:")
+
+
+def the_empty_range_names_the_refuted_causes(t):
+    return _swap(t, "        if head_check is not None and head_check.ok:\n",
+                 "        if False:\n")
+
+
+def the_unknown_head_reason_names_both_causes(t):
+    """The THIRD false-cause site: ignore what the caller knows and list both."""
+    return _swap(
+        t,
+        "        why = no_sha_reason or (\n",
+        "        why = None or (\n",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 X1-X3 — the three verbatim instruction blocks that shipped UNPINNED.
+# --------------------------------------------------------------------------- #
+# Each of these, applied alone, left the round-2 suite fully green at 58 passed.
+# X1 and X3 preserve the fragment an existing test pins and invert the sentence
+# around it — the walkable-by-rewording shape from `claude/RULES.md`. Only the
+# whole-string DIRECTIVE_LEDGER can see them.
+
+def add_unledgered_directive(t):
+    marker = ")\n\nDIRECTIVE = {d.id: d.text for d in SECTION_DIRECTIVES}"
+    return _swap(t, marker,
+                 '    Directive("unledgered", "**A fourth instruction nobody '
+                 'reviewed.**"),\n' + marker)
+
+
+# 🔴 The SURVIVES control for the directive ledger. Whitespace changes; the
+# instruction does not. A RED here means the new pin is keyed to layout.
+def rewrap_a_directive(t):
+    return _swap(
+        t,
+        '"Also hunt for **regressions this fix round itself introduced** — the "',
+        '"Also  hunt  for **regressions this fix round itself introduced**  — the "',
     )
 
 
@@ -509,8 +620,16 @@ ROWS = [
     ("H1  the ledger ignores the head check",
      {"test_the_ledger_refuses_to_measure_a_checkout_that_is_not_the_pr"},
      ledger_ignores_the_head_check),
+    # 🔴 H2 GAINED A SECOND KILLER in round 3, and it is a real coupling rather
+    # than a row gone vague: the COULD-NOT-VERIFY branch is the ONLY place a
+    # `head_check.reason` is rendered, so a mutation that never takes that
+    # branch necessarily hides the reason text that
+    # `..._unknown_head_sha_reason_names_one_cause_not_two` reads. Recorded in
+    # the same spirit as D2 and D7 — the alternative would be to weaken that
+    # test into asserting nothing about the brief.
     ("H2  the range hands out ..HEAD regardless",
-     {"test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head"},
+     {"test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head",
+      "test_the_unknown_head_sha_reason_names_one_cause_not_two"},
      range_ignores_the_head_check),
     ("H3  --emit-claims stamps the LOCAL head",
      {"test_emit_claims_stamps_the_prs_head_not_the_local_checkouts",
@@ -561,6 +680,96 @@ ROWS = [
     ("B5  the refusal drops the comment-kinds note",
      {"test_the_refusal_says_which_comment_kinds_it_cannot_see"},
      the_refusal_drops_the_comment_kinds_note),
+
+    # --------------------------------------------------------------------- #
+    # 🔴 N1-N7 — round 3. The two anchors, the self-range guards, and the
+    # empty-range reason that named causes `head_check` refutes.
+    # --------------------------------------------------------------------- #
+    # 🔴 N1 IS THE SHIPPED DEFECT RESTORED, and its killer set is deliberately
+    # WIDE: reading `<to>` as the delta anchor moves the range for every
+    # consumer at once, and a narrow expectation here would be the wrong
+    # claim. It is listed in full rather than trimmed to the "main" one.
+    ("N1  the range anchors on `<to>` again",
+     {"test_the_range_is_generated_from_the_previous_rounds_audited_sha",
+      "test_the_ledger_measures_from_the_tip_the_previous_round_audited",
+      "test_the_newest_claims_block_wins",
+      "test_the_range_says_head_was_verified_when_it_was",
+      "test_a_degenerate_self_range_is_reported_not_rendered_as_a_clean_diff",
+      "test_a_degenerate_self_range_is_named_by_the_ledger_too",
+      "test_a_bare_round_one_audited_sha_still_anchors_the_next_round"},
+     range_anchor_reads_the_audited_tip),
+    # The OTHER wrong fix: `audited_from` alone. A round-1 bare `audited=<sha>`
+    # then anchors nothing, and the remedy chain the delta refusal advertises
+    # dead-ends.
+    ("N2  the bare round-1 fallback is dropped",
+     {"test_a_bare_round_one_audited_sha_still_anchors_the_next_round",
+      "test_the_cumulative_figure_is_not_measured_without_a_round_one_anchor"},
+     range_anchor_loses_the_bare_fallback),
+    # 🔴 THE MIRROR IMAGE, and the reason the two readers are separate
+    # functions: "one anchor everywhere" is wrong on the WRITER's side, and it
+    # produces a superset rather than an empty range, so nothing else notices.
+    ("N3  --emit-claims writes the RANGE anchor as `<from>`",
+     {"test_emit_claims_records_the_tip_this_round_audited_not_the_range_anchor",
+      "test_emit_claims_prints_a_block_this_scripts_own_parser_accepts"},
+     emit_claims_writes_the_range_anchor),
+    ("N4  THE RANGE renders a self-range with no banner",
+     {"test_a_degenerate_self_range_is_reported_not_rendered_as_a_clean_diff"},
+     the_range_ignores_a_self_range),
+    ("N5  the ledger calls a self-range merely empty",
+     {"test_a_degenerate_self_range_is_named_by_the_ledger_too"},
+     the_ledger_ignores_a_self_range),
+    ("N6  --emit-claims writes `X..X` in silence",
+     {"test_emit_claims_warns_when_the_block_it_writes_is_a_self_range"},
+     emit_claims_drops_the_self_range_warning),
+    ("N7  the empty-range reason names the refuted causes",
+     {"test_an_empty_range_does_not_name_a_cause_the_head_check_refutes"},
+     the_empty_range_names_the_refuted_causes),
+    ("N8  the unknown-head reason ignores what the caller knows",
+     {"test_the_unknown_head_sha_reason_names_one_cause_not_two"},
+     the_unknown_head_reason_names_both_causes),
+
+    # --------------------------------------------------------------------- #
+    # 🔴 X1-X3 — the three unpinned verbatim blocks. Each passed a fully green
+    # 58-test suite before `SECTION_DIRECTIVES` existed.
+    # --------------------------------------------------------------------- #
+    # 🔴 X1 KEEPS the fragment `test_the_brief_carries_the_claims_...` pins
+    # ("never WHY IT IS CORRECT") and inverts the sentence around it into the
+    # framed audit the module's headline rule forbids. Any other killer would
+    # mean some test is reading this text for something it does not own.
+    ("X1  claims-framing inverted into 'take them as established'",
+     {"test_each_section_directive_carries_the_instruction_its_ledger_entry_names"},
+     reword_entry(
+         "Directive", "claims-framing",
+         "🔴 This is WHAT WAS CLAIMED, never WHY IT IS CORRECT. The fix round "
+         "already verified each of these, so take them as established unless "
+         "something obvious contradicts one.")),
+    ("X2  the delta-regressions instruction deleted outright",
+     {"test_the_section_directive_ledger_is_pinned_two_way",
+      "test_each_section_directive_carries_the_instruction_its_ledger_entry_names"},
+     drop_entry("Directive", "delta-regressions")),
+    # 🔴 X3 KEEPS "MOVES UNDER YOU" and "NOT a finding" — both pinned by
+    # `test_the_shared_checkout_state_is_reported_with_the_it_moves_warning` —
+    # and inverts the operative sentence into an instruction to WRITE to the
+    # shared checkout, contradicting the `no-fetch` clause two bars later.
+    ("X3  checkout-moves inverted into 'restore anything you see move'",
+     {"test_each_section_directive_carries_the_instruction_its_ledger_entry_names"},
+     reword_entry(
+         "Directive", "checkout-moves",
+         "🔴 **This checkout is SHARED with other sessions and agents. It "
+         "MOVES UNDER YOU** — the branch can change, files can appear and "
+         "vanish, and commits can land mid-audit. That is NOT a finding in "
+         "itself, but it is worth reporting. Restore anything you see move.")),
+    ("XA  add an unledgered fourth directive",
+     {"test_the_section_directive_ledger_is_pinned_two_way",
+      # It ships in the constant and reaches NO brief, which is its own
+      # hazard: an instruction nobody reads is not an instruction.
+      "test_every_section_directive_is_emitted_verbatim_in_the_delta_brief"},
+     add_unledgered_directive),
+    # 🔴 The SURVIVES control for the directive ledger — the sibling of S1. A
+    # RED here means the new pin is keyed to layout, and every reflow of the
+    # source becomes a test failure.
+    ("XS  re-space a directive (instruction identical)",
+     SURVIVES, rewrap_a_directive),
 ]
 
 

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -254,10 +254,14 @@ def rewrap_a_clause(t):
     # CHECKOUT section became three-state, and this row immediately reported
     # MUTATION DID NOT APPLY. Third time an assert-before-editing has caught a
     # row that would otherwise have scored as "the guard held".
+    # 🔴 RE-TARGETED AGAIN in round 5, for the fourth such catch: the clause
+    # went back to being unconditional ("write to any checkout that is not the
+    # copy YOU made"), and this row reported MUTATION DID NOT APPLY on the
+    # first run after that edit.
     return _swap(
         t,
-        '"**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to a "',
-        '"**Do NOT  `git fetch`,  `pull`,  `checkout`  or otherwise write to a  "',
+        '"**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to any "',
+        '"**Do NOT  `git fetch`,  `pull`,  `checkout`  or otherwise write to  any "',
     )
 
 
@@ -614,6 +618,115 @@ def the_round_one_range_points_at_the_pr_description(t):
     )
 
 
+# --------------------------------------------------------------------------- #
+# 🔴 Z1-Z8 — round 5.
+# --------------------------------------------------------------------------- #
+# Round 4 removed the false SHARED claim from the private checkout state and
+# replaced it with a WRITE GRANT over a tree that is not the auditor's, and
+# reworded the `no-fetch` clause from unconditional to conditional on a state
+# `gather_worktree_kind` cannot know (it measures the ASSEMBLER's cwd). Z1-Z3
+# restore each half. Z4 puts the toolchain's refuted rationale back, Z5-Z7 the
+# two `--emit-claims` holes, Z8 the unscoped cause clause.
+
+
+def the_private_state_grants_writing_again(t):
+    """Round 4's text, verbatim — 'yours alone … Writing here is fine'."""
+    return reword_entry(
+        "Directive", "checkout-private",
+        "🔴 **This is a PRIVATE worktree — yours alone.** Its `.git` is a link "
+        "into a shared repository, but the WORKING TREE is not shared, so "
+        "files appearing, vanishing or changing under you is **NOT expected "
+        "here and IS worth reporting** — that is the sibling-agent clobber "
+        "`claude/RULES.md` describes, not background noise. **If something "
+        "moves, report it with what moved and when.** Writing here is fine: "
+        "the no-write clause below is about a SHARED checkout, and this is "
+        "not one.")(t)
+
+
+def the_shared_state_drops_the_no_write_rule(t):
+    """Round 4's `checkout-moves`, which stated no rule of its own."""
+    return reword_entry(
+        "Directive", "checkout-moves",
+        "🔴 **This checkout is SHARED with other sessions and agents. It "
+        "MOVES UNDER YOU** — the branch can change, files can appear and "
+        "vanish, and commits can land mid-audit. That is expected and is NOT "
+        "your fault and NOT a finding. **Report what you observed moving and "
+        "carry on; do not chase it, and do not try to restore it.**")(t)
+
+
+def a_fourth_checkout_state_arrives_with_no_rule(t):
+    """A new `checkout-*` state nobody checked carries the no-write rule."""
+    marker = ")\n\nDIRECTIVE = {d.id: d.text for d in SECTION_DIRECTIVES}"
+    return _swap(t, marker,
+                 '    Directive("checkout-detached", "🔴 **This checkout is on '
+                 'a DETACHED HEAD.** Nobody wrote a rule for it."),\n' + marker)
+
+
+def the_no_fetch_clause_is_conditional_again(t):
+    """Round 4's spelling: armed only when the section says SHARED."""
+    return reword_entry(
+        "Clause", "no-fetch",
+        "**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to a "
+        "SHARED checkout — THE CHECKOUT section of this brief says whether "
+        "the one it names is shared.** Other sessions are in a shared tree; a "
+        "fetch there is a write with cross-session blast radius, and every "
+        "ref you need is already resolved for you here.")(t)
+
+
+def the_toolchain_reason_names_the_shared_checkout_again(t):
+    return _swap(
+        t,
+        '        "so running that copy runs the suite in a checkout that is NOT yours — "\n'
+        '        "the one this brief was assembled in, on whatever branch it is standing "\n'
+        '        "on, holding none of your mutations — and a `nix build <ref>#…` builds "\n',
+        '        "so running the shared copy runs the suite in the SHARED CHECKOUT on "\n'
+        '        "whatever branch it is standing on, and a `nix build <ref>#…` builds "\n',
+    )
+
+
+def the_emitted_block_loses_its_legend(t):
+    return _swap(
+        t,
+        '        "  legend: `<from>` = the tip THIS round\'s audit READ · `<to>` = the "\n'
+        '        "head THIS round\'s FIXES produced. Different shas — `<from>` is older.",\n'
+        '        "",\n',
+        "",
+    )
+
+
+def the_emitted_block_is_not_round_tripped(t):
+    return _swap(t,
+                 "        if facts.emit_from:\n"
+                 "            why = emitted_block_reads_back_as_written(",
+                 "        if False:\n"
+                 "            why = emitted_block_reads_back_as_written(")
+
+
+def an_empty_audited_is_ignored_again(t):
+    return _swap(t,
+                 "    if args.audited is not None and not args.audited.strip():",
+                 "    if False:")
+
+
+def the_degenerate_causes_stop_scoping_the_omission(t):
+    """Round 4's clause: the omission is blamed on every round."""
+    return _swap(
+        t,
+        '        "`<from>` position — which is what a bare round-1 `audited=<sha>` "\n'
+        '        "always means, and what `--emit-claims` records when `--audited` is "\n'
+        '        "omitted AT ROUND 1; from round 2 on, omitting it is correct, because "\n'
+        '        "`<from>` is then recovered from the previous block\'s `<to>`. "\n'
+        '        "`<from>` is the tip the PREVIOUS round AUDITED, so "\n'
+        '        "re-emit that block with `--audited <that round\'s actual tip sha>` "\n'
+        '        "and re-assemble — or nothing has been committed and pushed to "\n',
+        '        "`<from>` position — which is what `--emit-claims` records when "\n'
+        '        "`--audited` is omitted, and what a bare round-1 `audited=<sha>` "\n'
+        '        "always means; `<from>` is the tip the PREVIOUS round AUDITED, so "\n'
+        '        "re-emit that block with `--audited <the tip that round actually "\n'
+        '        "read>` and re-assemble — or nothing has been committed and pushed to "\n',
+    )
+
+
 # 🔴 The SURVIVES control for the directive ledger. Whitespace changes; the
 # instruction does not. A RED here means the new pin is keyed to layout.
 def rewrap_a_directive(t):
@@ -882,10 +995,21 @@ ROWS = [
     # produces a superset rather than an empty range, so nothing else notices.
     # `--audited` routes through `emit_from`, so swapping the writer's anchor
     # to `prev_sha` breaks the flag as well — round 4's addition.
+    # 🔴 KILLER SET GREW IN ROUND 5, for the same STRUCTURAL reason as Y7 and
+    # recorded rather than engineered away: this mutation makes the round-1
+    # branch fall through to the bare spelling, so a `--audited` value never
+    # reaches the header at all — and a guard that reads the PRINTED header
+    # correctly stays silent, because there is nothing wrong with what was
+    # printed. No end-to-end test of "a bad `--audited` is refused" can survive
+    # a mutant that stops the value being emitted. The alternative — asserting
+    # the printed `<from>` EQUALS `emit_from` — was measured and rejected: it
+    # made this row kill five tests and would answer a wrong-field bug in
+    # production with a misleading "it does not parse".
     ("N3  --emit-claims writes the RANGE anchor as `<from>`",
      {"test_emit_claims_records_the_tip_this_round_audited_not_the_range_anchor",
       "test_emit_claims_prints_a_block_this_scripts_own_parser_accepts",
-      "test_audited_supplies_the_tip_a_round_one_emit_cannot_derive"},
+      "test_audited_supplies_the_tip_a_round_one_emit_cannot_derive",
+      "test_emit_claims_refuses_an_audited_value_its_own_parser_cannot_read"},
      emit_claims_writes_the_range_anchor),
     ("N4  THE RANGE renders a self-range with no banner",
      {"test_a_degenerate_self_range_is_reported_not_rendered_as_a_clean_diff",
@@ -938,8 +1062,14 @@ ROWS = [
     # `test_the_shared_checkout_state_is_reported_with_the_it_moves_warning` —
     # and inverts the operative sentence into an instruction to WRITE to the
     # shared checkout, contradicting the `no-fetch` clause two bars later.
+    # 🔴 KILLER SET GREW IN ROUND 5, and the growth is the news: this
+    # replacement text also drops the no-write sentence round 5 added to every
+    # checkout state, so the per-state rule ledger fires as well. Leaving the
+    # old one-element set would have reported EXTRA-KILLER forever; narrowing
+    # the mutation to avoid it would remove the second hazard from the row.
     ("X3  checkout-moves inverted into 'restore anything you see move'",
-     {"test_each_section_directive_carries_the_instruction_its_ledger_entry_names"},
+     {"test_each_section_directive_carries_the_instruction_its_ledger_entry_names",
+      "test_every_checkout_state_carries_the_no_write_rule"},
      reword_entry(
          "Directive", "checkout-moves",
          "🔴 **This checkout is SHARED with other sessions and agents. It "
@@ -1006,8 +1136,15 @@ ROWS = [
       # The `checkout-unknown` directive then reaches no brief at all.
       "test_every_section_directive_is_emitted_verbatim_in_the_brief_that_owns_it"},
      the_unknown_worktree_state_collapses_to_shared),
+    # 🔴 KILLER SET GREW IN ROUND 5, and the growth is a real second
+    # consequence rather than a row losing its focus: with `--audited` ignored,
+    # `emit_from` is None at round 1, the round-trip refusal is never reached,
+    # and a value this script's own parser cannot read is emitted in silence.
+    # No test of "a bad `--audited` is refused" can survive the flag being
+    # dropped on the floor, so the coupling is in the code, not in the pins.
     ("Y7  --audited is parsed and ignored",
-     {"test_audited_supplies_the_tip_a_round_one_emit_cannot_derive"},
+     {"test_audited_supplies_the_tip_a_round_one_emit_cannot_derive",
+      "test_emit_claims_refuses_an_audited_value_its_own_parser_cannot_read"},
      the_audited_flag_is_ignored),
     ("Y8  --audited without --emit-claims is silent again",
      {"test_audited_without_emit_claims_says_it_changed_nothing"},
@@ -1035,6 +1172,63 @@ ROWS = [
      {"test_a_private_worktree_is_not_described_as_shared_and_is_not_absolved",
       "test_every_section_directive_is_emitted_verbatim_in_the_brief_that_owns_it"},
      a_private_worktree_is_called_shared),
+
+    # --------------------------------------------------------------------- #
+    # 🔴 Z1-Z8 — round 5.
+    # --------------------------------------------------------------------- #
+    # 🔴 Z1 IS THE INVERSION OF THE CORRECTED WRITE RULE, restored verbatim from
+    # round 4. Three pins fire, each a different claim: the whole-string ledger
+    # (the text moved), the permission probe (a grant appeared) and the
+    # per-state no-write ledger (the rule vanished).
+    #
+    # 🔴 A FOURTH WAS PREDICTED AND DID NOT FIRE, recorded because the
+    # prediction was wrong and the harness is what said so:
+    # `..._private_worktree_is_not_described_as_shared_and_is_not_absolved`
+    # stays GREEN under Z1, correctly. Round 4's text carries neither of its two
+    # negatives, and both of its positives survive — "PRIVATE linked worktree"
+    # comes from the `kind :` LINE, which this mutation does not touch, and
+    # "report it with what moved and when" is in round 4's text verbatim. That
+    # test covers the SHARED/PRIVATE description; the write GRANT is a claim it
+    # never made, which is exactly why round 5 needed a new probe.
+    ("Z1  the private state grants writing again",
+     {"test_each_section_directive_carries_the_instruction_its_ledger_entry_names",
+      "test_no_checkout_state_grants_write_permission_over_the_assembly_checkout",
+      "test_every_checkout_state_carries_the_no_write_rule"},
+     the_private_state_grants_writing_again),
+    ("Z2  the SHARED state drops its own no-write rule",
+     {"test_each_section_directive_carries_the_instruction_its_ledger_entry_names",
+      "test_every_checkout_state_carries_the_no_write_rule"},
+     the_shared_state_drops_the_no_write_rule),
+    ("Z2b a fourth checkout state arrives with no rule",
+     {"test_the_section_directive_ledger_is_pinned_two_way",
+      "test_the_directive_render_scenario_ledger_is_pinned_two_way",
+      "test_every_checkout_state_carries_the_no_write_rule"},
+     a_fourth_checkout_state_arrives_with_no_rule),
+    # 🔴 Z3 is the other half of round 4's regression: the clause that forbids
+    # the write was made conditional on a state this script cannot know. Killed
+    # by the whole-string CLAUSE ledger alone — the clause is still present,
+    # still ledgered by id and still emitted, which is exactly how the reword
+    # shipped.
+    ("Z3  no-fetch goes back to conditional-on-SHARED",
+     {"test_each_clause_carries_the_instruction_its_ledger_entry_names"},
+     the_no_fetch_clause_is_conditional_again),
+    ("Z4  TOOLCHAIN's reason names the SHARED CHECKOUT again",
+     {"test_the_toolchain_reason_is_true_in_both_checkout_states"},
+     the_toolchain_reason_names_the_shared_checkout_again),
+    ("Z5  the emitted block loses its legend",
+     {"test_the_emitted_skeleton_carries_a_legend_for_its_two_fields"},
+     the_emitted_block_loses_its_legend),
+    ("Z6  the emitted block is not round-tripped",
+     {"test_emit_claims_refuses_an_audited_value_its_own_parser_cannot_read"},
+     the_emitted_block_is_not_round_tripped),
+    ("Z7  an EMPTY --audited is ignored again",
+     {"test_emit_claims_refuses_an_audited_value_its_own_parser_cannot_read"},
+     an_empty_audited_is_ignored_again),
+    ("Z8  the degenerate causes stop scoping the omission",
+     {"test_each_section_directive_carries_the_instruction_its_ledger_entry_names",
+      "test_the_degenerate_cause_list_scopes_the_omitted_flag_to_round_one",
+      "test_a_degenerate_range_does_not_blame_a_checkout_it_verified"},
+     the_degenerate_causes_stop_scoping_the_omission),
 ]
 
 

--- a/scripts/tests/mutants-audit-ladder.sh
+++ b/scripts/tests/mutants-audit-ladder.sh
@@ -308,6 +308,16 @@ run "cross-repo worktree caveat inverted" \
     '🔴 `isolation:
   "worktree"` worktrees the **cwd'"'"'s** repo, not the PR'"'"'s' \
     'Use `isolation: "worktree"` for any repo'
+# The assembler router. The DELETION is the obvious mutant and the weak one;
+# this inverts the REFUSAL instead, leaving the router itself byte-identical.
+# That is the reading a reader would accept ("it warns, fine") and it describes a
+# different tool: a delta re-audit with no claims block silently becomes a blind
+# full audit, which then reads as covered. The whole-string pin is what catches
+# it — a keyword guard on "audit-dispatch.py" would stay green.
+run "assembler router's REFUSAL downgraded to a warning" \
+    test_the_operator_instructions_the_gate_depends_on_are_pinned "$SKILL" \
+    '**A delta round with no parseable block is REFUSED.**' \
+    'A delta round with no parseable block warns and proceeds.'
 run "stderr-capture rule inverted" \
     test_the_operator_instructions_the_gate_depends_on_are_pinned "$SKILL" \
     'Keep stderr on the terminal — folding it into the sum with

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -1056,13 +1056,23 @@ def test_each_section_directive_carries_the_instruction_its_ledger_entry_names()
 
 
 def test_the_directive_render_scenario_ledger_is_pinned_two_way():
-    """Every directive names a brief that carries it, and vice versa.
+    """Every directive names a SCENARIO, and every scenario names a directive.
 
-    🔴 INVARIANT GUARD; its evidence is mutants XA and Y1/Y2 (a directive added
-    with no scenario, or one whose section stops rendering it). Without this,
-    a directive could be added to `SECTION_DIRECTIVES`, ledgered whole, and
-    reach NO brief at all — an instruction nobody receives, pinned word for
-    word, reading as coverage.
+    🔴 THE SENTENCE ABOVE IS EXACTLY AS WIDE AS THE CODE BELOW, and its first
+    draft was not: it read "every directive names a brief THAT CARRIES IT",
+    which claims a rendering check this test does not make. Whether the
+    scenario's brief actually carries the directive is
+    `..._emitted_verbatim_in_the_brief_that_owns_it`, next door. Splitting them
+    is deliberate — one owns the LEDGER, one owns the RENDER — and describing
+    this one as if it did both is the "guard whose description is wider than
+    its implementation" failure `claude/RULES.md` names, which is also 🟡3 of
+    the round this test was written in.
+
+    🔴 INVARIANT GUARD; its evidence is mutant XA (a directive added with no
+    scenario) and X2 (one deleted). Without it a directive could be added to
+    `SECTION_DIRECTIVES`, ledgered whole, and be scoped to nothing at all —
+    after which the render check has no scenario to look in and passes
+    vacuously.
     """
     # 🔴 Against the SCRIPT's ids, not only against the sibling ledger. Two
     # test-module constants compared with each other are unreachable by the
@@ -3197,8 +3207,15 @@ FIX_MATRIX = (
 # grades every row correctly and asserts nothing. Derived from the current
 # measurement the way this repo derives every other floor —
 # `m - min(50, max(1, m // 20))` — rather than hand-picked, because a
-# hand-picked floor drifts from what it is protecting. At m = 48 that is 46.
-MIN_FIX_MATRIX_ROWS = 46
+# hand-picked floor drifts from what it is protecting.
+#
+# 🔴 COUNTED, not estimated. This comment first said "at m = 48 that is 46" and
+# BOTH numbers were wrong: the matrix holds 47 rows, and the formula gives
+# 47 - max(1, 2) = 45. Caught by counting the rows instead of trusting the
+# sentence — which is the same move as 🟢 "count them in the ledger" elsewhere
+# in this round, and it is recorded because an arithmetic claim nobody re-runs
+# is precisely what 🟡3 was about.
+MIN_FIX_MATRIX_ROWS = 45
 
 # 🔴 THE MUTANTS COLUMN IS AN EVIDENCE CLAIM, AND IT WAS UNGRADED.
 # `fix_matrix_problems` took `_mutants` and threw it away, so rewriting a

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -163,6 +163,54 @@ prints on an unknown key). `url` is what carries the base repo, and it is what
 `pr_slug` reads; `isCrossRepository` decides whether the head fields may stand
 in when there is no url.
 
+🔴 ROUND 7 — a fifth base, `3619fe68`, fixing round 6's findings
+------------------------------------------------------------------
+Round 6 returned two 🟡 and four 🟢, plus a PRE-EXISTING 🔴 found under a
+targeted probe. The 🔴 is the third instance of this ladder's recurring
+confusion and the first on a TIME axis: THE RANGE handed the auditor
+`<from>..HEAD` whenever the head was verified, and `HEAD` resolves in the
+AUDITOR's worktree — cut after assembly, from a repository other sessions push
+to. Round 3 conflated the operator's checkout with the tree under audit; round
+5 conflated the assembling process's cwd with where the auditor stands.
+
+The two 🟡: `own-worktree-is-writable` still said the no-write rule "is about
+the SHARED checkout", naming a scoping round 5 had removed from the clause it
+forward-references — so a cross-repo brief assembled in a PRIVATE worktree
+contradicted itself across three consecutive sections; and the exit-4 round
+trip is line-oriented on BOTH sides, so a TRAILING NEWLINE in `--audited`
+emitted a corrupt block at rc 0. The four 🟢 were all scaffolding: this
+module's own prose still asserted the premise round 5 refuted, the TOOLCHAIN
+equality drove two scenarios that were both same-repo, the no-write
+relationship was spelled as an id PREFIX, and the blind-spot rationale was
+false as stated.
+
+Measured at `3619fe68` the same way — `git show 3619fe68:scripts/audit-dispatch
+.py` into a scratch tree with THIS module copied in unchanged, under
+`PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`:
+
+    12 failed, 82 passed
+
+and only FOUR of the twelve are regression coverage. Of the other eight: ONE is
+round 7's new state-map guard, which ERRORS there for want of a constant the
+fix adds; the rest are pre-existing tests whose expected range spelling moved
+with the tip fix, plus the whole-string directive ledger.
+
+🔴 ONE OF ROUND 7's GUARDS CANNOT BE RED UNDER THAT PROCEDURE AT ALL, and the
+reason is worth naming rather than papering over: it scans THIS MODULE's prose,
+and the procedure copies this module in UNCHANGED. A base SCRIPT says nothing
+about a base DOCSTRING. It is filed as a guard, and its red was measured
+separately against `3619fe68`'s test module — where both `REFUTED_PREMISES`
+entries appear, normalised, and would read twice with the ledger present.
+
+🔴 AND THE PER-ROUND COUNTS ABOVE ARE CLAIMS ABOUT THE MODULE OF THEIR OWN
+ROUND. Re-running the same procedure with the CURRENT module gives larger
+numbers at every historical ref (54/34/27/19 at
+`abc41024`/`d9eb36a8`/`e06461f7`/`dd601793`), because each later round adds
+tests that are also red at the earlier trees. What is re-derivable, and was
+re-derived in round 7, is the claim the ledgers actually make: every name in
+every `RED_AT_BASE_*` set fails at its own ref. Zero false claims across all
+five refs.
+
 🔴 THE NEGATIVE-CONTROL MATRIX — measured, and RE-DERIVABLE
 -------------------------------------------------------------
 🔴 The rows below are transcribed from a harness that is IN THE TREE, and that
@@ -178,8 +226,9 @@ rows that justified adding a pin. Each row there names the EXACT killer set and
 reports WRONG-KILLER (an expected pin did not fire) separately from EXTRA-KILLER
 (the row no longer isolates what it names).
 
-Re-run 2026-08-28 against HEAD of this branch after the round-5 fixes — **76
-rows, all as expected**, over an 89-test positive control — each mutant applied
+Re-run 2026-08-28 against HEAD of this branch after the round-7 fixes — **83
+rows, all as expected**, over a 94-test positive control (it was 76 rows over
+89 after round 5) — each mutant applied
 to a COPY of
 `scripts/audit-dispatch.py` in a scratch tree (never the worktree), under
 `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`, with the unmutated copy as the
@@ -189,7 +238,10 @@ which is the most flattering possible wrong answer. Two rows have done exactly
 that: `C3`, written against the two-state `cross_repo` flag, and `H2`, whose
 branch became an `elif` when round 3 inserted the degenerate-self-range case
 ahead of it. Both were re-targeted; without that assert each would have scored
-as a guard holding.
+as a guard holding. 🔴 TWO MORE IN ROUND 7 — `Y6` and `Y14`, whose target was
+`render_checkout`'s inline state->directive dict, now the module-level
+`CHECKOUT_STATE_DIRECTIVE`. That makes FOUR rows this assert has caught, every
+one of them after a refactor that nobody thought touched the battery.
 
 🔴 THE ROUND-3 BATTERY CAUGHT TWO DEFECTS IN THE ROUND-3 TESTS THEMSELVES, and
 they are recorded because both are the shape this file warns about elsewhere:

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -113,13 +113,47 @@ Measured at `e06461f7` the same way: **15 failed, 68 passed**, of which FIVE
 are regression coverage. `RED_AT_BASE_R4` carries them and the constant says
 why the other ten are guards.
 
+🔴 ROUND 5 — a fourth base, `dd601793`
+---------------------------------------
+Round 5's audit found that round 4's own fix INVERTED the write rule while
+fixing the sharedness one: the private checkout state was rewritten to "**a
+PRIVATE worktree — yours alone** … Writing here is fine", and `no-fetch` was
+reworded in the same range from unconditional to conditional on a state
+`gather_worktree_kind` cannot know — it measures the ASSEMBLING process's cwd,
+and the consumer is a different process that WHERE TO WORK dispatches
+elsewhere. So the brief granted write permission over the dispatching session's
+tree and overrode its own `read-only` clause, in exactly the configuration
+production produces. TOOLCHAIN separately still called that path "the SHARED
+CHECKOUT" two bars after THE CHECKOUT had denied it, `--audited` accepted any
+string and the emitter's own parser truncated it in silence, and the
+degenerate-cause banner blamed an omission that is CORRECT from round 2 on.
+
+Measured at `dd601793` the same way — `git show dd601793:scripts/audit-dispatch
+.py` into a scratch tree with THIS module copied in unchanged, under
+`PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`:
+
+    10 failed, 79 passed
+
+and only FOUR of the ten are regression coverage. Of the other six: TWO are
+round 5's new guards, red there on an ABSENCE the fix adds (two of the three
+checkout states carry no no-write rule at that ref; there is no legend at all),
+and FOUR are pre-existing tests whose ledgers moved with the reword — the two
+whole-string ledger tests, the degenerate-cause test that asserts the ledgered
+text, and the private-worktree test whose POSITIVES moved. That last one stays
+filed under `e06461f7`: its two NEGATIVES are untouched and run first, and it
+was RE-MEASURED at that ref after the change, failing on the false SHARED claim
+exactly as before.
+
 🔴 THE FIX MATRIX GAINED TWO CHECKS IT DID NOT HAVE, and both were holes the
 round-4 audit found in this module's own bookkeeping: the `mutants` column was
 DISCARDED by `fix_matrix_problems` (rewriting a GUARD row to name a mutant that
 does not exist left the suite green, while for a GUARD row that column IS the
 evidence), and nothing required a `RED_AT_BASE` entry to appear in the matrix
-at all — nine round-2 detectors and one round-3 detector were in that state,
-so five findings could have dropped out with nothing going red.
+at all — ten rows over nine distinct detectors were in that state, so five
+findings could have dropped out with nothing going red. 🔴 THAT SENTENCE USED
+TO SAY "nine round-2 detectors and one round-3 detector", which counts TEN over
+a set of NINE: one test is red at two bases and carries a row for each. The
+count now comes out of the ledgers in the assertion itself.
 
 🔴 FINDING 3's PRESCRIPTION WAS WRONG ON ONE POINT, and it is recorded because
 the next person will reach for the same field: the audit said to use
@@ -144,8 +178,8 @@ rows that justified adding a pin. Each row there names the EXACT killer set and
 reports WRONG-KILLER (an expected pin did not fire) separately from EXTRA-KILLER
 (the row no longer isolates what it names).
 
-Re-run 2026-08-28 against HEAD of this branch after the round-4 fixes — **67
-rows, all as expected**, over an 83-test positive control — each mutant applied
+Re-run 2026-08-28 against HEAD of this branch after the round-5 fixes — **76
+rows, all as expected**, over an 89-test positive control — each mutant applied
 to a COPY of
 `scripts/audit-dispatch.py` in a scratch tree (never the worktree), under
 `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`, with the unmutated copy as the
@@ -169,9 +203,9 @@ they are recorded because both are the shape this file warns about elsewhere:
 
 The rows below are the pre-existing sixteen. Everything added since —
 W1-W5 + S1, H1-H4, T1-T2, P1-P2, K1-K3, L1, B1-B5 in round 2; N1-N8, X1-X3, XA
-and the SURVIVES control XS in round 3; Y1-Y14 in round 4 — is listed in the
-harness with its killer set and is NOT transcribed here; the harness is the
-authority on which rows exist.
+and the SURVIVES control XS in round 3; Y1-Y14 in round 4; Z1-Z8 in round 5 —
+is listed in the harness with its killer set and is NOT transcribed here; the
+harness is the authority on which rows exist.
 
 🔴 ROUND 4 RE-TARGETED FIVE PRE-EXISTING ROWS AND SHIFTED SEVEN KILLER SETS,
 and both kinds are worth reading before trusting any row here. S1 and N6
@@ -182,6 +216,20 @@ expected set had to CHANGE rather than grow: the hazard it names is now caught
 one guard earlier, and leaving the old name there would have left a DEAD pin
 reading as coverage.
 
+🔴 ROUND 5 RE-TARGETED S1 AGAIN — the FOURTH time assert-before-editing has
+caught a row that would otherwise have scored as "the guard held", and again on
+the `no-fetch` clause, which round 5 made unconditional. Three killer sets
+GREW, and the growth is recorded on each row because two of the three are a
+measured COUPLING rather than a pin doing new work: X3 also drops the no-write
+sentence round 5 added to every checkout state (real second hazard), while N3
+and Y7 each stop a `--audited` value from reaching the emitted header, so no
+end-to-end test of "a bad value is refused" can survive them. 🔴 One PREDICTED
+killer did NOT fire — Z1 leaves `..._private_worktree_is_not_described_as_shared
+_and_is_not_absolved` green, correctly, because that test covers the
+SHARED/PRIVATE description and the write GRANT is a claim it never made. The
+prediction was written down and the harness refuted it, which is the point of
+running it rather than reporting it.
+
 🔴 ROUND 4 ALSO INTRODUCED A THIRD EXPECTATION, `HOLE`, and it is not a synonym
 for `SURVIVES`. `SURVIVES` is a control (a pin must not be keyed to layout);
 `HOLE` is a measured GAP (Y3-Y5: three operative sentences nothing guards).
@@ -189,7 +237,7 @@ Printing "SURVIVED as required (control)" over an unguarded sentence is exactly
 the flattering wrong answer this battery exists to refuse.
 
   POS  unmutated copy .............................. 72 passed  <- control
-       (that figure is the ROUND-2 control; today's is 83 — the harness
+       (that figure is the ROUND-2 control; today's is 89 — the harness
         prints the current one, which is the number to read)
 
   D1   delete the `read-only` clause ............... 4 failed
@@ -364,17 +412,20 @@ CLAUSE_LEDGER = {
         "pointing at the real git dir, so a commit inside the copy lands on "
         "the branch you are auditing."
     ),
-    # 🔴 REWORDED IN ROUND 4, deliberately, and the ledger moves with it. The
-    # clause used to name "THE SHARED CHECKOUT section", a heading that only
-    # existed because the brief asserted SHARED of every checkout. THE CHECKOUT
-    # section is now three-state, so the clause names the section and lets the
-    # section say whether the tree it describes is shared — otherwise the
-    # clause forbids an auditor from writing to their OWN private worktree,
-    # contradicting `own-worktree-is-writable` in the same brief.
+    # 🔴 REWORDED TWICE, AND ROUND 5 REVERSED ROUND 4's DIRECTION. Round 4 made
+    # the prohibition CONDITIONAL — "write to a SHARED checkout — THE CHECKOUT
+    # section … says whether the one it names is shared" — which armed it on a
+    # state the script cannot know: `gather_worktree_kind` measures the tree the
+    # ASSEMBLER stands in, and in production it answers `private`, so the rule
+    # switched itself off over a tree belonging to the dispatching session.
+    # The axis that is true in every state is OWNERSHIP, not sharedness, and it
+    # keeps `own-worktree-is-writable` consistent: the copy YOU made is the one
+    # you may write to.
     "no-fetch": (
-        "**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to a "
-        "SHARED checkout — THE CHECKOUT section of this brief says whether "
-        "the one it names is shared.** Other sessions are in a shared tree; a "
+        "**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to any "
+        "checkout that is not the copy YOU made for this audit — including the "
+        "one THE CHECKOUT section names, which is where this brief was "
+        "assembled and is not yours.** Other sessions are in those trees; a "
         "fetch there is a write with cross-session blast radius, and every ref "
         "you need is already resolved for you here."
     ),
@@ -875,12 +926,16 @@ DIRECTIVE_LEDGER = {
         "narrowed check that now rejects a legitimate case, the rule reworded "
         "wider on one axis and narrower on another."
     ),
+    # 🔴 ROUND 5 added the no-write sentence. All three `checkout-*` states now
+    # carry it, which is what `CHECKOUT_STATE_NO_WRITE` pins as a RELATIONSHIP
+    # over the set rather than as a phrase in one entry.
     "checkout-moves": (
         "🔴 **This checkout is SHARED with other sessions and agents. It MOVES "
         "UNDER YOU** — the branch can change, files can appear and vanish, and "
         "commits can land mid-audit. That is expected and is NOT your fault "
-        "and NOT a finding. **Report what you observed moving and carry on; do "
-        "not chase it, and do not try to restore it.**"
+        "and NOT a finding. **Write nothing to it**, and report what you "
+        "observed moving and carry on; do not chase it, and do not try to "
+        "restore it."
     ),
     # ---------------------------------------------------------------- #
     # 🔴 ROUND 4's five. Two of them (`delta-scope`,
@@ -897,13 +952,21 @@ DIRECTIVE_LEDGER = {
         "delta this round exists to examine, and makes the round's cost "
         "indistinguishable from a first full audit."
     ),
+    # 🔴 ROUND 5 SCOPED THE FIRST CAUSE TO ROUND 1. From round 2 on, omitting
+    # `--audited` is CORRECT — the anchor is recovered from the previous
+    # block's `<to>` — so blaming the omission on a round-3 brief sent the
+    # operator to hand-type a value, which is how a placeholder reached the
+    # header. The re-emit instruction also stops quoting a phrase that is not a
+    # sha, for the same reason.
     "degenerate-range-causes": (
         "Either the `audited=` block was written with the fix tip in its "
-        "`<from>` position — which is what `--emit-claims` records when "
-        "`--audited` is omitted, and what a bare round-1 `audited=<sha>` "
-        "always means; `<from>` is the tip the PREVIOUS round AUDITED, so "
-        "re-emit that block with `--audited <the tip that round actually "
-        "read>` and re-assemble — or nothing has been committed and pushed to "
+        "`<from>` position — which is what a bare round-1 `audited=<sha>` "
+        "always means, and what `--emit-claims` records when `--audited` is "
+        "omitted AT ROUND 1; from round 2 on, omitting it is correct, because "
+        "`<from>` is then recovered from the previous block's `<to>`. "
+        "`<from>` is the tip the PREVIOUS round AUDITED, so "
+        "re-emit that block with `--audited <that round's actual tip sha>` "
+        "and re-assemble — or nothing has been committed and pushed to "
         "the PR since that sha was recorded, in which case there is no delta "
         "to audit yet. 🔴 What is NOT a cause: the round's fix commits being "
         "absent from this checkout. This checkout was VERIFIED at assembly "
@@ -912,15 +975,24 @@ DIRECTIVE_LEDGER = {
         "unmeasurable — so fetching or checking out here could not help, and "
         "the `no-fetch` clause forbids it anyway."
     ),
+    # 🔴 ROUND 5 REPLACED THE PREMISE, NOT THE SENTENCE. Round 4's version
+    # ("a PRIVATE worktree — yours alone … Writing here is fine") granted write
+    # permission over a tree that is NOT the auditor's, and inverted the
+    # movement claim in the unsafe direction ("NOT expected here"). Both follow
+    # from one false premise: `gather_worktree_kind` measures the ASSEMBLING
+    # process's cwd, while the consumer is a different process that WHERE TO
+    # WORK sends elsewhere. So this states only what the script knows — the
+    # path is where the brief was built — and grants nothing.
     "checkout-private": (
-        "🔴 **This is a PRIVATE worktree — yours alone.** Its `.git` is a link "
-        "into a shared repository, but the WORKING TREE is not shared, so "
-        "files appearing, vanishing or changing under you is **NOT expected "
-        "here and IS worth reporting** — that is the sibling-agent clobber "
-        "`claude/RULES.md` describes, not background noise. **If something "
-        "moves, report it with what moved and when.** Writing here is fine: "
-        "the no-write clause below is about a SHARED checkout, and this is "
-        "not one."
+        "🔴 **This is the checkout this brief was ASSEMBLED in — not "
+        "necessarily the one you are standing in.** Git reports it as a "
+        "PRIVATE linked worktree: its `.git` is a link into a shared "
+        "repository, and the working tree belongs to the session that BUILT "
+        "this brief, which is not you. That session is live in it, so files "
+        "here can appear, vanish and change. **Write nothing to it** — the "
+        "path is a fact about where the brief was built, never a tree you may "
+        "work in. If you do see something move here, report it with what "
+        "moved and when, and do not try to restore it."
     ),
     "checkout-unknown": (
         "🔴 **COULD NOT DETERMINE whether this checkout is shared** — the "
@@ -2218,8 +2290,14 @@ def test_a_private_worktree_is_not_described_as_shared_and_is_not_absolved():
         "alone. That absolution is what suppresses a sibling-agent clobber "
         "report — the one signal a private worktree can produce."
     )
-    assert "PRIVATE worktree" in checkout
-    assert "IS worth reporting" in checkout
+    # 🔴 The POSITIVES moved in round 5 and the reason is the finding: round 4
+    # replaced the false SHARED claim with "a PRIVATE worktree — yours alone …
+    # Writing here is fine", which is a WRITE GRANT over the dispatching
+    # session's tree. The state is still reported; what it licenses is not.
+    # Both negatives above are unchanged, so this is still red at `e06461f7`
+    # on the wrong ANSWER (that tree renders `checkout-moves`).
+    assert "PRIVATE linked worktree" in checkout
+    assert "report it with what moved and when" in checkout
 
 
 def test_an_unreadable_worktree_state_is_its_own_answer_and_keeps_the_no_write():
@@ -2342,6 +2420,355 @@ def test_an_uppercase_audited_sha_still_trips_the_degenerate_guard():
         f"range:\n{the_range}"
     )
     assert "verified at assembly time" not in the_range
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 ROUND 5 — THE BRIEF GRANTED WRITE PERMISSION OVER A TREE THAT IS NOT THE
+#              AUDITOR'S, AND OVERRODE ITS OWN READ-ONLY CLAUSE
+# --------------------------------------------------------------------------- #
+# Round 4 removed the false SHARED claim from the private state and replaced it
+# with "**a PRIVATE worktree — yours alone** … Writing here is fine: the
+# no-write clause below is about a SHARED checkout, and this is not one", and
+# reworded `no-fetch` in the same range from unconditional to conditional. So
+# the prohibition was ARMED ONLY when `gather_worktree_kind` returns `shared` —
+# and in the production configuration it returns `private`.
+#
+# 🔴 THE ROOT ERROR IS THE PREMISE. `gather_worktree_kind` measures the cwd of
+# the ASSEMBLING process; the consumer is a DIFFERENT process, dispatched by
+# WHERE TO WORK to make its own copy. "Private" therefore means "private to the
+# session that built the brief" — a session that is LIVE in that tree — and
+# under the other configuration (no isolation, inherited cwd) the same tree is
+# shared with the dispatcher and with sibling auditors. No state this script can
+# measure makes the tree the auditor's own.
+#
+# Observed live: the round-5 brief named this session's own agent worktree,
+# classified it PRIVATE and printed "Writing here is fine". The operator's
+# hand-written dispatch had to contradict the generated brief in prose —
+# retyping a correction over generated text being the failure this script exists
+# to remove.
+
+# 🔴 THE PROBE, and what it is and is not. Like `ABSENT_COMMIT_CLAIMS` above,
+# its job is to be RED AT THE BASE — to observe the wrong answer that shipped —
+# not to be unwalkable; a reword could step around it. Non-walkability comes
+# from the whole-string `DIRECTIVE_LEDGER` pin on every `checkout-*` entry and
+# from the relationship ledger below.
+#
+# SCOPED TO THE CHECKOUT SECTION on purpose: `own-worktree-is-writable` grants
+# writing to the worktree the AUDITOR built, in WHERE TO WORK, and that grant is
+# correct. What may never appear is a grant over the path THE CHECKOUT names.
+WRITE_PERMISSION_PHRASES = (
+    "Writing here is fine",
+    "yours alone",
+    "tree is yours",
+    "you may write",
+    "writing here is fine",
+    "free to write",
+)
+
+# The round-4 text, verbatim, kept ONLY as the positive control for the probe: a
+# scan that reports zero is indistinguishable from a scan wired to nothing.
+ROUND_4_WRITE_GRANT = (
+    "🔴 **This is a PRIVATE worktree — yours alone.** Its `.git` is a link "
+    "into a shared repository, but the WORKING TREE is not shared, so files "
+    "appearing, vanishing or changing under you is **NOT expected here and IS "
+    "worth reporting**. **If something moves, report it with what moved and "
+    "when.** Writing here is fine: the no-write clause below is about a SHARED "
+    "checkout, and this is not one."
+)
+
+CHECKOUT_STATE_DIRECTIVES = frozenset({
+    "checkout-moves", "checkout-private", "checkout-unknown",
+})
+# Matched case-insensitively at the first letter so "**Write nothing to it**"
+# and "and write nothing to it" both count — the sentence, not its capital.
+NO_WRITE_RULE = "rite nothing to it"
+
+
+def write_permissions_in(text):
+    return [p for p in WRITE_PERMISSION_PHRASES if p in text]
+
+
+def test_no_checkout_state_grants_write_permission_over_the_assembly_checkout():
+    """🔴 REGRESSION. Red at `dd601793` in the PRIVATE state.
+
+    The wrong ANSWER, not a missing word: the brief names a path, says the
+    working tree there is the reader's alone, and tells them writing to it is
+    fine — over a worktree belonging to the dispatching session, in the state
+    the production configuration actually produces.
+
+    The three states are driven together because the hazard is one claim with
+    three renderers, and a test scoped to any single state would have passed at
+    some base or other.
+    """
+    assert write_permissions_in(ROUND_4_WRITE_GRANT), (
+        "POSITIVE CONTROL: the probe cannot see the round-4 grant it was "
+        "written to catch, so a clean result below would say nothing at all"
+    )
+    for scenario in ("private-worktree", "delta", "unreadable-worktree"):
+        checkout = checkout_section(brief_for_scenario(scenario))
+        assert FAKE_REPO_DIR in checkout, (
+            f"scenario {scenario!r}: THE CHECKOUT does not name a path, so "
+            "this test is asserting over the wrong slice"
+        )
+        granted = write_permissions_in(checkout)
+        assert not granted, (
+            f"\n\nscenario {scenario!r}: THE CHECKOUT grants the auditor "
+            f"permission to write to `{FAKE_REPO_DIR}` — {granted}.\n"
+            "  That path is the tree the ASSEMBLER stood in. The auditor is a "
+            "different process, dispatched elsewhere by WHERE TO WORK, and the "
+            "session that owns this tree is live in it. The `read-only` clause "
+            "is non-negotiable and no state may override it.\n"
+            f"{checkout}"
+        )
+
+
+def test_every_checkout_state_carries_the_no_write_rule():
+    """🔴 INVARIANT GUARD — a RELATIONSHIP over the `checkout-*` set.
+
+    Its evidence is the mutation battery (Z1, Z2), not a base ref: at
+    `dd601793` two of the three states simply lack the sentence, which is an
+    absence the fix adds rather than a wrong answer observed.
+
+    A seam guard in the `claude/RULES.md` sense. The per-state directive is the
+    ONLY thing that survives a reword of the `no-fetch` clause — round 4
+    reworded that clause into a conditional one and the private state was left
+    with a write grant and no rule anywhere — so every state must carry the rule
+    itself. Pinned two-way: a fourth checkout state with no rule fails, and a
+    ledger entry naming no directive fails.
+    """
+    ids = {d.id for d in ad.SECTION_DIRECTIVES if d.id.startswith("checkout-")}
+    assert ids == set(CHECKOUT_STATE_DIRECTIVES), (
+        f"\n\nthe checkout states are {sorted(ids)}, not "
+        f"{sorted(CHECKOUT_STATE_DIRECTIVES)}.\n"
+        "  GREW: a new state renders auditor-facing prose that nobody checked "
+        "carries the no-write rule.\n"
+        "  SHRANK: a state was deleted and its ledger entry left behind."
+    )
+    for cid in sorted(ids):
+        assert NO_WRITE_RULE in ad.DIRECTIVE[cid], (
+            f"\n\nthe `{cid}` directive does not tell the auditor to write "
+            "nothing to the path THE CHECKOUT names. Only the per-state "
+            "directive survives a reword of the `no-fetch` clause, and round 4 "
+            "reworded that clause into one that switches itself off."
+        )
+    # 🔴 BEHAVIOURAL, because a structural check type-checks past prose that
+    # never reaches an artifact: each state's rule must be IN the section.
+    for cid in sorted(ids):
+        section = checkout_section(brief_for_scenario(DIRECTIVE_RENDERS_IN[cid]))
+        assert NO_WRITE_RULE in section, (
+            f"the `{cid}` rule is in the constant but not in the rendered "
+            f"section of the {DIRECTIVE_RENDERS_IN[cid]!r} scenario"
+        )
+
+
+def toolchain_section(brief):
+    """The TOOLCHAIN block, sliced off the two headings that bracket it."""
+    start = brief.index("## TOOLCHAIN")
+    return brief[start:brief.index(EXPECTED_INVARIANTS_HEADING, start)]
+
+
+def test_the_toolchain_reason_is_true_in_both_checkout_states():
+    """🔴 REGRESSION. Red at `dd601793` in the PRIVATE state.
+
+    `render_toolchain` interpolated `r = facts.cwd_repo_dir` into prose reading
+    "running the shared copy runs the suite in the SHARED CHECKOUT on whatever
+    branch it is standing on". In the private state `r` is a private worktree
+    and THE CHECKOUT has already said so two bars above, so the stated REASON is
+    refuted by the same document — and the rationale is what persuades. An
+    auditor who discounts it gates the un-mutated head, then obeys the next
+    sentence ("name the tier and the base sha") and names a tree that does not
+    contain what they tested. That is round 2's finding re-opened in a new
+    state.
+
+    🔴 The PRIVATE state runs FIRST so the red at the base is the FALSE claim.
+    In the shared state the sentence was true; making it state-independent is
+    the same fix, and the equality assertion at the foot is what pins it.
+    """
+    sections = {}
+    for scenario in ("private-worktree", "delta"):
+        tool = toolchain_section(brief_for_scenario(scenario))
+        sections[scenario] = tool
+        assert "SHARED CHECKOUT" not in tool, (
+            f"\n\nscenario {scenario!r}: TOOLCHAIN calls `{FAKE_REPO_DIR}` the "
+            "SHARED CHECKOUT. This section knows nothing about where the "
+            "auditor stands and THE CHECKOUT may have just denied that state, "
+            "so the reason must hold in every state — a refuted rationale is "
+            f"discounted along with the instruction it carries.\n{tool}"
+        )
+        assert "resolves its root from its own path" in tool, (
+            "the section no longer says WHY the assembly path is wrong there, "
+            "so the next editor puts it back"
+        )
+        assert "is NOT yours" in tool, (
+            "the reason no longer names the property that is true in every "
+            "state — that copy is not the auditor's"
+        )
+    assert sections["private-worktree"] == sections["delta"], (
+        "\n\nTOOLCHAIN now varies with the checkout state. It is rendered from "
+        "`facts.cwd_repo_dir` alone and knows nothing about where the auditor "
+        "stands, so a state-dependent sentence here is a claim it cannot "
+        "support in the branch it is not being read in."
+    )
+
+
+def test_emit_claims_refuses_an_audited_value_its_own_parser_cannot_read():
+    """🔴 REGRESSION. Red at `dd601793`, which truncated it in silence.
+
+    Measured there through the real code: `--audited "abc 123"` emitted
+    ``audited=abc 123..<head>``, which this script's OWN parser reads back as
+    `from=''`, `to='abc'` — so the next round diffs `abc..HEAD`. No warning at
+    emit, none reported malformed at parse, and the self-range guard cannot
+    fire. `--audited e06461f7..dd601793` corrupted `<to>` instead, which
+    cascades into the round after that.
+
+    🔴 This is the round-3 bug re-opened, and the brief ITSELF reproduced it:
+    `degenerate-range-causes` told the operator to re-emit "with `--audited
+    <the tip that round actually read>`", so pasting the placeholder yields
+    `from=''`, `to='<the'`.
+    """
+    bad = (
+        ("abc 123", "whitespace: cut at the first space"),
+        ("<the tip that round actually read>", "the brief's own placeholder"),
+        ("e06461f7..dd601793", "a RANGE where a single sha belongs"),
+    )
+    for value, why in bad:
+        rc, out, err = run_main(
+            ["900", "--round", "1", "--emit-claims", "--audited", value]
+        )
+        assert rc != 0, (
+            f"\n\n--audited {value!r} ({why}) was accepted: rc {rc}. The block "
+            f"it would emit does not round-trip through this script's own "
+            f"parser, and the NEXT round anchors its whole delta on that "
+            f"field.\nstdout:\n{out[-600:]}"
+        )
+        assert "```audit-claims" not in out, (
+            f"--audited {value!r} was refused but the malformed block was "
+            "printed anyway, which is what an operator pastes"
+        )
+        assert ad.EMIT_REFUSAL_HEADER in err and value in err, (
+            f"the refusal does not name the value it rejected:\n{err}"
+        )
+
+    # 🔴 THE OTHER SOURCE, so the guard is not keyed to the flag: `emit_from`
+    # is `emit_anchor(newest)` when `--audited` is omitted, recovered from a
+    # block a human typed into a PR comment. `audited=a..b..c` splits on the
+    # FIRST dot-pair, so `<to>` comes back holding a range — and this round
+    # would copy that corruption forward into its own block.
+    corrupt = (
+        "```audit-claims round=2 audited=aaaa1111..bbbb2222..cccc3333\n"
+        "1. a claim whose previous block carried two dot-pairs\n"
+        "```"
+    )
+    rc, out, err = run_main(
+        ["900", "--round", "3", "--emit-claims"], comments=[corrupt]
+    )
+    assert rc != 0 and ad.EMIT_REFUSAL_HEADER in err, (
+        "\n\na corrupt anchor INHERITED from the previous block is copied "
+        f"forward in silence; the flag is not the only way in. rc {rc}\n{err}"
+    )
+
+    # 🔴 An EMPTY value is the fifth measured row: falsy, so it fell through to
+    # the fallback and the flag was ignored in silence.
+    rc, out, err = run_main(["900", "--round", "1", "--emit-claims", "--audited", ""])
+    assert rc != 0 and ad.EMIT_REFUSAL_HEADER in err, (
+        f"`--audited ''` was ignored rather than refused: rc {rc}\n{err}"
+    )
+
+    # 🔴 NEGATIVE CONTROL — a checker that rejects everything is as useless as
+    # one that accepts everything. A well-formed sha still emits.
+    rc, out, err = run_main(
+        ["900", "--round", "1", "--emit-claims", "--audited", "abcd1234"]
+    )
+    assert rc == 0, err
+    blocks, malformed = ad.parse_claims_blocks([out[out.rindex("```audit-claims"):]])
+    # 🔴 DELIBERATELY NOT `audited_from == "abcd1234"`. That is the claim
+    # `..._audited_supplies_the_tip_a_round_one_emit_cannot_derive` owns, and
+    # re-asserting it here made mutants N3 and Y7 kill this row for someone
+    # else's reason — measured as EXTRA-KILLER. What this control claims is
+    # narrower and is the whole claim: a legitimate value is not rejected.
+    assert not malformed and len(blocks) == 1, (
+        f"the guard rejected a legitimate anchor: {blocks}, {malformed}"
+    )
+
+    # 🔴 NAMED BLIND SPOT, asserted so it cannot read as covered: a well-formed
+    # token that is no commit round-trips and is NOT caught. This script never
+    # resolves a sha — it refuses to touch the checkout at all.
+    rc, out, err = run_main(
+        ["900", "--round", "1", "--emit-claims", "--audited", "zzzzzzzz"]
+    )
+    assert rc == 0, (
+        "a non-sha token that round-trips cleanly is outside this guard's "
+        "reach, and the docstring says so — if it is now caught, widen the "
+        "claim rather than leaving this assertion inverted"
+    )
+
+
+def test_the_emitted_skeleton_carries_a_legend_for_its_two_fields():
+    """🔴 INVARIANT GUARD; its evidence is mutant Z5, not a base ref.
+
+    At `dd601793` there is no legend at all, so a red there is an absence the
+    fix adds rather than a wrong answer observed — which this module says
+    repeatedly is not evidence of anything.
+
+    The code and the docstrings were already correct and consistent about
+    `<from>` and `<to>`; the failure is at the HUMAN end, because a person
+    reasons from the emitted block and it carried no key to its own fields. The
+    operator wrote them the wrong way round in two consecutive briefs.
+
+    The legend sits OUTSIDE the fence, so the block it annotates must still
+    parse — asserted here, because a helpful line that breaks the parser would
+    trade one silent failure for another.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "3", "--emit-claims"], comments=[CLAIMS_BLOCK_R2]
+    )
+    assert rc == 0, err
+    tail = out[out.index("Paste this into the PR comment"):]
+    assert "legend:" in tail, f"the emitted block carries no legend:\n{tail}"
+    assert "the tip THIS round's audit READ" in tail
+    assert "the head THIS round's FIXES produced" in tail
+    blocks, malformed = ad.parse_claims_blocks([tail])
+    assert not malformed and len(blocks) == 1, (
+        f"the legend broke the parser it annotates: {malformed}\n{tail}"
+    )
+    # 🔴 The two fields are asserted PRESENT, never by value: which sha goes in
+    # `<from>` is `emit_anchor`'s claim and its own test's, and naming it here
+    # made mutant N3 kill this row for that test's reason.
+    assert blocks[0].audited_from and blocks[0].audited_to, (
+        f"the legend changed what the block parses to: {blocks[0]!r}"
+    )
+
+
+def test_the_degenerate_cause_list_scopes_the_omitted_flag_to_round_one():
+    """🟢 REGRESSION. Red at `dd601793`, where the clause was unscoped.
+
+    The banner offered "the `audited=` block was written with the fix tip in
+    its `<from>` position — which is what `--emit-claims` records when
+    `--audited` is omitted" flat, for every round. For round >= 2 omitting the
+    flag is CORRECT: `emit_from` falls back to `emit_anchor(newest)`, the
+    previous block's `<to>`, which IS the tip this round read. An operator
+    hitting the banner on a round-3 brief was told their emit was wrong and
+    pushed toward hand-typing a value — which is the trigger for the
+    `--audited` truncation above.
+
+    The behavioural half (omitting the flag at round >= 2 really is correct) is
+    owned by `..._records_the_tip_this_round_audited_not_the_range_anchor`; this
+    asserts the PROSE agrees with it, as a relationship between two clauses
+    rather than as a phrase.
+    """
+    text = norm(ad.directive("degenerate-range-causes"))
+    i = text.index("`--audited` is omitted")
+    tail = text[i:i + 120]
+    assert "AT ROUND 1" in tail, (
+        f"\n\nthe cause list blames an omitted `--audited` without scoping it "
+        f"to round 1:\n    …{tail}…\n"
+        "  From round 2 on the omission is correct, so this sends an operator "
+        "to hand-type a value into a field whose only safe content is a sha."
+    )
+    assert "from round 2 on, omitting it is correct" in text, (
+        "the clause names the round-1 case but never says what the other case "
+        "is, so a reader on round 3 still cannot tell whether it applies"
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -2918,10 +3345,32 @@ RED_AT_BASE_R4: frozenset[str] = frozenset({
     "test_an_uppercase_audited_sha_still_trips_the_degenerate_guard",
 })
 
+# 🔴 ROUND 5's base is the ROUND-4 TREE, `dd601793`. Measured the same way —
+# `git show dd601793:scripts/audit-dispatch.py` into a scratch tree with THIS
+# module copied in unchanged, `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`.
+# The counts are in the round-5 section of the module docstring.
+#
+# 🔴 TWO OF ROUND 5's SIX NEW TESTS ARE **NOT** HERE, and it is the same
+# distinction every earlier round had to make: their red at `dd601793` is an
+# ABSENCE the fix adds (no no-write sentence in two of the three states; no
+# legend at all), not a wrong answer observed. They are filed as guards with
+# mutants Z1/Z2 and Z5 as their evidence.
+RED_AT_BASE_R5: frozenset[str] = frozenset({
+    "test_no_checkout_state_grants_write_permission_over_the_assembly_checkout",
+    "test_the_toolchain_reason_is_true_in_both_checkout_states",
+    "test_emit_claims_refuses_an_audited_value_its_own_parser_cannot_read",
+    "test_the_degenerate_cause_list_scopes_the_omitted_flag_to_round_one",
+    # Pre-existing, and it MOVED with the fix: its positives asserted the
+    # round-4 wording ("PRIVATE worktree" / "IS worth reporting"). Its two
+    # NEGATIVES are untouched and run first, so it is still red at `e06461f7`
+    # on the false SHARED claim — it stays filed under that ref, not this one.
+})
+
 RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "abc41024": RED_AT_BASE_R2,
     "d9eb36a8": RED_AT_BASE_R3,
     "e06461f7": RED_AT_BASE_R4,
+    "dd601793": RED_AT_BASE_R5,
 }
 RED_AT_BASE: frozenset[str] = frozenset().union(*RED_AT_BASE_REFS.values())
 
@@ -3014,6 +3463,17 @@ INVARIANT_GUARDS_AND_LEDGERS = frozenset({
     # is the in-module negative control beside each.
     "test_the_fix_matrix_evidence_matches_the_two_ledgers",
     "test_control_the_fix_matrix_checker_catches_a_wrong_evidence_label",
+    # ------------------------------------------------------------------- #
+    # Round 5's guards. Both WERE run against `dd601793`; they are here
+    # because of HOW they fail there.
+    # ------------------------------------------------------------------- #
+    # The RELATIONSHIP half of the write-permission pair. At `dd601793` two of
+    # the three checkout states simply do not carry the no-write sentence —
+    # an absence the fix adds, not a wrong answer — so its evidence is mutants
+    # Z1 (a state drops the rule) and Z2 (a fourth state with no rule).
+    "test_every_checkout_state_carries_the_no_write_rule",
+    # There is no legend at `dd601793` at all. Mutant Z5 deletes it again.
+    "test_the_emitted_skeleton_carries_a_legend_for_its_two_fields",
 })
 
 # --------------------------------------------------------------------------- #
@@ -3201,6 +3661,38 @@ FIX_MATRIX = (
      "RED_AT_BASE entry could drop out of it silently",
      "test_the_fix_matrix_evidence_matches_the_two_ledgers",
      "GUARD", "IN-MODULE CONTROL"),
+
+    # ------------------------------------------------------------------ #
+    # 🔴 ROUND 5. Base `dd601793`.
+    # ------------------------------------------------------------------ #
+    ("r5/1a THE CHECKOUT granted WRITE permission over the assembling "
+     "session's tree — 'yours alone … Writing here is fine'",
+     "test_no_checkout_state_grants_write_permission_over_the_assembly_checkout",
+     "RED@dd601793", "Z1"),
+    ("r5/1b the no-write rule must live in EVERY checkout state, not only in "
+     "a `no-fetch` clause a later round can make conditional",
+     "test_every_checkout_state_carries_the_no_write_rule",
+     "GUARD", "Z1, Z2"),
+    ("r5/1c `no-fetch` was reworded from unconditional to conditional on a "
+     "state the script cannot know, disarming it in production",
+     "test_each_clause_carries_the_instruction_its_ledger_entry_names",
+     "GUARD", "Z3"),
+    ("r5/2  TOOLCHAIN's rationale called the assembly checkout the SHARED "
+     "CHECKOUT two bars after THE CHECKOUT denied it",
+     "test_the_toolchain_reason_is_true_in_both_checkout_states",
+     "RED@dd601793", "Z4"),
+    ("r5/3  --audited accepted any string; a value with a space, an embedded "
+     "`..` or a placeholder was truncated by the emitter's own parser",
+     "test_emit_claims_refuses_an_audited_value_its_own_parser_cannot_read",
+     "RED@dd601793", "Z6, Z7"),
+    ("r5/4  the degenerate-cause list blamed an omitted --audited on rounds "
+     "where omitting it is correct",
+     "test_the_degenerate_cause_list_scopes_the_omitted_flag_to_round_one",
+     "RED@dd601793", "Z8"),
+    ("r5/5  the emitted block carried no key to its own two fields, and the "
+     "operator wrote them the wrong way round twice running",
+     "test_the_emitted_skeleton_carries_a_legend_for_its_two_fields",
+     "GUARD", "Z5"),
 )
 
 # A COLLAPSE floor, not a growth floor: a matrix emptied by a bad refactor
@@ -3210,12 +3702,13 @@ FIX_MATRIX = (
 # hand-picked floor drifts from what it is protecting.
 #
 # 🔴 COUNTED, not estimated. This comment first said "at m = 48 that is 46" and
-# BOTH numbers were wrong: the matrix holds 47 rows, and the formula gives
+# BOTH numbers were wrong: the matrix held 47 rows, and the formula gives
 # 47 - max(1, 2) = 45. Caught by counting the rows instead of trusting the
-# sentence — which is the same move as 🟢 "count them in the ledger" elsewhere
-# in this round, and it is recorded because an arithmetic claim nobody re-runs
-# is precisely what 🟡3 was about.
-MIN_FIX_MATRIX_ROWS = 45
+# sentence — which is the same move as 🟢 "count them in the ledger" elsewhere,
+# and it is recorded because an arithmetic claim nobody re-runs is precisely
+# what that finding was about. Round 5 added seven rows: m = 54, and
+# 54 - max(1, 54 // 20) = 52. Counted again, not extrapolated.
+MIN_FIX_MATRIX_ROWS = 52
 
 # 🔴 THE MUTANTS COLUMN IS AN EVIDENCE CLAIM, AND IT WAS UNGRADED.
 # `fix_matrix_problems` took `_mutants` and threw it away, so rewriting a
@@ -3364,11 +3857,20 @@ def test_the_fix_matrix_evidence_matches_the_two_ledgers():
     # 🔴 CONTAINMENT, and it is the half that was missing entirely: every test
     # filed as regression coverage names a FINDING, and a finding with no row
     # here is a finding this matrix silently stopped asserting anything about.
-    # Nine round-2 detectors and one round-3 detector were in that state.
-    orphaned = RED_AT_BASE - {row[1] for row in FIX_MATRIX}
+    #
+    # 🔴 THE COUNT IS COMPUTED, and round 5 made it so. It read "Nine round-2
+    # detectors and one round-3 detector were in that state" — TEN over a set
+    # with NINE distinct members, because one test is red at two bases and
+    # carries a row for each. A hand-written count beside data that grows is a
+    # claim nobody re-reads, and this module has now carried three of them; the
+    # numbers below come out of the ledgers themselves.
+    detectors = {row[1] for row in FIX_MATRIX}
+    orphaned = RED_AT_BASE - detectors
     assert not orphaned, (
-        f"\n\n{len(orphaned)} test(s) are filed as regression coverage for a "
-        f"real defect and appear in NO matrix row: {sorted(orphaned)}\n"
+        f"\n\n{len(orphaned)} of {len(RED_AT_BASE)} test(s) filed as "
+        "regression coverage for a real defect appear in NO matrix row: "
+        f"{sorted(orphaned)}\n"
+        f"  ({len(RED_AT_BASE & detectors)} of them do have one.)\n"
         "  The ledger says each was watched RED at a named base, so each is a "
         "finding. Give it a row, or explain in the ledger why it is not one."
     )

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -2909,6 +2909,71 @@ _PRESCRIBED_COMMAND = re.compile(r"`audit-dispatch\.py ([^`]+)`")
 _FILL_IN = re.compile(r"<[^>]*>")
 PRESCRIPTION_SHA = "beefcafe"
 
+# The literal every prescription is spelled with. The usage block at the top of
+# the script writes the same name WITHOUT a backtick, so this does not match it
+# — which is correct: a usage line is not a remedy handed to an operator who
+# just hit a refusal.
+_PRESCRIPTION_LITERAL = "`audit-dispatch.py "
+
+
+def prescription_sites():
+    """-> {(first line, last line)} of every `print()` that prescribes a re-run.
+
+    🔴 ROUND 12 — READ OUT OF THE SCRIPT, NOT LISTED HERE. The guard below
+    calls itself a CLASS guard ("a third refusal that prescribes a command it
+    refuses fails here without anyone remembering to add a row") over two
+    HARDCODED inputs. That sentence is a coverage claim, and it was true only
+    by accident of there being exactly two sites today: an eighth refusal
+    reached by a different input would be prescribed, unrun, and unreported,
+    while the docstring went on promising otherwise. `claude/RULES.md` ->
+    guards-narrower: make the implementation as wide as the sentence.
+    """
+    src = SCRIPT.read_text(encoding="utf-8")
+    out = set()
+    for node in ast.walk(ast.parse(src)):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                and node.func.id == "print"):
+            continue
+        if _PRESCRIPTION_LITERAL in (ast.get_source_segment(src, node) or ""):
+            out.add((node.lineno, node.end_lineno))
+    return out
+
+
+def run_main_traced(argv, **kw):
+    """`run_main`, plus the set of `audit-dispatch.py` LINES the run executed.
+
+    🔴 ATTRIBUTION, not textual matching. The two refusals render prescriptions
+    that are BYTE-IDENTICAL under this module's fixtures (`--round 3` over a
+    `round=2` block makes both say `--round 2 --emit-claims …`), so a scan of
+    stderr cannot tell which site produced one — and a coverage claim built on
+    that would report both sites reached when only one ever ran. A line trace
+    can, because the two `print()` calls occupy disjoint line spans.
+
+    The previous trace function is saved and restored: a coverage runner or a
+    debugger installs its own, and clobbering it would break the tool rather
+    than this test.
+    """
+    out, err = io.StringIO(), io.StringIO()
+    runner = kw.pop("runner", None) or make_runner(**kw)
+    executed = set()
+
+    def trace_lines(frame, event, _arg):
+        if event == "line":
+            executed.add(frame.f_lineno)
+        return trace_lines
+
+    def trace_calls(frame, event, _arg):
+        return trace_lines if frame.f_code.co_filename == str(SCRIPT) else None
+
+    previous = sys.gettrace()
+    sys.settrace(trace_calls)
+    try:
+        rc = ad.main(argv, runner=runner, stdout=out, stderr=err,
+                     checklist_reader=fake_checklist)
+    finally:
+        sys.settrace(previous)
+    return rc, out.getvalue(), err.getvalue(), executed
+
 
 def prescribed_commands(err):
     """Every `audit-dispatch.py …` command a refusal PRINTED, as argv lists."""
@@ -2944,6 +3009,17 @@ def test_every_command_a_refusal_prescribes_actually_runs():
     🔴 THE GUARD IS THE CLASS, NOT THE TWO SITES. It reads the commands out of
     whatever the refusal printed and RUNS them; a third refusal that prescribes
     a command it refuses fails here without anyone remembering to add a row.
+
+    🔴 ROUND 12 MADE THAT SENTENCE TRUE. It was a claim about PRESCRIPTIONS
+    made by a loop over two HARDCODED inputs, so it covered a third refusal
+    only if that refusal happened to be reached by one of those two — and an
+    eighth refusal reached by a different input would have been prescribed,
+    never run, and never reported, under a docstring promising otherwise. The
+    prescription SITES are now read out of the script (`prescription_sites`)
+    and the cases must reach every one of them, attributed by LINE TRACE
+    because the two sites' rendered text is byte-identical under these
+    fixtures. Coverage is complete today; what changed is that it stays
+    complete or this goes red.
     """
     bad_block = (
         "```audit-claims round=2 audited=..\n"
@@ -2954,8 +3030,20 @@ def test_every_command_a_refusal_prescribes_actually_runs():
         "REFUSAL 1b (anchorless block)": {"comments": [bad_block]},
         "REFUSAL 1 (no block at all)": {"comments": []},
     }
+    sites = prescription_sites()
+    # POSITIVE CONTROL for the scanner: an empty site set makes the coverage
+    # assertion at the foot vacuously true, which is the reassuring zero
+    # `claude/RULES.md` says to feed a case that must move.
+    assert sites, (
+        "no `print()` in the script prescribes an `audit-dispatch.py` re-run "
+        f"at all — {_PRESCRIPTION_LITERAL!r} matched nothing, so the coverage "
+        "assertion below would pass over an empty set. Either the remedies "
+        "moved out of `print()` or the literal changed."
+    )
+    reached = set()
     for name, kw in cases.items():
-        rc, _out, err = run_main(["900", "--round", "3"], **kw)
+        rc, _out, err, executed = run_main_traced(["900", "--round", "3"], **kw)
+        reached |= {s for s in sites if any(s[0] <= n <= s[1] for n in executed)}
         assert rc == 2, f"{name}: expected the refusal, got rc {rc}"
         commands = prescribed_commands(err)
         # POSITIVE CONTROL for the extractor: a refusal that prescribes nothing
@@ -2974,6 +3062,18 @@ def test_every_command_a_refusal_prescribes_actually_runs():
                 "A refusal that prescribes a command it refuses reads to the "
                 "operator as their own error."
             )
+    unreached = sites - reached
+    assert not unreached, (
+        f"\n\n{len(unreached)} of the script's {len(sites)} prescription "
+        f"site(s) were never executed by any case here — lines {sorted(unreached)}.\n"
+        "  Each prints an `audit-dispatch.py …` remedy to an operator who has "
+        "just been refused, and nothing in this module has ever RUN what they "
+        "print. Add a case whose input reaches that refusal; the two here are "
+        "an anchorless `audited=` header and no block at all.\n"
+        "  This assertion is what makes this guard's docstring true: without "
+        "it the loop above covers whichever refusals these two inputs happen "
+        "to reach, and reads as covering all of them."
+    )
 
 
 def test_control_the_prescription_extractor_can_see_a_broken_remedy():

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -95,6 +95,32 @@ restates the diff). Round 3's guards are listed in
 `INVARIANT_GUARDS_AND_LEDGERS` with the reason each is a guard and the mutant
 that proves it executes.
 
+🔴 ROUND 4 — a third base, `e06461f7`
+--------------------------------------
+Round 4's audit found four 🟡 in the ROUND-3 tree, **two of them in code that
+round wrote**: the round-1 -> round-2 hop was empty by construction and
+`--emit-claims` was silent about it (the self-range warning was spelled on a
+field that is None at round 1, so it was structurally unreachable for the one
+spelling it was for); both new degenerate-range messages blamed "the round's
+fix commits are not in this checkout" over a checkout `anchor_is_head` had
+just verified to BE the PR's head; the "which blocks are NOT pinned" comment
+claimed a coverage that did not exist over an enumeration that was incomplete;
+and THE SHARED CHECKOUT asserted "shared" of whatever cwd was, including a
+private per-agent worktree — telling that auditor the movement it should
+report is expected and not a finding.
+
+Measured at `e06461f7` the same way: **15 failed, 68 passed**, of which FIVE
+are regression coverage. `RED_AT_BASE_R4` carries them and the constant says
+why the other ten are guards.
+
+🔴 THE FIX MATRIX GAINED TWO CHECKS IT DID NOT HAVE, and both were holes the
+round-4 audit found in this module's own bookkeeping: the `mutants` column was
+DISCARDED by `fix_matrix_problems` (rewriting a GUARD row to name a mutant that
+does not exist left the suite green, while for a GUARD row that column IS the
+evidence), and nothing required a `RED_AT_BASE` entry to appear in the matrix
+at all — nine round-2 detectors and one round-3 detector were in that state,
+so five findings could have dropped out with nothing going red.
+
 🔴 FINDING 3's PRESCRIPTION WAS WRONG ON ONE POINT, and it is recorded because
 the next person will reach for the same field: the audit said to use
 `isCrossRepository` + **`baseRepository`**. `gh pr view --json` HAS NO
@@ -118,8 +144,9 @@ rows that justified adding a pin. Each row there names the EXACT killer set and
 reports WRONG-KILLER (an expected pin did not fire) separately from EXTRA-KILLER
 (the row no longer isolates what it names).
 
-Re-run 2026-08-28 against HEAD of this branch after the round-3 fixes — **52
-rows, all as expected** — each mutant applied to a COPY of
+Re-run 2026-08-28 against HEAD of this branch after the round-4 fixes — **67
+rows, all as expected**, over an 83-test positive control — each mutant applied
+to a COPY of
 `scripts/audit-dispatch.py` in a scratch tree (never the worktree), under
 `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`, with the unmutated copy as the
 positive control. Every mutant asserted its target string present before
@@ -140,13 +167,30 @@ they are recorded because both are the shape this file warns about elsewhere:
     neighbouring test's assertion (the `<to>` sha) and had parsed the FIRST
     `audit-claims` fence in the output rather than the emitted one.
 
-The rows below are the pre-existing sixteen. The thirty-six added since —
+The rows below are the pre-existing sixteen. Everything added since —
 W1-W5 + S1, H1-H4, T1-T2, P1-P2, K1-K3, L1, B1-B5 in round 2; N1-N8, X1-X3, XA
-and the SURVIVES control XS in round 3 — are listed in the harness with their
-killer sets and are NOT transcribed here; the harness is the authority on which
-rows exist.
+and the SURVIVES control XS in round 3; Y1-Y14 in round 4 — is listed in the
+harness with its killer set and is NOT transcribed here; the harness is the
+authority on which rows exist.
+
+🔴 ROUND 4 RE-TARGETED FIVE PRE-EXISTING ROWS AND SHIFTED SEVEN KILLER SETS,
+and both kinds are worth reading before trusting any row here. S1 and N6
+reported MUTATION DID NOT APPLY (the `no-fetch` clause was reworded; the emit
+warning's predicate moved onto the next round's anchor) — without the
+assert-before-editing rule each would have scored as "the guard held". XA's
+expected set had to CHANGE rather than grow: the hazard it names is now caught
+one guard earlier, and leaving the old name there would have left a DEAD pin
+reading as coverage.
+
+🔴 ROUND 4 ALSO INTRODUCED A THIRD EXPECTATION, `HOLE`, and it is not a synonym
+for `SURVIVES`. `SURVIVES` is a control (a pin must not be keyed to layout);
+`HOLE` is a measured GAP (Y3-Y5: three operative sentences nothing guards).
+Printing "SURVIVED as required (control)" over an unguarded sentence is exactly
+the flattering wrong answer this battery exists to refuse.
 
   POS  unmutated copy .............................. 72 passed  <- control
+       (that figure is the ROUND-2 control; today's is 83 — the harness
+        prints the current one, which is the number to read)
 
   D1   delete the `read-only` clause ............... 4 failed
   D3   delete the `stop-rule` clause ............... 4 failed
@@ -263,6 +307,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -319,11 +364,19 @@ CLAUSE_LEDGER = {
         "pointing at the real git dir, so a commit inside the copy lands on "
         "the branch you are auditing."
     ),
+    # 🔴 REWORDED IN ROUND 4, deliberately, and the ledger moves with it. The
+    # clause used to name "THE SHARED CHECKOUT section", a heading that only
+    # existed because the brief asserted SHARED of every checkout. THE CHECKOUT
+    # section is now three-state, so the clause names the section and lets the
+    # section say whether the tree it describes is shared — otherwise the
+    # clause forbids an auditor from writing to their OWN private worktree,
+    # contradicting `own-worktree-is-writable` in the same brief.
     "no-fetch": (
-        "**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to the "
-        "shared checkout named in THE SHARED CHECKOUT section of this brief.** "
-        "Other sessions are in it; a fetch there is a write with cross-session "
-        "blast radius, and every ref you need is already resolved for you here."
+        "**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to a "
+        "SHARED checkout — THE CHECKOUT section of this brief says whether "
+        "the one it names is shared.** Other sessions are in a shared tree; a "
+        "fetch there is a write with cross-session blast radius, and every ref "
+        "you need is already resolved for you here."
     ),
     "stop-rule": (
         "**A clean round ENDS the ladder — ending it is the CORRECT outcome, "
@@ -447,6 +500,25 @@ OTHER_REPO_PR = dict(
 FAKE_REPO_DIR = "/fake/checkout/devrc"
 FAKE_ORIGIN = "git@github.com:example-org/devrc.git"
 
+# 🔴 The two paths `gather_worktree_kind` reads, in the shapes REAL git prints
+# them — measured at four points (repo root, repo subdirectory, linked
+# worktree, and this session's own agent worktree):
+#
+#     repo root        `.git`                          `.git`
+#     repo subdirectory `/abs/path/.git`               `../.git`
+#     linked worktree  `/abs/.git/worktrees/<name>`    `/abs/.git`
+#
+# The SUBDIRECTORY row is why the script resolves both paths before comparing
+# them: textually different, the same directory. A string compare there calls
+# every subdirectory of an ordinary clone a private worktree — wrong in the
+# direction that DROPS the no-write instruction.
+SHARED_GIT_DIRS = (0, ".git\n.git\n", "")
+PRIVATE_COMMON_DIR = f"{FAKE_REPO_DIR}/.git"
+PRIVATE_GIT_DIRS = (
+    0, f"{PRIVATE_COMMON_DIR}/worktrees/agent-7f3a\n{PRIVATE_COMMON_DIR}\n", ""
+)
+UNREADABLE_GIT_DIRS = (128, "", "fatal: not a git repository")
+
 CHECKLIST = (
     "**Audit for:**\n1. **Risks** — what breaks in production.\n"
     "9. **Second-order consequences** — ripple effects."
@@ -471,6 +543,7 @@ def make_runner(
     numstat=(0, "10\t2\tscripts/foo.py\n3\t0\tscripts/tests/test_foo.py\n", ""),
     head_sha="deadbee",
     local_head=None,
+    git_dirs=SHARED_GIT_DIRS,
 ):
     """A closed-world stand-in for `gh` and `git`. No process is spawned.
 
@@ -514,6 +587,13 @@ def make_runner(
             return 0, gh_stdout if gh_stdout is not None else json.dumps(payload), ""
         if cmd[:2] == ["git", "-C"]:
             verb = cmd[3]
+            # 🔴 BEFORE the other `rev-parse` rows: this one is identified by
+            # its FLAGS, and `cmd[-1] == "HEAD"` below would not match it but
+            # a future re-ordering could. `git_dirs` defaults to the SHARED
+            # answer, which is what every pre-existing test in this module
+            # assumes and asserts.
+            if verb == "rev-parse" and "--git-common-dir" in cmd:
+                return git_dirs
             if verb == "rev-parse" and "--show-toplevel" in cmd:
                 return 0, toplevel + "\n", ""
             if verb == "rev-parse" and "--abbrev-ref" in cmd:
@@ -802,7 +882,128 @@ DIRECTIVE_LEDGER = {
         "and NOT a finding. **Report what you observed moving and carry on; do "
         "not chase it, and do not try to restore it.**"
     ),
+    # ---------------------------------------------------------------- #
+    # 🔴 ROUND 4's five. Two of them (`delta-scope`,
+    # `own-worktree-is-writable`) are Y1 and Y2 — verbatim operative prose
+    # measured invertible against all 199 audit-related tests while every one
+    # stayed green. Two more are the states `checkout-moves` asserted its way
+    # past, and the fifth is the one writer for a cause list that was FALSE at
+    # both of its two sites.
+    # ---------------------------------------------------------------- #
+    "delta-scope": (
+        "**Audit ONLY that range — do NOT re-audit the whole PR.** Everything "
+        "below the range is work a previous round already dispositioned; "
+        "re-reading it re-reports findings that were answered, buries the "
+        "delta this round exists to examine, and makes the round's cost "
+        "indistinguishable from a first full audit."
+    ),
+    "degenerate-range-causes": (
+        "Either the `audited=` block was written with the fix tip in its "
+        "`<from>` position — which is what `--emit-claims` records when "
+        "`--audited` is omitted, and what a bare round-1 `audited=<sha>` "
+        "always means; `<from>` is the tip the PREVIOUS round AUDITED, so "
+        "re-emit that block with `--audited <the tip that round actually "
+        "read>` and re-assemble — or nothing has been committed and pushed to "
+        "the PR since that sha was recorded, in which case there is no delta "
+        "to audit yet. 🔴 What is NOT a cause: the round's fix commits being "
+        "absent from this checkout. This checkout was VERIFIED at assembly "
+        "time to be the PR's head commit, and that verification is the very "
+        "thing that makes this range DEGENERATE rather than merely "
+        "unmeasurable — so fetching or checking out here could not help, and "
+        "the `no-fetch` clause forbids it anyway."
+    ),
+    "checkout-private": (
+        "🔴 **This is a PRIVATE worktree — yours alone.** Its `.git` is a link "
+        "into a shared repository, but the WORKING TREE is not shared, so "
+        "files appearing, vanishing or changing under you is **NOT expected "
+        "here and IS worth reporting** — that is the sibling-agent clobber "
+        "`claude/RULES.md` describes, not background noise. **If something "
+        "moves, report it with what moved and when.** Writing here is fine: "
+        "the no-write clause below is about a SHARED checkout, and this is "
+        "not one."
+    ),
+    "checkout-unknown": (
+        "🔴 **COULD NOT DETERMINE whether this checkout is shared** — the "
+        "`git rev-parse --git-dir --git-common-dir` read that decides it did "
+        "not answer. **Treat it as SHARED and write nothing to it.** But do "
+        "NOT treat anything you see move as expected: that absolution belongs "
+        "to a checkout KNOWN to be shared, and this one is not known to be "
+        "anything. If something moves, report it AND report that its cause "
+        "could not be established here."
+    ),
+    "own-worktree-is-writable": (
+        "That worktree is YOURS: fetching and checking out inside it is fine. "
+        "The no-write rule below is about the SHARED checkout."
+    ),
 }
+
+# 🔴 WHICH BRIEF EACH DIRECTIVE SHIPS IN — a second, independent ledger, and it
+# exists because the emitted-verbatim test used to assert that EVERY directive
+# reaches a DELTA brief. That was true while all three shipped unconditionally;
+# it is false the moment a directive is owned by a STATE (a private worktree, a
+# cross-repo PR, a degenerate range), and the cheap fix — dropping the
+# conditional ones from the check — would have retired the only test that
+# proves a directive reaches an artifact at all.
+#
+# Each value names a scenario built by `brief_for_scenario` below. Pinned
+# two-way against `DIRECTIVE_LEDGER`, so a directive with no scenario (an
+# instruction nobody can be shown to receive) fails, and a scenario naming no
+# directive fails.
+DIRECTIVE_RENDERS_IN = {
+    "claims-framing": "delta",
+    "delta-scope": "delta",
+    "delta-regressions": "delta",
+    "degenerate-range-causes": "degenerate",
+    "checkout-moves": "delta",
+    "checkout-private": "private-worktree",
+    "checkout-unknown": "unreadable-worktree",
+    "own-worktree-is-writable": "cross-repo",
+}
+
+
+_CHECKOUT_HEADING = re.compile(r"^## THE (?:SHARED )?CHECKOUT\b.*$", re.M)
+
+
+def checkout_section(brief):
+    """The checkout block, sliced WITHOUT depending on the round-4 heading.
+
+    🔴 Deliberately matches the OLD spelling (`## THE SHARED CHECKOUT`) as well
+    as the new one. Slicing on the new heading alone made two round-4 tests
+    fail at `e06461f7` with `ValueError: substring not found` — an error for
+    want of a name the fix introduced, which `claude/RULES.md` says is not
+    evidence of anything. With both spellings matched, the same tests fail
+    there on the WRONG ANSWER instead, which is the claim they are making.
+    """
+    m = _CHECKOUT_HEADING.search(brief)
+    assert m, f"no checkout section in the brief at all:\n{brief[:400]}"
+    rest = brief[m.end():]
+    nxt = rest.find("\n## ")
+    return brief[m.start():m.end() + (nxt if nxt != -1 else len(rest))]
+
+
+def brief_for_scenario(name):
+    """-> the stdout of a run that MUST carry the directive(s) mapped to it."""
+    if name == "delta":
+        argv, kw = ["900", "--round", "3"], {"comments": [CLAIMS_BLOCK_R2]}
+    elif name == "degenerate":
+        argv, kw = ["900", "--round", "3"], {
+            "comments": [CLAIMS_BLOCK_R2], "pr": SELF_RANGE_PR,
+        }
+    elif name == "private-worktree":
+        argv, kw = ["900"], {"git_dirs": PRIVATE_GIT_DIRS}
+    elif name == "unreadable-worktree":
+        argv, kw = ["900"], {"git_dirs": UNREADABLE_GIT_DIRS}
+    elif name == "cross-repo":
+        argv, kw = ["900"], {"pr": OTHER_REPO_PR}
+    else:
+        raise AssertionError(f"no such scenario: {name!r}")
+    rc, out, err = run_main(argv, **kw)
+    assert rc == 0, f"scenario {name!r} exited {rc}: {err}"
+    assert len(out) > 3_000, (
+        f"scenario {name!r} produced only {len(out)} chars — a presence "
+        "assertion over it would be a claim about nothing"
+    )
+    return out
 
 
 def test_the_section_directive_ledger_is_pinned_two_way():
@@ -854,31 +1055,70 @@ def test_each_section_directive_carries_the_instruction_its_ledger_entry_names()
         )
 
 
-def test_every_section_directive_is_emitted_verbatim_in_the_delta_brief():
+def test_the_directive_render_scenario_ledger_is_pinned_two_way():
+    """Every directive names a brief that carries it, and vice versa.
+
+    🔴 INVARIANT GUARD; its evidence is mutants XA and Y1/Y2 (a directive added
+    with no scenario, or one whose section stops rendering it). Without this,
+    a directive could be added to `SECTION_DIRECTIVES`, ledgered whole, and
+    reach NO brief at all — an instruction nobody receives, pinned word for
+    word, reading as coverage.
+    """
+    # 🔴 Against the SCRIPT's ids, not only against the sibling ledger. Two
+    # test-module constants compared with each other are unreachable by the
+    # mutation battery — a guard with no possible evidence — and the claim that
+    # matters is about the directives that SHIP, not about this file's
+    # bookkeeping. Mutant XA (add an unledgered directive) is what proves it
+    # executes.
+    in_script = {d.id for d in ad.SECTION_DIRECTIVES}
+    scoped = set(DIRECTIVE_RENDERS_IN)
+    assert in_script == scoped, (
+        "\n\n`SECTION_DIRECTIVES` and `DIRECTIVE_RENDERS_IN` disagree.\n"
+        f"  ships but never shown to render: {sorted(in_script - scoped)}\n"
+        f"  scoped but not in the script   : {sorted(scoped - in_script)}\n"
+        "  A directive with no scenario is an instruction nobody can be shown "
+        "to receive; a scenario with no directive asserts nothing."
+    )
+    assert set(DIRECTIVE_LEDGER) == scoped, (
+        "\n\n`DIRECTIVE_LEDGER` and `DIRECTIVE_RENDERS_IN` disagree: "
+        f"{sorted(set(DIRECTIVE_LEDGER) ^ scoped)}"
+    )
+
+
+def test_every_section_directive_is_emitted_verbatim_in_the_brief_that_owns_it():
     """POSITIVE CONTROL: the constant is not the artifact, the brief is.
 
-    All three ship in a DELTA brief. Two of them (`claims-framing`,
-    `delta-regressions`) are deliberately absent from a round-1 brief — "this
-    fix round" is meaningless when there has not been one — which is why they
-    are directives owned by their sections rather than invariant clauses.
+    🔴 THIS USED TO ASSERT THAT EVERY DIRECTIVE REACHES A DELTA BRIEF, which
+    was true only while all three shipped unconditionally. Five of the eight
+    are now owned by a STATE — a degenerate range, a private worktree, an
+    unreadable one, a cross-repo PR — so the delta brief carries three of them
+    and the old assertion would have to be weakened to nothing. It is driven by
+    `DIRECTIVE_RENDERS_IN` instead: each directive is looked for in a brief
+    built for ITS state, and the two-way pin above stops a directive from
+    quietly having no state at all.
     """
-    rc, out, err = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
-    assert rc == 0, err
-    assert len(out) > 3_000, (
-        f"the assembled brief is only {len(out)} chars — every presence "
-        "assertion below would be a claim about nothing."
-    )
-    for directive in ad.SECTION_DIRECTIVES:
-        assert directive.text in out, (
-            f"directive {directive.id!r} is in SECTION_DIRECTIVES but does NOT "
-            "reach the emitted delta brief."
-        )
-    rc, out1, err = run_main(["900"])
-    assert rc == 0, err
-    assert ad.DIRECTIVE["checkout-moves"] in out1, (
-        "the shared-checkout warning is missing from a ROUND-1 brief — that "
-        "one is not delta-specific and the checkout moves under a first audit "
-        "exactly as much"
+    # 🔴 Compared against the SCRIPT's own text, not against `DIRECTIVE_LEDGER`.
+    # This test owns RENDERING; text drift is owned by
+    # `..._carries_the_instruction_its_ledger_entry_names`. Reading the ledger
+    # here would make every reword kill both, and a row that dies to two guards
+    # cannot show which one is alive — mutants X1 and X3 exist precisely to
+    # prove the whole-string ledger fires ALONE.
+    by_scenario = {}
+    for did, scenario in DIRECTIVE_RENDERS_IN.items():
+        by_scenario.setdefault(scenario, []).append(did)
+    for scenario, dids in sorted(by_scenario.items()):
+        out = brief_for_scenario(scenario)
+        for did in sorted(dids):
+            assert did in ad.DIRECTIVE, f"directive {did!r} is gone"
+            assert ad.DIRECTIVE[did] in out, (
+                f"\n\ndirective {did!r} is scoped to the {scenario!r} brief "
+                "but does NOT reach it — the section that owns it stopped "
+                "rendering it, so the instruction ships to nobody."
+            )
+    # The shared-checkout warning is not delta-specific: a first audit stands
+    # in the same tree and it moves exactly as much.
+    assert ad.DIRECTIVE["checkout-moves"] in run_main(["900"])[1], (
+        "the shared-checkout warning is missing from a ROUND-1 brief"
     )
 
 
@@ -1741,6 +1981,360 @@ def test_emit_claims_stamps_the_prs_head_not_the_local_checkouts():
 
 
 # --------------------------------------------------------------------------- #
+# 🔴 ROUND 4 — THE ROUND-1 -> ROUND-2 HOP, WHICH WAS EMPTY BY CONSTRUCTION
+# --------------------------------------------------------------------------- #
+# Round 3 spelled the self-range warning on `same_commit(facts.emit_from, head)`
+# — and for a ROUND-1 `--emit-claims` there is no prior block, so `emit_from` is
+# None and the guard is STRUCTURALLY UNREACHABLE. The bare block it writes
+# instead carries the identical hazard: `range_anchor` falls back to `<to>`, and
+# `<to>` IS the head it was just stamped at. Round 1 is the remedy the delta
+# refusal ADVERTISES, so the unreachable case was the advertised one — and this
+# PR's own live round-1 block (`audited=abc41024`, bare, the round-1 FIX tip) is
+# the instance.
+
+def test_a_round_one_emit_claims_says_head_is_an_assumption_not_a_measurement():
+    """🔴 REGRESSION. Red at `e06461f7`, which emitted it in total silence.
+
+    The observable at the base is not a wrong sha — it is NO STDERR AT ALL over
+    a block whose single sha makes the next round's range empty by
+    construction. The next round then renders DEGENERATE and the tip round 1
+    actually read is recorded nowhere.
+    """
+    rc, out, err = run_main(["900", "--round", "1", "--emit-claims"])
+    assert rc == 0, err
+    tail = out[out.rindex("```audit-claims"):]
+    blocks, malformed = ad.parse_claims_blocks([tail])
+    assert not malformed and len(blocks) == 1, f"{malformed}\n{tail}"
+    # 🔴 The BARE spelling, and deliberately NOT `audited_to == <the PR head>`:
+    # that claim is owned by `..._stamps_the_prs_head_not_the_local_checkouts`,
+    # and re-asserting it here made mutant H3 (read the LOCAL head) kill this
+    # row too — a row that dies for someone else's reason is not evidence for
+    # the one it names.
+    assert blocks[0].audited_from == "" and blocks[0].audited_to, (
+        "the round-1 block is not the bare `audited=<sha>` spelling this "
+        f"warning is about: {blocks[0]!r}"
+    )
+    assert "ASSUMED" in err, (
+        "\n\n`--emit-claims` at round 1 stamped the PR's CURRENT head into the "
+        "field the next round anchors on and said nothing. It runs AFTER the "
+        "round's fixes land, so that head is the one the FIXES produced — not "
+        f"the tip the round read. stderr was:\n{err}"
+    )
+    assert "EMPTY BY CONSTRUCTION" in err and "--audited" in err, (
+        "the warning does not say what goes wrong next, or how to supply the "
+        f"sha it could not derive. stderr was:\n{err}"
+    )
+
+
+def test_audited_supplies_the_tip_a_round_one_emit_cannot_derive():
+    """🔴 INVARIANT GUARD — `--audited` does not exist at `e06461f7`.
+
+    A test that fails there fails with `unrecognized arguments`, which is an
+    error for want of a name the fix introduced and is not evidence of
+    anything. Its evidence is mutant Y7 (the flag is parsed and ignored).
+
+    The assertion is END TO END on purpose: the emitted block is fed back
+    through this script's OWN parser as the next round's comment, because the
+    only thing that matters about the field is what the next round anchors on.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "1", "--emit-claims", "--audited", "abcd1234"]
+    )
+    assert rc == 0, err
+    tail = out[out.rindex("```audit-claims"):]
+    blocks, malformed = ad.parse_claims_blocks([tail])
+    assert not malformed and len(blocks) == 1, f"{malformed}\n{tail}"
+    assert blocks[0].audited_from == "abcd1234", (
+        f"\n\n`--audited abcd1234` did not reach the block's `<from>`: "
+        f"{blocks[0]!r}. That field is the ONLY way a round-1 comment can "
+        "record the tip its audit read; --emit-claims runs after the fixes and "
+        "cannot derive it."
+    )
+    # The `<to>` half is owned by `..._stamps_the_prs_head_not_the_local_...`
+    # and is deliberately not re-asserted here — see the sibling test.
+    assert "ASSUMED" not in err, (
+        f"the assumption warning still fired with --audited passed: {err}"
+    )
+
+    emitted = "\n".join(tail.splitlines()[:4])
+    rc2, out2, err2 = run_main(["900", "--round", "2"], comments=[emitted])
+    assert rc2 == 0, err2
+    assert "`abcd1234..HEAD`" in out2, (
+        "\n\nthe next round does not anchor on the tip round 1 audited, so the "
+        "round-1 -> round-2 hop still loses round 1's own fix commits."
+    )
+    assert "DEGENERATE RANGE" not in out2
+
+
+def test_audited_without_emit_claims_says_it_changed_nothing():
+    """🔴 INVARIANT GUARD (the flag does not exist at `e06461f7`); mutant Y8.
+
+    A flag that silently does nothing is the shape this module refuses
+    everywhere else. `--audited` is written by `--emit-claims` and by nothing
+    else, so an operator who passes it to a plain assembly run must not read
+    the silence as "recorded".
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "3", "--audited", "abcd1234"],
+        comments=[CLAIMS_BLOCK_R2],
+    )
+    assert rc == 0, err
+    assert "--audited" in err and "changed NOTHING" in err, (
+        f"the ignored flag was accepted in silence; stderr was:\n{err}"
+    )
+    assert "`aaaa1111..HEAD`" in out, (
+        "worse than silence: `--audited` moved the range this round DIFFS "
+        "from. It is the WRITER's anchor and must not touch the reader's."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 ROUND 4 — THE DEGENERATE-RANGE CAUSES, WHICH `anchor_is_head` REFUTES
+# --------------------------------------------------------------------------- #
+# `anchor_is_head` returns True only when `head_check.ok` — this checkout is
+# VERIFIED to be the PR's head. Both degenerate-range messages nevertheless
+# offered "the round's fix commits are not in this checkout", sending the
+# operator to fetch commits into a checkout that already has them, which the
+# brief's own `no-fetch` clause forbids there.
+
+# The spellings a message could use to claim the commits are absent. 🔴 This
+# probe is NOT what makes the guard non-walkable — a reword could step around
+# it. Its job is to be RED AT THE BASE, i.e. to observe the wrong answer that
+# shipped. Non-walkability comes from the whole-string `DIRECTIVE_LEDGER` pin
+# on `degenerate-range-causes` and from the writer ledger below it.
+ABSENT_COMMIT_CLAIMS = (
+    "not in this checkout",
+    "does not have them",
+    "checkout does not have",
+)
+
+
+def test_a_degenerate_range_does_not_blame_a_checkout_it_verified():
+    """🔴 REGRESSION. Red at `e06461f7`, at BOTH of its two sites.
+
+    The round-3 fix for this class said in its own commit message that it went
+    "to the CLASS rather than to one site" — and then wrote two new sites with
+    the same false cause nine lines below the one it fixed. So this asserts
+    over both consumers in one test: they are one hazard with two renderers,
+    and a test scoped to either would have passed at the base.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2], pr=SELF_RANGE_PR
+    )
+    assert rc == 0, err
+    sections = {
+        "THE RANGE": out[out.index("## THE RANGE"):out.index("## WHAT WAS CLAIMED")],
+        "THE LEDGER": out[out.index("## THE LEDGER"):],
+    }
+    for name, text in sections.items():
+        assert "EMPTY BY CONSTRUCTION" in text, (
+            f"{name} does not report the degenerate range at all, so this "
+            "test is asserting over the wrong slice"
+        )
+        for phrase in ABSENT_COMMIT_CLAIMS:
+            assert phrase not in text, (
+                f"\n\n{name} offers {phrase!r} as a cause for a range it "
+                "reached only because `anchor_is_head` confirmed this checkout "
+                "IS the PR's head commit. The operator is told to get commits "
+                "into a checkout that already has them — and the `no-fetch` "
+                "clause forbids that action there."
+            )
+        assert norm(DIRECTIVE_LEDGER["degenerate-range-causes"]) in norm(text), (
+            f"\n\n{name} does not carry the ledgered cause list, so it is "
+            "hand-rolling its own again — which is how the two sites drifted "
+            "apart from the one nine lines above them."
+        )
+
+
+def test_the_degenerate_range_causes_have_exactly_one_writer_per_consumer():
+    """🔴 INVARIANT GUARD, and the STRUCTURAL half of the pair above.
+
+    A seam guard in the `claude/RULES.md` sense: an asserted ledger of every
+    site that renders this cause list, failing when the set GROWS (a third
+    consumer joined with nobody reading its prose) or SHRINKS (a consumer went
+    back to hand-rolling). The phrase probe above cannot see either.
+
+    🔴 THE RESIDUAL BLIND SPOT, said rather than left to read as covered: a
+    BRAND-NEW degenerate surface that never calls `directive()` at all is
+    invisible here. Nothing mechanical in this module can see prose that has
+    not been written yet.
+    """
+    src = SCRIPT.read_text(encoding="utf-8")
+    sites, fn = set(), None
+    for line in src.splitlines():
+        m = re.match(r"def (\w+)\(", line)
+        if m:
+            fn = m.group(1)
+        if 'directive("degenerate-range-causes")' in line and fn:
+            sites.add(fn)
+    assert sites == {"measure_ledger", "render_range"}, (
+        f"\n\nthe degenerate-range cause list is rendered by {sorted(sites)}, "
+        "not by exactly the two consumers this ledger names.\n"
+        "  GREW: a new site renders auditor-facing prose that nobody reviewed "
+        "against `head_check`'s guarantee.\n"
+        "  SHRANK: a consumer is hand-rolling its own causes again — which is "
+        "the defect, not a refactor."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 ROUND 4 — "THE SHARED CHECKOUT" NAMED WHATEVER CWD WAS
+# --------------------------------------------------------------------------- #
+
+def test_a_private_worktree_is_not_described_as_shared_and_is_not_absolved():
+    """🔴 REGRESSION. Red at `e06461f7`, which asserted SHARED of every tree.
+
+    Run from `…/.claude/worktrees/agent-…` — where a dispatched auditor
+    usually stands — the brief printed a heading reading THE SHARED CHECKOUT
+    over "This checkout is SHARED with other sessions and agents. It MOVES
+    UNDER YOU … That is expected and is NOT your fault and NOT a finding."
+
+    🔴 The DIRECTION is the consequential half, and it is what this asserts:
+    an auditor in a private worktree who watches files move is told it is
+    expected and not a finding, which suppresses exactly the sibling-agent
+    clobber `claude/RULES.md` says to report.
+    """
+    checkout = checkout_section(brief_for_scenario("private-worktree"))
+    # 🔴 THE NEGATIVES FIRST, deliberately. Asserting "PRIVATE worktree" is
+    # present first would make this test fail at the base for want of a WORD
+    # the fix introduced; failing on the two false claims below is failing on
+    # the wrong ANSWER, which is what makes this regression coverage rather
+    # than a restatement of the diff.
+    assert "SHARED with other sessions" not in checkout, (
+        f"\n\nthe brief calls a PRIVATE per-agent worktree shared:\n{checkout}"
+    )
+    assert "NOT a finding" not in checkout, (
+        "\n\nthe brief absolves movement in a tree that is the auditor's "
+        "alone. That absolution is what suppresses a sibling-agent clobber "
+        "report — the one signal a private worktree can produce."
+    )
+    assert "PRIVATE worktree" in checkout
+    assert "IS worth reporting" in checkout
+
+
+def test_an_unreadable_worktree_state_is_its_own_answer_and_keeps_the_no_write():
+    """🔴 INVARIANT GUARD — the third state; mutant Y6 collapses it.
+
+    Same three-state rule as `render_worktree_directive`: not knowing is its
+    own answer, and it must keep the conservative instruction (write nothing)
+    WITHOUT the absolution (movement is expected). Collapsing it either way
+    picks a branch whose failure is silent.
+    """
+    checkout = checkout_section(brief_for_scenario("unreadable-worktree"))
+    assert "COULD NOT DETERMINE" in checkout
+    assert "write nothing to it" in checkout, (
+        "the unknown state dropped the conservative no-write instruction"
+    )
+    assert "NOT a finding" not in checkout, (
+        "the unknown state kept the absolution. The conservative half of "
+        "'treat it as shared' is the no-write rule; the absolution is the "
+        "half that costs a report."
+    )
+    # And the SHARED state still says what it always said.
+    shared = brief_for_scenario("delta")
+    assert "SHARED with other sessions" in shared and "NOT a finding" in shared
+
+
+def test_gather_worktree_kind_resolves_paths_before_comparing_them():
+    """🔴 INVARIANT GUARD — `gather_worktree_kind` does not exist at the base.
+
+    🔴 MEASURED AT THREE SHAPES, because one measurement here is not a claim:
+    real `git rev-parse --git-dir --git-common-dir` answers `.git`/`.git` at a
+    repo ROOT, `/abs/path/.git`/`../.git` in a repo SUBDIRECTORY, and
+    `/abs/.git/worktrees/<n>`/`/abs/.git` in a linked worktree. The middle row
+    is the trap: textually different, the same directory. Comparing the strings
+    calls every subdirectory of an ordinary clone a PRIVATE worktree — wrong in
+    the direction that drops the no-write instruction. `gather_repo_facts`
+    falls back to the raw cwd when `--show-toplevel` fails, so that row is
+    reachable in production. Mutant Y5b.
+    """
+    def stub(answer):
+        def runner(cmd, cwd=None):
+            assert "--git-common-dir" in cmd, cmd
+            return answer
+        return runner
+
+    root = ad.gather_worktree_kind(stub(SHARED_GIT_DIRS), FAKE_REPO_DIR)
+    assert root.kind == "shared", root
+
+    subdir = ad.gather_worktree_kind(
+        stub((0, f"{FAKE_REPO_DIR}/.git\n../.git\n", "")),
+        f"{FAKE_REPO_DIR}/sub",
+    )
+    assert subdir.kind == "shared", (
+        f"\n\na SUBDIRECTORY of an ordinary clone was classified {subdir!r}. "
+        "git answers `/abs/.git` and `../.git` there — different strings, the "
+        "same directory."
+    )
+
+    linked = ad.gather_worktree_kind(stub(PRIVATE_GIT_DIRS), FAKE_REPO_DIR)
+    assert linked.kind == "private", linked
+
+    for broken in (UNREADABLE_GIT_DIRS, (0, ".git\n", "")):
+        got = ad.gather_worktree_kind(stub(broken), FAKE_REPO_DIR)
+        assert got.kind == "unknown" and got.reason, (
+            f"a read that answered {broken!r} was not reported as unknown: "
+            f"{got!r}"
+        )
+
+
+def test_the_where_to_work_section_does_not_call_a_private_worktree_the_clone():
+    """🔴 REGRESSION. Red at `e06461f7`.
+
+    The repo RELATION is unaffected — a linked worktree really is the same
+    repository, and the isolation recommendation stays correct. The PATH is
+    not the shared clone, and the brief said it was: "the PR lives in
+    `<org>/devrc`, which is this session's own repository
+    (`…/worktrees/agent-…`)".
+    """
+    out = brief_for_scenario("private-worktree")
+    where = out[out.index("## WHERE TO WORK"):out.index("## THE RANGE")]
+    assert ad.ISOLATION_RECOMMEND in where, (
+        "the private-worktree case is still a SAME-REPO PR and the flag is "
+        "still right; only the description of the path was wrong"
+    )
+    assert "this session's own repository" not in where, (
+        f"\n\nthe brief names a private per-agent worktree as the session's "
+        f"repository, full stop:\n{where}"
+    )
+    assert "PRIVATE linked worktree" in where
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 ROUND 4 — `same_commit` WAS CASE-SENSITIVE
+# --------------------------------------------------------------------------- #
+
+def test_an_uppercase_audited_sha_still_trips_the_degenerate_guard():
+    """🔴 REGRESSION. Red at `e06461f7`, where one shift key disarmed the guard.
+
+    `git rev-parse` prints lowercase, but `audited=` is TYPED BY A HUMAN into a
+    PR comment. Compared case-sensitively, `ABC41024` is not the same commit as
+    `abc41024ff…`, `anchor_is_head` answers False at all three call sites, and
+    the confident "verified at assembly time to be PR #<n>'s head commit"
+    banner comes back over a range that cannot contain anything.
+    """
+    assert ad.same_commit("ABC41024", "abc41024ff00112233445566778899aabbccddee"), (
+        "`same_commit` is case-sensitive, so an upper- or mixed-case "
+        "`audited=` sha disables every degenerate-range guard in this script"
+    )
+    upper = (
+        "```audit-claims round=2 audited=AAAA1111..BBBB2222\n"
+        "1. a claim whose anchor was typed in upper case\n"
+        "```"
+    )
+    rc, out, err = run_main(
+        ["900", "--round", "3"], comments=[upper], pr=SELF_RANGE_PR
+    )
+    assert rc == 0, err
+    the_range = out[out.index("## THE RANGE"):out.index("## WHAT WAS CLAIMED")]
+    assert "DEGENERATE RANGE" in the_range, (
+        f"\n\nan UPPERCASE anchor equal to HEAD rendered as an ordinary "
+        f"range:\n{the_range}"
+    )
+    assert "verified at assembly time" not in the_range
+
+
+# --------------------------------------------------------------------------- #
 # THE LEDGER
 # --------------------------------------------------------------------------- #
 
@@ -2284,9 +2878,40 @@ RED_AT_BASE_R3: frozenset[str] = frozenset({
 # at both refs for two DIFFERENT reasons, so it is listed under both — which is
 # why the per-ref sets may overlap each other even though neither may overlap
 # the guard ledger.
+# 🔴 ROUND 4's base is the ROUND-3 TREE, `e06461f7`. Measured the same way —
+# `git show e06461f7:scripts/audit-dispatch.py` into a scratch tree with THIS
+# module copied in unchanged, `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`:
+#
+#     15 failed, 68 passed
+#
+# and only these FIVE are regression coverage. The other TEN fail there for
+# reasons this module already says are not evidence: `SystemExit: 2` from an
+# argparse flag the fix introduced (2), `AttributeError` for a function it
+# introduced (1), and an assertion over a directive, a worktree state or a
+# ledger that does not exist in that tree (7). They are filed as guards, with
+# the mutation battery as their evidence.
+#
+# 🔴 TWO OF THE FIVE ONLY BECAME REGRESSION COVERAGE AFTER BEING REWRITTEN, and
+# it is recorded because the first draft of each was the vacuous shape:
+#   * the private-worktree test sliced on the round-4 heading `## THE CHECKOUT`
+#     and died at the base with `ValueError: substring not found` — for want of
+#     a heading the fix introduced. `checkout_section` now matches the OLD
+#     spelling too, and it fails there on the false SHARED claim instead;
+#   * its assertions were ordered positive-first, so it failed on the absence
+#     of the word "PRIVATE". The negatives run first now, so the red is the
+#     wrong ANSWER.
+RED_AT_BASE_R4: frozenset[str] = frozenset({
+    "test_a_round_one_emit_claims_says_head_is_an_assumption_not_a_measurement",
+    "test_a_degenerate_range_does_not_blame_a_checkout_it_verified",
+    "test_a_private_worktree_is_not_described_as_shared_and_is_not_absolved",
+    "test_the_where_to_work_section_does_not_call_a_private_worktree_the_clone",
+    "test_an_uppercase_audited_sha_still_trips_the_degenerate_guard",
+})
+
 RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "abc41024": RED_AT_BASE_R2,
     "d9eb36a8": RED_AT_BASE_R3,
+    "e06461f7": RED_AT_BASE_R4,
 }
 RED_AT_BASE: frozenset[str] = frozenset().union(*RED_AT_BASE_REFS.values())
 
@@ -2346,8 +2971,34 @@ INVARIANT_GUARDS_AND_LEDGERS = frozenset({
     # XA, and the XS survives-control are their evidence.
     "test_the_section_directive_ledger_is_pinned_two_way",
     "test_each_section_directive_carries_the_instruction_its_ledger_entry_names",
-    "test_every_section_directive_is_emitted_verbatim_in_the_delta_brief",
+    "test_every_section_directive_is_emitted_verbatim_in_the_brief_that_owns_it",
     "test_control_a_directive_deleted_from_the_constant_is_detected",
+    # ------------------------------------------------------------------- #
+    # Round 4's guards. Each says in its own docstring why it is one, and
+    # every one of them WAS run against `e06461f7` — they are here because of
+    # HOW they failed there, not because nobody looked.
+    # ------------------------------------------------------------------- #
+    # `--audited` does not exist at `e06461f7`, so both die with `SystemExit:
+    # 2` from argparse. Mutants Y7 (the flag is parsed and ignored) and Y8
+    # (the ignored-flag warning removed) are their evidence.
+    "test_audited_supplies_the_tip_a_round_one_emit_cannot_derive",
+    "test_audited_without_emit_claims_says_it_changed_nothing",
+    # The STRUCTURAL half of the false-cause pair: a ledger of every site that
+    # renders the shared cause list, red when the set grows or shrinks. At the
+    # base the directive does not exist, so its red there is an absence.
+    # Mutants Y10 and Y11 (each site hand-rolls its own causes again).
+    "test_the_degenerate_range_causes_have_exactly_one_writer_per_consumer",
+    # The THIRD worktree state. `e06461f7` has no unknown branch at all, so
+    # "the unknown state kept the absolution" is not a defect it has — it is a
+    # state it lacks. Mutant Y6 collapses it back into SHARED.
+    "test_an_unreadable_worktree_state_is_its_own_answer_and_keeps_the_no_write",
+    # `AttributeError: ... no attribute 'gather_worktree_kind'`. Mutant Y5b
+    # (compare the two paths as strings) is what proves the resolution step
+    # executes — and the SUBDIRECTORY row is what proves it is needed.
+    "test_gather_worktree_kind_resolves_paths_before_comparing_them",
+    # Reads `SECTION_DIRECTIVES` against the scenario map; mutant XA (a
+    # directive added with no scenario) is its evidence.
+    "test_the_directive_render_scenario_ledger_is_pinned_two_way",
     # Guards over THIS module's own bookkeeping. The mutation battery mutates
     # the SCRIPT, never this module, so it cannot reach them — their evidence
     # is the in-module negative control beside each.
@@ -2451,15 +3102,166 @@ FIX_MATRIX = (
      "GUARD", "X1, X3 (XA, XS controls)"),
     ("r3/4  a 'watched RED at abc41024' label was wrong",
      "test_the_fix_matrix_evidence_matches_the_two_ledgers",
-     "GUARD", "its own in-module negative control"),
+     "GUARD", "IN-MODULE CONTROL"),
+
+    # ------------------------------------------------------------------ #
+    # 🔴 NINE ROUND-2 DETECTORS AND ONE ROUND-3 DETECTOR THAT WERE WATCHED
+    # RED AND HAD NO ROW. Nothing required a `RED_AT_BASE` entry to appear
+    # here, so a finding could be dropped from the matrix while its test
+    # stayed green and its ledger entry stayed put — the matrix would grade
+    # clean and assert nothing about the finding it had lost.
+    # `..._evidence_matches_the_two_ledgers` now requires the containment.
+    # ------------------------------------------------------------------ #
+    ("r2/2' the toolchain named the wrong tier in its gate commands",
+     "test_the_toolchain_section_names_the_tier_the_merge_gates_on",
+     "RED@abc41024", "T2"),
+    ("r2/4c missing_clauses() compared un-normalised text, so a re-wrap read "
+     "as a loss",
+     "test_missing_clauses_is_a_pure_function_over_the_text",
+     "RED@abc41024", "K3"),
+    ("r2/7b a bare round-1 block must anchor the NEXT round's cumulative figure",
+     "test_a_round_one_block_anchors_the_next_rounds_cumulative_figure",
+     "RED@abc41024", "-"),
+    ("r2/8a a 4-backtick opener closed with 3 was dropped in silence",
+     "test_a_malformed_fence_beside_a_readable_block_still_warns",
+     "RED@abc41024", "B1"),
+    ("r2/8b a longer closing fence closes under CommonMark and was dropped",
+     "test_a_longer_closing_fence_is_a_valid_close_and_is_read",
+     "RED@abc41024", "B2"),
+    ("r2/8c a claim wrapping onto a second line was silently truncated",
+     "test_a_claim_that_wraps_onto_a_continuation_line_keeps_its_tail",
+     "RED@abc41024", "B3"),
+    ("r2/8d a block cut short by a nested fence lost every claim after it",
+     "test_a_block_cut_short_by_a_nested_fence_is_reported",
+     "RED@abc41024", "B4"),
+    ("r2/8e the refusal did not say which comment kinds it cannot see",
+     "test_the_refusal_says_which_comment_kinds_it_cannot_see",
+     "RED@abc41024", "B5"),
+    ("r2/9' the head-verified note is the does-not-fire-spuriously control",
+     "test_the_range_says_head_was_verified_when_it_was",
+     "RED@d9eb36a8", "N1"),
+
+    # ------------------------------------------------------------------ #
+    # 🔴 ROUND 4. Base `e06461f7`.
+    # ------------------------------------------------------------------ #
+    ("r4/1a the round-1 -> round-2 hop was EMPTY BY CONSTRUCTION, and silent: "
+     "the self-range warning was spelled on a field that is None at round 1",
+     "test_a_round_one_emit_claims_says_head_is_an_assumption_not_a_measurement",
+     "RED@e06461f7", "Y9"),
+    ("r4/1b round 1 had no way to record the tip it AUDITED, only the tip its "
+     "fixes produced",
+     "test_audited_supplies_the_tip_a_round_one_emit_cannot_derive",
+     "GUARD", "Y7"),
+    ("r4/1c --audited without --emit-claims was a silent no-op",
+     "test_audited_without_emit_claims_says_it_changed_nothing",
+     "GUARD", "Y8"),
+    ("r4/2  BOTH degenerate-range messages blamed a checkout `head_check` had "
+     "just verified — written by the commit whose message claimed a class fix",
+     "test_a_degenerate_range_does_not_blame_a_checkout_it_verified",
+     "RED@e06461f7", "Y10, Y11"),
+    ("r4/2' the cause list must have exactly one writer per consumer",
+     "test_the_degenerate_range_causes_have_exactly_one_writer_per_consumer",
+     "GUARD", "Y10, Y11"),
+    ("r4/3  Y1/Y2: two OPERATIVE verbatim blocks shipped unpinned — the "
+     "delta-scope sentence and the cross-repo 'that worktree is YOURS'",
+     "test_each_section_directive_carries_the_instruction_its_ledger_entry_names",
+     "GUARD", "Y1, Y2"),
+    ("r4/3' a directive that reaches NO brief is an instruction nobody receives",
+     "test_the_directive_render_scenario_ledger_is_pinned_two_way",
+     "GUARD", "XA"),
+    ("r4/4a THE SHARED CHECKOUT named whatever cwd was, including a PRIVATE "
+     "per-agent worktree — and absolved the movement it should have reported",
+     "test_a_private_worktree_is_not_described_as_shared_and_is_not_absolved",
+     "RED@e06461f7", "Y14"),
+    ("r4/4b WHERE TO WORK called that worktree the session's own repository",
+     "test_the_where_to_work_section_does_not_call_a_private_worktree_the_clone",
+     "RED@e06461f7", "Y13"),
+    ("r4/4c not knowing is its own state: keep the no-write, drop the "
+     "absolution",
+     "test_an_unreadable_worktree_state_is_its_own_answer_and_keeps_the_no_write",
+     "GUARD", "Y6"),
+    ("r4/4d the two git dirs are compared as RESOLVED paths, never as strings",
+     "test_gather_worktree_kind_resolves_paths_before_comparing_them",
+     "GUARD", "Y5b"),
+    ("r4/5  same_commit was case-sensitive, so an uppercase `audited=` sha "
+     "disarmed every degenerate-range guard",
+     "test_an_uppercase_audited_sha_still_trips_the_degenerate_guard",
+     "RED@e06461f7", "Y12"),
+    ("r4/6  this matrix's own mutants column was UNGRADED, and every "
+     "RED_AT_BASE entry could drop out of it silently",
+     "test_the_fix_matrix_evidence_matches_the_two_ledgers",
+     "GUARD", "IN-MODULE CONTROL"),
 )
 
 # A COLLAPSE floor, not a growth floor: a matrix emptied by a bad refactor
-# grades every row correctly and asserts nothing.
-MIN_FIX_MATRIX_ROWS = 20
+# grades every row correctly and asserts nothing. Derived from the current
+# measurement the way this repo derives every other floor —
+# `m - min(50, max(1, m // 20))` — rather than hand-picked, because a
+# hand-picked floor drifts from what it is protecting. At m = 48 that is 46.
+MIN_FIX_MATRIX_ROWS = 46
+
+# 🔴 THE MUTANTS COLUMN IS AN EVIDENCE CLAIM, AND IT WAS UNGRADED.
+# `fix_matrix_problems` took `_mutants` and threw it away, so rewriting a
+# GUARD row's column to `"Z99 — a mutant that does not exist"` left the suite
+# fully green — while for a GUARD row that column IS the whole evidence, the
+# base-ref cell having been set to `GUARD` precisely because there is no base
+# ref to point at. It is now resolved against the harness's OWN `ROWS`.
+MUTANT_HARNESS = REPO / "scripts" / "tests" / "mutants-audit-dispatch.py"
+
+# The one evidence token that is legitimately not a mutant: a guard over this
+# module's own bookkeeping, which the battery cannot reach because it mutates
+# the SCRIPT and never this file. Spelled as a sentinel rather than as prose so
+# it cannot be confused with a column somebody forgot to fill in.
+IN_MODULE_CONTROL = "IN-MODULE CONTROL"
 
 
-def fix_matrix_problems(rows, red_by_ref, guards, known_tests):
+def _known_mutant_ids():
+    """Every mutant id the harness actually carries, read from the harness.
+
+    Imported, not restated: a ledger of mutant ids kept here by hand would go
+    stale in exactly the direction that makes a false claim pass.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "mutants_audit_dispatch", MUTANT_HARNESS
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return {label.split()[0] for label, _want, _mutate in mod.ROWS}
+
+
+KNOWN_MUTANT_IDS = _known_mutant_ids()
+
+_RANGE = re.compile(r"\b([A-Za-z]{1,2})(\d+)\s*-\s*(?:([A-Za-z]{1,2}))?(\d+)\b")
+_ID = re.compile(r"\b([A-Za-z]{1,2}\d+[a-z]?)\b")
+
+
+def mutant_ids(column, known=()):
+    """The mutant ids a matrix cell names, with `W1-W5` ranges expanded.
+
+    🔴 DIGIT-FORM IDS ARE FOUND BY SHAPE; digitless ones (`XA`, `XS`) only by
+    membership in `known`. Said plainly because it is the blind spot: a
+    digitless id somebody TYPO'd (`XB`) is invisible here, while a digit-form
+    invention (`Z99`) is caught. Widening the shape to digitless tokens makes
+    `IN`, `A` and every capitalised word in a prose cell into a mutant id, and
+    a checker that fires on prose is one nobody keeps.
+    """
+    rest, out = column, set()
+    for m in _RANGE.finditer(column):
+        pre, lo, pre2, hi = m.group(1), int(m.group(2)), m.group(3), int(m.group(4))
+        if pre2 and pre2 != pre:
+            continue
+        out.update(f"{pre}{n}" for n in range(lo, hi + 1))
+        rest = rest.replace(m.group(0), " ")
+    out.update(_ID.findall(rest))
+    for k in known:
+        if not any(c.isdigit() for c in k) and re.search(
+            rf"\b{re.escape(k)}\b", column
+        ):
+            out.add(k)
+    return out
+
+
+def fix_matrix_problems(rows, red_by_ref, guards, known_tests, known_mutants):
     """-> a list of complaints. Shared by the guard and its negative control.
 
     Kept as a function precisely so the control can drive the SAME code with a
@@ -2467,7 +3269,22 @@ def fix_matrix_problems(rows, red_by_ref, guards, known_tests):
     checker nobody has watched go red.
     """
     problems = []
-    for finding, detector, evidence, _mutants in rows:
+    for finding, detector, evidence, mutants in rows:
+        named = mutant_ids(mutants, known_mutants)
+        unknown = named - known_mutants
+        if unknown:
+            problems.append(
+                f"{finding}: names mutant(s) {sorted(unknown)}, which the "
+                "harness's own ROWS do not carry"
+            )
+        if evidence == "GUARD" and not named and mutants.strip() != IN_MODULE_CONTROL:
+            problems.append(
+                f"{finding}: labelled GUARD, but its mutants column "
+                f"{mutants!r} names no mutant. For a GUARD row that column IS "
+                f"the evidence — there is no base ref to point at. Use "
+                f"{IN_MODULE_CONTROL!r} only for a guard the battery cannot "
+                "reach at all."
+            )
         if detector not in known_tests:
             problems.append(f"{finding}: names no test called {detector!r}")
             continue
@@ -2510,9 +3327,15 @@ def test_the_fix_matrix_evidence_matches_the_two_ledgers():
         f"{MIN_FIX_MATRIX_ROWS}). A matrix that shrank grades every remaining "
         "row correctly and asserts nothing about the findings it dropped."
     )
+    assert KNOWN_MUTANT_IDS, (
+        "no mutant ids were read out of the harness at all, so the mutants "
+        "column below would be graded against an empty set and every row "
+        "would pass. Positive control: the harness carries dozens."
+    )
     here = {n for n in globals() if n.startswith("test_")}
     problems = fix_matrix_problems(
-        FIX_MATRIX, RED_AT_BASE_REFS, INVARIANT_GUARDS_AND_LEDGERS, here
+        FIX_MATRIX, RED_AT_BASE_REFS, INVARIANT_GUARDS_AND_LEDGERS, here,
+        KNOWN_MUTANT_IDS,
     )
     assert not problems, (
         "\n\nthe fix matrix claims evidence the ledgers do not support:\n  "
@@ -2521,26 +3344,47 @@ def test_the_fix_matrix_evidence_matches_the_two_ledgers():
           "row to GUARD, or add the detector to that ref's RED_AT_BASE set "
           "AFTER watching it fail there."
     )
+    # 🔴 CONTAINMENT, and it is the half that was missing entirely: every test
+    # filed as regression coverage names a FINDING, and a finding with no row
+    # here is a finding this matrix silently stopped asserting anything about.
+    # Nine round-2 detectors and one round-3 detector were in that state.
+    orphaned = RED_AT_BASE - {row[1] for row in FIX_MATRIX}
+    assert not orphaned, (
+        f"\n\n{len(orphaned)} test(s) are filed as regression coverage for a "
+        f"real defect and appear in NO matrix row: {sorted(orphaned)}\n"
+        "  The ledger says each was watched RED at a named base, so each is a "
+        "finding. Give it a row, or explain in the ledger why it is not one."
+    )
 
 
 def test_control_the_fix_matrix_checker_catches_a_wrong_evidence_label():
     """NEGATIVE CONTROL: the checker above must be able to go red.
 
-    Four deliberately wrong rows, one per rejection path. A checker that
-    returns an empty list for these is wired to nothing, and the guard beside
-    it would pass for any matrix at all.
+    ONE deliberately wrong row per rejection path — **count them in `bad`**,
+    which is what the assertion does. The docstring used to say "Four" over
+    five rows and five paths; a hand-written count beside data that grows is a
+    claim nobody re-reads, and this module has now carried two of them.
+
+    🔴 The last two paths are round 4's: the mutants column was DISCARDED, so
+    a GUARD row could name `"Z99 — a mutant that does not exist"`, or name
+    nothing at all, and grade clean — while for a GUARD row that column is the
+    entire evidence.
     """
     guards = frozenset({"test_a_guard"})
     red = {"aaaa1111": frozenset({"test_a_regression"})}
     known = {"test_a_guard", "test_a_regression"}
+    mutants = frozenset({"M1", "M2"})
     bad = (
         ("mislabelled guard", "test_a_guard", "RED@aaaa1111", "-"),
-        ("mislabelled regression", "test_a_regression", "GUARD", "-"),
+        ("mislabelled regression", "test_a_regression", "GUARD", "M1"),
         ("unknown ref", "test_a_regression", "RED@ffff9999", "-"),
-        ("nonexistent detector", "test_vanished", "GUARD", "-"),
-        ("nonsense evidence", "test_a_guard", "probably fine", "-"),
+        ("nonexistent detector", "test_vanished", "GUARD", "M1"),
+        ("nonsense evidence", "test_a_guard", "probably fine", "M1"),
+        ("mutant that does not exist", "test_a_guard", "GUARD",
+         "Z99 — a mutant that does not exist"),
+        ("guard whose evidence column is empty", "test_a_guard", "GUARD", "-"),
     )
-    problems = fix_matrix_problems(bad, red, guards, known)
+    problems = fix_matrix_problems(bad, red, guards, known, mutants)
     assert len(problems) == len(bad), (
         f"the checker reported {len(problems)} problem(s) for {len(bad)} "
         f"deliberately wrong rows: {problems}"
@@ -2548,10 +3392,22 @@ def test_control_the_fix_matrix_checker_catches_a_wrong_evidence_label():
     # And it must NOT fire on correct rows — a checker that rejects everything
     # is as useless as one that accepts everything.
     good = (
-        ("ok guard", "test_a_guard", "GUARD", "-"),
-        ("ok regression", "test_a_regression", "RED@aaaa1111", "-"),
+        ("ok guard", "test_a_guard", "GUARD", "M1"),
+        ("ok guard, range spelling", "test_a_guard", "GUARD", "M1-M2"),
+        ("ok guard the battery cannot reach", "test_a_guard", "GUARD",
+         IN_MODULE_CONTROL),
+        ("ok regression with no mutant", "test_a_regression", "RED@aaaa1111",
+         "-"),
     )
-    assert fix_matrix_problems(good, red, guards, known) == []
+    assert fix_matrix_problems(good, red, guards, known, mutants) == []
+    # 🔴 POSITIVE CONTROL for the range expander itself: a reassuring empty set
+    # is indistinguishable from a parser wired to nothing.
+    assert mutant_ids("W1-W5, R1") == {"W1", "W2", "W3", "W4", "W5", "R1"}
+    assert mutant_ids("X1, X3 (XA, XS controls)", {"XA", "XS"}) == {
+        "X1", "X3", "XA", "XS"
+    }
+    assert mutant_ids("Y5b") == {"Y5b"}
+    assert mutant_ids(IN_MODULE_CONTROL, {"XA"}) == set()
 
 
 def test_the_two_ledgers_partition_this_modules_tests():

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -496,6 +496,8 @@ import importlib.util
 import io
 import json
 import re
+import sys
+import tempfile
 import tokenize
 from pathlib import Path
 
@@ -1009,6 +1011,17 @@ def comment_with_prose():
     return SURROUNDING_PROSE.format(block=CLAIMS_BLOCK_R2)
 
 
+# 🔴 A REAL FILE ON DISK, because `--claims-file` is the one input this script
+# reads without going through the injected runner: `Path(...).read_text` is a
+# real open. A `tmp_path` fixture cannot serve it — `SCENARIO_RUNS` entries are
+# built by plain callables that every scenario-driven guard invokes, and a
+# pytest fixture is not available there. The `TemporaryDirectory` is bound to a
+# module global so it outlives collection and is removed at interpreter exit.
+_CLAIMS_FILE_DIR = tempfile.TemporaryDirectory(prefix="audit-dispatch-claims-")
+CLAIMS_FILE = Path(_CLAIMS_FILE_DIR.name) / "round-2-claims.md"
+CLAIMS_FILE.write_text(CLAIMS_BLOCK_R2, encoding="utf-8")
+
+
 # --------------------------------------------------------------------------- #
 # THE TWO-WAY PIN
 # --------------------------------------------------------------------------- #
@@ -1466,6 +1479,23 @@ SCENARIO_RUNS = {
         ["900", "--round", "3"],
         {"pr": {k: v for k, v in DEFAULT_PR.items() if k != "baseRefName"},
          "comments": [CLAIMS_BLOCK_R2]},
+    ),
+    # 🔴 ROUND 12 — THE MODE THE COMMENT ABOVE NAMES AS ALWAYS ASSUMED, AND NO
+    # SCENARIO RAN IT. Round 10 modelled the assumed-base state by DELETING
+    # `baseRefName` from a `gh` payload, which is the rarer of the two ways to
+    # reach it; `--claims-file` reaches it on every single run. The script
+    # meanwhile HARDCODED `baseRefName: "main"` in that branch, so the state
+    # the guard exists for was unreachable through the door it is always open
+    # on. Measured at `88b4105c`: `--round 3 --claims-file <f>` -> rc 0,
+    # silent stderr, banner ABSENT.
+    #
+    # 🔴 Its `pr` payload is DELIBERATELY ABSENT. In this mode `gh_pr_facts`
+    # is never called, so a payload here would be a fixture nothing reads —
+    # and reading one to decide what to expect is exactly the fixture defect
+    # `scenario_base_is_assumed` was written to avoid.
+    "claims-file-assumed-base": lambda: (
+        ["900", "--round", "3", "--claims-file", str(CLAIMS_FILE)],
+        {},
     ),
 }
 SCENARIOS = tuple(SCENARIO_RUNS)
@@ -2690,6 +2720,28 @@ def test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha():
 ASSUMED_BASE_BANNER = "THAT BASE BRANCH WAS ASSUMED, NOT READ"
 
 
+def scenario_base_is_assumed(name):
+    """Does this scenario's fixture leave the base branch to the DEFAULT?
+
+    🔴 ROUND 12 — TWO WAYS TO REACH THAT STATE, AND READING THE PR PAYLOAD SEES
+    ONLY ONE. `gh` can report no `baseRefName`, or the run can consult no `gh`
+    at all — and in the second case there IS no payload, so
+    `kw.get("pr") or DEFAULT_PR` falls to a fixture that HAS the field and the
+    guard would assert the banner's ABSENCE in the one mode that always
+    assumes. That is the fixture half of the same defect: the script hardcoded
+    the field, this module would have hardcoded the expectation, and the two
+    wrongs agree.
+
+    So the ARGV is consulted first: `--claims-file` decides it before any
+    payload is read.
+    """
+    argv, kw = SCENARIO_RUNS[name]()
+    if "--claims-file" in argv:
+        return True
+    payload = kw.get("pr") or DEFAULT_PR
+    return not payload.get("baseRefName")
+
+
 def test_no_brief_states_an_assumed_base_branch_as_a_fact():
     """🔴 REGRESSION. Red at `706a6b38`, scenario `delta-assumed-base`.
 
@@ -2718,29 +2770,43 @@ def test_no_brief_states_an_assumed_base_branch_as_a_fact():
     """
     seen_assumed = seen_read = 0
     for scenario in SCENARIOS:
-        kw = SCENARIO_RUNS[scenario]()[1]
-        payload = kw.get("pr") or DEFAULT_PR
         brief = brief_for_scenario(scenario)
-        if payload.get("baseRefName"):
+        if not scenario_base_is_assumed(scenario):
             seen_read += 1
             assert ASSUMED_BASE_BANNER not in brief, (
                 f"\n\nscenario {scenario!r}: the brief calls the base branch "
-                "assumed, in a run whose fixture reports "
-                f"{payload['baseRefName']!r}. A banner that fires when the "
-                "field WAS read is a banner every reader learns to skip."
+                "assumed, in a run whose fixture reports a real "
+                "`baseRefName`. A banner that fires when the field WAS read "
+                "is a banner every reader learns to skip."
             )
             continue
         seen_assumed += 1
         assert ASSUMED_BASE_BANNER in brief, (
-            f"\n\nscenario {scenario!r}: `gh` reported no `baseRefName`, so "
-            f"`{payload.get('baseRefName')!r}` fell back to this script's "
-            "default — and the brief states the result as a fact about the "
-            "PR's repository. `--not <base>` decides which commits count as "
-            "this round's payload."
+            f"\n\nscenario {scenario!r}: nothing in this run learned the PR's "
+            "`baseRefName` — `gh` reported none, or was never consulted — so "
+            "`main` is this script's DEFAULT, and the brief states the result "
+            "as a fact about the PR's repository. `--not <base>` decides "
+            "which commits count as this round's payload."
         )
+    # 🔴 ROUND 12 — THE ASSUMED SIDE IS COUNTED BY MECHANISM, NOT IN TOTAL. A
+    # single `seen_assumed` counter is satisfied by either door, and the
+    # `--claims-file` door is the one that was covered by nothing while a
+    # comment in the script asserted it was reached on EVERY run.
+    by_gh = [s for s in SCENARIOS
+             if scenario_base_is_assumed(s) and "--claims-file"
+             not in SCENARIO_RUNS[s]()[0]]
+    by_claims_file = [s for s in SCENARIOS
+                      if "--claims-file" in SCENARIO_RUNS[s]()[0]]
     assert seen_assumed and seen_read, (
         f"only one side was driven ({seen_assumed} assumed, {seen_read} read), "
         "so this guard pins a constant rather than a relationship"
+    )
+    assert by_gh and by_claims_file, (
+        f"the assumed side is reached by {len(by_gh)} `gh`-payload "
+        f"scenario(s) and {len(by_claims_file)} `--claims-file` scenario(s). "
+        "Both doors must be driven: the script hardcoded `baseRefName` in the "
+        "claims-file branch for two rounds, and a suite that only deletes the "
+        "field from a `gh` payload cannot see that."
     )
 
 
@@ -2766,7 +2832,7 @@ def test_the_tip_placeholder_ledger_matches_the_script():
             branch="b", dirty=0, prev_sha="aaaa1111", emit_from=None,
             claims=[], claims_round=None, checklist="", ledger=None,
             assembled_at="", claims_source="", head_check=None,
-            base_assumed=False,
+            base_assumed=False, base_assumed_reason=None,
         )
     ), (
         "the banner every keyed guard looks for is not what the note emits, so "

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -4861,15 +4861,53 @@ def test_a_failed_cumulative_measurement_does_not_print_a_false_cause():
     assert "not a missing anchor" in out
 
 
+# 🔴 ROUND 12 — THE WHOLE CAVEAT, NORMALISED, not two fragments out of it.
+# Measured at `88b4105c`: replacing "**as it stands in this checkout**, and"
+# with "and it is fine. It" — which guts the qualifier the whole caveat exists
+# for, and inverts what it tells the reader to do — left the suite at 109
+# passed, because both pinned fragments ("does not fetch", "stale base")
+# survive the reword untouched. `claude/RULES.md` -> spelled-guards: when the
+# artifact under test IS prose, a guard on words is walkable by rewording, so
+# pin the whole normalised string and pay the cosmetic-reflow cost.
+#
+# `origin/main` is interpolated from `facts.base_ref`; this run is round 3, so
+# that is the spelling the delta half renders.
+STALE_BASE_CAVEAT = norm(
+    "⚠ `<base>` here is `origin/main` **as it stands in this checkout**, and "
+    "it is the ONLY end of that command that can mean something different "
+    "where you are standing — both ends of the range itself are shas. This "
+    "script does not fetch (that would be a write to a checkout it does not "
+    "own), so a stale base re-reports upstream work as this round's payload. "
+    "If the number looks large, that is the first thing to check."
+)
+
+
 def test_the_ledger_says_the_base_was_not_fetched():
     """The script cannot fetch (that would be a write), so it says so.
 
     A stale `<base>` re-reports upstream work as this round's payload — measured
     at 201 lines where the truth was 1.
+
+    🔴 ROUND 12 — PINNED WHOLE. This test used to assert two fragments and was
+    killed by NO row in the mutation battery: zero occurrences of its name
+    across the full 100-row log, while it sits in `INVARIANT_GUARDS_AND_LEDGERS`
+    whose declared evidence IS the battery. Round 10 removed the evidence for
+    it when the C3 killer set shrank. Rows V26 and V27 restore it — one deletes
+    the caveat (this test is the sole detector, measured), one rewords it while
+    leaving both old fragments intact (the reachability control for the whole
+    string).
     """
     rc, out, err = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
     assert rc == 0, err
-    assert "does not fetch" in out and "stale base" in out
+    assert STALE_BASE_CAVEAT in norm(out), (
+        "\n\nTHE LEDGER's stale-base caveat is gone or reworded. It is the "
+        "only thing telling the reader that `--not <base>` resolves LOCALLY "
+        "in a checkout this script deliberately never fetched, and a reword "
+        "that keeps the words `does not fetch` and `stale base` while "
+        "dropping `as it stands in this checkout` inverts what it asks for "
+        "and passed a fragment pin.\n\n"
+        f"expected: {STALE_BASE_CAVEAT}\n\ngot section: {norm(out)[-1200:]}"
+    )
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -148,7 +148,6 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
-import sys
 from pathlib import Path
 
 import pytest

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -202,14 +202,82 @@ about a base DOCSTRING. It is filed as a guard, and its red was measured
 separately against `3619fe68`'s test module — where both `REFUTED_PREMISES`
 entries appear, normalised, and would read twice with the ledger present.
 
+🔴 ROUND 8 — a sixth base, `28492af2`, fixing round 7's findings
+------------------------------------------------------------------
+Round 7 returned two 🟡 and four 🟢. The larger 🟡 is the FOURTH instance of
+this ladder's recurring confusion, and it is the REPOSITORY axis: every `git`
+command this script runs goes to the assembly checkout, while every PR fact
+comes from `gh` about a repo that, cross-repo, is a DIFFERENT ONE. So
+`verify_head_is_the_pr` is structurally unable to pass there — THE RANGE
+diagnosed that as a checkout that had moved ("Resolve the range in a tree that
+CONTAINS the PR's head", of which there is none here and never will be), and
+THE LEDGER printed COULD NOT MEASURE on EVERY delta round of such a PR, leaving
+the ladder's own two-consecutive-zero payload gate uncomputed by anybody. No
+test built that state: both cross-repo scenarios ran at ROUND 1 and both delta
+scenarios were same-repo — a textbook isolation seam, and one the existing
+fixture would have hidden, because `OTHER_REPO_PR` inherited `DEFAULT_PR`'s
+`headRefOid` and so modelled the assembly checkout standing on a commit of
+another repository.
+
+The other 🟡: both prose guards were blind to a phrase wrapped across two `#`
+COMMENT lines and to single- or mixed-quote implicit concatenation, while both
+described themselves as handling exactly that — and a wrapped comment block is
+where this ladder writes every round's narrative.
+
+The four 🟢: round 7's tip fix was HALF-APPLIED (the DEGENERATE branch of the
+same `if`/`elif` still handed out `..HEAD`, under a banner claiming the range
+"can never contain anything, whatever the PR looks like"); the forward
+reference named a WIDER set than the clause it describes, differing on exactly
+the clone the brief's own recipe writes to; THE LEDGER's provenance line was
+the last copyable command whose `HEAD` resolves differently for the reader the
+brief invites to re-run it; and the re-derivability line below printed a
+FUNCTION count in a row of NODE-ID counts.
+
+🔴 ROUND 8 ALSO FOUND A FIFTH INSTANCE OF THE SHAPE, by sweeping for it rather
+than from a finding, and it is the sharpest of the six: `newest is not None`
+(a block PARSED) was read as "there is something to diff FROM". `audited=..`
+parses cleanly and yields two EMPTY halves, so a round-3 brief rendered
+``Diff `None..<the PR's head>` `` — a literal Python `None` inside a git rev
+spec — at rc 0, under "verified at assembly time", with THE LEDGER giving the
+ROUND-1 cause ("a first, full audit has no previous round") for a round that
+has one. Refused now, with the two causes named apart.
+
+Measured at `28492af2` the same way:
+
+    9 failed, 93 passed
+
+SIX of the nine are regression coverage (`RED_AT_BASE_R7`). Of the other three:
+two are the whole-string CLAUSE and DIRECTIVE ledgers, which moved with round
+8's reword of `no-fetch` and `own-worktree-is-writable`; one is the
+skipped-round warning guard, red there on an ABSENCE the fix adds. All three
+are filed as guards, not findings.
+
 🔴 AND THE PER-ROUND COUNTS ABOVE ARE CLAIMS ABOUT THE MODULE OF THEIR OWN
 ROUND. Re-running the same procedure with the CURRENT module gives larger
-numbers at every historical ref (54/34/27/19 at
-`abc41024`/`d9eb36a8`/`e06461f7`/`dd601793`), because each later round adds
-tests that are also red at the earlier trees. What is re-derivable, and was
-re-derived in round 7, is the claim the ledgers actually make: every name in
-every `RED_AT_BASE_*` set fails at its own ref. Zero false claims across all
-five refs.
+numbers at every historical ref, because each later round adds tests that are
+also red at the earlier trees. Measured 2026-08-28 with the round-8 module —
+NODE IDS, which is the unit every "N failed" figure in this docstring uses:
+
+    abc41024   64 failed, 38 passed      <- 64 node ids, 61 functions
+    d9eb36a8   41 failed, 61 passed
+    e06461f7   34 failed, 68 passed
+    dd601793   26 failed, 76 passed
+    3619fe68   20 failed, 82 passed
+    28492af2    9 failed, 93 passed
+
+🔴 THE FIRST NUMBER READ **54** UNTIL ROUND 8, AND 54 WAS THE OTHER UNIT — the
+count of distinct FUNCTIONS, where `pytest -q` printed 57, because three of
+them are parametrised. (With round 8's module the same pair reads 61 and 64;
+the gap is the same three.) Nothing else in this docstring switches units
+mid-list —
+`:30` and `:81` both say "N node ids, M functions" precisely so the two cannot
+be confused — so a lone 54 in a row of node-id counts is a claim that does not
+re-derive by the procedure it is filed under. Re-derived, not corrected from
+memory: the script above restores each ref and counts `^FAILED ` lines.
+
+What is re-derivable, and was re-derived again in round 8, is the claim the
+ledgers actually make: every name in every `RED_AT_BASE_*` set fails at its own
+ref. Zero false claims across all six refs.
 
 🔴 THE NEGATIVE-CONTROL MATRIX — measured, and RE-DERIVABLE
 -------------------------------------------------------------
@@ -226,9 +294,9 @@ rows that justified adding a pin. Each row there names the EXACT killer set and
 reports WRONG-KILLER (an expected pin did not fire) separately from EXTRA-KILLER
 (the row no longer isolates what it names).
 
-Re-run 2026-08-28 against HEAD of this branch after the round-7 fixes — **83
-rows, all as expected**, over a 94-test positive control (it was 76 rows over
-89 after round 5) — each mutant applied
+Re-run 2026-08-28 against HEAD of this branch after the round-8 fixes — **93
+rows, all as expected**, over a 102-test positive control (83 rows over 94
+after round 7; 76 over 89 after round 5) — each mutant applied
 to a COPY of
 `scripts/audit-dispatch.py` in a scratch tree (never the worktree), under
 `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`, with the unmutated copy as the
@@ -289,8 +357,10 @@ Printing "SURVIVED as required (control)" over an unguarded sentence is exactly
 the flattering wrong answer this battery exists to refuse.
 
   POS  unmutated copy .............................. 72 passed  <- control
-       (that figure is the ROUND-2 control; today's is 89 — the harness
-        prints the current one, which is the number to read)
+       (that figure is the ROUND-2 control; today's is 102 — the harness
+        prints the current one, which is the number to read, and it is the
+        only one that cannot go stale. This line said 89 through rounds 6 and
+        7 while the paragraph above it said 94, in the same docstring.)
 
   D1   delete the `read-only` clause ............... 4 failed
   D3   delete the `stop-rule` clause ............... 4 failed
@@ -404,10 +474,12 @@ HERMETIC: no test touches the network, spawns a process, or reads a real PR.
 """
 from __future__ import annotations
 
+import ast
 import importlib.util
 import io
 import json
 import re
+import tokenize
 from pathlib import Path
 
 import pytest
@@ -424,6 +496,85 @@ def _load():
 
 
 ad = _load()
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 ROUND 8 — THE PROSE NORMALISER, ONE RULE IN ONE PLACE
+# --------------------------------------------------------------------------- #
+# Two guards in this module scan Python SOURCE for a phrase a round has already
+# established is false: `surviving_refuted_premises` and the prose half of
+# `test_the_blind_spot_rationale_matches_what_the_script_actually_does`. Round 7
+# gave each its own copy of the same three-line normaliser, and round 8 measured
+# what both copies could not see. Planted at `28492af2`, one phrase per shape:
+#
+#     shape                                    round 7   round 8
+#     phrase on ONE `#` line                   CAUGHT    CAUGHT
+#     phrase WRAPPED over two `#` lines        MISSED    CAUGHT
+#     phrase wrapped inside one docstring      CAUGHT    CAUGHT
+#     "…" "…"  double-quoted concatenation     CAUGHT    CAUGHT
+#     '…' '…'  single-quoted concatenation     MISSED    CAUGHT
+#     "…" '…'  MIXED-quote concatenation       MISSED    CAUGHT
+#
+# The two MISSED comment rows are the ones that matter, because the wrapped `#`
+# comment is where this ladder writes its narrative: 119 multi-line comment
+# blocks over 766 comment lines in this module alone, one block per round. A
+# round restating a refuted premise in its own `🔴 ROUND N —` header — wrapped,
+# as every one of them is — scored ZERO on both guards and read as clean.
+#
+# 🔴 THE OLD NORMALISER'S DESCRIPTION WAS ALREADY WIDER THAN ITS CODE, twice
+# over, which is the failure `claude/RULES.md` -> guards-narrower names: it said
+# "these live in wrapped comments" while `" ".join(text.split())` leaves the `#`
+# sitting mid-phrase, and "adjacent literals are joined FIRST, exactly as the
+# compiler joins them" while `re.sub(r'"\s*"', "", …)` joins only the
+# double-quoted spelling. Widening the regex would have kept both claims one
+# quoting style ahead of the code, so the reading is handed to the PARSER:
+#
+#   * `ast` yields every string constant with implicit concatenation ALREADY
+#     performed — by the compiler itself, so "exactly as the compiler joins
+#     them" is now true by construction rather than by a regex that approximates
+#     it, and every quoting style (including an f-string joined to a plain
+#     literal) is covered without enumerating any of them.
+#   * `tokenize` yields COMMENT tokens, which cannot be confused with a `#`
+#     inside a string literal, and a run of them on CONSECUTIVE lines is joined
+#     into one chunk — that is what a reader sees when prose is wrapped.
+#
+# Chunks are kept SEPARATE (joined by newline, and no phrase here contains one)
+# so a phrase cannot be manufactured by butting two unrelated blocks together.
+def collapse_ws(text):
+    """-> `text` with every whitespace run collapsed to one space."""
+    return " ".join(text.split())
+
+
+def prose_chunks(source):
+    """-> the prose of Python `source` as chunks, the way a reader reads it.
+
+    A chunk is one contiguous run of comment lines, or one string constant.
+    """
+    chunks, run, prev_line = [], [], None
+    for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+        if tok.type != tokenize.COMMENT:
+            continue
+        line = tok.start[0]
+        body = re.sub(r"^#+\s?", "", tok.string)
+        if run and line == prev_line + 1:
+            run.append(body)
+        else:
+            if run:
+                chunks.append(" ".join(run))
+            run = [body]
+        prev_line = line
+    if run:
+        chunks.append(" ".join(run))
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            chunks.append(node.value)
+    return [collapse_ws(c) for c in chunks]
+
+
+def flat_prose(source):
+    """-> `prose_chunks` as one string a phrase count can run over."""
+    return "\n".join(prose_chunks(source))
+
 
 # --------------------------------------------------------------------------- #
 # 🔴 THE INDEPENDENT LEDGER — this is what makes the pin two-way.
@@ -473,13 +624,20 @@ CLAUSE_LEDGER = {
     # The axis that is true in every state is OWNERSHIP, not sharedness, and it
     # keeps `own-worktree-is-writable` consistent: the copy YOU made is the one
     # you may write to.
+    # 🔴 ROUND 8 DROPPED "FOR THIS AUDIT", the SECOND narrowing on this clause.
+    # It made the rule forbid the brief's own cross-repo recipe: WHERE TO WORK
+    # says `git -C <your local clone of owner/name> worktree add …`, and that
+    # clone is a checkout the auditor made but did not make FOR THIS AUDIT.
+    # The forward reference in `own-worktree-is-writable` named the wider set
+    # ("every checkout you did not make"), so the two sides disagreed on
+    # precisely the tree the recipe writes to. Both now spell `NO_WRITE_SCOPE`.
     "no-fetch": (
         "**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to any "
-        "checkout that is not the copy YOU made for this audit — including the "
-        "one THE CHECKOUT section names, which is where this brief was "
-        "assembled and is not yours.** Other sessions are in those trees; a "
-        "fetch there is a write with cross-session blast radius, and every ref "
-        "you need is already resolved for you here."
+        "checkout you did not make — including the one THE CHECKOUT section "
+        "names, which is where this brief was assembled and is not yours.** "
+        "Other sessions are in those trees; a fetch there is a write with "
+        "cross-session blast radius, and every ref you need is already "
+        "resolved for you here."
     ),
     "stop-rule": (
         "**A clean round ENDS the ladder — ending it is the CORRECT outcome, "
@@ -590,10 +748,27 @@ FORK_PR = {
     "headRepositoryOwner": {"login": "some-contributor"},
 }
 
+# 🔴 ROUND 8 — THE CROSS-REPO FIXTURE'S HEAD OID IS ITS OWN, AND THE ASSEMBLY
+# CHECKOUT'S IS A THIRD VALUE. `OTHER_REPO_PR` used to inherit `FAKE_HEAD_OID`
+# from `DEFAULT_PR`, and `make_runner`'s `local_head` defaults to the PR's own
+# `headRefOid` — so a cross-repo test written with the plain fixture modelled
+# the assembly checkout of `example-org/devrc` standing on a commit that exists
+# only in `someone-else/otherproj`. That state is PHYSICALLY IMPOSSIBLE, and it
+# is the state round 8's first cross-repo delta render was built in: the brief
+# read "verified at assembly time to be PR #900's head commit" for a PR in
+# another repository. `claude/RULES.md` -> mutation-sweep-blind-spots: pick
+# fixture values that are pairwise distinct, and distinct from any constant the
+# assertion names, or the fixture cannot see the bug.
+FAKE_OTHER_HEAD_OID = "aaaabbbbccccddddeeeeffff00001111a1a1a1a1"
+# What `git rev-parse HEAD` answers in the assembly checkout during a cross-repo
+# run: a commit of the OTHER project, equal to neither of the two above.
+FAKE_ASSEMBLY_HEAD = "9999999988888888777777776666666655555555"
+
 # A genuinely cross-repo PR: it lives in a repository that is NOT the cwd's.
 OTHER_REPO_PR = dict(
     DEFAULT_PR,
     url="https://example.invalid/someone-else/otherproj/pull/900",
+    headRefOid=FAKE_OTHER_HEAD_OID,
     headRepository={
         "name": "otherproj", "nameWithOwner": "someone-else/otherproj",
     },
@@ -630,6 +805,26 @@ CHECKLIST = (
 
 def fake_checklist(_repo_dir):
     return CHECKLIST
+
+
+# 🔴 THE FAKE'S OWN, INDEPENDENT READ of which repository each side names —
+# deliberately NOT `ad.pr_slug` / `ad._slug_from_remote`. A fake that asks the
+# code under test what the world looks like is a second sample of the thing in
+# doubt, not a model of it: `pr_slug` was WRONG for every fork PR for three
+# rounds, and a fixture derived from it would have modelled the same wrong
+# world and hidden the bug. Two lines of regex over the same two inputs is a
+# model; a call into the script is not.
+_FIXTURE_PR_URL = re.compile(r"^https?://[^/]+/([^/]+)/([^/]+)/pull/\d+")
+_FIXTURE_REMOTE = re.compile(r"[:/]([^/:]+)/([^/:]+?)(?:\.git)?$")
+
+
+def fixture_is_cross_repo(payload, origin):
+    """Does this PR fixture live in a DIFFERENT repository from `origin`?"""
+    u = _FIXTURE_PR_URL.match((payload.get("url") or "").strip())
+    r = _FIXTURE_REMOTE.search((origin or "").strip())
+    if not u or not r:
+        return False
+    return (u.group(1), u.group(2)) != (r.group(1), r.group(2))
 
 
 def make_runner(
@@ -671,7 +866,21 @@ def make_runner(
     """
     payload = dict(pr or DEFAULT_PR)
     payload["comments"] = [{"body": c} for c in comments]
-    resolved_head = local_head if local_head is not None else payload.get("headRefOid")
+    # 🔴 ROUND 8 — THE DEFAULT IS NOW PHYSICALLY POSSIBLE IN BOTH REPO STATES.
+    # "The checkout is standing on the PR" is the right default for a PR in
+    # THIS repository and a flat impossibility for one in another: no commit of
+    # `someone-else/otherproj` is ever `git rev-parse HEAD` in a clone of
+    # `example-org/devrc`. Defaulting to the PR's own oid regardless is how a
+    # cross-repo delta brief rendered "verified at assembly time to be PR
+    # #900's head commit" — the fixture asserted the state the guard exists to
+    # rule out. The freak case (a clone with a renamed remote that really does
+    # hold the commit) is still reachable: pass `local_head` explicitly.
+    if local_head is not None:
+        resolved_head = local_head
+    elif fixture_is_cross_repo(payload, origin):
+        resolved_head = FAKE_ASSEMBLY_HEAD
+    else:
+        resolved_head = payload.get("headRefOid")
     ranges = []
 
     def default_rev_list(spec):
@@ -1058,11 +1267,20 @@ DIRECTIVE_LEDGER = {
     # 🔴 ROUND 6. The second sentence used to read "about the SHARED checkout",
     # which named a scoping the `no-fetch` clause stopped having in round 5 —
     # so a cross-repo brief assembled in a PRIVATE worktree told the reader the
-    # rule was about a state the very next section denies. The scope is now
-    # stated by OWNERSHIP, the way the clause itself states it.
+    # rule was about a state the very next section denies. The scope is stated
+    # by OWNERSHIP.
+    #
+    # 🔴 ROUND 8. The first sentence now names the CLONE as well as the
+    # worktree, because the recipe two lines above it in WHERE TO WORK writes to
+    # the clone — `git -C <your local clone of owner/name> worktree add …` is a
+    # write to the clone, made before the worktree it grants exists. The second
+    # sentence is UNCHANGED; what moved to meet it was `no-fetch`, which had
+    # scoped itself to "the copy YOU made FOR THIS AUDIT" and so forbade that
+    # very command. Both sides are pinned to `NO_WRITE_SCOPE` now.
     "own-worktree-is-writable": (
-        "That worktree is YOURS: fetching and checking out inside it is fine. "
-        "The no-write rule below is about every checkout you did not make."
+        "That worktree is YOURS, and so is the clone you made it from: "
+        "fetching and checking out inside either is fine. The no-write rule "
+        "below is about every checkout you did not make."
     ),
 }
 
@@ -1153,6 +1371,17 @@ SCENARIO_RUNS = {
     "cross-repo": lambda: (["900"], {"pr": OTHER_REPO_PR}),
     "cross-repo-private": lambda: (["900"], {"pr": OTHER_REPO_PR,
                                              "git_dirs": PRIVATE_GIT_DIRS}),
+    # 🔴 ROUND 8 — THE MISSING CELL, and it is a textbook isolation seam. Both
+    # cross-repo scenarios ran at ROUND 1, where THE RANGE and THE LEDGER do
+    # not exist; both delta scenarios were SAME-REPO. So the pair
+    # cross-repo × delta — where every git command goes to a repository that
+    # holds neither end of the range — was covered by nothing, and the two
+    # sections it breaks were each hermetically tested on the other axis.
+    # `claude/RULES.md` -> isolation-seam: ask which surface your fixture does
+    # NOT load.
+    "cross-repo-delta": lambda: (["900", "--round", "3"],
+                                 {"pr": OTHER_REPO_PR,
+                                  "comments": [CLAIMS_BLOCK_R2]}),
 }
 SCENARIOS = tuple(SCENARIO_RUNS)
 
@@ -1466,6 +1695,129 @@ def test_the_newest_claims_block_wins():
         "the range is anchored at the newest block's `<to>`, which is the head "
         "the block was posted at: that range is EMPTY BY CONSTRUCTION whenever "
         "the block sits at the fix tip, which is the normal case"
+    )
+
+
+def test_a_block_that_parses_but_yields_no_anchor_is_refused():
+    """🔴 REGRESSION. Red at `28492af2`, which rendered ``Diff `None..<sha>` ``.
+
+    🔴 THE FIFTH INSTANCE of this ladder's recurring confusion, found by
+    sweeping for the shape rather than from a finding: `newest is not None`
+    (a block PARSED) was read as "there is something to diff FROM". Two
+    different facts. `audited=..` satisfies `\\baudited=(\\S+)`, splits into two
+    EMPTY halves, and `range_anchor` answers None over a block whose claims are
+    perfectly readable — so the delta refusal, which asks only whether a block
+    exists, let it through.
+
+    Measured at the base, `--round 3` over that block, rc 0 and silent stderr:
+
+        THE RANGE : Diff **`None..1111…5555`** … "This checkout's HEAD is
+                    `1111…5555`, verified at assembly time to be PR #900's
+                    head commit"
+        THE LEDGER: "Not measured: a first, full audit has no previous round
+                    to attribute against."
+
+    A literal Python `None` inside a git rev spec — a command that cannot run —
+    under the most confident banner the brief has; and the ROUND-1 cause given
+    for a round-3 brief that HAS a previous round, which is the false-cause
+    shape this module has already fixed at three other sites.
+    """
+    headless = "```audit-claims round=2 audited=..\n1. a claim\n```"
+    # 🔴 POSITIVE CONTROL for the fixture: the block must actually PARSE, with
+    # its claims intact. If it were merely malformed this would be REFUSAL 1's
+    # case, already covered, and the test would prove nothing new.
+    blocks, malformed = ad.parse_claims_blocks([headless])
+    assert len(blocks) == 1 and not malformed, (
+        f"the fixture no longer parses cleanly ({malformed}), so this test is "
+        "exercising the malformed-block path and not the no-anchor one"
+    )
+    assert blocks[0].items == ["a claim"], (
+        "the parsed block carries no claims, so it is not the state this "
+        "refusal is about — a block with nothing in it is REFUSAL 1's case"
+    )
+    assert ad.range_anchor(blocks[0]) is None, (
+        "the fixture now yields an anchor, so it cannot reach this refusal"
+    )
+
+    rc, out, err = run_main(["900", "--round", "3"], comments=[headless])
+    assert rc == 2, (
+        f"\n\na delta round with a block that yields NO ANCHOR exited {rc}. At "
+        "rc 0 the brief hands the auditor a range containing a literal "
+        f"`None`:\n{out[:600]}"
+    )
+    assert "None.." not in out, (
+        f"\n\nthe brief interpolated a literal `None` into the range:\n{out}"
+    )
+    assert "no sha this script can read" in err, (
+        f"\n\nthe refusal does not say WHY it refused:\n{err}"
+    )
+    # 🔴 IT MUST NOT NAME THE ROUND-1 CAUSE. That is the whole point: an anchor
+    # that is missing and an anchor that is unreadable need opposite fixes, and
+    # naming the wrong one sends the operator off to add a block they have.
+    assert "a first, full audit has no previous round" not in err + out, (
+        f"\n\nthe refusal states the ROUND-1 cause over a round-3 brief that "
+        f"HAS a previous round:\n{err}"
+    )
+    assert "NOT the round-1 case" in err, (
+        f"\n\nthe refusal does not distinguish itself from the round-1 case, "
+        f"which is the reader's first guess:\n{err}"
+    )
+    # 🔴 NEGATIVE CONTROL: an ordinary block must still be accepted, or the
+    # refusal above is satisfied by refusing everything.
+    rc2, out2, _ = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
+    assert rc2 == 0 and "## THE RANGE" in out2, (
+        "the no-anchor refusal now fires for a well-formed block too"
+    )
+
+
+def test_a_claims_block_more_than_one_round_behind_is_warned_about():
+    """🔴 INVARIANT GUARD; its evidence is mutant V16, not a base ref.
+
+    At `28492af2` there is no such warning at all, so a red there would be an
+    absence the fix adds rather than a wrong answer observed — which this
+    module says repeatedly is not evidence of anything. The same filing as the
+    emitted legend (Z5).
+
+    🔴 IT IS THE MIRROR OF A WARNING THAT ALREADY EXISTED, and the asymmetry is
+    the finding: a block from a LATER round warned ("check you are not
+    re-auditing a round that already ran"), a block four rounds EARLIER was
+    silent. `--round 7` over a `round=2` block puts round 2's claims under WHAT
+    WAS CLAIMED FIXED, anchors the range on round 2's sha, and frames the audit
+    on them — a delta over everything since round 2 presented as a delta since
+    round 6.
+
+    🔴 AND IT MUST NEVER BLOCK. Skipping a round number is legitimate, and `gh
+    pr view --json comments` returns ISSUE comments only, so a newer block
+    posted as a REVIEW comment is invisible here — a refusal would be wrong in
+    both cases. Asserted below, because "warns" and "does not block" are two
+    claims and the second is the one a later round would break.
+    """
+    old = ("```audit-claims round=2 audited=aaaa1111..bbbb2222\n"
+           "1. a claim from four rounds ago\n```")
+    rc, out, err = run_main(["900", "--round", "6"], comments=[old])
+    assert rc == 0, f"the gap warning BLOCKED (rc {rc}); it must not: {err}"
+    assert "a claim from four rounds ago" in out, (
+        "the block was not used at all, so this run is not the state the "
+        "warning is about"
+    )
+    assert "round(s) in between" in err, (
+        "\n\nno warning that the newest claims block is FOUR rounds behind the "
+        f"round asked for. The brief presents round 2's claims as this "
+        f"round's framing and says nothing about the gap.\nstderr: {err!r}"
+    )
+    assert "3 round(s)" in err, (
+        f"\n\nthe warning does not count the gap correctly — rounds 3, 4 and 5 "
+        f"posted nothing, so the gap is 3.\nstderr: {err!r}"
+    )
+    # 🔴 NEGATIVE CONTROL: the ADJACENT case must stay silent, or the warning
+    # fires on every ordinary round and is worth nothing.
+    adjacent = ("```audit-claims round=5 audited=aaaa1111..bbbb2222\n"
+                "1. the previous round's claim\n```")
+    rc2, _, err2 = run_main(["900", "--round", "6"], comments=[adjacent])
+    assert rc2 == 0
+    assert "round(s) in between" not in err2, (
+        f"\n\nthe gap warning fires for a block from the IMMEDIATELY previous "
+        f"round, which is the normal case:\nstderr: {err2!r}"
     )
 
 
@@ -1933,7 +2285,7 @@ def test_the_range_names_a_sha_and_not_head_when_the_head_is_verified():
     """
     rc, out, err = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
     assert rc == 0, err
-    frm, _, tip = rendered_range(out).partition("..")
+    tip = rendered_range(out).partition("..")[2]
     assert tip != "HEAD", (
         "\n\nTHE RANGE tells the auditor to diff `..HEAD`. That token resolves "
         "in THEIR worktree, which this brief has already told them to create "
@@ -1965,16 +2317,244 @@ def test_the_range_names_a_sha_and_not_head_when_the_head_is_verified():
     )[1]
     assert rendered_range(unverified).partition("..")[2] == FAKE_HEAD_OID
 
-    # 🔴 SCOPED TO THE AUDITOR-FACING INSTRUCTION, and this is the control that
-    # says so: THE LEDGER's provenance line keeps `..HEAD`, correctly. That
-    # command ran HERE, in the tree just verified, at assembly time. A fix that
-    # rewrote it would be claiming the assembler measured something it did not.
-    # Asked of the anchor THIS brief rendered, not of a literal, so a mutation
-    # that moves the anchor is not answered by this row.
-    assert f"{frm}..HEAD --not" in out, (
-        "THE LEDGER no longer reports the range it actually measured. It ran "
-        "`git rev-list`/`git log` in the assembly checkout, where `HEAD` is "
-        "the verified head — rewriting that line would misreport provenance."
+    # 🔴 ROUND 7 ASSERTED HERE THAT THE LEDGER'S PROVENANCE LINE KEEPS
+    # `..HEAD` — as the control saying this fix was scoped to the
+    # auditor-facing instruction. Round 8 measured that the scoping argument
+    # never justified the token (`measure_ledger` refuses unless the head check
+    # PASSED, so the sha and `HEAD` named the SAME COMMIT when the command ran),
+    # and moved that line onto the sha as well. The claim now lives in
+    # `test_the_ledgers_provenance_line_names_the_sha_it_resolved_not_head`,
+    # alone, rather than as a control inside a test about a different section —
+    # a control that asserts the OPPOSITE of a later fix is how a round gets
+    # talked out of one.
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 ROUND 8 — EVERY REF THE BRIEF HANDS OVER RESOLVES WHERE THE READER IS
+# --------------------------------------------------------------------------- #
+def ledger_section(brief):
+    """THE LEDGER block alone, sliced off the next `## ` heading."""
+    start = brief.index("## THE LEDGER")
+    rest = brief[start + len("## THE LEDGER"):]
+    nxt = rest.find("\n## ")
+    return brief[start:start + len("## THE LEDGER")
+                 + (nxt if nxt != -1 else len(rest))]
+
+
+def test_the_ledgers_provenance_line_names_the_sha_it_resolved_not_head():
+    """🔴 REGRESSION. Red at `28492af2`, which printed ``aaaa1111..HEAD --not``.
+
+    Round 7 moved THE RANGE's tip off `HEAD` and kept this line on it, with a
+    provenance argument that is sound as far as it goes: that command really
+    did run here, in the tree just verified. What the argument does not
+    establish is the SPELLING. `measure_ledger` refuses unless the head check
+    passed, so when it ran `HEAD` and `local_sha` were the SAME COMMIT — the
+    sha reports exactly what was measured and is the only spelling that
+    survives being copied.
+
+    And it is copied: this was the last command in the brief whose tip means
+    something else in the reader's worktree, and the paragraph under it invites
+    a re-run ("if the number looks large, that is the first thing to check").
+    Concrete failure: a commit lands after assembly, the auditor re-runs the
+    line in their own tree, `..HEAD` now covers it, and the longer file list
+    reads as the previous round having under-reported its payload.
+    """
+    rc, out, err = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
+    assert rc == 0, err
+    led = ledger_section(out)
+    # 🔴 POSITIVE CONTROL: a brief with no provenance line at all would satisfy
+    # every "must not contain" below while reporting nothing.
+    assert "--remerge-diff" in led, (
+        f"THE LEDGER prints no provenance command at all, so the assertions "
+        f"below are about nothing:\n{led}"
+    )
+    anchor = rendered_range(out).partition("..")[0]
+    assert f"{anchor}..{FAKE_HEAD_OID} --not" in led, (
+        "\n\nTHE LEDGER's provenance line does not name the sha it resolved. "
+        f"It measured `{anchor}..HEAD` in a checkout whose HEAD was verified "
+        f"to be {FAKE_HEAD_OID}; spelling that sha reports the same commit and "
+        f"re-runs to the same answer anywhere.\n{led}"
+    )
+    assert "..HEAD" not in led, (
+        "\n\nTHE LEDGER still hands the reader a `..HEAD`. That token resolves "
+        "where THEY are standing — a tree cut after this brief was assembled "
+        f"— and the brief tells them to re-run this command.\n{led}"
+    )
+
+
+def test_the_degenerate_range_names_shas_at_both_ends():
+    """🔴 REGRESSION. Red at `28492af2`, which rendered ``aaaa1111..HEAD``.
+
+    Round 7's tip fix was HALF-APPLIED: it moved the VERIFIED branch off the
+    token and its own comment recorded "Only the VERIFIED branch hardcoded
+    `HEAD`", while the DEGENERATE branch of the same `if`/`elif` — four lines
+    above it — still handed one out. The suite stayed fully green, so nothing
+    said otherwise.
+
+    🔴 THE BANNER OVER THAT RANGE MAKES AN ABSOLUTE CLAIM, which is what makes
+    the spelling load-bearing rather than cosmetic: "Both ends of the range
+    name the same commit, so it can never contain anything, whatever the PR
+    looks like." That is a property of the ASSEMBLY tree at assembly time. Under
+    `aaaa1111..HEAD` it is simply false in the auditor's tree the moment a
+    commit lands in between — the range is non-empty there, and the loudest
+    banner in the brief is telling them it cannot be.
+    """
+    brief = brief_for_scenario("degenerate")
+    section = range_section(brief)
+    # 🔴 POSITIVE CONTROL: assert we are reading the DEGENERATE branch. Without
+    # it a fixture change that stops producing a self-range would leave every
+    # assertion below true of the ordinary verified branch instead.
+    assert "DEGENERATE RANGE" in section, (
+        f"this scenario no longer renders the degenerate branch:\n{section}"
+    )
+    frm, _, tip = rendered_range(brief).partition("..")
+    assert tip != "HEAD", (
+        "\n\nthe DEGENERATE branch hands the auditor `..HEAD` while the banner "
+        "under it says the range 'can never contain anything, whatever the PR "
+        f"looks like'. In their tree it can.\n{section}"
+    )
+    assert tip == SELF_RANGE_HEAD, (
+        f"\n\nthe degenerate range ends at {tip!r}, not at the head that was "
+        f"verified ({SELF_RANGE_HEAD})."
+    )
+    assert ad.same_commit(frm, tip), (
+        f"\n\n`{frm}..{tip}` is not a self-range, so the DEGENERATE banner "
+        "above it is being printed over an ordinary range."
+    )
+
+
+def test_a_cross_repo_range_states_the_impossibility_not_a_moved_checkout():
+    """🔴 REGRESSION. Red at `28492af2`.
+
+    THE FOURTH INSTANCE OF THIS LADDER'S RECURRING CONFUSION, on the REPOSITORY
+    axis: the repo `gh` was asked about versus the repo `git` was run in. Every
+    git command goes to `repo_dir`, the assembly checkout, while the PR's facts
+    come from `gh` about `facts.repo`. Cross-repo those are different
+    repositories, so `verify_head_is_the_pr` is STRUCTURALLY unable to pass and
+    the could-not-verify branch fires on every cross-repo delta round.
+
+    Measured at the base, in this scenario: the brief said "this checkout's
+    HEAD is `9999…`, but the PR's head is `aaaa…` — the two are DIFFERENT
+    COMMITS", then "Resolve the range in a tree that CONTAINS the PR's head
+    before trusting any number derived from it". Both sentences describe a
+    checkout that has MOVED and can be moved back. Neither is true here: there
+    is no such tree in this repository and there never will be, so the
+    instruction is unfollowable and the reader is sent looking for a fix that
+    does not exist.
+    """
+    brief = brief_for_scenario("cross-repo-delta")
+    section = range_section(brief)
+    assert "CROSS-REPO" in brief, (
+        "this scenario no longer renders the cross-repo branch, so the "
+        "assertions below are about a different configuration"
+    )
+    # 🔴 POSITIVE CONTROL for the slice: a section with no verdict at all would
+    # satisfy every "must not say" below.
+    assert "🔴" in section, f"THE RANGE carries no banner at all:\n{section}"
+    assert "STRUCTURAL AND PERMANENT" in section, (
+        "\n\nTHE RANGE does not tell a cross-repo auditor that this checkout "
+        "CANNOT be standing on the PR. Without that, the two shas it prints "
+        f"read as a checkout that drifted.\n{section}"
+    )
+    assert "Resolve the range in a tree that CONTAINS" not in section, (
+        "\n\nTHE RANGE tells a cross-repo auditor to resolve the range in a "
+        "tree that contains the PR's head. This repository has no such tree "
+        f"and cannot acquire one — the instruction is unfollowable.\n{section}"
+    )
+    # The tip is still the PR's real head sha: naming the impossibility must
+    # not cost the auditor the one ref they CAN use in their own worktree.
+    assert rendered_range(brief).partition("..")[2] == FAKE_OTHER_HEAD_OID, (
+        "\n\nthe cross-repo range no longer ends at the PR's head sha, which "
+        "is the only tip that resolves in the worktree WHERE TO WORK sent "
+        "them to."
+    )
+
+
+def test_a_cross_repo_ledger_hands_the_attribution_gate_to_the_auditor():
+    """🔴 REGRESSION. Red at `28492af2`, which printed COULD NOT MEASURE.
+
+    `measure_ledger` refuses the moment the head check is not ok, and
+    cross-repo that check cannot pass — so THE LEDGER printed its generic
+    failure banner on EVERY delta round of such a PR, with advice ("Re-run the
+    command by hand") that points at the wrong repository. That is the
+    permanently-red gate `claude/RULES.md` names: a section that is red every
+    single time trains the reader to skip it.
+
+    🔴 AND WHAT GETS SKIPPED IS A GATE. The ladder ends on two consecutive
+    rounds of ZERO payload lines. Nobody but the auditor can compute that
+    number for a cross-repo PR, and at the base nothing told them so — the
+    brief reported a failure and moved on, leaving the stop condition
+    permanently unevaluated while reading as though the script had tried.
+    """
+    brief = brief_for_scenario("cross-repo-delta")
+    led = ledger_section(brief)
+    assert "NOT MEASURABLE FROM HERE" in led, (
+        f"\n\nTHE LEDGER does not say the measurement is structurally "
+        f"impossible from this repository:\n{led}"
+    )
+    assert "COULD NOT MEASURE" not in led, (
+        "\n\nTHE LEDGER reports a cross-repo round as a command that failed. "
+        "It did not fail; it was never runnable here, and it never will be — "
+        f"phrasing it as a failure invites a re-run in the wrong repo.\n{led}"
+    )
+    assert "ATTRIBUTION GATE IS YOURS" in led, (
+        "\n\nTHE LEDGER does not tell the auditor that the payload-attribution "
+        "gate is theirs to compute this round. A gate nobody evaluates never "
+        f"fires, and the ladder then runs forever on scaffolding.\n{led}"
+    )
+    # 🔴 THE HAND-OVER MUST BE RUNNABLE, and in the right tree. Asserted as a
+    # whole command line rather than by its parts: three correct fragments in
+    # an unrunnable order is exactly what a fragment pin cannot see.
+    assert (
+        "git -C <your worktree> log --numstat --format= --remerge-diff "
+        f"aaaa1111..{FAKE_OTHER_HEAD_OID} --not origin/main"
+    ) in led, (
+        f"\n\nTHE LEDGER hands over no runnable command, or one whose range "
+        f"is not this round's:\n{led}"
+    )
+    assert "<your worktree>" in led and "your clone of" in led.replace(
+        "YOUR clone of", "your clone of"
+    ), (
+        "\n\nTHE LEDGER does not say WHERE the command must run. `origin/main` "
+        "names this checkout's base branch here and the PR's base branch "
+        f"there; the command is only correct in one of them.\n{led}"
+    )
+
+
+def test_no_cross_repo_brief_claims_its_checkout_was_verified():
+    """🔴 THE SEAM GUARD, and it is also this module's fixture guard.
+
+    🔴 INVARIANT GUARD; its evidence is mutant V9, not a base ref. At
+    `28492af2` the SCRIPT would pass this — the sentence it forbids appears
+    only when the head check succeeded, and the base's cross-repo scenarios all
+    ran at round 1 where THE RANGE does not exist. What was wrong at the base
+    was the FIXTURE: `OTHER_REPO_PR` inherited `headRefOid` from `DEFAULT_PR`
+    and `make_runner` defaults the checkout's HEAD to it, so the first
+    cross-repo delta render printed "verified at assembly time to be PR #900's
+    head commit" for a PR in another repository. A test written with that
+    fixture would have passed in a physically impossible state.
+
+    So this pins the RELATIONSHIP rather than either side: no brief may claim
+    verification of a checkout it has itself just called a different
+    repository, in any scenario this module knows or later adds.
+    """
+    seen = 0
+    for scenario in SCENARIOS:
+        brief = brief_for_scenario(scenario)
+        if "## WHERE TO WORK — 🔴 CROSS-REPO" not in brief:
+            continue
+        seen += 1
+        assert "verified at assembly time" not in brief, (
+            f"\n\nscenario {scenario!r}: the brief says this checkout was "
+            "verified to be standing on the PR's head, two bars after saying "
+            "the PR lives in a DIFFERENT repository. One of the two is false, "
+            "and in the fixture it was the head check — the PR's oid was "
+            "handed to the assembly checkout's `rev-parse HEAD`."
+        )
+    assert seen, (
+        "no scenario renders a CROSS-REPO brief, so the loop above asserted "
+        "nothing. Either the heading moved or the cross-repo scenarios were "
+        "dropped from SCENARIO_RUNS."
     )
 
 
@@ -2822,6 +3402,29 @@ _KIND_LINE = re.compile(r"^\s*kind\s*:\s*(.+)$", re.M)
 # 🔴 Round 5's sentence, verbatim, kept ONLY as the positive control's payload.
 ROUND_5_NO_WRITE_SCOPE = "The no-write rule below is about the SHARED checkout."
 
+# 🔴 ROUND 8 — THE ONE FORM OF WORDS BOTH SIDES MUST USE FOR THE SAME SET.
+# Round 6 found a forward reference scoped to a STATE the clause had stopped
+# naming; round 7 fixed it by rewriting the reference to "every checkout you
+# did not make" while the clause said "any checkout that is not the copy YOU
+# made FOR THIS AUDIT". Still two sets — and the difference is not academic: it
+# lands exactly on the clone WHERE TO WORK tells a cross-repo auditor to run
+# `git worktree add` in, which they made but did not make for this audit.
+# Forbidden under the clause, permitted under the reference, prescribed by the
+# brief.
+#
+# The guard beside it therefore pins a PHRASE both sides must spell, not a
+# vocabulary either may avoid: a scope stated in two forms of words is two
+# scopes, whatever they were meant to mean. `claude/RULES.md` -> spelled-guards:
+# when the artifact under test is prose, pin the string.
+NO_WRITE_SCOPE = "checkout you did not make"
+
+# Round 7's clause scope, kept ONLY as the control's payload — the narrower of
+# the two sets, and the one that forbade the brief's own recipe.
+ROUND_7_CLAUSE_SCOPE = (
+    "**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to any "
+    "checkout that is not the copy YOU made for this audit.**"
+)
+
 
 def no_write_forward_references(text):
     """Sentences that tell the reader what the no-write rule COVERS.
@@ -2920,6 +3523,86 @@ def test_no_forward_reference_scopes_the_no_write_rule_to_a_denied_state():
         "no scenario renders a forward reference to the no-write rule at all, "
         "so the loop above asserted nothing. Either the sentence was deleted "
         "or `no_write_forward_references` no longer matches how it is spelled."
+    )
+
+
+def no_write_scope_disagreements(brief, clause_text):
+    """-> [(which side, sentence)] for each side that does not spell the scope.
+
+    🔴 THE RELATIONSHIP, not either component: the `no-fetch` clause and every
+    sentence that forward-references it must name ONE set, in ONE form of
+    words. Round 6's guard beside this asks a narrower question — does a
+    forward reference name a checkout STATE this brief denies — and a scope
+    can disagree without naming any state at all, which is precisely how round
+    7's fix passed it while narrowing the clause on a different axis.
+    """
+    out = []
+    if NO_WRITE_SCOPE not in norm(clause_text):
+        out.append(("the `no-fetch` clause", norm(clause_text)))
+    for s in no_write_forward_references(brief):
+        if NO_WRITE_SCOPE not in norm(s):
+            out.append(("a forward reference", norm(s)))
+    return out
+
+
+def test_the_no_write_forward_reference_states_the_clauses_own_scope():
+    """🔴 REGRESSION. Red at `28492af2`, on the CLAUSE side.
+
+    Measured there: the clause read "any checkout that is not the copy YOU
+    made FOR THIS AUDIT" and the sentence forward-referencing it read "every
+    checkout you did not make". Two sets, and the difference lands on exactly
+    one tree — the clone WHERE TO WORK tells a cross-repo auditor to write
+    into, three lines earlier: ``git -C <your local clone of owner/name>
+    worktree add …``. That clone is one they made; it is not one they made for
+    this audit. Forbidden by the clause, permitted by the reference,
+    prescribed by the brief.
+
+    🔴 AND THE COMMENT ABOVE THE REFERENCE ASSERTED THEY AGREED — "the scope is
+    stated the way the clause states it" — which is a claim about the clause
+    and was false. A comment is a claim too, and this one would have stopped
+    the next reader checking.
+
+    Round 6 fixed a forward reference that narrowed the rule it named; round 7
+    replaced that narrowing with another on a different axis. So the guard is
+    on the SET both sides must spell, not on the vocabulary either may avoid.
+    """
+    clause = {c.id: c.text for c in ad.INVARIANT_CLAUSES}["no-fetch"]
+
+    # 🔴 TWO POSITIVE CONTROLS, ONE PER SIDE. A predicate that can only see one
+    # of the two is half a guard, and which half is invisible is not something
+    # a clean result can tell you.
+    assert no_write_scope_disagreements(brief_for_scenario("cross-repo"),
+                                        ROUND_7_CLAUSE_SCOPE), (
+        "POSITIVE CONTROL (clause side): the scan cannot see round 7's own "
+        "clause wording, so a clean result below says nothing about the clause"
+    )
+    ref_control = (
+        "## THE CHECKOUT — state at assembly time\n\n"
+        "    kind   : SHARED — other sessions and agents are in this tree\n\n"
+        f"{ROUND_5_NO_WRITE_SCOPE}\n\n## NEXT\n"
+    )
+    assert no_write_scope_disagreements(ref_control, clause), (
+        "POSITIVE CONTROL (reference side): the scan cannot see round 5's own "
+        "sentence, so a clean result below says nothing about the reference"
+    )
+
+    seen = 0
+    for scenario in SCENARIOS:
+        brief = brief_for_scenario(scenario)
+        seen += len(no_write_forward_references(brief))
+        bad = no_write_scope_disagreements(brief, clause)
+        assert not bad, (
+            f"\n\nscenario {scenario!r}: the no-write rule's scope is stated "
+            f"in more than one form of words, so it names more than one set. "
+            f"Every side must spell {NO_WRITE_SCOPE!r}:\n"
+            + "".join(f"  {where}: {text!r}\n" for where, text in bad)
+            + "  The set that matters is the auditor's OWN checkouts, and the "
+            "brief's own cross-repo recipe writes to one of them — a clone "
+            "they made, and did not make for this audit."
+        )
+    assert seen, (
+        "no scenario renders a forward reference to the no-write rule at all, "
+        "so only the clause half of the loop above asserted anything."
     )
 
 
@@ -3283,22 +3966,47 @@ def test_the_blind_spot_rationale_matches_what_the_script_actually_does():
         + "\n".join("  " + " ".join(c) for c in resolving)
     )
 
-    # 🔴 AND THE PROSE MAY NOT SAY OTHERWISE. Normalised the same way
-    # `surviving_refuted_premises` normalises, and for the same two reasons:
-    # these live in wrapped comments and in implicitly-concatenated literals.
-    def flat(text):
-        return " ".join(re.sub(r'"\s*"', "", text).split())
+    # 🔴 AND THE PROSE MAY NOT SAY OTHERWISE. Read through `flat_prose`, the
+    # SHARED normaliser — one rule in one place. Round 7 gave this test its own
+    # copy of `surviving_refuted_premises`'s three-liner, and round 8 measured
+    # both copies blind to the same three shapes; two copies of a predicate are
+    # wrong at both sites in the same direction, which is exactly what happened.
+    script_src = Path(ad.__file__).read_text(encoding="utf-8")
+    script = flat_prose(script_src)
+    module = flat_prose(_THIS_MODULE_SOURCE)
 
-    script = flat(Path(ad.__file__).read_text(encoding="utf-8"))
-    module = flat(_THIS_MODULE_SOURCE)
-    # POSITIVE CONTROL for the scan itself.
-    assert flat(f"x {FALSE_BLIND_SPOT_RATIONALES[0]} y").count(
-        flat(FALSE_BLIND_SPOT_RATIONALES[0])) == 1, (
-        "POSITIVE CONTROL: the normalising counter cannot find a phrase it was "
-        "just handed, so every zero below would be meaningless"
+    # 🔴 POSITIVE CONTROL, ONE PER SHAPE, AND PLANTED INTO REAL SOURCE. Round
+    # 7's control handed the normaliser the bare string `f"x {phrase} y"` —
+    # which is not Python, is not the thing the assertions below scan, and
+    # could not have exercised a comment wrap or a concatenation even in
+    # principle. A control that shares no step with the measurement is not a
+    # control. These plant into the SCRIPT's own source, which is what the
+    # `== 0` assertion below reads.
+    probe = FALSE_BLIND_SPOT_RATIONALES[0]
+    assert not set(probe) & set("\"'\\"), (
+        f"the plants below embed {probe!r} in GENERATED Python source, so a "
+        "quote or a backslash in it would raise SyntaxError instead of "
+        "testing anything. Pick a quote-free ledger entry for this control."
     )
+    pw = probe.split()
+    ph, pt = " ".join(pw[:2]), " ".join(pw[2:])
+    assert ph and pt, f"{probe!r} does not split into two wrappable halves"
+    for shape, payload in {
+        "one `#` line": f"\n# {probe}\n",
+        "two `#` lines": f"\n# {ph}\n# {pt}\n",
+        "wrapped docstring": f'\ndef _plant():\n    """{ph}\n    {pt}"""\n',
+        'concat "…" "…"': f'\n_plant = ("{ph} "\n          "{pt}")\n',
+        "concat '…' '…'": f"\n_plant = ('{ph} '\n          '{pt}')\n",
+        "concat \"…\" '…'": f'\n_plant = ("{ph} "\n' + f"          '{pt}')\n",
+    }.items():
+        assert flat_prose(script_src + payload).count(collapse_ws(probe)) == 1, (
+            f"POSITIVE CONTROL ({shape}): the scan cannot see {probe!r} planted "
+            "into the script in that shape, so the zero asserted below says "
+            "nothing about a rationale written that way — and this ladder "
+            "writes its rationales in wrapped comment blocks."
+        )
     for phrase in FALSE_BLIND_SPOT_RATIONALES:
-        p = flat(phrase)
+        p = collapse_ws(phrase)
         assert script.count(p) == 0, (
             f"\n\n`scripts/audit-dispatch.py` states {phrase!r} of itself, "
             f"{script.count(p)} time(s). It is false — the run above resolved "
@@ -3994,12 +4702,48 @@ RED_AT_BASE_R6: frozenset[str] = frozenset({
     "test_the_range_names_a_sha_and_not_head_when_the_head_is_verified",
 })
 
+# 🔴 ROUND 8's base is the ROUND-7 TREE, `28492af2`. Measured the same way —
+# `git show 28492af2:scripts/audit-dispatch.py` into a scratch tree with THIS
+# module copied in unchanged, `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`:
+# **9 failed, 93 passed**. SIX of the nine are these; of the other three, two
+# are the whole-string clause and directive ledgers moving with round 8's
+# reword, and one is the skipped-round warning guard, which is red there on an
+# ABSENCE the fix adds.
+#
+# 🔴 THREE OF ROUND 8's NEW TESTS ARE **NOT** HERE, for three different
+# reasons, and each is recorded rather than quietly filed:
+#   * `..._claims_block_more_than_one_round_behind_is_warned_about` IS red at
+#     the base, and is filed as a guard anyway: no such warning exists there,
+#     so its red is an absence the fix adds, which this module says everywhere
+#     is not evidence of anything. Its evidence is mutant V16.
+#   * `..._no_cross_repo_brief_claims_its_checkout_was_verified` is GREEN at the
+#     base. What was wrong there was this module's FIXTURE, not the script:
+#     `OTHER_REPO_PR` inherited `DEFAULT_PR`'s `headRefOid`, so the checkout was
+#     modelled as standing on a commit of another repository. Carrying the FIXED
+#     fixture back to the base tree therefore passes. Its evidence is mutant V9.
+#   * `..._refuted_premise_survives_in_this_modules_prose` (round 7's) still
+#     cannot be red under this procedure at all — it scans THIS MODULE, which
+#     the procedure copies in unchanged.
+RED_AT_BASE_R7: frozenset[str] = frozenset({
+    # 🔴 NOT ONE OF ROUND 7's FINDINGS. Found in round 8 by sweeping for the
+    # ladder's recurring shape, which round 7's auditor asked for explicitly:
+    # `newest is not None` was read as "there is an anchor". Red at the base on
+    # a WRONG ANSWER, not an absence — `Diff `None..<sha>`` at rc 0.
+    "test_a_block_that_parses_but_yields_no_anchor_is_refused",
+    "test_the_ledgers_provenance_line_names_the_sha_it_resolved_not_head",
+    "test_the_degenerate_range_names_shas_at_both_ends",
+    "test_a_cross_repo_range_states_the_impossibility_not_a_moved_checkout",
+    "test_a_cross_repo_ledger_hands_the_attribution_gate_to_the_auditor",
+    "test_the_no_write_forward_reference_states_the_clauses_own_scope",
+})
+
 RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "abc41024": RED_AT_BASE_R2,
     "d9eb36a8": RED_AT_BASE_R3,
     "e06461f7": RED_AT_BASE_R4,
     "dd601793": RED_AT_BASE_R5,
     "3619fe68": RED_AT_BASE_R6,
+    "28492af2": RED_AT_BASE_R7,
 }
 RED_AT_BASE: frozenset[str] = frozenset().union(*RED_AT_BASE_REFS.values())
 
@@ -4112,6 +4856,23 @@ INVARIANT_GUARDS_AND_LEDGERS = frozenset({
     # in-test positive control is what keeps it honest per run. The battery
     # mutates the script and cannot reach it.
     "test_no_refuted_premise_survives_in_this_modules_prose",
+    # ------------------------------------------------------------------- #
+    # Round 8's one guard, and it is GREEN at `28492af2` for a reason worth
+    # keeping: the defect it closes was in this module's FIXTURE, not in the
+    # script. `OTHER_REPO_PR` inherited `DEFAULT_PR`'s `headRefOid` and
+    # `make_runner` defaults the assembly checkout's HEAD to the PR's own oid,
+    # so a cross-repo brief could be rendered with the checkout modelled as
+    # standing on a commit that exists only in the OTHER repository. Carrying
+    # the FIXED fixture back to the base tree therefore passes — a base script
+    # says nothing about a base fixture, the same shape as round 7's guard
+    # above. Its evidence is mutant V9, which restores the impossible state
+    # from the script side by claiming verification unconditionally.
+    "test_no_cross_repo_brief_claims_its_checkout_was_verified",
+    # There is no gap warning at `28492af2` at all, so a red there would be an
+    # absence the fix adds. Same filing as Z5's legend. Mutant V16 removes it
+    # again, and the test's own negative control (an ADJACENT block must stay
+    # silent) is what stops the warning being satisfied by firing always.
+    "test_a_claims_block_more_than_one_round_behind_is_warned_about",
 })
 
 # --------------------------------------------------------------------------- #
@@ -4368,6 +5129,58 @@ FIX_MATRIX = (
      "in a worktree cut AFTER assembly (pre-existing; the third instance)",
      "test_the_range_names_a_sha_and_not_head_when_the_head_is_verified",
      "RED@3619fe68", "V6"),
+
+    # ------------------------------------------------------------------ #
+    # 🔴 ROUND 7's FINDINGS, FIXED IN ROUND 8. Base `28492af2`.
+    # ------------------------------------------------------------------ #
+    ("r7/1  both prose guards were blind to a phrase wrapped across two `#` "
+     "COMMENT lines, and to single/mixed-quote implicit concatenation, while "
+     "both claimed to handle exactly that",
+     "test_the_blind_spot_rationale_matches_what_the_script_actually_does",
+     "RED@3619fe68", "V8, V10"),
+    ("r7/2a cross-repo, the head check CANNOT pass, so THE RANGE diagnosed a "
+     "structural impossibility as a checkout that had moved",
+     "test_a_cross_repo_range_states_the_impossibility_not_a_moved_checkout",
+     "RED@28492af2", "V11"),
+    ("r7/2b and THE LEDGER printed COULD NOT MEASURE on EVERY cross-repo delta "
+     "round — a permanently-red gate, with the ladder's own payload-attribution "
+     "gate left uncomputed by anyone",
+     "test_a_cross_repo_ledger_hands_the_attribution_gate_to_the_auditor",
+     "RED@28492af2", "V12"),
+    ("r7/2c the cross-repo fixture inherited the PR's `headRefOid`, so a "
+     "cross-repo test would have passed in a physically impossible state",
+     "test_no_cross_repo_brief_claims_its_checkout_was_verified",
+     "GUARD", "V9"),
+    ("r7/3  the round-7 tip fix was HALF-APPLIED: the DEGENERATE branch of the "
+     "same if/elif still handed out `..HEAD`, under a banner claiming the "
+     "range can never contain anything",
+     "test_the_degenerate_range_names_shas_at_both_ends",
+     "RED@28492af2", "V13"),
+    ("r7/4  the forward reference named a WIDER set than the clause it "
+     "describes, and the difference was the clone the brief's own recipe "
+     "writes to",
+     "test_the_no_write_forward_reference_states_the_clauses_own_scope",
+     "RED@28492af2", "V14"),
+    ("r7/5  THE LEDGER's provenance line was the last command in the brief "
+     "whose `HEAD` resolves differently for the reader the brief invites to "
+     "re-run it",
+     "test_the_ledgers_provenance_line_names_the_sha_it_resolved_not_head",
+     "RED@28492af2", "V15"),
+    # Disclosed by round 7's auditor rather than filed as a finding, and taken
+    # because it is the MIRROR of a warning that already shipped: a block from
+    # a LATER round warned, a block four rounds EARLIER was silent.
+    ("r7/6  a claims block several rounds behind was presented as this round's "
+     "framing, silently — the existing warning covered only the other direction",
+     "test_a_claims_block_more_than_one_round_behind_is_warned_about",
+     "GUARD", "V16"),
+    # 🔴 NOT ROUND 7's FINDING — round 8's own, found by sweeping for the
+    # recurring shape. Filed under round 7's base because that is the tree it
+    # was watched red at.
+    ("r8/1  a block that PARSED was read as a block that yields an ANCHOR: "
+     "`audited=..` rendered ``Diff `None..<sha>` `` at rc 0, under \"verified "
+     "at assembly time\", with THE LEDGER giving the round-1 cause",
+     "test_a_block_that_parses_but_yields_no_anchor_is_refused",
+     "RED@28492af2", "V17"),
 )
 
 # A COLLAPSE floor, not a growth floor: a matrix emptied by a bad refactor
@@ -4385,7 +5198,9 @@ FIX_MATRIX = (
 # 54 - max(1, 54 // 20) = 52. Counted again, not extrapolated. Round 7 added
 # seven more: m = 61, and 61 - max(1, 61 // 20) = 58. Counted by asking the
 # constant itself (`len(FIX_MATRIX)`), not by adding 7 to the last sentence.
-MIN_FIX_MATRIX_ROWS = 58
+# Round 8 added nine: m = 70, and 70 - max(1, 70 // 20) = 67. Counted the same
+# way, by importing the module and printing `len(FIX_MATRIX)`.
+MIN_FIX_MATRIX_ROWS = 67
 
 # 🔴 THE MUTANTS COLUMN IS AN EVIDENCE CLAIM, AND IT WAS UNGRADED.
 # `fix_matrix_problems` took `_mutants` and threw it away, so rewriting a
@@ -4644,9 +5459,10 @@ def surviving_refuted_premises(text):
     asserting the premise somewhere else; ZERO means the ledger entry was
     deleted, which is the same failure read from the other end.
 
-    🔴 NORMALISED TWICE OVER, AND THE FIRST TWO DRAFTS WERE NOT — each MISSED
-    an occurrence it was written for, and each reported the module CLEAN with
-    the premise sitting two lines away. Both were measured against `3619fe68`:
+    🔴 NORMALISED FOUR DRAFTS DEEP, AND THE FIRST THREE WERE NOT ENOUGH — each
+    MISSED an occurrence it was written for, and each reported the module CLEAN
+    with the premise sitting two lines away. The first two were measured
+    against `3619fe68`:
 
       * a raw `str.count` scored **0** for both phrases. They live in WRAPPED
         prose, so the source reads `where a dispatched auditor\\n    usually
@@ -4656,15 +5472,21 @@ def surviving_refuted_premises(text):
         spans a Python IMPLICIT CONCATENATION — the phrase is cut in half by a
         closing quote, a newline and an opening quote, and collapsing
         whitespace leaves the two quote characters sitting in the middle of
-        it. So adjacent literals are joined FIRST, exactly as the compiler
-        joins them, and only then is whitespace collapsed.
+        it. So adjacent literals had to be joined first.
+
+    The third — round 7's, the one this replaces — collapsed whitespace over a
+    `re.sub(r'"\\s*"', "", …)`, and scored **0** for a phrase wrapped across two
+    `#` COMMENT lines (the `#` is left sitting mid-phrase) and **0** for the
+    single- and mixed-quote spellings of the concatenation it claimed to join
+    "exactly as the compiler joins them". Measured at `28492af2`; the shape
+    table is beside `flat_prose`, which now does the reading.
 
     That is the "guard whose description is wider than its implementation"
-    failure, twice, in the guard written to catch a claim wider than its code.
+    failure, three times over, in the guard written to catch a claim wider than
+    its code.
     """
-    joined = re.sub(r'"\s*"', "", text)      # implicit string concatenation
-    flat = " ".join(joined.split())           # wrapped prose
-    counts = [(p, flat.count(" ".join(p.split()))) for p, _ in REFUTED_PREMISES]
+    flat = flat_prose(text)
+    counts = [(p, flat.count(collapse_ws(p))) for p, _ in REFUTED_PREMISES]
     return [(p, n) for p, n in counts if n != 1]
 
 
@@ -4691,11 +5513,37 @@ def test_no_refuted_premise_survives_in_this_modules_prose():
     # 🔴 POSITIVE CONTROL, through the same function: a clean result over a
     # scan that matched nothing is indistinguishable from a scan wired to
     # nothing. Plant a second copy and require it to be seen.
-    planted = f"{_THIS_MODULE_SOURCE}\n# {REFUTED_PREMISES[0][0]}\n"
-    assert surviving_refuted_premises(planted), (
-        "POSITIVE CONTROL: the scan cannot see a planted second copy of "
-        f"{REFUTED_PREMISES[0][0]!r}, so a clean result below says nothing"
+    #
+    # 🔴 ROUND 8 — ONE PLANT PER SHAPE, NOT ONE PLANT. Round 7's control planted
+    # a single-line `#` comment and nothing else, which is a shape its
+    # normaliser could already see; the two shapes it could NOT see went
+    # unexercised, so a control that passed said nothing about them. A control
+    # only covers the shapes it plants, and the shapes this ladder actually
+    # writes its prose in are the wrapped comment block and the concatenated
+    # literal.
+    phrase = REFUTED_PREMISES[0][0]
+    assert not set(phrase) & set("\"'\\"), (
+        f"the plants below embed {phrase!r} in GENERATED Python source, so a "
+        "quote or a backslash in it would raise SyntaxError instead of "
+        "testing anything. Pick a quote-free ledger entry for this control."
     )
+    words = phrase.split()
+    head, tail = " ".join(words[:3]), " ".join(words[3:])
+    assert head and tail, f"{phrase!r} does not split into two wrappable halves"
+    for shape, payload in {
+        "one `#` line": f"\n# {phrase}\n",
+        "two `#` lines": f"\n# {head}\n# {tail}\n",
+        "wrapped docstring": f'\ndef _plant():\n    """{head}\n    {tail}"""\n',
+        'concat "…" "…"': f'\n_plant = ("{head} "\n          "{tail}")\n',
+        "concat '…' '…'": f"\n_plant = ('{head} '\n          '{tail}')\n",
+        "concat \"…\" '…'": f'\n_plant = ("{head} "\n' + f"          '{tail}')\n",
+    }.items():
+        assert surviving_refuted_premises(_THIS_MODULE_SOURCE + payload), (
+            f"POSITIVE CONTROL ({shape}): the scan cannot see a planted second "
+            f"copy of {phrase!r} in that shape, so a clean result below says "
+            "nothing about prose written that way — and this ladder writes its "
+            "narrative in wrapped comment blocks."
+        )
     survivors = surviving_refuted_premises(_THIS_MODULE_SOURCE)
     assert not survivors, (
         "\n\nthis module states a premise the ladder has REFUTED:\n"

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -1332,11 +1332,22 @@ DIRECTIVE_LEDGER = {
     # `checkout` are refused there explicitly rather than left to the reader's
     # reading of "you made". The forward-reference sentence is untouched and
     # still spells `NO_WRITE_SCOPE`.
+    #
+    # 🔴 ROUND 12. That refusal was an ENUMERATION of three verbs, over the one
+    # tree in this brief whose blast radius is outside it: the `no-fetch`
+    # clause is scoped to "every checkout you did not make" and the clone is
+    # deliberately outside it, so this sentence is the ONLY rule covering that
+    # tree. `git -C <clone> remote update` — which is what an auditor reaches
+    # for when `fetch` is refused by name and they still need the PR branch
+    # present before `worktree add` — was unenumerated, and so were `switch`,
+    # `restore`, `reset`, `branch -f` and `gc`. The permission is now stated
+    # positively with a universal refusal after it.
     "own-worktree-is-writable": (
         "That worktree is YOURS: fetching and checking out inside it is fine. "
         "In the clone you made it from, `git worktree add` is the ONLY write "
-        "this brief asks for — do not `fetch`, `pull` or `checkout` there, "
-        "whoever made it, because other sessions may be standing in it. The "
+        "this brief asks for and the ONLY one you may make — every other "
+        "command that writes there is refused, named or not, whoever made "
+        "that clone, because other sessions may be standing in it. The "
         "no-write rule below is about every checkout you did not make."
     ),
 }
@@ -3848,6 +3859,31 @@ CLONE_WRITE_GRANT_PHRASES = (
     "checking out inside either",
 )
 
+# 🔴 ROUND 12 — ROUND 10's OWN GRANT, verbatim, kept as the positive control
+# for the ENUMERATION probe below. Same role as `ROUND_8_CLONE_GRANT`: it must
+# be RED, so a clean result over the shipping grant means something.
+ROUND_10_CLONE_GRANT = (
+    "That worktree is YOURS: fetching and checking out inside it is fine. "
+    "In the clone you made it from, `git worktree add` is the ONLY write "
+    "this brief asks for — do not `fetch`, `pull` or `checkout` there, "
+    "whoever made it, because other sessions may be standing in it. The "
+    "no-write rule below is about every checkout you did not make."
+)
+
+# A CLOSED LIST of refused verbs — "do not `a`, `b` or `c` there". The shape
+# that leaves `remote update`, `switch`, `restore`, `reset`, `branch -f` and
+# `gc` permitted by omission.
+_ENUMERATED_CLONE_REFUSAL = re.compile(
+    r"do not (?:`[a-z][a-z-]*`(?:, )?)+ ?or `[a-z][a-z-]*` there"
+)
+
+# The universal that replaces it: the permitted write stated positively, and
+# everything else refused whether or not anyone thought to name it.
+CLONE_GRANT_CATCH_ALL = (
+    "the ONLY one you may make — every other command that writes there is "
+    "refused, named or not"
+)
+
 # The recipe's own `git -C <clone> …` line, so the verb it runs there is read
 # and not remembered.
 _CLONE_RECIPE = re.compile(r"git -C <your local clone of [^>]*> ([a-z-]+)")
@@ -3877,6 +3913,19 @@ def test_the_clone_grant_covers_only_the_write_the_recipe_makes():
     🔴 THE RELATIONSHIP, not the wording: the verb is read off the recipe LINE,
     so a recipe that starts running something else in the clone fails here
     rather than silently acquiring permission for it.
+
+    🔴 ROUND 12 — AND THE REFUSAL MUST BE A UNIVERSAL, NOT A LIST. Round 10's
+    fix refused `fetch`, `pull` and `checkout` BY NAME, which leaves everything
+    unnamed permitted by omission: `git -C <clone> remote update` is what an
+    auditor reaches for once `fetch` is refused and they still need the PR
+    branch present before `worktree add`, and `switch`, `restore`, `reset`,
+    `branch -f` and `gc` are the same hole. This directive is the ONLY rule
+    covering that tree — the `no-fetch` clause is scoped to every checkout you
+    did NOT make, and round 7 chose that scope precisely so the recipe's
+    `worktree add` stops being forbidden — and it is the only finding in this
+    ladder whose consequence is a cross-session write into `~/workspace/<repo>`
+    while other sessions are working there. So the shipping grant must carry no
+    closed verb list AND must state the catch-all.
     """
     assert clone_write_grants_in(ROUND_8_CLONE_GRANT), (
         "POSITIVE CONTROL: the probe cannot see round 8's own grant, so a "
@@ -3905,9 +3954,27 @@ def test_the_clone_grant_covers_only_the_write_the_recipe_makes():
         "clone, so the next reader has only 'you made it' to reason from — "
         f"which is what round 8 reasoned from.\n{grant}"
     )
-    assert "do not `fetch`, `pull` or `checkout` there" in grant, (
-        "\n\nthe grant no longer refuses the two operations round 8 permitted "
-        f"in the clone.\n{grant}"
+    # 🔴 ROUND 12 — A CATCH-ALL, NOT A LONGER VERB LIST. Positive control
+    # first: the probe must be able to SEE round 10's enumeration, or a clean
+    # result over the shipping grant is a scan wired to nothing.
+    assert _ENUMERATED_CLONE_REFUSAL.search(ROUND_10_CLONE_GRANT), (
+        "POSITIVE CONTROL: the enumeration probe cannot see round 10's own "
+        "`do not `fetch`, `pull` or `checkout` there`, so a clean result "
+        "below would say nothing at all"
+    )
+    assert not _ENUMERATED_CLONE_REFUSAL.search(grant), (
+        "\n\nthe clone grant refuses a CLOSED LIST of verbs. Everything not "
+        "on it is permitted by omission — `remote update` is what an auditor "
+        "reaches for when `fetch` is refused by name and they still need the "
+        "PR branch present before `worktree add`, and `switch`, `restore`, "
+        "`reset`, `branch -f` and `gc` are the same hole. This is the only "
+        "rule covering that tree: the `no-fetch` clause is scoped to every "
+        f"checkout you did NOT make, and the clone is one you did.\n{grant}"
+    )
+    assert CLONE_GRANT_CATCH_ALL in grant, (
+        "\n\nthe grant no longer refuses everything other than the one write "
+        "it permits. A guard on words is walkable by rewording; the refusal "
+        f"here has to be a universal.\n{grant}"
     )
 
 

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -1,0 +1,978 @@
+#!/usr/bin/env python3
+"""Tests for `scripts/audit-dispatch.py` — the audit-brief assembler.
+
+WHAT THE SCRIPT IS FOR, so these tests are read at the right scope
+------------------------------------------------------------------
+The `/audit-pr` skill tells an operator to dispatch a subagent and supplies no
+procedure, so the brief was reassembled from prose every time. Measured over one
+session's 14 dispatches: 60,100 chars written by hand, 42% mean similarity
+between consecutive briefs, ZERO lines over 25 chars identical across all 14 —
+and three hard-won clauses present in early dispatches and LOST by later ones.
+The script exists to make the invariant sections impossible to forget; this
+module exists to make them impossible to delete quietly.
+
+🔴 WHICH TESTS ARE REGRESSION COVERAGE AND WHICH ARE NOT
+---------------------------------------------------------
+`claude/RULES.md` requires the distinction, and requires naming the base a test
+was watched red at. Here the honest answer is uncomfortable and is stated rather
+than dressed up:
+
+  RED_AT_BASE is **EMPTY, on purpose.** `scripts/audit-dispatch.py` did not
+  exist at `3b79a35a` (this branch's base). Every test below would ERROR at that
+  ref for want of the module, which is not evidence of anything — a test that
+  cannot import the thing it tests is not "red at base" in the sense the rule
+  means. NOTHING here is regression coverage for a bug that shipped.
+
+  Everything here is therefore an INVARIANT GUARD or a STRUCTURAL LEDGER. What
+  makes them non-vacuous is the MUTATION MATRIX below: each was watched to fail
+  against a deliberately mutated copy of the script, and the mutant is named
+  beside the test that caught it. A guard nobody watched go red is a guard
+  nobody has evidence for, whatever its base ref.
+
+  Both facts are asserted mechanically at the bottom of this module
+  (`test_the_two_ledgers_partition_this_modules_tests`), so a test cannot
+  quietly join or leave either list.
+
+🔴 THE NEGATIVE-CONTROL MATRIX — measured, and RE-DERIVABLE
+-------------------------------------------------------------
+🔴 The rows below are transcribed from a harness that is IN THE TREE, and that
+harness is the authority on which rows exist — count them there, not here:
+
+    nix develop ~/workspace/devrc -c python3 scripts/tests/mutants-audit-dispatch.py
+
+It exists rather than a scratchpad script for the reason
+`scripts/tests/mutants-audit-ladder.sh` records: devrc #900 wrote ~30 mutants
+into a docstring and every run of them happened in a session directory that no
+longer exists, so not one row could be re-checked by anyone else — including the
+rows that justified adding a pin. Each row there names the EXACT killer set and
+reports WRONG-KILLER (an expected pin did not fire) separately from EXTRA-KILLER
+(the row no longer isolates what it names).
+
+Run 2026-08-27 against HEAD of this branch, each mutant applied to a COPY of
+`scripts/audit-dispatch.py` in a scratch tree (never the worktree), under
+`PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`, with the unmutated copy as the
+positive control. Every mutant asserted its target string present before
+editing — a mutation that silently fails to apply reports "the guard held",
+which is the most flattering possible wrong answer.
+
+  POS  unmutated copy .............................. 37 passed  <- control
+
+  D1   delete the `read-only` clause ............... 4 failed
+  D3   delete the `stop-rule` clause ............... 4 failed
+  D4   delete the `nit-is-not-a-finding` clause .... 4 failed
+  D5   delete the `reverify-self-reported` clause .. 4 failed
+  D6   delete the `finding-format` clause .......... 4 failed
+  D7   delete the `do-not-merge` clause ............ 4 failed
+         all six kill the same four: ledger_is_pinned_two_way /
+         carries_the_instruction_its_ledger_entry_names /
+         rendered_section_holds_exactly /
+         control_a_clause_deleted_from_the_constant_is_detected
+  D2   delete the `no-fetch` clause ................ 4 failed
+         the three ledger tests, plus
+         missing_clause_check_warns_and_never_blocks — that one looks up
+         `no-fetch` BY ID, so deleting that particular clause makes it error.
+         Recorded rather than tidied away: it is a real coupling, and it is why
+         the deleted-clause CONTROL is a different test from the warn test.
+  A1   ADD an eighth clause with no ledger entry ... 3 failed
+         ledger_is_pinned_two_way / rendered_section_holds_exactly /
+         control_a_clause_deleted_from_the_constant_is_detected
+  R1   reword `stop-rule` to drop "ending it is the
+       CORRECT outcome, not a failure" — the clause
+       is still present and still emitted .......... 1 failed
+         carries_the_instruction_its_ledger_entry_names ALONE
+         🔴 THE REACHABILITY CONTROL. Every presence pin stays GREEN, so a red
+         here proves the FRAGMENT ledger executes and is not a second spelling
+         of the id ledger beside it.
+  F1   render the invariant section from a hardcoded
+       copy of the bullets, ignoring the constant ... 3 failed
+         ledger_is_pinned_two_way stays GREEN (the ids are untouched);
+         rendered_section_holds_exactly, emitted_verbatim_in_both_kinds and the
+         deleted-clause control go red. This is why the RENDERED section is
+         compared and not only the constant.
+  C1   the delta refusal removed (a round-N brief is
+       emitted with no claims block) ............... 3 failed
+         delta_refusal_exits_non_zero / refusal_names_what_it_looked_for /
+         refusal_fires_for_a_malformed_block
+  C2   claims read from the WHOLE comment body
+       instead of the fenced block ................. 3 failed
+         brief_carries_the_claims_and_not_the_reasoning (the framing
+         guarantee) / newest_claims_block_wins / emit_claims round-trip
+  C3   cross-repo decision inverted (`!=` -> `==`) . 3 failed
+         cross_repo_tells_the_agent_to_worktree_the_prs_repo /
+         same_repo_recommends_the_isolation_flag / decision_comes_from_the_repos
+  C4   the numstat command's non-zero exit reads as
+       a clean zero instead of COULD NOT MEASURE ... 1 failed
+         ledger_refuses_a_failed_command_rather_than_printing_zero
+  C5   the ledger classifies by a `test`-substring
+       pathspec and prints a number for X .......... 1 failed
+         ledger_shows_the_files_and_refuses_to_classify_them
+  C6   the missing-clause warning BLOCKS
+       (returns non-zero) .......................... 1 failed
+         missing_clause_check_warns_and_never_blocks
+
+🔴 ONE MEASURED NON-RESULT, RECORDED BECAUSE IT LOOKS LIKE COVERAGE:
+`test_every_clause_is_emitted_verbatim_in_both_kinds_of_brief` does **NOT** go
+red for D1-D7. It iterates `INVARIANT_CLAUSES` and asserts each entry reaches
+the brief, so a clause deleted from the constant is deleted from both sides of
+its comparison. It is the POSITIVE control (a zero-length or clause-free brief
+fails loudly) and F1's second killer — it is not a deletion detector, and
+reading it as one is exactly the "guard whose description is wider than its
+implementation" failure. The deletion detectors are the ledger tests.
+
+🔴 WHAT THIS MODULE DOES **NOT** ENFORCE
+-----------------------------------------
+1. **It cannot see a clause REWORDED into something weaker** beyond the one
+   fragment its ledger names. `CLAUSE_LEDGER` pins one load-bearing phrase per
+   clause, not the whole sentence, because the whole sentence would live in two
+   places and drift. So a rewrite that keeps the fragment and guts the rest is
+   invisible. Mitigation is review, not this file.
+2. **It proves nothing about BEHAVIOUR.** Nothing here shows any auditor read
+   the brief, obeyed the no-fetch clause, or stopped at a clean round. The
+   measurement that motivated the script was over transcripts; the verifier for
+   whether it CHANGED anything is a re-measurement over future dispatches, and
+   that claim is NOT made here.
+3. **It does not test the real `gh` or `git`.** Every test injects a runner. So
+   a wrong `gh --json` field name, or a `git` flag this host's version does not
+   have, is out of scope — the seam is tested, not the tools behind it. That is
+   deliberate (hermetic), and it is a real blind spot, not a covered one.
+4. **It does not check that the classification a human writes is CORRECT.** The
+   script deliberately refuses to classify payload vs scaffolding; nothing
+   mechanical can grade the answer.
+
+HERMETIC: no test touches the network, spawns a process, or reads a real PR.
+`test_nothing_here_spawns_a_subprocess` proves the first two by making
+`subprocess.run` raise for the duration of a full `main()` run.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "audit-dispatch.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("audit_dispatch", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ad = _load()
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE INDEPENDENT LEDGER — this is what makes the pin two-way.
+# --------------------------------------------------------------------------- #
+# If this ledger were derived from `ad.INVARIANT_CLAUSES` the whole test would
+# be vacuous: deleting a clause would delete it from both sides and the
+# comparison would stay green. So the ids and the load-bearing fragment of each
+# clause are RESTATED here by hand, and the duplication is the point.
+#
+# Each fragment is the phrase a dispatch measurably LOST when the clause was
+# written from memory (see the module docstring's table). Pinning the phrase
+# rather than the sentence is a deliberate trade: a reword that keeps the phrase
+# is invisible (blind spot 1), and a sentence pinned in two files drifts.
+CLAUSE_LEDGER = {
+    "read-only": "rm -f <copy>/.git",
+    "no-fetch": "Do NOT `git fetch`",
+    "stop-rule": "ending it is the CORRECT outcome, not a failure",
+    "nit-is-not-a-finding": "changes nothing a reader does is NOT a finding",
+    "reverify-self-reported": "self-reported numbers rather than accepting them",
+    "finding-format": "`payload` or `scaffolding` label",
+    "do-not-merge": "Do not merge — report only",
+}
+
+# Restated, not imported, for the same reason: the bullet extractor below must
+# not be steerable by the module it audits.
+EXPECTED_INVARIANTS_HEADING = "## 🔴 NON-NEGOTIABLE — every audit, every round"
+
+
+def bullets_in_invariant_section(brief: str) -> list[str]:
+    """Every `- ` bullet between the invariants heading and the next `## `.
+
+    A second, independent implementation on purpose — the script renders that
+    section, so a shared parser could agree with a broken renderer.
+    """
+    lines = brief.splitlines()
+    assert EXPECTED_INVARIANTS_HEADING in lines, (
+        "the rendered brief has no invariants heading spelled exactly "
+        f"{EXPECTED_INVARIANTS_HEADING!r} — every pin below is looking in a "
+        "section that does not exist, so they would all pass or all fail for "
+        "the wrong reason."
+    )
+    start = lines.index(EXPECTED_INVARIANTS_HEADING)
+    out = []
+    for line in lines[start + 1:]:
+        if line.startswith("## "):
+            break
+        if line.startswith("- "):
+            out.append(line[2:])
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Fakes for the ONE process boundary
+# --------------------------------------------------------------------------- #
+
+DEFAULT_PR = {
+    "title": "a synthetic PR title",
+    "url": "https://example.invalid/pulls/900",
+    "baseRefName": "main",
+    "headRepository": {"name": "devrc"},
+    "headRepositoryOwner": {"login": "example-org"},
+}
+
+FAKE_REPO_DIR = "/fake/checkout/devrc"
+FAKE_ORIGIN = "git@github.com:example-org/devrc.git"
+
+CHECKLIST = (
+    "**Audit for:**\n1. **Risks** — what breaks in production.\n"
+    "9. **Second-order consequences** — ripple effects."
+)
+
+
+def fake_checklist(_repo_dir):
+    return CHECKLIST
+
+
+def make_runner(
+    *,
+    comments=(),
+    pr=None,
+    gh_rc=0,
+    gh_stdout=None,
+    origin=FAKE_ORIGIN,
+    toplevel=FAKE_REPO_DIR,
+    branch="feat/some-branch",
+    status=" M scripts/a.py\n?? scripts/b.py\n",
+    rev_list=(0, "4\n", ""),
+    numstat=(0, "10\t2\tscripts/foo.py\n3\t0\tscripts/tests/test_foo.py\n", ""),
+    head_sha="deadbee",
+):
+    """A closed-world stand-in for `gh` and `git`. No process is spawned."""
+    payload = dict(pr or DEFAULT_PR)
+    payload["comments"] = [{"body": c} for c in comments]
+
+    def runner(cmd, cwd=None):
+        if cmd[0] == "gh":
+            if gh_rc:
+                return gh_rc, "", "gh: synthetic failure"
+            return 0, gh_stdout if gh_stdout is not None else json.dumps(payload), ""
+        if cmd[:2] == ["git", "-C"]:
+            verb = cmd[3]
+            if verb == "rev-parse" and "--show-toplevel" in cmd:
+                return 0, toplevel + "\n", ""
+            if verb == "rev-parse" and "--abbrev-ref" in cmd:
+                return 0, branch + "\n", ""
+            if verb == "rev-parse" and "--short" in cmd:
+                return 0, head_sha + "\n", ""
+            if verb == "remote":
+                return (0, origin + "\n", "") if origin else (1, "", "no origin")
+            if verb == "status":
+                return 0, status, ""
+            if verb == "rev-list":
+                return rev_list
+            if verb == "log":
+                return numstat
+        raise AssertionError(f"unexpected command in a hermetic test: {cmd}")
+
+    return runner
+
+
+def run_main(argv, **kw):
+    """-> (rc, stdout, stderr). Always with an injected runner."""
+    out, err = io.StringIO(), io.StringIO()
+    rc = ad.main(
+        argv,
+        runner=kw.pop("runner", make_runner(**kw)),
+        stdout=out,
+        stderr=err,
+        checklist_reader=fake_checklist,
+    )
+    return rc, out.getvalue(), err.getvalue()
+
+
+CLAIMS_BLOCK_R2 = (
+    "```audit-claims round=2 audited=aaaa1111..bbbb2222\n"
+    "1. the collapsed branch was split so each reports its own state\n"
+    "2. the over-stated quantifier was replaced with the measured floor\n"
+    "```"
+)
+
+# Prose that surrounds the block in a real PR comment. 🔴 This is the material a
+# framed audit would go on to CONFIRM, and it must never reach the brief.
+SURROUNDING_PROSE = (
+    "Round 2 fixes are pushed. WHY THIS IS CORRECT: the earlier guard already "
+    "rejects that input, so the second branch is unreachable and the split is "
+    "safe. I re-ran the sweep and every row is green.\n\n"
+    "{block}\n\n"
+    "Happy to walk through the reasoning if useful."
+)
+
+
+def comment_with_prose():
+    return SURROUNDING_PROSE.format(block=CLAIMS_BLOCK_R2)
+
+
+# --------------------------------------------------------------------------- #
+# THE TWO-WAY PIN
+# --------------------------------------------------------------------------- #
+
+def test_the_invariant_clause_ledger_is_pinned_two_way():
+    """A clause with no ledger entry, or a ledger entry naming no clause, fails.
+
+    🔴 Both directions, and the messages differ, because the fixes differ. A
+    clause deleted from the script is the LOSS this whole script exists to
+    prevent; a clause added without a ledger entry is an unreviewed instruction
+    riding into every future brief.
+    """
+    in_script = {c.id for c in ad.INVARIANT_CLAUSES}
+    in_ledger = set(CLAUSE_LEDGER)
+
+    dropped = in_ledger - in_script
+    assert not dropped, (
+        "\n\nscripts/audit-dispatch.py: invariant clause(s) "
+        f"{sorted(dropped)} are named in this module's ledger but no longer "
+        "exist in INVARIANT_CLAUSES.\n"
+        "  These are the clauses that were MEASURED to go missing when a brief "
+        "was written from memory — one of them (`no-fetch`) first appeared at "
+        "dispatch 9 of 14, and an auditor at dispatch 8 fetched in a repo the "
+        "brief had called read-only.\n"
+        "  If you removed one deliberately, delete its CLAUSE_LEDGER entry in "
+        "the same commit and say in the message which dispatch failure that "
+        "clause was closing."
+    )
+    added = in_script - in_ledger
+    assert not added, (
+        "\n\nscripts/audit-dispatch.py: invariant clause(s) "
+        f"{sorted(added)} are emitted into every brief but are not in this "
+        "module's ledger.\n"
+        "  Add a CLAUSE_LEDGER entry naming the load-bearing phrase, so a "
+        "later reword that guts the clause goes red here."
+    )
+
+
+def test_each_clause_carries_the_instruction_its_ledger_entry_names():
+    """🔴 The reachability control for the ledger above.
+
+    The id pin passes for a clause whose text has been reworded into something
+    weaker. This is the assertion that sees that — and mutant R1 (reword
+    `stop-rule` to drop "ending it is the CORRECT outcome, not a failure") kills
+    THIS test alone, with every presence pin still green.
+    """
+    by_id = {c.id: c.text for c in ad.INVARIANT_CLAUSES}
+    for cid, fragment in CLAUSE_LEDGER.items():
+        assert cid in by_id, f"clause {cid!r} is gone; see the two-way pin above"
+        assert fragment in by_id[cid], (
+            f"\n\nclause {cid!r} no longer contains the phrase this module "
+            f"pins:\n    {fragment!r}\n"
+            f"  It now reads:\n    {by_id[cid]!r}\n"
+            "  That phrase is the part a hand-written brief measurably lost. "
+            "If the reword is deliberate, update CLAUSE_LEDGER in the same "
+            "commit — which is the moment to notice you are rewriting an "
+            "instruction rather than reformatting one."
+        )
+
+
+@pytest.mark.parametrize("argv,kw", [
+    (["900"], {}),
+    (["900", "--round", "3"], {"comments": [CLAIMS_BLOCK_R2]}),
+])
+def test_every_clause_is_emitted_verbatim_in_both_kinds_of_brief(argv, kw):
+    """POSITIVE CONTROL: a real assembled brief carries every clause.
+
+    A zero-length or clause-free brief must fail loudly. Both round shapes are
+    covered because they take different render paths, and a clause section
+    wired into only one of them would otherwise look complete.
+    """
+    rc, out, err = run_main(argv, **kw)
+    assert rc == 0, f"assembly failed: {err}"
+    assert len(out) > 3_000, (
+        f"the assembled brief is only {len(out)} chars — a brief that short is "
+        "not a brief, and every 'clause is present' assertion below would be a "
+        "claim about nothing."
+    )
+    for clause in ad.INVARIANT_CLAUSES:
+        assert clause.text in out, (
+            f"clause {clause.id!r} is in INVARIANT_CLAUSES but does NOT reach "
+            f"the emitted brief for argv={argv}. The constant is not the "
+            "artifact; the brief is."
+        )
+
+
+def test_the_rendered_section_holds_exactly_the_ledgered_clauses():
+    """Two-way, against the RENDERED section rather than the constant.
+
+    This is what mutant F1 catches: a renderer that stops reading
+    INVARIANT_CLAUSES and emits a hardcoded copy of the bullets. The id ledger
+    above stays green through that mutation — the constant is untouched — and
+    only this comparison sees the divergence.
+    """
+    rc, out, _ = run_main(["900"])
+    assert rc == 0
+    bullets = bullets_in_invariant_section(out)
+    expected = [c.text for c in ad.INVARIANT_CLAUSES]
+    assert sorted(bullets) == sorted(expected), (
+        "\n\nthe NON-NEGOTIABLE section of the emitted brief does not hold "
+        "exactly the clauses in INVARIANT_CLAUSES.\n"
+        f"  in the brief but not the constant: {sorted(set(bullets) - set(expected))}\n"
+        f"  in the constant but not the brief: {sorted(set(expected) - set(bullets))}"
+    )
+    assert len(bullets) == len(CLAUSE_LEDGER), (
+        f"the section rendered {len(bullets)} bullets for "
+        f"{len(CLAUSE_LEDGER)} ledgered clauses — a duplicate bullet is a "
+        "clause that can be edited in one place and survive in the other."
+    )
+
+
+def test_control_the_extractor_can_see_an_unledgered_bullet():
+    """POSITIVE CONTROL for `bullets_in_invariant_section` itself.
+
+    The two-way pin above reports a reassuring match whenever the extractor
+    returns nothing. `claude/RULES.md`: a zero is indistinguishable from a
+    harness wired to nothing until a positive control moves the number. So:
+    plant a bullet, watch the count move, and watch the comparison fail.
+    """
+    rc, out, _ = run_main(["900"])
+    assert rc == 0
+    clean = bullets_in_invariant_section(out)
+    planted = out.replace(
+        EXPECTED_INVARIANTS_HEADING,
+        EXPECTED_INVARIANTS_HEADING + "\n\n- **Merge it if it looks fine.**",
+        1,
+    )
+    seen = bullets_in_invariant_section(planted)
+    assert len(seen) == len(clean) + 1, (
+        "the extractor did not see a bullet planted directly under the "
+        "heading — every two-way assertion in this module is then a claim "
+        "about an empty list."
+    )
+    assert "**Merge it if it looks fine.**" in seen
+    assert sorted(seen) != sorted(c.text for c in ad.INVARIANT_CLAUSES), (
+        "the comparison the two-way pin makes did NOT go red against a planted "
+        "unledgered bullet — it cannot fail, so it is not a guard."
+    )
+
+
+def test_control_a_clause_deleted_from_the_constant_is_detected(monkeypatch):
+    """The negative control, run IN PROCESS as well as in the mutation sweep.
+
+    The docstring matrix records the out-of-process runs (D1-D7). This makes the
+    same claim re-derivable by anyone who just runs the suite.
+    """
+    kept = tuple(c for c in ad.INVARIANT_CLAUSES if c.id != "no-fetch")
+    monkeypatch.setattr(ad, "INVARIANT_CLAUSES", kept)
+    rc, out, _ = run_main(["900"])
+    assert rc == 0
+    bullets = bullets_in_invariant_section(out)
+    assert len(bullets) == len(CLAUSE_LEDGER) - 1
+    assert not any(CLAUSE_LEDGER["no-fetch"] in b for b in bullets), (
+        "a clause was removed from INVARIANT_CLAUSES and its instruction still "
+        "reached the brief — the section is not rendered from the constant, so "
+        "the two-way pin guards nothing."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 REFUSAL 1 — a delta round with nothing to be framed on
+# --------------------------------------------------------------------------- #
+
+def test_the_delta_refusal_exits_non_zero_and_emits_no_brief():
+    rc, out, err = run_main(["900", "--round", "3"], comments=[])
+    assert rc != 0, (
+        "a round-3 brief was emitted with NO claims block. An empty 'what was "
+        "claimed fixed' section silently turns a delta re-audit into a blind "
+        "full audit — a different thing, which then reads as covered."
+    )
+    assert out.strip() == "", (
+        "the refusal still printed something on stdout; an operator pasting "
+        "stdout would dispatch a brief the script refused to vouch for."
+    )
+
+
+def test_the_refusal_names_what_it_looked_for_and_where():
+    """Assert on the MESSAGE, not just the exit code.
+
+    A refusal an operator cannot act on gets worked around, and the workaround
+    is 'run it without --round', which is exactly the silent downgrade the
+    refusal exists to prevent.
+    """
+    _, _, err = run_main(["900", "--round", "3"], comments=[])
+    assert ad.REFUSAL_HEADER in err
+    assert "audit-claims round=<n> audited=<sha>..<sha>" in err, (
+        "the refusal does not show the block shape it looked for"
+    )
+    assert "PR #900's comments" in err, "the refusal does not say where it looked"
+    assert "no `audit-claims` block" in err, "the refusal does not say what it found"
+    assert "--emit-claims" in err, (
+        "the refusal does not tell the operator how to produce the block it "
+        "wants — a refusal with no exit is a refusal people route around"
+    )
+
+
+@pytest.mark.parametrize("body,expected", [
+    ("```audit-claims round=3\n1. a thing\n```", "does not carry both"),
+    ("```audit-claims audited=aa..bb\n1. a thing\n```", "does not carry both"),
+    ("```audit-claims round=3 audited=aa..bb\nfixed some stuff\n```",
+     "no numbered claim lines"),
+])
+def test_the_refusal_fires_for_a_malformed_block_and_says_which_way(body, expected):
+    """A near-miss must be reported as a near-miss.
+
+    Silently skipping an unparseable fence produces the SAME observable as 'no
+    block at all' — and those need opposite fixes (repair the header vs write
+    the block). `claude/RULES.md`: an empty result cannot distinguish two
+    mechanisms.
+    """
+    rc, out, err = run_main(["900", "--round", "3"], comments=[body])
+    assert rc != 0 and out.strip() == ""
+    assert expected in err, (
+        f"the refusal message does not name the malformation. Got:\n{err}"
+    )
+
+
+def test_a_first_round_needs_no_claims_block():
+    """The refusal must not fire where a blind full audit is the CORRECT thing."""
+    rc, out, err = run_main(["900"], comments=[])
+    assert rc == 0, err
+    assert "FIRST, FULL adversarial audit" in out
+    assert "WHAT WAS CLAIMED FIXED" not in out, (
+        "a first audit must not carry a claims section at all — an empty one "
+        "reads as 'nothing was claimed', which is a different statement"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE FRAMING GUARANTEE
+# --------------------------------------------------------------------------- #
+
+def test_the_brief_carries_the_claims_and_not_the_reasoning_around_them():
+    """🔴 The rule that keeps a delta round from verifying its own frame.
+
+    The skill records three successive FRAMED audits confirming a claim purely
+    because the prompt handed them the answer, against one BLIND audit that
+    refuted it in a single pass. A PR comment holds BOTH the claims and the
+    argument for them, so the assembler reads only the fenced block.
+
+    Mutant C2 (read the whole comment body instead of the fence) kills this test
+    alone.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "3"], comments=[comment_with_prose()]
+    )
+    assert rc == 0, err
+
+    assert "the collapsed branch was split so each reports its own state" in out
+    assert "the over-stated quantifier was replaced with the measured floor" in out
+
+    for leaked in (
+        "WHY THIS IS CORRECT",
+        "so the second branch is unreachable and the split is safe",
+        "I re-ran the sweep and every row is green",
+        "Happy to walk through the reasoning if useful",
+    ):
+        assert leaked not in out, (
+            f"the brief reproduced reasoning from the PR comment: {leaked!r}.\n"
+            "  That is the material a framed audit goes on to CONFIRM. Only "
+            "the fenced block's numbered lines may reach the brief."
+        )
+    assert "never WHY IT IS CORRECT" in out, (
+        "the claims section does not tell the auditor that these are claims"
+    )
+
+
+def test_the_newest_claims_block_wins():
+    older = (
+        "```audit-claims round=2 audited=aaaa1111..bbbb2222\n"
+        "1. an older claim\n```"
+    )
+    newer = (
+        "```audit-claims round=4 audited=bbbb2222..cccc3333\n"
+        "1. a newer claim\n```"
+    )
+    rc, out, err = run_main(["900", "--round", "5"], comments=[older, newer])
+    assert rc == 0, err
+    assert "a newer claim" in out
+    assert "an older claim" not in out
+    assert "cccc3333..HEAD" in out, (
+        "the range must be anchored at the NEWEST audited tip, not the oldest"
+    )
+
+
+def test_emit_claims_prints_a_block_this_scripts_own_parser_accepts():
+    """A round trip, so the skeleton cannot drift away from the reader.
+
+    The next round REFUSES on an unparseable block, so a skeleton the parser
+    rejects would turn `--emit-claims` into a trap.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "3", "--emit-claims"], comments=[CLAIMS_BLOCK_R2]
+    )
+    assert rc == 0, err
+    tail = out[out.index("```audit-claims"):]
+    blocks, malformed = ad.parse_claims_blocks([tail])
+    assert not malformed, malformed
+    assert len(blocks) == 1
+    assert blocks[0].round_no == 3
+    assert blocks[0].audited_from == "bbbb2222"
+    assert blocks[0].audited_to == "deadbee"
+    assert len(blocks[0].items) >= 1
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE CROSS-REPO BRANCH — both directions
+# --------------------------------------------------------------------------- #
+
+def _isolation_lines(brief):
+    return [ln for ln in brief.splitlines() if 'isolation: "worktree"' in ln]
+
+
+def test_cross_repo_tells_the_agent_to_worktree_the_prs_repo_itself():
+    """🔴 The highest-value generated field.
+
+    `isolation: "worktree"` builds from the CWD's repo. For a PR in a different
+    repo that is the WRONG tree and the failure is quiet — the agent either
+    reports a briefed file missing, or silently audits the wrong repository.
+    """
+    pr = dict(DEFAULT_PR, headRepository={"name": "otherproj"},
+              headRepositoryOwner={"login": "someone-else"})
+    rc, out, err = run_main(["900"], pr=pr)
+    assert rc == 0, err
+
+    assert "git -C" in out and "worktree add" in out, (
+        "the cross-repo brief does not tell the agent to create the worktree "
+        "itself"
+    )
+    assert "someone-else/otherproj" in out, (
+        "the cross-repo brief does not name the repo the worktree must come from"
+    )
+    lines = _isolation_lines(out)
+    assert lines, "the brief says nothing about the isolation flag at all"
+    for line in lines:
+        assert "Do NOT" in line, (
+            "\n\nthe cross-repo brief mentions `isolation: \"worktree\"` on a "
+            f"line that does not forbid it:\n    {line}\n"
+            "  That flag worktrees the CWD's repo, which is the wrong one here."
+        )
+    assert ad.ISOLATION_RECOMMEND not in out
+
+
+def test_same_repo_recommends_the_isolation_flag_and_does_not_hand_roll():
+    """The reverse direction — measured, not assumed to follow from the first."""
+    rc, out, err = run_main(["900"])  # DEFAULT_PR is example-org/devrc, == origin
+    assert rc == 0, err
+    assert ad.ISOLATION_RECOMMEND in out
+    lines = _isolation_lines(out)
+    assert lines and not any("Do NOT" in ln for ln in lines), (
+        "the same-repo brief forbids the flag that is correct here"
+    )
+    where = out[out.index("## WHERE TO WORK"):out.index("## THE RANGE")]
+    assert "worktree add" not in where, (
+        "the same-repo brief tells the agent to hand-roll a worktree; that is "
+        "the cross-repo remedy and it is noise here"
+    )
+
+
+def test_the_cross_repo_decision_comes_from_the_repos_not_from_prose():
+    """The same run, differing only in the PR's repo, must flip the section."""
+    same = run_main(["900"])[1]
+    other = run_main(["900"], pr=dict(
+        DEFAULT_PR, headRepository={"name": "otherproj"},
+        headRepositoryOwner={"login": "someone-else"}))[1]
+    assert (ad.ISOLATION_FORBID in other) and (ad.ISOLATION_FORBID not in same)
+    assert (ad.ISOLATION_RECOMMEND in same) and (ad.ISOLATION_RECOMMEND not in other)
+
+
+# --------------------------------------------------------------------------- #
+# The generated facts
+# --------------------------------------------------------------------------- #
+
+def test_the_shared_checkout_state_is_reported_with_the_it_moves_warning():
+    rc, out, err = run_main(["900"], branch="feat/thing", status=" M a\n M b\n M c\n")
+    assert rc == 0, err
+    assert "feat/thing" in out
+    assert "3 uncommitted path(s)" in out
+    assert "MOVES UNDER YOU" in out
+    assert "NOT a finding" in out
+
+
+def test_the_toolchain_section_names_the_tier_the_merge_gates_on():
+    """Two of the three clauses the measurement showed decaying live here.
+
+    They are GENERATED (they interpolate the repo path), so they are not in
+    INVARIANT_CLAUSES — which means nothing else in this module would notice
+    them going missing.
+    """
+    rc, out, err = run_main(["900"])
+    assert rc == 0, err
+    assert "nix develop /fake/checkout/devrc -c python3 -m pytest" in out
+    assert "-p no:cacheprovider" in out
+    assert "No module named pytest" in out and "WRONG SHELL" in out, (
+        "the wrong-shell diagnosis is missing — it was present in 9 of the "
+        "first 9 measured dispatches and absent from 3 of the last 5"
+    )
+    assert "nix build /fake/checkout/devrc#checks.x86_64-linux.pytests" in out
+    assert "nix build /fake/checkout/devrc#checks.x86_64-linux.nodetests" in out
+    assert "gate.sh --tier both" in out
+    assert "git --version" in out
+
+
+def test_the_range_is_generated_from_the_previous_rounds_audited_sha():
+    rc, out, err = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
+    assert rc == 0, err
+    assert "`bbbb2222..HEAD`" in out, (
+        "the delta range is not anchored at the sha the previous round audited"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# THE LEDGER
+# --------------------------------------------------------------------------- #
+
+def test_the_ledger_shows_the_files_and_refuses_to_classify_them():
+    """🔴 The classification is a HUMAN judgement and the script says so.
+
+    A pathspec is wrong in both directions on ordinary names — `':!*test*'`
+    swallows `attestation/`, `latest/` and `inspector/` and keeps
+    `FooTest.java`. Mutant C5 (classify by pathspec and print an X) kills this.
+    """
+    rc, out, err = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
+    assert rc == 0, err
+    assert "scripts/foo.py" in out and "scripts/tests/test_foo.py" in out
+    assert "Classify these files yourself" in out
+    assert "payload lines changed THIS round: X" in out, (
+        "the ledger line must leave X for the human — a number here would be a "
+        "classification the script is not entitled to make"
+    )
+    assert "attestation" in out and "login.cy.ts" in out, (
+        "the counter-evidence for why a pathspec cannot do this is missing"
+    )
+
+
+@pytest.mark.parametrize("kw,expect", [
+    ({"rev_list": (128, "", "fatal: bad revision")}, "exited 128"),
+    ({"rev_list": (0, "0\n", "")}, "is EMPTY"),
+    ({"numstat": (128, "", "unknown option --remerge-diff")}, "exited 128"),
+    ({"numstat": (0, "1\t1\tx\n", "warning: unable to write object")},
+     "wrote to STDERR"),
+])
+def test_the_ledger_refuses_a_failed_command_rather_than_printing_zero(kw, expect):
+    """🔴 rc 0, silent stderr, non-empty range — all three, or no number.
+
+    Each of these produces a PLAUSIBLE zero: a git without `--remerge-diff`
+    exits 128 with empty output; an unwritable object store makes it UNDER-count
+    while exiting 0 and announcing itself only on stderr; a range whose commits
+    are not in this checkout prints nothing at all with rc 0.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2], **kw
+    )
+    assert rc == 0, err
+    assert "COULD NOT MEASURE" in out, (
+        "the ledger reported a number from a command that did not earn it"
+    )
+    assert expect in out, f"the reason does not name the failure. Got:\n{out}"
+    assert "payload lines changed THIS round" not in out, (
+        "a ledger line was printed under a COULD NOT MEASURE — the two must "
+        "not appear together, or the operator copies the line anyway"
+    )
+
+
+def test_the_cumulative_figure_is_not_measured_without_a_round_one_anchor():
+    """An unmeasurable quantity is reported as unmeasured, never substituted."""
+    bare = (
+        "```audit-claims round=2 audited=bbbb2222\n1. something\n```"
+    )
+    rc, out, err = run_main(["900", "--round", "3"], comments=[bare])
+    assert rc == 0, err
+    assert "(since round 1: Y)" in out
+    assert "NOT MEASURED" in out
+
+
+def test_the_ledger_says_the_base_was_not_fetched():
+    """The script cannot fetch (that would be a write), so it says so.
+
+    A stale `<base>` re-reports upstream work as this round's payload — measured
+    at 201 lines where the truth was 1.
+    """
+    rc, out, err = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
+    assert rc == 0, err
+    assert "does not fetch" in out and "stale base" in out
+
+
+# --------------------------------------------------------------------------- #
+# REFUSAL 2's opposite number: WARN, NEVER BLOCK
+# --------------------------------------------------------------------------- #
+
+def test_missing_clause_check_warns_and_never_blocks(monkeypatch, tmp_path):
+    """🔴 Warn-only, deliberately.
+
+    This check exists for a hand-edited `--out` file. `claude/RULES.md`: a
+    permanently-red gate is worse than no gate — it trains everyone to click
+    through. Blocking here would refuse to run over an edit that was deliberate.
+    Mutant C6 (raise instead of return) kills this test.
+    """
+    real_render = ad.render_brief
+    # By ID, not by index: an index makes this test's outcome depend on which
+    # OTHER clause a mutation deleted, which shows up in a sweep as this test
+    # dying for the wrong reason.
+    target = next(c for c in ad.INVARIANT_CLAUSES if c.id == "no-fetch")
+
+    def lossy(facts):
+        text = real_render(facts)
+        return text.replace(target.text, "(hand-edited away)")
+
+    monkeypatch.setattr(ad, "render_brief", lossy)
+    out_file = tmp_path / "brief.md"
+    rc, _, err = run_main(["900", "--out", str(out_file)])
+
+    assert rc == 0, "the missing-clause check BLOCKED; it must only warn"
+    assert "missing invariant clause(s)" in err and "no-fetch" in err
+    assert "WARNING, not a refusal" in err
+    assert out_file.read_text(encoding="utf-8"), (
+        "the brief was not written — a warning must not suppress the output"
+    )
+
+
+def test_missing_clauses_is_a_pure_function_over_the_text():
+    full = "\n".join(c.text for c in ad.INVARIANT_CLAUSES)
+    assert ad.missing_clauses(full) == []
+    assert ad.missing_clauses("") == [c.id for c in ad.INVARIANT_CLAUSES]
+    assert ad.missing_clauses(
+        full.replace(ad.INVARIANT_CLAUSES[0].text, "")
+    ) == [ad.INVARIANT_CLAUSES[0].id]
+
+
+# --------------------------------------------------------------------------- #
+# The parser, driven directly
+# --------------------------------------------------------------------------- #
+
+def test_parse_claims_blocks_reads_only_the_fence():
+    blocks, malformed = ad.parse_claims_blocks([comment_with_prose()])
+    assert not malformed
+    assert len(blocks) == 1
+    assert blocks[0].items == [
+        "the collapsed branch was split so each reports its own state",
+        "the over-stated quantifier was replaced with the measured floor",
+    ]
+    assert blocks[0].audited_from == "aaaa1111"
+    assert blocks[0].audited_to == "bbbb2222"
+
+
+def test_parse_claims_blocks_reports_a_bad_header_rather_than_skipping_it():
+    blocks, malformed = ad.parse_claims_blocks(
+        ["```audit-claims round=oops audited=aa..bb\n1. x\n```"]
+    )
+    assert blocks == []
+    assert malformed and "does not carry both" in malformed[0]
+
+
+def test_a_comment_with_no_fence_yields_nothing_and_no_false_malformation():
+    blocks, malformed = ad.parse_claims_blocks(
+        ["just prose, mentioning audit-claims and round=3 in passing"]
+    )
+    assert blocks == [] and malformed == []
+
+
+# --------------------------------------------------------------------------- #
+# HERMETICITY + the ledger-of-ledgers
+# --------------------------------------------------------------------------- #
+
+def test_nothing_here_spawns_a_subprocess(monkeypatch):
+    """Proves the injected seam is the ONLY process boundary.
+
+    If `main` ever reaches around the injected runner — a bare `subprocess.run`
+    for one convenient extra fact — this suite would silently start depending on
+    the host, the network and a real PR.
+    """
+    def explode(*a, **kw):
+        raise AssertionError(
+            "audit-dispatch.py spawned a process during a test that injected a "
+            f"runner: {a!r}"
+        )
+
+    monkeypatch.setattr(ad.subprocess, "run", explode)
+    rc, out, err = run_main(
+        ["900", "--round", "3", "--emit-claims"], comments=[CLAIMS_BLOCK_R2]
+    )
+    assert rc == 0, err
+    assert out
+
+
+def test_a_gh_failure_is_reported_and_not_papered_over():
+    rc, out, err = run_main(["900"], gh_rc=1)
+    assert rc != 0 and out.strip() == ""
+    assert "gh pr view 900" in err and "failed" in err
+
+
+# The two ledgers the module docstring commits to. RED_AT_BASE is empty ON
+# PURPOSE and that emptiness is asserted, so nobody can later read this module
+# as carrying regression coverage it does not have.
+RED_AT_BASE: frozenset[str] = frozenset()
+
+INVARIANT_GUARDS_AND_LEDGERS = frozenset({
+    "test_the_invariant_clause_ledger_is_pinned_two_way",
+    "test_each_clause_carries_the_instruction_its_ledger_entry_names",
+    "test_every_clause_is_emitted_verbatim_in_both_kinds_of_brief",
+    "test_the_rendered_section_holds_exactly_the_ledgered_clauses",
+    "test_control_the_extractor_can_see_an_unledgered_bullet",
+    "test_control_a_clause_deleted_from_the_constant_is_detected",
+    "test_the_delta_refusal_exits_non_zero_and_emits_no_brief",
+    "test_the_refusal_names_what_it_looked_for_and_where",
+    "test_the_refusal_fires_for_a_malformed_block_and_says_which_way",
+    "test_a_first_round_needs_no_claims_block",
+    "test_the_brief_carries_the_claims_and_not_the_reasoning_around_them",
+    "test_the_newest_claims_block_wins",
+    "test_emit_claims_prints_a_block_this_scripts_own_parser_accepts",
+    "test_cross_repo_tells_the_agent_to_worktree_the_prs_repo_itself",
+    "test_same_repo_recommends_the_isolation_flag_and_does_not_hand_roll",
+    "test_the_cross_repo_decision_comes_from_the_repos_not_from_prose",
+    "test_the_shared_checkout_state_is_reported_with_the_it_moves_warning",
+    "test_the_toolchain_section_names_the_tier_the_merge_gates_on",
+    "test_the_range_is_generated_from_the_previous_rounds_audited_sha",
+    "test_the_ledger_shows_the_files_and_refuses_to_classify_them",
+    "test_the_ledger_refuses_a_failed_command_rather_than_printing_zero",
+    "test_the_cumulative_figure_is_not_measured_without_a_round_one_anchor",
+    "test_the_ledger_says_the_base_was_not_fetched",
+    "test_missing_clause_check_warns_and_never_blocks",
+    "test_missing_clauses_is_a_pure_function_over_the_text",
+    "test_parse_claims_blocks_reads_only_the_fence",
+    "test_parse_claims_blocks_reports_a_bad_header_rather_than_skipping_it",
+    "test_a_comment_with_no_fence_yields_nothing_and_no_false_malformation",
+    "test_nothing_here_spawns_a_subprocess",
+    "test_a_gh_failure_is_reported_and_not_papered_over",
+    "test_the_two_ledgers_partition_this_modules_tests",
+})
+
+
+def test_the_two_ledgers_partition_this_modules_tests():
+    """A test cannot quietly join or leave either ledger.
+
+    Same shape as `scripts/tests/test_transcript_search.py`'s two lists, and for
+    the same reason: "watched red" is a claim about a specific base, and a
+    module whose docstring says "these are invariant guards" while quietly
+    growing an unlisted test is asserting coverage nobody checked.
+    """
+    here = {n for n in globals() if n.startswith("test_")}
+    assert RED_AT_BASE == frozenset(), (
+        "RED_AT_BASE is documented as empty because scripts/audit-dispatch.py "
+        "did not exist at 3b79a35a. If a test here IS regression coverage for "
+        "a shipped bug, name the base you watched it red at in the docstring "
+        "before adding it."
+    )
+    unlisted = here - INVARIANT_GUARDS_AND_LEDGERS - RED_AT_BASE
+    assert not unlisted, (
+        f"tests not in either ledger: {sorted(unlisted)}. Add each to "
+        "INVARIANT_GUARDS_AND_LEDGERS (or to RED_AT_BASE with its base ref)."
+    )
+    stale = (INVARIANT_GUARDS_AND_LEDGERS | RED_AT_BASE) - here
+    assert not stale, (
+        f"ledger entries naming no test: {sorted(stale)}. A ledger that names "
+        "a deleted test reads as coverage that no longer runs."
+    )

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -1003,9 +1003,14 @@ DIRECTIVE_LEDGER = {
         "anything. If something moves, report it AND report that its cause "
         "could not be established here."
     ),
+    # 🔴 ROUND 6. The second sentence used to read "about the SHARED checkout",
+    # which named a scoping the `no-fetch` clause stopped having in round 5 —
+    # so a cross-repo brief assembled in a PRIVATE worktree told the reader the
+    # rule was about a state the very next section denies. The scope is now
+    # stated by OWNERSHIP, the way the clause itself states it.
     "own-worktree-is-writable": (
         "That worktree is YOURS: fetching and checking out inside it is fine. "
-        "The no-write rule below is about the SHARED checkout."
+        "The no-write rule below is about every checkout you did not make."
     ),
 }
 
@@ -1053,22 +1058,60 @@ def checkout_section(brief):
     return brief[m.start():m.end() + (nxt if nxt != -1 else len(rest))]
 
 
+def range_section(brief):
+    """THE RANGE block alone, sliced off the next `## ` heading.
+
+    🔴 Exists because `"<sha>..HEAD" in out` is not a claim about THE RANGE:
+    THE LEDGER prints its own provenance line (`git log --numstat …
+    <anchor>..HEAD --not <base>`) carrying the same substring, and that one
+    legitimately keeps `..HEAD` because the command ran in the tree that was
+    just verified. An unscoped assertion is satisfied by the wrong section.
+    """
+    start = brief.index("## THE RANGE")
+    rest = brief[start + len("## THE RANGE"):]
+    nxt = rest.find("\n## ")
+    return brief[start:start + len("## THE RANGE") + (nxt if nxt != -1 else len(rest))]
+
+
+# 🔴 THE SCENARIOS AS DATA, so "every scenario this module knows" is something
+# a test can ITERATE rather than something an author has to remember to list.
+#
+# Round 6's finding: two guards that meant "every state / every brief" were
+# spelled as a hand-written pair and as an id PREFIX, and both were walkable —
+# re-introducing a forbidden phrase in the CROSS-REPO branch, and renaming a
+# `checkout-*` directive, each left the suite fully green. A scenario added
+# here is now automatically driven by every guard that iterates `SCENARIOS`.
+#
+# 🔴 `cross-repo-private` is not a hypothetical: it is the configuration that
+# produced round 6's 🟡 F1. `own-worktree-is-writable` renders ONLY in the
+# cross-repo branch, and the tree the brief is assembled in is routinely a
+# private per-agent worktree — so this is the pair whose two sections were
+# read together and found to contradict each other. Neither single-axis
+# scenario can produce it.
+# 🔴 THUNKS, not literals: `SELF_RANGE_PR` is defined with round 3's section
+# eight hundred lines below, where its 40-char shape is explained. A literal
+# dict here would resolve it at import and fail collection — and moving the
+# fixture up to satisfy this table would strand its reasoning.
+SCENARIO_RUNS = {
+    "delta": lambda: (["900", "--round", "3"], {"comments": [CLAIMS_BLOCK_R2]}),
+    "degenerate": lambda: (["900", "--round", "3"],
+                           {"comments": [CLAIMS_BLOCK_R2], "pr": SELF_RANGE_PR}),
+    "private-worktree": lambda: (["900"], {"git_dirs": PRIVATE_GIT_DIRS}),
+    "unreadable-worktree": lambda: (["900"], {"git_dirs": UNREADABLE_GIT_DIRS}),
+    "cross-repo": lambda: (["900"], {"pr": OTHER_REPO_PR}),
+    "cross-repo-private": lambda: (["900"], {"pr": OTHER_REPO_PR,
+                                             "git_dirs": PRIVATE_GIT_DIRS}),
+}
+SCENARIOS = tuple(SCENARIO_RUNS)
+
+
 def brief_for_scenario(name):
     """-> the stdout of a run that MUST carry the directive(s) mapped to it."""
-    if name == "delta":
-        argv, kw = ["900", "--round", "3"], {"comments": [CLAIMS_BLOCK_R2]}
-    elif name == "degenerate":
-        argv, kw = ["900", "--round", "3"], {
-            "comments": [CLAIMS_BLOCK_R2], "pr": SELF_RANGE_PR,
-        }
-    elif name == "private-worktree":
-        argv, kw = ["900"], {"git_dirs": PRIVATE_GIT_DIRS}
-    elif name == "unreadable-worktree":
-        argv, kw = ["900"], {"git_dirs": UNREADABLE_GIT_DIRS}
-    elif name == "cross-repo":
-        argv, kw = ["900"], {"pr": OTHER_REPO_PR}
-    else:
-        raise AssertionError(f"no such scenario: {name!r}")
+    try:
+        build = SCENARIO_RUNS[name]
+    except KeyError:
+        raise AssertionError(f"no such scenario: {name!r}") from None
+    argv, kw = build()
     rc, out, err = run_main(argv, **kw)
     assert rc == 0, f"scenario {name!r} exited {rc}: {err}"
     assert len(out) > 3_000, (
@@ -1353,12 +1396,21 @@ def test_the_newest_claims_block_wins():
     # block's `<to>`. `<to>` (`cccc3333`) is the head round 4's fixes produced
     # and is where the block was POSTED, so anchoring there is the self-range
     # defect round 3 fixed — see `range_anchor`.
-    assert "bbbb2222..HEAD" in out, (
+    #
+    # 🔴 SCOPED TO THE RANGE SECTION IN ROUND 7, and the old scope was
+    # VACUOUS-ADJACENT: `"bbbb2222..HEAD" in out` also matched THE LEDGER's
+    # provenance line (`git log --numstat … bbbb2222..HEAD --not main`), which
+    # legitimately keeps `..HEAD` because that command ran HERE. So both
+    # assertions could be satisfied by a section this test is not about, and
+    # when round 7 changed the rendered tip they did not move.
+    the_range = range_section(out)
+    assert f"bbbb2222..{FAKE_HEAD_OID}" in the_range, (
         "the range must be anchored at the newest BLOCK's `<from>` — the tip "
         "that round's audit read — not at the oldest block, and not at the "
-        "newest block's `<to>`, which is the head it was posted at"
+        f"newest block's `<to>`, which is the head it was posted at\n"
+        f"{the_range}"
     )
-    assert "cccc3333..HEAD" not in out, (
+    assert f"cccc3333..{FAKE_HEAD_OID}" not in the_range, (
         "the range is anchored at the newest block's `<to>`, which is the head "
         "the block was posted at: that range is EMPTY BY CONSTRUCTION whenever "
         "the block sits at the fix tip, which is the normal case"
@@ -1687,12 +1739,16 @@ def test_the_range_is_generated_from_the_previous_rounds_audited_sha():
     """
     rc, out, err = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
     assert rc == 0, err
-    assert "`aaaa1111..HEAD`" in out, (
+    # 🔴 The TIP moved in round 7 (a verified head renders as its SHA, never as
+    # `HEAD` — see `render_range`), so the range reads `aaaa1111..<pr head>`.
+    # The claim here is unchanged and is about the ANCHOR half.
+    the_range = range_section(out)
+    assert f"`aaaa1111..{FAKE_HEAD_OID}`" in the_range, (
         "\n\nthe delta range is not anchored at the tip the previous round "
         "AUDITED (`<from>`). The fixture's block is "
-        "`audited=aaaa1111..bbbb2222`."
+        f"`audited=aaaa1111..bbbb2222`.\n{the_range}"
     )
-    assert "`bbbb2222..HEAD`" not in out, (
+    assert f"`bbbb2222..{FAKE_HEAD_OID}`" not in the_range, (
         "\n\nthe range is anchored at `<to>` — the head the block was posted "
         "at. Whenever the block sits at the fix tip (the normal case) that "
         "range is empty, and THE RANGE section prints it with no warning."
@@ -1766,22 +1822,108 @@ def test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head():
 
 
 def test_the_range_says_head_was_verified_when_it_was():
-    """The other direction: a verified checkout still gets `..HEAD`, and says so.
+    """The other direction: a verified checkout gets the SHA, and says so.
 
     Measured separately from the failure case because "the guard fires" and "the
     guard does not fire spuriously" are different claims, and a check wired to
     always fail would satisfy the test above.
+
+    🔴 ROUND 7 changed what the verified branch renders — the tip is
+    `hc.local_sha`, not the token `HEAD`. The claim this test makes is
+    unchanged (the head check did not fire, and the brief says the head was
+    verified); only the spelling of the range moved.
+    `..._names_a_sha_and_not_head_when_the_head_is_verified` owns the new
+    claim.
     """
     rc, out, err = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
     assert rc == 0, err
-    the_range = out[out.index("## THE RANGE"):out.index("## WHAT WAS CLAIMED")]
-    assert "`aaaa1111..HEAD`" in the_range
+    the_range = range_section(out)
+    assert f"`aaaa1111..{FAKE_HEAD_OID}`" in the_range
     assert "COULD NOT VERIFY" not in the_range
     assert "DEGENERATE RANGE" not in the_range, (
         "the self-range banner fired on an ordinary, non-degenerate range — "
         "the anchor `aaaa1111` is not this checkout's HEAD"
     )
     assert FAKE_HEAD_OID in the_range and "verified at assembly time" in the_range
+
+
+_DIFF_LINE = re.compile(r"Diff \*\*`([^`]+)`\*\*")
+
+
+def rendered_range(brief):
+    """The `<from>..<tip>` spec THE RANGE actually tells the auditor to diff."""
+    m = _DIFF_LINE.search(range_section(brief))
+    assert m, f"THE RANGE names no diff spec at all:\n{range_section(brief)}"
+    return m.group(1)
+
+
+def test_the_range_names_a_sha_and_not_head_when_the_head_is_verified():
+    """🔴 REGRESSION. Red at `3619fe68`, which rendered ``aaaa1111..HEAD``.
+
+    THE THIRD INSTANCE OF THIS LADDER'S RECURRING CONFUSION, and the first on
+    the TIME axis. Round 3 conflated the operator's checkout with the tree
+    under audit; round 5 conflated the assembling process's cwd with where the
+    auditor stands. This one: the HEAD VERIFIED AT ASSEMBLY TIME versus the
+    HEAD THE AUDITOR'S COMMAND WILL RESOLVE.
+
+    `head_check.ok` is a fact about THIS tree at THIS moment. The auditor is
+    told two sections earlier to stand somewhere else — `isolation:
+    "worktree"`, or a `git worktree add` against a BRANCH in the cross-repo
+    recipe — in a tree cut after assembly from a repository the brief itself
+    describes as live under another session. A commit landing in between makes
+    `git diff <from>..HEAD` cover commits no claims block describes, and the
+    brief's own note asserts the range was verified while it does.
+
+    🔴 TWO TELLS THAT IT IS THE SAME INVERSION, asserted below rather than
+    argued: the UNVERIFIED branch already named a sha, and `emit_claims_skeleton`
+    already prefers the resolved PR head. Only the VERIFIED branch hardcoded the
+    token — the branch where being sure was mistaken for the range being stable.
+    """
+    rc, out, err = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
+    assert rc == 0, err
+    frm, _, tip = rendered_range(out).partition("..")
+    assert tip != "HEAD", (
+        "\n\nTHE RANGE tells the auditor to diff `..HEAD`. That token resolves "
+        "in THEIR worktree, which this brief has already told them to create "
+        f"themselves:\n{range_section(out)}"
+    )
+    assert tip == FAKE_HEAD_OID, (
+        f"\n\nthe verified range ends at {tip!r}, which is not the head that "
+        f"was verified ({FAKE_HEAD_OID}). Whatever it names, the auditor "
+        "resolves it in a tree this script never saw."
+    )
+    # 🔴 DELIBERATELY NO ASSERTION ON `<from>`. Which sha anchors the range is
+    # `..._range_is_generated_from_the_previous_rounds_audited_sha`'s claim, and
+    # asserting it here made mutant N1 (anchor reads `<to>`) kill this row for
+    # that test's reason — measured as EXTRA-KILLER. What this row claims is
+    # narrower and is the whole claim: the TIP is a sha.
+    # 🔴 THE CO-OCCURRENCE IS THE POINT, so it is asserted and not assumed: the
+    # same brief sends the reader to a different tree. Without this the tip
+    # rule would read as a style preference.
+    assert 'isolation: "worktree"' in out, (
+        "this brief does not send the auditor to a tree of their own, so the "
+        "claim above is about a configuration it is not testing"
+    )
+    assert "verified at assembly time" in range_section(out)
+
+    # 🔴 TELL ONE — the COULD-NOT-VERIFY branch already did the safe thing, and
+    # still does. If this ever regressed to `HEAD` the fix would be half-applied.
+    unverified = run_main(
+        ["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2], local_head=WRONG_HEAD
+    )[1]
+    assert rendered_range(unverified).partition("..")[2] == FAKE_HEAD_OID
+
+    # 🔴 SCOPED TO THE AUDITOR-FACING INSTRUCTION, and this is the control that
+    # says so: THE LEDGER's provenance line keeps `..HEAD`, correctly. That
+    # command ran HERE, in the tree just verified, at assembly time. A fix that
+    # rewrote it would be claiming the assembler measured something it did not.
+    # Asked of the anchor THIS brief rendered, not of a literal, so a mutation
+    # that moves the anchor is not answered by this row.
+    assert f"{frm}..HEAD --not" in out, (
+        "THE LEDGER no longer reports the range it actually measured. It ran "
+        "`git rev-list`/`git log` in the assembly checkout, where `HEAD` is "
+        "the verified head — rewriting that line would misreport provenance."
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -2023,7 +2165,7 @@ def test_a_bare_round_one_audited_sha_still_anchors_the_next_round():
     bare_r1 = "```audit-claims round=1 audited=aaaa1111\n1. a round-1 claim\n```"
     rc, out, err = run_main(["900", "--round", "2"], comments=[bare_r1])
     assert rc == 0, err
-    assert "`aaaa1111..HEAD`" in out, (
+    assert f"`aaaa1111..{FAKE_HEAD_OID}`" in range_section(out), (
         "a bare round-1 `audited=<sha>` no longer anchors the round-2 range; "
         f"stderr was:\n{err}"
     )
@@ -2141,7 +2283,7 @@ def test_audited_supplies_the_tip_a_round_one_emit_cannot_derive():
     emitted = "\n".join(tail.splitlines()[:4])
     rc2, out2, err2 = run_main(["900", "--round", "2"], comments=[emitted])
     assert rc2 == 0, err2
-    assert "`abcd1234..HEAD`" in out2, (
+    assert f"`abcd1234..{FAKE_HEAD_OID}`" in range_section(out2), (
         "\n\nthe next round does not anchor on the tip round 1 audited, so the "
         "round-1 -> round-2 hop still loses round 1's own fix commits."
     )
@@ -2164,7 +2306,7 @@ def test_audited_without_emit_claims_says_it_changed_nothing():
     assert "--audited" in err and "changed NOTHING" in err, (
         f"the ignored flag was accepted in silence; stderr was:\n{err}"
     )
-    assert "`aaaa1111..HEAD`" in out, (
+    assert f"`aaaa1111..{FAKE_HEAD_OID}`" in range_section(out), (
         "worse than silence: `--audited` moved the range this round DIFFS "
         "from. It is the WRITER's anchor and must not touch the reader's."
     )
@@ -2266,13 +2408,23 @@ def test_the_degenerate_range_causes_have_exactly_one_writer_per_consumer():
 def test_a_private_worktree_is_not_described_as_shared_and_is_not_absolved():
     """🔴 REGRESSION. Red at `e06461f7`, which asserted SHARED of every tree.
 
-    Run from `…/.claude/worktrees/agent-…` — where a dispatched auditor
-    usually stands — the brief printed a heading reading THE SHARED CHECKOUT
+    Run from `…/.claude/worktrees/agent-…` — the tree this script is ROUTINELY
+    ASSEMBLED IN — the brief printed a heading reading THE SHARED CHECKOUT
     over "This checkout is SHARED with other sessions and agents. It MOVES
     UNDER YOU … That is expected and is NOT your fault and NOT a finding."
 
+    🔴 ROUND 6 CORRECTED THIS PARAGRAPH. It used to place a dispatched auditor
+    in that worktree — the premise `REFUTED_PREMISES[0]` records, and the one
+    round 5 overturned: the tree is measured by the ASSEMBLING process, and
+    WHERE TO WORK sends the auditor somewhere else. The script's own docstring
+    was corrected in round 5 and this one was not, leaving the ladder's record
+    of the finding asserting the premise the finding overturned — twelve lines
+    above a docstring the same round edited.
+    `test_no_refuted_premise_survives_in_this_modules_prose` is what makes that
+    mechanical instead of noticed.
+
     🔴 The DIRECTION is the consequential half, and it is what this asserts:
-    an auditor in a private worktree who watches files move is told it is
+    a reader in a private worktree who watches files move is told it is
     expected and not a finding, which suppresses exactly the sibling-agent
     clobber `claude/RULES.md` says to report.
     """
@@ -2286,9 +2438,10 @@ def test_a_private_worktree_is_not_described_as_shared_and_is_not_absolved():
         f"\n\nthe brief calls a PRIVATE per-agent worktree shared:\n{checkout}"
     )
     assert "NOT a finding" not in checkout, (
-        "\n\nthe brief absolves movement in a tree that is the auditor's "
-        "alone. That absolution is what suppresses a sibling-agent clobber "
-        "report — the one signal a private worktree can produce."
+        "\n\nthe brief absolves movement in a PRIVATE linked worktree, which "
+        "belongs to one session and to no other. That absolution is what "
+        "suppresses a sibling-agent clobber report — the one signal a private "
+        "worktree can produce."
     )
     # 🔴 The POSITIVES moved in round 5 and the reason is the finding: round 4
     # replaced the false SHARED claim with "a PRIVATE worktree — yours alone …
@@ -2476,9 +2629,19 @@ ROUND_4_WRITE_GRANT = (
     "checkout, and this is not one."
 )
 
-CHECKOUT_STATE_DIRECTIVES = frozenset({
-    "checkout-moves", "checkout-private", "checkout-unknown",
-})
+# 🔴 THE STATES `render_checkout` CAN SELECT, keyed by the `gather_worktree_kind`
+# answer — pinned two-way against the SCRIPT's own map, never derived from an id
+# prefix. Round 6 measured why: renaming `checkout-private` to
+# `assembly-private`, dropping its no-write sentence and updating the three
+# ledgers left the whole 89-test suite GREEN, because the guard's set was
+# spelled "ids beginning `checkout-`" and the renamed directive fell out of it.
+# The relationship that matters is "every directive the renderer can select
+# carries the rule", and the renderer's selection is now readable.
+CHECKOUT_KIND_SCENARIO = {
+    "shared": "delta",
+    "private": "private-worktree",
+    "unknown": "unreadable-worktree",
+}
 # Matched case-insensitively at the first letter so "**Write nothing to it**"
 # and "and write nothing to it" both count — the sentence, not its capital.
 NO_WRITE_RULE = "rite nothing to it"
@@ -2533,32 +2696,179 @@ def test_every_checkout_state_carries_the_no_write_rule():
     ONLY thing that survives a reword of the `no-fetch` clause — round 4
     reworded that clause into a conditional one and the private state was left
     with a write grant and no rule anywhere — so every state must carry the rule
-    itself. Pinned two-way: a fourth checkout state with no rule fails, and a
-    ledger entry naming no directive fails.
+    itself.
+
+    🔴 ROUND 6 REPLACED HOW THE SET IS DERIVED, and the old spelling was the
+    finding. It read `{d.id for d in SECTION_DIRECTIVES if
+    d.id.startswith("checkout-")}` — an id PREFIX, i.e. a naming convention —
+    while the relationship it means is "every directive `render_checkout` can
+    SELECT". Measured at `3619fe68`: renaming `checkout-private` to
+    `assembly-private`, deleting its "Write nothing to it" and updating the
+    three ledgers left the suite at **89/89 green**. The renamed directive
+    simply fell out of the set, and a guard whose set can be emptied by a
+    rename is spelled, not structural. It now reads `render_checkout`'s own
+    `CHECKOUT_STATE_DIRECTIVE` map, and drives one SCENARIO per state rather
+    than looking each id up in a ledger that a rename also updates.
     """
-    ids = {d.id for d in ad.SECTION_DIRECTIVES if d.id.startswith("checkout-")}
-    assert ids == set(CHECKOUT_STATE_DIRECTIVES), (
-        f"\n\nthe checkout states are {sorted(ids)}, not "
-        f"{sorted(CHECKOUT_STATE_DIRECTIVES)}.\n"
+    states = ad.CHECKOUT_STATE_DIRECTIVE
+    assert set(states) == set(CHECKOUT_KIND_SCENARIO), (
+        f"\n\nthe checkout STATES are {sorted(states)}, not "
+        f"{sorted(CHECKOUT_KIND_SCENARIO)}.\n"
         "  GREW: a new state renders auditor-facing prose that nobody checked "
-        "carries the no-write rule.\n"
-        "  SHRANK: a state was deleted and its ledger entry left behind."
+        "carries the no-write rule, and no scenario drives it.\n"
+        "  SHRANK: a state was deleted and its scenario left behind."
     )
-    for cid in sorted(ids):
+    for kind, cid in sorted(states.items()):
+        assert cid in ad.DIRECTIVE, (
+            f"\n\nstate {kind!r} selects directive `{cid}`, which does not "
+            "exist. `render_checkout` would print the MISSING-BLOCK "
+            "placeholder for every brief assembled in that state."
+        )
         assert NO_WRITE_RULE in ad.DIRECTIVE[cid], (
-            f"\n\nthe `{cid}` directive does not tell the auditor to write "
-            "nothing to the path THE CHECKOUT names. Only the per-state "
-            "directive survives a reword of the `no-fetch` clause, and round 4 "
-            "reworded that clause into one that switches itself off."
+            f"\n\nstate {kind!r} selects `{cid}`, which does not tell the "
+            "auditor to write nothing to the path THE CHECKOUT names. Only "
+            "the per-state directive survives a reword of the `no-fetch` "
+            "clause, and round 4 reworded that clause into one that switches "
+            "itself off."
         )
     # 🔴 BEHAVIOURAL, because a structural check type-checks past prose that
-    # never reaches an artifact: each state's rule must be IN the section.
-    for cid in sorted(ids):
-        section = checkout_section(brief_for_scenario(DIRECTIVE_RENDERS_IN[cid]))
+    # never reaches an artifact: each state's rule must be IN the section a run
+    # in that state actually prints.
+    for kind, scenario in sorted(CHECKOUT_KIND_SCENARIO.items()):
+        section = checkout_section(brief_for_scenario(scenario))
         assert NO_WRITE_RULE in section, (
-            f"the `{cid}` rule is in the constant but not in the rendered "
-            f"section of the {DIRECTIVE_RENDERS_IN[cid]!r} scenario"
+            f"state {kind!r} (scenario {scenario!r}) renders a checkout "
+            f"section with no no-write rule in it:\n{section}"
         )
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 ROUND 6 — A FORWARD REFERENCE THAT NARROWED THE RULE IT NAMED
+# --------------------------------------------------------------------------- #
+# Round 5 rewrote `no-fetch` off SHAREDNESS and onto OWNERSHIP. The sentence in
+# `own-worktree-is-writable` that forward-references that clause was left
+# saying "the no-write rule below is about the SHARED checkout" — true at
+# `dd601793`, false at `3619fe68`, and the falsity is load-bearing: rendered in
+# the configuration production actually produces (a cross-repo PR assembled in
+# a private per-agent worktree) the brief reads, in order,
+#
+#   WHERE TO WORK : "The no-write rule below is about the SHARED checkout."
+#   THE CHECKOUT  : "kind : PRIVATE linked worktree — belongs to the session…"
+#   NON-NEGOTIABLE: "…write to any checkout that is not the copy YOU made…"
+#
+# which is the syllogism round 4 wrote into `checkout-private` and round 5
+# deleted, surviving one directive over. The reader can discharge the
+# non-negotiable clause on the grounds that this checkout is not shared.
+
+# The vocabulary the brief uses to REPORT a checkout state, as the `kind :`
+# line spells it. Deliberately the rendered words and not the internal kind
+# keys: what a forward reference can contradict is what the reader was told.
+CHECKOUT_STATE_WORDS = ("SHARED", "PRIVATE", "COULD NOT DETERMINE")
+
+_KIND_LINE = re.compile(r"^\s*kind\s*:\s*(.+)$", re.M)
+
+# 🔴 Round 5's sentence, verbatim, kept ONLY as the positive control's payload.
+ROUND_5_NO_WRITE_SCOPE = "The no-write rule below is about the SHARED checkout."
+
+
+def no_write_forward_references(text):
+    """Sentences that tell the reader what the no-write rule COVERS.
+
+    Sliced on sentence boundaries rather than on the directive, because the
+    hazard is a CLAIM ABOUT ANOTHER SECTION and any section may make one.
+    """
+    return [s for s in re.split(r"(?<=[.!])\s+", text) if "no-write rule" in s]
+
+
+def checkout_kind_word(brief):
+    """The state word THE CHECKOUT's `kind :` line reports for this brief.
+
+    Read off that LINE and not off the section, because two of the three state
+    directives legitimately mention a state they are not: `checkout-unknown`
+    says "Treat it as SHARED", and `checkout-private` mentions a "shared
+    repository". The `kind :` line is the brief's own answer.
+    """
+    m = _KIND_LINE.search(checkout_section(brief))
+    assert m, f"no `kind :` line in THE CHECKOUT:\n{checkout_section(brief)}"
+    named = [w for w in CHECKOUT_STATE_WORDS if w in m.group(1)]
+    assert len(named) == 1, (
+        f"the `kind :` line names {named}, so this brief has no single "
+        f"reported state to compare a forward reference against: {m.group(1)!r}"
+    )
+    return named[0]
+
+
+def no_write_scope_conflicts(brief):
+    """-> [(sentence, reported state, states it names instead)].
+
+    The RELATIONSHIP: a sentence that scopes the no-write rule to a checkout
+    state may not name a state THIS brief's own THE CHECKOUT section denies.
+    Deliberately says nothing about the `no-fetch` clause's wording — round 5
+    owns that, and re-asserting it here would make mutant Z3 kill this row for
+    someone else's reason.
+    """
+    kind = checkout_kind_word(brief)
+    out = []
+    for sentence in no_write_forward_references(brief):
+        wrong = [w for w in CHECKOUT_STATE_WORDS if w in sentence and w != kind]
+        if wrong:
+            out.append((sentence, kind, wrong))
+    return out
+
+
+def test_no_forward_reference_scopes_the_no_write_rule_to_a_denied_state():
+    """🔴 REGRESSION. Red at `3619fe68`, in the `cross-repo-private` scenario.
+
+    The wrong ANSWER, not a missing word: the brief tells the auditor the
+    no-write rule is about the SHARED checkout, two bars above its own
+    statement that the checkout in question is PRIVATE — and the clause it is
+    describing has had no sharedness scoping since round 5.
+
+    🔴 Both cross-repo scenarios are driven, and only ONE is red at the base.
+    In `cross-repo` the reported state really is SHARED, so the sentence is
+    merely stale there; the contradiction needs the PRIVATE assembly tree,
+    which is the ordinary case for an agent-dispatched round and is exactly
+    how round 6 observed it. A test scoped to `cross-repo` alone would have
+    passed at the base and reported the hazard absent.
+    """
+    # 🔴 POSITIVE CONTROL, through the same two helpers a real brief goes
+    # through. A conflict list that comes back empty is indistinguishable from
+    # a scan wired to nothing.
+    control = (
+        "## THE CHECKOUT — state at assembly time\n\n"
+        "    kind   : PRIVATE linked worktree — belongs to the session that "
+        "assembled this brief, not to you\n\n"
+        f"{ROUND_5_NO_WRITE_SCOPE}\n\n"
+        "## NEXT\n"
+    )
+    assert no_write_scope_conflicts(control), (
+        "POSITIVE CONTROL: the scan cannot see round 5's own sentence over a "
+        "PRIVATE `kind :` line, so a clean result below would say nothing"
+    )
+
+    seen = 0
+    for scenario in SCENARIOS:
+        brief = brief_for_scenario(scenario)
+        seen += len(no_write_forward_references(brief))
+        conflicts = no_write_scope_conflicts(brief)
+        assert not conflicts, (
+            f"\n\nscenario {scenario!r}: the brief scopes the no-write rule to "
+            "a checkout state its own THE CHECKOUT section denies.\n"
+            + "".join(
+                f"  says   : {s!r}\n  reports: kind = {k}\n  names   : {w}\n"
+                for s, k, w in conflicts
+            )
+            + "  The rule the sentence describes is scoped by OWNERSHIP — "
+            "every checkout you did not make — and has been since round 5. "
+            "Naming a STATE lets the reader discharge it on the grounds that "
+            "this checkout is not that state, which is round 4's syllogism "
+            "one directive over."
+        )
+    assert seen, (
+        "no scenario renders a forward reference to the no-write rule at all, "
+        "so the loop above asserted nothing. Either the sentence was deleted "
+        "or `no_write_forward_references` no longer matches how it is spelled."
+    )
 
 
 def toolchain_section(brief):
@@ -2567,7 +2877,7 @@ def toolchain_section(brief):
     return brief[start:brief.index(EXPECTED_INVARIANTS_HEADING, start)]
 
 
-def test_the_toolchain_reason_is_true_in_both_checkout_states():
+def test_the_toolchain_reason_is_true_in_every_scenario():
     """🔴 REGRESSION. Red at `dd601793` in the PRIVATE state.
 
     `render_toolchain` interpolated `r = facts.cwd_repo_dir` into prose reading
@@ -2583,9 +2893,20 @@ def test_the_toolchain_reason_is_true_in_both_checkout_states():
     🔴 The PRIVATE state runs FIRST so the red at the base is the FALSE claim.
     In the shared state the sentence was true; making it state-independent is
     the same fix, and the equality assertion at the foot is what pins it.
+
+    🔴 ROUND 6 WIDENED IT FROM TWO SCENARIOS TO ALL OF THEM, and the two it
+    drove were both SAME-REPO. Measured at `3619fe68`: re-introducing the
+    forbidden phrase in the CROSS-REPO branch left the suite at **89 passed**,
+    and no mutant row named it. An equality over two same-repo scenarios does
+    not pin state-independence — it pins independence of the one axis it
+    happened to vary. It now drives every scenario `brief_for_scenario` knows,
+    including the cross-repo pair, and requires the rendered section to be
+    BYTE-IDENTICAL across all of them: that is the claim the section's own
+    docstring makes ("this section knows nothing about where the auditor
+    stands"), stated as wide as the code it describes.
     """
     sections = {}
-    for scenario in ("private-worktree", "delta"):
+    for scenario in SCENARIOS:
         tool = toolchain_section(brief_for_scenario(scenario))
         sections[scenario] = tool
         assert "SHARED CHECKOUT" not in tool, (
@@ -2603,11 +2924,23 @@ def test_the_toolchain_reason_is_true_in_both_checkout_states():
             "the reason no longer names the property that is true in every "
             "state — that copy is not the auditor's"
         )
-    assert sections["private-worktree"] == sections["delta"], (
-        "\n\nTOOLCHAIN now varies with the checkout state. It is rendered from "
-        "`facts.cwd_repo_dir` alone and knows nothing about where the auditor "
-        "stands, so a state-dependent sentence here is a claim it cannot "
-        "support in the branch it is not being read in."
+    # 🔴 EQUALITY ACROSS EVERY SCENARIO, not across a chosen pair. Compared
+    # against ONE reference so the failure names which scenario diverged.
+    ref_name = SCENARIOS[0]
+    for scenario, tool in sections.items():
+        assert tool == sections[ref_name], (
+            f"\n\nTOOLCHAIN differs between {ref_name!r} and {scenario!r}. It "
+            "is rendered from `facts.cwd_repo_dir` alone and knows nothing "
+            "about where the auditor stands or which repo the PR is in, so a "
+            "scenario-dependent sentence here is a claim it cannot support in "
+            "the branch it is not being read in.\n"
+            f"--- {ref_name} ---\n{sections[ref_name]}\n"
+            f"--- {scenario} ---\n{tool}"
+        )
+    assert len(sections) == len(SCENARIOS) >= 5, (
+        f"only {len(sections)} scenario(s) were driven; an equality over a "
+        "handful of them pins independence of the axes they happen to vary "
+        "and nothing else — which is exactly how round 6 walked this guard"
     )
 
 
@@ -2673,6 +3006,18 @@ def test_emit_claims_refuses_an_audited_value_its_own_parser_cannot_read():
     assert rc != 0 and ad.EMIT_REFUSAL_HEADER in err, (
         f"`--audited ''` was ignored rather than refused: rc {rc}\n{err}"
     )
+    # 🔴 AND IT MUST GET ITS OWN DIAGNOSIS, not merely a refusal. Round 7's
+    # whitespace check subsumes the OUTCOME — `"".split() != [""]` — so with
+    # the empty branch deleted the run still exits 4, and mutant Z7 SURVIVED a
+    # test that asked only for a non-zero rc. The two failures need different
+    # explanations: an empty value would be silently IGNORED (falling back to
+    # the previous block's `<to>`, or to the bare round-1 spelling), which is
+    # nothing to do with whitespace leaving the header line. Telling an
+    # operator about newlines when they passed `""` sends them to the wrong fix.
+    assert "EMPTY value" in err and "indistinguishable from the flag being" in err, (
+        "\n\n`--audited ''` was refused, but not as an EMPTY value — the "
+        "explanation it got belongs to a different failure:\n" + err
+    )
 
     # 🔴 NEGATIVE CONTROL — a checker that rejects everything is as useless as
     # one that accepts everything. A well-formed sha still emits.
@@ -2691,8 +3036,19 @@ def test_emit_claims_refuses_an_audited_value_its_own_parser_cannot_read():
     )
 
     # 🔴 NAMED BLIND SPOT, asserted so it cannot read as covered: a well-formed
-    # token that is no commit round-trips and is NOT caught. This script never
-    # resolves a sha — it refuses to touch the checkout at all.
+    # token that is no commit round-trips and is NOT caught.
+    #
+    # 🔴 THE REASON PRINTED HERE FOR THREE ROUNDS WAS FALSE — see
+    # `FALSE_BLIND_SPOT_RATIONALES`, which now holds it and is the only place
+    # it may appear. It runs
+    # seven read-only `git -C <that checkout>` commands, two of which resolve
+    # this very token there (`rev-list --count <anchor>..HEAD`, `log --numstat
+    # … <anchor>..HEAD`). Reading is not writing, and the gap has a different
+    # cause: this script never FETCHES, so the assembly checkout may be missing
+    # an object that is fine on the PR, and a `cat-file` refusal there would
+    # reject a CORRECT value. The cost of leaving it open is bounded and loud —
+    # `rev-list` exits 128 and the ledger says COULD NOT MEASURE, naming the
+    # command, one round later.
     rc, out, err = run_main(
         ["900", "--round", "1", "--emit-claims", "--audited", "zzzzzzzz"]
     )
@@ -2701,6 +3057,207 @@ def test_emit_claims_refuses_an_audited_value_its_own_parser_cannot_read():
         "reach, and the docstring says so — if it is now caught, widen the "
         "claim rather than leaving this assertion inverted"
     )
+
+
+# 🔴 Values whose ONLY defect is SURROUNDING whitespace. What the operator
+# meant is unambiguous for every one of them — the stripped token — so an
+# emitted block can be held to carrying exactly that, which is a stronger claim
+# than "it exited non-zero". A value with an INTERIOR space (`abc 123`) is not
+# here: there is no single sha it unambiguously means, and its refusal is owned
+# by the test above.
+SURROUNDING_WHITESPACE_AUDITED = (
+    ("aaaa1111\n", "a TRAILING NEWLINE — the one that moves content off the "
+                   "header line"),
+    ("aaaa1111\r\n", "a CRLF line ending, as a Windows editor or a pasted "
+                     "shell capture produces"),
+    ("aaaa1111\n\n", "two newlines: the second lands a blank line in the body"),
+    ("aaaa1111 ", "a trailing space"),
+    (" aaaa1111", "a leading space"),
+    ("\taaaa1111", "a leading tab"),
+)
+
+
+def test_emit_claims_refuses_an_audited_value_whose_whitespace_leaves_the_line():
+    """🔴 REGRESSION. Red at `3619fe68` for a TRAILING NEWLINE.
+
+    Measured there through `main()`: `--audited $'aaaa1111\\n'` exited **0** and
+    printed a block reading ``audited=aaaa1111`` — the BARE round-1 spelling.
+    `<to>` was lost onto the next line as a stray `..<head>`, and
+    `parse_claims_blocks` reported `malformed=[]`. Round 3 then reads
+    `emit_anchor` = `aaaa1111`, emits `audited=aaaa1111..<head>`, and round 4
+    re-audits round 2's fixes on top of round 3's — silently, one round
+    downstream.
+
+    🔴 WHY THE EXISTING ROUND TRIP CANNOT SEE IT, which is why the fix is an
+    INPUT check and not a wider round trip: `emitted_block_reads_back_as_written`
+    compares the printed header LINE against a parse of that same printed header
+    LINE. `_EMITTED_AUDITED` is `re.M` + `$`; `parse_claims_blocks` reads line by
+    line. Both sides are line-oriented, so anything pushed onto the next line is
+    invisible to both and they agree — a control built out of the step it
+    doubts. The empty check misses it too: `.strip()` is truthy here.
+
+    🔴 AND THE OBVIOUS PREDICATE DOES NOT WORK. `len(value.split()) != 1` is
+    **1** for `'aaaa1111\\n'`, for `'aaaa1111 '` and for `'aaaa1111\\r'` alike,
+    because `str.split()` with no argument discards empty fields. Asserted below
+    against the real values, so a future simplification to that spelling fails
+    here rather than silently re-opening the hole.
+    """
+    # 🔴 THE STRUCTURAL CLAIM, asserted rather than described: fed the exact
+    # block a trailing newline produces, the round trip reports NO problem. If
+    # this ever starts returning a reason, the input check is no longer the
+    # only thing standing between that value and the emitted block — say so
+    # rather than leaving this reading as coverage it does not provide.
+    blind = (
+        "```audit-claims round=1 audited=aaaa1111\n"
+        f"..{FAKE_HEAD_OID[:8]}\n"
+        "1. a claim\n"
+        "```"
+    )
+    assert ad.emitted_block_reads_back_as_written(blind) is None, (
+        "the round trip now sees content pushed off the header line. Widen "
+        "this test's claim rather than leaving it asserting the opposite"
+    )
+    # 🔴 THE PREDICATE CONTROL. `len(split()) != 1` cannot distinguish these
+    # from a clean sha, so it is not what the script may use.
+    assert all(len(v.split()) == 1 for v, _ in SURROUNDING_WHITESPACE_AUDITED), (
+        "a value here no longer has the property that makes this test's point "
+        "— `len(split())` must be 1 for every row, or the hole it guards is a "
+        "different one"
+    )
+
+    for value, why in SURROUNDING_WHITESPACE_AUDITED:
+        rc, out, err = run_main(
+            ["900", "--round", "1", "--emit-claims", "--audited", value]
+        )
+        # 🔴 THE CONTENT CLAIM FIRST, and it is the one that is red at the
+        # base: whatever is emitted must read back as the value that was
+        # given. rc alone would be satisfied by a refusal for any reason.
+        if "```audit-claims" in out:
+            tail = out[out.rindex("```audit-claims"):]
+            blocks, malformed = ad.parse_claims_blocks([tail])
+            got = (blocks[0].audited_from, blocks[0].audited_to) if blocks else None
+            assert not malformed and got == (value.strip(), FAKE_HEAD_OID[:8]), (
+                f"\n\n--audited {value!r} ({why}) was ACCEPTED, and the block "
+                f"it printed does not carry it.\n"
+                f"  wanted `<from>`/`<to>`: {(value.strip(), FAKE_HEAD_OID[:8])}\n"
+                f"  reads back as        : {got}\n"
+                f"  malformed            : {malformed}\n"
+                "  The next round anchors its whole delta on `<from>` and "
+                "copies `<to>` forward, and nothing downstream reports this "
+                f"malformed.\n{tail}"
+            )
+        assert rc != 0 and ad.EMIT_REFUSAL_HEADER in err, (
+            f"\n\n--audited {value!r} ({why}) was accepted: rc {rc}. It is not "
+            "one whitespace-free token, and the emitted header is a single "
+            f"LINE.\nstderr:\n{err}"
+        )
+        assert repr(value) in err or value.strip() in err, (
+            f"the refusal does not name the value it rejected:\n{err}"
+        )
+
+    # 🔴 NEGATIVE CONTROL — the check must not reject a clean sha. Without it a
+    # guard that refuses everything reads as green here.
+    rc, out, err = run_main(
+        ["900", "--round", "1", "--emit-claims", "--audited", "aaaa1111"]
+    )
+    assert rc == 0, f"the whitespace check rejected a clean sha:\n{err}"
+    tail = out[out.rindex("```audit-claims"):]
+    blocks, malformed = ad.parse_claims_blocks([tail])
+    assert not malformed and len(blocks) == 1
+
+
+# 🔴 THE RATIONALES THE BLIND-SPOT NOTE GAVE, AND WHY EACH IS FALSE. Same
+# exactly-once contract as `REFUTED_PREMISES`: this ledger is the one place
+# either may be written. The SCRIPT must not carry them at all.
+FALSE_BLIND_SPOT_RATIONALES = (
+    "never resolves a sha",
+    "never resolves the sha",
+    "refuses to touch the checkout at all",
+)
+
+
+def recording_runner(**kw):
+    """A `make_runner` that also records every command it is asked to run."""
+    inner = make_runner(**kw)
+    seen = []
+
+    def runner(cmd, cwd=None):
+        seen.append(list(cmd))
+        return inner(cmd, cwd=cwd)
+
+    runner.seen = seen
+    return runner
+
+
+def test_the_blind_spot_rationale_matches_what_the_script_actually_does():
+    """🔴 REGRESSION. Red at `3619fe68`, in the SCRIPT and in this module.
+
+    The `--emit-claims` round trip has a named blind spot — a well-formed token
+    that is no commit is not caught — and for three rounds both files gave the
+    same reason for leaving it open: that this script does no sha resolution in
+    the assembly checkout, because it will not touch it. Measured below: it
+    issues read-only `git -C <that checkout>` commands, and two of them resolve
+    exactly that token there. Reading is not writing.
+
+    🔴 KEEP THE GAP, REPLACE THE REASON — and this test pins only the half it
+    can measure. The true reason (no `git fetch` is ever run, so the checkout
+    may legitimately lack an object that is fine on the PR, and refusing there
+    would be a false positive on a correct value) is prose and is not
+    machine-checked. What IS checked is that a rationale contradicted by the
+    script's own behaviour cannot be restated: a false cause is how a later
+    round closes a hole that was never there, or leaves one it thinks is
+    unreachable.
+    """
+    runner = recording_runner(comments=[CLAIMS_BLOCK_R2])
+    rc, out, err = run_main(["900", "--round", "3"], runner=runner)
+    assert rc == 0, err
+
+    in_checkout = [c for c in runner.seen if c[:3] == ["git", "-C", FAKE_REPO_DIR]]
+    assert in_checkout, (
+        "POSITIVE CONTROL: this run issued no `git -C <the assembly checkout>` "
+        "command at all, so the measurement below is about nothing"
+    )
+    resolving = [c for c in in_checkout if any(".." in a for a in c)]
+    assert resolving, (
+        "\n\nno command resolved a revision RANGE in the assembly checkout, "
+        "which is the observation that refutes the old rationale. Commands "
+        f"run there:\n" + "\n".join("  " + " ".join(c) for c in in_checkout)
+    )
+    anchor = CLAIMS_BLOCK_R2.split("audited=")[1].split("..")[0]
+    assert any(anchor in a for c in resolving for a in c), (
+        f"\n\nno command resolved the `audited=` token {anchor!r} itself. The "
+        "blind spot is about THAT token; a range over some other pair would "
+        "not make the old rationale false.\n"
+        + "\n".join("  " + " ".join(c) for c in resolving)
+    )
+
+    # 🔴 AND THE PROSE MAY NOT SAY OTHERWISE. Normalised the same way
+    # `surviving_refuted_premises` normalises, and for the same two reasons:
+    # these live in wrapped comments and in implicitly-concatenated literals.
+    def flat(text):
+        return " ".join(re.sub(r'"\s*"', "", text).split())
+
+    script = flat(Path(ad.__file__).read_text(encoding="utf-8"))
+    module = flat(_THIS_MODULE_SOURCE)
+    # POSITIVE CONTROL for the scan itself.
+    assert flat(f"x {FALSE_BLIND_SPOT_RATIONALES[0]} y").count(
+        flat(FALSE_BLIND_SPOT_RATIONALES[0])) == 1, (
+        "POSITIVE CONTROL: the normalising counter cannot find a phrase it was "
+        "just handed, so every zero below would be meaningless"
+    )
+    for phrase in FALSE_BLIND_SPOT_RATIONALES:
+        p = flat(phrase)
+        assert script.count(p) == 0, (
+            f"\n\n`scripts/audit-dispatch.py` states {phrase!r} of itself, "
+            f"{script.count(p)} time(s). It is false — the run above resolved "
+            f"{anchor!r} in that checkout with "
+            f"`{' '.join(resolving[0])}` — and a comment is a claim too."
+        )
+        assert module.count(p) == 1, (
+            f"\n\nthis module states {phrase!r}, {module.count(p)} time(s). "
+            "It may appear exactly once: in FALSE_BLIND_SPOT_RATIONALES, as a "
+            "record of a rationale that was measured false."
+        )
 
 
 def test_the_emitted_skeleton_carries_a_legend_for_its_two_fields():
@@ -3357,7 +3914,7 @@ RED_AT_BASE_R4: frozenset[str] = frozenset({
 # mutants Z1/Z2 and Z5 as their evidence.
 RED_AT_BASE_R5: frozenset[str] = frozenset({
     "test_no_checkout_state_grants_write_permission_over_the_assembly_checkout",
-    "test_the_toolchain_reason_is_true_in_both_checkout_states",
+    "test_the_toolchain_reason_is_true_in_every_scenario",
     "test_emit_claims_refuses_an_audited_value_its_own_parser_cannot_read",
     "test_the_degenerate_cause_list_scopes_the_omitted_flag_to_round_one",
     # Pre-existing, and it MOVED with the fix: its positives asserted the
@@ -3366,11 +3923,31 @@ RED_AT_BASE_R5: frozenset[str] = frozenset({
     # on the false SHARED claim — it stays filed under that ref, not this one.
 })
 
+# 🔴 ROUND 7's base is the ROUND-6 TREE, `3619fe68`. Measured the same way —
+# `git show 3619fe68:scripts/audit-dispatch.py` into a scratch tree with THIS
+# module copied in unchanged, `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`.
+#
+# 🔴 ONE OF ROUND 7's FIVE NEW TESTS IS **NOT** HERE, and the distinction is a
+# new one: `..._refuted_premise_survives_in_this_modules_prose` scans THIS
+# MODULE's prose, and the red-at-base procedure copies this module in
+# UNCHANGED. It structurally cannot be red under it — a base script says
+# nothing about a base docstring. It is filed as a guard whose evidence is its
+# own in-module positive control, and its red WAS measured, separately: the
+# base module's prose carries both ledger entries once each (normalised), so
+# with the ledger's own copy present each reads 2.
+RED_AT_BASE_R6: frozenset[str] = frozenset({
+    "test_no_forward_reference_scopes_the_no_write_rule_to_a_denied_state",
+    "test_emit_claims_refuses_an_audited_value_whose_whitespace_leaves_the_line",
+    "test_the_blind_spot_rationale_matches_what_the_script_actually_does",
+    "test_the_range_names_a_sha_and_not_head_when_the_head_is_verified",
+})
+
 RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "abc41024": RED_AT_BASE_R2,
     "d9eb36a8": RED_AT_BASE_R3,
     "e06461f7": RED_AT_BASE_R4,
     "dd601793": RED_AT_BASE_R5,
+    "3619fe68": RED_AT_BASE_R6,
 }
 RED_AT_BASE: frozenset[str] = frozenset().union(*RED_AT_BASE_REFS.values())
 
@@ -3474,6 +4051,15 @@ INVARIANT_GUARDS_AND_LEDGERS = frozenset({
     "test_every_checkout_state_carries_the_no_write_rule",
     # There is no legend at `dd601793` at all. Mutant Z5 deletes it again.
     "test_the_emitted_skeleton_carries_a_legend_for_its_two_fields",
+    # ------------------------------------------------------------------- #
+    # Round 7's one guard. It scans THIS MODULE's prose, and the red-at-base
+    # procedure copies this module in UNCHANGED — so no base SCRIPT can make
+    # it red, and filing it as regression coverage would be a claim the
+    # procedure cannot support. Its red was measured separately (the base
+    # module carries both ledger entries once each, normalised) and its
+    # in-test positive control is what keeps it honest per run. The battery
+    # mutates the script and cannot reach it.
+    "test_no_refuted_premise_survives_in_this_modules_prose",
 })
 
 # --------------------------------------------------------------------------- #
@@ -3679,7 +4265,7 @@ FIX_MATRIX = (
      "GUARD", "Z3"),
     ("r5/2  TOOLCHAIN's rationale called the assembly checkout the SHARED "
      "CHECKOUT two bars after THE CHECKOUT denied it",
-     "test_the_toolchain_reason_is_true_in_both_checkout_states",
+     "test_the_toolchain_reason_is_true_in_every_scenario",
      "RED@dd601793", "Z4"),
     ("r5/3  --audited accepted any string; a value with a space, an embedded "
      "`..` or a placeholder was truncated by the emitter's own parser",
@@ -3693,6 +4279,43 @@ FIX_MATRIX = (
      "operator wrote them the wrong way round twice running",
      "test_the_emitted_skeleton_carries_a_legend_for_its_two_fields",
      "GUARD", "Z5"),
+
+    # ------------------------------------------------------------------ #
+    # 🔴 ROUND 6's FINDINGS, FIXED IN ROUND 7. Base `3619fe68`.
+    # ------------------------------------------------------------------ #
+    ("r6/1  `own-worktree-is-writable` scoped the no-write rule to the SHARED "
+     "checkout, naming a scoping round 5 removed from the clause it describes",
+     "test_no_forward_reference_scopes_the_no_write_rule_to_a_denied_state",
+     "RED@3619fe68", "V4"),
+    ("r6/2  the exit-4 round trip is line-oriented on BOTH sides, so a "
+     "TRAILING NEWLINE in `--audited` emitted a corrupt block at rc 0",
+     "test_emit_claims_refuses_an_audited_value_whose_whitespace_leaves_the_line",
+     "RED@3619fe68", "V5"),
+    ("r6/3  this module's own prose still asserted the premise round 5 refuted",
+     "test_no_refuted_premise_survives_in_this_modules_prose",
+     "GUARD", "IN-MODULE CONTROL"),
+    # 🔴 THE SAME DETECTOR AS r5/2, DELIBERATELY, and its evidence label is
+    # r5/2's — the test really was watched red at `dd601793` and that has not
+    # changed. What round 6 found was that it was too NARROW (two scenarios,
+    # both same-repo), and a width claim has no base ref: its evidence is the
+    # mutant that walks the narrow version, which is why V7 is named here and
+    # not folded into r5/2's column.
+    ("r6/4  the TOOLCHAIN equality drove two scenarios, both same-repo, so a "
+     "cross-repo-only reword left it green",
+     "test_the_toolchain_reason_is_true_in_every_scenario",
+     "RED@dd601793", "V7"),
+    ("r6/5  the no-write relationship was spelled as an id PREFIX, so a rename "
+     "emptied the set it guards",
+     "test_every_checkout_state_carries_the_no_write_rule",
+     "GUARD", "V1, V2"),
+    ("r6/6  the blind-spot rationale said the script resolves no sha in that "
+     "checkout; it resolves that very token there, twice",
+     "test_the_blind_spot_rationale_matches_what_the_script_actually_does",
+     "RED@3619fe68", "V3"),
+    ("r6/7  the VERIFIED range handed out `..HEAD`, which the auditor resolves "
+     "in a worktree cut AFTER assembly (pre-existing; the third instance)",
+     "test_the_range_names_a_sha_and_not_head_when_the_head_is_verified",
+     "RED@3619fe68", "V6"),
 )
 
 # A COLLAPSE floor, not a growth floor: a matrix emptied by a bad refactor
@@ -3707,8 +4330,10 @@ FIX_MATRIX = (
 # sentence — which is the same move as 🟢 "count them in the ledger" elsewhere,
 # and it is recorded because an arithmetic claim nobody re-runs is precisely
 # what that finding was about. Round 5 added seven rows: m = 54, and
-# 54 - max(1, 54 // 20) = 52. Counted again, not extrapolated.
-MIN_FIX_MATRIX_ROWS = 52
+# 54 - max(1, 54 // 20) = 52. Counted again, not extrapolated. Round 7 added
+# seven more: m = 61, and 61 - max(1, 61 // 20) = 58. Counted by asking the
+# constant itself (`len(FIX_MATRIX)`), not by adding 7 to the last sentence.
+MIN_FIX_MATRIX_ROWS = 58
 
 # 🔴 THE MUTANTS COLUMN IS AN EVIDENCE CLAIM, AND IT WAS UNGRADED.
 # `fix_matrix_problems` took `_mutants` and threw it away, so rewriting a
@@ -3927,6 +4552,110 @@ def test_control_the_fix_matrix_checker_catches_a_wrong_evidence_label():
     }
     assert mutant_ids("Y5b") == {"Y5b"}
     assert mutant_ids(IN_MODULE_CONTROL, {"XA"}) == set()
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 ROUND 6 — THE LADDER'S OWN RECORD CONTRADICTED THE SCRIPT
+# --------------------------------------------------------------------------- #
+# Round 5 refuted the premise round 4 built its write grant from. It corrected
+# the SCRIPT's docstring and left this module's, which went on stating the
+# refuted premise as fact — in the docstring of the very test that records the
+# finding, twelve lines above a docstring the same round edited.
+#
+# A premise nobody re-reads is exactly what acquires this error, so the ledger
+# is machine-checked rather than trusted. Each entry is a phrase that may now
+# appear EXACTLY ONCE in this module: here, as a record of what was refuted.
+#
+# 🔴 SCOPED TO THIS MODULE, and the scope is not an accident. The SCRIPT also
+# quotes the first phrase once, inside `gather_worktree_kind`'s docstring,
+# where it is explicitly marked false — a legitimate second copy this check
+# deliberately does not reach, because a count over two files could be
+# satisfied by the wrong file holding both.
+REFUTED_PREMISES = (
+    ("where a dispatched auditor usually stands",
+     "round 5: `gather_worktree_kind` measures the cwd of the ASSEMBLING "
+     "process, and WHERE TO WORK dispatches the auditor to a tree it makes "
+     "itself. No state this script can measure puts the auditor here."),
+    ("the auditor's alone",
+     "round 5: the assembly tree belongs to the session that BUILT the brief, "
+     "and under an inherited cwd it is shared with the dispatcher and with "
+     "sibling auditors. It is the auditor's in neither configuration."),
+)
+
+_THIS_MODULE_SOURCE = Path(__file__).read_text(encoding="utf-8")
+
+
+def surviving_refuted_premises(text):
+    """-> [(phrase, count)] for every refuted premise not stated exactly once.
+
+    ONE occurrence is the ledger entry itself. A SECOND is this module
+    asserting the premise somewhere else; ZERO means the ledger entry was
+    deleted, which is the same failure read from the other end.
+
+    🔴 NORMALISED TWICE OVER, AND THE FIRST TWO DRAFTS WERE NOT — each MISSED
+    an occurrence it was written for, and each reported the module CLEAN with
+    the premise sitting two lines away. Both were measured against `3619fe68`:
+
+      * a raw `str.count` scored **0** for both phrases. They live in WRAPPED
+        prose, so the source reads `where a dispatched auditor\\n    usually
+        stands`. Fixed by collapsing whitespace — the same normalisation the
+        script uses in `missing_clauses`, for the same reason.
+      * whitespace alone still scored **0** for entry 1, because that one
+        spans a Python IMPLICIT CONCATENATION — the phrase is cut in half by a
+        closing quote, a newline and an opening quote, and collapsing
+        whitespace leaves the two quote characters sitting in the middle of
+        it. So adjacent literals are joined FIRST, exactly as the compiler
+        joins them, and only then is whitespace collapsed.
+
+    That is the "guard whose description is wider than its implementation"
+    failure, twice, in the guard written to catch a claim wider than its code.
+    """
+    joined = re.sub(r'"\s*"', "", text)      # implicit string concatenation
+    flat = " ".join(joined.split())           # wrapped prose
+    counts = [(p, flat.count(" ".join(p.split()))) for p, _ in REFUTED_PREMISES]
+    return [(p, n) for p, n in counts if n != 1]
+
+
+def test_no_refuted_premise_survives_in_this_modules_prose():
+    """🔴 REGRESSION. Red at `3619fe68`, on both entries.
+
+    Measured there: entry 0 of the ledger above appeared in
+    `..._private_worktree_is_not_described_as_shared_and_is_not_absolved`'s
+    docstring and entry 1 in one of its assertion messages — both stating, as
+    the reason a test exists, the premise round 5 established is false. The
+    commit message for `3619fe68` claims both docstrings were corrected; the
+    script's was, this module's was not.
+
+    🔴 THIS DOCSTRING DELIBERATELY DOES NOT QUOTE EITHER PHRASE. Quoting one
+    here would be a second occurrence and would fail this very test — which is
+    the ledger working, not a limitation: the record of what was refuted lives
+    in ONE place, and everything else refers to it by index.
+
+    🔴 THIS IS PROSE, SO THE GUARD IS ON THE WHOLE PHRASE. `claude/RULES.md`:
+    when the artifact under test IS prose, a guard on a WORD is walkable by
+    rewording. A reword that keeps the claim keeps the phrase; a reword that
+    drops the phrase has also dropped the claim, which is the outcome wanted.
+    """
+    # 🔴 POSITIVE CONTROL, through the same function: a clean result over a
+    # scan that matched nothing is indistinguishable from a scan wired to
+    # nothing. Plant a second copy and require it to be seen.
+    planted = f"{_THIS_MODULE_SOURCE}\n# {REFUTED_PREMISES[0][0]}\n"
+    assert surviving_refuted_premises(planted), (
+        "POSITIVE CONTROL: the scan cannot see a planted second copy of "
+        f"{REFUTED_PREMISES[0][0]!r}, so a clean result below says nothing"
+    )
+    survivors = surviving_refuted_premises(_THIS_MODULE_SOURCE)
+    assert not survivors, (
+        "\n\nthis module states a premise the ladder has REFUTED:\n"
+        + "".join(
+            f"  {p!r}: {n} occurrence(s), want exactly 1 (the ledger entry)\n"
+            f"    refuted by {dict(REFUTED_PREMISES)[p]}\n"
+            for p, n in survivors
+        )
+        + "  A test module is the ladder's record of what each round found. "
+        "Reading as coverage while restating the thing that was overturned is "
+        "worse than saying nothing, because it stops the next round looking."
+    )
 
 
 def test_the_two_ledgers_partition_this_modules_tests():

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -321,7 +321,7 @@ notable one is `C3`: SEVEN of the thirteen names round 8 added LEFT it, because
 THE LEDGER stopped turning on `repo_relation` alone — the departure is round
 10's finding B, measured rather than argued.
 
-🔴 ROUND 10's BASE is `706a6b38`, measured the same way: **7 failed, 101
+🔴 ROUND 10's BASE is `706a6b38`, measured the same way: **7 failed, 102
 passed**. FIVE are its regression coverage (`RED_AT_BASE_R9`); of the other
 two, one is the whole-string DIRECTIVE ledger moving with the reword of
 `own-worktree-is-writable`, and one is
@@ -5268,12 +5268,14 @@ RED_AT_BASE_R7: frozenset[str] = frozenset({
 # 🔴 ROUND 10's base is the ROUND-9 TREE, `706a6b38`. Measured the same way —
 # `git show 706a6b38:scripts/audit-dispatch.py` into a scratch tree with THIS
 # module copied in unchanged, `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`:
-# **7 failed, 101 passed**. FOUR of the seven are these. Of the other three,
-# one is the whole-string directive ledger moving with round 10's reword of
-# `own-worktree-is-writable`, one is this partition guard itself (the new tests
-# are not in the base module's ledgers), and one is
+# **7 failed, 102 passed**. FIVE of the seven are these. Of the other two, one
+# is the whole-string directive ledger moving with round 10's reword of
+# `own-worktree-is-writable`, and one is
 # `test_the_tip_placeholder_ledger_matches_the_script`, filed as a guard above
 # because its red there is an `AttributeError` for a name the fix introduces.
+# (An earlier run of the same procedure read 7/101 with the partition guard
+# among the failures, because the base module's ledgers did not yet list this
+# round's tests. The figure above is the FINAL one, re-measured after they did.)
 #
 # 🔴 `test_no_brief_claims_a_verification_its_own_fixture_refutes` is NOT here
 # and is not new: round 8 filed it as a guard, and round 10 RESCOPED it. It is

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -311,6 +311,23 @@ as a guard holding. 🔴 TWO MORE IN ROUND 7 — `Y6` and `Y14`, whose target wa
 `CHECKOUT_STATE_DIRECTIVE`. That makes FOUR rows this assert has caught, every
 one of them after a refactor that nobody thought touched the battery.
 
+🔴 ROUND 10 RE-RAN IT AFTER ITS OWN FIXES — **100 rows, all as expected**, over
+a 109-test positive control. FOUR MORE rows reported MUTATION DID NOT APPLY and
+were re-targeted (`C6` and `K2`, on a pure RE-INDENT — the brief-rendering
+block moved inside `if brief_refused is None:`; `V11` and `V12`, whose branch
+conditions moved onto the shared `cross_repo_holds_neither_end` predicate).
+That makes EIGHT rows this assert has caught. TEN killer sets moved, and the
+notable one is `C3`: SEVEN of the thirteen names round 8 added LEFT it, because
+THE LEDGER stopped turning on `repo_relation` alone — the departure is round
+10's finding B, measured rather than argued.
+
+🔴 ROUND 10's BASE is `706a6b38`, measured the same way: **7 failed, 101
+passed**. FIVE are its regression coverage (`RED_AT_BASE_R9`); of the other
+two, one is the whole-string DIRECTIVE ledger moving with the reword of
+`own-worktree-is-writable`, and one is
+`..._tip_placeholder_ledger_matches_the_script`, red there on an
+`AttributeError` for a name the fix introduces and therefore filed as a guard.
+
 🔴 THE ROUND-3 BATTERY CAUGHT TWO DEFECTS IN THE ROUND-3 TESTS THEMSELVES, and
 they are recorded because both are the shape this file warns about elsewhere:
   * `N5` (delete the LEDGER's self-range branch) SURVIVED a fully green suite,
@@ -827,6 +844,26 @@ def fixture_is_cross_repo(payload, origin):
     return (u.group(1), u.group(2)) != (r.group(1), r.group(2))
 
 
+def fixture_resolved_head(payload, origin, local_head):
+    """What `git rev-parse HEAD` answers in the ASSEMBLY checkout, per fixture.
+
+    🔴 ROUND 10 — LIFTED OUT OF `make_runner` SO A GUARD CAN ASK THE SAME
+    QUESTION. `test_no_brief_claims_a_verification_its_own_fixture_refutes`
+    needs to know whether a scenario models a checkout standing on the PR's
+    head; re-deriving that beside the fake would be a second copy of the rule
+    the fake applies, and the two would disagree the first time either moved —
+    which is the shape this whole module keeps finding in the script.
+
+    It is still a MODEL and not a call into the code under test: what it
+    encodes is the fixture's own three-case default, nothing the script decides.
+    """
+    if local_head is not None:
+        return local_head
+    if fixture_is_cross_repo(payload, origin):
+        return FAKE_ASSEMBLY_HEAD
+    return payload.get("headRefOid")
+
+
 def make_runner(
     *,
     comments=(),
@@ -875,12 +912,7 @@ def make_runner(
     # #900's head commit" — the fixture asserted the state the guard exists to
     # rule out. The freak case (a clone with a renamed remote that really does
     # hold the commit) is still reachable: pass `local_head` explicitly.
-    if local_head is not None:
-        resolved_head = local_head
-    elif fixture_is_cross_repo(payload, origin):
-        resolved_head = FAKE_ASSEMBLY_HEAD
-    else:
-        resolved_head = payload.get("headRefOid")
+    resolved_head = fixture_resolved_head(payload, origin, local_head)
     ranges = []
 
     def default_rev_list(spec):
@@ -1277,10 +1309,22 @@ DIRECTIVE_LEDGER = {
     # sentence is UNCHANGED; what moved to meet it was `no-fetch`, which had
     # scoped itself to "the copy YOU made FOR THIS AUDIT" and so forbade that
     # very command. Both sides are pinned to `NO_WRITE_SCOPE` now.
+    #
+    # 🔴 ROUND 10. Round 8's "and so is the clone you made it from: fetching
+    # and checking out inside EITHER is fine" granted the two operations with
+    # cross-session blast radius over a tree the recipe names only as `<your
+    # local clone of owner/name>` — on this host, in practice,
+    # `~/workspace/<repo>`. The recipe performs exactly ONE write there,
+    # `worktree add`, so that is what the grant now names; `fetch`/`pull`/
+    # `checkout` are refused there explicitly rather than left to the reader's
+    # reading of "you made". The forward-reference sentence is untouched and
+    # still spells `NO_WRITE_SCOPE`.
     "own-worktree-is-writable": (
-        "That worktree is YOURS, and so is the clone you made it from: "
-        "fetching and checking out inside either is fine. The no-write rule "
-        "below is about every checkout you did not make."
+        "That worktree is YOURS: fetching and checking out inside it is fine. "
+        "In the clone you made it from, `git worktree add` is the ONLY write "
+        "this brief asks for — do not `fetch`, `pull` or `checkout` there, "
+        "whoever made it, because other sessions may be standing in it. The "
+        "no-write rule below is about every checkout you did not make."
     ),
 }
 
@@ -1382,6 +1426,47 @@ SCENARIO_RUNS = {
     "cross-repo-delta": lambda: (["900", "--round", "3"],
                                  {"pr": OTHER_REPO_PR,
                                   "comments": [CLAIMS_BLOCK_R2]}),
+    # 🔴 ROUND 10 — THE MISSING CELL'S OWN MIRROR. Round 8 added the
+    # cross-repo × delta pair and left the other axis: a PR whose `headRefOid`
+    # is UNKNOWN. `cross-repo-delta` is built from `OTHER_REPO_PR`, which HAS
+    # one, and the module's single `headRefOid=None` test ran the SAME-repo
+    # fixture — so the state where `range_tip` answers a PLACEHOLDER inside a
+    # cross-repo rev spec was reachable by no scenario at all.
+    "cross-repo-delta-no-head-sha": lambda: (
+        ["900", "--round", "3"],
+        {"pr": dict(OTHER_REPO_PR, headRefOid=None),
+         "comments": [CLAIMS_BLOCK_R2]},
+    ),
+    # The SAME-repo spelling of that state: nothing here is cross-repo, the
+    # head check simply never learned a sha. `range_tip` returns the identical
+    # placeholder, so a fix scoped to the cross-repo branch alone leaves this
+    # one printing an unrunnable rev spec.
+    "delta-no-head-sha": lambda: (
+        ["900", "--round", "3"],
+        {"pr": dict(DEFAULT_PR, headRefOid=None),
+         "comments": [CLAIMS_BLOCK_R2], "local_head": None},
+    ),
+    # 🔴 ROUND 10 — THE STATE `render_range`'s OWN COMMENT SAYS IS REAL and no
+    # scenario modelled: a clone whose `origin` names a different repository
+    # while HOLDING the PR's head commit (a renamed remote, a mirror). The
+    # relation is `cross`; the head check PASSES. It is what separates
+    # "different slug" from "holds neither end of the range", and THE LEDGER
+    # was conflating them.
+    "cross-repo-renamed-remote-delta": lambda: (
+        ["900", "--round", "3"],
+        {"pr": OTHER_REPO_PR, "comments": [CLAIMS_BLOCK_R2],
+         "local_head": FAKE_OTHER_HEAD_OID},
+    ),
+    # 🔴 ROUND 10's SEVENTH INSTANCE, found by sweeping rather than from a
+    # finding: `base_ref` is `data.get("baseRefName") or "main"` — a DEFAULT —
+    # and every site printing it presented it as a fact about the PR. This is
+    # the state `--claims-file` mode is ALWAYS in, because it consults no `gh`
+    # and hardcodes the field.
+    "delta-assumed-base": lambda: (
+        ["900", "--round", "3"],
+        {"pr": {k: v for k, v in DEFAULT_PR.items() if k != "baseRefName"},
+         "comments": [CLAIMS_BLOCK_R2]},
+    ),
 }
 SCENARIOS = tuple(SCENARIO_RUNS)
 
@@ -2521,7 +2606,343 @@ def test_a_cross_repo_ledger_hands_the_attribution_gate_to_the_auditor():
     )
 
 
-def test_no_cross_repo_brief_claims_its_checkout_was_verified():
+# 🔴 ROUND 10 — THE SENTENCE THE CROSS-REPO RANGE SAID UNCONDITIONALLY, kept
+# here so a guard can forbid it in the one state where it is false.
+TIP_IS_A_SHA_CLAIM = "So the range above names the PR's head SHA outright"
+
+# The banner every site printing an unresolved tip must carry.
+TIP_PLACEHOLDER_BANNER = "THE TIP OF THAT RANGE IS A PLACEHOLDER, NOT A SHA"
+
+# 🔴 SPELLED HERE AND NOT READ FROM `ad.TIP_PLACEHOLDER`, deliberately. The
+# red-at-base procedure copies THIS module into a tree holding the BASE script,
+# and `TIP_PLACEHOLDER` does not exist there — reading it would make the guard
+# below die of `AttributeError` for want of a name the fix introduced, which
+# this module says everywhere is not evidence of a defect. The literal is what
+# the base actually printed. `test_the_tip_placeholder_ledger_matches_the_script`
+# is what keeps the two in step.
+TIP_PLACEHOLDER_TEXT = "<the PR's head sha>"
+
+
+def test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha():
+    """🔴 REGRESSION. Red at `706a6b38`, scenario `cross-repo-delta-no-head-sha`.
+
+    Measured there, rc 0 and silent stderr:
+
+        Diff **`aaaa1111..<the PR's head sha>`**
+        …
+            the PR's head sha is not known here (`gh pr view` was consulted and
+            reported no `headRefOid` for this PR)
+        So the range above names the PR's head SHA outright — read from
+        `gh pr view --json headRefOid` …
+
+    and THE LEDGER, under "THE ATTRIBUTION GATE IS YOURS THIS ROUND — it is not
+    optional and nobody else can compute it":
+
+        git -C <your worktree> log … aaaa1111..<the PR's head sha> --not
+        origin/main
+
+    Two sentences apart, the brief says it never learned `headRefOid` and that
+    the range was read from `headRefOid`. `repo_relation == "cross"` was read as
+    "the tip is a known sha" — the same weaker-fact-read-as-stronger shape as
+    round 8's REFUSAL 1b, which refused a non-sha token in a rev spec at the
+    ANCHOR end and left the TIP end alone.
+
+    🔴 DRIVEN OVER EVERY SCENARIO, not over the two that are cross-repo. The
+    placeholder comes from `range_tip`, which knows nothing about repos: the
+    SAME-repo `delta-no-head-sha` scenario prints it from the could-not-verify
+    branch. A fix scoped to the branch the finding was filed against would
+    leave that one unguarded, which is this ladder's most-repeated defect.
+    """
+    seen = 0
+    for scenario in SCENARIOS:
+        brief = brief_for_scenario(scenario)
+        if TIP_PLACEHOLDER_TEXT not in brief:
+            continue
+        seen += 1
+        assert TIP_PLACEHOLDER_BANNER in brief, (
+            f"\n\nscenario {scenario!r}: the brief spells "
+            f"{TIP_PLACEHOLDER_TEXT!r} — inside a git rev spec, and inside the "
+            "command THE LEDGER calls mandatory — and never says it is not a "
+            "sha. A rev spec carrying it cannot run, and rc 0 with silent "
+            "stderr is what the reader has to go on."
+        )
+        assert TIP_IS_A_SHA_CLAIM not in brief, (
+            f"\n\nscenario {scenario!r}: the brief claims the range names the "
+            "PR's head sha outright, in a run whose own reason line says it "
+            "never learned that field. One of the two sentences is false."
+        )
+    assert seen, (
+        "no scenario renders an unresolved tip, so the loop above asserted "
+        "nothing. `cross-repo-delta-no-head-sha` and `delta-no-head-sha` are "
+        "what put the placeholder in a brief; if they were dropped or their "
+        "`headRefOid` came back, this guard covers nothing."
+    )
+    # 🔴 POSITIVE CONTROL for the OTHER side: a scenario with a real tip must
+    # still get the confident sentence, or the fix above is "delete the claim"
+    # rather than "make it conditional".
+    assert TIP_IS_A_SHA_CLAIM in brief_for_scenario("cross-repo-delta"), (
+        "the cross-repo range no longer tells an auditor with a KNOWN head sha "
+        "that both ends of the range resolve in their worktree — the branch "
+        "was made conditional and then never rendered its true case"
+    )
+
+
+ASSUMED_BASE_BANNER = "THAT BASE BRANCH WAS ASSUMED, NOT READ"
+
+
+def test_no_brief_states_an_assumed_base_branch_as_a_fact():
+    """🔴 REGRESSION. Red at `706a6b38`, scenario `delta-assumed-base`.
+
+    🔴 THE SEVENTH INSTANCE, and it came from the sweep round 9's auditor asked
+    for rather than from a finding. `base_ref` is `data.get("baseRefName") or
+    "main"` — a DEFAULT — and every site printing it presented it as a
+    measurement. Measured at the base with `baseRefName` absent, rc 0 and
+    silent stderr, THE LEDGER's cross-repo hand-over read:
+
+        Run this in the worktree WHERE TO WORK told you to make … where
+        `origin/main` names THAT repository's base branch and not this
+        checkout's
+
+    an assertion about a repository nothing was ever asked about. `--claims-file`
+    mode reaches it on EVERY run — it consults no `gh` and hardcodes
+    `baseRefName: "main"`, exactly as it hardcodes no `headRefOid`, and that
+    second omission already carried a reason string while this one did not.
+
+    It matters because `--not <base>` is what decides which commits count as
+    this round's payload, and the payload figure is the ladder's own stop
+    condition: a wrong base moves the number silently, at rc 0.
+
+    🔴 DRIVEN BOTH WAYS over every scenario, so the fix cannot be "print the
+    banner always" — a warning that fires on every run is the permanently-red
+    gate `claude/RULES.md` names.
+    """
+    seen_assumed = seen_read = 0
+    for scenario in SCENARIOS:
+        kw = SCENARIO_RUNS[scenario]()[1]
+        payload = kw.get("pr") or DEFAULT_PR
+        brief = brief_for_scenario(scenario)
+        if payload.get("baseRefName"):
+            seen_read += 1
+            assert ASSUMED_BASE_BANNER not in brief, (
+                f"\n\nscenario {scenario!r}: the brief calls the base branch "
+                "assumed, in a run whose fixture reports "
+                f"{payload['baseRefName']!r}. A banner that fires when the "
+                "field WAS read is a banner every reader learns to skip."
+            )
+            continue
+        seen_assumed += 1
+        assert ASSUMED_BASE_BANNER in brief, (
+            f"\n\nscenario {scenario!r}: `gh` reported no `baseRefName`, so "
+            f"`{payload.get('baseRefName')!r}` fell back to this script's "
+            "default — and the brief states the result as a fact about the "
+            "PR's repository. `--not <base>` decides which commits count as "
+            "this round's payload."
+        )
+    assert seen_assumed and seen_read, (
+        f"only one side was driven ({seen_assumed} assumed, {seen_read} read), "
+        "so this guard pins a constant rather than a relationship"
+    )
+
+
+def test_the_tip_placeholder_ledger_matches_the_script():
+    """🔴 INVARIANT GUARD. Its evidence is mutant V21, not a base ref.
+
+    The guard above spells the placeholder as a LITERAL so it can be red at a
+    base tree that has no `TIP_PLACEHOLDER`. That literal is a second copy, and
+    a second copy that nobody compares is how a guard quietly stops matching
+    what ships. This is the comparison.
+    """
+    assert ad.TIP_PLACEHOLDER == TIP_PLACEHOLDER_TEXT, (
+        f"\n\nthe script writes {ad.TIP_PLACEHOLDER!r} and this module looks "
+        f"for {TIP_PLACEHOLDER_TEXT!r}. Every guard keyed on the literal is "
+        "scanning for a string no brief contains."
+    )
+    assert TIP_PLACEHOLDER_BANNER in ad.unresolved_tip_note(
+        ad.Facts(
+            pr=900, repo="a/b", title="t", base_ref="origin/main", url="",
+            round_no=3, cwd_repo_dir="/x", cwd_repo_slug="a/b",
+            repo_relation="same", worktree=ad.gather_worktree_kind(
+                lambda cmd, cwd=None: UNREADABLE_GIT_DIRS, "/x"),
+            branch="b", dirty=0, prev_sha="aaaa1111", emit_from=None,
+            claims=[], claims_round=None, checklist="", ledger=None,
+            assembled_at="", claims_source="", head_check=None,
+            base_assumed=False,
+        )
+    ), (
+        "the banner every keyed guard looks for is not what the note emits, so "
+        "those guards can never fire"
+    )
+
+
+def test_a_cross_repo_ledger_prints_a_measurement_the_head_check_vouched_for():
+    """🔴 REGRESSION. Red at `706a6b38`, scenario `cross-repo-renamed-remote-delta`.
+
+    `render_range`'s cross-repo branch is ordered after the `hc.ok` branch on
+    purpose, and its comment says why: `repo_relation` compares SLUGS, and a
+    clone with a renamed remote or a mirror can name a different repository
+    while HOLDING the PR's head commit. `render_ledger` did not adopt that
+    ordering — it asked `repo_relation == "cross"` alone.
+
+    Measured at the base in exactly that state (rc 0, silent stderr):
+
+        head_check.ok = True
+        facts.ledger  = 4 commits, 13 added, 2 deleted
+        THE RANGE : "verified at assembly time to be PR #900's head commit"
+        THE LEDGER: "NOT MEASURABLE FROM HERE … which holds neither end of the
+                     range. A number measured here would be a measurement of
+                     another project, so none is printed."
+
+    The measurement SUCCEEDED and was discarded; every clause of that sentence
+    is false; and the two sections contradict each other inside one document.
+    Both sites now ask `cross_repo_holds_neither_end`, which consults the head
+    check first — one rule, one place.
+    """
+    brief = brief_for_scenario("cross-repo-renamed-remote-delta")
+    led = ledger_section(brief)
+    assert "NOT MEASURABLE FROM HERE" not in led, (
+        "\n\nTHE LEDGER calls the measurement structurally impossible in a run "
+        "whose head check PASSED — the checkout holds the PR's head commit, "
+        f"which is what THE RANGE two bars above says.\n{led}"
+    )
+    assert "13        2" in led, (
+        "\n\nTHE LEDGER prints no numbers, so the successful measurement was "
+        f"still thrown away:\n{led}"
+    )
+    assert (
+        f"aaaa1111..{FAKE_OTHER_HEAD_OID} --not origin/main"
+    ) in led, (
+        f"\n\nTHE LEDGER's provenance line does not name the range it "
+        f"measured:\n{led}"
+    )
+    # 🔴 THE OTHER SIDE OF THE PREDICATE, so this is not "delete the branch".
+    # A cross-repo run whose head check FAILED must still hand the gate over.
+    assert "NOT MEASURABLE FROM HERE" in ledger_section(
+        brief_for_scenario("cross-repo-delta")
+    ), (
+        "the cross-repo hand-over stopped rendering for a checkout that really "
+        "does hold neither end of the range — round 8's permanently-red ledger "
+        "is back"
+    )
+
+
+# 🔴 ROUND 10 — A REFUSAL'S REMEDY IS A CLAIM, AND IT WAS FALSE AT BOTH SITES.
+# `<...>` spans are the operator's fill-in-the-blank; a real sha goes in before
+# the command can be run at all.
+_PRESCRIBED_COMMAND = re.compile(r"`audit-dispatch\.py ([^`]+)`")
+_FILL_IN = re.compile(r"<[^>]*>")
+PRESCRIPTION_SHA = "beefcafe"
+
+
+def prescribed_commands(err):
+    """Every `audit-dispatch.py …` command a refusal PRINTED, as argv lists."""
+    return [
+        _FILL_IN.sub(PRESCRIPTION_SHA, m.group(1)).split()
+        for m in _PRESCRIBED_COMMAND.finditer(err)
+    ]
+
+
+def test_every_command_a_refusal_prescribes_actually_runs():
+    """🔴 REGRESSION. Red at `706a6b38`, for BOTH refusals.
+
+    Measured there, over a `round=2` block whose header is `audited=..`:
+
+        900 --round 3                             -> rc 2, refusal
+        900 --round 2 --emit-claims --audited abc12345
+                                                  -> rc 2, the SAME refusal,
+                                                     stdout EMPTY
+
+    and with no block at all:
+
+        900 --round 3                             -> rc 2, refusal
+        900 --round 2 --emit-claims               -> rc 2, stdout EMPTY
+
+    Both refusals hand the operator a `--emit-claims` re-run as their
+    mechanical remedy and then refuse it, because the refusal is ordered before
+    the emit half and re-reads the same unreadable comment. The operator sees
+    the same text twice and reads it as their own typo. (REFUSAL 1's remedy is
+    sound at round 2 — `--round 1 --emit-claims` needs no block — and
+    unrunnable from round 3 up, which is why "it usually works" was true and
+    useless.)
+
+    🔴 THE GUARD IS THE CLASS, NOT THE TWO SITES. It reads the commands out of
+    whatever the refusal printed and RUNS them; a third refusal that prescribes
+    a command it refuses fails here without anyone remembering to add a row.
+    """
+    bad_block = (
+        "```audit-claims round=2 audited=..\n"
+        "1. a claim that parses fine\n"
+        "```"
+    )
+    cases = {
+        "REFUSAL 1b (anchorless block)": {"comments": [bad_block]},
+        "REFUSAL 1 (no block at all)": {"comments": []},
+    }
+    for name, kw in cases.items():
+        rc, _out, err = run_main(["900", "--round", "3"], **kw)
+        assert rc == 2, f"{name}: expected the refusal, got rc {rc}"
+        commands = prescribed_commands(err)
+        # POSITIVE CONTROL for the extractor: a refusal that prescribes nothing
+        # the regex can see would make every assertion below vacuous.
+        assert commands, (
+            f"\n\n{name}: no `audit-dispatch.py …` command was found in the "
+            f"refusal, so this guard checked nothing:\n{err}"
+        )
+        for argv in commands:
+            rc2, out2, err2 = run_main(argv, **kw)
+            assert "```audit-claims" in out2, (
+                f"\n\n{name}: the remedy it prints does not produce the block "
+                f"it promises.\n  ran    : audit-dispatch.py {' '.join(argv)}\n"
+                f"  rc     : {rc2}\n  stdout : {out2[:300]!r}\n"
+                f"  stderr : {err2[:600]!r}\n"
+                "A refusal that prescribes a command it refuses reads to the "
+                "operator as their own error."
+            )
+
+
+def test_control_the_prescription_extractor_can_see_a_broken_remedy():
+    """NEGATIVE CONTROL for the guard above: it must be able to go red.
+
+    Built from a REAL refusal's text with its remedy rewritten to the command
+    that genuinely fails — the delta round itself. If this passes, the guard
+    above is a scan wired to nothing.
+    """
+    bad_block = (
+        "```audit-claims round=2 audited=..\n1. a claim\n```"
+    )
+    _rc, _out, err = run_main(["900", "--round", "3"], comments=[bad_block])
+    broken = err.replace(
+        "audit-dispatch.py 900 --round 2 --emit-claims "
+        "--audited <the tip that round read>",
+        "audit-dispatch.py 900 --round 3",
+    )
+    commands = prescribed_commands(broken)
+    assert ["900", "--round", "3"] in commands, (
+        f"the extractor cannot see the rewritten remedy: {commands}"
+    )
+    rc2, out2, _err2 = run_main(["900", "--round", "3"], comments=[bad_block])
+    assert rc2 == 2 and "```audit-claims" not in out2, (
+        "the control command does not actually fail, so it proves nothing "
+        "about the guard's ability to report one that does"
+    )
+
+
+def scenario_checkout_stands_on_the_pr(name):
+    """Does this scenario's FIXTURE put the assembly checkout on the PR's head?
+
+    Answered from the scenario's own kwargs through `fixture_resolved_head` —
+    the one place that models `git rev-parse HEAD` — so the guard below and the
+    fake cannot drift apart.
+    """
+    _argv, kw = SCENARIO_RUNS[name]()
+    payload = dict(kw.get("pr") or DEFAULT_PR)
+    resolved = fixture_resolved_head(
+        payload, kw.get("origin", FAKE_ORIGIN), kw.get("local_head")
+    )
+    oid = payload.get("headRefOid")
+    return bool(resolved and oid and ad.same_commit(resolved, oid))
+
+
+def test_no_brief_claims_a_verification_its_own_fixture_refutes():
     """🔴 THE SEAM GUARD, and it is also this module's fixture guard.
 
     🔴 INVARIANT GUARD; its evidence is mutant V9, not a base ref. At
@@ -2534,27 +2955,55 @@ def test_no_cross_repo_brief_claims_its_checkout_was_verified():
     head commit" for a PR in another repository. A test written with that
     fixture would have passed in a physically impossible state.
 
-    So this pins the RELATIONSHIP rather than either side: no brief may claim
-    verification of a checkout it has itself just called a different
-    repository, in any scenario this module knows or later adds.
+    🔴 ROUND 10 RESCOPED IT, BECAUSE IT WAS PINNED TO THE WRONG SIDE. Round 8
+    spelled the relationship as "no CROSS-REPO brief may claim verification" —
+    while `render_range`'s own comment three bars away says that state IS real
+    and is why its cross-repo branch is ordered after the head check: a clone
+    with a renamed remote, or a mirror, names a different repository and holds
+    the PR's head commit anyway. The guard passed only because no scenario
+    modelled it; adding `cross-repo-renamed-remote-delta` makes it fail on
+    CORRECT output. Measured — that is the first thing the new scenario did.
+
+    The fact the brief's sentence actually claims is `head_check.ok`, so what
+    this pins is the sentence against the FIXTURE'S OWN modelled `rev-parse
+    HEAD` — in any scenario this module knows or later adds, cross-repo or not.
+    A repo relation is not a head check, which is the whole of round 10's
+    finding B.
     """
-    seen = 0
+    claimed, cross = [], 0
     for scenario in SCENARIOS:
         brief = brief_for_scenario(scenario)
-        if "## WHERE TO WORK — 🔴 CROSS-REPO" not in brief:
+        cross += "## WHERE TO WORK — 🔴 CROSS-REPO" in brief
+        if "verified at assembly time" not in brief:
             continue
-        seen += 1
-        assert "verified at assembly time" not in brief, (
-            f"\n\nscenario {scenario!r}: the brief says this checkout was "
-            "verified to be standing on the PR's head, two bars after saying "
-            "the PR lives in a DIFFERENT repository. One of the two is false, "
-            "and in the fixture it was the head check — the PR's oid was "
-            "handed to the assembly checkout's `rev-parse HEAD`."
+        claimed.append(scenario)
+        kw = SCENARIO_RUNS[scenario]()[1]
+        payload = dict(kw.get("pr") or DEFAULT_PR)
+        modelled = fixture_resolved_head(
+            payload, kw.get("origin", FAKE_ORIGIN), kw.get("local_head")
         )
-    assert seen, (
-        "no scenario renders a CROSS-REPO brief, so the loop above asserted "
-        "nothing. Either the heading moved or the cross-repo scenarios were "
-        "dropped from SCENARIO_RUNS."
+        assert scenario_checkout_stands_on_the_pr(scenario), (
+            f"\n\nscenario {scenario!r}: the brief says this checkout was "
+            "verified to be standing on the PR's head, and this scenario's "
+            "own fixture refutes it —\n"
+            f"  fixture `git rev-parse HEAD` : {modelled!r}\n"
+            f"  fixture PR headRefOid        : {payload.get('headRefOid')!r}\n"
+            "One of the two is false, and a test written in that state would "
+            "pass in a physically impossible world."
+        )
+    # 🔴 TWO POSITIVE CONTROLS, because two different zeroes would read as a
+    # pass. No scenario claiming verification means the loop asserted nothing;
+    # no scenario rendering CROSS-REPO means the configuration this guard was
+    # born in has stopped being covered.
+    assert claimed, (
+        "no scenario renders the 'verified at assembly time' sentence at all, "
+        "so the loop above asserted nothing. Either the sentence moved or "
+        "every delta scenario stopped passing the head check."
+    )
+    assert cross, (
+        "no scenario renders a CROSS-REPO brief, so this guard no longer "
+        "covers the seam it was written for. Either the heading moved or the "
+        "cross-repo scenarios were dropped from SCENARIO_RUNS."
     )
 
 
@@ -3315,6 +3764,85 @@ def test_no_checkout_state_grants_write_permission_over_the_assembly_checkout():
             "is non-negotiable and no state may override it.\n"
             f"{checkout}"
         )
+
+
+# 🔴 ROUND 10 — THE ROUND-8 GRANT, verbatim, kept ONLY as this probe's positive
+# control. Same role as `ROUND_4_WRITE_GRANT` and `ROUND_5_NO_WRITE_SCOPE`
+# above: its job is to be RED AT THE BASE, not to be unwalkable —
+# non-walkability comes from the whole-string `DIRECTIVE_LEDGER` pin.
+ROUND_8_CLONE_GRANT = (
+    "That worktree is YOURS, and so is the clone you made it from: "
+    "fetching and checking out inside either is fine. The no-write rule "
+    "below is about every checkout you did not make."
+)
+
+CLONE_WRITE_GRANT_PHRASES = (
+    "the clone you made it from: fetching",
+    "inside either is fine",
+    "checking out inside either",
+)
+
+# The recipe's own `git -C <clone> …` line, so the verb it runs there is read
+# and not remembered.
+_CLONE_RECIPE = re.compile(r"git -C <your local clone of [^>]*> ([a-z-]+)")
+
+
+def clone_write_grants_in(text):
+    return [p for p in CLONE_WRITE_GRANT_PHRASES if p in text]
+
+
+def test_the_clone_grant_covers_only_the_write_the_recipe_makes():
+    """🔴 REGRESSION. Red at `706a6b38`, scenario `cross-repo`.
+
+    Round 8 widened `own-worktree-is-writable` from "fetching and checking out
+    inside IT" to "inside EITHER" — the worktree AND the clone — to legitimise
+    the `worktree add` its own recipe performs. But the recipe writes to that
+    clone exactly ONCE, and the grant authorised two more operations with
+    cross-session blast radius, over a tree the brief names only as `<your
+    local clone of owner/name>`. On this host that placeholder resolves in
+    practice to `~/workspace/<repo>`: a long-lived checkout other sessions are
+    working in, and a `fetch` or `checkout` there is precisely the write the
+    `no-fetch` clause exists to prevent.
+
+    "The clone YOU made" arguably excludes those trees — but nothing in the
+    brief disambiguated it and the placeholder invites the substitution, so the
+    grant is stated as the OPERATION it covers.
+
+    🔴 THE RELATIONSHIP, not the wording: the verb is read off the recipe LINE,
+    so a recipe that starts running something else in the clone fails here
+    rather than silently acquiring permission for it.
+    """
+    assert clone_write_grants_in(ROUND_8_CLONE_GRANT), (
+        "POSITIVE CONTROL: the probe cannot see round 8's own grant, so a "
+        "clean result below would say nothing at all"
+    )
+    brief = brief_for_scenario("cross-repo")
+    verbs = _CLONE_RECIPE.findall(brief)
+    assert verbs == ["worktree"], (
+        "\n\nWHERE TO WORK's recipe no longer runs exactly one `git -C "
+        f"<clone> …` command, or runs a different one: {verbs}. The grant "
+        "below is scoped to the write the recipe makes, so the two move "
+        "together."
+    )
+    granted = clone_write_grants_in(brief)
+    assert not granted, (
+        f"\n\nthe brief grants the auditor `fetch`/`checkout` inside the clone "
+        f"— {granted}. The recipe's only write there is `{verbs[0]} add`; "
+        "everything else is a cross-session write into a tree the brief calls "
+        "`<your local clone of owner/name>`, which on this host is a shared, "
+        "long-lived checkout.\n"
+        + ad.DIRECTIVE["own-worktree-is-writable"]
+    )
+    grant = ad.DIRECTIVE["own-worktree-is-writable"]
+    assert "`git worktree add` is the ONLY write" in grant, (
+        "\n\nthe grant no longer says which single operation it covers in the "
+        "clone, so the next reader has only 'you made it' to reason from — "
+        f"which is what round 8 reasoned from.\n{grant}"
+    )
+    assert "do not `fetch`, `pull` or `checkout` there" in grant, (
+        "\n\nthe grant no longer refuses the two operations round 8 permitted "
+        f"in the clone.\n{grant}"
+    )
 
 
 def test_every_checkout_state_carries_the_no_write_rule():
@@ -4737,6 +5265,32 @@ RED_AT_BASE_R7: frozenset[str] = frozenset({
     "test_the_no_write_forward_reference_states_the_clauses_own_scope",
 })
 
+# 🔴 ROUND 10's base is the ROUND-9 TREE, `706a6b38`. Measured the same way —
+# `git show 706a6b38:scripts/audit-dispatch.py` into a scratch tree with THIS
+# module copied in unchanged, `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`:
+# **7 failed, 101 passed**. FOUR of the seven are these. Of the other three,
+# one is the whole-string directive ledger moving with round 10's reword of
+# `own-worktree-is-writable`, one is this partition guard itself (the new tests
+# are not in the base module's ledgers), and one is
+# `test_the_tip_placeholder_ledger_matches_the_script`, filed as a guard above
+# because its red there is an `AttributeError` for a name the fix introduces.
+#
+# 🔴 `test_no_brief_claims_a_verification_its_own_fixture_refutes` is NOT here
+# and is not new: round 8 filed it as a guard, and round 10 RESCOPED it. It is
+# still green at this base for the same reason — a base script says nothing
+# about a base fixture — and its evidence is still mutant V9.
+RED_AT_BASE_R9: frozenset[str] = frozenset({
+    "test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha",
+    "test_a_cross_repo_ledger_prints_a_measurement_the_head_check_vouched_for",
+    "test_every_command_a_refusal_prescribes_actually_runs",
+    "test_the_clone_grant_covers_only_the_write_the_recipe_makes",
+    # 🔴 NOT ONE OF ROUND 9's FINDINGS — round 10's own, found by the sweep its
+    # auditor asked for. Red at the base on a WRONG ANSWER, not an absence: the
+    # brief asserted a DEFAULT base branch as a fact about the PR's repository,
+    # at rc 0, inside the hand-over THE LEDGER calls mandatory.
+    "test_no_brief_states_an_assumed_base_branch_as_a_fact",
+})
+
 RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "abc41024": RED_AT_BASE_R2,
     "d9eb36a8": RED_AT_BASE_R3,
@@ -4744,6 +5298,7 @@ RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "dd601793": RED_AT_BASE_R5,
     "3619fe68": RED_AT_BASE_R6,
     "28492af2": RED_AT_BASE_R7,
+    "706a6b38": RED_AT_BASE_R9,
 }
 RED_AT_BASE: frozenset[str] = frozenset().union(*RED_AT_BASE_REFS.values())
 
@@ -4867,12 +5422,27 @@ INVARIANT_GUARDS_AND_LEDGERS = frozenset({
     # says nothing about a base fixture, the same shape as round 7's guard
     # above. Its evidence is mutant V9, which restores the impossible state
     # from the script side by claiming verification unconditionally.
-    "test_no_cross_repo_brief_claims_its_checkout_was_verified",
+    "test_no_brief_claims_a_verification_its_own_fixture_refutes",
     # There is no gap warning at `28492af2` at all, so a red there would be an
     # absence the fix adds. Same filing as Z5's legend. Mutant V16 removes it
     # again, and the test's own negative control (an ADJACENT block must stay
     # silent) is what stops the warning being satisfied by firing always.
     "test_a_claims_block_more_than_one_round_behind_is_warned_about",
+    # ------------------------------------------------------------------- #
+    # Round 10's two guards. Both WERE run against `706a6b38`; they are here
+    # because of HOW they behave there.
+    # ------------------------------------------------------------------- #
+    # RED at `706a6b38` with `AttributeError: module 'audit_dispatch' has no
+    # attribute 'TIP_PLACEHOLDER'` — an error for want of a name the fix
+    # introduces, not the defect being observed, which this module refuses to
+    # count as regression coverage. Mutant V21 (the two spellings of the
+    # placeholder drift apart) is its evidence.
+    "test_the_tip_placeholder_ledger_matches_the_script",
+    # GREEN at `706a6b38`, and it must be: it is the NEGATIVE CONTROL for
+    # `test_every_command_a_refusal_prescribes_actually_runs`, showing that
+    # guard can see a remedy that genuinely fails. A control that went red at
+    # the base would be a second sample of the thing in doubt.
+    "test_control_the_prescription_extractor_can_see_a_broken_remedy",
 })
 
 # --------------------------------------------------------------------------- #
@@ -4894,6 +5464,14 @@ INVARIANT_GUARDS_AND_LEDGERS = frozenset({
 #
 # `evidence` is `RED@<ref>` — the test was watched to FAIL at that tree — or
 # `GUARD`, meaning its evidence is the mutation battery and NOT a base ref.
+
+# The one evidence token that is legitimately not a mutant: a guard over this
+# module's own bookkeeping, which the battery cannot reach because it mutates
+# the SCRIPT and never this file. Spelled as a sentinel rather than as prose so
+# it cannot be confused with a column somebody forgot to fill in. Defined ABOVE
+# the matrix because a row now names it.
+IN_MODULE_CONTROL = "IN-MODULE CONTROL"
+
 FIX_MATRIX = (
     ("r2/1a ledger measured the OPERATOR'S checkout, not the PR",
      "test_the_ledger_refuses_to_measure_a_checkout_that_is_not_the_pr",
@@ -5149,7 +5727,7 @@ FIX_MATRIX = (
      "RED@28492af2", "V12"),
     ("r7/2c the cross-repo fixture inherited the PR's `headRefOid`, so a "
      "cross-repo test would have passed in a physically impossible state",
-     "test_no_cross_repo_brief_claims_its_checkout_was_verified",
+     "test_no_brief_claims_a_verification_its_own_fixture_refutes",
      "GUARD", "V9"),
     ("r7/3  the round-7 tip fix was HALF-APPLIED: the DEGENERATE branch of the "
      "same if/elif still handed out `..HEAD`, under a banner claiming the "
@@ -5181,6 +5759,41 @@ FIX_MATRIX = (
      "at assembly time\", with THE LEDGER giving the round-1 cause",
      "test_a_block_that_parses_but_yields_no_anchor_is_refused",
      "RED@28492af2", "V17"),
+    # --------------------------------------------------------------------- #
+    # Round 10. Its base is `706a6b38` — the round-9 tree.
+    # --------------------------------------------------------------------- #
+    ("r10/A the range and the ledger asserted the TIP was a sha without "
+     "checking one was known: `Diff `28492af2..<the PR's head sha>`` at rc 0, "
+     "and the same token inside the `git log` THE LEDGER calls mandatory",
+     "test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha",
+     "RED@706a6b38", "V18"),
+    ("r10/A' the two spellings of that placeholder — `range_tip`'s and "
+     "`--emit-claims`' — were open-coded literals with nothing comparing them",
+     "test_the_tip_placeholder_ledger_matches_the_script",
+     "GUARD", "V21"),
+    ("r10/B THE LEDGER's cross-repo branch was not ordered after the head "
+     "check, unlike THE RANGE's: for a renamed-remote clone it DISCARDED a "
+     "successful measurement to print \"holds neither end of the range\"",
+     "test_a_cross_repo_ledger_prints_a_measurement_the_head_check_vouched_for",
+     "RED@706a6b38", "V19"),
+    ("r10/C both refusals prescribed a `--emit-claims` re-run as their "
+     "mechanical remedy and then refused it, byte for byte, with empty stdout",
+     "test_every_command_a_refusal_prescribes_actually_runs",
+     "RED@706a6b38", "V20 V23"),
+    ("r10/C' the negative control for that guard: a remedy that genuinely "
+     "fails must be reported, or the scan is wired to nothing",
+     "test_control_the_prescription_extractor_can_see_a_broken_remedy",
+     "GUARD", IN_MODULE_CONTROL),
+    ("r10/D `own-worktree-is-writable` granted `fetch` and `checkout` in the "
+     "CLONE — a tree the recipe names `<your local clone of owner/name>`, in "
+     "practice a long-lived checkout other sessions are working in",
+     "test_the_clone_grant_covers_only_the_write_the_recipe_makes",
+     "RED@706a6b38", "V22"),
+    ("r10/E the SEVENTH instance, found by sweeping: `base_ref` is "
+     "`baseRefName or \"main\"` — a DEFAULT — and every site printing it stated "
+     "it as a fact about the PR's repository, at rc 0",
+     "test_no_brief_states_an_assumed_base_branch_as_a_fact",
+     "RED@706a6b38", "V24"),
 )
 
 # A COLLAPSE floor, not a growth floor: a matrix emptied by a bad refactor
@@ -5199,8 +5812,10 @@ FIX_MATRIX = (
 # seven more: m = 61, and 61 - max(1, 61 // 20) = 58. Counted by asking the
 # constant itself (`len(FIX_MATRIX)`), not by adding 7 to the last sentence.
 # Round 8 added nine: m = 70, and 70 - max(1, 70 // 20) = 67. Counted the same
-# way, by importing the module and printing `len(FIX_MATRIX)`.
-MIN_FIX_MATRIX_ROWS = 67
+# way, by importing the module and printing `len(FIX_MATRIX)`. Round 10 added
+# seven: m = 77, and 77 - max(1, 77 // 20) = 74. Counted the same way again —
+# `len(FIX_MATRIX)` printed from an import, not seven added to the last sentence.
+MIN_FIX_MATRIX_ROWS = 74
 
 # 🔴 THE MUTANTS COLUMN IS AN EVIDENCE CLAIM, AND IT WAS UNGRADED.
 # `fix_matrix_problems` took `_mutants` and threw it away, so rewriting a
@@ -5209,12 +5824,6 @@ MIN_FIX_MATRIX_ROWS = 67
 # base-ref cell having been set to `GUARD` precisely because there is no base
 # ref to point at. It is now resolved against the harness's OWN `ROWS`.
 MUTANT_HARNESS = REPO / "scripts" / "tests" / "mutants-audit-dispatch.py"
-
-# The one evidence token that is legitimately not a mutant: a guard over this
-# module's own bookkeeping, which the battery cannot reach because it mutates
-# the SCRIPT and never this file. Spelled as a sentinel rather than as prose so
-# it cannot be confused with a column somebody forgot to fill in.
-IN_MODULE_CONTROL = "IN-MODULE CONTROL"
 
 
 def _known_mutant_ids():

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -14,24 +14,77 @@ module exists to make them impossible to delete quietly.
 🔴 WHICH TESTS ARE REGRESSION COVERAGE AND WHICH ARE NOT
 ---------------------------------------------------------
 `claude/RULES.md` requires the distinction, and requires naming the base a test
-was watched red at. Here the honest answer is uncomfortable and is stated rather
-than dressed up:
+was watched red at.
 
-  RED_AT_BASE is **EMPTY, on purpose.** `scripts/audit-dispatch.py` did not
-  exist at `3b79a35a` (this branch's base). Every test below would ERROR at that
-  ref for want of the module, which is not evidence of anything — a test that
-  cannot import the thing it tests is not "red at base" in the sense the rule
-  means. NOTHING here is regression coverage for a bug that shipped.
+  RED_AT_BASE WAS EMPTY AND IS NOT ANY MORE, and the reason is the point of this
+  section. It was empty because `scripts/audit-dispatch.py` did not exist at
+  `3b79a35a` (this branch's base): every test would have ERRORED there for want
+  of the module, which is not evidence of anything.
 
-  Everything here is therefore an INVARIANT GUARD or a STRUCTURAL LEDGER. What
-  makes them non-vacuous is the MUTATION MATRIX below: each was watched to fail
-  against a deliberately mutated copy of the script, and the mutant is named
-  beside the test that caught it. A guard nobody watched go red is a guard
-  nobody has evidence for, whatever its base ref.
+  Round 2's adversarial audit then found NINE defects in the shipped script —
+  three 🔴, six 🟡, every one reproduced live — so there is now a base with a
+  real bug in it: **`abc41024`**, the branch head that carried them. Measured
+  by restoring that script into a scratch tree with this module copied in
+  unchanged, under `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`:
 
-  Both facts are asserted mechanically at the bottom of this module
-  (`test_the_two_ledgers_partition_this_modules_tests`), so a test cannot
-  quietly join or leave either list.
+      24 failed, 34 passed          <- 24 node ids, 21 functions
+
+  Those 21 are `RED_AT_BASE`, and three of them are labelled INSIDE that
+  constant as weaker evidence than the rest: two assert text the fix added
+  rather than observing a wrong answer, and one pins a sentence about a gap
+  this PR documents but does not close.
+
+  Everything else is an INVARIANT GUARD or a STRUCTURAL LEDGER. What makes those
+  non-vacuous is the MUTATION MATRIX below: each was watched to fail against a
+  deliberately mutated copy of the script, and the mutant is named beside the
+  test that caught it. A guard nobody watched go red is a guard nobody has
+  evidence for, whatever its base ref.
+
+  Both ledgers are asserted mechanically at the bottom of this module
+  (`test_the_two_ledgers_partition_this_modules_tests`), which now also refuses
+  an entry appearing in BOTH — a test is regression coverage or it is a guard,
+  and listing it twice makes the count of what was watched red unreadable.
+
+🔴 THE ROUND-2 FIX MATRIX — one line per finding, per `claude/RULES.md`
+-----------------------------------------------------------------------
+Each row names the defect, the test that detects it, and the mutant that proves
+that test executes. Every "red at" cell is `abc41024`.
+
+  finding                              detector (red at abc41024)      mutant
+  1a ledger measured the OPERATOR'S    ..._ledger_refuses_to_measure_   H1
+     checkout, not the PR              a_checkout_that_is_not_the_pr
+  1b range handed out `..HEAD` from    ..._range_does_not_hand_out_a_   H2
+     the wrong tree                    head_that_is_not_the_prs_head
+  1c --emit-claims stamped the LOCAL   ..._emit_claims_stamps_the_prs_  H3
+     head as the audited sha           head_not_the_local_checkouts
+  2  toolchain gated the SHARED        ..._toolchain_gates_the_         T1, T2
+     checkout                          auditors_copy_not_the_shared_...
+  3  fork PRs inverted the cross-repo  ..._fork_pr_against_this_repo_   C3, P1
+     directive; the FIXTURE agreed     is_not_treated_as_cross_repo
+                                       + ..._prs_repo_is_read_from_the_url
+  4  missing_clauses() unreachable     ..._clause_check_runs_over_a_    K1, K2
+                                       file_that_can_actually_be_lossy
+                                       + ..._out_file_is_read_back...
+  5  five clause rewords INVERTED the  ..._each_clause_carries_the_     W1-W5
+     instruction and stayed green      instruction_its_ledger_...      (+S1)
+  6  a FALSE cause printed for a       ..._failed_cumulative_           L1
+     failed cumulative measurement     measurement_does_not_print_a_...
+  7  --round 1 --emit-claims emitted   ..._emit_claims_prints_a_block_  H4
+     a block parsing to garbage        ..._parser_accepts (rows 2, 3)
+                                       + ..._round_one_block_anchors_...
+  8  the parser dropped four shapes    ..._fence_the_parser_cannot_     B1-B5
+     silently, and truncated wrapped   read_is_reported_not_skipped
+     claims                            + 4 siblings
+  9  "repo cannot be determined"       ..._undeterminable_repo_gets_    P2
+     collapsed into SAME-REPO          its_own_branch_not_the_same...
+
+🔴 FINDING 3's PRESCRIPTION WAS WRONG ON ONE POINT, and it is recorded because
+the next person will reach for the same field: the audit said to use
+`isCrossRepository` + **`baseRepository`**. `gh pr view --json` HAS NO
+`baseRepository` FIELD (checked against `gh`'s own field list, which is what it
+prints on an unknown key). `url` is what carries the base repo, and it is what
+`pr_slug` reads; `isCrossRepository` decides whether the head fields may stand
+in when there is no url.
 
 🔴 THE NEGATIVE-CONTROL MATRIX — measured, and RE-DERIVABLE
 -------------------------------------------------------------
@@ -48,22 +101,31 @@ rows that justified adding a pin. Each row there names the EXACT killer set and
 reports WRONG-KILLER (an expected pin did not fire) separately from EXTRA-KILLER
 (the row no longer isolates what it names).
 
-Run 2026-08-27 against HEAD of this branch, each mutant applied to a COPY of
+Re-run 2026-08-27 against HEAD of this branch after the round-2 fixes — **39
+rows, all as expected** — each mutant applied to a COPY of
 `scripts/audit-dispatch.py` in a scratch tree (never the worktree), under
 `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`, with the unmutated copy as the
 positive control. Every mutant asserted its target string present before
 editing — a mutation that silently fails to apply reports "the guard held",
-which is the most flattering possible wrong answer.
+which is the most flattering possible wrong answer. (One row did exactly that
+this round: `C3` had been written against the two-state `cross_repo` flag, and
+reported MUTATION DID NOT APPLY the moment that became three-state
+`repo_relation`. It is re-targeted; without that assert it would have scored as
+a guard holding.)
 
-  POS  unmutated copy .............................. 37 passed  <- control
+The rows below are the pre-existing sixteen. The twenty-three added this round —
+W1-W5 and the SURVIVES control S1, H1-H4, T1-T2, P1-P2, K1-K3, L1, B1-B5 — are
+listed in the harness with their killer sets and are NOT transcribed here; the
+harness is the authority on which rows exist.
+
+  POS  unmutated copy .............................. 58 passed  <- control
 
   D1   delete the `read-only` clause ............... 4 failed
   D3   delete the `stop-rule` clause ............... 4 failed
   D4   delete the `nit-is-not-a-finding` clause .... 4 failed
   D5   delete the `reverify-self-reported` clause .. 4 failed
   D6   delete the `finding-format` clause .......... 4 failed
-  D7   delete the `do-not-merge` clause ............ 4 failed
-         all six kill the same four: ledger_is_pinned_two_way /
+         all five kill the same four: ledger_is_pinned_two_way /
          carries_the_instruction_its_ledger_entry_names /
          rendered_section_holds_exactly /
          control_a_clause_deleted_from_the_constant_is_detected
@@ -73,6 +135,12 @@ which is the most flattering possible wrong answer.
          `no-fetch` BY ID, so deleting that particular clause makes it error.
          Recorded rather than tidied away: it is a real coupling, and it is why
          the deleted-clause CONTROL is a different test from the warn test.
+  D7   delete the `do-not-merge` clause ............ 5 failed
+         the same four, plus out_file_is_read_back_and_checked — the SECOND
+         instance of D2's shape, and for the same reason: that test looks
+         `do-not-merge` up BY ID to model a lossy write. An INDEX would be
+         worse, not better; it would make the test's outcome depend on which
+         OTHER clause a mutation deleted.
   A1   ADD an eighth clause with no ledger entry ... 3 failed
          ledger_is_pinned_two_way / rendered_section_holds_exactly /
          control_a_clause_deleted_from_the_constant_is_detected
@@ -81,25 +149,31 @@ which is the most flattering possible wrong answer.
        is still present and still emitted .......... 1 failed
          carries_the_instruction_its_ledger_entry_names ALONE
          🔴 THE REACHABILITY CONTROL. Every presence pin stays GREEN, so a red
-         here proves the FRAGMENT ledger executes and is not a second spelling
-         of the id ledger beside it.
+         here proves the CLAUSE ledger executes and is not a second spelling
+         of the id ledger beside it. W1-W5 are the same shape, one per
+         instruction that a fragment pin could not see.
   F1   render the invariant section from a hardcoded
-       copy of the bullets, ignoring the constant ... 3 failed
+       copy of the bullets, ignoring the constant ... 4 failed
          ledger_is_pinned_two_way stays GREEN (the ids are untouched);
-         rendered_section_holds_exactly, emitted_verbatim_in_both_kinds and the
-         deleted-clause control go red. This is why the RENDERED section is
-         compared and not only the constant.
+         rendered_section_holds_exactly, emitted_verbatim_in_both_kinds, the
+         deleted-clause control and the `--check` round trip go red. This is
+         why the RENDERED section is compared and not only the constant — and
+         the `--check` row is the one that reaches it through a real FILE.
   C1   the delta refusal removed (a round-N brief is
-       emitted with no claims block) ............... 3 failed
+       emitted with no claims block) ............... 4 failed
          delta_refusal_exits_non_zero / refusal_names_what_it_looked_for /
-         refusal_fires_for_a_malformed_block
+         refusal_fires_for_a_malformed_block / refusal_says_which_comment_kinds
   C2   claims read from the WHOLE comment body
        instead of the fenced block ................. 3 failed
          brief_carries_the_claims_and_not_the_reasoning (the framing
          guarantee) / newest_claims_block_wins / emit_claims round-trip
-  C3   cross-repo decision inverted (`!=` -> `==`) . 3 failed
+  C3   the two KNOWN repo states swapped .......... 4 failed
          cross_repo_tells_the_agent_to_worktree_the_prs_repo /
          same_repo_recommends_the_isolation_flag / decision_comes_from_the_repos
+         / fork_pr_against_this_repo_is_not_treated_as_cross_repo — the last
+         one is what proves the FORK case rides this same decision. The fixture
+         used to encode a model in which it did not, which is how three
+         cross-repo tests and this mutant all passed over a live bug.
   C4   the numstat command's non-zero exit reads as
        a clean zero instead of COULD NOT MEASURE ... 1 failed
          ledger_refuses_a_failed_command_rather_than_printing_zero
@@ -107,8 +181,10 @@ which is the most flattering possible wrong answer.
        pathspec and prints a number for X .......... 1 failed
          ledger_shows_the_files_and_refuses_to_classify_them
   C6   the missing-clause warning BLOCKS
-       (returns non-zero) .......................... 1 failed
-         missing_clause_check_warns_and_never_blocks
+       (returns non-zero) .......................... 2 failed
+         missing_clause_check_warns_and_never_blocks /
+         out_file_is_read_back_and_checked (it too asserts rc 0 over a `--out`
+         run whose file is missing a clause)
 
 🔴 ONE MEASURED NON-RESULT, RECORDED BECAUSE IT LOOKS LIKE COVERAGE:
 `test_every_clause_is_emitted_verbatim_in_both_kinds_of_brief` does **NOT** go
@@ -121,11 +197,22 @@ implementation" failure. The deletion detectors are the ledger tests.
 
 🔴 WHAT THIS MODULE DOES **NOT** ENFORCE
 -----------------------------------------
-1. **It cannot see a clause REWORDED into something weaker** beyond the one
-   fragment its ledger names. `CLAUSE_LEDGER` pins one load-bearing phrase per
-   clause, not the whole sentence, because the whole sentence would live in two
-   places and drift. So a rewrite that keeps the fragment and guts the rest is
-   invisible. Mitigation is review, not this file.
+1. **It cannot see a clause reworded into a SEMANTICALLY IDENTICAL sentence.**
+   🔴 This item used to read "it cannot see a clause REWORDED into something
+   weaker", and that was a live hole, not a documented limit: `CLAUSE_LEDGER`
+   pinned one phrase per clause, and five rewords that INVERTED their clause
+   passed a fully green 37-test suite — including one telling every future
+   auditor that "one confirming round after a clean one is prudent", which is
+   what `claude/RULES.md` forbids.
+
+   The ledger now pins the WHOLE whitespace-normalised clause, the way the
+   sibling module `scripts/tests/test_audit_ladder_stop_rule.py` pins the prose
+   it guards. What remains out of reach is what remains out of reach there too:
+   a restatement in different words that means the same thing. There is no known
+   mechanical fix, and the cost of the pin is that a cosmetic REWORD now fails
+   here — which is the price, deliberately paid, for a machine-readable claim.
+   A pure re-wrap is free: whitespace is normalised, and mutant S1 is the
+   SURVIVES control proving it.
 2. **It proves nothing about BEHAVIOUR.** Nothing here shows any auditor read
    the brief, obeyed the no-fetch clause, or stopped at a clean round. The
    measurement that motivated the script was over transcripts; the verifier for
@@ -170,22 +257,83 @@ ad = _load()
 # --------------------------------------------------------------------------- #
 # If this ledger were derived from `ad.INVARIANT_CLAUSES` the whole test would
 # be vacuous: deleting a clause would delete it from both sides and the
-# comparison would stay green. So the ids and the load-bearing fragment of each
-# clause are RESTATED here by hand, and the duplication is the point.
+# comparison would stay green. So the ids and the WHOLE TEXT of each clause are
+# RESTATED here by hand, and the duplication is the point.
 #
-# Each fragment is the phrase a dispatch measurably LOST when the clause was
-# written from memory (see the module docstring's table). Pinning the phrase
-# rather than the sentence is a deliberate trade: a reword that keeps the phrase
-# is invisible (blind spot 1), and a sentence pinned in two files drifts.
+# 🔴 THESE USED TO BE FRAGMENTS, AND FIVE INSTRUCTION-INVERTING REWORDS PASSED A
+# FULLY GREEN 37-TEST SUITE:
+#
+#   read-only      -> "Edit the repo under audit freely if it helps."
+#   no-fetch       -> "`pull` and `checkout` in the shared checkout are fine."
+#   finding-format -> `file:line` and the scenario requirement deleted
+#   reverify       -> "Where time allows, re-verify…"
+#   stop-rule      -> "one confirming round after a clean one is prudent"
+#
+# The last one makes every future brief instruct auditors to do the thing
+# `claude/RULES.md` forbids. A fragment pin certifies that a PHRASE is present,
+# never that the instruction around it still says what it said.
+#
+# So these are WHOLE, whitespace-normalised strings, the way the sibling module
+# `scripts/tests/test_audit_ladder_stop_rule.py` pins the prose it guards — and
+# for the reason it cites, `claude/RULES.md` -> spelled-guards: "when the
+# artifact under test IS prose, a guard on WORDS is walkable by REWORDING — pin
+# the WHOLE normalised string. A cosmetic reword then fails the test — pay it,
+# for a machine-readable claim."
+#
+# Normalising whitespace is what keeps the price to a REWORD and not a re-wrap:
+# the mutation battery carries a SURVIVES control ("re-wrap a clause across
+# different line breaks") proving a pure re-flow stays green here.
 CLAUSE_LEDGER = {
-    "read-only": "rm -f <copy>/.git",
-    "no-fetch": "Do NOT `git fetch`",
-    "stop-rule": "ending it is the CORRECT outcome, not a failure",
-    "nit-is-not-a-finding": "changes nothing a reader does is NOT a finding",
-    "reverify-self-reported": "self-reported numbers rather than accepting them",
-    "finding-format": "`payload` or `scaffolding` label",
-    "do-not-merge": "Do not merge — report only",
+    "read-only": (
+        "**READ-ONLY — you modify nothing in the repository under audit.** If "
+        "you must mutate something to test a theory, do it in a `cp -a` copy "
+        "and run `rm -f <copy>/.git` FIRST: a worktree's `.git` is a FILE "
+        "pointing at the real git dir, so a commit inside the copy lands on "
+        "the branch you are auditing."
+    ),
+    "no-fetch": (
+        "**Do NOT `git fetch`, `pull`, `checkout` or otherwise write to the "
+        "shared checkout named in THE SHARED CHECKOUT section of this brief.** "
+        "Other sessions are in it; a fetch there is a write with cross-session "
+        "blast radius, and every ref you need is already resolved for you here."
+    ),
+    "stop-rule": (
+        "**A clean round ENDS the ladder — ending it is the CORRECT outcome, "
+        "not a failure.** Rounds continue only while the previous round "
+        "produced a finding that needed fixing. Do not manufacture findings to "
+        "justify the round, and do not run another round to confirm a clean "
+        "one."
+    ),
+    "nit-is-not-a-finding": (
+        "**A nit that changes nothing a reader does is NOT a finding.** If the "
+        "fix would be a reword with no behavioural, decision or correctness "
+        "consequence, leave it out of the findings and say so in one line "
+        "under the verdict instead."
+    ),
+    "reverify-self-reported": (
+        "**Re-verify the fix commit's own self-reported numbers rather than "
+        "accepting them.** Counts, byte sizes, mutation-sweep results and "
+        "\"watched red at <sha>\" claims in a commit message or PR body are "
+        "claims to check against the tree, never evidence."
+    ),
+    "finding-format": (
+        "**Report each finding with `file:line`, a concrete failure scenario "
+        "(the input, the path taken, the wrong output) and a `payload` or "
+        "`scaffolding` label** — payload is what the PR exists to ship; "
+        "scaffolding is the tests, fixtures and notes a round wrote to guard "
+        "it."
+    ),
+    "do-not-merge": (
+        "**Do not merge — report only.** No pushes, no PR comments, no "
+        "`gh pr merge`. Hand the findings back and let the operator act on "
+        "them."
+    ),
 }
+
+
+def norm(text: str) -> str:
+    """Whitespace-normalised. A re-wrap must not fail; a reword must."""
+    return " ".join(text.split())
 
 # Restated, not imported, for the same reason: the bullet extractor below must
 # not be steerable by the module it audits.
@@ -219,13 +367,54 @@ def bullets_in_invariant_section(brief: str) -> list[str]:
 # Fakes for the ONE process boundary
 # --------------------------------------------------------------------------- #
 
+# 🔴 THIS FIXTURE SHARED THE DEFECT IT WAS SUPPOSED TO CATCH. It carried no
+# `isCrossRepository`, no `headRefOid`, and a `url` of the wrong SHAPE
+# (`.../pulls/900`), so every cross-repo test — and mutant C3 — ran against a
+# model of `gh` in which the head repo IS the PR's repo. That model is false for
+# every fork PR, and it is why three tests and a mutation row all passed through
+# the bug.
+#
+# Field shapes are copied from real `gh pr view --json` output (values are
+# synthetic; the host is `example.invalid` on purpose — this repo is public).
+# The load-bearing shape is `url` = `<scheme>://<host>/<owner>/<name>/pull/<n>`,
+# which names the repo the PR LIVES in.
+FAKE_HEAD_OID = "1111111122222222333333334444444455555555"
+
 DEFAULT_PR = {
     "title": "a synthetic PR title",
-    "url": "https://example.invalid/pulls/900",
+    "url": "https://example.invalid/example-org/devrc/pull/900",
     "baseRefName": "main",
-    "headRepository": {"name": "devrc"},
+    "headRefOid": FAKE_HEAD_OID,
+    "isCrossRepository": False,
+    "headRepository": {"name": "devrc", "nameWithOwner": "example-org/devrc"},
     "headRepositoryOwner": {"login": "example-org"},
 }
+
+# A FORK PR: opened from a contributor's fork AGAINST `example-org/devrc`, which
+# is the cwd's repo. Verified against real `gh` output for a fork PR (the head
+# repo is the contributor's, `url` is the base repo's, `isCrossRepository` is
+# true). The correct brief for this is the SAME-REPO one.
+FORK_PR = {
+    "title": "a synthetic fork PR title",
+    "url": "https://example.invalid/example-org/devrc/pull/900",
+    "baseRefName": "main",
+    "headRefOid": FAKE_HEAD_OID,
+    "isCrossRepository": True,
+    "headRepository": {
+        "name": "devrc", "nameWithOwner": "some-contributor/devrc",
+    },
+    "headRepositoryOwner": {"login": "some-contributor"},
+}
+
+# A genuinely cross-repo PR: it lives in a repository that is NOT the cwd's.
+OTHER_REPO_PR = dict(
+    DEFAULT_PR,
+    url="https://example.invalid/someone-else/otherproj/pull/900",
+    headRepository={
+        "name": "otherproj", "nameWithOwner": "someone-else/otherproj",
+    },
+    headRepositoryOwner={"login": "someone-else"},
+)
 
 FAKE_REPO_DIR = "/fake/checkout/devrc"
 FAKE_ORIGIN = "git@github.com:example-org/devrc.git"
@@ -253,10 +442,20 @@ def make_runner(
     rev_list=(0, "4\n", ""),
     numstat=(0, "10\t2\tscripts/foo.py\n3\t0\tscripts/tests/test_foo.py\n", ""),
     head_sha="deadbee",
+    local_head=None,
 ):
-    """A closed-world stand-in for `gh` and `git`. No process is spawned."""
+    """A closed-world stand-in for `gh` and `git`. No process is spawned.
+
+    `local_head` is what `git rev-parse HEAD` returns in the operator's
+    checkout. It DEFAULTS to the PR's own `headRefOid`, i.e. the checkout is
+    standing on the PR — the only state in which the delta half of a brief means
+    what it says. Pass a different sha to model the shared checkout having moved
+    (which it does, constantly), and `None` explicitly for a PR fixture with no
+    `headRefOid`.
+    """
     payload = dict(pr or DEFAULT_PR)
     payload["comments"] = [{"body": c} for c in comments]
+    resolved_head = local_head if local_head is not None else payload.get("headRefOid")
 
     def runner(cmd, cwd=None):
         if cmd[0] == "gh":
@@ -271,6 +470,10 @@ def make_runner(
                 return 0, branch + "\n", ""
             if verb == "rev-parse" and "--short" in cmd:
                 return 0, head_sha + "\n", ""
+            if verb == "rev-parse" and cmd[-1] == "HEAD":
+                return (0, resolved_head + "\n", "") if resolved_head else (
+                    128, "", "fatal: ambiguous argument 'HEAD'"
+                )
             if verb == "remote":
                 return (0, origin + "\n", "") if origin else (1, "", "no origin")
             if verb == "status":
@@ -285,11 +488,17 @@ def make_runner(
 
 
 def run_main(argv, **kw):
-    """-> (rc, stdout, stderr). Always with an injected runner."""
+    """-> (rc, stdout, stderr). Always with an injected runner.
+
+    `runner` is popped BEFORE the default is built: `kw.pop(k, default)`
+    evaluates its default eagerly, so building `make_runner(**kw)` inline passed
+    `runner=` straight into `make_runner` and raised.
+    """
     out, err = io.StringIO(), io.StringIO()
+    runner = kw.pop("runner", None) or make_runner(**kw)
     rc = ad.main(
         argv,
-        runner=kw.pop("runner", make_runner(**kw)),
+        runner=runner,
         stdout=out,
         stderr=err,
         checklist_reader=fake_checklist,
@@ -358,24 +567,35 @@ def test_the_invariant_clause_ledger_is_pinned_two_way():
 
 
 def test_each_clause_carries_the_instruction_its_ledger_entry_names():
-    """🔴 The reachability control for the ledger above.
+    """🔴 The reachability control for the ledger above — and the reword guard.
 
     The id pin passes for a clause whose text has been reworded into something
-    weaker. This is the assertion that sees that — and mutant R1 (reword
-    `stop-rule` to drop "ending it is the CORRECT outcome, not a failure") kills
-    THIS test alone, with every presence pin still green.
+    weaker. This is the assertion that sees that: mutant R1 (reword `stop-rule`)
+    and mutants W1-W5 (five rewords that INVERT the instruction) each kill THIS
+    test alone, with every presence pin still green.
+
+    🔴 WHOLE STRING, whitespace-normalised, not a fragment. With fragments,
+    all five inversions passed a green 37-test suite — including one that told
+    every future auditor "one confirming round after a clean one is prudent",
+    the exact thing `claude/RULES.md` forbids.
     """
     by_id = {c.id: c.text for c in ad.INVARIANT_CLAUSES}
-    for cid, fragment in CLAUSE_LEDGER.items():
+    for cid, pinned in CLAUSE_LEDGER.items():
         assert cid in by_id, f"clause {cid!r} is gone; see the two-way pin above"
-        assert fragment in by_id[cid], (
-            f"\n\nclause {cid!r} no longer contains the phrase this module "
-            f"pins:\n    {fragment!r}\n"
-            f"  It now reads:\n    {by_id[cid]!r}\n"
-            "  That phrase is the part a hand-written brief measurably lost. "
-            "If the reword is deliberate, update CLAUSE_LEDGER in the same "
+        assert norm(pinned) == norm(by_id[cid]), (
+            f"\n\nclause {cid!r} is not, word for word, what this module "
+            f"pins.\n  pinned here :\n    {norm(pinned)!r}\n"
+            f"  in the script:\n    {norm(by_id[cid])!r}\n"
+            "  🔴 This is a WHOLE-STRING pin because the artifact is prose and "
+            "a keyword guard is walkable by rewording (claude/RULES.md, "
+            "spelled-guards). Whitespace is normalised, so a RE-WRAP is free "
+            "and only a REWORD fails.\n"
+            "  If the reword is deliberate, update CLAUSE_LEDGER in the SAME "
             "commit — which is the moment to notice you are rewriting an "
-            "instruction rather than reformatting one."
+            "instruction rather than reformatting one. Five rewords that "
+            "inverted their clause outright passed the fragment version of "
+            "this pin, one of them telling auditors to run a confirming round "
+            "after a clean one."
         )
 
 
@@ -471,7 +691,7 @@ def test_control_a_clause_deleted_from_the_constant_is_detected(monkeypatch):
     assert rc == 0
     bullets = bullets_in_invariant_section(out)
     assert len(bullets) == len(CLAUSE_LEDGER) - 1
-    assert not any(CLAUSE_LEDGER["no-fetch"] in b for b in bullets), (
+    assert not any(norm(CLAUSE_LEDGER["no-fetch"]) in norm(b) for b in bullets), (
         "a clause was removed from INVARIANT_CLAUSES and its instruction still "
         "reached the brief — the section is not rendered from the constant, so "
         "the two-way pin guards nothing."
@@ -604,24 +824,66 @@ def test_the_newest_claims_block_wins():
     )
 
 
-def test_emit_claims_prints_a_block_this_scripts_own_parser_accepts():
+@pytest.mark.parametrize("argv,kw,want_from,want_round", [
+    # The shape the round-trip test used to cover ALONE.
+    (["900", "--round", "3", "--emit-claims"], {"comments": [CLAIMS_BLOCK_R2]},
+     "bbbb2222", 3),
+    # 🔴 REGRESSION, red at `abc41024`. `--round 1 --emit-claims` is the exact
+    # command the delta refusal names as the fix, and with no prior block
+    # `prev_sha` was None, so the PLACEHOLDER `<the sha round 1 audited>` was
+    # interpolated into the header. `_HEADER_AUDITED` then captured `<the`,
+    # found no `..`, and produced `audited_from=''`, `audited_to='<the'` — and
+    # the next round's brief said ``Diff `<the..HEAD` `` with rc 0 and no
+    # refusal at all. The parser already accepts a bare sha; round 1 emits it.
+    (["900", "--emit-claims"], {"comments": []}, "", 1),
+    (["900", "--round", "1", "--emit-claims"], {"comments": []}, "", 1),
+])
+def test_emit_claims_prints_a_block_this_scripts_own_parser_accepts(
+    argv, kw, want_from, want_round
+):
     """A round trip, so the skeleton cannot drift away from the reader.
 
     The next round REFUSES on an unparseable block, so a skeleton the parser
-    rejects would turn `--emit-claims` into a trap.
+    rejects would turn `--emit-claims` into a trap — and it was one for the
+    round-1 shape, which is the one the refusal tells people to run.
     """
-    rc, out, err = run_main(
-        ["900", "--round", "3", "--emit-claims"], comments=[CLAIMS_BLOCK_R2]
-    )
+    rc, out, err = run_main(argv, **kw)
     assert rc == 0, err
     tail = out[out.index("```audit-claims"):]
     blocks, malformed = ad.parse_claims_blocks([tail])
-    assert not malformed, malformed
+    assert not malformed, (
+        f"the block this script EMITS is one its own parser rejects: "
+        f"{malformed}\n{tail}"
+    )
     assert len(blocks) == 1
-    assert blocks[0].round_no == 3
-    assert blocks[0].audited_from == "bbbb2222"
-    assert blocks[0].audited_to == "deadbee"
+    assert blocks[0].round_no == want_round
+    assert blocks[0].audited_from == want_from
+    assert blocks[0].audited_to == FAKE_HEAD_OID[:8], (
+        f"the audited TIP parsed as {blocks[0].audited_to!r}. A placeholder "
+        "that survives into the header is worse than a refusal: it parses, so "
+        "the next round anchors a range on it and reports rc 0."
+    )
+    assert "<the" not in tail, (
+        "a placeholder reached the emitted header; the next round reads this "
+        "field literally"
+    )
     assert len(blocks[0].items) >= 1
+
+
+def test_a_round_one_block_anchors_the_next_rounds_cumulative_figure():
+    """The other half of the round-1 emission: the bare sha IS the anchor.
+
+    `--emit-claims` at round 1 writes `audited=<sha>` with no `..`, and that sha
+    is exactly the quantity `round_one_anchor` needs. Reading it keeps the
+    remedy chain the refusal advertises from dead-ending in a permanently
+    NOT MEASURED cumulative.
+    """
+    r1 = ad.ClaimsBlock(1, "", "aaaa1111", ["a claim"])
+    later = ad.ClaimsBlock(3, "bbbb2222", "cccc3333", ["another"])
+    assert ad.round_one_anchor([r1, later]) == "aaaa1111"
+    # A bare sha on a LATER round is NOT an anchor — it says what that round
+    # audited, and round 1's tip is then genuinely unknown.
+    assert ad.round_one_anchor([ad.ClaimsBlock(2, "", "bbbb2222", ["x"])]) is None
 
 
 # --------------------------------------------------------------------------- #
@@ -639,9 +901,7 @@ def test_cross_repo_tells_the_agent_to_worktree_the_prs_repo_itself():
     repo that is the WRONG tree and the failure is quiet — the agent either
     reports a briefed file missing, or silently audits the wrong repository.
     """
-    pr = dict(DEFAULT_PR, headRepository={"name": "otherproj"},
-              headRepositoryOwner={"login": "someone-else"})
-    rc, out, err = run_main(["900"], pr=pr)
+    rc, out, err = run_main(["900"], pr=OTHER_REPO_PR)
     assert rc == 0, err
 
     assert "git -C" in out and "worktree add" in out, (
@@ -681,11 +941,107 @@ def test_same_repo_recommends_the_isolation_flag_and_does_not_hand_roll():
 def test_the_cross_repo_decision_comes_from_the_repos_not_from_prose():
     """The same run, differing only in the PR's repo, must flip the section."""
     same = run_main(["900"])[1]
-    other = run_main(["900"], pr=dict(
-        DEFAULT_PR, headRepository={"name": "otherproj"},
-        headRepositoryOwner={"login": "someone-else"}))[1]
+    other = run_main(["900"], pr=OTHER_REPO_PR)[1]
     assert (ad.ISOLATION_FORBID in other) and (ad.ISOLATION_FORBID not in same)
     assert (ad.ISOLATION_RECOMMEND in same) and (ad.ISOLATION_RECOMMEND not in other)
+
+
+def test_a_fork_pr_against_this_repo_is_not_treated_as_cross_repo():
+    """🔴 REGRESSION. Red at `abc41024`, where it emitted the CROSS-REPO brief.
+
+    `pr_slug` read `headRepositoryOwner`/`headRepository` — the repo the head
+    BRANCH lives in, which for a fork PR is the contributor's fork. Verified
+    against real `gh` output for a fork PR against `cli/cli`: head reports
+    `ylfeng250/cli` while the PR lives in `cli/cli` and `isCrossRepository` is
+    true. So a fork PR opened against THIS repo computed
+    `repo=some-contributor/devrc != cwd_slug` and emitted the cross-repo branch:
+    "the PR lives in `some-contributor/devrc` … Do NOT use `isolation:
+    \"worktree\"` … `git -C <your local clone of some-contributor/devrc>
+    worktree add`". Every part of that is wrong, `gh pr diff` in the fork fails,
+    and no such clone exists.
+
+    🔴 All three cross-repo tests and mutant C3 passed through this bug because
+    `DEFAULT_PR` encoded the same wrong model. The fixture is corrected; this is
+    the case that could not have passed under it.
+    """
+    rc, out, err = run_main(["900"], pr=FORK_PR)
+    assert rc == 0, err
+
+    assert ad.ISOLATION_RECOMMEND in out, (
+        "\n\na fork PR opened AGAINST this repo got the cross-repo brief. The "
+        "PR lives in the repo this session is standing in; the worktree flag "
+        "is correct here and hand-rolling one against a clone of the fork is "
+        "not."
+    )
+    assert ad.ISOLATION_FORBID not in out
+    assert "some-contributor/devrc" not in out, (
+        "\n\nthe brief names the CONTRIBUTOR'S FORK as the repo to work in. "
+        "That is the head repo, not the PR's repo — `gh pr diff` there fails "
+        "and the local clone the brief tells the agent to use does not exist."
+    )
+    assert "example-org/devrc" in out
+
+
+def test_the_prs_repo_is_read_from_the_url_not_from_the_head_repo():
+    """The unit-level statement of the same fact, driven through `pr_slug`.
+
+    Kept beside the brief-level test because the two fail differently: this one
+    says WHICH field was misread, the one above says what the operator sees.
+    """
+    assert ad.pr_slug(FORK_PR) == "example-org/devrc"
+    assert ad.pr_slug(DEFAULT_PR) == "example-org/devrc"
+    assert ad.pr_slug(OTHER_REPO_PR) == "someone-else/otherproj"
+    # `--repo` still wins over everything: it is the operator stating it.
+    assert ad.pr_slug(FORK_PR, "stated/outright") == "stated/outright"
+    # No url, but `isCrossRepository` false ⇒ the head fields ARE the PR's repo.
+    assert ad.pr_slug({
+        "url": "", "isCrossRepository": False,
+        "headRepository": {"name": "devrc"},
+        "headRepositoryOwner": {"login": "example-org"},
+    }) == "example-org/devrc"
+    # No url and cross-repository ⇒ the head fields are the FORK. Answering
+    # from them would be the bug above, so this returns None and the brief
+    # renders its COULD NOT DETERMINE branch.
+    assert ad.pr_slug({
+        "url": "", "isCrossRepository": True,
+        "headRepository": {"name": "devrc"},
+        "headRepositoryOwner": {"login": "some-contributor"},
+    }) is None
+
+
+def test_an_undeterminable_repo_gets_its_own_branch_not_the_same_repo_one():
+    """🔴 REGRESSION. Red at `abc41024`, where it emitted the SAME-REPO brief.
+
+    `cross_repo` was `bool(cwd_slug and repo and cwd_slug != repo)`, so a falsy
+    `cwd_slug` — no `origin` remote — made the three-state decision evaluate
+    FALSE and silently become "same repo", which recommends the flag whose
+    failure is silent. The measured output contradicted itself in one
+    paragraph: "The PR lives in `<org>/<other-repo>`, which is this session's
+    own repository (`/home/…/devrc`)" followed by the isolation directive.
+    """
+    rc, out, err = run_main(["900"], pr=OTHER_REPO_PR, origin=None)
+    assert rc == 0, err
+
+    assert "COULD NOT DETERMINE" in out, (
+        "\n\nwith no `origin` remote the script still claimed to know which "
+        "repository the PR is in. Three states, not two: not knowing is its "
+        "own answer."
+    )
+    assert ad.ISOLATION_RECOMMEND not in out, (
+        "\n\nthe brief RECOMMENDED `isolation: \"worktree\"` for a PR whose "
+        "repository it could not determine. That flag worktrees the cwd's "
+        "repo; recommending it is only safe once the repos are known to match."
+    )
+    assert ad.ISOLATION_FORBID in out, (
+        "the undetermined branch must default to NOT using the flag"
+    )
+    assert "which is this session's own repository" not in out, (
+        "\n\nthe brief asserted the PR is in this session's repository — the "
+        "self-contradicting claim this branch exists to stop"
+    )
+    assert "--repo owner/name" in out, (
+        "the branch does not tell the operator how to answer the question"
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -716,10 +1072,62 @@ def test_the_toolchain_section_names_the_tier_the_merge_gates_on():
         "the wrong-shell diagnosis is missing — it was present in 9 of the "
         "first 9 measured dispatches and absent from 3 of the last 5"
     )
-    assert "nix build /fake/checkout/devrc#checks.x86_64-linux.pytests" in out
-    assert "nix build /fake/checkout/devrc#checks.x86_64-linux.nodetests" in out
+    assert "nix build <your worktree>#checks.x86_64-linux.pytests" in out
+    assert "nix build <your worktree>#checks.x86_64-linux.nodetests" in out
     assert "gate.sh --tier both" in out
     assert "git --version" in out
+
+
+def test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout():
+    """🔴 REGRESSION. Red at `abc41024`, where every command named the shared
+    checkout.
+
+    `r = facts.cwd_repo_dir` was interpolated into all four commands, so the
+    brief said `nix develop <shared> -c bash <shared>/scripts/gate.sh` and
+    `nix build <shared>#checks…`. `gate.sh` resolves its `ROOT` from its own
+    `BASH_SOURCE`, so that runs the suite IN the shared checkout on whatever
+    branch it is standing on, and the `nix build` builds that ref's tree —
+    while WHERE TO WORK three bars earlier told the agent to work elsewhere.
+    The auditor then obeys the next sentence, "name the tier and the base sha",
+    and names the wrong sha.
+
+    `nix develop {r}` is the ONE allowed use: it resolves a dev shell, not a
+    tree under test.
+    """
+    rc, out, err = run_main(["900"])
+    assert rc == 0, err
+
+    toolchain = out[out.index("## TOOLCHAIN"):out.index("## 🔴 NON-NEGOTIABLE")]
+    # 🔴 The COMMANDS, not the prose around them. The prose necessarily names
+    # both the shared path and the two commands in order to explain the rule,
+    # and a check that cannot tell an instruction from its rationale would go
+    # red on the fix that closes the finding.
+    commands, inside = [], False
+    for line in toolchain.splitlines():
+        if line.startswith("```"):
+            inside = not inside
+            continue
+        if inside and line.strip():
+            commands.append(line)
+    assert commands, "no command block found in the toolchain section at all"
+
+    for line in commands:
+        if "gate.sh" in line or "nix build" in line:
+            assert FAKE_REPO_DIR not in line.replace(
+                f"nix develop {FAKE_REPO_DIR}", ""
+            ), (
+                "\n\nthe toolchain section tells the auditor to run the GATE "
+                f"or a `nix build` against the shared checkout:\n    {line}\n"
+                "  gate.sh resolves its root from its own path, so that runs "
+                "the suite in the shared checkout on whatever branch it is "
+                "standing on — not on the tree under audit. Only `nix develop "
+                "<repo>` may name it, and only to resolve the dev shell."
+            )
+    assert "<your worktree>/scripts/gate.sh" in out
+    assert "resolves its root from its own path" in out, (
+        "the section does not say WHY the shared path is wrong there, so the "
+        "next editor puts it back"
+    )
 
 
 def test_the_range_is_generated_from_the_previous_rounds_audited_sha():
@@ -727,6 +1135,117 @@ def test_the_range_is_generated_from_the_previous_rounds_audited_sha():
     assert rc == 0, err
     assert "`bbbb2222..HEAD`" in out, (
         "the delta range is not anchored at the sha the previous round audited"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE FOURTH READ RULE — is this checkout even standing on the PR?
+# --------------------------------------------------------------------------- #
+
+WRONG_HEAD = "9999999988888888777777776666666655555555"
+
+
+def test_the_ledger_refuses_to_measure_a_checkout_that_is_not_the_pr():
+    """🔴 REGRESSION. Red at `abc41024`, which printed a confident ledger.
+
+    `measure_ledger` was handed the operator's checkout and hard-coded `HEAD`,
+    and nothing checked HEAD was the PR's head. Reproduced from a clone standing
+    on an unrelated feature branch against real PR #958: rc 0, silent stderr, a
+    non-empty range — all three advertised read rules satisfied — and a file
+    list belonging to that branch. Standing on `main` produced the banner "🔴
+    Zero changed lines over a NON-EMPTY range. That is a real measurement, not a
+    failure."
+
+    A measurement of the wrong tree is not a measurement, so it earns the same
+    COULD NOT MEASURE the other three failures earn.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2], local_head=WRONG_HEAD
+    )
+    assert rc == 0, err
+    assert "COULD NOT MEASURE" in out, (
+        "\n\nthe ledger printed a number measured against a checkout that is "
+        "NOT standing on the PR. rc 0, silent stderr and a non-empty range are "
+        "all satisfied in that state and the answer is still about another "
+        "tree."
+    )
+    assert "not standing on the PR" in out and WRONG_HEAD in out, (
+        "the COULD NOT MEASURE does not NAME this cause, so the operator "
+        "re-runs the command by hand in the same wrong checkout"
+    )
+    assert "payload lines changed THIS round" not in out, (
+        "a ledger line was printed under a COULD NOT MEASURE"
+    )
+
+
+def test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head():
+    """🔴 REGRESSION. Red at `abc41024`: `<prev>..HEAD` was emitted regardless.
+
+    The range section is the instruction the auditor actually runs. Handing it
+    `..HEAD` while the shared checkout is on another branch points the whole
+    delta audit at the wrong diff — and reads as an ordinary range.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2], local_head=WRONG_HEAD
+    )
+    assert rc == 0, err
+    the_range = out[out.index("## THE RANGE"):out.index("## WHAT WAS CLAIMED")]
+    # The INSTRUCTION, not the explanation of why `..HEAD` is unsafe — that
+    # sentence necessarily contains the token it is warning about.
+    assert "Diff **`bbbb2222..HEAD`**" not in the_range, (
+        f"\n\nthe range still tells the auditor to diff `..HEAD` while this "
+        f"checkout is on {WRONG_HEAD} and the PR's head is {FAKE_HEAD_OID}:\n"
+        f"{the_range}"
+    )
+    assert FAKE_HEAD_OID in the_range, (
+        "the range does not name the PR's actual head sha, which is the only "
+        "thing the auditor can resolve the range against"
+    )
+    assert "COULD NOT VERIFY" in the_range
+
+
+def test_the_range_says_head_was_verified_when_it_was():
+    """The other direction: a verified checkout still gets `..HEAD`, and says so.
+
+    Measured separately from the failure case because "the guard fires" and "the
+    guard does not fire spuriously" are different claims, and a check wired to
+    always fail would satisfy the test above.
+    """
+    rc, out, err = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
+    assert rc == 0, err
+    the_range = out[out.index("## THE RANGE"):out.index("## WHAT WAS CLAIMED")]
+    assert "`bbbb2222..HEAD`" in the_range
+    assert "COULD NOT VERIFY" not in the_range
+    assert FAKE_HEAD_OID in the_range and "verified at assembly time" in the_range
+
+
+def test_emit_claims_stamps_the_prs_head_not_the_local_checkouts():
+    """🔴 REGRESSION. Red at `abc41024`, which stamped `rev-parse --short HEAD`.
+
+    The `audited=` sha is the field the NEXT round anchors its range and its
+    ledger on. Stamping the local HEAD recorded whatever branch the shared
+    checkout was standing on — `main`'s tip, in the reproduction — as the sha
+    this round audited, and the next round then measured from there.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "3", "--emit-claims"],
+        comments=[CLAIMS_BLOCK_R2],
+        local_head=WRONG_HEAD,
+        head_sha="deadbee",
+    )
+    assert rc == 0, err
+    block = out[out.index("```audit-claims"):]
+    assert "deadbee" not in block, (
+        "\n\nthe emitted block carries the LOCAL checkout's HEAD as the sha "
+        f"this round audited:\n{block}\n"
+        "  The next round anchors on this field."
+    )
+    assert FAKE_HEAD_OID[:8] in block, (
+        "the emitted block does not carry the PR's own head sha"
+    )
+    assert "NOT standing on it" in err, (
+        "the mismatch was stamped over silently; the operator writing the "
+        "claims needs to know the checkout they measured in is not the PR"
     )
 
 
@@ -792,6 +1311,54 @@ def test_the_cumulative_figure_is_not_measured_without_a_round_one_anchor():
     assert rc == 0, err
     assert "(since round 1: Y)" in out
     assert "NOT MEASURED" in out
+    assert "no `audit-claims` block carried a round-1 anchor sha" in out, (
+        "with genuinely no anchor, the no-anchor reason is the TRUE one and "
+        "must still be the one printed"
+    )
+
+
+def test_a_failed_cumulative_measurement_does_not_print_a_false_cause():
+    """🔴 REGRESSION. Red at `abc41024`, which printed a specific, false reason.
+
+    When the cumulative measurement failed, `cumulative` stayed None and the
+    brief stated "NOT MEASURED: no `audit-claims` block carried a round-1 anchor
+    sha" — printed even when one DID. The operator is then sent to add an anchor
+    that already exists, while the real fault (a sha `rev-list` cannot resolve)
+    goes unnamed.
+
+    Two mechanisms, one observable — the exact rule this module cites everywhere
+    else to justify its own COULD-NOT-MEASURE design.
+
+    Driven by failing the SECOND `rev-list` only: the per-round measurement
+    succeeds (so a ledger is rendered) and the cumulative one, from the anchor,
+    does not.
+    """
+    calls = {"n": 0}
+    base = make_runner(comments=[CLAIMS_BLOCK_R2])
+
+    def runner(cmd, cwd=None):
+        if cmd[:2] == ["git", "-C"] and cmd[3] == "rev-list":
+            calls["n"] += 1
+            if calls["n"] > 1:
+                return 128, "", "fatal: bad revision 'aaaa1111..HEAD'"
+        return base(cmd, cwd)
+
+    rc, out, err = run_main(["900", "--round", "3"], runner=runner)
+    assert rc == 0, err
+    assert calls["n"] >= 2, (
+        "the cumulative measurement never ran, so this test proves nothing "
+        "about what happens when it fails"
+    )
+    assert "(since round 1: Y)" in out and "NOT MEASURED" in out
+    assert "no `audit-claims` block carried a round-1 anchor sha" not in out, (
+        "\n\nthe brief blamed a MISSING round-1 anchor for a measurement that "
+        "failed WITH one in hand. That sends the operator to add a block that "
+        "is already there, and leaves the real fault unnamed."
+    )
+    assert "fatal: bad revision" in out, (
+        "the real reason the cumulative figure is missing is not reported"
+    )
+    assert "not a missing anchor" in out
 
 
 def test_the_ledger_says_the_base_was_not_fetched():
@@ -846,6 +1413,99 @@ def test_missing_clauses_is_a_pure_function_over_the_text():
     assert ad.missing_clauses(
         full.replace(ad.INVARIANT_CLAUSES[0].text, "")
     ) == [ad.INVARIANT_CLAUSES[0].id]
+    # A RE-WRAP is not a loss. A brief that has been through an editor or a
+    # paste has different line breaks and the same instructions.
+    rewrapped = "\n".join(
+        "\n".join(c.text.split(" ")) for c in ad.INVARIANT_CLAUSES
+    )
+    assert ad.missing_clauses(rewrapped) == [], (
+        "a pure re-wrap was reported as missing clauses — the check would then "
+        "be red on every hand-edited brief, which is the permanently-red gate "
+        "claude/RULES.md says trains people to click through"
+    )
+
+
+def test_the_clause_check_runs_over_a_file_that_can_actually_be_lossy(tmp_path):
+    """🔴 REGRESSION. Red at `abc41024`, where `--check` did not exist.
+
+    The guard's own docstring said "it exists for a hand-edited `--out` file" —
+    but nothing read `--out` back. Its only caller passed the string
+    `render_brief` had just built out of `INVARIANT_CLAUSES`, so every clause
+    was present BY CONSTRUCTION and no user input could make it fire. The suite
+    reached it only by monkeypatching `render_brief` to a lossy stub: the
+    `unreachable-guards` shape in `claude/RULES.md`.
+
+    It mattered. The hand-written brief that dispatched the audit of this script
+    HAD been edited — several clauses shortened, the checklist paraphrased — and
+    the shipped check could not notice.
+
+    So: round-trip a real brief through a real file, degrade it the way a human
+    editing it would, and check that from the file.
+    """
+    generated = tmp_path / "brief.md"
+    rc, _, err = run_main(["900", "--out", str(generated)])
+    assert rc == 0, err
+    text = generated.read_text(encoding="utf-8")
+
+    # Control: the generated file as written is complete, and says so.
+    # 🔴 The count is READ, not literal. A literal `7` here made every
+    # clause-deletion mutant (D1-D7) and the clause-addition mutant (A1)
+    # extra-kill this test, which is a coupling to the SIZE of a constant this
+    # test does not own — `test_the_rendered_section_holds_exactly_the_
+    # ledgered_clauses` owns that, against the independent ledger.
+    rc, out, err = run_main(["--check", str(generated)])
+    assert rc == 0
+    assert f"all {len(ad.INVARIANT_CLAUSES)} invariant clause(s) present" in out, out
+    assert "missing invariant clause(s)" not in err
+
+    # Now degrade it the way the measured hand-edit did: shorten two clauses.
+    dropped = ad.INVARIANT_CLAUSES[0]
+    shortened = ad.INVARIANT_CLAUSES[2]
+    edited = tmp_path / "edited.md"
+    edited.write_text(
+        text.replace(dropped.text, "").replace(
+            shortened.text, "**A clean round ends the ladder.**"
+        ),
+        encoding="utf-8",
+    )
+    rc, out, err = run_main(["--check", str(edited)])
+    assert rc == 0, "the clause check BLOCKED; it must only warn"
+    assert "missing invariant clause(s)" in err, (
+        f"\n\n`--check` did not notice two clauses removed from a real brief "
+        f"file. stderr was:\n{err}"
+    )
+    assert dropped.id in err and shortened.id in err
+    assert "WARNING, not a refusal" in err
+
+
+def test_the_out_file_is_read_back_and_checked(monkeypatch, tmp_path):
+    """The second real input: what landed on DISK, not the string in memory.
+
+    A write that lost bytes, or a `--out` path something else rewrites, is
+    exactly what this check is described as guarding and could not see.
+    """
+    out_file = tmp_path / "brief.md"
+    real_write = Path.write_text
+    target = next(c for c in ad.INVARIANT_CLAUSES if c.id == "do-not-merge")
+
+    def lossy_write(self, data, *a, **kw):
+        # Model a write that lands short — the file, not the brief, is wrong.
+        if str(self) == str(out_file):
+            data = data.replace(target.text, "(lost in the write)")
+        return real_write(self, data, *a, **kw)
+
+    monkeypatch.setattr(Path, "write_text", lossy_write)
+    rc, _, err = run_main(["900", "--out", str(out_file)])
+
+    assert rc == 0
+    assert "missing invariant clause(s)" in err and target.id in err, (
+        "\n\nthe brief on disk was missing a clause and the check passed — it "
+        "was still reading the in-memory string, where every clause is present "
+        "by construction"
+    )
+    assert str(out_file) in err, (
+        "the warning does not say WHICH artifact is missing the clause"
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -879,6 +1539,137 @@ def test_a_comment_with_no_fence_yields_nothing_and_no_false_malformation():
     assert blocks == [] and malformed == []
 
 
+@pytest.mark.parametrize("label,text,expect", [
+    (
+        "an unclosed fence",
+        "```audit-claims round=2 audited=aa..bb\n1. a claim\n",
+        "never CLOSED",
+    ),
+    (
+        "a 4-backtick opener closed with 3",
+        "````audit-claims round=2 audited=aa..bb\n1. a claim\n```\n",
+        "never CLOSED",
+    ),
+])
+def test_a_fence_the_parser_cannot_read_is_reported_not_skipped(label, text, expect):
+    """🔴 REGRESSION. Red at `abc41024`, where all of these vanished silently.
+
+    The module's own comment promised "A block whose header does not parse is
+    reported as MALFORMED rather than skipped: skipping it silently would
+    produce the same observable as 'no block at all', and those need different
+    fixes." That was false for four shapes, because the old regex required the
+    closing fence to be byte-identical to the opener and dropped anything else
+    with no report. The refusal then said "no `audit-claims` block in any of the
+    1 comment(s) read" — false, and it points at the wrong fix (write a block,
+    rather than close the one you wrote).
+
+    A closing fence SHORTER than the opener does not close it under CommonMark
+    either, so the 4-then-3 case really is unclosed and is now named as such.
+    """
+    blocks, malformed = ad.parse_claims_blocks([text])
+    assert blocks == [], f"{label}: unexpectedly parsed"
+    assert malformed, (
+        f"\n\n{label} was skipped SILENTLY. That produces the same observable "
+        "as 'nobody posted a block', and the two need opposite fixes."
+    )
+    assert expect in malformed[0], malformed
+
+
+def test_a_longer_closing_fence_is_a_valid_close_and_is_read():
+    """The direction that is valid CommonMark and renders CLOSED on GitHub.
+
+    A 3-backtick opener closed with 4 was ALSO dropped silently. The block is
+    well-formed, so the right answer is to read it — not to report it.
+    """
+    blocks, malformed = ad.parse_claims_blocks(
+        ["```audit-claims round=2 audited=aa..bb\n1. a claim\n````\n"]
+    )
+    assert not malformed, malformed
+    assert len(blocks) == 1 and blocks[0].items == ["a claim"]
+
+
+def test_a_claim_that_wraps_onto_a_continuation_line_keeps_its_tail():
+    """🔴 REGRESSION. Red at `abc41024`, where the continuation was DROPPED.
+
+    This one does not fail, it CHANGES THE CLAIM — and the next round is framed
+    on the truncated text, which is the one thing the framing rule above says
+    must be exact.
+    """
+    blocks, malformed = ad.parse_claims_blocks([
+        "```audit-claims round=2 audited=aa..bb\n"
+        "1. the collapsed branch was split so each\n"
+        "   reports its own state\n"
+        "2. a second claim\n"
+        "```"
+    ])
+    assert not malformed, malformed
+    assert blocks[0].items == [
+        "the collapsed branch was split so each reports its own state",
+        "a second claim",
+    ], (
+        "\n\na wrapped claim lost everything after its first line. The next "
+        "round is framed on exactly this text."
+    )
+
+
+def test_a_block_cut_short_by_a_nested_fence_is_reported():
+    """🔴 REGRESSION. Red at `abc41024`: everything after the nested fence went.
+
+    A fence inside the body ends the block — CommonMark and GitHub agree — so
+    the claims after it are outside it. The block still parses, with FEWER
+    claims, and nothing said so.
+    """
+    blocks, malformed = ad.parse_claims_blocks([
+        "```audit-claims round=2 audited=aa..bb\n"
+        "1. tightened the guard, was:\n"
+        "```py\n"
+        "if x: pass\n"
+        "```\n"
+        "2. the claim nobody ever read\n"
+        "```\n"
+    ])
+    assert len(blocks) == 1, "the readable half of the block was lost too"
+    assert any("CUT SHORT by a nested fence" in m for m in malformed), (
+        f"\n\nclaims after a nested fence were dropped with no report. "
+        f"malformed was {malformed}"
+    )
+
+
+def test_a_malformed_fence_beside_a_readable_block_still_warns(tmp_path):
+    """The report has to REACH the operator when a usable block exists.
+
+    The refusal only fires when there is NO block, so a comment holding one
+    readable block and one unreadable fence would otherwise pass as complete.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "3"],
+        comments=[
+            CLAIMS_BLOCK_R2,
+            "```audit-claims round=2 audited=cc..dd\n1. never closed\n",
+        ],
+    )
+    assert rc == 0, err
+    assert "could not read cleanly" in err and "never CLOSED" in err, (
+        f"\n\nan unreadable fence beside a readable block was silent. "
+        f"stderr:\n{err}"
+    )
+    assert "the collapsed branch was split" in out, (
+        "the warning suppressed the block that DID parse"
+    )
+
+
+def test_the_refusal_says_which_comment_kinds_it_cannot_see():
+    """`gh pr view --json comments` returns ISSUE comments only.
+
+    A block posted as a review comment, inside a review thread, or in the PR
+    body is invisible here — so "no block in any of the N comment(s) read" is a
+    claim about a narrower corpus than the operator has in mind.
+    """
+    _, _, err = run_main(["900", "--round", "3"], comments=[])
+    assert "ISSUE comments only" in err
+    assert "REVIEW comment" in err and "DESCRIPTION" in err
+
+
 # --------------------------------------------------------------------------- #
 # HERMETICITY + the ledger-of-ledgers
 # --------------------------------------------------------------------------- #
@@ -910,13 +1701,67 @@ def test_a_gh_failure_is_reported_and_not_papered_over():
     assert "gh pr view 900" in err and "failed" in err
 
 
-# The two ledgers the module docstring commits to. RED_AT_BASE is empty ON
-# PURPOSE and that emptiness is asserted, so nobody can later read this module
-# as carrying regression coverage it does not have.
-RED_AT_BASE: frozenset[str] = frozenset()
+# The two ledgers the module docstring commits to.
+#
+# 🔴 RED_AT_BASE WAS EMPTY, AND IS NOT ANY MORE. It was empty because the script
+# did not exist at this branch's base, so nothing here could be regression
+# coverage for a shipped bug. Round 2's adversarial audit found nine defects in
+# the shipped script, every one reproduced live, and each test below was watched
+# to FAIL against `abc41024` — the branch head that carried them. That is a real
+# base with a real bug in it, so these belong in this list and not the other.
+# The list is the MEASURED one — `git show abc41024:scripts/audit-dispatch.py`
+# into a scratch tree with this module copied in unchanged, run under
+# `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`: **24 failed, 34 passed**
+# (24 node ids, 21 functions; three of them are parametrised rows of one).
+RED_AT_BASE_REF = "abc41024"
+RED_AT_BASE: frozenset[str] = frozenset({
+    "test_a_fork_pr_against_this_repo_is_not_treated_as_cross_repo",
+    "test_the_prs_repo_is_read_from_the_url_not_from_the_head_repo",
+    "test_an_undeterminable_repo_gets_its_own_branch_not_the_same_repo_one",
+    "test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout",
+    "test_the_ledger_refuses_to_measure_a_checkout_that_is_not_the_pr",
+    "test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head",
+    "test_emit_claims_stamps_the_prs_head_not_the_local_checkouts",
+    "test_a_failed_cumulative_measurement_does_not_print_a_false_cause",
+    "test_missing_clauses_is_a_pure_function_over_the_text",
+    "test_the_clause_check_runs_over_a_file_that_can_actually_be_lossy",
+    "test_the_out_file_is_read_back_and_checked",
+    "test_a_fence_the_parser_cannot_read_is_reported_not_skipped",
+    "test_a_longer_closing_fence_is_a_valid_close_and_is_read",
+    "test_a_claim_that_wraps_onto_a_continuation_line_keeps_its_tail",
+    "test_a_block_cut_short_by_a_nested_fence_is_reported",
+    "test_a_malformed_fence_beside_a_readable_block_still_warns",
+    "test_the_refusal_says_which_comment_kinds_it_cannot_see",
+    "test_emit_claims_prints_a_block_this_scripts_own_parser_accepts",
+    "test_a_round_one_block_anchors_the_next_rounds_cumulative_figure",
+    # 🔴 THREE ENTRIES WHOSE REDNESS IS WEAKER EVIDENCE THAN THE REST, said
+    # here rather than left for a reader to assume otherwise. Every other entry
+    # above fails at the base by exercising the defect and observing the wrong
+    # ANSWER. These three fail at the base because they assert text or a branch
+    # the fix ADDED, so their red is a restatement of the diff:
+    #   * `..._names_the_tier_the_merge_gates_on` is a PRE-EXISTING guard whose
+    #     expected strings changed with the fix (`nix build <your worktree>#…`),
+    #     not new coverage;
+    #   * `..._range_says_head_was_verified_when_it_was` is the
+    #     does-not-fire-spuriously control for the head check — necessary (a
+    #     check wired to always fail would satisfy its sibling), and not itself
+    #     a detector;
+    #   * `..._refusal_says_which_comment_kinds_it_cannot_see` pins a sentence.
+    #     The gap it documents — `--json comments` returns issue comments only —
+    #     is NOT closed by this PR, and no test here can close it.
+    "test_the_toolchain_section_names_the_tier_the_merge_gates_on",
+    "test_the_range_says_head_was_verified_when_it_was",
+})
 
 INVARIANT_GUARDS_AND_LEDGERS = frozenset({
     "test_the_invariant_clause_ledger_is_pinned_two_way",
+    # 🔴 GREEN at `abc41024`, MEASURED — and it is the guard for finding 5, so
+    # the temptation to file it as regression coverage is real and is refused
+    # here. The clause TEXTS did not change in this round; what changed is that
+    # this module now pins them WHOLE instead of by fragment. Carrying the new
+    # ledger back to the base tree therefore passes. Its evidence is not a base
+    # ref at all — it is mutants W1-W5, five rewords that INVERT their clause
+    # and each kill this test alone.
     "test_each_clause_carries_the_instruction_its_ledger_entry_names",
     "test_every_clause_is_emitted_verbatim_in_both_kinds_of_brief",
     "test_the_rendered_section_holds_exactly_the_ledgered_clauses",
@@ -928,19 +1773,16 @@ INVARIANT_GUARDS_AND_LEDGERS = frozenset({
     "test_a_first_round_needs_no_claims_block",
     "test_the_brief_carries_the_claims_and_not_the_reasoning_around_them",
     "test_the_newest_claims_block_wins",
-    "test_emit_claims_prints_a_block_this_scripts_own_parser_accepts",
     "test_cross_repo_tells_the_agent_to_worktree_the_prs_repo_itself",
     "test_same_repo_recommends_the_isolation_flag_and_does_not_hand_roll",
     "test_the_cross_repo_decision_comes_from_the_repos_not_from_prose",
     "test_the_shared_checkout_state_is_reported_with_the_it_moves_warning",
-    "test_the_toolchain_section_names_the_tier_the_merge_gates_on",
     "test_the_range_is_generated_from_the_previous_rounds_audited_sha",
     "test_the_ledger_shows_the_files_and_refuses_to_classify_them",
     "test_the_ledger_refuses_a_failed_command_rather_than_printing_zero",
     "test_the_cumulative_figure_is_not_measured_without_a_round_one_anchor",
     "test_the_ledger_says_the_base_was_not_fetched",
     "test_missing_clause_check_warns_and_never_blocks",
-    "test_missing_clauses_is_a_pure_function_over_the_text",
     "test_parse_claims_blocks_reads_only_the_fence",
     "test_parse_claims_blocks_reports_a_bad_header_rather_than_skipping_it",
     "test_a_comment_with_no_fence_yields_nothing_and_no_false_malformation",
@@ -959,11 +1801,16 @@ def test_the_two_ledgers_partition_this_modules_tests():
     growing an unlisted test is asserting coverage nobody checked.
     """
     here = {n for n in globals() if n.startswith("test_")}
-    assert RED_AT_BASE == frozenset(), (
-        "RED_AT_BASE is documented as empty because scripts/audit-dispatch.py "
-        "did not exist at 3b79a35a. If a test here IS regression coverage for "
-        "a shipped bug, name the base you watched it red at in the docstring "
-        "before adding it."
+    assert RED_AT_BASE_REF, (
+        "RED_AT_BASE is non-empty, so it must name the base ref every one of "
+        "its tests was watched to FAIL at. 'Watched red' is a claim about a "
+        "specific tree; without the ref it is not a claim at all."
+    )
+    overlap = RED_AT_BASE & INVARIANT_GUARDS_AND_LEDGERS
+    assert not overlap, (
+        f"tests in BOTH ledgers: {sorted(overlap)}. A test is regression "
+        "coverage or it is an invariant guard; listing it twice makes the "
+        "count of what was watched red unreadable."
     )
     unlisted = here - INVARIANT_GUARDS_AND_LEDGERS - RED_AT_BASE
     assert not unlisted, (

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -45,38 +45,55 @@ was watched red at.
   an entry appearing in BOTH — a test is regression coverage or it is a guard,
   and listing it twice makes the count of what was watched red unreadable.
 
-🔴 THE ROUND-2 FIX MATRIX — one line per finding, per `claude/RULES.md`
------------------------------------------------------------------------
-Each row names the defect, the test that detects it, and the mutant that proves
-that test executes. Every "red at" cell is `abc41024`.
+🔴 THE FIX MATRIX IS `FIX_MATRIX`, NOT THIS DOCSTRING
+------------------------------------------------------
+One row per finding — the defect, the test that detects it, the EVIDENCE for
+that test (a base ref it was watched red at, or `GUARD` when its evidence is the
+mutation battery instead), and the mutants. It is a module-level constant near
+the bottom, graded against the two ledgers by
+`test_the_fix_matrix_evidence_matches_the_two_ledgers`, and that test carries an
+in-module negative control.
 
-  finding                              detector (red at abc41024)      mutant
-  1a ledger measured the OPERATOR'S    ..._ledger_refuses_to_measure_   H1
-     checkout, not the PR              a_checkout_that_is_not_the_pr
-  1b range handed out `..HEAD` from    ..._range_does_not_hand_out_a_   H2
-     the wrong tree                    head_that_is_not_the_prs_head
-  1c --emit-claims stamped the LOCAL   ..._emit_claims_stamps_the_prs_  H3
-     head as the audited sha           head_not_the_local_checkouts
-  2  toolchain gated the SHARED        ..._toolchain_gates_the_         T1, T2
-     checkout                          auditors_copy_not_the_shared_...
-  3  fork PRs inverted the cross-repo  ..._fork_pr_against_this_repo_   C3, P1
-     directive; the FIXTURE agreed     is_not_treated_as_cross_repo
-                                       + ..._prs_repo_is_read_from_the_url
-  4  missing_clauses() unreachable     ..._clause_check_runs_over_a_    K1, K2
-                                       file_that_can_actually_be_lossy
-                                       + ..._out_file_is_read_back...
-  5  five clause rewords INVERTED the  ..._each_clause_carries_the_     W1-W5
-     instruction and stayed green      instruction_its_ledger_...      (+S1)
-  6  a FALSE cause printed for a       ..._failed_cumulative_           L1
-     failed cumulative measurement     measurement_does_not_print_a_...
-  7  --round 1 --emit-claims emitted   ..._emit_claims_prints_a_block_  H4
-     a block parsing to garbage        ..._parser_accepts (rows 2, 3)
-                                       + ..._round_one_block_anchors_...
-  8  the parser dropped four shapes    ..._fence_the_parser_cannot_     B1-B5
-     silently, and truncated wrapped   read_is_reported_not_skipped
-     claims                            + 4 siblings
-  9  "repo cannot be determined"       ..._undeterminable_repo_gets_    P2
-     collapsed into SAME-REPO          its_own_branch_not_the_same...
+🔴 IT USED TO BE A PROSE TABLE HERE, UNDER THE HEADER "detector (red at
+abc41024)" and the sentence "Every 'red at' cell is `abc41024`" — AND THAT WAS
+FALSE FOR ONE ROW. Finding 5's detector,
+`test_each_clause_carries_the_instruction_its_ledger_entry_names`, is GREEN at
+`abc41024` and is not among the 24 that failed there; the constant fifty lines
+below said exactly that, and the table said the opposite. Its real evidence is
+mutants W1-W5, which is arguably stronger than a base ref — only the LABEL was
+wrong, and a reader checking whether that finding had been watched red would
+have read the table and stopped. A table nobody can check acquires this kind of
+error, so the record moved into data and the prose stops here.
+
+🔴 ROUND 3 — a second base, and it is `d9eb36a8`, not `abc41024`
+-----------------------------------------------------------------
+Round 3's audit found defects in the ROUND-2 tree: the delta range was EMPTY BY
+CONSTRUCTION (`audited=` meant `<to>` to the reader and `<to>` to the writer, so
+`<to>..HEAD` had HEAD on both ends), the empty-range reason named two causes
+`head_check` refutes, and three verbatim instruction blocks shipped unpinned
+while three inversions passed a fully green 58-test suite.
+
+`RED_AT_BASE_REFS` maps each base ref to the tests watched red there. Round 3's
+set is measured against `git show d9eb36a8:scripts/audit-dispatch.py` restored
+into a scratch tree with THIS module copied in unchanged, under
+`PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`:
+
+    14 failed, 58 passed         <- 14 node ids, 14 functions
+
+🔴 AND ONLY **NINE** OF THOSE FOURTEEN ARE IN `RED_AT_BASE_R3`. The other five
+fail with `AttributeError: module 'audit_dispatch' has no attribute
+'SECTION_DIRECTIVES'` (four) or `... 'range_anchor'` (one) — they ERROR for
+want of a name the fix introduced, which this module's opening section already
+says is not evidence of anything. Counting them would inflate the regression
+tally with five tests that never reached an assertion, so they are filed as
+guards with the mutation battery as their evidence, and the gap between 14 and
+9 is written down here rather than left for a reader to reconcile.
+
+One of the nine is labelled INSIDE the constant as weaker evidence than the
+rest (it is the does-not-fire-spuriously control for the new banner, so its red
+restates the diff). Round 3's guards are listed in
+`INVARIANT_GUARDS_AND_LEDGERS` with the reason each is a guard and the mutant
+that proves it executes.
 
 🔴 FINDING 3's PRESCRIPTION WAS WRONG ON ONE POINT, and it is recorded because
 the next person will reach for the same field: the audit said to use
@@ -101,24 +118,35 @@ rows that justified adding a pin. Each row there names the EXACT killer set and
 reports WRONG-KILLER (an expected pin did not fire) separately from EXTRA-KILLER
 (the row no longer isolates what it names).
 
-Re-run 2026-08-27 against HEAD of this branch after the round-2 fixes — **39
+Re-run 2026-08-28 against HEAD of this branch after the round-3 fixes — **52
 rows, all as expected** — each mutant applied to a COPY of
 `scripts/audit-dispatch.py` in a scratch tree (never the worktree), under
 `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`, with the unmutated copy as the
 positive control. Every mutant asserted its target string present before
 editing — a mutation that silently fails to apply reports "the guard held",
-which is the most flattering possible wrong answer. (One row did exactly that
-this round: `C3` had been written against the two-state `cross_repo` flag, and
-reported MUTATION DID NOT APPLY the moment that became three-state
-`repo_relation`. It is re-targeted; without that assert it would have scored as
-a guard holding.)
+which is the most flattering possible wrong answer. Two rows have done exactly
+that: `C3`, written against the two-state `cross_repo` flag, and `H2`, whose
+branch became an `elif` when round 3 inserted the degenerate-self-range case
+ahead of it. Both were re-targeted; without that assert each would have scored
+as a guard holding.
 
-The rows below are the pre-existing sixteen. The twenty-three added this round —
-W1-W5 and the SURVIVES control S1, H1-H4, T1-T2, P1-P2, K1-K3, L1, B1-B5 — are
-listed in the harness with their killer sets and are NOT transcribed here; the
-harness is the authority on which rows exist.
+🔴 THE ROUND-3 BATTERY CAUGHT TWO DEFECTS IN THE ROUND-3 TESTS THEMSELVES, and
+they are recorded because both are the shape this file warns about elsewhere:
+  * `N5` (delete the LEDGER's self-range branch) SURVIVED a fully green suite,
+    because the test asserting "EMPTY BY CONSTRUCTION" was reading the WHOLE
+    brief and matching THE RANGE section's banner instead. Two sections saying
+    the same phrase is not two guards. Fixed by slicing the ledger section.
+  * `H3` and `C2` came back EXTRA-KILLER against new rows that had duplicated a
+    neighbouring test's assertion (the `<to>` sha) and had parsed the FIRST
+    `audit-claims` fence in the output rather than the emitted one.
 
-  POS  unmutated copy .............................. 58 passed  <- control
+The rows below are the pre-existing sixteen. The thirty-six added since —
+W1-W5 + S1, H1-H4, T1-T2, P1-P2, K1-K3, L1, B1-B5 in round 2; N1-N8, X1-X3, XA
+and the SURVIVES control XS in round 3 — are listed in the harness with their
+killer sets and are NOT transcribed here; the harness is the authority on which
+rows exist.
+
+  POS  unmutated copy .............................. 72 passed  <- control
 
   D1   delete the `read-only` clause ............... 4 failed
   D3   delete the `stop-rule` clause ............... 4 failed
@@ -439,7 +467,7 @@ def make_runner(
     toplevel=FAKE_REPO_DIR,
     branch="feat/some-branch",
     status=" M scripts/a.py\n?? scripts/b.py\n",
-    rev_list=(0, "4\n", ""),
+    rev_list=None,
     numstat=(0, "10\t2\tscripts/foo.py\n3\t0\tscripts/tests/test_foo.py\n", ""),
     head_sha="deadbee",
     local_head=None,
@@ -452,10 +480,32 @@ def make_runner(
     what it says. Pass a different sha to model the shared checkout having moved
     (which it does, constantly), and `None` explicitly for a PR fixture with no
     `headRefOid`.
+
+    🔴 `rev_list` USED TO BE A CONSTANT `(0, "4\\n", "")`, and that made the
+    DEGENERATE self-range STRUCTURALLY INVISIBLE to this whole module: a fake
+    `git rev-list` that answers "4 commits" whatever range it is asked about
+    cannot model `<sha>..HEAD` where `<sha>` IS HEAD, so no test here could
+    observe the state that shipped in every round-3 brief. The default is now a
+    FUNCTION of the range spec — a self-range counts 0, anything else counts 4 —
+    and every request is recorded on `runner.ranges` so a test can assert WHICH
+    range was measured, not merely that something was.
+
+    Pass a tuple to pin one canned answer (the old behaviour, still used by the
+    read-rule rows), or a callable taking the range spec.
     """
     payload = dict(pr or DEFAULT_PR)
     payload["comments"] = [{"body": c} for c in comments]
     resolved_head = local_head if local_head is not None else payload.get("headRefOid")
+    ranges = []
+
+    def default_rev_list(spec):
+        """0 commits for a self-range, 4 otherwise — what real `git` would say."""
+        left, _, right = spec.partition("..")
+        if right == "HEAD":
+            right = resolved_head or ""
+        if left and right and (right.startswith(left) or left.startswith(right)):
+            return 0, "0\n", ""
+        return 0, "4\n", ""
 
     def runner(cmd, cwd=None):
         if cmd[0] == "gh":
@@ -479,11 +529,18 @@ def make_runner(
             if verb == "status":
                 return 0, status, ""
             if verb == "rev-list":
-                return rev_list
+                spec = cmd[-1]
+                ranges.append(spec)
+                if callable(rev_list):
+                    return rev_list(spec)
+                if rev_list is not None:
+                    return rev_list
+                return default_rev_list(spec)
             if verb == "log":
                 return numstat
         raise AssertionError(f"unexpected command in a hermetic test: {cmd}")
 
+    runner.ranges = ranges
     return runner
 
 
@@ -699,6 +756,157 @@ def test_control_a_clause_deleted_from_the_constant_is_detected(monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
+# 🔴 THE SECTION-DIRECTIVE LEDGER — the SECOND independent whole-string pin.
+# --------------------------------------------------------------------------- #
+# Round 2 made whole-string pinning the standard for auditor instructions and
+# then applied it to `INVARIANT_CLAUSES` ALONE. Three further blocks of
+# verbatim, non-generated instruction prose shipped in every delta brief
+# unpinned, and each of these inversions, applied on its own, left the suite
+# fully green at 58 passed:
+#
+#   render_claims    keep the pinned fragment "never WHY IT IS CORRECT" and
+#                    rewrite the operative sentence to "The fix round already
+#                    verified each of these, so take them as established
+#                    unless something obvious contradicts one."
+#   render_range     delete the whole "Also hunt for regressions this fix round
+#                    itself introduced" instruction
+#   render_checkout  invert "NOT a finding … do not chase it, and do not try to
+#                    restore it" into "a finding worth reporting. Restore
+#                    anything you see move."
+#
+# The first inverts the script's own headline 🔴 rule into the framed audit it
+# documents; the third tells the auditor to WRITE to the shared checkout, two
+# bars before the `no-fetch` clause forbids it. Exactly the W1-W5 shape — the
+# pinned fragment survives and the instruction says the opposite.
+#
+# RESTATED BY HAND, not imported, for the same reason `CLAUSE_LEDGER` is: a
+# ledger derived from the constant it audits deletes from both sides at once.
+DIRECTIVE_LEDGER = {
+    "claims-framing": (
+        "🔴 This is WHAT WAS CLAIMED, never WHY IT IS CORRECT — nothing here is "
+        "established. Three successive FRAMED audits confirmed a claim purely "
+        "because the prompt handed them the answer; one BLIND audit refuted it "
+        "in a single pass. Verify each item against the diff and state, per "
+        "item: **actually fixed / partially / not / made worse**."
+    ),
+    "delta-regressions": (
+        "Also hunt for **regressions this fix round itself introduced** — the "
+        "guard that is now too strict, the branch that is now unreachable, the "
+        "narrowed check that now rejects a legitimate case, the rule reworded "
+        "wider on one axis and narrower on another."
+    ),
+    "checkout-moves": (
+        "🔴 **This checkout is SHARED with other sessions and agents. It MOVES "
+        "UNDER YOU** — the branch can change, files can appear and vanish, and "
+        "commits can land mid-audit. That is expected and is NOT your fault "
+        "and NOT a finding. **Report what you observed moving and carry on; do "
+        "not chase it, and do not try to restore it.**"
+    ),
+}
+
+
+def test_the_section_directive_ledger_is_pinned_two_way():
+    """A directive with no ledger entry, or an entry naming none, fails.
+
+    🔴 INVARIANT GUARD. Its evidence is mutants X1-X3 and XA, not a base ref:
+    `SECTION_DIRECTIVES` does not exist at `d9eb36a8`, so "red at the base"
+    here would only restate that the fix added a constant.
+    """
+    in_script = {d.id for d in ad.SECTION_DIRECTIVES}
+    in_ledger = set(DIRECTIVE_LEDGER)
+    dropped = in_ledger - in_script
+    assert not dropped, (
+        f"\n\nsection directive(s) {sorted(dropped)} are ledgered here but no "
+        "longer exist in SECTION_DIRECTIVES. Each is verbatim auditor "
+        "instruction prose that was MEASURED to be invertible while the suite "
+        "stayed green; deleting one needs its ledger entry deleted in the same "
+        "commit, with the message saying which instruction the brief now lacks."
+    )
+    added = in_script - in_ledger
+    assert not added, (
+        f"\n\nsection directive(s) {sorted(added)} ship in the brief with no "
+        "ledger entry here — an unreviewed instruction riding into every "
+        "future dispatch. Add the WHOLE text to DIRECTIVE_LEDGER."
+    )
+
+
+def test_each_section_directive_carries_the_instruction_its_ledger_entry_names():
+    """WHOLE string, whitespace-normalised — the guard the three inversions beat.
+
+    🔴 INVARIANT GUARD; mutants X1 (claims-framing inverted) and X3
+    (checkout-moves inverted) each kill this test ALONE, with every presence
+    pin still green. XS (a pure re-space) must SURVIVE it.
+    """
+    by_id = {d.id: d.text for d in ad.SECTION_DIRECTIVES}
+    for did, pinned in DIRECTIVE_LEDGER.items():
+        assert did in by_id, f"directive {did!r} is gone; see the two-way pin"
+        assert norm(pinned) == norm(by_id[did]), (
+            f"\n\ndirective {did!r} is not, word for word, what this module "
+            f"pins.\n  pinned here :\n    {norm(pinned)!r}\n"
+            f"  in the script:\n    {norm(by_id[did])!r}\n"
+            "  🔴 A fragment guard on prose is walkable by rewording "
+            "(claude/RULES.md, spelled-guards), and these three were walked: "
+            "each inversion above passed a fully green 58-test suite. "
+            "Whitespace is normalised, so a RE-WRAP is free and only a REWORD "
+            "fails. If the reword is deliberate, update DIRECTIVE_LEDGER in "
+            "the SAME commit — that is the moment to notice you are rewriting "
+            "an instruction rather than reformatting one."
+        )
+
+
+def test_every_section_directive_is_emitted_verbatim_in_the_delta_brief():
+    """POSITIVE CONTROL: the constant is not the artifact, the brief is.
+
+    All three ship in a DELTA brief. Two of them (`claims-framing`,
+    `delta-regressions`) are deliberately absent from a round-1 brief — "this
+    fix round" is meaningless when there has not been one — which is why they
+    are directives owned by their sections rather than invariant clauses.
+    """
+    rc, out, err = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
+    assert rc == 0, err
+    assert len(out) > 3_000, (
+        f"the assembled brief is only {len(out)} chars — every presence "
+        "assertion below would be a claim about nothing."
+    )
+    for directive in ad.SECTION_DIRECTIVES:
+        assert directive.text in out, (
+            f"directive {directive.id!r} is in SECTION_DIRECTIVES but does NOT "
+            "reach the emitted delta brief."
+        )
+    rc, out1, err = run_main(["900"])
+    assert rc == 0, err
+    assert ad.DIRECTIVE["checkout-moves"] in out1, (
+        "the shared-checkout warning is missing from a ROUND-1 brief — that "
+        "one is not delta-specific and the checkout moves under a first audit "
+        "exactly as much"
+    )
+
+
+def test_control_a_directive_deleted_from_the_constant_is_detected(monkeypatch):
+    """NEGATIVE CONTROL, in process: a deletion must be visible in the BRIEF.
+
+    Deleting a directive renders a loud placeholder rather than raising, so
+    that a deletion cannot take every test in the module down with it and score
+    as "killed" for the wrong reason. This proves the placeholder path is real
+    and that the instruction genuinely leaves the brief.
+    """
+    kept = tuple(d for d in ad.SECTION_DIRECTIVES if d.id != "delta-regressions")
+    monkeypatch.setattr(ad, "SECTION_DIRECTIVES", kept)
+    monkeypatch.setattr(ad, "DIRECTIVE", {d.id: d.text for d in kept})
+    rc, out, err = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
+    assert rc == 0, err
+    assert norm(DIRECTIVE_LEDGER["delta-regressions"]) not in norm(out), (
+        "a directive was removed from the constant and its instruction still "
+        "reached the brief — the section is not rendered from the constant, so "
+        "the two-way pin guards nothing"
+    )
+    assert "MISSING VERBATIM BLOCK `delta-regressions`" in out, (
+        "the deletion is SILENT in the brief. A missing instruction that "
+        "leaves no mark is exactly the loss this ledger exists to prevent."
+    )
+
+
+# --------------------------------------------------------------------------- #
 # 🔴 REFUSAL 1 — a delta round with nothing to be framed on
 # --------------------------------------------------------------------------- #
 
@@ -819,8 +1027,19 @@ def test_the_newest_claims_block_wins():
     assert rc == 0, err
     assert "a newer claim" in out
     assert "an older claim" not in out
-    assert "cccc3333..HEAD" in out, (
-        "the range must be anchored at the NEWEST audited tip, not the oldest"
+    # 🔴 The NEWEST BLOCK's `<from>`, not the oldest block's and not that
+    # block's `<to>`. `<to>` (`cccc3333`) is the head round 4's fixes produced
+    # and is where the block was POSTED, so anchoring there is the self-range
+    # defect round 3 fixed — see `range_anchor`.
+    assert "bbbb2222..HEAD" in out, (
+        "the range must be anchored at the newest BLOCK's `<from>` — the tip "
+        "that round's audit read — not at the oldest block, and not at the "
+        "newest block's `<to>`, which is the head it was posted at"
+    )
+    assert "cccc3333..HEAD" not in out, (
+        "the range is anchored at the newest block's `<to>`, which is the head "
+        "the block was posted at: that range is EMPTY BY CONSTRUCTION whenever "
+        "the block sits at the fix tip, which is the normal case"
     )
 
 
@@ -1131,10 +1350,30 @@ def test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout():
 
 
 def test_the_range_is_generated_from_the_previous_rounds_audited_sha():
+    """🔴 REGRESSION. Red at `d9eb36a8`, which anchored on `<to>`.
+
+    `audited=<from>..<to>` records that the round's fix took the tree from
+    `<from>` — the tip that round's AUDIT read — to `<to>`, the head its fixes
+    produced. A delta round therefore reads everything since the
+    previously-audited tip, which is `<from>`.
+
+    Anchoring on `<to>` made the range EMPTY BY CONSTRUCTION, because
+    `--emit-claims` stamps the PR's CURRENT head into that field: the block is
+    posted at the fix tip, so `<to>` IS HEAD. Reproduced live on devrc #958 —
+    the round-2 comment carried `audited=abc41024..d9eb36a8` and `--round 3`
+    rendered ``Diff `d9eb36a8..HEAD` `` with HEAD being `d9eb36a8`.
+    """
     rc, out, err = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
     assert rc == 0, err
-    assert "`bbbb2222..HEAD`" in out, (
-        "the delta range is not anchored at the sha the previous round audited"
+    assert "`aaaa1111..HEAD`" in out, (
+        "\n\nthe delta range is not anchored at the tip the previous round "
+        "AUDITED (`<from>`). The fixture's block is "
+        "`audited=aaaa1111..bbbb2222`."
+    )
+    assert "`bbbb2222..HEAD`" not in out, (
+        "\n\nthe range is anchored at `<to>` — the head the block was posted "
+        "at. Whenever the block sits at the fix tip (the normal case) that "
+        "range is empty, and THE RANGE section prints it with no warning."
     )
 
 
@@ -1192,7 +1431,7 @@ def test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head():
     the_range = out[out.index("## THE RANGE"):out.index("## WHAT WAS CLAIMED")]
     # The INSTRUCTION, not the explanation of why `..HEAD` is unsafe — that
     # sentence necessarily contains the token it is warning about.
-    assert "Diff **`bbbb2222..HEAD`**" not in the_range, (
+    assert "Diff **`aaaa1111..HEAD`**" not in the_range, (
         f"\n\nthe range still tells the auditor to diff `..HEAD` while this "
         f"checkout is on {WRONG_HEAD} and the PR's head is {FAKE_HEAD_OID}:\n"
         f"{the_range}"
@@ -1214,9 +1453,261 @@ def test_the_range_says_head_was_verified_when_it_was():
     rc, out, err = run_main(["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2])
     assert rc == 0, err
     the_range = out[out.index("## THE RANGE"):out.index("## WHAT WAS CLAIMED")]
-    assert "`bbbb2222..HEAD`" in the_range
+    assert "`aaaa1111..HEAD`" in the_range
     assert "COULD NOT VERIFY" not in the_range
+    assert "DEGENERATE RANGE" not in the_range, (
+        "the self-range banner fired on an ordinary, non-degenerate range — "
+        "the anchor `aaaa1111` is not this checkout's HEAD"
+    )
     assert FAKE_HEAD_OID in the_range and "verified at assembly time" in the_range
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 ROUND 3 — `audited=` HAS ONE MEANING AND TWO READERS
+# --------------------------------------------------------------------------- #
+# `<from>` is the tip that round's AUDIT read; `<to>` is the head its FIXES
+# produced. Reading `<to>` as the delta anchor made the range EMPTY BY
+# CONSTRUCTION, because `--emit-claims` stamps the PR's current head into that
+# same field and the block is posted at the fix tip.
+
+# A checkout standing on the sha the round-2 fixture names as its `<from>`, so
+# `<from>..HEAD` is a SELF-RANGE. 40 chars, like real `rev-parse` output —
+# `same_commit` has to bridge the length difference, and a `==` would not.
+SELF_RANGE_HEAD = "aaaa1111000000000000000000000000000000ff"
+SELF_RANGE_PR = dict(DEFAULT_PR, headRefOid=SELF_RANGE_HEAD)
+
+# A PR whose head IS the round-2 fixture's `<to>` — the state the live PR was
+# in when `--round 3 --emit-claims` printed `audited=d9eb36a8..d9eb36a8`.
+AT_FIX_TIP_HEAD = "bbbb2222000000000000000000000000000000ff"
+AT_FIX_TIP_PR = dict(DEFAULT_PR, headRefOid=AT_FIX_TIP_HEAD)
+
+
+def test_the_ledger_measures_from_the_tip_the_previous_round_audited():
+    """🔴 REGRESSION. Red at `d9eb36a8`, which ran `rev-list bbbb2222..HEAD`.
+
+    The strongest form of the anchor claim: not what the brief SAYS, but which
+    range `git` was actually asked about. The ledger and THE RANGE section are
+    separate consumers of the same anchor and were wrong together.
+    """
+    runner = make_runner(comments=[CLAIMS_BLOCK_R2])
+    rc, out, err = run_main(["900", "--round", "3"], runner=runner)
+    assert rc == 0, err
+    assert runner.ranges, (
+        "no `git rev-list` ran at all, so this test proves nothing about which "
+        "range the ledger measures"
+    )
+    assert runner.ranges[0] == "aaaa1111..HEAD", (
+        f"\n\nthe ledger measured {runner.ranges[0]!r}. The fixture's block is "
+        "`audited=aaaa1111..bbbb2222`, so the tip the previous round AUDITED "
+        "is `aaaa1111`; `bbbb2222` is the head that round's fixes produced and "
+        "is where the block was posted."
+    )
+
+
+def test_a_degenerate_self_range_is_reported_not_rendered_as_a_clean_diff():
+    """🔴 REGRESSION. Red at `d9eb36a8`, which rendered it with full confidence.
+
+    THE RANGE section does not consult the ledger, so a `<sha>..HEAD` whose
+    `<sha>` IS HEAD was printed under "verified at assembly time to be PR
+    #958's head commit" followed by "Do not re-audit the whole PR". An auditor
+    obeying that diffs nothing, finds nothing, reports a clean round — and the
+    `stop-rule` clause in the same brief converts that into "the ladder ENDS".
+    Zero claims checked, and the brief reads as covered.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2], pr=SELF_RANGE_PR
+    )
+    assert rc == 0, err
+    the_range = out[out.index("## THE RANGE"):out.index("## WHAT WAS CLAIMED")]
+    assert "DEGENERATE RANGE" in the_range, (
+        f"\n\nthe brief handed out a range whose two ends are the same commit "
+        f"with no warning:\n{the_range}"
+    )
+    assert "EMPTY BY CONSTRUCTION" in the_range
+    assert "verified at assembly time" not in the_range, (
+        "the confident head-verified sentence is still printed over a range "
+        "that cannot contain anything — both were in the live round-3 brief"
+    )
+    # 🔴 The stop-rule interaction is the reason this is 🔴 and not 🟡: the
+    # banner has to say that a finding-free pass here is NOT a clean round.
+    assert "NOT evidence" in the_range and "ladder ENDS" in the_range, (
+        "the banner does not tell the auditor that an empty result here is a "
+        "fact about the RANGE, so the stop-rule clause converts it into a "
+        "clean round anyway"
+    )
+
+
+def test_a_degenerate_self_range_is_named_by_the_ledger_too():
+    """🔴 REGRESSION. Red at `d9eb36a8`: the ledger called it merely EMPTY.
+
+    Two consumers, one hazard. "The range is empty" is a real measurement about
+    the PR; "the range cannot contain anything" is a fact about the range, and
+    the responses differ — the first says wait for the fixes, the second says
+    the `audited=` field or this checkout is wrong.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "3"], comments=[CLAIMS_BLOCK_R2], pr=SELF_RANGE_PR
+    )
+    assert rc == 0, err
+    # 🔴 THE LEDGER SECTION ALONE. Asserting over the whole brief made this
+    # test pass on THE RANGE section's banner instead — mutant N5 (delete the
+    # ledger's self-range branch) SURVIVED a fully green suite until this slice
+    # was added. Two sections saying the same phrase is not two guards.
+    ledger = out[out.index("## THE LEDGER"):]
+    assert "COULD NOT MEASURE" in ledger
+    assert "EMPTY BY CONSTRUCTION" in ledger, (
+        "\n\nthe ledger reported a self-range as an ordinary empty one, which "
+        "sends the operator to wait for commits that would not help"
+    )
+    assert SELF_RANGE_HEAD in ledger, (
+        "the reason does not name the HEAD it collided with, so the operator "
+        "cannot see that the two ends are the same commit"
+    )
+    assert "payload lines changed THIS round" not in ledger
+
+
+def test_an_empty_range_does_not_name_a_cause_the_head_check_refutes():
+    """🔴 REGRESSION. Red at `d9eb36a8`, which named two refuted causes.
+
+    The COULD NOT MEASURE for an empty range said "Either the fixes are not
+    committed yet, or this checkout does not have them" — while `head_check`, a
+    parameter of that same function already required `ok` twelve lines above,
+    proves this checkout IS the PR's head and refutes the second outright. The
+    live round-3 brief printed "verified at assembly time to be PR #958's head
+    commit" and "this checkout does not have them" in one document.
+
+    Same false-cause shape as the cumulative reason fixed in round 2 — that fix
+    was scoped to one site rather than to the class.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "3"],
+        comments=[CLAIMS_BLOCK_R2],
+        rev_list=(0, "0\n", ""),
+    )
+    assert rc == 0, err
+    assert "COULD NOT MEASURE" in out and "is EMPTY" in out
+    assert "this checkout does not have them" not in out, (
+        "\n\nthe brief offered 'this checkout does not have them' as a cause "
+        "for an empty range in a checkout it had just VERIFIED to be the PR's "
+        "head. The reader cannot tell which half to act on."
+    )
+    assert "IS the PR's head" in out, (
+        "the surviving cause is not stated positively, so the reader is left "
+        "with a list rather than an answer"
+    )
+
+
+def test_the_unknown_head_sha_reason_names_one_cause_not_two(tmp_path):
+    """🔴 REGRESSION. Red at `d9eb36a8` — the THIRD site of the same shape.
+
+    Round 2 fixed one false-cause message and round 3's audit found a second;
+    this is the third, found by sweeping the class rather than the two named.
+    `verify_head_is_the_pr` reported "the PR's head sha is not known here
+    (`gh` was not consulted — `--claims-file` mode — or reported no
+    `headRefOid`)" — two causes with nothing to choose between them, in a
+    function whose CALLER is the thing that decided whether to consult `gh` at
+    all.
+    """
+    claims = tmp_path / "claims.md"
+    claims.write_text(CLAIMS_BLOCK_R2, encoding="utf-8")
+    rc, out, err = run_main(
+        ["900", "--round", "3", "--claims-file", str(claims)],
+        pr=dict(DEFAULT_PR, headRefOid=None),
+        local_head=WRONG_HEAD,
+    )
+    assert rc == 0, err
+    the_range = out[out.index("## THE RANGE"):out.index("## WHAT WAS CLAIMED")]
+    assert "COULD NOT VERIFY" in the_range
+    assert "`--claims-file` mode" in the_range, (
+        "the reason does not name the cause that actually applies"
+    )
+    assert "or reported no `headRefOid`" not in the_range, (
+        "\n\nthe reason still offers a second cause the caller had already "
+        "ruled out. A reader cannot tell which half to act on, and one of them "
+        "sends them to check `gh` output that was never fetched."
+    )
+
+
+def test_emit_claims_records_the_tip_this_round_audited_not_the_range_anchor():
+    """The WRITER's anchor is `<to>`, and it is NOT the reader's.
+
+    🔴 INVARIANT GUARD, green at `d9eb36a8` — recorded as such rather than
+    filed with the regressions it sits beside. The base got this right by
+    accident: it used ONE anchor for both sides, and `<to>` happens to be the
+    correct one HERE. It exists because the obvious simplification of the
+    round-3 fix — "one anchor, use `range_anchor` everywhere" — is wrong in the
+    other direction and would ship a block whose `<from>` makes the NEXT round
+    re-audit this round's predecessor as well. Mutant N3 kills it.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "3", "--emit-claims"], comments=[CLAIMS_BLOCK_R2]
+    )
+    assert rc == 0, err
+    # 🔴 `rindex`, not `index`: the EMITTED skeleton is the last fence in the
+    # output, and a brief that reproduces a comment verbatim would otherwise
+    # hand this test the INPUT block to parse. Mutant C2 fired here on `index`
+    # — a killer that says nothing about the anchor this test owns.
+    tail = out[out.rindex("```audit-claims"):]
+    blocks, malformed = ad.parse_claims_blocks([tail])
+    assert not malformed and len(blocks) == 1, f"{malformed}\n{tail}"
+    assert blocks[0].audited_from == "bbbb2222", (
+        f"\n\nthe emitted `<from>` is {blocks[0].audited_from!r}. It must be "
+        "the tip THIS round's audit read — the newest block's `<to>` — not the "
+        "sha this round diffed FROM (`aaaa1111`), which would make the next "
+        "round re-audit the previous round's fix commits as well."
+    )
+    # The `<to>` half is owned by `..._stamps_the_prs_head_not_the_local_...`
+    # and is deliberately NOT re-asserted here: duplicating it made mutant H3
+    # kill this row too, which reads as coverage of the anchor and is not.
+
+
+def test_emit_claims_warns_when_the_block_it_writes_is_a_self_range():
+    """🔴 REGRESSION. Red at `d9eb36a8`, which emitted it in silence.
+
+    Measured on the live PR: `--round 2 --emit-claims` and `--round 3
+    --emit-claims` BOTH printed `audited=d9eb36a8..d9eb36a8` with no warning of
+    any kind. A block like that records a round whose fixes changed nothing,
+    and the next round then anchors a range that is empty by construction.
+    """
+    rc, out, err = run_main(
+        ["900", "--round", "3", "--emit-claims"],
+        comments=[CLAIMS_BLOCK_R2],
+        pr=AT_FIX_TIP_PR,
+        # The LOCAL `rev-parse --short HEAD` is made to agree with the PR's
+        # head here on purpose: the warning must fire because the two ends of
+        # the range are equal, not because of WHICH sha `--emit-claims` reads.
+        # With the two disagreeing, mutant H3 (read the local head) killed this
+        # row as well, and a row that dies for someone else's reason is not
+        # evidence for this one.
+        head_sha="bbbb2222",
+    )
+    assert rc == 0, err
+    assert "SELF-RANGE" in err, (
+        "\n\n`--emit-claims` wrote `audited=bbbb2222..bbbb2222` and said "
+        f"nothing. stderr was:\n{err}"
+    )
+    assert "EMPTY BY CONSTRUCTION" in err and "do not post this block" in err
+
+
+def test_a_bare_round_one_audited_sha_still_anchors_the_next_round():
+    """The round-1 spelling has no `<from>`, and must fall back to `<to>`.
+
+    🔴 INVARIANT GUARD, green at `d9eb36a8` — the bare form was already read
+    correctly there, by the same accident. `--emit-claims` at round 1 writes
+    `audited=<sha>` with no `..`, so a fix that reached for `audited_from`
+    ALONE would leave the round-2 range with no anchor at all, breaking the
+    exact remedy chain the delta refusal advertises. Mutant N2 kills it.
+    """
+    bare_r1 = "```audit-claims round=1 audited=aaaa1111\n1. a round-1 claim\n```"
+    rc, out, err = run_main(["900", "--round", "2"], comments=[bare_r1])
+    assert rc == 0, err
+    assert "`aaaa1111..HEAD`" in out, (
+        "a bare round-1 `audited=<sha>` no longer anchors the round-2 range; "
+        f"stderr was:\n{err}"
+    )
+    assert ad.range_anchor(ad.ClaimsBlock(1, "", "aaaa1111", ["x"])) == "aaaa1111"
+    assert ad.range_anchor(ad.ClaimsBlock(2, "cc", "dd", ["x"])) == "cc"
+    assert ad.emit_anchor(ad.ClaimsBlock(2, "cc", "dd", ["x"])) == "dd"
 
 
 def test_emit_claims_stamps_the_prs_head_not_the_local_checkouts():
@@ -1713,8 +2204,15 @@ def test_a_gh_failure_is_reported_and_not_papered_over():
 # into a scratch tree with this module copied in unchanged, run under
 # `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`: **24 failed, 34 passed**
 # (24 node ids, 21 functions; three of them are parametrised rows of one).
-RED_AT_BASE_REF = "abc41024"
-RED_AT_BASE: frozenset[str] = frozenset({
+#
+# 🔴 THERE ARE NOW TWO BASES, AND ONE SHARED REF WOULD BE A LIE ABOUT BOTH.
+# Round 3's audit found defects in the ROUND-2 tree, so its regression tests
+# were watched red at `d9eb36a8`, not at `abc41024` — where several of them
+# would fail for a different reason entirely (the code they exercise did not
+# exist). "Watched red" is a claim about a SPECIFIC tree, so each set carries
+# its own, and the partition test refuses a set with no ref or a ref with no
+# set.
+RED_AT_BASE_R2: frozenset[str] = frozenset({
     "test_a_fork_pr_against_this_repo_is_not_treated_as_cross_repo",
     "test_the_prs_repo_is_read_from_the_url_not_from_the_head_repo",
     "test_an_undeterminable_repo_gets_its_own_branch_not_the_same_repo_one",
@@ -1753,6 +2251,45 @@ RED_AT_BASE: frozenset[str] = frozenset({
     "test_the_range_says_head_was_verified_when_it_was",
 })
 
+# 🔴 ROUND 3's base is the ROUND-2 TREE. Every entry here was watched to FAIL
+# against `d9eb36a8` by restoring `git show d9eb36a8:scripts/audit-dispatch.py`
+# into a scratch tree with THIS module copied in unchanged, under
+# `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`. The measured counts are in
+# the round-3 section of the module docstring.
+#
+# They are NOT listed under `abc41024`: several exercise code that round 2
+# ADDED (the head check, the read-back), so a red there would be an import-time
+# accident rather than the defect being observed.
+RED_AT_BASE_R3: frozenset[str] = frozenset({
+    "test_the_range_is_generated_from_the_previous_rounds_audited_sha",
+    # Pre-existing, and it MOVED LEDGERS this round: its anchor assertion was
+    # `cccc3333..HEAD` (the newest block's `<to>`), which is the defect. It now
+    # asserts `bbbb2222..HEAD` and observes the wrong answer at `d9eb36a8`.
+    "test_the_newest_claims_block_wins",
+    "test_the_ledger_measures_from_the_tip_the_previous_round_audited",
+    "test_a_degenerate_self_range_is_reported_not_rendered_as_a_clean_diff",
+    "test_a_degenerate_self_range_is_named_by_the_ledger_too",
+    "test_emit_claims_warns_when_the_block_it_writes_is_a_self_range",
+    "test_an_empty_range_does_not_name_a_cause_the_head_check_refutes",
+    "test_the_unknown_head_sha_reason_names_one_cause_not_two",
+    # 🔴 ONE WEAKER ENTRY, said rather than left to assume: this is the
+    # does-not-fire-spuriously control for the degenerate-range banner, and it
+    # is red at `d9eb36a8` because the anchor it asserts (`aaaa1111..HEAD`)
+    # is the FIXED one. Its red is a restatement of the diff, not a defect
+    # observed — the same class as the three flagged under `abc41024`.
+    "test_the_range_says_head_was_verified_when_it_was",
+})
+
+# 🔴 ONE TEST, TWO BASES. `..._range_says_head_was_verified_when_it_was` is red
+# at both refs for two DIFFERENT reasons, so it is listed under both — which is
+# why the per-ref sets may overlap each other even though neither may overlap
+# the guard ledger.
+RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
+    "abc41024": RED_AT_BASE_R2,
+    "d9eb36a8": RED_AT_BASE_R3,
+}
+RED_AT_BASE: frozenset[str] = frozenset().union(*RED_AT_BASE_REFS.values())
+
 INVARIANT_GUARDS_AND_LEDGERS = frozenset({
     "test_the_invariant_clause_ledger_is_pinned_two_way",
     # 🔴 GREEN at `abc41024`, MEASURED — and it is the guard for finding 5, so
@@ -1772,12 +2309,10 @@ INVARIANT_GUARDS_AND_LEDGERS = frozenset({
     "test_the_refusal_fires_for_a_malformed_block_and_says_which_way",
     "test_a_first_round_needs_no_claims_block",
     "test_the_brief_carries_the_claims_and_not_the_reasoning_around_them",
-    "test_the_newest_claims_block_wins",
     "test_cross_repo_tells_the_agent_to_worktree_the_prs_repo_itself",
     "test_same_repo_recommends_the_isolation_flag_and_does_not_hand_roll",
     "test_the_cross_repo_decision_comes_from_the_repos_not_from_prose",
     "test_the_shared_checkout_state_is_reported_with_the_it_moves_warning",
-    "test_the_range_is_generated_from_the_previous_rounds_audited_sha",
     "test_the_ledger_shows_the_files_and_refuses_to_classify_them",
     "test_the_ledger_refuses_a_failed_command_rather_than_printing_zero",
     "test_the_cumulative_figure_is_not_measured_without_a_round_one_anchor",
@@ -1789,7 +2324,234 @@ INVARIANT_GUARDS_AND_LEDGERS = frozenset({
     "test_nothing_here_spawns_a_subprocess",
     "test_a_gh_failure_is_reported_and_not_papered_over",
     "test_the_two_ledgers_partition_this_modules_tests",
+    # ------------------------------------------------------------------- #
+    # Round 3's guards. None is red at `d9eb36a8` and each says why in its
+    # own docstring; their evidence is the mutation battery.
+    # ------------------------------------------------------------------- #
+    # GREEN at `d9eb36a8` by ACCIDENT: the base used one anchor for both the
+    # reader and the writer, and `<to>` happens to be right on the writer's
+    # side. This pins that, so the obvious "one anchor everywhere"
+    # simplification of the round-3 fix goes red. Mutant N3.
+    "test_emit_claims_records_the_tip_this_round_audited_not_the_range_anchor",
+    # The BEHAVIOURAL half is green at `d9eb36a8` — the bare round-1 spelling
+    # was already read correctly there. The test does fail at that ref, but
+    # with `AttributeError: ... no attribute 'range_anchor'` from the unit
+    # assertions at its foot, which is not the defect being observed. Mutant
+    # N2 (drop the bare fallback) is what proves it executes.
+    "test_a_bare_round_one_audited_sha_still_anchors_the_next_round",
+    # 🔴 These four DO fail at `d9eb36a8` — with `AttributeError: module
+    # 'audit_dispatch' has no attribute 'SECTION_DIRECTIVES'`. That is an
+    # error for want of a name the fix introduced, not the defect being
+    # observed, so they are NOT counted as regression coverage. Mutants X1-X3,
+    # XA, and the XS survives-control are their evidence.
+    "test_the_section_directive_ledger_is_pinned_two_way",
+    "test_each_section_directive_carries_the_instruction_its_ledger_entry_names",
+    "test_every_section_directive_is_emitted_verbatim_in_the_delta_brief",
+    "test_control_a_directive_deleted_from_the_constant_is_detected",
+    # Guards over THIS module's own bookkeeping. The mutation battery mutates
+    # the SCRIPT, never this module, so it cannot reach them — their evidence
+    # is the in-module negative control beside each.
+    "test_the_fix_matrix_evidence_matches_the_two_ledgers",
+    "test_control_the_fix_matrix_checker_catches_a_wrong_evidence_label",
 })
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE FIX MATRIX AS DATA — because the prose version carried a FALSE LABEL.
+# --------------------------------------------------------------------------- #
+# Round 2's matrix lived in the module docstring under the column header
+# "detector (red at abc41024)" and the sentence "Every 'red at' cell is
+# `abc41024`". Row 5's detector —
+# `test_each_clause_carries_the_instruction_its_ledger_entry_names` — is GREEN
+# at that ref and is not among the 24 that failed there; the constant fifty
+# lines below said so, and the table said the opposite. Its real evidence is
+# mutants W1-W5, which is arguably stronger; only the LABEL was wrong.
+#
+# A table nobody can check acquires exactly this kind of error, so the matrix
+# is now DATA and the two ledgers are what grade it. Prose may still describe
+# it; prose may no longer be the record.
+#
+#   (finding, detector test name, evidence, mutants)
+#
+# `evidence` is `RED@<ref>` — the test was watched to FAIL at that tree — or
+# `GUARD`, meaning its evidence is the mutation battery and NOT a base ref.
+FIX_MATRIX = (
+    ("r2/1a ledger measured the OPERATOR'S checkout, not the PR",
+     "test_the_ledger_refuses_to_measure_a_checkout_that_is_not_the_pr",
+     "RED@abc41024", "H1"),
+    ("r2/1b range handed out `..HEAD` from the wrong tree",
+     "test_the_range_does_not_hand_out_a_head_that_is_not_the_prs_head",
+     "RED@abc41024", "H2"),
+    ("r2/1c --emit-claims stamped the LOCAL head as the audited sha",
+     "test_emit_claims_stamps_the_prs_head_not_the_local_checkouts",
+     "RED@abc41024", "H3"),
+    ("r2/2  toolchain gated the SHARED checkout",
+     "test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout",
+     "RED@abc41024", "T1, T2"),
+    ("r2/3  fork PRs inverted the cross-repo directive",
+     "test_a_fork_pr_against_this_repo_is_not_treated_as_cross_repo",
+     "RED@abc41024", "C3, P1"),
+    ("r2/3b the PR's repo was read from the HEAD repo",
+     "test_the_prs_repo_is_read_from_the_url_not_from_the_head_repo",
+     "RED@abc41024", "P1"),
+    ("r2/4  missing_clauses() was unreachable",
+     "test_the_clause_check_runs_over_a_file_that_can_actually_be_lossy",
+     "RED@abc41024", "K1"),
+    ("r2/4b the --out file was never read back",
+     "test_the_out_file_is_read_back_and_checked",
+     "RED@abc41024", "K2"),
+    # 🔴 THE ROW THE PROSE TABLE MISLABELLED. Green at `abc41024`, measured.
+    ("r2/5  five clause rewords INVERTED the instruction and stayed green",
+     "test_each_clause_carries_the_instruction_its_ledger_entry_names",
+     "GUARD", "W1-W5, R1"),
+    ("r2/6  a FALSE cause printed for a failed cumulative measurement",
+     "test_a_failed_cumulative_measurement_does_not_print_a_false_cause",
+     "RED@abc41024", "L1"),
+    ("r2/7  --round 1 --emit-claims emitted a block parsing to garbage",
+     "test_emit_claims_prints_a_block_this_scripts_own_parser_accepts",
+     "RED@abc41024", "H4"),
+    ("r2/8  the parser dropped four fence shapes silently",
+     "test_a_fence_the_parser_cannot_read_is_reported_not_skipped",
+     "RED@abc41024", "B1"),
+    ("r2/9  'repo cannot be determined' collapsed into SAME-REPO",
+     "test_an_undeterminable_repo_gets_its_own_branch_not_the_same_repo_one",
+     "RED@abc41024", "P2"),
+
+    ("r3/1a the delta range anchored on `<to>`, so it was empty by construction",
+     "test_the_range_is_generated_from_the_previous_rounds_audited_sha",
+     "RED@d9eb36a8", "N1"),
+    ("r3/1a' the same, over the NEWEST of several blocks",
+     "test_the_newest_claims_block_wins",
+     "RED@d9eb36a8", "N1"),
+    ("r3/1b the LEDGER measured that same wrong range",
+     "test_the_ledger_measures_from_the_tip_the_previous_round_audited",
+     "RED@d9eb36a8", "N1"),
+    ("r3/1c THE RANGE rendered a self-range with full confidence",
+     "test_a_degenerate_self_range_is_reported_not_rendered_as_a_clean_diff",
+     "RED@d9eb36a8", "N4"),
+    ("r3/1d the ledger called a self-range an ordinary empty one",
+     "test_a_degenerate_self_range_is_named_by_the_ledger_too",
+     "RED@d9eb36a8", "N5"),
+    ("r3/1e --emit-claims wrote `X..X` in silence",
+     "test_emit_claims_warns_when_the_block_it_writes_is_a_self_range",
+     "RED@d9eb36a8", "N6"),
+    ("r3/1f the WRITER's anchor must stay `<to>` under the fix",
+     "test_emit_claims_records_the_tip_this_round_audited_not_the_range_anchor",
+     "GUARD", "N3"),
+    ("r3/1g a bare round-1 `audited=<sha>` must still anchor round 2",
+     "test_a_bare_round_one_audited_sha_still_anchors_the_next_round",
+     "GUARD", "N2"),
+    ("r3/2  the empty-range reason named two causes head_check refutes",
+     "test_an_empty_range_does_not_name_a_cause_the_head_check_refutes",
+     "RED@d9eb36a8", "N7"),
+    ("r3/2' the same shape at a THIRD site, found by sweeping the class",
+     "test_the_unknown_head_sha_reason_names_one_cause_not_two",
+     "RED@d9eb36a8", "N8"),
+    ("r3/3  three verbatim instruction blocks shipped unpinned",
+     "test_each_section_directive_carries_the_instruction_its_ledger_entry_names",
+     "GUARD", "X1, X3 (XA, XS controls)"),
+    ("r3/4  a 'watched RED at abc41024' label was wrong",
+     "test_the_fix_matrix_evidence_matches_the_two_ledgers",
+     "GUARD", "its own in-module negative control"),
+)
+
+# A COLLAPSE floor, not a growth floor: a matrix emptied by a bad refactor
+# grades every row correctly and asserts nothing.
+MIN_FIX_MATRIX_ROWS = 20
+
+
+def fix_matrix_problems(rows, red_by_ref, guards, known_tests):
+    """-> a list of complaints. Shared by the guard and its negative control.
+
+    Kept as a function precisely so the control can drive the SAME code with a
+    deliberately wrong row: a checker whose only caller is the happy path is a
+    checker nobody has watched go red.
+    """
+    problems = []
+    for finding, detector, evidence, _mutants in rows:
+        if detector not in known_tests:
+            problems.append(f"{finding}: names no test called {detector!r}")
+            continue
+        if evidence.startswith("RED@"):
+            ref = evidence[len("RED@"):]
+            if ref not in red_by_ref:
+                problems.append(f"{finding}: unknown base ref {ref!r}")
+            elif detector not in red_by_ref[ref]:
+                problems.append(
+                    f"{finding}: claims {detector} was watched RED at {ref}, "
+                    f"but it is not in that ref's RED_AT_BASE set"
+                )
+        elif evidence == "GUARD":
+            if detector not in guards:
+                problems.append(
+                    f"{finding}: labelled GUARD but {detector} is filed as "
+                    "regression coverage"
+                )
+        else:
+            problems.append(f"{finding}: evidence {evidence!r} is neither "
+                            "RED@<ref> nor GUARD")
+    return problems
+
+
+def test_the_fix_matrix_evidence_matches_the_two_ledgers():
+    """🔴 Every detector's EVIDENCE LABEL is graded by the ledgers, not by prose.
+
+    🔴 INVARIANT GUARD. The mutation battery mutates `scripts/audit-dispatch.py`
+    and never this module, so it cannot reach this test; its evidence is
+    `test_control_the_fix_matrix_checker_catches_a_wrong_evidence_label`, which
+    drives the same function with a row that must be rejected.
+
+    This exists because the prose table said `RED@abc41024` for a detector that
+    is GREEN there, fifty lines above a constant that said so. A reader
+    checking whether finding 5 had been watched red would have read the table
+    and stopped.
+    """
+    assert len(FIX_MATRIX) >= MIN_FIX_MATRIX_ROWS, (
+        f"the fix matrix has {len(FIX_MATRIX)} rows (floor "
+        f"{MIN_FIX_MATRIX_ROWS}). A matrix that shrank grades every remaining "
+        "row correctly and asserts nothing about the findings it dropped."
+    )
+    here = {n for n in globals() if n.startswith("test_")}
+    problems = fix_matrix_problems(
+        FIX_MATRIX, RED_AT_BASE_REFS, INVARIANT_GUARDS_AND_LEDGERS, here
+    )
+    assert not problems, (
+        "\n\nthe fix matrix claims evidence the ledgers do not support:\n  "
+        + "\n  ".join(problems)
+        + "\n  A 'watched RED at <sha>' label is a measurement claim. Move the "
+          "row to GUARD, or add the detector to that ref's RED_AT_BASE set "
+          "AFTER watching it fail there."
+    )
+
+
+def test_control_the_fix_matrix_checker_catches_a_wrong_evidence_label():
+    """NEGATIVE CONTROL: the checker above must be able to go red.
+
+    Four deliberately wrong rows, one per rejection path. A checker that
+    returns an empty list for these is wired to nothing, and the guard beside
+    it would pass for any matrix at all.
+    """
+    guards = frozenset({"test_a_guard"})
+    red = {"aaaa1111": frozenset({"test_a_regression"})}
+    known = {"test_a_guard", "test_a_regression"}
+    bad = (
+        ("mislabelled guard", "test_a_guard", "RED@aaaa1111", "-"),
+        ("mislabelled regression", "test_a_regression", "GUARD", "-"),
+        ("unknown ref", "test_a_regression", "RED@ffff9999", "-"),
+        ("nonexistent detector", "test_vanished", "GUARD", "-"),
+        ("nonsense evidence", "test_a_guard", "probably fine", "-"),
+    )
+    problems = fix_matrix_problems(bad, red, guards, known)
+    assert len(problems) == len(bad), (
+        f"the checker reported {len(problems)} problem(s) for {len(bad)} "
+        f"deliberately wrong rows: {problems}"
+    )
+    # And it must NOT fire on correct rows — a checker that rejects everything
+    # is as useless as one that accepts everything.
+    good = (
+        ("ok guard", "test_a_guard", "GUARD", "-"),
+        ("ok regression", "test_a_regression", "RED@aaaa1111", "-"),
+    )
+    assert fix_matrix_problems(good, red, guards, known) == []
 
 
 def test_the_two_ledgers_partition_this_modules_tests():
@@ -1801,11 +2563,16 @@ def test_the_two_ledgers_partition_this_modules_tests():
     growing an unlisted test is asserting coverage nobody checked.
     """
     here = {n for n in globals() if n.startswith("test_")}
-    assert RED_AT_BASE_REF, (
+    assert RED_AT_BASE_REFS, (
         "RED_AT_BASE is non-empty, so it must name the base ref every one of "
         "its tests was watched to FAIL at. 'Watched red' is a claim about a "
         "specific tree; without the ref it is not a claim at all."
     )
+    for ref, names in RED_AT_BASE_REFS.items():
+        assert ref and names, (
+            f"base ref {ref!r} maps to {sorted(names)} — a ref with no tests, "
+            "or a set with no ref, is half a claim. Delete it or fill it in."
+        )
     overlap = RED_AT_BASE & INVARIANT_GUARDS_AND_LEDGERS
     assert not overlap, (
         f"tests in BOTH ledgers: {sorted(overlap)}. A test is regression "

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -2663,6 +2663,11 @@ TIP_PLACEHOLDER_BANNER = "THE TIP OF THAT RANGE IS A PLACEHOLDER, NOT A SHA"
 # is what keeps the two in step.
 TIP_PLACEHOLDER_TEXT = "<the PR's head sha>"
 
+# The `gh pr view … --json headRefOid` command the placeholder banner hands
+# over. Matched up to the closing backtick that ends the inline code span, so
+# a missing `--repo` is visible as an absence in the captured text.
+_HEAD_OID_LOOKUP = re.compile(r"`(gh pr view [^`]*--json headRefOid[^`]*)`")
+
 
 def test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha():
     """🔴 REGRESSION. Red at `706a6b38`, scenario `cross-repo-delta-no-head-sha`.
@@ -2694,7 +2699,7 @@ def test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha():
     branch. A fix scoped to the branch the finding was filed against would
     leave that one unguarded, which is this ladder's most-repeated defect.
     """
-    seen = 0
+    seen = lookups = 0
     for scenario in SCENARIOS:
         brief = brief_for_scenario(scenario)
         if TIP_PLACEHOLDER_TEXT not in brief:
@@ -2712,11 +2717,40 @@ def test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha():
             "PR's head sha outright, in a run whose own reason line says it "
             "never learned that field. One of the two sentences is false."
         )
+        # 🔴 ROUND 12 — AND THE COMMAND IT HANDS OVER MUST NAME A REPOSITORY.
+        # `--repo` used to be dropped whenever the PR's repo was UNKNOWN,
+        # handing over a bare `gh pr view 900 --json headRefOid` that resolves
+        # against the auditor's CWD — in a brief that may have just told them
+        # that is a DIFFERENT repository from the PR's. It returns a sha, at
+        # rc 0, for another project's PR #900. Driven by
+        # `claims-file-assumed-base`, whose payload carries no `url` and so
+        # reaches `REPO_UNKNOWN`.
+        for lookup in _HEAD_OID_LOOKUP.findall(brief):
+            lookups += 1
+            assert "--repo " in lookup, (
+                f"\n\nscenario {scenario!r}: the brief tells the auditor to "
+                f"resolve the tip with `{lookup}` — no `--repo`, so it "
+                "resolves against whatever repository their shell is standing "
+                "in and answers about a DIFFERENT PR of the same number, at "
+                "rc 0. When this run never learned the PR's repository the "
+                "honest hand-over is a `<...>` fill-in, which cannot run "
+                "until the operator supplies it."
+            )
     assert seen, (
         "no scenario renders an unresolved tip, so the loop above asserted "
         "nothing. `cross-repo-delta-no-head-sha` and `delta-no-head-sha` are "
         "what put the placeholder in a brief; if they were dropped or their "
         "`headRefOid` came back, this guard covers nothing."
+    )
+    # 🔴 POSITIVE CONTROL for the `--repo` arm: a regex that matches nothing
+    # reports a clean zero indistinguishable from a brief that never hands the
+    # command over. The number has to have moved.
+    assert lookups, (
+        f"{seen} scenario(s) render an unresolved tip and NONE of them spells "
+        "a `gh pr view … --json headRefOid` command the regex can see, so the "
+        "`--repo` assertion above ran zero times. Either the hand-over stopped "
+        "being rendered or `_HEAD_OID_LOOKUP` no longer matches how it is "
+        "spelled."
     )
     # 🔴 POSITIVE CONTROL for the OTHER side: a scenario with a real tip must
     # still get the confident sentence, or the fix above is "delete the claim"
@@ -3120,7 +3154,29 @@ def scenario_checkout_stands_on_the_pr(name):
 
 
 def test_no_brief_claims_a_verification_its_own_fixture_refutes():
-    """🔴 THE SEAM GUARD, and it is also this module's fixture guard.
+    """🔴 THE SEAM GUARD over the brief's claim and the fixture's own model.
+
+    🔴 ROUND 12 CORRECTED THIS HEADING. It used to read "and it is also this
+    module's fixture guard", which is a coverage claim this test does not
+    support: the assertion and the fake BOTH resolve the checkout's HEAD
+    through `fixture_resolved_head`, so a defect IN that function moves both
+    sides together and this guard cannot see it. Measured — regressing
+    `fixture_resolved_head` to round 8's behaviour (default to the PR's own
+    `headRefOid` regardless of repo) leaves THIS TEST GREEN — 4 failed, 105
+    passed, and this is not one of the four. Coverage is not lost; it lives in
+    those four:
+
+        test_a_cross_repo_range_states_the_impossibility_not_a_moved_checkout
+        test_a_cross_repo_ledger_hands_the_attribution_gate_to_the_auditor
+        test_a_cross_repo_ledger_prints_a_measurement_the_head_check_vouched_for
+        test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha
+
+    `claude/RULES.md` -> guards-narrower: do not leave a description wider
+    than the code.
+
+    What it DOES pin is the relationship below — the brief's "verified at
+    assembly time" sentence against the scenario's modelled `rev-parse HEAD`,
+    in any scenario this module knows or later adds.
 
     🔴 INVARIANT GUARD; its evidence is mutant V9, not a base ref. At
     `28492af2` the SCRIPT would pass this — the sentence it forbids appears

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -652,6 +652,31 @@ SKILL_CROSS_REPO_WORKTREE = (
     "for a PR in another repo have the agent run `git -C <that-repo> worktree "
     "add …` itself."
 )
+# 🔴 THE ROUTER TO THE ASSEMBLER. `scripts/audit-dispatch.py` exists because the
+# invariant sections of a brief were being retyped every time and MEASURABLY
+# lost: over one session's 14 dispatches, "do NOT git fetch" appeared in 5,
+# "a clean round ending is correct" in 6, and the payload/scaffolding label in
+# 10 — and the auditor at dispatch 8 fetched in a repo the brief had called
+# read-only, because the clause first appears at dispatch 9.
+#
+# A `flows/`-style tool that nothing NAMES does not fire, so the router line is
+# the whole delivery mechanism and deleting it costs the tool. Pinned WHOLE,
+# including the refusal clause: a router that survives while "REFUSED" is
+# reworded to "warns" describes a different tool — the silent downgrade of a
+# delta re-audit into a blind full audit is precisely what the refusal exists to
+# prevent, and a reader who believes it warns will not check.
+#
+# The path is the `~/workspace/devrc/...` form every other skill uses, for the
+# reason test_doc_path_rot.py records: a skill is read with the cwd in some
+# unrelated project, where a bare `scripts/x.py` resolves to nothing.
+SKILL_ASSEMBLER_ROUTER = (
+    "🔴 **Assemble the brief with "
+    "`~/workspace/devrc/scripts/audit-dispatch.py <pr> [--round N]`** — it "
+    "generates the range, the cross-repo worktree directive, checkout state "
+    "and toolchain, reads the prior round's claims from the fenced "
+    "`audit-claims` block ONLY, and carries the invariant clauses verbatim. "
+    "**A delta round with no parseable block is REFUSED.**"
+)
 SKILL_ENVIRONMENT_BRIEF = (
     "**Brief the auditor on the environment, or it will report false findings** "
     "— a fresh worktree is not a working checkout, and an auditor hitting this "
@@ -1104,6 +1129,9 @@ def test_the_operator_instructions_the_gate_depends_on_are_pinned():
     )
     _assert_pinned_once(
         SKILL_MD, SKILL_CROSS_REPO_WORKTREE, "the cross-repo worktree hazard"
+    )
+    _assert_pinned_once(
+        SKILL_MD, SKILL_ASSEMBLER_ROUTER, "the audit-dispatch.py router"
     )
 
 


### PR DESCRIPTION
## Why

`/audit-pr` says "dispatch a subagent … against this checklist" and supplies **no procedure**, so the brief was reassembled from prose every time. Measured over one session's **14 audit dispatches**:

- **60,100 characters** of brief hand-written (mean 4,292 each)
- **42%** mean similarity between consecutive briefs; **zero** lines >25 chars identical across all 14
- hard-won clauses **accreted** rather than being present from the start, and three were **LOST after being learned**:

```
instruction                      present in dispatch #
                                 1  2  3  4  5  6  7  8  9 10 11 12 13 14
do NOT git fetch            5/14 ·  ·  ·  ·  ·  ·  ·  ·  ✓  ✓  ·  ✓  ✓  ✓
shared checkout warning     9/14 ·  ·  ·  ·  ·  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓
'ending it is CORRECT'      6/14 ·  ·  ·  ·  ·  ·  ·  ✓  ✓  ✓  ·  ✓  ✓  ✓
'a nit is not a finding'    9/14 ·  ·  ·  ·  ✓  ✓  ✓  ✓  ✓  ✓  ·  ✓  ✓  ✓
bare pytest = wrong shell  10/14 ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ·  ✓  ·  ·  ·
payload/scaffolding label  10/14 ·  ·  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ·  ·  ✓  ✓
sandbox tier named         11/14 ·  ·  ✓  ✓  ✓  ✓  ✓  ✓  ✓  ·  ✓  ✓  ✓  ✓
```

What actually followed: the auditor at dispatch 8 ran `git fetch` in a repo the brief had called read-only (the clause first appears at 9); the first five auditors reported the shared checkout moving as if it might be their fault; the seven rounds before dispatch 8 ran under a stop rule that never said stopping was the correct outcome.

## What this adds

`scripts/audit-dispatch.py <pr> [--round N] [--repo owner/name] [--out FILE] [--emit-claims]` prints a brief to stdout. **It dispatches nothing and writes nothing to the repo under audit.**

**Generated per invocation** — the parts a human gets wrong:

| fact | how |
|---|---|
| the range | `<previously-audited-sha>..HEAD`, from the prior round's claims block |
| 🔴 cross-repo | the PR's repo vs the cwd's repo decides whether the brief says `git -C <clone> worktree add` **or** `isolation: "worktree"`. That flag worktrees the CWD's repo; for a PR elsewhere it is the wrong tree and it fails quietly |
| shared checkout | branch, dirty-path count, and "it moves under you; report it, don't chase it" |
| toolchain | `nix develop … pytest -p no:cacheprovider`, the `No module named pytest` = wrong-shell diagnosis, `gate.sh --tier both`, and the **sandbox tier named as the one the merge actually gates on** |
| ledger | the skill's own `git log --numstat --format= --remerge-diff <prev>..HEAD --not <base>` |

**Verbatim, from one module-level constant** (`INVARIANT_CLAUSES`): READ-ONLY + `rm -f <copy>/.git`; no `git fetch` in the shared checkout; the stop rule *including* "ending it is the CORRECT outcome, not a failure"; "a nit that changes nothing a reader does is NOT a finding"; re-verify the fix commit's self-reported numbers; `file:line` + a concrete failure scenario + a `payload`/`scaffolding` label; do not merge — report only.

The nine-item checklist is **read from `SKILL.md`, never restated** — one rule, one place; that block has already been silently shaved once under a commit message claiming the opposite.

## Two refusals, deliberately different in severity

1. 🔴 **`--round N` (N≥2) with no parseable claims block REFUSES** (exit 2) and names what it looked for, where it looked, what it found, and how to produce one. An empty "what was claimed fixed" section silently turns a delta re-audit into a **blind full audit** — a different thing that would then read as covered. Same shape as `ladder-depth-sweep.py`'s refused zero.
2. **A brief missing an invariant clause WARNS and never blocks.** It exists for a hand-edited `--out` file; `claude/RULES.md` is explicit that a permanently-red gate trains everyone to click through.

## The framing constraint

A delta round is framed on **what was claimed fixed**, never **why it is correct** — three framed audits confirmed a claim the prompt handed them; one blind audit refuted it in a single pass. PR comments carry both, so only the fenced block is read:

````
```audit-claims round=3 audited=997375ec..9f638fd4
1. run_move collapsed WRONG-KILLER into NOT EXCLUSIVE — now two branches
2. the "97% / most" quantifier over-stated what the measurement supports
```
````

`--emit-claims` prints a skeleton the parser accepts (round-tripped by a test, so it cannot drift into a shape the next round refuses).

## The ledger does NOT classify

It enforces the skill's read rules — **rc 0, silent stderr, non-empty range** — and prints `COULD NOT MEASURE` with **no number** otherwise. It shows the changed-file list and leaves `X` for a human: the classification is a human judgement, and a pathspec is wrong in both directions on ordinary names (`':!*test*'` swallows `attestation/`, `latest/`, `inspector/`; keeps `FooTest.java`, `login.cy.ts`). It **does not fetch** — that would be the same write the brief forbids — and says so, so a stale `<base>` is visible rather than silent.

## Tests

`scripts/tests/test_audit_dispatch.py` — **37, hermetic.** The `gh`/`git` seam is injected and `test_nothing_here_spawns_a_subprocess` proves it by making `subprocess.run` raise for a full `main()` run.

The clause list is pinned **two-way** against an independent ledger in the test module (ids restated by hand — deriving them from the constant would make the whole comparison vacuous), *and* against the **rendered** section, so neither a deletion nor a renderer that stops reading the constant passes.

`scripts/tests/mutants-audit-dispatch.py` is the **committed** negative-control battery — kept in the tree for the reason `mutants-audit-ladder.sh` records: #900's ~30 mutants lived in a scratchpad nobody could re-run. Each row names its **exact** killer set and reports WRONG-KILLER separately from EXTRA-KILLER.

## SKILL.md

Router line added and pinned whole in `test_audit_ladder_stop_rule.py` (11 tests, unchanged count), with a mutant row in `mutants-audit-ladder.sh` that **inverts the refusal into a warning** rather than deleting the line — the reading a reader would accept, describing a different tool.

The body went 81 B over budget with the line added, so the high-yield change-class **anecdotes** were demoted to `reference/round-ladder-evidence.md`. The **class list** — which is what decides whether to audit at all — stays in the body. `skill-audit.py`: within budget, references intact.
