### PR TITLE
fix(audit-dispatch): round 13 — the brief blamed `gh` for a repo `gh` was never asked about, and its cross-repo recipe could not be run

### DIFF
--- a/claude/skills/audit-pr/SKILL.md
+++ b/claude/skills/audit-pr/SKILL.md
@@ -14,8 +14,10 @@ Target: `$ARGUMENTS`:
 - A number → that GitHub PR (`gh pr diff <n>`, `gh pr view <n>`).
 - `current` / empty → the current branch's diff vs its base/trunk.
 - Several numbers → audit each, one subagent per PR so they don't collide. 🔴 `isolation:
-  "worktree"` worktrees the **cwd's** repo, not the PR's — for a PR in another repo have the
-  agent run `git -C <that-repo> worktree add …` itself.
+  "worktree"` worktrees the **cwd's** repo, not the PR's — for a PR in another repo run the
+  recipe the brief's WHERE TO WORK section PRINTS, never a remembered one. It is a namespaced
+  `refs/pull/<n>/head` fetch then a **detached** `worktree add`: naming the PR's head branch
+  instead fails `rc 128` in any clone that has not fetched it, and always for a fork PR.
 
 ## What to do
 

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -551,14 +551,40 @@ SECTION_DIRECTIVES = (
     # So the permission is stated POSITIVELY and everything else is refused by
     # a universal, not by an enumeration: exactly the "assert the state, never
     # a word another feature can spell" rule in `claude/RULES.md`.
+    #
+    # 🔴 ROUND 13 — AND THE RECIPE AND THIS RULE COULD NOT BOTH BE OBEYED.
+    # Round 12 left "`git worktree add` is the ONLY write … you may make"
+    # standing over a recipe that named `<the PR's head branch>`, a ref the
+    # clone only has if it has FETCHED — a write this sentence refuses.
+    # Measured on scratch repos, git 2.55.0: `worktree add <path> pr-head` in
+    # an unfetched clone is `fatal: invalid reference`, **rc 128**, and a FORK
+    # PR's branch is never in `origin` so it is rc 128 after any fetch. And
+    # `--detach` + "fetch inside the worktree", the one workaround the old
+    # wording permitted, is NOT a workaround: a linked worktree shares the
+    # clone's ref store and object store, so the fetch wrote
+    # `refs/remotes/fork/pr-head` into the CLONE and `git -C <clone> cat-file
+    # -e <sha>` returned 0. The auditor could either not run the command or
+    # comply with one sentence while violating another.
+    #
+    # The honest answer was that the rule must permit a narrowly-scoped fetch,
+    # so it says so precisely. The permission is still POSITIVE and still ends
+    # in the universal — what changed is that the set it names is now the set
+    # the recipe actually runs, which is what the guard reads it against.
     Directive(
         "own-worktree-is-writable",
-        "That worktree is YOURS: fetching and checking out inside it is fine. "
-        "In the clone you made it from, `git worktree add` is the ONLY write "
-        "this brief asks for and the ONLY one you may make — every other "
-        "command that writes there is refused, named or not, whoever made "
-        "that clone, because other sessions may be standing in it. The "
-        "no-write rule below is about every checkout you did not make.",
+        "That worktree is YOURS: checking out inside it is fine — but it is "
+        "not a separate repository. A linked worktree SHARES the clone's ref "
+        "store and object store, so a fetch run inside it writes to the clone "
+        "as well; there is no fetching into the worktree alone, and a rule "
+        "that pretended otherwise would be obeyed by a command that breaks "
+        "it. So the clone's permission is the set of writes the recipe above "
+        "actually makes, stated positively: the `fetch` into `refs/audit/`, "
+        "the detached `worktree` add, and the `worktree` remove and "
+        "`update-ref` that undo them. Those are the ONLY writes this brief "
+        "asks for and the ONLY ones you may make — every other command that "
+        "writes there is refused, named or not, whoever made that clone, "
+        "because other sessions may be standing in it. The no-write rule "
+        "below is about every checkout you did not make.",
     ),
 )
 
@@ -906,8 +932,24 @@ Facts = namedtuple(
     "pr repo title base_ref url round_no cwd_repo_dir cwd_repo_slug repo_relation "
     "worktree branch dirty prev_sha emit_from claims claims_round checklist "
     "ledger assembled_at claims_source head_check base_assumed "
-    "base_assumed_reason",
+    "base_assumed_reason repo_unknown_reason",
 )
+# 🔴 `repo_unknown_reason` — ROUND 13'S NINTH INSTANCE, AND THE THIRD IN THIS
+# EXACT FAMILY. `no_sha_reason` was `headRefOid`, `base_assumed_reason` was
+# `baseRefName`, and this one is WHICH REPOSITORY THE PR IS IN. Every one of
+# the three is the same mistake — a predicate read as a STRONGER fact than it
+# carries: `repo_relation == "unknown"` was read as "`gh` was asked and had
+# nothing", so `render_worktree_directive` offered exactly two causes (no
+# `origin` remote, else "`gh` did not report it") and had no branch for "`gh`
+# was never consulted". `--claims-file` mode consults no `gh` at all, so a run
+# in that mode with a resolvable cwd slug took the `gh` branch and the brief
+# CONTRADICTED ITSELF inside one document — THE RANGE saying "this run is
+# `--claims-file` mode, which consults no `gh`" while WHERE TO WORK said `gh`
+# was asked and did not answer. Measured at `6349a8b9`: `--round 3
+# --claims-file <f>` in a checkout WITH an `origin` remote, rc 0, silent
+# stderr, both sentences present. The remedy is the mechanism that already
+# exists twice — the branch that DECIDED the cause names it — and not a
+# second pattern.
 # 🔴 `base_assumed` — ROUND 10's SEVENTH INSTANCE, found by the sweep round 9's
 # auditor asked for and not by a finding. `base_ref` is
 # `data.get("baseRefName") or "main"`: a DEFAULT, and every site printing it
