### PR TITLE
docs(browser): reclaim SKILL.md headroom and fix an over-broad site_notes claim

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -24,19 +24,15 @@ host and pick the right `--instance` first. Architecture / security model:
 ## FIRST DECISION: agent or direct?
 
 **Open-ended READ — "go find X and tell me Y" → reach for `browser agent` FIRST.**
-A cheap autonomous model works in its OWN isolated tab and returns a compact
-`{answer,evidence,steps_used,status}` — the page HTML (10K–100K tokens on a heavy
-page) never enters YOUR context.
+It works in its OWN isolated tab and returns a compact
+`{answer,evidence,steps_used,status}` — the page HTML never enters YOUR context.
+Ambiguous → agent first: taking over is cheap, so it wins even at a low hit rate.
 
 **Drive ops directly when** the task is **precise** (URL + selector/JS known, 1–3
 ops) · **interactive** (click/type/submit/upload) · **diagnostic** (the agent is
-BLIND — its tool returns no pixels; you must SEE a screenshot, or hit-test paint
-order) · **secret** — agent-read pages go to
-**OpenRouter/DeepSeek**: never banking, private mail, credential managers, or
-anything you wouldn't hand a third party. Nor **virtualised/lazy-loaded lists**.
-
-KNOW something from it → agent. Ambiguous → agent first: taking over is cheap, so
-agent-first wins even at a low success rate.
+BLIND — no pixels; you must SEE a screenshot, or hit-test paint order) ·
+**virtualised/lazy-loaded** · **secret** — agent-read pages go to
+**OpenRouter/DeepSeek**: never banking, private mail or credential managers.
 
 🔴 The AGENT's auto-`wake` covers a hidden `text`/`html` read but **never `eval`/`js`** — so
 ASSERT a non-zero content count in any `js` measurement. It also never sees
@@ -63,14 +59,14 @@ Result payloads land under `.result.data`.
 | `close` / `release` | close this session's owned tab / drop ownership without closing it |
 | `tabs` | list open tabs (`.data.ownedTabId` flags yours) |
 | `nav <url> [--wake[=MS]]` | navigate the owned/active tab; it lands hidden, so `--wake` un-throttles in the SAME call |
-| `text [selector] [--max-bytes N] [--annotated]` | **cheap read** — visible `innerText` (optional CSS selector), byte-capped by default. ~98% smaller than `html` — **prefer it**. `--annotated` gives per-element extraction — use it when you need a SELECTOR to click/type; works with `--frame`. Byte cap, envelope fields, `--annotated` schema → `reference/read-envelopes.md` |
+| `text [selector] [--max-bytes N] [--annotated]` | **cheap read** — visible `innerText` (optional CSS selector), byte-capped by default. ~98% smaller than `html` — **prefer it**. `--annotated` gives per-element extraction — use it when you need a SELECTOR to click/type; works with `--frame`. Envelope fields + the `--annotated` schema → `reference/read-envelopes.md` |
 | `html [--max-bytes N]` | `outerHTML`, same byte cap and envelope. One uncapped `html` on a heavy SPA is ~100K tokens — the cap is ON by default |
 | `js '<expr>'` (alias: `eval`) | run JS in the tab, return its value; same wire op either way. **Prefer the `js` spelling in a worktree-isolated agent** — Claude Code's isolation guard refuses any command with the literal token `eval` |
 | `screenshot [path] [--fullpage] [--data-url] [--json]` | CDP capture — **works on a BACKGROUND/occluded tab**. **Always writes a `.png`** (to `path`, else a 0600 temp); base64 **NEVER** printed — **`Read` it**. ⚠ with `path`, stdout is the bare path, NOT JSON — add `--json` (refused with `--data-url`). `--data-url` = escape hatch |
 | `frames` | list the tab's frames (`frameId`/`url`/`parentFrameId`) **incl. cross-origin OOPIFs** — pick a numeric `frameId` for `--frame` |
 | `click <selector>` · `type <text> [--selector S]` · `key <Enter\|Tab\|Escape\|Backspace\|Delete\|Arrow*\|Home\|End\|Page*> [--selector S]` | the input ops — click the element's centre, type text, send one bounded keypress. All three: **TRUSTED** CDP on the top frame, **SYNTHETIC** inside `--frame` |
 | `upload <selector> <path>` | fill an `<input type=file>` via CDP — Chrome reads the file BY PATH, **no bytes cross the bridge**. AUDIT-LOGGED, **operator-only** (agent → `op_not_allowed:upload`) |
