### PR TITLE
fix(seed): the push verdict compared COUNTS, so a correct multi-host push exited 7 — and a broken single-host one could pass

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -115,10 +115,17 @@
       # encrypt/decrypt round trip (it generates its own throwaway identity; the
       # operator's key is never touched), so without age here the whole file is an
       # import error inside the sandbox rather than a green-with-skips.
+      # glibc.bin: provides `locale`, WITHOUT WHICH A COLLATION TEST CANNOT RUN.
+      # MEASURED — the sandbox has no `locale` binary, so
+      # test_subsystem_store_api.py's collation regression fell back to C and its
+      # assertions became trivially true THERE while passing on the dev host:
+      # with both `comm` calls unpinned, that tier reported 1 failure instead of
+      # 2, i.e. the defect was invisible on the tier that gates the merge.
+      # Paired with LOCALE_ARCHIVE below — the binary alone lists only C.
       gateTools = [
         gatePyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux pkgs.jq
         pkgs.gnugrep pkgs.curl pkgs.nodejs pkgs.nix pkgs.opencode pkgs.logrotate
-        pkgs.rsync pkgs.zsh pkgs.age
+        pkgs.rsync pkgs.zsh pkgs.age pkgs.glibc.bin
       ];
     in
     {
@@ -199,6 +206,10 @@
           # Set in BOTH tiers (here and checks.pytests) or the sandbox would
           # misclassify its own repo defects as environment faults.
           export DEVRC_GATE_ENV=1
+          # Set in BOTH tiers, for the same reason DEVRC_GATE_ENV is: a test
+          # whose subject is COLLATION must see the same locales in each, or the
+          # gating tier silently degrades to C and stops observing the bug.
+          export LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive
           echo "devrc: gate toolchain ready — bash scripts/run-tests.sh ." >&2
         '';
       };
@@ -351,6 +362,10 @@
             patchShebangs src/scripts
             # Same marker the devShell sets — see its shellHook for why.
             export DEVRC_GATE_ENV=1
+            # Same reason, same pairing: `locale` comes from glibc.bin in
+            # gateTools, the locales themselves from here. Without this the
+            # binary lists only `C` and a collation test cannot be made to fail.
+            export LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive
             export HOME="$TMPDIR/home"
             mkdir -p "$HOME"
             cd src

--- a/flake.nix
+++ b/flake.nix
@@ -206,14 +206,26 @@
           # both `comm` calls in seed.sh unpinned, the sandbox reported ONE
           # failure where the dev host reported TWO.
           #
-          # ⚠ An earlier version of this also added `pkgs.glibc.bin` to
-          # gateTools, on the stated grounds that a collation test "cannot run"
-          # without the `locale` binary. MEASURED FALSE: with LOCALE_ARCHIVE set
-          # and no `locale` binary at all, `LC_ALL=en_US.UTF-8 sort` collates
-          # correctly. Only a test's *probe* wanted the binary, and it cost 21
-          # store binaries (getconf, ldd, iconv, …) shadowing the system copies
-          # for every human in `nix develop`. The test now detects the locale by
-          # exercising the capability instead, so the binary is not needed.
+          # ⚠ TWO CORRECTIONS ON THE RECORD, because the first attempt to
+          # correct this was itself wrong.
+          #
+          # An earlier version added `pkgs.glibc.bin` to gateTools, on the
+          # stated grounds that a collation test "cannot run" without the
+          # `locale` binary. MEASURED FALSE: with LOCALE_ARCHIVE set and no
+          # `locale` binary at all, `LC_ALL=en_US.UTF-8 sort` collates
+          # correctly. Only a test's *probe* wanted it; the test now detects the
+          # locale by exercising the capability, so the entry was dropped.
+          #
+          # 🔴 The commit that dropped it then justified the removal by saying
+          # the entry had been "shadowing the system getconf/ldd/iconv for every
+          # human in `nix develop`". ALSO MEASURED FALSE — and after the
+          # removal: `nix develop` still resolves `locale` and `getconf` from a
+          # STORE glibc-bin, because `mkShell`'s stdenv cc-wrapper supplies it
+          # regardless (a bare `mkShell { packages = []; }` resolves them too).
+          # What the removal actually changes is the SANDBOX, which is
+          # `runCommandLocal`/stdenvNoCC and has no cc-wrapper — the opposite
+          # tier from the one that claim credited. The entry is still right to
+          # drop, for the first reason and not the second.
           export LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive
           echo "devrc: gate toolchain ready — bash scripts/run-tests.sh ." >&2
         '';

--- a/flake.nix
+++ b/flake.nix
@@ -115,17 +115,10 @@
       # encrypt/decrypt round trip (it generates its own throwaway identity; the
       # operator's key is never touched), so without age here the whole file is an
       # import error inside the sandbox rather than a green-with-skips.
