### PR TITLE
fix(tests): the backtracking check timed a SUBPROCESS and asserted an absolute 2.0s — it measured interpreter startup, not the regex

### DIFF
--- a/scripts/claude-hooks/tests/test_bash_guard.py
+++ b/scripts/claude-hooks/tests/test_bash_guard.py
@@ -279,19 +279,74 @@ ok = blocked and not err
 fail += not ok
 print(f"{'PASS' if ok else 'FAIL'}  secret inside -m still caught{'  ' + err if err else ''}")
 
-# No pathological backtracking anywhere in the remaining patterns.
-for label, probe in [
-    ("quote+backslash run", 'git commit -m "' + "\\" * 200),
+# --- no pathological backtracking anywhere in the remaining patterns --------
+# 🔴 THE ABSOLUTE WALL-CLOCK IS GONE, AND IT WAS MEASURING THE WRONG THING.
+# This asserted `elapsed < 2.0` around `run()`, which SPAWNS A PYTHON
+# SUBPROCESS — so the number was interpreter startup + imports + JSON framing,
+# with the regex a rounding error inside it. MEASURED on this host: one
+# subprocess round trip on a TRIVIAL command is ~22 ms, and the 32k probe costs
+# ~214 ms of actual matching. On a box carrying agent load (this repo has
+# measured 18–51) startup alone crosses 2 s, so the check went red with no
+# backtracking present at all — a flaky gate on a hook that runs for every Bash
+# call. `claude/RULES.md`: a flaky test is FIXABLE; remove the timing
+# dependency rather than re-running.
+#
+# 🔴 THE FIX IS A RATIO AGAINST A SAME-LENGTH BENIGN CONTROL, IN-PROCESS.
+# Both halves run in the same interpreter, back to back, under whatever load is
+# present — so load scales both and CANCELS, while superlinear backtracking does
+# not. `guard_core` is imported directly because `bash-guard.py` calls `main()`
+# at module level and is not import-safe.
+#
+# MEASURED separation, same host, same moment:
+#     as shipped (fixed)                       -> ratio 0.98x
+#     _BLIND_SHORT reverted to `-[A-Za-z]*A[A-Za-z]*`
+#       (the historical quadratic shape)       -> ratio 6.39x
+# The threshold sits between them with ~3x margin either way. Observed fixed
+# ratios across probes: 0.76x, 0.98x, 1.02x.
+#
+# ⚠ The benign control is the SAME LENGTH and the SAME SHAPE, differing only in
+# the character that carried the historical trigger. A shorter control would
+# make the ratio a length comparison instead of a backtracking one.
+sys.path.insert(0, os.path.dirname(GUARD))
+import guard_core as _gc  # noqa: E402  — after the sys.path hop, deliberately
+
+_BACKTRACK_RATIO_MAX = 3.0
+
+
+def _best_evaluate_secs(cmd, reps=3):
+    """Fastest of `reps` in-process evaluations. MIN, not mean: a scheduler
+    preemption can only make a sample slower, so the minimum is the closest
+    estimate of the work itself and the least sensitive to a noisy box."""
+    best = float("inf")
+    for _ in range(reps):
+        t0 = time.perf_counter()
+        _gc.evaluate(cmd, policy="claude-code", cwd=None)
+        best = min(best, time.perf_counter() - t0)
+    return best
+
+
+for label, probe, benign in [
+    ("quote+backslash run",
+     'git commit -m "' + "\\" * 200,
+     'git commit -m "' + "x" * 200),
     # the old _BLIND_FLAG had two adjacent [A-Za-z]* around the A and went
-    # quadratic when the run failed the trailing boundary: 6s at 32k.
-    ("long -AAAA… run", "git a" + "dd -" + "A" * 32000 + "!"),
+    # quadratic when the run failed the trailing boundary: 6s at 32k. The
+    # control swaps the A's for x's — same length, no trigger.
+    ("long -AAAA… run",
+     "git a" + "dd -" + "A" * 32000 + "!",
+     "git a" + "dd -" + "x" * 32000 + "!"),
 ]:
-    t0 = time.time()
+    t_probe = _best_evaluate_secs(probe)
+    t_benign = _best_evaluate_secs(benign)
+    ratio = t_probe / max(t_benign, 1e-9)
+    # ...and the END-TO-END behaviour is still asserted through the adapter, so
+    # this stays a test of the guard and not only of a regex's shape.
     _, err = run(probe)
-    elapsed = time.time() - t0
-    ok = elapsed < 2.0 and not err
+    ok = ratio < _BACKTRACK_RATIO_MAX and not err
     fail += not ok
-    print(f"{'PASS' if ok else 'FAIL'}  no catastrophic backtracking: {label} ({elapsed:.2f}s)")
+    print(f"{'PASS' if ok else 'FAIL'}  no catastrophic backtracking: {label} "
+          f"({ratio:.2f}x vs a same-length benign control, "
+          f"limit {_BACKTRACK_RATIO_MAX}x){'  ' + err if err else ''}")
 
 # --- check_git_commit_to_main, END TO END THROUGH THE ADAPTER ---------------
 # 🔴 The other cases in this file are pure text shapes. This one is not: the check


### PR DESCRIPTION
The last inherited item from `handoff-find-session-opencode.md`.

## It was not merely flaky — it was measuring the wrong thing

```python
t0 = time.time(); _, err = run(probe); elapsed = time.time() - t0
ok = elapsed < 2.0 and not err
```

`run()` **spawns a Python subprocess**, so `elapsed` was interpreter startup + imports + JSON framing, with the regex a rounding error inside it.

**MEASURED on this host:**

| | cost |
|---|---|
| one subprocess round trip, TRIVIAL command | ~22 ms |
| the 32k probe's actual matching | ~214 ms |
| the assertion's ceiling | 2000 ms |

~7× headroom on a quiet box — and this session measured **41× load inflation on the same infrastructure** (a 203-test target going 3.30 s → 136.90 s *while still passing*). 260 ms × 41 = **10.7 s**. So the red was reachable with no backtracking present at all, on a hook that runs for every Bash call. `claude/RULES.md`: a flaky test is fixable; remove the timing dependency rather than re-running.

## The fix: a ratio against a same-length benign control, in-process

Both halves run in the same interpreter back to back, so load scales both and **cancels**; superlinear backtracking does not. `guard_core` is imported directly because `bash-guard.py` calls `main()` at module level and is not import-safe. Best-of-3 per side, **MIN not mean** — a scheduler preemption can only make a sample slower.

⚠ The control is the **same length and shape**, differing only in the character that carried the historical trigger (`A` → `x`). A shorter control would turn the ratio into a length comparison instead of a backtracking one.

**MEASURED separation, same host, same moment:**

| pattern | ratio |
|---|---|
| as shipped (fixed) | **0.98×** |
| `_BLIND_SHORT` reverted to `-[A-Za-z]*A[A-Za-z]*` (the historical quadratic shape) | **6.39×** |

Threshold **3.0×** sits between them with ~3× margin either way. Observed fixed ratios across probes: 0.76×, 0.98×, 1.01×, 1.02×.

## Mutation-verified, not asserted

With the quadratic shape reintroduced, the long probe reports **6.95×** and the suite goes `RESULT: 1 failure(s)` — while the `quote+backslash` probe **stays green at 0.70×**, because it does not exercise `_BLIND_SHORT`. The failure is therefore attributable to the mutated pattern and not to a neighbour going red for its own reasons.

The end-to-end `run(probe)` assertion is **kept** alongside the ratio, so this stays a test of the guard through its adapter and not only of a regex's shape.

## Gate — merged tree, both tiers run SEQUENTIALLY

| tier | result |
|---|---|
| `devrc-pytests` | `collected=18909 passed=18907 skipped=2 failed=0` — `RESULT: PASS` |
| `devrc-nodetests` | `suites=5 files=38 tests=1366 pass=1366 fail=0` — `RESULT: PASS` |

⚠ Building both derivations in one `nix build` produces false failures from nested-nix store contention; run them one at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJ737dd7nvHxCgkWeTNjx6