@@ -1347,12 +1389,66 @@ def render_worktree_directive(facts):
     flag whose failure mode is silent.
     """
     if facts.repo_relation == "unknown":
-        unknown_side = (
-            "this checkout has no `origin` remote to resolve a slug from"
-            if not facts.cwd_repo_slug else
-            "`gh` did not report which repository the PR lives in"
+        # 🔴 ROUND 13 — TWO BRANCHES FOR THREE CAUSES, AND THE MISSING ONE IS
+        # REACHED BY THE MODE ROUND 12 ADDED. See `repo_unknown_reason` on
+        # `Facts`: the `else` here asserted `gh` had been consulted, which is
+        # false on every `--claims-file` run. The cause is named by the branch
+        # that DECIDED it, exactly as `no_sha_reason` and `base_assumed_reason`
+        # are.
+        #
+        # 🔴 AND THE TWO SIDES ARE NOT MUTUALLY EXCLUSIVE. `repo_relation` is
+        # "unknown" when EITHER side failed to resolve, so both can be, and an
+        # `if`/`else` then reports half the answer as the whole of it.
+        unknown_sides = []
+        if not facts.cwd_repo_slug:
+            unknown_sides.append(
+                "this checkout has no `origin` remote to resolve a slug from"
+            )
+        if facts.repo == REPO_UNKNOWN:
+            unknown_sides.append(
+                facts.repo_unknown_reason
+                or "nothing this run consulted reported which repository the "
+                   "PR lives in"
+            )
+        unknown_side = "; and ".join(unknown_sides) or (
+            "the two sides of the comparison could not be resolved"
         )
-        return "\n".join([
+
+        # 🔴 ROUND 13 — AND THE COMMANDS PRESCRIBED HERE MUST MATCH THE SIDE
+        # THAT IS ACTUALLY UNKNOWN. This block used to print BOTH lookups
+        # unconditionally, including a bare
+        #
+        #     gh pr view 900 --json url          # the repo the PR lives in
+        #
+        # with no `--repo` and no stated cwd. Run in the auditor's own
+        # repository that returns THAT repository's PR #900 at rc 0 — so the
+        # one answer it can produce is "same repo", which is precisely the
+        # answer this branch exists because it cannot rule out. It is the
+        # hazard `unresolved_tip_note` closed for the `headRefOid` lookup,
+        # left unfixed one site over.
+        #
+        # `gh` cannot DISCOVER this at all — `--repo` IS the question — so it
+        # is stated as a CONFIRMATION of a candidate the operator brings, with
+        # a `<...>` fill-in that cannot run until they do.
+        answers = []
+        if facts.repo == REPO_UNKNOWN:
+            answers += [
+                f"# which repository PR #{facts.pr} is in. `gh pr view` cannot "
+                "DISCOVER this: with no `--repo`",
+                "# it resolves against whatever repository your CWD is in, and "
+                "would answer about THAT",
+                f"# repository's PR #{facts.pr}, at rc 0. Read the owner/name "
+                "off the PR's own URL, then",
+                "# confirm it here:",
+                f"gh pr view {facts.pr} --json url --repo <owner/name — this "
+                "run never learned which repository the PR is in>",
+            ]
+        if not facts.cwd_repo_slug:
+            answers += [
+                "# which repository this checkout is in:",
+                f"git -C {facts.cwd_repo_dir} remote get-url origin",
+            ]
+        lines = [
             "## WHERE TO WORK — 🔴 COULD NOT DETERMINE — decide by hand",
             "",
             "This script could not establish whether the PR is in THIS "
@@ -1373,13 +1469,22 @@ def render_worktree_directive(facts):
             "Answer it, then follow the matching directive:",
             "",
             "```",
-            f"gh pr view {facts.pr} --json url          # the repo the PR lives in",
-            f"git -C {facts.cwd_repo_dir} remote get-url origin",
+            *answers,
             "```",
-            "",
-            "Or re-run this script with `--repo owner/name` to state the PR's "
-            "repository outright.",
-        ])
+        ]
+        # 🔴 ROUND 13 — AND THIS REMEDY IS OFFERED ONLY WHERE IT WORKS.
+        # `--repo` states the PR's side; the comparison needs BOTH, so on a
+        # run whose cwd slug is the unresolved half it changes nothing and the
+        # brief was prescribing a re-run that lands in this same branch. Same
+        # class as the two findings above it: a remedy stated for a cause it
+        # does not address.
+        if facts.repo == REPO_UNKNOWN and facts.cwd_repo_slug:
+            lines += [
+                "",
+                "Or re-run this script with `--repo owner/name` to state the "
+                "PR's repository outright.",
+            ]
+        return "\n".join(lines)
     if facts.repo_relation == "cross":
         return "\n".join([
             "## WHERE TO WORK — 🔴 CROSS-REPO",
@@ -1394,11 +1499,55 @@ def render_worktree_directive(facts):
             "fails quietly — the agent either reports a briefed file missing or "
             "silently audits the wrong tree.",
             "",
-            "Create the worktree yourself, against the PR's own clone:",
+            # 🔴 ROUND 13 — THE OLD RECIPE COULD NOT BE RUN AND OBEYED AT THE
+            # SAME TIME, on the one tree in this brief whose failure lands
+            # OUTSIDE it. It was
+            #
+            #     git -C <clone> worktree add /tmp/audit-prN-rR <the PR's head branch>
+            #
+            # and `worktree add` resolves that branch name against refs the
+            # clone ALREADY has. Measured on scratch repos, git 2.55.0:
+            # `fatal: invalid reference: pr-head`, **rc 128**, whenever the
+            # clone has not fetched since the PR opened — the normal case —
+            # and the CERTAIN case for a FORK PR, whose branch is never in
+            # `origin` at all (measured: still rc 128 after a full `fetch`).
+            # The only workaround compatible with the grant below — `worktree
+            # add --detach`, then fetch INSIDE the worktree — writes into the
+            # clone regardless: a linked worktree shares the clone's ref store
+            # and object store, so `refs/remotes/fork/pr-head` appeared in the
+            # clone and `git -C <clone> cat-file -e <sha>` returned 0.
+            #
+            # So the rule had to say what it really permits. It now permits
+            # exactly these writes, and they are ADDITIVE: `refs/pull/N/head`
+            # is the PR's head as GitHub publishes it ON THE BASE REPOSITORY,
+            # so one fetch reaches a fork PR too; it lands in a private
+            # `refs/audit/` namespace nothing else reads, moving no existing
+            # ref; `--detach` creates no `refs/heads/<branch>` (which the old
+            # recipe did, and which fails rc 128 when another worktree already
+            # holds that branch); and the teardown removes both. Measured on
+            # scratch repos: the clone's ref list, HEAD, index, working tree,
+            # config and remotes were byte-identical before and after except
+            # for the one `refs/audit/` ref.
+            "Create the worktree yourself, against the PR's own clone. Every "
+            "write below is ADDITIVE — one ref in a private `refs/audit/` "
+            "namespace nothing else reads, and objects — so no existing ref, "
+            "branch, index or working tree of that clone moves. "
+            f"`refs/pull/{facts.pr}/head` is the PR's head as GitHub publishes "
+            "it on the BASE repository, which is why this reaches a FORK PR "
+            "too; naming the head BRANCH instead cannot, and fails `rc 128` "
+            "for any PR the clone has not fetched since.",
             "",
             "```",
-            f"git -C <your local clone of {facts.repo}> worktree add "
-            f"/tmp/audit-pr{facts.pr}-r{facts.round_no} <the PR's head branch>",
+            f"git -C <your local clone of {facts.repo}> fetch origin "
+            f"refs/pull/{facts.pr}/head:refs/audit/pr{facts.pr}-r{facts.round_no}",
+            f"git -C <your local clone of {facts.repo}> worktree add --detach "
+            f"/tmp/audit-pr{facts.pr}-r{facts.round_no} "
+            f"refs/audit/pr{facts.pr}-r{facts.round_no}",
+            "# when you are done, undo both:",
+            f"git -C <your local clone of {facts.repo}> worktree remove "
+            f"/tmp/audit-pr{facts.pr}-r{facts.round_no}",
+            f"git -C <your local clone of {facts.repo}> update-ref -d "
+            f"refs/audit/pr{facts.pr}-r{facts.round_no}",
             "```",
             "",
             directive("own-worktree-is-writable"),
@@ -1451,8 +1600,18 @@ TIP_PLACEHOLDER = "<the PR's head sha>"
 
 # 🔴 `facts.repo` when NOTHING answered which repository the PR lives in. A
 # sentinel and not a slug, so no command may interpolate it: `gh pr view 900
-# --repo UNKNOWN (not reported by ...)` is a shell error, not a lookup.
-REPO_UNKNOWN = "UNKNOWN (not reported by `gh`; pass --repo owner/name)"
+# --repo UNKNOWN (this run never learned ...)` is a shell error, not a lookup.
+#
+# 🔴 ROUND 13 — ITS TEXT NAMED A CAUSE, AND THE CAUSE WAS OFTEN WRONG. It read
+# "UNKNOWN (not reported by `gh`; pass --repo owner/name)", which is the same
+# false attribution as the WHERE TO WORK branch it prints inside: on a
+# `--claims-file` run nothing was ever reported by `gh` because `gh` was never
+# asked. A SENTINEL cannot know its own cause — the branch that set it does —
+# so this states only what is true of every cause, and the cause itself is
+# carried by `repo_unknown_reason`. The `--repo` hint went with it: it resolves
+# the PR's side only, so on a run whose UNRESOLVED side is the cwd's slug it
+# was advice that changes nothing.
+REPO_UNKNOWN = "UNKNOWN (this run never learned which repository the PR is in)"
 
 
 def range_tip(facts):
@@ -2645,6 +2804,16 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
             "this run is `--claims-file` mode, which consults no `gh` and so "
             "never learns the PR's `baseRefName`"
         )
+        # 🔴 ROUND 13 — THE SAME PER-CAUSE RULE, ONE FIELD OVER AGAIN, and the
+        # THIRD time this family has been fixed at one field and left at the
+        # next. `render_worktree_directive` said "`gh` did not report which
+        # repository the PR lives in" for a run that never consulted `gh`, in
+        # a brief whose RANGE section says so two headings away.
+        repo_unknown_reason = (
+            "this run is `--claims-file` mode, which consults no `gh` and so "
+            "never learns which repository the PR lives in — and neither "
+            "`--repo` nor a PR url supplied it"
+        )
     else:
         data, comment_texts = gh_pr_facts(runner, args.pr, args.repo)
         claims_source = f"PR #{args.pr}'s comments"
@@ -2655,6 +2824,10 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
         base_assumed_reason = (
             "`gh pr view` was consulted and reported no `baseRefName` for "
             "this PR"
+        )
+        repo_unknown_reason = (
+            "`gh pr view` was consulted and reported no `url` this script "
+            "could read a repository out of, and `--repo` was not passed"
         )
         if data.get("_error"):
             print(f"🔴 `gh pr view {args.pr}` failed: {data['_error']}",
@@ -2930,6 +3103,7 @@ def main(argv=None, runner=real_runner, cwd=None, stdout=None, stderr=None,
         head_check=head_check,
         base_assumed=base_assumed,
         base_assumed_reason=base_assumed_reason,
+        repo_unknown_reason=repo_unknown_reason,
     )
 
     # 🔴 THE REFUSAL'S SCOPE IS THE BRIEF, AND ONLY THE BRIEF. A refused run

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -104,7 +104,12 @@ HARNESS_REL = "scripts/tests/mutants-audit-dispatch.py"
 # COLLECTED too few. A floor that tracks the suite has to be re-derived when
 # the suite grows — the alternative is the one measured above, a number nobody
 # updated for four rounds while the thing it protects doubled.
-MIN_TESTS = 104
+#
+# 🔴 ROUND 13 RAISED IT AGAIN, 104 -> 107, at m = 112 — COUNTED from a green
+# run of the module (`112 passed`), not from adding this round's three new
+# tests to the last sentence, which is the arithmetic the paragraph above
+# records going wrong twice.
+MIN_TESTS = 107
 
 # A row may name this instead of a killer set: the mutation MUST leave the suite
 # green. See the module docstring — the clause ledger pins whole normalised
@@ -1112,6 +1117,122 @@ def the_clone_grant_reverts_to_the_enumeration(t):
         "no-write rule below is about every checkout you did not make.")(t)
 
 
+def the_unknown_repo_cause_goes_back_to_two_branches(t):
+    """Round 13's finding F1: round 12's `unknown_side`, verbatim.
+
+    The PREDICATE half. Two branches for three causes, so a `--claims-file`
+    run — which consults no `gh` — is told `gh` did not report, two headings
+    from the same brief's own sentence saying no `gh` was consulted.
+    """
+    return _swap(
+        t,
+        '        unknown_sides = []\n'
+        '        if not facts.cwd_repo_slug:\n'
+        '            unknown_sides.append(\n'
+        '                "this checkout has no `origin` remote to resolve a slug from"\n'
+        '            )\n'
+        '        if facts.repo == REPO_UNKNOWN:\n'
+        '            unknown_sides.append(\n'
+        '                facts.repo_unknown_reason\n'
+        '                or "nothing this run consulted reported which repository the "\n'
+        '                   "PR lives in"\n'
+        '            )\n'
+        '        unknown_side = "; and ".join(unknown_sides) or (\n'
+        '            "the two sides of the comparison could not be resolved"\n'
+        '        )\n',
+        '        unknown_side = (\n'
+        '            "this checkout has no `origin` remote to resolve a slug from"\n'
+        '            if not facts.cwd_repo_slug else\n'
+        '            "`gh` did not report which repository the PR lives in"\n'
+        '        )\n',
+    )
+
+
+def the_claims_file_names_the_gh_cause(t):
+    """Round 13's finding F1: the INPUT half, not the predicate.
+
+    Exactly the V24/V25 split one field over. The three-way branch can be
+    correct while the reason the `--claims-file` branch hands it is the `gh`
+    sentence — and then the brief says the same false thing at rc 0.
+    """
+    return _swap(
+        t,
+        '        repo_unknown_reason = (\n'
+        '            "this run is `--claims-file` mode, which consults no `gh` and so "\n'
+        '            "never learns which repository the PR lives in — and neither "\n'
+        '            "`--repo` nor a PR url supplied it"\n'
+        '        )\n',
+        '        repo_unknown_reason = (\n'
+        '            "`gh pr view` was consulted and reported no `url` this script "\n'
+        '            "could read a repository out of, and `--repo` was not passed"\n'
+        '        )\n',
+    )
+
+
+def the_repo_lookup_drops_repo_again(t):
+    """Round 13's finding F1, sibling: round 12's bare `gh pr view`.
+
+    Run in the auditor's own repository it returns THAT repository's PR of the
+    same number, at rc 0 — so the one answer it can produce is the "same repo"
+    the section it sits in exists because it cannot rule out.
+    """
+    return _swap(
+        t,
+        '                f"gh pr view {facts.pr} --json url --repo <owner/name — this "\n'
+        '                "run never learned which repository the PR is in>",\n',
+        '                f"gh pr view {facts.pr} --json url",\n',
+    )
+
+
+def the_recipe_goes_back_to_naming_the_head_branch(t):
+    """Round 13's finding F2: round 12's recipe, verbatim.
+
+    `worktree add` resolves `<the PR's head branch>` against refs the clone
+    already has, and putting it there is a `fetch` the grant refuses.
+    Measured on scratch repos, git 2.55.0: rc 128 for an unfetched clone, and
+    rc 128 for a FORK PR after any fetch.
+    """
+    return _swap(
+        t,
+        '            "```",\n'
+        '            f"git -C <your local clone of {facts.repo}> fetch origin "\n'
+        '            f"refs/pull/{facts.pr}/head:refs/audit/pr{facts.pr}-r{facts.round_no}",\n'
+        '            f"git -C <your local clone of {facts.repo}> worktree add --detach "\n'
+        '            f"/tmp/audit-pr{facts.pr}-r{facts.round_no} "\n'
+        '            f"refs/audit/pr{facts.pr}-r{facts.round_no}",\n'
+        '            "# when you are done, undo both:",\n'
+        '            f"git -C <your local clone of {facts.repo}> worktree remove "\n'
+        '            f"/tmp/audit-pr{facts.pr}-r{facts.round_no}",\n'
+        '            f"git -C <your local clone of {facts.repo}> update-ref -d "\n'
+        '            f"refs/audit/pr{facts.pr}-r{facts.round_no}",\n'
+        '            "```",\n',
+        '            "```",\n'
+        '            f"git -C <your local clone of {facts.repo}> worktree add "\n'
+        '            f"/tmp/audit-pr{facts.pr}-r{facts.round_no} <the PR\'s head branch>",\n'
+        '            "```",\n',
+    )
+
+
+def the_clone_grant_respells_the_enumeration(t):
+    """Round 13's finding F4, and it is the mutant the OLD probe could not see.
+
+    Measured at `6349a8b9`: re-spelling round 10's `do not …, … or … there` as
+    `never …, … or … in that clone` left the whole 109-test suite GREEN. The
+    closed list is back — `remote update`, `switch`, `restore`, `reset`,
+    `branch -f`, `gc` permitted by omission — and only the whole-string ledger
+    saw the reword at all, which says nothing about the hazard. The verb-SET
+    relationship is what kills it now.
+    """
+    return reword_entry(
+        "Directive", "own-worktree-is-writable",
+        "That worktree is YOURS: fetching and checking out inside it is fine. "
+        "In the clone you made it from, `git worktree add` is the ONLY write "
+        "this brief asks for and the ONLY one you may make — never `fetch`, "
+        "`pull` or `checkout` in that clone, whoever made it, because other "
+        "sessions may be standing in it. The no-write rule below is about "
+        "every checkout you did not make.")(t)
+
+
 def the_claims_file_hardcodes_the_base_ref(t):
     """Round 12's finding: `--claims-file` mode asserting a base it never read.
 
