### PR TITLE
docs(handoff): youtube-disable-numkeys extension

### DIFF
--- a/claudedocs/handoff-youtube-disable-numkeys.md
+++ b/claudedocs/handoff-youtube-disable-numkeys.md
@@ -1,0 +1,14 @@
+# Handoff: youtube-disable-numkeys extension — 2026-08-29
+
+## Goal
+Create a browser extension that disables number keys (0-9) from triggering seeking on YouTube, track it in the devrc repo, and merge it.
+
+## State now
+- Branch: `main` (merged via PR #1042, commit `341996aa`)
+- **DONE**: extension created, icon added, tracked in repo, PR created and merged
+- Files: `scripts/youtube-disable-numkeys/extension/` (manifest.json, content.js, icons/)
+- Version: 1.1 (bumped from 1.0 to add PNG icons — MV3 doesn't support SVG for icons)
+- Verified working via browser-bridge: number keys `5` and `9` blocked from seeking on a YouTube video
+
+## How to verify
+Load unpacked from `scripts/youtube-disable-numkeys/extension/` in `brave://extensions`, navigate to a YouTube video, press number keys — video should NOT seek.


### PR DESCRIPTION
Handoff doc for the youtube-disable-numkeys extension session.