### PR TITLE
docs(handoff): ranks 5, 6 and 7 shipped, deployed and verified — clawgate 0.8.18

### DIFF
--- a/claudedocs/handoff-tmux-webapp.md
+++ b/claudedocs/handoff-tmux-webapp.md
@@ -9,148 +9,42 @@ and an **attention queue** that surfaces sessions needing a human so Zach can ju
 
 ## Status
 
-**Phase 1 (attention queue) SHIPPED. Phase 2 (tmux read model) COMPLETE. Rank 3 (read-only
-`capture-pane` rendering) ✅ DONE 2026-08-28. Rank 5 (the fail-closed terminal-write auth
-wrapper) ✅ DONE 2026-08-29 — `ZacxDev/homelab-infra#516`, squash `c8635976`, DEPLOYED as clawgate
-0.8.13 and VERIFIED LIVE. The lowest-numbered OPEN item is now rank 6 (the layout schema +
-`clawgatectl view`/`panel` verbs).**
+**Phases 1–4 SHIPPED. Ranks 5, 6 and 7 are ✅ DONE, deployed and verified live 2026-08-30.
+clawgate is at 0.8.18. The lowest-numbered OPEN item is rank 8 (housekeeping).**
 
-🔴 **RANK 5 SHIPPED THE WRAPPER BUT NOT ITS SECRET, DELIBERATELY.** The SOPS age identity is on
-NEITHER host, so `CLAWGATE_TERMINAL_TOKEN` is wired `optional: true` and the surface boots
-**DISABLED (fail-closed)**. That is the intended resting state — nothing calls it yet — but it
-means "the wrapper is deployed" and "the wrapper would let a legitimate caller through" are
-**two different claims**, and only the first is true today. See rank 5 for the one operator step.
+🔴 **DO NOT READ A VERSION FROM THIS DOC — `clawgatectl health` is the only authority.** It said
+**0.8.18** at 2026-08-30 06:30Z immediately after this session deployed it. The line has now
+carried **nine** values in four days (0.8.7 → 0.8.8 → 0.8.9 → 0.8.10 → 0.8.11 → 0.8.13 → 0.8.15
+and 0.8.17 from concurrent sessions → 0.8.16 → 0.8.18). ⚠ **0.8.12 and 0.8.14 EXIST IN HARBOR AND
+WERE NEVER DEPLOYED** — each was built, then discarded before merge because trunk gained a
+`containers/clawgate` fix while the PR was in review and the image would have carried a HIGHER
+version number with LESS code. A tag existing is not a tag having shipped.
 
-🔴 **A FORK THAT IS NOW RANK 7's, SURFACED WHILE BUILDING RANK 5:** the browser holds **no
-credential at all** (`comment_delete.go:110-130`), and the app's pattern for UI mutation is an
-*open twin route*. That pattern cannot carry `send-keys`. Read rank 5's last paragraph before
-designing the grid UI.
+**Live at handoff (measured, not assumed):** pod `clawgate-78b9d497d6-klzmh` Running/ready,
+`restarts=0`, image `0.8.18`; server self-reports 0.8.18. `GET /ui/layout` → **200** (was 404 on
+0.8.17 — before-control taken). A seeded panel resolved against a real live window
+(`laptop · wheat · devrc`, `hotkey_display` = `Alt+w`). Terminal write surface still boots
+**`DISABLED (fail-closed)`**, its intended resting state.
 
-🔴 **DO NOT READ A VERSION FROM THIS DOC** — `clawgatectl health` is the only authority. It said
-**0.8.13** at 2026-08-29 20:58Z immediately after this session deployed it. This line has now
-carried **six** values in three days (0.8.7 → 0.8.8 → 0.8.9 from a concurrent session → 0.8.10 →
-0.8.11 → 0.8.13), which is the whole argument for reading the cluster instead of this paragraph.
-⚠ **0.8.12 EXISTS IN HARBOR AND WAS NEVER DEPLOYED** — built before #503 landed on trunk and
-superseded pre-merge; see rank 5. A tag existing is not a tag having shipped.
+🔴 **`clawgatectl` IS 0.8.17 ON BOTH HOSTS AGAINST AN 0.8.18 SERVER — a skew note now fires on
+every command.** `clawgatectl` is built from each host's LOCAL `homelab-talos` tree, so a pin bump
+alone does not update it. Fix: `git -C ~/workspace/homelab-talos merge --ff-only origin/trunk`
+then `home-manager switch --flake ~/workspace/devrc --impure`, on BOTH hosts. Left undone
+deliberately — a standing skew warning trains you to ignore skew warnings, so it is rank 8's
+first item.
 
