### PR TITLE
feat(session-manager): publish the captured pane SCREEN the collector already had and threw away (tmux-webapp rank 3)

### DIFF
--- a/claude/skills/session-manager/SKILL.md
+++ b/claude/skills/session-manager/SKILL.md
@@ -174,8 +174,8 @@ So read them from the run, not from here. `report["caveats"]` is structured and 
 prints one footer line each **unconditionally**, so an agent that runs the script cold gets
 them anyway. The vocabulary is the keys of `CAVEATS` in `scripts/session-manager` —
 `claude_detection`, `fuzzyclaw_scope`, `kind_scope`, `ledger_scope`, `waiting_signal`,
-`unsent_prompt` — which `measured_caveats` fills in per scan. That list is gated against the
-script's own `CAVEATS`; the prose this section used to hold was not, and had rotted to five.
+`unsent_prompt`, `pane_preview` — which `measured_caveats` fills in per scan. That list is
+gated both ways against the script's own `CAVEATS`.
 
 ## 🔴 Read the exit code — the two zeroes are different facts
 

--- a/claude/skills/session-manager/reference/payload-contract.md
+++ b/claude/skills/session-manager/reference/payload-contract.md
@@ -17,6 +17,7 @@ _Moved verbatim out of `SKILL.md` on 2026-08-21, when the body was cut from 23,2
 | `--claude-only` | drop the **shell** rows (`CLASS=shell`) — a `cluster` dispatch is an agent and is KEPT. Every count then describes the FILTERED set; `summary.excluded_shells` says how many went and `summary.kinds_excluded_by_filter` names any kind removed entirely |
 | `--no-ch` | skip ClickHouse — the client is never constructed |
 | `--no-capture` | skip the pane scrape; **every** `waiting_probable` AND `unsent_prompt` becomes `null` (both roll-up numbers `null`, never `0`) |
+| `--pane-preview` | publish each Claude pane's **visible screen** as `pane_preview`. Costs no extra tmux work (the capture already runs — `waiting`/`unsent` are derived from it and it used to throw the screen away), but makes the document **2.63x** larger: measured live back to back, 122,731 B without / 322,204 B with. Off by default for that reason; `--lean` drops it, so do not pass both |
 | `--fuzzyclaw` / `--no-fuzzyclaw` | the task-file join is **OFF by default** (see below) |
 | `--no-ledger` | skip the per-host agent-ledger read. Rows then have **no age and no session id** — the #419 view, reproducible on demand |
 | `--plain` | `tail` only: strip ANSI at the source instead of `sed`-ing it out |
@@ -120,6 +121,16 @@ unconditionally — an agent that runs the script cold never reads this file:
   **no longer discarded** — the caveat points at `unsent_prompt`, which now carries it.
 - `unsent_prompt` — the status vocabulary, the claude-rows-only scope, and `separate_from:
   waiting_probable` as a FIELD rather than a sentence a consumer has to parse.
+- `pane_preview` — the status vocabulary, the claude-rows-only scope, the opt-in flag and
+  the per-pane byte cap, all as FIELDS. 🔴 It is rendered **even though the field is off by
+  default**, and that is the point: a reader seeing `pane_preview: null` on every row
+  otherwise cannot tell "these panes are blank" from "nobody asked for the text".
+  `pane_preview_status` is the discriminator — `disabled` (never asked, and it beats every
+  other reason), `not_claude` (shells are never captured), `uncaptured` / `skipped` /
+  `error` (asked, not measured), `truncated` (measured, but this is a PREFIX), `ok`.
+  🔴 It is the **visible screen and never scrollback** — scrollback costs ~4,014 B per line
+  fleet-wide and would breach clawgate's 4 MB ingest at ~650 lines/pane. Use `tail` for
+  history, one window at a time.
 
 …plus `report["not_measured"]` and a `▸ NOT MEASURED HERE` section, which are the same idea
 one level out: not a qualification on a number this tool produced, but the list of

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -167,6 +167,14 @@ HONEST LIMITS (stated, not implied away — AND CARRIED IN THE OUTPUT as
     it, and a draft taller than the box is not recognised; both report
     `no_input_box`, which is UNMEASURED, never an empty draft. Shell panes are
     never scraped at all. See CAVEATS["unsent_prompt"].
+  * `pane_preview` is OFF unless `--pane-preview` is passed, because it is the
+    one field that changes the payload's order of magnitude (measured live,
+    both forms back to back: 122,731 bytes without, 322,204 with — 2.63x).
+    It is the VISIBLE SCREEN only — never scrollback, which would
+    breach the consumer's 4 MB ingest cap at ~650 lines per pane — and it is
+    capped per pane, with `pane_preview_status: "truncated"` saying so. Shell
+    panes are never captured, so they report `not_claude`, never an empty
+    screen. See CAVEATS["pane_preview"].
   * PR review state, the mail queue, cluster alerts, the durable initiative
     board and GUI windows outside tmux are NOT measured by this tool at all.
     They are enumerated in `report["not_measured"]` with the skill that owns
@@ -195,7 +203,8 @@ and the roll-ups a caller usually wants are:
 Each row carries: kind, host, session, window_index, window_id, window_name,
 codename, label, label_source, hotkey, pane_id, path, command, task, claude,
 busy, age_secs, age_source, status, waiting_probable, waiting_signals,
-waiting_status, unsent_prompt, unsent_prompt_status, claude_session_id, runtime,
+waiting_status, unsent_prompt, unsent_prompt_status, pane_preview,
+pane_preview_status, claude_session_id, runtime,
 ledger, fuzzyclaw, panes. The row ledger is pinned by a test.
 
 🔴 `waiting_probable` AND `unsent_prompt` ARE TWO SIGNALS, NOT ONE
@@ -561,6 +570,66 @@ _PROMPT_MARK_RE = re.compile(r"^\s*❯[ \t]?")
 UNSENT_STATUSES = ("ok", "no_input_box", "uncaptured", "not_claude",
                    "skipped", "error")
 