-| `wake [--wait MS]`, or `text\|html\|js\|nav\|open --wake[=MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement** — the fix for an empty or `hidden` read. **Wake once per PAGE, not per read.** `--wake` folds un-throttle+read into one call; refused with `--frame`. Settle/cap, once-per-page, ISOLATED-vs-MAIN world → `reference/spa-wake.md` |
+| `wake [--wait MS]`, or `text\|html\|js\|nav\|open --wake[=MS]` | **UN-THROTTLE a hidden/background tab with NO focus movement** — the fix for an empty or `hidden` read. **Wake once per PAGE, not per read.** `--wake` folds un-throttle+read into one call; refused with `--frame`. Settle/cap, ISOLATED-vs-MAIN world → `reference/spa-wake.md` |
 | `activate` | **⚠⚠ TAKES THE OPERATOR'S SCREEN — LAST RESORT.** The i3 raise is OPT-IN: `--focus` (auto-on on a TTY) → raise, else `withheld`; `skipped` where there is no i3. **NOT** the hidden-tab fix — that is `wake`, see `reference/spa-wake.md` |
 | `emulate <preset>\|--reset` | **device emulation** (mobile testing) on a tab you `open`ed; sticky, owned-tab-only. Presets, `--reset`, `--recreate` → `reference/emulation.md` |
 | `agent "<goal>"` | the autonomous browser-agent — see **FIRST DECISION** above, then `reference/agent.md` |
@@ -78,32 +74,30 @@ Result payloads land under `.result.data`.
 ## 🔴 Four traps that return a WRONG answer SILENTLY
 
 1. **`js`/`eval` evaluates ONE EXPRESSION, not a script.** A multi-statement body
-   (`window.scrollBy(0,1400); "ok"`) returns **`null` with no error** — it looks
-   like a broken bridge and isn't. Wrap it: `(function(){ …; return x })()`.
+   returns **`null` with no error** — it looks like a broken bridge and isn't.
+   Wrap it: `(function(){ …; return x })()`.
 2. **Strict page CSP silently blocks the injected script — notably GitHub.** Even
    `document.title` comes back `null`, no error. **Use `text`/`html` there — they
-   work**, because they don't inject script. (`chrome://`/`brave://` URLs also give
-   `null` + `Cannot access a chrome:// URL`.)
+   work**, because they inject no script. `chrome://`/`brave://` also give `null`.
 3. **A background/hidden tab is THROTTLED → a shell-only DOM**, indistinguishable
-   from a genuinely broken site. `open` creates tabs hidden, so this is the common
-   case. Check `data.hidden` / `document.visibilityState`, then **`wake`** — never
-   `activate`, and spoofing `visibilityState` does not recover the page.
+   from a genuinely broken site — and `open` creates tabs hidden, so this is the
+   common case. Check `data.hidden`, then **`wake`** (never `activate`; spoofing
+   `visibilityState` does not work).
    **A reload RE-throttles: re-`wake` or clicks go silently inert.**
    → `reference/spa-wake.md`
-4. **A JS `.click()` does not open a React/Mantine popover — and the read then
-   reports a confident ABSENCE.** Use the trusted **`click`** op, **ONCE** (it is a
-   TOGGLE, so a stale earlier click makes the next read lie); prove it with
-   `aria-expanded`. **And an OPEN menu can still hide a SECOND VIEW behind a
-   chevron-row drill-in — its items are not in the DOM until you click it, so
-   "not in the dropdown" is NOT "not in the UI".** → `reference/css-hit-test.md`
+4. **A JS `.click()` does not open a React/Mantine popover — the read then reports
+   a confident ABSENCE.** Use the trusted **`click`** op, **ONCE** (it TOGGLES, so
+   a stale earlier click makes the next read lie); prove it with `aria-expanded`.
+   **An OPEN menu can still hide a SECOND VIEW behind a chevron-row drill-in — its
+   items are not in the DOM until you click it, so "not in the dropdown" is NOT
+   "not in the UI".** → `reference/css-hit-test.md`
 
 ## When things look broken — triage
 
 `health` FIRST (the extension drops mid-session with no error), then `wake` a
 throttled/empty read, then fall back to `text`/`html` before concluding the
-bridge is down. Full flow — including stale-build vs restart, and what `null` /
-`unknown_op` each mean — →
-`~/workspace/devrc/scripts/browser-bridge/reference/errors.md`.
+bridge is down. Full flow — stale-build vs restart, and what `null` /
+`unknown_op` each mean → `reference/errors.md`.
 
 🔴 **Never diagnose a site OUTAGE from a browser read** — "broken for real
 users?" needs server-side evidence (RUM, metrics, pod health, anonymous `curl`).
@@ -113,9 +107,9 @@ users?" needs server-side evidence (RUM, metrics, pod health, anonymous `curl`).
 It's their real browser, not a scratch VM. Don't `nav` a tab that may hold unsaved
 work (a half-typed comment, a form) — `open` your own tab, or an obviously
 disposable one. 🔴 If ANYTHING takes their screen — `activate`, the X-fallback
-capture — RECORD focus AND workspace first, restore BOTH at the end, on failure
-too. Restoring focus usually carries the workspace, but not always — restore it
-explicitly. Why, and the commands → `reference/spa-wake.md`.
+capture — RECORD focus AND workspace first and restore BOTH at the end, on
+failure too; restoring focus does not reliably carry the workspace. Why, and the
+commands → `reference/spa-wake.md`.
 
 ## Reference files — load ONE only when its trigger fires
 
