### PR TITLE
docs(handoff): audit-pr-ladder CLOSED — all four ranks done, shipped and verified at the consumer, and two items this thread introduced

### DIFF
--- a/claudedocs/handoff-audit-pr-ladder.md
+++ b/claudedocs/handoff-audit-pr-ladder.md
@@ -16,25 +16,31 @@ sessions, then fix what the measurement exposed. It exposed that the ladder's
 findings-keyed stop rule does not terminate in the guard-hardening regime.
 
 ## State now
-- Branch: `main`. Nothing of this work is uncommitted.
-- **Eight PRs, all MERGED and verified by content in `origin/main`** (never by ancestry —
-  a squash merge makes the branch head permanently a non-ancestor):
-  - `#900` attribution gate · `#922` two worktree hazards · `#933` the two instruments
-  - `#958` → squash `1b2117b6` — `scripts/audit-dispatch.py`, the brief assembler
-  - `#979` → `8bab93b1` — espanso `:acq` split, rescued off the workbench's `main`
-  - `#993` → `c7d70a40` — the ladder writeup in `round-ladder-evidence.md`
-  - `#999` → `22e2830a` — espanso exact-trigger preference
-  - `#1001` → `289865af` — round-13 fixes (`repo_unknown_reason`, runnable cross-repo recipe)
-- **Deployed AND verified at the consumer**, not just the deploy: `#999` needed
-  `systemctl --user restart keylog.service` on both hosts (workbench PID 2851719→2937124,
-  laptop 1718672→1721180), then the original symptom was re-run against the deployed
-  module `/nix/store/jawj46mw…-hm_keylog`: `acq` and `alo` both moved `None` → their own
-  snippet, every other term unchanged.
-- **Hosts CONVERGED 2026-08-28 22:37** — `ship.sh` fast-forwarded both from `1c0db104` to
-  `7d3aec1a` and verified them equal; `2 hosts compared, both at 7d3aec1a`. 🔴 The workbench
-  leg still printed `DIRTY AND IN THE ARTIFACT` and **that is not stale** — see the
-  `discord-embed-ext` investigation below; the workbench generation is `origin/main` plus
-  another session's uncommitted extension.
+- Branch: `main`. **Nothing of this thread is uncommitted or unpushed.** Claims released,
+  worktrees removed.
+- **ALL FOUR handoff ranks are CLOSED**, and every PR merged — verified by CONTENT, never
+  ancestry:
+  - `#1023` → `8e33bf1d` — the three main-unblockers (espanso `ask`, opencode pin, store-api
+    load flake). Merged by someone else mid-audit.
+  - `#1033` → `70eff59c` — audit rounds 1+2 follow-ups
+  - `#1009` → `442bde83` — the RULES worktree-config surface + ceiling bump
+  - `#1005` → `aaa5514c` — this doc, ranks 2–4, and the `#996` retraction
+- **SHIPPED AND VERIFIED AT THE CONSUMER**, not merely deployed. `ship.sh` converged both
+  hosts to `aaa5514c`; the deployed `~/.config/espanso/match/base.yml` now reads
+  `:dacq search_terms = ['feedback','dispatch','process','elicit','scope','include']` with
+  `ask` gone, and the live detector resolves `'ask' -> ':acq'` as a **unique** match (1, not
+  2). Both keylog collectors restarted so the running processes hold it (workbench
+  2360918→1440860, laptop 4136134→601904, both `running`).
+- **Rank 2 closed by its OWNER, not by me.** `git status -s scripts/discord-embed-ext/` is
+  empty and `main` carries `v0.3.0`. 🔴 **The observer defect this thread found is FIXED
+  there** — the `found > 0 && observer` reconnect gate is gone, and the suite floor moved
+  50 → 128, so the observer-lifecycle test the harness never had now exists.
+- **The audit ladder ran TWO rounds and stopped.** Round 1 found 3🟡/4🟢, round 2 confirmed
+  all of them fixed and found 5 more — but round 2's findings were about scaffolding round 1
+  had just written, which is the attribution signal that the ladder has left the PR.
+- ⚠ **No `clawgate-task:` field**: the resolver returned rc 5, 0 tasks. Its positive control
+  proves the board is reachable and the token accepted — but a WRONG session id also answers
+  `200` with an empty array, so that zero is **not** a clean bill of health.
 
 ## Closed investigations — both were diagnosed on 2026-08-28
 
