### PR TITLE
fix(store-api): the listen backlog was the stdlib default 5 against a server whose own suite fires 8 concurrent appends (#1030)

### DIFF
--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -575,6 +575,11 @@ DEFAULT_STORE = "/data"
 DEFAULT_TOKEN_FILE = "/run/secrets/subsystem-store/token"
 DEFAULT_PORT = 8102
 
+# Listen (accept-queue) depth. `socketserver.TCPServer` defaults to 5, which is
+# below this server's own concurrency; see `build_server` for the measurement
+# and for why this must be a CLASS attribute to reach the socket at all.
+LISTEN_BACKLOG = 128
+
 EXIT_CONFIG = 78  # sysexits.h EX_CONFIG — a misconfiguration, not a crash.
 
 
@@ -4272,7 +4277,37 @@ def build_server(
     _Handler.limiter = limiter if limiter is not None else RateLimiter()
     if audit is not None:
         _Handler.audit = staticmethod(audit)
-    return ThreadingHTTPServer((host, port), _Handler)
+
+    # 🔴 THE LISTEN BACKLOG IS SET HERE, AND IT MUST BE A CLASS ATTRIBUTE.
+    # `TCPServer.__init__` calls `server_activate()` -> `listen(
+    # self.request_queue_size)` before it returns, so assigning to the INSTANCE
+    # afterwards changes the attribute and NOT the socket — the kernel queue
+    # keeps whatever depth `__init__` used. A test that set it on the instance
+    # and then asserted the attribute would pass while the socket stayed at 5.
+    #
+    # `socketserver.TCPServer.request_queue_size` defaults to **5**, against a
+    # server whose own tests fire 8 simultaneous appends. MEASURED on this host
+    # (#1030), 200 racers x 3 rounds through `build_server`:
+    #
+    #     backlog    5 -> 389 ConnectionResetError, 211/600 answered 200
+    #     backlog  128 ->   0 ConnectionResetError, 600/600 answered 200
+    #     backlog 4096 ->   0 ConnectionResetError, 600/600 answered 200
+    #
+    # The resets are NOT immediate: the failing writers show elapsed times
+    # clustered at 1.0s and 2.2s, which are TCP SYN-retransmit intervals. So
+    # this is an accept-queue overflow that the client experiences as a reset
+    # AFTER retrying, which is why it presents as a load-correlated flake rather
+    # than a clean refusal — and why `net.ipv4.tcp_abort_on_overflow=0` does not
+    # rule the mechanism out, as it first appears to.
+    #
+    # 128 rather than `socket.SOMAXCONN`: SOMAXCONN is host-dependent (4096
+    # here, 128 on older kernels), and a value that changes per host makes the
+    # guard below assert something different per host. Linux silently caps the
+    # request at somaxconn anyway, so 128 is a floor everywhere and exact here.
+    class _Server(ThreadingHTTPServer):
+        request_queue_size = LISTEN_BACKLOG
+
+    return _Server((host, port), _Handler)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -56,6 +56,8 @@ import io
 import os
 import re
 import shutil
+import socket
+import socketserver
 import stat
 import tarfile
 import secrets
@@ -14996,3 +14998,134 @@ def test_the_SINK_call_is_inside_the_lock_not_beside_it():
         "the detector cannot see a sink call outside the lock, so its empty "
         "list above is a fact about the walker and nothing else"
     )
+
+
+class TestTheListenBacklogIsDeepEnoughForThisServersOwnConcurrency:
+    """#1030. `socketserver.TCPServer.request_queue_size` defaults to **5**,
+    against a server whose own suite fires 8 simultaneous appends. Overflowing
+    the accept queue does not refuse cleanly: the client retries the SYN and
+    then sees `ConnectionResetError: [Errno 104]`, which reads as a transport
+    flake correlated with host load.
+
+    🔴 THIS IS MEASURED AGAINST THE SOCKET, NOT THE ATTRIBUTE, and that is the
+    whole point of the arm. `TCPServer.__init__` calls `server_activate()` ->
+    `listen(self.request_queue_size)` before it returns, so a fix that assigns
+    to the INSTANCE changes the attribute and leaves the kernel queue at 5. An
+    `assert server.request_queue_size == 128` would pass for that broken fix —
+    it is a claim about a name, and the defect lives in the socket. So the queue
+    is FILLED and the landings are COUNTED.
+
+    Deterministic by construction: nothing ever accepts, so there is no race to
+    lose and no scheduling luck involved. MEASURED on a bare socket — backlog 5
+    admits 6 of 24 (the kernel's documented backlog+1) and backlog 128 admits
+    24 of 24.
+    """
+
+    # Comfortably past the default 5 and comfortably under LISTEN_BACKLOG, and
+    # deliberately not a multiple of either: a bound that sits exactly on a
+    # boundary cannot tell a fix from an off-by-one.
+    ATTEMPTS = 24
+    CONNECT_TIMEOUT = 0.4
+
+    def _fill(self, port: int) -> int:
+        """Connections that LAND while nothing is accepting."""
+        landed, held = 0, []
+        try:
+            for _ in range(self.ATTEMPTS):
+                sock = socket.socket()
+                sock.settimeout(self.CONNECT_TIMEOUT)
+                try:
+                    sock.connect(("127.0.0.1", port))
+                except OSError:
+                    sock.close()
+                    continue
+                landed += 1
+                held.append(sock)
+        finally:
+            for sock in held:
+                sock.close()
+        return landed
+
+    def test_the_SOCKET_build_server_returns_queues_more_than_the_default_five(
+        self, scoped_store: Path
+    ):
+        """RED at `request_queue_size = 5`: only 6 of 24 land."""
+        httpd = api.build_server(
+            host="127.0.0.1", port=0, store_root=str(scoped_store),
+            tokens=(ZACH,), trusted_proxies=(LOOPBACK_PROXY,),
+            limiter=None, audit=None,
+        )
+        # 🔴 `serve_forever` is NEVER started. An accepting server would drain
+        # the queue and every attempt would land whatever the backlog is, which
+        # is the vacuous-green version of this test.
+        try:
+            landed = self._fill(httpd.server_address[1])
+        finally:
+            httpd.server_close()
+        assert landed == self.ATTEMPTS, (
+            f"only {landed} of {self.ATTEMPTS} connections could be QUEUED "
+            "against the server `build_server` returns, so its accept queue is "
+            "shallower than this server's own concurrency. That is #1030: the "
+            "excess connects retry their SYN and then surface as "
+            "ConnectionResetError, which presents as a load-correlated flake "
+            "rather than a refusal. Note this counts LANDINGS on the socket — "
+            "if you 'fixed' it by assigning request_queue_size to the instance, "
+            "the attribute moved and the socket did not, because "
+            "TCPServer.__init__ has already called listen()."
+        )
+
+    def test_the_default_five_would_still_FAIL_this_probe(self):
+        """The positive control for the arm above, and it is not optional.
+
+        Without it, `landed == ATTEMPTS` is unfalsifiable: a probe that can
+        never fail reports a full queue for any backlog at all, and the guard
+        would stay green if `LISTEN_BACKLOG` were reverted to 5 tomorrow. This
+        pins that the probe DISCRIMINATES, using the stdlib default explicitly
+        rather than a number copied from the fix.
+        """
+        srv = socketserver.TCPServer.__new__(socketserver.TCPServer)
+        sock = socket.socket()
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(("127.0.0.1", 0))
+            sock.listen(socketserver.TCPServer.request_queue_size)
+            landed = self._fill(sock.getsockname()[1])
+        finally:
+            sock.close()
+            del srv
+        assert landed < self.ATTEMPTS, (
+            f"the probe queued all {self.ATTEMPTS} connections against a socket "
+            f"listening at the STDLIB DEFAULT backlog of "
+            f"{socketserver.TCPServer.request_queue_size} — so it cannot "
+            "distinguish a deep queue from a shallow one, and the sibling "
+            "test's pass means nothing."
+        )
+
+    def test_build_server_sets_the_backlog_as_a_CLASS_attribute(
+        self, scoped_store: Path
+    ):
+        """The mechanism, pinned separately from the effect.
+
+        The effect test above is the one that matters, but it cannot say WHY it
+        passes — a host whose kernel silently widened the queue would green it.
+        This asserts the class the server is an instance of carries the value,
+        which is the only assignment that reaches `server_activate()`.
+        """
+        httpd = api.build_server(
+            host="127.0.0.1", port=0, store_root=str(scoped_store),
+            tokens=(ZACH,), trusted_proxies=(LOOPBACK_PROXY,),
+            limiter=None, audit=None,
+        )
+        try:
+            assert type(httpd).request_queue_size == api.LISTEN_BACKLOG, (
+                "the server's CLASS does not carry LISTEN_BACKLOG, so "
+                "TCPServer.__init__ listened at whatever it inherited"
+            )
+            assert api.LISTEN_BACKLOG > socketserver.TCPServer.request_queue_size, (
+                f"LISTEN_BACKLOG ({api.LISTEN_BACKLOG}) is not actually deeper "
+                f"than the stdlib default "
+                f"({socketserver.TCPServer.request_queue_size}) it exists to "
+                "replace"
+            )
+        finally:
+            httpd.server_close()


### PR DESCRIPTION
Closes the mechanism in #1030.

## The defect

`socketserver.TCPServer.request_queue_size` defaults to **5**. `build_server` never set it, so the accept queue was five deep on a server whose own suite fires 8 simultaneous appends.

Overflow does not refuse cleanly. The client retries the SYN and *then* sees `ConnectionResetError: [Errno 104]` — which is why this presented as a transport flake correlated with host load rather than as a refusal, and why it kept blocking a **required** check on diffs that provably could not affect it (a docs-only PR went red on it twice today).

⚠ **`net.ipv4.tcp_abort_on_overflow=0` appears to rule this mechanism out, and does not.** That sysctl means overflow drops the SYN rather than resetting — I nearly discarded the hypothesis on it. The failing writers' elapsed times cluster at **1.0 s and 2.2 s**, which are TCP SYN-retransmit intervals: the reset lands *after* a retry. Recorded in the source so the next reader doesn't repeat the detour.

## Measurement — controlled, varying only the backlog

Through the real `build_server`, 200 racers × 3 rounds:

| `request_queue_size` | `ConnectionResetError` | answered 200 |
|---|---|---|
| **5 (what shipped)** | **389** | 211 / 600 |
| 128 | 0 | 600 / 600 |
| 4096 | 0 | 600 / 600 |

128 rather than `socket.SOMAXCONN`: SOMAXCONN is host-dependent (4096 here, 128 on older kernels), and a per-host value makes the guard assert something different per host. Linux caps the request at somaxconn anyway.

## It must be a CLASS attribute

`TCPServer.__init__` calls `server_activate()` → `listen(self.request_queue_size)` **before returning**, so an instance assignment moves the name and leaves the socket at 5. That is the plausible wrong fix, and a test asserting the attribute would bless it.

So the regression test counts **landings on the socket**: it fills the accept queue while nothing accepts. Deterministic by construction — no threads, no scheduling luck, which is what #1030 asked for ("the timing dependency removed rather than retried").

| | result |
|---|---|
| red at `origin/main` | `only 6 of 24` — `assert 6 == 24` |
| green at HEAD | 3 passed |
| instance-assignment mutant | killed by **both** arms, each with its own message (`assert 6 == 24`, `assert 5 == 128`) |
| third arm | pins that the probe still discriminates at the stdlib default, so the sibling's pass is not unfalsifiable |

## Verification, stated at the scope actually run

- Full `test_subsystem_store_api.py`: **641 passed** (638 pre-existing + 3 new).
- **20 consecutive runs** of `test_EIGHT_concurrent_appends_all_survive`, `test_two_CONCURRENT_appends_of_DIFFERENT_bullets_BOTH_survive` and the new guards: **20 pass / 0 fail**.
- Sandbox tier (`nix build .#checks.x86_64-linux.{pytests,nodetests}`) on this branch: see the comment below.

🔴 **Scope note — the literal closing condition was NOT met, deliberately.** #1030 asks for 20 consecutive runs of the *whole* `pytests` derivation. That is ~3.5 hours of saturating a box shared with many concurrent agent sessions, which would induce load flakes in their work. What is above is not green-by-sampling — it is an identified mechanism plus a deterministic red→green test — which addresses the intent the 20-run condition was written for. Flagging rather than implying the condition was satisfied; say the word and I will run the literal version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJ737dd7nvHxCgkWeTNjx6