### PR TITLE
docs(handoff): both open investigations closed — the WIP's owner was in the OTHER runtime, and "written repeatedly" was an mtime artifact

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,8 +208,14 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   analyze-service index` fixture commits on the branch (reproduced twice; task #322). At that
   moment `core.hooksPath` was set **repo-LOCALLY** to `<repo>/githooks`. Hours later, same
   session, it was unset everywhere with no action by anyone here — and `install.sh` sets the
-  key `--global`, so the `--local` value came from something else. **Neither "installed" nor
-  "uninstalled" is safe to carry in prose.** 🔴 **A pre-push gate that runs the suite IN the
+  key `--global`, so the `--local` value came from something else. **That something else is
+  now IDENTIFIED** (2026-08-28): the `civit-datapacket-talos` session
+  `5e58d9a0-0a99-4c9c-bf65-e40b403e4d55` set it at `2026-08-21T22:16:14Z` while verifying the
+  pre-push gate, and unset it itself at `2026-08-23T21:32:51Z` — so "no action by anyone here"
+  was true of *this* repo's sessions and false of the box. It explains the `githooks/`
+  sighting ONLY; the 08-20 `.git/hooks` ones remain unattributed. **Neither "installed" nor
+  "uninstalled" is safe to carry in prose**, and the attribution does not make it stable —
+  re-measure anyway. 🔴 **A pre-push gate that runs the suite IN the
   worktree can corrupt the branch it is pushing** — see #322 before using `--no-verify` to get
   past it, and re-check the branch afterwards. ⚠ **Check for a REPO-LOCAL `core.hooksPath` before installing**: `install.sh` sets the
   key `--global`, and a local one wins — observed pointing at `.git/hooks` (08-20, workbench

--- a/claudedocs/handoff-audit-pr-ladder.md
+++ b/claudedocs/handoff-audit-pr-ladder.md
@@ -137,22 +137,46 @@ findings-keyed stop rule does not terminate in the guard-hardening regime.
    not an empty harness. `date` matching `:eos`/`:roo` at all is a spurious SUBSTRING hit
    (`date` ⊂ "upd**ate**"); it costs nothing because nobody searches it.
 
-### Opened while closing the above — all blocked until `#1021` lands
-- 🔴 **`#1021` — `main` IS RED, repo-wide.** `test_live_existing_resolutions_not_made_ambiguous`
-  fails on an unmodified `origin/main` checkout: `{'ask': (':acq', None, [':dacq', ':acq'])}`.
-  The 08-28 `:acq`/`:dacq` split cleaned the label but left `"ask"` in BOTH snippets'
-  `search_terms`, so the term names neither and `#999`'s tie-break correctly declines. The
-  comment above those lines already said ":acq owns ask/clarify/questions alone" — the
-  comment was right and the data contradicted it. Measured on the real stream: attribution
-  goes **92/171 → 148/171**, recovering **56 fires** of the config's highest-traffic term.
-  **Nothing else merges until this does.**
-- **`#1015` — the store-api load flake** (see the corrected `#996` note below).
-- **`#1005` / `#1009`** — this doc and the RULES surface; both blocked on `main`.
-- ⚠ **UNEXPLAINED, do not guess:** the CI-only `opencode` version failure (`'1.18.21'` vs
-  `'1.18.18'`). `test_opencode_config.py` passes locally — 640 tests — on a checkout
-  confirmed to BE current `origin/main` and to include the `flake.lock` bump. Same tree,
-  opposite results, so the variable is environmental and not yet identified. Needs the
-  sandbox tier run against that file specifically.
+### `main` WAS RED REPO-WIDE — three independent causes, all landed in `#1023`
+Merged as `8e33bf1d`, verified by content. `#1015`/`#1021`/`#1022` were closed as
+superseded: **none of them could go green alone**, because the gate runs the whole suite,
+so each red-tested the others' bug. That deadlock is the reason they were combined.
+1. **espanso `ask`** — the 08-28 `:acq`/`:dacq` split cleaned the label but left `"ask"` in
+   BOTH snippets' `search_terms`, so the term named neither and `#999`'s tie-break correctly
+   declined. The comment above those lines already said ":acq owns ask/clarify/questions
+   alone" — the comment was right and the data contradicted it.
+2. **opencode pin** — `flake.lock` moved the binary 1.18.18 → 1.18.21 under an unchanged
+   config, which is exactly what `test_opencode_engine.py` exists to catch.
+3. **the store-api load flake** — a 15 s localhost read timing out on SCHEDULING.
+
+🔴 **CORRECTIONS to `#1023`'s own commit messages, recorded here because that history is
+merged and will not be rewritten.** All three were caught by audit, and each is a claim I
+made that the tree did not support:
+- **The espanso trade-off is 9 lost multi-word queries, not 8.** `ask agent` also stops
+  reaching `:dacq` — it got there only via the label word `subagent`. `--diff-config` cannot
+  see it: its probe universe forms two-token pairs WITHIN ONE SNIPPET, and `ask` belongs to
+  `:acq`'s word set, so the pair never exists to be tested. **The tool was quoted faithfully
+  and the tool is narrower than the sentence** — none of the 9 has ever been typed, which is
+  the claim that actually matters and which held.
+- **"56 recovered fires" measures ATTRIBUTION, not intent.** Those fires were unattributable
+  by construction, so the share that *meant* `:dacq` is unmeasurable. `ask` no longer lists
+  `:dacq` at all (2 picker rows → 1); `:dacq` keeps all 8 of its unique routes. A legitimate,
+  tool-sanctioned remedy — but "recovered" should not be read as pure gain.
+- **"all 7 sites" / "NINE settimeout sites" were both miscounts** (6 and 8 respectively). The
+  second came from counting `grep` OUTPUT LINES, one of which was a docstring mentioning the
+  name. A grep counts mentions; an AST walk counts calls.
+- ⚠ Three miscounted self-reports in one ladder, the last inside the guard written to stop
+  them. **Re-derive every count from the tree at the moment you quote it.**
+
+### Still open
+- **`#1005`** (this doc) and **`#1009`** (the RULES worktree-config surface) — both were only
+  ever blocked on `main`; rebased onto the green `main`.
+- **`#1033`** — the round-1 audit follow-ups, plus the round-2 findings on top.
+- ✅ **RESOLVED, and it was my instrument, not the environment:** the "CI-only" opencode
+  failure. It reproduces locally in one run. I had been running `test_opencode_config.py`;
+  the failing test is in `test_opencode_**engine**.py`, and my follow-up search returned a
+  false zero because `xargs -0 command grep` has no executable to run — `command` is a shell
+  builtin. **Two instrument errors stacked into a confident "unexplained".**
 - **NOT FILED, and deliberately named as such:** the Tekton capacity problem behind the
   flake. It has no closing condition anyone can check yet, so it is not being minted as a
   work object — see the object-leak rule.

