### PR TITLE
docs(handoff): the crop IS verified live — and three things this doc told the next session to do were wrong

### DIFF
--- a/claudedocs/handoff-discord-embed-ext-clipping.md
+++ b/claudedocs/handoff-discord-embed-ext-clipping.md
@@ -13,11 +13,59 @@ Non-blocking: if it exits non-zero, print the stderr line and carry on.
 ## Goal
 Enlarged Discord media must not be cropped by ancestors with `overflow: hidden`.
 
-## State now — the fix is written and gated; it is NOT verified in Brave
+## State now — VERIFIED LIVE: the crop is gone. One sub-item is still open.
 
 🔴 **Heading kept verbatim so this REPLACES rather than stacking a second `State now`
-above the stale one.** Both its clauses are still literally true — but it now understates:
-the work is MERGED and SHIPPED. Read on.
+above the stale one.** Its old text said "NOT verified in Brave". **That is now false for
+the crop** — measured 2026-08-30, positive control satisfied. The lightbox half is still
+open. Read on.
+
+### Measured 2026-08-30 on a real channel (`personal - other` instance)
+
+One self-consistent probe, `attachments` NON-ZERO so the rest means something:
+
+| measure | value |
+|---|---|
+| `attachments` (**positive control**) | **14** |
+| `marked` | **14 / 14**, and `marked_not_attachment` = **0** |
+| non-message media on the page | **129** (100 avatars, 16 icons, 9 clan-badges, 4 emojis) — **0 marked** |
+| `max-height` cap lifted | **14 / 14** |
+| `unclipped` ancestors | **44** |
+| **still clipped by an ancestor (axis-correct)** | **0** ← the claim this work exists for |
+| rendered past Discord's 400×300 cap | 10 of 14; the other 4 are natural-size-small and correctly not upscaled |
+
+An earlier independent read on a different tab agreed in shape: attachments 19, marked 19,
+unclipped 54. **The 2026-08-24 avatar hazard is closed live** — 129 avatars/icons/emojis on
+screen, none touched.
+
+⚠ **The first clip detector had an AXIS bug** and reported a false positive: it flagged an
+`overflow-x: hidden; overflow-y: scroll` scroller as clipping, when the element only
+overflowed on the *scroll* axis. Test each axis against its OWN overflow property; the
+numbers above are from the corrected version.
+
+### 🔴 Three corrections to what this doc used to say
+
+1. **The extension is registered in exactly ONE profile, and NOT at the path this doc named.**
+   Brave `Profile 2` (named `other` — the `personal - other` bridge instance) holds it,
+   unpacked, id `dffjnoklmild…`, dev mode on. Its registered path is the **repo working
+   tree** `scripts/discord-embed-ext/extension`, **not** `~/.local/share/discord-embed-ext`.
+   All three copies (nix, repo, `origin/main`) were byte-identical when checked, so no harm
+   today — but Brave runs whatever that checkout holds, and this doc's own Gotchas note that
+   the base clone's branch gets moved by other sessions. Old step 2 ("Load unpacked it at
+   `~/.local/share/discord-embed-ext`") would have created a SECOND registration.
+2. **That is why the previous probe read zero.** It probed the `work` instance (Brave
+   `Default`), which has **no discord-embed-ext registered at all**. A zero there was
+   structural, never a symptom — a stronger statement than the earlier retraction, which
+   only said the stylesheet inference was void.
+3. **No restart was needed.** The registration's `last_update_time` is 2026-08-29 19:56,
+   after the 0.3.0 bytes landed at 14:01 — it was reloaded at `brave://extensions`. The
+   Brave process itself had been up since 08-26 and still is.
+
+### 🔴 There is no `Reset` control — this doc's "all five" was wrong
+
+`lightbox.js` builds `−`, a `100%` label, `+`, and `◀`/`▶` (nav arrows only when the
+message holds more than one media). Keys: `Escape`, `←`, `→`, `+`/`=`, `-`/`_`. **No reset
+button and no reset key exist in 0.3.0.** Do not go looking for one.
 
 - **#1010 MERGED** as squash `2a8a8982` (2026-08-29T19:00:39Z). **#1023 MERGED** as
   `8e33bf1d` — it had to go first, see below. **#1024 CLOSED** as my own duplicate.
@@ -29,8 +77,12 @@ the work is MERGED and SHIPPED. Read on.
 - **Shipped**: `ship.sh` converged both hosts, 0 dangling / 0 stale artifacts each,
   cross-host agreement on one sha. Deployed copy is byte-identical to `origin/main`
   and reports `0.3.0`.
