### PR TITLE
docs(tekton): two ADMISSION-class causes of a red devrc-ci check that are NOT your diff

### DIFF
--- a/claude/skills/tekton/SKILL.md
+++ b/claude/skills/tekton/SKILL.md
@@ -247,6 +247,27 @@ debugging, changing or copying a specific pipeline.
     EventListener log is what discriminates: `kubectl -n tekton-ci logs -l eventlistener --since=15m`
     shows `"/trigger":"<name>"` and `ResolvedParams` for an event that DID match.
 
+6. **A gate pod rejected at ADMISSION posts a FAILED TEST, so it reads as a bad change.**
+   Two ways this has bitten, both on `devrc-ci`, both 2026-08-29/30:
+   **(a) PodSecurity.** `tekton-ci` carried no `pod-security.kubernetes.io/*` label, so it
+   inherited the cluster default `baseline`, which forbids **hostPath** outright. When
+   `6bec075e` swapped the gate's RWO PVC for a per-node hostPath nix cache, every gate pod
+   died with `pods "devrc-ci-<id>-gate-pod" is forbidden: violates PodSecurity
+   "baseline:latest": hostPath volumes (volume "nix-cache")`. Admission failure does **not**
+   retry into success — the pod is never created, the `gate` TaskRun reads
+   `PodAdmissionFailed` while `notify`/`report` succeed, and both required checks post
+   `COULD NOT RUN`, so with `enforce_admins: true` **nothing could merge**. Fixed by
+   `pod-security.kubernetes.io/enforce: privileged` on the namespace (`686d6ff0`).
+   ⚠ That is a **broader** grant than the 7 infra namespaces already carrying it — this one
+   runs webhook-triggered CI. The narrow fix is a baseline-compatible cache.
+   **(b) `sandbox = false` in the CI pod.** The `nix build .#checks…` tier is only hermetic
+   where nix's sandbox is ON. With it off, the *same derivation hash* produced `failed=1` on
+   the dev host and `failed=43` in CI — identical inputs, different output, i.e. impure.
+   🔴 **Before debugging any diff against a red `devrc-ci` run, check both:**
+   `kubectl get taskrun <run>-gate -n tekton-ci -o jsonpath='{.status.conditions[*].message}'`
+   and `kubectl exec -n tekton-ci <gate-pod> -c step-pytests -- sh -c 'nix config show | grep "^sandbox "'`.
+   A red check whose cause is either of these is a **broken gate, not a bad change**.
+
 ## What / where
 
 - **Tekton Operator v0.80.0** → Pipelines **1.12.2** / Triggers **0.36.0** / Dashboard


### PR DESCRIPTION
Routed here by the `subsystem-index` protocol: the lesson is a durable ops-gotcha, not a subsystem fact, so the index was the wrong home and the `tekton` skill is the right one.

The skill already documents the congestion/preemption route to `NOT RUN: <leg>` and says plainly it is **a broken gate, not a bad change**. Both causes below produce the *same* reading and neither is congestion — so the existing tell ("it heals when the queue drains") is **false** for them. They heal only when someone fixes the cluster.

## (a) PodSecurity — hostPath vs the cluster default
`tekton-ci` carried no `pod-security.kubernetes.io/*` label, so it inherited the cluster default `baseline`, which forbids `hostPath` outright. When `homelab-infra` `6bec075e` swapped the gate's RWO PVC for a per-node hostPath nix cache:

```
pods "devrc-ci-<id>-gate-pod" is forbidden: violates PodSecurity
"baseline:latest": hostPath volumes (volume "nix-cache")
```

Admission failure does **not** retry into success — the pod is never created. The `gate` TaskRun reads `PodAdmissionFailed` while `notify`/`report` succeed, both required checks post `COULD NOT RUN`, and with `enforce_admins: true` on devrc's `main` **nothing could merge**. Fixed by `686d6ff0`.

## (b) `sandbox = false` in the CI pod
The `nix build .#checks…` tier is hermetic **only where nix's sandbox is on**. Measured:

| | derivation `ydzfas1zzmm446y07ivymknxmirdzavi` |
|---|---|
| dev host (`sandbox = true`) | `failed=1` |
| CI pod (`sandbox = false`) | `failed=43` |

Identical inputs, different output — impurity by definition. Two unrelated PRs failed with *identical* counts on trees that were green locally, which is what gave it away.

## Why gotcha 6 and not gotcha 0
The list is read in order and the congestion entries are still the commoner cause. Both new ones are a single `kubectl` read away, so the entry gives the exact commands rather than describing the symptom.

Body-only edit — no `description:` change, so **no skill-listing cost**. Verified: `test_skill_descriptions.py` + `test_skill_tiers.py` + `test_doc_path_rot.py` → 139 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJzmPYW8nDjauyCHRtS8Ai