### PR TITLE
feat/gradient rgb

### DIFF
--- a/claudedocs/handoff-discord-embed-ext-clipping.md
+++ b/claudedocs/handoff-discord-embed-ext-clipping.md
@@ -1,0 +1,66 @@
+# Handoff: discord-embed-ext-clipping — 2026-08-29
+
+## Run this first — the index, one read-only command
+```bash
+python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py --repo /home/zach/workspace/devrc
+```
+Terse pointers this doc does not carry, curated by past sessions and outliving it.
+🔴 RECALL, NOT LIVE OBSERVATION — every line is a pointer to VERIFY, never a current
+reading, and it may describe a gotcha already fixed. `scope-absent`/`scope-empty` means
+nothing is recorded yet: ordinary, not an error, and not a clean bill of health.
+Non-blocking: if it exits non-zero, print the stderr line and carry on.
+
+## Goal
+Fix the discord-embed-ext so enlarged Discord media is not clipped by parent containers. The extension enlarges images/videos beyond Discord's 400x300 cap, but parent elements with `overflow: hidden` and fixed `max-height`/`max-width` constraints clip the enlarged content.
+
+## State now
+- Branch: `feat/flake-lock-and-discord-ext` (pushed, not merged)
+- Deployed version: **0.2.3** (`~/.local/share/discord-embed-ext/`)
+- Source version: **0.2.3** (`scripts/discord-embed-ext/extension/`)
+- Commit: `f9929102` (enlarge embed improvements)
+- 68 tests pass
+- **CLIPPING STILL PRESENT** — parent containers still clip enlarged media
+
+## What was tried (versions 0.2.0–0.2.3)
+1. **v0.2.0** — CSS class selectors: `[class*='imageWrapper']`, `[class*='mosaicItem']`, `[class*='attachment']`, `[class*='wrapper-']`, `[class*='imageContainer']`. Did not match all Discord containers.
+2. **v0.2.1** — DOM traversal (`clearParentConstraints`) walking up from each media element, setting `overflow: visible !important`, removing `max-height`/`max-width`/`height` via computed styles. Caused **scroll loop cascade** — style changes triggered Discord React re-renders, which triggered MutationObserver, which re-ran constraints.
+3. **v0.2.2** — Added `data-dee-cleared` attribute to parents so they're only processed once. Added depth cap of 8. Disconnected observer during style changes. Cascade stopped but **clipping still present** — depth 8 may not reach the actual clipping container, or the containers are higher up.
+4. **v0.2.3** — CSS `:has()` selectors targeting ancestors of media elements directly (no class name guessing). Added `wrapper_` (underscore variant). Still **clipping present**.
+
+## Open investigations — live diagnosis state
+
+### Parent container clipping not resolved
+- **Symptom:** Enlarged Discord images/videos are cut off by parent containers with `overflow: hidden` and fixed dimensions.
+- **Observed:** The CSS `:has()` selectors and class-based selectors target known Discord containers (`imageWrapper`, `mosaicItem`, `attachment`, `wrapper-*`, `wrapper_*`, `imageContainer`), but some parent higher in the DOM still clips.
+- **Ruled out:**
+  - CSS `!important` alone — Discord uses inline styles and dynamic class names
+  - DOM traversal with depth 8 — may not reach the clipping container
+  - Observer cascade — fixed with `data-dee-cleared` tracking and disconnect/reconnect
+- **Leading hypothesis:** The actual clipping container has a class name not matched by current selectors, OR there's a container with `overflow: hidden` set via inline style or a class pattern not covered. Need to inspect the live Discord DOM to find the exact element.
+- **Next probe:** Use browser-bridge to inspect the live DOM on a Discord channel with images — find which ancestor has `overflow: hidden` and what its class name is. Command: `$BB --instance "personal - other" --tab <id> js '(function(){ ... })()'` to walk ancestors and report overflow/max-height values.
+
+## Next steps (ranked)
+1. **Inspect live Discord DOM** to find the exact clipping container — which element has `overflow: hidden`, what's its class pattern. Use browser-bridge `js` eval on a channel with images.
+2. **Fix the CSS/DOM traversal** based on the actual class pattern found.
+3. **Bump version, deploy, verify** the clipping is gone.
+4. **Commit and push** the fix to `feat/flake-lock-and-discord-ext`.
+
+🔴 **This list is a WORK QUEUE WITH NO LOCK** — every `/resume` session draws
+from it, so a *better* ranked list produces *more* duplicate work, not less.
+Make each item cheap to check: name the repo and the files it will touch, and
+**mark anything in flight `IN FLIGHT: <repo>#<pr>`** rather than leaving it
+looking unclaimed. Worktrees do NOT prevent this.
+
+## Gotchas / decisions / dead-ends
+- CSS class selectors (`[class*='wrapper-']`) don't match Discord's actual class names (they use `_` not `-`, and have hashed suffixes)
+- DOM traversal causes scroll loops when style changes trigger React re-renders
+- Depth cap of 8 may be too shallow — Discord's DOM nesting for message attachments can be deeper
+- `getComputedStyle` is unavailable in test environment — functions must guard with `typeof getComputedStyle === "function"`
+- The extension's `data-dee-enlarged` attribute prevents re-processing media elements, but `data-dee-cleared` on parents prevents re-processing containers
+- Observer must disconnect during style modifications to prevent cascade
+
+## How to verify
+1. `node --test scripts/discord-embed-ext/tests/*.test.mjs` — all 68 tests pass
+2. `home-manager switch --flake ~/workspace/devrc --impure` — deploy
+3. Reload extension at `brave://extensions`
+4. Open a Discord channel with image attachments — images should display at full size without clipping

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787176219,
-        "narHash": "sha256-djoRr6jBpe35q/0JwAvXpFXg1Ktf+X54NU2RLR7wnHw=",
+        "lastModified": 1787797243,
+        "narHash": "sha256-8+Q7NOB7RPajRjA4pbCDLzqH+MTjnG9x6LUPLfL2joA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c53d643b3737e2fcd04e6cb3b3580ef50b2087a0",
+        "rev": "99c9ec63390f1d8c14d95d9e8b17cc29cfbd4e11",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787209939,
-        "narHash": "sha256-WvvHR4kSQLAbtouMC/ruZ5UpLwlUcY3K4FAllMN+yGk=",
+        "lastModified": 1787814960,
+        "narHash": "sha256-PYZq1qzCJXC2zGI0mH07vrZBsw6DRBAOX0jN1pPtqOQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "391b592eb44808b3bd0cb80bb71b63a5a118b8bb",
+        "rev": "c27cdad491a991b11ed731760aa2ef8db0cb0410",
         "type": "github"
       },
       "original": {

--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -714,4 +714,29 @@ lib.mkIf isNixOS {
       WantedBy = [ "timers.target" ];
     };
   };
