### PR TITLE
feat(run-tests): --targets, so a run can cover a SUBSET of the target list — plus the one guard that was blind to partial runs

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -176,6 +176,8 @@ trap 'exit 130' INT
 
 SET="hermetic"
 ROOT=""
+# Empty = run the whole selected SET. Populated only by --targets/DEVRC_TARGETS.
+ONLY_TARGETS="${DEVRC_TARGETS:-}"
 CHECK_TARGETS_ONLY=0
 CHECK_FLOORS_ONLY=0
 while [ $# -gt 0 ]; do
@@ -189,6 +191,11 @@ while [ $# -gt 0 ]; do
     # Same idea for GUARD 3's floor table: validate the two-way pin between
     # TARGET_FLOORS and the target list, print the table, exit. No pytest.
     --check-floors) CHECK_FLOORS_ONLY=1; shift ;;
+    # Run a SUBSET of the target list. Space-separated, and every entry must
+    # already be a declared target — see the ONLY_TARGETS block below for why
+    # this cannot be a free-form path filter.
+    --targets) ONLY_TARGETS="${2:-}"; shift; [ $# -gt 0 ] && shift ;;
+    --targets=*) ONLY_TARGETS="${1#*=}"; shift ;;
     *) ROOT="$1"; shift ;;
   esac
 done
