### PR TITLE
fix(subsystem-store-api): audit BEFORE responding, and serialise the audit sink

### DIFF
--- a/scripts/subsystem-store-api/README.md
+++ b/scripts/subsystem-store-api/README.md
@@ -105,15 +105,38 @@ parse as no marker at all — a silently vanishing badge.
 | `500` + `X-Store-Status: internal-error` | a handler raised something nobody anticipated. The body is a **constant** — no exception text reaches the wire — the traceback goes to the pod log, and **the audit line is still written**. A metered request must never vanish from the audit trail; two defects in one audit round dropped the connection with no response and no record at all |
 
 🔴 **THE `500` BACKSTOP NEVER SENDS A *SECOND* RESPONSE.** A handler that raises
-*after* it has already answered — `_append_bullet` responds `200` and *then*
-audits — used to produce a complete `200` followed by a complete `500` on one
-connection. The `200` had advertised the socket as reusable, so a pooling proxy
-(Traefik does this by default) hands the trailing `500` to the **next** client on
-it: the response desync the request-body drain exists to prevent, arriving from
-the other direction. `_respond` now records that it has answered, and the
-backstop logs, audits and **closes** instead of answering twice. That case is
-audited as `status=internal-error-after-response`, distinct from the ordinary
-`internal-error` so the two are not conflated in Loki.
+*after* it has already answered — `_append_bullet` used to respond `200` and
+*then* audit — used to produce a complete `200` followed by a complete `500` on
+one connection. The `200` had advertised the socket as reusable, so a pooling
+proxy (Traefik does this by default) hands the trailing `500` to the **next**
+client on it: the response desync the request-body drain exists to prevent,
+arriving from the other direction. `_respond` now records that it has answered,
+and the backstop logs, audits and **closes** instead of answering twice. That
+case is audited as `status=internal-error-after-response`, distinct from the
+ordinary `internal-error` so the two are not conflated in Loki.
+
+🔴 **THE AUDIT LINE IS WRITTEN *BEFORE* THE RESPONSE, AND THE SINK IS LOCKED.**
+Log the decision, then act on it. Two things follow, and both are properties an
+operator reads the stream for:
+
+* **A sequential client's records are in request order.** They were not: the
+  response used to be written first, so request `N+1` could be accepted on a new
+  handler thread and reach the sink before request `N` did. Observed once in CI
+  as two audit lines emitted in the wrong order, then green on re-run — rare,
+  and real. Ordering is now structural: holding response `N` means line `N` is
+  already in the stream.
+* **Two concurrent requests cannot interleave their writes.** The default sink is
+  `print(line, flush=True)` — the record and the terminator are two writes on one
+  stream — so overlapping handlers could emit one line carrying two requests'
+  fields and one carrying none. A single process-wide lock is held across the
+  whole sink call.
+
+⚠ The price, because it is a real behaviour change: an audit sink that **raises**
+now does so before any byte is on the wire, so the request is answered `500`
+rather than served with no record. On a write that means a landed mutation can
+be reported as a `500`. Fail-closed is the right direction for a service whose
+reason to exist is a complete audit trail, but it is a direction, not a free
+win.
 
 The same backstop covers the **READ** dispatch. It used to cover writes only —
 an exception in `/recall`, `/search` or `/snapshot` dropped the connection with

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -2524,6 +2524,21 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
     trusted_proxies: tuple[Any, ...] = ()
     limiter: RateLimiter | None = None
     audit: Callable[[str], None] = staticmethod(lambda line: print(line, flush=True))
+    # 🔴 ONE LOCK, HELD ACROSS THE WHOLE SINK CALL, BECAUSE `print` IS NOT ATOMIC.
+    # `ThreadingHTTPServer` runs one handler per connection concurrently and the
+    # default sink is `print(line, flush=True)`, which is TWO writes on one
+    # `TextIOWrapper` — the record, then the terminator. Two handlers reaching it
+    # together can therefore emit `<A><B>\n\n`: one line holding two requests'
+    # fields and one holding none, in a stream whose entire purpose is to be
+    # greppable per request. Nothing in `BaseHTTPRequestHandler` serialises this;
+    # the GIL orders the individual `write` calls and says nothing about which
+    # pair they belong to.
+    #
+    # It is a CLASS attribute so `build_server`'s `_Handler` subclass inherits
+    # the SAME object: the thing being serialised is one process's stdout, not
+    # one handler instance, so a per-instance lock would serialise nothing (a
+    # fresh handler per connection means a fresh lock per connection).
+    _audit_lock: "threading.Lock" = threading.Lock()
 
     # Per-request identity, reset at the top of every dispatch so a keep-alive
     # connection cannot carry the previous request's fingerprint into this
@@ -2609,7 +2624,7 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
 
         🔴 A SECOND RESPONSE ON ONE CONNECTION IS A DESYNC, NOT A COURTESY. The
         first version of this backstop called `_respond(500, …)` unconditionally,
-        and `_append_bullet` answers `200` and THEN audits — so anything raising
+        and `_append_bullet` answered `200` and THEN audited — so anything raising
         after that `_respond` (a broken audit sink, a full disk on stderr, or
         simply the next statement somebody adds below it) put a complete `200`
         and a complete `500` on the same socket. Worse than the usual case: the
@@ -2624,11 +2639,27 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
 
         🔴 THE AUDIT IS THE LAST THING AND IS ITSELF GUARDED. "A metered request
         must never vanish from the audit trail" is the point of this function,
-        but if the sink is what raised — the one production-reachable route to
-        the already-responded arm — calling it again re-raises out of
+        but if the sink is what raised — the one production-reachable route into
+        this function at all — calling it again re-raises out of
         `do_POST`, past `handle_one_request`, and the traceback the operator
         needs is replaced by socketserver's. Print, then try; a sink that cannot
         record cannot be made to.
+
+        ⚠ THAT ROUTE NOW ARRIVES ON THE OTHER ARM, AND THE SENTENCE ABOVE USED
+        TO SAY "the already-responded arm". `_audit` runs BEFORE `_respond` at
+        every call site (see `_audit`), so a raising sink raises before any byte
+        is written: `_responded` is False and this function answers `500`. The
+        already-responded arm is now reached only by a statement failing AFTER a
+        completed `_respond`, which in this file means an exception injected by a
+        test — production has no statement there. Both arms are still exercised;
+        which case reaches which one has swapped.
+
+        🔴 THIS IS THE ONE PLACE THAT AUDITS AFTER RESPONDING, AND IT MUST STAY
+        THAT WAY: the status it records (`internal-error` vs
+        `internal-error-after-response`) is not knowable until `_responded` has
+        been read, and on the already-responded arm the bytes went out long
+        before this function was called. `test_every_audit_call_site_PRECEDES_
+        its_response` exempts `_backstop` by name for exactly this reason.
 
         🔴 AND SO ARE BOTH PRINTS, WHICH IS THE HALF THIS DOCSTRING USED TO
         CLAIM WITHOUT THE CODE PROVIDING IT. The paragraph above reasons about
@@ -2733,13 +2764,47 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         `peer=untrusted` also tells the reader how to interpret `ip=`: trusted
         means the field came from `CF-Connecting-IP`, untrusted means it is the
         TCP peer and the header was never read.
+
+        🔴 CALL THIS BEFORE `_respond`, NEVER AFTER — LOG THE DECISION, THEN ACT
+        ON IT. Every one of the 33 call sites in this class used to be
+        `_respond(...)` followed by `_audit(...)`, which put the bytes on the
+        wire first. Two consequences, both measured:
+
+          * ORDER. A SEQUENTIAL client's request N+1 is accepted on a NEW handler
+            thread as soon as request N's response is written, so handler N+1
+            could reach this method before handler N did and the stream came out
+            in the wrong order. Observed once in the nix sandbox tier:
+            `test_the_audit_line_names_WHICH_fingerprint_matched` failed on
+            `token=<A> in audit[0]` with the two lines swapped, then passed on
+            re-run and in ~20 runs after — rare, and real. With the audit first,
+            "the client holds response N" implies "line N is already in the
+            sink", so a sequential client's records are in request order by
+            construction rather than by luck.
+          * WHICH DIRECTION A CRASH FAILS IN. Something raising between the two
+            calls used to lose the record entirely (`_backstop` then logs
+            `internal-error-after-response`, which names the request but not what
+            it did); now it over-reports — the outcome line is already out and
+            the backstop adds its 500 beside it. For an audit trail, a duplicate
+            beats a hole.
+
+        ⚠ AND THE PRICE, STATED BECAUSE IT IS A REAL BEHAVIOUR CHANGE: a sink
+        that RAISES now does so before the response, so a request whose record
+        cannot be written is answered `500` by `_backstop` instead of being
+        served with no record. On the write path that means a landed mutation
+        can be reported as a 500. That is the fail-closed direction for a
+        service whose reason to exist is a complete audit trail, and it is the
+        state `TestTheBackstopSurvivesITSOWNLogSink` pins.
+
+        🔴 THE SINK CALL IS SERIALISED. See `_audit_lock` — the lock, not this
+        ordering, is what stops two CONCURRENT requests interleaving their
+        writes; ordering alone fixes nothing for callers that overlap.
         """
         peer_state = (
             "-"
             if self._peer_trusted is None
             else ("trusted" if self._peer_trusted else "untrusted")
         )
-        self.audit(
+        line = (
             "store-api audit "
             f"ts={datetime.now(timezone.utc).isoformat(timespec='seconds')} "
             f"ip={audit_field(self._client_ip or '-')} "
@@ -2757,6 +2822,14 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             f"auth={'ok' if self._token_fp else 'fail'} "
             f"result={int(result)} status={audit_field(status, limit=32)}"
         )
+        # 🔴 THE FORMATTING IS OUTSIDE THE LOCK AND THE SINK CALL IS INSIDE IT.
+        # Narrow on purpose: every field above is per-request state, so building
+        # the string contends with nothing, while the sink is the one shared
+        # resource. Holding the lock across the sink — rather than around a bare
+        # `write` inside it — is what makes the guarantee hold for an INJECTED
+        # sink too, which is the only shape the tests can observe.
+        with self._audit_lock:
+            self.audit(line)
 
     # --- methods ----------------------------------------------------------------
 
@@ -2979,6 +3052,7 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
                 # it did wrong; it discriminates nothing about the store, because
                 # a legacy row is UNRESTRICTED and this answer is the same for
                 # every scope, existing or not.
+                self._audit(path, 403, "legacy-cannot-write")
                 self._respond(
                     403,
                     b"forbidden: this credential has no identity, so a bullet "
@@ -2986,27 +3060,26 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
                     b"a `<token> <identity> <scopes>` row\n",
                     headers={"X-Store-Status": "legacy-cannot-write"},
                 )
-                self._audit(path, 403, "legacy-cannot-write")
                 return
             if any(not SAFE_PATH_COMPONENT.fullmatch(p) for p in parts):
                 # The same refusal the read router makes, for the same reason:
                 # these components reach the filesystem. See `_handle`.
+                self._audit(path, 400, "bad-request")
                 self._respond(
                     400, b"bad request: invalid path component\n",
                     headers={"X-Store-Status": "bad-request"},
                 )
-                self._audit(path, 400, "bad-request")
                 return
             if not framed:
                 # `_consume_body` refused the framing (chunked, a duplicated or
                 # negative `Content-Length`, an over-long or slow body). The
                 # connection is already marked for close; the caller is told, and
                 # NOTHING is written from bytes this server could not frame.
+                self._audit(path, 400, "bad-request")
                 self._respond(
                     400, b"bad request: unreadable request body\n",
                     headers={"X-Store-Status": "bad-request"},
                 )
-                self._audit(path, 400, "bad-request")
                 return
             # 🔴 THE SLICE COMES FROM THE TABLE, NOT FROM THE REQUEST. It read
             # `parts[1 : len(parts) - tail_len]`, and `len(parts)` is
@@ -3053,8 +3126,8 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         # 🔴 THE UNCHANGED TAIL. `read-only` is a claim about THIS ROUTE, not
         # about the server: `/api/v1/recall/<scope>` and `/api/v1/snapshot` have
         # no write verb and never will, and that is what this answers.
-        self._respond(405, b"read-only\n", headers={"Allow": "GET, HEAD"})
         self._audit(path, 405, "method-not-allowed")
+        self._respond(405, b"read-only\n", headers={"Allow": "GET, HEAD"})
 
     def _write_route(self, path: str) -> "tuple[str, list[str], int, int] | None":
         """Match one request against `WRITE_ROUTES`, or `None`.
