### PR TITLE
fix(espanso): both snippets may spell "ask" — attribution gets a declared owner instead of the picker losing a route

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -266,16 +266,19 @@ in
           # 'ask' ⊂ 'task' is the documented way a neighbour silently steals it.
           # :dacq keeps the words he actually types for THIS snippet (feedback,
           # dispatch, process); :acq owns ask/clarify/questions alone.
-          # 2026-08-29: `"ask"` REMOVED from :dacq below. The split above says in
-          # so many words that ":acq owns ask/clarify/questions alone", and the
-          # label was duly cleaned — but the search_terms were not, so BOTH
-          # snippets went on declaring "ask" exactly. The tie-break added for this
-          # (#999) can only rescue a term that NAMES one trigger outright; neither
-          # of these is named "ask", so the term resolved to None and every fire
-          # of the config's highest-traffic term was recorded UNATTRIBUTED again —
-          # the very outcome the split was meant to prevent. It also turned
-          # `main` red repo-wide. The comment was right and the data was wrong:
-          # this makes the data match it.
+          # 2026-08-29: `"ask"` was REMOVED from :dacq to make the term resolve
+          # uniquely — and then deliberately RESTORED (with "clarifying"), which
+          # is the state below. Read the removal as a bug report about the
+          # MECHANISM, not about this line: "ask"/"clarify" is how :dacq is
+          # actually searched for, so deleting them bought a telemetry row by
+          # spending a real picker route. Both snippets spelling "ask" is now
+          # SUPPORTED — `espanso_detect._AMBIGUOUS_TERM_OWNER` declares that
+          # :acq owns "ask"/"clarify" for ATTRIBUTION while the picker keeps
+          # listing both rows. 🔴 Adding a term here that another snippet also
+          # spells is therefore fine for the picker but silently costs
+          # attribution unless that table names an owner — the live guard
+          # `test_live_existing_resolutions_not_made_ambiguous` is what tells
+          # you, and it is not optional to read.
           { trigger = ":dacq"; replace = "dispatch subagent to process feedback\nask clarifying questions and recommend improvements and anything useful to include before dispatching (include complete test coverage)"; label = "Process feedback: dispatch subagent + elicit scope"; search_terms = ["ask" "clarifying" "feedback" "dispatch" "process" "elicit" "scope" "include"]; }
           { trigger = ":acq"; replace = "ask clarifying questions"; label = "ask clarifying questions"; search_terms = ["ask" "clarify" "clarifying" "questions"]; }
           { trigger = ":alo"; replace = "anything left outstanding from this thread? are all the objectives i specified directly and via the handoff fully addressed?"; label = "Anything left outstanding?"; search_terms = ["anything" "left" "outstanding" "loose" ]; }

--- a/scripts/collector/keylog/espanso_detect.py
+++ b/scripts/collector/keylog/espanso_detect.py
@@ -52,6 +52,34 @@ SEARCH_TERM_MAX = 64
 # variants, so match by substring rather than the exact class.
 ESPANSO_SEARCH_WM_CLASS = ".espanso-wrapped"
 
+# 🔴 SEARCH_TERMS SERVE TWO CONSUMERS THAT WANT OPPOSITE THINGS, and this table
+# is where the conflict is resolved instead of being fought out in the config.
+# The espanso PICKER wants recall — every word that should list a row, listed on
+# every snippet it should list (see `_PICKER_ROWS` in the tests: ambiguity there
+# means "two rows", which is the feature). `_attribute` wants precision — one
+# snippet, or nothing, so telemetry can name it. A term deliberately spelled on
+# two snippets for the picker's sake therefore has NO unique answer to read off
+# the config, and before this table the only way to give attribution one was to
+# delete the term from the picker — trading a real search route for a telemetry
+# row. That trade was made twice (2026-08-28, 2026-08-29) and reverted by hand
+# both times.
+#
+# So: term -> the snippet that OWNS it for attribution, consulted ONLY on the
+# already-ambiguous branch and ONLY over the snippets the term genuinely matches
+# (`owner in matched` below). Both clauses are load-bearing — the table can
+# never re-point a term that resolves uniquely today, and can never invent a
+# resolution to a snippet the term does not reach. A term that is ambiguous and
+# NOT listed here still resolves to None; silence is not a licence to guess.
+#
+# 'ask' is the highest-traffic term in the whole config (58 fires, 2026-08-06..19)
+# and ':dacq' spells it — plus 'clarifying', which 'clarify' is a substring of —
+# because "ask"/"clarify" is how the dispatch snippet is actually searched for.
+# ':acq' ("ask clarifying questions") is what a bare 'ask' MEANS.
+_AMBIGUOUS_TERM_OWNER = {
+    "ask": ":acq",
+    "clarify": ":acq",
+}
+
 
 def _is_espanso_search_window(app) -> bool:
     """True when `app` is espanso's own search window (which steals X focus)."""