@@ -747,6 +754,60 @@ DEVHOST_TARGETS=(
 TARGETS=("${HERMETIC_TARGETS[@]}")
 if [ "$SET" = "all" ]; then
   TARGETS+=("${DEVHOST_TARGETS[@]}")
+fi
+
+# --- TARGET SUBSET (--targets / DEVRC_TARGETS) --------------------------------
+# 🔴 A SUBSET IS A CLAIM THAT THE UNSELECTED TARGETS COULD NOT HAVE CAUGHT THE
+# CHANGE, and nothing here can check that claim. So this mechanism is built to
+# make the DANGEROUS mistakes loud and the safe ones cheap:
+#
+#   * An UNKNOWN target is FATAL, never silently dropped. A typo'd path that
+#     quietly selected nothing would exit 0 having run nothing, which is the
+#     single worst outcome a test runner has — it reads exactly like a pass.
+#     (`run-tests.sh --targets scripts/dl-router` — no `/tests` — is the shape
+#     that would otherwise do it.)
+#   * An EMPTY selection is FATAL for the same reason. "Nothing to run" is
+#     never a verdict this script is allowed to reach.
+#   * Selection NARROWS the SET, it does not widen it: asking for a devhost
+#     target under `--set hermetic` is an unknown-target error, not an implicit
+#     `--set all`.
+#
+# ⚠ The FLOOR follows automatically and that is not luck — GUARD 3's global
+# floor is already computed as the SUM OVER `$TARGETS` (see MIN_TESTS_COMPUTED),
+# so narrowing this array narrows the floor with it. Verified by probe: a
+# 2-target run reported `floor: 575 = sum of 2 per-target floors`.
+#
+# 📖 What this does NOT do: pick the targets for you. Mapping changed paths to
+# targets is a separate, fallible decision and lives outside this script.
+if [ -n "$ONLY_TARGETS" ]; then
+  _requested=()
+  # shellcheck disable=SC2206
+  _requested=($ONLY_TARGETS)
+  if [ "${#_requested[@]}" -eq 0 ]; then
+    echo "run-tests: FATAL — --targets was given but resolved to NOTHING." >&2
+    echo "           A run that selects no targets would exit 0 having tested" >&2
+    echo "           nothing. Omit --targets to run the whole '$SET' set." >&2
+    exit 3
+  fi
+  _selected=()
+  for _r in "${_requested[@]}"; do
+    _hit=0
+    for _t in "${TARGETS[@]}"; do
+      [ "$_r" = "$_t" ] && { _hit=1; break; }
+    done
+    if [ "$_hit" -eq 0 ]; then
+      echo "run-tests: FATAL — --targets names '$_r', which is not a target in the '$SET' set." >&2
+      echo "           Targets are exact entries of HERMETIC_TARGETS (plus" >&2
+      echo "           DEVHOST_TARGETS under --set all), not path prefixes." >&2
+      echo "           Run with --check-targets to print the declared list." >&2
+      exit 3
+    fi
+    _selected+=("$_r")
+  done
+  TARGETS=("${_selected[@]}")
+  echo "run-tests: SUBSET — ${#TARGETS[@]} of the '$SET' set selected via --targets." >&2
+  echo "           Unselected targets did NOT run; this verdict is about the" >&2
+  echo "           selected ones only." >&2
 fi
 
 # --- GUARD 3's floor table: PER-TARGET, and NOT an exact total -----------------
@@ -1971,7 +2032,15 @@ if [ "$CHECK_FLOORS_ONLY" -eq 1 ]; then
     fi
   done
   echo "  ----"
-  echo "  GLOBAL floor (sum over the $SET set) = $MIN_TESTS_COMPUTED"
+  # 🔴 SAY WHICH SET IT SUMMED. With `--targets` this is the sum over the
+  # SELECTED targets, not over `$SET` — printing "the hermetic set" there is a
+  # false claim about coverage, and the number it labels is exactly the one a
+  # reader uses to decide whether the run was complete.
+  if [ -n "$ONLY_TARGETS" ]; then
+    echo "  GLOBAL floor (sum over the ${#TARGETS[@]} SELECTED target(s), a SUBSET of $SET) = $MIN_TESTS_COMPUTED"
+  else
+    echo "  GLOBAL floor (sum over the $SET set) = $MIN_TESTS_COMPUTED"
+  fi
   exit 0
 fi
 
@@ -3646,6 +3715,52 @@ _split_skip_entry() {
 # the entry applies HERE, 1 if not. An invalid condition sets `fail` and returns
 # 1 — fail CLOSED, so a typo cannot silently widen a pin.
 _skip_entry_applies() {
+  # 🔴 AN ENTRY WHOSE TARGET DID NOT RUN CANNOT APPLY. This half is separate
+  # from the condition below and was missing until 2026-08-30, when `--targets`
+  # made a partial run reachable: a 2-target subset reported
+  #   ERROR: 1 test(s) skipped, but 2 of 3 pinned entries apply here.
+  # because the signal/Postgres pin was counted while `scripts/signal/tests`
+  # was not in the run at all. The run was correct and the guard called it a
+  # failure — the exact way a gate teaches people to ignore it.
+  #
+  # ⚠ Ordered FIRST deliberately. The condition arm below can set `fail` on a
+  # malformed entry, and an entry belonging to a target this run never touched
+  # must not be able to fail the run. It is still validated on any run that
+  # DOES include its target, which is every full run.
+  # ⚠ GATED ON A SUBSET BEING ACTIVE, and that is not a shortcut — an
+  # unconditional version broke 8 tests in test_conditional_skip_pins.py.
+  # Those drive this predicate with SYNTHETIC ledgers whose entries name dirs
+  # that are not real targets, which is the only way to exercise the condition
+  # grammar (invalid `unset:`, a 4-field entry, an unknown prefix) without
+  # inventing a real skip. Filtering unconditionally made every synthetic entry
+  # inapplicable, so those tests counted ZERO applicable pins and the grammar
+  # checks they exist for stopped running — a guard silently disabled by a
+  # change that looked like a strict improvement.
+  #
+  # 🔴 AND DO NOT WRITE THAT COUNTER'S NAME IN A COMMENT HERE. The harness in
+  # test_conditional_skip_pins.py extracts the real blocks out of this file by
+  # UNIQUE text anchors and asserts each occurs exactly once; the first draft of
+  # this comment quoted the anchor verbatim and broke the extraction — 11 tests
+  # red, from a comment. Prose in this file is load-bearing.
+  #
+  # On a FULL run every EXPECTED_SKIPS dir is a declared target anyway (pinned
+  # by test_a_pinned_skip_... and verified: all three are exact targets), so
+  # this gate costs nothing there and changes behaviour only where the defect
+  # lived.
+  # 🔴 `${ONLY_TARGETS:-}`, NOT `$ONLY_TARGETS`. This function is EXTRACTED from
+  # this file and executed standalone under `bash -uo pipefail` by
+  # test_conditional_skip_pins.py, where neither this variable nor TARGETS
+  # exists. A bare expansion is an unbound-variable abort there — exit 127,
+  # 11 tests red, and the message points at a line number in a synthesised
+  # harness rather than at this file. The default keeps the extracted copy
+  # runnable, and in the real script the variable is always set anyway.
+  if [ -n "${ONLY_TARGETS:-}" ]; then
+    local _in_run=0 _t
+    for _t in "${TARGETS[@]}"; do
+      [ "$edir" = "$_t" ] && { _in_run=1; break; }
+    done
+    if [ "$_in_run" -eq 0 ]; then return 1; fi
+  fi
   case "$econd" in
     "") return 0 ;;
     unset:*)

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -207,14 +207,33 @@ ROOT=""
 ONLY_TARGETS="${DEVRC_TARGETS:-}"
 ONLY_TARGETS_GIVEN=0
 ONLY_TARGETS_SOURCE=""
+# 🔴 THE FLAG AND THE ENV VAR ARE TRACKED SEPARATELY, and the reason is a
+# regression this file already shipped once: a single `--targets` on a shell
+# where DEVRC_TARGETS happened to be exported was rejected as
+# "--targets given more than once", naming no environment variable, so the only
+# remedy (`env -u DEVRC_TARGETS`) appeared nowhere and the advice printed was
+# already satisfied. It also broke the ordinary precedence every other tool
+# here has — an explicit flag OVERRIDES ambient configuration.
+#
+# So: only a REPEATED FLAG is fatal. The flag beats the environment and SAYS it
+# did, because a selection the operator did not type is the one worth naming.
+ONLY_TARGETS_FLAG_GIVEN=0
+ONLY_TARGETS_ENV_GIVEN=0
 if [ -n "${DEVRC_TARGETS+x}" ]; then
   ONLY_TARGETS_GIVEN=1
+  ONLY_TARGETS_ENV_GIVEN=1
   ONLY_TARGETS_SOURCE="the DEVRC_TARGETS environment variable"
 fi
 # Set once the full target list is known, so the SUBSET note can say "N of M"
 # rather than a bare N that reads like a total.
 SET_TOTAL=0
-# Appended to the SUMMARY banner and the RESULT line. Empty on a full run.
+# Appended to the SUMMARY banner and to the PARTIAL RUN block below it. Empty on
+# a full run.
+#
+# 🔴 NOT to the `RESULT:` line, and do NOT add it there — that line is matched
+# `^RESULT: (PASS|FAIL) \(exit=(\d+)\)$`, ANCHORED AT BOTH ENDS, by
+# test_gate_exit_truthfulness.py. A draft of this feature appended to it and the
+# anchored assertion was the only thing that objected. See `_emit_verdict`.
 SUBSET_NOTE=""
 CHECK_TARGETS_ONLY=0
 CHECK_FLOORS_ONLY=0
@@ -239,12 +258,20 @@ while [ $# -gt 0 ]; do
     # nobody is watching. This whole block's doctrine is that a selection
     # mistake must be loud.
     --targets|--targets=*)
-      if [ "$ONLY_TARGETS_GIVEN" -eq 1 ]; then
+      if [ "$ONLY_TARGETS_FLAG_GIVEN" -eq 1 ]; then
         echo "run-tests: FATAL — --targets given more than once." >&2
         echo "           Last-wins would silently discard the earlier selection." >&2
         echo "           Pass ONE --targets with the whole space-separated list." >&2
         exit 3
       fi
+      # The flag WINS over an ambient DEVRC_TARGETS rather than colliding with
+      # it. Announced, not silent: a value the operator did not type is exactly
+      # the one that should be named when it is overridden.
+      if [ "$ONLY_TARGETS_ENV_GIVEN" -eq 1 ]; then
+        echo "run-tests: --targets OVERRIDES the DEVRC_TARGETS environment variable" >&2
+        echo "           (env value: '${ONLY_TARGETS}'). The flag wins." >&2
+      fi
+      ONLY_TARGETS_FLAG_GIVEN=1
       ONLY_TARGETS_GIVEN=1
       ONLY_TARGETS_SOURCE="--targets"
       case "$1" in
@@ -861,9 +888,18 @@ if [ "$ONLY_TARGETS_GIVEN" -eq 1 ]; then
   _requested=($ONLY_TARGETS)
   set +f
   if [ "${#_requested[@]}" -eq 0 ]; then
-    echo "run-tests: FATAL — --targets was given but resolved to NOTHING." >&2
+    # 🔴 NAME THE KNOB THAT IS ACTUALLY SET. A set-but-EMPTY DEVRC_TARGETS
+    # reaches here with no `--targets` on the command line, and telling that
+    # operator to "omit --targets" is advice they have already followed — the
+    # remedy is `unset DEVRC_TARGETS`, which must therefore appear.
+    echo "run-tests: FATAL — ${ONLY_TARGETS_SOURCE} was given but resolved to NOTHING." >&2
     echo "           A run that selects no targets would exit 0 having tested" >&2
-    echo "           nothing. Omit --targets to run the whole '$SET' set." >&2
+    echo "           nothing." >&2
+    if [ "$ONLY_TARGETS_FLAG_GIVEN" -eq 1 ]; then
+      echo "           Omit --targets to run the whole '$SET' set." >&2
+    else
+      echo "           \`unset DEVRC_TARGETS\` to run the whole '$SET' set." >&2
+    fi
     exit 3
   fi
   _selected=()
@@ -873,7 +909,7 @@ if [ "$ONLY_TARGETS_GIVEN" -eq 1 ]; then
       [ "$_r" = "$_t" ] && { _hit=1; break; }
     done
     if [ "$_hit" -eq 0 ]; then
-      echo "run-tests: FATAL — --targets names '$_r', which is not a target in the '$SET' set." >&2
+      echo "run-tests: FATAL — ${ONLY_TARGETS_SOURCE} names '$_r', which is not a target in the '$SET' set." >&2
       echo "           Targets are exact entries of HERMETIC_TARGETS (plus" >&2
       echo "           DEVHOST_TARGETS under --set all), not path prefixes." >&2
       echo "           Run with --check-targets to print the declared list." >&2
@@ -893,7 +929,7 @@ if [ "$ONLY_TARGETS_GIVEN" -eq 1 ]; then
     # anyone reading the mapper's own output.
     for _s in ${_selected[@]+"${_selected[@]}"}; do
       if [ "$_s" = "$_r" ]; then
-        echo "run-tests: FATAL — --targets names '$_r' more than once." >&2
+        echo "run-tests: FATAL — ${ONLY_TARGETS_SOURCE} names '$_r' more than once." >&2
         echo "           A duplicate runs one suite twice and counts it twice," >&2
         echo "           inflating the collected total AND the derived floor, so" >&2
         echo "           the run satisfies a floor its own duplication created." >&2
@@ -904,7 +940,11 @@ if [ "$ONLY_TARGETS_GIVEN" -eq 1 ]; then
     _selected+=("$_r")
   done
   TARGETS=("${_selected[@]}")
-  # Carried into the SUMMARY header and the RESULT line — see GUARD 6. stderr
+  # Carried into the SUMMARY header and the PARTIAL RUN block below it.
+  # 🔴 NOT into the `RESULT:` line — see `_emit_verdict`, whose format is pinned
+  # anchored-at-both-ends. An earlier version of THIS COMMENT said "and the
+  # RESULT line — see GUARD 6", which is an instruction to re-create the defect
+  # the same commit had just removed. stderr
   # alone is not enough: `gate.sh` prints from the SUMMARY banner DOWN, so
   # anything announced above it is invisible on the surface CLAUDE.md tells
   # people to read.
@@ -913,7 +953,10 @@ if [ "$ONLY_TARGETS_GIVEN" -eq 1 ]; then
   # harder of the two to notice. Saying which one selected turns "why did this
   # only run 3 targets" into a one-line answer.
   SUBSET_NOTE=" — SUBSET: ${#TARGETS[@]} of ${SET_TOTAL} ${SET} target(s) via ${ONLY_TARGETS_SOURCE}"
-  echo "run-tests: SUBSET — ${#TARGETS[@]} of the '$SET' set selected via ${ONLY_TARGETS_SOURCE}." >&2
+  # "N of M", never a bare N: the denominator is what makes this a coverage
+  # statement rather than a count. Same reason SET_TOTAL is captured before
+  # narrowing.
+  echo "run-tests: SUBSET: ${#TARGETS[@]} of ${SET_TOTAL} '$SET' target(s) selected via ${ONLY_TARGETS_SOURCE}." >&2
   echo "           Unselected targets did NOT run; this verdict is about the" >&2
   echo "           selected ones only." >&2
 fi
@@ -2063,7 +2106,17 @@ if [ "${#bad_targets[@]}" -gt 0 ]; then
 fi
 
 if [ "$CHECK_TARGETS_ONLY" -eq 1 ]; then
-  echo "run-tests: all ${#TARGETS[@]} $SET target(s) resolve."
+  # 🔴 SAY WHEN THIS IS A SUBSET. `all N hermetic target(s) resolve` after
+  # validating ONE entry of twenty-eight is the same false full-set claim F3
+  # fixed on the floor table and F1 fixed in the SUMMARY banner — this is the
+  # third early-exit surface, and it was missed twice because the three are
+  # nowhere near each other. GUARD 5's coverage is exactly the selection.
+  if [ -n "$SUBSET_NOTE" ]; then
+    echo "run-tests: all ${#TARGETS[@]} SELECTED target(s) resolve — a SUBSET of the $SET set (${SET_TOTAL} target(s)), via ${ONLY_TARGETS_SOURCE}."
+    echo "           GUARD 5 did NOT validate the unselected ones."
+  else
+    echo "run-tests: all ${#TARGETS[@]} $SET target(s) resolve."
+  fi
   for t in "${TARGETS[@]}"; do
     if [ -d "$t" ]; then echo "  dir   $t"; else echo "  file  $t"; fi
   done
@@ -2144,7 +2197,7 @@ if [ "$CHECK_FLOORS_ONLY" -eq 1 ]; then
       # set, which is the same false-label defect fixed on the GLOBAL line one
       # screen below, missed here because the two are not adjacent.
       if [ -n "$SUBSET_NOTE" ]; then
-        echo "  floor ${entry##*|}  ${_ft}  [not SELECTED by --targets — excluded from the global sum]"
+        echo "  floor ${entry##*|}  ${_ft}  [not SELECTED by ${ONLY_TARGETS_SOURCE} — excluded from the global sum]"
       else
         echo "  floor ${entry##*|}  ${_ft}  [not in the $SET set — excluded from the global sum]"
       fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -97,14 +97,29 @@
 #              measurement. Raise it, don't lower it. Per-target floors have no
 #              env override on purpose — the whole point is that they are
 #              reviewed edits.
+#   DEVRC_TARGETS
+#              same as `--targets` (see Usage), for callers that cannot add an
+#              argument. 🔴 An EXPORTED value applies to every run-tests.sh in
+#              the shell, including ones you did not mean to narrow — the
+#              pre-push hook's, and any nested run a test spawns. A subset run
+#              says so in the SUMMARY banner and names this variable as the
+#              source, precisely because nobody TYPED it and it is therefore
+#              the harder of the two to notice. Prefer the flag; export this
+#              only for the length of one command.
 #
 # Usage:
-#   scripts/run-tests.sh [--set hermetic|all] [--check-targets] [--check-floors] [ROOT]
+#   scripts/run-tests.sh [--set hermetic|all] [--check-targets] [--check-floors]
+#                        [--targets "<t1> <t2> ..."] [ROOT]
 #     --set hermetic  (default) — targets safe to run offline in the nix sandbox.
 #     --set all                 — hermetic + any targets deferred to the dev host.
 #     --check-targets           — run GUARD 5 only (validate the target list and
 #                                 exit; no pytest, no tool precondition). Cheap
 #                                 enough to be exercised by a unit test.
+#     --targets "<list>"        — run only these targets, space-separated. Each
+#                                 must be an EXACT entry of the selected set;
+#                                 an unknown name, a duplicate, an empty value
+#                                 or a repeated flag is FATAL (exit 3). Also
+#                                 settable as DEVRC_TARGETS.
 #     --check-floors            — run GUARD 3a only (validate the TARGET_FLOORS
 #                                 two-way pin, print the table and the derived
 #                                 global floor, exit). Same reason: cheap.
@@ -146,6 +161,14 @@ _emit_verdict() {
   local rc="$1"
   [ "$VERDICT_EMITTED" -eq 0 ] || return 0
   VERDICT_EMITTED=1
+  # 🔴 THIS LINE'S FORMAT IS A MACHINE CONTRACT — DO NOT APPEND TO IT.
+  # `test_gate_exit_truthfulness.py` matches it with `^RESULT: (PASS|FAIL)
+  # \(exit=(\d+)\)$`, ANCHORED AT BOTH ENDS. A first draft of the subset work
+  # appended " — SUBSET: N of M" here to make a partial run legible; that is a
+  # real need (see the SUMMARY banner) but this is the wrong place for it, and
+  # the anchored assertion is the only thing that would have said so.
+  # The subset fact goes in the banner and in the line below it, both of which
+  # `gate.sh` prints, and neither of which anything parses.
   if [ "$rc" -eq 0 ]; then
     echo "RESULT: PASS (exit=0)"
   else
@@ -177,7 +200,22 @@ trap 'exit 130' INT
 SET="hermetic"
 ROOT=""
 # Empty = run the whole selected SET. Populated only by --targets/DEVRC_TARGETS.
+#
+# 🔴 TWO VARIABLES, because "asked for a subset" and "asked for a NON-EMPTY
+# subset" are different questions and only the first can distinguish
+# `--targets ""` (a broken caller, FATAL) from no flag at all (a full run).
 ONLY_TARGETS="${DEVRC_TARGETS:-}"
+ONLY_TARGETS_GIVEN=0
+ONLY_TARGETS_SOURCE=""
+if [ -n "${DEVRC_TARGETS+x}" ]; then
+  ONLY_TARGETS_GIVEN=1
+  ONLY_TARGETS_SOURCE="the DEVRC_TARGETS environment variable"
+fi
+# Set once the full target list is known, so the SUBSET note can say "N of M"
+# rather than a bare N that reads like a total.
+SET_TOTAL=0
+# Appended to the SUMMARY banner and the RESULT line. Empty on a full run.
+SUBSET_NOTE=""
 CHECK_TARGETS_ONLY=0
 CHECK_FLOORS_ONLY=0
 while [ $# -gt 0 ]; do
@@ -194,8 +232,26 @@ while [ $# -gt 0 ]; do
     # Run a SUBSET of the target list. Space-separated, and every entry must
     # already be a declared target — see the ONLY_TARGETS block below for why
     # this cannot be a free-form path filter.
-    --targets) ONLY_TARGETS="${2:-}"; shift; [ $# -gt 0 ] && shift ;;
-    --targets=*) ONLY_TARGETS="${1#*=}"; shift ;;
+    # 🔴 REPEATING THE FLAG IS FATAL, not last-wins. Conventional flag
+    # semantics would silently discard the earlier selection, and the caller
+    # that hits this is a WRAPPER appending its own `--targets` on top of one
+    # the operator already passed — so the discarded half is exactly the half
+    # nobody is watching. This whole block's doctrine is that a selection
+    # mistake must be loud.
+    --targets|--targets=*)
+      if [ "$ONLY_TARGETS_GIVEN" -eq 1 ]; then
+        echo "run-tests: FATAL — --targets given more than once." >&2
+        echo "           Last-wins would silently discard the earlier selection." >&2
+        echo "           Pass ONE --targets with the whole space-separated list." >&2
+        exit 3
+      fi
+      ONLY_TARGETS_GIVEN=1
+      ONLY_TARGETS_SOURCE="--targets"
+      case "$1" in
+        --targets=*) ONLY_TARGETS="${1#*=}"; shift ;;
+        *)           ONLY_TARGETS="${2:-}"; shift; [ $# -gt 0 ] && shift ;;
+      esac
+      ;;
     *) ROOT="$1"; shift ;;
   esac
 done
