### PR TITLE
feat: quiesce-workload skill + scripts

### DIFF
--- a/claude/skill-tiers.json
+++ b/claude/skill-tiers.json
@@ -81,6 +81,10 @@
       "tier": "B",
       "why": "'prune the analyze-service index' -- named, not described; and the three prune-* siblings spend most of their prose disambiguating each other, which name-only makes moot"
     },
+    "quiesce-workload": {
+      "tier": "B",
+      "why": "called by name ('quiesce stash-sense', 'resume prometheus'); no symptom routes here -- you already know the workload"
+    },
     "prune-memory": {
       "tier": "B",
       "why": "'prune memory' / MEMORY.md is named explicitly whenever this is wanted"

--- a/claude/skills/quiesce-workload/SKILL.md
+++ b/claude/skills/quiesce-workload/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: quiesce-workload
+description: "Suspend a Flux workload (scale to 0) or resume. Finds cluster from PID or pod"
+argument-hint: "<name or PID> — e.g. 'stash-sense', '3828249', 'prometheus'"
+---
+
+# /quiesce-workload — suspend or resume a Flux-managed workload
+
+Input: `$ARGUMENTS`. This is either:
+- A **service/pod name** (e.g. `stash-sense`, `prometheus`)
+- A **PID** on the local machine (e.g. `3828249`)
+- A bare keyword to search for across clusters
+
+The script handles the deterministic action; you handle the investigation.
+
+## Step 1 — resolve the target
+
+### If input is a PID
+
+```bash
+# Get the container's cgroup to find the pod UID
+cat /proc/<PID>/cgroup | head -5
+
+# The cgroup path contains the pod UID (the long hex string after /pod/)
+# Search all clusters for that pod UID:
+KUBECONFIG=$KC_HOMELAB kubectl get pods -A -o json | jq -r '.items[] | select(.metadata.uid == "<UID>") | "\(.metadata.namespace) \(.metadata.name)"'
+KUBECONFIG=$KC_WORKBENCH kubectl get pods -A -o json | jq -r '.items[] | select(.metadata.uid == "<UID>") | "\(.metadata.namespace) \(.metadata.name)"'
+```
+
+Also check the process command for clues:
+```bash
+ps -p <PID> -o pid,ppid,cmd --no-headers
+```
+
+### If input is a name or keyword
+
+Search all three clusters:
+```bash
+KUBECONFIG=$KC_HOMELAB kubectl get pods -A | grep -i "<name>"
+KUBECONFIG=$KC_WORKBENCH kubectl get pods -A | grep -i "<name>"
+KUBECONFIG=$KC_PROD kubectl get pods -A | grep -i "<name>"
+```
+
+### Once you have namespace + pod name, find the deployment and kustomization
+
+```bash
+# Get the deployment name from the pod's ownerReferences
+KUBECONFIG=$KC_<CLUSTER> kubectl get pod <pod-name> -n <namespace> -o json | jq -r '.metadata.ownerReferences[] | select(.kind=="ReplicaSet") | .name'
+
+# Strip the replicaset suffix to get the deployment name
+# e.g. stash-sense-56d7bcbb9d-zkpzb → deployment is stash-sense
+
+# Find the matching Flux kustomization
+KUBECONFIG=$KC_<CLUSTER> kubectl get kustomizations -A | grep -i "<deployment-or-part-of-it>"
+```
+
+🔴 **The kustomization name may not match the deployment name exactly.** Match by substring or check the kustomization's `spec.targetRef`.
+
+## Step 2 — run the script
+
+Once you have: `<cluster> <namespace> <kustomization> [deployment]`
+
+### To quiesce (suspend + scale to 0):
+
+```bash
+bash ~/workspace/devrc/scripts/quiesce-workload.sh <cluster> <namespace> <kustomization> [deployment]
+```
+
+### To resume (unsuspend + scale back up):
+
+```bash
+bash ~/workspace/devrc/scripts/resume-workload.sh <cluster> <namespace> <kustomization> [deployment] [replicas]
+```
+
+The `deployment` argument is needed only when it differs from the kustomization name. `replicas` defaults to 1.
+
+## Step 3 — report
+
+State what was done:
+- Which cluster, namespace, kustomization
+- The CPU/memory it was consuming (from the initial `ps` or pod metrics)
+- That it's terminating / scaled to 0
+- The resume command for when they want it back
+
+## Reference — cluster handles
+
+| Cluster | Handle | Use for |
+|---|---|---|
+| homelab | `$KC_HOMELAB` | Talos Linux, GitOps via Flux |
+| workbench | `$KC_WORKBENCH` | NixOS + k3s, media stack, SGLang |
+| prod | `$KC_PROD` | Hetzner k0s, production |
+
+All handles are exported in `~/.zshenv` and injected into opencode's bash tool via the env plugin.

--- a/scripts/quiesce-workload.sh
+++ b/scripts/quiesce-workload.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# quiesce — suspend a Flux kustomization and scale its deployment to 0.
+#
+# Deterministic primitive for killing a flux-managed workload. The agent
+# figures out WHICH kustomization/deployment; this script does the action.
+#
+# Usage:
+#   quiesce-workload.sh <cluster> <namespace> <kustomization> [deployment]
+#
+# Examples:
+#   quiesce-workload.sh workbench media-stack stash-sense
+#   quiesce-workload.sh homelab monitoring prometheus-prometheus
+#
+# Cluster is matched against the kubeconfig handles exported in .zshenv:
+#   homelab   → $KC_HOMELAB
+#   workbench → $KC_WORKBENCH
+#   prod      → $KC_PROD
+#
+# Exit codes:
+#   0  success — kustomization suspended, deployment scaled to 0
+#   1  usage / bad cluster name
+#   2  flux suspend failed
+#   3  kubectl scale failed
+#   4  verification failed (pod not terminating)
+#
+# To resume:  resume-workload.sh <cluster> <namespace> <kustomization> [deployment]
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <cluster> <namespace> <kustomization> [deployment]" >&2
+  echo "  cluster: homelab | workbench | prod" >&2
+  exit 1
+fi
+
+CLUSTER="$1"
+NAMESPACE="$2"
+KUSTOMIZATION="$3"
+DEPLOYMENT="${4:-$KUSTOMIZATION}"
+
+case "$CLUSTER" in
+  homelab)   KC="${KC_HOMELAB:?KC_HOMELAB not set}" ;;
+  workbench) KC="${KC_WORKBENCH:?KC_WORKBENCH not set}" ;;
+  prod)      KC="${KC_PROD:?KC_PROD not set}" ;;
+  *) echo "Unknown cluster: $CLUSTER (expected homelab | workbench | prod)" >&2; exit 1 ;;
+esac
+
+echo "→ Suspending kustomization $KUSTOMIZATION (flux-system) on $CLUSTER..."
+if ! KUBECONFIG="$KC" flux suspend kustomization "$KUSTOMIZATION" -n flux-system; then
+  echo "ERROR: flux suspend failed" >&2
+  exit 2
+fi
+
+echo "→ Scaling deployment $DEPLOYMENT in $NAMESPACE to 0..."
+if ! KUBECONFIG="$KC" kubectl scale deployment "$DEPLOYMENT" -n "$NAMESPACE" --replicas=0; then
+  echo "ERROR: kubectl scale failed" >&2
+  exit 3
+fi
+
+echo "→ Verifying pod termination..."
+sleep 2
+PODS=$(KUBECONFIG="$KC" kubectl get pods -n "$NAMESPACE" -l "app=$DEPLOYMENT" --no-headers 2>/dev/null || true)
+if echo "$PODS" | grep -q Terminating; then
+  echo "OK: pod terminating"
+elif echo "$PODS" | grep -q "No resources found"; then
+  echo "OK: no pods remaining"
+elif [[ -z "$PODS" ]]; then
+  echo "OK: no matching pods found (label may differ — check manually)"
+else
+  echo "WARNING: pods still present:" >&2
+  echo "$PODS" >&2
+  exit 4
+fi
+
+echo ""
+echo "Done. Workload $KUSTOMIZATION quiesced on $CLUSTER."
+echo "To resume: resume-workload.sh $CLUSTER $NAMESPACE $KUSTOMIZATION $DEPLOYMENT"

