### PR TITLE
fix(tests): store-api hang-detectors were timing out on SCHEDULING — ~60% of devrc CI runs were failing repo-wide

### DIFF
--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -72,6 +72,31 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
+
+# 🔴 ONE bound for every "this should already have happened" wait in this module
+# — the localhost HTTP round-trips, `wait_closed`, `await_audit`. These are
+# HANG-DETECTORS: they exist so a broken server fails the test instead of hanging
+# the suite forever, and their value is not a correctness claim about how fast
+# anything must be.
+#
+# It is deliberately NOT used for the raw-socket `settimeout(...)` calls further
+# down. Those are DRAIN bounds — the loop terminator for a `recv`-until-quiet
+# read — so raising one adds its full value to the suite's runtime instead of
+# only to the latency of a genuine failure. Same spelling, opposite meaning; a
+# single shared constant across both would be wrong.
+#
+# Why 60 and not 15: measured 2026-08-29, the devrc Tekton gate was failing
+# ~60% of runs REPO-WIDE (6 of 10 in one window, on unrelated branches) with
+# `TimeoutError` out of `socket.py` — a localhost round-trip that lost the
+# scheduler for >15 s while 12 pipelineruns shared the node and this suite ran
+# 637 s under xdist. The test logic was never reached, so the gate reported a
+# code failure for a capacity problem. 60 s absorbs a 4x scheduling delay and
+# still fails a genuinely hung server well inside the task timeout.
+#
+# 🔴 This is the SYMPTOM fix. The cause is a 10-minute parallel suite competing
+# with a saturated cluster, which belongs to Tekton capacity, not to this file.
+HANG_TIMEOUT = 60.0
+
 API_DIR = ROOT / "scripts" / "subsystem-store-api"
 SERVER_PATH = API_DIR / "server.py"
 SEED_PATH = API_DIR / "seed.sh"
@@ -268,7 +293,7 @@ def fetch(
     for key, value in (extra_headers or {}).items():
         req.add_header(key, value)
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
+        with urllib.request.urlopen(req, timeout=HANG_TIMEOUT) as resp:
             return resp.status, dict(resp.headers), resp.read()
     except urllib.error.HTTPError as exc:
         return exc.code, dict(exc.headers), exc.read()
@@ -282,7 +307,7 @@ def _raw_request(host: str, path: str, headers: list[tuple[str, str]]) -> int:
     of expressing the "two `CF-Connecting-IP`s" case. `http.client.putheader`
     can.
     """
-    conn = http.client.HTTPConnection(host, timeout=15)
+    conn = http.client.HTTPConnection(host, timeout=HANG_TIMEOUT)
     try:
         conn.putrequest("GET", path, skip_host=True, skip_accept_encoding=True)
         conn.putheader("Host", host)
@@ -414,7 +439,7 @@ class Drained:
         """The whole stream, for `x not in out` style assertions."""
         return "\n".join(self.all)
 
-    def wait_closed(self, timeout: float = 15.0) -> bool:
+    def wait_closed(self, timeout: float = HANG_TIMEOUT) -> bool:
         """Block until the process's stdout reaches EOF. Returns whether it did.
 
         Read `text` only AFTER this. Without it the reader thread may still be
@@ -465,7 +490,7 @@ def drain_output(proc) -> Drained:
     return out
 
 
-def await_audit(out: "Drained | AuditLog", n: int, timeout: float = 15.0) -> "list[str]":
+def await_audit(out: "Drained | AuditLog", n: int, timeout: float = HANG_TIMEOUT) -> "list[str]":
     """Wait for at least `n` audit lines, then return them. RAISES if they never
     arrive.
 
@@ -4020,7 +4045,7 @@ def fetch_from(
     """
     host, _, port = base.removeprefix("http://").partition(":")
     conn = http.client.HTTPConnection(
-        host, int(port), timeout=15, source_address=(source_ip, 0)
+        host, int(port), timeout=HANG_TIMEOUT, source_address=(source_ip, 0)
     )
     try:
         headers = {}
@@ -5747,7 +5772,7 @@ class TestTrustedProxyOverTheRealProcess:
             store, token_file, trusted_proxies=NOT_LOOPBACK_PROXY
         ) as (_base, proc):
             proc.terminate()
-            stdout, _err = proc.communicate(timeout=15)
+            stdout, _err = proc.communicate(timeout=HANG_TIMEOUT)
         assert f"trusted-proxies={NOT_LOOPBACK_PROXY}" in stdout, stdout
 
 


### PR DESCRIPTION
The devrc gate has been red on `TestTheActorComesFromTheTOKEN.test_a_FORGED_actor_in_the_body_is_DISCARDED`
across **unrelated branches**. It is not a defect in any of them, and not in the
store API either.

## Measured, from the gate pod's own log
```
raise OSError("cannot read from timed out object")
E   TimeoutError: timed out
socket.py:720: TimeoutError
1 failed, 9818 passed ... in 637.72s (0:10:37)
```
A localhost round-trip lost the scheduler for >15 s while **12 Tekton pipelineruns**
shared the node and this suite ran 637 s under xdist. **6 of 10 devrc runs in one
window failed this way**, on unrelated branches. The test logic was never reached —
a capacity problem was being reported as a code failure.

That is the permanently-red gate the rules warn trains everyone to click through.
It had already trained me once tonight to write off a red check as "just a flake".

## The fix
15 s was never a correctness bound. It is a **hang-detector**: it exists so a broken
server fails the test instead of wedging the suite. That job survives at 60 s; the
false positives do not.

Consolidated to one `HANG_TIMEOUT` across all **7** sites — the same predicate
open-coded at N sites is wrong at N−1, and this one had already drifted into two
spellings (`timeout=15` and `timeout: float = 15.0`).

## 🔴 What was deliberately NOT changed
The raw-socket `settimeout(5)` calls look identical and mean the **opposite**: they
are **drain bounds** — the loop terminator for a `recv`-until-quiet read. Raising one
adds its full value to suite runtime rather than only to the latency of a genuine
failure. A single constant across both would have been wrong. Verified still at 5 s.

## The instrument was validated, not assumed
Raising a bound can silently **disable** the guard — trading a flaky gate for a
wedged one. Against a server that accepts and never answers:

```
HANG_TIMEOUT = 60.0  (finite=True)
detector fired after 60.1s with TimeoutError('timed out')
✅ fires at the NEW bound, not silently disabled
✅ drain bounds still at 5s: 3 sites — untouched
```

So it fails **for the right reason** and **at the right bound**, and the constant is
asserted finite and positive (a `None`/`0` would wait forever).

## Budget
A genuinely hung server now costs 4× longer to fail. Gate task allows **45m**, suite
runs **~10.6m** — still fits. Full file re-run green: **614 passed in 289.94s**.

## Scope, stated honestly
🔴 **This is the symptom.** The cause is a 10-minute parallel suite competing with a
saturated cluster — Tekton capacity, not this file.

🔴 **Correction to an earlier revision of this description, which said that was
"filing separately". It was not filed, and I am not filing it.** It has no closing
condition anyone could check — no merged PR, no cleared alert, no command that exits
0 — and no named owner, so minting it as a work object would be an object leak: a
ticket that reads as covered while nothing can ever close it. It is recorded as an
open, unowned condition in `claudedocs/handoff-audit-pr-ladder.md` instead, which is
the honest shape for it.

Also: **#996 did not close this flake family.** It addressed audit ordering and sink
serialisation, never the client bound. The handoff currently claims otherwise and
tonight falsifies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUzHBeB8LfTDwzCxnAJn2d