@@ -1195,6 +1316,32 @@ def a_third_prescription_site_nothing_drives(t):
         '            f"  Fix: run `audit-dispatch.py {args.pr} --round 1 "\n'
         '            "--emit-claims --audited <sha>`.",\n'
         "            file=err_stream,\n"
+        "        )\n"
+        "        print(\n",
+    )
+
+
+def a_third_prescription_site_written_through_err_stream(t):
+    """🔴 ROUND 13 — V29's MUTATION IN THE SPELLING THE SCANNER COULD NOT SEE.
+
+    Same planted third prescription, same unreached branch — but written
+    `err_stream.write(...)` instead of `print(..., file=err_stream)`. Round
+    12's `prescription_sites` matched `ast.Call` whose func is the NAME
+    `print`, so an `Attribute` func fell straight out of the set and this
+    mutant SURVIVED a green 109-test suite, while the guard's docstring went
+    on calling itself a class guard. The scanner reads every call now.
+
+    It is deliberately the SAME defect as V29, differing only in the API used
+    to print it — which is the whole finding: the hazard is the unrun
+    prescription, never the function that emitted it.
+    """
+    return _swap(
+        t,
+        "    if args.audited and not args.emit_claims:\n        print(\n",
+        "    if args.audited and not args.emit_claims:\n"
+        "        err_stream.write(\n"
+        '            f"  Fix: run `audit-dispatch.py {args.pr} --round 1 "\n'
+        '            "--emit-claims --audited <sha>`.\\n"\n'
         "        )\n"
         "        print(\n",
     )