+# --------------------------------------------------------------------------- #
+# 🔴 `pane_preview` — THE CAPTURED TEXT ITSELF, WHICH THIS TOOL ALREADY HAD AND
+# THREW AWAY.
+#
+# `waiting_probable` and `unsent_prompt` are both DERIVED from the capture batch
+# below, which then discards the screen it read. clawgate's tmux read model
+# (`tmux_snapshots`, migration 0027) wants that screen: a grid of panes an
+# operator can scan without opening 46 terminals. Publishing it costs ZERO extra
+# tmux work — the text is already in `captures` when `fold_windows` runs.
+#
+# 🔴 OFF BY DEFAULT, because it is the one field that changes the payload's
+# ORDER OF MAGNITUDE. Measured 2026-08-28 across the live fleet: the 46 Claude
+# panes (36 workbench + 10 laptop) carry 154,171 bytes of visible screen, which
+# JSON-encodes against a whole report of 122,731 bytes to give 322,204 — a
+# 2.63x document, measured by running both forms back to back rather than by
+# adding an estimate to a baseline (an earlier revision of this comment carried
+# the estimate, 2.9x, and it was wrong by a tenth — the two forms are one
+# command apart, so there was never a reason to project it).
+# Every other consumer (`drift_phase2`, `cairn_who`, the skills) reads
+# a handful of scalar fields and would pay that for nothing, so the text rides
+# an explicit `--pane-preview` and nothing else changes shape.
+#
+# 🔴 VISIBLE SCREEN ONLY — SCROLLBACK IS NOT AN OPTION HERE, and the reason is a
+# hard bound rather than taste. clawgate's ingest caps one push at 4 MB
+# (`maxTmuxPushBytes`). Measured across the same fleet, each extra line of
+# scrollback costs ~4,014 bytes fleet-wide, so `-S -1000` computes to 6.13 MB and
+# the cap is breached at roughly 650 lines per pane. `capture-pane` with no `-S`
+# is the visible screen, and that is deliberate, not a default left unexamined.
+# Scrollback belongs to `tail`, which serves one window on demand.
+#
+# The status vocabulary is UNSENT_STATUSES' five shared reasons — the preview
+# rides the same capture, so it shares every reason a capture did not happen —
+# plus two of its own:
+#   disabled   — `--pane-preview` was not passed. NOT a measurement.
+#   truncated  — the pane WAS captured and its screen exceeded
+#                MAX_PANE_PREVIEW_BYTES, so `pane_preview` holds a PREFIX.
+# 🔴 `truncated` is a separate status rather than a silently short string: a
+# consumer rendering a prefix as if it were the whole screen shows an operator a
+# pane that ends mid-word and reads as a crashed agent.
+PREVIEW_STATUSES = ("ok", "truncated", "uncaptured", "not_claude",
+                    "skipped", "error", "disabled")
+
+# 🔴 THE PER-PANE CAP, AND WHAT IT DOES *NOT* BOUND.
+#
+# Measured 2026-08-28: the largest single visible pane on the fleet was 6,616
+# bytes (workbench) / 3,125 (laptop), against panes up to 343x65. 16 KiB is ~2.4x
+# that largest observed screen, so truncation is a guard against a pathological
+# pane rather than something the normal fleet hits.
+#
+# 🔴 IT BOUNDS ONE PANE, NOT THE DOCUMENT, and the difference is worth stating
+# because the arithmetic is not reassuring at the limit: MaxWindowsPerHost is 600
+# server-side, and 600 x 16 KiB is 9.8 MB — over the 4 MB body cap. Today's fleet
+# is 46 Claude panes, so the reachable worst case is ~750 KB and the cap is ~5x
+# away; it becomes reachable somewhere north of 250 full-screen Claude panes. The
+# backstop is the server's `MaxBytesReader`, which rejects the push LOUDLY (413)
+# and keeps the last good snapshot — stale-and-labelled, which is the failure
+# this read model already chose everywhere else. This comment exists so nobody
+# reads the per-pane cap as a document bound it is not.
+MAX_PANE_PREVIEW_BYTES = 16 * 1024
+
 # 🔴 The per-pane capture batch. ONE tmux invocation per host captures every
 # Claude pane's visible screen, with a `display-message` marker between them —
 # 40 separate `capture-pane` calls over SSH would be 40 round trips.
@@ -846,6 +915,34 @@ CAVEATS = {
                  "different and noisier thing. A draft taller than the input "
                  "box, or a modal that replaces the box, reports "
                  "`no_input_box`, i.e. UNMEASURED, never an empty draft."),
+    },
+    "pane_preview": {
+        "method": "capture_pane_visible_screen",
+        "scope": "claude_rows_only",
+        "statuses": list(PREVIEW_STATUSES),
+        "opt_in_flag": "--pane-preview",
+        "max_bytes_per_pane": MAX_PANE_PREVIEW_BYTES,
+        "note": ("The pane's VISIBLE SCREEN as `capture-pane` returns it, "
+                 "published so a consumer can render a grid without opening "
+                 "every terminal. OFF unless `--pane-preview` is passed: it is "
+                 "a 2.63x document (measured live across 46 Claude panes: "
+                 "122,731 bytes without, 322,204 with), which "
+                 "every consumer reading a scalar field would pay for nothing. "
+                 "🔴 It is the visible screen and NOT scrollback — each extra "
+                 "line costs ~4,014 bytes fleet-wide, so scrollback would "
+                 "breach a 4 MB ingest at ~650 lines per pane; `tail` serves "
+                 "one window's history on demand instead. A screen over "
+                 "max_bytes_per_pane is cut on a character boundary and "
+                 "reported `truncated`, NEVER silently shortened — an "
+                 "unlabelled prefix ends mid-word and reads as a crashed "
+                 "agent. `pane_preview: null` with status `disabled` means the "
+                 "flag was not passed and NOTHING was asked; with any other "
+                 "status it means asked and not measured. Shell panes are "
+                 "never captured (`not_claude`), so a fleet of shells reports "
+                 "no previews rather than empty screens. The text is a "
+                 "point-in-time read: it is exactly as fresh as the scan, and "
+                 "a consumer polling on an interval renders a screen up to one "
+                 "interval old."),
     },
 }
 