@@ -265,7 +293,17 @@ class EspansoDetector:
         # it can never re-point a term that resolves uniquely today; the tie is
         # broken only when EXACTLY ONE candidate is named outright.
         exact = [trig for trig in matched if self._names_trigger(t, trig)]
-        return exact[0] if len(exact) == 1 else None
+        if len(exact) == 1:
+            return exact[0]
+        # Still ambiguous, and no candidate is named outright. A term may be
+        # spelled on two snippets ON PURPOSE, for the picker's sake — see
+        # `_AMBIGUOUS_TERM_OWNER`. `owner in matched` keeps the declaration
+        # honest: it picks among the snippets this term actually reaches and
+        # cannot invent one, so a stale entry goes inert rather than wrong.
+        owner = _AMBIGUOUS_TERM_OWNER.get(t)
+        if owner is not None and owner in matched:
+            return owner
+        return None
 
     @staticmethod
     def _names_trigger(term, trig):

--- a/scripts/collector/keylog/tests/test_espanso_detect.py
+++ b/scripts/collector/keylog/tests/test_espanso_detect.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import espanso_triggers as ET       # noqa: E402
+import espanso_detect as ED         # noqa: E402
 from espanso_detect import EspansoDetector  # noqa: E402
 
 # A representative slice of the live config. :date is a prefix of :datetime
@@ -507,11 +508,16 @@ def test_multiword_term_with_extra_whitespace_is_tokenized():
 #                  mutation-checked instead — see the PR body.
 #
 # These fixtures carry the REAL triggers/labels/search_terms from nix/home.nix.
+# 🔴 2026-08-29: `:dacq` regained "ask" + "clarifying" there (deliberately — see
+# `_AMBIGUOUS_TERM_OWNER`), so this fixture was updated to match. Keeping the
+# older, narrower list would have left every test below green while the live
+# config had gone ambiguous: a fixture that has drifted from the file it claims
+# to mirror asserts the past, and reads as coverage of the present.
 ACQ_BASE = {"matches": [
     {"trigger": ":dacq", "replace": "...",
      "label": "Process feedback: dispatch subagent + elicit scope",
-     "search_terms": ["feedback", "dispatch", "process", "elicit", "scope",
-                      "include"]},
+     "search_terms": ["ask", "clarifying", "feedback", "dispatch", "process",
+                      "elicit", "scope", "include"]},
     {"trigger": ":acq", "replace": "...", "label": "ask clarifying questions",
      "search_terms": ["ask", "clarify", "clarifying", "questions"]},
 ]}
@@ -593,6 +599,126 @@ def test_naming_tiebreak_does_not_reach_the_picker():
     d = _det_for(ACQ_BASE)
     assert {t for t in d.ts.triggers if d._term_matches("acq", t)} == {
         ":acq", ":dacq"}