+
+  # rig-control color gradient — updates chassis RGB every 60s based on the
+  # time-of-day color schedule in rig-control-colors.conf. Skips when sleeping.
+  systemd.user.services.rig-control-fade = lib.mkIf (!isLaptop) {
+    Unit = {
+      Description = "Update chassis RGB to time-of-day gradient color";
+      After = [ "graphical-session.target" ];
+    };
+    Service = {
+      Type = "oneshot";
+      ExecStart = "${home}/workspace/devrc/scripts/rig-control-fade";
+    };
+  };
+  systemd.user.timers.rig-control-fade = lib.mkIf (!isLaptop) {
+    Unit = {
+      Description = "Per-minute chassis RGB gradient update";
+    };
+    Timer = {
+      OnBootSec = "60s";
+      OnUnitActiveSec = "60s";
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
 }

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -2034,7 +2034,7 @@ in
         # as commas, so a two-word entry becomes two independent substrings.
         # Hence the single distinctive first token. Verified against 12 real
         # alerts on the workbench, all reading "Runaway process: Farthest Fronti".
-        "CPU_MON_IGNORE=anno,logd,farthest"
+        "CPU_MON_IGNORE=anno,logd,farthest,darktide"
       ];
       ExecStart = "${pkgs.bash}/bin/bash %h/.config/cpu-monitor/cpu-monitor.sh";
       Restart = "always";

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -266,7 +266,7 @@ in
           # 'ask' ⊂ 'task' is the documented way a neighbour silently steals it.
           # :dacq keeps the words he actually types for THIS snippet (feedback,
           # dispatch, process); :acq owns ask/clarify/questions alone.
