### PR TITLE
fix(audit-dispatch): the brief ASSERTED a toolchain the target repo does not have

### DIFF
--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -2058,16 +2058,27 @@ def render_toolchain(facts):
         "pytest on PATH; a loaded direnv is not the dev shell. Do not report "
         "that as a finding and do not build an ad-hoc `nix-shell` around it.",
         "",
-        "Run the whole dev-host gate (its EXIT STATUS is authoritative; also "
-        "read each runner's own `RESULT:` line):",
+        "Run the whole dev-host gate, **if this repo has one** — `scripts/gate.sh` "
+        "and the `checks` flake outputs below exist in SOME repos and not "
+        "others. 🔴 Check before you run, and if they are absent that is a "
+        "fact about the repo, NOT a finding about the PR and NOT a reason to "
+        "build an ad-hoc substitute: find how this repo actually runs its "
+        "suite (here it may be `scripts/tests/run-ci-suite.sh` off a manifest) "
+        "and say in your report which tier you actually exercised. Where it "
+        "does exist, its EXIT STATUS is authoritative; also read each "
+        "runner's own `RESULT:` line:",
         "",
         "```",
         f"nix develop {r} -c bash <your worktree>/scripts/gate.sh --tier both",
         "```",
         "",
-        "🔴 The gate above is the DEV-HOST tier. **The tier the merge actually "
-        "gates on is the sandbox one**, which builds from a store copy with no "
-        "`.git` and is therefore blind to different things:",
+        "🔴 The gate above is the DEV-HOST tier. Where a repo ALSO exposes "
+        "`checks` flake outputs, **the tier the merge gates on is the sandbox "
+        "one**, which builds from a store copy with no `.git` and is therefore "
+        "blind to different things. Confirm they exist before quoting a result "
+        "from them — `nix eval <repo>#checks.x86_64-linux --apply builtins.attrNames` "
+        "errors outright in a repo that has none, and a brief that ASSERTED "
+        "they exist sent one audit chasing a tier its repo does not have:",
         "",
         "```",
         "nix build <your worktree>#checks.x86_64-linux.pytests",


### PR DESCRIPTION
The `TOOLCHAIN` section is emitted for **every** repo and names three things that exist only in `devrc`. Measured against `homelab-infra`, where `/audit-pr` runs routinely:

| instruction the brief gives | in homelab-infra |
|---|---|
| `bash <worktree>/scripts/gate.sh --tier both` | **absent** (present in devrc) |
| `nix build <worktree>#checks.x86_64-linux.pytests` | **absent** — `nix eval` errors: *"does not provide attribute `checks.x86_64-linux`"* |
| `nix build <worktree>#checks.x86_64-linux.nodetests` | **absent**, same |

So the brief told every auditor of that repo to run a gate that is not there — and then told them the absent one was **"the tier the merge actually gates on"**. A real audit round hit exactly this and correctly reported it could not verify that tier. The finding was true, and the brief is what made it true.

## Why not just make it repo-conditional

Its own docstring pins it: `test_the_toolchain_reason_is_true_in_every_scenario` requires the section **byte-identical across every scenario**, and a prior round measured that a cross-repo-only reword walked that test. So the fix here is to stop **asserting** and start **instructing** — uniform text that is true in both repos:

- name `gate.sh` and the `checks` outputs as things that exist in **some** repos;
- tell the auditor to check before running;
- say their absence is a fact about the **repo**, not a finding about the PR, and not a licence to build an ad-hoc substitute (a clause immediately above already forbids exactly that for the `pytest` case);
- name the discriminating command — `nix eval <repo>#checks.x86_64-linux --apply builtins.attrNames`, which **errors outright** rather than returning empty, so it cannot be misread as "no checks defined";
- require the report to say which tier was actually exercised.

**A repo-AWARE toolchain section is the bigger fix and is deliberately not taken here** — it needs that pin relaxed, which is a design decision for the tool's owner, not a side effect of a bug fix.

## Verification

- **355 tests pass**, including the byte-identical toolchain pin — the change is uniform, which is what that test permits.
- End-to-end: a brief generated for a real `homelab-infra` PR now carries the conditional wording (checked on the rendered output, not just the source).

Found while auditing `homelab-infra#549` (comic-flex deploy guards, clawgate #442).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHAhMatsFm5ZbukgTcC7vM