@@ -1344,6 +1441,37 @@ def parse_captures(raw, nonce) -> dict:
         elif cur is not None:
             out[cur].append(line)
     return {k: "\n".join(v) for k, v in out.items()}
+
+
+def build_pane_preview(text, max_bytes=MAX_PANE_PREVIEW_BYTES) -> dict:
+    """The captured screen, bounded, with a status that says which it is.
+
+    Returns `{"text": str|None, "status": "ok"|"truncated"}`.
+
+    🔴 THE CAP IS IN BYTES AND THE CUT IS ON A CHARACTER BOUNDARY. The bound
+    that matters is the one on the wire — clawgate's 4 MB body cap counts
+    encoded bytes, not code points — but slicing a UTF-8 encoding at an
+    arbitrary offset can land mid-sequence, and a pane full of box-drawing glyphs
+    (which is every Claude Code TUI) is exactly where that happens. Encoding,
+    slicing and decoding with `errors="ignore"` drops the partial sequence at the
+    tail rather than emitting a replacement character or raising.
+
+    🔴 TRUNCATION IS REPORTED, NEVER SILENT. A prefix that is not labelled is
+    indistinguishable from a pane whose screen really did end there, and the
+    consumer of this field renders it to a human deciding whether an agent is
+    stuck. `ok` means "this is the whole visible screen"; anything else means it
+    is not, and `PREVIEW_STATUSES` enumerates the rest.
+
+    An EMPTY capture is `ok` with an empty string, not None: the pane was read
+    and the screen was blank, which is a measurement. `None` is reserved for the
+    paths where nothing was read at all, and `fold_windows` owns those.
+    """
+    raw = text or ""
+    enc = raw.encode("utf-8")
+    if len(enc) <= max_bytes:
+        return {"text": raw, "status": "ok"}
+    return {"text": enc[:max_bytes].decode("utf-8", errors="ignore"),
+            "status": "truncated"}
 
 
 def _is_status_line(line) -> bool:
@@ -1855,7 +1983,8 @@ def index_tasks_by_window(tasks) -> dict:
 def fold_windows(panes, host, slots=None, task_index=None,
                  threshold=DEFAULT_STALE_THRESHOLD, now=None,
                  slot_window_ids=None, captures=None,
-                 capture_status="skipped", ledger_index=None) -> list:
+                 capture_status="skipped", ledger_index=None,
+                 pane_preview=False) -> list:
     """Collapse panes into one row per (session, window_index).
 
     A window is `claude` if ANY of its panes is; the row's task/busy/pane_id
@@ -1962,15 +2091,24 @@ def fold_windows(panes, host, slots=None, task_index=None,
         # NOT-MEASURED PATHS, but is resolved into its OWN pair of fields. It is
         # NEVER mixed into `w_probable` — see the comment block at
         # `UNSENT_STATUSES` for the measurement that makes that load-bearing.
+        # 🔴 `pane_preview` RIDES THE SAME CAPTURE AGAIN, so it inherits the same
+        # four not-measured paths — but it gets its OWN status for the reason
+        # `unsent_prompt` did: a pane that captured perfectly can still yield a
+        # `truncated` preview, which is a fact about the SCREEN, not about the
+        # capture. `disabled` is checked first and beats every other reason,
+        # because when the flag is off nothing about the pane was asked.
         if not is_claude:
             w_status, w_probable, w_signals = "not_claude", None, None
             u_status, u_text = "not_claude", None
+            p_status, p_text = "not_claude", None
         elif captures is None:
             w_status, w_probable, w_signals = capture_status, None, None
             u_status, u_text = capture_status, None
+            p_status, p_text = capture_status, None
         elif lead.get("pane_id") not in captures:
             w_status, w_probable, w_signals = "uncaptured", None, None
             u_status, u_text = "uncaptured", None
+            p_status, p_text = "uncaptured", None
         else:
             det = detect_waiting(captures[lead.get("pane_id")])
             w_status = "ok"
@@ -1981,6 +2119,15 @@ def fold_windows(panes, host, slots=None, task_index=None,
             # that same text perfectly well.
             uns = detect_unsent_prompt(captures[lead.get("pane_id")])
             u_status, u_text = uns["status"], uns["text"]
+            prev = build_pane_preview(captures[lead.get("pane_id")])
+            p_status, p_text = prev["status"], prev["text"]
+        if not pane_preview:
+            # 🔴 The flag was not passed, so `pane_preview: null` here says
+            # NOTHING WAS ASKED — it is not a measured-empty screen. Overwriting
+            # the status computed above is the point: a row that reports
+            # `not_claude` while the text was never requested would let a
+            # consumer conclude the fleet holds no Claude panes.
+            p_status, p_text = "disabled", None
         rows.append({
             # 🔴 WHAT KIND OF ENTITY THIS ROW IS. Always `tmux` here — this
             # function folds PANES, so by construction every row it builds has
@@ -2034,6 +2181,15 @@ def fold_windows(panes, host, slots=None, task_index=None,
             # `waiting_status` exists to refuse, one signal over.
             "unsent_prompt": u_text,
             "unsent_prompt_status": u_status,
+            # 🔴 THE CAPTURED SCREEN, AND THE PAIR IS THE POINT AGAIN.
+            # `pane_preview` is the text clawgate's read model renders;
+            # `pane_preview_status` is what makes a null readable. `null` +
+            # `disabled` is "you did not ask for it"; `null` + anything else is
+            # "asked and not measured", and `truncated` is "measured, but this
+            # is a PREFIX". Collapsing any of those would render a partial
+            # screen to an operator as though it were the whole pane.
+            "pane_preview": p_text,
+            "pane_preview_status": p_status,
             # Same precedence as `age_secs`, and for the same reason: this is the
             # ONE carrier of the session id into the ClickHouse join, so a stale
             # fuzzyclaw value overwriting a live ledger one would resolve a
@@ -2578,7 +2734,7 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
            slots=None, ch_sql=SQL_RECENT_SESSIONS,
            claude_only=False, use_capture=True, capture_nonce=None,
            clawgate_reader=None, clawgate_path=None,
-           use_ledger=True, ledger_outputs=None) -> dict:
+           use_ledger=True, ledger_outputs=None, pane_preview=False) -> dict:
     """Build the whole report. Every source is injectable, so this is the
     function the hermetic suite exercises end-to-end.
 