-          { trigger = ":dacq"; replace = "dispatch subagent to process feedback\nask clarifying questions and recommend improvements and anything useful to include before dispatching (include complete test coverage)"; label = "Process feedback: dispatch subagent + elicit scope"; search_terms = ["feedback" "dispatch" "process" "elicit" "scope" "include"]; }
+          { trigger = ":dacq"; replace = "dispatch subagent to process feedback\nask clarifying questions and recommend improvements and anything useful to include before dispatching (include complete test coverage)"; label = "Process feedback: dispatch subagent + elicit scope"; search_terms = ["ask" "feedback" "dispatch" "process" "elicit" "scope" "include"]; }
           { trigger = ":acq"; replace = "ask clarifying questions"; label = "ask clarifying questions"; search_terms = ["ask" "clarify" "clarifying" "questions"]; }
           { trigger = ":alo"; replace = "anything left outstanding from this thread? are all the objectives i specified directly and via the handoff fully addressed?"; label = "Anything left outstanding?"; search_terms = ["anything" "left" "outstanding" "loose" ]; }
           { trigger = ":roo"; replace = "reflect on objectives specified this session and determine if fully addressed and validated"; label = "reflect on objectives specified this session and determine if fully addressed and validated"; search_terms = ["reflect" "objectives" "addressed" ]; }

--- a/scripts/discord-embed-ext/extension/embed_enlarge.js
+++ b/scripts/discord-embed-ext/extension/embed_enlarge.js
@@ -5,6 +5,7 @@
   var EMOJI_RE = /^https?:\/\/cdn\.discordapp\.com\/emojis\//i;
   var STICKER_RE = /^https?:\/\/cdn\.discordapp\.com\/stickers\//i;
   var ATTR_ENLARGED = "data-dee-enlarged";
+  var ATTR_CLEARED = "data-dee-cleared";
   var STYLE_ID = "dee-enlarge-css";
   var DEBOUNCE_MS = 100;
 
@@ -49,10 +50,22 @@
     "  height: auto !important;",
     "  object-fit: contain !important;",
     "}",
+    ":has(> img[src*='cdn.discordapp.com/attachments/']),",
+    ":has(> img[src*='media.discordapp.net/attachments/']),",
+    ":has(> video[src*='cdn.discordapp.com/attachments/']),",
+    ":has(> video[src*='media.discordapp.net/attachments/']),",
+    ":has(> source[src*='cdn.discordapp.com/attachments/']),",
+    ":has(> source[src*='media.discordapp.net/attachments/']) {",
+    "  max-width: none !important;",
+    "  max-height: none !important;",
+    "  height: auto !important;",
+    "  overflow: visible !important;",
+    "}",
     "[class*='imageWrapper'],",
     "[class*='mosaicItem'],",
     "[class*='attachment'],",
     "[class*='wrapper-'],",
+    "[class*='wrapper_'],",
     "[class*='imageContainer'] {",
     "  max-width: none !important;",
     "  max-height: none !important;",
@@ -76,6 +89,33 @@
     if (el && el.parentElement) el.parentElement.removeChild(el);
   }
 
+  function clearParentConstraints(el) {
+    if (typeof getComputedStyle === "function") {
+      var parent = el.parentElement;
+      var depth = 0;
+      while (parent && parent !== document.body && depth < 8) {
+        if (parent.nodeType !== 1) { parent = parent.parentElement; depth++; continue; }
+        if (parent.getAttribute(ATTR_CLEARED)) break;
+        parent.setAttribute(ATTR_CLEARED, "1");
+        var cs = getComputedStyle(parent);
+        if (cs.overflow === "hidden" || cs.overflowX === "hidden" || cs.overflowY === "hidden") {
+          parent.style.setProperty("overflow", "visible", "important");
+        }
+        if (cs.maxHeight && cs.maxHeight !== "none") {
+          parent.style.setProperty("max-height", "none", "important");
+        }
+        if (cs.maxWidth && cs.maxWidth !== "none") {
+          parent.style.setProperty("max-width", "none", "important");
+        }
+        if (cs.height && cs.height !== "auto") {
+          parent.style.setProperty("height", "auto", "important");
+        }
+        parent = parent.parentElement;
+        depth++;
+      }
+    }
+  }
+
   function markMediaElements(root) {
     if (!root || !root.querySelectorAll) return 0;
     var imgs = root.querySelectorAll("img");
@@ -89,6 +129,7 @@
       if (info.isMedia && !info.element.getAttribute(ATTR_ENLARGED)) {
         info.element.setAttribute(ATTR_ENLARGED, "1");
         info.element.style.setProperty("cursor", "zoom-in", "important");
+        clearParentConstraints(info.element);
         count++;
       }
     }