@@ -3162,8 +3235,8 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             # into a keep-alive channel. Recorded as an EQUIVALENT MUTANT rather
             # than left as an unexplained survivor.
             self.close_connection = True
-            self._unauthorized()
             self._audit(path, 401, "malformed-request")
+            self._unauthorized()
             return
         self._drain_body()
         if not self._identify_and_meter(path):
@@ -3189,8 +3262,8 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         the operator can still tell a credential-stuffing run from a
         misconfigured client, in a place the attacker cannot read.
         """
-        self._unauthorized()
         self._audit(path, 401, status)
+        self._unauthorized()
 
     def _raw_path(self) -> str:
         """The request target, never parsed. Safe to log; safe on any input.
@@ -3229,8 +3302,8 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             # reassigned. Recorded at the declaration; not pinned by any test.
             self._visible_scopes = ()
             self._identity = None
-            self._unauthorized()
             self._audit(self._raw_path(), 401, "malformed-target")
+            self._unauthorized()
             return None
 
     def _identify_and_meter(self, path: str) -> bool:
@@ -3344,11 +3417,11 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             # — but "harmless because of where it happens to be mounted" is not a
             # property this file should rely on. Authenticated, so it may be told
             # what it did wrong.
+            self._audit(path, 400, "bad-request")
             self._respond(
                 400, b"bad request: invalid path component\n",
                 headers={"X-Store-Status": "bad-request"},
             )
-            self._audit(path, 400, "bad-request")
             return
 
         try:
@@ -3405,31 +3478,31 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             # mechanism, as the `_backstop` bug — so, same helper. A log write
             # may never decide whether the request gets answered.
             _print_exc_quietly()
+            self._audit(path, 503, "store-unreachable")
             self._respond(
                 503,
                 b"store unreadable: an entry name or body is not valid UTF-8\n",
                 headers={"X-Store-Status": "store-unreachable", "X-Store-Exit": "3"},
             )
-            self._audit(path, 503, "store-unreachable")
             return
         except ValueError as exc:
             # A caller error, and the caller is authenticated, so it may be told
             # what it did wrong.
             body = f"bad request: {exc}\n".encode("utf-8")
-            self._respond(400, body, headers={"X-Store-Status": "bad-request"})
             self._audit(path, 400, "bad-request")
+            self._respond(400, body, headers={"X-Store-Status": "bad-request"})
             return
         except (rc.StoreMissingError, rc.EntryUnreadableError) as exc:
             # 🔴 THE STATE THIS WHOLE DESIGN EXISTS TO KEEP SEPARATE. The store
             # was NOT read. Not a 200, not an empty digest, not "nothing recorded
             # yet" — a 503 that says so, carrying the reader's own sentence.
             body = f"{exc}\n".encode("utf-8")
+            self._audit(path, 503, "store-unreachable")
             self._respond(
                 503,
                 body,
                 headers={"X-Store-Status": "store-unreachable", "X-Store-Exit": "3"},
             )
-            self._audit(path, 503, "store-unreachable")
             return
         except Exception:  # noqa: BLE001 — deliberate backstop, see `_backstop`
             # 🔴 THE READ DISPATCH VANISHED THE SAME WAY THE WRITE ONE DID, AND
@@ -3444,8 +3517,8 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             self._backstop(path)
             return
 
-        self._respond(404, b"no such endpoint\n", headers={"X-Store-Status": "no-route"})
         self._audit(path, 404, "no-route")
+        self._respond(404, b"no such endpoint\n", headers={"X-Store-Status": "no-route"})
 
     # --- handlers ---------------------------------------------------------------
 
@@ -3474,6 +3547,7 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         # thing it qualifies has already been believed.
         fresh_header, fresh_prose = snapshot_freshness(self.store_root)
         body = (fresh_prose + "\n\n" + text + "\n").encode("utf-8")
+        self._audit(path, 200, status)
         self._respond(
             200,
             body,
@@ -3491,7 +3565,6 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
                 "X-Store-Snapshot": fresh_header,
             },
         )
-        self._audit(path, 200, status)
 
     def _recall(self, scope: str, params: dict[str, list[str]]) -> None:
         mode_values = params.get("mode")
@@ -3590,12 +3663,12 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         if scope_filter is not None and not SAFE_PATH_COMPONENT.fullmatch(scope_filter):
             # Same refusal as a bad path component: this value reaches the
             # filesystem, and the caller is authenticated so it may be told.
+            self._audit(urlsplit(self.path).path, 400, "bad-request")
             self._respond(
                 400,
                 b"bad request: invalid scope\n",
                 headers={"X-Store-Status": "bad-request"},
             )
-            self._audit(urlsplit(self.path).path, 400, "bad-request")
             return
 
         # 🔴 THE FOURTH ENUMERATION CHANNEL, AND THE ONLY ONE `load_store` CANNOT
@@ -3627,12 +3700,12 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             # 🔴 The store was NOT read. Same state, same code and the same
             # reasoning as `_recall`'s: an empty tar and an unreadable store must
             # never render alike, because one of them is a lie.
+            self._audit(urlsplit(self.path).path, 503, "store-unreachable")
             self._respond(
                 503,
                 f"store unreadable: {exc}\n".encode("utf-8"),
                 headers={"X-Store-Status": "store-unreachable", "X-Store-Exit": "3"},
             )
-            self._audit(urlsplit(self.path).path, 503, "store-unreachable")
             return
 
         def _member(path: Path, arcname: str) -> tarfile.TarInfo:
@@ -3709,12 +3782,12 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
 
         if unreadable:
             body = ("store unreadable:\n  " + "\n  ".join(unreadable) + "\n").encode()
+            self._audit(urlsplit(self.path).path, 503, "store-unreachable")
             self._respond(
                 503,
                 body,
                 headers={"X-Store-Status": "store-unreachable", "X-Store-Exit": "3"},
             )
-            self._audit(urlsplit(self.path).path, 503, "store-unreachable")
             return
 
         buf = io.BytesIO()
@@ -3740,15 +3813,16 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
                         tar.addfile(_member(entry, arcname), fh)
                     count += 1
         except OSError as exc:
+            self._audit(urlsplit(self.path).path, 503, "store-unreachable")
             self._respond(
                 503,
                 f"store unreadable: {exc}\n".encode("utf-8"),
                 headers={"X-Store-Status": "store-unreachable", "X-Store-Exit": "3"},
             )
-            self._audit(urlsplit(self.path).path, 503, "store-unreachable")
             return
 
         fresh_header, _prose = snapshot_freshness(self.store_root)
+        self._audit(urlsplit(self.path).path, 200, "snapshot")
         self._respond(
             200,
             buf.getvalue(),
@@ -3768,7 +3842,6 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
                 "X-Store-Entries": str(count),
             },
         )
-        self._audit(urlsplit(self.path).path, 200, "snapshot")
 
     # --- write handlers (criteria 4-6) ------------------------------------------
 
@@ -3789,10 +3862,10 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         The WIRE does not discriminate; the audit LOG does, via `status`, in a
         place the caller cannot read.
         """
+        self._audit(path, 404, status)
         self._respond(
             404, b"not found\n", headers={"X-Store-Status": "not-found"}
         )
-        self._audit(path, 404, status)
 
     def _resolve_writable(self, scope: str, ref: str, path: str) -> Any:
         """The entry a write targets, or `None` having already answered.
@@ -3816,23 +3889,23 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             # The caller is authenticated AND may see this scope, so it may be
             # told: an ambiguous ref is a caller error with a defined remedy, and
             # it names only entries this caller can already read.
+            self._audit(path, 400, "bad-request")
             self._respond(
                 400,
                 f"bad request: {exc}\n".encode("utf-8"),
                 headers={"X-Store-Status": "bad-request"},
             )
-            self._audit(path, 400, "bad-request")
             return None
         except (rc.StoreMissingError, rc.EntryUnreadableError) as exc:
             # 🔴 THE STORE WAS NOT READ. Never a 404 — "I could not look" and
             # "it is not there" are the four-state rule's two states and a write
             # must not conflate them any more than a read may.
+            self._audit(path, 503, "store-unreachable")
             self._respond(
                 503,
                 f"{exc}\n".encode("utf-8"),
                 headers={"X-Store-Status": "store-unreachable", "X-Store-Exit": "3"},
             )
-            self._audit(path, 503, "store-unreachable")
             return None
         if entry is None:
             # No such ref — and a MALFORMED entry lands here too, because
@@ -3878,21 +3951,21 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             # response, no `X-Store-Status` and — the part that matters — NO
             # AUDIT LINE, on a request that had already been metered. It is a
             # caller error like any other malformed body and is answered as one.
+            self._audit(path, 400, "bad-request")
             self._respond(
                 400,
                 f"bad request: body must be JSON ({exc})\n".encode("utf-8"),
                 headers={"X-Store-Status": "bad-request"},
             )
-            self._audit(path, 400, "bad-request")
             return
         problem = _bullet_request_problem(payload)
         if problem is not None:
+            self._audit(path, 400, "bad-request")
             self._respond(
                 400,
                 f"bad request: {problem}\n".encode("utf-8"),
                 headers={"X-Store-Status": "bad-request"},
             )
-            self._audit(path, 400, "bad-request")
             return
         entry = self._resolve_writable(scope, ref, path)
         if entry is None:
@@ -3907,21 +3980,22 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
                 today=_today(),
             )
         except EntryShapeError as exc:
+            self._audit(path, 422, "entry-shape")
             self._respond(
                 422,
                 f"unprocessable: {exc}\n".encode("utf-8"),
                 headers={"X-Store-Status": "entry-shape"},
             )
-            self._audit(path, 422, "entry-shape")
             return
         except OSError as exc:
+            self._audit(path, 503, "store-unreachable")
             self._respond(
                 503,
                 f"store unreadable: {exc}\n".encode("utf-8"),
                 headers={"X-Store-Status": "store-unreachable", "X-Store-Exit": "3"},
             )
-            self._audit(path, 503, "store-unreachable")
             return
+        self._audit(path, 200, status)
         self._respond(
             200,
             # 🔴 `encode_entry_text`, because `line` is NOT always the line this
@@ -3957,7 +4031,6 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
                 "ETag": f'"{revision}"',
             },
         )