-- 🔴 **NOT verified in Brave.** Nobody has yet seen an uncropped image. See the
-  open investigation below — the probe I used earlier is now structurally invalid.
+- ✅ **VERIFIED in Brave 2026-08-30** for the crop: 14 attachments, 14 marked, **0 still
+  clipped**, 0 of 129 avatars/icons/emojis touched. Table above.
+- 🔴 **The LIGHTBOX is still unverified.** A trusted CDP click on a marked image did not
+  create `#dee-lightbox-host`. That is ONE unexplained observation, **not a defect** — see
+  the open investigation below, which names the two rival mechanisms and the one read that
+  separates them.
 
 ## 🔴 The thing that was actually wrong
 
@@ -72,7 +124,8 @@ implementation's duplicate).
 | mutation sweep | 10 mutants, **10/10 killed**, each by its own named test |
 | sandbox tier (what Tekton gates) | `nodetests` **PASS** on the merged tree, discord suite `tests=134 pass=134 floor=128` |
 | dev-host tier | node 1366/1366; pytest 2 failures, both reproduced at the unmodified branch tip — `test_opencode_engine` (opencode 1.18.21 vs pinned 1.18.18) and `test_espanso_detect` (`:acq`/`:dacq` collision). Neither is in a file this touches. |
-| **live in Brave** | 🔴 **NOT DONE.** Nothing here proves the crop is gone on a real page. |
+| **live in Brave — the crop** | ✅ **DONE 2026-08-30.** 14 attachments, 14/14 marked, 44 ancestors unclipped, **0 still clipped**, 0 of 129 avatars/icons/emojis touched. |
+| **live in Brave — the lightbox** | 🔴 **NOT DONE.** A trusted click did not open it; two rival mechanisms, undiscriminated. |
 
 🔴 One mutant **SURVIVED** the first sweep and the fixture was fixed, not the score:
 deleting the message-boundary break changed nothing, because the only ancestor above
@@ -82,16 +135,18 @@ If you touch that walk, keep that element or the guard silently stops being test
 
 ## Next steps (ranked)
 
-1. **Verify live in Brave** — the only open correctness question for this work.
-   Full Brave restart → `brave://extensions` → confirm *Discord Embed Enlarge 0.3.0*
-   is loaded from `~/.local/share/discord-embed-ext` → open a channel **with image
-   attachments** → run the probe above and require `attachments > 0` → confirm the
-   image is uncropped and clicking it opens the lightbox with working
-   `+` / `−` / `Reset` / `‹` / `›` (all five were dead in v0.2.3).
-2. **If it is NOT loaded**, `Load unpacked` it once at `~/.local/share/discord-embed-ext`.
-   Nix keeps that directory correct but cannot register it with Brave.
+1. **Settle the lightbox — the ONLY open correctness question left.** Cheapest first,
+   and it needs no tooling: in Brave `Profile 2` (`other`), click any Discord message
+   image. A black overlay with `−  100%  +` means it works and this topic is closed.
+   If nothing happens, run the hit-test in the open investigation below **before**
+   touching `lightbox.js` — the likeliest cause is not in our code.
+2. **Do NOT `Load unpacked` anything.** It is already registered in `Profile 2`, from
+   `scripts/discord-embed-ext/extension` (the repo tree, not the nix path). A second
+   registration is the failure mode here, not the fix. Check
+   `brave://extensions` before assuming absence — and note the `work` profile
+   (`Default`) has never had it, so probing there measures nothing.
 3. **Nothing else is outstanding for this topic.** Both PRs are merged, both hosts
-   shipped and verified. Do not re-open the engine work without a live reading first.
+   shipped, and the crop is verified live. Do not re-open the engine work.
 
 ## Gotchas / decisions / dead-ends
 
@@ -160,48 +215,65 @@ If you touch that walk, keep that element or the guard silently stops being test
    positive control.
 ## Open investigations — live diagnosis state
 