@@ -755,6 +811,11 @@ TARGETS=("${HERMETIC_TARGETS[@]}")
 if [ "$SET" = "all" ]; then
   TARGETS+=("${DEVHOST_TARGETS[@]}")
 fi
+# Captured BEFORE any narrowing, so the subset note can say "N of M". Taken
+# here rather than recomputed later because `TARGETS` is the thing that gets
+# narrowed — reading it afterwards would report "N of N" on every subset run,
+# which is precisely the reassuring-but-wrong number this is for.
+SET_TOTAL="${#TARGETS[@]}"
 
 # --- TARGET SUBSET (--targets / DEVRC_TARGETS) --------------------------------
 # 🔴 A SUBSET IS A CLAIM THAT THE UNSELECTED TARGETS COULD NOT HAVE CAUGHT THE
@@ -779,10 +840,26 @@ fi
 #
 # 📖 What this does NOT do: pick the targets for you. Mapping changed paths to
 # targets is a separate, fallible decision and lives outside this script.
-if [ -n "$ONLY_TARGETS" ]; then
-  _requested=()
-  # shellcheck disable=SC2206
+# 🔴 SELECTION IS REQUESTED, NOT MERELY NON-EMPTY. `ONLY_TARGETS_GIVEN` is set
+# by the flag/env READ, so `--targets ""` and `--targets=` are FATAL below
+# instead of falling through to a full run. An empty VALUE is the likeliest
+# shape of a broken caller — `--targets "$(compute_targets)"` when the computer
+# returned nothing — and silently running everything there is the fail-safe
+# direction but the WRONG report: the operator asked for a subset and was given
+# a full run with no word said.
+if [ "$ONLY_TARGETS_GIVEN" -eq 1 ]; then
+  # 🔴 `set -f` — an unquoted array assignment performs PATHNAME EXPANSION as
+  # well as word splitting, and only the splitting is wanted. Without it,
+  # `--targets 'scripts/collector/*/tests'` selects whatever happens to exist
+  # on disk: delete one of those suites and the glob silently selects fewer and
+  # the run stays GREEN, while a FULL run goes red on GUARD 5 (`does not
+  # exist`). That converts the #276 failure this whole file exists to prevent
+  # into a silent narrowing. Restored immediately after; nothing between these
+  # two lines may rely on globbing.
+  set -f
+  # shellcheck disable=SC2206  # word splitting is intended here; globbing is not, hence set -f
   _requested=($ONLY_TARGETS)
+  set +f
   if [ "${#_requested[@]}" -eq 0 ]; then
     echo "run-tests: FATAL — --targets was given but resolved to NOTHING." >&2
     echo "           A run that selects no targets would exit 0 having tested" >&2
@@ -802,10 +879,41 @@ if [ -n "$ONLY_TARGETS" ]; then
       echo "           Run with --check-targets to print the declared list." >&2
       exit 3
     fi
+    # 🔴 A DUPLICATE IS FATAL, not deduped. It inflates every coverage number
+    # this mechanism prints AND DEFEATS THE FLOOR BY ITS OWN DERIVATION: the
+    # repeated target contributes its floor twice and then satisfies the
+    # doubled floor by running twice. Measured — one suite, two executions,
+    # `SUBSET — 2 … TOTAL collected=26 … floor: 24`, exit 0, reading as two
+    # targets' worth of coverage.
+    #
+    # Fatal rather than silently deduped because the caller this exists for is
+    # a path->target MAPPER, which emits duplicates by construction (two
+    # changed files, one owning target). A mapper that does that has a bug, and
+    # quietly collapsing it hides the bug while the numbers still read wrong to
+    # anyone reading the mapper's own output.
+    for _s in ${_selected[@]+"${_selected[@]}"}; do
+      if [ "$_s" = "$_r" ]; then
+        echo "run-tests: FATAL — --targets names '$_r' more than once." >&2
+        echo "           A duplicate runs one suite twice and counts it twice," >&2
+        echo "           inflating the collected total AND the derived floor, so" >&2
+        echo "           the run satisfies a floor its own duplication created." >&2
+        echo "           De-duplicate the selection before passing it." >&2
+        exit 3
+      fi
+    done
     _selected+=("$_r")
   done
   TARGETS=("${_selected[@]}")
-  echo "run-tests: SUBSET — ${#TARGETS[@]} of the '$SET' set selected via --targets." >&2
+  # Carried into the SUMMARY header and the RESULT line — see GUARD 6. stderr
+  # alone is not enough: `gate.sh` prints from the SUMMARY banner DOWN, so
+  # anything announced above it is invisible on the surface CLAUDE.md tells
+  # people to read.
+  # 🔴 NAME THE SOURCE. An exported DEVRC_TARGETS narrows every run in the
+  # shell — the pre-push hook's included — and nobody typed it, so it is the
+  # harder of the two to notice. Saying which one selected turns "why did this
+  # only run 3 targets" into a one-line answer.
+  SUBSET_NOTE=" — SUBSET: ${#TARGETS[@]} of ${SET_TOTAL} ${SET} target(s) via ${ONLY_TARGETS_SOURCE}"
+  echo "run-tests: SUBSET — ${#TARGETS[@]} of the '$SET' set selected via ${ONLY_TARGETS_SOURCE}." >&2
   echo "           Unselected targets did NOT run; this verdict is about the" >&2
   echo "           selected ones only." >&2
 fi
@@ -2028,7 +2136,18 @@ if [ "$CHECK_FLOORS_ONLY" -eq 1 ]; then
     if [ "$_in_set" -eq 1 ]; then
       echo "  floor ${entry##*|}  ${_ft}"
     else
-      echo "  floor ${entry##*|}  ${_ft}  [not in the $SET set — excluded from the global sum]"
+      # 🔴 SAY WHY IT IS EXCLUDED, and do not say "$SET" when a SUBSET is what
+      # excluded it. Measured: `--targets scripts/collector/tests
+      # --check-floors` printed 28 rows reading `scripts/tests [not in the
+      # hermetic set …]` — and `scripts/tests` is the FIRST entry of
+      # HERMETIC_TARGETS. The row was describing the selection while naming the
+      # set, which is the same false-label defect fixed on the GLOBAL line one
+      # screen below, missed here because the two are not adjacent.
+      if [ -n "$SUBSET_NOTE" ]; then
+        echo "  floor ${entry##*|}  ${_ft}  [not SELECTED by --targets — excluded from the global sum]"
+      else
+        echo "  floor ${entry##*|}  ${_ft}  [not in the $SET set — excluded from the global sum]"
+      fi
     fi
   done
   echo "  ----"
@@ -3597,7 +3716,24 @@ for SHELL_TEST in "${SHELL_TESTS[@]}"; do
   TIMINGS+=("$(( $(date +%s) - _st_t0 ))"$'\t'"$_st_rc"$'\t'"$SHELL_TEST")
 done
 
