### PR TITLE
docs(handoff): browser-bridge tab refs shipped and live-verified — and the doc's own plan was wrong in two measured ways

### DIFF
--- a/claudedocs/handoff-browser-bridge-architecture-trace.md
+++ b/claudedocs/handoff-browser-bridge-architecture-trace.md
@@ -17,39 +17,28 @@ Non-blocking: if it exits non-zero, print the stderr line and carry on.
 Trace and document the browser-bridge extension's full architecture (three-actor command channel) and the devrc skill+flows pattern (SKILL.md → reference/ → flows/) as observed in the codebase. Research-only session, no code changes.
 
 ## State now
-- Branch: `main`, clean working tree, no uncommitted changes
-- No PRs opened or modified this session
-- No deploys or builds in flight
-- Clawgate task: **not resolved** (no session ID)
-
-### What was produced
-- Complete architecture trace of browser-bridge: the three actors (CLI → server.py → MV3 extension), the HTTP long-poll transport, multi-instance routing, security model, op set (18 ops), deployment chain (home-manager atomic swap to `~/.local/share/browser-bridge-ext/`), and the build-marker freshness mechanism (#324)
-- Identification of the skill+flows pattern: the three-layer SKILL.md (always-on routing surface, ~1% context budget) → reference/ (durable FACTS, 0 cost until triggered) → flows/ (PROCEDURES, never auto-fire, named by hooks or SKILL.md table rows)
-- Concrete mapping of how `browser` implements this: `SKILL.md` + 13 reference files (including `sites/` sub-registry) + no flows/ (browser ops are direct, not procedural)
-- Contrast with `clawgate` which has both reference/ (12 files) and flows/ (2 files: `task-authoring.md`, `task-pickup.md`)
-
-### Key files traced
-| File | Role |
-|---|---|
-| `scripts/browser-bridge/browser` | CLI entrypoint (bash, 2325 lines) |
-| `scripts/browser-bridge/server.py` | Loopback rendezvous server (Python stdlib, 3592 lines, port 8788) |
-| `scripts/browser-bridge/extension/service_worker.js` | MV3 background worker (chrome.* glue) |
-| `scripts/browser-bridge/extension/protocol.js` | Pure protocol logic (testable with node --test, no chrome.*) |
-| `scripts/browser-bridge/extension/manifest.json` | MV3 manifest, version 0.8.1 |
-| `scripts/browser-bridge/extension/build_id.js` | Generated BUILD_MARKER literal (#324) |
-| `scripts/browser-bridge/extension/options.js` | Persist port/token/label to chrome.storage.local |
-| `scripts/browser-bridge/opencode/tools/browser_tool_impl.mjs` | opencode browser-agent's typed tool (no shell, RCE fix from PR #180) |
-| `scripts/browser-bridge/SKILL.md` | Always-on skill routing surface |
-| `scripts/browser-bridge/reference/*.md` | 13 durable-fact files (spa-wake, auth-pages, emulation, etc.) |
-| `scripts/browser-bridge/reference/sites/_index.json` | Per-host registry (host-suffix matching, longest-wins) |
-| `nix/home.nix:526-745` | Extension deployment (atomic dir exchange) |
-| `nix/home.nix:2389-2421` | systemd user service for server.py |
+- Branch: `main`, clean. **The feature is MERGED, SHIPPED and LIVE-VERIFIED.**
+- **devrc #1063** — `bd1572f3` — the toolbar icon copies `bw://<host>/<instance>/<tabId>`; the `browser` CLI expands it into `--instance`+`--tab` from either argument position.
+- **devrc #1103** — `d4a3a000` — `SKILL.md` now says `context` is how you RESOLVE a ref. Net **−27 bytes**.
+- **devrc #1091** — open issue: two defects in the click-wiring guard (below).
+- Deployed: `ship.sh` converged both hosts and verified; the workbench needed a second `home-manager switch` (ship reported `rc=13` consumer-stale, which the trailing `SHIP_RC=0` from a `| tail` hid).
+- 🔴 **LIVE-VERIFIED, both halves, against real Brave — not mocks:**
+  - CLI: `browser bw://workbench/work/<tabId> context` → routed to that exact tabId; a ref minted on `laptop` refused loudly; a malformed ref refused rather than split; ref + `--instance` refused rather than ranked.
+  - Extension: after the operator restarted Brave and clicked the icon, `ping` reports `buildMarker: 66b98084daecd880` and `whoami` reports `stale=False` on the `work` profile. The marker is a literal in the loaded module graph, so it describes RUNNING code, not the load directory.
+- ⚠ **The `personal - other` profile is still on `b817ef1e88267a40`, `stale=True`.** Staleness is PER PROFILE, so the icon click in that profile still runs the old no-op code until it is reloaded.
 
 ## Open investigations — live diagnosis state
 (No unresolved investigations — this was a read-only research session.)
 
 ## Next steps (ranked)
-1. No action items — this was a documentation/understanding session. The traces produced are reference material, not work items.
+1. Delete the stranded branch `origin/docs/browser-bridge-tab-ref-proposal` (`d923cc4`). It carries an unmerged edit to THIS doc whose implementation plan is wrong in two measured ways (see Gotchas); leaving it invites someone to land guidance that is known false. Nothing depends on it — this doc supersedes it.
+   forcing: none
+2. devrc **#1091** — the click-wiring guard goes red on a legitimate `try { … }` and is blinded by a `//`-bearing string above the call. Scaffolding only; cannot affect what ships. The issue carries a four-row mutation table as its closing condition.
+   forcing: none
+3. Reload the extension in the `personal - other` Brave profile so its icon click runs the new code.
+   forcing: none
+
+🔴 **Every remaining item is `forcing: none` — that is the honest reading, not an oversight.** The effort is finished: the feature is merged, deployed and verified live. Nothing external is pushing any of these, and per the queue contract none of them is eligible to be worked by a `/resume` session drawing from this list.
 
 ## Gotchas / decisions / dead-ends
 - The `reference/` vs `flows/` distinction is defined in `CLAUDE.md:127-131`: reference holds facts you verify against; flows holds procedures you execute. A flows file does not auto-fire — something must name it (a SKILL.md table row, or a hook that names the path).
@@ -60,5 +49,38 @@ Trace and document the browser-bridge extension's full architecture (three-actor
 - 🔴 **Deployment of this subsystem is SPLIT, and `readlink -f` is the only arbiter.** `SKILL.md` and the `browser` CLI are `mkOutOfStoreSymlink`s into the repo — an edit is LIVE immediately, no switch. `server.py` is a `/nix/store` copy — editing the repo does NOTHING until `home-manager switch` (+ `systemctl --user restart browser-bridge`). `ls -la` shows only the first hop and misleads. The trace above describes SOURCE; it says nothing about what is running.
 - 🔴 **A green test suite is explicitly NOT verification here** — `scripts/browser-bridge/reference/security-ops.md` owns the gate and makes live-verify against real Brave the bar. An in-process fake cannot meet it, so an agent working only from tests CANNOT close a bridge change; the loop is merge → switch → live-verify.
 
+- **CARRIED FORWARD from the 2026-08-27 `How to verify` section**, which this update replaced —
+  it is a dated measurement, not status, and the replace would have dropped it: the doc's
+  architecture claims were re-verified against the tree on 2026-08-27 (op parity in
+  `server.py:179` vs `protocol.js:47`; `protocol.js` chrome-free in code; the `sites/` matcher at
+  `server.py:1153-1193`; both `nix/home.nix` line ranges; zero `child_process`/`exec`/`spawn` in
+  `browser_tool_impl.mjs`). The clawgate reference-file count was wrong (11 → 12) and was corrected
+  then. ⚠ Those line numbers are as-of 2026-08-27 and this session moved `server.py` not at all but
+  `protocol.js`/`service_worker.js` substantially — re-derive rather than trusting the offsets.
+- 🔴 **This doc's own earlier implementation plan was WRONG IN TWO PLACES, both found by building it.** They are recorded because the unmerged branch `docs/browser-bridge-tab-ref-proposal` still states them:
+  - **`navigator.clipboard.writeText()` is NOT reachable from an MV3 service worker** — there is no `document`. Injecting into the page instead needs that document FOCUSED (it is not, after a toolbar click) and is refused under a strict page CSP, so it would have failed precisely on GitHub. The copy goes through an **offscreen document** (`reasons: ["CLIPBOARD"]`, `document.execCommand("copy")`).
+  - **"first 8 chars of the auto-id" DOES NOT ROUTE.** `server.py` `_resolve_target_locked` matches `target in (inst.key, inst.instance_id)` — EXACT. An abbreviated id fails `unknown_instance` on first use. A ref carries the full routing key: the label when set, else the whole UUID.
+- 🔴 **The feature would have shipped INERT without `clipboardWrite`, and no test tier could see it.** `execCommand("copy")` is permitted without that permission only inside a short-lived handler for a user action; this copy runs after `config()`, a tab query, a NETWORK `/whoami` round trip and `createDocument()`, in a document that never had transient activation. `execCommand` reports refusal by RETURNING FALSE, not throwing — so the symptom would have been a ✗ badge and an untouched clipboard on every click, forever. `action_click.test.mjs` mocked the clipboard reply as `{ok:true}` and `offscreen.js` was imported by ZERO tests. An audit measured it: 8 mutations of the offscreen writer, **7 survived** the full 869-pytest/549-node suite.
+- 🔴 **Six audit rounds; only ROUND 1 found a defect that would have reached the operator.** Rounds 2–5 each found a real defect *in a guard written to close the previous round*: a refusal that named a spelling (`bw://`) instead of the state (any `TAB`, then any `FRAME`); a SKILL.md ledger guard that survived its own negative control because it matched a backticked word appearing one sentence later; a check that passed on the exact mutant its comment named as closed; and a positive control resting on the very defect it controlled for (it proved a stub could see inheritance BY USING `BB_INSTANCE`, so fixing that leak would have broken the control). **Rounds 5 and 6 changed ZERO payload lines**, which is the stop condition that ended the ladder.
+- 🔴 **The wiring guard missed the same mutant FOUR times, and the FIX SHAPE was the cause.** Each round REPLACED the previous check (text pin → anchored regex → line-depth scan → raw-source scan) rather than joining it, so each closed one hole and opened another; round 4's rewrite resurrected three mutants round 3 had killed. It now asserts THREE independent things and says a future round may ADD to them but must not swap one for another. It is the SOLE coverage of the wiring — no test anywhere calls `startBackground()`.
+- 🔴 **The two tiers disagree, repeatedly, and only the sandbox gates the merge.** Two of this effort's own tests were green on the dev host and RED in `nix build .#checks…pytests`: one pair asserted `browser agent` had reached the wire (it does so only once its model-backend prerequisites are met, which come from the developer's environment); another wrote a stub with `#!/usr/bin/env bash`, which does not exist in the nix sandbox. The second is what `scripts/testlib/mockbin.py` exists to prevent — its own docstring records four prior sites and warns that "a rule re-derived at every call site regenerates the same bug at the next one".
+- **A `bw://` ref is resolvable with `browser <ref> context`** — 459 bytes, one round trip, no script injection (so no strict-CSP trap) and no dependence on the tab being foregrounded. It echoes back the extension's own `tabId`, so a routing mismatch is visible rather than assumed.
+- **Contention, not code**: `SQLite database … is busy` / `opening lock file "…/big-lock"` / `test_live_cotenants_does_not_count_this_process` counting a live `git` are all the concurrent-nix-build false-failure class now documented in `CLAUDE.md`. Proven here: the SAME tree, same derivation, failed under load and passed quiet.
+
 ## How to verify
-No verification needed for the session itself — it was read-only with no code changes. The doc's own claims WERE re-verified against the tree on 2026-08-27 (op parity in `server.py:179` vs `protocol.js:47`, `protocol.js` chrome-free in code, the `sites/` matcher at `server.py:1153-1193`, both `nix/home.nix` line ranges, and zero `child_process`/`exec`/`spawn` in `browser_tool_impl.mjs`); the clawgate reference-file count was wrong (11 → 12) and is corrected above.
+```bash
+BB=~/workspace/devrc/scripts/browser-bridge/browser
+
+# 1. running code is the shipped build (the ONLY signal that describes RUNNING code)
+$BB --instance work ping        # buildMarker must be 66b98084daecd880
+$BB whoami                      # work: stale=False
+
+# 2. the CLI half, end to end — resolve any ref the icon produced
+$BB bw://workbench/work/<tabId> context     # echoes back that exact tabId
+
+# 3. the refusals (each must FAIL, and send nothing)
+$BB bw://laptop/work/123 context            # minted on the other host
+$BB bw://workbench/work context             # malformed
+$BB --instance work bw://workbench/work/123 context   # ref + flag
+```
+Repo gates: `nix build .#checks.x86_64-linux.pytests` and `…nodetests` — 🔴 **one at a time**; a combined invocation produces false failures (nix-store contention), documented in `CLAUDE.md`.


### PR DESCRIPTION
Updates the canonical handoff for the browser-bridge tab-reference effort, which is now **finished**: merged, deployed and live-verified.

The doc previously described the work as a *proposal*. It is now `bd1572f3` (#1063) + `d4a3a000` (#1103), on both hosts, with both halves verified against real Brave rather than mocks.

## Why this matters beyond a status update

The doc carried an implementation plan that turned out to be **wrong in two measured ways**, and the branch `docs/browser-bridge-tab-ref-proposal` still states them:

- **`navigator.clipboard.writeText()` is not reachable from an MV3 service worker** — no `document`. The page-injection alternative needs that document focused (it isn't, after a toolbar click) and is refused under a strict page CSP, so it would have failed precisely on GitHub.
- **"first 8 chars of the auto-id" does not route** — `server.py` `_resolve_target_locked` matches `target in (inst.key, inst.instance_id)`, exactly. An abbreviated id fails `unknown_instance` on first use.

Left as guidance, both would mislead the next reader. That is the substance of this update.

It also records the finding that mattered most: **the feature would have shipped inert without `clipboardWrite`**, and neither test tier could see it — `execCommand("copy")` reports refusal by returning `false`, the test mocked the clipboard reply as `{ok:true}`, and `offscreen.js` was imported by zero tests. An audit measured 8 mutations of the offscreen writer with **7 surviving** the full suite.

## Two carried-forward details

- The 2026-08-27 `How to verify` line was a **dated measurement, not status**, so the `How to verify` replacement would have dropped it. It is carried into `Gotchas` — with the caveat that its line numbers predate this session, which moved `protocol.js` and `service_worker.js` substantially.
- **No `clawgate-task:` field was written.** `clawgate_handoff.sh resolve` exited 5 (0 tasks for this session). Its own positive control shows the board is reachable and the token accepted, but a wrong session id also answers 200 with an empty array — so that zero is not a clean bill of health, and the honest move is to record nothing.

## Ranked next steps: all three are `forcing: none`

That is the accurate reading, not an oversight — the effort is done and nothing external is pushing the remainder. Per the queue contract they are not eligible to be worked.

## Closing condition

The handoff doc on `main` describes the effort as merged, deployed and live-verified, and no longer states the two refuted implementation claims.

Checked by: this PR merging — after which `git show origin/main:claudedocs/handoff-browser-bridge-architecture-trace.md` contains "LIVE-VERIFIED" and does not present `navigator.clipboard.writeText()` or the 8-char auto-id as the plan.
