### PR TITLE
docs(handoff): the clipboard fix shipped INERT — correct the deploy claim

### DIFF
--- a/claudedocs/handoff-clipboard-research.md
+++ b/claudedocs/handoff-clipboard-research.md
@@ -23,16 +23,61 @@ Research modern best practices for clipboard and terminal clipboard interaction 
 - **Resume session:** both open decisions resolved, and a bug the research missed
   was found, fixed and gated.
   - `unnamedplus` — **declined**, no change.
-  - `"+y` dead with no `DISPLAY` — **fixed** on `fix/nvim-osc52-clipboard`
-    (`.config/nvim/lua/config/native.lua` + `scripts/tests/test_nvim_clipboard_osc52.py`,
-    5 tests, no surviving mutants).
-- 🔴 **Deploy: this file needs NO `home-manager switch`.** `~/.config/nvim/init.lua`
-  is a store copy, but the `init.vim` baked into it sources everything through
-  `$DEVRC_DIR` (set in `nix/graphical.nix:630`) — i.e. straight out of the
-  `~/workspace/devrc` **working tree**. So the nvim change goes live on `git pull`
-  alone. Measured, not inferred: the red/green test drove it by pointing
-  `DEVRC_DIR` at a worktree. `readlink -f` cannot answer this one — the path is
-  reached through an env var, not a symlink.
+  - `"+y` dead with no `DISPLAY` — fixed in **#1027**, which then turned out to
+    be INERT in production until **#1043**. See the block below before trusting
+    anything in this section.
+- 🔴 **THE CLIPBOARD FIX (#1027) SHIPPED INERT. #1043 is what made it work.**
+  Everything above this line was written before that was known; the paragraph
+  that used to sit here claimed the change "goes live on `git pull` alone,
+  no `home-manager switch`" and cited `$DEVRC_DIR` as the mechanism. Both
+  halves were wrong, and it is quoted rather than deleted because the way it
+  was wrong is the reusable part.
+
+  Measured over real ssh to the laptop, against the deployed copy, AFTER #1027
+  had merged and shipped:
+
+  ```
+  Error in /home/zach/.config/nvim/init.lua:
+  E484: Can't open file /.config/nvim/config/native.vim
+  clipboard: No provider. Try ":checkhealth" or ":h clipboard".
+  ```
+
+  `$DEVRC_DIR` was set in exactly ONE place — a systemd user service's
+  `Environment=` block in `nix/graphical.nix` — so it existed only inside a
+  graphical session. `init.vim` sourced every other config file through it, so
+  off-session the first `source` raised E484 and **aborted the entire nvim
+  config**: no options, no leader mappings, no lua half, no plugin config.
+  neovim had been running unconfigured over ssh, on a bare TTY, in units and in
+  cron — invisible because the only place anyone reads a config error is the
+  terminal in front of them, which is the one place the variable was set.
+
+  🔴 **Why no test caught it, which is the lesson worth keeping:** #1027's
+  red/green harness **set `$DEVRC_DIR` itself**, manufacturing the one
+  precondition that does not hold in production. **A fixture that supplies an
+  environment cannot observe that environment being absent.** The fix was
+  correct, merged, green, mutation-tested — and did nothing where it mattered.
+
+- **Fixed in #1043**: nix substitutes the repo path into `init.vim` at BUILD
+  time, `init.lua` self-locates via `debug.getinfo`, and `lazygit.lua` — found
+  by the new guard, not by hand — stopped pointing at
+  `nil/.config/lazygit/config.yml`. Guards: a hermetic relationship test that
+  NO file under `.config/nvim` reads `$DEVRC_DIR` at runtime (comments
+  stripped, mutation-tested), plus a dev-host red/green counting E484s from the
+  real chain.
+
+- 🔴 **Deploy: a `home-manager switch` IS required** (the corrected claim).
+  `init.vim` is `builtins.readFile`'d into the store, so the substitution
+  happens at build time. Files it sources — `native.lua`, `native.vim` — are
+  still read from the `~/workspace/devrc` working tree at runtime, so edits to
+  THOSE remain live on `git pull`. The two are different questions and the old
+  paragraph collapsed them into one.
+
+- ✅ **VERIFIED on the real path, 2026-08-29**, both hosts at `638959b4`:
+  `ssh` → `nvim` → `"+yy` on the laptop went from `E484=9, No provider,
+  OSC52=0` to `E484=0, No provider=0, OSC52=1`, payload decoding to the exact
+  yanked line. Workbench resolves the same substituted store `init.vim`. This
+  is the first claim in this effort verified on the path that actually failed
+  rather than a reconstruction of it.
 
 ## Research findings — clipboard/terminal clipboard best practices (2025-2026)
 
@@ -174,10 +219,12 @@ is free. The trigger to revisit is an OBSERVED lost clipboard, not this note.
 ## How to verify
 - tmux clipboard: copy in tmux copy-mode → paste in another app (OSC 52 path)
 - 🔴 **Neovim off-display — the one that was broken.** From the *other* host:
-  `ssh <host>` → `nvim <file>` → `"+yy` → paste locally. Before the fix this
-  printed `clipboard: No provider`; it should now paste. **Verify from a real
-  ssh session, not by unsetting `DISPLAY` locally** — same observable, and only
-  the real path exercises the terminal that has to honour the escape.
+  `ssh <host>` → `nvim <file>` → `"+yy` → paste locally. **Verify from a real
+  ssh session, not by unsetting `DISPLAY` locally, and NOT by setting
+  `DEVRC_DIR` in the probe** — supplying that variable is precisely what hid
+  the breakage for a whole release. Counting E484s in the captured pty is the
+  cheap discriminator: a config that did not load reports the clipboard symptom
+  for a reason that has nothing to do with the clipboard.
 - Neovim on the local X11 session must be UNCHANGED: `:lua print(vim.g.clipboard)`
   → `nil` (xclip autodetection, untouched by the fix).
 - Espanso: type `:clip` → clipboard contents expand inline


### PR DESCRIPTION
The handoff doc asserted in bold that the nvim change "goes live on `git pull` alone, no home-manager switch", citing `$DEVRC_DIR` as the mechanism, and recorded #1027 as simply "fixed".

#1027 merged, shipped, and did nothing: `$DEVRC_DIR` is graphical-session-only, so off-session `init.vim` raised E484 on its first source and aborted the entire nvim config. #1043 fixed it via build-time substitution — so a switch IS required for `init.vim`, while the files it sources stay live on pull. The old paragraph collapsed those two questions into one.

The retracted claim is quoted rather than deleted: #1027s harness SET `$DEVRC_DIR` itself, manufacturing the one precondition that does not hold in production. **A fixture that supplies an environment cannot observe that environment being absent.**

Also forbids that shortcut in "How to verify", and records the verification that now exists: laptop over real ssh, E484=9/No provider/OSC52=0 → E484=0/No provider=0/OSC52=1, payload decoding to the yanked line; both hosts at 638959b4.

Docs only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUG9ivyCsz5rpNbs9R52f1