-echo "======================== SUMMARY ($SET set) ========================"
+# 🔴 THE BANNER MUST CARRY THE SUBSET, because this is where `gate.sh` STARTS
+# READING. It locates `^=\{8,\} .*SUMMARY` and prints from there DOWN, so the
+# stderr announcement emitted at the top of the run is excluded by
+# construction — measured: a 1-target run through `gate.sh` showed
+# `SUMMARY (hermetic set)` as its FIRST line and `GATE: RESULT=PASS`. A bare
+# "$SET set" there is a positive claim that the whole set ran, printed on the
+# one surface CLAUDE.md tells people to read.
+echo "======================== SUMMARY ($SET set)${SUBSET_NOTE} ========================"
+# Second, unmissable statement of the same fact, on the line right below the
+# banner — i.e. the SECOND line `gate.sh` prints. The banner is easy to skim
+# past; a run that tested a fraction of the suite should have to say so in a
+# sentence, next to the numbers a reader is about to believe.
+if [ -n "$SUBSET_NOTE" ]; then
+  echo "  🔴 PARTIAL RUN — ${#TARGETS[@]} of ${SET_TOTAL} declared '$SET' target(s) ran."
+  echo "     Every count below is for the SELECTED targets only. The unselected"
+  echo "     ones were NOT executed and this verdict says nothing about them."
+  echo "     Selected: ${TARGETS[*]}"
+fi
 for r in "${RESULTS[@]}"; do echo "  $r"; done
 echo "  ----"
 echo "  TOTAL collected=$TOT_COLLECTED  passed=$TOT_PASSED  skipped=$TOT_SKIPPED  failed=$TOT_FAILED  (floor: $MIN_TESTS = sum of ${#TARGETS[@]} per-target floors)"
