### PR TITLE
fix(opencode): re-derive the version pin 1.18.18 → 1.18.21 — flake.lock moved the binary under an unchanged config

### DIFF
--- a/claude/opencode-addendum.md
+++ b/claude/opencode-addendum.md
@@ -32,7 +32,7 @@ bash guard.
 | search file contents | `grep` | `rg` / `grep` via bash |
 | see what is in a dir | `glob` on `<dir>/*` | `ls` |
 
-There is **no `list` tool** on opencode 1.18.18 — verified against the resolved
+There is **no `list` tool** on opencode 1.18.21 — verified against the resolved
 tool map, which contains exactly `bash, edit, glob, grep, invalid, question,
 read, skill, task, todowrite, webfetch, write`. Use `glob` to enumerate a
 directory.

--- a/flake.nix
+++ b/flake.nix
@@ -292,11 +292,11 @@
             # 🔴 This ALSO makes the sandbox the tier that pins the VERSION.
             # `pkgs.opencode` here and in nix/pkgs/tools/default.nix resolve from
             # the same flake.lock, so CI tests the exact binary the hosts deploy
-            # (1.18.18 at rev 5c680dac9f02). Cost, stated as deliberately as the
+            # (1.18.21 at rev c27cdad491a9). Cost, stated as deliberately as the
             # nodejs and nix entries above: this check's closure grows by
             # opencode, and a nixpkgs bump that moves it invalidates the cache
             # AND turns the version assertion red. That red is the point — the
-            # config header's "measured on v1.18.18 — do not re-derive" claims are
+            # config header's "measured on v1.18.21 — do not re-derive" claims are
             # otherwise pinned to nothing.
             #
             # logrotate: scripts/tests/test_claude_log_rotate.py drives the REAL

