### PR TITLE
fix(tests): store-api hang-detectors time out on SCHEDULING — the pytests gate is failing 74% of runs repo-wide

### DIFF
--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -72,6 +72,31 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
+
+# 🔴 ONE bound for every "this should already have happened" wait in this module
+# — the localhost HTTP round-trips, `wait_closed`, `await_audit`. These are
+# HANG-DETECTORS: they exist so a broken server fails the test instead of hanging
+# the suite forever, and their value is not a correctness claim about how fast
+# anything must be.
+#
+# It is deliberately NOT used for the raw-socket `settimeout(...)` calls further
+# down. Those are DRAIN bounds — the loop terminator for a `recv`-until-quiet
+# read — so raising one adds its full value to the suite's runtime instead of
+# only to the latency of a genuine failure. Same spelling, opposite meaning; a
+# single shared constant across both would be wrong.
+#
+# Why 60 and not 15: measured 2026-08-29, the devrc Tekton gate was failing
+# ~60% of runs REPO-WIDE (6 of 10 in one window, on unrelated branches) with
+# `TimeoutError` out of `socket.py` — a localhost round-trip that lost the
+# scheduler for >15 s while 12 pipelineruns shared the node and this suite ran
+# 637 s under xdist. The test logic was never reached, so the gate reported a
+# code failure for a capacity problem. 60 s absorbs a 4x scheduling delay and
+# still fails a genuinely hung server well inside the task timeout.
+#
+# 🔴 This is the SYMPTOM fix. The cause is a 10-minute parallel suite competing
+# with a saturated cluster, which belongs to Tekton capacity, not to this file.
+HANG_TIMEOUT = 60.0
+
 API_DIR = ROOT / "scripts" / "subsystem-store-api"
 SERVER_PATH = API_DIR / "server.py"
 SEED_PATH = API_DIR / "seed.sh"
@@ -268,7 +293,7 @@ def fetch(
     for key, value in (extra_headers or {}).items():
         req.add_header(key, value)
     try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
+        with urllib.request.urlopen(req, timeout=HANG_TIMEOUT) as resp:
             return resp.status, dict(resp.headers), resp.read()
     except urllib.error.HTTPError as exc:
         return exc.code, dict(exc.headers), exc.read()
@@ -282,7 +307,7 @@ def _raw_request(host: str, path: str, headers: list[tuple[str, str]]) -> int:
     of expressing the "two `CF-Connecting-IP`s" case. `http.client.putheader`
     can.
     """
-    conn = http.client.HTTPConnection(host, timeout=15)
+    conn = http.client.HTTPConnection(host, timeout=HANG_TIMEOUT)
     try:
         conn.putrequest("GET", path, skip_host=True, skip_accept_encoding=True)
         conn.putheader("Host", host)
@@ -414,7 +439,7 @@ class Drained:
         """The whole stream, for `x not in out` style assertions."""
         return "\n".join(self.all)
 
-    def wait_closed(self, timeout: float = 15.0) -> bool:
+    def wait_closed(self, timeout: float = HANG_TIMEOUT) -> bool:
         """Block until the process's stdout reaches EOF. Returns whether it did.
 
         Read `text` only AFTER this. Without it the reader thread may still be
@@ -465,7 +490,7 @@ def drain_output(proc) -> Drained:
     return out
 
 
-def await_audit(out: "Drained | AuditLog", n: int, timeout: float = 15.0) -> "list[str]":
+def await_audit(out: "Drained | AuditLog", n: int, timeout: float = HANG_TIMEOUT) -> "list[str]":
     """Wait for at least `n` audit lines, then return them. RAISES if they never
     arrive.
 
@@ -4020,7 +4045,7 @@ def fetch_from(
     """
     host, _, port = base.removeprefix("http://").partition(":")
     conn = http.client.HTTPConnection(
-        host, int(port), timeout=15, source_address=(source_ip, 0)
+        host, int(port), timeout=HANG_TIMEOUT, source_address=(source_ip, 0)
     )
     try:
         headers = {}
@@ -5747,7 +5772,7 @@ class TestTrustedProxyOverTheRealProcess:
             store, token_file, trusted_proxies=NOT_LOOPBACK_PROXY
         ) as (_base, proc):
             proc.terminate()