@@ -3743,10 +3879,21 @@ _skip_entry_applies() {
   # this comment quoted the anchor verbatim and broke the extraction — 11 tests
   # red, from a comment. Prose in this file is load-bearing.
   #
-  # On a FULL run every EXPECTED_SKIPS dir is a declared target anyway (pinned
-  # by test_a_pinned_skip_... and verified: all three are exact targets), so
-  # this gate costs nothing there and changes behaviour only where the defect
-  # lived.
+  # On a FULL run every EXPECTED_SKIPS dir is a declared target today (all
+  # three checked by hand), so this gate costs nothing there and changes
+  # behaviour only where the defect lived. That relationship is now PINNED by
+  # test_every_expected_skip_dir_is_a_declared_target — an earlier draft of
+  # this comment claimed it was pinned when it was not, which is the shape
+  # RULES.md calls out: reading as coverage while providing none is worse than
+  # none, because it stops anyone looking.
+  #
+  # ⚠ The two halves of the ledger use DIFFERENT path semantics and that is a
+  # live trap: the matching loop below treats a ledger dir as a PREFIX
+  # (`grep -qE "\] $edir/"`), while this filter requires an EXACT `TARGETS`
+  # entry. An entry naming a parent directory — `scripts/collector` for a skip
+  # inside `scripts/collector/tests` — works today and would be silently
+  # dropped here under any subset. The pin above is what keeps that from
+  # landing unnoticed.
   # 🔴 `${ONLY_TARGETS:-}`, NOT `$ONLY_TARGETS`. This function is EXTRACTED from
   # this file and executed standalone under `bash -uo pipefail` by
   # test_conditional_skip_pins.py, where neither this variable nor TARGETS

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -895,7 +895,21 @@ if [ "$ONLY_TARGETS_GIVEN" -eq 1 ]; then
     echo "run-tests: FATAL — ${ONLY_TARGETS_SOURCE} was given but resolved to NOTHING." >&2
     echo "           A run that selects no targets would exit 0 having tested" >&2
     echo "           nothing." >&2
-    if [ "$ONLY_TARGETS_FLAG_GIVEN" -eq 1 ]; then
+    # 🔴 THREE STATES, NOT TWO. Reading only the FLAG collapses
+    # flag-empty-WITH-an-ambient-env into the flag-only case and prints "Omit
+    # --targets to run the whole set" — which is FALSE: omitting the flag hands
+    # the selection back to DEVRC_TARGETS and runs a SUBSET, at exit 0, with the
+    # operator having been told it would be the whole set. Obeying the tool then
+    # produces exactly the silently-narrowed run this block exists to prevent.
+    #
+    # Measured on the round-2 tree: `DEVRC_TARGETS=scripts/opencode/tests
+    # run-tests.sh --targets ""` printed that advice, and following it ran
+    # `SUBSET: 1 of 28` and exited 0.
+    if [ "$ONLY_TARGETS_FLAG_GIVEN" -eq 1 ] && [ "$ONLY_TARGETS_ENV_GIVEN" -eq 1 ]; then
+      echo "           BOTH are set. Omit --targets AND \`unset DEVRC_TARGETS\` to run" >&2
+      echo "           the whole '$SET' set — omitting only the flag leaves the" >&2
+      echo "           environment variable selecting a SUBSET." >&2
+    elif [ "$ONLY_TARGETS_FLAG_GIVEN" -eq 1 ]; then
       echo "           Omit --targets to run the whole '$SET' set." >&2
     else
       echo "           \`unset DEVRC_TARGETS\` to run the whole '$SET' set." >&2

--- a/scripts/tests/test_run_tests_targets.py
+++ b/scripts/tests/test_run_tests_targets.py
@@ -45,6 +45,7 @@ as regression coverage"):
 """
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import subprocess
@@ -83,12 +84,25 @@ def _require_check_targets(runner: Path) -> None:
 
 
 def _run(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
+    """Run the runner with a SCRUBBED environment.
+
+    🔴 `DEVRC_TARGETS` is removed, and that is not hygiene — it is what keeps
+    the other guards in this file honest. It selects a subset exactly like
+    `--targets`, so an exported value makes
+    `test_check_targets_accepts_the_real_target_list`,
+    `test_a_file_target_is_accepted` and `test_check_floors_accepts_the_real_table`
+    validate a one-entry list while their names claim they validated the
+    shipped one. The developer most likely to have it exported is the one
+    debugging a subset run — i.e. exactly when these guards matter.
+    """
+    env = {k: v for k, v in os.environ.items() if k != "DEVRC_TARGETS"}
     return subprocess.run(
         ["bash", *args],
         cwd=str(cwd or REPO_ROOT),
         capture_output=True,
         text=True,
         timeout=120,
+        env=env,
     )
 
 
@@ -445,3 +459,242 @@ def test_a_pinned_skip_whose_TARGET_did_not_run_does_not_count():
     assert proc.returncode == 0, (
         f"a single-target subset run should pass, got {proc.returncode}.\n{combined}"
     )
+
+
+# --- findings from the round-1 adversarial audit of #1073 ----------------------
+# Each of these kills a mutant that SURVIVED the first six. They are here because
+# an audit found them, not because they were designed in — recorded so the next
+# reader knows which properties were learned the hard way.
+
+
+def test_the_SELECTED_set_is_exactly_what_was_REQUESTED():
+    """🔴 F10. The first six tests asserted the floor MOVED and that the run
+    ANNOUNCED itself — neither pins the selection's identity or size.
+
+    Measured mutant (non-deletion, so the weak deletion sweep could not see it):
+
+        _selected+=("$_r")
+        ->  [ "${#_selected[@]}" -eq 0 ] && _selected+=("$_r")
+
+    i.e. run only the FIRST requested target. It SURVIVED all six new tests AND
+    all 69 tests across the four meta-test files. Production behaviour under it:
+    `--targets "A B"` runs A only, announces "1 of the hermetic set", floors at
+    A's floor alone, and exits 0 — the file header's own named hazard, silently
+    green.
+
+    So this asserts the COUNT and the IDENTITY of what ran, from the floor
+    table, which lists exactly the selected targets.
+    """
+    _require_targets_flag(RUN_TESTS)
+    want = ["scripts/collector/tests", "scripts/opencode/tests"]
+    proc = _run([str(RUN_TESTS), "--targets", " ".join(want), "--check-floors",
+                 str(REPO_ROOT)])
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    selected = {m.group(1) for m in
+                re.finditer(r"^  floor \d+  (\S+)\s*$", proc.stdout, re.M)}
+    assert selected == set(want), (
+        f"the run selected {sorted(selected)} but was asked for {sorted(want)}. "
+        "A selection that silently drops a requested target runs less than the "
+        "operator believes and still exits 0."
+    )
+
+
+def test_a_DUPLICATE_target_is_FATAL():
+    """🔴 F2. A repeat inflates every coverage number AND defeats the floor by
+    its own derivation — the duplicate contributes its floor twice, then
+    satisfies the doubled floor by running twice.
+
+    Measured before the fix: one suite, two executions,
+    `SUBSET — 2 …  TOTAL collected=26 …  floor: 24`, exit 0.
+
+    Reachable by exactly the path->target mapper this is groundwork for, which
+    emits duplicates by construction when two changed files share one target.
+    """
+    _require_targets_flag(RUN_TESTS)
+    t = "scripts/collector/i3/tests"
+    proc = _run([str(RUN_TESTS), "--targets", f"{t} {t}", "--check-floors",
+                 str(REPO_ROOT)])
+    assert proc.returncode == 3, (
+        f"a duplicated target must be FATAL, got {proc.returncode}.\n"
+        f"{proc.stdout}\n{proc.stderr}"
+    )
+    assert "more than once" in proc.stderr, proc.stderr
+
+
+def test_the_value_is_NOT_glob_expanded():
+    """🔴 F8. `_requested=($ONLY_TARGETS)` does PATHNAME EXPANSION as well as
+    word splitting; only the splitting is wanted.
+
+    Measured before the fix: `--targets 'scripts/collector/*/tests'` selected 5
+    targets and exited 0. That makes the selection track the FILESYSTEM — delete
+    one of those suites and the glob silently selects four and stays green,
+    while a FULL run goes red on GUARD 5 (`does not exist`). It converts the
+    #276 failure this file exists for into a silent narrowing.
+
+    A glob must now be FATAL as an unknown target, because after `set -f` the
+    literal `scripts/collector/*/tests` matches no declared entry.
+    """
+    _require_targets_flag(RUN_TESTS)
+    proc = _run([str(RUN_TESTS), "--targets", "scripts/collector/*/tests",
+                 "--check-floors", str(REPO_ROOT)])
+    assert proc.returncode == 3, (
+        f"a glob must not be expanded into a selection, got {proc.returncode}. "
+        f"If this selected several targets, the value was expanded against the "
+        f"filesystem.\n{proc.stdout}\n{proc.stderr}"
+    )
+
+
+def test_an_EMPTY_targets_value_is_FATAL_not_a_full_run():
+    """🟢 G1 → real. `--targets ""` and `--targets=` previously fell through to
+    a FULL run, contradicting the block's own stated rule and the name of
+    `test_an_empty_selection_is_FATAL` (which only ever covered `"   "`).
+
+    Fail-safe in direction, wrong in report: the operator asked for a subset and
+    silently got everything. The likeliest producer is a broken caller —
+    `--targets "$(compute)"` where compute returned nothing.
+    """
+    _require_targets_flag(RUN_TESTS)
+    for args in (["--targets", ""], ["--targets="]):
+        proc = _run([str(RUN_TESTS), *args, "--check-floors", str(REPO_ROOT)])
+        assert proc.returncode == 3, (
+            f"{args} should be FATAL, got {proc.returncode} — an empty value "
+            f"must not fall through to a full run.\n{proc.stdout}\n{proc.stderr}"
+        )
+
+
+def test_repeating_the_flag_is_FATAL_not_last_wins():
+    """🟡 F7. Last-wins silently discards the earlier selection, and the caller
+    that hits it is a WRAPPER appending its own `--targets` on top of the
+    operator's — so the discarded half is the half nobody is watching."""
+    _require_targets_flag(RUN_TESTS)
+    proc = _run([str(RUN_TESTS), "--targets", "scripts/collector/tests",
+                 "--targets", "scripts/opencode/tests", "--check-floors",
+                 str(REPO_ROOT)])
+    assert proc.returncode == 3, (
+        f"--targets twice must be FATAL, got {proc.returncode}.\n{proc.stderr}"
+    )
+
+
+def test_a_partial_run_is_declared_where_gate_sh_actually_LOOKS():
+    """🔴 F1, and the reason it was deploy-blocking.
+
+    `gate.sh` locates `^=\\{8,\\} .*SUMMARY` and prints from there DOWN, so the
+    stderr announcement emitted at the TOP of the run is excluded by
+    construction. Measured before the fix: a 1-target run through `gate.sh`
+    showed `SUMMARY (hermetic set)` as its FIRST line and `GATE: RESULT=PASS` as
+    its last — a positive claim that the whole set ran, on the one surface
+    CLAUDE.md tells people to read.
+
+    Asserted on the SUMMARY region specifically, not on the whole output, so it
+    cannot pass on the strength of the top-of-run announcement.
+    """
+    _require_targets_flag(RUN_TESTS)
+    proc = _run([str(RUN_TESTS), "--targets", "scripts/collector/i3/tests",
+                 str(REPO_ROOT)])
+    assert "SUMMARY" in proc.stdout, f"no SUMMARY banner:\n{proc.stdout[-3000:]}"
+    tail = proc.stdout[proc.stdout.index("SUMMARY"):]
+    assert "SUBSET" in tail or "PARTIAL RUN" in tail, (
+        "the SUMMARY region — everything gate.sh shows an operator — does not "
+        "say the run was partial. A reader sees full-set framing over a "
+        f"fraction of the suite.\n{tail[:1500]}"
+    )
+
+
+def test_every_expected_skip_dir_is_a_declared_target():
+    """🟡 F5. The comment on `_skip_entry_applies` asserted this was pinned; it
+    was not. Pinning it now, because that filter matches a ledger dir EXACTLY
+    against TARGETS while the matching loop treats it as a PREFIX — so an entry
+    naming a parent directory works today and would be silently dropped under
+    any subset.
+    """
+    src = RUN_TESTS.read_text()
+    m = re.search(r"EXPECTED_SKIPS=\((.*?)\n\)", src, re.S)
+    assert m, "could not find EXPECTED_SKIPS in run-tests.sh"
+    dirs = {e.split("|")[0] for e in re.findall(r'^\s*"([^"]+)"', m.group(1), re.M)}
+    assert dirs, "parsed ZERO ledger entries — the parser is broken, not the ledger"
+    declared = set(_hermetic_targets())
+    md = re.search(r"^DEVHOST_TARGETS=\((.*?)^\)", src, re.S | re.M)
+    if md:
+        declared |= {l.strip() for l in md.group(1).splitlines()
+                     if l.strip() and not l.strip().startswith("#")}
+    assert dirs <= declared, (
+        f"EXPECTED_SKIPS names dir(s) that are not declared targets: "
+        f"{sorted(dirs - declared)}. `_skip_entry_applies` matches these "
+        "EXACTLY against TARGETS, so under a subset such an entry is silently "
+        "inapplicable and its skip becomes UNPINNED."
+    )
+
+
+def test_DEVRC_TARGETS_is_equivalent_to_the_flag_and_names_itself():
+    """🟡 F9. The env var was reachable, undocumented and untested: the string
+    `DEVRC_TARGETS` occurred in exactly ONE place in the repo — the line that
+    read it — so a mutant deleting that read survived the entire suite.
+
+    Two properties, because either alone is insufficient:
+
+    1. **Equivalence.** A caller that cannot add an argument must get the same
+       selection, and the same derived floor, as one that can.
+    2. **Attribution.** An EXPORTED value narrows every run-tests.sh in the
+       shell — the pre-push hook's included — and nobody typed it. The run must
+       name the environment as the source, or "why did this only run 3 targets"
+       has no answer in the output.
+    """
+    _require_targets_flag(RUN_TESTS)
+    t = "scripts/collector/i3/tests"
+    src = RUN_TESTS.read_text()
+    assert "DEVRC_TARGETS" in src, "the env override is gone from run-tests.sh"
+
+    flag = _run([str(RUN_TESTS), "--targets", t, "--check-floors", str(REPO_ROOT)])
+    env = subprocess.run(
+        ["bash", str(RUN_TESTS), "--check-floors", str(REPO_ROOT)],
+        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120,
+        env={**os.environ, "DEVRC_TARGETS": t},
+    )
+    assert flag.returncode == 0 and env.returncode == 0, (flag.stderr, env.stderr)
+
+    def _floor(out: str) -> str:
+        m = re.search(r"GLOBAL floor .*? = (\d+)", out)
+        assert m, f"no GLOBAL floor line:\n{out}"
+        return m.group(1)
+
+    assert _floor(flag.stdout) == _floor(env.stdout), (
+        "DEVRC_TARGETS and --targets produced DIFFERENT floors, so they are not "
+        "the same mechanism and the env path is unguarded by every other test "
+        "in this file."
+    )
+    assert "DEVRC_TARGETS" in env.stderr, (
+        "a subset selected by the environment did not name the environment as "
+        f"its source — an ambient value is the one nobody typed.\n{env.stderr}"
+    )
+    assert "DEVRC_TARGETS" not in flag.stderr, (
+        "a flag-selected subset blamed the environment.\n" + flag.stderr
+    )
+
+
+def test_the_meta_test_harness_is_immune_to_an_ambient_DEVRC_TARGETS():
+    """🟡 F9, second half — the one that makes OTHER guards lie.
+
+    `_run` inherits `os.environ`. With `DEVRC_TARGETS` exported, three
+    target-list guards in this file pass VACUOUSLY —
+    `test_check_targets_accepts_the_real_target_list`,
+    `test_a_file_target_is_accepted` and `test_check_floors_accepts_the_real_table`
+    would each validate a one-entry list while claiming to validate the shipped
+    one. A developer debugging a subset run is exactly the person with that
+    variable exported.
+
+    So `_run` must scrub it. This asserts the scrubbing, not the intent.
+    """
+    saved = os.environ.get("DEVRC_TARGETS")
+    os.environ["DEVRC_TARGETS"] = "scripts/collector/i3/tests"
+    try:
+        proc = _run([str(RUN_TESTS), "--check-floors", str(REPO_ROOT)])
+        assert "SUBSET" not in proc.stderr, (
+            "_run leaked an ambient DEVRC_TARGETS into the runner, so every "
+            "full-set assertion in this file can pass against a 1-target run.\n"
+            + proc.stderr
+        )
+    finally:
+        if saved is None:
+            os.environ.pop("DEVRC_TARGETS", None)
+        else:
+            os.environ["DEVRC_TARGETS"] = saved

--- a/scripts/tests/test_run_tests_targets.py
+++ b/scripts/tests/test_run_tests_targets.py
@@ -59,6 +59,9 @@ RUN_TESTS = REPO_ROOT / "scripts" / "run-tests.sh"
 # The entry #276 added and the gate then silently refused to run.
 GUARD_CORE_TARGET = "scripts/claude-hooks/tests/test_guard_core.py"
 
+# The default --set, named once so a message cannot drift from the value.
+SETNAME = "hermetic"
+
 
 def _require_check_targets(runner: Path) -> None:
     """Fail FAST if the runner has no --check-targets flag.
@@ -447,10 +450,11 @@ def test_a_pinned_skip_whose_TARGET_did_not_run_does_not_count():
         f"{tiny} now owns a pinned skip, so it can no longer isolate this "
         f"property. Pinned targets: {sorted(pinned_dirs)}"
     )
-    proc = subprocess.run(
-        ["bash", str(RUN_TESTS), "--targets", tiny, str(REPO_ROOT)],
-        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=300,
-    )
+    # Through `_run`, NOT a bare subprocess.run: this test bypassed the scrub
+    # and so inherited an ambient DEVRC_TARGETS, giving the developer debugging
+    # a subset run a spurious RED — the mirror of the vacuous GREEN the scrub
+    # exists to prevent. `_run`'s 120s timeout is ample; this costs ~13s.
+    proc = _run([str(RUN_TESTS), "--targets", tiny, str(REPO_ROOT)])
     combined = proc.stdout + proc.stderr
     assert "pinned entries apply here" not in combined, (
         "a subset excluding every pinned-skip target still counted pinned "
@@ -612,11 +616,15 @@ def test_every_expected_skip_dir_is_a_declared_target():
     assert m, "could not find EXPECTED_SKIPS in run-tests.sh"
     dirs = {e.split("|")[0] for e in re.findall(r'^\s*"([^"]+)"', m.group(1), re.M)}
     assert dirs, "parsed ZERO ledger entries — the parser is broken, not the ledger"
+    # 🔴 HERMETIC_TARGETS ALONE — deliberately NOT the union with
+    # DEVHOST_TARGETS. Measured: with the union, adding
+    # `"scripts/devhost-tests|a devhost-only skip"` to the ledger left this pin
+    # GREEN while a DEFAULT `--set hermetic` run goes red with
+    # `N test(s) skipped, but M of K pinned entries apply here` — because that
+    # target never runs under `--set hermetic`, and the skip filter is gated on
+    # a subset being active (F4), so nothing filters it out. The union made this
+    # guard blind to the exact case it was advertised as catching.
     declared = set(_hermetic_targets())
-    md = re.search(r"^DEVHOST_TARGETS=\((.*?)^\)", src, re.S | re.M)
-    if md:
-        declared |= {l.strip() for l in md.group(1).splitlines()
-                     if l.strip() and not l.strip().startswith("#")}
     assert dirs <= declared, (
         f"EXPECTED_SKIPS names dir(s) that are not declared targets: "
         f"{sorted(dirs - declared)}. `_skip_entry_applies` matches these "
@@ -693,8 +701,145 @@ def test_the_meta_test_harness_is_immune_to_an_ambient_DEVRC_TARGETS():
             "full-set assertion in this file can pass against a 1-target run.\n"
             + proc.stderr
         )
+        # 🔴 AND it must have RUN. Asserting only the absence of "SUBSET" is
+        # satisfied by a scrub that sets the variable to EMPTY instead of
+        # dropping the key: the runner then exits 3 with `resolved to NOTHING`,
+        # prints no SUBSET line, and this guard stays green over a run that
+        # never happened.
+        assert proc.returncode == 0, (
+            f"the scrubbed run exited {proc.returncode} — an empty-string "
+            f"scrub is not a scrub.\n{proc.stdout}\n{proc.stderr}"
+        )
     finally:
         if saved is None:
             os.environ.pop("DEVRC_TARGETS", None)
         else:
             os.environ["DEVRC_TARGETS"] = saved
+
+
+# --- findings from the round-2 delta audit ------------------------------------
+
+
+def test_the_subset_note_reports_N_of_the_FULL_set_not_N_of_N():
+    """🟡 round-2 F5. `SET_TOTAL` is captured BEFORE narrowing, and five lines of
+    comment explain why — but nothing asserted it.
+
+    Measured mutant (non-deletion): `${SET_TOTAL}` -> `${#TARGETS[@]}` at both
+    read sites. Banner becomes `SUBSET: 1 of 1 hermetic target(s)` and the
+    PARTIAL RUN block `1 of 1`. It SURVIVED all 23 tests in this file, with a
+    positive control in the same copy proving the mutated runner was executing.
+
+    "1 of 1" is the reassuring-but-wrong number: it reads as a complete run of a
+    one-target set. The denominator is the whole point of the note.
+    """
+    _require_targets_flag(RUN_TESTS)
+    full = len(_hermetic_targets())
+    assert full >= 10, f"only {full} targets parsed — the parser is broken"
+    proc = _run([str(RUN_TESTS), "--targets", "scripts/collector/i3/tests",
+                 "--check-floors", str(REPO_ROOT)])
+    combined = proc.stdout + proc.stderr
+    m = re.search(r"SUBSET:\s*(\d+)\s+of\s+(\d+)", combined)
+    assert m, f"no 'SUBSET: N of M' in the output:\n{combined[:1200]}"
+    selected, total = int(m.group(1)), int(m.group(2))
+    assert selected == 1, f"expected 1 selected, got {selected}"
+    assert total == full, (
+        f"the note says '{selected} of {total}' but the {SETNAME} set has "
+        f"{full} targets. A denominator equal to the numerator turns a partial "
+        "run into what reads as a complete one."
+    )
+
+    # 🔴 AND THE BANNER, which is a SECOND site with its own copy of the same
+    # expression. Watched: mutating only `SUBSET_NOTE` (the banner) to
+    # `N of N` left this test green, because the early-exit path above reads the
+    # stderr line instead. Two sites, two assertions — pinning one proves
+    # nothing about the other.
+    real = _run([str(RUN_TESTS), "--targets", "scripts/collector/i3/tests",
+                 str(REPO_ROOT)])
+    assert "SUMMARY" in real.stdout, f"no banner:\n{real.stdout[-2000:]}"
+    tail = real.stdout[real.stdout.index("SUMMARY"):]
+    mb = re.search(r"SUBSET:\s*(\d+)\s+of\s+(\d+)", tail)
+    assert mb, f"the SUMMARY region carries no 'N of M':\n{tail[:1200]}"
+    assert int(mb.group(2)) == full, (
+        f"the banner says '{mb.group(1)} of {mb.group(2)}' but the {SETNAME} "
+        f"set has {full} targets."
+    )
+
+
+def test_every_early_exit_surface_declares_a_partial_run():
+    """🟡 round-2 F1/F3/F4 as ONE property, because they were fixed one at a
+    time and a fourth surface would be missed the same way.
+
+    Each of these exits before the SUMMARY banner and is somebody's whole view
+    of the run. Asserted together so a new early-exit path has to answer this
+    test rather than be discovered by the next audit.
+    """
+    _require_targets_flag(RUN_TESTS)
+    t = "scripts/collector/i3/tests"
+    for flag in ("--check-targets", "--check-floors"):
+        proc = _run([str(RUN_TESTS), "--targets", t, flag, str(REPO_ROOT)])
+        assert proc.returncode == 0, f"{flag}: {proc.stdout}\n{proc.stderr}"
+        assert re.search(r"SUBSET|SELECTED", proc.stdout), (
+            f"{flag} printed no subset caveat on stdout — the surface an "
+            f"operator reads. A one-target run reads as the whole set.\n"
+            f"{proc.stdout[:1200]}"
+        )
+
+
+def test_the_flag_OVERRIDES_an_ambient_env_var_and_says_so():
+    """🟡 round-2 F2 — a regression the previous fix round introduced.
+
+    Measured before the fix: a SINGLE `--targets` on a shell with
+    DEVRC_TARGETS exported was rejected `--targets given more than once`
+    (exit 3), naming no environment variable, so the remedy appeared nowhere and
+    the advice printed was already satisfied. It also removed the ordinary
+    precedence that an explicit flag beats ambient configuration.
+    """
+    _require_targets_flag(RUN_TESTS)
+    flagged = "scripts/collector/i3/tests"
+    ambient = "scripts/opencode/tests"
+    env = {**os.environ, "DEVRC_TARGETS": ambient}
+    proc = subprocess.run(
+        ["bash", str(RUN_TESTS), "--targets", flagged, "--check-floors",
+         str(REPO_ROOT)],
+        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120, env=env,
+    )
+    assert proc.returncode == 0, (
+        "a single --targets alongside an ambient DEVRC_TARGETS must not be "
+        f"fatal, got {proc.returncode}.\n{proc.stdout}\n{proc.stderr}"
+    )
+    rows = {m.group(1) for m in
+            re.finditer(r"^  floor \d+  (\S+)\s*$", proc.stdout, re.M)}
+    assert rows == {flagged}, (
+        f"the flag did not win: selection is {sorted(rows)}, expected "
+        f"[{flagged!r}]. An explicit flag must override ambient configuration."
+    )
+    assert "OVERRIDES" in proc.stderr and "DEVRC_TARGETS" in proc.stderr, (
+        "the override was silent — a selection the operator did NOT type was "
+        f"discarded without a word.\n{proc.stderr}"
+    )
+
+
+def test_a_set_but_EMPTY_env_var_names_the_env_var_in_its_remedy():
+    """🟡 round-2 F3. `DEVRC_TARGETS=` (set, empty) is fatal — defensible — but
+    the message said "Omit --targets", which that operator has already done.
+    The only remedy is `unset DEVRC_TARGETS`, so it has to appear."""
+    _require_targets_flag(RUN_TESTS)
+    env = {**os.environ, "DEVRC_TARGETS": ""}
+    proc = subprocess.run(
+        ["bash", str(RUN_TESTS), "--check-floors", str(REPO_ROOT)],
+        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120, env=env,
+    )
+    assert proc.returncode == 3, f"expected 3, got {proc.returncode}"
+    # 🔴 The FATAL LINE ITSELF, not just the string somewhere in stderr. The
+    # remedy line below it mentions DEVRC_TARGETS independently, so a bare
+    # `"DEVRC_TARGETS" in proc.stderr` stays green while the headline reverts to
+    # blaming `--targets`. Watched: that mutant survived.
+    fatal = [l for l in proc.stderr.splitlines() if "FATAL" in l]
+    assert fatal, f"no FATAL line at all:\n{proc.stderr}"
+    assert "DEVRC_TARGETS" in fatal[0], (
+        "the FATAL line blames a flag the reader never passed; the variable "
+        f"that IS set is named nowhere on it.\n{fatal[0]}"
+    )
+    assert "--targets" not in fatal[0], (
+        f"the FATAL line names --targets, which was not given.\n{fatal[0]}"
+    )

--- a/scripts/tests/test_run_tests_targets.py
+++ b/scripts/tests/test_run_tests_targets.py
@@ -983,3 +983,42 @@ def test_check_floors_declares_the_subset_on_its_GLOBAL_line():
     assert "SELECTED" in line[0] and "SUBSET" in line[0], (
         "the GLOBAL floor line does not say it summed a SUBSET — it is the "
         f"number a reader uses to judge the run's coverage.\n{line[0]}")
+
+
+def test_the_SUMMARY_BANNER_names_the_real_selection_source():
+    """🔴 round-4 M12 — the one surface the class scan structurally could not see.
+
+    `test_no_message_hardcodes_the_flag_when_the_ENVIRONMENT_selected` runs only
+    under `--check-floors` and `--check-targets`, and BOTH exit before
+    `SUBSET_NOTE` is rendered into the SUMMARY banner. So the banner — the line
+    `gate.sh` starts reading, and the whole reason F1 was deploy-blocking — was
+    outside a guard whose docstring says "every operator-facing string".
+
+    Measured: mutating the banner's `${ONLY_TARGETS_SOURCE}` to a hardcoded
+    `--targets` printed
+
+        ==== SUMMARY (hermetic set) — SUBSET: 1 of 28 hermetic target(s) via --targets ====
+
+    for an env-selected run with NO flag on the command line, and SURVIVED all 30
+    tests in this file AND the gating sandbox tier with byte-identical counts.
+    An operator reading that checks their command line, finds no `--targets`, and
+    has no way to attribute the narrowing — the exact question these lines exist
+    to answer.
+
+    This needs a REAL run (no `--check-*`), because the banner only exists on one.
+    """
+    _require_targets_flag(RUN_TESTS)
+    proc = _run_env([str(RUN_TESTS), str(REPO_ROOT)], ENV_ONLY)
+    assert proc.returncode == 0, f"{proc.stdout[-1500:]}\n{proc.stderr[-1500:]}"
+    assert "SUMMARY" in proc.stdout, f"no banner:\n{proc.stdout[-1500:]}"
+    # The SUMMARY region is exactly what gate.sh prints; assert inside it only.
+    tail = proc.stdout[proc.stdout.index("SUMMARY"):]
+    head = tail.splitlines()[0]
+    assert "DEVRC_TARGETS" in head, (
+        "the SUMMARY banner does not name the environment variable that "
+        f"selected — it is the line gate.sh starts reading.\n{head}")
+    assert "--targets" not in head, (
+        f"the banner blames a flag that was never passed.\n{head}")
+    # And the PARTIAL RUN block immediately below it, same reasoning.
+    block = "\n".join(tail.splitlines()[1:6])
+    assert "PARTIAL RUN" in block, f"no PARTIAL RUN block:\n{block}"

--- a/scripts/tests/test_run_tests_targets.py
+++ b/scripts/tests/test_run_tests_targets.py
@@ -843,3 +843,143 @@ def test_a_set_but_EMPTY_env_var_names_the_env_var_in_its_remedy():
     assert "--targets" not in fatal[0], (
         f"the FATAL line names --targets, which was not given.\n{fatal[0]}"
     )
+
+
+# --- findings from the round-3 delta audit ------------------------------------
+# Round 3's lesson was not a code defect: it was that FIVE of round 2's own
+# message fixes shipped with no guard able to see them regress — including G7,
+# a round-2 finding, fixed and then immediately unpinned. One table below covers
+# the class, so a sixth message does not need a seventh round to notice.
+
+
+ENV_ONLY = {"DEVRC_TARGETS": "scripts/collector/i3/tests"}
+
+
+def _run_env(args: list[str], extra: dict) -> subprocess.CompletedProcess:
+    """Run the runner with EXTRA env, bypassing `_run`'s scrub on purpose."""
+    return subprocess.run(
+        ["bash", *args], cwd=str(REPO_ROOT), capture_output=True, text=True,
+        timeout=120, env={**os.environ, **extra},
+    )
+
+
+def test_no_message_hardcodes_the_flag_when_the_ENVIRONMENT_selected():
+    """🟡 round-3. Every operator-facing string that names the selection source
+    must name the REAL one.
+
+    Five mutants re-hardcoding `--targets` survived round 2's suite: the
+    unknown-target FATAL, the duplicate FATAL, the floor-row label (which IS
+    round-2 finding G7, fixed without a guard), the subset announcement, and the
+    GUARD 5 sentence. All are reachable with DEVRC_TARGETS set and no flag.
+
+    Asserted as a CLASS over the whole output rather than per message, because
+    the failure mode is a NEW message being added unguarded — which a per-message
+    test cannot see.
+    """
+    _require_targets_flag(RUN_TESTS)
+    # (args, must the run succeed?) — each drives a different message path.
+    cases = [
+        (["--check-floors"], True),
+        (["--check-targets"], True),
+    ]
+    for args, ok in cases:
+        proc = _run_env([str(RUN_TESTS), *args, str(REPO_ROOT)], ENV_ONLY)
+        assert (proc.returncode == 0) == ok, (
+            f"{args}: rc={proc.returncode}\n{proc.stdout}\n{proc.stderr}")
+        blob = proc.stdout + proc.stderr
+        assert "DEVRC_TARGETS" in blob, (
+            f"{args}: nothing named the environment variable that selected.\n{blob[:900]}")
+        offenders = [l for l in blob.splitlines()
+                     if "--targets" in l and "DEVRC_TARGETS" not in l
+                     and "OVERRIDES" not in l]
+        assert not offenders, (
+            f"{args}: these lines blame `--targets`, which was never passed — "
+            f"the environment selected:\n  " + "\n  ".join(offenders[:6]))
+
+    # 🔴 `--check-targets` must also say what it did NOT validate. GUARD 5's
+    # whole claim is "every declared target resolves"; under a subset it checked
+    # one of twenty-eight, and the sentence saying so is the difference between
+    # a narrowed claim and a false one. Watched: deleting it passed the file.
+    ct = _run_env([str(RUN_TESTS), "--check-targets", str(REPO_ROOT)], ENV_ONLY)
+    assert "GUARD 5 did NOT validate the unselected ones." in ct.stdout, (
+        "--check-targets under a subset no longer states that GUARD 5 skipped "
+        f"the unselected targets.\n{ct.stdout[:900]}")
+
+    # 🔴 The FATAL paths driven FROM THE ENVIRONMENT, which is the only way to
+    # see them mis-attribute. Driving them with a flag cannot: the flag IS the
+    # source, so a hardcoded "--targets" is accidentally correct and the mutant
+    # survives. Watched: re-hardcoding the unknown-target FATAL passed the whole
+    # file until this loop drove it via DEVRC_TARGETS.
+    for value, needle in (("definitely/not/a/target", "definitely/not/a/target"),
+                          ("scripts/tests scripts/tests", "more than once")):
+        proc = _run_env([str(RUN_TESTS), "--check-floors", str(REPO_ROOT)],
+                        {"DEVRC_TARGETS": value})
+        assert proc.returncode == 3, (
+            f"DEVRC_TARGETS={value!r}: expected 3, got {proc.returncode}\n{proc.stderr}")
+        assert needle in proc.stderr, proc.stderr
+        fatal = [l for l in proc.stderr.splitlines() if "FATAL" in l]
+        assert fatal and "DEVRC_TARGETS" in fatal[0], (
+            "the FATAL line blames `--targets` for a selection the ENVIRONMENT "
+            f"made.\n{fatal[0] if fatal else proc.stderr}")
+
+
+def test_the_empty_selection_remedy_names_EVERY_knob_that_is_set():
+    """🟡 round-3, and the regression that round found.
+
+    The remedy branch read only the FLAG, so flag-empty-WITH-an-ambient-env
+    printed "Omit --targets to run the whole set" — and omitting the flag hands
+    the selection back to DEVRC_TARGETS, running a SUBSET at exit 0. The operator
+    is told the opposite of what happens, and following the advice produces the
+    silently-narrowed run this whole block exists to prevent.
+
+    🔴 The previous round's test for this asserted only on the FATAL headline and
+    never on the remedy, so deleting the entire remedy branch left it green
+    (watched). This asserts the remedy line itself, in all three states.
+    """
+    _require_targets_flag(RUN_TESTS)
+
+    def _remedy(args, env):
+        p = _run_env([str(RUN_TESTS), *args, "--check-floors", str(REPO_ROOT)], env)
+        assert p.returncode == 3, f"{args} {env}: expected 3, got {p.returncode}\n{p.stderr}"
+        return p.stderr
+
+    # flag empty, env ALSO set -> must name BOTH
+    both = _remedy(["--targets", ""], ENV_ONLY)
+    assert "unset DEVRC_TARGETS" in both and "--targets" in both, (
+        "with BOTH set, the remedy must name both knobs; omitting only the flag "
+        f"leaves the environment selecting a subset.\n{both}")
+
+    # env set-but-empty, no flag -> must name the env var, never the flag
+    env_only = _remedy([], {"DEVRC_TARGETS": ""})
+    assert "unset DEVRC_TARGETS" in env_only, env_only
+    assert "Omit --targets" not in env_only, (
+        f"told to omit a flag that was never passed.\n{env_only}")
+
+    # flag empty, NO env -> must name the flag, never the env var
+    flag_only = subprocess.run(
+        ["bash", str(RUN_TESTS), "--targets", "", "--check-floors", str(REPO_ROOT)],
+        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120,
+        env={k: v for k, v in os.environ.items() if k != "DEVRC_TARGETS"},
+    ).stderr
+    assert "Omit --targets" in flag_only, flag_only
+    assert "unset DEVRC_TARGETS" not in flag_only, (
+        f"told to unset a variable that was not set.\n{flag_only}")
+
+
+def test_check_floors_declares_the_subset_on_its_GLOBAL_line():
+    """🟢 round-3. The earlier early-exit test matched `SUBSET|SELECTED` over the
+    whole of stdout — satisfied by the 27 unselected floor-row labels
+    (`[not SELECTED by ...]`), never by the GLOBAL line it was aimed at.
+
+    Watched: reverting the GLOBAL line to `sum over the $SET set` left that test
+    GREEN. This one reads the GLOBAL line specifically.
+    """
+    _require_targets_flag(RUN_TESTS)
+    proc = _run([str(RUN_TESTS), "--targets", "scripts/collector/i3/tests",
+                 "--check-floors", str(REPO_ROOT)])
+    assert proc.returncode == 0, proc.stderr
+    line = [l for l in proc.stdout.splitlines() if "GLOBAL floor" in l]
+    assert line, f"no GLOBAL floor line:\n{proc.stdout[:900]}"
+    assert "SELECTED" in line[0] and "SUBSET" in line[0], (
+        "the GLOBAL floor line does not say it summed a SUBSET — it is the "
+        f"number a reader uses to judge the run's coverage.\n{line[0]}")

--- a/scripts/tests/test_run_tests_targets.py
+++ b/scripts/tests/test_run_tests_targets.py
@@ -262,3 +262,186 @@ def test_check_targets_is_cheap_and_runs_no_tests(tmp_path):
         "--check-targets ran a suite; it is supposed to validate the list only.\n"
         f"{proc.stdout}"
     )
