### PR TITLE
feat(browser-bridge): the toolbar icon was a no-op — it now copies a bw:// tab reference the CLI can route

### DIFF
--- a/scripts/browser-bridge/README.md
+++ b/scripts/browser-bridge/README.md
@@ -175,7 +175,10 @@ always-detach) is in the **CDP ops** section below.
 There is **no `cookies` op** in the CLI, `server.py` or the extension, and the
 manifest deliberately does **not** request the `cookies` permission (verified:
 `permissions` is `["scripting","tabs","activeTab","storage","alarms","debugger",
-"webNavigation"]`). A cookie-read op is credential exfiltration by definition —
+"webNavigation","offscreen","clipboardWrite"]` — pinned against the manifest by
+`tests/offscreen_clipboard.test.mjs`, because a prose permission list is exactly
+the claim a reader consults to judge whether this extension is over-permissioned,
+and it had already gone stale once). A cookie-read op is credential exfiltration by definition —
 it hands a live session token to a caller. Adding one would mean, at minimum:
 hard-denying it to the autonomous browser-agent the way `upload` is (see
 *opencode browser-agent*), audit-logging every read, and accepting that session

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -50,7 +50,7 @@ once, on stderr.
 A toolbar-icon click copies `bw://<host>/<instance>/<tabId>` — one token that IS
 `--instance`+`--tab`, either side of the op; the host field is verified. 🔴 For
 `type`/`js`/`eval`/`agent` it is a reference only BEFORE the op — after it, it is
-the text/goal you send. `agent` refuses a LEADING one and any `--tab`.
+the text/goal you send. `agent` refuses a LEADING one, `--tab` and `--frame`.
 Result payloads land under `.result.data`.
 
 | command | does |

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -9,7 +9,7 @@ description: Drive the user's LIVE, logged-in Brave browser — read the active 
 BB=~/workspace/devrc/scripts/browser-bridge/browser   # ← run it by this exact path
 $BB whoami                          # ORIENT FIRST: HOST + connected profiles + extension_stale
 $BB --instance <key> open <url>     # open a NEW tab THIS session owns → returns tabId
-$BB --instance <key> --tab <id> text   # cheap read of a specific tab
+$BB bw://<host>/<inst>/<tabId> text # cheap read of the tab Zach's icon-click copied
 ```
 
 🔴 **Run `whoami` first on every fresh browser task.** Both hosts are hostname
@@ -47,6 +47,9 @@ Global flags, usable before any op: `--instance <key>` (which profile),
 Env defaults `$BB_INSTANCE`/`$BB_TAB`/`$BB_FRAME` (flag wins; zsh does NOT
 split an unquoted `$F`). ⚠ an export outlives the call — env-routed ops say so
 once, on stderr.
+A toolbar-icon click copies `bw://<host>/<instance>/<tabId>` — one token that IS
+`--instance`+`--tab`, either side of the op. Host verified; mixing it with those
+flags errors.
 Result payloads land under `.result.data`.
 
 | command | does |

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -49,7 +49,8 @@ split an unquoted `$F`). ⚠ an export outlives the call — env-routed ops say 
 once, on stderr.
 A toolbar-icon click copies `bw://<host>/<instance>/<tabId>` — one token that IS
 `--instance`+`--tab`, either side of the op. Host verified; mixing it with those
-flags errors.
+flags errors. 🔴 For `type`/`js`/`eval` it is a reference only BEFORE the op —
+after it, it is the text/expression you are sending. `agent` refuses it (own tab).
 Result payloads land under `.result.data`.
 
 | command | does |
@@ -107,12 +108,11 @@ users?" needs server-side evidence (RUM, metrics, pod health, anonymous `curl`).
 
 ## This is the user's LIVE session
 
-It's their real browser, not a scratch VM. Don't `nav` a tab that may hold unsaved
-work (a half-typed comment, a form) — `open` your own tab, or an obviously
-disposable one. 🔴 If ANYTHING takes their screen — `activate`, the X-fallback
-capture — RECORD focus AND workspace first and restore BOTH at the end, on
-failure too; restoring focus does not reliably carry the workspace. Why, and the
-commands → `reference/spa-wake.md`.
+Their real browser, not a scratch VM: don't `nav` a tab that may hold unsaved work
+(a half-typed comment, a form) — `open` your own, or an obviously disposable one.
+Anything that takes their screen (`activate`, X-fallback) is governed by RULES.md
+→ "The Operator's Screen Is Not Yours To Take", which loads every session; the
+record/restore commands → `reference/spa-wake.md`.
 
 ## Reference files — load ONE only when its trigger fires
 

--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -9,7 +9,7 @@ description: Drive the user's LIVE, logged-in Brave browser — read the active 
 BB=~/workspace/devrc/scripts/browser-bridge/browser   # ← run it by this exact path
 $BB whoami                          # ORIENT FIRST: HOST + connected profiles + extension_stale
 $BB --instance <key> open <url>     # open a NEW tab THIS session owns → returns tabId
-$BB bw://<host>/<inst>/<tabId> text # cheap read of the tab Zach's icon-click copied
+$BB bw://<host>/<inst>/<tabId> text # read the tab the icon-click copied
 ```
 
 🔴 **Run `whoami` first on every fresh browser task.** Both hosts are hostname
@@ -48,9 +48,9 @@ Env defaults `$BB_INSTANCE`/`$BB_TAB`/`$BB_FRAME` (flag wins; zsh does NOT
 split an unquoted `$F`). ⚠ an export outlives the call — env-routed ops say so
 once, on stderr.
 A toolbar-icon click copies `bw://<host>/<instance>/<tabId>` — one token that IS
-`--instance`+`--tab`, either side of the op. Host verified; mixing it with those
-flags errors. 🔴 For `type`/`js`/`eval` it is a reference only BEFORE the op —
-after it, it is the text/expression you are sending. `agent` refuses it (own tab).
+`--instance`+`--tab`, either side of the op; the host field is verified. 🔴 For
+`type`/`js`/`eval`/`agent` it is a reference only BEFORE the op — after it, it is
+the text/goal you send. `agent` refuses a LEADING one and any `--tab`.
 Result payloads land under `.result.data`.
 
 | command | does |

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -644,10 +644,20 @@ fi
 # `agent` had never honoured. A guard that names one spelling of a hazard does
 # not cover the hazard. `TAB_SRC` names whichever source supplied it, so the
 # refusal is legible whether it came from a reference, a flag or the environment.
-if [ "${1:-}" = "agent" ] && [ -n "$TAB" ]; then
-  _agent_hint=""
+#
+# 🔴 AND `--frame` IS THE SAME HAZARD — the second widening, found the same way.
+# Keying on TAB alone left the SIBLING routing variable untouched:
+# `browser --frame evil.example agent …` discarded the flag in silence (the
+# original F1 shape, unfixed), and an exported `$BB_FRAME` reached
+# browser-agent's environment while `_note_env_routing` printed `routed from the
+# ENVIRONMENT` for a route `agent` had never honoured. browser-agent accepts
+# neither flag. So the guard covers every routing variable the agent cannot
+# keep, not the one that happened to be reported.
+_agent_hint=""
+if [ "${1:-}" = "agent" ]; then
   [ -n "$INSTANCE" ] && _agent_hint=" Target the profile with --instance ${INSTANCE} instead."
-  die "agent cannot honour a tab (${TAB_SRC} gave tab ${TAB}) — browser-agent has no --tab and always works in its own new tab.${_agent_hint}"
+  [ -z "$TAB" ]   || die "agent cannot honour a tab (${TAB_SRC} gave tab ${TAB}) — browser-agent has no --tab and always works in its own new tab.${_agent_hint}"
+  [ -z "$FRAME" ] || die "agent cannot honour a frame (${FRAME_SRC} gave ${FRAME}) — browser-agent has no --frame and always works in its own new tab.${_agent_hint}"
 fi
 
 SESSION_ID="$(derive_session_id)"
@@ -2503,6 +2513,17 @@ else:
     aargs=()
     [ -n "$INSTANCE" ] && aargs+=(--instance "$INSTANCE")
     aargs+=("$@")
+    # 🔴 CLOSE THE LEAK AT THE SEAM, not just at the door. The guard above
+    # refuses a tab/frame that REACHES it — but `--tab ""` is an explicit-empty
+    # that clears the shell variable while leaving the EXPORT intact, and that is
+    # the idiom this file documents for `--instance`. An operator who exports
+    # BB_TAB, hits the refusal and clears it the documented way would otherwise
+    # hand browser-agent an environment in which every child `browser` call it
+    # makes routes to that tab — a confident answer about the wrong page, rc 0.
+    # browser-agent accepts neither flag, so neither variable can mean anything
+    # below this point. BB_INSTANCE is deliberately NOT unset: --instance IS
+    # forwarded, so inheriting it is consistent rather than a leak.
+    unset BB_TAB BB_FRAME
     exec "$HERE/browser-agent" "${aargs[@]}"
     ;;
   # ""|-h|--help|help is handled EARLIER (above the token-file read) so that

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -598,11 +598,24 @@ for _s in $REF_FREE_TEXT_SUBCOMMANDS; do
 done
 if [ "$_ref_free_text" -eq 0 ]; then
   _ref_kept=()
+  _ref_after_ddash=0
   for _a in "$@"; do
-    case "$_a" in
-      bw://*) [ -z "$REF" ] || die "two bw:// references on one command line"; REF="$_a" ;;
-      *)      _ref_kept+=("$_a") ;;
-    esac
+    # 🔴 `--` ENDS reference scanning. Everything after it is an explicit
+    # positional by the operator's own declaration, and this loop runs BEFORE
+    # each subcommand's own parser, so without this a `browser text -- 'bw://…'`
+    # had its escaped selector eaten as a route and sent NO selector at all
+    # (measured). Narrow — it needs a selector/path/url that literally begins
+    # `bw://` — but `pos_rest` exists in this file precisely because `--` was
+    # silently dropped once before.
+    if [ "$_ref_after_ddash" -eq 0 ] && [ "$_a" = "--" ]; then
+      _ref_after_ddash=1; _ref_kept+=("$_a"); continue
+    fi
+    if [ "$_ref_after_ddash" -eq 0 ]; then
+      case "$_a" in
+        bw://*) [ -z "$REF" ] || die "two bw:// references on one command line"; REF="$_a"; continue ;;
+      esac
+    fi
+    _ref_kept+=("$_a")
   done
   set -- ${_ref_kept[@]+"${_ref_kept[@]}"}
 fi
@@ -614,6 +627,16 @@ if [ -n "$REF" ]; then
   [ "$REF_SAW_INSTANCE_FLAG" -eq 0 ] || die "--instance conflicts with $REF — pass one or the other"
   [ "$REF_SAW_TAB_FLAG" -eq 0 ]      || die "--tab conflicts with $REF — pass one or the other"
   parse_tab_ref "$REF"
+  # 🔴 `agent` CANNOT HONOUR THE TAB HALF, so it must not silently keep the other
+  # half. `browser-agent` has no --tab: the agent arm forwards --instance only and
+  # the autonomous agent always works in its OWN freshly-opened tab. Left routing,
+  # the operator clicks the icon on the tab they care about, pastes the reference,
+  # and gets a confident answer about a BLANK page — a wrong answer with no error
+  # anywhere. A reference is a promise about one specific tab; the only honest
+  # response from a subcommand that cannot keep it is to refuse.
+  if [ "${1:-}" = "agent" ]; then
+    die "agent cannot honour ${REF} — it always works in its own new tab (browser-agent has no --tab). Use --instance ${INSTANCE} instead."
+  fi
 fi
 
 SESSION_ID="$(derive_session_id)"
@@ -1663,17 +1686,46 @@ if [ -n "$REF_HOST" ]; then
   _wraw="$(_curl GET /whoami)" || die "curl failed talking to ${BASE}/whoami (verifying $REF)"
   _wcode="${_wraw##*$'\n'}"; _wresp="${_wraw%$'\n'*}"
   [ "$_wcode" = "200" ] || { echo "$_wresp" >&2; die "HTTP $_wcode from /whoami (verifying $REF)"; }
-  _whost="$(printf '%s' "$_wresp" | python3 -c '
+  # 🔴 Every shape that is not a host label must come out as the empty string,
+  # WITHOUT raising. A `host` that is a string rather than an object used to
+  # reach `.get` and print an AttributeError traceback to stderr before falling
+  # through to the proceed branch — so a PARSE failure was reported to the
+  # operator as "the bridge cannot identify its host", which is a different fact
+  # and sends them to the wrong place. `_whost_why` keeps the two apart.
+  # Emits `<reason>:<label>` on ONE line. The reason is the parser's own verdict —
+  # deriving it afterwards from the response TEXT was measured wrong: a body with
+  # `"host": "workbench"` contains the key, so a grep for it reported an
+  # unreadable SHAPE as an unidentifiable HOST.
+  _wparsed="$(printf '%s' "$_wresp" | python3 -c '
 import json, sys
+def out(reason, label=""):
+    sys.stdout.write(reason + ":" + label)
+    raise SystemExit(0)
 try:
     d = json.load(sys.stdin)
 except Exception:
-    sys.exit(0)
-h = d.get("host") if isinstance(d, dict) else None
-sys.stdout.write(str((h or {}).get("label") or ""))
+    out("unreadable")
+if not isinstance(d, dict):
+    out("unreadable")
+h = d.get("host")
+if h is None:
+    out("absent")
+if not isinstance(h, dict):
+    out("unreadable")
+label = h.get("label")
+if label is None:
+    out("absent")
+if not isinstance(label, str):
+    out("unreadable")
+out("ok", label)
 ')"
+  _whost="${_wparsed#*:}"
+  case "${_wparsed%%:*}" in
+    unreadable) _whost_why="answered /whoami in a shape this CLI could not read" ;;
+    *)          _whost_why="cannot identify its host" ;;
+  esac
   if [ -z "$_whost" ] || [ "$_whost" = "unknown" ]; then
-    echo "browser: this bridge cannot identify its host, so $REF's host field" \
+    echo "browser: this bridge ${_whost_why}, so $REF's host field" \
          "('${REF_HOST}') was NOT verified — proceeding." >&2
   elif [ "$_whost" != "$REF_HOST" ]; then
     die "$REF was minted on '${REF_HOST}'; this bridge is '${_whost}'. The tab it names is on the other host — run it there."

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -2521,9 +2521,21 @@ else:
     # hand browser-agent an environment in which every child `browser` call it
     # makes routes to that tab — a confident answer about the wrong page, rc 0.
     # browser-agent accepts neither flag, so neither variable can mean anything
-    # below this point. BB_INSTANCE is deliberately NOT unset: --instance IS
-    # forwarded, so inheriting it is consistent rather than a leak.
-    unset BB_TAB BB_FRAME
+    # below this point.
+    #
+    # 🔴 BB_INSTANCE IS UNSET TOO, and the reasoning that exempted it was wrong
+    # in exactly one case — the same explicit-empty this comment block is built
+    # on. "`--instance` IS forwarded, so inheriting it is consistent" holds when
+    # a value survives: the arm forwards it explicitly two lines up. It does NOT
+    # hold for `browser --instance "" agent …`, the documented way to clear an
+    # inherited BB_INSTANCE (see the PRECEDENCE note above): INSTANCE is then
+    # empty, so NO --instance is forwarded, while BB_INSTANCE survives the exec
+    # and every child call browser-agent makes re-reads it — driving the WRONG
+    # BRAVE PROFILE, with no advisory, because the flag reset INSTANCE_SRC so
+    # `_note_env_routing` stays silent. Unsetting is safe for the other two
+    # cases precisely because the value is forwarded as an argument when it
+    # exists; the environment copy is never the thing that carries it.
+    unset BB_TAB BB_FRAME BB_INSTANCE
     exec "$HERE/browser-agent" "${aargs[@]}"
     ;;
   # ""|-h|--help|help is handled EARLIER (above the token-file read) so that

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -16,6 +16,21 @@
 # more than one and no --instance, a command ERRORS (it never guesses) and lists
 # the connected instances — pick one with --instance <key>.
 #
+# Tab references (bw://):
+#   Clicking the Browser Bridge toolbar icon copies a reference to the tab you
+#   are looking at — bw://<host>/<instance>/<tabId>, e.g. bw://workbench/main/12345.
+#   Paste it in place of --instance/--tab:
+#
+#     browser screenshot bw://workbench/main/12345
+#     browser bw://workbench/main/12345 text
+#
+#   Either position works. The <host> field is VERIFIED against the bridge before
+#   the command runs, so a reference pasted into a session on the other host
+#   fails loudly instead of driving a same-labelled profile there. Combining a
+#   reference with --instance/--tab is an error, not a precedence question. For
+#   `type`, `js`/`eval` and `agent` — whose argument is arbitrary text — only the
+#   leading position is a reference; a trailing bw://… is the value you meant.
+#
 # Per-session tab isolation (fixes concurrent-session clobbering):
 #   Two Claude sessions driving one browser used to interleave on ONE shared
 #   active tab. Now each session can `open` its OWN tab; the server records the
@@ -328,7 +343,53 @@ TAB_SRC="--tab";           [ -n "${BB_TAB:-}" ]      && TAB_SRC="\$BB_TAB"
 FRAME_SRC="--frame";       [ -n "${BB_FRAME:-}" ]    && FRAME_SRC="\$BB_FRAME"
 ENV_ROUTE_NOTED=0
 
+# --- bw:// tab references ---------------------------------------------------- #
+# A `bw://<host>/<instance>/<tabId>` reference is one pasteable token that means
+# exactly `--instance <instance> --tab <tabId>`, plus an assertion about WHICH
+# HOST it was minted on. The extension produces it when the operator clicks the
+# toolbar icon (extension/protocol.js `buildTabRef` is the one definition of the
+# format); this end consumes it.
+REF=""                        # the raw reference, once seen
+REF_HOST=""                   # its host field — checked against /whoami below
+REF_SAW_INSTANCE_FLAG=0       # an explicit --instance also appeared
+REF_SAW_TAB_FLAG=0            # an explicit --tab also appeared
+# Subcommands whose positional argument is ARBITRARY OPERATOR TEXT, where a
+# leading `bw://` is a value and not a reference: `type` types it into a page,
+# `js`/`eval` evaluate it, `agent` reads it as a goal. For these the reference is
+# accepted ONLY in the leading (pre-subcommand) position, so that
+# `browser type 'bw://…'` still types the literal string. Every other subcommand
+# takes a URL, a selector, a path or a number — none of which can begin `bw://`
+# — so a reference is unambiguous there and may appear in the natural
+# paste order (`browser screenshot bw://…`).
+REF_FREE_TEXT_SUBCOMMANDS="type js eval agent"
+
 die() { echo "browser: $*" >&2; exit 1; }
+
+# parse_tab_ref REF — split a reference into REF_HOST / INSTANCE / TAB, or die
+# with a message that names the offending field. Every field is validated here
+# rather than at the point of use: a reference that parses into the WRONG fields
+# routes a real command at a real browser, so the only safe failure is a loud one.
+parse_tab_ref() {
+  local raw="$1" rest h k t
+  rest="${raw#bw://}"
+  [ "$rest" != "$raw" ] || die "not a bw:// reference: $raw"
+  # EXACTLY two separators. Both `bw://a/b` and `bw://a/b/c/d` are refused rather
+  # than parsed into whichever three fields happen to fall out.
+  case "$rest" in
+    */*/*/*) die "too many '/' in reference: $raw (want bw://<host>/<instance>/<tabId>)" ;;
+    */*/*)   : ;;
+    *)       die "reference must be bw://<host>/<instance>/<tabId> (got: $raw)" ;;
+  esac
+  h="${rest%%/*}"; rest="${rest#*/}"
+  k="${rest%%/*}"; t="${rest#*/}"
+  # The same character class the builder enforces (protocol.js TAB_REF_FIELD_RE).
+  case "$h" in (*[!A-Za-z0-9._-]*|"") die "reference host is not ref-safe: '${h}' in $raw" ;; esac
+  case "$k" in (*[!A-Za-z0-9._-]*|"") die "reference instance is not ref-safe: '${k}' in $raw" ;; esac
+  case "$t" in (*[!0-9]*|"")          die "reference tab id must be numeric: '${t}' in $raw" ;; esac
+  REF_HOST="$h"
+  INSTANCE="$k"; INSTANCE_SRC="the bw:// reference"
+  TAB="$t";      TAB_SRC="the bw:// reference"
+}
 
 # derive_session_id — a STABLE identifier for THIS Claude session, identical
 # across the many `browser` invocations one session makes (each is a fresh
@@ -476,10 +537,15 @@ derive_session_id() {
 # subcommand. --print-session-id short-circuits (no server/token needed).
 while [ $# -gt 0 ]; do
   case "$1" in
-    --instance) shift; [ $# -ge 1 ] || die "usage: browser --instance <key> <subcommand>"; INSTANCE="$1"; INSTANCE_SRC="--instance"; shift ;;
-    --instance=*) INSTANCE="${1#--instance=}"; INSTANCE_SRC="--instance"; shift ;;
-    --tab) shift; [ $# -ge 1 ] || die "usage: browser --tab <id> <subcommand>"; TAB="$1"; TAB_SRC="--tab"; shift ;;
-    --tab=*) TAB="${1#--tab=}"; TAB_SRC="--tab"; shift ;;
+    --instance) shift; [ $# -ge 1 ] || die "usage: browser --instance <key> <subcommand>"; INSTANCE="$1"; INSTANCE_SRC="--instance"; REF_SAW_INSTANCE_FLAG=1; shift ;;
+    --instance=*) INSTANCE="${1#--instance=}"; INSTANCE_SRC="--instance"; REF_SAW_INSTANCE_FLAG=1; shift ;;
+    --tab) shift; [ $# -ge 1 ] || die "usage: browser --tab <id> <subcommand>"; TAB="$1"; TAB_SRC="--tab"; REF_SAW_TAB_FLAG=1; shift ;;
+    --tab=*) TAB="${1#--tab=}"; TAB_SRC="--tab"; REF_SAW_TAB_FLAG=1; shift ;;
+    # A reference in the leading position works for EVERY subcommand, including
+    # the free-text ones. It is only consumed, never applied, here: applying it
+    # before the whole line is read would let a later --instance overwrite it
+    # silently, which is the disagreement the check below refuses outright.
+    bw://*) [ -z "$REF" ] || die "two bw:// references on one command line"; REF="$1"; shift ;;
     --frame) shift; [ $# -ge 1 ] || die "usage: browser --frame <frameId|url-substring> <subcommand>"; FRAME="$1"; FRAME_SRC="--frame"; shift ;;
     --frame=*) FRAME="${1#--frame=}"; FRAME_SRC="--frame"; shift ;;
     --print-session-id) derive_session_id; echo; exit 0 ;;