-        self._audit(path, 200, status)
 
     def _replace_entry(
         self, scope: str, ref: str, body: bytes, path: str
@@ -3983,34 +4056,34 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
         """
         raw = sole_header(self.headers, "If-Match")
         if raw is None:
+            self._audit(path, 428, "precondition-required")
             self._respond(
                 428,
                 b"precondition required: send If-Match with the entry revision "
                 b"(sha256 of the entry file, first 16 hex characters)\n",
                 headers={"X-Store-Status": "precondition-required"},
             )
-            self._audit(path, 428, "precondition-required")
             return
         if_match = parse_if_match(raw)
         if "*" in if_match:
+            self._audit(path, 400, "bad-request")
             self._respond(
                 400,
                 b"bad request: If-Match: * is refused - it matches any revision, "
                 b"which is the same as sending no precondition at all\n",
                 headers={"X-Store-Status": "bad-request"},
             )
-            self._audit(path, 400, "bad-request")
             return
         if not if_match:
             # A header that is present but names NO entity-tag (`If-Match:` or
             # `If-Match: ,`) is not a precondition. Refusing it is the same
             # answer `*` gets, for the same reason: it would gate nothing.
+            self._audit(path, 400, "bad-request")
             self._respond(
                 400,
                 b"bad request: If-Match names no entity-tag\n",
                 headers={"X-Store-Status": "bad-request"},
             )
-            self._audit(path, 400, "bad-request")
             return
         entry = self._resolve_writable(scope, ref, path)
         if entry is None:
@@ -4027,6 +4100,7 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
             # 🔴 THE FILE IS UNCHANGED, and the CURRENT revision rides the
             # response: a client told only "no" cannot retry, and a client that
             # cannot retry re-sends without the precondition.
+            self._audit(path, 412, "precondition-failed")
             self._respond(
                 412,
                 b"precondition failed: the entry has changed since that revision\n",
@@ -4035,30 +4109,29 @@ class StoreRequestHandler(BaseHTTPRequestHandler):
                     "ETag": f'"{exc.current}"',
                 },
             )
-            self._audit(path, 412, "precondition-failed")
             return
         except (EntryShapeError, UnicodeDecodeError) as exc:
+            self._audit(path, 422, "entry-shape")
             self._respond(
                 422,
                 f"unprocessable: {exc}\n".encode("utf-8"),
                 headers={"X-Store-Status": "entry-shape"},
             )
-            self._audit(path, 422, "entry-shape")
             return
         except OSError as exc:
+            self._audit(path, 503, "store-unreachable")
             self._respond(
                 503,
                 f"store unreadable: {exc}\n".encode("utf-8"),
                 headers={"X-Store-Status": "store-unreachable", "X-Store-Exit": "3"},
             )
-            self._audit(path, 503, "store-unreachable")
             return
+        self._audit(path, 200, "replaced")
         self._respond(
             200,
             b"replaced\n",
             headers={"X-Store-Status": "replaced", "ETag": f'"{revision}"'},
         )
-        self._audit(path, 200, "replaced")
 
 
 def _today() -> str:

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -13578,8 +13578,15 @@ class TestNoRequestEverAuditsTwiceAndNoneVanishes:
         A duplicate beats a hole: the operator can see that the request was
         served AND that answering it failed. `settle` pins the ceiling at two, so
         "audit first" cannot quietly become "audit twice on every request".
+
+        🔴 THE OWN-COPY (`_tee`) IS WHY THIS DIES ON ITS OWN MESSAGE. Waiting for
+        two records first would make the KILLING assertion `await_audit`'s
+        ("expected at least 2, got 1") — a true statement that names a count
+        instead of naming the missing outcome. The copy is read before any
+        waiter, so the failure says which record was lost.
         """
         calls = {"n": 0}
+        records: "list[str]" = []
         real_respond = api.StoreRequestHandler._respond
 
         def flaky(self, code, body, **kwargs):
@@ -13589,25 +13596,27 @@ class TestNoRequestEverAuditsTwiceAndNoneVanishes:
             return real_respond(self, code, body, **kwargs)
 
         monkeypatch.setattr(api.StoreRequestHandler, "_respond", flaky)
-        with running(store) as (base, audit):
+        with running(store, wrap_sink=_tee(records)) as (base, audit):
             code, headers, body = fetch(
                 f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN
             )
-            await_audit(audit, 2)
+            await_audit(audit, 1)
         monkeypatch.undo()
 
         assert code == 500, (code, body)
         assert headers["X-Store-Status"] == "internal-error"
-        lines = settle(audit, 2)
-        assert "result=200 status=recalled" in lines[0], (
-            "the outcome the handler had already decided was never written — "
-            f"the record was lost in the crash: {lines}"
+        assert any("result=200 status=recalled" in ln for ln in records), (
+            "the outcome the handler had already decided was NEVER WRITTEN — the "
+            "record died with the response it was waiting for. The trail holds "
+            f"only: {records}"
         )
-        assert "result=500 status=internal-error" in lines[1], lines
         # And it really was the injected failure, not a store that answered 500
         # on its own: `_respond` was reached twice, the handler's and the
         # backstop's.
         assert calls["n"] == 2, calls
+        lines = settle(audit, 2)
+        assert "result=200 status=recalled" in lines[0], lines
+        assert "result=500 status=internal-error" in lines[1], lines
 
     def test_an_exception_AFTER_a_completed_response_audits_EXACTLY_TWICE(
         self, store: Path, monkeypatch

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -192,6 +192,7 @@ def running(
     tokens=None,
     limiter=None,
     trusted_proxies=(LOOPBACK_PROXY,),
+    wrap_sink=None,
 ):
     """Bind a real server on :0 and drive it over a real socket.
 
@@ -203,8 +204,19 @@ def running(
     works on it. The response-does-not-imply-the-line race `drain_output`
     documents is NOT a property of the subprocess pipe — it is a property of
     `ThreadingHTTPServer`, and this in-process server has exactly the same one.
+
+    🔴 `wrap_sink` IS THE SEAM THAT MAKES THE ORDERING AND ATOMICITY DEFECTS
+    OBSERVABLE WITHOUT A SLEEP. It takes the recording sink and returns the sink
+    actually installed, so a test can interpose a GATE (hold the first record and
+    watch whether the client sails on) or a deliberately NON-ATOMIC writer (emit
+    the record and its terminator as two writes — the shape `print` really has).
+    The `AuditLog` is still handed every record either way, so `await_audit` and
+    `settle` keep working at those sites. Wrapping here rather than standing up a
+    second server helper means such a test inherits this teardown rather than
+    open-coding a copy of it.
     """
     audit = AuditLog()
+    sink = audit.append if wrap_sink is None else wrap_sink(audit.append)
     httpd = api.build_server(
         host="127.0.0.1",
         port=0,
@@ -212,7 +224,7 @@ def running(
         tokens=(token,) if tokens is None else tuple(tokens),
         trusted_proxies=tuple(trusted_proxies),
         limiter=limiter,
-        audit=audit.append,
+        audit=sink,
     )
     thread = threading.Thread(target=httpd.serve_forever, daemon=True)
     thread.start()
@@ -335,13 +347,22 @@ class AuditLog(list):
     🔴 IT IS A REAL `list` BECAUSE FORTY-ODD ASSERTIONS READ IT AS ONE, and it
     carries `Drained`'s read surface because `await_audit` is the one helper in
     this file that knows how to wait for a line. The race is NOT a property of
-    the subprocess pipe: `_respond` runs before `_audit` on a
-    `ThreadingHTTPServer`, so an in-process `fetch()` returning proves exactly
-    as little about the audit line as a subprocess one does. Before this class
-    existed the in-process sites had no way to wait at all, and the only thing
-    standing between them and a red run was `shutdown()`'s 0.5s poll interval —
-    a `sleep` nobody wrote down. Measured: with the handler's `_audit` delayed
-    past that interval, the teardown "barrier" vanishes entirely.
+    the subprocess pipe: it is a property of `ThreadingHTTPServer`, so an
+    in-process `fetch()` returning proves exactly as little about the audit line
+    as a subprocess one does. Before this class existed the in-process sites had
+    no way to wait at all, and the only thing standing between them and a red run
+    was `shutdown()`'s 0.5s poll interval — a `sleep` nobody wrote down.
+    Measured: with the handler's `_audit` delayed past that interval, the
+    teardown "barrier" vanishes entirely.
+
+    🔴 AND THE WAIT IS STILL NEEDED NOW THAT `_audit` RUNS BEFORE `_respond`.
+    That ordering makes "the client holds response N" imply "line N is in the
+    sink" for the request the client is holding — but the append is to a plain
+    `list` from a handler thread nothing joins, and requests that are NOT the one
+    being awaited (a `/healthz`, a pipelined second request, a lockout probe) are
+    still in flight. `TestTheAuditLineIsWrittenBEFORETheResponse` pins the new
+    ordering property directly; these helpers keep waiting rather than leaning on
+    it, because a waiter is correct under both.
 
     🔴 `closed` IS `None`, NOT AN UNSET `Event`, AND THAT IS THE HONEST VALUE.
     A `Drained` reaches EOF when the pipe closes, which is a real "no more lines
@@ -409,12 +430,15 @@ class Drained:
 def drain_output(proc) -> Drained:
     """Start draining a RUNNING process's stdout; returns the growing record.
 
-    🔴 THE RESPONSE DOES NOT IMPLY THE LOG LINE, and every test that reads audit
-    output has to be written around that. A handler writes its response and only
-    THEN calls `_audit()`, on a ThreadingHTTPServer — so `fetch`/`fetch_from`
-    returning means the response was written, not that the handler thread has
-    reached its `print`. Any test that calls `proc.terminate()` on the client's
-    return is racing the line it is about to assert on.
+    🔴 THE RESPONSE DOES NOT IMPLY EVERY LOG LINE, and every test that reads
+    audit output has to be written around that. A handler used to write its
+    response and only THEN call `_audit()`, on a ThreadingHTTPServer — so
+    `fetch`/`fetch_from` returning meant the response was written, not that the
+    handler thread had reached its `print`. `_audit` now runs FIRST (see
+    `TestTheAuditLineIsWrittenBEFORETheResponse`), which settles the awaited
+    request's own line but says nothing about any OTHER request still in flight
+    on this process. A test that calls `proc.terminate()` on one client's return
+    is still racing every line it has not waited for.
 
     Draining also keeps the pipe buffer from becoming a SECOND timing
     dependency. Teardown stays with `running_subprocess`.
@@ -497,18 +521,30 @@ def await_audit(out: "Drained | AuditLog", n: int, timeout: float = 15.0) -> "li
     `wait_closed()` form because a subprocess pipe really does have an EOF.
 
     🔴 AND IT GUARANTEES A COUNT, NEVER AN ORDER — the half that cost a red run
-    after the count race was closed everywhere. `_audit` runs AFTER `_respond`,
-    so a client can send request N+1 while handler N has still not appended:
-    request N's line can land SECOND. `await_audit(audit, 2)` is then perfectly
-    satisfied by two lines in the WRONG order, and a caller reading `lines[0]`
-    attributes one request's fields to another. MEASURED: with every positional
-    site waiting only at the end, `test_a_ROTATION_end_to_end_old_still_works_
-    then_stops` failed on `lines[0]` inside a full-file run.
+    after the count race was closed everywhere. `_audit` used to run AFTER
+    `_respond`, so a client could send request N+1 while handler N had still not
+    appended: request N's line landed SECOND. `await_audit(audit, 2)` is then
+    perfectly satisfied by two lines in the WRONG order, and a caller reading
+    `lines[0]` attributes one request's fields to another. MEASURED: with every
+    positional site waiting only at the end, `test_a_ROTATION_end_to_end_old_
+    still_works_then_stops` failed on `lines[0]` inside a full-file run.
 
-    So a POSITIONAL read has a second obligation: wait for line N BEFORE issuing
-    request N+1, which makes the position a fact rather than an assumption. A
-    caller that only aggregates (`len`, `any`, `all`, `sum`, `join`) has no such
-    obligation.
+    🔴 THE SERVER-SIDE HALF OF THAT IS NOW FIXED — AND THIS OBLIGATION STAYS.
+    `_audit` runs BEFORE `_respond`, so for a client that issues request N+1
+    only after response N has come back, the records are in request order by
+    construction. Two reasons the rule below does not relax: (a) it is a claim
+    about a SEQUENTIAL client, and a site with two requests genuinely in flight
+    (`threading.Thread`, a pipelined socket, a `/healthz` alongside an API call)
+    gets no ordering promise at all; (b) leaning on it would make every
+    positional site in this file a second, uncounted assertion of the ordering
+    property — so a regression there would show up as forty confusing failures
+    instead of the one guard that exists to state it,
+    `TestTheAuditLineIsWrittenBEFORETheResponse`.
+
+    So a POSITIONAL read keeps its second obligation: wait for line N BEFORE
+    issuing request N+1, which makes the position a fact rather than an
+    assumption. A caller that only aggregates (`len`, `any`, `all`, `sum`,
+    `join`) has no such obligation.
 
     🔴 THE OBLIGATION IS "AT MOST ONE AUDITED REQUEST IS IN FLIGHT PER WAIT",
     NOT "one request per wait" — an earlier draft of this paragraph claimed
@@ -5841,9 +5877,10 @@ def _transitive(seed: dict, funcs: dict) -> dict:
 def test_no_test_reads_an_AUDIT_LINE_from_a_process_it_just_terminated():
     """🔴 THE SEAM GUARD. The hazard is a RELATIONSHIP inside one test — reading
     audit records out of a stream while also being the thing that killed the
-    process producing them. `_respond` runs before `_audit`, so the client's
-    return proves nothing about the line, and terminating on it races the
-    emission.
+    process producing them. A client's return proves nothing about the lines it
+    did not wait for — `_audit` precedes `_respond` for the request in hand and
+    says nothing about any other handler thread — and terminating on it races
+    the emission.
 
     🔴 WHAT IT DELIBERATELY PERMITS:
     `test_the_startup_line_NAMES_the_trusted_proxies` terminates and reads stdout
@@ -6063,8 +6100,8 @@ def test_every_exact_count_site_goes_through_settle():
     guards with their own mutation matrices, and neither belongs in a change
     that inherits this PR's.
     """
-    assert _settle_call_sites() == 15, (
-        f"expected exactly 15 `settle(...)` call sites, found "
+    assert _settle_call_sites() == 21, (
+        f"expected exactly 21 `settle(...)` call sites, found "
         f"{_settle_call_sites()}. A ceiling was added or given up; if that is "
         "intended, update this count AND say in the commit which property the "
         "file no longer asserts."
@@ -6075,13 +6112,13 @@ def test_the_settle_call_site_THRESHOLD_is_load_bearing_not_decorative():
     """🔴 The mutant the threshold's own sweep cannot supply, for `settle`.
 
     Deleting the helper everywhere drives the count to 0 and kills `>= 1`,
-    `>= 14` and `== 15` identically. This removes ONE site from a COPY of the
-    source and requires the count to actually move to 14 — the case that
-    separates a real ceiling census from a floor that fifteen sites could
+    `>= 20` and `== 21` identically. This removes ONE site from a COPY of the
+    source and requires the count to actually move to 20 — the case that
+    separates a real ceiling census from a floor that twenty-one sites could
     satisfy with one.
     """
     src = Path(__file__).read_text()
-    assert _settle_call_sites(src) == 15, "fixture drift: the real count moved"
+    assert _settle_call_sites(src) == 21, "fixture drift: the real count moved"
 
     # A literal that appears exactly once as real code. (It also appears in this
     # line, later in the file; `count=1` takes the earlier, real occurrence, and
@@ -6089,9 +6126,9 @@ def test_the_settle_call_site_THRESHOLD_is_load_bearing_not_decorative():
     one_removed = src.replace("lines = settle(audit, 21)",
                               "lines = []  # mutant", 1)
     assert one_removed != src, "the mutation did not apply — this test is vacuous"
-    assert _settle_call_sites(one_removed) == 14, (
+    assert _settle_call_sites(one_removed) == 20, (
         "removing one call site did not move the count, so the threshold cannot "
-        "distinguish fifteen ceilings from fourteen"
+        "distinguish twenty-one ceilings from twenty"
     )
 
 
@@ -6271,10 +6308,13 @@ def test_no_test_INDEXES_a_live_audit_list():
 
     One of them was observed failing: `test_a_LOCKED_OUT_response_is_BYTE_
     IDENTICAL_to_an_ordinary_401` asserted on `audit[-1]` and got the PREVIOUS
-    request's `status=unauthorized`. `_respond` runs before `_audit`, and
+    request's `status=unauthorized`. `_respond` ran before `_audit` then, and
     `ThreadingHTTPServer` uses DAEMON threads — which `socketserver._Threads`
     refuses to track — so `server_close()` joins nothing: neither `fetch`
     returning NOR the `with` block exiting proves the last handler has appended.
+    The first half of that is fixed (`_audit` is emitted first now); the DAEMON
+    half is not, and a site with a second request in flight has no ordering
+    promise at all, so the ban stands.
 
     An unknown number of tests carrying a known race is worse than the one that
     was caught, so the count is pinned here rather than left to the next reader.
@@ -6358,9 +6398,9 @@ def test_no_test_INDEXES_a_live_audit_list():
         if unguarded:
             offenders.append(f"{fn.name} (line {fn.lineno}) reads at {unguarded}")
     assert not offenders, (
-        "these tests index the LIVE audit list: `_respond` runs before `_audit` "
-        "and the handler threads are never joined, so the record may not be "
-        "there yet. Use `lines = await_audit(audit, n)` and index `lines`, and "
+        "these tests index the LIVE audit list: the handler threads are never "
+        "joined and a request the client is not holding may not have appended "
+        "yet. Use `lines = await_audit(audit, n)` and index `lines`, and "
         "`settle(audit, n)` after the `with` block for an exact count:\n  "
         + "\n  ".join(offenders)
     )
@@ -12269,8 +12309,8 @@ def _request(host: str, method: str, target: str, body: bytes | None = None) -> 
 class TestTheBackstopNeverSendsASecondResponse:
     """🔴 THE GUARD ADDED TO CLOSE THE AUDIT HOLE REOPENED THE DESYNC HOLE.
 
-    `_append_bullet` calls `_respond(200, …)` and THEN `_audit(…)`, and both used
-    to sit inside the dispatch backstop's `try`. Anything raising after that
+    `_append_bullet` used to call `_respond(200, …)` and THEN `_audit(…)`, and
+    both sat inside the dispatch backstop's `try`. Anything raising after that
     `_respond` — a broken audit sink, a full disk on stderr, or simply the next
     statement somebody adds below it — made the backstop call `_respond(500, …)`
     on a connection that had already sent a complete `200`. `_respond` has no
@@ -12279,11 +12319,15 @@ class TestTheBackstopNeverSendsASecondResponse:
     trailing `500` to the NEXT client on it. That is the response-desync class
     `_drain_body`'s own docstring exists to prevent.
 
-    ⚠ HONEST REACHABILITY: induced here by wrapping the handler. In production
-    the only statement after that `_respond` is `_audit`, so it needs the audit
-    sink to raise — but "no statement will ever be added after a `_respond`" is a
-    promise, not a guard, which is why the fix is a flag inside `_respond` rather
-    than a rule about where code may go.
+    ⚠ HONEST REACHABILITY, AND IT IS NOW THINNER THAN IT WAS — WHICH IS A REASON
+    TO KEEP THESE TESTS, NOT TO DELETE THEM. The already-responded arm is
+    induced here by wrapping the handler. It used to have a production route
+    (`_audit` ran after `_respond`, so a raising sink reached it); with the audit
+    emitted FIRST there is no statement after a completed `_respond` at any call
+    site, so nothing in production reaches this arm today. That is precisely the
+    state the fix is a flag inside `_respond` rather than a rule about where code
+    may go: "no statement will ever be added after a `_respond`" is a promise,
+    and the next person to add one gets the guard instead of the desync.
     """
 
     def test_an_exception_AFTER_the_response_sends_NO_second_response(
@@ -12613,16 +12657,31 @@ class TestTheBackstopSurvivesITSOWNLogSink:
         self, scoped_store: Path, monkeypatch, capfd
     ):
         """The SECOND print, on the route the docstring calls the only
-        production-reachable one: the AUDIT SINK is what raised. The append has
-        already answered `200`, so the backstop owes only a log entry — and when
-        the log is what is broken it must end the request cleanly anyway.
+        production-reachable one: the AUDIT SINK is what raised. The backstop
+        owes an answer and a log entry — and when the log is what is broken it
+        must end the request cleanly anyway.
 
         🔴 THE OBSERVABLE IS STDERR, NOT THE WIRE, and that is not a weaker
-        claim — it is the claim. The `200` is already out either way, so with
-        the second print unguarded the exception escapes `do_POST`, past
+        claim — it is the claim. An answer goes out either way, so with the
+        second print unguarded the exception escapes `do_POST`, past
         `handle_one_request`, into `socketserver.BaseServer.handle_error`, whose
         banner replaces the operator's traceback. That banner appearing is the
         failure.
+
+        🔴 THE ANSWER MOVED FROM `200` TO `500`, AND THAT IS THE PRICE OF
+        AUDIT-BEFORE-RESPOND, WRITTEN DOWN RATHER THAN DISCOVERED LATER. This
+        test asserted `200` while `_audit` ran AFTER `_respond`: the append
+        answered, the sink then raised, and the caller was served a request that
+        had no record. Now the sink raises BEFORE any byte is written, so
+        `_responded` is False and the backstop answers `500` — the request is
+        REFUSED rather than silently unrecorded.
+
+        ⚠ AND THE MUTATION STILL LANDED, which is the uncomfortable half and is
+        asserted below rather than glossed: the append is complete before the
+        outcome is known, so a broken sink produces a `500` over a write that
+        happened. That is the fail-closed direction for an audit trail — the
+        operator sees a failure instead of nothing — but it is not free, and a
+        client that retries on `500` will append twice.
         """
         broken = _RaisingTraceback()
 
@@ -12647,11 +12706,18 @@ class TestTheBackstopSurvivesITSOWNLogSink:
         captured = capfd.readouterr()
 
         # 🔴 THE WRITE LANDED. Without this every assertion below is satisfied by
-        # a server that refused the append and therefore had nothing to audit.
+        # a server that refused the append and therefore had nothing to audit —
+        # and it is also the half that makes the `500` below a TRADE rather than
+        # a clean refusal. See the docstring.
         assert BULLET_SINKLESS in nuance_of(path), path.read_text()
         answers = _responses(raw)
-        assert len(answers) == 1, f"a second response followed the 200: {raw!r}"
-        assert answers[0].startswith(b"200 "), raw
+        assert len(answers) == 1, f"a second response followed the answer: {raw!r}"
+        assert answers[0].startswith(b"500 "), (
+            "a request whose audit record could not be written was SERVED. With "
+            "`_audit` before `_respond` the sink raises before any byte is on "
+            "the wire, so the backstop owes a 500 — an unrecordable request is "
+            f"refused, not answered: {raw!r}"
+        )
         assert saw_eof, "the connection was left open after an unknown-state request"
         # BOTH prints were attempted — the handler's exception and the audit
         # failure. `>= 1` would be satisfied without ever reaching the second
@@ -12975,3 +13041,807 @@ class TestTheSurrogateNoteNamesTheRealGuard:
             "THEREFORE LOAD-BEARING HERE, NOT MERELY DEFENSIVE, AND MUST NOT BE "
             "REMOVED ON THE STRENGTH OF THIS COMMENT."
         ) in text, "the corrected reason is not in the file"
+
+
+# =============================================================================
+# THE AUDIT LINE IS WRITTEN *BEFORE* THE RESPONSE, AND THE SINK IS SERIALISED.
+#
+# 🔴 TWO DEFECTS, ONE CALL-SITE SHAPE. Every handler in `server.py` used to
+# `_respond(...)` and only then `_audit(...)`, against a `ThreadingHTTPServer`
+# whose default sink is a bare unlocked `print`.
+#
+#   ORDERING     A SEQUENTIAL client's request N+1 is accepted on a NEW handler
+#                thread the moment response N is on the wire, so handler N+1
+#                could reach the sink before handler N did and the stream came
+#                out in the wrong order. Seen once in the nix sandbox tier:
+#                `test_the_audit_line_names_WHICH_fingerprint_matched` failed on
+#                `token=<A> in audit[0]` with the two records SWAPPED, then
+#                passed on re-run and in ~20 runs after. Rare, and real.
+#   ATOMICITY    `print(line, flush=True)` is TWO writes on one stream — the
+#                record, then the terminator — so two overlapping handlers can
+#                emit `<A><B>\n\n`: one line carrying two requests' fields and
+#                one carrying none.
+#
+# 🔴 AND THEY NEED DIFFERENT FIXES, WHICH IS WHY THEY GET DIFFERENT TESTS.
+# Ordering alone leaves genuinely concurrent callers interleaving; a lock alone
+# leaves a sequential client's records out of order. Each test below is red
+# under exactly one of the two mutants — see the PR's matrix.
+#
+# 🔴 NOTHING HERE WAITS ON A SLEEP TO MAKE ITS VERDICT. The observable is forced
+# by the injected sink (`running(..., wrap_sink=...)`): a GATE that holds the
+# first record so the client's own progress becomes the measurement, and a
+# deliberately NON-ATOMIC writer that cannot help but interleave if it is
+# allowed to run twice at once. The two bounded windows below are windows for a
+# FAILURE to appear in, never a wait for success to finish — the same shape
+# `settle` uses, and for the same reason.
+# =============================================================================
+
+# How long to keep watching for the client to sail past a HELD audit record.
+# It is the width of the ordering claim: with the record held, the response must
+# not have been written, so the client cannot have started its next request. Not
+# a wait for anything to succeed — the gate is released immediately afterwards,
+# whatever we saw. A saturated host stretches the client and this window on the
+# SAME clock, so it cannot turn a green run red; it can only miss a violation.
+_ORDER_PROBE_S = 1.0
+
+# How long the non-atomic sink holds its record open, waiting for a second
+# writer to interleave with it. With the sink serialised no second writer can
+# ever arrive, so this window is spent in full, once, by one test.
+_SPLIT_WINDOW_S = 0.5
+
+# 🔴 A TOKEN THIS SECTION OWNS, AND ITS FINGERPRINT WRITTEN OUT BY HAND. The
+# whole-line pin below must not compute its expectation with `api.token_id` —
+# that asserts `x == x` and stays green through a change to the digest that
+# every operator's grep depends on. sha256("p"*48).hexdigest()[:12].
+PINNED_TOKEN = "p" * 48
+PINNED_TOKEN_ID = "d64bf41c3707"
+
+# 🔴 THE WHOLE RECORD, FIELD FOR FIELD, NOT A KEYWORD. A guard spelled as
+# `"token=" in line` passes on a line whose fields are in the wrong order, on a
+# line that lost `identity=`, and on two records fused into one — which is
+# precisely the atomicity defect. `fullmatch` or nothing.
+_AUDIT_LINE_RE = re.compile(
+    r"store-api audit "
+    r"ts=\S+ ip=\S+ peer=(?:-|trusted|untrusted) method=\S+ path=\S+ "
+    r"token=\S+ identity=\S+ auth=(?:ok|fail) result=\d+ status=\S+"
+)
+
+
+def _poll_until(predicate, timeout: float) -> bool:
+    """Spin until `predicate()` is true or `timeout` elapses. Says which.
+
+    🔴 A POLL RATHER THAN `Event.wait(t)`, AND THE REASON IS A GUARD IN THIS
+    FILE RATHER THAN A PREFERENCE. `_KILLERS` counts a bare `.wait` ATTRIBUTE as
+    terminating a process, so a test that waits on an `Event` and also reads
+    audit records is a false offender in
+    `test_no_test_reads_an_AUDIT_LINE_from_a_process_it_just_terminated` — the
+    same collision that made `settle` spell its barrier `wait_closed()` instead
+    of `closed.wait()`. Polling is the identical synchronisation in a shape that
+    guard can tell apart from a kill.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+class _Rendezvous:
+    """A meeting point for `parties` threads that TIMES OUT instead of blocking.
+
+    Deliberately not `threading.Barrier`: its `wait()` carries the verb
+    `_KILLERS` reads as a process kill (see `_poll_until`), and a broken barrier
+    RAISES where every caller here wants a boolean. It is also sticky on purpose
+    — once enough threads have arrived it stays satisfied — so a late arrival
+    returns immediately rather than hanging on a second generation.
+    """
+
+    def __init__(self, parties: int = 2) -> None:
+        self.parties = parties
+        self.arrived = 0
+        self._lock = threading.Lock()
+
+    def arrive(self, timeout: float) -> bool:
+        """Count this thread in, then wait for the rest. `False` = timed out."""
+        with self._lock:
+            self.arrived += 1
+        return _poll_until(lambda: self.arrived >= self.parties, timeout)
+
+
+class _GatedSink:
+    """Holds the FIRST record handed to it until the test lets go.
+
+    🔴 THIS IS THE WHOLE INSTRUMENT FOR THE ORDERING CLAIM, AND IT WORKS BY
+    MAKING THE CLIENT THE MEASUREMENT. With the record held:
+
+      audit-before-respond -> response 1 is not on the wire, so a sequential
+                              client is still blocked inside its FIRST request
+      respond-before-audit -> response 1 went out before the sink was entered,
+                              so the client has already issued its SECOND
+
+    "Which request has the client started" is a fact about the client, observed
+    from outside the server, and it does not depend on how fast anything runs.
+    """
+
+    def __init__(self) -> None:
+        self.reached = _Rendezvous(parties=1)   # set when the first record is held
+        self.released = False
+        self.seen = 0
+        self._lock = threading.Lock()
+
+    def release(self) -> None:
+        self.released = True
+
+    def __call__(self, inner):
+        def sink(line: str) -> None:
+            with self._lock:
+                self.seen += 1
+                first = self.seen == 1
+            if first:
+                self.reached.arrive(0.0)
+                # A generous ceiling: the test releases explicitly, in a
+                # `finally`, so this bound is only reached if the test itself
+                # died — in which case hanging the server thread would turn one
+                # failure into a suite that never finishes.
+                _poll_until(lambda: self.released, 30.0)
+            inner(line)
+
+        return sink
+
+
+class _SplittingSink:
+    """A sink whose write is NON-ATOMIC in exactly the way `print` is.
+
+    `print(line, flush=True)` writes the record and the terminator separately.
+    This reproduces that split and FORCES the hazard rather than hoping for it:
+    between the two writes it waits for a SECOND writer to arrive, so any sink
+    that admits two threads at once must produce `<A><B>\\n\\n`. When the sink is
+    serialised the second writer can never arrive, the window is spent, and the
+    two records come out whole and terminated.
+
+    `pieces` is an ordinary list appended without a lock ON PURPOSE — the append
+    ORDER is the measurement, and serialising it here would destroy the very
+    thing under test. `list.append` is atomic, so the list itself is safe.
+    """
+
+    def __init__(self, window: float) -> None:
+        self.pieces: "list[str]" = []
+        self.window = window
+        self.mid = _Rendezvous(parties=2)
+
+    @property
+    def stream(self) -> str:
+        """Everything the sink wrote, in the order it wrote it."""
+        return "".join(self.pieces)
+
+    def __call__(self, inner):
+        def sink(line: str) -> None:
+            self.pieces.append(line)
+            self.mid.arrive(self.window)
+            self.pieces.append("\n")
+            inner(line)
+
+        return sink
+
+
+def _tee(records: "list[str]"):
+    """A `wrap_sink` that copies every record into `records` and passes it on.
+
+    The copy is what a test may read while the server is RUNNING: it is the
+    test's own list, so the ban on indexing the live `AuditLog`
+    (`test_no_test_INDEXES_a_live_audit_list`) is not being walked around — that
+    ban is about reading a shared record with no waiter, and these sites are
+    asserting a per-request ordering property the waiter would hide.
+    """
+
+    def wrap(inner):
+        def sink(line: str) -> None:
+            records.append(line)
+            inner(line)
+
+        return sink
+
+    return wrap
+
+
+def _without_ts(line: str) -> str:
+    """The record with its one genuinely varying field replaced by a marker."""
+    return re.sub(r"ts=\S+", "ts=<TS>", line, count=1)
+
+
+class TestTheAuditLineIsWrittenBEFORETheResponse:
+    """§ the record is a PRECONDITION of the answer, not a footnote to it."""
+
+    def test_HOLDING_the_first_record_STOPS_the_client_reaching_the_second(
+        self, store: Path
+    ):
+        """🔴 THE DETERMINISTIC REPRODUCTION. No sleep decides this verdict.
+
+        The sink holds request A's record. Two mutually exclusive states follow,
+        and the client tells us which one we are in: if the response is written
+        before the record, A has already come back and the client has issued B;
+        if the record is written first, the client is still inside A.
+
+        MEASURED at the base ref (`_audit` after `_respond`): `reached` came back
+        `['A', 'B']` and the records came back in the order B, A. Both
+        assertions below are red there, on their own messages.
+        """
+        gate = _GatedSink()
+        reached: "list[str]" = []
+
+        def client(base: str) -> None:
+            for name, scope in (("A", SCOPE), ("B", OTHER_SCOPE)):
+                # Recorded BEFORE the request, so this list means "has issued",
+                # never "has completed" — the client blocking inside A must not
+                # be readable as the same state as never having started it.
+                reached.append(name)
+                fetch(f"{base}/api/v1/recall/{scope}", token=GOOD_TOKEN)
+
+        with running(store, wrap_sink=gate) as (base, audit):
+            worker = threading.Thread(target=client, args=(base,), daemon=True)
+            worker.start()
+            try:
+                assert gate.reached.arrive(15.0), (
+                    "the sink was never handed a record — the gate cannot have "
+                    "measured anything"
+                )
+                # A window for the VIOLATION to appear in. It is released
+                # immediately after, whatever we saw; nothing here waits for a
+                # success to finish.
+                _poll_until(lambda: len(reached) >= 2, _ORDER_PROBE_S)
+                seen = list(reached)
+            finally:
+                gate.release()
+            worker.join(timeout=30)
+            assert not worker.is_alive(), "the client never finished"
+            await_audit(audit, 2)
+
+        assert seen == ["A"], (
+            "the client issued its SECOND request while the FIRST request's "
+            "audit record was still being held — so the response was written "
+            f"before the record. Requests issued: {seen}"
+        )
+        # 🔴 THE ORDER, ASSERTED RATHER THAN ASSUMED — and this is the one site
+        # in the file entitled to read positions without interleaving its waits,
+        # because the ordering IS its subject. See `await_audit`.
+        lines = settle(audit, 2)
+        assert f"path=/api/v1/recall/{SCOPE}" in lines[0], lines
+        assert f"path=/api/v1/recall/{OTHER_SCOPE}" in lines[1], lines
+
+    def test_EVERY_sequential_response_arrives_WITH_its_record_already_written(
+        self, store: Path
+    ):
+        """The same property read at SIX points instead of one, per request.
+
+        ⚠ HONEST LABELLING: at the base ref this is a RACE, not a certain red —
+        the handler reaches its `print` microseconds after the client returns,
+        so it fails only sometimes. It is here because the property it states is
+        the one an operator relies on ("the response implies the record"), and
+        stating it once per request is what makes the claim cover more than a
+        single hand-built scenario. The DETERMINISTIC guard is the gate above.
+        """
+        records: "list[str]" = []
+        wanted = [SCOPE, OTHER_SCOPE, SCOPE, OTHER_SCOPE, SCOPE, OTHER_SCOPE]
+        with running(store, wrap_sink=_tee(records)) as (base, audit):
+            for issued, scope in enumerate(wanted, start=1):
+                code, _headers, _body = fetch(
+                    f"{base}/api/v1/recall/{scope}", token=GOOD_TOKEN
+                )
+                assert code == 200, (scope, code)
+                snapshot = list(records)
+                assert len(snapshot) == issued, (
+                    f"request {issued} (/{scope}) came back with "
+                    f"{len(snapshot)} record(s) written, expected {issued} — "
+                    "the response does not imply the record"
+                )
+                assert f"path=/api/v1/recall/{scope}" in snapshot[-1], (
+                    f"request {issued} was for /{scope} but the newest record "
+                    f"is {snapshot[-1]!r} — the records are out of order"
+                )
+            await_audit(audit, len(wanted))
+        settle(audit, len(wanted))
+
+    def test_the_WHOLE_normalised_record_is_pinned_field_for_field(
+        self, store: Path
+    ):
+        """🔴 PINNED AS ONE STRING, BECAUSE EVERY FIELD IS LOAD-BEARING.
+
+        `token=` is what makes an overlap rotation checkable, `identity=` is
+        which allowlist applied, `peer=` is how `ip=` must be read, and their
+        ORDER is what the operator's grep and the Loki parser are written
+        against. A test spelled as four `in` checks is walked by a reorder, by a
+        dropped field, and by two records fused into one line.
+
+        The expectation is a literal this test owns — the fingerprint included
+        (see `PINNED_TOKEN_ID`) — never a value computed from `server.py`.
+        """
+        with running(store, token=PINNED_TOKEN) as (base, audit):
+            code, _headers, _body = fetch(
+                f"{base}/api/v1/recall/{SCOPE}",
+                token=PINNED_TOKEN,
+                client_ip=CLIENT_IP,
+            )
+            line = await_audit(audit, 1)[0]
+        assert code == 200, code
+        assert _without_ts(line) == (
+            "store-api audit ts=<TS> "
+            f"ip={CLIENT_IP} peer=trusted method=GET "
+            f"path=/api/v1/recall/{SCOPE} "
+            f"token={PINNED_TOKEN_ID} identity=legacy auth=ok "
+            "result=200 status=recalled"
+        ), line
+        # The normaliser must actually have removed something, or the pin above
+        # is over a string that never varied and says nothing about `ts=`.
+        assert _without_ts(line) != line, line
+        assert re.search(r"ts=\d{4}-\d{2}-\d{2}T", line), line
+
+
+class TestTwoConcurrentRequestsCannotINTERLEAVETheirRecords:
+    """§ ordering fixes a SEQUENTIAL client; only a lock fixes overlapping ones.
+
+    🔴 THE HAZARD IS IN THE SINK, NOT IN THE HANDLER. `ThreadingHTTPServer` runs
+    a handler per connection and the shipped sink is `print(line, flush=True)`,
+    which is two writes on one `TextIOWrapper`. The GIL orders the individual
+    writes and says nothing about which pair they belong to, so the failure mode
+    is a stream in which one line holds two requests' fields — `token=` from one
+    caller beside `path=` from another, in the record the rotation procedure and
+    the auth-fail alert both parse.
+    """
+
+    def test_two_CONCURRENT_records_come_out_WHOLE_and_separately_terminated(
+        self, store: Path, monkeypatch
+    ):
+        """🔴 THE INTERLEAVING IS FORCED, NOT AWAITED.
+
+        Two things are arranged, and both are needed:
+
+          THE DOOR   `_audit` is wrapped so both handler threads are parked
+                     immediately BEFORE the serialised region and released
+                     together. Without it, thread A could simply finish before
+                     thread B was scheduled and the unlocked sink would look
+                     serialised — a mutant surviving on timing.
+          THE SPLIT  the sink writes the record, waits for a second writer, then
+                     writes the terminator. If two threads are ever inside it at
+                     once, B's record MUST land between A's two writes.
+
+        So `<A>\\n<B>\\n` is only reachable when the sink is serialised, and
+        `<A><B>\\n\\n` is the certain outcome when it is not. MEASURED with the
+        lock removed: one line holding both records and one empty line, failing
+        on the whole-line regex below.
+        """
+        split = _SplittingSink(window=_SPLIT_WINDOW_S)
+        door = _Rendezvous(parties=2)
+        real_audit = api.StoreRequestHandler._audit
+
+        def at_the_door(self, *args, **kwargs):
+            # OUTSIDE the serialised region on purpose: this parks both threads
+            # at the entrance, it does not hold them apart.
+            door.arrive(15.0)
+            return real_audit(self, *args, **kwargs)
+
+        monkeypatch.setattr(api.StoreRequestHandler, "_audit", at_the_door)
+        with running(store, wrap_sink=split) as (base, audit):
+            workers = [
+                threading.Thread(
+                    target=fetch,
+                    args=(f"{base}/api/v1/recall/{scope}",),
+                    kwargs={"token": GOOD_TOKEN},
+                    daemon=True,
+                )
+                for scope in (SCOPE, OTHER_SCOPE)
+            ]
+            for worker in workers:
+                worker.start()
+            for worker in workers:
+                worker.join(timeout=30)
+            assert not any(worker.is_alive() for worker in workers), (
+                "a client never came back — the door never opened"
+            )
+            await_audit(audit, 2)
+        monkeypatch.undo()
+
+        # The positive control for the instrument itself: a door nobody reached
+        # would make every assertion below a statement about a sink that was
+        # only ever entered once.
+        assert door.arrived == 2, (
+            f"{door.arrived} handler thread(s) reached the sink — the two "
+            "requests were not concurrent, so nothing was measured"
+        )
+        stream = split.stream
+        assert stream.endswith("\n"), repr(stream)
+        emitted = stream.split("\n")[:-1]
+        assert len(emitted) == 2, (
+            f"the stream holds {len(emitted)} line(s) for two requests: "
+            f"{stream!r}"
+        )
+        for line in emitted:
+            assert line.count(AUDIT_PREFIX) == 1, (
+                f"{line.count(AUDIT_PREFIX)} records were fused into one line — "
+                f"two writers interleaved: {line!r}"
+            )
+            assert _AUDIT_LINE_RE.fullmatch(line), (
+                f"not a whole, well-formed audit record: {line!r}"
+            )
+        paths = sorted(re.search(r"path=(\S+)", line).group(1) for line in emitted)
+        assert paths == sorted(
+            [f"/api/v1/recall/{SCOPE}", f"/api/v1/recall/{OTHER_SCOPE}"]
+        ), paths
+
+    def test_the_LOCK_is_ONE_object_every_handler_class_shares(self, store: Path):
+        """🔴 A PER-INSTANCE LOCK WOULD SERIALISE NOTHING, AND WOULD LOOK FINE.
+
+        `ThreadingHTTPServer` builds a NEW handler instance per connection, so a
+        lock created in `__init__` is a fresh lock per caller — never contended,
+        never wrong-looking, and completely inert. The thing being serialised is
+        one process's stdout, so the lock has to outlive the instance and the
+        server: `build_server`'s `_Handler` subclass must share the base class's.
+        """
+        first = api.build_server(
+            host="127.0.0.1", port=0, store_root=str(store),
+            tokens=(GOOD_TOKEN,), trusted_proxies=(LOOPBACK_PROXY,),
+        )
+        second = api.build_server(
+            host="127.0.0.1", port=0, store_root=str(store),
+            tokens=(GOOD_TOKEN,), trusted_proxies=(LOOPBACK_PROXY,),
+        )
+        try:
+            shared = api.StoreRequestHandler._audit_lock
+            assert first.RequestHandlerClass._audit_lock is shared
+            assert second.RequestHandlerClass._audit_lock is shared, (
+                "two servers in one process hold different audit locks, so "
+                "their records can still interleave on one stdout"
+            )
+        finally:
+            first.server_close()
+            second.server_close()
+
+
+class TestNoRequestEverAuditsTwiceAndNoneVanishes:
+    """§ the record count per request, across the outcomes and the backstop."""
+
+    def test_FOUR_different_outcomes_produce_EXACTLY_four_records(
+        self, store: Path
+    ):
+        """One line per request at four DIFFERENT call sites — a 200, a 401, a
+        404 and a 405 — so "the reorder duplicated or dropped a record" is
+        checked where the reorder happened rather than on one happy path.
+
+        `settle`, not a snapshot: the claim is a CEILING.
+        """
+        with running(store) as (base, audit):
+            ok, _h, _b = fetch(f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN)
+            await_audit(audit, 1)
+            denied, _h, _b = fetch(f"{base}/api/v1/recall/{SCOPE}")
+            await_audit(audit, 2)
+            missing, _h, _b = fetch(f"{base}/api/v1/nowhere", token=GOOD_TOKEN)
+            await_audit(audit, 3)
+            refused, _h, _b = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN, method="POST"
+            )
+            await_audit(audit, 4)
+        assert (ok, denied, missing, refused) == (200, 401, 404, 405)
+        lines = settle(audit, 4)
+        assert [int(re.search(r"result=(\d+)", ln).group(1)) for ln in lines] == [
+            200, 401, 404, 405
+        ], lines
+
+    def test_healthz_adds_NOTHING_even_while_an_audited_request_is_in_flight(
+        self, store: Path
+    ):
+        """🔴 `/healthz` IS DELIBERATELY UNAUDITED, AND THE ZERO NEEDS A CONTROL.
+
+        Sequential probes are already pinned by `test_health_is_NOT_audited`.
+        This asks the question the reorder actually changes: the probes run
+        CONCURRENTLY with an audited request, i.e. through the same serialised
+        sink, where a `/healthz` that had acquired a record would be visible as
+        a fifth line. The audited request is the positive control — its record
+        proves the sink was wired to something.
+        """
+        with running(store) as (base, audit):
+            probes = [
+                threading.Thread(
+                    target=fetch, args=(f"{base}/healthz",), daemon=True
+                )
+                for _ in range(4)
+            ]
+            for probe in probes:
+                probe.start()
+            code, _headers, _body = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN
+            )
+            for probe in probes:
+                probe.join(timeout=30)
+            assert not any(probe.is_alive() for probe in probes)
+            await_audit(audit, 1)
+        assert code == 200, code
+        lines = settle(audit, 1)
+        assert "/healthz" not in lines[0], lines[0]
+
+    def test_a_handler_that_DIES_before_its_response_has_ALREADY_logged_it(
+        self, store: Path, monkeypatch
+    ):
+        """🔴 THE PAYOFF OF AUDITING FIRST, AND IT IS RED AT THE BASE REF.
+
+        `_respond` is made to raise on its FIRST call only — so the backstop's
+        own `500` still goes out, and the induced failure sits exactly in the
+        window between the decision and the wire.
+
+          base ref (respond first)  ONE record: `result=500
+                                    status=internal-error`. What the request
+                                    actually DID is lost — the outcome was never
+                                    written.
+          here    (audit first)     TWO: the outcome (`result=200
+                                    status=recalled`) already in the stream, and
+                                    the backstop's 500 beside it.
+
+        A duplicate beats a hole: the operator can see that the request was
+        served AND that answering it failed. `settle` pins the ceiling at two, so
+        "audit first" cannot quietly become "audit twice on every request".
+        """
+        calls = {"n": 0}
+        real_respond = api.StoreRequestHandler._respond
+
+        def flaky(self, code, body, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ZeroDivisionError("between the record and the wire")
+            return real_respond(self, code, body, **kwargs)
+
+        monkeypatch.setattr(api.StoreRequestHandler, "_respond", flaky)
+        with running(store) as (base, audit):
+            code, headers, body = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN
+            )
+            await_audit(audit, 2)
+        monkeypatch.undo()
+
+        assert code == 500, (code, body)
+        assert headers["X-Store-Status"] == "internal-error"
+        lines = settle(audit, 2)
+        assert "result=200 status=recalled" in lines[0], (
+            "the outcome the handler had already decided was never written — "
+            f"the record was lost in the crash: {lines}"
+        )
+        assert "result=500 status=internal-error" in lines[1], lines
+        # And it really was the injected failure, not a store that answered 500
+        # on its own: `_respond` was reached twice, the handler's and the
+        # backstop's.
+        assert calls["n"] == 2, calls
+
+    def test_an_exception_AFTER_a_completed_response_audits_EXACTLY_TWICE(
+        self, store: Path, monkeypatch
+    ):
+        """The other arm, with the CEILING the existing coverage of it lacks.
+
+        `TestTheREADDispatchIsBackstoppedToo` asserts both records are present;
+        it cannot see a THIRD. The already-responded arm is now reachable only
+        by a statement failing after a completed `_respond` — which is what this
+        wrapper is — so pinning its count is the only way "the reorder did not
+        add a record here" stays a checked claim.
+        """
+        real_recall = api.StoreRequestHandler._recall
+
+        def then_raise(self, *args, **kwargs):
+            real_recall(self, *args, **kwargs)
+            raise ZeroDivisionError("after the recall response")
+
+        monkeypatch.setattr(api.StoreRequestHandler, "_recall", then_raise)
+        with running(store) as (base, audit):
+            code, _headers, _body = fetch(
+                f"{base}/api/v1/recall/{SCOPE}", token=GOOD_TOKEN
+            )
+            await_audit(audit, 2)
+        monkeypatch.undo()
+
+        assert code == 200, code
+        lines = settle(audit, 2)
+        assert "result=200 status=recalled" in lines[0], lines
+        assert "result=500 status=internal-error-after-response" in lines[1], lines
+
+
+# =============================================================================
+# THE LEDGERS — the two structural rules, pinned where they are written.
+# =============================================================================
+
+# 🔴 `_backstop` IS THE ONE EXEMPTION, AND IT IS EARNED, NOT GRANTED. The status
+# it records (`internal-error` vs `internal-error-after-response`) is not
+# knowable until `_responded` has been read, and on the already-responded arm the
+# bytes went out before the function was even called. Every other site in the
+# class decides its outcome first and can therefore log it first.
+_AUDITS_AFTER_RESPONDING = frozenset({"_backstop"})
+
+# The number of `_audit(...)` calls that sit immediately in front of the
+# `_respond(...)`/`_unauthorized()` they describe. A census, so DELETING a call
+# site is as loud as reordering one — a route that stops auditing is the failure
+# this whole section is about, and an offender list of zero cannot see it.
+_AUDIT_BEFORE_RESPOND_PAIRS = 33
+
+
+def _respond_names() -> "frozenset[str]":
+    """The methods that put bytes on the wire. `_unauthorized` is a `_respond`."""
+    return frozenset({"_respond", "_unauthorized"})
+
+
+def _self_call(stmt: ast.AST) -> "str | None":
+    """`self.<name>(...)` as a bare statement -> `<name>`; anything else None."""
+    if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
+        return None
+    func = stmt.value.func
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name) \
+            and func.value.id == "self":
+        return func.attr
+    return None
+
+
+def _audit_order(source: "str | None" = None) -> "tuple[int, list[str]]":
+    """`(pairs, offenders)` for the audit-before-respond rule in `server.py`.
+
+    An offender is an `_audit(...)` that appears AFTER a `_respond(...)` or
+    `_unauthorized()` in the same statement sequence — the shape both defects
+    came from. A pair is an `_audit(...)` immediately in front of one.
+
+    Scoped to `StoreRequestHandler` and to each method's own statement
+    sequences, so a helper elsewhere in the file cannot make the count drift.
+    """
+    tree = ast.parse(source if source is not None else SERVER_PATH.read_text())
+    handler = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.ClassDef) and node.name == "StoreRequestHandler"
+    )
+    responders = _respond_names()
+    pairs, offenders = 0, []
+    for method in handler.body:
+        if not isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if method.name in _AUDITS_AFTER_RESPONDING:
+            continue
+        for node in ast.walk(method):
+            for field in ("body", "orelse", "finalbody"):
+                seq = getattr(node, field, None)
+                if not isinstance(seq, list):
+                    continue
+                responded = None
+                for index, stmt in enumerate(seq):
+                    name = _self_call(stmt)
+                    if name in responders and responded is None:
+                        responded = stmt.lineno
+                    elif name == "_audit":
+                        if responded is not None:
+                            offenders.append(
+                                f"{method.name}: _audit at line {stmt.lineno} "
+                                f"follows a response at line {responded}"
+                            )
+                        following = seq[index + 1] if index + 1 < len(seq) else None
+                        if following is not None and _self_call(following) in responders:
+                            pairs += 1
+    return pairs, sorted(offenders)
+
+
+def test_every_audit_call_site_PRECEDES_its_response():
+    """🔴 THE RULE, PINNED WHERE IT IS WRITTEN RATHER THAN ONLY WHERE IT SHOWS.
+
+    The behavioural guards above catch the reorder on the routes they exercise.
+    This catches it at the EDIT, on all 33 sites at once, including the ones no
+    test drives — and it catches the far likelier regression, which is not
+    somebody reverting the fix but somebody adding the 34th call site by copying
+    the shape of a neighbour they happened to read before this change.
+
+    🔴 WHAT IT CANNOT SEE, so it is not read as more than it is: an `_audit`
+    reached through a helper (`self._log_it()`), a response written by calling
+    `self.wfile.write` directly, and any ordering between two DIFFERENT
+    statement sequences (an `_audit` in an `else:` after a `_respond` in the
+    `if:` is not a violation and is not counted as one).
+    """
+    pairs, offenders = _audit_order()
+    assert not offenders, (
+        "these sites put the response on the wire before the record. A "
+        "sequential client's next request then races the record it precedes, "
+        "and a crash in between loses the outcome entirely — audit first, then "
+        "respond (see `StoreRequestHandler._audit`):\n  " + "\n  ".join(offenders)
+    )
+    assert pairs == _AUDIT_BEFORE_RESPOND_PAIRS, (
+        f"expected {_AUDIT_BEFORE_RESPOND_PAIRS} `_audit(...)` calls sitting "
+        f"immediately in front of a response, found {pairs}. A route was added "
+        "or stopped auditing; if that is intended, update the census AND say in "
+        "the commit which requests no longer appear in the audit trail."
+    )
+
+
+def test_the_audit_ORDER_detector_can_SEE_the_defect_it_bans():
+    """🔴 THE POSITIVE CONTROL, BUILT FROM THE REAL FILE.
+
+    An offender list of zero is a fact about the walker until the walker has
+    been shown the shape. The mutation is applied to a COPY of `server.py` — the
+    405 pair, spelled exactly as it is in the source — and both halves of the
+    verdict must move: one offender named, and the pair census down by one.
+    A control built from a synthetic two-line fixture would prove neither, since
+    the real file's shape (a method body inside a class inside a module, with
+    the pair nested in an `if`) is the thing being parsed.
+    """
+    src = SERVER_PATH.read_text()
+    correct = (
+        '        self._audit(path, 405, "method-not-allowed")\n'
+        '        self._respond(405, b"read-only\\n", headers={"Allow": "GET, HEAD"})\n'
+    )
+    assert src.count(correct) == 1, (
+        "fixture drift: the 405 pair is no longer spelled the way this control "
+        "expects, so the mutation below would not apply"
+    )
+    swapped = src.replace(
+        correct,
+        '        self._respond(405, b"read-only\\n", headers={"Allow": "GET, HEAD"})\n'
+        '        self._audit(path, 405, "method-not-allowed")\n',
+        1,
+    )
+    assert swapped != src, "the mutation did not apply — this control is vacuous"
+
+    pairs, offenders = _audit_order(swapped)
+    assert len(offenders) == 1, (
+        f"the detector saw {len(offenders)} offender(s) in a source with "
+        f"exactly one reordered site: {offenders}"
+    )
+    assert "_write_route_405" in offenders[0] or "method" in offenders[0] \
+        or "_audit at line" in offenders[0], offenders
+    assert pairs == _AUDIT_BEFORE_RESPOND_PAIRS - 1, (
+        f"the pair census did not move when a pair was broken: {pairs}"
+    )
+
+
+def _sink_calls_outside_the_lock(source: "str | None" = None) -> "list[int]":
+    """Lines in `_audit` where the SINK is called from outside `_audit_lock`."""
+    tree = ast.parse(source if source is not None else SERVER_PATH.read_text())
+    audit = next(
+        node for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "_audit"
+    )
+    guarded: "list[tuple[int, int]]" = []
+    for node in ast.walk(audit):
+        if not isinstance(node, (ast.With, ast.AsyncWith)):
+            continue
+        for item in node.items:
+            expr = item.context_expr
+            if isinstance(expr, ast.Attribute) and expr.attr == "_audit_lock" \
+                    and isinstance(expr.value, ast.Name) and expr.value.id == "self":
+                guarded.append((node.body[0].lineno, node.body[-1].end_lineno))
+    loose = []
+    for node in ast.walk(audit):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "audit"
+                and isinstance(func.value, ast.Name) and func.value.id == "self"):
+            continue
+        if not any(start <= node.lineno <= end for start, end in guarded):
+            loose.append(node.lineno)
+    return sorted(loose)
+
+
+def test_the_SINK_call_is_inside_the_lock_not_beside_it():
+    """🔴 A LOCK HELD AROUND THE WRONG THING IS A LOCK THAT SERIALISES NOTHING.
+
+    The behavioural guard is
+    `test_two_CONCURRENT_records_come_out_WHOLE_and_separately_terminated`; this
+    is the cheap ledger beside it, because the way this regresses is not a
+    deletion (which that test catches loudly) but a refactor that keeps the
+    `with` and moves the sink call out from under it — leaving a lock, a
+    comment, and no serialisation.
+    """
+    loose = _sink_calls_outside_the_lock()
+    assert loose == [], (
+        "the audit SINK is called from outside `self._audit_lock` at lines "
+        f"{loose} — two concurrent handlers can interleave their writes"
+    )
+
+    # Positive control, built by removing the real `with` from a copy of the
+    # real file: the detector must flag the call it just uncovered.
+    src = SERVER_PATH.read_text()
+    locked = "        with self._audit_lock:\n            self.audit(line)\n"
+    assert src.count(locked) == 1, "fixture drift: the locked sink call moved"
+    unlocked = src.replace(locked, "        self.audit(line)\n", 1)
+    assert unlocked != src, "the mutation did not apply — this control is vacuous"
+    assert _sink_calls_outside_the_lock(unlocked), (
+        "the detector cannot see a sink call outside the lock, so its empty "
+        "list above is a fact about the walker and nothing else"
+    )

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -13868,13 +13868,22 @@ def test_the_SINK_call_is_inside_the_lock_not_beside_it():
     # keeps the mutant syntactically valid whatever the body holds.
     src = SERVER_PATH.read_text()
     lines = src.splitlines(keepends=True)
