### PR TITLE
docs(handoff): ranks 1-3 all closed — and #1030 is only HALF closed, which the old text would have hidden

### DIFF
--- a/claudedocs/handoff-find-session-live-first.md
+++ b/claudedocs/handoff-find-session-live-first.md
@@ -43,8 +43,9 @@ calls, 5 of them pure flailing.
   local host is scanned without ssh, so it cannot be made to fail genuinely — reaching that
   branch requires a stub, which is exactly what the rank-1 item existed to stop trusting. Say
   "stub-only" about it rather than "verified".
-- Open issues: **#1029** (three guard-walkability gaps), **#1030** (flake, second mechanism),
-  **#1031** (two deferrals). **#1028 closed**, verified fixed by #1023.
+- Open issues: **#1030** is HALF closed — #1062 fixed the backlog mechanism, the
+  `socket.py` timeout mechanism is confirmed STILL LIVE at 60 s. **#1029 closed** by
+  #1071. **#1031 closed** by #1076. **#1028 closed**, verified fixed by #1023.
 
 **What shipped — carried forward verbatim, this is durable and not status:**
 
@@ -161,6 +162,42 @@ COMMON degraded state". Quote the pair, never the 1.25 s alone.
 
 ## Open investigations — live diagnosis state
 
+### `test_subsystem_store_api.py` flake — the BACKLOG mechanism is CLOSED; the TIMEOUT one is NOT
+🔴 **STATUS 2026-08-30. Read this before the block below, which is preserved as the
+diagnosis that led here and is now partly historical.**
+
+- **Mechanism A (backlog) — FIXED, #1062 (`430fe3e1`), closes #1030.** `build_server` never
+  set `request_queue_size`, so the accept queue was the stdlib default **5** against a suite
+  that fires 8 concurrent appends. Controlled experiment through the real `build_server`,
+  200 racers × 3 rounds, varying ONLY the backlog: **5 → 389 `ConnectionResetError`;
+  128 → 0; 4096 → 0.** Fixed as `LISTEN_BACKLOG = 128`, a **class** attribute —
+  `TCPServer.__init__` calls `listen()` before returning, so an instance assignment moves
+  the name and leaves the socket at 5. The regression test counts LANDINGS ON THE SOCKET
+  (fills the accept queue while nothing accepts), so it is deterministic and kills that
+  wrong fix.
+  ⚠ **`net.ipv4.tcp_abort_on_overflow=0` appears to rule this mechanism out, and does not.**
+  That sysctl means overflow drops the SYN rather than resetting, so the theory looks dead.
+  The failing writers' elapsed times cluster at **1.0 s and 2.2 s** — TCP SYN-retransmit
+  intervals — i.e. the reset lands AFTER a retry. Do not re-derive this dead end.
+- **Mechanism B (`TimeoutError` out of `socket.py`) — STILL LIVE, and #1023 did NOT hold.**
+  Observed 2026-08-29 on `devrc-ci-hrqf4` (PR #1040, a **docs-only** diff):
+  `TimeoutError: timed out` at `socket.py:720` in
+  `TestTheActorComesFromTheTOKEN.test_a_FORGED_actor_in_the_body_is_DISCARDED`. #1023 raised
+  `HANG_TIMEOUT` 15 s → 60 s for exactly this; it recurred at 60 s. **This closes the open
+  question in #1030's last comment**, which reported the same test failing on docs-only
+  #1034 and said "I did not capture this run's exception — it may be a fourth". It is not a
+  fourth; it is B.
+- 🔴 **Why B happens: devrc CI is PINNED TO ONE NODE.** The PipelineRun carries
+  `nodeSelector: kubernetes.io/hostname=talos-xr6-r7p`. So "the cluster drained" is the
+  wrong load measure — during the failure that node was at **91%** CPU while the others sat
+  at 22–52%, and 87% at re-trigger. Any further work on B should start there, not at the
+  cluster-wide run count.
+- **Load-vs-assertion evidence, same tree, local vs Tekton:** the 203-test target went
+  3.30 s → **136.90 s (41×) and still PASSED**, while every other target inflated 1.8–2.6×.
+  Load inflates EVERY test; a real assertion inflates exactly one.
+
+**The original diagnosis, preserved:**
+
 ### `test_subsystem_store_api.py` concurrent-append flake — TWO distinct mechanisms, only one fixed
 - **Symptom + exact repro:** `tekton/devrc-pytests` (a **required** check with
   `enforce_admins: true`) fails intermittently on
@@ -195,25 +232,36 @@ COMMON degraded state". Quote the pair, never the 1.25 s alone.
   check whether a hook writes it.
 
 ## Next steps (ranked)
-🔴 **RENUMBERED TWICE, deliberately.** The original item 1 (deploy) and then the
-partial-fleet verification both closed, so everything has shifted up by two. `claim-work
---list` was checked before each renumber. The rank-1 claim
-`find-session-live-first-1` was **released on completion** — a new rank 1 must be claimed
-under the slug `claim-work --slug-for` prints today, which is the SAME string for a
-DIFFERENT item. Derive it fresh; do not reuse a slug from an older copy of this list.
+🔴 **RENUMBERED THREE TIMES.** Deploy, then the partial-fleet verification, then ranks 1–3
+(#1030/#1029/#1031) all closed, so everything has shifted up by four in total. `claim-work
+--list` was checked before each renumber. 🔴 **The slug `claim-work --slug-for` prints for a
+rank is POSITIONAL — the same string names a DIFFERENT item after every renumber. Derive it
+fresh; never reuse one copied from an older version of this list.** All three
+`find-session-live-first-*` claims were released on completion.
 
-1. **#1030** — the store-api flake's SECOND mechanism (see the investigation block). ⚠ Someone
-   else holds `devrc-store-api-timeout-flake`, which is the *timeout* mechanism #1023 already
-   fixed — a different failure of the same test. Do not read that claim as covering this.
-   Repo: `devrc`.
-2. **#1029** — three residual guard-walkability gaps in
-   `scripts/tests/test_find_session_skill_contract.py`. Repo: `devrc`.
-3. **#1031** — two knowingly-deferred items (`excluded_shells` measured-zero asymmetry; the
-   row-field ledger's substring `__doc__` guard). Repo: `devrc`.
-4. **Inherited from `handoff-find-session-opencode.md`:**
+**CLOSED since the last revision — do not re-do these:**
+
+| was | issue | landed |
+|---|---|---|
+| rank 1 | **#1030** store-api listen backlog (mechanism A only) | **#1062** → `430fe3e1` |
+| rank 2 | **#1029** three guard-walkability gaps | **#1071** → `3d8caaa1` |
+| rank 3 | **#1031** both deferred items | **#1076** (open at time of writing) |
+
+⚠ **#1030 is only HALF closed.** #1062 fixed the backlog mechanism; the `socket.py`
+`TimeoutError` mechanism is confirmed still live at `HANG_TIMEOUT = 60 s` — see the
+investigation block, which now carries the captured exception and the node-pinning lead.
+Whether #1030 stays open or is re-filed against mechanism B is a judgement for whoever picks
+it up; the evidence is on the issue.
+
+1. **Inherited from `handoff-find-session-opencode.md`:**
    `scripts/claude-hooks/tests/test_bash_guard.py:294`'s "no catastrophic backtracking" check
    still asserts on wall-clock and flakes under load. Its sibling item (dirty
    `embed_enlarge.js`) is CLOSED — it landed as #1010. Repo: `devrc`.
+2. **The store-api flake's mechanism B** — the `socket.py` `TimeoutError` under scheduler
+   starvation, which #1023 was meant to fix and did not. Start at the **node pinning**
+   (`nodeSelector: talos-xr6-r7p`), not at the cluster-wide run count. Repo: `devrc` +
+   `homelab-talos` (the pipeline definition lives there). Closing condition is NOT yet
+   written; write one before starting.
 
 🔴 This list is a WORK QUEUE and `claim-work` is its lock — `claim-work --slug-for <this doc>
 <rank>`, then `claim-work <slug> --subject "<text>"`, and sweep `gh pr list --state open` too.
@@ -233,6 +281,26 @@ DIFFERENT item. Derive it fresh; do not reuse a slug from an older copy of this 
   exit codes were all genuine. **Ask which layer your fake occupies and whether the claim
   lives above it.** A netns pushes it to zero layers, at the cost of blacking out the network
   for everything in the process tree.
+- 🔴 **RUN THE TWO CHECK DERIVATIONS SEQUENTIALLY — a combined `nix build` produces FALSE
+  FAILURES.** `nix build .#checks.x86_64-linux.pytests .#checks.x86_64-linux.nodetests`
+  builds both at once, and the nested-`nix` tests inside them contend on the store:
+  measured 2026-08-30, `SQLite database … is busy` evaluating `nix/home.nix` plus
+  `OperationalError('database is locked')` in dl-router — **2 failures on a tree that passes
+  0 one at a time.** Load-dependent, so earlier combined runs were green and looked fine.
+  A combined run's GREEN is trustworthy (a contended run fails loudly, it does not fake a
+  pass); its **RED is not**, until re-checked sequentially. This cost a near-miss report of
+  "#1029 broke the gate".
+- 🔴 **A RED required check: read the EXCEPTION, never the test name.** The same test in
+  `test_subsystem_store_api.py` failed three different ways in one session, each wanting a
+  different response: `ConnectionResetError` (mechanism A — a real defect, now fixed),
+  `TimeoutError` at `socket.py` (mechanism B — starvation, legitimately re-triggerable),
+  and 45 × `big-lock: Permission denied` (CI infrastructure, nothing to do with the tree).
+  A fourth red was neither — it was the PR sitting on a **red `main`**, where re-triggering
+  can never help. "Red check → re-trigger" is the reflex that turns a gate into noise.
+- ⚠ **`nix build` reports exit 0 for a FAILED build when its output is piped.** `… | tail`
+  swallows the status; the run that failed 45 tests printed `NIXBUILD_RC=0`. Read the
+  runners' own `RESULT:` lines, which is what the repo already tells you to do — this is the
+  documented trap, hit anyway.
 - **Live-first is the whole design.** The archive walk is 30.1 s; the live scan is 1.82 s and
   already carries `task`/`path`/`label`/`hotkey`/`status`/`waiting_signals`/
   `claude_session_id`. For "check on something I believe is in flight", the archive is the

--- a/claudedocs/handoff-find-session-live-first.md
+++ b/claudedocs/handoff-find-session-live-first.md
@@ -187,14 +187,28 @@ diagnosis that led here and is now partly historical.**
   question in #1030's last comment**, which reported the same test failing on docs-only
   #1034 and said "I did not capture this run's exception — it may be a fourth". It is not a
   fourth; it is B.
-- 🔴 **Why B happens: devrc CI is PINNED TO ONE NODE.** The PipelineRun carries
-  `nodeSelector: kubernetes.io/hostname=talos-xr6-r7p`. So "the cluster drained" is the
-  wrong load measure — during the failure that node was at **91%** CPU while the others sat
-  at 22–52%, and 87% at re-trigger. Any further work on B should start there, not at the
-  cluster-wide run count.
-- **Load-vs-assertion evidence, same tree, local vs Tekton:** the 203-test target went
-  3.30 s → **136.90 s (41×) and still PASSED**, while every other target inflated 1.8–2.6×.
-  Load inflates EVERY test; a real assertion inflates exactly one.
+- 🔴 **B IS NOT (ONLY) STARVATION — do not start from the load hypothesis.** #1023 attributed
+  it to scheduler starvation and raised the timeout; that framing survived into an earlier
+  draft of this very block, and **two observations hours apart contradict each other:**
+
+  | | 2026-08-29 `devrc-ci-hrqf4` | 2026-08-30 `devrc-ci-8q8rt` |
+  |---|---|---|
+  | exception | `TimeoutError` @ `socket.py:720` | **the same** |
+  | 203-test target vs local | **41×** (3.30 s → 136.90 s) | **1.6×** (3.30 s → 5.28 s) |
+  | its node's CPU | **91%** | **44%** |
+  | all nodes | one saturated | 24–44% |
+
+  Same signature, essentially NO load the second time. So starvation is not sufficient to
+  explain B, and "raise the timeout" / "fix the scheduling" may both miss it. The honest
+  state is **uncharacterised**; treat the load story as a REFUTED first guess, not a lead.
+- ⚠ **The node-pinning fact is still true and still worth knowing, but it is NOT the
+  explanation.** The PipelineRun carries `nodeSelector:
+  kubernetes.io/hostname=talos-xr6-r7p`, so cluster-wide run counts say nothing about
+  whether a devrc run is contended. That mattered for the 91% occurrence and not for the
+  44% one.
+- **The load-vs-assertion discriminator itself is sound and worth reusing:** load inflates
+  EVERY target, a real assertion inflates exactly one. It is what separated the two rows
+  above — and what stopped the 41× occurrence being read as a code defect.
 
 **The original diagnosis, preserved:**
 
@@ -257,11 +271,14 @@ it up; the evidence is on the issue.
    `scripts/claude-hooks/tests/test_bash_guard.py:294`'s "no catastrophic backtracking" check
    still asserts on wall-clock and flakes under load. Its sibling item (dirty
    `embed_enlarge.js`) is CLOSED — it landed as #1010. Repo: `devrc`.
-2. **The store-api flake's mechanism B** — the `socket.py` `TimeoutError` under scheduler
-   starvation, which #1023 was meant to fix and did not. Start at the **node pinning**
-   (`nodeSelector: talos-xr6-r7p`), not at the cluster-wide run count. Repo: `devrc` +
-   `homelab-talos` (the pipeline definition lives there). Closing condition is NOT yet
-   written; write one before starting.
+2. **The store-api flake's mechanism B** — `TimeoutError` out of `socket.py`, which #1023
+   was meant to fix and did not. 🔴 **Do NOT start from the starvation hypothesis: it is
+   REFUTED** (fired at 44% node CPU with 1.6x target inflation, having also fired at 91%
+   with 41x). The mechanism is UNCHARACTERISED. Two facts worth carrying in: the node
+   pinning is real but explains only one of the two occurrences, and the failing tests move
+   around inside `test_subsystem_store_api.py` (four distinct classes so far) while the
+   exception does not. Repo: `devrc`. Closing condition is NOT yet written; write one
+   before starting, and make it name the MECHANISM rather than a green sample.
 
 🔴 This list is a WORK QUEUE and `claim-work` is its lock — `claim-work --slug-for <this doc>
 <rank>`, then `claim-work <slug> --subject "<text>"`, and sweep `gh pr list --state open` too.
@@ -293,7 +310,9 @@ it up; the evidence is on the issue.
 - 🔴 **A RED required check: read the EXCEPTION, never the test name.** The same test in
   `test_subsystem_store_api.py` failed three different ways in one session, each wanting a
   different response: `ConnectionResetError` (mechanism A — a real defect, now fixed),
-  `TimeoutError` at `socket.py` (mechanism B — starvation, legitimately re-triggerable),
+  `TimeoutError` at `socket.py` (mechanism B — uncharacterised; re-triggering a PR that
+  provably cannot reach that file is legitimate, but that is a claim about the DIFF and not
+  a diagnosis of the flake),
   and 45 × `big-lock: Permission denied` (CI infrastructure, nothing to do with the tree).
   A fourth red was neither — it was the PR sitting on a **red `main`**, where re-triggering
   can never help. "Red check → re-trigger" is the reflex that turns a gate into noise.


### PR DESCRIPTION
Three ranked items landed since the last revision (#1062, #1071, #1076), so the queue was three items stale and its rank-1 pointer named work already merged.

## 🔴 The correction that matters is not the tick-list

**#1030 was filed as one defect. It is two, and only one is fixed.**

| mechanism | status |
|---|---|
| **A — listen backlog** | **CLOSED** by #1062. `request_queue_size` was the stdlib default **5** against a suite firing 8 concurrent appends. Measured through the real `build_server`: backlog 5 → **389** `ConnectionResetError`, 128 → 0, 4096 → 0 |
| **B — `TimeoutError` out of `socket.py`** | **STILL LIVE.** #1023 raised `HANG_TIMEOUT` 15 s → 60 s for exactly this, and it recurred at 60 s |

Mechanism B was captured on `devrc-ci-hrqf4` — a **docs-only** PR, which is the cheapest possible exoneration of the diff. That also **answers the open question in #1030's last comment**, which saw the same test fail on docs-only #1034 and said *"I did not capture this run's exception — it may be a fourth"*. It is not a fourth; it is B.

The dead end is recorded too, because it looks convincing: **`net.ipv4.tcp_abort_on_overflow=0` appears to rule the backlog out and does not** — the resets land *after* a SYN retransmit, with elapsed times clustered at 1.0 s and 2.2 s.

And the lead for B: **devrc CI is pinned to one node** (`nodeSelector: talos-xr6-r7p`), which sat at 91% CPU during the failure while the others were at 22–52%. Cluster-wide run counts say nothing about whether a devrc run will starve.

## Three operational gotchas, each measured the hard way

- **Run the two check derivations SEQUENTIALLY.** A combined `nix build` produces *false* failures from nested-nix store contention — 2 failures on a tree that passes 0 one at a time. A combined **GREEN** is trustworthy (a contended run fails loudly); a combined **RED** is not. This nearly went out as "#1029 broke the gate".
- **A red required check wants its EXCEPTION read, not its test name.** One test failed three different ways in this session — `ConnectionResetError`, `TimeoutError`, and 45 × `big-lock: Permission denied` — each needing a different response. A fourth red was the PR sitting on a **red `main`**, where no re-trigger could ever help.
- **`nix build | tail` reports exit 0 for a failed build.** Already documented in `CLAUDE.md`; hit anyway.

## Queue

Re-ranked to two items. The positional-slug hazard is now called out explicitly: the string `claim-work --slug-for` prints for a rank names a **different item** after every renumber, and this list has been renumbered three times.

Docs-only. Content gates: 211 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJ737dd7nvHxCgkWeTNjx6