-            stdout, _err = proc.communicate(timeout=15)
+            stdout, _err = proc.communicate(timeout=HANG_TIMEOUT)
         assert f"trusted-proxies={NOT_LOOPBACK_PROXY}" in stdout, stdout
 
 


### PR DESCRIPTION
Opening a PR for an **existing, already-pushed commit** (`8d1f6671`, authored 2026-08-29 12:28) that never had one raised. No code was written for this PR — the change is unmodified; what follows is the verification it was missing.

## Why this matters right now

The `tekton/devrc-pytests` gate is failing across unrelated commits, so it is currently blocking every open PR rather than catching defects in any of them.

Measured on the live cluster 2026-08-29:

- **Retained `devrc-ci` runs: 17 failed / 6 succeeded — a 26% pass rate.**
- Six failing runs, six different commits, and **each failed a *different* single test** out of ~18,555:

| run | commit | failing test |
|---|---|---|
| `devrc-ci-292dv` | `d3363d74` (**on main**) | `TestTheBackstopNeverSendsASecondResponse...` |
| `devrc-ci-4875k` | `5ccdc81a` | `TestTheActorComesFromTheTOKEN...` |
| `devrc-ci-5r998` | `9742196c` | `TestTheActorComesFromTheTOKEN...` |
| `devrc-ci-7n557` | `51aac4b7` | `TestTheActorComesFromTheTOKEN...` |
| `devrc-ci-8wqm4` | `2809482e` (**on main**) | `test_without_the_unset_the_runner_hands...` |
| `devrc-ci-69gz8` | `ea44ed69` | `TestAppendIsCommutativeAndIdempotent...` |

Two of those commits are **on `main`**, so this is not a property of anyone's branch. A different single test failing each time, out of 18,555, is a load signature — not six unrelated defects.

## That the fix reaches the observed failure

Worth stating explicitly, because a timeout bump is easy to wave through without checking it touches the failing path.

`devrc-ci-69gz8` failed with `KeyError: 'a'` at `test_subsystem_store_api.py:10076` — the assertion reads `results["a"]`, and the key is absent because the writer thread raised instead of recording a result. The thread had already been asserted `not is_alive()`, so it finished by exception, and the traceback bottoms out in `socket.py` `TimeoutError`.

That path is `post_bullet` → `fetch` → `urllib.request.urlopen(req, timeout=...)`, which is one of the seven sites this commit moves from `15` to `HANG_TIMEOUT`. So the fix widens exactly the bound that broke, not a neighbouring one.

## What the change is careful about

It does **not** apply the constant to the raw-socket `settimeout()` calls. Those are drain bounds — the terminator for a `recv`-until-quiet loop — where raising the value adds its full amount to every run's wall time, instead of only to the latency of a genuine failure. Same spelling, opposite meaning. That distinction is documented in the comment rather than left for the next reader to rediscover.

## Verification, and its limits

- **Merged tree, not just the branch** (the branch is 20 commits behind `main`; `git merge-tree` exits 0, no conflict): built `main` + this branch and ran the affected suite — **614 passed in 304.88s**.
- The specific failing test also passes in isolation on unmodified `main` (4.62s), which is what rules out a real defect and identifies this as load-sensitivity rather than breakage.

🔴 **A local green run cannot prove a load flake is fixed.** Both runs above were serial and unloaded — the condition that broke CI is 4 xdist workers competing with a saturated cluster, which I did not reproduce. The real evidence is this gate's pass rate over the next several runs. Treat the local numbers as "no regression introduced", not as "the flake is gone".

🔴 **This is the symptom fix, and the commit says so itself:** the cause is a ~10-minute parallel suite competing for a saturated node. Aligning pytest's worker count to the pod's cgroup budget rather than the node's `nproc` is tracked separately (clawgate **418**) and is not attempted here.

## Closing condition

`tekton/devrc-pytests` passes on this PR, and the next several `devrc-ci` runs on unrelated commits stop failing on single scattered tests. If the pass rate does not move off ~26%, this was the wrong lever and the capacity work in 418 is the real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017myTrjbhq4fTZGiacQVjMM