@@ -520,6 +586,35 @@ for _s in $SUBCOMMANDS; do
   if [ "$_s" = "${1:-}" ]; then _sub_known=1; break; fi
 done
 [ "$_sub_known" -eq 1 ] || die "unknown subcommand: ${1:-} (try: $SUBCOMMANDS)"
+
+# --- consume a bw:// reference given in the natural paste order -------------- #
+# `browser screenshot bw://workbench/main/12345` — the reference AFTER the
+# subcommand, which is how it reads when pasted out of a prompt. Skipped entirely
+# for the free-text subcommands (see REF_FREE_TEXT_SUBCOMMANDS), where such a
+# token is a value the operator meant to send.
+_ref_free_text=0
+for _s in $REF_FREE_TEXT_SUBCOMMANDS; do
+  if [ "$_s" = "${1:-}" ]; then _ref_free_text=1; break; fi
+done
+if [ "$_ref_free_text" -eq 0 ]; then
+  _ref_kept=()
+  for _a in "$@"; do
+    case "$_a" in
+      bw://*) [ -z "$REF" ] || die "two bw:// references on one command line"; REF="$_a" ;;
+      *)      _ref_kept+=("$_a") ;;
+    esac
+  done
+  set -- ${_ref_kept[@]+"${_ref_kept[@]}"}
+fi
+
+if [ -n "$REF" ]; then
+  # 🔴 A reference and an explicit flag can DISAGREE, and there is no reading of
+  # "last one wins" that is safe: whichever is ignored, the command runs against
+  # a tab the operator did not name. Refuse instead of picking.
+  [ "$REF_SAW_INSTANCE_FLAG" -eq 0 ] || die "--instance conflicts with $REF — pass one or the other"
+  [ "$REF_SAW_TAB_FLAG" -eq 0 ]      || die "--tab conflicts with $REF — pass one or the other"
+  parse_tab_ref "$REF"
+fi
 
 SESSION_ID="$(derive_session_id)"
 
@@ -1551,6 +1646,40 @@ sub="${1:-}"; shift || true
 # The flag loop above exits for --help/--print-session-id before reaching this
 # line, so a command that never touches the wire never emits it.
 _note_env_routing
+
+# --- the reference's HOST field, checked against the bridge we are talking to - #
+# 🔴 THIS IS THE POINT OF THE HOST FIELD, and it has to be a real request. This
+# CLI only ever talks to 127.0.0.1, so a reference minted on the workbench and
+# pasted into a laptop session cannot reach the tab it names — but it CAN reach a
+# same-labelled profile on this machine (labels are unique per host, not across
+# hosts) and drive the wrong browser while returning a perfectly ordinary
+# envelope. One cheap diagnostic GET buys a loud failure instead.
+#
+# It FAILS CLOSED on disagreement and OPEN on ignorance: a server that cannot
+# identify its own host answers "unknown", and refusing there would make every
+# reference unusable on a host with no ACTIVITY_HOST rather than catching
+# anything. That case warns on stderr and proceeds — stdout stays pure.
+if [ -n "$REF_HOST" ]; then
+  _wraw="$(_curl GET /whoami)" || die "curl failed talking to ${BASE}/whoami (verifying $REF)"
+  _wcode="${_wraw##*$'\n'}"; _wresp="${_wraw%$'\n'*}"
+  [ "$_wcode" = "200" ] || { echo "$_wresp" >&2; die "HTTP $_wcode from /whoami (verifying $REF)"; }
+  _whost="$(printf '%s' "$_wresp" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+h = d.get("host") if isinstance(d, dict) else None
+sys.stdout.write(str((h or {}).get("label") or ""))
+')"
+  if [ -z "$_whost" ] || [ "$_whost" = "unknown" ]; then
+    echo "browser: this bridge cannot identify its host, so $REF's host field" \
+         "('${REF_HOST}') was NOT verified — proceeding." >&2
+  elif [ "$_whost" != "$REF_HOST" ]; then
+    die "$REF was minted on '${REF_HOST}'; this bridge is '${_whost}'. The tab it names is on the other host — run it there."
+  fi
+fi
+
 case "$sub" in
   health)
     raw="$(_curl GET /health)" || die "curl failed talking to ${BASE}/health"

--- a/scripts/browser-bridge/browser
+++ b/scripts/browser-bridge/browser
@@ -627,16 +627,27 @@ if [ -n "$REF" ]; then
   [ "$REF_SAW_INSTANCE_FLAG" -eq 0 ] || die "--instance conflicts with $REF — pass one or the other"
   [ "$REF_SAW_TAB_FLAG" -eq 0 ]      || die "--tab conflicts with $REF — pass one or the other"
   parse_tab_ref "$REF"
-  # 🔴 `agent` CANNOT HONOUR THE TAB HALF, so it must not silently keep the other
-  # half. `browser-agent` has no --tab: the agent arm forwards --instance only and
-  # the autonomous agent always works in its OWN freshly-opened tab. Left routing,
-  # the operator clicks the icon on the tab they care about, pastes the reference,
-  # and gets a confident answer about a BLANK page — a wrong answer with no error
-  # anywhere. A reference is a promise about one specific tab; the only honest
-  # response from a subcommand that cannot keep it is to refuse.
-  if [ "${1:-}" = "agent" ]; then
-    die "agent cannot honour ${REF} — it always works in its own new tab (browser-agent has no --tab). Use --instance ${INSTANCE} instead."
-  fi
+fi
+
+# 🔴 `agent` CANNOT HONOUR A TAB FROM ANY SOURCE — and this check is deliberately
+# on the STATE (`TAB` is set) rather than on the spelling that first exposed it.
+# `browser-agent` has no --tab: the agent arm forwards --instance only, and the
+# autonomous agent always works in its OWN freshly-opened tab. So a tab named
+# here is silently discarded and the agent answers about a DIFFERENT page —
+# confidently, with no error anywhere.
+#
+# 🔴 THE FIRST VERSION OF THIS GUARD ONLY REFUSED `bw://`, and an audit walked
+# straight around it: `browser --tab 12345 agent …` reproduced the identical
+# wrong answer with no mention of the discarded flag, and an exported `$BB_TAB`
+# was worse still — it leaked into browser-agent's OWN child `browser` calls, so
+# the tab reappeared on the wire while `_note_env_routing` claimed a route that
+# `agent` had never honoured. A guard that names one spelling of a hazard does
+# not cover the hazard. `TAB_SRC` names whichever source supplied it, so the
+# refusal is legible whether it came from a reference, a flag or the environment.
+if [ "${1:-}" = "agent" ] && [ -n "$TAB" ]; then
+  _agent_hint=""
+  [ -n "$INSTANCE" ] && _agent_hint=" Target the profile with --instance ${INSTANCE} instead."
+  die "agent cannot honour a tab (${TAB_SRC} gave tab ${TAB}) — browser-agent has no --tab and always works in its own new tab.${_agent_hint}"
 fi
 
 SESSION_ID="$(derive_session_id)"

--- a/scripts/browser-bridge/extension/build_id.js
+++ b/scripts/browser-bridge/extension/build_id.js
@@ -24,4 +24,4 @@
 //   * a hash computed in the worker over its own source — same disk read
 // The marker must be a LITERAL in a module the worker imported, so that it was
 // frozen into the loaded module graph at load time and travels with the code.
-export const BUILD_MARKER = "1d06f03fc740b26a";
+export const BUILD_MARKER = "66b98084daecd880";

--- a/scripts/browser-bridge/extension/build_id.js
+++ b/scripts/browser-bridge/extension/build_id.js
@@ -24,4 +24,4 @@
 //   * a hash computed in the worker over its own source — same disk read
 // The marker must be a LITERAL in a module the worker imported, so that it was
 // frozen into the loaded module graph at load time and travels with the code.
-export const BUILD_MARKER = "aada672ff3a5ded7";
+export const BUILD_MARKER = "1d06f03fc740b26a";

--- a/scripts/browser-bridge/extension/manifest.json
+++ b/scripts/browser-bridge/extension/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 3,
   "name": "Browser Bridge (command channel)",
-  "version": "0.8.1.43738",
+  "version": "0.8.1.7430",
   "description": "Lets a local Claude Code skill drive the active Brave tab (getHtml/eval/tabs/nav/screenshot/frames/click/type/key/activate/upload/emulate/ping) via a loopback, token-authenticated rendezvous server. Local-only, authorized personal automation.",
-  "permissions": ["scripting", "tabs", "activeTab", "storage", "alarms", "debugger", "webNavigation"],
+  "permissions": ["scripting", "tabs", "activeTab", "storage", "alarms", "debugger", "webNavigation", "offscreen"],
   "host_permissions": ["http://127.0.0.1:8788/*", "<all_urls>"],
   "icons": {
     "16": "icons/icon-16.png",

--- a/scripts/browser-bridge/extension/manifest.json
+++ b/scripts/browser-bridge/extension/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 3,
   "name": "Browser Bridge (command channel)",
-  "version": "0.8.1.7430",
+  "version": "0.8.1.26297",
   "description": "Lets a local Claude Code skill drive the active Brave tab (getHtml/eval/tabs/nav/screenshot/frames/click/type/key/activate/upload/emulate/ping) via a loopback, token-authenticated rendezvous server. Local-only, authorized personal automation.",
-  "permissions": ["scripting", "tabs", "activeTab", "storage", "alarms", "debugger", "webNavigation", "offscreen"],
+  "permissions": ["scripting", "tabs", "activeTab", "storage", "alarms", "debugger", "webNavigation", "offscreen", "clipboardWrite"],
   "host_permissions": ["http://127.0.0.1:8788/*", "<all_urls>"],
   "icons": {
     "16": "icons/icon-16.png",

--- a/scripts/browser-bridge/extension/offscreen.html
+++ b/scripts/browser-bridge/extension/offscreen.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!-- offscreen.html — the extension's clipboard writer, and nothing else.
+
+     An MV3 service worker has no `document`, so it cannot reach the clipboard.
+     This page exists solely so `chrome.offscreen.createDocument({reasons:
+     ["CLIPBOARD"]})` has something to load; the worker creates it on a toolbar
+     click, posts the text, and closes it again. It is never visible, never
+     navigated, and loads no remote resource.
+
+     ⚠ This file is NOT covered by the build marker: gen-build-marker.py hashes
+     `*.js` + manifest.json, so an edit HERE would not move the marker and
+     `extension_stale` could not see it. It is kept deliberately inert — a
+     textarea and a script tag — so there is nothing here to go stale. Any real
+     logic belongs in offscreen.js, which IS hashed. -->
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Browser Bridge — offscreen</title>
+</head>
+<body>
+  <textarea id="sink"></textarea>
+  <script src="offscreen.js"></script>
+</body>
+</html>

--- a/scripts/browser-bridge/extension/offscreen.js
+++ b/scripts/browser-bridge/extension/offscreen.js
@@ -1,0 +1,36 @@
+// offscreen.js — write one string to the clipboard on behalf of the service
+// worker, which cannot reach the clipboard itself (no `document` in MV3).
+//
+// 🔴 `document.execCommand("copy")`, NOT `navigator.clipboard.writeText()`.
+// The async Clipboard API requires the calling document to be FOCUSED; an
+// offscreen document is never focused, so writeText() rejects with
+// "Document is not focused" every single time. execCommand on a selected
+// textarea has no such requirement and is the path Chrome's own offscreen
+// clipboard sample uses. It is deprecated-but-supported, and there is no
+// replacement reachable from this context.
+//
+// The listener answers ONLY its own `target`, because chrome.runtime.sendMessage
+// fans out to every extension context except the sender — an options page that
+// grew a listener must not be able to answer for the clipboard.
+const TARGET = "offscreen-clipboard";
+
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (!msg || msg.target !== TARGET) return false;   // not ours: stay silent
+  if (msg.type !== "copy") {
+    sendResponse({ ok: false, error: `unknown type: ${String(msg.type)}` });
+    return false;
+  }
+  try {
+    const sink = document.getElementById("sink");
+    sink.value = String(msg.text == null ? "" : msg.text);
+    sink.select();
+    // execCommand REPORTS failure by returning false rather than throwing, so
+    // the boolean is the whole result — treating a completed call as success is
+    // how a ✓ badge ends up over an empty clipboard.
+    const ok = document.execCommand("copy");
+    sendResponse(ok ? { ok: true } : { ok: false, error: "execCommand refused" });
+  } catch (e) {
+    sendResponse({ ok: false, error: String((e && e.message) || e) });
+  }
+  return false;                                      // answered synchronously
+});

--- a/scripts/browser-bridge/extension/offscreen.js
+++ b/scripts/browser-bridge/extension/offscreen.js
@@ -9,6 +9,19 @@
 // clipboard sample uses. It is deprecated-but-supported, and there is no
 // replacement reachable from this context.
 //
+// 🔴 AND IT NEEDS THE `clipboardWrite` PERMISSION — the manifest declares it, and
+// dropping it makes this file silently inert. `execCommand("copy")` is allowed
+// without that permission ONLY inside a short-lived event handler for a user
+// action. This copy is neither: by the time it runs, the worker has awaited
+// config(), the active tab, a NETWORK /whoami round trip and the creation of
+// this very document — and this document never had transient activation at all.
+// Without the permission `execCommand` returns FALSE (it does not throw), which
+// this listener reports honestly as {ok:false}, so the symptom is a ✗ badge and
+// an untouched clipboard on EVERY click, forever. Chrome's own
+// cookbook.offscreen-clipboard-write sample declares `clipboardWrite` for
+// exactly this reason. tests/offscreen_clipboard.test.mjs pins both permissions
+// against the manifest.
+//
 // The listener answers ONLY its own `target`, because chrome.runtime.sendMessage
 // fans out to every extension context except the sender — an options page that
 // grew a listener must not be able to answer for the clipboard.

--- a/scripts/browser-bridge/extension/protocol.js
+++ b/scripts/browser-bridge/extension/protocol.js
@@ -2953,3 +2953,75 @@ export function pollHeaders(instanceId, label, active, extVersion, extId,
 export function resultWithInstance(envelope, instanceId) {
   return { ...envelope, instanceId: String(instanceId || "") };
 }
+
+// --- tab references (`bw://`) ----------------------------------------------- //
+// A self-contained, pasteable handle for ONE tab, on ONE profile, on ONE host:
+//
+//     bw://<host>/<instance>/<tabId>          e.g. bw://workbench/main/12345
+//
+// It exists for the toolbar-click path: the operator is LOOKING at a tab, clicks
+// the Browser Bridge icon, and gets a string they can paste into a prompt —
+// `browser bw://workbench/main/12345 screenshot` then routes straight back to
+// that exact tab. The three fields are precisely the three things a command
+// cannot infer from the paste:
+//
+//   host      WHICH machine's bridge. It is a CHECK, not a route: the CLI only
+//             ever talks to 127.0.0.1, so a ref carried to the other host must
+//             fail loudly instead of silently operating on a same-labelled
+//             profile over there.
+//   instance  the server's routing key — `--instance`.
+//   tabId     Chrome's numeric tab id — `--tab`.
+export const TAB_REF_SCHEME = "bw://";
+
+// 🔴 The instance field is the FULL routing key, never a prefix of it. The
+// server resolves a target with `target in (inst.key, inst.instance_id)`
+// (server.py `_resolve_target_locked`) — an EXACT match against either. So an
+// abbreviated auto-id does not route at all, and a ref built from one would fail
+// as `unknown_instance` on the very first command. `key = label or instance_id`
+// (server.py, `register`), so that is what this mirrors: the label when the
+// profile has one, else the whole UUID.
+export function tabRefKey(label, instanceId) {
+  const l = String(label || "").trim();
+  return l || String(instanceId || "").trim();
+}
+
+// The character class the host and instance fields must satisfy. Deliberately
+// NARROW. The ref is split on `/` by a bash CLI and pasted onto shell command
+// lines, so a `/`, a space or a quote in an operator-chosen label would produce
+// a ref that parses cleanly into the WRONG fields — the silent-wrong-answer
+// shape this subsystem keeps finding. Percent-encoding was the alternative and
+// was rejected: it moves a decoder into bash to serve a label that is set once,
+// by hand, from names that are ASCII in practice (`main`, `work`). A label
+// outside this class is REFUSED with a message naming it, rather than mangled.
+// A bare auto-id (a UUID) is hex + dashes, so it always satisfies this.
+export const TAB_REF_FIELD_RE = /^[A-Za-z0-9._-]+$/;
+
+// Build the ref, or throw an Error whose message is the reason. Every throw is a
+// condition the CLICKING OPERATOR can act on, so the messages are the badge
+// tooltip text — not internal codes.
+export function buildTabRef({ host, label, instanceId, tabId } = {}) {
+  const h = String(host || "").trim();
+  // "unknown" is `resolve_host()`'s own answer when it cannot identify the
+  // machine (server.py). Minting a ref with it would make the host field — the
+  // one thing that catches a cross-host paste — vacuous, and there is no second
+  // chance to check a token once it is on the clipboard.
+  if (!h || h === "unknown") {
+    throw new Error("bridge could not identify this host");
+  }
+  if (!TAB_REF_FIELD_RE.test(h)) {
+    throw new Error(`host label is not ref-safe: ${h}`);
+  }
+  const key = tabRefKey(label, instanceId);
+  if (!key) throw new Error("this profile has no label and no instance id");
+  if (!TAB_REF_FIELD_RE.test(key)) {
+    throw new Error(
+      `instance label is not ref-safe: ${key} — use only letters, digits, . _ -`);
+  }
+  // Chrome tab ids are non-negative integers. `chrome.tabs.TAB_ID_NONE` is -1,
+  // which is a real value a devtools/background target can carry — it must not
+  // become a ref that looks routable.
+  if (!Number.isInteger(tabId) || tabId < 0) {
+    throw new Error(`no routable tab id (got: ${String(tabId)})`);
+  }
+  return `${TAB_REF_SCHEME}${h}/${key}/${tabId}`;
+}

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -1956,6 +1956,19 @@ function sleep(ms) {
 const TAB_REF_BADGE_MS = 2500;          // how long the ✓/✗ badge stays up
 const TAB_REF_WHOAMI_BUDGET_MS = 3000;  // the /whoami read is on the click path
 const TAB_REF_CLIPBOARD_BUDGET_MS = 3000;
+// The two budgets, read through one function so a test can shorten them without
+// waiting 3s per case — and, more to the point, so the BOUND ITSELF is a seam a
+// test can assert on. Pinning the constant is not the same claim as pinning that
+// the click path uses it (the same gap `loopTiming` exists to close one level
+// up). Production passes nothing and gets the constants above.
+function tabRefTiming() {
+  const o = (typeof globalThis !== "undefined" && globalThis.BROWSER_BRIDGE_TAB_REF_TIMING) || {};
+  return {
+    whoamiMs: o.whoamiMs != null ? o.whoamiMs : TAB_REF_WHOAMI_BUDGET_MS,
+    clipboardMs: o.clipboardMs != null ? o.clipboardMs : TAB_REF_CLIPBOARD_BUDGET_MS,
+    badgeMs: o.badgeMs != null ? o.badgeMs : TAB_REF_BADGE_MS,
+  };
+}
 const OFFSCREEN_URL = "offscreen.html";
 // The message envelope the offscreen document answers. `target` namespaces it so
 // an options page (or any future extension context) that also listens cannot
@@ -2049,7 +2062,7 @@ async function flashBadge(text, color, title) {
         chrome.action.setBadgeText({ text: "" });
         chrome.action.setTitle({ title: "Browser Bridge" });
       } catch (e) { /* the worker may have been suspended; harmless */ }
-    }, TAB_REF_BADGE_MS);
+    }, tabRefTiming().badgeMs);
   } catch (e) { /* feedback is best-effort — never mask the real outcome */ }
 }
 
@@ -2062,11 +2075,11 @@ async function handleActionClick() {
     const cfg = await config();
     const tab = await activeTab();                   // throws no_active_tab
     const host = await promiseWithTimeout(
-      fetchHostLabel(cfg), TAB_REF_WHOAMI_BUDGET_MS, "whoami", {}, "op_timeout");
+      fetchHostLabel(cfg), tabRefTiming().whoamiMs, "whoami", {}, "op_timeout");
     const ref = buildTabRef({
       host, label: cfg.label, instanceId: cfg.instanceId, tabId: tab.id,
     });
-    await promiseWithTimeout(writeClipboard(ref), TAB_REF_CLIPBOARD_BUDGET_MS,
+    await promiseWithTimeout(writeClipboard(ref), tabRefTiming().clipboardMs,
                              "clipboard", {}, "op_timeout");
     await flashBadge("✓", "#1a7f37", `Copied ${ref}`);
     return { ok: true, ref };
@@ -2078,6 +2091,20 @@ async function handleActionClick() {
   }
 }
 
+// Wire the toolbar click to the handler above. Extracted from startBackground()
+// so a test can drive the REGISTRATION rather than only the handler: an audit
+// replaced the whole registration with `if (false) {}` and every one of the 549
+// node tests and 33 pytest cases stayed green, because `handleActionClick` is
+// exported and was only ever called directly. That is the seam nobody owned —
+// on the one path in this subsystem that cannot be live-verified from here.
+// `action` is a parameter so the test can pass its own recorder; production
+// passes nothing and gets chrome.action.
+function registerActionClick(action = (typeof chrome !== "undefined" && chrome.action)) {
+  if (!action || !action.onClicked) return false;
+  action.onClicked.addListener(() => { handleActionClick(); });
+  return true;
+}
+
 // --- MV3 keepalive + background wiring -------------------------------------- //
 // All the real-browser side effects (event listeners, the keepalive alarm, and the
 // immediate loop kick) are grouped here so a unit test can import this module for its