@@ -1394,6 +1541,13 @@ ROWS = [
       # that PROVES the fork case rides the same decision as the others — the
       # fixture used to encode a model in which it did not.
       "test_a_fork_pr_against_this_repo_is_not_treated_as_cross_repo",
+      # 🔴 ROUND 13 — ONE MORE, and the SAME coupling as the two below rather
+      # than a new one: the recipe guard reads the `cross-repo` scenario's
+      # WHERE TO WORK section, and the inversion sends that scenario down the
+      # SAME-repo branch, which renders no recipe at all. It fires on the
+      # guard's own "asserting over nothing" assertion, which is the answer
+      # that assertion exists to give.
+      "test_the_cross_repo_recipe_can_actually_be_run",
       # 🔴 TWO MORE IN ROUND 4, and both are real couplings rather than a row
       # gone vague. `own-worktree-is-writable` is rendered ONLY by the
       # cross-repo branch, so inverting the decision means the cross-repo
@@ -1564,12 +1718,24 @@ ROWS = [
      {"test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout",
       "test_the_toolchain_section_names_the_tier_the_merge_gates_on"},
      nix_build_points_at_the_shared_checkout),
+    # 🔴 ROUND 13 WIDENED BOTH KILLER SETS, and both additions are real
+    # couplings. Round 13's `unknown-repo-gh-said-nothing` scenario is a `gh`
+    # payload with NO `url` and `isCrossRepository` TRUE — precisely the fork
+    # shape P1 mutates — so under P1 the head fields answer, the repo becomes
+    # KNOWN, and the unknown branch that guard reads is never rendered. Under
+    # P2 the same scenario collapses into same-repo for the same effect. Both
+    # fire on the "COULD NOT DETERMINE is not in this section" assertion, i.e.
+    # the guard reporting that it was pointed at the wrong section — which is
+    # what that assertion is for. Listed in full rather than trimmed, the same
+    # treatment C3, Y2, V4, V21 and V33 get.
     ("P1  pr_slug reads the HEAD repo again",
      {"test_a_fork_pr_against_this_repo_is_not_treated_as_cross_repo",
-      "test_the_prs_repo_is_read_from_the_url_not_from_the_head_repo"},
+      "test_the_prs_repo_is_read_from_the_url_not_from_the_head_repo",
+      "test_no_brief_blames_gh_for_a_repo_gh_was_never_asked_about"},
      pr_slug_reads_the_head_repo),
     ("P2  'cannot determine' collapses to same-repo",
-     {"test_an_undeterminable_repo_gets_its_own_branch_not_the_same_repo_one"},
+     {"test_an_undeterminable_repo_gets_its_own_branch_not_the_same_repo_one",
+      "test_no_brief_blames_gh_for_a_repo_gh_was_never_asked_about"},
      unknown_repo_collapses_to_same),
     ("K1  --check always reports clean",
      {"test_the_clause_check_runs_over_a_file_that_can_actually_be_lossy"},
@@ -2107,6 +2273,44 @@ ROWS = [
     ("V29 a THIRD prescription site nothing drives",
      {"test_every_command_a_refusal_prescribes_actually_runs"},
      a_third_prescription_site_nothing_drives),
+    # 🔴 ROUND 13. V30 and V31 are the SAME split as V24/V25 one field over:
+    # the PREDICATE that picks a cause, and the INPUT it picks from. Only the
+    # second reaches a tree whose three-way branch is already correct, which is
+    # the state a fix that stopped at `render_worktree_directive` would leave.
+    ("V30 the unknown-repo cause reverts to two branches for three causes",
+     {"test_no_brief_blames_gh_for_a_repo_gh_was_never_asked_about"},
+     the_unknown_repo_cause_goes_back_to_two_branches),
+    ("V31 `--claims-file` hands over the `gh` cause it cannot have",
+     {"test_no_brief_blames_gh_for_a_repo_gh_was_never_asked_about"},
+     the_claims_file_names_the_gh_cause),
+    ("V32 the repo lookup drops `--repo` again",
+     {"test_no_gh_pr_view_this_script_prescribes_omits_repo"},
+     the_repo_lookup_drops_repo_again),
+    # 🔴 V33's killer set is TWO, and the width IS the coupling. Reverting the
+    # recipe makes it unrunnable (its own guard) AND leaves the grant naming
+    # `fetch` and `update-ref` that the recipe no longer runs — which is the
+    # grant/recipe relationship, firing from the other side. Listed in full
+    # rather than trimmed, the same treatment V21 and V22 get.
+    ("V33 the cross-repo recipe names the PR's head BRANCH again",
+     {"test_the_cross_repo_recipe_can_actually_be_run",
+      "test_the_clone_grant_covers_only_the_write_the_recipe_makes"},
+     the_recipe_goes_back_to_naming_the_head_branch),
+    # 🔴 V34 IS THE ROW THAT MEASURED FINDING F4. Run against `6349a8b9` it
+    # SURVIVED a fully green 109-test suite: the old probe matched the literal
+    # `do not …, … or … there` and this re-spelling walks straight past it,
+    # while every presence pin stays green. Same shape as V28 — restoring a
+    # reworded directive necessarily moves the whole-string ledger too — but
+    # the row's own reason is the verb-SET check, which is what replaced the
+    # spelled one.
+    ("V34 the clone grant re-spells the closed verb list",
+     {"test_the_clone_grant_covers_only_the_write_the_recipe_makes",
+      "test_each_section_directive_carries_the_instruction_its_ledger_entry_names"},
+     the_clone_grant_respells_the_enumeration),
+    # 🔴 V35 IS V29 IN A DIFFERENT SPELLING, and that is the entire point: it
+    # SURVIVED at `6349a8b9` because the scanner matched `print` by NAME.
+    ("V35 a third prescription site written through `err_stream.write`",
+     {"test_every_command_a_refusal_prescribes_actually_runs"},
+     a_third_prescription_site_written_through_err_stream),
 ]
 
 

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -481,6 +481,17 @@ implementation" failure. The deletion detectors are the ledger tests.
    a wrong `gh --json` field name, or a `git` flag this host's version does not
    have, is out of scope — the seam is tested, not the tools behind it. That is
    deliberate (hermetic), and it is a real blind spot, not a covered one.
+
+   🔴 ROUND 13 PAID FOR IT ONCE. Finding F2 — the cross-repo recipe fails
+   `rc 128` in a clone that has not fetched the PR's branch, and ALWAYS for a
+   fork PR — is exactly a fact about real `git`, and no test here could have
+   seen it. `test_the_cross_repo_recipe_can_actually_be_run` pins the
+   RELATIONSHIP that made it possible (a ref `worktree add` resolves must be
+   one the recipe itself created), which IS machine-readable; the rc-128
+   measurements, and the verification that the replacement recipe runs on a
+   real fork-PR clone and leaves it byte-identical bar one `refs/audit/` ref,
+   were made by hand and recorded in the fix commit. Read the pin as covering
+   the shape, never the tool.
 4. **It does not check that the classification a human writes is CORRECT.** The
    script deliberately refuses to classify payload vs scaffolding; nothing
    mechanical can grade the answer.
@@ -1342,13 +1353,31 @@ DIRECTIVE_LEDGER = {
     # present before `worktree add` — was unenumerated, and so were `switch`,
     # `restore`, `reset`, `branch -f` and `gc`. The permission is now stated
     # positively with a universal refusal after it.
+    #
+    # 🔴 ROUND 13. The grant and the recipe it covers could not BOTH be obeyed.
+    # `worktree add <the PR's head branch>` resolves a ref the clone only has
+    # after a FETCH, and this sentence refused every write but `worktree add` —
+    # measured rc 128 on scratch repos for an unfetched clone, and rc 128 for a
+    # FORK PR after any fetch, because that branch is never in `origin`. The
+    # one compliant workaround (`--detach`, then fetch inside the worktree)
+    # writes into the clone anyway: a linked worktree shares the clone's ref
+    # store and object store. So the recipe changed to a namespaced, additive
+    # `refs/pull/<n>/head` fetch plus a DETACHED add, and this grant now names
+    # that set. Still positive, still ending in the universal.
     "own-worktree-is-writable": (
-        "That worktree is YOURS: fetching and checking out inside it is fine. "
-        "In the clone you made it from, `git worktree add` is the ONLY write "
-        "this brief asks for and the ONLY one you may make — every other "
-        "command that writes there is refused, named or not, whoever made "
-        "that clone, because other sessions may be standing in it. The "
-        "no-write rule below is about every checkout you did not make."
+        "That worktree is YOURS: checking out inside it is fine — but it is "
+        "not a separate repository. A linked worktree SHARES the clone's ref "
+        "store and object store, so a fetch run inside it writes to the clone "
+        "as well; there is no fetching into the worktree alone, and a rule "
+        "that pretended otherwise would be obeyed by a command that breaks "
+        "it. So the clone's permission is the set of writes the recipe above "
+        "actually makes, stated positively: the `fetch` into `refs/audit/`, "
+        "the detached `worktree` add, and the `worktree` remove and "
+        "`update-ref` that undo them. Those are the ONLY writes this brief "
+        "asks for and the ONLY ones you may make — every other command that "
+        "writes there is refused, named or not, whoever made that clone, "
+        "because other sessions may be standing in it. The no-write rule "
+        "below is about every checkout you did not make."
     ),
 }
 
@@ -1507,6 +1536,21 @@ SCENARIO_RUNS = {
     "claims-file-assumed-base": lambda: (
         ["900", "--round", "3", "--claims-file", str(CLAIMS_FILE)],
         {},
+    ),
+    # 🔴 ROUND 13 — THE OTHER SIDE OF `repo_unknown_reason`, so its guard is
+    # not "delete the `gh` sentence". `gh` IS consulted here and genuinely
+    # reports nothing this script can read a repository out of: no `url`, and
+    # `isCrossRepository` true, so the head fields are the FORK's and
+    # `pr_slug` refuses to answer from them. `repo_relation` is "unknown" for
+    # a reason that IS about `gh`, and the brief must say so.
+    #
+    # `claims-file-assumed-base` above is the OPPOSITE cause and needed no new
+    # scenario: round 12 added it, and it was already rendering the WHERE TO
+    # WORK contradiction this round found — `gh` blamed by a run that consults
+    # no `gh`, at rc 0, with the truth two headings away in THE RANGE.
+    "unknown-repo-gh-said-nothing": lambda: (
+        ["900"],
+        {"pr": dict(DEFAULT_PR, url="", isCrossRepository=True)},
     ),
 }
 SCENARIOS = tuple(SCENARIO_RUNS)
@@ -2162,8 +2206,200 @@ def test_an_undeterminable_repo_gets_its_own_branch_not_the_same_repo_one():
         "\n\nthe brief asserted the PR is in this session's repository — the "
         "self-contradicting claim this branch exists to stop"
     )
