### PR TITLE
docs(browser-bridge): civit.ai notes are per-HOST, so point at the per-APP source

### DIFF
--- a/scripts/browser-bridge/reference/sites/civit.ai.md
+++ b/scripts/browser-bridge/reference/sites/civit.ai.md
@@ -19,6 +19,24 @@ This file is only what is true of **an App Block**.
 deterministically is `capture.sh <recipe>`; only recipe **authoring** needs the
 by-hand flow this file describes.
 
+🔴 **Read the recipe even when you ARE driving by hand — it is the only PER-APP
+source that exists.** This file is per-HOST, and `civit.ai` matches *every*
+`<slug>.civit.ai`: what you are reading is true of all blocks and specific to
+none. Three fields of
+`<talos-infra>/.claude/skills/app-capture/scripts/recipes/<slug>.json` answer
+questions you would otherwise pay for live:
+
+| field | what it saves you |
+|---|---|
+| `ready.testid` + `ready._comment` | the anchor that means BOOTED — **and the rejected candidates, each with the reason it fails**: a validation message that vanishes once the control unblocks, loading art present in one read and absent in the next, the static `#root` shell that exists before boot and in a deadlocked frame |
+| `clickable` | every selector that recipe may activate. 🔴 Read this as a HAZARD list: the spend path rejects untrusted events, but an ordinary authenticated mutation — post, vote, edit, withdraw — does not, so these are the controls that really act on the operator's account. Here no guard will refuse one for you |
+| `states` | the screens known to be reachable, named, in the order that reaches them |
+
+⚠ The pointer is **cross-repo and gated by nothing** — no check in this repo can
+see that path, and app-capture's own doc-rot gate cannot see this file. If the
+recipes move, this rots silently: confirm the directory before concluding an app
+has no recipe.
+
 ---
 
 ## 🔴 A block renders in a CROSS-ORIGIN IFRAME — every DOM op needs `--frame`


### PR DESCRIPTION
## Why

`site_notes` resolves on a host **suffix**, and `civit.ai` matches every `<slug>.civit.ai` — so `reference/sites/civit.ai.md` is structurally incapable of saying anything app-specific. An agent driving `sensei` and one driving `gen-matrix` are handed the identical 78 lines.

The per-app facts do exist: they are the `app-capture` recipes in `civitai/talos-infra`. This file already said *"check whether a recipe already exists"* without saying **where** one is or **what is in it**.

## What changed

One paragraph + a 3-row table naming the recipes directory and the fields worth lifting before the first op:

| field | why a hand-driver wants it |
|---|---|
| `ready.testid` + `ready._comment` | the anchor that means BOOTED — and the **rejected** candidates with the reason each fails. This file already warns that a click into a still-booting app is discarded and that the *next* wait times out naming a control that is fine; the reject-list is what stops you picking one of those anchors. |
| `clickable` | framed as a **hazard list**, not a ledger. The spend path rejects untrusted events; an ordinary authenticated mutation (post, vote, edit, withdraw) does not — and by hand there is no `plan.py` to refuse an unledgered one. |
| `states` | the screens known to be reachable. |

## What it deliberately does NOT do

**No content is mirrored into this repo.** `innovation-upstream/devrc` is public and `civitai/talos-infra` is private, so generating per-slug notes from the recipes would publish per-app selectors and anchors — and would create exactly the stale second copy that this file and app-capture's `bridge-facts.md` already warn each other about. Only field **names** and a path cross the boundary; every **value** stays in the private repo.

The file states, rather than leaves to be discovered, that the pointer is cross-repo and **gated by nothing** — no check here can see that path, and app-capture's doc-rot gate cannot see this file.

## The follow-on, if this proves used

The non-copying way to automate it is a second, **local** notes root — an allowlisted absolute path the bridge may resolve — so content stays in the private clone and only a pointer is emitted. That needs the bare-filename validation in `server.py:_load_site_index` relaxed behind an allowlist, which is why it is not in this PR.

## Verification

- All **7** shipped recipes carry `ready.testid`, `ready._comment`, `clickable` and `states` — enumerated over the directory, not sampled.
- `tests/test_site_notes.py` + `tests/test_skill_size.py`: **75 passed**. Those grade the registry mechanism and SKILL.md's byte ceiling — no test asserts this file's prose, so they show nothing structural broke, **not** that the new paragraph is right. The paragraph's claims were checked against the recipes directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdJ3wjBdcgbCMfX9qNRKkf