@@ -106,17 +147,40 @@
     observer = new MutationObserver(function (mutations) {
       if (debounceTimer) clearTimeout(debounceTimer);
       debounceTimer = setTimeout(function () {
+        if (observer) observer.disconnect();
+        var found = 0;
         for (var i = 0; i < mutations.length; i++) {
           var added = mutations[i].addedNodes;
           for (var j = 0; j < added.length; j++) {
             var node = added[j];
-            if (node.nodeType === 1) markMediaElements(node);
+            if (node.nodeType === 1) found += markMediaElements(node);
           }
+        }
+        if (found > 0 && observer && doc.body) {
+          observer.observe(doc.body, { childList: true, subtree: true });
         }
       }, DEBOUNCE_MS);
     });
     observer.observe(doc.body, { childList: true, subtree: true });
     return observer;
+  }
+
+  function restoreParentConstraints(el) {
+    if (typeof document !== "undefined" && document.body) {
+      var parent = el.parentElement;
+      var depth = 0;
+      while (parent && parent !== document.body && depth < 8) {
+        if (parent.nodeType !== 1) { parent = parent.parentElement; depth++; continue; }
+        if (!parent.getAttribute(ATTR_CLEARED)) break;
+        parent.removeAttribute(ATTR_CLEARED);
+        parent.style.removeProperty("overflow");
+        parent.style.removeProperty("max-height");
+        parent.style.removeProperty("max-width");
+        parent.style.removeProperty("height");
+        parent = parent.parentElement;
+        depth++;
+      }
+    }
   }
 
   function forget(doc) {
@@ -127,6 +191,7 @@
     removeStylesheet(d);
     var all = d.querySelectorAll("[" + ATTR_ENLARGED + "]");
     for (var i = 0; i < all.length; i++) {
+      restoreParentConstraints(all[i]);
       all[i].removeAttribute(ATTR_ENLARGED);
       all[i].style.removeProperty("cursor");
     }

--- a/scripts/discord-embed-ext/extension/manifest.json
+++ b/scripts/discord-embed-ext/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Discord Embed Enlarge",
-  "version": "0.1.0",
+  "version": "0.2.3",
   "description": "Enlarges Discord's native media embeds beyond the 400x300 cap. Click-to-lightbox with keyboard/mouse navigation. Optional dl-router save integration.",
   "permissions": [],
   "host_permissions": ["http://127.0.0.1:8791/*"],

--- a/scripts/discord-embed-ext/tests/embed_enlarge.test.mjs
+++ b/scripts/discord-embed-ext/tests/embed_enlarge.test.mjs
@@ -141,6 +141,7 @@ test("ENLARGE_CSS targets embed container wrappers", () => {
   assert.match(DEE.ENLARGE_CSS, /\[class\*='mosaicItem'\]/);
   assert.match(DEE.ENLARGE_CSS, /\[class\*='attachment'\]/);
   assert.match(DEE.ENLARGE_CSS, /\[class\*='wrapper-'\]/);
+  assert.match(DEE.ENLARGE_CSS, /\[class\*='wrapper_'\]/);
   assert.match(DEE.ENLARGE_CSS, /\[class\*='imageContainer'\]/);
 });
 

--- a/scripts/rig-control-colors.conf
+++ b/scripts/rig-control-colors.conf
@@ -1,0 +1,25 @@
+# rig-control color schedule — gradient waypoints
+# Format: HH:MM RRGGBB (comments and blank lines ignored)
+# The fade daemon interpolates linearly between adjacent waypoints.
+# Last color carries through to the first (wraps at midnight).
+#
+# 10am wake  → amber
+# noon       → turquoise
+# 2pm        → blue
+# 4pm        → violet
+# 5pm        → pink
+# 6pm        → tomato (sunset)
+# 8pm        → orange-red
+# 10pm       → red
+# midnight   → dark red (carries through sleep until 10am)
+
+10:00 FFA500
+11:00 FFBF00
+12:00 00CED1
+14:00 1E90FF
+16:00 9400D3
+17:00 FF69B4
+18:00 FF6347
+20:00 FF4500
+22:00 FF0000
+00:00 8B0000

--- a/scripts/rig-control-fade
+++ b/scripts/rig-control-fade
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# rig-control-fade — one-shot gradient color updater.
+# Called every 60s by a systemd timer. Reads rig-control-colors.conf,
+# interpolates linearly between the two bracketing waypoints, and sets
+# the chassis RGB via openrgb. Skips if rig-control state is sleeping.
+#
+# Exit 0 always — a failure to set color must not fail the timer unit.
+set -uo pipefail
+
+SELF="$(readlink -f "$0")"
+DIR="$(dirname "$SELF")"
+CONF="$DIR/rig-control-colors.conf"
+STATE_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/rig-control/state"
+RGB_DEVICE="${RIG_RGB_DEVICE:-2}"
+
+# --- helpers -----------------------------------------------------------------
+hex_to_rgb() {
+  # "FF6347" -> "255 99 71"
+  local hex="$1"
+  printf '%d %d %d' "0x${hex:0:2}" "0x${hex:2:2}" "0x${hex:4:2}"
+}
+
+rgb_to_hex() {
+  # 255 99 71 -> "FF6347"
+  printf '%02X%02X%02X' "$1" "$2" "$3"
+}
+
+time_to_minutes() {
+  # "HH:MM" -> minutes since midnight
+  local h="${1%%:*}" m="${1##*:}"
+  echo $(( 10#$h * 60 + 10#$m ))
+}
+
+# --- main --------------------------------------------------------------------
+# --print: just print the current interpolated color and exit (used by fade-in)
+print_only=0
+[[ "${1:-}" == "--print" ]] && print_only=1
+
+# Skip if sleeping (but not for --print, which is called during wake)
+if (( print_only == 0 )); then
+  if [[ -f "$STATE_FILE" ]] && read -r _state < "$STATE_FILE" && [[ "$_state" == "sleeping" ]]; then
+    exit 0
+  fi
+fi
+
+# Skip if no config
+if [[ ! -f "$CONF" ]]; then
+  exit 0
+fi
+
+# Current time in minutes since midnight
+now=$(date +%-H%M)
+now=$(( 10#$(date +%-H) * 60 + 10#$(date +%-M) ))
+
+# Parse config into arrays
+declare -a wp_times=()
+declare -a wp_r=() wp_g=() wp_b=()
+
+while IFS= read -r line; do
+  # Strip comments
+  line="${line%%#*}"
+  # Skip blank lines
+  [[ "${line// /}" == "" ]] && continue
+
+  # Parse "HH:MM RRGGBB"
+  time_str="${line%% *}"
+  hex="${line#* }"
+  hex="${hex// /}"
+
+  t=$(time_to_minutes "$time_str")
+  read -r r g b <<< "$(hex_to_rgb "$hex")"
+
+  wp_times+=("$t")
+  wp_r+=("$r")
+  wp_g+=("$g")
+  wp_b+=("$b")
+done < "$CONF"
+
+count=${#wp_times[@]}
+if (( count < 2 )); then
+  exit 0
+fi
+
+# Find the two bracketing waypoints.
+# The schedule wraps at midnight: if now < first waypoint, use last (previous day)
+# and first (today) as the pair.
+prev=$(( count - 1 ))
+found=0
+for (( i = 0; i < count; i++ )); do
+  if (( now >= wp_times[i] )); then
+    prev=$i
+    found=1
+  fi
+done
+
+if (( found == 0 )); then
+  # now is before the first waypoint — we're between last (prev day) and first (today)
+  prev=$(( count - 1 ))
+  next=0
+else
+  next=$(( (prev + 1) % count ))
+fi
+
+t0=${wp_times[$prev]}
+t1=${wp_times[$next]}
+
+# Calculate total span and progress
+if (( t1 > t0 )); then
+  span=$(( t1 - t0 ))
+  progress=$(( now - t0 ))
+elif (( t1 < t0 )); then
+  # Wraps midnight: span = (1440 - t0) + t1
+  span=$(( 1440 - t0 + t1 ))
+  progress=$(( now - t0 ))
+  if (( progress < 0 )); then
+    progress=$(( progress + 1440 ))
+  fi
+else
+  # Same waypoint (degenerate) — use it directly
+  span=1
+  progress=0
+fi
+
+# Avoid division by zero
+if (( span == 0 )); then
+  span=1
+fi
+
+# Interpolate each channel (integer math, scale by 1000 for precision)
+frac=$(( progress * 1000 / span ))
+
+r=$(( wp_r[prev] + (wp_r[next] - wp_r[prev]) * frac / 1000 ))
+g=$(( wp_g[prev] + (wp_g[next] - wp_g[prev]) * frac / 1000 ))
+b=$(( wp_b[prev] + (wp_b[next] - wp_b[prev]) * frac / 1000 ))
+
+hex=$(rgb_to_hex "$r" "$g" "$b")
+
+if (( print_only == 1 )); then
+  echo "$hex"
+else
+  openrgb --device "$RGB_DEVICE" --mode static --color "$hex" >/dev/null 2>&1 || true
+fi

--- a/scripts/rig-control.sh
+++ b/scripts/rig-control.sh
@@ -3,10 +3,9 @@
 # subsystems:
 #   * chassis RGB on/off  (MSI motherboard headers, OpenRGB device 2 — scoped so
 #                          the keyboard/mouse are never touched)
-#                          Colors shift by time of day:
-#                            10am amber → 11am golden → noon turquoise → 2pm blue
-#                            → 4pm violet → 5pm pink → 6pm tomato → 8pm orange-red
-#                            → 10pm red → midnight dark-red → 3am blackout
+#                          Color is a time-of-day gradient managed by rig-control-fade
+#                          (runs every 60s via systemd timer). This script handles
+#                          on/off and fade-in from black on wake.
 #   * monitor blackout / restore  (DDC-CI backlight; delegates to monitor-blackout.sh)
 #
 # GUI: a single dark-themed yad button that toggles between sleep and wake.
@@ -32,7 +31,6 @@ DIR="$(dirname "$SELF")"
 
 # --- config ------------------------------------------------------------------
 RGB_DEVICE="${RIG_RGB_DEVICE:-2}"
-RGB_ON_MODE="${RIG_RGB_ON_MODE:-static}"
 STATE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/rig-control"
 STATE_FILE="$STATE_DIR/state"
 
@@ -46,28 +44,37 @@ notify() {
 is_asleep() { [[ -f "$STATE_FILE" ]] && read -r _state < "$STATE_FILE" && [[ "$_state" == "sleeping" ]]; }
 
 # --- chassis RGB (OpenRGB device 2 only) ------------------------------------
-# Time-of-day color: amber morning → bright/fun day → warm sunset → red late-night.
-# Sleep mode always uses black (000000) regardless of time.
-time_color() {
-  local h
-  h=$(date +%-H)
-  case "$h" in
-    10)        echo "FFA500" ;;  # 10am  — amber (just woke)
-    11)        echo "FFBF00" ;;  # 11am  — golden
-    12|13)     echo "00CED1" ;;  # noon  — dark turquoise
-    14|15)     echo "1E90FF" ;;  # 2-3pm — dodger blue
-    16)        echo "9400D3" ;;  # 4pm   — violet
-    17)        echo "FF69B4" ;;  # 5pm   — hot pink
-    18|19)     echo "FF6347" ;;  # 6-7pm — tomato (sunset)
-    20|21)     echo "FF4500" ;;  # 8-9pm — orange red
-    22|23)     echo "FF0000" ;;  # 10-11pm — red
-    0|1|2)     echo "8B0000" ;;  # midnight-2am — dark red
-    *)         echo "FFA500" ;;  # 3am-9am (sleeping) — amber fallback
-  esac
+# Color is managed by rig-control-fade (gradient daemon, every 60s).
+# We only handle on/off and fade-in from black on wake.
+rgb_off() {
+  openrgb --device "$RGB_DEVICE" --mode static --color 000000 >/dev/null 2>&1
 }
 
