### PR TITLE
fix: unblock the required pytest gate — it is red on main for every PR

### DIFF
--- a/claude/opencode-addendum.md
+++ b/claude/opencode-addendum.md
@@ -32,7 +32,7 @@ bash guard.
 | search file contents | `grep` | `rg` / `grep` via bash |
 | see what is in a dir | `glob` on `<dir>/*` | `ls` |
 
-There is **no `list` tool** on opencode 1.18.18 — verified against the resolved
+There is **no `list` tool** on opencode 1.18.21 — verified against the resolved
 tool map, which contains exactly `bash, edit, glob, grep, invalid, question,
 read, skill, task, todowrite, webfetch, write`. Use `glob` to enumerate a
 directory.

--- a/flake.nix
+++ b/flake.nix
@@ -292,11 +292,11 @@
             # 🔴 This ALSO makes the sandbox the tier that pins the VERSION.
             # `pkgs.opencode` here and in nix/pkgs/tools/default.nix resolve from
             # the same flake.lock, so CI tests the exact binary the hosts deploy
-            # (1.18.18 at rev 5c680dac9f02). Cost, stated as deliberately as the
+            # (1.18.21 at rev c27cdad491a9). Cost, stated as deliberately as the
             # nodejs and nix entries above: this check's closure grows by
             # opencode, and a nixpkgs bump that moves it invalidates the cache
             # AND turns the version assertion red. That red is the point — the
-            # config header's "measured on v1.18.18 — do not re-derive" claims are
+            # config header's "measured on v1.18.21 — do not re-derive" claims are
             # otherwise pinned to nothing.
             #
             # logrotate: scripts/tests/test_claude_log_rotate.py drives the REAL

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -266,7 +266,14 @@ in
           # 'ask' ⊂ 'task' is the documented way a neighbour silently steals it.
           # :dacq keeps the words he actually types for THIS snippet (feedback,
           # dispatch, process); :acq owns ask/clarify/questions alone.
-          { trigger = ":dacq"; replace = "dispatch subagent to process feedback\nask clarifying questions and recommend improvements and anything useful to include before dispatching (include complete test coverage)"; label = "Process feedback: dispatch subagent + elicit scope"; search_terms = ["ask" "feedback" "dispatch" "process" "elicit" "scope" "include"]; }
+          # 🔴 DO NOT PUT "ask" BACK IN :dacq's search_terms. #979 shipped the
+          # split without it; f04bb5c6 added it back and made 'ask' ambiguous
+          # over both snippets again, so the highest-traffic term in the config
+          # went UNATTRIBUTED and the required pytest gate went red on main. The
+          # comment two lines up was already the contract — the code just stopped
+          # honouring it. If :dacq needs to be findable by an ask-like word, give
+          # it one :acq does not own, never "ask" itself.
+          { trigger = ":dacq"; replace = "dispatch subagent to process feedback\nask clarifying questions and recommend improvements and anything useful to include before dispatching (include complete test coverage)"; label = "Process feedback: dispatch subagent + elicit scope"; search_terms = ["feedback" "dispatch" "process" "elicit" "scope" "include"]; }
           { trigger = ":acq"; replace = "ask clarifying questions"; label = "ask clarifying questions"; search_terms = ["ask" "clarify" "clarifying" "questions"]; }
           { trigger = ":alo"; replace = "anything left outstanding from this thread? are all the objectives i specified directly and via the handoff fully addressed?"; label = "Anything left outstanding?"; search_terms = ["anything" "left" "outstanding" "loose" ]; }
           { trigger = ":roo"; replace = "reflect on objectives specified this session and determine if fully addressed and validated"; label = "reflect on objectives specified this session and determine if fully addressed and validated"; search_terms = ["reflect" "objectives" "addressed" ]; }