-    audit = next(
+    # 🔴 `audit_fn`, NOT `audit`. This binds an AST FunctionDef, but
+    # `_raw_audit_reads` flags the NAME — deliberately, since it cannot tell an
+    # audit-record read from anything else spelled that way — so a local called
+    # `audit` here makes this a FALSE OFFENDER in
+    # `test_no_test_INDEXES_a_live_audit_list`. MEASURED: it did, in BOTH gate
+    # tiers, on that test. What missed it was checking the edit with a `-k`
+    # filter that excluded the seam guard — a subset run is a claim about the
+    # subset. Renamed rather than widening the guard: the guard is right that a
+    # `test*` function should not carry a bare `audit` Load.
+    audit_fn = next(
         node for node in ast.walk(ast.parse(src))
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
         and node.name == "_audit"
     )
     blocks = [
-        node for node in ast.walk(audit)
+        node for node in ast.walk(audit_fn)
         if isinstance(node, (ast.With, ast.AsyncWith))
         and any(
             isinstance(item.context_expr, ast.Attribute)

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -13785,13 +13785,27 @@ def test_the_audit_ORDER_detector_can_SEE_the_defect_it_bans():
     )
     assert swapped != src, "the mutation did not apply — this control is vacuous"
 
+    # 🔴 THE LINE NUMBERS ARE COMPUTED FROM THE MUTATED TEXT THIS TEST OWNS, and
+    # the offender must name BOTH. An earlier draft accepted
+    # `"_audit at line" in offenders[0]`, which every offender string contains by
+    # construction — a disjunction that could not fail, sitting inside the one
+    # test whose whole job is to prove the detector points somewhere real. A
+    # detector that flags the right COUNT at the wrong PLACE sends the next
+    # reader to a site that is fine.
+    audit_line = 1 + swapped.splitlines().index(
+        '        self._audit(path, 405, "method-not-allowed")'
+    )
+    respond_line = audit_line - 1
+
     pairs, offenders = _audit_order(swapped)
     assert len(offenders) == 1, (
         f"the detector saw {len(offenders)} offender(s) in a source with "
         f"exactly one reordered site: {offenders}"
     )
-    assert "_write_route_405" in offenders[0] or "method" in offenders[0] \
-        or "_audit at line" in offenders[0], offenders
+    assert (
+        f"_audit at line {audit_line} follows a response at line {respond_line}"
+        in offenders[0]
+    ), (offenders, audit_line, respond_line)
     assert pairs == _AUDIT_BEFORE_RESPOND_PAIRS - 1, (
         f"the pair census did not move when a pair was broken: {pairs}"
     )

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -13857,13 +13857,44 @@ def test_the_SINK_call_is_inside_the_lock_not_beside_it():
         f"{loose} — two concurrent handlers can interleave their writes"
     )
 
-    # Positive control, built by removing the real `with` from a copy of the
-    # real file: the detector must flag the call it just uncovered.
+    # 🔴 THE CONTROL'S MUTATION IS STRUCTURAL, NOT A FIXED TWO-LINE STRING, AND
+    # THAT IS A FIX RATHER THAN A FLOURISH. It used to `str.replace` the exact
+    # text `with self._audit_lock:\n    self.audit(line)\n` with the bare call.
+    # MEASURED against an unrelated mutant that added a second statement inside
+    # the block: the two-line pattern still matched, the replacement orphaned the
+    # extra statement at the old indent, and this test died inside `ast.parse`
+    # with `IndentationError` — an exception, from a control whose whole job is
+    # to produce a specific ASSERTION. Lifting the block by its own AST span
+    # keeps the mutant syntactically valid whatever the body holds.
     src = SERVER_PATH.read_text()
-    locked = "        with self._audit_lock:\n            self.audit(line)\n"
-    assert src.count(locked) == 1, "fixture drift: the locked sink call moved"
-    unlocked = src.replace(locked, "        self.audit(line)\n", 1)
+    lines = src.splitlines(keepends=True)
+    audit = next(
+        node for node in ast.walk(ast.parse(src))
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "_audit"
+    )
+    blocks = [
+        node for node in ast.walk(audit)
+        if isinstance(node, (ast.With, ast.AsyncWith))
+        and any(
+            isinstance(item.context_expr, ast.Attribute)
+            and item.context_expr.attr == "_audit_lock"
+            for item in node.items
+        )
+    ]
+    assert len(blocks) == 1, (
+        f"fixture drift: `_audit` holds {len(blocks)} `_audit_lock` block(s), so "
+        "the control does not know which one to lift"
+    )
+    block = blocks[0]
+    body = lines[block.body[0].lineno - 1:block.body[-1].end_lineno]
+    unlocked = "".join(
+        lines[:block.lineno - 1]
+        + [ln[4:] if ln.startswith("    ") else ln for ln in body]
+        + lines[block.body[-1].end_lineno:]
+    )
     assert unlocked != src, "the mutation did not apply — this control is vacuous"
+    ast.parse(unlocked)  # the mutant must be a SOURCE FILE, not a syntax error
     assert _sink_calls_outside_the_lock(unlocked), (
         "the detector cannot see a sink call outside the lock, so its empty "
         "list above is a fact about the walker and nothing else"


### PR DESCRIPTION
## The defect

`scripts/subsystem-store-api/server.py` serves under `ThreadingHTTPServer`. Every handler
**responded first and audited second**, at all 33 call sites, into a bare unlocked sink:

```python
        self._respond(...)              # bytes on the wire
        self._audit(path, 200, status)  # record written afterwards
...
    audit: Callable[[str], None] = staticmethod(lambda line: print(line, flush=True))
```

Two independent bugs follow.

**ORDERING.** `ThreadingHTTPServer` accepts request `N+1` on a **new thread** the moment
response `N` is written, so handler `N+1` could reach the sink before handler `N` had
appended — a **sequential** client's records came out in the wrong order. Observed once in
the nix sandbox tier: `TestTokenSetAndOverlapRotation::test_the_audit_line_names_WHICH_fingerprint_matched`
failed on `token=<A> in audit[0]` with the two lines swapped, then green on re-run and in
~20 runs after. Rare, and real.

**ATOMICITY.** `print(line, flush=True)` is **two** writes on one `TextIOWrapper` — the
record, then the terminator — so two overlapping handlers could emit `<A><B>\n\n`: one line
carrying two requests' fields and one carrying none. Reproduced verbatim below.

## The fix

Implemented as briefed — **audit before responding, and lock the sink** — verified rather
than assumed. Two things worth stating explicitly:

1. **Ordering and atomicity need different fixes and get different guards.** Ordering alone
   leaves genuinely concurrent callers interleaving; the lock alone leaves a sequential
   client's records out of order. The matrix below shows each mutant killing a disjoint set,
   and `M0 = M1 ∪ M2` exactly.
2. **The lock is a CLASS attribute, not per-instance.** `ThreadingHTTPServer` builds a new
   handler per connection, so a lock created in `__init__` would be a fresh lock per caller —
   never contended, never wrong-looking, completely inert. `build_server`'s `_Handler`
   subclass shares the base class's, and mutant **M3** exists because that is invisible
   otherwise.

`_backstop` still audits last and is the one exemption, spelled out in `_AUDITS_AFTER_RESPONDING`
and in its own docstring: the status it records (`internal-error` vs
`internal-error-after-response`) is not knowable until `_responded` has been read.

### ⚠ One real behaviour change, not a free win

An audit sink that **raises** now does so before any byte is on the wire, so `_backstop`
answers `500` instead of the request being served with no record. On a write path that means
**a landed mutation can be reported as a 500** — the append completes before the outcome is
known. Fail-closed is the right direction for a service whose reason to exist is a complete
audit trail, but a client that retries on `500` will append twice.

This is the one existing test that had to move: `TestTheBackstopSurvivesITSOWNLogSink::test_a_RAISING_AUDIT_SINK_AND_a_RAISING_print_exc_still_end_the_request`
asserted `200`; it now asserts `500` **and** asserts the landed-write half explicitly, so the
trade is written down rather than discovered later. Its `broken.calls == 2` (both guarded
prints reached) and its "no socketserver banner" claim are untouched — the coverage did not
shrink, and mutant **M1** shows it still has teeth.

Also corrected, because a comment is a claim: every docstring in `server.py`, the README and
the test helpers that asserted "`_respond` runs before `_audit`".

## The deterministic reproduction

**No sleep decides any verdict here.** The observable is forced through the injectable sink
(`running(..., wrap_sink=...)`, a new seam on the existing helper).

**Ordering** — the sink *holds* request A's record, and the measurement is the **client's own
progress**, observed from outside the server:

| | with the record held |
|---|---|
| audit-before-respond | response A is not on the wire → the client is still blocked inside **A** |
| respond-before-audit | response A went out before the sink was entered → the client has already issued **B** |

Before (mutant M1 / base ref) and after, verbatim from the runs:

```
BEFORE  AssertionError: the client issued its SECOND request while the FIRST request's
        audit record was still being held — so the response was written before the
        record. Requests issued: ['A', 'B']
AFTER   ['A'], and the two records in request order
```

**Atomicity** — the interleave is *forced*, not awaited. Handler threads are parked at the
entrance to the serialised region and released together (so a mutant cannot survive on
"thread A happened to finish first"), and the sink writes the record, waits for a second
writer, then writes the terminator. `<A>\n<B>\n` is only reachable when the sink is
serialised:

```
BEFORE  AssertionError: 2 records were fused into one line — two writers interleaved:
        'store-api audit ts=… path=/api/v1/recall/gizmo-notes … status=recalledstore-api
         audit ts=… path=/api/v1/recall/widget-cfg … status=recalled'
AFTER   two whole records, each `fullmatch`ing the complete field set, each terminated
```

Neither uses `threading.Event.wait` / `Barrier.wait`: `_KILLERS` in this file counts a bare
`.wait` attribute as a process kill, so an `Event`-based test that also reads audit records is
a **false offender** in `test_no_test_reads_an_AUDIT_LINE_from_a_process_it_just_terminated` —
the same collision that made `settle` spell its barrier `wait_closed()`. `_poll_until` /
`_Rendezvous` are the same synchronisation in a shape that guard can tell apart, and both say
why in their docstrings.

## Red → green matrix

Six mutants. Each was **verified applied on disk by sha256 before any verdict was read**, run
under `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` purged before and after, and the tree
restored and re-hashed (`restored OK`) after each. Verdicts read from pytest's `-rf` summary
and the failure text, never from an exit code.

* **M1** — ordering reverted (all 33 pairs swapped back), lock kept
* **M2** — lock removed from around the sink call, ordering kept
* **M0** — both, i.e. the true base ref
* **M3** — `build_server` gives each server its **own** lock (the tidy-looking, inert variant)
* **M4** — every record emitted **twice** (the shape of a bad merge of this change: the new
  call site added in front of the response, the old one behind it not removed)
* **M5** — on the **test** file: `_audit_order` reports offenders at a line 7 further down —
  the count and census stay right, only the location moves
* **M6** — two adjacent fields swapped in the record (`identity=` / `auth=`)

| guard | M1 | M2 | M0 | M3 | M4 | M5 | M6 | killed on |
|---|---|---|---|---|---|---|---|---|
| `test_HOLDING_the_first_record_STOPS_the_client_reaching_the_second` | 🔴 | | 🔴 | | 🔴 | | | own |
| `test_EVERY_sequential_response_arrives_WITH_its_record_already_written` | 🔴¹ | | 🔴 | | 🔴 | | | own |
| `test_the_WHOLE_normalised_record_is_pinned_field_for_field` | | | | | | | 🔴 | own |
| `test_two_CONCURRENT_records_come_out_WHOLE_and_separately_terminated` | | 🔴 | 🔴 | | 🔴 | | 🔴 | own |
| `test_the_LOCK_is_ONE_object_every_handler_class_shares` | | | | 🔴 | | | | own |
| `test_FOUR_different_outcomes_produce_EXACTLY_four_records` | | | | | 🔴 | | | `settle` ceiling |
| `test_healthz_adds_NOTHING_even_while_an_audited_request_is_in_flight` | | | | | 🔴 | | | `settle` ceiling |
| `test_a_handler_that_DIES_before_its_response_has_ALREADY_logged_it` | 🔴 | | 🔴 | | 🔴 | | | own |
| `test_an_exception_AFTER_a_completed_response_audits_EXACTLY_TWICE` | | | | | 🔴 | | | `settle` ceiling |
| `test_every_audit_call_site_PRECEDES_its_response` | 🔴 | | 🔴 | | | | | own |
| `test_the_audit_ORDER_detector_can_SEE_the_defect_it_bans` | 🔴² | | 🔴² | | | 🔴 | | own |
| `test_the_SINK_call_is_inside_the_lock_not_beside_it` | | 🔴 | 🔴 | | | | | own |
| *(existing, updated)* `…RAISING_AUDIT_SINK_AND_a_RAISING_print_exc…` | 🔴 | | 🔴 | | | | | own |
| **red count** | **5** | **2** | **8** | **1** | **7** | **1** | **2** | |

**Every one of the 12 new guards is killed by at least one mutant** — none is an unexercised
invariant guard. Counting distinct guards: **13 driven, 13 watched red, 0 that no mutant
kills.** Of the kills, **10 are on the guard's own assertion** and **3 are on `settle`'s
ceiling message** — which is the guard's own instrument, prints the whole ledger, and is the
correct killer for an exact-count claim. **0 died by exception, and nothing skips.**

¹ Intermittent **by construction**, and labelled as such in its own docstring: at the base ref
the handler reaches its `print` microseconds after the client returns, so this one is a race
rather than a certain red (red in 1 of 2 M1 runs; certain under M4). It is kept because it
states the property an operator relies on — "the response implies the record" — at six points
instead of one. The deterministic guard is the gate above it.

² Dies on its own `fixture drift: the 405 pair is no longer spelled the way this control
expects` assertion — the correct diagnosis when the shape it mutates has been reverted
wholesale. M5 is the mutant that proves the *rest* of that control has teeth.

### Two defects the mutants found in my own guards, fixed in this PR

* **A control that could not fail.** `test_the_audit_ORDER_detector_can_SEE_the_defect_it_bans`
  accepted `or "_audit at line" in offenders[0]` — a disjunct every offender string contains
  by construction, inside the one test whose job is proving the detector points somewhere
  real. It now computes the mutated site's line numbers from text it owns and requires the
  offender to name **both**; M5 exists to prove that assertion moves.
* **A control that died by exception.** Under M4, `test_the_SINK_call_is_inside_the_lock_not_beside_it`
  built its mutant with a fixed two-line `str.replace`; the extra statement inside the block
  was orphaned at the old indent and the test died inside `ast.parse` with `IndentationError`.
  It now lifts the block by its own AST span and asserts the mutant parses — and correctly
  **passes** under M4, since a double emit is not a lock defect.

## What the tests cover

12 new tests, 1 existing test updated.

* **Ordering** — the gated reproduction above, plus 6 sequential requests each asserting the
  record was already written *and* that it names the path just requested.
* **Atomicity** — the forced-interleave reproduction, asserting **whole well-formed records**
  with a `fullmatch` over the entire field set (never a substring), plus a `door.arrived == 2`
  positive control so "two records came out clean" cannot be a fact about a sink that was only
  entered once. Plus the shared-lock identity test (M3).
* **The whole record pinned field for field** as one normalised string — `ts=` is the only
  field replaced, and the normaliser is itself checked to have removed something. The token
  fingerprint is a **literal this test owns** (`PINNED_TOKEN_ID = "d64bf41c3707"`), never
  `api.token_id(...)`, which would assert `x == x` and stay green through a change to the
  digest every operator's grep depends on.
* **Nothing audits twice, nothing vanishes** — `settle` ceilings on four *different* outcomes
  (200/401/404/405, i.e. four different call sites), on the crash-between-record-and-wire case
  (exactly two: the outcome plus the backstop's 500), and on the already-responded backstop arm
  (exactly two). The existing coverage of that arm asserts both records are *present*; it
  cannot see a third.
* **`/healthz` still emits nothing** — asked the way the fix actually changes: four probes
  running **concurrently** with an audited request, i.e. through the same serialised sink,
  where a probe that acquired a record would show as an extra line. The audited request is the
  positive control that the sink was wired to anything at all.
* **Two structural ledgers**, each with a positive control built by mutating a copy of the
  **real** `server.py` (not a synthetic fixture): every `_audit` precedes its response — with a
  **census of 33**, so a route that stops auditing is as loud as one that reorders — and the
  sink call is inside the lock rather than beside it. Both docstrings state what they cannot
  see.

`settle` census 15 → 21 (six ceilings added, none given up); both threshold tests updated.

## Gates

Base sha: **`9175cedf`**, this branch's tip, which **includes a merge of `origin/main`**
(`787b6114`) — so both tiers ran on the **merged tree**, not the PR branch alone. The two runs
were sequential, not concurrent, so neither was measured under the other's load.

⚠ `main` **moved during this work**: `4c03d43e` at hand-off → `9a8d9c81` when the worktree was
cut → `8bab93b1` now. The three intervening commits touch `claudedocs/*`, `nix/home.nix` and
`scripts/collector/keylog/tests/` — **disjoint** from the three files here, so there is no
overlapping region to re-read for a semantic conflict, and the merge is textually clean.

* **dev-host tier** — `nix develop … scripts/gate.sh --tier both --set all`: `GATE: RESULT=PASS exit=0` — `PASS pytest exit=0 verdict='RESULT: PASS (exit=0)'`, `PASS node exit=0 verdict='RESULT: PASS (exit=0)'`
* **sandbox tier (the one Tekton gates on)** — `nix build .#checks.x86_64-linux.{pytests,nodetests}`,
  verdicts read from the runners' own `RESULT:` lines in `nix log`, not from an exit code:
  **PASS**. pytests `TOTAL collected=18288 passed=18286 skipped=2 failed=0 (floor: 15970 = sum of 28 per-target floors)` → `RESULT: PASS (exit=0)`; nodetests `TOTAL suites=5 files=39 tests=1300 pass=1300 fail=0 skipped=0 (floor: 1239)` → `RESULT: PASS (exit=0)`

No new imports in `server.py` (`threading` was already imported), so the container closure
guard is unaffected.

### A defect the gates caught in my own work, and what it cost

An earlier revision of the lock control bound the `_audit` **AST FunctionDef** to a local
called `audit`. `_raw_audit_reads` flags the *name* — it cannot tell an audit-record read from
anything else spelled that way — so the control became a **false offender** in
`test_no_test_INDEXES_a_live_audit_list`. **Both** tiers went red on it. What missed it was
verifying that edit with a `-k` filter that excluded the seam guard: a subset run is a claim
about the subset. Renamed to `audit_fn` rather than widening the guard, which is right about
the shape it bans. Both tiers were then re-run from scratch on the corrected tree; the
verdicts above are from those runs, not from the earlier ones.