+
+
+# --- `--targets`: running a SUBSET of the declared target list -----------------
+# 🔴 EVERY TEST BELOW IS ABOUT ONE HAZARD: a subset run that tests less than the
+# operator thinks it did. The mechanism exists so CI can skip suites a change
+# could not have broken, which means its failure mode is a GREEN run that never
+# executed the suite holding the regression. So the dangerous inputs — a typo, an
+# empty selection, a target from another set — must all be FATAL, and the ones
+# that are merely narrow must SAY they are narrow.
+#
+# These use `--check-floors`, which applies the subset and exits before pytest,
+# so each costs milliseconds rather than a suite run. That is the same trick
+# `_require_check_targets` above documents, for the same reason.
+
+
+def _require_targets_flag(runner: Path) -> None:
+    """Fail FAST and by name if `--targets` is absent from this revision.
+
+    Without it the flag falls through to `*) ROOT="$1"` exactly as
+    `--check-targets` once did, the trailing ROOT overwrites it, and the runner
+    executes the ENTIRE suite — so every assertion below would pass or fail for
+    reasons unrelated to what it claims to test.
+    """
+    assert "--targets" in runner.read_text(), (
+        f"{runner} has no --targets flag, so the subset mechanism does not "
+        "exist in this revision and these guards are vacuous."
+    )
+
+
+def test_a_subset_narrows_the_target_list_and_the_floor_follows():
+    """The floor is DERIVED, so narrowing the list must narrow the floor.
+
+    This is the property that makes a subset run safe to gate on at all: if the
+    floor stayed at the full-set sum, every subset run would fail GUARD 3 and
+    the mechanism would be unusable; if the floor were not derived at all, a
+    subset could collapse to zero tests and still pass.
+    """
+    _require_targets_flag(RUN_TESTS)
+    two = ["scripts/collector/tests", "scripts/opencode/tests"]
+    sub = _run([str(RUN_TESTS), "--targets", " ".join(two), "--check-floors",
+                str(REPO_ROOT)])
+    full = _run([str(RUN_TESTS), "--check-floors", str(REPO_ROOT)])
+    assert sub.returncode == 0, f"subset --check-floors failed:\n{sub.stdout}\n{sub.stderr}"
+
+    def _floor(out: str) -> int:
+        # NOT `\([^)]*\)` — the subset label contains a nested `target(s)`, so a
+        # non-greedy run up to the ` = ` is the only form that reads both.
+        m = re.search(r"GLOBAL floor .*? = (\d+)", out)
+        assert m, f"no GLOBAL floor line in output:\n{out}"
+        return int(m.group(1))
+
+    sub_floor, full_floor = _floor(sub.stdout), _floor(full.stdout)
+    assert 0 < sub_floor < full_floor, (
+        f"a 2-target subset floor ({sub_floor}) must be positive and strictly "
+        f"below the full-set floor ({full_floor}). Equal means the floor is not "
+        "derived from the selection; zero means it collapsed."
+    )
+
+
+def test_a_subset_run_SAYS_it_ran_a_subset():
+    """A narrowed run must announce itself on stderr.
+
+    🔴 The verdict line of a subset run looks exactly like a full one — same
+    PASS, same shape. Whoever reads it has no other way to know that most of the
+    suite did not execute, so the announcement is the only thing separating
+    "the gate passed" from "the gate passed on 2 of 29 targets".
+    """
+    _require_targets_flag(RUN_TESTS)
+    proc = _run([str(RUN_TESTS), "--targets", "scripts/collector/tests",
+                 "--check-floors", str(REPO_ROOT)])
+    # 🔴 stderr SPECIFICALLY, and a string the floor line does not contain.
+    # The first version asserted "SUBSET" in stdout+stderr, which the floor
+    # line's own "a SUBSET of hermetic" satisfies — so deleting the
+    # announcement entirely left the test green. Watched: that mutant survived.
+    assert "selected via --targets" in proc.stderr, (
+        "a --targets run did not announce the narrowing on stderr. The verdict "
+        "line of a subset run is identical to a full one, so this announcement "
+        f"is the only thing that distinguishes them.\n{proc.stderr}"
+    )
+    assert re.search(r"SELECTED target\(s\), a SUBSET", proc.stdout), (
+        "the floor line must say it summed the SELECTED targets, not '$SET' — "
+        f"labelling a subset sum as the full set is a false coverage claim.\n{proc.stdout}"
+    )
+
+
+def test_an_unknown_target_is_FATAL_not_silently_dropped():
+    """The typo case, and the reason the whole mechanism is allowlist-based.
+
+    `scripts/dl-router` (no `/tests`) is a real directory and an obvious thing
+    to type. Under a prefix- or filter-based design it would select NOTHING and
+    the run would exit 0 having tested nothing — indistinguishable from a pass.
+    """
+    _require_targets_flag(RUN_TESTS)
+    proc = _run([str(RUN_TESTS), "--targets", "scripts/dl-router",
+                 "--check-floors", str(REPO_ROOT)])
+    assert proc.returncode == 3, (
+        f"expected exit 3 for an unknown target, got {proc.returncode}.\n"
+        f"{proc.stdout}\n{proc.stderr}"
+    )
+    assert "scripts/dl-router" in proc.stderr, (
+        f"the error must NAME the offending target.\n{proc.stderr}"
+    )
+
+
+def test_an_empty_selection_is_FATAL():
+    """'Nothing to run' is never a verdict this script may reach."""
+    _require_targets_flag(RUN_TESTS)
+    proc = _run([str(RUN_TESTS), "--targets", "   ", "--check-floors",
+                 str(REPO_ROOT)])
+    assert proc.returncode == 3, (
+        f"expected exit 3 for an empty selection, got {proc.returncode}.\n"
+        f"{proc.stdout}\n{proc.stderr}"
+    )
+
+
+def test_a_subset_may_NARROW_the_set_but_never_WIDEN_it():
+    """A devhost target under `--set hermetic` is an error, not an implicit
+    `--set all`.
+
+    The two sets exist because devhost targets need a real desktop; letting
+    `--targets` reach into the other set would run them in an environment that
+    cannot satisfy them, and the failure would look like a code defect.
+    """
+    _require_targets_flag(RUN_TESTS)
+    devhost = "scripts/devhost-tests"
+    assert devhost in RUN_TESTS.read_text(), (
+        f"{devhost} is no longer declared; pick another DEVHOST_TARGETS entry"
+    )
+    proc = _run([str(RUN_TESTS), "--targets", devhost, "--check-floors",
+                 str(REPO_ROOT)])
+    assert proc.returncode == 3, (
+        f"a devhost target under --set hermetic must be FATAL, got "
+        f"{proc.returncode}.\n{proc.stdout}\n{proc.stderr}"
+    )
+
+
+def test_a_pinned_skip_whose_TARGET_did_not_run_does_not_count():
+    """🔴 The guard that a subset run broke, pinned BEHAVIOURALLY.
+
+    EXPECTED_SKIPS entries are keyed by target. `_skip_entry_applies` honoured
+    the entry's CONDITION but not whether its target was in the run, so a subset
+    that excluded every pinned target still counted them:
+
+        ERROR: 1 test(s) skipped, but 2 of 3 pinned entries apply here.
+
+    The run was correct and the guard called it a failure — how a gate teaches
+    people to ignore it.
+
+    ⚠ This asserts BEHAVIOUR, not source text. The first version checked that
+    `for _t in "${TARGETS[@]}"` appeared in the function; deleting the `if` that
+    USES that loop's result left the loop in place and the test green. Watched:
+    that mutant survived. A source check could see the ingredient and not the
+    decision, which is the whole failure mode.
+
+    Runs ONE tiny target that owns no pinned skip, so a broken predicate counts
+    >0 expected skips against 0 observed and the run goes red.
+    """
+    _require_targets_flag(RUN_TESTS)
+    tiny = "scripts/collector/i3/tests"
+    assert tiny in _hermetic_targets(), (
+        f"{tiny} is no longer a declared target; pick another small one that "
+        "does not appear in EXPECTED_SKIPS"
+    )
+    src = RUN_TESTS.read_text()
+    m = re.search(r"EXPECTED_SKIPS=\((.*?)\n\)", src, re.S)
+    assert m, "could not find EXPECTED_SKIPS in run-tests.sh"
+    pinned_dirs = {e.split("|")[0] for e in re.findall(r'^\s*"([^"]+)"', m.group(1), re.M)}
+    assert tiny not in pinned_dirs, (
+        f"{tiny} now owns a pinned skip, so it can no longer isolate this "
+        f"property. Pinned targets: {sorted(pinned_dirs)}"
+    )
+    proc = subprocess.run(
+        ["bash", str(RUN_TESTS), "--targets", tiny, str(REPO_ROOT)],
+        cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=300,
+    )
+    combined = proc.stdout + proc.stderr
+    assert "pinned entries apply here" not in combined, (
+        "a subset excluding every pinned-skip target still counted pinned "
+        f"entries — `_skip_entry_applies` is not filtering on TARGETS.\n{combined}"
+    )
+    assert proc.returncode == 0, (
+        f"a single-target subset run should pass, got {proc.returncode}.\n{combined}"
+    )


