### PR TITLE
fix(nvim): the whole config failed to load outside a graphical session — and that is why #1027 shipped inert

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -1,4 +1,17 @@
-nvimConfigDir=string.format("%s/.config/nvim", os.getenv("DEVRC_DIR"))
+-- 🔴 SELF-LOCATING, deliberately -- do NOT reintroduce os.getenv("DEVRC_DIR").
+-- That variable is set only by a systemd Environment= line in graphical.nix, so
+-- outside a graphical session (ssh, a bare TTY, a unit, cron) it is nil, and
+-- string.format("%s", nil) yields the literal "nil" -- every source() below then
+-- resolved under "nil/.config/nvim/" and the whole lua half silently did not
+-- load. Measured over real ssh 2026-08-29.
+--
+-- This file's own path cannot be unset, so deriving the directory from it
+-- removes the dependency rather than defaulting it. nix substitutes the same
+-- path into init.vim at build time so that THIS file can be found in the first
+-- place; the two must agree, and neither reads the environment.
+local thisFile = debug.getinfo(1, "S").source:sub(2)
+nvimConfigDir = thisFile:match("^(.*)/init%.lua$")
+assert(nvimConfigDir, "could not derive the nvim config dir from " .. thisFile)
 
 local function source(relPath)
   dofile(string.format("%s/lua/%s", nvimConfigDir, relPath))

--- a/.config/nvim/lua/config/plugin/lazygit.lua
+++ b/.config/nvim/lua/config/plugin/lazygit.lua
@@ -1,7 +1,15 @@
 vim.g.lazygit_floating_window_scaling_factor = 1
 vim.g.lazygit_use_custom_config_file_path = 1
-local devrcDir = os.getenv("DEVRC_DIR")
-local path = string.format("%s/.config/lazygit/config.yml", devrcDir)
+-- 🔴 Derived from init.lua's self-located root, NOT from the environment.
+-- $DEVRC_DIR is set only by a systemd Environment= line in graphical.nix, so in
+-- any non-graphical session it is nil and string.format("%s", nil) yields the
+-- literal "nil" -- lazygit was silently pointed at "nil/.config/lazygit/
+-- config.yml" over ssh. `nvimConfigDir` is set by init.lua before this file is
+-- sourced and is <repo>/.config/nvim, so one level up is the repo root.
+local repoRoot = assert(nvimConfigDir, "nvimConfigDir unset -- init.lua must run first")
+                   :match("^(.*)/%.config/nvim$")
+assert(repoRoot, "could not derive the repo root from " .. tostring(nvimConfigDir))
+local path = string.format("%s/.config/lazygit/config.yml", repoRoot)
 
 vim.g.lazygit_config_file_path = path
 

--- a/nix/programs/default.nix
+++ b/nix/programs/default.nix
@@ -1,6 +1,9 @@
 { pkgs, config, ... }:
 let
-  neovim = import ./neovim {pkgs=pkgs;};
+  # `config` for home.homeDirectory: neovim's extraConfig substitutes the repo
+  # path into init.vim at BUILD time rather than leaving `$DEVRC_DIR` to be
+  # resolved at runtime. See nix/programs/neovim/default.nix for why.
+  neovim = import ./neovim {pkgs=pkgs; config=config;};
   zsh = import ./zsh {config=config;};
   fzf = import ./fzf {};
   bash = import ./bash {config=config;};

--- a/nix/programs/neovim/default.nix
+++ b/nix/programs/neovim/default.nix
@@ -1,13 +1,40 @@
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 
 let
   plugins = (import ./plugins.nix {pkgs=pkgs;});
