### PR TITLE
docs(browser-bridge): register vetr.com site notes (verified, with the drive lane walked back)

### DIFF
--- a/scripts/browser-bridge/reference/css-hit-test.md
+++ b/scripts/browser-bridge/reference/css-hit-test.md
@@ -68,6 +68,22 @@ $BB --instance work js '(function(){
 
 Any `insidePop:false` is the bug, and `hit` is the culprit.
 
+🔴 **`elementFromPoint` returns `null` for a point OUTSIDE the viewport — which is
+indistinguishable from "something is covering it".** Read `null` as *unknown*,
+never as *covered*: it is how a hit-test invents a blocking overlay that does not
+exist. Off-canvas drawers and mobile menus are the common source, and they sit at
+NEGATIVE coordinates (measured on one app: a nav control centred at `x = -249`).
+So **filter to in-viewport centres before hit-testing**, and say how many
+candidates you dropped:
+
+```js
+const cx = r.left + r.width/2, cy = r.top + r.height/2;
+if (cx < 0 || cy < 0 || cx > innerWidth || cy > innerHeight) return "off-viewport";
+```
+
+Corollary: a zero-size rect (`width` or `height` === 0) also has no meaningful
+centre — drop those first too.
+
 **3. Walk the ancestors for the first stacking-context creator.** The offender is
 almost never the element you're staring at. Check each ancestor's computed
 `transform`, `filter`, `opacity` (<1), `isolation`, `will-change`, `contain`, and

--- a/scripts/browser-bridge/reference/css-hit-test.md
+++ b/scripts/browser-bridge/reference/css-hit-test.md
@@ -54,35 +54,32 @@ the covering element instead of guessing — in the real case it returned the *n
 card's NSFW-reveal `<button>`, which reading the popover's own CSS would never
 have suggested.
 
+🔴 **`elementFromPoint` returns `null` for a point OUTSIDE the viewport — which is
+indistinguishable from "something is covering it".** Read `null` as *unknown*,
+never as *covered*: it is how a hit-test invents a blocking overlay that does not
+exist. Off-canvas drawers and mobile menus are the common source, and they sit at
+NEGATIVE coordinates (measured on one app: a nav control centred at `x = -249`). A
+zero-size rect has no meaningful centre either. So the probe **skips** both cases
+and labels them, rather than folding them in with the covered points:
+
 ```bash
 $BB --instance work js '(function(){
   const el = document.querySelector(".cm-updated-pop");
   const r  = el.getBoundingClientRect();
+  if (r.width <= 0 || r.height <= 0) return "zero-size rect — nothing to hit-test";
+  const inVp = (x,y) => x >= 0 && y >= 0 && x < innerWidth && y < innerHeight;
   const pts = [[r.left+8, r.top+8], [r.left+r.width/2, r.top+r.height/2], [r.right-8, r.bottom-8]];
   return JSON.stringify(pts.map(([x,y]) => {
+    if (!inVp(x,y)) return {x, y, skipped: "off-viewport"};
     const hit = document.elementFromPoint(x, y);
     return {x, y, hit: hit && hit.className, insidePop: !!hit && el.contains(hit)};
   }));
 })()'
 ```
 
-Any `insidePop:false` is the bug, and `hit` is the culprit.
-
-🔴 **`elementFromPoint` returns `null` for a point OUTSIDE the viewport — which is
-indistinguishable from "something is covering it".** Read `null` as *unknown*,
-never as *covered*: it is how a hit-test invents a blocking overlay that does not
-exist. Off-canvas drawers and mobile menus are the common source, and they sit at
-NEGATIVE coordinates (measured on one app: a nav control centred at `x = -249`).
-So **filter to in-viewport centres before hit-testing**, and say how many
-candidates you dropped:
-
-```js
-const cx = r.left + r.width/2, cy = r.top + r.height/2;
-if (cx < 0 || cy < 0 || cx > innerWidth || cy > innerHeight) return "off-viewport";
-```
-
-Corollary: a zero-size rect (`width` or `height` === 0) also has no meaningful
-centre — drop those first too.
+Any `insidePop:false` is the bug, and `hit` is the culprit. A `skipped` point is
+**not** evidence either way — if every point is skipped you have measured nothing,
+so say so instead of reporting "not covered".
 
 **3. Walk the ancestors for the first stacking-context creator.** The offender is
 almost never the element you're staring at. Check each ancestor's computed

--- a/scripts/browser-bridge/reference/sites/_index.json
+++ b/scripts/browser-bridge/reference/sites/_index.json
@@ -13,6 +13,7 @@
   ],
   "sites": {
     "civit.ai": "civit.ai.md",
-    "civitai.com": "civitai.com.md"
+    "civitai.com": "civitai.com.md",
+    "vetr.com": "vetr.com.md"
   }
 }

--- a/scripts/browser-bridge/reference/sites/vetr.com.md
+++ b/scripts/browser-bridge/reference/sites/vetr.com.md
@@ -69,8 +69,9 @@ environment into the API's `.env` **verbatim, with no test-mode assertion**. Pro
 runs `sk_live`/`pk_live`, and Lane A is the lane where you are told to click
 Book. So on the stripe rail, **export the test keys first** —
 `~/.config/vetr/stripe-test.env` (`pk_test`/`sk_test`/`whsec`) — and never run it
-with a live key in the shell. Keyless works for every non-payment flow (the API
-falls back to a placeholder secret).
+with a live key in the shell. Keyless works for every non-payment flow — the key
+is simply left **empty** (`vetr-api/config/services.php` has no default), and the
+payment/pool-loop specs self-skip.
 
 🔴 **You must mint your own token — the script does NOT give you one.** It
 captures `e2e:mint-tokens`, validates the JSON with `jq empty` and **discards
@@ -81,12 +82,20 @@ below has no input. Mint one yourself — there is no system PHP on NixOS, so
 borrow the one the script already built:
 
 ```bash
-PHP=$(ls /nix/store/*vetr-e2e-tools*/bin/php | head -1)
-(cd ~/workspace/scratch/vetr/vetr-api && "$PHP" artisan e2e:mint-tokens)   # → JSON
+# /tmp/vetr-e2e-tools is the script's own -o output link (e2e-hermetic-nixos.sh:126,139).
+# Use it, NOT a /nix/store glob: the glob's lexicographic winner is an arbitrary
+# PAST build (measured: 8.4.19 vs the live 8.4.24) and, unlike this link, is not a
+# GC root. Requires the KEEP_UP stack to be up — it needs the .env the script wrote.
+(cd ~/workspace/scratch/vetr/vetr-api && /tmp/vetr-e2e-tools/bin/php artisan e2e:mint-tokens)
 ```
 
-Re-minting is safe: `--seed` is opt-in (`vetr-api/app/Console/Commands/E2EMintTokens.php`),
-so a bare run issues fresh tokens without touching the seeded data.
+🔴 **Re-minting REVOKES the token already in your tab.** `E2EMintTokens.php:77`
+does `$user->tokens()->where('name','e2e')->delete()` for every fixture before
+issuing new ones — so the tab you seeded goes 401 and reads logged-OUT, which this
+file elsewhere teaches you to read as a seeding-order mistake. **Re-seed after
+every mint.** (`--seed` *is* opt-in, so a bare run leaves seeded rows alone — but
+it is not otherwise inert: it also touches Stripe/CIM to provision the saved card,
+`:112-138`.)
 
 ## 🔴 The auth seed — and why Playwright's version does NOT transfer
 
@@ -210,12 +219,36 @@ still stalled); **not the seeded keys**; **not the token**; **not GTM/Brave
 Shields** (`TagManager.initialize` is try/caught non-fatal, `root.tsx:288`);
 **not the error boundary** (it renders a visible "Oops!", `root.tsx:400`).
 
-⚠ **Do NOT reuse the earlier claim that the brand splash rules this out.** An
-earlier revision of this file argued "not the splash, it renders the literal text
-'Vetr'". That was **wrong and self-defeating**: the `~2s` dark "Vetr" splash was
-*replaced* by the textless skeleton above (`root.tsx:378-384` says so), and the
-served `index.html` contains "Vetr" only in its `<title>`. Stalled hydration is
-the live hypothesis, not an excluded one.
+### 🔴 vetr has TWO full-screen boot overlays. Tell them apart by TEXT.
+
+Conflating these produced two wrong findings in a row, in opposite directions.
+
+| | `HydrateFallback` | brand `Splash` |
+|---|---|---|
+| where | `vetr-app/app/root.tsx:377-398` | `app/components/splash.tsx:105-118`, mounted via `components/GeneralComponents.tsx:1,10` |
+| identify by | `[data-testid=app-boot-skeleton]` | `[data-testid=brand-splash]` |
+| text | **none** (`aria-hidden`) | renders **"Vetr"** as `<span>` per letter |
+| when | before the JS bundle executes | **after** hydration, first visit per tab (`sessionStorage.splashSeen`) |
+| holds for | until hydration | `minimumVisibleTime` **2000ms**, and on a non-landing route until `navigation.state === "idle" && isFetching === 0` (`splash.tsx:60-62`) |
+| blocks clicks | it *is* the page | no — `pointer-events-none`, but `z-[9999]` and opaque |
+
+🔴 **The brand `Splash` is LIVE — do not read anywhere that it was removed.** An
+earlier revision of this file claimed it "was *replaced* by" the skeleton, citing
+`root.tsx:378-384`. **That is false.** That comment says the pre-hydration paint
+*used to be blank, which read as* a ~2s dark "Vetr" splash — it is about the
+**blank**, not about `splash.tsx`, which is still imported and still rendered. The
+built `index.html` also contains "Vetr" **twice** (`<title>` and
+`apple-mobile-web-app-title`), neither of them rendered text.
+
+This matters operationally because **the remedy above is "open a fresh tab"** —
+and a fresh tab is exactly the case that gets the brand splash: an opaque
+full-viewport dark overlay for ≥2s that, on an authed route, additionally waits
+for **every in-flight query**. That is the state most easily mistaken for a stall.
+
+So, precisely: a read with **zero `innerText`** does rule the brand splash out —
+splash renders text. What it does **not** rule out is stalled hydration, because
+`HydrateFallback` is textless too. Two different textless-vs-texted states; check
+for both by `data-testid`, never by emptiness.
 
 🔴 **So: if a vetr route reads blank, `close` the tab and `open` a fresh one
 BEFORE forming any theory.** Why a reused tab reaches that state is a
@@ -230,10 +263,12 @@ up where it belongs, in `reference/css-hit-test.md`.
 
 - **`innerText` needs layout**; a backgrounded/occluded tab returns `""` for a
   page that is rendering fine. Use `textContent` for "is anything in the DOM",
-  and a **`screenshot` for what state it is in** — the screenshot is the only
-  thing that separated "pre-hydration skeleton" from "mounted but data-less".
-- **A button/link count of 0 means nothing.** The chooser renders three role
-  cards and still counted 0 `button,a`.
+  and a **`screenshot`** when you need to see which state it is in. (Cheaper and
+  deterministic for the boot states specifically: query the two `data-testid`s in
+  the table above.)
+- **A button/link count of 0 means nothing** — a pre-hydration skeleton has no
+  text *and* no controls, by construction. Measured: the chooser renders three
+  role cards and still counted 0 `button,a`.
 - **`elementFromPoint` returns `null` for an off-viewport point**, which reads
   identically to "covered by an overlay". vetr renders an off-canvas menu at
   negative x, so its controls sit at e.g. `x = -249`. **Filter to in-viewport