-      # glibc.bin: provides `locale`, WITHOUT WHICH A COLLATION TEST CANNOT RUN.
-      # MEASURED — the sandbox has no `locale` binary, so
-      # test_subsystem_store_api.py's collation regression fell back to C and its
-      # assertions became trivially true THERE while passing on the dev host:
-      # with both `comm` calls unpinned, that tier reported 1 failure instead of
-      # 2, i.e. the defect was invisible on the tier that gates the merge.
-      # Paired with LOCALE_ARCHIVE below — the binary alone lists only C.
       gateTools = [
         gatePyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux pkgs.jq
         pkgs.gnugrep pkgs.curl pkgs.nodejs pkgs.nix pkgs.opencode pkgs.logrotate
-        pkgs.rsync pkgs.zsh pkgs.age pkgs.glibc.bin
+        pkgs.rsync pkgs.zsh pkgs.age
       ];
     in
     {
@@ -206,9 +199,21 @@
           # Set in BOTH tiers (here and checks.pytests) or the sandbox would
           # misclassify its own repo defects as environment faults.
           export DEVRC_GATE_ENV=1
-          # Set in BOTH tiers, for the same reason DEVRC_GATE_ENV is: a test
-          # whose subject is COLLATION must see the same locales in each, or the
-          # gating tier silently degrades to C and stops observing the bug.
+          # 🔴 LOCALE_ARCHIVE IS THE LOAD-BEARING HALF, AND IT IS SET IN BOTH
+          # TIERS FOR THE SAME REASON DEVRC_GATE_ENV IS. A test whose subject is
+          # COLLATION must see the same locales in each, or the gating tier
+          # silently degrades to C and stops observing the bug: measured, with
+          # both `comm` calls in seed.sh unpinned, the sandbox reported ONE
+          # failure where the dev host reported TWO.
+          #
+          # ⚠ An earlier version of this also added `pkgs.glibc.bin` to
+          # gateTools, on the stated grounds that a collation test "cannot run"
+          # without the `locale` binary. MEASURED FALSE: with LOCALE_ARCHIVE set
+          # and no `locale` binary at all, `LC_ALL=en_US.UTF-8 sort` collates
+          # correctly. Only a test's *probe* wanted the binary, and it cost 21
+          # store binaries (getconf, ldd, iconv, …) shadowing the system copies
+          # for every human in `nix develop`. The test now detects the locale by
+          # exercising the capability instead, so the binary is not needed.
           export LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive
           echo "devrc: gate toolchain ready — bash scripts/run-tests.sh ." >&2
         '';
@@ -362,9 +367,9 @@
             patchShebangs src/scripts
             # Same marker the devShell sets — see its shellHook for why.
             export DEVRC_GATE_ENV=1
-            # Same reason, same pairing: `locale` comes from glibc.bin in
-            # gateTools, the locales themselves from here. Without this the
-            # binary lists only `C` and a collation test cannot be made to fail.
+            # Same reason as the devShell's copy — see its shellHook, which
+            # also records why `pkgs.glibc.bin` is NOT here. Without this the
+            # sandbox has only `C` and a collation test cannot be made to fail.
             export LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive
             export HOME="$TMPDIR/home"
             mkdir -p "$HOME"

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -111,24 +111,51 @@ for d in "$STAGE"/*/; do
   [[ -d "$d" ]] || continue
   staged_scopes=$((staged_scopes + 1))
   name=$(basename "$d")
-  # `index(...)==1` is a LITERAL prefix test — a scope name is not a regex, and
-  # `grep -c "^$name/"` would mis-count one containing `.` or `[`.
-  n=$(awk -v p="$name/" 'index($0, p) == 1 {c++} END {print c + 0}' "$staged_list")
+  # `index(...)==1` is a LITERAL PREFIX test on purpose — twice over. A scope
+  # name is not a regex, so `grep -c "^$name/"` mis-counts one containing `.` or
+  # `[`; and `index(...) > 0` would be a SUBSTRING test, which with scopes `foo`
+  # and `xfoo` counts `xfoo/n.md` against `foo`.
+  # 🔴 Passed through ENVIRON, not `awk -v`: `-v` interprets escape sequences,
+  # so a scope literally named `a\tb` would be searched for as `a<TAB>b` and
+  # report entries=0 beside a non-zero total.
+  n=$(P="$name/" awk 'index($0, ENVIRON["P"]) == 1 {c++} END {print c + 0}' "$staged_list")
   printf 'seed: staged scope %-28s entries=%s\n' "$name" "$n"
-  [[ -L "${d%/}" ]] && excluded+=("$name (symlink — tar ships the link, not its contents)")
 done
 
 # 🔴 LOUD, NOT SILENT. A scope that ships nothing used to produce either a wrong
 # MISMATCH (dot-directory) or a false OK (symlink). Excluding it from the
 # verdict is correct; saying nothing about it would just move the lie.
+#
+# 🔴 BOTH ARMS USE THE SAME PREDICATE — "does it actually hold a `.md`" — and
+# that is a fix, not symmetry for its own sake. The symlink arm used to fire
+# unconditionally, so a symlinked scope holding NO markdown produced the header
+# "1 scope director(ies) hold .md files that will NOT be shipped" over a
+# directory that holds none. In a change whose whole subject is not claiming
+# what has not been established, that sentence was exactly the wrong one to
+# leave. `find "$d"` with the trailing slash follows the link deliberately here:
+# the question is what the operator would LOSE, which is the target's contents.
+_holds_md() { [[ -n "$(find "$1" -maxdepth 1 -name '*.md' -print -quit 2>/dev/null)" ]]; }
+
+# `shopt -p` captures the CALLER's settings and the eval restores exactly those
+# — `shopt -u` unconditionally would clear an option the caller had set.
+#
+# 🔴 `|| true` IS LOAD-BEARING, NOT DEFENSIVE. `shopt -p` EXITS 1 when any named
+# option is UNSET — which is the ordinary case here — so under `set -e` the bare
+# assignment aborted the script after the per-scope lines and before the stamp.
+# Measured: rc 1, and 20 of the file's seed tests went red at once. It still
+# PRINTS the correct restore commands on that non-zero exit, so the capture is
+# sound; only the status is misleading.
+_shopt_saved=$(shopt -p nullglob dotglob || true)
 shopt -s nullglob dotglob
 for d in "$STAGE"/*/; do
   name=$(basename "$d")
-  [[ "$name" == .* ]] || continue
-  [[ -n "$(find "$d" -maxdepth 1 -name '*.md' -print -quit)" ]] &&
-    excluded+=("$name (dot-directory — not in the tar member list)")
+  if [[ "$name" == .* ]]; then
+    _holds_md "$d" && excluded+=("$name (dot-directory — not in the tar member list)")
+  elif [[ -L "${d%/}" ]]; then
+    _holds_md "$d" && excluded+=("$name (symlink — tar ships the link, not its contents)")
+  fi
 done
-shopt -u nullglob dotglob
+eval "$_shopt_saved"
 if [[ ${#excluded[@]} -gt 0 ]]; then
   echo "seed: NOTE ${#excluded[@]} scope director(ies) hold .md files that will NOT be shipped, and are excluded from the count and the verdict:"
   printf 'seed:   %s\n' "${excluded[@]}"

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -154,12 +154,61 @@ tar -C "$STAGE" -cf - -- "${members[@]}" \
   | kubectl -n "$ns" exec -i "$pod" -- \
       tar -C "$DEST" --no-same-owner --no-same-permissions -xf -
 
-remote_entries=$(kubectl -n "$ns" exec "$pod" -- \
-  find "$DEST" -maxdepth 2 -name '*.md' -type f | wc -l)
-echo "seed: PUSHED pod=$pod dest=$DEST remote_entries=$remote_entries local_entries=$staged_entries"
+# 🔴 CONTAINMENT ON NAMES, NOT EQUALITY OF COUNTS. This guard used to read
+# `remote_entries != staged_entries -> exit 7`, which is only correct while
+# exactly ONE host ever seeds.
+#
+# The store is PER-HOST and unreplicated, and the extract adds and overwrites
+# but never deletes — so a second host's entries legitimately sit in $DEST that
+# this stage never held. Counting then failed a CORRECT push, and did it AFTER
+# the content had already landed: a failure verdict on a push that worked, which
+# invites a retry that changes nothing. That is the same shape the tar member
+# list above was fixed for. MEASURED 2026-08-28: this host staged 129 over a pod
+# holding 75 (a strict subset, so equality happened to hold); the other host's
+# ~26 would have staged against a remote of 129+ and exited 7 every time,
+# leaving criterion 8 unfinishable by the tool meant to finish it.
+#
+# Equality was also WEAKER than it looked in the single-host case it was written
+# for: 129 staged against 129 remote passes while one staged file is missing and
+# one foreign file makes up the number. The question a push actually has to
+# answer is "did everything I staged land?" — a SUBSET check on NAMES, which is
+# also the `comm -23` the re-seed card prescribes. So this is not a relaxation:
+# it fails strictly more broken pushes than the count did, and stops failing the
+# correct ones.
+#
+# Both sides use `-mindepth 2 -maxdepth 2` so they answer the SAME question —
+# `<scope>/<entry>.md` and nothing else. The old remote count used `-maxdepth 2`
+# alone, which would also have counted a stray top-level `*.md` the stage cannot
+# contain.
+_seed_tmp=$(mktemp -d)
+trap 'rm -rf "$_seed_tmp"' EXIT
+staged_list="$_seed_tmp/staged"; remote_list="$_seed_tmp/remote"
+missing_f="$_seed_tmp/missing";  foreign_f="$_seed_tmp/foreign"
 
-if [[ "$remote_entries" != "$staged_entries" ]]; then
-  echo "seed: MISMATCH — remote holds $remote_entries entry files, the stage held $staged_entries." >&2
+( cd "$STAGE" && find . -mindepth 2 -maxdepth 2 -name '*.md' -type f ) \
+  | sed 's|^\./||' | LC_ALL=C sort > "$staged_list"
+kubectl -n "$ns" exec "$pod" -- \
+  sh -c "cd '$DEST' && find . -mindepth 2 -maxdepth 2 -name '*.md' -type f" \
+  | sed 's|^\./||' | LC_ALL=C sort > "$remote_list"
+
+remote_entries=$(wc -l < "$remote_list" | tr -d ' ')
+comm -23 "$staged_list" "$remote_list" > "$missing_f"
+comm -13 "$staged_list" "$remote_list" > "$foreign_f"
+n_missing=$(wc -l < "$missing_f" | tr -d ' ')
+n_foreign=$(wc -l < "$foreign_f" | tr -d ' ')
+
+echo "seed: PUSHED pod=$pod dest=$DEST remote_entries=$remote_entries staged_entries=$staged_entries"
+
+# Printed BESIDE the verdict, never instead of it: a pod holding entries this
+# host does not have is the NORMAL multi-host state, and silence about it would
+# make the two numbers above look like a discrepancy nobody explained.
+if [[ "$n_foreign" -gt 0 ]]; then
+  echo "seed: NOTE $n_foreign entry file(s) on the pod were not staged by this host — expected when another host also seeds. They were left untouched, not deleted."
+fi
+
+if [[ "$n_missing" -gt 0 ]]; then
+  echo "seed: MISMATCH — $n_missing of $staged_entries staged entry file(s) did NOT land on the pod:" >&2
+  sed 's/^/  /' "$missing_f" >&2
   exit 7
 fi
-echo "seed: OK"
+echo "seed: OK all $staged_entries staged entries are present on the pod"

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -71,15 +71,68 @@ mkdir -p "$STAGE"
 # is not a flag about the source and cannot remove anything from it.
 rsync -a --delete "$STORE"/ "$STAGE"/
 
+_seed_tmp=$(mktemp -d)
+trap 'rm -rf "$_seed_tmp"' EXIT
+staged_list="$_seed_tmp/staged"
+
+# 🔴 ONE PREDICATE FOR THE COUNT AND FOR THE COMPARISON, because two walks with
+# different rules DID disagree and the script said OK anyway.
+#
+# `staged_entries` used to be `find "$d" -maxdepth 1` over `"$STAGE"/*/`. The
+# trailing slash makes a SYMLINKED scope resolve, so that walk counted through
+# it — while the comparison's `find .` does not descend a symlink and `tar`
+# archives the link rather than its target. Measured: a store with `normal/n.md`
+# and a symlinked `symscope/` printed
+#
+#     seed: PUSHED … remote_entries=1 staged_entries=2
+#     seed: OK all 2 staged entries are present on the pod        (rc 0)
+#
+# — the two numbers visibly disagreeing one line apart, one entry silently not
+# landed, and a completeness claim over it. 🔴 AND THE OLD COUNT-EQUALITY CHECK
+# WOULD HAVE CAUGHT THIS (1 != 2 -> exit 7), so the claim this block used to
+# make — that it "fails strictly more broken pushes than the count did" — was
+# FALSE. It is true only now that both sides come from `_shippable_entries`.
+#
+# The predicate is "what the tar will ACTUALLY land": depth-2 `*.md` regular
+# files, under a scope directory that is neither a dot-directory (the member
+# list is `"$STAGE"/*/` without `dotglob`) nor a symlink (`find` does not
+# descend one, and tar ships the link itself).
+_shippable_entries() {
+  ( cd "$1" && find . -mindepth 2 -maxdepth 2 ! -path './.*' -name '*.md' -type f ) \
+    | sed 's|^\./||' | LC_ALL=C sort
+}
+
+_shippable_entries "$STAGE" > "$staged_list"
+staged_entries=$(wc -l < "$staged_list" | tr -d ' ')
+
 staged_scopes=0
-staged_entries=0
+excluded=()
 for d in "$STAGE"/*/; do
   [[ -d "$d" ]] || continue
   staged_scopes=$((staged_scopes + 1))
-  n=$(find "$d" -maxdepth 1 -name '*.md' -type f | wc -l)
-  staged_entries=$((staged_entries + n))
-  printf 'seed: staged scope %-28s entries=%s\n' "$(basename "$d")" "$n"
+  name=$(basename "$d")
+  # `index(...)==1` is a LITERAL prefix test — a scope name is not a regex, and
+  # `grep -c "^$name/"` would mis-count one containing `.` or `[`.
+  n=$(awk -v p="$name/" 'index($0, p) == 1 {c++} END {print c + 0}' "$staged_list")
+  printf 'seed: staged scope %-28s entries=%s\n' "$name" "$n"
+  [[ -L "${d%/}" ]] && excluded+=("$name (symlink — tar ships the link, not its contents)")
 done
+
+# 🔴 LOUD, NOT SILENT. A scope that ships nothing used to produce either a wrong
+# MISMATCH (dot-directory) or a false OK (symlink). Excluding it from the
+# verdict is correct; saying nothing about it would just move the lie.
+shopt -s nullglob dotglob
+for d in "$STAGE"/*/; do
+  name=$(basename "$d")
+  [[ "$name" == .* ]] || continue
+  [[ -n "$(find "$d" -maxdepth 1 -name '*.md' -print -quit)" ]] &&
+    excluded+=("$name (dot-directory — not in the tar member list)")
+done
+shopt -u nullglob dotglob
+if [[ ${#excluded[@]} -gt 0 ]]; then
+  echo "seed: NOTE ${#excluded[@]} scope director(ies) hold .md files that will NOT be shipped, and are excluded from the count and the verdict:"
+  printf 'seed:   %s\n' "${excluded[@]}"
+fi
 
 # The count is printed BESIDE what produced it, never alone. A bare "0 entries"
 # from a run that walked nothing reads exactly like a genuinely empty store —
@@ -172,29 +225,35 @@ tar -C "$STAGE" -cf - -- "${members[@]}" \
 # for: 129 staged against 129 remote passes while one staged file is missing and
 # one foreign file makes up the number. The question a push actually has to
 # answer is "did everything I staged land?" — a SUBSET check on NAMES, which is
-# also the `comm -23` the re-seed card prescribes. So this is not a relaxation:
-# it fails strictly more broken pushes than the count did, and stops failing the
-# correct ones.
+# also the `comm -23` the re-seed card prescribes.
+#
+# ⚠ CORRECTION, measured: this comment used to end "it fails strictly more
+# broken pushes than the count did". That was FALSE as first written. A
+# SYMLINKED scope produced `remote_entries=1 staged_entries=2` and then
+# `seed: OK`, rc 0 — a push the old count-equality check WOULD have failed
+# (1 != 2). Containment only dominates the count once BOTH sides come from one
+# predicate, which is what `_shippable_entries` above now guarantees; before
+# that, the two walks disagreed and the comparison believed the wrong one.
 #
 # Both sides use `-mindepth 2 -maxdepth 2` so they answer the SAME question —
 # `<scope>/<entry>.md` and nothing else. The old remote count used `-maxdepth 2`
 # alone, which would also have counted a stray top-level `*.md` the stage cannot
 # contain.
-_seed_tmp=$(mktemp -d)
-trap 'rm -rf "$_seed_tmp"' EXIT
-staged_list="$_seed_tmp/staged"; remote_list="$_seed_tmp/remote"
+remote_list="$_seed_tmp/remote"
 missing_f="$_seed_tmp/missing";  foreign_f="$_seed_tmp/foreign"
 
-# 🔴 `! -path './.*'` — THE COMPARED POPULATION MUST BE THE PUSHED ONE. The tar
-# member list (above) and `staged_entries` (further up) are both built from
-# `"$STAGE"/*/`, and without `dotglob` that glob SKIPS dot-directories. A bare
-# `find` does not, so a `.hidden/` scope holding a `.md` would be listed as
-# staged, never archived, never land, and be reported missing — "1 of 1 staged
-# entry file(s) did NOT land" over an entry that was never shipped, which is
-# this script's own bug shape reintroduced one guard lower. Excluded on BOTH
-# sides so the two lists keep answering one question.
-( cd "$STAGE" && find . -mindepth 2 -maxdepth 2 ! -path './.*' -name '*.md' -type f ) \
-  | sed 's|^\./||' | LC_ALL=C sort > "$staged_list"
+# 🔴 `$staged_list` IS NOT RECOMPUTED HERE. It is the same file
+# `_shippable_entries` wrote before the push, which is what makes
+# `staged_entries` and the compared set one population rather than two walks
+# that agree by luck. See that function for the symlink case where they did not.
+#
+# The remote side runs the IDENTICAL expression, on purpose: same `-mindepth 2
+# -maxdepth 2` (a `<scope>/<entry>.md` and nothing above or below it), same
+# dot-directory exclusion (the tar cannot put one there), same `-type f` (a
+# DIRECTORY named `*.md` is not an entry — the server 503'd on exactly that).
+# Any clause dropped from one side and not the other silently changes what the
+# comparison means, so `test_the_two_find_expressions_are_IDENTICAL` pins them
+# against each other.
 kubectl -n "$ns" exec "$pod" -- \
   sh -c "cd '$DEST' && find . -mindepth 2 -maxdepth 2 ! -path './.*' -name '*.md' -type f" \
   | sed 's|^\./||' | LC_ALL=C sort > "$remote_list"

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -224,7 +224,12 @@ if [[ ${#excluded[@]} -gt 0 ]]; then
   # output says ("tar ships the link, not its contents"), so the block
   # contradicted itself two rows apart. What is true of every state that reaches
   # here is that the directory contributes nothing to the entry set.
-  echo "seed: NOTE ${#excluded[@]} scope director(ies) contribute NO entries, and are excluded from the count and the verdict:"
+  # ⚠ "the ENTRY count", not "the count". The second clause was left unexamined
+  # while the first was corrected twice, and it is loose: `staged_scopes` counts
+  # a SYMLINKED scope and not a dot one, so a store of 3 scope dirs can print
+  # "2 … excluded" beside `scopes=2` and the numbers do not reconcile. What is
+  # excluded on every arm is the ENTRY count and the verdict.
+  echo "seed: NOTE ${#excluded[@]} scope director(ies) contribute NO entries, and are excluded from the entry count and the verdict:"
   printf 'seed:   %s\n' "${excluded[@]}"
 fi
 

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -157,10 +157,22 @@ done
 # `-maxdepth 1` is deliberate: only depth-1 `*.md` inside the scope is shippable
 # at all, so widening it would announce a scope over files that no scope, dot or
 # otherwise, could ever ship.
+#
+# 🔴 EVIDENCE BEATS THE ERROR, and the order matters. `|| return 2` alone
+# discards `$out` unread, so a probe that BOTH matched a file AND exited
+# non-zero would report "could not check" over a match it actually had. Not
+# reachable at `-maxdepth 1` — the only rc≠0 sources there are the starting
+# point itself (measured across GNU find 4.11 and bfs 4.1: an unreadable
+# SUBdirectory, a broken symlink child and a child directory named `*.md` all
+# exit 0) — but it becomes reachable the moment someone widens the depth, and
+# nothing in the old comment said the discriminator depended on that. Checking
+# the match first makes the function correct at any depth.
 _md_state() {
-  local out
-  out=$(find "$1" -maxdepth 1 -name '*.md' -print -quit 2>/dev/null) || return 2
-  [[ -n "$out" ]]
+  local out rc
+  out=$(find "$1" -maxdepth 1 -name '*.md' -print -quit 2>/dev/null); rc=$?
+  [[ -n "$out" ]] && return 0
+  [[ $rc -ne 0 ]] && return 2
+  return 1
 }
 
 # 🔴 UNCONDITIONAL `-u`, AND A RESTORE-THE-CALLER'S-SETTINGS VERSION WAS TRIED
@@ -204,7 +216,15 @@ if [[ ${#excluded[@]} -gt 0 ]]; then
   # 🔴 THE HEADER ASSERTS NOTHING ABOUT CONTENTS. It used to say the listed
   # directories "hold .md files" — true for the two states that established it,
   # FALSE for the `could not check` one. Each entry states its own reason.
-  echo "seed: NOTE ${#excluded[@]} scope director(ies) will NOT ship, and are excluded from the count and the verdict:"
+  # 🔴 "CONTRIBUTE NO ENTRIES", NOT "WILL NOT SHIP" — the third wording of this
+  # line, and the second correction. "hold .md files" asserted contents the
+  # probe could not always read; "will NOT ship" then over-claimed on a
+  # different axis, because a symlinked scope DOES ship — as a symlink. Measured:
+  # the tar lands `symscope` on the pod as a link, which the very next line of
+  # output says ("tar ships the link, not its contents"), so the block
+  # contradicted itself two rows apart. What is true of every state that reaches
+  # here is that the directory contributes nothing to the entry set.
+  echo "seed: NOTE ${#excluded[@]} scope director(ies) contribute NO entries, and are excluded from the count and the verdict:"
   printf 'seed:   %s\n' "${excluded[@]}"
 fi
 

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -134,18 +134,39 @@ done
 # what has not been established, that sentence was exactly the wrong one to
 # leave. `find "$d"` with the trailing slash follows the link deliberately here:
 # the question is what the operator would LOSE, which is the target's contents.
-_holds_md() { [[ -n "$(find "$1" -maxdepth 1 -name '*.md' -print -quit 2>/dev/null)" ]]; }
-
-# `shopt -p` captures the CALLER's settings and the eval restores exactly those
-# — `shopt -u` unconditionally would clear an option the caller had set.
+# 🔴 AN ERROR IS NOT "NO", AND `2>/dev/null` MADE IT ONE. This probe briefly
+# carried `2>/dev/null`, which turned a symlinked scope whose target is
+# UNREADABLE from a loud over-report into total silence: no NOTE, rc 0, `seed:
+# OK`, and the operator loses the target's contents with no signal at all. In a
+# block headed "LOUD, NOT SILENT" that was the wrong direction to fail.
+# `_shippable_entries` does not descend the symlink either, so nothing else
+# would have surfaced it. A probe that cannot answer therefore announces.
 #
-# 🔴 `|| true` IS LOAD-BEARING, NOT DEFENSIVE. `shopt -p` EXITS 1 when any named
-# option is UNSET — which is the ordinary case here — so under `set -e` the bare
-# assignment aborted the script after the per-scope lines and before the stamp.
-# Measured: rc 1, and 20 of the file's seed tests went red at once. It still
-# PRINTS the correct restore commands on that non-zero exit, so the capture is
-# sound; only the status is misleading.
-_shopt_saved=$(shopt -p nullglob dotglob || true)
+# `-maxdepth 1` is deliberate: only depth-1 `*.md` inside the scope is shippable
+# at all, so widening it would announce a scope over files that no scope, dot or
+# otherwise, could ever ship.
+_holds_md() {
+  local out rc
+  out=$(find "$1" -maxdepth 1 -name '*.md' -print -quit 2>&1); rc=$?
+  [[ -n "$out" || $rc -ne 0 ]]
+}
+
+# 🔴 UNCONDITIONAL `-u`, AND A RESTORE-THE-CALLER'S-SETTINGS VERSION WAS TRIED
+# HERE AND REVERTED ON EVIDENCE. It looked tidier and was measurably worse:
+#
+#   * The tar member list below is `"$STAGE"/*/`, correct ONLY while `dotglob`
+#     is OFF. Restoring a caller who had it ON made a dot-scope SHIP — measured
+#     under `BASHOPTS=dotglob`, `.hidden/` landed on the pod while the remote
+#     listing's `! -path './.*'` still excluded it, so it was shipped, never
+#     verified, and the NOTE saying "not in the tar member list" became FALSE.
+#     The unconditional reset makes that independent of the ambient shell.
+#   * The property it claimed to protect is UNOBSERVABLE: this file is only ever
+#     run as `bash seed.sh` (checked every reference), and shell options do not
+#     propagate out of a script. The sole consumer of the restore was the member
+#     list twenty lines below it.
+#   * And it was already violated for the other half of the pair — line 62 does
+#     an unconditional `shopt -u nullglob` long before here, so a caller's
+#     `nullglob` is gone regardless.
 shopt -s nullglob dotglob
 for d in "$STAGE"/*/; do
   name=$(basename "$d")
@@ -155,7 +176,7 @@ for d in "$STAGE"/*/; do
     _holds_md "$d" && excluded+=("$name (symlink — tar ships the link, not its contents)")
   fi
 done
-eval "$_shopt_saved"
+shopt -u nullglob dotglob
 if [[ ${#excluded[@]} -gt 0 ]]; then
   echo "seed: NOTE ${#excluded[@]} scope director(ies) hold .md files that will NOT be shipped, and are excluded from the count and the verdict:"
   printf 'seed:   %s\n' "${excluded[@]}"

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -185,15 +185,45 @@ trap 'rm -rf "$_seed_tmp"' EXIT
 staged_list="$_seed_tmp/staged"; remote_list="$_seed_tmp/remote"
 missing_f="$_seed_tmp/missing";  foreign_f="$_seed_tmp/foreign"
 
-( cd "$STAGE" && find . -mindepth 2 -maxdepth 2 -name '*.md' -type f ) \
+# 🔴 `! -path './.*'` — THE COMPARED POPULATION MUST BE THE PUSHED ONE. The tar
+# member list (above) and `staged_entries` (further up) are both built from
+# `"$STAGE"/*/`, and without `dotglob` that glob SKIPS dot-directories. A bare
+# `find` does not, so a `.hidden/` scope holding a `.md` would be listed as
+# staged, never archived, never land, and be reported missing — "1 of 1 staged
+# entry file(s) did NOT land" over an entry that was never shipped, which is
+# this script's own bug shape reintroduced one guard lower. Excluded on BOTH
+# sides so the two lists keep answering one question.
+( cd "$STAGE" && find . -mindepth 2 -maxdepth 2 ! -path './.*' -name '*.md' -type f ) \
   | sed 's|^\./||' | LC_ALL=C sort > "$staged_list"
 kubectl -n "$ns" exec "$pod" -- \
-  sh -c "cd '$DEST' && find . -mindepth 2 -maxdepth 2 -name '*.md' -type f" \
+  sh -c "cd '$DEST' && find . -mindepth 2 -maxdepth 2 ! -path './.*' -name '*.md' -type f" \
   | sed 's|^\./||' | LC_ALL=C sort > "$remote_list"
 
 remote_entries=$(wc -l < "$remote_list" | tr -d ' ')
-comm -23 "$staged_list" "$remote_list" > "$missing_f"
-comm -13 "$staged_list" "$remote_list" > "$foreign_f"
+
+# 🔴 `LC_ALL=C` ON `comm` TOO, NOT ONLY ON THE SORTS. Both lists are sorted
+# `LC_ALL=C` above; GNU `comm` compares AND order-checks in the AMBIENT locale,
+# so C-sorted input is "not in sorted order" to a `comm` running under
+# en_US.UTF-8 — which is this host (`LANG=en_US.UTF-8`, `LC_COLLATE` unset).
+#
+# It fires only when the two conditions the multi-host case guarantees are BOTH
+# met: an UNPAIRABLE line (GNU comm arms the order check only after one) and an
+# adjacency where C and locale order disagree — e.g. `<scope>/README.md` beside
+# `<scope>/backblaze.md`, which the real store is full of. So the FIRST push
+# after another host seeds would abort at `set -e` on comm's rc=1, printing
+# three "not in sorted order" diagnostics and NO verdict at all: no PUSHED, no
+# NOTE, no OK, no MISMATCH — content landed, exit code unexplained. Exactly the
+# "failure verdict on a push that worked" this block was written to remove.
+#
+# The PR's own live run could not see it: it had staged == remote exactly, so
+# nothing was unpairable and the order check never armed.
+#
+# 🔴 `--nocheck-order` is NOT the fix — it silences the diagnostic while the SET
+# OPERATION still collates in the ambient locale and returns the WRONG CONTENT
+# (measured: staged `[a/README.md, a/b.md]` vs remote `[a/b.md]` reports BOTH as
+# missing). The collation has to be C on both sides of the comparison.
+LC_ALL=C comm -23 "$staged_list" "$remote_list" > "$missing_f"
+LC_ALL=C comm -13 "$staged_list" "$remote_list" > "$foreign_f"
 n_missing=$(wc -l < "$missing_f" | tr -d ' ')
 n_foreign=$(wc -l < "$foreign_f" | tr -d ' ')
 

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -134,21 +134,33 @@ done
 # what has not been established, that sentence was exactly the wrong one to
 # leave. `find "$d"` with the trailing slash follows the link deliberately here:
 # the question is what the operator would LOSE, which is the target's contents.
-# 🔴 AN ERROR IS NOT "NO", AND `2>/dev/null` MADE IT ONE. This probe briefly
-# carried `2>/dev/null`, which turned a symlinked scope whose target is
-# UNREADABLE from a loud over-report into total silence: no NOTE, rc 0, `seed:
-# OK`, and the operator loses the target's contents with no signal at all. In a
-# block headed "LOUD, NOT SILENT" that was the wrong direction to fail.
-# `_shippable_entries` does not descend the symlink either, so nothing else
-# would have surfaced it. A probe that cannot answer therefore announces.
+# 🔴 THREE STATES, NOT TWO — AND THE THIRD IS WHY. This probe has now been
+# wrong in both directions, one round apart:
+#
+#   * with `2>/dev/null` it was SILENT about a symlinked scope whose target is
+#     unreadable — no NOTE, rc 0, `seed: OK`, and the operator loses that
+#     scope's contents with nothing to say so. Wrong direction under a block
+#     headed "LOUD, NOT SILENT".
+#   * announcing on any error then fixed the silence but reused the "holds .md
+#     files" wording, so an unreadable target with NO markdown in it was
+#     announced as holding some — the exact unestablished claim this whole
+#     change exists to stop making, reintroduced by the fix for the previous
+#     defect.
+#
+# So the caller gets a state, not a boolean, and picks wording that matches what
+# was actually established: 0 = holds markdown · 1 = does not · 2 = COULD NOT
+# CHECK. `find`'s own exit status is the discriminator (measured: rc 1 on an
+# unreadable directory, rc 0 on a readable one), which is why stderr is
+# discarded rather than captured — the rc carries the whole signal, and
+# capturing the text only risked it reaching a message.
 #
 # `-maxdepth 1` is deliberate: only depth-1 `*.md` inside the scope is shippable
 # at all, so widening it would announce a scope over files that no scope, dot or
 # otherwise, could ever ship.
-_holds_md() {
-  local out rc
-  out=$(find "$1" -maxdepth 1 -name '*.md' -print -quit 2>&1); rc=$?
-  [[ -n "$out" || $rc -ne 0 ]]
+_md_state() {
+  local out
+  out=$(find "$1" -maxdepth 1 -name '*.md' -print -quit 2>/dev/null) || return 2
+  [[ -n "$out" ]]
 }
 
 # 🔴 UNCONDITIONAL `-u`, AND A RESTORE-THE-CALLER'S-SETTINGS VERSION WAS TRIED
@@ -170,15 +182,29 @@ _holds_md() {
 shopt -s nullglob dotglob
 for d in "$STAGE"/*/; do
   name=$(basename "$d")
+  # `|| st=$?` keeps a non-zero state out of errexit's way — a bare call would
+  # abort the script on the ordinary "does not hold markdown" answer.
+  st=0
   if [[ "$name" == .* ]]; then
-    _holds_md "$d" && excluded+=("$name (dot-directory — not in the tar member list)")
+    _md_state "$d" || st=$?
+    case $st in
+      0) excluded+=("$name (dot-directory — not in the tar member list)") ;;
+      2) excluded+=("$name (dot-directory — UNREADABLE, contents could not be checked)") ;;
+    esac
   elif [[ -L "${d%/}" ]]; then
-    _holds_md "$d" && excluded+=("$name (symlink — tar ships the link, not its contents)")
+    _md_state "$d" || st=$?
+    case $st in
+      0) excluded+=("$name (symlink — tar ships the link, not its contents)") ;;
+      2) excluded+=("$name (symlink — target UNREADABLE, contents could not be checked)") ;;
+    esac
   fi
 done
 shopt -u nullglob dotglob
 if [[ ${#excluded[@]} -gt 0 ]]; then
-  echo "seed: NOTE ${#excluded[@]} scope director(ies) hold .md files that will NOT be shipped, and are excluded from the count and the verdict:"
+  # 🔴 THE HEADER ASSERTS NOTHING ABOUT CONTENTS. It used to say the listed
+  # directories "hold .md files" — true for the two states that established it,
+  # FALSE for the `could not check` one. Each entry states its own reason.
+  echo "seed: NOTE ${#excluded[@]} scope director(ies) will NOT ship, and are excluded from the count and the verdict:"
   printf 'seed:   %s\n' "${excluded[@]}"
 fi
 

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -2316,9 +2316,18 @@ WRITE_ROUTES: dict[tuple[str, str], tuple[str, int, tuple[str, ...]]] = {
 }
 
 # How deep to walk when dating the served copy. Deliberately the SAME depth
-# `seed.sh` uses for its own `remote_entries` count (`find -maxdepth 2 -name
-# '*.md'`), so the two numbers are answers to the same question and a
-# disagreement between them means something real rather than a units mismatch.
+# `seed.sh` uses for its own entry listings, so the two numbers are answers to
+# the same question and a disagreement between them means something real rather
+# than a units mismatch.
+#
+# ⚠ The expression this comment used to quote — `find -maxdepth 2 -name '*.md'`
+# — is no longer what seed.sh runs. Its push verdict now lists BOTH sides with
+# `find . -mindepth 2 -maxdepth 2 ! -path './.*' -name '*.md' -type f`. The two
+# added clauses move it TOWARD this walk, not away: `_freshness_walk` below
+# already visits only non-dotted directories at depth 2, so it likewise excluded
+# top-level `*.md` and dot-scopes. Quoting the sibling's source verbatim is what
+# let this rot, so the invariant is stated instead: BOTH count `<scope>/*.md`,
+# excluding the store root and any dot-directory.
 _FRESHNESS_MAXDEPTH = 2
 
 

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2394,12 +2394,15 @@ def run_seed(*args: str, env: "dict[str, str] | None" = None) -> subprocess.Comp
 # the POSIX way to rebuild the argument list without an array, and it preserves
 # arguments containing spaces, which a string accumulator would not.
 FAKE_KUBECTL_BODY = r"""
-# 🔴 `set -u`: the bash original had `set -uo pipefail` and the POSIX rewrite
-# dropped it. Without it an unset $FAKE_DEST makes the sed below `s|/data||g`,
-# which silently rewrites every path to a RELATIVE one instead of erroring —
-# the stub would then "work" against the wrong directory. `pipefail` is not
-# POSIX and nothing here pipes, so only `-u` is restored.
-set -u
+# 🔴 AN EXPLICIT TOP-LEVEL `:?` GUARD, NOT `set -u`, AND THAT IS A MEASUREMENT.
+# The bash original had `set -uo pipefail`; the POSIX rewrite dropped it; round 2
+# restored `set -u`. Round 3's sweep showed that restoration SURVIVED its own
+# mutant — the only reference to $FAKE_DEST sits inside a `$( … )`, so an unbound
+# variable there kills the SUBSHELL while the stub carries on with an empty
+# substitution (`s|/data||g`, silently rewriting absolute paths to relative).
+# `:?` at top level exits the stub itself, which is what makes the failure
+# observable — and therefore testable — by a caller.
+: "${FAKE_DEST:?FAKE_DEST must be set - the stub would otherwise rewrite /data to the empty string}"
 # Stands in for kubectl in seed.sh's push half. $FAKE_DEST is the pretend /data;
 # $FAKE_DROP, if set, removes one member AFTER the extract, which is how "a
 # staged entry that did not land" is simulated without faking the guard itself.
@@ -2788,9 +2791,17 @@ class TestSeedPushVerdict:
 
         r = self._push(store, tmp_path, env)
 
+        # 🔴 ASSERT THE GUARD'S OWN MESSAGE, NOT MERELY A NON-ZERO RC. `rc != 0`
+        # alone does NOT isolate this: without the guard the stub still fails,
+        # later and for an unrelated reason (`tar -C ""`), so the mutant survived
+        # a green run. The specific string is what proves THIS guard fired.
         assert r.returncode != 0, (
-            "the stub ran with FAKE_DEST unset instead of erroring — `set -u` "
-            f"is missing from FAKE_KUBECTL_BODY. stdout={r.stdout}"
+            f"the stub ran with FAKE_DEST unset instead of erroring. stdout={r.stdout}"
+        )
+        assert "FAKE_DEST must be set" in r.stderr + r.stdout, (
+            "the stub failed, but not because of its own unset-variable guard — "
+            "so this test does not pin that guard. "
+            f"stderr={r.stderr!r} stdout={r.stdout!r}"
         )
 
     def test_an_EMPTY_dot_scope_is_not_announced_as_holding_md_files(
@@ -2865,6 +2876,15 @@ class TestSeedPushVerdict:
         # from a wrong MISMATCH to a silent omission.
         assert ".hidden (dot-directory" in r.stdout, (
             "the excluded scope must be NAMED, not silently dropped: " + r.stdout
+        )
+        # 🔴 AND IT MUST ACTUALLY NOT SHIP. The NOTE says "not in the tar member
+        # list"; that is only true while `dotglob` is off when the member list is
+        # built. Leaving it set SURVIVED the sweep — the entry then lands on the
+        # pod while the remote listing still excludes `./.*`, so it is shipped,
+        # never verified, and the NOTE's sentence becomes false.
+        assert not (dest / ".hidden").exists(), (
+            "the dot-scope was SHIPPED despite the NOTE saying it would not be — "
+            f"pod holds: {sorted(p.name for p in dest.iterdir())}"
         )
 
 

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -3043,6 +3043,20 @@ class TestSeedPushVerdict:
             "reached the dot arm but not its unreadable state — the wrong "
             f"reason would still read as covered: {note}"
         )
+        # 🔴 PIN THE WHOLE HEADER, NOT A KEYWORD. This one sentence has been
+        # FALSE twice in two rounds, each time on a different axis: "hold .md
+        # files" asserted contents an unreadable probe could not read, and
+        # "will NOT ship" was wrong because a symlinked scope DOES ship — as a
+        # symlink, which the very next line of output says. Both reverts passed
+        # a suite that only checked for absent keywords, because a keyword guard
+        # is satisfied by any rewording. When the artifact under test is prose,
+        # the normalised whole is the only machine-readable claim. A deliberate
+        # reword must fail here and be re-verified; that cost is the point.
+        header = next(l for l in r.stdout.splitlines() if l.startswith("seed: NOTE"))
+        assert header == (
+            "seed: NOTE 1 scope director(ies) contribute NO entries, and are "
+            "excluded from the count and the verdict:"
+        ), f"the NOTE header changed; re-verify it is true of EVERY state: {header!r}"
 
     def test_the_stub_REFUSES_to_run_with_FAKE_DEST_unset(
         self, store: Path, tmp_path: Path, fake_cluster

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -51,6 +51,7 @@ import http.client
 import importlib.util
 import json
 from testlib import hermetic_git  # noqa: E402
+from testlib import mockbin  # noqa: E402
 import io
 import os
 import re
@@ -2377,23 +2378,55 @@ def run_seed(*args: str, env: "dict[str, str] | None" = None) -> subprocess.Comp
 # against a filesystem the test controls rather than against a mock of itself.
 # `$FAKE_DROP` deletes one member AFTER the extract, which is how a staged entry
 # that does not land is simulated without pretending the guard ran.
-FAKE_KUBECTL = r"""#!/usr/bin/env bash
-set -uo pipefail
-[[ "${1:-}" == "-n" ]] && shift 2
-sub="${1:-}"; shift || true
+#
+# 🔴 POSIX sh, AND `mockbin.write_exec` OWNS THE SHEBANG. The first version of
+# this stub wrote `#!/usr/bin/env bash` itself. `/usr/bin/env` does not exist in
+# the nix sandbox that gates merges, and the two tiers reported that completely
+# differently: the dev host showed ONE tidy failure in `test_runtime_shebangs`,
+# while the gating tier showed `5 failed` — the guard PLUS all four tests here,
+# which never ran at all (`bad interpreter`, rc 126). The class had zero
+# coverage on the only tier that matters, and the dev-host run could not say so.
+#
+# Resolving the path with `shutil.which` is not enough either: that scanner
+# flags a test writing ANY shebang, and its allowlist is explicitly not the way
+# to green a new site. So the body is POSIX sh — no arrays, no `[[ ]]`, no
+# `${a//…}` — and `write_exec` supplies `#!<sh>`. The `set --` rotate below is
+# the POSIX way to rebuild the argument list without an array, and it preserves
+# arguments containing spaces, which a string accumulator would not.
+FAKE_KUBECTL_BODY = r"""
+# Stands in for kubectl in seed.sh's push half. $FAKE_DEST is the pretend /data;
+# $FAKE_DROP, if set, removes one member AFTER the extract, which is how "a
+# staged entry that did not land" is simulated without faking the guard itself.
+if [ "${1:-}" = "-n" ]; then shift 2; fi
+sub="${1:-}"
+if [ $# -gt 0 ]; then shift; fi
 case "$sub" in
-  get) echo "fake-pod-0" ;;
+  get)
+    echo "fake-pod-0"
+    ;;
   exec)
-    [[ "${1:-}" == "-i" ]] && shift
-    shift                                   # the pod name
-    [[ "${1:-}" == "--" ]] && shift
-    cmd=(); for a in "$@"; do cmd+=("${a///data/$FAKE_DEST}"); done
-    "${cmd[@]}"; rc=$?
-    if [[ -n "${FAKE_DROP:-}" && "${cmd[0]}" == "tar" ]]; then
+    if [ "${1:-}" = "-i" ]; then shift; fi
+    if [ $# -gt 0 ]; then shift; fi
+    if [ "${1:-}" = "--" ]; then shift; fi
+    n=$#
+    i=0
+    while [ "$i" -lt "$n" ]; do
+      a="$1"
+      shift
+      set -- "$@" "$(printf '%s' "$a" | sed "s|/data|$FAKE_DEST|g")"
+      i=$((i + 1))
+    done
+    "$@"
+    rc=$?
+    if [ -n "${FAKE_DROP:-}" ] && [ "${1:-}" = "tar" ]; then
       rm -f "$FAKE_DEST/$FAKE_DROP"
     fi
-    exit $rc ;;
-  *) echo "fake kubectl: unexpected subcommand: $sub" >&2; exit 64 ;;
+    exit "$rc"
+    ;;
+  *)
+    echo "fake kubectl: unexpected subcommand: $sub" >&2
+    exit 64
+    ;;
 esac
 """
 
@@ -2404,9 +2437,7 @@ def fake_cluster(tmp_path: Path):
     directory standing in for the pod's `/data`."""
     bindir = tmp_path / "fakebin"
     bindir.mkdir()
-    k = bindir / "kubectl"
-    k.write_text(FAKE_KUBECTL)
-    k.chmod(0o755)
+    mockbin.write_exec(bindir / "kubectl", FAKE_KUBECTL_BODY)
     dest = tmp_path / "pod-data"
     dest.mkdir()
     env = {
@@ -2422,14 +2453,24 @@ class TestSeedPushVerdict:
     SUBSET check on names — and NOT "does the remote hold exactly as many files
     as the stage", which is only true while one host ever seeds."""
 
-    def _push(self, store: Path, tmp_path: Path, env, **kw):
+    def _push(self, store: Path, tmp_path: Path, env):
         return run_seed(
             "--store", str(store),
             "--stage", str(tmp_path / "stage"),
             "--push", "ns/app",
             env=env,
-            **kw,
         )
+
+    @staticmethod
+    def _foreign(dest: Path, name: str = "from-the-other-host.md") -> Path:
+        """An entry the OTHER host seeded. Its presence is what arms GNU comm's
+        order check — without an unpairable line the check never runs, which is
+        why an exactly-matching push cannot see a collation bug."""
+        d = dest / "a-scope-only-the-laptop-has"
+        d.mkdir(exist_ok=True)
+        p = d / name
+        p.write_text("---\nservice: x\n---\n")
+        return p
 
     def test_POSITIVE_CONTROL_the_fake_cluster_really_receives_the_push(
         self, store: Path, tmp_path: Path, fake_cluster
@@ -2514,6 +2555,88 @@ class TestSeedPushVerdict:
             "counts matched, so the old guard would have passed this broken push"
         )
         assert f"{SCOPE}/thing-alpha.md" in r.stderr
+
+    # --- the three dimensions the first fixture was structurally blind to -----
+    #
+    # 🔴 THE ORIGINAL FIXTURE COULD NOT SEE ANY OF THESE. It was all-lowercase,
+    # all hyphen-slug, no top-level `.md`, no dot-directory — so it pinned none
+    # of the ways the REAL store differs, and a mutation sweep over it left five
+    # survivors. An audit found two live defects in that blind spot. Each test
+    # below is named for the dimension, not the symptom.
+
+    def test_a_README_beside_a_lowercase_sibling_survives_a_UTF8_LOCALE(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 REGRESSION. Both lists are sorted `LC_ALL=C`, but GNU `comm`
+        compares AND order-checks in the AMBIENT locale — so under en_US.UTF-8 a
+        C-sorted list is "not in sorted order", `comm` exits 1, and `set -e`
+        kills the script with NO verdict printed at all.
+
+        Needs BOTH: an unpairable line (comm arms the order check only after
+        one) and an adjacency where C and en_US disagree. `README.md` beside
+        `backblaze.md`/`thing-alpha.md` is that adjacency, and the real store is
+        full of it — so the FIRST push after another host seeds would abort."""
+        enc = "en_US.UTF-8"
+        have = subprocess.run(
+            ["locale", "-a"], capture_output=True, text=True
+        ).stdout.lower()
+        if "en_us.utf8" not in have and "en_us.utf-8" not in have:
+            pytest.skip(f"{enc} not generated here; the collation cannot be forced")
+
+        env, dest = fake_cluster
+        # C sorts `README.md` BEFORE `thing-alpha.md`; en_US sorts it AFTER.
+        (store / SCOPE / "README.md").write_text(_entry("README", SCOPE))
+        self._foreign(dest)
+        env = {**env, "LC_ALL": enc, "LANG": enc}
+
+        r = self._push(store, tmp_path, env)
+
+        assert "not in sorted order" not in r.stderr, (
+            "comm order-checked in the ambient locale over C-sorted input: "
+            f"stderr={r.stderr}"
+        )
+        assert r.returncode == 0, f"rc={r.returncode} stdout={r.stdout} stderr={r.stderr}"
+        assert "seed: OK" in r.stdout
+        assert "NOTE 1 entry file(s)" in r.stdout
+
+    def test_a_TOP_LEVEL_md_in_the_store_is_not_reported_missing(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """The store root really does hold a `README.md`. It is not an entry,
+        the tar member list never ships it, and `-mindepth 2` is what keeps it
+        out of the comparison — a dimension no earlier fixture had, so dropping
+        that flag survived the sweep while breaking every real push."""
+        env, dest = fake_cluster
+        (store / "README.md").write_text("# the store's own readme\n")
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 0, f"stdout={r.stdout} stderr={r.stderr}"
+        assert "README.md" not in r.stderr
+        assert "seed: OK" in r.stdout
+
+    def test_a_DOT_DIRECTORY_scope_is_not_reported_missing(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """`staged_entries` and the tar member list are both built from
+        `"$STAGE"/*/`, which without `dotglob` skips dot-directories — so a
+        `.hidden/` scope is never archived. A bare `find` would list it as
+        staged and then report it missing: "1 of 1 staged entry file(s) did NOT
+        land" over something that was never shipped. The compared population has
+        to be the PUSHED one."""
+        env, dest = fake_cluster
+        hidden = store / ".hidden"
+        hidden.mkdir()
+        (hidden / "b.md").write_text(_entry("b", ".hidden"))
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 0, (
+            f"a dot-scope is not pushed, so it must not be reported missing. "
+            f"stdout={r.stdout} stderr={r.stderr}"
+        )
+        assert ".hidden" not in r.stderr
+        assert "seed: OK" in r.stdout
 
 
 class TestSeedIsNonDestructive:

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2600,21 +2600,39 @@ class TestSeedPushVerdict:
         # `gateTools`, `LOCALE_ARCHIVE` in the devShell AND in checks.pytests)
         # and its absence is a HARD FAILURE naming the cause. A degradation that
         # silently weakens a test is worse than a red one that says why.
-        enc = "en_US.UTF-8"
-        locale_bin = shutil.which("locale")
-        have = ""
-        if locale_bin:
-            have = subprocess.run(
-                [locale_bin, "-a"], capture_output=True, text=True
-            ).stdout.lower()
-        assert "en_us.utf8" in have or "en_us.utf-8" in have, (
-            f"{enc} is unavailable (locale binary: {locale_bin}), so this test "
-            "cannot make the ambient collation differ from C and would pass "
-            "vacuously. This is a GATE ENVIRONMENT regression, not a defect in "
-            "seed.sh: flake.nix must keep `pkgs.glibc.bin` in gateTools and "
-            "export LOCALE_ARCHIVE in BOTH the devShell and checks.pytests."
+        # 🔴 AVAILABILITY IS DETECTED BY EXERCISING THE CAPABILITY, NOT BY
+        # PROBING FOR A BINARY. An earlier version ran `locale -a` and asserted
+        # `en_US.utf8` appeared. That was the wrong question twice over: it
+        # needed `pkgs.glibc.bin` on the shared devShell PATH (21 store binaries
+        # shadowing the system `getconf`/`ldd`/`iconv` for every human in
+        # `nix develop`) to answer it, and MEASURED — with `LOCALE_ARCHIVE` set
+        # and NO `locale` binary at all, `LC_ALL=en_US.UTF-8 sort` collates
+        # correctly. The binary was never load-bearing; `LOCALE_ARCHIVE` is.
+        #
+        # So the check IS the control: sort one inverting pair under C and under
+        # en_US and require the orders to DIFFER. That single assertion answers
+        # "is a non-C collation available" and "does this fixture still invert"
+        # at once — and it cannot pass while the collation is unavailable, which
+        # is exactly the vacuity this test kept falling into.
+        forced = "en_US.UTF-8"
+        pair = f"{SCOPE}/README.md\n{SCOPE}/backblaze.md\n"
+
+        def _sorted_under(lc: str) -> str:
+            return subprocess.run(
+                ["sort"], input=pair, capture_output=True, text=True,
+                env={**os.environ, "LC_ALL": lc},
+            ).stdout
+
+        c_order, loc_order = _sorted_under("C"), _sorted_under(forced)
+        assert c_order != loc_order, (
+            f"`sort` orders {SCOPE}/README.md and {SCOPE}/backblaze.md the same "
+            f"under C and under {forced}, so comm's order check cannot arm and "
+            "this test would pass whether or not the collation is pinned.\n"
+            "Either the fixture stopped inverting, or — far more likely — this "
+            "is a GATE ENVIRONMENT regression rather than a defect in seed.sh: "
+            "flake.nix must export LOCALE_ARCHIVE in BOTH the devShell and "
+            "checks.pytests, or the tier has only the C locale."
         )
-        forced = enc
 
         env, dest = fake_cluster
         # 🔴 THE PAIR MUST ACTUALLY INVERT, AND THE FIRST VERSION OF THIS TEST
@@ -2627,25 +2645,7 @@ class TestSeedPushVerdict:
         (store / SCOPE / "README.md").write_text(_entry("README", SCOPE))
         (store / SCOPE / "backblaze.md").write_text(_entry("backblaze", SCOPE))
         self._foreign(dest)
-        env = {**env, "LC_ALL": enc, "LANG": enc}
-
-        # The control, so this test cannot quietly stop pinning its dimension:
-        # if the two collations ever agree on this pair, comm's order check
-        # cannot arm and a green here would mean nothing.
-        pair = f"{SCOPE}/README.md\n{SCOPE}/backblaze.md\n"
-        c_order = subprocess.run(
-            ["sort"], input=pair, capture_output=True, text=True,
-            env={**os.environ, "LC_ALL": "C"},
-        ).stdout
-        loc_order = subprocess.run(
-            ["sort"], input=pair, capture_output=True, text=True,
-            env={**os.environ, "LC_ALL": forced},
-        ).stdout
-        assert c_order != loc_order, (
-            f"fixture no longer inverts between C and {forced} — comm's order "
-            "check cannot arm, so this test would pass whether or not the "
-            "collation is pinned"
-        )
+        env = {**env, "LC_ALL": forced, "LANG": forced}
 
         r = self._push(store, tmp_path, env)
 
@@ -2683,17 +2683,42 @@ class TestSeedPushVerdict:
         on the REMOTE side all SURVIVED. Comparing the two expressions to each
         other catches an asymmetry in either direction, which per-side
         assertions did not."""
-        src = SEED_PATH.read_text()
-        exprs = re.findall(r"find \. (-mindepth[^\n\"]*?-type f)", src)
-        assert len(exprs) == 2, (
-            f"expected exactly 2 entry-listing find expressions in seed.sh, "
-            f"found {len(exprs)}: {exprs}"
+        # 🔴 CAPTURE TO THE END OF THE EXPRESSION, NOT TO `-type f`. The first
+        # version stopped at the first `-type f` (non-greedy), so everything
+        # AFTER it was invisible: appending `-o -type d` to the remote find
+        # SURVIVED a fully green 34-test run, which would have put depth-2
+        # DIRECTORIES into `remote_list` and reported them as foreign entries on
+        # every push. A guard whose stated purpose is "an asymmetry changes what
+        # the comparison MEANS" must see the whole expression.
+        #
+        # The `cd` target is captured too: `( cd "$1/sub" && find . … )` leaves
+        # both expressions textually identical while the sides walk different
+        # trees.
+        pat = re.compile(
+            r"""cd\s+['"]?(?P<root>[^'"\s&]+)['"]?\s*&&\s*find\s+\.\s+"""
+            r"""(?P<expr>.+?)\s*(?:\)|")"""
         )
-        staged, remote = (" ".join(e.split()) for e in exprs)
+        found = []
+        for line in SEED_PATH.read_text().splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue  # comments quote these expressions when explaining them
+            m = pat.search(stripped)
+            if m:
+                found.append((m.group("root"), " ".join(m.group("expr").split())))
+        assert len(found) == 2, (
+            f"expected exactly 2 `cd … && find .` entry listings in seed.sh, "
+            f"found {len(found)}: {found}"
+        )
+        (staged_root, staged), (remote_root, remote) = found
         assert staged == remote, (
             "the staged and remote listings no longer ask the same question — "
             "an asymmetry silently changes what the comparison MEANS:\n"
             f"  staged: {staged}\n  remote: {remote}"
+        )
+        assert staged_root != remote_root, (
+            "both listings walk the same root, so one of them is not reading "
+            f"what it is supposed to: {staged_root!r} / {remote_root!r}"
         )
         for clause in ("-mindepth 2", "-maxdepth 2", "! -path './.*'", "-type f"):
             assert clause in staged, f"{clause!r} is no longer pinned: {staged}"
@@ -2725,6 +2750,78 @@ class TestSeedPushVerdict:
             "a scope that ships NOTHING must be named, not silently dropped: "
             + r.stdout
         )
+
+    def test_the_per_scope_count_is_a_PREFIX_match_not_a_substring(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """`entries=N` beside each scope had no coverage in either direction —
+        a mutation sweep survived both `index($0,p) > 0` (substring) and the
+        whole count hardcoded. With scopes `foo` and `xfoo`, a substring test
+        counts `xfoo/n.md` against `foo`, so `foo` reports 2 while holding 1."""
+        env, dest = fake_cluster
+        for name in ("foo", "xfoo"):
+            (store / name).mkdir()
+            (store / name / "n.md").write_text(_entry("n", name))
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 0, f"stdout={r.stdout} stderr={r.stderr}"
+        counts = dict(re.findall(r"staged scope (\S+)\s+entries=(\d+)", r.stdout))
+        assert counts.get("foo") == "1", (
+            f"`foo` must count only its own entry, got {counts.get('foo')!r} "
+            f"— a substring match would say 2. {r.stdout}"
+        )
+        assert counts.get("xfoo") == "1", counts
+
+    def test_the_stub_REFUSES_to_run_with_FAKE_DEST_unset(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """Pins the `set -u` the bash→POSIX rewrite dropped and round 2 restored.
+
+        Without it an unset `$FAKE_DEST` makes the stub's `sed` become
+        `s|/data||g`, silently rewriting every absolute path to a relative one —
+        the stub then 'works' against the wrong directory and every assertion
+        built on it is meaningless. That regression was re-introducible with a
+        fully green suite until this test existed."""
+        env, _ = fake_cluster
+        env = {k: v for k, v in env.items() if k != "FAKE_DEST"}
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode != 0, (
+            "the stub ran with FAKE_DEST unset instead of erroring — `set -u` "
+            f"is missing from FAKE_KUBECTL_BODY. stdout={r.stdout}"
+        )
+
+    def test_an_EMPTY_dot_scope_is_not_announced_as_holding_md_files(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """The NOTE header says the listed directories "hold .md files". Both
+        arms must therefore PROBE for one — the symlink arm used to fire
+        unconditionally, announcing a symlinked scope that held no markdown at
+        all. A change about not claiming the unestablished must not ship that
+        sentence."""
+        env, dest = fake_cluster
+        empty_real = tmp_path / "empty-target"
+        empty_real.mkdir()
+        (store / "emptysym").symlink_to(empty_real)
+        (store / ".emptydot").mkdir()
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 0, f"stdout={r.stdout} stderr={r.stderr}"
+        # Scoped to the NOTE block: both scopes legitimately appear in the
+        # per-scope `entries=0` lines, and asserting over the whole of stdout
+        # would fail on that correct output.
+        note = "\n".join(
+            l for l in r.stdout.splitlines()
+            if l.startswith("seed: NOTE") or l.startswith("seed:   ")
+        )
+        assert "emptysym" not in note, (
+            "a symlinked scope holding NO .md was announced as holding some:\n"
+            + note
+        )
+        assert ".emptydot" not in note, note
 
     def test_a_TOP_LEVEL_md_in_the_store_is_not_reported_missing(
         self, store: Path, tmp_path: Path, fake_cluster

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2584,10 +2584,35 @@ class TestSeedPushVerdict:
             pytest.skip(f"{enc} not generated here; the collation cannot be forced")
 
         env, dest = fake_cluster
-        # C sorts `README.md` BEFORE `thing-alpha.md`; en_US sorts it AFTER.
+        # 🔴 THE PAIR MUST ACTUALLY INVERT, AND THE FIRST VERSION OF THIS TEST
+        # DID NOT. `README.md` beside `thing-alpha.md` orders the SAME under
+        # both collations (C: 'R'<'t'; en_US: 'r'<'t'), so nothing was out of
+        # order, `comm` never complained, and the mutant that strips `LC_ALL=C`
+        # from the comm calls SURVIVED a fully green run. The inversion needs a
+        # lowercase sibling sorting BEFORE `README` in en_US and AFTER it in C —
+        # 'b' is 0x62, above 'R' at 0x52, but below 'r' when case is folded.
         (store / SCOPE / "README.md").write_text(_entry("README", SCOPE))
+        (store / SCOPE / "backblaze.md").write_text(_entry("backblaze", SCOPE))
         self._foreign(dest)
         env = {**env, "LC_ALL": enc, "LANG": enc}
+
+        # The control, so this test cannot quietly stop pinning its dimension:
+        # if the two collations ever agree on this pair, the mutant is invisible
+        # and a green here would mean nothing.
+        pair = f"{SCOPE}/README.md\n{SCOPE}/backblaze.md\n"
+        c_order = subprocess.run(
+            ["sort"], input=pair, capture_output=True, text=True,
+            env={**os.environ, "LC_ALL": "C"},
+        ).stdout
+        loc_order = subprocess.run(
+            ["sort"], input=pair, capture_output=True, text=True,
+            env={**os.environ, "LC_ALL": enc},
+        ).stdout
+        assert c_order != loc_order, (
+            "fixture no longer inverts between C and "
+            f"{enc} — comm's order check cannot arm, so this test would pass "
+            "whether or not the collation is pinned"
+        )
 
         r = self._push(store, tmp_path, env)
 

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2470,6 +2470,30 @@ class TestSeedPushVerdict:
             env=env,
         )
 
+    # 🔴 ONE PIN, ONE PLACE, PARAMETERISED BY COUNT. This sentence has been
+    # FALSE three times — "hold .md files" asserted contents an unreadable probe
+    # could not read; "will NOT ship" was wrong because a symlinked scope DOES
+    # ship, as a symlink; and "excluded from the count" is loose because
+    # `staged_scopes` counts a symlinked scope and not a dot one. Keyword guards
+    # caught none of them: any rewording satisfies `"X" not in stdout`, and two
+    # such guards had become unfalsifiable — no code path could emit the string
+    # they forbade. When the artifact under test is prose, the normalised WHOLE
+    # is the only machine-readable claim, and a deliberate reword must fail here
+    # and be re-verified. The count is a parameter so a fixture that gains an
+    # excluded scope reports THAT, instead of misdirecting at the wording.
+    @staticmethod
+    def _assert_note_header(stdout: str, n: int) -> None:
+        headers = [l for l in stdout.splitlines() if l.startswith("seed: NOTE")]
+        assert len(headers) == 1, f"expected exactly one NOTE header: {headers}"
+        assert headers[0] == (
+            f"seed: NOTE {n} scope director(ies) contribute NO entries, and are "
+            "excluded from the entry count and the verdict:"
+        ), (
+            "the NOTE header changed. If the COUNT moved, fix the caller; if the "
+            "WORDING moved, re-verify it is true of EVERY state that reaches it "
+            f"— three earlier wordings were not. Got: {headers[0]!r}"
+        )
+
     @staticmethod
     def _foreign(dest: Path, name: str = "from-the-other-host.md") -> Path:
         """An entry the OTHER host seeded. Its presence is what arms GNU comm's
@@ -2927,12 +2951,16 @@ class TestSeedPushVerdict:
     ):
         """🔴 AN ERROR IS NOT "NO".
 
-        ⚠ Read this with `_md_state` open: it deliberately carries
-        `2>/dev/null` TODAY and depends on it. The defect below was never the
-        redirect — it was discarding `find`'s EXIT STATUS, which is the whole
-        discriminator. An earlier version of this docstring blamed the three
-        characters, and deleting them (which no test catches) is exactly what a
-        maintainer would have done next.
+        ⚠ Read this with `_md_state` open. The defect below was never the
+        `2>/dev/null` — it was discarding `find`'s EXIT STATUS, which is the
+        whole discriminator. An earlier version of this docstring blamed the
+        three characters; a later one over-corrected and called them
+        load-bearing. MEASURED, both false: with the redirect removed, stdout is
+        byte-identical and rc is identical over a store with an unreadable
+        dot-symlink — the only difference is one extra `Permission denied` line
+        on stderr, which nothing consumes. The redirect suppresses an
+        EXPECTED-condition diagnostic and nothing more, which is why no test
+        catches its removal and why none should.
 
         The probe briefly treated a failed `find` as "no markdown here",
         which turned an unreadable symlink target from a loud over-report into
@@ -2968,9 +2996,7 @@ class TestSeedPushVerdict:
             "the unreadable case must say so, not borrow the holds-markdown "
             f"wording: {r.stdout}"
         )
-        assert "hold .md files" not in r.stdout, (
-            "the NOTE header asserts contents it could not check: " + r.stdout
-        )
+        self._assert_note_header(r.stdout, 1)
 
     def test_an_UNREADABLE_target_with_NO_markdown_is_not_called_a_holder(
         self, store: Path, tmp_path: Path, fake_cluster
@@ -3010,9 +3036,7 @@ class TestSeedPushVerdict:
             "announced, but not as the state that was actually established: "
             + r.stdout
         )
-        assert "hold .md files" not in r.stdout, (
-            "announced as holding markdown that nobody could read: " + r.stdout
-        )
+        self._assert_note_header(r.stdout, 1)
 
     def test_the_DOT_arm_of_the_unreadable_state_is_reachable_and_covered(
         self, store: Path, tmp_path: Path, fake_cluster
@@ -3052,11 +3076,7 @@ class TestSeedPushVerdict:
         # is satisfied by any rewording. When the artifact under test is prose,
         # the normalised whole is the only machine-readable claim. A deliberate
         # reword must fail here and be re-verified; that cost is the point.
-        header = next(l for l in r.stdout.splitlines() if l.startswith("seed: NOTE"))
-        assert header == (
-            "seed: NOTE 1 scope director(ies) contribute NO entries, and are "
-            "excluded from the count and the verdict:"
-        ), f"the NOTE header changed; re-verify it is true of EVERY state: {header!r}"
+        self._assert_note_header(r.stdout, 1)
 
     def test_the_stub_REFUSES_to_run_with_FAKE_DEST_unset(
         self, store: Path, tmp_path: Path, fake_cluster
@@ -3089,11 +3109,16 @@ class TestSeedPushVerdict:
     def test_an_EMPTY_dot_scope_is_not_announced_as_holding_md_files(
         self, store: Path, tmp_path: Path, fake_cluster
     ):
-        """The NOTE header says the listed directories "hold .md files". Both
-        arms must therefore PROBE for one — the symlink arm used to fire
-        unconditionally, announcing a symlinked scope that held no markdown at
-        all. A change about not claiming the unestablished must not ship that
-        sentence."""
+        """Both arms must PROBE before naming a directory — the symlink arm
+        used to fire unconditionally, announcing a scope that held no markdown
+        at all.
+
+        ⚠ The header no longer says "hold .md files" (it says "contribute NO
+        entries"), so announcing an empty excluded scope would no longer be a
+        FALSE claim — but it is still noise about a directory the operator
+        cannot act on, and the probe is what keeps the list meaningful. Do not
+        "restore" the old wording on the strength of this test's name: it was
+        removed because it asserted contents an unreadable probe cannot read."""
         env, dest = fake_cluster
         empty_real = tmp_path / "empty-target"
         empty_real.mkdir()

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2751,6 +2751,17 @@ class TestSeedPushVerdict:
         r = self._push(store, tmp_path, env)
 
         assert r.returncode == 0, f"stdout={r.stdout} stderr={r.stderr}"
+        # 🔴 POSITIVE CONTROL, AND IT IS FREE. Everything below holds just as
+        # well if BASHOPTS were ignored entirely — by a future bash, by
+        # `set -o posix`, by a typo in the option name — and this test is the
+        # SOLE killer of the caller-restoring shopt regression, so a silent
+        # vacuity here re-opens that class with a green suite. The per-scope
+        # loop DOES honour the ambient option, so a `.hidden` line appears only
+        # when dotglob really armed.
+        assert "staged scope .hidden" in r.stdout, (
+            "BASHOPTS=dotglob did not arm — this test is not exercising the "
+            f"dimension it names, so its pass means nothing. {r.stdout}"
+        )
         assert not (dest / ".hidden").exists(), (
             "with dotglob set in the environment the dot-scope SHIPPED — the "
             "member list must not depend on the ambient shell. pod holds: "
@@ -2771,8 +2782,14 @@ class TestSeedPushVerdict:
         (an `-o -type d` on the remote side, a widened `-maxdepth`), it is
         reported as another host's entry on every single push."""
         env, dest = fake_cluster
+        # 🔴 THE NAME MATTERS. A directory called `a-subdirectory` is excluded
+        # by `-name '*.md'`, NOT by `-type f` — so the plainest mutant (dropping
+        # `-type f` from the remote find) stayed invisible, caught only by the
+        # textual guard this test was written to replace. Named `*.md`, the only
+        # clause that can exclude it is `-type f`. It is also the exact shape the
+        # server 503'd on: a DIRECTORY named `*.md`.
         (dest / SCOPE).mkdir(parents=True, exist_ok=True)
-        (dest / SCOPE / "a-subdirectory").mkdir()
+        (dest / SCOPE / "a-subdirectory.md").mkdir()
 
         r = self._push(store, tmp_path, env)
 
@@ -2924,11 +2941,56 @@ class TestSeedPushVerdict:
         finally:
             locked.chmod(0o755)  # so tmp_path cleanup can proceed
 
+        assert r.returncode == 0, (
+            f"rc={r.returncode} — measured 0 today; a future change that "
+            f"aborted after the NOTE would otherwise stay green. {r.stderr}"
+        )
         assert "lockedsym" in "".join(
             l for l in r.stdout.splitlines() if l.startswith("seed:   ")
         ), (
             "an unreadable symlinked scope was silently dropped instead of "
             f"announced: {r.stdout}"
+        )
+        # 🔴 AND THE WORDING MUST NOT ASSERT WHAT THE PROBE COULD NOT ESTABLISH.
+        # Announcing on error fixed the silence; reusing the "holds .md files"
+        # wording then claimed markdown in a directory nobody could read — the
+        # same unestablished-claim defect, one round later.
+        assert "UNREADABLE" in r.stdout, (
+            "the unreadable case must say so, not borrow the holds-markdown "
+            f"wording: {r.stdout}"
+        )
+        assert "hold .md files" not in r.stdout, (
+            "the NOTE header asserts contents it could not check: " + r.stdout
+        )
+
+    def test_an_UNREADABLE_target_with_NO_markdown_is_not_called_a_holder(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 The case the sibling above CANNOT reach, because its target really
+        does hold `l.md` — so it would pass even while the wording lied.
+
+        Here the target holds no markdown at all and is unreadable. Announcing
+        it is right; announcing it as a directory that "holds .md files" is a
+        claim about bytes nobody could see, and is exactly the defect that the
+        fix for the previous round's silence reintroduced."""
+        env, dest = fake_cluster
+        locked = tmp_path / "empty-locked"
+        locked.mkdir()
+        (locked / "notes.txt").write_text("no markdown here\n")
+        (store / "emptylocked").symlink_to(locked)
+        locked.chmod(0o000)
+        try:
+            r = self._push(store, tmp_path, env)
+        finally:
+            locked.chmod(0o755)  # so tmp_path cleanup can proceed
+
+        assert r.returncode == 0, f"stdout={r.stdout} stderr={r.stderr}"
+        assert "emptylocked" in r.stdout, (
+            "a scope whose contents could not be read must still be announced: "
+            + r.stdout
+        )
+        assert "hold .md files" not in r.stdout, (
+            "announced as holding markdown that nobody could read: " + r.stdout
         )
 
     def test_the_stub_REFUSES_to_run_with_FAKE_DEST_unset(

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2847,7 +2847,7 @@ class TestSeedPushVerdict:
     def test_a_scope_whose_md_is_TOO_DEEP_is_not_announced(
         self, store: Path, tmp_path: Path, fake_cluster
     ):
-        """`_holds_md` uses `-maxdepth 1` because only depth-1 `*.md` inside a
+        """`_md_state` uses `-maxdepth 1` because only depth-1 `*.md` inside a
         scope is shippable at all. Widening it survived the class and would
         announce a scope over files no scope could ever ship."""
         env, dest = fake_cluster
@@ -2925,7 +2925,16 @@ class TestSeedPushVerdict:
     def test_a_symlinked_scope_whose_target_is_UNREADABLE_is_still_announced(
         self, store: Path, tmp_path: Path, fake_cluster
     ):
-        """🔴 AN ERROR IS NOT "NO". `_holds_md` briefly carried `2>/dev/null`,
+        """🔴 AN ERROR IS NOT "NO".
+
+        ⚠ Read this with `_md_state` open: it deliberately carries
+        `2>/dev/null` TODAY and depends on it. The defect below was never the
+        redirect — it was discarding `find`'s EXIT STATUS, which is the whole
+        discriminator. An earlier version of this docstring blamed the three
+        characters, and deleting them (which no test catches) is exactly what a
+        maintainer would have done next.
+
+        The probe briefly treated a failed `find` as "no markdown here",
         which turned an unreadable symlink target from a loud over-report into
         complete silence — no NOTE, rc 0, `seed: OK`, and the operator loses
         that scope's contents with nothing to say so. `_shippable_entries` does
@@ -2985,12 +2994,54 @@ class TestSeedPushVerdict:
             locked.chmod(0o755)  # so tmp_path cleanup can proceed
 
         assert r.returncode == 0, f"stdout={r.stdout} stderr={r.stderr}"
-        assert "emptylocked" in r.stdout, (
-            "a scope whose contents could not be read must still be announced: "
+        # 🔴 SCOPED TO THE NOTE LINES. `"emptylocked" in r.stdout` was satisfied
+        # by the unrelated per-scope line `staged scope emptylocked entries=0`,
+        # so the half this test exists for — that it is ANNOUNCED — guarded
+        # nothing: reverting `_md_state`'s error state to a plain "no" removed
+        # the NOTE entirely and this assertion stayed green.
+        note = "\n".join(
+            l for l in r.stdout.splitlines() if l.startswith("seed:   ")
+        )
+        assert "emptylocked" in note, (
+            "a scope whose contents could not be read must still be ANNOUNCED, "
+            f"not merely mentioned in the per-scope lines: {r.stdout}"
+        )
+        assert "UNREADABLE" in note, (
+            "announced, but not as the state that was actually established: "
             + r.stdout
         )
         assert "hold .md files" not in r.stdout, (
             "announced as holding markdown that nobody could read: " + r.stdout
+        )
+
+    def test_the_DOT_arm_of_the_unreadable_state_is_reachable_and_covered(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 The `2)` arm of the DOT branch had no coverage — deleting it left
+        every test green.
+
+        It is reachable, but not the obvious way: a real unreadable dot
+        DIRECTORY never gets here, because `rsync` fails first (rc 23) and
+        `set -e` aborts the staging. The path that does reach it is a
+        dot-NAMED SYMLINK to an unreadable target — the dot branch wins the
+        `if`/`elif`, and the probe cannot read through the link."""
+        env, dest = fake_cluster
+        locked = tmp_path / "dot-locked-target"
+        locked.mkdir()
+        (locked / "d.md").write_text(_entry("d", "dotsym"))
+        (store / ".dotsym").symlink_to(locked)
+        locked.chmod(0o000)
+        try:
+            r = self._push(store, tmp_path, env)
+        finally:
+            locked.chmod(0o755)
+
+        assert r.returncode == 0, f"stdout={r.stdout} stderr={r.stderr}"
+        note = "\n".join(l for l in r.stdout.splitlines() if l.startswith("seed:   "))
+        assert ".dotsym" in note, f"the dot arm did not announce it: {r.stdout}"
+        assert "dot-directory — UNREADABLE" in note, (
+            "reached the dot arm but not its unreadable state — the wrong "
+            f"reason would still read as covered: {note}"
         )
 
     def test_the_stub_REFUSES_to_run_with_FAKE_DEST_unset(

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2350,12 +2350,170 @@ class TestAuditLog:
 # =============================================================================
 
 
-def run_seed(*args: str) -> subprocess.CompletedProcess:
+def run_seed(*args: str, env: "dict[str, str] | None" = None) -> subprocess.CompletedProcess:
     # `bash <script>` rather than the shebang: `/usr/bin/env` does not exist in
     # the nix sandbox that gates merges (see test_runtime_shebangs.py).
+    #
+    # `env` defaults to None so every existing caller inherits the ambient
+    # environment exactly as before; the push tests pass one to put a fake
+    # `kubectl` on PATH.
     return subprocess.run(
-        ["bash", str(SEED_PATH), *args], capture_output=True, text=True, timeout=120
+        ["bash", str(SEED_PATH), *args],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
     )
+
+
+# 🔴 THE PUSH HALF WAS UNTESTED, AND THAT IS HOW THE COUNT GUARD SHIPPED WRONG.
+# seed.sh's own header says "staging is hermetic and testable, pushing needs a
+# cluster", so every seed test above stops at `--stage`. The verdict that
+# decides whether a push SUCCEEDED therefore lived in the only half nothing
+# exercised, and it was wrong for the multi-host case the store has always had.
+#
+# This fake answers `get pod`, runs the real `tar` extract into a real
+# directory, and runs the remote `find` there too — so the guard executes
+# against a filesystem the test controls rather than against a mock of itself.
+# `$FAKE_DROP` deletes one member AFTER the extract, which is how a staged entry
+# that does not land is simulated without pretending the guard ran.
+FAKE_KUBECTL = r"""#!/usr/bin/env bash
+set -uo pipefail
+[[ "${1:-}" == "-n" ]] && shift 2
+sub="${1:-}"; shift || true
+case "$sub" in
+  get) echo "fake-pod-0" ;;
+  exec)
+    [[ "${1:-}" == "-i" ]] && shift
+    shift                                   # the pod name
+    [[ "${1:-}" == "--" ]] && shift
+    cmd=(); for a in "$@"; do cmd+=("${a///data/$FAKE_DEST}"); done
+    "${cmd[@]}"; rc=$?
+    if [[ -n "${FAKE_DROP:-}" && "${cmd[0]}" == "tar" ]]; then
+      rm -f "$FAKE_DEST/$FAKE_DROP"
+    fi
+    exit $rc ;;
+  *) echo "fake kubectl: unexpected subcommand: $sub" >&2; exit 64 ;;
+esac
+"""
+
+
+@pytest.fixture
+def fake_cluster(tmp_path: Path):
+    """`(env, dest)` — an environment whose `kubectl` is the fake above, and the
+    directory standing in for the pod's `/data`."""
+    bindir = tmp_path / "fakebin"
+    bindir.mkdir()
+    k = bindir / "kubectl"
+    k.write_text(FAKE_KUBECTL)
+    k.chmod(0o755)
+    dest = tmp_path / "pod-data"
+    dest.mkdir()
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_DEST": str(dest),
+    }
+    return env, dest
+
+
+class TestSeedPushVerdict:
+    """🔴 The push verdict must answer "did everything I staged land?" — a
+    SUBSET check on names — and NOT "does the remote hold exactly as many files
+    as the stage", which is only true while one host ever seeds."""
+
+    def _push(self, store: Path, tmp_path: Path, env, **kw):
+        return run_seed(
+            "--store", str(store),
+            "--stage", str(tmp_path / "stage"),
+            "--push", "ns/app",
+            env=env,
+            **kw,
+        )
+
+    def test_POSITIVE_CONTROL_the_fake_cluster_really_receives_the_push(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """Reported BESIDE the verdicts below. A guard asserted against a
+        cluster that received NOTHING is green for the wrong reason — every
+        assertion in this class would hold over an empty directory."""
+        env, dest = fake_cluster
+        r = self._push(store, tmp_path, env)
+        assert r.returncode == 0, r.stderr
+        landed = sorted(p.name for p in (dest / SCOPE).glob("*.md"))
+        assert landed == ["thing-alpha.md"], (
+            f"the fake cluster received {landed!r} — the push did not happen, "
+            "so nothing below is evidence about the guard"
+        )
+        assert "seed: OK" in r.stdout
+
+    def test_entries_from_ANOTHER_HOST_do_not_fail_a_correct_push(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 THE REGRESSION. Red before this change: the old guard compared
+        COUNTS, so a pod already holding a second host's entries made a correct
+        push exit 7 — after the content had landed. The store is per-host and
+        the extract never deletes, so this is the NORMAL state, not an error."""
+        env, dest = fake_cluster
+        foreign = dest / "a-scope-only-the-laptop-has"
+        foreign.mkdir()
+        (foreign / "from-the-other-host.md").write_text("---\nservice: x\n---\n")
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 0, (
+            f"a correct multi-host push must not fail. stderr={r.stderr}"
+        )
+        assert "NOTE 1 entry file(s)" in r.stdout, r.stdout
+        assert (foreign / "from-the-other-host.md").exists(), (
+            "the other host's entry was DELETED — the push must add and "
+            "overwrite, never remove"
+        )
+
+    def test_a_staged_entry_that_does_NOT_land_exits_7_and_NAMES_it(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """The guard must still bite, and say WHICH file — a bare count told an
+        operator a number and left them to find the gap by hand."""
+        env, dest = fake_cluster
+        env = {**env, "FAKE_DROP": f"{SCOPE}/thing-alpha.md"}
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 7, f"rc={r.returncode} stdout={r.stdout}"
+        assert "MISMATCH" in r.stderr
+        assert f"{SCOPE}/thing-alpha.md" in r.stderr, (
+            "the failure must name the entry that did not land"
+        )
+        assert not (dest / SCOPE / "thing-alpha.md").exists()
+
+    def test_a_missing_entry_is_caught_even_when_the_COUNTS_MATCH(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 The case the old count guard could not see, and the reason this is
+        a STRENGTHENING rather than a relaxation: one staged file absent while a
+        foreign file makes the totals agree. Count-equality passes; containment
+        does not."""
+        env, dest = fake_cluster
+        foreign = dest / "a-scope-only-the-laptop-has"
+        foreign.mkdir()
+        (foreign / "makes-up-the-number.md").write_text("---\nservice: x\n---\n")
+        env = {**env, "FAKE_DROP": f"{SCOPE}/thing-alpha.md"}
+
+        r = self._push(store, tmp_path, env)
+
+        m = re.search(r"STAGED scopes=\d+ entries=(\d+)", r.stdout)
+        assert m is not None, f"seed.sh printed no STAGED line: {r.stdout}"
+        staged = int(m.group(1))
+        remote = len(list(dest.glob("*/*.md")))
+        assert remote == staged, (
+            f"fixture no longer exercises the blind spot: remote={remote} "
+            f"staged={staged} — they must be EQUAL for this test to mean anything"
+        )
+        assert r.returncode == 7, (
+            "counts matched, so the old guard would have passed this broken push"
+        )
+        assert f"{SCOPE}/thing-alpha.md" in r.stderr
 
 
 class TestSeedIsNonDestructive:

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2394,6 +2394,12 @@ def run_seed(*args: str, env: "dict[str, str] | None" = None) -> subprocess.Comp
 # the POSIX way to rebuild the argument list without an array, and it preserves
 # arguments containing spaces, which a string accumulator would not.
 FAKE_KUBECTL_BODY = r"""
+# 🔴 `set -u`: the bash original had `set -uo pipefail` and the POSIX rewrite
+# dropped it. Without it an unset $FAKE_DEST makes the sed below `s|/data||g`,
+# which silently rewrites every path to a RELATIVE one instead of erroring —
+# the stub would then "work" against the wrong directory. `pipefail` is not
+# POSIX and nothing here pipes, so only `-u` is restored.
+set -u
 # Stands in for kubectl in seed.sh's push half. $FAKE_DEST is the pretend /data;
 # $FAKE_DROP, if set, removes one member AFTER the extract, which is how "a
 # staged entry that did not land" is simulated without faking the guard itself.
@@ -2576,31 +2582,39 @@ class TestSeedPushVerdict:
         one) and an adjacency where C and en_US disagree. `README.md` beside
         `backblaze.md`/`thing-alpha.md` is that adjacency, and the real store is
         full of it — so the FIRST push after another host seeds would abort."""
-        # 🔴 THIS TEST DOES NOT SKIP, AND THAT IS DELIBERATE — TWICE OVER.
+        # 🔴 THIS TEST NEITHER SKIPS NOR DEGRADES — IT FAILS IF IT CANNOT RUN,
+        # AND THAT TOOK THREE TRIES TO GET RIGHT.
         #
-        # First it CRASHED the gating tier: `locale` does not exist in the nix
-        # sandbox, so `subprocess.run(["locale", …])` raised FileNotFoundError
-        # and the tier went 2 failed / 9794 passed. Then, made to skip, it went
-        # red a different way: `run-tests.sh` refuses an UNPINNED skip ("a skip
-        # is a test that did not run"), and its pin conditions key on ENV VARS
-        # (`unset:VAR`) while this predicate is locale AVAILABILITY — so an
-        # unconditional pin would red the DEV HOST, where the locale exists, the
-        # test runs, and the expected skip never happens.
+        #   1. It CRASHED the gating tier: no `locale` binary in the nix sandbox,
+        #      so `subprocess.run(["locale", …])` raised FileNotFoundError.
+        #   2. Made to skip, it went red differently: `run-tests.sh` refuses an
+        #      UNPINNED skip, and EXPECTED_SKIPS conditions key on env vars
+        #      (`unset:VAR`) while this predicate is locale AVAILABILITY — an
+        #      unconditional pin reds the dev host, where the test does run.
+        #   3. Made to fall back to C, it passed on BOTH tiers while being
+        #      VACUOUS on the gating one: measured with both `comm` calls
+        #      unpinned, the sandbox reported ONE failure where the dev host
+        #      reported two. The defect was invisible exactly where it counts.
         #
-        # So it runs everywhere, on the strongest collation available: en_US
-        # where it exists (the real regression), ambient otherwise (weaker, and
-        # the assertion message says which was exercised). The invariant is
-        # carried on every tier by
-        # `test_EVERY_comm_call_in_seed_sh_PINS_its_collation` — which is what
-        # makes running weak here acceptable rather than a silent gap.
+        # So the locale is now supplied to both tiers (`glibc.bin` in
+        # `gateTools`, `LOCALE_ARCHIVE` in the devShell AND in checks.pytests)
+        # and its absence is a HARD FAILURE naming the cause. A degradation that
+        # silently weakens a test is worse than a red one that says why.
+        enc = "en_US.UTF-8"
         locale_bin = shutil.which("locale")
         have = ""
         if locale_bin:
             have = subprocess.run(
                 [locale_bin, "-a"], capture_output=True, text=True
             ).stdout.lower()
-        forced = "en_US.UTF-8" if ("en_us.utf8" in have or "en_us.utf-8" in have) else None
-        enc = forced or "C"
+        assert "en_us.utf8" in have or "en_us.utf-8" in have, (
+            f"{enc} is unavailable (locale binary: {locale_bin}), so this test "
+            "cannot make the ambient collation differ from C and would pass "
+            "vacuously. This is a GATE ENVIRONMENT regression, not a defect in "
+            "seed.sh: flake.nix must keep `pkgs.glibc.bin` in gateTools and "
+            "export LOCALE_ARCHIVE in BOTH the devShell and checks.pytests."
+        )
+        forced = enc
 
         env, dest = fake_cluster
         # 🔴 THE PAIR MUST ACTUALLY INVERT, AND THE FIRST VERSION OF THIS TEST
@@ -2616,71 +2630,100 @@ class TestSeedPushVerdict:
         env = {**env, "LC_ALL": enc, "LANG": enc}
 
         # The control, so this test cannot quietly stop pinning its dimension:
-        # if the two collations ever agree on this pair, the mutant is invisible
-        # and a green here would mean nothing. Only meaningful when a non-C
-        # collation was actually available to force.
-        if forced:
-            pair = f"{SCOPE}/README.md\n{SCOPE}/backblaze.md\n"
-            c_order = subprocess.run(
-                ["sort"], input=pair, capture_output=True, text=True,
-                env={**os.environ, "LC_ALL": "C"},
-            ).stdout
-            loc_order = subprocess.run(
-                ["sort"], input=pair, capture_output=True, text=True,
-                env={**os.environ, "LC_ALL": forced},
-            ).stdout
-            assert c_order != loc_order, (
-                f"fixture no longer inverts between C and {forced} — comm's "
-                "order check cannot arm, so this test would pass whether or not "
-                "the collation is pinned"
-            )
+        # if the two collations ever agree on this pair, comm's order check
+        # cannot arm and a green here would mean nothing.
+        pair = f"{SCOPE}/README.md\n{SCOPE}/backblaze.md\n"
+        c_order = subprocess.run(
+            ["sort"], input=pair, capture_output=True, text=True,
+            env={**os.environ, "LC_ALL": "C"},
+        ).stdout
+        loc_order = subprocess.run(
+            ["sort"], input=pair, capture_output=True, text=True,
+            env={**os.environ, "LC_ALL": forced},
+        ).stdout
+        assert c_order != loc_order, (
+            f"fixture no longer inverts between C and {forced} — comm's order "
+            "check cannot arm, so this test would pass whether or not the "
+            "collation is pinned"
+        )
 
         r = self._push(store, tmp_path, env)
 
-        where = (
-            f"forced LC_ALL={forced}" if forced
-            else "NO non-C locale available here, so this ran under C and is the "
-                 "WEAK half; the strong half is "
-                 "test_EVERY_comm_call_in_seed_sh_PINS_its_collation"
-        )
         assert "not in sorted order" not in r.stderr, (
-            f"comm order-checked in the ambient locale over C-sorted input "
-            f"({where}): stderr={r.stderr}"
+            f"comm order-checked in the ambient locale (LC_ALL={forced}) over "
+            f"C-sorted input: stderr={r.stderr}"
         )
         assert r.returncode == 0, (
-            f"rc={r.returncode} ({where}) stdout={r.stdout} stderr={r.stderr}"
+            f"rc={r.returncode} under LC_ALL={forced} "
+            f"stdout={r.stdout} stderr={r.stderr}"
         )
         assert "seed: OK" in r.stdout
         assert "NOTE 1 entry file(s)" in r.stdout
 
-    def test_EVERY_comm_call_in_seed_sh_PINS_its_collation(self):
-        """The STRUCTURAL half of the locale regression, and the half that runs
-        on BOTH tiers.
+    # 🔴 A STRUCTURAL `comm`-SPELLING GUARD WAS TRIED HERE AND DELETED, ON
+    # EVIDENCE. It regex'd seed.sh for a bare `comm` not prefixed by `LC_ALL=C`.
+    # An audit walked it three ways — `/usr/bin/comm -23 …`, `_cmp=comm` then
+    # `$_cmp -23 …`, and a second `comm` later on an already-prefixed line — and
+    # it ALSO rejected three safe spellings (`env LC_ALL=C comm`, a line
+    # continuation, a global `export LC_ALL=C`). It asserted a WORD, and the
+    # hazard has other shapes. Supplying the locale to both tiers (flake.nix)
+    # lets the behavioural test above assert the STATE instead, everywhere.
 
-        🔴 The behavioural test above needs a generated `en_US.UTF-8`. The nix
-        sandbox that GATES THE MERGE has no `locale` binary and no such locale,
-        so there it skips — and a skip is not coverage. Without this, the
-        dimension that produced the round-1 🔴 would be pinned only on the dev
-        host, which is the two-tier blindness `claude/RULES.md` names.
+    def test_the_two_find_expressions_are_IDENTICAL(self):
+        """Local and remote listings must ask ONE question.
 
-        Pins the whole invariant rather than a keyword: every `comm` the script
-        executes must carry `LC_ALL=C`. Sorting both inputs under C is NOT
-        enough — GNU `comm` compares and order-checks in the ambient locale, so
-        an unpinned `comm` over C-sorted input aborts the script with rc 1 and
-        prints no verdict at all."""
-        offenders = []
-        for i, line in enumerate(SEED_PATH.read_text().splitlines(), 1):
-            stripped = line.strip()
-            if stripped.startswith("#"):
-                continue  # the block comment discusses `comm` at length
-            if re.search(r"(?<![\w./-])comm\s", stripped) and not stripped.startswith(
-                "LC_ALL=C comm "
-            ):
-                offenders.append(f"  {SEED_PATH.name}:{i}: {stripped}")
-        assert not offenders, (
-            "a `comm` call in seed.sh does not pin its collation — sorting the "
-            "inputs under LC_ALL=C is not enough, because comm itself collates "
-            "in the AMBIENT locale:\n" + "\n".join(offenders)
+        Every clause carries a case: `-mindepth 2` excludes the store's own
+        top-level `README.md`; `-maxdepth 2` stops a nested directory becoming a
+        phantom entry; `! -path './.*'` matches the tar member list, which is
+        `"$STAGE"/*/` without `dotglob`; `-type f` refuses a DIRECTORY named
+        `*.md` (the server 503'd on exactly that).
+
+        A mutation sweep found the clauses were pinned on the STAGED side only —
+        dropping `! -path './.*'`, widening `-maxdepth`, or dropping `-type f`
+        on the REMOTE side all SURVIVED. Comparing the two expressions to each
+        other catches an asymmetry in either direction, which per-side
+        assertions did not."""
+        src = SEED_PATH.read_text()
+        exprs = re.findall(r"find \. (-mindepth[^\n\"]*?-type f)", src)
+        assert len(exprs) == 2, (
+            f"expected exactly 2 entry-listing find expressions in seed.sh, "
+            f"found {len(exprs)}: {exprs}"
+        )
+        staged, remote = (" ".join(e.split()) for e in exprs)
+        assert staged == remote, (
+            "the staged and remote listings no longer ask the same question — "
+            "an asymmetry silently changes what the comparison MEANS:\n"
+            f"  staged: {staged}\n  remote: {remote}"
+        )
+        for clause in ("-mindepth 2", "-maxdepth 2", "! -path './.*'", "-type f"):
+            assert clause in staged, f"{clause!r} is no longer pinned: {staged}"
+
+    def test_a_SYMLINKED_scope_is_excluded_and_SAID_so(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 REGRESSION. `staged_entries` walked `"$STAGE"/*/` with a trailing
+        slash, which RESOLVES a symlinked scope, while the comparison's `find .`
+        does not descend one and `tar` ships the link rather than its target.
+        Measured before the fix: `remote_entries=1 staged_entries=2` followed by
+        `seed: OK all 2 staged entries are present`, rc 0 — a completeness claim
+        over an entry that never landed, and one the OLD count-equality check
+        would have caught. Both sides now come from `_shippable_entries`."""
+        env, dest = fake_cluster
+        real = tmp_path / "outside"
+        real.mkdir()
+        (real / "e.md").write_text(_entry("e", "symscope"))
+        (store / "symscope").symlink_to(real)
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 0, f"stdout={r.stdout} stderr={r.stderr}"
+        m = re.search(r"remote_entries=(\d+) staged_entries=(\d+)", r.stdout)
+        assert m and m.group(1) == m.group(2), (
+            "the two counts disagree and the run still succeeded: " + r.stdout
+        )
+        assert "symscope (symlink" in r.stdout, (
+            "a scope that ships NOTHING must be named, not silently dropped: "
+            + r.stdout
         )
 
     def test_a_TOP_LEVEL_md_in_the_store_is_not_reported_missing(
@@ -2721,6 +2764,11 @@ class TestSeedPushVerdict:
         )
         assert ".hidden" not in r.stderr
         assert "seed: OK" in r.stdout
+        # 🔴 Excluding it is right; saying nothing about it just moves the lie
+        # from a wrong MISMATCH to a silent omission.
+        assert ".hidden (dot-directory" in r.stdout, (
+            "the excluded scope must be NAMED, not silently dropped: " + r.stdout
+        )
 
 
 class TestSeedIsNonDestructive:

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2576,26 +2576,31 @@ class TestSeedPushVerdict:
         one) and an adjacency where C and en_US disagree. `README.md` beside
         `backblaze.md`/`thing-alpha.md` is that adjacency, and the real store is
         full of it — so the FIRST push after another host seeds would abort."""
-        # 🔴 `locale` IS NOT PRESENT IN THE NIX SANDBOX, and calling it there
-        # raised FileNotFoundError — this test FAILED the gating tier rather
-        # than skipping it. Resolve the binary first, and treat "cannot force
-        # the collation" as a skip that says so. The structural test below
-        # covers this invariant on the tier where this one cannot run; a skip
-        # is not coverage, which is exactly why that one exists.
-        enc = "en_US.UTF-8"
+        # 🔴 THIS TEST DOES NOT SKIP, AND THAT IS DELIBERATE — TWICE OVER.
+        #
+        # First it CRASHED the gating tier: `locale` does not exist in the nix
+        # sandbox, so `subprocess.run(["locale", …])` raised FileNotFoundError
+        # and the tier went 2 failed / 9794 passed. Then, made to skip, it went
+        # red a different way: `run-tests.sh` refuses an UNPINNED skip ("a skip
+        # is a test that did not run"), and its pin conditions key on ENV VARS
+        # (`unset:VAR`) while this predicate is locale AVAILABILITY — so an
+        # unconditional pin would red the DEV HOST, where the locale exists, the
+        # test runs, and the expected skip never happens.
+        #
+        # So it runs everywhere, on the strongest collation available: en_US
+        # where it exists (the real regression), ambient otherwise (weaker, and
+        # the assertion message says which was exercised). The invariant is
+        # carried on every tier by
+        # `test_EVERY_comm_call_in_seed_sh_PINS_its_collation` — which is what
+        # makes running weak here acceptable rather than a silent gap.
         locale_bin = shutil.which("locale")
         have = ""
         if locale_bin:
             have = subprocess.run(
                 [locale_bin, "-a"], capture_output=True, text=True
             ).stdout.lower()
-        if "en_us.utf8" not in have and "en_us.utf-8" not in have:
-            pytest.skip(
-                f"{enc} is not generated here (locale binary: {locale_bin}), so the "
-                "ambient collation cannot be made to differ from C. This dimension "
-                "is UNCOVERED behaviourally on this tier — see "
-                "test_EVERY_comm_call_in_seed_sh_PINS_its_collation."
-            )
+        forced = "en_US.UTF-8" if ("en_us.utf8" in have or "en_us.utf-8" in have) else None
+        enc = forced or "C"
 
         env, dest = fake_cluster
         # 🔴 THE PAIR MUST ACTUALLY INVERT, AND THE FIRST VERSION OF THIS TEST
@@ -2612,29 +2617,39 @@ class TestSeedPushVerdict:
 
         # The control, so this test cannot quietly stop pinning its dimension:
         # if the two collations ever agree on this pair, the mutant is invisible
-        # and a green here would mean nothing.
-        pair = f"{SCOPE}/README.md\n{SCOPE}/backblaze.md\n"
-        c_order = subprocess.run(
-            ["sort"], input=pair, capture_output=True, text=True,
-            env={**os.environ, "LC_ALL": "C"},
-        ).stdout
-        loc_order = subprocess.run(
-            ["sort"], input=pair, capture_output=True, text=True,
-            env={**os.environ, "LC_ALL": enc},
-        ).stdout
-        assert c_order != loc_order, (
-            "fixture no longer inverts between C and "
-            f"{enc} — comm's order check cannot arm, so this test would pass "
-            "whether or not the collation is pinned"
-        )
+        # and a green here would mean nothing. Only meaningful when a non-C
+        # collation was actually available to force.
+        if forced:
+            pair = f"{SCOPE}/README.md\n{SCOPE}/backblaze.md\n"
+            c_order = subprocess.run(
+                ["sort"], input=pair, capture_output=True, text=True,
+                env={**os.environ, "LC_ALL": "C"},
+            ).stdout
+            loc_order = subprocess.run(
+                ["sort"], input=pair, capture_output=True, text=True,
+                env={**os.environ, "LC_ALL": forced},
+            ).stdout
+            assert c_order != loc_order, (
+                f"fixture no longer inverts between C and {forced} — comm's "
+                "order check cannot arm, so this test would pass whether or not "
+                "the collation is pinned"
+            )
 
         r = self._push(store, tmp_path, env)
 
-        assert "not in sorted order" not in r.stderr, (
-            "comm order-checked in the ambient locale over C-sorted input: "
-            f"stderr={r.stderr}"
+        where = (
+            f"forced LC_ALL={forced}" if forced
+            else "NO non-C locale available here, so this ran under C and is the "
+                 "WEAK half; the strong half is "
+                 "test_EVERY_comm_call_in_seed_sh_PINS_its_collation"
         )
-        assert r.returncode == 0, f"rc={r.returncode} stdout={r.stdout} stderr={r.stderr}"
+        assert "not in sorted order" not in r.stderr, (
+            f"comm order-checked in the ambient locale over C-sorted input "
+            f"({where}): stderr={r.stderr}"
+        )
+        assert r.returncode == 0, (
+            f"rc={r.returncode} ({where}) stdout={r.stdout} stderr={r.stderr}"
+        )
         assert "seed: OK" in r.stdout
         assert "NOTE 1 entry file(s)" in r.stdout
 

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2576,12 +2576,26 @@ class TestSeedPushVerdict:
         one) and an adjacency where C and en_US disagree. `README.md` beside
         `backblaze.md`/`thing-alpha.md` is that adjacency, and the real store is
         full of it — so the FIRST push after another host seeds would abort."""
+        # 🔴 `locale` IS NOT PRESENT IN THE NIX SANDBOX, and calling it there
+        # raised FileNotFoundError — this test FAILED the gating tier rather
+        # than skipping it. Resolve the binary first, and treat "cannot force
+        # the collation" as a skip that says so. The structural test below
+        # covers this invariant on the tier where this one cannot run; a skip
+        # is not coverage, which is exactly why that one exists.
         enc = "en_US.UTF-8"
-        have = subprocess.run(
-            ["locale", "-a"], capture_output=True, text=True
-        ).stdout.lower()
+        locale_bin = shutil.which("locale")
+        have = ""
+        if locale_bin:
+            have = subprocess.run(
+                [locale_bin, "-a"], capture_output=True, text=True
+            ).stdout.lower()
         if "en_us.utf8" not in have and "en_us.utf-8" not in have:
-            pytest.skip(f"{enc} not generated here; the collation cannot be forced")
+            pytest.skip(
+                f"{enc} is not generated here (locale binary: {locale_bin}), so the "
+                "ambient collation cannot be made to differ from C. This dimension "
+                "is UNCOVERED behaviourally on this tier — see "
+                "test_EVERY_comm_call_in_seed_sh_PINS_its_collation."
+            )
 
         env, dest = fake_cluster
         # 🔴 THE PAIR MUST ACTUALLY INVERT, AND THE FIRST VERSION OF THIS TEST
@@ -2623,6 +2637,36 @@ class TestSeedPushVerdict:
         assert r.returncode == 0, f"rc={r.returncode} stdout={r.stdout} stderr={r.stderr}"
         assert "seed: OK" in r.stdout
         assert "NOTE 1 entry file(s)" in r.stdout
+
+    def test_EVERY_comm_call_in_seed_sh_PINS_its_collation(self):
+        """The STRUCTURAL half of the locale regression, and the half that runs
+        on BOTH tiers.
+
+        🔴 The behavioural test above needs a generated `en_US.UTF-8`. The nix
+        sandbox that GATES THE MERGE has no `locale` binary and no such locale,
+        so there it skips — and a skip is not coverage. Without this, the
+        dimension that produced the round-1 🔴 would be pinned only on the dev
+        host, which is the two-tier blindness `claude/RULES.md` names.
+
+        Pins the whole invariant rather than a keyword: every `comm` the script
+        executes must carry `LC_ALL=C`. Sorting both inputs under C is NOT
+        enough — GNU `comm` compares and order-checks in the ambient locale, so
+        an unpinned `comm` over C-sorted input aborts the script with rc 1 and
+        prints no verdict at all."""
+        offenders = []
+        for i, line in enumerate(SEED_PATH.read_text().splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue  # the block comment discusses `comm` at length
+            if re.search(r"(?<![\w./-])comm\s", stripped) and not stripped.startswith(
+                "LC_ALL=C comm "
+            ):
+                offenders.append(f"  {SEED_PATH.name}:{i}: {stripped}")
+        assert not offenders, (
+            "a `comm` call in seed.sh does not pin its collation — sorting the "
+            "inputs under LC_ALL=C is not enough, because comm itself collates "
+            "in the AMBIENT locale:\n" + "\n".join(offenders)
+        )
 
     def test_a_TOP_LEVEL_md_in_the_store_is_not_reported_missing(
         self, store: Path, tmp_path: Path, fake_cluster

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2728,6 +2728,35 @@ class TestSeedPushVerdict:
         for clause in ("-mindepth 2", "-maxdepth 2", "! -path './.*'", "-type f"):
             assert clause in staged, f"{clause!r} is no longer pinned: {staged}"
 
+    def test_a_dot_scope_does_not_ship_EVEN_WITH_dotglob_SET(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 THE SUITE WAS BLIND TO THIS DIMENSION, WHICH IS HOW THE DEFECT GOT
+        IN. Every other test here runs with bash's default options, so a change
+        that made the tar member list depend on the AMBIENT shell passed
+        everything.
+
+        The member list is `"$STAGE"/*/`, correct only while `dotglob` is off. A
+        version of this script restored the caller's `dotglob` before building
+        it; under `BASHOPTS=dotglob` a dot-scope then LANDED on the pod while the
+        remote listing's `! -path './.*'` still excluded it — shipped, never
+        verified, and the NOTE saying "not in the tar member list" was false.
+        Asking which dimension the config fixes is what surfaces this class."""
+        env, dest = fake_cluster
+        hidden = store / ".hidden"
+        hidden.mkdir()
+        (hidden / "h.md").write_text(_entry("h", ".hidden"))
+        env = {**env, "BASHOPTS": "dotglob"}
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 0, f"stdout={r.stdout} stderr={r.stderr}"
+        assert not (dest / ".hidden").exists(), (
+            "with dotglob set in the environment the dot-scope SHIPPED — the "
+            "member list must not depend on the ambient shell. pod holds: "
+            f"{sorted(p.name for p in dest.iterdir())}"
+        )
+
     def test_a_DEPTH_2_DIRECTORY_on_the_pod_is_not_an_entry(
         self, store: Path, tmp_path: Path, fake_cluster
     ):

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2599,16 +2599,18 @@ class TestSeedPushVerdict:
         #      unpinned, the sandbox reported ONE failure where the dev host
         #      reported two. The defect was invisible exactly where it counts.
         #
-        # So the locale is now supplied to both tiers (`glibc.bin` in
-        # `gateTools`, `LOCALE_ARCHIVE` in the devShell AND in checks.pytests)
-        # and its absence is a HARD FAILURE naming the cause. A degradation that
-        # silently weakens a test is worse than a red one that says why.
+        # So the locale is now supplied to both tiers by `LOCALE_ARCHIVE`,
+        # exported in the devShell AND in checks.pytests, and its absence is a
+        # HARD FAILURE naming the cause. A degradation that silently weakens a
+        # test is worse than a red one that says why.
+        # (This comment used to add "`glibc.bin` in `gateTools`" — a requirement
+        # the block below deliberately removed. It was left standing four lines
+        # above its own correction; see flake.nix for both retractions.)
         # 🔴 AVAILABILITY IS DETECTED BY EXERCISING THE CAPABILITY, NOT BY
         # PROBING FOR A BINARY. An earlier version ran `locale -a` and asserted
-        # `en_US.utf8` appeared. That was the wrong question twice over: it
-        # needed `pkgs.glibc.bin` on the shared devShell PATH (21 store binaries
-        # shadowing the system `getconf`/`ldd`/`iconv` for every human in
-        # `nix develop`) to answer it, and MEASURED — with `LOCALE_ARCHIVE` set
+        # `en_US.utf8` appeared. That was the wrong question: it needed
+        # `pkgs.glibc.bin` added to gateTools purely to answer it, and MEASURED
+        # — with `LOCALE_ARCHIVE` set
         # and NO `locale` binary at all, `LC_ALL=en_US.UTF-8 sort` collates
         # correctly. The binary was never load-bearing; `LOCALE_ARCHIVE` is.
         #
@@ -2726,6 +2728,94 @@ class TestSeedPushVerdict:
         for clause in ("-mindepth 2", "-maxdepth 2", "! -path './.*'", "-type f"):
             assert clause in staged, f"{clause!r} is no longer pinned: {staged}"
 
+    def test_a_DEPTH_2_DIRECTORY_on_the_pod_is_not_an_entry(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 THE BEHAVIOURAL HALF OF THE TWO-LISTINGS INVARIANT, and the durable
+        one. The textual identity guard has now lost this race twice: first by
+        capturing only to `-type f`, then — after being 'fixed' — to an escaped
+        `\\( … \\)` group, which recreated the same hole and stayed green across
+        the whole class. A guard over a shell expression's SPELLING keeps
+        finding new shapes to miss; this asserts the STATE instead.
+
+        A depth-2 directory on the pod must not enter `remote_list`. If it does
+        (an `-o -type d` on the remote side, a widened `-maxdepth`), it is
+        reported as another host's entry on every single push."""
+        env, dest = fake_cluster
+        (dest / SCOPE).mkdir(parents=True, exist_ok=True)
+        (dest / SCOPE / "a-subdirectory").mkdir()
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 0, f"stdout={r.stdout} stderr={r.stderr}"
+        assert "were not staged by this host" not in r.stdout, (
+            "a DIRECTORY on the pod was counted as an entry and reported as "
+            f"foreign — the two listings disagree: {r.stdout}"
+        )
+
+    def test_a_scope_name_containing_a_BACKSLASH_ESCAPE_counts_correctly(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        r"""`awk -v p=…` INTERPRETS escape sequences, so a scope literally named
+        `a\tb` was searched for as `a<TAB>b` and reported entries=0 beside a
+        non-zero total. Passing it through ENVIRON fixes that — and a straight
+        revert to `-v` was green across the whole class until this existed."""
+        # STAGE-ONLY, deliberately: the count line this pins is printed before
+        # the push, and a backslash in a scope name independently breaks the tar
+        # member list (`tar: a\tb: Cannot stat`) — a pre-existing defect this
+        # round does not touch. Requiring rc 0 would make the test about that
+        # instead, and it would never pass.
+        weird = store / "a\\tb"
+        weird.mkdir()
+        (weird / "n.md").write_text(_entry("n", "a-tb"))
+
+        r = run_seed("--store", str(store), "--stage", str(tmp_path / "stage"))
+
+        assert r.returncode == 0, f"stdout={r.stdout} stderr={r.stderr}"
+        counts = dict(re.findall(r"staged scope (\S+)\s+entries=(\d+)", r.stdout))
+        assert counts.get("a\\tb") == "1", (
+            "a scope whose name contains a backslash escape mis-counted: "
+            f"{counts} — awk -v would read it as a literal tab. {r.stdout}"
+        )
+
+    def test_a_dot_scope_that_is_ALSO_a_symlink_is_announced_ONCE(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """The two NOTE arms are `if`/`elif` for a reason: turning the `elif`
+        into a second `if` was green across the class while printing one
+        directory twice under a header that counts them."""
+        env, dest = fake_cluster
+        real = tmp_path / "dotsym-target"
+        real.mkdir()
+        (real / "e.md").write_text(_entry("e", "dotsym"))
+        (store / ".dotsym").symlink_to(real)
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 0, f"stdout={r.stdout} stderr={r.stderr}"
+        named = [l for l in r.stdout.splitlines() if ".dotsym" in l and l.startswith("seed:   ")]
+        assert len(named) == 1, f"announced {len(named)} times, want 1: {named}"
+        header = [l for l in r.stdout.splitlines() if l.startswith("seed: NOTE")]
+        assert "1 scope" in header[0], f"the count must match the list: {header}"
+
+    def test_a_scope_whose_md_is_TOO_DEEP_is_not_announced(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """`_holds_md` uses `-maxdepth 1` because only depth-1 `*.md` inside a
+        scope is shippable at all. Widening it survived the class and would
+        announce a scope over files no scope could ever ship."""
+        env, dest = fake_cluster
+        deep = store / ".deep" / "sub"
+        deep.mkdir(parents=True)
+        (deep / "x.md").write_text(_entry("x", "deep"))
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 0, f"stdout={r.stdout} stderr={r.stderr}"
+        assert ".deep" not in "".join(
+            l for l in r.stdout.splitlines() if l.startswith("seed:   ")
+        ), f"announced a scope whose only .md is too deep to ship: {r.stdout}"
+
     def test_a_SYMLINKED_scope_is_excluded_and_SAID_so(
         self, store: Path, tmp_path: Path, fake_cluster
     ):
@@ -2761,20 +2851,56 @@ class TestSeedPushVerdict:
         a mutation sweep survived both `index($0,p) > 0` (substring) and the
         whole count hardcoded. With scopes `foo` and `xfoo`, a substring test
         counts `xfoo/n.md` against `foo`, so `foo` reports 2 while holding 1."""
+        # 🔴 THE FIXTURE MUST DEFEAT THREE MUTANTS, AND THE FIRST VERSION BEAT
+        # ONLY ONE. It used `foo`/`xfoo` with one entry each, so every true
+        # count was 1 and the assertions were `== "1"` — hardcoding `n=1`
+        # SURVIVED (only `n=0` and `n=2` died), the constant-equals-fixture trap.
+        # And `xfoo` extends `foo` on the LEFT, so dropping the `/` separator
+        # (`P="$name"`) survived too. Hence: one scope with TWO entries, and a
+        # `foo`/`foobar` pair where the separator is what distinguishes them.
         env, dest = fake_cluster
-        for name in ("foo", "xfoo"):
+        for name, n in (("foo", 2), ("foobar", 1), ("xfoo", 1)):
             (store / name).mkdir()
-            (store / name / "n.md").write_text(_entry("n", name))
+            for i in range(n):
+                (store / name / f"n{i}.md").write_text(_entry(f"n{i}", name))
 
         r = self._push(store, tmp_path, env)
 
         assert r.returncode == 0, f"stdout={r.stdout} stderr={r.stderr}"
         counts = dict(re.findall(r"staged scope (\S+)\s+entries=(\d+)", r.stdout))
-        assert counts.get("foo") == "1", (
-            f"`foo` must count only its own entry, got {counts.get('foo')!r} "
-            f"— a substring match would say 2. {r.stdout}"
+        assert counts.get("foo") == "2", (
+            f"`foo` holds 2 entries, got {counts.get('foo')!r} — a substring "
+            f"match would add xfoo's, a dropped separator would add foobar's. "
+            f"{r.stdout}"
         )
+        assert counts.get("foobar") == "1", counts
         assert counts.get("xfoo") == "1", counts
+
+    def test_a_symlinked_scope_whose_target_is_UNREADABLE_is_still_announced(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 AN ERROR IS NOT "NO". `_holds_md` briefly carried `2>/dev/null`,
+        which turned an unreadable symlink target from a loud over-report into
+        complete silence — no NOTE, rc 0, `seed: OK`, and the operator loses
+        that scope's contents with nothing to say so. `_shippable_entries` does
+        not descend the symlink either, so nothing else surfaces it."""
+        env, dest = fake_cluster
+        locked = tmp_path / "locked-target"
+        locked.mkdir()
+        (locked / "l.md").write_text(_entry("l", "locked"))
+        (store / "lockedsym").symlink_to(locked)
+        locked.chmod(0o000)
+        try:
+            r = self._push(store, tmp_path, env)
+        finally:
+            locked.chmod(0o755)  # so tmp_path cleanup can proceed
+
+        assert "lockedsym" in "".join(
+            l for l in r.stdout.splitlines() if l.startswith("seed:   ")
+        ), (
+            "an unreadable symlinked scope was silently dropped instead of "
+            f"announced: {r.stdout}"
+        )
 
     def test_the_stub_REFUSES_to_run_with_FAKE_DEST_unset(
         self, store: Path, tmp_path: Path, fake_cluster


### PR DESCRIPTION
`seed.sh`'s push verdict was `remote_entries != staged_entries -> exit 7`. That is only correct while exactly **one** host ever seeds.

The store is per-host and unreplicated, and the tar extract adds and overwrites but never deletes — so a second host's entries legitimately sit in `$DEST` that this stage never held. The count then failed a **correct** push, and did it *after* the content had landed: a failure verdict on a push that worked, which invites a retry that changes nothing. That is the same shape the tar member list a few lines above was already fixed for.

**Measured 2026-08-28** while finishing criterion 8: this host staged 129 over a pod holding 75 — a strict subset, so equality happened to hold and the re-seed passed. The other host's ~26 would stage against a remote of 129+ and exit 7 every time, leaving criterion 8 unfinishable by the tool meant to finish it.

### This is a strengthening, not a relaxation

Count-equality was also **weaker than it looked** in the single-host case it was written for: 129 staged against 129 remote passes while one staged file is missing and one foreign file makes up the number. The question a push actually has to answer is *"did everything I staged land?"* — a subset check on **names**, which is also the `comm -23` the re-seed card prescribes.

So the new guard fails strictly more broken pushes than the count did, and stops failing the correct ones. Extra remote entries are now reported as a `NOTE` beside the verdict, never instead of it. A missing entry is named, rather than leaving the operator a number and a manual diff.

Both sides now use `-mindepth 2 -maxdepth 2`, so they answer the same question — `<scope>/<entry>.md`. The old remote count used `-maxdepth 2` alone, which would also have counted a stray top-level `*.md` the stage cannot contain.

### The push half had no tests at all

`seed.sh`'s header says *"staging is hermetic and testable, pushing needs a cluster"*, so every existing seed test stops at `--stage`. **The verdict deciding whether a push succeeded lived in the only half nothing exercised** — which is how this shipped wrong.

Added a fake `kubectl` (answers `get pod`, runs the real `tar` extract into a real directory, runs the remote `find` there too), so the guard executes against a filesystem the test controls rather than a mock of itself. `$FAKE_DROP` removes one member after the extract to simulate an entry that does not land.

### Red/green matrix

Every regression test was watched to fail against `origin/main`'s `seed.sh`:

| test | pre-change | post-change |
|---|---|---|
| foreign host's entries don't fail a correct push | **RED** (exit 7) | green |
| a dropped entry exits 7 **and names it** | **RED** (unnamed) | green |
| dropped entry caught **when counts match** | **RED** (`assert 0 == 7`) | green |
| positive control — fake cluster really receives the push | green | green |

The third is the blind spot demonstrated live: pre-change output read `remote_entries=3 local_entries=3` / `seed: OK` on a push that had dropped an entry.

Suite: **606 passed** (was 602). Also exercised end-to-end against the live pod — `seed: OK all 129 staged entries are present on the pod`, rc=0, reads 200, legacy writes still 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nc4ReML29g4pJos3BshJAh