### PR TITLE
fix(espanso): a search term that NAMES a snippet wins over ones merely containing it

### DIFF
--- a/scripts/collector/keylog/espanso_detect.py
+++ b/scripts/collector/keylog/espanso_detect.py
@@ -21,8 +21,10 @@ Two detection paths:
      keylogger calls `feed_search_open`; subsequent chars accumulate as the
      search TERM (not the direct ring) until a close boundary (Enter, Escape,
      focus change, or idle). We fuzzy-attribute the term to a snippet; a unique
-     match is attributed, zero/multiple → trigger=None, but the search-open +
-     term are recorded regardless. Search events are always `inferred=True`.
+     match is attributed, and when several match, a term that NAMES exactly one
+     of them outright (it IS that trigger, with or without the ':') takes it.
+     Otherwise → trigger=None, but the search-open + term are recorded
+     regardless. Search events are always `inferred=True`.
 
 Honest limitation: "ring ends with a trigger" ≈ "espanso fired", EXCEPT in
 per-app espanso-disabled contexts (still far better than phrase-counting). The
@@ -250,7 +252,26 @@ class EspansoDetector:
         if not t:
             return None
         matched = [trig for trig in self.ts.triggers if self._term_matches(t, trig)]
-        return matched[0] if len(matched) == 1 else None
+        if len(matched) == 1:
+            return matched[0]
+        # Matching is by SUBSTRING (see `_token_matches`), so a term can match a
+        # snippet it merely occurs INSIDE. When ":acq" was split into ":dacq" +
+        # ":acq" on 2026-08-28 the bare term "acq" started matching BOTH
+        # (`"acq" in ":dacq"` is True) and every such fire was recorded
+        # UNATTRIBUTED. A term that NAMES one snippet outright — it equals that
+        # trigger, with or without the leading ":" — is not ambiguous about
+        # which snippet it means, so that snippet wins over the ones that merely
+        # contain it. This is consulted ONLY on the already-ambiguous branch, so
+        # it can never re-point a term that resolves uniquely today; the tie is
+        # broken only when EXACTLY ONE candidate is named outright.
+        exact = [trig for trig in matched if self._names_trigger(t, trig)]
+        return exact[0] if len(exact) == 1 else None
+
+    @staticmethod
+    def _names_trigger(term, trig):
+        """True when `term` IS this trigger, spelled with or without its ':'."""
+        low = (trig or "").lower()
+        return bool(low) and term in (low, low[1:] if low.startswith(":") else low)
 
     def _term_matches(self, term, trig):
         """True when EVERY whitespace-separated token of `term` matches `trig`.

--- a/scripts/collector/keylog/tests/test_espanso_detect.py
+++ b/scripts/collector/keylog/tests/test_espanso_detect.py
@@ -139,14 +139,17 @@ def test_search_fuzzy_zero_match_still_emits_with_term():
 
 
 def test_search_fuzzy_multiple_match_is_ambiguous():
-    # "date" is a substring of BOTH :date and :datetime → ambiguous → trigger None.
+    # "dat" is a substring of BOTH :date and :datetime → ambiguous → trigger None.
+    # It deliberately NAMES neither: the 2026-08-28 exact-name tie-break resolves
+    # a term that IS one of the candidate triggers (so bare "date" now lands on
+    # :date), and this test is about the ambiguity path, not about that.
     d = _det()
     d.feed_search_open(app=APP, session=SESS, now=0.0)
-    _type(d, "date", now=1.0)
+    _type(d, "dat", now=1.0)
     evs = list(d.feed_char("\n", app=APP, session=SESS, now=5.0))
     assert len(evs) == 1
     assert evs[0].trigger is None
-    assert evs[0].search_term == "date"
+    assert evs[0].search_term == "dat"
 
 
 def test_search_flush_on_idle_without_enter():
@@ -269,15 +272,16 @@ def test_focus_steal_by_espanso_window_keeps_search_and_attributes():
 
 
 def test_focus_steal_ambiguous_term_still_emits_trigger_none():
-    # Same focus-steal path, but an ambiguous term ("date" ⊂ :date and :datetime)
+    # Same focus-steal path, but an ambiguous term ("dat" ⊂ :date and :datetime,
+    # and NAMING neither — see the exact-name note on the ambiguity test above)
     # → trigger=None yet the event is still emitted (real search, unattributed).
     d = _det()
     d.feed_search_open(app="Alacritty", session="win-term", now=0.0)
-    _type(d, "date", app=ESPANSO_WIN, session="win-esp", now=1.0)
+    _type(d, "dat", app=ESPANSO_WIN, session="win-esp", now=1.0)
     out = list(d.feed_char("\n", app=ESPANSO_WIN, session="win-esp", now=6.0))
     assert len(out) == 1
     assert out[0].trigger is None
-    assert out[0].search_term == "date"
+    assert out[0].search_term == "dat"
     assert out[0].method == "search"
     assert out[0].app == "Alacritty"  # origin window preserved
 
@@ -449,7 +453,10 @@ def test_multiword_all_tokens_required():
 
 
 def test_single_word_term_behaviour_unchanged():
-    # The single-token path must be byte-for-byte the old semantics.
+    # The single-token MATCHING path is byte-for-byte the old semantics (the
+    # 2026-08-05 multi-word fix changed nothing here). Attribution has since
+    # gained one tie-break on the AMBIGUOUS branch only — pinned explicitly
+    # below, alongside a term that names nothing and stays ambiguous.
     d = _det_for(CIVIT_BASE)
     assert d._term_matches("prod", ":cpk") is True
     assert d._term_matches("prod", ":cc") is False
@@ -459,13 +466,133 @@ def test_single_word_term_behaviour_unchanged():
     # ...and on the original fixture set too.
     d2 = _det()
     assert d2._attribute("leverage") == ":rnx"
-    assert d2._attribute("date") is None
+    # "dat" matches :date AND :datetime and names neither → still ambiguous.
+    assert d2._attribute("dat") is None
+    # Bare "date" also matches both, but it NAMES :date, so the 2026-08-28
+    # exact-name tie-break takes it. This asserted None before that fix; it is
+    # the one single-token outcome that moved, and only on the branch that used
+    # to return None. Recorded here rather than deleted so the change is visible.
+    assert d2._attribute("date") == ":date"
     assert d2._attribute("zzzzz") is None
 
 
 def test_multiword_term_with_extra_whitespace_is_tokenized():
     d = _det_for(CIVIT_BASE)
     assert d._attribute("  civit   prod  ") == ":cpk"
+
+
+# -- FIX 4: a term that NAMES one of the snippets it matches ------------------
+# 2026-08-28. `:acq` was SPLIT into `:dacq` (dispatch) + `:acq` (the bare ask).
+# Matching is by SUBSTRING, so the bare term "acq" then matched BOTH
+# (`"acq" in ":dacq"` is True) and `_attribute` returned None — every such fire
+# recorded UNATTRIBUTED, live on both hosts. Measured across three trees via the
+# module's own scraper: unique at 7aff8471 (pre-split), AMBIGUOUS at 4f1e4c56
+# (the split) and still AMBIGUOUS at d1a9fd5e.
+#
+# The fix is STRUCTURAL, not a rename: when several snippets match and exactly
+# one of them is NAMED outright by the term (the term IS that trigger, with or
+# without the ':'), that one wins. It closes the whole `:dX` / `:X` class rather
+# than this instance. `test_live_bare_trigger_names_resolve_to_their_own_snippet`
+# is the live-config half of the same claim.
+#
+# 🔴 WHICH OF THESE ARE REGRESSION COVERAGE. Measured against 6349a8b9 (the tree
+# the bug is live on), with the tests below in place and only the fix reverted:
+#   RED at base  — test_bare_acq_resolves_to_acq_not_ambiguous,
+#                  test_acq_end_to_end_through_search_ui,
+#                  test_live_bare_trigger_names_resolve_to_their_own_snippet
+#   GREEN at base — the other four here. They are INVARIANT GUARDS, not
+#                  regression coverage: they pin what the tie-break must NOT do
+#                  (re-point a unique match, break the picker, break the direct
+#                  path, resolve a term naming TWO snippets). Each was
+#                  mutation-checked instead — see the PR body.
+#
+# These fixtures carry the REAL triggers/labels/search_terms from nix/home.nix.
+ACQ_BASE = {"matches": [
+    {"trigger": ":dacq", "replace": "...",
+     "label": "Process feedback: dispatch subagent + elicit scope",
+     "search_terms": ["feedback", "dispatch", "process", "elicit", "scope",
+                      "include"]},
+    {"trigger": ":acq", "replace": "...", "label": "ask clarifying questions",
+     "search_terms": ["ask", "clarify", "clarifying", "questions"]},
+]}
+
+
+def test_bare_acq_resolves_to_acq_not_ambiguous():
+    # RED before the fix: _attribute returned None because "acq" ⊂ ":dacq".
+    d = _det_for(ACQ_BASE)
+    assert d._term_matches("acq", ":acq") is True
+    assert d._term_matches("acq", ":dacq") is True   # the substring collision
+    assert d._attribute("acq") == ":acq"
+    # The colon-spelled form was never ambiguous and must stay put.
+    assert d._attribute(":acq") == ":acq"
+    # ...and the OTHER side of the split is untouched, by either spelling.
+    assert d._attribute("dacq") == ":dacq"
+    assert d._attribute(":dacq") == ":dacq"
+
+
+def test_acq_split_interface_words_still_resolve():
+    # The tie-break must not swallow the words that already resolved uniquely.
+    d = _det_for(ACQ_BASE)
+    for term, want in [("ask", ":acq"), ("clarify", ":acq"),
+                       ("questions", ":acq"), ("feedback", ":dacq"),
+                       ("dispatch", ":dacq"), ("elicit", ":dacq")]:
+        assert d._attribute(term) == want, term
+
+
+def test_naming_tiebreak_only_fires_on_the_ambiguous_branch():
+    # A term matching several snippets and naming NONE of them stays None — the
+    # tie-break is not "pick the shortest" or "pick the first".
+    d = _det_for(ACQ_BASE)
+    assert sorted(t for t in d.ts.triggers if d._term_matches("ac", t)) == [
+        ":acq", ":dacq"]
+    assert d._attribute("ac") is None
+    # A multi-token term cannot name a trigger, so it is unaffected.
+    assert d._attribute("acq zzzzz") is None
+
+
+def test_naming_two_triggers_at_once_stays_ambiguous():
+    # `exactly one` is load-bearing: with both "acq" and ":acq" configured, the
+    # term names BOTH, so there is no winner and None is the honest answer.
+    # (Mutating `len(exact) == 1` to `if exact` is what this catches.)
+    both = {"matches": [
+        {"trigger": ":acq", "replace": "...", "label": "colon form",
+         "search_terms": []},
+        {"trigger": "acq", "replace": "...", "label": "bare form",
+         "search_terms": []},
+    ]}
+    d = _det_for(both)
+    assert d._attribute("acq") is None
+
+
+def test_acq_end_to_end_through_search_ui():
+    # The whole point: a real Ctrl+Space search for "acq" must now be ATTRIBUTED
+    # rather than land as an unattributed row in activity.events.
+    d = _det_for(ACQ_BASE)
+    d.feed_search_open(app=APP, session=SESS, now=0.0)
+    _type(d, "acq", now=1.0)
+    evs = list(d.feed_char("\n", app=APP, session=SESS, now=9.0))
+    assert len(evs) == 1
+    assert evs[0].trigger == ":acq"
+    assert evs[0].search_term == "acq"
+    assert evs[0].method == "search" and evs[0].inferred is True
+
+
+def test_acq_split_direct_triggers_are_unaffected():
+    # The DIRECT path is a different mechanism (ring-endswith, shortest match)
+    # and ':dacq' does not end with ':acq', so typing either fires itself.
+    d = _det_for(ACQ_BASE)
+    assert [e.trigger for e in _type(d, "hello :acq")] == [":acq"]
+    d2 = _det_for(ACQ_BASE)
+    assert [e.trigger for e in _type(d2, "hello :dacq")] == [":dacq"]
+
+
+def test_naming_tiebreak_does_not_reach_the_picker():
+    # Attribution and the espanso PICKER are different questions: the picker
+    # lists every match, and this fix must not remove a row. `_term_matches` is
+    # what the picker guard reads, and it is untouched.
+    d = _det_for(ACQ_BASE)
+    assert {t for t in d.ts.triggers if d._term_matches("acq", t)} == {
+        ":acq", ":dacq"}
 
 
 # --------------------------------------------------------------------------- #
@@ -644,6 +771,12 @@ _EXISTING_RESOLUTIONS = [
     # vocabulary, not only if search_terms do.
     ("clarify", ":acq"), ("questions", ":acq"),
     ("elicit", ":dacq"), ("subagent", ":dacq"),
+    # The split's OTHER half, missed by the row above and by the prefix/suffix
+    # collision guard alike: the bare trigger name "acq" is a SUBSTRING of
+    # ":dacq", so it matched both and every such fire landed UNATTRIBUTED. The
+    # collision guard cannot see it — ":dacq".endswith(":acq") is False. ADDED,
+    # never in place of a row; see the ANTI-VACUITY note below.
+    ("acq", ":acq"), ("dacq", ":dacq"),
     ("cc", ":cc"), ("kubecl", ":kuc"), ("spine", ":csc"), ("orch", ":cmo"),
     ("home", ":hlt"), ("prod", ":cpk"), ("datap", ":cdp"), ("civit prod", ":cpk"),
 ]
@@ -654,7 +787,10 @@ def test_live_existing_resolutions_not_made_ambiguous():
     # 2026-08-19), so the cheap way to "fix" a future failure is to delete the
     # row that broke — which is exactly the regression this guard exists to
     # catch. A floor, not an exact count.
-    assert len(_EXISTING_RESOLUTIONS) >= 20, (
+    # The floor is the CURRENT row count (26 on 2026-08-28, ratcheted up from a
+    # stale 20 that had let four added rows go unprotected). `>=` so adding a
+    # row stays green; deleting one goes red, which is the whole point.
+    assert len(_EXISTING_RESOLUTIONS) >= 26, (
         "_EXISTING_RESOLUTIONS shrank — a pinned resolution was deleted rather "
         "than fixed; that is the failure mode, not the fix"
     )
@@ -762,6 +898,14 @@ def test_live_triggers_have_no_prefix_or_suffix_collisions():
     Where one trigger is a prefix or suffix of another the two disagree, so the
     keylog signal misattributes. Pin zero such pairs — and prove the checker can
     SEE one, so the zero is a real zero and not a check wired to nothing.
+
+    🔴 SCOPE: this covers the DIRECT path ONLY, because that path matches on the
+    ring's SUFFIX. It is structurally blind to the SEARCH path, which matches by
+    SUBSTRING anywhere — ':acq' is a substring of ':dacq' while
+    `":dacq".endswith(":acq")` is False, so that pair passed here for ten days
+    while every bare 'acq' search landed unattributed. The search half is
+    `test_live_bare_trigger_names_resolve_to_their_own_snippet` below; the two
+    together are the claim, neither alone.
     """
     def pairs(trigs):
         found = set()
