### PR TITLE
docs(handoff): rank 8a closed and verified past the version label; 8b in flight as homelab-infra#566

### DIFF
--- a/claudedocs/handoff-tmux-webapp.md
+++ b/claudedocs/handoff-tmux-webapp.md
@@ -11,7 +11,9 @@ and an **attention queue** that surfaces sessions needing a human so Zach can ju
 
 **Phases 1–4 SHIPPED. Ranks 5, 6, 7 and 8a are ✅ DONE, deployed and verified live.
 clawgate is at 0.8.18 and `clawgatectl` now MATCHES it on both hosts. The lowest-numbered OPEN
-item is rank 8b, IN FLIGHT as `ZacxDev/homelab-infra#566`.**
+item is rank 8b, IN FLIGHT as `ZacxDev/homelab-infra#566` — its `clawgate-e2e` closing condition
+is MET (124 tests, 2 skipped); only the merge is outstanding, blocked by an INFRASTRUCTURE
+failure (`proxy.golang.org` TLS timeouts), not by the change. Rank 8e's number is now measured.**
 
 🔴 **DO NOT READ A VERSION FROM THIS DOC — `clawgatectl health` is the only authority.** It said
 **0.8.18** at 2026-08-30. The line has carried **nine** values in four days (0.8.7 → 0.8.8 → 0.8.9
@@ -39,8 +41,10 @@ intended resting state.
   `ship.sh` silently skips. Recovered preserve → verify-on-origin → `reset --keep`.
 - **`ZacxDev/homelab-infra#566`** — OPEN, rank 8b: `containers/clawgate/e2e/tests/layout.spec.ts`,
   the layout tab's first browser coverage. 2 tests green locally, mutation-swept **5 killed /
-  0 survived / 0 invalid**. 🔴 **NOT yet green in `clawgate-e2e` — that check has not registered on
-  the PR at all.** See Open investigations.
+  0 survived / 0 invalid**. ✅ **`clawgate-e2e` PASSED — "124 tests, 2 skipped"**, so 8b's closing
+  condition is met. ⚠ `clawgate-ci` on the same PR reads `FAILED: go`, which is **5× TLS handshake
+  timeout against `proxy.golang.org`** — a network failure on a diff with zero Go files. Re-run it;
+  do not debug the diff. See Open investigations.
 - **`innovation-upstream/devrc#1056`** — the tmux server SENTINEL (producer half of rank 6).
   Was stuck with BOTH checks at `ERROR` (a broken gate, not a bad change) and `mergeable: UNKNOWN`.
   Rebased off 34-behind onto current `main` (`c0736f9f`) and force-pushed → now **MERGEABLE** with
@@ -248,16 +252,21 @@ before that date may name a different item — do not renumber again without rel
    - a. ✅ **DONE 2026-08-30 — `clawgatectl` is 0.8.18 on BOTH hosts.** See Status. Closing
      condition (`--version` == `health`) met, then exercised with a cross-host round trip.
    - b. 🔄 **IN FLIGHT: `ZacxDev/homelab-infra#566`** — `layout.spec.ts`, the layout tab's first
-     browser coverage. Green locally + 5/5 mutants killed. **Closing condition is green in
-     `clawgate-e2e`, which has NOT registered on the PR** — read Open investigations first.
+     browser coverage. Green locally + 5/5 mutants killed. ✅ **Closing condition MET:
+     `clawgate-e2e` passed, 124 tests / 2 skipped.** Remaining work is only to land it: `clawgate-ci`
+     needs a re-run (a `proxy.golang.org` TLS timeout, not the diff) and `gitops-validate` says
+     `COULD NOT RUN`. **Neither is a verdict on the change** — read Open investigations first.
    - c. Eight sleep-based timing bets in
      `containers/clawgate/internal/api/{push_task,task_comment}_test.go` (pre-existing; mechanical
      now `awaitPushesSettled` exists).
    - d. A scanner test for in-body `! grep` — closing condition: a test in both bats suites that
      reds on a planted `! grep` assertion.
    - e. **Re-derive `MIN_PASSED` (and check `MAX_SKIPPED`) in `clawgate-e2e-pipeline.yaml`.**
-     Closing condition: the value is set from a real `clawgate-e2e` run that included
-     `layout.spec.ts`. Currently 110, derived from 118 collected; a local run now collects 126.
+     🔴 **THE NUMBER IS NOW MEASURED, from CI, on a run that included `layout.spec.ts`:**
+     `124 tests, 2 skipped`, corroborated by a local `120 passed / 4 flaky / 2 skipped`
+     (`ran_ok = passed + flaky` = 124, the pipeline's own rule). At the existing 110/118 ≈ 93.2%
+     ratio that is **`MIN_PASSED: 115`** (currently 110, i.e. it tolerates losing 14 tests).
+     Closing condition: that value committed. ⚠ `MAX_SKIPPED` is 6 against a measured 2 — leave it.
 
 🔴 **There is no rank 9.** A previous revision listed one — "get three portable lessons into
 MEMORY.md" — and it was NOT a work item: the operator confirmed 2026-08-27 that MEMORY.md is not
@@ -365,7 +374,42 @@ are fixed: the script is committed, and this section exists.
   what runs** — without Docker, `test.skip` on `!dockerAvailable()` leaves 11 of 18 spec files and
   goes green.
 
+### ✅ RESOLVED — `clawgate-e2e` DID register on #566, and it PASSED
+🔴 **This CORRECTS the block below, which is left in place because the mistake is the lesson.**
+`tekton/clawgate-e2e` → **success, "clawgate e2e passed — 124 tests, 2 skipped"** on head
+`88d53d0d`. It had simply not been *scheduled yet* when I read the check list minutes after
+opening the PR. **I read an absence as a fact about the pipeline when it was a fact about the
+CLOCK** — the rival mechanism ("not started yet") was never named, and an empty result cannot
+distinguish the two. Rank 8b's closing condition IS met.
+
+⚠ **The same reading gives rank 8e its number, from BOTH tiers, and they agree:** CI reported
+`124 tests, 2 skipped`; the local full run reported `120 passed / 4 flaky / 2 skipped` in 21.9m,
+and the pipeline's own rule is `ran_ok = passed + flaky` = **124**. Applying the existing
+derivation ratio (110/118 ≈ 93.2%) gives **`MIN_PASSED: 115`**. The 4 flaky were
+`task-comment-delete.spec.ts:44`, `tasks.spec.ts:523`, `tasks.spec.ts:555` and
+`tasks-mobile.spec.ts:854` — all pre-existing, none reachable from an e2e-only diff.
+
+### ✅ RESOLVED — `clawgate-ci` "FAILED: go" on #566 is a NETWORK failure, not a code failure
+- **Observed (with values):** the pipeline run is `clawgate-ci-nndsh` in ns `tekton-ci`, param
+  `revision=88d53d0d…` (MY sha — so it could NOT be dismissed as someone else's), failing step
+  `step-verdict` exit 1 over `go fail / extension pass / hook pass`. The `step-go` log ends with
+  **5×** `net/http: TLS handshake timeout` fetching `github.com/jackc/pgx/v5@v5.10.0`,
+  `github.com/spf13/cobra@v1.10.2` and `github.com/coder/websocket@v1.8.14` from
+  `proxy.golang.org`, then `go leg rc=1`. Not one compile or test error.
+- **Ruled out:** my diff. It contains **zero** Go files (`git show --name-only` on the commit), and
+  the same tree is green locally: `go build ./...` rc 0, `go vet ./...` rc 0 and no output,
+  `go test ./...` **20 ok packages / 0 FAIL** (the 20 is the positive control — an empty filtered
+  output alone would not have proved the runner ran).
+- **How to read it:** this is the same family as the documented docker.io DNS poisoning on this
+  LAN — module fetches over TLS timing out. **Re-run the pipeline; do not debug the diff.**
+- ⚠ `tekton/gitops-validate` on the same PR says **`COULD NOT RUN: scripts-tests`**, which this
+  repo's CLAUDE.md defines as a gate that stopped before a leg reported — also not a verdict on
+  the change.
+
 ### `clawgate-e2e` has not registered as a check on `ZacxDev/homelab-infra#566`
+⚠ **SUPERSEDED — see the RESOLVED block immediately above. The conclusion was WRONG.** Kept
+verbatim because the failure mode is worth recognising: an absent check and a not-yet-scheduled
+check are byte-identical in `gh pr checks`, and I diagnosed the first without naming the second.
 - **Symptom + exact repro:** `gh pr checks 566 --repo ZacxDev/homelab-infra` lists **only**
   `tekton/ux-audit-clawgate` (PENDING). The suite this PR exists to extend is not among them.
 - **Observed (with values):** `gh pr view 566 --json statusCheckRollup` → exactly one row,

--- a/claudedocs/handoff-tmux-webapp.md
+++ b/claudedocs/handoff-tmux-webapp.md
@@ -9,42 +9,42 @@ and an **attention queue** that surfaces sessions needing a human so Zach can ju
 
 ## Status
 
-**Phases 1–4 SHIPPED. Ranks 5, 6 and 7 are ✅ DONE, deployed and verified live 2026-08-30.
-clawgate is at 0.8.18. The lowest-numbered OPEN item is rank 8 (housekeeping).**
+**Phases 1–4 SHIPPED. Ranks 5, 6, 7 and 8a are ✅ DONE, deployed and verified live.
+clawgate is at 0.8.18 and `clawgatectl` now MATCHES it on both hosts. The lowest-numbered OPEN
+item is rank 8b, IN FLIGHT as `ZacxDev/homelab-infra#566`.**
 
 🔴 **DO NOT READ A VERSION FROM THIS DOC — `clawgatectl health` is the only authority.** It said
-**0.8.18** at 2026-08-30 06:30Z immediately after this session deployed it. The line has now
-carried **nine** values in four days (0.8.7 → 0.8.8 → 0.8.9 → 0.8.10 → 0.8.11 → 0.8.13 → 0.8.15
-and 0.8.17 from concurrent sessions → 0.8.16 → 0.8.18). ⚠ **0.8.12 and 0.8.14 EXIST IN HARBOR AND
-WERE NEVER DEPLOYED** — each was built, then discarded before merge because trunk gained a
-`containers/clawgate` fix while the PR was in review and the image would have carried a HIGHER
-version number with LESS code. A tag existing is not a tag having shipped.
+**0.8.18** at 2026-08-30. The line has carried **nine** values in four days (0.8.7 → 0.8.8 → 0.8.9
+→ 0.8.10 → 0.8.11 → 0.8.13 → 0.8.15 and 0.8.17 from concurrent sessions → 0.8.16 → 0.8.18).
+⚠ **0.8.12 and 0.8.14 EXIST IN HARBOR AND WERE NEVER DEPLOYED** — each was built, then discarded
+before merge because trunk gained a `containers/clawgate` fix while the PR was in review and the
+image would have carried a HIGHER version number with LESS code. A tag existing is not a tag
+having shipped.
 
-**Live at handoff (measured, not assumed):** pod `clawgate-78b9d497d6-klzmh` Running/ready,
-`restarts=0`, image `0.8.18`; server self-reports 0.8.18. `GET /ui/layout` → **200** (was 404 on
-0.8.17 — before-control taken). A seeded panel resolved against a real live window
-(`laptop · wheat · devrc`, `hotkey_display` = `Alt+w`). Terminal write surface still boots
-**`DISABLED (fail-closed)`**, its intended resting state.
+✅ **RANK 8a IS CLOSED — `clawgatectl` is 0.8.18 on BOTH hosts** (was 0.8.17 against an 0.8.18
+server, so a skew note fired on every command). **No devrc change was needed**:
+`nix/pkgs/tools/clawgatectl.nix` builds from each host's LOCAL `~/workspace/homelab-talos` tree and
+DERIVES its version from the Go source it compiles, so the fix was `merge --ff-only origin/trunk`
+on the laptop (5 behind; its source still said 0.8.17) followed by `ship.sh`. Verified past the
+label — see "How to verify"; a matching label is exactly what the 2026-08-14 incident also showed.
 
-🔴 **`clawgatectl` IS 0.8.17 ON BOTH HOSTS AGAINST AN 0.8.18 SERVER — a skew note now fires on
-every command.** `clawgatectl` is built from each host's LOCAL `homelab-talos` tree, so a pin bump
-alone does not update it. Fix: `git -C ~/workspace/homelab-talos merge --ff-only origin/trunk`
-then `home-manager switch --flake ~/workspace/devrc --impure`, on BOTH hosts. Left undone
-deliberately — a standing skew warning trains you to ignore skew warnings, so it is rank 8's
-first item.
+**Live at handoff (measured, not assumed):** both hosts at devrc `bd1572f3`, `ship.sh` **rc 0**
+with cross-host agreement **COMPARED**. `clawgatectl --version` == `clawgatectl health` == 0.8.18
+on workbench and laptop. Terminal write surface still boots **`DISABLED (fail-closed)`**, its
+intended resting state.
 
-**Shipped this session, newest first:**
-- **`ZacxDev/homelab-infra#538`** — rank 7, the layout GRID UI — squash **`fb9b75e5`**, deployed as
-  **0.8.18** (pin `3b90b6ee`, committed directly to `trunk`; that repo's own CLAUDE.md states
-  *"Commit = live deploy"*, which is what makes the exception apply — it was re-read, not assumed).
-  Four adversarial audit rounds, eleven findings, all fixed and each re-verified by a mutant.
-- **`ZacxDev/homelab-infra#527`** — rank 6, the persisted layout model — squash **`7bb78908`**,
-  deployed as 0.8.16. Migration `0028`, `internal/layout`, `clawgatectl view`/`panel`.
-- **`ZacxDev/homelab-infra#516`** — rank 5, the fail-closed terminal-write tier — squash
-  **`c8635976`**, deployed as 0.8.13.
-- **`innovation-upstream/devrc#1036`** — the handoff + the rescued dnsmasq script — squash `f8a35942`.
-- **`innovation-upstream/devrc#1056`** — the tmux server SENTINEL (producer half of rank 6) —
-  🔴 **STILL OPEN, still held.** See Open investigations.
+**Landed this session:**
+- **`innovation-upstream/devrc#1090`** — MERGED, squash **`52fdd983`**. The previous session's
+  handoff doc, which branch protection had left as a **local-only commit on `main`** — the state
+  `ship.sh` silently skips. Recovered preserve → verify-on-origin → `reset --keep`.
+- **`ZacxDev/homelab-infra#566`** — OPEN, rank 8b: `containers/clawgate/e2e/tests/layout.spec.ts`,
+  the layout tab's first browser coverage. 2 tests green locally, mutation-swept **5 killed /
+  0 survived / 0 invalid**. 🔴 **NOT yet green in `clawgate-e2e` — that check has not registered on
+  the PR at all.** See Open investigations.
+- **`innovation-upstream/devrc#1056`** — the tmux server SENTINEL (producer half of rank 6).
+  Was stuck with BOTH checks at `ERROR` (a broken gate, not a bad change) and `mergeable: UNKNOWN`.
+  Rebased off 34-behind onto current `main` (`c0736f9f`) and force-pushed → now **MERGEABLE** with
+  the gate running. ⚠ Still OPEN; claim `tmux-webapp-6` still held.
 
 ## Platform: this is a clawgate feature
 | | |
@@ -201,12 +201,16 @@ before that date may name a different item — do not renumber again without rel
 1. ✅ **DONE 2026-08-27** — the idle reaper had never fired because it COULD NOT (`time.NewTicker`
    delivers its first tick one whole interval in; a 24h ticker in a pod that lives 5h fires never).
    `ZacxDev/homelab-infra#457`, clawgate 0.8.7. Verified over six production sweeps.
+   forcing: none
 2. ✅ **DONE 2026-08-27** — detached suggest POST, `ZacxDev/homelab-infra#451` (`a38360a5`).
    8030ms → 22ms, measured old-hook vs new against a server that accepts and never replies.
+   forcing: none
 3. ✅ **DONE 2026-08-28** — read-only `capture-pane` rendering, both halves
    (`devrc#992` + `ZacxDev/homelab-infra#496`), clawgate 0.8.10.
+   forcing: none
 4. ✅ **DONE 2026-08-28** — the tmux snapshot ingest + host-side pusher
    (`ZacxDev/homelab-infra#468` + `devrc#974`), clawgate 0.8.8. Proof was an UNATTENDED tick.
+   forcing: none
 5. ✅ **DONE 2026-08-29 — `ZacxDev/homelab-infra#516`, squash `c8635976`, deployed 0.8.13.**
    `requireTerminalToken`: the ONLY fail-closed tier. Refuses (503, handler never called) unless
    `CLAWGATE_TERMINAL_TOKEN` is set, ≥32 chars, and a DIFFERENT value from the hook token.
@@ -217,6 +221,7 @@ before that date may name a different item — do not renumber again without rel
    "the terminal surface is unprovisioned" into an outage of the approval router.
    **To arm it:** `clawgate gentoken` → add `CLAWGATE_TERMINAL_TOKEN` via
    `sops clusters/workbench/apps/clawgate/secrets.enc.yaml`. No code or manifest change needed.
+   forcing: none
 6. ✅ **DONE 2026-08-29 — `ZacxDev/homelab-infra#527`, squash `7bb78908`, deployed 0.8.16.**
    Migration `0028` (`layout_views` + `layout_panels` + `tmux_snapshots.tmux_server_id`),
    `internal/layout` (resolver), machine routes, `clawgatectl view`/`panel` verbs.
@@ -227,28 +232,32 @@ before that date may name a different item — do not renumber again without rel
    matching FIVE windows. So panels resolve against the live snapshot on every read and report
    `resolved`/`ambiguous`/`missing`/`unreported`/`host_unreachable`. Ambiguity renders as a CHOICE.
    ⚠ **Claim `tmux-webapp-6` is STILL HELD** pending `devrc#1056` — see Open investigations.
+   forcing: none
 7. ✅ **DONE 2026-08-30 — `ZacxDev/homelab-infra#538`, squash `fb9b75e5`, deployed 0.8.18.**
    The htmx layout tab: views, per-panel live resolution, and organisation controls.
    🔴 **THE UI TIER CARRIES ONLY REVERSIBLE CONTROLS, TRUE BY CONSTRUCTION NOT BY COMMENT.**
    collapse/expand/archive, each undoable via Restore. The destructive control was REMOVED —
    button, route, handler and ledger entry — leaving `clawgatectl panel rm` (requireHookToken) as
    the only delete path. `TestTheLayoutUISurfaceOffersOnlyReversibleControls` fails by name if a
-   DELETE reappears. Verified live: `hx-post`=1 (positive control), `hx-delete`=0, and
-   `DELETE /ui/layout/views/1/panels/1` → 404.
-   🔴 **The browser-credential fork that rank 5 surfaced is now ANSWERED for this surface and still
-   OPEN for a web terminal.** The browser holds no credential, so UI writes sit on the
-   pass-through `requireSession` tier following `comment_delete.go:110-130`'s precedent — acceptable
-   ONLY because layout rows execute nothing. That argument does NOT extend to `send-keys`.
-8. **Housekeeping, cheap — the lowest-numbered OPEN item:**
-   a. 🔴 **Bring `clawgatectl` current on both hosts** (0.8.17 vs an 0.8.18 server). See Status.
-      Closing condition: `clawgatectl --version` == `clawgatectl health` on both hosts.
-   b. **An e2e spec for the layout tab.** `clawgate-e2e` is green but runs 20 spec files and NONE
-      touches layout — that green says nothing about this feature. Closing condition: a
-      `layout.spec.ts` exercising collapse/expand/archive/restore, green in `clawgate-e2e`.
-   c. Eight sleep-based timing bets in `containers/clawgate/internal/api/{push_task,task_comment}_test.go`
-      (pre-existing; mechanical now `awaitPushesSettled` exists).
-   d. A scanner test for in-body `! grep` — closing condition: a test in both bats suites that reds
-      on a planted `! grep` assertion.
+   DELETE reappears.
+   forcing: none
+8. **Housekeeping — 8a DONE, 8b IN FLIGHT, 8c–8e open.**
+   forcing: gate — `clawgate-e2e` was green through all four of #538's audit rounds while running
+   ZERO specs that touch layout, so the gate asserted a coverage it did not have. 8b closes that;
+   8e is the floor that gate reads.
+   - a. ✅ **DONE 2026-08-30 — `clawgatectl` is 0.8.18 on BOTH hosts.** See Status. Closing
+     condition (`--version` == `health`) met, then exercised with a cross-host round trip.
+   - b. 🔄 **IN FLIGHT: `ZacxDev/homelab-infra#566`** — `layout.spec.ts`, the layout tab's first
+     browser coverage. Green locally + 5/5 mutants killed. **Closing condition is green in
+     `clawgate-e2e`, which has NOT registered on the PR** — read Open investigations first.
+   - c. Eight sleep-based timing bets in
+     `containers/clawgate/internal/api/{push_task,task_comment}_test.go` (pre-existing; mechanical
+     now `awaitPushesSettled` exists).
+   - d. A scanner test for in-body `! grep` — closing condition: a test in both bats suites that
+     reds on a planted `! grep` assertion.
+   - e. **Re-derive `MIN_PASSED` (and check `MAX_SKIPPED`) in `clawgate-e2e-pipeline.yaml`.**
+     Closing condition: the value is set from a real `clawgate-e2e` run that included
+     `layout.spec.ts`. Currently 110, derived from 118 collected; a local run now collects 126.
 
 🔴 **There is no rank 9.** A previous revision listed one — "get three portable lessons into
 MEMORY.md" — and it was NOT a work item: the operator confirmed 2026-08-27 that MEMORY.md is not
@@ -262,14 +271,17 @@ used here, so nothing could ever have closed it.
     - **The `main()` wiring ledger pins syntax, not reachability.** Wrapping a loop's start in a
       condition false in production keeps it green — verified. NOT closable statically. The
       compensating control is the runtime entry log line, which is itself guarded.
-
+    forcing: none
 11. **The archive drawer loses its `open` after every write-triggered swap.** KNOWN, UNFIXED, and
     noted in-code at `layoutArchivedDrawer` with both rejected fixes: `open` unconditionally
     defeats the decluttering the drawer exists for, and `hx-preserve` pins a stale node so Restore
     would not update the card. The correct fix is the `taskCardScript` treatment (a once-bound
-    listener re-applying `open` after settle) — new client JS, which needs 8b's e2e spec to be
-    verifiable at all. Closing condition: restoring three archived panels in a browser without
-    reopening the drawer between each.
+    listener re-applying `open` after settle). **8b now makes it verifiable** — but note
+    `layout.spec.ts` deliberately does NOT assert the drawer stays open (pinning a known bug would
+    go red the day it is fixed), so fixing this needs a NEW assertion, not an existing one turning
+    green. Closing condition: restoring three archived panels in a browser without reopening the
+    drawer between each.
+    forcing: none
 
 ## Open investigations — live diagnosis state
 
@@ -352,6 +364,43 @@ are fixed: the script is committed, and this section exists.
 - **Next probe:** write `containers/clawgate/e2e/tests/layout.spec.ts` and run `make e2e`. 🔴 **COUNT
   what runs** — without Docker, `test.skip` on `!dockerAvailable()` leaves 11 of 18 spec files and
   goes green.
+
+### `clawgate-e2e` has not registered as a check on `ZacxDev/homelab-infra#566`
+- **Symptom + exact repro:** `gh pr checks 566 --repo ZacxDev/homelab-infra` lists **only**
+  `tekton/ux-audit-clawgate` (PENDING). The suite this PR exists to extend is not among them.
+- **Observed (with values):** `gh pr view 566 --json statusCheckRollup` → exactly one row,
+  `tekton/ux-audit-clawgate  PENDING`. Contrast devrc#1056, where both `tekton/devrc-pytests` and
+  `tekton/devrc-nodetests` appear within minutes of a push.
+- **Ruled out:** the ERROR-state class that hit devrc#1056 — that showed the checks PRESENT with
+  conclusion `ERROR`. Here the check is ABSENT, which is a different failure with a different fix
+  (a fresh push clears an ERROR; it will not conjure a check that never triggers).
+- **Leading hypothesis:** the `clawgate-e2e` trigger is path- or event-filtered and either has not
+  fired yet or does not match a PR touching only `containers/clawgate/e2e/**`. UNPROVEN.
+- **Next probe:**
+  ```bash
+  grep -n 'interceptor\|filter\|cel\|clawgate-e2e' \
+    ~/workspace/homelab-talos/clusters/homelab/apps/tekton-pipelines/triggers/clawgate-e2e-pipeline.yaml
+  gh pr checks 566 --repo ZacxDev/homelab-infra
+  ```
+- 🔴 **Rank 8b's closing condition is "green in `clawgate-e2e`", so a check that never runs does
+  NOT satisfy it** — an absent check reads as "nothing to see", which is the opposite of what it is.
+
+### `MIN_PASSED` in the e2e pipeline is stale, and it was deliberately NOT re-derived
+- **Symptom + exact repro:** `clusters/homelab/apps/tekton-pipelines/triggers/clawgate-e2e-pipeline.yaml`
+  line ~550 sets `MIN_PASSED: "110"`, derived from a CI run measured at **118 passed / 2 skipped**.
+  A local full run on the 8b branch collects **126**.
+- **Observed (with values):** `Running 126 tests using 1 worker` (local `make e2e`, no filter; 31
+  passed / 0 failed at the point this handoff was written — the run was still going). The pipeline
+  header says: *"🔴 BOTH ARE MEASURED AND WILL DRIFT. Re-derive them when the suite changes size —
+  from a real run, the way these were, not by adjusting until green."*
+- **Ruled out:** raising it from the **local** number. The dev-host tier and the CI tier are
+  different environments with different skip sets; a floor CI cannot meet is the permanently-red
+  gate this repo warns about, which is strictly worse than a loose one.
+- **Leading hypothesis:** the floor was ALREADY stale before 8b — 126 collected locally against a
+  118-derived floor means trunk grew by ~6 tests that nobody re-derived for.
+- **Next probe:** read passed/skipped off the **first `clawgate-e2e` run that includes
+  `layout.spec.ts`**, then set `MIN_PASSED` to ~93% of it, the way the existing comment derives 110
+  from 118. It is a `-lt` floor, so nothing is broken meanwhile.
 
 ## Gotchas
 - 🔴 **A FAILED `git worktree add` DOES NOT STOP THE NEXT `git -C <path>` — AND I LANDED A
@@ -753,13 +802,86 @@ are fixed: the script is committed, and this section exists.
     app=clawgate` lists a `Succeeded` leftover too, so a `.items[0]` jsonpath reports the wrong
     image. Confirm the pod is `Running` **and ready**.
 
+- 🔴 **A version label that MATCHES is not evidence the code is there — and the first probe of it
+  was VACUOUS.** `clawgatectl view list` printed the parent command's help and **exited 0**: the
+  verb is **`ls`**, and cobra treats an unknown positional as help. That is precisely the
+  2026-08-14 silent-no-op shape (`task status` printing help, exit 0), now at the *verification*
+  layer rather than the labelling one. The real check is a round trip that MOVES A NUMBER: write
+  from one host, read from the other. `view ls` returning `[]` with rc 0 is indistinguishable from
+  a client wired to nothing until the count has been watched go 0 → 1 → 0.
+- 🔴 **`ship.sh` rc 11 was a RACE, not a failure — `origin/main` moved between the two legs.** The
+  local leg fast-forwarded to `ad891a5c`, then verified against a HEAD that had already advanced to
+  `bd1572f3` (another session merging). Both hosts ended on the same sha and the immediate re-run
+  was rc 0 with agreement COMPARED. **Re-run before diagnosing an rc 11** — but still read the
+  per-host lines, because a genuine skip hides among greens.
+- 🔴 **A clean rebase is not a clean merge, and devrc#1056's had a real semantic overlap.** It was
+  34 behind; `git rebase origin/main` reported no conflict. Main's `e212415e` (#1076) had meanwhile
+  replaced the session-manager row-field ledger's permissive `assert field in sm.__doc__` with a
+  **SET** comparison failing in BOTH directions — and #1056 adds fields. It is fine ONLY because
+  `tmux_server_id` lands on the **host** dict, not the row dict. The check that settles it is
+  `git log <base>..<tip> -- <each file the branch touches>` then reading the merged region; the
+  green suite alone would not have told the two apart.
+- 🔴 **A Tekton check posted as `ERROR` is a broken gate, not a bad change — and only a fresh push
+  clears it.** devrc#1056 sat at `ERROR`/`ERROR`, `mergeable: UNKNOWN`, no `targetUrl`. Rebase +
+  force-push moved it to `pending` + `MERGEABLE`. Rebasing beats an empty commit here: afterwards
+  the branch head IS the merged tree, so the gate run is a statement about what merging produces.
+- 🔴 **An e2e fixture can make a guard vacuous in a way that reads exactly like a product bug.**
+  `layout.spec.ts`'s control-set assertion (`['archived','collapsed','expanded']`) failed on its
+  first run with `expanded` missing. Not a bug: an **expanded** card offers Collapse + Archive and
+  no Expand at all, and Restore lives only on the **archived** card in the drawer. Seeded
+  all-expanded — the obvious fixture — the union is `{archived, collapsed}`. Fix: one panel in
+  EACH state.
+- 🔴 **A panel that does not RESOLVE renders an EMPTY detail block, so "collapsed hides the detail"
+  would have been true of nothing.** `layoutPanelDetail`'s `default` arm returns `g.Text("")`, so
+  an `unreported` panel draws the same body expanded or collapsed. The spec therefore pushes a real
+  snapshot via `POST /api/tmux/snapshot` first. ⚠ That body is **session-manager's own `--json`
+  document** — a `hosts` OBJECT keyed by host name,
+  `{"ts":…,"hosts":{"<h>":{"reachable":true,"windows":[…]}}}` — NOT a list of snapshots. And the
+  window keys are **mixed case**: `codename` and `tmuxSessionName` camel, `window_id` /
+  `window_name` / `window_index` / `claude_session_id` / `hotkey_display` snake.
+- **Assert the ATTRIBUTE, not the text.** Mutant E (`data-hotkey-display` re-derived through
+  `strings.ToLower`) left the visible text `Alt+i` while the attribute became `alt+i`. A text
+  assertion survives it; the attribute assertion killed it, at line 184.
+- **A worktree of `homelab-talos` needs `e2e/node_modules` linked.** `package-lock.json` is
+  **gitignored** there, so a fresh worktree has none and a naive `cmp` against the base clone
+  reports DIFFERS when the file is simply ABSENT. `ln -sfn <base>/containers/clawgate/e2e/node_modules`
+  suffices — `ensure-node-modules.sh` checks the declared deps, not the directory.
+- **Docker on the workbench cannot pull, but `postgres:16-alpine` is already cached**, so full-mode
+  e2e runs locally without touching docker.io. `docker images | grep postgres` before assuming
+  otherwise.
+- ⚠ **`core.hooksPath` was set REPO-LOCALLY on `homelab-talos`** at push time
+  (`/home/zach/workspace/homelab-talos/.git/hooks` — sample-only, so nothing ran). It is the
+  documented volatile value: **re-measure at the moment you push**, and verify the branch afterwards
+  (`local HEAD == ls-remote`, commit count) rather than trusting the push message.
+- **Branch protection on devrc `main` strands a `handoff_doc.py --push`.** Recovery order is
+  preserve → **verify on origin** → `reset --keep`: branch the topic, push it, confirm the sha with
+  `git ls-remote`, and only then move `main`. devrc#1090 is the worked example.
+
 ## How to verify
 
 ```bash
 clawgatectl health                 # the LIVE version; never expect a number from this doc
-clawgatectl --version              # must MATCH the server on BOTH hosts; a mismatch means the
-                                   # local homelab-talos tree is behind (see rank 8a)
+clawgatectl --version              # must MATCH the server on BOTH hosts
 ```
+
+🔴 **A MATCHING LABEL IS NOT ENOUGH — make a number move.** The 2026-08-14 incident shipped a
+correct-looking label over a binary missing the commands, and a bare `view ls` returning `[]` with
+rc 0 cannot be told from a client wired to nothing. ⚠ **The verb is `ls`, not `list`** — `list`
+prints help and exits 0.
+```bash
+ssh zach@10.42.0.100 'clawgatectl --version; clawgatectl health'   # laptop label agreement
+ssh zach@10.42.0.100 'clawgatectl view create verify-probe'        # WRITE from the laptop
+clawgatectl view ls                                                # READ on the workbench: 0 -> 1
+clawgatectl view rm <id>; clawgatectl view ls                      # back to []
+bash ~/workspace/devrc/scripts/ship.sh   # rc 0 + cross-host agreement COMPARED (not "NOT COMPARED")
+```
+
+**Rank 8b — the layout spec:**
+```bash
+make -C ~/workspace/homelab-talos/containers/clawgate e2e ARGS="layout.spec.ts"   # expect 2 passed
+gh pr checks 566 --repo ZacxDev/homelab-infra   # 🔴 clawgate-e2e must APPEAR, not merely pass
+```
+Needs Docker (`postgres:16-alpine` is cached locally) or `CLAWGATE_E2E_DATABASE_URL`.
 
 **Is rank 7 (the layout grid) actually working?**
 ```bash


### PR DESCRIPTION
Handoff update for the tmux-webapp work.

| rank | state |
|---|---|
| 8a — `clawgatectl` currency on both hosts | ✅ **DONE**, verified end-to-end |
| 8b — an e2e spec for the layout tab | 🔄 **IN FLIGHT**, `ZacxDev/homelab-infra#566` |
| 8e — re-derive the e2e `MIN_PASSED` floor | **new**, with a named closing condition |

## Why this is a PR and not a push to main

Same as #1090: `handoff_doc.py --confirm` commits, branch protection blocks the push, and an un-pushed commit on `main` is the state `ship.sh` skips over silently. Recovered by the documented order — preserve on this branch → **verify on origin** (`ls-remote` confirmed `78fa05d3`) → `reset --keep origin/main` (rc 0). `main` is clean.

## What the update carries

**Rank 8a needed no devrc change at all.** `nix/pkgs/tools/clawgatectl.nix` builds from each host's *local* `~/workspace/homelab-talos` tree and derives its version from the Go source it compiles, so the fix was `merge --ff-only origin/trunk` on the laptop (5 behind; its source still said `0.8.17`) then `ship.sh`.

🔴 **The verification is the part worth reading.** My first probe was vacuous: `clawgatectl view list` printed the parent command's help and **exited 0** — the verb is `ls`, and cobra treats an unknown positional as help. That is the same silent-no-op shape as the 2026-08-14 incident, but at the *verification* layer rather than the labelling one, and the version label was correct throughout. The real check is a round trip that moves a number: the laptop wrote a view, the workbench read it back, the workbench deleted it, both returned to `[]`.

**Two open investigations added**, both with observed values and a runnable next probe: `clawgate-e2e` has not registered as a check on #566 at all (an **absent** check, unlike #1056's **ERROR** checks — different failure, different fix), and the e2e `MIN_PASSED` floor is stale in a way that predates this work.

**Gotchas added:** `ship.sh` rc 11 as a race rather than a failure; a clean rebase hiding a real semantic overlap in #1056 (main had replaced a permissive substring ledger with a two-way set comparison); `ERROR` ≠ `failure` on a Tekton check; two e2e fixtures that are vacuous in ways that read exactly like product bugs; and asserting the attribute rather than the text.

🔴 **Carried forward rather than dropped**, after the tool flagged them: the whole 68-line `How to verify` section — my first draft would have replaced it with only the new commands, losing the reaper, migration and terminal-tier checks. The `Measured 2026-08-27 pre-fix: open=59, resolved=31, all=90` instrument-validation line is preserved verbatim.

Also fixed a section-name mismatch the tool caught: my delta said `## State now` where the doc has `## Status`, which would have added a **second** status section and left the real one stale.

## Not claimed

The full local e2e suite was still running at handoff (31/126, 0 failed). No `clawgate-task:` field was written — `clawgate_handoff.sh resolve` exited **5**, and an unknown session id also answers 200 with an empty array, so that zero is not a clean bill of health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)