+
+
+# -- FIX 5: a term two snippets spell ON PURPOSE ------------------------------
+# 2026-08-29. `:dacq` regained "ask" and "clarifying" in nix/home.nix, because
+# that is how the dispatch snippet is actually searched for. `_names_trigger`
+# cannot rescue either term (neither snippet is NAMED "ask"), so both went to
+# None and the live guard went red. The two previous responses both deleted the
+# terms from `:dacq` — buying a telemetry row with a real picker route, and
+# reverted by hand each time.
+#
+# The fix is a DECLARED owner (`_AMBIGUOUS_TERM_OWNER`), consulted only on the
+# already-ambiguous branch and only over the snippets the term genuinely
+# reaches. The tests below pin both halves: that it resolves the declared case,
+# and — the part that keeps it from becoming "guess something" — that an
+# ambiguous term with NO declaration still returns None.
+def test_declared_owner_resolves_a_term_both_snippets_spell():
+    # RED without _AMBIGUOUS_TERM_OWNER: both are None, because ':dacq' spells
+    # "ask" outright and "clarify" ⊂ its "clarifying".
+    d = _det_for(ACQ_BASE)
+    assert d._term_matches("ask", ":dacq") is True     # the deliberate overlap
+    assert d._term_matches("ask", ":acq") is True
+    assert d._attribute("ask") == ":acq"
+    assert d._term_matches("clarify", ":dacq") is True  # via "clarifying"
+    assert d._attribute("clarify") == ":acq"
+
+
+def test_declared_owner_does_not_reach_the_picker():
+    # The whole reason the table exists: BOTH rows must still list. If this ever
+    # shrinks to one, the fix has re-made the mistake it was written to undo.
+    d = _det_for(ACQ_BASE)
+    assert {t for t in d.ts.triggers if d._term_matches("ask", t)} == {
+        ":acq", ":dacq"}
+    assert {t for t in d.ts.triggers if d._term_matches("clarify", t)} == {
+        ":acq", ":dacq"}
+
+
+def test_undeclared_ambiguous_term_still_resolves_to_none():
+    # 🔴 The honesty guard. Mutating the owner lookup to a positional pick
+    # (`matched[0]`, "shortest trigger", "first declared") passes every test
+    # above and fails here. Silence in the table is NOT a licence to guess.
+    d = _det_for(ACQ_BASE)
+    assert sorted(t for t in d.ts.triggers if d._term_matches("ac", t)) == [
+        ":acq", ":dacq"]
+    assert "ac" not in ED._AMBIGUOUS_TERM_OWNER
+    assert d._attribute("ac") is None
+
+
+def test_declared_owner_cannot_invent_a_resolution(monkeypatch):
+    # `owner in matched` is load-bearing: a stale entry — a snippet renamed, or
+    # a term that no longer reaches it — must go INERT, never point at a snippet
+    # the term does not match. Deleting that clause turns this red.
+    monkeypatch.setitem(ED._AMBIGUOUS_TERM_OWNER, "ac", ":zzz-not-a-trigger")
+    d = _det_for(ACQ_BASE)
+    assert ":zzz-not-a-trigger" not in d.ts.triggers
+    assert d._attribute("ac") is None
+
+
+def test_declared_owner_never_repoints_a_unique_match(monkeypatch):
+    # 🔴 AN INVARIANT GUARD, NOT REGRESSION COVERAGE — labelled as one because a
+    # mutation sweep proved it cannot fail on its own. `owner in matched` makes
+    # this property STRUCTURAL: if the owner is among the matches and there is
+    # only one match, the owner IS that match, so consulting the table earlier
+    # is a no-op. Measured — moving the lookup above the uniqueness check (M4)
+    # and above `_names_trigger` (M5) both left this GREEN; the guard that
+    # actually killed them is
+    # `test_naming_a_trigger_still_beats_the_declared_owner`, and the one that
+    # kills a dropped `owner in matched` is
+    # `test_declared_owner_cannot_invent_a_resolution`.
+    # It stays because it documents the invariant those two rest on. Do not
+    # count it as evidence the ordering is tested.
+    d = _det_for(ACQ_BASE)
+    assert d._attribute("questions") == ":acq"
+    monkeypatch.setitem(ED._AMBIGUOUS_TERM_OWNER, "questions", ":dacq")
+    assert d._attribute("questions") == ":acq"
+
+
+def test_naming_a_trigger_still_beats_the_declared_owner(monkeypatch):
+    # Precedence: a term that IS a trigger name is a stronger signal than a
+    # hand-declared owner, so `_names_trigger` must be consulted first. Swapping
+    # the two blocks in `_attribute` turns this red.
+    monkeypatch.setitem(ED._AMBIGUOUS_TERM_OWNER, "acq", ":dacq")
+    d = _det_for(ACQ_BASE)
+    assert d._attribute("acq") == ":acq"
+
+
+def test_every_declared_owner_names_a_real_live_trigger():
+    """A typo or a renamed snippet leaves an entry that can never fire.
+
+    ANTI-VACUITY: this reads the LIVE config, so an empty trigger set would make
+    it pass with nothing checked — `_live_det` is pinned non-trivial by
+    `test_live_scraper_observes_the_real_config`, and asserted again here.
+    """
+    d = _live_det()
+    assert len(d.ts.triggers) > 20, "the live scraper found almost nothing"
+    unknown = {term: trig for term, trig in ED._AMBIGUOUS_TERM_OWNER.items()
+               if trig not in d.ts.triggers}
+    assert not unknown, (
+        "these _AMBIGUOUS_TERM_OWNER entries name a trigger that no longer "
+        "exists in nix/home.nix, so they are dead: " + repr(unknown))
+
+
+def test_the_declared_owner_table_is_actually_load_bearing():
+    """At least one entry must be DOING something on the live config.
+
+    Without this the whole mechanism can go inert — every term resolving
+    uniquely again — and the tests above would keep passing while nothing
+    consults the table. That is the state in which someone deletes it as unused,
+    and the picker terms go with it. If this fails, the honest fix is to delete
+    the now-inert entry, not to keep it as decoration.
+    """
+    d = _live_det()
+    working = []
+    for term, trig in ED._AMBIGUOUS_TERM_OWNER.items():
+        matched = [t for t in d.ts.triggers if d._term_matches(term, t)]
+        if len(matched) > 1 and trig in matched and d._attribute(term) == trig:
+            working.append(term)
+    assert working, (
+        "no _AMBIGUOUS_TERM_OWNER entry resolves an actually-ambiguous live "
+        "term — the table is inert and asserts nothing: "
+        + repr(dict(ED._AMBIGUOUS_TERM_OWNER)))
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What broke