-⚠ **THE PREVIOUS REVISION OF THIS HEADER SAID "MERGED-BUT-NOT-DEPLOYED" AND WARNED THAT THE
-FIRST SIGHT WOULD BE `collector predates the field` ON EVERY CARD. Both were true when written
-and are now FALSE** — the deploy landed within the hour, and because the DATA half shipped first
-the tab rendered real screens immediately. The warning's *reasoning* stands and is why the status
-vocabulary exists; its *reading* does not. Third time this header has gone stale inside a day.
-
-**Live at handoff (2026-08-28, measured not assumed):** pod `clawgate-fcd8c945b-44rqj`
-Running/ready, `restarts=0`, image `0.8.10`; `clawgatectl --version` **0.8.10 on BOTH hosts** (no
-skew note — the `buildVersion` half of the bump landed). `GET /ui/tmux` → **200, 208,347 bytes**,
-both host sections, **48 pane screens**, 0 stale badges, 0 unreachable, and the decision-surface
-scan clean **on the live page**. Read model **48 `ok` / 28 `not_claude`**, largest preview
-9,032 B against the 16 KiB cap, **0 truncated**. Feeder ticking unattended at ~450 KB/push,
-**~10.5% of the 4 MB ingest cap**.
-
-**Both host checkouts current:** devrc `main` = `1c0db104` on both (`ship.sh`, cross-host
-agreement at one sha); `homelab-talos` `trunk` = `8c6a8508` on both — the laptop's was **17
-commits behind** and was fast-forwarded this session, because `clawgatectl` is BUILT from that
-tree and a switch there would otherwise have shipped a stale binary. `ship.sh` does NOT converge
-that repo.
-
-*How the design got here (carried forward):* settled 2026-08-26 across two rounds — a greenfield
-session, then an audit that reopened four decisions — then a re-platform onto clawgate that resolved
-three of them outright. The sections below from `## Platform` down are that design, still current.
-
-**Shipped, newest first:**
-- **`ZacxDev/homelab-infra#496`** — rank 3's RENDERING half — merged as **`844a7350`** and
-  **DEPLOYED as clawgate 0.8.10** (pin `8c6a8508`). A read-only Tmux tab: one section per host
-  with independent staleness + reachability badges, one card per window carrying the pane's
-  visible screen. 🔴 **No decision surface, and that is a PREREQUISITE not a preference** — a
-  write here is `send-keys`, and rank 5's fail-closed wrapper does not exist yet.
-  ⚠ Adding the tab needed **five** registry entries (`tabKeys`, `tabHeadings`, the sidebar, the
-  JS `TABS` array, the JS `HEADINGS` map); the repo's own guards caught the two that were missed.
-- **`innovation-upstream/devrc#992`** — rank 3's DATA path — merged as **`3d29aba1`**, shipped to
-  both hosts. `session-manager` publishes each Claude pane's visible screen as `pane_preview` +
-  `pane_preview_status`, from the capture batch that ALREADY ran and threw the screen away, so
-  it costs zero extra tmux work. Opt-in `--pane-preview`; the pusher is the one caller that
-  passes it. 🔴 **No server change was needed** — migration 0027's "unknown fields preserved
-  verbatim" contract held, verified end-to-end against live 0.8.9 BEFORE any UI existed
-  (POST 322 KB → 200; GET returned 46 rows `ok` / 26 `not_claude`, rename intact).
-  Gates: BOTH sandbox tiers green on the branch AND on the MERGED tree.
-- **`innovation-upstream/devrc#996`** — not this feature, but it is what UNBLOCKED it:
-  `test_subsystem_store_api.py` had gone broadly flaky under load and was reddening
-  `tekton/devrc-pytests` for **three PRs at once, including its own fix**. Merged `1b1f71ad`.
-- **`innovation-upstream/devrc#974`** — the host-side pusher, phase 2's remaining half — merged as
-  **`f0308e46`** and shipped to both hosts. `scripts/tmux-snapshot-push.sh` + a serverMode-gated
-  systemd timer (2 min). ✅ **VERIFIED BY AN UNATTENDED TICK**, which is the only proof that counts
-  here: every earlier success was a hand-run. Journal `pushed …B … HTTP 200` at 2m0s spacing with
-  `Result=success`, and `receivedAt` advancing `20:02:52 → 20:04:52` while the push count went 3 → 4.
-- **`innovation-upstream/devrc#970`** — merged as **`8ca23613`**. ⚠ Its kickoff named head sha
-  `e5773b1c`, which had **never been pushed** and existed only in a local worktree — so GitHub's
-  head was `6e2ced2d` throughout, and that, not a Tekton fault, is why no PipelineRun ever appeared
-  for it. The kickoff also said to remove that worktree, which would have **destroyed the audit-pr
-  fix**; it was pushed first.
-- **`ZacxDev/homelab-infra#468`** — the tmux snapshot ingest, phase 2's server half — merged as
-  **`32f49804`**, then DEPLOYED as **0.8.8** (pin `628a963a`). `POST/GET /api/tmux/snapshot`,
-  migration `0027`, and `internal/tmux`, which owns the vocabulary boundary. 🔴 Merging it had
-  changed nothing running — the image pin is an immutable literal with no Flux image automation —
-  which is exactly why it sat inert until the pin moved.
-- **`ZacxDev/homelab-infra#457`** — the idle reaper's own cadence — merged as `3a66e3e0`, deployed
-  as **0.8.7** (pin `cc51b9b4`) and verified over 4.5h of production sweeps. See rank 1.
-- **`#451`** (detached suggest POST) merged as `a38360a5`, live on BOTH hosts (hook files verified
-  byte-identical, `f793ab9c…`).
-- **`#422`** (the attention queue) merged as `5a008e4f`; **`#427`** (one-line `buildVersion` fix) as
-  `f2f8cb7e`; **`#432`** closed after fast-forwarding onto the branch to keep one reviewable PR.
-- **`innovation-upstream/devrc#890`** — this doc's audited rewrite — merged as `f53ef8a6`;
-  **`#959`** (ranks 1/3/4 + the lessons below) as `660e0671`.
-
-**Phase 1 was verified through the real path, not inferred (carried forward):** a genuine
-`AskUserQuestion` produced a `kind=question priority=high` entry sorted **above ten `idle` rows** —
-the priority-ordering fix demonstrated in production. Repeated from the laptop after its hook was
-fixed: entry id 149, `host=laptop`, hook `exit=0` with empty stdout (still defers). Test entry
-resolved afterwards.
-
-**What the feature is:** attention entries (migration `0026`), kinds `question` (high) / `idle`
-(low), raised by the `AskUserQuestion` path, the Stop hook, and `clawgatectl attention
-raise|ls|resolve`; surfaced in an htmx tab and pushed via the pre-existing `POST /api/notify`.
-🔴 An entry is **not** a decision object — no approve/deny, it carries a *destination*.
-
-⚠ **SUPERSEDED READING, kept for the reasoning below it** — the pod and version named here
-rolled several times the same day. **Live health at handoff (2026-08-28 09:53Z):** pod
-`clawgate-7c78695584-mcc74`, image `0.8.7`, `restarts=0`, up since 07:21:45Z — it **rolled cleanly**
-during the session, which wiped the earlier sweep history with the old pod. The queue is bounded:
-`open=23`, **`idle_past_4h=0`** (baseline before the fix: 64 open / 21 eligible). 🔴 **The reaper
-has logged no `attention-reap: resolved` line since that roll, and that is CORRECT, not a
-regression** — the pass is silent when it resolves nothing, and nothing has been eligible. This is
-exactly the case the unconditional boot line exists for: `07:21:46 attention reaper: sweeping every
-30m0s …` is the only thing distinguishing a healthy silent sweep from a reaper that never started.
-
-**The laptop had a five-month-old hook.** Its `PermissionRequest` hook was registered at
-`~/.claude/clawgate-hook.sh` — a regular file (not a symlink; `readlink -f` resolves to itself),
-byte-identical to commit `03efe4ed`, **clawgate 0.3.1**, mtime 2026-06-06. Its Stop hook *was* on
-the repo path, so the idle path worked while the **question path was dead** — the exact use case
-this feature exists for, silently, on one host. Repointed at the repo path via `jq` against a
-timestamped backup (21 hooks / 7 keys preserved, one-line diff). The stale 0.3.1 copy is still on
-disk, now referenced by nothing.
-
-**Seven audit rounds ran on #422; the ladder stopped when a round came back clean, never on a
-verdict.** Three compounding defects would have made the queue bury the questions it exists to
-surface (idle never reaped + priority absent from the sort + a 100-row limit taking the *oldest*).
-**Nine separate instruments were caught measuring nothing**, including three harnesses built to
-check earlier ones, one that scored an *unmutated* tree as SURVIVED, and a CI timer that had both
-fire-and-forget tests passing on literally nothing. Two of those predated this work and were found
-only because the **merged tree** was gated instead of the branch.
-
-🔴 **#468 ran FIVE more rounds, and the pattern there is the finding: every round found a defect the
-PREVIOUS round's fix had introduced.** An atomicity fix caused a 30%-reproducible deadlock
-(randomised map order vs row locks); fixing that left a guard three separate mutants walked through;
-and `UseNumber`, added so a nanosecond timestamp would not be corrupted, re-opened a read
-amplification that a 32-char cap missed (`1e100000` is 8 chars) and `ParseFloat` then closed only
-half of (it returns `0, nil` on UNDERFLOW). Round 5 was the first with **no behaviour defect**.
-⚠ **Stopped there — ONE round short of the mechanical two-zero-payload gate** — because round 5 was
-auditing test code round 4 wrote, and round 6 would have audited test code round 5 wrote. That is a
-judgement, not the rule; a sixth round is a legitimate thing to ask for.
-
-**Lowest-numbered OPEN item is rank 3** (read-only `capture-pane` rendering). ⚠ Its
-`🔴 DEPENDENCY — cannot be built before item 4` paragraph is **SATISFIED as of 2026-08-28**: item 4
-immediately below it is ✅ DONE, and the delivery path it was waiting for now exists and runs every
-2 minutes. Nothing else about rank 3 changed; it still needs no further decisions.
+**Shipped this session, newest first:**
+- **`ZacxDev/homelab-infra#538`** — rank 7, the layout GRID UI — squash **`fb9b75e5`**, deployed as
+  **0.8.18** (pin `3b90b6ee`, committed directly to `trunk`; that repo's own CLAUDE.md states
+  *"Commit = live deploy"*, which is what makes the exception apply — it was re-read, not assumed).
+  Four adversarial audit rounds, eleven findings, all fixed and each re-verified by a mutant.
+- **`ZacxDev/homelab-infra#527`** — rank 6, the persisted layout model — squash **`7bb78908`**,
+  deployed as 0.8.16. Migration `0028`, `internal/layout`, `clawgatectl view`/`panel`.
+- **`ZacxDev/homelab-infra#516`** — rank 5, the fail-closed terminal-write tier — squash
+  **`c8635976`**, deployed as 0.8.13.
+- **`innovation-upstream/devrc#1036`** — the handoff + the rescued dnsmasq script — squash `f8a35942`.
+- **`innovation-upstream/devrc#1056`** — the tmux server SENTINEL (producer half of rank 6) —
+  🔴 **STILL OPEN, still held.** See Open investigations.
 
 ## Platform: this is a clawgate feature
 | | |
@@ -301,376 +195,81 @@ From the analyze-service index (**recall — verify before relying on**):
 🔴 **Ranks are STABLE and are NOT renumbered when an item completes** — the rank is half a claim's
 identity (`claim-work --slug-for claudedocs/handoff-tmux-webapp.md <rank>`), so re-ranking silently
 re-points every live claim. A finished item stays in place marked ✅ DONE; take the lowest-numbered
-open one, not "the first in the list". *History, carried forward:* the 2026-08-26 renumbering
-superseded an earlier 1–7 list, so a claim slug minted before that date may name a different item —
-do not renumber again without releasing the live claims first.
+OPEN one. *History:* a 2026-08-26 renumbering superseded an earlier 1–7 list, so a slug minted
+before that date may name a different item — do not renumber again without releasing live claims.
 