@@ -110,76 +116,17 @@ findings-keyed stop rule does not terminate in the guard-hardening regime.
   other "surfaces a worktree does not hand you" in `claude/RULES.md`.
 
 ## Next steps (ranked)
-1. 🔴 **Zach: answer the stalled opencode session** (repo: `devrc`; session
-   `ses_fbe5f77a2ffeaJr0G0S7i4lUKa`). It has been waiting since 21:08 on *"Reload the
-   extension in Brave"*, and **`v0.2.3` is already what Brave loads on the workbench.**
-   Give it the observer finding above — it is iterating on CSS and the bug is its own
-   `disconnect()`/`if (found > 0)` reconnect. **Closing condition:** the WIP is committed or
-   PR'd and `git -C $DEVRC status -s scripts/discord-embed-ext/` is empty; checked by
-   whoever runs `ship.sh` next, since the workbench leg prints `DIRTY AND IN THE ARTIFACT`
-   until then. Nothing here should commit another session's mid-iteration work for it.
-2. **Land the observer fix + its first test** (repo: `devrc`,
-   `scripts/discord-embed-ext/`). Reconnect unconditionally, and add the observer-lifecycle
-   test the suite has never had — which needs `FakeMutationObserver` to record connection
-   state and `FakeElement` to set `nodeType = 1`, or the test passes vacuously. Repro script
-   + controls: see the closed investigation above. **Do this only after rank 1** — the file
-   is another session's live working copy.
-3. ✅ **DONE — the config/remote worktree surface is in `claude/RULES.md`** as `#1009` (the
-   sixth surface, plus an "an mtime cannot NAME a writer" clause on the find-the-WRITER
-   rule, plus the `worktree-config` archive anchor). It needed a ceiling bump: floor-relative
-   slack was **4 B**, the eviction sweep was re-run by the ledger's own documented method and
-   returned **0 B** for the third consecutive time, and the ledger had already predicted "the
-   next NEW rule pays ceiling". `MAX_BYTES` 41,400 → 42,450, slack held at precedent.
-4. ✅ **ANSWERED — `date` needs NO action, and that is measured, not assumed.** The condition
-   this doc set was "only if the keylog shows it is a term actually typed". It is not: over
-   the observed search stream, **56 term rows and `date` appears ZERO times**, with `ask`
-   visible 4× in the same output as the positive control — so the zero is a measurement and
-   not an empty harness. `date` matching `:eos`/`:roo` at all is a spurious SUBSTRING hit
-   (`date` ⊂ "upd**ate**"); it costs nothing because nobody searches it.
-
-### `main` WAS RED REPO-WIDE — three independent causes, all landed in `#1023`
-Merged as `8e33bf1d`, verified by content. `#1015`/`#1021`/`#1022` were closed as
-superseded: **none of them could go green alone**, because the gate runs the whole suite,
-so each red-tested the others' bug. That deadlock is the reason they were combined.
-1. **espanso `ask`** — the 08-28 `:acq`/`:dacq` split cleaned the label but left `"ask"` in
-   BOTH snippets' `search_terms`, so the term named neither and `#999`'s tie-break correctly
-   declined. The comment above those lines already said ":acq owns ask/clarify/questions
-   alone" — the comment was right and the data contradicted it.
-2. **opencode pin** — `flake.lock` moved the binary 1.18.18 → 1.18.21 under an unchanged
-   config, which is exactly what `test_opencode_engine.py` exists to catch.
-3. **the store-api load flake** — a 15 s localhost read timing out on SCHEDULING.
-
-🔴 **CORRECTIONS to `#1023`'s own commit messages, recorded here because that history is
-merged and will not be rewritten.** All three were caught by audit, and each is a claim I
-made that the tree did not support:
-- **The espanso trade-off is 9 lost multi-word queries, not 8.** `ask agent` also stops
-  reaching `:dacq` — it got there only via the label word `subagent`. `--diff-config` cannot
-  see it: its probe universe forms two-token pairs WITHIN ONE SNIPPET, and `ask` belongs to
-  `:acq`'s word set, so the pair never exists to be tested. **The tool was quoted faithfully
-  and the tool is narrower than the sentence** — none of the 9 has ever been typed, which is
-  the claim that actually matters and which held.
-- **"56 recovered fires" measures ATTRIBUTION, not intent.** Those fires were unattributable
-  by construction, so the share that *meant* `:dacq` is unmeasurable. `ask` no longer lists
-  `:dacq` at all (2 picker rows → 1); `:dacq` keeps all 8 of its unique routes. A legitimate,
-  tool-sanctioned remedy — but "recovered" should not be read as pure gain.
-- **"all 7 sites" / "NINE settimeout sites" were both miscounts** (6 and 8 respectively). The
-  second came from counting `grep` OUTPUT LINES, one of which was a docstring mentioning the
-  name. A grep counts mentions; an AST walk counts calls.
-- ⚠ Three miscounted self-reports in one ladder, the last inside the guard written to stop
-  them. **Re-derive every count from the tree at the moment you quote it.**
-
-### Still open
-- **`#1005`** (this doc) and **`#1009`** (the RULES worktree-config surface) — both were only
-  ever blocked on `main`; rebased onto the green `main`.
-- **`#1033`** — the round-1 audit follow-ups, plus the round-2 findings on top.
-- ✅ **RESOLVED, and it was my instrument, not the environment:** the "CI-only" opencode
-  failure. It reproduces locally in one run. I had been running `test_opencode_config.py`;
-  the failing test is in `test_opencode_**engine**.py`, and my follow-up search returned a
-  false zero because `xargs -0 command grep` has no executable to run — `command` is a shell
-  builtin. **Two instrument errors stacked into a confident "unexplained".**
-- **NOT FILED, and deliberately named as such:** the Tekton capacity problem behind the
-  flake. It has no closing condition anyone can check yet, so it is not being minted as a
-  work object — see the object-leak rule.
+1. **Merge `#1035`** (repo: `devrc`, `nix/pkgs/tools/default.nix`) — a one-line fix for the
+   stale nixpkgs rev *this thread introduced*. Diff reviewed and the ground truth verified
+   against `flake.lock` independently; only its checks were outstanding.
+2. **Close `#1041` as redundant** (repo: `devrc`) — it opens a PR for commit `8d1f6671`,
+   which is the closed `#1015`'s commit, on the premise that it "never had one raised". It
+   did, and `HANG_TIMEOUT = 60.0` has been on `main` since `8e33bf1d` (18:37) — `#1041` was
+   opened at 20:26, ~2h later. Merging it is a no-op at best. **Comment before closing** so
+   that session stops work rather than re-opening; its measurement is worth keeping.
+3. **Tekton capacity** (repo: `homelab-talos` / the `tekton` skill, NOT devrc) — the real
+   fix behind rank 2's evidence. Needs a decision on whether it becomes work at all; see the
+   open investigation above for why it is not filed.
 
 ## Gotchas / decisions / dead-ends
 - 🔴 **The ladder never returned a clean round in twelve.** The stop rule assumes
