### PR TITLE
docs(clawgate): "the browser layer is UNGATED by CI" was false in three places

### DIFF
--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -192,10 +192,18 @@ toolchain and the dispatch `curl`. Durable facts only:
   provisions — has **no Cilium**, so `agent-hardening.md` is a **homelab** playbook.
 - **Alloy has no auto-reloader** — if clawgate metrics vanish from homelab Prometheus, restart Alloy
   first (`telemetry.md`).
-- **Red GitHub Actions checks on `homelab-infra` are NOISE** (billing-blocked); the real gate is
-  Tekton `clawgate-ci` (`tekton` skill). 🔴 **But `clawgate-ci` does NOT run Playwright —
-  browser-layer changes are UNGATED.** Run `make e2e` locally and **count**: without Docker,
-  `test.skip` on `!dockerAvailable()` leaves **11 of 18 spec files / 77 of 113 tests**, green.
+- **Red GitHub Actions checks on `homelab-infra` are NOISE** (billing-blocked); the real checks are
+  Tekton (`tekton` skill). 🔴 **`clawgate-ci` does NOT run Playwright — but `clawgate-e2e`, a
+  SEPARATE check, DOES.** This line read "browser-layer changes are UNGATED" and that was false:
+  measured on #564, `tekton/clawgate-e2e` → `clawgate e2e passed — 122 tests, 2 skipped`, running
+  `make e2e` on the PR's own specs. ⚠ It RUNS; whether it BLOCKS is **unmeasured** —
+  `GET /branches/trunk/protection` 403s on this private repo without GitHub Pro, so nobody here can
+  read the required-check list. Do not upgrade "green" to "protected". 🔴 **Its Postgres is REAL,
+  not Docker** — Tekton pods have no daemon, and `clawgate-e2e-pipeline.yaml` says a Docker-based
+  gate would have self-skipped every full-mode spec and gone green having tested almost nothing.
+  That trap is live LOCALLY: without Docker, `test.skip` on `!dockerAvailable()` drops most
+  full-mode spec files silently. So run `make e2e` locally and **count** — compare the collected
+  total against the check's own `N tests, M skipped` string rather than trusting either alone.
 - 🔴 **The browser extension does NOT ship via Flux — merging to `trunk` deploys NOTHING.** Brave
   loads it unpacked from `~/workspace/clawgate-extension/containers/clawgate/extension` (branch
   `clawgate-ext-local`, same path on **BOTH hosts**); deploy = `merge --ff-only origin/trunk` on both

--- a/claude/skills/clawgate/SKILL.md
+++ b/claude/skills/clawgate/SKILL.md
@@ -192,18 +192,10 @@ toolchain and the dispatch `curl`. Durable facts only:
   provisions — has **no Cilium**, so `agent-hardening.md` is a **homelab** playbook.
 - **Alloy has no auto-reloader** — if clawgate metrics vanish from homelab Prometheus, restart Alloy
   first (`telemetry.md`).
-- **Red GitHub Actions checks on `homelab-infra` are NOISE** (billing-blocked); the real checks are
-  Tekton (`tekton` skill). 🔴 **`clawgate-ci` does NOT run Playwright — but `clawgate-e2e`, a
-  SEPARATE check, DOES.** This line read "browser-layer changes are UNGATED" and that was false:
-  measured on #564, `tekton/clawgate-e2e` → `clawgate e2e passed — 122 tests, 2 skipped`, running
-  `make e2e` on the PR's own specs. ⚠ It RUNS; whether it BLOCKS is **unmeasured** —
-  `GET /branches/trunk/protection` 403s on this private repo without GitHub Pro, so nobody here can
-  read the required-check list. Do not upgrade "green" to "protected". 🔴 **Its Postgres is REAL,
-  not Docker** — Tekton pods have no daemon, and `clawgate-e2e-pipeline.yaml` says a Docker-based
-  gate would have self-skipped every full-mode spec and gone green having tested almost nothing.
-  That trap is live LOCALLY: without Docker, `test.skip` on `!dockerAvailable()` drops most
-  full-mode spec files silently. So run `make e2e` locally and **count** — compare the collected
-  total against the check's own `N tests, M skipped` string rather than trusting either alone.
+- **Red GitHub Actions checks on `homelab-infra` are NOISE**; real checks: Tekton (`tekton` skill).
+  🔴 **`clawgate-ci` runs no Playwright — but `clawgate-e2e`, a SEPARATE check, DOES; "the browser
+  layer is UNGATED" was FALSE.** ⚠ RUNS is not BLOCKS; `make e2e` without Docker self-skips most
+  full-mode files and reads green — **COUNT**. `extension.md`.
 - 🔴 **The browser extension does NOT ship via Flux — merging to `trunk` deploys NOTHING.** Brave
   loads it unpacked from `~/workspace/clawgate-extension/containers/clawgate/extension` (branch
   `clawgate-ext-local`, same path on **BOTH hosts**); deploy = `merge --ff-only origin/trunk` on both

--- a/claude/skills/clawgate/reference/extension.md
+++ b/claude/skills/clawgate/reference/extension.md
@@ -187,6 +187,21 @@ Verifying the picker's privacy guard by hand has a trap that makes the obvious t
 
 ## CI scope
 `clawgate-ci` (Tekton — see the `tekton` skill) runs `go build`/`vet`/`test -race` + extension