### PR DESCRIPTION
Groundwork for CI impact analysis — running only the suites a change could have broken. **This lands the mechanism only**: nothing selects targets automatically yet and the gate still runs everything.

## Why a mechanism and not a path filter

A subset run asserts that the unselected targets could not have caught the change, and nothing here can check that claim. So its failure mode is a **green run that never executed the suite holding the regression**, and every design choice follows from that:

- an **unknown** target is FATAL (exit 3), never dropped. `--targets scripts/dl-router` — no `/tests` — is a real directory and an obvious thing to type; under a prefix filter it selects nothing and exits 0 having tested nothing, which reads exactly like a pass
- an **empty** selection is FATAL. "Nothing to run" is not a verdict this script may reach
- selection **narrows**, never widens: a devhost target under `--set hermetic` is an unknown-target error, not an implicit `--set all`
- a subset run **says so** on stderr, and the floor line says it summed the *selected* targets. Its verdict is otherwise byte-identical to a full run's

## The floor needed no work

GUARD 3's global floor is already `sum over $TARGETS`, so narrowing the array narrows the floor. Probed: a 2-target run reports `floor: 575 = sum of 2 per-target floors`. The risk I expected to be largest was already closed in the repo.

## The actual bug, which a partial run made reachable

`_skip_entry_applies` honoured an `EXPECTED_SKIPS` entry's *condition* but not whether its target was in the run, so a subset counted pins for suites that never executed:

```
ERROR: 1 test(s) skipped, but 2 of 3 pinned entries apply here.
```

A correct run, failed by its own guard. Now filtered on `TARGETS` membership, ordered before the condition arm so an entry from an untouched target cannot set `fail`.

⚠️ That filter is **gated on a subset being active**. An unconditional version broke 8 tests in `test_conditional_skip_pins.py`, which drives this predicate with synthetic ledgers naming dirs that are not real targets — the only way to exercise the condition grammar. Filtering unconditionally silently disabled those grammar checks. It looked like a strict improvement.

## Two traps the full suite caught that nothing faster did

Both are now comments at the site:

- that harness extracts blocks from `run-tests.sh` by **unique text anchors** and asserts each occurs once. A comment I added quoted an anchor verbatim — **11 tests red, from prose**. All six anchors re-verified unique
- it also extracts `_skip_entry_applies` and runs it under `bash -u`, where neither `ONLY_TARGETS` nor `TARGETS` exists. A bare `$ONLY_TARGETS` aborts with exit 127 — hence `${ONLY_TARGETS:-}`

## Tests

6 new, every one watched to fail on a mutant: membership decision removed · membership always-true · announcement dropped · floor label lying · `${ONLY_TARGETS:-}` reverted (that one takes 11 tests red, so it is covered rather than merely asserted).

🔴 **Two of them were vacuous on the first mutation run**, which is worth naming: one asserted the `for _t in "${TARGETS[@]}"` loop *existed*, and deleting the `if` that used its result left it green — the ingredient, not the decision. The other asserted `"SUBSET"` appeared in the output, which the floor line's own "a SUBSET of hermetic" already satisfied. Both are now behavioural.

## Verification

- **dev-host tier**: `RESULT: PASS` — 18,834 collected, 18,832 passed, 2 skipped, 0 failed
- an earlier run was red on `test_skill_tiers.py`, which is **not from this branch**: controlled by running it at clean `origin/main` (passes) and at this branch's base (fails). Fixed by #1069 after the branch was cut; rebased onto it
- **sandbox tier** (`nix build .#checks.x86_64-linux.pytests`) — the tier Tekton gates on — running; I will post the result

## What this does not do

Nothing picks targets automatically. Mapping changed paths to targets is a separate, fallible decision and is deliberately outside this script.

Two measured findings for whoever takes that on:
- the gated tier is **structurally blind to git** (`cp -r ${./.} src` has no `.git`), so impact analysis cannot be computed inside `nix build` — it has to be computed in the clone step and written into the tree
- a mapping alone is worth **~1.7×** on the last 25 merged PRs, because every subsystem is referenced from inside `scripts/tests`. It is worth **~3.6×** only if `scripts/tests` is first decomposed into its repo-wide scanners and its subsystem-specific tests