### PR TITLE
fix(browser-bridge tests): the origin-token test asserted an ORDER the spool never promised

### DIFF
--- a/scripts/browser-bridge/tests/test_server.py
+++ b/scripts/browser-bridge/tests/test_server.py
@@ -3324,20 +3324,72 @@ def test_the_two_origin_tokens_are_distinct_and_recorded_verbatim(telemetry):
 
     Asserted as distinctness plus verbatim round-trip, so a mutant that collapsed
     them to a single constant dies here rather than in a test that only checks
-    `origin` is truthy."""
+    `origin` is truthy.
+
+    🔴 ORDER IS NOT PART OF THAT CLAIM, AND ASSERTING IT MADE THIS TEST FLAKY.
+    It used to read `seen == list(ORIGIN_TOKENS)` off a bare
+    `_wait_events(spool_dir, 2)`. Observed 2026-08-29 in the `nix build
+    .#checks…pytests` sandbox tier on an unchanged tree:
+    `AssertionError: ['opencode-inherited', 'browser-agent']` — both tokens
+    present, verbatim, REVERSED. A re-run of the identical derivation passed, and
+    the test passed 8/8 in isolation, so the failure is a race and not a
+    regression: the emit runs off the critical path AFTER the HTTP response
+    (see `_wait_events`), so the first command's emit can still be in flight when
+    the second one's lands.
+
+    Two independent defects were in that one line, and routing fixes only one:
+      * FOREIGN ROWS — a bare count assumes every row in the spool is this
+        test's, which `_wait_ops`' docstring measures as false. Fixed the
+        established way: both commands routed to an instance id minted per run,
+        selected with `where=_routed_to(inst)`.
+      * ORDER — routing does NOT pin it. Fixed by comparing SORTED, because
+        which of the two landed first was never something this test set out to
+        pin. Sorting keeps the mutant that matters dead: collapsing both origins
+        to one constant yields `['x','x']`, which no ordering makes equal to two
+        distinct tokens.
+
+    🔴 WHY AN ORDER-SAFETY AUDIT WALKED PAST THIS SITE — A BUCKETING ERROR, not
+    an oversight, and worth more than the fix. `_wait_events`' docstring audits
+    its own n>=2 sites and concludes "All 8 remaining real waits are order-safe".
+    This call was `_wait_events(spool_dir, len(ORIGIN_TOKENS))` — an n=2 wait
+    spelled with a NON-LITERAL `n`, which that docstring's counting
+    (`39 n=1 + 5 until= + 9 n>=2`) folds into the n=1 bucket. n=1 needs no
+    ordering argument, so the site was never in the population the audit
+    examined. `test_positional_spool_reader_ratchet` classifies it correctly, in
+    a `n dynamic` sub-bucket its own comment calls "informational" — and the
+    totals agreeing at 48 is exactly what made the disagreement look harmless.
+    The two counts differed only in WHICH BUCKET, and the bucket was the part
+    that mattered.
+
+    An earlier draft of this docstring said "this site was a NINTH n>=2 site".
+    That was wrong in the same direction as the bug: it was never counted among
+    the nine.
+
+    ⚠ NOT FIXED HERE, and named so it is not mistaken for covered:
+    `test_an_absent_origin_header_is_not_the_same_as_an_empty_one` unpacks its
+    pair POSITIONALLY and says in so many words that order between its two rows
+    IS the signal — so it carries this same race, with routing that cannot help
+    it. It issues both commands before waiting, so its order is not structurally
+    pinned either. It has not been seen to fail, and it was not changed on the
+    strength of a theory; making it safe means sequencing (wait for the first
+    row, then issue the second), which is a change to a passing test and belongs
+    in its own PR."""
     spool_dir = telemetry
     assert len(set(ORIGIN_TOKENS)) == len(ORIGIN_TOKENS), ORIGIN_TOKENS
+    # Unique per RUN, so a test added later cannot defeat the filter.
+    inst = "origin-tokens-" + uuid.uuid4().hex[:12]
     srv, _ = _serve()