@@ -2086,13 +2113,7 @@ async function handleActionClick() {
 function startBackground() {
   chrome.runtime.onInstalled.addListener(() => loop());
   chrome.runtime.onStartup.addListener(() => loop());
-  // Toolbar click → copy a bw:// tab reference. Registered HERE (not at module
-  // top level) so importing this module under BROWSER_BRIDGE_NO_AUTOSTART still
-  // requires no chrome.action mock; the handler itself is exported and tested
-  // directly.
-  if (chrome.action && chrome.action.onClicked) {
-    chrome.action.onClicked.addListener(() => { handleActionClick(); });
-  }
+  registerActionClick();
   chrome.alarms.create("bridge-keepalive", { periodInMinutes: 1 });
   chrome.alarms.onAlarm.addListener((a) => {
     // keepaliveTick, NOT loop(): a bare loop() call hits `if (running) return`
@@ -2141,8 +2162,17 @@ if (!(typeof globalThis !== "undefined" && globalThis.BROWSER_BRIDGE_NO_AUTOSTAR
 // assert it copies the right string, and refuses rather than copying a wrong
 // one, is to call it against a mocked chrome. Nothing in the extension imports
 // it; the listener above closes over it directly.
+// `registerActionClick`, `OFFSCREEN_CLIPBOARD_TARGET` and `OFFSCREEN_URL` are
+// exported for TESTS only. The first is the wiring seam described above. The
+// other two are the CROSS-FILE literals: this worker names a target string and a
+// page url that only `offscreen.js` and `offscreen.html` can honour, in two
+// other files, with no shared module and no schema — the same shape as the
+// CLI↔protocol.js seam that already has a guard. Renaming either half alone left
+// the whole suite green (measured: 7 of 8 offscreen mutants SURVIVED), so
+// tests/offscreen_clipboard.test.mjs compares them.
 export { execute, OPS, ALLOWED_OPS, cdpAttached, loop, emulationState,
-         documentEmulation, loopTiming, handleActionClick };
+         documentEmulation, loopTiming, handleActionClick, registerActionClick,
+         OFFSCREEN_CLIPBOARD_TARGET, OFFSCREEN_URL };
 
 // A read/reset window onto the loop's private liveness state, for tests.
 export const loopState = {

--- a/scripts/browser-bridge/extension/service_worker.js
+++ b/scripts/browser-bridge/extension/service_worker.js
@@ -63,6 +63,9 @@ import {
   parsePageContext, annotatePageContext,
   // annotated text: structured element extraction for `text --annotated`.
   annotatedTextFn, ANNOTATED_TEXT_MAX_ITEMS_DEFAULT, byteCapElements,
+  // `bw://` tab references: the toolbar-click → clipboard path. Pure builder +
+  // its validation, so the refusals are unit-testable without a browser.
+  buildTabRef,
 } from "./protocol.js";
 
 // The BUILD MARKER (#324) — a generated LITERAL that travels with THIS module
@@ -1934,6 +1937,147 @@ function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+// --- toolbar click → copy a `bw://` tab reference --------------------------- //
+// The manifest has always declared a click-only `action` (icon + title, no
+// popup) with NOTHING listening, so clicking the toolbar icon was a silent
+// no-op. It now copies a `bw://<host>/<instance>/<tabId>` reference for the tab
+// the operator is looking at — see protocol.js `buildTabRef` for the format and
+// why each field is in it.
+//
+// 🔴 THE CLIPBOARD IS NOT REACHABLE FROM AN MV3 SERVICE WORKER. There is no
+// `document`, so `navigator.clipboard.writeText()` is undefined here; and
+// `navigator.clipboard` in a page injected via chrome.scripting needs that
+// document to be FOCUSED, which it is not after a toolbar click (focus is in
+// browser chrome), and is refused outright on a strict-CSP page — the same class
+// as trap #2 in SKILL.md, which would make this feature fail precisely on
+// GitHub. So the copy goes through an OFFSCREEN DOCUMENT with reason
+// `CLIPBOARD`, which is Chrome's supported path for exactly this and is
+// independent of the page: it works on `brave://` pages and PDFs too.
+const TAB_REF_BADGE_MS = 2500;          // how long the ✓/✗ badge stays up
+const TAB_REF_WHOAMI_BUDGET_MS = 3000;  // the /whoami read is on the click path
+const TAB_REF_CLIPBOARD_BUDGET_MS = 3000;
+const OFFSCREEN_URL = "offscreen.html";
+// The message envelope the offscreen document answers. `target` namespaces it so
+// an options page (or any future extension context) that also listens cannot
+// answer for it — sendMessage fans out to EVERY context except the sender.
+const OFFSCREEN_CLIPBOARD_TARGET = "offscreen-clipboard";
+
+// The host label, read from the bridge itself. It is deliberately NOT cached:
+// the extension has no other way to learn it, and a cached label would survive
+// the profile being carried to the other host — which is the one thing the ref's
+// host field exists to catch.
+async function fetchHostLabel(cfg) {
+  let res;
+  try {
+    res = await fetch(`${base(cfg.port)}/whoami`,
+                      { headers: authHeaders(cfg.token) });
+  } catch (e) {
+    throw new Error("bridge not reachable — is browser-bridge running?");
+  }
+  if (res.status === 401 || res.status === 403) {
+    throw new Error("bridge rejected the token — re-paste it in Options");
+  }
+  if (!res.ok) throw new Error(`bridge returned HTTP ${res.status}`);
+  const body = await res.json();
+  return (body && body.host && body.host.label) || "";
+}
+
+// Ensure the offscreen document exists, tolerating the two races that matter:
+// `hasDocument` is absent on older Chromium, and two rapid clicks can both see
+// "no document" and both call createDocument (the second rejects).
+async function ensureOffscreenDocument() {
+  if (!chrome.offscreen || !chrome.offscreen.createDocument) {
+    throw new Error("this browser has no offscreen API (needs Chromium 109+)");
+  }
+  try {
+    if (chrome.offscreen.hasDocument && await chrome.offscreen.hasDocument()) {
+      return;
+    }
+  } catch (e) { /* fall through and let createDocument decide */ }
+  try {
+    await chrome.offscreen.createDocument({
+      url: OFFSCREEN_URL,
+      reasons: ["CLIPBOARD"],
+      justification: "write a bw:// tab reference to the clipboard",
+    });
+  } catch (e) {
+    // "Only a single offscreen document may be created" — someone won the race,
+    // which is the outcome we wanted anyway.
+    if (!/single offscreen/i.test(String((e && e.message) || e))) throw e;
+  }
+}
+
+async function writeClipboard(text) {
+  await ensureOffscreenDocument();
+  try {
+    const reply = await chrome.runtime.sendMessage({
+      target: OFFSCREEN_CLIPBOARD_TARGET, type: "copy", text,
+    });
+    // 🔴 A missing/!ok reply is a FAILURE, not a maybe. execCommand("copy")
+    // reports false rather than throwing, so believing an absent reply is how
+    // the badge would say ✓ over an empty clipboard.
+    if (!reply || !reply.ok) {
+      throw new Error(`clipboard write refused${reply && reply.error ? `: ${reply.error}` : ""}`);
+    }
+  } finally {
+    // Close it again rather than leaving a hidden document alive: this worker's
+    // lifetime is load-bearing (the long-poll IS the keepalive), and an
+    // always-present offscreen document changes that lifetime for a feature
+    // that runs for ~20ms per click.
+    try {
+      if (chrome.offscreen && chrome.offscreen.closeDocument) {
+        await chrome.offscreen.closeDocument();
+      }
+    } catch (e) { /* best-effort */ }
+  }
+}
+
+// Badge + tooltip are the whole feedback surface. Deliberately NOT
+// chrome.notifications: that needs another permission on a live-cookie
+// extension, and the operator is looking at the toolbar button they just
+// clicked.
+async function flashBadge(text, color, title) {
+  if (!chrome.action) return;
+  try {
+    await chrome.action.setBadgeText({ text });
+    if (chrome.action.setBadgeBackgroundColor) {
+      await chrome.action.setBadgeBackgroundColor({ color });
+    }
+    await chrome.action.setTitle({ title });
+    setTimeout(() => {
+      try {
+        chrome.action.setBadgeText({ text: "" });
+        chrome.action.setTitle({ title: "Browser Bridge" });
+      } catch (e) { /* the worker may have been suspended; harmless */ }
+    }, TAB_REF_BADGE_MS);
+  } catch (e) { /* feedback is best-effort — never mask the real outcome */ }
+}
+
+// Returns a {ok, ref?, error?} record. It NEVER throws: it is an event-listener
+// body, so a rejection would surface only as an unhandled promise in a worker
+// nobody is watching. Exported for tests/action_click.test.mjs, which drives it
+// against a mocked chrome; nothing in the extension imports it.
+async function handleActionClick() {
+  try {
+    const cfg = await config();
+    const tab = await activeTab();                   // throws no_active_tab
+    const host = await promiseWithTimeout(
+      fetchHostLabel(cfg), TAB_REF_WHOAMI_BUDGET_MS, "whoami", {}, "op_timeout");
+    const ref = buildTabRef({
+      host, label: cfg.label, instanceId: cfg.instanceId, tabId: tab.id,
+    });
+    await promiseWithTimeout(writeClipboard(ref), TAB_REF_CLIPBOARD_BUDGET_MS,
+                             "clipboard", {}, "op_timeout");
+    await flashBadge("✓", "#1a7f37", `Copied ${ref}`);
+    return { ok: true, ref };
+  } catch (e) {
+    const msg = String((e && e.message) || e);
+    const human = msg === "no_active_tab" ? "no active tab to reference" : msg;
+    await flashBadge("✗", "#b42318", `Browser Bridge — ${human}`);
+    return { ok: false, error: human };
+  }
+}
+
 // --- MV3 keepalive + background wiring -------------------------------------- //
 // All the real-browser side effects (event listeners, the keepalive alarm, and the
 // immediate loop kick) are grouped here so a unit test can import this module for its
@@ -1942,6 +2086,13 @@ function sleep(ms) {
 function startBackground() {
   chrome.runtime.onInstalled.addListener(() => loop());
   chrome.runtime.onStartup.addListener(() => loop());
+  // Toolbar click → copy a bw:// tab reference. Registered HERE (not at module
+  // top level) so importing this module under BROWSER_BRIDGE_NO_AUTOSTART still
+  // requires no chrome.action mock; the handler itself is exported and tested
+  // directly.
+  if (chrome.action && chrome.action.onClicked) {
+    chrome.action.onClicked.addListener(() => { handleActionClick(); });
+  }
   chrome.alarms.create("bridge-keepalive", { periodInMinutes: 1 });
   chrome.alarms.onAlarm.addListener((a) => {
     // keepaliveTick, NOT loop(): a bare loop() call hits `if (running) return`
@@ -1985,8 +2136,13 @@ if (!(typeof globalThis !== "undefined" && globalThis.BROWSER_BRIDGE_NO_AUTOSTAR
 // suite stayed green, because the relationship test reads the constant while the
 // behavioural tests inject an override. Exporting it lets one assertion close that
 // gap without a 1.5s timing test.
+// `handleActionClick` is exported for TESTS only — the toolbar-click path has no
+// wire surface at all (no op, no /cmd, no result envelope), so the ONLY way to
+// assert it copies the right string, and refuses rather than copying a wrong
+// one, is to call it against a mocked chrome. Nothing in the extension imports
+// it; the listener above closes over it directly.
 export { execute, OPS, ALLOWED_OPS, cdpAttached, loop, emulationState,
-         documentEmulation, loopTiming };
+         documentEmulation, loopTiming, handleActionClick };
 
 // A read/reset window onto the loop's private liveness state, for tests.
 export const loopState = {

--- a/scripts/browser-bridge/tests/action_click.test.mjs
+++ b/scripts/browser-bridge/tests/action_click.test.mjs
@@ -24,12 +24,25 @@ import assert from "node:assert/strict";
 
 const TAB_ID = 4242;
 
+// 🔴 SLOW, NOT HUNG — and that is the whole design of the two bound tests below.
+// A never-settling stub makes a removed bound show up as a CANCELLED test, and
+// node:test reports cancelled separately from failed: measured, deleting either
+// bound gave `pass 567, fail 0, cancelled 1` against a control of 568, which the
+// runner's floor check would wave through. A stub that answers LATE instead
+// makes the bound's absence a plain assertion failure — the product either
+// times out at its budget (20ms) or returns success at 200ms, and those are
+// different observable outcomes rather than one hang.
+const SLOW_MS = 200;
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
 const state = {
   storage: { port: 8788, token: "t0ken", label: "main", instanceId: "auto-id-uuid" },
   tab: { id: TAB_ID, url: "https://example.test/x", title: "X", active: true },
   tabs: null,                        // null → query returns [state.tab]
   whoami: { status: 200, body: { ok: true, host: { label: "workbench" } } },
   whoamiThrows: false,
+  whoamiSlowMs: 0,
+  clipboardSlowMs: 0,
   clipboardReply: { ok: true },
   offscreenExists: false,
   offscreenCreateThrows: null,
@@ -42,12 +55,17 @@ function reset() {
   state.tabs = null;
   state.whoami = { status: 200, body: { ok: true, host: { label: "workbench" } } };
   state.whoamiThrows = false;
+  state.whoamiSlowMs = 0;
+  state.clipboardSlowMs = 0;
   state.clipboardReply = { ok: true };
   state.offscreenExists = false;
   state.offscreenCreateThrows = null;
   state.calls = { fetch: [], created: [], closed: [], messages: [], badge: [], title: [] };
 }
 
+// Short budgets so the two timeout cases cost ~40ms instead of 6s. The BOUNDS
+// themselves are asserted below; this only moves where they sit.
+globalThis.BROWSER_BRIDGE_TAB_REF_TIMING = { whoamiMs: 20, clipboardMs: 20, badgeMs: 5 };
 globalThis.BROWSER_BRIDGE_NO_AUTOSTART = true;
 globalThis.chrome = {
   storage: { local: {
@@ -80,7 +98,11 @@ globalThis.chrome = {
     async closeDocument() { state.calls.closed.push(true); state.offscreenExists = false; },
   },
   runtime: {
-    async sendMessage(msg) { state.calls.messages.push(msg); return state.clipboardReply; },
+    async sendMessage(msg) {
+      state.calls.messages.push(msg);
+      if (state.clipboardSlowMs) await sleep(state.clipboardSlowMs);
+      return state.clipboardReply;
+    },
     getManifest() { return { version: "0.0.0.0" }; },
     id: "mockextensionid",
     onInstalled: { addListener() {} },
@@ -94,6 +116,7 @@ globalThis.chrome = {
 
 globalThis.fetch = async (url, init) => {
   state.calls.fetch.push({ url, init });
+  if (state.whoamiSlowMs) await sleep(state.whoamiSlowMs);
   if (state.whoamiThrows) throw new TypeError("Failed to fetch");
   const { status, body } = state.whoami;
   return {
@@ -275,4 +298,119 @@ test("handleActionClick NEVER throws — it is an event-listener body", async ()
   } finally {
     chrome.storage.local.get = realGet;
   }
+});
+
+// --------------------------------------------------------------------------- //
+// THE WIRING — that the handler is reachable from a real click at all
+// --------------------------------------------------------------------------- //
+// 🔴 WHY THESE TWO TESTS EXIST TOGETHER. An audit replaced the whole listener
+// registration with `if (false) {}` and all 549 node tests plus 33 pytest cases
+// stayed green: `handleActionClick` is exported and every test called it
+// directly, so nothing anywhere asserted a real click could reach it. On the one
+// path in this subsystem that cannot be live-verified from here, both ends were
+// unguarded.
+//
+// The first test is BEHAVIOURAL — it drives the listener `registerActionClick`
+// actually registers. The second is STRUCTURAL, and it exists because the
+// behavioural one cannot see the mutant that matters: `registerActionClick` can
+// be perfect while nothing calls it. `startBackground()` cannot simply be run
+// here — it also starts the poll loop, which is a deliberate `while (true)` —
+// so its call site is asserted to be UNCONDITIONAL instead.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const { registerActionClick } = await import("../extension/service_worker.js");
+
+test("registerActionClick registers a listener that actually performs the copy", async () => {
+  reset();
+  const registered = [];
+  const ok = registerActionClick({ onClicked: { addListener(fn) { registered.push(fn); } } });
+  assert.equal(ok, true);
+  assert.equal(registered.length, 1, "exactly one click listener");
+
+  // Drive it the way Chrome would — with a tab argument, and no await available
+  // to the caller. The listener fires handleActionClick and drops the promise,
+  // so wait for the effect rather than the call.
+  registered[0]({ id: TAB_ID });
+  for (let i = 0; i < 50 && state.calls.messages.length === 0; i++) {
+    await new Promise((r) => setTimeout(r, 2));
+  }
+  assert.equal(copied(), `bw://workbench/main/${TAB_ID}`,
+    "a click must reach the clipboard — this is the whole feature");
+});
+
+test("registerActionClick is a no-op where chrome.action is absent", () => {
+  // `null`, not `undefined`: a default parameter fires only on `undefined`, so
+  // passing that would silently fall back to the mock's own chrome.action and
+  // this test would assert the opposite of what it reads as.
+  assert.equal(registerActionClick(null), false);
+  assert.equal(registerActionClick({}), false, "no onClicked → nothing to wire");
+});
+
+test("🔴 startBackground() calls it UNCONDITIONALLY", () => {
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "..", "extension", "service_worker.js"),
+    "utf8");
+  const start = src.indexOf("function startBackground()");
+  assert.notEqual(start, -1, "startBackground vanished — re-point this guard");
+  // Walk the function body tracking brace depth, so a call moved inside ANY
+  // nested block is seen as nested rather than as present.
+  let depth = 0, i = src.indexOf("{", start), end = -1;
+  const lines = [];
+  let lineStart = i;
+  for (; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}") { depth--; if (depth === 0) { end = i; break; } }
+    else if (src[i] === "\n") {
+      lines.push({ text: src.slice(lineStart, i), depth });
+      lineStart = i + 1;
+    }
+  }
+  assert.notEqual(end, -1, "could not find the end of startBackground");
+  const hits = lines.filter((l) => /(^|[^.\w])registerActionClick\s*\(/.test(l.text));
+  assert.equal(hits.length, 1,
+    `expected exactly one registerActionClick call in startBackground, found ${hits.length}`);
+  assert.equal(hits[0].depth, 1,
+    "the call is nested inside a block — a click may never be wired");
+  assert.equal(hits[0].text.trim(), "registerActionClick();",
+    "the call carries a condition or a guard — pin the whole statement, because " +
+    "`if (false) registerActionClick();` is the mutant this test exists to kill");
+});
+
+// --------------------------------------------------------------------------- //
+// Bounds and the remaining feedback paths
+// --------------------------------------------------------------------------- //
+test("403 gets the SAME re-paste guidance as 401", () => {
+  // Both are "the bridge rejected your token". Mapping one to a bare HTTP code
+  // sends the operator to the wrong place with no hint about Options.
+  reset();
+  state.whoami = { status: 403, body: {} };
+  return handleActionClick().then((out) => {
+    assert.equal(out.ok, false);
+    assert.match(out.error, /re-paste it in Options/);
+  });
+});
+
+// The explicit timeout is a backstop only; the kill comes from the LATE stub
+// above (see SLOW_MS) so a removed bound fails an assertion rather than wedging.
+test("a /whoami that never answers is BOUNDED, not a hung click", { timeout: 5000 }, async () => {
+  // Without the budget the click hangs forever with no badge and no error, and
+  // the operator has no signal at all. Removing the bound must be visible.
+  reset();
+  state.whoamiSlowMs = SLOW_MS;
+  const out = await handleActionClick();
+  assert.equal(out.ok, false);
+  assert.match(out.error, /op_timeout:whoami/);
+  assert.equal(state.calls.messages.length, 0, "nothing may be copied on a timeout");
+});
+
+// The explicit timeout is a backstop only; the kill comes from the LATE stub
+// above (see SLOW_MS) so a removed bound fails an assertion rather than wedging.
+test("a clipboard write that never answers is BOUNDED too", { timeout: 5000 }, async () => {
+  reset();
+  state.clipboardSlowMs = SLOW_MS;
+  const out = await handleActionClick();
+  assert.equal(out.ok, false);
+  assert.match(out.error, /op_timeout:clipboard/);
 });

--- a/scripts/browser-bridge/tests/action_click.test.mjs
+++ b/scripts/browser-bridge/tests/action_click.test.mjs
@@ -348,28 +348,91 @@ test("registerActionClick is a no-op where chrome.action is absent", () => {
   assert.equal(registerActionClick({}), false, "no onClicked → nothing to wire");
 });
 
-test("🔴 nothing can exit startBackground() before it wires the click", () => {
+// --- the wiring guard's own instrument, tested on a KNOWN input -------------- //
+// Elide comments, string literals, and the bodies of NESTED FUNCTIONS, leaving
+// the statements that belong to the function itself.
+//
+// Nested-function elision is not tidiness: an MV3 worker is mostly callbacks, and
+// `chrome.runtime.onMessage.addListener((m, s, r) => { if (!m) return false; … })`
+// contains `return` statements that exit the CALLBACK, not the worker. A scan
+// that counted those would go red on the most ordinary edit anyone could make to
+// this function — and a permanently-red gate on legitimate work is what trains
+// people to delete the guard, which here is the sole coverage of the wiring.
+function elideNested(code) {
+  const noLiterals = code
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\/\/[^\n]*/g, " ")
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''")
+    .replace(/`(?:[^`\\]|\\.)*`/g, "``");
+  // Walk once; whenever a `=>` or `function` introduces a block, skip that block.
+  let out = "", i = 0;
+  while (i < noLiterals.length) {
+    const rest = noLiterals.slice(i);
+    const m = rest.match(/^(=>|\bfunction\b)([^{;]*)\{/);
+    if (m) {
+      let depth = 0, j = i + m[0].length - 1;
+      for (; j < noLiterals.length; j++) {
+        if (noLiterals[j] === "{") depth++;
+        else if (noLiterals[j] === "}") { depth--; if (depth === 0) { j++; break; } }
+      }
+      out += " ";                       // the whole callback becomes whitespace
+      i = j;
+      continue;
+    }
+    out += noLiterals[i];
+    i++;
+  }
+  return out;
+}
+
+test("HARNESS: elideNested keeps the function's OWN statements and drops callbacks'", () => {
+  // 🔴 The instrument, validated on input whose answer is known — because the
+  // guard below is a claim about a string this function produced, and an
+  // over-eager elider would make that claim vacuous while looking healthy.
+  const sample = `
+    chrome.runtime.onInstalled.addListener(() => { return loop(); });
+    // return in a comment
+    const msg = "return in a string";
+    if (chrome.debugger) {
+      chrome.debugger.onDetach.addListener((s) => { if (s) return; });
+    }
+    doTheThing();
+  `;
+  const out = elideNested(sample);
+  assert.match(out, /chrome\.runtime\.onInstalled/, "own statements must survive");
+  assert.match(out, /doTheThing\(\)/, "own statements must survive");
+  assert.match(out, /if \(chrome\.debugger\)/, "a plain block is NOT a function");
+  assert.doesNotMatch(out, /(^|[^.\w])return\b/,
+    "every `return` here belongs to a callback, a comment or a string");
+  // POSITIVE CONTROL for the assertion above: a return that IS the function's own
+  // must survive elision, or the guard could never see one.
+  assert.match(elideNested("if (x) { return; } doTheThing();"), /(^|[^.\w])return\b/,
+    "an own-body return was elided — the guard would be blind to the real defect");
+});
+
+test("🔴 the click wiring is reached, unconditionally, before anything can exit", () => {
   // 🔴 THIS IS THE SOLE COVERAGE OF THE WIRING. No test calls startBackground()
   // — every suite sets BROWSER_BRIDGE_NO_AUTOSTART, because it also starts the
-  // poll loop — so if this check has a hole, the toolbar click can be dead with
-  // the whole suite green. It has had two.
+  // poll loop — so if this check has a hole, the toolbar click can be dead in a
+  // real Brave with the whole suite green. It has had FOUR holes:
   //
-  // Round 2 pinned the statement text: `if (false) registerActionClick();` died,
-  // but `if (globalThis.__x) return;` above the call SURVIVED, because the guard
-  // only looked at the call's own line.
-  // Round 3 added an early-exit scan anchored with /^\s*(return|throw)/ — which
-  // could not match `if (…) return;`, a line starting with `if`.
-  // Round 4 widened WHERE on the line the token may sit, and still missed
-  // `if (…) { return; }` — the braced spelling, which is the idiom this very
-  // file uses — because the scan filtered to lines whose depth was 1 AT THEIR
-  // END, and a `return` inside braces ends at depth 2.
+  //   round 2  pinned the call's statement text -> `if (…) return;` ABOVE it survived
+  //   round 3  scanned /^\s*(return|throw)/     -> cannot match a line starting `if`
+  //   round 4  widened WHERE on the line        -> `if (…) { return; }` survived,
+  //            because it filtered to lines at depth 1 measured at their END
+  //   round 5  replaced the line logic with a raw-source scan and DROPPED the two
+  //            older assertions -> `if (false) registerActionClick();` came back
+  //            from the dead, along with `if (x) { registerActionClick(); }` and
+  //            the call moved inside an existing block
   //
-  // Three misses, one shape: the check kept reasoning about LINES. So it no
-  // longer does. It takes the raw source between the function's opening brace
-  // and the call, strips comments and string literals (the token appears in
-  // both, and matching those would fail loud but for the wrong reason), and
-  // asserts no `return`/`throw` survives at ANY depth. There is nothing left
-  // for a spelling to hide behind.
+  // The fourth is the instructive one: rounds 2-4 each traded a hole for a hole
+  // because the fix REPLACED the previous check instead of joining it. So this
+  // asserts THREE independent things, and a future round may add to them but
+  // must not swap one for another:
+  //   (a) the call exists, at the function's own top level (not nested in a block)
+  //   (b) its statement is exactly `registerActionClick();` — no condition
+  //   (c) nothing in the function's OWN statements above it can exit early
   const src = readFileSync(
     join(dirname(fileURLToPath(import.meta.url)), "..", "extension", "service_worker.js"),
     "utf8");
@@ -381,22 +444,27 @@ test("🔴 nothing can exit startBackground() before it wires the click", () => 
     "registerActionClick() is not called in startBackground() at all — a click " +
     "can never reach the handler");
 
-  // Everything the function does BEFORE wiring the click.
   const before = src.slice(open + 1, call);
-  const stripped = before
-    .replace(/\/\*[\s\S]*?\*\//g, " ")      // block comments
-    .replace(/\/\/[^\n]*/g, " ")             // line comments
-    .replace(/"(?:[^"\\]|\\.)*"/g, '""')      // double-quoted strings
-    .replace(/'(?:[^'\\]|\\.)*'/g, "''")      // single-quoted
-    .replace(/`(?:[^`\\]|\\.)*`/g, "``");     // templates
 
-  // ANTI-VACUITY: the stripper must leave the real statements behind, or this
-  // whole assertion is a claim about an empty string.
-  assert.match(stripped, /chrome\.runtime\.onInstalled/,
-    "comment/string stripping ate the function body — the check below would " +
-    "pass vacuously");
+  // (a) DEPTH: the call must sit at the function's own level. Counting braces in
+  // the elided text means a callback's braces cannot fake the depth either way.
+  const beforeOwn = elideNested(before);
+  let depth = 0;
+  for (const ch of beforeOwn) { if (ch === "{") depth++; else if (ch === "}") depth--; }
+  assert.equal(depth, 0,
+    "registerActionClick() is nested inside a block — it may never run. " +
+    "`if (chrome.action) { registerActionClick(); }` reads as harmless tidying " +
+    "and silently unwires the toolbar click on any build where the guard is false.");
 
-  const early = stripped.match(/(^|[^.\w])(return|throw)\b/);
+  // (b) STATEMENT: no condition on the call's own line.
+  const lineStart = src.lastIndexOf("\n", call) + 1;
+  const lineEnd = src.indexOf("\n", call);
+  assert.equal(src.slice(lineStart, lineEnd).trim(), "registerActionClick();",
+    "the call carries a condition or a guard — `if (false) registerActionClick();` " +
+    "is the round-2 mutant, and it must stay dead");
+
+  // (c) EARLY EXIT: nothing in the function's own statements above it returns.
+  const early = beforeOwn.match(/(^|[^.\w])(return|throw)\b/);
   assert.equal(early, null,
     "an early return/throw sits between the start of startBackground() and the " +
     "click wiring — the toolbar click would never be registered, and no other " +

--- a/scripts/browser-bridge/tests/action_click.test.mjs
+++ b/scripts/browser-bridge/tests/action_click.test.mjs
@@ -388,11 +388,20 @@ test("🔴 startBackground()'s call to it carries no condition", () => {
   // No early exit above it at the function's own level. This is the audit's
   // `if (globalThis.__x) return;` mutant: the call stays syntactically
   // unconditional while becoming dead.
+  // 🔴 THE TOKEN ANYWHERE ON THE LINE, NOT ANCHORED AT ITS START. The first
+  // version used /^\s*(return|throw)\b/, which cannot match the very mutant the
+  // comment above names: `if (globalThis.__x) return;` is a line beginning with
+  // `if`. An audit measured it SURVIVING all 568 tests — a guard passing on the
+  // case its own comment claims is closed, which is worse than no guard because
+  // it stops the next reader re-testing it. No depth-1 line above the call
+  // contains either token today, so this cannot false-positive on the body as
+  // written.
   const idx = lines.indexOf(hits[0]);
   const above = lines.slice(0, idx).filter((l) => l.depth === 1);
-  assert.ok(!above.some((l) => /^\s*(return|throw)\b/.test(l.text)),
-    "an early return/throw sits above the call — it is syntactically " +
-    "unconditional and never reached");
+  const early = above.find((l) => /(^|[^.\w])(return|throw)\b/.test(l.text));
+  assert.ok(!early,
+    "an early exit sits above the call — it is syntactically unconditional and " +
+    `never reached: ${early && early.text.trim()}`);
 });
 
 // --------------------------------------------------------------------------- //

--- a/scripts/browser-bridge/tests/action_click.test.mjs
+++ b/scripts/browser-bridge/tests/action_click.test.mjs
@@ -1,0 +1,278 @@
+// Glue tests for the TOOLBAR CLICK path (service_worker.js handleActionClick)
+// against a mocked chrome — no Brave, no server, no clipboard.
+//
+// WHY THIS FILE EXISTS. Every other thing the worker does has a wire surface: a
+// command goes in, an envelope comes out, and the server, the CLI and half a
+// dozen tests can all see it. The click path has none — it reads config, asks
+// the bridge who it is, and puts a string on the system clipboard. If it copies
+// the WRONG string, or copies nothing while flashing a ✓, there is no envelope
+// anywhere that says so; the operator finds out when a later command drives
+// someone else's tab. So the assertions here are about what LANDED on the
+// clipboard and, just as much, about what did NOT.
+//
+// The mock is deliberately strict in three places, each pinning a mistake that
+// would otherwise pass:
+//   * `execCommand` failure is reported by RETURN VALUE, so "the call completed"
+//     is not success — the offscreen reply carries {ok:false} and must be fatal.
+//   * /whoami is a real fetch in production; here it is a stub whose response is
+//     switched per test, including the unreachable and 401 cases.
+//   * the offscreen document is created and CLOSED around each copy, and the
+//     test records both so a regression that leaves it open is visible.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const TAB_ID = 4242;
+
+const state = {
+  storage: { port: 8788, token: "t0ken", label: "main", instanceId: "auto-id-uuid" },
+  tab: { id: TAB_ID, url: "https://example.test/x", title: "X", active: true },
+  tabs: null,                        // null → query returns [state.tab]
+  whoami: { status: 200, body: { ok: true, host: { label: "workbench" } } },
+  whoamiThrows: false,
+  clipboardReply: { ok: true },
+  offscreenExists: false,
+  offscreenCreateThrows: null,
+  calls: { fetch: [], created: [], closed: [], messages: [], badge: [], title: [] },
+};
+
+function reset() {
+  state.storage = { port: 8788, token: "t0ken", label: "main", instanceId: "auto-id-uuid" };
+  state.tab = { id: TAB_ID, url: "https://example.test/x", title: "X", active: true };
+  state.tabs = null;
+  state.whoami = { status: 200, body: { ok: true, host: { label: "workbench" } } };
+  state.whoamiThrows = false;
+  state.clipboardReply = { ok: true };
+  state.offscreenExists = false;
+  state.offscreenCreateThrows = null;
+  state.calls = { fetch: [], created: [], closed: [], messages: [], badge: [], title: [] };
+}
+
+globalThis.BROWSER_BRIDGE_NO_AUTOSTART = true;
+globalThis.chrome = {
+  storage: { local: {
+    async get(keys) {
+      const out = {};
+      for (const k of [].concat(keys)) {
+        if (state.storage[k] !== undefined) out[k] = state.storage[k];
+      }
+      return out;
+    },
+    async set() {},
+  } },
+  tabs: {
+    async query() { return state.tabs === null ? [state.tab] : state.tabs; },
+    async get(id) { return { ...state.tab, id }; },
+  },
+  action: {
+    async setBadgeText(o) { state.calls.badge.push(o.text); },
+    async setBadgeBackgroundColor() {},
+    async setTitle(o) { state.calls.title.push(o.title); },
+    onClicked: { addListener() {} },
+  },
+  offscreen: {
+    async hasDocument() { return state.offscreenExists; },
+    async createDocument(opts) {
+      if (state.offscreenCreateThrows) throw new Error(state.offscreenCreateThrows);
+      state.calls.created.push(opts);
+      state.offscreenExists = true;
+    },
+    async closeDocument() { state.calls.closed.push(true); state.offscreenExists = false; },
+  },
+  runtime: {
+    async sendMessage(msg) { state.calls.messages.push(msg); return state.clipboardReply; },
+    getManifest() { return { version: "0.0.0.0" }; },
+    id: "mockextensionid",
+    onInstalled: { addListener() {} },
+    onStartup: { addListener() {} },
+  },
+  alarms: { create() {}, onAlarm: { addListener() {} } },
+  debugger: { onDetach: { addListener() {} } },
+  webNavigation: { async getAllFrames() { return []; } },
+  scripting: { async executeScript() { return [{ result: null }]; } },
+};
+
+globalThis.fetch = async (url, init) => {
+  state.calls.fetch.push({ url, init });
+  if (state.whoamiThrows) throw new TypeError("Failed to fetch");
+  const { status, body } = state.whoami;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() { return body; },
+  };
+};
+
+const { handleActionClick } = await import("../extension/service_worker.js");
+
+// The one string the whole feature exists to produce. Same literal as
+// tests/tab_ref.test.mjs and tests/test_browser_tab_ref.py.
+function copied() {
+  const m = state.calls.messages[state.calls.messages.length - 1];
+  return m && m.text;
+}
+
+// --------------------------------------------------------------------------- //
+test("a click copies bw://<host>/<label>/<tabId> and badges a tick", async () => {
+  reset();
+  const out = await handleActionClick();
+  assert.deepEqual(out, { ok: true, ref: `bw://workbench/main/${TAB_ID}` });
+  assert.equal(copied(), `bw://workbench/main/${TAB_ID}`);
+  assert.equal(state.calls.badge[0], "✓");
+  assert.match(state.calls.title[0], /^Copied bw:\/\/workbench\/main\/4242$/);
+});
+
+test("the host comes from /whoami on EVERY click — it is never assumed or cached", async () => {
+  reset();
+  await handleActionClick();
+  assert.equal(state.calls.fetch.length, 1);
+  assert.match(state.calls.fetch[0].url, /^http:\/\/127\.0\.0\.1:8788\/whoami$/);
+  assert.equal(state.calls.fetch[0].init.headers.Authorization, "Bearer t0ken");
+  // A SECOND click must ask again: a cached label survives the profile being
+  // carried to the other host, which is the one thing the host field catches.
+  state.whoami = { status: 200, body: { ok: true, host: { label: "laptop" } } };
+  const out = await handleActionClick();
+  assert.equal(state.calls.fetch.length, 2);
+  assert.equal(out.ref, `bw://laptop/main/${TAB_ID}`);
+});
+
+test("an UNLABELLED profile copies the full auto-id", async () => {
+  reset();
+  state.storage.label = "";
+  const out = await handleActionClick();
+  assert.equal(out.ref, `bw://workbench/auto-id-uuid/${TAB_ID}`);
+});
+
+test("the offscreen document is created for the copy and CLOSED again", async () => {
+  reset();
+  await handleActionClick();
+  assert.equal(state.calls.created.length, 1);
+  assert.deepEqual(state.calls.created[0].reasons, ["CLIPBOARD"]);
+  assert.equal(state.calls.created[0].url, "offscreen.html");
+  assert.equal(state.calls.closed.length, 1, "it must not be left alive after the copy");
+  assert.equal(state.offscreenExists, false);
+});
+
+test("the copy message is namespaced so another context cannot answer for it", async () => {
+  reset();
+  await handleActionClick();
+  const m = state.calls.messages[0];
+  assert.equal(m.target, "offscreen-clipboard");
+  assert.equal(m.type, "copy");
+});
+
+test("a pre-existing offscreen document is reused, not re-created", async () => {
+  reset();
+  state.offscreenExists = true;
+  const out = await handleActionClick();
+  assert.equal(out.ok, true);
+  assert.equal(state.calls.created.length, 0);
+});
+
+test("losing the create RACE is not a failure — the document exists either way", async () => {
+  reset();
+  state.offscreenCreateThrows = "Only a single offscreen document may be created.";
+  const out = await handleActionClick();
+  assert.equal(out.ok, true, "the other click already created it; copy anyway");
+  assert.equal(copied(), `bw://workbench/main/${TAB_ID}`);
+});
+
+test("a create failure that is NOT the race is fatal and copies nothing", async () => {
+  reset();
+  state.offscreenCreateThrows = "boom";
+  const out = await handleActionClick();
+  assert.equal(out.ok, false);
+  assert.equal(state.calls.messages.length, 0);
+  assert.equal(state.calls.badge[0], "✗");
+});
+
+// --- the refusals: nothing is copied, and the badge says so ----------------- //
+test("a REFUSED clipboard write is a failure, not a completed call", async () => {
+  reset();
+  // execCommand("copy") returns false rather than throwing — the exact reason a
+  // "the call returned" test would go green over an empty clipboard.
+  state.clipboardReply = { ok: false, error: "execCommand refused" };
+  const out = await handleActionClick();
+  assert.equal(out.ok, false);
+  assert.match(out.error, /clipboard write refused: execCommand refused/);
+  assert.equal(state.calls.badge[0], "✗");
+});
+
+test("an ABSENT reply is a failure too", async () => {
+  reset();
+  state.clipboardReply = undefined;
+  const out = await handleActionClick();
+  assert.equal(out.ok, false);
+  assert.match(out.error, /clipboard write refused/);
+});
+
+test("no active tab → a named refusal, no copy", async () => {
+  reset();
+  state.tabs = [];
+  const out = await handleActionClick();
+  assert.deepEqual(out, { ok: false, error: "no active tab to reference" });
+  assert.equal(state.calls.messages.length, 0);
+  assert.equal(state.calls.badge[0], "✗");
+});
+
+test("bridge unreachable → a named refusal, no copy", async () => {
+  reset();
+  state.whoamiThrows = true;
+  const out = await handleActionClick();
+  assert.equal(out.ok, false);
+  assert.match(out.error, /bridge not reachable/);
+  assert.equal(state.calls.messages.length, 0);
+});
+
+test("a rejected token says to re-paste it, rather than reporting a generic HTTP error", async () => {
+  reset();
+  state.whoami = { status: 401, body: {} };
+  const out = await handleActionClick();
+  assert.equal(out.ok, false);
+  assert.match(out.error, /re-paste it in Options/);
+});
+
+test("any other HTTP status names the status", async () => {
+  reset();
+  state.whoami = { status: 503, body: {} };
+  const out = await handleActionClick();
+  assert.equal(out.ok, false);
+  assert.match(out.error, /HTTP 503/);
+});
+
+test("a bridge that cannot identify its host copies NOTHING", async () => {
+  reset();
+  // 🔴 The CLI proceeds-with-a-warning on `unknown` because it has a live bridge
+  // to compare against and refusing there would strand a host with no
+  // ACTIVITY_HOST. The EXTENSION has the opposite duty: a ref minted with an
+  // unverifiable host is a token that will be pasted somewhere else later, and
+  // there is no second chance to check it. It must not be minted at all.
+  state.whoami = { status: 200, body: { ok: true, host: { label: "unknown" } } };
+  const out = await handleActionClick();
+  assert.equal(out.ok, false);
+  assert.match(out.error, /could not identify this host/);
+  assert.equal(state.calls.messages.length, 0);
+});
+
+test("an unsafe LABEL is refused by name rather than mangled into a ref", async () => {
+  reset();
+  state.storage.label = "my profile";
+  const out = await handleActionClick();
+  assert.equal(out.ok, false);
+  assert.match(out.error, /instance label is not ref-safe: my profile/);
+  assert.equal(state.calls.messages.length, 0);
+});
+
+test("handleActionClick NEVER throws — it is an event-listener body", async () => {
+  reset();
+  // Make the very first await fail in a way nothing catches specifically.
+  const realGet = chrome.storage.local.get;
+  chrome.storage.local.get = async () => { throw new Error("storage exploded"); };
+  try {
+    const out = await handleActionClick();
+    assert.equal(out.ok, false);
+    assert.match(out.error, /storage exploded/);
+  } finally {
+    chrome.storage.local.get = realGet;
+  }
+});

--- a/scripts/browser-bridge/tests/action_click.test.mjs
+++ b/scripts/browser-bridge/tests/action_click.test.mjs
@@ -348,60 +348,59 @@ test("registerActionClick is a no-op where chrome.action is absent", () => {
   assert.equal(registerActionClick({}), false, "no onClicked → nothing to wire");
 });
 
-test("🔴 startBackground()'s call to it carries no condition", () => {
-  // 🔴 THE NAME IS NARROWER THAN "UNCONDITIONALLY" ON PURPOSE. This walks the
-  // function body and pins the statement; it cannot prove REACHABILITY, and an
-  // audit demonstrated the gap: inserting `if (globalThis.__x) return;` as the
-  // first line of startBackground() leaves the call unconditional, at depth 1,
-  // and never executed — all 568 tests stay green. The check below now also
-  // refuses an early return ABOVE the call, which closes the demonstrated
-  // mutant; it still does not close "unreachable" in general. A description
-  // that reads as coverage while providing less is worse than none, so the
-  // sentence is trimmed to what the body actually decides.
+test("🔴 nothing can exit startBackground() before it wires the click", () => {
+  // 🔴 THIS IS THE SOLE COVERAGE OF THE WIRING. No test calls startBackground()
+  // — every suite sets BROWSER_BRIDGE_NO_AUTOSTART, because it also starts the
+  // poll loop — so if this check has a hole, the toolbar click can be dead with
+  // the whole suite green. It has had two.
+  //
+  // Round 2 pinned the statement text: `if (false) registerActionClick();` died,
+  // but `if (globalThis.__x) return;` above the call SURVIVED, because the guard
+  // only looked at the call's own line.
+  // Round 3 added an early-exit scan anchored with /^\s*(return|throw)/ — which
+  // could not match `if (…) return;`, a line starting with `if`.
+  // Round 4 widened WHERE on the line the token may sit, and still missed
+  // `if (…) { return; }` — the braced spelling, which is the idiom this very
+  // file uses — because the scan filtered to lines whose depth was 1 AT THEIR
+  // END, and a `return` inside braces ends at depth 2.
+  //
+  // Three misses, one shape: the check kept reasoning about LINES. So it no
+  // longer does. It takes the raw source between the function's opening brace
+  // and the call, strips comments and string literals (the token appears in
+  // both, and matching those would fail loud but for the wrong reason), and
+  // asserts no `return`/`throw` survives at ANY depth. There is nothing left
+  // for a spelling to hide behind.
   const src = readFileSync(
     join(dirname(fileURLToPath(import.meta.url)), "..", "extension", "service_worker.js"),
     "utf8");
   const start = src.indexOf("function startBackground()");
   assert.notEqual(start, -1, "startBackground vanished — re-point this guard");
-  // Walk the function body tracking brace depth, so a call moved inside ANY
-  // nested block is seen as nested rather than as present.
-  let depth = 0, i = src.indexOf("{", start), end = -1;
-  const lines = [];
-  let lineStart = i;
-  for (; i < src.length; i++) {
-    if (src[i] === "{") depth++;
-    else if (src[i] === "}") { depth--; if (depth === 0) { end = i; break; } }
-    else if (src[i] === "\n") {
-      lines.push({ text: src.slice(lineStart, i), depth });
-      lineStart = i + 1;
-    }
-  }
-  assert.notEqual(end, -1, "could not find the end of startBackground");
-  const hits = lines.filter((l) => /(^|[^.\w])registerActionClick\s*\(/.test(l.text));
-  assert.equal(hits.length, 1,
-    `expected exactly one registerActionClick call in startBackground, found ${hits.length}`);
-  assert.equal(hits[0].depth, 1,
-    "the call is nested inside a block — a click may never be wired");
-  assert.equal(hits[0].text.trim(), "registerActionClick();",
-    "the call carries a condition or a guard — pin the whole statement, because " +
-    "`if (false) registerActionClick();` is the mutant this test exists to kill");
-  // No early exit above it at the function's own level. This is the audit's
-  // `if (globalThis.__x) return;` mutant: the call stays syntactically
-  // unconditional while becoming dead.
-  // 🔴 THE TOKEN ANYWHERE ON THE LINE, NOT ANCHORED AT ITS START. The first
-  // version used /^\s*(return|throw)\b/, which cannot match the very mutant the
-  // comment above names: `if (globalThis.__x) return;` is a line beginning with
-  // `if`. An audit measured it SURVIVING all 568 tests — a guard passing on the
-  // case its own comment claims is closed, which is worse than no guard because
-  // it stops the next reader re-testing it. No depth-1 line above the call
-  // contains either token today, so this cannot false-positive on the body as
-  // written.
-  const idx = lines.indexOf(hits[0]);
-  const above = lines.slice(0, idx).filter((l) => l.depth === 1);
-  const early = above.find((l) => /(^|[^.\w])(return|throw)\b/.test(l.text));
-  assert.ok(!early,
-    "an early exit sits above the call — it is syntactically unconditional and " +
-    `never reached: ${early && early.text.trim()}`);
+  const open = src.indexOf("{", start);
+  const call = src.indexOf("registerActionClick()", open);
+  assert.notEqual(call, -1,
+    "registerActionClick() is not called in startBackground() at all — a click " +
+    "can never reach the handler");
+
+  // Everything the function does BEFORE wiring the click.
+  const before = src.slice(open + 1, call);
+  const stripped = before
+    .replace(/\/\*[\s\S]*?\*\//g, " ")      // block comments
+    .replace(/\/\/[^\n]*/g, " ")             // line comments
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""')      // double-quoted strings
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''")      // single-quoted
+    .replace(/`(?:[^`\\]|\\.)*`/g, "``");     // templates
+
+  // ANTI-VACUITY: the stripper must leave the real statements behind, or this
+  // whole assertion is a claim about an empty string.
+  assert.match(stripped, /chrome\.runtime\.onInstalled/,
+    "comment/string stripping ate the function body — the check below would " +
+    "pass vacuously");
+
+  const early = stripped.match(/(^|[^.\w])(return|throw)\b/);
+  assert.equal(early, null,
+    "an early return/throw sits between the start of startBackground() and the " +
+    "click wiring — the toolbar click would never be registered, and no other " +
+    `test would notice. Found: ${early && early[0].trim()}`);
 });
 
 // --------------------------------------------------------------------------- //

--- a/scripts/browser-bridge/tests/action_click.test.mjs
+++ b/scripts/browser-bridge/tests/action_click.test.mjs
@@ -348,7 +348,16 @@ test("registerActionClick is a no-op where chrome.action is absent", () => {
   assert.equal(registerActionClick({}), false, "no onClicked → nothing to wire");
 });
 
-test("🔴 startBackground() calls it UNCONDITIONALLY", () => {
+test("🔴 startBackground()'s call to it carries no condition", () => {
+  // 🔴 THE NAME IS NARROWER THAN "UNCONDITIONALLY" ON PURPOSE. This walks the
+  // function body and pins the statement; it cannot prove REACHABILITY, and an
+  // audit demonstrated the gap: inserting `if (globalThis.__x) return;` as the
+  // first line of startBackground() leaves the call unconditional, at depth 1,
+  // and never executed — all 568 tests stay green. The check below now also
+  // refuses an early return ABOVE the call, which closes the demonstrated
+  // mutant; it still does not close "unreachable" in general. A description
+  // that reads as coverage while providing less is worse than none, so the
+  // sentence is trimmed to what the body actually decides.
   const src = readFileSync(
     join(dirname(fileURLToPath(import.meta.url)), "..", "extension", "service_worker.js"),
     "utf8");
@@ -376,6 +385,14 @@ test("🔴 startBackground() calls it UNCONDITIONALLY", () => {
   assert.equal(hits[0].text.trim(), "registerActionClick();",
     "the call carries a condition or a guard — pin the whole statement, because " +
     "`if (false) registerActionClick();` is the mutant this test exists to kill");
+  // No early exit above it at the function's own level. This is the audit's
+  // `if (globalThis.__x) return;` mutant: the call stays syntactically
+  // unconditional while becoming dead.
+  const idx = lines.indexOf(hits[0]);
+  const above = lines.slice(0, idx).filter((l) => l.depth === 1);
+  assert.ok(!above.some((l) => /^\s*(return|throw)\b/.test(l.text)),
+    "an early return/throw sits above the call — it is syntactically " +
+    "unconditional and never reached");
 });
 
 // --------------------------------------------------------------------------- //

--- a/scripts/browser-bridge/tests/offscreen_clipboard.test.mjs
+++ b/scripts/browser-bridge/tests/offscreen_clipboard.test.mjs
@@ -1,0 +1,224 @@
+// The OFFSCREEN CLIPBOARD SEAM — the only code path in this subsystem with no
+// wire surface at all, and (before this file) no coverage either.
+//
+// WHY THIS FILE EXISTS. An adversarial audit of PR #1063 mutated the offscreen
+// clipboard writer eight ways and **seven survived** the entire browser-bridge
+// suite — 869 pytest cases and 549 node tests, with the build marker regenerated
+// each time so a kill would have been behavioural:
+//
+//   * offscreen.js's TARGET renamed          → nobody answers the worker  SURVIVED
+//   * the execCommand return value ignored   → ✓ over an empty clipboard  SURVIVED
+//   * the textarea never select()ed          → copies nothing            SURVIVED
+//   * switched to navigator.clipboard        → rejects every time        SURVIVED
+//   * the `offscreen` permission removed     → createDocument throws     SURVIVED
+//   * offscreen.html stops loading its js    → no listener exists        SURVIVED
+//   * offscreen.html drops the #sink textarea→ nothing to select         SURVIVED
+//
+// The reason is structural, not an oversight of one assertion: `action_click`
+// tests the WORKER against a mocked chrome, and its mock answers the clipboard
+// message itself. Nothing had ever loaded `offscreen.js`. So this file drives
+// the real listener, and pins the four cross-file literals that only another
+// file can honour — a target string, a page url, a permission list, and the
+// script/element the page must contain.
+//
+// 🔴 THE PERMISSION IS PART OF THE CODE PATH. `document.execCommand("copy")` is
+// allowed without `clipboardWrite` ONLY inside a short-lived handler for a user
+// action. This copy runs after config(), a tab query, a NETWORK /whoami round
+// trip and createDocument(), in a document that never had transient activation —
+// so the permission is load-bearing, and without it execCommand returns FALSE
+// rather than throwing. That is a feature that ships inert while every test is
+// green, which is exactly why it is asserted here and not left to prose.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const EXT = join(dirname(fileURLToPath(import.meta.url)), "..", "extension");
+const read = (f) => readFileSync(join(EXT, f), "utf8");
+
+const manifest = JSON.parse(read("manifest.json"));
+const offscreenHtml = read("offscreen.html");
+const offscreenSrc = read("offscreen.js");
+
+// --------------------------------------------------------------------------- //
+// The cross-file literals
+// --------------------------------------------------------------------------- //
+test("the manifest declares BOTH permissions the clipboard path needs", () => {
+  const p = manifest.permissions;
+  assert.ok(p.includes("offscreen"),
+    "chrome.offscreen.createDocument() throws without the `offscreen` permission");
+  assert.ok(p.includes("clipboardWrite"),
+    "execCommand('copy') outside a short-lived user-action handler needs " +
+    "`clipboardWrite` — without it it returns FALSE and every click copies nothing");
+});
+
+test("README's prose permission list is the manifest's, exactly", () => {
+  // 🔴 A prose list is what a reader consults to judge whether this extension is
+  // over-permissioned, and it had already gone stale once — it still claimed the
+  // pre-`offscreen` set after the permission landed. Pinned as a SET so the
+  // order in either file is free, but membership is not.
+  const readme = readFileSync(join(EXT, "..", "README.md"), "utf8");
+  const m = readme.match(/`permissions` is `\[([^\]]*)\]`/s);
+  assert.ok(m, "the README's `permissions` claim vanished — re-point this guard");
+  const claimed = m[1].split(",").map((s) => s.trim().replace(/^"|"$/g, ""))
+    .filter(Boolean);
+  assert.deepEqual(new Set(claimed), new Set(manifest.permissions),
+    `README claims [${[...claimed].sort()}], manifest has [${[...manifest.permissions].sort()}]`);
+});
+
+test("the page the worker asks for is the page that exists, and it loads its script", () => {
+  // OFFSCREEN_URL is a string in the worker; nothing made it name a real file.
+  assert.match(offscreenHtml, /<script\s+src="offscreen\.js">/,
+    "offscreen.html must load offscreen.js — without it the document exists, " +
+    "registers no listener, and sendMessage resolves to undefined");
+  assert.match(offscreenHtml, /id="sink"/,
+    "offscreen.html must carry the #sink textarea the listener selects");
+});
+
+test("the worker's target string and the page's are the SAME string", async () => {
+  // Two literals, two files, no shared module — the same shape as the
+  // CLI↔protocol.js seam that already has a guard.
+  globalThis.BROWSER_BRIDGE_NO_AUTOSTART = true;
+  const { OFFSCREEN_CLIPBOARD_TARGET, OFFSCREEN_URL } =
+    await import("../extension/service_worker.js");
+  const m = offscreenSrc.match(/const TARGET = "([^"]+)"/);
+  assert.ok(m, "offscreen.js's TARGET literal vanished — re-point this guard");
+  assert.equal(m[1], OFFSCREEN_CLIPBOARD_TARGET,
+    "the worker addresses a target the offscreen document does not answer to");
+  assert.equal(OFFSCREEN_URL, "offscreen.html");
+});
+
+// The file's own header NAMES `navigator.clipboard.writeText()` to explain why it
+// is not used, so a guard over the raw text matches the warning and can never
+// fail. Strip `//` comments first and assert against CODE only — with a positive
+// control below proving the stripper still leaves code behind to match.
+const offscreenCode = offscreenSrc
+  .split("\n").filter((l) => !/^\s*\/\//.test(l)).join("\n");
+
+test("offscreen.js does NOT reach for navigator.clipboard", () => {
+  // Its own header says writeText() rejects in an unfocused document EVERY time.
+  // A refactor to the "modern" API is the plausible mistake, and it is silent:
+  // the promise rejects, the catch reports it, and the badge shows ✗ forever.
+  assert.match(offscreenCode, /document\.execCommand\("copy"\)/,
+    "POSITIVE CONTROL: comment-stripping left no code to match — the assertion " +
+    "below would pass vacuously");
+  assert.doesNotMatch(offscreenCode, /navigator\s*\.\s*clipboard/,
+    "an offscreen document is never focused — writeText() cannot work here");
+  // ...and the raw file DOES mention it, which is what makes the strip necessary.
+  assert.match(offscreenSrc, /navigator\.clipboard/,
+    "if the header no longer explains the choice, this guard's premise moved");
+});
+
+// --------------------------------------------------------------------------- //
+// The listener, driven for real
+// --------------------------------------------------------------------------- //
+// The module registers its listener at import and reads `document` from the
+// global at CALL time, so it is imported ONCE and the DOM is swapped per case.
+// (An earlier draft re-imported with a cache-busting query per case; the listener
+// captured from the fresh instance was not the one under test in later cases and
+// the file went red for a harness reason. One import, swapped globals, is both
+// simpler and closer to how the real document behaves.)
+let LISTENER = null;
+globalThis.chrome = {
+  runtime: { onMessage: { addListener(fn) { LISTENER = fn; } } },
+};
+globalThis.document = { getElementById() { return null; }, execCommand() { return false; } };
+await import("../extension/offscreen.js");
+
+test("HARNESS: importing offscreen.js registers exactly one listener", () => {
+  // Anti-vacuity. Every behavioural case below calls LISTENER; if the import had
+  // registered nothing they would all fail with "not a function" — a harness
+  // error that reads like seven product defects. Assert the instrument first.
+  assert.equal(typeof LISTENER, "function",
+    "offscreen.js registered no chrome.runtime.onMessage listener");
+});
+
+function mockDom({ copyResult = true, throwOn = null } = {}) {
+  const calls = { select: 0, exec: [], value: [] };
+  const sink = {
+    set value(v) { calls.value.push(v); this._v = v; },
+    get value() { return this._v; },
+    select() { calls.select += 1; },
+  };
+  globalThis.document = {
+    getElementById(id) { return id === "sink" ? sink : null; },
+    execCommand(cmd) {
+      calls.exec.push({ cmd, selectedAt: calls.select });
+      if (throwOn === cmd) throw new Error("execCommand exploded");
+      return copyResult;
+    },
+  };
+  return { listener: LISTENER, calls, sink };
+}
+
+function send(listener, msg) {
+  let reply;
+  const ret = listener(msg, {}, (r) => { reply = r; });
+  return { reply, ret };
+}
+
+test("a copy message selects the textarea and reports execCommand's TRUE", () => {
+  const { listener, calls } = mockDom({ copyResult: true });
+  const { reply } = send(listener, { target: "offscreen-clipboard", type: "copy", text: "bw://workbench/main/12345" });
+  assert.deepEqual(reply, { ok: true });
+  assert.deepEqual(calls.value, ["bw://workbench/main/12345"]);
+  assert.equal(calls.select, 1, "the textarea must be selected before the copy");
+  assert.equal(calls.exec.length, 1);
+  assert.equal(calls.exec[0].cmd, "copy");
+  // 🔴 ORDERING, not just occurrence: execCommand must run AFTER select(), or it
+  // copies whatever the previous selection was. `selectedAt` is the select count
+  // at the moment execCommand ran.
+  assert.equal(calls.exec[0].selectedAt, 1,
+    "execCommand('copy') ran before select() — it would copy the wrong thing");
+});
+
+test("🔴 execCommand returning FALSE is a FAILURE, not a completed call", () => {
+  // The whole clipboardWrite failure mode surfaces here and nowhere else:
+  // execCommand REPORTS refusal by return value and never throws.
+  const { listener } = mockDom({ copyResult: false });
+  const { reply } = send(listener, { target: "offscreen-clipboard", type: "copy", text: "x" });
+  assert.equal(reply.ok, false);
+  assert.match(reply.error, /execCommand refused/);
+});
+
+test("a throw is caught and reported, not left to reject", () => {
+  const { listener } = mockDom({ throwOn: "copy" });
+  const { reply } = send(listener, { target: "offscreen-clipboard", type: "copy", text: "x" });
+  assert.equal(reply.ok, false);
+  assert.match(reply.error, /execCommand exploded/);
+});
+
+test("a message for ANOTHER target is left entirely alone", () => {
+  // sendMessage fans out to every extension context except the sender, so an
+  // options page's traffic passes through here. Answering it would make this
+  // document a liar about someone else's message.
+  const { listener, calls } = mockDom();
+  let replied = false;
+  const ret = listener({ target: "something-else", type: "copy", text: "x" }, {}, () => { replied = true; });
+  assert.equal(replied, false, "it must not answer another context's message");
+  assert.equal(ret, false, "returning true would hold the channel open");
+  assert.equal(calls.exec.length, 0);
+});
+
+test("a malformed/absent message does not throw", () => {
+  const { listener } = mockDom();
+  for (const msg of [undefined, null, {}, { target: "offscreen-clipboard" }]) {
+    assert.doesNotThrow(() => listener(msg, {}, () => {}));
+  }
+});
+
+test("an unknown type on OUR target is refused by name", () => {
+  const { listener, calls } = mockDom();
+  const { reply } = send(listener, { target: "offscreen-clipboard", type: "paste" });
+  assert.equal(reply.ok, false);
+  assert.match(reply.error, /unknown type: paste/);
+  assert.equal(calls.exec.length, 0);
+});
+
+test("a null text copies the empty string rather than the literal 'null'", () => {
+  const { listener, calls } = mockDom();
+  send(listener, { target: "offscreen-clipboard", type: "copy", text: null });
+  assert.deepEqual(calls.value, [""]);
+});

--- a/scripts/browser-bridge/tests/tab_ref.test.mjs
+++ b/scripts/browser-bridge/tests/tab_ref.test.mjs
@@ -1,0 +1,101 @@
+// Unit tests for the `bw://` tab-reference BUILDER (extension/protocol.js).
+//
+// The reference is the whole wire format between the toolbar click and the CLI:
+// nothing else carries it, and there is no envelope, op or server route to catch
+// a mistake in it. So the format is pinned as a WHOLE NORMALISED STRING here,
+// and the same literal is asserted from the consuming end in
+// tests/test_browser_tab_ref.py. A change to either side alone turns one of the
+// two red.
+//
+// The refusals matter more than the happy path. A reference is pasted onto a
+// shell command line and split on `/` by a bash CLI, so every malformed field
+// this builder lets through becomes a command that runs against SOME tab rather
+// than none — the silent-wrong-answer shape, at the one point in this subsystem
+// where there is no envelope to inspect afterwards.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { buildTabRef, tabRefKey, TAB_REF_SCHEME, TAB_REF_FIELD_RE } =
+  await import("../extension/protocol.js");
+
+// The canonical example. Also the literal in the CLI test and in SKILL.md.
+const CANONICAL = "bw://workbench/main/12345";
+
+test("the canonical reference is built byte-for-byte", () => {
+  assert.equal(
+    buildTabRef({ host: "workbench", label: "main", instanceId: "ignored-when-labelled", tabId: 12345 }),
+    CANONICAL);
+});
+
+test("scheme constant is the prefix of what the builder emits", () => {
+  assert.ok(CANONICAL.startsWith(TAB_REF_SCHEME));
+});
+
+test("an UNLABELLED profile carries the FULL auto-id, never a prefix of it", () => {
+  // 🔴 This is the whole reason tabRefKey exists. server.py resolves a target
+  // with `target in (inst.key, inst.instance_id)` — an EXACT match — so an
+  // abbreviated id does not route and the reference would fail as
+  // `unknown_instance` on its first use. The fixture id is a real UUID shape:
+  // any prefix of it is a DIFFERENT string, which is what makes this test able
+  // to see a truncation at all.
+  const id = "9f1c7b2e-4a55-4c31-8de0-6b0f2a7c1d34";
+  const ref = buildTabRef({ host: "laptop", label: "", instanceId: id, tabId: 7 });
+  assert.equal(ref, `bw://laptop/${id}/7`);
+  assert.ok(ref.includes(id), "the ENTIRE instance id must survive into the ref");
+});
+
+test("a label WINS over the auto-id (that is what the server keys on)", () => {
+  assert.equal(tabRefKey("work", "9f1c7b2e-4a55"), "work");
+  assert.equal(tabRefKey("  work  ", "9f1c7b2e-4a55"), "work", "surrounding space is trimmed");
+  assert.equal(tabRefKey("", "9f1c7b2e-4a55"), "9f1c7b2e-4a55");
+  assert.equal(tabRefKey("   ", "9f1c7b2e-4a55"), "9f1c7b2e-4a55",
+    "a whitespace-only label is not a label");
+});
+
+// --- refusals --------------------------------------------------------------- //
+const REFUSED = [
+  ["an unknown host", { host: "unknown", label: "main", instanceId: "i", tabId: 1 },
+   /could not identify this host/],
+  ["an empty host", { host: "", label: "main", instanceId: "i", tabId: 1 },
+   /could not identify this host/],
+  ["a label containing a separator", { host: "workbench", label: "a/b", instanceId: "i", tabId: 1 },
+   /not ref-safe/],
+  ["a label containing a space", { host: "workbench", label: "my profile", instanceId: "i", tabId: 1 },
+   /not ref-safe/],
+  ["a label containing a quote", { host: "workbench", label: "it's", instanceId: "i", tabId: 1 },
+   /not ref-safe/],
+  ["a label containing a shell metachar", { host: "workbench", label: "a;rm", instanceId: "i", tabId: 1 },
+   /not ref-safe/],
+  ["no label and no id", { host: "workbench", label: "", instanceId: "", tabId: 1 },
+   /no label and no instance id/],
+  ["TAB_ID_NONE", { host: "workbench", label: "main", instanceId: "i", tabId: -1 },
+   /no routable tab id/],
+  ["a non-integer tab id", { host: "workbench", label: "main", instanceId: "i", tabId: 1.5 },
+   /no routable tab id/],
+  ["a missing tab id", { host: "workbench", label: "main", instanceId: "i" },
+   /no routable tab id/],
+  ["a string tab id", { host: "workbench", label: "main", instanceId: "i", tabId: "12345" },
+   /no routable tab id/],
+];
+
+for (const [name, args, pattern] of REFUSED) {
+  test(`REFUSES ${name}`, () => {
+    assert.throws(() => buildTabRef(args), pattern);
+  });
+}
+
+test("no arguments at all is a refusal, not a reference", () => {
+  assert.throws(() => buildTabRef(), /could not identify this host/);
+});
+
+// A separator inside a field is the failure the whole character class exists to
+// prevent; assert on the CONSEQUENCE, not just that the class rejects it.
+test("a label with a separator cannot produce a ref that splits into 3 fields", () => {
+  assert.throws(() => buildTabRef(
+    { host: "workbench", label: "a/b", instanceId: "i", tabId: 12 }), /not ref-safe/);
+  // and the class itself agrees, so the CLI's mirror of it has something to match
+  assert.equal(TAB_REF_FIELD_RE.test("a/b"), false);
+  assert.equal(TAB_REF_FIELD_RE.test("main"), true);
+  assert.equal(TAB_REF_FIELD_RE.test("9f1c7b2e-4a55-4c31-8de0-6b0f2a7c1d34"), true);
+});

--- a/scripts/browser-bridge/tests/test_browser_tab_ref.py
+++ b/scripts/browser-bridge/tests/test_browser_tab_ref.py
@@ -64,6 +64,7 @@ from pathlib import Path
 
 import pytest
 from cli_budget import CLI_TIMEOUT_S  # noqa: E402
+from testlib import mockbin  # noqa: E402
 
 BB = Path(__file__).resolve().parent.parent          # scripts/browser-bridge
 CLI = BB / "browser"
@@ -707,10 +708,15 @@ def test_the_agent_arm_does_not_LEAK_routing_env_to_its_children(bridge, tmp_pat
     stub_dir = tmp_path / f"stub-{var}"
     stub_dir.mkdir()
     (stub_dir / "browser").write_text(CLI.read_text(encoding="utf-8"), encoding="utf-8")
-    (stub_dir / "browser-agent").write_text(
-        '#!/usr/bin/env bash\n'
-        f'printf "SEEN {var}=[%s]\\n" "${{{var}-<unset>}}"\n', encoding="utf-8")
-    (stub_dir / "browser-agent").chmod(0o755)
+    # 🔴 write_exec, NOT a hand-written shebang. `#!/usr/bin/env bash` execs on
+    # the NixOS dev host and does NOT exist in the nix build sandbox, so a stub
+    # written that way is green here and ENOENT in the tier the merge gates on.
+    # This file learned it the way the repo already had five times over — see
+    # scripts/testlib/mockbin.py, which exists precisely so the rule is not
+    # re-derived at a sixth call site. The body is POSIX sh; write_exec owns the
+    # shebang so no call site can reintroduce the trap.
+    mockbin.write_exec(stub_dir / "browser-agent",
+                       f'printf "SEEN {var}=[%s]\\n" "${{{var}-<unset>}}"\n')
 
     clear = {"--tab": '', "--frame": ''}["--tab" if var == "BB_TAB" else "--frame"]
     flag = "--tab" if var == "BB_TAB" else "--frame"
@@ -738,10 +744,8 @@ def test_POSITIVE_CONTROL_the_stub_agent_can_see_an_inherited_var(bridge, tmp_pa
     stub_dir = tmp_path / "stub-control"
     stub_dir.mkdir()
     (stub_dir / "browser").write_text(CLI.read_text(encoding="utf-8"), encoding="utf-8")
-    (stub_dir / "browser-agent").write_text(
-        '#!/usr/bin/env bash\nprintf "SEEN BB_INSTANCE=[%s]\\n" "${BB_INSTANCE-<unset>}"\n',
-        encoding="utf-8")
-    (stub_dir / "browser-agent").chmod(0o755)
+    mockbin.write_exec(stub_dir / "browser-agent",
+                       'printf "SEEN BB_INSTANCE=[%s]\\n" "${BB_INSTANCE-<unset>}"\n')
     # BB_INSTANCE is deliberately NOT unset by the agent arm — --instance IS
     # forwarded, so inheriting it is consistent. That makes it the right control.
     r = subprocess.run(

--- a/scripts/browser-bridge/tests/test_browser_tab_ref.py
+++ b/scripts/browser-bridge/tests/test_browser_tab_ref.py
@@ -70,6 +70,7 @@ class _Stub(BaseHTTPRequestHandler):
     """Records /cmd bodies; answers /whoami with whatever host label is set."""
     bodies: list = []
     host_label = "workbench"
+    host_payload = None
     whoami_hits = 0
 
     def _reply(self, code, payload):
@@ -87,12 +88,27 @@ class _Stub(BaseHTTPRequestHandler):
             self.bodies.append(json.loads(raw))
         except ValueError:
             self.bodies.append({"__unparseable__": raw})
+        # `open` must answer with a tabId: `browser agent` opens its own tab
+        # first and refuses to continue without one, so a stub that omits it
+        # fails every agent case for a harness reason.
+        data = {"value": 1}
+        try:
+            if json.loads(raw).get("op") == "open":
+                data = {"tabId": 4242, "url": "about:blank"}
+        except ValueError:
+            pass
         self._reply(200, {"ok": True, "result": {"id": "c", "ok": True,
-                                                 "data": {"value": 1}}})
+                                                 "data": data}})
 
     def do_GET(self):
         if self.path.startswith("/whoami"):
             type(self).whoami_hits += 1
+            # `host_payload`, when set, REPLACES the whole body — the CLI's parser
+            # has to survive shapes server.py would never emit, and a test that
+            # can only vary the label cannot express those.
+            if self.host_payload is not None:
+                self._reply(200, self.host_payload)
+                return
             host = ({"label": self.host_label} if self.host_label is not None
                     else None)
             self._reply(200, {"ok": True, "host": host, "instances": []})
@@ -108,6 +124,7 @@ def bridge(tmp_path):
     class _Handler(_Stub):
         bodies = []                                  # fresh per test
         host_label = "workbench"
+        host_payload = None
         whoami_hits = 0
 
     srv = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
@@ -344,13 +361,23 @@ def test_a_trailing_reference_is_TEXT_for_the_free_text_subcommands(bridge):
     assert "tab" not in body, body
 
 
-@pytest.mark.parametrize("sub", ["js", "eval"])
-def test_js_takes_a_trailing_reference_as_the_expression(bridge, sub):
-    """INVARIANT GUARD (green at d202ef59) — see the test above."""
-    ref_expr = f'"{CANONICAL}"'
-    r = bridge.run(sub, ref_expr)
+@pytest.mark.parametrize("sub, field", [("js", "js"), ("eval", "js")])
+def test_js_takes_a_trailing_reference_as_the_expression(bridge, sub, field):
+    """INVARIANT GUARD (green at d202ef59) — see the test above.
+
+    🔴 THE FIXTURE IS UNQUOTED, AND THAT IS THE WHOLE TEST. An earlier version
+    passed ``'"bw://workbench/main/12345"'`` — a JS string *literal*, which does
+    not start with ``bw://``, so the ``bw://*`` glob could never match it and the
+    guard could not fail however the exemption list was mutated. An audit
+    measured it: dropping ``eval`` from REF_FREE_TEXT_SUBCOMMANDS SURVIVED.
+    A fixture that cannot reach the branch it names is not a guard.
+    """
+    r = bridge.run(sub, CANONICAL)
     assert r.returncode == 0, r.stderr
-    assert "target" not in bridge.bodies[-1], bridge.bodies[-1]
+    body = bridge.bodies[-1]
+    assert body[field] == CANONICAL, body
+    assert "target" not in body, body
+    assert "tab" not in body, body
 
 
 def test_the_LEADING_position_still_routes_a_free_text_subcommand(bridge):
@@ -411,3 +438,117 @@ def test_the_scheme_literal_is_the_same_on_both_sides_of_the_seam():
         f"diverged")
     assert f"    {scheme}*)" in cli, (
         f"the CLI's global-flag loop does not dispatch on {scheme!r}")
+
+
+# --------------------------------------------------------------------------- #
+# `agent` cannot keep the promise a reference makes
+# --------------------------------------------------------------------------- #
+def test_agent_REFUSES_a_reference_rather_than_honouring_half_of_it(bridge):
+    """🔴 The wrong-answer case an audit found, and why refusing beats routing.
+
+    `browser-agent` has no `--tab`: the agent arm forwards `--instance` only, and
+    the autonomous agent always works in its OWN freshly-opened tab. So a routed
+    reference kept the instance and silently dropped the tab — the operator
+    clicks the icon on the tab they care about, pastes the ref, and gets a
+    confident answer about a BLANK page, with no error anywhere.
+
+    A reference is a promise about ONE tab. A subcommand that cannot keep it must
+    refuse, not keep the half it happens to support.
+    """
+    r = bridge.run(CANONICAL, "agent", "--dry-run", "do a thing")
+    assert r.returncode != 0, r.stdout
+    assert "agent cannot honour" in r.stderr
+    assert "--instance main" in r.stderr, "the error must name the way forward"
+    assert bridge.bodies == [], f"nothing may be dispatched: {bridge.bodies}"
+
+
+def test_agent_still_works_with_an_explicit_instance(bridge):
+    """INVARIANT GUARD: the refusal above is scoped to the reference.
+
+    Refusing `--instance` too would break the documented way to target the agent,
+    which is the failure mode a too-wide guard would introduce here.
+
+    🔴 ASSERTS THE REQUEST, NOT THE EXIT CODE, and deliberately. `browser agent`
+    drives a real model backend this stub does not provide, so it exits non-zero
+    here no matter what the parser did. What is under test is the ROUTING the CLI
+    produced, which is visible in the first body it sent — reading rc would make
+    this test a claim about the stub.
+    """
+    bridge.run("--instance", "main", "agent", "--dry-run", "do a thing")
+    assert bridge.bodies, "the agent path sent nothing at all — parse failed early"
+    assert bridge.bodies[0].get("target") == "main", bridge.bodies[0]
+
+
+def test_the_free_text_list_covers_agent_too(bridge):
+    """A TRAILING bw:// is a goal for `agent`, not a route.
+
+    Dropping `agent` from REF_FREE_TEXT_SUBCOMMANDS SURVIVED an audit's mutation
+    because nothing exercised it. With it dropped the token is stripped from the
+    goal and turned into routing — visible here as a `target` that must not exist.
+    Same rc caveat as the test above.
+    """
+    bridge.run("agent", "--dry-run", CANONICAL)
+    assert bridge.bodies, "the agent path sent nothing at all — parse failed early"
+    # 🔴 Assert on the REFERENCE'S values, not on the mere presence of a `tab`.
+    # browser-agent legitimately sends `{"op":"close","tab":<its own>}` to tear
+    # down the tab IT opened; a blanket "no tab anywhere" assertion fails on that
+    # and would read as the parser leaking when it is the agent cleaning up.
+    for b in bridge.bodies:
+        assert b.get("target") != CANONICAL_INSTANCE, (
+            f"the reference was consumed as a route: {b}")
+        assert b.get("tab") != CANONICAL_TAB, (
+            f"the reference was consumed as a route: {b}")
+
+
+# --------------------------------------------------------------------------- #
+# `--` ends reference scanning
+# --------------------------------------------------------------------------- #
+def test_a_double_dash_ENDS_reference_scanning(bridge):
+    """An explicitly-escaped positional is not a route.
+
+    The strip loop runs BEFORE each subcommand's own parser, so without honouring
+    `--` a `browser text -- 'bw://…'` had its selector eaten and sent NO selector
+    at all — the escaped argument vanished and the command silently re-targeted.
+    `pos_rest` exists in this file precisely because `--` was dropped once before.
+    """
+    r = bridge.run("text", "--", CANONICAL)
+    assert r.returncode == 0, r.stderr
+    body = bridge.bodies[-1]
+    assert body.get("selector") == CANONICAL, body
+    assert "target" not in body, body
+    assert "tab" not in body, body
+
+
+def test_a_reference_BEFORE_a_double_dash_still_routes(bridge):
+    """CONTROL for the test above: `--` ends scanning, it does not disable it."""
+    r = bridge.run("text", CANONICAL, "--", "main")
+    assert r.returncode == 0, r.stderr
+    body = bridge.bodies[-1]
+    assert body["target"] == CANONICAL_INSTANCE, body
+    assert body.get("selector") == "main", body
+
+
+# --------------------------------------------------------------------------- #
+# The /whoami parse cannot raise, and says WHICH thing went wrong
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("payload, why", [
+    ({"ok": True, "host": "workbench"}, "host is a string, not an object"),
+    ({"ok": True, "host": {"label": 5}}, "label is not a string"),
+    ({"ok": True}, "no host key at all"),
+    ([1, 2, 3], "the whole body is not an object"),
+])
+def test_an_unreadable_whoami_never_raises_and_fails_open(bridge, payload, why):
+    """A PARSE failure must not surface as a Python traceback, and must not be
+    reported as "the bridge cannot identify its host" — that is a different fact
+    and sends the operator somewhere else entirely."""
+    bridge.handler.host_payload = payload
+    r = bridge.run(CANONICAL, "text")
+    assert r.returncode == 0, f"{why}: {r.stderr}"
+    assert "Traceback" not in r.stderr, f"{why}: {r.stderr}"
+    assert "AttributeError" not in r.stderr, f"{why}: {r.stderr}"
+    assert "NOT verified" in r.stderr, why
+    assert bridge.bodies and bridge.bodies[-1]["target"] == CANONICAL_INSTANCE
+    if why != "no host key at all":
+        assert "could not read" in r.stderr, (
+            f"{why}: an unreadable SHAPE must be named as such, not reported as "
+            f"an unidentifiable host")

--- a/scripts/browser-bridge/tests/test_browser_tab_ref.py
+++ b/scripts/browser-bridge/tests/test_browser_tab_ref.py
@@ -1,0 +1,413 @@
+"""The CLI end of the `bw://` tab reference (scripts/browser-bridge/browser).
+
+Fully HEADLESS: no Brave, no extension, no real bridge. A stub loopback server
+stands in for server.py — it answers /whoami with a host label the test chooses
+and records the exact JSON body the CLI POSTs to /cmd. So every assertion here
+is about the WIRE SHAPE the reference produced, which is the thing that can be
+silently wrong.
+
+WHAT A WRONG ANSWER LOOKS LIKE HERE, and why the assertions are shaped this way:
+
+  A reference is one opaque token that expands into ``--instance`` and ``--tab``.
+  If it expands into the WRONG pair, nothing anywhere reports an error — the
+  command reaches a real browser, drives a real tab, and returns a perfectly
+  ordinary envelope. The operator finds out when a screenshot shows the wrong
+  page. There is no envelope field, no op and no server route that can catch it
+  after the fact, so the parse itself is the only place to catch it.
+
+  That makes the three interesting cases: (a) a well-formed reference must land
+  on EXACTLY the target it names, (b) a malformed one must be refused rather
+  than split into whichever three fields fall out, and (c) a reference minted on
+  the OTHER host must fail loudly, because the labels are unique per host and
+  not across hosts — ``main`` exists on both machines.
+
+THE FORMAT IS PINNED IN TWO PLACES ON PURPOSE. ``bw://workbench/main/12345``
+appears here and in ``tests/tab_ref.test.mjs``, which asserts the extension
+BUILDS exactly that string from the same inputs. Neither end can be changed
+alone without turning the other red — the two files are the seam, and the seam
+is where a format lives when no single component owns it.
+
+RED-AT-BASE MATRIX. Measured against ``d202ef59`` (the commit before this
+change), with only the three new test files copied in:
+
+    pytest  scripts/browser-bridge/tests/test_browser_tab_ref.py
+            29 FAILED / 4 passed at d202ef59  →  33 passed at HEAD
+    node    tests/tab_ref.test.mjs + tests/action_click.test.mjs
+            34 FAILED / 0 passed at d202ef59  →  34 passed at HEAD
+
+The 4 that were already green are labelled ``INVARIANT GUARD`` in place: they
+pin behaviour this change must NOT take away, and none of them is evidence the
+feature works.
+
+Run: nix develop ~/workspace/devrc -c python3 -m pytest \\
+       scripts/browser-bridge/tests/test_browser_tab_ref.py -q
+"""
+import json
+import os
+import shutil
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+from cli_budget import CLI_TIMEOUT_S  # noqa: E402
+
+BB = Path(__file__).resolve().parent.parent          # scripts/browser-bridge
+CLI = BB / "browser"
+
+# The canonical reference. Same literal as tests/tab_ref.test.mjs.
+CANONICAL = "bw://workbench/main/12345"
+CANONICAL_INSTANCE = "main"
+CANONICAL_TAB = 12345
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("curl") is None,
+    reason="the browser CLI is bash and talks to the bridge with curl")
+
+
+class _Stub(BaseHTTPRequestHandler):
+    """Records /cmd bodies; answers /whoami with whatever host label is set."""
+    bodies: list = []
+    host_label = "workbench"
+    whoami_hits = 0
+
+    def _reply(self, code, payload):
+        raw = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(n).decode()
+        try:
+            self.bodies.append(json.loads(raw))
+        except ValueError:
+            self.bodies.append({"__unparseable__": raw})
+        self._reply(200, {"ok": True, "result": {"id": "c", "ok": True,
+                                                 "data": {"value": 1}}})
+
+    def do_GET(self):
+        if self.path.startswith("/whoami"):
+            type(self).whoami_hits += 1
+            host = ({"label": self.host_label} if self.host_label is not None
+                    else None)
+            self._reply(200, {"ok": True, "host": host, "instances": []})
+            return
+        self._reply(200, {"ok": True, "instances": []})
+
+    def log_message(self, *a):
+        pass
+
+
+@pytest.fixture
+def bridge(tmp_path):
+    class _Handler(_Stub):
+        bodies = []                                  # fresh per test
+        host_label = "workbench"
+        whoami_hits = 0
+
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+
+    tokfile = tmp_path / "token"
+    tokfile.write_text("test-token-abc123\n")
+
+    env = dict(os.environ)
+    env.update({
+        "BROWSER_BRIDGE_HOST": "127.0.0.1",
+        "BROWSER_BRIDGE_PORT": str(srv.server_address[1]),
+        "BROWSER_BRIDGE_TOKEN_FILE": str(tokfile),
+        "CLAUDE_CODE_SESSION_ID": "pytest-tab-ref",
+        "HOME": str(tmp_path),
+    })
+    # The env-default targeting knobs must not leak in from the developer's own
+    # shell: BB_INSTANCE would seed INSTANCE and make the override tests lie.
+    for k in ("BB_INSTANCE", "BB_TAB", "BB_FRAME"):
+        env.pop(k, None)
+
+    class _Bridge:
+        handler = _Handler
+        bodies = _Handler.bodies
+
+        @staticmethod
+        def run(*args, **kw):
+            e = dict(env)
+            e.update(kw.pop("env", {}))
+            return subprocess.run(["bash", str(CLI), *args], env=e,
+                                  capture_output=True, text=True,
+                                  timeout=CLI_TIMEOUT_S)
+
+    try:
+        yield _Bridge
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+# --------------------------------------------------------------------------- #
+# It routes — and routes to EXACTLY what it names
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("argv, label", [
+    ([CANONICAL, "text"], "leading position"),
+    (["text", CANONICAL], "trailing position (the natural paste order)"),
+])
+def test_a_reference_expands_into_target_and_tab(bridge, argv, label):
+    r = bridge.run(*argv)
+    assert r.returncode == 0, f"{label}: {r.stderr}"
+    assert len(bridge.bodies) == 1, f"{label}: {bridge.bodies}"
+    body = bridge.bodies[0]
+    assert body["op"] == "text", label
+    assert body["target"] == CANONICAL_INSTANCE, label
+    assert body["tab"] == CANONICAL_TAB, label
+
+
+def test_both_positions_produce_a_byte_identical_request(bridge):
+    """The invariant, stated as one assertion rather than inferred from two.
+
+    Two spellings of the same reference that differ ANYWHERE in the body is a
+    bug even when both happen to route today — it means one of them is carrying
+    something the other is not.
+    """
+    bridge.run(CANONICAL, "text")
+    bridge.run("text", CANONICAL)
+    assert len(bridge.bodies) == 2
+    assert bridge.bodies[0] == bridge.bodies[1]
+
+
+def test_the_reference_is_stripped_from_the_subcommand_arguments(bridge):
+    """It must not ALSO arrive as the subcommand's own positional.
+
+    `screenshot`'s positional is an output PATH. A reference left in argv would
+    be taken as one, and the failure would be a file-write error naming a path
+    the operator never typed — or, worse, a written file.
+    """
+    r = bridge.run("text", CANONICAL, "main")
+    assert r.returncode == 0, r.stderr
+    body = bridge.bodies[-1]
+    assert body["target"] == CANONICAL_INSTANCE
+    # `main` here is `text`'s CSS-selector positional and must survive untouched.
+    assert body.get("selector") == "main", body
+
+
+def test_an_unlabelled_profiles_full_uuid_survives_the_round_trip(bridge):
+    """The whole auto-id, not a prefix — the server matches targets EXACTLY."""
+    uuid = "9f1c7b2e-4a55-4c31-8de0-6b0f2a7c1d34"
+    r = bridge.run(f"bw://workbench/{uuid}/7", "text")
+    assert r.returncode == 0, r.stderr
+    assert bridge.bodies[-1]["target"] == uuid
+    assert bridge.bodies[-1]["tab"] == 7
+
+
+# --------------------------------------------------------------------------- #
+# The host check — the cross-paste case
+# --------------------------------------------------------------------------- #
+def test_a_reference_from_the_OTHER_host_is_refused_before_any_command(bridge):
+    bridge.handler.host_label = "laptop"
+    r = bridge.run(CANONICAL, "text")
+    assert r.returncode != 0
+    assert "minted on 'workbench'" in r.stderr
+    assert "this bridge is 'laptop'" in r.stderr
+    # 🔴 The point: NOTHING was sent. A refusal that still drove a tab would be
+    # the bug with a warning printed over it.
+    assert bridge.bodies == [], bridge.bodies
+
+
+def test_a_matching_host_is_verified_against_the_bridge_not_assumed(bridge):
+    """The check must be a real read, so a wrong host can be SEEN.
+
+    A positive control for the assertion above: if /whoami were never called,
+    the cross-host test would pass for the wrong reason (nothing to disagree
+    with), so pin that the request happens.
+    """
+    before = bridge.handler.whoami_hits
+    r = bridge.run(CANONICAL, "text")
+    assert r.returncode == 0, r.stderr
+    assert bridge.handler.whoami_hits == before + 1
+
+
+def test_a_bridge_that_cannot_name_its_host_warns_and_proceeds(bridge):
+    """FAIL OPEN on ignorance, closed on disagreement.
+
+    A host with no ACTIVITY_HOST resolves to "unknown"; refusing there would
+    strand every reference on that host while catching nothing.
+    """
+    bridge.handler.host_label = "unknown"
+    r = bridge.run(CANONICAL, "text")
+    assert r.returncode == 0, r.stderr
+    assert "NOT verified" in r.stderr
+    assert bridge.bodies and bridge.bodies[-1]["target"] == CANONICAL_INSTANCE
+    # The warning goes to stderr ONLY — stdout stays parseable JSON.
+    assert "NOT verified" not in r.stdout
+    json.loads(r.stdout)
+
+
+def test_a_missing_host_object_is_treated_as_unknown_not_as_a_match(bridge):
+    bridge.handler.host_label = None                 # /whoami answers host: null
+    r = bridge.run(CANONICAL, "text")
+    assert r.returncode == 0, r.stderr
+    assert "NOT verified" in r.stderr
+
+
+def test_no_reference_means_no_whoami_call(bridge):
+    """INVARIANT GUARD (green at d202ef59): the check is scoped to the feature.
+
+    An ordinary command must not grow a round trip. Green before this change
+    too — it pins back-compat the change must not take away, and is NOT evidence
+    the feature works.
+    """
+    before = bridge.handler.whoami_hits
+    r = bridge.run("--instance", "main", "text")
+    assert r.returncode == 0, r.stderr
+    assert bridge.handler.whoami_hits == before
+
+
+# --------------------------------------------------------------------------- #
+# Refusals — a malformed reference must never be split into three fields
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("ref, expect", [
+    ("bw://workbench/main", "reference must be bw://"),
+    ("bw://workbench", "reference must be bw://"),
+    ("bw://", "reference must be bw://"),
+    ("bw://workbench/main/12345/extra", "too many '/'"),
+    ("bw://workbench/main/notanumber", "tab id must be numeric"),
+    ("bw://workbench/main/", "tab id must be numeric"),
+    ("bw://workbench//12345", "instance is not ref-safe"),
+    ("bw:///main/12345", "host is not ref-safe"),
+    ("bw://work bench/main/12345", "host is not ref-safe"),
+    ("bw://workbench/ma in/12345", "instance is not ref-safe"),
+    ("bw://workbench/ma;rm/12345", "instance is not ref-safe"),
+])
+def test_a_malformed_reference_is_refused_and_sends_nothing(bridge, ref, expect):
+    r = bridge.run(ref, "text")
+    assert r.returncode != 0, f"{ref} was ACCEPTED: {r.stdout}"
+    assert expect in r.stderr, f"{ref}: {r.stderr}"
+    assert bridge.bodies == [], f"{ref} still reached the bridge: {bridge.bodies}"
+
+
+@pytest.mark.parametrize("argv", [
+    ["--instance", "other", CANONICAL, "text"],
+    [CANONICAL, "--instance", "other", "text"],
+    ["--instance", "other", "text", CANONICAL],
+])
+def test_a_reference_and_an_explicit_instance_is_refused_not_ranked(bridge, argv):
+    """No precedence rule is safe here — whichever loses, the wrong tab runs."""
+    r = bridge.run(*argv)
+    assert r.returncode != 0, r.stdout
+    assert "--instance conflicts with" in r.stderr
+    assert bridge.bodies == []
+
+
+@pytest.mark.parametrize("argv", [
+    ["--tab", "999", CANONICAL, "text"],
+    [CANONICAL, "--tab", "999", "text"],
+])
+def test_a_reference_and_an_explicit_tab_is_refused_not_ranked(bridge, argv):
+    r = bridge.run(*argv)
+    assert r.returncode != 0, r.stdout
+    assert "--tab conflicts with" in r.stderr
+    assert bridge.bodies == []
+
+
+def test_two_references_are_refused(bridge):
+    r = bridge.run(CANONICAL, "text", "bw://workbench/other/999")
+    assert r.returncode != 0
+    assert "two bw:// references" in r.stderr
+    assert bridge.bodies == []
+
+
+# --------------------------------------------------------------------------- #
+# The free-text subcommands
+# --------------------------------------------------------------------------- #
+def test_a_trailing_reference_is_TEXT_for_the_free_text_subcommands(bridge):
+    """INVARIANT GUARD (green at d202ef59): `browser type bw://…` types the
+    literal string; it does not route.
+
+    Green before this change because nothing parsed references at all — which is
+    exactly what makes it the right guard: the feature must not TAKE THIS AWAY.
+    It is not evidence the feature works.
+
+    This is the one place the two positions deliberately differ, and it is why
+    the trailing form is not simply "strip any bw:// token": `type`, `js`/`eval`
+    and `agent` take arbitrary operator text, and silently eating a value that
+    happens to start `bw://` would be a different silent-wrong-answer.
+    """
+    r = bridge.run("type", CANONICAL, "--selector", "#x")
+    assert r.returncode == 0, r.stderr
+    body = bridge.bodies[-1]
+    assert body["op"] == "type"
+    assert body["text"] == CANONICAL, body
+    assert "target" not in body, body
+    assert "tab" not in body, body
+
+
+@pytest.mark.parametrize("sub", ["js", "eval"])
+def test_js_takes_a_trailing_reference_as_the_expression(bridge, sub):
+    """INVARIANT GUARD (green at d202ef59) — see the test above."""
+    ref_expr = f'"{CANONICAL}"'
+    r = bridge.run(sub, ref_expr)
+    assert r.returncode == 0, r.stderr
+    assert "target" not in bridge.bodies[-1], bridge.bodies[-1]
+
+
+def test_the_LEADING_position_still_routes_a_free_text_subcommand(bridge):
+    """…so the feature is not simply unavailable for `type`."""
+    r = bridge.run(CANONICAL, "type", "hello", "--selector", "#x")
+    assert r.returncode == 0, r.stderr
+    body = bridge.bodies[-1]
+    assert body["target"] == CANONICAL_INSTANCE
+    assert body["tab"] == CANONICAL_TAB
+    assert body["text"] == "hello"
+
+
+# --------------------------------------------------------------------------- #
+# Interaction with the env defaults
+# --------------------------------------------------------------------------- #
+def test_a_reference_overrides_the_env_defaults(bridge):
+    """BB_INSTANCE/BB_TAB are DEFAULTS; the reference is on the command line.
+
+    The precedence the CLI already documents is "an explicit flag always wins
+    over the environment". A reference is command-line, so it wins — and unlike
+    two flags it cannot be a typo the operator can see, which is why this is
+    pinned rather than left to read off the assignment order.
+    """
+    r = bridge.run(CANONICAL, "text",
+                   env={"BB_INSTANCE": "envprofile", "BB_TAB": "999"})
+    assert r.returncode == 0, r.stderr
+    body = bridge.bodies[-1]
+    assert body["target"] == CANONICAL_INSTANCE
+    assert body["tab"] == CANONICAL_TAB
+
+
+# --------------------------------------------------------------------------- #
+# The seam: the CLI and the extension must agree on the scheme
+# --------------------------------------------------------------------------- #
+def test_the_scheme_literal_is_the_same_on_both_sides_of_the_seam():
+    """No component owns this format, so nothing else would notice a rename.
+
+    The extension MINTS references and the CLI CONSUMES them, in different
+    languages, with no shared module and no schema between them. Renaming the
+    scheme on one side leaves the other silently unable to parse anything the
+    first produces — and every existing test on each side keeps passing, because
+    each is internally consistent.
+    """
+    protocol = (BB / "extension" / "protocol.js").read_text(encoding="utf-8")
+    cli = CLI.read_text(encoding="utf-8")
+
+    marker = 'export const TAB_REF_SCHEME = "'
+    assert marker in protocol, (
+        "TAB_REF_SCHEME vanished from protocol.js — this guard now checks "
+        "nothing. Re-point it at whatever defines the scheme.")
+    scheme = protocol.split(marker, 1)[1].split('"', 1)[0]
+    assert scheme, "empty scheme parsed out of protocol.js"
+
+    # The CLI strips the scheme and dispatches on it; both spellings must be the
+    # value the extension mints.
+    assert f'rest="${{raw#{scheme}}}"' in cli, (
+        f"the CLI does not strip {scheme!r} — the builder and the parser have "
+        f"diverged")
+    assert f"    {scheme}*)" in cli, (
+        f"the CLI's global-flag loop does not dispatch on {scheme!r}")

--- a/scripts/browser-bridge/tests/test_browser_tab_ref.py
+++ b/scripts/browser-bridge/tests/test_browser_tab_ref.py
@@ -718,11 +718,13 @@ def test_the_agent_arm_does_not_LEAK_routing_env_to_its_children(bridge, tmp_pat
     mockbin.write_exec(stub_dir / "browser-agent",
                        f'printf "SEEN {var}=[%s]\\n" "${{{var}-<unset>}}"\n')
 
-    clear = {"--tab": '', "--frame": ''}["--tab" if var == "BB_TAB" else "--frame"]
     flag = {"BB_TAB": "--tab", "BB_FRAME": "--frame",
             "BB_INSTANCE": "--instance"}[var]
     r = subprocess.run(
-        ["bash", str(stub_dir / "browser"), flag, clear, "--instance", "main",
+        # "" is the EXPLICIT-EMPTY this file documents as the way to clear an
+        # inherited BB_*: it zeroes the shell variable while leaving the export
+        # intact, which is exactly the shape that leaked.
+        ["bash", str(stub_dir / "browser"), flag, "", "--instance", "main",
          "agent", "some goal"],
         env={**bridge.env_for_stub(), var: "999"},
         capture_output=True, text=True, timeout=CLI_TIMEOUT_S)
@@ -804,3 +806,38 @@ def test_SKILL_md_names_every_routing_flag_the_agent_guard_REFUSES():
         f"refusal sentence does not name {sorted(missing.values())}. An agent "
         f"reading SKILL.md will use it and get rc 1 with no warning there. "
         f"Sentence: {text!r}")
+
+
+def test_an_explicitly_cleared_instance_forwards_NOTHING_and_leaks_NOTHING(bridge, tmp_path):
+    """The exact shape the BB_INSTANCE fix's own comment describes.
+
+    The leak matrix above passes `--instance "" --instance main`, so INSTANCE
+    ends up "main" — that pins the unconditional `unset`, but it never exercises
+    the case the defect actually lived in: `--instance ""` ALONE, where nothing
+    is forwarded as an argument and the export was the only thing left carrying
+    a profile. An audit noted the gap; this closes it.
+
+    Both halves matter and they are different claims: no `--instance` reaches
+    browser-agent's argv (so it does not silently route), AND no BB_INSTANCE
+    reaches its environment (so its own child `browser` calls do not either).
+    """
+    stub_dir = tmp_path / "stub-cleared"
+    stub_dir.mkdir()
+    (stub_dir / "browser").write_text(CLI.read_text(encoding="utf-8"), encoding="utf-8")
+    mockbin.write_exec(
+        stub_dir / "browser-agent",
+        'printf "ARGV=[%s]\\n" "$*"\n'
+        'printf "ENV BB_INSTANCE=[%s]\\n" "${BB_INSTANCE-<unset>}"\n')
+    r = subprocess.run(
+        ["bash", str(stub_dir / "browser"), "--instance", "", "agent", "some goal"],
+        env={**bridge.env_for_stub(), "BB_INSTANCE": "work"},
+        capture_output=True, text=True, timeout=CLI_TIMEOUT_S)
+    assert "ARGV=[" in r.stdout, (
+        f"the stub agent never ran, so this test proves nothing: {r.stdout!r} "
+        f"/ {r.stderr!r}")
+    assert "--instance" not in r.stdout.split("ENV ")[0], (
+        f"an explicitly-cleared instance was still forwarded: {r.stdout!r}")
+    assert "ENV BB_INSTANCE=[<unset>]" in r.stdout, (
+        f"BB_INSTANCE survived into browser-agent's environment, so its child "
+        f"`browser` calls would drive profile 'work' — the wrong Brave profile, "
+        f"with nothing on stderr saying so. stdout: {r.stdout!r}")

--- a/scripts/browser-bridge/tests/test_browser_tab_ref.py
+++ b/scripts/browser-bridge/tests/test_browser_tab_ref.py
@@ -691,7 +691,7 @@ def test_agent_refuses_a_frame_from_any_source(bridge, argv, env, source, word):
     assert bridge.bodies == [], f"nothing may be dispatched: {bridge.bodies}"
 
 
-@pytest.mark.parametrize("var", ["BB_TAB", "BB_FRAME"])
+@pytest.mark.parametrize("var", ["BB_TAB", "BB_FRAME", "BB_INSTANCE"])
 def test_the_agent_arm_does_not_LEAK_routing_env_to_its_children(bridge, tmp_path, var):
     """🔴 The guard closes the DOOR; this closes the SEAM.
 
@@ -719,7 +719,8 @@ def test_the_agent_arm_does_not_LEAK_routing_env_to_its_children(bridge, tmp_pat
                        f'printf "SEEN {var}=[%s]\\n" "${{{var}-<unset>}}"\n')
 
     clear = {"--tab": '', "--frame": ''}["--tab" if var == "BB_TAB" else "--frame"]
-    flag = "--tab" if var == "BB_TAB" else "--frame"
+    flag = {"BB_TAB": "--tab", "BB_FRAME": "--frame",
+            "BB_INSTANCE": "--instance"}[var]
     r = subprocess.run(
         ["bash", str(stub_dir / "browser"), flag, clear, "--instance", "main",
          "agent", "some goal"],
@@ -735,23 +736,71 @@ def test_the_agent_arm_does_not_LEAK_routing_env_to_its_children(bridge, tmp_pat
 
 
 def test_POSITIVE_CONTROL_the_stub_agent_can_see_an_inherited_var(bridge, tmp_path):
-    """The two assertions above are ABSENCES — prove the stub can see a leak.
+    """The assertions above are ABSENCES — prove the stub can see a leak.
 
-    If the stub simply never observed the environment, `[<unset>]` would be
-    reported for a variable that WAS inherited, and the guard would pass while
-    testing nothing.
+    If the stub never ran, or never observed the environment, `[<unset>]` would
+    be reported for a variable that WAS inherited and every leak assertion would
+    pass while testing nothing. That is not hypothetical: it is exactly what
+    happened when the stubs carried a `/usr/bin/env` shebang and could not exec
+    in the nix sandbox — this control is what said so.
     """
     stub_dir = tmp_path / "stub-control"
     stub_dir.mkdir()
     (stub_dir / "browser").write_text(CLI.read_text(encoding="utf-8"), encoding="utf-8")
-    mockbin.write_exec(stub_dir / "browser-agent",
-                       'printf "SEEN BB_INSTANCE=[%s]\\n" "${BB_INSTANCE-<unset>}"\n')
-    # BB_INSTANCE is deliberately NOT unset by the agent arm — --instance IS
-    # forwarded, so inheriting it is consistent. That makes it the right control.
+    # 🔴 THE CONTROL MUST NOT REST ON THE DEFECT IT CONTROLS FOR. This used
+    # BB_INSTANCE, on the stated reasoning that the agent arm deliberately does
+    # not unset it — and that reasoning WAS the bug: `--instance ""` forwarded
+    # nothing while BB_INSTANCE survived the exec, so browser-agent's children
+    # drove the wrong Brave profile. Closing that leak would have broken this
+    # control, which is the tell that the control was load-bearing on a defect.
+    # BROWSER_BRIDGE_PORT is read by the CLI and never unset by it, so it
+    # measures inheritance without measuring the thing under test.
+    mockbin.write_exec(
+        stub_dir / "browser-agent",
+        'printf "SEEN BROWSER_BRIDGE_PORT=[%s]\\n" "${BROWSER_BRIDGE_PORT-<unset>}"\n')
     r = subprocess.run(
         ["bash", str(stub_dir / "browser"), "agent", "some goal"],
-        env={**bridge.env_for_stub(), "BB_INSTANCE": "main"},
+        env=bridge.env_for_stub(),
         capture_output=True, text=True, timeout=CLI_TIMEOUT_S)
-    assert "SEEN BB_INSTANCE=[main]" in r.stdout, (
-        f"the stub cannot observe an inherited variable at all, so the leak "
+    assert "SEEN BROWSER_BRIDGE_PORT=[" in r.stdout, (
+        f"the stub never ran or never read the environment, so the leak "
         f"assertions above are vacuous. stdout: {r.stdout!r}")
+    assert "<unset>" not in r.stdout, (
+        f"an inherited variable did NOT reach the stub, so an absence there "
+        f"proves nothing about unsetting. stdout: {r.stdout!r}")
+
+
+def test_SKILL_md_names_every_routing_flag_the_agent_guard_REFUSES():
+    """🔴 The second ledger: the refusal list, not the exemption list.
+
+    The free-text pin above caught SKILL.md drifting on which subcommands treat
+    a trailing reference as text. It does NOT see the other list this sentence
+    carries — which routing flags `agent` refuses — and that one drifted the
+    moment the guard was widened from `--tab` to `--frame`: SKILL.md kept saying
+    "`agent` refuses a LEADING one and any `--tab`", so an agent routing off it
+    writes `browser --frame checkout-iframe agent "fill the form"` and gets rc 1
+    for a reason the file it read does not mention.
+
+    Derived from the guard itself: each `[ -z "$VAR" ] || die "agent cannot
+    honour ..."` line names a variable, and each variable has a flag spelling
+    SKILL.md must name.
+    """
+    cli = CLI.read_text(encoding="utf-8")
+    refused = set(re.findall(
+        r'\[ -z "\$([A-Z]+)" \][^\n]*\|\| die "agent cannot honour', cli))
+    assert refused, (
+        "no `agent cannot honour` refusals parsed out of the CLI — this guard "
+        "now checks nothing. Re-point it at whatever implements the refusal.")
+    flags = {v: f"--{v.lower()}" for v in refused}
+
+    skill = (BB / "SKILL.md").read_text(encoding="utf-8")
+    sentence = re.search(r"`agent` refuses[^\n]*(\n[^\n]*)?", skill)
+    assert sentence, ("SKILL.md no longer describes the `agent` refusal at all — "
+                      "re-point this guard rather than deleting it.")
+    text = sentence.group(0)
+    missing = {v: f for v, f in flags.items() if f"`{f}`" not in text}
+    assert not missing, (
+        f"the CLI refuses {sorted(flags.values())} for `agent`, but SKILL.md's "
+        f"refusal sentence does not name {sorted(missing.values())}. An agent "
+        f"reading SKILL.md will use it and get rc 1 with no warning there. "
+        f"Sentence: {text!r}")

--- a/scripts/browser-bridge/tests/test_browser_tab_ref.py
+++ b/scripts/browser-bridge/tests/test_browser_tab_ref.py
@@ -39,8 +39,10 @@ The 4 that were already green are labelled ``INVARIANT GUARD`` in place: they
 pin behaviour this change must NOT take away, and none of them is evidence the
 feature works.
 
-Audit round 1 added the `agent`, ``--`` and /whoami-shape cases; this file now
-holds 43. 🔴 Two of those additions FAILED IN THE NIX SANDBOX while passing on
+Audit rounds 1-3 added the `agent`, ``--``, /whoami-shape, SKILL.md-ledger and
+env-leak cases. (No count here on purpose: the first version of this paragraph
+carried one, and it was stale within the same session. Count the tests if you
+need the number.) 🔴 Two of those additions FAILED IN THE NIX SANDBOX while passing on
 the dev host, because they asserted that `browser agent` had reached the wire —
 which it does only once its model-backend prerequisites are met, and those come
 from the developer's own environment. They now key on `browser-agent`'s
@@ -159,6 +161,12 @@ def bridge(tmp_path):
     class _Bridge:
         handler = _Handler
         bodies = _Handler.bodies
+
+        @staticmethod
+        def env_for_stub():
+            """The same env `run` uses — for tests that invoke a COPY of the CLI
+            beside a stub `browser-agent`, rather than the real one."""
+            return dict(env)
 
         @staticmethod
         def run(*args, **kw):
@@ -488,29 +496,6 @@ def test_POSITIVE_CONTROL_the_missing_goal_error_is_producible(bridge):
         f"assertions below are vacuous. stderr was: {r.stderr!r}")
 
 
-def test_agent_still_works_with_an_explicit_instance(bridge):
-    """INVARIANT GUARD: the refusal above is scoped to the reference.
-
-    Refusing `--instance` too would break the documented way to target the agent,
-    which is the failure mode a too-wide guard would introduce here.
-
-    🔴 ASSERTS STDERR, NOT THE REQUEST BODIES, AND THAT IS THE FIX FOR A REAL
-    TWO-TIER BUG. An earlier version asserted that the agent path had sent
-    something to the bridge. It passed on the dev host and FAILED in the nix
-    sandbox — the tier the merge gates on — because `browser agent` reaches the
-    wire only once its model-backend prerequisites are satisfied, and those come
-    from the developer's own environment. The test was therefore a claim about
-    whoever ran it. `browser-agent` refuses a missing goal BEFORE any network or
-    backend work, so every assertion here is decided by argument parsing alone
-    and reads the same in both tiers.
-    """
-    r = bridge.run("--instance", "main", "agent", "--dry-run", "do a thing")
-    assert "agent cannot honour" not in r.stderr, (
-        "the reference guard fired on an explicit --instance: " + r.stderr)
-    assert "a goal is required" not in r.stderr, (
-        "the goal was eaten before browser-agent saw it: " + r.stderr)
-
-
 def test_the_free_text_list_covers_agent_too(bridge):
     """A TRAILING bw:// is a GOAL for `agent`, not a route.
 
@@ -663,12 +648,106 @@ def test_agent_refuses_a_tab_from_ANY_source(bridge, argv, env, source):
 
 
 def test_agent_without_any_tab_is_untouched(bridge):
-    """INVARIANT GUARD: the refusal is scoped to a TAB, not to `agent`.
+    """INVARIANT GUARD: the refusal is scoped to a ROUTING VARIABLE, not to `agent`.
 
     A guard widened onto the subcommand rather than the state would break the
     documented way to run the agent, which is the regression a too-wide fix
-    introduces here.
+    introduces here — and every widening in this ladder (bw:// -> --tab -> $BB_TAB
+    -> --frame -> $BB_FRAME) had to keep this case green.
+
+    This replaces a near-duplicate (`test_agent_still_works_with_an_explicit_
+    instance`) that had identical input and the same two assertions, differing
+    only in its failure text.
     """
     r = bridge.run("--instance", "main", "agent", "--dry-run", "do a thing")
     assert "agent cannot honour" not in r.stderr, r.stderr
     assert "a goal is required" not in r.stderr, r.stderr
+
+
+# --------------------------------------------------------------------------- #
+# `agent` refuses EVERY routing variable it cannot keep — and leaks none
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("argv, env, source, word", [
+    (["--frame", "evil.example", "--instance", "main", "agent", "g"], {},
+     "--frame", "frame"),
+    (["--instance", "main", "agent", "g"], {"BB_FRAME": "evil.example"},
+     "$BB_FRAME", "frame"),
+])
+def test_agent_refuses_a_frame_from_any_source(bridge, argv, env, source, word):
+    """🔴 The SECOND widening, found the same way as the first.
+
+    Keying the guard on `TAB` alone left the sibling routing variable untouched:
+    `browser --frame evil.example agent …` discarded the flag in silence — the
+    original defect's exact shape — and an exported `$BB_FRAME` reached
+    browser-agent while `_note_env_routing` announced a route `agent` had never
+    honoured. browser-agent accepts neither flag, so neither can mean anything
+    past this point.
+    """
+    r = bridge.run(*argv, env=env)
+    assert r.returncode != 0, r.stdout
+    assert f"agent cannot honour a {word}" in r.stderr, r.stderr
+    assert source in r.stderr, f"the refusal must name the source: {r.stderr}"
+    assert bridge.bodies == [], f"nothing may be dispatched: {bridge.bodies}"
+
+
+@pytest.mark.parametrize("var", ["BB_TAB", "BB_FRAME"])
+def test_the_agent_arm_does_not_LEAK_routing_env_to_its_children(bridge, tmp_path, var):
+    """🔴 The guard closes the DOOR; this closes the SEAM.
+
+    `--tab ""` is an explicit-empty that clears the shell variable while leaving
+    the EXPORT intact — and that is the idiom this file documents for
+    `--instance`. So an operator who exports BB_TAB, hits the refusal, and clears
+    it the documented way still hands browser-agent an environment in which every
+    child `browser` call routes to that tab: a confident answer about the wrong
+    page, rc 0, no error anywhere.
+
+    Driven against a STUB browser-agent that prints its inherited environment, so
+    this needs no model backend and reads the same in both tiers.
+    """
+    stub_dir = tmp_path / f"stub-{var}"
+    stub_dir.mkdir()
+    (stub_dir / "browser").write_text(CLI.read_text(encoding="utf-8"), encoding="utf-8")
+    (stub_dir / "browser-agent").write_text(
+        '#!/usr/bin/env bash\n'
+        f'printf "SEEN {var}=[%s]\\n" "${{{var}-<unset>}}"\n', encoding="utf-8")
+    (stub_dir / "browser-agent").chmod(0o755)
+
+    clear = {"--tab": '', "--frame": ''}["--tab" if var == "BB_TAB" else "--frame"]
+    flag = "--tab" if var == "BB_TAB" else "--frame"
+    r = subprocess.run(
+        ["bash", str(stub_dir / "browser"), flag, clear, "--instance", "main",
+         "agent", "some goal"],
+        env={**bridge.env_for_stub(), var: "999"},
+        capture_output=True, text=True, timeout=CLI_TIMEOUT_S)
+
+    assert "SEEN" in r.stdout, (
+        f"the stub agent never ran, so this test proves nothing: "
+        f"{r.stdout!r} / {r.stderr!r}")
+    assert f"SEEN {var}=[<unset>]" in r.stdout, (
+        f"{var} leaked into browser-agent's environment; its child `browser` "
+        f"calls would route with it. stdout: {r.stdout!r}")
+
+
+def test_POSITIVE_CONTROL_the_stub_agent_can_see_an_inherited_var(bridge, tmp_path):
+    """The two assertions above are ABSENCES — prove the stub can see a leak.
+
+    If the stub simply never observed the environment, `[<unset>]` would be
+    reported for a variable that WAS inherited, and the guard would pass while
+    testing nothing.
+    """
+    stub_dir = tmp_path / "stub-control"
+    stub_dir.mkdir()
+    (stub_dir / "browser").write_text(CLI.read_text(encoding="utf-8"), encoding="utf-8")
+    (stub_dir / "browser-agent").write_text(
+        '#!/usr/bin/env bash\nprintf "SEEN BB_INSTANCE=[%s]\\n" "${BB_INSTANCE-<unset>}"\n',
+        encoding="utf-8")
+    (stub_dir / "browser-agent").chmod(0o755)
+    # BB_INSTANCE is deliberately NOT unset by the agent arm — --instance IS
+    # forwarded, so inheriting it is consistent. That makes it the right control.
+    r = subprocess.run(
+        ["bash", str(stub_dir / "browser"), "agent", "some goal"],
+        env={**bridge.env_for_stub(), "BB_INSTANCE": "main"},
+        capture_output=True, text=True, timeout=CLI_TIMEOUT_S)
+    assert "SEEN BB_INSTANCE=[main]" in r.stdout, (
+        f"the stub cannot observe an inherited variable at all, so the leak "
+        f"assertions above are vacuous. stdout: {r.stdout!r}")

--- a/scripts/browser-bridge/tests/test_browser_tab_ref.py
+++ b/scripts/browser-bridge/tests/test_browser_tab_ref.py
@@ -53,6 +53,7 @@ Run: nix develop ~/workspace/devrc -c python3 -m pytest \\
 """
 import json
 import os
+import re
 import shutil
 import subprocess
 import threading
@@ -581,3 +582,93 @@ def test_an_unreadable_whoami_never_raises_and_fails_open(bridge, payload, why):
         assert "could not read" in r.stderr, (
             f"{why}: an unreadable SHAPE must be named as such, not reported as "
             f"an unidentifiable host")
+
+
+# --------------------------------------------------------------------------- #
+# SKILL.md names the exemption list — pin it to the CLI's
+# --------------------------------------------------------------------------- #
+def test_SKILL_md_names_every_free_text_subcommand_the_CLI_exempts():
+    """🔴 SKILL.md is the file an AGENT reads; the CLI header is not.
+
+    The exemption is a hand-maintained list in two places, in two languages, and
+    the failure is silent in the direction that matters: add a subcommand to
+    `REF_FREE_TEXT_SUBCOMMANDS` without updating SKILL.md and an agent reads
+    "either side of the op", writes `browser <that-sub> bw://…` expecting
+    routing, and instead sends the reference as TEXT — rc 0, wrong tab, no error.
+    That is the same class as the README permission list that had already gone
+    stale, and this file already carries a seam test of exactly this shape.
+
+    Pinned as a SET, so the order and the surrounding prose stay free.
+    """
+    cli = CLI.read_text(encoding="utf-8")
+    m = re.search(r'^REF_FREE_TEXT_SUBCOMMANDS="([^"]*)"', cli, re.M)
+    assert m, ("REF_FREE_TEXT_SUBCOMMANDS vanished from the CLI — this guard now "
+               "checks nothing. Re-point it at whatever defines the list.")
+    declared = set(m.group(1).split())
+    assert declared, "the CLI's exemption list parsed EMPTY — the pin would be vacuous"
+
+    skill = (BB / "SKILL.md").read_text(encoding="utf-8")
+    # 🔴 PIN THE EXEMPTION SENTENCE, NOT THE PARAGRAPH. The first version of this
+    # guard collected every `backticked` lowercase word in the surrounding
+    # paragraph — and SURVIVED its own negative control, because deleting `agent`
+    # from the exemption list left it named one sentence later ("`agent` REFUSES a
+    # leading one"). A guard satisfied by an unrelated mention of the word is
+    # satisfied by the very rot it exists to catch. Match the slash-separated run
+    # that carries the claim, and nothing else.
+    # `\s+`, not a literal space: SKILL.md is hard-wrapped, so the list can sit on
+    # the line after "For". The first version required a space and went red on a
+    # pure reflow — which was the guard behaving correctly (it said "re-point me"
+    # rather than passing), but the pattern should tolerate wrapping.
+    m2 = re.search(
+        r"For\s+((?:`[a-z]+`/)*`[a-z]+`)\s+it is a reference only BEFORE",
+        skill)
+    assert m2, ("SKILL.md's free-text exemption sentence is gone or reworded past "
+                "this pattern — re-point this guard rather than deleting it; "
+                "without it the list silently stops being a claim about the CLI.")
+    named = set(re.findall(r"`([a-z]+)`", m2.group(1)))
+    assert named, "the exemption sentence parsed EMPTY — the pin would be vacuous"
+    assert named == declared, (
+        f"SKILL.md's free-text list and the CLI's disagree. SKILL.md names "
+        f"{sorted(named)}; the CLI exempts {sorted(declared)}. An agent reading "
+        f"SKILL.md will expect routing for anything missing here and get TEXT — "
+        f"rc 0, wrong tab, no error.")
+
+
+# --------------------------------------------------------------------------- #
+# `agent` refuses a TAB, not a SPELLING
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("argv, env, source", [
+    (["--tab", "12345", "--instance", "main", "agent", "--dry-run", "g"], {}, "--tab"),
+    (["--instance", "main", "agent", "--dry-run", "g"], {"BB_TAB": "12345"}, "$BB_TAB"),
+])
+def test_agent_refuses_a_tab_from_ANY_source(bridge, argv, env, source):
+    """🔴 The first version of this guard refused only the `bw://` spelling, and
+    an audit walked around it in two steps.
+
+    `browser --tab 12345 agent …` reproduced the exact wrong answer the guard
+    exists to prevent — the tab discarded in silence, the agent answering about
+    its own blank tab — with no mention of the dropped flag. An exported
+    `$BB_TAB` was worse: it leaked into browser-agent's OWN child `browser`
+    calls, so the tab reappeared on the wire while `_note_env_routing` announced
+    a route `agent` had never honoured.
+
+    The guard now keys on the STATE (a tab is set) and names whichever source
+    supplied it, which is what makes it cover a hazard rather than a word.
+    """
+    r = bridge.run(*argv, env=env)
+    assert r.returncode != 0, r.stdout
+    assert "agent cannot honour a tab" in r.stderr, r.stderr
+    assert source in r.stderr, f"the refusal must name the source: {r.stderr}"
+    assert bridge.bodies == [], f"nothing may be dispatched: {bridge.bodies}"
+
+
+def test_agent_without_any_tab_is_untouched(bridge):
+    """INVARIANT GUARD: the refusal is scoped to a TAB, not to `agent`.
+
+    A guard widened onto the subcommand rather than the state would break the
+    documented way to run the agent, which is the regression a too-wide fix
+    introduces here.
+    """
+    r = bridge.run("--instance", "main", "agent", "--dry-run", "do a thing")
+    assert "agent cannot honour" not in r.stderr, r.stderr
+    assert "a goal is required" not in r.stderr, r.stderr

--- a/scripts/browser-bridge/tests/test_browser_tab_ref.py
+++ b/scripts/browser-bridge/tests/test_browser_tab_ref.py
@@ -31,13 +31,22 @@ RED-AT-BASE MATRIX. Measured against ``d202ef59`` (the commit before this
 change), with only the three new test files copied in:
 
     pytest  scripts/browser-bridge/tests/test_browser_tab_ref.py
-            29 FAILED / 4 passed at d202ef59  →  33 passed at HEAD
+            29 FAILED / 4 passed at d202ef59  →  33 passed at the first tip
     node    tests/tab_ref.test.mjs + tests/action_click.test.mjs
-            34 FAILED / 0 passed at d202ef59  →  34 passed at HEAD
+            34 FAILED / 0 passed at d202ef59  →  34 passed at the first tip
 
 The 4 that were already green are labelled ``INVARIANT GUARD`` in place: they
 pin behaviour this change must NOT take away, and none of them is evidence the
 feature works.
+
+Audit round 1 added the `agent`, ``--`` and /whoami-shape cases; this file now
+holds 43. 🔴 Two of those additions FAILED IN THE NIX SANDBOX while passing on
+the dev host, because they asserted that `browser agent` had reached the wire —
+which it does only once its model-backend prerequisites are met, and those come
+from the developer's own environment. They now key on `browser-agent`'s
+missing-goal refusal, which is decided before any network or backend work and
+therefore reads the same in both tiers. **Ask of any assertion here which tier
+it can be true in.**
 
 Run: nix develop ~/workspace/devrc -c python3 -m pytest \\
        scripts/browser-bridge/tests/test_browser_tab_ref.py -q
@@ -462,42 +471,62 @@ def test_agent_REFUSES_a_reference_rather_than_honouring_half_of_it(bridge):
     assert bridge.bodies == [], f"nothing may be dispatched: {bridge.bodies}"
 
 
+def test_POSITIVE_CONTROL_the_missing_goal_error_is_producible(bridge):
+    """🔴 The two tests below assert an ABSENCE, which is worth nothing until
+    the string is shown to be producible HERE, in THIS environment.
+
+    Both read "`a goal is required` must not appear". A typo in that literal, a
+    reworded error in `browser-agent`, or an environment where the agent path
+    dies even earlier would make each of them pass while testing nothing — the
+    reassuring-zero shape. This case feeds an input that MUST produce it (an
+    `agent` invocation with no goal at all) and watches the string appear.
+    """
+    r = bridge.run("agent", "--dry-run")
+    assert "a goal is required" in r.stderr, (
+        "the missing-goal error is not reachable here, so the two absence "
+        f"assertions below are vacuous. stderr was: {r.stderr!r}")
+
+
 def test_agent_still_works_with_an_explicit_instance(bridge):
     """INVARIANT GUARD: the refusal above is scoped to the reference.
 
     Refusing `--instance` too would break the documented way to target the agent,
     which is the failure mode a too-wide guard would introduce here.
 
-    🔴 ASSERTS THE REQUEST, NOT THE EXIT CODE, and deliberately. `browser agent`
-    drives a real model backend this stub does not provide, so it exits non-zero
-    here no matter what the parser did. What is under test is the ROUTING the CLI
-    produced, which is visible in the first body it sent — reading rc would make
-    this test a claim about the stub.
+    🔴 ASSERTS STDERR, NOT THE REQUEST BODIES, AND THAT IS THE FIX FOR A REAL
+    TWO-TIER BUG. An earlier version asserted that the agent path had sent
+    something to the bridge. It passed on the dev host and FAILED in the nix
+    sandbox — the tier the merge gates on — because `browser agent` reaches the
+    wire only once its model-backend prerequisites are satisfied, and those come
+    from the developer's own environment. The test was therefore a claim about
+    whoever ran it. `browser-agent` refuses a missing goal BEFORE any network or
+    backend work, so every assertion here is decided by argument parsing alone
+    and reads the same in both tiers.
     """
-    bridge.run("--instance", "main", "agent", "--dry-run", "do a thing")
-    assert bridge.bodies, "the agent path sent nothing at all — parse failed early"
-    assert bridge.bodies[0].get("target") == "main", bridge.bodies[0]
+    r = bridge.run("--instance", "main", "agent", "--dry-run", "do a thing")
+    assert "agent cannot honour" not in r.stderr, (
+        "the reference guard fired on an explicit --instance: " + r.stderr)
+    assert "a goal is required" not in r.stderr, (
+        "the goal was eaten before browser-agent saw it: " + r.stderr)
 
 
 def test_the_free_text_list_covers_agent_too(bridge):
-    """A TRAILING bw:// is a goal for `agent`, not a route.
+    """A TRAILING bw:// is a GOAL for `agent`, not a route.
 
     Dropping `agent` from REF_FREE_TEXT_SUBCOMMANDS SURVIVED an audit's mutation
-    because nothing exercised it. With it dropped the token is stripped from the
-    goal and turned into routing — visible here as a `target` that must not exist.
-    Same rc caveat as the test above.
+    because nothing exercised it. The discriminator is deterministic and needs no
+    backend: with `agent` on the list the reference survives as the goal, so
+    `browser-agent` gets one; with `agent` dropped, the token is stripped out as
+    routing and the agent is left with NO goal at all — which it refuses by name,
+    before any network work.
     """
-    bridge.run("agent", "--dry-run", CANONICAL)
-    assert bridge.bodies, "the agent path sent nothing at all — parse failed early"
-    # 🔴 Assert on the REFERENCE'S values, not on the mere presence of a `tab`.
-    # browser-agent legitimately sends `{"op":"close","tab":<its own>}` to tear
-    # down the tab IT opened; a blanket "no tab anywhere" assertion fails on that
-    # and would read as the parser leaking when it is the agent cleaning up.
-    for b in bridge.bodies:
-        assert b.get("target") != CANONICAL_INSTANCE, (
-            f"the reference was consumed as a route: {b}")
-        assert b.get("tab") != CANONICAL_TAB, (
-            f"the reference was consumed as a route: {b}")
+    r = bridge.run("agent", "--dry-run", CANONICAL)
+    assert "a goal is required" not in r.stderr, (
+        "the trailing reference was consumed as a route, leaving no goal: "
+        + r.stderr)
+    assert "agent cannot honour" not in r.stderr, (
+        "a TRAILING reference must be text for `agent`, not a refused route: "
+        + r.stderr)
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/run-node-tests.sh
+++ b/scripts/run-node-tests.sh
@@ -164,7 +164,7 @@ cd "$ROOT" || { echo "run-node-tests: cannot cd to ROOT=$ROOT" >&2; exit 2; }
 # (`nix build .#checks.x86_64-linux.nodetests`); floors sit just under the real
 # totals so ordinary test-writing does not trip them but a collapse does.
 #
-#   scripts/browser-bridge/tests        14 files   468 tests
+#   scripts/browser-bridge/tests        18 files   568 tests
 #   scripts/dl-router/tests             13 files   508 tests
 #   scripts/collector/browser-ext/tests  2 files    21 tests
 #
@@ -187,7 +187,7 @@ cd "$ROOT" || { echo "run-node-tests: cannot cd to ROOT=$ROOT" >&2; exit 2; }
 # move that turned the pytest global floor into less than half the real total.
 # A floor is a function of the measurement, not an opinion: `m - min(50, max(1, m/20))`.
 SUITES=(
-  "scripts/browser-bridge/tests|15|490"
+  "scripts/browser-bridge/tests|18|540"
   # Ungated until 2026-08-03: `FILES=` above named browser-bridge alone, so these
   # 508 tests had never run under any gate since dl-router was written.
   "scripts/dl-router/tests|13|500"


### PR DESCRIPTION
Picks up ranks 1 + 2 of `claudedocs/handoff-browser-bridge-architecture-trace.md`
(the doc that session pushed to `docs/browser-bridge-tab-ref-proposal`, still
unmerged). Claimed as `browser-bridge-architecture-trace-1` / `-2`.

## What it does

The manifest has always declared a click-only `action` — icon + title, no popup —
with **nothing listening**. Clicking the Browser Bridge toolbar icon did nothing
at all. It now copies a reference to the tab you are looking at:

```
click the icon  ->  bw://workbench/main/12345          (clipboard)
browser screenshot bw://workbench/main/12345           (routes back to that tab)
```

One token that expands into `--instance` + `--tab`, so "screenshot the tab I'm
on" stops needing two identifiers the operator cannot see.

## Two places the proposal was wrong, both found by building it

* **`navigator.clipboard.writeText()` is not reachable from an MV3 service
  worker** — there is no `document`. Injecting into the page instead needs that
  document *focused* (it is not, after a toolbar click) and is refused outright
  under a strict page CSP — so it would have failed precisely on GitHub, which is
  SKILL.md trap #2 arrived at from the other direction. The copy goes through an
  **offscreen document** (`reasons: ["CLIPBOARD"]`, `document.execCommand("copy")`),
  which is page-independent and works on `brave://` pages and PDFs too. New
  `offscreen` permission + `offscreen.{html,js}`.
* **"first 8 chars of the auto-id" does not route.** `server.py` resolves a
  target with `target in (inst.key, inst.instance_id)` — an exact match — so an
  abbreviated id fails as `unknown_instance` on first use. The reference carries
  the full routing key: the label when set, else the whole UUID.

## The host field is a check, not a route

The CLI only ever talks to `127.0.0.1`, so a reference minted on the workbench
and pasted into a laptop session cannot reach the tab it names — but it **can**
reach a same-labelled profile on *this* machine (labels are unique per host, not
across hosts) and drive the wrong browser while returning an ordinary envelope.
The CLI verifies the field against `/whoami` before dispatching anything.

It fails **closed on disagreement, open on ignorance**: a bridge that answers
`unknown` warns on stderr and proceeds, because refusing there would strand every
reference on a host with no `ACTIVITY_HOST` while catching nothing. The extension
takes the **opposite** side of that same call and refuses to *mint* a ref it
cannot verify — there is no second chance to check a token once it is on the
clipboard.

## Refusals over guesses

A malformed reference is refused rather than split into whichever three fields
fall out. A label containing `/`, a space or a quote is named rather than
mangled. A reference given *alongside* `--instance`/`--tab` is an error, not a
precedence question — whichever side lost, the command would run against a tab
the operator did not name.

Both argument positions work (`browser <ref> <op>` and the natural paste order
`browser <op> <ref>`), except for `type`/`js`/`eval`/`agent`, whose positional is
arbitrary operator text: there only the leading position is a reference, so
`browser type 'bw://…'` still types the literal string.

## Tests — red-at-base matrix

Measured against `d202ef59` with only the three new test files copied in:

| suite | at d202ef59 | at HEAD |
|---|---|---|
| `pytest tests/test_browser_tab_ref.py` | **29 FAILED** / 4 passed | 33 passed |
| `node tests/tab_ref.test.mjs` + `tests/action_click.test.mjs` | **34 FAILED** / 0 passed | 34 passed |

The 4 already-green are labelled `INVARIANT GUARD` in place — an ordinary command
must not grow a `/whoami` round trip, and the free-text subcommands must keep
treating a trailing `bw://` as text. Back-compat this change must not take away;
not evidence the feature works.

The click path has **no wire surface** — no op, no envelope, nothing the server
or CLI can see. So `action_click.test.mjs` asserts what landed on the clipboard
and, as much, what did not: a `{ok:false}` reply from `execCommand` is fatal
rather than a ✓ badge over an empty clipboard.

The format is pinned in **two** files on purpose. Nothing owns it: the extension
mints it in JS, the CLI consumes it in bash, no shared module, no schema. Both
ends pin the same literal, and a seam test reads `TAB_REF_SCHEME` out of
`protocol.js` and asserts the CLI still strips and dispatches on that exact value.

`SKILL.md`: net **−24 bytes** — the `bw://` line replaces the quick-start's
`--instance <key> --tab <id>` example, which the flags paragraph 30 lines below
already documents in full.

## Gate

| tier | result |
|---|---|
| `gate.sh --tier node --set all` | **PASS** — browser-bridge 549 tests (was 515) |
| `gate.sh --tier pytest --set all` (dev host) | browser-bridge **869 passed**; 1 failure, in `scripts/collector/keylog` |
| `nix build .#checks…pytests` (the Tekton tier) | browser-bridge **869 passed**; same 1 failure |

🔴 **That one failure is pre-existing on `main`, not from this change.**
`test_espanso_detect.py::test_live_existing_resolutions_not_made_ambiguous`,
`{'ask': (':acq', None, …), 'clarify': (':acq', None, …)}`. Control run: it fails
**identically at `origin/main` (d202ef59)** with nothing from this branch
present. It is what #1058 and #1060 are for. This PR touches nothing under
`scripts/collector/`, and until one of those lands the required check is red for
every PR.

## 🔴 NOT VERIFIED — the live gate is a human step

`reference/security-ops.md` makes live-verify against real Brave the only gate
that counts, and **this PR has not passed it**. What is claimed here is source +
two green test tiers, nothing more. The toolbar click is a genuine user gesture
that cannot be driven from the bridge, so:

1. merge → `git pull` → `home-manager switch` → **full Brave restart** (a reload ↻
   is unreliable; the `offscreen` permission is new)
2. `browser ping` → `buildMarker` must read `1d06f03fc740b26a`
3. click the icon on any tab → paste → expect `bw://<host>/<label>/<tabId>`
4. `browser screenshot <that ref>` → confirm it captured **that** tab
5. cross-host: paste a workbench ref into a laptop session → expect the loud
   refusal, not a screenshot

## Known gap, not closed here

`gen-build-marker.py` hashes `*.js` + `manifest.json`, so `offscreen.html` is
**not** covered by the build marker — an edit there would not move it and
`extension_stale` could not see it. Pre-existing (`options.html` has the same
hole). Mitigated by keeping that file inert: a textarea and a script tag, with
the comment saying so. Widening `marker_inputs` to `*.html` is a real fix and its
own PR.