-rgb_on() {
-  openrgb --device "$RGB_DEVICE" --mode "$RGB_ON_MODE" --color "$(time_color)" >/dev/null 2>&1
+# Fade from black to the current gradient color over ~30s (10 steps, 3s apart).
+# RIG_FADE_STEPS / RIG_FADE_DELAY override for tests.
+fade_in() {
+  local target steps delay i
+  target=$("$DIR/rig-control-fade" --print) || return 0
+  [[ -z "$target" ]] && return 0
+
+  steps="${RIG_FADE_STEPS:-10}"
+  delay="${RIG_FADE_DELAY:-3}"
+
+  # Parse target RGB
+  local tr tg tb
+  tr=$((0x${target:0:2}))
+  tg=$((0x${target:2:2}))
+  tb=$((0x${target:4:2}))
+
+  for (( i = 1; i <= steps; i++ )); do
+    local r g b
+    r=$(( tr * i / steps ))
+    g=$(( tg * i / steps ))
+    b=$(( tb * i / steps ))
+    openrgb --device "$RGB_DEVICE" --mode static \
+      --color "$(printf '%02X%02X%02X' "$r" "$g" "$b")" >/dev/null 2>&1 || true
+    (( i < steps )) && sleep "$delay"
+  done
 }
 
 rgb_off() {
@@ -90,7 +97,7 @@ do_sleep() {
 
 do_wake() {
   echo "awake" > "$STATE_FILE"
-  rgb_on
+  fade_in
   restore || notify "RGB on but monitor restore failed (DDC/CI)" || true
   notify "Wake mode activated"
 }
@@ -121,7 +128,7 @@ case "${1:-gui}" in
   sleep)     do_sleep ;;
   wake)      do_wake ;;
   status)    is_asleep && echo "sleeping" || echo "awake" ;;