--- a/scripts/resume-workload.sh
+++ b/scripts/resume-workload.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# resume — unsuspend a Flux kustomization and scale its deployment back up.
+#
+# Inverse of quiesce-workload.sh. Restores a workload that was suspended + scaled
+# to 0 by the quiesce script.
+#
+# Usage:
+#   resume-workload.sh <cluster> <namespace> <kustomization> [deployment] [replicas]
+#
+# Examples:
+#   resume-workload.sh workbench media-stack stash-sense
+#   resume-workload.sh homelab monitoring prometheus-prometheus 2
+#
+# Exit codes:
+#   0  success — kustomization resumed, deployment scaled up
+#   1  usage / bad cluster name
+#   2  flux resume failed
+#   3  kubectl scale failed
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <cluster> <namespace> <kustomization> [deployment] [replicas]" >&2
+  echo "  cluster: homelab | workbench | prod" >&2
+  echo "  replicas: defaults to 1" >&2
+  exit 1
+fi
+
+CLUSTER="$1"
+NAMESPACE="$2"
+KUSTOMIZATION="$3"
+DEPLOYMENT="${4:-$KUSTOMIZATION}"
+REPLICAS="${5:-1}"
+
+case "$CLUSTER" in
+  homelab)   KC="${KC_HOMELAB:?KC_HOMELAB not set}" ;;
+  workbench) KC="${KC_WORKBENCH:?KC_WORKBENCH not set}" ;;
+  prod)      KC="${KC_PROD:?KC_PROD not set}" ;;
+  *) echo "Unknown cluster: $CLUSTER (expected homelab | workbench | prod)" >&2; exit 1 ;;
+esac
+
+echo "→ Resuming kustomization $KUSTOMIZATION (flux-system) on $CLUSTER..."
+if ! KUBECONFIG="$KC" flux resume kustomization "$KUSTOMIZATION" -n flux-system; then
+  echo "ERROR: flux resume failed" >&2
+  exit 2
+fi
+
+echo "→ Scaling deployment $DEPLOYMENT in $NAMESPACE to $REPLICAS..."
+if ! KUBECONFIG="$KC" kubectl scale deployment "$DEPLOYMENT" -n "$NAMESPACE" --replicas="$REPLICAS"; then
+  echo "ERROR: kubectl scale failed" >&2
+  exit 3
+fi
+
+echo ""
+echo "Done. Workload $KUSTOMIZATION resumed on $CLUSTER (replicas=$REPLICAS)."
+echo "Flux will reconcile to the desired state on its next loop."


### PR DESCRIPTION
Adds deterministic scripts and agent skill for suspending/resuming Flux-managed workloads.

**Scripts:**
- `quiesce-workload.sh` — suspend kustomization + scale deployment to 0 + verify
- `resume-workload.sh` — unsuspend + scale back up

**Skill:**
- `claude/skills/quiesce-workload/SKILL.md` — agent investigation logic (PID → cgroup → pod UID → cluster → kustomization)

**Usage:** `/quiesce-workload stash-sense` in opencode (auto-generated from skill), or `bash scripts/quiesce-workload.sh workbench media-stack stash-sense` directly.