### PR TITLE
feat(cairn): put `cairn` on PATH — and pin the deploy mode its own lib lookup forces

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1259,6 +1259,21 @@ in
   # the last switch's version while the checkout moved on.
   home.file.".local/bin/claim-work".source =
     config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/claim-work.sh";
+
+  # 🔴 `cairn` — the read-through client for the hosted subsystem store, ON PATH
+  # for the same reason as `claim-work` above: the handoff/resume flow names it as
+  # a bare command, and an agent running in another repo cannot resolve an absolute
+  # devrc path. Bare command on `home.sessionPath` resolves from any cwd.
+  #
+  # 🔴 mkOutOfStoreSymlink is NOT a preference here — it is REQUIRED. `scripts/cairn`
+  # reaches its siblings through `Path(__file__).resolve().parent / "lib"` (:68, and
+  # again at :756/:808/:818 for `cairn_who`), exactly like the opencode CLI above.
+  # `.resolve()` follows the symlink back to the checkout, so `lib/` is found in the
+  # repo. A store copy would resolve `__file__` into /nix/store, where `lib/` is NOT
+  # deployed — the import would fail outright. Only this one path is symlinked;
+  # `scripts/lib/` must not be deployed, same rule as opencode's `lib/`.
+  home.file.".local/bin/cairn".source =
+    config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/cairn";
   # Claude Code hooks managed here (the script only — the settings.json
   # registration is per-host/unmanaged, as for bash-guard.py above, whose script
   # is likewise managed now). audit-pr-nudge fires

--- a/scripts/tests/test_cairn_cli.py
+++ b/scripts/tests/test_cairn_cli.py
@@ -1253,3 +1253,63 @@ class TestTheHarnessItself:
                          token="z" * 48)
         assert proc.returncode != 0
         assert "401" in proc.stderr, proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# 🔴 THE DEPLOY SEAM: `cairn` is on PATH, and HOW it is deployed is load-bearing.
+#
+# `scripts/cairn` reaches its siblings through `Path(__file__).resolve().parent
+# / "lib"`. Deployed as a home-manager STORE COPY, `__file__` resolves into
+# /nix/store — where `scripts/lib/` is deliberately NOT deployed — and every
+# `import subsystem_recall` dies at startup. Deployed as an
+# `mkOutOfStoreSymlink`, `.resolve()` follows the link back into the checkout
+# and `lib/` is found.
+#
+# Neither half is enough on its own, which is why this is one guard over a
+# RELATIONSHIP rather than two component checks:
+#   - pinning only the nix spelling would keep asserting "must be out-of-store"
+#     long after someone rewrote cairn to vendor its imports, i.e. it would
+#     outlive its own reason and nobody could tell;
+#   - pinning only the __file__ lookup would stay green while the deploy line
+#     silently became a store copy and the shipped command stopped starting.
+# So: assert the reason still exists, THEN assert the deploy mode it forces.
+# ---------------------------------------------------------------------------
+
+NIX_HOME = REPO / "nix" / "home.nix"
+
+
+def test_cairn_still_resolves_its_lib_relative_to_its_own_file():
+    """The REASON half of the seam. If this fails, the guard below is pinning a
+    constraint that no longer applies — delete both, don't loosen one."""
+    src = (REPO / "scripts" / "cairn").read_text()
+    assert 'Path(__file__).resolve().parent / "lib"' in src, (
+        "scripts/cairn no longer derives its lib/ path from __file__. The "
+        "out-of-store requirement below may be obsolete — re-derive it rather "
+        "than editing the assertion."
+    )
+    # …and that the path it builds is actually imported from, not dead code.
+    assert "import subsystem_recall" in src, (
+        "scripts/cairn no longer imports from its sibling lib/"
+    )
+    assert (REPO / "scripts" / "lib" / "subsystem_recall.py").exists()
+
+
+def test_cairn_is_deployed_out_of_store_not_as_a_store_copy():
+    """The DEPLOY half. A store copy ships a `cairn` that cannot start."""
+    nix = NIX_HOME.read_text()
+    assert 'home.file.".local/bin/cairn".source' in nix, (
+        "the `cairn` PATH entry is gone from nix/home.nix"
+    )
+    # The whole assignment, whatever it spans, must name mkOutOfStoreSymlink.
+    head = nix.split('home.file.".local/bin/cairn".source', 1)[1]
+    assignment = head.split(";", 1)[0]
+    assert "mkOutOfStoreSymlink" in assignment, (
+        "`cairn` is deployed as a STORE COPY. Its `Path(__file__).resolve()` "
+        "lib lookup will resolve into /nix/store, where scripts/lib/ is not "
+        "deployed, and the command will fail on import. Use "
+        "mkOutOfStoreSymlink, as claim-work/dl-route/opencode-dispatch do.\n"
+        f"got: {assignment.strip()!r}"
+    )
+    assert "${workspace}/devrc/scripts/cairn" in assignment, (
+        f"`cairn` points somewhere unexpected: {assignment.strip()!r}"
+    )


### PR DESCRIPTION
## What

Adds `cairn` — the read-through client for the hosted subsystem store — to `home.sessionPath` as a bare command, mirroring `claim-work` directly above it in `nix/home.nix`.

It was reachable only by absolute path, so an agent working in another repo could not run it. That is the same gap `claim-work` was placed on PATH to close: a bare command resolves from any cwd, in either runtime.

## Why `mkOutOfStoreSymlink` is required, not preferred

`scripts/cairn` reaches its siblings through `Path(__file__).resolve().parent / "lib"` — at `:68` for the module-level `subsystem_recall` / `subsystem_touch` imports, and again at `:756/:808/:818` for the lazy `cairn_who` ones.

A home-manager **store copy** would resolve `__file__` into `/nix/store`, where `scripts/lib/` is deliberately not deployed, and every invocation would die on import. `.resolve()` follows the symlink back into the checkout, so the out-of-store form is what makes the command work at all.

## The guard

That constraint previously lived only in a comment. It is now pinned — over the **relationship**, not one side of it:

| test | pins |
|---|---|
| `test_cairn_still_resolves_its_lib_relative_to_its_own_file` | the REASON — cairn really does derive `lib/` from `__file__` |
| `test_cairn_is_deployed_out_of_store_not_as_a_store_copy` | the DEPLOY MODE that reason forces |

Pinning only the second would outlive its own justification if `cairn` were ever rewritten to vendor its imports, and nobody could tell. Pinning only the first would stay green while the deploy line silently became a store copy and the shipped command stopped starting.

## Both halves were watched to fail

Each died with **its own** assertion, not the other's:

- deploy line → `../scripts/cairn` (a store copy): the deploy half fails with the `STORE COPY` message, and **the reason half stays green** — so neither guard masks the other.
- `Path(__file__)...` → a fixed path: the reason half fails with its own message.

The `scripts/cairn` mutant was restored from `cp -a` and re-verified byte-identical to `origin/main`.

## Verified end to end

Switched this tree and reproduced the original symptom (`cairn` not on PATH):

- `command -v cairn` → `/home/zach/.local/bin/cairn`
- `readlink -f ~/.local/bin/cairn` → terminates in the checkout, **not** `/nix/store` (the arbiter, per RULES.md)
- `cairn --help` → rc=0, empty stderr — exercises the module-level import
- `cairn who --help`, **run from `/tmp`** → rc=0 — exercises the lazy import *and* proves cwd-independence

`scripts/cairn` is unchanged by this PR. Rank 6 of `claudedocs/handoff-cairn-task-linkage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TY12oTR7U9BSzaEe4KoucA