### PR TITLE
fix(skill-tiers): re-pin the measurements after quiesce-workload landed — main is red

### DIFF
--- a/scripts/tests/test_skill_tiers.py
+++ b/scripts/tests/test_skill_tiers.py
@@ -83,14 +83,14 @@ MIN_SKILLS = 30
 # 36-entry total quoted in a 37-entry tree, and one contradicted the number the
 # same change reported to its reviewer.
 # --------------------------------------------------------------------------- #
-MEASURED_ENTRIES = 37
+MEASURED_ENTRIES = 38
 MEASURED_TIER_A_ENTRIES = 24
 MEASURED_TIER_A_CHARS = 8_909
 # devrc's whole listing under the ledger (tier A in full, tier B name-only).
-MEASURED_UNDER_LEDGER_CHARS = 9_101
+MEASURED_UNDER_LEDGER_CHARS = 9_120
 # ...and what the same 37 entries would cost with every skill tier A. The
 # difference is what the ledger buys: 3,907 chars.
-MEASURED_ALL_TIER_A_CHARS = 13_008
+MEASURED_ALL_TIER_A_CHARS = 13_106
 
 # 🔴 THE TIER-A RATCHET, in the REAL formula: the tier-A block cost
 # `sum(len(name) + 4 + min(len(desc), 1536)) + (n - 1)`.


### PR DESCRIPTION
`scripts/tests/test_skill_tiers.py::test_the_quoted_measurements_match_the_live_tree` **fails on pristine `origin/main`** at `c8223366`.

#1066 added the `quiesce-workload` skill and its tier-B ledger entry, which moves three of the five quoted measurements. The re-pin did not land with it.

**Verified as a property of `main`, not of a branch** — the test fails in a clean detached worktree at `origin/main` with no other changes:

```
FAILED scripts/tests/test_skill_tiers.py::test_the_quoted_measurements_match_the_live_tree
1 failed, 40 passed
```

Values copied **verbatim from what the test prints on failure**, not recomputed by hand — which is what its own message and `CLAUDE.md` both instruct:

| | before | after |
|---|---|---|
| `MEASURED_ENTRIES` | 37 | 38 |
| `MEASURED_UNDER_LEDGER_CHARS` | 9_101 | 9_120 |
| `MEASURED_ALL_TIER_A_CHARS` | 13_008 | 13_106 |

`MEASURED_TIER_A_ENTRIES` (24) and `MEASURED_TIER_A_CHARS` (8_909) are **unchanged**, which is the tell that the new skill is tier B: a name-only entry costs the listing ~12 chars and spends none of the tier-A ratchet. Nothing here touches `TIER_A_CEILING_CHARS` — this re-pins the *description* of the tree; it does not move the ratchet.

After: `41 passed`.

⚠ Both required checks gate on this and `enforce_admins` is true, so while it is red **nothing merges**. This is not a cosmetic pin — it is currently blocking every open PR, including #1065.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKNxp2cPBhJ8pK5wW6hhc2