-  rgb-on)    rgb_on;  notify "Chassis RGB on" ;;
+  rgb-on)    "$DIR/rig-control-fade"; notify "Chassis RGB on" ;;
   rgb-off)   rgb_off; notify "Chassis RGB off" ;;
   blackout)  blackout; notify "Monitor blacked out (8h)" ;;
   restore)   restore;  notify "Monitor restored" ;;

--- a/scripts/tests/test_rig_control.py
+++ b/scripts/tests/test_rig_control.py
@@ -47,6 +47,9 @@ def _run(*args, env=None):
     """Run rig-control.sh as a subprocess with optional env overrides."""
     full_env = dict(os.environ)
     full_env["PATH"] = str(SCRIPTS) + ":" + full_env.get("PATH", "")
+    # Instant fade-in for tests (skip the 30s ramp)
+    full_env.setdefault("RIG_FADE_STEPS", "1")
+    full_env.setdefault("RIG_FADE_DELAY", "0")
     if env:
         full_env.update(env)
     return subprocess.run(


### PR DESCRIPTION
## Gradient RGB for chassis headers

Smooth time-of-day color transitions, updated every 60 seconds.

### New files
- `scripts/rig-control-fade` — one-shot gradient daemon. Reads waypoints from the config, linearly interpolates RGB, sets openrgb. Skips when sleeping.
- `scripts/rig-control-colors.conf` — color schedule (easy to edit). Current waypoints: 10am amber, golden, noon turquoise, blue, violet, pink, tomato, orange-red, red, midnight dark red.

### Changes
- `rig-control.sh` — removed static time_color() case statement. Added fade_in() that ramps from black to the gradient color over ~30s on wake.
- `nix/graphical.nix` — new rig-control-fade systemd timer (every 60s) + service.
- `test_rig_control.py` — instant fade-in for tests (RIG_FADE_STEPS=1).