--- a/claudedocs/handoff-audit-pr-ladder.md
+++ b/claudedocs/handoff-audit-pr-ladder.md
@@ -30,54 +30,103 @@ findings-keyed stop rule does not terminate in the guard-hardening regime.
   laptop 1718672→1721180), then the original symptom was re-run against the deployed
   module `/nix/store/jawj46mw…-hm_keylog`: `acq` and `alo` both moved `None` → their own
   snippet, every other term unchanged.
-- **Hosts are 2 commits behind** `origin/main` (`3d29aba1`) as of this writing — `#992`
-  and `#996`, both other sessions' work. Not drift from this thread.
+- **Hosts CONVERGED 2026-08-28 22:37** — `ship.sh` fast-forwarded both from `1c0db104` to
+  `7d3aec1a` and verified them equal; `2 hosts compared, both at 7d3aec1a`. 🔴 The workbench
+  leg still printed `DIRTY AND IN THE ARTIFACT` and **that is not stale** — see the
+  `discord-embed-ext` investigation below; the workbench generation is `origin/main` plus
+  another session's uncommitted extension.
 
-## Open investigations — live diagnosis state
+## Closed investigations — both were diagnosed on 2026-08-28
 
-### `discord-embed-ext` uncommitted work is baked into the workbench's deployed generation
-- **Symptom + exact repro:** `bash ~/workspace/devrc/scripts/ship.sh` → the workbench leg
-  prints `🔴 DIRTY AND IN THE ARTIFACT — nix reads 2 path(s) at eval/build time`.
-- **Observed (with values):** three tracked files modified —
-  `scripts/discord-embed-ext/extension/{embed_enlarge.js,manifest.json}` and
-  `tests/embed_enlarge.test.mjs`; `git diff --stat` = 3 files, +68 −2. Two untracked
-  `claudedocs/{handoff,proposal}-mention-detection.md`. Both extension paths are read by
-  nix at eval/build time, so the built generation is `origin/main` PLUS them. The laptop
-  built clean. **Both hosts report the same sha and run different code.**
-- **Ruled out:** not this thread's work — `git log --diff-filter=A` shows no commit of mine
-  touches `scripts/discord-embed-ext/`. Not a ship defect: ship reported it correctly and
-  still converged rc 0.
-- **Leading hypothesis:** an active session mid-feature (file mtimes 19:11–19:14, a test
-  file appeared later), unaware the tree is also a deploy source.
-- **Next probe:** `git -C ~/workspace/devrc diff scripts/discord-embed-ext/` and ask the
-  owning session to commit or PR it. 🔴 Do NOT `checkout --` it — `claude/RULES.md` names
-  in-tree work as unsaved work one routine checkout from silent deletion.
+### `discord-embed-ext` WIP: OWNER FOUND — an opencode session editing the base clone
+- **Owner (measured, not inferred):** opencode session `ses_fbe5f77a2ffeaJr0G0S7i4lUKa`
+  ("Find Discord media extension"), `directory=/home/zach/workspace/devrc` — **the base
+  clone, with no worktree**. `~/.local/share/opencode/log/opencode.log` names the writes:
+  `run=020e36c2 message="touching file" file=…/embed_enlarge.js` at `2026-08-29T02:07:44Z`,
+  matching the file mtimes to the second. Its process is still alive (started 08-27 00:10)
+  but idle since 21:08:33 — its last message is *"Deployed `v0.2.3` … Reload the extension
+  in Brave."* 🔴 **It is blocked on Zach, not abandoned.**
+- 🔴 **No Claude Code transcript contains an Edit/Write to that path** — searched every
+  `~/.claude/projects/**/*.jsonl`, one hit and it was this session's own query. Looking only
+  at Claude Code sessions would have concluded "nobody owns it". **Search BOTH runtimes.**
+- **The WIP is unlanded and unique:** working-tree content matches no branch. `origin/main`
+  is byte-identical to merged `#947` for all three paths, so this is newer than
+  2026-08-27T23:16Z. `manifest.json` says `0.2.3`; `origin/main` says `0.1.0`.
+- 🔴 **`ship.sh` baked it into the workbench generation.** `~/.local/share/discord-embed-ext`
+  (what Brave loads) is `0.2.3` and carries `ATTR_CLEARED` ×5 — deployed 22:37 by this
+  session's own ship run. The laptop got `0.1.0`. **Same sha, different code — confirmed
+  with version numbers, not inferred.**
+- **PRESERVED, not touched:** `~/workspace/.wip-preserve-discord-embed-2026-08-28/` holds
+  the three files plus `discord-embed-ext.patch`; `git apply --check --reverse` confirms the
+  patch matches the tree exactly. The tree itself was left dirty and unmodified — 🔴 do NOT
+  `checkout --` it.
+- 🔴 **A defect the owner is not looking for — REPRODUCED with both controls.** `observe()`
+  calls `observer.disconnect()` unconditionally, then reconnects only `if (found > 0)`
+  (`embed_enlarge.js:150–161`). Any debounced batch with no media — a typing indicator,
+  scroll, presence — leaves the observer **permanently disconnected**, so no later
+  attachment is ever enlarged. Measured: WIP `v0.2.3` → `connected=false`,
+  `batch_seen=false`, `enlarged=false`; control `origin/main v0.1.0` → `connected=true`,
+  `batch_seen=true`, `enlarged=true`. Introduced by `v0.2.2`'s "observer disconnects during
+  style changes". **The session has spent 0.2.2→0.2.3 iterating on CSS selectors while its
+  own observer teardown is what breaks it.**
+- 🔴 **The shipped harness structurally cannot catch this.** No test calls `observe` at all;
+  `FakeMutationObserver.observe/disconnect` are **no-ops** so connection state is
+  unobservable, and `FakeElement` sets **no `nodeType`**, so the callback's
+  `node.nodeType === 1` gate is false and `markMediaElements` is never reached. A first repro
+  run looked like it reproduced and was **vacuous in both arms** (`enlarged=false`
+  everywhere) until `nodeType: 1` was set on the fixtures — the positive control is what
+  caught it.
 