+
+  # 🔴 `$DEVRC_DIR` IS NOT A SESSION VARIABLE. It is set in exactly one place --
+  # a systemd user service's `Environment=` block in nix/graphical.nix -- so it
+  # exists only inside a graphical session. Unlike `$DEVRC` and `$HOMELAB`, it
+  # is NOT in .zshenv.
+  #
+  # init.vim sources every other config file through it, so with the variable
+  # unset the first line expands to `source /.config/nvim/config/native.vim`,
+  # raises E484, and ABORTS THE WHOLE CONFIG -- no options, no leader mappings,
+  # no plugin config, no lua half. Measured 2026-08-29 over real ssh to the
+  # laptop:
+  #
+  #     Error in /home/zach/.config/nvim/init.lua:
+  #     E484: Can't open file /.config/nvim/config/native.vim
+  #     clipboard: No provider. Try ":checkhealth" or ":h clipboard".
+  #
+  # So neovim has been running with NO configuration at all in every non-
+  # graphical context: ssh, a bare TTY, a systemd unit, cron. It looked healthy
+  # because the only place anyone reads a config error is the terminal they are
+  # sitting in front of, which is the one place the variable IS set.
+  #
+  # Substituted at BUILD time instead of resolved at RUNTIME: there is no
+  # environment left to get wrong. This still points at the WORKING TREE, so
+  # editing the sourced files applies with no switch, exactly as before.
+  devrcDir = "${config.home.homeDirectory}/workspace/devrc";
+  initVim = builtins.replaceStrings [ "$DEVRC_DIR" ] [ devrcDir ]
+    (builtins.readFile ../../../.config/nvim/init.vim);
 in
 {
   enable = true;
   defaultEditor = true;
   #package = pkgs.neovim;
-  extraConfig = builtins.readFile ../../../.config/nvim/init.vim;
+  extraConfig = initVim;
   plugins = with pkgs.vimPlugins; with plugins; [
     undotree
     vim-signify

--- a/scripts/devhost-tests/test_nvim_clipboard_behaviour.py
+++ b/scripts/devhost-tests/test_nvim_clipboard_behaviour.py
@@ -14,11 +14,21 @@ key on a missing BINARY, not an env var. A flat pin would have gone red on the
 dev host, where nvim exists and the tests run -- exactly the failure the
 SIGNAL_PG_DSN entry documents. So they moved to the tier that HAS nvim.
 
-🔴 These deliberately load the config the way neovim really loads it -- through
-`$DEVRC_DIR`, as init.vim does -- rather than `nvim --clean -c luafile`. The
-clean form works and is hermetic, but it proves only that the block behaves in
-ISOLATION; it cannot see the block failing to be REACHED (a rename, a source
-line dropped from init.lua). The seam is the part worth testing.
+🔴 SCOPE, stated because an earlier version of this docstring overclaimed it.
+It said these tests load the config "the way neovim really loads it -- through
+$DEVRC_DIR" and were therefore testing the SEAM. That was wrong twice over:
+the fixture SET $DEVRC_DIR itself, so it manufactured the one precondition that
+does not hold in production -- and the config chain was, at that moment,
+completely broken over ssh for exactly that reason, which these tests could not
+see. A correct clipboard fix shipped inert behind a green suite.
+
+So the claim is now the narrower true one: this file covers the BEHAVIOUR of
+the clipboard block, loaded explicitly with `-c luafile`. Whether the block is
+REACHED through init.vim -> init.lua with no session environment is a different
+question, owned by test_nvim_config_loads_offsession.py (which counts E484s
+from the real chain) and by the registration guard in
+scripts/tests/test_nvim_clipboard_osc52.py. Two files, two claims, neither
+pretending to make the other's.
 """
 from __future__ import annotations
 
@@ -48,13 +58,29 @@ def _run_nvim_offdisplay(tmp: Path, keys: str) -> bytes:
     probe.write_text("OSC52-FIXTURE-LINE\n")
     log = tmp / "pty.bin"
 
+    # 🔴 Load THIS tree's block explicitly, not via $DEVRC_DIR. That variable
+    # used to point neovim at this worktree; the repo path is now substituted
+    # into init.vim at BUILD time, so it is no longer read at all -- the old
+    # fixture would have quietly exercised the DEPLOYED clone in
+    # ~/workspace/devrc and passed whatever this branch contains.
+    #
+    # `-c luafile` on a normally-started nvim rather than `-u <init.vim>`:
+    # `-u` bypasses the nix wrapper, so no plugins are on the runtimepath, the
+    # config errors and nvim blocks on a press-ENTER prompt -- the tests hung
+    # for the full timeout. Reaching the block through the whole config chain is
+    # covered separately, by the E484 count in
+    # test_nvim_config_loads_offsession.py; this file covers the BEHAVIOUR.
     env = dict(os.environ)
     env.pop("DISPLAY", None)
+    # Deliberately NOT set -- the config must not need it, and a fixture that
+    # supplies it cannot see it being absent. That is how the first version of
+    # this fix shipped inert.
+    env.pop("DEVRC_DIR", None)
     env["SSH_TTY"] = "/dev/pts/0"
-    env["DEVRC_DIR"] = str(REPO)
 
     subprocess.run(
-        ["script", "-qfc", f"nvim {probe} {keys} -c 'qa!'", str(log)],
+        ["script", "-qfc",
+         f"nvim -c 'luafile {NATIVE_LUA}' {probe} {keys} -c 'qa!'", str(log)],
         env=env,
         capture_output=True,
         timeout=60,
@@ -119,10 +145,10 @@ def test_the_provider_matches_the_environment_it_runs_in():
     scripts/tests/conftest.py exists to prevent.
     """
     env = dict(os.environ)
-    env["DEVRC_DIR"] = str(REPO)
+    env.pop("DEVRC_DIR", None)
     res = subprocess.run(
         [
-            "nvim", "--headless",
+            "nvim", "--headless", "-c", f"luafile {NATIVE_LUA}",
             "-c", 'lua io.write(vim.g.clipboard and "SET" or "UNSET")',
             "-c", "qa!",
         ],

--- a/scripts/devhost-tests/test_nvim_config_loads_offsession.py
+++ b/scripts/devhost-tests/test_nvim_config_loads_offsession.py
@@ -1,0 +1,84 @@
+"""BEHAVIOURAL: the nvim config must survive a session with no $DEVRC_DIR.
+
+Dev-host tier -- drives a real nvim, which the nix sandbox has not got.
+
+The bug this pins was found over real ssh, but it reproduces LOCALLY by simply
+unsetting the variable, which is what makes it testable at all:
+
+    env -u DEVRC_DIR nvim -c 'source .config/nvim/init.vim'
+    -> E484: Can't open file /.config/nvim/config/native.vim   (x9)
+
+🔴 THE FIXTURE MUST NOT SUPPLY DEVRC_DIR. The clipboard suite that shipped just
+before this one set it in every subprocess env, which manufactured the one
+precondition that does not hold in production -- so a correct fix shipped inert
+and the tests stayed green. `_env_without_session()` exists to make that
+mistake loud rather than repeatable.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+INIT_VIM = REPO / ".config" / "nvim" / "init.vim"
+
+
+def _env_without_session() -> dict:
+    """The environment an ssh session actually has: no DEVRC_DIR, no DISPLAY."""
+    env = dict(os.environ)
+    env.pop("DEVRC_DIR", None)
+    env.pop("DISPLAY", None)
+    return env
+
+
+def _source_count_e484(init_path: Path) -> int:
+    """Source `init_path` in a bare nvim and count E484s."""
+    res = subprocess.run(
+        ["nvim", "--clean", "--headless", "-c", f"source {init_path}", "-c", "qa!"],
+        env=_env_without_session(), capture_output=True, text=True, timeout=120,
+    )
+    return (res.stdout + res.stderr).count("E484")
+
+
+def test_the_unsubstituted_init_vim_still_reproduces_the_bug():
+    """🔴 RED CONTROL. If this stops failing, the green half proves nothing.
+
+    The repo's init.vim carries the literal `$DEVRC_DIR` token on purpose --
+    nix replaces it at build time. Sourced RAW with the variable unset, it must
+    still break, or the fixture is no longer reproducing the reported symptom.
+    """
+    n = _source_count_e484(INIT_VIM)
+    assert n > 0, (
+        "sourcing the raw init.vim with DEVRC_DIR unset produced no E484. "
+        "Either the token was removed from init.vim (then delete this test and "
+        "the substitution together) or the reproduction has drifted -- in which "
+        "case the green half below is measuring nothing."
+    )
+
+
+def test_the_build_substituted_init_vim_loads_with_no_session_env():
+    """GREEN. Exactly what nix ships: the token replaced with the repo path.
+
+    Reproduces `builtins.replaceStrings ["$DEVRC_DIR"] [<repo>]` rather than
+    importing it, because the nix evaluation is not available here -- the
+    hermetic suite pins that the module still performs that substitution.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        substituted = Path(td) / "init.vim"
+        substituted.write_text(INIT_VIM.read_text().replace("$DEVRC_DIR", str(REPO)))
+        n = _source_count_e484(substituted)
+
+    assert n == 0, (
+        f"the substituted init.vim still raised {n} E484(s) with DEVRC_DIR "
+        "unset -- something under .config/nvim resolves a path through the "
+        "environment rather than through the substituted root"
+    )
+
+
+def test_the_tools_this_tier_needs_are_present():
+    """Fail loudly rather than skip -- an unpinned skip is what moved this file
+    out of the hermetic target in the first place."""
+    assert shutil.which("nvim"), "nvim missing on the dev-host tier"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1802,8 +1802,9 @@ TARGET_FLOORS=(
   # is collected only under `--set all` — but the floor table is checked against
   # hermetic AND dev-host targets both ways, so it needs an entry regardless or
   # GUARD 3a reports it unfloored.
-  # `_suggested_floor 4` = 4 - min(50, max(1, 4/20 = 0 -> 1)) = 3.
-  "scripts/devhost-tests|3"
+  # 2026-08-29 (+3): the $DEVRC_DIR off-session config tests joined it.
+  # `_suggested_floor 7` = 7 - min(50, max(1, 7/20 = 0 -> 1)) = 6.
+  "scripts/devhost-tests|6"
 )
 
 # The allowance rule, in one place, used by BOTH the drift message and anyone

--- a/scripts/tests/test_nvim_config_loads_without_session_env.py
+++ b/scripts/tests/test_nvim_config_loads_without_session_env.py
@@ -1,0 +1,139 @@
+"""neovim's config must load with NO graphical session. Fully hermetic.
+
+🔴 MEASURED 2026-08-29, over real ssh to the laptop, against the DEPLOYED copy:
+
+    Error in /home/zach/.config/nvim/init.lua:
+    E484: Can't open file /.config/nvim/config/native.vim
+    clipboard: No provider. Try ":checkhealth" or ":h clipboard".
+
+`$DEVRC_DIR` is set in exactly ONE place -- a systemd user service's
+`Environment=` block in nix/graphical.nix -- so it exists only inside a
+graphical session. Unlike `$DEVRC` and `$HOMELAB` it is NOT in .zshenv.
+init.vim sources every other config file through it, so with the variable unset
+the first source expands to `/.config/nvim/config/native.vim`, raises E484 and
+ABORTS THE WHOLE CONFIG: no options, no leader mappings, no lua half, no
+plugin config. neovim had been running unconfigured in every non-graphical
+context -- ssh, a bare TTY, a systemd unit, cron -- and it looked healthy
+because the only place anyone reads a config error is the terminal in front of
+them, which is the one place the variable IS set.
+
+🔴 WHY THIS GUARD EXISTS RATHER THAN A BEHAVIOURAL TEST ALONE. The OSC 52
+clipboard fix that shipped just before this one was verified by a red/green
+harness that SET `DEVRC_DIR` itself. That manufactured the exact precondition
+which does not hold in production, so the harness could not observe this class
+at all, and a correct fix shipped INERT in the situation it was written for.
+The lesson generalises past this variable: a test that supplies an environment
+cannot see the environment being absent. These assertions therefore pin the
+RELATIONSHIP -- nothing under .config/nvim may read $DEVRC_DIR at runtime, and
+the one remaining mention must be the token nix substitutes at build time.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+NVIM_DIR = REPO / ".config" / "nvim"
+INIT_VIM = NVIM_DIR / "init.vim"
+NEOVIM_NIX = REPO / "nix" / "programs" / "neovim" / "default.nix"
+PROGRAMS_NIX = REPO / "nix" / "programs" / "default.nix"
+
+
+def _strip_comments(text: str, path: Path) -> str:
+    """Drop comment lines so a guard cannot fire on prose ABOUT the hazard.
+
+    🔴 Not cosmetic. The fix for this bug puts an explanatory comment naming
+    $DEVRC_DIR at the top of the very files that no longer read it, so a raw
+    substring check reports every fixed file as an offender -- and the obvious
+    "fix" is to delete the explanation that stops the next person reintroducing
+    it. Strip the comments; assert on the code.
+    """
+    marker = '"' if path.suffix == ".vim" else "--"
+    out = []
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith(marker):
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def _config_files() -> list[Path]:
+    files = sorted(p for p in NVIM_DIR.rglob("*") if p.suffix in {".vim", ".lua"})
+    assert len(files) >= 10, (
+        f"only {len(files)} nvim config files found under {NVIM_DIR} -- the "
+        "enumeration is broken, and an empty list would pass every assertion "
+        "below vacuously"
+    )
+    return files
+
+
+def test_nix_substitutes_the_repo_path_into_init_vim_at_build_time():
+    """The build must resolve $DEVRC_DIR so the runtime never has to."""
+    src = NEOVIM_NIX.read_text()
+    assert "builtins.replaceStrings" in src, (
+        f"{NEOVIM_NIX.relative_to(REPO)} no longer substitutes the repo path; "
+        "init.vim would again depend on $DEVRC_DIR being set at runtime"
+    )
+    assert '"$DEVRC_DIR"' in src, "the substitution no longer names $DEVRC_DIR"
+    assert "config.home.homeDirectory" in src, (
+        "the substituted path is not derived from home.homeDirectory"
+    )
+    # The module cannot use `config` unless it is passed one.
+    assert re.search(r"import\s+\./neovim\s*\{[^}]*config\s*=\s*config",
+                     PROGRAMS_NIX.read_text()), (
+        f"{PROGRAMS_NIX.relative_to(REPO)} does not pass `config` to the neovim "
+        "module, so config.home.homeDirectory cannot resolve"
+    )
+
+
+def test_no_nvim_config_file_reads_DEVRC_DIR_at_runtime():
+    """🔴 THE RELATIONSHIP, across the whole tree -- not one file.
+
+    init.vim is exempt: its `$DEVRC_DIR` occurrences are the substitution TOKEN,
+    replaced at build time before neovim ever sees them. Every other file is
+    read at runtime from the working tree, where no substitution happens, so a
+    reference there is a live dependency on a graphical session.
+    """
+    offenders = []
+    for f in _config_files():
+        if f == INIT_VIM:
+            continue
+        if "DEVRC_DIR" in _strip_comments(f.read_text(), f):
+            offenders.append(str(f.relative_to(REPO)))
+    assert offenders == [], (
+        "these nvim config files read $DEVRC_DIR at runtime, so they load only "
+        "inside a graphical session and are silently absent over ssh:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_init_lua_derives_its_directory_from_its_own_path():
+    """The positive half: it must locate itself, not merely avoid the env var.
+
+    Asserting only the absence above would be satisfied by a file that hardcodes
+    a path, or by one that computes nothing at all.
+    """
+    raw = (NVIM_DIR / "init.lua").read_text()
+    src = _strip_comments(raw, NVIM_DIR / "init.lua")
+    assert "debug.getinfo" in src, (
+        "init.lua no longer derives its directory from its own path"
+    )
+    assert "os.getenv" not in src, (
+        "init.lua reads the environment again; string.format('%s', nil) yields "
+        'the literal "nil" and every source() silently resolves under "nil/"'
+    )
+
+
+def test_init_vim_still_carries_the_token_the_build_replaces():
+    """Both halves of the substitution must agree, or the build is a no-op.
+
+    A silently-unmatched replaceStrings leaves init.vim exactly as written and
+    the config goes back to depending on the environment -- with the nix side
+    still looking correct.
+    """
+    assert "$DEVRC_DIR" in INIT_VIM.read_text(), (
+        "init.vim no longer contains $DEVRC_DIR, so the replaceStrings in "
+        f"{NEOVIM_NIX.relative_to(REPO)} matches nothing and silently does "
+        "nothing. If the path was hardcoded instead, drop the substitution too."
+    )


### PR DESCRIPTION
Follow-up to #1027, which shipped **inert**. This is the reason why.

## The bug

Measured over real ssh to the laptop, against the deployed copy:

```
Error in /home/zach/.config/nvim/init.lua:
E484: Can't open file /.config/nvim/config/native.vim
clipboard: No provider. Try ":checkhealth" or ":h clipboard".
```

`$DEVRC_DIR` is set in exactly **one** place — a systemd user service's `Environment=` block in `nix/graphical.nix`. Unlike `$DEVRC` and `$HOMELAB` it is **not** in `.zshenv`, so it exists only inside a graphical session. `init.vim` sources every other config file through it, so with the variable unset the first source expands to `/.config/nvim/config/native.vim`, raises E484, and **aborts the entire config** — no options, no leader mappings, no lua half, no plugin config.

neovim has been running unconfigured in every non-graphical context: ssh, a bare TTY, a systemd unit, cron. It looked healthy because the only place anyone reads a config error is the terminal in front of them — the one place the variable is set.

## Why the tests could not see it

#1027's red/green harness **set `$DEVRC_DIR` itself**, manufacturing the one precondition that does not hold in production. The clipboard fix was correct, merged, green, and did nothing where it mattered.

The generalisable form: **a test that supplies an environment cannot observe that environment being absent.** The guards here pin the relationship instead — no file under `.config/nvim` may read `$DEVRC_DIR` at runtime.

## The fix — remove the dependency, don't default it

- nix substitutes the repo path into `init.vim` at **build time**; `programs/default.nix` now passes `config` through for `home.homeDirectory`. Still points at the working tree, so live edits need no switch.
- `init.lua` derives its directory from its own path (`debug.getinfo`).
- **`lazygit.lua` had the same bug**, found by the new guard — it had been pointing at `nil/.config/lazygit/config.yml` over ssh.

## Guards

- **Hermetic**: no `.config/nvim` file reads `$DEVRC_DIR` at runtime; `init.lua` self-locates; init.vim still carries the token the build replaces (so a silently-unmatched `replaceStrings` cannot pass). Comments are stripped before matching — the fix adds explanatory comments naming `$DEVRC_DIR` to the very files that no longer read it, and a raw substring check would flag them and invite deleting the explanation. Mutation-tested by reintroducing a real `getenv`.
- **Dev-host**: red control (raw init.vim with the variable unset still raises E484) + green (build-substituted form raises none).

Also corrects #1027's clipboard fixture, which set `$DEVRC_DIR` and — now that the variable is unread — would have silently exercised the deployed clone in `~/workspace/devrc` rather than its own branch, plus its docstring, which claimed to test a seam it was blind to.

## Gate

`nix build .#checks.x86_64-linux.{pytests,nodetests}` on this branch: `collected=18563 passed=18561 skipped=2 failed=0`, `RESULT: PASS`, no ERROR or UNPINNED lines. Base includes #1023, so main's earlier red is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUG9ivyCsz5rpNbs9R52f1
