### PR TITLE
fix: bar click toggle for rig-control

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -337,13 +337,18 @@ let
       { button = "left"; cmd = "yad --calendar --width=200 --height=200 --undecorated --fixed --close-on-unfocus --no-buttons"; }
     ];
   };
-  # rigcontrol: workbench only. Instant toggle on left-click (sleep ↔ wake),
-  # no yad menu. The block script reads the state file and calls rig-control.sh
-  # sleep or wake directly; i3status-rust passes $BLOCK_BUTTON to the command.
+  # rigcontrol: workbench only. Instant toggle on left-click (sleep ↔ wake).
+  # The click handler runs via setsid -f so it doesn't block the bar during
+  # the ~30s fade-in. i3status-rust does NOT pass $BLOCK_BUTTON to custom
+  # block commands, so the toggle lives in a [[block.click]] handler, not
+  # inside the render script.
   rigcontrolBlock = {
     block = "custom";
     command = "${scriptsDir}/i3blocks-rigcontrol";
     interval = "once";
+    click = [
+      { button = "left"; cmd = "setsid -f ${home}/workspace/devrc/scripts/rig-control-toggle"; }
+    ];
   };
   # claude-runs: workbench only. LIVE count of Claude-Code-in-tmux runs — renders
   # `󰕮 N` (N>0) / bare `󰕮` (N==0) / `󰕮 ?` (could not measure), always neutral

--- a/scripts/i3blocks-rigcontrol
+++ b/scripts/i3blocks-rigcontrol
@@ -1,18 +1,13 @@
 #!/usr/bin/env bash
-# i3blocks instant-toggle block for rig-control sleep/wake.
-#   interval=once  -> renders the icon at startup; i3blocks re-runs this on click
-#                     with $BLOCK_BUTTON set (1=left, 2=middle, 3=right).
-# Left-click toggles between sleep and wake instantly (no yad menu).
-# Icon reflects sleep state: ☀ (awake) or 🌙 (sleeping).
-RIG="$HOME/workspace/devrc/scripts/rig-control.sh"
+# i3blocks render script for rig-control sleep/wake icon.
+#   interval=once  -> renders at startup; re-runs on bar click.
+# Click handling lives in [[block.click]] in the nix config (i3status-rust
+# does NOT pass $BLOCK_BUTTON to custom block commands).
+# Icon: ☀ (awake) or 🌙 (sleeping).
 STATE_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/rig-control/state"
 
-is_asleep() { [[ -f "$STATE_FILE" ]] && read -r _s < "$STATE_FILE" && [[ "$_s" == "sleeping" ]]; }
-
-case "${BLOCK_BUTTON:-}" in
-  1) if is_asleep; then "$RIG" wake >/dev/null 2>&1
-     else "$RIG" sleep >/dev/null 2>&1
-     fi ;;
-esac
-
-if is_asleep; then echo "🌙"; else echo "☀"; fi
+if [[ -f "$STATE_FILE" ]] && read -r _s < "$STATE_FILE" && [[ "$_s" == "sleeping" ]]; then
+  echo "🌙"
+else
+  echo "☀"
+fi

--- a/scripts/rig-control-toggle
+++ b/scripts/rig-control-toggle
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# rig-control-toggle — instant sleep/wake toggle for the bar click handler.
+# Called by i3status-rust's [[block.click]] via setsid -f (non-blocking).
+STATE_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/rig-control/state"
+RIG="$HOME/workspace/devrc/scripts/rig-control.sh"
+
+if [[ -f "$STATE_FILE" ]] && read -r _s < "$STATE_FILE" && [[ "$_s" == "sleeping" ]]; then
+  "$RIG" wake >/dev/null 2>&1
+else
+  "$RIG" sleep >/dev/null 2>&1
+fi


### PR DESCRIPTION
Fix: bar click toggle for rig-control.

i3status-rust does NOT pass $BLOCK_BUTTON to custom block commands, so the in-script toggle was dead code. Move toggle to a [[block.click]] handler (the i3status-rust way) with setsid -f to avoid blocking the bar during the ~30s fade-in.

- New rig-control-toggle script: reads state, calls wake or sleep
- rigcontrolBlock gets a click handler pointing at the toggle script
- i3blocks-rigcontrol simplified to icon-only render
