### PR TITLE
fix(session-manager,tests): close both knowingly-deferred items — excluded_shells published a measured zero, and the row ledger's guard could not see a deletion (#1031)

### DIFF
--- a/claude/skills/session-manager/reference/payload-contract.md
+++ b/claude/skills/session-manager/reference/payload-contract.md
@@ -62,8 +62,12 @@ matched nothing" about a scan that measured nothing — the rule `detail_matched
 followed. The **terms and the field list are still published** over an unreachable fleet:
 which filter was *requested* is known regardless of whether anything answered.
 ⚠ A **partially** reachable fleet publishes real counts — one host answering is a
-measurement. ⚠ `excluded_shells` has the same shape and is deliberately **not**
-null-guarded: it is a pre-existing field and redefining it belongs in its own change.
+measurement. 🔴 **`excluded_shells` and its `summary` mirror now follow the SAME rule**
+(#1031): `null` over an unreachable fleet, a real count otherwise. Until that landed the
+two halves of one render contradicted each other — `FILTER --claude-only: 0 shell
+window(s) excluded` beside `FILTER --match 'x': an unmeasured number of row(s) matched` —
+so a consumer reading the first line learned a measured-looking zero about a fleet nobody
+reached.
 
 🔴 **`summary.matched` is NOT `summary.total_sessions`.** On a `detail` they differ by
 construction — the row filter matched N, then `filter_report` narrowed to 0 or 1. The

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -2509,8 +2509,11 @@ def summarize(report) -> dict:
         # `--claude-only` every number above describes the FILTERED set (see
         # `gather`), so a reader that does not know the filter ran would read a
         # real "0 agent windows" and a "0 because the shells were dropped"
-        # identically. `excluded_shells` is None — not 0 — when the filter
-        # never ran: nothing was excluded because nothing was ever counted.
+        # identically. `excluded_shells` is None — not 0 — in TWO states: when
+        # the filter never ran (nothing was excluded because nothing was ever
+        # counted), and when NO HOST ANSWERED (#1031 item 1 — a count over a
+        # fleet nobody reached is not a zero). Same rule as `excluded_by_match`;
+        # they used to disagree, and one render printed both.
         #
         # 🔴 IT IS `excluded_shells`, NOT `excluded_non_claude`. The old name
         # was accurate only while the predicate was `r["claude"]` and every row
@@ -3261,13 +3264,23 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
         # would publish a confident `0` — "the filter ran and matched nothing"
         # — about a scan that measured nothing at all. `detail_matched` is
         # already `None` in exactly this state; these now agree with it.
-        # ⚠ `excluded_shells` has the SAME shape and is deliberately NOT changed
-        # here: it is a pre-existing published field with its own tests, and
-        # redefining it belongs in its own change, not smuggled into this one.
+        # 🔴 `excluded_shells` NOW AGREES — #1031 item 1. It used to publish a
+        # hard `0` in exactly this state, which made the two FILTER lines of one
+        # render contradict each other about what an unreachable fleet means:
+        #
+        #     FILTER --claude-only: 0 shell window(s) excluded
+        #     FILTER --match 'x': an unmeasured number of row(s) matched
+        #
+        # The deferral was deliberate — it is a pre-existing published field, so
+        # redefining it wanted its own change rather than a drive-by inside the
+        # find-session PR. This is that change. MEASURED before it, on
+        # `715df9e4`, against a genuinely unreachable single-host fleet:
+        # `excluded_shells: 0` beside `excluded_by_match: None`.
         fleet_measured = any(h.get("reachable")
                              for h in report["hosts"].values())
         if claude_only:
-            report["filters"]["excluded_shells"] = excluded_shells
+            report["filters"]["excluded_shells"] = (
+                excluded_shells if fleet_measured else None)
         if match_terms:
             # 🔴 THE TERMS AND THE FIELDS TRAVEL WITH THE VERDICT. A consumer
             # that finds zero rows must be able to tell "nothing matched these

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -6530,6 +6530,33 @@ def test_the_documented_JSON_ROW_PATH_is_where_the_rows_actually_are():
     assert 'report["hosts"][<"workbench"|"laptop">]["windows"]' in sm.__doc__
 
 
+#: Delimits the docstring's row enumeration. BOTH anchors are load-bearing: the
+#: opener alone would run to the end of the docstring and re-admit every name
+#: that merely appears somewhere, which is the gap #1031 item 2 exists to close.
+_ROW_BLOCK_RE = re.compile(
+    r"Each row carries:(.*?)\.\s+The row ledger is pinned by a test\.", re.S)
+
+
+def _documented_row_fields() -> set:
+    """Row names from the docstring's `Each row carries:` block ONLY.
+
+    🔴 A MISSING BLOCK IS LOUD, NEVER AN EMPTY SET. If the docstring is reworded
+    so the anchors stop matching, an empty return would compare unequal to
+    `expected` and read as "the docs dropped every field" — a confusing red for
+    the wrong reason. Worse, an earlier draft that returned `set()` and was
+    compared with `<=` would have gone permanently GREEN. Fail here, naming the
+    anchor, so the fix is to re-point the regex rather than delete the guard.
+    """
+    match = _ROW_BLOCK_RE.search(sm.__doc__ or "")
+    assert match, (
+        "the module docstring has no `Each row carries: … . The row ledger is "
+        "pinned by a test.` block, so this guard is reading nothing. The "
+        "docstring was reworded — re-point `_ROW_BLOCK_RE`, do NOT widen this "
+        "back to a whole-`__doc__` substring check (#1031 item 2).")
+    names = {word.strip() for word in match.group(1).replace("\n", " ").split(",")}
+    return {name for name in names if name}
+
+
 def test_the_row_FIELD_LEDGER_fails_when_it_grows_or_shrinks():
     """🔴 Both directions. A field that disappears turns a consumer's read into
     a permanent None; one that appears undocumented is a contract nobody
@@ -6561,8 +6588,27 @@ def test_the_row_FIELD_LEDGER_fails_when_it_grows_or_shrinks():
         "panes",
     }
     assert set(row) == expected
-    for field in expected:
-        assert field in sm.__doc__, f"{field} is undocumented in the header"
+    # 🔴 THE ROW-ENUMERATION BLOCK, NOT THE WHOLE `__doc__` (#1031 item 2).
+    # This used to be `assert field in sm.__doc__` — a substring test across a
+    # 275-line docstring. MEASURED: 24 of the 32 row names also occur elsewhere
+    # in that docstring, including all three fields involved in the #992 merge
+    # region (`hotkey_display`, `pane_preview`, `pane_preview_status`), so
+    # deleting a name from the enumeration left the guard green while the
+    # enumeration it claims to pin was wrong. Re-measured on `715df9e4` before
+    # this change: removing `hotkey_display` from the block -> 2 passed.
+    #
+    # Scoped to the block AND compared as a SET, so it fails in BOTH directions:
+    # a name dropped from the enumeration, and a name added to it that no row
+    # carries. The `in` loop could only ever see the first, and only when the
+    # word appeared nowhere else.
+    documented = _documented_row_fields()
+    assert documented == expected, (
+        "the module docstring's `Each row carries:` block and the row payload "
+        "disagree:\n"
+        f"  in the docstring only: {sorted(documented - expected)}\n"
+        f"  on the row only      : {sorted(expected - documented)}\n"
+        "Update the block — it is the header a consumer reads before touching "
+        "a field.")
 
 
 # =========================================================================== #
@@ -11309,6 +11355,50 @@ def test_a_PARTIALLY_reachable_fleet_still_publishes_real_counts():
     got = base_gather(runner=runner, use_fuzzyclaw=False, match=["zzkiwi"])
     assert got["filters"]["matched"] == 1
     assert got["filters"]["excluded_by_match"] == 2
+
+
+# --------------------------------------------------------------------------- #
+# #1031 item 1 — `excluded_shells` publishes the SAME null, so one render's two
+# FILTER lines cannot disagree about what an unreachable fleet means.
+# --------------------------------------------------------------------------- #
+def test_excluded_shells_is_None_not_ZERO_over_an_unreachable_fleet():
+    """🔴 THE ASYMMETRY THIS CLOSES. Both halves of one output used to read:
+
+        FILTER --claude-only: 0 shell window(s) excluded
+        FILTER --match 'x': an unmeasured number of row(s) matched
+
+    A hard `0` there says "the filter ran and excluded nothing" about a fleet
+    nobody reached. `excluded_by_match` was corrected during the #989 ladder;
+    this field was knowingly deferred (#1031) because it is pre-existing and
+    published, and redefining it wanted its own change. This is that change.
+    """
+    down = make_runner(local_rc=1, local_err="tmux: connection failed",
+                       remote_rc=255, remote_err="ssh: no route")
+    got = base_gather(runner=down, use_fuzzyclaw=False, claude_only=True)
+    assert got["filters"]["excluded_shells"] is None
+    assert got["summary"]["excluded_shells"] is None, (
+        "the summary mirror still publishes a measured-looking count — the two "
+        "publishers disagree, which is the shape this closes")
+
+
+def test_excluded_shells_IS_a_real_zero_when_the_fleet_ANSWERED():
+    """The measured counterpart, so the `None` above is a FILTER DECISION and
+    not a field quietly wired to null. Without this, deleting the count entirely
+    would pass the test above."""
+    runner = make_runner(local_panes=MATCH_PANES, local_windows=MATCH_WINDOWS,
+                         remote_panes="", remote_windows="")
+    got = base_gather(runner=runner, use_fuzzyclaw=False, claude_only=True)
+    assert got["filters"]["excluded_shells"] is not None
+    assert isinstance(got["filters"]["excluded_shells"], int)
+
+
+def test_excluded_shells_survives_a_PARTIALLY_reachable_fleet():
+    """Same boundary as its sibling: one host answering is a measurement, so the
+    null must NOT fire on the fleet's common degraded state."""
+    runner = make_runner(local_panes=MATCH_PANES, local_windows=MATCH_WINDOWS,
+                         remote_rc=255, remote_err="ssh: no route")
+    got = base_gather(runner=runner, use_fuzzyclaw=False, claude_only=True)
+    assert got["filters"]["excluded_shells"] is not None
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes both items in #1031. Each was deferred from the #989 ladder on purpose — both change something pre-existing with its own readers — and #1031 exists so the deferral was a tracked object rather than a sentence in a merged PR body.

## Item 1 — `excluded_shells` is `null`, never `0`, over an unreachable fleet

Two halves of **one render** contradicted each other:

```
FILTER --claude-only: 0 shell window(s) excluded
FILTER --match 'x': an unmeasured number of row(s) matched
```

A hard `0` says *"the filter ran and excluded nothing"* about a fleet nobody reached. `excluded_by_match` was corrected in-ladder; this field was not, so the two disagreed about what an unmeasured fleet means.

**MEASURED** against a genuinely unreachable single-host fleet before the change: `excluded_shells: 0` beside `excluded_by_match: None`. After: both `null`, summary mirror included, and the two FILTER lines read the same way. The renderer already handled `None`, so this is the assignment only.

Three tests, matching the sibling's shape:

| test | why it exists |
|---|---|
| null when nothing answered | the item itself |
| **a real count when the fleet answered** | so the null is a FILTER DECISION and not a field quietly wired to null — without it, deleting the count entirely would pass |
| a real count on a **partially** reachable fleet | one host answering is a measurement; a null there would fire on the fleet's most common degraded state |

Matrix: **red at `origin/main`** (`assert 0 is None`), green at HEAD.

## Item 2 — the row-field ledger is scoped to the docstring's enumeration block

`assert field in sm.__doc__` was a substring test across a 275-line docstring. 24 of 32 row names also occur elsewhere in it, so deleting a name from the enumeration left the guard green.

**RE-MEASURED on `715df9e4` before changing anything:** removing `hotkey_display` from the block → **2 passed**, because the word still appears twice elsewhere in the docstring.

Now parsed out of the `Each row carries: … . The row ledger is pinned by a test.` block and compared as a **SET**, so it fails in **both** directions — a name dropped from the enumeration, and a name added that no row carries. The `in` loop could only ever see the first, and only when the word appeared nowhere else.

The same mutant now dies with its **own named assertion** — `on the row only: ['hotkey_display']` — which is exactly what #1031's closing condition asks for ("not with a sibling test's error").

⚠ A missing block is a **loud failure naming the anchor**, never an empty set. An empty return would compare unequal and read as "the docs dropped every field" — a red for the wrong reason — and under a subset comparison would have gone permanently green.

## Docs updated in the same commit

`payload-contract.md` and the source comment both described the asymmetry as **deliberate**. Left alone they would now be false claims about shipped behaviour.

## Gate — merged tree (`3d8caaa1` + this branch), both tiers run SEQUENTIALLY

| tier | result |
|---|---|
| `devrc-pytests` | `collected=18835 passed=18833 skipped=2 failed=0` — `RESULT: PASS` |
| `devrc-nodetests` | `suites=5 files=38 tests=1366 pass=1366 fail=0` — `RESULT: PASS` |

⚠ Building both derivations in ONE `nix build` invocation produced two false failures earlier in this session (`SQLite database … is busy` evaluating `nix/home.nix`, and `OperationalError('database is locked')` in dl-router) from nested-nix store contention. Same tree passes one at a time. A combined run's RED is not trustworthy without a sequential re-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJ737dd7nvHxCgkWeTNjx6