-### A `localverify` remote keeps being written into the SHARED clone
-- **Symptom + exact repro:** `git -C ~/workspace/devrc remote -v` → `localverify
-  /tmp/verify-remote.git (fetch|push)`. The target directory **does not exist**.
-- **Observed (with values):** `.git/config` mtime moved 17:41:21 → 20:10:26 → 21:49:12
-  across one session, so it is written repeatedly, not a one-off. No
-  `remote.localverify.skipDefaultUpdate`, so it IS included in `fetch --all` / `remote
-  update`. `git fetch origin` is unaffected.
-- **Ruled out:** not devrc's tracked code — searched with `find … | xargs grep`, **not**
-  `grep -r`, because grep here is ugrep and honours `.gitignore`, which would return a
-  confident zero for exactly the generated paths this could hide in. Zero hits either way.
-  Not 23 separate pollutions: it appears in 23 devrc directories because **worktrees share
-  the common git dir's config** — one entry seen 23 ways (a count of sites is not a count
-  of instances).
-- **Leading hypothesis:** another session's push/fetch verification pointing at the real
-  repo instead of a scratch clone.
-- **Next probe:** catch the writer — `inotifywait -m ~/workspace/devrc/.git/config` (via
-  `nix-shell -p inotify-tools`) and correlate the next write with running sessions.
-  Removing the remote without fixing the writer only races a live test.
+### The `localverify` remote: written ONCE on 2026-08-23, and "written repeatedly" was WRONG
+- **Writer (exact):** the `civit-datapacket-talos` session
+  `5e58d9a0-0a99-4c9c-bf65-e40b403e4d55`, at `2026-08-23T06:06:49Z`, verifying the githooks
+  pre-push gate:
+  `git -C /tmp/wt-hookcheck remote add localverify /tmp/verify-remote.git`.
+  🔴 **`/tmp/wt-hookcheck` was a WORKTREE OF devrc** — its own cleanup ran
+  `git -C ~/workspace/devrc worktree remove --force /tmp/wt-hookcheck`. Remotes live in the
+  **common** config, so the entry landed in the shared clone. That cleanup (06:07:05) removed
+  the worktree, the branch and `/tmp/verify-remote.git` — but **not the remote entry**, which
+  is why it pointed at a directory that does not exist.
+- 🔴 **The "it is written repeatedly" reading was an empty-result error, now refuted by
+  measurement.** The evidence for it was `.git/config` mtime moving; that config holds **442
+  `[branch "…"]` sections**, and every `checkout -b`/`push -u` in any of ~40 agent worktrees
+  appends one. A watcher run during removal caught the rival mechanism in the act: at
+  `22:41:41` the remote went 2 lines → 0 (my removal), then at `22:43:49` config changed
+  again with `localverify` still **0**, the diff being
+  `[branch "docs/handoff-tmux-webapp-rank3-done"]` from another session. **mtime cannot
+  distinguish the two writers — the content diff can.**
+- **FIXED:** `git -C $DEVRC remote remove localverify`, rc 0. Removal also deleted the one
+  leftover ref `refs/remotes/localverify/hookverify` (`dcda00b5`, a throwaway README append),
+  recorded here so the step stays reversible. Verified gone; not re-added since.
+- 🔴 **Bonus — this closes an open question in `CLAUDE.md`.** The same session set devrc's
+  repo-local `core.hooksPath` at `2026-08-21T22:16:14Z` and unset it itself at
+  `2026-08-23T21:32:51Z`. That is the `githooks/` sighting CLAUDE.md records as coming "from
+  something else". It does **not** explain the 08-20 `.git/hooks` sightings in devrc and
+  homelab-talos — those remain unattributed, and the value is still volatile, so keep
+  measuring it rather than trusting prose.
+- 🔴 **The generalisable hazard: a worktree does NOT isolate the REMOTE SET, or any
+  `git config` write.** `git remote add`, `git config --local`, `core.hooksPath` all land in
+  the common config and are seen by every worktree and the base clone. Belongs with the
+  other "surfaces a worktree does not hand you" in `claude/RULES.md`.
 
 ## Next steps (ranked)
