### PR TITLE
fix(espanso): main is RED — both :dacq and :acq declare "ask", and the comment already said :acq owns it alone

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -266,7 +266,17 @@ in
           # 'ask' ⊂ 'task' is the documented way a neighbour silently steals it.
           # :dacq keeps the words he actually types for THIS snippet (feedback,
           # dispatch, process); :acq owns ask/clarify/questions alone.
-          { trigger = ":dacq"; replace = "dispatch subagent to process feedback\nask clarifying questions and recommend improvements and anything useful to include before dispatching (include complete test coverage)"; label = "Process feedback: dispatch subagent + elicit scope"; search_terms = ["ask" "feedback" "dispatch" "process" "elicit" "scope" "include"]; }
+          # 2026-08-29: `"ask"` REMOVED from :dacq below. The split above says in
+          # so many words that ":acq owns ask/clarify/questions alone", and the
+          # label was duly cleaned — but the search_terms were not, so BOTH
+          # snippets went on declaring "ask" exactly. The tie-break added for this
+          # (#999) can only rescue a term that NAMES one trigger outright; neither
+          # of these is named "ask", so the term resolved to None and every fire
+          # of the config's highest-traffic term was recorded UNATTRIBUTED again —
+          # the very outcome the split was meant to prevent. It also turned
+          # `main` red repo-wide. The comment was right and the data was wrong:
+          # this makes the data match it.
+          { trigger = ":dacq"; replace = "dispatch subagent to process feedback\nask clarifying questions and recommend improvements and anything useful to include before dispatching (include complete test coverage)"; label = "Process feedback: dispatch subagent + elicit scope"; search_terms = ["feedback" "dispatch" "process" "elicit" "scope" "include"]; }
           { trigger = ":acq"; replace = "ask clarifying questions"; label = "ask clarifying questions"; search_terms = ["ask" "clarify" "clarifying" "questions"]; }
           { trigger = ":alo"; replace = "anything left outstanding from this thread? are all the objectives i specified directly and via the handoff fully addressed?"; label = "Anything left outstanding?"; search_terms = ["anything" "left" "outstanding" "loose" ]; }
           { trigger = ":roo"; replace = "reflect on objectives specified this session and determine if fully addressed and validated"; label = "reflect on objectives specified this session and determine if fully addressed and validated"; search_terms = ["reflect" "objectives" "addressed" ]; }


### PR DESCRIPTION
`origin/main` currently fails, reproduced on an **unmodified checkout**:

```
search terms regressed: {'ask': (':acq', None, [':dacq', ':acq'])}
```

Every open PR in the repo inherits this, so nothing can merge until it lands.

## Not a detector bug
The 2026-08-28 split of `:acq` into `:dacq` + `:acq` cleaned the **label** but left
`"ask"` in **both** snippets' `search_terms`. So the term matched two snippets and
*named* neither — and #999's tie-break can only rescue a term that names one trigger
outright, so it correctly declined.

The comment sitting directly above those two lines already stated the intent:

> `:dacq` keeps the words he actually types for THIS snippet (feedback, dispatch,
> process); **`:acq` owns ask/clarify/questions alone.**

The comment was right; the data contradicted it. *A comment is a claim too.* This
makes the data match it — one word removed.

## Measured on the real search stream
The block's own instructions require a replay after any edit here. Keylog,
2026-08-20+, `--source keys`:

| | `'ask'` | resolves |
|---|---|---|
| baseline (deployed) | 54+2 fires → `-NONE-` | **92/171** |
| candidate (this fix) | → `:acq` | **148/171** |

**56 recovered fires.** `ask` is the highest-traffic term in the config and every one
was being logged UNATTRIBUTED — exactly what the split was meant to prevent.

## Trade-off, stated rather than hidden
8 multi-word queries that reached `:dacq` via "ask" (`ask dispatch`, `ask feedback`, …)
now reach nothing. `--diff-config` grades only whole words with a surviving owner, so
it passes them **silently** — I checked them against the observed stream instead, and
**none of the 8 has ever been typed**. The cost is theoretical; the 56 fires are real.

```
--diff-config : GATE: PASS — nothing lost its findability
--lint        : ambiguous 23 -> 22  ('ask' row gone)
keylog tests  : 93 passed
```

## Closes rank 4 of the handoff, in the same measurement
`date` resolves to `None` because it substring-matches `:eos` ("upd**ate**") and `:roo`
while naming neither. The handoff made acting on it **conditional** on the keylog
showing it is a term actually typed.

It is not: 56 term rows in the window, `date` appears **zero** times — with `ask`
visible 4× in the same output as the positive control, so that zero is a measurement
and not an empty harness. **Correct action on `date`: none.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUzHBeB8LfTDwzCxnAJn2d