`fc024d59` ("espanso", direct to `main`) restored `"ask"` + `"clarifying"` to `:dacq`'s `search_terms`. That is deliberate — it is how the dispatch snippet is actually searched for. It also turned `main` red repo-wide:

```
FAILED test_espanso_detect.py::test_live_existing_resolutions_not_made_ambiguous
  {'ask': (':acq', None, [':dacq', ':acq']), 'clarify': (':acq', None, [':dacq', ':acq'])}
```

`clarify` breaks too, as a substring of the new `"clarifying"`. `_names_trigger` (#999) cannot rescue either — neither snippet is *named* "ask".

## Why not just delete the terms again

That has now been the response twice (2026-08-28, 2026-08-29) and was reverted by hand both times. `search_terms` serves **two consumers that want opposite things**:

- the espanso **PICKER** wants recall — ambiguity there means *two rows*, which is the feature (`_PICKER_ROWS` exists to protect exactly this, after a 2026-08-19 pass stripped labels to force uniqueness and blanked the picker for `nebula`/`mesh`/`remote`);
- **`_attribute`** wants precision, so telemetry can name one snippet.

Deleting a term buys a telemetry row by spending a real search route. The config was not the bug; the mechanism was.

## The fix

`espanso_detect._AMBIGUOUS_TERM_OWNER` declares that `:acq` owns `"ask"`/`"clarify"` for **attribution**, while both picker rows keep listing. It is consulted **only** on the already-ambiguous branch, **after** `_names_trigger`, and **only** over snippets the term genuinely matches (`owner in matched`).

Both clauses are load-bearing: it can never re-point a term that resolves uniquely today, and never invent a resolution to a snippet the term does not reach — a stale entry goes **inert**, not wrong. An ambiguous term with **no** entry still returns `None`; silence is not a licence to guess.

`nix/home.nix` keeps `:dacq`'s line exactly as `fc024d59` wrote it. Only the comment above it changed — it asserted `"ask" REMOVED from :dacq` directly above the line that spells it.

## Mutation-verified

Six mutants, each killed by a **named** guard. Run under `PYTHONDONTWRITEBYTECODE=1` (stale-bytecode blind spot), unmutated tree green (101 passed) as the positive control, source restored byte-identical after.

| mutant | killed by |
|---|---|
| M1 owner branch removed (fix reverted) | 4 red, incl. the live guard + `test_declared_owner_resolves_a_term_both_snippets_spell` |
| M2 positional pick (`return matched[0]`) | 13 red, incl. `test_undeclared_ambiguous_term_still_resolves_to_none` |
| M3 `owner in matched` dropped | **exactly 1** — `test_declared_owner_cannot_invent_a_resolution` |
| M4 lookup above the uniqueness check | `test_naming_a_trigger_still_beats_the_declared_owner` |
| M5 lookup above `_names_trigger` | `test_naming_a_trigger_still_beats_the_declared_owner` |
| M6 table emptied ("it looks unused") | 4 red, incl. `test_the_declared_owner_table_is_actually_load_bearing` |

M1 makes `test_declared_owner_resolves_a_term_both_snippets_spell` **regression coverage**, not an invariant guard.

🔴 **`test_declared_owner_never_repoints_a_unique_match` is labelled IN THE TEST as an invariant guard, not regression coverage.** It stayed green under M4 *and* M5: `owner in matched` makes the property structural (owner among the matches, with one match, *is* that match). Recorded rather than counted.

## Also

`ACQ_BASE` had drifted from `nix/home.nix` — it still carried the pre-`fc024d59` `search_terms`, so every fixture test would have stayed green while the live config went ambiguous. Updated, which is what turns `test_acq_split_interface_words_still_resolve` into real coverage of this path.

## Gate — both tiers, named

- **dev-host tier** (`run-tests.sh` inside `nix develop`): `RESULT: PASS (exit=0)`, `collected=18703 passed=18701 skipped=2 failed=0` (floor 16024). Node: `1366/1366` (floor 1317).
- **sandbox tier** — the one Tekton gates on — `nix build .#checks.x86_64-linux.{pytests,nodetests}` → **rc=0**.

Base sha `0e6ca437`. ⚠ Green on this branch is not a claim about the merged tree (`strict` is false).