@@ -2849,7 +3005,8 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
             captures=captures.get(host),
             capture_status=capture_status.get(host, "skipped"),
             # Per host, unlike fuzzyclaw's local-only index above.
-            ledger_index=(ledger_res.get(host) or {}).get("index"))
+            ledger_index=(ledger_res.get(host) or {}).get("index"),
+            pane_preview=pane_preview)
 
     # --- 🔴 --claude-only: drop the shells, and COUNT what was dropped -------
     # The summary then describes the RENDERED set, which is the safe direction:
@@ -3678,6 +3835,7 @@ def render_caveats(report) -> list:
     wt = cav.get("waiting_signal") or {}
     kd = cav.get("kind_scope") or {}
     un = cav.get("unsent_prompt") or {}
+    pv = cav.get("pane_preview") or {}
     return [
         # 🔴 The signal set is ENUMERATED in the footer, because `WAIT: no` is
         # the cell a reader will over-trust. Naming the three things that were
@@ -3731,6 +3889,21 @@ def render_caveats(report) -> list:
         "a modal reports `no_input_box`".format(
             un.get("scope", "claude_rows_only"),
             "/".join(un.get("statuses") or UNSENT_STATUSES)),
+        # 🔴 Printed even though the field is OFF by default, and that is the
+        # whole reason it earns a line. A reader who sees `pane_preview: null`
+        # on every row has no way to tell "these panes are blank" from "nobody
+        # asked for the text" — the same unnamed-population defect `not_measured`
+        # exists for, one field down. The line names the flag that turns it on
+        # and the one thing it will never carry, so a reader does not go looking
+        # for scrollback that is not there.
+        "  caveat[pane_preview]: the captured SCREEN is published on {} only "
+        "and ONLY with {} — without it every row is `pane_preview_status: "
+        "disabled`, which is NOT a measured-empty pane. Visible screen only, "
+        "never scrollback (use `tail`); over {} bytes it is cut and reported "
+        "`truncated`, never silently short".format(
+            pv.get("scope", "claude_rows_only"),
+            pv.get("opt_in_flag", "--pane-preview"),
+            pv.get("max_bytes_per_pane", MAX_PANE_PREVIEW_BYTES)),
         "  caveat[kind_scope]: " + _fmt_kind_scope(kd),
     ]
 
@@ -4060,6 +4233,21 @@ def build_parser():
                    help="skip the per-host pane capture. Every row's "
                         "waiting_probable is then null (never false) and "
                         "summary.waiting.probable is null, never 0.")
+    # 🔴 OPT-IN, and the flag is the whole cost control. See the comment block
+    # at PREVIEW_STATUSES for the measurement: the text is already captured, so
+    # this costs no extra tmux work, but it makes the document 2.63x larger and
+    # every other consumer reads scalars.
+    p.add_argument("--pane-preview", action="store_true",
+                   help="JSON only: publish each Claude pane's VISIBLE SCREEN "
+                        "as `pane_preview`, for a consumer that renders panes "
+                        "(clawgate's tmux read model). Costs no extra tmux "
+                        "work — the capture already happens — but makes the "
+                        "document ~2.63x larger, which is why it is off by "
+                        "default. Visible screen only, never scrollback (use "
+                        "`tail` for history); capped per pane, with "
+                        "`pane_preview_status: truncated` saying so. Without "
+                        "this flag every row reports status `disabled`, which "
+                        "is NOT a measurement.")
     p.add_argument("--plain", action="store_true",
                    help="tail: strip ANSI at the source (drops tmux's -e) "
                         "instead of making every caller sed it out")
@@ -4184,7 +4372,8 @@ def main(argv=None):
                     use_ledger=not args.no_ledger,
                     use_capture=not args.no_capture,
                     threshold=args.stale_threshold,
-                    claude_only=args.claude_only)
+                    claude_only=args.claude_only,
+                    pane_preview=args.pane_preview)
 
     if args.subcommand == "detail":
         if not args.target:
@@ -4202,6 +4391,22 @@ def main(argv=None):
     if args.lean and not args.json:
         print("(--lean shapes the JSON payload; it has no effect without "
               "--json)", file=sys.stderr)
+    # 🔴 SAY SO RATHER THAN COLLECT IT SILENTLY. Without `--json` the preview is
+    # never rendered — no text view prints a pane's screen — so the flag would
+    # otherwise buy an operator a 2.63x in-memory document and no output
+    # difference whatsoever, which reads as the feature being broken.
+    if args.pane_preview and not args.json:
+        print("(--pane-preview shapes the JSON payload; it has no effect "
+              "without --json)", file=sys.stderr)
+    # 🔴 The two flags pull in OPPOSITE directions and the lean view wins.
+    # `--lean` projects rows onto LEAN_ROW_FIELDS, which does not carry the
+    # preview (it is the agent-shaped view; a screen dump is the one thing it
+    # exists to omit). Asking for both is not an error, but it collects the text
+    # and then drops it, so say which one took effect.
+    if args.pane_preview and args.lean and args.json:
+        print("(--lean drops pane_preview: the lean view carries "
+              "lean_row_fields only. Drop --lean to render panes.)",
+              file=sys.stderr)
     # 🔴 COMPUTED BEFORE THE PROJECTION, deliberately. `exit_code_for` reads
     # `hosts[*].reachable`, so running it on the LEAN report would make the exit
     # CONTRACT silently depend on `reachable` staying in `LEAN_HOST_FIELDS` — a

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -1766,6 +1766,15 @@ def test_json_golden_schema_and_values():
         # not a thing this row is entitled to say.
         "unsent_prompt": None,
         "unsent_prompt_status": "uncaptured",