-1. ✅ **DONE 2026-08-27 — it had never fired because it COULD NOT. `ZacxDev/homelab-infra#457`.**
-   Not an observation task: the reaper was inert in production for the whole of its life.
+1. ✅ **DONE 2026-08-27** — the idle reaper had never fired because it COULD NOT (`time.NewTicker`
+   delivers its first tick one whole interval in; a 24h ticker in a pod that lives 5h fires never).
+   `ZacxDev/homelab-infra#457`, clawgate 0.8.7. Verified over six production sweeps.
+2. ✅ **DONE 2026-08-27** — detached suggest POST, `ZacxDev/homelab-infra#451` (`a38360a5`).
+   8030ms → 22ms, measured old-hook vs new against a server that accepts and never replies.
+3. ✅ **DONE 2026-08-28** — read-only `capture-pane` rendering, both halves
+   (`devrc#992` + `ZacxDev/homelab-infra#496`), clawgate 0.8.10.
+4. ✅ **DONE 2026-08-28** — the tmux snapshot ingest + host-side pusher
+   (`ZacxDev/homelab-infra#468` + `devrc#974`), clawgate 0.8.8. Proof was an UNATTENDED tick.
+5. ✅ **DONE 2026-08-29 — `ZacxDev/homelab-infra#516`, squash `c8635976`, deployed 0.8.13.**
+   `requireTerminalToken`: the ONLY fail-closed tier. Refuses (503, handler never called) unless
+   `CLAWGATE_TERMINAL_TOKEN` is set, ≥32 chars, and a DIFFERENT value from the hook token.
+   🔴 **The secret is still UNPROVISIONED and the surface boots DISABLED — that is correct, not a
+   regression.** The SOPS age identity is on NEITHER host (`~/.config/sops/age/` empty on the
+   workbench, absent on the laptop), so it could not be encrypted. Wired `optional: true`, because
+   without it a missing key is a `CreateContainerConfigError` that stops the WHOLE pod — turning
+   "the terminal surface is unprovisioned" into an outage of the approval router.
+   **To arm it:** `clawgate gentoken` → add `CLAWGATE_TERMINAL_TOKEN` via
+   `sops clusters/workbench/apps/clawgate/secrets.enc.yaml`. No code or manifest change needed.
+6. ✅ **DONE 2026-08-29 — `ZacxDev/homelab-infra#527`, squash `7bb78908`, deployed 0.8.16.**
+   Migration `0028` (`layout_views` + `layout_panels` + `tmux_snapshots.tmux_server_id`),
+   `internal/layout` (resolver), machine routes, `clawgatectl view`/`panel` verbs.
+   🔴 **A PANEL STORES A DESCRIPTION, NOT A REFERENCE — this is the load-bearing design.** Measured
+   across all 79 live windows: no field is both unique and stable. `window_id` is unique but tmux
+   reissues from `@0` on restart; `claude_session_id` is unique+stable but only 47/79 have one;
+   `codename` is stable (checked-in table) but session-level; name triples collide 13 ways, one
+   matching FIVE windows. So panels resolve against the live snapshot on every read and report
+   `resolved`/`ambiguous`/`missing`/`unreported`/`host_unreachable`. Ambiguity renders as a CHOICE.
+   ⚠ **Claim `tmux-webapp-6` is STILL HELD** pending `devrc#1056` — see Open investigations.
+7. ✅ **DONE 2026-08-30 — `ZacxDev/homelab-infra#538`, squash `fb9b75e5`, deployed 0.8.18.**
+   The htmx layout tab: views, per-panel live resolution, and organisation controls.
+   🔴 **THE UI TIER CARRIES ONLY REVERSIBLE CONTROLS, TRUE BY CONSTRUCTION NOT BY COMMENT.**
+   collapse/expand/archive, each undoable via Restore. The destructive control was REMOVED —
+   button, route, handler and ledger entry — leaving `clawgatectl panel rm` (requireHookToken) as
+   the only delete path. `TestTheLayoutUISurfaceOffersOnlyReversibleControls` fails by name if a
+   DELETE reappears. Verified live: `hx-post`=1 (positive control), `hx-delete`=0, and
+   `DELETE /ui/layout/views/1/panels/1` → 404.
+   🔴 **The browser-credential fork that rank 5 surfaced is now ANSWERED for this surface and still
+   OPEN for a web terminal.** The browser holds no credential, so UI writes sit on the
+   pass-through `requireSession` tier following `comment_delete.go:110-130`'s precedent — acceptable
+   ONLY because layout rows execute nothing. That argument does NOT extend to `send-keys`.
+8. **Housekeeping, cheap — the lowest-numbered OPEN item:**
+   a. 🔴 **Bring `clawgatectl` current on both hosts** (0.8.17 vs an 0.8.18 server). See Status.
+      Closing condition: `clawgatectl --version` == `clawgatectl health` on both hosts.
+   b. **An e2e spec for the layout tab.** `clawgate-e2e` is green but runs 20 spec files and NONE
+      touches layout — that green says nothing about this feature. Closing condition: a
+      `layout.spec.ts` exercising collapse/expand/archive/restore, green in `clawgate-e2e`.
+   c. Eight sleep-based timing bets in `containers/clawgate/internal/api/{push_task,task_comment}_test.go`
+      (pre-existing; mechanical now `awaitPushesSettled` exists).
+   d. A scanner test for in-body `! grep` — closing condition: a test in both bats suites that reds
+      on a planted `! grep` assertion.
 
-   **Mechanism.** The reap's only caller was `retentionPass`, whose only caller was
-   `RunRetention`'s **24h** ticker — and `time.NewTicker` delivers its FIRST tick one whole
-   interval in. Sweeping once required a pod to survive 24h. Measured: since the feature shipped
-   (0.8.3, ReplicaSet created `2026-08-27T16:00:08Z`) the longest-lived pod managed **5h02m**
-   (0.8.4 got 15m, 0.8.5 2h41m, `restarts=0`); clawgate deploys far oftener than daily. The live
-   pod's log held **zero** `retention:` lines. 🔴 The leader lease was **ruled out** as a rival
-   mechanism rather than assumed innocent — `leader(background-loops): acquired lease` appears 30s
-   after boot. The ticker was the sole blocker.
+🔴 **There is no rank 9.** A previous revision listed one — "get three portable lessons into
+MEMORY.md" — and it was NOT a work item: the operator confirmed 2026-08-27 that MEMORY.md is not
+used here, so nothing could ever have closed it.
 