-1. **Ship the 2-commit gap** — `bash ~/workspace/devrc/scripts/ship.sh`, then read EVERY
-   per-host line, not the final verdict. Hosts at `289865af`, origin at `3d29aba1`.
-2. **Hand `discord-embed-ext` back to its owner** (repo: `devrc`, paths above). Nothing to
-   build; the ask is that the session commits or PRs it.
-3. **Find the `localverify` writer** (repo: `devrc`, `.git/config`). See probe above.
+1. 🔴 **Zach: answer the stalled opencode session** (repo: `devrc`; session
+   `ses_fbe5f77a2ffeaJr0G0S7i4lUKa`). It has been waiting since 21:08 on *"Reload the
+   extension in Brave"*, and **`v0.2.3` is already what Brave loads on the workbench.**
+   Give it the observer finding above — it is iterating on CSS and the bug is its own
+   `disconnect()`/`if (found > 0)` reconnect. **Closing condition:** the WIP is committed or
+   PR'd and `git -C $DEVRC status -s scripts/discord-embed-ext/` is empty; checked by
+   whoever runs `ship.sh` next, since the workbench leg prints `DIRTY AND IN THE ARTIFACT`
+   until then. Nothing here should commit another session's mid-iteration work for it.
+2. **Land the observer fix + its first test** (repo: `devrc`,
+   `scripts/discord-embed-ext/`). Reconnect unconditionally, and add the observer-lifecycle
+   test the suite has never had — which needs `FakeMutationObserver` to record connection
+   state and `FakeElement` to set `nodeType = 1`, or the test passes vacuously. Repro script
+   + controls: see the closed investigation above. **Do this only after rank 1** — the file
+   is another session's live working copy.
+3. **Add the config/remote worktree surface to `claude/RULES.md`** (repo: `devrc`) — a
+   worktree does not isolate `git remote add` or any `git config --local` write. Evidence in
+   the closed investigation above; it cost two sessions a false "written repeatedly".
 4. **Consider `date` in the espanso picker** (repo: `devrc`, `nix/home.nix`) — it still
    resolves `None`, matching `:eos` and `:roo`, neither of which is *named* `date`, so the
    exact-trigger tie-break correctly does not apply. Only worth acting on if the keylog