@@ -245,13 +280,17 @@ up where it belongs, in `reference/css-hit-test.md`.
 - **A returned Promise is not awaited.** An `async` expression comes back empty,
   with no error — consistent with `SKILL.md`'s "evaluates ONE EXPRESSION". Use one
   self-contained *synchronous* expression, or `curl` the API directly.
-- ⚠ **`window` state did not survive between two consecutive `js` calls** on the
-  same page (`window.__x = …`, then reading it back returned nothing). **This is
-  UNEXPLAINED and it contradicts the mechanism docs** — `reference/spa-wake.md`
-  states `js`/`eval` is **MAIN** world "by definition" (the ISOLATED-world note in
-  the CLI header is about `text`/`html`, not `js`). So do not conclude "isolated
-  world" from this, and do not rely on cross-call globals either. If you need the
-  mechanism, resolve it in `spa-wake.md` — not here.
+- ⚠ **`window` state may not survive between two consecutive `js` calls.**
+  Observed here (`window.__x = …`, then reading it back returned nothing).
+  🔴 **Check whether your call used `--frame` first — that IS the answer:**
+  `--frame` eval runs `Page.createIsolatedWorld` and gets a **brand-new isolated
+  world on every call** (`extension/service_worker.js:539-542`), so page globals
+  are invisible and cross-call state is gone by design. This file tells you to use
+  `--frame` for the authnet hosted-CIM iframe, so it is the likely case. Without
+  `--frame`, `js` is **MAIN** world (`service_worker.js:864-871` default,
+  `:841-846` under `--wake`) and the disappearance is **unexplained** — either way,
+  do not rely on cross-call globals. Note the ISOLATED-world line in the CLI header
+  is about `text`/`html`, not `js`.
 
 ## Other traps
 

--- a/scripts/browser-bridge/reference/sites/vetr.com.md
+++ b/scripts/browser-bridge/reference/sites/vetr.com.md
@@ -102,14 +102,13 @@ $BB --instance <key> --tab $TAB nav http://127.0.0.1:5174/user --wake
 because the boot that mattered already happened. That failure looks exactly like
 a bad token.
 
-**Measured 2026-08-27 against the hermetic stack, laptop, Brave profile `work`:**
-the seed half of this works. Before the seed, `/user` issues only `/api/config`;
-after the seed + second `nav` the app issues `/api/auth/me` and renders the
-**authed dashboard skeleton** rather than redirecting to auth. The token was
-independently confirmed valid (`/api/auth/me` → `E2E Owner`, id 1, tz `UTC`).
-
-🔴 **But see "the render problem" below — the seed authenticating is NOT the same
-as the page becoming drivable, and in that run it did not.**
+**Verified end-to-end 2026-08-27, hermetic stack, laptop, Brave profile `work`:**
+on a fresh tab the recipe lands the **fully-rendered authed dashboard** (1232
+chars of `innerText` — "Quick Actions / My Vet Appointments / … / Switch/Add
+profile") with the **complete data fan-out** (`/api/user/pets`, `/api/indicators`,
+`/api/vets/popular`, `/api/user/subscriptions`, …). Negative control: seeding
+without the second `nav` leaves the page logged-out. Token confirmed
+independently (`/api/auth/me` → `E2E Owner`, id 1, tz `UTC`).
 
 - **Role** is `vetr-profile` — a plain zustand-persist key, **NOT** under the
   Capacitor prefix: `{state:{profile:"user"|"vet"|"servicer"},version:0}`. A vet
@@ -124,6 +123,13 @@ as the page becoming drivable, and in that run it did not.**
 can open a **`fixed inset-0 z-[9999]` overlay** (`FeedbackModalRenderer.tsx:35`).
 It intercepts every click, so the page reads fine and every input op silently
 does nothing.
+
+**Measured, both controls.** WITHOUT the opt-out: the modal fires — "Timezone
+Mismatch Detected / Your device timezone (America/Winnipeg) doesn't match…" — its
+rect is `1124×1361`, **exactly the viewport**, `pointer-events: auto`,
+`z-index: 9999`, and a hit-test of **all 35 in-viewport controls** returns the
+modal as the topmost element for **every one of them**. WITH
+`timezone_mismatch_dismissed` seeded: no modal, dashboard renders normally.
 
 Playwright dodges it by pinning `timezoneId: "UTC"` to match the seeded fixtures
 (they are all UTC). **The bridge is the operator's real browser and cannot pin a
@@ -145,44 +151,55 @@ availability slot you were about to measure.
 It only fires for an **authed** user with a differing saved profile tz, so a
 logged-out walk never sees it.
 
-## 🔴 THE RENDER PROBLEM — unresolved, and it gates the whole drive lane
+## 🔴 A TIRED TAB GOES BLANK — and it reads exactly like "vetr is broken"
 
-Measured 2026-08-27 against the hermetic stack (the same origin that had just
-served **53 passed / 7 skipped / 0 failed** to Playwright minutes earlier):
+The single most expensive thing that happened while writing this file. **A tab
+reused across many `nav`s stopped rendering any route** — app shell mounted,
+`textContent` was only the react-router bootstrap script. It reproduced on
+`/choose-experience` (logged-OUT, 4 green Playwright tests against that same
+origin), on `/user`, and on `/user/appointments`, across 6+ attempts with
+`--wake` up to 10s and `localStorage.clear()`.
 
-| route | in a bridge-driven tab |
-|---|---|
-| `/` (welcome) | rendered content **once** ("Vetr — One App for Every Pet Need"), and on a later `nav` showed only the empty splash `<section>` |
-| `/choose-experience` (logged-OUT, 4 green Playwright tests) | **blank** — app shell mounts, zero interactive elements, `textContent` is just the react-router bootstrap script. 6+ attempts, `--wake` up to 10s, storage cleared |
-| `/user` (authed) | authenticated, but a **permanent skeleton**: `/api/auth/me` + `/api/config` fire and then **no dashboard queries at all**, versus the full `/api/user/pets`+`/api/indicators`+… fan-out the same origin served Playwright |
-| `/user/appointments` | blank |
+**It was written up as a vetr defect. It was not one.** A `close` + fresh `open`
+of the *same URL* rendered everything immediately — the chooser's three role
+cards, the authed dashboard with its full data fan-out.
 
-**What was ruled OUT:**
-- Not the server — all three paths return an **identical** 5176-byte SPA-fallback
-  `index.html`, HTTP 200 (`cmp` clean).
-- Not throttling. The tab was `activate`d: `visibilityState` went `visible`, the
-  skeleton shimmer advanced (so animations run) — and it was **still blank, with
-  still no new API calls**.
-- Not the seeded keys — `localStorage.clear()` then re-`nav` reproduced it.
-- Not a bad token — verified server-side.
+Ruled out along the way, so nobody re-runs them: **not the server** (all paths
+return an identical 5176-byte SPA-fallback `index.html`, 200, `cmp` clean);
+**not throttling** (`activate`d — `visibilityState: visible`, animations
+advancing, still blank); **not the seeded keys**; **not the token**; **not the
+splash** (it renders the literal text "Vetr", and these reads had *zero*
+`innerText`); **not GTM/Brave Shields** (`TagManager.initialize` is try/caught
+non-fatal, `root.tsx:288`); **not the error boundary** (it renders a visible
+"Oops!", `root.tsx:400`).
 
-**Mechanism is UNKNOWN.** Do not guess one from this file. Two candidates were
-never separated: a hydration race on non-root paths (the shell's baked
-`__reactRouterContext` is for `/`), or something about a bridge-driven tab that a
-Playwright context does not reproduce. The `/` result moving between two reads
-says it is at least partly **racy**, not a hard failure.
+🔴 **So: if a vetr route reads blank, `close` the tab and `open` a fresh one
+BEFORE forming any theory.** The root cause of the tired-tab state is unknown and
+is a bridge-level question, not a vetr one.
 
-**So, until this is root-caused:**
-- 🔴 **Do not treat a blank vetr route as a bug in vetr.** Playwright renders these
-  same routes green. Reproduce it in the suite before reporting anything.
-- **Enter at `/` and navigate in-app** rather than deep-linking a route.
-- **For anything that must actually work, use the Playwright/ux-audit harness, not
-  the bridge.** The bridge's proven vetr capability today is *reading the welcome
-  screen and proving an auth seed took*, not walking the funnel.
-- `js` runs in an **ISOLATED world**: `window` state does **not** survive between
-  calls (`window.__x = …` then reading it back returns nothing), and a returned
-  **Promise is not awaited** (`async` expressions come back empty). Use one
-  self-contained synchronous expression, or `curl` the API directly.
+### 🔴 And your blankness detector is probably lying
+
+Three separate instruments gave a confident wrong answer here. All three are
+generic — they are not about vetr:
+
+- **`innerText` needs layout**; a backgrounded/occluded tab can return `""` for a
+  page that is rendering fine. Use `textContent` to decide "is anything in the
+  DOM", and a **`screenshot` to decide what state it is in** — the screenshot is
+  what finally separated "skeleton loading" from "nothing mounted".
+- **A button/link count of 0 means nothing.** The chooser renders three role
+  cards and still counted 0 `button,a`. A skeleton legitimately has no text and
+  no controls.
+- **`elementFromPoint` returns `null` for an off-viewport point**, which reads
+  identically to "covered by an overlay". vetr renders an off-canvas menu at
+  negative x, so its controls sit at e.g. `x = -249`. **Filter to in-viewport
+  centres first**, then hit-test.
+
+### `js` runs in an ISOLATED world
+
+`window` state does **not** survive between calls (`window.__x = …` then reading
+it back returns nothing), page globals set by the app may not be visible, and a
+returned **Promise is not awaited** (`async` expressions come back empty). Use
+one self-contained synchronous expression, or `curl` the API directly.
 
 ## Other traps
 
@@ -231,3 +248,7 @@ cancellation-with-fee, Rx gating, subscription purchase, admin), and eyeballing 
 fix before someone writes the spec. **It is not a substitute for a spec** — when a
 bridge walk finds something, the deliverable is a spec in `vetr-app/e2e/`, not a
 note.
+
+🔴 **And nothing a bridge walk finds is a vetr defect until the suite reproduces
+it.** The suite renders these routes green; this file's own worst mistake was
+skipping that step.

--- a/scripts/browser-bridge/reference/sites/vetr.com.md
+++ b/scripts/browser-bridge/reference/sites/vetr.com.md
@@ -102,6 +102,15 @@ $BB --instance <key> --tab $TAB nav http://127.0.0.1:5174/user --wake
 because the boot that mattered already happened. That failure looks exactly like
 a bad token.
 
+**Measured 2026-08-27 against the hermetic stack, laptop, Brave profile `work`:**
+the seed half of this works. Before the seed, `/user` issues only `/api/config`;
+after the seed + second `nav` the app issues `/api/auth/me` and renders the
+**authed dashboard skeleton** rather than redirecting to auth. The token was
+independently confirmed valid (`/api/auth/me` → `E2E Owner`, id 1, tz `UTC`).
+
+🔴 **But see "the render problem" below — the seed authenticating is NOT the same
+as the page becoming drivable, and in that run it did not.**
+
 - **Role** is `vetr-profile` — a plain zustand-persist key, **NOT** under the
   Capacitor prefix: `{state:{profile:"user"|"vet"|"servicer"},version:0}`. A vet
   token whose `me()` has no `vet` relation redirects to `/vet/register`; that is