@@ -224,37 +171,106 @@ made that the tree did not support:
   claim was written from the fix's *description* rather than from what it touched. Before
   writing "closed", name the mechanism and check the fix actually reaches it.
 
+- 🔴 **CARRIED FORWARD from the ranked list, which this update replaces — corrections to
+  `#1023`'s own commit messages, kept because that history is MERGED and will not be
+  rewritten.** (a) the espanso trade-off is **9** lost multi-word queries, not 8 — `ask agent`
+  also stops reaching `:dacq`, via the label word `subagent`, and `--diff-config`'s probe
+  universe forms two-token pairs WITHIN ONE SNIPPET so that pair never exists to be tested;
+  the claim that matters — none of the 9 has ever been typed — still holds. (b) **"56
+  recovered fires" measures ATTRIBUTION, not intent**: those fires were unattributable by
+  construction, so the share that *meant* `:dacq` is unmeasurable, and `ask` no longer lists
+  `:dacq` at all (2 picker rows → 1) while `:dacq` keeps all 8 of its unique routes. A
+  legitimate, tool-sanctioned remedy — but not pure gain.
+- 🔴 **THREE miscounted self-reports in one ladder, the last inside the guard written to
+  stop them.** "all 7 sites" (6), "NINE settimeout sites" (8), "8 lost espanso queries" (9).
+  Each was a number I produced and then trusted instead of re-deriving. The last is the
+  sharpest: it came from counting `grep -n 'settimeout('` OUTPUT LINES, one of which was the
+  docstring *mentioning* the name I was counting. **A grep counts MENTIONS; an AST walk
+  counts CALLS.** Re-derive every count from the tree at the moment you quote it.
+- 🔴 **Several of this thread's wrong claims were true of the INSTRUMENT, not the FILE.** A
+  literal-string grep reported as a property of the tree; a `-k` filter that deselected the
+  failing test and returned a confident "5 passed"; `xargs -0 command grep` returning a
+  silent zero because `command` is a shell BUILTIN with no executable to run. Two of those
+  stacked into a confident *"unexplained — same tree, opposite results"* about the opencode
+  failure, which in fact reproduced locally in one run against the right file. **Before
+  quoting a zero, make the instrument produce a non-zero on a case you know is there.**
+- 🔴 **A DETECTOR-DRIVEN FIX INHERITS THE DETECTOR'S BLIND SPOT.** The pin re-key was
+  line-targeted at what the ledger flagged, and the ledger only sees version literals — so a
+  stale *rev* on a line with no version survived, untouched and unreported (`#1035`). Ask
+  what the detector CANNOT see before treating its output as the work list.
+- 🔴 **Neither PR could go green alone — a DEADLOCK, not a preference.** `#1015`/`#1021`/
+  `#1022` each fixed one of three independent reds, and the gate runs the whole suite, so
+  each red-tested the others' bug. Combining them into `#1023` was the only path to a green
+  run. When several PRs each fix part of a repo-wide red, expect this and plan for one branch.
+- **A ledger SNIPPET or COMMENT containing a version literal is itself a claim in the pin
+  surface** — the entry's own source line becomes an old-version line and matches twice.
+  Every entry is version-free for this reason. Tripped twice in one session, the second time
+  in the comment written to explain it.
+- **`settimeout(None)` survived the drain guard's first draft, fully green.** `ast.unparse`
+  renders it `"None"`, which is not `.isdigit()`, so a size-based arm cannot see the one
+  value that means *block forever*. Guards over rendered source need an explicit arm per
+  non-numeric hazard.
+- 🔴 **The store-api timeout fix is a SYMPTOM fix and the label was load-bearing.** It was
+  shipped saying so, and `#1009` then failed at the new 60 s bound. Do not read `#1023` as
+  having fixed the flake.
+
 ## How to verify
 ```bash
-# --- the two closed investigations (2026-08-28) ---
-# the stray remote is gone and has NOT come back
-git -C $DEVRC remote -v | grep localverify || echo "localverify: gone"
-# who owns the discord WIP — the answer is in the OTHER runtime's log, not a transcript
-grep -a 'embed_enlarge' ~/.local/share/opencode/log/opencode.log | tail -3
-# the observer defect, with its control (expect: WIP connected=false / main connected=true)
-git -C $DEVRC show origin/main:scripts/discord-embed-ext/extension/embed_enlarge.js > /tmp/dee_main.js
-node claudedocs/repro-discord-embed-observer.mjs \
-  $DEVRC/scripts/discord-embed-ext/extension/embed_enlarge.js "WIP"
-node claudedocs/repro-discord-embed-observer.mjs /tmp/dee_main.js "CONTROL origin/main"
-# what Brave actually loads (0.2.3 = the uncommitted WIP; 0.1.0 = origin/main)
-grep -o '"version"[^,]*' ~/.local/share/discord-embed-ext/manifest.json
-
-# --- earlier work in this thread ---
-# every PR landed by CONTENT, never ancestry (squash merges break ancestry forever)
+# --- this thread's closing state (2026-08-29) ---
+# every PR landed by CONTENT, never ancestry
 git -C ~/workspace/devrc fetch origin main
-git -C ~/workspace/devrc show origin/main:scripts/audit-dispatch.py | grep -c 'refs/audit/'   # 7
-git -C ~/workspace/devrc show origin/main:scripts/collector/keylog/espanso_detect.py | grep -c '_names_trigger'  # 2
+git -C ~/workspace/devrc show origin/main:claude/RULES.md | grep -c 'its CONFIG and REMOTES'        # 1
+git -C ~/workspace/devrc show origin/main:scripts/tests/test_rules_size.py | grep -c 'MAX_BYTES = 42_450'  # 1
+git -C ~/workspace/devrc show origin/main:scripts/tests/test_subsystem_store_api.py | grep -c 'block-forever'  # 1
 
-# the espanso fix is live in the RUNNING collector, not merely deployed
-systemctl --user show keylog.service -p MainPID -p SubState
-python3 - <<'PY'
-import sys, yaml
-D = "/nix/store/jawj46mwcz9xd5ly4ixja5kdr9wvsmf6-hm_keylog"   # re-resolve after any switch
-sys.path.insert(0, D)
-import espanso_triggers as ET
-from espanso_detect import EspansoDetector
-d = EspansoDetector(ET.load_triggers(yaml.safe_load(open("/home/zach/.config/espanso/match/base.yml")), {"search_shortcut": "CTRL+SPACE"}))
-for t in ("acq", "alo"):
-    print(t, "->", d._attribute(t))    # expect :acq and :alo, NOT None
-PY
+# the espanso fix is LIVE in the deployed config, not merely merged
+nix develop ~/workspace/devrc -c python3 -c "
+import yaml; cfg=yaml.safe_load(open('/home/zach/.config/espanso/match/base.yml'))
+print([m.get('search_terms') for m in cfg['matches'] if m.get('trigger')==':dacq'])"
+# expect NO 'ask'
+
+# rank 2's closing condition, and the observer defect that came with it
+git -C ~/workspace/devrc status -s scripts/discord-embed-ext/                                    # empty
+git -C ~/workspace/devrc show origin/main:scripts/discord-embed-ext/extension/embed_enlarge.js \
+  | grep -c 'found > 0 && observer'                                                              # 0 = fixed
+
+# the stale rev still on main (rank 1 fixes it)
+git -C ~/workspace/devrc show origin/main:nix/pkgs/tools/default.nix | sed -n '22,24p'
 ```
