### PR TITLE
docs(browser-bridge): redact two public-exposure lines from the civitai.com site notes

### DIFF
--- a/scripts/browser-bridge/reference/sites/civitai.com.md
+++ b/scripts/browser-bridge/reference/sites/civitai.com.md
@@ -300,8 +300,8 @@ under a minute:
    than an unchanged `messages-container`.
 
 Pin a **numeric** before/after alongside them (`[data-testid="buzz-balance"]` here —
-constant at `4,169,692 BUZZ` across the whole run) and sweep for error surfaces the
-container would not show:
+read it once up front and assert it is unchanged across the whole run) and sweep for
+error surfaces the container would not show:
 
 ```bash
 $BB --instance work --tab "$TAB" --frame "$FR" js '(function(){var o=[];document.querySelectorAll("[role=alert], .error, [class*=error], [class*=toast], [class*=notification]").forEach(function(e){o.push((e.innerText||"").trim().slice(0,100))});return JSON.stringify({errors:o})})()'
@@ -322,8 +322,7 @@ unmoved, over ~70 s and two send routes (button and `key Enter`).
   (whole-DOM search).
 - **NOT ruled out:** an `isTrusted`-gated branch on the specific handler under test.
   Synthetic input reaching *one* path is not proof it reaches *another*. Say so in the
-  report rather than claiming a slam dunk — and note that such a gate would still be a
-  bug the app ships.
+  report rather than claiming a slam dunk.
 
 ---
 


### PR DESCRIPTION
Two lines in `scripts/browser-bridge/reference/sites/civitai.com.md` published things that did not need to be public. **devrc is a public repo** (`innovation-upstream/devrc`, `isPrivate:false`), which is what makes these worth removing; neither line carried any of the method's value.

### What changed

**1. `:303` — the operator's actual Buzz balance.** It was the worked example of "pin a numeric invariant across a run". The technique is the point, not the figure. The line now tells the reader to read the value once up front and assert it is unchanged — which is what they should do with *their own* balance anyway.

**2. `:326` — an editorial aside about an unfixed defect.** The `isTrusted` paragraph closed with a claim that such a gate "would still be a bug the app ships" — a public assertion about a defect in someone else's product, made in passing in a tooling doc. The paragraph's actual point (synthetic input reaching one path is not proof it reaches another, so do not report a slam dunk) is unchanged and stands without it.

Net: 3 insertions, 4 deletions, one file.

### Verification

Swept the whole tracked tree before editing rather than trusting the enumeration — `git grep` on `origin/main` for both the delimited (`4,169,692`) and undelimited (`4169692`) forms returns **exactly one hit**, the line at `:303`. A positive control on a synthetic string confirms the pattern can match, so the single hit is a real count and not a dead regex.

### Not addressed, deliberately

🔴 **This only changes the tip.** Both lines remain in this public repo's **git history**, and redacting the working tree does not unpublish them. Rewriting history on a shared public repo is an operator call with real blast radius (every clone and open PR), not something to fold into a docs PR. Flagging it so the decision is explicit rather than assumed closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017myTrjbhq4fTZGiacQVjMM