--- a/nix/pkgs/tools/default.nix
+++ b/nix/pkgs/tools/default.nix
@@ -12,18 +12,19 @@ with pkgs; [
   # hosts, which drifted: MEASURED 2026-08-02, laptop 1.18.4 / workbench 1.18.9,
   # each movable independently by a `nix profile upgrade` that nothing records.
   # scripts/opencode/opencode.jsonc documents a large set of load-bearing
-  # behaviours annotated "measured on v1.18.18 — do not re-derive" (last-match-
+  # behaviours annotated "measured on v1.18.21 — do not re-derive" (last-match-
   # wins permission ordering, the hidden title/summary/compaction agents
   # inheriting the global permission block, the exact tool set). A few bullets
   # there — `ask` semantics under `opencode run` among them — are explicitly
   # CARRIED FORWARD at an older version instead, each saying so on its own line.
   # Those claims were pinned to a version nothing pinned.
   #
-  # This entry pins them: MEASURED at flake.lock's nixpkgs rev 5c680dac9f02,
-  # `pkgs.opencode` is 1.18.18 — store path
-  # /nix/store/3y4zcklfn3hfk9gn08csfzd3vwfjhkl0-opencode-1.18.18. (It was
-  # 1.18.4 at rev 9bc02893134c when this pin was introduced, and 1.18.16 at rev
-  # 044bfe75bfe4; the 2026-08-13 and 2026-08-19 bumps each re-derived the claims
+  # This entry pins them: MEASURED at flake.lock's nixpkgs rev c27cdad491a9,
+  # `pkgs.opencode` is 1.18.21 — store path
+  # /nix/store/iqc8xfx692ym3pds6ky0vhqzscg6kgxd-opencode-1.18.21. (It was
+  # 1.18.4 at rev 9bc02893134c when this pin was introduced, 1.18.16 at rev 044bfe75bfe4, 1.18.18 at rev 5c680dac9f02;
+  # the 2026-08-13, 2026-08-19 and
+  # 2026-08-29 bumps each re-derived the claims
   # against the new binary rather than re-spelling them — see PINNED_VERSION in
   # scripts/tests/test_opencode_engine.py.) A nixpkgs bump
   # that moves it now shows up as a flake.lock diff AND fails

--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -2210,15 +2210,21 @@ field** (the CDP ops are bounded typed ops only; see the CDP security model abov
   Because the gate runs **before** the tab is opened, a gate failure leaks no tab.
 
   *Prerequisite:* an opencode whose `debug agent` reports a browser-only tool set.
-  **Both hosts run 1.18.18 and both resolve browser-only** (verified 2026-08-19:
-  the gate replicated ON EACH HOST parses to exactly one enabled tool, `browser`,
-  with every host tool present and `false`). There is no version-skew caveat
-  here any more. The hosts CONVERGED on 2026-08-15 and the pin's move to 1.18.18
-  had reached both before it was re-keyed — verified at the consumer, both
+  **Both hosts run 1.18.21 and both resolve browser-only** — but those are two
+  measurements with two dates, and only the first was re-taken at the current
+  pin. HOSTS: verified 2026-08-29 at the consumer, both
   `readlink -f $(command -v opencode)` resolving to the same
-  `…-opencode-1.18.18` store path — so the pin and the deploy agree. The
+  `…-opencode-1.18.21` store path the flake provides, so the pin and the deploy
+  agree. RESOLUTION: the gate replicated ON EACH HOST — parsing to exactly one
+  enabled tool, `browser`, with every host tool present and `false` — was last
+  run 2026-08-19 on the superseded binary; it carries forward because the
+  2026-08-29 bump's differential found the resolved tool map IDENTICAL across
+  the two binaries for all seven agents, not because it was re-run per host.
+  There is no version-skew caveat
+  here any more. The hosts CONVERGED on 2026-08-15 and the pin's move to 1.18.21
+  had reached both before it was re-keyed. The
   browser-only resolution was measured identical on 1.18.4 and 1.18.16, and again
-  on the 1.18.18 binary, so no bump has changed it. 🔴 The RAW dump is NOT byte-stable, on either binary: the
+  on the 1.18.21 binary, so no bump has changed it. 🔴 The RAW dump is NOT byte-stable, on either binary: the
   `permission` array's order follows a directory walk and varies run to run, so
   `cmp` on two dumps differs for reasons that have nothing to do with the version.
   Compare the resolved tool set, or canonicalise first. So the deploy gap does not
@@ -2311,7 +2317,7 @@ ln -sf ~/workspace/devrc/scripts/browser-bridge/opencode/tools/browser_tool_impl
 the wrapper substitutes them per run.)
 
 **opencode version.** The custom-tool mechanism (`.opencode/tools/*.js`,
-`permission: {"*": deny, …}`) is **verified on 1.18.18, which is what BOTH hosts
+`permission: {"*": deny, …}`) is **verified on 1.18.21, which is what BOTH hosts
 run and what `flake.lock` pins** (measured identical on 1.18.4 before the bump) — `opencode debug agent
 browser-agent` resolves to `bash:false … browser:true`
 (exactly one enabled tool) on each, plus an end-to-end `opencode debug agent …

--- a/scripts/browser-bridge/reference/agent.md
+++ b/scripts/browser-bridge/reference/agent.md
@@ -26,7 +26,7 @@ command unrunnable, which is why fixing the first didn't appear to help:
    be reached. Fixed by probing without injecting.
 
 🔴 **Every doc misattributed both symptoms to an opencode *version* problem for the
-entire arc.** They are not version-related — both hosts run 1.18.18 and both
+entire arc.** They are not version-related — both hosts run 1.18.21 and both
 resolve browser-only, and the same resolution was measured on 1.18.4 and 1.18.16
 before the bumps. Do not re-open that hypothesis.
 
@@ -248,7 +248,7 @@ browser agent "go to news.ycombinator.com and report the top 3 story titles" \
   fail-closed property is *verified at runtime* rather than trusted — on any
   opencode where the host-tool denial didn't take, `browser agent` refuses instead
   of running the model unconfined. The gate runs BEFORE the tab is opened, so a
-  gate failure leaks no tab. **Both hosts run 1.18.18 and both resolve
+  gate failure leaks no tab. **Both hosts run 1.18.21 and both resolve
   browser-only**, and it resolved identically on 1.18.4 and 1.18.16 before the
   bumps — there is no version-skew caveat.
   - ⚠ **If you check the gate by hand, redirect to a FILE**

--- a/scripts/opencode/README.md
+++ b/scripts/opencode/README.md
@@ -269,7 +269,7 @@ existence guard**, and defined a `KC_PROD` that zsh did not have. Add a handle i
   (`*.env` → ask); a blanket allow is appended after it and silently defeats it
   on every agent. The default already allows every non-`.env` read, so the
   correct configuration is to say nothing.
-- **There is no `list` tool and no `websearch` tool** on 1.18.18. The resolved set
+- **There is no `list` tool and no `websearch` tool** on 1.18.21. The resolved set
   is exactly {bash, edit, glob, grep, invalid, question, read, skill, task,
   todowrite, webfetch, write}. Naming a nonexistent tool is a silent no-op that
   reads like configuration.

--- a/scripts/opencode/agent/k8s.md
+++ b/scripts/opencode/agent/k8s.md
@@ -8,7 +8,7 @@ permission:
   write: deny
   # 🔴 NO `"*": allow` HERE. Agent rules are APPENDED AFTER the global block and
   # opencode is LAST-MATCH-WINS, so an agent-level wildcard NULLIFIES every
-  # global deny/ask at a stroke. Measured on 1.18.18: with `"*": allow` present
+  # global deny/ask at a stroke. Measured on 1.18.21: with `"*": allow` present
   # it landed at index 74, after all 30 global rules, and only the 4 rules below
   # it survived — `git stash`, `git reset --hard`, `git add -A`, `rm -rf ~…`,
   # `sops -d`, `nixos-rebuild` and `home-manager switch` were all plain ALLOW on

--- a/scripts/opencode/agent/review.md
+++ b/scripts/opencode/agent/review.md
@@ -6,7 +6,7 @@ temperature: 0.1
 permission:
   edit: deny
   write: deny
-  # MEASURED on 1.18.18 (`opencode debug agent review`): the agent's bash rules
+  # MEASURED on 1.18.21 (`opencode debug agent review`): the agent's bash rules
   # are APPENDED AFTER the global block, so the resolved list is
   #   [0] allow *   … global asks/denies …   [N] deny *   [N+1…] these allows
   # Last-match-wins therefore makes [N] the effective default: any command that

--- a/scripts/opencode/opencode.jsonc
+++ b/scripts/opencode/opencode.jsonc
@@ -44,7 +44,7 @@
 // patterns has known bypasses, which is the whole reason layer 2 exists.
 //
 // ==========================================================================
-// Mechanics of layer 1 (measured on v1.18.18 — do not re-derive)
+// Mechanics of layer 1 (measured on v1.18.21 — do not re-derive)
 // ==========================================================================
 //
 // 🔴 PERMISSION ORDERING IS LOAD-BEARING AND IS THE INVERSE OF CLAUDE CODE.
@@ -135,7 +135,7 @@
 // "restore consistency" by re-widening any of these four rules to infix without
 // reading those tests first.
 //
-// Other measured facts baked into this file (v1.18.18, EXCEPT where a bullet
+// Other measured facts baked into this file (v1.18.21, EXCEPT where a bullet
 // says otherwise — the 2026-08-19 re-derivation could not reach three of them,
 // and a claim relabelled to a version nothing measured it on is worse than a
 // stale one, because it looks fresh):
@@ -161,7 +161,7 @@
 //     `reference` (now `references`), `maxSteps` (now `steps`).
 //     `theme`/`keybinds`/`tui` moved to a separate ~/.config/opencode/tui.json
 //     and are NOT set here.
-//   * there is NO `list` tool and NO `websearch` tool on 1.18.18. The real set is
+//   * there is NO `list` tool and NO `websearch` tool on 1.18.21. The real set is
 //     exactly {bash, edit, glob, grep, invalid, question, read, skill, task,
 //     todowrite, webfetch, write}. Naming a nonexistent tool here is a no-op.
 {
@@ -252,7 +252,7 @@
     // — a blanket `"read": "allow"` here lands AFTER those and silently defeats
     // the `.env` guard on every agent. The default already allows everything
     // except `.env`, so there is nothing to add.
-    // `list` and `websearch` are absent because NO SUCH TOOLS EXIST on 1.18.18.
+    // `list` and `websearch` are absent because NO SUCH TOOLS EXIST on 1.18.21.
     "glob": "allow",
     "grep": "allow",
     "edit": "allow",

--- a/scripts/tests/test_opencode_config.py
+++ b/scripts/tests/test_opencode_config.py
@@ -46,7 +46,7 @@ WHAT IS UNDER TEST (see scripts/opencode/README.md for the measurements):
      manual sweep into a standing assertion — after them, 10 of 77 survive, and
      all ten are non-bash tool rows.
 
-  3. The resolver model itself. opencode 1.18.18 resolves a permission by
+  3. The resolver model itself. opencode 1.18.21 resolves a permission by
      `findLast` over a FLAT ORDERED array (built-in defaults, then agent rules,
      then user config — later wins), matching with a hand-rolled glob→regex:
 
@@ -201,7 +201,7 @@ def agent_permission(name: str) -> dict:
 # --------------------------------------------------------------------------- #
 # 🔴 the resolver model
 #
-# Faithful port of opencode 1.18.18's `Wildcard.match` + the `findLast` resolver.
+# Faithful port of opencode 1.18.21's `Wildcard.match` + the `findLast` resolver.
 # See the module docstring for the verbatim source it was ported from and for
 # how it was validated against the real engine. THE PORT ITSELF now lives in
 # scripts/opencode/lib/oc_permissions.py (imported above) so that
@@ -1739,12 +1739,12 @@ def test_tool_level_permissions_are_pinned_exactly():
 
 @pytest.mark.parametrize("dead", ["list", "websearch"])
 def test_no_nonexistent_tools_in_permission_block(dead):
-    """There is no `list` and no `websearch` tool on 1.18.18. The resolved tool
+    """There is no `list` and no `websearch` tool on 1.18.21. The resolved tool
     map is exactly {bash, edit, glob, grep, invalid, question, read, skill,
     task, todowrite, webfetch, write}. Naming a nonexistent tool is a silent
     no-op that reads like configuration."""
     assert dead not in load_config()["permission"], (
-        f"{dead!r} is not a tool on opencode 1.18.18 — the key does nothing"
+        f"{dead!r} is not a tool on opencode 1.18.21 — the key does nothing"
     )
 
 
@@ -1953,7 +1953,7 @@ def test_nav_has_no_shell():
 def test_nav_is_kept_lean():
     """nav must not carry the skill catalogue or be able to recurse.
 
-    VERIFIED against `opencode debug agent nav` on 1.18.18: with these denies the
+    VERIFIED against `opencode debug agent nav` on 1.18.21: with these denies the
     resolved tool set is exactly {glob, grep, read} (+ the internal `invalid`).
     Without `skill: deny` it also carries {skill, task, todowrite, webfetch} —
     and `skill` alone injects the whole catalogue, measured at ~3,730 tokens on
@@ -1968,7 +1968,7 @@ def test_nav_is_kept_lean():
 
 
 def test_no_agent_promises_a_list_tool():
-    """There is NO `list` tool on opencode 1.18.18."""
+    """There is NO `list` tool on opencode 1.18.21."""
     targets = [AGENT_DIR / f"{n}.md" for n in EXPECTED_AGENTS] + [ADDENDUM]
     bad = []
     for p in targets:

--- a/scripts/tests/test_opencode_engine.py
+++ b/scripts/tests/test_opencode_engine.py
@@ -11,7 +11,7 @@ duplicate of it).
   That is a real gap, and it is exactly the gap the version pin exists to cover:
   a config whose keys are unchanged can have its RESOLVED MEANING changed by the
   binary underneath it. opencode.jsonc's header documents a large set of
-  behaviours annotated "measured on v1.18.18 — do not re-derive" — last-match-
+  behaviours annotated "measured on v1.18.21 — do not re-derive" — last-match-
   wins ordering, hidden agents inheriting the global permission block, the exact
   tool set. A static test cannot see any of those change. This file runs the
   real engine and checks them.
@@ -91,7 +91,7 @@ ROOT = Path(__file__).resolve().parents[2]
 OC_DIR = ROOT / "scripts" / "opencode"
 TOOLS_NIX = ROOT / "nix" / "pkgs" / "tools" / "default.nix"
 
-# 🔴 THE PIN. Every "measured on v1.18.18" claim in opencode.jsonc's header, in
+# 🔴 THE PIN. Every "measured on v1.18.21" claim in opencode.jsonc's header, in
 # scripts/opencode/README.md and in test_opencode_config.py's docstrings is keyed
 # to this exact version. It is pinned declaratively by nix/pkgs/tools/default.nix
 # resolving `pkgs.opencode` out of flake.lock's nixpkgs.
@@ -170,9 +170,41 @@ TOOLS_NIX = ROOT / "nix" / "pkgs" / "tools" / "default.nix"
 # hook-behaviour claims (`permission.ask` never fires, `tool.execute.before` does)
 # in scripts/opencode/README.md and scripts/opencode/plugin/guard.js. Those need
 # a running hook to observe and were not re-measured here.
-PINNED_VERSION = "1.18.18"
+#
+# 🔴 RE-DERIVED AGAIN 1.18.18 -> 1.18.21 (2026-08-29), by the SAME method as the
+# two bumps above, because `chore: update flake.lock` moved the binary without
+# re-keying anything and left this assertion RED on main — so the required
+# `tekton/devrc-pytests` check was failing for every PR in the repo, not just the
+# one that noticed. What was measured, with its controls, so the next bump can
+# repeat it rather than trust this paragraph:
+#
+#   * `debug agent <a> --pure` for ALL SEVEN agents under BOTH binaries — store
+#     paths 3y4zcklfn3hfk9gn08csfzd3vwfjhkl0 (superseded) and
+#     iqc8xfx692ym3pds6ky0vhqzscg6kgxd (current), named by hash so this record
+#     carries no version literal of its own — config dir seeded from this repo,
+#     minimal env, stdout to a file. 7/7 IDENTICAL — permission array, resolved
+#     tool map, model, description, prompt and mode. A cleaner result than the
+#     2026-08-19 pass, which found `compaction`'s built-in prompt had moved.
+#   * SAME-BINARY CONTROL, as the paragraph above demands before any
+#     cross-version verdict is believed: two runs of 1.18.21 collapse to
+#     identical on all seven agents. The readdir nondeterminism that once made
+#     two same-binary runs differ on 434 lines does not arise under this
+#     harness's env, because HOME is an empty temp dir and there is no
+#     ~/.claude/skills or ~/.config/opencode/skills to walk.
+#   * NEGATIVE CONTROL on the comparison itself, so "IDENTICAL" is not just what
+#     it always says: `nav` vs `k8s` on ONE binary reports DIFFERS on seven
+#     top-level keys.
+#   * POSITIVE CONTROL on the captures: 10 top-level keys, 12 resolved tools and
+#     92-119 permission entries per agent, no error markers — the dumps compared
+#     are real engine output, not two identically-failed runs.
+#   * This whole file against the CURRENT binary, before the pin below was
+#     re-keyed: 24 passed, 1 failed — exactly that assertion. And against the
+#     SUPERSEDED binary WITH the re-keyed pin and the renumbered claims: 1
+#     failed, again exactly that assertion. So the pin discriminates in both
+#     directions rather than being green by default.
+PINNED_VERSION = "1.18.21"
 
-# MEASURED via `opencode debug agent nav --pure` at 1.18.18. This is the cost AND
+# MEASURED via `opencode debug agent nav --pure` at 1.18.21. This is the cost AND
 # blast-radius pin that test_opencode_config.py's `test_nav_is_kept_lean` only
 # asserts about the CONFIG KEYS; here it is read off the engine's resolved tool
 # map. `skill` alone injects the ~3,730-token catalogue on every request.
@@ -813,8 +845,27 @@ HISTORICAL_VERSION_CLAIMS = (
     # match. Both entries are now keyed on text only their own line carries.
     ("scripts/tests/test_opencode_engine.py", "not merely re-spelled",
      "names the 2026-08-13 transition itself"),
-    ("scripts/tests/test_opencode_engine.py", "RE-DERIVED AGAIN",
+    ("scripts/tests/test_opencode_engine.py", "(2026-08-19), by the SAME method",
      "names the 2026-08-19 transition itself"),
+    # 🔴 The 2026-08-29 bump. Its own transition line names both versions by
+    # construction; the rest below were NOT re-derived at the new pin, and
+    # renumbering them would turn a dated measurement into a false one that
+    # reads exactly like a fresh reading. Every snippet here is version-FREE,
+    # per the note on _VERSION_RE — one quoting a literal matches itself.
+    ("scripts/tests/test_opencode_engine.py", "(2026-08-29), by the SAME method",
+     "names the 2026-08-29 transition itself"),
+    ("scripts/tests/test_opencode_engine.py", "store path), so those lines now carry the pinned",
+     "dated 2026-08-19 consumer re-verification; a historical record"),
+    ("scripts/opencode/README.md", "Re-measured **2026-08-19** on engine",
+     "dated COST measurement — token/spend figures were not re-measured at the new pin"),
+    ("nix/home.nix", "COST — re-measured 2026-08-19 on engine",
+     "dated COST measurement — the A/B token pair was not re-run at the new pin"),
+    ("scripts/browser-bridge/README.md", "binary: `TaskTool.execute` creates a child",
+     "TaskTool.execute internals — the differential covered agent resolution, not this"),
+    ("scripts/browser-bridge/browser", "binary: `TaskTool.execute` creates a CHILD",
+     "same claim in the CLI; not re-derived"),
+    ("scripts/browser-bridge/browser", "binary, `TaskTool.execute` creates a child session",
+     "same claim again in the CLI's long-form note; not re-derived"),
     ("scripts/tests/test_opencode_engine.py", "deliberately still keyed to",
      "the pin's own note naming the not-re-derived subset"),
     ("scripts/tests/test_opencode_engine.py", "MEASURED 2026-08-11 on the workbench, opencode",
@@ -1101,7 +1152,7 @@ def test_engine_and_model_agree_on_every_pinned_command(engine_name, model_agent
 # --------------------------------------------------------------------------- #
 def test_engine_resolves_navs_tool_set_to_exactly_the_pinned_four():
     """test_opencode_config.py's `test_nav_is_kept_lean` docstring says "VERIFIED
-    against `opencode debug agent nav` on 1.18.18: the resolved tool set is
+    against `opencode debug agent nav` on 1.18.21: the resolved tool set is
     exactly {glob, grep, read} (+ the internal `invalid`)" — but that file
     asserts only the CONFIG KEYS, so the verification was a one-off nobody
     re-ran. This re-runs it every gate.


### PR DESCRIPTION
`tekton/devrc-pytests` is a **required** check with `enforce_admins: true`, and it has been failing on `main` itself — so nothing in the repo could merge, not just the PR that noticed.

**Measured**, not inferred: `nix build .#checks.x86_64-linux.pytests` from `origin/main` → **FAIL**, `passed=18337 failed=3`.