@@ -783,3 +927,65 @@ def test_live_triggers_have_no_prefix_or_suffix_collisions():
         "mean nothing"
     )
     assert pairs(live) == set(), f"colliding triggers in nix/home.nix: {pairs(live)}"
+
+
+def test_live_bare_trigger_names_resolve_to_their_own_snippet():
+    """Typing a snippet's own name must attribute to THAT snippet.
+
+    The SEARCH-path half of the collision guard above. Search attribution
+    matches by SUBSTRING, so one trigger being a substring of another anywhere
+    (not just at an end) makes the shorter one's own name ambiguous. Measured
+    2026-08-28: ':acq' split into ':dacq' + ':acq' made bare 'acq' match BOTH,
+    `_attribute` returned None, and every such fire was recorded UNATTRIBUTED on
+    both hosts — with the prefix/suffix guard green throughout.
+
+    The expectation is DERIVED from the live config (every trigger, not a typed
+    list), so it cannot be weakened by deleting the row that broke, and a
+    27th snippet is covered the day it is added. It goes RED both if the config
+    regrows such a pair without the fix and if the tie-break in `_attribute` is
+    removed — measured red at 6349a8b9 on 'acq' AND 'alo'.
+
+    ANTI-VACUITY: an empty or tiny trigger set would make this pass while
+    checking nothing, and `_attribute` returning the term itself would satisfy
+    it trivially — so pin a count floor and prove the checker can go RED, by
+    running it over a config that carries a known-bad pair.
+    """
+    live = _live_base()["matches"]
+    trigs = [m["trigger"] for m in live]
+    assert len(trigs) >= 20, f"scraper found only {len(trigs)} snippets: {trigs}"
+
+    def unresolved(base):
+        d = EspansoDetector(ET.load_triggers(base, DEFAULT))
+        bad = {}
+        for t in [m["trigger"] for m in base["matches"]]:
+            bare = t[1:] if t.startswith(":") else t
+            got = d._attribute(bare)
+            if got != t:
+                bad[bare] = (t, got,
+                             sorted(x for x in d.ts.triggers
+                                    if d._term_matches(bare, x)))
+        return bad
+
+    # NEGATIVE CONTROL: seed a snippet whose trigger is an existing one spelled
+    # WITHOUT the colon. Its bare name then names TWO snippets, so the tie-break
+    # cannot break it and `_attribute` must stay None — the one bare-name
+    # ambiguity that survives the fix, and therefore the case that proves this
+    # checker can still go red. (A plain containment pair like ':xmt'/':xmty' is
+    # NOT a valid control here: the tie-break resolves it by design, which is
+    # exactly what this guard asserts about ':acq' vs ':dacq'.)
+    seeded = {"matches": live + [
+        {"trigger": "mt", "replace": "...", "label": "seeded control",
+         "search_terms": []},
+    ]}
+    control = unresolved(seeded)
+    assert "mt" in control, (
+        "the bare-name checker failed its negative control — it did not see "
+        "'mt' naming both ':mt' and a seeded 'mt', so its zero below would "
+        "mean nothing: " + repr(control)
+    )
+
+    bad = unresolved(_live_base())
+    assert not bad, (
+        "these snippets' own names no longer attribute to them "
+        "(name -> (trigger, attributed, matching snippets)): " + repr(bad)
+    )