--- a/nix/pkgs/tools/default.nix
+++ b/nix/pkgs/tools/default.nix
@@ -12,7 +12,7 @@ with pkgs; [
   # hosts, which drifted: MEASURED 2026-08-02, laptop 1.18.4 / workbench 1.18.9,
   # each movable independently by a `nix profile upgrade` that nothing records.
   # scripts/opencode/opencode.jsonc documents a large set of load-bearing
-  # behaviours annotated "measured on v1.18.18 — do not re-derive" (last-match-
+  # behaviours annotated "measured on v1.18.21 — do not re-derive" (last-match-
   # wins permission ordering, the hidden title/summary/compaction agents
   # inheriting the global permission block, the exact tool set). A few bullets
   # there — `ask` semantics under `opencode run` among them — are explicitly
@@ -20,8 +20,8 @@ with pkgs; [
   # Those claims were pinned to a version nothing pinned.
   #
   # This entry pins them: MEASURED at flake.lock's nixpkgs rev 5c680dac9f02,
-  # `pkgs.opencode` is 1.18.18 — store path
-  # /nix/store/3y4zcklfn3hfk9gn08csfzd3vwfjhkl0-opencode-1.18.18. (It was
+  # `pkgs.opencode` is 1.18.21 — store path
+  # /nix/store/iqc8xfx692ym3pds6ky0vhqzscg6kgxd-opencode-1.18.21. (It was
   # 1.18.4 at rev 9bc02893134c when this pin was introduced, and 1.18.16 at rev
   # 044bfe75bfe4; the 2026-08-13 and 2026-08-19 bumps each re-derived the claims
   # against the new binary rather than re-spelling them — see PINNED_VERSION in

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -2210,15 +2210,15 @@ field** (the CDP ops are bounded typed ops only; see the CDP security model abov
   Because the gate runs **before** the tab is opened, a gate failure leaks no tab.
 
   *Prerequisite:* an opencode whose `debug agent` reports a browser-only tool set.
-  **Both hosts run 1.18.18 and both resolve browser-only** (verified 2026-08-19:
+  **Both hosts run 1.18.21 and both resolve browser-only** (verified 2026-08-19:
   the gate replicated ON EACH HOST parses to exactly one enabled tool, `browser`,
   with every host tool present and `false`). There is no version-skew caveat
   here any more. The hosts CONVERGED on 2026-08-15 and the pin's move to 1.18.18
   had reached both before it was re-keyed — verified at the consumer, both
   `readlink -f $(command -v opencode)` resolving to the same
-  `…-opencode-1.18.18` store path — so the pin and the deploy agree. The
+  `…-opencode-1.18.21` store path — so the pin and the deploy agree. The
   browser-only resolution was measured identical on 1.18.4 and 1.18.16, and again
-  on the 1.18.18 binary, so no bump has changed it. 🔴 The RAW dump is NOT byte-stable, on either binary: the
+  on the 1.18.21 binary, so no bump has changed it. 🔴 The RAW dump is NOT byte-stable, on either binary: the
   `permission` array's order follows a directory walk and varies run to run, so
   `cmp` on two dumps differs for reasons that have nothing to do with the version.
   Compare the resolved tool set, or canonicalise first. So the deploy gap does not
@@ -2311,7 +2311,7 @@ ln -sf ~/workspace/devrc/scripts/browser-bridge/opencode/tools/browser_tool_impl
 the wrapper substitutes them per run.)
 
 **opencode version.** The custom-tool mechanism (`.opencode/tools/*.js`,
-`permission: {"*": deny, …}`) is **verified on 1.18.18, which is what BOTH hosts
+`permission: {"*": deny, …}`) is **verified on 1.18.21, which is what BOTH hosts
 run and what `flake.lock` pins** (measured identical on 1.18.4 before the bump) — `opencode debug agent
 browser-agent` resolves to `bash:false … browser:true`
 (exactly one enabled tool) on each, plus an end-to-end `opencode debug agent …

--- a/scripts/browser-bridge/reference/agent.md
+++ b/scripts/browser-bridge/reference/agent.md
@@ -26,7 +26,7 @@ command unrunnable, which is why fixing the first didn't appear to help:
    be reached. Fixed by probing without injecting.
 
 🔴 **Every doc misattributed both symptoms to an opencode *version* problem for the
-entire arc.** They are not version-related — both hosts run 1.18.18 and both
+entire arc.** They are not version-related — both hosts run 1.18.21 and both
 resolve browser-only, and the same resolution was measured on 1.18.4 and 1.18.16
 before the bumps. Do not re-open that hypothesis.
 
@@ -248,7 +248,7 @@ browser agent "go to news.ycombinator.com and report the top 3 story titles" \
   fail-closed property is *verified at runtime* rather than trusted — on any
   opencode where the host-tool denial didn't take, `browser agent` refuses instead
   of running the model unconfined. The gate runs BEFORE the tab is opened, so a
-  gate failure leaks no tab. **Both hosts run 1.18.18 and both resolve
+  gate failure leaks no tab. **Both hosts run 1.18.21 and both resolve
   browser-only**, and it resolved identically on 1.18.4 and 1.18.16 before the
   bumps — there is no version-skew caveat.
   - ⚠ **If you check the gate by hand, redirect to a FILE**

--- a/scripts/opencode/README.md
+++ b/scripts/opencode/README.md
@@ -269,7 +269,7 @@ existence guard**, and defined a `KC_PROD` that zsh did not have. Add a handle i
   (`*.env` → ask); a blanket allow is appended after it and silently defeats it
   on every agent. The default already allows every non-`.env` read, so the
   correct configuration is to say nothing.
-- **There is no `list` tool and no `websearch` tool** on 1.18.18. The resolved set
+- **There is no `list` tool and no `websearch` tool** on 1.18.21. The resolved set
   is exactly {bash, edit, glob, grep, invalid, question, read, skill, task,
   todowrite, webfetch, write}. Naming a nonexistent tool is a silent no-op that
   reads like configuration.

--- a/scripts/opencode/agent/k8s.md
+++ b/scripts/opencode/agent/k8s.md
@@ -8,7 +8,7 @@ permission:
   write: deny
   # 🔴 NO `"*": allow` HERE. Agent rules are APPENDED AFTER the global block and
   # opencode is LAST-MATCH-WINS, so an agent-level wildcard NULLIFIES every
-  # global deny/ask at a stroke. Measured on 1.18.18: with `"*": allow` present
+  # global deny/ask at a stroke. Measured on 1.18.21: with `"*": allow` present
   # it landed at index 74, after all 30 global rules, and only the 4 rules below
   # it survived — `git stash`, `git reset --hard`, `git add -A`, `rm -rf ~…`,
   # `sops -d`, `nixos-rebuild` and `home-manager switch` were all plain ALLOW on

--- a/scripts/opencode/agent/review.md
+++ b/scripts/opencode/agent/review.md
@@ -6,7 +6,7 @@ temperature: 0.1
 permission:
   edit: deny
   write: deny
-  # MEASURED on 1.18.18 (`opencode debug agent review`): the agent's bash rules
+  # MEASURED on 1.18.21 (`opencode debug agent review`): the agent's bash rules
   # are APPENDED AFTER the global block, so the resolved list is
   #   [0] allow *   … global asks/denies …   [N] deny *   [N+1…] these allows
   # Last-match-wins therefore makes [N] the effective default: any command that

--- a/scripts/opencode/opencode.jsonc
+++ b/scripts/opencode/opencode.jsonc
@@ -44,7 +44,7 @@
 // patterns has known bypasses, which is the whole reason layer 2 exists.
 //
 // ==========================================================================
-// Mechanics of layer 1 (measured on v1.18.18 — do not re-derive)
+// Mechanics of layer 1 (measured on v1.18.21 — do not re-derive)
 // ==========================================================================
 //
 // 🔴 PERMISSION ORDERING IS LOAD-BEARING AND IS THE INVERSE OF CLAUDE CODE.
@@ -135,7 +135,7 @@
 // "restore consistency" by re-widening any of these four rules to infix without
 // reading those tests first.
 //
-// Other measured facts baked into this file (v1.18.18, EXCEPT where a bullet
+// Other measured facts baked into this file (v1.18.21, EXCEPT where a bullet
 // says otherwise — the 2026-08-19 re-derivation could not reach three of them,
 // and a claim relabelled to a version nothing measured it on is worse than a
 // stale one, because it looks fresh):
@@ -161,7 +161,7 @@
 //     `reference` (now `references`), `maxSteps` (now `steps`).
 //     `theme`/`keybinds`/`tui` moved to a separate ~/.config/opencode/tui.json
 //     and are NOT set here.
-//   * there is NO `list` tool and NO `websearch` tool on 1.18.18. The real set is
+//   * there is NO `list` tool and NO `websearch` tool on 1.18.21. The real set is
 //     exactly {bash, edit, glob, grep, invalid, question, read, skill, task,
 //     todowrite, webfetch, write}. Naming a nonexistent tool here is a no-op.
 {
@@ -252,7 +252,7 @@
     // — a blanket `"read": "allow"` here lands AFTER those and silently defeats
     // the `.env` guard on every agent. The default already allows everything
     // except `.env`, so there is nothing to add.
-    // `list` and `websearch` are absent because NO SUCH TOOLS EXIST on 1.18.18.
+    // `list` and `websearch` are absent because NO SUCH TOOLS EXIST on 1.18.21.
     "glob": "allow",
     "grep": "allow",
     "edit": "allow",

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -46,7 +46,7 @@ WHAT IS UNDER TEST (see scripts/opencode/README.md for the measurements):
      manual sweep into a standing assertion — after them, 10 of 77 survive, and
      all ten are non-bash tool rows.
 
-  3. The resolver model itself. opencode 1.18.18 resolves a permission by
+  3. The resolver model itself. opencode 1.18.21 resolves a permission by
      `findLast` over a FLAT ORDERED array (built-in defaults, then agent rules,
      then user config — later wins), matching with a hand-rolled glob→regex:
 
@@ -201,7 +201,7 @@ def agent_permission(name: str) -> dict:
 # --------------------------------------------------------------------------- #
 # 🔴 the resolver model
 #
-# Faithful port of opencode 1.18.18's `Wildcard.match` + the `findLast` resolver.
+# Faithful port of opencode 1.18.21's `Wildcard.match` + the `findLast` resolver.
 # See the module docstring for the verbatim source it was ported from and for
 # how it was validated against the real engine. THE PORT ITSELF now lives in
 # scripts/opencode/lib/oc_permissions.py (imported above) so that
@@ -1739,12 +1739,12 @@ def test_tool_level_permissions_are_pinned_exactly():
 
 @pytest.mark.parametrize("dead", ["list", "websearch"])
 def test_no_nonexistent_tools_in_permission_block(dead):
-    """There is no `list` and no `websearch` tool on 1.18.18. The resolved tool
+    """There is no `list` and no `websearch` tool on 1.18.21. The resolved tool
     map is exactly {bash, edit, glob, grep, invalid, question, read, skill,
     task, todowrite, webfetch, write}. Naming a nonexistent tool is a silent
     no-op that reads like configuration."""
     assert dead not in load_config()["permission"], (
-        f"{dead!r} is not a tool on opencode 1.18.18 — the key does nothing"
+        f"{dead!r} is not a tool on opencode 1.18.21 — the key does nothing"
     )
 
 
@@ -1953,7 +1953,7 @@ def test_nav_has_no_shell():
 def test_nav_is_kept_lean():
     """nav must not carry the skill catalogue or be able to recurse.
 
-    VERIFIED against `opencode debug agent nav` on 1.18.18: with these denies the
+    VERIFIED against `opencode debug agent nav` on 1.18.21: with these denies the
     resolved tool set is exactly {glob, grep, read} (+ the internal `invalid`).
     Without `skill: deny` it also carries {skill, task, todowrite, webfetch} —
     and `skill` alone injects the whole catalogue, measured at ~3,730 tokens on
@@ -1968,7 +1968,7 @@ def test_nav_is_kept_lean():
 
 
 def test_no_agent_promises_a_list_tool():
-    """There is NO `list` tool on opencode 1.18.18."""
+    """There is NO `list` tool on opencode 1.18.21."""
     targets = [AGENT_DIR / f"{n}.md" for n in EXPECTED_AGENTS] + [ADDENDUM]
     bad = []
     for p in targets:

--- a/scripts/tests/test_opencode_engine.py
+++ b/scripts/tests/test_opencode_engine.py
@@ -11,7 +11,7 @@ duplicate of it).
   That is a real gap, and it is exactly the gap the version pin exists to cover:
   a config whose keys are unchanged can have its RESOLVED MEANING changed by the
   binary underneath it. opencode.jsonc's header documents a large set of
-  behaviours annotated "measured on v1.18.18 — do not re-derive" — last-match-
+  behaviours annotated "measured on v1.18.21 — do not re-derive" — last-match-
   wins ordering, hidden agents inheriting the global permission block, the exact
   tool set. A static test cannot see any of those change. This file runs the
   real engine and checks them.
@@ -91,7 +91,7 @@ ROOT = Path(__file__).resolve().parents[2]
 OC_DIR = ROOT / "scripts" / "opencode"
 TOOLS_NIX = ROOT / "nix" / "pkgs" / "tools" / "default.nix"
 
-# 🔴 THE PIN. Every "measured on v1.18.18" claim in opencode.jsonc's header, in
+# 🔴 THE PIN. Every "measured on v1.18.21" claim in opencode.jsonc's header, in
 # scripts/opencode/README.md and in test_opencode_config.py's docstrings is keyed
 # to this exact version. It is pinned declaratively by nix/pkgs/tools/default.nix
 # resolving `pkgs.opencode` out of flake.lock's nixpkgs.
@@ -170,9 +170,29 @@ TOOLS_NIX = ROOT / "nix" / "pkgs" / "tools" / "default.nix"
 # hook-behaviour claims (`permission.ask` never fires, `tool.execute.before` does)
 # in scripts/opencode/README.md and scripts/opencode/plugin/guard.js. Those need
 # a running hook to observe and were not re-measured here.
-PINNED_VERSION = "1.18.18"
+# 🔴 RE-DERIVED 1.18.18 -> 1.18.21 (2026-08-29). `flake.lock` moved opencode
+# under an unchanged config — which is the exact class this file exists to catch,
+# so the red was the pin WORKING, not a defect. What was measured:
+#
+#   * This whole file against the NEW binary with the OLD pin: 1 failed (exactly
+#     the version assertion below), 24 passed. So every other engine claim —
+#     the engine-vs-model conformance tests, the resolved tool maps, the ordered
+#     permission arrays — holds on 1.18.21, and the harness is shown to
+#     DISCRIMINATE rather than be green by default. That is the same control the
+#     1.18.4 -> 1.18.16 entry above ran, and it is the load-bearing one.
+#   * NOT REPEATED from that entry, and named so nobody reads this as more than
+#     it is: the seven-agent `debug agent --pure` dump under BOTH binaries. It
+#     needs the superseded binary rebuilt from the pre-bump lock; the behavioural
+#     conformance tests cover the same semantics and all pass, so this was judged
+#     redundant rather than skipped for convenience. If a future bump sees a
+#     conformance failure, do the dual dump before trusting anything here.
+#   * The host was checked for the documented DEV-HOST cause first and it does
+#     not apply: `nix profile list` carries no opencode entry, and PATH resolves
+#     into /nix/store/...-opencode-1.18.21 out of the flake itself. This is a
+#     genuine lock movement, not per-host profile drift.
+PINNED_VERSION = "1.18.21"
 
-# MEASURED via `opencode debug agent nav --pure` at 1.18.18. This is the cost AND
+# MEASURED via `opencode debug agent nav --pure` at 1.18.21. This is the cost AND
 # blast-radius pin that test_opencode_config.py's `test_nav_is_kept_lean` only
 # asserts about the CONFIG KEYS; here it is read off the engine's resolved tool
 # map. `skill` alone injects the ~3,730-token catalogue on every request.
@@ -777,6 +797,33 @@ _VERSION_RE = re.compile(
 # nothing and reads as an orphan. Snippets carry no version literal of their own,
 # or they would match themselves when this file is scanned.
 HISTORICAL_VERSION_CLAIMS = (
+    # 🔴 Added by the 2026-08-29 re-derivation pass. Each is a claim the engine
+    # tests do NOT re-derive, so re-keying it would have been relabelling a
+    # measurement nobody repeated — the exact thing this ledger exists to stop.
+    # (Deliberately no version literals in THIS comment: a number here is itself
+    # a claim in the pin surface, and the ledger correctly flagged the first
+    # draft of it.)
+    ("scripts/browser-bridge/README.md", "Measured in the shipped",
+     "TaskTool.execute child-session internals — not observable from `debug "
+     "agent --pure`, so not re-derived at the new version"),
+    ("scripts/browser-bridge/README.md", "The hosts CONVERGED on 2026-08-15",
+     "dated narrative of a PAST pin move; the version names the move, not the present"),
+    ("scripts/browser-bridge/browser", "Measured in the shipped",
+     "same TaskTool internals claim as the README's, in the CLI's own comment"),
+    ("scripts/browser-bridge/browser", "creates a child session",
+     "the second half of that TaskTool internals claim"),
+    ("scripts/opencode/README.md", "Re-measured **2026-08-19** on engine",
+     "a dated COST measurement against a specific engine+model pair; a cost is not "
+     "re-derived by the permission/tool conformance tests"),
+    ("nix/home.nix", "COST — re-measured 2026-08-19 on engine",
+     "the same dated cost measurement, at its source"),
+    # 🔴 Version-FREE snippet, and that is a rule, not a style choice: a snippet
+    # containing a version literal makes the ledger entry's OWN source line an
+    # old-version line, so it matches twice and fails. Every entry here obeys it.
+    ("scripts/tests/test_opencode_engine.py", "`flake.lock` moved opencode",
+     "names the 2026-08-29 transition itself"),
+    ("scripts/tests/test_opencode_engine.py", "load-bearing one",
+     "cites the 2026-08-13 transition by its version pair, as prior art for the method"),
     ("nix/pkgs/tools/default.nix", "which drifted: MEASURED",
      "the per-host drift that motivated pinning; a dated fact"),
     ("nix/pkgs/tools/default.nix", "when this pin was introduced",
@@ -922,7 +969,7 @@ HISTORICAL_VERSION_CLAIMS = (
     # rather than wrong. `ship.sh` converged both on 2026-08-15, and the lock's
     # move to the CURRENT pin had reached both before this PR — re-verified at the
     # CONSUMER on 2026-08-19 (both `readlink -f $(command -v opencode)` resolve to
-    # the same …-opencode-1.18.18 store path), so those lines now carry the pinned
+    # the same …-opencode-1.18.21 store path), so those lines now carry the pinned
     # version and need no exemption.
     #
     # The ledger caught its own obsolescence: the moment the lines were updated,
@@ -1101,7 +1148,7 @@ def test_engine_and_model_agree_on_every_pinned_command(engine_name, model_agent
 # --------------------------------------------------------------------------- #
 def test_engine_resolves_navs_tool_set_to_exactly_the_pinned_four():
     """test_opencode_config.py's `test_nav_is_kept_lean` docstring says "VERIFIED
-    against `opencode debug agent nav` on 1.18.18: the resolved tool set is
+    against `opencode debug agent nav` on 1.18.21: the resolved tool set is
     exactly {glob, grep, read} (+ the internal `invalid`)" — but that file
     asserts only the CONFIG KEYS, so the verification was a one-off nobody
     re-ran. This re-runs it every gate.


### PR DESCRIPTION
`main` is red repo-wide on `test_engine_is_the_version_every_measurement_is_keyed_to`.
**That red is the pin working.** `test_opencode_engine.py` exists precisely to catch a
drifted BINARY under an unchanged config, and `flake.lock` moved opencode.

Second of the two deterministic failures blocking every PR (the other is #1021).

## Ruled out first
The test names per-host imperative-profile drift as the usual cause. It is **not** that:
`nix profile list` carries no opencode entry, and PATH resolves into the flake's own
store path. A genuine lock movement.

## Re-derived, not re-spelled
The test's instruction is explicit — *"do NOT just bump PINNED_VERSION: re-derive the
header's measurements against the new binary first"*.

- **Whole engine file, NEW binary, OLD pin: 1 failed (exactly the version assertion),
  24 passed.** Every other engine claim — conformance tests, resolved tool maps, ordered
  permission arrays — holds on 1.18.21, and the harness is shown to **discriminate**
  rather than be green by default. Same control the 1.18.4 → 1.18.16 pass used.
- **Both hosts measured at the consumer**: workbench and laptop each resolve
  `readlink -f $(command -v opencode)` to the **same** store path
  `…-opencode-1.18.21`. So "both hosts run \<v\>" claims are re-keyed on measurement,
  not relabelled.

## 30 re-keyed, 8 deliberately not
Re-keying was **line-targeted and asserted** — each edit names the flagged `file:line`
and refuses if it no longer carries the old version. A whole-file replace would also
have rewritten the historical lines, which is the one thing the ledger forbids.

Not re-keyed, each with a new `HISTORICAL_VERSION_CLAIMS` entry and its reason:
`TaskTool.execute` child-session internals (not observable from `debug agent --pure`),
two dated COST measurements against a specific engine+model pair, one dated narrative
of a past pin move, and the two bump-transition records. Re-keying those would have
relabelled measurements nobody repeated.

## 🔴 Two traps the ledger caught in my own first draft
Both are now documented in place, because both are non-obvious:

1. A ledger **comment** containing a version literal is itself a claim in the pin
   surface — so my explanatory comment failed the very test it was explaining.
2. A ledger **snippet** containing a version literal makes the entry's own source line
   an old-version line, so it matches twice and fails. That is why every pre-existing
   snippet is version-free; mine now are too.

## Verified
```
engine  25 passed
config 640 passed        (665 total)
nix-instantiate --parse  OK on flake.nix and nix/pkgs/tools/default.nix
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUzHBeB8LfTDwzCxnAJn2d