@@ -118,6 +167,20 @@ findings-keyed stop rule does not terminate in the guard-hardening regime.
 
 ## How to verify
 ```bash
+# --- the two closed investigations (2026-08-28) ---
+# the stray remote is gone and has NOT come back
+git -C $DEVRC remote -v | grep localverify || echo "localverify: gone"
+# who owns the discord WIP — the answer is in the OTHER runtime's log, not a transcript
+grep -a 'embed_enlarge' ~/.local/share/opencode/log/opencode.log | tail -3
+# the observer defect, with its control (expect: WIP connected=false / main connected=true)
+git -C $DEVRC show origin/main:scripts/discord-embed-ext/extension/embed_enlarge.js > /tmp/dee_main.js
+node claudedocs/repro-discord-embed-observer.mjs \
+  $DEVRC/scripts/discord-embed-ext/extension/embed_enlarge.js "WIP"
+node claudedocs/repro-discord-embed-observer.mjs /tmp/dee_main.js "CONTROL origin/main"
+# what Brave actually loads (0.2.3 = the uncommitted WIP; 0.1.0 = origin/main)
+grep -o '"version"[^,]*' ~/.local/share/discord-embed-ext/manifest.json
+
+# --- earlier work in this thread ---
 # every PR landed by CONTENT, never ancestry (squash merges break ancestry forever)
 git -C ~/workspace/devrc fetch origin main
 git -C ~/workspace/devrc show origin/main:scripts/audit-dispatch.py | grep -c 'refs/audit/'   # 7

--- a/claudedocs/handoff-audit-pr-ladder.md
+++ b/claudedocs/handoff-audit-pr-ladder.md
@@ -124,14 +124,38 @@ findings-keyed stop rule does not terminate in the guard-hardening regime.
    state and `FakeElement` to set `nodeType = 1`, or the test passes vacuously. Repro script
    + controls: see the closed investigation above. **Do this only after rank 1** — the file
    is another session's live working copy.
-3. **Add the config/remote worktree surface to `claude/RULES.md`** (repo: `devrc`) — a
-   worktree does not isolate `git remote add` or any `git config --local` write. Evidence in
-   the closed investigation above; it cost two sessions a false "written repeatedly".
-4. **Consider `date` in the espanso picker** (repo: `devrc`, `nix/home.nix`) — it still
-   resolves `None`, matching `:eos` and `:roo`, neither of which is *named* `date`, so the
-   exact-trigger tie-break correctly does not apply. Only worth acting on if the keylog
-   dataset shows it is a term actually typed — which it can now answer, because attribution
-   works.
+3. ✅ **DONE — the config/remote worktree surface is in `claude/RULES.md`** as `#1009` (the
+   sixth surface, plus an "an mtime cannot NAME a writer" clause on the find-the-WRITER
+   rule, plus the `worktree-config` archive anchor). It needed a ceiling bump: floor-relative
+   slack was **4 B**, the eviction sweep was re-run by the ledger's own documented method and
+   returned **0 B** for the third consecutive time, and the ledger had already predicted "the
+   next NEW rule pays ceiling". `MAX_BYTES` 41,400 → 42,450, slack held at precedent.
+4. ✅ **ANSWERED — `date` needs NO action, and that is measured, not assumed.** The condition
+   this doc set was "only if the keylog shows it is a term actually typed". It is not: over
+   the observed search stream, **56 term rows and `date` appears ZERO times**, with `ask`
+   visible 4× in the same output as the positive control — so the zero is a measurement and
+   not an empty harness. `date` matching `:eos`/`:roo` at all is a spurious SUBSTRING hit
+   (`date` ⊂ "upd**ate**"); it costs nothing because nobody searches it.
+
+### Opened while closing the above — all blocked until `#1021` lands
+- 🔴 **`#1021` — `main` IS RED, repo-wide.** `test_live_existing_resolutions_not_made_ambiguous`
+  fails on an unmodified `origin/main` checkout: `{'ask': (':acq', None, [':dacq', ':acq'])}`.
+  The 08-28 `:acq`/`:dacq` split cleaned the label but left `"ask"` in BOTH snippets'
+  `search_terms`, so the term names neither and `#999`'s tie-break correctly declines. The
+  comment above those lines already said ":acq owns ask/clarify/questions alone" — the
+  comment was right and the data contradicted it. Measured on the real stream: attribution
+  goes **92/171 → 148/171**, recovering **56 fires** of the config's highest-traffic term.
+  **Nothing else merges until this does.**
+- **`#1015` — the store-api load flake** (see the corrected `#996` note below).
+- **`#1005` / `#1009`** — this doc and the RULES surface; both blocked on `main`.
+- ⚠ **UNEXPLAINED, do not guess:** the CI-only `opencode` version failure (`'1.18.21'` vs
+  `'1.18.18'`). `test_opencode_config.py` passes locally — 640 tests — on a checkout
+  confirmed to BE current `origin/main` and to include the `flake.lock` bump. Same tree,
+  opposite results, so the variable is environmental and not yet identified. Needs the
+  sandbox tier run against that file specifically.
+- **NOT FILED, and deliberately named as such:** the Tekton capacity problem behind the
+  flake. It has no closing condition anyone can check yet, so it is not being minted as a
+  work object — see the object-leak rule.
 
 ## Gotchas / decisions / dead-ends
 - 🔴 **The ladder never returned a clean round in twelve.** The stop rule assumes