-    assert "--repo owner/name" in out, (
-        "the branch does not tell the operator how to answer the question"
+    # 🔴 ROUND 13 CHANGED WHICH REMEDY THIS ASSERTS, and the old one was the
+    # finding. It pinned "`--repo owner/name`" — but this run's unresolved half
+    # is the CWD's slug, and `--repo` states the PR's. `repo_relation` needs
+    # BOTH, so re-running with `--repo` lands in this exact branch again: a
+    # remedy prescribed for a cause it cannot address, the same class as the
+    # false `gh` attribution two guards below. What answers THIS run's question
+    # is the origin lookup, so that is what the brief now offers and what this
+    # pins.
+    assert f"git -C {FAKE_REPO_DIR} remote get-url origin" in out, (
+        "the branch does not tell the operator how to answer the question it "
+        "could not answer — which side is unresolved here is the CWD's slug"
+    )
+    assert "`--repo owner/name` to state" not in out, (
+        "\n\nthe brief offers `--repo owner/name` as the remedy for a run "
+        "whose unresolved half is the CWD's slug. `--repo` states the PR's "
+        "side; the comparison needs both, so that re-run lands right back in "
+        "this branch."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 ROUND 13 — THE NINTH INSTANCE OF ONE MISTAKE, AND THE THIRD IN ITS FAMILY
+# --------------------------------------------------------------------------- #
+# A predicate read as a STRONGER fact than it carries. `headRefOid` (round 10),
+# `baseRefName` (round 12), and now WHICH REPOSITORY THE PR IS IN: the brief
+# said "`gh` did not report which repository the PR lives in" for a run that
+# consults no `gh` at all, two headings from its own sentence saying so.
+#
+# The two probes below are deliberately different shapes. The first reads the
+# CAUSE the brief states and drives BOTH causes, so its fix cannot be "delete
+# the `gh` sentence". The second is a CLASS guard over every scenario: no
+# `gh pr view` this script hands an auditor may omit `--repo`, whatever section
+# prints it.
+
+def where_to_work_section(brief):
+    """The WHERE TO WORK block alone, sliced off the next `## ` heading."""
+    start = brief.index("## WHERE TO WORK")
+    rest = brief[start + len("## WHERE TO WORK"):]
+    nxt = rest.find("\n## ")
+    return brief[start:start + len("## WHERE TO WORK")
+                 + (nxt if nxt != -1 else len(rest))]
+
+
+# 🔴 EVERY WAY THIS SECTION CAN ATTRIBUTE THE UNKNOWN TO `gh`. Not one phrase:
+# the defect had TWO spellings in one section — the branch sentence ("`gh` did
+# not report which repository the PR lives in") and the `REPO_UNKNOWN` sentinel
+# printed three lines under it ("UNKNOWN (not reported by `gh`; …)") — and a
+# guard on either alone is satisfied while the other still lies.
+_BLAMES_GH = re.compile(
+    r"reported by `gh`"
+    r"|`gh[^`]*` (?:was consulted|did not report)"
+    r"|`gh[^`]*`[^.]*? reported no"
+)
+
+# The literal cause the `--claims-file` branch owns. Every OTHER section of the
+# same brief already spells this for `headRefOid` and `baseRefName`; the point
+# is that WHERE TO WORK now agrees with them.
+CLAIMS_FILE_CAUSE = "consults no `gh`"
+
+
+def test_no_brief_blames_gh_for_a_repo_gh_was_never_asked_about():
+    """🔴 REGRESSION. Red at `6349a8b9`, scenario `claims-file-assumed-base`.
+
+    `render_worktree_directive` had TWO branches for the unknown state — no
+    `origin` remote, else "`gh` did not report which repository the PR lives
+    in" — and no third for "`gh` was never consulted". `--claims-file` mode
+    with a resolvable cwd slug therefore took the `gh` branch, and round 12's
+    own new scenario rendered a brief that CONTRADICTS ITSELF: THE RANGE says
+    "this run is `--claims-file` mode, which consults no `gh`" while WHERE TO
+    WORK says `gh` was asked and did not answer. Measured at that base with a
+    real checkout: rc 0, silent stderr.
+
+    Both causes are driven. A guard that only checked the claims-file side
+    would be satisfied by deleting the `gh` sentence outright, which would
+    make the brief silent about a cause that is real and common.
+    """
+    where = where_to_work_section(brief_for_scenario("claims-file-assumed-base"))
+    assert "COULD NOT DETERMINE" in where, (
+        f"\n\nthe scenario stopped rendering the unknown branch, so this "
+        f"guard is asserting over the wrong section:\n{where}"
+    )
+    assert not _BLAMES_GH.search(where), (
+        "\n\nWHERE TO WORK blames `gh` for not reporting the PR's repository "
+        "in a run that consulted no `gh`. The same brief says so itself two "
+        "headings away — one document, two contradictory statements, at rc 0 "
+        f"and with silent stderr.\n{where}"
+    )
+    assert CLAIMS_FILE_CAUSE in where, (
+        "\n\nWHERE TO WORK does not name the cause this run actually has. "
+        "The branch that DECIDED not to consult `gh` is the one that knows "
+        "why, exactly as `no_sha_reason` and `base_assumed_reason` are set "
+        f"there.\n{where}"
+    )
+
+    # 🔴 THE OTHER SIDE, so the fix is not "delete the sentence". Here `gh`
+    # really was consulted and really reported nothing readable.
+    where = where_to_work_section(
+        brief_for_scenario("unknown-repo-gh-said-nothing")
+    )
+    assert "COULD NOT DETERMINE" in where, (
+        f"\n\nthe `gh`-was-asked scenario no longer reaches the unknown "
+        f"branch:\n{where}"
+    )
+    assert _BLAMES_GH.search(where), (
+        "\n\nWHERE TO WORK stopped naming `gh` even for a run that DID "
+        "consult it and got nothing back. That is the real cause here, and "
+        "a brief that will not name it sends the operator looking at the "
+        f"wrong thing.\n{where}"
+    )
+    assert CLAIMS_FILE_CAUSE not in where, (
+        "\n\nthe `gh` scenario now claims to be `--claims-file` mode: the "
+        f"per-cause reason is stuck on one value.\n{where}"
+    )
+
+
+# 🔴 EVERY `gh pr view` THIS SCRIPT HANDS OVER, wherever it prints one. Round
+# 12 fixed exactly one site (`unresolved_tip_note`'s `headRefOid` lookup) and
+# left the sibling in WHERE TO WORK — so this reads the class, not the site.
+#
+# 🔴 THE PR NUMBER IS THE DISCRIMINATOR, and it is a real one rather than a
+# convenience. A COMMAND the auditor is meant to run names the PR
+# (`gh pr view 900 --json url`); a PROVENANCE sentence names only the API the
+# script itself read a field from ("read from `gh pr view --json headRefOid`")
+# and is not something anyone types. Requiring `--repo` on the second would be
+# a fix to prose that never runs — the "widen the implementation to the
+# sentence, but no wider" half of `claude/RULES.md` -> guards-narrower. The
+# NEGATIVE control below pins that both readings are live.
+_GH_PR_VIEW = re.compile(r"gh pr view \d+[^\n`]*")
+
+# A provenance mention, verbatim from THE LEDGER's cross-repo hand-over. It
+# must NOT be flagged: it is not a command.
+PROVENANCE_GH_MENTION = (
+    "read from `gh pr view --json headRefOid`, not resolved in any tree"
+)
+
+# The bare lookup round 12 left in place: run in the auditor's own repository
+# it returns THAT repository's PR #900 at rc 0, so the only answer it can ever
+# produce is "same repo" — the answer the section it sits in exists because it
+# cannot rule out.
+ROUND_12_UNQUALIFIED_LOOKUP = (
+    "gh pr view 900 --json url          # the repo the PR lives in"
+)
+
+
+def unqualified_gh_lookups_in(text):
+    return [c for c in _GH_PR_VIEW.findall(text) if "--repo" not in c]
+
+
+def test_no_gh_pr_view_this_script_prescribes_omits_repo():
+    """🔴 REGRESSION. Red at `6349a8b9`, scenario `claims-file-assumed-base`.
+
+    `gh pr view <n> --json <field>` with no `--repo` resolves against whatever
+    repository the auditor's CWD is in. Every brief that prints one has ALSO
+    just told them their CWD may be — or definitely is — a different
+    repository from the PR's, so the command returns another project's PR
+    #<n>, at rc 0, and reads as confirmation.
+
+    Round 12 closed this for the `headRefOid` lookup and wrote a paragraph
+    explaining why; the `--json url` lookup one section over kept the bare
+    form. So this guard is over the CLASS and over every scenario, rather than
+    over the one site a finding was filed against — `claude/RULES.md` ->
+    guards-narrower.
+    """
+    assert unqualified_gh_lookups_in(ROUND_12_UNQUALIFIED_LOOKUP), (
+        "POSITIVE CONTROL: the probe cannot see round 12's own bare lookup, "
+        "so a clean result below would say nothing at all"
+    )
+    # 🔴 NEGATIVE CONTROL, and it is not decoration: without it the cheapest
+    # way to green this guard is to bolt `--repo` onto a PROVENANCE sentence
+    # nobody runs, which fixes nothing and makes the next reader think the
+    # class is covered.
+    assert not unqualified_gh_lookups_in(PROVENANCE_GH_MENTION), (
+        "NEGATIVE CONTROL: the probe flags a sentence describing where the "
+        "script read a field, not a command anyone types. Widened that far it "
+        "demands `--repo` on prose and stops meaning anything."
+    )
+    seen = 0
+    for scenario in SCENARIOS:
+        brief = brief_for_scenario(scenario)
+        found = _GH_PR_VIEW.findall(brief)
+        seen += len(found)
+        bare = unqualified_gh_lookups_in(brief)
+        assert not bare, (
+            f"\n\nscenario {scenario!r} hands the auditor a `gh pr view` with "
+            f"no `--repo`: {bare}\n"
+            "  It resolves against their CWD's repository, returns that "
+            "project's PR of the same number at rc 0, and the one answer it "
+            "can produce is the 'same repo' this brief cannot rule out."
+        )
+    # 🔴 A ZERO HERE IS NOT A PASS. If no scenario prints a `gh pr view` at
+    # all, the loop above proved nothing about a class it never observed.
+    assert seen, (
+        "no scenario in this module renders a `gh pr view` command, so the "
+        "sweep above is a scan wired to nothing"
     )
 
 
@@ -2878,6 +3114,7 @@ def test_the_tip_placeholder_ledger_matches_the_script():
             claims=[], claims_round=None, checklist="", ledger=None,
             assembled_at="", claims_source="", head_check=None,
             base_assumed=False, base_assumed_reason=None,
+            repo_unknown_reason=None,
         )
     ), (
         "the banner every keyed guard looks for is not what the note emits, so "
@@ -2950,8 +3187,8 @@ PRESCRIPTION_SHA = "beefcafe"
 _PRESCRIPTION_LITERAL = "`audit-dispatch.py "
 
 
-def prescription_sites():
-    """-> {(first line, last line)} of every `print()` that prescribes a re-run.
+def prescription_sites(src=None):
+    """-> {(first line, last line)} of every CALL that prescribes a re-run.
 
     🔴 ROUND 12 — READ OUT OF THE SCRIPT, NOT LISTED HERE. The guard below
     calls itself a CLASS guard ("a third refusal that prescribes a command it
@@ -2961,16 +3198,68 @@ def prescription_sites():
     reached by a different input would be prescribed, unrun, and unreported,
     while the docstring went on promising otherwise. `claude/RULES.md` ->
     guards-narrower: make the implementation as wide as the sentence.
+
+    🔴 ROUND 13 — AND ROUND 12's OWN IMPLEMENTATION WAS NARROWER THAN ITS OWN
+    SENTENCE, in exactly the shape it had just named. It matched `ast.Call`
+    whose func is the NAME `print`, so two real spellings SURVIVED a fully
+    green 109-test suite when measured: a prescription written through
+    `err_stream.write(...)` (the func is an Attribute, not a Name), and
+    `print(_CONST, file=...)` where the literal lives in a module constant so
+    the CALL's own source segment does not contain it. Coverage was complete
+    by accident — both shipping sites are bare `print()` — which is the worst
+    version of this defect, because the docstring reads as a guarantee.
+    Neither shape is exotic: the script already writes to `err_stream` by name
+    all over `main`, and it already hoists shared prose into constants
+    (`TIP_PLACEHOLDER`, `REPO_UNKNOWN`).
+
+    So the scan is over EVERY call, by two routes: the literal appearing in
+    the call's own source, or the call referencing a name bound to a string
+    that carries it. `src` is injectable so the controls below can feed it
+    both survivors — a scanner asserted to be wide, and never fed a case it
+    must catch, is the "reassuring zero" this module refuses everywhere else.
     """
-    src = SCRIPT.read_text(encoding="utf-8")
-    out = set()
-    for node in ast.walk(ast.parse(src)):
-        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
-                and node.func.id == "print"):
+    src = SCRIPT.read_text(encoding="utf-8") if src is None else src
+    tree = ast.parse(src)
+
+    carriers = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
             continue
-        if _PRESCRIPTION_LITERAL in (ast.get_source_segment(src, node) or ""):
+        if _PRESCRIPTION_LITERAL in (
+                ast.get_source_segment(src, node.value) or ""):
+            carriers |= {t.id for t in node.targets
+                         if isinstance(t, ast.Name)}
+
+    out = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        carried = carriers & {
+            n.id for n in ast.walk(node) if isinstance(n, ast.Name)
+        }
+        if carried or _PRESCRIPTION_LITERAL in (
+                ast.get_source_segment(src, node) or ""):
             out.add((node.lineno, node.end_lineno))
     return out
+
+
+# 🔴 THE TWO SPELLINGS ROUND 12's SCANNER COULD NOT SEE, measured SURVIVING a
+# green 109-test suite at `6349a8b9`. They are the controls for the widened
+# one: each MUST be found, or the docstring above is a coverage claim over an
+# implementation that does not make it.
+PRESCRIPTION_SURVIVORS = {
+    "written through `err_stream.write`, not `print`": (
+        'def f(err_stream):\n'
+        '    err_stream.write(\n'
+        '        "Fix: run `audit-dispatch.py 900 --round 1 --emit-claims`."\n'
+        '    )\n'
+    ),
+    "the literal hoisted into a module constant": (
+        'REMEDY = "Fix: run `audit-dispatch.py 900 --round 1 --emit-claims`."\n'
+        'def f(err_stream):\n'
+        '    print(REMEDY, file=err_stream)\n'
+    ),
+}
 
 
 def run_main_traced(argv, **kw):
@@ -3069,11 +3358,22 @@ def test_every_command_a_refusal_prescribes_actually_runs():
     # assertion at the foot vacuously true, which is the reassuring zero
     # `claude/RULES.md` says to feed a case that must move.
     assert sites, (
-        "no `print()` in the script prescribes an `audit-dispatch.py` re-run "
-        f"at all — {_PRESCRIPTION_LITERAL!r} matched nothing, so the coverage "
+        "no call in the script prescribes an `audit-dispatch.py` re-run at "
+        f"all — {_PRESCRIPTION_LITERAL!r} matched nothing, so the coverage "
         "assertion below would pass over an empty set. Either the remedies "
-        "moved out of `print()` or the literal changed."
+        "moved or the literal changed."
     )
+    # 🔴 ROUND 13 — AND THE SCANNER'S WIDTH IS MEASURED, NOT ASSERTED. Both
+    # spellings below SURVIVED this guard at `6349a8b9` while it matched only
+    # a bare `print()`. Feeding them here is what makes `prescription_sites`'s
+    # docstring a claim the implementation actually keeps: `claude/RULES.md`
+    # -> guards-narrower, applied to the guard that names that rule.
+    for shape, source in PRESCRIPTION_SURVIVORS.items():
+        assert prescription_sites(source), (
+            f"POSITIVE CONTROL: the scanner cannot see a prescription {shape}. "
+            "It reports a clean sweep of the sites it happens to recognise, "
+            "which is not the class its docstring names."
+        )
     reached = set()
     for name, kw in cases.items():
         rc, _out, err, executed = run_main_traced(["900", "--round", "3"], **kw)
@@ -4029,24 +4329,149 @@ ROUND_10_CLONE_GRANT = (
 # A CLOSED LIST of refused verbs — "do not `a`, `b` or `c` there". The shape
 # that leaves `remote update`, `switch`, `restore`, `reset`, `branch -f` and
 # `gc` permitted by omission.
+#
+# 🔴 ROUND 13 — THIS PROBE IS ITSELF A SPELLED GUARD, and it was measured
+# walkable. Re-spelling round 10's enumeration as "never `fetch`, `pull` or
+# `checkout` in that clone" leaves it — and the whole 109-test suite — green:
+# the enumeration is back, permitting `remote update` and `switch` by omission
+# again, and nothing sees it. It is KEPT, because a second check that fails
+# differently is worth its cost, but it is no longer the thing the guard
+# relies on: `git_verbs_named_in` below asserts the STATE (which git verbs the
+# grant names) instead of a phrase, and no rewording moves that.
 _ENUMERATED_CLONE_REFUSAL = re.compile(
     r"do not (?:`[a-z][a-z-]*`(?:, )?)+ ?or `[a-z][a-z-]*` there"
 )
 
-# The universal that replaces it: the permitted write stated positively, and
+# 🔴 ROUND 13's OWN RE-SPELLING, verbatim, as the second positive control for
+# the structural probe. Measured GREEN against the shipping suite at
+# `6349a8b9` while re-introducing the enumeration round 12 removed.
+ROUND_13_RESPELLED_ENUMERATION = (
+    "That worktree is YOURS: fetching and checking out inside it is fine. "
+    "In the clone you made it from, `git worktree add` is the ONLY write "
+    "this brief asks for and the ONLY one you may make — never `fetch`, "
+    "`pull` or `checkout` in that clone, whoever made it, because other "
+    "sessions may be standing in it. The no-write rule below is about every "
+    "checkout you did not make."
+)
+
+# The universal that replaces it: the permitted writes stated positively, and
 # everything else refused whether or not anyone thought to name it.
 CLONE_GRANT_CATCH_ALL = (
-    "the ONLY one you may make — every other command that writes there is "
+    "the ONLY ones you may make — every other command that writes there is "
     "refused, named or not"
 )
 
-# The recipe's own `git -C <clone> …` line, so the verb it runs there is read
-# and not remembered.
+# The recipe's own `git -C <clone> …` lines, so what it runs there is READ and
+# not remembered. `_CLONE_RECIPE` keeps the verb-only reading the grant/recipe
+# relationship is built on; `_CLONE_RECIPE_CMD` keeps the whole command, which
+# is what the ref-provenance probe needs.
 _CLONE_RECIPE = re.compile(r"git -C <your local clone of [^>]*> ([a-z-]+)")
+_CLONE_RECIPE_CMD = re.compile(r"^git -C <your local clone of [^>]*> (.+)$", re.M)
+
+# 🔴 ROUND 13 — ROUND 12's RECIPE LINE, verbatim, as the positive control for
+# the ref-provenance probe. It is the line that CANNOT BE RUN: `worktree add`
+# resolves `<the PR's head branch>` against refs the clone already has, and
+# nothing in the recipe puts it there. Measured on scratch repos with git
+# 2.55.0 — `fatal: invalid reference: pr-head`, rc 128, both for a clone that
+# has not fetched since the PR opened and (after a full fetch) for a FORK PR,
+# whose branch is never in `origin`.
+ROUND_12_CLONE_RECIPE = (
+    "git -C <your local clone of someone-else/otherproj> worktree add "
+    "/tmp/audit-pr900-r1 <the PR's head branch>"
+)
 
 
 def clone_write_grants_in(text):
     return [p for p in CLONE_WRITE_GRANT_PHRASES if p in text]
+
+
+def git_verbs_named_in(text):
+    """Every git SUBCOMMAND a backticked span in `text` names.
+
+    🔴 ROUND 13 — THE STATE, NOT A PHRASE. The hazard the enumeration probe
+    means to catch is "this grant names git verbs the recipe does not run",
+    and that is a fact about the SET of verbs, not about the words "do not" or
+    "never". Reading the set makes every re-spelling of a closed list fail
+    identically, which is the `claude/RULES.md` spelled-guards remedy.
+
+    A token counts when it is the first word of a backticked span (after an
+    optional leading `git`) and is not path-shaped — so `refs/audit/` and
+    `refs/pull/<n>/head` are excluded by the slash and no vocabulary of known
+    verbs is needed, which is what would re-introduce a closed list inside the
+    guard itself.
+    """
+    out = set()
+    for span in re.findall(r"`([^`]+)`", text):
+        toks = span.split()
+        if toks and toks[0] == "git":
+            toks = toks[1:]
+        if not toks:
+            continue
+        head = toks[0]
+        if "/" in head or not re.fullmatch(r"[a-z][a-z-]*", head):
+            continue
+        out.add(head)
+    return out
+
+
+def clone_recipe_commands(text):
+    """The `git -C <clone> …` commands the recipe runs, whole, in order."""
+    return [m.group(1) for m in _CLONE_RECIPE_CMD.finditer(text)]
+
+
+def _worktree_add_committish(cmd):
+    """-> what a `worktree add` line asks git to RESOLVE, or None."""
+    parts = cmd.split()
+    if parts[:2] != ["worktree", "add"]:
+        return None
+    rest = [p for p in parts[2:] if not p.startswith("--")]
+    return " ".join(rest[1:]) or None
+
+
+def unrunnable_recipe_steps(cmds):
+    """-> the reasons this recipe cannot be run as written. Empty is the pass.
+
+    🔴 THE RELATIONSHIP, not a spelling: every ref a `worktree add` resolves in
+    the clone must be one an EARLIER line of the same recipe created there.
+    Round 12's recipe named the PR's head BRANCH, which is a ref the clone only
+    has if it has fetched — and fetching there is the write the grant refuses,
+    so the recipe and the rule could not both be obeyed. A fork PR's branch is
+    not in that clone's `origin` at any point, so no permitted fetch would help
+    either.
+    """
+    created, problems = set(), []
+    for cmd in cmds:
+        parts = cmd.split()
+        if parts[:1] == ["fetch"]:
+            for p in parts[1:]:
+                if ":" in p:
+                    src, dst = p.split(":", 1)
+                    created.add(dst)
+                    if not src.startswith("refs/pull/"):
+                        problems.append(
+                            f"the fetch reads {src!r}, which is not the "
+                            "`refs/pull/<n>/head` GitHub publishes on the BASE "
+                            "repository — a fork PR's head is reachable by no "
+                            "other ref in that clone's `origin`"
+                        )
+        tip = _worktree_add_committish(cmd)
+        if tip is None:
+            continue
+        if tip not in created:
+            problems.append(
+                f"`worktree add` resolves {tip!r}, which no earlier line of "
+                "this recipe put in the clone. git answers `fatal: invalid "
+                "reference`, rc 128, unless the clone happens to have fetched "
+                "it already — and putting it there is a write the grant "
+                "refuses"
+            )
+        if "--detach" not in cmd.split():
+            problems.append(
+                "`worktree add` is not `--detach`ed, so it creates "
+                "`refs/heads/<branch>` in the SHARED clone and fails rc 128 "
+                "when another worktree already holds that branch"
+            )
+    return problems
 
 
 def test_the_clone_grant_covers_only_the_write_the_recipe_makes():
@@ -4089,26 +4514,54 @@ def test_the_clone_grant_covers_only_the_write_the_recipe_makes():
     )
     brief = brief_for_scenario("cross-repo")
     verbs = _CLONE_RECIPE.findall(brief)
-    assert verbs == ["worktree"], (
-        "\n\nWHERE TO WORK's recipe no longer runs exactly one `git -C "
-        f"<clone> …` command, or runs a different one: {verbs}. The grant "
-        "below is scoped to the write the recipe makes, so the two move "
-        "together."
+    assert verbs, (
+        "\n\nWHERE TO WORK's recipe no longer runs any `git -C <clone> …` "
+        "command, so the grant below is scoped to nothing and every check "
+        "under it is vacuous."
     )
     granted = clone_write_grants_in(brief)
     assert not granted, (
-        f"\n\nthe brief grants the auditor `fetch`/`checkout` inside the clone "
-        f"— {granted}. The recipe's only write there is `{verbs[0]} add`; "
-        "everything else is a cross-session write into a tree the brief calls "
-        "`<your local clone of owner/name>`, which on this host is a shared, "
-        "long-lived checkout.\n"
+        f"\n\nthe brief grants the auditor blanket `fetch`/`checkout` inside "
+        f"the clone — {granted}. Its writes there are {sorted(set(verbs))}, "
+        "each one narrowly scoped; a blanket grant is a cross-session write "
+        "into a tree the brief calls `<your local clone of owner/name>`, "
+        "which on this host is a shared, long-lived checkout.\n"
         + ad.DIRECTIVE["own-worktree-is-writable"]
     )
     grant = ad.DIRECTIVE["own-worktree-is-writable"]
-    assert "`git worktree add` is the ONLY write" in grant, (
-        "\n\nthe grant no longer says which single operation it covers in the "
+    assert "the ONLY writes this brief asks for" in grant, (
+        "\n\nthe grant no longer says which operations it covers in the "
         "clone, so the next reader has only 'you made it' to reason from — "
         f"which is what round 8 reasoned from.\n{grant}"
+    )
+    # 🔴 ROUND 13 — THE RELATIONSHIP, READ BOTH WAYS. The grant must name the
+    # verbs the recipe runs and NO OTHERS. Naming fewer leaves a write the
+    # brief itself asks for unpermitted (which is finding F2: `worktree add`
+    # over a ref only a forbidden `fetch` could supply). Naming more is the
+    # closed-verb-list hazard in its structural spelling — round 10's
+    # `fetch`/`pull`/`checkout` and round 13's re-wording of it both land here,
+    # because both name verbs the recipe does not run.
+    #
+    # Positive controls FIRST, and there are two, because the regex probe
+    # below could see round 10's phrasing and could NOT see round 13's.
+    for label, control in (
+        ("round 10's enumeration", ROUND_10_CLONE_GRANT),
+        ("round 13's re-spelling of it", ROUND_13_RESPELLED_ENUMERATION),
+    ):
+        assert git_verbs_named_in(control) != set(verbs), (
+            f"POSITIVE CONTROL: the verb-set probe reads {label} as agreeing "
+            "with the recipe, so a clean result below would say nothing at all"
+        )
+    assert git_verbs_named_in(grant) == set(verbs), (
+        "\n\nthe grant names git verbs the recipe does not run, or omits ones "
+        f"it does: grant {sorted(git_verbs_named_in(grant))} vs recipe "
+        f"{sorted(set(verbs))}.\n"
+        "  MORE than the recipe: a closed list of refused verbs, whatever "
+        "words wrap it — everything unnamed is permitted by omission, and "
+        "this directive is the ONLY rule covering that tree.\n"
+        "  FEWER: the brief asks for a write it does not permit, which is a "
+        "recipe the auditor can obey or run but not both.\n"
+        f"{grant}"
     )
     # 🔴 ROUND 12 — A CATCH-ALL, NOT A LONGER VERB LIST. Positive control
     # first: the probe must be able to SEE round 10's enumeration, or a clean
@@ -4128,9 +4581,78 @@ def test_the_clone_grant_covers_only_the_write_the_recipe_makes():
         f"checkout you did NOT make, and the clone is one you did.\n{grant}"
     )
     assert CLONE_GRANT_CATCH_ALL in grant, (
-        "\n\nthe grant no longer refuses everything other than the one write "
-        "it permits. A guard on words is walkable by rewording; the refusal "
+        "\n\nthe grant no longer refuses everything other than the writes it "
+        "permits. A guard on words is walkable by rewording; the refusal "
         f"here has to be a universal.\n{grant}"
+    )
+
+
+def test_the_cross_repo_recipe_can_actually_be_run():
+    """🔴 REGRESSION. Red at `6349a8b9`, scenario `cross-repo`.
+
+    Round 12's recipe was one line:
+
+        git -C <clone> worktree add /tmp/audit-pr900-r1 <the PR's head branch>
+
+    and `worktree add` resolves that branch against refs the clone ALREADY
+    has. Measured on scratch repos, git 2.55.0:
+
+      * clone has not fetched since the PR opened (the normal case)
+            -> `fatal: invalid reference: pr-head`, rc 128
+      * FORK PR, after a full `git fetch origin` (the CERTAIN case — that
+        branch is never in the base repo's `origin`)
+            -> `fatal: invalid reference: fork-pr-head`, rc 128
+
+    Putting the ref there is a `fetch` in the clone, which
+    `own-worktree-is-writable` refuses. The one workaround that wording
+    permitted — `worktree add --detach`, then fetch INSIDE the worktree — is
+    not a workaround at all: a linked worktree shares the clone's ref store
+    and object store, so the fetch wrote `refs/remotes/fork/pr-head` into the
+    CLONE, added a remote to the CLONE's config, and `git -C <clone> cat-file
+    -e <sha>` returned 0. The auditor could either not run the recipe or
+    comply with one sentence while violating another — on the ONE tree in this
+    brief whose failure lands outside it, a cross-session write into
+    `~/workspace/<repo>` while other sessions are working there.
+
+    Same class as `test_every_command_a_refusal_prescribes_actually_runs` one
+    section over: a prescription that cannot be run.
+
+    🔴 WHAT THIS DOES NOT DO is spawn git — the module is hermetic and says so
+    (blind spot 3 in its docstring). The rc-128 measurements above were made
+    by hand on real repos and are recorded in the fix commit; what this pins
+    is the RELATIONSHIP that made them possible, which is machine-readable:
+    a ref `worktree add` resolves must be one the recipe itself created.
+    """
+    # 🔴 POSITIVE CONTROL. The probe must be able to SEE round 12's line, or a
+    # clean result below is a scan wired to nothing.
+    control = unrunnable_recipe_steps(
+        clone_recipe_commands(ROUND_12_CLONE_RECIPE)
+    )
+    assert any("invalid reference" in p for p in control), (
+        "POSITIVE CONTROL: the probe does not flag round 12's own recipe, "
+        f"which is the line measured at rc 128: {control}"
+    )
+
+    brief = brief_for_scenario("cross-repo")
+    cmds = clone_recipe_commands(brief)
+    assert cmds, (
+        "\n\nWHERE TO WORK's cross-repo recipe runs no `git -C <clone> …` "
+        "command at all, so this guard is asserting over nothing"
+    )
+    assert any(c.split()[:2] == ["worktree", "add"] for c in cmds), (
+        f"\n\nthe recipe no longer creates a worktree: {cmds}. The section's "
+        "whole job is to hand a cross-repo auditor a tree to work in."
+    )
+    problems = unrunnable_recipe_steps(cmds)
+    assert not problems, (
+        "\n\nWHERE TO WORK's recipe cannot be run as written:\n  - "
+        + "\n  - ".join(problems)
+        + "\n\nThat section is the only place a cross-repo auditor is told "
+        "where to work, and the tree it names is a long-lived checkout other "
+        "sessions are standing in. A recipe that fails rc 128 sends them "
+        "looking for a verb that gets the ref there — which is exactly the "
+        "cross-session write `own-worktree-is-writable` exists to refuse.\n"
+        + "\n".join(cmds)
     )
 
 
@@ -5620,6 +6142,34 @@ RED_AT_BASE_R9: frozenset[str] = frozenset({
     "test_no_brief_states_an_assumed_base_branch_as_a_fact",
 })
 
+# 🔴 ROUND 13. Three tests, watched RED at `6349a8b9` — the tree round 12's
+# work MERGED into, which is why round 13 audited it rather than a branch. Each
+# is red there on a WRONG ANSWER, not on an absence:
+#
+#   test_no_brief_blames_gh_for_a_repo_gh_was_never_asked_about
+#       WHERE TO WORK: "`gh` did not report which repository the PR lives in"
+#       in a `--claims-file` run, whose own RANGE section two headings away
+#       says the run consults no `gh`. rc 0, silent stderr.
+#   test_no_gh_pr_view_this_script_prescribes_omits_repo
+#       the same section prescribes `gh pr view 900 --json url` with no
+#       `--repo`, which in the auditor's own repo returns THAT repo's PR #900
+#       at rc 0 — so it can only ever confirm "same repo".
+#   test_the_cross_repo_recipe_can_actually_be_run
+#       `worktree add <path> <the PR's head branch>` names a ref the clone has
+#       only if it FETCHED, and the grant beneath it refuses every write but
+#       `worktree add`. Measured rc 128 on real scratch repos, git 2.55.0.
+#
+# `test_an_undeterminable_repo_gets_its_own_branch_not_the_same_repo_one` and
+# `test_the_clone_grant_covers_only_the_write_the_recipe_makes` are NOT
+# repeated here — both were already filed at earlier refs, and both are red at
+# this one too for round 13's reasons. A test belongs to the ref it was FIRST
+# watched red at.
+RED_AT_BASE_R13: frozenset[str] = frozenset({
+    "test_no_brief_blames_gh_for_a_repo_gh_was_never_asked_about",
+    "test_no_gh_pr_view_this_script_prescribes_omits_repo",
+    "test_the_cross_repo_recipe_can_actually_be_run",
+})
+
 RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "abc41024": RED_AT_BASE_R2,
     "d9eb36a8": RED_AT_BASE_R3,
@@ -5628,6 +6178,7 @@ RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "3619fe68": RED_AT_BASE_R6,
     "28492af2": RED_AT_BASE_R7,
     "706a6b38": RED_AT_BASE_R9,
+    "6349a8b9": RED_AT_BASE_R13,
 }
 RED_AT_BASE: frozenset[str] = frozenset().union(*RED_AT_BASE_REFS.values())
 
@@ -6123,6 +6674,36 @@ FIX_MATRIX = (
      "it as a fact about the PR's repository, at rc 0",
      "test_no_brief_states_an_assumed_base_branch_as_a_fact",
      "RED@706a6b38", "V24"),
+    # 🔴 ROUND 13, audited against the MERGED tree rather than a branch.
+    ("r13/F1 the NINTH instance and the THIRD in one family: "
+     "`repo_relation == \"unknown\"` read as \"`gh` was asked and had "
+     "nothing\", so a `--claims-file` run — which consults no `gh` — rendered "
+     "a brief contradicting itself in two sections, at rc 0",
+     "test_no_brief_blames_gh_for_a_repo_gh_was_never_asked_about",
+     "RED@6349a8b9", "V30 V31"),
+    ("r13/F1' the same section prescribed `gh pr view <n> --json url` with no "
+     "`--repo`, which in the auditor's own repo answers about THAT repo's PR "
+     "of the same number at rc 0 — the hazard round 12 closed one site over",
+     "test_no_gh_pr_view_this_script_prescribes_omits_repo",
+     "RED@6349a8b9", "V32"),
+    ("r13/F2 the cross-repo recipe and its catch-all could not both be "
+     "obeyed: `worktree add <the PR's head branch>` needs a ref only a FETCH "
+     "puts in the clone, and the grant refused every write but `worktree "
+     "add`. Measured rc 128 on real repos, and certain for a fork PR",
+     "test_the_cross_repo_recipe_can_actually_be_run",
+     "RED@6349a8b9", "V33"),
+    ("r13/F3 the prescription scanner was NARROWER THAN ITS OWN DOCSTRING: it "
+     "matched `ast.Call` whose func is the NAME `print`, so a prescription "
+     "via `err_stream.write` or via a module constant SURVIVED a green suite. "
+     "Coverage was complete only by accident of both real sites being bare "
+     "`print()`",
+     "test_every_command_a_refusal_prescribes_actually_runs",
+     "RED@706a6b38", "V20 V23 V29 V35"),
+    ("r13/F4 the closed-verb-list probe was itself SPELLED — re-wording round "
+     "10's enumeration left the whole suite green. Replaced by a verb-SET "
+     "relationship read off the recipe, which no rewording moves",
+     "test_the_clone_grant_covers_only_the_write_the_recipe_makes",
+     "RED@706a6b38", "V22 V28 V34"),
 )
 
 # A COLLAPSE floor, not a growth floor: a matrix emptied by a bad refactor

--- a/scripts/tests/test_audit_ladder_stop_rule.py
+++ b/scripts/tests/test_audit_ladder_stop_rule.py
@@ -647,10 +647,23 @@ SKILL_REWORD_REGRESSION = (
 # missing, or silently audits the wrong tree. Measured: with the caveat
 # unpinned, replacing it with "use `isolation: \"worktree\"` for any repo" was
 # green.
+# 🔴 ROUND 13 REWORDED IT, and the reword is the finding rather than a shave.
+# The old sentence paraphrased the recipe as "`git -C <that-repo> worktree add
+# …`", which is a recipe that CANNOT BE RUN: `worktree add` resolves the PR's
+# head branch against refs the clone already has, so it is `fatal: invalid
+# reference`, rc 128, in any clone that has not fetched since the PR opened —
+# and unconditionally for a FORK PR, whose branch is never in that clone's
+# `origin`. Measured on real scratch repos, git 2.55.0. The generated brief
+# now prints a namespaced `refs/pull/<n>/head` fetch plus a DETACHED
+# `worktree add`, so this line stops carrying a second, stale copy of the
+# recipe and routes to the one place that owns it.
 SKILL_CROSS_REPO_WORKTREE = (
     "🔴 `isolation: \"worktree\"` worktrees the **cwd's** repo, not the PR's — "
-    "for a PR in another repo have the agent run `git -C <that-repo> worktree "
-    "add …` itself."
+    "for a PR in another repo run the recipe the brief's WHERE TO WORK section "
+    "PRINTS, never a remembered one. It is a namespaced `refs/pull/<n>/head` "
+    "fetch then a **detached** `worktree add`: naming the PR's head branch "
+    "instead fails `rc 128` in any clone that has not fetched it, and always "
+    "for a fork PR."
 )
 # 🔴 THE ROUTER TO THE ASSEMBLER. `scripts/audit-dispatch.py` exists because the
 # invariant sections of a brief were being retyped every time and MEASURABLY


### PR DESCRIPTION
fix(audit-dispatch): the brief blamed `gh` for a repo `gh` was never asked about, and its cross-repo recipe could not be run

Round 13 audited the MERGED result of #958's twelve-round ladder and found two
defects. Both are the ladder's own recurring shape.

F1 — the NINTH instance, and the THIRD in one family
----------------------------------------------------
`render_worktree_directive`'s unknown branch had exactly two causes — no
`origin` remote, else "`gh` did not report which repository the PR lives in" —
and no third for "`gh` was never consulted". `--claims-file` mode consults no
`gh`, so a run in that mode with a resolvable cwd slug took the `gh` branch and
rendered a brief CONTRADICTING ITSELF: THE RANGE says "this run is
`--claims-file` mode, which consults no `gh`" while WHERE TO WORK says `gh` was
asked and did not answer. Reproduced at `6349a8b9` in a real checkout with an
`origin` remote: rc 0, silent stderr, both sentences present. It is round 12's
own new scenario.

The same mistake as `no_sha_reason` (`headRefOid`) and `base_assumed_reason`
(`baseRefName`), one field over: a predicate read as a STRONGER fact than it
carries. Fixed with the mechanism that already exists twice — a per-cause
`repo_unknown_reason` set at BOTH `main()` branches, each text true for its own
cause. The two sides are also no longer exclusive: `repo_relation` is "unknown"
when EITHER side failed, so both are named when both did.

Three further sites in the same section, all the same class:
  * `gh pr view 900 --json url` with no `--repo` — in the auditor's own repo
    that returns THAT repo's PR #900 at rc 0, so the only answer it can produce
    is "same repo", the one this branch exists because it cannot rule out. It
    is the hazard round 12 closed for the `headRefOid` lookup, left one site
    over. `gh` cannot DISCOVER the repo (`--repo` IS the question), so it is
    now a CONFIRMATION with a `<...>` fill-in that cannot run until filled.
  * the two lookups were printed unconditionally; each now renders only for the
    side that is actually unknown.
  * "Or re-run with `--repo owner/name`" resolves the PR's side only, so on a
    run whose unresolved half is the cwd's slug it lands back in this branch.
    Offered only where it works.
  * `REPO_UNKNOWN` itself read "UNKNOWN (not reported by `gh`; …)" — a SENTINEL
    stating a cause it cannot know. It now states only what is true of every
    cause.

F2 — a recipe that could not be run and obeyed at once
-------------------------------------------------------
`own-worktree-is-writable` said `git worktree add` was "the ONLY one you may
make — every other command that writes there is refused, named or not", over a
recipe naming `<the PR's head branch>`. Measured on real scratch repos, git
2.55.0:

  * `worktree add <path> pr-head` in a clone that has not fetched since the PR
    opened -> `fatal: invalid reference: pr-head`, rc 128. The normal case.
  * a FORK PR after a full `git fetch origin` -> rc 128, because that branch is
    never in the base repo's `origin`. The certain case.
  * the only grant-compliant workaround, `worktree add --detach` then fetch
    INSIDE the worktree, writes into the clone anyway: a linked worktree shares
    the clone's ref store and object store, so `refs/remotes/fork/pr-head`
    appeared in the clone, a remote was added to the clone's config, and
    `git -C <clone> cat-file -e <sha>` returned 0.
  * the permitted `worktree add` also created `refs/heads/<branch>` in the
    shared clone, and failed rc 128 when another worktree held that branch.

So the honest answer is that the rule must permit a narrowly-scoped fetch, and
it now says so precisely rather than papering over it. The recipe is:

    git -C <clone> fetch origin refs/pull/<n>/head:refs/audit/pr<n>-r<r>
    git -C <clone> worktree add --detach /tmp/audit-pr<n>-r<r> refs/audit/pr<n>-r<r>
    git -C <clone> worktree remove /tmp/audit-pr<n>-r<r>
    git -C <clone> update-ref -d refs/audit/pr<n>-r<r>

`refs/pull/<n>/head` is the PR's head as GitHub publishes it ON THE BASE
repository (verified against this repo: `git ls-remote origin refs/pull/958/head`
-> a6a7aa4b), so one fetch reaches a fork PR. Verified end to end on a real
fork-PR scratch clone that another session was mid-work in: both steps rc 0, the
worktree lands exactly on `refs/pull/900/head`, and the clone's refs, HEAD,
index, working tree, config and remotes are unchanged except for the single
`refs/audit/` ref — which the teardown removes, restoring the clone byte for
byte. The grant names that set positively and still ends in the universal.

F3 — the prescription scanner was narrower than its own docstring
------------------------------------------------------------------
`prescription_sites()` matched `ast.Call` whose func is the NAME `print` and
whose source segment holds the literal, while calling itself a CLASS guard.
Measured: a prescription via `err_stream.write(...)`, or `print(_CONST, …)`
with the literal in a module constant, SURVIVED a fully green 109-test suite.
Coverage was complete only by accident of both real sites being bare `print()`.
It now scans every call, by the literal or by a name bound to a string carrying
it, and both survivors are fed to it as controls.

F4 — the closed-verb-list probe was itself a spelled guard
------------------------------------------------------------
Measured: re-spelling round 10's enumeration as "never `fetch`, `pull` or
`checkout` in that clone" left the whole suite green — the enumeration is back
and nothing sees it. The regex is kept as a second, differently-failing check,
but the guard now asserts the STATE: the set of git verbs the grant names must
equal the set the recipe runs in the clone, read off the recipe. Round 10's
wording and round 13's re-spelling are both positive controls.

Evidence
--------
Red at `6349a8b9` (origin/main, the merged tree), measured by carrying this
module onto the base script in a scratch tree under PYTHONDONTWRITEBYTECODE=1:

    test_no_brief_blames_gh_for_a_repo_gh_was_never_asked_about       RED
    test_no_gh_pr_view_this_script_prescribes_omits_repo              RED
    test_the_cross_repo_recipe_can_actually_be_run                    RED

each on its OWN assertion, not a collateral error. Suite: 112 passed at HEAD.

Mutation battery (`scripts/tests/mutants-audit-dispatch.py`): 111 rows, all as
expected; positive control (unmutated copy) `112 passed`. Six new rows —
V30 (the predicate reverts to two branches), V31 (the `--claims-file` INPUT
hands over the `gh` cause), V32 (`--repo` dropped again), V33 (the recipe names
the head branch again), V34 (the grant re-spells the closed list — the mutant
that SURVIVED before this round), V35 (a prescription via `err_stream.write` —
likewise). Three pre-existing rows (C3, P1, P2) gained a killer, each a real
coupling recorded in full rather than trimmed. Collapse floor re-derived by
COUNTING: 104 -> 107 at m = 112.

What is NOT covered: the rc-128 measurements are facts about real `git`, and
this module is hermetic by construction. The guard pins the RELATIONSHIP that
made them possible — a ref `worktree add` resolves must be one the recipe
itself created — and the module's blind-spot list now records that split.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