@@ -136,6 +145,45 @@ availability slot you were about to measure.
 It only fires for an **authed** user with a differing saved profile tz, so a
 logged-out walk never sees it.
 
+## 🔴 THE RENDER PROBLEM — unresolved, and it gates the whole drive lane
+
+Measured 2026-08-27 against the hermetic stack (the same origin that had just
+served **53 passed / 7 skipped / 0 failed** to Playwright minutes earlier):
+
+| route | in a bridge-driven tab |
+|---|---|
+| `/` (welcome) | rendered content **once** ("Vetr — One App for Every Pet Need"), and on a later `nav` showed only the empty splash `<section>` |
+| `/choose-experience` (logged-OUT, 4 green Playwright tests) | **blank** — app shell mounts, zero interactive elements, `textContent` is just the react-router bootstrap script. 6+ attempts, `--wake` up to 10s, storage cleared |
+| `/user` (authed) | authenticated, but a **permanent skeleton**: `/api/auth/me` + `/api/config` fire and then **no dashboard queries at all**, versus the full `/api/user/pets`+`/api/indicators`+… fan-out the same origin served Playwright |
+| `/user/appointments` | blank |
+
+**What was ruled OUT:**
+- Not the server — all three paths return an **identical** 5176-byte SPA-fallback
+  `index.html`, HTTP 200 (`cmp` clean).
+- Not throttling. The tab was `activate`d: `visibilityState` went `visible`, the
+  skeleton shimmer advanced (so animations run) — and it was **still blank, with
+  still no new API calls**.
+- Not the seeded keys — `localStorage.clear()` then re-`nav` reproduced it.
+- Not a bad token — verified server-side.
+
+**Mechanism is UNKNOWN.** Do not guess one from this file. Two candidates were
+never separated: a hydration race on non-root paths (the shell's baked
+`__reactRouterContext` is for `/`), or something about a bridge-driven tab that a
+Playwright context does not reproduce. The `/` result moving between two reads
+says it is at least partly **racy**, not a hard failure.
+
+**So, until this is root-caused:**
+- 🔴 **Do not treat a blank vetr route as a bug in vetr.** Playwright renders these
+  same routes green. Reproduce it in the suite before reporting anything.
+- **Enter at `/` and navigate in-app** rather than deep-linking a route.
+- **For anything that must actually work, use the Playwright/ux-audit harness, not
+  the bridge.** The bridge's proven vetr capability today is *reading the welcome
+  screen and proving an auth seed took*, not walking the funnel.
+- `js` runs in an **ISOLATED world**: `window` state does **not** survive between
+  calls (`window.__x = …` then reading it back returns nothing), and a returned
+  **Promise is not awaited** (`async` expressions come back empty). Use one
+  self-contained synchronous expression, or `curl` the API directly.
+
 ## Other traps
 
 - **`wake` every page.** The SPA boots hidden in a bridge-opened tab and a
@@ -164,10 +212,18 @@ logged-out walk never sees it.
 
 ## What the browser bridge is FOR here (and what it is not)
 
