### PR TITLE
docs(resume,handoff): `--repo` takes a PATH, and the placeholder said `<repo>`

### DIFF
--- a/claude/skills/handoff/SKILL.md
+++ b/claude/skills/handoff/SKILL.md
@@ -63,7 +63,7 @@ Topic argument (optional): `$ARGUMENTS`. If empty, infer a short kebab-case topi
 
    ## Run this first — the index, one read-only command
    ```bash
-   python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py --repo <repo>
+   python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py --repo <path>
    ```
    Terse pointers this doc does not carry, curated by past sessions and outliving it.
    🔴 RECALL, NOT LIVE OBSERVATION — every line is a pointer to VERIFY, never a current

--- a/claude/skills/resume/SKILL.md
+++ b/claude/skills/resume/SKILL.md
@@ -61,8 +61,19 @@ Topic argument (optional): `$ARGUMENTS`.
 4. **Surface what the subsystem index already records for this repo** (read-only, ~1 command, no network):
 
    ```bash
-   python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py --repo <repo>
+   python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py --repo <path>
    ```
+
+   🔴 **`--repo` takes a PATH, not a repo name.** A bare name is resolved against your
+   **cwd**, so `--repo datapacket-talos` becomes `$PWD/datapacket-talos` and the run
+   **exits 3** with a raw `git ... cannot change to` error. Pass an absolute path or one
+   of the pre-exported handles (`$DEVRC`, `$HOMELAB`, `$DATAPACKET`, `$CIVITAI`), or use
+   **`--scope <name>`**, which names the store directory directly and skips git
+   derivation entirely. MEASURED 2026-08-28: a session following this block verbatim with
+   a bare name got the exit-3 and had to recover to `--scope`. That matters more here than
+   it looks — this command is the store's ONLY read surface, and the store spent its early
+   life with two writers and no reader; a prescribed command that errors sends it straight
+   back to unread.
 
    This is the **read half** of the store `/analyze-service` and `/handoff` write to — the terse pointer sheet that *outlives the handoff doc you just read*. It had two writers and no reader, so nothing ever opened it at resume time.
 


### PR DESCRIPTION
## The failure

A session followed the `/handoff` and `/resume` "Run this first" block verbatim, substituting a repo **name** for the `<repo>` placeholder:

```
$ subsystem_recall.py --repo datapacket-talos
subsystem-recall: git command failed (git -C /tmp/datapacket-talos rev-parse
  --path-format=absolute --git-common-dir): exit 128: fatal: cannot change to
  '/tmp/datapacket-talos': No such file or directory
```

**exit 3, zero stdout** — measured unpiped, so that is the tool's own status and not a pipeline's. `--repo` is resolved against the cwd, so a bare name becomes `$PWD/<name>`.

**The tool is not at fault.** It fails loudly and correctly. The placeholder `<repo>` is what invited a name where a path was required.

## Why it matters more than a typo

This command is the subsystem store's **only read surface**, and `resume/SKILL.md` itself records that the store spent its early life with *"two writers and no reader, so nothing ever opened it at resume time."* A prescribed first command that errors is exactly how it returns to unread. The recovery (`--scope <name>`, which names the store directory directly and skips git derivation) is not discoverable from a raw `cannot change to` git error.

## The change

- **`handoff/SKILL.md`** — `<repo>` → `<path>`. **Byte-neutral by construction** (both placeholders are 6 chars). That is load-bearing here: the file is at **23,097 bytes against an enforced budget of 23,100** — three bytes of headroom — so a net-positive edit would have needed an eviction in the same commit.
- **`resume/SKILL.md`** — the same swap plus the explanation, the pre-exported handles (`$DEVRC` / `$HOMELAB` / `$DATAPACKET` / `$CIVITAI`) and the `--scope` alternative. No ceiling on this file, so the prose lives here.

## Deliberately not fixed

The **error message** should name the likely mistake and both fixes rather than surfacing git's `cannot change to`. That is a change to `scripts/lib/subsystem_recall.py`, which **#963 is currently modifying and is under adversarial audit** — touching it now would collide. Queued to land on top of #963.

## Tests

`test_handoff_skill_size.py`, `test_skill_audit.py`, `test_doc_path_rot.py`, `test_skill_descriptions.py`, `test_skill_tiers.py` — **264 passed**, dev-host tier via `nix develop … -c python3 -m pytest`. The sandbox tier Tekton gates on runs on this PR.