### PR TITLE
fix(clawgatectl): vendorHash drifted — home-manager switch failed on workbench

### DIFF
--- a/nix/pkgs/tools/clawgatectl.nix
+++ b/nix/pkgs/tools/clawgatectl.nix
@@ -133,7 +133,7 @@ let
     # MEASURED by building with a deliberately wrong hash and taking the "got:"
     # value from the failure. Do not hand-edit: change go.mod/go.sum and this
     # must be re-derived the same way.
-    vendorHash = "sha256-vJk2z5piIye+YwhsiyHqhUgXzHd6bHsr1kWH7PqUX7k=";
+    vendorHash = "sha256-T2rgqEv5MEWXkOaAHNWpxEUY/Z60x7lGS/lyWWxNhPg=";
 
     # Only the CLI. The module also contains the clawgate SERVER, which pulls in
     # helm and client-go and has no business being built on a laptop.


### PR DESCRIPTION
fix(clawgatectl): vendorHash drifted — home-manager switch failed on workbench

`home-manager switch` failed on the workbench with a fixed-output hash mismatch
for clawgatectl-0.8.6-go-modules:

  specified: sha256-vJk2z5piIye+YwhsiyHqhUgXzHd6bHsr1kWH7PqUX7k=
  got:       sha256-T2rgqEv5MEWXkOaAHNWpxEUY/Z60x7lGS/lyWWxNhPg=

Updated to the observed value. Checked before accepting it, rather than pasting
the hash reflexively:

  - containers/clawgate/go.mod and go.sum are UNCHANGED since bc928dd6, long
    before the clawgate work that triggered this rebuild. The dependency SET did
    not move, and go.sum still pins every module's contents cryptographically —
    vendorHash is nix's cache key over that fetch, not the security boundary.
  - src is cleanSource(containers/clawgate) only, so the untracked go.mod sitting
    in the homelab-talos repo ROOT is not a build input and cannot explain it.
  - the laptop switched fine on the same devrc commit, which is consistent with
    the pathExists guard: a host without ~/workspace/homelab-talos never builds
    this package at all.

Verified after the switch: clawgatectl 0.8.6 on PATH, matching the live server
0.8.6, the skew note silent, and `agent task --help` rendering the corrected
guidance.

⚠ Also worth recording: a bare `home-manager switch --impure` (no --flake) fails
with `attribute 'isNixOS' missing`, because that attribute is supplied by
extraSpecialArgs in flake.nix's homeConfigurations."zach". Use
`home-manager switch --flake ~/workspace/devrc#zach --impure`, or scripts/ship.sh.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
