### PR TITLE
fix: wake exits 1 under set -e due to (( )) && leak

### DIFF
--- a/scripts/rig-control.sh
+++ b/scripts/rig-control.sh
@@ -73,7 +73,7 @@ fade_in() {
     b=$(( tb * i / steps ))
     openrgb --device "$RGB_DEVICE" --mode static \
       --color "$(printf '%02X%02X%02X' "$r" "$g" "$b")" >/dev/null 2>&1 || true
-    (( i < steps )) && sleep "$delay"
+    if (( i < steps )); then sleep "$delay"; fi
   done
 }
 


### PR DESCRIPTION
Fix: wake exits 1 under set -e.

(( i < steps )) && sleep returns exit code 1 from the (( )) on the LHS of && inside a function body with set -e. Change to if/then/fi.

This caused wake clicks to silently fail — do_wake() died after fade_in() before restore() ran, leaving the monitor blacked out.
