### PR TITLE
fix(audit-dispatch): PROBE the PR's repo for the TOOLCHAIN commands — the repo-aware section #1104 deferred

### DIFF
--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -2022,9 +2022,14 @@ RepoToolchain = namedtuple(
 # reached and a `nix build …#checks…` would be prescribed anyway.
 #
 # 🔴 ROUND 15 — THE REGEX WAS NEVER THE DEFENCE, AND MEASURING IT SAID SO. Both
-# patterns below now run over `_nix_strip`ped text, so a `checks = {` inside a
-# devShell heredoc or inside a `/* … */` comment is not text either of them can
-# see. Measured at `5bad0a0c` against the un-stripped scanner: a heredoc holding
+# patterns below now run over the text `_nix_scan` has BLANKED, so a
+# `checks = {` inside a devShell heredoc or inside a `/* … */` comment is not
+# text either of them can see. (Round 15 wrote `_nix_strip`ped here; round 16
+# split the scanner into `_nix_scan` — which returns the blanked text AND the
+# `clean` flag the hedge is keyed on — and left `_nix_strip` behind as a
+# test-only wrapper. The production path is `_flake_check_names` -> `_nix_scan`;
+# nothing in production calls `_nix_strip`.) Measured at `5bad0a0c` against the
+# un-stripped scanner: a heredoc holding
 #
 #     checks = {
 #     unit = 1;
@@ -2099,6 +2104,56 @@ def _nix_scan(text):
     So the scan is a STACK now: `${…}` inside a string pushes a CODE frame,
     `}` at that frame's depth 0 pops back into the string, and an identifier is
     consumed by MAXIMAL MUNCH so its trailing apostrophes cannot open anything.
+
+    🔴 THAT REVERSED A DOCUMENTED SAFETY DIRECTION, AND ROUND 16 REPLACED THE
+    SENTENCE THAT SAID SO INSTEAD OF UPDATING IT. `ba321c06` carried an explicit
+    STATED LIMIT: `${…}` interpolations inside a string "are real nix code and
+    this blanks them with the rest of the string … That is the SAFE direction —
+    the probe under-reads and the brief hedges — and it is the direction chosen
+    deliberately." The stack necessarily does the OPPOSITE: `${` inside a string
+    pushes a CODE frame, so an interpolation body is now SCANNED AS CODE.
+
+    That is the fix, not a regression — `shellHook = '' ${lib.optionalString c
+    '' … ''} '';` cannot be lexed at all without descending into the
+    interpolation, and NOT descending is what produced both round-16 failures,
+    in both directions. But the deliberate under-read is gone in one narrow
+    shape, and a docstring that documents the new mechanism while quietly
+    dropping the old limit reads as if nothing about the direction changed.
+
+    🔴 SO: THE RESIDUAL EXPOSURE, MEASURED. A `checks` binding that exists ONLY
+    inside an interpolation is now READ where it used to be blanked:
+
+        shellHook = '' echo ${lib.foo {
+        checks = {
+        phantom = 1;
+        };
+        }} '';
+
+    Through `_flake_check_names`, in BOTH string flavours (`''…''` and `"…"`):
+    `ba321c06` -> `None`, HEAD -> `['phantom']`, with `clean` True — so the
+    brief would fence `nix build <wt>#checks.x86_64-linux.phantom` against a
+    repository that declares no such attribute, and `clean` cannot catch it
+    because nothing about that scan is unclean. CONTROL, same run: an ordinary
+    top-level `checks.x86_64-linux = {` reads `['real']` on BOTH sides, so this
+    is the lexer changing its mind and not a fixture that broke one of them.
+
+    It needs a LINE-ANCHORED `checks… = {` inside an interpolation, which is not
+    an idiom anything writes — re-measured for this note over EVERY `flake.nix`
+    on this host, 1154 files: 0 changed answer between the `ba321c06` flat
+    scanner and this stack, and 0 lex unclean. The fixture above is the positive
+    control for that zero: it is the shape a real repository would have to
+    contain, and it DOES move the answer, so the 0 is a fact about the corpus
+    and not about a probe wired to nothing.
+
+    🔴 IT IS RECORDED AS A KNOWN LIMIT AND DELIBERATELY NOT GUARDED. Any guard
+    for it has to tell a `checks` match found inside an interpolation from one
+    found outside — which means the CODE frames must record their nesting and
+    the match offsets must be filtered against it. That is a change to what the
+    lexer records, and destabilising a lexer whose two previous rounds each
+    shipped a confident wrong answer, in order to close a shape with no measured
+    instance, is the wrong trade. If it ever bites, `clean` is not the valve to
+    reach for: an interpolation body is not uncertain, it is code, and the brief
+    would hedge for a reason that is not true.
 
     🔴 AND IT REPORTS ITS OWN UNCERTAINTY, because "the lexer got lost" and "the
     file has no checks" are different sentences and the second is the confident
@@ -2226,7 +2281,20 @@ def _nix_scan(text):
 
 
 def _nix_strip(text):
-    """The blanked text alone — for callers that do not read `clean`."""
+    """The blanked text alone. 🔴 A TEST SEAM — there are NO production callers.
+
+    Every production read goes through `_nix_scan` directly (`_flake_check_names`
+    below is the only one), because the second half of that tuple — `clean` — is
+    what the hedge is keyed on: where the lexer got lost the probe must answer
+    the hedged `[]`, never a name list and never a bolded "no `checks` output".
+
+    So do NOT read this wrapper as evidence that a route exists which reads the
+    blanked text WITHOUT consulting `clean`. There is no such caller, and adding
+    one would reopen exactly the hazard `clean` was introduced to close. It
+    survives only so the stripper's own invariants — length, newline count, what
+    is blanked and what is left standing — can be pinned in the suite without
+    each assertion unpacking a two-tuple.
+    """
     return _nix_scan(text)[0]
 
 

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -2002,6 +2002,416 @@ def render_checkout(facts):
     return "\n".join(lines)
 
 
+NIX_SYSTEM = "x86_64-linux"
+
+RepoToolchain = namedtuple(
+    "RepoToolchain",
+    "root probed gate_sh gate_tier ci_suite flake flake_pytest check_names "
+    "py_tests envrc_uses envrc_present",
+)
+
+# 🔴 `checks` AS A FLAKE OUTPUT, not as the word "checks". The first spelling of
+# this regex was `^\s*checks\b[^\n=]*=`, and it matched
+#
+#     checks = pr.get("statusCheckRollup", [])
+#
+# inside a python heredoc embedded in `homelab-infra`'s `flake.nix` devShell —
+# a repository whose flake declares NO `checks` output at all. A loose probe
+# that answers YES for a repo without the artifact regenerates the exact defect
+# this detection exists to close, one level down: the fallback would never be
+# reached and a `nix build …#checks…` would be prescribed anyway. So the shapes
+# accepted are the two a flake output can actually take, both requiring the
+# opening brace of an attrset to CLOSE the line.
+CHECKS_ATTR = re.compile(
+    r"^[ \t]*checks(?:\.[^\s=]+)?[ \t]*=[ \t]*(?:forAllSystems[^\n]*)?\{[ \t]*$",
+    re.M,
+)
+_NIX_NAME = re.compile(r"^[ \t]*([A-Za-z_][A-Za-z0-9_'-]*)[ \t]*=")
+_PROBE_MAX_BYTES = 400_000
+_PROBE_MAX_DIRS = 400
+_PROBE_MAX_DEPTH = 4
+_PROBE_SKIP_DIRS = {
+    ".git", "node_modules", "__pycache__", "result", ".direnv", ".venv",
+    "target", "dist", "build", ".mypy_cache", ".pytest_cache",
+}
+
+
+def _flake_check_names(text):
+    """-> the `checks.<system>` attribute names, [] if unreadable, None if none.
+
+    Three answers, because three different sentences are true of them, and
+    collapsing any two prescribes a command for a repo that does not have it:
+    `None` = this flake declares no `checks` output (there IS no sandbox tier);
+    `[]` = it declares one but this parse could not read the names (say so and
+    hand over `nix flake show`); a non-empty list = names to run.
+
+    Brace depth over the attrset, with nix's `''…''` indented strings skipped
+    so a shell body's braces do not close the block early. Measured on the two
+    real flakes: `devrc` -> ['pytests', 'nodetests'] (an indentation-only scan
+    returned ['pytests'], because a build script's lines start at column 0),
+    `homelab-infra` -> None on both its worktree and its HEAD copy.
+    """
+    if not text:
+        return None
+    m = CHECKS_ATTR.search(text)
+    if not m:
+        return None
+    names, depth, in_str = [], 0, False
+    for line in text[m.start():].splitlines()[:4000]:
+        code, i = [], 0
+        while i < len(line):
+            if line[i:i + 2] == "''":
+                in_str = not in_str
+                i += 2
+                continue
+            if not in_str:
+                code.append(line[i])
+            i += 1
+        code = "".join(code)
+        if depth == 1:
+            mm = _NIX_NAME.match(code)
+            if mm:
+                names.append(mm.group(1))
+        depth += code.count("{") - code.count("}")
+        if depth <= 0:
+            break
+    return names
+
+
+def _read_probe(base, rel):
+    """The text of `<base>/<rel>`, or None. Never raises, never writes."""
+    try:
+        p = base / rel
+        if not p.is_file():
+            return None
+        return p.read_text(encoding="utf-8", errors="replace")[:_PROBE_MAX_BYTES]
+    except OSError:
+        return None
+
+
+def _has_python_tests(base):
+    """True if a `test_*.py` exists within a BOUNDED walk of `base`.
+
+    Bounded on purpose — brief generation must not become slow or failure-prone
+    on a large checkout, and an unbounded walk of a monorepo is both. A cap hit
+    answers False, which lands in the honest not-detected wording rather than
+    prescribing a runner for tests nobody confirmed exist.
+    """
+    seen = 0
+    try:
+        base_depth = len(base.parts)
+        for root, dirs, files in os.walk(base):
+            seen += 1
+            if seen > _PROBE_MAX_DIRS:
+                return False
+            dirs[:] = [
+                d for d in dirs
+                if d not in _PROBE_SKIP_DIRS and not d.startswith(".")
+            ]
+            if len(Path(root).parts) - base_depth >= _PROBE_MAX_DEPTH:
+                dirs[:] = []
+            for f in files:
+                if f.startswith("test_") and f.endswith(".py"):
+                    return True
+    except OSError:
+        return False
+    return False
+
+
+def _envrc_uses(text):
+    """The `use …` lines of an `.envrc`, in order. [] if it has none."""
+    if text is None:
+        return None
+    return [ln.strip() for ln in text.splitlines() if ln.strip().startswith("use ")]
+
+
+def detect_repo_toolchain(root):
+    """Probe the repository the PR LIVES IN for the commands that exist there.
+
+    🔴 `root` is None whenever this run holds no checkout of that repository —
+    the cross-repo and unknown-relation branches of WHERE TO WORK. Every field
+    is then falsy and `render_toolchain` prescribes NOTHING, which is the whole
+    point: a fabricated command costs the auditor a round and can be reported
+    as a broken gate against a PR that is fine, so it is strictly worse than an
+    absent one.
+
+    Cheap and side-effect free by construction: `is_file`, a capped `read_text`
+    and one bounded `os.walk`. No build, no `nix` invocation, no network. A
+    probe that cannot answer answers "no".
+    """
+    if not root:
+        return RepoToolchain(None, False, None, False, False, False, False,
+                             None, False, None, False)
+    base = Path(root)
+    gate = _read_probe(base, "scripts/gate.sh")
+    flake = _read_probe(base, "flake.nix")
+    envrc = _read_probe(base, ".envrc")
+    try:
+        ci_suite = (base / "scripts" / "tests" / "run-ci-suite.sh").is_file()
+    except OSError:
+        ci_suite = False
+    return RepoToolchain(
+        root=str(root),
+        probed=True,
+        gate_sh=gate is not None,
+        # A FLAG IS AN ARTIFACT TOO. `--tier both` is devrc's spelling; another
+        # repo's `scripts/gate.sh` need not take it, and appending it blind is
+        # the same fabrication one argument over.
+        gate_tier=bool(gate and "--tier" in gate and "both" in gate),
+        ci_suite=ci_suite,
+        flake=flake is not None,
+        flake_pytest=bool(flake and "pytest" in flake),
+        check_names=_flake_check_names(flake),
+        py_tests=_has_python_tests(base),
+        envrc_uses=_envrc_uses(envrc),
+        envrc_present=envrc is not None,
+    )
+
+
+def toolchain_probe_root(facts):
+    """The checkout to probe — the PR's OWN repository, or None.
+
+    🔴 ONE derivation, reusing the relation WHERE TO WORK already decided. Only
+    the same-repo branch is standing in a checkout of the repository the PR
+    lives in; in the cross-repo branch `cwd_repo_dir` is a DIFFERENT project,
+    and probing it would answer questions about the wrong repository — the
+    original defect with a new source. "Unknown" is not "same": that is the
+    distinction `render_worktree_directive`'s own docstring was written for.
+    """
+    return facts.cwd_repo_dir if facts.repo_relation == "same" else None
+
+
+# 🔴 A CONSTANT, so state-independence is STRUCTURAL and not merely tested.
+# `test_the_toolchain_reason_is_true_in_every_scenario` used to pin this by
+# comparing the whole TOOLCHAIN section across every scenario for byte
+# equality; the commands below it are now derived from the target repository,
+# which is a DIFFERENT axis from the scenario axis that guard varies, so the
+# equality moved onto this block alone. It takes no argument at all, which is
+# the strongest form of the claim its own prose makes: this reason knows
+# nothing about where the auditor stands, and cannot be made to.
+TOOLCHAIN_HEAD = "\n".join([
+    "## TOOLCHAIN — the exact commands, and the two ways they lie",
+    "",
+    "🔴 `<your worktree>` below is **your own copy** — the one WHERE TO WORK "
+    "told you to make. The checkout this brief was assembled in appears below "
+    "at most ONCE, as the argument to `nix develop`, where it resolves the dev "
+    "shell and nothing else. Never point a gate script or a `nix build` at it: "
+    "a gate script resolves its root from its own path, so running that copy "
+    "runs the suite in a checkout that is NOT yours — one holding none of your "
+    "mutations — and a `nix build <ref>#…` builds that ref's tree, not yours.",
+])
+
+# 🔴 ALSO A CONSTANT, and for the same reason. Both notes are true of every
+# repository and every checkout state; only what sits BETWEEN them is derived.
+TOOLCHAIN_TAIL = "\n".join([
+    "Name the tier and the base sha in any claim you make about the gate — "
+    "\"the gate passed\" is true of one run, one tier, one base, and reads "
+    "as a property of the change. 🔴 Name the RUNNER too, by path: everything "
+    "above was PROBED out of this repository rather than assumed, so a claim "
+    "about \"the gate\" that does not say which script produced it cannot be "
+    "checked by anyone reading your report.",
+    "",
+    "`git --version` before you trust a range: `--remerge-diff` needs git "
+    "≥ 2.35, and a git without it exits 128 with EMPTY output, which reads "
+    "exactly like a clean zero.",
+])
+
+TOOLCHAIN_COMMANDS_HEADING = "### The commands — PROBED, not assumed"
+
+
+def _toolchain_not_probed(facts):
+    """The honest refusal: nothing was read, so nothing is prescribed."""
+    return [
+        TOOLCHAIN_COMMANDS_HEADING,
+        "",
+        "🔴 **NOTHING WAS PROBED HERE, SO NOTHING IS PRESCRIBED.** The PR "
+        f"lives in `{facts.repo}`, and this run holds no checkout of that "
+        "repository to read — "
+        + ("WHERE TO WORK could not establish which repository the PR is in"
+           if facts.repo_relation == "unknown" else
+           f"`{facts.cwd_repo_dir}` is a DIFFERENT repository")
+        + ". So this brief does not know what that repository's gate is "
+        "called, or whether it has one.",
+        "",
+        "🔴 **That silence is deliberate — do not read it as \"there is no "
+        "gate\".** A command invented here would cost you a round, and a "
+        "missing script reads exactly like a broken gate, which is a finding "
+        "against a PR that is fine.",
+        "",
+        "Find the runner yourself, in the worktree WHERE TO WORK told you to "
+        "make — `scripts/gate.sh`, `scripts/tests/run-ci-suite.sh`, a "
+        "`Makefile` target, the repo's CI workflow, its `CLAUDE.md` — and "
+        "**NAME the one you used, by path**, in your report.",
+    ]
+
+
+def toolchain_shell(tc):
+    """The `nix develop <r> -c ` prefix, or "" — ONE rule, ONE place.
+
+    🔴 It was two, briefly, and they disagreed: the subset command asked
+    "does this flake provide pytest" and the gate command asked only "is there
+    a flake", so a repository with a flake that does NOT carry the test
+    toolchain got a `nix develop` wrapper around its own runner — which is how
+    `homelab-infra`'s `run-ci-suite.sh`, a script that works because it uses
+    the AMBIENT python, would have been prescribed inside a shell measured to
+    have no pytest in it. A flake alone is not evidence of a test shell.
+
+    `tc.root` is the checkout the brief was assembled in AND a checkout of the
+    PR's repository — the two coincide in the only branch that reaches here,
+    which is why this one use of it is sound where pointing a gate at it is
+    not: it resolves a dev shell, never a tree under test.
+    """
+    return f"nix develop {tc.root} -c " if (tc.flake and tc.flake_pytest) else ""
+
+
+def _toolchain_pytest_lines(facts, tc):
+    """The subset-run command, and the wrong-shell diagnosis that goes with it.
+
+    🔴 THE SHELL IS PROBED TOO. `nix develop <r> -c python3 -m pytest` was
+    emitted unconditionally, and MEASURED against `homelab-infra` it exits
+    `ModuleNotFoundError: No module named 'pytest'` — while the very next bar
+    told the auditor that error means the WRONG SHELL and not a broken suite.
+    So the brief manufactured a failure and then instructed the reader to
+    disregard the one true signal it had produced. That repo's own runner
+    invokes a BARE `python3 -m pytest`, which works.
+    """
+    if not tc.py_tests:
+        return []
+    shell = toolchain_shell(tc)
+    lines = [
+        "Run a SUBSET of the suite:",
+        "",
+        "```",
+        f"{shell}python3 -m pytest <paths> -q -p no:cacheprovider",
+        "```",
+        "",
+    ]
+    if shell:
+        lines.append(
+            "🔴 A bare `python3 -m pytest` failing with **`No module named "
+            "pytest`** means you are in the WRONG SHELL, not that the suite is "
+            f"broken. This repo's `.envrc` is {_fmt_uses(tc)}, which does not "
+            "put pytest on PATH; a loaded direnv is not the dev shell. Do not "
+            "report that as a finding and do not build an ad-hoc `nix-shell` "
+            "around it."
+        )
+    else:
+        lines.append(
+            "⚠ The command above is BARE on purpose: this brief did not detect "
+            "a dev shell that puts pytest on PATH for this repository "
+            + ("(its `flake.nix` names no pytest anywhere)" if tc.flake else
+               "(it has no `flake.nix`)")
+            + f", and its `.envrc` is {_fmt_uses(tc)}. 🔴 If it fails with "
+            "**`No module named pytest`** you are in the WRONG SHELL and not "
+            "looking at a broken suite: find the shell this repository's own "
+            "runner uses, say which in your report, and do not build an ad-hoc "
+            "`nix-shell` around it."
+        )
+    return lines + [""]
+
+
+def _fmt_uses(tc):
+    """The target repo's `.envrc`, as read — never a remembered string."""
+    if not tc.envrc_present:
+        return ("absent from the tree probed (it may be gitignored, in which "
+                "case it never came with your worktree either)")
+    if not tc.envrc_uses:
+        return "present but declares no `use` line"
+    return " + ".join(f"`{u}`" for u in tc.envrc_uses)
+
+
+def _toolchain_gate_lines(facts, tc):
+    """The repo's own runner(s) — or the refusal to name one."""
+    shell = toolchain_shell(tc)
+    cmds = []
+    if tc.gate_sh:
+        tier = " --tier both" if tc.gate_tier else ""
+        cmds.append(f"{shell}bash <your worktree>/scripts/gate.sh{tier}")
+    if tc.ci_suite:
+        cmds.append(f"{shell}bash <your worktree>/scripts/tests/run-ci-suite.sh")
+    if not cmds:
+        return [
+            "🔴 **NO REPO GATE WAS DETECTED.** Neither `scripts/gate.sh` nor "
+            f"`scripts/tests/run-ci-suite.sh` exists in `{tc.root}`, so this "
+            "brief will not name a runner it cannot see — a command that does "
+            "not exist costs you a round and reads exactly like a broken gate. "
+            "Find the runner yourself (a `Makefile` target, the CI workflow, "
+            "the repo's `CLAUDE.md`) and **NAME the one you used, by path**.",
+            "",
+        ]
+    return [
+        "Run the repository's own gate (its EXIT STATUS is authoritative; also "
+        "read each runner's own `RESULT:` line)"
+        + (" — BOTH of these exist here, so say which you ran"
+           if len(cmds) > 1 else "") + ":",
+        "",
+        "```",
+        *cmds,
+        "```",
+        "",
+    ]
+
+
+# 🔴 KEPT FROM #1104, DELIBERATELY, AND IT IS THE ONE THING THERE THIS FILE
+# COULD NOT DERIVE FOR ITSELF. `_flake_check_names` is a REGEX over `flake.nix`,
+# so it can be wrong in both directions — a `checks` output declared through a
+# helper this pattern does not match reads as absent, and a name it does read
+# could still fail to resolve. #1104's discriminator is what lets the auditor
+# CHECK this brief instead of trusting it, and its argument for `nix eval` over
+# `nix flake show` is right and is why it replaced the `flake show` this branch
+# first suggested: `nix eval` on a repo with no `checks` **errors outright**,
+# where a listing that comes back empty is indistinguishable from a listing
+# that failed. An empty result cannot separate two mechanisms; an error can.
+CHECKS_DISCRIMINATOR = (
+    f"nix eval <your worktree>#checks.{NIX_SYSTEM} --apply builtins.attrNames"
+)
+
+
+def _toolchain_checks_lines(facts, tc):
+    """The sandbox tier — only when the flake really declares one."""
+    if not tc.flake:
+        return [
+            f"⚠ `{tc.root}` has no `flake.nix`, so there is no "
+            "`nix build …#checks…` tier to run; the runner above is the only "
+            "gate this brief could find.",
+            "",
+        ]
+    if tc.check_names is None:
+        return [
+            f"⚠ `{tc.root}/flake.nix` declares **no `checks` output**, so this "
+            "repository has no sandbox tier — `nix build <your "
+            f"worktree>#checks.{NIX_SYSTEM}.…` would fail with an attribute "
+            "error, which is a fact about the REPO and not a finding about the "
+            "PR. The runner above is the only gate this brief could find. That "
+            "reading came from a regex over `flake.nix`, so if you want to "
+            f"confirm it rather than trust it: `{CHECKS_DISCRIMINATOR}` errors "
+            "outright in a repo that has none, which an empty listing cannot "
+            "tell you.",
+            "",
+        ]
+    if not tc.check_names:
+        return [
+            f"⚠ `{tc.root}/flake.nix` declares `checks` outputs, but this "
+            "brief could not read their names out of it. List them with "
+            f"`{CHECKS_DISCRIMINATOR}` and run each — do NOT guess a name.",
+            "",
+        ]
+    return [
+        "🔴 The gate above is the DEV-HOST tier. **The tier the merge actually "
+        "gates on is the sandbox one**, which builds from a store copy with no "
+        "`.git` and is therefore blind to different things. These names were "
+        f"read out of `{tc.root}/flake.nix` by a regex; if `nix build` reports "
+        f"one is not an attribute, run `{CHECKS_DISCRIMINATOR}` and use what it "
+        "lists rather than reporting a broken gate:",
+        "",
+        "```",
+        *[f"nix build <your worktree>#checks.{NIX_SYSTEM}.{n}"
+          for n in tc.check_names],
+        "```",
+        "",
+    ]
+
+
 def render_toolchain(facts):
     """🔴 The operator's checkout resolves the TOOLCHAIN and nothing else.
 
@@ -2029,136 +2439,84 @@ def render_toolchain(facts):
     nothing about where the auditor stands, so it says only what is true in
     every state — that copy is not yours and holds none of your mutations.
     `test_the_toolchain_reason_is_true_in_every_scenario` drives EVERY scenario
-    that module knows and requires this section byte-identical across all of
+    that module knows and requires this REASON byte-identical across all of
     them — round 5 drove two, both same-repo, and round 6 measured that a
     cross-repo-only reword walked it.
+
+    🔴 ROUND 14 — THE REASON WAS STATE-INDEPENDENT AND THE COMMANDS WERE
+    DEVRC-SHAPED. Every command below `r = facts.cwd_repo_dir` was hardcoded to
+    THIS repository's layout, so a brief generated for any other target
+    prescribed scripts that do not exist there.
+
+    🔴 THIS REWRITES A FUNCTION #1104 (`9e23c379`) JUST LANDED, AND TAKES THE
+    DECISION THAT PR EXPLICITLY DEFERRED: "a repo-AWARE toolchain section is
+    the bigger fix and is deliberately not taken here — it needs that pin
+    relaxed, which is a design decision for the tool's owner." #1104 hedged the
+    prose — "if this repo has one", "exist in SOME repos and not others" — and
+    left all four commands INSIDE the fences and the `.envrc` sentence
+    hardcoded. Re-measured on merged `origin/main` at `9e23c379`, against a
+    real `homelab-infra` checkout: all four still emitted, and the brief still
+    says "This repo's `.envrc` is `use opencode`" for a file whose `use` lines
+    are `use flake` and `use opencode`. Hedging prose does not stop an auditor
+    copying a fenced command. What IS kept from #1104 is its discriminator —
+    see `CHECKS_DISCRIMINATOR`, which is better than what this branch first
+    wrote and replaced it.
+
+    Measured against `ZacxDev/homelab-infra` for its PR #530, from a real
+    checkout of it:
+
+        scripts/gate.sh                      ABSENT (rc 2, no such file)
+        flake `checks` outputs               NONE declared, at HEAD and in-tree
+        .envrc                               `use flake` + `use opencode`,
+                                             not the `use opencode` asserted
+        its real runner                      scripts/tests/run-ci-suite.sh
+        nix develop <root> -c python3 -m pytest
+                                             ModuleNotFoundError: No module
+                                             named 'pytest'
+
+    Three prescribed commands that cannot run, one false statement about
+    `.envrc` — and the fourth is the worst of the four, because the bar
+    immediately under it told the auditor that `No module named pytest` means
+    the WRONG SHELL and not a broken suite. The brief manufactured a failure
+    and then instructed the reader to disregard the only true signal it had
+    produced. An auditor following it verbatim burns a round on four missing
+    things and can plausibly report the gate broken against a PR that is fine.
+
+    🔴 SO THE SECTION IS SPLIT ON THE AXIS THAT ACTUALLY VARIES. The REASON
+    (`TOOLCHAIN_HEAD`/`TOOLCHAIN_TAIL`) is now a CONSTANT taking no argument —
+    state-independence made structural rather than merely asserted — and only
+    the COMMANDS between them are derived, by `detect_repo_toolchain`, from the
+    repository the PR lives in. Those are two different axes: the guard varies
+    the SCENARIO, and the scenario does not change what is on the target's
+    disk. `toolchain_probe_root` is the single place that decides which
+    checkout may be read, and it reuses the relation WHERE TO WORK already
+    computed rather than deriving a second one.
+
+    🔴 AND WHEN NOTHING CAN BE PROBED, NOTHING IS PRESCRIBED. Cross-repo, this
+    run holds no checkout of the PR's repository; the section then says so and
+    hands the search over, because a fabricated command is strictly worse than
+    an absent one — the absent one costs a lookup, the fabricated one costs a
+    round and can be written up as a finding.
     """
-    r = facts.cwd_repo_dir
-    return "\n".join([
-        "## TOOLCHAIN — the exact commands, and the two ways they lie",
-        "",
-        "🔴 `<your worktree>` below is **your own copy** — the one WHERE TO WORK "
-        f"told you to make. `{r}` appears ONLY as the argument to `nix develop`, "
-        "where it resolves the dev shell and nothing else. Never point the gate "
-        "or a `nix build` at it: `gate.sh` resolves its root from its own path, "
-        "so running that copy runs the suite in a checkout that is NOT yours — "
-        "the one this brief was assembled in, on whatever branch it is standing "
-        "on, holding none of your mutations — and a `nix build <ref>#…` builds "
-        "that ref's tree, not yours.",
-        "",
-        "Run a SUBSET of the suite:",
-        "",
-        "```",
-        f"nix develop {r} -c python3 -m pytest <paths> -q -p no:cacheprovider",
-        "```",
-        "",
-        "🔴 A bare `python3 -m pytest` failing with **`No module named "
-        "pytest`** means you are in the WRONG SHELL, not that the suite is "
-        "broken. This repo's `.envrc` is `use opencode`, which does not put "
-        "pytest on PATH; a loaded direnv is not the dev shell. Do not report "
-        "that as a finding and do not build an ad-hoc `nix-shell` around it.",
-        "",
-        "Run the whole dev-host gate, **if this repo has one** — `scripts/gate.sh` "
-        "and the `checks` flake outputs below exist in SOME repos and not "
-        "others. 🔴 Check before you run, and if they are absent that is a "
-        "fact about the repo, NOT a finding about the PR and NOT a reason to "
-        "build an ad-hoc substitute: find how this repo actually runs its "
-        "suite (here it may be `scripts/tests/run-ci-suite.sh` off a manifest) "
-        "and say in your report which tier you actually exercised. Where it "
-        "does exist, its EXIT STATUS is authoritative; also read each "
-        "runner's own `RESULT:` line:",
-        "",
-        "```",
-        f"nix develop {r} -c bash <your worktree>/scripts/gate.sh --tier both",
-        "```",
-        "",
-        "🔴 The gate above is the DEV-HOST tier. Where a repo ALSO exposes "
-        "`checks` flake outputs, **the tier the merge gates on is the sandbox "
-        "one**, which builds from a store copy with no `.git` and is therefore "
-        "blind to different things. Confirm they exist before quoting a result "
-        "from them — `nix eval <repo>#checks.x86_64-linux --apply builtins.attrNames` "
-        "errors outright in a repo that has none, and a brief that ASSERTED "
-        "they exist sent one audit chasing a tier its repo does not have:",
-        "",
-        "```",
-        "nix build <your worktree>#checks.x86_64-linux.pytests --no-link -L",
-        "nix build <your worktree>#checks.x86_64-linux.nodetests --no-link -L",
-        "```",
-        "",
-        "🔴 **`-L` IS NOT OPTIONAL AND THIS BRIEF USED TO OMIT IT.** `nix build` "
-        "prints NO build log for a build that SUCCEEDS unless you pass "
-        "`-L`/`--print-build-logs` — so the instruction above to read a "
-        "`RESULT:` line was, for the sandbox tier, an instruction to read "
-        "something that is never printed. MEASURED 2026-08-30 on a builder "
-        "emitting 201 lines plus a `RESULT:` line: without `-L`, **3 console "
-        "lines, 0 builder lines**. ⚠ A FAILING build is the exception — nix "
-        "prints the tail of its log inline, bounded by `log-lines` (25 by "
-        "default), which is why the omission survived: the red case looked fine.",
-        "",
-        "⚠ **`--no-link` is deliberate**: you are briefed READ-ONLY, and the "
-        "un-flagged form drops a `result` symlink into your cwd. It changes "
-        "nothing about what is built or logged.",
-        "",
-        "🔴 **AND `-L` WRITES TO STDERR, SO A BARE PIPE OR `>` CAPTURES NOTHING "
-        "— REDIRECT IT.** An earlier draft of this very block said \"even a "
-        "`| tail -40` keeps the `RESULT:` line as its last\", which is FALSE as "
-        "written and was caught by an audit of the commit that added it. "
-        "Measured on the same builder: `-L … | tail -40` with stderr left alone "
-        "keeps **0 lines and 0 `RESULT:` hits**; `-L … 2>&1 | tail -40` keeps 40 "
-        "lines with `RESULT:` last. The `nix log` form below is the opposite — "
-        "it writes to STDOUT, so `>` works there and not here. **Do not carry a "
-        "redirect across from one to the other.**",
-        "",
-        "🔴 **AND AN ALREADY-BUILT DERIVATION PRINTS NOTHING AT ALL, `-L` OR "
-        "NOT — so silence is never a pass.** Read the derivation's own log "
-        "instead, which survives caching and a swallowed console:",
-        "",
-        "```",
-        "DRV=$(nix path-info --derivation <your worktree>#checks.x86_64-linux.pytests)",
-        "[ -n \"$DRV\" ] || { echo 'NO DERIVATION — this repo has no such tier'; exit 1; }",
-        "nix log \"$DRV\" > /tmp/tier.log || { echo 'NO LOG — never built HERE'; exit 1; }",
-        "test -s /tmp/tier.log || { echo 'EMPTY LOG — do not grep it'; exit 1; }",
-        "grep -n 'RESULT:' /tmp/tier.log          # the LAST hit is the verdict",
-        "grep -c 'panic: test timed out' /tmp/tier.log",
-        "```",
-        "",
-        "🔴 **ALL THREE GUARD LINES ARE LOAD-BEARING, AND THEY CLOSE THREE "
-        "DIFFERENT FALSE GREENS — DO NOT DROP ANY OF THEM.**",
-        "",
-        "- **`[ -n \"$DRV\" ]` — the worst one, because it fails LOUD-LOOKING.** "
-        "If the tier does not exist, `nix path-info --derivation` errors to "
-        "STDERR (which the `>` two lines down discards) and `$DRV` is EMPTY. "
-        "`nix log \"\"` does not fail — it resolves the empty installable as `.` "
-        "and prints **the cwd flake's default package log**. MEASURED in a "
-        "throwaway flake: neither of the other two guards fires, `test -s` "
-        "passes because the file is genuinely non-empty, and the auditor greps a "
-        "FOREIGN log reading `RESULT: PASS (exit=0)`. That is an affirmative "
-        "false green off another derivation entirely — strictly worse than the "
-        "silence this block was written to fix. ⚠ A repo with no "
-        "`packages.default` is immune by luck of flake shape, not by design.",
-        "- **`|| { … }` on `nix log`** — a derivation never built HERE exits **1** "
-        "with `build log … is not available`, but `>` has already truncated the "
-        "file, so `grep -c 'panic: test timed out'` prints a reassuring **0**, "
-        "identical to a green run. MEASURED on this repo's own "
-        "`checks.x86_64-linux.nodetests`.",
-        "- **`test -s`** — guards EMPTY only, and claims nothing about a "
-        "truncated log.",
-        "",
-        "An earlier draft of this block said \"do NOT read an exit code\" here, "
-        "which suppressed the one signal separating those states. Read the "
-        "CONTENT — and check there IS content, and that it is YOURS, first. "
-        "⚠ `exit 1` is right for a dispatched agent's fresh shell; pasted into "
-        "an INTERACTIVE shell it closes it, so the diagnosis is echoed before "
-        "each exit.",
-        "",
-        "Name the tier and the base sha in any claim you make about the gate — "
-        "\"the gate passed\" is true of one run, one tier, one base, and reads "
-        "as a property of the change.",
-        "",
-        "`git --version` before you trust a range: `--remerge-diff` needs git "
-        "≥ 2.35, and a git without it exits 128 with EMPTY output, which reads "
-        "exactly like a clean zero.",
-    ])
+    tc = detect_repo_toolchain(toolchain_probe_root(facts))
+    if not tc.probed:
+        body = _toolchain_not_probed(facts)
+    else:
+        body = [
+            TOOLCHAIN_COMMANDS_HEADING,
+            "",
+            f"Everything below was read off `{tc.root}`, a checkout of "
+            f"`{facts.repo}` — the repository this PR lives in. It may be "
+            "standing on another branch, so treat a command that has since "
+            "moved as a lookup, never as a finding.",
+            "",
+            *_toolchain_pytest_lines(facts, tc),
+            *_toolchain_gate_lines(facts, tc),
+            *_toolchain_checks_lines(facts, tc),
+        ]
+    while body and not body[-1]:
+        body.pop()
+    return "\n".join([TOOLCHAIN_HEAD, "", *body, "", TOOLCHAIN_TAIL])
 
 
 def payload_summary_line(facts, cumulative):

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -2879,7 +2879,20 @@ def _toolchain_checks_lines(tc):
         "lists rather than reporting a broken gate:",
         "",
         "```",
-        *[f"nix build <your worktree>#checks.{NIX_SYSTEM}.{n}"
+        # 🔴 `--no-link -L` IS NOT DECORATION, AND THIS LINE IS A MERGED-TREE
+        # RESOLUTION. `nix build` prints NO build log for a build that SUCCEEDS
+        # unless you pass `-L`/`--print-build-logs`, so the sentence above
+        # telling the auditor to read a runner's own `RESULT:` line is, for the
+        # sandbox tier, an instruction to read something never printed;
+        # `--no-link` keeps a `result` symlink out of the cwd of an auditor
+        # briefed READ-ONLY. `5324bf47` (#1133) fixed exactly that on the two
+        # HARDCODED lines this branch replaced with a probed list — the two
+        # changes are textually disjoint and semantically collide, and the
+        # merged tree was RED on `_assert_every_nix_build_prints_its_log` until
+        # this carried the flags. Emitting them per NAME rather than twice is
+        # what that guard's own docstring asks for: "a THIRD tier added later is
+        # covered automatically".
+        *[f"nix build <your worktree>#checks.{NIX_SYSTEM}.{n} --no-link -L"
           for n in tc.check_names],
         "```",
         "",

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -2019,13 +2019,35 @@ RepoToolchain = namedtuple(
 # a repository whose flake declares NO `checks` output at all. A loose probe
 # that answers YES for a repo without the artifact regenerates the exact defect
 # this detection exists to close, one level down: the fallback would never be
-# reached and a `nix build …#checks…` would be prescribed anyway. So the shapes
-# accepted are the two a flake output can actually take, both requiring the
-# opening brace of an attrset to CLOSE the line.
-CHECKS_ATTR = re.compile(
-    r"^[ \t]*checks(?:\.[^\s=]+)?[ \t]*=[ \t]*(?:forAllSystems[^\n]*)?\{[ \t]*$",
-    re.M,
-)
+# reached and a `nix build …#checks…` would be prescribed anyway.
+#
+# 🔴 ROUND 15 — THE REGEX WAS NEVER THE DEFENCE, AND MEASURING IT SAID SO. Both
+# patterns below now run over `_nix_strip`ped text, so a `checks = {` inside a
+# devShell heredoc or inside a `/* … */` comment is not text either of them can
+# see. Measured at `5bad0a0c` against the un-stripped scanner: a heredoc holding
+#
+#     checks = {
+#     unit = 1;
+#     }
+#
+# answered `['unit']` and the brief fenced `nix build …#checks.x86_64-linux.unit`
+# for a flake declaring nothing of the sort; a `/* */`-commented block did the
+# same. The strictness of the opening-brace requirement had closed ONE spelling
+# of that hazard (`checks = pr.get(...)`) and left the shape it was written for.
+#
+# 🔴 AND THE STRICTNESS WAS ALSO WRONG IN THE OTHER DIRECTION. `CHECKS_ATTR`
+# accepted three shapes — `checks = {`, `checks.<x> = {`, and a `forAllSystems`
+# call named by HARDCODING devrc's own helper — and answered `None` ("this
+# repository HAS no sandbox tier") for `genAttrs`, for flake-parts' `perSystem`
+# `checks.default`, for `checks.<system>.default = …` and for
+# `checks.<system> = base // {…}`. `None` is the CONFIDENT answer, and the brief
+# states it in bold; the safe answer for a shape that is recognisably a `checks`
+# declaration whose names cannot be read is `[]` — "declared, names unreadable,
+# here is the discriminator". So `CHECKS_ATTR` is now any `checks` binding whose
+# line ENDS in the attrset's opening brace (the names are readable), and
+# `CHECKS_DECL` is any `checks` binding at all (declared; names not readable).
+CHECKS_ATTR = re.compile(r"^[ \t]*checks(?:\.[^\s=]+)*[ \t]*=[^\n]*\{[ \t]*$", re.M)
+CHECKS_DECL = re.compile(r"^[ \t]*checks(?:\.[^\s=]+)*[ \t]*=", re.M)
 _NIX_NAME = re.compile(r"^[ \t]*([A-Za-z_][A-Za-z0-9_'-]*)[ \t]*=")
 _PROBE_MAX_BYTES = 400_000
 _PROBE_MAX_DIRS = 400
@@ -2036,43 +2058,137 @@ _PROBE_SKIP_DIRS = {
 }
 
 
+def _nix_strip(text):
+    """`text` with strings and comments BLANKED — same length, same newlines.
+
+    🔴 ONE PASS, BEFORE ANY PATTERN RUNS, and the length invariant is what lets
+    a `re.M` match index straight back into the scan below. Everything a nix
+    lexer would not treat as code becomes a space: `''…''` indented strings,
+    `"…"` strings, `#` line comments and `/* … */` block comments. Newlines are
+    preserved so a line-anchored pattern still sees the same line structure.
+
+    🔴 THE `''` ESCAPES ARE THE POINT, AND THEY ARE THE MEASURED DEFECT. The
+    previous scanner toggled "in string" on ANY `''`, and nix spells three
+    different things with two apostrophes: `''` opens/closes, `''${…}` is a
+    LITERAL `${`, and `'''` is a literal `''`. Measured at `5bad0a0c` on devrc's
+    OWN `flake.nix` with a single `echo ''${HOME}` added inside the `pytests`
+    build script, the toggle closed the string early and the answer went from
+    `['pytests', 'nodetests']` to `['pytests', 'rc', 'rc']` — TWO fabricated
+    `nix build` targets named after a shell variable, and `nodetests`, a check
+    the merge really does gate on, dropped in silence. A non-empty list is
+    indistinguishable from a complete one, so the `[]` valve never fires.
+    devrc's flake carries no `''${` today; one ordinary edit is the whole
+    distance between here and that answer.
+
+    🔴 A STATED LIMIT, not a covered case: `${…}` INTERPOLATIONS inside a string
+    are real nix code and this blanks them with the rest of the string. So a
+    `checks` binding written inside an interpolation is invisible here. That is
+    the SAFE direction — the probe under-reads and the brief hedges — and it is
+    the direction chosen deliberately, because the alternative is a recursive
+    lexer for a heuristic whose whole job is to avoid confident wrong answers.
+    """
+    out = list(text)
+    i, n = 0, len(text)
+
+    def blank(start, stop):
+        for k in range(start, min(stop, n)):
+            if out[k] != "\n":
+                out[k] = " "
+
+    while i < n:
+        two = text[i:i + 2]
+        if two == "''":                       # indented string
+            blank(i, i + 2)
+            i += 2
+            while i < n:
+                if text[i:i + 2] == "''":
+                    nxt = text[i + 2:i + 3]
+                    if nxt in ("$", "'"):     # ''${…}  and  '''  — escapes
+                        blank(i, i + 3)
+                        i += 3
+                        continue
+                    if nxt == "\\":           # ''\<c> — an escape sequence
+                        blank(i, i + 4)
+                        i += 4
+                        continue
+                    blank(i, i + 2)           # the terminator
+                    i += 2
+                    break
+                blank(i, i + 1)
+                i += 1
+            continue
+        if text[i] == '"':                    # ordinary string
+            blank(i, i + 1)
+            i += 1
+            while i < n:
+                if text[i] == "\\":
+                    blank(i, i + 2)
+                    i += 2
+                    continue
+                if text[i] == '"':
+                    blank(i, i + 1)
+                    i += 1
+                    break
+                blank(i, i + 1)
+                i += 1
+            continue
+        if text[i] == "#":                    # line comment
+            j = text.find("\n", i)
+            j = n if j == -1 else j
+            blank(i, j)
+            i = j
+            continue
+        if two == "/*":                       # block comment
+            j = text.find("*/", i + 2)
+            j = n if j == -1 else j + 2
+            blank(i, j)
+            i = j
+            continue
+        i += 1
+    return "".join(out)
+
+
 def _flake_check_names(text):
     """-> the `checks.<system>` attribute names, [] if unreadable, None if none.
 
     Three answers, because three different sentences are true of them, and
-    collapsing any two prescribes a command for a repo that does not have it:
+    collapsing any two either prescribes a command for a repo that does not
+    have it or denies a tier to one that does:
     `None` = this flake declares no `checks` output (there IS no sandbox tier);
     `[]` = it declares one but this parse could not read the names (say so and
-    hand over `nix flake show`); a non-empty list = names to run.
+    hand over `CHECKS_DISCRIMINATOR` — `nix eval …#checks.<system> --apply
+    builtins.attrNames`, which is what the code has always done; this docstring
+    said `nix flake show` for two rounds while the function three bars below
+    argues at length why `flake show` is the WRONG instrument here);
+    a non-empty list = names to run.
 
-    Brace depth over the attrset, with nix's `''…''` indented strings skipped
-    so a shell body's braces do not close the block early. Measured on the two
-    real flakes: `devrc` -> ['pytests', 'nodetests'] (an indentation-only scan
-    returned ['pytests'], because a build script's lines start at column 0),
-    `homelab-infra` -> None on both its worktree and its HEAD copy.
+    🔴 DEGRADE TOWARD THE HEDGE, NEVER TOWARD THE CONFIDENT ANSWER. A shape
+    this parse recognises as a `checks` binding but cannot enumerate answers
+    `[]` and not `None`: `None` makes the brief state in bold that the
+    repository has no sandbox tier — the tier the same section calls the one
+    the merge gates on — and it was the answer for `genAttrs`, for flake-parts'
+    `perSystem`, and for `checks.<system> = base // {…}`.
+
+    Brace depth over the attrset, run over `_nix_strip`ped source so neither a
+    build script's braces nor a heredoc's text can move the counter. Measured
+    on the two real flakes: `devrc` -> ['pytests', 'nodetests'] (an
+    indentation-only scan returned ['pytests'], because a build script's lines
+    start at column 0), `homelab-infra` -> None on both its worktree and its
+    HEAD copy.
     """
     if not text:
         return None
-    m = CHECKS_ATTR.search(text)
+    code = _nix_strip(text)
+    m = CHECKS_ATTR.search(code)
     if not m:
-        return None
-    names, depth, in_str = [], 0, False
-    for line in text[m.start():].splitlines()[:4000]:
-        code, i = [], 0
-        while i < len(line):
-            if line[i:i + 2] == "''":
-                in_str = not in_str
-                i += 2
-                continue
-            if not in_str:
-                code.append(line[i])
-            i += 1
-        code = "".join(code)
+        return [] if CHECKS_DECL.search(code) else None
+    names, depth = [], 0
+    for line in code[m.start():].splitlines()[:4000]:
         if depth == 1:
-            mm = _NIX_NAME.match(code)
+            mm = _NIX_NAME.match(line)
             if mm:
                 names.append(mm.group(1))
-        depth += code.count("{") - code.count("}")
+        depth += line.count("{") - line.count("}")
         if depth <= 0:
             break
     return names
@@ -2089,13 +2205,32 @@ def _read_probe(base, rel):
         return None
 
 
-def _has_python_tests(base):
-    """True if a `test_*.py` exists within a BOUNDED walk of `base`.
+# 🔴 THREE ANSWERS, FOR THE SAME REASON `_flake_check_names` HAS THREE. "I
+# found none" and "I stopped looking" are different sentences, and a probe that
+# spells them the same way makes the brief state the first when the second is
+# true.
+PY_TESTS_FOUND = "found"
+PY_TESTS_NONE = "none"
+PY_TESTS_UNKNOWN = "unknown"
+
+
+def _python_test_probe(base):
+    """-> FOUND / NONE / UNKNOWN for `test_*.py` within a BOUNDED walk of `base`.
 
     Bounded on purpose — brief generation must not become slow or failure-prone
-    on a large checkout, and an unbounded walk of a monorepo is both. A cap hit
-    answers False, which lands in the honest not-detected wording rather than
-    prescribing a runner for tests nobody confirmed exist.
+    on a large checkout, and an unbounded walk of a monorepo is both.
+
+    🔴 THE CAP USED TO FAIL SILENTLY, AND IT WAS THE ONLY PROBE HERE THAT DID.
+    It answered `False`, this function's docstring called that "the honest
+    not-detected wording", and there was no such wording: `_toolchain_pytest_
+    lines` returned `[]`, so the subset command AND the whole wrong-shell bar
+    vanished with no note at all, while `_toolchain_gate_lines` and
+    `_toolchain_checks_lines` each emit an explicit absence bar. Measured
+    2026-08-30 on `~/workspace/civit`: 157,319 directories within depth ≤ 4
+    after the skip list, first `test_*.py` at walk visit 1,185, so
+    `_PROBE_MAX_DIRS` is reached long before it — `False` for a repository that
+    HAS a python suite. `os.walk` order is arbitrary, so which side of the cap
+    a monorepo lands on is not even stable between runs.
     """
     seen = 0
     try:
@@ -2103,7 +2238,7 @@ def _has_python_tests(base):
         for root, dirs, files in os.walk(base):
             seen += 1
             if seen > _PROBE_MAX_DIRS:
-                return False
+                return PY_TESTS_UNKNOWN
             dirs[:] = [
                 d for d in dirs
                 if d not in _PROBE_SKIP_DIRS and not d.startswith(".")
@@ -2112,10 +2247,10 @@ def _has_python_tests(base):
                 dirs[:] = []
             for f in files:
                 if f.startswith("test_") and f.endswith(".py"):
-                    return True
+                    return PY_TESTS_FOUND
     except OSError:
-        return False
-    return False
+        return PY_TESTS_UNKNOWN
+    return PY_TESTS_NONE
 
 
 def _envrc_uses(text):
@@ -2137,11 +2272,28 @@ def detect_repo_toolchain(root):
 
     Cheap and side-effect free by construction: `is_file`, a capped `read_text`
     and one bounded `os.walk`. No build, no `nix` invocation, no network. A
-    probe that cannot answer answers "no".
+    probe that cannot answer answers "no" — except `py_tests`, which has a
+    third answer, because "I stopped looking" is not "there are none".
+
+    🔴 BUILT BY KEYWORD IN BOTH BRANCHES. The not-probed branch used to pass
+    ELEVEN bare positional values, so reordering a field of an 11-tuple
+    mis-assigned every one after it in silence while the other construction —
+    keyword — stayed correct, and nothing compares the two.
     """
     if not root:
-        return RepoToolchain(None, False, None, False, False, False, False,
-                             None, False, None, False)
+        return RepoToolchain(
+            root=None,
+            probed=False,
+            gate_sh=None,
+            gate_tier=False,
+            ci_suite=False,
+            flake=False,
+            flake_pytest=False,
+            check_names=None,
+            py_tests=PY_TESTS_UNKNOWN,
+            envrc_uses=None,
+            envrc_present=False,
+        )
     base = Path(root)
     gate = _read_probe(base, "scripts/gate.sh")
     flake = _read_probe(base, "flake.nix")
@@ -2162,7 +2314,7 @@ def detect_repo_toolchain(root):
         flake=flake is not None,
         flake_pytest=bool(flake and "pytest" in flake),
         check_names=_flake_check_names(flake),
-        py_tests=_has_python_tests(base),
+        py_tests=_python_test_probe(base),
         envrc_uses=_envrc_uses(envrc),
         envrc_present=envrc is not None,
     )
@@ -2189,27 +2341,46 @@ def toolchain_probe_root(facts):
 # equality moved onto this block alone. It takes no argument at all, which is
 # the strongest form of the claim its own prose makes: this reason knows
 # nothing about where the auditor stands, and cannot be made to.
+# 🔴 THE COUNT IN THIS SENTENCE WAS FALSE IN EVERY BRIEF THAT RENDERED IT.
+# #1104's wording was "appears ONLY as the argument to `nix develop`", which was
+# true of what that revision rendered; this branch strengthened it into a COUNT
+# — "at most ONCE" — while adding two prose mentions of the same path. Measured
+# at `5bad0a0c` for devrc: FOUR occurrences, two of them not `nix develop`
+# arguments (``Everything below was read off `{tc.root}` `` and ``read out of
+# `{tc.root}/flake.nix` by a regex``). Nothing pinned it, because the guard over
+# this block asks whether the rendered text IS this constant and never whether
+# this constant is TRUE — see `test_the_toolchain_head_claim_is_true_of_the_
+# rendered_brief`, which now asks the second question.
 TOOLCHAIN_HEAD = "\n".join([
     "## TOOLCHAIN — the exact commands, and the two ways they lie",
     "",
     "🔴 `<your worktree>` below is **your own copy** — the one WHERE TO WORK "
     "told you to make. The checkout this brief was assembled in appears below "
-    "at most ONCE, as the argument to `nix develop`, where it resolves the dev "
-    "shell and nothing else. Never point a gate script or a `nix build` at it: "
-    "a gate script resolves its root from its own path, so running that copy "
-    "runs the suite in a checkout that is NOT yours — one holding none of your "
-    "mutations — and a `nix build <ref>#…` builds that ref's tree, not yours.",
+    "in RUNNABLE commands only as the argument to `nix develop`, where it "
+    "resolves the dev shell and nothing else; the prose names it too, to say "
+    "what was read out of it. Never point a gate script or a `nix build` at "
+    "it: a gate script resolves its root from its own path, so running that "
+    "copy runs the suite in a checkout that is NOT yours — one holding none of "
+    "your mutations — and a `nix build <ref>#…` builds that ref's tree, not "
+    "yours.",
 ])
 
 # 🔴 ALSO A CONSTANT, and for the same reason. Both notes are true of every
 # repository and every checkout state; only what sits BETWEEN them is derived.
+#
+# 🔴 AND ONE OF THEM WAS NOT. "everything above was PROBED out of this
+# repository rather than assumed" is a claim about a STATE, frozen into a
+# state-INDEPENDENT constant, and the cross-repo branch renders it three lines
+# under its own `🔴 NOTHING WAS PROBED HERE, SO NOTHING IS PRESCRIBED` — one
+# document contradicting itself, with `test_the_toolchain_reason_is_true_in_
+# every_scenario` CERTIFYING the contradiction by requiring the tail verbatim in
+# every scenario. The clause moved to `_toolchain_probed_runner_note`, which is
+# emitted only where it is true; the not-probed branch has always carried its
+# own spelling of the same instruction ("**NAME the one you used, by path**").
 TOOLCHAIN_TAIL = "\n".join([
     "Name the tier and the base sha in any claim you make about the gate — "
     "\"the gate passed\" is true of one run, one tier, one base, and reads "
-    "as a property of the change. 🔴 Name the RUNNER too, by path: everything "
-    "above was PROBED out of this repository rather than assumed, so a claim "
-    "about \"the gate\" that does not say which script produced it cannot be "
-    "checked by anyone reading your report.",
+    "as a property of the change.",
     "",
     "`git --version` before you trust a range: `--remerge-diff` needs git "
     "≥ 2.35, and a git without it exits 128 with EMPTY output, which reads "
@@ -2260,12 +2431,21 @@ def toolchain_shell(tc):
     PR's repository — the two coincide in the only branch that reaches here,
     which is why this one use of it is sound where pointing a gate at it is
     not: it resolves a dev shell, never a tree under test.
+
+    🔴 ROUND 15 — AND IT IS STILL A PYTHON PROBE DECIDING A LANGUAGE-AGNOSTIC
+    QUESTION. `flake_pytest` is `"pytest" in flake` over the whole file, and its
+    answer wraps the gate as well as the pytest command. Narrowing it to the
+    devShell means locating that region in arbitrary nix, and getting it wrong
+    REMOVES the wrapper from the brief for this repository itself — a worse
+    failure than the one it fixes — so the limit is STATED to the reader
+    instead, in `_toolchain_shell_note`, which is also where the wrong-shell
+    diagnosis now lives so that it covers every command and not only this one.
     """
     return f"nix develop {tc.root} -c " if (tc.flake and tc.flake_pytest) else ""
 
 
 def _toolchain_pytest_lines(facts, tc):
-    """The subset-run command, and the wrong-shell diagnosis that goes with it.
+    """The subset-run command, or the reason there is none. NEVER silence.
 
     🔴 THE SHELL IS PROBED TOO. `nix develop <r> -c python3 -m pytest` was
     emitted unconditionally, and MEASURED against `homelab-infra` it exits
@@ -2274,11 +2454,38 @@ def _toolchain_pytest_lines(facts, tc):
     So the brief manufactured a failure and then instructed the reader to
     disregard the one true signal it had produced. That repo's own runner
     invokes a BARE `python3 -m pytest`, which works.
+
+    🔴 AND THE TWO NON-COMMAND ANSWERS ARE NOW SAID OUT LOUD, differently. This
+    returned `[]` for both of them, so the whole bar vanished — no subset
+    command, and (before the note was lifted out of here) no wrong-shell
+    diagnosis anywhere in the section. An auditor reading no python line at all
+    concludes there is no python suite, which is exactly the confident answer
+    the capped walk cannot support.
     """
-    if not tc.py_tests:
-        return []
+    if tc.py_tests == PY_TESTS_UNKNOWN:
+        return [
+            "🔴 **THE PYTHON-TEST PROBE DID NOT FINISH, so this brief does not "
+            "know whether there is a python suite here.** The walk of "
+            f"`{tc.root}` hit its bound ({_PROBE_MAX_DIRS} directories at depth "
+            f"≤ {_PROBE_MAX_DEPTH}, `.git`/`node_modules`/build output already "
+            "skipped) before it found a `test_*.py`, or a directory in it could "
+            "not be read. **That is not \"there are no python tests\"** — on a "
+            "monorepo the walk order decides which answer you get, so read this "
+            "as a lookup you still owe, not as a fact about the repository.",
+            "",
+        ]
+    if tc.py_tests == PY_TESTS_NONE:
+        return [
+            f"⚠ No `test_*.py` was found anywhere in `{tc.root}` within depth "
+            f"{_PROBE_MAX_DEPTH}, so no python subset command is prescribed — "
+            "the walk COMPLETED and found none, which is a different answer "
+            "from the one above. If this repository's tests are somewhere else "
+            "or are not python, find its runner and **NAME the one you used, "
+            "by path**.",
+            "",
+        ]
     shell = toolchain_shell(tc)
-    lines = [
+    return [
         "Run a SUBSET of the suite:",
         "",
         "```",
@@ -2286,28 +2493,64 @@ def _toolchain_pytest_lines(facts, tc):
         "```",
         "",
     ]
+
+
+def _toolchain_shell_note(tc):
+    """The WRONG-SHELL diagnosis — ONE WRITER, and it is no longer python-only.
+
+    🔴 IT LIVED INSIDE `_toolchain_pytest_lines`, WHICH IS THE WRONG OWNER. The
+    gate command above it can run ANY language's tests, and the shell decision
+    that wraps it is made by ONE python-specific probe (`tc.flake_pytest`, i.e.
+    "does `flake.nix` mention pytest"). So a repository with a real
+    `scripts/gate.sh`, a flake devShell providing `nodejs`, and no python tests
+    rendered a BARE `bash <wt>/scripts/gate.sh` with no `nix develop` and no
+    wrong-shell bar anywhere in the section — the gate then fails `node:
+    command not found` and reads exactly like a broken gate, which is the
+    finding this whole section exists to stop an auditor filing.
+
+    🔴 WHAT IT DOES NOT DO, SAID OUT LOUD RATHER THAN IMPLIED: it does not
+    narrow `flake_pytest` to the devShell. `"pytest" in flake` is the whole
+    file, so a flake naming pytest only inside a `checks…pytests` derivation
+    still gets the wrapper. Narrowing it means finding the devShell region in
+    arbitrary nix, and getting that wrong REMOVES the wrapper from the brief
+    for this repository itself — a worse failure than the one it fixes. The
+    honest move is the one taken here: state exactly what was measured, so the
+    auditor can check it in one command instead of trusting it.
+    """
+    shell = toolchain_shell(tc)
     if shell:
-        lines.append(
+        return [
             "🔴 A bare `python3 -m pytest` failing with **`No module named "
             "pytest`** means you are in the WRONG SHELL, not that the suite is "
             f"broken. This repo's `.envrc` is {_fmt_uses(tc)}, which does not "
             "put pytest on PATH; a loaded direnv is not the dev shell. Do not "
             "report that as a finding and do not build an ad-hoc `nix-shell` "
-            "around it."
-        )
-    else:
-        lines.append(
-            "⚠ The command above is BARE on purpose: this brief did not detect "
-            "a dev shell that puts pytest on PATH for this repository "
-            + ("(its `flake.nix` names no pytest anywhere)" if tc.flake else
-               "(it has no `flake.nix`)")
-            + f", and its `.envrc` is {_fmt_uses(tc)}. 🔴 If it fails with "
-            "**`No module named pytest`** you are in the WRONG SHELL and not "
-            "looking at a broken suite: find the shell this repository's own "
-            "runner uses, say which in your report, and do not build an ad-hoc "
-            "`nix-shell` around it."
-        )
-    return lines + [""]
+            "around it.",
+            "",
+            "🔴 The same applies to EVERY command above, in EVERY language. The "
+            f"`nix develop {tc.root} -c` wrapper is there because `{tc.root}/"
+            "flake.nix` mentions `pytest` SOMEWHERE — this brief did not check "
+            "where, and that is a python fact deciding the shell for a gate "
+            "that may run node, go or anything else. A `<tool>: command not "
+            "found` from any command above is the WRONG SHELL and not a broken "
+            "gate: find the shell this repository's own runner uses, say which "
+            "in your report, and do not build an ad-hoc `nix-shell` around it.",
+            "",
+        ]
+    return [
+        "⚠ Every command above is BARE on purpose: this brief did not detect a "
+        "dev shell for this repository "
+        + ("(its `flake.nix` names no pytest anywhere, which is the only shell "
+           "probe made here)" if tc.flake else
+           "(it has no READABLE `flake.nix` — absent, or present and "
+           "unreadable by this probe)")
+        + f", and its `.envrc` is {_fmt_uses(tc)}. 🔴 If any of them fails with "
+        "**`No module named pytest`** — or with any other `<tool>: command not "
+        "found` — you are in the WRONG SHELL and not looking at a broken gate: "
+        "find the shell this repository's own runner uses, say which in your "
+        "report, and do not build an ad-hoc `nix-shell` around it.",
+        "",
+    ]
 
 
 def _fmt_uses(tc):
@@ -2318,6 +2561,28 @@ def _fmt_uses(tc):
     if not tc.envrc_uses:
         return "present but declares no `use` line"
     return " + ".join(f"`{u}`" for u in tc.envrc_uses)
+
+
+def _toolchain_probed_runner_note():
+    """The "name the runner, by path" clause — SCOPED TO THE PROBED BRANCH.
+
+    🔴 IT WAS IN `TOOLCHAIN_TAIL`, whose comment claimed both its notes were
+    "true of every repository and every checkout state". This one is not: it
+    says "everything above was PROBED out of this repository rather than
+    assumed", and cross-repo the same document says `🔴 NOTHING WAS PROBED
+    HERE, SO NOTHING IS PRESCRIBED` three lines earlier — with the scenario
+    guard requiring the tail verbatim in every scenario, so the contradiction
+    was certified rather than caught. The not-probed branch carries its own
+    spelling of the instruction ("**NAME the one you used, by path**"), which
+    is why moving this one loses no coverage.
+    """
+    return [
+        "🔴 Name the RUNNER too, by path: everything above was PROBED out of "
+        "this repository rather than assumed, so a claim about \"the gate\" "
+        "that does not say which script produced it cannot be checked by "
+        "anyone reading your report.",
+        "",
+    ]
 
 
 def _toolchain_gate_lines(facts, tc):
@@ -2371,7 +2636,14 @@ def _toolchain_checks_lines(facts, tc):
     """The sandbox tier — only when the flake really declares one."""
     if not tc.flake:
         return [
-            f"⚠ `{tc.root}` has no `flake.nix`, so there is no "
+            # 🔴 "no READABLE", because `_read_probe` answers None for BOTH an
+            # absent file and one it could not open — a mode-000 `flake.nix`
+            # rendered "has no `flake.nix`", a confident claim about the
+            # repository derived from a failed read. Same class as the walk cap
+            # above; fixed in the direction that costs no new state, by saying
+            # only what the probe actually established.
+            f"⚠ `{tc.root}` has no READABLE `flake.nix` (absent, or present "
+            "and unreadable by this probe), so there is no "
             "`nix build …#checks…` tier to run; the runner above is the only "
             "gate this brief could find.",
             "",
@@ -2497,11 +2769,32 @@ def render_toolchain(facts):
     hands the search over, because a fabricated command is strictly worse than
     an absent one — the absent one costs a lookup, the fabricated one costs a
     round and can be written up as a finding.
+
+    🔴 ROUND 15 — SILENCE IS NOT AN ANSWER EITHER, AND TWO BRANCHES USED IT.
+    `_toolchain_pytest_lines` returned `[]` both when the walk found no tests
+    and when the walk STOPPED, so the whole python bar vanished with no note
+    while both sibling probes emit an explicit absence bar; and the wrong-shell
+    diagnosis lived inside that same function, so a repository with a real
+    gate, a nodejs devShell and no python tests got a bare gate command and no
+    diagnosis anywhere in the section. Three answers now, each said out loud,
+    and the shell note is emitted once beside whatever commands exist.
+
+    🔴 ROUND 15 — THE COMMANDS BAR IS PINNED ACROSS SCENARIOS AGAIN. Round 14
+    moved the reason into a constant and lifted the cross-scenario equality off
+    the commands bar entirely, and its own docstring called that "not
+    weakened". Measured false: a sentence keyed on the auditor's own worktree
+    kind survived at 115 passed. The pin is back, WITHIN each target the probe
+    can distinguish — see `TOOLCHAIN_TARGET_OF` in the test module.
     """
     tc = detect_repo_toolchain(toolchain_probe_root(facts))
     if not tc.probed:
         body = _toolchain_not_probed(facts)
     else:
+        prescriptions = [
+            *_toolchain_pytest_lines(facts, tc),
+            *_toolchain_gate_lines(facts, tc),
+            *_toolchain_checks_lines(facts, tc),
+        ]
         body = [
             TOOLCHAIN_COMMANDS_HEADING,
             "",
@@ -2510,10 +2803,14 @@ def render_toolchain(facts):
             "standing on another branch, so treat a command that has since "
             "moved as a lookup, never as a finding.",
             "",
-            *_toolchain_pytest_lines(facts, tc),
-            *_toolchain_gate_lines(facts, tc),
-            *_toolchain_checks_lines(facts, tc),
+            *prescriptions,
         ]
+        # 🔴 The shell note describes "every command above", so it is emitted
+        # only where there IS one. A brief that prescribed nothing runnable
+        # would otherwise carry a diagnosis for commands it never gave.
+        if any(ln.startswith("```") for ln in prescriptions):
+            body += _toolchain_shell_note(tc)
+        body += _toolchain_probed_runner_note()
     while body and not body[-1]:
         body.pop()
     return "\n".join([TOOLCHAIN_HEAD, "", *body, "", TOOLCHAIN_TAIL])

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -2058,8 +2058,8 @@ _PROBE_SKIP_DIRS = {
 }
 
 
-def _nix_strip(text):
-    """`text` with strings and comments BLANKED — same length, same newlines.
+def _nix_scan(text):
+    """-> (`text` with strings/comments BLANKED, `clean`) — same length, same \\n.
 
     🔴 ONE PASS, BEFORE ANY PATTERN RUNS, and the length invariant is what lets
     a `re.M` match index straight back into the scan below. Everything a nix
@@ -2067,8 +2067,8 @@ def _nix_strip(text):
     `"…"` strings, `#` line comments and `/* … */` block comments. Newlines are
     preserved so a line-anchored pattern still sees the same line structure.
 
-    🔴 THE `''` ESCAPES ARE THE POINT, AND THEY ARE THE MEASURED DEFECT. The
-    previous scanner toggled "in string" on ANY `''`, and nix spells three
+    🔴 THE `''` ESCAPES ARE THE POINT, AND THEY WERE THE MEASURED DEFECT. The
+    round-14 scanner toggled "in string" on ANY `''`, and nix spells three
     different things with two apostrophes: `''` opens/closes, `''${…}` is a
     LITERAL `${`, and `'''` is a literal `''`. Measured at `5bad0a0c` on devrc's
     OWN `flake.nix` with a single `echo ''${HOME}` added inside the `pytests`
@@ -2077,18 +2077,46 @@ def _nix_strip(text):
     `nix build` targets named after a shell variable, and `nodetests`, a check
     the merge really does gate on, dropped in silence. A non-empty list is
     indistinguishable from a complete one, so the `[]` valve never fires.
-    devrc's flake carries no `''${` today; one ordinary edit is the whole
-    distance between here and that answer.
 
-    🔴 A STATED LIMIT, not a covered case: `${…}` INTERPOLATIONS inside a string
-    are real nix code and this blanks them with the rest of the string. So a
-    `checks` binding written inside an interpolation is invisible here. That is
-    the SAFE direction — the probe under-reads and the brief hedges — and it is
-    the direction chosen deliberately, because the alternative is a recursive
-    lexer for a heuristic whose whole job is to avoid confident wrong answers.
+    🔴 ROUND 16 — THE ESCAPE FIX LEFT THE SAME CLASS OPEN IN TWO MORE SHAPES,
+    AND `''` IS NOT A TOKEN YOU CAN LEX WITHOUT A STACK. Both measured at
+    `ba321c06` through `_flake_check_names`:
+
+      * `shellHook = '' ${lib.optionalString c '' … ''} '';` — an ordinary
+        nixpkgs idiom. A flat "scan to the next `''`" reads the `''` that OPENS
+        the nested string as the OUTER string's terminator, so the
+        interpolation's body is not blanked, it is PROMOTED TO CODE. A flake
+        declaring no `checks` at all answered `['unit']` — a fabricated
+        `nix build …#checks.x86_64-linux.unit`. And when the promoted region
+        contains an odd token (an `''${` escape, a lone `"`), string parity
+        inverts for the REST OF THE FILE and a flake that really does declare
+        `checks.x86_64-linux = { unit; lint; }` answered `None` — "**no `checks`
+        output**", in bold. Both directions, one root cause.
+      * `foo'' = 1;` — a legal nix identifier, because `'` is an identifier
+        character (`_NIX_NAME` already allows it). Read as a string opener it
+        blanked the rest of the file: `None` again.
+
+    So the scan is a STACK now: `${…}` inside a string pushes a CODE frame,
+    `}` at that frame's depth 0 pops back into the string, and an identifier is
+    consumed by MAXIMAL MUNCH so its trailing apostrophes cannot open anything.
+
+    🔴 AND IT REPORTS ITS OWN UNCERTAINTY, because "the lexer got lost" and "the
+    file has no checks" are different sentences and the second is the confident
+    one. `clean` is False when the scan ends inside a string or an interpolation,
+    when a `/* …` never closes, when a `}` closes nothing, or when the brace
+    count does not return to zero (which is also what a `_PROBE_MAX_BYTES`
+    truncation looks like). The caller degrades to the hedged `[]` on that —
+    never to `None`, never to a name list. Measured across 313 real `flake.nix`
+    files on this host: every one lexes clean, and none changed its answer.
     """
     out = list(text)
-    i, n = 0, len(text)
+    n = len(text)
+    i = 0
+    clean = True
+    # A stack of frames. `["code", depth]` counts braces so a `}` can be told
+    # from an interpolation close; `["ind"]` / `["dq"]` are the two string
+    # flavours. The bottom frame is the file itself.
+    stack = [["code", 0]]
 
     def blank(start, stop):
         for k in range(start, min(stop, n)):
@@ -2096,56 +2124,110 @@ def _nix_strip(text):
                 out[k] = " "
 
     while i < n:
+        frame = stack[-1]
+        kind = frame[0]
+        ch = text[i]
         two = text[i:i + 2]
-        if two == "''":                       # indented string
-            blank(i, i + 2)
-            i += 2
-            while i < n:
-                if text[i:i + 2] == "''":
-                    nxt = text[i + 2:i + 3]
-                    if nxt in ("$", "'"):     # ''${…}  and  '''  — escapes
-                        blank(i, i + 3)
-                        i += 3
-                        continue
-                    if nxt == "\\":           # ''\<c> — an escape sequence
-                        blank(i, i + 4)
-                        i += 4
-                        continue
-                    blank(i, i + 2)           # the terminator
-                    i += 2
-                    break
+        if kind == "code":
+            # 🔴 MAXIMAL MUNCH FIRST. `foo'' = 1;` is ONE identifier in nix, and
+            # a scanner that sees `foo` then `''` opens a string that never
+            # closes and blanks the rest of the file.
+            if ch.isalpha() or ch == "_":
+                j = i + 1
+                while j < n and (text[j].isalnum() or text[j] in "_'-"):
+                    j += 1
+                i = j
+                continue
+            if two == "''":
+                blank(i, i + 2)
+                stack.append(["ind"])
+                i += 2
+                continue
+            if ch == '"':
                 blank(i, i + 1)
+                stack.append(["dq"])
                 i += 1
+                continue
+            if ch == "#":                     # line comment
+                j = text.find("\n", i)
+                j = n if j == -1 else j
+                blank(i, j)
+                i = j
+                continue
+            if two == "/*":                   # block comment
+                j = text.find("*/", i + 2)
+                if j == -1:
+                    clean = False
+                    blank(i, n)
+                    i = n
+                    continue
+                blank(i, j + 2)
+                i = j + 2
+                continue
+            if ch == "{":
+                frame[1] += 1
+                i += 1
+                continue
+            if ch == "}":
+                if frame[1] > 0:
+                    frame[1] -= 1
+                elif len(stack) > 1:          # closes the `${…}` that pushed us
+                    blank(i, i + 1)
+                    stack.pop()
+                else:                         # a `}` with nothing open
+                    clean = False
+                i += 1
+                continue
+            i += 1
             continue
-        if text[i] == '"':                    # ordinary string
+        if kind == "ind":
+            if two == "''":
+                nxt = text[i + 2:i + 3]
+                if nxt in ("$", "'"):         # ''${…}  and  '''  — escapes
+                    blank(i, i + 3)
+                    i += 3
+                    continue
+                if nxt == "\\":               # ''\<c> — an escape sequence
+                    blank(i, i + 4)
+                    i += 4
+                    continue
+                blank(i, i + 2)               # the terminator
+                stack.pop()
+                i += 2
+                continue
+            if two == "${":                   # an interpolation: CODE again
+                blank(i, i + 2)
+                stack.append(["code", 0])
+                i += 2
+                continue
             blank(i, i + 1)
             i += 1
-            while i < n:
-                if text[i] == "\\":
-                    blank(i, i + 2)
-                    i += 2
-                    continue
-                if text[i] == '"':
-                    blank(i, i + 1)
-                    i += 1
-                    break
-                blank(i, i + 1)
-                i += 1
             continue
-        if text[i] == "#":                    # line comment
-            j = text.find("\n", i)
-            j = n if j == -1 else j
-            blank(i, j)
-            i = j
+        # kind == "dq"
+        if ch == "\\":
+            blank(i, i + 2)
+            i += 2
             continue
-        if two == "/*":                       # block comment
-            j = text.find("*/", i + 2)
-            j = n if j == -1 else j + 2
-            blank(i, j)
-            i = j
+        if ch == '"':
+            blank(i, i + 1)
+            stack.pop()
+            i += 1
             continue
+        if two == "${":
+            blank(i, i + 2)
+            stack.append(["code", 0])
+            i += 2
+            continue
+        blank(i, i + 1)
         i += 1
-    return "".join(out)
+    if len(stack) != 1 or stack[0][1] != 0:
+        clean = False
+    return "".join(out), clean
+
+
+def _nix_strip(text):
+    """The blanked text alone — for callers that do not read `clean`."""
+    return _nix_scan(text)[0]
 
 
 def _flake_check_names(text):
@@ -2169,7 +2251,16 @@ def _flake_check_names(text):
     the merge gates on — and it was the answer for `genAttrs`, for flake-parts'
     `perSystem`, and for `checks.<system> = base // {…}`.
 
-    Brace depth over the attrset, run over `_nix_strip`ped source so neither a
+    🔴 ROUND 16 — AND THAT RULE NOW COVERS THE LEXER, WHICH IS WHERE IT WAS
+    MISSING. `_nix_scan` reports whether it ended in a state a nix file can
+    actually be in; when it did not — an unterminated string, an unclosed
+    interpolation or comment, braces that never balance, which is also what a
+    `_PROBE_MAX_BYTES` truncation looks like — this returns `[]` before reading
+    anything. Both of round 16's measured failures routed to a CONFIDENT answer
+    (a fabricated `['unit']` one way, a bolded "no `checks` output" the other),
+    so the valve has to sit above the parse and not inside it.
+
+    Brace depth over the attrset, run over `_nix_scan`ned source so neither a
     build script's braces nor a heredoc's text can move the counter. Measured
     on the two real flakes: `devrc` -> ['pytests', 'nodetests'] (an
     indentation-only scan returned ['pytests'], because a build script's lines
@@ -2178,7 +2269,9 @@ def _flake_check_names(text):
     """
     if not text:
         return None
-    code = _nix_strip(text)
+    code, clean = _nix_scan(text)
+    if not clean:
+        return []
     m = CHECKS_ATTR.search(code)
     if not m:
         return [] if CHECKS_DECL.search(code) else None
@@ -2351,14 +2444,33 @@ def toolchain_probe_root(facts):
 # this block asks whether the rendered text IS this constant and never whether
 # this constant is TRUE — see `test_the_toolchain_head_claim_is_true_of_the_
 # rendered_brief`, which now asks the second question.
+#
+# 🔴 ROUND 16 — AND THE REPLACEMENT PUT A STATE-DEPENDENT CLAIM STRAIGHT BACK
+# INTO THE STATE-INDEPENDENT CONSTANT. "the prose names it too, to say what was
+# read out of it" was measured at `ba321c06` across all thirteen scenarios the
+# module had there:
+#
+#     probed      (6)   3 prose lines naming the assembly checkout   -> true
+#     cross-repo  (5)   1, and it says "is a DIFFERENT repository"   -> false
+#     repo-unknown(2)   0 — the path is absent from the section      -> false
+#
+# and the guard over it drove ONLY `delta`, the one state where the sentence is
+# true — a guard narrower than the sentence it certifies, which is the shape
+# round 15's F2 was filed for, reappearing one round later in its own fix. The
+# clause is now the WIDEST thing true in all three states: wherever the path
+# turns up outside a `nix develop` argument it is PROSE, a statement ABOUT that
+# checkout and never an instruction to run in it. That is mechanically checkable
+# (no fenced line may name it except as the `nix develop` argument), and it is
+# checked in EVERY scenario rather than in one.
 TOOLCHAIN_HEAD = "\n".join([
     "## TOOLCHAIN — the exact commands, and the two ways they lie",
     "",
     "🔴 `<your worktree>` below is **your own copy** — the one WHERE TO WORK "
     "told you to make. The checkout this brief was assembled in appears below "
     "in RUNNABLE commands only as the argument to `nix develop`, where it "
-    "resolves the dev shell and nothing else; the prose names it too, to say "
-    "what was read out of it. Never point a gate script or a `nix build` at "
+    "resolves the dev shell and nothing else; wherever else it appears it is "
+    "PROSE — a statement ABOUT that checkout, never something to run in. Never "
+    "point a gate script or a `nix build` at "
     "it: a gate script resolves its root from its own path, so running that "
     "copy runs the suite in a checkout that is NOT yours — one holding none of "
     "your mutations — and a `nix build <ref>#…` builds that ref's tree, not "
@@ -2444,7 +2556,7 @@ def toolchain_shell(tc):
     return f"nix develop {tc.root} -c " if (tc.flake and tc.flake_pytest) else ""
 
 
-def _toolchain_pytest_lines(facts, tc):
+def _toolchain_pytest_lines(tc):
     """The subset-run command, or the reason there is none. NEVER silence.
 
     🔴 THE SHELL IS PROBED TOO. `nix develop <r> -c python3 -m pytest` was
@@ -2475,13 +2587,21 @@ def _toolchain_pytest_lines(facts, tc):
             "",
         ]
     if tc.py_tests == PY_TESTS_NONE:
+        # 🔴 ROUND 16 — "A DIFFERENT ANSWER FROM THE ONE ABOVE" POINTED AT A BAR
+        # THAT IS NEVER ABOVE IT. The two branches are mutually exclusive
+        # (`if UNKNOWN: return …` above), so the bar this sentence contrasted
+        # itself with is emitted in exactly the runs where this one is not. A
+        # cross-reference to something not on the page is worse than no
+        # cross-reference: the reader goes looking. The contrast is real and
+        # worth keeping, so it now names the OTHER ANSWER instead of a position.
         return [
             f"⚠ No `test_*.py` was found anywhere in `{tc.root}` within depth "
             f"{_PROBE_MAX_DEPTH}, so no python subset command is prescribed — "
-            "the walk COMPLETED and found none, which is a different answer "
-            "from the one above. If this repository's tests are somewhere else "
-            "or are not python, find its runner and **NAME the one you used, "
-            "by path**.",
+            "the walk COMPLETED and found none. That is a different answer "
+            "from \"the walk did not finish\", which this brief says instead "
+            "when it hits its bound, and neither is printed with the other. If "
+            "this repository's tests are somewhere else or are not python, "
+            "find its runner and **NAME the one you used, by path**.",
             "",
         ]
     shell = toolchain_shell(tc)
@@ -2516,25 +2636,39 @@ def _toolchain_shell_note(tc):
     for this repository itself — a worse failure than the one it fixes. The
     honest move is the one taken here: state exactly what was measured, so the
     auditor can check it in one command instead of trusting it.
+
+    🔴 ROUND 16 — AND IT DIAGNOSED A COMMAND THE SECTION HAD JUST REFUSED TO
+    GIVE. The `python3 -m pytest` bar was emitted whenever the shell wrapper
+    was, including when `py_tests` is NONE — three lines after the brief says
+    "no python subset command is prescribed". The language-agnostic bar is the
+    one that is true in every state, so it is now unconditional and
+    self-contained, and the python-specific one is emitted only where a
+    `python3 -m pytest` really is fenced above it. The rule is the general one,
+    not a special case for NONE: a diagnosis of a command this section did not
+    prescribe sends the reader looking for a command that is not there.
     """
     shell = toolchain_shell(tc)
     if shell:
-        return [
-            "🔴 A bare `python3 -m pytest` failing with **`No module named "
-            "pytest`** means you are in the WRONG SHELL, not that the suite is "
-            f"broken. This repo's `.envrc` is {_fmt_uses(tc)}, which does not "
-            "put pytest on PATH; a loaded direnv is not the dev shell. Do not "
-            "report that as a finding and do not build an ad-hoc `nix-shell` "
-            "around it.",
-            "",
-            "🔴 The same applies to EVERY command above, in EVERY language. The "
+        lines = []
+        if tc.py_tests == PY_TESTS_FOUND:
+            lines += [
+                "🔴 A bare `python3 -m pytest` failing with **`No module named "
+                "pytest`** means you are in the WRONG SHELL, not that the suite "
+                f"is broken. This repo's `.envrc` is {_fmt_uses(tc)}, which "
+                "does not put pytest on PATH; a loaded direnv is not the dev "
+                "shell. Do not report that as a finding and do not build an "
+                "ad-hoc `nix-shell` around it.",
+                "",
+            ]
+        return lines + [
+            "🔴 A `<tool>: command not found` from ANY command above is the "
+            "WRONG SHELL and not a broken gate — in EVERY language. The "
             f"`nix develop {tc.root} -c` wrapper is there because `{tc.root}/"
             "flake.nix` mentions `pytest` SOMEWHERE — this brief did not check "
             "where, and that is a python fact deciding the shell for a gate "
-            "that may run node, go or anything else. A `<tool>: command not "
-            "found` from any command above is the WRONG SHELL and not a broken "
-            "gate: find the shell this repository's own runner uses, say which "
-            "in your report, and do not build an ad-hoc `nix-shell` around it.",
+            "that may run node, go or anything else. Find the shell this "
+            "repository's own runner uses, say which in your report, and do "
+            "not build an ad-hoc `nix-shell` around it.",
             "",
         ]
     return [
@@ -2585,7 +2719,7 @@ def _toolchain_probed_runner_note():
     ]
 
 
-def _toolchain_gate_lines(facts, tc):
+def _toolchain_gate_lines(tc):
     """The repo's own runner(s) — or the refusal to name one."""
     shell = toolchain_shell(tc)
     cmds = []
@@ -2632,7 +2766,7 @@ CHECKS_DISCRIMINATOR = (
 )
 
 
-def _toolchain_checks_lines(facts, tc):
+def _toolchain_checks_lines(tc):
     """The sandbox tier — only when the flake really declares one."""
     if not tc.flake:
         return [
@@ -2791,9 +2925,9 @@ def render_toolchain(facts):
         body = _toolchain_not_probed(facts)
     else:
         prescriptions = [
-            *_toolchain_pytest_lines(facts, tc),
-            *_toolchain_gate_lines(facts, tc),
-            *_toolchain_checks_lines(facts, tc),
+            *_toolchain_pytest_lines(tc),
+            *_toolchain_gate_lines(tc),
+            *_toolchain_checks_lines(tc),
         ]
         body = [
             TOOLCHAIN_COMMANDS_HEADING,

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -389,21 +389,28 @@ def emit_claims_interpolates_the_placeholder(t):
     )
 
 
+# 🔴 T1/T2 RE-TARGETED IN ROUND 14, SAME MUTATION, NEW SITE. The commands moved
+# out of one `return [...]` literal into `_toolchain_gate_lines` /
+# `_toolchain_checks_lines`, which build them from the PROBED repo. The defect
+# they model is unchanged — a command under test pointed at the assembly
+# checkout instead of the auditor's worktree — so the rows keep their ids and
+# their killer sets. Left un-retargeted these would have failed to APPLY, which
+# this harness reports rather than scoring as "the guard held".
 def gate_points_at_the_shared_checkout(t):
     return _swap(
         t,
-        'f"nix develop {r} -c bash <your worktree>/scripts/gate.sh --tier both",',
-        'f"nix develop {r} -c bash {r}/scripts/gate.sh --tier both",',
+        'cmds.append(f"{shell}bash <your worktree>/scripts/gate.sh{tier}")',
+        'cmds.append(f"{shell}bash {tc.root}/scripts/gate.sh{tier}")',
     )
 
 
 def nix_build_points_at_the_shared_checkout(t):
     return _swap(
         t,
-        '        "nix build <your worktree>#checks.x86_64-linux.pytests",\n'
-        '        "nix build <your worktree>#checks.x86_64-linux.nodetests",\n',
-        '        f"nix build {r}#checks.x86_64-linux.pytests",\n'
-        '        f"nix build {r}#checks.x86_64-linux.nodetests",\n',
+        '        *[f"nix build <your worktree>#checks.{NIX_SYSTEM}.{n}"\n'
+        "          for n in tc.check_names],\n",
+        '        *[f"nix build {tc.root}#checks.{NIX_SYSTEM}.{n}"\n'
+        "          for n in tc.check_names],\n",
     )
 
 
@@ -694,10 +701,12 @@ def the_output_contract_drops_the_per_finding_format(t):
 
 
 def the_toolchain_drops_name_the_tier(t):
+    # Round 14: the sentence moved into the `TOOLCHAIN_TAIL` constant, so its
+    # indentation dropped from 8 to 4. Same sentence, same mutation.
     return _swap(
         t,
-        '        "Name the tier and the base sha in any claim you make about the gate — "',
-        '        "There is no need to name the tier or the base sha. "',
+        '    "Name the tier and the base sha in any claim you make about the gate — "',
+        '    "There is no need to name the tier or the base sha. "',
     )
 
 
@@ -1355,19 +1364,25 @@ def the_toolchain_names_the_shared_checkout_cross_repo_only(t):
     suite at 89 green with no row naming it. Only a guard that drives every
     scenario — and requires the section byte-identical across them — can see it.
     """
+    # 🔴 ROUND 14 RE-TARGETED IT, AND THE MUTATION GOT *HARDER* TO WRITE —
+    # which is the point of moving the reason into a no-argument constant.
+    # There is no longer any `facts` in scope where the reason is built, so a
+    # scenario-dependent rationale can only be smuggled back in by APPENDING
+    # one at the render site. That is exactly what this does, and it is still
+    # cross-repo-only: round 5's guard drove two same-repo scenarios and left
+    # this reword at 89 green with no row naming it.
     return _swap(
         t,
-        "    r = facts.cwd_repo_dir\n    return \"\\n\".join([\n"
-        '        "## TOOLCHAIN — the exact commands, and the two ways they lie",',
-        "    r = facts.cwd_repo_dir\n"
-        '    _why = ("so running that copy runs the suite in the SHARED CHECKOUT on "\n'
-        '            "whatever branch it is standing on"\n'
-        '            if facts.repo_relation == "cross" else\n'
-        '            "so running that copy runs the suite in a checkout that is NOT '
-        'yours")\n'
-        "    return \"\\n\".join([\n"
-        '        "## TOOLCHAIN — the exact commands, and the two ways they lie",\n'
-        '        _why,',
+        "    tc = detect_repo_toolchain(toolchain_probe_root(facts))\n",
+        "    tc = detect_repo_toolchain(toolchain_probe_root(facts))\n"
+        '    if facts.repo_relation == "cross":\n'
+        "        return \"\\n\".join([\n"
+        "            TOOLCHAIN_HEAD,\n"
+        '            "so running that copy runs the suite in the SHARED CHECKOUT '
+        'on whatever branch it is standing on",\n'
+        "            TOOLCHAIN_COMMANDS_HEADING,\n"
+        "            TOOLCHAIN_TAIL,\n"
+        "        ])\n",
     )
 
 
@@ -1383,13 +1398,16 @@ def the_no_fetch_clause_is_conditional_again(t):
 
 
 def the_toolchain_reason_names_the_shared_checkout_again(t):
+    # Round 14: the reason is `TOOLCHAIN_HEAD`, so the false claim goes back
+    # into the constant. Same words, same finding, one indent level out.
     return _swap(
         t,
-        '        "so running that copy runs the suite in a checkout that is NOT yours — "\n'
-        '        "the one this brief was assembled in, on whatever branch it is standing "\n'
-        '        "on, holding none of your mutations — and a `nix build <ref>#…` builds "\n',
-        '        "so running the shared copy runs the suite in the SHARED CHECKOUT on "\n'
-        '        "whatever branch it is standing on, and a `nix build <ref>#…` builds "\n',
+        '    "a gate script resolves its root from its own path, so running that copy "\n'
+        '    "runs the suite in a checkout that is NOT yours — one holding none of your "\n'
+        '    "mutations — and a `nix build <ref>#…` builds that ref\'s tree, not yours.",\n',
+        '    "a gate script resolves its root from its own path, so running the shared "\n'
+        '    "copy runs the suite in the SHARED CHECKOUT on whatever branch it is "\n'
+        '    "standing on, and a `nix build <ref>#…` builds that ref\'s tree.",\n',
     )
 
 
@@ -1433,6 +1451,87 @@ def the_degenerate_causes_stop_scoping_the_omission(t):
         '        "always means; `<from>` is the tip the PREVIOUS round AUDITED, so "\n'
         '        "re-emit that block with `--audited <the tip that round actually "\n'
         '        "read>` and re-assemble — or nothing has been committed and pushed to "\n',
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 V36-V41 — round 14. Base `bd1572f3`. The target-repo toolchain probes.
+# --------------------------------------------------------------------------- #
+# Each probe is broken in BOTH directions where both are reachable: V36 claims
+# an artifact that is absent, V37 denies one that is present. A single
+# direction grades only half of a predicate, and the half it omits is the one
+# that silently STOPS prescribing a real command.
+
+
+def the_gate_is_prescribed_without_probing_for_it(t):
+    """V36 — pretend `scripts/gate.sh` exists everywhere. THE ORIGINAL DEFECT."""
+    return _swap(t, "    if tc.gate_sh:\n", "    if True:\n")
+
+
+def the_gate_is_never_prescribed_even_where_it_exists(t):
+    """V37 — the mirror: a real `scripts/gate.sh` goes unmentioned.
+
+    The direction a one-sided mutation misses. A probe wired to always-False
+    keeps every "did not fabricate" assertion green while quietly removing the
+    repository's real gate from every brief.
+    """
+    return _swap(t, "    if tc.gate_sh:\n", "    if False:\n")
+
+
+def the_checks_probe_matches_the_word_not_the_output(t):
+    """V38 — the loose regex this detection started with.
+
+    It matched `checks = pr.get("statusCheckRollup", [])` inside a python
+    heredoc in `homelab-infra`'s real devShell, so a flake declaring NO checks
+    output answered yes and the honest fallback became unreachable.
+    """
+    return _swap(
+        t,
+        'r"^[ \\t]*checks(?:\\.[^\\s=]+)?[ \\t]*=[ \\t]*(?:forAllSystems[^\\n]*)?\\{[ \\t]*$",',
+        'r"^[ \\t]*checks\\b[^\\n=]*=",',
+    )
+
+
+def the_envrc_sentence_is_hardcoded_again(t):
+    """V39 — the remembered string instead of the file on disk."""
+    return _swap(
+        t,
+        '            f"broken. This repo\'s `.envrc` is {_fmt_uses(tc)}, which does not "\n',
+        '            "broken. This repo\'s `.envrc` is `use opencode`, which does not "\n',
+    )
+
+
+def the_probe_reads_the_cwd_repo_cross_repo_too(t):
+    """V40 — probe the WRONG repository rather than admit to knowing nothing.
+
+    The fix's own trap. Cross-repo the cwd IS a probeable repository; it is
+    simply not the one the PR lives in, so this yields a confident,
+    fully-formed, entirely irrelevant command list — the original defect with a
+    new source. It also collapses every scenario onto one commands bar, which
+    is the second thing the scenario guard now refuses.
+    """
+    return _swap(
+        t,
+        '    return facts.cwd_repo_dir if facts.repo_relation == "same" else None\n',
+        "    return facts.cwd_repo_dir\n",
+    )
+
+
+def the_checks_scan_stops_tracking_nix_strings(t):
+    """V41 — drop the `''…''` skip from the check-name scan.
+
+    A brace inside a build script then moves the depth counter and the block
+    closes early, so a flake's SECOND check name is never read. Isolated to the
+    string toggle: the surrounding depth arithmetic is untouched, so a kill
+    here is attributable to string tracking and nothing else.
+    """
+    return _swap(
+        t,
+        '            if line[i:i + 2] == "\'\'":\n'
+        "                in_str = not in_str\n"
+        "                i += 2\n"
+        "                continue\n",
+        "",
     )
 
 
@@ -1556,6 +1655,21 @@ ROWS = [
       # where the WHERE TO WORK section has no private-worktree note at all.
       "test_every_section_directive_is_emitted_verbatim_in_the_brief_that_owns_it",
       "test_the_where_to_work_section_does_not_call_a_private_worktree_the_clone",
+      # 🔴 ROUND 14 ADDED FOUR, and they are the same coupling reaching one
+      # section further. TOOLCHAIN now derives its COMMANDS from the
+      # repository the PR lives in, and `toolchain_probe_root` asks
+      # `repo_relation` to decide which checkout may be read — deliberately
+      # REUSING the decision WHERE TO WORK already made rather than computing
+      # a second one. So inverting that decision swaps the two toolchain
+      # branches wholesale: the same-repo briefs stop prescribing anything and
+      # the cross-repo brief starts prescribing the wrong repository's layout.
+      # That the row's set grew here is the evidence that the reuse is real;
+      # a second, independent derivation would have left C3 untouched and left
+      # the two sections free to disagree.
+      "test_the_toolchain_prescribes_only_commands_it_probed",
+      "test_the_toolchain_prescribes_nothing_when_it_cannot_probe",
+      "test_the_toolchain_section_names_the_tier_the_merge_gates_on",
+      "test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout",
       # 🔴 ROUND 8 ADDED NINE MORE, and every one is the same coupling seen
       # from a new angle: round 8 made THE RANGE and THE LEDGER consult
       # `repo_relation`, so inverting that decision now moves both sections in
@@ -2116,8 +2230,15 @@ ROWS = [
       # branch's own override.
       "test_the_degenerate_range_names_shas_at_both_ends"},
      the_verified_range_hands_out_head_again),
+    # 🔴 ROUND 14 WIDENED THIS KILLER SET, and the addition is a real
+    # coupling rather than a row going vague. This mutant now returns EARLY in
+    # the cross-repo branch, so the section it renders carries the commands
+    # heading with no commands bar under it and no "NOTHING WAS PROBED HERE" —
+    # which is exactly what round 14's cross-repo guard reads. Measured, not
+    # predicted: the battery reported it as an EXTRA-KILLER first.
     ("V7  TOOLCHAIN names the SHARED CHECKOUT, cross-repo only",
-     {"test_the_toolchain_reason_is_true_in_every_scenario"},
+     {"test_the_toolchain_reason_is_true_in_every_scenario",
+      "test_the_toolchain_prescribes_nothing_when_it_cannot_probe"},
      the_toolchain_names_the_shared_checkout_cross_repo_only),
 
     # --------------------------------------------------------------------- #
@@ -2311,6 +2432,38 @@ ROWS = [
     ("V35 a third prescription site written through `err_stream.write`",
      {"test_every_command_a_refusal_prescribes_actually_runs"},
      a_third_prescription_site_written_through_err_stream),
+
+    # --------------------------------------------------------------------- #
+    # 🔴 V36-V41 — round 14. Base `bd1572f3`.
+    # --------------------------------------------------------------------- #
+    ("V36 gate.sh prescribed without probing for it",
+     {"test_the_toolchain_prescribes_only_commands_it_probed"},
+     the_gate_is_prescribed_without_probing_for_it),
+    # Two killers, both measured: one asserts the gate command is PRESENT
+    # (`gate.sh --tier both`), the other asserts the auditor's own worktree is
+    # what it names (`<your worktree>/scripts/gate.sh`). Suppressing the whole
+    # command removes both strings, so both fire — the second for a reason
+    # adjacent to what it owns, which is why it is recorded here rather than
+    # left to look like an accident.
+    ("V37 gate.sh never prescribed, even where it exists",
+     {"test_the_toolchain_section_names_the_tier_the_merge_gates_on",
+      "test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout"},
+     the_gate_is_never_prescribed_even_where_it_exists),
+    ("V38 the checks probe matches the WORD, not the output",
+     {"test_the_flake_checks_probe_reads_an_output_and_not_the_word",
+      "test_the_toolchain_prescribes_only_commands_it_probed"},
+     the_checks_probe_matches_the_word_not_the_output),
+    ("V39 the .envrc sentence is hardcoded again",
+     {"test_the_toolchain_prescribes_only_commands_it_probed"},
+     the_envrc_sentence_is_hardcoded_again),
+    ("V40 cross-repo, the WRONG repository is probed anyway",
+     {"test_the_toolchain_prescribes_nothing_when_it_cannot_probe",
+      "test_the_toolchain_reason_is_true_in_every_scenario"},
+     the_probe_reads_the_cwd_repo_cross_repo_too),
+    ("V41 the check-name scan stops tracking nix strings",
+     {"test_the_flake_checks_probe_reads_an_output_and_not_the_word",
+      "test_the_toolchain_section_names_the_tier_the_merge_gates_on"},
+     the_checks_scan_stops_tracking_nix_strings),
 ]
 
 

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -1455,7 +1455,7 @@ def the_degenerate_causes_stop_scoping_the_omission(t):
 
 
 # --------------------------------------------------------------------------- #
-# 🔴 V36-V41 — round 14. Base `bd1572f3`. The target-repo toolchain probes.
+# 🔴 V36-V41 — round 14. Base `9e23c379` (#1104 merged). Target-repo probes.
 # --------------------------------------------------------------------------- #
 # Each probe is broken in BOTH directions where both are reachable: V36 claims
 # an artifact that is absent, V37 denies one that is present. A single
@@ -2434,7 +2434,7 @@ ROWS = [
      a_third_prescription_site_written_through_err_stream),
 
     # --------------------------------------------------------------------- #
-    # 🔴 V36-V41 — round 14. Base `bd1572f3`.
+    # 🔴 V36-V41 — round 14. Base `9e23c379` — `origin/main` with #1104 in.
     # --------------------------------------------------------------------- #
     ("V36 gate.sh prescribed without probing for it",
      {"test_the_toolchain_prescribes_only_commands_it_probed"},

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -110,11 +110,24 @@ HARNESS_REL = "scripts/tests/mutants-audit-dispatch.py"
 # tests to the last sentence, which is the arithmetic the paragraph above
 # records going wrong twice.
 #
-# 🔴 ROUND 15 RAISED IT AGAIN, 107 -> 115, at m = 121 — COUNTED from a green run
+# 🔴 ROUND 15 RAISED IT AGAIN, 107 -> 116, at m = 122 — COUNTED from a green run
 # of the module (`122 passed`) and put through the same formula,
-# `122 - min(50, max(1, 122 // 20))`, not derived by adding this round's seven
-# new tests to the last sentence.
-MIN_TESTS = 116
+# `122 - min(50, max(1, 122 // 20))` = 122 - 6 = 116, not derived by adding that
+# round's seven new tests to the last sentence.
+#
+# 🔴 AND THAT SENTENCE WAS WRONG IN BOTH ITS FIGURES — the THIRD time this
+# block has recorded exactly that, which is why it is corrected in place rather
+# than appended to. It read "107 -> 115, at m = 121" while quoting its own
+# correct `122 - min(50, max(1, 122 // 20))` and sitting above `MIN_TESTS = 116`.
+# A reader re-deriving from "m = 121" gets 115 and would "correct" the constant
+# DOWNWARD, loosening the collapse floor by one on the strength of a sentence
+# nobody re-ran. Read the CONSTANT, re-derive from a COUNT, and fix the prose to
+# match — never the other way round.
+#
+# 🔴 ROUND 16 RAISED IT AGAIN, 116 -> 120, at m = 126 — COUNTED from a green run
+# of the module (`126 passed`), `126 - min(50, max(1, 126 // 20))` = 126 - 6 =
+# 120, not derived by adding this round's four new tests to 116.
+MIN_TESTS = 120
 
 # A row may name this instead of a killer set: the mutation MUST leave the suite
 # green. See the module docstring — the clause ledger pins whole normalised
@@ -1528,7 +1541,8 @@ def the_checks_probe_matches_the_word_not_the_output(t):
     `CHECKS_DECL` matches that same heredoc line in the raw source. Same
     hazard, same killers, at the layer that now carries it.
     """
-    return _swap(t, "    code = _nix_strip(text)\n", "    code = text\n")
+    return _swap(t, "    code, clean = _nix_scan(text)\n",
+                 "    code, clean = text, True\n")
 
 
 def a_state_dependent_sentence_moves_into_the_commands_bar(t):
@@ -1582,8 +1596,8 @@ def the_indented_string_escapes_are_terminators_again(t):
     """
     return _swap(
         t,
-        '                    if nxt in ("$", "\'"):     # \'\'${…}  and  \'\'\'  — escapes\n',
-        "                    if False:\n",
+        '                if nxt in ("$", "\'"):         # \'\'${…}  and  \'\'\'  — escapes\n',
+        "                if False:\n",
     )
 
 
@@ -1591,8 +1605,8 @@ def the_envrc_sentence_is_hardcoded_again(t):
     """V39 — the remembered string instead of the file on disk."""
     return _swap(
         t,
-        '            f"broken. This repo\'s `.envrc` is {_fmt_uses(tc)}, which does not "\n',
-        '            "broken. This repo\'s `.envrc` is `use opencode`, which does not "\n',
+        '                f"is broken. This repo\'s `.envrc` is {_fmt_uses(tc)}, which "\n',
+        '                "is broken. This repo\'s `.envrc` is `use opencode`, which "\n',
     )
 
 
@@ -1613,19 +1627,22 @@ def the_probe_reads_the_cwd_repo_cross_repo_too(t):
 
 
 def the_checks_scan_stops_tracking_nix_strings(t):
-    """V41 — the `''…''` skip is dropped. RE-TARGETED IN ROUND 15.
+    """V41 — the `''…''` skip is dropped. RE-TARGETED IN ROUNDS 15 AND 16.
 
-    Same defect, one layer over: the toggle used to live in the name scan and
-    now lives in `_nix_strip`, so the mutation is "an indented string is not a
-    string". A brace inside a build script then moves the depth counter and the
-    block closes early, so a flake's SECOND check name is never read. Isolated
-    to the indented-string branch: `"…"`, `#` and `/* */` handling and the
-    depth arithmetic are untouched.
+    Same defect, one layer over each time: the toggle lived in the name scan,
+    then in `_nix_strip`, and now in the CODE frame of `_nix_scan`, so the
+    mutation is still "an indented string is not a string". A brace inside a
+    build script then moves the depth counter and the block closes early, so a
+    flake's SECOND check name is never read. Isolated to the one branch that
+    OPENS an indented string from code: `"…"`, `#`, `/* */`, the escape
+    handling and the depth arithmetic are untouched.
     """
     return _swap(
         t,
-        '        if two == "\'\'":                       # indented string\n',
-        "        if False:\n",
+        '            if two == "\'\'":\n                blank(i, i + 2)\n'
+        '                stack.append(["ind"])\n',
+        '            if False:\n                blank(i, i + 2)\n'
+        '                stack.append(["ind"])\n',
     )
 
 
@@ -1721,8 +1738,163 @@ def the_wrong_shell_note_is_pytest_only_again(t):
     """
     return _swap(
         t,
-        '            "🔴 The same applies to EVERY command above, in EVERY language. The "\n',
+        '            "🔴 A `<tool>: command not found` from ANY command above is the "\n'
+        '            "WRONG SHELL and not a broken gate — in EVERY language. The "\n',
         '            "🔴 A note about the wrapper. The "\n',
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Round 16 — V53-V61. Base `ba321c06`, this branch's own head one round on.
+# --------------------------------------------------------------------------- #
+
+def a_nested_interpolation_is_string_text_again(t):
+    """V53 — round 16, the FABRICATION direction of the nested-`''` defect.
+
+    Drops the one branch that makes `${…}` inside an indented string re-enter
+    CODE, so the `''` that OPENS a nested string reads as the OUTER one's
+    terminator again and the interpolation body is scanned as code. Measured at
+    `ba321c06` on `shellHook = '' ${lib.optionalString c '' checks = { unit = 1;
+    } ''} '';` — a flake declaring NO checks output answered **`['unit']`**, so
+    the brief fenced `nix build <wt>#checks.x86_64-linux.unit` at a repository
+    that has no such attribute.
+
+    Isolated to that branch: the escape handling, the terminator and the brace
+    arithmetic are untouched, so a kill here is attributable to interpolation
+    tracking alone.
+    """
+    return _swap(
+        t,
+        '            if two == "${":                   # an interpolation: CODE again\n',
+        "            if False:\n",
+    )
+
+
+def an_identifier_ending_in_apostrophes_opens_a_string(t):
+    """V54 — round 16, the DENIAL direction of the same class.
+
+    Drops the maximal-munch identifier branch, so `foo'' = 1;` — a legal nix
+    name, because `'` is an identifier character — is read as `foo` followed by
+    a string opener that never closes. Measured at `ba321c06`: the rest of the
+    file is blanked and the answer is `None`, the brief's bolded "**no `checks`
+    output**", for a flake whose next binding is the checks block.
+    """
+    return _swap(
+        t,
+        '            if ch.isalpha() or ch == "_":\n',
+        "            if False:\n",
+    )
+
+
+def the_lexer_never_admits_it_got_lost(t):
+    """V55 — round 16. The uncertainty valve is welded shut.
+
+    `_nix_scan` reports whether it ended in a state a nix file can be in. With
+    the valve gone, an unterminated string or a `_PROBE_MAX_BYTES` truncation
+    answers with whatever the patterns happen to say over the mis-lexed text —
+    and both of round 16's measured failures routed to the CONFIDENT answer,
+    which is the whole reason the hedge exists.
+    """
+    return _swap(t, "    if not clean:\n        return []\n",
+                 "    if False:\n        return []\n")
+
+
+def the_scan_stops_stripping_line_comments(t):
+    """V56 — round 16. `#` comments are code again.
+
+    The reachability control for the comment branch, and it is NOT the inert
+    `CHECKS_SHAPES_NOT_CODE` row: the anchored regex rejects a `#`-commented
+    `checks` line whatever the stripper does. What this reaches is the other
+    direction — an ordinary sentence in a comment (`# … the ''-string idiom …`)
+    opening an indented string that never closes, blanking the REAL checks
+    block after it.
+    """
+    return _swap(
+        t,
+        '            if ch == "#":                     # line comment\n',
+        "            if False:\n",
+    )
+
+
+def _not_probed_sentence_keyed_on(kind):
+    """A WHERE-TO-WORK-contradicting sentence in the NOT-PROBED commands bar.
+
+    🔴 THE TWO ROWS BUILT FROM THIS ARE A PAIR, AND THE PAIR IS THE POINT.
+    Round 15 pinned the commands bar within each declared target and guarded its
+    own non-degeneracy with `any(len(kinds) >= 2)`. Measured at `ba321c06`, the
+    partition→checkout-state map was
+
+        probed-devrc-shape    n=6  {private, shared, unknown}
+        cross-repo-otherproj  n=5  {private, shared}
+        repo-unknown          n=2  {shared}
+
+    so `any` was satisfied by the first row alone and NO not-probed scenario was
+    `unknown` kind at all. `kind="unknown"` SURVIVED at **122 passed**;
+    `kind="private"` was killed. Same insertion, same file, one word apart —
+    which is what makes the survivor a measurement of the guard's blind spot
+    rather than a claim about it.
+    """
+    def mutate(t):
+        anchor = (
+            '        "`Makefile` target, the repo\'s CI workflow, its `CLAUDE.md` — and "\n'
+            '        "**NAME the one you used, by path**, in your report.",\n'
+        )
+        return _swap(t, anchor, anchor + (
+            f'        ("Your checkout is a {kind.upper()} one, so the SHARED "\n'
+            '         "checkout is the right place to run the gate."\n'
+            f'         if facts.worktree and facts.worktree.kind == "{kind}" else ""),\n'
+        ))
+    mutate.__name__ = f"a_not_probed_sentence_keyed_on_{kind}"
+    return mutate
+
+
+def the_head_reclaims_prose_it_does_not_always_have(t):
+    """V59 — round 16. Round 15's own replacement wording, restored.
+
+    "the prose names it too, to say what was read out of it" is a claim about a
+    STATE frozen into the state-INDEPENDENT constant. Counted at `ba321c06`:
+    true in the 6 probed scenarios (3 prose lines), false in the 5 cross-repo
+    ones (1 line, and it says "is a DIFFERENT repository"), flatly false in the
+    2 repo-unknown ones (0 — the path is absent from the section).
+
+    🔴 IT IS KILLED BY A WHOLE-STRING PIN, NOT BY A WORD. `claude/RULES.md`:
+    when the artifact under test IS prose, a guard on words is walkable by
+    rewording, so the constant is pinned normalised and whole. A cosmetic reword
+    goes red here on purpose — that is the price of a machine-readable claim,
+    and the docstring on the guard says what to re-measure before changing it.
+    """
+    return _swap(
+        t,
+        '    "resolves the dev shell and nothing else; wherever else it appears it is "\n'
+        '    "PROSE — a statement ABOUT that checkout, never something to run in. Never "\n',
+        '    "resolves the dev shell and nothing else; the prose names it too, to say "\n'
+        '    "what was read out of it. Never "\n',
+    )
+
+
+def the_pytest_diagnosis_is_emitted_without_a_pytest_command(t):
+    """V60 — round 16. The bar diagnoses a command the section did not give.
+
+    Measured at `ba321c06`: with `py_tests` NONE and a flake that names pytest,
+    the section said "no python subset command is prescribed" and then opened
+    the wrong-shell bar with `A bare python3 -m pytest failing…` three lines
+    later. The reader goes looking for a command that is not there.
+    """
+    return _swap(t, "        if tc.py_tests == PY_TESTS_FOUND:\n",
+                 "        if True:\n")
+
+
+def the_absence_bar_points_at_a_bar_that_is_never_above_it(t):
+    """V61 — round 16. The dangling cross-reference, restored.
+
+    The UNKNOWN and NONE branches are mutually exclusive (`if UNKNOWN: return
+    …`), so "a different answer from the one above" names a bar that is emitted
+    in exactly the runs where this one is not.
+    """
+    return _swap(
+        t,
+        '            "from \\"the walk did not finish\\", which this brief says instead "\n',
+        '            "from the one above, which this brief says instead "\n',
     )
 
 
@@ -1915,7 +2087,12 @@ ROWS = [
       "test_a_placeholder_tip_is_never_handed_over_as_though_it_were_a_sha",
       "test_the_clone_grant_covers_only_the_write_the_recipe_makes",
       "test_every_section_directive_is_emitted_verbatim_in_the_brief_that_owns_it",
-      "test_the_where_to_work_section_does_not_call_a_private_worktree_the_clone"},
+      "test_the_where_to_work_section_does_not_call_a_private_worktree_the_clone",
+      # 🔴 ROUND 16 ADDED ONE, and it is the same coupling again rather than
+      # a row gone vague: the absence-bar guard drives three PROBED trees,
+      # and the inversion sends all three down the not-probed branch where
+      # the section prescribes nothing and carries no wrong-shell bar.
+      "test_the_python_absence_bar_does_not_point_at_a_bar_that_is_not_there"},
      invert_cross_repo),
     ("C4  numstat failure reads as a clean zero",
      {"test_the_ledger_refuses_a_failed_command_rather_than_printing_zero"},
@@ -2060,11 +2237,21 @@ ROWS = [
      {"test_a_fork_pr_against_this_repo_is_not_treated_as_cross_repo",
       "test_the_prs_repo_is_read_from_the_url_not_from_the_head_repo",
       "test_no_brief_blames_gh_for_a_repo_gh_was_never_asked_about",
-      "test_the_toolchain_reason_is_true_in_every_scenario"},
+      "test_the_toolchain_reason_is_true_in_every_scenario",
+      # 🔴 ROUND 16: the head-claim guard now asserts, in EVERY scenario, that
+      # a fenced command names the assembly checkout IFF that scenario's
+      # declared target is the probed one. Any mutation that moves a
+      # scenario between the probed and not-probed branches therefore trips
+      # it — which is the same one-decision-reused coupling C3 records, seen
+      # from the guard that was widened to see it.
+      "test_the_toolchain_head_claim_is_true_of_the_rendered_brief"},
      pr_slug_reads_the_head_repo),
     ("P2  'cannot determine' collapses to same-repo",
      {"test_an_undeterminable_repo_gets_its_own_branch_not_the_same_repo_one",
-      "test_no_brief_blames_gh_for_a_repo_gh_was_never_asked_about"},
+      "test_no_brief_blames_gh_for_a_repo_gh_was_never_asked_about",
+      # round 16: the two `repo-unknown` scenarios start PROBING, so the
+      # per-target fenced-command assertion in the head-claim guard fires.
+      "test_the_toolchain_head_claim_is_true_of_the_rendered_brief"},
      unknown_repo_collapses_to_same),
     ("K1  --check always reports clean",
      {"test_the_clause_check_runs_over_a_file_that_can_actually_be_lossy"},
@@ -2373,8 +2560,12 @@ ROWS = [
      {"test_each_clause_carries_the_instruction_its_ledger_entry_names",
       NO_WRITE_SCOPE_GUARD},
      the_no_fetch_clause_is_conditional_again),
+    # 🔴 ROUND 16 GAVE THIS ROW A SECOND KILLER, and that is the point of the
+    # whole-string pin: any edit to `TOOLCHAIN_HEAD` — including one that
+    # reads perfectly well — now has to be re-measured against all three
+    # targets before it lands.
     ("Z4  TOOLCHAIN's reason names the SHARED CHECKOUT again",
-     {"test_the_toolchain_reason_is_true_in_every_scenario"},
+     {"test_the_toolchain_reason_is_true_in_every_scenario", "test_the_toolchain_head_claim_is_true_of_the_rendered_brief"},
      the_toolchain_reason_names_the_shared_checkout_again),
     ("Z5  the emitted block loses its legend",
      {"test_the_emitted_skeleton_carries_a_legend_for_its_two_fields"},
@@ -2679,7 +2870,11 @@ ROWS = [
      {"test_the_flake_checks_probe_reads_an_output_and_not_the_word",
       "test_the_toolchain_prescribes_only_commands_it_probed",
       "test_the_flake_checks_probe_reads_nix_code_and_not_text_that_looks_like_it",
-      "test_the_toolchain_section_names_the_tier_the_merge_gates_on"},
+      "test_the_toolchain_section_names_the_tier_the_merge_gates_on",
+      # round 16: unstripped text also fabricates from the nested fixtures,
+      # and it is what the clean/dirty pair reads.
+      "test_a_nested_indented_string_inside_an_interpolation_is_not_a_terminator",
+      "test_the_probe_hedges_when_the_nix_scan_did_not_end_cleanly"},
      the_checks_probe_matches_the_word_not_the_output),
     # 🔴 ROUND 15 — the `_fmt_uses` fallbacks now have fixtures (a repo with no
     # `.envrc` at all, and one declaring no `use` line), and hardcoding the
@@ -2691,13 +2886,21 @@ ROWS = [
     ("V40 cross-repo, the WRONG repository is probed anyway",
      {"test_the_toolchain_prescribes_nothing_when_it_cannot_probe",
       "test_the_toolchain_reason_is_true_in_every_scenario",
-      "test_no_toolchain_note_claims_a_probe_the_brief_itself_denies"},
+      "test_no_toolchain_note_claims_a_probe_the_brief_itself_denies",
+      # round 16: a not-probed target that prescribes fenced commands is
+      # exactly what the per-target assertion refuses.
+      "test_the_toolchain_head_claim_is_true_of_the_rendered_brief"},
      the_probe_reads_the_cwd_repo_cross_repo_too),
     ("V41 the check-name scan stops tracking nix strings",
      {"test_the_flake_checks_probe_reads_an_output_and_not_the_word",
       "test_the_toolchain_section_names_the_tier_the_merge_gates_on",
       "test_the_flake_checks_probe_reads_nix_code_and_not_text_that_looks_like_it",
-      "test_the_toolchain_prescribes_only_commands_it_probed"},
+      "test_the_toolchain_prescribes_only_commands_it_probed",
+      # round 16: a build script scanned as code is what the nested fixtures
+      # are made of, and an indented string that never opens never closes
+      # either, so the clean/dirty pair sees it too.
+      "test_a_nested_indented_string_inside_an_interpolation_is_not_a_terminator",
+      "test_the_probe_hedges_when_the_nix_scan_did_not_end_cleanly"},
      the_checks_scan_stops_tracking_nix_strings),
 
     # --------------------------------------------------------------------- #
@@ -2715,10 +2918,15 @@ ROWS = [
      {"test_the_flake_checks_probe_reads_nix_code_and_not_text_that_looks_like_it"},
      the_checks_probe_denies_a_shape_it_cannot_enumerate),
     ("V43 `''${…}` and `'''` close an indented string again",
-     {"test_the_flake_checks_probe_reads_nix_code_and_not_text_that_looks_like_it"},
+     {"test_the_flake_checks_probe_reads_nix_code_and_not_text_that_looks_like_it",
+      # round 16: the `an ''${…} escape` nested body reaches it too.
+      "test_a_nested_indented_string_inside_an_interpolation_is_not_a_terminator"},
      the_indented_string_escapes_are_terminators_again),
     ("V44 the walk cap answers 'no python tests' in silence",
-     {"test_a_capped_python_test_walk_is_not_reported_as_no_python_tests"},
+     {"test_a_capped_python_test_walk_is_not_reported_as_no_python_tests",
+      # round 16 drives all three py_tests states, so a cap that answers NONE
+      # is visible from the absence bar too.
+      "test_the_python_absence_bar_does_not_point_at_a_bar_that_is_not_there"},
      the_walk_cap_answers_no_python_tests),
     ("V45 run-ci-suite.sh prescribed without probing for it",
      {"test_the_toolchain_probes_are_reachable_in_both_directions"},
@@ -2734,17 +2942,61 @@ ROWS = [
      the_gate_tier_flag_is_never_prescribed),
     ("V49 a pytest command for a repo with no python tests",
      {"test_a_capped_python_test_walk_is_not_reported_as_no_python_tests",
-      "test_the_toolchain_probes_are_reachable_in_both_directions"},
+      "test_the_toolchain_probes_are_reachable_in_both_directions",
+      "test_the_python_absence_bar_does_not_point_at_a_bar_that_is_not_there"},
      the_python_tests_are_assumed_present),
     ("V50 the wrong-shell bar is emitted only beside a pytest command",
      {"test_the_wrong_shell_diagnosis_covers_every_command_not_only_pytest",
       "test_the_toolchain_section_names_the_tier_the_merge_gates_on",
       "test_the_toolchain_prescribes_only_commands_it_probed",
-      "test_the_toolchain_probes_are_reachable_in_both_directions"},
+      "test_the_toolchain_probes_are_reachable_in_both_directions",
+      "test_the_python_absence_bar_does_not_point_at_a_bar_that_is_not_there"},
      the_wrong_shell_note_goes_back_inside_the_pytest_branch),
     ("V51 the wrong-shell bar stops covering every language",
-     {"test_the_wrong_shell_diagnosis_covers_every_command_not_only_pytest"},
+     {"test_the_wrong_shell_diagnosis_covers_every_command_not_only_pytest",
+      "test_the_python_absence_bar_does_not_point_at_a_bar_that_is_not_there"},
      the_wrong_shell_note_is_pytest_only_again),
+
+    # --------------------------------------------------------------------- #
+    # 🔴 V53-V61 — round 16. Base `ba321c06`. Three of round 15's fixes left
+    # their CLASS open one shape further out, so every row here is paired with
+    # the row that reaches the OTHER direction of the same defect: V53/V54 for
+    # the nested-`''` lex, V57/V58 for the not-probed blind spot (the second is
+    # the positive control that the first's survival was the GUARD's fault and
+    # not the harness's), V60/V61 for the two dangling references.
+    # --------------------------------------------------------------------- #
+    ("V53 a nested `''` inside `${…}` terminates the outer string again",
+     {"test_a_nested_indented_string_inside_an_interpolation_is_not_a_terminator"},
+     a_nested_interpolation_is_string_text_again),
+    ("V54 `foo'' = 1;` opens a string instead of naming a binding",
+     {"test_a_nested_indented_string_inside_an_interpolation_is_not_a_terminator",
+      # a name that opens a string also leaves the scan UNTERMINATED, so the
+      # clean/dirty pair sees it — a second, independent detector.
+      "test_the_probe_hedges_when_the_nix_scan_did_not_end_cleanly"},
+     an_identifier_ending_in_apostrophes_opens_a_string),
+    ("V55 the lexer's uncertainty valve is welded shut",
+     {"test_the_probe_hedges_when_the_nix_scan_did_not_end_cleanly"},
+     the_lexer_never_admits_it_got_lost),
+    ("V56 `#` line comments are scanned as code",
+     {"test_the_comment_stripper_is_reachable_in_its_own_right",
+      # the `a `#` character` nested body carries a comment too.
+      "test_a_nested_indented_string_inside_an_interpolation_is_not_a_terminator"},
+     the_scan_stops_stripping_line_comments),
+    ("V57 a sentence keyed on the UNKNOWN checkout state, not probed",
+     {"test_the_toolchain_reason_is_true_in_every_scenario"},
+     _not_probed_sentence_keyed_on("unknown")),
+    ("V58 the same sentence keyed on PRIVATE — the positive control",
+     {"test_the_toolchain_reason_is_true_in_every_scenario"},
+     _not_probed_sentence_keyed_on("private")),
+    ("V59 TOOLCHAIN_HEAD reclaims prose it does not always have",
+     {"test_the_toolchain_head_claim_is_true_of_the_rendered_brief"},
+     the_head_reclaims_prose_it_does_not_always_have),
+    ("V60 the pytest wrong-shell bar with no pytest command above it",
+     {"test_the_python_absence_bar_does_not_point_at_a_bar_that_is_not_there"},
+     the_pytest_diagnosis_is_emitted_without_a_pytest_command),
+    ("V61 the absence bar points at a bar that is never above it",
+     {"test_the_python_absence_bar_does_not_point_at_a_bar_that_is_not_there"},
+     the_absence_bar_points_at_a_bar_that_is_never_above_it),
 ]
 
 

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -109,7 +109,12 @@ HARNESS_REL = "scripts/tests/mutants-audit-dispatch.py"
 # run of the module (`112 passed`), not from adding this round's three new
 # tests to the last sentence, which is the arithmetic the paragraph above
 # records going wrong twice.
-MIN_TESTS = 107
+#
+# 🔴 ROUND 15 RAISED IT AGAIN, 107 -> 115, at m = 121 — COUNTED from a green run
+# of the module (`122 passed`) and put through the same formula,
+# `122 - min(50, max(1, 122 // 20))`, not derived by adding this round's seven
+# new tests to the last sentence.
+MIN_TESTS = 116
 
 # A row may name this instead of a killer set: the mutation MUST leave the suite
 # green. See the module docstring — the clause ledger pins whole normalised
@@ -1400,14 +1405,18 @@ def the_no_fetch_clause_is_conditional_again(t):
 def the_toolchain_reason_names_the_shared_checkout_again(t):
     # Round 14: the reason is `TOOLCHAIN_HEAD`, so the false claim goes back
     # into the constant. Same words, same finding, one indent level out.
+    # Round 15 re-wrapped the constant (the false "at most ONCE" count came out
+    # of it), so the target moved with the wrap — the ASSERT-BEFORE-RUN check
+    # is what caught that rather than a silently unmutated file.
     return _swap(
         t,
-        '    "a gate script resolves its root from its own path, so running that copy "\n'
-        '    "runs the suite in a checkout that is NOT yours — one holding none of your "\n'
-        '    "mutations — and a `nix build <ref>#…` builds that ref\'s tree, not yours.",\n',
-        '    "a gate script resolves its root from its own path, so running the shared "\n'
-        '    "copy runs the suite in the SHARED CHECKOUT on whatever branch it is "\n'
-        '    "standing on, and a `nix build <ref>#…` builds that ref\'s tree.",\n',
+        '    "it: a gate script resolves its root from its own path, so running that "\n'
+        '    "copy runs the suite in a checkout that is NOT yours — one holding none of "\n'
+        '    "your mutations — and a `nix build <ref>#…` builds that ref\'s tree, not "\n'
+        '    "yours.",\n',
+        '    "it: a gate script resolves its root from its own path, so running the "\n'
+        '    "shared copy runs the suite in the SHARED CHECKOUT on whatever branch it "\n'
+        '    "is standing on, and a `nix build <ref>#…` builds that ref\'s tree.",\n',
     )
 
 
@@ -1461,6 +1470,30 @@ def the_degenerate_causes_stop_scoping_the_omission(t):
 # an artifact that is absent, V37 denies one that is present. A single
 # direction grades only half of a predicate, and the half it omits is the one
 # that silently STOPS prescribing a real command.
+#
+# 🔴 ROUND 15 — THAT SENTENCE WAS A RULE THE ROWS DID NOT OBEY, and three
+# probes had NO mutant in either direction. Measured at `5bad0a0c`, each
+# inversion survived a fully green 115-test suite while shipping a fabricated
+# command. The ledger is now explicit, so "both directions" is checkable rather
+# than asserted:
+#
+#     probe            claims-it-exists   denies-it-exists
+#     gate_sh          V36                V37
+#     ci_suite         V45                V46
+#     gate_tier        V47                V48
+#     py_tests         V49                V44 (the hedge collapsing into "none")
+#     check_names      V38 (text as code) V42 (a real shape denied)
+#     probe_root       V40                — (there is no "probe less" defect
+#                                            here; the not-probed branch IS the
+#                                            honest answer, and V7 covers its
+#                                            body being replaced)
+#
+# The cause of the gap was FIXTURE REACH, not a missing assertion:
+# `_write_repo(py_test=False)` was called by nothing, no fixture had a
+# `gate.sh` without `--tier both`, and no test asked whether `run-ci-suite.sh`
+# was ABSENT from the devrc-shaped brief. A branch no fixture enters is a
+# branch no assertion can grade, so the row would have been vacuous even if
+# somebody had written it.
 
 
 def the_gate_is_prescribed_without_probing_for_it(t):
@@ -1479,16 +1512,78 @@ def the_gate_is_never_prescribed_even_where_it_exists(t):
 
 
 def the_checks_probe_matches_the_word_not_the_output(t):
-    """V38 — the loose regex this detection started with.
+    """V38 — the probe reads TEXT rather than CODE. RE-TARGETED IN ROUND 15.
 
-    It matched `checks = pr.get("statusCheckRollup", [])` inside a python
-    heredoc in `homelab-infra`'s real devShell, so a flake declaring NO checks
-    output answered yes and the honest fallback became unreachable.
+    It used to loosen the regex, because the regex WAS the defence: a loose
+    `^\\s*checks\\b[^\\n=]*=` matched `checks = pr.get("statusCheckRollup", [])`
+    inside a python heredoc in `homelab-infra`'s real devShell, so a flake
+    declaring NO checks output answered yes and the honest fallback became
+    unreachable.
+
+    🔴 THAT SPELLING IS NOW INERT, AND SAYING SO IS THE POINT. Round 15's fix
+    strips nix strings and comments BEFORE either pattern runs, so the heredoc
+    is not text any regex can see — loose or strict, the answer is the same and
+    the row would have reported SURVIVED, a hole where a covered hazard used to
+    be. The defence moved, so the mutation moves with it: drop the strip, and
+    `CHECKS_DECL` matches that same heredoc line in the raw source. Same
+    hazard, same killers, at the layer that now carries it.
+    """
+    return _swap(t, "    code = _nix_strip(text)\n", "    code = text\n")
+
+
+def a_state_dependent_sentence_moves_into_the_commands_bar(t):
+    """V52 — round 15's BLOCKING finding, as a row.
+
+    Round 14 moved the reason into a constant and lifted the cross-scenario pin
+    off the COMMANDS bar entirely. This is the sentence that walked the gap:
+    keyed on the AUDITOR's own worktree kind — which no probe reads — and
+    flatly contradicting WHERE TO WORK, exactly as round 5's did. Measured at
+    `5bad0a0c`: **115 passed, SURVIVED**. The same sentence inside the old
+    whole-section `return [...]` at `9e23c379` was killed by this guard, so the
+    finding was reopened by the text sitting three lines lower.
+    """
+    anchor = (
+        '            "standing on another branch, so treat a command that has since "\n'
+        '            "moved as a lookup, never as a finding.",\n'
+    )
+    return _swap(t, anchor, anchor + (
+        '            (f"Your checkout is a PRIVATE linked worktree ({facts.worktree}), so "\n'
+        '             "the SHARED checkout is the right place to run the gate."\n'
+        '             if facts.worktree and facts.worktree.kind == "private" else\n'
+        '             f"Worktree kind: {facts.worktree.kind if facts.worktree else None}."),\n'
+    ))
+
+
+def the_checks_probe_denies_a_shape_it_cannot_enumerate(t):
+    """V42 — round 15. `[]` collapses back into `None`: the CONFIDENT answer.
+
+    A `checks` binding whose names this parse cannot read is "declared, names
+    unreadable"; answering `None` makes the brief state in bold that the
+    repository has NO sandbox tier — the tier the same section calls the one
+    the merge gates on. Measured at `5bad0a0c` for `genAttrs`, flake-parts'
+    `perSystem`, `checks.<system>.default` and `checks.<system> = base // {…}`.
     """
     return _swap(
         t,
-        'r"^[ \\t]*checks(?:\\.[^\\s=]+)?[ \\t]*=[ \\t]*(?:forAllSystems[^\\n]*)?\\{[ \\t]*$",',
-        'r"^[ \\t]*checks\\b[^\\n=]*=",',
+        "        return [] if CHECKS_DECL.search(code) else None\n",
+        "        return None\n",
+    )
+
+
+def the_indented_string_escapes_are_terminators_again(t):
+    """V43 — round 15. `''${…}` and `'''` read as closing an indented string.
+
+    The measured consequence on devrc's OWN flake with one `echo ''${HOME}` in
+    the `pytests` build script: `['pytests', 'nodetests']` -> `['pytests',
+    'rc', 'rc']`. Two fabricated `nix build` targets named after a shell
+    variable, and `nodetests` — a check the merge really gates on — dropped in
+    silence. Isolated to the escape branch: the terminator branch and the depth
+    arithmetic are untouched, so a kill here is attributable to escapes alone.
+    """
+    return _swap(
+        t,
+        '                    if nxt in ("$", "\'"):     # \'\'${…}  and  \'\'\'  — escapes\n',
+        "                    if False:\n",
     )
 
 
@@ -1518,20 +1613,116 @@ def the_probe_reads_the_cwd_repo_cross_repo_too(t):
 
 
 def the_checks_scan_stops_tracking_nix_strings(t):
-    """V41 — drop the `''…''` skip from the check-name scan.
+    """V41 — the `''…''` skip is dropped. RE-TARGETED IN ROUND 15.
 
-    A brace inside a build script then moves the depth counter and the block
-    closes early, so a flake's SECOND check name is never read. Isolated to the
-    string toggle: the surrounding depth arithmetic is untouched, so a kill
-    here is attributable to string tracking and nothing else.
+    Same defect, one layer over: the toggle used to live in the name scan and
+    now lives in `_nix_strip`, so the mutation is "an indented string is not a
+    string". A brace inside a build script then moves the depth counter and the
+    block closes early, so a flake's SECOND check name is never read. Isolated
+    to the indented-string branch: `"…"`, `#` and `/* */` handling and the
+    depth arithmetic are untouched.
     """
     return _swap(
         t,
-        '            if line[i:i + 2] == "\'\'":\n'
-        "                in_str = not in_str\n"
-        "                i += 2\n"
-        "                continue\n",
-        "",
+        '        if two == "\'\'":                       # indented string\n',
+        "        if False:\n",
+    )
+
+
+def the_walk_cap_answers_no_python_tests(t):
+    """V44 — round 15. The cap fails SILENTLY again, as it did at `5bad0a0c`.
+
+    "I stopped looking" collapses into "there are none", which is the confident
+    answer, and the brief then omits the subset command with no note at all.
+    Measured reachable on a real repository: `~/workspace/civit` has 157,319
+    directories within depth ≤ 4 after the skip list and its first `test_*.py`
+    at walk visit 1,185.
+    """
+    return _swap(t,
+                 "                return PY_TESTS_UNKNOWN\n",
+                 "                return PY_TESTS_NONE\n")
+
+
+def the_ci_suite_is_prescribed_without_probing_for_it(t):
+    """V45 — round 15. `run-ci-suite.sh` for a repo that has none.
+
+    V36's shape at the sibling site the both-directions rule above never
+    reached: measured SURVIVING a fully green 115-test suite at `5bad0a0c`,
+    because no fixture asserted that runner was ABSENT from the devrc-shaped
+    brief.
+    """
+    return _swap(t, "    if tc.ci_suite:\n", "    if True:\n")
+
+
+def the_ci_suite_is_never_prescribed_even_where_it_exists(t):
+    """V46 — the mirror of V45: a real `run-ci-suite.sh` goes unmentioned."""
+    return _swap(t, "    if tc.ci_suite:\n", "    if False:\n")
+
+
+def the_gate_tier_flag_is_assumed(t):
+    """V47 — round 15. `--tier both` appended to any repo's gate.sh.
+
+    The EXACT fabrication that field exists to prevent, and it survived at
+    `5bad0a0c`: no fixture had a `gate.sh` lacking `--tier both`, so the branch
+    that omits the flag was entered by nothing.
+    """
+    return _swap(
+        t,
+        '        gate_tier=bool(gate and "--tier" in gate and "both" in gate),\n',
+        "        gate_tier=True,\n",
+    )
+
+
+def the_gate_tier_flag_is_never_prescribed(t):
+    """V48 — the mirror: a `gate.sh` that DOES take `--tier both` runs without
+    it, so the auditor runs one tier and reports on two."""
+    return _swap(
+        t,
+        '        gate_tier=bool(gate and "--tier" in gate and "both" in gate),\n',
+        "        gate_tier=False,\n",
+    )
+
+
+def the_python_tests_are_assumed_present(t):
+    """V49 — round 15. `python3 -m pytest` for a repo with no python tests.
+
+    `_write_repo`'s `py_test=` was never passed `False` by any call site, so
+    the branch that suppresses the command was executed by no test and the
+    inversion SURVIVED at `5bad0a0c`.
+    """
+    return _swap(t,
+                 "    if tc.py_tests == PY_TESTS_NONE:\n",
+                 "    if False:\n")
+
+
+def the_wrong_shell_note_goes_back_inside_the_pytest_branch(t):
+    """V50 — round 15. The diagnosis is emitted only where pytest is.
+
+    The measured state at `5bad0a0c`: the bar lived in
+    `_toolchain_pytest_lines`, so a repository with a real gate, a flake
+    devShell providing `nodejs` and no python tests got a BARE gate command and
+    no wrong-shell diagnosis anywhere in the section. `node: command not found`
+    then reads exactly like a broken gate.
+    """
+    return _swap(
+        t,
+        '        if any(ln.startswith("```") for ln in prescriptions):\n',
+        "        if False:\n",
+    )
+
+
+def the_wrong_shell_note_is_pytest_only_again(t):
+    """V51 — round 15. The language-agnostic sentence is reworded away.
+
+    Leaves the pytest sentence and the phrase `WRONG SHELL` in place, so a
+    guard that asks only for those stays green while an auditor whose gate
+    fails on `node`, `go` or `cargo` has been told nothing. The SPELLED-guard
+    control for V50: the bar is present, and says less than it claims to.
+    """
+    return _swap(
+        t,
+        '            "🔴 The same applies to EVERY command above, in EVERY language. The "\n',
+        '            "🔴 A note about the wrapper. The "\n',
     )
 
 
@@ -1670,6 +1861,17 @@ ROWS = [
       "test_the_toolchain_prescribes_nothing_when_it_cannot_probe",
       "test_the_toolchain_section_names_the_tier_the_merge_gates_on",
       "test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout",
+      # 🔴 ROUND 15 ADDED FIVE MORE, and they are the SAME coupling one layer
+      # on: every one of round 15's new toolchain guards drives a probed
+      # repository, and the inversion sends all five of them down the
+      # not-probed branch, where the section prescribes nothing at all. That
+      # the set grew again is the same evidence the round-14 note records —
+      # one decision, reused, rather than a second derivation free to disagree.
+      "test_a_capped_python_test_walk_is_not_reported_as_no_python_tests",
+      "test_the_toolchain_head_claim_is_true_of_the_rendered_brief",
+      "test_the_toolchain_probes_are_reachable_in_both_directions",
+      "test_the_wrong_shell_diagnosis_covers_every_command_not_only_pytest",
+      "test_an_unreadable_flake_is_not_reported_as_an_absent_one",
       # 🔴 ROUND 8 ADDED NINE MORE, and every one is the same coupling seen
       # from a new angle: round 8 made THE RANGE and THE LEDGER consult
       # `repo_relation`, so inverting that decision now moves both sections in
@@ -1825,12 +2027,20 @@ ROWS = [
     ("H4  round-1 placeholder back in the header",
      {"test_emit_claims_prints_a_block_this_scripts_own_parser_accepts"},
      emit_claims_interpolates_the_placeholder),
+    # 🔴 ROUND 15 ADDED ONE KILLER TO EACH, and it is the same coupling in
+    # both: `TOOLCHAIN_HEAD` promises the assembly checkout appears in RUNNABLE
+    # commands only as the `nix develop` argument, and round 15 added a guard
+    # that checks that promise against the RENDERED brief rather than against
+    # the constant. Pointing the gate or the `nix build` at that path is
+    # exactly the claim it falsifies, so it fires by construction.
     ("T1  gate.sh points at the shared checkout",
-     {"test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout"},
+     {"test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout",
+      "test_the_toolchain_head_claim_is_true_of_the_rendered_brief"},
      gate_points_at_the_shared_checkout),
     ("T2  nix build points at the shared checkout",
      {"test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout",
-      "test_the_toolchain_section_names_the_tier_the_merge_gates_on"},
+      "test_the_toolchain_section_names_the_tier_the_merge_gates_on",
+      "test_the_toolchain_head_claim_is_true_of_the_rendered_brief"},
      nix_build_points_at_the_shared_checkout),
     # 🔴 ROUND 13 WIDENED BOTH KILLER SETS, and both additions are real
     # couplings. Round 13's `unknown-repo-gh-said-nothing` scenario is a `gh`
@@ -1842,10 +2052,15 @@ ROWS = [
     # the guard reporting that it was pointed at the wrong section — which is
     # what that assertion is for. Listed in full rather than trimmed, the same
     # treatment C3, Y2, V4, V21 and V33 get.
+    # 🔴 ROUND 15 — ONE MORE, and it is round 15's own partition pin: with the
+    # fork shape resolving to a KNOWN repo, `unknown-repo-gh-said-nothing`
+    # leaves the `repo-unknown` partition and its commands bar stops matching
+    # `claims-file-assumed-base`'s. The within-target equality is what fires.
     ("P1  pr_slug reads the HEAD repo again",
      {"test_a_fork_pr_against_this_repo_is_not_treated_as_cross_repo",
       "test_the_prs_repo_is_read_from_the_url_not_from_the_head_repo",
-      "test_no_brief_blames_gh_for_a_repo_gh_was_never_asked_about"},
+      "test_no_brief_blames_gh_for_a_repo_gh_was_never_asked_about",
+      "test_the_toolchain_reason_is_true_in_every_scenario"},
      pr_slug_reads_the_head_repo),
     ("P2  'cannot determine' collapses to same-repo",
      {"test_an_undeterminable_repo_gets_its_own_branch_not_the_same_repo_one",
@@ -2236,9 +2451,14 @@ ROWS = [
     # heading with no commands bar under it and no "NOTHING WAS PROBED HERE" —
     # which is exactly what round 14's cross-repo guard reads. Measured, not
     # predicted: the battery reported it as an EXTRA-KILLER first.
+    # 🔴 ROUND 15 — a third killer, same coupling as the second: the mutant
+    # replaces the whole cross-repo section body, so the not-probed branch
+    # renders neither `NOTHING WAS PROBED HERE` nor its "name the runner by
+    # path" hand-over, and round 15's contradiction guard reads exactly those.
     ("V7  TOOLCHAIN names the SHARED CHECKOUT, cross-repo only",
      {"test_the_toolchain_reason_is_true_in_every_scenario",
-      "test_the_toolchain_prescribes_nothing_when_it_cannot_probe"},
+      "test_the_toolchain_prescribes_nothing_when_it_cannot_probe",
+      "test_no_toolchain_note_claims_a_probe_the_brief_itself_denies"},
      the_toolchain_names_the_shared_checkout_cross_repo_only),
 
     # --------------------------------------------------------------------- #
@@ -2445,25 +2665,86 @@ ROWS = [
     # command removes both strings, so both fire — the second for a reason
     # adjacent to what it owns, which is why it is recorded here rather than
     # left to look like an accident.
+    # 🔴 ROUND 15 — two more, both from fixtures that did not exist before.
+    # Suppressing every `gate.sh` removes the ONLY command from two new
+    # single-purpose repos (the no-`--tier` gate and the nodejs-flake gate), and
+    # each guard fires on its own "the command under test is absent" assertion.
     ("V37 gate.sh never prescribed, even where it exists",
      {"test_the_toolchain_section_names_the_tier_the_merge_gates_on",
-      "test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout"},
+      "test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout",
+      "test_the_toolchain_probes_are_reachable_in_both_directions",
+      "test_the_wrong_shell_diagnosis_covers_every_command_not_only_pytest"},
      the_gate_is_never_prescribed_even_where_it_exists),
-    ("V38 the checks probe matches the WORD, not the output",
+    ("V38 the checks probe reads TEXT rather than CODE",
      {"test_the_flake_checks_probe_reads_an_output_and_not_the_word",
-      "test_the_toolchain_prescribes_only_commands_it_probed"},
+      "test_the_toolchain_prescribes_only_commands_it_probed",
+      "test_the_flake_checks_probe_reads_nix_code_and_not_text_that_looks_like_it",
+      "test_the_toolchain_section_names_the_tier_the_merge_gates_on"},
      the_checks_probe_matches_the_word_not_the_output),
+    # 🔴 ROUND 15 — the `_fmt_uses` fallbacks now have fixtures (a repo with no
+    # `.envrc` at all, and one declaring no `use` line), and hardcoding the
+    # sentence removes both of their answers.
     ("V39 the .envrc sentence is hardcoded again",
-     {"test_the_toolchain_prescribes_only_commands_it_probed"},
+     {"test_the_toolchain_prescribes_only_commands_it_probed",
+      "test_the_toolchain_probes_are_reachable_in_both_directions"},
      the_envrc_sentence_is_hardcoded_again),
     ("V40 cross-repo, the WRONG repository is probed anyway",
      {"test_the_toolchain_prescribes_nothing_when_it_cannot_probe",
-      "test_the_toolchain_reason_is_true_in_every_scenario"},
+      "test_the_toolchain_reason_is_true_in_every_scenario",
+      "test_no_toolchain_note_claims_a_probe_the_brief_itself_denies"},
      the_probe_reads_the_cwd_repo_cross_repo_too),
     ("V41 the check-name scan stops tracking nix strings",
      {"test_the_flake_checks_probe_reads_an_output_and_not_the_word",
-      "test_the_toolchain_section_names_the_tier_the_merge_gates_on"},
+      "test_the_toolchain_section_names_the_tier_the_merge_gates_on",
+      "test_the_flake_checks_probe_reads_nix_code_and_not_text_that_looks_like_it",
+      "test_the_toolchain_prescribes_only_commands_it_probed"},
      the_checks_scan_stops_tracking_nix_strings),
+
+    # --------------------------------------------------------------------- #
+    # 🔴 V42-V51 — round 15. Base `5bad0a0c` — THIS BRANCH's own head. Six of
+    # these are the both-directions rule applied where round 14 stated it and
+    # did not apply it: `ci_suite`, `gate_tier` and `py_tests` each had NO
+    # mutant in either direction, and all three inversions were measured
+    # SURVIVING a fully green 115-test suite while shipping a fabricated
+    # command. The cause was fixture reach, not a missing assertion.
+    # --------------------------------------------------------------------- #
+    ("V52 a state-dependent sentence in the COMMANDS bar",
+     {"test_the_toolchain_reason_is_true_in_every_scenario"},
+     a_state_dependent_sentence_moves_into_the_commands_bar),
+    ("V42 a checks shape it cannot enumerate is DENIED, not hedged",
+     {"test_the_flake_checks_probe_reads_nix_code_and_not_text_that_looks_like_it"},
+     the_checks_probe_denies_a_shape_it_cannot_enumerate),
+    ("V43 `''${…}` and `'''` close an indented string again",
+     {"test_the_flake_checks_probe_reads_nix_code_and_not_text_that_looks_like_it"},
+     the_indented_string_escapes_are_terminators_again),
+    ("V44 the walk cap answers 'no python tests' in silence",
+     {"test_a_capped_python_test_walk_is_not_reported_as_no_python_tests"},
+     the_walk_cap_answers_no_python_tests),
+    ("V45 run-ci-suite.sh prescribed without probing for it",
+     {"test_the_toolchain_probes_are_reachable_in_both_directions"},
+     the_ci_suite_is_prescribed_without_probing_for_it),
+    ("V46 run-ci-suite.sh never prescribed, even where it exists",
+     {"test_the_toolchain_prescribes_only_commands_it_probed"},
+     the_ci_suite_is_never_prescribed_even_where_it_exists),
+    ("V47 `--tier both` appended to a gate that never showed it takes one",
+     {"test_the_toolchain_probes_are_reachable_in_both_directions"},
+     the_gate_tier_flag_is_assumed),
+    ("V48 `--tier both` dropped from a gate that does take it",
+     {"test_the_toolchain_section_names_the_tier_the_merge_gates_on"},
+     the_gate_tier_flag_is_never_prescribed),
+    ("V49 a pytest command for a repo with no python tests",
+     {"test_a_capped_python_test_walk_is_not_reported_as_no_python_tests",
+      "test_the_toolchain_probes_are_reachable_in_both_directions"},
+     the_python_tests_are_assumed_present),
+    ("V50 the wrong-shell bar is emitted only beside a pytest command",
+     {"test_the_wrong_shell_diagnosis_covers_every_command_not_only_pytest",
+      "test_the_toolchain_section_names_the_tier_the_merge_gates_on",
+      "test_the_toolchain_prescribes_only_commands_it_probed",
+      "test_the_toolchain_probes_are_reachable_in_both_directions"},
+     the_wrong_shell_note_goes_back_inside_the_pytest_branch),
+    ("V51 the wrong-shell bar stops covering every language",
+     {"test_the_wrong_shell_diagnosis_covers_every_command_not_only_pytest"},
+     the_wrong_shell_note_is_pytest_only_again),
 ]
 
 

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -425,9 +425,10 @@ def gate_points_at_the_shared_checkout(t):
 def nix_build_points_at_the_shared_checkout(t):
     return _swap(
         t,
-        '        *[f"nix build <your worktree>#checks.{NIX_SYSTEM}.{n}"\n'
+        '        *[f"nix build <your worktree>#checks.{NIX_SYSTEM}.{n}'
+        ' --no-link -L"\n'
         "          for n in tc.check_names],\n",
-        '        *[f"nix build {tc.root}#checks.{NIX_SYSTEM}.{n}"\n'
+        '        *[f"nix build {tc.root}#checks.{NIX_SYSTEM}.{n} --no-link -L"\n'
         "          for n in tc.check_names],\n",
     )
 

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -496,6 +496,26 @@ implementation" failure. The deletion detectors are the ledger tests.
    script deliberately refuses to classify payload vs scaffolding; nothing
    mechanical can grade the answer.
 
+🔴 ROUND 15's BASE IS `5bad0a0c` — THIS BRANCH'S OWN HEAD, not `origin/main`,
+because every finding it carries is a defect this branch shipped. Measured with
+the base script and the current module: **6 failed, 116 passed**, and all six
+fail on an ASSERTION rather than an import or a missing symbol — checked
+deliberately, since an arity red is not regression coverage. `RED_AT_BASE_R15`
+carries them.
+
+Its other half is not a base ref at all. Three probes (`ci_suite`, `gate_tier`,
+`py_tests`) had NO mutant in either direction, and all three inversions were
+measured SURVIVING a fully green 115-test suite while shipping a fabricated
+command — `--tier both` appended to any repo's `gate.sh` being the exact
+fabrication that field exists to prevent. The cause was FIXTURE REACH:
+`_write_repo(py_test=False)` was called by nothing, no fixture had a `gate.sh`
+lacking `--tier both`, and no test asked whether `run-ci-suite.sh` was ABSENT
+from the devrc-shaped brief. A branch no fixture enters is a branch no assertion
+can grade, so a row written for it would have been vacuous too. That is why
+`test_the_toolchain_probes_are_reachable_in_both_directions` is filed as a GUARD
+and its evidence is V45/V47/V49: a fixture-reach fix cannot be watched red
+anywhere, which is precisely why it goes unnoticed.
+
 HERMETIC: no test touches the network, spawns a process, or reads a real PR.
 `test_nothing_here_spawns_a_subprocess` proves the first two by making
 `subprocess.run` raise for the duration of a full `main()` run.
@@ -928,6 +948,24 @@ PY
 }
 """
 
+# 🔴 A FLAKE THAT PROVIDES A TOOLCHAIN AND NAMES NO PYTEST. The shape round 15
+# found unguarded: `toolchain_shell` asks ONE question — does `flake.nix`
+# mention pytest — and wraps the LANGUAGE-AGNOSTIC gate with the answer, so this
+# repository's gate is prescribed bare and fails `node: command not found`.
+NODE_ONLY_FLAKE = """\
+{
+  outputs = { self, nixpkgs }:
+    {
+      devShells.default = pkgs.mkShell {
+        buildInputs = [ pkgs.nodejs pkgs.esbuild ];
+      };
+      checks.x86_64-linux = {
+        nodetests = pkgs.runCommandLocal "nodetests" { } "node --test";
+      };
+    };
+}
+"""
+
 # Also shebang-free, and for the same reason as `run-ci-suite.sh` above: the
 # probe reads this text looking for `--tier` and `both` and never runs it. What
 # matters is that both markers are present in the shapes devrc's real
@@ -938,6 +976,19 @@ DEVRC_GATE = """\
 case "$1" in
   --tier) TIER="${2:-both}" ;;
 esac
+"""
+
+# 🔴 A `scripts/gate.sh` THAT DOES NOT TAKE `--tier`, which no fixture had. The
+# branch that omits the flag was entered by nothing, so `gate_tier=True` — the
+# exact fabrication that field exists to prevent — survived a green suite.
+# Shebang-free for the same reason as `DEVRC_GATE` and `run-ci-suite.sh` above:
+# nothing here is executed, and a shebang a TEST writes trips the repo-wide
+# `test_no_test_writes_a_usr_bin_env_shebang_at_runtime` guard, which only the
+# full gate runs.
+PLAIN_GATE = """\
+# scripts/gate.sh — this repository's gate takes no arguments at all.
+set -euo pipefail
+python3 -m pytest .
 """
 
 _write_repo(FAKE_REPO_DIR, envrc="use opencode\n", gate=DEVRC_GATE,
@@ -1691,6 +1742,76 @@ SCENARIO_RUNS = {
     ),
 }
 SCENARIOS = tuple(SCENARIO_RUNS)
+
+# 🔴 WHAT THE COMMANDS BAR IS ALLOWED TO VARY WITH — declared, not inferred.
+#
+# Round 14 split TOOLCHAIN on one axis (reason vs commands) and pinned only the
+# REASON across scenarios. Round 15 measured what that left open: inserting
+#
+#     (f"Your checkout is a PRIVATE linked worktree ({facts.worktree}), so "
+#      "the SHARED checkout is the right place to run the gate."
+#      if facts.worktree and facts.worktree.kind == "private" else
+#      f"Worktree kind: {facts.worktree.kind if facts.worktree else None}.")
+#
+# into the PROBED body — a sentence that varies with AUDITOR STATE and flatly
+# contradicts WHERE TO WORK — left the module at **115 passed**, while the same
+# sentence in the old whole-section `return [...]` at `9e23c379` was killed by
+# this very guard. Round 5's finding, reopened by sitting three lines lower.
+#
+# The relaxation was justified for the COMMANDS, which must differ by TARGET
+# REPOSITORY. It was not justified for auditor state, which the probe never
+# reads. So the pin is restored WITHIN each target: two scenarios that probe the
+# same thing must render byte-identical commands, whatever the round, the head
+# sha, the base, or the kind of checkout the brief was assembled in.
+#
+# 🔴 THE KEY IS NOT "PROBE ROOT". That was the first spelling and it is too
+# coarse: `cross-repo` and `unknown-repo-gh-said-nothing` both probe NOTHING,
+# and the not-probed branch legitimately names `facts.repo` and says WHY it
+# could not probe — two different sentences for two different states. The axes
+# the bar may depend on are the target's identity, its content, and whether it
+# was probeable; everything else is auditor state.
+TOOLCHAIN_TARGET_KEYS = frozenset({
+    "probed-devrc-shape",     # a real checkout of the PR's repo, on disk
+    "cross-repo-otherproj",   # a DIFFERENT repository is in the cwd
+    "repo-unknown",           # which repository the PR is in was never learned
+})
+TOOLCHAIN_TARGET_OF = {
+    "delta": "probed-devrc-shape",
+    "degenerate": "probed-devrc-shape",
+    "private-worktree": "probed-devrc-shape",
+    "unreadable-worktree": "probed-devrc-shape",
+    "delta-no-head-sha": "probed-devrc-shape",
+    "delta-assumed-base": "probed-devrc-shape",
+    "cross-repo": "cross-repo-otherproj",
+    "cross-repo-private": "cross-repo-otherproj",
+    "cross-repo-delta": "cross-repo-otherproj",
+    "cross-repo-delta-no-head-sha": "cross-repo-otherproj",
+    "cross-repo-renamed-remote-delta": "cross-repo-otherproj",
+    "claims-file-assumed-base": "repo-unknown",
+    "unknown-repo-gh-said-nothing": "repo-unknown",
+}
+
+# The three checkout states, by the phrase `render_checkout_state` prints for
+# each. Spelled here so a reword breaks this loudly rather than silently
+# collapsing every scenario into "kind unknown" and making the non-degeneracy
+# assertion below vacuous.
+CHECKOUT_KIND_MARKERS = {
+    "private": "PRIVATE linked worktree",
+    "shared": "SHARED — other sessions and agents are in this tree",
+    "unknown": "🔴 COULD NOT DETERMINE",
+}
+
+
+def checkout_kind_of(brief):
+    """-> 'private' | 'shared' | 'unknown', or an assertion if it is ambiguous."""
+    section = checkout_section(brief)
+    hit = [k for k, marker in CHECKOUT_KIND_MARKERS.items() if marker in section]
+    assert len(hit) == 1, (
+        f"THE CHECKOUT names {len(hit)} of the three states ({hit}); this "
+        "helper can no longer tell them apart, so any claim built on it is "
+        f"vacuous:\n{section}"
+    )
+    return hit[0]
 
 
 def brief_for_scenario(name):
@@ -5182,20 +5303,31 @@ def test_the_toolchain_reason_is_true_in_every_scenario():
     cross-repo (the defect, with a new source). It genuinely could not coexist,
     so the split is stated rather than smuggled.
 
-    🔴 THE PROPERTY IT PROTECTED IS NOT WEAKENED — it became STRUCTURAL. The
-    reason lives in `TOOLCHAIN_HEAD`/`TOOLCHAIN_TAIL`, module-level CONSTANTS
-    taking no argument, so a state-dependent rationale is no longer merely
-    unasserted, it is unwritable without deleting the constant. This guard
-    still drives every scenario, still runs the three phrase assertions over
-    the FULL section, and now checks BOTH that the reason bars are byte-equal
-    across scenarios AND that each IS the constant — which the old equality did
-    not do, and which is what makes "byte-identical to WHAT" answerable. It
-    also fails if every scenario renders the SAME commands bar, the shape this
-    fix would take if the detection were inert.
+    🔴 ROUND 14 CLAIMED "THE PROPERTY IT PROTECTED IS NOT WEAKENED — it became
+    STRUCTURAL", AND THAT WAS FALSE. It was measured false at `5bad0a0c`: the
+    reason bar did become a constant, but the pin was lifted off the COMMANDS
+    bar entirely, and a state-dependent sentence three lines lower — one that
+    varies with the auditor's own worktree kind and contradicts WHERE TO WORK —
+    walked the whole module at 115 passed. See `TOOLCHAIN_TARGET_OF`, which
+    carries the mutation and the measurement. A claim that a relaxation is
+    lossless is the kind of claim that stops the next reader checking, so it is
+    corrected here rather than softened.
+
+    What is true: the reason lives in `TOOLCHAIN_HEAD`, a module-level CONSTANT
+    taking no argument, so a state-dependent RATIONALE is unwritable without
+    deleting the constant. What is now also true, and is the round-15 fix: the
+    COMMANDS bar is pinned byte-identical WITHIN each target
+    (`TOOLCHAIN_TARGET_OF`), so the only axis it may vary on is the one the
+    probe actually reads. This guard still drives every scenario, still runs
+    the three phrase assertions over the FULL section, still requires the
+    reason to BE the constant, and still fails if every scenario renders the
+    same commands bar (the shape this fix would take if the detection were
+    inert).
     """
-    sections, reasons = {}, {}
+    sections, reasons, briefs = {}, {}, {}
     for scenario in SCENARIOS:
-        tool = toolchain_section(brief_for_scenario(scenario))
+        briefs[scenario] = brief_for_scenario(scenario)
+        tool = toolchain_section(briefs[scenario])
         sections[scenario] = tool
         assert "SHARED CHECKOUT" not in tool, (
             f"\n\nscenario {scenario!r}: TOOLCHAIN calls `{FAKE_REPO_DIR}` the "
@@ -5277,6 +5409,60 @@ def test_the_toolchain_reason_is_true_in_every_scenario():
         "defect with a new source — or the detection is inert and one "
         "repository's layout is being prescribed at every target.\n"
         f"  scenarios: {sorted(prescribing)}"
+    )
+
+    # 🔴 ROUND 15 — THE COMMANDS BAR, PINNED WITHIN EACH TARGET. Everything
+    # above this point grades the REASON; the finding is that the bar BELOW the
+    # reason lost its pin altogether when round 14 split the section, and that
+    # a sentence keyed on `facts.worktree` walks straight through the gap.
+    assert set(TOOLCHAIN_TARGET_OF) == set(SCENARIOS), (
+        "\n\nTOOLCHAIN_TARGET_OF and SCENARIOS disagree. A scenario with no "
+        "declared target is one this pin silently skips, which is how the "
+        f"whole guard gets emptied.\n  only in the table: "
+        f"{sorted(set(TOOLCHAIN_TARGET_OF) - set(SCENARIOS))}\n"
+        f"  only in SCENARIOS: {sorted(set(SCENARIOS) - set(TOOLCHAIN_TARGET_OF))}"
+    )
+    assert set(TOOLCHAIN_TARGET_OF.values()) <= TOOLCHAIN_TARGET_KEYS, (
+        "a scenario declares a target outside the closed enumeration. Adding a "
+        "key is how a state-dependent sentence gets accommodated instead of "
+        "fixed — the new key would put the offending scenario in a partition "
+        "of its own, where nothing compares it to anything: "
+        f"{sorted(set(TOOLCHAIN_TARGET_OF.values()) - TOOLCHAIN_TARGET_KEYS)}"
+    )
+    by_target = {}
+    for scenario in SCENARIOS:
+        by_target.setdefault(TOOLCHAIN_TARGET_OF[scenario], []).append(scenario)
+    for key, members in sorted(by_target.items()):
+        assert len(members) >= 2, (
+            f"target {key!r} is declared by ONE scenario ({members}), so "
+            "within-target equality asserts nothing there. A partition of one "
+            "is the shape this pin degrades into."
+        )
+        ref = members[0]
+        for scenario in members[1:]:
+            got = sections[scenario].split(ad.TOOLCHAIN_COMMANDS_HEADING, 1)[1]
+            want = sections[ref].split(ad.TOOLCHAIN_COMMANDS_HEADING, 1)[1]
+            assert got == want, (
+                f"\n\nTOOLCHAIN's COMMANDS bar differs between {ref!r} and "
+                f"{scenario!r}, which probe the SAME target ({key}). Nothing "
+                "on the auditor's side — round, head sha, base ref, dirty "
+                "count, or the kind of checkout this brief was assembled in — "
+                "is read by the probe, so a difference here is a claim the "
+                "section cannot support in the state it is not being read in. "
+                "That is round 5's finding, one bar lower.\n"
+                f"--- {ref} ---\n{want}\n--- {scenario} ---\n{got}"
+            )
+    # 🔴 NON-DEGENERACY, and it is what makes the equality above a MEASUREMENT.
+    # A partition whose members all share one checkout state cannot see a
+    # sentence keyed on that state — the equality would hold vacuously. At
+    # least one partition must span two of the three states, or this pin is
+    # blind to the exact mutation it was written for.
+    kinds = {key: {checkout_kind_of(briefs[s]) for s in members}
+             for key, members in by_target.items()}
+    assert any(len(k) >= 2 for k in kinds.values()), (
+        "\n\nno target partition spans two checkout states, so the equality "
+        "above cannot see a sentence that varies with the auditor's own "
+        f"worktree — the mutation this guard exists for. states: {kinds}"
     )
 
 
@@ -5398,7 +5584,7 @@ def test_the_toolchain_prescribes_only_commands_it_probed(tmp_path):
     )
 
 
-def test_the_toolchain_prescribes_nothing_when_it_cannot_probe(tmp_path):
+def test_the_toolchain_prescribes_nothing_when_it_cannot_probe():
     """🔴 Cross-repo: no checkout of the PR's repo, so NO command is invented.
 
     The counterpart to the guard above, and the one that pins the design's
@@ -5431,7 +5617,7 @@ def test_the_toolchain_prescribes_nothing_when_it_cannot_probe(tmp_path):
     )
 
 
-def test_the_flake_checks_probe_reads_an_output_and_not_the_word(tmp_path):
+def test_the_flake_checks_probe_reads_an_output_and_not_the_word():
     """🔴 The three answers `_flake_check_names` must keep distinct.
 
     `None` (no `checks` output), `[]` (declared but unreadable) and a name list
@@ -5458,6 +5644,526 @@ def test_the_flake_checks_probe_reads_an_output_and_not_the_word(tmp_path):
         "a truncated/unreadable checks block must answer [] — 'declared but "
         "I could not read the names' — and not None, which claims the "
         "repository HAS no sandbox tier"
+    )
+
+
+# 🔴 ROUND 15 — THE SHAPES THE PROBE ANSWERED WRONG, IN BOTH DIRECTIONS. Every
+# one measured at `5bad0a0c` through the real function; the comment beside each
+# row is what it answered THERE.
+CHECKS_SHAPES_DECLARED = {
+    # `None` at `5bad0a0c` — "this repository has no sandbox tier", in bold, for
+    # five flakes that all declare one. `None` is the CONFIDENT answer and it
+    # routed to it, rather than to the hedged `[]` the function already had.
+    "genAttrs": """{
+  outputs = { self, nixpkgs }: {
+    checks = nixpkgs.lib.genAttrs [ "x86_64-linux" ] (system: {
+      unit = 1;
+      lint = 2;
+    });
+  };
+}
+""",
+    "flake-parts perSystem checks.default": """{
+  outputs = inputs: flake-parts.lib.mkFlake { } {
+    perSystem = { pkgs, ... }: {
+      checks.default = pkgs.runCommand "x" { } "true";
+    };
+  };
+}
+""",
+    "checks.<system>.default": """{
+  outputs = { self }: {
+    checks.x86_64-linux.default = derivation { };
+  };
+}
+""",
+    "checks.<system> = base // {…}": """{
+  outputs = { self }: {
+    checks.x86_64-linux = base // {
+      unit = 1;
+    };
+  };
+}
+""",
+    "checks = eachSystem (…)": """{
+  outputs = { self }: {
+    checks = eachSystem (system: {
+      unit = 1;
+    });
+  };
+}
+""",
+}
+
+# The mirror: text that LOOKS like a `checks` declaration and is not code. Both
+# answered a fabricated tier at `5bad0a0c` — the heredoc `['unit']`, the comment
+# `['unit']` — and the brief fenced `nix build …#checks.x86_64-linux.unit` for a
+# flake declaring nothing of the sort.
+CHECKS_SHAPES_NOT_CODE = {
+    "a devShell heredoc holding `checks = {`": """{
+  outputs = { self }: {
+    devShells.default = pkgs.mkShell {
+      shellHook = ''
+python3 - <<'PY'
+checks = {
+unit = 1;
+}
+PY
+      '';
+    };
+  };
+}
+""",
+    "a `/* … */`-commented checks block": """{
+  outputs = { self }: {
+    /*
+    checks.x86_64-linux = {
+      unit = 1;
+    };
+    */
+    packages.default = 1;
+  };
+}
+""",
+    "a `#`-commented checks block": """{
+  outputs = { self }: {
+#   checks.x86_64-linux = {
+#     unit = 1;
+#   };
+    packages.default = 1;
+  };
+}
+""",
+}
+
+# devrc's real `checks.${system}` block with nix's two-apostrophe ESCAPES in the
+# build script — `''${VAR}` is a literal `${VAR}`, `'''` is a literal `''`.
+# Neither closes the string, and a scanner that toggles on any `''` thinks both
+# do.
+#
+# 🔴 ONE ESCAPE PER FIXTURE, AND THE FIRST DRAFT PUT BOTH IN ONE. Measured: with
+# `echo ''${HOME}` AND `echo '''` in the same build script, the escapes-are-
+# terminators mutant (V43) SURVIVED — two spurious toggles cancel, the string
+# parity is restored by the second one, and the answer comes back correct for
+# entirely the wrong reason. A fixture whose two defects annihilate is the
+# `claude/RULES.md` "fixture landing exactly on its own boundary" shape, and it
+# scored a real hazard as covered. Each constant now carries exactly one.
+_ESCAPE_TAIL = "rc=$?\npython3 -m pytest .\n"
+DEVRC_FLAKE_WITH_DOLLAR_ESCAPE = DEVRC_FLAKE.replace(
+    "python3 -m pytest .\n", "echo ''${HOME}\n" + _ESCAPE_TAIL,
+)
+DEVRC_FLAKE_WITH_QUOTE_ESCAPE = DEVRC_FLAKE.replace(
+    "python3 -m pytest .\n", "echo '''\n" + _ESCAPE_TAIL,
+)
+
+
+def test_the_flake_checks_probe_reads_nix_code_and_not_text_that_looks_like_it():
+    """🔴 REGRESSION. Red at `5bad0a0c` on eight of its ten rows.
+
+    One root cause, three failure modes, and the fix is one pass: strip nix's
+    strings and comments BEFORE any pattern runs, then widen the shapes.
+
+    **The `''` escapes.** The scanner toggled "in string" on any `''`, and nix
+    spells three things with two apostrophes. Measured on devrc's OWN
+    `flake.nix` with a single `echo ''${HOME}` added inside the `pytests` build
+    script: `['pytests', 'nodetests']` became **`['pytests', 'rc', 'rc']`** —
+    two fabricated `nix build` targets named after a shell variable, and
+    `nodetests`, a check the merge really gates on, dropped in silence. A
+    non-empty list is indistinguishable from a complete one, so the `[]` valve
+    never fires.
+
+    **False-PRESENT.** The pattern ran over RAW text, so a `checks = {` inside
+    a devShell heredoc or inside a comment answered a fabricated tier — the
+    same defect the strict-regex fix closed for the `checks = pr.get(...)`
+    spelling and left for every other one.
+
+    **False-ABSENT.** The pattern accepted three shapes, one of them naming
+    devrc's own `forAllSystems` helper by hardcoding it, and answered `None`
+    for `genAttrs`, for flake-parts' `perSystem`, for `checks.<system>.default`
+    and for `checks.<system> = base // {…}`. `None` makes the brief state in
+    BOLD that the repository has no sandbox tier — the tier the same section
+    calls the one the merge gates on. It routed to the strongest wrong answer
+    rather than to the hedged middle it already had.
+    """
+    for name, text in CHECKS_SHAPES_DECLARED.items():
+        got = ad._flake_check_names(text)
+        assert got is not None, (
+            f"\n\nshape {name!r} declares a `checks` output and the probe "
+            "answered None — 'this repository has no sandbox tier', which the "
+            "brief states in bold. The hedged `[]` already exists for a shape "
+            "whose names cannot be read; None is for a flake that declares "
+            "nothing."
+        )
+    # …and where the names ARE readable they are read, so "not None" above is
+    # not satisfied by a probe that answers `[]` to everything.
+    assert ad._flake_check_names(CHECKS_SHAPES_DECLARED["genAttrs"]) == [
+        "unit", "lint"
+    ]
+    assert ad._flake_check_names(
+        CHECKS_SHAPES_DECLARED["checks.<system> = base // {…}"]) == ["unit"]
+    assert ad._flake_check_names(
+        CHECKS_SHAPES_DECLARED["checks = eachSystem (…)"]) == ["unit"]
+
+    for name, text in CHECKS_SHAPES_NOT_CODE.items():
+        assert ad._flake_check_names(text) is None, (
+            f"\n\n{name} was read as a flake `checks` OUTPUT. It is not code, "
+            "and the brief fences a `nix build …#checks…` for whatever names "
+            "come out of it — a command that exits on an attribute error and "
+            "reads exactly like a broken gate."
+        )
+
+    for name, text in (("''${…}", DEVRC_FLAKE_WITH_DOLLAR_ESCAPE),
+                       ("'''", DEVRC_FLAKE_WITH_QUOTE_ESCAPE)):
+        assert ad._flake_check_names(text) == ["pytests", "nodetests"], (
+            f"\n\n`{name}` is an ESCAPE inside a nix indented string, not a "
+            "terminator. Read as a terminator, the rest of the build script "
+            "is scanned as code: the measured answer on devrc's own flake was "
+            "['pytests', 'rc', 'rc'] — invented targets named after a shell "
+            "variable, and `nodetests`, a real merge-gating check, dropped."
+        )
+    # 🔴 THE POSITIVE CONTROL FOR THE STRIPPER ITSELF. A reassuring "no
+    # fabricated name" is indistinguishable from a stripper that blanks the
+    # whole file, which would make every row above pass for the wrong reason.
+    assert ad._flake_check_names(DEVRC_FLAKE) == ["pytests", "nodetests"]
+    stripped = ad._nix_strip(DEVRC_FLAKE)
+    assert len(stripped) == len(DEVRC_FLAKE), (
+        "`_nix_strip` must preserve LENGTH — the match offset it returns is "
+        "used to index the scan, so a stripper that shortens the text scans "
+        "from the wrong place"
+    )
+    assert stripped.count("\n") == DEVRC_FLAKE.count("\n"), (
+        "`_nix_strip` must preserve NEWLINES, or every line-anchored pattern "
+        "over its output sees a different file"
+    )
+    assert "checks.${system} = {" in stripped, (
+        "the stripper blanked a line of CODE; every 'no fabricated name' row "
+        "above would then pass because nothing survives the strip at all"
+    )
+    assert "runHook preBuild" not in stripped, (
+        "the stripper left a `''…''` build script in place, so the rows above "
+        "are asserting nothing about stripping"
+    )
+
+
+def test_a_capped_python_test_walk_is_not_reported_as_no_python_tests(tmp_path):
+    """🔴 REGRESSION. Red at `5bad0a0c`, where the cap failed SILENTLY.
+
+    `_has_python_tests` answered `False` on a cap hit and its docstring called
+    that "the honest not-detected wording". There was no such wording:
+    `_toolchain_pytest_lines` returned `[]`, so the subset command AND the
+    wrong-shell bar vanished with no note, while both sibling probes emit an
+    explicit absence bar. Reachable on a real repository here — measured
+    2026-08-30 on `~/workspace/civit`: 157,319 directories within depth ≤ 4
+    after the skip list, first `test_*.py` at walk visit 1,185, so `py_tests`
+    answered False for a repo that HAS a python suite. `os.walk` order is
+    arbitrary, so which side of the cap a monorepo lands on is not stable.
+
+    Both fixtures are DETERMINISTIC, which is the point: the capped one has no
+    `test_*.py` at all, so no walk order can find one and the only way to leave
+    the loop is the cap; the empty one is small enough that the walk always
+    completes. Two states, two different sentences.
+    """
+    wide = Path(tmp_path / "wide")
+    _write_repo(wide, envrc="use flake\n", gate=DEVRC_GATE, flake=DEVRC_FLAKE,
+                py_test=False)
+    for i in range(ad._PROBE_MAX_DIRS + 100):
+        (wide / f"d{i:04d}").mkdir()
+    # 🔴 FIXTURE REACH, established WITHOUT naming a symbol this fix
+    # introduced: the tree exceeds the cap, so the walk cannot leave the loop
+    # any other way, and it holds no `test_*.py`, so no walk order finds one.
+    assert sum(1 for _ in wide.iterdir()) > ad._PROBE_MAX_DIRS
+    assert not list(wide.rglob("test_*.py"))
+    rc, out, err = run_main(["900"], toplevel=str(wide))
+    assert rc == 0, err
+    tool = toolchain_section(out)
+    assert "THE PYTHON-TEST PROBE DID NOT FINISH" in tool, (
+        f"\n\nthe walk hit its bound and the brief says nothing about it. An "
+        f"auditor who reads no python line concludes there is no python "
+        f"suite:\n{tool}"
+    )
+    assert 'not "there are no python tests"' in tool, (
+        "the capped bar does not say what it is NOT, which is the whole "
+        "distinction the third answer exists to carry"
+    )
+    for line in toolchain_commands(tool):
+        assert "python3 -m pytest" not in line, (
+            f"\n\na pytest command is prescribed for a repository whose test "
+            f"probe never finished:\n    {line}"
+        )
+
+    # 🔴 THE OTHER ANSWER, and it must read differently. A walk that COMPLETED
+    # and found nothing is a fact about the repository; a walk that stopped is
+    # a lookup the auditor still owes.
+    empty = Path(tmp_path / "empty")
+    _write_repo(empty, envrc="use flake\n", gate=DEVRC_GATE, flake=DEVRC_FLAKE,
+                py_test=False)
+    rc, out, err = run_main(["900"], toplevel=str(empty))
+    assert rc == 0, err
+    tool = toolchain_section(out)
+    assert "No `test_*.py` was found" in tool and "the walk COMPLETED" in tool, (
+        f"\n\nthe absent-tests answer is not stated, or is not distinguished "
+        f"from the capped one:\n{tool}"
+    )
+    assert "THE PYTHON-TEST PROBE DID NOT FINISH" not in tool, (
+        "a completed walk is reported as a cap hit, which collapses the two "
+        "answers back into one"
+    )
+    # 🔴 THE THIRD ANSWER, so "no pytest command" above is a measurement and
+    # not a constant, and so the three states are pinned as three.
+    assert ad._python_test_probe(wide) == ad.PY_TESTS_UNKNOWN
+    assert ad._python_test_probe(empty) == ad.PY_TESTS_NONE
+    assert ad._python_test_probe(Path(FAKE_REPO_DIR)) == ad.PY_TESTS_FOUND
+    assert len({ad.PY_TESTS_UNKNOWN, ad.PY_TESTS_NONE, ad.PY_TESTS_FOUND}) == 3, (
+        "two of the three answers are spelled the same, so the branches that "
+        "distinguish them cannot be reached separately"
+    )
+
+
+def test_the_wrong_shell_diagnosis_covers_every_command_not_only_pytest(tmp_path):
+    """🔴 REGRESSION. Red at `5bad0a0c`. A python probe picked the NODE shell.
+
+    `toolchain_shell` asks ONE question — does `flake.nix` mention pytest — and
+    its answer wraps the language-agnostic gate as well as the pytest command.
+    So a repository with a real `scripts/gate.sh`, a flake devShell providing
+    `nodejs`, and no python tests rendered a BARE `bash <wt>/scripts/gate.sh`
+    with NO `nix develop` and, because the wrong-shell bar lived inside
+    `_toolchain_pytest_lines`, no wrong-shell diagnosis ANYWHERE in the
+    section. That gate fails `node: command not found` and reads exactly like a
+    broken gate — the mirror of the defect this section exists to prevent, and
+    the one the brief itself calls "a finding against a PR that is fine".
+    """
+    node = _write_repo(tmp_path / "node-repo", envrc="use flake\n",
+                       gate=DEVRC_GATE, flake=NODE_ONLY_FLAKE, py_test=False)
+    rc, out, err = run_main(["900"], toplevel=node)
+    assert rc == 0, err
+    tool = toolchain_section(out)
+    cmds = toolchain_commands(tool)
+    assert any("gate.sh" in c for c in cmds), (
+        f"the repository's real gate is not prescribed at all, so the claim "
+        f"below is about nothing:\n{cmds}"
+    )
+    assert "WRONG SHELL" in tool, (
+        f"\n\nthis brief prescribes a BARE gate for a repository whose flake "
+        f"provides its toolchain, and carries no wrong-shell diagnosis "
+        f"anywhere. `node: command not found` then reads as a broken "
+        f"gate:\n{tool}"
+    )
+    assert "command not found" in tool, (
+        f"\n\nthe only wrong-shell wording is the pytest one, so an auditor "
+        f"whose gate fails on `node`/`go`/`cargo` has been told nothing:\n{tool}"
+    )
+    # The bar must be honest about what decided the shell. This repository's
+    # flake names no pytest, which is the ONLY shell probe made.
+    assert "the only shell probe made here" in tool, (
+        f"\n\nthe brief does not say WHICH probe decided there is no dev "
+        f"shell, so the auditor cannot check it:\n{tool}"
+    )
+    # 🔴 AND THE MIRROR, so "the note is present" is not a constant: a repo
+    # whose flake DOES name pytest gets the wrapper AND a note saying that a
+    # python fact decided the shell for every command above it.
+    tool = toolchain_section(brief_for_scenario("delta"))
+    assert "in EVERY language" in tool and "mentions `pytest` SOMEWHERE" in tool, (
+        f"\n\nthe wrapped branch does not say that ONE python probe decided "
+        f"the shell for commands that may run anything:\n{tool}"
+    )
+
+
+def test_an_unreadable_flake_is_not_reported_as_an_absent_one(tmp_path):
+    """🔴 REGRESSION. Red at `5bad0a0c`. A failed READ became a fact about the repo.
+
+    `_read_probe` answers `None` for an absent file and for one it could not
+    open alike, so a `flake.nix` the probe cannot read rendered ``⚠ `<root>`
+    has no `flake.nix` `` — the same class as the walk cap two guards up, and
+    the same remedy: say only what the probe established. Fixed in the
+    direction that costs no new state, because the wording was the whole
+    over-claim.
+    """
+    root = Path(_write_repo(tmp_path / "locked", envrc="use flake\n",
+                            gate=DEVRC_GATE, flake=DEVRC_FLAKE))
+    flake = root / "flake.nix"
+    flake.chmod(0)
+    try:
+        # 🔴 FIXTURE REACH, established rather than assumed: mode 000 is not
+        # unreadable for root, and a test that silently ran as one would assert
+        # the ABSENT branch's wording about a file it read fine.
+        if flake.is_file() and ad._read_probe(root, "flake.nix") is not None:
+            pytest.skip("this user can read a mode-000 file (running as root?)")
+        assert flake.is_file(), "the fixture is not the state under test"
+        tool = toolchain_section(run_main(["900"], toplevel=str(root))[1])
+    finally:
+        flake.chmod(0o644)
+    assert "no READABLE `flake.nix`" in tool, (
+        f"\n\nthe probe could not OPEN this repository's `flake.nix`, and the "
+        f"brief reports that the repository HAS none — a claim about the repo "
+        f"derived from a failed read:\n{tool}"
+    )
+
+
+def test_the_toolchain_head_claim_is_true_of_the_rendered_brief():
+    """🔴 REGRESSION. Red at `5bad0a0c`: the constant made a FALSE count.
+
+    `TOOLCHAIN_HEAD` said the assembly checkout "appears below at most ONCE, as
+    the argument to `nix develop`". #1104's wording was "appears ONLY as the
+    argument to `nix develop`" and was true of what that revision rendered;
+    this branch strengthened it into a COUNT while adding two prose mentions of
+    the same path. Measured at `5bad0a0c` for devrc: FOUR occurrences, two of
+    them not `nix develop` arguments.
+
+    Nothing pinned it, and the reason is worth stating: the guard over this
+    block asks whether the rendered reason IS this constant, never whether the
+    constant is TRUE of what follows it. A claim can be pinned byte-for-byte
+    and false in every brief that carries it.
+    """
+    root = FAKE_REPO_DIR
+    tool = toolchain_section(brief_for_scenario("delta"))
+    assert "at most ONCE" not in tool, (
+        "the false COUNT is back. The path appears in prose too; a count over "
+        "the whole section cannot be satisfied while it does"
+    )
+    fenced = toolchain_commands(tool)
+    naming = [c for c in fenced if root in c]
+    assert naming, (
+        "no fenced command names the assembly checkout at all, so the claim "
+        "under test is vacuous here. Check FAKE_REPO_DIR is still probed."
+    )
+    for line in naming:
+        assert line.startswith(f"nix develop {root} -c "), (
+            f"\n\na RUNNABLE command names the assembly checkout somewhere "
+            f"other than as the `nix develop` argument:\n    {line}\n"
+            "  That is the tree under test pointing at somebody else's "
+            "checkout, which is what TOOLCHAIN_HEAD promises never happens."
+        )
+        assert line.replace(f"nix develop {root} -c ", "", 1).count(root) == 0, (
+            f"\n\nthe assembly checkout appears a SECOND time in one command, "
+            f"past the `nix develop` argument:\n    {line}"
+        )
+    # 🔴 THE OTHER HALF OF THE REWORDED CLAIM, asserted so the reword is not a
+    # retreat: the prose really does name the path, and says what was read.
+    prose = [ln for ln in tool.splitlines()
+             if root in ln and ln not in fenced]
+    assert len(prose) >= 2, (
+        f"\n\nthe head now says the prose names the path 'to say what was read "
+        f"out of it', and {len(prose)} prose line(s) do. If that drops to "
+        "zero the sentence should go back to #1104's 'ONLY as the argument to "
+        "`nix develop`', which would then be true again."
+    )
+
+
+def test_no_toolchain_note_claims_a_probe_the_brief_itself_denies():
+    """🔴 REGRESSION. Red at `5bad0a0c`, in the cross-repo and unknown states.
+
+    `TOOLCHAIN_TAIL`'s own comment said "Both notes are true of every
+    repository and every checkout state". One was not: "everything above was
+    PROBED out of this repository rather than assumed" is a claim about a
+    STATE, and the not-probed branch renders it three lines under its own
+    `🔴 NOTHING WAS PROBED HERE, SO NOTHING IS PRESCRIBED`. One document
+    contradicting itself — and `test_the_toolchain_reason_is_true_in_every_
+    scenario` CERTIFIED the contradiction, because it requires the tail
+    verbatim in every scenario.
+    """
+    denied, probed = 0, 0
+    for scenario in SCENARIOS:
+        tool = toolchain_section(brief_for_scenario(scenario))
+        if "NOTHING WAS PROBED HERE" in tool:
+            denied += 1
+            assert "everything above was PROBED out of this repository" not in tool, (
+                f"\n\nscenario {scenario!r}: the section says NOTHING WAS "
+                f"PROBED HERE and then says everything above was probed out of "
+                f"this repository. A reader believes neither, and the "
+                f"instruction each carries goes with it:\n{tool}"
+            )
+            # …and the instruction the moved clause carried must survive here.
+            assert "NAME the one you used, by path" in tool, (
+                "the not-probed branch lost the 'name the runner by path' "
+                "instruction along with the false clause"
+            )
+        else:
+            probed += 1
+            assert "everything above was PROBED out of this repository" in tool, (
+                f"\n\nscenario {scenario!r} DID probe, and the clause that "
+                f"tells the auditor to name the runner by path is gone:\n{tool}"
+            )
+    assert denied and probed, (
+        f"both states must be present or this guard grades one branch: "
+        f"{probed} probed, {denied} not"
+    )
+
+
+def test_the_toolchain_probes_are_reachable_in_both_directions(tmp_path):
+    """🔴 INVARIANT GUARD, and its evidence is that it CLOSES three mutants.
+
+    `mutants-audit-dispatch.py` states the rule — "Each probe is broken in BOTH
+    directions where both are reachable" — and it was applied to `gate_sh`, the
+    checks regex, `flake_pytest` and `probe_root`, and to none of these three.
+    Measured at `5bad0a0c`, each SURVIVED a fully green 115-test suite while
+    shipping a fabricated command:
+
+        `if tc.ci_suite:` -> `if True:`   `bash <wt>/scripts/tests/
+                                          run-ci-suite.sh` for devrc, which has
+                                          no such file
+        `if not tc.py_tests: return []`   `python3 -m pytest` for a repo with
+          -> `if False:`                  no python tests
+        `gate_tier=bool(...)` -> `True`   `--tier both` on any repo's gate.sh —
+                                          the exact fabrication that field
+                                          exists to prevent
+
+    The root cause is FIXTURE REACH, not a missing assertion: `_write_repo`'s
+    `py_test=` was never passed `False` by any call site, no fixture had a
+    `gate.sh` lacking `--tier both`, and no test asked whether
+    `run-ci-suite.sh` was ABSENT from the devrc-shaped brief. A branch no
+    fixture enters is a branch no assertion can grade.
+    """
+    # 1. A repo with a gate that does NOT take `--tier`, and no run-ci-suite.
+    plain = _write_repo(tmp_path / "plain", envrc="use flake\n",
+                        gate=PLAIN_GATE, flake=DEVRC_FLAKE)
+    tool = toolchain_section(run_main(["900"], toplevel=plain)[1])
+    cmds = toolchain_commands(tool)
+    assert any(c.endswith("/scripts/gate.sh") for c in cmds), (
+        f"\n\nthis repo HAS a `scripts/gate.sh` and the brief prescribes it "
+        f"with arguments it never showed it takes, or not at all:\n{cmds}"
+    )
+    for line in cmds:
+        assert "--tier" not in line, (
+            f"\n\n`--tier both` is prescribed for a `gate.sh` whose text does "
+            f"not contain it. A flag is an artifact too:\n    {line}"
+        )
+        assert "run-ci-suite.sh" not in line, (
+            f"\n\n`run-ci-suite.sh` is prescribed for a repository that has "
+            f"none:\n    {line}"
+        )
+
+    # 2. The devrc-shaped fixture the rest of the module drives: no
+    # `run-ci-suite.sh` there either, and nothing asserted it.
+    tool = toolchain_section(brief_for_scenario("delta"))
+    for line in toolchain_commands(tool):
+        assert "run-ci-suite.sh" not in line, (
+            f"\n\nthe devrc-shaped target has no `scripts/tests/"
+            f"run-ci-suite.sh`, and the brief hands one over:\n    {line}"
+        )
+
+    # 3. A repo with NO python tests: no pytest command, and it says why.
+    nopy = _write_repo(tmp_path / "nopy", envrc="use flake\n",
+                       gate=DEVRC_GATE, flake=DEVRC_FLAKE, py_test=False)
+    tool = toolchain_section(run_main(["900"], toplevel=nopy)[1])
+    for line in toolchain_commands(tool):
+        assert "python3 -m pytest" not in line, (
+            f"\n\na pytest command is prescribed for a repository with no "
+            f"`test_*.py` anywhere:\n    {line}"
+        )
+
+    # 4. `_fmt_uses`' two fallbacks, neither of which any fixture reached.
+    noenv = _write_repo(tmp_path / "noenv", envrc=None, gate=DEVRC_GATE,
+                        flake=DEVRC_FLAKE)
+    tool = toolchain_section(run_main(["900"], toplevel=noenv)[1])
+    assert "absent from the tree probed" in tool, (
+        f"\n\nthe repo has no `.envrc` and the brief does not say so:\n{tool}"
+    )
+    blank = _write_repo(tmp_path / "blank", envrc="# nothing to declare\n",
+                        gate=DEVRC_GATE, flake=DEVRC_FLAKE)
+    tool = toolchain_section(run_main(["900"], toplevel=blank)[1])
+    assert "present but declares no `use` line" in tool, (
+        f"\n\nthe repo's `.envrc` declares no `use` line and the brief does "
+        f"not say so:\n{tool}"
     )
 
 
@@ -6656,6 +7362,28 @@ RED_AT_BASE_R14: frozenset[str] = frozenset({
     "test_the_toolchain_prescribes_nothing_when_it_cannot_probe",
 })
 
+# 🔴 ROUND 15. Base `5bad0a0c` — THIS BRANCH'S OWN HEAD when round 2's audit
+# read it, not `origin/main`. That is the honest base for a fix round: every
+# finding below is a defect this branch SHIPPED, so the tree that carries them
+# is the tree to watch these five go red in.
+#
+# All five fail on an ASSERTION, not on an import or a missing symbol — checked
+# deliberately, because `claude/RULES.md` says an arity/`AttributeError` red is
+# not regression coverage. Two of them touch symbols this fix introduces
+# (`_nix_strip`, `_python_test_probe`, `PY_TESTS_*`) and both were ORDERED so
+# the wrong-answer assertions run FIRST: the checks-shape test fails on
+# `genAttrs` answering `None`, and the capped-walk test fails on the brief
+# saying nothing about a walk that stopped. The symbol-level rows sit after
+# them, where at the base they are unreachable.
+RED_AT_BASE_R15: frozenset[str] = frozenset({
+    "test_the_flake_checks_probe_reads_nix_code_and_not_text_that_looks_like_it",
+    "test_a_capped_python_test_walk_is_not_reported_as_no_python_tests",
+    "test_the_wrong_shell_diagnosis_covers_every_command_not_only_pytest",
+    "test_the_toolchain_head_claim_is_true_of_the_rendered_brief",
+    "test_no_toolchain_note_claims_a_probe_the_brief_itself_denies",
+    "test_an_unreadable_flake_is_not_reported_as_an_absent_one",
+})
+
 RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "abc41024": RED_AT_BASE_R2,
     "d9eb36a8": RED_AT_BASE_R3,
@@ -6666,6 +7394,7 @@ RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "706a6b38": RED_AT_BASE_R9,
     "6349a8b9": RED_AT_BASE_R13,
     "9e23c379": RED_AT_BASE_R14,
+    "5bad0a0c": RED_AT_BASE_R15,
 }
 RED_AT_BASE: frozenset[str] = frozenset().union(*RED_AT_BASE_REFS.values())
 
@@ -6680,6 +7409,14 @@ INVARIANT_GUARDS_AND_LEDGERS = frozenset({
     # (which an indentation-only scan reads as one name, because a build
     # script's lines start at column 0).
     "test_the_flake_checks_probe_reads_an_output_and_not_the_word",
+    # 🔴 GREEN at `5bad0a0c`, MEASURED — and that is exactly the finding. The
+    # three probes it drives BEHAVE correctly there; what was missing was any
+    # fixture that entered their branches, so `if tc.ci_suite: -> if True:`,
+    # `if not tc.py_tests: return [] -> if False:` and `gate_tier=… -> True`
+    # each SURVIVED a fully green suite while shipping a fabricated command.
+    # Its evidence is therefore V42-V46, not a base ref: a fixture-reach fix
+    # cannot be watched red anywhere, which is precisely why it goes unnoticed.
+    "test_the_toolchain_probes_are_reachable_in_both_directions",
     "test_the_invariant_clause_ledger_is_pinned_two_way",
     # 🔴 GREEN at `abc41024`, MEASURED — and it is the guard for finding 5, so
     # the temptation to file it as regression coverage is real and is refused
@@ -7232,6 +7969,73 @@ FIX_MATRIX = (
      "one, because a build script's lines start at column 0",
      "test_the_flake_checks_probe_reads_an_output_and_not_the_word",
      "GUARD", "V38 V41"),
+    # --------------------------------------------------------------------- #
+    # Round 15. Its base is `5bad0a0c` — THIS BRANCH's own head, because every
+    # finding here is a defect this branch shipped.
+    # --------------------------------------------------------------------- #
+    ("r15/F1 round 14 lifted the cross-scenario pin off the COMMANDS bar and "
+     "asserted in its own docstring that the property was 'not weakened — it "
+     "became STRUCTURAL'. Measured false: a sentence keyed on the AUDITOR's "
+     "worktree kind, contradicting WHERE TO WORK, survived at 115 passed three "
+     "lines below where the same sentence was killed at `9e23c379`. The pin is "
+     "restored WITHIN each declared target, which is the axis the probe reads",
+     "test_the_toolchain_reason_is_true_in_every_scenario",
+     "RED@dd601793", "V52"),
+    ("r15/F2 `TOOLCHAIN_HEAD` said the assembly checkout appears 'at most "
+     "ONCE, as the argument to `nix develop`'. FOUR occurrences in the devrc "
+     "rendering, two of them prose. #1104's 'ONLY as the argument' was true; "
+     "this branch strengthened it into a count and broke it, and the guard "
+     "over that block asks whether the text IS the constant, never whether the "
+     "constant is TRUE",
+     "test_the_toolchain_head_claim_is_true_of_the_rendered_brief",
+     "RED@5bad0a0c", "-"),
+    ("r15/F3 `TOOLCHAIN_TAIL` froze a STATE-dependent claim ('everything above "
+     "was PROBED out of this repository') into a state-INDEPENDENT constant, "
+     "so the cross-repo brief contradicted itself three lines apart — and the "
+     "scenario guard CERTIFIED it by requiring the tail verbatim everywhere",
+     "test_no_toolchain_note_claims_a_probe_the_brief_itself_denies",
+     "RED@5bad0a0c", "-"),
+    ("r15/F4 the battery states 'each probe is broken in BOTH directions where "
+     "both are reachable' and three probes had no mutant at all: `ci_suite`, "
+     "`py_tests` and `gate_tier`. All three inversions SURVIVED a green "
+     "115-test suite while shipping a fabricated command — `--tier both` on "
+     "any repo's gate.sh being the exact fabrication that field exists to "
+     "prevent. The cause was FIXTURE REACH: `_write_repo(py_test=False)` was "
+     "called by nothing, no fixture had a gate without `--tier`, and no test "
+     "asked whether `run-ci-suite.sh` was ABSENT",
+     "test_the_toolchain_probes_are_reachable_in_both_directions",
+     "GUARD", "V45 V47 V49"),
+    ("r15/F5+F6+F7 the checks parser, one root cause and three failure modes: "
+     "`''${…}`/`'''` read as string TERMINATORS turned devrc's own flake into "
+     "['pytests', 'rc', 'rc'] — two invented `nix build` targets and a real "
+     "merge-gating check dropped; the pattern ran over RAW text, so a heredoc "
+     "or a comment holding `checks = {` fabricated a tier; and it accepted "
+     "three shapes only, answering the CONFIDENT `None` ('no sandbox tier', in "
+     "bold) for genAttrs, flake-parts `perSystem`, `checks.<system>.default` "
+     "and `checks.<system> = base // {…}`",
+     "test_the_flake_checks_probe_reads_nix_code_and_not_text_that_looks_like_it",
+     "RED@5bad0a0c", "V38 V41 V42 V43"),
+    ("r15/F8 the 400-directory walk cap failed SILENTLY, alone among the "
+     "probes here: it answered False and the whole python bar vanished with no "
+     "note, while both siblings emit an explicit absence bar. Reachable on a "
+     "real repo — `~/workspace/civit`, 157,319 dirs at depth ≤ 4, first "
+     "`test_*.py` at visit 1,185 — and `os.walk` order decides which side of "
+     "the cap a monorepo lands on",
+     "test_a_capped_python_test_walk_is_not_reported_as_no_python_tests",
+     "RED@5bad0a0c", "V44 V49"),
+    ("r15/nit a `flake.nix` the probe could not OPEN rendered `has no "
+     "flake.nix` — a fact about the repository derived from a failed read, and "
+     "the same class as the walk cap. `_read_probe` answers None for absent "
+     "and for unreadable alike; the wording was the whole over-claim",
+     "test_an_unreadable_flake_is_not_reported_as_an_absent_one",
+     "RED@5bad0a0c", "-"),
+    ("r15/F9 one PYTHON-specific probe (`'pytest' in flake.nix`) decided the "
+     "shell for the language-agnostic gate, and the wrong-shell bar lived "
+     "inside the pytest branch — so a repo with a real gate, a nodejs devShell "
+     "and no python tests got a BARE gate and no diagnosis anywhere. `node: "
+     "command not found` then reads exactly like a broken gate",
+     "test_the_wrong_shell_diagnosis_covers_every_command_not_only_pytest",
+     "RED@5bad0a0c", "V50 V51"),
 )
 
 # A COLLAPSE floor, not a growth floor: a matrix emptied by a bad refactor
@@ -7253,7 +8057,9 @@ FIX_MATRIX = (
 # way, by importing the module and printing `len(FIX_MATRIX)`. Round 10 added
 # seven: m = 77, and 77 - max(1, 77 // 20) = 74. Counted the same way again —
 # `len(FIX_MATRIX)` printed from an import, not seven added to the last sentence.
-MIN_FIX_MATRIX_ROWS = 74
+# Round 15: m = 93 (printed from an import, NOT derived by adding this round's
+# rows to 77 — rounds 11-14 also added some), and 93 - max(1, 93 // 20) = 89.
+MIN_FIX_MATRIX_ROWS = 89
 
 # 🔴 THE MUTANTS COLUMN IS AN EVIDENCE CLAIM, AND IT WAS UNGRADED.
 # `fix_matrix_problems` took `_mutants` and threw it away, so rewriting a

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -805,7 +805,134 @@ OTHER_REPO_PR = dict(
     headRepositoryOwner={"login": "someone-else"},
 )
 
-FAKE_REPO_DIR = "/fake/checkout/devrc"
+# 🔴 A REAL DIRECTORY ON DISK, and it must stay one. `render_toolchain` PROBES
+# the checkout the PR lives in — `scripts/gate.sh`, `flake.nix`'s `checks`
+# outputs, `.envrc` — and prescribes only what it finds. A `/fake/checkout/…`
+# string (what this was) makes every probe answer "absent", so the whole suite
+# would exercise the not-detected branch and NOTHING would cover the devrc
+# shape the pre-existing guards assert. Same class as the `rev_list` constant
+# in `make_runner`: a fixture that cannot enter the branch under test.
+#
+# Written once at import, beside `CLAIMS_FILE` and for the same reason — the
+# `SCENARIO_RUNS` entries are plain callables and cannot take a `tmp_path`.
+# `use opencode`, a `--tier both` gate and `checks.${system}` with TWO names
+# are devrc's real shapes, measured at `/home/zach/workspace/devrc`.
+_FAKE_REPO_TMP = tempfile.TemporaryDirectory(prefix="audit-dispatch-repo-")
+FAKE_REPO_DIR = str(Path(_FAKE_REPO_TMP.name) / "devrc")
+
+
+def _write_repo(root, *, envrc, gate=None, ci_suite=False, flake=None,
+                py_test=True):
+    """Materialise a repo-shaped tree for `detect_repo_toolchain` to probe."""
+    root = Path(root)
+    (root / "scripts" / "tests").mkdir(parents=True, exist_ok=True)
+    if envrc is not None:
+        (root / ".envrc").write_text(envrc, encoding="utf-8")
+    if gate is not None:
+        (root / "scripts" / "gate.sh").write_text(gate, encoding="utf-8")
+    if ci_suite:
+        (root / "scripts" / "tests" / "run-ci-suite.sh").write_text(
+            "#!/usr/bin/env bash\npython3 -m pytest \"$@\"\n", encoding="utf-8")
+    if flake is not None:
+        (root / "flake.nix").write_text(flake, encoding="utf-8")
+    if py_test:
+        (root / "scripts" / "tests" / "test_x.py").write_text(
+            "def test_x():\n    assert True\n", encoding="utf-8")
+    return str(root)
+
+
+# devrc's own flake shape: `checks.${system}` holding exactly `pytests` and
+# `nodetests`, and a dev shell that names pytest. The `''…''` block is not
+# decoration — it is what an indentation-only name scan trips over, and the
+# reason `_flake_check_names` tracks nix strings.
+DEVRC_FLAKE = """\
+{
+  outputs = { self, nixpkgs }:
+    let
+      forAllSystems = f: f;
+    in forAllSystems (system: {
+      devShells.default = pkgs.mkShell {
+        buildInputs = [ pkgs.python3Packages.pytest ];
+        shellHook = ''
+echo "devrc: gate toolchain ready"
+if [ -n "$X" ]; then
+  echo hi
+fi
+        '';
+      };
+      checks.${system} = {
+        pytests =
+        pkgs.runCommandLocal "devrc-pytests"
+          {
+            nativeBuildInputs = [ pkgs.git pkgs.ripgrep ];
+          }
+          ''
+runHook preBuild
+for f in *.py; do echo "{$f}"; done
+grep -c '}' out.txt || true
+python3 -m pytest .
+          '';
+        nodetests =
+        pkgs.runCommandLocal "devrc-nodetests"
+          {
+            nativeBuildInputs = [ pkgs.nodejs ];
+          }
+          ''
+node --test
+          '';
+      };
+    });
+}
+"""
+# 🔴 THE FIXTURE MUST REACH THE BRANCHES IT GRADES, and the first draft did
+# not. `pytests = pkgs.runCommandLocal "…" { } ''…''` kept brace depth at 1 for
+# the whole block, so a mutant that mishandles NESTING could not be observed —
+# a fixture landing exactly on its own boundary. The real file spans the
+# derivation attrset over several lines (depth 2), and its build scripts start
+# at column 0, which is what an indentation-bounded scan trips over. The
+# unbalanced `grep -c '}'` above is the third real shape: a brace inside a
+# `''…''` string that skews depth for anyone not tracking nix strings.
+
+# `homelab-infra`'s shape, measured 2026-08-29: NO `scripts/gate.sh`, NO
+# `checks` output, `.envrc` is `use flake` + `use opencode`, and its real
+# runner is `scripts/tests/run-ci-suite.sh`. The `checks = pr.get(...)` line is
+# VERBATIM from a python heredoc inside that repo's real devShell — it is the
+# string a loose `^\s*checks\b.*=` probe matched, answering "this flake
+# declares checks" for a flake that declares none.
+HOMELAB_FLAKE = """\
+{
+  description = "Homelab infrastructure development shell";
+  outputs = { self, nixpkgs }:
+    {
+      devShells = forAllSystems (system: {
+        default = pkgs.mkShell {
+          buildInputs = with pkgs; [ kubectl fluxcd sops age gh ];
+          shellHook = ''
+python3 - <<'PY'
+def ci_status(checks):
+    if not checks:
+        return "none"
+checks = pr.get("statusCheckRollup", [])
+PY
+          '';
+        };
+      });
+    };
+}
+"""
+
+DEVRC_GATE = """\
+#!/usr/bin/env bash
+#   scripts/gate.sh [--tier pytest|node|both] [--set hermetic|all]
+#     --tier both      (default) run both runners; the gate is red if either is.
+case "$1" in
+  --tier) TIER="${2:-both}" ;;
+esac
+"""
+
+_write_repo(FAKE_REPO_DIR, envrc="use opencode\n", gate=DEVRC_GATE,
+            flake=DEVRC_FLAKE)
+
 FAKE_ORIGIN = "git@github.com:example-org/devrc.git"
 
 # 🔴 The two paths `gather_worktree_kind` reads, in the shapes REAL git prints
@@ -2425,7 +2552,7 @@ def test_the_toolchain_section_names_the_tier_the_merge_gates_on():
     """
     rc, out, err = run_main(["900"])
     assert rc == 0, err
-    assert "nix develop /fake/checkout/devrc -c python3 -m pytest" in out
+    assert f"nix develop {FAKE_REPO_DIR} -c python3 -m pytest" in out
     assert "-p no:cacheprovider" in out
     assert "No module named pytest" in out and "WRONG SHELL" in out, (
         "the wrong-shell diagnosis is missing — it was present in 9 of the "
@@ -4982,6 +5109,26 @@ def toolchain_section(brief):
     return brief[start:brief.index(EXPECTED_INVARIANTS_HEADING, start)]
 
 
+def toolchain_commands(section):
+    """The non-blank lines inside TOOLCHAIN's fences — what it PRESCRIBES.
+
+    🔴 The distinction every guard over this section needs, and the one a
+    substring scan cannot make. The prose must be free to NAME a command in
+    order to say it is ABSENT — "`nix build …#checks…` would fail with an
+    attribute error", "look for `scripts/gate.sh`" — so a scan of the whole
+    section forbids the very sentences that close the fabricated-command
+    finding. Only a fenced line is offered as runnable.
+    """
+    out, inside = [], False
+    for line in section.splitlines():
+        if line.startswith("```"):
+            inside = not inside
+            continue
+        if inside and line.strip():
+            out.append(line)
+    return out
+
+
 def test_the_toolchain_reason_is_true_in_every_scenario():
     """🔴 REGRESSION. Red at `dd601793` in the PRIVATE state.
 
@@ -5005,12 +5152,38 @@ def test_the_toolchain_reason_is_true_in_every_scenario():
     and no mutant row named it. An equality over two same-repo scenarios does
     not pin state-independence — it pins independence of the one axis it
     happened to vary. It now drives every scenario `brief_for_scenario` knows,
-    including the cross-repo pair, and requires the rendered section to be
+    including the cross-repo pair, and requires the rendered REASON to be
     BYTE-IDENTICAL across all of them: that is the claim the section's own
     docstring makes ("this section knows nothing about where the auditor
     stands"), stated as wide as the code it describes.
+
+    🔴 ROUND 14 NARROWED THE SLICE FROM THE SECTION TO THE REASON, AND WIDENED
+    THE PIN FROM AN EQUALITY TO AN IDENTITY. Deliberate; here is all of it.
+
+    The COMMANDS under the reason are now derived from the repository the PR
+    lives in (`detect_repo_toolchain`), because hardcoding devrc's layout
+    prescribed three non-existent commands and one false `.envrc` claim against
+    `homelab-infra`. Target-repo content and audit scenario are DIFFERENT AXES:
+    the `cross-repo` scenarios hold no checkout of the PR's repository to read,
+    so their commands bar honestly says nothing was probed, while a same-repo
+    one lists real commands. A whole-section equality cannot express that, and
+    the only two ways to keep it are to blind the generator (prescribe devrc's
+    layout at every target — the defect) or to probe the WRONG repository
+    cross-repo (the defect, with a new source). It genuinely could not coexist,
+    so the split is stated rather than smuggled.
+
+    🔴 THE PROPERTY IT PROTECTED IS NOT WEAKENED — it became STRUCTURAL. The
+    reason lives in `TOOLCHAIN_HEAD`/`TOOLCHAIN_TAIL`, module-level CONSTANTS
+    taking no argument, so a state-dependent rationale is no longer merely
+    unasserted, it is unwritable without deleting the constant. This guard
+    still drives every scenario, still runs the three phrase assertions over
+    the FULL section, and now checks BOTH that the reason bars are byte-equal
+    across scenarios AND that each IS the constant — which the old equality did
+    not do, and which is what makes "byte-identical to WHAT" answerable. It
+    also fails if every scenario renders the SAME commands bar, the shape this
+    fix would take if the detection were inert.
     """
-    sections = {}
+    sections, reasons = {}, {}
     for scenario in SCENARIOS:
         tool = toolchain_section(brief_for_scenario(scenario))
         sections[scenario] = tool
@@ -5029,23 +5202,252 @@ def test_the_toolchain_reason_is_true_in_every_scenario():
             "the reason no longer names the property that is true in every "
             "state — that copy is not the auditor's"
         )
-    # 🔴 EQUALITY ACROSS EVERY SCENARIO, not across a chosen pair. Compared
-    # against ONE reference so the failure names which scenario diverged.
+        # The reason is everything before the COMMANDS heading. Sliced on that
+        # heading, which is itself a constant, so no scenario can move the
+        # boundary out from under this guard.
+        assert ad.TOOLCHAIN_COMMANDS_HEADING in tool, (
+            f"scenario {scenario!r}: the commands heading is gone, so this "
+            "guard can no longer tell the reason from the prescription and "
+            "would pass over a rationale that had become state-dependent"
+        )
+        reasons[scenario] = tool.split(ad.TOOLCHAIN_COMMANDS_HEADING)[0]
+
     ref_name = SCENARIOS[0]
-    for scenario, tool in sections.items():
-        assert tool == sections[ref_name], (
-            f"\n\nTOOLCHAIN differs between {ref_name!r} and {scenario!r}. It "
-            "is rendered from `facts.cwd_repo_dir` alone and knows nothing "
-            "about where the auditor stands or which repo the PR is in, so a "
-            "scenario-dependent sentence here is a claim it cannot support in "
-            "the branch it is not being read in.\n"
-            f"--- {ref_name} ---\n{sections[ref_name]}\n"
-            f"--- {scenario} ---\n{tool}"
+    for scenario, reason in reasons.items():
+        assert reason == reasons[ref_name], (
+            f"\n\nTOOLCHAIN's REASON differs between {ref_name!r} and "
+            f"{scenario!r}. It knows nothing about where the auditor stands or "
+            "which repo the PR is in, so a scenario-dependent sentence here is "
+            "a claim it cannot support in the branch it is not being read "
+            f"in.\n--- {ref_name} ---\n{reasons[ref_name]}\n"
+            f"--- {scenario} ---\n{reason}"
+        )
+        # 🔴 IDENTITY, not merely equality. Equality across scenarios is silent
+        # about WHAT they all equal: re-deriving the reason from `facts` would
+        # satisfy it under this module's fixtures, where `cwd_repo_dir` holds
+        # one value — which is how round 6 was walked one level up.
+        assert reason.strip() == ad.TOOLCHAIN_HEAD.strip(), (
+            f"\n\nscenario {scenario!r}: the reason bar is no longer "
+            "`TOOLCHAIN_HEAD` rendered verbatim. That constant takes no "
+            "argument — that is what makes state-independence structural — so "
+            "re-deriving or reformatting it here reopens round 5's finding.\n"
+            f"--- rendered ---\n{reason}\n--- constant ---\n{ad.TOOLCHAIN_HEAD}"
+        )
+        assert ad.TOOLCHAIN_TAIL in sections[scenario], (
+            f"scenario {scenario!r}: the state-independent TAIL — name the "
+            "tier and the base sha, and the `git --version` note — is not "
+            "rendered verbatim"
         )
     assert len(sections) == len(SCENARIOS) >= 5, (
         f"only {len(sections)} scenario(s) were driven; an equality over a "
         "handful of them pins independence of the axes they happen to vary "
         "and nothing else — which is exactly how round 6 walked this guard"
+    )
+    # 🔴 THE PIN THAT KEEPS THE SPLIT HONEST, AND IT ASKS ABOUT PRESCRIPTIONS
+    # RATHER THAN TEXT. The first spelling compared the commands bars for
+    # inequality — and MEASURED (mutant V40) it did not fire when the WRONG
+    # repository was probed cross-repo, because that bar names `facts.repo`,
+    # which differs between the scenarios anyway. A text difference is not the
+    # property; the property is that a scenario holding no checkout of the PR's
+    # repository offers NOTHING to run, and one holding a checkout offers
+    # something. Both states must be present, or this whole module is grading
+    # one branch.
+    prescribing = {s: toolchain_commands(t) for s, t in sections.items()}
+    assert any(c for c in prescribing.values()), (
+        "no scenario prescribed a single runnable command — the probe answers "
+        "'absent' everywhere, so every assertion about what it emits is "
+        "vacuous. Check `FAKE_REPO_DIR` is still a real directory on disk."
+    )
+    silent = [s for s, c in prescribing.items() if not c]
+    assert silent, (
+        "\n\nEVERY scenario prescribed commands, including the cross-repo ones "
+        "that hold no checkout of the repository the PR lives in. Either the "
+        "probe is reading the WRONG repository there — a confident, "
+        "fully-formed, entirely irrelevant command list, which is the original "
+        "defect with a new source — or the detection is inert and one "
+        "repository's layout is being prescribed at every target.\n"
+        f"  scenarios: {sorted(prescribing)}"
+    )
+
+
+def test_the_toolchain_prescribes_only_commands_it_probed(tmp_path):
+    """🔴 REGRESSION. Red at `bd1572f3`, on a real target that has none of them.
+
+    Every TOOLCHAIN command interpolated `facts.cwd_repo_dir` into devrc's OWN
+    layout, so a brief for a PR in any other repository prescribed scripts that
+    do not exist there. Measured 2026-08-29 against `ZacxDev/homelab-infra`
+    (PR #530) from a real checkout of it:
+
+        scripts/gate.sh                 ABSENT
+        flake `checks` outputs          NONE, at HEAD and in the working tree
+        .envrc                          `use flake` + `use opencode`
+        its real runner                 scripts/tests/run-ci-suite.sh
+        nix develop <root> -c python3 -m pytest
+                                        ModuleNotFoundError: No module named
+                                        'pytest'
+
+    Four prescriptions, none runnable — and the last is the worst, because the
+    bar under it told the auditor that `No module named pytest` means the WRONG
+    SHELL and not a broken suite, so the brief manufactured a failure and told
+    the reader to disregard the one true signal it produced. An auditor
+    following it hits four missing things and can report the gate broken
+    against a PR that is fine.
+
+    The fixture is that repo's SHAPE, not that repo — its `.envrc`, its runner,
+    and a `flake.nix` whose devShell embeds a python heredoc containing
+    `checks = pr.get("statusCheckRollup", [])`. That line is verbatim from the
+    real file and is the reason the probe matches a flake OUTPUT rather than
+    the word: the first regex here answered "this flake declares checks" for a
+    flake that declares none, which would have prescribed the `nix build` line
+    anyway and left the fallback unreachable.
+    """
+    root = _write_repo(tmp_path / "homelab-talos",
+                       envrc="use flake\nuse opencode\n",
+                       ci_suite=True, flake=HOMELAB_FLAKE)
+    rc, out, err = run_main(["900"], toplevel=root)
+    assert rc == 0, err
+    tool = toolchain_section(out)
+    # 🔴 THE COMMANDS, NOT THE PROSE AROUND THEM — the same distinction
+    # `test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout`
+    # draws, and for the same reason. The prose must be free to NAME an absent
+    # command in order to say it is absent ("`nix build …#checks…` would fail
+    # with an attribute error"); a scan that cannot tell a prescription from
+    # its rationale goes red on the sentence that closes the finding.
+    cmds = toolchain_commands(tool)
+    assert cmds, "no command block at all in a section that probed a real repo"
+
+    for line in cmds:
+        assert "gate.sh" not in line, (
+            f"\n\nthe brief prescribes `gate.sh` for a repository with no "
+            f"`scripts/gate.sh`:\n    {line}\n{tool}"
+        )
+        assert "nix build" not in line, (
+            f"\n\na `nix build …#checks…` is prescribed against a flake that "
+            f"declares no `checks` output; it exits on an attribute error, "
+            f"which reads exactly like a broken gate:\n    {line}\n{tool}"
+        )
+        assert "nix develop" not in line, (
+            f"\n\na `nix develop` wrapper is prescribed around this "
+            f"repository's commands, but its flake names no pytest — that is "
+            f"the wrapper measured to exit `No module named 'pytest'`:\n"
+            f"    {line}\n{tool}"
+        )
+    assert "This repo's `.envrc` is `use opencode`" not in tool, (
+        f"\n\nthe brief asserts this repo's `.envrc` is `use opencode`. It is "
+        f"`use flake` + `use opencode`, and that string was remembered from "
+        f"devrc rather than read:\n{tool}"
+    )
+    assert "`use flake` + `use opencode`" in tool, (
+        f"\n\nthe `.envrc` this brief names is not the one on disk:\n{tool}"
+    )
+    # The runner that DOES exist is named, and the absent tier is called
+    # absent rather than passed over in silence — an auditor who reads no
+    # sandbox line at all goes looking for one.
+    assert "bash <your worktree>/scripts/tests/run-ci-suite.sh" in tool, (
+        f"\n\nthe repository's real runner is not prescribed:\n{tool}"
+    )
+    assert "no `checks` output" in tool, (
+        f"\n\nthe brief is silent about the missing sandbox tier; silence "
+        f"sends the auditor hunting for one:\n{tool}"
+    )
+    # 🔴 And the bare subset command, NOT one wrapped in a shell measured to
+    # have no pytest in it.
+    assert "python3 -m pytest <paths> -q -p no:cacheprovider" in cmds
+
+    # 🔴 THE OTHER `.envrc` BRANCH, AND A FIXTURE THAT CAN SEE THE MUTANT.
+    # The wrong-shell diagnosis has two spellings — one for a repo whose flake
+    # DOES carry pytest, one for a repo that does not — and only the second is
+    # exercised above. MEASURED: with the module's devrc-shaped fixture alone,
+    # hardcoding the sentence back to `use opencode` (mutant V39) SURVIVED a
+    # fully green suite, because that fixture's `.envrc` IS `use opencode` and
+    # a value that can only ever equal the constant cannot see a mutant that
+    # returns the constant. So this one says something else, deliberately.
+    other = _write_repo(tmp_path / "devrc-shaped", envrc="use flake\n",
+                        gate=DEVRC_GATE, flake=DEVRC_FLAKE)
+    rc, out, err = run_main(["900"], toplevel=other)
+    assert rc == 0, err
+    tool = toolchain_section(out)
+    assert "This repo's `.envrc` is `use flake`," in tool, (
+        f"\n\nthe `.envrc` named in the wrong-shell diagnosis is not the one "
+        f"on disk — it says `use flake` and nothing else:\n{tool}"
+    )
+    assert "`use opencode`" not in tool, (
+        f"\n\nthe brief names `use opencode` for a repository whose `.envrc` "
+        f"does not contain it. That string is devrc's, remembered rather than "
+        f"read, and it is the claim an auditor cannot check:\n{tool}"
+    )
+    # …and this shape DOES get the shell wrapper, because its flake carries
+    # pytest. The negative control for the branch above: same code, opposite
+    # answer, so "no `nix develop`" is a measurement and not a constant.
+    assert any(f"nix develop {other} -c python3 -m pytest" in line
+               for line in toolchain_commands(tool)), (
+        f"\n\nthis repository's flake DOES carry pytest, so the subset command "
+        f"must be wrapped in its dev shell. Without this the 'no `nix develop`' "
+        f"assertion above is a constant rather than a "
+        f"measurement:\n{toolchain_commands(tool)}"
+    )
+
+
+def test_the_toolchain_prescribes_nothing_when_it_cannot_probe(tmp_path):
+    """🔴 Cross-repo: no checkout of the PR's repo, so NO command is invented.
+
+    The counterpart to the guard above, and the one that pins the design's
+    whole point: a fabricated command is strictly worse than an absent one.
+    An absent one costs the auditor a lookup; a fabricated one costs a round
+    and can be written up as a finding against a PR that is fine.
+
+    The trap this closes is subtle — the cwd IS a probeable repository here
+    (devrc's shape, `FAKE_REPO_DIR`), it is simply the WRONG one. Probing it
+    would produce a confident, fully-formed, entirely irrelevant command list,
+    which is the original defect with a new source rather than a fix.
+    """
+    tool = toolchain_section(brief_for_scenario("cross-repo"))
+    assert "NOTHING WAS PROBED HERE" in tool, (
+        f"\n\ncross-repo, and the brief still prescribes commands:\n{tool}"
+    )
+    # 🔴 NO FENCED BLOCK AT ALL. The prose deliberately still NAMES
+    # `scripts/gate.sh` and `scripts/tests/run-ci-suite.sh` — as places to go
+    # LOOK — so a substring scan over the whole section would forbid the
+    # hand-over this branch exists to give. What must be empty is the set of
+    # things presented as runnable.
+    assert toolchain_commands(tool) == [], (
+        f"\n\ncross-repo, the brief still hands over runnable commands — read "
+        f"out of `{FAKE_REPO_DIR}`, a DIFFERENT repository from the one the PR "
+        f"lives in:\n{toolchain_commands(tool)}\n{tool}"
+    )
+    assert "NAME the one you used" in tool, (
+        "the hand-over does not ask the auditor to name the runner they "
+        "found, so the report cannot be checked by anyone"
+    )
+
+
+def test_the_flake_checks_probe_reads_an_output_and_not_the_word(tmp_path):
+    """🔴 The three answers `_flake_check_names` must keep distinct.
+
+    `None` (no `checks` output), `[]` (declared but unreadable) and a name list
+    are three different sentences, and collapsing any two either prescribes a
+    command for a repo without it or suppresses one for a repo with it.
+
+    The `homelab-infra` row is the negative control that a loose probe fails,
+    and the `devrc` row is the positive control that an indentation-only scan
+    fails: a build script's lines start at column 0, so bounding the block by
+    indentation stopped at the first of them and returned `['pytests']` alone.
+    """
+    assert ad._flake_check_names(HOMELAB_FLAKE) is None, (
+        "`checks = pr.get(...)` inside a devShell heredoc was read as a flake "
+        "`checks` OUTPUT — the repo declares none"
+    )
+    assert ad._flake_check_names(DEVRC_FLAKE) == ["pytests", "nodetests"], (
+        "the two real check names were not both read out of a devrc-shaped "
+        "flake; a scan that stops at the first low-indent line inside a "
+        "`''…''` build script returns ['pytests']"
+    )
+    assert ad._flake_check_names("") is None
+    assert ad._flake_check_names(None) is None
+    assert ad._flake_check_names("checks.${system} = {\n") == [], (
+        "a truncated/unreadable checks block must answer [] — 'declared but "
+        "I could not read the names' — and not None, which claims the "
+        "repository HAS no sandbox tier"
     )
 
 
@@ -6201,6 +6603,25 @@ RED_AT_BASE_R13: frozenset[str] = frozenset({
     "test_the_cross_repo_recipe_can_actually_be_run",
 })
 
+# 🔴 ROUND 14's base is `bd1572f3`, `origin/main` at the time. Measured the
+# same way — `git show bd1572f3:scripts/audit-dispatch.py` into a scratch tree
+# with THIS module copied in unchanged, `PYTHONDONTWRITEBYTECODE=1
+# -p no:cacheprovider`. Both fail on an ASSERTION, not on an import or an
+# arity error: the base script renders a TOOLCHAIN section fine, it just
+# renders devrc's layout into it whatever the target.
+#
+# 🔴 `test_the_flake_checks_probe_reads_an_output_and_not_the_word` is NOT
+# here, deliberately. `_flake_check_names` does not exist at `bd1572f3`, so it
+# would fail there with `AttributeError` — a claim about the symbol's absence
+# and not about any behaviour. That is the vacuous shape this module refuses to
+# count as regression coverage, so it is filed as an invariant guard and its
+# evidence is its own two controls (the real `homelab-infra` heredoc line, the
+# real devrc two-name block) plus mutants V38 and V41.
+RED_AT_BASE_R14: frozenset[str] = frozenset({
+    "test_the_toolchain_prescribes_only_commands_it_probed",
+    "test_the_toolchain_prescribes_nothing_when_it_cannot_probe",
+})
+
 RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "abc41024": RED_AT_BASE_R2,
     "d9eb36a8": RED_AT_BASE_R3,
@@ -6210,10 +6631,21 @@ RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "28492af2": RED_AT_BASE_R7,
     "706a6b38": RED_AT_BASE_R9,
     "6349a8b9": RED_AT_BASE_R13,
+    "bd1572f3": RED_AT_BASE_R14,
 }
 RED_AT_BASE: frozenset[str] = frozenset().union(*RED_AT_BASE_REFS.values())
 
 INVARIANT_GUARDS_AND_LEDGERS = frozenset({
+    # 🔴 An invariant guard, NOT regression coverage — `_flake_check_names`
+    # does not exist at `bd1572f3`, so its red there would be an
+    # `AttributeError` about a missing symbol rather than a wrong answer. Its
+    # evidence is its own pair of controls, both taken from real files: the
+    # `checks = pr.get(...)` line out of `homelab-infra`'s devShell heredoc
+    # (which the first regex here matched, answering "declares checks" for a
+    # flake that declares none) and devrc's two-name `checks.${system}` block
+    # (which an indentation-only scan reads as one name, because a build
+    # script's lines start at column 0).
+    "test_the_flake_checks_probe_reads_an_output_and_not_the_word",
     "test_the_invariant_clause_ledger_is_pinned_two_way",
     # 🔴 GREEN at `abc41024`, MEASURED — and it is the guard for finding 5, so
     # the temptation to file it as regression coverage is real and is refused
@@ -6735,6 +7167,37 @@ FIX_MATRIX = (
      "relationship read off the recipe, which no rewording moves",
      "test_the_clone_grant_covers_only_the_write_the_recipe_makes",
      "RED@706a6b38", "V22 V28 V34"),
+    # --------------------------------------------------------------------- #
+    # Round 14. Its base is `bd1572f3` — `origin/main` at the time.
+    # --------------------------------------------------------------------- #
+    ("r14/1 every TOOLCHAIN command hardcoded devrc's own layout, so a brief "
+     "for any other target prescribed scripts that do not exist there. "
+     "Measured against `ZacxDev/homelab-infra` #530 from a real checkout: no "
+     "`scripts/gate.sh`, no flake `checks` output, `.envrc` is `use flake` + "
+     "`use opencode` and not the `use opencode` asserted, and `nix develop "
+     "<root> -c python3 -m pytest` exits `No module named 'pytest'` — under a "
+     "bar telling the auditor that error means the WRONG SHELL, not a broken "
+     "suite. Four unrunnable prescriptions, one of them manufacturing the "
+     "failure it then told the reader to disregard",
+     "test_the_toolchain_prescribes_only_commands_it_probed",
+     "RED@bd1572f3", "V36 V38 V39"),
+    ("r14/2 and the fix's own trap: cross-repo, the cwd IS a probeable "
+     "repository, it is merely the WRONG one. Probing it yields a confident, "
+     "fully-formed, entirely irrelevant command list — the same defect with a "
+     "new source. Nothing detected must prescribe NOTHING, because a "
+     "fabricated command costs a round and reads as a broken gate, while an "
+     "absent one costs a lookup",
+     "test_the_toolchain_prescribes_nothing_when_it_cannot_probe",
+     "RED@bd1572f3", "V40"),
+    ("r14/3 the `checks` probe matched the WORD and not a flake OUTPUT: "
+     "`checks = pr.get(\"statusCheckRollup\", [])`, inside a python heredoc in "
+     "`homelab-infra`'s real devShell, answered \"this flake declares checks\" "
+     "for a flake that declares none — which would have prescribed the `nix "
+     "build` anyway and left the honest fallback unreachable. The mirror "
+     "error: an indentation-only name scan reads devrc's two-name block as "
+     "one, because a build script's lines start at column 0",
+     "test_the_flake_checks_probe_reads_an_output_and_not_the_word",
+     "GUARD", "V38 V41"),
 )
 
 # A COLLAPSE floor, not a growth floor: a matrix emptied by a bad refactor

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -6622,6 +6622,18 @@ RED_AT_BASE_R13: frozenset[str] = frozenset({
 # a scratch tree with THIS module copied in unchanged,
 # `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider` -> **4 failed, 111 passed**.
 #
+# 🔴 `9e23c379` IS KEPT AS THE ANCHOR EVEN THOUGH MAIN MOVED AGAIN (the branch
+# was rebased a second time, onto `ebbe5eaa`) — and that is a MEASUREMENT, not
+# a convenience. This module's rule is "a test belongs to the ref it was FIRST
+# watched red at", and the two refs are the same tree for this script:
+#   git rev-parse 9e23c379:scripts/audit-dispatch.py
+#   git rev-parse ebbe5eaa:scripts/audit-dispatch.py
+#     -> 0298a689d176d517b4997aa48216b3cfd67ada70   (both)
+# Byte-identical blob, so the red measured at `9e23c379` describes the current
+# merge-base exactly. `9e23c379` is the more informative of the two because it
+# is #1104's OWN merge commit — naming it is what makes "the competing fix
+# landed and this is still red" a checkable claim rather than an assertion.
+#
 # 🔴 AND THAT RE-MEASUREMENT IS THE WHOLE POINT: #1104 FIXED THIS SECTION AND
 # BOTH ROWS ARE STILL RED AT ITS MERGE COMMIT. It hedged the prose ("if this
 # repo has one", "exist in SOME repos and not others") and left all four

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -831,8 +831,15 @@ def _write_repo(root, *, envrc, gate=None, ci_suite=False, flake=None,
     if gate is not None:
         (root / "scripts" / "gate.sh").write_text(gate, encoding="utf-8")
     if ci_suite:
+        # 🔴 NO SHEBANG, and none is wanted. `detect_repo_toolchain` only ever
+        # asks `is_file()` about this path — nothing here is executed, so a
+        # shebang would be decoration that trips
+        # `test_no_test_writes_a_usr_bin_env_shebang_at_runtime` (the repo-wide
+        # guard that says an executable a test WRITES must go through
+        # `testlib.mockbin.write_exec`). Caught by the full gate, not by
+        # running this module alone.
         (root / "scripts" / "tests" / "run-ci-suite.sh").write_text(
-            "#!/usr/bin/env bash\npython3 -m pytest \"$@\"\n", encoding="utf-8")
+            'python3 -m pytest "$@"\n', encoding="utf-8")
     if flake is not None:
         (root / "flake.nix").write_text(flake, encoding="utf-8")
     if py_test:
@@ -921,8 +928,11 @@ PY
 }
 """
 
+# Also shebang-free, and for the same reason as `run-ci-suite.sh` above: the
+# probe reads this text looking for `--tier` and `both` and never runs it. What
+# matters is that both markers are present in the shapes devrc's real
+# `scripts/gate.sh` carries them.
 DEVRC_GATE = """\
-#!/usr/bin/env bash
 #   scripts/gate.sh [--tier pytest|node|both] [--set hermetic|all]
 #     --tier both      (default) run both runners; the gate is red if either is.
 case "$1" in

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -1740,6 +1740,39 @@ SCENARIO_RUNS = {
         ["900"],
         {"pr": dict(DEFAULT_PR, url="", isCrossRepository=True)},
     ),
+    # 🔴 ROUND 16 — THE THREE MISSING CELLS OF THE TARGET × CHECKOUT-KIND GRID,
+    # and the reason they are added TOGETHER rather than one per finding. Round
+    # 15 restored the commands pin within each target and guarded its own
+    # non-degeneracy with `any(len(kinds) >= 2)`. Measured at `ba321c06`:
+    #
+    #     probed-devrc-shape    n=6  {private, shared, unknown}
+    #     cross-repo-otherproj  n=5  {private, shared}
+    #     repo-unknown          n=2  {shared}
+    #
+    # `any` is satisfied by the first row alone, so it certified NOTHING about
+    # the other two — and no NOT-PROBED scenario was `unknown` kind at all.
+    # Measured: inserting into `_toolchain_not_probed` a sentence keyed on
+    # `facts.worktree.kind == "unknown"` — one that flatly contradicts WHERE TO
+    # WORK, exactly round 15's F1 in its third state — left the module at
+    # **122 passed**, while the same insertion keyed on `"private"` was killed.
+    #
+    # The grid is now COMPLETE and the assertion asks for the whole row, not for
+    # two of it: every target spans all three checkout states. That is the
+    # mechanical form of the property, so the next un-covered cell is a hole
+    # this guard NAMES rather than one it happens to miss.
+    "cross-repo-unreadable-worktree": lambda: (
+        ["900"], {"pr": OTHER_REPO_PR, "git_dirs": UNREADABLE_GIT_DIRS},
+    ),
+    "unknown-repo-private-worktree": lambda: (
+        ["900"],
+        {"pr": dict(DEFAULT_PR, url="", isCrossRepository=True),
+         "git_dirs": PRIVATE_GIT_DIRS},
+    ),
+    "unknown-repo-unreadable-worktree": lambda: (
+        ["900"],
+        {"pr": dict(DEFAULT_PR, url="", isCrossRepository=True),
+         "git_dirs": UNREADABLE_GIT_DIRS},
+    ),
 }
 SCENARIOS = tuple(SCENARIO_RUNS)
 
@@ -1787,8 +1820,11 @@ TOOLCHAIN_TARGET_OF = {
     "cross-repo-delta": "cross-repo-otherproj",
     "cross-repo-delta-no-head-sha": "cross-repo-otherproj",
     "cross-repo-renamed-remote-delta": "cross-repo-otherproj",
+    "cross-repo-unreadable-worktree": "cross-repo-otherproj",
     "claims-file-assumed-base": "repo-unknown",
     "unknown-repo-gh-said-nothing": "repo-unknown",
+    "unknown-repo-private-worktree": "repo-unknown",
+    "unknown-repo-unreadable-worktree": "repo-unknown",
 }
 
 # The three checkout states, by the phrase `render_checkout_state` prints for
@@ -5454,16 +5490,37 @@ def test_the_toolchain_reason_is_true_in_every_scenario():
             )
     # 🔴 NON-DEGENERACY, and it is what makes the equality above a MEASUREMENT.
     # A partition whose members all share one checkout state cannot see a
-    # sentence keyed on that state — the equality would hold vacuously. At
-    # least one partition must span two of the three states, or this pin is
-    # blind to the exact mutation it was written for.
+    # sentence keyed on that state — the equality would hold vacuously there.
+    #
+    # 🔴 ROUND 16 — `any(len(k) >= 2)` CERTIFIED ONE PARTITION AND CALLED IT
+    # THE PIN. Measured at `ba321c06`: `probed-devrc-shape` spanned all three
+    # states and satisfied it single-handed, while `cross-repo-otherproj` had
+    # {private, shared} and `repo-unknown` had {shared} ALONE — so the
+    # not-probed branch was blind to `unknown` in both of its partitions.
+    # Inserting into `_toolchain_not_probed` a WHERE-TO-WORK-contradicting
+    # sentence keyed on `facts.worktree.kind == "unknown"` left the module at
+    # **122 passed**; the same insertion keyed on `"private"` was killed. That is
+    # round 15's F1 in its third state, one `any` away.
+    #
+    # So the requirement is the WHOLE GRID: every target spans every checkout
+    # state. `any` -> `all` alone would still let a partition sit at two of
+    # three; naming the state set makes the missing cell a named hole rather
+    # than an unnoticed one. `CHECKOUT_KIND_MARKERS` is the enumeration, so
+    # adding a fourth checkout state fails HERE, loudly, instead of quietly
+    # halving what this pin can see.
     kinds = {key: {checkout_kind_of(briefs[s]) for s in members}
              for key, members in by_target.items()}
-    assert any(len(k) >= 2 for k in kinds.values()), (
-        "\n\nno target partition spans two checkout states, so the equality "
-        "above cannot see a sentence that varies with the auditor's own "
-        f"worktree — the mutation this guard exists for. states: {kinds}"
-    )
+    every_state = set(CHECKOUT_KIND_MARKERS)
+    for key, seen in sorted(kinds.items()):
+        assert seen == every_state, (
+            f"\n\ntarget {key!r} spans only {sorted(seen)} of the "
+            f"{sorted(every_state)} checkout states, so the within-target "
+            "equality above is BLIND to a sentence keyed on "
+            f"{sorted(every_state - seen)} in this branch — which is exactly "
+            "the mutation this guard exists for, and it survived a fully green "
+            "suite once already.\n  scenarios in this target: "
+            f"{sorted(by_target[key])}\n  full grid: {kinds}"
+        )
 
 
 def test_the_toolchain_prescribes_only_commands_it_probed(tmp_path):
@@ -5736,6 +5793,102 @@ PY
 """,
 }
 
+# 🔴 ROUND 16 — THE `#` ROW ABOVE IS INERT AGAINST THE STRIPPER, SAID OUT LOUD
+# RATHER THAN LEFT TO READ AS COVERAGE. `CHECKS_ATTR`/`CHECKS_DECL` are anchored
+# `^[ \t]*checks`, and a `#` line comment puts a `#` before the word on every
+# line it comments out — so that row answers `None` at every revision this
+# module has ever had, stripper or no stripper. It is kept because it pins the
+# ANCHOR (a future `re.search` without `^` would fabricate a tier from it), and
+# `test_the_comment_stripper_is_reachable_in_its_own_right` below asserts the
+# comment text really is blanked, which is the claim the row's NAME makes and
+# the row itself cannot support. The load-bearing `#` case is the FALSE-ABSENT
+# one directly below: a comment whose text would otherwise open a string.
+#
+# `# … the ''-string idiom …` is an ordinary sentence to write in a flake, and
+# an unstripped `''` in it opens an indented string that never closes: the real
+# `checks` block after it is blanked and the answer is `None`, in bold.
+CHECKS_COMMENTED_APOSTROPHES = """{
+  outputs = { self }: {
+    # we do not use the ''-string idiom here, and "unbalanced quotes happen
+    checks.x86_64-linux = {
+      unit = 1;
+      lint = 2;
+    };
+  };
+}
+"""
+
+# 🔴 ROUND 16 — A LEGAL NIX IDENTIFIER THAT ENDS IN APOSTROPHES. `'` is an
+# identifier character (this module's own `_NIX_NAME` allows it), so `foo'' = 1;`
+# is ONE token. Measured at `ba321c06`: read as a string opener it blanked the
+# REST OF THE FILE and the answer was `None` — "**no `checks` output**" for a
+# flake whose next binding is the checks block.
+CHECKS_IDENT_WITH_APOSTROPHES = """{
+  outputs = { self }: rec {
+    foo'' = 1;
+    checks.x86_64-linux = {
+      unit = 1;
+      lint = 2;
+    };
+  };
+}
+"""
+
+
+# 🔴 ROUND 16 — THE SHAPE THE FLAT FIXTURES CANNOT REACH, AND IT IS THE SAME
+# CLASS ONE LEVEL DOWN. `shellHook = '' ${lib.optionalString c '' … ''} '';` is
+# an ordinary nixpkgs idiom, and a scanner that walks to "the next `''`" reads
+# the `''` that OPENS the nested string as the OUTER one's terminator. Two
+# consequences, both measured at `ba321c06`, both CONFIDENT answers:
+#
+#   * the interpolation's body is not blanked, it is PROMOTED TO CODE — a flake
+#     declaring no `checks` at all answered `['unit']`, i.e. the brief fenced
+#     `nix build …#checks.x86_64-linux.unit` for a target that has none;
+#   * when that promoted region holds an odd token (an `''${` escape, a lone
+#     `"`), string parity inverts for the rest of the file and a flake that DOES
+#     declare `checks.x86_64-linux = { unit; lint; }` answered `None`.
+#
+# So the fixtures are a PRODUCT, not a row: every inner body × both outer
+# states. A single nested fixture would have covered whichever direction its own
+# body happened to produce and left the other open — which is how the flat F7
+# fixture left this whole class open in the first place.
+def _nested_interp_flake(body, declares):
+    """A flake whose devShell interpolates a NESTED `''…''`, ± a checks output."""
+    return (
+        "{\n"
+        "  outputs = { self }: {\n"
+        "    devShells.x86_64-linux.default = pkgs.mkShell {\n"
+        "      shellHook = ''\n"
+        "        ${lib.optionalString cond ''\n"
+        + body
+        + "        ''}\n"
+        "        echo hi\n"
+        "      '';\n"
+        "    };\n"
+        + ("    checks.x86_64-linux = {\n"
+           "      unit = 1;\n"
+           "      lint = 2;\n"
+           "    };\n" if declares else "")
+        + "  };\n"
+        "}\n"
+    )
+
+
+NESTED_INNER_BODIES = {
+    "plain": "          echo nested\n",
+    "an ''${…} escape": "          export P=''${HOME}/bin\n",
+    "a lone double quote": "          echo \"unbalanced\n",
+    "a `#` character": "          echo '# not a comment'\n",
+    "text that LOOKS like a checks binding": (
+        "          checks = {\n"
+        "          unit = 1;\n"
+        "          }\n"
+    ),
+    "a nested interpolation of its own": (
+        "          echo ${toString ${n}}\n"
+    ),
+}
+
 # devrc's real `checks.${system}` block with nix's two-apostrophe ESCAPES in the
 # build script — `''${VAR}` is a literal `${VAR}`, `'''` is a literal `''`.
 # Neither closes the string, and a scanner that toggles on any `''` thinks both
@@ -5845,6 +5998,156 @@ def test_the_flake_checks_probe_reads_nix_code_and_not_text_that_looks_like_it()
     )
 
 
+def test_a_nested_indented_string_inside_an_interpolation_is_not_a_terminator():
+    """🔴 REGRESSION. Red at `ba321c06` in BOTH directions, on this branch's fix.
+
+    Round 15 taught the scanner nix's three two-apostrophe spellings and left
+    the token that cannot be lexed without a STACK: the `''` that OPENS a nested
+    string inside a `${…}`. `shellHook = '' ${lib.optionalString c '' … ''} '';`
+    is an ordinary nixpkgs idiom, and a flat "walk to the next `''`" reads that
+    opener as the OUTER string's terminator.
+
+    Measured at `ba321c06` through `_flake_check_names`:
+
+        no `checks` output at all           -> ['unit']   (FABRICATED)
+        `checks.x86_64-linux = {unit;lint;}`
+          with an ''${…} escape in the body -> None       ("**no `checks`
+                                                           output**", in bold)
+
+    The first fences `nix build <wt>#checks.x86_64-linux.unit` against a repo
+    that has no such attribute — a command that exits on an attribute error and
+    reads exactly like a broken gate. The second denies the tier the same
+    section calls the one the merge gates on. Both are the CONFIDENT answer; the
+    `[]` valve cannot fire for either, because `CHECKS_DECL` runs over the same
+    mis-lexed text.
+
+    🔴 THE FIXTURES ARE A PRODUCT, NOT A ROW. Which direction a nested fixture
+    exposes depends on the parity of the tokens in its body, so one fixture
+    covers one direction by luck. Every inner body is driven against BOTH outer
+    states, and `test_the_probe_hedges_when_the_nix_scan_did_not_end_cleanly`
+    below pins where the answer goes when the lexer is genuinely lost.
+    """
+    for name, body in NESTED_INNER_BODIES.items():
+        absent = ad._flake_check_names(_nested_interp_flake(body, declares=False))
+        assert absent is None, (
+            f"\n\ninner body {name!r}: the flake declares NO `checks` output "
+            f"and the probe answered {absent!r}. The nested `''` was read as "
+            "the outer string's terminator, so the interpolation body was "
+            "promoted to CODE — and the brief fences a `nix build "
+            "…#checks…<name>` for a repository that has no such attribute."
+        )
+        present = ad._flake_check_names(_nested_interp_flake(body, declares=True))
+        assert present == ["unit", "lint"], (
+            f"\n\ninner body {name!r}: the flake DOES declare "
+            "`checks.x86_64-linux = {{ unit; lint; }}` and the probe answered "
+            f"{present!r}. `None` there is the brief stating in BOLD that the "
+            "repository has no sandbox tier; a short list is a tier run "
+            "half-way. Both are confident, and the nested string is what "
+            "inverted the parity."
+        )
+    # 🔴 THE OTHER TWO SHAPES OF THE SAME CLASS — `''` that is not a string
+    # delimiter at all, and `''` inside a `#` comment.
+    assert ad._flake_check_names(CHECKS_IDENT_WITH_APOSTROPHES) == [
+        "unit", "lint"
+    ], (
+        "`foo'' = 1;` is ONE nix identifier — `'` is an identifier character, "
+        "which `_NIX_NAME` already knew. Read as a string opener it blanks the "
+        "rest of the file and the answer is `None`."
+    )
+    assert ad._flake_check_names(CHECKS_COMMENTED_APOSTROPHES) == [
+        "unit", "lint"
+    ], (
+        "a `#` comment mentioning the `''`-string idiom opened an indented "
+        "string that never closed, blanking the real `checks` block after it"
+    )
+
+
+def test_the_comment_stripper_is_reachable_in_its_own_right():
+    """🔴 THE `#` ROW IN `CHECKS_SHAPES_NOT_CODE` IS INERT, AND THIS IS WHY.
+
+    Both patterns are anchored `^[ \\t]*checks`, and a `#` line comment puts a
+    `#` in front of the word on every line it comments out. So that row answers
+    `None` at every revision this module has ever had — stripper or no stripper
+    — and it reads as coverage of the comment handling while providing none.
+    `claude/RULES.md`: a guard that reads as coverage while providing none is
+    worse than no guard, because it stops anyone looking.
+
+    Two things are pinned here instead, and neither is walkable by the anchor:
+    the comment TEXT is really blanked (so the row's own name becomes true of
+    something), and a `#` comment whose text would otherwise open a string does
+    not blank the code after it — the case the anchor cannot reach and the one
+    that flips a real answer.
+    """
+    text = CHECKS_SHAPES_NOT_CODE["a `#`-commented checks block"]
+    stripped = ad._nix_strip(text)
+    assert "checks" not in stripped, (
+        "the `#`-commented `checks` line survived the strip. The anchored "
+        "regex rejects it anyway, which is why the fixture row cannot see "
+        "this — an unanchored `re.search` would fabricate a tier from it."
+    )
+    assert "packages.default = 1;" in stripped, (
+        "the stripper blanked the CODE after the comment too, so the assertion "
+        "above passes for a stripper that blanks everything"
+    )
+    # The positive control for the whole comment branch: without it the fixture
+    # below answers `None`, because its `''` opens a string that never closes.
+    assert ad._flake_check_names(CHECKS_COMMENTED_APOSTROPHES) == ["unit", "lint"]
+
+
+def test_the_probe_hedges_when_the_nix_scan_did_not_end_cleanly():
+    """🔴 WHERE THE LEXER IS LOST, THE ANSWER IS `[]` — never `None`, never names.
+
+    Round 16's two measured failures both routed to the STRONGEST wrong answer:
+    a fabricated name list one way, a bolded "no `checks` output" the other.
+    `None` and a name list are the two confident sentences; `[]` is the hedge
+    that hands over `CHECKS_DISCRIMINATOR`. So `_nix_scan` reports whether it
+    ended in a state a nix file can be in, and the caller degrades on that
+    BEFORE it reads anything — the valve has to sit above the parse, because
+    both patterns run over the same mis-lexed text.
+
+    A `_PROBE_MAX_BYTES` truncation is the same observable and lands the same
+    way, which is the point: this is a property of the SCAN, not a list of
+    known-bad inputs.
+    """
+    clean_cases = {
+        "devrc's own flake": DEVRC_FLAKE,
+        "homelab-infra's flake": HOMELAB_FLAKE,
+        "an identifier ending in apostrophes": CHECKS_IDENT_WITH_APOSTROPHES,
+        "a nested interpolation": _nested_interp_flake(
+            NESTED_INNER_BODIES["plain"], declares=True),
+    }
+    for name, text in clean_cases.items():
+        assert ad._nix_scan(text)[1] is True, (
+            f"\n\n{name} does not lex cleanly, so `_flake_check_names` now "
+            "hedges `[]` for it — the hedge is only honest while the clean "
+            "cases really are clean, or every repository gets it"
+        )
+    dirty_cases = {
+        "an unterminated indented string": "checks.x86_64-linux = ''\n  unit\n",
+        "an unterminated double quote": 'checks.x86_64-linux = "unit\n',
+        "an unclosed interpolation": "a = ''${\n",
+        "an unclosed block comment": "/* checks.x86_64-linux = {\n  unit = 1;\n",
+        "braces that never balance (a truncated read)":
+            "checks.${system} = {\n",
+    }
+    for name, text in dirty_cases.items():
+        assert ad._nix_scan(text)[1] is False, (
+            f"\n\n{name} was reported as a CLEAN lex, so nothing degrades and "
+            "whatever the patterns then say is stated with full confidence"
+        )
+        assert ad._flake_check_names(text) == [], (
+            f"\n\n{name}: the probe answered "
+            f"{ad._flake_check_names(text)!r} rather than the hedged `[]`. "
+            "`None` states in bold that the repository has no sandbox tier and "
+            "a name list fences a `nix build` at it; the lexer did not finish, "
+            "so it is entitled to neither."
+        )
+    # 🔴 THE POSITIVE CONTROL FOR THE VALVE ITSELF: a hedge that fired on
+    # everything would make every row above pass while destroying the function.
+    assert ad._flake_check_names(DEVRC_FLAKE) == ["pytests", "nodetests"]
+    assert ad._flake_check_names(HOMELAB_FLAKE) is None
+
+
 def test_a_capped_python_test_walk_is_not_reported_as_no_python_tests(tmp_path):
     """🔴 REGRESSION. Red at `5bad0a0c`, where the cap failed SILENTLY.
 
@@ -5917,6 +6220,88 @@ def test_a_capped_python_test_walk_is_not_reported_as_no_python_tests(tmp_path):
         "two of the three answers are spelled the same, so the branches that "
         "distinguish them cannot be reached separately"
     )
+
+
+def test_the_python_absence_bar_does_not_point_at_a_bar_that_is_not_there(tmp_path):
+    """🔴 REGRESSION. Red at `ba321c06`, on both halves. Two dangling references.
+
+    **The cross-reference.** The `PY_TESTS_NONE` bar said the completed walk
+    "is a different answer from the one above". The branches are mutually
+    exclusive — `if UNKNOWN: return …; if NONE: return …` — so the bar it
+    contrasted itself with is emitted in exactly the runs where this one is
+    not. A reader sent looking for a bar that is never on the page.
+
+    **The diagnosis of an unprescribed command.** With `NONE` and a flake that
+    names pytest, `_toolchain_shell_note` opened with a `python3 -m pytest`
+    wrong-shell bar three lines after the same section said no python subset
+    command is prescribed. Fixed as the general rule and not as a NONE special
+    case: the python-specific bar is emitted only where a `python3 -m pytest`
+    is actually fenced above it, and the language-agnostic one — which is true
+    in every state — is unconditional and self-contained.
+
+    Driven over all THREE `py_tests` states, because "the bar is absent" is
+    satisfied by a note that vanished and "the bar is present" by one that never
+    varies. Both are the failure this pins.
+    """
+    trees = {}
+    for name, py_test in (("none", False), ("found", True)):
+        root = Path(tmp_path / name)
+        _write_repo(root, envrc="use flake\n", gate=DEVRC_GATE,
+                    flake=DEVRC_FLAKE, py_test=py_test)
+        trees[name] = root
+    wide = Path(tmp_path / "unknown")
+    _write_repo(wide, envrc="use flake\n", gate=DEVRC_GATE, flake=DEVRC_FLAKE,
+                py_test=False)
+    for i in range(ad._PROBE_MAX_DIRS + 100):
+        (wide / f"d{i:04d}").mkdir()
+    trees["unknown"] = wide
+    # 🔴 FIXTURE REACH, ESTABLISHED RATHER THAN ASSUMED. Without this the three
+    # rows below could all be the same state and every assertion would be a
+    # claim about one branch wearing three names.
+    assert [ad._python_test_probe(trees[k]) for k in ("none", "found", "unknown")
+            ] == [ad.PY_TESTS_NONE, ad.PY_TESTS_FOUND, ad.PY_TESTS_UNKNOWN]
+
+    sections = {}
+    for name, root in trees.items():
+        rc, out, err = run_main(["900"], toplevel=str(root))
+        assert rc == 0, err
+        sections[name] = toolchain_section(out)
+
+    # 🔴 "the one above", not "from the one above": the narrower spelling is
+    # walkable by "different from the one printed above". Nothing else in this
+    # section says it — the sibling bars say "The runner above" — so the wider
+    # phrase costs no false red and closes the reword.
+    assert "the one above" not in sections["none"], (
+        f"\n\nthe completed-walk bar points at 'the one above'. The capped bar "
+        f"is the only thing it can mean and the two branches are mutually "
+        f"exclusive, so it is never above:\n{sections['none']}"
+    )
+    assert "the walk COMPLETED and found none" in sections["none"], (
+        "the contrast itself was dropped instead of being re-pointed; the two "
+        "answers are the whole reason there are three states"
+    )
+    # The python-specific diagnosis: present exactly where a python command is.
+    for name, section in sections.items():
+        fenced_pytest = any("python3 -m pytest" in c
+                            for c in toolchain_commands(section))
+        diagnosed = "A bare `python3 -m pytest` failing" in section
+        assert diagnosed == fenced_pytest, (
+            f"\n\npy_tests={name!r}: a `python3 -m pytest` wrong-shell bar is "
+            f"{'present' if diagnosed else 'absent'} while such a command is "
+            f"{'fenced' if fenced_pytest else 'NOT fenced'} above it. A "
+            f"diagnosis of a command this section did not prescribe sends the "
+            f"reader looking for something that is not there:\n{section}"
+        )
+        # …and the language-agnostic bar is there in EVERY state, so dropping
+        # the python one is not the note vanishing again (round 15's F9).
+        assert "WRONG SHELL and not a broken gate" in section, (
+            f"\n\npy_tests={name!r}: no wrong-shell diagnosis at all. That is "
+            f"round 15's F9 re-opened by this round's fix:\n{section}"
+        )
+        assert "in EVERY language" in section, (
+            f"py_tests={name!r}: the diagnosis no longer says it covers every "
+            f"language, so it reads as a python note again:\n{section}"
+        )
 
 
 def test_the_wrong_shell_diagnosis_covers_every_command_not_only_pytest(tmp_path):
@@ -6013,39 +6398,121 @@ def test_the_toolchain_head_claim_is_true_of_the_rendered_brief():
     block asks whether the rendered reason IS this constant, never whether the
     constant is TRUE of what follows it. A claim can be pinned byte-for-byte
     and false in every brief that carries it.
+
+    🔴 ROUND 16 — RED AT `ba321c06` TOO, ON ROUND 15'S OWN REPLACEMENT WORDING,
+    AND ON THIS GUARD'S OWN SCOPE. "the prose names it too, to say what was read
+    out of it" is a claim about a STATE, put back into the state-INDEPENDENT
+    constant. Counted at `ba321c06` over all thirteen scenarios the module had
+    there (round 16 adds three more, closing the target x checkout-kind grid):
+
+        probed       (6)  3 prose lines naming the assembly checkout  -> true
+        cross-repo   (5)  1, and it says "is a DIFFERENT repository"  -> false
+        repo-unknown (2)  0 — the path is absent from the section     -> flatly
+
+    and this guard drove ONLY `delta`. A guard narrower than the sentence it
+    certifies is the shape round 15's F2 was filed for, reproduced one round
+    later inside F2's own fix — so the fix is BOTH halves: the clause is now the
+    widest thing true in every state (wherever the path appears outside a
+    `nix develop` argument it is PROSE, never something to run in), and the
+    guard drives every scenario the module has.
+
+    The `assert prose` half is scoped to the states that HAVE prose, and its
+    non-vacuity is asserted globally instead: if no scenario anywhere named the
+    path in prose, the clause should go back to #1104's "ONLY as the argument to
+    `nix develop`", which would then be true again.
     """
     root = FAKE_REPO_DIR
-    tool = toolchain_section(brief_for_scenario("delta"))
-    assert "at most ONCE" not in tool, (
-        "the false COUNT is back. The path appears in prose too; a count over "
-        "the whole section cannot be satisfied while it does"
-    )
-    fenced = toolchain_commands(tool)
-    naming = [c for c in fenced if root in c]
-    assert naming, (
-        "no fenced command names the assembly checkout at all, so the claim "
-        "under test is vacuous here. Check FAKE_REPO_DIR is still probed."
-    )
-    for line in naming:
-        assert line.startswith(f"nix develop {root} -c "), (
-            f"\n\na RUNNABLE command names the assembly checkout somewhere "
-            f"other than as the `nix develop` argument:\n    {line}\n"
-            "  That is the tree under test pointing at somebody else's "
-            "checkout, which is what TOOLCHAIN_HEAD promises never happens."
+    fenced_naming_total, prose_naming_total = 0, 0
+    for scenario in SCENARIOS:
+        tool = toolchain_section(brief_for_scenario(scenario))
+        assert "at most ONCE" not in tool, (
+            f"\n\nscenario {scenario!r}: the false COUNT is back. The path "
+            "appears in prose too; a count over the whole section cannot be "
+            "satisfied while it does"
         )
-        assert line.replace(f"nix develop {root} -c ", "", 1).count(root) == 0, (
-            f"\n\nthe assembly checkout appears a SECOND time in one command, "
-            f"past the `nix develop` argument:\n    {line}"
+        fenced = toolchain_commands(tool)
+        naming = [c for c in fenced if root in c]
+        fenced_naming_total += len(naming)
+        for line in naming:
+            assert line.startswith(f"nix develop {root} -c "), (
+                f"\n\nscenario {scenario!r}: a RUNNABLE command names the "
+                f"assembly checkout somewhere other than as the `nix develop` "
+                f"argument:\n    {line}\n"
+                "  That is the tree under test pointing at somebody else's "
+                "checkout, which is what TOOLCHAIN_HEAD promises never happens."
+            )
+            assert line.replace(
+                f"nix develop {root} -c ", "", 1).count(root) == 0, (
+                f"\n\nscenario {scenario!r}: the assembly checkout appears a "
+                f"SECOND time in one command, past the `nix develop` "
+                f"argument:\n    {line}"
+            )
+        prose_naming_total += len(
+            [ln for ln in tool.splitlines() if root in ln and ln not in fenced])
+        # 🔴 PER-SCENARIO NON-VACUITY, KEYED ON THE DECLARED TARGET — and it is
+        # here because the global counters below LOST a kill without it.
+        # Measured: mutant C3 (the cross-repo decision inverted) was killed by
+        # this guard while it drove `delta` alone, and survived the first
+        # global-counter spelling — the inversion makes the cross-repo
+        # scenarios probe, so the totals stay non-zero and only the
+        # per-scenario shape can see that the WRONG scenarios produced them.
+        # `TOOLCHAIN_TARGET_OF` is the declared intent; a rendering that
+        # disagrees with it is the finding.
+        probed_target = TOOLCHAIN_TARGET_OF[scenario] == "probed-devrc-shape"
+        assert bool(naming) == probed_target, (
+            f"\n\nscenario {scenario!r} is declared "
+            f"{TOOLCHAIN_TARGET_OF[scenario]!r} and "
+            f"{'names' if naming else 'does NOT name'} the assembly checkout "
+            f"in a fenced command. A probed target must run something in that "
+            f"dev shell; a NOT-probed one must prescribe nothing at all — a "
+            f"fenced command there is a confident command list for a "
+            f"repository this run never read.\n  fenced: {fenced}"
         )
-    # 🔴 THE OTHER HALF OF THE REWORDED CLAIM, asserted so the reword is not a
-    # retreat: the prose really does name the path, and says what was read.
-    prose = [ln for ln in tool.splitlines()
-             if root in ln and ln not in fenced]
-    assert len(prose) >= 2, (
-        f"\n\nthe head now says the prose names the path 'to say what was read "
-        f"out of it', and {len(prose)} prose line(s) do. If that drops to "
-        "zero the sentence should go back to #1104's 'ONLY as the argument to "
-        "`nix develop`', which would then be true again."
+    # 🔴 BOTH NON-VACUITY CONTROLS, GLOBAL RATHER THAN PER-SCENARIO — because
+    # neither half is true in every state and pretending otherwise is the
+    # finding. A section that never names the path at all satisfies every loop
+    # above while saying nothing.
+    assert fenced_naming_total, (
+        "no fenced command in ANY scenario names the assembly checkout, so the "
+        "`nix develop` half of the claim is vacuous everywhere. Check "
+        "FAKE_REPO_DIR is still a real directory that gets probed."
+    )
+    assert prose_naming_total, (
+        "no scenario names the assembly checkout in PROSE, so the reworded "
+        "clause describes something that never happens. Put #1104's 'ONLY as "
+        "the argument to `nix develop`' back — it would be true again."
+    )
+    # 🔴 THE WHOLE NORMALISED STRING, and it is the only instrument that works
+    # here. `claude/RULES.md`: when the artifact under test IS prose, a guard on
+    # WORDS is walkable by REWORDING — and this constant has now been reworded
+    # into a false claim TWICE, in the fix for the previous rewording each time
+    # ("at most ONCE" -> "the prose names it too"). Neither loop above can see
+    # it: both are still satisfied by a head that says something untrue about
+    # states it does not render in.
+    #
+    # A cosmetic reword fails here on purpose. Before changing it, RE-COUNT the
+    # prose lines naming the assembly path per target — 3 / 1 / 0 at `ba321c06`
+    # for probed / cross-repo / repo-unknown — and write only what holds in all
+    # three; then paste the new normalised string in.
+    assert " ".join(ad.TOOLCHAIN_HEAD.split()) == (
+        "## TOOLCHAIN — the exact commands, and the two ways they lie 🔴 "
+        "`<your worktree>` below is **your own copy** — the one WHERE TO WORK "
+        "told you to make. The checkout this brief was assembled in appears "
+        "below in RUNNABLE commands only as the argument to `nix develop`, "
+        "where it resolves the dev shell and nothing else; wherever else it "
+        "appears it is PROSE — a statement ABOUT that checkout, never "
+        "something to run in. Never point a gate script or a `nix build` at "
+        "it: a gate script resolves its root from its own path, so running "
+        "that copy runs the suite in a checkout that is NOT yours — one "
+        "holding none of your mutations — and a `nix build <ref>#…` builds "
+        "that ref's tree, not yours."
+    ), (
+        "\n\nTOOLCHAIN_HEAD changed. It is a state-INDEPENDENT constant, so "
+        "every claim in it must hold in all three targets and all three "
+        "checkout states; this pin is whole-string because the last two "
+        "rewordings each replaced a false claim with a different false claim "
+        "and no word-level guard could tell.\n"
+        f"--- now ---\n{' '.join(ad.TOOLCHAIN_HEAD.split())}"
     )
 
 
@@ -7384,6 +7851,29 @@ RED_AT_BASE_R15: frozenset[str] = frozenset({
     "test_an_unreadable_flake_is_not_reported_as_an_absent_one",
 })
 
+# 🔴 ROUND 16. Base `ba321c06` — round 15's OWN head, for the same reason round
+# 15 used `5bad0a0c`: every finding here is a defect this branch shipped one
+# round ago, so that is the tree to watch them go red in.
+#
+# All fail on an ASSERTION, not on an import or a missing symbol — checked,
+# because `claude/RULES.md` says an arity/`AttributeError` red is not regression
+# coverage. `_nix_scan` is NEW in round 16, so
+# `test_the_probe_hedges_when_the_nix_scan_did_not_end_cleanly` would go red at
+# `ba321c06` with `AttributeError` and is filed as an invariant guard instead.
+#
+# 🔴 `test_the_toolchain_head_claim_is_true_of_the_rendered_brief` IS LISTED
+# UNDER TWO REFS, and that is a measurement rather than bookkeeping. At
+# `5bad0a0c` it fails on round 15's false COUNT ("at most ONCE"); at `ba321c06`
+# it fails on round 16's finding — the reworded clause is a claim about a STATE
+# and the guard drove only `delta`, the one state it is true in. Same test, two
+# different assertions, two different trees. It was NOT renamed: a rename would
+# quietly retire the `5bad0a0c` row rather than add to it.
+RED_AT_BASE_R16: frozenset[str] = frozenset({
+    "test_a_nested_indented_string_inside_an_interpolation_is_not_a_terminator",
+    "test_the_toolchain_head_claim_is_true_of_the_rendered_brief",
+    "test_the_python_absence_bar_does_not_point_at_a_bar_that_is_not_there",
+})
+
 RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "abc41024": RED_AT_BASE_R2,
     "d9eb36a8": RED_AT_BASE_R3,
@@ -7395,6 +7885,7 @@ RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "6349a8b9": RED_AT_BASE_R13,
     "9e23c379": RED_AT_BASE_R14,
     "5bad0a0c": RED_AT_BASE_R15,
+    "ba321c06": RED_AT_BASE_R16,
 }
 RED_AT_BASE: frozenset[str] = frozenset().union(*RED_AT_BASE_REFS.values())
 
@@ -7409,6 +7900,19 @@ INVARIANT_GUARDS_AND_LEDGERS = frozenset({
     # (which an indentation-only scan reads as one name, because a build
     # script's lines start at column 0).
     "test_the_flake_checks_probe_reads_an_output_and_not_the_word",
+    # 🔴 ROUND 16. Both would fail at `ba321c06` with `AttributeError` —
+    # `_nix_scan` does not exist there — which is a claim about a symbol's
+    # absence and not about any behaviour, the vacuous shape this module refuses
+    # to count. Their evidence is their own controls (the clean/dirty pair, and
+    # the code-survives-the-strip assertion beside the comment one) plus mutants
+    # V53-V56.
+    "test_the_probe_hedges_when_the_nix_scan_did_not_end_cleanly",
+    # 🔴 GREEN at `ba321c06`, MEASURED, and that IS its finding: the `#` row in
+    # `CHECKS_SHAPES_NOT_CODE` is rejected by the anchored regex alone, so it
+    # answers `None` at every revision and tests nothing about the stripper it
+    # is named for. This says so and pins the two `#` claims that are not
+    # walkable by the anchor.
+    "test_the_comment_stripper_is_reachable_in_its_own_right",
     # 🔴 GREEN at `5bad0a0c`, MEASURED — and that is exactly the finding. The
     # three probes it drives BEHAVE correctly there; what was missing was any
     # fixture that entered their branches, so `if tc.ci_suite: -> if True:`,
@@ -8036,6 +8540,60 @@ FIX_MATRIX = (
      "command not found` then reads exactly like a broken gate",
      "test_the_wrong_shell_diagnosis_covers_every_command_not_only_pytest",
      "RED@5bad0a0c", "V50 V51"),
+    # --------------------------------------------------------------------- #
+    # Round 16. Base `ba321c06`. Every row is one of round 15's own fixes with
+    # the CLASS still open one shape further out — which is the pattern worth
+    # naming: each previous round closed the instances it was shown.
+    # --------------------------------------------------------------------- #
+    ("r16/N1 the `''` lex needed a STACK, and round 15 gave it a flag. A `''` "
+     "that OPENS a nested string inside `${…}` was read as the OUTER string's "
+     "terminator, so `shellHook = '' ${lib.optionalString c '' … ''} '';` — an "
+     "ordinary nixpkgs idiom — promoted the interpolation body to CODE. Both "
+     "directions measured at `ba321c06`: a flake with NO checks output answered "
+     "['unit'] (a fenced `nix build` at a non-existent attribute), and one that "
+     "DOES declare checks answered None once the promoted region inverted "
+     "string parity. `foo'' = 1;`, a legal nix identifier, did the same",
+     "test_a_nested_indented_string_inside_an_interpolation_is_not_a_terminator",
+     "RED@ba321c06", "V53 V54"),
+    ("r16/N1b where the lexer cannot be sure the answer is now the HEDGE. Both "
+     "of N1's failures routed to a CONFIDENT answer — a fabricated name list "
+     "one way, a bolded 'no `checks` output' the other — so `_nix_scan` reports "
+     "whether it ended in a state a nix file can be in and the caller degrades "
+     "to `[]` above the parse, not inside it",
+     "test_the_probe_hedges_when_the_nix_scan_did_not_end_cleanly",
+     "GUARD", "V55"),
+    ("r16/nit the `#`-commented row in CHECKS_SHAPES_NOT_CODE is INERT: both "
+     "patterns are anchored `^[ \\t]*checks`, so it answers None at every "
+     "revision, stripper or no stripper, and reads as coverage of the comment "
+     "branch while providing none",
+     "test_the_comment_stripper_is_reachable_in_its_own_right",
+     "GUARD", "V56"),
+    ("r16/N2 round 15's non-degeneracy pin was `any(len(kinds) >= 2)`, which "
+     "one partition satisfied alone. Measured at `ba321c06`: cross-repo spanned "
+     "{private, shared} and repo-unknown {shared} — no NOT-PROBED scenario was "
+     "`unknown` kind at all — so a WHERE-TO-WORK-contradicting sentence keyed "
+     "on `worktree.kind == 'unknown'` in `_toolchain_not_probed` survived at "
+     "122 passed while the same sentence keyed on 'private' was killed. The "
+     "grid is now complete and the assertion asks for the whole row",
+     "test_the_toolchain_reason_is_true_in_every_scenario",
+     "RED@dd601793", "V52 V57 V58"),
+    ("r16/N3 the F2 reword put a state-dependent claim straight back into the "
+     "state-INDEPENDENT constant — 'the prose names it too, to say what was "
+     "read out of it', measured true in 6 scenarios, false in 5, flatly false "
+     "in 2 — and its guard drove `delta` alone, the one state it holds in. Both "
+     "halves fixed: the clause is the widest thing true everywhere, the guard "
+     "drives every scenario, and the constant is pinned WHOLE because two "
+     "rewordings in a row each replaced a false claim with another one",
+     "test_the_toolchain_head_claim_is_true_of_the_rendered_brief",
+     "RED@ba321c06", "V59"),
+    ("r16/N4 two dangling references in one bar: the completed-walk note "
+     "contrasted itself with 'the one above' when the branches are mutually "
+     "exclusive, and the wrong-shell bar opened with a `python3 -m pytest` "
+     "diagnosis three lines after the section said no python command is "
+     "prescribed. Fixed as the general rule — the python bar is emitted only "
+     "where a python command is fenced",
+     "test_the_python_absence_bar_does_not_point_at_a_bar_that_is_not_there",
+     "RED@ba321c06", "V60 V61"),
 )
 
 # A COLLAPSE floor, not a growth floor: a matrix emptied by a bad refactor
@@ -8059,7 +8617,9 @@ FIX_MATRIX = (
 # `len(FIX_MATRIX)` printed from an import, not seven added to the last sentence.
 # Round 15: m = 93 (printed from an import, NOT derived by adding this round's
 # rows to 77 — rounds 11-14 also added some), and 93 - max(1, 93 // 20) = 89.
-MIN_FIX_MATRIX_ROWS = 89
+# Round 16: m = 99 (printed from an import again, NOT 93 plus this round's six),
+# and 99 - min(50, max(1, 99 // 20)) = 99 - 4 = 95.
+MIN_FIX_MATRIX_ROWS = 95
 
 # 🔴 THE MUTANTS COLUMN IS AN EVIDENCE CLAIM, AND IT WAS UNGRADED.
 # `fix_matrix_problems` took `_mutants` and threw it away, so rewriting a

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -6242,6 +6242,28 @@ def test_the_python_absence_bar_does_not_point_at_a_bar_that_is_not_there(tmp_pa
     Driven over all THREE `py_tests` states, because "the bar is absent" is
     satisfied by a note that vanished and "the bar is present" by one that never
     varies. Both are the failure this pins.
+
+    🔴 …AND OVER EXACTLY ONE SHELL STATE, WHICH IS THE REACH THIS TEST HAS. Said
+    out loud, because the equality below is FALSE in the other shell state and
+    NOT for a defect. All three fixtures use `DEVRC_FLAKE`, which names pytest,
+    so all three take `_toolchain_shell_note`'s `shell` branch. Measured on the
+    fourth combination — `py_tests` FOUND with a flake that names no pytest, so
+    no dev shell is detected — a BARE `python3 -m pytest <paths>` IS fenced
+    (`_toolchain_pytest_lines` prefixes it with `shell`, which is then "") while
+    the python-specific bar is NOT emitted: `fenced_pytest=True,
+    diagnosed=False`, and `diagnosed == fenced_pytest` goes red.
+
+    That is scaffolding, not payload. The bare branch carries its own
+    `No module named pytest` diagnosis in its own wording, and
+    `test_the_wrong_shell_diagnosis_covers_every_command_not_only_pytest` is
+    what pins it. The two sibling assertions below are likewise spelled to the
+    shell branch's sentences ("…and not a broken gate", "in EVERY language"),
+    neither of which the bare branch's single sentence contains.
+
+    So the shell axis is now ASSERTED as a precondition rather than left
+    implied: a future no-shell fixture added to `trees` trips that assertion,
+    which names the reason, instead of tripping the equality and reading as a
+    real defect in the payload.
     """
     trees = {}
     for name, py_test in (("none", False), ("found", True)):
@@ -6282,6 +6304,23 @@ def test_the_python_absence_bar_does_not_point_at_a_bar_that_is_not_there(tmp_pa
     )
     # The python-specific diagnosis: present exactly where a python command is.
     for name, section in sections.items():
+        # 🔴 THE SHELL AXIS, PINNED RATHER THAN ASSUMED — see the docstring.
+        # Every assertion in this loop is spelled to `_toolchain_shell_note`'s
+        # SHELL branch. The BARE branch says all three things differently and
+        # the equality below is genuinely false there, so a no-shell fixture
+        # must fail HERE, naming the reason, and not there wearing the costume
+        # of a payload regression.
+        assert "Every command above is BARE on purpose" not in section, (
+            f"\n\npy_tests={name!r}: this fixture landed in the BARE (no dev "
+            f"shell detected) branch of `_toolchain_shell_note`. The three "
+            f"assertions below are spelled to the SHELL branch's wording and "
+            f"are FALSE in the bare branch WITHOUT any defect — measured: a "
+            f"no-shell repo with `py_tests=FOUND` fences a bare `python3 -m "
+            f"pytest` and emits no python-specific bar, so `diagnosed == "
+            f"fenced_pytest` goes red. The bare branch is pinned by "
+            f"`test_the_wrong_shell_diagnosis_covers_every_command_not_only_"
+            f"pytest`; pin it there, not by widening this loop:\n{section}"
+        )
         fenced_pytest = any("python3 -m pytest" in c
                             for c in toolchain_commands(section))
         diagnosed = "A bare `python3 -m pytest` failing" in section

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -5281,7 +5281,7 @@ def test_the_toolchain_reason_is_true_in_every_scenario():
 
 
 def test_the_toolchain_prescribes_only_commands_it_probed(tmp_path):
-    """🔴 REGRESSION. Red at `bd1572f3`, on a real target that has none of them.
+    """🔴 REGRESSION. Red at `9e23c379` — #1104 MERGED, and still red there.
 
     Every TOOLCHAIN command interpolated `facts.cwd_repo_dir` into devrc's OWN
     layout, so a brief for a PR in any other repository prescribed scripts that
@@ -6613,15 +6613,27 @@ RED_AT_BASE_R13: frozenset[str] = frozenset({
     "test_the_cross_repo_recipe_can_actually_be_run",
 })
 
-# 🔴 ROUND 14's base is `bd1572f3`, `origin/main` at the time. Measured the
-# same way — `git show bd1572f3:scripts/audit-dispatch.py` into a scratch tree
-# with THIS module copied in unchanged, `PYTHONDONTWRITEBYTECODE=1
-# -p no:cacheprovider`. Both fail on an ASSERTION, not on an import or an
-# arity error: the base script renders a TOOLCHAIN section fine, it just
-# renders devrc's layout into it whatever the target.
+# 🔴 ROUND 14's base is `9e23c379` — `origin/main` with #1104 ALREADY MERGED,
+# and NOT the tree this work started on. It began at `bd1572f3`; #1104 landed
+# mid-run, the branch was rebased onto it, and `bd1572f3` stopped being the
+# merge-base. A ledger still naming it would be a claim about a tree this
+# branch is not built on, so the matrix was RE-MEASURED at the new anchor
+# rather than carried over: `git show 9e23c379:scripts/audit-dispatch.py` into
+# a scratch tree with THIS module copied in unchanged,
+# `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider` -> **4 failed, 111 passed**.
+#
+# 🔴 AND THAT RE-MEASUREMENT IS THE WHOLE POINT: #1104 FIXED THIS SECTION AND
+# BOTH ROWS ARE STILL RED AT ITS MERGE COMMIT. It hedged the prose ("if this
+# repo has one", "exist in SOME repos and not others") and left all four
+# commands inside the FENCES and the `.envrc` sentence hardcoded — so at
+# `9e23c379` the first row still fails on `assert "nix develop" not in line`,
+# a wrapper measured to exit `No module named 'pytest'` on that very target,
+# and the second on the absent hand-over. Both fail on an ASSERTION, not on an
+# import or an arity error: the base script renders a TOOLCHAIN section fine,
+# it just renders devrc's layout into it whatever the target.
 #
 # 🔴 `test_the_flake_checks_probe_reads_an_output_and_not_the_word` is NOT
-# here, deliberately. `_flake_check_names` does not exist at `bd1572f3`, so it
+# here, deliberately. `_flake_check_names` does not exist at `9e23c379`, so it
 # would fail there with `AttributeError` — a claim about the symbol's absence
 # and not about any behaviour. That is the vacuous shape this module refuses to
 # count as regression coverage, so it is filed as an invariant guard and its
@@ -6641,13 +6653,13 @@ RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "28492af2": RED_AT_BASE_R7,
     "706a6b38": RED_AT_BASE_R9,
     "6349a8b9": RED_AT_BASE_R13,
-    "bd1572f3": RED_AT_BASE_R14,
+    "9e23c379": RED_AT_BASE_R14,
 }
 RED_AT_BASE: frozenset[str] = frozenset().union(*RED_AT_BASE_REFS.values())
 
 INVARIANT_GUARDS_AND_LEDGERS = frozenset({
     # 🔴 An invariant guard, NOT regression coverage — `_flake_check_names`
-    # does not exist at `bd1572f3`, so its red there would be an
+    # does not exist at `9e23c379`, so its red there would be an
     # `AttributeError` about a missing symbol rather than a wrong answer. Its
     # evidence is its own pair of controls, both taken from real files: the
     # `checks = pr.get(...)` line out of `homelab-infra`'s devShell heredoc
@@ -7178,7 +7190,7 @@ FIX_MATRIX = (
      "test_the_clone_grant_covers_only_the_write_the_recipe_makes",
      "RED@706a6b38", "V22 V28 V34"),
     # --------------------------------------------------------------------- #
-    # Round 14. Its base is `bd1572f3` — `origin/main` at the time.
+    # Round 14. Its base is `9e23c379` — `origin/main` with #1104 merged.
     # --------------------------------------------------------------------- #
     ("r14/1 every TOOLCHAIN command hardcoded devrc's own layout, so a brief "
      "for any other target prescribed scripts that do not exist there. "
@@ -7190,7 +7202,7 @@ FIX_MATRIX = (
      "suite. Four unrunnable prescriptions, one of them manufacturing the "
      "failure it then told the reader to disregard",
      "test_the_toolchain_prescribes_only_commands_it_probed",
-     "RED@bd1572f3", "V36 V38 V39"),
+     "RED@9e23c379", "V36 V38 V39"),
     ("r14/2 and the fix's own trap: cross-repo, the cwd IS a probeable "
      "repository, it is merely the WRONG one. Probing it yields a confident, "
      "fully-formed, entirely irrelevant command list — the same defect with a "
@@ -7198,7 +7210,7 @@ FIX_MATRIX = (
      "fabricated command costs a round and reads as a broken gate, while an "
      "absent one costs a lookup",
      "test_the_toolchain_prescribes_nothing_when_it_cannot_probe",
-     "RED@bd1572f3", "V40"),
+     "RED@9e23c379", "V40"),
     ("r14/3 the `checks` probe matched the WORD and not a flake OUTPUT: "
      "`checks = pr.get(\"statusCheckRollup\", [])`, inside a python heredoc in "
      "`homelab-infra`'s real devShell, answered \"this flake declares checks\" "


### PR DESCRIPTION
Takes the design decision **#1104 explicitly deferred to the tool's owner**:

> "A repo-AWARE toolchain section is the bigger fix and is deliberately not taken here — it needs that pin relaxed, which is a **design decision for the tool's owner**, not a side effect of a bug fix."

This is that decision, taken and evidenced, for you to accept or reject. **It rewrites `render_toolchain`, which #1104 just landed** — what I kept from it is called out below.

## The defect SURVIVES #1104

Re-measured on merged `origin/main` at `9e23c379` (#1104's own merge commit), against a real `homelab-infra` checkout. #1104 hedged the prose — *"if this repo has one"*, *"exist in SOME repos and not others"* — and left **all four commands inside the fences** and the `.envrc` sentence hardcoded:

| what the brief still emits at `9e23c379` | reality in `homelab-infra` |
|---|---|
| `nix develop <root> -c python3 -m pytest …` | **`ModuleNotFoundError: No module named 'pytest'`** — measured live |
| ``This repo's `.envrc` is `use opencode` `` | it is `use flake` **+** `use opencode` |
| `bash <worktree>/scripts/gate.sh --tier both` | no `scripts/gate.sh` |
| `nix build <worktree>#checks.x86_64-linux.{pytests,nodetests}` | flake declares **no** `checks` output (`pytest` appears **0** times in it) |

Hedging prose does not stop an auditor copying a fenced command.

### 🔴 The sharpest one, and it is new

The `pytest` wrapper **manufactures the very error whose own next paragraph says "do not report that as a finding."** The brief produces a failure and then instructs the reader to disregard the only true signal it produced. (`homelab-infra`'s real runner uses a **bare** `python3 -m pytest`, which works.) That item is absent from #1104 entirely.

## Design: detect, don't assume — and when you can't, prescribe NOTHING

`detect_repo_toolchain(root)` — `is_file`, a capped `read_text`, one bounded `os.walk`. No build, no `nix`, no network; **~3–4 ms/call** on both real repos. A probe that cannot answer answers *no*.

`toolchain_probe_root` is the **single** place deciding which checkout may be read, and it **reuses** the relation `WHERE TO WORK` already computed rather than deriving a second one. Cross-repo → root is `None` → **no fenced commands at all**, just an honest hand-over. A fabricated command costs the auditor a round and reads as a broken gate; an absent one costs a lookup.

The `checks` probe matches a flake **output**, not the word: the first regex matched `checks = pr.get("statusCheckRollup", [])` inside a python heredoc in `homelab-infra`'s real devShell — answering *"declares checks"* for a flake that declares none, which would have left the honest fallback unreachable.

### What I kept from #1104

**Its `nix eval …#checks.<system> --apply builtins.attrNames` discriminator**, deliberately, in **both** checks branches — see `CHECKS_DISCRIMINATOR`. It is the one thing there this file could not derive for itself: `_flake_check_names` is a regex and can be wrong in both directions, so the auditor needs a way to **check** this brief instead of trusting it. #1104's argument for `nix eval` over `nix flake show` is right and is why it **replaced** the `flake show` this branch first wrote — `nix eval` *errors outright*, where an empty listing cannot be told from a listing that failed. Its "absent is a fact about the REPO, not a finding about the PR" framing is kept too. Dropped: the hedging prose and the "may be `run-ci-suite.sh`" guess — superseded by detecting and naming the real runner as a runnable command.

## The scenario pin: split deliberately, and STRENGTHENED

`test_the_toolchain_reason_is_true_in_every_scenario` required the whole section byte-identical across every scenario. Target-repo content and audit scenario are **different axes** — the cross-repo scenarios hold no checkout of the PR's repo — so the two genuinely cannot coexist. The only ways to keep the old pin are to blind the generator (prescribe one layout everywhere — the defect) or to probe the **wrong** repository cross-repo (the defect, with a new source).

So the REASON moved into `TOOLCHAIN_HEAD` / `TOOLCHAIN_TAIL`: module-level **constants taking no argument**. State-independence is now **structural** — a state-dependent rationale is no longer merely unasserted, it is unwritable without deleting the constant.

The guard still drives every scenario and keeps its three phrase assertions over the full section. It **gained two checks the old one lacked**:
1. **identity** against the constant — the old equality never said *what* they all equalled, so re-deriving the reason from `facts` would have satisfied it under fixtures where `cwd_repo_dir` holds one value (exactly how round 6 was walked one level up);
2. **some scenario prescribes nothing and some prescribes something** — goes red if the detection ever becomes inert, or if the wrong repo is probed cross-repo.

## Verification

| | result |
|---|---|
| `test_audit_dispatch.py` | **115 passed** (111 + 4 new) |
| red at `9e23c379` (#1104 merged) | **4 failed, 111 passed** |
| mutation battery | **117 rows, all as expected** |
| devrc gate `--tier both` | **`GATE: RESULT=PASS exit=0`** · pytest `RESULT: PASS (exit=0)` · node `RESULT: PASS (exit=0)` · 19394/19396, 0 failed |

**Red-at-base, with error CLASS:**

| test | class at `9e23c379` |
|---|---|
| `test_the_toolchain_prescribes_only_commands_it_probed` | **AssertionError** (fires on `assert "nix develop" not in line`) |
| `test_the_toolchain_prescribes_nothing_when_it_cannot_probe` | **AssertionError** |
| `test_the_flake_checks_probe_reads_an_output_and_not_the_word` | AttributeError → filed as an **invariant guard**, *not* regression coverage |

The anchor is `9e23c379` rather than the current merge-base because it is #1104's own merge commit — and that it still describes the merge-base is **measured, not assumed**: `9e23c379:scripts/audit-dispatch.py` and `809486fa:scripts/audit-dispatch.py` are the same blob `0298a689`.

**Mutation findings I had to fix rather than explain away:**
- **V39 SURVIVED** on the first run. The module's devrc fixture `.envrc` **is** `use opencode` — a value that can only ever equal the constant cannot see a mutant that returns the constant. Added a fixture that says something else.
- The devrc flake fixture sat exactly on brace-depth 1, its own boundary, so nesting mutants were unobservable. Rebuilt to mirror the real file.
- `FAKE_REPO_DIR` was a `/fake/checkout/…` string: every probe would answer "absent" and the whole suite would grade one branch. Now a real devrc-shaped directory.
- V7 / V37 / C3 killer sets widened to couplings the battery **measured**, not predicted. C3 growing to include the toolchain tests is the evidence that `toolchain_probe_root` genuinely reuses one decision instead of computing a second.

**Scope of the local gate:** measured on the merged tree at `ebbe5eaa` + these commits. `main` moved twice more during the run (`ebbe5eaa` → `809486fa`); the branch is rebased onto `809486fa` and re-verified there (module 115, battery 117, both end-to-end blocks, `scripts/tests` collects 10710 against floor 10269 / ceiling 12836), but the **full** gate was not re-run after that last rebase — CI gates the final merge.

## End-to-end, on the final tree

**Target `ZacxDev/homelab-infra` #530** — no `gate.sh`, no flake `checks`, real `.envrc`, real runner, bare pytest:

```
### The commands — PROBED, not assumed

Everything below was read off `/home/zach/workspace/homelab-talos`, a checkout of
`ZacxDev/homelab-infra` — the repository this PR lives in. …

Run a SUBSET of the suite:

    python3 -m pytest <paths> -q -p no:cacheprovider

⚠ The command above is BARE on purpose: this brief did not detect a dev shell that
puts pytest on PATH for this repository (its `flake.nix` names no pytest anywhere),
and its `.envrc` is `use flake` + `use opencode`. 🔴 If it fails with **`No module
named pytest`** you are in the WRONG SHELL and not looking at a broken suite …

Run the repository's own gate …:

    bash <your worktree>/scripts/tests/run-ci-suite.sh

⚠ …/flake.nix declares **no `checks` output**, so this repository has no sandbox
tier — `nix build …#checks.x86_64-linux.…` would fail with an attribute error,
which is a fact about the REPO and not a finding about the PR. … if you want to
confirm it rather than trust it: `nix eval <your worktree>#checks.x86_64-linux
--apply builtins.attrNames` errors outright in a repo that has none.
```

**POSITIVE CONTROL — a devrc PR — still emits devrc's real commands, unchanged:**

```
    nix develop /home/zach/workspace/devrc -c python3 -m pytest <paths> -q -p no:cacheprovider
    nix develop /home/zach/workspace/devrc -c bash <your worktree>/scripts/gate.sh --tier both
    nix build <your worktree>#checks.x86_64-linux.pytests
    nix build <your worktree>#checks.x86_64-linux.nodetests
```

…with ``This repo's `.envrc` is `use opencode` `` — now **read**, not remembered. The fix has not blinded the generator to a repo that genuinely has these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