--- a/scripts/session-analysis/espanso-usage.py
+++ b/scripts/session-analysis/espanso-usage.py
@@ -688,8 +688,9 @@ def render_terms(fires, ts):
     out.append("")
     out.append(f"### unattributed ({unattr_total} fires over "
                f"{len(fires['unattributed'])} distinct terms)")
-    out.append("   `_attribute` returns None whenever a term matches 0 or >=2 "
-               "snippets — by design.")
+    out.append("   `_attribute` returns None whenever a term matches 0 "
+               "snippets, or >=2 with no single one NAMED outright (the term "
+               "IS that trigger, with or without the ':') — by design.")
     out.append(f"{'n':>5}  {'term':28} competing snippets (current config)")
     det = EspansoDetector(ts) if ts is not None else None
     for term, n in sorted(fires["unattributed"], key=lambda r: (-r[1], r[0])):
@@ -994,8 +995,10 @@ def lint(ts):
     🔴 EVERY finding here is about ATTRIBUTION, never about reachability.
     espanso's search UI lists EVERY match as a row and the user picks one, so a
     term matching >=2 snippets shows two rows — it does NOT fail. What breaks is
-    `_attribute`, which returns None on >=2 matches, so the fire is recorded
-    UNATTRIBUTED (`_close_search` emits the row either way). A snippet with no
+    `_attribute`, which returns None on >=2 matches unless exactly one of them
+    is NAMED outright by the term (it IS that trigger, with or without the ':';
+    2026-08-28), so the fire is recorded UNATTRIBUTED
+    (`_close_search` emits the row either way). A snippet with no
     uniquely-resolving term is therefore INVISIBLE TO THIS TOOL, not unreachable
     to the user.
 