-coverage + hook bats. It does **NOT** run Playwright, so the browser layer is UNGATED by CI. Run
-`make e2e` locally and **count** the results: `tasks.spec.ts` `test.skip`s the whole file without
-Docker, so a "green" run can mean 17 tests never executed.
+coverage + hook bats, and does **NOT** run Playwright.
+
+🔴 **That is not the same as "the browser layer is UNGATED by CI", which this file used to say and
+which is false.** A SEPARATE Tekton check, `clawgate-e2e`, runs `make e2e` on the PR's own specs.
+Measured on homelab-infra#564: `tekton/clawgate-e2e` → `clawgate e2e passed — 122 tests, 2 skipped`.
+Its Postgres is REAL rather than Docker, because Tekton pods have no daemon — see
+`clawgate-e2e-pipeline.yaml`, which documents that a Docker-based gate would have self-skipped every
+full-mode spec and gone green having tested almost nothing.
+
+⚠ **RUNS is not BLOCKS.** Whether `clawgate-e2e` is a required check is **unmeasured**:
+`GET /repos/ZacxDev/homelab-infra/branches/trunk/protection` 403s on this private repo without
+GitHub Pro, so the required-check list is unreadable from here. Never read its green as "the merge
+was protected".
+
+The local skip trap is still real and still yours to defeat: without Docker, `test.skip` on
+`!dockerAvailable()` drops the full-mode spec files silently. So run `make e2e` locally and **count**
+— then compare that total against the check's own `N tests, M skipped` string, rather than trusting
+either number alone.

--- a/claudedocs/handoff-tmux-webapp.md
+++ b/claudedocs/handoff-tmux-webapp.md
@@ -553,6 +553,15 @@ check are byte-identical in `gh pr checks`, and I diagnosed the first without na
 - 🔴 **`clawgate-ci` does NOT run Playwright — this feature is almost entirely browser-layer, so
   it is UNGATED.** Run `make e2e` locally and **count**: without Docker, `test.skip` on
   `!dockerAvailable()` leaves **11 of 18 spec files / 77 of 113 tests** and goes green.
+  - ⚠ **CORRECTED 2026-08-30, by a different effort — the "so it is UNGATED" half is FALSE.**
+    `clawgate-ci` genuinely does not run Playwright, but a SEPARATE Tekton check does:
+    measured on homelab-infra#564, `tekton/clawgate-e2e` → `clawgate e2e passed — 122 tests,
+    2 skipped`, running `make e2e` on the PR's own specs against a REAL Postgres (Tekton pods
+    have no Docker daemon). Whether it BLOCKS is unmeasured — branch protection 403s on this
+    private repo without GitHub Pro. The local Docker skip trap above is still real; the spec
+    counts are stale (21 files / 124 collected as of this date). Canonical text now lives in
+    the `clawgate` skill + its `reference/extension.md`; this bullet is left in place because
+    the rest of the doc reasons from it.
 - 🔴 **`clawgatectl` is built from a LOCAL working tree of homelab-talos**, so it can be present
   but STALE — a behind checkout ships a binary **missing verbs that prints help and exits 0**
   under a plausible version label. This already happened (0.7.95, no `task status`). New verbs


### PR DESCRIPTION
A 🔴-marked claim in the `clawgate` skill, its `reference/extension.md`, and `claudedocs/handoff-tmux-webapp.md` said `clawgate-ci` does not run Playwright **and therefore** the browser layer is ungated at merge. The first half is true. The conclusion is false.

**I acted on it this session before catching it.** I justified four Go guards on `ZacxDev/homelab-infra#564` with "the browser layer is ungated at merge" — then watched `tekton/clawgate-e2e` report `clawgate e2e passed — 122 tests, 2 skipped` on that same PR.

## Measured on #564, not read

| check | what it runs |
|---|---|
| `tekton/clawgate-ci` | `go build`/`vet`/`test -race` + extension coverage + hook bats. **No Playwright** — this half was always right |
| `tekton/clawgate-e2e` | `make e2e` on the PR's own specs → `clawgate e2e passed — 122 tests, 2 skipped` |

`clawgate-e2e`'s Postgres is **real, not Docker** — Tekton pods have no daemon, and `clawgate-e2e-pipeline.yaml` documents that a Docker-based gate would have self-skipped every full-mode spec and gone green having tested almost nothing.

## ⚠ RUNS is not BLOCKS — and I could not measure the second half

`GET /repos/ZacxDev/homelab-infra/branches/trunk/protection` returns **403** without GitHub Pro, so the required-check list is unreadable from this host. Both corrected files say that explicitly instead of upgrading a green check into "the merge was protected" — the exact failure mode `devrc/CLAUDE.md` already records for its own merge-gate marker, where the value never moved while branch protection changed underneath it three times.

## What is kept

The local skip trap is unchanged and still real: without Docker, `test.skip` on `!dockerAvailable()` drops the full-mode spec files silently. The advice is now to count locally **and** compare against the check's own `N tests, M skipped` string — either number alone can be a green that ran nothing.

The stale counts (11 of 18 files / 77 of 113 tests) are no longer stated as fact. Today measures 21 files / 124 collected, and that will rot too.

`handoff-tmux-webapp.md` gets a **dated correction under** the original bullet rather than a rewrite: it belongs to another effort and the rest of that doc reasons from the sentence, so silently editing it would leave the surrounding argument unmoored.

**Gate:** docs-only. Ran the doc/skill subset in the flake devShell — `test_skill_descriptions`, `test_skill_tiers`, `test_skill_audit`, `test_doc_path_rot`, `test_handoff_doc`, `test_closing_condition_single_source` — **531 passed**. The two required Tekton tiers gate the merge.