### PR TITLE
feat(session-manager,find-session): answer "is it still running, which window" LIVE — the 30s archive was the wrong instrument

### DIFF
--- a/claude/skills/find-session/SKILL.md
+++ b/claude/skills/find-session/SKILL.md
@@ -49,8 +49,11 @@ python3 /home/zach/workspace/devrc/scripts/find-session.py <terms> --live [--tai
   ARCHIVE block prints `live/closed state is PARTIAL`, and the JSON carries
   `archive.live_coverage_complete: false` beside `live_ids_measured: true`. Do not report
   an `<UNMEASURED>` hit as finished.
-- 🔴 **SIX flags reach the ARCHIVE leg ONLY** — `--any`, `--project`, `--since`,
-  `--claude-only`, `--opencode-only`, `--all` — and the tool names them on stderr. Surface
+- 🔴 **These flags reach the ARCHIVE leg ONLY** — `--any`, `--project`, `--since`,
+  `--claude-only`, `--opencode-only`, `--all` — and the tool names them on stderr. (That
+  list is `ARCHIVE_ONLY_FLAGS` in the script and is pinned against this line by
+  `test_find_session_skill_contract.py`; it carries no count, because a count is a claim
+  nothing enforces.) Surface
   that notice: an empty LIVE section under `--any` is a measured absence under semantics
   the user did not ask for. 🔴 **A CORPUS selector is worse than "not filtered":**
   `--opencode-only --live` shows tmux windows of any runtime, and if the live leg matches
@@ -63,13 +66,17 @@ python3 /home/zach/workspace/devrc/scripts/find-session.py <terms> --live [--tai
   (window closed between the scan and the tail, host gone, no tmux server) prints
   `TAIL: FAILED — … exited N` and exits 4, with `tail.rc` / `tail.ok` in the JSON. Only
   rc 0 and rc 3 are measured; rc 3 renders as an explicitly MEASURED empty pane.
-- Exit codes: `0` found · `2` usage (`--tail` without `--live`, `--limit` below 1) ·
-  `3` `--tail` could not resolve to one window on a FULLY measured fleet ·
-  🔴 **`4` = SOMETHING WAS NOT MEASURED, and it now covers three cases** — the live scan
-  failed or no host answered; the tail resolved but `session-manager tail` failed
-  (rc 2/4/5); or `--tail` found zero matches while a host was unreachable, so the absence
-  is not measured. Branch on `tail.ok` / `tail.rc` / `tail.coverage_complete` in `--json`
-  rather than on `4` alone. `--live` composes with `--json`, which then emits
+- **Exit codes.** 🔴 These sentences are `EXIT_CONTRACT` in `scripts/find-session.py`,
+  copied verbatim and pinned by `scripts/tests/test_find_session_skill_contract.py` — which
+  also pins each one against the behaviour it describes. Do not reword them here alone; an
+  earlier hand-written version of this table shipped two claims the code contradicted.
+- `0` — the run completed. NOT a claim that anything matched — an empty LIVE section and an empty ARCHIVE section both exit 0.
+- `2` — bad arguments: `--tail` without `--live`, `--limit` below 1, or an unparseable `--since`.
+- `3` — `--tail` ONLY: it could not resolve to exactly one live window — several matched, or none did on a fleet where every host answered. It carries NO claim about coverage; the candidate list may be incomplete, and `tail.coverage_complete` is the field that says so.
+- `4` — `--tail` ONLY: something the tail needed was NOT measured — the live scan failed or no host answered, or `session-manager tail` itself failed (rc 2/4/5), or nothing matched while a host was unreachable. Without `--tail` a failed scan still exits 0 and says so in the LIVE section.
+- Branch on `tail.ok` / `tail.rc` / `tail.coverage_complete` in `--json` rather than on the
+  code alone — `tail.coverage_complete` is `null` when the scan never ran, `false` when it
+  ran and a host was missing. `--live` composes with `--json`, which then emits
   `{live, archive, tail}` instead of the bare array.
 - 🔴 **NEVER PASTE CAPTURED OPERATOR TEXT INTO A COMMITTED FILE.** `--live --json` passes
   the live rows through verbatim, and one of them is `unsent_prompt` — text the operator

--- a/claude/skills/find-session/SKILL.md
+++ b/claude/skills/find-session/SKILL.md
@@ -49,18 +49,28 @@ python3 /home/zach/workspace/devrc/scripts/find-session.py <terms> --live [--tai
   ARCHIVE block prints `live/closed state is PARTIAL`, and the JSON carries
   `archive.live_coverage_complete: false` beside `live_ids_measured: true`. Do not report
   an `<UNMEASURED>` hit as finished.
-- 🔴 **`--any`, `--project` and `--since` reach the ARCHIVE leg ONLY** and the tool says so
-  on stderr — the live scan ANDs its terms, has no cwd filter and no date axis. Surface
+- 🔴 **SIX flags reach the ARCHIVE leg ONLY** — `--any`, `--project`, `--since`,
+  `--claude-only`, `--opencode-only`, `--all` — and the tool names them on stderr. Surface
   that notice: an empty LIVE section under `--any` is a measured absence under semantics
-  the user did not ask for. `--limit` DOES bound the LIVE section (it prints
-  `showing N of M`) but deliberately does **not** narrow the `--tail` ambiguity check.
+  the user did not ask for. 🔴 **A CORPUS selector is worse than "not filtered":**
+  `--opencode-only --live` shows tmux windows of any runtime, and if the live leg matches
+  the archive never runs, so **the corpus the user chose is never searched**. The notice
+  says to pass `--deep`; do that rather than reporting the live rows as the answer.
+  `--limit` DOES bound the LIVE section (it prints `showing N of M`) but deliberately does
+  **not** narrow the `--tail` ambiguity check; `--limit` below 1 is a usage error (it used
+  to mean "everything" on one leg and "nothing" on the other).
 - 🔴 **A failed `--tail` is not an empty window.** `session-manager tail` returning 2/4/5
   (window closed between the scan and the tail, host gone, no tmux server) prints
   `TAIL: FAILED — … exited N` and exits 4, with `tail.rc` / `tail.ok` in the JSON. Only
   rc 0 and rc 3 are measured; rc 3 renders as an explicitly MEASURED empty pane.
-- Exit codes: `0` found · `2` usage (e.g. `--tail` without `--live`) · `3` `--tail` could
-  not resolve to one window · `4` the live fleet was not measured. `--live` composes with
-  `--json`, which then emits `{live, archive, tail}` instead of the bare array.
+- Exit codes: `0` found · `2` usage (`--tail` without `--live`, `--limit` below 1) ·
+  `3` `--tail` could not resolve to one window on a FULLY measured fleet ·
+  🔴 **`4` = SOMETHING WAS NOT MEASURED, and it now covers three cases** — the live scan
+  failed or no host answered; the tail resolved but `session-manager tail` failed
+  (rc 2/4/5); or `--tail` found zero matches while a host was unreachable, so the absence
+  is not measured. Branch on `tail.ok` / `tail.rc` / `tail.coverage_complete` in `--json`
+  rather than on `4` alone. `--live` composes with `--json`, which then emits
+  `{live, archive, tail}` instead of the bare array.
 - 🔴 **NEVER PASTE CAPTURED OPERATOR TEXT INTO A COMMITTED FILE.** `--live --json` passes
   the live rows through verbatim, and one of them is `unsent_prompt` — text the operator
   typed and never sent. `--tail` output is a whole pane of it. devrc is a **PUBLIC** repo,

--- a/claude/skills/find-session/SKILL.md
+++ b/claude/skills/find-session/SKILL.md
@@ -70,7 +70,7 @@ python3 /home/zach/workspace/devrc/scripts/find-session.py <terms> --live [--tai
   copied verbatim and pinned by `scripts/tests/test_find_session_skill_contract.py` — which
   also pins each one against the behaviour it describes. Do not reword them here alone; an
   earlier hand-written version of this table shipped two claims the code contradicted.
-- `0` — the run completed. NOT a claim that anything matched — an empty LIVE section and an empty ARCHIVE section both exit 0.
+- `0` — the run completed. NOT a claim that anything matched — an empty LIVE section and an empty ARCHIVE section both exit 0. 🔴 NOR a claim about coverage: a `--tail` that resolved to ONE window exits 0 even when a host did not answer, so another window may match on the host that was never asked. This is the code a caller ACTS on — read `tail.coverage_complete` before treating the resolution as unique.
 - `2` — bad arguments: `--tail` without `--live`, `--limit` below 1, or an unparseable `--since`.
 - `3` — `--tail` ONLY: it could not resolve to exactly one live window — several matched, or none did on a fleet where every host answered. It carries NO claim about coverage; the candidate list may be incomplete, and `tail.coverage_complete` is the field that says so.
 - `4` — `--tail` ONLY: something the tail needed was NOT measured — the live scan failed or no host answered, or `session-manager tail` itself failed (rc 2/4/5), or nothing matched while a host was unreachable. Without `--tail` a failed scan still exits 0 and says so in the LIVE section.

--- a/claude/skills/find-session/SKILL.md
+++ b/claude/skills/find-session/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: find-session
 description: "Find a past Claude Code OR opencode session by keyword — searches both runtimes on both hosts and returns ranked sessions with the resume command. Use to recover 'the session where we did X'."
-argument-hint: "<term> [<term> …] [--live [--deep] [--tail N]] [--project SUBSTR] [--since YYYY-MM-DD] [--any] [--limit N] [--claude-only|--opencode-only]"
+argument-hint: "<term> [<term> …] [--live [--deep] [--tail N]] [--limit N] [--project SUBSTR (archive only)] [--since YYYY-MM-DD (archive only)] [--any (archive only)] [--claude-only|--opencode-only]"
 allowed-tools: Bash, Read
 ---
 
@@ -42,8 +42,22 @@ python3 /home/zach/workspace/devrc/scripts/find-session.py <terms> --live [--tai
   say so in your answer rather than reporting the empty result as an absence. The tool
   falls back to the archive in all three cases and labels why.
 - Archive hits are annotated **`<LIVE>` / `<CLOSED>` / `<UNMEASURED>`** by joining on
-  `claude_session_id` against a second, *unfiltered* live scan. `UNMEASURED` means no live
-  scan answered — it is not `CLOSED`.
+  `claude_session_id` against a second, *unfiltered* live scan. 🔴 **A `<CLOSED>` needs
+  FULL coverage; a `<LIVE>` does not.** Finding the id on a host that answered proves the
+  session is live. Failing to find it proves nothing while any host is down — so with the
+  laptop asleep (this fleet's common degraded state) a miss reads `<UNMEASURED>`, the
+  ARCHIVE block prints `live/closed state is PARTIAL`, and the JSON carries
+  `archive.live_coverage_complete: false` beside `live_ids_measured: true`. Do not report
+  an `<UNMEASURED>` hit as finished.
+- 🔴 **`--any`, `--project` and `--since` reach the ARCHIVE leg ONLY** and the tool says so
+  on stderr — the live scan ANDs its terms, has no cwd filter and no date axis. Surface
+  that notice: an empty LIVE section under `--any` is a measured absence under semantics
+  the user did not ask for. `--limit` DOES bound the LIVE section (it prints
+  `showing N of M`) but deliberately does **not** narrow the `--tail` ambiguity check.
+- 🔴 **A failed `--tail` is not an empty window.** `session-manager tail` returning 2/4/5
+  (window closed between the scan and the tail, host gone, no tmux server) prints
+  `TAIL: FAILED — … exited N` and exits 4, with `tail.rc` / `tail.ok` in the JSON. Only
+  rc 0 and rc 3 are measured; rc 3 renders as an explicitly MEASURED empty pane.
 - Exit codes: `0` found · `2` usage (e.g. `--tail` without `--live`) · `3` `--tail` could
   not resolve to one window · `4` the live fleet was not measured. `--live` composes with
   `--json`, which then emits `{live, archive, tail}` instead of the bare array.

--- a/claude/skills/find-session/SKILL.md
+++ b/claude/skills/find-session/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: find-session
 description: "Find a past Claude Code OR opencode session by keyword — searches both runtimes on both hosts and returns ranked sessions with the resume command. Use to recover 'the session where we did X'."
-argument-hint: "<term> [<term> …] [--project SUBSTR] [--since YYYY-MM-DD] [--any] [--limit N] [--claude-only|--opencode-only]"
+argument-hint: "<term> [<term> …] [--live [--deep] [--tail N]] [--project SUBSTR] [--since YYYY-MM-DD] [--any] [--limit N] [--claude-only|--opencode-only]"
 allowed-tools: Bash, Read
 ---
 
@@ -11,7 +11,54 @@ Goal: kill the hand-typed "find the session where we did pr 235 / migrated the r
 
 Query: `$ARGUMENTS`.
 
-## What to do
+## 🔴 If the user thinks it might still be RUNNING, use `--live` — 1.8 s, not 30 s
+
+Measured 2026-08-28: the transcript walk below takes **30.1 s**; the live cross-host tmux
+scan takes **1.82 s**, and its rows already carry the task, the label, the hotkey, the
+status, `waiting_probable`, the path and the session id. For *"find that thing I lost
+track of, is it still running, which window, where did it leave off"* the archive is the
+**wrong instrument** — it searches the past for a question about now.
+
+```bash
+python3 /home/zach/workspace/devrc/scripts/find-session.py <terms> --live [--tail 80]
+```
+
+- **Live first, archive only as a fallback.** If any live window matched, the 30 s walk is
+  skipped entirely and the output says so. `--deep` runs both.
+- **Matched against `task`, `label` and `codename` — deliberately NOT `path`.** Measured on
+  a 72-row scan: one substring hit **1** row on `task` and **29** on `path`, because nearly
+  every window shares a repo path. The LIVE header prints the field list it searched, so
+  surface it if a query the user expected to hit found nothing.
+- **`--tail N` answers "where did it leave off"** by printing that window's scrollback —
+  only when the match resolved to **exactly one** window. 🔴 **It REFUSES otherwise**:
+  several matched → exit 3, listing the candidates with a ready-made command for each
+  (*do not pick one for them* — a scrollback printed from the wrong window reads as a
+  correct answer); none matched → exit 3; the fleet was not measured → exit 4.
+- **Quote `hotkey_display` from the output verbatim; never re-derive a chord.** `M-v` opens
+  `scratch3`/violet and `M-V` opens `scratch4`/**Vapor** — different sessions. A previous
+  run read `hotkey: v` and answered `Alt+Shift+V`, sending the operator to the wrong window.
+- 🔴 **An unreachable host is never "not running".** `LIVE: SCAN FAILED` / `LIVE: NO HOST
+  ANSWERED` / a `NOT searched: <host>` line each mean the fleet was **not measured** —
+  say so in your answer rather than reporting the empty result as an absence. The tool
+  falls back to the archive in all three cases and labels why.
+- Archive hits are annotated **`<LIVE>` / `<CLOSED>` / `<UNMEASURED>`** by joining on
+  `claude_session_id` against a second, *unfiltered* live scan. `UNMEASURED` means no live
+  scan answered — it is not `CLOSED`.
+- Exit codes: `0` found · `2` usage (e.g. `--tail` without `--live`) · `3` `--tail` could
+  not resolve to one window · `4` the live fleet was not measured. `--live` composes with
+  `--json`, which then emits `{live, archive, tail}` instead of the bare array.
+- 🔴 **NEVER PASTE CAPTURED OPERATOR TEXT INTO A COMMITTED FILE.** `--live --json` passes
+  the live rows through verbatim, and one of them is `unsent_prompt` — text the operator
+  typed and never sent. `--tail` output is a whole pane of it. devrc is a **PUBLIC** repo,
+  as is every `claudedocs/` note, commit message, PR body and fixture an agent writes into
+  it. Report either as a **count, a length or a shape**, never verbatim. (The human `--live`
+  section deliberately does not print `unsent_prompt` at all.)
+
+The live scan is `session-manager scan --json --lean --no-ch --match …`; the match
+predicate lives THERE, not in `find-session.py`, so the two tools cannot disagree. Details:
+`~/.claude/skills/session-manager/reference/payload-contract.md`.
+
+## What to do (the archive search)
 
 1. Run the search helper:
    ```bash
@@ -50,4 +97,4 @@ Notes:
   sessions, and there are ~6x more of them than there are sessions).
 - To actually re-enter a session, the user runs `claude --resume <id>` themselves (a session can't resume into another from here).
 
-Pair: `/resume` (re-enter from a handoff doc), `/handoff` (so next time there's a doc instead of archaeology).
+Pair: `/resume` (re-enter from a handoff doc), `/handoff` (so next time there's a doc instead of archaeology), `session-manager` (the live fleet in full — this skill's `--live` is a one-question slice of it).

--- a/claude/skills/session-manager/reference/payload-contract.md
+++ b/claude/skills/session-manager/reference/payload-contract.md
@@ -52,8 +52,21 @@ mirrored into `summary`:
 |---|---|
 | `filters.match` / `summary.match` | the terms. **`null`, never `[]`**, when no filter ran |
 | `filters.match_fields` / `summary.match_fields` | what was ACTUALLY searched — this is where you see whether `path` was in the set |
-| `filters.matched` | rows that survived, stated positively |
-| `filters.excluded_by_match` / `summary.excluded_by_match` | rows the filter dropped. `null`, never `0`, when no filter ran |
+| `filters.matched` / `summary.matched` | rows that survived, stated positively |
+| `filters.excluded_by_match` / `summary.excluded_by_match` | rows the filter dropped |
+
+🔴 **`matched` and `excluded_by_match` are `null`, never `0`, in TWO states**: when no
+filter ran, and when **no host was reachable**. A `0` there would say "the filter ran and
+matched nothing" about a scan that measured nothing — the rule `detail_matched` already
+followed. The **terms and the field list are still published** over an unreachable fleet:
+which filter was *requested* is known regardless of whether anything answered.
+⚠ A **partially** reachable fleet publishes real counts — one host answering is a
+measurement. ⚠ `excluded_shells` has the same shape and is deliberately **not**
+null-guarded: it is a pre-existing field and redefining it belongs in its own change.
+
+🔴 **`summary.matched` is NOT `summary.total_sessions`.** On a `detail` they differ by
+construction — the row filter matched N, then `filter_report` narrowed to 0 or 1. The
+table's `FILTER --match` line quotes `matched`, because that line describes the FILTER.
 
 **Exit code**: reachable hosts + zero matches is **`3` (EXIT_EMPTY)**, never `0`. No host
 reachable is still **`4`** — the zero is unmeasured either way the rows are filtered.
@@ -84,7 +97,26 @@ you asked for index '3' (searched: workbench); NOT searched: laptop — unreacha
 |---|---|
 | `filters.detail_target` | the address you asked for |
 | `filters.detail_matched` | rows matched. `0` is the miss; **`null` means NO host answered** |
-| `filters.detail_sibling_indices` | the indices that DO exist for that session name. `[]` = no such session; **`null` = unmeasured** |
+| `filters.detail_sibling_indices` | the indices that exist for that session name **on the hosts that answered, BEFORE any row filter**. `[]` = no such session; **`null` = unmeasured** |
+| `filters.detail_filtered_out` | **`true` = the window EXISTS and a row filter removed it.** `null` = unmeasured |
+
+🔴 **UNDER `--claude-only` / `--match`, A MISS IS USUALLY THE FILTER'S DOING.** Rows are
+filtered in `gather` BEFORE `filter_report` narrows, so a naive sibling list enumerates only
+the survivors. Measured live at an earlier revision: `detail scratch2:1 --claude-only`
+answered *"session 'scratch2' has windows ['2', '3', '4']"* while window 1 existed on BOTH
+searched hosts — a flat falsehood that `(searched: …)` made read as authoritative.
+
+`gather` therefore samples `filters.prefilter_window_indices` (`{session: [index…]}`,
+reachable hosts only, **`detail` only** — a 1-row `--match` scan must not carry a fleet's
+index map back) and the message now distinguishes three misses:
+
+```
+detail: WINDOW 'scratch2:1' EXISTS but a ROW FILTER (--claude-only) removed it — this
+empty result is the FILTER's doing, NOT a measured absence. …
+detail: NO SUCH WINDOW 'scratch2:9' — session 'scratch2' has windows ['1','2','3','4'];
+you asked for index '9' (indices measured BEFORE the row filter --claude-only) …
+detail: NO SUCH WINDOW 'zz:1' — no session named 'zz' exists on any host that answered …
+```
 
 🔴 **Nothing is printed and the fields are `null` when no host was reachable.** An address
 that could not be CHECKED is not an address that does not EXIST — the exit code is `4` there,

--- a/claude/skills/session-manager/reference/payload-contract.md
+++ b/claude/skills/session-manager/reference/payload-contract.md
@@ -107,8 +107,8 @@ answered *"session 'scratch2' has windows ['2', '3', '4']"* while window 1 exist
 searched hosts — a flat falsehood that `(searched: …)` made read as authoritative.
 
 `gather` therefore samples `filters.prefilter_window_indices` (`{session: [index…]}`,
-reachable hosts only, **`detail` only** — a 1-row `--match` scan must not carry a fleet's
-index map back) and the message now distinguishes three misses:
+**`detail` only** — a 1-row `--match` scan must not carry a fleet's index map back) and the
+message now distinguishes three misses:
 
 ```
 detail: WINDOW 'scratch2:1' EXISTS but a ROW FILTER (--claude-only) removed it — this
@@ -117,6 +117,12 @@ detail: NO SUCH WINDOW 'scratch2:9' — session 'scratch2' has windows ['1','2',
 you asked for index '9' (indices measured BEFORE the row filter --claude-only) …
 detail: NO SUCH WINDOW 'zz:1' — no session named 'zz' exists on any host that answered …
 ```
+
+⚠ **The map contains only hosts that answered — but not because it filters on that.** An
+unreachable host's `windows` is `[]`, so it contributes nothing wherever rows are read. The
+property is over-determined (`run_tmux` returns empty stdout on every unreachable path
+*and* the population loop skips such a host), so no single-mechanism change reds a test.
+Do not read a green suite as licence to delete the remaining enforcement.
 
 🔴 **Nothing is printed and the fields are `null` when no host was reachable.** An address
 that could not be CHECKED is not an address that does not EXIST — the exit code is `4` there,

--- a/claude/skills/session-manager/reference/payload-contract.md
+++ b/claude/skills/session-manager/reference/payload-contract.md
@@ -15,6 +15,8 @@ _Moved verbatim out of `SKILL.md` on 2026-08-21, when the body was cut from 23,2
 | `--lean` | 🔴 **with `--json`, prefer this.** The agent-shaped view: rows trimmed to the fields that answer this tool's question, **untruncated**, with every measurement discriminator and the caveats kept |
 | `--host workbench\|laptop\|all` | default `all`; `tail` resolves `all` to LOCAL |
 | `--claude-only` | drop the **shell** rows (`CLASS=shell`) — a `cluster` dispatch is an agent and is KEPT. Every count then describes the FILTERED set; `summary.excluded_shells` says how many went and `summary.kinds_excluded_by_filter` names any kind removed entirely |
+| `--match SUBSTR` | **repeatable**, `scan`/`list`/`detail`. Keep only rows whose **`task`, `label` or `codename`** contains SUBSTR, case-insensitively. Terms are **ANDed** (a row must match all — the same default `find-session.py` uses), and one term may satisfy itself in a different field from another. Every count then describes the MATCHED set; see below |
+| `--match-path` | add **`path`** to the fields `--match` searches. **OFF by default, and that is the feature** |
 | `--no-ch` | skip ClickHouse — the client is never constructed |
 | `--no-capture` | skip the pane scrape; **every** `waiting_probable` AND `unsent_prompt` becomes `null` (both roll-up numbers `null`, never `0`) |
 | `--fuzzyclaw` / `--no-fuzzyclaw` | the task-file join is **OFF by default** (see below) |
@@ -23,6 +25,71 @@ _Moved verbatim out of `SKILL.md` on 2026-08-21, when the body was cut from 23,2
 | `--stale-threshold <secs>` | default 3600; `age >= threshold` is stale |
 | `--lines N` | `tail` scrollback depth (default 100) |
 
+
+## 🔴 `--match` — asking the LIVE scan "which window is about X"
+
+This is the flag that makes `session-manager` the right instrument for *"find the thing I
+lost track of"*. Measured 2026-08-28: the transcript-archive walk (`find-session.py`) takes
+**30.1 s**; `session-manager --json --lean --no-ch` takes **1.82 s** and 66 of its 72 rows
+carried a populated `task`. For a question about what is running NOW, the archive is the
+wrong corpus. `find-session.py --live` drives exactly this flag.
+
+🔴 **`path` IS NOT SEARCHED BY DEFAULT, AND THE NUMBERS ARE WHY.** One query substring, one
+72-row scan:
+
+| matched against | rows hit |
+|---|---|
+| `task` | **1** — the correct window |
+| `path` | **29** — nearly every window shares a repo path |
+
+A filter whose answer is 40% of the fleet is the unfiltered scan wearing a filter's
+authority. Pass `--match-path` when you genuinely mean "everything in that checkout".
+
+**What the payload tells you, so a zero is never ambiguous** — in `report["filters"]` and
+mirrored into `summary`:
+
+| key | meaning |
+|---|---|
+| `filters.match` / `summary.match` | the terms. **`null`, never `[]`**, when no filter ran |
+| `filters.match_fields` / `summary.match_fields` | what was ACTUALLY searched — this is where you see whether `path` was in the set |
+| `filters.matched` | rows that survived, stated positively |
+| `filters.excluded_by_match` / `summary.excluded_by_match` | rows the filter dropped. `null`, never `0`, when no filter ran |
+
+**Exit code**: reachable hosts + zero matches is **`3` (EXIT_EMPTY)**, never `0`. No host
+reachable is still **`4`** — the zero is unmeasured either way the rows are filtered.
+
+`--match` composes with `--claude-only`; both narrow the same row set and share ONE
+`kinds_excluded_by_filter` answer. It has no effect on `tail`, which says so on stderr.
+
+## 🔴 `detail <session>:<index>` — the output SHAPE, and the two row keys
+
+**`detail --json` returns the FULL REPORT**, with `hosts[*].windows` narrowed to the one
+matching row. It does **not** return `{"window": {...}}`. `main()` calls `filter_report`,
+which keeps every host's reachability facts — dropping them would turn *"unreachable"* into
+*"not found"*. So read `blob["hosts"][<host>]["windows"][0]`, not `blob["window"]`.
+
+**The row keys are `window_index` and `path`** — not `window`, not `cwd`. A `.get("window")`
+returns `None` forever and reads exactly like a measured null.
+
+🔴 **A MISS IS NOW LOUD.** An address matching no window used to hand back a silent empty
+window list, byte-identical to *"found it, the window is idle"*. It now prints to **stderr**
+and records the same facts structurally:
+
+```
+detail: NO SUCH WINDOW 'scratch3:3' — session 'scratch3' has windows ['1', '2'];
+you asked for index '3' (searched: workbench); NOT searched: laptop — unreachable, …
+```
+
+| key | meaning |
+|---|---|
+| `filters.detail_target` | the address you asked for |
+| `filters.detail_matched` | rows matched. `0` is the miss; **`null` means NO host answered** |
+| `filters.detail_sibling_indices` | the indices that DO exist for that session name. `[]` = no such session; **`null` = unmeasured** |
+
+🔴 **Nothing is printed and the fields are `null` when no host was reachable.** An address
+that could not be CHECKED is not an address that does not EXIST — the exit code is `4` there,
+not `3`, and saying "no such window" would send you to re-check your spelling instead of your
+SSH. **Do not guess an index from the session NAME**: `scratch3`'s windows are `1` and `2`.
 
 ## Summary buckets, and `kind` vs `CLASS`
 
@@ -97,6 +164,20 @@ The table's old CODENAME column is now LABEL and renders `Grove (S)`.
 window, read from the slot table's own `key` field. It is **`null` (never `""`) on tiers 2
 and 3**: no binding exists for a session outside the table, so quoting a key there would
 send the operator to press something and land nowhere.
+
+🔴 **QUOTE `hotkey_display`, NEVER DERIVE THE CHORD FROM `hotkey` YOURSELF.** Every row
+carries `hotkey_display` (in `LEAN_ROW_FIELDS` too): `null` when `hotkey` is null,
+`Alt+<k>` for a lower-case key, `Alt+Shift+<K>` for an upper-case one.
+
+**Case is significant and it is NOT a Shift convention.** Per `scripts/tmux-scratch-slots.sh`,
+`M-v` → `scratch3`/violet and `M-V` → `scratch4`/**Vapor** — two DIFFERENT sessions.
+Measured 2026-08-28: a run read `hotkey: v` off a row, answered `Alt+Shift+V`, and sent the
+operator to a real window that was the wrong one. The derivation lives in ONE function now
+(`hotkey_display`) and its result is on the row, so no reader has to perform it.
+
+⚠ The TABLE's `LABEL` cell still shows the RAW key — `violet (v)`, `Vapor (V)` — because the
+column is 14 characters and `Yarrow (Alt+Shift+Y)` is 20. That parenthesis is a **key**, not
+a chord; run it through the rule above (or read `--json`) before quoting it to a human.
 
 🔴 **`label` is NOT an address — `session:window` still is.** Two sessions sitting in one
 repo resolve to the SAME label, so quote both. New non-scratch sessions get a real tmux name

--- a/scripts/find-session.py
+++ b/scripts/find-session.py
@@ -86,7 +86,51 @@ LIVE_TIMEOUT_SECS = 90
 EXIT_OK = 0
 EXIT_USAGE = 2
 EXIT_AMBIGUOUS = 3      # --tail could not resolve to exactly one window
-EXIT_UNAVAILABLE = 4    # the live fleet was not measured — same code as the sibling
+EXIT_UNAVAILABLE = 4    # --tail only: something the tail needed was not measured
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE EXIT CONTRACT, AS DATA — because the shipped doc got it wrong TWICE
+# --------------------------------------------------------------------------- #
+# `claude/skills/find-session/SKILL.md` is what an agent reads before branching
+# on an exit code, and it shipped two false claims at once:
+#
+#   * "3 = --tail could not resolve to one window on a FULLY MEASURED fleet".
+#     False. Two live matches with a host DOWN also exits 3, while the run
+#     itself prints "this candidate list is INCOMPLETE". A wrapper reading
+#     `rc == 3 => here are all the candidates` reports a complete list under
+#     this fleet's documented common degraded state — the "real but wrong
+#     window" failure this whole change exists to prevent, relocated to the
+#     caller.
+#   * "4 = the live scan failed or no host answered", with no `--tail`
+#     qualifier. False. EVERY source of this code is inside the tail path;
+#     without `--tail` a failed scan exits 0, because the LIVE section says so
+#     in prose and the archive still ran.
+#
+# So the table is DATA here, one sentence per code, and a test pins the shipped
+# doc against it AND pins each sentence against the behaviour it describes.
+# Correcting the prose alone would have left the next drift undetected — which
+# is what happened between the last two rounds.
+#
+# 🔴 THE SENTENCES SAY WHAT THE CODE MEANS, NOT WHAT THE CALLER SHOULD WANT.
+# `3` and `4` are BOTH `--tail`-only, and neither carries any claim about fleet
+# coverage: read `tail.coverage_complete` for that.
+EXIT_CONTRACT = (
+    (EXIT_OK, "the run completed. NOT a claim that anything matched — an empty "
+              "LIVE section and an empty ARCHIVE section both exit 0."),
+    (EXIT_USAGE, "bad arguments: `--tail` without `--live`, `--limit` below 1, "
+                 "or an unparseable `--since`."),
+    (EXIT_AMBIGUOUS, "`--tail` ONLY: it could not resolve to exactly one live "
+                     "window — several matched, or none did on a fleet where "
+                     "every host answered. It carries NO claim about coverage; "
+                     "the candidate list may be incomplete, and "
+                     "`tail.coverage_complete` is the field that says so."),
+    (EXIT_UNAVAILABLE, "`--tail` ONLY: something the tail needed was NOT "
+                       "measured — the live scan failed or no host answered, "
+                       "or `session-manager tail` itself failed (rc 2/4/5), or "
+                       "nothing matched while a host was unreachable. Without "
+                       "`--tail` a failed scan still exits 0 and says so in the "
+                       "LIVE section."),
+)
 
 
 def _default_run(argv, timeout=LIVE_TIMEOUT_SECS):
@@ -223,6 +267,25 @@ def live_coverage_complete(res):
     return res.get("status") == "ok" and not res.get("hosts_unreachable")
 
 
+def live_coverage_state(res):
+    """`True` / `False` / **`None`** — the PUBLISHABLE form of coverage.
+
+    🔴 `live_coverage_complete` is a two-valued PREDICATE and is right for
+    branching: on a scan that never ran, "was coverage complete?" is correctly
+    False, because it certainly was not. But PUBLISHING that False says
+    *measured, and incomplete* about a scan that produced no measurement at all
+    — the exact shape removed from `hosts_unreachable` one field over, in the
+    same commit that introduced this one.
+
+    `None` for `status == "error"` only. `unavailable` is NOT unmeasured here:
+    that scan RAN and every host was genuinely unreachable, so `False` is a real
+    answer.
+    """
+    if res.get("status") == "error":
+        return None
+    return live_coverage_complete(res)
+
+
 def live_state_of(session_id, live_ids, coverage_complete=True):
     """`LIVE` / `CLOSED` / `UNMEASURED` for one archive hit.
 
@@ -300,7 +363,13 @@ def archive_only_notice(args):
     line = ("(ARCHIVE-ONLY flags, ignored by the live scan: "
             + "; ".join(f"{spelling} ({why})" for _, spelling, why in named)
             + " — the LIVE section below is NOT filtered by them)")
-    if any(dest in CORPUS_SELECTOR_DESTS for dest, _, _ in named):
+    # 🔴 ...AND NOT WHEN `--deep` ALREADY FORCES THE ARCHIVE. The sentence exists
+    # to say "the corpus you chose may go unsearched — pass --deep"; with
+    # `--deep` already passed the archive DOES run, so it is advice to do the
+    # thing the caller has done. That is the same "noise that trains the reader
+    # to skip the line" this file refused to append to `--since`.
+    if (any(dest in CORPUS_SELECTOR_DESTS for dest, _, _ in named)
+            and not getattr(args, "deep", False)):
         # 🔴 The consequence, not just the fact. A corpus selector says WHICH
         # ARCHIVE to search, and the archive does not run at all when the live
         # leg matches — so the corpus the caller explicitly chose can go
@@ -441,7 +510,18 @@ def render_live(res, limit=None):
     return out
 
 
-def parse_args(argv=None):
+def build_parser():
+    """The parser, EXPOSED — so the archive-only partition can be checked
+    against the parser's own ACTIONS rather than against a parsed namespace.
+
+    🔴 A namespace is not the flag set. `set(vars(parse_args([...])))` misses any
+    flag declared `default=argparse.SUPPRESS`, which is absent from the namespace
+    entirely — so such a flag was in neither half of the partition and the
+    equality still held. Measured: a `--newest-first` with `SUPPRESS`, classified
+    nowhere, left the whole suite green while the gate's own comment claimed
+    "adding a flag without deciding which fails the suite". Reading `_actions`
+    sees every declared flag whatever its default.
+    """
     p = argparse.ArgumentParser(add_help=True, description="Find past Claude Code and opencode sessions by keyword.")
     p.add_argument("terms", nargs="+", help="search terms (ANDed unless --any)")
     p.add_argument("--project", default="", help="only sessions whose cwd/project contains this substring")
@@ -466,7 +546,19 @@ def parse_args(argv=None):
                    help="with --live: print the last N scrollback lines of the "
                         "matched window. REFUSES on an ambiguous match rather "
                         "than guessing (exit 3), and lists the candidates.")
-    return p.parse_args(argv)
+    return p
+
+
+def parser_dests():
+    """Every destination the parser DECLARES, `help` excluded.
+
+    Read off `_actions`, not off a parsed namespace — see `build_parser`.
+    """
+    return {a.dest for a in build_parser()._actions if a.dest != "help"}
+
+
+def parse_args(argv=None):
+    return build_parser().parse_args(argv)
 
 
 def render(r):
@@ -792,7 +884,12 @@ def main(argv=None):
                 # the only match ON THE HOSTS THAT ANSWERED. Neither fact is
                 # readable from `archive.*`, which describes a different scan
                 # (the unfiltered one) and is absent entirely on the fast path.
-                "coverage_complete": live_coverage_complete(live),
+                # 🔴 `live_coverage_state`, NOT `live_coverage_complete`: the
+                # predicate is two-valued and publishing its `False` for a scan
+                # that never ran claims *measured, and incomplete*. `SKILL.md`
+                # points a branching caller at THIS field, so it is the one
+                # field that must be able to say "unmeasured".
+                "coverage_complete": live_coverage_state(live),
                 "hosts_unreachable": live["hosts_unreachable"],
                 "message": "\n".join(tail_lines) or None,
                 # 🔴 `rc` and `ok` TRAVEL WITH THE TEXT. An empty `text` beside

--- a/scripts/find-session.py
+++ b/scripts/find-session.py
@@ -116,7 +116,12 @@ EXIT_UNAVAILABLE = 4    # --tail only: something the tail needed was not measure
 # coverage: read `tail.coverage_complete` for that.
 EXIT_CONTRACT = (
     (EXIT_OK, "the run completed. NOT a claim that anything matched — an empty "
-              "LIVE section and an empty ARCHIVE section both exit 0."),
+              "LIVE section and an empty ARCHIVE section both exit 0. 🔴 NOR a "
+              "claim about coverage: a `--tail` that resolved to ONE window "
+              "exits 0 even when a host did not answer, so another window may "
+              "match on the host that was never asked. This is the code a "
+              "caller ACTS on — read `tail.coverage_complete` before treating "
+              "the resolution as unique."),
     (EXIT_USAGE, "bad arguments: `--tail` without `--live`, `--limit` below 1, "
                  "or an unparseable `--since`."),
     (EXIT_AMBIGUOUS, "`--tail` ONLY: it could not resolve to exactly one live "
@@ -712,7 +717,12 @@ def main(argv=None):
             since = datetime.fromisoformat(a.since)
         except ValueError:
             print(f"bad --since date: {a.since!r} (want YYYY-MM-DD)", file=sys.stderr)
-            sys.exit(2)
+            # 🔴 `return EXIT_USAGE`, not `sys.exit(2)`. The literal was correct
+            # and `EXIT_CONTRACT` names this path in the exit-2 sentence — but a
+            # renumbering of `EXIT_USAGE` would have moved the constant and left
+            # this literal behind, splitting a documented pair silently. It also
+            # makes the path testable in-process like every other exit.
+            return EXIT_USAGE
 
     if a.tail is not None and not a.live:
         print("--tail requires --live: it prints the scrollback of a LIVE tmux "

--- a/scripts/find-session.py
+++ b/scripts/find-session.py
@@ -146,6 +146,15 @@ def live_scan(terms=()):
         detail = (stderr or stdout or "").strip()[:200]
         return dict(out, error=(f"session-manager exited {rc} and produced no "
                                 f"JSON on stdout: {detail!r}"))
+    # 🔴 VALID JSON IS NOT A REPORT. `json.loads("[]")` and `json.loads("null")`
+    # both succeed and then `report.get` raises AttributeError OUTSIDE the try —
+    # crashing a function whose entire contract is to return a status-
+    # discriminated result rather than raise. A truncated pipe or a wrapper that
+    # prints a bare array is enough.
+    if not isinstance(report, dict):
+        return dict(out, error=(f"session-manager exited {rc} and produced "
+                                f"{type(report).__name__}, not a report "
+                                "object, on stdout"))
     hosts = report.get("hosts") or {}
     out["hosts_reachable"] = sorted(k for k, v in hosts.items() if v.get("reachable"))
     out["hosts_unreachable"] = sorted(k for k, v in hosts.items()
@@ -167,6 +176,11 @@ def live_session_ids(res):
     🔴 `None` MEANS UNMEASURED, and it is what stops an archive hit being
     labelled CLOSED on the strength of a scan that never ran. A caller must
     branch on it; `set()` is the measured "the fleet holds no session ids".
+
+    ⚠ A NON-`None` RETURN IS NOT PROOF OF FULL COVERAGE. `status == "ok"` means
+    at least ONE host answered, so this set can be built from a partial fleet.
+    `live_coverage_complete` is the second half of the answer and a caller that
+    wants to say CLOSED needs BOTH — see `live_state_of`.
     """
     if res.get("status") != "ok":
         return None
@@ -174,11 +188,44 @@ def live_session_ids(res):
             if r.get("claude_session_id")}
 
 
-def live_state_of(session_id, live_ids):
-    """`LIVE` / `CLOSED` / `UNMEASURED` for one archive hit."""
+def live_coverage_complete(res):
+    """Did EVERY host answer? Only then can a MISS mean anything.
+
+    🔴 THE DEFECT THIS EXISTS FOR. `live_scan` sets `status: "ok"` when ANY host
+    answers, and `hosts_unreachable` may be non-empty in that state. Off that
+    set alone, every archive hit whose session lives on the DOWN host was
+    stamped `CLOSED` — a confident "that session is finished" about a machine
+    nobody talked to — with `live_ids_measured: true` and no warning printed.
+    On this fleet the laptop is a secondary machine that is frequently asleep,
+    so the partial fleet is the COMMON degraded state, not an exotic one.
+
+    Per-host attribution is deliberately NOT attempted: an archive hit carries a
+    `cwd` and a session id but no host, and the Claude transcript corpus is read
+    from local disk while the opencode corpus is read from both hosts — so there
+    is no sound mapping from a hit to the host that would confirm it. The
+    coarse answer is the one that is true.
+    """
+    return res.get("status") == "ok" and not res.get("hosts_unreachable")
+
+
+def live_state_of(session_id, live_ids, coverage_complete=True):
+    """`LIVE` / `CLOSED` / `UNMEASURED` for one archive hit.
+
+    🔴 A POSITIVE IS A MEASUREMENT WHATEVER THE COVERAGE; A NEGATIVE IS NOT.
+    Finding the id on a host that answered proves the session is live, and no
+    unreachable peer can make that false. Failing to find it proves nothing
+    unless every host answered — so a miss under partial coverage is
+    `UNMEASURED`, never `CLOSED`.
+
+    `coverage_complete` defaults to True so the parameter cannot be forgotten
+    into a silently WEAKER verdict; forgetting it yields the strict old
+    behaviour, which is wrong loudly rather than wrong quietly.
+    """
     if live_ids is None:
         return "UNMEASURED"
-    return "LIVE" if session_id in live_ids else "CLOSED"
+    if session_id in live_ids:
+        return "LIVE"
+    return "CLOSED" if coverage_complete else "UNMEASURED"
 
 
 def fmt_age(secs):
@@ -214,15 +261,32 @@ def live_tail_argv(row, lines):
             "--host", str(row.get("host")), "--plain", "--lines", str(int(lines))]
 
 
+# 🔴 THE TAIL EXIT CODES THAT ARE NOT FAILURES. `session-manager tail` returns
+# 0 for a scrollback and 3 (EXIT_EMPTY) for a window whose scrollback really is
+# empty — a MEASURED empty. Everything else (2 no-such-window, 4 host
+# unreachable, 5 no tmux server) means the scrollback was NOT obtained, and
+# rendering that as "(empty scrollback)" over exit 0 is the silent-zero failure
+# this whole tool exists to refuse. The window closing between the scan and the
+# tail is an ordinary race, not an exotic one.
+TAIL_MEASURED_RCS = (0, 3)
+
+
 def live_tail(row, lines):
+    """One window's scrollback, with `ok` DISCRIMINATED from an empty string.
+
+    `ok` is False whenever the scrollback was not obtained; `rc` travels with
+    it so a caller never has to infer the reason from an empty `text`.
+    """
     try:
         rc, stdout, stderr = RUN(live_tail_argv(row, lines))
     except Exception as e:  # noqa: BLE001
-        return {"rc": None, "text": "", "error": f"{type(e).__name__}: {e}"}
-    return {"rc": rc, "text": stdout, "error": (stderr or "").strip() or None}
+        return {"rc": None, "ok": False, "text": "",
+                "error": f"{type(e).__name__}: {e}"}
+    return {"rc": rc, "ok": rc in TAIL_MEASURED_RCS, "text": stdout,
+            "error": (stderr or "").strip() or None}
 
 
-def render_live(res):
+def render_live(res, limit=None):
     """The LIVE section. Returns a list of lines, ALWAYS non-empty."""
     out = []
     if res["status"] == "error":
@@ -252,7 +316,16 @@ def render_live(res):
         out.append("  (no live window matched these terms on the hosts that "
                    "answered)")
         return out
-    for i, r in enumerate(rows, 1):
+    # 🔴 `--limit` BOUNDS THE DISPLAY, NOT THE MEASUREMENT. The header above
+    # already printed the full match count, and `_tail_outcome` is handed the
+    # UNSLICED list — capping the ambiguity check at the display limit would
+    # turn "several matched, I refuse" into "one is showing, I will tail that
+    # one", which is guessing with extra steps.
+    shown = rows if limit is None or limit <= 0 else rows[:limit]
+    if len(shown) < len(rows):
+        out.append(f"  (showing {len(shown)} of {len(rows)} — raise --limit "
+                   "to see the rest)")
+    for i, r in enumerate(shown, 1):
         # 🔴 `hotkey_display` is READ, never derived here. `M-v` and `M-V` are
         # different sessions; the one writer of that spelling is
         # `session-manager.hotkey_display`, and re-deriving it in this renderer
@@ -432,6 +505,26 @@ def main(argv=None):
     if a.deep and not a.live:
         print("(--deep only means something with --live: without it the "
               "transcript walk always runs)", file=sys.stderr)
+    # 🔴 A FLAG THAT REACHES ONLY ONE LEG MUST SAY SO. `--any`, `--project` and
+    # `--since` are ARCHIVE-only: the live scan has no OR mode (`--match` ANDs),
+    # no cwd filter that is not `--match-path`, and no date axis at all. Left
+    # silent, `find-session.py redis vpn --any --live` sent ANDed terms to the
+    # live leg and then printed "(no live window matched these terms…)" — a
+    # measured absence under semantics the caller did not ask for. This diff
+    # already prints five notices of exactly this class; these are the rest.
+    if a.live:
+        archive_only = []
+        if a.any:
+            archive_only.append("--any (the live scan ANDs; there is no OR mode)")
+        if a.project:
+            archive_only.append("--project (try --match-path on session-manager)")
+        if a.since:
+            archive_only.append("--since (live rows have an age, not a date)")
+        if archive_only:
+            print("(ARCHIVE-ONLY flags, ignored by the live scan: "
+                  + "; ".join(archive_only)
+                  + " — the LIVE section below is NOT filtered by them)",
+                  file=sys.stderr)
 
     # ------------------------------------------------------------------ #
     # THE CLASSIC PATH — unchanged, byte for byte, including `--json`'s
@@ -459,7 +552,7 @@ def main(argv=None):
     # carry the fields the question is actually about.
     # ------------------------------------------------------------------ #
     live = live_scan(a.terms)
-    live_lines = render_live(live)
+    live_lines = render_live(live, limit=a.limit)
 
     # 🔴 ONE PREDICATE, ONE PLACE — `run_archive` is DERIVED from the reason
     # rather than computed beside it. The two were open-coded separately for one
@@ -480,6 +573,11 @@ def main(argv=None):
     run_archive = archive_reason is not None
 
     results, live_ids = [], None
+    # 🔴 `complete` GATES ONLY THE **CLOSED** VERDICT — see `live_state_of`. It
+    # starts True so that a run which never builds an id set (`live_ids is None`)
+    # still reports UNMEASURED through the `live_ids` branch, rather than
+    # depending on this flag at all.
+    coverage_complete = True
     if run_archive:
         results = archive_search(a, since)
         # 🔴 A SECOND, UNFILTERED scan, and it is not waste. The first scan was
@@ -488,7 +586,15 @@ def main(argv=None):
         # archive hit CLOSED off that set would state a measured absence about a
         # window the filter removed. Only on this path, which already costs 30 s,
         # so the fast path never pays for it.
-        live_ids = live_session_ids(live_scan())
+        unfiltered = live_scan()
+        live_ids = live_session_ids(unfiltered)
+        # ...and the COVERAGE of that scan, which is a separate fact from
+        # whether it produced a set at all. A fleet where one host was asleep
+        # yields a perfectly real id set that cannot support a single CLOSED.
+        coverage_complete = live_coverage_complete(unfiltered)
+
+    def _state(sid):
+        return live_state_of(sid, live_ids, coverage_complete)
 
     shown = results[: a.limit]
     tail_row, tail_code, tail_lines, tail_res = None, EXIT_OK, [], None
@@ -496,6 +602,23 @@ def main(argv=None):
         tail_row, tail_code, tail_lines = _tail_outcome(a, live)
         if tail_row is not None:
             tail_res = live_tail(tail_row, a.tail)
+            # 🔴 A TAIL THAT DID NOT RUN IS NOT AN EMPTY WINDOW. `rc` 2/4/5 mean
+            # the window vanished between the scan and the tail, the host went
+            # away, or there is no tmux server — none of which is "the pane is
+            # blank". Nothing branched on `rc` before, so all three printed
+            # "(empty scrollback)" and exited 0.
+            if not tail_res["ok"]:
+                tail_code = EXIT_UNAVAILABLE
+                tail_lines = [
+                    f"TAIL: FAILED — `session-manager tail` exited "
+                    f"{tail_res['rc']} for "
+                    f"{tail_row.get('session')}:{tail_row.get('window_index')} "
+                    f"on {tail_row.get('host')}: "
+                    f"{tail_res.get('error') or 'no stderr'}",
+                    "  🔴 The scrollback was NOT read. This is not an empty "
+                    "window — the window may have closed between the scan and "
+                    "the tail, or the host may have gone away.",
+                ]
 
     if a.json:
         # 🔴 A NEW ENVELOPE, not a widened list. `--json` without `--live` still
@@ -511,11 +634,19 @@ def main(argv=None):
                 "reason": archive_reason or "live matched",
                 "total": len(results),
                 # `live_state` is UNMEASURED, not CLOSED, when no live scan
-                # could supply the id set.
-                "results": [dict(render(r),
-                                 live_state=live_state_of(r["session_id"], live_ids))
+                # could supply the id set — OR when the scan that supplied it
+                # did not cover every host.
+                "results": [dict(render(r), live_state=_state(r["session_id"]))
                             for r in shown],
                 "live_ids_measured": live_ids is not None,
+                # 🔴 THE SECOND HALF, PUBLISHED SEPARATELY, because it is a
+                # different fact. `live_ids_measured: true` with
+                # `live_coverage_complete: false` is the state in which a MISS
+                # proves nothing — and it used to be reported as CLOSED.
+                "live_coverage_complete": (coverage_complete
+                                           if live_ids is not None else None),
+                "live_hosts_unreachable": (unfiltered["hosts_unreachable"]
+                                           if run_archive else None),
             },
             "tail": None if a.tail is None else {
                 "requested_lines": a.tail,
@@ -526,6 +657,12 @@ def main(argv=None):
                 },
                 "refused": tail_row is None,
                 "message": "\n".join(tail_lines) or None,
+                # 🔴 `rc` and `ok` TRAVEL WITH THE TEXT. An empty `text` beside
+                # `ok: false` is "the scrollback was not read"; beside
+                # `ok: true` it is a measured empty pane. Publishing `error`
+                # alone left those indistinguishable whenever stderr was quiet.
+                "rc": (tail_res or {}).get("rc"),
+                "ok": (tail_res or {}).get("ok"),
                 "text": (tail_res or {}).get("text"),
                 "error": (tail_res or {}).get("error"),
             },
@@ -542,6 +679,15 @@ def main(argv=None):
         if live_ids is None:
             print("  ⚠ live/closed state is UNMEASURED — the live scan did not "
                   "answer, so no hit below can be called CLOSED.")
+        elif not coverage_complete:
+            # 🔴 ITS OWN LINE, in the ARCHIVE block. The LIVE section's caveat
+            # says an absence "cannot appear BELOW" and refers to the live row
+            # list; it says nothing about these annotations, which are a
+            # different claim printed under a different heading.
+            print("  ⚠ live/closed state is PARTIAL — "
+                  + ", ".join(unfiltered["hosts_unreachable"])
+                  + " did not answer, so a hit that is NOT marked <LIVE> is "
+                    "UNMEASURED rather than CLOSED.")
         if not results:
             print(f"  No sessions matched: {' '.join(a.terms)}")
         else:
@@ -550,18 +696,23 @@ def main(argv=None):
             print()
             for i, r in enumerate(shown, 1):
                 print("\n".join(render_archive_hit(
-                    i, r, live_state_of(r["session_id"], live_ids))))
+                    i, r, _state(r["session_id"]))))
     if a.tail is not None:
         print()
         if tail_lines:
             print("\n".join(tail_lines))
-        if tail_res is not None:
+        # 🔴 Only a MEASURED tail prints a scrollback block. A failed one has
+        # already printed its FAILED lines above; falling through would append
+        # "(empty scrollback)" under a header claiming to show the last N lines.
+        if tail_res is not None and tail_res["ok"]:
             print(f"TAIL {tail_row.get('host')} "
                   f"{tail_row.get('session')}:{tail_row.get('window_index')} "
                   f"(last {a.tail} lines)")
             if tail_res.get("error"):
                 print(f"  tail reported: {tail_res['error']}")
-            sys.stdout.write(tail_res.get("text") or "  (empty scrollback)\n")
+            sys.stdout.write(tail_res.get("text")
+                             or "  (empty scrollback — MEASURED, the pane "
+                                "really is blank)\n")
     return tail_code
 
 

--- a/scripts/find-session.py
+++ b/scripts/find-session.py
@@ -9,9 +9,35 @@ best matching snippets — plus how to resume it.
 The walk, the ranking and the snippet extraction live in `scripts/lib/transcript_search.py`
 and are shared with `scripts/check-clickup-addressed/`. This file is the CLI only.
 
+🔴 `--live` INVERTS THE INSTRUMENT, AND THE MEASUREMENT IS WHY
+--------------------------------------------------------------------------
+Measured 2026-08-28 on this host: the transcript-archive walk above takes
+**30.1 s**; `session-manager --json --lean --no-ch` — the LIVE cross-host tmux
+scan — takes **1.82 s** and its rows already carry `task`, `label`, `hotkey`,
+`status`, `waiting_probable`, `path` and `claude_session_id`, with `task`
+populated on 66 of 72 rows.
+
+So for the question people actually ask — *"find that thing I lost track of, is
+it still running, which window, where did it leave off"* — the 30-second archive
+search is the WRONG instrument: it answers a question about the past over a
+corpus that cannot say whether anything is running now. `--live` runs the live
+scan FIRST and falls back to the archive only when the live fleet matched
+nothing (or `--deep` forces both).
+
+`--tail N` closes the loop: it prints the scrollback of the resolved window, so
+one call answers "where did it leave off" too. It REFUSES on an ambiguous match
+rather than picking one — see `window-triage` §7, "Ambiguity is refused, not
+guessed".
+
+🔴 AN UNREACHABLE HOST IS NEVER RENDERED AS "NOT RUNNING". Same rule the opencode
+leg already follows: if the live scan fails, or a host did not answer, that is
+said out loud and the empty LIVE section is labelled UNMEASURED. The one sentence
+this tool must never emit is "it is not running" off a look that never happened.
+
 Usage:
   find-session.py <term> [<term> ...] [--project SUBSTR] [--since YYYY-MM-DD]
                   [--limit N] [--all] [--json]
+                  [--live [--deep] [--tail N]]
 
   Terms are ANDed by default (a session must match all). Pass --any to OR them.
   Quote a multi-word term to match it as a phrase: find-session.py "pr 235"
@@ -20,10 +46,13 @@ Examples:
   find-session.py redis vpn            # sessions mentioning both redis AND vpn
   find-session.py "pr 235"             # the session where PR 235 was worked
   find-session.py minio --project talos --since 2026-05-01
+  find-session.py widget-cache --live            # live first, archive fallback
+  find-session.py widget-cache --live --tail 60  # ...and where it left off
 """
 import argparse
 import json
 import os
+import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -36,6 +65,217 @@ from opencode_search import search_opencode  # noqa: E402
 
 # Reassigned by tests to point at a tmp corpus. Read at CALL time, never captured.
 ROOT = DEFAULT_ROOT
+
+# --------------------------------------------------------------------------- #
+# THE LIVE LEG — one subprocess, and the MATCHING happens on the other side
+# --------------------------------------------------------------------------- #
+# 🔴 THE MATCH PREDICATE IS NOT RE-IMPLEMENTED HERE. `session-manager --match`
+# owns it (`MATCH_FIELDS` / `row_matches` in that file), and this passes the
+# terms through. A second copy here would be the one-rule-one-place failure with
+# the worst possible symptom: the two tools would answer the same words with
+# different sets and neither would say so. It also means the field list this
+# prints comes from the payload (`filters.match_fields`), not from a literal
+# that can drift away from what was actually searched.
+SESSION_MANAGER = str(Path(__file__).resolve().parent / "session-manager")
+
+# The live scan measured 1.82 s. The ceiling is generous because it makes an
+# ssh round trip to the peer host; a timeout is reported as a FAILED scan, never
+# as an empty fleet.
+LIVE_TIMEOUT_SECS = 90
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_AMBIGUOUS = 3      # --tail could not resolve to exactly one window
+EXIT_UNAVAILABLE = 4    # the live fleet was not measured — same code as the sibling
+
+
+def _default_run(argv, timeout=LIVE_TIMEOUT_SECS):
+    """The ONE impure edge this file adds. Replaced wholesale by the tests."""
+    p = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+    return p.returncode, p.stdout, p.stderr
+
+
+# Reassigned by tests. Read at CALL time (`RUN(...)` resolves the module
+# attribute), never captured as a default argument — the same reason
+# `session-manager` resolves `ch_client_factory` at call time.
+RUN = _default_run
+
+
+def live_scan_argv(terms=()):
+    """`session-manager scan --json --lean --no-ch [--match T]...`.
+
+    `--lean` and `--no-ch` are not incidental: the lean view is the agent-shaped
+    row projection (and the only one carrying `hotkey_display`), and ClickHouse
+    answers session-history questions that this call is not asking.
+
+    `sys.executable`, not the shebang: this must work from a nix devShell, a
+    systemd unit and a bare cron alike, none of which agree about PATH.
+    """
+    argv = [sys.executable, SESSION_MANAGER, "scan", "--json", "--lean", "--no-ch"]
+    for t in terms:
+        argv += ["--match", str(t)]
+    return argv
+
+
+def live_scan(terms=()):
+    """Run the live scan and return a STATUS-DISCRIMINATED result.
+
+    `status` is `ok` / `unavailable` / `error`, and `rows` is only believable
+    when it is `ok`:
+
+      * `error`       — the subprocess did not run, or produced no JSON. Nothing
+                        was measured.
+      * `unavailable` — it ran and NO host answered. Still nothing measured; the
+                        empty row list is not a fleet with no windows.
+      * `ok`          — at least one host answered. `hosts_unreachable` may
+                        still be non-empty, and a window living only on such a
+                        host cannot appear in `rows` — which is why that list
+                        travels with the verdict instead of being dropped.
+    """
+    out = {"status": "error", "rows": [], "hosts_reachable": [],
+           "hosts_unreachable": [], "match_fields": None, "error": None,
+           "rc": None, "terms": [str(t) for t in terms]}
+    try:
+        rc, stdout, stderr = RUN(live_scan_argv(terms))
+    except Exception as e:  # noqa: BLE001 — a failed scan must degrade, not crash
+        return dict(out, error=f"{type(e).__name__}: {e}")
+    out["rc"] = rc
+    try:
+        report = json.loads(stdout)
+    except Exception:  # noqa: BLE001
+        detail = (stderr or stdout or "").strip()[:200]
+        return dict(out, error=(f"session-manager exited {rc} and produced no "
+                                f"JSON on stdout: {detail!r}"))
+    hosts = report.get("hosts") or {}
+    out["hosts_reachable"] = sorted(k for k, v in hosts.items() if v.get("reachable"))
+    out["hosts_unreachable"] = sorted(k for k, v in hosts.items()
+                                      if not v.get("reachable"))
+    out["rows"] = [r for name in sorted(hosts)
+                   for r in (hosts[name].get("windows") or [])]
+    out["match_fields"] = (report.get("filters") or {}).get("match_fields")
+    # 🔴 The discriminant, and it is the whole reason this function exists: a
+    # scan where no host answered has an empty `rows` that means NOTHING WAS
+    # MEASURED. Reporting that as "not running" is the one claim this tool must
+    # never make.
+    out["status"] = "ok" if out["hosts_reachable"] else "unavailable"
+    return out
+
+
+def live_session_ids(res):
+    """The set of `claude_session_id`s the live fleet is holding — or `None`.
+
+    🔴 `None` MEANS UNMEASURED, and it is what stops an archive hit being
+    labelled CLOSED on the strength of a scan that never ran. A caller must
+    branch on it; `set()` is the measured "the fleet holds no session ids".
+    """
+    if res.get("status") != "ok":
+        return None
+    return {r.get("claude_session_id") for r in res.get("rows") or []
+            if r.get("claude_session_id")}
+
+
+def live_state_of(session_id, live_ids):
+    """`LIVE` / `CLOSED` / `UNMEASURED` for one archive hit."""
+    if live_ids is None:
+        return "UNMEASURED"
+    return "LIVE" if session_id in live_ids else "CLOSED"
+
+
+def fmt_age(secs):
+    """Coarse human age. `None` is stated, never rendered as `0s`."""
+    if secs is None:
+        return "no age recorded"
+    s = int(secs)
+    if s < 60:
+        return f"{s}s"
+    if s < 3600:
+        return f"{s // 60}m"
+    if s < 86400:
+        return f"{s // 3600}h{(s % 3600) // 60:02d}m"
+    return f"{s // 86400}d{(s % 86400) // 3600:02d}h"
+
+
+def live_resume_command(row):
+    """How to re-enter this window's agent session, or None when it has no id."""
+    sid = row.get("claude_session_id")
+    if not sid:
+        return None
+    if row.get("runtime") == "opencode":
+        return f"opencode --session {sid}"
+    return f"claude --resume {sid}"
+
+
+def live_tail_argv(row, lines):
+    """🔴 `--host` IS PASSED EXPLICITLY. `session-manager tail` resolves
+    `--host all` to the LOCAL host, so a tail of a laptop row without it
+    searches the workbench and reports the window missing."""
+    return [sys.executable, SESSION_MANAGER, "tail",
+            f"{row.get('session')}:{row.get('window_index')}",
+            "--host", str(row.get("host")), "--plain", "--lines", str(int(lines))]
+
+
+def live_tail(row, lines):
+    try:
+        rc, stdout, stderr = RUN(live_tail_argv(row, lines))
+    except Exception as e:  # noqa: BLE001
+        return {"rc": None, "text": "", "error": f"{type(e).__name__}: {e}"}
+    return {"rc": rc, "text": stdout, "error": (stderr or "").strip() or None}
+
+
+def render_live(res):
+    """The LIVE section. Returns a list of lines, ALWAYS non-empty."""
+    out = []
+    if res["status"] == "error":
+        out.append(f"LIVE: SCAN FAILED — {res['error']}")
+        out.append("  🔴 NOT 'nothing is running': the live fleet was not "
+                   "measured at all.")
+        return out
+    if res["status"] == "unavailable":
+        out.append("LIVE: NO HOST ANSWERED — the live fleet was NOT measured.")
+        out.append("  unreachable: " +
+                   (", ".join(res["hosts_unreachable"]) or "unknown"))
+        out.append("  🔴 An empty result here is UNMEASURED, not 'nothing is "
+                   "running'.")
+        return out
+    rows = res["rows"]
+    head = (f"LIVE ({len(rows)} matched"
+            f"; searched: {', '.join(res['hosts_reachable'])}")
+    if res["hosts_unreachable"]:
+        head += f"; NOT searched: {', '.join(res['hosts_unreachable'])}"
+    head += (f"; fields: {', '.join(res['match_fields'] or ['<all rows>'])})")
+    out.append(head)
+    if res["hosts_unreachable"]:
+        out.append("  ⚠ " + ", ".join(res["hosts_unreachable"]) +
+                   " did not answer — a window living only there cannot appear "
+                   "below, so this is not a measured absence on that host.")
+    if not rows:
+        out.append("  (no live window matched these terms on the hosts that "
+                   "answered)")
+        return out
+    for i, r in enumerate(rows, 1):
+        # 🔴 `hotkey_display` is READ, never derived here. `M-v` and `M-V` are
+        # different sessions; the one writer of that spelling is
+        # `session-manager.hotkey_display`, and re-deriving it in this renderer
+        # is exactly the mistake it exists to remove.
+        chord = r.get("hotkey_display") or "no hotkey"
+        out.append(f"{i}. {r.get('host')}  "
+                   f"{r.get('session')}:{r.get('window_index')}  "
+                   f"{r.get('label')} [{chord}]  "
+                   f"{r.get('status')} · {fmt_age(r.get('age_secs'))} "
+                   f"(age from {r.get('age_source') or 'no writer'})")
+        # Tri-state, dumped as JSON so `null` is visibly not `false`.
+        out.append(f"   waiting_probable: {json.dumps(r.get('waiting_probable'))}"
+                   f"   [{r.get('waiting_status')}]")
+        out.append(f"   waiting_signals:  {json.dumps(r.get('waiting_signals'))}")
+        out.append(f"   task: {r.get('task') or '—'}")
+        out.append(f"   path: {r.get('path') or '—'}")
+        resume = live_resume_command(r)
+        out.append(f"   resume: {resume}" if resume else
+                   "   resume: no agent session id on this row — "
+                   f"attach with `tmux attach -t {r.get('session')}:"
+                   f"{r.get('window_index')}` on {r.get('host')}")
+        out.append("   tail:   " + " ".join(live_tail_argv(r, 100)[1:]))
+    return out
 
 
 def parse_args(argv=None):
@@ -52,6 +292,17 @@ def parse_args(argv=None):
     p.add_argument("--opencode-only", action="store_true",
                    help="search only opencode sessions (skip Claude Code)")
     p.add_argument("--json", action="store_true", help="emit JSON instead of human text")
+    p.add_argument("--live", action="store_true",
+                   help="scan the LIVE cross-host tmux fleet FIRST (1.8s) and "
+                        "only fall back to the 30s transcript walk when nothing "
+                        "live matched. Matches task/label/codename — NOT path.")
+    p.add_argument("--deep", action="store_true",
+                   help="with --live: run the transcript walk TOO, even when "
+                        "live windows matched")
+    p.add_argument("--tail", type=int, default=None, metavar="N",
+                   help="with --live: print the last N scrollback lines of the "
+                        "matched window. REFUSES on an ambiguous match rather "
+                        "than guessing (exit 3), and lists the candidates.")
     return p.parse_args(argv)
 
 
@@ -75,16 +326,9 @@ def render(r):
     return d
 
 
-def main(argv=None):
-    a = parse_args(argv)
-    since = None
-    if a.since:
-        try:
-            since = datetime.fromisoformat(a.since)
-        except ValueError:
-            print(f"bad --since date: {a.since!r} (want YYYY-MM-DD)", file=sys.stderr)
-            sys.exit(2)
-
+def archive_search(a, since):
+    """The 30 s two-corpus transcript walk. Unchanged; factored out so the
+    `--live` path can decide WHETHER to pay for it."""
     # 🔴 `--all` used to be INERT. Its handler sat behind `if not a.all and typ not in
     # ("user", "assistant")`, twenty lines after an unconditional `if typ not in
     # ("user", "assistant"): continue` had already skipped everything it could have
@@ -112,35 +356,213 @@ def main(argv=None):
     # Re-rank the merged set by the same criteria
     results.sort(key=lambda r: (len(r["matched_terms"]), r["total_hits"], r["last_local"]),
                  reverse=True)
+    return results
+
+
+def render_archive_hit(i, r, state=None):
+    """One archive hit, optionally annotated with its LIVE/CLOSED state."""
+    out = []
+    date = (r["last"] or r["first"])[:16].replace("T", " ")
+    project = os.path.basename(r["cwd"]) or r["project_dir"]
+    source_tag = f"  [{r['source']}]" if r.get("source") else ""
+    # 🔴 The annotation is a JOIN on `claude_session_id`, and `UNMEASURED` is a
+    # real third value — an archive hit is only CLOSED when a live scan actually
+    # ran and did not hold its id.
+    tag = f"  <{state}>" if state else ""
+    out.append(f"{i}. [{date}] {project}  ({r['branch'] or 'no-branch'})"
+               f"{source_tag}{tag}  ·  {r['total_hits']} hits")
+    if r["genesis"]:
+        out.append(f"   opened: {r['genesis'][:120]!r}")
+    for term, (role, snip) in r["snippets"].items():
+        out.append(f"   {term} → ({role}) …{snip[:120]}…")
+    if r.get("source") == "opencode":
+        out.append(f"   resume: opencode --session {r['session_id']}")
+    else:
+        out.append(f"   resume: claude --resume {r['session_id']}")
+    out.append(f"   file:   {r['path']}")
+    out.append("")
+    return out
+
+
+def _tail_outcome(a, live):
+    """Resolve `--tail` to ONE window, or REFUSE and say why.
+
+    Returns `(row_or_None, exit_code, lines)`. 🔴 It never picks a row when the
+    match is ambiguous — `window-triage` §7, "Ambiguity is refused, not
+    guessed": a scrollback printed from the wrong window is an answer that reads
+    as correct, which is strictly worse than no answer.
+    """
+    if live["status"] != "ok":
+        return None, EXIT_UNAVAILABLE, [
+            "TAIL: REFUSED — the live fleet was not measured, so there is no "
+            "window to tail. See the LIVE section above."]
+    rows = live["rows"]
+    if len(rows) == 1:
+        return rows[0], EXIT_OK, []
+    if not rows:
+        return None, EXIT_AMBIGUOUS, [
+            "TAIL: REFUSED — no live window matched, so there is nothing to "
+            "tail. Narrow or widen the terms, or use --deep for the archive."]
+    lines = [f"TAIL: REFUSED — {len(rows)} live windows matched and this tool "
+             "does not guess which one you meant. Re-run with a narrower term, "
+             "or tail one directly:"]
+    for r in rows:
+        lines.append("  " + " ".join(live_tail_argv(r, a.tail)[1:])
+                     + f"    # {r.get('label')} "
+                       f"[{r.get('hotkey_display') or 'no hotkey'}] — "
+                       f"{r.get('task') or 'no task'}")
+    return None, EXIT_AMBIGUOUS, lines
+
+
+def main(argv=None):
+    a = parse_args(argv)
+    since = None
+    if a.since:
+        try:
+            since = datetime.fromisoformat(a.since)
+        except ValueError:
+            print(f"bad --since date: {a.since!r} (want YYYY-MM-DD)", file=sys.stderr)
+            sys.exit(2)
+
+    if a.tail is not None and not a.live:
+        print("--tail requires --live: it prints the scrollback of a LIVE tmux "
+              "window, which the transcript archive cannot supply.",
+              file=sys.stderr)
+        return EXIT_USAGE
+    if a.deep and not a.live:
+        print("(--deep only means something with --live: without it the "
+              "transcript walk always runs)", file=sys.stderr)
+
+    # ------------------------------------------------------------------ #
+    # THE CLASSIC PATH — unchanged, byte for byte, including `--json`'s
+    # bare-list shape. `--live` is opt-in precisely so no existing caller's
+    # output moves.
+    # ------------------------------------------------------------------ #
+    if not a.live:
+        results = archive_search(a, since)
+        shown = results[: a.limit]
+        if a.json:
+            print(json.dumps([render(r) for r in shown], indent=2))
+            return EXIT_OK
+        if not results:
+            print(f"No sessions matched: {' '.join(a.terms)}")
+            return EXIT_OK
+        print(f"{len(results)} session(s) matched {' '.join(a.terms)!r}"
+              + (f" (showing {len(shown)})" if len(shown) < len(results) else "")
+              + "\n")
+        for i, r in enumerate(shown, 1):
+            print("\n".join(render_archive_hit(i, r)))
+        return EXIT_OK
+
+    # ------------------------------------------------------------------ #
+    # 🔴 LIVE FIRST. 1.8 s against the archive walk's 30.1 s, and the live rows
+    # carry the fields the question is actually about.
+    # ------------------------------------------------------------------ #
+    live = live_scan(a.terms)
+    live_lines = render_live(live)
+
+    # 🔴 ONE PREDICATE, ONE PLACE — `run_archive` is DERIVED from the reason
+    # rather than computed beside it. The two were open-coded separately for one
+    # revision and already disagreed about `--deep`'s precedence, which is the
+    # "wrong at N−1 of N sites, in the same direction" shape `claude/RULES.md`
+    # names. Consolidating also made the UNMEASURED branch observable: a
+    # mutation sweep scored its removal SURVIVED while the two were independent,
+    # because a failed scan carries zero rows anyway and the `not rows` clause
+    # picked up the slack silently. Now dropping it changes the printed reason.
+    #
+    # The order is the point: "we could not look" must never launder into "we
+    # looked and there is nothing".
+    archive_reason = (
+        "--deep" if a.deep
+        else "the live scan was UNMEASURED" if live["status"] != "ok"
+        else "no live match" if not live["rows"]
+        else None)
+    run_archive = archive_reason is not None
+
+    results, live_ids = [], None
+    if run_archive:
+        results = archive_search(a, since)
+        # 🔴 A SECOND, UNFILTERED scan, and it is not waste. The first scan was
+        # NARROWED by the terms, so a session that IS live but whose window
+        # title no longer says those words is absent from it — annotating an
+        # archive hit CLOSED off that set would state a measured absence about a
+        # window the filter removed. Only on this path, which already costs 30 s,
+        # so the fast path never pays for it.
+        live_ids = live_session_ids(live_scan())
 
     shown = results[: a.limit]
+    tail_row, tail_code, tail_lines, tail_res = None, EXIT_OK, [], None
+    if a.tail is not None:
+        tail_row, tail_code, tail_lines = _tail_outcome(a, live)
+        if tail_row is not None:
+            tail_res = live_tail(tail_row, a.tail)
 
     if a.json:
-        print(json.dumps([render(r) for r in shown], indent=2))
-        return 0
+        # 🔴 A NEW ENVELOPE, not a widened list. `--json` without `--live` still
+        # emits the bare archive array every existing caller parses; adding
+        # `live` keys to that array's elements would have changed a shape nobody
+        # asked to change.
+        print(json.dumps({
+            "live": {k: live[k] for k in
+                     ("status", "rows", "hosts_reachable", "hosts_unreachable",
+                      "match_fields", "error", "rc", "terms")},
+            "archive": {
+                "ran": run_archive,
+                "reason": archive_reason or "live matched",
+                "total": len(results),
+                # `live_state` is UNMEASURED, not CLOSED, when no live scan
+                # could supply the id set.
+                "results": [dict(render(r),
+                                 live_state=live_state_of(r["session_id"], live_ids))
+                            for r in shown],
+                "live_ids_measured": live_ids is not None,
+            },
+            "tail": None if a.tail is None else {
+                "requested_lines": a.tail,
+                "resolved": None if tail_row is None else {
+                    "host": tail_row.get("host"),
+                    "target": f"{tail_row.get('session')}:"
+                              f"{tail_row.get('window_index')}",
+                },
+                "refused": tail_row is None,
+                "message": "\n".join(tail_lines) or None,
+                "text": (tail_res or {}).get("text"),
+                "error": (tail_res or {}).get("error"),
+            },
+        }, indent=2, default=str))
+        return tail_code
 
-    if not results:
-        print(f"No sessions matched: {' '.join(a.terms)}")
-        return 0
-
-    print(f"{len(results)} session(s) matched {' '.join(a.terms)!r}"
-          + (f" (showing {len(shown)})" if len(shown) < len(results) else "") + "\n")
-    for i, r in enumerate(shown, 1):
-        date = (r["last"] or r["first"])[:16].replace("T", " ")
-        project = os.path.basename(r["cwd"]) or r["project_dir"]
-        source_tag = f"  [{r['source']}]" if r.get("source") else ""
-        print(f"{i}. [{date}] {project}  ({r['branch'] or 'no-branch'}){source_tag}  ·  {r['total_hits']} hits")
-        if r["genesis"]:
-            print(f"   opened: {r['genesis'][:120]!r}")
-        for term, (role, snip) in r["snippets"].items():
-            print(f"   {term} → ({role}) …{snip[:120]}…")
-        if r.get("source") == "opencode":
-            print(f"   resume: opencode --session {r['session_id']}")
+    print("\n".join(live_lines))
+    print()
+    if not run_archive:
+        print(f"ARCHIVE: skipped — the live fleet answered. Pass --deep to "
+              f"search the {len(a.terms)}-term transcript walk too (~30s).")
+    else:
+        print(f"ARCHIVE ({len(results)} matched; ran because: {archive_reason})")
+        if live_ids is None:
+            print("  ⚠ live/closed state is UNMEASURED — the live scan did not "
+                  "answer, so no hit below can be called CLOSED.")
+        if not results:
+            print(f"  No sessions matched: {' '.join(a.terms)}")
         else:
-            print(f"   resume: claude --resume {r['session_id']}")
-        print(f"   file:   {r['path']}")
+            if len(shown) < len(results):
+                print(f"  (showing {len(shown)})")
+            print()
+            for i, r in enumerate(shown, 1):
+                print("\n".join(render_archive_hit(
+                    i, r, live_state_of(r["session_id"], live_ids))))
+    if a.tail is not None:
         print()
-    return 0
+        if tail_lines:
+            print("\n".join(tail_lines))
+        if tail_res is not None:
+            print(f"TAIL {tail_row.get('host')} "
+                  f"{tail_row.get('session')}:{tail_row.get('window_index')} "
+                  f"(last {a.tail} lines)")
+            if tail_res.get("error"):
+                print(f"  tail reported: {tail_res['error']}")
+            sys.stdout.write(tail_res.get("text") or "  (empty scrollback)\n")
+    return tail_code
 
 
 if __name__ == "__main__":

--- a/scripts/find-session.py
+++ b/scripts/find-session.py
@@ -131,9 +131,19 @@ def live_scan(terms=()):
                         still be non-empty, and a window living only on such a
                         host cannot appear in `rows` — which is why that list
                         travels with the verdict instead of being dropped.
+
+    🔴 BOTH HOST LISTS ARE `None`, NEVER `[]`, ON THE `error` PATHS. The scan did
+    not run, so "which hosts answered" was never measured — and an empty
+    `hosts_unreachable` reads as the strongest possible claim, *every host
+    answered*. It leaked straight into the payload as
+    `archive.live_hosts_unreachable: []` for a scan that never happened, which is
+    the null-never-`[]` rule this same change wrote into `payload-contract.md`.
+    Fixed at the SOURCE rather than at the two publishers, so a third publisher
+    cannot reintroduce it. `status == "unavailable"` is different: the scan DID
+    run and every host really is unreachable, so both lists are real there.
     """
-    out = {"status": "error", "rows": [], "hosts_reachable": [],
-           "hosts_unreachable": [], "match_fields": None, "error": None,
+    out = {"status": "error", "rows": [], "hosts_reachable": None,
+           "hosts_unreachable": None, "match_fields": None, "error": None,
            "rc": None, "terms": [str(t) for t in terms]}
     try:
         rc, stdout, stderr = RUN(live_scan_argv(terms))
@@ -199,11 +209,16 @@ def live_coverage_complete(res):
     On this fleet the laptop is a secondary machine that is frequently asleep,
     so the partial fleet is the COMMON degraded state, not an exotic one.
 
-    Per-host attribution is deliberately NOT attempted: an archive hit carries a
-    `cwd` and a session id but no host, and the Claude transcript corpus is read
-    from local disk while the opencode corpus is read from both hosts — so there
-    is no sound mapping from a hit to the host that would confirm it. The
-    coarse answer is the one that is true.
+    Per-host attribution is deliberately NOT attempted, and the reason is NOT
+    "the hit's host is unknown" — an earlier draft of this docstring said that
+    and it was wrong for half the corpus. A Claude transcript hit's host IS
+    known: `~/.claude/projects` is read from LOCAL disk only, so every Claude hit
+    came from this machine. What makes an inference from that unsound is
+    `claude --resume`: a session recorded on one host can be resumed and running
+    on the OTHER, so "this transcript is local, therefore its live window would
+    be local" does not follow. (The opencode corpus is read from both hosts, so
+    those hits genuinely carry no host.) Either way the coarse answer is the one
+    that is true, and it is what this returns.
     """
     return res.get("status") == "ok" and not res.get("hosts_unreachable")
 
@@ -226,6 +241,74 @@ def live_state_of(session_id, live_ids, coverage_complete=True):
     if session_id in live_ids:
         return "LIVE"
     return "CLOSED" if coverage_complete else "UNMEASURED"
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE ARCHIVE-ONLY FLAG LEDGER — A LIST, NOT A SENTENCE
+# --------------------------------------------------------------------------- #
+# An earlier revision hand-listed three flags here and closed the comment with
+# "this diff already prints five notices of exactly this class; THESE ARE THE
+# REST". That sentence was false when it was written: `--claude-only`,
+# `--opencode-only` and `--all` were missing, and a completeness claim is worse
+# than the omission it decorates, because it tells the next reader to stop
+# looking. Measured on the live fleet:
+#
+#   $ find-session.py <term> --live --opencode-only
+#   LIVE (3 matched; …)  ->  a tmux window running CLAUDE
+#
+# The caller selected the opencode corpus and got Claude windows — and because
+# the live leg matched, `run_archive` stayed False, so the opencode corpus was
+# never searched at all.
+#
+# So the set is DATA and a test pins it against the parser two-way: every
+# argparse destination is either live-aware or in this ledger, and adding a flag
+# without deciding which fails the suite. The sentence cannot drift from the
+# list again because there is no sentence.
+#
+# `(dest, spelling, why)`.
+ARCHIVE_ONLY_FLAGS = (
+    ("any", "--any", "the live scan ANDs its terms; there is no OR mode"),
+    ("project", "--project", "no cwd filter on the live leg — try `--match-path` "
+                             "on session-manager"),
+    ("since", "--since", "live rows carry an age, not a date"),
+    ("claude_only", "--claude-only", "CORPUS selection; live rows have a "
+                                     "`runtime` but the scan has no corpus axis"),
+    ("opencode_only", "--opencode-only", "CORPUS selection; same reason"),
+    ("all", "--all", "widens the TRANSCRIPT search surface only"),
+)
+
+# The destinations that DO reach the live leg (or steer both). Pinned beside the
+# ledger so the two-way test has both halves of the partition in one place.
+LIVE_AWARE_DESTS = frozenset({"terms", "live", "deep", "tail", "limit", "json"})
+
+# Which archive-only flags additionally mean the archive result is the ONLY one
+# that can answer the question — a corpus/surface selector. Named separately
+# because their notice has to say more than "not filtered by them".
+CORPUS_SELECTOR_DESTS = frozenset({"claude_only", "opencode_only", "all"})
+
+
+def archive_only_notice(args):
+    """The stderr line for archive-only flags passed alongside `--live`, or None.
+
+    Derived from `ARCHIVE_ONLY_FLAGS`, so it cannot name a different set from the
+    one the test pins.
+    """
+    named = [(dest, spelling, why) for dest, spelling, why in ARCHIVE_ONLY_FLAGS
+             if getattr(args, dest, None)]
+    if not named:
+        return None
+    line = ("(ARCHIVE-ONLY flags, ignored by the live scan: "
+            + "; ".join(f"{spelling} ({why})" for _, spelling, why in named)
+            + " — the LIVE section below is NOT filtered by them)")
+    if any(dest in CORPUS_SELECTOR_DESTS for dest, _, _ in named):
+        # 🔴 The consequence, not just the fact. A corpus selector says WHICH
+        # ARCHIVE to search, and the archive does not run at all when the live
+        # leg matches — so the corpus the caller explicitly chose can go
+        # unsearched while the run reports success.
+        line += ("\n(...and a CORPUS selector only steers the ARCHIVE, which is "
+                 "SKIPPED when the live scan matches: pass --deep to actually "
+                 "search the corpus you selected)")
+    return line
 
 
 def fmt_age(secs):
@@ -321,7 +404,14 @@ def render_live(res, limit=None):
     # UNSLICED list — capping the ambiguity check at the display limit would
     # turn "several matched, I refuse" into "one is showing, I will tail that
     # one", which is guessing with extra steps.
-    shown = rows if limit is None or limit <= 0 else rows[:limit]
+    #
+    # 🔴 THE SLICE IS THE ARCHIVE LEG'S SLICE, EXACTLY. It used to read
+    # `limit <= 0` as "unbounded", so `--limit 0` showed the whole fleet here and
+    # nothing at all in the ARCHIVE section of the SAME run. `main` now rejects
+    # `--limit < 1` outright, so the only values reaching this are >= 1 (or None
+    # from a direct call) — and the expression no longer carries a second,
+    # contradictory meaning for anything else.
+    shown = rows if limit is None else rows[:limit]
     if len(shown) < len(rows):
         out.append(f"  (showing {len(shown)} of {len(rows)} — raise --limit "
                    "to see the rest)")
@@ -464,15 +554,47 @@ def _tail_outcome(a, live):
     match is ambiguous — `window-triage` §7, "Ambiguity is refused, not
     guessed": a scrollback printed from the wrong window is an answer that reads
     as correct, which is strictly worse than no answer.
+
+    🔴 PARTIAL COVERAGE IS ITS OWN CLAIM AND IS MADE HERE, not inherited. The
+    reason the ARCHIVE block got its own PARTIAL line — "the LIVE section's
+    caveat refers to the live row list, not to these annotations, which are a
+    different claim under a different heading" — applies verbatim to the TAIL
+    block, and was not applied there for one revision. Under a partial fleet:
+
+      * ZERO rows is NOT "there is nothing to tail" (exit 3). The window may be
+        on the host that did not answer, so this is UNMEASURED — exit 4, the
+        same code the fleet-not-measured branch uses, because it is the same
+        fact about a narrower question.
+      * ONE row still tails, but the resolution is DISCLOSED as possibly
+        non-unique. Refusing here would make `--tail` useless whenever the
+        laptop is asleep, which is a permanently-red gate — but claiming "this
+        is the one" is the guess the whole function exists to refuse.
+      * SEVERAL rows already refuse; the candidate list is simply also
+        incomplete, and says so.
     """
     if live["status"] != "ok":
         return None, EXIT_UNAVAILABLE, [
             "TAIL: REFUSED — the live fleet was not measured, so there is no "
             "window to tail. See the LIVE section above."]
+    complete = live_coverage_complete(live)
+    # SUBSCRIPT, not `.get` — the scan result is read by subscript throughout
+    # these four functions on purpose, so `test_the_live_row_field_ledger_...`'s
+    # AST sweep for `<row>.get("field")` cannot pick up a non-row key.
+    missing = ", ".join(live["hosts_unreachable"] or []) or "a host"
     rows = live["rows"]
     if len(rows) == 1:
-        return rows[0], EXIT_OK, []
+        if complete:
+            return rows[0], EXIT_OK, []
+        return rows[0], EXIT_OK, [
+            f"⚠ TAIL: resolved on PARTIAL coverage — {missing} did not answer, "
+            "so this is the only match ON THE HOSTS THAT DID. Another window "
+            "may match there; the scrollback below is real either way."]
     if not rows:
+        if not complete:
+            return None, EXIT_UNAVAILABLE, [
+                f"TAIL: REFUSED — no live window matched, but {missing} did not "
+                "answer, so this is NOT 'there is nothing to tail'. The window "
+                "may be there and UNMEASURED. Use --deep for the archive."]
         return None, EXIT_AMBIGUOUS, [
             "TAIL: REFUSED — no live window matched, so there is nothing to "
             "tail. Narrow or widen the terms, or use --deep for the archive."]
@@ -484,6 +606,9 @@ def _tail_outcome(a, live):
                      + f"    # {r.get('label')} "
                        f"[{r.get('hotkey_display') or 'no hotkey'}] — "
                        f"{r.get('task') or 'no task'}")
+    if not complete:
+        lines.append(f"  ⚠ {missing} did not answer — this candidate list is "
+                     "INCOMPLETE, so a narrower term may still be ambiguous.")
     return None, EXIT_AMBIGUOUS, lines
 
 
@@ -505,26 +630,25 @@ def main(argv=None):
     if a.deep and not a.live:
         print("(--deep only means something with --live: without it the "
               "transcript walk always runs)", file=sys.stderr)
-    # 🔴 A FLAG THAT REACHES ONLY ONE LEG MUST SAY SO. `--any`, `--project` and
-    # `--since` are ARCHIVE-only: the live scan has no OR mode (`--match` ANDs),
-    # no cwd filter that is not `--match-path`, and no date axis at all. Left
-    # silent, `find-session.py redis vpn --any --live` sent ANDed terms to the
-    # live leg and then printed "(no live window matched these terms…)" — a
-    # measured absence under semantics the caller did not ask for. This diff
-    # already prints five notices of exactly this class; these are the rest.
+    # 🔴 `--limit` BELOW 1 MEANT TWO OPPOSITE THINGS IN ONE RUN: the live leg
+    # read `<= 0` as "unbounded, show everything" and the archive leg took
+    # `results[:0]` and showed nothing. One flag, one number, contradictory
+    # halves — and neither reading is useful. Rejected outright instead of
+    # picking a winner, because a degenerate input deserves a message rather
+    # than a silent choice. This is a behaviour change on the classic path for
+    # `--limit < 1` only, and it is deliberate.
+    if a.limit < 1:
+        print(f"--limit must be at least 1 (got {a.limit}). Below 1 the two "
+              "legs disagreed: the live section showed everything and the "
+              "archive section showed nothing.", file=sys.stderr)
+        return EXIT_USAGE
+    # 🔴 A FLAG THAT REACHES ONLY ONE LEG MUST SAY SO — see `ARCHIVE_ONLY_FLAGS`
+    # for the ledger and for why this is data rather than an inline list closed
+    # by a completeness sentence.
     if a.live:
-        archive_only = []
-        if a.any:
-            archive_only.append("--any (the live scan ANDs; there is no OR mode)")
-        if a.project:
-            archive_only.append("--project (try --match-path on session-manager)")
-        if a.since:
-            archive_only.append("--since (live rows have an age, not a date)")
-        if archive_only:
-            print("(ARCHIVE-ONLY flags, ignored by the live scan: "
-                  + "; ".join(archive_only)
-                  + " — the LIVE section below is NOT filtered by them)",
-                  file=sys.stderr)
+        notice = archive_only_notice(a)
+        if notice:
+            print(notice, file=sys.stderr)
 
     # ------------------------------------------------------------------ #
     # THE CLASSIC PATH — unchanged, byte for byte, including `--json`'s
@@ -645,6 +769,12 @@ def main(argv=None):
                 # proves nothing — and it used to be reported as CLOSED.
                 "live_coverage_complete": (coverage_complete
                                            if live_ids is not None else None),
+                # 🔴 `None`, NEVER `[]`, FOR A SCAN THAT NEVER RAN. `live_scan`
+                # now seeds both host lists `None` on its error paths (see its
+                # docstring), so this passes the discriminated value straight
+                # through instead of laundering an unmeasured scan into "every
+                # host answered". `run_archive` False means no second scan was
+                # made at all, which is also not a measurement.
                 "live_hosts_unreachable": (unfiltered["hosts_unreachable"]
                                            if run_archive else None),
             },
@@ -656,6 +786,14 @@ def main(argv=None):
                               f"{tail_row.get('window_index')}",
                 },
                 "refused": tail_row is None,
+                # 🔴 THE TAIL BLOCK CARRIES ITS OWN COVERAGE. A `refused: true`
+                # with zero matches under a partial fleet is UNMEASURED, not
+                # "there is nothing to tail", and a `resolved` row under one is
+                # the only match ON THE HOSTS THAT ANSWERED. Neither fact is
+                # readable from `archive.*`, which describes a different scan
+                # (the unfiltered one) and is absent entirely on the fast path.
+                "coverage_complete": live_coverage_complete(live),
+                "hosts_unreachable": live["hosts_unreachable"],
                 "message": "\n".join(tail_lines) or None,
                 # 🔴 `rc` and `ok` TRAVEL WITH THE TEXT. An empty `text` beside
                 # `ok: false` is "the scrollback was not read"; beside

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -2383,6 +2383,13 @@ def summarize(report) -> dict:
         "match": filters.get("match"),
         "match_fields": filters.get("match_fields"),
         "excluded_by_match": filters.get("excluded_by_match"),
+        # 🔴 `matched` IS MIRRORED HERE TOO, and it is NOT `total_sessions`. On a
+        # `detail` report the two disagree by construction — `filter_report`
+        # narrows a second time, so `total_sessions` is 0 or 1 while `matched`
+        # is what the ROW FILTER matched. The table's filter line quoted
+        # `total_sessions` and therefore reported the wrong number on exactly
+        # that path, while `filters.matched` sat there unread.
+        "matched": filters.get("matched"),
         "hosts_reachable": sorted(k for k, v in report["hosts"].items()
                                   if v["reachable"]),
         "hosts_unreachable": sorted(k for k, v in report["hosts"].items()
@@ -2693,7 +2700,7 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
            claude_only=False, use_capture=True, capture_nonce=None,
            clawgate_reader=None, clawgate_path=None,
            use_ledger=True, ledger_outputs=None,
-           match=None, match_path=False) -> dict:
+           match=None, match_path=False, prefilter_index_map=False) -> dict:
     """Build the whole report. Every source is injectable, so this is the
     function the hermetic suite exercises end-to-end.
 
@@ -2787,7 +2794,12 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
                     "match": None,
                     "match_fields": None,
                     "matched": None,
-                    "excluded_by_match": None},
+                    "excluded_by_match": None,
+                    # `{session: [index, ...]}` sampled BEFORE the row filters,
+                    # for `detail`. `None` = never sampled (no filter ran, or
+                    # the caller did not ask), which is a different fact from
+                    # `{}` = sampled and the reachable hosts had no rows.
+                    "prefilter_window_indices": None},
         # 🔴 The clawgate approval queue. Filled in below; the skeleton carries
         # a `status` from the first byte so no code path can publish a bare
         # count. See `read_clawgate_queue` for the four outcomes.
@@ -3026,10 +3038,43 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
         excluded_shells, excluded_by_match = 0, 0
         fields = match_fields(match_path)
         kinds_before, kinds_after = set(), set()
+        # 🔴 THE PRE-FILTER INDEX MAP — `{session: [window_index, ...]}` sampled
+        # BEFORE either filter runs, and it is what makes a `detail` miss honest.
+        #
+        # `filter_report` derives `detail_sibling_indices` from the rows it is
+        # handed, and by then a row filter has already run — so under
+        # `--match`/`--claude-only` it enumerated only the SURVIVORS and printed
+        # a flat falsehood: measured live, `detail scratch3:1 --match datapacket`
+        # answered "session 'scratch3' has windows ['2']" while window 1 existed
+        # on BOTH searched hosts. That is worse than the silent empty it
+        # replaced, because `(searched: laptop, workbench)` makes it read as
+        # authoritative. Sampled here, the sibling list is a fact about the SCAN
+        # rather than about the filter.
+        #
+        # OPT-IN (`prefilter_index_map`), because only `detail` consumes it and
+        # a 1-row `--match` should not carry a 72-row index map back — the whole
+        # point of the flag is a small payload. `None` when it was not recorded,
+        # so `filter_report` can tell "not sampled" from "sampled and empty".
+        prefilter = {} if prefilter_index_map else None
         for host in hosts:
             entry = report["hosts"][host]
             rows_here = entry["windows"]
             kinds_before |= {row_kind(r) for r in rows_here}
+            if prefilter is not None:
+                # 🔴 NO `and entry["reachable"]` HERE, AND THAT IS DELIBERATE.
+                # The rule is right — a host that never answered must not
+                # contribute a measured presence or absence of window indices —
+                # but as a runtime CHECK it is unreachable: `gather` gives an
+                # unreachable host `windows: []` by construction, so the loop
+                # below visits nothing for it either way. A mutation sweep
+                # proved it: deleting the clause changed no test. An
+                # unreachable guard reads as a defence and is not one, so the
+                # rule is stated as a PRECONDITION and pinned directly by
+                # `test_an_unreachable_host_carries_NO_rows_...`, which is the
+                # thing that can actually fail.
+                for r in rows_here:
+                    prefilter.setdefault(str(r.get("session")), set()).add(
+                        str(r.get("window_index")))
             if claude_only:
                 kept = [r for r in rows_here if not dropped_by_claude_only(r)]
                 excluded_shells += len(rows_here) - len(kept)
@@ -3041,6 +3086,20 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
                 rows_here = kept
             kinds_after |= {row_kind(r) for r in rows_here}
             entry["windows"] = rows_here
+        if prefilter is not None:
+            report["filters"]["prefilter_window_indices"] = {
+                sess: sorted(idxs, key=_index_sort_key)
+                for sess, idxs in prefilter.items()}
+        # 🔴 A COUNT OVER A FLEET NOBODY REACHED IS NOT A ZERO. With every host
+        # down the loop above visits only empty row lists, so both counters
+        # would publish a confident `0` — "the filter ran and matched nothing"
+        # — about a scan that measured nothing at all. `detail_matched` is
+        # already `None` in exactly this state; these now agree with it.
+        # ⚠ `excluded_shells` has the SAME shape and is deliberately NOT changed
+        # here: it is a pre-existing published field with its own tests, and
+        # redefining it belongs in its own change, not smuggled into this one.
+        fleet_measured = any(h.get("reachable")
+                             for h in report["hosts"].values())
         if claude_only:
             report["filters"]["excluded_shells"] = excluded_shells
         if match_terms:
@@ -3051,11 +3110,17 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
             # difference between a 1-row answer and a 29-row one (see
             # `MATCH_FIELDS`). `matched` is the surviving count stated
             # positively, so a reader never has to subtract to learn it.
+            #
+            # The TERMS and FIELDS are published even over an unreachable fleet:
+            # "which filter was requested" is known regardless of whether
+            # anything answered. Only the COUNTS go null.
             report["filters"]["match"] = list(match_terms)
             report["filters"]["match_fields"] = list(fields)
-            report["filters"]["excluded_by_match"] = excluded_by_match
-            report["filters"]["matched"] = sum(
-                len(report["hosts"][h]["windows"]) for h in hosts)
+            report["filters"]["excluded_by_match"] = (
+                excluded_by_match if fleet_measured else None)
+            report["filters"]["matched"] = (
+                sum(len(report["hosts"][h]["windows"]) for h in hosts)
+                if fleet_measured else None)
         # Sorted for a deterministic render, for the same reason as
         # `kinds_produced`. `[]` — not absent — when a filter ran and removed
         # no whole kind: a filter DID run, so "which kinds did it remove" is a
@@ -3590,13 +3655,20 @@ def render_table(report) -> str:
         # An empty table under a `--match` is otherwise indistinguishable from
         # an empty fleet — and a reader who cannot see that `path` was excluded
         # cannot tell why their repo-shaped query found nothing.
+        # 🔴 `matched`, NOT `total_sessions`. They are the same number on a
+        # `scan` and DIFFERENT on a `detail`, where `filter_report` narrows a
+        # second time — so quoting `total_sessions` printed "1 row(s) matched"
+        # under a filter that matched three, with the right number sitting
+        # unread in `filters.matched`. Both counts are `null`-not-`0` over an
+        # unreachable fleet, and the sentence says so rather than printing a
+        # zero nobody measured.
+        def _n(v):
+            return "an unmeasured number of" if v is None else v
         out.append("  FILTER --match {}: {} row(s) matched, {} excluded; "
                    "fields searched = {}".format(
                        " ".join(repr(t) for t in summ["match"]),
-                       summ.get("total_sessions"),
-                       summ.get("excluded_by_match")
-                       if summ.get("excluded_by_match") is not None
-                       else "an unmeasured number of",
+                       _n(summ.get("matched")),
+                       _n(summ.get("excluded_by_match")),
                        ", ".join(summ.get("match_fields") or ["?"])))
     if summ.get("hosts_unreachable"):
         out.append("  UNREACHABLE HOSTS: " +
@@ -4386,7 +4458,12 @@ def main(argv=None):
                     use_capture=not args.no_capture,
                     threshold=args.stale_threshold,
                     claude_only=args.claude_only,
-                    match=args.match, match_path=args.match_path)
+                    match=args.match, match_path=args.match_path,
+                    # 🔴 ONLY `detail` consumes the pre-filter index map, and
+                    # only it pays for it. A 1-row `--match` scan must not carry
+                    # a 72-session index map back — a small payload is the whole
+                    # point of that flag.
+                    prefilter_index_map=(args.subcommand == "detail"))
 
     if args.match_path and not args.match:
         print("(--match-path widens --match, which was not given: no row "
@@ -4604,11 +4681,25 @@ def filter_report(report, session, window_index) -> dict:
 
       * `detail_target`            — the address that was asked for;
       * `detail_matched`           — how many rows it matched (0 is the miss);
-      * `detail_sibling_indices`   — the window indices that DO exist for that
-        session name, which is the fact that turns "not found" into a next step.
+      * `detail_sibling_indices`   — the window indices that exist for that
+        session name **on the hosts that answered, BEFORE any row filter ran**.
         `[]` means the session name itself matched nothing.
+      * `detail_filtered_out`      — `True` when the target DOES exist but a row
+        filter (`--claude-only` / `--match`) removed it. That is a miss caused
+        by the FILTER, not an absence in the fleet, and the two are different
+        answers.
 
-    🔴 ALL THREE ARE `None` WHEN NO HOST WAS REACHABLE. A miss measured against
+    🔴 THE SIBLING LIST IS SAMPLED PRE-FILTER, AND THAT IS THE WHOLE POINT.
+    `gather` runs the row filters before this function ever sees the report, so
+    deriving the siblings from the rows handed here enumerated only the
+    SURVIVORS. Measured live: `detail scratch3:1 --match datapacket` answered
+    "session 'scratch3' has windows ['2']" while window 1 existed on both
+    searched hosts. `gather` now records `filters.prefilter_window_indices` for
+    exactly this, and it is preferred whenever present; the row-derived fallback
+    is used only when no filter ran, where the two are identical by
+    construction.
+
+    🔴 ALL FOUR ARE `None` WHEN NO HOST WAS REACHABLE. A miss measured against
     a fleet nobody could reach is UNMEASURED, not "not found", and an empty
     sibling list there would assert a measured absence about windows nothing
     looked at. `exit_code_for` already separates those two (EXIT_UNAVAILABLE vs
@@ -4625,17 +4716,24 @@ def filter_report(report, session, window_index) -> dict:
                          and str(r.get("window_index")) == str(window_index)]
         out["hosts"][name] = h2
     matched = sum(len(h["windows"]) for h in out["hosts"].values())
-    # Siblings are read off the REACHABLE hosts' UNFILTERED rows: a host that
-    # never answered cannot contribute a measured absence of window indices.
-    siblings = sorted(
-        {str(r.get("window_index")) for name in reachable
-         for r in report["hosts"][name].get("windows", [])
-         if str(r.get("session")) == str(session)},
-        key=_index_sort_key)
+    pre = (report.get("filters") or {}).get("prefilter_window_indices")
+    if pre is not None:
+        siblings = list(pre.get(str(session), []))
+    else:
+        # No row filter ran (or nothing sampled), so the rows handed here ARE
+        # the unfiltered set. Reachable hosts only: a host that never answered
+        # cannot contribute a measured absence of window indices.
+        siblings = sorted(
+            {str(r.get("window_index")) for name in reachable
+             for r in report["hosts"][name].get("windows", [])
+             if str(r.get("session")) == str(session)},
+            key=_index_sort_key)
+    filtered_out = bool(matched == 0 and str(window_index) in siblings)
     out["filters"] = dict(report.get("filters") or {})
     out["filters"]["detail_target"] = f"{session}:{window_index}"
     out["filters"]["detail_matched"] = matched if reachable else None
     out["filters"]["detail_sibling_indices"] = siblings if reachable else None
+    out["filters"]["detail_filtered_out"] = filtered_out if reachable else None
     out["summary"] = summarize(out)
     # 🔴 THE CAVEATS ARE RE-DERIVED HERE TOO. This path re-runs `summarize` and
     # then renders through `render_caveats`, so leaving the inherited caveats
@@ -4645,6 +4743,21 @@ def filter_report(report, session, window_index) -> dict:
     # this second summarize call was not; a rule enforced at one of its two
     # sites is the failure this whole change keeps re-finding.
     out["caveats"] = measured_caveats(out)
+    return out
+
+
+def _active_row_filters(filters) -> list:
+    """Which ROW filters ran, spelled as the flags an operator would drop.
+
+    ONE definition, because two messages and a test all need the same answer and
+    a second copy would name a set the first does not.
+    """
+    out = []
+    if (filters or {}).get("claude_only"):
+        out.append("--claude-only")
+    terms = (filters or {}).get("match")
+    if terms:
+        out.append("--match " + " ".join(repr(t) for t in terms))
     return out
 
 
@@ -4662,11 +4775,24 @@ def detail_not_found_message(report):
         entries carry `reachable: false` + `error`; this stays quiet rather than
         contradicting them.
 
-    When it DOES speak, it names the window indices that exist for that session
-    name — the fact that separates "you have the wrong index" from "there is no
-    such session", which are two different next steps and were previously the
-    same silence. It also names which hosts were searched and which were not,
-    so a hit that only exists on an unreachable peer cannot be read as absent.
+    🔴 IT DISTINGUISHES THREE MISSES, because they are three different next
+    steps and only one of them means the window is not there:
+
+      1. THE FILTER REMOVED IT (`detail_filtered_out`). The window EXISTS; a
+         `--claude-only` / `--match` dropped its row. Saying "NO SUCH WINDOW"
+         here is a flat falsehood, and `(searched: …)` makes it read as
+         authoritative — it was measured live on `detail scratch3:1 --match
+         datapacket`, for a window present on BOTH searched hosts. This is the
+         same class `render_table` already guards with "their absence above is
+         the FILTER's doing, not a measured absence"; that guard existed at one
+         of its two sites.
+      2. WRONG INDEX. The session exists and its indices are named — sampled
+         BEFORE the row filters (see `filter_report`), so the list is a fact
+         about the scan and not about the filter.
+      3. NO SUCH SESSION on any host that answered.
+
+    It also names which hosts were searched and which were not, so a hit that
+    only exists on an unreachable peer cannot be read as absent.
     """
     filters = report.get("filters") or {}
     target = filters.get("detail_target")
@@ -4678,12 +4804,23 @@ def detail_not_found_message(report):
     unsearched = sorted(k for k, v in hosts.items() if not v.get("reachable"))
     session, _, widx = str(target).partition(":")
     siblings = filters.get("detail_sibling_indices") or []
-    if siblings:
+    active = _active_row_filters(filters)
+    if filters.get("detail_filtered_out"):
+        head = (f"detail: WINDOW {target!r} EXISTS but a ROW FILTER "
+                f"({', '.join(active) or 'unknown'}) removed it — this empty "
+                "result is the FILTER's doing, NOT a measured absence. Re-run "
+                "without the filter to inspect it")
+    elif siblings:
         head = (f"detail: NO SUCH WINDOW {target!r} — session {session!r} has "
                 f"windows {siblings}; you asked for index {widx!r}")
+        if active:
+            head += (f" (indices measured BEFORE the row filter "
+                     f"{', '.join(active)})")
     else:
         head = (f"detail: NO SUCH WINDOW {target!r} — no session named "
                 f"{session!r} exists on any host that answered")
+        if active:
+            head += (f" (measured BEFORE the row filter {', '.join(active)})")
     tail = f" (searched: {', '.join(searched)})"
     if unsearched:
         tail += (f"; NOT searched: {', '.join(unsearched)} — unreachable, so "

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -3064,14 +3064,24 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
                 # 🔴 NO `and entry["reachable"]` HERE, AND THAT IS DELIBERATE.
                 # The rule is right — a host that never answered must not
                 # contribute a measured presence or absence of window indices —
-                # but as a runtime CHECK it is unreachable: `gather` gives an
-                # unreachable host `windows: []` by construction, so the loop
-                # below visits nothing for it either way. A mutation sweep
-                # proved it: deleting the clause changed no test. An
-                # unreachable guard reads as a defence and is not one, so the
-                # rule is stated as a PRECONDITION and pinned directly by
-                # `test_an_unreachable_host_carries_NO_rows_...`, which is the
-                # thing that can actually fail.
+                # but as a runtime CHECK it is unreachable: an unreachable host's
+                # `windows` is `[]`, so the loop below visits nothing for it
+                # either way. A mutation sweep proved it: deleting the clause
+                # changed no test. An unreachable guard reads as a defence and is
+                # not one, so the rule is stated as a PRECONDITION instead.
+                #
+                # ⚠ AND THE PRECONDITION IS OVER-DETERMINED, which is why no
+                # single-mechanism mutation reds anything. TWO independent
+                # mechanisms hold it: `run_tmux` returns `stdout: ""` on every
+                # unreachable path, so `fold_windows` produces no rows; AND the
+                # population loop above skips a host that did not answer. An
+                # audit deleted the second and all tests stayed green — correctly,
+                # because the first still held.
+                # `test_an_unreachable_host_carries_NO_rows_...` therefore pins
+                # the PROPERTY and cannot attribute it to either mechanism.
+                # 🔴 So: do not read a green suite as licence to delete the
+                # remaining enforcement. Deleting BOTH is what this depends on
+                # not happening, and nothing here detects it.
                 for r in rows_here:
                     prefilter.setdefault(str(r.get("session")), set()).add(
                         str(r.get("window_index")))

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -193,10 +193,11 @@ and the roll-ups a caller usually wants are:
                                         which skill owns each
 
 Each row carries: kind, host, session, window_index, window_id, window_name,
-codename, label, label_source, hotkey, pane_id, path, command, task, claude,
-busy, age_secs, age_source, status, waiting_probable, waiting_signals,
-waiting_status, unsent_prompt, unsent_prompt_status, claude_session_id, runtime,
-ledger, fuzzyclaw, panes. The row ledger is pinned by a test.
+codename, label, label_source, hotkey, hotkey_display, pane_id, path, command,
+task, claude, busy, age_secs, age_source, status, waiting_probable,
+waiting_signals, waiting_status, unsent_prompt, unsent_prompt_status,
+claude_session_id, runtime, ledger, fuzzyclaw, panes. The row ledger is pinned
+by a test.
 
 🔴 `waiting_probable` AND `unsent_prompt` ARE TWO SIGNALS, NOT ONE
 --------------------------------------------------------------------------
@@ -253,6 +254,14 @@ field (`scratch2:G:#d79921:Gold`) — never a second copy of that mapping. It is
 `null`, never `""`, for tiers 2 and 3: no `$mod+Shift+<k>` binding EXISTS for
 a session outside the table, and a fabricated key sends the operator to press
 something and land nowhere.
+
+🔴 `hotkey_display` IS THE CHORD, AND IT EXISTS BECAUSE THE CASE RULE IS NOT
+GUESSABLE. `M-v` opens `scratch3` and `M-V` opens `scratch4` — DIFFERENT
+sessions, per `scripts/tmux-scratch-slots.sh`. Measured 2026-08-28: a consumer
+read `hotkey: v` off a row and answered `Alt+Shift+V`, sending the operator to a
+real window that was the wrong one. The derivation now happens in exactly one
+function (`hotkey_display`) and its result rides on the row, so no reader has to
+know the rule. `null` wherever `hotkey` is null, never `""`.
 
 It is ADDITIVE. Two sessions can resolve to the SAME label — `0` and `8` are
 both sitting in one repo today — so a label alone identifies nothing. Every
@@ -700,6 +709,54 @@ def dropped_by_claude_only(row) -> bool:
         it out would delete the evidence rather than surface it.
     """
     return row_class(row) == "shell"
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 `--match` — THE FIELD SET IS THE WHOLE DESIGN, AND `path` IS NOT IN IT
+# --------------------------------------------------------------------------- #
+# Measured on the live fleet 2026-08-28, one 72-row scan, one query substring:
+#
+#   matched against `task`  ->  1 row   (the correct one)
+#   matched against `path`  -> 29 rows
+#
+# 29 of 72 windows share a repo path, so `path` does not DISCRIMINATE — it
+# admits nearly every window that happens to sit in the same checkout, and the
+# one true hit is then indistinguishable from the 28 that merely live nearby.
+# A filter whose answer is "40% of the fleet" is not an answer; it is the
+# unfiltered scan with a filter's authority attached.
+#
+# So the default set is the three fields that say WHAT A WINDOW IS DOING or
+# WHICH ONE IT IS, and `path` is opt-in behind `--match-path` for the case where
+# the operator really is asking "everything in that repo".
+MATCH_FIELDS = ("task", "label", "codename")
+MATCH_FIELD_PATH = "path"
+
+
+def match_fields(match_path=False) -> tuple:
+    """The fields `--match` looks at. ONE definition, so the payload's
+    `filters.match_fields` cannot disagree with what was actually searched."""
+    return MATCH_FIELDS + ((MATCH_FIELD_PATH,) if match_path else ())
+
+
+def row_matches(row, terms, fields=MATCH_FIELDS) -> bool:
+    """Case-insensitive substring match of every term, over `fields`.
+
+    🔴 TERMS ARE **AND**ed, and each term may land in a DIFFERENT field. That is
+    `find-session.py`'s default semantics ("a session must match all"), and the
+    two tools are read as one instrument by the operator asking "find the thing
+    I lost track of" — a filter that ORed here while the archive search ANDed
+    would return different sets for the same words with nothing saying so.
+
+    🔴 EACH TERM IS TESTED PER FIELD, never against the fields joined into one
+    string. A joined haystack lets a term span a field boundary — matching text
+    that exists in no field — which is a hit no reader can explain.
+
+    An EMPTY `terms` matches everything: "no filter was requested" and "a filter
+    that rejects the world" must not be the same call. The caller decides
+    whether a filter ran; this only says whether a row survives one.
+    """
+    hay = [str(row.get(f) or "").casefold() for f in fields]
+    return all(any(str(t).casefold() in h for h in hay) for t in terms)
 
 
 # 🔴 THE TWO LIMITS THAT CHANGE WHAT THE OUTPUT MEANS, CARRIED IN THE OUTPUT.
@@ -1239,11 +1296,52 @@ def resolve_label(session, path, slots=None, home=None) -> dict:
     return {"label": LABEL_FALLBACK, "label_source": "fallback", "hotkey": None}
 
 
+def hotkey_display(hotkey):
+    """The CHORD an operator actually presses, derived from `hotkey` in ONE place.
+
+    `None` -> `None`; a LOWERCASE key -> `Alt+<k>`; an UPPERCASE key ->
+    `Alt+Shift+<K>`.
+
+    🔴 CASE IS SIGNIFICANT AND IT IS NOT A SHIFT CONVENTION. Per
+    `scripts/tmux-scratch-slots.sh`, `M-v` opens `scratch3` (violet) and `M-V`
+    opens `scratch4` (Vapor) — two DIFFERENT sessions. So `Alt+v` and
+    `Alt+Shift+V` are not two spellings of one chord, and lowercasing or
+    uppercasing a key while rendering it sends the operator to a real window
+    that is the wrong one. Measured 2026-08-28: a run read `hotkey: v` off a row
+    and rendered `Alt+Shift+V` in its answer.
+
+    That happened because the DERIVATION lived in the reader's head. It lives
+    here now, and the row carries the answer (`hotkey_display`, in
+    `LEAN_ROW_FIELDS`), so no consumer has to perform it.
+
+    🔴 `None`, NEVER `""`. `resolve_label` returns `hotkey: None` on tiers 2 and
+    3 because no key EXISTS for a session outside the slot table; an empty
+    string here would render as `Alt+` and read as a real chord.
+    """
+    if not hotkey:
+        return None
+    # `.isupper()` and not a manual A-Z range: a digit or a symbol is neither
+    # upper nor lower, so it falls to the un-shifted spelling, which is what
+    # `bind -n M-<key>` binds for it.
+    return f"Alt+Shift+{hotkey}" if hotkey.isupper() else f"Alt+{hotkey}"
+
+
 def render_label(row) -> str:
     """The label as an OPERATOR reads it: `Gold (G)` when a hotkey exists,
     the bare label when none does. One writer, so the table and any other
     surface cannot spell the parenthesis differently — or, worse, print an
-    empty `()` for a session that has no key."""
+    empty `()` for a session that has no key.
+
+    🔴 THE PARENTHESIS HOLDS THE RAW KEY, NOT A CHORD, AND THAT IS DELIBERATE.
+    `hotkey_display` is the one writer of the chord spelling, and it is NOT
+    routed through here: the LABEL column is 14 characters wide (pinned by
+    `test_..._render_label_...<= 14` against `Yarrow (Y)`), and `Yarrow
+    (Alt+Shift+Y)` is 20 — it would be truncated back into an ambiguous stub by
+    the very `_trunc` that renders it. So the table states the KEY, case
+    preserved, and the chord is carried on the row for the consumer that needs
+    it. A test pins that this function never emits `Alt+`, so the two surfaces
+    cannot converge on two spellings of one thing.
+    """
     label = (row or {}).get("label") or "—"
     key = (row or {}).get("hotkey")
     return f"{label} ({key})" if key else label
@@ -2005,6 +2103,11 @@ def fold_windows(panes, host, slots=None, task_index=None,
             # 🔴 `null` for every non-slot session, because no hotkey EXISTS
             # for one. Never "".
             "hotkey": lab["hotkey"],
+            # 🔴 THE CHORD, DERIVED IN ONE PLACE. See `hotkey_display`: `v` and
+            # `V` are different sessions, so the row carries the answer rather
+            # than leaving each consumer to guess whether an upper-case key
+            # means Shift. `null` wherever `hotkey` is null — never "".
+            "hotkey_display": hotkey_display(lab["hotkey"]),
             "pane_id": lead.get("pane_id"),
             "path": lead.get("path", ""),
             "command": lead.get("command", ""),
@@ -2269,6 +2372,17 @@ def summarize(report) -> dict:
         # be read as a statement about what the scan produced when it is a
         # statement about what survived. None — not [] — when no filter ran.
         "kinds_excluded_by_filter": filters.get("kinds_excluded_by_filter"),
+        # 🔴 `--match` TRAVELS WITH ITS COUNTS FOR THE SAME REASON `claude_only`
+        # DOES — every number above describes the MATCHED set. `match` is the
+        # terms (null when no filter ran, never `[]`), `match_fields` names what
+        # was actually searched — the reader's way of seeing that `path` was
+        # excluded, which is the difference between 1 hit and 29 — and
+        # `excluded_by_match` is how many rows the filter dropped, so an empty
+        # table is readable as "the fleet has rows, none said these words"
+        # rather than as "the fleet is empty".
+        "match": filters.get("match"),
+        "match_fields": filters.get("match_fields"),
+        "excluded_by_match": filters.get("excluded_by_match"),
         "hosts_reachable": sorted(k for k, v in report["hosts"].items()
                                   if v["reachable"]),
         "hosts_unreachable": sorted(k for k, v in report["hosts"].items()
@@ -2578,7 +2692,8 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
            slots=None, ch_sql=SQL_RECENT_SESSIONS,
            claude_only=False, use_capture=True, capture_nonce=None,
            clawgate_reader=None, clawgate_path=None,
-           use_ledger=True, ledger_outputs=None) -> dict:
+           use_ledger=True, ledger_outputs=None,
+           match=None, match_path=False) -> dict:
     """Build the whole report. Every source is injectable, so this is the
     function the hermetic suite exercises end-to-end.
 
@@ -2660,9 +2775,19 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
         # 🔴 Both counters are None, never 0/[]: the filter has not run yet, so
         # nothing has been excluded BECAUSE nothing has been counted. A `[]`
         # here would tell `measured_caveats` a filter ran and removed no kind.
+        # 🔴 EVERY `--match` counter is None, never 0/[], for the SAME reason as
+        # `excluded_shells` above: no filter has run, so nothing was excluded
+        # BECAUSE nothing was counted. `match: null` and `match: []` would be
+        # indistinguishable statements about whether a filter ran at all, and
+        # "no rows matched" vs "no filter was asked for" is exactly the pair a
+        # consumer reading an empty row list has to tell apart.
         "filters": {"claude_only": bool(claude_only),
                     "excluded_shells": None,
-                    "kinds_excluded_by_filter": None},
+                    "kinds_excluded_by_filter": None,
+                    "match": None,
+                    "match_fields": None,
+                    "matched": None,
+                    "excluded_by_match": None},
         # 🔴 The clawgate approval queue. Filled in below; the skeleton carries
         # a `status` from the first byte so no code path can publish a bare
         # count. See `read_clawgate_queue` for the four outcomes.
@@ -2884,21 +3009,56 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
     # the unfiltered rows instead would have swapped one disagreement for
     # another: a line reading "rows in this scan are kind=cluster/tmux" printed
     # over a table with no cluster row in it.
-    if claude_only:
-        excluded = 0
+    #
+    # 🔴 THE TWO ROW FILTERS SHARE ONE PASS AND ONE `kinds_excluded_by_filter`.
+    # `--claude-only` and `--match` both narrow the same row set, and the
+    # question "which whole kinds did A FILTER remove" has ONE answer, not one
+    # per flag. Computing it per flag would let `--claude-only --match foo`
+    # publish the second filter's answer over the first's, which is the
+    # attributes-to-the-build-what-belongs-to-the-filter defect this block was
+    # written to close, re-created between two filters instead of between a
+    # filter and the build. So `kinds_before` is sampled ONCE before either
+    # runs and `kinds_after` ONCE after both, and the per-flag counters
+    # (`excluded_shells`, `excluded_by_match`) stay separate because THOSE are
+    # per-flag facts.
+    match_terms = [t for t in (match or ()) if str(t) != ""]
+    if claude_only or match_terms:
+        excluded_shells, excluded_by_match = 0, 0
+        fields = match_fields(match_path)
         kinds_before, kinds_after = set(), set()
         for host in hosts:
             entry = report["hosts"][host]
-            kinds_before |= {row_kind(r) for r in entry["windows"]}
-            kept = [r for r in entry["windows"]
-                    if not dropped_by_claude_only(r)]
-            kinds_after |= {row_kind(r) for r in kept}
-            excluded += len(entry["windows"]) - len(kept)
-            entry["windows"] = kept
-        report["filters"]["excluded_shells"] = excluded
+            rows_here = entry["windows"]
+            kinds_before |= {row_kind(r) for r in rows_here}
+            if claude_only:
+                kept = [r for r in rows_here if not dropped_by_claude_only(r)]
+                excluded_shells += len(rows_here) - len(kept)
+                rows_here = kept
+            if match_terms:
+                kept = [r for r in rows_here
+                        if row_matches(r, match_terms, fields)]
+                excluded_by_match += len(rows_here) - len(kept)
+                rows_here = kept
+            kinds_after |= {row_kind(r) for r in rows_here}
+            entry["windows"] = rows_here
+        if claude_only:
+            report["filters"]["excluded_shells"] = excluded_shells
+        if match_terms:
+            # 🔴 THE TERMS AND THE FIELDS TRAVEL WITH THE VERDICT. A consumer
+            # that finds zero rows must be able to tell "nothing matched these
+            # words in these fields" from "nothing exists" — and must be able
+            # to see that `path` was NOT searched, because that is the
+            # difference between a 1-row answer and a 29-row one (see
+            # `MATCH_FIELDS`). `matched` is the surviving count stated
+            # positively, so a reader never has to subtract to learn it.
+            report["filters"]["match"] = list(match_terms)
+            report["filters"]["match_fields"] = list(fields)
+            report["filters"]["excluded_by_match"] = excluded_by_match
+            report["filters"]["matched"] = sum(
+                len(report["hosts"][h]["windows"]) for h in hosts)
         # Sorted for a deterministic render, for the same reason as
-        # `kinds_produced`. `[]` — not absent — when the filter ran and removed
-        # no whole kind: the filter DID run, so "which kinds did it remove" is a
+        # `kinds_produced`. `[]` — not absent — when a filter ran and removed
+        # no whole kind: a filter DID run, so "which kinds did it remove" is a
         # measurement whose answer is none. The key is absent only when no
         # filter ran, which is the honest shape for "never measured" and mirrors
         # `excluded_shells` being None rather than 0 in that case.
@@ -3425,6 +3585,19 @@ def render_table(report) -> str:
                        "this scan produced — their absence above is the "
                        "FILTER's doing, not a measured absence".format(
                            "/".join(gone)))
+    if summ.get("match"):
+        # 🔴 The filter is stated where the counts are, and it names the FIELDS.
+        # An empty table under a `--match` is otherwise indistinguishable from
+        # an empty fleet — and a reader who cannot see that `path` was excluded
+        # cannot tell why their repo-shaped query found nothing.
+        out.append("  FILTER --match {}: {} row(s) matched, {} excluded; "
+                   "fields searched = {}".format(
+                       " ".join(repr(t) for t in summ["match"]),
+                       summ.get("total_sessions"),
+                       summ.get("excluded_by_match")
+                       if summ.get("excluded_by_match") is not None
+                       else "an unmeasured number of",
+                       ", ".join(summ.get("match_fields") or ["?"])))
     if summ.get("hosts_unreachable"):
         out.append("  UNREACHABLE HOSTS: " +
                    ", ".join(summ["hosts_unreachable"]))
@@ -3555,6 +3728,11 @@ LEAN_ROW_FIELDS = (
     # the ambiguity this whole view exists to remove.
     "kind",
     "host", "session", "window_index", "label", "label_source", "hotkey",
+    # 🔴 `hotkey_display` RIDES WITH `hotkey`, and it is not duplication — it is
+    # the DERIVATION, performed once. Dropping it from this view would put the
+    # `v`-vs-`V` case rule back in the reader's head, which is where it produced
+    # a confident answer sending the operator to the wrong live window.
+    "hotkey_display",
     # what it is working on, and WHICH agent is doing it
     "path", "task", "runtime",
     # what state it is in
@@ -4070,6 +4248,24 @@ def build_parser():
                         "set; summary.excluded_shells says how many were "
                         "dropped and summary.kinds_excluded_by_filter names "
                         "any kind removed entirely. No effect on `tail`.")
+    # 🔴 THE FIELD SET IS THE FEATURE. See `MATCH_FIELDS` for the measurement:
+    # one query substring hit 1 row on `task` and 29 of 72 on `path`, because
+    # nearly every window shares a repo path. `path` is therefore opt-in.
+    p.add_argument("--match", action="append", default=None, metavar="SUBSTR",
+                   help="scan/list/detail: keep only rows whose task, label or "
+                        "codename contains SUBSTR (case-insensitive). "
+                        "Repeatable; terms are ANDed, matching "
+                        "find-session.py's default. Every summary count then "
+                        "describes the MATCHED set; summary.match names the "
+                        "terms, summary.match_fields what was searched and "
+                        "summary.excluded_by_match how many rows were dropped. "
+                        "Reachable hosts + zero matches exits 3 (EXIT_EMPTY), "
+                        "never 0. No effect on `tail`.")
+    p.add_argument("--match-path", action="store_true",
+                   help="add `path` to the fields --match searches. OFF by "
+                        "default and measured: one substring matched 1 of 72 "
+                        "rows on `task` and 29 of 72 on `path`, so `path` "
+                        "admits most of the fleet instead of discriminating.")
     p.add_argument("--lines", type=int, default=DEFAULT_TAIL_LINES,
                    help="tail: scrollback lines")
     return p
@@ -4094,6 +4290,11 @@ def main(argv=None):
         if args.claude_only:
             print("(--claude-only has no effect on `tail`: it targets one "
                   "named window)", file=sys.stderr)
+        # Same rule, same reason, one flag over: a silently ignored flag is how
+        # a caller concludes it was honoured.
+        if args.match or args.match_path:
+            print("(--match/--match-path have no effect on `tail`: it targets "
+                  "one named window)", file=sys.stderr)
         # `tail` RETURNS before the shared --lean notice below, so it needs its
         # own. Silently ignoring it here is the exact rule this flag's own
         # justification cites, broken where the precedent sits one line up.
@@ -4184,7 +4385,12 @@ def main(argv=None):
                     use_ledger=not args.no_ledger,
                     use_capture=not args.no_capture,
                     threshold=args.stale_threshold,
-                    claude_only=args.claude_only)
+                    claude_only=args.claude_only,
+                    match=args.match, match_path=args.match_path)
+
+    if args.match_path and not args.match:
+        print("(--match-path widens --match, which was not given: no row "
+              "filter ran)", file=sys.stderr)
 
     if args.subcommand == "detail":
         if not args.target:
@@ -4196,6 +4402,14 @@ def main(argv=None):
             print(str(e), file=sys.stderr)
             return EXIT_USAGE
         report = filter_report(report, sess, widx)
+        # 🔴 A MISS IS SAID OUT LOUD. `filter_report` used to hand back an empty
+        # window list and nothing else, which reads exactly like a successful
+        # scan of a window that has nothing in it. On stderr, so a `--json`
+        # consumer's stdout is untouched — and the same facts are in
+        # `report["filters"]` for a consumer that never reads stderr at all.
+        miss = detail_not_found_message(report)
+        if miss:
+            print(miss, file=sys.stderr)
         report["session_history"] = detail_history(report,
                                                    use_ch=not args.no_ch)
 
@@ -4368,17 +4582,60 @@ def detail_history(report, use_ch=True, ch_client_factory=None,
     return res
 
 
+def _index_sort_key(idx: str):
+    """Numeric where possible, lexical otherwise — so `[1, 2, 10]` does not
+    render as `[1, 10, 2]` in a message whose whole job is to be read."""
+    return (0, int(idx), "") if idx.isdigit() else (1, 0, idx)
+
+
 def filter_report(report, session, window_index) -> dict:
     """Narrow a report to ONE window. Hosts keep their reachability facts —
-    dropping them would turn "unreachable" into "not found"."""
+    dropping them would turn "unreachable" into "not found".
+
+    🔴 IT ALSO RECORDS THE MISS, and that is not bookkeeping. This function
+    returned an EMPTY window list for a non-matching address and said nothing —
+    byte-identical, on stdout and in the exit path, to "the window exists and
+    has nothing in it". Measured 2026-08-28: a run guessed window index `3` from
+    the session name `scratch3` (the real index was `2`), got the silent empty
+    back, and spent four more tool calls before it worked out that the address
+    was wrong rather than the window idle.
+
+    So the narrowed report carries, in `filters`:
+
+      * `detail_target`            — the address that was asked for;
+      * `detail_matched`           — how many rows it matched (0 is the miss);
+      * `detail_sibling_indices`   — the window indices that DO exist for that
+        session name, which is the fact that turns "not found" into a next step.
+        `[]` means the session name itself matched nothing.
+
+    🔴 ALL THREE ARE `None` WHEN NO HOST WAS REACHABLE. A miss measured against
+    a fleet nobody could reach is UNMEASURED, not "not found", and an empty
+    sibling list there would assert a measured absence about windows nothing
+    looked at. `exit_code_for` already separates those two (EXIT_UNAVAILABLE vs
+    EXIT_EMPTY) from `hosts[*].reachable`; this keeps the structured fields
+    telling the same story.
+    """
     out = dict(report)
     out["hosts"] = {}
+    reachable = [name for name, h in report["hosts"].items() if h.get("reachable")]
     for name, h in report["hosts"].items():
         h2 = dict(h)
         h2["windows"] = [r for r in h.get("windows", [])
                          if str(r.get("session")) == str(session)
                          and str(r.get("window_index")) == str(window_index)]
         out["hosts"][name] = h2
+    matched = sum(len(h["windows"]) for h in out["hosts"].values())
+    # Siblings are read off the REACHABLE hosts' UNFILTERED rows: a host that
+    # never answered cannot contribute a measured absence of window indices.
+    siblings = sorted(
+        {str(r.get("window_index")) for name in reachable
+         for r in report["hosts"][name].get("windows", [])
+         if str(r.get("session")) == str(session)},
+        key=_index_sort_key)
+    out["filters"] = dict(report.get("filters") or {})
+    out["filters"]["detail_target"] = f"{session}:{window_index}"
+    out["filters"]["detail_matched"] = matched if reachable else None
+    out["filters"]["detail_sibling_indices"] = siblings if reachable else None
     out["summary"] = summarize(out)
     # 🔴 THE CAVEATS ARE RE-DERIVED HERE TOO. This path re-runs `summarize` and
     # then renders through `render_caveats`, so leaving the inherited caveats
@@ -4389,6 +4646,50 @@ def filter_report(report, session, window_index) -> dict:
     # sites is the failure this whole change keeps re-finding.
     out["caveats"] = measured_caveats(out)
     return out
+
+
+def detail_not_found_message(report):
+    """The LOUD stderr line for a `detail` that matched no window — or `None`.
+
+    PURE, and it returns `None` in exactly two cases, both deliberate:
+
+      * a window WAS found (`detail_matched` non-zero) — nothing to say;
+      * NO host was reachable, so `detail_matched` is `None`. 🔴 An address that
+        could not be checked is UNMEASURED, not "not found". Printing "no such
+        window" over an unreachable fleet states a fact about a machine nobody
+        talked to, and sends the reader to re-check their spelling instead of
+        their SSH. `exit_code_for` returns EXIT_UNAVAILABLE there and the host
+        entries carry `reachable: false` + `error`; this stays quiet rather than
+        contradicting them.
+
+    When it DOES speak, it names the window indices that exist for that session
+    name — the fact that separates "you have the wrong index" from "there is no
+    such session", which are two different next steps and were previously the
+    same silence. It also names which hosts were searched and which were not,
+    so a hit that only exists on an unreachable peer cannot be read as absent.
+    """
+    filters = report.get("filters") or {}
+    target = filters.get("detail_target")
+    matched = filters.get("detail_matched")
+    if not target or matched is None or matched:
+        return None
+    hosts = report.get("hosts") or {}
+    searched = sorted(k for k, v in hosts.items() if v.get("reachable"))
+    unsearched = sorted(k for k, v in hosts.items() if not v.get("reachable"))
+    session, _, widx = str(target).partition(":")
+    siblings = filters.get("detail_sibling_indices") or []
+    if siblings:
+        head = (f"detail: NO SUCH WINDOW {target!r} — session {session!r} has "
+                f"windows {siblings}; you asked for index {widx!r}")
+    else:
+        head = (f"detail: NO SUCH WINDOW {target!r} — no session named "
+                f"{session!r} exists on any host that answered")
+    tail = f" (searched: {', '.join(searched)})"
+    if unsearched:
+        tail += (f"; NOT searched: {', '.join(unsearched)} — unreachable, so "
+                 f"{target!r} may exist there and this is not a measured "
+                 "absence on that host")
+    return head + tail
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_find_session_live.py
+++ b/scripts/tests/test_find_session_live.py
@@ -46,6 +46,7 @@ real media path or third-party hostname may appear here.
 """
 from __future__ import annotations
 
+import argparse
 import ast
 import importlib.machinery
 import importlib.util
@@ -746,17 +747,22 @@ def test_fmt_age_states_a_MISSING_age_rather_than_rendering_zero():
 #   R1-8  `live_scan` raised AttributeError on valid-but-non-object JSON,
 #         outside the try, from a function whose contract is to discriminate.
 #
-# 🔴 WHICH OF THESE IS REGRESSION COVERAGE. MEASURED at NODE level: this file
-# and its sibling were collected at both shas and the head tests run against
-# base source — **66 new nodes across the two, 46 RED and 20 GREEN at a6f09d5a**.
-# SEVEN of the green are from THIS file and are named below.
+# 🔴 WHICH OF THESE IS REGRESSION COVERAGE. The GREEN-at-base ones are named in
+# `R1_INVARIANT_GUARDS` below, and a test asserts every name resolves.
 #
-# ⚠ An earlier revision said "56 nodes … 10 GREEN" and "the SIX green ones from
-# THIS file". The red count was exact; the rest came from a FUNCTION-level sweep
-# that did not expand `parametrize` and skipped functions whose name already
-# existed at base. This file's own miscount was `test_the_R1_invariant_guard_
-# ledger_names_only_tests_that_exist` — the ledger's gate was itself missing
-# from the ledger.
+# ⚠ NO NODE COUNTS HERE, DELIBERATELY, AND THE REASON IS THE HISTORY. This
+# comment carried "56 nodes … 10 GREEN", then "66 … 20 GREEN"; the sibling
+# section carried "29 … 13 GREEN". EVERY ONE was measured wrong — the first by a
+# function-level sweep that skipped `parametrize` expansion, the last because a
+# later fix in the SAME commit added five nodes after the number was typed.
+#
+# A count that the next commit invalidates is a claim nothing enforces, which is
+# the class three consecutive audit rounds kept finding. It cannot be derived at
+# test time (it needs the head tests run against an OLD sha), so it is DELETED
+# rather than corrected: understated coverage that reads as precise is worse
+# than no number. The per-round matrices live in the PR body, each with the sha
+# and the method that produced it. What stays here is the LEDGER, because a name
+# either resolves or it does not.
 # =========================================================================== #
 R1_INVARIANT_GUARDS = frozenset({
     # The strict default of `live_state_of` IS the old behaviour — that is the
@@ -1116,15 +1122,10 @@ def test_a_REAL_report_object_still_parses():
 #   F8  🟢 `--limit 0` was unbounded on the live leg and empty on the archive
 #       leg — one flag, opposite meanings in one run. Now a usage error.
 #
-# 🔴 MEASURED AT NODE LEVEL against 9f9dcbde — 29 NEW nodes across the two
-# files, 16 RED and 13 GREEN, plus 5 MODIFIED nodes that also went red (the four
-# `test_valid_but_NON_OBJECT_json…` params, whose assertion tightened from `[]`
-# to `None` for F3, and `…ARCHIVE_ONLY_flag…[any]`, whose needle moved). FIVE of
-# the 13 green are from THIS file and are named below.
-#
-# The method is deliberately node-level: round 1's ledger was wrong precisely
-# because it counted FUNCTIONS whose names were new, which skipped `parametrize`
-# expansion and skipped modified-but-same-named tests.
+# 🔴 The GREEN-at-9f9dcbde ones are named in `R2_INVARIANT_GUARDS` below. NO
+# NODE COUNTS — see the note above §2's ledger: this section's count was typed
+# before a later fix in the same commit added five nodes, and was wrong on
+# arrival. The matrix lives in the PR body with its sha and method.
 # =========================================================================== #
 R2_INVARIANT_GUARDS = frozenset({
     # NEGATIVE control on F1's extra sentence — a non-corpus archive-only flag
@@ -1161,11 +1162,14 @@ def test_the_archive_only_ledger_PARTITIONS_every_argparse_destination():
     now: every parser destination is either live-aware or archive-only, and a
     NEW flag that is neither fails here rather than shipping a silent one-leg
     filter under a comment claiming the class is closed.
+
+    🔴 READ OFF `_actions`, NOT OFF A PARSED NAMESPACE (R2 finding 🟢-3). A flag
+    declared `default=argparse.SUPPRESS` never appears in the namespace, so it
+    fell into NEITHER half and the equality still held — the gate's own comment
+    claimed such a flag "fails the suite" while it measurably did not.
+    `test_a_SUPPRESSED_flag_cannot_escape_the_partition` is the control.
     """
-    # The destination set is read from a real parse of a minimal argv, so it is
-    # whatever the parser ACTUALLY declares rather than a second hand-written
-    # list — the thing that drifted in the first place.
-    dests = set(vars(fs.parse_args(["zzterm"])))
+    dests = fs.parser_dests()
     assert dests, "the parser declared no destinations — gate wired to nothing"
     ledger = {d for d, _, _ in fs.ARCHIVE_ONLY_FLAGS}
     assert dests == fs.LIVE_AWARE_DESTS | ledger, (
@@ -1428,3 +1432,182 @@ def test_limit_ONE_is_accepted_and_bounds_both_legs(monkeypatch):
     got = run_main(monkeypatch, ["zzterm", "--live", "--limit", "1"], run)
     assert got["rc"] == fs.EXIT_OK
     assert "(showing 1 of 3" in got["out"]
+
+
+# =========================================================================== #
+# §4 — AUDIT FIX ROUND 3-DELTA (against tip 6914aa33)
+#
+#   R3-🟡2  `tail.coverage_complete` published a measured-looking `false` for a
+#           scan that NEVER RAN, while the sibling `archive.live_coverage_
+#           complete` was `null` in the same document — the exact shape F3
+#           removed from `hosts_unreachable` ONE FIELD OVER, in the same commit.
+#           And `SKILL.md` names this field as the branch point, so the doc
+#           pointed the reader at the one field that could not discriminate.
+#   R3-🟢2  The corpus-consequence sentence fired even under `--deep`, telling a
+#           caller to "pass --deep" in a run that already had.
+#   R3-🟢3  The partition gate read a parsed NAMESPACE, so a flag declared
+#           `default=argparse.SUPPRESS` was in neither half and the equality
+#           still held — while the gate's comment claimed such a flag fails.
+#
+# 🔴 NO NODE COUNTS IN THIS SECTION. Two rounds running, a hand-typed
+# "N new / R red / G green" was measured wrong — the second time because a fix
+# added five nodes AFTER the number was written. A count that a later commit
+# invalidates is a claim nothing enforces, which is the class this whole round
+# is about. The per-round matrices live in the PR body with the sha and method
+# that produced them; the LEDGERS below stay, because a name either resolves or
+# it does not and a test checks that.
+# =========================================================================== #
+R3_GREEN_AT_AUDITED_TIP = frozenset({
+    # NEGATIVE control on the tri-state: a MEASURED partial fleet must still
+    # publish `false`. "Always null" would pass the never-ran probe and destroy
+    # the field on the fleet state it exists for.
+    "test_a_MEASURED_partial_fleet_still_publishes_FALSE",
+    # NEGATIVE control on the --deep suppression: suppressing the corpus
+    # sentence unconditionally would pass that probe and silently undo R2-F1.
+    "test_the_corpus_sentence_STILL_fires_without_deep",
+    # This ledger's own gate — no behaviour to regress.
+    "test_the_R3_ledger_names_only_tests_that_exist",
+})
+
+
+def test_the_R3_ledger_names_only_tests_that_exist():
+    assert R3_GREEN_AT_AUDITED_TIP, "the ledger is empty — gate wired to nothing"
+    for entry in R3_GREEN_AT_AUDITED_TIP:
+        assert entry.split("[", 1)[0] in globals(), (
+            f"{entry!r} is listed in the R3 ledger but no such test exists")
+
+def test_tail_coverage_is_NULL_for_a_scan_that_never_ran(monkeypatch):
+    """🔴 R3-🟡2. `live_coverage_complete` is a two-valued PREDICATE and is right
+    for branching; PUBLISHING its `False` says *measured, and incomplete* about
+    a scan that produced no measurement."""
+    got = run_main(monkeypatch, ["zzterm", "--live", "--json", "--tail", "20"],
+                   make_run(boom=OSError("session-manager is not on this host")),
+                   archive=[])
+    blob = json.loads(got["out"])
+    assert blob["live"]["status"] == "error"
+    assert blob["tail"]["coverage_complete"] is None, (
+        "a scan that never ran published a measured-looking coverage verdict")
+    assert blob["tail"]["hosts_unreachable"] is None
+    # ...and it agrees with its sibling in the SAME document, which is the
+    # inconsistency that made this findable at all.
+    assert blob["archive"]["live_coverage_complete"] is None
+
+
+@pytest.mark.parametrize("status,unreachable,expect", [
+    ("ok", [], True),
+    ("ok", ["laptop"], False),
+    # `unavailable` RAN and every host was unreachable — a real measurement.
+    ("unavailable", ["workbench", "laptop"], False),
+    ("error", None, None),
+], ids=["full", "partial", "unavailable", "never-ran"])
+def test_live_coverage_state_is_the_TRI_STATE_publishable_form(status,
+                                                               unreachable,
+                                                               expect):
+    """The whole truth table, so no cell is reachable only by accident. 🔴 The
+    `unavailable` row is the one that must NOT be `None`: that scan ran."""
+    assert fs.live_coverage_state(
+        {"status": status, "hosts_unreachable": unreachable}) is expect
+
+
+def test_the_PREDICATE_and_the_PUBLISHED_form_differ_only_on_never_ran():
+    """One writer each, and their disagreement is exactly one case. If they
+    agreed everywhere the tri-state would be pointless; if they disagreed
+    anywhere else, branching and publishing would have drifted apart."""
+    cases = [
+        {"status": "ok", "hosts_unreachable": []},
+        {"status": "ok", "hosts_unreachable": ["laptop"]},
+        {"status": "unavailable", "hosts_unreachable": ["a", "b"]},
+        {"status": "error", "hosts_unreachable": None},
+    ]
+    differ = [c for c in cases
+              if fs.live_coverage_complete(c) != fs.live_coverage_state(c)]
+    assert [c["status"] for c in differ] == ["error"]
+
+
+def test_a_MEASURED_partial_fleet_still_publishes_FALSE(monkeypatch):
+    """NEGATIVE CONTROL: "always null" would pass the never-ran probe and
+    destroy the field's usefulness on the fleet state it exists for."""
+    got = run_main(monkeypatch, ["zzterm", "--live", "--json", "--tail", "20"],
+                   partial_run(), archive=[])
+    tail = json.loads(got["out"])["tail"]
+    assert tail["coverage_complete"] is False
+    assert tail["hosts_unreachable"] == ["laptop"]
+
+
+# --------------------------------------------------------------------------- #
+# R3-🟢2 — the corpus sentence must not fire when --deep already ran the archive
+# --------------------------------------------------------------------------- #
+def test_the_corpus_sentence_is_SUPPRESSED_when_deep_already_forced_the_archive(
+        monkeypatch):
+    """🔴 R3-🟢2. The sentence exists to say "the corpus you chose may go
+    unsearched — pass --deep". Printing it in a run that already passed `--deep`
+    is advice to do the thing the caller did — the same "noise that trains the
+    reader to skip the line" this file refused to append to `--since`."""
+    run = make_run({("zzterm",): (0, live_report([ROW_VIOLET],
+                                                 match_fields=DEFAULT_MATCH_FIELDS)),
+                    (): (0, live_report([ROW_VIOLET]))})
+    got = run_main(monkeypatch,
+                   ["zzterm", "--live", "--deep", "--opencode-only"], run,
+                   archive=[archive_hit("dddddddd-4444-4555-8666-777777777777")])
+    # the flag is still NAMED — it genuinely does not filter the live section
+    assert "ARCHIVE-ONLY flags" in got["err"]
+    assert "--opencode-only" in got["err"]
+    # ...but the advice is gone, because the archive DID run
+    assert "pass --deep" not in got["err"]
+    assert got["archive_calls"] == 1
+    assert "ran because: --deep" in got["out"]
+
+
+def test_the_corpus_sentence_STILL_fires_without_deep(monkeypatch):
+    """NEGATIVE CONTROL — suppressing it unconditionally would pass the probe
+    above and silently undo R2-F1."""
+    run = make_run({("zzterm",): (0, live_report([ROW_VIOLET],
+                                                 match_fields=DEFAULT_MATCH_FIELDS))})
+    got = run_main(monkeypatch, ["zzterm", "--live", "--opencode-only"], run)
+    assert "pass --deep" in got["err"]
+
+
+def test_archive_only_notice_reads_deep_off_the_ARGS_not_a_global():
+    """The pure function, both ways, so the branch is pinned without a run."""
+    base = fs.parse_args(["zzterm", "--live", "--opencode-only"])
+    assert "pass --deep" in fs.archive_only_notice(base)
+    deep = fs.parse_args(["zzterm", "--live", "--deep", "--opencode-only"])
+    assert "pass --deep" not in fs.archive_only_notice(deep)
+    assert "--opencode-only" in fs.archive_only_notice(deep)
+
+
+# --------------------------------------------------------------------------- #
+# R3-🟢3 — a SUPPRESSED flag must not escape the partition
+# --------------------------------------------------------------------------- #
+def test_parser_dests_reads_the_ACTIONS_not_a_parsed_namespace():
+    """🔴 The mechanism, stated: `vars(parse_args(...))` cannot see a
+    `SUPPRESS`-defaulted flag at all."""
+    assert fs.parser_dests() == set(vars(fs.parse_args(["zzterm"]))), (
+        "no SUPPRESS flag exists today, so the two views must agree — if they "
+        "do not, one of them is already wrong")
+    assert "help" not in fs.parser_dests()
+
+
+def test_a_SUPPRESSED_flag_cannot_escape_the_partition(monkeypatch):
+    """🔴 R3-🟢3, THE CONTROL THE OLD GATE FAILED. A flag declared with
+    `default=argparse.SUPPRESS` is absent from the namespace, so the old
+    namespace-based equality held with the flag classified NOWHERE — measured
+    94/94 green with exactly this planted. Read off `_actions`, it is caught.
+    """
+    real = fs.build_parser
+
+    def with_suppressed():
+        p = real()
+        p.add_argument("--newest-first", action="store_true",
+                       default=argparse.SUPPRESS,
+                       help="planted: classified in neither half")
+        return p
+
+    monkeypatch.setattr(fs, "build_parser", with_suppressed)
+    dests = fs.parser_dests()
+    assert "newest_first" in dests, (
+        "the destination view cannot see a SUPPRESS-defaulted flag — the "
+        "partition gate is blind to exactly the flag it claims to catch")
+    ledger = {d for d, _, _ in fs.ARCHIVE_ONLY_FLAGS}
+    assert dests != fs.LIVE_AWARE_DESTS | ledger, (
+        "an unclassified flag left the partition equality holding")

--- a/scripts/tests/test_find_session_live.py
+++ b/scripts/tests/test_find_session_live.py
@@ -1,0 +1,724 @@
+#!/usr/bin/env python3
+"""Tests for `scripts/find-session.py --live` — the live-first session lookup.
+
+🔴 WHY THIS EXISTS. Measured on this host 2026-08-28: the transcript-archive
+walk takes **30.1 s**; the live cross-host tmux scan takes **1.82 s** and its
+rows already carry `task`, `label`, `hotkey`, `status`, `waiting_probable`,
+`path` and `claude_session_id`. For "find that thing I lost track of, is it
+still running, which window, where did it leave off", the archive is the wrong
+instrument — it answers a question about the past over a corpus that cannot say
+whether anything is running now. `--live` inverts the order.
+
+🔴 EVERY TEST HERE IS HERMETIC. `RUN` — the one subprocess seam this feature
+adds — is replaced wholesale, so no test spawns `session-manager`, reads a real
+tmux server or touches SSH. `test_the_seam_is_actually_replaced` is the positive
+control on that claim.
+
+🔴 THE SEAM GUARDS ARE THE POINT OF THIS FILE. Both sides of this feature are
+hermetically tested against their OWN fixtures, which is exactly the state
+`claude/RULES.md` calls "verified in isolation is the new vacuous green": the
+observed failure was a consumer assuming `detail --json` returns
+`{"window": ...}` and that rows carry `window`/`cwd` (they carry
+`window_index`/`path`). So this module pins the RELATIONSHIP — the argv this
+file builds is parsed by `session-manager`'s OWN parser, and every row field
+this file READS is checked against `session-manager`'s OWN `LEAN_ROW_FIELDS`.
+
+🔴 RED AT BASE, AND WHAT THAT IS WORTH HERE. All 33 nodes were replayed against
+a detached worktree at 9e452d34 and all 33 went red — but for TWO different
+reasons, and conflating them would overstate the coverage:
+
+  * most are red because the BEHAVIOUR did not exist (no `--live`, no live-first
+    ordering, no ambiguity refusal, no LIVE/CLOSED annotation);
+  * `test_json_WITHOUT_live_keeps_the_bare_ARRAY_every_caller_parses`,
+    `test_the_classic_TEXT_path_is_untouched_by_this_feature`,
+    `test_fmt_age_states_a_MISSING_age_rather_than_rendering_zero`,
+    `test_the_seam_is_actually_replaced`,
+    `test_the_fake_run_can_distinguish_a_scan_from_a_tail` and
+    `test_the_exit_CODE_VOCABULARY_is_pinned_to_LITERALS` are red at base only
+    because the HARNESS they use (`fs.RUN`, `fs.archive_search`, `fs.EXIT_*`,
+    `fs.fmt_age`) does not exist there. The first two are BACKWARD-COMPATIBILITY
+    guards — the classic paths are unchanged and these pin that — and the rest
+    are controls on this module's own instrument. None of them is evidence that
+    a bug was fixed, and none is counted as such.
+
+Fixtures are synthetic: this repo is PUBLIC and no captured transcript text,
+real media path or third-party hostname may appear here.
+"""
+from __future__ import annotations
+
+import ast
+import importlib.machinery
+import importlib.util
+import inspect
+import io
+import json
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "scripts"
+
+
+def _load(path, name):
+    loader = importlib.machinery.SourceFileLoader(name, str(path))
+    spec = importlib.util.spec_from_file_location(name, str(path), loader=loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+fs = _load(SCRIPTS / "find-session.py", "fs_live_under_test")
+sm = _load(SCRIPTS / "session-manager", "sm_for_seam_check")
+
+
+# =========================================================================== #
+# FIXTURES — synthetic, and pairwise distinct in every field an assertion names
+# =========================================================================== #
+# 🔴 THE TWO ROWS DIFFER IN THE HOTKEY *CASE*, deliberately. `M-v` opens
+# scratch3/violet and `M-V` opens scratch4/Vapor — DIFFERENT sessions. A fixture
+# with one case could not tell `hotkey_display` from a function that shifts
+# unconditionally.
+ROW_VIOLET = {
+    "kind": "tmux", "host": "workbench", "session": "scratch3",
+    "window_index": "2", "label": "violet", "label_source": "codename",
+    "hotkey": "v", "hotkey_display": "Alt+v",
+    "path": "/home/zach/workspace/zzsigma",
+    "task": "refactor the zzkiwi cache",
+    "runtime": "claude", "claude": True, "busy": True, "status": "busy",
+    "age_secs": 240.0, "age_source": "ledger",
+    "waiting_probable": False, "waiting_signals": [], "waiting_status": "ok",
+    "unsent_prompt": None, "unsent_prompt_status": "ok",
+    "claude_session_id": "aaaaaaaa-1111-4222-8333-444444444444",
+}
+ROW_VAPOR = {
+    "kind": "tmux", "host": "laptop", "session": "scratch4",
+    "window_index": "5", "label": "Vapor", "label_source": "codename",
+    "hotkey": "V", "hotkey_display": "Alt+Shift+V",
+    "path": "/home/zach/workspace/zztheta",
+    "task": "zzkiwi migration follow-up",
+    "runtime": "opencode", "claude": True, "busy": False, "status": "stale",
+    "age_secs": 7200.0, "age_source": "ledger",
+    "waiting_probable": True, "waiting_signals": ["a_question_was_asked"],
+    "waiting_status": "ok",
+    "unsent_prompt": None, "unsent_prompt_status": "ok",
+    "claude_session_id": "bbbbbbbb-2222-4333-8444-555555555555",
+}
+# A live row that no `--match` term selects — it exists so the UNFILTERED second
+# scan can hold a session id the FILTERED one does not.
+ROW_ORCHID = {
+    "kind": "tmux", "host": "workbench", "session": "scratch8",
+    "window_index": "1", "label": "Orchid", "label_source": "codename",
+    "hotkey": "O", "hotkey_display": "Alt+Shift+O",
+    "path": "/home/zach/workspace/zzomega",
+    "task": "zzunrelated bookkeeping",
+    "runtime": "claude", "claude": True, "busy": False, "status": "idle",
+    "age_secs": 60.0, "age_source": "ledger",
+    "waiting_probable": False, "waiting_signals": [], "waiting_status": "ok",
+    "unsent_prompt": None, "unsent_prompt_status": "ok",
+    "claude_session_id": "cccccccc-3333-4444-8555-666666666666",
+}
+
+DEFAULT_MATCH_FIELDS = ["task", "label", "codename"]
+
+
+def live_report(rows, reachable=("workbench", "laptop"), unreachable=(),
+                match_fields=None):
+    """A `session-manager --json --lean` payload, narrowed to what this consumer
+    reads. Hosts keep their reachability facts, which is the whole reason the
+    unreachable case is distinguishable at all."""
+    hosts = {}
+    for h in reachable:
+        hosts[h] = {"reachable": True, "error": None, "windows_measured": True,
+                    "windows": [r for r in rows if r["host"] == h]}
+    for h in unreachable:
+        hosts[h] = {"reachable": False, "error": "ssh: no route to host",
+                    "windows_measured": False, "windows": []}
+    return {
+        "view": "lean",
+        "hosts": hosts,
+        "filters": {"match": None if match_fields is None else ["zzkiwi"],
+                    "match_fields": match_fields},
+        "summary": {"total_sessions": sum(len(h["windows"]) for h in hosts.values())},
+    }
+
+
+def archive_hit(session_id, project="zzsigma", term="zzkiwi"):
+    """One transcript-search result, in the shape `render()` and
+    `render_archive_hit()` consume. Synthetic throughout."""
+    return {
+        "session_id": session_id,
+        "cwd": f"/home/zach/workspace/{project}",
+        "project_dir": f"-home-zach-workspace-{project}",
+        "branch": "feat/zzbranch",
+        "first": "2026-08-20T09:00:00",
+        "last": "2026-08-20T17:30:00",
+        "genesis": "a synthetic opening line",
+        "matched_terms": [term],
+        "total_hits": 4,
+        "snippets": {term: ("user", "a synthetic matching snippet")},
+        "path": f"/home/zach/.claude/projects/-x/{session_id}.jsonl",
+        "last_local": 0,
+    }
+
+
+def make_run(by_terms=None, tail=(0, "synthetic scrollback line\n", ""),
+             boom=None, raw=None):
+    """A fake `RUN`. It answers a SCAN by the `--match` terms it was given —
+    which is exactly the contract this consumer depends on: the MATCH PREDICATE
+    lives on the other side of the subprocess, not here.
+
+    `by_terms` maps a tuple of terms to `(rc, report)`. `raw` overrides the whole
+    stdout (for the "produced no JSON" path); `boom` makes the call raise.
+    """
+    by_terms = by_terms or {}
+    calls = []
+
+    def run(argv, timeout=None):
+        calls.append(list(argv))
+        if boom is not None:
+            raise boom
+        if "tail" in argv:
+            return tail
+        if raw is not None:
+            return raw
+        terms = tuple(argv[i + 1] for i, a in enumerate(argv) if a == "--match")
+        rc, report = by_terms[terms]
+        return rc, json.dumps(report), ""
+
+    run.calls = calls
+    return run
+
+
+def run_main(monkeypatch, argv, run, archive=None):
+    """Drive `main()` with the seam replaced, capturing stdout+stderr.
+
+    `archive` replaces `archive_search` — the 30 s walk is not what this module
+    is testing, and a test that paid for it could not observe whether it RAN.
+    """
+    monkeypatch.setattr(fs, "RUN", run)
+    seen = {"archive_calls": 0}
+
+    def fake_archive(a, since):
+        seen["archive_calls"] += 1
+        return list(archive or [])
+
+    monkeypatch.setattr(fs, "archive_search", fake_archive)
+    out, err = io.StringIO(), io.StringIO()
+    monkeypatch.setattr(sys, "stdout", out)
+    monkeypatch.setattr(sys, "stderr", err)
+    rc = fs.main(list(argv))
+    seen["rc"] = rc
+    seen["out"] = out.getvalue()
+    seen["err"] = err.getvalue()
+    seen["calls"] = run.calls
+    return seen
+
+
+def scan_calls(calls):
+    return [c for c in calls if "scan" in c]
+
+
+def tail_calls(calls):
+    return [c for c in calls if "tail" in c]
+
+
+# =========================================================================== #
+# THE HARNESS ITSELF — validated before any verdict is read off it
+# =========================================================================== #
+def test_the_seam_is_actually_replaced(monkeypatch):
+    """🔴 NEGATIVE CONTROL ON HERMETICITY. If `RUN` were not the only edge, a
+    test could quietly spawn a real `session-manager` against the operator's
+    live fleet and grade whatever it found."""
+    def forbidden(argv, timeout=None):
+        raise AssertionError(f"a real subprocess was attempted: {argv!r}")
+
+    monkeypatch.setattr(fs, "RUN", forbidden)
+    res = fs.live_scan(["zzkiwi"])
+    assert res["status"] == "error"
+    assert "AssertionError" in res["error"]
+
+
+def test_the_exit_CODE_VOCABULARY_is_pinned_to_LITERALS():
+    """🔴 FOUND BY THE MUTATION SWEEP, AND IT IS THE CLASSIC SHAPE.
+
+    Every `rc` assertion in this file compares against `fs.EXIT_*`, which is
+    self-satisfying: a mutant that rewrites the CONSTANT moves both sides of the
+    comparison and survives. Measured — `EXIT_AMBIGUOUS = 3` -> `0` was the
+    battery's POSITIVE CONTROL and it SURVIVED a fully green suite, which is
+    exactly `claude/RULES.md`'s "a fixture that can only ever produce the
+    constant's own value cannot see a mutant that hardcodes the literal".
+
+    So the literals are pinned here, once, and they are the SIBLING's vocabulary
+    — a caller reading an rc off either tool must not have to learn two tables.
+    """
+    assert (fs.EXIT_OK, fs.EXIT_USAGE, fs.EXIT_AMBIGUOUS,
+            fs.EXIT_UNAVAILABLE) == (0, 2, 3, 4)
+    # ...and they ARE `session-manager`'s, read from it rather than restated.
+    assert fs.EXIT_OK == sm.EXIT_OK
+    assert fs.EXIT_USAGE == sm.EXIT_USAGE
+    assert fs.EXIT_AMBIGUOUS == sm.EXIT_EMPTY
+    assert fs.EXIT_UNAVAILABLE == sm.EXIT_UNAVAILABLE
+    # Collapsing any two would make a refusal indistinguishable from a success.
+    assert len({fs.EXIT_OK, fs.EXIT_USAGE, fs.EXIT_AMBIGUOUS,
+                fs.EXIT_UNAVAILABLE}) == 4
+
+
+def test_the_fake_run_can_distinguish_a_scan_from_a_tail():
+    """POSITIVE CONTROL on the fixture. A harness that cannot tell the two
+    subprocesses apart cannot pin which one a fact came from, however many
+    tests are green."""
+    run = make_run({("zzkiwi",): (0, live_report([ROW_VIOLET]))},
+                   tail=(0, "TAILTEXT\n", ""))
+    rc, out, _ = run(fs.live_scan_argv(["zzkiwi"]))
+    assert rc == 0 and json.loads(out)["view"] == "lean"
+    assert run(fs.live_tail_argv(ROW_VIOLET, 20))[1] == "TAILTEXT\n"
+
+
+# =========================================================================== #
+# 🔴 SEAM GUARDS — the defect lives BETWEEN the two hermetically-tested halves
+# =========================================================================== #
+def test_the_live_scan_ARGV_is_one_SESSION_MANAGER_ACTUALLY_ACCEPTS():
+    """🔴 Parsed by `session-manager`'s OWN parser, not by a copy of its flags.
+
+    The observed run failed on exactly this class: it assumed a shape the other
+    side does not produce. A structural check here is what stops this file
+    building an argv that argparse rejects (or, worse, silently ignores).
+    """
+    argv = fs.live_scan_argv(["zzkiwi", "zzsigma"])
+    assert argv[0] == sys.executable
+    assert argv[1] == str(SCRIPTS / "session-manager")
+    ns = sm.build_parser().parse_args(argv[2:])
+    assert ns.subcommand == "scan"
+    assert ns.json is True and ns.lean is True and ns.no_ch is True
+    assert ns.match == ["zzkiwi", "zzsigma"]
+    # ...and an unfiltered scan asks for NO filter at all, rather than an empty
+    # one — `--match ''` would be a filter that rejects the world.
+    assert sm.build_parser().parse_args(fs.live_scan_argv()[2:]).match is None
+
+
+def test_the_tail_ARGV_names_the_ROWS_HOST_and_is_one_the_parser_accepts():
+    """🔴 `session-manager tail` resolves `--host all` to the LOCAL host, so a
+    tail of a laptop row without an explicit `--host` searches the workbench and
+    reports the window missing — a not-found that is really a wrong-machine."""
+    argv = fs.live_tail_argv(ROW_VAPOR, 40)
+    ns = sm.build_parser().parse_args(argv[2:])
+    assert ns.subcommand == "tail"
+    assert ns.target == "scratch4:5"
+    assert ns.host == "laptop"
+    assert ns.plain is True
+    assert ns.lines == 40
+
+
+# The row fields the LIVE renderer reads. Pinned TWO WAY below: against what the
+# source actually reads, and against what `session-manager` actually emits.
+LIVE_ROW_FIELDS_READ = frozenset({
+    "host", "session", "window_index", "label", "hotkey_display", "status",
+    "age_secs", "age_source", "waiting_probable", "waiting_status",
+    "waiting_signals", "task", "path", "claude_session_id", "runtime",
+})
+
+_LIVE_ROW_READERS = ("render_live", "live_resume_command", "live_tail_argv",
+                     "_tail_outcome")
+
+
+def _row_gets(*fns):
+    """Every `<row>.get("field")` literal in `fns`, read by `ast`.
+
+    These four functions consume a ROW and nothing else through `.get` — the
+    scan-result dict is read by subscript throughout, deliberately, so this
+    sweep cannot pick up a non-row key. A regex would; an AST walk over the
+    parsed source is the version that cannot be fooled by a key name appearing
+    in a comment.
+    """
+    found = set()
+    for fn in fns:
+        tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "get"
+                    and node.args
+                    and isinstance(node.args[0], ast.Constant)
+                    and isinstance(node.args[0].value, str)):
+                found.add(node.args[0].value)
+    return found
+
+
+def test_the_live_row_field_ledger_is_pinned_TWO_WAY_against_what_is_READ():
+    """🔴 A LEDGER OF A SET ANOTHER FUNCTION OWNS, checked both directions.
+
+    Reading a NEW row field without adding it here would leave the
+    cross-side check below blind to it — a guard whose description claims
+    coverage while its body covers one side.
+    """
+    read = _row_gets(*(getattr(fs, n) for n in _LIVE_ROW_READERS))
+    assert read, "the AST sweep found NO row field — the gate is wired to nothing"
+    assert read == set(LIVE_ROW_FIELDS_READ), (
+        "the ledger disagrees with what the live renderer actually reads:\n"
+        f"  only read  : {sorted(read - set(LIVE_ROW_FIELDS_READ))}\n"
+        f"  only listed: {sorted(set(LIVE_ROW_FIELDS_READ) - read)}")
+
+
+def test_every_live_row_field_READ_is_one_SESSION_MANAGER_ACTUALLY_EMITS():
+    """🔴 THE SEAM, as a RELATIONSHIP rather than two components.
+
+    The observed run assumed rows carried `window` and `cwd`; they carry
+    `window_index` and `path`. `--lean` is what this consumer asks for, so
+    `LEAN_ROW_FIELDS` is the authoritative set — a field dropped from that view
+    would make this renderer print `None` forever with nothing saying why.
+    """
+    missing = sorted(f for f in LIVE_ROW_FIELDS_READ
+                     if f not in sm.LEAN_ROW_FIELDS)
+    assert not missing, (
+        f"the LIVE renderer reads row fields the lean view does not carry: "
+        f"{missing}. Either add them to `LEAN_ROW_FIELDS` in "
+        f"`scripts/session-manager`, or stop reading them here — a `None` from "
+        "a field the view omitted is indistinguishable from a measured null.")
+    # POSITIVE CONTROL: prove this comparison can go RED, so the clean verdict
+    # above is not a fact about an empty loop.
+    assert "window" not in sm.LEAN_ROW_FIELDS, (
+        "positive control broken: `window` was supposed to be a name the lean "
+        "view does NOT carry")
+
+
+# =========================================================================== #
+# LIVE FIRST — and the archive only when it has to run
+# =========================================================================== #
+def test_a_live_match_SKIPS_the_30_second_archive(monkeypatch):
+    """🔴 THE WHOLE POINT. 1.8 s answered the question; 30.1 s must not be paid
+    on top of it."""
+    run = make_run({("zzkiwi",): (0, live_report([ROW_VIOLET, ROW_VAPOR],
+                                                 match_fields=DEFAULT_MATCH_FIELDS))})
+    got = run_main(monkeypatch, ["zzkiwi", "--live"], run,
+                   archive=[archive_hit("aaaaaaaa-1111-4222-8333-444444444444")])
+    assert got["archive_calls"] == 0, "the archive walk ran despite a live hit"
+    assert got["rc"] == fs.EXIT_OK
+    assert "LIVE (2 matched" in got["out"]
+    assert "ARCHIVE: skipped" in got["out"]
+    # ...and exactly ONE subprocess: the unfiltered second scan is only paid for
+    # on the archive path.
+    assert len(scan_calls(got["calls"])) == 1
+
+
+def test_no_live_match_FALLS_BACK_to_the_archive(monkeypatch):
+    run = make_run({("zznothing",): (3, live_report([], match_fields=DEFAULT_MATCH_FIELDS)),
+                    (): (0, live_report([ROW_VIOLET, ROW_ORCHID]))})
+    got = run_main(monkeypatch, ["zznothing", "--live"], run,
+                   archive=[archive_hit("dddddddd-4444-4555-8666-777777777777")])
+    assert got["archive_calls"] == 1
+    assert "no live window matched" in got["out"]
+    assert "ran because: no live match" in got["out"]
+
+
+def test_deep_runs_BOTH_even_when_the_live_fleet_answered(monkeypatch):
+    run = make_run({("zzkiwi",): (0, live_report([ROW_VIOLET],
+                                                 match_fields=DEFAULT_MATCH_FIELDS)),
+                    (): (0, live_report([ROW_VIOLET, ROW_ORCHID]))})
+    got = run_main(monkeypatch, ["zzkiwi", "--live", "--deep"], run,
+                   archive=[archive_hit("aaaaaaaa-1111-4222-8333-444444444444")])
+    assert got["archive_calls"] == 1
+    assert "ran because: --deep" in got["out"]
+
+
+def test_the_UNFILTERED_second_scan_is_what_the_annotation_joins_on(monkeypatch):
+    """🔴 THE FILTERED SCAN CANNOT ANNOTATE. It was NARROWED by the terms, so a
+    session that IS live but whose window title no longer says those words is
+    absent from it — labelling its archive hit CLOSED off that set would state a
+    measured absence about a window the FILTER removed.
+
+    `ROW_ORCHID` is exactly that window: live, and matched by no term.
+    """
+    run = make_run({("zznothing",): (3, live_report([], match_fields=DEFAULT_MATCH_FIELDS)),
+                    (): (0, live_report([ROW_VIOLET, ROW_ORCHID]))})
+    got = run_main(monkeypatch, ["zznothing", "--live"], run, archive=[
+        archive_hit(ROW_ORCHID["claude_session_id"]),
+        archive_hit("dddddddd-4444-4555-8666-777777777777"),
+    ])
+    # the FILTERED scan matched nothing, yet Orchid is correctly LIVE
+    assert "<LIVE>" in got["out"]
+    assert "<CLOSED>" in got["out"]
+    # ...and it took a second, term-free scan to know that
+    unfiltered = [c for c in scan_calls(got["calls"]) if "--match" not in c]
+    assert len(unfiltered) == 1
+
+
+def test_archive_hits_are_annotated_LIVE_or_CLOSED_by_session_id(monkeypatch):
+    run = make_run({("zznothing",): (3, live_report([], match_fields=DEFAULT_MATCH_FIELDS)),
+                    (): (0, live_report([ROW_VIOLET]))})
+    got = run_main(monkeypatch, ["zznothing", "--live", "--json"], run, archive=[
+        archive_hit(ROW_VIOLET["claude_session_id"]),
+        archive_hit("dddddddd-4444-4555-8666-777777777777"),
+    ])
+    blob = json.loads(got["out"])
+    states = [r["live_state"] for r in blob["archive"]["results"]]
+    assert states == ["LIVE", "CLOSED"]
+    assert blob["archive"]["live_ids_measured"] is True
+
+
+def test_the_annotation_is_UNMEASURED_not_CLOSED_when_the_live_scan_FAILED(
+        monkeypatch):
+    """🔴 The claim "that session is closed" requires a look that happened. A
+    failed scan must not launder into a measured absence."""
+    run = make_run(boom=OSError("session-manager is not on this host"))
+    got = run_main(monkeypatch, ["zzkiwi", "--live", "--json"], run,
+                   archive=[archive_hit(ROW_VIOLET["claude_session_id"])])
+    blob = json.loads(got["out"])
+    assert blob["live"]["status"] == "error"
+    assert blob["archive"]["live_ids_measured"] is False
+    assert [r["live_state"] for r in blob["archive"]["results"]] == ["UNMEASURED"]
+    assert fs.live_state_of("anything", None) == "UNMEASURED"
+    # ...and the measured counterpart, so the None branch is not the only one
+    # ever exercised.
+    assert fs.live_state_of("anything", set()) == "CLOSED"
+    assert fs.live_state_of("x", {"x"}) == "LIVE"
+
+
+# =========================================================================== #
+# THE LIVE SECTION — what it says, and what it must never say
+# =========================================================================== #
+def test_the_LIVE_section_carries_the_CHORD_and_never_derives_it(monkeypatch):
+    """🔴 THE SECOND DEFECT. The answer that sent the operator to the wrong
+    window derived `Alt+Shift+V` from `hotkey: v`. The chord is READ from
+    `hotkey_display` here, and both cases appear in one render so a renderer
+    that shifts unconditionally fails."""
+    run = make_run({("zzkiwi",): (0, live_report([ROW_VIOLET, ROW_VAPOR],
+                                                 match_fields=DEFAULT_MATCH_FIELDS))})
+    out = run_main(monkeypatch, ["zzkiwi", "--live"], run)["out"]
+    assert "[Alt+v]" in out
+    assert "[Alt+Shift+V]" in out
+    assert "[Alt+Shift+v]" not in out, (
+        "the renderer shifted a lower-case key — `M-v` and `M-V` are different "
+        "sessions")
+
+
+def test_the_LIVE_section_answers_the_whole_question_in_one_call(monkeypatch):
+    """Host, address, label+chord, status/age, the waiting pair with its
+    VERBATIM signal list, the task, the path, and how to get back in."""
+    run = make_run({("zzkiwi",): (0, live_report([ROW_VAPOR],
+                                                 match_fields=DEFAULT_MATCH_FIELDS))})
+    out = run_main(monkeypatch, ["zzkiwi", "--live"], run)["out"]
+    assert "laptop  scratch4:5" in out
+    assert "Vapor [Alt+Shift+V]" in out
+    assert "stale · 2h00m" in out
+    assert "waiting_probable: true" in out
+    assert '"a_question_was_asked"' in out
+    assert "task: zzkiwi migration follow-up" in out
+    assert "path: /home/zach/workspace/zztheta" in out
+    # an opencode row resumes with opencode, never `claude --resume`
+    assert f"resume: opencode --session {ROW_VAPOR['claude_session_id']}" in out
+    assert "claude --resume" not in out
+    # ...and the mirror image, so the branch is not hardcoded either way
+    out2 = run_main(monkeypatch, ["zzkiwi", "--live"],
+                    make_run({("zzkiwi",): (0, live_report([ROW_VIOLET]))}))["out"]
+    assert f"resume: claude --resume {ROW_VIOLET['claude_session_id']}" in out2
+
+
+def test_a_NULL_waiting_probable_renders_as_null_not_false(monkeypatch):
+    """🔴 The tri-state survives the render. `waiting_probable: null` means the
+    pane was never scraped; printing `false` would answer "is anything waiting
+    on you" off a look that never happened."""
+    row = dict(ROW_VIOLET, waiting_probable=None, waiting_signals=None,
+               waiting_status="uncaptured")
+    run = make_run({("zzkiwi",): (0, live_report([row]))})
+    out = run_main(monkeypatch, ["zzkiwi", "--live"], run)["out"]
+    assert "waiting_probable: null" in out
+    assert "[uncaptured]" in out
+    assert "waiting_signals:  null" in out
+
+
+def test_a_row_with_NO_session_id_offers_an_ATTACH_rather_than_a_fake_resume(
+        monkeypatch):
+    row = dict(ROW_VIOLET, claude_session_id=None)
+    run = make_run({("zzkiwi",): (0, live_report([row]))})
+    out = run_main(monkeypatch, ["zzkiwi", "--live"], run)["out"]
+    assert "no agent session id on this row" in out
+    assert "tmux attach -t scratch3:2" in out
+    assert fs.live_resume_command(row) is None
+
+
+# =========================================================================== #
+# 🔴 UNREACHABLE IS NEVER "NOT RUNNING"
+# =========================================================================== #
+def test_an_UNREACHABLE_PEER_is_loud_and_the_absence_is_labelled(monkeypatch):
+    run = make_run({("zzkiwi",): (0, live_report([ROW_VIOLET],
+                                                 reachable=("workbench",),
+                                                 unreachable=("laptop",),
+                                                 match_fields=DEFAULT_MATCH_FIELDS))})
+    out = run_main(monkeypatch, ["zzkiwi", "--live"], run)["out"]
+    assert "NOT searched: laptop" in out
+    assert "did not answer" in out
+    assert "not a measured absence on that host" in out
+
+
+def test_NO_HOST_ANSWERING_is_UNMEASURED_not_an_empty_fleet(monkeypatch):
+    """🔴 The one sentence this tool must never emit is "it is not running" off
+    a look that never happened."""
+    run = make_run({("zzkiwi",): (4, live_report([], reachable=(),
+                                                 unreachable=("workbench", "laptop")))})
+    got = run_main(monkeypatch, ["zzkiwi", "--live"], run)
+    assert "LIVE: NO HOST ANSWERED" in got["out"]
+    assert "UNMEASURED, not 'nothing is running'" in got["out"]
+    # and it FELL BACK, because "we could not look" must not become "we looked"
+    assert got["archive_calls"] == 1
+    assert "the live scan was UNMEASURED" in got["out"]
+
+
+@pytest.mark.parametrize("kw,needle", [
+    (dict(boom=OSError("no such file")), "OSError"),
+    (dict(raw=(2, "", "session-manager: unrecognized arguments")), "no JSON"),
+    (dict(raw=(0, "not json at all", "")), "no JSON"),
+])
+def test_a_BROKEN_live_scan_is_a_FAILED_scan_not_an_empty_one(monkeypatch, kw,
+                                                              needle):
+    got = run_main(monkeypatch, ["zzkiwi", "--live"], make_run(**kw))
+    assert "LIVE: SCAN FAILED" in got["out"]
+    assert needle in got["out"]
+    assert "NOT 'nothing is running'" in got["out"]
+    assert got["archive_calls"] == 1
+
+
+def test_live_scan_status_discriminates_all_three_outcomes(monkeypatch):
+    """The three statuses must be mutually distinguishable — an `ok` with zero
+    rows is the only one that means "we looked and found nothing"."""
+    monkeypatch.setattr(fs, "RUN", make_run({("t",): (3, live_report([]))}))
+    assert fs.live_scan(["t"])["status"] == "ok"
+    monkeypatch.setattr(fs, "RUN", make_run(
+        {("t",): (4, live_report([], reachable=(), unreachable=("workbench",)))}))
+    assert fs.live_scan(["t"])["status"] == "unavailable"
+    monkeypatch.setattr(fs, "RUN", make_run(boom=RuntimeError("x")))
+    assert fs.live_scan(["t"])["status"] == "error"
+    # ...and only `ok` yields a usable id set
+    monkeypatch.setattr(fs, "RUN", make_run({(): (0, live_report([ROW_VIOLET]))}))
+    assert fs.live_session_ids(fs.live_scan()) == {ROW_VIOLET["claude_session_id"]}
+
+
+# =========================================================================== #
+# --tail — ambiguity is REFUSED, not guessed
+# =========================================================================== #
+def test_tail_of_a_SINGLE_match_shells_out_with_that_ROWS_HOST(monkeypatch):
+    run = make_run({("zzkiwi",): (0, live_report([ROW_VAPOR],
+                                                 match_fields=DEFAULT_MATCH_FIELDS))},
+                   tail=(0, "synthetic last lines\n", ""))
+    got = run_main(monkeypatch, ["zzkiwi", "--live", "--tail", "40"], run)
+    assert got["rc"] == fs.EXIT_OK
+    calls = tail_calls(got["calls"])
+    assert len(calls) == 1
+    assert calls[0][2:] == ["tail", "scratch4:5", "--host", "laptop",
+                            "--plain", "--lines", "40"]
+    assert "TAIL laptop scratch4:5 (last 40 lines)" in got["out"]
+    assert "synthetic last lines" in got["out"]
+
+
+def test_tail_REFUSES_an_AMBIGUOUS_match_and_lists_the_candidates(monkeypatch):
+    """🔴 `window-triage` §7: ambiguity is refused, not guessed. A scrollback
+    printed from the wrong window is an answer that READS as correct, which is
+    strictly worse than no answer."""
+    run = make_run({("zzkiwi",): (0, live_report([ROW_VIOLET, ROW_VAPOR],
+                                                 match_fields=DEFAULT_MATCH_FIELDS))})
+    got = run_main(monkeypatch, ["zzkiwi", "--live", "--tail", "40"], run)
+    assert got["rc"] == fs.EXIT_AMBIGUOUS
+    assert tail_calls(got["calls"]) == [], "it tailed a window it had not resolved"
+    assert "TAIL: REFUSED — 2 live windows matched" in got["out"]
+    # both candidates are named, with a command that resolves each one
+    assert "tail scratch3:2 --host workbench" in got["out"]
+    assert "tail scratch4:5 --host laptop" in got["out"]
+
+
+def test_tail_with_NO_live_match_refuses_rather_than_tailing_nothing(monkeypatch):
+    run = make_run({("zznothing",): (3, live_report([], match_fields=DEFAULT_MATCH_FIELDS)),
+                    (): (0, live_report([]))})
+    got = run_main(monkeypatch, ["zznothing", "--live", "--tail", "40"], run)
+    assert got["rc"] == fs.EXIT_AMBIGUOUS
+    assert "no live window matched" in got["out"]
+    assert tail_calls(got["calls"]) == []
+
+
+def test_tail_over_an_UNMEASURED_fleet_is_UNAVAILABLE_not_ambiguous(monkeypatch):
+    """A refusal because nothing was measured is a different fact from a refusal
+    because two windows matched, and the exit codes say so."""
+    run = make_run({("zzkiwi",): (4, live_report([], reachable=(),
+                                                 unreachable=("workbench", "laptop"))),
+                    (): (4, live_report([], reachable=(),
+                                        unreachable=("workbench", "laptop")))})
+    got = run_main(monkeypatch, ["zzkiwi", "--live", "--tail", "40"], run)
+    assert got["rc"] == fs.EXIT_UNAVAILABLE
+    assert "TAIL: REFUSED — the live fleet was not measured" in got["out"]
+
+
+def test_tail_without_live_is_a_USAGE_error(monkeypatch):
+    got = run_main(monkeypatch, ["zzkiwi", "--tail", "40"], make_run())
+    assert got["rc"] == fs.EXIT_USAGE
+    assert "--tail requires --live" in got["err"]
+    assert got["calls"] == []
+    assert got["archive_calls"] == 0
+
+
+# =========================================================================== #
+# --json composition, and the shape existing callers already parse
+# =========================================================================== #
+def test_live_composes_with_json_and_carries_every_discriminant(monkeypatch):
+    run = make_run({("zzkiwi",): (0, live_report([ROW_VIOLET],
+                                                 reachable=("workbench",),
+                                                 unreachable=("laptop",),
+                                                 match_fields=DEFAULT_MATCH_FIELDS))},
+                   tail=(0, "synthetic tail\n", ""))
+    got = run_main(monkeypatch, ["zzkiwi", "--live", "--json", "--tail", "12"], run)
+    blob = json.loads(got["out"])
+    assert set(blob) == {"live", "archive", "tail"}
+    assert blob["live"]["status"] == "ok"
+    assert blob["live"]["hosts_reachable"] == ["workbench"]
+    assert blob["live"]["hosts_unreachable"] == ["laptop"]
+    assert blob["live"]["match_fields"] == DEFAULT_MATCH_FIELDS
+    assert blob["live"]["terms"] == ["zzkiwi"]
+    assert [r["session"] for r in blob["live"]["rows"]] == ["scratch3"]
+    assert blob["archive"]["ran"] is False
+    assert blob["tail"]["refused"] is False
+    assert blob["tail"]["resolved"] == {"host": "workbench",
+                                        "target": "scratch3:2"}
+    assert blob["tail"]["text"] == "synthetic tail\n"
+    assert blob["tail"]["requested_lines"] == 12
+
+
+def test_json_WITHOUT_live_keeps_the_bare_ARRAY_every_caller_parses(monkeypatch):
+    """INVARIANT GUARD, and a backward-compatibility one: `--live` is opt-in
+    precisely so no existing caller's output moves. Widening the array's
+    elements instead would have changed a shape nobody asked to change."""
+    got = run_main(monkeypatch, ["zzkiwi", "--json"], make_run(),
+                   archive=[archive_hit("eeeeeeee-5555-4666-8777-888888888888")])
+    blob = json.loads(got["out"])
+    assert isinstance(blob, list)
+    assert blob[0]["session_id"] == "eeeeeeee-5555-4666-8777-888888888888"
+    assert "live_state" not in blob[0]
+    assert got["calls"] == [], "the classic path ran a live scan"
+
+
+def test_the_classic_TEXT_path_is_untouched_by_this_feature(monkeypatch):
+    """INVARIANT GUARD. The renderer was factored out of `main`; this pins that
+    the factoring changed nothing a reader sees."""
+    got = run_main(monkeypatch, ["zzkiwi"], make_run(),
+                   archive=[archive_hit("ffffffff-6666-4777-8888-999999999999")])
+    assert "1 session(s) matched 'zzkiwi'" in got["out"]
+    assert "resume: claude --resume ffffffff-6666-4777-8888-999999999999" in got["out"]
+    assert "<LIVE>" not in got["out"] and "<CLOSED>" not in got["out"]
+    assert got["calls"] == []
+
+
+def test_deep_without_live_says_it_did_nothing(monkeypatch):
+    """A silently ignored flag is how a caller concludes it was honoured."""
+    got = run_main(monkeypatch, ["zzkiwi", "--deep"], make_run(), archive=[])
+    assert "--deep only means something with --live" in got["err"]
+
+
+def test_fmt_age_states_a_MISSING_age_rather_than_rendering_zero():
+    """🔴 A null age is not age 0 — no writer has recorded that window yet."""
+    assert fs.fmt_age(None) == "no age recorded"
+    assert fs.fmt_age(0) == "0s"
+    assert fs.fmt_age(0) != fs.fmt_age(None)
+    assert fs.fmt_age(45) == "45s"
+    assert fs.fmt_age(600) == "10m"
+    assert fs.fmt_age(7200) == "2h00m"
+    assert fs.fmt_age(90000) == "1d01h"

--- a/scripts/tests/test_find_session_live.py
+++ b/scripts/tests/test_find_session_live.py
@@ -746,10 +746,17 @@ def test_fmt_age_states_a_MISSING_age_rather_than_rendering_zero():
 #   R1-8  `live_scan` raised AttributeError on valid-but-non-object JSON,
 #         outside the try, from a function whose contract is to discriminate.
 #
-# 🔴 WHICH OF THESE IS REGRESSION COVERAGE. MEASURED: this file and its sibling
-# were copied into a detached worktree at a6f09d5a — 56 new nodes across the
-# two, 46 RED and 10 GREEN. The six GREEN ones from THIS file are below; none is
-# evidence a bug was fixed.
+# 🔴 WHICH OF THESE IS REGRESSION COVERAGE. MEASURED at NODE level: this file
+# and its sibling were collected at both shas and the head tests run against
+# base source — **66 new nodes across the two, 46 RED and 20 GREEN at a6f09d5a**.
+# SEVEN of the green are from THIS file and are named below.
+#
+# ⚠ An earlier revision said "56 nodes … 10 GREEN" and "the SIX green ones from
+# THIS file". The red count was exact; the rest came from a FUNCTION-level sweep
+# that did not expand `parametrize` and skipped functions whose name already
+# existed at base. This file's own miscount was `test_the_R1_invariant_guard_
+# ledger_names_only_tests_that_exist` — the ledger's gate was itself missing
+# from the ledger.
 # =========================================================================== #
 R1_INVARIANT_GUARDS = frozenset({
     # The strict default of `live_state_of` IS the old behaviour — that is the
@@ -766,13 +773,18 @@ R1_INVARIANT_GUARDS = frozenset({
     "test_the_JSON_live_rows_are_NOT_truncated_by_limit",
     # POSITIVE control on the isinstance guard.
     "test_a_REAL_report_object_still_parses",
+    # This ledger's own gate — it has no behaviour to regress, and it was the
+    # entry this ledger forgot about itself.
+    "test_the_R1_invariant_guard_ledger_names_only_tests_that_exist",
 })
 
 
 def test_the_R1_invariant_guard_ledger_names_only_tests_that_exist():
-    for name in R1_INVARIANT_GUARDS:
-        assert name in globals(), (
-            f"{name!r} is listed as an R1 invariant guard but no such test exists")
+    assert R1_INVARIANT_GUARDS, "the ledger is empty — the gate is wired to nothing"
+    for entry in R1_INVARIANT_GUARDS:
+        func = entry.split("[", 1)[0]
+        assert func in globals(), (
+            f"{entry!r} is listed as an R1 invariant guard but no such test exists")
 
 # 🔴 ROW_VAPOR lives on the LAPTOP and ROW_VIOLET on the WORKBENCH. That split is
 # what makes the partial-fleet probes reachable: with the laptop down, Vapor's
@@ -969,7 +981,7 @@ def test_the_tail_MEASURED_rc_set_is_pinned_to_literals():
 # R1-4 — an archive-only flag must say it did not reach the live leg
 # --------------------------------------------------------------------------- #
 @pytest.mark.parametrize("flag,needle", [
-    (["--any"], "--any (the live scan ANDs; there is no OR mode)"),
+    (["--any"], "--any (the live scan ANDs its terms; there is no OR mode)"),
     (["--project", "zzproj"], "--project"),
     (["--since", "2026-01-01"], "--since"),
 ], ids=["any", "project", "since"])
@@ -1061,7 +1073,13 @@ def test_valid_but_NON_OBJECT_json_is_a_discriminated_error_not_a_crash(body):
         fs.RUN = old
     assert res["status"] == "error"
     assert "not a report object" in res["error"]
-    assert res["rows"] == [] and res["hosts_reachable"] == []
+    assert res["rows"] == []
+    # 🔴 R2-F3: BOTH host lists are `None`, never `[]`. An empty
+    # `hosts_unreachable` is the strongest possible claim — *every host
+    # answered* — about a scan that never ran, and it leaked into the payload as
+    # `archive.live_hosts_unreachable: []`.
+    assert res["hosts_reachable"] is None
+    assert res["hosts_unreachable"] is None
 
 
 def test_a_REAL_report_object_still_parses():
@@ -1074,3 +1092,339 @@ def test_a_REAL_report_object_still_parses():
         fs.RUN = old
     assert res["status"] == "ok"
     assert len(res["rows"]) == 1
+
+
+# =========================================================================== #
+# §3 — AUDIT FIX ROUND 2 (against tip 9f9dcbde)
+#
+#   F1  🟡 `--claude-only` / `--opencode-only` / `--all` still reached ONLY the
+#       archive leg, silently — UNDER a comment whose last line asserted the
+#       class was closed ("these are the rest"). Reproduced on the live fleet:
+#       `--live --opencode-only` returned tmux windows running CLAUDE, and
+#       because the live leg matched, `run_archive` stayed False so the opencode
+#       corpus was never searched at all. The completeness sentence is worse
+#       than the omission: it tells the next reader to stop looking. The set is
+#       DATA now (`ARCHIVE_ONLY_FLAGS`) and is pinned two-way against argparse.
+#   F2  🟡 `_tail_outcome` stated a measured absence under a partial fleet:
+#       "no live window matched, so there is nothing to tail", exit 3, with no
+#       coverage field anywhere in the `tail` JSON — while the ARCHIVE block
+#       three lines earlier correctly printed `⚠ live/closed state is PARTIAL`.
+#   F3  🟡 `hosts_unreachable: []` for a scan that never ran reads as "every
+#       host answered". Fixed at the SOURCE (`live_scan` seeds both host lists
+#       `None`), so no publisher can reintroduce it.
+#   F6  🟢 exit 4 now means three things; documented rather than split.
+#   F8  🟢 `--limit 0` was unbounded on the live leg and empty on the archive
+#       leg — one flag, opposite meanings in one run. Now a usage error.
+#
+# 🔴 MEASURED AT NODE LEVEL against 9f9dcbde — 29 NEW nodes across the two
+# files, 16 RED and 13 GREEN, plus 5 MODIFIED nodes that also went red (the four
+# `test_valid_but_NON_OBJECT_json…` params, whose assertion tightened from `[]`
+# to `None` for F3, and `…ARCHIVE_ONLY_flag…[any]`, whose needle moved). FIVE of
+# the 13 green are from THIS file and are named below.
+#
+# The method is deliberately node-level: round 1's ledger was wrong precisely
+# because it counted FUNCTIONS whose names were new, which skipped `parametrize`
+# expansion and skipped modified-but-same-named tests.
+# =========================================================================== #
+R2_INVARIANT_GUARDS = frozenset({
+    # NEGATIVE control on F1's extra sentence — a non-corpus archive-only flag
+    # must NOT get the corpus warning, or the line becomes noise.
+    "test_a_NON_corpus_archive_only_flag_gets_the_SHORT_notice",
+    # NEGATIVE control on F2 — with every host answering, "there is nothing to
+    # tail" is TRUE and exit 3 is right. "Always say unmeasured" would pass the
+    # partial-fleet probe and make the message useless.
+    "test_a_tail_with_NO_match_on_a_FULL_fleet_is_still_a_MEASURED_absence",
+    # NEGATIVE control on F3 — `unavailable` means the scan RAN, so those host
+    # lists are real measurements and must NOT be nulled with the error paths.
+    "test_an_UNAVAILABLE_scan_publishes_REAL_host_lists",
+    # BOUNDARY control on F8 — `--limit 1` is the smallest legitimate value and
+    # a check one off would reject it (a permanently-red gate).
+    "test_limit_ONE_is_accepted_and_bounds_both_legs",
+    # This ledger's own gate.
+    "test_the_R2_ledger_names_only_tests_that_exist",
+})
+
+
+def test_the_R2_ledger_names_only_tests_that_exist():
+    assert R2_INVARIANT_GUARDS, "the ledger is empty — the gate is wired to nothing"
+    for entry in R2_INVARIANT_GUARDS:
+        assert entry.split("[", 1)[0] in globals(), (
+            f"{entry!r} is listed as an R2 invariant guard but no such test exists")
+
+
+# --------------------------------------------------------------------------- #
+# F1 — the archive-only ledger, and the completeness claim made structural
+# --------------------------------------------------------------------------- #
+def test_the_archive_only_ledger_PARTITIONS_every_argparse_destination():
+    """🔴 F1, STRUCTURALLY. The old inline list was closed by a sentence —
+    "these are the rest" — that was false when written. There is no sentence
+    now: every parser destination is either live-aware or archive-only, and a
+    NEW flag that is neither fails here rather than shipping a silent one-leg
+    filter under a comment claiming the class is closed.
+    """
+    # The destination set is read from a real parse of a minimal argv, so it is
+    # whatever the parser ACTUALLY declares rather than a second hand-written
+    # list — the thing that drifted in the first place.
+    dests = set(vars(fs.parse_args(["zzterm"])))
+    assert dests, "the parser declared no destinations — gate wired to nothing"
+    ledger = {d for d, _, _ in fs.ARCHIVE_ONLY_FLAGS}
+    assert dests == fs.LIVE_AWARE_DESTS | ledger, (
+        "a find-session flag is neither live-aware nor in ARCHIVE_ONLY_FLAGS:\n"
+        f"  unclassified: {sorted(dests - fs.LIVE_AWARE_DESTS - ledger)}\n"
+        f"  named but absent from the parser: "
+        f"{sorted((fs.LIVE_AWARE_DESTS | ledger) - dests)}\n"
+        "Decide which leg it reaches; do not leave it silent.")
+    # the two halves are disjoint — a flag cannot be both
+    assert not (fs.LIVE_AWARE_DESTS & ledger)
+    # ...and the corpus selectors are a SUBSET of the archive-only set
+    assert fs.CORPUS_SELECTOR_DESTS <= ledger
+
+
+def test_the_ledger_contains_the_THREE_FLAGS_THE_SENTENCE_MISSED():
+    """The specific regression, named. A structural partition that happened to
+    classify these as live-aware would pass the test above."""
+    ledger = {d for d, _, _ in fs.ARCHIVE_ONLY_FLAGS}
+    assert {"claude_only", "opencode_only", "all"} <= ledger
+
+
+@pytest.mark.parametrize("flag,dest", [
+    (["--claude-only"], "claude_only"),
+    (["--opencode-only"], "opencode_only"),
+    (["--all"], "all"),
+], ids=["claude-only", "opencode-only", "all"])
+def test_a_CORPUS_flag_with_live_says_the_corpus_was_never_searched(
+        monkeypatch, flag, dest):
+    """🔴 F1's headline: `--live --opencode-only` showed Claude tmux windows and
+    never searched opencode, because a matching live leg skips the archive
+    entirely. The notice has to say THAT, not merely "not filtered by them"."""
+    run = make_run({("zzterm",): (0, live_report([ROW_VIOLET],
+                                                 match_fields=DEFAULT_MATCH_FIELDS))})
+    got = run_main(monkeypatch, ["zzterm", "--live"] + flag, run,
+                   archive=[archive_hit("dddddddd-4444-4555-8666-777777777777")])
+    assert "ARCHIVE-ONLY flags, ignored by the live scan" in got["err"]
+    assert "CORPUS selector only steers the ARCHIVE" in got["err"]
+    assert "pass --deep" in got["err"]
+    # ...and the run really did skip the archive, which is what makes the
+    # sentence necessary rather than decorative.
+    assert got["archive_calls"] == 0
+    assert "ARCHIVE: skipped" in got["out"]
+
+
+def test_a_NON_corpus_archive_only_flag_gets_the_SHORT_notice(monkeypatch):
+    """NEGATIVE CONTROL on the extra sentence: `--since` does not steer a corpus,
+    so appending the corpus warning to it would be noise that trains the reader
+    to skip the line."""
+    run = make_run({("zzterm",): (0, live_report([ROW_VIOLET]))})
+    got = run_main(monkeypatch, ["zzterm", "--live", "--since", "2026-01-01"], run)
+    assert "ARCHIVE-ONLY flags" in got["err"]
+    assert "CORPUS selector" not in got["err"]
+
+
+def test_archive_only_notice_is_None_when_nothing_applies():
+    """The pure function, so the notice's absence is testable without a run."""
+    ns = fs.parse_args(["zzterm", "--live"])
+    assert fs.archive_only_notice(ns) is None
+    assert fs.archive_only_notice(fs.parse_args(["zzterm", "--live", "--all"]))
+
+
+def test_the_notice_NAMES_every_flag_that_was_passed(monkeypatch):
+    """Several at once must all be listed — reporting only the first would be a
+    count of declarations rather than of instances."""
+    run = make_run({("zzterm",): (0, live_report([ROW_VIOLET]))})
+    got = run_main(monkeypatch,
+                   ["zzterm", "--live", "--any", "--all", "--project", "zzp"],
+                   run)
+    for spelling in ("--any", "--all", "--project"):
+        assert spelling in got["err"], spelling
+
+
+# --------------------------------------------------------------------------- #
+# F2 — the TAIL block states its own coverage
+# --------------------------------------------------------------------------- #
+def test_a_tail_with_NO_match_under_a_PARTIAL_fleet_is_UNMEASURED(monkeypatch):
+    """🔴 F2. "no live window matched, so there is nothing to tail" is a measured
+    absence, and it was printed with exit 3 while a host had not answered — three
+    lines under an ARCHIVE block that correctly said PARTIAL. The reasoning that
+    earned the ARCHIVE block its own line applies verbatim here."""
+    got = run_main(monkeypatch, ["zzterm", "--live", "--tail", "20"],
+                   partial_run(), archive=[])
+    assert got["rc"] == fs.EXIT_UNAVAILABLE, "still exit 3 (AMBIGUOUS)"
+    assert "TAIL: REFUSED — no live window matched, but laptop did not answer" \
+        in got["out"]
+    assert "NOT 'there is nothing to tail'" in got["out"]
+    assert "UNMEASURED" in got["out"]
+
+
+def test_a_tail_with_NO_match_on_a_FULL_fleet_is_still_a_MEASURED_absence(
+        monkeypatch):
+    """NEGATIVE CONTROL: with every host answering, "there is nothing to tail" is
+    TRUE and the exit code stays 3. "Always say unmeasured" would pass the probe
+    above and make the message useless."""
+    run = make_run({("zzterm",): (3, live_report([], match_fields=DEFAULT_MATCH_FIELDS)),
+                    (): (0, live_report([]))})
+    got = run_main(monkeypatch, ["zzterm", "--live", "--tail", "20"], run, archive=[])
+    assert got["rc"] == fs.EXIT_AMBIGUOUS
+    assert "no live window matched, so there is nothing to tail" in got["out"]
+    assert "did not answer" not in got["out"]
+
+
+def test_a_SINGLE_match_under_a_PARTIAL_fleet_still_tails_but_DISCLOSES_it(
+        monkeypatch):
+    """🔴 Refusing here would make `--tail` useless whenever the laptop sleeps —
+    a permanently-red gate. Claiming "this is the one" would be the guess the
+    function exists to refuse. So it tails AND says the resolution may not be
+    unique."""
+    run = make_run({("zzterm",): (0, live_report([ROW_VIOLET],
+                                                 match_fields=DEFAULT_MATCH_FIELDS,
+                                                 **PARTIAL)),
+                    (): (0, live_report([ROW_VIOLET], **PARTIAL))},
+                   tail=(0, "synthetic scrollback\n", ""))
+    got = run_main(monkeypatch, ["zzterm", "--live", "--tail", "20"], run)
+    assert got["rc"] == fs.EXIT_OK
+    assert "resolved on PARTIAL coverage" in got["out"]
+    assert "Another window may match there" in got["out"]
+    assert "synthetic scrollback" in got["out"]
+    assert len(tail_calls(got["calls"])) == 1
+
+
+def test_SEVERAL_matches_under_a_PARTIAL_fleet_say_the_candidate_list_is_SHORT(
+        monkeypatch):
+    """The refusal was already right; the candidate list is also incomplete."""
+    run = make_run({("zzterm",): (0, live_report([ROW_VIOLET, ROW_VAPOR],
+                                                 match_fields=DEFAULT_MATCH_FIELDS,
+                                                 reachable=("workbench", "laptop"),
+                                                 unreachable=())),
+                    (): (0, live_report([ROW_VIOLET, ROW_VAPOR]))})
+    # ...first the FULL-fleet control: no incompleteness line
+    got = run_main(monkeypatch, ["zzterm", "--live", "--tail", "20"], run)
+    assert got["rc"] == fs.EXIT_AMBIGUOUS
+    assert "candidate list is INCOMPLETE" not in got["out"]
+
+    rows = [dict(ROW_VIOLET), dict(ROW_VIOLET, session="scratch5",
+                                   window_index="7")]
+    partial = make_run({("zzterm",): (0, live_report(rows, **PARTIAL,
+                                                     match_fields=DEFAULT_MATCH_FIELDS)),
+                        (): (0, live_report(rows, **PARTIAL))})
+    got2 = run_main(monkeypatch, ["zzterm", "--live", "--tail", "20"], partial)
+    assert got2["rc"] == fs.EXIT_AMBIGUOUS
+    assert "candidate list is INCOMPLETE" in got2["out"]
+    assert tail_calls(got2["calls"]) == []
+
+
+def test_the_tail_JSON_carries_its_OWN_coverage_fields(monkeypatch):
+    """🔴 `archive.*` describes the UNFILTERED scan and is absent entirely on the
+    fast path, so a `tail` consumer could not read coverage from it."""
+    got = run_main(monkeypatch, ["zzterm", "--live", "--json", "--tail", "20"],
+                   partial_run(), archive=[])
+    tail = json.loads(got["out"])["tail"]
+    assert tail["coverage_complete"] is False
+    assert tail["hosts_unreachable"] == ["laptop"]
+    assert tail["refused"] is True
+
+    full = make_run({("zzterm",): (0, live_report([ROW_VIOLET]))},
+                    tail=(0, "x\n", ""))
+    got2 = run_main(monkeypatch, ["zzterm", "--live", "--json", "--tail", "20"],
+                    full)
+    tail2 = json.loads(got2["out"])["tail"]
+    assert tail2["coverage_complete"] is True
+    assert tail2["hosts_unreachable"] == []
+
+
+# --------------------------------------------------------------------------- #
+# F3 — an unmeasured host list is null, never []
+# --------------------------------------------------------------------------- #
+def test_live_hosts_unreachable_is_NULL_for_a_scan_that_never_ran(monkeypatch):
+    """🔴 F3. `[]` reads as the strongest possible claim — every host answered —
+    about a scan that errored. The same round wrote null-never-`[]` into
+    `payload-contract.md` as doctrine."""
+    got = run_main(monkeypatch, ["zzterm", "--live", "--json"],
+                   make_run(boom=OSError("session-manager is not on this host")),
+                   archive=[archive_hit("dddddddd-4444-4555-8666-777777777777")])
+    blob = json.loads(got["out"])
+    assert blob["live"]["status"] == "error"
+    assert blob["live"]["hosts_unreachable"] is None
+    assert blob["live"]["hosts_reachable"] is None
+    assert blob["archive"]["live_ids_measured"] is False
+    assert blob["archive"]["live_coverage_complete"] is None
+    assert blob["archive"]["live_hosts_unreachable"] is None, (
+        "an unmeasured scan published an EMPTY unreachable list, which reads as "
+        "'every host answered'")
+
+
+def test_an_UNAVAILABLE_scan_publishes_REAL_host_lists(monkeypatch):
+    """NEGATIVE CONTROL, and the boundary that matters: `unavailable` means the
+    scan RAN and every host was unreachable, so those lists are measurements.
+    Nulling them too would lose the only fact that run produced."""
+    run = make_run({("zzterm",): (4, live_report([], reachable=(),
+                                                 unreachable=("workbench", "laptop"))),
+                    (): (4, live_report([], reachable=(),
+                                        unreachable=("workbench", "laptop")))})
+    got = run_main(monkeypatch, ["zzterm", "--live", "--json"], run, archive=[])
+    blob = json.loads(got["out"])
+    assert blob["live"]["status"] == "unavailable"
+    assert blob["live"]["hosts_unreachable"] == ["laptop", "workbench"]
+    assert blob["live"]["hosts_reachable"] == []
+    assert blob["archive"]["live_hosts_unreachable"] == ["laptop", "workbench"]
+
+
+# --------------------------------------------------------------------------- #
+# F8 — one flag, one meaning
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("value", ["0", "-1"], ids=["zero", "negative"])
+def test_limit_below_one_is_a_USAGE_error_on_BOTH_legs(monkeypatch, value):
+    """🔴 F8. `--limit 0` was UNBOUNDED on the live leg (`limit <= 0` meant show
+    everything) and EMPTY on the archive leg (`results[:0]`) — the same flag,
+    the same number, opposite meanings in one run. Rejected rather than
+    silently picking a winner."""
+    got = run_main(monkeypatch, ["zzterm", "--live", "--limit", value],
+                   make_run(), archive=[])
+    assert got["rc"] == fs.EXIT_USAGE
+    assert "--limit must be at least 1" in got["err"]
+    assert got["calls"] == [], "it ran a live scan despite the bad argument"
+    assert got["archive_calls"] == 0
+
+
+def test_limit_below_one_is_rejected_on_the_CLASSIC_path_too(monkeypatch):
+    """The check sits before the `--live` branch, so both legs agree. This IS a
+    behaviour change on the classic path for `--limit < 1`, and it is
+    deliberate: the previous behaviour there was a silent empty result."""
+    got = run_main(monkeypatch, ["zzterm", "--limit", "0"], make_run(),
+                   archive=[archive_hit("dddddddd-4444-4555-8666-777777777777")])
+    assert got["rc"] == fs.EXIT_USAGE
+    assert got["archive_calls"] == 0
+
+
+@pytest.mark.parametrize("limit,expect", [
+    (None, 3), (1, 1), (2, 2), (9, 3),
+    # 🔴 THE VALUE THE CLI NOW REJECTS, pinned AT THE FUNCTION anyway. `main`
+    # rejects `--limit < 1`, which makes the old `limit <= 0` special case
+    # unreachable from the CLI — a mutation sweep scored restoring it SURVIVED
+    # for exactly that reason. `render_live` is called directly by tests and by
+    # anything that imports it, so its slice semantics are pinned here rather
+    # than left to depend on a caller's validation. `0` means ZERO rows, the
+    # same as the archive leg's `results[:0]` — never "everything".
+    (0, 0),
+], ids=["none", "one", "two", "over", "zero"])
+def test_render_live_slices_like_the_ARCHIVE_leg_at_every_limit(limit, expect):
+    res = {"status": "ok", "rows": [dict(ROW_VIOLET, session=f"s{i}")
+                                    for i in range(3)],
+           "hosts_reachable": ["workbench"], "hosts_unreachable": [],
+           "match_fields": DEFAULT_MATCH_FIELDS}
+    rendered = "\n".join(fs.render_live(res, limit=limit))
+    shown = sum(1 for line in rendered.splitlines()
+                if line[:1].isdigit() and ". workbench" in line)
+    assert shown == expect, rendered
+    # the header always states the FULL count, whatever the display cap
+    assert "LIVE (3 matched" in rendered
+
+
+def test_limit_ONE_is_accepted_and_bounds_both_legs(monkeypatch):
+    """POSITIVE CONTROL on the boundary — a check one off would reject the
+    smallest legitimate value, which is the permanently-red-gate shape."""
+    rows = [dict(ROW_VIOLET, session=f"s{i}", window_index=str(i))
+            for i in range(3)]
+    run = make_run({("zzterm",): (0, live_report(rows,
+                                                 match_fields=DEFAULT_MATCH_FIELDS))})
+    got = run_main(monkeypatch, ["zzterm", "--live", "--limit", "1"], run)
+    assert got["rc"] == fs.EXIT_OK
+    assert "(showing 1 of 3" in got["out"]

--- a/scripts/tests/test_find_session_live.py
+++ b/scripts/tests/test_find_session_live.py
@@ -23,9 +23,16 @@ observed failure was a consumer assuming `detail --json` returns
 file builds is parsed by `session-manager`'s OWN parser, and every row field
 this file READS is checked against `session-manager`'s OWN `LEAN_ROW_FIELDS`.
 
-🔴 RED AT BASE, AND WHAT THAT IS WORTH HERE. All 33 nodes were replayed against
-a detached worktree at 9e452d34 and all 33 went red — but for TWO different
-reasons, and conflating them would overstate the coverage:
+🔴 RED AT BASE, AND WHAT THAT IS WORTH HERE. Every node this file held AT THE
+TIME was replayed against a detached worktree at 9e452d34, and all of them went
+red — but for TWO different reasons, and conflating them would overstate the
+coverage:
+
+⚠ NO COUNT HERE, and its absence is deliberate — see the note above
+`R1_INVARIANT_GUARDS`. This sentence used to say "all 33 nodes"; the file
+collects far more now, because four later rounds added to it. A count frozen to
+a sha that the file has since outgrown reads as a live measurement, which is the
+same defect the counts below it were deleted for.
 
   * most are red because the BEHAVIOUR did not exist (no `--live`, no live-first
     ordering, no ambiguity refusal, no LIVE/CLOSED annotation);

--- a/scripts/tests/test_find_session_live.py
+++ b/scripts/tests/test_find_session_live.py
@@ -722,3 +722,355 @@ def test_fmt_age_states_a_MISSING_age_rather_than_rendering_zero():
     assert fs.fmt_age(600) == "10m"
     assert fs.fmt_age(7200) == "2h00m"
     assert fs.fmt_age(90000) == "1d01h"
+
+
+# =========================================================================== #
+# §2 — AUDIT FIX ROUND 1 (against tip a6f09d5a)
+#
+#   R1-1  🔴 A PARTIAL FLEET LABELLED A RUNNING SESSION `CLOSED`. `live_scan`
+#         sets `status: "ok"` when ANY host answers and `hosts_unreachable` may
+#         be non-empty in that state, but `live_session_ids` returned `None`
+#         only on `status != "ok"`. So with the laptop asleep — this fleet's
+#         COMMON degraded state — every archive hit whose session lived there
+#         was stamped `CLOSED`, `live_ids_measured` said `true`, the
+#         `⚠ UNMEASURED` line never printed and the exit code was 0. The LIVE
+#         section's own caveat does not cover it: that line says the absence
+#         "cannot appear BELOW" and refers to the live row list, not to the
+#         separate ARCHIVE block.
+#   R1-3  A FAILED `--tail` printed "(empty scrollback)" and exited 0. `rc` was
+#         captured and nothing branched on it.
+#   R1-4  `--any` / `--project` / `--since` reached only the archive leg,
+#         silently — so `--any --live` sent ANDed terms and then reported a
+#         measured absence under semantics nobody asked for. `--limit` did not
+#         bound the LIVE section at all.
+#   R1-8  `live_scan` raised AttributeError on valid-but-non-object JSON,
+#         outside the try, from a function whose contract is to discriminate.
+#
+# 🔴 WHICH OF THESE IS REGRESSION COVERAGE. MEASURED: this file and its sibling
+# were copied into a detached worktree at a6f09d5a — 56 new nodes across the
+# two, 46 RED and 10 GREEN. The six GREEN ones from THIS file are below; none is
+# evidence a bug was fixed.
+# =========================================================================== #
+R1_INVARIANT_GUARDS = frozenset({
+    # The strict default of `live_state_of` IS the old behaviour — that is the
+    # point of defaulting the new argument that way.
+    "test_live_state_of_defaults_to_the_STRICT_reading",
+    # NEGATIVE controls on the archive-only notice: it must not fire when it has
+    # nothing to say, or the reader learns to skip the line.
+    "test_no_archive_only_notice_when_none_was_passed",
+    "test_the_notice_does_not_fire_without_live",
+    # `--limit` never reached the live leg at a6f09d5a, so the ambiguity check
+    # was already unsliced. These pin that ADDING the display cap did not
+    # narrow it, which is the regression the change could have introduced.
+    "test_limit_does_NOT_narrow_the_TAIL_ambiguity_check",
+    "test_the_JSON_live_rows_are_NOT_truncated_by_limit",
+    # POSITIVE control on the isinstance guard.
+    "test_a_REAL_report_object_still_parses",
+})
+
+
+def test_the_R1_invariant_guard_ledger_names_only_tests_that_exist():
+    for name in R1_INVARIANT_GUARDS:
+        assert name in globals(), (
+            f"{name!r} is listed as an R1 invariant guard but no such test exists")
+
+# 🔴 ROW_VAPOR lives on the LAPTOP and ROW_VIOLET on the WORKBENCH. That split is
+# what makes the partial-fleet probes reachable: with the laptop down, Vapor's
+# session can only be confirmed on a host that did not answer.
+PARTIAL = dict(reachable=("workbench",), unreachable=("laptop",))
+
+
+def partial_run(matched_rows=(), unfiltered_rows=(ROW_VIOLET,)):
+    """A fake scan pair where the LAPTOP never answers."""
+    return make_run({
+        ("zzterm",): (3 if not matched_rows else 0,
+                      live_report(list(matched_rows),
+                                  match_fields=DEFAULT_MATCH_FIELDS, **PARTIAL)),
+        (): (0, live_report(list(unfiltered_rows), **PARTIAL)),
+    })
+
+
+def test_the_partial_fixture_really_is_partial_and_still_yields_an_id_set():
+    """POSITIVE CONTROL. R1-1 only exists in the state where `status == "ok"`
+    AND a host is missing AND an id set was still built — if the fixture failed
+    any of those, every probe below would pass for the wrong reason."""
+    monkey = partial_run()
+    fs_res = None
+    try:
+        old, fs.RUN = fs.RUN, monkey
+        fs_res = fs.live_scan()
+    finally:
+        fs.RUN = old
+    assert fs_res["status"] == "ok"
+    assert fs_res["hosts_unreachable"] == ["laptop"]
+    assert fs.live_session_ids(fs_res) == {ROW_VIOLET["claude_session_id"]}
+    assert fs.live_coverage_complete(fs_res) is False
+
+
+def test_a_PARTIAL_fleet_never_stamps_CLOSED_but_still_confirms_LIVE(monkeypatch):
+    """🔴 R1-1, THE HEADLINE, and both directions in ONE render.
+
+    A POSITIVE is a measurement whatever the coverage — finding the id on a host
+    that answered proves the session is live, and no sleeping peer makes that
+    false. A NEGATIVE proves nothing unless every host answered. A blanket
+    "UNMEASURED on any unreachable host" would pass the CLOSED half of this and
+    fail the LIVE half, so the two are asserted together.
+    """
+    got = run_main(monkeypatch, ["zzterm", "--live", "--json"], partial_run(),
+                   archive=[
+                       archive_hit(ROW_VIOLET["claude_session_id"]),   # workbench
+                       archive_hit(ROW_VAPOR["claude_session_id"]),    # laptop
+                   ])
+    blob = json.loads(got["out"])
+    states = [r["live_state"] for r in blob["archive"]["results"]]
+    assert states == ["LIVE", "UNMEASURED"], (
+        "a session that could only be confirmed on the host that did NOT "
+        "answer was given a verdict")
+    assert "CLOSED" not in states
+
+
+def test_the_partial_fleet_publishes_COVERAGE_beside_live_ids_measured(
+        monkeypatch):
+    """`live_ids_measured: true` alone was the lie — a set existed, so the flag
+    read as a full measurement. Coverage is a SEPARATE fact and is published as
+    one, with the hosts named."""
+    got = run_main(monkeypatch, ["zzterm", "--live", "--json"], partial_run(),
+                   archive=[archive_hit(ROW_VAPOR["claude_session_id"])])
+    arch = json.loads(got["out"])["archive"]
+    assert arch["live_ids_measured"] is True
+    assert arch["live_coverage_complete"] is False
+    assert arch["live_hosts_unreachable"] == ["laptop"]
+
+
+def test_the_partial_fleet_warns_IN_THE_ARCHIVE_BLOCK(monkeypatch):
+    """🔴 The LIVE section's caveat is about the live ROW LIST ("cannot appear
+    below"). The annotations are a different claim under a different heading and
+    need their own line."""
+    got = run_main(monkeypatch, ["zzterm", "--live"], partial_run(),
+                   archive=[archive_hit(ROW_VAPOR["claude_session_id"])])
+    out = got["out"]
+    assert "live/closed state is PARTIAL" in out
+    assert "laptop did not answer" in out
+    assert "UNMEASURED rather than CLOSED" in out
+    assert "<UNMEASURED>" in out
+    assert "<CLOSED>" not in out
+
+
+def test_a_FULLY_reachable_fleet_still_says_CLOSED(monkeypatch):
+    """NEGATIVE CONTROL, and the permanently-red-gate check: "never say CLOSED"
+    would kill the annotation entirely and pass every probe above."""
+    run = make_run({("zzterm",): (3, live_report([], match_fields=DEFAULT_MATCH_FIELDS)),
+                    (): (0, live_report([ROW_VIOLET]))})
+    got = run_main(monkeypatch, ["zzterm", "--live", "--json"], run, archive=[
+        archive_hit(ROW_VIOLET["claude_session_id"]),
+        archive_hit("dddddddd-4444-4555-8666-777777777777"),
+    ])
+    blob = json.loads(got["out"])
+    assert [r["live_state"] for r in blob["archive"]["results"]] == ["LIVE",
+                                                                    "CLOSED"]
+    assert blob["archive"]["live_coverage_complete"] is True
+    assert blob["archive"]["live_hosts_unreachable"] == []
+    assert "live/closed state is PARTIAL" not in got["out"]
+
+
+@pytest.mark.parametrize("ids,complete,sid,expect", [
+    ({"x"}, True, "x", "LIVE"),
+    ({"x"}, False, "x", "LIVE"),      # a positive survives partial coverage
+    ({"x"}, True, "y", "CLOSED"),
+    ({"x"}, False, "y", "UNMEASURED"),  # ...a negative does not
+    (None, True, "y", "UNMEASURED"),
+    (None, False, "y", "UNMEASURED"),
+])
+def test_live_state_of_is_a_function_of_BOTH_the_set_and_the_coverage(
+        ids, complete, sid, expect):
+    """The whole truth table, so no cell is reachable only by accident."""
+    assert fs.live_state_of(sid, ids, complete) == expect
+
+
+def test_live_state_of_defaults_to_the_STRICT_reading():
+    """A caller that forgets the new argument gets the old, stricter behaviour —
+    wrong loudly rather than wrong quietly."""
+    assert fs.live_state_of("y", {"x"}) == "CLOSED"
+
+
+@pytest.mark.parametrize("res,expect", [
+    ({"status": "ok", "hosts_unreachable": []}, True),
+    ({"status": "ok", "hosts_unreachable": ["laptop"]}, False),
+    ({"status": "unavailable", "hosts_unreachable": ["a", "b"]}, False),
+    ({"status": "error", "hosts_unreachable": []}, False),
+])
+def test_live_coverage_complete_needs_BOTH_ok_and_a_full_fleet(res, expect):
+    assert fs.live_coverage_complete(res) is expect
+
+
+# --------------------------------------------------------------------------- #
+# R1-3 — a tail that did not run is not an empty window
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("rc,label", [
+    (2, "the host answered, no such window (it closed between scan and tail)"),
+    (4, "the host went unreachable"),
+    (5, "no tmux server on that host"),
+], ids=["no-such-window", "unreachable", "no-server"])
+def test_a_FAILED_tail_is_loud_and_does_NOT_exit_zero(monkeypatch, rc, label):
+    """🔴 R1-3. `rc` was captured and nothing branched on it, so all three of
+    these printed "(empty scrollback)" over exit 0 — a silent zero on the one
+    half of this feature that answers "where did it leave off"."""
+    run = make_run({("zzterm",): (0, live_report([ROW_VAPOR],
+                                                 match_fields=DEFAULT_MATCH_FIELDS))},
+                   tail=(rc, "", "tail: something went wrong"))
+    got = run_main(monkeypatch, ["zzterm", "--live", "--tail", "40"], run)
+    assert got["rc"] == fs.EXIT_UNAVAILABLE, f"exit 0 on a failed tail ({label})"
+    assert f"TAIL: FAILED — `session-manager tail` exited {rc}" in got["out"]
+    assert "The scrollback was NOT read" in got["out"]
+    assert "empty scrollback" not in got["out"], (
+        "a failed tail still rendered as an empty window")
+
+
+def test_a_MEASURED_empty_scrollback_is_still_a_success(monkeypatch):
+    """NEGATIVE CONTROL, and the boundary: `session-manager tail` returns 3 for
+    a window whose scrollback really IS empty. Treating every non-zero rc as a
+    failure would turn a measured empty into an error."""
+    for rc in (0, 3):
+        run = make_run({("zzterm",): (0, live_report([ROW_VAPOR]))},
+                       tail=(rc, "", ""))
+        got = run_main(monkeypatch, ["zzterm", "--live", "--tail", "40"], run)
+        assert got["rc"] == fs.EXIT_OK, rc
+        assert "MEASURED, the pane really is blank" in got["out"]
+        assert "TAIL: FAILED" not in got["out"]
+
+
+def test_the_tail_rc_and_ok_TRAVEL_IN_THE_JSON(monkeypatch):
+    """An empty `text` beside `ok: false` is "not read"; beside `ok: true` it is
+    a measured empty pane. Publishing `error` alone left those the same whenever
+    stderr happened to be quiet."""
+    run = make_run({("zzterm",): (0, live_report([ROW_VAPOR]))},
+                   tail=(5, "", ""))
+    got = run_main(monkeypatch, ["zzterm", "--live", "--json", "--tail", "9"],
+                   run)
+    tail = json.loads(got["out"])["tail"]
+    assert tail["rc"] == 5
+    assert tail["ok"] is False
+    assert tail["text"] == ""
+    assert tail["refused"] is False        # it RESOLVED; the tail then failed
+    assert "TAIL: FAILED" in tail["message"]
+
+
+def test_the_tail_MEASURED_rc_set_is_pinned_to_literals():
+    """The sibling's own vocabulary: 0 = scrollback, 3 = measured empty.
+    Comparing against the constant alone would be self-satisfying."""
+    assert fs.TAIL_MEASURED_RCS == (0, 3)
+    assert sm.EXIT_OK in fs.TAIL_MEASURED_RCS
+    assert sm.EXIT_EMPTY in fs.TAIL_MEASURED_RCS
+    for bad in (sm.EXIT_USAGE, sm.EXIT_UNAVAILABLE, sm.EXIT_NO_SERVER):
+        assert bad not in fs.TAIL_MEASURED_RCS
+
+
+# --------------------------------------------------------------------------- #
+# R1-4 — an archive-only flag must say it did not reach the live leg
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("flag,needle", [
+    (["--any"], "--any (the live scan ANDs; there is no OR mode)"),
+    (["--project", "zzproj"], "--project"),
+    (["--since", "2026-01-01"], "--since"),
+], ids=["any", "project", "since"])
+def test_an_ARCHIVE_ONLY_flag_says_it_did_not_reach_the_live_scan(
+        monkeypatch, flag, needle):
+    """🔴 R1-4. `find-session.py redis vpn --any --live` sent ANDed terms to the
+    live leg and then printed "(no live window matched these terms…)" — a
+    measured absence under semantics the caller did not request. This diff
+    already prints five notices of exactly this class."""
+    run = make_run({("zzterm",): (0, live_report([ROW_VIOLET],
+                                                 match_fields=DEFAULT_MATCH_FIELDS))})
+    got = run_main(monkeypatch, ["zzterm", "--live"] + flag, run)
+    assert "ARCHIVE-ONLY flags, ignored by the live scan" in got["err"]
+    assert needle in got["err"]
+    assert "NOT filtered by them" in got["err"]
+
+
+def test_no_archive_only_notice_when_none_was_passed(monkeypatch):
+    """NEGATIVE CONTROL — "always warn" would pass all three probes above and
+    train the reader to ignore the line."""
+    run = make_run({("zzterm",): (0, live_report([ROW_VIOLET]))})
+    got = run_main(monkeypatch, ["zzterm", "--live"], run)
+    assert "ARCHIVE-ONLY flags" not in got["err"]
+
+
+def test_the_notice_does_not_fire_without_live(monkeypatch):
+    """Without `--live` those flags reach the only leg there is."""
+    got = run_main(monkeypatch, ["zzterm", "--any"], make_run(), archive=[])
+    assert "ARCHIVE-ONLY flags" not in got["err"]
+
+
+def test_limit_BOUNDS_THE_LIVE_SECTION_and_says_how_many_it_hid(monkeypatch):
+    """🔴 R1-4's other half: the real fleet is 75 rows and `--limit` bounded
+    only the archive list."""
+    rows = [dict(ROW_VIOLET, session=f"s{i}", window_index=str(i),
+                 claude_session_id=f"0000000{i}-1111-4222-8333-444444444444")
+            for i in range(5)]
+    run = make_run({("zzterm",): (0, live_report(rows,
+                                                 match_fields=DEFAULT_MATCH_FIELDS))})
+    got = run_main(monkeypatch, ["zzterm", "--live", "--limit", "2"], run)
+    assert "LIVE (5 matched" in got["out"], "the header must state the FULL count"
+    assert "(showing 2 of 5 — raise --limit to see the rest)" in got["out"]
+    assert "1. workbench  s0:0" in got["out"]
+    assert "2. workbench  s1:1" in got["out"]
+    assert "s2:2" not in got["out"]
+
+
+def test_limit_does_NOT_narrow_the_TAIL_ambiguity_check(monkeypatch):
+    """🔴 Capping the ambiguity check at the DISPLAY limit would turn "several
+    matched, I refuse" into "one is showing, I will tail that one" — guessing
+    with extra steps. `--limit 1` over two matches must still refuse."""
+    run = make_run({("zzterm",): (0, live_report([ROW_VIOLET, ROW_VAPOR],
+                                                 match_fields=DEFAULT_MATCH_FIELDS))})
+    got = run_main(monkeypatch, ["zzterm", "--live", "--limit", "1", "--tail", "5"],
+                   run)
+    assert got["rc"] == fs.EXIT_AMBIGUOUS
+    assert "2 live windows matched" in got["out"]
+    assert tail_calls(got["calls"]) == []
+    # ...and both candidates are still listed, even the one --limit hid
+    assert "tail scratch3:2 --host workbench" in got["out"]
+    assert "tail scratch4:5 --host laptop" in got["out"]
+
+
+def test_the_JSON_live_rows_are_NOT_truncated_by_limit(monkeypatch):
+    """`--limit` is a DISPLAY cap. A machine consumer asked for the payload, and
+    silently handing it a slice would be a measured absence of the rest."""
+    rows = [dict(ROW_VIOLET, session=f"s{i}", window_index=str(i))
+            for i in range(4)]
+    run = make_run({("zzterm",): (0, live_report(rows))})
+    got = run_main(monkeypatch, ["zzterm", "--live", "--json", "--limit", "1"],
+                   run)
+    assert len(json.loads(got["out"])["live"]["rows"]) == 4
+
+
+# --------------------------------------------------------------------------- #
+# R1-8 — valid JSON is not a report
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("body", ["[]", "null", '"a string"', "3"],
+                         ids=["array", "null", "string", "number"])
+def test_valid_but_NON_OBJECT_json_is_a_discriminated_error_not_a_crash(body):
+    """🔴 R1-8. `report.get("hosts")` sat OUTSIDE the try, so any of these raised
+    AttributeError out of a function whose whole contract is to return a status
+    instead of raising. A truncated pipe or a wrapper printing a bare array is
+    enough."""
+    old, fs.RUN = fs.RUN, make_run(raw=(0, body, ""))
+    try:
+        res = fs.live_scan(["zzterm"])
+    finally:
+        fs.RUN = old
+    assert res["status"] == "error"
+    assert "not a report object" in res["error"]
+    assert res["rows"] == [] and res["hosts_reachable"] == []
+
+
+def test_a_REAL_report_object_still_parses():
+    """POSITIVE CONTROL on the isinstance guard — a check that rejects
+    everything would satisfy all four probes above."""
+    old, fs.RUN = fs.RUN, make_run({(): (0, live_report([ROW_VIOLET]))})
+    try:
+        res = fs.live_scan()
+    finally:
+        fs.RUN = old
+    assert res["status"] == "ok"
+    assert len(res["rows"]) == 1

--- a/scripts/tests/test_find_session_skill_contract.py
+++ b/scripts/tests/test_find_session_skill_contract.py
@@ -29,15 +29,14 @@ probe, so nothing here spawns `session-manager` or reads a real tmux server.
 """
 from __future__ import annotations
 
-import argparse
+import ast
 import contextlib
 import importlib.machinery
 import importlib.util
+import inspect
 import io
 import json
-import os
 import re
-import sys
 from pathlib import Path
 
 import pytest
@@ -75,6 +74,34 @@ R3_GREEN_AT_AUDITED_TIP = frozenset({
     "test_the_R3_ledger_names_only_tests_that_exist",
 })
 
+# 🔴 GREEN AT 0c874add, AND THAT IS THE FINDING AGAIN. Round 5's two 🟡 were GAPS
+# IN GUARDS, not broken artifacts: the shipped table and the code were correct at
+# that sha, so a guard that now catches the hazard passes there too. Their
+# evidence is the MUTATION sweep against the auditor's own planted hazards — the
+# transposed exit rows, the `else:`-branch return and the bare literal `4`, each
+# of which the auditor measured GREEN against the old guards.
+#
+# A red-at-base row would be the wrong claim for these, and offering one would be
+# the overstatement this ladder keeps finding.
+R4_GREEN_AT_AUDITED_TIP = frozenset({
+    "test_the_doc_table_PAIRS_each_code_with_its_own_contract_sentence",
+    "test_the_tail_path_whitelist_EXCLUDES_the_else_branch",
+    "test_the_source_scan_SEES_a_bare_integer_literal",
+    "test_the_source_scan_IGNORES_the_declaration_and_the_contract_table",
+    "test_renaming_the_tail_helper_makes_this_guard_RED_not_vacuous",
+    "test_the_bare_literal_scan_CAN_fire",
+    # two of this parametrised test's three causes were already exercised; only
+    # the `--since` cause is new behaviour, and that param IS red at base.
+    "test_every_CAUSE_the_exit_2_sentence_NAMES_really_exits_2",
+})
+
+
+def test_the_R4_ledger_names_only_tests_that_exist():
+    assert R4_GREEN_AT_AUDITED_TIP, "the ledger is empty — gate wired to nothing"
+    for entry in R4_GREEN_AT_AUDITED_TIP:
+        assert entry.split("[", 1)[0] in globals(), (
+            f"{entry!r} is listed in the R4 ledger but no such test exists")
+
 
 def test_the_R3_ledger_names_only_tests_that_exist():
     assert R3_GREEN_AT_AUDITED_TIP, "the ledger is empty — gate wired to nothing"
@@ -107,29 +134,50 @@ def test_the_skill_exists_and_the_contract_is_not_empty(body):
     assert len(fs.EXIT_CONTRACT) >= 4
 
 
-def test_every_contract_sentence_appears_VERBATIM_in_the_shipped_doc(body):
-    """🔴 Whole normalised strings, never keywords. `claude/RULES.md`: "when the
-    artifact under test IS prose, a guard on WORDS is walkable by REWORDING —
-    pin the WHOLE normalised string". Both of the false claims this replaced
-    were rewordings of true ones."""
-    haystack = _norm(body)
-    missing = [(code, txt) for code, txt in fs.EXIT_CONTRACT
-               if _norm(txt) not in haystack]
-    assert not missing, (
-        "the shipped skill body no longer carries these EXIT_CONTRACT sentences "
-        "verbatim:\n"
-        + "".join(f"  exit {c}: {_norm(t)!r}\n" for c, t in missing)
-        + "Reword the CONSTANT and copy it here, never the other way round — "
-          "the doc is the derived artifact.")
+def _documented_exit_table(body: str) -> dict:
+    """The shipped table as `{code: normalised sentence}` — the PAIRING.
+
+    🔴 THIS IS THE WHOLE FIX FOR THE ROUND-4 GAP. Two guards used to stand here:
+    one asked whether each sentence appeared SOMEWHERE in the file, the other
+    compared only the SET of codes. Neither read which sentence sat beside which
+    code, so TRANSPOSING the exit-3 and exit-4 rows — making the shipped skill
+    say 3 means "something the tail needed was NOT measured" and 4 means "could
+    not resolve to exactly one live window", exactly inverted — left 122/122
+    passing, and 377/377 across every generic skill gate. Nothing else in the
+    tree reads this file.
+
+    The failure that buys is this PR's own founding argument, relocated to the
+    caller: a wrapper branches `rc == 3 ⇒ report unmeasured` / `rc == 4 ⇒ here
+    are the candidates`, and under the inverted table treats an ambiguous
+    multi-window match as a scan failure and an unmeasured tail as a settled
+    candidate list.
+    """
+    return {int(code): _norm(text)
+            for code, text in re.findall(r"^- `(\d)` — (.*)$", body, re.M)}
 
 
-def test_the_doc_states_every_code_and_INVENTS_none(body):
-    """Both directions. A doc that documents a code the script cannot return
-    sends a caller to write a branch that never fires."""
-    documented = {int(m) for m in re.findall(r"^- `(\d)` — ", body, re.M)}
-    declared = {code for code, _ in fs.EXIT_CONTRACT}
+def test_the_doc_table_PAIRS_each_code_with_its_own_contract_sentence(body):
+    """🔴 ONE assertion replacing two weaker ones — equality on the MAPPING.
+
+    Set-of-codes plus sentences-appear-somewhere is satisfied by any
+    permutation. Equality on `{code: sentence}` is not.
+    """
+    documented = _documented_exit_table(body)
+    declared = {code: _norm(text) for code, text in fs.EXIT_CONTRACT}
+    assert documented, (
+        "no `- `N` — ...` rows parsed out of the shipped skill body — the table "
+        "moved or was reformatted, and this gate is reading nothing. Re-point "
+        "it rather than deleting it.")
     assert documented == declared, (
-        f"doc documents {sorted(documented)}, script declares {sorted(declared)}")
+        "the shipped exit-code table disagrees with `EXIT_CONTRACT`:\n"
+        + "".join(
+            f"  exit {c}:\n    doc   : {documented.get(c, '<MISSING>')!r}\n"
+            f"    script: {declared.get(c, '<NOT DECLARED>')!r}\n"
+            for c in sorted(set(documented) | set(declared))
+            if documented.get(c) != declared.get(c))
+        + "Reword the CONSTANT and copy it here, never the other way round — "
+          "the doc is the derived artifact. A code paired with ANOTHER code's "
+          "sentence is the failure this replaced two weaker guards to catch.")
 
 
 def test_the_contract_codes_are_the_scripts_own_EXIT_constants():
@@ -253,51 +301,222 @@ def test_exit_4_DOES_arise_when_the_same_failure_happens_under_tail():
     assert rc == fs.EXIT_UNAVAILABLE
 
 
+def _tail_path_lines(tree) -> set:
+    """Line numbers that are DEFINITIONALLY on the `--tail` path.
+
+    🔴 `node.body` ONLY — NOT `node.lineno..node.end_lineno`.
+
+    `ast.If.end_lineno` spans the `orelse`, so whitelisting the whole node marks
+    the `else:` / `elif` body of `if a.tail is not None:` as on the tail path
+    when it is definitionally the NO-`--tail` path — the exact complement.
+    Measured: a `return EXIT_UNAVAILABLE` planted in such an `else:` was
+    computed as ALLOWED and the suite stayed 122/122 green.
+    """
+    allowed = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_tail_outcome":
+            allowed |= set(range(node.lineno, node.end_lineno + 1))
+        if isinstance(node, ast.If) and "a.tail is not None" in ast.unparse(node.test):
+            for stmt in node.body:          # the TRUE branch, and nothing else
+                allowed |= set(range(stmt.lineno, stmt.end_lineno + 1))
+    return allowed
+
+
+def _contract_lines(tree) -> set:
+    """`EXIT_CONTRACT`'s own span — it names the constant as DATA, not a path.
+
+    Empty when the tree has no such assignment, so the synthetic trees the
+    controls below build do not have to carry one. That the REAL module HAS one
+    is asserted separately — an empty skip set there would silently widen what
+    this excludes.
+    """
+    node = next((n for n in ast.walk(tree)
+                 if isinstance(n, ast.Assign)
+                 and any(getattr(t, "id", "") == "EXIT_CONTRACT"
+                         for t in n.targets)), None)
+    return set() if node is None else set(range(node.lineno, node.end_lineno + 1))
+
+
+def exit_unavailable_sources(tree) -> list:
+    """Every line that can PRODUCE exit 4 — by name OR by literal.
+
+    Factored out so the negative controls below grade the REAL predicate rather
+    than a re-implementation of it.
+
+    🔴 THE LITERAL HALF MATTERS. An `ast.Name` scan cannot see `return 4`, so
+    the previous version was blind to the plainest possible way of writing the
+    hazard — measured, and green. Declarations (`EXIT_UNAVAILABLE = 4`) and the
+    contract table are excluded: they are where the value is DEFINED and
+    DESCRIBED, not returned.
+    """
+    declarations = {n.lineno for n in ast.walk(tree)
+                    if isinstance(n, ast.Assign)
+                    and any(getattr(t, "id", "") == "EXIT_UNAVAILABLE"
+                            for t in n.targets)}
+    skip = declarations | _contract_lines(tree)
+    by_name = {n.lineno for n in ast.walk(tree)
+               if isinstance(n, ast.Name) and n.id == "EXIT_UNAVAILABLE"}
+    by_literal = {n.lineno for n in ast.walk(tree)
+                  if isinstance(n, ast.Constant) and n.value is not True
+                  and isinstance(n.value, int) and n.value == fs.EXIT_UNAVAILABLE}
+    return sorted((by_name | by_literal) - skip)
+
+
+@pytest.mark.parametrize("argv,why", [
+    (["zzterm", "--since", "not-a-date"], "an unparseable `--since`"),
+    (["zzterm", "--live", "--limit", "0"], "`--limit` below 1"),
+    (["zzterm", "--tail", "5"], "`--tail` without `--live`"),
+], ids=["since", "limit", "tail-without-live"])
+def test_every_CAUSE_the_exit_2_sentence_NAMES_really_exits_2(argv, why):
+    """🔴 The module docstring claims this file "pins each sentence against the
+    BEHAVIOUR it describes". The exit-2 sentence names three causes and only two
+    were exercised — `--since` was added to the prose and asserted nowhere.
+
+    A sentence that enumerates causes is a claim per cause.
+    """
+    assert _norm(why) in _norm(dict(fs.EXIT_CONTRACT)[fs.EXIT_USAGE]), (
+        f"{why!r} is not actually named in the exit-2 sentence — this probe and "
+        "the contract have drifted apart")
+    rc, _, err = _run(argv, _runner(_report([])), archive=[])
+    assert rc == fs.EXIT_USAGE, f"{why} did not exit {fs.EXIT_USAGE}"
+    assert err.strip(), "it exited 2 without telling the operator why"
+
+
+def test_no_exit_path_uses_a_BARE_LITERAL_instead_of_the_constant():
+    """🔴 THE COUPLING THAT WOULD SPLIT SILENTLY. The `--since` path used
+    `sys.exit(2)` — correct today, and named by the exit-2 sentence, but a
+    renumbering of `EXIT_USAGE` would move the constant and leave the literal
+    behind, breaking a documented pair with nothing to notice.
+
+    Every exit value the contract declares must be produced through its NAME.
+    Declarations and the contract table itself are excluded — that is where the
+    values are defined and described.
+    """
+    tree = ast.parse(inspect.getsource(fs))
+    declared = {code for code, _ in fs.EXIT_CONTRACT}
+    names = {"EXIT_OK", "EXIT_USAGE", "EXIT_AMBIGUOUS", "EXIT_UNAVAILABLE"}
+    skip = _contract_lines(tree) | {
+        n.lineno for n in ast.walk(tree)
+        if isinstance(n, ast.Assign)
+        and any(getattr(t, "id", "") in names for t in n.targets)}
+
+    offenders = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Return, ast.Call)):
+            continue
+        # `return <int>` and `sys.exit(<int>)`
+        if isinstance(node, ast.Call):
+            if ast.unparse(node.func) not in ("sys.exit", "exit"):
+                continue
+            args = node.args
+        else:
+            args = [node.value] if node.value is not None else []
+        for arg in args:
+            if (isinstance(arg, ast.Constant) and arg.value is not True
+                    and isinstance(arg.value, int) and arg.value in declared
+                    and node.lineno not in skip):
+                offenders.append((node.lineno, arg.value))
+    assert not offenders, (
+        "an exit value the contract declares is produced as a BARE LITERAL "
+        f"rather than through its constant: {offenders}. Use the EXIT_* name so "
+        "a renumbering cannot split the code from the sentence that documents it.")
+
+
+def test_the_bare_literal_scan_CAN_fire():
+    """POSITIVE CONTROL — a scan that matched nothing would pass the test above
+    on any tree at all."""
+    tree = ast.parse(f"import sys\ndef f():\n    sys.exit({fs.EXIT_USAGE})\n")
+    found = [n for n in ast.walk(tree)
+             if isinstance(n, ast.Call) and ast.unparse(n.func) == "sys.exit"
+             and n.args and isinstance(n.args[0], ast.Constant)
+             and n.args[0].value in {c for c, _ in fs.EXIT_CONTRACT}]
+    assert found, "the offender shape this scan looks for is unmatchable"
+
+
 def test_every_EXIT_UNAVAILABLE_source_is_on_the_tail_path():
     """🔴 STRUCTURAL, so the sentence stays true of code nobody has written yet.
 
     The `--tail ONLY` claim is about WHERE the code can arise, and a behavioural
-    probe only samples the paths it thought of. This asserts that every textual
-    source of `EXIT_UNAVAILABLE` in the module is inside `_tail_outcome` or
-    inside `main`'s `if a.tail is not None:` block — so a NEW return added
-    outside the tail path fails here rather than silently falsifying the doc.
+    probe only samples the paths it thought of. Every source of the value — by
+    NAME or by LITERAL — must sit inside `_tail_outcome` or inside the TRUE
+    branch of `main`'s `if a.tail is not None:`.
+
+    Two blind spots this had in round 4, both measured green with the hazard
+    planted, both closed here: the `else:` body counted as tail-path (see
+    `_tail_path_lines`), and `return 4` was invisible (see
+    `exit_unavailable_sources`).
     """
-    import ast
-    import inspect
-    src = inspect.getsource(fs)
-    tree = ast.parse(src)
-
-    allowed_lines = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef) and node.name == "_tail_outcome":
-            allowed_lines |= set(range(node.lineno, node.end_lineno + 1))
-        if isinstance(node, ast.If):
-            # `if a.tail is not None:` — the tail block inside `main`
-            test = ast.unparse(node.test)
-            if "a.tail is not None" in test:
-                allowed_lines |= set(range(node.lineno, node.end_lineno + 1))
-
-    uses = [n.lineno for n in ast.walk(tree)
-            if isinstance(n, ast.Name) and n.id == "EXIT_UNAVAILABLE"]
-    assert uses, "no EXIT_UNAVAILABLE reference found — gate wired to nothing"
-    stray = sorted(set(uses) - allowed_lines
-                   - {n.lineno for n in ast.walk(tree)
-                      if isinstance(n, ast.Assign)
-                      and any(getattr(t, "id", "") == "EXIT_UNAVAILABLE"
-                              for t in n.targets)}
-                   - {c for c, _ in [(0, 0)]})
-    # the EXIT_CONTRACT tuple itself references the constant; that is data, not
-    # a return path, so exclude the contract's own lines.
-    contract = next(n for n in ast.walk(tree)
-                    if isinstance(n, ast.Assign)
-                    and any(getattr(t, "id", "") == "EXIT_CONTRACT"
-                            for t in n.targets))
-    stray = [ln for ln in stray
-             if not (contract.lineno <= ln <= contract.end_lineno)]
+    tree = ast.parse(inspect.getsource(fs))
+    sources = exit_unavailable_sources(tree)
+    assert sources, "no EXIT_UNAVAILABLE source found — gate wired to nothing"
+    stray = sorted(set(sources) - _tail_path_lines(tree))
     assert not stray, (
-        f"EXIT_UNAVAILABLE is returned outside the --tail path at lines {stray}. "
-        "The shipped skill body says exit 4 is `--tail` ONLY; either keep it "
-        "that way or change EXIT_CONTRACT and the doc together.")
+        f"exit {fs.EXIT_UNAVAILABLE} can be produced outside the --tail path at "
+        f"lines {stray}. The shipped skill body says it is `--tail` ONLY; either "
+        "keep it that way or change EXIT_CONTRACT and the doc together.")
+
+
+def test_the_tail_path_whitelist_EXCLUDES_the_else_branch():
+    """🔴 NEGATIVE CONTROL for blind spot 1, graded by the REAL helper.
+
+    `if a.tail is not None: ... else: ...` — the `else` body is the no-`--tail`
+    path by definition, and `end_lineno` spanning it is what made the old
+    whitelist cover its own complement.
+    """
+    tree = ast.parse(
+        "def main(a):\n"
+        "    if a.tail is not None:\n"
+        "        x = 1\n"
+        "    else:\n"
+        "        return 4\n")
+    allowed = _tail_path_lines(tree)
+    assert 3 in allowed, "the TRUE branch must be on the tail path"
+    assert 5 not in allowed, (
+        "the else: branch is whitelisted as tail-path — that is the complement "
+        "of the tail path, and it is where a stray return would hide")
+
+
+def test_the_source_scan_SEES_a_bare_integer_literal():
+    """🔴 NEGATIVE CONTROL for blind spot 2, graded by the REAL helper. An
+    `ast.Name` scan cannot see `return 4`."""
+    tree = ast.parse(f"def f():\n    return {fs.EXIT_UNAVAILABLE}\n")
+    assert exit_unavailable_sources(tree) == [2], (
+        "a bare integer literal equal to EXIT_UNAVAILABLE is invisible to the "
+        "source scan — the plainest way to write the hazard")
+
+
+def test_the_source_scan_IGNORES_the_declaration_and_the_contract_table():
+    """POSITIVE CONTROL in the other direction: a scan that flagged the
+    constant's own definition, or the table that DESCRIBES it, would be
+    permanently red — worse than no gate."""
+    tree = ast.parse(inspect.getsource(fs))
+    sources = set(exit_unavailable_sources(tree))
+    assert sources & _tail_path_lines(tree) == sources, (
+        "the clean tree must have every source on the tail path")
+    # 🔴 The REAL module must HAVE an EXIT_CONTRACT span. `_contract_lines`
+    # returns empty for a tree without one, so an empty skip set here would mean
+    # the exclusion is silently doing nothing rather than excluding the table.
+    assert _contract_lines(tree), (
+        "no EXIT_CONTRACT assignment found in the module — the contract-table "
+        "exclusion is wired to nothing")
+    assert not (sources & _contract_lines(tree))
+    other_ints = [n.lineno for n in ast.walk(tree)
+                  if isinstance(n, ast.Constant) and isinstance(n.value, int)
+                  and n.value not in (fs.EXIT_UNAVAILABLE, True, False)]
+    assert other_ints, "fixture: the module must contain other integer literals"
+    assert not (sources & set(other_ints) - set(exit_unavailable_sources(tree)))
+
+
+def test_renaming_the_tail_helper_makes_this_guard_RED_not_vacuous():
+    """🔴 The failure mode a whitelist-based guard is prone to: if the anchor it
+    keys on disappears, the allowed set empties and everything reads as stray —
+    LOUD. Asserted so nobody "fixes" that into a silent pass."""
+    src = inspect.getsource(fs).replace("_tail_outcome", "_renamed_outcome")
+    tree = ast.parse(src)
+    assert exit_unavailable_sources(tree), "sources vanished — that would be vacuous"
+    assert set(exit_unavailable_sources(tree)) - _tail_path_lines(tree), (
+        "renaming the tail helper left this guard green; it must go RED so the "
+        "anchor's disappearance is visible rather than silently vacuous")
 
 
 # =========================================================================== #

--- a/scripts/tests/test_find_session_skill_contract.py
+++ b/scripts/tests/test_find_session_skill_contract.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""The SHIPPED `find-session` skill body, pinned against the code it describes.
+
+🔴 WHY THIS FILE EXISTS. `claude/skills/find-session/SKILL.md` ships to both
+hosts via home-manager and is the interface an agent reads before branching on an
+exit code — it is PAYLOAD. Nothing in `scripts/tests/` referenced it, and it
+shipped two false claims at once:
+
+  * "`3` — `--tail` could not resolve to one window on a **FULLY MEASURED
+    fleet**". Measured false: two live matches with a host DOWN also exits 3,
+    while the run itself prints "this candidate list is INCOMPLETE". A wrapper
+    branching `rc == 3 => here are all the candidates` reports a complete list
+    under this fleet's documented common degraded state.
+  * "`4` = the live scan failed or no host answered", with no `--tail`
+    qualifier while the neighbouring cases named the tail explicitly. Measured
+    false: every source of that code is on the tail path, and without `--tail`
+    a failed scan exits 0.
+
+🔴 THE POINT IS THE DIRECTION OF DERIVATION. Correcting the prose would have
+fixed the instance; the class is "a claim wider than the thing that enforces
+it", which has now produced findings in three consecutive audit rounds. So the
+sentences live in `EXIT_CONTRACT` in the script, the doc copies them verbatim,
+this module pins the copy, AND — because a doc that merely agrees with a
+constant is still two restatements of an unchecked belief — it pins each
+sentence against the BEHAVIOUR it describes.
+
+Hermetic: the live subprocess seam (`RUN`) is replaced in every behavioural
+probe, so nothing here spawns `session-manager` or reads a real tmux server.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import importlib.machinery
+import importlib.util
+import io
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO / "scripts"
+SKILL_MD = REPO / "claude" / "skills" / "find-session" / "SKILL.md"
+
+
+def _load(path, name):
+    loader = importlib.machinery.SourceFileLoader(name, str(path))
+    spec = importlib.util.spec_from_file_location(name, str(path), loader=loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+fs = _load(SCRIPTS / "find-session.py", "fs_skill_contract")
+
+
+# 🔴 GREEN AT 6914aa33 — and for these, that is the FINDING, not a weakness.
+# The audit's second false claim was that exit 4 meant "the live scan failed",
+# unqualified. The CODE was already right: a failed scan without `--tail` always
+# exited 0. Only the DOC was wrong. So the behavioural probes pass at the audited
+# tip and the doc probes do not — which is exactly the shape of "a claim wider
+# than the thing that enforces it", and the reason this module pins BOTH.
+#
+# No counts here; see the note in `test_find_session_live.py` above
+# `R1_INVARIANT_GUARDS` for why a hand-typed matrix is not kept in-tree.
+R3_GREEN_AT_AUDITED_TIP = frozenset({
+    "test_exit_3_ALSO_arises_on_a_fully_measured_fleet",
+    "test_exit_4_is_TAIL_ONLY_a_failed_scan_without_tail_still_exits_0",
+    "test_exit_4_DOES_arise_when_the_same_failure_happens_under_tail",
+    # This ledger's own gate — no behaviour to regress.
+    "test_the_R3_ledger_names_only_tests_that_exist",
+})
+
+
+def test_the_R3_ledger_names_only_tests_that_exist():
+    assert R3_GREEN_AT_AUDITED_TIP, "the ledger is empty — gate wired to nothing"
+    for entry in R3_GREEN_AT_AUDITED_TIP:
+        assert entry.split("[", 1)[0] in globals(), (
+            f"{entry!r} is listed in the R3 ledger but no such test exists")
+
+
+def _norm(text: str) -> str:
+    """Whitespace-run normalisation and nothing else — line WRAPPING is cosmetic
+    and must not decide a verdict; wording is not. Same normaliser the other
+    prose gates in this repo use."""
+    return " ".join(text.split())
+
+
+@pytest.fixture
+def body():
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+# =========================================================================== #
+# THE EXIT-CODE TABLE — doc vs constant, BOTH directions
+# =========================================================================== #
+def test_the_skill_exists_and_the_contract_is_not_empty(body):
+    """POSITIVE CONTROL before any verdict: a gate reading an empty file or an
+    empty constant would pass every assertion below by vacuity."""
+    assert SKILL_MD.is_file()
+    assert body.strip()
+    assert fs.EXIT_CONTRACT, "EXIT_CONTRACT is empty — the gate is wired to nothing"
+    assert len(fs.EXIT_CONTRACT) >= 4
+
+
+def test_every_contract_sentence_appears_VERBATIM_in_the_shipped_doc(body):
+    """🔴 Whole normalised strings, never keywords. `claude/RULES.md`: "when the
+    artifact under test IS prose, a guard on WORDS is walkable by REWORDING —
+    pin the WHOLE normalised string". Both of the false claims this replaced
+    were rewordings of true ones."""
+    haystack = _norm(body)
+    missing = [(code, txt) for code, txt in fs.EXIT_CONTRACT
+               if _norm(txt) not in haystack]
+    assert not missing, (
+        "the shipped skill body no longer carries these EXIT_CONTRACT sentences "
+        "verbatim:\n"
+        + "".join(f"  exit {c}: {_norm(t)!r}\n" for c, t in missing)
+        + "Reword the CONSTANT and copy it here, never the other way round — "
+          "the doc is the derived artifact.")
+
+
+def test_the_doc_states_every_code_and_INVENTS_none(body):
+    """Both directions. A doc that documents a code the script cannot return
+    sends a caller to write a branch that never fires."""
+    documented = {int(m) for m in re.findall(r"^- `(\d)` — ", body, re.M)}
+    declared = {code for code, _ in fs.EXIT_CONTRACT}
+    assert documented == declared, (
+        f"doc documents {sorted(documented)}, script declares {sorted(declared)}")
+
+
+def test_the_contract_codes_are_the_scripts_own_EXIT_constants():
+    """The sentences must describe the constants the code actually returns, not
+    a parallel set of integers."""
+    declared = {code for code, _ in fs.EXIT_CONTRACT}
+    assert declared == {fs.EXIT_OK, fs.EXIT_USAGE, fs.EXIT_AMBIGUOUS,
+                        fs.EXIT_UNAVAILABLE}
+    assert len(declared) == 4, "two codes collapsed onto one integer"
+
+
+def test_no_code_appears_twice_in_the_contract():
+    codes = [code for code, _ in fs.EXIT_CONTRACT]
+    assert len(codes) == len(set(codes))
+
+
+# =========================================================================== #
+# ...AND THE SENTENCES PINNED AGAINST BEHAVIOUR
+#
+# A doc agreeing with a constant is still two copies of an unchecked belief.
+# These are the two claims that were FALSE, executed.
+# =========================================================================== #
+def _run(argv, run, archive=None):
+    """Drive `main()` with the subprocess seam replaced. Returns (rc, out, err)."""
+    old_run, old_archive = fs.RUN, fs.archive_search
+    fs.RUN = run
+    fs.archive_search = lambda a, since: list(archive or [])
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = fs.main(list(argv))
+    finally:
+        fs.RUN, fs.archive_search = old_run, old_archive
+    return rc, out.getvalue(), err.getvalue()
+
+
+ROW = {
+    "kind": "tmux", "host": "workbench", "session": "scratch3",
+    "window_index": "2", "label": "violet", "label_source": "codename",
+    "hotkey": "v", "hotkey_display": "Alt+v", "path": "/w/zzsigma",
+    "task": "zzterm synthetic", "runtime": "claude", "claude": True,
+    "busy": True, "status": "busy", "age_secs": 60.0, "age_source": "ledger",
+    "waiting_probable": False, "waiting_signals": [], "waiting_status": "ok",
+    "unsent_prompt": None, "unsent_prompt_status": "ok",
+    "claude_session_id": "aaaaaaaa-1111-4222-8333-444444444444",
+}
+ROW_TWO = dict(ROW, session="scratch5", window_index="7",
+               claude_session_id="bbbbbbbb-2222-4333-8444-555555555555")
+
+
+def _report(rows, unreachable=()):
+    hosts = {"workbench": {"reachable": True, "error": None,
+                           "windows_measured": True, "windows": list(rows)}}
+    for h in unreachable:
+        hosts[h] = {"reachable": False, "error": "ssh: no route",
+                    "windows_measured": False, "windows": []}
+    return {"view": "lean", "hosts": hosts,
+            "filters": {"match": ["zzterm"],
+                        "match_fields": ["task", "label", "codename"]},
+            "summary": {"total_sessions": len(rows)}}
+
+
+def _runner(report, boom=None):
+    def run(argv, timeout=None):
+        if boom is not None:
+            raise boom
+        if "tail" in argv:
+            return 0, "synthetic scrollback\n", ""
+        return (0 if report["hosts"]["workbench"]["windows"] else 3,
+                json.dumps(report), "")
+    return run
+
+
+def test_exit_3_carries_NO_claim_that_the_fleet_was_fully_measured():
+    """🔴 THE FIRST FALSE SENTENCE, EXECUTED. Two live matches with `laptop`
+    down exits 3 — the doc used to say 3 meant a FULLY measured fleet, so a
+    wrapper branching on it would report an incomplete candidate list as
+    complete."""
+    rc, out, _ = _run(["zzterm", "--live", "--tail", "20"],
+                      _runner(_report([ROW, ROW_TWO], unreachable=("laptop",))))
+    assert rc == fs.EXIT_AMBIGUOUS
+    assert "candidate list is INCOMPLETE" in out, (
+        "fixture broken: this run must be the partial-fleet ambiguous case")
+    # ...and the doc no longer claims otherwise.
+    assert "FULLY measured fleet" not in SKILL_MD.read_text(encoding="utf-8")
+
+
+def test_exit_3_ALSO_arises_on_a_fully_measured_fleet():
+    """The other half, so the sentence is not simply inverted: with every host
+    answering, an ambiguous match is still 3."""
+    rc, out, _ = _run(["zzterm", "--live", "--tail", "20"],
+                      _runner(_report([ROW, ROW_TWO])))
+    assert rc == fs.EXIT_AMBIGUOUS
+    assert "candidate list is INCOMPLETE" not in out
+
+
+@pytest.mark.parametrize("argv", [
+    ["zzterm", "--live"],
+    ["zzterm", "--live", "--json"],
+], ids=["text", "json"])
+def test_exit_4_is_TAIL_ONLY_a_failed_scan_without_tail_still_exits_0(argv):
+    """🔴 THE SECOND FALSE SENTENCE, EXECUTED. The doc said 4 meant "the live
+    scan failed or no host answered" with no `--tail` qualifier — but every
+    source of that code is on the tail path, so a failed scan WITHOUT `--tail`
+    exits 0 and reports the failure in prose instead."""
+    rc, out, _ = _run(argv, _runner(_report([]), boom=OSError("no such file")),
+                      archive=[])
+    assert rc == fs.EXIT_OK, (
+        "a failed scan without --tail no longer exits 0; the contract sentence "
+        "for exit 4 says it does")
+    if "--json" not in argv:
+        assert "LIVE: SCAN FAILED" in out
+
+
+def test_exit_4_DOES_arise_when_the_same_failure_happens_under_tail():
+    """The positive half of the same sentence — otherwise "4 is unreachable"
+    would satisfy the probe above."""
+    rc, _, _ = _run(["zzterm", "--live", "--tail", "20"],
+                    _runner(_report([]), boom=OSError("no such file")),
+                    archive=[])
+    assert rc == fs.EXIT_UNAVAILABLE
+
+
+def test_every_EXIT_UNAVAILABLE_source_is_on_the_tail_path():
+    """🔴 STRUCTURAL, so the sentence stays true of code nobody has written yet.
+
+    The `--tail ONLY` claim is about WHERE the code can arise, and a behavioural
+    probe only samples the paths it thought of. This asserts that every textual
+    source of `EXIT_UNAVAILABLE` in the module is inside `_tail_outcome` or
+    inside `main`'s `if a.tail is not None:` block — so a NEW return added
+    outside the tail path fails here rather than silently falsifying the doc.
+    """
+    import ast
+    import inspect
+    src = inspect.getsource(fs)
+    tree = ast.parse(src)
+
+    allowed_lines = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_tail_outcome":
+            allowed_lines |= set(range(node.lineno, node.end_lineno + 1))
+        if isinstance(node, ast.If):
+            # `if a.tail is not None:` — the tail block inside `main`
+            test = ast.unparse(node.test)
+            if "a.tail is not None" in test:
+                allowed_lines |= set(range(node.lineno, node.end_lineno + 1))
+
+    uses = [n.lineno for n in ast.walk(tree)
+            if isinstance(n, ast.Name) and n.id == "EXIT_UNAVAILABLE"]
+    assert uses, "no EXIT_UNAVAILABLE reference found — gate wired to nothing"
+    stray = sorted(set(uses) - allowed_lines
+                   - {n.lineno for n in ast.walk(tree)
+                      if isinstance(n, ast.Assign)
+                      and any(getattr(t, "id", "") == "EXIT_UNAVAILABLE"
+                              for t in n.targets)}
+                   - {c for c, _ in [(0, 0)]})
+    # the EXIT_CONTRACT tuple itself references the constant; that is data, not
+    # a return path, so exclude the contract's own lines.
+    contract = next(n for n in ast.walk(tree)
+                    if isinstance(n, ast.Assign)
+                    and any(getattr(t, "id", "") == "EXIT_CONTRACT"
+                            for t in n.targets))
+    stray = [ln for ln in stray
+             if not (contract.lineno <= ln <= contract.end_lineno)]
+    assert not stray, (
+        f"EXIT_UNAVAILABLE is returned outside the --tail path at lines {stray}. "
+        "The shipped skill body says exit 4 is `--tail` ONLY; either keep it "
+        "that way or change EXIT_CONTRACT and the doc together.")
+
+
+# =========================================================================== #
+# THE ARCHIVE-ONLY FLAG LIST — named in the doc, owned by the script
+# =========================================================================== #
+# 🔴 THE ENUMERATION IS BRACKETED BY TWO ANCHOR PHRASES, not by the bullet.
+#
+# A `spelling in body` check is satisfied by the flag being named ANYWHERE, and
+# a bullet-scoped check is satisfied by the CONTINUATION prose, which mentions
+# `--opencode-only --live` a few lines further down inside the same bullet.
+# Measured, twice: deleting `--opencode-only` from the enumeration survived both
+# spellings of the guard. That is precisely the failure the round-3 audit found
+# in the `__doc__` substring check — reproduced here while writing its
+# replacement, which is why the bracketing is the point and not a detail.
+#
+# Same idiom, and same reason, as `test_session_manager_skill_size.py`'s
+# CAVEAT_LIST_HEAD / _TAIL: bound the LIST, then compare the list.
+FLAG_LIST_HEAD = "**These flags reach the ARCHIVE leg ONLY** —"
+FLAG_LIST_TAIL = "— and the tool names them on stderr."
+
+
+def _documented_archive_only_flags(body: str) -> list:
+    """The flags the doc ENUMERATES, read from between the two anchors."""
+    text = _norm(body)
+    start = text.find(_norm(FLAG_LIST_HEAD))
+    assert start != -1, (
+        f"{FLAG_LIST_HEAD!r} not found in {SKILL_MD}. That phrase opens the "
+        "archive-only enumeration and is what this gate uses to find it. If the "
+        "bullet was reworded, re-point the anchor; if the enumeration was "
+        "deleted, delete this gate in the same commit and say so.")
+    end = text.find(_norm(FLAG_LIST_TAIL), start)
+    assert end != -1, (
+        f"{FLAG_LIST_TAIL!r} not found after the head anchor — the enumeration "
+        "has no closing anchor, so this gate cannot bound it.")
+    return re.findall(r"`(--[a-z-]+)`", text[start + len(_norm(FLAG_LIST_HEAD)):end])
+
+
+def test_the_enumeration_slicer_really_bounds_the_LIST(body):
+    """POSITIVE CONTROL on the slicer, because every verdict below is a
+    statement about the SLICE. Its own bullet's continuation prose names
+    `--opencode-only` and `--limit`; neither may be inside the bounded list by
+    accident, or the two-way comparison below proves nothing."""
+    text = _norm(body)
+    start = text.find(_norm(FLAG_LIST_HEAD))
+    end = text.find(_norm(FLAG_LIST_TAIL), start)
+    sliced = text[start:end]
+    assert 0 < len(sliced) < len(text) / 4, "the slice is empty or unbounded"
+    assert "--limit" not in sliced, (
+        "the slice reaches into the bullet's continuation prose — it would then "
+        "be satisfied by a flag mentioned there rather than enumerated here")
+    assert _documented_archive_only_flags(body), "the slicer parsed no flags"
+
+
+def test_the_doc_enumerates_EXACTLY_the_ARCHIVE_ONLY_flags(body):
+    """🔴 TWO-WAY. The doc used to open this bullet with a COUNT ("SIX flags…"),
+    a claim nothing enforced — right the day it was written and silently wrong
+    the moment a seventh is added. The count is gone; membership is pinned in
+    BOTH directions, so the doc can neither drop a flag the script filters nor
+    advertise one it does not."""
+    documented = sorted(_documented_archive_only_flags(body))
+    declared = sorted(s for _, s, _ in fs.ARCHIVE_ONLY_FLAGS)
+    assert documented == declared, (
+        "the shipped doc's archive-only enumeration disagrees with "
+        "`ARCHIVE_ONLY_FLAGS`:\n"
+        f"  doc enumerates : {documented}\n"
+        f"  script declares: {declared}\n"
+        f"  only in the doc   : {sorted(set(documented) - set(declared))}\n"
+        f"  only in the script: {sorted(set(declared) - set(documented))}\n"
+        "Being named elsewhere in the file does not count — a reader of this "
+        "enumeration would not see it.")
+
+
+def test_the_doc_does_not_carry_a_FLAG_COUNT_that_nothing_enforces(body):
+    """A number in prose is the exact shape this round is removing. If a count
+    is wanted, derive it; do not type it."""
+    line = next((ln for ln in body.splitlines()
+                 if "reach the ARCHIVE leg ONLY" in ln), None)
+    assert line, "the archive-only bullet moved — re-point this gate"
+    assert not re.search(r"\b(TWO|THREE|FOUR|FIVE|SIX|SEVEN|EIGHT|\d+)\s+flags",
+                         line, re.I), (
+        f"the archive-only bullet states a flag COUNT: {line!r}. A count drifts "
+        "the moment a flag is added; name the flags, or derive the number.")

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -10326,9 +10326,14 @@ def test_measured_not_measured_is_PURE_and_shares_nothing_with_the_constant():
 # claims coverage it does not have.
 # =========================================================================== #
 #
-# MEASURED, not asserted: replayed against a detached worktree at 9e452d34 with
-# this exact file copied in — 45 collected §14 nodes, 38 RED and 7 GREEN. The 7
-# are precisely the set below.
+# The GREEN-at-9e452d34 ones are precisely the set below, and a test asserts
+# every name resolves.
+#
+# ⚠ NO COUNT HERE, deliberately — see the note above `R1_INVARIANT_GUARDS`. This
+# comment used to carry "45 collected §14 nodes, 38 RED and 7 GREEN"; §14 has
+# grown across four later rounds, so that number describes a file that no longer
+# exists while reading as a live measurement. The per-round matrices live in the
+# PR body with the sha and method that produced each one.
 INVARIANT_GUARDS_ADDED_HERE = frozenset({
     # `exit_code_for` already returned EXIT_EMPTY for a detail miss over a
     # reachable fleet, and EXIT_UNAVAILABLE when nothing answered. What was

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -1839,6 +1839,10 @@ def test_json_golden_schema_and_values():
         "match": None,
         "match_fields": None,
         "excluded_by_match": None,
+        # 🔴 MIRRORED FROM `filters.matched`, and it is NOT `total_sessions` —
+        # on a `detail` report those two disagree by construction. `None` here
+        # because no row filter ran.
+        "matched": None,
         "hosts_reachable": ["laptop", "workbench"],
         "hosts_unreachable": [],
         "fuzzyclaw_live": 1,
@@ -4704,7 +4708,12 @@ def test_main_json_end_to_end_carries_the_split_and_the_filter(
                                # here would say "a --match ran and matched
                                # nothing" over a scan that returned two rows.
                                "match": None, "match_fields": None,
-                               "matched": None, "excluded_by_match": None}
+                               "matched": None, "excluded_by_match": None,
+                               # `--claude-only` DID run, but this scan is not a
+                               # `detail`, so the pre-filter index map was never
+                               # sampled. `None`, not `{}`: "not sampled" and
+                               # "sampled and empty" are different facts.
+                               "prefilter_window_indices": None}
 
 
 def test_detail_under_claude_only_explains_its_own_emptiness(monkeypatch):
@@ -10584,13 +10593,30 @@ def test_row_matches_finds_a_CODENAME_that_disagrees_with_the_LABEL():
     assert sm.row_matches(row, ["zzdelta"], sm.match_fields(True)) is True
 
 
-def test_a_term_may_not_SPAN_two_fields():
-    """Joining the fields into one haystack would match text that exists in no
-    field — a hit no reader can explain."""
+def test_the_span_fixture_matches_each_field_ALONE():
+    """POSITIVE CONTROL for the span battery below: if neither field matched on
+    its own, "the concatenation does not match" would be true of a predicate
+    wired to nothing."""
     row = {"task": "abc", "label": "def", "codename": None, "path": None}
     assert sm.row_matches(row, ["abc"]) is True
     assert sm.row_matches(row, ["def"]) is True
-    assert sm.row_matches(row, ["abcdef"]) is False
+
+
+# 🔴 EVERY PLAUSIBLE JOIN, NOT ONE. The first version of this guard asserted
+# only `"abcdef"` — a ZERO-separator join — while its docstring claimed the
+# fields are "never joined into one string". An audit mutated `row_matches` to a
+# SPACE-joined haystack and all 653 tests stayed green: the description claimed
+# coverage the body did not provide, which `claude/RULES.md` calls worse than no
+# coverage. The separator set is what makes this a claim about the CLASS.
+@pytest.mark.parametrize("sep", ["", " ", "|", "\n", "\t", "\x00", ", ", " — "],
+                         ids=["empty", "space", "pipe", "newline", "tab",
+                              "nul", "comma-space", "em-dash"])
+def test_a_term_may_not_SPAN_two_fields(sep):
+    """Joining the fields into one haystack would match text that exists in no
+    field — a hit no reader can explain."""
+    row = {"task": "abc", "label": "def", "codename": None, "path": None}
+    assert sm.row_matches(row, ["abc" + sep + "def"]) is False, (
+        f"a term spanning the field boundary matched under a {sep!r} join")
 
 
 def test_an_EMPTY_term_list_matches_everything_rather_than_nothing():
@@ -10892,4 +10918,349 @@ def test_detail_json_is_the_FULL_REPORT_SHAPE_not_a_bare_window(monkeypatch,
     # ...and the two row keys the same run got wrong.
     assert row["window_index"] == "2" and "window" not in row
     assert row["path"] and "cwd" not in row
+
+
+# =========================================================================== #
+# §15 — AUDIT FIX ROUND 1 (against tip a6f09d5a)
+#
+# 🔴 THE TWO DEPLOY-BLOCKERS AN ADVERSARIAL AUDIT FOUND, and three smaller ones.
+# Only the session-manager half is here; `test_find_session_live.py` §2 carries
+# the `find-session.py` half.
+#
+#   R1-2  A `detail` MISS UNDER A ROW FILTER ASSERTED A FALSE MEASURED ABSENCE.
+#         `gather` filters rows BEFORE `filter_report` narrows, so the sibling
+#         list enumerated only the survivors. Reproduced live:
+#           detail scratch3:1 --match datapacket
+#           -> "session 'scratch3' has windows ['2']"
+#         while window 1 existed on BOTH searched hosts. `(searched: laptop,
+#         workbench)` made it read as authoritative — worse than the silent
+#         empty it replaced, which at least asserted nothing.
+#   R1-5  `filters.matched` / `.excluded_by_match` published a measured `0` over
+#         a fleet where NO host answered, while `detail_matched` was already
+#         `None` in that exact state.
+#   R1-6  The table's filter line quoted `total_sessions`, which is a DIFFERENT
+#         number from `filters.matched` on a `detail` — and `filters.matched`
+#         was read by nothing.
+#   R1-7  The span guard was spelled to a zero-separator join (fixed above).
+#
+# 🔴 WHICH OF THESE IS REGRESSION COVERAGE. MEASURED, not asserted: this file
+# and its sibling were copied into a detached worktree at a6f09d5a — 56 new
+# nodes across the two, 46 RED and 10 GREEN. The GREEN ones are named in
+# `R1_INVARIANT_GUARDS` (here) and `R1_INVARIANT_GUARDS` in
+# `test_find_session_live.py`; none of them is evidence a bug was fixed.
+#
+# ⚠ ONE FINDING IN THIS ROUND WAS A GUARD GAP, NOT A CODE DEFECT. The span guard
+# (`test_a_term_may_not_SPAN_two_fields`, widened above) passes at a6f09d5a in
+# both its old and new forms, because `row_matches` was already per-field — the
+# auditor's space-joined MUTANT is what the old spelling could not see. Its
+# evidence is the mutation sweep (N27/N28), not a red-at-tip run.
+# =========================================================================== #
+R1_INVARIANT_GUARDS = frozenset({
+    # A partially reachable fleet already published real counts; R1-5 is only
+    # about the NO-host-answered state.
+    "test_a_PARTIALLY_reachable_fleet_still_publishes_real_counts",
+    # The fixture control for the R1-2 probes.
+    "test_the_scratch3_fixture_really_has_BOTH_windows_before_any_filter",
+    # The positive control for the span battery.
+    "test_the_span_fixture_matches_each_field_ALONE",
+    # 🔴 The PRECONDITION that replaced an unreachable guard — see its docstring.
+    # It held at a6f09d5a too; pinning it is what makes removing the guard safe.
+    "test_an_unreachable_host_carries_NO_rows_which_is_what_makes_the_maps_safe",
+})
+
+
+def test_the_R1_invariant_guard_ledger_names_only_tests_that_exist():
+    for name in R1_INVARIANT_GUARDS:
+        assert name in globals(), (
+            f"{name!r} is listed as an R1 invariant guard but no such test exists")
+
+
+def scratch3_detail(target_index, **kw):
+    """A `detail` report over the scratch3 fixture, WITH the pre-filter map.
+
+    `prefilter_index_map=True` mirrors what `main()` passes for the `detail`
+    subcommand — the parameter exists so a 1-row `--match` scan does not carry a
+    whole fleet's index map back.
+    """
+    kw.setdefault("prefilter_index_map", True)
+    return sm.filter_report(scratch3_gather(**kw), "scratch3", target_index)
+
+
+def test_the_scratch3_fixture_really_has_BOTH_windows_before_any_filter():
+    """POSITIVE CONTROL. Every R1-2 assertion is about a window the filter
+    removes; if the fixture never built it, they would all pass vacuously."""
+    rows = [r for h in scratch3_gather()["hosts"].values() for r in h["windows"]]
+    assert sorted((r["session"], r["window_index"]) for r in rows) == [
+        ("scratch3", "1"), ("scratch3", "2")]
+    # ...and window 1 is the SHELL, so `--claude-only` is what removes it.
+    by_idx = {r["window_index"]: r for r in rows}
+    assert by_idx["1"]["claude"] is False
+    assert by_idx["2"]["claude"] is True
+
+
+@pytest.mark.parametrize("kw,flag", [
+    (dict(claude_only=True), "--claude-only"),
+    # a term that only the CLAUDE window's task carries, so the shell row goes
+    (dict(match=["lost track"]), "--match 'lost track'"),
+], ids=["claude-only", "match"])
+def test_a_detail_MISS_CAUSED_BY_A_ROW_FILTER_says_so_instead_of_NO_SUCH_WINDOW(
+        kw, flag):
+    """🔴 R1-2, THE HEADLINE. The window EXISTS; a row filter removed its row.
+    Calling that "NO SUCH WINDOW" is a flat falsehood, and the `(searched: …)`
+    clause makes it read as authoritative."""
+    report = scratch3_detail("1", **kw)
+    msg = sm.detail_not_found_message(report)
+    assert msg is not None
+    assert "WINDOW 'scratch3:1' EXISTS but a ROW FILTER" in msg
+    assert flag in msg
+    assert "NOT a measured absence" in msg
+    assert "NO SUCH WINDOW" not in msg, (
+        "the filtered-out case still claims the window does not exist")
+    # ...and structurally, for a consumer that never reads stderr
+    assert report["filters"]["detail_filtered_out"] is True
+    assert report["filters"]["detail_matched"] == 0
+
+
+@pytest.mark.parametrize("kw", [
+    dict(claude_only=True),
+    dict(match=["lost track"]),
+], ids=["claude-only", "match"])
+def test_the_sibling_indices_are_measured_BEFORE_the_row_filter(kw):
+    """🔴 R1-2, the other half: the enumerated list must be a fact about the
+    SCAN, not about the filter. `['2']` was the shipped answer."""
+    report = scratch3_detail("9", **kw)
+    assert report["filters"]["detail_sibling_indices"] == ["1", "2"], (
+        "the sibling list is filter-scoped again — it enumerates survivors")
+    msg = sm.detail_not_found_message(report)
+    assert "session 'scratch3' has windows ['1', '2']" in msg
+    # ...and the reader is told a filter was in play, so the count above and the
+    # empty table below cannot be read as disagreeing.
+    assert "measured BEFORE the row filter" in msg
+    assert report["filters"]["detail_filtered_out"] is False
+
+
+def test_WITHOUT_a_row_filter_the_message_makes_NO_filter_claim():
+    """NEGATIVE CONTROL. Without it, "always mention a filter" passes both
+    probes above while lying on the common path."""
+    report = scratch3_detail("9")
+    msg = sm.detail_not_found_message(report)
+    assert "NO SUCH WINDOW 'scratch3:9'" in msg
+    assert "ROW FILTER" not in msg and "BEFORE the row filter" not in msg
+    assert report["filters"]["detail_filtered_out"] is False
+    # ...and nothing was sampled, because no filter ran.
+    assert report["filters"]["prefilter_window_indices"] is None
+
+
+def test_an_unknown_SESSION_under_a_filter_still_says_no_such_session():
+    """The third miss shape keeps its own wording, and still discloses the
+    filter — a `[]` sibling list under a filter is a pre-filter measurement and
+    the reader has to be able to tell."""
+    report = scratch3_detail("1", claude_only=True)
+    report["filters"]["detail_target"] = "zznosuch:1"
+    report["filters"]["detail_sibling_indices"] = []
+    report["filters"]["detail_filtered_out"] = False
+    msg = sm.detail_not_found_message(report)
+    assert "no session named 'zznosuch'" in msg
+    assert "measured BEFORE the row filter --claude-only" in msg
+
+
+def test_the_prefilter_map_is_OPT_IN_so_a_match_scan_does_not_carry_it():
+    """The map exists for `detail`. A 1-row `--match` scan carrying a whole
+    fleet's index map would defeat the flag's entire purpose."""
+    scan = match_gather(match=["zzkiwi"])
+    assert scan["filters"]["prefilter_window_indices"] is None
+    detail_side = match_gather(match=["zzkiwi"], prefilter_index_map=True)
+    pre = detail_side["filters"]["prefilter_window_indices"]
+    assert pre is not None
+    # every session the scan SAW, not just the one row that survived
+    assert sorted(pre) == ["match-one", "match-two", "scratch2"]
+    assert pre["match-one"] == ["1"]
+    # ...and it is never sampled when NO filter ran, because then the rows
+    # themselves are the unfiltered set.
+    assert match_gather(prefilter_index_map=True)[
+        "filters"]["prefilter_window_indices"] is None
+
+
+def test_an_unreachable_host_carries_NO_rows_which_is_what_makes_the_maps_safe():
+    """🔴 THE PRECONDITION, PINNED — because the guard for it was UNREACHABLE.
+
+    Both the pre-filter index map and `filter_report`'s row-derived fallback
+    must not let a host that never answered contribute a measured presence or
+    absence of window indices. `gather` gives an unreachable host `windows: []`,
+    so neither loop can see one — which a mutation sweep confirmed by deleting
+    the `entry["reachable"]` clause from the map and changing NO test. A guard
+    that cannot fire reads as a defence and is not one, so it was removed and
+    the property it depended on is asserted here instead, where a change to
+    `gather` really would red.
+    """
+    runner = make_runner(local_panes=SCRATCH3_PANES,
+                         local_windows=SCRATCH3_WINDOWS,
+                         remote_rc=255, remote_err="ssh: no route")
+    got = base_gather(runner=runner, use_fuzzyclaw=False)
+    assert got["hosts"]["laptop"]["reachable"] is False
+    assert got["hosts"]["laptop"]["windows"] == [], (
+        "an unreachable host carries rows — the pre-filter index map and "
+        "`filter_report`'s sibling fallback both rely on this being impossible")
+    # positive control: the REACHABLE host in the same scan does carry rows, so
+    # the assertion above is not observing an empty scan.
+    assert got["hosts"]["workbench"]["windows"]
+
+
+def test_the_prefilter_map_excludes_hosts_that_never_answered():
+    """The consequence of the precondition above, observed on the map itself.
+
+    INVARIANT GUARD, not regression coverage: it holds whether or not the map
+    filters on reachability, because there is nothing to filter.
+    """
+    runner = make_runner(local_panes=SCRATCH3_PANES,
+                         local_windows=SCRATCH3_WINDOWS,
+                         remote_rc=255, remote_err="ssh: no route")
+    got = base_gather(runner=runner, use_fuzzyclaw=False, claude_only=True,
+                      prefilter_index_map=True)
+    assert got["filters"]["prefilter_window_indices"] == {"scratch3": ["1", "2"]}
+
+
+def test_a_detail_over_an_UNREACHABLE_fleet_leaves_filtered_out_None_too():
+    """The fourth field joins the same rule: nothing was measured, so it is not
+    `False` (which would assert the filter did not remove it)."""
+    down = make_runner(local_rc=1, local_err="tmux: connection failed",
+                       remote_rc=255, remote_err="ssh: no route")
+    report = sm.filter_report(
+        base_gather(runner=down, use_fuzzyclaw=False, claude_only=True,
+                    prefilter_index_map=True),
+        "scratch3", "1")
+    assert report["filters"]["detail_filtered_out"] is None
+    assert report["filters"]["detail_matched"] is None
+    assert report["filters"]["detail_sibling_indices"] is None
+    assert sm.detail_not_found_message(report) is None
+
+
+def test_main_detail_under_a_filter_is_LOUD_about_the_FILTER(monkeypatch,
+                                                             capsys):
+    """END-TO-END, and it pins that `main()` asks `gather` for the pre-filter
+    map on the `detail` subcommand — without that the message regresses."""
+    seen = {}
+
+    def fake_gather(**kw):
+        seen.update(kw)
+        return scratch3_gather(claude_only=kw.get("claude_only", False),
+                               prefilter_index_map=kw.get(
+                                   "prefilter_index_map", False))
+
+    monkeypatch.setattr(sm, "gather", fake_gather)
+    monkeypatch.setattr(sm, "local_host_label", lambda *a, **k: "workbench")
+    rc = sm.main(["detail", "scratch3:1", "--json", "--no-ch", "--claude-only"])
+    cap = capsys.readouterr()
+    assert seen["prefilter_index_map"] is True, (
+        "main() did not ask for the pre-filter map on a `detail`")
+    assert rc == sm.EXIT_EMPTY
+    assert "EXISTS but a ROW FILTER" in cap.err
+    blob = json.loads(cap.out)
+    assert blob["filters"]["detail_filtered_out"] is True
+
+
+def test_main_SCAN_does_not_ask_for_the_prefilter_map(monkeypatch, capsys):
+    """NEGATIVE CONTROL on the same wiring — a `scan` must not pay for it."""
+    seen = {}
+
+    def fake_gather(**kw):
+        seen.update(kw)
+        return match_gather(match=kw.get("match"))
+
+    monkeypatch.setattr(sm, "gather", fake_gather)
+    monkeypatch.setattr(sm, "local_host_label", lambda *a, **k: "workbench")
+    sm.main(["scan", "--json", "--no-ch", "--match", "zzkiwi"])
+    capsys.readouterr()
+    assert seen["prefilter_index_map"] is False
+
+
+# --------------------------------------------------------------------------- #
+# R1-5 — a count over a fleet nobody reached is not a zero
+# --------------------------------------------------------------------------- #
+def test_match_counts_are_None_not_ZERO_over_an_unreachable_fleet():
+    """🔴 R1-5. `matched: 0` there says "the filter ran and matched nothing"
+    about a scan that measured nothing. `detail_matched` was already `None` in
+    exactly this state; these now agree with it."""
+    down = make_runner(local_rc=1, local_err="tmux: connection failed",
+                       remote_rc=255, remote_err="ssh: no route")
+    got = base_gather(runner=down, use_fuzzyclaw=False, match=["zzkiwi"])
+    assert got["filters"]["matched"] is None
+    assert got["filters"]["excluded_by_match"] is None
+    assert got["summary"]["matched"] is None
+    assert got["summary"]["excluded_by_match"] is None
+    # ...but WHICH filter was requested is known regardless, so the terms and
+    # the field list are still published. Dropping them would lose the only
+    # thing that distinguishes this from an unfiltered unreachable scan.
+    assert got["filters"]["match"] == ["zzkiwi"]
+    assert got["filters"]["match_fields"] == ["task", "label", "codename"]
+    assert sm.exit_code_for(got) == sm.EXIT_UNAVAILABLE
+
+
+def test_match_counts_ARE_real_zeros_when_the_fleet_ANSWERED():
+    """The measured counterpart, so the None above is a filter decision and not
+    a field wired to null. A reachable fleet with no match publishes `0`."""
+    got = match_gather(match=["zznothinghere"])
+    assert got["filters"]["matched"] == 0
+    assert got["filters"]["excluded_by_match"] == 3
+    assert got["summary"]["matched"] == 0
+
+
+def test_a_PARTIALLY_reachable_fleet_still_publishes_real_counts():
+    """One host answering is a measurement. The null applies only when NOTHING
+    answered — otherwise the flag would go null on the fleet's most common
+    degraded state and stop being readable at all."""
+    runner = make_runner(local_panes=MATCH_PANES, local_windows=MATCH_WINDOWS,
+                         remote_rc=255, remote_err="ssh: no route")
+    got = base_gather(runner=runner, use_fuzzyclaw=False, match=["zzkiwi"])
+    assert got["filters"]["matched"] == 1
+    assert got["filters"]["excluded_by_match"] == 2
+
+
+# --------------------------------------------------------------------------- #
+# R1-6 — the table's filter line quoted the wrong number
+# --------------------------------------------------------------------------- #
+def test_the_table_filter_line_quotes_MATCHED_not_total_sessions():
+    """🔴 R1-6. On a `detail` the two disagree by construction: the row filter
+    matched 2 and `filter_report` then narrowed to 1, so `total_sessions` is 1.
+    The line describes the FILTER, so it must quote the filter's number — which
+    was sitting unread in `filters.matched`."""
+    scan = match_gather(match=["zz"])
+    assert scan["filters"]["matched"] == 2, "fixture: --match zz must hit 2 rows"
+    narrowed = sm.filter_report(scan, "match-one", "1")
+    assert narrowed["summary"]["total_sessions"] == 1, (
+        "fixture broken: the two numbers must DIFFER or this proves nothing")
+    text = sm.render_table(narrowed)
+    assert "2 row(s) matched" in text
+    assert "1 row(s) matched" not in text
+
+
+def test_the_table_filter_line_says_UNMEASURED_rather_than_printing_a_null():
+    """Over an unreachable fleet both counts are None; the sentence must read as
+    a sentence, not print `None row(s) matched`."""
+    down = make_runner(local_rc=1, local_err="tmux: connection failed",
+                       remote_rc=255, remote_err="ssh: no route")
+    text = sm.render_table(
+        base_gather(runner=down, use_fuzzyclaw=False, match=["zzkiwi"]))
+    assert "an unmeasured number of row(s) matched" in text
+    assert "None row(s)" not in text
+
+
+def test_summary_matched_is_MIRRORED_from_filters_not_recomputed():
+    """One writer. A second derivation here is how `total_sessions` came to be
+    quoted in the first place."""
+    scan = match_gather(match=["zz"])
+    assert scan["summary"]["matched"] == scan["filters"]["matched"] == 2
+    narrowed = sm.filter_report(scan, "match-one", "1")
+    assert narrowed["summary"]["matched"] == 2
+    assert narrowed["summary"]["total_sessions"] == 1
+
+
+def test_the_active_row_filter_list_is_ONE_definition():
+    """Both miss messages and the tests name the same set; a second copy would
+    describe filters the first does not."""
+    assert sm._active_row_filters({}) == []
+    assert sm._active_row_filters({"claude_only": True}) == ["--claude-only"]
+    assert sm._active_row_filters({"match": ["a", "b"]}) == ["--match 'a' 'b'"]
+    assert sm._active_row_filters(
+        {"claude_only": True, "match": ["a"]}) == ["--claude-only", "--match 'a'"]
 

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -10608,9 +10608,14 @@ def test_the_span_fixture_matches_each_field_ALONE():
 # SPACE-joined haystack and all 653 tests stayed green: the description claimed
 # coverage the body did not provide, which `claude/RULES.md` calls worse than no
 # coverage. The separator set is what makes this a claim about the CLASS.
-@pytest.mark.parametrize("sep", ["", " ", "|", "\n", "\t", "\x00", ", ", " — "],
-                         ids=["empty", "space", "pipe", "newline", "tab",
-                              "nul", "comma-space", "em-dash"])
+SPAN_SEPARATORS = (
+    ("empty", ""), ("space", " "), ("pipe", "|"), ("newline", "\n"),
+    ("tab", "\t"), ("nul", "\x00"), ("comma-space", ", "), ("em-dash", " — "),
+)
+
+
+@pytest.mark.parametrize("sep", [s for _, s in SPAN_SEPARATORS],
+                         ids=[i for i, _ in SPAN_SEPARATORS])
 def test_a_term_may_not_SPAN_two_fields(sep):
     """Joining the fields into one haystack would match text that exists in no
     field — a hit no reader can explain."""
@@ -10943,17 +10948,31 @@ def test_detail_json_is_the_FULL_REPORT_SHAPE_not_a_bare_window(monkeypatch,
 #         was read by nothing.
 #   R1-7  The span guard was spelled to a zero-separator join (fixed above).
 #
-# 🔴 WHICH OF THESE IS REGRESSION COVERAGE. MEASURED, not asserted: this file
-# and its sibling were copied into a detached worktree at a6f09d5a — 56 new
-# nodes across the two, 46 RED and 10 GREEN. The GREEN ones are named in
-# `R1_INVARIANT_GUARDS` (here) and `R1_INVARIANT_GUARDS` in
-# `test_find_session_live.py`; none of them is evidence a bug was fixed.
+# 🔴 WHICH OF THESE IS REGRESSION COVERAGE. MEASURED at NODE level (params
+# counted individually), by collecting both files at both shas and running the
+# head tests against base source: **66 new nodes across the two files, 46 RED
+# and 20 GREEN at a6f09d5a.**
 #
-# ⚠ ONE FINDING IN THIS ROUND WAS A GUARD GAP, NOT A CODE DEFECT. The span guard
-# (`test_a_term_may_not_SPAN_two_fields`, widened above) passes at a6f09d5a in
-# both its old and new forms, because `row_matches` was already per-field — the
-# auditor's space-joined MUTANT is what the old spelling could not see. Its
-# evidence is the mutation sweep (N27/N28), not a red-at-tip run.
+# ⚠ AN EARLIER REVISION OF THIS PARAGRAPH SAID "56 nodes … 10 GREEN", AND ITS
+# COMPLETENESS SENTENCE WAS FALSE. The red count was exact; the node and green
+# counts were taken from a FUNCTION-level sweep that skipped `parametrize`
+# expansion and skipped functions whose NAME already existed at base. The 10
+# it missed were the 8 `test_a_term_may_not_SPAN_two_fields[…]` params (green at
+# base — disclosed in prose, absent from the machine ledger) and the 2
+# `test_the_R1_invariant_guard_ledger_names_only_tests_that_exist` nodes. A
+# ledger whose sentence claims to name every green while naming 10 of 20 is the
+# "description wider than the implementation" shape both of round 1's blockers
+# had.
+#
+# So the parametrised entries are now DERIVED from the same tuple the
+# `parametrize` reads (`SPAN_SEPARATORS`), not retyped: adding a separator
+# extends the ledger automatically and cannot drift from the test it counts.
+#
+# ⚠ ONE FINDING IN ROUND 1 WAS A GUARD GAP, NOT A CODE DEFECT. The span guard
+# passes at a6f09d5a in both its old and new forms, because `row_matches` was
+# already per-field — the auditor's space-joined MUTANT is what the old spelling
+# could not see. Its evidence is the mutation sweep (N27/N28), not a red-at-tip
+# run. That is why all 8 of its params are GREEN below.
 # =========================================================================== #
 R1_INVARIANT_GUARDS = frozenset({
     # A partially reachable fleet already published real counts; R1-5 is only
@@ -10963,16 +10982,46 @@ R1_INVARIANT_GUARDS = frozenset({
     "test_the_scratch3_fixture_really_has_BOTH_windows_before_any_filter",
     # The positive control for the span battery.
     "test_the_span_fixture_matches_each_field_ALONE",
-    # 🔴 The PRECONDITION that replaced an unreachable guard — see its docstring.
-    # It held at a6f09d5a too; pinning it is what makes removing the guard safe.
-    "test_an_unreachable_host_carries_NO_rows_which_is_what_makes_the_maps_safe",
+    # This ledger's own gate — it has no behaviour to regress.
+    "test_the_R1_invariant_guard_ledger_names_only_tests_that_exist",
+}) | {
+    # 🔴 DERIVED, not retyped. See the paragraph above: these 8 were green at
+    # base and missing from the hand-written ledger.
+    f"test_a_term_may_not_SPAN_two_fields[{ident}]" for ident, _ in SPAN_SEPARATORS
+}
+
+# 🔴 RED AT BASE FOR A HARNESS REASON, NOT A BEHAVIOURAL ONE — a THIRD category,
+# because calling these regression coverage overstates it and calling them
+# invariant guards contradicts the measurement.
+#
+# `test_the_prefilter_map_excludes_hosts_that_never_answered` counts RED at
+# a6f09d5a only because the `prefilter_index_map` kwarg did not exist there, so
+# `gather` raised `TypeError` before any assertion ran. Its own docstring calls
+# it an invariant guard, and that is the truthful description of what it PINS;
+# the red is an artefact of a new parameter name. Both statements are true and
+# the disagreement between them was worth reconciling rather than picking one.
+R1_RED_ONLY_BECAUSE_A_SYMBOL_IS_NEW = frozenset({
+    "test_the_prefilter_map_excludes_hosts_that_never_answered",
 })
 
 
-def test_the_R1_invariant_guard_ledger_names_only_tests_that_exist():
-    for name in R1_INVARIANT_GUARDS:
-        assert name in globals(), (
-            f"{name!r} is listed as an R1 invariant guard but no such test exists")
+@pytest.mark.parametrize("ledger,label", [
+    (R1_INVARIANT_GUARDS, "R1_INVARIANT_GUARDS"),
+    (R1_RED_ONLY_BECAUSE_A_SYMBOL_IS_NEW, "R1_RED_ONLY_BECAUSE_A_SYMBOL_IS_NEW"),
+], ids=["invariant-guards", "harness-red"])
+def test_the_R1_invariant_guard_ledger_names_only_tests_that_exist(ledger, label):
+    """Every ledger entry must resolve to a real test — a name that does not is
+    a claim about coverage that nothing backs.
+
+    Parametrised node ids (`name[param]`) are checked on their FUNCTION half;
+    the param half is derived from the same tuple the `parametrize` reads, so it
+    cannot name an id that does not exist.
+    """
+    assert ledger, f"{label} is empty — the gate is wired to nothing"
+    for entry in ledger:
+        func = entry.split("[", 1)[0]
+        assert func in globals(), (
+            f"{entry!r} is listed in {label} but no such test exists")
 
 
 def scratch3_detail(target_index, **kw):
@@ -11081,29 +11130,58 @@ def test_the_prefilter_map_is_OPT_IN_so_a_match_scan_does_not_carry_it():
         "filters"]["prefilter_window_indices"] is None
 
 
-def test_an_unreachable_host_carries_NO_rows_which_is_what_makes_the_maps_safe():
-    """🔴 THE PRECONDITION, PINNED — because the guard for it was UNREACHABLE.
+@pytest.mark.parametrize("kw,label", [
+    (dict(remote_rc=255, remote_err="ssh: no route"), "ssh-failure"),
+    (dict(remote_rc=1, remote_err="tmux: connection failed"), "tmux-failure"),
+    (dict(remote_rc=127, remote_err="command not found: tmux"), "no-tmux-binary"),
+], ids=["ssh-failure", "tmux-failure", "no-tmux-binary"])
+def test_an_unreachable_host_carries_NO_rows_which_is_what_makes_the_maps_safe(
+        kw, label):
+    """🔴 THE PRECONDITION, PINNED — AND WHAT THIS CAN AND CANNOT SEE.
 
     Both the pre-filter index map and `filter_report`'s row-derived fallback
-    must not let a host that never answered contribute a measured presence or
-    absence of window indices. `gather` gives an unreachable host `windows: []`,
-    so neither loop can see one — which a mutation sweep confirmed by deleting
-    the `entry["reachable"]` clause from the map and changing NO test. A guard
-    that cannot fire reads as a defence and is not one, so it was removed and
-    the property it depended on is asserted here instead, where a change to
-    `gather` really would red.
+    rely on a host that never answered contributing no window indices. This
+    asserts that PROPERTY across three unreachable modes.
+
+    🔴 IT DOES **NOT** PIN ANY ONE ENFORCEMENT OF IT, and an earlier revision of
+    this docstring claimed it did ("where a change to `gather` really would
+    red"). That sentence was false. The property is OVER-DETERMINED: `run_tmux`
+    returns `stdout: ""` on every unreachable path so `fold_windows` yields no
+    rows, AND `gather`'s population loop skips a host that did not answer. An
+    audit deleted the second and all 649 tests stayed green — correctly, because
+    the first still held. So this is an INVARIANT guard on the property; it
+    cannot attribute the property to a mechanism, and a green run here is not
+    licence to delete the remaining enforcement.
+
+    What it does catch is the property actually breaking — e.g. a `gather` that
+    marks an unreachable host `reachable` (mutant N10), or any future path that
+    populates rows for a host with no answer.
     """
     runner = make_runner(local_panes=SCRATCH3_PANES,
-                         local_windows=SCRATCH3_WINDOWS,
-                         remote_rc=255, remote_err="ssh: no route")
+                         local_windows=SCRATCH3_WINDOWS, **kw)
     got = base_gather(runner=runner, use_fuzzyclaw=False)
-    assert got["hosts"]["laptop"]["reachable"] is False
-    assert got["hosts"]["laptop"]["windows"] == [], (
-        "an unreachable host carries rows — the pre-filter index map and "
-        "`filter_report`'s sibling fallback both rely on this being impossible")
-    # positive control: the REACHABLE host in the same scan does carry rows, so
+    # THE INVARIANT, over every host rather than one named one: no row may exist
+    # for any host that did not answer.
+    #
+    # 🔴 THE OBSERVATION IS MATERIALISED BEFORE IT IS JUDGED, so an empty sweep
+    # cannot pass. A mutation sweep caught the earlier `for name in unreachable:`
+    # form SURVIVING a `[:0]` slice — the loop body never ran and every other
+    # assertion in the test still held, which is a guard that reads as coverage
+    # while executing nothing.
+    unreachable = [n for n, h in got["hosts"].items() if not h.get("reachable")]
+    assert unreachable, f"fixture {label}: no host went unreachable"
+    observed = {n: got["hosts"][n]["windows"] for n in unreachable}
+    assert len(observed) == len(unreachable) >= 1, (
+        "the sweep visited fewer hosts than it claimed to")
+    for name, windows in observed.items():
+        assert windows == [], (
+            f"unreachable host {name} carries rows — the pre-filter index map "
+            "and `filter_report`'s sibling fallback both rely on this being "
+            "impossible")
+    # positive control: a REACHABLE host in the same scan does carry rows, so
     # the assertion above is not observing an empty scan.
-    assert got["hosts"]["workbench"]["windows"]
+    assert any(got["hosts"][n]["windows"] for n in got["hosts"]
+               if n not in unreachable)
 
 
 def test_the_prefilter_map_excludes_hosts_that_never_answered():
@@ -11263,4 +11341,97 @@ def test_the_active_row_filter_list_is_ONE_definition():
     assert sm._active_row_filters({"match": ["a", "b"]}) == ["--match 'a' 'b'"]
     assert sm._active_row_filters(
         {"claude_only": True, "match": ["a"]}) == ["--claude-only", "--match 'a'"]
+
+
+# =========================================================================== #
+# §16 — AUDIT FIX ROUND 2 (against tip 9f9dcbde), session-manager half
+#
+#   R2-F5  `test_an_unreachable_host_carries_NO_rows_…` claimed to pin an
+#          invariant "where a change to `gather` really would red". It does not:
+#          the property is OVER-DETERMINED — `run_tmux` returns empty stdout on
+#          every unreachable path AND the population loop skips such a host — so
+#          an audit deleted the second enforcement and all 649 tests stayed
+#          green, correctly. The CODE was never weakened; the SENTENCE was
+#          wider than its assertion, which is the shape of both round-0
+#          blockers. The docstring now says what it can and cannot see, and the
+#          assertion is widened to the property across three unreachable modes
+#          and EVERY host rather than one named one.
+#   R2-F4  The node ledger said 56 nodes / 10 green; the measurement is 66 / 20.
+#          The parametrised entries are DERIVED from `SPAN_SEPARATORS` now.
+# =========================================================================== #
+
+# 🔴 MEASURED AT NODE LEVEL against 9f9dcbde — 29 NEW nodes across the two
+# files, 16 RED and 13 GREEN. EIGHT of the green are from THIS file. They are
+# all controls or prose/ledger guards; none is evidence a bug was fixed.
+#
+# ⚠ `test_the_unreachable_host_precondition_docstring_does_not_OVERCLAIM` is
+# green at EVERY sha BY CONSTRUCTION: the artifact it inspects is a docstring in
+# THIS file, so a run against older SOURCE still reads the new prose. It pins
+# that a retracted overclaim stays retracted; it can never be red-at-base and is
+# not offered as regression coverage.
+R2_INVARIANT_GUARDS = frozenset({
+    # The precondition itself held at 9f9dcbde — F5 was about the SENTENCE, not
+    # the property. All three unreachable modes are green there.
+    *(f"test_an_unreachable_host_carries_NO_rows_which_is_what_makes_the_maps_safe[{i}]"
+      for i in ("ssh-failure", "tmux-failure", "no-tmux-binary")),
+    # Ledger gates and prose guards — structural, no behaviour to regress.
+    "test_the_R1_invariant_guard_ledger_names_only_tests_that_exist",
+    "test_the_R1_ledgers_do_not_OVERLAP",
+    "test_the_span_ledger_entries_are_DERIVED_from_the_parametrize_source",
+    "test_the_unreachable_host_precondition_docstring_does_not_OVERCLAIM",
+})
+
+
+def test_the_R2_ledger_names_only_tests_that_exist():
+    assert R2_INVARIANT_GUARDS, "the ledger is empty — the gate is wired to nothing"
+    for entry in R2_INVARIANT_GUARDS:
+        assert entry.split("[", 1)[0] in globals(), (
+            f"{entry!r} is listed as an R2 invariant guard but no such test exists")
+
+
+def test_the_R1_ledgers_do_not_OVERLAP():
+    """A test cannot be both an invariant guard and red-only-for-a-symbol. The
+    two ledgers partition; an entry in both would make either claim unfalsifiable."""
+    assert not (R1_INVARIANT_GUARDS & R1_RED_ONLY_BECAUSE_A_SYMBOL_IS_NEW)
+
+
+def test_the_span_ledger_entries_are_DERIVED_from_the_parametrize_source():
+    """🔴 R2-F4, structurally. The 8 span params were green at base and absent
+    from the hand-written ledger while its sentence claimed to name every green.
+    Deriving them from the SAME tuple the `parametrize` reads is what stops the
+    two drifting again — this pins that they still are derived, and that the
+    count matches."""
+    span = {e for e in R1_INVARIANT_GUARDS
+            if e.startswith("test_a_term_may_not_SPAN_two_fields[")}
+    assert len(span) == len(SPAN_SEPARATORS) == 8
+    assert span == {f"test_a_term_may_not_SPAN_two_fields[{i}]"
+                    for i, _ in SPAN_SEPARATORS}
+    # ...and the ids really are the ones pytest will generate: no duplicates,
+    # and each separator distinct, so a param cannot silently collapse.
+    idents = [i for i, _ in SPAN_SEPARATORS]
+    assert len(set(idents)) == len(idents)
+    assert len({s for _, s in SPAN_SEPARATORS}) == len(SPAN_SEPARATORS)
+
+
+def test_the_unreachable_host_precondition_docstring_does_not_OVERCLAIM():
+    """🔴 R2-F5 AS A PROSE GUARD. The retracted sentence promised that a change
+    to `gather` "really would red" — it does not, because the property is
+    double-enforced. A docstring wider than its assertion is what this whole PR
+    keeps being audited for, so the retraction is pinned rather than trusted.
+    """
+    doc = test_an_unreachable_host_carries_NO_rows_which_is_what_makes_the_maps_safe.__doc__
+    assert "OVER-DETERMINED" in doc
+    assert "cannot attribute the property to a mechanism" in doc
+    assert "where a change to `gather` really would red" not in doc, (
+        "the retracted overclaim is back in the docstring")
+
+
+def test_the_gather_comment_names_BOTH_enforcements_of_the_precondition():
+    """A maintainer reading only `gather` must not conclude a red gate protects
+    the second enforcement. The comment names both mechanisms and says deleting
+    both is undetected."""
+    import inspect
+    src = inspect.getsource(sm.gather)
+    assert "OVER-DETERMINED" in src
+    assert "do not read a green suite as licence to delete" in src.lower()
 

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -10963,25 +10963,22 @@ def test_detail_json_is_the_FULL_REPORT_SHAPE_not_a_bare_window(monkeypatch,
 #         was read by nothing.
 #   R1-7  The span guard was spelled to a zero-separator join (fixed above).
 #
-# 🔴 WHICH OF THESE IS REGRESSION COVERAGE. MEASURED at NODE level (params
-# counted individually), by collecting both files at both shas and running the
-# head tests against base source: **66 new nodes across the two files, 46 RED
-# and 20 GREEN at a6f09d5a.**
+# 🔴 WHICH OF THESE IS REGRESSION COVERAGE. The GREEN-at-base ones are named in
+# `R1_INVARIANT_GUARDS` below; a test asserts every name resolves, and the
+# parametrised entries are DERIVED from the same tuple the `parametrize` reads
+# (`SPAN_SEPARATORS`) so adding a separator extends the ledger automatically.
 #
-# ⚠ AN EARLIER REVISION OF THIS PARAGRAPH SAID "56 nodes … 10 GREEN", AND ITS
-# COMPLETENESS SENTENCE WAS FALSE. The red count was exact; the node and green
-# counts were taken from a FUNCTION-level sweep that skipped `parametrize`
-# expansion and skipped functions whose NAME already existed at base. The 10
-# it missed were the 8 `test_a_term_may_not_SPAN_two_fields[…]` params (green at
-# base — disclosed in prose, absent from the machine ledger) and the 2
-# `test_the_R1_invariant_guard_ledger_names_only_tests_that_exist` nodes. A
-# ledger whose sentence claims to name every green while naming 10 of 20 is the
-# "description wider than the implementation" shape both of round 1's blockers
-# had.
+# ⚠ NO NODE COUNTS, DELIBERATELY. This paragraph carried "56 nodes … 10 GREEN",
+# then "66 … 20 GREEN"; the §15 section carried "29 … 13 GREEN". All three were
+# measured wrong — the first by a function-level sweep that skipped
+# `parametrize` expansion and same-named-but-modified tests, the last because a
+# fix later in the SAME commit added five nodes after the number was typed.
 #
-# So the parametrised entries are now DERIVED from the same tuple the
-# `parametrize` reads (`SPAN_SEPARATORS`), not retyped: adding a separator
-# extends the ledger automatically and cannot drift from the test it counts.
+# A count the next commit invalidates is a claim nothing enforces — the class
+# three consecutive audit rounds kept finding. It cannot be derived at test time
+# (it needs the head tests run against an OLD sha), so it is DELETED rather than
+# corrected: understated coverage that reads as precise is worse than no number.
+# The per-round matrices live in the PR body with their sha and method.
 #
 # ⚠ ONE FINDING IN ROUND 1 WAS A GUARD GAP, NOT A CODE DEFECT. The span guard
 # passes at a6f09d5a in both its old and new forms, because `row_matches` was
@@ -11371,13 +11368,15 @@ def test_the_active_row_filter_list_is_ONE_definition():
 #          blockers. The docstring now says what it can and cannot see, and the
 #          assertion is widened to the property across three unreachable modes
 #          and EVERY host rather than one named one.
-#   R2-F4  The node ledger said 56 nodes / 10 green; the measurement is 66 / 20.
-#          The parametrised entries are DERIVED from `SPAN_SEPARATORS` now.
+#   R2-F4  The node ledger's counts were wrong. They are DELETED now rather than
+#          corrected (a third correction would have been the third wrong
+#          number); the parametrised ledger entries are DERIVED from
+#          `SPAN_SEPARATORS`.
 # =========================================================================== #
 
-# 🔴 MEASURED AT NODE LEVEL against 9f9dcbde — 29 NEW nodes across the two
-# files, 16 RED and 13 GREEN. EIGHT of the green are from THIS file. They are
-# all controls or prose/ledger guards; none is evidence a bug was fixed.
+# 🔴 The GREEN-at-9f9dcbde ones from THIS file are named below. They are all
+# controls or prose/ledger guards; none is evidence a bug was fixed. No counts —
+# see the note above `R1_INVARIANT_GUARDS`.
 #
 # ⚠ `test_the_unreachable_host_precondition_docstring_does_not_OVERCLAIM` is
 # green at EVERY sha BY CONSTRUCTION: the artifact it inspects is a docstring in

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -1741,6 +1741,12 @@ def test_json_golden_schema_and_values():
         # fixture's, not the real table's — pinned so a hardcoded map cannot
         # satisfy it.
         "hotkey": "S",
+        # 🔴 ...and the CHORD, derived from it in one place. `S` is UPPERCASE in
+        # this fixture, so the shifted spelling is the correct one — and the
+        # lower-case sibling (`Alt+v` from `v`) is pinned separately, because a
+        # single-case golden cannot tell `f"Alt+Shift+{k}"` from a function that
+        # returns the shifted form unconditionally.
+        "hotkey_display": "Alt+Shift+S",
         "pane_id": "%11",
         "path": "/home/zach/workspace/repo-alpha",
         "command": "claude",
@@ -1826,6 +1832,13 @@ def test_json_golden_schema_and_values():
         "claude_only": False,
         "excluded_shells": None,
         "kinds_excluded_by_filter": None,
+        # 🔴 The `--match` trio under the SAME null-not-zero rule: no filter was
+        # asked for, so the terms are null (never `[]`), the field list is null
+        # (never the default tuple — publishing it would assert a search that
+        # never ran) and the excluded count is null, never `0`.
+        "match": None,
+        "match_fields": None,
+        "excluded_by_match": None,
         "hosts_reachable": ["laptop", "workbench"],
         "hosts_unreachable": [],
         "fuzzyclaw_live": 1,
@@ -4685,7 +4698,13 @@ def test_main_json_end_to_end_carries_the_split_and_the_filter(
     assert blob["filters"] == {"claude_only": True, "excluded_shells": 2,
                                # the filter RAN and removed no whole kind —
                                # `[]`, not None, and not absent
-                               "kinds_excluded_by_filter": []}
+                               "kinds_excluded_by_filter": [],
+                               # 🔴 ...and the OTHER row filter did NOT run, so
+                               # every one of its keys is null. `matched: 0`
+                               # here would say "a --match ran and matched
+                               # nothing" over a scan that returned two rows.
+                               "match": None, "match_fields": None,
+                               "matched": None, "excluded_by_match": None}
 
 
 def test_detail_under_claude_only_explains_its_own_emptiness(monkeypatch):
@@ -6501,7 +6520,13 @@ def test_the_row_FIELD_LEDGER_fails_when_it_grows_or_shrinks():
     expected = {
         "kind",
         "host", "session", "window_index", "window_id", "window_name",
-        "codename", "label", "label_source", "hotkey", "pane_id", "path",
+        "codename", "label", "label_source", "hotkey",
+        # 🔴 The DERIVED chord, riding with `hotkey` for the same reason
+        # `label_source` rides with `label`. The raw key alone left the
+        # `v`-vs-`V` case rule in the CONSUMER's head, and a consumer performed
+        # it wrong against a live fleet — see `sm.hotkey_display`.
+        "hotkey_display",
+        "pane_id", "path",
         "command",
         "task", "claude", "busy", "age_secs", "age_source", "status",
         "waiting_probable", "waiting_signals", "waiting_status",
@@ -7068,6 +7093,11 @@ def test_the_LEAN_row_field_ledger_fails_when_it_grows_or_shrinks():
     assert set(sm.LEAN_ROW_FIELDS) == {
         "kind",
         "host", "session", "window_index", "label", "label_source", "hotkey",
+        # 🔴 The chord, derived ONCE. This is the AGENT-shaped view, and the
+        # agent is exactly the reader that rendered `hotkey: v` as
+        # `Alt+Shift+V`; dropping it here puts the derivation back where it
+        # already failed.
+        "hotkey_display",
         "path", "task", "runtime", "claude", "busy", "status", "age_secs",
         "age_source",
         "waiting_probable", "waiting_signals", "waiting_status",
@@ -10245,4 +10275,621 @@ def test_measured_not_measured_is_PURE_and_shares_nothing_with_the_constant():
         entry["owner_skill"] = "clobbered"
     assert sm.NOT_MEASURED_POPULATIONS == before
     assert sm.measured_not_measured({})[0]["note"] != "clobbered"
+
+
+# =========================================================================== #
+# §14 — LIVE-FIRST LOOKUP: `hotkey_display`, `--match`, and the LOUD detail miss
+#
+# 🔴 THE THREE DEFECTS THIS SECTION PINS, all measured on one real run
+# (2026-08-28, "find this thing I lost track of"): 127 s, 9 tool calls, 5 of
+# them pure flailing.
+#
+#   1. `detail <addr>` that matched NOTHING returned a silent empty window list
+#      — byte-identical to "found it, the window is idle". The run guessed index
+#      `3` from the session name `scratch3`; the real index was `2`, and nothing
+#      said so. (`test_a_detail_miss_*`)
+#   2. The row carried `hotkey: v` and the answer rendered `Alt+Shift+V`. Per
+#      `scripts/tmux-scratch-slots.sh`, `M-v` is scratch3/violet and `M-V` is
+#      scratch4/Vapor — DIFFERENT sessions, so the operator was sent to a real
+#      window that was the wrong one. (`test_hotkey_display_*`)
+#   3. There was no way to ask the live scan "which window is about X", so the
+#      30 s transcript archive was used for a question about NOW. (`test_match_*`)
+#
+# 🔴 WHICH OF THESE ARE REGRESSION COVERAGE. Everything below was watched RED at
+# 9e452d34 EXCEPT the tests named in `INVARIANT_GUARDS_ADDED_HERE`, which pin
+# behaviour the pre-change tree already had. They are listed rather than left to
+# be assumed, because counting an invariant guard as a fixed bug is how a suite
+# claims coverage it does not have.
+# =========================================================================== #
+#
+# MEASURED, not asserted: replayed against a detached worktree at 9e452d34 with
+# this exact file copied in — 45 collected §14 nodes, 38 RED and 7 GREEN. The 7
+# are precisely the set below.
+INVARIANT_GUARDS_ADDED_HERE = frozenset({
+    # `exit_code_for` already returned EXIT_EMPTY for a detail miss over a
+    # reachable fleet, and EXIT_UNAVAILABLE when nothing answered. What was
+    # missing was the MESSAGE and the structured count, not the code. Pinned so
+    # a later refactor of the miss path cannot quietly fold the two together.
+    "test_the_detail_exit_CODES_were_already_right_and_stay_right",
+    # `render_label` is UNCHANGED by this work. This asserts it stayed that way.
+    "test_render_label_states_the_KEY_and_never_a_CHORD",
+    # `filter_report` already copied the report before narrowing it; the new
+    # `detail_*` bookkeeping is what could have broken that.
+    "test_filter_report_does_not_MUTATE_the_report_it_narrows",
+    # A POSITIVE CONTROL on the `--match` fixture, not a bug: it asserts the
+    # UNFILTERED shape, so it passes wherever `fold_windows` works. Without it a
+    # `0 rows` verdict below could not be told from a fixture that built none.
+    "test_the_match_fixture_produces_the_rows_the_probes_below_assume",
+    # A NEGATIVE control on the miss message: a `detail` that FINDS its window
+    # printed nothing before this change and prints nothing after it.
+    "test_main_detail_HIT_prints_no_miss_line",
+    # This ledger's own gate.
+    "test_the_invariant_guard_ledger_names_only_tests_that_exist",
+    # `detail --json` always returned the full report shape; the observed run
+    # assumed otherwise. Pinning a shape that was always right is not a fix —
+    # it is what makes the reference doc's new claim machine-checked.
+    "test_detail_json_is_the_FULL_REPORT_SHAPE_not_a_bare_window",
+})
+
+
+def test_the_invariant_guard_ledger_names_only_tests_that_exist():
+    """A ledger that names a deleted test asserts nothing while reading as if it
+    does. Both directions are not available here (a regression test is not
+    enumerated), so at minimum every name must resolve."""
+    for name in INVARIANT_GUARDS_ADDED_HERE:
+        assert name in globals(), (
+            f"{name!r} is listed as an invariant guard but no such test exists")
+
+
+# --------------------------------------------------------------------------- #
+# hotkey_display — ONE writer for a chord whose CASE selects the session
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("key,expect", [
+    ("v", "Alt+v"),
+    ("V", "Alt+Shift+V"),
+    # A second letter, so a mutant that hardcodes the `v`/`V` pair dies. The
+    # fixture letters are pairwise distinct from each other AND from every
+    # letter the assertions elsewhere in this file name.
+    ("q", "Alt+q"),
+    ("Q", "Alt+Shift+Q"),
+    # Neither upper nor lower: `bind -n M-7` needs no Shift.
+    ("7", "Alt+7"),
+    # 🔴 `resolve_label` returns None on tiers 2 and 3 and that is load-bearing.
+    (None, None),
+    # ...and "" must NOT become `Alt+`, which would read as a real chord.
+    ("", None),
+])
+def test_hotkey_display_maps_CASE_to_the_shift_modifier(key, expect):
+    assert sm.hotkey_display(key) == expect
+
+
+def test_the_two_CASES_of_one_letter_are_DIFFERENT_CHORDS():
+    """🔴 THE DEFECT, stated as the thing that must not be true again.
+
+    Both cases are asserted AND asserted to DIFFER. A mutant that returns
+    `f"Alt+Shift+{k}"` unconditionally, or that normalises the key's case,
+    satisfies exactly one of the first two lines and fails the third.
+    """
+    lower, upper = sm.hotkey_display("v"), sm.hotkey_display("V")
+    assert lower == "Alt+v"
+    assert upper == "Alt+Shift+V"
+    assert lower != upper, (
+        "the two cases collapsed to one chord — `M-v` is scratch3/violet and "
+        "`M-V` is scratch4/Vapor, so this sends the operator to the wrong "
+        "live window")
+    # ...and the case is PRESERVED, not normalised: `Alt+V` (no Shift) and
+    # `Alt+Shift+v` are each a chord bound to nothing.
+    assert "Alt+V" not in lower and upper != "Alt+Shift+v"
+
+
+def test_the_case_significance_is_READ_OUT_OF_the_slot_table_not_asserted_here():
+    """🔴 A SEAM guard: "case selects a different session" is a fact about
+    `scripts/tmux-scratch-slots.sh`, and this reads it there.
+
+    A hand-written pair here would agree with the table today and drift the
+    first time a slot is rekeyed — the same reason
+    `test_the_hotkey_comes_from_the_SLOT_TABLE_not_a_second_map` reads its
+    expectation out of the table text rather than restating it.
+    """
+    table = os.path.normpath(os.path.join(_HERE, "..", "tmux-scratch-slots.sh"))
+    slots = sm.load_scratch_slots(paths=[table])
+    assert slots, "positive control: the real slot table parsed as EMPTY"
+    by_key = {}
+    for session, entry in slots.items():
+        by_key.setdefault(entry["key"], []).append(session)
+    pairs = [(k, k.upper()) for k in sorted(by_key)
+             if k.islower() and k.upper() in by_key]
+    assert pairs, (
+        "no lower/upper key pair exists in the slot table any more, so the case "
+        "rule `hotkey_display` encodes is no longer load-bearing — re-justify "
+        "the function or delete it; do not leave this test asserting a dead fact")
+    for lo, up in pairs:
+        assert by_key[lo] != by_key[up], (
+            f"{lo!r} and {up!r} map to the same session, so case selects nothing")
+        assert sm.hotkey_display(lo) != sm.hotkey_display(up)
+
+
+def test_hotkey_display_is_None_on_the_TIERS_THAT_HAVE_NO_KEY():
+    """Tiers 2 and 3 carry `hotkey: None`; the derived chord must be None too —
+    never `""`, never invented."""
+    rows = sm.fold_windows(
+        sm.parse_panes("%91|9001|no-slot-here|1|w-n|/w/synth-juliet|zsh|title"),
+        "workbench", slots={}, now=NOW)
+    assert rows[0]["label_source"] == "path"
+    assert rows[0]["hotkey"] is None
+    assert rows[0]["hotkey_display"] is None
+
+
+def test_hotkey_display_rides_on_every_row_and_in_the_LEAN_view():
+    """The derivation is performed ONCE, by the producer — so the consumer that
+    got it wrong never has to perform it at all."""
+    report = base_gather()
+    rows = [r for h in report["hosts"].values() for r in h["windows"]]
+    assert rows, "positive control: the fixture must produce rows"
+    for r in rows:
+        assert r["hotkey_display"] == sm.hotkey_display(r["hotkey"])
+    assert "hotkey_display" in sm.LEAN_ROW_FIELDS
+    lean = sm.lean_report(report)
+    for r in [x for h in lean["hosts"].values() for x in h["windows"]]:
+        assert "hotkey_display" in r
+
+
+def test_render_label_states_the_KEY_and_never_a_CHORD():
+    """INVARIANT GUARD — `render_label` is deliberately NOT routed through
+    `hotkey_display`, and this pins the two surfaces apart.
+
+    The LABEL column is 14 characters (`_trunc(render_label(r), 14)`), and
+    `Yarrow (Alt+Shift+Y)` is 20 — routing it through would produce a truncated
+    stub MORE ambiguous than the raw key, not less. So the table states the key
+    with its case intact and the chord travels on the row.
+    """
+    assert sm.render_label({"label": "violet", "hotkey": "v"}) == "violet (v)"
+    assert sm.render_label({"label": "Vapor", "hotkey": "V"}) == "Vapor (V)"
+    for row in ({"label": "violet", "hotkey": "v"},
+                {"label": "Vapor", "hotkey": "V"}):
+        assert "Alt+" not in sm.render_label(row), (
+            "the table started spelling a chord; if that is deliberate, check "
+            "the 14-char LABEL column still fits it before changing this test")
+    assert len(sm.render_label({"label": "Yarrow", "hotkey": "Y"})) <= 14
+
+
+# --------------------------------------------------------------------------- #
+# --match — the FIELD SET is the feature, and `path` is not in it
+# --------------------------------------------------------------------------- #
+# 🔴 THE FIXTURE IS THE `29 of 72` SHAPE AT THREE-ROW SCALE. Both non-slot
+# windows sit under the same `zzpapaya` directory and neither one's LABEL or
+# TASK says that word (their labels are the deeper leaves `zzsigma`/`zztheta`):
+#
+#   `zzkiwi`    -> 1 row  (a task, and only one of them)
+#   `zzsigma`   -> 1 row  (a label)
+#   `zzpapaya`  -> 0 rows by default, 2 rows under --match-path
+#
+# Every token is pairwise distinct and none appears in any constant the
+# assertions name, so a mutant that hardcodes a field name or a literal cannot
+# survive by coincidence.
+MATCH_PANES = "\n".join([
+    f"%31|3001|match-one|1|w-one|/home/zach/workspace/zzpapaya/zzsigma|claude"
+    f"|{BRAILLE} refactor the zzkiwi cache",
+    f"%32|3002|match-two|4|w-two|/home/zach/workspace/zzpapaya/zztheta|claude"
+    f"|{SPARKLE} unrelated zzmango work",
+    # A slot session, so `codename` is populated and tier 1 is exercised.
+    f"%33|3003|scratch2|9|w-three|/home/zach/tmp|claude|{SPARKLE} third thing",
+])
+MATCH_WINDOWS = "@31|1|match-one\n@32|4|match-two\n@33|9|scratch2\n"
+
+
+def match_gather(**kw):
+    """`base_gather` over MATCH_PANES, with an EMPTY but REACHABLE laptop.
+
+    Reachable-and-empty rather than absent: every exit-code assertion below
+    depends on "the fleet answered", and a fixture that could not tell that from
+    "the fleet is down" would grade the wrong thing.
+    """
+    defaults = dict(
+        runner=make_runner(local_panes=MATCH_PANES,
+                           local_windows=MATCH_WINDOWS,
+                           remote_panes="", remote_windows=""),
+        use_fuzzyclaw=False)
+    defaults.update(kw)
+    return base_gather(**defaults)
+
+
+def _sessions(report):
+    return sorted(r["session"] for h in report["hosts"].values()
+                  for r in h["windows"])
+
+
+def test_the_match_fixture_produces_the_rows_the_probes_below_assume():
+    """POSITIVE CONTROL on the instrument, before any of its verdicts.
+
+    A zero from `--match` is indistinguishable from a zero produced by a fixture
+    that never built the rows. This asserts the unfiltered shape — three rows,
+    the labels the path leaves give them, the codename tier 1 supplies, and that
+    the shared path segment appears in NO other matched field.
+    """
+    rows = {r["session"]: r for h in match_gather()["hosts"].values()
+            for r in h["windows"]}
+    assert sorted(rows) == ["match-one", "match-two", "scratch2"]
+    assert rows["match-one"]["label"] == "zzsigma"
+    assert rows["match-two"]["label"] == "zztheta"
+    assert rows["scratch2"]["codename"] == "Vapor"
+    for r in rows.values():
+        assert "zzpapaya" not in (r["task"] or "")
+        assert "zzpapaya" not in (r["label"] or "")
+        assert "zzpapaya" not in (r["codename"] or "")
+    assert sum("zzpapaya" in r["path"] for r in rows.values()) == 2
+
+
+def test_match_does_NOT_search_path_by_default():
+    """🔴 THE MEASUREMENT, AS A TEST. On the live fleet one query substring hit
+    1 of 72 rows on `task` and 29 of 72 on `path`, because nearly every window
+    shares a repo path. A filter whose answer is 40% of the fleet is the
+    unfiltered scan wearing a filter's authority."""
+    assert _sessions(match_gather(match=["zzpapaya"])) == []
+    assert "path" not in sm.match_fields()
+    assert sm.MATCH_FIELDS == ("task", "label", "codename")
+
+
+def test_match_path_ADDS_path_and_is_the_positive_control_for_the_zero_above():
+    """🔴 Without this, the `0 rows` above is indistinguishable from a filter
+    wired to nothing. Same term, same fixture, one flag — and the number moves
+    from 0 to 2."""
+    got = match_gather(match=["zzpapaya"], match_path=True)
+    assert _sessions(got) == ["match-one", "match-two"]
+    assert sm.match_fields(True) == ("task", "label", "codename", "path")
+    assert got["summary"]["match_fields"] == ["task", "label", "codename", "path"]
+
+
+@pytest.mark.parametrize("term,expect", [
+    ("zzkiwi", ["match-one"]),          # task
+    ("ZZKIWI", ["match-one"]),          # ...case-insensitively
+    ("zzsigma", ["match-one"]),         # label (tier 2, the cwd leaf)
+    ("zzmango", ["match-two"]),         # a DIFFERENT row's task
+    ("vapor", ["scratch2"]),            # tier-1 codename/label, lower-cased
+    ("zznothinghere", []),
+])
+def test_match_searches_task_label_and_codename(term, expect):
+    assert _sessions(match_gather(match=[term])) == expect
+
+
+def test_match_terms_are_ANDed_like_find_sessions_default():
+    """Two tools read as one instrument; an OR here against the archive's AND
+    would return different sets for the same words with nothing saying so."""
+    assert _sessions(match_gather(match=["zzkiwi"])) == ["match-one"]
+    assert _sessions(match_gather(match=["zzmango"])) == ["match-two"]
+    # Together they match nothing, because no row carries both.
+    assert _sessions(match_gather(match=["zzkiwi", "zzmango"])) == []
+    # A pair that DOES co-occur on one row still matches — across two DIFFERENT
+    # fields, which is the shape an OR-vs-AND mutant cannot fake.
+    assert _sessions(match_gather(match=["zzkiwi", "zzsigma"])) == ["match-one"]
+
+
+def test_row_matches_finds_a_CODENAME_that_disagrees_with_the_LABEL():
+    """🔴 STATED HONESTLY, AND NOT COUNTED AS REGRESSION COVERAGE.
+
+    On today's rows `label` EQUALS `codename` whenever a codename exists
+    (`resolve_label` tier 1 returns the codename AS the label), so `codename` in
+    `MATCH_FIELDS` adds no reach against production rows right now. It is in the
+    set so that a change to that precedence — a path label winning over a slot
+    name — cannot silently make a session unfindable by the name its hotkeys
+    use. This drives the predicate directly with a row where the two DISAGREE,
+    so the field is proven wired rather than assumed.
+    """
+    row = {"task": "zzalpha", "label": "zzbravo", "codename": "zzcharlie",
+           "path": "zzdelta"}
+    assert sm.row_matches(row, ["zzcharlie"]) is True
+    assert sm.row_matches(row, ["zzbravo"]) is True
+    assert sm.row_matches(row, ["zzalpha"]) is True
+    assert sm.row_matches(row, ["zzdelta"]) is False
+    assert sm.row_matches(row, ["zzdelta"], sm.match_fields(True)) is True
+
+
+def test_a_term_may_not_SPAN_two_fields():
+    """Joining the fields into one haystack would match text that exists in no
+    field — a hit no reader can explain."""
+    row = {"task": "abc", "label": "def", "codename": None, "path": None}
+    assert sm.row_matches(row, ["abc"]) is True
+    assert sm.row_matches(row, ["def"]) is True
+    assert sm.row_matches(row, ["abcdef"]) is False
+
+
+def test_an_EMPTY_term_list_matches_everything_rather_than_nothing():
+    """"No filter was requested" and "a filter that rejects the world" are
+    different facts. The CALLER decides whether a filter ran."""
+    assert sm.row_matches({"task": "anything"}, []) is True
+    got = match_gather(match=[])
+    assert len(_sessions(got)) == 3
+    assert got["filters"]["match"] is None
+    assert got["summary"]["excluded_by_match"] is None
+
+
+def test_every_count_and_caveat_describes_the_MATCHED_set():
+    """🔴 The rule `--claude-only` already follows: a filtered report may not
+    print a summary describing the unfiltered scan."""
+    got = match_gather(match=["zzkiwi"])
+    assert got["summary"]["total_sessions"] == 1
+    assert got["summary"]["claude"] == 1
+    assert sum(b["total"] for b in got["summary"]["status"].values()) == 1
+    assert got["summary"]["kind"] == {"tmux": 1}
+    assert got["summary"]["match"] == ["zzkiwi"]
+    assert got["summary"]["match_fields"] == ["task", "label", "codename"]
+    assert got["summary"]["excluded_by_match"] == 2
+    assert got["filters"]["matched"] == 1
+    # ...and the CAVEATS were RE-DERIVED, not inherited. When the filter removes
+    # every row, `kinds_produced` must be empty rather than still claiming
+    # `tmux` — the caveat line and the table it sits under cannot disagree.
+    empty = match_gather(match=["zznothinghere"])
+    assert empty["caveats"]["kind_scope"]["kinds_produced"] == []
+    assert empty["caveats"]["kind_scope"]["kinds_excluded_by_filter"] == ["tmux"]
+
+
+def test_match_and_claude_only_COMPOSE_and_share_one_kinds_excluded_answer():
+    """Two row filters over one row set, and ONE answer to "which whole kinds
+    did a filter remove" — computed across both rather than once per flag."""
+    got = match_gather(match=["zzkiwi"], claude_only=True)
+    assert _sessions(got) == ["match-one"]
+    assert got["filters"]["excluded_shells"] == 0     # every fixture row is claude
+    assert got["filters"]["excluded_by_match"] == 2
+    assert got["filters"]["kinds_excluded_by_filter"] == []
+
+
+def test_the_filters_key_says_a_filter_RAN_so_zero_rows_is_never_zero_windows():
+    """A consumer reading an empty row list must be able to tell "nothing
+    matched these words in these fields" from "the fleet has no windows"."""
+    got = match_gather(match=["zznothinghere"])
+    assert got["filters"]["match"] == ["zznothinghere"]
+    assert got["filters"]["match_fields"] == ["task", "label", "codename"]
+    assert got["filters"]["matched"] == 0
+    assert got["filters"]["excluded_by_match"] == 3
+    # ...and with NO filter every one of those is null, never 0/[].
+    unfiltered = match_gather()
+    for key in ("match", "match_fields", "matched", "excluded_by_match"):
+        assert unfiltered["filters"][key] is None, key
+
+
+def test_a_match_with_zero_hits_on_a_REACHABLE_fleet_is_EMPTY_not_OK():
+    """🔴 `EXIT_OK` here would tell a caller the scan succeeded AND found the
+    thing. The rows are gone; the hosts answered; that is EXIT_EMPTY."""
+    assert sm.exit_code_for(match_gather(match=["zznothinghere"])) == sm.EXIT_EMPTY
+    assert sm.exit_code_for(match_gather(match=["zzkiwi"])) == sm.EXIT_OK
+
+
+def test_a_match_with_zero_hits_on_an_UNREACHABLE_fleet_is_UNAVAILABLE():
+    """The zero is UNMEASURED there, and it must not read as a real zero."""
+    down = make_runner(local_rc=1, local_err="tmux: connection failed",
+                       remote_rc=255, remote_err="ssh: no route")
+    got = base_gather(runner=down, use_fuzzyclaw=False, match=["zzkiwi"])
+    assert sm.exit_code_for(got) == sm.EXIT_UNAVAILABLE
+
+
+def test_main_match_end_to_end_through_the_CLI(monkeypatch, capsys,
+                                               absent_blocked_cache):
+    """END-TO-END, because every test above injects `gather()`."""
+    monkeypatch.setattr(sm, "local_host_label", lambda *a, **k: "workbench")
+    monkeypatch.setattr(sm, "_default_runner",
+                        make_runner(local_panes=MATCH_PANES,
+                                    local_windows=MATCH_WINDOWS))
+    monkeypatch.setattr(sm, "read_fuzzyclaw_texts", lambda *a, **k: [])
+    rc = sm.main(["scan", "--json", "--no-ch", "--lean", "--host", "workbench",
+                  "--match", "zzkiwi"])
+    blob = json.loads(capsys.readouterr().out)
+    assert rc == sm.EXIT_OK
+    rows = [r for h in blob["hosts"].values() for r in h["windows"]]
+    assert [r["session"] for r in rows] == ["match-one"]
+    assert blob["filters"]["match"] == ["zzkiwi"]
+    assert blob["filters"]["match_fields"] == ["task", "label", "codename"]
+    assert blob["summary"]["excluded_by_match"] == 2
+    # the lean row carries the chord, which is what the live-first caller reads
+    assert "hotkey_display" in rows[0]
+
+    rc_empty = sm.main(["scan", "--json", "--no-ch", "--host", "workbench",
+                        "--match", "zznothinghere"])
+    capsys.readouterr()
+    assert rc_empty == sm.EXIT_EMPTY
+
+
+def test_the_TABLE_states_the_match_filter_and_the_fields_it_searched():
+    """An empty table under a `--match` is otherwise indistinguishable from an
+    empty fleet — and a reader who cannot see that `path` was excluded cannot
+    tell why their repo-shaped query found nothing."""
+    text = sm.render_table(match_gather(match=["zzkiwi"]))
+    assert "FILTER --match 'zzkiwi'" in text
+    assert "1 row(s) matched, 2 excluded" in text
+    assert "fields searched = task, label, codename" in text
+    # ...and no such line at all when no filter ran.
+    assert "FILTER --match" not in sm.render_table(match_gather())
+
+
+def test_match_has_no_effect_on_tail_and_SAYS_so(monkeypatch, capsys):
+    """A silently ignored flag is how a caller concludes it was honoured."""
+    monkeypatch.setattr(sm, "local_host_label", lambda *a, **k: "workbench")
+    monkeypatch.setattr(sm, "_default_runner", make_runner())
+    sm.main(["tail", "scratch7:3", "--host", "workbench", "--match", "zzkiwi"])
+    assert "no effect on `tail`" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------- #
+# detail — a miss must be LOUD, and must name the indices that DO exist
+# --------------------------------------------------------------------------- #
+# 🔴 THE OBSERVED FAILURE, REPRODUCED EXACTLY: a session named `scratch3` whose
+# real window index is `2`, asked for as `scratch3:3` because the reader took
+# the digit out of the session NAME.
+SCRATCH3_PANES = "\n".join([
+    "%41|4001|scratch3|1|w-a|/home/zach/workspace/zzsigma|zsh|a bare shell",
+    f"%42|4002|scratch3|2|w-b|/home/zach/workspace/zztheta|claude"
+    f"|{BRAILLE} the work that was lost track of",
+])
+SCRATCH3_WINDOWS = "@41|1|scratch3\n@42|2|scratch3\n"
+
+
+def scratch3_gather(**kw):
+    defaults = dict(
+        runner=make_runner(local_panes=SCRATCH3_PANES,
+                           local_windows=SCRATCH3_WINDOWS,
+                           remote_panes="", remote_windows=""),
+        use_fuzzyclaw=False)
+    defaults.update(kw)
+    return base_gather(**defaults)
+
+
+def test_a_detail_miss_NAMES_THE_INDICES_THAT_DO_EXIST():
+    """🔴 THE FIX FOR THE OBSERVED RUN. `scratch3:3` does not exist; `1` and `2`
+    do, and saying so is what turns a dead end into a next step."""
+    report = sm.filter_report(scratch3_gather(), "scratch3", "3")
+    msg = sm.detail_not_found_message(report)
+    assert msg is not None, "a miss returned NO message — the silent empty is back"
+    assert "NO SUCH WINDOW 'scratch3:3'" in msg
+    assert "session 'scratch3' has windows ['1', '2']" in msg
+    assert "you asked for index '3'" in msg
+    # ...and the same facts structurally, so a --json consumer never parses prose
+    assert report["filters"]["detail_target"] == "scratch3:3"
+    assert report["filters"]["detail_matched"] == 0
+    assert report["filters"]["detail_sibling_indices"] == ["1", "2"]
+
+
+def test_the_sibling_indices_are_sorted_NUMERICALLY_not_lexically():
+    """`[1, 2, 10]`, not `[1, 10, 2]` — in a message whose whole job is to be
+    read. The fixture indices overshoot the single digits deliberately: a set
+    that never crosses 9 cannot tell the two sorts apart."""
+    panes = "\n".join(
+        f"%5{i}|500{i}|manywin|{i}|w-{i}|/w/synth-kilo|zsh|t" for i in (2, 10, 1))
+    windows = "".join(f"@5{i}|{i}|manywin\n" for i in (2, 10, 1))
+    report = sm.filter_report(
+        base_gather(runner=make_runner(local_panes=panes, local_windows=windows,
+                                       remote_panes="", remote_windows=""),
+                    use_fuzzyclaw=False),
+        "manywin", "99")
+    assert report["filters"]["detail_sibling_indices"] == ["1", "2", "10"]
+
+
+def test_a_detail_miss_on_an_UNKNOWN_SESSION_says_that_instead():
+    """Two different next steps: fix the index, or find the right session."""
+    report = sm.filter_report(scratch3_gather(), "zznosuchsession", "1")
+    msg = sm.detail_not_found_message(report)
+    assert "no session named 'zznosuchsession'" in msg
+    assert "has windows" not in msg
+    assert report["filters"]["detail_sibling_indices"] == []
+
+
+def test_a_detail_that_FINDS_its_window_says_NOTHING():
+    """NEGATIVE CONTROL. Without it, "report every detail as missing" is a
+    mutation that passes every probe above."""
+    report = sm.filter_report(scratch3_gather(), "scratch3", "2")
+    assert report["filters"]["detail_matched"] == 1
+    assert sm.detail_not_found_message(report) is None
+
+
+def test_a_detail_miss_over_an_UNREACHABLE_FLEET_is_UNMEASURED_not_NOT_FOUND():
+    """🔴 An address that could not be CHECKED is not an address that does not
+    EXIST. Saying "no such window" here states a fact about a machine nobody
+    talked to, and sends the reader to re-check their spelling instead of their
+    SSH."""
+    down = make_runner(local_rc=1, local_err="tmux: connection failed",
+                       remote_rc=255, remote_err="ssh: no route")
+    report = sm.filter_report(base_gather(runner=down, use_fuzzyclaw=False),
+                              "scratch3", "3")
+    assert sm.detail_not_found_message(report) is None
+    assert report["filters"]["detail_matched"] is None
+    assert report["filters"]["detail_sibling_indices"] is None, (
+        "an EMPTY sibling list here would assert a measured absence of windows "
+        "on hosts that never answered")
+    assert sm.exit_code_for(report) == sm.EXIT_UNAVAILABLE
+
+
+def test_a_PARTIAL_fleet_miss_names_the_host_it_could_not_search():
+    """One host answered and one did not: the miss is real on the first and
+    UNMEASURED on the second, and the message says both."""
+    runner = make_runner(local_panes=SCRATCH3_PANES,
+                         local_windows=SCRATCH3_WINDOWS,
+                         remote_rc=255, remote_err="ssh: no route")
+    report = sm.filter_report(base_gather(runner=runner, use_fuzzyclaw=False),
+                              "scratch3", "3")
+    msg = sm.detail_not_found_message(report)
+    assert "searched: workbench" in msg
+    assert "NOT searched: laptop" in msg
+    assert "not a measured absence on that host" in msg
+    # the siblings still come from the host that DID answer
+    assert report["filters"]["detail_sibling_indices"] == ["1", "2"]
+
+
+def test_the_detail_exit_CODES_were_already_right_and_stay_right():
+    """INVARIANT GUARD — NOT regression coverage.
+
+    `exit_code_for` already separated a reachable miss (3) from an unmeasured
+    one (4) before this change; what was missing was the message and the
+    structured count. Pinned so a refactor of the miss path cannot fold the two
+    codes together while the new message keeps looking right.
+    """
+    hit = sm.filter_report(scratch3_gather(), "scratch3", "2")
+    miss = sm.filter_report(scratch3_gather(), "scratch3", "3")
+    down = sm.filter_report(
+        base_gather(runner=make_runner(local_rc=1, local_err="tmux: down",
+                                       remote_rc=255, remote_err="ssh: no route"),
+                    use_fuzzyclaw=False),
+        "scratch3", "3")
+    assert sm.exit_code_for(hit) == sm.EXIT_OK
+    assert sm.exit_code_for(miss) == sm.EXIT_EMPTY
+    assert sm.exit_code_for(down) == sm.EXIT_UNAVAILABLE
+
+
+def test_main_detail_MISS_is_loud_on_STDERR_and_leaves_stdout_parseable(
+        monkeypatch, capsys):
+    """END-TO-END. The human line goes to stderr so a `--json` consumer's stdout
+    is untouched — and the same facts sit in `filters` for a consumer that never
+    reads stderr at all."""
+    monkeypatch.setattr(sm, "gather", lambda **kw: scratch3_gather())
+    monkeypatch.setattr(sm, "local_host_label", lambda *a, **k: "workbench")
+    rc = sm.main(["detail", "scratch3:3", "--json", "--no-ch"])
+    cap = capsys.readouterr()
+    assert rc == sm.EXIT_EMPTY
+    assert "NO SUCH WINDOW 'scratch3:3'" in cap.err
+    assert "['1', '2']" in cap.err
+    blob = json.loads(cap.out)
+    assert blob["filters"]["detail_matched"] == 0
+    assert blob["filters"]["detail_sibling_indices"] == ["1", "2"]
+
+
+def test_main_detail_HIT_prints_no_miss_line(monkeypatch, capsys):
+    """NEGATIVE CONTROL on the CLI wiring, not just on the pure function."""
+    monkeypatch.setattr(sm, "gather", lambda **kw: scratch3_gather())
+    monkeypatch.setattr(sm, "local_host_label", lambda *a, **k: "workbench")
+    rc = sm.main(["detail", "scratch3:2", "--json", "--no-ch"])
+    cap = capsys.readouterr()
+    assert rc == sm.EXIT_OK
+    assert "NO SUCH WINDOW" not in cap.err
+
+
+def test_filter_report_does_not_MUTATE_the_report_it_narrows():
+    """INVARIANT GUARD. `filters` is written through on the narrowed COPY; the
+    original must not grow `detail_*` keys, or a second `filter_report` over the
+    same report would inherit the first one's verdict."""
+    report = scratch3_gather()
+    before = copy.deepcopy(report["filters"])
+    sm.filter_report(report, "scratch3", "3")
+    assert report["filters"] == before
+
+
+def test_detail_json_is_the_FULL_REPORT_SHAPE_not_a_bare_window(monkeypatch,
+                                                                capsys):
+    """🔴 THE FIRST OF THE FIVE WASTED CALLS IN THE OBSERVED RUN: it assumed
+    `detail --json` returns `{"window": {...}}`. It returns the whole report
+    with `hosts[*].windows` NARROWED — hosts keep their reachability facts,
+    because dropping them would turn "unreachable" into "not found".
+
+    INVARIANT GUARD on the shape (it was always this), pinned because the
+    reference doc now states it and a claim nothing checks is the failure mode
+    this repo keeps re-finding.
+    """
+    monkeypatch.setattr(sm, "gather", lambda **kw: scratch3_gather())
+    monkeypatch.setattr(sm, "local_host_label", lambda *a, **k: "workbench")
+    sm.main(["detail", "scratch3:2", "--json", "--no-ch"])
+    blob = json.loads(capsys.readouterr().out)
+    assert "window" not in blob, "detail grew a bare `window` key"
+    assert set(blob) >= {"hosts", "summary", "filters", "caveats",
+                         "session_history"}
+    assert set(blob["hosts"]) == {"workbench", "laptop"}
+    row = blob["hosts"]["workbench"]["windows"][0]
+    # ...and the two row keys the same run got wrong.
+    assert row["window_index"] == "2" and "window" not in row
+    assert row["path"] and "cwd" not in row
 


### PR DESCRIPTION
## The problem, measured

"Find this thing I lost track of — is it still running, which tmux window, where did it leave off?" took two tools and a human gluing them together. An observed run cost **127 s, $0.0056 and 9 tool calls, 5 of them pure flailing**, and its final answer sent the operator to a **real but wrong** live window.

Measured on the workbench, 2026-08-28:

| | |
|---|---|
| `find-session.py <terms>` (transcript archive walk) | **30.1 s** |
| `session-manager --json --lean --no-ch` (live fleet) | **1.82 s**, 72 rows, `task` populated on 66 |
| one query substring matched against **`task`** | **1** row (the right one) |
| one query substring matched against **`path`** | **29** rows |

So the 30-second archive is the wrong instrument for a question about *now*, and `path` does not discriminate — 29 of 72 windows share a repo path.

Re-confirmed live on this branch: `--match devrc` → **1** matched / 71 excluded; `--match devrc --match-path` → **10** matched / 62 excluded.

## What changed

### 1. `--match` on `session-manager` (`scan`/`list`/`detail`)
- Case-insensitive substring over **`task`, `label`, `codename`**. Repeatable; terms are **ANDed** (matching `find-session.py`'s default), and one term may satisfy itself in a different field from another.
- `--match-path` adds `path`. **Off by default**; the 1-vs-29 measurement is in the flag's help text and beside `MATCH_FIELDS`.
- Filtered rows recompute **`summary` and `caveats`** the way `filter_report` does — a `--match` that removes every row now publishes `kinds_produced: []`, not a stale `["tmux"]`.
- `filters.match` / `.match_fields` / `.matched` / `.excluded_by_match`, all **`null` never `0`** when no filter ran. So "no rows matched these words in these fields" can never be read as "nothing exists", and a reader can see that `path` was excluded. **`summary` mirrors `match` / `match_fields` / `excluded_by_match` / `matched`.**

> ⚠ **CORRECTION (2026-08-29).** An earlier revision of this body said `filters.matched` was "mirrored into `summary`". **That was false at `a6f09d5a`** — `summary.matched` did not exist; the audit confirmed it live and `payload-contract.md` was right where this body was wrong. It is true as of `9f9dcbde`, which adds the mirror as part of audit finding 6 (the table's filter line was quoting `total_sessions`). Flagged rather than silently edited, because a reader may have believed the earlier version.
- Reachable hosts + zero matches ⇒ **`EXIT_EMPTY` (3)**, never 0. No host reachable ⇒ still `EXIT_UNAVAILABLE` (4). `exit_code_for` is still computed **before** the lean projection (the 🔴 at `main()` is untouched).
- `--claude-only` and `--match` now share **one pass and one `kinds_excluded_by_filter` answer** instead of one per flag — computing it per flag would let the second filter's answer overwrite the first's.
- No effect on `tail`; it says so on stderr.

### 2. A non-matching `detail` address is LOUD
`filter_report` returned a silent empty window list — byte-identical to "found it, the window is idle". The observed run guessed index `3` from the session name `scratch3`; the real index was `2`.

Verified against the live fleet on this branch (`exit 3`):

```
detail: NO SUCH WINDOW 'scratch15:9' — session 'scratch15' has windows
['1', '2', '3', '4', '5']; you asked for index '9' (searched: laptop, workbench)
```

`filters.detail_target` / `.detail_matched` / `.detail_sibling_indices` carry the same facts structurally. 🔴 **All three are `null` and nothing is printed when no host was reachable** — an address that could not be *checked* is not an address that does not *exist*, and `EXIT_UNAVAILABLE` already says which case you are in. A partial fleet names the host it could not search.

### 3. `hotkey_display` — one writer for a chord whose CASE picks the session
The row said `hotkey: v`; the answer said `Alt+Shift+V`. Per `scripts/tmux-scratch-slots.sh` (🔴 comment) and `window-triage`, `M-v` is `scratch3`/violet and `M-V` is `scratch4`/**Vapor** — different sessions.

Every row, and `LEAN_ROW_FIELDS`, now carries `hotkey_display`: `None` / `Alt+<k>` / `Alt+Shift+<K>`, derived in exactly one function. `None` on tiers 2 and 3, never `""`.

**`render_label` is deliberately NOT routed through it, and every existing test stays green.** The LABEL column is 14 characters (`_trunc(render_label(r), 14)`, pinned by an existing `<= 14` assertion against `Yarrow (Y)`) and `Yarrow (Alt+Shift+Y)` is 20 — routing it through would produce a truncated stub *more* ambiguous than the raw key. The table states the KEY with its case intact; a new test pins that it never emits `Alt+`, so the two surfaces cannot converge on two spellings of one thing.

### 4. `find-session.py --live [--deep] [--tail N]`
1. Live scan first (`session-manager scan --json --lean --no-ch --match …`).
2. LIVE section: host, `session:window_index`, label + `hotkey_display`, status/age + `age_source`, the `waiting_probable` tri-state (JSON-dumped so `null` is visibly not `false`) with the verbatim `waiting_signals`, task, path, and the resume command (`opencode --session` for an opencode row, an attach hint when there is no session id).
3. The 30 s walk runs only when nothing live matched, or the scan was UNMEASURED, or `--deep`.
4. Archive hits are annotated **`<LIVE>` / `<CLOSED>` / `<UNMEASURED>`** by joining on `claude_session_id`.
5. `--tail N` shells out to `session-manager tail … --plain --lines N`, **with the row's `--host`** (the sibling resolves `--host all` to LOCAL, so omitting it tails the wrong machine). It **refuses** an ambiguous match (exit 3) and lists the candidates.
6. Composes with `--json`, which then emits `{live, archive, tail}` — the bare-array shape existing callers parse is untouched when `--live` is absent.

🔴 **The match predicate is not re-implemented.** `--live` passes the terms to `session-manager --match`; the field list it prints comes from `filters.match_fields` in the payload, not a literal. The two tools cannot answer the same words differently.

🔴 **Unreachable is never "not running".** A failed scan, a fleet where no host answered, and a partial fleet each print their own labelled section, and the tool still falls back to the archive.

Verified end to end on the real fleet: `find-session.py devrc --live --tail 8` → live hit on the **laptop**, `[Alt+i]`, archive skipped, and the laptop window's scrollback printed over SSH — one call, ~2 s.

### Files, labelled

| file | new/modified | payload or scaffolding |
|---|---|---|
| `scripts/session-manager` | modified | payload |
| `scripts/find-session.py` | modified | payload |
| `claude/skills/find-session/SKILL.md` | **modified** | payload (ships to `~/.claude` on a switch) |
| `claude/skills/session-manager/reference/payload-contract.md` | **modified** — it has existed since #663; this PR adds sections to it | payload (ships) |
| `scripts/tests/test_session_manager.py` | modified | scaffolding |
| `scripts/tests/test_find_session_live.py` | **new** (`git add`ed — a new file the flake would otherwise omit) | scaffolding |

`claude/skills/session-manager/SKILL.md` is **not in the diff at all**.

### Docs
`claude/skills/session-manager/SKILL.md` is **untouched** (`MAX_BYTES` unchanged, 152 B spare intact). The new material — the flag table rows, `--match` semantics and payload keys, the `detail` output-shape trap (**it returns the FULL report, not `{"window": …}`**), the `window_index`/`path` row-key names, and `hotkey_display` — went into `reference/payload-contract.md`, which SKILL.md already routes to. `claude/skills/find-session/SKILL.md` documents `--live`/`--deep`/`--tail`, the ambiguity refusal, the unreachable-host rule and the NEVER-PASTE rule for `unsent_prompt`/`--tail` output.

---

## Red at base / green at HEAD

Base = **`9e452d34`** (the branch point). Measured by copying the final test files into a detached worktree at that sha and running them there under `PYTHONDONTWRITEBYTECODE=1`.

| file | nodes | RED at `9e452d34` | GREEN at `9e452d34` |
|---|---|---|---|
| `test_session_manager.py` §14 (new) | 45 | **38** | 7 |
| `test_session_manager.py` (4 pre-existing ledgers/goldens I updated) | 4 | **4** | 0 |
| `test_find_session_live.py` (new file) | 33 | **33** | 0 |

**At HEAD: 653 passed, 0 failed** across both files.

The 4 pre-existing tests that go red at base are the row/lean field ledgers and the two goldens — they are red *because* `hotkey_display` and the `--match` filter keys are new, which is exactly what a two-way ledger is for.

### The 7 that are GREEN at base are INVARIANT GUARDS, not regression coverage
They are enumerated in `INVARIANT_GUARDS_ADDED_HERE` and a test asserts every name resolves:

| test | why it is not a fix |
|---|---|
| `test_the_detail_exit_CODES_were_already_right_and_stay_right` | `exit_code_for` already returned 3 for a reachable miss and 4 for an unmeasured one. What was missing was the **message and the structured count**. |
| `test_render_label_states_the_KEY_and_never_a_CHORD` | `render_label` is unchanged; this pins that it stayed that way. |
| `test_filter_report_does_not_MUTATE_the_report_it_narrows` | it already copied; the new `detail_*` bookkeeping is what could have broken it. |
| `test_the_match_fixture_produces_the_rows_the_probes_below_assume` | a **positive control on the fixture** — without it a `0 rows` verdict is indistinguishable from a fixture that built none. |
| `test_main_detail_HIT_prints_no_miss_line` | a **negative control**: without it, "report every detail as missing" passes every miss probe. |
| `test_detail_json_is_the_FULL_REPORT_SHAPE_not_a_bare_window` | the shape was always this; pinning it is what makes the reference doc's new claim machine-checked. |
| `test_the_invariant_guard_ledger_names_only_tests_that_exist` | this ledger's own gate. |

### And 5 of the 33 in `test_find_session_live.py` are red at base only because the HARNESS is absent
`test_json_WITHOUT_live_keeps_the_bare_ARRAY_every_caller_parses`, `test_the_classic_TEXT_path_is_untouched_by_this_feature`, `test_fmt_age_states_a_MISSING_age_rather_than_rendering_zero`, `test_the_seam_is_actually_replaced` and `test_the_exit_CODE_VOCABULARY_is_pinned_to_LITERALS` reference `fs.RUN` / `fs.archive_search` / `fs.EXIT_*` / `fs.fmt_age`, which do not exist at base. The first two are **backward-compatibility guards**; the rest are controls on the module's own instrument. **None of them is evidence a bug was fixed**, and the module docstring says so.

---

## Mutation sweep — 38/38 killed by their own named guard

Run under `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` deleted between mutants (the whole-second-mtime staleness trap). A mutant counts as KILLED only when the test named in its `expect` fails — a mutant that dies against a *different* test is reported MISDIRECTED. Green control (unmutated tree clean) asserted before the batch and again after restore.

- `hotkey_display` (6): always-shift, never-shift, inverted `isupper`, `""`-not-`None`, upper-casing the key, and **dropping `hotkey_display` from `LEAN_ROW_FIELDS`** — the last one dies against the *cross-file seam guard* in `test_find_session_live.py`.
- `--match` (11): `path` always searched, `path` in the default set, `--match-path` inert, OR-instead-of-AND, case-sensitive terms, joined haystack, empty-terms-reject-the-world, `matched` never published, summary drops the terms / the excluded count, caveats inherited instead of re-derived.
- `detail` miss (8): the miss line never printed, not-found over an unreachable fleet, `detail_matched: 0` when unmeasured, siblings as a measured `[]` when unmeasured, lexical sibling sort, the siblings never named, *every* detail reported as a miss, the unsearched host not named.
- `find-session --live` (12): archive always runs, `--deep` loses its precedence, the UNMEASURED branch removed from the reason chain, unmeasured annotated as CLOSED, no-reachable-host still reads `ok`, tail guesses the first of several, tail drops `--host`, annotate from the FILTERED scan, the renderer derives the chord itself, `waiting_probable` rendered with `str` not `json.dumps`, `--lean`/`--no-ch` dropped from the scan argv, `--tail` without `--live` silently accepted.
- **Positive control**: `EXIT_AMBIGUOUS = 3` → `0`.

### 🔴 Two findings the sweep produced, both fixed in this PR

1. **The positive control SURVIVED on the first run.** Every `rc` assertion compared against `fs.EXIT_AMBIGUOUS`, which is self-satisfying — a mutant that rewrites the constant moves both sides. Exactly `claude/RULES.md`'s "a fixture that can only ever produce the constant's own value cannot see a mutant that hardcodes the literal". Fixed by `test_the_exit_CODE_VOCABULARY_is_pinned_to_LITERALS`, which pins `(0, 2, 3, 4)` as literals *and* against `session-manager`'s own `EXIT_*`. The control now dies against that test.
2. **`run_archive` and `archive_reason` were open-coded separately and already disagreed about `--deep`'s precedence** — the "wrong at N−1 of N sites" shape. Removing the `status != "ok"` clause from `run_archive` scored **SURVIVED**, because a failed scan carries zero rows anyway so the `not rows` clause picked up the slack silently. Consolidated: `run_archive` is now derived from `archive_reason`, which made the branch observable (the printed reason moves), and both mutants now die.

---

## Gate

Base sha: **`9e452d34`** (branch point). Both tiers below were run against commit **`a6f09d5a`** with a **clean working tree** (`git status --porcelain` empty; the sandbox run prints no `Git tree is dirty` warning, unlike an earlier probe).

- **dev-host tier** — `nix develop <worktree> --command bash scripts/gate.sh`
  → **`GATE: RESULT=PASS exit=0`**
  · pytest `TOTAL collected=18334 passed=18332 skipped=2 failed=0` (floor 15970)
  · node `TOTAL suites=5 files=39 tests=1300 pass=1300 fail=0` (floor 1239)
- **sandbox tier** (the one Tekton gates the merge on) — `nix build --no-link .#checks.x86_64-linux.pytests .#checks.x86_64-linux.nodetests`
  → both derivations **built**, exit 0.
- Subset while iterating: `nix develop ~/workspace/devrc -c python3 -m pytest scripts/tests/test_session_manager.py scripts/tests/test_find_session_live.py -q` → **653 passed**.

⚠ A bare `bash scripts/gate.sh` *outside* the devShell exits 3 with `required tool(s) missing from PATH: logrotate` — a missing environment, not a code failure. Both runs above are from inside `nix develop`.

## What I could NOT verify

- **The `29 of 72` figure in the source comments and help text is the brief's measurement, not one I re-took.** What I did re-measure on the live fleet today is `devrc`: **1** hit on the default fields vs **10** with `--match-path` (72 rows, both hosts reachable). The ratio and the conclusion hold; the specific 29 belongs to a different substring.
- **The laptop was reachable for every live probe I ran**, so the partial-fleet and no-host-answered paths were exercised only against injected fixtures, never against a genuinely down peer.
- **`--live` was not exercised against a live *opencode* row** — the `opencode --session` resume branch is covered by a fixture only.
- **Neither tier was run against the MERGED tree.** `origin/main` moved to **`4c03d43e`** while this was in flight — 3 commits touching `claudedocs/handoff-{cairn,tmux-webapp}.md`, `scripts/lib/subsystem_{recall,touch}.py` and `scripts/tests/test_{repo_path_guard,subsystem_touch}.py`, i.e. **zero overlap** with the six files here. But `strict` is false on this repo's branch protection, so a green check is a claim about this BRANCH; gating the merged tree is still owed. (The base is an ancestor of `origin/main`, so it fast-forwards.)
- **Nothing is deployed.** These are repo scripts run from the checkout, but `claude/skills/**` only reaches `~/.claude/skills/` on a `home-manager switch` / `ship.sh` — merging this does not update the deployed skill bodies.

---

# Audit fix round 1 — `a6f09d5a` → `9f9dcbde`

A blind adversarial audit against `a6f09d5a` returned two deploy-blockers and six
smaller findings. All eight are addressed. Each 🔴 was reproduced before it was fixed.

## 🔴 1 — a partial fleet labelled a RUNNING session `CLOSED`  · FIXED

`live_scan` sets `status: "ok"` when **any** host answers and `hosts_unreachable` may be
non-empty in that state, but `live_session_ids` returned UNMEASURED only on
`status != "ok"`. With the laptop asleep — this fleet's *common* degraded state — every
archive hit whose session lived there was stamped `CLOSED`, with `live_ids_measured: true`,
no warning, exit 0.

**Reproduced end-to-end through the real subprocess path** (a stub `session-manager`
reporting workbench-up / laptop-down; only `ROOT` and `SESSION_MANAGER` redirected, `RUN`
untouched, so an actual process is spawned):

| | `workbench` (UP) | `laptop` (DOWN) | `live_coverage_complete` |
|---|---|---|---|
| `a6f09d5a` | `LIVE` | **`CLOSED`** | *key absent* |
| `9f9dcbde` | `LIVE` | **`UNMEASURED`** | `false` |

**Chosen fix: coarse, not per-host — and the reason is in the code.** An archive hit carries
a `cwd` and a session id but **no host**, and the Claude transcript corpus is read from
local disk while the opencode corpus is read from both hosts, so there is no sound
hit→host mapping to attribute with. But a **positive is a measurement whatever the
coverage**: finding the id on a host that answered proves the session is live, and no
sleeping peer makes that false. So `LIVE` survives a partial fleet and only `CLOSED`
requires a full one. A blanket "UNMEASURED on any unreachable host" would have been
strictly worse, and `test_a_PARTIAL_fleet_never_stamps_CLOSED_but_still_confirms_LIVE`
asserts both halves in one render so that shortcut cannot pass.

`live_ids_measured` now tells the truth by being **joined by a second field rather than
redefined**: `archive.live_coverage_complete` and `archive.live_hosts_unreachable` are
published beside it, because "a set was obtained" and "the set covers everything" are
different facts. The ARCHIVE block gets its own `⚠ live/closed state is PARTIAL` line — as
the audit noted, the LIVE section's caveat says an absence "cannot appear **below**" and
refers to the live row list, not to these annotations.

## 🔴 2 — a `detail` miss under a row filter asserted a false measured absence · FIXED

**Reproduced live on the real fleet** (`scratch2` window 1 exists on *both* hosts):

```
a6f09d5a$ session-manager detail scratch2:1 --claude-only
detail: NO SUCH WINDOW 'scratch2:1' — session 'scratch2' has windows ['2', '3', '4'];
you asked for index '1' (searched: laptop, workbench)

9f9dcbde$ session-manager detail scratch2:1 --claude-only
detail: WINDOW 'scratch2:1' EXISTS but a ROW FILTER (--claude-only) removed it — this
empty result is the FILTER's doing, NOT a measured absence. Re-run without the filter
to inspect it (searched: laptop, workbench)
```

…and the wrong-index shape, same fleet: `['2','3','4']` → `['1','2','3','4']` with
`(indices measured BEFORE the row filter --claude-only)` appended.

**I did both halves the audit offered**, because stating the filter scope alone would have
left the message self-contradictory: under a filter, `detail_matched == 0` does not mean
"no such window", it means "no row survived", so a *correct* sibling list would have
printed "has windows ['1','2']" directly above "NO SUCH WINDOW … index '1'". So `gather`
now samples `filters.prefilter_window_indices` **before** the row filters and the message
distinguishes **three** misses — the filter removed it / wrong index / no such session —
with `filters.detail_filtered_out` carrying the first structurally.

The map is **opt-in** (`prefilter_index_map`, set by `main()` for the `detail` subcommand
only): a 1-row `--match` scan must not carry a 24-session index map back, since a small
payload is that flag's whole purpose. Verified live: `scan --match e` → map is `None`;
`detail scratch2:1 --claude-only` → map has 24 sessions.

**The docstring was narrower than the code and is fixed too** — `filter_report` and
`detail_not_found_message` both now state the pre-filter sampling and the three shapes.

## 🟡 3 — a failed `--tail` printed "(empty scrollback)" and exited 0 · FIXED

`TAIL_MEASURED_RCS = (0, 3)`. rc 3 is `session-manager`'s *measured* empty pane and stays a
success (rendered as "MEASURED, the pane really is blank"); rc 2/4/5 — window closed
between the scan and the tail, host gone, no tmux server — now print
`TAIL: FAILED — \`session-manager tail\` exited N` and exit **4**, with `tail.rc` and
`tail.ok` published in the JSON. The `ok: false` + empty `text` pair is what separates "not
read" from "measured empty" when stderr happens to be quiet.

## 🟡 4 — `--any` / `--project` / `--since` / `--limit` · FIXED

- `--any`, `--project`, `--since` are **archive-only** (the live scan ANDs, has no cwd
  filter and no date axis) and now print an ARCHIVE-ONLY notice on stderr — the sixth
  notice of a class this diff already had five of. Verified live:
  `find-session.py devrc --live --any` prints
  `(ARCHIVE-ONLY flags, ignored by the live scan: --any (the live scan ANDs; there is no OR mode) …)`.
- `--limit` now **reaches** the live leg: `LIVE (2 matched …)` then
  `(showing 1 of 2 — raise --limit to see the rest)`. 🔴 It deliberately does **not** narrow
  the `--tail` ambiguity check — capping that would turn "several matched, I refuse" into
  "one is showing, I'll tail that one", which is guessing with extra steps — and the JSON
  `live.rows` is never truncated. Both pinned.
- `claude/skills/find-session/SKILL.md` line 4 updated: the three flags are marked
  `(archive only)` in `argument-hint`, with a body bullet.

## 🟡 5 — measured zeros over an unreachable fleet · FIXED

`filters.matched` / `.excluded_by_match` (and their `summary` mirrors) are `None` when no
host answered, agreeing with `detail_matched`. The **terms and field list are still
published** — which filter was *requested* is known regardless. A **partially** reachable
fleet still publishes real counts. ⚠ `excluded_shells` has the same shape and is
**deliberately not changed**: it is a pre-existing published field with its own tests, and
redefining it belongs in its own change rather than smuggled into this one. Noted in the
source and in `payload-contract.md`.

## 🟢 6 — the table quoted `total_sessions` · FIXED

The `FILTER --match` line describes the **filter**, and on a `detail` report the two numbers
differ by construction. It quotes `summary.matched` now, and `summarize()` mirrors
`filters.matched` — which is also what makes this PR body's earlier "mirrored into summary"
claim true rather than aspirational. Both counts render as "an unmeasured number of" rather
than `None` when the fleet was unreachable.

## 🟢 7 — the span guard · FIXED, but it was a GUARD gap, not a code defect

`test_a_term_may_not_SPAN_two_fields` is now parametrised over **8 separators** (empty,
space, pipe, newline, tab, NUL, comma-space, em-dash) with a positive control that each
field matches alone.

🔴 **Reported precisely: `row_matches` was already correct at `a6f09d5a`** — the
parametrised guard passes there too (measured: 10 passed at the tip). What the old spelling
could not see was the auditor's *mutant*. So this finding has **no red-at-tip row**; its
evidence is mutants N27/N28, which the old guard survived and the new one kills.

## 🟢 8 — `live_scan` crashed on valid-but-non-object JSON · FIXED

One `isinstance(report, dict)`, inside the discriminated path. `[]`, `null`, `"a string"`
and `3` all return `status: "error"` with `not a report object` instead of raising
`AttributeError` out of a function whose contract is to never raise.

## Bonus: an unreachable guard, removed rather than kept

The pre-filter map's `and entry.get("reachable")` clause was **unreachable as a
difference** — a mutant deleting it SURVIVED, because `gather` gives an unreachable host
`windows: []` by construction. Per `claude/RULES.md` ("an unreachable guard reads as a
defence and is not one") the clause is gone and the **precondition** is pinned directly by
`test_an_unreachable_host_carries_NO_rows_which_is_what_makes_the_maps_safe`, which a
mutation of `gather` does kill (N10).

---

## Round 1: red at `a6f09d5a` / green at `9f9dcbde`

Measured by copying the final test files into a detached worktree at `a6f09d5a`, under
`PYTHONDONTWRITEBYTECODE=1`.

| | nodes | RED at `a6f09d5a` | GREEN at `a6f09d5a` |
|---|---|---|---|
| new nodes across both test files | **56** | **46** | 10 |

**At `9f9dcbde`: 716 passed, 0 failed** across the two files (853 including the doc/skill
gates).

The 10 green-at-tip are enumerated in `R1_INVARIANT_GUARDS` in each file, with a test that
every listed name resolves. They are: the strict default of `live_state_of`; the two
negative controls on the archive-only notice; the two `--limit`-must-not-narrow guards; the
`isinstance` positive control; the partial-fleet-still-counts guard; the scratch3 fixture
control; the span positive control; and the unreachable-host precondition. **None is
evidence a bug was fixed**, and both `🔴` findings' probes are in the RED 46.

The two probes for 🔴 1 and 🔴 2 exercise the **real** failure, not an adjacent invariant:
`test_a_PARTIAL_fleet_never_stamps_CLOSED_but_still_confirms_LIVE` runs a genuine partial
fleet, and `test_a_detail_MISS_CAUSED_BY_A_ROW_FILTER_…` /
`test_the_sibling_indices_are_measured_BEFORE_the_row_filter` run a genuinely filtered
`detail` under both `--claude-only` and `--match`.

## Round 1 mutation sweep — 32/32 killed by their own named guard

`PYTHONDONTWRITEBYTECODE=1`, `__pycache__` cleared between mutants, green control asserted
before the batch and again after restore. A mutant counts as KILLED only when the test named
in its `expect` fails; dying against a different test is reported MISDIRECTED.

- **R1-1** (6): coverage ignores unreachable hosts · a miss is always CLOSED · the coverage
  gate swallows the POSITIVE too · `main` never measures coverage · the ARCHIVE warning is
  dropped · coverage is not published.
- **R1-2** (7): siblings fall back to the filtered rows · `filtered_out` never detected ·
  `filtered_out` fires on every miss · **an unreachable host is given rows** (the replacement
  for the survivor described above) · `main` asks for the map always / never · the filter is
  not named in the wrong-index message.
- **R1-3** (4): a measured-empty rc called a failure · every rc treated as measured ·
  nothing branches on the rc · the failed tail still prints a scrollback block.
- **R1-4** (4): the `--any` notice dropped · the notice fires unconditionally · `--limit`
  does not bound the live section · `--limit` NARROWS the ambiguity check.
- **R1-5** (3): `excluded_by_match` is a measured zero again · `fleet_measured` always
  true · always false (the permanently-red-gate control).
- **R1-6** (2): the table quotes `total_sessions` again · `summary` does not mirror.
- **R1-7** (2): **the auditor's own space-joined haystack**, plus a newline-joined one.
  Both survived at `a6f09d5a`; both die now.
- **R1-8** (3): the guard removed · the guard admits a bare array · the guard rejects
  everything (the permanently-red-gate control).
- **Positive control**: `EXIT_AMBIGUOUS = 3` → `0`, killed by
  `test_the_exit_CODE_VOCABULARY_is_pinned_to_LITERALS`.

## Round 1 gate

Base sha `9e452d34`; tip **`9f9dcbde`**, clean working tree.

- **dev-host** — `nix develop <worktree> --command bash scripts/gate.sh --tier both`
  → **`GATE: RESULT=PASS exit=0`**
  · pytest `TOTAL collected=18399 passed=18397 skipped=2 failed=0` (floor 15970)
  · node `TOTAL suites=5 files=39 tests=1300 pass=1300 fail=0` (floor 1239)
- **sandbox** (the tier Tekton gates on) — `nix build --no-link .#checks.x86_64-linux.pytests .#checks.x86_64-linux.nodetests`
  → both derivations **built**, exit 0, on a clean tree (no `Git tree is dirty` warning).

## Round 1: what I could NOT verify

- **The partial-fleet path was never exercised against a genuinely sleeping laptop.** The
  laptop answered every real probe I ran, so 🔴 1's end-to-end reproduction used a stub
  `session-manager` that reports the laptop unreachable. The subprocess, the JSON parse and
  the whole `main()` path are real; the *unreachability* is simulated.
- **`--tail`'s failure path was likewise not raced live.** rc 2/4/5 came from the injected
  runner, not from a window that actually closed mid-run.
- **The coarse coverage fix means a hit on a reachable host's session is still
  `UNMEASURED` when any peer is down.** That is deliberate (no sound hit→host mapping) but
  it is a real loss of precision versus a per-host scheme, and it will read as `UNMEASURED`
  more often than strictly necessary.
- **Neither tier ran on the merged tree** — see the round-0 note; `origin/main` has moved
  again since.
- Nothing is deployed; `claude/skills/**` reaches `~/.claude/` only on a `home-manager
  switch` / `ship.sh`.

---

# Audit fix round 2 — `9f9dcbde` → `58916673`

A **fresh** auditor ran the delta `a6f09d5a..9f9dcbde` blind. All eight round-1 claims
verified as actually fixed (seven complete, one partial), nothing made worse, 21 independent
mutants rebuilt with 20 killed by their own named test. It raised six new findings and
deferred one. All addressed below.

## 🟡 F1 — three corpus flags reached one leg silently, under a comment claiming the class was closed · FIXED

`--claude-only`, `--opencode-only` and `--all` still reached only the archive leg, with no
notice — beneath a comment whose last line read *"this diff already prints five notices of
exactly this class; **these are the rest**"*. That sentence was false when written, and a
completeness claim is worse than the omission it decorates: it tells the next reader to stop
looking.

**Reproduced on the real fleet at `9f9dcbde`** — `find-session.py devrc --live
--opencode-only` printed **0 bytes of stderr** and returned tmux windows running Claude.
And because the live leg matched, `run_archive` stayed False, so **the opencode corpus the
caller explicitly selected was never searched at all**.

**Fixed structurally, not by extending the list.** `ARCHIVE_ONLY_FLAGS` is data,
`LIVE_AWARE_DESTS` is the other half of the partition, and
`test_the_archive_only_ledger_PARTITIONS_every_argparse_destination` asserts the two
**equal the parser's own destination set**, read from a real parse rather than a second
hand-written list. A new flag that is neither now fails the suite instead of shipping a
silent one-leg filter. There is no completeness sentence left to drift.

Corpus selectors get the *consequence* too, not just the fact. At `58916673`:

```
(ARCHIVE-ONLY flags, ignored by the live scan: --opencode-only (CORPUS selection; …)
 — the LIVE section below is NOT filtered by them)
(...and a CORPUS selector only steers the ARCHIVE, which is SKIPPED when the live scan
 matches: pass --deep to actually search the corpus you selected)
```

⚠ **Deliberately NOT done: making a corpus selector force the archive leg to run.** It
would fix the "never searched" half outright, but it puts a 30 s walk on every
`--live --claude-only` and is a behaviour choice rather than a defect fix. Flagged here
rather than taken unilaterally.

## 🟡 F2 — `_tail_outcome` stated a measured absence under a partial fleet · FIXED

The ARCHIVE block printed `⚠ live/closed state is PARTIAL` and three lines later the run
ended with *"TAIL: REFUSED — no live window matched, so there is nothing to tail"*, exit
**3**, with no coverage field anywhere in the `tail` JSON. My own reasoning for giving the
ARCHIVE block its own line applied verbatim and had not been applied.

**Reproduced end-to-end through the real subprocess path** (stub `session-manager`, laptop
down):

| | exit | message | `tail.coverage_complete` |
|---|---|---|---|
| `9f9dcbde` | **3** | "…so there is nothing to tail" | *key absent* |
| `58916673` | **4** | "…but laptop did not answer, so this is NOT 'there is nothing to tail'. The window may be there and UNMEASURED." | `false` |

All three arms covered, and the middle one is a judgement worth naming: **one match under
partial coverage still tails**, with the resolution disclosed as possibly non-unique.
Refusing there would make `--tail` useless whenever the laptop sleeps — a permanently-red
gate — while claiming "this is the one" would be the guess the function exists to refuse.
**Several matches** still refuse and now say the candidate list is incomplete.
`tail.coverage_complete` + `tail.hosts_unreachable` are published because `archive.*`
describes a *different* scan and is absent entirely on the fast path.

## 🟡 F3 — `live_hosts_unreachable: []` for a scan that never ran · FIXED

Fixed **at the source**: `live_scan` seeds *both* host lists `None` on its error paths, so
no publisher can reintroduce it — rather than patching the one field the audit caught.
`status: "unavailable"` is deliberately unchanged: that scan **ran**, every host really was
unreachable, and those lists are measurements. Both directions are pinned.

## 🟡 F4 — the round-1 node ledger was wrong, and its completeness sentence false · FIXED

Re-measured at **node level**: **66 new nodes, 46 RED, 20 GREEN** — the red count was
exact, the other two were not. The round-1 sweep counted *functions whose names were new*,
so it skipped `parametrize` expansion and same-named-but-modified tests. The 10 missing
greens were the 8 `test_a_term_may_not_SPAN_two_fields[…]` params and the 2 ledger-gate
nodes.

The parametrised entries are now **derived from the same `SPAN_SEPARATORS` tuple the
`parametrize` reads**, so they cannot drift again, and a test pins that they still are
derived. `test_the_prefilter_map_excludes_hosts_that_never_answered` is reconciled into a
third, honest category — `R1_RED_ONLY_BECAUSE_A_SYMBOL_IS_NEW` — since it is red at base
only because the `prefilter_index_map` kwarg did not exist there, while what it *pins* is
genuinely an invariant. A test asserts the two ledgers do not overlap.

**This round's own matrix was measured the same way** (`redmatrix2.py`: collect node ids at
both shas, diff those, run head tests against base source) so the method that produced the
wrong number is not reused.

## 🟡 F5 — the test did not pin what its docstring claimed · FIXED (the sentence, not the code)

🔴 **The code was never weak, and the fix is a retraction.** The property is
**over-determined**: `run_tmux` returns `stdout: ""` on every unreachable path *and* the
population loop skips a host that did not answer. The auditor deleted the second and all
649 tests stayed green — **correctly**. What was wrong was the sentence *"where a change to
`gather` really would red"*.

- the docstring now states the over-determination and says it **cannot attribute the
  property to a mechanism**;
- the assertion is widened to the property across **three unreachable modes** and **every**
  unreachable host, not one named one;
- `gather`'s comment names **both** mechanisms and warns that deleting both is undetected;
- `payload-contract.md`'s *"reachable hosts only"* — describing a filter the code does not
  have — is gone.

Two prose guards (`…docstring_does_not_OVERCLAIM`, `…gather_comment_names_BOTH_…`) pin the
retraction. ⚠ The first is green at every sha **by construction** — the artifact it
inspects is a docstring in the test file itself — and is declared as such rather than
offered as regression coverage.

## 🟢 F6 — exit 4 now means three things · FIXED (docs)

`claude/skills/find-session/SKILL.md` names all three (fleet unmeasured / the tail itself
failed / `--tail` found nothing under partial coverage) and points a branching caller at
`tail.ok` / `tail.rc` / `tail.coverage_complete`. No new code, per the audit's own
suggestion.

## 🟢 F8 — `--limit 0` meant opposite things on the two legs · FIXED

Measured at `9f9dcbde`: `--live --limit 0` exited 0 and showed **2** live rows (the live
leg read `<= 0` as unbounded) while the archive leg took `results[:0]` and showed nothing.
Now a usage error on both legs (`rc 2`), checked before either leg runs.

⚠ **This is a deliberate behaviour change on the classic path** for `--limit < 1` only,
where the previous behaviour was a silent empty result. Everything `>= 1` is unchanged, and
`--limit 1` is pinned as the boundary. `render_live`'s slice is additionally pinned **at
the function level** for `limit=0`, because `main`'s validation makes that branch
unreachable from the CLI and a mutation restoring the old special case would otherwise
survive.

## 🟡 F7 — KNOWINGLY DEFERRED

Over a dead fleet, `FILTER --claude-only: 0 shell window(s) excluded` sits beside
`FILTER --match 'x': an unmeasured number of row(s) matched`. `excluded_shells` has exactly
the shape this PR null-guarded for `matched`/`excluded_by_match`, and it is **not changed
here on purpose**: it is a pre-existing published field with its own tests and its own
readers, and redefining it is a payload-contract change that deserves its own PR and its own
audit rather than being smuggled into a fix round. It is called out in the source and in
`payload-contract.md` so the asymmetry is visible rather than accidental.

## Also folded in

The auditor's correction to `live_coverage_complete`'s stated reason. The old comment said
per-host attribution fails because "an archive hit carries no host" — **wrong for half the
corpus**: `~/.claude/projects` is read from local disk only, so a Claude hit's host *is*
known. What makes the inference unsound is **cross-host `claude --resume`** (a session
recorded here can be running there). The conclusion and the coarse trade are unchanged; the
comment said *why* wrongly.

The three items the auditor explicitly cleared were left alone.

---

## Round 2: red at `9f9dcbde` / green at `58916673`

Node-level, by collecting node ids at both shas and running the head tests against base
source under `PYTHONDONTWRITEBYTECODE=1`.

| | nodes | RED at `9f9dcbde` | GREEN at `9f9dcbde` |
|---|---|---|---|
| **new** nodes across both test files | **29** | **16** | 13 |
| **modified** nodes (assertion tightened) | 5 | **5** | 0 |

The 5 modified are the four `test_valid_but_NON_OBJECT_json…` params (F3: `[]` → `None`)
and `…ARCHIVE_ONLY_flag…[any]` (needle moved). **At `58916673`: 746 passed, 0 failed** across
the two files.

The 13 green are enumerated in `R2_INVARIANT_GUARDS` in each file (8 in
`test_session_manager.py`, 5 in `test_find_session_live.py`), each with a resolve-check.
They are negative controls (a non-corpus flag must **not** get the corpus sentence; a full
fleet must still say "nothing to tail"; `unavailable` must still publish real host lists),
the `--limit 1` boundary control, the three unreachable-mode params for the F5 property,
and the ledger/prose guards. **None is evidence a bug was fixed.**

F1's probe is a real corpus-flag run through `main()` asserting the notice **and** that the
archive was skipped — not an adjacent invariant.

## Round 2 mutation sweep — 25/25 killed by their own named guard

`PYTHONDONTWRITEBYTECODE=1`, `__pycache__` cleared between mutants, green control before and
after restore. Positive control: `EXIT_AMBIGUOUS = 3 → 0`, killed by
`test_the_exit_CODE_VOCABULARY_is_pinned_to_LITERALS`.

- **F1** (7): the three flags drop out of the ledger · a flag is in neither half · the
  halves overlap · the corpus sentence dropped / fires for everything · only the first flag
  named · the notice fires with nothing to say.
- **F2** (6): tail ignores coverage on a zero match / calls every zero match unmeasured · a
  single match hides its partial coverage · a partial candidate list claims completeness ·
  the JSON drops its coverage field / reports the wrong hosts.
- **F3** (2): the error path seeds `[]` again · the *measured* lists get nulled too.
- **F8** (3): below-1 accepted again · the boundary off by one · the live leg reads
  non-positive as unbounded again.
- **F4/F5** (6): the span ledger stops being derived · the two ledgers overlap · a ledger
  names a test that does not exist · `gather` loses its both-enforcements warning · the
  retracted overclaim comes back · the precondition sweep stops checking every host.

🔴 **Two mutants SURVIVED the first pass and were fixed rather than explained away.**
(1) Restoring `limit <= 0` in `render_live` survived because `main` now rejects that input
— the branch is unreachable from the CLI. Closed by pinning `render_live`'s slice at the
**function** level. (2) `for name in unreachable:` → `unreachable[:0]` survived: the loop
body never ran and every other assertion still held — a guard reading as coverage while
executing nothing. Closed by materialising the observation before judging it and asserting
the sweep visited what it claimed.

## Round 2 gate

Base sha `9e452d34`; tip **`58916673`**, clean working tree.

- **dev-host** — `nix develop <worktree> --command bash scripts/gate.sh --tier both`
  → **`GATE: RESULT=PASS exit=0`**
  · pytest `TOTAL collected=18432 passed=18430 skipped=2 failed=0` (floor 15970)
  · node `TOTAL suites=5 files=39 tests=1300 pass=1300 fail=0` (floor 1239)
- **sandbox** (the tier Tekton gates on) — `nix build --no-link .#checks.x86_64-linux.pytests .#checks.x86_64-linux.nodetests`
  → both derivations **built**, exit 0, clean tree (no `Git tree is dirty` warning).

## Round 2 files

| file | payload or scaffolding | note |
|---|---|---|
| `scripts/find-session.py` | **payload** | all of F1/F2/F3/F8 |
| `scripts/session-manager` | **payload** | **comment-only this round** (verified: the diff contains no non-comment line) |
| `claude/skills/find-session/SKILL.md` | **payload** (ships on a switch) | F1, F6, F8 |
| `claude/skills/session-manager/reference/payload-contract.md` | **payload** (ships) | F5's "reachable hosts only" removal |
| `scripts/tests/test_find_session_live.py` | scaffolding | |
| `scripts/tests/test_session_manager.py` | scaffolding | |

## Round 2: what I could NOT verify

- **The partial fleet is still simulated.** The laptop answered every real probe this round
  too, so F2's end-to-end reproduction used a stub `session-manager`. The subprocess, the
  JSON parse, `main()` and the exit code are real; the unreachability is not.
- **The `--opencode-only` "corpus never searched" half is disclosed, not closed.** A caller
  who ignores the notice still gets live rows instead of an opencode search. Forcing the
  archive would close it and is deliberately not done here (see F1).
- **Neither tier ran on the merged tree.** The auditor did gate it and reported a FAILURE in
  `scripts/browser-bridge/tests/test_server.py` that is **not from this PR** — server and
  test code are byte-identical between my head tree and the merged tree, it passes in
  isolation there, and wall times show no load inflation. Per the coordinator that is being
  handled separately and I have not touched it.

---

## ⚠ NEW SINCE ROUND 2 WAS WRITTEN: this PR now genuinely CONFLICTS with `main`

Measured after pushing `58916673`, and it changes the "13 commits behind, none touching my
6 files" picture the round-2 notes were written against:

```
$ gh pr view 989 --json mergeable,mergeStateStatus
  mergeable: CONFLICTING   mergeStateStatus: DIRTY

$ git merge-tree --write-tree 58916673 origin/main   # exit code, not a marker grep
  exit 1
  CONFLICT (content): Merge conflict in scripts/session-manager
  CONFLICT (content): Merge conflict in scripts/tests/test_session_manager.py
```

`main` is now **17 commits ahead**, and exactly one of them touches these files:
**`3d29aba1` — "feat(session-manager): publish the captured pane SCREEN … (#992)"**, which
adds `pane_preview` + `pane_preview_status` row fields.

🔴 **This is an overlap in the same regions, not an incidental one.** Both changes add row
fields, so both edit the row construction in `fold_windows`, `LEAN_ROW_FIELDS`, the row
field ledger test and the `--json` golden. A clean textual resolution would still leave a
**semantic** conflict — two field-ledger literals and one golden dict that each side edited
for a different reason — so this needs the merged result of those regions read, not just a
conflict resolved.

**I have deliberately NOT resolved it in this round.** It is outside the round's scope, it
arrived after the fix brief, and a wrong resolution in a file two PRs are both extending is
exactly the kind of thing that costs another audit cycle. It is also not the pre-existing
`browser-bridge` flake the coordinator is handling separately — that one is unrelated and
untouched.

**Recommendation:** rebase or merge as its own step.

> ✅ **RESOLVED in round 3 — see the section below.** Merged as `6914aa33`;
> `gh pr view 989` now reads `MERGEABLE`. This section is kept for the record
> of what the conflict was, not as a live warning.

---

# Round 3 — conflict resolved. `58916673` + `origin/main` → **`6914aa33`**

The conflict flagged at the end of round 2 is resolved. **Merge, not rebase** — additive, no
force-push, and every sha already reported to reviewers (`a6f09d5a`, `9f9dcbde`,
`58916673`) stays reachable.

`3d29aba1` (#992, "publish the captured pane SCREEN") is **already merged into `main`**, so
this was entirely a one-sided resolution with no other open PR's review thread at stake.

## 🔴 A clean git merge is not a clean merge — every overlapping region was READ

Both sides **add row fields**, so both edit the same enumerations for different reasons.
The textual conflict was the easy half.

| region | conflict? | ours | theirs (#992) | merged result |
|---|---|---|---|---|
| module docstring row list | **yes** | `hotkey_display` | `pane_preview`, `pane_preview_status` | **union**, in field order. A test asserts every row field appears in `sm.__doc__`, so a dropped name reds |
| `gather()` signature | **yes** | `match`, `match_path`, `prefilter_index_map` | `pane_preview=False` | **union** |
| `gather()` call in `main()` | **yes** | `match=`, `match_path=`, `prefilter_index_map=` + the `--match-path` notice | `pane_preview=args.pane_preview` | **union**, notice kept |
| test file (one hunk) | **yes** | §14/§15, 1,149 lines | §P `pane_preview`, 209 lines | **both**, concatenated |
| `fold_windows` row dict | auto | `"hotkey_display": hotkey_display(...)` | `"pane_preview"`, `"pane_preview_status"` | **carries all three** |
| `LEAN_ROW_FIELDS` | auto | `hotkey_display` | *deliberately none* | `hotkey_display` present, `pane_preview` **absent — and that is #992's own intent** |
| row FIELD ledger test | auto | `hotkey_display` | `pane_preview`, `pane_preview_status` | two-way `==`, enumerates **all three** |
| LEAN row ledger test | auto | `hotkey_display` | — | two-way `==`, `hotkey_display` and correctly no `pane_preview` |
| `--json` golden | auto | `"hotkey_display": "Alt+Shift+S"` | `"pane_preview": None`, `"pane_preview_status": "disabled"` | full-dict `==` carrying **all three** |
| `payload-contract.md` | auto | `hotkey_display` + `--match` sections | `--pane-preview` rows | both |

**The `LEAN_ROW_FIELDS` row is the one that needed checking rather than assuming.** A merge
that dropped `pane_preview` from the lean view would look identical to a correct one. I
parsed `origin/main`'s own copy: `pane_preview` is **not** in it there either, and main
carries a `(--lean drops pane_preview: …)` notice saying why. So the merged list is the
union of what each side *intended* to carry, not a casualty.

**The `--json` golden was the dangerous case the brief named** — a golden that silently
accepts a subset. It asserts **full-dict equality** and carries all three fields, so it was
read rather than inferred from a green run.

The test-file hunk was resolved **mechanically, not by retyping**: the merge base between
the two sides is empty (both merely append), so a script sliced both bodies verbatim and
concatenated them, asserting the base really was empty first. Retyping 1,300 lines is how a
golden silently loses a field.

## Gate — the first genuinely merged tree for this PR

Previous rounds could only gate the branch. Merged sha **`6914aa33`**, clean working tree.

- **dev-host** — `nix develop <worktree> --command bash scripts/gate.sh --tier both`
  → **`GATE: RESULT=PASS exit=0`**
  · pytest `TOTAL collected=18491 passed=18489 skipped=2 failed=0` (floor 15970)
  · node `TOTAL suites=5 files=39 tests=1300 pass=1300 fail=0` (floor 1239)
- **sandbox** (the tier Tekton gates on) — `nix build --no-link .#checks.x86_64-linux.pytests .#checks.x86_64-linux.nodetests`
  → both derivations **built**, exit 0, clean tree.

⚠ `scripts/browser-bridge/tests` passed **515/515** in my merged-tree run. That is one
observation, not a verdict on the flake the coordinator is handling separately — a
timing-sensitive test passing once says nothing. I have not touched it.

## `mergeable` re-read from GitHub (not inferred from the local merge)

```
$ gh pr view 989 --json mergeable,mergeStateStatus,headRefOid
  headRefOid: 6914aa33…   mergeable: MERGEABLE   mergeStateStatus: BLOCKED
```

`BLOCKED` here was the two required Tekton checks not yet reported for that head. The
conflict is gone, which is what this section is about.

> ⚠ **Do not read that sentence forward.** "Not yet reported" was true of `6914aa33` at
> the moment it was written and became FALSE at the next head: at `0c874add` the checks
> did report and `tekton/devrc-pytests` **failed** — see the correction in the round-4
> section below. `BLOCKED` means "a required check is not currently satisfied"; it does
> not distinguish *pending* from *failed*, and I twice read it as the former. As of
> `22ac6012` both checks are **SUCCESS** and the PR reads `MERGEABLE` / **`CLEAN`**.

## Live end-to-end, re-run on the merged tree

A merge is a code change and resets the verification gate, so every earlier live check was
re-run against `6914aa33`:

| check | result on the merged tree |
|---|---|
| `scan --match e` | 66 matched / 10 excluded, `summary.matched` agrees, `prefilter_window_indices: None` |
| `detail scratch2:1 --claude-only` | rc 3, "WINDOW … EXISTS but a ROW FILTER … removed it", `detail_filtered_out: true`, siblings `['1','2','3','4','5']` (pre-filter), 24-session map |
| `--live --any` | the ARCHIVE-ONLY notice fires |
| `--live --opencode-only` | notice **plus** the corpus-consequence sentence |
| `--live --limit 0` | rc 2, usage error |
| `--live --limit 1` | `LIVE (2 matched …)` + `(showing 1 of 2 …)` |
| partial fleet + `--tail` (stub host down) | rc **4**, "…but laptop did not answer… NOT 'there is nothing to tail'", `tail.coverage_complete: false` |
| partial fleet archive join | `LIVE` for the reachable host's session, **`UNMEASURED`** for the down host's, `live_coverage_complete: false` |

## 🔴 A deliberate behaviour trade, stated here rather than left in a source comment

**A corpus selector does NOT force the archive leg to run.** `--live --opencode-only` still
skips the 30 s transcript walk when the live scan matches, so the opencode corpus the caller
selected can go unsearched. The tool now says so loudly on stderr and tells you to pass
`--deep`.

Forcing the archive would close that outright. It is **not** done because it puts a 30 s
walk on every `--live --claude-only` — a bad trade for a flag people pass habitually, and a
behaviour choice rather than a defect fix. If you would rather have correctness over speed
there, say so and I will flip it; it is one condition.

## Round 3: what I could NOT verify

- **Nothing about this round was measured against a genuinely unreachable host.** Same
  limitation as rounds 1 and 2: the laptop answered every real probe, so the partial-fleet
  re-runs used the stub `session-manager`.
- **The merged tree has not been re-audited.** Round 3's delta covers `9f9dcbde..6914aa33`,
  i.e. the round-2 fixes *and* this resolution, and neither has been through an adversarial
  pass yet.
- **`mergeStateStatus: BLOCKED`** is the required checks pending on the new head; I have not
  waited for Tekton to report on `6914aa33`.

---

# Audit fix round 4 — `6914aa33` → **`0c874add`**

The round-3 delta audit returned no 🔴, three 🟡 and three 🟢. All six addressed.

## 🔴 The pattern, taken seriously

Round 1's two blockers, two of round 2's findings and **four of round 3's six** are one
shape: **a claim wider than the thing that enforces it.** Not logic bugs — sentences. 🟡-3
was the same class as the previous round's F4, *repeated for its own round*.

So this round does not fix a number by typing a better number, or a coverage sentence by
rewording it. **Where a claim can be derived, it is derived. Where it cannot, it is deleted
rather than restated.**

## 🟡-1 — the shipped exit-code contract stated two things the code contradicts · FIXED

`claude/skills/find-session/SKILL.md` is **payload** — it ships to both hosts and is what an
agent reads before branching on an exit code — and **no test read it**.

| claim | verdict |
|---|---|
| *"`3` … on a **FULLY MEASURED** fleet"* | **False.** Two matches with a host down also exits 3, while the run prints `this candidate list is INCOMPLETE`. A wrapper branching `rc == 3 ⇒ complete candidate list` reproduces the wrong-window failure in the caller. |
| *"`4` = the live scan failed or no host answered"*, unqualified | **False.** Every source of that code is on the tail path. |

🔴 **Measured at BOTH shas for (b): a failed scan without `--tail` exits `0` at `6914aa33`
and at `0c874add`.** The *code* was always right; only the doc was wrong. That is why the
behavioural probes for it are green at the audited tip and the *doc* probes are red — which
is the finding's shape exactly.

**Fixed by inverting the direction of derivation.** The sentences are `EXIT_CONTRACT` in
`scripts/find-session.py`; the doc copies them verbatim; and a new
`scripts/tests/test_find_session_skill_contract.py` pins the copy **both ways** *and* pins
each sentence against the behaviour it describes — because a doc agreeing with a constant is
still two copies of an unchecked belief. `test_every_EXIT_UNAVAILABLE_source_is_on_the_tail_path`
is **structural (AST)**, so a *new* return added off the tail path fails there rather than
silently falsifying the doc.

## 🟡-2 — `tail.coverage_complete` published a measured-looking `false` for a scan that never ran · FIXED

The exact shape F3 removed **one field over, in the same commit** — and `SKILL.md` names this
field as the branch point, so the doc pointed the reader at the one field that could not
discriminate.

`live_coverage_complete` stays as the two-valued **predicate** (correct for branching);
`live_coverage_state` is the publishable **tri-state**. They differ on exactly one case, and
a test asserts that. `unavailable` deliberately stays `false` — that scan *ran*.

## 🟡-3 — the coverage ledger was wrong again · COUNTS DELETED, not corrected

Claimed 29/16/13; the measurement was 35/17/18. Root cause worth recording: **five nodes
were added later in the same commit** (to close my own mutation survivor) *after* the number
was typed.

🔴 **A third correction would have been the third wrong number.** The counts cannot be
derived at test time — they need the head tests run against an old sha — so they are
**deleted from both test files**, with the reason in place of the number. Understated
coverage that reads as precise is worse than no number. What stays is the **ledger**: a name
either resolves or it does not, and a test checks that. Per-round matrices live here, each
with its sha and method.

## 🟢-1 — a guard cited for a region it does not cover · CLAIM RETRACTED

> ⚠ **RETRACTION.** The round-3 section above, and the merge commit message, say the
> docstring row-list resolution is protected because *"a test asserts every row field appears
> in `__doc__`"*. **That is not true.**
> `test_the_row_FIELD_LEDGER_fails_when_it_grows_or_shrinks` does `assert field in
> sm.__doc__` — a substring check across the whole ~500-line docstring — and **24 of 32 row
> names occur elsewhere in it**, including all three fields the conflict was about. Two
> mutants deleting `pane_preview, pane_preview_status` and `hotkey_display` from the row
> enumeration **survive the full suite**.
>
> **The merged docstring is still correct** — it was read directly, and that reading is what
> the round-3 table reports. The guard simply is not the reason. The guard is **pre-existing
> on `origin/main` and is not touched by this PR**; only the claim was mine, so only the
> claim is withdrawn. **Follow-up worth doing, deliberately not done here:** scope that
> assertion to the row-enumeration paragraph rather than the whole docstring.

## 🟢-2 — the corpus sentence fired even under `--deep` · FIXED

Telling a caller to *"pass `--deep`"* in a run that already passed `--deep` is the same
"noise that trains the reader to skip the line" this file refused to append to `--since`.
Measured on the real fleet: **1 occurrence at `6914aa33`, 0 at `0c874add`** with the flag
still named, and **1** in the no-`--deep` control.

## 🟢-3 — a `SUPPRESS`-defaulted flag could escape the partition · FIXED

The gate read `set(vars(parse_args([...])))`, which cannot see a flag declared
`default=argparse.SUPPRESS` — so such a flag sat in neither half and the equality still held,
while the gate's own comment claimed it "fails the suite". `build_parser` is exposed and
`parser_dests()` reads `_actions`. `test_a_SUPPRESSED_flag_cannot_escape_the_partition`
plants exactly that flag as the control.

`SKILL.md`'s **"SIX flags"** count is gone — a count is a claim nothing enforces. The
enumeration is pinned **two-way** against `ARCHIVE_ONLY_FLAGS`, bracketed by two anchor
phrases.

## ⚠ Two measurement bugs of my own, caught mid-round

Both the same class as the findings, and both fixed rather than worked around:

1. **My first doc-enumeration guard used a whole-body substring check** and a mutant deleting
   `--opencode-only` **SURVIVED** — the bullet's continuation prose names it again. That is
   the round-3 🟢-1 shape, reproduced while writing its replacement. Now bracketed to the
   enumeration and compared as a set.
2. **My red/green matrix script split node ids on `::` and kept only the name**, collapsing
   the two same-named ledger tests into one and undercounting green by exactly one. Fixed to
   keep the file; the numbers below are post-fix.

---

## Round 4: red at `6914aa33` / green at `0c874add`

Node-level: collect node ids at both shas (file-qualified), run the head tests against base
source under `PYTHONDONTWRITEBYTECODE=1`.

| | count |
|---|---|
| NEW nodes | **28** |
| …RED at `6914aa33` | **20** |
| …GREEN at `6914aa33` | 8 |
| MODIFIED and red | 1 (`test_the_archive_only_ledger_PARTITIONS_every_argparse_destination`) |
| removed / unaccounted | 0 / 0 |

**At `0c874add`: 792 passed, 0 failed** across the three files.

The 8 green are named in `R3_GREEN_AT_AUDITED_TIP` in each file, with a resolve-check. They
are the negative/positive controls (a measured partial fleet must still publish `false`; the
corpus sentence must still fire without `--deep`; exit 3 must still arise on a full fleet;
exit 4 must still arise under `--tail`), the two ledger gates, **and the two
`test_exit_4_is_TAIL_ONLY…` params — green because the behaviour was always right and only
the doc was wrong**, which is the finding, not a gap.

## Round 4 mutation sweep — 16/16 killed by their own named guard

`PYTHONDONTWRITEBYTECODE=1`, `__pycache__` cleared between mutants, green control before and
after restore. Positive control: `EXIT_AMBIGUOUS = 3 → 0`, killed by
`test_the_exit_CODE_VOCABULARY_is_pinned_to_LITERALS`.

- **🟡-1** (6): the doc loses a contract sentence · documents a code the script cannot return ·
  two codes collapse onto one integer · exit 3 starts claiming a full fleet · a failed scan
  without `--tail` stops exiting 0 · an `EXIT_UNAVAILABLE` return appears off the tail path.
- **🟡-2** (3): the published coverage becomes the two-valued predicate again · the tri-state
  nulls a *measured* `unavailable` scan · the tri-state collapses onto the predicate.
- **🟢-2** (2): the sentence fires under `--deep` again · it never fires.
- **🟢-3** (4): `parser_dests` reads a namespace again · leaks `help` into the partition ·
  the doc stops naming a flag · a flag COUNT comes back.

## Round 4 gate

Tip **`0c874add`**, clean working tree.

- **dev-host** — `nix develop <worktree> --command bash scripts/gate.sh --tier both`
  → **`GATE: RESULT=PASS exit=0`**
  · pytest `TOTAL collected=18519 passed=18517 skipped=2 failed=0` (floor 15970)
  · node `TOTAL suites=5 files=39 tests=1300 pass=1300 fail=0` (floor 1239)
- **sandbox** (the tier Tekton gates on) — `nix build --no-link .#checks.x86_64-linux.pytests .#checks.x86_64-linux.nodetests`
  → both derivations **built**, exit 0, clean tree.
- `gh pr view 989 --json mergeable,mergeStateStatus` → **`MERGEABLE`** / `BLOCKED`
  on head `0c874add`. (It read `UNKNOWN` immediately after the push — GitHub
  recomputing — so that was the settled value, not the first one returned.)

> 🔴 **CORRECTION — this section was WRONG when written, and the error is exactly the
> class this PR keeps being audited for.** It read `BLOCKED` as "the required checks
> have not reported yet". They *had* reported: **`tekton/devrc-pytests` FAILED at
> 2026-08-29T05:25:58Z on head `0c874add`**. My two local tiers were green and I
> reported the gate from them — the very thing the brief for round 0 said not to do.
>
> **The failure is not this change.** Independently verified by the coordinator:
> `scripts/tests/test_subsystem_store_api.py` is byte-identical to `origin/main` and
> exists on both sides, `request_queue_size` is never set anywhere in the tree
> (`ThreadingHTTPServer`'s default backlog of 5 against 8 simultaneous connects), and
> four samples split FAIL/FAIL/PASS at head with a clean PASS at `origin/main`. It is
> being handled separately and I have not touched it.
>
> ⚠ **One residual coupling that IS mine, stated rather than hidden:** the suite runs
> `-n 4 --dist loadfile`, so **adding a test file changes worker packing** and therefore
> which tests run concurrently with that racy one. `scripts/tests/test_find_session_skill_contract.py`
> is new in round 4 and may be **unmasking** a latent flake even though it cannot cause
> it. Round 5 adds no new file, but it does change that file's node count, which is the
> same lever.

## Round 4 files

| file | payload / scaffolding |
|---|---|
| `scripts/find-session.py` | **payload** |
| `claude/skills/find-session/SKILL.md` | **payload** (ships on a switch) |
| `scripts/tests/test_find_session_skill_contract.py` | scaffolding — **NEW**, `git add`ed |
| `scripts/tests/test_find_session_live.py` | scaffolding |
| `scripts/tests/test_session_manager.py` | scaffolding (comment-only this round) |

## Round 4: what I could NOT verify

- **🟡-1(a) was not reproduced against a genuinely unreachable host.** The exit-3 partial-fleet
  case is covered hermetically and by the auditor's own live run; my live re-runs used the
  stub, as in every prior round.
- **The `__doc__` guard is left as found** (🟢-1). The docstring is correct today by reading,
  not by enforcement, and the follow-up is proposed rather than done.
- **F7 remains knowingly deferred** — `excluded_shells` still publishes `0` over a dead fleet
  beside `matched`'s `an unmeasured number of`.
- The two items the coordinator excluded — the `DEVRC-GITENV-VIOLATION` teardown errors from
  another session writing the operator's global git config, and the `browser-bridge` flake —
  were not investigated or touched.

---

# Audit fix round 5 — `0c874add` → **`22ac6012`**

The round-4 delta audit returned no 🔴, two 🟡 and three 🟢. All five addressed.

**Both 🟡 are in the scaffolding written LAST round to close this ladder's own recurring
shape** — guards that pass while the thing they advertise is false. Neither broke anything
today; both would have let the next drift ship silently.

## 🟡-1 — the doc↔contract pin did not bind a SENTENCE to its CODE · FIXED

Two guards stood here: one asked whether each sentence appeared *somewhere*, the other
compared only the *set* of codes. **Neither read the pairing.**

Transposing the exit-3 and exit-4 rows — so the shipped skill says `3` means *"something the
tail needed was NOT measured"* and `4` means *"could not resolve to exactly one live
window"*, exactly inverted — left **122/122** passing, and **377/377** across every generic
skill gate. Nothing else in the tree reads that file.

The failure that buys is this PR's own founding argument relocated to the caller: a wrapper
branches `rc == 3 ⇒ report unmeasured` / `rc == 4 ⇒ here are the candidates`, and under the
inverted table treats an ambiguous multi-window match as a scan failure and an unmeasured
tail as a settled candidate list.

**Both guards replaced by ONE equality on `{code: sentence}`.** The transposition is mutant
**R01** below and now dies.

## 🟡-2 — the "AST-structural" guard whitelisted the tail path's COMPLEMENT, and was blind to a literal · FIXED

`ast.If.end_lineno` spans the `orelse`, so `range(node.lineno, node.end_lineno + 1)` marked
the `else:` body of `if a.tail is not None:` as *on the tail path* — when it is
definitionally the no-`--tail` path. And an `ast.Name` scan cannot see `return 4`. Both
hazards were measured green by the auditor.

🔴 **The guard was working, not dead** — the auditor's positive control (the same return one
block later) *was* killed by it, and renaming `_tail_outcome` makes it red rather than
vacuous. So this **tightens a live guard**:

- `_tail_path_lines` whitelists `node.body` only;
- `exit_unavailable_sources` scans for the value by **name OR literal**;
- each blind spot has its own negative control graded by the **real** helper;
- `test_renaming_the_tail_helper_makes_this_guard_RED_not_vacuous` pins the loud-failure
  property so nobody turns it into a silent pass.

The docstring headline ("STRUCTURAL, so the sentence stays true of code nobody has written
yet") is now true of the scan rather than wider than it. Mutants **R05** (`else:`-branch
return) and **R06** (bare literal `4`) are the auditor's own, and both die.

## 🟢-1 — two hand-typed counts survived in the files that now forbid them · FIXED

`test_find_session_live.py` said *"All 33 nodes … all 33 went red"* (the file collects far
more now) and `test_session_manager.py` said *"45 collected §14 nodes, 38 RED and 7 GREEN"*.
A reader hit the deliberate-absence note and then a precise-looking count **in the same
file**, which reads as one the policy vetted. Both deleted, with the reason in their place.

## 🟢-2 — the exit-2 sentence named a cause nothing asserted · FIXED

*"or an unparseable `--since`"* was true but pinned nowhere, and that path used a bare
`sys.exit(2)` rather than `return EXIT_USAGE` — so renumbering the constant would have split
a documented pair silently.

- the path returns the **constant** now;
- **every cause the sentence names** is exercised (`--since`, `--limit` below 1, `--tail`
  without `--live`), and the probe asserts the cause is actually named in the sentence, so
  the test and the contract cannot drift apart;
- a new AST guard fails if **any** declared exit value is produced as a bare literal, with a
  positive control proving the offender shape is matchable.

Live, both shas: `--since not-a-date` → **rc 2** at `0c874add` and at `22ac6012`. The
behaviour was already right; what changed is that it goes through the name and is pinned.

## 🟢-3 — the coverage disclaimer was on exit 3 but not exit 0 · FIXED

**rc 0 is the code a caller ACTS on.** Verified live on the merged tree: one match with
`laptop` down under `--tail` → `rc 0`, `tail.refused: false`, `tail.resolved:
{workbench, scratch3:2}`, `tail.coverage_complete: false`, `tail.hosts_unreachable:
["laptop"]`. The exit-0 sentence now says the code carries no coverage claim and points at
the field that does.

Also cleaned while editing those lines: the dead `- {c for c, _ in [(0, 0)]}` term and three
unused imports in the new test file.

---

## Round 5: red at `0c874add` / green at `22ac6012`

Node-level, file-qualified ids, head tests run against base source under
`PYTHONDONTWRITEBYTECODE=1`.

| | count |
|---|---|
| NEW nodes | **11** |
| …RED at `0c874add` | **2** |
| …GREEN at `0c874add` | 9 |
| removed (the two weak guards replaced by the mapping equality) | 2 |
| modified-and-red / unaccounted | 0 / 0 |

**At `22ac6012`: 801 passed, 0 failed** across the three files.

🔴 **Only 2 red, and that is the correct claim rather than a thin one.** 🟡-1 and 🟡-2 are
**gaps in guards, not broken artifacts** — the shipped table and the code were already right
at `0c874add`, so a guard that now catches the hazard passes there too. Offering a
red-at-base row for them would be the overstatement this ladder keeps finding. **Their
evidence is the mutation sweep against the auditor's own planted hazards**, each of which
was measured green against the old guards. The 2 red are 🟢-2's real behaviour change. The 9
green are ledgered in `R4_GREEN_AT_AUDITED_TIP` with a resolve-check.

⚠ **A measurement error of my own, caught and corrected here.** My first re-run of this
matrix reported `11 new / 0 red / 1 green` — because the base worktree still had head test
files copied into it from the previous round's run, so "base" was not base. Recreated
pristine (`git status --porcelain` empty) before the numbers above. Reported because a
silently reused worktree is exactly the stale-observation trap.

## Round 5 mutation sweep — 12/12 killed by their own named guard

`PYTHONDONTWRITEBYTECODE=1`, `__pycache__` cleared between mutants, green control before the
batch and again after restore. Positive control: `EXIT_AMBIGUOUS = 3 → 0`, killed by
`test_the_exit_CODE_VOCABULARY_is_pinned_to_LITERALS`.

| mutant | killed by |
|---|---|
| **R01 — transpose the exit-3 and exit-4 rows** *(the auditor's own)* | `…doc_table_PAIRS_each_code_with_its_own_contract_sentence` |
| R02 — a row keeps its code but loses its sentence | same |
| R03 — the doc documents a code the script cannot return | same |
| R04 — a contract sentence reworded only in the CONSTANT | same |
| **R05 — `EXIT_UNAVAILABLE` returned in the `else:` branch** *(the auditor's own)* | `…every_EXIT_UNAVAILABLE_source_is_on_the_tail_path` |
| **R06 — exit 4 produced as a BARE LITERAL** *(the auditor's own)* | same |
| R07 — the whitelist spans the `orelse` again | `…tail_path_whitelist_EXCLUDES_the_else_branch` |
| R08 — the source scan goes blind to literals again | `…source_scan_SEES_a_bare_integer_literal` |
| R09 — the `--since` path uses a bare literal again | `…no_exit_path_uses_a_BARE_LITERAL_instead_of_the_constant` |
| R10 — an unparseable `--since` stops exiting 2 | `…every_CAUSE_the_exit_2_sentence_NAMES_really_exits_2` |
| R11 — the exit-0 coverage disclaimer is dropped | `…doc_table_PAIRS_each_code_with_its_own_contract_sentence` |
| PC — `EXIT_AMBIGUOUS = 3 → 0` | `…exit_CODE_VOCABULARY_is_pinned_to_LITERALS` |

⚠ R11's first spelling spliced mid-string and broke the parse, reddening every test in the
file — a **MISDIRECTED** result, not a kill. Rewritten to replace the whole tuple entry so
the mutant is valid Python; only then does it count.

## Round 5 gate — and the gate history, stated plainly

Tip **`22ac6012`**, clean working tree.

- **dev-host** — `nix develop <worktree> --command bash scripts/gate.sh --tier both`
  → **`GATE: RESULT=PASS exit=0`**
  · pytest `TOTAL collected=18528 passed=18526 skipped=2 failed=0` (floor 15970)
  · node `TOTAL suites=5 files=39 tests=1300 pass=1300 fail=0` (floor 1239)
- **sandbox** — `nix build --no-link .#checks.x86_64-linux.pytests .#checks.x86_64-linux.nodetests`
  → both derivations **built**, exit 0, clean tree.
- **The required checks, re-read from GitHub** (not inferred from the local run):
  `tekton/devrc-pytests` **SUCCESS**, `tekton/devrc-nodetests` **SUCCESS** on head
  `22ac6012`; `mergeable: MERGEABLE`, `mergeStateStatus: **CLEAN**`.

🔴 **THE GATE WENT RED IN BETWEEN, AND IT IS GREEN BY SAMPLING, NOT BY REPAIR.**
`tekton/devrc-pytests` **failed** at `0c874add` (2026-08-29T05:25:58Z) on a concurrency
flake in `scripts/tests/test_subsystem_store_api.py` — a file **byte-identical to
`origin/main`** and present on both sides. Mechanism: `ThreadingHTTPServer`'s default
`request_queue_size = 5` against 8 simultaneous connects; the field is set **nowhere** in the
tree. Four samples split FAIL / FAIL / PASS at head with a clean PASS at `origin/main`.
**Nothing was fixed** — the check is green at `22ac6012` because this run sampled the other
side of a race. It is being handled separately and I have not touched it.

⚠ **A residual coupling that IS mine.** The suite runs `-n 4 --dist loadfile`, so **adding a
test file changes worker packing** and therefore which tests run concurrently with that racy
one. `scripts/tests/test_find_session_skill_contract.py` is new as of round 4 and **cannot
cause** the flake, but may be **unmasking** it. Round 5 adds no new file yet still changes
that file's node count — the same lever. Stated rather than left for the next red run to
rediscover.

## Round 5 files

| file | payload / scaffolding | lines |
|---|---|---|
| `scripts/find-session.py` | **payload** | 14 |
| `claude/skills/find-session/SKILL.md` | **payload** (ships on a switch) | 2 |
| `scripts/tests/test_find_session_skill_contract.py` | scaffolding | 343 |
| `scripts/tests/test_find_session_live.py` | scaffolding | 13 |
| `scripts/tests/test_session_manager.py` | scaffolding (comment-only) | 11 |

## Round 5: what I could NOT verify

- **The green Tekton check is a sample, not a repair** — see above. A second push could red
  it again without anything in this PR changing.
- **Nothing this round was measured against a genuinely unreachable host**; 🟢-3's live
  reproduction used the stub `session-manager`, as in every prior round.
- **F7 remains knowingly deferred** — `excluded_shells` still publishes `0` over a dead
  fleet beside `matched`'s "an unmeasured number of".
- **The `__doc__` substring guard is still as found** (round-4 🟢-1) — the merged docstring
  is correct by reading, not by enforcement, and tightening it stays a proposed follow-up.
- The two items the coordinator excluded — the `DEVRC-GITENV-VIOLATION` teardown errors from
  another session writing the operator's global git config, and the `browser-bridge` flake —
  were not investigated or touched.