-### Is the extension actually running in Brave, and is the crop gone?
-- **Symptom + exact repro:** unknown — this has never been observed either way at
-  0.3.0. Repro path: open a Discord channel that contains real message
-  **attachments** (not avatars), look at whether the image is cropped, then click it.
-- **Observed (with values):** probed the live `work` profile, tab `1642098896`
-  (`#notes`), 2026-08-29 after the ship:
-  `{"attachments_present": 0, "cdn_path_segments": {"avatars": 21, "icons": 35},
-  "dee_global": "undefined", "marked": 0, "unclipped": 0, "zoom_cursor": 0}`.
-- 🔴 **Ruled out — and this kills my own earlier conclusion.** The previous handoff
-  said "the extension injects in NEITHER reachable profile
-  (`#dee-enlarge-css` absent, 0 elements marked)". **That inference is void at
-  0.3.0.** The restored #804 engine injects **no stylesheet at all** — `grep -c
-  'createElement("style")'` on `extension/embed_enlarge.js` is **0**. Only the
-  rejected v0.2.3 had `dee-enlarge-css`. So a missing stylesheet is the EXPECTED
-  reading now and is evidence of nothing.
-- **Also ruled out as a signal:** `typeof globalThis.__DEE__` from the bridge. Content
-  scripts run in an ISOLATED world, so the bridge's eval cannot see `__DEE__` whether
-  or not the extension is loaded. `undefined` there is not absence either.
-- **Why the counts are unmeasured, not zero:** that channel contains **0**
-  `/attachments/` or `/external/` media. `applyOverride` only ever marks message
-  media, so `marked: 0` is what a WORKING extension also reports there. An empty
-  result cannot distinguish the two mechanisms.
-- **Leading hypothesis:** unknown, genuinely. It may be working and simply
-  unobserved. It may not be `Load unpacked`ed — that is a manual step nix cannot do,
-  and the tree was replaced at a new path by the deploy.
-- **Next probe (run verbatim, on a channel WITH attachments):**
+### CLOSED 2026-08-30 — is the extension running, and is the crop gone? YES.
+
+Measured, positive control satisfied. Numbers in `State now` above. Do not re-derive.
+The three things that made the earlier reading unmeasurable, so nobody repeats them:
+
+- The old probe ran against the **`work` instance**, which has **no discord-embed-ext
+  registered at all**. Not a stale build, not an injection failure — the extension was
+  never there. Probe `personal - other` (Brave `Profile 2`).
+- That channel held **0** attachments, so `marked: 0` was what a WORKING extension also
+  reports. `attachments > 0` is the positive control and is not optional.
+- `#dee-enlarge-css` and `globalThis.__DEE__` are BOTH non-signals: the restored #804
+  engine injects no stylesheet, and content scripts run in an isolated world the bridge's
+  eval cannot see. Their absence means nothing either way.
+
+⚠ **The `personal - other` bridge blocker is INTERMITTENT, not permanent.** The old text
+said that instance "cannot inject into `discord.com` at all". On 2026-08-30 it injected
+fine for several probes, then returned `Cannot access contents of the page` again on a
+fresh tab, with `extension_stale: true` throughout (build `b817ef1e88267a40` vs expected
+`aada672ff3a5ded7`). If a read fails there, retry before concluding anything.
+
+### OPEN — does clicking a marked image open the lightbox?
+
+- **Symptom:** a trusted CDP click on a `[data-dee-enlarged]` image did **not** create
+  `#dee-lightbox-host`. Observed once, on one image.
+- 🔴 **This is NOT a diagnosis.** An empty result cannot separate the two mechanisms
+  below, and picking the one you already suspect is a coin flip you will record as a
+  finding.
+  1. **Discord's overlay ate the click.** `installAutoStart` walks **UP** from
+     `e.target`. Discord renders an anchor over the image; if that anchor is a
+     *sibling* of the `<img>` rather than an ancestor, the walk never reaches the
+     marked element and the handler correctly does nothing. **Nothing is broken.**
+  2. A genuine failure of the click hook.
+- **What is already ruled IN:** per-element prep completed. `embed_enlarge.js:248` writes
+  `cursor: zoom-in` immediately before `setAttribute(ATTR_ENLARGED, "1")` at :250, and all
+  14 elements carried the attribute — so that code path ran to the end on every one.
+- 🔴 **The five in-shadow controls cannot be exercised or observed from page JS at all.**
+  `lightbox.js:119` attaches the shadow root with `mode: "closed"`, so `host.shadowRoot`
+  is `null`. A screenshot is the only programmatic route. `#dee-lightbox-host` itself is
+  in the LIGHT dom, so open/closed IS observable — that is the whole budget.
+- **The one read that separates the two mechanisms** (read-only, opens nothing):
   ```bash
   BB=~/workspace/devrc/scripts/browser-bridge/browser
-  $BB --instance work --tab <id> wake --wait 1500
-  $BB --instance work --tab <id> js '(function(){
-    var segs={},els=document.querySelectorAll("img,video,source");
-    for(var i=0;i<els.length;i++){var s=els[i].getAttribute("src")||"";
-      if(!/discordapp/.test(s))continue;
-      try{var u=new URL(s);var k=u.pathname.split("/")[1]||"root";segs[k]=(segs[k]||0)+1;}catch(e){}}
-    return {segments:segs,
-            attachments:(segs.attachments||0)+(segs.external||0),
-            marked:document.querySelectorAll("[data-dee-enlarged]").length,
-            unclipped:document.querySelectorAll("[data-dee-unclipped]").length};})()'
+  $BB --instance 'personal - other' --tab <id> wake --wait 2000
+  $BB --instance 'personal - other' --tab <id> js '(function(){
+    var m=document.querySelectorAll("[data-dee-enlarged]"),out=[],vh=innerHeight;
+    for(var i=0;i<m.length&&out.length<3;i++){
+      var e=m[i],r=e.getBoundingClientRect();
+      if(!(r.width>40&&r.height>40))continue;
+      var cx=Math.round(r.left+r.width/2),cy=Math.round(r.top+r.height/2);
+      if(cy<0||cy>vh)continue;
+      var hit=document.elementFromPoint(cx,cy),t=hit,found=false,d=0,walk=[];
+      while(t&&d<8){walk.push(t.tagName);
+        if(t.getAttribute&&t.getAttribute("data-dee-enlarged")==="1"){found=true;break;}
+        t=t.parentElement;d++;}
+      out.push({hit_is_the_img:hit===e,walk_up_reaches_marked:found,chain:walk});}
+    return out;})()'
   ```