-   **The second defect, which outlives the restart story:** even a pod that never restarted swept
-   every 24h against a 4h window — an entry sat up to **6× its own window** past eligibility. This
-   doc used to call the 4h constant "the single knob". It never was; the sweep interval was.
-
-   **Fix:** a dedicated leader-gated `RunAttentionReap` on `api.AttentionReapInterval` (30m), with
-   `retentionPass` still calling the same extracted pass daily as a backstop — one implementation,
-   two schedulers. Four audit rounds; the ladder stopped on the **attribution gate** (two
-   consecutive rounds whose fixes changed zero payload lines), not on a verdict.
-
-   🔴 **The diagnostic tell has CHANGED — the old string no longer exists.** Two lines now:
-   - at boot, unconditionally: `attention reaper: sweeping every 30m0s for idle entries not seen for 4h0m0s`
-   - on a sweep that resolved something: `attention-reap: resolved N idle attention entry(ies) not seen for 4h0m0s`
-
-   The prefix moved off `retention:` deliberately: two schedulers drive the pass now, so a
-   `retention:` line could no longer say *which* swept. And the **entry line is the load-bearing
-   one** — the pass is silent when it resolves nothing, so without it a pod whose reaper never
-   started and a pod sweeping a healthy empty queue emit byte-identical logs. That
-   indistinguishability is exactly what hid this bug, and "0 log lines" was the evidence for it.
-
-   **SHIPPED — clawgate 0.8.7 is live** (`3a66e3e0` merged; pin `cc51b9b4`; Flux reconciled; pod
-   `clawgate-7c78695584-zqdjf` Running/ready). ⚠ The pin had moved to **0.8.6 under me** mid-session
-   (a concurrent ship), so 0.8.7 was derived from the LIVE pin re-read at the moment of acting —
-   and 0.8.6 was confirmed **by content** to predate the merge and not contain the fix.
-   First evidence in this feature's history that the reaper exists at runtime:
-   `02:04:10 attention reaper: sweeping every 30m0s …` followed by
-   `02:04:40 leader(background-loops): acquired lease`.
-
-   **Forced end-to-end validation (2026-08-28), because waiting 30m is not the only option — but
-   restarting the pod is NOT a way to force it: that RESETS the ticker and makes it strictly
-   worse.** There is no on-demand route. So the deployed tree was run against a throwaway Postgres
-   with **one line changed** (the interval to 5s) and **synthetic** rows — never copied production
-   entries, which carry captured session text. Result:
-   `attention-reap: resolved 3 idle attention entry(ies) not seen for 4h0m0s`, taking exactly the
-   3 stale `idle` rows while 2 fresh `idle`, a stale `question` and a stale `manual` all survived,
-   with `created_at` backdated 30 days on **every** row so the reap provably keys on `updated_at`.
-   A negative control ran first: two sweeps with nothing stale resolved nothing and logged nothing.
-   🔴 **This closes a real gap — every unit test runs against a FAKE store, so the `pgstore` SQL had
-   never been exercised by the loop against a real Postgres.** 🔴 **But it changed the very variable
-   the bug was about (the interval), so it is NOT a substitute for observing the 30m production
-   tick** — that is what the boot line's `every 30m0s`, the AST cadence guard and the `main()`
-   ledger are for.
-
-   ✅ **VERIFIED IN PRODUCTION 2026-08-28 — the behaviour nobody had ever observed.** Six sweeps
-   over 4.5h, every one landing on exactly `:04:10` / `:34:10` (boot 02:04:10 + n×30m0s), so the
-   cadence is measured over many ticks rather than inferred from one:
-   `02:34:10` resolved **23**, then 8 / 1 / 2 / 5 / 11 at 04:04, 05:04, 05:34, 06:04, 06:34.
-   The bound is holding, checked against the DB and not just the log: open **64 → 11**, resolved
-   45 → 107, **idle entries still past the 4h window = 0**, and both `question` rows preserved.
-   Steady state ~11 against `attentionPanelLimit` 100 — the runaway this feature was losing to is
-   closed.
-
-   Claim `tmux-webapp-1` released.
-2. ✅ **DONE 2026-08-27 — `ZacxDev/homelab-infra#451`, merged as `a38360a5`. Deployed and verified
-   on BOTH hosts.** The suggest POST is detached (payload renamed to a **sibling of `WORKDIR`**,
-   fork, child `rm`s before it logs). Claim `tmux-webapp-2` released.
-   **Measured independently, old hook vs new, against a server that accepts and never replies:
-   8030/8031/8037 ms → 22/21/21 ms.** Verified live through the real path after each pull:
-   workbench `exit 0`, empty stdout, **28 ms**; laptop `exit 0`, empty stdout, **199 ms** (its
-   endpoint is the homelab gateway over nebula, not a LAN NodePort — the extra ~170 ms is the
-   route, not the fork). Both logged `suggest sent ok` from the detached child; no scratch leaked.
-   ⚠ The two hosts pulled at different moments, so they carry the detach at different commits
-   (`a38360a5` / `6cda752c`) — `drift-check.sh` will report that correctly and it is not a defect.
-3. ✅ **DONE 2026-08-28 — BOTH HALVES SHIPPED, DEPLOYED AND VERIFIED THROUGH THE REAL PATH.**
-   Data path: `innovation-upstream/devrc#992` (squash `3d29aba1`), shipped to both hosts.
-   Rendering: `ZacxDev/homelab-infra#496` (squash `844a7350`), **deployed as clawgate 0.8.10**
-   (pin `8c6a8508`). Claim `tmux-webapp-3` released.
-
-   **DECIDED 2026-08-28 (Zach): read-only `capture-pane` rendering first**, over vendoring
-   xterm.js. Carried forward because the REASON outlives the decision and rank 7 will face it
-   again:
-   - 🔴 **THE PREMISE THIS ITEM CARRIED FOR TWO SESSIONS WAS FALSE, and it was the whole
-     argument.** It read "clawgate vendors only two hand-written JS files (~3.7 KB) and **no
-     third-party bundle**, so xterm.js would be the first." Measured 2026-08-28: the two
-     hand-written files live at `internal/ui/js/{filter-toggle,tag-normalize}.js`, individually
-     `go:embed`ed — and **`web/static/vendor/` ALREADY holds FIVE third-party bundles totalling
-     ~245 KB** (`htmx.min.js` 51, `faro-web-sdk.iife.js` 93, `faro-web-tracing.iife.js` 82,
-     `idiomorph-ext.min.js` 10, `sse.js` 9), all swept up by `//go:embed static`. **xterm.js
-     would be the SIXTH; the "no precedent" objection does not exist.** Vendoring is solved and
-     offline-safe here: drop the file in `web/static/vendor/`, reference it, done.
-   - **The decision survives on a BETTER reason:** an interactive terminal means `send-keys` =
-     arbitrary command execution as Zach on both machines, so **item 5's fail-closed wrapper is a
-     hard prerequisite** — "vendor xterm.js" drags the highest-stakes decision in this project
-     forward. Read-only has no write path and therefore no such coupling. That is why the tab
-     that shipped carries no decision surface, enforced by a test.
-
-   🔴 **THE DOC SAID THIS ITEM "NEEDS NO FURTHER DECISIONS" AND THAT WAS WRONG.** It never said
-   WHERE the pane text rides. Measuring first surfaced a real fork — fold it into the existing
-   2-minute push, or build an on-demand rendezvous — that would have been costly to get wrong
-   across two repos. **Zach chose snapshot-carried previews.**
-
-   **The measurements that constrain the design** (72 live panes, 45 workbench + 27 laptop):
-   - 🔴 **SCROLLBACK IS EXCLUDED ON A HARD BOUND.** ~**4,014 B per line fleet-wide**, so
-     `-S -1000` computes to **6.13 MB** against `maxTmuxPushBytes` (4 MB) — the cap breaches at
-     **~650 lines/pane**. Visible screen only; `tail` serves history one window at a time.
-   - 🔴 **ONLY 22% OF PANES CHANGE PER TICK** (10 of 45 over a real 120 s interval), so 77% of
-     the bytes are resent unchanged. In absolute terms that is cheap (62 MB/day gzipped) — **the
-     objection is STALENESS, not bandwidth.** That is the standing argument for an on-demand
-     path later, and the reason one was NOT built now.
-   - shipped shape: 46 Claude panes carry text, 26 shells report `not_claude`. Per-pane cap
-     16 KiB ≈ 2.4x the largest pane then observed (6,616 B).
-
-   🔴 **THE RATIO IS NOT A CONSTANT, AND THIS DOC SHOULD NOT BE READ AS IF IT WERE.** The PR and
-   an earlier revision here say **2.63x** (122,731 → 322,204 B, measured back to back). **In
-   production the first post-deploy push was 3.81x** (115,002 → 438,538 B) and it now sits at
-   ~450 KB. Both readings are honest; the ratio moves with pane count and how full each screen
-   is. What is stable is the headroom: **~10.5% of the 4 MB cap**, ~9.6x clear.
-
-   **Producer, as shipped.** `pane_preview` + `pane_preview_status` on every row, sourced from
-   the capture batch that ALREADY ran (`waiting_probable`/`unsent_prompt` are derived from it and
-   it threw the screen away) — so it costs **zero extra tmux work**. Opt-in `--pane-preview`;
-   `tmux-snapshot-push.sh` is the one caller that passes it, pinned by its own argv test because
-   dropping the flag is a one-word edit that leaves every other test green while the read model
-   stores rows that structurally cannot render. 🔴 **NO SERVER CHANGE WAS NEEDED** — migration
-   0027's "unknown fields preserved verbatim" contract held, verified end-to-end against live
-   0.8.9 before any UI existed.
-
-   **Renderer, as shipped.** `internal/ui/tmux.go` + `internal/api/tmux_ui.go`, `GET /tmux` +
-   `GET /ui/tmux`.
-   - 🔴 **NO DECISION SURFACE, AND IT IS A HARD PREREQUISITE.** A write here is `send-keys` =
-     arbitrary command execution as Zach on both machines, and **item 5's fail-closed wrapper
-     does not exist yet**. `TestTmuxGridCarriesNoDecisionSurface` asserts the RENDERED HTML has
-     no form/button/hx-post — against output, not source, because a helper that emits a button
-     is still a button. **Do not add one before item 5.**
-   - 🔴 **THE FOUR NULLS.** `disabled` (never asked) / `not_claude` (shell, never captured) /
-     `uncaptured`+`skipped`+`error` (asked, not measured) / `truncated` (a PREFIX, shown AND
-     labelled) / `ok`, plus the EMPTY status = "collector predates the field". A test pins that
-     no two share a sentence. This is what makes a half-deployed fleet debuggable.
-   - 🔴 **THE TAB NEEDED FIVE REGISTRY ENTRIES** — `tabKeys`, `tabHeadings`, the sidebar, **the
-     JS `TABS` array** and **the JS `HEADINGS` map**. The existing guards caught the two that
-     were missed (`TestAttentionTabIsWiredIntoEveryTabList`, and the axe scan on two
-     `text-slate-500` uses at 4.24:1). Adding an eighth tab? Expect all five.
-   - 🔴 **THE PANEL POLLS (60 s), it does not await an SSE event.** This read model is fed by an
-     OUTSIDE agent and clawgate emits no `tmux.changed`; an `sse:` trigger would look like
-     working code and never fire. Pinned by a test.
-   - The two HUMAN routes are registered **unconditionally**, outside `registerTmuxRoutes`'
-     nil-store guard, because `Page` renders the panel on every boot — a store-less boot would
-     otherwise paint a tab whose panel 404s. MACHINE routes stay behind the guard.
-
-   ✅ **VERIFIED LIVE 2026-08-28, not inferred.** Pod `clawgate-fcd8c945b-44rqj` Running/ready,
-   `restarts=0`, image `0.8.10`; `clawgatectl health` = 0.8.10; `clawgatectl --version` = 0.8.10
-   on BOTH hosts (no skew note). `GET /ui/tmux` → **200, 208,347 bytes**, both host sections,
-   **48 pane screens**, age badges `1m ago`, 0 stale, 0 unreachable, and the decision-surface
-   scan clean **on the live page**. Read model: 48 `ok` / 28 `not_claude`, largest preview
-   9,032 B against the 16 KiB cap, **0 truncated**.
-
-   Tests: 15 producer + 15 renderer, mutation-swept **10/10** and **11/11** non-equivalent
-   mutants killed, each with a green baseline verified BEFORE and AFTER.
-4. ✅ **DONE 2026-08-28 — BOTH HALVES SHIPPED, DEPLOYED AND OBSERVED RUNNING UNATTENDED.**
-   Server: `ZacxDev/homelab-infra#468` (`32f49804`), deployed as clawgate **0.8.8**
-   (`628a963a`). Pusher: `innovation-upstream/devrc#974`, squash-merged **`f0308e46`**,
-   shipped to both hosts (`ship.sh` — cross-host agreement verified at one sha).
-   Claim `tmux-webapp-4` released.
-
-   🔴 **THE PROOF IS AN UNATTENDED TICK, NOT A HAND-RUN PUSH.** Every earlier success in
-   this item's history was me invoking the script. Measured after the switch, with no human
-   action: journal shows successive `pushed …B … HTTP 200` at 14:58:47 / 15:00:49 / 15:02:5x
-   / 15:04:5x (2m0s apart, `Result=success`, `ExecMainStatus=0`), and `receivedAt` advanced
-   `20:02:52 → 20:04:52` across a tick while the push count went 3 → 4. Read model:
-   workbench 45 windows / 34 with `runtime`, laptop 27 / 10.
-
-   ⚠ **Live clawgate is now 0.8.9** — another session shipped it mid-work. My 0.8.8 deploy is
-   superseded, not undone; the snapshot routes were re-verified on 0.8.9 (200 with token, 401
-   without). **Read the live pin, never this line.**
-
-   ⚠ The timer is `serverMode`-gated to the workbench and the laptop correctly shows
-   `linked`-not-enabled. That is CORRECTNESS, not scoping: `session-manager --json` collects
-   BOTH hosts from the workbench, so two reporters would fight over every row.
-
-   🔴 **Two decisions here were made AGAINST this doc, on measurement.** (a) It specified a unit on
-   EACH host; `session-manager --json` already collects BOTH from the workbench (it SSHes to the
-   laptop) in **~970 ms**, returning 43 workbench + 28 laptop windows — so ONE agent, and the schema
-   is per-host so a second reporter can be added later with no server change. (b) It sketched a
-   WebSocket; rank 3 deferred the interactive terminal, so a persistent socket buys nothing today
-   and adds reconnect/backoff state to get wrong. **Periodic HTTPS POST.**
-
-   **What shipped:** `POST/GET /api/tmux/snapshot` behind `requireHookToken`, migration `0027`
-   (latest-per-host, no reaper — a snapshot is current-state, so there is nothing to retain and no
-   reaper to get wrong, which is the mistake `attention_entries` paid for), and `internal/tmux`,
-   which exists to own the VOCABULARY BOUNDARY: session-manager spells its tmux session `session`,
-   so the collision arrives WITH THE PAYLOAD and is renamed to `tmuxSessionName` at ingest.
-
-   **The pusher, as shipped.** `scripts/tmux-snapshot-push.sh` + a `serverMode`-gated systemd
-   user timer (`OnUnitActiveSec=2min`), posting `session-manager --json` VERBATIM; the server
-   normalises, so the host stays a dumb pipe and the vocabulary rename lives where it is
-   tested. Cadence measured, not guessed: 1298 / 1196 / 1193 ms per collection, ~1% duty
-   cycle. ⚠ Its real per-run cost is up to FOUR ssh invocations (no `ControlMaster`) plus one
-   ClickHouse query — ~2,880 handshakes/day, not the 720 an earlier estimate implied.
-
-   🔴 **Distinct exit codes are the ONLY alarm it has** — 2 no creds, 3 collector failed,
-   4 transport, 5 non-2xx, 6 torn collection. It deliberately wires **no** `OnFailure` toast:
-   that toast defeats do-not-disturb and is justified by ~1 firing in 9 days, so at this
-   cadence a sustained outage would fire it 720×/day and burn down the channel. ⚠ **The
-   compensating control is `/standup` reading the failed-unit list, NOT read-model staleness**
-   — nothing reads `GET /api/tmux/snapshot` outside clawgate's own tests, so `receivedAt`
-   staleness is recorded and unread. That covers the exit codes and NOT an exit-0-achieving-
-   nothing, which is why the redirect and unmeasured-zero cases are handled in the script.
-
-   🔴 **Four audit rounds; every one found a defect the previous round's fix introduced.**
-   Round 2: `rc=$?` after `if ! cmd` is always 0 (so every failure logged `rc=0`, worst on a
-   timeout, which has empty stderr too); success tested `HTTP < 400`, so a 3xx meant curl
-   returned the redirect, nothing was stored, and it logged "pushed" and exited 0; and
-   `windows_measured` — the discriminant `session-manager` computes precisely to separate an
-   unmeasured zero from a real one — was being discarded at the last place that still had it,
-   so a reachable-but-unenumerated host would overwrite a good 44-window snapshot with a
-   false zero. Round 3's fix then **dropped `gawk`** as "unused": `agent_ledger` runs `awk 1`,
-   `awk` exists only in gawk, and the `2>/dev/null; exit 0` hides the error while the `echo`
-   sentinel still prints — 34 of 45 windows silently lost `runtime`. Round 3 also broke BOTH
-   required checks with a **pure prose change**, because `launcher_scan.py` reads raw text and
-   the comment named a hazardous binary. Round 4 caught `30[0-9]` failing to exclude 304.
-
-   🔴 **A mutation sweep certified two of these as covered when they were not.** The `rc=0`
-   mutant SURVIVED a green file (nothing asserted the number), and the 304 mutant reported
-   *killed* against a test that was **already red** — a mutant dies for free when the baseline
-   is red, and I had never run that test unmutated. Final: 24 mutants, 24 killed, with the
-   controls fixed. **The sweeps found less than the auditor did.**
-
-   **Five audit rounds ran. Every round found a defect the PREVIOUS round's fix introduced** —
-   round 1 an atomicity bug; fixing it caused a 30%-reproducible deadlock (randomised map order vs
-   row locks); fixing THAT left a guard three separate mutants walked through; and `UseNumber`,
-   added so a nanosecond timestamp is not corrupted, re-opened an amplification that a 32-char cap
-   missed (`1e100000` is 8 chars) and `ParseFloat` then closed only half of (it returns `0, nil` on
-   UNDERFLOW). Round 5 was the first with **no behaviour defect**. Stopped there — one round short
-   of the mechanical two-zero-payload gate — because round 5 was auditing test code round 4 wrote.
-   Residual amplification measured **8.1x**, ratio-bounded, down from 1,107x.
-5. ✅ **DONE 2026-08-29 — `ZacxDev/homelab-infra#516`, squash `c8635976`, DEPLOYED as clawgate
-   0.8.13 and VERIFIED LIVE.** The wrapper exists, is tested, and ships **with no caller**, which
-   was the requirement: "before any write endpoint exists, not after."
-
-   ✅ **Verified 2026-08-29 20:58Z, through the real path, with both controls:** pod
-   `clawgate-7c9fd4bcc5-d25v6` Running/ready `restarts=0` image `0.8.13`; `clawgatectl health`
-   (the SERVER, not the deploy) = **0.8.13**; and the boot line present:
-   `terminal write surface: DISABLED (fail-closed) — CLAWGATE_TERMINAL_TOKEN is not set`.
-   🔴 **A BEFORE-CONTROL WAS TAKEN AND VALIDATED** — the running 0.8.11 pod matched that grep
-   **0** times while the same grep shape matched the reaper's boot line **1** time, so the zero
-   was a fact about the log rather than a grep wired to nothing, and the line that appeared after
-   the roll is genuinely new.
-
-   🔴 **WHAT IS *NOT* VERIFIED, AND CANNOT BE YET: the 503 refusal in production.** No route uses
-   the wrapper — that is the entire point of shipping it first — so there is nothing to probe.
-   The refusal behaviour rests on the unit tests plus the mutation sweep, and the LIVE evidence is
-   the boot line alone. Do not upgrade "deployed and announcing DISABLED" into "the refusal was
-   exercised in production"; the first route to use it is what makes that claim available.
-
-   ⚠ **0.8.12 EXISTS IN HARBOR AND WAS NEVER DEPLOYED.** It was built from a tree that predated
-   `e8635c5f` (#503, the `Migrate` advisory-lock fix), which landed on trunk mid-review with **no
-   pin bump** — so 0.8.12 would have carried a pin reading NEWER than trunk while omitting a fix
-   trunk already had, and the next reader would have concluded #503 was deployed. Rebuilt from the
-   merged tree as **0.8.13** (a NEW tag, not a re-push: overwriting a mutable tag has cost this
-   project once). 🔴 **Deploying 0.8.13 therefore also SHIPPED #503** — whose own audit follow-ups
-   are still open as `ZacxDev/homelab-infra#509`.
-
-   **What shipped.** `requireTerminalToken` in `internal/api/auth.go`, gated by a **dedicated**
-   `CLAWGATE_TERMINAL_TOKEN`. `AuthConfig.TerminalWriteRefusal()` is the single predicate; it
-   refuses when the token is unset, shorter than 32 chars, **or equal to the hook token**. A
-   refused request gets **503 and the handler is never called**. `clawgate gentoken` now mints
-   both tokens as independent entropy.
-
-   🔴 **DEDICATED SECRET, DECIDED WITH ZACH BEFORE BUILDING — and the reason is measurable, not
-   stylistic.** The hook token is handed to every hook script on both hosts, written to
-   `~/.claude/clawgate.env`, minted into agent pod env (`internal/agents/values.go`), and travels
-   **in cleartext** to the LAN NodePort many times a day. It is the wrong secret to guard code
-   execution. Reusing it would also have inherited enforce-when-set, i.e. the exact defect.
-
-   🔴 **THE BOOT LINE IS THE LOAD-BEARING DIAGNOSTIC, and it is logged in BOTH directions**
-   (`terminal write surface: ENABLED …` / `DISABLED (fail-closed) — <which refusal>`). A healthy
-   idle surface and one refusing everything are otherwise byte-identical in the log, because
-   nothing calls the surface. That is rank 1's failure shape exactly. The reason names WHICH
-   refusal fired and **never reaches an HTTP response** — the 503 body says only "not configured".
-
-   🔴 **THE SECRET IS NOT PROVISIONED, AND THAT IS THE HANDED-OVER STEP.** The SOPS **age identity
-   is on NEITHER host** (`~/.config/sops/age/` is empty on the workbench and absent on the
-   laptop), so `sops -d` fails rc 128 and I could not add the key. The manifest therefore wires
-   it with **`optional: true`**, which is the fail-closed design rather than a loose end: without
-   it a missing key is a `CreateContainerConfigError` that stops the **whole pod**, turning "the
-   terminal surface is unprovisioned" into a full outage of the approval router. With it the pod
-   boots, logs `DISABLED (fail-closed)`, and 503s that surface. **Adding the key later flips it to
-   ENABLED with no manifest change and no code change.**
-   Operator step: `clawgate gentoken` → take the `CLAWGATE_TERMINAL_TOKEN` line →
-   `sops clusters/workbench/apps/clawgate/secrets.enc.yaml`, add it under `stringData`.
-
-   **The route ledger.** `internal/api/terminal_write_ledger_test.go` **parses** every
-   `mux.HandleFunc` (go/ast, comments discarded) and fails any future write on the terminal path
-   prefixes not behind `requireTerminalToken`. `POST /api/tmux/snapshot` is the one **enumerated**
-   exemption with its reason, pinned **two-way** so it cannot rot. It resolves **aliased** wrappers
-   (`op := s.requireOperatorToken` is real style in `operator.go`). ⚠ **Labelled in-file as an
-   INVARIANT GUARD, not regression coverage** — no bug ever violated it.
-   🔴 A raw-text scanner was rejected on measurement, not taste: this package's own comments
-   discuss `send-keys`, and a prose-only change has reddened both required tiers in the fleet
-   before.
-
-   🔴 **THE SYNTHETIC CONTROLS CALL THE REAL VERDICT.** The first draft had the end-to-end test
-   re-implement the ledger's decision over its fixtures — which proves a COPY works while any
-   mutation of the real loop sails through. Extracted to one `auditTerminalWrites` used by both.
-
-   **Verification.** Mutation sweep **15/15 killed, 0 survived, 0 invalid**, each by its
-   **expected** test; green baseline verified before AND after the refactor; every mutant asserts
-   its edit applied exactly once, so a patch matching nothing reports INVALID rather than
-   SURVIVED. 🔴 **The sweep's own attribution parser was WRONG on the first run** — it printed
-   `FAIL:` for every mutant instead of the test name (`split()[1]` is the literal "FAIL:") — so
-   no kill was attributable. Fixed and re-run before anything was quoted. Full `go test ./...`
-   on the **merged** tree: exit 0, 19 `ok` + 2 no-test-files, 0 FAIL.
-
-   Claim `tmux-webapp-5` released.
-
-   🔴 **A FORK THIS DOC NEVER NAMED, AND IT LANDS ON RANK 7 — NOT ON THIS ITEM.**
-   `comment_delete.go:110-130` records that **the browser holds NO credential at all**: clawgate
-   has no human auth, so the app's established pattern for a UI-driven mutation is an **open twin
-   route** behind the pass-through `requireSession`, precisely because rendering a token into the
-   page would hand it to anyone who can load the open LAN page. **That pattern cannot be used for
-   `send-keys`.** So "what does a human in a browser present to the fail-closed wrapper" is
-   genuinely open. It did NOT block this item — middleware is caller-agnostic; curl and
-   `clawgatectl` can carry the token today. It DOES block a browser terminal, and the three
-   candidate answers (a machine-only surface; a token the operator pastes into that browser once;
-   serving writes only through the Authelia edge) are materially different work.
-6. **Layout schema + `clawgatectl view`/`panel` verbs** (phase 3) — views/panels/targets/state in
-   Postgres, so a human drag and an agent call are the same operation.
-7. **The grid UI** (phase 4), then organization ops behind item 5's auth.
-8. **Housekeeping, cheap:** eight more sleep-based timing bets in
-   `containers/clawgate/internal/api/{push_task,task_comment}_test.go` (pre-existing; mechanical now
-   the `awaitPushesSettled` barrier exists); and a scanner test for in-body `! grep` — closing
-   condition: a test in both bats suites that reds on a planted `! grep` assertion.
-
-🔴 **There is no rank 9. A previous revision listed one — "get three portable lessons into
-`MEMORY.md`" — and it was NOT a work item: the operator confirmed 2026-08-27 that MEMORY.md is not
-used here, so nothing could ever have closed it.** Removed deliberately rather than left to be
-re-read by every resume. The lessons themselves are kept where they belong: the clawgate-specific
-ones in the subsystem index (`homelab-talos/clawgate.md`), and the two generic ones — bats `! grep`
-inertness and the zsh `EPOCHREALTIME` trap — in this doc's own **Gotchas**, which appends and
-survives. Nothing was lost by dropping the item; only the false claim that work was outstanding.
-
-10. **Two guard gaps #457's ladder left open deliberately, both scaffolding-scope.** Recorded here
-    because the ladder stopped on the attribution gate (two consecutive zero-payload rounds), not
-    because these were closed.
-    - **`RunSweeper`'s ticker survives `NewTicker`→`NewTimer`** against the whole api package —
-      i.e. the same one-shot defect class, still unguarded on a *different* loop. Pre-existing and
-      unrelated to #457, found incidentally. `RunRetention` and `RunReconciler` are worth the same
-      check. The structural pattern to copy now exists:
-      `TestRunAttentionReapTicksOnTheIntervalItWasGiven`. Closing condition: a mutation of each
-      loop's ticker reds a named test.
+10. **Two guard gaps #457's ladder left open deliberately, both scaffolding-scope.**
+    - **`RunSweeper`'s ticker survives `NewTicker`→`NewTimer`** against the whole api package — the
+      same one-shot defect class, unguarded on a different loop. `RunRetention` and `RunReconciler`
+      deserve the same check. Pattern to copy: `TestRunAttentionReapTicksOnTheIntervalItWasGiven`.
+      Closing condition: a mutation of each loop's ticker reds a named test.
     - **The `main()` wiring ledger pins syntax, not reachability.** Wrapping a loop's start in a
-      condition false in production (`if os.Getenv(...)=="1"`) keeps it green — verified. NOT
-      closable statically, because the start is legitimately inside `if pool != nil`; banning
-      enclosing conditions would red the real code. Documented in-test. The compensating control is
-      the runtime entry log line, which is itself now guarded.
+      condition false in production keeps it green — verified. NOT closable statically. The
+      compensating control is the runtime entry log line, which is itself guarded.
 
-**Parked with the operator (not work items until answered):**
-- Seam tests **skip in `clawgate-ci`** — the Go image has no `jq`. Closing it edits a pipeline every
-  PR in the repo runs. `TestSeamASlowSuggestPostCostsTheHookNothing` — the only test driving *real*
-  curl at a *real* server — is therefore ungated.
-- `ZacxDev/homelab-infra` has **no branch protection at all** (the API 403s — needs GitHub Pro or a
-  public repo). Nothing there is mechanically required; every merge rests on the reader.
-- The **passive backstop was declined**: all three raisers need an agent to cooperate or a hook to
-  fire, so an agent that hangs, crashes or is killed raises nothing — and those strand longest.
-  `session-manager`'s waiting-detection is read-only and cheap to add if the queue misses cases.
+11. **The archive drawer loses its `open` after every write-triggered swap.** KNOWN, UNFIXED, and
+    noted in-code at `layoutArchivedDrawer` with both rejected fixes: `open` unconditionally
+    defeats the decluttering the drawer exists for, and `hx-preserve` pins a stale node so Restore
+    would not update the card. The correct fix is the `taskCardScript` treatment (a once-bound
+    listener re-applying `open` after settle) — new client JS, which needs 8b's e2e spec to be
+    verifiable at all. Closing condition: restoring three archived panels in a browser without
+    reopening the drawer between each.
 
 ## Open investigations — live diagnosis state
 
@@ -710,6 +309,49 @@ already on that daemon from the build.
 did not exist.** The docker.io diagnosis lived only in the header comment of an **untracked**
 `nix/system/apply-dnsmasq-docker-io-pin.sh` — one routine `checkout` from silent deletion. Both
 are fixed: the script is committed, and this section exists.
+
+### `devrc#1056` (the tmux server sentinel) is merged-blocked, and the reason CHANGED mid-session
+- **Symptom:** the producer half of rank 6 — `session-manager` publishing `tmux_server_id` per host —
+  is complete, mutation-swept 8/8, verified against real tmux on both hosts (52/52 and 28/28 rows
+  parsed through the real ssh path), and has been sitting open since 2026-08-29.
+- **Observed (with values):** first blocker was devrc `main` red on
+  `test_espanso_detect.py::test_live_existing_resolutions_not_made_ambiguous`, asserting
+  `{'ask': (':acq', None, [':dacq', ':acq']), 'clarify': (':acq', None, [':dacq', ':acq'])}`.
+  Discriminating control run: **the identical assertion fails on a clean `origin/main`** in an
+  unrelated checkout, so it is not this diff. Claimed by another session as
+  `espanso-ask-tiebreak-main-red`. **As of 2026-08-30 06:30Z the checks read
+  `tekton/devrc-nodetests=ERROR` and `tekton/devrc-pytests=ERROR`, not `failure`** — per devrc's own
+  CLAUDE.md that distinction matters: `error` means the gate stopped before a leg reported, i.e. a
+  broken gate rather than a bad change.
+- **Ruled out:** this PR's own diff. It touches `scripts/session-manager` and its test only; the
+  espanso test is in `scripts/collector/keylog/`, and the full suite was green on the branch apart
+  from that one pre-existing failure (`failed=1` of 18,713 collected).
+- **Leading hypothesis:** two unrelated blockers in sequence — a real main-red (someone else's, being
+  fixed) followed by an infrastructure error on the gate itself.
+- **Next probe:** `gh pr checks 1056 --repo innovation-upstream/devrc` and, if still ERROR, read the
+  PipelineRun rather than the status — a check posted as `error` with `COULD NOT RUN: <leg>` is a
+  broken gate and must not be debugged against the diff.
+- 🔴 **Consequence while it stays open:** `tmux_server_id` is NULL on both hosts, so the resolver's
+  window-id tier disables itself (unknown sentinel ≠ agreement) and panels resolve by
+  codename/name. Verified live — that is the designed degradation, not a fault. **Claim
+  `tmux-webapp-6` is deliberately still held** until this lands and the sentinel is observed
+  non-null end to end.
+
+### The layout tab has never been exercised in a browser
+- **Symptom:** rank 7 is a UI feature whose every claim rests on Go tests and rendered-HTML
+  assertions.
+- **Observed:** `clawgate-e2e` is GREEN on the merged tip — `stats: passed=118 failed=0 skipped=2
+  flaky=0 rc=0` — but it ran 20 spec files (`requests`, `tasks`, `agent-chat`, `operator`,
+  `routing`, `responsive`, …) and **`grep -ic layout` over the whole run log returns 0**. That green
+  says nothing about this feature.
+- **Ruled out:** "e2e covers it" — measured above. Also ruled out: that the run hid a failure; an
+  earlier read of "118 failed" was a grep straddling the fields of `passed=118 failed=0`.
+- **Leading hypothesis:** no hypothesis needed — it is simply uncovered. The specific risks are the
+  htmx swap whose target contains the issuing button (`hx-disabled-elt="this"` has four precedents
+  here, so low but unmeasured), a real axe scan on the new fragment, and rank 11's drawer behaviour.
+- **Next probe:** write `containers/clawgate/e2e/tests/layout.spec.ts` and run `make e2e`. 🔴 **COUNT
+  what runs** — without Docker, `test.skip` on `!dockerAvailable()` leaves 11 of 18 spec files and
+  goes green.
 
 ## Gotchas
 - 🔴 **A FAILED `git worktree add` DOES NOT STOP THE NEXT `git -C <path>` — AND I LANDED A
@@ -1040,81 +682,145 @@ are fixed: the script is committed, and this section exists.
   is the actual command. This already has an entry above; it is repeated because a mutation sweep
   that widens to the full package will surface it as two mystery kills and look like a real find.
 
+- 🔴 **A GUARD THAT SCANS ROUTE STRINGS CANNOT SEE WHAT A HANDLER DOES, AND ITS OWN POSITIVE CONTROL
+  WILL TELL YOU IT WORKS.** `TestTheLayoutUIAddsNothingToTheTerminalSurface` scanned
+  `mux.HandleFunc` PATTERNS and carried a control proving the string scan fired. Planting
+  `exec.CommandContext(…, "tmux", "send-keys", …)` in the unauthenticated handler — applied once,
+  compiling, no route string touched — left the ENTIRE suite green, that test included. The
+  docstring named a property the body never checked. Fixed by AST-scanning handlers (comments
+  discarded — a raw-text scan fires on this repo's own prose and has reddened the gate before).
+  **Ask what the code must DO, then check the guard inspects that, not its neighbour.**
+- 🔴 **A LEDGER ENTRY THAT JUSTIFIES AN EXEMPTION IS THE HIGHEST-VALUE PLACE FOR A FALSE CLAIM.**
+  `allowedNonTerminalWrites` said view-scoping stopped "an unauthenticated LAN client walking 1..N
+  and emptying every view". `GET /ui/layout` is on the pass-through tier and renders every panel's
+  write address, so one anonymous GET hands over the whole arrangement — measured: 9 addresses
+  harvested, 9/9 panels destroyed, all 200. The scoping raised a full wipe from P requests to 1+P.
+  **The fix was structural, not documentary:** the irreversible control was removed, so the sentence
+  that needed justifying no longer exists.
+- 🔴 **THREE OF MY OWN MUTANTS WERE INVALID AND ONE ALMOST READ AS A PASS.** Two failed to compile
+  and one had an anchor that matched 0 times — each printed a green suite that looks exactly like a
+  survivor. **A patch that does not apply EXACTLY once, or does not compile, is INVALID — never a
+  kill and never a survivor.** Assert the match count before applying, and check the build before
+  scoring.
+- 🔴 **A `-run` FILTER CAN EXCLUDE THE ONLY TEST THAT WOULD HAVE CAUGHT YOU — TWICE IN ONE SESSION.**
+  `-run Vocab` skipped the module-wide `TestNoProducerStructCallsAFieldSessionAlone`, and I
+  concluded the vocabulary scan did not cover a new package when it does. Separately,
+  `-run 'Layout|layout'` never ran `TestAHostOnlyPanelIsREJECTEDByTheAPINotStored`, which was
+  failing. **Run the whole package before concluding a guard has a gap.**
+- 🔴 **A THEORY THAT EXPLAINS THE FAILURE IS NOT EVIDENCE FOR IT.** `clawgate-ci` and
+  `clawgate-ux-audit` failed repeatedly; I attributed it to cluster load with real numbers — 22.7x
+  median wall-time inflation across packages with ZERO failures, 12 concurrent PipelineRuns, nodes
+  at 51–62%. All of that was true and it was the WRONG MECHANISM. Both went green the moment #509's
+  advisory-lock fix became an ancestor. Every symptom was lock-shaped: a statement timeout on
+  `ensure schema_migrations`, "failed to take a FREE lease", and an 11–15s stall exactly where
+  `Migrate` takes its advisory lock. **Change one variable and re-measure before calling a cause.**
+- 🔴 **A BARE PR NUMBER IS AMBIGUOUS ACROSS REPOS AND THE WRONG ONE RESOLVES SILENTLY.**
+  `audit-dispatch.py 538` assembled a brief for `devrc#538` (a docs handoff) because that is the
+  cwd's repo; the target was `ZacxDev/homelab-infra#538`. Caught only by reading the generated
+  brief's TITLE. Pass `--repo owner/name` whenever the PR is not in the cwd's repo.
+- 🔴 **`gofmt -w <dir>` REFORMATS PRE-EXISTING FILES AND SILENTLY WIDENS YOUR DIFF.** Seven files I
+  never touched appeared in the change set as pure alignment churn. Format only the files you edited.
+- ⚠ **An image built during review can silently omit a fix that landed on trunk mid-review.**
+  0.8.12 and 0.8.14 were both discarded for exactly this: trunk gained a `containers/clawgate`
+  commit (#503, then #509) while the PR sat, so the image would have carried a HIGHER version with
+  LESS code. **Before pushing a pin, check `git log HEAD..origin/trunk -- containers/clawgate` and
+  rebuild if it is non-empty.** Never re-push a mutable tag — mint a new one.
+- ⚠ **`docker push` sends registry auth from the LOCAL client, not the `DOCKER_HOST` daemon.**
+  `DOCKER_HOST=ssh://zach@10.42.0.100 docker push` fails `unauthorized to access repository:
+  library/clawgate` because the workbench's `~/.docker/config.json` has no `harbor.homelab.lan`
+  entry while the laptop's does. **Run the push ON the laptop**; the image is already there from the
+  build. `docker manifest inspect` also fails on the self-signed CA — use `docker pull` to confirm
+  Harbor serves a tag.
+- ⚠ **A squash merge makes `merge --ff-only` refuse forever** — the branch tip is not an ancestor.
+  That refusal is correct, not a fault; make a fresh worktree off `origin/trunk` instead.
+- 🔴 **CARRIED FORWARD FROM RANK 3's ENTRY (2026-08-28) — two measurements that CONSTRAIN any
+  future read-model work and lived only in a REPLACE section until now:**
+  - **SCROLLBACK IS EXCLUDED ON A HARD BOUND.** ~**4,014 B per line fleet-wide**, so `-S -1000`
+    computes to **6.13 MB** against `maxTmuxPushBytes` (4 MB) — the cap breaches at **~650
+    lines/pane**. Visible screen only; `tail` serves history one window at a time.
+  - **ONLY ~22% OF PANES CHANGE PER TICK** (10 of 45 over a real 120 s interval), so ~77% of the
+    bytes are resent unchanged. In absolute terms that is cheap (~62 MB/day gzipped) — **the
+    objection is STALENESS, not bandwidth.** That is the standing argument for an on-demand path,
+    and the reason one was not built.
+- 🔴 **MOVED HERE FROM `How to verify` so a status replace cannot drop them again — these are
+  durable and were nearly lost in the 2026-08-30 update:**
+  - **`clawgatectl` is built from the LOCAL `homelab-talos` tree**, so a behind checkout ships a
+    binary missing verbs that prints help and **exits 0** under a plausible version label. Both
+    hosts need `homelab-talos` current *before* a `home-manager switch`. Measured 2026-08-28: the
+    laptop was **17 commits behind** while the workbench was current — `ship.sh` does NOT converge
+    that repo. Live again 2026-08-30: both hosts 0.8.17 against an 0.8.18 server (rank 8a).
+  - **After any deploy, check ALL pods, not `.items[0]`** — `kubectl -n clawgate get pods -l
+    app=clawgate` lists a `Succeeded` leftover too, so a `.items[0]` jsonpath reports the wrong
+    image. Confirm the pod is `Running` **and ready**.
+
 ## How to verify
 
 ```bash
-clawgatectl health                 # read the LIVE version; do not expect a number from this doc
-clawgatectl --version              # must MATCH the server, on BOTH hosts — a mismatch means the
-                                   # buildVersion half of a pin bump was missed (reddens trunk)
+clawgatectl health                 # the LIVE version; never expect a number from this doc
+clawgatectl --version              # must MATCH the server on BOTH hosts; a mismatch means the
+                                   # local homelab-talos tree is behind (see rank 8a)
 ```
 
-**Is rank 3 actually working?** (the tmux pane grid — end to end, not a unit test)
+**Is rank 7 (the layout grid) actually working?**
 ```bash
-# 1. the FEEDER is passing the flag and the timer — not you — is running it.
-#    A hand-run push proves nothing; the journal is the evidence.
-journalctl --user -u tmux-snapshot-push.service --since -10min | grep pushed
-#    expect ~450 KB every 2m0s. ~115 KB means --pane-preview is NOT being passed.
-
-# 2. the READ MODEL carries screens, and the STATUS FIELD is the discriminator —
-#    never grep the page for a word, pane content can spell it (see Gotchas).
 TOK=$(grep -E '^\s*(export\s+)?CLAWGATE_HOOK_TOKEN=' ~/.claude/clawgate.env | tail -1 | sed 's/.*=//; s/"//g')
-curl -s -H "Authorization: Bearer $TOK" http://192.168.50.250:30302/api/tmux/snapshot \
-  | python3 -c 'import json,sys,collections
-c=collections.Counter(); mx=0
-for r in json.load(sys.stdin):
-    for w in r.get("windows") or []:
-        c[w.get("pane_preview_status")]+=1
-        mx=max(mx,len((w.get("pane_preview") or "").encode()))
-print(dict(c), f"largest={mx:,}B cap=16,384")'
-#    expect {"ok": ~48, "not_claude": ~28}. ALL `disabled` => the collector ran without
-#    --pane-preview. ALL `null`/empty-status => that host is on a collector PREDATING the field.
-
-# 3. the TAB renders it.
-curl -s -o /dev/null -w '%{http_code}\n' http://192.168.50.250:30302/ui/tmux    # 200
-curl -s http://192.168.50.250:30302/ui/tmux | grep -c '<pre'                    # pane screens
+B=http://192.168.50.250:30302
+curl -s -o /dev/null -w '%{http_code}\n' "$B/ui/layout"     # 200
 ```
-🔴 **The decision-surface invariant, checked on the LIVE page — item 5's fail-closed auth wrapper
-does not exist yet, so this tab must have no write surface at all:**
+🔴 **Seed a view before trusting any absence.** An empty layout page is ~318 bytes and trivially
+contains zero of everything — a "0 hx-delete" on it is a reassuring zero, not a measurement:
 ```bash
-curl -s http://192.168.50.250:30302/ui/tmux | grep -cE '<form|<button|hx-post|hx-delete|hx-put'
-# MUST be 0. Anything else means a control reached a tab whose write path is `send-keys`,
-# i.e. arbitrary command execution as Zach on both machines.
+curl -s -X POST -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json' \
+  -d '{"name":"verify"}' "$B/api/layout/views" >/dev/null
+curl -s -X POST -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json' \
+  -d '{"host":"laptop","codename":"wheat","windowName":"devrc"}' \
+  "$B/api/layout/views/verify/panels" >/dev/null
+curl -s "$B/ui/layout" > /tmp/l.html
+grep -c 'hx-post'   /tmp/l.html    # POSITIVE CONTROL — must be >0, proving the scan sees controls
+grep -c 'hx-delete' /tmp/l.html    # MUST be 0
+curl -s -o /dev/null -w '%{http_code}\n' -X DELETE "$B/ui/layout/views/1/panels/1"   # 404 = route gone
+# clean up: DELETE /api/layout/views/<id> with the token
 ```
 
-**Is the idle reaper actually running?** (rank 1's answer — for ~9h it was NOT, and nothing said so)
+**Is rank 5's terminal tier still fail-closed?** The boot line is UNCONDITIONAL and in both
+directions — its absence is the alarm, and a silent healthy surface and a silently-refusing one are
+otherwise byte-identical:
+```bash
+KUBECONFIG=$KC_WORKBENCH kubectl -n clawgate logs -l app=clawgate --tail=-1 \
+  | grep 'terminal write surface'
+# expect: DISABLED (fail-closed) — CLAWGATE_TERMINAL_TOKEN is not set
+```
+
+**Did a migration actually apply?** A rollout can half-do a schema change silently:
+```bash
+KUBECONFIG=$KC_WORKBENCH kubectl -n clawgate logs -l app=clawgate --tail=-1 | grep 'applied migration'
+```
+⚠ A pod that did NOT apply one logs nothing — absence means an EARLIER pod applied it, not that it
+is missing. The functional proof is stronger: create and delete a view through `/api/layout/views`,
+which requires both `layout_views` and `layout_panels` to exist.
+
+**Is the idle reaper running?** (rank 1's answer — for ~9h it was NOT, and nothing said so)
 ```bash
 # 1. it announced itself at boot. This line is unconditional; its ABSENCE is the alarm.
 KUBECONFIG=$KC_WORKBENCH kubectl -n clawgate logs -l app=clawgate --tail=-1 \
   | grep 'attention reaper: sweeping every'
-# 2. it has swept something (only logs when N>0, so an empty result is NOT a failure)
+# 2. it has swept something (logs ONLY when N>0, so an empty result is NOT a failure)
 KUBECONFIG=$KC_WORKBENCH kubectl -n clawgate logs -l app=clawgate --tail=-1 | grep 'attention-reap:'
-# 3. the queue is bounded. Count OPEN idle rows past the 4h window — a healthy
-#    steady state is ~30, and anything climbing toward attentionPanelLimit (100) means
-#    the sweep is not keeping up.
-curl -s -H "Authorization: Bearer $CLAWGATE_HOOK_TOKEN" http://192.168.50.250:30302/api/attention \
-  | python3 -c 'import json,sys,datetime as d
-now=d.datetime.now(d.timezone.utc); rows=json.load(sys.stdin)
-idle=[r for r in rows if r["kind"]=="idle"]
-old=[r for r in idle if (now-d.datetime.fromisoformat(r["updatedAt"].replace("Z","+00:00"))).total_seconds()>4*3600]
-print(f"open={len(rows)} idle={len(idle)} idle_past_4h={len(old)}")'
 ```
-🔴 **Validate this instrument before quoting a zero** — `GET /api/attention` defaults to
+🔴 **Validate that instrument before quoting a zero** — `GET /api/attention` defaults to
 `state=open`, so cross-check `?state=resolved` and `?state=all` and confirm open+resolved==all.
 Measured 2026-08-27 pre-fix: open=59, resolved=31, all=90 — the filter discriminates.
-- 🔴 **`clawgatectl` is built from the LOCAL `homelab-talos` tree**, so a behind checkout ships a
-  binary missing verbs that prints help and **exits 0** under a plausible version label. Both hosts
-  need `homelab-talos` current *before* a `home-manager switch`. Measured 2026-08-28: the laptop
-  was **17 commits behind** while the workbench was current — `ship.sh` does NOT converge it.
-- **The attention feature's own proof** is end-to-end, not a unit test: trigger a real
-  `AskUserQuestion`, then confirm a `kind=question priority=high` row appears via
-  `curl -H "Authorization: Bearer $CLAWGATE_HOOK_TOKEN" http://192.168.50.250:30302/api/attention`
-  — and that it sorts **above** the `idle` rows. Entry fields are camelCase (`sessionId`), not
-  snake_case.
-- **Per host**, confirm the hook that will actually run:
-  `readlink -f "$(jq -r '.hooks.PermissionRequest[].hooks[].command' ~/.claude/settings.json | sed 's/^CLAUDE_HOST=[a-z]* //')"`
-  must terminate inside `homelab-talos`, and that file must contain `raise_attention_question`.
-- After any deploy: the pod is `Running` **and ready** — `kubectl -n clawgate get pods -l
-  app=clawgate` lists a `Succeeded` leftover too, so a `.items[0]` jsonpath reports the wrong image.
+
+**The attention feature's own proof is end-to-end, not a unit test:** trigger a real
+`AskUserQuestion`, then confirm a `kind=question priority=high` row appears via
+`curl -H "Authorization: Bearer $CLAWGATE_HOOK_TOKEN" http://192.168.50.250:30302/api/attention`
+— and that it sorts **above** the `idle` rows. Entry fields are camelCase (`sessionId`).
+
+**Per host, confirm the hook that will actually run:**
+```bash
+readlink -f "$(jq -r '.hooks.PermissionRequest[].hooks[].command' ~/.claude/settings.json | sed 's/^CLAUDE_HOST=[a-z]* //')"
+```
+must terminate inside `homelab-talos`, and that file must contain `raise_attention_question`.
 ## Run this first — the index, one read-only command
 ```bash
 python3 ~/workspace/devrc/scripts/lib/subsystem_recall.py --repo ~/workspace/devrc


### PR DESCRIPTION
Handoff update for the tmux-webapp work. Ranks **5, 6 and 7** are all done, deployed and verified live; clawgate is at **0.8.18**.

| rank | what | shipped |
|---|---|---|
| 5 | fail-closed terminal-write auth tier | `ZacxDev/homelab-infra#516` → 0.8.13 |
| 6 | persisted layout model + `clawgatectl view`/`panel` | `#527` → 0.8.16 |
| 7 | the layout grid UI | `#538` → 0.8.18 |

## Why this is a PR and not a push to main

`handoff_doc.py --push` was rejected by branch protection (`2 of 2 required status checks are expected`), leaving the commit local-only on `main` — the state `ship.sh` skips over silently. Recovered by the documented order: preserve on this topic branch → **verify it landed on origin** (`ls-remote` confirmed `662ae8fc`) → `reset --keep origin/main`. Nothing was lost and `main` is untouched.

## What the update carries

- **Status / Next steps / How to verify** rewritten for the new state. Ranks are **not renumbered** — they are half a `claim-work` slug's identity.
- **Open investigations** (append): `devrc#1056` is still held, and its blocker **changed** — the espanso `main`-red is now a gate `ERROR`, which per devrc's own CLAUDE.md means the gate stopped before a leg reported, not that the change is bad. Second entry: the layout tab has **never been exercised in a browser** — `clawgate-e2e` is green but runs 20 spec files and none touch layout.
- **Gotchas** (append): the vacuous-guard lesson (a positive control that confirmed the wrong property), INVALID mutants that read as passes, the `-run`-filter blind spot, the load-vs-lock misdiagnosis, the ambiguous-PR-number trap, and the image-built-during-review hazard that discarded 0.8.12 and 0.8.14.

🔴 **Durable content the merge tool flagged and I carried forward rather than dropping**: the scrollback hard bound (~4,014 B/line ⇒ 6.13 MB against a 4 MB cap) and the ~22%-of-panes-change-per-tick measurement, both of which constrain any future read-model work and lived only in a REPLACE section. Also moved the `clawgatectl`-is-built-from-a-local-tree gotcha and the `.items[0]`-reports-the-wrong-image gotcha into the APPEND section so a future status replace cannot drop them again.

## Not verified, and said so in the doc

No browser exercise of the layout tab; the nix sandbox tier was not run locally (Tekton is the first to see it); the 0.69/30.71 ms figures behind the DoS finding were measured once and never re-measured — the fix is pinned as a decode-count property instead, which is the stronger claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QLRabXW49ewAAdNyek251