+## Open investigations — live diagnosis state
+
+### 🔴 A stale claim I introduced in `#1023`, still on `main` — fix open as `#1035`
+- **Symptom + exact repro:**
+  `git -C ~/workspace/devrc show origin/main:nix/pkgs/tools/default.nix | sed -n '22,24p'`
+  → `MEASURED at flake.lock's nixpkgs rev 5c680dac9f02, `pkgs.opencode` is 1.18.21 — store
+  path /nix/store/iqc8xfx…-opencode-1.18.21`. **One sentence, two halves, disagreeing.**
+- **Observed (with values):** `origin/main`'s `flake.lock` pins nixpkgs at **`c27cdad491a9`**
+  (read from the lock's `nodes.nixpkgs.locked.rev`), and the store path quoted in that same
+  sentence is the one *that* rev produces. So the rev is the only stale half.
+- **Ruled out:** not a second occurrence of the version drift — the VERSION and the STORE
+  PATH on lines 23–24 are both correct. Only the rev on line 22 is wrong.
+- 🔴 **Root cause, and it generalises:** the re-key was line-targeted at exactly the lines
+  the pin-surface ledger flagged, and **that ledger only flags VERSION literals**. Line 22
+  carries a *rev* and no version, so it was structurally invisible to the detector and
+  therefore invisible to a fix driven by the detector. **A fix driven by a detector is only
+  as wide as what the detector can see** — the method was sound and its blind spot was
+  inherited whole.
+- **Next probe:** none needed, the diagnosis is complete. `#1035` is a correct one-line fix
+  by another session; merge it when its checks land.
+
+### The Tekton capacity problem — now with numbers, still unowned
+- **Symptom + exact repro:** `tekton/devrc-pytests` fails on unrelated commits, blocking
+  every open PR rather than catching defects in any of them.
+- **Observed (with values):** `#1009`'s post-rebase run failed **at the 60 s bound** —
+  `TimeoutError` at `socket.py:720`, `1 failed, 10031 passed` in `721.93s`. A localhost
+  round-trip that did not complete in a minute. Independently, `#1041` measured the retained
+  `devrc-ci` runs: **17 failed / 6 succeeded — a 26% pass rate**, six failing runs on six
+  different commits, **each failing a DIFFERENT single test** out of ~18,555.
+- **Ruled out:** not a defect in any of those PRs (six different tests, six different
+  commits); not the store-api client bound alone (`#1023` raised it and the failure recurred
+  at the new bound).
+- **Leading hypothesis:** a ~12-minute xdist suite competing with a saturated cluster. The
+  store-api timeout was one of **six** symptoms; raising it fixed one.
+- 🔴 **DELIBERATELY NOT FILED as a work item.** It has no closing condition anyone can check
+  and no named owner, so a ticket would read as covered while nothing could close it — see
+  the object-leak rule. Recorded here as an open, unowned condition instead.


### PR DESCRIPTION
Closes the `audit-pr-ladder` thread. Every rank done, every PR merged, shipped to both hosts
and **verified at the consumer** — plus two items this thread *created* that are still open.

## What closed
- All four handoff ranks. **Rank 2 was closed by its OWNER**, not by me: the tree is clean,
  `main` carries `v0.3.0`, and 🔴 **the observer defect this thread found is fixed there** —
  the `found > 0 && observer` reconnect gate is gone and the node suite floor moved 50 → 128,
  so the observer-lifecycle test the harness never had now exists.
- Four PRs merged and verified by content: `#1023` `8e33bf1d`, `#1033` `70eff59c`,
  `#1009` `442bde83`, `#1005` `aaa5514c`.
- Shipped: both hosts at `aaa5514c`; the **deployed** espanso config no longer carries `ask`
  on `:dacq` and the live detector resolves `'ask' -> ':acq'` as a unique match; both keylog
  collectors restarted so the running processes hold it.

## What this thread introduced and did NOT close
- 🔴 **`#1035` — a stale nixpkgs rev I left on `main`.** `nix/pkgs/tools/default.nix:22` still
  reads `MEASURED at flake.lock's nixpkgs rev 5c680dac9f02` beside `is 1.18.21`; the lock
  actually pins `c27cdad491a9`. **A detector-driven fix inherits the detector's blind spot** —
  the re-key edited exactly the lines the pin ledger flagged, and that ledger matches VERSION
  literals only, so a rev on a line with no version was invisible to it and therefore to the
  fix. Someone else wrote the one-line correction; it needs merging.
- **`#1041` is redundant** — it opens a PR for `8d1f6671` (the closed `#1015`) on the premise
  it never had one. `HANG_TIMEOUT = 60.0` has been on `main` since 18:37; `#1041` was opened
  at 20:26. Its *measurement* is worth keeping though.

## The thing most worth reading
🔴 **The store-api timeout fix is a SYMPTOM fix, and the label turned out to be load-bearing.**
`#1009` then failed **at the new 60 s bound** — `1 failed, 10031 passed` in `721s`. Independently
`#1041` measured **17 failed / 6 succeeded across retained runs (26% pass rate), six failing runs
on six different commits each failing a DIFFERENT single test**. `#1023` fixed one of six
symptoms. The Tekton capacity problem is deliberately **not filed** — no closing condition anyone
can check and no owner, so a ticket would read as covered while nothing could close it.

## Also recorded
Three miscounted self-reports in one ladder, the last inside the guard written to stop them —
the sharpest came from counting `grep` OUTPUT LINES, one of which was the docstring *mentioning*
the name being counted. And several wrong claims that were true of the **instrument** rather than
the file (a literal-string grep quoted as a property of the tree; a `-k` filter that deselected
the failing test; `xargs -0 command grep` returning a silent zero because `command` is a builtin).

⚠ No `clawgate-task:` field — the resolver returned rc 5 / 0 tasks. Its positive control shows the
board is reachable, but a wrong session id also answers `200` with an empty array, so that zero is
not a clean bill of health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUzHBeB8LfTDwzCxnAJn2d