@@ -133,4 +127,4 @@ explicitly. Why, and the commands → `reference/spa-wake.md`.
 | `reference/auth-pages.md` | an authenticated request; you were about to read a cookie; a read looks logged-OUT; `extension_connected:false` |
 | `reference/security-ops.md` | 🔴 **you are MODIFYING browser-bridge** (the live-verify-on-real-Brave gate is mandatory); the user asks whether/what it records; first-time setup or a second profile |
 | `reference/x-fallback.md` | CDP `screenshot` is unsatisfactory and you must capture the raw X window (`DISPLAY`/`XAUTHORITY`, xdotool/maim) |
-| `reference/sites/<host>.md` | 🔴 **READ IT BEFORE the first action on that host, not after something fails** — the CLI names it in every result envelope (`site_notes`). It carries that site's **multi-step FLOWS** (sign-in, account switching, pickers, wizards) plus the reads that lie there. Skipping it is how a one-click flow gets reported to the operator as a blocker |
+| `reference/sites/<host>.md` | 🔴 **READ IT BEFORE the first action on that host, not after something fails** — a tab op names it (`site_notes`) for a REGISTERED host only; identity reads (`whoami`/`health`/`ping`) and unknown hosts carry no field, so ABSENCE means nothing. It carries that site's **multi-step FLOWS** (sign-in, account switching, pickers, wizards) plus the reads that lie there. Skipping it is how a one-click flow gets reported to the operator as a blocker |


### PR DESCRIPTION
Closes rank 3 of `claudedocs/handoff-browser-agent-site-notes.md`.

## Why

`scripts/browser-bridge/SKILL.md` sat at **12,028 B against a 12,038 B enforced gate — 10 bytes of slack.** That is less than one row of either table that actually grows (ops mean **190 B**, reference mean **166 B**, per the constants `tests/test_skill_size.py` owns). The next op added turns a required check red — the permanently-red-gate hazard, where the gate stops meaning anything because everyone clicks through it.

**Now 11,720 B** — 568 B of headroom against a required 250, i.e. **318 B / ~1.7 ops rows of growth room, up from 0.05 rows.**

`skill-audit.py` said *"no prune needed"*. That is true **of bytes**, and it is why this PR is a compression plus one correctness fix rather than a demotion: the file is a router at its target size, not an archive that grew.

## What moved

Nothing moved to a sidecar. Every claim removed from the core was first confirmed — by reading the destination, not by a one-shot cite — to survive in the file the core already routes to:

| removed from core | survives at |
|---|---|
| agent decision prose (context cost, low-hit-rate argument) | `agent.md:111` |
| "Nor virtualised/lazy-loaded lists" (kept inline, depth dropped) | `agent.md:189` |
| `Cannot access a chrome:// URL` | `errors.md:96`, verbatim |
| `document.visibilityState` check + "spoofing does not recover" | `spa-wake.md:28-35` |
| record/restore focus **and** workspace — the commands | `spa-wake.md:259-266` |

Plus two intra-cell duplications: `wake` stated "once-per-page" twice, `text` stated its byte cap twice.

## Staleness fix — the part the byte audit could not see

The `reference/sites/<host>.md` row claimed the CLI names `site_notes` **in every result envelope**. Measured wrong on two axes:

- `_annotate_site_notes` is called only from `_handle_cmd` (`server.py:3731`) — never from `_whoami` or `do_GET`, so the identity reads carry no field;
- it sets the field only when the host is **REGISTERED**.

So a reader treating **absence** of `site_notes` as "no notes exist for this host" was being misled by the core, on the one row whose whole job is to stop a host being driven un-briefed. Narrowed to say exactly that.

Four other core claims were checked and are **correct as written**, so they stand — recorded so the next pass does not re-derive them:

- the 24-op table matches `SUBCOMMANDS` (`browser:515`) exactly, as a set;
- `extension_stale` is on `health` + `whoami` and **not** `instances` — measured live, 2 / 2 / 0;
- only `SKILL.md` and the CLI are symlinked into `~/.claude/skills/browser/`;
- `README.md` exists at the path the core cites.

## Verification

- **`tests/test_skill_size.py` 4 passed — and watched to FAIL.** Negative control: padded to 12,331 B, both the ceiling and headroom tests went red naming `RECLAIM: 293 bytes`. A gate never seen failing proves nothing about a green.
- **Full browser-bridge suite: 809 passed.**
- `skill-audit.py`: within budget, 12 reference files resolve, no orphans.
- **Routing paths resolved by hand** (`errors`, `spa-wake`, `css-hit-test`, `agent`, `read-envelopes`). The auditor resolves paths against the skill directory, which always succeeds — its tick is not evidence a reader following the core actually finds the file.

## Pairing

Every guard kept its imperative in the core alongside the trigger it protects — the four silent-wrong-answer traps, the screen-theft rule, and the agent privacy rule — because their triggers (`js`, `open`, `click`, `activate`, `agent`) are all core ops. Demoting a warning away from the instruction it guards is the documented failure mode of this kind of pass; it did not happen here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eexd2kXFxXfd44SXsg4Dm