+        # 🔴 `disabled`, NOT `uncaptured`, and the difference is the point: this
+        # fixture does not pass `--pane-preview`, so the text was never asked
+        # for. The sibling field above says `uncaptured` because the unsent
+        # scrape WAS asked for and this pane's screen did not reach it. Two
+        # fields riding one capture, reporting two different reasons for the
+        # same null — which is exactly what a consumer needs to tell "nobody
+        # asked" from "asked and missed".
+        "pane_preview": None,
+        "pane_preview_status": "disabled",
         "claude_session_id": "11111111-2222-4333-8444-555555555555",
         # 🔴 `runtime` names WHICH agent recorded the window. Null here because
         # this fixture runs `use_ledger=False`, so no writer answered — and
@@ -5064,7 +5073,8 @@ def test_the_caveats_are_in_the_json_as_structured_fields_not_prose():
     string a consumer would have to parse."""
     cav = mix_gather()["caveats"]
     assert set(cav) == {"claude_detection", "fuzzyclaw_scope", "ledger_scope",
-                        "waiting_signal", "unsent_prompt", "kind_scope"}
+                        "waiting_signal", "unsent_prompt", "kind_scope",
+                        "pane_preview"}
     det = cav["claude_detection"]
     assert det["method"] == "pane_current_command_regex"
     assert det["pattern"] == sm.CLAUDE_RE.pattern == "claude"
@@ -6508,6 +6518,11 @@ def test_the_row_FIELD_LEDGER_fails_when_it_grows_or_shrinks():
         # The FOURTH signal. It rides the same capture as `waiting` but is a
         # separate pair of fields on purpose — see `UNSENT_STATUSES`.
         "unsent_prompt", "unsent_prompt_status",
+        # The captured SCREEN, off unless `--pane-preview`. Present on every row
+        # either way — `disabled` is a status, not an absence, so a consumer can
+        # tell "not asked" from "asked and not measured". See
+        # `PREVIEW_STATUSES`.
+        "pane_preview", "pane_preview_status",
         "claude_session_id", "runtime", "ledger", "fuzzyclaw",
         "panes",
     }
@@ -10246,3 +10261,213 @@ def test_measured_not_measured_is_PURE_and_shares_nothing_with_the_constant():
     assert sm.NOT_MEASURED_POPULATIONS == before
     assert sm.measured_not_measured({})[0]["note"] != "clobbered"
 
+
+
+# =========================================================================== #
+# §P — `pane_preview`: the captured screen this tool already had and threw away
+#
+# 🔴 THE DEFECT CLASS THIS SECTION EXISTS FOR. `waiting_probable` and
+# `unsent_prompt` are both DERIVED from the capture batch, which then discarded
+# the screen. Publishing it is cheap — the text is already in `captures` — but it
+# introduces a THIRD field pair riding one capture, and the first two got their
+# own statuses precisely because sharing one is how "not measured" becomes
+# "measured empty". These tests pin that the third does not regress that.
+#
+# Every test here drives `fold_windows` through a real `gather`, because the
+# statuses are decided by which of four capture paths a row took, and a test that
+# calls the builder directly cannot see a path it was never routed down.
+# =========================================================================== #
+
+def test_the_preview_carries_the_pane_SCREEN_VERBATIM_when_asked():
+    """END-TO-END: capture goes in, the screen comes out on the row.
+
+    🔴 Asserts the WHOLE captured string, not a substring of it. A `in` check
+    passes against a preview that dropped every line but one, which is exactly
+    what a truncation bug produces — and a screen-dump field whose contract is
+    "this is what the pane shows" cannot be pinned by a fragment.
+    """
+    rep = waiting_gather(local={"%11": PANE_IDLE}, pane_preview=True)
+    row = _row(rep, "workbench", "scratch7", "3")
+    assert row["pane_preview"] == PANE_IDLE
+    assert row["pane_preview_status"] == "ok"
+
+
+def test_WITHOUT_the_flag_the_status_is_disabled_NOT_a_measured_empty_screen():
+    """🔴 THE NULL-VS-NULL DISTINCTION, and it is the whole reason the status
+    field exists. Off by default, `pane_preview` is null on every row — and a
+    consumer must be able to tell that from a fleet whose panes are genuinely
+    blank. `disabled` says NOTHING WAS ASKED.
+
+    KILLS: emitting the fields only when the flag is on (absence is not a
+    readable status), and defaulting the status to `ok` or `not_claude`.
+    """
+    rep = waiting_gather(local={"%11": PANE_IDLE})
+    row = _row(rep, "workbench", "scratch7", "3")
+    assert row["pane_preview"] is None
+    assert row["pane_preview_status"] == "disabled"
+    # ...and the field PAIR is present on every row, not just the claude one.
+    for host in ("workbench", "laptop"):
+        for r in rep["hosts"][host]["windows"]:
+            assert r["pane_preview_status"] == "disabled"
+            assert r["pane_preview"] is None
+
+
+def test_disabled_BEATS_every_other_reason_including_ones_that_were_measured():
+    """🔴 PRECEDENCE, stated as a test because the implementation computes the
+    other statuses FIRST and then overwrites them.
+
+    The sibling `unsent_prompt_status` on the SAME rows reports the real capture
+    path (`ok` for the captured claude pane, `not_claude` for a shell). If
+    `pane_preview_status` ever reported those instead, a consumer would read
+    `not_claude` and conclude the fleet holds no Claude panes — when in fact
+    nobody asked for the text. The two fields must DISAGREE here, and that
+    disagreement is correct.
+    """
+    rep = waiting_gather(local={"%11": PANE_IDLE})
+    claude = _row(rep, "workbench", "scratch7", "3")
+    assert claude["unsent_prompt_status"] == "ok"        # measured, capture ran
+    assert claude["pane_preview_status"] == "disabled"   # ...but never asked
+    shells = [r for r in rep["hosts"]["workbench"]["windows"] if not r["claude"]]
+    assert shells, "fixture must contain a shell row for this to mean anything"
+    for r in shells:
+        assert r["unsent_prompt_status"] == "not_claude"
+        assert r["pane_preview_status"] == "disabled"
+
+
+def test_a_SHELL_row_reports_not_claude_never_an_empty_screen():
+    """The capture batch is Claude-panes-only, so a shell was never read. `""`
+    would say "this pane's screen is blank", which is a measurement nobody
+    took."""
+    rep = waiting_gather(local={"%11": PANE_IDLE}, pane_preview=True)
+    shells = [r for r in rep["hosts"]["workbench"]["windows"] if not r["claude"]]
+    assert shells
+    for r in shells:
+        assert r["pane_preview"] is None
+        assert r["pane_preview_status"] == "not_claude"
+
+
+def test_a_claude_pane_MISSING_from_the_batch_reports_uncaptured():
+    """The batch ran and answered, and this pane was not in it — distinct from
+    the batch not running at all. Same four-path discipline as `waiting`."""
+    rep = waiting_gather(local={}, pane_preview=True)   # batch ran, no %11 in it
+    row = _row(rep, "workbench", "scratch7", "3")
+    assert row["pane_preview"] is None
+    assert row["pane_preview_status"] == "uncaptured"
+
+
+def test_no_capture_propagates_the_BATCHS_OWN_reason_to_the_preview():
+    """🔴 `skipped` is not `uncaptured`. With `--no-capture` the batch never ran,
+    so the reason belongs to the batch; reporting `uncaptured` would blame the
+    pane for a decision the caller made."""
+    rep = base_gather(use_capture=False, pane_preview=True)
+    row = _row(rep, "workbench", "scratch7", "3")
+    assert row["pane_preview"] is None
+    assert row["pane_preview_status"] == "skipped"
+    assert row["unsent_prompt_status"] == "skipped"      # the sibling agrees here
+
+
+def test_the_preview_status_VOCABULARY_IS_CLOSED():
+    """🔴 Same rule as UNSENT_STATUSES: a status outside the enumeration is one
+    no consumer branches on, and it would be published silently. Swept across
+    every path this file can drive, flag ON and OFF."""
+    reps = [
+        waiting_gather(local={"%11": PANE_IDLE}, pane_preview=True),
+        waiting_gather(local={"%11": PANE_IDLE}),
+        waiting_gather(local={}, pane_preview=True),
+        base_gather(use_capture=False, pane_preview=True),
+        base_gather(runner=make_runner(local_rc=1, remote_rc=1),
+                    pane_preview=True),
+    ]
+    seen = set()
+    for rep in reps:
+        for host in rep["hosts"].values():
+            for r in host["windows"]:
+                seen.add(r["pane_preview_status"])
+    assert seen, "swept nothing — the fixtures produced no rows"
+    assert seen <= set(sm.PREVIEW_STATUSES), f"undeclared status: {seen}"
+    # POSITIVE CONTROL: the sweep really did reach more than one path, so a
+    # vocabulary that happened to hold one value is not what made this pass.
+    assert len(seen) >= 3, seen
+
+
+def test_an_EMPTY_captured_screen_is_ok_with_an_empty_string_NOT_null():
+    """🔴 A pane that was READ and showed nothing is a measurement, and it must
+    not collapse into the null that means "not measured". This is the one case
+    where `pane_preview` is falsy while its status is `ok`, so a consumer
+    testing truthiness rather than the status gets it wrong — which is why the
+    status is the documented discriminator."""
+    assert sm.build_pane_preview("") == {"text": "", "status": "ok"}
+    assert sm.build_pane_preview(None) == {"text": "", "status": "ok"}
+
+
+def test_the_preview_TRUNCATES_and_SAYS_SO_rather_than_going_quietly_short():
+    """🔴 The bound needs BOTH halves — what it admits and what it rejects — and
+    the fixtures are LITERAL sizes, never `"x" * MAX_PANE_PREVIEW_BYTES`. A
+    fixture derived from the constant scales with it, so raising the constant to
+    a billion would keep this green while allocating a gigabyte.
+    """
+    # ADMITS: exactly at the bound is whole, not truncated.
+    at = sm.build_pane_preview("y" * 64, max_bytes=64)
+    assert at == {"text": "y" * 64, "status": "ok"}
+    # REJECTS: one byte over is cut TO the bound and labelled.
+    over = sm.build_pane_preview("y" * 65, max_bytes=64)
+    assert over["status"] == "truncated"
+    assert over["text"] == "y" * 64
+    assert len(over["text"].encode()) == 64
+
+
+def test_truncation_cuts_on_a_CHARACTER_boundary_not_a_byte_offset():
+    """🔴 THE CASE THE REAL FLEET IS MADE OF. Every Claude Code pane is box-
+    drawing glyphs, which are 3 bytes each in UTF-8 — so a byte-offset slice
+    lands mid-sequence on almost every truncation that will ever happen here.
+
+    10 glyphs x 3 bytes = 30 bytes; a cap of 20 falls INSIDE the 7th. The result
+    must be 6 whole glyphs (18 bytes), never a partial sequence, a replacement
+    character, or a UnicodeDecodeError.
+    """
+    screen = "─" * 10
+    assert len(screen.encode()) == 30           # the fixture is what I think
+    out = sm.build_pane_preview(screen, max_bytes=20)
+    assert out["status"] == "truncated"
+    assert out["text"] == "─" * 6
+    assert len(out["text"].encode()) == 18      # under the cap, on a boundary
+    assert "�" not in out["text"]          # no replacement char smuggled in
+
+
+def test_the_per_pane_cap_is_pinned_to_a_LITERAL():
+    """🔴 Pin the CONSTANT, not just behaviour derived from it. Measured
+    2026-08-28 the largest real pane was 6,616 bytes, so 16 KiB is ~2.4x the
+    observed maximum — a guard against a pathological pane, not a routine cut.
+    Changing it is a payload-budget decision that should fail here first."""
+    assert sm.MAX_PANE_PREVIEW_BYTES == 16384
+
+
+def test_the_caveat_names_the_FLAG_and_the_scrollback_EXCLUSION():
+    """🔴 The caveat is the only thing telling a cold reader why every preview is
+    null, and where scrollback went. Pins the two claims a reader acts on, not
+    the prose around them."""
+    cav = base_gather()["caveats"]["pane_preview"]
+    assert cav["opt_in_flag"] == "--pane-preview"
+    assert cav["scope"] == "claude_rows_only"
+    assert cav["max_bytes_per_pane"] == sm.MAX_PANE_PREVIEW_BYTES
+    assert list(cav["statuses"]) == list(sm.PREVIEW_STATUSES)
+    assert "scrollback" in cav["note"]
+    # the footer renders it, so a text-mode reader sees it too
+    line = [ln for ln in sm.render_caveats(base_gather())
+            if "caveat[pane_preview]" in ln]
+    assert len(line) == 1
+    assert "--pane-preview" in line[0] and "scrollback" in line[0]
+
+
+def test_the_flag_reaches_gather_and_is_OFF_in_its_signature():
+    """🔴 The wiring, pinned at the seam. A flag parsed and never passed is the
+    shape that ships an inert feature — and `pane_preview` defaulting to True in
+    `gather` would make every existing consumer pay the 2.9x silently."""
+    import inspect
+    assert (inspect.signature(sm.gather).parameters["pane_preview"].default
+            is False)
+    assert (inspect.signature(sm.fold_windows).parameters["pane_preview"].default
+            is False)
+    p = sm.build_parser()
+    assert p.parse_args(["scan", "--json"]).pane_preview is False
+    assert p.parse_args(["scan", "--json", "--pane-preview"]).pane_preview is True

--- a/scripts/tests/test_tmux_snapshot_push.py
+++ b/scripts/tests/test_tmux_snapshot_push.py
@@ -987,3 +987,78 @@ def test_write_exec_REFUSES_a_caller_supplied_shebang():
     with pytest.raises(AssertionError):
         # The helper's OWN shebang constant, not a literal — see HASHBANG above.
         write_exec(Path("/tmp/never-written-by-this-test"), SHEBANG + "printf x\n")
+
+
+# ── the collector ARGV: the read model is only renderable if the flag is sent ──
+
+
+def test_the_collector_is_invoked_WITH_pane_preview(server, tmp_path):
+    """🔴 THE FLAG IS PART OF THE PAYLOAD CONTRACT AND NOTHING ELSE GUARDS IT.
+
+    `session-manager` publishes `pane_preview` only when asked; it is off by
+    default there because every other consumer reads scalar fields and would pay
+    a 2.63x document for text it ignores (measured on the live fleet: 122,731
+    bytes without, 322,204 with). This caller is the one that wants it, so the
+    flag lives here — which means dropping it is a ONE-WORD edit that leaves
+    every other test in this file green, the push succeeding, the server
+    accepting, and the read model storing rows whose every pane reads
+    `pane_preview_status: disabled`. An inert feature with a green suite.
+
+    That is not hypothetical in this script's history: a previous round deleted
+    `gawk` from the unit's PATH as "unused" and silently lost `runtime` on 34 of
+    45 windows, because the failure logged nothing and exited 0.
+
+    KILLS: removing `--pane-preview`, and misspelling it (argparse would reject
+    an unknown flag at runtime, but this stub does not, so the assertion is on
+    the exact token).
+    """
+    argv_log = tmp_path / "collector-argv.txt"
+    data = tmp_path / "doc.json"
+    data.write_text(json.dumps(SAMPLE_DOC))
+    stub = write_exec(
+        tmp_path / "argv-recording-collector",
+        f'printf "%s\\n" "$@" > {argv_log}\n'
+        f"cat {data}\n",
+    )
+    proc = run_push(
+        collector_path=stub,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server),
+                   "CLAWGATE_HOOK_TOKEN": "tok-abc"},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    # POSITIVE CONTROL: the recorder actually ran and captured something, so an
+    # assertion against its contents is not being made about an empty file that
+    # a broken stub would produce just as happily.
+    assert argv_log.exists(), "the argv recorder never ran"
+    args = argv_log.read_text().split()
+    assert args, "the collector was invoked with NO arguments at all"
+    assert "--json" in args, args
+    assert "--pane-preview" in args, args
+
+
+def test_the_collector_is_NOT_asked_for_the_lean_view(server, tmp_path):
+    """🔴 `--lean` would silently defeat the flag above. The lean projection
+    drops every field outside LEAN_ROW_FIELDS, and `pane_preview` is not one of
+    them — so `--json --lean --pane-preview` collects the screens and then
+    throws them away, pushing a document that looks well-formed and renders
+    nothing. Pinned as an ABSENCE because that is the failure mode: adding a
+    flag here is easy and reviewing what it removes is not."""
+    argv_log = tmp_path / "collector-argv.txt"
+    data = tmp_path / "doc.json"
+    data.write_text(json.dumps(SAMPLE_DOC))
+    stub = write_exec(
+        tmp_path / "argv-recording-collector-lean",
+        f'printf "%s\\n" "$@" > {argv_log}\n'
+        f"cat {data}\n",
+    )
+    proc = run_push(
+        collector_path=stub,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server),
+                   "CLAWGATE_HOOK_TOKEN": "tok-abc"},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    args = argv_log.read_text().split()
+    assert args, "the argv recorder captured nothing"
+    assert "--lean" not in args, args

--- a/scripts/tmux-snapshot-push.sh
+++ b/scripts/tmux-snapshot-push.sh
@@ -132,8 +132,29 @@ fi
 # log line carrying no information at all, from the one path most likely to
 # happen (a wedged ssh to a sleeping laptop). That defeats this script's own
 # distinct-exit-code doctrine at the header.
+#
+# 🔴 `--pane-preview` IS PART OF THE PAYLOAD CONTRACT, NOT A TUNING KNOB.
+# The read model exists so an operator can see what panes are showing; without
+# this flag every row arrives `pane_preview_status: disabled` and the server
+# stores a document that structurally cannot render one. It is off by DEFAULT in
+# the collector because every other consumer reads scalar fields and would pay
+# for the text — this is the one caller that wants it, so this is where it is
+# turned on.
+#
+# MEASURED 2026-08-28 on the live fleet, both forms back to back: 122,731 bytes
+# without, 322,204 with — 2.63x, of which 46 Claude panes contribute 109,256
+# characters of screen and the 26 shells contribute none (they report
+# `not_claude`, never an empty screen). That lands at ~7.7% of the server's
+# 4 MB `maxTmuxPushBytes`, so the cap is ~13x away at today's pane count.
+#
+# 🔴 IT IS THE VISIBLE SCREEN AND MUST STAY SO. Scrollback costs ~4,014 bytes
+# per line fleet-wide, which breaches that same cap at roughly 650 lines per
+# pane — `-S -1000` computes to 6.13 MB. A push over the cap is rejected 413 and
+# the read model silently keeps its LAST GOOD snapshot, so the damage would
+# present as a read model that quietly stops advancing, not as an error anyone
+# sees. History belongs to `session-manager tail`, one window at a time.
 set +e
-timeout "$COLLECT_TIMEOUT" "$SM" --json >"$PAYLOAD" 2>"$COLLECT_ERR"
+timeout "$COLLECT_TIMEOUT" "$SM" --json --pane-preview >"$PAYLOAD" 2>"$COLLECT_ERR"
 COLLECT_RC=$?
 set -e
 if [ "$COLLECT_RC" -ne 0 ]; then


### PR DESCRIPTION
clawgate's tmux read model stores 72 windows every 2 minutes and **cannot render one of them** — nothing in the payload carries what a pane *shows*. This adds `pane_preview` + `pane_preview_status`, sourced from the capture batch that **already runs**: `waiting_probable` and `unsent_prompt` are both derived from it and it then discarded the screen. Zero extra tmux work.

## Measured first, because the cost decided the design

72 panes live (45 workbench + 27 laptop):

| | bytes |
|---|---|
| today's push | 110,806 |
| visible capture, all 72 panes, raw | 249,042 |
| JSON escaping/structure overhead | **+38.9%** |
| gzip(JSON) | 5.3x reduction |

Two measurements changed what got built:

- **Scrollback is excluded, on a hard bound rather than taste.** Each extra line costs **~4,014 B fleet-wide**, so `-S -1000` computes to **6.13 MB** against the server's 4 MB `maxTmuxPushBytes` — the cap breaches at **~650 lines/pane**. Visible screen only; history stays with `tail`, one window on demand.
- **Only 22% of panes change per tick** (10 of 45 over a real 120s interval), so 77% of the bytes would be resent unchanged. The costs are cheap in absolute terms (62 MB/day gzipped) — the objection is *staleness*, not bandwidth. A 2-minute-old preview is right for "which session needs me" and wrong for watching output scroll, so on-demand capture stays a separate transport and a later item.

## Off by default

`drift_phase2`, `cairn_who` and the skills read scalar fields and would pay for text they ignore, so it rides `--pane-preview` and the pusher is the one caller that passes it. Measured live, both forms back to back: **122,731 B without, 322,204 with — 2.63x**, or **7.7% of the 4 MB cap**.

## No server change was needed

Migration 0027 promises unknown fields are preserved verbatim. Verified end-to-end against **live clawgate 0.8.9**: POST 322 KB → 200, GET returned 46 rows `ok` / 26 `not_claude` carrying real screens, with the `session` → `tmuxSessionName` rename intact on preview-bearing rows. The production timer overwrote the probe within 2 minutes, so nothing was left in the read model.

## The status field is the point, not decoration

Four nulls that look identical must stay distinguishable: `disabled` (never asked — and it **beats every other reason**, so a consumer cannot read `not_claude` and conclude the fleet holds no agents), `not_claude` (shells are never captured, never an empty screen), `uncaptured` (batch ran, this pane missed), `skipped`/`error` (the batch's own reason), `truncated` (a **prefix** — an unlabelled one ends mid-word and reads as a crashed agent). Truncation cuts on a **character boundary**: every Claude pane is 3-byte box glyphs, so a byte-offset slice lands mid-sequence on almost every truncation that will ever happen here.

## Testing

15 new tests. **Mutation sweep: 10/10 non-equivalent mutants killed**, with an unmutated green baseline verified *before and after*, a positive control that dies for a known reason, and `PYTHONDONTWRITEBYTECODE=1` against the stale-bytecode trap. The one survivor was `text or ""` → `text if text is not None else ""` — **equivalent** for `str|None`; a non-equivalent mutant on that same line kills 3 tests.

The pusher's argv is pinned separately (flag removed / misspelled / `--lean` added each red it), because dropping it is a one-word edit that leaves every other test green while the read model stores rows that structurally cannot render — the same shape as the `gawk`-removed-as-unused regression this script already paid for once.

## Gate

All four tiers green on this branch:

- sandbox `devrc-pytests` **PASS** (exit 0) — collected 18,291, passed 18,289, failed 0, floor 15,970
- sandbox `devrc-nodetests` **PASS** (exit 0) — 1300/1300
- dev-host node **PASS** — 1300/1300
- dev-host pytest — 9804/9804 green on 2 of 3 runs

⚠ **One dev-host run red on `TestTrustedProxyOverTheRealProcess::test_THE_DEFECT_the_five_forged_attempts_are_CHARGED_TO_THE_FORGER`**, and I am reporting it rather than burying it. Evidence it is the documented flake and not this diff: that test's own comment records the identical signature (`assert 4 == 5`, four audit lines) at 3/20 locally plus two consecutive sandbox reds; this branch touches **neither** that file nor `scripts/lib` (empty `git diff --stat` for both); branch full-target ran **2 green / 1 red**, `origin/main` ran green, and the test alone ran **6/6 on both trees**; the box was at load 18–40 from concurrent agents, and unrelated targets' wall times swung ~2x run to run — load inflating every test, which is the documented load-flake tell. Both **sandbox** tiers, which are what gate the merge, passed. I cannot prove a negative; that is the evidence.

## Scope

This is rank 3's **data path**. The **rendering half** — a tmux tab in clawgate's `internal/ui` — is a separate `homelab-talos` PR; nothing reads `GET /api/tmux/snapshot` yet, so until that lands the screens arrive and no page shows them.

Deploy note: the systemd unit runs the script from the **working tree** (`%h/workspace/devrc/scripts/…`) and the collector default is the working-tree path too, so this goes live on `ship.sh`'s pull — **no `home-manager switch` and no unit change**, and the preview path adds no new binary, so the unit's PATH is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hFhuL3EQnGXDhcmG7dtfM