| tree | sandbox pytests |
|---|---|
| `origin/main` | FAIL — `passed=18337 failed=3` |
| this branch | **PASS** — `passed=18340 failed=0` |

Both previously-red suites now pass: `scripts/tests 9819/9819`, `scripts/collector/keylog/tests 93/93`. `nodetests` also green (`1300/1300`).

Two independent causes.

## 1. espanso — `ask` went ambiguous again

`#979` shipped the `:acq`/`:dacq` split with `"ask"` deliberately **not** in `:dacq`'s `search_terms`. `f04bb5c6` ("espanso") added it back. `_token_matches` reads `search_terms`, so `ask` matched both snippets, `_attribute` returned `None`, and the highest-traffic term in the whole config (58 fires in the 2026-08-06..19 window) went **UNATTRIBUTED**.

`nix/home.nix`'s own comment two lines above already stated the contract — *":acq owns ask/clarify/questions alone"* — the code just stopped honouring it.

Fixed in the **config**, not the pinned table, which is what the test's own ANTI-VACUITY note requires: *"had the term merely gone ambiguous, the fix would be the config"*. Verified the test reads this tree (`HOME_NIX` resolves to the worktree copy, and the `:dacq` line no longer contains `ask`), and that its positive control `test_live_scraper_observes_the_real_config` is green.

