### PR TITLE
rig-control: fix time_color zero-padded hour

### DIFF
--- a/scripts/rig-control.sh
+++ b/scripts/rig-control.sh
@@ -50,7 +50,7 @@ is_asleep() { [[ -f "$STATE_FILE" ]] && read -r _state < "$STATE_FILE" && [[ "$_
 # Sleep mode always uses black (000000) regardless of time.
 time_color() {
   local h
-  h=$(date +%H)
+  h=$(date +%-H)
   case "$h" in
     10)        echo "FFA500" ;;  # 10am  — amber (just woke)
     11)        echo "FFBF00" ;;  # 11am  — golden


### PR DESCRIPTION
Fix: 01 returns zero-padded hours ('01' not '1'), so the midnight-2am dark red case never matched. Changed to .