@@ -1040,7 +1043,14 @@ def lint(ts):
             if trig not in m:
                 findings.append({"kind": "self-miss", "trigger": trig,
                                  "message": f"own term {t!r} does NOT match itself"})
-            elif len(m) == 1:
+            elif det._attribute(t) == trig:
+                # ASK THE REAL RESOLVER, don't re-derive it. This used to test
+                # `len(m) == 1`, a second copy of `_attribute`'s rule — and the
+                # two diverged on 2026-08-28 when `_attribute` gained a
+                # tie-break for a term that NAMES one of the snippets it
+                # matches. A no-op on today's config (no declared term is a bare
+                # trigger name except 'kickoff', which already matched uniquely)
+                # — the point is that it cannot drift again.
                 unique.append(t)
         if terms and not unique:
             findings.append({"kind": "unreachable", "trigger": trig,
@@ -1067,7 +1077,8 @@ def render_lint(findings, config_path):
     out = [f"## LINT — offline ATTRIBUTION check ({config_path})", "",
            "   🔴 AMBIGUOUS IS NOT DEAD. espanso lists EVERY match as a row and",
            "   the user picks one, so an ambiguous term still fires. What breaks",
-           "   is `_attribute` (None on >=2 matches), so the fire is logged",
+           "   is `_attribute` (None on >=2 matches, unless exactly one is",
+           "   NAMED outright by the term), so the fire is logged",
            "   UNATTRIBUTED — these findings are about TELEMETRY, not reach.",
            "   Fix one by changing which WORDS a snippet spells. NEVER by",
            "   removing its label: espanso then shows the raw expansion as the",

--- a/scripts/session-analysis/tests/test_espanso_usage.py
+++ b/scripts/session-analysis/tests/test_espanso_usage.py
@@ -566,6 +566,32 @@ def test_lint_flags_a_trigger_that_is_a_prefix_of_another():
     assert "prefix" in _kinds(findings)
 
 
+def test_lint_uniqueness_is_the_detectors_own_attribute_rule():
+    """`unique` must ask `_attribute`, not re-derive it as `len(matches) == 1`.
+
+    Two snippets whose triggers CONTAIN one another (the 2026-08-28 ':acq' /
+    ':dacq' split) plus a search_term equal to the shorter one's bare name. That
+    term matches BOTH snippets, so the old `len(m) == 1` copy of the rule saw no
+    unique term and reported ':acq' unreachable — while `_attribute` resolves it
+    outright. RED before the consolidation: 'unreachable' was in the kinds.
+    """
+    # Every OTHER declared term of ':acq' is deliberately shared with ':dacq',
+    # so the bare name is its ONLY resolving term — otherwise the snippet has a
+    # unique term anyway and the test passes on the old rule too (measured: the
+    # first version of this fixture did exactly that and was green at base).
+    acq = {"trigger": ":acq", "replace": "ask clarifying questions",
+           "label": "dispatch scope", "search_terms": ["acq"]}
+    dacq = {"trigger": ":dacq", "replace": "dispatch subagent",
+            "label": "dispatch scope extra", "search_terms": ["dispatch"]}
+    findings = M.lint(_ts([acq, dacq]))
+    unreachable = {f["trigger"] for f in findings if f["kind"] == "unreachable"}
+    assert ":acq" not in unreachable, findings
+    # ...and the term is still REPORTED as ambiguous, because it does list two
+    # picker rows. Resolution and reachability stay separate questions.
+    assert any(f["kind"] == "ambiguous" and "'acq'" in f["message"]
+               for f in findings), findings
+
+
 def test_lint_uses_the_detectors_own_label_tokenizer():
     """A hyphenated label word must not be reported as a self-miss: the detector
     splits the label on non-alphanumerics, so 'homelab-talos' is never a token."""


### PR DESCRIPTION
## The defect

`acq` resolves **AMBIGUOUS** and every such espanso fire is recorded **UNATTRIBUTED** — live on both hosts right now.

`_token_matches` tests `token in trig.lower()` — a **substring** test. After `:acq` was split into `:dacq` + `:acq`, the bare token `acq` matches BOTH (`"acq" in ":dacq"` is True), so `_attribute("acq")` returns `None`.

Measured across four trees via the test module's own `_live_base()` / `_term_matches`:

| tree | `acq` resolves to |
|---|---|
| `7aff8471` (pre-split) | `:acq`, unique |
| `4f1e4c56` (the split) | **AMBIGUOUS** `[':dacq', ':acq']` |
| `d1a9fd5e` (the fix meant to prevent this) | **still AMBIGUOUS** |
| `6349a8b9` (`origin/main` today) | **still AMBIGUOUS** |

The existing guard cannot see it. `test_live_triggers_have_no_prefix_or_suffix_collisions` tests **whole-trigger** prefix/suffix and `":dacq".endswith(":acq")` is False. That guard is *correct for the DIRECT path* (which matches on the ring's SUFFIX); it is structurally blind to the **SEARCH** path, which matches substrings anywhere. Both halves are now stated in its docstring, with a named sibling for the other half.

## The fix — structural, not a rename

`:dacq` is the operator's deliberate spelling (`d` + `acq`), so renaming it was rejected. Instead, in `_attribute`: when several snippets match and **exactly one of them is NAMED outright** by the term (the term IS that trigger, with or without the leading `:`), that one wins.

This closes the whole `:dX` / `:X` class rather than this instance. It is consulted **only on the already-ambiguous branch**, so it can never re-point a term that resolves uniquely today — verified by measurement, not by reading:

## Resolution diff (the blast radius)

Every term in `_EXISTING_RESOLUTIONS`, `_MT_TERMS`, `_AUDIT_2026_08_19_RESOLUTIONS`, `_PICKER_ROWS`, plus **every trigger bare and colon-spelled** — 101 terms over 26 triggers — dumped before and after and diffed:

```
terms compared: 101   CHANGED: 2
  'acq': None -> ':acq'
  'alo': None -> ':alo'
picker-row (_term_matches) changes: []
```

Both moves are `None -> the correct snippet`. `alo` was a **second live instance of the same defect**, not found by the brief: `alo` is a substring of `talos` in the labels of `:hlt` ("homelab-talos path") and `:cdp` ("civitai datapacket-talos path"), so it matched three snippets. It is not a pinned term anywhere, which is why it was silent.

**Zero `_term_matches` changes**, so no espanso **picker** row is added or removed — attribution and reachability stay separate questions, and `test_live_picker_rows_stay_reachable` is untouched.

Bare-trigger-name sweep before the fix: 24 of 26 already resolved to their own snippet; the two exceptions were exactly `acq` and `alo`.

## RED-at-base matrix

Run at `6349a8b9` with all the new/changed tests in place and only the two source files reverted, under `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`:

| test | at `6349a8b9` | at HEAD |
|---|---|---|
| `test_espanso_detect.py::test_bare_acq_resolves_to_acq_not_ambiguous` | **RED** `assert None == ':acq'` | green |
| `test_espanso_detect.py::test_acq_end_to_end_through_search_ui` | **RED** `EspansoEvent(trigger=None…).trigger` | green |
| `test_espanso_detect.py::test_live_bare_trigger_names_resolve_to_their_own_snippet` | **RED** `{'acq': …None…, 'alo': …None…}` | green |
| `test_espanso_detect.py::test_live_existing_resolutions_not_made_ambiguous` | **RED** (the new `("acq", ":acq")` row) | green |
| `test_espanso_detect.py::test_single_word_term_behaviour_unchanged` | **RED** `assert None == ':date'` | green |
| `test_espanso_usage.py::test_lint_uniqueness_is_the_detectors_own_attribute_rule` | **RED** `assert ':acq' not in {':acq'}` | green |

Each fails with **its own** assertion, not a neighbour's.

Four other new tests are **GREEN at base by design** — they pin what the tie-break must NOT do. They are labelled **INVARIANT GUARDS** in the source rather than counted as regression coverage: `test_acq_split_interface_words_still_resolve`, `test_naming_tiebreak_only_fires_on_the_ambiguous_branch`, `test_naming_two_triggers_at_once_stays_ambiguous`, `test_acq_split_direct_triggers_are_unaffected`, `test_naming_tiebreak_does_not_reach_the_picker`.

## Mutation sweep

Five mutants, each run with `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider` (each produced a *different* failure set, which is the evidence the mutant actually executed rather than a cached `.pyc`):

| mutant | killed by |
|---|---|
| revert `_attribute` entirely | the 5 tests above, each on its own assertion |
| `len(exact) == 1` → `if exact` | `test_naming_two_triggers_at_once_stays_ambiguous` (its whole reason to exist) |
| drop the colon-stripped form (`term == low`) | 6 tests |
| equality → substring in `_names_trigger` | 5 tests |
| tie-break accepts every candidate (`exact = list(matched)`) | 5 tests |
| remove the `len(matched) == 1` short-circuit | 12 tests — proves the short-circuit is load-bearing, i.e. the tie-break really is confined to the ambiguous branch |

## Coverage changes

- `("acq", ":acq")` and `("dacq", ":dacq")` **added** to `_EXISTING_RESOLUTIONS`. Rows added, never deleted — per the table's own ANTI-VACUITY note. Its floor was a stale `>= 20` against 24 actual rows (four added rows were unprotected); ratcheted to the real **26**, still `>=` so additions stay green and only a deletion reds.
- New live guard `test_live_bare_trigger_names_resolve_to_their_own_snippet` — the SEARCH-path sibling of the collision guard. Its expectation is **derived from `nix/home.nix`**, not a typed list, so it cannot be weakened by deleting the row that broke and a 27th snippet is covered the day it is added. It carries a **negative control** (seed a trigger spelling an existing one without the colon, so the term names two snippets and the tie-break cannot rescue it) — asserted to fire before the real zero is read.
- `test_search_fuzzy_multiple_match_is_ambiguous` and `test_focus_steal_ambiguous_term_still_emits_trigger_none` switched their ambiguity vehicle from `"date"` to `"dat"`, which matches `:date` + `:datetime` and **names neither**. Their subject (emit the row with `trigger=None`) is unchanged; only the fixture term moved.
- `test_single_word_term_behaviour_unchanged` now pins `_attribute("date") == ":date"` (was `is None`) with the reason inline, plus `_attribute("dat") is None` as the retained ambiguity case. Its comment no longer claims more than it checks. This is the one hermetic-fixture outcome that moved; it cannot arise on the live config, where the prefix/suffix guard forbids a `:date`/`:datetime` pair.

## Second-order: `espanso-usage.py`

Three prose claims that the implementation now contradicts were corrected — two of them are printed **into the audit report**, not just comments (`render_terms`, `render_lint`, and `lint()`'s docstring): "`_attribute` returns None on >=2 matches" is no longer true unconditionally.

`lint()`'s uniqueness test was a **second copy** of `_attribute`'s rule (`len(m) == 1`) and had just diverged from it. Consolidated onto `det._attribute(t) == trig`. Verified a **no-op on today's config**: `declared_terms` is search_terms + label words, and the only one that is also a bare trigger name is `kickoff`, which already matched uniquely. The new test isolates the divergence with a fixture where the bare name is the snippet's *only* resolving term.

## What was run

Local, dev-host tier, base `6349a8b9`, via `nix develop ~/workspace/devrc -c python3 -m pytest … -q -p no:cacheprovider`:

- `scripts/collector/keylog/tests/` — **93 passed**
- `scripts/session-analysis/tests/` — **491 passed**
- `scripts/tests/` (repo-wide guards, `--deselect test_subsystem_store_api.py` for its known flaky race) — see the comment below; it was still running when this PR was opened.

The full `scripts/gate.sh` was **not** run and neither was the `nix build .#checks…` sandbox tier — both Tekton tiers are required and run on push, and they are the tier the merge is gated on. Gate the **merged** tree before merging; `strict` is false, so a green check here is a claim about this branch only.

⚠ If `scripts/tests/test_subsystem_store_api.py` fails in CI it is a known flaky race (`TestLockoutOverHTTP` / `TestTrustedProxyOverHTTP` / `TestTheActorComesFromTheTOKEN`), not this change — nothing here touches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
