### PR TITLE
docs(browser): say that `context` is how you RESOLVE a bw:// ref — net -27 bytes

### DIFF
--- a/scripts/browser-bridge/SKILL.md
+++ b/scripts/browser-bridge/SKILL.md
@@ -9,7 +9,6 @@ description: Drive the user's LIVE, logged-in Brave browser — read the active 
 BB=~/workspace/devrc/scripts/browser-bridge/browser   # ← run it by this exact path
 $BB whoami                          # ORIENT FIRST: HOST + connected profiles + extension_stale
 $BB --instance <key> open <url>     # open a NEW tab THIS session owns → returns tabId
-$BB bw://<host>/<inst>/<tabId> text # read the tab the icon-click copied
 ```
 
 🔴 **Run `whoami` first on every fresh browser task.** Both hosts are hostname
@@ -48,7 +47,8 @@ Env defaults `$BB_INSTANCE`/`$BB_TAB`/`$BB_FRAME` (flag wins; zsh does NOT
 split an unquoted `$F`). ⚠ an export outlives the call — env-routed ops say so
 once, on stderr.
 A toolbar-icon click copies `bw://<host>/<instance>/<tabId>` — one token that IS
-`--instance`+`--tab`, either side of the op; the host field is verified. 🔴 For
+`--instance`+`--tab`, either side of the op; host verified. `<ref> context`
+resolves one. 🔴 For
 `type`/`js`/`eval`/`agent` it is a reference only BEFORE the op — after it, it is
 the text/goal you send. `agent` refuses a LEADING one, `--tab` and `--frame`.
 Result payloads land under `.result.data`.
@@ -58,7 +58,7 @@ Result payloads land under `.result.data`.
 | `whoami` | **read-only identity** (global; no `--instance`) — host label (`laptop`/`workbench`), connected instances (active-tab **domain** only), bridge diagnostics, `extension_version_current` |
 | `health` / `instances` | connected instances + count (JSON: key, label, instanceId, tab url/title). `extension_stale` on `health`+`whoami`, NOT `instances` — ⚠ `null` = "undecidable", NOT "fine" → `reference/errors.md` |
 | `ping` | **which extension CODE is loaded?** → `{pong,extensionVersion,buildMarker,id,ops}`; read `buildMarker` — version+id describe the DIRECTORY. Staleness is PER PROFILE |
-| `context` | **page metadata, no DOM read** — url/domain/path/query/title/tabId, tab-scoped. Cheapest read; ⚠ NOT a render check → `reference/read-envelopes.md` |
+| `context` | **page metadata, no DOM read** — url/domain/path/query/title/tabId, tab-scoped. Cheapest read; also RESOLVES a `bw://` ref; ⚠ NOT a render check → `reference/read-envelopes.md` |
 | `open [url] [--wake[=MS]]` | open a NEW tab this session owns (default `about:blank`, **created in the BACKGROUND/hidden**), returns `tabId`. 🔴 A re-`open` does NOT navigate — it DISCARDS your url → `reference/tabs-instances.md` |
 | `close` / `release` | close this session's owned tab / drop ownership without closing it |
 | `tabs` | list open tabs (`.data.ownedTabId` flags yours) |


### PR DESCRIPTION
Follow-on to #1063. An agent holding a `bw://workbench/work/1642101066` and wanting to know what it points at had no reason to reach for `context` — the ops table described it as "page metadata, no DOM read" and nothing connected it to references. The capability was already there and already live; only the signpost was missing.

Measured against the real bridge, one round trip, **459 bytes**:

```
$ browser bw://workbench/work/1642101066 context
  url    https://www.youtube.com/watch?v=…
  domain www.youtube.com
  path   /watch    searchParams {v: …}
  title  …
  tabId  1642101066          ← echoed by the extension, so a routing
                               mismatch is visible rather than assumed
```

It is the *right* resolver, not merely an available one:

- injects no script, so it cannot hit the strict-CSP trap that makes `js`/`eval` return `null` on GitHub;
- does not depend on the tab being foregrounded, unlike a DOM read of a throttled background tab;
- `text` is byte-capped but still returns page copy, and one uncapped `html` on a heavy SPA is ~100K tokens.

## What changed

Two lines in `SKILL.md`:

- the `context` ops-table row now says it also **RESOLVES** a `bw://` ref (+29 bytes);
- the quick-start's `$BB bw://<host>/<inst>/<tabId> text` line is **evicted** — it duplicated the row it now points at, and used the wrong verb for its own purpose: a line demonstrating what a pasted ref is *for* should resolve it, not read its text. The flags paragraph carries the example instead, one line shorter.

**Net −27 bytes** (11,994 → 11,967), so the addition is paid for rather than borrowed against the ceiling.

## A correction worth recording

When I proposed this I said it would cost "~60 bytes against 294 bytes of headroom". That number was wrong in a way worth naming: **294 is headroom above the FLOOR** (`MAX_BYTES − size`), while the number that binds is the enforced budget `MAX_BYTES − MIN_HEADROOM_BYTES`, which left **44 bytes** of slack. The first attempt was +64 and `test_skill_size.py` caught it. The gate did its job; the figure I quoted when asking permission was not the figure that governs.

## Gate

`test_skill_size.py`, `test_surface_parity.py` and `test_browser_tab_ref.py` — **73 passed**. The last two matter because #1063 added two ledger tests that parse `SKILL.md` prose (the free-text exemption list and the `agent` refusal list); a reflow of this paragraph is exactly what could have broken their patterns, and did not.

Sandbox tier run separately per CLAUDE.md's guidance that building both check derivations concurrently produces false failures.

## Closing condition

`SKILL.md` names `context` as the way to resolve a `bw://` ref, and the byte ceiling still passes.

Checked by: this PR merging with `tekton/devrc-pytests` and `tekton/devrc-nodetests` green — both are required checks, so a green merge is the observable end-state.
