### PR TITLE
feat(hooks): the handoff write guard — armed on a /resume READ, gating at Stop

### DIFF
--- a/claudedocs/handoff-write-guard-mutation-sweep.py
+++ b/claudedocs/handoff-write-guard-mutation-sweep.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Mutation sweep for handoff-write-guard.py -- the evidence behind this hook's
+"N/N killed" claim, committed rather than left in a scratchpad.
+
+Run it against a CLEAN worktree of the branch, never against the primary clone:
+
+    git worktree add --detach /tmp/hwg <ref>
+    HWG_TREE=/tmp/hwg python3 claudedocs/handoff-write-guard-mutation-sweep.py
+
+It EDITS the hook in place and restores it in a `finally`, so a tree with other
+uncommitted work in that file is not a safe place to run it.
+
+Each mutant must (a) go RED, and (b) go red on the SPECIFIC test named for it — a
+mutant that dies to a neighbour proves nothing about the guard it targets.
+
+PYTHONDONTWRITEBYTECODE=1 throughout: a same-length edit landing in the same whole
+second as the last import is invisible to CPython's mtime+size cache, and the mutant
+would be scored SURVIVED without ever executing.
+"""
+import os
+import subprocess
+import sys
+
+WT = os.environ.get("HWG_TREE", "/tmp/wt-hwg")
+HOOK = os.path.join(WT, "scripts/claude-hooks/handoff-write-guard.py")
+TEST = os.path.join(WT, "scripts/claude-hooks/tests/test_handoff_write_guard.py")
+
+# (label, old, new, the test that MUST fail)
+MUTANTS = [
+    ("wrote>= -> wrote>",
+     "if wrote_at is not None and wrote_at >= read_at:",
+     "if wrote_at is not None and wrote_at > read_at:",
+     "test_a_write_in_the_SAME_tool_call_as_the_read_satisfies"),
+    ("drop the mtime satisfaction route",
+     'if isinstance(doc, str) and doc and os.path.getmtime(doc) >= read_at:',
+     'if isinstance(doc, str) and doc and os.path.getmtime(doc) < read_at and False:',
+     "test_the_docs_own_mtime_satisfies_even_with_no_observation"),
+    ("mtime route ignores the anchor",
+     'if isinstance(doc, str) and doc and os.path.getmtime(doc) >= read_at:',
+     'if isinstance(doc, str) and doc and os.path.getmtime(doc) >= 0:',
+     "test_an_mtime_BEFORE_the_read_does_not_satisfy"),
+    ("drop the wrote satisfaction route",
+     "if wrote_at is not None and wrote_at >= read_at:",
+     "if wrote_at is not None and wrote_at >= read_at and False:",
+     "test_a_handoff_doc_py_run_satisfies"),
+    ("unreadable read stamp -> written instead of unknown",
+     '    if read_at is None:\n        # 🔴 CANNOT MEASURE',
+     '    if read_at is None:\n        return "written"\n        # 🔴 CANNOT MEASURE',
+     "test_an_unreadable_read_stamp_is_a_notice_and_never_blocks"),
+    ("drop the work gate at Stop",
+     "    if not work_happened(state_dir):",
+     "    if not work_happened(state_dir) and False:",
+     "test_read_with_no_work_is_silent_and_bumps_NOTHING"),
+    ("Stop stops refusing a subagent",
+     '    if d.get("agent_id"):\n        return ("silent", "")',
+     '    if d.get("agent_id") and False:\n        return ("silent", "")',
+     "test_these_stop_shaped_payloads_are_refused"),
+    ("Stop stops refusing SubagentStop",
+     '    if d.get("hook_event_name") not in (None, "Stop"):',
+     '    if d.get("hook_event_name") not in (None, "Stop", "SubagentStop"):',
+     "test_these_stop_shaped_payloads_are_refused"),
+    ("record_read stops consulting the tombstone",
+     "    if is_dismissed(state_dir, key):\n        return False",
+     "    if is_dismissed(state_dir, key) and False:\n        return False",
+     "test_dismiss_SURVIVES_a_later_read_of_the_same_doc"),
+    ("MAX_DOCS census removed",
+     'if len([n for n in os.listdir(state_dir) if n.startswith("read-")]) >= MAX_DOCS:',
+     'if len([n for n in os.listdir(state_dir) if n.startswith("read-")]) >= 99:',
+     "test_at_most_three_docs_are_tracked_per_session"),
+    ("record_read stops being idempotent",
+     "    if os.path.exists(path):\n        return False",
+     "    if os.path.exists(path) and False:\n        return False",
+     "test_a_re_read_never_moves_the_first_read_timestamp"),
+    ("arming drops the handoff-basename filter",
+     "        if not _is_handoff_basename(raw):\n            continue",
+     "        if not _is_handoff_basename(raw) and False:\n            continue",
+     "test_these_bash_commands_do_NOT_arm"),
+    ("arming drops the comment strip",
+     '        stripped = re.sub(COMMENT_PAT, " ", cmd)',
+     '        stripped = cmd',
+     "test_a_path_after_a_hash_is_a_comment_not_a_read"),
+    ("arming resolves without requiring the directory",
+     "        if os.path.isdir(os.path.dirname(c)):\n            return c",
+     "        if True:\n            return c",
+     "test_a_path_whose_directory_does_not_exist_does_NOT_arm"),
+    ("Read arm loses cwd as a base",
+     '        bases = _bases("", d.get("cwd"))',
+     '        bases = []',
+     "test_a_RELATIVE_Read_path_resolves_against_cwd"),
+    ("arming ignores -C and uses cwd only",
+     "    out = []\n    for m in DASH_C_RX.finditer(cmd or \"\"):",
+     "    out = []\n    for m in DASH_C_RX.finditer(\"\"):",
+     "test_a_git_show_off_a_ref_arms_and_resolves_through_the_dash_C"),
+    ("arming admits a Write as a read",
+     '    if tool == "Read":',
+     '    if tool in ("Read", "Write", "Edit"):',
+     "test_a_WRITE_of_a_handoff_doc_does_NOT_arm"),
+    ("arming accepts a subagent's read",
+     "    docs = [] if agent else handoff_read_docs(data)",
+     "    docs = handoff_read_docs(data)",
+     "test_a_subagents_read_does_NOT_arm_the_parent"),
+    ("subagent handoff WRITE stops satisfying the parent",
+     "    if is_handoff_write(data):",
+     "    if is_handoff_write(data) and not agent:",
+     "test_a_subagents_handoff_WRITE_also_counts"),
+    ("subagent work stops counting",
+     "    if is_work(data):",
+     "    if is_work(data) and not agent:",
+     "test_a_subagents_WORK_does_count_once_the_parent_has_read"),
+    ("ladder: one more block",
+     "MAX_BLOCKS = 2",
+     "MAX_BLOCKS = 3",
+     "test_the_ladder_moves_block_block_notice_silent"),
+    ("ladder: never relents",
+     "MAX_FIRES = 3",
+     "MAX_FIRES = 99",
+     "test_the_ladder_moves_block_block_notice_silent"),
+    ("unknown spends the BLOCK budget",
+     'if escalate(bump_fires(state_dir, key, "unknown")) != "silent":',
+     'if escalate(bump_fires(state_dir, key)) != "silent":',
+     "test_an_unreadable_read_stamp_is_a_notice_and_never_blocks"),
+    ("notice becomes additionalContext (the channel that does NOT relent)",
+     '    elif kind == "notice":\n        json.dump({"systemMessage": text}, sys.stdout)',
+     '    elif kind == "notice":\n        json.dump({"hookSpecificOutput": {"additionalContext": text}}, sys.stdout)',
+     "test_a_notice_alone_never_forces_a_continuation"),
+    ("the doc key becomes the full path",
+     '    return _sanitize(os.path.basename(doc_path))',
+     '    return _sanitize(str(doc_path))',
+     "test_the_key_is_the_basename_so_one_doc_read_three_ways_books_one_slot"),
+    ("dismiss stops writing the tombstone",
+     "    write_dismissal_tombstone(state_dir, key, doc=doc, now=now)",
+     "    pass",
+     "test_dismiss_SURVIVES_a_later_read_of_the_same_doc"),
+    ("the fast path is taken AFTER the work write",
+     "    if not tracked and not docs:",
+     "    if False:",
+     "test_the_fast_path_does_exactly_one_stat_and_nothing_else"),
+    ("state root shared with the precedent",
+     '"claude-handoff-write", "s")',
+     '"claude-clawgate-writeback", "s")',
+     "test_the_handoff_guards_cache_root_is_its_OWN"),
+]
+
+# POSITIVE CONTROL: a mutant that must be caught, proving the harness can go red at all.
+CONTROL = ("POSITIVE CONTROL: emit() never writes",
+           '    if kind == "block":',
+           '    if False:',
+           "test_the_real_process_blocks_end_to_end")
+
+ONDISK = os.path.join(WT, "scripts/claude-hooks/tests/test_on_disk_artifact_names.py")
+
+
+def run(target_test, extra_file=None):
+    env = dict(os.environ, PYTHONDONTWRITEBYTECODE="1")
+    files = [TEST] + ([extra_file] if extra_file else [])
+    p = subprocess.run([sys.executable, "-m", "pytest", *files,
+                        "-q", "-p", "no:cacheprovider", "--no-header", "-x",
+                        "-k", target_test.split("[")[0]],
+                       cwd=WT, capture_output=True, text=True, env=env, timeout=600)
+    return p
+
+
+def main():
+    original = open(HOOK).read()
+    results = []
+    for label, old, new, test in [CONTROL] + MUTANTS:
+        if old not in original:
+            results.append((label, "PATTERN-NOT-FOUND", ""))
+            continue
+        if original.count(old) != 1:
+            results.append((label, "PATTERN-AMBIGUOUS(%d)" % original.count(old), ""))
+            continue
+        extra = ONDISK if "cache_root_is_its_OWN" in test else None
+        try:
+            open(HOOK, "w").write(original.replace(old, new, 1))
+            p = run(test, extra)
+            # Count the runner's OWN result lines rather than reading an exit code.
+            tail = [ln for ln in p.stdout.splitlines() if " failed" in ln or " passed" in ln]
+            killed = "failed" in (tail[-1] if tail else "")
+            named = test in p.stdout
+            results.append((label, "KILLED" if killed else "SURVIVED",
+                            "%s | named=%s" % (tail[-1] if tail else "NO SUMMARY", named)))
+        finally:
+            open(HOOK, "w").write(original)
+    for label, verdict, detail in results:
+        print("%-9s %-62s %s" % (verdict, label, detail))
+    bad = [r for r in results if r[1] != "KILLED"]
+    print("\n%d/%d killed" % (len(results) - len(bad), len(results)))
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1417,6 +1417,34 @@ in
   home.file.".claude/hooks/clawgate-writeback-guard.py" = {
     source = ../scripts/claude-hooks/clawgate-writeback-guard.py;
   };
+  # 🔴 THE HANDOFF WRITE GUARD — the write-back guard's counterpart on the OTHER
+  # record. That one makes a clawgate pickup report back to the board; this one makes
+  # a session that RESUMED a handoff doc write one before it stops.
+  #
+  # PostToolUse (NO matcher, same reason as its neighbour) watches for a READ of a
+  # specific handoff doc — a `Read` of `claudedocs/handoff-*.md`, or the `git show
+  # <ref>:claudedocs/…` form these repos use for a doc on an unmerged branch — and for
+  # REAL WORK after it. Stop then measures whether ANY handoff was written since that
+  # read: a `handoff_doc.py` run, a Write/Edit of a handoff doc, or the resumed doc's
+  # own mtime. Three routes unioned, so it self-suppresses however the doc got written
+  # — including under a different topic, which the measurement counts as recorded.
+  #
+  # 🔴 ARMED ON THE READ, NOT ON SessionStart, and that is the design: arming at
+  # session start would fire on every session that never touched a handoff. Measured
+  # over 253 `/resume` sessions (2026-08-15..08-29): 22 (8.7%) never recorded their
+  # work, ZERO of them because the write gate correctly declined, and the dominant
+  # loss bucket is a session that ENDED CLEANLY — 8 of 16 — with a Stop hook already
+  # firing in 8 of 8 of them. `claudedocs/handoff-skill-chain-usage-audit.md`.
+  #
+  # Escalates block, block, notice, silence per doc per session, never blocks when it
+  # could not measure (it says so instead), and every error path exits 0. Unlike its
+  # neighbour it spawns NO subprocess on any path.
+  #
+  # 🔴 A NEW file, so it must be `git add`ed or the flake silently omits it and the
+  # switch still succeeds with the hook absent — this repo's standing trap.
+  home.file.".claude/hooks/handoff-write-guard.py" = {
+    source = ../scripts/claude-hooks/handoff-write-guard.py;
+  };
   # 🔴 THE CLAWGATE TASK INTERVIEW GATE — the write-back guard's counterpart at the
   # OTHER end of a task's life. That one makes a pickup report back; this one makes
   # a CREATE say what "done" means.

--- a/scripts/claude-hooks/handoff-write-guard.py
+++ b/scripts/claude-hooks/handoff-write-guard.py
@@ -107,6 +107,15 @@ from a measured ladder without a measurement of my own would be speculation. The
 per-doc budget is the same, but MAX_DOCS is 3 rather than 5, so the worst case a
 session can reach is strictly cheaper than the guard this is modelled on.
 
+MULTI-TURN COST, STATED RATHER THAN DISCOVERED IN PRODUCTION. Work that spans several
+turns fires once per turn until the per-doc ladder is spent: at most TWO forced
+continuations and one `systemMessage`, then silence forever for that doc in that
+session. Because the anchor is the READ and not the last work event, a handoff written
+at ANY point after the read ends it permanently — so the ordinary shape is exactly one
+block, the model writes the doc, and the guard never speaks again. The shape that
+costs the full ladder is a session that is told to write a handoff, declines twice,
+and stops; that is the shape this exists for.
+
 🔴 `additionalContext` IS NOT A NON-BLOCKING CHANNEL ON Stop. The CLI pushes it into
 the SAME `blockingErrors` array as `decision:"block"`, so emitting it would force a
 continuation while claiming not to; `systemMessage` is yielded on the message channel

--- a/scripts/claude-hooks/handoff-write-guard.py
+++ b/scripts/claude-hooks/handoff-write-guard.py
@@ -1,0 +1,1150 @@
+#!/usr/bin/env python3
+"""Make the handoff write NON-OPTIONAL for a session that resumed one: PostToolUse
+watches, Stop gates.
+
+WHY THIS EXISTS — MEASURED OVER 253 SESSIONS, AND THE LOSS BUCKET IS THIS MOMENT
+--------------------------------------------------------------------------------
+`claudedocs/handoff-skill-chain-usage-audit.md` measured the `/handoff` -> `/resume`
+chain over 2026-08-15..08-29, both hosts, both runtimes: of **253** graded sessions
+whose genesis was a `/resume` kickoff, **231 (91.3%) recorded** their work and
+**22 (8.7%) did not**. Legitimate declines (`no-change`/`no-advance`) were **ZERO**,
+so the gap is not the write gate correctly refusing — it is the write never being
+attempted: **19 of the 22 never invoked `handoff_doc.py` at all.**
+
+Rank 1 of that arc then split the 16 readable never-run losses by how the session
+ENDED, and the split is what selects this remedy over an auto-draft:
+
+    D cleanly-ended        8   50.0%   <- the dominant bucket
+    B interrupted-at-end   4   25.0%
+    A context-exhausted    2   12.5%
+    0 never-started        2   12.5%   (zero assistant turns)
+
+The losses end CLEANLY, 8-vs-2 against exhaustion. A session that runs out of context
+needs an auto-draft-before-compaction and would be reached by 2 of 16; a session that
+finishes its work and stops needs a NUDGE AT THE MOMENT IT STOPS, and that is a `Stop`
+hook. 🔴 The decisive number: `stop_hook_summary` rows are present in **8 of 8**
+cleanly-ended losers (13 of 16 overall) — so the hook infrastructure demonstrably
+EXECUTES in 100% of the bucket this is built for. It is not merely warranted, it is
+mechanically reachable exactly where the handoff is being lost.
+
+Prose already lost here, the same way it did for the clawgate write-back. `/handoff`
+exists, `/resume` step 6 points at it, and 19 sessions still never ran it.
+PRINCIPLES.md prefers a deterministic/structural fix over prompt-tuning; this is that
+fix, and `clawgate-writeback-guard.py` is its measured precedent — same arm-on-read /
+gate-on-Stop shape, 86% write-back compliance on the board it guards.
+
+🔴 ARMED ON A `/resume` **READ**, NOT ON SESSION START
+------------------------------------------------------
+Arming on `SessionStart` would fire on every session that never touched a handoff —
+most of them — and a guard that nags the majority to write a document they have no
+business writing is worse than no guard. The act that defines the measured population
+is the READ of a specific handoff doc, so that is what arms this hook:
+
+    Read(file_path=".../claudedocs/handoff-<topic>.md")     # /resume step 3
+    Bash: git show <ref>:claudedocs/handoff-<topic>.md      # the same read, off a ref
+    Bash: cat/head/less .../claudedocs/handoff-<topic>.md
+
+Same reasoning as the precedent's: gate on the act that PROVABLY happened in the
+losing sessions, not on the act you wish had.
+
+WHAT FIRES IT — THREE CONDITIONS, ALL REQUIRED
+-----------------------------------------------
+  1. the session READ a specific handoff doc (above), and
+  2. REAL WORK happened in the session — an Edit/Write/NotebookEdit tool call, or a
+     Bash `git commit` / `git push` / `gh pr create|merge` / `gh release create`
+     **in command position, outside quotes and comments** (see WORK_BASH_PAT), and
+  3. NO handoff write is observable since that doc's first read — neither an
+     invocation of `handoff_doc.py`, nor a Write/Edit of any handoff doc, nor an
+     mtime on the resumed doc itself at or after the read.
+
+Condition 2 is the false-positive killer and it is not optional. A session that
+resumes a doc, reconciles it, reports "nothing has moved" and stops owes the record
+NOTHING — and the measurement agrees: `no-change`/`no-advance` declines were counted
+as legitimate and were zero, i.e. the skill's own gate already handles that case.
+Nothing here fires on a read alone.
+
+Condition 3 is a MEASUREMENT of the filesystem plus this session's own observations,
+never an inference from one alone. It is what makes the hook self-suppressing: the
+moment a handoff is written the guard goes quiet, including for a doc written by
+`/handoff` in a throwaway worktree, by a different process, or under a different
+topic entirely.
+
+🔴 TOPIC DRIFT COUNTS AS RECORDED, DELIBERATELY. 25 of the 253 sessions resumed doc X
+and wrote doc Y (`clawgate-usage-audit` -> `clawgatectl-agent-delivery`). The
+measurement scored those RECORDED — the work IS on disk and committed, scope
+legitimately moves — so this guard must too, or it would block 25 sessions that did
+exactly the right thing. That is why the `handoff_doc.py` / handoff-doc-write
+observations are SESSION-level and path-agnostic, while only the mtime route is
+per-doc. (What drift genuinely costs — doc X left looking maintained while going
+stale — is rank 3 of that arc, and is NOT this hook's job.)
+
+🔴 THE COMPARISON ANCHOR IS THE **FIRST READ** OF EACH DOC, NOT THE LAST WORK EVENT —
+AND THAT IS THE ONE PLACE THIS DELIBERATELY DIVERGES FROM ITS PRECEDENT. The clawgate
+guard must anchor on the last work event because its skill's pickup ritual posts a
+"Starting" comment BEFORE the work, which would satisfy a read-anchored check at
+pickup and make a missing COMPLETION write-back unobservable. There is no pre-work
+handoff ritual: `/handoff` runs at the END of a session, so a read anchor has no such
+degenerate case — and a work anchor would import a false-positive class this one does
+not have. The shape that class produces is routine here:
+
+    write the doc (mtime T) -> `git -C $WT commit` -> `git push` (work at T+90s) -> Stop
+
+Anchored on the last work event that owes another handoff write; anchored on the read
+it is satisfied, correctly. The cost of the read anchor is named rather than hidden:
+a session that writes its handoff EARLY and then works for hours without updating it
+is scored as recorded. That is the same thing the measurement scored, and it is a
+much rarer and milder shape than blocking every session that commits after writing.
+
+ESCALATION LADDER — per session, per doc
+-----------------------------------------
+    fire 1  ->  decision: block      (FORCED CONTINUATION; `reason` reaches the model)
+    fire 2  ->  decision: block      (FORCED CONTINUATION)
+    fire 3  ->  systemMessage        (the turn ENDS; operator sees it, model does not)
+    fire 4+ ->  silent
+
+Identical rungs to the precedent, which is measured at 86% compliance — deviating
+from a measured ladder without a measurement of my own would be speculation. The
+per-doc budget is the same, but MAX_DOCS is 3 rather than 5, so the worst case a
+session can reach is strictly cheaper than the guard this is modelled on.
+
+🔴 `additionalContext` IS NOT A NON-BLOCKING CHANNEL ON Stop. The CLI pushes it into
+the SAME `blockingErrors` array as `decision:"block"`, so emitting it would force a
+continuation while claiming not to; `systemMessage` is yielded on the message channel
+and is not fed back to the model. That is a re-derivation from the installed bundle,
+not from documentation — the full reads, both controls, and the
+`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` interaction are in `clawgate-writeback-guard.py`'s
+module docstring, which is the ONE place they are recorded. `emit()` below has
+exactly the two channels that docstring proves are distinct, and no third.
+
+🔴 THERE IS DELIBERATELY NO `stop_hook_active` GATE, for the precedent's reason: the
+SECOND block is the whole point — it is what catches a turn that acknowledged the
+first block and stopped anyway — and the ladder bounds the loop at 2 per doc, far
+inside the CLI's own cap of 8.
+
+🔴 THE SUBAGENT RULE IS ASYMMETRIC, and both halves are inherited from a measurement,
+not invented here. A subagent's tool call arrives wearing the PARENT's `session_id`
+with only `agent_id` to tell them apart:
+  * a subagent's READ must NOT arm the parent — the precedent measured that as a
+    false positive, a parent blocked on something only a subagent touched;
+  * a subagent's WORK IS the session's work — the parent dispatched it, the parent
+    owns the record. Refusing it deleted the precedent's yield on the exact incident
+    it existed for.
+Stop carrying an `agent_id`, and SubagentStop, are refused outright: a subagent's turn
+never reaches the operator, so it owes them nothing.
+
+🔴 FAIL-OPEN, ALWAYS. Every internal exception exits 0 with empty stdout and blocks
+nothing. `main()` has exactly ONE exit and it is always 0. A hook that wedges a turn
+to enforce a bookkeeping ritual has inverted its own cost model.
+
+🔴 HOT PATH. PostToolUse fires after EVERY tool call of every session. The fast path
+is: one dict read for `agent_id`, resolve the state dir from `session_id` (string
+work, no IO), ONE `os.path.exists`, and — for a main-thread call only — the arming
+regex. A session that has never read a handoff doc and is not reading one now does
+nothing else: no directory creation, no state read, no subprocess, and it does not
+import `shutil` (see the deferred-import note). Unlike its precedent this hook spawns
+NO subprocess on ANY path, Stop included: condition 3 is filesystem-only.
+
+WHAT THIS STRUCTURALLY CANNOT SEE (say it here, not in a report nobody re-reads):
+  * the 2 never-started sessions of the 16. They produced zero assistant turns, so no
+    Stop fired and no hook of any kind could have reached them. Named because it
+    bounds the ceiling: this remedy addresses at most 14 of 16, not 16;
+  * the 4 interrupted-at-end sessions in the general case — 3 of 4 did fire a Stop
+    hook, so most are reachable, but an interrupt that kills the process is not;
+  * a read performed only inside a subagent (the read half refuses `agent_id`);
+  * a read via a route the arming regex does not match — a `Grep`/`Glob` result the
+    model read off screen, an editor, someone pasting the body in;
+  * WHICH doc a given write belongs to. Two of the three satisfaction routes are
+    session-level by construction, because drift must count (see above). The
+    consequence is stated rather than hidden: `read X -> read Y -> write only Y`
+    is SILENT for X. That is the deliberate side of the trade;
+  * whether the handoff that WAS written is any good — it checks that one exists
+    since the read, never what it says. `/handoff`'s own write gate owns quality;
+  * a handoff doc whose directory does not exist on this host. Arming requires the
+    resolved `claudedocs/` directory to be real, so a path that resolves nowhere is
+    not armed at all — the quiet direction;
+  * anything on a host where this hook is not deployed, or a runtime that is not
+    Claude Code. The measurement covered opencode too; this covers Claude Code only.
+
+Deployed by `nix/home.nix`; registered on PostToolUse (no matcher) + Stop by
+`register-nudge-hook.py`. It has ONE other mode, and it is not a hook mode:
+
+    handoff-write-guard.py --dismiss <doc-key> --session <session_id>
+
+Every invocation of that mode appends one JSON line to
+`~/.cache/claude-handoff-write/dismissals` — it is a bypass of a deterministic guard,
+so it is MEASURABLE rather than merely discouraged in the block text.
+"""
+import datetime
+import json
+import os
+import re
+import sys
+import time
+
+# 🔴 DEFERRED IMPORT, AND THE REASON IS THE HOT PATH — the same reasoning
+# `clawgate-writeback-guard.py` records and measured (`shutil` alone was 3.7 ms of
+# that hook's per-call cost). `shutil` is reachable ONLY from `prune`'s removal
+# branch, i.e. only on a Stop that has something stale to sweep. `re` and `json` stay
+# at the top: the arming pattern is consulted before the fast-path return and the
+# payload is JSON on stdin, so both are on a path that cannot avoid them.
+#
+# 🔴 This hook imports NO `subprocess` at all, on any path. Its precedent needs one
+# because its condition 3 is a live read of a remote board; condition 3 here is a
+# stat and two file reads, so there is nothing to spawn.
+shutil = None
+
+
+def _sh():
+    """`shutil`, imported on first use. Bound to the MODULE attribute so a test can
+    monkeypatch `guard.shutil` once the Stop path has touched it.
+
+    No `if shutil is None` memo guard: `import` IS the memo (every call after the
+    first is a `sys.modules` lookup), and a guard whose only effect is skipping that
+    lookup is a branch no mutation can kill.
+    """
+    global shutil
+    import shutil as _m
+    shutil = _m
+    return shutil
+
+
+# --------------------------------------------------------------------------- #
+# Tunables
+# --------------------------------------------------------------------------- #
+
+# 🔴 THE LADDER. Two forced continuations per doc, then one operator-facing notice,
+# then silence forever for that doc in that session. Both numbers are the precedent's,
+# which is measured at 86% compliance; the CLI's own consecutive-block cap is 8, so
+# this stays far inside a ceiling that would otherwise end the turn with a warning.
+MAX_BLOCKS = 2
+MAX_FIRES = 3
+
+# 🔴 Enforced at the WRITER (`record_read`), so `tracked_docs` structurally cannot
+# return a fourth. Three rather than the precedent's five because a session normally
+# resumes ONE handoff: the extra slots exist for the `/resume` shapes that legitimately
+# read two (a doc plus the doc it drifted to), not to track a survey.
+MAX_DOCS = 3
+
+# Session state older than this is swept at Stop. Two weeks: long enough that a
+# session resumed after a weekend still has its ledger, short enough that the cache
+# cannot grow without bound.
+STATE_TTL_SECS = 14 * 24 * 3600
+
+# The write path `/handoff` step 5 drives. Named here so the block text and the
+# observation agree on one string.
+HANDOFF_TOOL = "scripts/lib/handoff_doc.py"
+
+# --------------------------------------------------------------------------- #
+# Triggers
+#
+# 🔴 BOTH DIRECTIONS MATTER. This must match a read of a SPECIFIC handoff doc and
+# must NOT match the ways a session merely talks about handoffs. `ls claudedocs/`,
+# `grep -rn 'handoff' claudedocs/` and a bare `claudedocs/` all lack the `.md`
+# basename, so none of them arms anything — the pattern requires `claudedocs/` and a
+# handoff-shaped `.md` basename in ONE contiguous run of path characters.
+# --------------------------------------------------------------------------- #
+
+# A run of path characters containing `claudedocs/` and ending in `.md`.
+#
+# 🔴 `:` IS NOT IN THE CHARACTER CLASS, AND THAT IS LOAD-BEARING RATHER THAN
+# INCIDENTAL. `git show origin/zach/topic:claudedocs/handoff-x.md` is the canonical way
+# to read a handoff that lives on an unmerged branch — this repo's own CLAUDE.md
+# prescribes it — and excluding `:` makes the match start cleanly at `claudedocs/`
+# instead of swallowing the ref. The remaining leading run is what carries a `-C`-less
+# absolute or `~`-prefixed path.
+HANDOFF_PATH_RX = re.compile(r"[A-Za-z0-9_.~@%+/-]*claudedocs/[A-Za-z0-9_.%+-]+\.md")
+
+# 🔴 TWO BASENAME SHAPES, because `/resume` resolves in exactly this order and the
+# second one is a real repo's real handoff: `claudedocs/handoff-*.md` first, then
+# `claudedocs/*HANDOFF*.md` (civitai-manager names its doc `SESSION-HANDOFF.md`).
+# A skill that resolves two shapes and a guard that arms on one would be silent for
+# whichever repo uses the other.
+HANDOFF_BASENAME_RX = re.compile(r"(?:^handoff-.*\.md$)|(?:^.*HANDOFF.*\.md$)")
+
+# `python3 …/handoff_doc.py` — the write `/handoff` step 5 performs. Anchored on the
+# interpreter so a `grep handoff_doc.py` or a doc mentioning the filename is not
+# mistaken for a run of it.
+HANDOFF_RUN_RX = re.compile(r"\bpython3?(?:\.\d+)?\s+(?:-\S+\s+)*\S*handoff_doc\.py\b")
+
+# `git -C <dir>` / `git -C<dir>`, used ONLY to widen the set of base directories a
+# relative match is resolved against. Never used to decide anything.
+DASH_C_RX = re.compile(r"(?:^|\s)-C\s*(\S+)")
+
+# Tool calls that ARE work, by name. Also the tools whose `file_path` can SATISFY,
+# when it names a handoff doc.
+WORK_TOOLS = ("Edit", "Write", "NotebookEdit")
+
+# The payload keys a file-taking tool uses. `NotebookEdit` uses `notebook_path`.
+PATH_KEYS = ("file_path", "notebook_path")
+
+# 🔴 THIS BLOCK IS A VERBATIM COPY OF `clawgate-writeback-guard.py`'s WORK DETECTION,
+# AND THE DUPLICATION IS DELIBERATE, DECLARED, AND PINNED BY A TEST RATHER THAN BY
+# THIS COMMENT. `claude/RULES.md` says one rule, one place — so the alternative was
+# considered and rejected on measured grounds: extracting it into a shared hook
+# module would add an import to the OTHER hook's fast path, which fires after every
+# tool call of every session and whose owners measured its cost to ~0.1 ms across
+# several audit rounds. Paying a regression on a BLOCKING hook that is not in this
+# change's scope, to de-duplicate two constants, is the wrong trade.
+#
+# What replaces the shared module is an ASSERTED LEDGER: the pair of files is pinned
+# byte-for-byte on these three patterns by
+# `tests/test_handoff_write_guard.py::test_the_work_detection_is_byte_identical_to_the_precedent`,
+# which fails when EITHER copy moves. So the copies cannot drift silently, which is
+# the failure mode the rule is actually about. If a third copy is ever wanted, extract
+# then — three call sites is where the import cost stops being the dominant term.
+#
+# The reasoning the patterns encode, in one line each (the full measurements are in
+# the precedent): quoted runs and trailing comments are stripped FIRST, so a command
+# that MENTIONS `git commit` is not one that RUNS it; the verb must be in COMMAND
+# POSITION; a quoted run becomes a one-character TOKEN rather than whitespace, because
+# blanking it let `git -C "$DEVRC" commit` read the subcommand as the flag's value —
+# and `git -C <path>` is the form these repos mandate.
+#
+# Pattern STRINGS, not compiled objects, for the precedent's measured reason: none of
+# them is reachable from the fast path, and compiling them at import made every tool
+# call in every session pay for regexes almost none of them use.
+_CMD_START = r"(?:^|[\n;&|(){}`]|\$\()\s*(?:(?:then|else|do|!)\s+)*"
+WORK_BASH_PAT = (
+    _CMD_START
+    + r"git\s+(?:-[A-Za-z]\s+\S+\s+|--[A-Za-z][-\w]*(?:=\S+)?\s+)*(?:commit|push)\b"
+    r"|" + _CMD_START
+    + r"gh\s+(?:pr\s+(?:create|merge)|release\s+create)\b")
+QUOTED_PLACEHOLDER = "''"
+QUOTED_PAT = r"'[^']*'|\"(?:[^\"\\]|\\.)*\""
+COMMENT_PAT = r"(?:^|(?<=\s))#[^\n]*"
+
+# State file names. `work` is a session-level stamp; `wrote` is the session-level
+# record of a handoff write. 🔴 Their prefixes are deliberately disjoint from `read-`,
+# `fires-`, `unknown-` and `dismissed-`: `tracked_docs` selects on `read-` and
+# `record_read`'s MAX_DOCS census counts only those, so no other artifact can be
+# mistaken for a tracked doc or consume a tracking slot.
+STATE_WORK = "work"
+STATE_WROTE = "wrote"
+DISMISSED_PREFIX = "dismissed-"
+
+
+# --------------------------------------------------------------------------- #
+# Session-scoped state
+# --------------------------------------------------------------------------- #
+def _state_root():
+    """HOME read at CALL time, not import time, so a test can point it somewhere safe."""
+    return os.path.join(os.path.expanduser("~"), ".cache",
+                        "claude-handoff-write", "s")
+
+
+def _sanitize(part):
+    """One path component, made safe to join onto the state root.
+
+    🔴 THE ALLOWED SET INCLUDES `.`, SO IT MUST EXCLUDE THE ALL-DOTS COMPONENTS. `/` is
+    already replaced, which leaves exactly `.`, `..`, `...` … as the strings that can
+    traverse: a `--dismiss ..` would otherwise resolve to the state ROOT rather than to
+    a file inside a session dir. An enumerated fix, not a pattern: a component that is
+    nothing but dots is neutered; `handoff-x.md` and `v1.2.3` are untouched. Copied
+    from the precedent, where the same defect was found and fixed.
+    """
+    out = re.sub(r"[^A-Za-z0-9_.-]", "_", str(part))[:120]
+    if out and set(out) <= {"."}:
+        out = "_" * len(out)
+    return out
+
+
+def _state_dir(data):
+    session = (data or {}).get("session_id")
+    if not isinstance(session, str) or not session:
+        return None
+    return os.path.join(_state_root(), _sanitize(session))
+
+
+def doc_key(doc_path):
+    """The per-doc ledger key: the sanitized BASENAME.
+
+    Basename rather than the full path, deliberately. The same handoff doc is reached
+    through several spellings in one session — the base clone's copy, the throwaway
+    worktree copy that `/handoff` actually writes, a `..`-bearing relative resolution
+    — and keying on the spelling would book an entry per spelling, spend every one of
+    the MAX_DOCS slots, and emit a block per spelling naming the same file. The
+    resolved path is stored INSIDE the record, so nothing is lost.
+
+    🔴 THE COST, NAMED: two different repos each holding a `handoff-<same-topic>.md`
+    collide onto one ledger entry, so the second read is a no-op and only the first
+    doc's path is reported. It errs toward FEWER blocks, which is the quiet direction,
+    and the alternative — keying on the full path — was measured to be worse in the
+    common case rather than the rare one.
+    """
+    return _sanitize(os.path.basename(doc_path))
+
+
+def _read_path(state_dir, key):
+    return os.path.join(state_dir, "read-%s" % key)
+
+
+def _read_tmp_name(key):
+    """`record_read`'s temp file, deliberately OUTSIDE the `read-` namespace.
+
+    🔴 The precedent shipped this as `read-<id>.tmp` and it was wrong: a temp file that
+    outlived its `os.replace` — the CLI kills a hook on its timeout, a
+    `home-manager switch` swaps the file mid-run — was parsed by the reader as a
+    genuine tracked entry, so the Stop gate demanded a write-back for a read that was
+    never committed, and the census counted it. The leading `.` is what does the work;
+    keep any future scheme out of `read-`/`fires-`/`unknown-`/`dismissed-` too.
+    """
+    return ".tmp-read-%s" % key
+
+
+def _dismissed_path(state_dir, key):
+    return os.path.join(state_dir, "%s%s" % (DISMISSED_PREFIX, key))
+
+
+def is_dismissed(state_dir, key):
+    """Has `--dismiss` been run for THIS doc in THIS session?
+
+    EXISTENCE is the entire signal; the contents are documentation for a human reading
+    the cache by hand. A truncated tombstone still silences — the fail-QUIET direction,
+    and the right one: the operator asserted out loud that this session owes no
+    handoff, so a half-written file must not resurrect the nagging.
+    """
+    return os.path.exists(_dismissed_path(state_dir, key))
+
+
+def write_dismissal_tombstone(state_dir, key, doc="", now=None):
+    """Record that this session dismissed this doc. Best-effort; the return value is
+    NOT what `dismiss_main` reports on — that re-measures the disk.
+
+    `makedirs` matches every other writer here: a PRE-EMPTIVE dismissal — "this
+    session's work is not a handoff", said before any read — still has to mean
+    something.
+    """
+    try:
+        os.makedirs(state_dir, exist_ok=True)
+        with open(_dismissed_path(state_dir, key), "w") as fh:
+            json.dump({"doc": str(doc), "dismissed_ts": now_iso(now)}, fh)
+        return True
+    except Exception:                     # noqa: BLE001
+        return False
+
+
+def _fires_path(state_dir, key, kind="fires"):
+    """`fires-<key>` for a MEASURED missing handoff, `unknown-<key>` for a
+    could-not-measure notice. 🔴 Two counters, deliberately — the precedent's lesson:
+    sharing one let an unmeasurable early Stop spend the block budget that a genuinely
+    missing write needs later, so the case the hook exists for could no longer be
+    blocked in that session."""
+    return os.path.join(state_dir, "%s-%s" % (kind, key))
+
+
+def now_iso(now=None):
+    ts = datetime.datetime.fromtimestamp(
+        time.time() if now is None else now, datetime.timezone.utc)
+    return ts.isoformat().replace("+00:00", "Z")
+
+
+def parse_ts(s):
+    """RFC3339 -> epoch seconds, or None."""
+    if not isinstance(s, str) or not s.strip():
+        return None
+    t = s.strip()
+    if t.endswith("Z") or t.endswith("z"):
+        t = t[:-1] + "+00:00"
+    try:
+        dt = datetime.datetime.fromisoformat(t)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    return dt.timestamp()
+
+
+def tracked_docs(state_dir):
+    """{key: {"doc": <abs path>, "first_read_ts": <rfc3339>}} for docs this session
+    has read. A record missing either field is skipped rather than defaulted: a
+    truncated write must not produce a verdict about a document nobody can name."""
+    out = {}
+    try:
+        names = os.listdir(state_dir)
+    except Exception:
+        return out
+    for name in sorted(names):
+        if not name.startswith("read-"):
+            continue
+        try:
+            with open(os.path.join(state_dir, name)) as fh:
+                rec = json.load(fh)
+            doc = rec["doc"]
+            ts = rec["first_read_ts"]
+        except Exception:
+            continue
+        if isinstance(doc, str) and doc and isinstance(ts, str) and ts:
+            out[name[len("read-"):]] = {"doc": doc, "first_read_ts": ts}
+    return out
+
+
+def record_read(state_dir, doc_path, now=None):
+    """Record the FIRST read of `doc_path`. Idempotent: a later read never moves the
+    timestamp, because the window this hook measures over starts at the first one."""
+    key = doc_key(doc_path)
+    path = _read_path(state_dir, key)
+    # ONE existence check. A second copy after `makedirs` would be provably redundant —
+    # `makedirs(exist_ok=True)` can neither create nor delete THIS file — so neither
+    # copy could be killed by a mutation. The cheap one is kept, so a re-read of an
+    # already-recorded doc still costs no `makedirs`.
+    if os.path.exists(path):
+        return False
+    # 🔴 THE DISMISSAL TOMBSTONE IS CONSULTED HERE, AT THE WRITER, AND NOWHERE ELSE.
+    # The precedent measured, in production and twice, that clearing the ledger without
+    # a tombstone does not dismiss anything: it restores the session to its pre-read
+    # state, so the very next read re-arms the guard — and the natural way to confirm a
+    # dismissal took is to LOOK AT THE DOC, which is a read. 90 ms apart, in the same
+    # tool call. AFTER the `exists` above, so a re-read of an already-tracked doc still
+    # costs one stat.
+    if is_dismissed(state_dir, key):
+        return False
+    os.makedirs(state_dir, exist_ok=True)
+    if len([n for n in os.listdir(state_dir) if n.startswith("read-")]) >= MAX_DOCS:
+        return False
+    tmp = os.path.join(state_dir, _read_tmp_name(key))
+    with open(tmp, "w") as fh:
+        json.dump({"doc": doc_path, "first_read_ts": now_iso(now)}, fh)
+    os.replace(tmp, path)
+    return True
+
+
+def record_work(state_dir, now=None):
+    """Stamp that REAL WORK happened. Session-level by construction — nothing in a
+    PostToolUse payload says which doc an edit belongs to."""
+    os.makedirs(state_dir, exist_ok=True)
+    with open(os.path.join(state_dir, STATE_WORK), "w") as fh:
+        fh.write(now_iso(now))
+
+
+def record_wrote(state_dir, now=None):
+    """Stamp that a HANDOFF WRITE was observed — a `handoff_doc.py` run, or a
+    Write/Edit whose target is a handoff doc.
+
+    🔴 SESSION-LEVEL AND PATH-AGNOSTIC ON PURPOSE, and this is the topic-drift
+    accommodation made mechanical: 25 of the 253 measured sessions resumed doc X and
+    wrote doc Y, and the measurement scored every one of them RECORDED. Keying this
+    stamp to a path would block those 25 for doing exactly the right thing.
+    """
+    os.makedirs(state_dir, exist_ok=True)
+    with open(os.path.join(state_dir, STATE_WROTE), "w") as fh:
+        fh.write(now_iso(now))
+
+
+def work_happened(state_dir):
+    return os.path.exists(os.path.join(state_dir, STATE_WORK))
+
+
+def _stamp(state_dir, name):
+    """The RFC3339 string in a stamp file, or None. None is the FAIL-QUIET direction
+    for `work` (no verdict) and the FAIL-LOUD one for `wrote` (nothing satisfies), so
+    it is not a shared default — each caller states which it wants."""
+    try:
+        with open(os.path.join(state_dir, name)) as fh:
+            return fh.read().strip() or None
+    except Exception:                     # noqa: BLE001
+        return None
+
+
+def bump_fires(state_dir, key, kind="fires"):
+    """Read-increment-write the per-doc fire counter; returns the NEW 1-based count."""
+    path = _fires_path(state_dir, key, kind)
+    n = 0
+    try:
+        with open(path) as fh:
+            n = int(fh.read().strip() or "0")
+    except Exception:
+        n = 0
+    n += 1
+    try:
+        os.makedirs(state_dir, exist_ok=True)
+        with open(path, "w") as fh:
+            fh.write(str(n))
+    except Exception:
+        pass
+    return n
+
+
+def dismiss(state_dir, key, doc="", now=None):
+    """Clear ONE doc from ONE session's ledger AND tombstone it. Returns the file names
+    removed (the tombstone is a write, not a removal, and is not in that list).
+
+    🔴 THIS IS THE ESCAPE HATCH AND IT HAS TO BE A MECHANISM. The precedent measured
+    that a prose escape ("if you did not do this work, say so and stop") does not work:
+    saying something changes no state, so the next Stop re-blocks with identical text.
+    """
+    removed = []
+    for name in ("read-%s" % key, "fires-%s" % key, "unknown-%s" % key):
+        try:
+            os.remove(os.path.join(state_dir, name))
+            removed.append(name)
+        except Exception:                 # noqa: BLE001
+            pass
+    write_dismissal_tombstone(state_dir, key, doc=doc, now=now)
+    return removed
+
+
+def _ledger_residue(state_dir, key):
+    """Which of this doc's ledger entries are STILL on disk. Sorted; usually empty.
+
+    🔴 THIS EXISTS BECAUSE `dismiss`'s `removed` LIST CANNOT ANSWER THE QUESTION THE
+    REPORT ASKS. `removed` is "which `os.remove` calls did not raise", so an unwritable
+    session dir makes it EMPTY — byte-identical to "there was nothing here to remove".
+    The precedent printed `nothing to dismiss` over a `read-` file that was sitting in
+    the ledger, measured against a `0o500` dir. Only the disk distinguishes the two.
+    """
+    return sorted(name for name in ("read-%s" % key, "fires-%s" % key,
+                                    "unknown-%s" % key)
+                  if os.path.exists(os.path.join(state_dir, name)))
+
+
+def _dismissals_path():
+    """The audit log, deliberately OUTSIDE the per-session root that `prune` sweeps, so
+    a session dir ageing out cannot take the record of its dismissals with it."""
+    return os.path.join(os.path.dirname(_state_root()), "dismissals")
+
+
+def record_dismissal(key, session_id, removed, now=None):
+    """Append ONE line per `--dismiss` invocation. Returns True if it was written.
+
+    🔴 `--dismiss` IS A REAL BYPASS OF A DETERMINISTIC GUARD. In a hook whose entire
+    premise is that prose lost 19 sessions out of 22, gating the bypass on prose alone
+    and then not measuring it is the same mistake one level up. A no-op dismissal
+    records too, so repeat attempts are visible rather than silently identical to a
+    first one. Fail-open: an unwritable log never changes what `--dismiss` does.
+    """
+    try:
+        path = _dismissals_path()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "a") as fh:
+            fh.write(json.dumps({"ts": now_iso(now), "doc_key": _sanitize(key),
+                                 "session": _sanitize(session_id),
+                                 "removed": sorted(removed)},
+                                sort_keys=True) + "\n")
+        return True
+    except Exception:                     # noqa: BLE001
+        return False
+
+
+def prune(ttl=STATE_TTL_SECS, now=None):
+    """Drop session state directories older than `ttl`. Returns the names removed.
+
+    🔴 Keyed on the directory's OWN mtime, which the last write to it moved — so a
+    long-lived session is not swept out from under itself. Errors are swallowed per
+    entry: a state dir that cannot be removed is a few bytes, and a Stop hook that
+    raises is felt at the exact moment a session is trying to end.
+    """
+    root = _state_root()
+    cutoff = (time.time() if now is None else now) - ttl
+    removed = []
+    try:
+        names = os.listdir(root)
+    except Exception:
+        return removed
+    for name in names:
+        path = os.path.join(root, name)
+        try:
+            if os.path.getmtime(path) >= cutoff:
+                continue
+            _sh().rmtree(path, ignore_errors=True)
+            removed.append(name)
+        except Exception:                 # noqa: BLE001
+            pass
+    return removed
+
+
+def escalate(fire_number):
+    """1-based fire number -> "block" | "notice" | "silent".
+
+    "notice" is the rung that RELENTS, and it emits `systemMessage` — NOT
+    `hookSpecificOutput.additionalContext`, which the CLI feeds into the same
+    `blockingErrors` array as a block and which therefore does not relent at all. See
+    `emit` and the module docstring.
+    """
+    if fire_number <= MAX_BLOCKS:
+        return "block"
+    if fire_number <= MAX_FIRES:
+        return "notice"
+    return "silent"
+
+
+# --------------------------------------------------------------------------- #
+# Trigger matching
+# --------------------------------------------------------------------------- #
+def _strip_literals(cmd):
+    """Replace quoted runs with QUOTED_PLACEHOLDER and blank trailing `#` comments, so
+    a command that MENTIONS a work verb is not mistaken for one that RUNS it. Copied
+    verbatim from the precedent — see the ledger note above WORK_BASH_PAT.
+    """
+    return re.sub(COMMENT_PAT, " ",
+                  re.sub(QUOTED_PAT, QUOTED_PLACEHOLDER, cmd))
+
+
+def _is_handoff_basename(path):
+    return bool(HANDOFF_BASENAME_RX.match(os.path.basename(path)))
+
+
+def _bases(cmd, cwd):
+    """Directories a RELATIVE handoff path may be resolved against, in priority order.
+
+    🔴 `cwd` ALONE IS WRONG HERE, AND THAT IS NOT HYPOTHETICAL — it is how this very
+    arc's own sessions read their handoff. These repos are dispatch hubs: a session
+    sits in one clone and reads a doc out of another with
+    `git -C ~/workspace/devrc show <ref>:claudedocs/handoff-x.md`. Resolved against
+    `cwd` that names a `claudedocs/` in the WRONG repo — which either does not exist
+    (silent, fine) or exists and books the wrong document (not fine). Each `-C` value
+    in the same command is tried FIRST, and the whole thing is gated on the resolved
+    directory actually existing, so a wrong guess resolves nowhere rather than wrongly.
+    """
+    out = []
+    for m in DASH_C_RX.finditer(cmd or ""):
+        d = os.path.expanduser(os.path.expandvars(m.group(1)))
+        if d not in out:
+            out.append(d)
+    if isinstance(cwd, str) and cwd:
+        out.append(cwd)
+    return out
+
+
+def _resolve(raw, bases):
+    """A matched path token -> an absolute doc path whose DIRECTORY exists, or None.
+
+    🔴 THE DIRECTORY, NOT THE FILE. Requiring the file would refuse the case this arc
+    ran into itself: a handoff that exists only on an unmerged branch and is read with
+    `git show`. Its `claudedocs/` dir is right there, `/handoff` will write into it,
+    and the guard can measure that. Requiring the directory is what keeps a path that
+    resolves NOWHERE from arming anything — the quiet direction.
+    """
+    p = os.path.expanduser(raw)
+    cands = [p] if os.path.isabs(p) else [os.path.join(b, p) for b in bases]
+    for c in cands:
+        c = os.path.normpath(c)
+        if os.path.isdir(os.path.dirname(c)):
+            return c
+    return None
+
+
+def handoff_read_docs(data):
+    """Every handoff doc this PostToolUse payload is a READ of. Order-preserving,
+    de-duplicated, absolute, and empty for anything that is not a read.
+
+    🔴 ONLY READS ARM. A `Write`/`Edit` of a handoff doc is the thing that SATISFIES
+    this guard (see `is_handoff_write`), so admitting it here would let one tool call
+    arm and satisfy in the same instant — noise with no yield, and a second ledger
+    entry for a doc the session is already finished with.
+
+    🔴 THE BASH ARM DOES **NOT** STRIP QUOTES, and that is a deliberate asymmetry with
+    `is_work`. Quote-stripping exists to stop a command that MENTIONS a work verb from
+    counting as one; here the corresponding over-match is a session that greps for a
+    handoff doc by full path and then does real work without writing a handoff — which
+    this guard has no business staying silent about anyway. Stripping quotes would
+    instead lose the ordinary `cat "$D/claudedocs/handoff-x.md"`, i.e. trade a benign
+    over-match for a real blind spot. Comments are still stripped: a `#`-commented path
+    is not a read by anybody's reading. The over-match shape is TESTED, not hoped away.
+    """
+    d = data or {}
+    tool = d.get("tool_name")
+    ti = d.get("tool_input") or {}
+    raws, bases = [], []
+    if tool == "Read":
+        for k in PATH_KEYS:
+            v = ti.get(k)
+            if isinstance(v, str) and v:
+                raws.append(v)
+    elif tool == "Bash":
+        cmd = ti.get("command")
+        if not isinstance(cmd, str) or not cmd:
+            return []
+        stripped = re.sub(COMMENT_PAT, " ", cmd)
+        raws = HANDOFF_PATH_RX.findall(stripped)
+        bases = _bases(stripped, d.get("cwd"))
+    else:
+        return []
+    out = []
+    for raw in raws:
+        if not _is_handoff_basename(raw):
+            continue
+        resolved = _resolve(raw, bases)
+        if resolved and resolved not in out:
+            out.append(resolved)
+    return out
+
+
+def is_work(data):
+    """True when this PostToolUse payload is REAL WORK, not a read or a look-around."""
+    d = data or {}
+    if d.get("tool_name") in WORK_TOOLS:
+        return True
+    if d.get("tool_name") != "Bash":
+        return False
+    cmd = (d.get("tool_input") or {}).get("command")
+    if not isinstance(cmd, str):
+        return False
+    return bool(re.search(WORK_BASH_PAT, _strip_literals(cmd)))
+
+
+def is_handoff_write(data):
+    """True when this PostToolUse payload IS a handoff being written.
+
+    Two routes, and both are needed. `handoff_doc.py` is the one `/handoff` mandates
+    ("Never `Write` the doc yourself") and is the exact instrument the 8.7% figure was
+    measured with — 19 of the 22 losers never invoked it. The Write/Edit route covers
+    the doc being authored by any other means, including into a throwaway worktree
+    whose copy is not the one the read resolved to.
+    """
+    d = data or {}
+    if d.get("tool_name") in WORK_TOOLS:
+        ti = d.get("tool_input") or {}
+        for k in PATH_KEYS:
+            v = ti.get(k)
+            if isinstance(v, str) and v and _is_handoff_basename(v) and "claudedocs/" in v:
+                return True
+        return False
+    if d.get("tool_name") != "Bash":
+        return False
+    cmd = (d.get("tool_input") or {}).get("command")
+    if not isinstance(cmd, str):
+        return False
+    return bool(HANDOFF_RUN_RX.search(_strip_literals(cmd)))
+
+
+# --------------------------------------------------------------------------- #
+# The verdict for one tracked doc
+# --------------------------------------------------------------------------- #
+def doc_state(state_dir, rec):
+    """-> "written" | "missing" | "unknown" for ONE tracked doc.
+
+    🔴 THREE SATISFACTION ROUTES, UNIONED. Two are session-level (a `handoff_doc.py`
+    run, a write to any handoff doc) because topic drift must count as recorded; the
+    third is the resumed doc's OWN mtime, which catches a write this process never
+    observed — another tool, another process, a `/handoff` run in a session that
+    reloaded. A union is what makes the guard self-suppressing rather than a record of
+    what one hook happened to see.
+
+    🔴 `>=`, not `>`, against the read: one Bash call can be both a read and a write
+    (`git show …:claudedocs/x.md && python3 …/handoff_doc.py …`) and `post_tool_use`
+    stamps both from the SAME `now`, so an equal pair is a write ON that read.
+    """
+    read_at = parse_ts(rec.get("first_read_ts"))
+    if read_at is None:
+        # 🔴 CANNOT MEASURE, NOT CLEAN. A truncated read stamp leaves no anchor to
+        # compare anything against; reporting silence here would report the same
+        # observable as a session that wrote its handoff.
+        return "unknown"
+    wrote_at = parse_ts(_stamp(state_dir, STATE_WROTE))
+    if wrote_at is not None and wrote_at >= read_at:
+        return "written"
+    doc = rec.get("doc")
+    try:
+        if isinstance(doc, str) and doc and os.path.getmtime(doc) >= read_at:
+            return "written"
+    except OSError:
+        # The doc is not on disk — the `git show` case. NOT unknown: the two
+        # session-level routes above are still real measurements of this session, and
+        # they both came back negative. Falling through to "missing" is what keeps the
+        # unmerged-branch shape inside the guard's reach.
+        pass
+    return "missing"
+
+
+# --------------------------------------------------------------------------- #
+# Messages
+# --------------------------------------------------------------------------- #
+def dismiss_cmd(key, session_id):
+    return ("python3 ~/.claude/hooks/handoff-write-guard.py --dismiss %s --session %s"
+            % (_sanitize(key), _sanitize(session_id)))
+
+
+def missing_text(doc, key, first_read_ts, session_id=""):
+    """The block/notice text for a MEASURED missing handoff write."""
+    return (
+        "handoff write-back guard: this session read `%s` at %s and then did real "
+        "work (an edit, a commit, a push or a PR), but NO handoff has been written "
+        "since that read.\n"
+        "\n"
+        "Write it before the turn ends — run `/handoff`. It drives `%s`, which is "
+        "what this guard measures. A doc under a DIFFERENT topic also satisfies "
+        "this: scope legitimately moves, and any handoff write in this session "
+        "counts.\n"
+        "\n"
+        "Why you are being stopped for a bookkeeping step: measured over 253 "
+        "`/resume` sessions, 22 (8.7%%) never recorded their work, ZERO of them "
+        "because the write gate correctly declined, and the single largest loss "
+        "bucket — 8 of 16 — is a session that ENDED CLEANLY. That is this moment.\n"
+        "\n"
+        "If this session's work genuinely does not belong in a handoff, dismiss it. "
+        "Saying so changes no state; this does:\n"
+        "  %s"
+        % (os.path.basename(doc), first_read_ts, HANDOFF_TOOL,
+           dismiss_cmd(key, session_id)))
+
+
+def unknown_text(doc, key, session_id=""):
+    """The notice text for a doc whose state could NOT be measured. NEVER a block."""
+    return (
+        "handoff write-back guard: could NOT measure whether a handoff was written "
+        "for `%s` — its ledger entry is unreadable, so this is a cannot-measure, not "
+        "a clean bill of health. If this session did work worth resuming from, run "
+        "`/handoff`.\n"
+        "  %s"
+        % (os.path.basename(doc), dismiss_cmd(key, session_id)))
+
+
+# --------------------------------------------------------------------------- #
+# PostToolUse
+# --------------------------------------------------------------------------- #
+def post_tool_use(data, now=None):
+    """Record reads, work and handoff writes. Returns a small dict, for tests.
+
+    🔴 THE ORDERING IS THE POINT ON THIS PATH. `os.path.exists` on the session's state
+    dir and the arming regex come FIRST, and a session that is neither tracked nor
+    reading a handoff returns before touching the filesystem again.
+    """
+    # 🔴 THE SUBAGENT RULE IS ASYMMETRIC — a subagent's tool call arrives wearing the
+    # PARENT's `session_id`, so `agent_id` is the only field separating them. Its READ
+    # must not arm the parent (the precedent measured that as a false positive: a
+    # parent blocked on a doc only a subagent touched); its WORK is the session's work
+    # (the parent dispatched it and owns the record). So `agent_id` suppresses only the
+    # read half, and the work half still requires the session to be ALREADY TRACKED.
+    agent = bool((data or {}).get("agent_id"))
+    state_dir = _state_dir(data)
+    if state_dir is None:
+        return {"fast_path": True, "recorded": [], "work": False, "wrote": False}
+    tracked = os.path.exists(state_dir)
+    # A subagent's payload never contributes docs, so the arming regex is skipped
+    # entirely for it — the fast path stays one `exists` and no `re` work.
+    docs = [] if agent else handoff_read_docs(data)
+    if not tracked and not docs:
+        # 🔴 THE FAST-PATH RETURN. Exactly ONE filesystem call has happened and nothing
+        # has been spawned. Everything below — the work regex, the write regex, every
+        # write and stat of a state file — is reachable ONLY for a session that has
+        # actually read a handoff doc.
+        return {"fast_path": True, "recorded": [], "work": False, "wrote": False}
+
+    recorded = []
+    for doc in docs:
+        try:
+            if record_read(state_dir, doc, now=now):
+                recorded.append(doc)
+        except Exception:                 # noqa: BLE001 — fail-open, per read
+            pass
+    # Work and writes count only for a session that has read a handoff, and the
+    # fast-path return above IS that gate: reaching this line means `tracked or docs`
+    # was true. A second `and (tracked or recorded)` here would be a copy of a decision
+    # already made — unkillable by any mutation.
+    marked = wrote = False
+    if is_work(data):
+        try:
+            record_work(state_dir, now=now)
+            marked = True
+        except Exception:                 # noqa: BLE001
+            pass
+    if is_handoff_write(data):
+        try:
+            record_wrote(state_dir, now=now)
+            wrote = True
+        except Exception:                 # noqa: BLE001
+            pass
+    return {"fast_path": False, "recorded": recorded, "work": marked, "wrote": wrote}
+
+
+# --------------------------------------------------------------------------- #
+# Stop
+# --------------------------------------------------------------------------- #
+def stop_decision(data):
+    """Pure-ish decision for a Stop payload -> (kind, text), kind in
+    {"silent", "notice", "block"}. Side effect: it bumps the per-doc fire counters,
+    which is what the ladder is made of."""
+    d = data if isinstance(data, dict) else {}
+    if d.get("hook_event_name") not in (None, "Stop"):
+        return ("silent", "")             # 🔴 SubagentStop and friends: refused
+    if d.get("agent_id"):
+        return ("silent", "")
+    state_dir = _state_dir(d)
+    if state_dir is None or not os.path.exists(state_dir):
+        return ("silent", "")
+    if not work_happened(state_dir):
+        # 🔴 THE FALSE-POSITIVE KILLER. A session that resumed a doc, reconciled it,
+        # reported that nothing had moved and stopped owes the record NOTHING — and
+        # the measurement agrees: legitimate `no-change` declines were counted
+        # separately and were ZERO, so this case is already handled by the skill.
+        return ("silent", "")
+
+    docs = tracked_docs(state_dir)
+    if not docs:
+        return ("silent", "")
+
+    session_id = d.get("session_id") or ""
+    blocks, notices = [], []
+    # No `[:MAX_DOCS]` slice: `record_read` refuses to create a fourth `read-` file, so
+    # `tracked_docs` structurally cannot return more than MAX_DOCS and a slice here
+    # would be a second copy of a cap already enforced at the writer.
+    for key in sorted(docs):
+        rec = docs[key]
+        state = doc_state(state_dir, rec)
+        if state == "written":
+            continue
+        if state == "unknown":
+            # 🔴 NEVER blocks, and spends its OWN counter. Cannot-measure is reported,
+            # never enforced — and never at the expense of the block budget a measured
+            # miss will need if the state becomes readable later in this session.
+            if escalate(bump_fires(state_dir, key, "unknown")) != "silent":
+                notices.append(unknown_text(rec.get("doc", key), key, session_id))
+            continue
+        rung = escalate(bump_fires(state_dir, key))
+        if rung == "silent":
+            continue
+        (blocks if rung == "block" else notices).append(
+            missing_text(rec.get("doc", key), key, rec.get("first_read_ts", "?"),
+                         session_id))
+
+    # 🔴 A "could not measure" notice NEVER CAUSES a block — only `blocks` does. When
+    # some other doc is blocking anyway the notice rides along in the same reason
+    # rather than being dropped, but a Stop whose every doc is unmeasurable can only
+    # ever reach `notice`, which does not force a continuation at all.
+    if blocks:
+        return ("block", "\n\n".join(blocks + notices))
+    if notices:
+        return ("notice", "\n\n".join(notices))
+    return ("silent", "")
+
+
+def emit(kind, text):
+    """The ONE writer. `silent` is handled HERE rather than at the call site, so there
+    is exactly one place that decides what reaches stdout.
+
+    🔴 THERE ARE EXACTLY TWO CHANNELS AND ONLY ONE OF THEM ENDS THE TURN.
+    `decision:"block"` forces a continuation. `systemMessage` does not — the CLI
+    yields it on the message channel, never into `blockingErrors`, and its attachment
+    renders to the operator without being fed back to the model.
+    `hookSpecificOutput.additionalContext` is NOT a third option: on Stop the CLI
+    pushes it into the same `blockingErrors` array as a block, so emitting it here
+    would force a continuation while claiming not to. It is deliberately absent.
+    """
+    if kind == "block":
+        json.dump({"decision": "block", "reason": text}, sys.stdout)
+        sys.stdout.write("\n")
+    elif kind == "notice":
+        json.dump({"systemMessage": text}, sys.stdout)
+        sys.stdout.write("\n")
+
+
+# --------------------------------------------------------------------------- #
+# --dismiss
+# --------------------------------------------------------------------------- #
+def dismiss_report(key, session_id, removed, tombstoned, residue=()):
+    """The ONE sentence `--dismiss` prints. A pure function of what actually happened,
+    so the claim can be pinned as a whole string by a test rather than sampled for
+    keywords — a two-word check on this text would be satisfied by its own prefix.
+
+    🔴 THE PROMISE IS SCOPED TO THE SESSION, AND THAT IS THE FIX, NOT A HEDGE. The
+    precedent's text said "It will not ask about this again", which was false twice
+    over: the next read re-armed the guard, and even with a tombstone it says nothing
+    about the NEXT session, which correctly starts fresh. Both are stated.
+
+    🔴 The state dir is NOT printed: it is an absolute path containing $HOME, and
+    everything this writes goes to stdout, which the model reads and may quote onward.
+
+    🔴 BOTH HALVES ARE MEASURED OFF DISK. `removed` alone cannot tell "nothing to
+    remove" from "the removal FAILED" — both are an empty list — so the head asks the
+    filesystem via `_ledger_residue`, and the promise asks it via `is_dismissed`.
+    """
+    sess = _sanitize(session_id)
+    k = _sanitize(key)
+    # 🔴 THE RESIDUE BRANCH OWNS BOTH HALVES OF THE SENTENCE, AND COMES FIRST. A ledger
+    # entry that survived falsifies both other clauses at once: the head would report
+    # nothing to dismiss about a doc demonstrably still in the ledger, and the promise
+    # would claim a silence `tracked_docs` will not honour.
+    if residue:
+        return ("handoff write-back guard: could NOT clear `%s` from session %s's "
+                "ledger — %s still present. WARNING: nothing was dismissed and this "
+                "guard will still ask about `%s` in session %s."
+                % (k, sess, ", ".join(sorted(residue)), k, sess))
+    if removed:
+        head = ("handoff write-back guard: dismissed `%s` for session %s (cleared %s)."
+                % (k, sess, ", ".join(sorted(removed))))
+    else:
+        head = ("handoff write-back guard: nothing to dismiss — `%s` is not in "
+                "session %s's ledger." % (k, sess))
+    if tombstoned:
+        tail = ("It will not ask about `%s` again in session %s, even if the doc is "
+                "read again — a NEW session starts fresh." % (k, sess))
+    else:
+        tail = ("WARNING: the tombstone could NOT be written, so a later read of `%s` "
+                "in session %s will arm this guard again." % (k, sess))
+    return head + " " + tail
+
+
+def dismiss_main(argv):
+    """`--dismiss <doc-key> --session <session_id>` — the escape hatch, as a command.
+
+    Prints one line saying what it did and returns. NEVER reads stdin: it is invoked
+    by a model from a Bash tool call, where stdin is not a hook payload.
+
+    🔴 `--session` is REQUIRED and is not defaulted. This process has no way to learn
+    the caller's session id, and guessing would land a dismissal on some other
+    session's ledger. The block text supplies it already filled in.
+
+    🔴 The key is accepted as a BASENAME too (`handoff-x.md`), because that is what the
+    operator sees in the block text's first line; `doc_key` sanitizes either spelling
+    to the same ledger key, so both work and neither can traverse.
+    """
+    key = sess = None
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--dismiss" and i + 1 < len(argv):
+            key, i = argv[i + 1], i + 2
+        elif argv[i] == "--session" and i + 1 < len(argv):
+            sess, i = argv[i + 1], i + 2
+        else:
+            i += 1
+    if key is None or sess is None:
+        sys.stdout.write("usage: handoff-write-guard.py --dismiss <doc-key> "
+                         "--session <session_id>\n")
+        return
+    k = doc_key(key)
+    if not k:
+        sys.stdout.write("not a handoff doc key: %s\n" % _sanitize(key))
+        return
+    state_dir = _state_dir({"session_id": sess})
+    if state_dir is None:
+        sys.stdout.write("not a session id: %s\n" % _sanitize(sess))
+        return
+    removed = dismiss(state_dir, k, doc=key)
+    record_dismissal(k, sess, removed)
+    # 🔴 BOTH CLAIMS ARE RE-MEASURED OFF DISK, NOT TAKEN FROM A RETURN VALUE. A
+    # tombstone write that failed while an EARLIER dismissal's tombstone is still
+    # present leaves the promise TRUE, and only asking the filesystem sees that.
+    sys.stdout.write(dismiss_report(k, sess, removed,
+                                    is_dismissed(state_dir, k),
+                                    _ledger_residue(state_dir, k)) + "\n")
+
+
+def main():
+    # 🔴 ONE exit, and it is always 0. Nothing inside the try may call sys.exit():
+    # SystemExit is a BaseException and would sail past `except Exception`.
+    try:
+        # 🔴 THE CLI MODE IS DECIDED BEFORE THE STDIN READ and never performs one. A
+        # hook invocation carries no argv, so this cannot shadow the hook path — and
+        # reading stdin in CLI mode would hang on a terminal forever.
+        if "--dismiss" in sys.argv[1:]:
+            dismiss_main(sys.argv[1:])
+            data, event = None, None
+        else:
+            data = json.load(sys.stdin)
+            event = (data or {}).get("hook_event_name")
+        if event == "PostToolUse":
+            post_tool_use(data)
+        elif event == "Stop":
+            emit(*stop_decision(data))
+            # AFTER the decision has been emitted: the operator's turn never waits on
+            # housekeeping, and a prune that raises cannot suppress a verdict already
+            # written.
+            prune()
+        # every other event, SubagentStop included, is not ours
+    except Exception:                     # noqa: BLE001 — see the fail-open note above
+        pass
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/claude-hooks/handoff-write-guard.py
+++ b/scripts/claude-hooks/handoff-write-guard.py
@@ -759,6 +759,14 @@ def handoff_read_docs(data):
             v = ti.get(k)
             if isinstance(v, str) and v:
                 raws.append(v)
+        # 🔴 `cwd` IS A BASE HERE TOO, EVEN THOUGH THE TOOL ASKS FOR AN ABSOLUTE PATH.
+        # `lib/subsystem_touch.py` — which reads these same payloads out of transcripts
+        # — records that `file_path` is "ABSOLUTE whenever the caller passed an
+        # absolute", i.e. a relative one reaches the payload verbatim when the caller
+        # passes one. Without a base, such a read resolves nowhere and arms nothing:
+        # a silent blind spot rather than a visible one, which is the shape this file
+        # keeps trying to avoid. There is no `-C` on a Read, so `cwd` is the only base.
+        bases = _bases("", d.get("cwd"))
     elif tool == "Bash":
         cmd = ti.get("command")
         if not isinstance(cmd, str) or not cmd:

--- a/scripts/claude-hooks/register-nudge-hook.py
+++ b/scripts/claude-hooks/register-nudge-hook.py
@@ -103,6 +103,10 @@ Registers (APPEND surface):
     task write-back non-optional — PostToolUse watches for a read of a specific task
     id and for real work after it, Stop re-reads the board live and blocks a turn
     that is about to end with the card still uncommented).
+  * PostToolUse / Stop: handoff-write-guard.py (the same shape on the OTHER record —
+    PostToolUse watches for a READ of a specific handoff doc and for real work after
+    it, Stop measures whether any handoff was written since that read and blocks a
+    turn about to end without one. Armed on the read, never on session start).
   * PreToolUse(Bash) / PostToolUse(Bash): bg-command-capture.py — INSTRUMENTATION,
     not a guard and not a nudge. It has no verdict, writes nothing to stdout and
     returns 0 on every input; it appends the VERBATIM command string of every
@@ -113,9 +117,10 @@ Registers (APPEND surface):
     command and `run_in_background`, PostToolUse has the `backgroundTaskId` that
     names the run's output file.
 
-🔴 TWO of these carry NO `matcher` on PostToolUse — agent-ledger-hook.py and
-clawgate-writeback-guard.py — unlike the three nudges above. Those three are about
-the shape of a Bash COMMAND, so `Bash` is the right scope. The other two are not:
+🔴 THREE of these carry NO `matcher` on PostToolUse — agent-ledger-hook.py,
+clawgate-writeback-guard.py and handoff-write-guard.py — unlike the three nudges
+above. The NUDGES are about the shape of a Bash COMMAND, so `Bash` is the right
+scope for them. These three are not:
 
   * the ledger records that a tool call HAPPENED, and scoping it to Bash would
     silently stop the heartbeat for a session doing a long stretch of Read/Edit work
@@ -127,6 +132,12 @@ the shape of a Bash COMMAND, so `Bash` is the right scope. The other two are not
     for an hour — the commonest shape of the failure it exists to catch — and would
     stay silent for it. The Bash half (`git commit` / `git push` / `gh pr create`) is
     the part a matcher WOULD cover, and it is the smaller half.
+  * the handoff write guard has the same second job, on the other record: it is
+    watching for REAL WORK after a handoff READ, and — additionally — for the
+    handoff WRITE itself, which is a `Write`/`Edit` of a `claudedocs/handoff-*.md`
+    whenever the doc was not produced by `handoff_doc.py`. Under a `Bash` matcher
+    it would be blind to both, i.e. it would nag sessions that HAD recorded their
+    work and miss the ones that had not.
 
 The cost, MEASURED rather than asserted: ~21 ms per call against ~9 ms for a bare
 interpreter start, and the hook throttles at 30s, so the overwhelming majority of
@@ -219,6 +230,7 @@ MANAGED_HOOK_SCRIPTS = frozenset({
     "clawgate-task-interview-guard.py",
     "clawgate-writeback-guard.py",
     "gh-issue-closing-condition-guard.py",
+    "handoff-write-guard.py",
     "next-step-nudge.py",
     "search-tool-nudge.py",
     "shell-env-nudge.py",
@@ -591,6 +603,19 @@ LEDGER_EVENTS = ["SessionStart", "UserPromptSubmit", "PostToolUse", "Stop"]
 WRITEBACK_CMD = with_python("~/.claude/hooks/clawgate-writeback-guard.py")
 WRITEBACK_EVENTS = ["PostToolUse", "Stop"]
 
+# The handoff write-back guard — the write-back guard's counterpart on the OTHER
+# record. That one makes a clawgate pickup report back to the board; this one makes
+# a session that RESUMED a handoff doc write one before it stops. Same two events and
+# the same NO-matcher PostToolUse entry, for the same reason: half of what it watches
+# for (the work, and the handoff write itself) is an Edit/Write tool call.
+#
+# 🔴 NOT registered on SessionStart, deliberately, and that is the design rather than
+# an omission: arming there would fire on every session that never touched a handoff.
+# It arms on the READ — see the hook's module docstring for the 253-session
+# measurement that selects the read as the trigger.
+HANDOFF_GUARD_CMD = with_python("~/.claude/hooks/handoff-write-guard.py")
+HANDOFF_GUARD_EVENTS = ["PostToolUse", "Stop"]
+
 # 🔴 THE FIRST PreToolUse HOOK THIS SCRIPT REGISTERS, and that is a widening of
 # the append surface, not a rewording of it. Until now PreToolUse was
 # rewrite-only: bash-guard's INTERPRETER was this script's, its REGISTRATION was
@@ -652,7 +677,8 @@ SINGLE_EVENT_CMDS = {
 # remove. It is reported instead — see the end of the de-dup pass.
 REGISTERED_SCRIPTS = frozenset(
     hook_script_of(c)
-    for c in POST_BASH_CMDS + PRE_BASH_CMDS + [NOTIFY_CMD, LEDGER_CMD, WRITEBACK_CMD]
+    for c in POST_BASH_CMDS + PRE_BASH_CMDS + [NOTIFY_CMD, LEDGER_CMD, WRITEBACK_CMD,
+                                               HANDOFF_GUARD_CMD]
     + [c for cmds in SINGLE_EVENT_CMDS.values() for c in cmds]
 )
 
@@ -1092,6 +1118,23 @@ for event in WRITEBACK_EVENTS:
         continue
     arr.append({"hooks": [{"type": "command", "command": WRITEBACK_CMD}]})
     added.append("%s: %s" % (event, WRITEBACK_CMD))
+
+# --- the handoff write guard (append-only, same discipline) ------------------
+# 🔴 THE SECOND **Stop** ENTRY HERE THAT CAN BLOCK — the fourth blocking hook this
+# script registers overall, the other two being PreToolUse gates — and it is
+# appended AFTER the clawgate one so the order of the two Stop blockers is a
+# decision rather than an accident of table position. Each
+# caps itself independently — two consecutive blocks per task and per doc — so a
+# session holding both a clawgate card and a resumed handoff can in principle stack
+# toward the CLI's cap of 8, at which point the CLI ends the turn with a warning. A
+# graceful ceiling, named rather than hidden; the same interaction the write-back
+# guard's own docstring records for MAX_TASKS.
+for event in HANDOFF_GUARD_EVENTS:
+    arr = hooks.setdefault(event, [])
+    if hook_script_of(HANDOFF_GUARD_CMD) in registered_scripts(arr):
+        continue
+    arr.append({"hooks": [{"type": "command", "command": HANDOFF_GUARD_CMD}]})
+    added.append("%s: %s" % (event, HANDOFF_GUARD_CMD))
 
 # --- single-event hooks (append-only, same discipline) -----------------------
 for event, cmds in SINGLE_EVENT_CMDS.items():

--- a/scripts/claude-hooks/tests/test_handoff_write_guard.py
+++ b/scripts/claude-hooks/tests/test_handoff_write_guard.py
@@ -222,6 +222,16 @@ def test_the_second_basename_shape_arms(home, repo):
     assert guard.handoff_read_docs(read_tool(doc)) == [doc]
 
 
+def test_a_RELATIVE_Read_path_resolves_against_cwd(home, repo):
+    """🔴 The Read tool asks for an absolute path, but `lib/subsystem_touch.py` — which
+    reads these same payloads out of transcripts — records that `file_path` is absolute
+    "whenever the caller passed an absolute", i.e. a relative one arrives verbatim.
+    Without `cwd` as a base such a read arms NOTHING, which is a silent blind spot."""
+    got = guard.handoff_read_docs(
+        read_tool("claudedocs/" + DOC, cwd=str(repo)))
+    assert got == [str(repo / "claudedocs" / DOC)]
+
+
 def test_a_relative_path_resolves_against_cwd(home, repo):
     cmd = "head -50 claudedocs/%s" % DOC
     assert guard.handoff_read_docs(bash(cmd, cwd=str(repo))) == [

--- a/scripts/claude-hooks/tests/test_handoff_write_guard.py
+++ b/scripts/claude-hooks/tests/test_handoff_write_guard.py
@@ -296,6 +296,19 @@ def test_a_subagents_WORK_does_count_once_the_parent_has_read(home, repo):
     assert guard.work_happened(sd)
 
 
+def test_a_subagents_handoff_WRITE_also_counts(home, repo):
+    """The same asymmetry, on the satisfaction side rather than the work side — and it
+    has to hold, or dispatching the write to a subagent would leave the parent blocked
+    for a handoff that is on disk. Same justification: the parent dispatched it."""
+    sd = seed(str(repo / "claudedocs" / DOC))
+    other = str(repo / "claudedocs" / "handoff-elsewhere.md")
+    guard.post_tool_use(
+        payload(tool_name="Write", tool_input={"file_path": other}, agent_id="agt-1"),
+        now=AFTER_READ_EPOCH)
+    assert guard._stamp(sd, guard.STATE_WROTE) is not None
+    assert guard.stop_decision(payload(event="Stop")) == ("silent", "")
+
+
 # --------------------------------------------------------------------------- #
 # 2. THE FALSE-POSITIVE KILLER
 # --------------------------------------------------------------------------- #

--- a/scripts/claude-hooks/tests/test_handoff_write_guard.py
+++ b/scripts/claude-hooks/tests/test_handoff_write_guard.py
@@ -1,0 +1,830 @@
+#!/usr/bin/env python3
+"""Tests for handoff-write-guard.py — the hook that makes the handoff write
+non-optional for a session that resumed one.
+
+WHAT THIS FILE IS FOR
+
+  1. 🔴 BOTH DIRECTIONS OF THE ARMING TRIGGER. The NON-matches are as load-bearing as
+     the matches: this hook can BLOCK a turn, and arming it off `ls claudedocs/`, a
+     grep, a non-handoff `.md`, or a path that resolves nowhere would put a block in
+     front of a session that never resumed anything. Every one is a separate case.
+
+  2. 🔴 THE FALSE-POSITIVE KILLER, TESTED AS AN ABSENCE OF ANY STATE CHANGE. A session
+     that reads a handoff, reconciles it, reports "nothing moved" and stops must never
+     fire — the measurement counted zero legitimate declines, so that path is already
+     handled by the skill and this guard must stay out of it. Asserted not just by the
+     verdict but by the fire counter NEVER BEING CREATED, so a mutation that reorders
+     the work gate below the ladder is visible even if it happens to end up silent.
+
+  3. 🔴 THE LADDER IS DRIVEN WITH LITERALS THE CONSTANTS CANNOT EQUAL. This repo has
+     been bitten repeatedly by a fixture whose value equals the constant it tests, so
+     `MAX_BLOCKS = 2` / `MAX_FIRES = 3` / `MAX_DOCS = 3` are never checked by something
+     that produces 2 or 3 by construction: counters are seeded at 0 and at 9, the doc
+     cap is driven with 5 docs, and the decision is watched to MOVE.
+
+  4. 🔴 EVERY "CANNOT MEASURE" PATH IS A NOTICE, NEVER A BLOCK — the empty-result trap
+     in RULES.md: a hook that goes silent when it cannot measure reports the same
+     observable as one that measured a clean session.
+
+  5. 🔴 THE NON-BLOCKING RUNG IS ASSERTED ON THE OBSERVABLE, NOT ON A KIND STRING.
+     `stop_decision` returning "notice" is a SPELLING of non-blocking; the CLI decides
+     from the emitted JSON, and `hookSpecificOutput.additionalContext` — which reads as
+     non-blocking — is pushed into the same `blockingErrors` array as a block. Every
+     such assertion runs the verdict through the real `guard.emit` and asks
+     `forces_a_continuation(<the emitted JSON>)`.
+
+  6. 🔴 THE DISMISSAL IS VERIFIED BY RE-READING THE DOC AFTERWARDS. The precedent's
+     `--dismiss` shipped broken through three audit rounds because every test drove it
+     and then asserted silence, and none of them re-read the thing afterwards — which
+     is the one act that re-armed the guard, and also the natural way a human confirms
+     a dismissal took. That exact sequence is a case here.
+
+  7. THE HOT PATH. PostToolUse fires after every tool call, so the fast path is
+     asserted by COUNTING filesystem calls, not by trusting a comment.
+
+  8. 🔴 THE ANTI-DRIFT LEDGER. The work-detection patterns are a declared verbatim copy
+     of clawgate-writeback-guard.py's. `test_the_work_detection_is_byte_identical_to_
+     the_precedent` fails when EITHER copy moves, which is the failure mode "one rule,
+     one place" is actually about.
+"""
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = Path(HERE).resolve().parents[2]
+HOOK = os.path.abspath(os.path.join(HERE, os.pardir, "handoff-write-guard.py"))
+PRECEDENT = os.path.abspath(os.path.join(HERE, os.pardir,
+                                         "clawgate-writeback-guard.py"))
+HOME_NIX = ROOT / "nix" / "home.nix"
+REGISTRAR = ROOT / "scripts" / "claude-hooks" / "register-nudge-hook.py"
+
+
+def _load(name, path):
+    loader = importlib.machinery.SourceFileLoader(name, path)
+    spec = importlib.util.spec_from_file_location(name, path, loader=loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+guard = _load("handoff_write_guard_undertest", HOOK)
+
+SESSION = "sess-handoff-write-1"
+DOC = "handoff-skill-chain-usage-audit.md"
+# Fixed instants, pinned as LITERALS rather than computed here, and all four DISTINCT
+# so no assertion can pass by two anchors collapsing onto one value.
+READ_TS = "2026-08-20T12:00:00.000000Z"
+READ_EPOCH = 1787227200.0
+BEFORE_READ_EPOCH = 1787223600.0        # 11:00Z — an hour before the read
+WORK_EPOCH = 1787229000.0               # 12:30Z
+AFTER_READ_EPOCH = 1787230800.0         # 13:00Z
+
+
+def forces_a_continuation(out):
+    """Would this hook output make the CLI re-query the model instead of ending the
+    turn? Transcribed from claude-code 2.1.220's `bin/.claude-wrapped`, function
+    `Ycd`, which pushes BOTH shapes into ONE `blockingErrors` array:
+
+        if (F.blockingError)      { … E.push(G); … }
+        if (F.additionalContexts) { … E.push(j); … }
+        if (E.length > 0) return { blockingErrors: E, preventContinuation: !1 };
+
+    `systemMessage` is absent from that path on purpose: it is yielded as a
+    `hook_system_message` MESSAGE and never reaches `E`. The full bundle reads and both
+    controls live in clawgate-writeback-guard.py's module docstring, which is the one
+    place they are recorded.
+    """
+    if not isinstance(out, dict):
+        return False
+    if out.get("decision") == "block":
+        return True
+    hso = out.get("hookSpecificOutput")
+    return bool(isinstance(hso, dict) and hso.get("additionalContext"))
+
+
+def emitted(capsys, verdict):
+    """Run one `(kind, text)` verdict through the REAL writer and return the JSON that
+    reached stdout (None when it wrote nothing)."""
+    guard.emit(*verdict)
+    raw = capsys.readouterr().out
+    return json.loads(raw) if raw.strip() else None
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    h = tmp_path / "home"
+    (h / ".claude").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(h))
+    return h
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    """A repo with a real `claudedocs/` dir. The DIRECTORY is what arming requires."""
+    d = tmp_path / "repo" / "claudedocs"
+    d.mkdir(parents=True)
+    return d.parent
+
+
+def payload(event="PostToolUse", session_id=SESSION, cwd=None, **kw):
+    base = {"hook_event_name": event, "session_id": session_id,
+            "transcript_path": "/home/zach/.claude/projects/p/a.jsonl",
+            "cwd": cwd or "/home/zach/workspace/devrc"}
+    base.update(kw)
+    return base
+
+
+def bash(cmd, **kw):
+    return payload(tool_name="Bash", tool_input={"command": cmd}, **kw)
+
+
+def read_tool(path, **kw):
+    return payload(tool_name="Read", tool_input={"file_path": path}, **kw)
+
+
+def state_dir(session=SESSION):
+    return guard._state_dir({"session_id": session})
+
+
+def seed(doc, ts=READ_TS, work=True, session=SESSION):
+    """Put a session into the state the Stop gate reads: doc read, work done.
+
+    🔴 The work stamp is a FIXED instant, never `time.time()`. A "now" here would sit
+    in the real present and make every fixture retroactively stale — a whole file of
+    tests that pass or fail by the calendar.
+    """
+    sd = state_dir(session)
+    os.makedirs(sd, exist_ok=True)
+    with open(guard._read_path(sd, guard.doc_key(doc)), "w") as fh:
+        json.dump({"doc": str(doc), "first_read_ts": ts}, fh)
+    if work:
+        guard.record_work(sd, now=WORK_EPOCH)
+    return sd
+
+
+def run_hook(payload_dict, argv=(), env=None):
+    """The hook as a REAL process — the only way to make a claim about its exit code
+    and about what it does or does not write to stdout/stderr."""
+    e = dict(os.environ)
+    if env:
+        e.update(env)
+    return subprocess.run(
+        [sys.executable, HOOK, *argv],
+        input="" if payload_dict is None else json.dumps(payload_dict),
+        capture_output=True, text=True, env=e, timeout=60)
+
+
+# --------------------------------------------------------------------------- #
+# 1. ARMING — the matches
+# --------------------------------------------------------------------------- #
+def test_the_Read_tool_on_an_absolute_handoff_path_arms(home, repo):
+    doc = str(repo / "claudedocs" / DOC)
+    assert guard.handoff_read_docs(read_tool(doc)) == [doc]
+
+
+def test_a_git_show_off_a_ref_arms_and_resolves_through_the_dash_C(home, repo):
+    """🔴 THE SHAPE THIS ARC'S OWN SESSIONS USED. A handoff that lives only on an
+    unmerged branch is read as `git -C <repo> show <ref>:claudedocs/<doc>`. Two things
+    are asserted at once: the `:` does not get swallowed into the path (so the match
+    starts at `claudedocs/`), and the base is taken from `-C` rather than from `cwd`,
+    which in a dispatch-hub session names a DIFFERENT repo entirely."""
+    cmd = ("git -C %s show origin/zach/skill-chain-usage-audit:claudedocs/%s"
+           % (repo, DOC))
+    got = guard.handoff_read_docs(bash(cmd, cwd="/nowhere/else"))
+    assert got == [str(repo / "claudedocs" / DOC)]
+
+
+def test_a_quoted_cat_arms_because_the_bash_arm_does_not_strip_quotes(home, repo):
+    """🔴 THE DELIBERATE ASYMMETRY WITH `is_work`. Quote-stripping exists to stop a
+    command that MENTIONS a work verb counting as one. Applying it here would lose the
+    ordinary `cat "$D/claudedocs/handoff-x.md"` — a real blind spot traded for a benign
+    over-match. This case is what pins the asymmetry."""
+    cmd = 'cat "%s/claudedocs/%s"' % (repo, DOC)
+    assert guard.handoff_read_docs(bash(cmd)) == [str(repo / "claudedocs" / DOC)]
+
+
+def test_the_second_basename_shape_arms(home, repo):
+    """`/resume` resolves `claudedocs/handoff-*.md` FIRST and `claudedocs/*HANDOFF*.md`
+    second, and the second is a real repo's real handoff (civitai-manager's
+    SESSION-HANDOFF.md). A skill that resolves two shapes and a guard that arms on one
+    is silent for whichever repo uses the other."""
+    doc = str(repo / "claudedocs" / "SESSION-HANDOFF.md")
+    assert guard.handoff_read_docs(read_tool(doc)) == [doc]
+
+
+def test_a_relative_path_resolves_against_cwd(home, repo):
+    cmd = "head -50 claudedocs/%s" % DOC
+    assert guard.handoff_read_docs(bash(cmd, cwd=str(repo))) == [
+        str(repo / "claudedocs" / DOC)]
+
+
+# --------------------------------------------------------------------------- #
+# 1b. ARMING — the NON-matches, which are the load-bearing half
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("cmd", [
+    "ls claudedocs/",                              # a survey, not a read of one doc
+    "ls -t claudedocs/handoff-*.md | head",        # a glob is not a specific doc
+    "grep -rn handoff claudedocs/",                # searching, not reading
+    "cat claudedocs/notes.md",                     # not a handoff basename
+    "cat docs/handoff-format.md",                  # handoff-shaped, wrong directory
+    "# cat claudedocs/handoff-x.md",               # the whole line is a comment
+    "python3 scripts/lib/handoff_doc.py --repo . --topic x",        # a WRITE, not a read
+])
+def test_these_bash_commands_do_NOT_arm(home, repo, cmd):
+    """🔴 A guard that can BLOCK must be shown NOT to fire, one shape per case."""
+    assert guard.handoff_read_docs(bash(cmd, cwd=str(repo))) == []
+
+
+def test_a_path_after_a_hash_is_a_comment_not_a_read(home, repo):
+    """🔴 THE DISCRIMINATOR FOR COMMENT-STRIPPING, built so that dropping the strip
+    changes the RESULT rather than merely a count. One command names TWO handoff docs
+    — one being read, one mentioned after a `#` — so a mutant that skips the strip
+    returns two entries and books a document the session never opened."""
+    cmd = "cat claudedocs/handoff-x.md  # and see claudedocs/handoff-y.md"
+    got = guard.handoff_read_docs(bash(cmd, cwd=str(repo)))
+    assert got == [str(repo / "claudedocs" / "handoff-x.md")]
+
+
+def test_a_path_whose_directory_does_not_exist_does_NOT_arm(home, tmp_path):
+    """🔴 THE QUIET DIRECTION. Arming requires the resolved `claudedocs/` to be real, so
+    a dispatch-hub session that names a doc in a repo this host does not have arms
+    nothing, rather than booking a document nobody can measure."""
+    cmd = "cat %s/nosuchrepo/claudedocs/%s" % (tmp_path, DOC)
+    assert guard.handoff_read_docs(bash(cmd)) == []
+
+
+def test_a_WRITE_of_a_handoff_doc_does_NOT_arm(home, repo):
+    """🔴 ONLY READS ARM. A Write/Edit of a handoff doc is what SATISFIES this guard, so
+    admitting it here would let one tool call arm and satisfy in the same instant."""
+    doc = str(repo / "claudedocs" / DOC)
+    for tool in ("Write", "Edit"):
+        p = payload(tool_name=tool, tool_input={"file_path": doc})
+        assert guard.handoff_read_docs(p) == []
+        # …and the positive half in the same breath: it SATISFIES instead.
+        assert guard.is_handoff_write(p) is True
+
+
+def test_a_subagents_read_does_NOT_arm_the_parent(home, repo):
+    """🔴 THE ASYMMETRIC RULE, READ HALF. A subagent's tool call wears the PARENT's
+    session_id; accepting its read armed the precedent's parent off a doc only the
+    subagent touched — measured as a false positive."""
+    doc = str(repo / "claudedocs" / DOC)
+    out = guard.post_tool_use(read_tool(doc, agent_id="agt-1"))
+    assert out["fast_path"] is True and out["recorded"] == []
+    assert not os.path.exists(state_dir())
+
+
+def test_a_subagents_WORK_does_count_once_the_parent_has_read(home, repo):
+    """🔴 THE ASYMMETRIC RULE, WORK HALF — the direction the precedent got wrong, which
+    deleted its yield on the exact incident it existed for. The parent dispatched the
+    subagent; the parent owns the record."""
+    sd = seed(str(repo / "claudedocs" / DOC), work=False)
+    out = guard.post_tool_use(
+        payload(tool_name="Edit", tool_input={"file_path": "/x/y.py"},
+                agent_id="agt-1"))
+    assert out["work"] is True
+    assert guard.work_happened(sd)
+
+
+# --------------------------------------------------------------------------- #
+# 2. THE FALSE-POSITIVE KILLER
+# --------------------------------------------------------------------------- #
+def test_read_with_no_work_is_silent_and_bumps_NOTHING(home, repo):
+    """🔴 Asserted on the STATE as well as the verdict. A verdict-only assertion cannot
+    see a mutation that reorders the work gate below the ladder — it would still return
+    silent for this input while having spent a fire."""
+    sd = seed(str(repo / "claudedocs" / DOC), work=False)
+    assert guard.stop_decision(payload(event="Stop")) == ("silent", "")
+    assert [n for n in os.listdir(sd) if n.startswith("fires-")] == []
+
+
+def test_a_session_that_never_read_a_handoff_is_silent(home):
+    assert guard.stop_decision(payload(event="Stop")) == ("silent", "")
+
+
+# --------------------------------------------------------------------------- #
+# 3. THE THREE SATISFACTION ROUTES — unioned, so each is checked ALONE
+# --------------------------------------------------------------------------- #
+def test_a_handoff_doc_py_run_satisfies(home, repo):
+    sd = seed(str(repo / "claudedocs" / DOC))
+    guard.record_wrote(sd, now=AFTER_READ_EPOCH)
+    assert guard.stop_decision(payload(event="Stop")) == ("silent", "")
+
+
+def test_a_write_to_a_DIFFERENT_handoff_doc_satisfies(home, repo):
+    """🔴 TOPIC DRIFT COUNTS AS RECORDED, AND THIS IS THAT DECISION MADE MECHANICAL.
+    25 of the 253 measured sessions resumed doc X and wrote doc Y; the measurement
+    scored every one RECORDED, because the work IS on disk. A guard keyed to the path
+    would block 25 sessions for doing exactly the right thing."""
+    sd = seed(str(repo / "claudedocs" / DOC))
+    other = str(repo / "claudedocs" / "handoff-clawgatectl-agent-delivery.md")
+    assert guard.is_handoff_write(
+        payload(tool_name="Write", tool_input={"file_path": other})) is True
+    guard.post_tool_use(
+        payload(tool_name="Write", tool_input={"file_path": other}),
+        now=AFTER_READ_EPOCH)
+    assert guard.stop_decision(payload(event="Stop")) == ("silent", "")
+    assert sd  # the state dir is the one the verdict was read from
+
+
+def test_the_docs_own_mtime_satisfies_even_with_no_observation(home, repo):
+    """The route that catches a write this process never SAW — another tool, another
+    process, a `/handoff` in a session that reloaded. Without it the guard would be a
+    record of what one hook happened to observe rather than a measurement."""
+    doc = repo / "claudedocs" / DOC
+    doc.write_text("x")
+    os.utime(doc, (AFTER_READ_EPOCH, AFTER_READ_EPOCH))
+    seed(str(doc))
+    assert guard.stop_decision(payload(event="Stop")) == ("silent", "")
+
+
+def test_an_mtime_BEFORE_the_read_does_not_satisfy(home, repo):
+    """The negative control for the route above: a doc that exists and is merely OLD
+    must not read as written. Without this, `getmtime` returning any number at all
+    would satisfy and the whole route would be inert-but-green."""
+    doc = repo / "claudedocs" / DOC
+    doc.write_text("x")
+    os.utime(doc, (BEFORE_READ_EPOCH, BEFORE_READ_EPOCH))
+    seed(str(doc))
+    kind, text = guard.stop_decision(payload(event="Stop"))
+    assert kind == "block" and DOC in text
+
+
+def test_a_wrote_stamp_BEFORE_the_read_does_not_satisfy(home, repo):
+    """The same boundary on the observation route: a handoff written for a PREVIOUS
+    doc, before this one was resumed, is not this doc's record."""
+    sd = seed(str(repo / "claudedocs" / DOC))
+    guard.record_wrote(sd, now=BEFORE_READ_EPOCH)
+    assert guard.stop_decision(payload(event="Stop"))[0] == "block"
+
+
+def test_a_write_in_the_SAME_tool_call_as_the_read_satisfies(home, repo):
+    """🔴 `>=`, not `>`. One Bash call can be both a read and a write
+    (`git show …:claudedocs/x.md && python3 …/handoff_doc.py …`) and `post_tool_use`
+    stamps both from the SAME `now`, so an equal pair is a write ON that read."""
+    doc = str(repo / "claudedocs" / DOC)
+    sd = seed(doc, ts=guard.now_iso(READ_EPOCH))
+    guard.record_wrote(sd, now=READ_EPOCH)
+    assert guard.stop_decision(payload(event="Stop")) == ("silent", "")
+
+
+def test_the_missing_case_blocks_and_names_the_doc_and_the_escape(home, repo):
+    seed(str(repo / "claudedocs" / DOC))
+    kind, text = guard.stop_decision(payload(event="Stop"))
+    assert kind == "block"
+    assert DOC in text
+    assert "/handoff" in text
+    assert guard.HANDOFF_TOOL in text
+    # 🔴 The escape must arrive with the session id ALREADY FILLED IN. The precedent
+    # measured that an escape the caller has to look something up for is not used.
+    assert ("--dismiss %s --session %s" % (guard.doc_key(DOC), SESSION)) in text
+
+
+# --------------------------------------------------------------------------- #
+# 4. THE LADDER
+# --------------------------------------------------------------------------- #
+def test_the_ladder_moves_block_block_notice_silent(home, repo, capsys):
+    """🔴 DRIVEN FROM 0 WITH THE DECISION WATCHED TO MOVE, and every rung's
+    non-blockingness asserted on the EMITTED JSON rather than on the kind string.
+    Neither the seed (0) nor the assertions mention 2 or 3, so a fixture cannot pass by
+    equalling the constant it is testing."""
+    seed(str(repo / "claudedocs" / DOC))
+    stop = payload(event="Stop")
+    rungs = []
+    for _ in range(5):
+        verdict = guard.stop_decision(stop)
+        rungs.append(verdict[0])
+        out = emitted(capsys, verdict)
+        if verdict[0] == "block":
+            assert forces_a_continuation(out) is True
+        else:
+            assert forces_a_continuation(out) is False
+    assert rungs == ["block", "block", "notice", "silent", "silent"]
+
+
+def test_a_counter_seeded_high_is_already_silent(home, repo):
+    """Seeded at NINE — a literal neither MAX_BLOCKS nor MAX_FIRES can equal — so the
+    ladder's ceiling is checked without the fixture producing the constant."""
+    sd = seed(str(repo / "claudedocs" / DOC))
+    with open(guard._fires_path(sd, guard.doc_key(DOC)), "w") as fh:
+        fh.write("9")
+    assert guard.stop_decision(payload(event="Stop")) == ("silent", "")
+
+
+def test_escalate_is_a_pure_function_of_the_fire_number():
+    assert [guard.escalate(n) for n in (1, 2, 3, 4, 9)] == [
+        "block", "block", "notice", "silent", "silent"]
+
+
+# --------------------------------------------------------------------------- #
+# 5. CANNOT-MEASURE IS A NOTICE, NEVER A BLOCK
+# --------------------------------------------------------------------------- #
+def test_an_unreadable_read_stamp_is_a_notice_and_never_blocks(home, repo, capsys):
+    """🔴 THE EMPTY-RESULT TRAP. A truncated read stamp leaves no anchor; going silent
+    would report the same observable as a session that wrote its handoff. It reports —
+    and it may not spend the BLOCK budget, so it is driven up its own ladder and every
+    rung is checked against the emitted JSON."""
+    sd = seed(str(repo / "claudedocs" / DOC), ts="not-a-timestamp")
+    stop = payload(event="Stop")
+    kinds = []
+    for _ in range(4):
+        verdict = guard.stop_decision(stop)
+        kinds.append(verdict[0])
+        assert forces_a_continuation(emitted(capsys, verdict)) is False
+    assert kinds == ["notice", "notice", "notice", "silent"]
+    # …and on its OWN counter, so an unmeasurable early Stop cannot spend the budget a
+    # measured miss needs later in the same session.
+    assert os.path.exists(guard._fires_path(sd, guard.doc_key(DOC), "unknown"))
+    assert not os.path.exists(guard._fires_path(sd, guard.doc_key(DOC)))
+
+
+def test_a_notice_alone_never_forces_a_continuation(home, repo, capsys):
+    verdict = ("notice", "hello")
+    assert forces_a_continuation(emitted(capsys, verdict)) is False
+
+
+def test_silent_writes_nothing_at_all(home, capsys):
+    assert emitted(capsys, ("silent", "anything")) is None
+
+
+# --------------------------------------------------------------------------- #
+# 6. Stop-event scoping
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("kw", [
+    {"event": "SubagentStop"},
+    {"event": "Stop", "agent_id": "agt-1"},
+    {"event": "PostToolUse"},
+])
+def test_these_stop_shaped_payloads_are_refused(home, repo, kw):
+    """A subagent's turn never reaches the operator, so it owes them nothing — and a
+    non-Stop event is simply not this function's."""
+    seed(str(repo / "claudedocs" / DOC))
+    assert guard.stop_decision(payload(**kw)) == ("silent", "")
+
+
+# --------------------------------------------------------------------------- #
+# 7. MAX_DOCS, enforced at the WRITER
+# --------------------------------------------------------------------------- #
+def test_at_most_three_docs_are_tracked_per_session(home, repo):
+    """Driven with FIVE docs — a literal MAX_DOCS cannot equal — and asserted on
+    `tracked_docs`, i.e. on what the Stop gate can actually see."""
+    sd = state_dir()
+    for i in range(5):
+        guard.record_read(sd, str(repo / "claudedocs" / ("handoff-%d.md" % i)))
+    assert len(guard.tracked_docs(sd)) == guard.MAX_DOCS
+    assert guard.MAX_DOCS == 3
+
+
+def test_the_key_is_the_basename_so_one_doc_read_three_ways_books_one_slot(home, repo):
+    """🔴 Keying on the SPELLING would book three entries for one document, spend every
+    tracking slot, and emit three blocks naming the same file.
+
+    🔴 THE THREE SPELLINGS ARE PAIRWISE DISTINCT AS STRINGS, AND THAT IS THE WHOLE
+    TEST. A first version used three spellings that normalise to the same string, so
+    the fixture could only ever produce one value and a mutant keying on the FULL PATH
+    survived a green assertion — the exact "fixture can only produce the constant's own
+    value" shape RULES.md names. These three are the ones a real session produces:
+    the base clone's copy, the throwaway worktree's copy that `/handoff` actually
+    writes, and a `..`-bearing spelling out of a relative resolution.
+    """
+    sd = state_dir()
+    spellings = [
+        str(repo / "claudedocs" / DOC),
+        "/tmp/wt-handoff-1234/claudedocs/" + DOC,
+        str(repo / "claudedocs" / "sub" / ".." / DOC),
+    ]
+    assert len(set(spellings)) == 3          # the fixture CAN move; the key must not
+    for spelling in spellings:
+        guard.record_read(sd, spelling)
+    assert len(guard.tracked_docs(sd)) == 1
+    assert list(guard.tracked_docs(sd)) == [guard.doc_key(DOC)]
+
+
+def test_a_re_read_never_moves_the_first_read_timestamp(home, repo):
+    sd = state_dir()
+    doc = str(repo / "claudedocs" / DOC)
+    guard.record_read(sd, doc, now=READ_EPOCH)
+    assert guard.record_read(sd, doc, now=AFTER_READ_EPOCH) is False
+    assert guard.tracked_docs(sd)[guard.doc_key(DOC)]["first_read_ts"] == \
+        guard.now_iso(READ_EPOCH)
+
+
+# --------------------------------------------------------------------------- #
+# 8. --dismiss, INCLUDING the re-read that broke the precedent twice
+# --------------------------------------------------------------------------- #
+def test_dismiss_silences_the_guard(home, repo):
+    seed(str(repo / "claudedocs" / DOC))
+    guard.dismiss_main(["--dismiss", DOC, "--session", SESSION])
+    assert guard.stop_decision(payload(event="Stop")) == ("silent", "")
+
+
+def test_dismiss_SURVIVES_a_later_read_of_the_same_doc(home, repo):
+    """🔴 THE REGRESSION THAT SHIPPED PAST THREE AUDIT ROUNDS OF THE PRECEDENT, because
+    every test drove `--dismiss` and then asserted silence and none re-read the thing
+    afterwards. Clearing the ledger alone restores the session to its PRE-READ state,
+    so the next read re-arms the guard — and the natural way to confirm a dismissal
+    took is to look at the doc, which IS a read. The tombstone is what makes the
+    promise true, and this is the case that can see it."""
+    doc = str(repo / "claudedocs" / DOC)
+    seed(doc)
+    guard.dismiss_main(["--dismiss", DOC, "--session", SESSION])
+    guard.post_tool_use(read_tool(doc))          # <- the confirming re-read
+    assert guard.tracked_docs(state_dir()) == {}
+    assert guard.stop_decision(payload(event="Stop")) == ("silent", "")
+
+
+def test_dismiss_is_scoped_to_ONE_session(home, repo):
+    """A NEW session starts fresh, which is the escape from a dismissal and is exactly
+    what the report promises."""
+    doc = str(repo / "claudedocs" / DOC)
+    seed(doc)
+    seed(doc, session="sess-other")
+    guard.dismiss_main(["--dismiss", DOC, "--session", SESSION])
+    assert guard.stop_decision(payload(event="Stop")) == ("silent", "")
+    assert guard.stop_decision(payload(event="Stop",
+                                       session_id="sess-other"))[0] == "block"
+
+
+def test_dismiss_is_scoped_to_ONE_doc(home, repo):
+    sd = state_dir()
+    for name in (DOC, "handoff-other.md"):
+        guard.record_read(sd, str(repo / "claudedocs" / name), now=READ_EPOCH)
+    guard.record_work(sd, now=WORK_EPOCH)
+    guard.dismiss_main(["--dismiss", DOC, "--session", SESSION])
+    kind, text = guard.stop_decision(payload(event="Stop"))
+    assert kind == "block"
+    assert "handoff-other.md" in text and DOC not in text
+
+
+def test_the_dismiss_report_is_pinned_as_a_WHOLE_string(home, repo):
+    """🔴 A two-word check on this text would be satisfied by its own static prefix.
+    The sentence is a claim about the state of the world, so it is pinned whole."""
+    k = guard.doc_key(DOC)
+    assert guard.dismiss_report(k, SESSION, ["read-" + k], True, ()) == (
+        "handoff write-back guard: dismissed `%s` for session %s (cleared read-%s). "
+        "It will not ask about `%s` again in session %s, even if the doc is read "
+        "again — a NEW session starts fresh." % (k, SESSION, k, k, SESSION))
+
+
+def test_the_residue_branch_owns_BOTH_halves_of_the_sentence(home, repo):
+    """🔴 `removed` is empty both when there was nothing to remove AND when the removal
+    FAILED. The precedent printed `nothing to dismiss` over a ledger entry that was
+    sitting on disk. Pairing a head that says nothing happened with a promise the state
+    cannot keep is the defect; one branch owning both clauses is the fix."""
+    k = guard.doc_key(DOC)
+    out = guard.dismiss_report(k, SESSION, [], True, ["read-" + k])
+    assert "could NOT clear" in out and "nothing was dismissed" in out
+    assert "will still ask" in out
+    assert "It will not ask" not in out
+
+
+def test_the_dismissal_is_recorded_in_an_audit_log_outside_the_swept_root(home, repo):
+    """🔴 `--dismiss` IS A REAL BYPASS of a deterministic guard. In a hook whose premise
+    is that prose lost 19 sessions of 22, gating the bypass on prose and not measuring
+    it is the same mistake one level up. The log is also OUTSIDE the per-session root,
+    so a session ageing out cannot take the record of its dismissals with it."""
+    seed(str(repo / "claudedocs" / DOC))
+    guard.dismiss_main(["--dismiss", DOC, "--session", SESSION])
+    path = guard._dismissals_path()
+    assert not path.startswith(guard._state_root())
+    rows = [json.loads(ln) for ln in open(path) if ln.strip()]
+    assert rows[-1]["doc_key"] == guard.doc_key(DOC)
+    assert rows[-1]["session"] == SESSION
+    # A NO-OP dismissal records too, so repeat attempts are visible rather than
+    # silently identical to a first one.
+    guard.dismiss_main(["--dismiss", DOC, "--session", SESSION])
+    assert len([ln for ln in open(path) if ln.strip()]) == 2
+
+
+def test_dismiss_never_reads_stdin_and_needs_both_flags(home):
+    """The CLI mode is decided BEFORE any stdin read: a `--dismiss` invocation comes
+    from a Bash tool call, where reading stdin would hang on a terminal forever."""
+    p = run_hook(None, argv=["--dismiss", DOC])
+    assert p.returncode == 0
+    assert p.stdout.startswith("usage: handoff-write-guard.py --dismiss")
+
+
+def test_a_dots_only_key_cannot_traverse_out_of_the_session_dir(home):
+    """🔴 The allowed character set includes `.`, so it must exclude the all-dots
+    components — otherwise `--dismiss ..` resolves to the state ROOT rather than to a
+    file inside a session dir."""
+    assert "/" not in guard.doc_key("..")
+    assert set(guard.doc_key("..")) == {"_"}
+    assert guard.doc_key("../../etc/passwd") == "passwd"
+
+
+# --------------------------------------------------------------------------- #
+# 9. THE HOT PATH — counted, not asserted from a comment
+# --------------------------------------------------------------------------- #
+def test_the_fast_path_does_exactly_one_stat_and_nothing_else(home, monkeypatch):
+    """PostToolUse fires after EVERY tool call of every session. A session that has
+    never read a handoff and is not reading one now must do one `exists` and stop."""
+    calls = {"exists": 0, "listdir": 0, "makedirs": 0, "open": 0}
+    real_exists, real_listdir = os.path.exists, os.listdir
+    real_makedirs, real_open = os.makedirs, open
+    monkeypatch.setattr(os.path, "exists",
+                        lambda p: (calls.__setitem__("exists", calls["exists"] + 1),
+                                   real_exists(p))[1])
+    monkeypatch.setattr(os, "listdir",
+                        lambda p: (calls.__setitem__("listdir", calls["listdir"] + 1),
+                                   real_listdir(p))[1])
+    monkeypatch.setattr(os, "makedirs",
+                        lambda *a, **k: (calls.__setitem__("makedirs",
+                                                           calls["makedirs"] + 1),
+                                         real_makedirs(*a, **k))[1])
+    monkeypatch.setattr(guard, "open",
+                        lambda *a, **k: (calls.__setitem__("open", calls["open"] + 1),
+                                         real_open(*a, **k))[1], raising=False)
+    out = guard.post_tool_use(bash("git status -s"))
+    assert out["fast_path"] is True
+    assert calls == {"exists": 1, "listdir": 0, "makedirs": 0, "open": 0}
+
+
+def test_a_subagent_call_skips_the_arming_regex_entirely(home, monkeypatch):
+    """The subagent path stays one `exists` and no `re` work: a subagent's payload
+    never contributes docs, so consulting the pattern for it would be pure cost."""
+    seen = []
+
+    class _Spy:
+        def findall(self, s):
+            seen.append(s)
+            return []
+
+    monkeypatch.setattr(guard, "HANDOFF_PATH_RX", _Spy())
+    guard.post_tool_use(bash("cat claudedocs/%s" % DOC, agent_id="agt-1"))
+    assert seen == []
+    # POSITIVE CONTROL: the spy CAN see a call, so the empty above is a measurement
+    # and not a probe wired to nothing.
+    guard.post_tool_use(bash("cat claudedocs/%s" % DOC))
+    assert len(seen) == 1
+
+
+def test_the_hook_spawns_no_subprocess_on_any_path(home, repo):
+    """🔴 A CLAIM ABOUT THE MODULE, PINNED STRUCTURALLY. Unlike its precedent this hook
+    never needs one — condition 3 is a stat and two file reads — and `subprocess` is
+    the single most expensive import a per-tool-call hook can take (3.4 ms, measured on
+    the precedent). Pinned by source rather than by a comment, so re-adding it is a
+    visible decision."""
+    src = open(HOOK).read()
+    body = [ln for ln in src.splitlines() if not ln.lstrip().startswith("#")]
+    assert not any("import subprocess" in ln for ln in body)
+    # POSITIVE CONTROL: the scan CAN see an import in this file.
+    assert any(ln.strip() == "import json" for ln in body)
+
+
+def test_shutil_is_deferred_off_the_hot_path(home):
+    """`shutil` is reachable only from `prune`'s removal branch. A module-level import
+    would be paid by every tool call of every session."""
+    assert guard.shutil is None or "shutil" in sys.modules
+    src = open(HOOK).read()
+    top = src.split("def _sh(")[0]
+    assert "\nimport shutil" not in top
+
+
+# --------------------------------------------------------------------------- #
+# 10. FAIL-OPEN — the whole contract, through a REAL process
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("stdin", [
+    "", "not json", "null", "[]", '{"hook_event_name":"Stop"}',
+    '{"hook_event_name":"Stop","session_id":123}',
+    '{"hook_event_name":"PostToolUse","session_id":"s","tool_input":null}',
+    '{"hook_event_name":"Nonsense"}',
+])
+def test_every_malformed_input_exits_0_with_empty_stdout(home, stdin):
+    p = subprocess.run([sys.executable, HOOK], input=stdin, capture_output=True,
+                       text=True, env={**os.environ, "HOME": str(home)}, timeout=60)
+    assert p.returncode == 0
+    assert p.stdout == ""
+
+
+def test_an_unwritable_state_root_never_blocks(home, repo, monkeypatch):
+    """A guard that raises is felt at the exact moment a session is trying to end."""
+    sd = seed(str(repo / "claudedocs" / DOC))
+
+    def boom(*a, **k):
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(os, "makedirs", boom)
+    kind, _ = guard.stop_decision(payload(event="Stop"))
+    # It may still report (the ledger is already on disk) but must never raise.
+    assert kind in ("block", "notice", "silent")
+    assert sd
+
+
+def test_the_real_process_blocks_end_to_end(home, repo):
+    """🔴 THE ONE END-TO-END CASE. Every other assertion here is in-process; this drives
+    the actual script over stdin and reads the JSON the CLI would read, so the emit
+    contract is checked as a whole rather than by its parts."""
+    seed(str(repo / "claudedocs" / DOC))
+    p = run_hook(payload(event="Stop"), env={"HOME": str(home)})
+    assert p.returncode == 0
+    out = json.loads(p.stdout)
+    assert out["decision"] == "block" and DOC in out["reason"]
+    assert forces_a_continuation(out) is True
+
+
+# --------------------------------------------------------------------------- #
+# 11. prune
+# --------------------------------------------------------------------------- #
+def test_prune_drops_only_state_older_than_the_ttl(home):
+    root = guard._state_root()
+    os.makedirs(os.path.join(root, "old"))
+    os.makedirs(os.path.join(root, "new"))
+    now = 2_000_000_000.0
+    os.utime(os.path.join(root, "old"), (now - guard.STATE_TTL_SECS - 60,) * 2)
+    os.utime(os.path.join(root, "new"), (now - 60,) * 2)
+    assert guard.prune(now=now) == ["old"]
+    assert sorted(os.listdir(root)) == ["new"]
+
+
+# --------------------------------------------------------------------------- #
+# 12. THE ANTI-DRIFT LEDGER for the declared copy
+# --------------------------------------------------------------------------- #
+def test_the_work_detection_is_byte_identical_to_the_precedent():
+    """🔴 THE COPY IS DECLARED, SO IT IS PINNED. `claude/RULES.md` says one rule, one
+    place — and the alternative here (a shared hook module) would add an import to a
+    BLOCKING hook's per-tool-call fast path, whose owners measured its cost across
+    several audit rounds. What that rule is actually about is silent DRIFT between
+    copies, and this closes exactly that: it fails when EITHER file's copy moves, so
+    the two can only change together.
+
+    Compared as SOURCE LINES rather than by importing the precedent, because importing
+    it would execute its module body inside this suite for no benefit.
+    """
+    names = ("_CMD_START", "WORK_BASH_PAT", "QUOTED_PLACEHOLDER", "QUOTED_PAT",
+             "COMMENT_PAT")
+
+    def block(path):
+        src = open(path).read().splitlines()
+        out, taking = {}, None
+        for ln in src:
+            for n in names:
+                if ln.startswith(n + " = "):
+                    taking = n
+                    out[taking] = []
+            if taking is not None:
+                out[taking].append(ln.rstrip())
+                if ln.rstrip().endswith(")") or (
+                        ln.startswith(taking + " = ") and not ln.rstrip().endswith("(")):
+                    if ln.count("(") <= ln.count(")"):
+                        taking = None
+        return out
+
+    mine, theirs = block(HOOK), block(PRECEDENT)
+    assert set(mine) == set(names), sorted(set(names) - set(mine))
+    assert mine == theirs, "the work-detection copy has drifted from its precedent"
+
+
+def test_is_work_agrees_with_the_precedent_on_the_shapes_that_matter():
+    """A behavioural companion to the byte pin above: a structural check type-checks
+    past a wrong argument, so the predicate is also exercised on the shapes the
+    precedent's own measurements named."""
+    assert guard.is_work(bash('git -C "$DEVRC" commit -m "msg"')) is True
+    assert guard.is_work(bash("git -C /lit push")) is True
+    assert guard.is_work(bash("gh pr create --fill")) is True
+    assert guard.is_work(payload(tool_name="Edit",
+                                 tool_input={"file_path": "/a/b.py"})) is True
+    assert guard.is_work(bash("echo remember to git commit later")) is False
+    assert guard.is_work(bash("grep -rn 'git commit' scripts/")) is False
+    assert guard.is_work(bash("git log --oneline -3")) is False
+    assert guard.is_work(bash("git status  # git push later")) is False
+
+
+# --------------------------------------------------------------------------- #
+# 13. THE DELIVERY SEAM — a hook that ships unregistered sits INERT
+# --------------------------------------------------------------------------- #
+def test_home_nix_deploys_this_hook():
+    """#452's lesson: a hook can ship to both hosts, report a successful switch, and do
+    nothing, with no signal anywhere. Every component tested, the seam owned by nobody."""
+    assert 'home.file.".claude/hooks/handoff-write-guard.py"' in HOME_NIX.read_text()
+
+
+def test_the_registrar_registers_it_on_PostToolUse_and_Stop_and_nowhere_else():
+    src = REGISTRAR.read_text()
+    assert '"~/.claude/hooks/handoff-write-guard.py"' in src
+    assert '"handoff-write-guard.py",' in src          # MANAGED_HOOK_SCRIPTS
+    # The event table, read as a literal so a rename of either event is visible.
+    line = [ln for ln in src.splitlines()
+            if ln.startswith("HANDOFF_GUARD_EVENTS")]
+    assert line, "no HANDOFF_GUARD_EVENTS table in the registrar"
+    assert line[0].split("=", 1)[1].strip() == '["PostToolUse", "Stop"]'
+
+
+def test_the_block_text_points_at_a_flow_that_exists():
+    """A block message is an instruction to a place; a dead pointer is worse than none."""
+    assert (ROOT / guard.HANDOFF_TOOL).is_file()
+    assert (ROOT / "claude" / "skills" / "handoff" / "SKILL.md").is_file()
+
+
+if __name__ == "__main__":                                  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/scripts/claude-hooks/tests/test_on_disk_artifact_names.py
+++ b/scripts/claude-hooks/tests/test_on_disk_artifact_names.py
@@ -110,6 +110,11 @@ LIB = os.path.join(ROOT, "scripts", "lib")
 # and from every task id the other suites use (193, 200, 201).
 TASK_A = 307
 TASK_B = 911
+# Fixture handoff docs for the handoff-write guard. Basenames sharing no letter after
+# the mandatory `handoff-` prefix, so a truncating or transposing mutant cannot turn
+# one into the other — the same discipline as the task ids above.
+DOC_A = "/repo/claudedocs/handoff-alpha.md"
+DOC_B = "/repo/claudedocs/handoff-zulu.md"
 SESSION = "sess-on-disk-a1"
 AGENT = "agent-on-disk-b2"
 
@@ -331,6 +336,76 @@ def test_the_read_write_is_still_ATOMIC_via_a_temp_file(home):
 
 
 # --------------------------------------------------------------------------- #
+# 2b. handoff-write-guard.py — the same name-set, on its own cache root
+# --------------------------------------------------------------------------- #
+def test_the_handoff_write_guard_writes_EXACTLY_these_paths(home):
+    """🔴 The whole tree, as literals — the same assertion shape as the write-back
+    guard's above, and for the same reason: `.cache`, `claude-handoff-write`, `s`,
+    `work`, `wrote` and `dismissals` are all names a rename could move with a green
+    suite behind it.
+
+    `wrote` is the one this hook adds over its precedent, and it is the load-bearing
+    one: it is the session-level record that a handoff WAS written, so a rename of it
+    makes every session look un-recorded and the guard blocks turns that did nothing
+    wrong. `work` and `wrote` differ in one letter and sort adjacently, which is
+    exactly the pair a transposing mutant would swap — so both are here.
+    """
+    guard = load(os.path.join(HOOKS, "handoff-write-guard.py"), "hwguard_names")
+    sd = guard._state_dir({"session_id": SESSION})
+
+    guard.record_read(sd, DOC_A, now=1787227200.0)
+    guard.record_work(sd, now=1787229000.0)
+    guard.record_wrote(sd, now=1787230800.0)
+    guard.bump_fires(sd, guard.doc_key(DOC_A))                  # the MEASURED counter
+    guard.bump_fires(sd, guard.doc_key(DOC_A), "unknown")       # the CANNOT-MEASURE one
+    guard.write_dismissal_tombstone(sd, guard.doc_key(DOC_B), now=1787229000.0)
+    guard.record_dismissal(guard.doc_key(DOC_B), SESSION, [], now=1787229000.0)
+
+    root = ".cache/claude-handoff-write"
+    a, b = guard.doc_key(DOC_A), guard.doc_key(DOC_B)
+    assert paths_under(home) == sorted([
+        "%s/dismissals" % root,
+        "%s/s/%s/dismissed-%s" % (root, SESSION, b),
+        "%s/s/%s/fires-%s" % (root, SESSION, a),
+        "%s/s/%s/read-%s" % (root, SESSION, a),
+        "%s/s/%s/unknown-%s" % (root, SESSION, a),
+        "%s/s/%s/work" % (root, SESSION),
+        "%s/s/%s/wrote" % (root, SESSION),
+    ])
+
+
+def test_the_handoff_guards_doc_key_is_in_the_NAME_not_only_in_the_body(home):
+    """The positive control for the assertion above: it must be able to MOVE.
+
+    A single-doc fixture could be satisfied by a writer that hardcodes that name, so
+    two docs are driven through the same writers and the trees compared. `alpha` and
+    `zulu` share no letter, so a mutant that truncates or transposes cannot produce
+    one from the other.
+    """
+    guard = load(os.path.join(HOOKS, "handoff-write-guard.py"), "hwguard_names_2")
+    sd = guard._state_dir({"session_id": SESSION})
+    guard.record_read(sd, DOC_A, now=1787227200.0)
+    guard.record_read(sd, DOC_B, now=1787227200.0)
+    names = sorted(n for n in os.listdir(sd) if n.startswith("read-"))
+    assert names == sorted(["read-" + guard.doc_key(DOC_A),
+                            "read-" + guard.doc_key(DOC_B)])
+    assert names[0] != names[1]
+
+
+def test_the_handoff_guards_cache_root_is_its_OWN(home):
+    """🔴 The two guards must not share a root. They have independent ladders and
+    independent TTL sweeps, and a shared root would let one hook's `prune` remove the
+    other's live ledger mid-session — silently, since both fail open."""
+    hw = load(os.path.join(HOOKS, "handoff-write-guard.py"), "hwguard_root")
+    wb = load(os.path.join(HOOKS, "clawgate-writeback-guard.py"), "wbguard_root")
+    assert hw._state_root() != wb._state_root()
+    assert hw._state_root() == os.path.join(
+        str(home), ".cache", "claude-handoff-write", "s")
+    assert hw._dismissals_path() == os.path.join(
+        str(home), ".cache", "claude-handoff-write", "dismissals")
+
+
+# --------------------------------------------------------------------------- #
 # 3. next-step-nudge.py — four unpinned names
 # --------------------------------------------------------------------------- #
 def test_the_next_step_nudge_writes_EXACTLY_this_path(home):
@@ -513,6 +588,7 @@ def test_the_ledger_directory_is_this_exact_path_under_HOME(home):
 # path assertion above is caught by the corroboration in the same test.
 PINNED_HERE = {
     "clawgate-writeback-guard.py",
+    "handoff-write-guard.py",
     "next-step-nudge.py",
     "shell-env-nudge.py",
     "search-tool-nudge.py",

--- a/scripts/claude-hooks/tests/test_register_nudge_hook.py
+++ b/scripts/claude-hooks/tests/test_register_nudge_hook.py
@@ -124,6 +124,10 @@ TMUX_STOP = "~/.config/tmux/task-hook.sh"
 BCS = "bash ~/.claude/hooks/base-clone-staleness.sh"
 LEDGER = PY + " ~/.claude/hooks/agent-ledger-hook.py"
 WRITEBACK = PY + " ~/.claude/hooks/clawgate-writeback-guard.py"
+# The handoff write guard — the write-back guard's counterpart on the OTHER
+# record, appended after it on the same two events. It is why the whole-set
+# equalities and the "exactly N hook commands" counts below each moved by one.
+HANDOFF_GUARD = PY + " ~/.claude/hooks/handoff-write-guard.py"
 INTERVIEW = PY + " ~/.claude/hooks/clawgate-task-interview-guard.py"
 BASH_GUARD = PY + " ~/.claude/hooks/bash-guard.py"
 # The backgrounded-command capture log (ClickUp 868ktvqf9) — the SECOND entry
@@ -238,9 +242,9 @@ with tempfile.TemporaryDirectory() as tmp:
     # disturb plus the four it appends. Asserted as a SET EQUALITY, not membership
     # checks: equality fails when the set GROWS (a hook registered by accident) as
     # well as when it SHRINKS (one clobbered), which membership checks cannot see.
-    check("2: exactly the six expected Stop hooks, none clobbered, none extra",
+    check("2: exactly the seven expected Stop hooks, none clobbered, none extra",
           set(cmds(d, "Stop")) == {TMUX_STOP, CLAWGATE_STOP, NOTIFY, NEXT_STEP,
-                                   LEDGER, WRITEBACK})
+                                   LEDGER, WRITEBACK, HANDOFF_GUARD})
     check("1: next-step-nudge registered on Stop", NEXT_STEP in cmds(d, "Stop"))
     # Ordering: the two foreign hooks keep their original relative order and stay ahead
     # of everything this script appends. Appending (rather than inserting) is what makes
@@ -344,11 +348,11 @@ with tempfile.TemporaryDirectory() as tmp:
     post = cmds(d, "PostToolUse")
     WB_EXPANDED = PY + " " + home + "/.claude/hooks/clawgate-writeback-guard.py"
     SHELL_HOMEVAR = PY + " $HOME/.claude/hooks/shell-env-nudge.py"
-    check("8: PostToolUse holds exactly the three migrated hooks plus the two appended ones",
+    check("8: PostToolUse holds exactly the three migrated hooks plus the three appended ones",
           set(post) == {PY + " ~/.claude/hooks/audit-pr-nudge.py",
                         SHELL_HOMEVAR, WB_EXPANDED, SEARCH_NUDGE, LEDGER,
-                        BG_CAPTURE})
-    check("8: no hook was double-registered", len(post) == 6)
+                        BG_CAPTURE, HANDOFF_GUARD})
+    check("8: no hook was double-registered", len(post) == 7)
     check("8: the $HOME/ spelling was rewritten in place, not re-added",
           post.count(SHELL_HOMEVAR) == 1
           and PY + " ~/.claude/hooks/shell-env-nudge.py" not in post)
@@ -426,7 +430,7 @@ with tempfile.TemporaryDirectory() as tmp:
     check("3: no duplicate next-step-nudge on Stop", cmds(d2, "Stop").count(NEXT_STEP) == 1)
     check("3: Stop set unchanged by the second run",
           set(cmds(d2, "Stop")) == {TMUX_STOP, CLAWGATE_STOP, NOTIFY, NEXT_STEP,
-                                    LEDGER, WRITEBACK})
+                                    LEDGER, WRITEBACK, HANDOFF_GUARD})
     check("3: no duplicate clawgate-writeback-guard on Stop",
           cmds(d2, "Stop").count(WRITEBACK) == 1)
     check("3: no duplicate clawgate-writeback-guard on PostToolUse",
@@ -744,13 +748,14 @@ with tempfile.TemporaryDirectory() as tmp:
           entries(d12, "PostToolUse") == [
               ("Bash", AUDIT), ("Bash", SHELL), ("Bash", SEARCH_NUDGE),
               (None, LEDGER), ("Bash", LEDGER), (None, WRITEBACK),
-              ("Bash", BG_CAPTURE)])
+              ("Bash", BG_CAPTURE), (None, HANDOFF_GUARD)])
     check("12: Stop healed, keeping the first copy of each and the three survivors",
           entries(d12, "Stop") == [
               (None, TMUX_STOP), (None, CLAWGATE_STOP),
               (None, NOTIFY), (None, NEXT_STEP),
               (None, LEDGER), (None, WRITEBACK),
-              (None, NOTIFY_ARGS), (None, LEDGER), (None, WRITEBACK)])
+              (None, NOTIFY_ARGS), (None, LEDGER), (None, WRITEBACK),
+              (None, HANDOFF_GUARD)])
     # 🔴 The matchered Stop copy is GONE, and the unmatchered one is what stayed.
     # Spelled out on its own because the list equality above would also pass if
     # BOTH had been removed, or if the wrong one had survived.
@@ -917,8 +922,10 @@ for hostile, why, hostile_cwd, expected_reason in HOSTILE_OVERRIDES:
         # 18 -> 19: base-clone-staleness.sh joined SINGLE_EVENT_CMDS on
         # SessionStart, so one converged run holds one more command.
         # 19 -> 20: gh-issue-closing-condition-guard.py joined PRE_BASH_CMDS.
-        check(tag + ": three consecutive runs hold exactly 20 hook commands",
-              counts == [20, 20, 20])
+        # 20 -> 22: handoff-write-guard.py joined BOTH PostToolUse and Stop, so
+        #           one converged run holds two more commands than it did.
+        check(tag + ": three consecutive runs hold exactly 22 hook commands",
+              counts == [22, 22, 22])
         with open(settings) as f:
             d13 = json.load(f)
         written = [c for ev in d13.get("hooks", {}) for c in cmds(d13, ev)
@@ -1097,7 +1104,7 @@ with tempfile.TemporaryDirectory() as tmp:
     check("16: Stop healed to one entry per script, keeping the FIRST of each",
           entries(d16, "Stop") == [
               (None, TMUX_STOP), (None, NOTIFY), (None, NEXT_STEP),
-              ("Bash", LEDGER), ("", WRITEBACK)])
+              ("Bash", LEDGER), ("", WRITEBACK), (None, HANDOFF_GUARD)])
     check("16: exactly four Stop duplicates were removed",
           len([ln for ln in p16.stdout.splitlines() if ln.startswith("  - ")]) == 4)
     # THE CONTROL: unchanged on a matcher-supporting event.

--- a/scripts/claude-hooks/tests/test_registrar_activation.py
+++ b/scripts/claude-hooks/tests/test_registrar_activation.py
@@ -90,6 +90,7 @@ NEXT_STEP = HOOK_PY + " ~/.claude/hooks/next-step-nudge.py"
 NOTIFY = HOOK_PY + " ~/.claude/hooks/claude-notify.py"
 LEDGER = HOOK_PY + " ~/.claude/hooks/agent-ledger-hook.py"
 WRITEBACK = HOOK_PY + " ~/.claude/hooks/clawgate-writeback-guard.py"
+HANDOFF_GUARD = HOOK_PY + " ~/.claude/hooks/handoff-write-guard.py"
 INTERVIEW = HOOK_PY + " ~/.claude/hooks/clawgate-task-interview-guard.py"
 BASH_GUARD = HOOK_PY + " ~/.claude/hooks/bash-guard.py"
 BG_CAPTURE = HOOK_PY + " ~/.claude/hooks/bg-command-capture.py"
@@ -203,7 +204,7 @@ def test_it_says_what_it_did_on_stdout(tmp_path):
     assert NEXT_STEP in p.stdout, p.stdout
 
 
-def test_three_foreign_stop_hooks_come_back_as_six_originals_intact_and_in_order(tmp_path):
+def test_three_foreign_stop_hooks_come_back_as_seven_originals_intact_and_in_order(tmp_path):
     """🔴 Losing the clawgate Stop hook would silently break remote approval."""
     home = make_home(tmp_path, settings_with(THREE_FOREIGN_STOP_HOOKS))
 
@@ -214,19 +215,22 @@ def test_three_foreign_stop_hooks_come_back_as_six_originals_intact_and_in_order
     # SET equality, not membership: it fails when the set SHRINKS (one clobbered) and
     # when it GROWS (something registered by accident), which membership cannot see.
     assert set(after) == set(THREE_FOREIGN_STOP_HOOKS) | {NEXT_STEP, LEDGER,
-                                                        WRITEBACK}, after
-    assert len(after) == 6, after
+                                                        WRITEBACK,
+                                                        HANDOFF_GUARD}, after
+    assert len(after) == 7, after
     # The three originals keep their identity AND their relative order, and stay ahead
     # of the appended ones — append-only, never a rewrite.
     assert after[:3] == THREE_FOREIGN_STOP_HOOKS, after
-    # 🔴 The three appended hooks in the order the registrant adds them. Order is
+    # 🔴 The four appended hooks in the order the registrant adds them. Order is
     # load-bearing for next-step-nudge (it returns additionalContext and should
     # run after the notifiers have observed the turn) and irrelevant to the
     # ledger, which neither blocks nor prints — but it is pinned so a reordering
     # is a decision someone makes rather than a diff nobody reads. The write-back
-    # guard is the only one here that can BLOCK, and it likewise lands after every
-    # foreign owner has already seen the turn.
-    assert after[3:] == [LEDGER, WRITEBACK, NEXT_STEP], after
+    # guard and the handoff write guard are the two here that can BLOCK, and both
+    # likewise land after every foreign owner has already seen the turn — the
+    # handoff one last, so the two blocking hooks have a stable order rather than
+    # an incidental one.
+    assert after[3:] == [LEDGER, WRITEBACK, HANDOFF_GUARD, NEXT_STEP], after
 
 
 def test_unrelated_settings_content_is_untouched(tmp_path):

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -673,6 +673,18 @@ HERMETIC_TARGETS=(
   # contract and its exit-0-on-anything backstop are all gated here rather than left
   # to the ungated hand-rolled scripts beside it.
   scripts/claude-hooks/tests/test_clawgate_writeback_guard.py
+  # Same reason again — a FILE, not the directory. The handoff write guard is the
+  # write-back guard's counterpart on the OTHER record — the fourth hook here that
+  # can BLOCK, and the second that blocks at Stop; it fires on both the per-tool-call
+  # hot path and Stop. Its arming
+  # NON-matches (`ls claudedocs/`, a grep, a non-handoff `.md`, a path that resolves
+  # nowhere, a WRITE rather than a read) are the load-bearing half, and its
+  # no-work-after-read false-positive killer, its never-block-when-unmeasurable
+  # contract, its dismissal tombstone (which its precedent shipped BROKEN past three
+  # audit rounds, because every test drove the dismissal and none re-read the card
+  # afterwards) and its exit-0-on-anything backstop are all gated here rather than
+  # left to the ungated hand-rolled scripts beside it.
+  scripts/claude-hooks/tests/test_handoff_write_guard.py
   # Same reason again — a FILE, not the directory. The write-back guard's
   # counterpart at the OTHER end of a task's life: this one denies a `task create`
   # whose body carries no `## Acceptance criteria`, and — deliberately — one whose
@@ -1808,7 +1820,18 @@ TARGET_FLOORS=(
   # collected. Deliberately small — one test per module whose names it pins, plus the
   # two-sided classification guard that fails when a hook module appears or vanishes.
   #   _suggested_floor 13 = 13 - min(50, max(1, 13/20 = 0 -> 1)) = 12.
-  "scripts/claude-hooks/tests/test_on_disk_artifact_names.py|12"
+  # 2026-08-30, the handoff write guard adds three cases to that registry (its own
+  # whole-tree path pin, the doc-key positive control, and the assertion that its
+  # cache root is NOT shared with the write-back guard): 13 -> 16 collected.
+  #   _suggested_floor 16 = 16 - min(50, max(1, 16/20 = 0 -> 1)) = 15.
+  "scripts/claude-hooks/tests/test_on_disk_artifact_names.py|15"
+  # 2026-08-30, the handoff write guard arrives as a NEW target: 67 collected,
+  # 0 skipped, measured by pytest on this branch. It is the write-back guard's
+  # counterpart on the OTHER record — armed on a READ of a handoff doc, gating at
+  # Stop — and the count is dominated by the arming trigger's NON-matches and by
+  # the three satisfaction routes, each checked alone plus its negative control.
+  #   _suggested_floor 67 = 67 - min(50, max(1, 67/20 = 3)) = 64.
+  "scripts/claude-hooks/tests/test_handoff_write_guard.py|64"
   # 2026-08-21, the backgrounded-command capture log (868ktvqf9) arrives as a NEW
   # target: 80 collected, 0 skipped, measured by this gate on this branch.
   #   _suggested_floor 80 = 80 - min(50, max(1, 80/20 = 4)) = 76.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1825,13 +1825,13 @@ TARGET_FLOORS=(
   # cache root is NOT shared with the write-back guard): 13 -> 16 collected.
   #   _suggested_floor 16 = 16 - min(50, max(1, 16/20 = 0 -> 1)) = 15.
   "scripts/claude-hooks/tests/test_on_disk_artifact_names.py|15"
-  # 2026-08-30, the handoff write guard arrives as a NEW target: 67 collected,
+  # 2026-08-30, the handoff write guard arrives as a NEW target: 68 collected,
   # 0 skipped, measured by pytest on this branch. It is the write-back guard's
   # counterpart on the OTHER record — armed on a READ of a handoff doc, gating at
   # Stop — and the count is dominated by the arming trigger's NON-matches and by
   # the three satisfaction routes, each checked alone plus its negative control.
-  #   _suggested_floor 67 = 67 - min(50, max(1, 67/20 = 3)) = 64.
-  "scripts/claude-hooks/tests/test_handoff_write_guard.py|64"
+  #   _suggested_floor 68 = 68 - min(50, max(1, 68/20 = 3)) = 65.
+  "scripts/claude-hooks/tests/test_handoff_write_guard.py|65"
   # 2026-08-21, the backgrounded-command capture log (868ktvqf9) arrives as a NEW
   # target: 80 collected, 0 skipped, measured by this gate on this branch.
   #   _suggested_floor 80 = 80 - min(50, max(1, 80/20 = 4)) = 76.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1825,13 +1825,13 @@ TARGET_FLOORS=(
   # cache root is NOT shared with the write-back guard): 13 -> 16 collected.
   #   _suggested_floor 16 = 16 - min(50, max(1, 16/20 = 0 -> 1)) = 15.
   "scripts/claude-hooks/tests/test_on_disk_artifact_names.py|15"
-  # 2026-08-30, the handoff write guard arrives as a NEW target: 68 collected,
+  # 2026-08-30, the handoff write guard arrives as a NEW target: 69 collected,
   # 0 skipped, measured by pytest on this branch. It is the write-back guard's
   # counterpart on the OTHER record — armed on a READ of a handoff doc, gating at
   # Stop — and the count is dominated by the arming trigger's NON-matches and by
   # the three satisfaction routes, each checked alone plus its negative control.
-  #   _suggested_floor 68 = 68 - min(50, max(1, 68/20 = 3)) = 65.
-  "scripts/claude-hooks/tests/test_handoff_write_guard.py|65"
+  #   _suggested_floor 69 = 69 - min(50, max(1, 69/20 = 3)) = 66.
+  "scripts/claude-hooks/tests/test_handoff_write_guard.py|66"
   # 2026-08-21, the backgrounded-command capture log (868ktvqf9) arrives as a NEW
   # target: 80 collected, 0 skipped, measured by this gate on this branch.
   #   _suggested_floor 80 = 80 - min(50, max(1, 80/20 = 4)) = 76.


### PR DESCRIPTION
Rank 2 of the skill-chain-usage-audit arc (devrc#1055), and the thing rank 1 was gating.

## What the measurement says, and what it selects

Over 253 `/resume`-genesis sessions (2026-08-15..08-29, both hosts, both runtimes): **231 (91.3%) recorded their work, 22 (8.7%) did not.** Legitimate declines — the write gate correctly refusing a no-change session — were **ZERO**, so the gap is not the gate declining; it is the write never being attempted. **19 of the 22 never invoked `handoff_doc.py` at all.**

Rank 1 then split the 16 readable never-run losses by how the session ENDED:

| bucket | n | share |
|---|---|---|
| **D cleanly-ended** | **8** | 50.0% |
| B interrupted-at-end | 4 | 25.0% |
| A context-exhausted | 2 | 12.5% |
| 0 never-started | 2 | 12.5% |

The losses end **cleanly, 8-vs-2** against exhaustion. That picks a nudge at the moment the session stops over an auto-draft before compaction (which would reach 2 of 16). And `stop_hook_summary` rows are present in **8 of 8** cleanly-ended losers, 13 of 16 overall — the hook infrastructure demonstrably executes in 100% of the dominant bucket.

Prose has already lost here: `/handoff` exists, `/resume` step 6 points at it, and 19 sessions still never ran it. PRINCIPLES.md prefers a deterministic fix over prompt-tuning.

## The design

Modelled on `clawgate-writeback-guard.py`, which measures 86% write-back compliance on the board it guards. Same shape: PostToolUse watches, Stop gates.

**Armed on a `/resume` READ, never on `SessionStart`** — arming at session start fires on every session that never touched a handoff. The act that defines the measured population is the read of a specific doc, so that is the trigger: a `Read` of `claudedocs/handoff-*.md` (or `*HANDOFF*.md`, which is what `/resume`'s own fallback resolves), or the `git show <ref>:claudedocs/…` form these repos use for a doc on an unmerged branch.

**Three conditions, all required:** the read; REAL WORK after it (Edit/Write/NotebookEdit, or `git commit`/`git push`/`gh pr create|merge` in command position); and no observable handoff write since that read.

**Three satisfaction routes, unioned**, so it self-suppresses however the doc got written: a `handoff_doc.py` run, a Write/Edit of any handoff doc, or the resumed doc's own mtime. Two of the three are **session-level on purpose** — 25 of the 253 sessions resumed doc X and wrote doc Y, and the measurement scored every one of them RECORDED, so a guard keyed to the path would block 25 sessions for doing exactly the right thing.

Ladder: `block, block, systemMessage, silent`, per doc, MAX_DOCS 3 — strictly cheaper than the precedent's worst case. `--dismiss` is a real mechanism with a tombstone, not a sentence. Fail-open throughout; one exit, always 0.

### Two deliberate divergences from the precedent, both named in the docstring

1. **The satisfaction anchor is each doc's FIRST READ, not the last work event.** The clawgate guard must anchor on work because its pickup ritual posts a "Starting" comment *before* the work. There is no pre-work handoff ritual — `/handoff` runs at the end — so a read anchor has no degenerate case, and a work anchor would import a false-positive class this record does not have (write the doc → commit → push → blocked). The cost is stated: a session that writes its handoff early and then works for hours without updating it scores as recorded. That is what the measurement scored too.
2. **It spawns NO subprocess on any path.** Condition 3 is a stat and two file reads, so there is nothing to spawn — unlike the precedent, whose condition 3 is a live board read.

## Verification

- **69 new tests** + 3 added to the on-disk artifact-name registry; the whole `scripts/claude-hooks/tests/` tree is green (2922 → passes).
- **29-mutant sweep, 29/29 killed**, each required to die on its **own named test** rather than to a neighbour, plus a positive control proving the harness can go red. The sweep ships as `claudedocs/handoff-write-guard-mutation-sweep.py` rather than living in a scratchpad — the arc's own recorded lesson is that a quoted number needs its script in the repo.
- **End-to-end, as a real process, over the measured loss shape**: `git show` a handoff on a branch → Edit → commit+push → Stop **blocks**; then `handoff_doc.py` runs and the next Stop is **silent**. Read-with-no-work is silent and bumps no counter. A session that never touched a handoff leaves nothing on disk at all.
- **The dismissal was verified by RE-READING the doc afterwards** — the act that broke the precedent's `--dismiss` twice in production and survived three of its audit rounds, because every test there drove the dismissal and none re-read the card.
- **Two self-audit rounds, each on the previous round's delta**; round 3 found nothing, which ends the ladder. Round 2's finding was real: a relative `Read` `file_path` resolved against no base and armed **nothing** — a silent blind spot.

## Delivery seam

`nix/home.nix` deploys it and `register-nudge-hook.py` registers it on PostToolUse (no matcher) + Stop, both pinned two-way by the existing tests — #452's lesson is a hook that ships to both hosts, reports a successful switch, and sits inert.

🔴 **NOT deployed.** It needs a `home-manager switch`, which is the operator's call, and the guard cannot be claimed to work on this host until that has happened.

## Known blind spots (in the docstring, not only here)

The 2 never-started sessions produced zero turns, so no hook could reach them — this addresses at most 14 of 16, not 16. A read only inside a subagent does not arm. Two docs read, only one written back, is silent for the other — the deliberate side of counting drift as recorded. It checks that a handoff exists since the read, never whether it is any good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NheJsXreNq6GDmKpcQiW6
