### PR TITLE
docs(adoption-scan,activity): route "is skill X used?" to its owner — the measurement shipped, the signpost did not

### DIFF
--- a/claude/skills/activity/SKILL.md
+++ b/claude/skills/activity/SKILL.md
@@ -73,6 +73,15 @@ Per-source detail that matters when querying:
   `~/.claude/skills/activity/reference/queries.md`).
 - `claude` — tails `~/.claude/projects/**/*.jsonl`. Kinds: `prompt`/`command` (message
   stream), `session-summary` (Layer A rollups), `session-insight` (Layer B facets).
+  🔴 **"Was skill X ever used?" — do NOT hand-write SQL or grep `text` for the name.**
+  The `session-summary` payload carries `skills_used` / `skills_invoked` /
+  `commands_typed` (skill→count maps, forward-only, **first rows 2026-08-29**), and the
+  owning entry point is **`find-session --skill NAME`** — not this skill and not
+  `adoption-scan`, which sees only the 9 `invocation.py` emitters and cannot see a skill
+  at all. Measured 2026-08-29: keyword-searching `signal` returned **678** sessions
+  against **6** real uses, 5 of them on the *laptop* — so a grep, or a one-host search,
+  answers the reverse of the truth. Report "no recorded use since <date>", never
+  "never used".
 - `i3` — `window::focus` + `workspace::focus` → `i3-source`; captures attention even when
   NOT typing. Carries `app`=WM_CLASS + `payload.workspace`.
 - `browser-bridge` — TWO kinds, and the distinction is load-bearing. `kind=cmd` is one row

--- a/claude/skills/adoption-scan/SKILL.md
+++ b/claude/skills/adoption-scan/SKILL.md
@@ -28,6 +28,22 @@ that calls `collector/invocation.py:emit_invocation`** — `verify-agent-work`, 
 rows and the drafter cwd heuristic). **Anything that does not emit is invisible, and no registry
 row can change that.**
 
+🔴 **SKILLS ARE NOT IN THIS REPORT — and "is skill X used?" has a DIFFERENT owner.**
+This scan sees the 9 `invocation.py` emitters above; a **skill** (`signal`, `browser`,
+`handoff`, …) is not one of them, so asking this report about a skill gets silence, not a
+zero. **The answer lives in `find-session --skill NAME`** (`scripts/find-session.py`), which
+reads the `skills_used` / `skills_invoked` rollup the Claude session-tailer writes onto
+`source='claude', kind='session-summary'`.
+
+🔴 **Do not answer a skill-usage question by grepping transcripts for the skill's name.** That
+is the exact mistake this routing line exists to prevent: measured 2026-08-29, `signal` returned
+**678** keyword-matching sessions and **6** real uses — and 5 of the 6 were on the *laptop*, so a
+workbench-only keyword search answered "never used", the reverse of the truth. Mention ≠ use, and
+one host ≠ the fleet.
+
+⚠ `skills_used` is **forward-only** (first rows 2026-08-29): a skill genuinely used before that
+date reads as unused. Say "no recorded use since <date>", never "never used".
+
 **Known uncovered: the `make ux-audit` harnesses** (naida / vetr / auditloop-self / remix /
 civitai-manager — see `ux-audit-loops`). They run from a Makefile inside those repos, not through
 a devrc wrapper, and emit **nothing**. So this scan **cannot** answer "is `make ux-audit` actually


### PR DESCRIPTION
Closes **G4** from `claudedocs/followups-skill-usage-telemetry.md`.

## Why this matters more than a docs nit
devrc#1000 shipped the *measurement* — `skills_used` on the Claude `session-summary` rollup, plus `find-session --skill`. Nothing pointed anyone at it: `git grep -c -- --skill` over both SKILL.md bodies returned **0**.

So the incident that motivated the entire effort **could recur with the fix fully deployed.** The next person asking "was the `signal` skill ever used?" still lands on `adoption-scan` or `activity`, and neither says where the answer lives. We fixed the capability and left the routing.

## The mistake, named with its measurement
Both bullets now carry the numbers, because the failure is counterintuitive enough that prose alone would not stop it:

| approach | result for `signal` |
|---|---|
| keyword search | **678** sessions |
| `find-session --skill signal` | **6** real uses — and **5 of the 6 on the laptop** |

Mention ≠ use, and one host ≠ the fleet. **Either error alone** produces "never used" — the reverse of the truth.

Both bullets also state the forward-only boundary (first rows 2026-08-29), with the prescribed phrasing: *"no recorded use since `<date>`"*, never *"never used"*.

## Placement
`adoption-scan`'s line goes in its existing **"Coverage limit — it can only see tools that EMIT"** section, which already enumerates the report's blind spots. A skill is not one of the 9 `invocation.py` emitters, so asking that report about a skill returns silence, not a zero — worth saying explicitly, since a zero there would read as a `DEAD` verdict.

## Body-only, by design
Routing normally belongs in a `description` — but that is the always-on listing surface ratcheted by `test_skill_descriptions.py`, and spending budget here is unnecessary: `adoption-scan` **already auto-fires** on "is anyone using X", so its *body* is what loads at the moment the question gets asked. **Zero listing cost.**

Verified: no `description:` line changed; `test_skill_descriptions.py` + `test_skill_tiers.py` → **62 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJzmPYW8nDjauyCHRtS8Ai