-  🔴 **`attachments` must be NON-ZERO before `marked` means anything.** If it is 0 you
-  measured nothing — find another channel. That pair IS the positive control.
-- **Blocker on the other profile:** the `personal - other` instance's browser-bridge
-  extension cannot inject into `discord.com` at all (`Cannot access contents of the
-  page`). Both bridge instances reported `extension_stale: true` vs expected build
-  `aada672ff3`. A full Brave restart after a switch is what clears that.
+  **`walk_up_reaches_marked: false` ⇒ mechanism 1 — the code is fine, the click never
+  had a chance.** `true` with no lightbox on a real click ⇒ mechanism 2, and only then is
+  `lightbox.js` worth opening.
+- **Cheaper still, and it needs no tooling:** click an image by hand in `Profile 2`. A
+  black overlay with `−  100%  +` closes this outright.


### PR DESCRIPTION
The live check this doc has carried as `OPEN:` since 2026-08-29 is **done for the crop**.

| measure | value |
|---|---|
| `attachments` (**positive control**) | **14** — non-zero, so the rest means something |
| `marked` | **14 / 14**, `marked_not_attachment` = 0 |
| non-message media on screen | **129** (100 avatars, 16 icons, 9 clan-badges, 4 emojis) — **0 marked** |
| `max-height` cap lifted | 14 / 14 |
| `unclipped` ancestors | 44 |
| **still clipped by an ancestor (axis-correct)** | **0** ← the claim this work exists for |

The 2026-08-24 avatar hazard is closed **live**, not just in fixtures.

> ⚠️ The first clip detector had an **axis** bug — it flagged an `overflow-x: hidden; overflow-y: scroll` scroller as clipping when the element only overflowed on the *scroll* axis. Each axis must be tested against its own overflow property. The numbers above are from the corrected version; that gotcha is now in the doc.

## Three corrections, each of which would have cost the next session real time

1. **The extension is registered in ONE profile, from the repo working tree** — Brave `Profile 2` (the `personal - other` bridge instance), path `scripts/discord-embed-ext/extension`, **not** `~/.local/share/discord-embed-ext`. The old ranked step 2 said to `Load unpacked` it at the nix path; that would have created a **second registration**. It now says explicitly not to.
2. **That is why the earlier probe read zero** — a stronger statement than the previous retraction. The old probe ran against the `work` instance, which has **no discord-embed-ext registered at all**. Structural, not a stale build and not an injection failure.
3. **There is no `Reset` control.** The doc claimed `+` / `−` / `Reset` / `‹` / `›`, "all five". `lightbox.js` builds `−`, a `100%` label, `+`, `◀`, `▶`, and binds Escape / ← / → / `+` / `-`. No reset button, no reset key.

Also corrected: the `personal - other` bridge blocker is **intermittent**, not permanent — it injected fine for several probes, then refused again on a fresh tab. The old text said it "cannot inject into discord.com at all".

## Deliberately still open

A trusted click on a marked image did not create `#dee-lightbox-host`. **That is one observation and not a diagnosis** — an empty result cannot separate "Discord's overlay anchor is a *sibling* of the `<img>`, so `installAutoStart`'s walk-**up** never reaches the marked element and nothing is broken" from a real failure of the click hook.

The block now names both mechanisms and carries the **read-only hit-test that discriminates them** (`walk_up_reaches_marked: false` ⇒ mechanism 1, don't open `lightbox.js`), plus the cheaper hand check that closes it outright. It also records that the five in-shadow controls are **unobservable from page JS at all** — `attachShadow({mode: "closed"})` — so nobody burns time trying.

Docs-only: one file, no executable content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)