-The Playwright suite is the regression gate: 28 spec files, and **most of it
-self-skips** without the hermetic env — a bare `npm run e2e` resolves roughly 25
-passed / 35 skipped. Nothing runs it automatically (GitHub Actions is dark
-org-wide; Tekton runs only `vitest`/`typecheck`/`a11y`).
+The Playwright suite is the regression gate: 28 spec files, 55 static `test()`
+calls (viewport-parameterized describes multiply that). **Its coverage depends
+entirely on the env**: a bare `npm run e2e` resolves ~25 passed / 35 skipped,
+because every authed spec self-skips without the `E2E_*` vars. Under the full
+hermetic stack it is **53 passed / 7 skipped / 0 failed** (measured 2026-08-27,
+10.7m). Nothing runs it automatically — GitHub Actions is dark org-wide and
+Tekton runs only `vitest`/`typecheck`/`a11y`.
+
+⚠ On the **laptop**, `~/.config/vetr/authnet.env` holds PROD creds while the
+harness forces `ANET_ENDPOINT=sandbox`, so `e2e:mint-tokens` fails the card
+provision with `E00007` and leaves `owner_has_saved_card:false`. The saved-card
+specs then self-skip. Do not read a green laptop run as covering them.
 
 So the bridge's job is the **exploratory half the suite does not cover**:
 reproducing a UX report, walking a flow with no spec (pool decline/expire,

--- a/scripts/browser-bridge/reference/sites/vetr.com.md
+++ b/scripts/browser-bridge/reference/sites/vetr.com.md
@@ -227,10 +227,27 @@ Conflating these produced two wrong findings in a row, in opposite directions.
 |---|---|---|
 | where | `vetr-app/app/root.tsx:377-398` | `app/components/splash.tsx:105-118`, mounted via `components/GeneralComponents.tsx:1,10` |
 | identify by | `[data-testid=app-boot-skeleton]` | `[data-testid=brand-splash]` |
+| looks like | grey shimmer bars on the page background | **bright orange→lime** full-viewport gradient (`.bg-splash` = `from-[#ff5301] to-[#d1ff27]`, `app/app.css:361-363`) — *not* dark |
 | text | **none** (`aria-hidden`) | renders **"Vetr"** as `<span>` per letter |
-| when | before the JS bundle executes | **after** hydration, first visit per tab (`sessionStorage.splashSeen`) |
-| holds for | until hydration | `minimumVisibleTime` **2000ms**, and on a non-landing route until `navigation.state === "idle" && isFetching === 0` (`splash.tsx:60-62`) |
-| blocks clicks | it *is* the page | no — `pointer-events-none`, but `z-[9999]` and opaque |
+| when | before the JS bundle executes | **after** hydration, first visit per tab (`sessionStorage.splashSeen`, a raw key — no Capacitor prefix) |
+| holds for | until hydration | **depends on the ENTRY path, not on auth** — see below |
+| blocks clicks | it *is* the page | **no** — `pointer-events-none`, so a hit-test can **never** return it. A `z-9999` element that *does* block is the timezone modal above, not this |
+
+🔴 **The splash's duration is keyed on LANDING vs non-landing — never on authed
+vs logged-out.** `landingEntry` is the **entry** URL matching
+`LANDING_PREFIXES = ["/user/vets", "/user/servicers", "/user/shop"]`
+(`splash.tsx:17`), captured once at first mount:
+
+| entry | floor | waits for in-flight queries? |
+|---|---|---|
+| **landing** (`/user/vets/:id`, `/user/servicers…`, `/user/shop…`) | **300ms** (`LANDING_FLOOR_MS`, `:18,39`) | **no** — `navigation.state === "idle"` only (`:60-61`) |
+| anything else (incl. `/auth/login`, `/user`) | **2000ms** (`minimumVisibleTime`, `:29`) | **yes** — `&& isFetching === 0` (`:62`) |
+
+Note both landing paths are **authed** routes, so an auth-keyed rule would get them
+exactly backwards. Add `debounceMs` 200 (`:78`) and a 500ms fade (`:97`): the real
+non-landing floor is ~2.2s, and `[data-testid=brand-splash]` **stays in the DOM at
+`opacity-0` for ~500ms after it looks gone** — and `opacity:0` text still counts in
+`innerText`.
 
 🔴 **The brand `Splash` is LIVE — do not read anywhere that it was removed.** An
 earlier revision of this file claimed it "was *replaced* by" the skeleton, citing
@@ -242,8 +259,10 @@ built `index.html` also contains "Vetr" **twice** (`<title>` and
 
 This matters operationally because **the remedy above is "open a fresh tab"** —
 and a fresh tab is exactly the case that gets the brand splash: an opaque
-full-viewport dark overlay for ≥2s that, on an authed route, additionally waits
-for **every in-flight query**. That is the state most easily mistaken for a stall.
+full-viewport orange→lime overlay which, on a **non-landing** entry, holds ~2.2s
+*and* waits for every in-flight query. That is the state most easily mistaken for a
+stall. On a **landing** entry it is a 300ms flash instead — so the same walk looks
+different depending only on which URL you entered at.
 
 So, precisely: a read with **zero `innerText`** does rule the brand splash out —
 splash renders text. What it does **not** rule out is stalled hydration, because
@@ -282,15 +301,25 @@ up where it belongs, in `reference/css-hit-test.md`.
   self-contained *synchronous* expression, or `curl` the API directly.
 - ⚠ **`window` state may not survive between two consecutive `js` calls.**
   Observed here (`window.__x = …`, then reading it back returned nothing).
-  🔴 **Check whether your call used `--frame` first — that IS the answer:**
-  `--frame` eval runs `Page.createIsolatedWorld` and gets a **brand-new isolated
-  world on every call** (`extension/service_worker.js:539-542`), so page globals
-  are invisible and cross-call state is gone by design. This file tells you to use
-  `--frame` for the authnet hosted-CIM iframe, so it is the likely case. Without
-  `--frame`, `js` is **MAIN** world (`service_worker.js:864-871` default,
-  `:841-846` under `--wake`) and the disappearance is **unexplained** — either way,
-  do not rely on cross-call globals. Note the ISOLATED-world line in the CLI header
-  is about `text`/`html`, not `js`.
+  **`--frame` has TWO eval branches and only one of them explains it** — so this is
+  not a general answer:
+  - **same-process** frame → `Page.createIsolatedWorld` with a **fresh world per
+    call** (`extension/service_worker.js:537-544`) ⇒ globals invisible, cross-call
+    state gone by design.
+  - **cross-origin OOPIF** → evaluated in that frame's own flat session's
+    **default (MAIN) context** (`:546-549`) ⇒ globals *do* persist.
+
+  ⚠ **vetr's authnet hosted-CIM iframe is the OOPIF case, not the isolated one** —
+  it is served from `accept.authorize.net`
+  (`app/components/payments/authnet-hosted-add-card.tsx:12-14`), cross-site to the
+  app origin. So `--frame` does **not** explain the loss for the one iframe this
+  file sends you into. Without `--frame` at all, `js` is **MAIN** world
+  (`service_worker.js:864-871`; `:841-846` under `--wake`).
+
+  Net: the observation is **still unexplained** for a top-frame call, which is what
+  it was made on. `reference/frames-cdp.md:45-46` is authoritative on the split; the
+  ISOLATED-world line in the CLI header is about `text`/`html`, not `js`. Either
+  way, do not rely on cross-call globals.
 
 ## Other traps
 

--- a/scripts/browser-bridge/reference/sites/vetr.com.md
+++ b/scripts/browser-bridge/reference/sites/vetr.com.md
@@ -1,0 +1,177 @@
+# vetr.com — two lanes, the auth seed, and the modal that eats every click
+
+**Load this when:** a result envelope named this file in `site_notes` · you are
+about to drive or read `app.vetr.com` / `api.vetr.com` / `admin.vetr.com` · you
+are pointing the bridge at the LOCAL hermetic E2E stack (`127.0.0.1:5174`) ·
+an authed vetr read looks logged-OUT · a vetr page renders but every click is
+swallowed · you are about to conclude vetr is broken from a browser read.
+
+Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`.
+Mechanism files stay authoritative for mechanism: throttling and `wake` →
+`reference/spa-wake.md`; hit-testing → `reference/css-hit-test.md`; iframes and
+OOPIFs → `reference/frames-cdp.md`; proving a read is the live authenticated
+session → `reference/auth-pages.md`. This file is only what is true of **vetr**.
+
+Project context lives in `~/workspace/scratch/vetr/{CLAUDE.md,OPS.md}`. The
+Playwright suite this file borrows from is `vetr-app/e2e/`.
+
+---
+
+## 🔴 TWO LANES. Pick one before the first op.
+
+vetr is a **pet-care marketplace running LIVE Authorize.net**. `api.vetr.com` is
+real money — a booking driven there charges a real card, and a registration
+driven there writes a real row (a past session had to hand-delete test users out
+of the production database).
+
+**The Playwright suite refuses to run against prod** — `assertNotProductionTarget()`
+in `vetr-app/e2e/support/playwright-shared.ts` guards `E2E_BASE_URL`,
+`E2E_API_BASE_URL` *and* the build-time `VITE_API_BASE_URL`. **The browser
+bridge has NO such guard.** Nothing stops you. So:
+
+| lane | target | allowed |
+|---|---|---|
+| **A — drive** | the hermetic stack, `http://127.0.0.1:5174` (API `:8000`) | anything: `click`, `type`, `upload`, booking, registration, checkout |
+| **B — read** | `app.vetr.com`, `admin.vetr.com`, `api.vetr.com` | `text` / `html` / `context` / `screenshot` **only** |
+
+🔴 **The registry routes on HOST, so only Lane B ever names this file.** Verified:
+`vetr.com`, `app.`, `api.` and `admin.vetr.com` all resolve here; `127.0.0.1` and
+`localhost` resolve to **nothing**. Lane A — the lane where you are actually
+allowed to click — is therefore the lane that will **never** hand you these notes.
+Load this file deliberately when you bring the stack up, and brief it into any
+`browser agent` yourself (the agent never sees `site_notes` at all).
+
+🔴 **Lane B never `click`s a money or write control.** "Just checking the button
+works" on prod is a charge. If a question needs a click, bring up Lane A.
+
+🔴 **Never diagnose a vetr OUTAGE from a browser read** — that needs pod health,
+Loki/Prometheus (`obs-read`), or an anonymous `curl`, not a tab.
+
+## Lane A — bring up the hermetic stack
+
+```bash
+cd ~/workspace/scratch/vetr/vetr-app        # ← per-host path: CONFIRM with `git -C . remote -v`
+KEEP_UP=1 scripts/e2e-hermetic-nixos.sh     # docker mysql → vetr-api :8000 → SPA :5174
+```
+
+`KEEP_UP=1` runs the Playwright suite and then **leaves the stack up** for you to
+drive. It also prints the fixture ids you need. `scripts/e2e-hermetic-nixos.sh`
+self-provisions php84 + chromium from nix; you do not need to be in a nix shell.
+
+The stack forces `ANET_ENDPOINT=sandbox`, so Authorize.net traffic goes to
+`apitest.authorize.net` — no real money on Lane A. `PAYMENT_GATEWAY` defaults to
+**authnet** (matching prod); `PAYMENT_GATEWAY=stripe` for the legacy rail.
+
+Fixture tokens/ids come from `php artisan e2e:mint-tokens` (the script exports
+them as `E2E_*`; re-mint by hand in `../vetr-api` if the shell is gone).
+
+## 🔴 The auth seed — and why Playwright's version does NOT transfer
+
+The SPA reads its Sanctum token from **Capacitor Preferences**, which on web is
+`localStorage` under the group prefix `CapacitorStorage.`, storing the value
+**verbatim** — and `NativeStorage.set` (`vetr-app/app/lib/utils.ts`) has already
+`JSON.stringify`'d it. So the token is **double-quoted**:
+
+```
+localStorage["CapacitorStorage.token"] = "\"<token>\""     // note the quotes
+```
+
+Playwright seeds this with `page.addInitScript`, which runs **before app JS on
+every navigation** (`e2e/fixtures/auth.ts`). **The bridge has no such hook** —
+`js` only runs after the page has already booted. So the order is different, and
+the order is the whole trick:
+
+```bash
+BB=~/workspace/devrc/scripts/browser-bridge/browser
+TAB=$($BB --instance <key> open http://127.0.0.1:5174/ --wake | jq -r .result.data.tabId)
+
+# 1. same-origin now, so localStorage is writable
+$BB --instance <key> --tab $TAB js '(function(){
+  localStorage.setItem("CapacitorStorage.token", JSON.stringify("<E2E_AUTH_TOKEN>"));
+  localStorage.setItem("vetr-profile", JSON.stringify({state:{profile:"user"},version:0}));
+  localStorage.setItem("CapacitorStorage.timezone_mismatch_dismissed",
+                       JSON.stringify(Intl.DateTimeFormat().resolvedOptions().timeZone));
+  return Object.keys(localStorage).length;
+})()'
+
+# 2. NOW navigate — root.tsx me() reads the token on THIS boot
+$BB --instance <key> --tab $TAB nav http://127.0.0.1:5174/user --wake
+```
+
+**Seeding then reading without the second `nav` gives you the logged-OUT page**,
+because the boot that mattered already happened. That failure looks exactly like
+a bad token.
+
+- **Role** is `vetr-profile` — a plain zustand-persist key, **NOT** under the
+  Capacitor prefix: `{state:{profile:"user"|"vet"|"servicer"},version:0}`. A vet
+  token whose `me()` has no `vet` relation redirects to `/vet/register`; that is
+  the API's answer, not a seeding bug.
+- Prove the seed took the way `reference/auth-pages.md` says — read the rendered
+  page, not the storage you just wrote.
+
+## 🔴 The timezone modal — a full-screen overlay that swallows every click
+
+`root.tsx` compares the profile timezone against the device timezone on boot and
+can open a **`fixed inset-0 z-[9999]` overlay** (`FeedbackModalRenderer.tsx:35`).
+It intercepts every click, so the page reads fine and every input op silently
+does nothing.
+
+Playwright dodges it by pinning `timezoneId: "UTC"` to match the seeded fixtures
+(they are all UTC). **The bridge is the operator's real browser and cannot pin a
+timezone** — on this host (America/Winnipeg) the modal fires on every authed
+Lane-A boot.
+
+The predicate is `shouldPromptTimezoneMismatch` (`app/lib/utils/timezone.ts`) and
+it has two opt-outs. **Use `timezone_mismatch_dismissed`** — it is local-only:
+
+```
+localStorage["CapacitorStorage.timezone_mismatch_dismissed"] = "\"America/Winnipeg\""
+```
+
+🔴 **Do NOT use the other opt-out, `always_update_timezone`.** It does not just
+suppress the modal — it makes the app `setTimezone()` **PATCH the profile on the
+server**, silently rewriting your fixture vet/owner's timezone and moving every
+availability slot you were about to measure.
+
+It only fires for an **authed** user with a differing saved profile tz, so a
+logged-out walk never sees it.
+
+## Other traps
+
+- **`wake` every page.** The SPA boots hidden in a bridge-opened tab and a
+  throttled read returns a shell — indistinguishable from a broken app. A reload
+  re-throttles. → `reference/spa-wake.md`
+- **First-visit gate.** `localStorage["vetr.authVisited"] === "1"` (a plain key,
+  no prefix) decides `/auth/register` vs `/auth/login` for a logged-out visitor
+  (`app/lib/onboarding/auth-visited.ts`). A profile that has been here before
+  lands somewhere different than a fresh one — set or clear it deliberately
+  rather than reporting "the app sent me to the wrong screen".
+- **Check the gateway before touching checkout.** `GET /config` →
+  `data.payments.gateway`, cached in `NativeStorage["config"]`;
+  `resolveGateway()` defaults to `"stripe"` when unreadable
+  (`app/lib/payments/gateway.ts`). Under **authnet**, card capture is the
+  Authorize.net **HOSTED CIM `<iframe name=addPaymentChannel>`**
+  (`app/components/payments/authnet-hosted-add-card.tsx`) — so it needs
+  `--frame`, and input inside a frame is **SYNTHETIC**, not trusted CDP.
+  → `reference/frames-cdp.md`
+- **Mobile-first.** The app is a phone-shaped SPA that clamps to a phone column
+  on desktop. `emulate` a mobile preset before judging any layout; the audit
+  harnesses walk it at 390×844. → `reference/emulation.md`
+- **Lane B, admin.** `admin.vetr.com` is Filament at the domain root
+  (`ADMIN_PATH=/`), login `https://admin.vetr.com/login`. It is the right way to
+  READ prod vet/servicer/subscription state — far cheaper than SSH — but it is
+  also a write UI, so Lane B's read-only rule applies to it too.
+
+## What the browser bridge is FOR here (and what it is not)
+
+The Playwright suite is the regression gate: 28 spec files, and **most of it
+self-skips** without the hermetic env — a bare `npm run e2e` resolves roughly 25
+passed / 35 skipped. Nothing runs it automatically (GitHub Actions is dark
+org-wide; Tekton runs only `vitest`/`typecheck`/`a11y`).
+
+So the bridge's job is the **exploratory half the suite does not cover**:
+reproducing a UX report, walking a flow with no spec (pool decline/expire,
+cancellation-with-fee, Rx gating, subscription purchase, admin), and eyeballing a
+fix before someone writes the spec. **It is not a substitute for a spec** — when a
+bridge walk finds something, the deliverable is a spec in `vetr-app/e2e/`, not a
+note.

--- a/scripts/browser-bridge/reference/sites/vetr.com.md
+++ b/scripts/browser-bridge/reference/sites/vetr.com.md
@@ -308,7 +308,11 @@ Read the named flags **before** the `z9999` array — the array alone is ambiguo
 2. **`splash`** ⇒ the brand splash. 🔴 **It matches the `z9999` filter too** —
    `splash.tsx:108` is `fixed … z-[9999]` — and its `textContent` is **"Vetr"**, so
    without this flag you would read it as an unknown modal and go looking for a
-   dismiss that does not exist. It clears itself; wait it out.
+   dismiss that does not exist. It has no dismiss — but **do not just "wait it
+   out"**: it self-clears on a time floor only on a **landing** entry. On any other
+   entry it also waits for `isFetching === 0`, so a hung query keeps it up
+   indefinitely (see the splash-timing table above). If it does not clear, the
+   question is which query is stuck, not which overlay this is.
 3. **`toast`** ⇒ a toast is live. That div is only rendered while at least one toast
    exists, so its presence is a binary answer — and it will *also* appear in `z9999`.
 4. **A `z9999` entry reading "Timezone Mismatch Detected"** ⇒ the modal above; the
@@ -326,9 +330,11 @@ Read the named flags **before** the `z9999` array — the array alone is ambiguo
 
 The first row is why the `splash` flag exists: the splash really does land in `z9999`
 with the text **"Vetr"**, and without the flag you would read it as an unnamed modal.
-⚠ **Not verified: the toast-present case** — no toast could be triggered on demand
-(the interceptor's are gated off, see below), so step 3's *positive* half rests on
-the library's behaviour, not a measurement here.
+⚠ **Not verified: the toast-present case.** The *interceptor* toasts cannot be
+triggered (gated off — see below), and no action-handler toast was exercised, so
+step 3's *positive* half rests on the library's behaviour rather than a measurement
+here. Toasts **are** reachable in Lane A by clicking; if you exercise one, add the
+row.
 
 ⚠ **Keep the strict `=== "9999"`.** Measured on the same page, a regex
 (`/9999/.test(zIndex)`) returns **an extra element**: `PullToRefresh.tsx:183`,

--- a/scripts/browser-bridge/reference/sites/vetr.com.md
+++ b/scripts/browser-bridge/reference/sites/vetr.com.md
@@ -282,50 +282,69 @@ different depending only on which URL you entered at.
 
 ### 🔴 `z-index: 9999` does NOT identify the timezone modal
 
-An earlier revision of this file said a `z-9999` blocker "is **always** the timezone
-modal". **False, and it sends you to a remedy that cannot work.** There are (at
-least) **two distinct z-9999 `pointer-events: auto` surfaces** in a browser tab.
+An earlier revision said a `z-9999` blocker "is **always** the timezone modal".
+False — z-9999 is shared. **Identify the blocker, don't infer it:**
 
-**(a) The shared `FeedbackModalRenderer` backdrop** (`FeedbackModalRenderer.tsx:35`).
-The timezone modal (`root.tsx:334`) is *one* of **eleven** `<FeedbackModal>` callers
-— the other ten include the exact surfaces this file routes you to:
+```js
+// one expression. NB the modal has no data-testid — find it by computed style.
+(function(){
+  var z = [].slice.call(document.querySelectorAll("div")).filter(function(e){
+    var s = getComputedStyle(e);
+    return s.position === "fixed" && s.zIndex === "9999";
+  });
+  return JSON.stringify({
+    boot:  !!document.querySelector("[data-testid=app-boot-skeleton]"),
+    toast: !!document.querySelector(".Toastify__toast-container"),
+    z9999: z.map(function(e){ return (e.innerText || "").trim().slice(0, 80); })
+  });
+})()
+```
 
-- `routes/user/vets/vet-view.tsx:1764` — `/user/vets/:id`, the landing route above
-- `routes/user/bookings/booking-checkout.tsx:88` and
-  `routes/user/appointments/appointment-checkout.tsx:143` — the checkout screens the
-  gateway trap below sends you into
-- plus `bookings/index.tsx`, `appointments/index.tsx`, `servicer-service-view.tsx`,
-  `my-pets-create.tsx`, `pages/contact.tsx`, `professional-report.tsx`,
-  `PetOwnerHomeBookingCard.tsx`
+1. **`.Toastify__toast-container` present** ⇒ a toast is live. That div is only
+   rendered while at least one toast exists, so its presence is a binary answer.
+2. **A `z9999` entry reading "Timezone Mismatch Detected"** ⇒ the modal above; that
+   is the *only* one `timezone_mismatch_dismissed` clears.
+3. **Any other title** ⇒ a different `<FeedbackModal>`; dismiss it on its own terms.
 
-**(b) The react-toastify container — and in a bridge walk this is the LIKELIER
-one.** `<ToastContainer>` is mounted unconditionally on every route
-(`root.tsx:161`), and `ReactToastify.css` sets `--toastify-z-index: 9999` (`:29`,
-applied `:52`) with **no `pointer-events` rule anywhere in the stylesheet** ⇒
-default `auto`. The axios interceptor fires `toast.error` on **any** API error
-(`app/lib/api/axios.tsx:151,192,197`), and vetr passes `closeOnClick={false}` +
-`autoClose={5000}` (`root.tsx:161-167`). So an API error parks a clickable
-`position: fixed`, top-right, z-9999 box over the page for 5s. Bounded, at least:
-`--toastify-container-width: fit-content` (`:15`, applied `:55`), so with no toast up
-the container is zero-size and intercepts nothing.
+(That filter is the one measured against this app: it returned the timezone modal
+plus its inner panel, and the modal as topmost for all 35 in-viewport controls.)
 
-⚠ **`UpdateApp.tsx:9` is `fixed inset-0 z-[9999]` with no `pointer-events-none`, but
-you will NEVER meet it in a browser** — `setUpdateStoreUrl` has exactly one call site
-(`root.tsx:245`) behind `if (!Capacitor.isNativePlatform()) return;` (`root.tsx:236`),
-plus `isProduction` and an outdated native build. And where it *does* fire it is an
-early `return` replacing the whole tree (`root.tsx:320-322`), not an overlay — so it
-cannot produce the "page reads fine, clicks do nothing" symptom at all. Listed only
-because an earlier revision of this file offered it as the non-`FeedbackModal`
-example; it is a phantom.
+**Why a title and not a z-index.** `z-[9999]` + `pointer-events: auto` is the
+**shared** `FeedbackModalRenderer` backdrop (`FeedbackModalRenderer.tsx:35`), and the
+timezone modal (`root.tsx:334`) is *one* of **eleven** `<FeedbackModal>` callers. The
+other ten include surfaces this file routes you to —
+`routes/user/vets/vet-view.tsx:1764` (`/user/vets/:id`, the landing route above),
+`routes/user/bookings/booking-checkout.tsx:88` and
+`routes/user/appointments/appointment-checkout.tsx:143` (the checkout screens in the
+gateway trap below), plus `bookings/index.tsx`, `appointments/index.tsx`,
+`servicer-service-view.tsx`, `my-pets-create.tsx`, `pages/contact.tsx`,
+`professional-report.tsx`, `PetOwnerHomeBookingCard.tsx`. `title` is a required prop
+rendered as plain text (`FeedbackModal.tsx:8`, `FeedbackModalRenderer.tsx:60`), so
+`innerText` reads it.
 
-🔴 **So read the modal's TITLE, never its z-index.** Only
-"Timezone Mismatch Detected" is cleared by `timezone_mismatch_dismissed`; a
-success/error `FeedbackModal` needs its own dismiss (`title` is a required prop and
-renders as plain text, `FeedbackModal.tsx:8` / `FeedbackModalRenderer.tsx:60`, so
-`innerText` reads it); a toast has no title row at all — check for
-`.Toastify__toast-container`. What the splash row above *does* license is the one-way
-inference: the splash is `pointer-events-none`, so whatever a hit-test returns, it
-is not the splash.
+**The toast container is the other z-9999 surface** (`<ToastContainer>` at
+`root.tsx:161`, `--toastify-z-index: 9999` at `ReactToastify.css:29`, applied `:52`;
+stylesheet imported `root.tsx:30`). Two things about it that are easy to get wrong:
+
+- ⚠ **A toast implies a prior click.** vetr's toasts come from **component action
+  handlers** (~68 `toast.*` calls across 14 non-test files). The axios interceptor's
+  two toasts are gated on `config?.toastr` (`axios.tsx:151,197`) — and **vetr-api's
+  `GET /config` never sends a `toastr` key**, so they do not fire; the third
+  (`:192`) is a client-side HEIC-conversion failure only. So a toast does not appear
+  from a passive read.
+- ⚠ **At mobile widths it is a full-width top strip, not a corner box** —
+  `ReactToastify.css:115-117` sets `width: 100vw` at `≤480px`, and this file tells you
+  to `emulate` 390×844. Don't rule it out because your control is on the left.
+  `autoClose` is 5000ms but `pauseOnFocusLoss` is set (`root.tsx:168`), and a
+  bridge tab is often unfocused — so treat it as *until dismissed*, not 5s.
+
+⚠ `UpdateApp.tsx:9` is also `fixed inset-0 z-[9999]`, but **you cannot meet it in a
+browser**: its only trigger (`root.tsx:245`) sits behind
+`if (!Capacitor.isNativePlatform()) return;` (`:236`). Noted only so nobody re-adds
+it as a candidate.
+
+The splash licenses one inference and only one: it is `pointer-events-none`, so
+whatever a hit-test returns, it is **not** the splash.
 
 So, precisely: a read with **zero `innerText`** does rule the brand splash out —
 splash renders text. What it does **not** rule out is stalled hydration, because

--- a/scripts/browser-bridge/reference/sites/vetr.com.md
+++ b/scripts/browser-bridge/reference/sites/vetr.com.md
@@ -55,15 +55,38 @@ KEEP_UP=1 scripts/e2e-hermetic-nixos.sh     # docker mysql → vetr-api :8000 �
 ```
 
 `KEEP_UP=1` runs the Playwright suite and then **leaves the stack up** for you to
-drive. It also prints the fixture ids you need. `scripts/e2e-hermetic-nixos.sh`
-self-provisions php84 + chromium from nix; you do not need to be in a nix shell.
+drive. `scripts/e2e-hermetic-nixos.sh` self-provisions php84 + chromium from nix;
+you do not need to be in a nix shell. Add `-- --grep <spec>` to cut the ~11-minute
+full run down to one spec when you only want the stack.
 
-The stack forces `ANET_ENDPOINT=sandbox`, so Authorize.net traffic goes to
-`apitest.authorize.net` — no real money on Lane A. `PAYMENT_GATEWAY` defaults to
-**authnet** (matching prod); `PAYMENT_GATEWAY=stripe` for the legacy rail.
+On the **authnet** rail (the default, matching prod) the stack forces
+`ANET_ENDPOINT=sandbox`, so Authorize.net traffic goes to `apitest.authorize.net`
+— no real money.
 
-Fixture tokens/ids come from `php artisan e2e:mint-tokens` (the script exports
-them as `E2E_*`; re-mint by hand in `../vetr-api` if the shell is gone).
+🔴 **That protection is authnet-ONLY. `PAYMENT_GATEWAY=stripe` has NO equivalent
+check:** `e2e-hermetic-nixos.sh:243-250` copies `STRIPE_SECRET_KEY` out of your
+environment into the API's `.env` **verbatim, with no test-mode assertion**. Prod
+runs `sk_live`/`pk_live`, and Lane A is the lane where you are told to click
+Book. So on the stripe rail, **export the test keys first** —
+`~/.config/vetr/stripe-test.env` (`pk_test`/`sk_test`/`whsec`) — and never run it
+with a live key in the shell. Keyless works for every non-payment flow (the API
+falls back to a placeholder secret).
+
+🔴 **You must mint your own token — the script does NOT give you one.** It
+captures `e2e:mint-tokens`, validates the JSON with `jq empty` and **discards
+it** (`:260-261`), then `export`s the ids into its **own** process (`:264-276`).
+It is invoked, not sourced, so nothing reaches your shell, and the `KEEP_UP`
+message prints only ports and the container name. Without a token the auth seed
+below has no input. Mint one yourself — there is no system PHP on NixOS, so
+borrow the one the script already built:
+
+```bash
+PHP=$(ls /nix/store/*vetr-e2e-tools*/bin/php | head -1)
+(cd ~/workspace/scratch/vetr/vetr-api && "$PHP" artisan e2e:mint-tokens)   # → JSON
+```
+
+Re-minting is safe: `--seed` is opt-in (`vetr-api/app/Console/Commands/E2EMintTokens.php`),
+so a bare run issues fresh tokens without touching the seeded data.
 
 ## 🔴 The auth seed — and why Playwright's version does NOT transfer
 
@@ -136,70 +159,99 @@ Playwright dodges it by pinning `timezoneId: "UTC"` to match the seeded fixtures
 timezone** — on this host (America/Winnipeg) the modal fires on every authed
 Lane-A boot.
 
-The predicate is `shouldPromptTimezoneMismatch` (`app/lib/utils/timezone.ts`) and
-it has two opt-outs. **Use `timezone_mismatch_dismissed`** — it is local-only:
+The predicate is `shouldPromptTimezoneMismatch` (`app/lib/utils/timezone.ts:16-30`)
+and it has two opt-outs. **Use `timezone_mismatch_dismissed`** — it is local-only.
+
+🔴 **Write the DEVICE's zone, computed at runtime — never a literal.** The
+predicate suppresses only when `dismissedTz === deviceTz` (`timezone.ts:27`), so a
+hardcoded zone copied from this file silently does **nothing** on any host in a
+different one, and you get the click-eating modal you were just told you had
+disabled:
 
 ```
-localStorage["CapacitorStorage.timezone_mismatch_dismissed"] = "\"America/Winnipeg\""
+// right — this is the form used in the seed recipe above
+localStorage.setItem("CapacitorStorage.timezone_mismatch_dismissed",
+                     JSON.stringify(Intl.DateTimeFormat().resolvedOptions().timeZone));
 ```
 
 🔴 **Do NOT use the other opt-out, `always_update_timezone`.** It does not just
-suppress the modal — it makes the app `setTimezone()` **PATCH the profile on the
-server**, silently rewriting your fixture vet/owner's timezone and moving every
+suppress the modal — it makes the app `setTimezone()` **write the profile back to
+the server** (`authStore.ts` → `profileApi.editProfile`, a `POST /user/profile`),
+silently rewriting your fixture vet/owner's timezone and moving every
 availability slot you were about to measure.
 
 It only fires for an **authed** user with a differing saved profile tz, so a
 logged-out walk never sees it.
 
-## 🔴 A TIRED TAB GOES BLANK — and it reads exactly like "vetr is broken"
+## 🔴 A TIRED TAB STALLS PRE-HYDRATION — and it reads exactly like "vetr is broken"
 
 The single most expensive thing that happened while writing this file. **A tab
-reused across many `nav`s stopped rendering any route** — app shell mounted,
-`textContent` was only the react-router bootstrap script. It reproduced on
-`/choose-experience` (logged-OUT, 4 green Playwright tests against that same
-origin), on `/user`, and on `/user/appointments`, across 6+ attempts with
-`--wake` up to 10s and `localStorage.clear()`.
+reused across many `nav`s stopped rendering any route.** It reproduced on
+`/choose-experience` (logged-OUT, 4 Playwright tests against that same origin),
+on `/user`, and on `/user/appointments`, across 6+ attempts with `--wake` up to
+10s and `localStorage.clear()`. **It was written up as a vetr defect. It is not
+one** — a `close` + fresh `open` of the *same URL* rendered everything
+immediately.
 
-**It was written up as a vetr defect. It was not one.** A `close` + fresh `open`
-of the *same URL* rendered everything immediately — the chooser's three role
-cards, the authed dashboard with its full data fan-out.
+🔴 **Identify it by the FALLBACK, not by emptiness.** SSR is off, so until the JS
+bundle loads and React mounts, the only thing painted is `HydrateFallback`
+(`vetr-app/app/root.tsx:377-398`): `data-testid="app-boot-skeleton"`,
+`aria-hidden="true"`, `className="relative flex h-dvh flex-col"`, **exactly 3
+children**, and **no text nodes anywhere**. That is what a stalled tab is showing.
+It is trivially mistaken for a mounted app shell — the observation that started
+this whole mess was literally "`DIV.relative flex h-dvh flex-col`, kids=3, so
+React mounted". It had not. **Query `[data-testid=app-boot-skeleton]`: present ⇒
+the bundle never executed, and nothing you read afterwards is about the route.**
 
-Ruled out along the way, so nobody re-runs them: **not the server** (all paths
-return an identical 5176-byte SPA-fallback `index.html`, 200, `cmp` clean);
-**not throttling** (`activate`d — `visibilityState: visible`, animations
-advancing, still blank); **not the seeded keys**; **not the token**; **not the
-splash** (it renders the literal text "Vetr", and these reads had *zero*
-`innerText`); **not GTM/Brave Shields** (`TagManager.initialize` is try/caught
-non-fatal, `root.tsx:288`); **not the error boundary** (it renders a visible
-"Oops!", `root.tsx:400`).
+Ruled out, so nobody re-runs them: **not the server** (all paths return an
+identical 5176-byte SPA-fallback `index.html`, 200, `cmp` clean); **not
+throttling** (`activate`d — `visibilityState: visible`, animations advancing,
+still stalled); **not the seeded keys**; **not the token**; **not GTM/Brave
+Shields** (`TagManager.initialize` is try/caught non-fatal, `root.tsx:288`);
+**not the error boundary** (it renders a visible "Oops!", `root.tsx:400`).
+
+⚠ **Do NOT reuse the earlier claim that the brand splash rules this out.** An
+earlier revision of this file argued "not the splash, it renders the literal text
+'Vetr'". That was **wrong and self-defeating**: the `~2s` dark "Vetr" splash was
+*replaced* by the textless skeleton above (`root.tsx:378-384` says so), and the
+served `index.html` contains "Vetr" only in its `<title>`. Stalled hydration is
+the live hypothesis, not an excluded one.
 
 🔴 **So: if a vetr route reads blank, `close` the tab and `open` a fresh one
-BEFORE forming any theory.** The root cause of the tired-tab state is unknown and
-is a bridge-level question, not a vetr one.
+BEFORE forming any theory.** Why a reused tab reaches that state is a
+bridge-level question, not a vetr one.
 
 ### 🔴 And your blankness detector is probably lying
 
-Three separate instruments gave a confident wrong answer here. All three are
-generic — they are not about vetr:
+Three instruments each gave a confident wrong answer here. **All three are
+generic** — they belong to the mechanism files, and this list is the vetr-shaped
+illustration, not the home of the rule. The `elementFromPoint` one is now written
+up where it belongs, in `reference/css-hit-test.md`.
 
-- **`innerText` needs layout**; a backgrounded/occluded tab can return `""` for a
-  page that is rendering fine. Use `textContent` to decide "is anything in the
-  DOM", and a **`screenshot` to decide what state it is in** — the screenshot is
-  what finally separated "skeleton loading" from "nothing mounted".
+- **`innerText` needs layout**; a backgrounded/occluded tab returns `""` for a
+  page that is rendering fine. Use `textContent` for "is anything in the DOM",
+  and a **`screenshot` for what state it is in** — the screenshot is the only
+  thing that separated "pre-hydration skeleton" from "mounted but data-less".
 - **A button/link count of 0 means nothing.** The chooser renders three role
-  cards and still counted 0 `button,a`. A skeleton legitimately has no text and
-  no controls.
+  cards and still counted 0 `button,a`.
 - **`elementFromPoint` returns `null` for an off-viewport point**, which reads
   identically to "covered by an overlay". vetr renders an off-canvas menu at
   negative x, so its controls sit at e.g. `x = -249`. **Filter to in-viewport
-  centres first**, then hit-test.
+  centres first**, then hit-test — otherwise you will "discover" a blocking
+  overlay that is not there.
 
-### `js` runs in an ISOLATED world
+### Two `js` behaviours that cost real time here
 
-`window` state does **not** survive between calls (`window.__x = …` then reading
-it back returns nothing), page globals set by the app may not be visible, and a
-returned **Promise is not awaited** (`async` expressions come back empty). Use
-one self-contained synchronous expression, or `curl` the API directly.
+- **A returned Promise is not awaited.** An `async` expression comes back empty,
+  with no error — consistent with `SKILL.md`'s "evaluates ONE EXPRESSION". Use one
+  self-contained *synchronous* expression, or `curl` the API directly.
+- ⚠ **`window` state did not survive between two consecutive `js` calls** on the
+  same page (`window.__x = …`, then reading it back returned nothing). **This is
+  UNEXPLAINED and it contradicts the mechanism docs** — `reference/spa-wake.md`
+  states `js`/`eval` is **MAIN** world "by definition" (the ISOLATED-world note in
+  the CLI header is about `text`/`html`, not `js`). So do not conclude "isolated
+  world" from this, and do not rely on cross-call globals either. If you need the
+  mechanism, resolve it in `spa-wake.md` — not here.
 
 ## Other traps
 
@@ -234,8 +286,14 @@ calls (viewport-parameterized describes multiply that). **Its coverage depends
 entirely on the env**: a bare `npm run e2e` resolves ~25 passed / 35 skipped,
 because every authed spec self-skips without the `E2E_*` vars. Under the full
 hermetic stack it is **53 passed / 7 skipped / 0 failed** (measured 2026-08-27,
-10.7m). Nothing runs it automatically — GitHub Actions is dark org-wide and
-Tekton runs only `vitest`/`typecheck`/`a11y`.
+10.7m).
+
+**As of 2026-08-27 nothing runs it automatically** — GitHub Actions is quota-dark
+org-wide (the tell: runs fail in 2–4s with **zero** steps), and the Tekton jobs
+that do run are `vetr-app`'s `vitest`/`typecheck`/`a11y` plus `vetr-api-pest` —
+none of which is the Playwright suite. ⚠ **Re-check before relying on this**: a
+workflow named `e2e (hermetic)` exists on `vetr-app` and resumes running the suite
+by itself when the quota resets.
 
 ⚠ On the **laptop**, `~/.config/vetr/authnet.env` holds PROD creds while the
 harness forces `ANET_ENDPOINT=sandbox`, so `e2e:mint-tokens` fails the card

--- a/scripts/browser-bridge/reference/sites/vetr.com.md
+++ b/scripts/browser-bridge/reference/sites/vetr.com.md
@@ -316,11 +316,26 @@ Read the named flags **before** the `z9999` array — the array alone is ambiguo
 5. **Any other `z9999` text, with all three flags false** ⇒ a different
    `<FeedbackModal>`; dismiss it on its own terms.
 
-⚠ **This exact expression has not been run against the app** — it is assembled from
-parts that were. Do not quote it as measured. What *was* measured used a **regex**
-(`/9999/.test(zIndex)`), which is not the same filter: it also matches
-`#top-bar-bg`'s `z-index: 999999999999`, so it returned an extra empty-text element.
-Strict `=== "9999"` above avoids that; if you loosen it, expect the over-match back.
+**Measured against the hermetic stack, 2026-08-28, this exact expression:**
+
+| state | result |
+|---|---|
+| fresh tab on `/`, splash up | `{boot:false, splash:true, toast:false, z9999:["Vetr"]}` |
+| authed `/user`, opt-out cleared | `{boot:false, splash:false, toast:false, z9999:["Timezone Mismatch Detected…"]}` |
+| no toast live | `.Toastify__toast-container` **absent**; the always-mounted wrapper is a `<section class="Toastify">`, so it never enters the `div` filter |
+
+The first row is why the `splash` flag exists: the splash really does land in `z9999`
+with the text **"Vetr"**, and without the flag you would read it as an unnamed modal.
+⚠ **Not verified: the toast-present case** — no toast could be triggered on demand
+(the interceptor's are gated off, see below), so step 3's *positive* half rests on
+the library's behaviour, not a measurement here.
+
+⚠ **Keep the strict `=== "9999"`.** Measured on the same page, a regex
+(`/9999/.test(zIndex)`) returns **an extra element**: `PullToRefresh.tsx:183`,
+computed `z-index: 999999`, `pointer-events: none`, 2px tall, empty text. Harmless
+but it makes the array ambiguous — and an earlier revision of this file mis-attributed
+that extra element to the modal's own inner panel, which is `position: relative` and
+can never match at all.
 
 **Why a title and not a z-index.** `z-[9999]` + `pointer-events: auto` is the
 **shared** `FeedbackModalRenderer` backdrop (`FeedbackModalRenderer.tsx:35`), and the

--- a/scripts/browser-bridge/reference/sites/vetr.com.md
+++ b/scripts/browser-bridge/reference/sites/vetr.com.md
@@ -287,27 +287,40 @@ False — z-9999 is shared. **Identify the blocker, don't infer it:**
 
 ```js
 // one expression. NB the modal has no data-testid — find it by computed style.
+// textContent, not innerText: innerText is "" on an occluded tab (see below).
 (function(){
   var z = [].slice.call(document.querySelectorAll("div")).filter(function(e){
     var s = getComputedStyle(e);
     return s.position === "fixed" && s.zIndex === "9999";
   });
   return JSON.stringify({
-    boot:  !!document.querySelector("[data-testid=app-boot-skeleton]"),
-    toast: !!document.querySelector(".Toastify__toast-container"),
-    z9999: z.map(function(e){ return (e.innerText || "").trim().slice(0, 80); })
+    boot:   !!document.querySelector("[data-testid=app-boot-skeleton]"),
+    splash: !!document.querySelector("[data-testid=brand-splash]"),
+    toast:  !!document.querySelector(".Toastify__toast-container"),
+    z9999:  z.map(function(e){ return (e.textContent || "").trim().slice(0, 80); })
   });
 })()
 ```
 
-1. **`.Toastify__toast-container` present** ⇒ a toast is live. That div is only
-   rendered while at least one toast exists, so its presence is a binary answer.
-2. **A `z9999` entry reading "Timezone Mismatch Detected"** ⇒ the modal above; that
-   is the *only* one `timezone_mismatch_dismissed` clears.
-3. **Any other title** ⇒ a different `<FeedbackModal>`; dismiss it on its own terms.
+Read the named flags **before** the `z9999` array — the array alone is ambiguous:
 
-(That filter is the one measured against this app: it returned the timezone modal
-plus its inner panel, and the modal as topmost for all 35 in-viewport controls.)
+1. **`boot`** ⇒ stalled pre-hydration; nothing else you read is about the route.
+2. **`splash`** ⇒ the brand splash. 🔴 **It matches the `z9999` filter too** —
+   `splash.tsx:108` is `fixed … z-[9999]` — and its `textContent` is **"Vetr"**, so
+   without this flag you would read it as an unknown modal and go looking for a
+   dismiss that does not exist. It clears itself; wait it out.
+3. **`toast`** ⇒ a toast is live. That div is only rendered while at least one toast
+   exists, so its presence is a binary answer — and it will *also* appear in `z9999`.
+4. **A `z9999` entry reading "Timezone Mismatch Detected"** ⇒ the modal above; the
+   *only* one `timezone_mismatch_dismissed` clears.
+5. **Any other `z9999` text, with all three flags false** ⇒ a different
+   `<FeedbackModal>`; dismiss it on its own terms.
+
+⚠ **This exact expression has not been run against the app** — it is assembled from
+parts that were. Do not quote it as measured. What *was* measured used a **regex**
+(`/9999/.test(zIndex)`), which is not the same filter: it also matches
+`#top-bar-bg`'s `z-index: 999999999999`, so it returned an extra empty-text element.
+Strict `=== "9999"` above avoids that; if you loosen it, expect the over-match back.
 
 **Why a title and not a z-index.** `z-[9999]` + `pointer-events: auto` is the
 **shared** `FeedbackModalRenderer` backdrop (`FeedbackModalRenderer.tsx:35`), and the
@@ -326,12 +339,16 @@ rendered as plain text (`FeedbackModal.tsx:8`, `FeedbackModalRenderer.tsx:60`), 
 `root.tsx:161`, `--toastify-z-index: 9999` at `ReactToastify.css:29`, applied `:52`;
 stylesheet imported `root.tsx:30`). Two things about it that are easy to get wrong:
 
-- ⚠ **A toast implies a prior click.** vetr's toasts come from **component action
-  handlers** (~68 `toast.*` calls across 14 non-test files). The axios interceptor's
-  two toasts are gated on `config?.toastr` (`axios.tsx:151,197`) — and **vetr-api's
-  `GET /config` never sends a `toastr` key**, so they do not fire; the third
-  (`:192`) is a client-side HEIC-conversion failure only. So a toast does not appear
-  from a passive read.
+- ⚠ **A toast implies a prior click.** vetr's toasts are raised from **component
+  action handlers**. The two in the axios interceptor are gated on `config?.toastr`
+  (`axios.tsx:151,197`) — and **vetr-api's `GET /config` sends no `toastr` key**, so
+  they do not fire; the third (`:192`) is a client-side HEIC-conversion failure only.
+  So a toast does not appear from a passive read. (Caveat the doc owes you: `config`
+  is the *cached* payload, so a stale cache — or storage you seeded by hand, which
+  this file teaches — could still carry `toastr`.)
+- ⚠ **Clicking the toast body will not dismiss it** — vetr passes
+  `closeOnClick={false}` (`root.tsx:166`). Use its close button. Worth knowing in the
+  one section of this file about clicks that do nothing.
 - ⚠ **At mobile widths it is a full-width top strip, not a corner box** —
   `ReactToastify.css:115-117` sets `width: 100vw` at `≤480px`, and this file tells you
   to `emulate` 390×844. Don't rule it out because your control is on the left.

--- a/scripts/browser-bridge/reference/sites/vetr.com.md
+++ b/scripts/browser-bridge/reference/sites/vetr.com.md
@@ -154,9 +154,9 @@ independently (`/api/auth/me` → `E2E Owner`, id 1, tz `UTC`).
 `root.tsx` compares the profile timezone against the device timezone on boot and
 can open a **`fixed inset-0 z-[9999]` overlay** (`FeedbackModalRenderer.tsx:35`).
 It intercepts every click, so the page reads fine and every input op silently
-does nothing. ⚠ That renderer is **shared by ten `<FeedbackModal>` callers** — this
-modal is identified by its **title**, never by its z-index (see "`z-index: 9999`
-does NOT identify the timezone modal" below).
+does nothing. ⚠ That renderer is **shared by eleven `<FeedbackModal>` callers** —
+this modal is identified by its **title**, never by its z-index (see "`z-index:
+9999` does NOT identify the timezone modal" below).
 
 **Measured, both controls.** WITHOUT the opt-out: the modal fires — "Timezone
 Mismatch Detected / Your device timezone (America/Winnipeg) doesn't match…" — its
@@ -283,11 +283,12 @@ different depending only on which URL you entered at.
 ### 🔴 `z-index: 9999` does NOT identify the timezone modal
 
 An earlier revision of this file said a `z-9999` blocker "is **always** the timezone
-modal". **False, and it sends you to a remedy that cannot work.** `z-[9999]` +
-`pointer-events: auto` is the **shared** `FeedbackModalRenderer` backdrop
-(`FeedbackModalRenderer.tsx:35`) — the timezone modal (`root.tsx:334`) is just *one*
-of **ten** `<FeedbackModal>` callers. The others include the exact surfaces this file
-routes you to:
+modal". **False, and it sends you to a remedy that cannot work.** There are (at
+least) **two distinct z-9999 `pointer-events: auto` surfaces** in a browser tab.
+
+**(a) The shared `FeedbackModalRenderer` backdrop** (`FeedbackModalRenderer.tsx:35`).
+The timezone modal (`root.tsx:334`) is *one* of **eleven** `<FeedbackModal>` callers
+— the other ten include the exact surfaces this file routes you to:
 
 - `routes/user/vets/vet-view.tsx:1764` — `/user/vets/:id`, the landing route above
 - `routes/user/bookings/booking-checkout.tsx:88` and
@@ -297,14 +298,32 @@ routes you to:
   `my-pets-create.tsx`, `pages/contact.tsx`, `professional-report.tsx`,
   `PetOwnerHomeBookingCard.tsx`
 
-And a **separate** z-9999 blocker that is not a `FeedbackModal` at all:
-`components/UpdateApp.tsx:9` (`fixed inset-0 z-[9999]`, no `pointer-events-none`),
-rendered from `root.tsx:321`.
+**(b) The react-toastify container — and in a bridge walk this is the LIKELIER
+one.** `<ToastContainer>` is mounted unconditionally on every route
+(`root.tsx:161`), and `ReactToastify.css` sets `--toastify-z-index: 9999` (`:29`,
+applied `:52`) with **no `pointer-events` rule anywhere in the stylesheet** ⇒
+default `auto`. The axios interceptor fires `toast.error` on **any** API error
+(`app/lib/api/axios.tsx:151,192,197`), and vetr passes `closeOnClick={false}` +
+`autoClose={5000}` (`root.tsx:161-167`). So an API error parks a clickable
+`position: fixed`, top-right, z-9999 box over the page for 5s. Bounded, at least:
+`--toastify-container-width: fit-content` (`:15`, applied `:55`), so with no toast up
+the container is zero-size and intercepts nothing.
+
+⚠ **`UpdateApp.tsx:9` is `fixed inset-0 z-[9999]` with no `pointer-events-none`, but
+you will NEVER meet it in a browser** — `setUpdateStoreUrl` has exactly one call site
+(`root.tsx:245`) behind `if (!Capacitor.isNativePlatform()) return;` (`root.tsx:236`),
+plus `isProduction` and an outdated native build. And where it *does* fire it is an
+early `return` replacing the whole tree (`root.tsx:320-322`), not an overlay — so it
+cannot produce the "page reads fine, clicks do nothing" symptom at all. Listed only
+because an earlier revision of this file offered it as the non-`FeedbackModal`
+example; it is a phantom.
 
 🔴 **So read the modal's TITLE, never its z-index.** Only
 "Timezone Mismatch Detected" is cleared by `timezone_mismatch_dismissed`; a
-success/error `FeedbackModal` needs its own dismiss, and `UpdateApp` is a
-force-upgrade screen. What the splash row above *does* license is the one-way
+success/error `FeedbackModal` needs its own dismiss (`title` is a required prop and
+renders as plain text, `FeedbackModal.tsx:8` / `FeedbackModalRenderer.tsx:60`, so
+`innerText` reads it); a toast has no title row at all — check for
+`.Toastify__toast-container`. What the splash row above *does* license is the one-way
 inference: the splash is `pointer-events-none`, so whatever a hit-test returns, it
 is not the splash.
 

--- a/scripts/browser-bridge/reference/sites/vetr.com.md
+++ b/scripts/browser-bridge/reference/sites/vetr.com.md
@@ -154,7 +154,9 @@ independently (`/api/auth/me` → `E2E Owner`, id 1, tz `UTC`).
 `root.tsx` compares the profile timezone against the device timezone on boot and
 can open a **`fixed inset-0 z-[9999]` overlay** (`FeedbackModalRenderer.tsx:35`).
 It intercepts every click, so the page reads fine and every input op silently
-does nothing.
+does nothing. ⚠ That renderer is **shared by ten `<FeedbackModal>` callers** — this
+modal is identified by its **title**, never by its z-index (see "`z-index: 9999`
+does NOT identify the timezone modal" below).
 
 **Measured, both controls.** WITHOUT the opt-out: the modal fires — "Timezone
 Mismatch Detected / Your device timezone (America/Winnipeg) doesn't match…" — its
@@ -231,23 +233,37 @@ Conflating these produced two wrong findings in a row, in opposite directions.
 | text | **none** (`aria-hidden`) | renders **"Vetr"** as `<span>` per letter |
 | when | before the JS bundle executes | **after** hydration, first visit per tab (`sessionStorage.splashSeen`, a raw key — no Capacitor prefix) |
 | holds for | until hydration | **depends on the ENTRY path, not on auth** — see below |
-| blocks clicks | it *is* the page | **no** — `pointer-events-none`, so a hit-test can **never** return it. A `z-9999` element that *does* block is the timezone modal above, not this |
+| blocks clicks | it *is* the page | **no** — `pointer-events-none`, so a hit-test can never return it. But do **not** infer the converse: see below |
 
 🔴 **The splash's duration is keyed on LANDING vs non-landing — never on authed
 vs logged-out.** `landingEntry` is the **entry** URL matching
 `LANDING_PREFIXES = ["/user/vets", "/user/servicers", "/user/shop"]`
 (`splash.tsx:17`), captured once at first mount:
 
-| entry | floor | waits for in-flight queries? |
-|---|---|---|
-| **landing** (`/user/vets/:id`, `/user/servicers…`, `/user/shop…`) | **300ms** (`LANDING_FLOOR_MS`, `:18,39`) | **no** — `navigation.state === "idle"` only (`:60-61`) |
-| anything else (incl. `/auth/login`, `/user`) | **2000ms** (`minimumVisibleTime`, `:29`) | **yes** — `&& isFetching === 0` (`:62`) |
+Matching is exact-or-slash (`:20-22`), so `/user/vetsomething` does **not** count.
+`debounceMs` (200, `:29`) is added to **both** branches (`:70,78` —
+`remaining + debounceMs`), so the real floors are:
+
+| entry | constant | **real floor** | waits for in-flight queries? |
+|---|---|---|---|
+| **landing** (`/user/vets/:id`, `/user/servicers…`, `/user/shop…`) | 300ms (`LANDING_FLOOR_MS`, `:18,39`) | **500ms** | **no** — `navigation.state === "idle"` only (`:60-61`) |
+| anything else (incl. `/auth/login`, `/user`) | 2000ms (`minimumVisibleTime`, `:29`) | **~2200ms** | **yes** — `&& isFetching === 0` (`:62`) |
 
 Note both landing paths are **authed** routes, so an auth-keyed rule would get them
-exactly backwards. Add `debounceMs` 200 (`:78`) and a 500ms fade (`:97`): the real
-non-landing floor is ~2.2s, and `[data-testid=brand-splash]` **stays in the DOM at
-`opacity-0` for ~500ms after it looks gone** — and `opacity:0` text still counts in
-`innerText`.
+exactly backwards. The floors are minimums, not durations — a non-landing entry
+waits as long as queries stay in flight.
+
+`landingEntry` is captured **once at first mount** from the entry URL
+(`useRef`, `:36-38`), so navigating in or out of a landing route later does **not**
+change the behaviour. `<Splash />` is rendered with no props
+(`GeneralComponents.tsx:10`), so the `:29` defaults are what actually apply.
+
+⚠ **The testid outlives the visible splash by the 500ms fade.** `visible→false`
+applies `opacity-0` and arms a 500ms unmount timer at the same moment (`:94-100`,
+`transition-opacity duration-500`), so for that 500ms
+`[data-testid=brand-splash]` is still in the DOM, mid-fade — and its text still
+counts in `innerText`, because nothing sets `display:none`, `visibility:hidden` or
+`aria-hidden` on it.
 
 🔴 **The brand `Splash` is LIVE — do not read anywhere that it was removed.** An
 earlier revision of this file claimed it "was *replaced* by" the skeleton, citing
@@ -261,8 +277,36 @@ This matters operationally because **the remedy above is "open a fresh tab"** �
 and a fresh tab is exactly the case that gets the brand splash: an opaque
 full-viewport orange→lime overlay which, on a **non-landing** entry, holds ~2.2s
 *and* waits for every in-flight query. That is the state most easily mistaken for a
-stall. On a **landing** entry it is a 300ms flash instead — so the same walk looks
+stall. On a **landing** entry it is a ~500ms flash instead — so the same walk looks
 different depending only on which URL you entered at.
+
+### 🔴 `z-index: 9999` does NOT identify the timezone modal
+
+An earlier revision of this file said a `z-9999` blocker "is **always** the timezone
+modal". **False, and it sends you to a remedy that cannot work.** `z-[9999]` +
+`pointer-events: auto` is the **shared** `FeedbackModalRenderer` backdrop
+(`FeedbackModalRenderer.tsx:35`) — the timezone modal (`root.tsx:334`) is just *one*
+of **ten** `<FeedbackModal>` callers. The others include the exact surfaces this file
+routes you to:
+
+- `routes/user/vets/vet-view.tsx:1764` — `/user/vets/:id`, the landing route above
+- `routes/user/bookings/booking-checkout.tsx:88` and
+  `routes/user/appointments/appointment-checkout.tsx:143` — the checkout screens the
+  gateway trap below sends you into
+- plus `bookings/index.tsx`, `appointments/index.tsx`, `servicer-service-view.tsx`,
+  `my-pets-create.tsx`, `pages/contact.tsx`, `professional-report.tsx`,
+  `PetOwnerHomeBookingCard.tsx`
+
+And a **separate** z-9999 blocker that is not a `FeedbackModal` at all:
+`components/UpdateApp.tsx:9` (`fixed inset-0 z-[9999]`, no `pointer-events-none`),
+rendered from `root.tsx:321`.
+
+🔴 **So read the modal's TITLE, never its z-index.** Only
+"Timezone Mismatch Detected" is cleared by `timezone_mismatch_dismissed`; a
+success/error `FeedbackModal` needs its own dismiss, and `UpdateApp` is a
+force-upgrade screen. What the splash row above *does* license is the one-way
+inference: the splash is `pointer-events-none`, so whatever a hit-test returns, it
+is not the splash.
 
 So, precisely: a read with **zero `innerText`** does rule the brand splash out —
 splash renders text. What it does **not** rule out is stalled hydration, because
@@ -314,7 +358,8 @@ up where it belongs, in `reference/css-hit-test.md`.
   (`app/components/payments/authnet-hosted-add-card.tsx:12-14`), cross-site to the
   app origin. So `--frame` does **not** explain the loss for the one iframe this
   file sends you into. Without `--frame` at all, `js` is **MAIN** world
-  (`service_worker.js:864-871`; `:841-846` under `--wake`).
+  (`service_worker.js:864-871`; under `--wake` the branch is `:849`, asserted in the
+  comment at `:841-846`).
 
   Net: the observation is **still unexplained** for a top-frame call, which is what
   it was made on. `reference/frames-cdp.md:45-46` is authoritative on the split; the


### PR DESCRIPTION
## What

Registers `reference/sites/vetr.com.md` + its `_index.json` entry. vetr had no
site-notes entry, so every result envelope on `app.`/`api.`/`admin.vetr.com`
emitted no `site_notes` and these flows were rediscovered per session.

## Why these two things are in it

- **vetr runs LIVE Authorize.net.** The Playwright suite refuses to target prod
  (`assertNotProductionTarget`, including the build-time `VITE_API_BASE_URL`);
  the bridge has no equivalent guard. Hence an explicit two-lane split: drive
  only the hermetic stack, read-only on `*.vetr.com`.
- **The timezone modal.** `root.tsx` opens a `fixed inset-0 z-[9999]` overlay on
  a profile/device timezone mismatch. Playwright dodges it with
  `timezoneId:"UTC"`; the bridge drives the operator's real browser and cannot.
  Fixtures are `UTC` (`E2ESeeder.php:71`), this host is `America/Winnipeg`.

## Nearly everything here is measured, with controls

(One exception, stated in the file: the toast-**present** branch of the discriminator
is not measured. See the results table in the file and correction comment 8.)

**The auth seed works end-to-end.** On a fresh tab, seed + second `nav` lands the
full authed dashboard (1232 chars `innerText`) with the complete data fan-out
(`/api/user/pets`, `/api/indicators`, `/api/vets/popular`,
`/api/user/subscriptions`, …). Negative control: seeding *without* the second
`nav` leaves the page logged-out — the `addInitScript`-vs-post-boot-`js` ordering
trap is real. Token confirmed independently (`E2E Owner`, id 1, tz `UTC`).

**The timezone modal, both controls.** Without the opt-out it fires: rect
`1124x1361` = exactly the viewport, `pointer-events: auto`, `z-index: 9999`, and
a hit-test of **all 35 in-viewport controls** returns the modal as topmost for
every one. With `timezone_mismatch_dismissed` seeded: no modal, dashboard
renders. The file steers to that opt-out and warns off `always_update_timezone`,
which `setTimezone()`s the fixture's profile **server-side**.

## ⚠️ Read the commit history — commit 2 was WRONG and commit 3 retracts it

`aa6fa270` reported that every non-root vetr route renders blank in a bridge tab
and declared the drive lane unusable. **That was a bad instrument, not a vetr
defect**, and `9006a8c5` retracts it. The blanks were a *reused* tab that had
stopped rendering; a fresh `open` at the same URL rendered everything.

Three instruments each gave a confident wrong answer, and the file now leads with
that because it is generic:
- `innerText` needs layout and returns `""` for an occluded tab that renders fine.
- A `button,a` count of 0 proves nothing — the chooser renders three role cards
  and counts 0.
- `elementFromPoint` returns `null` for an **off-viewport** point, identical to
  "covered by an overlay". vetr's off-canvas menu puts controls at `x = -249`.

The tired-tab behaviour is kept as a bridge-level trap with unknown root cause,
the rule "close and reopen **before** forming a theory", and the full ruled-out
list so nobody re-runs it (server: identical 5176-byte SPA fallback, `cmp` clean;
throttling: `activate`d, visible, animations advancing, still blank; seeded keys;
token; splash — renders the literal text "Vetr" and these reads had zero
`innerText`; GTM/Brave Shields — try/caught non-fatal, `root.tsx:288`; error
boundary — renders a visible "Oops!", `root.tsx:400`).

Standing rule added, because this session violated it: **nothing a bridge walk
finds is a vetr defect until the suite reproduces it.**

## Also recorded

- `js` is **MAIN** world (`service_worker.js:864-871`) — an earlier revision of this
  body said ISOLATED, which is wrong; see the correction comments. A returned
  Promise is not awaited, and cross-call `window` state was observed not to survive
  (unexplained for a top-frame call).
- Suite coverage is env-dependent, so both numbers are given: **~25 passed / 35
  skipped bare** vs **53 passed / 7 skipped / 0 failed hermetic** (10.7m,
  measured). The 7 skips are unattributed — the harness forces the `github`
  reporter, which does not name them.
- Laptop gotcha: `~/.config/vetr/authnet.env` holds PROD creds while the harness
  forces `ANET_ENDPOINT=sandbox`, so `e2e:mint-tokens` fails the card provision
  with `E00007` and leaves `owner_has_saved_card:false` — silently self-skipping
  the saved-card specs.
- Host routing verified: `vetr.com`/`app.`/`api.`/`admin.` resolve to the file;
  `notvetr.com`, `vetr.com.evil.invalid`, `127.0.0.1`, `localhost` do not. So the
  hermetic lane — the only lane allowed to click — never surfaces these notes,
  which the file says.

## Tests

`tests/test_site_notes.py` + `test_skill_size.py` → **75 passed**. Instrument validated, not just green:
dropping the registry entry turns `test_index_and_files_are_the_same_set` RED
(`assert not ['vetr.com.md']`); restored, green. `SKILL.md` untouched, so the
"SKILL.md never names an individual site" invariant is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuDZJLkUhvu4yXJ6d8x6Rt

