### PR TITLE
rig-control: don't let monitor restore failure block wake

### DIFF
--- a/scripts/rig-control.sh
+++ b/scripts/rig-control.sh
@@ -91,7 +91,7 @@ do_sleep() {
 do_wake() {
   echo "awake" > "$STATE_FILE"
   rgb_on
-  restore
+  restore || notify "RGB on but monitor restore failed (DDC/CI)" || true
   notify "Wake mode activated"
 }
 


### PR DESCRIPTION
When DDC/CI monitor restore fails (bus not responding), RGB stays on and a toast reports the failure instead of the whole wake action aborting.