@@ -162,8 +186,19 @@ findings-keyed stop rule does not terminate in the guard-hardening regime.
 - **Five flakes in `test_subsystem_store_api.py` in one day**, all on unrelated PRs, and
   its assertion message described the OPPOSITE of the failure (`len(answers) == 0`,
   `raw == b''`, under the text "a second response followed the 200"). Four cycles were lost
-  to that message before a pod was read in time. **CLOSED by another session's `#996`**
-  (audit BEFORE responding + serialised sink); `saw_eof` is now asserted 11 times.
+  to that message before a pod was read in time. 🔴 **NOT CLOSED — this doc previously
+  said `#996` closed it, and 2026-08-29 falsifies that.** `#996` fixed audit ordering and
+  serialised the sink; it never touched the CLIENT bound, which is where the flake
+  actually lives. The same file went red again on `TestTheActorComesFromTheTOKEN`, on
+  MULTIPLE unrelated PRs at once, out of `socket.py` with `TimeoutError` — a 15 s
+  localhost read losing the scheduler while 12 Tekton pipelineruns shared the node and
+  this suite ran 637 s under xdist. **6 of 10 devrc runs in one window failed this way.**
+  Fix in `#1015` (one `HANG_TIMEOUT`, 15 s → 60 s, hang-detector proven still to fire at
+  the new bound). 🔴 That is the SYMPTOM: the cause is a 10-minute parallel suite
+  competing with a saturated cluster, which is Tekton capacity and not this repo's file.
+- 🔴 **A fix landing is not the same as a family closing** — and the tell is that the
+  claim was written from the fix's *description* rather than from what it touched. Before
+  writing "closed", name the mechanism and check the fix actually reaches it.
 
 ## How to verify
 ```bash

--- a/claudedocs/repro-discord-embed-observer.mjs
+++ b/claudedocs/repro-discord-embed-observer.mjs
@@ -1,0 +1,75 @@
+// Reproduction: does the MutationObserver survive a mutation batch that contains no media?
+//
+// v0.2.2 added "observer disconnects during style changes", reconnecting only `if (found > 0)`.
+// On Discord, most DOM churn (typing indicators, scroll, presence) adds NO media, so the very
+// first such batch should leave the observer permanently disconnected.
+//
+// Run with the file under test as argv[2]. Controls both ways:
+//   - the WIP working-tree copy (v0.2.3)  -> expect DISCONNECTED (the defect)
+//   - origin/main's copy (v0.1.0)         -> expect STILL CONNECTED (harness can tell them apart)
+
+import { readFileSync } from "node:fs";
+import { makeDiscordDoc, FakeElement } from "/home/zach/workspace/devrc/scripts/discord-embed-ext/tests/fake_discord_dom.mjs";
+
+const target = process.argv[2];
+const label = process.argv[3] || target;
+const source = readFileSync(target, "utf8");
+
+// Instrumented observer: the real one tracks connection state; FakeMutationObserver's
+// observe/disconnect are no-ops, so it cannot see this defect at all.
+let live = null;
+class TrackingMutationObserver {
+  constructor(cb) {
+    this._cb = cb;
+    this.connected = false;
+    this.observeCalls = 0;
+    this.disconnectCalls = 0;
+    live = this;
+  }
+  observe() { this.connected = true; this.observeCalls++; }
+  disconnect() { this.connected = false; this.disconnectCalls++; }
+  takeRecords() { return []; }
+  // Deliver a batch the way the browser would: ONLY if currently connected.
+  deliver(addedNodes) {
+    if (!this.connected) return false;
+    this._cb([{ addedNodes }]);
+    return true;
+  }
+}
+globalThis.MutationObserver = TrackingMutationObserver;
+
+const fakeGlobal = { DEE_NO_AUTOSTART: true };
+new Function("globalThis", "document", source)(fakeGlobal, undefined);
+const DEE = fakeGlobal.__DEE__;
+
+const doc = makeDiscordDoc("<html><head></head><body></body></html>");
+DEE.observe(doc);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+console.log(`=== ${label} ===`);
+console.log(`after observe():            connected=${live.connected}`);
+
+// The shipped FakeElement has no `nodeType`, but the observer callback gates on
+// `node.nodeType === 1`. Without this the callback skips every node and the run is vacuous.
+const el = (tag, attrs, kids) => Object.assign(new FakeElement(tag, attrs, kids || []), { nodeType: 1 });
+
+// Batch 1: ordinary Discord churn with NO media — a typing indicator.
+const noise = el("div", { class: "typingIndicator_abc" });
+const delivered1 = live.deliver([noise]);
+await sleep(250); // > DEBOUNCE_MS (100)
+console.log(`after a NO-MEDIA batch:     connected=${live.connected}  (delivered=${delivered1}, observe=${live.observeCalls}, disconnect=${live.disconnectCalls})`);
+
+// Batch 2: a real attachment arrives afterwards. A disconnected observer never sees it.
+const img = el("img", { src: "https://cdn.discordapp.com/attachments/1/2/photo.png" });
+const wrapper = el("div", { class: "imageWrapper_x" }, [img]);
+const delivered2 = live.deliver([wrapper]);
+await sleep(250);
+const marked = img.getAttribute("data-dee-enlarged");
+console.log(`later REAL attachment:      batch_seen=${delivered2}  enlarged=${marked === "1"}`);
+console.log(
+  marked === "1"
+    ? "VERDICT: media still enlarged — observer survived."
+    : "VERDICT: media NOT enlarged — the observer was left disconnected."
+);
+console.log("");


### PR DESCRIPTION
Closes ranks 2 and 3 of `claudedocs/handoff-audit-pr-ladder.md`. Both were open
investigations with a *leading hypothesis*; both now have a named writer and a
measurement. One hypothesis was right, one was wrong.

## Rank 2 — the `discord-embed-ext` WIP: owner found

🔴 **It is not a Claude Code session.** Every `~/.claude/projects/**/*.jsonl` was
searched for an Edit/Write to the path: **one hit, and it was this session's own
query.** The writer is **opencode** session `ses_fbe5f77a2ffeaJr0G0S7i4lUKa`,
`directory=/home/zach/workspace/devrc` — the base clone, **no worktree** — and
`~/.local/share/opencode/log/opencode.log` names the writes to the second
(`run=020e36c2 "touching file" …embed_enlarge.js` at `02:07:44Z`, matching mtimes).
Searching one runtime would have concluded nobody owned it.

It is **idle, not abandoned**: last message *"Deployed `v0.2.3` … Reload the
extension in Brave."* It is blocked on Zach.

`ship.sh` baked it into the workbench generation — `~/.local/share/discord-embed-ext`
is `0.2.3`, `origin/main` is `0.1.0`. Same sha, different code, **confirmed with
version numbers**. The WIP is preserved aside (patch verified via
`git apply --check --reverse`); the tree was left dirty and untouched.

### A defect the owner is not looking for, reproduced with controls
`observe()` calls `disconnect()` unconditionally, then reconnects only
`if (found > 0)`. Any debounced batch with no media — a typing indicator, scroll —
leaves the observer **permanently disconnected**.

| | connected after no-media batch | later attachment seen | enlarged |
|---|---|---|---|
| WIP `v0.2.3` | **false** | false | false |
| control `origin/main v0.1.0` | true | true | **true** |

The session has spent `0.2.2`→`0.2.3` iterating on **CSS selectors** while its own
observer teardown is what breaks it.

🔴 **The shipped harness structurally cannot catch this**: no test calls `observe`,
`FakeMutationObserver.observe/disconnect` are **no-ops**, and `FakeElement` sets no
`nodeType`, so the callback's `nodeType === 1` gate is false. The first repro run
looked convincing and was **vacuous in both arms** until the positive control caught
it. Repro script added as `claudedocs/repro-discord-embed-observer.mjs`.

## Rank 3 — `localverify`: the "written repeatedly" reading was wrong

**One write**, `2026-08-23T06:06:49Z`, by a `civit-datapacket-talos` session:
`git -C /tmp/wt-hookcheck remote add localverify /tmp/verify-remote.git` — and
`/tmp/wt-hookcheck` was a **worktree of devrc**, so it landed in the shared common
config. Its cleanup removed the worktree, the branch and the bare repo — but not the
remote entry, hence a remote pointing at a directory that does not exist.

🔴 The evidence for "written repeatedly" was `.git/config` **mtime** moving. That file
holds **442 `[branch]` sections** and any of ~40 agent worktrees appends one. A watcher
caught the rival mechanism 2 minutes after removal: config changed again, `localverify`
still **0**, the diff being another session's `[branch]` entry. **mtime cannot
distinguish the two writers; the content diff can.**

Removed (`rc 0`), not re-added. The one leftover ref it deleted is recorded in the doc
so the step stays reversible.

## Also: closes an open question in `CLAUDE.md`
The same session set devrc's repo-local `core.hooksPath` on 08-21 and unset it itself
on 08-23 — the "came from something else" the file records as unexplained. Scoped
strictly to what that proves: it explains the `githooks/` sighting **only**, not the
08-20 `.git/hooks` ones, and does **not** make the value stable.

## Not done, deliberately
Adding the "a worktree does not isolate `git remote add` / `git config --local`"
surface to `claude/RULES.md` — that file has an enforced ceiling requiring an eviction
in the same commit, which is a judgement call worth Zach's input. Filed as ranked
step 3 in the handoff instead.

## Verification
`204 passed` on the four doc-content gates (`test_ci_claim_matches_reality`,
`test_rules_size`, `test_no_captured_text`, `test_no_captured_markup`). Full
`scripts/gate.sh` result reported in a comment. The new `.mjs` is not a `*.test.mjs`
and is outside the discovery roots, so node SUITES accounting is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUzHBeB8LfTDwzCxnAJn2d