## 2. opencode — the lock moved the binary to 1.18.21 without re-keying anything

Same shape as #570 and the 2026-08-13 bump. The pin's own message forbids the one-line fix, so the claims were **re-derived first**, with controls reported as pairs:

- `debug agent <a> --pure` for **all seven** agents under **both** binaries: **7/7 IDENTICAL** — permission array, resolved tool map, model, description, prompt, mode. Cleaner than the 08-19 bump, which found `compaction`'s built-in prompt had moved.
- **Same-binary control**, which the file demands before any cross-version verdict is believed: two runs of the new binary collapse to identical on all seven agents. The readdir nondeterminism that once made two same-binary runs differ on 434 lines does not arise under this harness's env — `HOME` is an empty temp dir, so there are no skills directories to walk.
- **Negative control** on the comparison itself: `nav` vs `k8s` on one binary reports DIFFERS on seven top-level keys — so "IDENTICAL" is not all it can say.
- **Positive control** on the captures: 10 top-level keys, 12 resolved tools, 92–119 permission entries per agent, no error markers.
- **Discrimination, both directions**: the file against the current binary *before* re-keying → 1 failed (exactly the version assertion); against the superseded binary *after* re-keying → 1 failed, the same one.

Then the pin was re-keyed and **27 claim lines renumbered across 11 files**. Deployed-state lines are renumbered on a measurement, not on faith: both hosts resolve `…-opencode-1.18.21`, the same store path the flake provides (2026-08-29, `readlink -f $(command -v opencode)` on workbench and laptop).

### Deliberately NOT renumbered

Renumbering an un-re-derived claim turns a dated measurement into a false one that reads like a fresh reading. These are ledgered as historical instead:

- the two dated **cost** measurements — token/spend figures were not re-run;
- the three **`TaskTool.execute` internals** claims — the differential covered agent resolution, not that.

Every new ledger snippet is **version-free**, per the file's own note: a snippet quoting a literal matches itself when this file is scanned.

One renumbered line needed more than a number. The browser-bridge *"both hosts run … and both resolve browser-only"* claim bundled a host reading with a per-host gate replication; only the first was re-taken. They are now stated separately, each with its own date and the reason the second carries forward.

## Why this is its own PR

Neither fix belongs to the discord-embed-ext work that surfaced them (#1010), and unblocking the gate unblocks every open PR, not one.