-    ext = FakeExtension(srv)
+    ext = FakeExtension(srv, instance_id=inst)
     ext.start()
     try:
         assert _wait_connected(srv, want=True)
         for token in ORIGIN_TOKENS:
-            assert _cmd_sess(srv, {"op": "tabs"}, sid=LEAKED_ID,
+            assert _cmd_sess(srv, {"op": "tabs", "target": inst}, sid=LEAKED_ID,
                              origin=token)[0] == 200
-        evs = _wait_events(spool_dir, len(ORIGIN_TOKENS))
-        seen = [json.loads(e["payload"])["origin"] for e in evs]
-        assert seen == list(ORIGIN_TOKENS), seen
+        evs = _wait_ops(spool_dir, "tabs", len(ORIGIN_TOKENS),
+                        where=_routed_to(inst))
+        seen = sorted(json.loads(e["payload"])["origin"] for e in evs)
+        assert seen == sorted(ORIGIN_TOKENS), seen
     finally:
         ext.stop(); srv.shutdown(); srv.server_close()
 

--- a/scripts/collector/keylog/espanso_detect.py
+++ b/scripts/collector/keylog/espanso_detect.py
@@ -75,6 +75,28 @@ ESPANSO_SEARCH_WM_CLASS = ".espanso-wrapped"
 # and ':dacq' spells it — plus 'clarifying', which 'clarify' is a substring of —
 # because "ask"/"clarify" is how the dispatch snippet is actually searched for.
 # ':acq' ("ask clarifying questions") is what a bare 'ask' MEANS.
+#
+# 🔴 BLIND SPOT, MEASURED — THE LOOKUP IS AN EXACT-STRING MATCH, SO PREFIXES OF
+# AN OWNED TERM ARE NOT OWNED. `_term_matches` is a SUBSTRING test, so a typed
+# prefix reaches both snippets and lands on the ambiguous branch, where
+# `.get(t)` then misses because the typed string is not a key. Measured
+# 2026-08-30 against the real keylog search stream (661 espanso rows): "ask"
+# resolves because it is typed EXACTLY, 118 times — but "clar" (1 fire ever)
+# now resolves to None, where before ":dacq" spelled "clarifying" it reached
+# ":acq". Prefix typing is the norm here, not the exception: "rec"/"recom",
+# "kic", "orch" are all how the picker is really driven.
+#
+# NOT fixed with per-prefix entries — "cla"/"clari"/"clarif" are equally valid
+# prefixes and the table cannot enumerate them. The real options are to make the
+# lookup prefix-aware (an owner claims a typed term that is a prefix of an owned
+# one AND matches that owner) or to accept it. ACCEPTED, on the measurement: one
+# fire in the entire recorded history does not justify the mechanism, and a
+# prefix-aware lookup can re-point terms the exact form never touched, so it
+# needs its own mutation battery.
+#
+# Same measurement, recorded so it is not re-litigated: "clarifying" has been
+# typed ZERO times, so it gets no entry — an owner justified by intuition rather
+# than the search stream is exactly what this comment exists to prevent.
 _AMBIGUOUS_TERM_OWNER = {
     "ask": ":acq",
     "clarify": ":acq",

--- a/scripts/tests/test_positional_spool_reader_ratchet.py
+++ b/scripts/tests/test_positional_spool_reader_ratchet.py
@@ -112,28 +112,41 @@ POSITIONAL_BUCKET = "_wait_events positional (no until=)"
 # 🔴 Measured by THIS module's own `classify_wait_calls()` -- never by grep, and
 # never by hand -- over `scripts/browser-bridge/tests` at:
 #
-#     BASE SHA   20beb3c4  ("docs(handoff): #783's residual is DECIDED ...")
-#     DATE       2026-08-26
+#     BASE SHA   this branch (PR #1074), the commit that lowers the pin to 47.
+#                Deliberately not a hex sha: the measurement is OF the commit
+#                doing the lowering, so any sha written here would be the one
+#                before the change it describes.
+#     DATE       2026-08-30
 #
-# Full breakdown at that sha, all six buckets, 62 call sites total:
+# Full breakdown at that commit, re-measured by `classify_wait_calls()` (never by
+# hand), all six buckets, 62 call sites total:
 #
-#     48  _wait_events positional (no until=)   <- RATCHETED
+#     47  _wait_events positional (no until=)   <- RATCHETED
 #              38  of which n literal 1 / defaulted
 #               9  of which n >= 2
-#               1  of which n dynamic
+#               0  of which n dynamic
 #      5  _wait_events until=                        SAFE
 #      4  _wait_ops op-only                          discriminated by op
-#      2  _wait_ops where=                           discriminated by op + row
+#      3  _wait_ops where=                           discriminated by op + row
 #      3  _wait_payload op-only                      discriminated by op
 #
-# ⚠ The 38/1 split is where a SECOND counting method disagreed, and it is worth
-# recording because it is the same class of error the AST rule exists to stop.
-# A first-pass probe treated a NON-LITERAL `n` as the default 1 and reported
-# `39 n=1 + 9 n>=2`; the classifier below reports the one dynamic site
-# (`_wait_events(spool_dir, len(ORIGIN_TOKENS))`, in
-# `test_the_two_origin_tokens_are_distinct_and_recorded_verbatim`) as its own
-# sub-bucket. The two agree on 48, which is the number that is ratcheted -- the
-# sub-split is informational and nothing gates on it.
+# ⚠ The dynamic sub-bucket went 1 -> 0 and `_wait_ops where=` 2 -> 3: the SAME
+# site moved between them. `_wait_events(spool_dir, len(ORIGIN_TOKENS))` in
+# `test_the_two_origin_tokens_are_distinct_and_recorded_verbatim` became
+# `_wait_ops(spool_dir, "tabs", …, where=_routed_to(inst))` after it flaked in
+# the sandbox tier (2026-08-29, both origin tokens verbatim but REVERSED).
+#
+# 🔴 AND THE SUB-SPLIT EARNED ITS KEEP -- read this before calling it
+# informational. The `_wait_events` docstring audited its own n>=2 sites and
+# concluded "All 8 remaining real waits are order-safe". That audit could not
+# see the site that actually flaked, because its own counting (`39 n=1 + 5
+# until= + 9 n>=2`) folded the DYNAMIC site into n=1 -- exactly the first-pass
+# error recorded here, where a NON-LITERAL `n` reads as the default 1. A site
+# whose `n` is `len(...)` is an n>=2 site in every way that matters to ordering,
+# and bucketing it as n=1 is what let an order-dependent assertion sit outside
+# an order-safety audit for four days. The two methods still agree on the
+# RATCHETED total; they disagreed about which bucket, and the bucket was the
+# part that mattered.
 #
 # ⚠ The `_wait_ops op-only` figure of 4 includes ONE call that is not a test
 # site: `_wait_payload`'s own body calls `_wait_ops(spool_dir, op, 1, **kw)`.
@@ -151,7 +164,7 @@ POSITIONAL_BUCKET = "_wait_events positional (no until=)"
 #: How many positional `_wait_events` call sites the corpus is allowed to have.
 #: Two-way: growing this is a REGRESSION, shrinking it is a WIN that must be
 #: banked by editing this number and the ledger in the same commit.
-PINNED_POSITIONAL_TOTAL = 48
+PINNED_POSITIONAL_TOTAL = 47
 
 #: Per-enclosing-function ledger of the same 48 sites, keyed
 #: `<file>::<dotted function path>`. Line numbers are deliberately NOT pinned --
@@ -197,7 +210,6 @@ PINNED_POSITIONAL_SITES = {
     "test_server.py::test_the_release_short_circuit_attributes_an_ordinary_session": 1,
     "test_server.py::test_the_same_id_fills_the_session_when_no_origin_is_declared": 1,
     "test_server.py::test_the_session_column_carries_the_bare_id_not_the_wire_tag": 1,
-    "test_server.py::test_the_two_origin_tokens_are_distinct_and_recorded_verbatim": 1,
     "test_server.py::test_upload_dispatches_and_audit_event_has_op_domain_path": 1,
     "test_server.py::test_wait_events_reports_a_timeout_instead_of_returning_short": 1,
     "test_server.py::test_wake_telemetry_is_metadata_only": 1,


### PR DESCRIPTION
## The flake

Observed 2026-08-29 in the `nix build .#checks.x86_64-linux.pytests` sandbox tier, on an **unchanged tree**:

```
AssertionError: ['opencode-inherited', 'browser-agent']
assert ['opencode-in...rowser-agent'] == ['browser-age...de-inherited']
```

Both tokens present, both verbatim, **reversed**. A re-run of the identical derivation passed (`rc=0`), and the test passed 8/8 in isolation — so it's a race, not a regression. The mechanism is in `_wait_events`' own docstring: the emit runs off the critical path **after** the HTTP response, so the first command's emit can still be in flight when the second one's lands. Nothing orders them.

It cost a full ~10-minute sandbox cycle to prove it wasn't the change under test, and it sits on a **required** check with `enforce_admins: true` — no override, and the failure reads as a bad diff.

## Two defects in one line; routing fixes only one

- **Foreign rows** — `_wait_events(spool_dir, 2)` assumes every row in the spool is this test's, which `_wait_ops`' docstring *measures* as false (`ACTIVITY_SPOOL_DIR` is process-global and re-pointed per test). Fixed the established way: both commands routed to a per-run instance id, selected with `where=_routed_to(inst)` — the same idiom `test_an_absent_origin_header_is_not_the_same_as_an_empty_one` already uses.
- **Order** — routing does **not** pin it. Fixed by comparing `sorted`. Which token landed first was never part of this test's claim, which is *distinctness plus verbatim round-trip*.

## Sorting did not weaken it — mutation-verified

The mutant this test exists to kill is still dead. Collapsing `payload["origin"]` to the single constant `"browser-agent"` (`server.py:1418`) → **FAILED in 1.82s**; source restored byte-identical → **passed in 1.17s**. `['x','x']` cannot equal two distinct tokens under any ordering.

Suites: **461 passed** (browser-bridge), **101 passed** (keylog).

🔴 **I cannot reproduce the race on demand, and am not claiming a watched-fail.** The fix removes the *dependency*, not the race. What is verified is the property, not the timing.

## A claim this makes true again

`_wait_events` says of its n>=2 sites: *"All 8 remaining real waits are order-safe — either they wait for the earlier event before issuing the next request, so file order is pinned structurally, or they assert something order-independent."* This site was a **ninth** that did neither. It is order-independent now, which makes that sentence true rather than merely re-counted.

## ⚠ Named, not fixed

`test_an_absent_origin_header_is_not_the_same_as_an_empty_one` unpacks its pair **positionally** and states that order between its two rows *is* the signal — so it carries this same race, with routing that cannot help it, and it also issues both commands before waiting. **It has never been seen to fail and was not changed on the strength of a theory.** Making it safe means sequencing (wait for the first row, then issue the second) — a change to a passing test, and its own PR.

## Batched (unrelated, to save a CI cycle on a saturated cluster)

Records the **measured** blind spot in `_AMBIGUOUS_TERM_OWNER` from #1060: the lookup is an exact-string match while `_term_matches` is a substring test, so **prefixes of an owned term are not owned**. Measured against the real keylog stream (661 espanso rows) — `ask` resolves because it is typed exactly, 118×; `clar` (1 fire ever) now resolves to `None`. Prefix typing is the norm here (`rec`/`recom`/`kic`/`orch`).

**Accepted rather than patched**: per-prefix entries can't enumerate `cla`/`clari`/`clarif`, and a prefix-aware lookup can re-point terms the exact form never touched, so it needs its own mutation battery. The same measurement records that `clarifying` has been typed **zero** times and so gets no entry — an owner justified by intuition instead of the search stream is exactly what the comment exists to prevent.

Comment-only in that file; no behaviour change.