### PR TITLE
feat(ci-speedup): measure what scripts/tests actually reads — the ceiling is 1.08x, so do not build rank 3 yet

### DIFF
--- a/claudedocs/measurement-scripts-tests-readsets.md
+++ b/claudedocs/measurement-scripts-tests-readsets.md
@@ -56,11 +56,13 @@ bound on skippability until someone has tried to break it again.
 
 ⚠ The last step, 1.01x → 1.02x, is the one exception and it was a POLICY
 change, not a defect fix: round 3 deleted the operand-based acquittal (four
-defects came out of guessing scope from argv) and restored an unambiguous `-C`
-rule. That let three files whose only opacity was `git -C <tmp fixture repo>
-<unknown verb>` leave OPAQUE — a command with `-C` at an absolute outside path
-demonstrably operates on another tree. Precision gained, not safety traded; the
-verdict is unchanged either way.
+defects came out of guessing scope from argv) and kept only `-C`. That let
+three files whose only opacity was `git -C <tmp fixture repo> <unknown verb>`
+leave OPAQUE — **for a command whose grammar defines `-C`**, an absolute
+outside value does name another tree. That qualifier is load-bearing and was
+missing here for one round: stated unqualified, it is the exact generalisation
+defect 10 below disproved. Precision gained, not safety traded; the verdict is
+unchanged either way.
 
 ### 🔴 The recommendation this produces: DO NOT BUILD RANK 3
 
@@ -147,7 +149,7 @@ DEVRC_READSET_OUT=/tmp/rs PYTHONPATH=$DEVRC/scripts \
 python3 scripts/lib/readset_classify.py /tmp/rs.*.json --json /tmp/readsets.json
 ```
 
-## This classifier reproduced the bug it exists to fix — nine times
+## This classifier reproduced the bug it exists to fix — ten times
 
 The pattern is the deliverable's real lesson. Every one matched *characters* or
 an *enumeration* rather than the operation actually performed:
@@ -176,6 +178,14 @@ an *enumeration* rather than the operation actually performed:
    blind spot, re-introduced through the exec path. Neither that set nor
    `_GIT_WRITERS` had any test: mutants emptying `_HARMLESS` and removing
    `init` from `_GIT_WRITERS` both **survived a full green suite**.
+
+10. Consulted `-C` before knowing the command, so ANY argv merely containing
+    the token was acquitted — `bash -c '… git -C /tmp/fx rev-parse …'`, where
+    it sits in **script text**, and `bash run-tests.sh -C /tmp/outdir`, where
+    it is another program's flag. 🔴 **Found inside the single acquittal round
+    3 kept BECAUSE it was supposed to be unambiguous** — it is unambiguous only
+    for a command whose grammar defines it. All 38 guards passed with the hole
+    open.
 
 Findings 1, 2 and 4 came from a mutation sweep that also showed **three guards
 were unreachable** — an earlier acquittal always won, so deleting the guard

--- a/claudedocs/measurement-scripts-tests-readsets.md
+++ b/claudedocs/measurement-scripts-tests-readsets.md
@@ -1,0 +1,139 @@
+# Measured: what `scripts/tests` actually reads — and what decomposing it is worth
+
+**Date:** 2026-08-30 · **Effort:** ci-speedup rank 2 · **Claim:** `ci-speedup-2`
+
+## Why this exists
+
+`claudedocs/handoff-ci-speedup.md` ranks "decompose `scripts/tests`" second and
+attaches a 🔴 to its own input:
+
+> The repo-wide-scanner classifier is NOT trustworthy. A regex for
+> `git ls-files` / `REPO_ROOT.rglob` said 32 of 139 files (394s, 29%); positive
+> and negative controls passed, but it over-classifies … The true always-run set
+> is between ~8s and 394s and needs **empirical** measurement (change an
+> unrelated file, see what fails), not another regex.
+
+This is that measurement. It is not a regex and it is not a perturbation run —
+it is a **read-set trace**: what each test file actually opens, lists, scans and
+spawns, recorded by a `sys.addaudithook` while the suite runs.
+
+## The answer
+
+143 of 143 collectible test files measured (the other 4 files in the directory
+are `conftest.py` and three `mutation_battery_*`/`mutants-*` harnesses, none of
+them collectible tests). Timing measured in a **separate, untraced** run so the
+hook's overhead is not in the numbers.
+
+| bucket | files | seconds | share |
+|---|---|---|---|
+| **ALWAYS-RUN** — proven to read the tree | 22 | 163.1s | 12.6% |
+| **OPAQUE** — read set UNKNOWN | 18 | 704.3s | 54.5% |
+| **scoped** — proven bounded | 93 | 425.9s | 32.9% |
+
+- **The proven always-run set is 163.1s.** The handoff bracketed it at "between
+  ~8s and 394s"; it lands in the lower half, and far below the 394s the regex
+  implied.
+- **Best-case speedup from a perfect path→target mapping: 1.49x.** The handoff
+  estimated rank 3 at "~1.7x alone but ~3.6x after". 1.49x is the measured
+  ceiling *today*, and the 3.6x is not reachable while OPAQUE stands.
+- Estimate history is now **3x → 1.7x → uncertain → 1.49x measured.**
+
+### Cross-check on the timing
+
+Summed per-test durations come to **1293.3s** visible, plus ~74s of sub-5ms
+durations pytest hides (27,012 of them, capped at 0.005s each). That totals
+~1367s — and the handoff independently quotes **1367s of work** for this suite,
+derived by a different route. The timing instrument reproduces a number nobody
+fed it.
+
+## 🔴 The finding that reframes rank 3
+
+**The blocker is not file layout. It is subprocess opacity.**
+
+54.5% of the suite's time sits in 18 files that shell out to `bash -c` /
+`python -c` with a repo-root cwd. The audit hook is per-interpreter and cannot
+see a child process's reads, so those files' dependencies are genuinely
+unmeasured — and a path→target mapping must fail safe and run them all. Two
+files are most of it:
+
+| file | time | bucket |
+|---|---|---|
+| `test_subsystem_store_api.py` | 313.3s | OPAQUE |
+| `test_run_tests_floors.py` | 171.2s | OPAQUE |
+| `test_run_tests_preconditions.py` | 77.3s | OPAQUE |
+| `test_drift_check.py` | 62.7s | OPAQUE |
+
+Resolving the top two alone adjudicates ~37% of total suite time. That is a
+better next move than splitting directories, and it is cheap to state as a
+target: make those tests' repo reads visible (declare them, or run the child
+under a tracer), then re-run this measurement.
+
+**`test_drift_check.py` is the specific file the handoff named as the regex's
+false positive.** It is not ALWAYS-RUN here. It is OPAQUE — its repo-wide-ness
+is *unproven*, which is a different and more honest answer than either the
+regex's "repo-wide" or a bare "scoped".
+
+## Why OPAQUE is its own bucket
+
+Folding unknown into always-run would inflate a number that then reads as
+measured; folding it into scoped would be unsafe. RULES.md is explicit that
+UNMEASURED must not be folded into a clean count, so it is reported separately
+and a consumer must treat it as must-run.
+
+## The tools
+
+- `scripts/testlib/readset_plugin.py` — the tracer. Opt in with
+  `-p testlib.readset_plugin` and `DEVRC_READSET_OUT=<prefix>`; writes one JSON
+  shard per xdist worker. Attributes **both** collection-time (module-level) and
+  runtest-time reads, because several files in this corpus read `nix/home.nix`
+  at import.
+- `scripts/lib/readset_classify.py` — merges shards and assigns buckets.
+- `scripts/tests/test_readset_classify.py` — 15 guards, every one pinning a bug
+  this classifier actually shipped.
+
+Reproduce:
+
+```bash
+DEVRC_READSET_OUT=/tmp/rs PYTHONPATH=$DEVRC/scripts \
+  python3 -m pytest scripts/tests -q -p no:cacheprovider \
+  -p testlib.nolaunch_plugin -p testlib.spool_plugin \
+  -p testlib.gitenv_plugin -p testlib.nogit_plugin \
+  -p testlib.readset_plugin -n 4 --dist loadfile
+python3 scripts/lib/readset_classify.py /tmp/rs.*.json --json readsets.json
+```
+
+## What this cannot see — state these with any claim
+
+- **Reads inside a subprocess.** The whole OPAQUE bucket. Argv and cwd are
+  recorded; the child's own `open` calls are not.
+- **A test whose outcome depends on a file it never reads** — e.g. one asserting
+  a count someone else computed. No read-tracer can see that. Perturbation can,
+  and has the complementary blind spot (an innocuous edit does not trip a
+  scanner that only fails on violations). Neither method is sufficient alone.
+- **One run.** These are single-observation read sets; a test with a
+  data-dependent branch could read more on another run. The direction of that
+  error is under-classification, which is the unsafe one.
+
+## Building the classifier reproduced the very bug it exists to fix — four times
+
+Worth recording, because the pattern is the point. Each draft matched
+*characters* rather than *operations*, exactly as the original regex did:
+
+1. Matched the bare tool name → `git init -q /tmp/x` scored as a repo scan.
+2. Matched a read verb anywhere in argv → a stub binary invoked as
+   `/tmp/.../bw --nointeraction status` scored as a repo scan.
+3. Same → `bash -c '<script mentioning git log>'` scored as a repo scan, off the
+   **script text**.
+4. Took the first non-flag token as the git subcommand → `git -C scripts
+   ls-files` read as subcommand "scripts" and was **acquitted**. This one is
+   under-classification: it moved **15 files** out of ALWAYS-RUN. Fixing it took
+   the count 7 → 22 and the always-run time 104.7s → 163.1s.
+
+A mutation sweep found 1, 2 and 4; three of the guards were **unreachable** —
+an earlier acquittal always won, so deleting the guard changed nothing and the
+test that "covered" it stayed green. A `-C` branch was also found to be dead
+code (never the sole acquitter) and deleted rather than left reading as
+coverage.
+
+**A classifier built to fix over-classification that itself over-classifies is
+worse than none, because its number reads as measured.**

--- a/claudedocs/measurement-scripts-tests-readsets.md
+++ b/claudedocs/measurement-scripts-tests-readsets.md
@@ -1,4 +1,4 @@
-# Measured: what `scripts/tests` actually reads — and what decomposing it is worth
+# Measured: what `scripts/tests` actually reads — and why decomposing it buys ~8%
 
 **Date:** 2026-08-30 · **Effort:** ci-speedup rank 2 · **Claim:** `ci-speedup-2`
 
@@ -13,83 +13,101 @@ attaches a 🔴 to its own input:
 > is between ~8s and 394s and needs **empirical** measurement (change an
 > unrelated file, see what fails), not another regex.
 
-This is that measurement. It is not a regex and it is not a perturbation run —
-it is a **read-set trace**: what each test file actually opens, lists, scans and
-spawns, recorded by a `sys.addaudithook` while the suite runs.
+This is that measurement — a **read-set trace**, not a regex and not
+perturbation: a `sys.addaudithook` records what each test file opens, lists,
+scans and spawns while the suite runs.
 
 ## The answer
 
-143 of 143 collectible test files measured (the other 4 files in the directory
-are `conftest.py` and three `mutation_battery_*`/`mutants-*` harnesses, none of
-them collectible tests). Timing measured in a **separate, untraced** run so the
-hook's overhead is not in the numbers.
+**All 144 test files in `scripts/tests` classified.** Timing comes from a
+separate, untraced run so the hook's overhead is not in the numbers.
 
-| bucket | files | seconds | share |
-|---|---|---|---|
-| **ALWAYS-RUN** — proven to read the tree | 22 | 163.1s | 12.6% |
-| **OPAQUE** — read set UNKNOWN | 18 | 704.3s | 54.5% |
-| **scoped** — proven bounded | 93 | 425.9s | 32.9% |
+🔴 **TWO DENOMINATORS, NAMED — they are not the same number.** 144 files are
+classified; only **133** have timing pytest will show, because `--durations`
+hides everything under 5 ms. An earlier draft of this table quoted the timing
+denominator's file counts under the classification's total and published
+`22 + 18 + 93 = 133` against a claimed 143. Both halves are given below.
 
-- **The proven always-run set is 163.1s.** The handoff bracketed it at "between
-  ~8s and 394s"; it lands in the lower half, and far below the 394s the regex
-  implied.
-- **Best-case speedup from a perfect path→target mapping: 1.49x.** The handoff
-  estimated rank 3 at "~1.7x alone but ~3.6x after". 1.49x is the measured
-  ceiling *today*, and the 3.6x is not reachable while OPAQUE stands.
-- Estimate history is now **3x → 1.7x → uncertain → 1.49x measured.**
+| bucket | files | of which timed | seconds | share of timed |
+|---|---|---|---|---|
+| **ALWAYS-RUN** — proven to read the tree | 27 | 27 | 185.5s | 14.3% |
+| **OPAQUE** — read set UNKNOWN | 61 | 60 | 1010.2s | 78.1% |
+| **scoped** — proven bounded | 56 | 46 | 97.6s | 7.5% |
+| total | **144** | **133** | 1293.3s | |
 
-### Cross-check on the timing
+- **Best-case ceiling for a perfect path→target mapping: 1.08x.**
+- Estimate history: **3x → 1.7x → uncertain → 1.49x → 1.08x measured.** The
+  1.49x was this document's own first answer and it was wrong; see below.
+- The handoff estimated rank 3 at "~1.7x alone but ~3.6x after". Neither is
+  reachable. **Only 7.5% of this suite's time is provably skippable today.**
 
-Summed per-test durations come to **1293.3s** visible, plus ~74s of sub-5ms
-durations pytest hides (27,012 of them, capped at 0.005s each). That totals
-~1367s — and the handoff independently quotes **1367s of work** for this suite,
-derived by a different route. The timing instrument reproduces a number nobody
-fed it.
+### 🔴 The recommendation this produces: DO NOT BUILD RANK 3 YET
 
-## 🔴 The finding that reframes rank 3
+A path→target mapping built on today's tree buys **8%**. The work that raises
+its ceiling is making the opaque subprocesses legible — until then the mapping
+is a large mechanism guarding a rounding error, and every unmeasured file it
+inherits is a chance to skip a test that should have run.
 
-**The blocker is not file layout. It is subprocess opacity.**
+## 🔴 Subprocess opacity is the whole story
 
-54.5% of the suite's time sits in 18 files that shell out to `bash -c` /
-`python -c` with a repo-root cwd. The audit hook is per-interpreter and cannot
-see a child process's reads, so those files' dependencies are genuinely
-unmeasured — and a path→target mapping must fail safe and run them all. Two
-files are most of it:
+**78.1% of suite time** is 61 files that spawn a child process at a repo cwd
+whose reads this tracer cannot see. The audit hook is per-interpreter; a child's
+own `open` calls are invisible. We record argv and cwd, and a consumer must
+treat such a file as must-run.
 
-| file | time | bucket |
-|---|---|---|
-| `test_subsystem_store_api.py` | 313.3s | OPAQUE |
-| `test_run_tests_floors.py` | 171.2s | OPAQUE |
-| `test_run_tests_preconditions.py` | 77.3s | OPAQUE |
-| `test_drift_check.py` | 62.7s | OPAQUE |
+The biggest single contributors are `test_subsystem_store_api.py` and
+`test_run_tests_floors.py`. Making the top few legible — by declaring their repo
+reads, or running the child under a tracer — decides more than any directory
+split, and is the prerequisite for rank 3 being worth building.
 
-Resolving the top two alone adjudicates ~37% of total suite time. That is a
-better next move than splitting directories, and it is cheap to state as a
-target: make those tests' repo reads visible (declare them, or run the child
-under a tracer), then re-run this measurement.
+`test_drift_check.py`, the file the handoff named as the regex's false positive,
+is **OPAQUE** here — not ALWAYS-RUN. "Unproven" is a different and more honest
+answer than either the regex's "repo-wide" or a bare "scoped".
 
-**`test_drift_check.py` is the specific file the handoff named as the regex's
-false positive.** It is not ALWAYS-RUN here. It is OPAQUE — its repo-wide-ness
-is *unproven*, which is a different and more honest answer than either the
-regex's "repo-wide" or a bare "scoped".
+## Why OPAQUE is its own bucket, and why it is the DEFAULT
 
-## Why OPAQUE is its own bucket
+Folding unknown into always-run inflates a number that then reads as measured;
+folding it into scoped is unsafe. RULES.md is explicit that UNMEASURED must not
+be folded into a clean count.
 
-Folding unknown into always-run would inflate a number that then reads as
-measured; folding it into scoped would be unsafe. RULES.md is explicit that
-UNMEASURED must not be folded into a clean count, so it is reported separately
-and a consumer must treat it as must-run.
+🔴 **Opacity is the fall-through, not an enumerated list.** The first version
+named the interpreters it considered opaque (`bash`, `python3`, …) and keyed on
+the literal token `-c`. That implied everything unnamed was transparent, which
+is backwards: a nested `python3 -m pytest <repo dir>` and a
+`bash <repo script> <REPO_ROOT>` — the corpus's two most common opaque shapes —
+matched neither branch and were published as "scoped, proven bounded". Only a
+**recognised, adjudicated** command may now be scored clean.
+
+## What this cannot see — state these with any claim
+
+- **Reads inside a subprocess.** The entire OPAQUE bucket.
+- 🔴 **Stat-only dependencies.** CPython raises **no audit event** for
+  `os.stat`/`os.lstat`/`Path.exists()`/`Path.is_dir()`/`os.path.exists`
+  (measured on 3.12.14, the gate's interpreter). A guard whose only dependency
+  is `(REPO_ROOT / "scripts" / "x.sh").exists()` records an **empty** read set
+  and classifies as bounded — so adding or deleting the very file it polices
+  re-runs nothing. The corpus contains this shape. An earlier version listed
+  `os.stat` in the traced-event set, where it raised nothing while *reading as*
+  coverage.
+- **Symlinks are not followed** — `_rel` avoids `resolve()` so the hook cannot
+  re-enter, so a read reached through a symlink is attributed to the link path.
+- **A test whose outcome depends on a file it never reads** — e.g. one asserting
+  a count someone else computed. No read-tracer can see that; perturbation can,
+  and has the complementary blind spot (an innocuous edit does not trip a
+  scanner that only fails on violations). Neither method suffices alone.
+- **One run.** Single-observation read sets; a data-dependent branch could read
+  more next time. That error direction is under-classification, the unsafe one.
 
 ## The tools
 
 - `scripts/testlib/readset_plugin.py` — the tracer. Opt in with
-  `-p testlib.readset_plugin` and `DEVRC_READSET_OUT=<prefix>`; writes one JSON
-  shard per xdist worker. Attributes **both** collection-time (module-level) and
-  runtest-time reads, because several files in this corpus read `nix/home.nix`
-  at import.
-- `scripts/lib/readset_classify.py` — merges shards and assigns buckets.
-- `scripts/tests/test_readset_classify.py` — 15 guards, every one pinning a bug
-  this classifier actually shipped.
+  `-p testlib.readset_plugin` and `DEVRC_READSET_OUT=<prefix>`; one JSON shard
+  per xdist worker. Attributes **both** collection-time (module-level) and
+  runtest-time reads, because several files here read `nix/home.nix` at import.
+  It is inert unless that `-p` is passed.
+- `scripts/lib/readset_classify.py` — merges shards, assigns buckets.
+- `scripts/tests/test_readset_classify.py` — 27 guards, each pinning a defect
+  one of these two files actually shipped.
 
 Reproduce:
 
@@ -99,41 +117,43 @@ DEVRC_READSET_OUT=/tmp/rs PYTHONPATH=$DEVRC/scripts \
   -p testlib.nolaunch_plugin -p testlib.spool_plugin \
   -p testlib.gitenv_plugin -p testlib.nogit_plugin \
   -p testlib.readset_plugin -n 4 --dist loadfile
-python3 scripts/lib/readset_classify.py /tmp/rs.*.json --json readsets.json
+python3 scripts/lib/readset_classify.py /tmp/rs.*.json --json /tmp/readsets.json
 ```
 
-## What this cannot see — state these with any claim
+## This classifier reproduced the bug it exists to fix — seven times
 
-- **Reads inside a subprocess.** The whole OPAQUE bucket. Argv and cwd are
-  recorded; the child's own `open` calls are not.
-- **A test whose outcome depends on a file it never reads** — e.g. one asserting
-  a count someone else computed. No read-tracer can see that. Perturbation can,
-  and has the complementary blind spot (an innocuous edit does not trip a
-  scanner that only fails on violations). Neither method is sufficient alone.
-- **One run.** These are single-observation read sets; a test with a
-  data-dependent branch could read more on another run. The direction of that
-  error is under-classification, which is the unsafe one.
+The pattern is the deliverable's real lesson. Every one matched *characters* or
+an *enumeration* rather than the operation actually performed:
 
-## Building the classifier reproduced the very bug it exists to fix — four times
-
-Worth recording, because the pattern is the point. Each draft matched
-*characters* rather than *operations*, exactly as the original regex did:
-
-1. Matched the bare tool name → `git init -q /tmp/x` scored as a repo scan.
-2. Matched a read verb anywhere in argv → a stub binary invoked as
-   `/tmp/.../bw --nointeraction status` scored as a repo scan.
-3. Same → `bash -c '<script mentioning git log>'` scored as a repo scan, off the
-   **script text**.
+1. Matched the bare tool name → `git init -q /tmp/x` scored a repo scan.
+2. Matched a read verb anywhere in argv → a stub invoked as
+   `/tmp/.../bw --nointeraction status` scored a repo scan.
+3. Same, off **script text** inside `bash -c '<script mentioning git log>'`.
 4. Took the first non-flag token as the git subcommand → `git -C scripts
-   ls-files` read as subcommand "scripts" and was **acquitted**. This one is
-   under-classification: it moved **15 files** out of ALWAYS-RUN. Fixing it took
-   the count 7 → 22 and the always-run time 104.7s → 163.1s.
+   ls-files` read as subcommand "scripts" and was **acquitted**.
+5. Keyed OPAQUE on the literal `-c` → nested `pytest <repo dir>` and
+   `bash <repo script>` scored "proven bounded".
+6. Acquitted on argv[0] being an absolute path outside the repo → real
+   `/nix/store/.../git ls-files` scans of this tree acquitted.
+7. Required cwd to be exactly `.` → a scan run with `cwd=scripts` acquitted.
 
-A mutation sweep found 1, 2 and 4; three of the guards were **unreachable** —
-an earlier acquittal always won, so deleting the guard changed nothing and the
-test that "covered" it stayed green. A `-C` branch was also found to be dead
-code (never the sole acquitter) and deleted rather than left reading as
-coverage.
+Findings 1, 2 and 4 were caught by a mutation sweep that also showed **three
+guards were unreachable** — an earlier acquittal always won, so deleting the
+guard changed nothing while its "covering" test stayed green. Findings 5, 6 and
+7, plus the `os.stat` and two `_rel` defects, came from an adversarial audit
+that reproduced them on **real corpus files**, not invented argv.
 
-**A classifier built to fix over-classification that itself over-classifies is
-worse than none, because its number reads as measured.**
+🔴 **And the fix round introduced its own regression, in the unsafe direction.**
+Switching the operand check to a separator-terminated prefix made REPO_ROOT
+itself compare as outside the repo — `/…/devrc` does not start with `/…/devrc/`
+— silently acquitting `git -C <REPO_ROOT> ls-files`, the most common way this
+corpus spells a scan. ALWAYS-RUN fell 22 → 9 and it was caught only by diffing
+the two classification runs against each other, not by any test.
+
+Two pre-existing tests had to have their assertions **inverted**: they asserted
+that an absolute-path binary was acquitted, and that a same-directory fixture
+was not a dependency. Both passed. Both were wrong.
+
+**A classifier built to fix over-classification that itself misclassifies is
+worse than none, because its number reads as measured.** That is why every
+number above is stated with its denominator and its blind spots.

--- a/claudedocs/measurement-scripts-tests-readsets.md
+++ b/claudedocs/measurement-scripts-tests-readsets.md
@@ -133,7 +133,7 @@ matched neither branch and were published as "scoped, proven bounded". Only a
   runtest-time reads, because several files here read `nix/home.nix` at import.
   It is inert unless that `-p` is passed.
 - `scripts/lib/readset_classify.py` — merges shards, assigns buckets.
-- `scripts/tests/test_readset_classify.py` — 38 guards, each pinning a defect
+- `scripts/tests/test_readset_classify.py` — 40 guards, each pinning a defect
   one of these two files actually shipped.
 
 Reproduce:

--- a/claudedocs/measurement-scripts-tests-readsets.md
+++ b/claudedocs/measurement-scripts-tests-readsets.md
@@ -1,4 +1,4 @@
-# Measured: what `scripts/tests` actually reads — and why decomposing it buys ~8%
+# Measured: what `scripts/tests` actually reads — and why decomposing it buys ~1%
 
 **Date:** 2026-08-30 · **Effort:** ci-speedup rank 2 · **Claim:** `ci-speedup-2`
 
@@ -31,26 +31,42 @@ denominator's file counts under the classification's total and published
 | bucket | files | of which timed | seconds | share of timed |
 |---|---|---|---|---|
 | **ALWAYS-RUN** — proven to read the tree | 27 | 27 | 185.5s | 14.3% |
-| **OPAQUE** — read set UNKNOWN | 61 | 60 | 1010.2s | 78.1% |
-| **scoped** — proven bounded | 56 | 46 | 97.6s | 7.5% |
+| **OPAQUE** — read set UNKNOWN | 79 | 78 | 1096.4s | 84.8% |
+| **scoped** — proven bounded | 38 | 28 | 11.4s | 0.9% |
 | total | **144** | **133** | 1293.3s | |
 
-- **Best-case ceiling for a perfect path→target mapping: 1.08x.**
-- Estimate history: **3x → 1.7x → uncertain → 1.49x → 1.08x measured.** The
-  1.49x was this document's own first answer and it was wrong; see below.
+- **Best-case ceiling for a perfect path→target mapping: 1.01x.**
+- **99.1% of this suite's time must run on any change.** Provably skippable:
+  **11.4 seconds.**
 - The handoff estimated rank 3 at "~1.7x alone but ~3.6x after". Neither is
-  reachable. **Only 7.5% of this suite's time is provably skippable today.**
+  reachable, and neither is anything close to them.
 
-### 🔴 The recommendation this produces: DO NOT BUILD RANK 3 YET
+### 🔴 Estimate history — and why the direction is the finding
 
-A path→target mapping built on today's tree buys **8%**. The work that raises
-its ceiling is making the opaque subprocesses legible — until then the mapping
-is a large mechanism guarding a rounding error, and every unmeasured file it
-inherits is a chance to skip a test that should have run.
+**3x → 1.7x → uncertain → 1.49x → 1.08x → 1.01x.**
+
+The last three are this document's own successive answers, each corrected by an
+adversarial audit round. **Every correction moved files OUT of `scoped`, never
+into it.** That one-directional drift is itself the result: a read-tracer's
+natural failure mode is to under-record — anything it cannot see looks like an
+absence of dependency, which reads as "bounded". A classifier built on one will
+be optimistic by construction, and will keep being optimistic in ways that only
+adversarial review surfaces. Treat any future number from this tool as an
+UPPER bound on skippability until someone has tried to break it again.
+
+### 🔴 The recommendation this produces: DO NOT BUILD RANK 3
+
+A path→target mapping built on today's tree buys **1%** — eleven seconds of a
+1293-second suite. It would be a large, safety-critical mechanism guarding a
+rounding error, inheriting 79 unmeasured files as chances to skip a test that
+should have run.
+
+The work that unlocks it is making the opaque subprocesses legible. That is a
+different, smaller, and far better-scoped task than decomposing a directory.
 
 ## 🔴 Subprocess opacity is the whole story
 
-**78.1% of suite time** is 61 files that spawn a child process at a repo cwd
+**84.8% of suite time** is 79 files that spawn a child process at a repo cwd
 whose reads this tracer cannot see. The audit hook is per-interpreter; a child's
 own `open` calls are invisible. We record argv and cwd, and a consumer must
 treat such a file as must-run.
@@ -89,8 +105,11 @@ matched neither branch and were published as "scoped, proven bounded". Only a
   re-runs nothing. The corpus contains this shape. An earlier version listed
   `os.stat` in the traced-event set, where it raised nothing while *reading as*
   coverage.
-- **Symlinks are not followed** — `_rel` avoids `resolve()` so the hook cannot
-  re-enter, so a read reached through a symlink is attributed to the link path.
+- **Symlinks are not followed** — `_rel` avoids `resolve()`, so a read reached
+  through a symlink is attributed to the link, not the target. (An earlier note
+  said `resolve()` was avoided because it re-enters the audit hook. That was
+  false: `Path.resolve()` raises no audit event either. The real cost is
+  syscalls on a hot path — a different argument, and the honest one.)
 - **A test whose outcome depends on a file it never reads** — e.g. one asserting
   a count someone else computed. No read-tracer can see that; perturbation can,
   and has the complementary blind spot (an innocuous edit does not trip a
@@ -106,7 +125,7 @@ matched neither branch and were published as "scoped, proven bounded". Only a
   runtest-time reads, because several files here read `nix/home.nix` at import.
   It is inert unless that `-p` is passed.
 - `scripts/lib/readset_classify.py` — merges shards, assigns buckets.
-- `scripts/tests/test_readset_classify.py` — 27 guards, each pinning a defect
+- `scripts/tests/test_readset_classify.py` — 34 guards, each pinning a defect
   one of these two files actually shipped.
 
 Reproduce:
@@ -120,7 +139,7 @@ DEVRC_READSET_OUT=/tmp/rs PYTHONPATH=$DEVRC/scripts \
 python3 scripts/lib/readset_classify.py /tmp/rs.*.json --json /tmp/readsets.json
 ```
 
-## This classifier reproduced the bug it exists to fix — seven times
+## This classifier reproduced the bug it exists to fix — nine times
 
 The pattern is the deliverable's real lesson. Every one matched *characters* or
 an *enumeration* rather than the operation actually performed:
@@ -136,19 +155,34 @@ an *enumeration* rather than the operation actually performed:
 6. Acquitted on argv[0] being an absolute path outside the repo → real
    `/nix/store/.../git ls-files` scans of this tree acquitted.
 7. Required cwd to be exactly `.` → a scan run with `cwd=scripts` acquitted.
+8. Let the operand acquittal run BEFORE the fall-through, making it the only
+   escape hatch from OPAQUE: **18,806 execs across 68 of 144 files**, leaving
+   15 of the 56 then-"proven bounded" files holding an acquitted
+   `bash`/`python3`/`node` child at a repo cwd — two of them running
+   `bash <copy of run-tests.sh> <REPO_ROOT>`, a walk of the entire repo.
+   🔴 **Same defect class as #5, in the very commit written to fix #5, reached
+   by the other route — and the document shipped in that commit asserted it
+   was closed.**
+9. Put `test` and `which` in a set documented as "reads nothing of this tree".
+   `test -f scripts/drift-check.sh` stats this tree — the module's own stat
+   blind spot, re-introduced through the exec path. Neither that set nor
+   `_GIT_WRITERS` had any test: mutants emptying `_HARMLESS` and removing
+   `init` from `_GIT_WRITERS` both **survived a full green suite**.
 
-Findings 1, 2 and 4 were caught by a mutation sweep that also showed **three
-guards were unreachable** — an earlier acquittal always won, so deleting the
-guard changed nothing while its "covering" test stayed green. Findings 5, 6 and
-7, plus the `os.stat` and two `_rel` defects, came from an adversarial audit
-that reproduced them on **real corpus files**, not invented argv.
+Findings 1, 2 and 4 came from a mutation sweep that also showed **three guards
+were unreachable** — an earlier acquittal always won, so deleting the guard
+changed nothing while its "covering" test stayed green. Findings 5–7 and the
+`os.stat` and `_rel` defects came from a first adversarial audit; 8 and 9 from
+a second, blind delta audit. All were reproduced on **real corpus files**, not
+invented argv.
 
-🔴 **And the fix round introduced its own regression, in the unsafe direction.**
-Switching the operand check to a separator-terminated prefix made REPO_ROOT
-itself compare as outside the repo — `/…/devrc` does not start with `/…/devrc/`
-— silently acquitting `git -C <REPO_ROOT> ls-files`, the most common way this
-corpus spells a scan. ALWAYS-RUN fell 22 → 9 and it was caught only by diffing
-the two classification runs against each other, not by any test.
+🔴 **Both fix rounds introduced their own regressions, both unsafe.** Round 1's
+separator-terminated prefix made REPO_ROOT itself compare as outside the repo
+— `/…/devrc` does not start with `/…/devrc/` — silently acquitting
+`git -C <REPO_ROOT> ls-files`, the commonest scan spelling here; ALWAYS-RUN
+fell 22 → 9, caught only by diffing two classification runs, not by any test.
+Round 2's is #8 above. **Budget for this: a fix round is a code change and
+re-opens the verification gate.**
 
 Two pre-existing tests had to have their assertions **inverted**: they asserted
 that an absolute-path binary was acquitted, and that a same-directory fixture

--- a/claudedocs/measurement-scripts-tests-readsets.md
+++ b/claudedocs/measurement-scripts-tests-readsets.md
@@ -1,4 +1,4 @@
-# Measured: what `scripts/tests` actually reads — and why decomposing it buys ~1%
+# Measured: what `scripts/tests` actually reads — and why decomposing it buys ~2%
 
 **Date:** 2026-08-30 · **Effort:** ci-speedup rank 2 · **Claim:** `ci-speedup-2`
 
@@ -30,35 +30,43 @@ denominator's file counts under the classification's total and published
 
 | bucket | files | of which timed | seconds | share of timed |
 |---|---|---|---|---|
-| **ALWAYS-RUN** — proven to read the tree | 27 | 27 | 185.5s | 14.3% |
-| **OPAQUE** — read set UNKNOWN | 79 | 78 | 1096.4s | 84.8% |
-| **scoped** — proven bounded | 38 | 28 | 11.4s | 0.9% |
+| **ALWAYS-RUN** — proven to read the tree | 28 | 28 | 193.6s | 15.0% |
+| **OPAQUE** — read set UNKNOWN | 75 | 74 | 1078.3s | 83.4% |
+| **scoped** — proven bounded | 41 | 31 | 21.4s | 1.7% |
 | total | **144** | **133** | 1293.3s | |
 
-- **Best-case ceiling for a perfect path→target mapping: 1.01x.**
-- **99.1% of this suite's time must run on any change.** Provably skippable:
-  **11.4 seconds.**
+- **Best-case ceiling for a perfect path→target mapping: 1.02x.**
+- **98.3% of this suite's time must run on any change.** Provably skippable:
+  **21.4 seconds.**
 - The handoff estimated rank 3 at "~1.7x alone but ~3.6x after". Neither is
   reachable, and neither is anything close to them.
 
 ### 🔴 Estimate history — and why the direction is the finding
 
-**3x → 1.7x → uncertain → 1.49x → 1.08x → 1.01x.**
+**3x → 1.7x → uncertain → 1.49x → 1.08x → 1.01x → 1.02x.**
 
-The last three are this document's own successive answers, each corrected by an
-adversarial audit round. **Every correction moved files OUT of `scoped`, never
-into it.** That one-directional drift is itself the result: a read-tracer's
-natural failure mode is to under-record — anything it cannot see looks like an
-absence of dependency, which reads as "bounded". A classifier built on one will
-be optimistic by construction, and will keep being optimistic in ways that only
-adversarial review surfaces. Treat any future number from this tool as an
-UPPER bound on skippability until someone has tried to break it again.
+The last four are this document's own successive answers, each corrected by an
+adversarial audit round. **The three corrections that fixed a DEFECT all moved
+files out of `scoped`; none ever moved files in.** That one-directional drift
+is the result: a read-tracer under-records by nature — anything it cannot see
+looks like an absence of dependency, which reads as "bounded" — so a classifier
+built on one is optimistic by construction, and keeps being optimistic in ways
+only adversarial review surfaces. Treat any number from this tool as an UPPER
+bound on skippability until someone has tried to break it again.
+
+⚠ The last step, 1.01x → 1.02x, is the one exception and it was a POLICY
+change, not a defect fix: round 3 deleted the operand-based acquittal (four
+defects came out of guessing scope from argv) and restored an unambiguous `-C`
+rule. That let three files whose only opacity was `git -C <tmp fixture repo>
+<unknown verb>` leave OPAQUE — a command with `-C` at an absolute outside path
+demonstrably operates on another tree. Precision gained, not safety traded; the
+verdict is unchanged either way.
 
 ### 🔴 The recommendation this produces: DO NOT BUILD RANK 3
 
-A path→target mapping built on today's tree buys **1%** — eleven seconds of a
-1293-second suite. It would be a large, safety-critical mechanism guarding a
-rounding error, inheriting 79 unmeasured files as chances to skip a test that
+A path→target mapping built on today's tree buys **under 2%** — twenty-one
+seconds of a 1293-second suite. It would be a large, safety-critical mechanism guarding a
+rounding error, inheriting 75 unmeasured files as chances to skip a test that
 should have run.
 
 The work that unlocks it is making the opaque subprocesses legible. That is a
@@ -66,7 +74,7 @@ different, smaller, and far better-scoped task than decomposing a directory.
 
 ## 🔴 Subprocess opacity is the whole story
 
-**84.8% of suite time** is 79 files that spawn a child process at a repo cwd
+**83.4% of suite time** is 75 files that spawn a child process at a repo cwd
 whose reads this tracer cannot see. The audit hook is per-interpreter; a child's
 own `open` calls are invisible. We record argv and cwd, and a consumer must
 treat such a file as must-run.
@@ -125,7 +133,7 @@ matched neither branch and were published as "scoped, proven bounded". Only a
   runtest-time reads, because several files here read `nix/home.nix` at import.
   It is inert unless that `-p` is passed.
 - `scripts/lib/readset_classify.py` — merges shards, assigns buckets.
-- `scripts/tests/test_readset_classify.py` — 34 guards, each pinning a defect
+- `scripts/tests/test_readset_classify.py` — 38 guards, each pinning a defect
   one of these two files actually shipped.
 
 Reproduce:

--- a/scripts/lib/readset_classify.py
+++ b/scripts/lib/readset_classify.py
@@ -90,7 +90,7 @@ def _is_repo_cwd(cwd: str) -> bool:
     return not cwd.startswith("/")
 
 
-def _effective_cwd(toks: list[str], cwd: str) -> str:
+def _effective_cwd(toks: list[str], head: str, cwd: str) -> str:
     """The tree the command operates on: `-C <path>` wins over the real cwd.
 
     🔴 THE ONLY SURVIVING ACQUITTAL, and it is here because it is the only one
@@ -101,7 +101,20 @@ def _effective_cwd(toks: list[str], cwd: str) -> str:
 
     A relative `-C` is resolved against the current cwd, so `-C subdir` from a
     repo cwd stays inside — that case genuinely IS a scan of this tree.
+
+    🔴 ONLY FOR COMMANDS THAT HAVE A `-C`. The first version scanned the whole
+    token list before the head was known, so ANY argv containing the two
+    characters `-C` was acquitted — including
+    `bash -c '… git -C /tmp/fx rev-parse …'`, where `-C` is inside the SCRIPT
+    TEXT, and `bash run-tests.sh -C /tmp/outdir`, where it is some other
+    program's unrelated flag. Both scored CLEAN. That is this module's own
+    original sin — reading an option-shaped token out of a string as evidence
+    about scope — for the fifth time, surviving inside the one acquittal that
+    was kept because it was supposed to be unambiguous. It is only unambiguous
+    for a command whose grammar defines it.
     """
+    if head != "git" and head not in _DIRECT_SCANNERS:
+        return cwd
     if "-C" not in toks:
         return cwd
     i = toks.index("-C")
@@ -192,7 +205,7 @@ def _exec_verdict(execs: set[str]) -> tuple[list[str], list[str]]:
         # — it names the tree the command operates on. Measured cost of
         # dropping the rest: 13 files move OPAQUE -> ALWAYS-RUN, ZERO `scoped`
         # files change, so the published ceiling is unaffected.
-        eff_cwd = _effective_cwd(toks, cwd)
+        eff_cwd = _effective_cwd(toks, head, cwd)
         if not _is_repo_cwd(eff_cwd):
             continue                    # -C names another tree
 

--- a/scripts/lib/readset_classify.py
+++ b/scripts/lib/readset_classify.py
@@ -40,14 +40,48 @@ _GIT_READERS = frozenset({"ls-files", "grep", "diff", "log", "show",
 _DIRECT_SCANNERS = frozenset({"rg", "grep", "egrep", "fgrep", "find",
                               "ugrep", "ack"})
 # Interpreters that run code this tracer cannot see into.
-_OPAQUE_INTERPRETERS = frozenset({"bash", "sh", "zsh", "python", "python3",
-                                  "perl", "env"})
+# 🔴 AN `_OPAQUE_INTERPRETERS` SET LIVED HERE AND IS GONE. Naming the
+# interpreters that are opaque implies everything unnamed is transparent, which
+# is exactly backwards and is what let a nested pytest score as clean. With the
+# fall-through inverted, opacity is the DEFAULT and the set had no readers.
 # git options that consume the NEXT argv token; their value is not a subcommand.
 _GIT_OPTS_WITH_VALUE = frozenset({"-C", "-c", "--git-dir", "--work-tree",
                                   "--namespace", "--exec-path"})
+# git verbs that WRITE and read nothing of the working tree worth tracking.
+# Anything not here and not in _GIT_READERS is an unknown verb => OPAQUE.
+_GIT_WRITERS = frozenset({"init", "add", "commit", "config", "checkout",
+                          "branch", "tag", "push", "fetch", "clone", "remote",
+                          "reset", "rm", "mv", "stash", "switch", "restore",
+                          "update-ref", "symbolic-ref", "gc", "worktree"})
+# Commands positively adjudicated as reading nothing of this tree. Deliberately
+# TINY: membership here is a claim, and the default for everything else is
+# OPAQUE. Add only after checking what the command actually reads.
+_HARMLESS = frozenset({"true", "false", "echo", "printf", "sleep", "uname",
+                       "id", "whoami", "hostname", "date", "which", "test"})
 
 # A cwd token meaning "this repo" — the two that make a scan repo-wide.
 _REPO_CWD = (".", "<inherited>")
+_ROOT_S = str(REPO_ROOT)
+_ROOT_PREFIX = _ROOT_S + "/"
+
+
+def _is_repo_cwd(cwd: str) -> bool:
+    """True when the command ran anywhere INSIDE this repo.
+
+    🔴 A SUBDIR CWD IS STILL THIS TREE. Matching only "." and "<inherited>"
+    acquitted `git ls-files` run with `cwd=scripts` and `rg --files` run with
+    `cwd=scripts/tests` — real scans of this repo, scored as reading nothing.
+    That is the same under-classification as the `-C` bug, reached by the other
+    route, and the module already documents that `git -C <subdir> ls-files`
+    "genuinely IS a scan of this tree".
+    """
+    if cwd in _REPO_CWD:
+        return True
+    if cwd.startswith("<"):
+        return False                    # <outside-repo> and friends
+    # _rel() already emitted these repo-RELATIVE, so any non-token value here
+    # is a path inside the repo.
+    return not cwd.startswith("/")
 
 
 def _load(shards: list[Path]) -> dict[str, dict[str, set]]:
@@ -96,26 +130,35 @@ def _exec_verdict(execs: set[str]) -> tuple[list[str], list[str]]:
         # `git -C <relative-subdir> ls-files`, genuinely IS a scan of this tree
         # and must keep counting as one. Re-adding a `-C` rule needs a case
         # that this function would otherwise get wrong — there wasn't one.
-        if cwd not in _REPO_CWD:
+        if not _is_repo_cwd(cwd):
             continue                    # scanning someone else's tree
 
         head = toks[0].rsplit("/", 1)[-1]
 
-        # An opaque interpreter: we cannot see what it reads.
-        if head in _OPAQUE_INTERPRETERS and any(t in ("-c",) for t in toks[1:3]):
-            opaque.append(" ".join(toks[:3]))
-            continue
-
         # An absolute OPERAND outside the repo names the real subject. Skip
-        # toks[0] (the executable's own path is not what it reads) — but a stub
-        # binary living in /tmp is itself evidence the work is not in this repo.
+        # toks[0]: the executable's own PATH is not what it reads — `git` lives
+        # in /nix/store here, and acquitting on that acquitted real
+        # `/nix/store/.../git ls-files` scans of this tree.
+        # 🔴 REPO_ROOT ITSELF IS INSIDE THE REPO. Comparing against the
+        # separator-terminated prefix alone excludes the root path, because
+        # "/…/devrc" does not start with "/…/devrc/". A fix round introduced
+        # exactly that and silently acquitted 14 files whose scan is spelled
+        # `git -C <REPO_ROOT> ls-files …` — the single most common form in this
+        # corpus, and under-classification again.
         operands = [t for t in toks[1:] if not t.startswith("-")]
-        if any(t.startswith("/") and not t.startswith(str(REPO_ROOT))
+        if any(t.startswith("/") and t != _ROOT_S and not t.startswith(_ROOT_PREFIX)
                for t in operands):
             continue
-        if toks[0].startswith("/") and not toks[0].startswith(str(REPO_ROOT)):
-            continue                    # a stub/fixture binary outside the repo
 
+        # 🔴 FALL-THROUGH IS OPAQUE, NOT CLEAN. Anything not positively
+        # adjudicated below is UNKNOWN. The first version only marked a child
+        # opaque when the literal token `-c` sat in toks[1:3], so the corpus's
+        # DOMINANT opacity shapes fell through BOTH branches and were reported
+        # as "scoped — proven bounded": a nested `python3 -m pytest <repo dir>`
+        # and `bash <repo script> <REPO_ROOT>` each scored as bounded with two
+        # trigger prefixes. That is under-classification — a real test skipped
+        # when it should have run, the direction this module declares must
+        # never happen. Only a RECOGNISED command may be scored clean.
         if head == "git":
             # 🔴 SKIP THE VALUE OF ANY OPTION THAT TAKES ONE. Taking the first
             # non-flag token as the subcommand reads `git -C scripts ls-files`
@@ -137,8 +180,14 @@ def _exec_verdict(execs: set[str]) -> tuple[list[str], list[str]]:
                 break
             if sub in _GIT_READERS:
                 scans.append(argv)
+            elif sub not in _GIT_WRITERS:
+                opaque.append(" ".join(toks[:3]))   # unknown git verb
         elif head in _DIRECT_SCANNERS:
             scans.append(argv)
+        elif head in _HARMLESS:
+            pass                                    # adjudicated clean
+        else:
+            opaque.append(" ".join(toks[:3]))       # UNKNOWN — never clean
     return scans, opaque
 
 
@@ -153,11 +202,13 @@ def classify(merged: dict[str, dict[str, set]], self_scope: bool = True) -> dict
         if f.startswith("<"):
             continue                    # bookkeeping buckets, not a test file
         paths = set(rec["paths"])
-        # A test reading its own file/dir is not a dependency worth recording —
-        # it is how pytest imports it. Everything else is.
-        own = str(Path(f).parent)
-        external = {p for p in paths
-                    if not (self_scope and (p == f or p.startswith(own + "/")))}
+        # 🔴 ONLY THE FILE ITSELF, NOT ITS DIRECTORY. Excluding everything under
+        # `Path(f).parent` erased every same-directory dependency: for any file
+        # in `scripts/tests/`, that dropped `scripts/tests/doc-path-baseline.tsv`
+        # and all of `scripts/tests/fixtures/`. Change a fixture and a
+        # triggers-driven map re-runs nothing. Importing yourself is the only
+        # read that is genuinely not a dependency.
+        external = {p for p in paths if not (self_scope and p == f)}
         scanners, opaque = _exec_verdict(rec["execs"])
         reads_root = "." in paths
         always = bool(scanners) or reads_root

--- a/scripts/lib/readset_classify.py
+++ b/scripts/lib/readset_classify.py
@@ -56,8 +56,14 @@ _GIT_WRITERS = frozenset({"init", "add", "commit", "config", "checkout",
 # Commands positively adjudicated as reading nothing of this tree. Deliberately
 # TINY: membership here is a claim, and the default for everything else is
 # OPAQUE. Add only after checking what the command actually reads.
+# 🔴 `test` AND `which` WERE HERE AND ARE NOT HARMLESS. `test -f
+# scripts/drift-check.sh` at a repo cwd stats a file in this tree, and `which`
+# walks PATH; both scored CLEAN. That is this module's own declared stat-only
+# blind spot re-introduced through the exec path — in the set whose comment
+# claims its members read nothing. Membership here is a CLAIM about a command's
+# filesystem behaviour; check it before adding.
 _HARMLESS = frozenset({"true", "false", "echo", "printf", "sleep", "uname",
-                       "id", "whoami", "hostname", "date", "which", "test"})
+                       "id", "whoami", "hostname", "date"})
 
 # A cwd token meaning "this repo" — the two that make a scan repo-wide.
 _REPO_CWD = (".", "<inherited>")
@@ -143,12 +149,22 @@ def _exec_verdict(execs: set[str]) -> tuple[list[str], list[str]]:
         # separator-terminated prefix alone excludes the root path, because
         # "/…/devrc" does not start with "/…/devrc/". A fix round introduced
         # exactly that and silently acquitted 14 files whose scan is spelled
-        # `git -C <REPO_ROOT> ls-files …` — the single most common form in this
-        # corpus, and under-classification again.
+        # `git -C <REPO_ROOT> ls-files …`.
+        #
+        # 🔴 THIS IS A NARROWING OF A RECOGNISED COMMAND, NOT A BLANKET
+        # ACQUITTAL — it must NOT run before the fall-through. As an early
+        # `continue` it became the ONLY escape hatch from OPAQUE and fired on
+        # `<interpreter> <repo script> <tmp_path>`, the corpus's commonest
+        # shape: 18,806 execs across 68 of 144 files, leaving 15 of 56
+        # "proven bounded" files holding an acquitted bash/python3/node child
+        # at a repo cwd — including two running `bash <copy of run-tests.sh>
+        # <REPO_ROOT>`, a walk of the whole repo. Same defect class as the
+        # `-c` keying it was written to replace, reached the other way.
+        # An UNRECOGNISED head is opaque no matter where its operands point.
         operands = [t for t in toks[1:] if not t.startswith("-")]
-        if any(t.startswith("/") and t != _ROOT_S and not t.startswith(_ROOT_PREFIX)
-               for t in operands):
-            continue
+        outside_operand = any(
+            t.startswith("/") and t != _ROOT_S and not t.startswith(_ROOT_PREFIX)
+            for t in operands)
 
         # 🔴 FALL-THROUGH IS OPAQUE, NOT CLEAN. Anything not positively
         # adjudicated below is UNKNOWN. The first version only marked a child
@@ -179,11 +195,13 @@ def _exec_verdict(execs: set[str]) -> tuple[list[str], list[str]]:
                 sub = t
                 break
             if sub in _GIT_READERS:
-                scans.append(argv)
+                if not outside_operand:             # narrows a RECOGNISED read
+                    scans.append(argv)
             elif sub not in _GIT_WRITERS:
                 opaque.append(" ".join(toks[:3]))   # unknown git verb
         elif head in _DIRECT_SCANNERS:
-            scans.append(argv)
+            if not outside_operand:
+                scans.append(argv)
         elif head in _HARMLESS:
             pass                                    # adjudicated clean
         else:

--- a/scripts/lib/readset_classify.py
+++ b/scripts/lib/readset_classify.py
@@ -90,6 +90,31 @@ def _is_repo_cwd(cwd: str) -> bool:
     return not cwd.startswith("/")
 
 
+def _effective_cwd(toks: list[str], cwd: str) -> str:
+    """The tree the command operates on: `-C <path>` wins over the real cwd.
+
+    🔴 THE ONLY SURVIVING ACQUITTAL, and it is here because it is the only one
+    that is UNAMBIGUOUS. `-C` names a directory by definition; an arbitrary
+    operand does not (grep's first operand is a pattern, an option's value is
+    not a path the command reads *from*, and a relative path may or may not
+    escape). Every attempt to infer scope from operands produced a defect.
+
+    A relative `-C` is resolved against the current cwd, so `-C subdir` from a
+    repo cwd stays inside — that case genuinely IS a scan of this tree.
+    """
+    if "-C" not in toks:
+        return cwd
+    i = toks.index("-C")
+    if i + 1 >= len(toks):
+        return cwd
+    target = toks[i + 1]
+    if not target.startswith("/"):
+        return cwd                      # relative: still under the repo cwd
+    if target == _ROOT_S or target.startswith(_ROOT_PREFIX):
+        return "."                      # an absolute path INTO this repo
+    return "<outside-repo>"
+
+
 def _load(shards: list[Path]) -> dict[str, dict[str, set]]:
     merged: dict[str, dict[str, set]] = defaultdict(
         lambda: {"paths": set(), "execs": set()})
@@ -151,20 +176,25 @@ def _exec_verdict(execs: set[str]) -> tuple[list[str], list[str]]:
         # exactly that and silently acquitted 14 files whose scan is spelled
         # `git -C <REPO_ROOT> ls-files …`.
         #
-        # 🔴 THIS IS A NARROWING OF A RECOGNISED COMMAND, NOT A BLANKET
-        # ACQUITTAL — it must NOT run before the fall-through. As an early
-        # `continue` it became the ONLY escape hatch from OPAQUE and fired on
-        # `<interpreter> <repo script> <tmp_path>`, the corpus's commonest
-        # shape: 18,806 execs across 68 of 144 files, leaving 15 of 56
-        # "proven bounded" files holding an acquitted bash/python3/node child
-        # at a repo cwd — including two running `bash <copy of run-tests.sh>
-        # <REPO_ROOT>`, a walk of the whole repo. Same defect class as the
-        # `-c` keying it was written to replace, reached the other way.
-        # An UNRECOGNISED head is opaque no matter where its operands point.
-        operands = [t for t in toks[1:] if not t.startswith("-")]
-        outside_operand = any(
-            t.startswith("/") and t != _ROOT_S and not t.startswith(_ROOT_PREFIX)
-            for t in operands)
+        # 🔴 THE OPERAND-BASED ACQUITTAL IS GONE. Four separate defects came
+        # out of trying to decide, from argv alone, whether a command's
+        # operands point outside this tree — the last three all in the UNSAFE
+        # direction:
+        #   * as an early `continue` it outranked the OPAQUE fall-through;
+        #   * an option VALUE counts as an operand, so
+        #     `git ls-files --exclude-from /tmp/ex`, `find . -newer /tmp/stamp`
+        #     and `grep -rf /tmp/pats .` all scored CLEAN while scanning here;
+        #   * and `grep`'s first operand is a PATTERN, not a path, so no
+        #     path-shaped test can classify it without per-tool argv grammar.
+        # Deciding this correctly needs a parser per tool. Being SAFE needs
+        # only the rule the module already states: ambiguity resolves to
+        # ALWAYS-RUN. So the only acquittal left is `-C`, which is unambiguous
+        # — it names the tree the command operates on. Measured cost of
+        # dropping the rest: 13 files move OPAQUE -> ALWAYS-RUN, ZERO `scoped`
+        # files change, so the published ceiling is unaffected.
+        eff_cwd = _effective_cwd(toks, cwd)
+        if not _is_repo_cwd(eff_cwd):
+            continue                    # -C names another tree
 
         # 🔴 FALL-THROUGH IS OPAQUE, NOT CLEAN. Anything not positively
         # adjudicated below is UNKNOWN. The first version only marked a child
@@ -195,13 +225,11 @@ def _exec_verdict(execs: set[str]) -> tuple[list[str], list[str]]:
                 sub = t
                 break
             if sub in _GIT_READERS:
-                if not outside_operand:             # narrows a RECOGNISED read
-                    scans.append(argv)
+                scans.append(argv)
             elif sub not in _GIT_WRITERS:
                 opaque.append(" ".join(toks[:3]))   # unknown git verb
         elif head in _DIRECT_SCANNERS:
-            if not outside_operand:
-                scans.append(argv)
+            scans.append(argv)
         elif head in _HARMLESS:
             pass                                    # adjudicated clean
         else:

--- a/scripts/lib/readset_classify.py
+++ b/scripts/lib/readset_classify.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Turn measured read sets into a per-test-file TRIGGER SET.
+
+Input: the `*.json` shards written by `testlib/readset_plugin.py` (one per xdist
+worker). Output: for each test file, the repo paths whose change could plausibly
+change that file's outcome — plus the subset that must run on ANY change.
+
+🔴 THE CLASSIFICATION IS DELIBERATELY PESSIMISTIC IN ONE DIRECTION. A tracer
+sees reads, not causation, so "read it" is treated as "depends on it" even when
+the test merely stat'd the path. The reverse error — calling a file scoped when
+it is not — would silently skip a test that should have run, so every ambiguous
+case resolves to ALWAYS-RUN. A mapping built from this must ALSO fail safe:
+an unknown path runs everything.
+
+Why a subprocess is treated as reading a whole subtree: the audit hook is
+per-interpreter and cannot see a child's opens. A `git ls-files` at REPO_ROOT is
+therefore scored as reading the entire tree, which is what it does.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# 🔴 SUBCOMMANDS THAT READ A TREE — not "any command whose name is git".
+# The first draft matched the bare token "git" and promptly flagged
+# `git init -q /tmp/...` as a repo-wide scan: cwd was <inherited>, argv
+# contained "git", done. That is the SAME over-classification the regex
+# classifier made (`claudedocs/handoff-ci-speedup.md`), just one layer up —
+# matching the tool instead of the operation. `init`, `config`, `commit` and
+# friends are not reads of this tree.
+_GIT_READERS = frozenset({"ls-files", "grep", "diff", "log", "show",
+                          "rev-list", "status", "ls-tree", "blame"})
+# Tools whose whole purpose is to walk a tree from cwd.
+_DIRECT_SCANNERS = frozenset({"rg", "grep", "egrep", "fgrep", "find",
+                              "ugrep", "ack"})
+# Interpreters that run code this tracer cannot see into.
+_OPAQUE_INTERPRETERS = frozenset({"bash", "sh", "zsh", "python", "python3",
+                                  "perl", "env"})
+# git options that consume the NEXT argv token; their value is not a subcommand.
+_GIT_OPTS_WITH_VALUE = frozenset({"-C", "-c", "--git-dir", "--work-tree",
+                                  "--namespace", "--exec-path"})
+
+# A cwd token meaning "this repo" — the two that make a scan repo-wide.
+_REPO_CWD = (".", "<inherited>")
+
+
+def _load(shards: list[Path]) -> dict[str, dict[str, set]]:
+    merged: dict[str, dict[str, set]] = defaultdict(
+        lambda: {"paths": set(), "execs": set()})
+    for shard in shards:
+        data = json.loads(shard.read_text())
+        for f, rec in data.items():
+            merged[f]["paths"].update(rec.get("paths", []))
+            merged[f]["execs"].update(rec.get("execs", []))
+    return merged
+
+
+def _exec_verdict(execs: set[str]) -> tuple[list[str], list[str]]:
+    """Split execs into (proven repo scans, OPAQUE ones we cannot see into).
+
+    🔴 ONLY THE COMMAND AND ITS SUBCOMMAND ARE INSPECTED. Scanning every token
+    of the argv was wrong twice in one sitting: it flagged a stub binary called
+    `.../bw --nointeraction status` (because "status" is a git read verb), and
+    it flagged `bash -c '<300-line script>'` because a read verb appeared in the
+    SCRIPT TEXT. That is the identical failure the regex classifier made and
+    that this whole exercise exists to remove — matching characters rather than
+    the operation being performed.
+
+    🔴 OPAQUE IS ITS OWN BUCKET, NOT A QUIET "ALWAYS-RUN". `bash -c`, `sh -c`
+    and friends run code this tracer cannot see; at a repo-root cwd their read
+    set is genuinely UNKNOWN. Folding unknown into always-run would inflate the
+    always-run count with cases nobody measured and make the number look
+    authoritative; folding it into scoped would be unsafe. It is reported
+    separately so a consumer can fail safe on it AND a reader can see how much
+    of the corpus is still unmeasured.
+    """
+    scans: list[str] = []
+    opaque: list[str] = []
+    for e in sorted(execs):
+        argv, _, cwd = e.partition("\t@")
+        toks = argv.split()
+        if not toks:
+            continue
+
+        # 🔴 THERE WAS A `-C <path>` BRANCH HERE AND IT WAS DEAD CODE — deleted
+        # after a mutation sweep showed it could never be the sole acquitter.
+        # It only rewrote the cwd when the `-C` path was absolute AND outside
+        # the repo, which is exactly the case the OPERAND rule below already
+        # rejects; disabling the branch changed no verdict. The remaining case,
+        # `git -C <relative-subdir> ls-files`, genuinely IS a scan of this tree
+        # and must keep counting as one. Re-adding a `-C` rule needs a case
+        # that this function would otherwise get wrong — there wasn't one.
+        if cwd not in _REPO_CWD:
+            continue                    # scanning someone else's tree
+
+        head = toks[0].rsplit("/", 1)[-1]
+
+        # An opaque interpreter: we cannot see what it reads.
+        if head in _OPAQUE_INTERPRETERS and any(t in ("-c",) for t in toks[1:3]):
+            opaque.append(" ".join(toks[:3]))
+            continue
+
+        # An absolute OPERAND outside the repo names the real subject. Skip
+        # toks[0] (the executable's own path is not what it reads) — but a stub
+        # binary living in /tmp is itself evidence the work is not in this repo.
+        operands = [t for t in toks[1:] if not t.startswith("-")]
+        if any(t.startswith("/") and not t.startswith(str(REPO_ROOT))
+               for t in operands):
+            continue
+        if toks[0].startswith("/") and not toks[0].startswith(str(REPO_ROOT)):
+            continue                    # a stub/fixture binary outside the repo
+
+        if head == "git":
+            # 🔴 SKIP THE VALUE OF ANY OPTION THAT TAKES ONE. Taking the first
+            # non-flag token as the subcommand reads `git -C scripts ls-files`
+            # as subcommand "scripts" and acquits a REAL scan of this tree —
+            # under-classification, the direction that silently skips a test
+            # that should have run. Caught by
+            # test_dash_C_into_a_repo_SUBDIR_is_still_a_scan_of_this_tree.
+            sub, skip_next = "", False
+            for t in toks[1:]:
+                if skip_next:
+                    skip_next = False
+                    continue
+                if t in _GIT_OPTS_WITH_VALUE:
+                    skip_next = True
+                    continue
+                if t.startswith("-"):
+                    continue
+                sub = t
+                break
+            if sub in _GIT_READERS:
+                scans.append(argv)
+        elif head in _DIRECT_SCANNERS:
+            scans.append(argv)
+    return scans, opaque
+
+
+def _top(p: str, depth: int = 2) -> str:
+    parts = [x for x in p.split("/") if x]
+    return "/".join(parts[:depth]) if parts else "."
+
+
+def classify(merged: dict[str, dict[str, set]], self_scope: bool = True) -> dict:
+    out = {}
+    for f, rec in merged.items():
+        if f.startswith("<"):
+            continue                    # bookkeeping buckets, not a test file
+        paths = set(rec["paths"])
+        # A test reading its own file/dir is not a dependency worth recording —
+        # it is how pytest imports it. Everything else is.
+        own = str(Path(f).parent)
+        external = {p for p in paths
+                    if not (self_scope and (p == f or p.startswith(own + "/")))}
+        scanners, opaque = _exec_verdict(rec["execs"])
+        reads_root = "." in paths
+        always = bool(scanners) or reads_root
+        out[f] = {
+            "always_run": always,
+            "opaque": bool(opaque) and not always,
+            "why_always": (["reads repo root"] if reads_root else []) + scanners,
+            "why_opaque": opaque[:3],
+            "triggers": sorted({_top(p) for p in external}),
+            "n_paths": len(external),
+            "sample_paths": sorted(external)[:12],
+        }
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("shards", nargs="+", type=Path)
+    ap.add_argument("--json", type=Path, help="write full result here")
+    args = ap.parse_args()
+
+    merged = _load(args.shards)
+    result = classify(merged)
+
+    always = sorted(f for f, r in result.items() if r["always_run"])
+    opaque = sorted(f for f, r in result.items() if r["opaque"])
+    scoped = sorted(f for f, r in result.items()
+                    if not r["always_run"] and not r["opaque"])
+
+    print(f"measured test files : {len(result)}")
+    print(f"  ALWAYS-RUN        : {len(always)}   (proven to read the tree)")
+    print(f"  OPAQUE            : {len(opaque)}   (spawn an interpreter at repo "
+          f"root — read set UNKNOWN, not measured; a consumer must fail safe "
+          f"and run them)")
+    print(f"  scoped            : {len(scoped)}   (proven bounded)")
+    if not result:
+        print("\n🔴 ZERO FILES MEASURED — the tracer produced nothing. That is an "
+              "instrument failure, not a clean result. Do not read the zeros above "
+              "as 'no file is repo-wide'.", file=sys.stderr)
+        return 3
+
+    print("\n=== ALWAYS-RUN (any change) ===")
+    for f in always:
+        why = "; ".join(result[f]["why_always"][:2])
+        print(f"  {f}\n      why: {why}")
+
+    print("\n=== SCOPED — top trigger prefixes ===")
+    for f in scoped:
+        t = result[f]["triggers"]
+        print(f"  {f}\n      triggers({len(t)}): {', '.join(t[:8])}")
+
+    if args.json:
+        args.json.write_text(json.dumps(result, indent=1, sort_keys=True))
+        print(f"\nwrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/testlib/readset_plugin.py
+++ b/scripts/testlib/readset_plugin.py
@@ -37,6 +37,16 @@ WHAT IT CANNOT SEE — state these with the result, never quietly
 - **Reads by a C extension that bypasses the audit events.** Rare here, but it
   is why the runner ships a POSITIVE CONTROL: a file with a known, deliberate
   repo read must appear in the output, or the instrument is wired to nothing.
+- 🔴 **STAT-ONLY DEPENDENCIES ARE INVISIBLE.** CPython raises no audit event for
+  `os.stat`/`os.lstat`/`Path.exists()`/`Path.is_dir()`/`os.path.exists`
+  (measured, 3.12.14). A guard whose only dependency is
+  `(REPO_ROOT / "scripts" / "x.sh").exists()` records an EMPTY read set and
+  classifies as bounded — so deleting or adding the very file it polices
+  re-runs nothing. This is an under-classification and the corpus contains the
+  shape. A consumer must not treat a small read set as proof of independence.
+- **Symlinks are not followed** — `_rel` deliberately avoids `resolve()` to keep
+  the hook from re-entering, so a read reached through a symlink into the repo
+  is attributed to the link's path, not the target's.
 
 Attribution covers BOTH phases, because module-level reads are real: several
 files in this corpus do `(REPO_ROOT / "nix" / "home.nix").read_text()` at import
@@ -55,7 +65,15 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # Events worth paying for. The hook runs on EVERY audited operation in the
 # interpreter, so the first thing it does is a frozenset membership test and an
 # early return; anything more expensive here shows up as suite wall time.
-_PATH_EVENTS = frozenset({"open", "os.listdir", "os.scandir", "os.stat"})
+# 🔴 `os.stat` IS DELIBERATELY ABSENT, AND ITS ABSENCE IS A BLIND SPOT.
+# CPython raises no audit event for `os.stat`/`os.lstat`/`Path.exists()`/
+# `Path.is_dir()`/`os.path.exists` — measured on 3.12.14, the gate's own
+# interpreter. An earlier draft listed "os.stat" here, which raised NOTHING
+# while READING as coverage: a guard asserting `(REPO_ROOT / "x.sh").exists()`
+# recorded a read set of `[]` and classified as `scoped, triggers(0)`.
+# A dead entry in this set is worse than an honest omission, so it is gone and
+# the gap is named in the module docstring and in the published measurement.
+_PATH_EVENTS = frozenset({"open", "os.listdir", "os.scandir"})
 _EXEC_EVENTS = frozenset({"subprocess.Popen", "os.system", "os.exec"})
 _WANTED = _PATH_EVENTS | _EXEC_EVENTS
 
@@ -68,16 +86,38 @@ _current: list[str] = []          # a stack; [-1] is the file being attributed
 _writing = False                  # re-entrancy guard for our own output write
 
 
+_ROOT_S = str(REPO_ROOT)
+_ROOT_PREFIX = _ROOT_S + "/"
+
+
 def _rel(p: str) -> str | None:
-    """Repo-relative path, or None if it is not inside this repo."""
+    """Repo-relative path, or None if it is not inside this repo.
+
+    🔴 THE PREFIX MUST CARRY A SEPARATOR. A bare `p.startswith(REPO_ROOT)`
+    matches SIBLING directories that merely share the name — with REPO_ROOT
+    `/home/zach/workspace/devrc`, the path
+    `/home/zach/workspace/devrc-readsets/scripts/x.py` mapped to
+    `-readsets/scripts/x.py` and became a phantom trigger prefix. Not
+    theoretical: this box carries ~45 `devrc-*` sibling worktrees, and the
+    corpus contains tests that exist to work with sibling clones.
+
+    🔴 A RELATIVE PATH IS STILL A REPO PATH. The `open` audit event carries the
+    path exactly as passed, so `open("scripts/x")` under a repo-root cwd used to
+    be discarded entirely — under-classification, the unsafe direction. Joined
+    against cwd here, still without `resolve()`.
+
+    No `resolve()`: it stats the path, which re-enters the hook. Symlinks into
+    the repo are therefore NOT followed — a named limitation, not an oversight.
+    """
     try:
-        # No resolve() here: it stats the path, which re-enters the hook and is
-        # the single most expensive thing this function could do. Trading exact
-        # symlink resolution for a hook that does not quadratically re-enter.
-        if not p.startswith(str(REPO_ROOT)):
+        if not p.startswith("/"):
+            cwd = os.getcwd()
+            p = cwd + "/" + p if not cwd.endswith("/") else cwd + p
+        if p == _ROOT_S:
+            return "."
+        if not p.startswith(_ROOT_PREFIX):
             return None
-        rel = p[len(str(REPO_ROOT)):].lstrip("/")
-        return rel or "."
+        return p[len(_ROOT_PREFIX):] or "."
     except Exception:
         return None
 

--- a/scripts/testlib/readset_plugin.py
+++ b/scripts/testlib/readset_plugin.py
@@ -106,8 +106,12 @@ def _rel(p: str) -> str | None:
     be discarded entirely — under-classification, the unsafe direction. Joined
     against cwd here, still without `resolve()`.
 
-    No `resolve()`: it stats the path, which re-enters the hook. Symlinks into
-    the repo are therefore NOT followed — a named limitation, not an oversight.
+    No `resolve()` — but NOT because it re-enters the hook. An earlier version
+    of this comment said that, and it is false: `Path.resolve()` raises no
+    audit event at all (measured, 3.12.14 — the same fact that makes stat
+    invisible above). The real cost is syscalls per recorded path on a hot
+    path. Consequence either way: symlinks into the repo are NOT followed, and
+    a read reached through one is attributed to the link, not the target.
     """
     try:
         if not p.startswith("/"):
@@ -117,7 +121,10 @@ def _rel(p: str) -> str | None:
             return "."
         if not p.startswith(_ROOT_PREFIX):
             return None
-        return p[len(_ROOT_PREFIX):] or "."
+        # lstrip: a doubled separator (`<ROOT>//scripts`) would otherwise yield
+        # "/scripts", which the classifier's cwd test reads as an ABSOLUTE path
+        # and therefore outside the repo — acquitting a real scan.
+        return p[len(_ROOT_PREFIX):].lstrip("/") or "."
     except Exception:
         return None
 
@@ -140,10 +147,12 @@ def _hook(event: str, args) -> None:
             if isinstance(target, (bytes, int)):
                 return                      # fd or bytes path: not useful here
             s = os.fspath(target) if hasattr(target, "__fspath__") else str(target)
-            if any(part in s for part in _SKIP_PARTS):
-                return
             rel = _rel(s)
-            if rel is not None:
+            # 🔴 FILTER THE NORMALISED PATH, NOT THE RAW ONE. _SKIP_PARTS is
+            # slash-anchored ("/.git/"), so screening the raw string stopped
+            # matching once relative paths began to be kept: a relative
+            # `open(".git/HEAD")` slipped through and was recorded.
+            if rel is not None and not any(part in "/" + rel for part in _SKIP_PARTS):
                 b["paths"].add(rel)
         else:
             # (executable, args, cwd, env) for subprocess.Popen

--- a/scripts/testlib/readset_plugin.py
+++ b/scripts/testlib/readset_plugin.py
@@ -117,6 +117,14 @@ def _rel(p: str) -> str | None:
         if not p.startswith("/"):
             cwd = os.getcwd()
             p = cwd + "/" + p if not cwd.endswith("/") else cwd + p
+        # 🔴 COLLAPSE `..` BEFORE THE PREFIX TEST. Joining a relative path
+        # against the cwd can produce `<repo>/scripts/../../devrc-sibling/x`,
+        # which passes `startswith(<repo>/)` and records the phantom trigger
+        # prefix `scripts/..` — the exact sibling-directory failure the
+        # separator-terminated prefix was added to prevent, reached by the
+        # relative route. `normpath` is pure string work: no stat, no syscall.
+        if ".." in p:
+            p = os.path.normpath(p)
         if p == _ROOT_S:
             return "."
         if not p.startswith(_ROOT_PREFIX):

--- a/scripts/testlib/readset_plugin.py
+++ b/scripts/testlib/readset_plugin.py
@@ -1,0 +1,187 @@
+"""Record the REPO PATHS each test file actually reads — measured, not inferred.
+
+WHY THIS EXISTS, AND WHY IT IS NOT A REGEX
+------------------------------------------
+`claudedocs/handoff-ci-speedup.md` carries a 🔴 gotcha: a regex classifier for
+`git ls-files` / `REPO_ROOT.rglob` called 32 of 139 files "repo-wide scanners",
+and the number is NOT TRUSTWORTHY because it over-classifies. The named example
+is `test_drift_check.py`, which the regex flagged on line 1440 — where
+`git ls-files` appears inside a *fixture string*, a shell snippet the test feeds
+to the script under test. Reading the source cannot tell those apart: the same
+characters mean "scans the tree" in one line and "is test data" in the next.
+
+Running the test can. This plugin installs a `sys.addaudithook` and records the
+paths each test file OPENS, LISTS and SCANS, plus every subprocess it spawns and
+the cwd it spawned it in. A `git ls-files` executed with cwd inside a `tmp_path`
+fixture repo is visibly not a scan of this repo; one executed at REPO_ROOT
+visibly is.
+
+🔴 THE OUTPUT IS A READ SET, NOT A BOOLEAN. "repo-wide" turned out to be the
+wrong shape for the question. `test_drift_check.py` genuinely must re-run when a
+`.sh` under `scripts/` or a `.nix` under `nix/pkgs/` changes (it rglobs both) —
+and genuinely need not when a doc in `claudedocs/` does. Collapsing that to one
+bit is what made the earlier number both wrong and unfalsifiable. A read set is
+also the input rank 3 (the path->target mapping) actually needs.
+
+WHAT IT CANNOT SEE — state these with the result, never quietly
+--------------------------------------------------------------
+- **Reads inside a subprocess.** The audit hook is per-interpreter, so a child
+  process's own `open` calls are invisible. We record the ARGV and CWD instead,
+  and a consumer must treat a subprocess rooted at REPO_ROOT as reading
+  everything beneath it. That is deliberately the pessimistic direction.
+- **A test whose outcome depends on a file it never reads** (e.g. it asserts on
+  a count someone else computed). No read-tracer can see that; only perturbation
+  can, and perturbation has its own blind spot (an innocuous edit does not trip
+  a scanner that only fails on violations). The two methods are complementary
+  and neither is sufficient alone.
+- **Reads by a C extension that bypasses the audit events.** Rare here, but it
+  is why the runner ships a POSITIVE CONTROL: a file with a known, deliberate
+  repo read must appear in the output, or the instrument is wired to nothing.
+
+Attribution covers BOTH phases, because module-level reads are real: several
+files in this corpus do `(REPO_ROOT / "nix" / "home.nix").read_text()` at import
+time, which happens during COLLECTION and would be lost by a runtest-only hook.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Events worth paying for. The hook runs on EVERY audited operation in the
+# interpreter, so the first thing it does is a frozenset membership test and an
+# early return; anything more expensive here shows up as suite wall time.
+_PATH_EVENTS = frozenset({"open", "os.listdir", "os.scandir", "os.stat"})
+_EXEC_EVENTS = frozenset({"subprocess.Popen", "os.system", "os.exec"})
+_WANTED = _PATH_EVENTS | _EXEC_EVENTS
+
+# Noise that is never a signal about the source tree.
+_SKIP_PARTS = ("__pycache__", "/.git/", "/.pytest_cache/", "/node_modules/")
+
+# file-under-test (repo-relative str) -> {"paths": set, "execs": set}
+_RECORDS: dict[str, dict[str, set]] = {}
+_current: list[str] = []          # a stack; [-1] is the file being attributed
+_writing = False                  # re-entrancy guard for our own output write
+
+
+def _rel(p: str) -> str | None:
+    """Repo-relative path, or None if it is not inside this repo."""
+    try:
+        # No resolve() here: it stats the path, which re-enters the hook and is
+        # the single most expensive thing this function could do. Trading exact
+        # symlink resolution for a hook that does not quadratically re-enter.
+        if not p.startswith(str(REPO_ROOT)):
+            return None
+        rel = p[len(str(REPO_ROOT)):].lstrip("/")
+        return rel or "."
+    except Exception:
+        return None
+
+
+def _bucket() -> dict[str, set] | None:
+    if _writing or not _current:
+        return None
+    return _RECORDS.setdefault(_current[-1], {"paths": set(), "execs": set()})
+
+
+def _hook(event: str, args) -> None:
+    if event not in _WANTED:
+        return
+    b = _bucket()
+    if b is None:
+        return
+    try:
+        if event in _PATH_EVENTS:
+            target = args[0]
+            if isinstance(target, (bytes, int)):
+                return                      # fd or bytes path: not useful here
+            s = os.fspath(target) if hasattr(target, "__fspath__") else str(target)
+            if any(part in s for part in _SKIP_PARTS):
+                return
+            rel = _rel(s)
+            if rel is not None:
+                b["paths"].add(rel)
+        else:
+            # (executable, args, cwd, env) for subprocess.Popen
+            argv = args[1] if len(args) > 1 else args[0]
+            cwd = args[2] if len(args) > 2 else None
+            if isinstance(argv, (list, tuple)):
+                argv_s = " ".join(str(a) for a in argv[:6])
+            else:
+                argv_s = str(argv)
+            # An empty cwd means "inherited", which for this suite is REPO_ROOT;
+            # a cwd outside the repo is the case that ACQUITS a `git ls-files`,
+            # so it gets its own token rather than being blanked to look local.
+            if cwd is None:
+                cwd_s = "<inherited>"
+            else:
+                cwd_s = _rel(str(cwd))
+                if cwd_s is None:
+                    cwd_s = "<outside-repo>"
+            b["execs"].add(f"{argv_s}\t@{cwd_s}")
+    except Exception:
+        # A tracer must never be able to fail the suite it is measuring.
+        return
+
+
+sys.addaudithook(_hook)
+
+
+# ---------------------------------------------------------------- pytest hooks
+
+def _file_of(nodeid: str) -> str:
+    return nodeid.split("::", 1)[0]
+
+
+def pytest_collectstart(collector):
+    """Module IMPORT happens here, and module-level repo reads are real reads.
+
+    🔴 KEYED ON `nodeid`, NOT on a repo-relative path. The first draft used
+    `_rel(collector.path)`, which returns None for any test file outside
+    REPO_ROOT — so nothing was pushed, `_current` stayed empty, and EVERY
+    module-level read was silently dropped. The controls caught it: a
+    deliberate import-time `flake.nix` read did not appear in the output. It
+    also made the two phases disagree, since runtest attributes by nodeid.
+    One key for both phases, or the halves cannot be merged.
+    """
+    nodeid = getattr(collector, "nodeid", "") or ""
+    if nodeid.endswith(".py"):
+        _current.append(nodeid)
+    else:
+        _current.append(_current[-1] if _current else "<pre-collection>")
+
+
+def pytest_collectreport(report):
+    if _current:
+        _current.pop()
+
+
+def pytest_runtest_protocol(item, nextitem):
+    _current.append(_file_of(item.nodeid))
+    return None  # advisory only; let the default protocol run
+
+
+def pytest_runtest_logfinish(nodeid, location):
+    if _current:
+        _current.pop()
+
+
+def pytest_sessionfinish(session, exitstatus):
+    global _writing
+    out = os.environ.get("DEVRC_READSET_OUT")
+    if not out:
+        return
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+    _writing = True
+    try:
+        payload = {
+            f: {"paths": sorted(v["paths"]), "execs": sorted(v["execs"])}
+            for f, v in _RECORDS.items()
+        }
+        Path(f"{out}.{worker}.json").write_text(json.dumps(payload, indent=1))
+    finally:
+        _writing = False

--- a/scripts/tests/test_readset_classify.py
+++ b/scripts/tests/test_readset_classify.py
@@ -27,8 +27,55 @@ sys.modules["readset_classify"] = rc
 _SPEC.loader.exec_module(rc)
 
 
+_PSPEC = importlib.util.spec_from_file_location(
+    "readset_plugin", REPO_ROOT / "scripts" / "testlib" / "readset_plugin.py")
+rp = importlib.util.module_from_spec(_PSPEC)
+sys.modules["readset_plugin"] = rp
+_PSPEC.loader.exec_module(rp)
+
+
 def _verdict(*execs):
     return rc._exec_verdict(set(execs))
+
+
+# ------------------------------------------------- plugin: path attribution
+
+def test_a_SIBLING_worktree_is_not_inside_this_repo():
+    """🟡 AUDIT R1-F6. `devrc-readsets` startswith `devrc`.
+
+    A bare prefix compare mapped /home/zach/workspace/devrc-readsets/scripts/x
+    to '-readsets/scripts/x' — a phantom trigger prefix. ~45 such sibling
+    worktrees exist on this box, and the corpus has tests built around them.
+    """
+    sibling = str(rp.REPO_ROOT) + "-readsets/scripts/x.py"
+    assert rp._rel(sibling) is None, rp._rel(sibling)
+
+
+def test_a_path_inside_the_repo_is_still_relative_to_it():
+    """The positive control for the sibling guard — it must not over-reject."""
+    inside = str(rp.REPO_ROOT) + "/scripts/lib/x.py"
+    assert rp._rel(inside) == "scripts/lib/x.py"
+    assert rp._rel(str(rp.REPO_ROOT)) == "."
+
+
+def test_a_RELATIVE_path_read_is_not_discarded(monkeypatch):
+    """🟡 AUDIT R1-F7. The `open` event carries the path AS PASSED.
+
+    `open("scripts/x")` under a repo-root cwd used to return None and vanish —
+    under-classification, the unsafe direction.
+    """
+    monkeypatch.chdir(rp.REPO_ROOT)
+    assert rp._rel("scripts/lib/relative_read.py") == "scripts/lib/relative_read.py"
+
+
+def test_os_stat_is_NOT_claimed_as_a_traced_event():
+    """🔴 AUDIT R1-F2. CPython raises no audit event for stat.
+
+    Listing it raised nothing while READING as coverage. Pinning its absence so
+    nobody re-adds it believing it works.
+    """
+    assert "os.stat" not in rp._PATH_EVENTS
+    assert "STAT-ONLY DEPENDENCIES ARE INVISIBLE" in rp.__doc__
 
 
 # --------------------------------------------------------- positive controls
@@ -79,17 +126,18 @@ def test_a_stub_binary_outside_the_repo_is_NOT_a_scan():
     assert scans == []
 
 
-def test_a_SCANNER_binary_living_outside_the_repo_is_acquitted():
-    """Reaches the argv[0] acquittal — nothing else here does.
+def test_a_SCANNER_at_an_absolute_path_scanning_DOT_is_a_scan():
+    """🟡 AUDIT R1-F3 — THIS TEST'S ASSERTION WAS INVERTED BY THE AUDIT.
 
-    🔴 Mutation sweep: deleting that guard left all 12 other tests green. The
-    stub-binary test above never reaches it, because `bw` is not a recognised
-    scanner and is dropped one branch earlier. This uses a basename that IS a
-    scanner (`grep`) at a path outside the tree, with an operand that would
-    otherwise pass, so argv[0] is the only thing left that can acquit it.
+    It used to assert that an absolute-path executable outside the repo was
+    ACQUITTED, and it passed, and it was wrong: where the BINARY lives says
+    nothing about what it READS. `grep -r needle .` at a repo cwd scans this
+    tree whether grep came from /nix/store, /usr/bin or a fixture dir — and the
+    corpus really does invoke git by absolute store path. The old rule
+    acquitted genuine `/nix/store/.../git ls-files` scans.
     """
     scans, _ = _verdict("/tmp/fixtures/bin/grep -r needle .\t@.")
-    assert scans == [], scans
+    assert len(scans) == 1, scans
 
 
 def test_a_git_WRITE_subcommand_at_repo_root_is_not_a_scan():
@@ -148,10 +196,16 @@ def test_reading_the_repo_root_makes_a_file_always_run():
     assert out["scripts/tests/test_x.py"]["always_run"] is True
 
 
-def test_own_directory_reads_do_not_count_as_a_dependency():
-    """Importing yourself is not a dependency on the rest of the tree."""
+def test_reading_only_YOUR_OWN_FILE_is_not_a_dependency():
+    """🟡 AUDIT R1-F8 — THIS TEST'S FIXTURE WAS NARROWED BY THE AUDIT.
+
+    It used to include a sibling `helper.txt` and assert n_paths == 0, which
+    passed and was wrong: excluding the whole parent directory erased every
+    same-directory dependency (fixtures, the doc-path baseline). Only the
+    file's own import is genuinely not a dependency.
+    """
     merged = {"scripts/tests/test_x.py": {
-        "paths": {"scripts/tests/test_x.py", "scripts/tests/helper.txt"},
+        "paths": {"scripts/tests/test_x.py"},
         "execs": set()}}
     out = rc.classify(merged)["scripts/tests/test_x.py"]
     assert out["always_run"] is False
@@ -165,6 +219,93 @@ def test_an_external_read_becomes_a_trigger_prefix():
     out = rc.classify(merged)["scripts/tests/test_x.py"]
     assert out["always_run"] is False
     assert set(out["triggers"]) == {"nix/pkgs", "scripts/lib"}
+
+
+# ------------------------------------------- audit round 1 (PR #1120) fixes
+
+def test_a_nested_pytest_over_a_repo_dir_is_OPAQUE_not_scoped():
+    """🔴 AUDIT R1-F1. The corpus's dominant opacity shape.
+
+    Keying OPAQUE on the literal token `-c` let a nested
+    `python3 -m pytest <repo dir>` fall through BOTH branches and be reported
+    as "scoped — proven bounded" with two trigger prefixes. Real: measured on
+    test_hook_tests_dir_collects.py.
+    """
+    scans, opaque = _verdict(
+        "/nix/store/x/python3 -m pytest -p no:cacheprovider scripts/claude-hooks/tests\t@.")
+    assert scans == [], scans
+    assert len(opaque) == 1, opaque
+
+
+def test_bash_running_a_repo_SCRIPT_is_OPAQUE_not_scoped():
+    """🔴 AUDIT R1-F1, second shape: `bash <repo script> <REPO_ROOT>`.
+
+    No `-c`, so the old rule scored it clean; it is a repo-wide walk.
+    """
+    scans, opaque = _verdict("bash scripts/run-node-tests.sh --check-suites .\t@.")
+    assert scans == [], scans
+    assert len(opaque) == 1, opaque
+
+
+def test_an_UNRECOGNISED_command_is_OPAQUE_never_clean():
+    """🔴 AUDIT R1-F1 generalised: fall-through must be UNKNOWN, not clean."""
+    scans, opaque = _verdict("some-unknown-tool --do-a-thing\t@.")
+    assert scans == []
+    assert len(opaque) == 1, opaque
+
+
+def test_git_by_ABSOLUTE_store_path_is_still_a_scan():
+    """🟡 AUDIT R1-F3. `git` lives in /nix/store here.
+
+    Acquitting on argv[0] being an absolute path outside the repo acquitted
+    real `/nix/store/.../git ls-files` scans — and the corpus does invoke git
+    by absolute store path via the mockbin/gitenv machinery.
+    """
+    scans, _ = _verdict("/nix/store/abc-git-2.55.0/bin/git ls-files\t@.")
+    assert len(scans) == 1, scans
+
+
+def test_a_scan_from_a_repo_SUBDIR_cwd_is_still_a_scan():
+    """🟡 AUDIT R1-F4. The untested twin of the `-C` bug, other route."""
+    scans, _ = _verdict("git ls-files\t@scripts")
+    assert len(scans) == 1, scans
+    scans2, _ = _verdict("rg --files\t@scripts/tests")
+    assert len(scans2) == 1, scans2
+
+
+def test_an_operand_that_IS_the_repo_root_is_not_treated_as_outside():
+    """🔴 REGRESSION INTRODUCED BY THE ROUND-1 FIX ROUND ITSELF.
+
+    Switching the operand check to a separator-terminated prefix made
+    REPO_ROOT itself fail the test — "/…/devrc" does not start with
+    "/…/devrc/" — so `git -C <REPO_ROOT> ls-files` was acquitted. That is the
+    most common way this corpus spells a repo scan: 14 files silently lost
+    their ALWAYS-RUN verdict (22 -> 9) before this was caught by diffing the
+    two classification runs.
+    """
+    root = str(rc.REPO_ROOT)
+    scans, _ = _verdict(f"git -C {root} ls-files --error-unmatch scripts/x.py\t@.")
+    assert len(scans) == 1, scans
+
+
+def test_a_same_directory_fixture_is_a_dependency():
+    """🟡 AUDIT R1-F8. Self-scoping must exclude the FILE, not the DIRECTORY."""
+    merged = {"scripts/tests/test_x.py": {
+        "paths": {"scripts/tests/test_x.py",
+                  "scripts/tests/doc-path-baseline.tsv",
+                  "scripts/tests/fixtures/sample.json"},
+        "execs": set()}}
+    out = rc.classify(merged)["scripts/tests/test_x.py"]
+    assert out["n_paths"] == 2, out["sample_paths"]
+    assert "scripts/tests" in out["triggers"]
+
+
+def test_a_git_WRITE_verb_is_clean_but_an_UNKNOWN_verb_is_opaque():
+    """The fall-through inversion must not make every git call opaque."""
+    scans, opaque = _verdict("git commit -m msg\t@.")
+    assert (scans, opaque) == ([], []), (scans, opaque)
+    scans2, opaque2 = _verdict("git some-new-verb\t@.")
+    assert scans2 == [] and len(opaque2) == 1, (scans2, opaque2)
 
 
 def test_opaque_does_not_silently_become_always_run():

--- a/scripts/tests/test_readset_classify.py
+++ b/scripts/tests/test_readset_classify.py
@@ -273,6 +273,69 @@ def test_a_scan_from_a_repo_SUBDIR_cwd_is_still_a_scan():
     assert len(scans2) == 1, scans2
 
 
+def test_an_interpreter_running_a_REPO_SCRIPT_on_a_tmp_arg_is_OPAQUE():
+    """🔴 AUDIT R2-F1. The operand acquittal must not outrank the fall-through.
+
+    As an early `continue` it became the ONLY escape from OPAQUE and fired on
+    the corpus's commonest shape — 18,806 execs across 68 of 144 files, leaving
+    15 of 56 "proven bounded" files holding an acquitted interpreter child.
+    Real: test_claude_log_rotate.py runs `bash <REPO>/scripts/.../rotate.sh
+    /tmp/...` and published triggers that do not include that script, so
+    editing it would re-run nothing.
+    """
+    root = str(rc.REPO_ROOT)
+    scans, opaque = _verdict(
+        f"bash {root}/scripts/claude-log-rotate/rotate.sh /tmp/x/dot-claude\t@.")
+    assert scans == [], scans
+    assert len(opaque) == 1, opaque
+
+
+def test_bash_running_a_repo_script_over_THE_REPO_is_opaque_not_scoped():
+    """🔴 AUDIT R2-F1, the worst real instance: a walk of the whole repo."""
+    root = str(rc.REPO_ROOT)
+    scans, opaque = _verdict(f"bash /tmp/copy/run-tests.sh {root}\t@.")
+    assert scans == [] and len(opaque) == 1, (scans, opaque)
+
+
+def test_an_outside_operand_still_acquits_a_RECOGNISED_scanner():
+    """The narrowing must survive being moved inside the recognised arms."""
+    scans, opaque = _verdict("grep -r needle /tmp/elsewhere\t@.")
+    assert scans == [] and opaque == [], (scans, opaque)
+    scans2, _ = _verdict("git -C /tmp/fixture ls-files\t@.")
+    assert scans2 == [], scans2
+
+
+def test_test_and_which_are_NOT_adjudicated_harmless():
+    """🟡 AUDIT R2-F2. `test -f <repo path>` stats this tree.
+
+    Both were in _HARMLESS and scored CLEAN — the module's own stat blind spot
+    re-introduced through the exec path. A mutation emptying _HARMLESS survived
+    the whole suite, so the set had no coverage at all.
+    """
+    for argv in ("test -f scripts/drift-check.sh", "which drift-check.sh"):
+        scans, opaque = _verdict(f"{argv}\t@.")
+        assert scans == [], (argv, scans)
+        assert len(opaque) == 1, (argv, opaque)
+
+
+def test_a_genuinely_harmless_command_is_still_clean():
+    """Positive control for the set — emptying it must be detectable."""
+    scans, opaque = _verdict("true\t@.")
+    assert (scans, opaque) == ([], []), (scans, opaque)
+
+
+def test_an_unknown_git_verb_is_opaque_but_a_known_writer_is_clean():
+    """🟡 AUDIT R2-F2. _GIT_WRITERS had no guard; dropping a member survived."""
+    for verb in ("init", "config", "worktree"):
+        scans, opaque = _verdict(f"git {verb} something\t@.")
+        assert (scans, opaque) == ([], []), (verb, scans, opaque)
+
+
+def test_a_doubled_separator_in_a_cwd_still_reads_as_inside_the_repo():
+    """🟢 AUDIT R2-F4. `<ROOT>//scripts` yielded '/scripts' -> read as absolute."""
+    assert rp._rel(str(rp.REPO_ROOT) + "//scripts") == "scripts"
+
+
 def test_an_operand_that_IS_the_repo_root_is_not_treated_as_outside():
     """🔴 REGRESSION INTRODUCED BY THE ROUND-1 FIX ROUND ITSELF.
 

--- a/scripts/tests/test_readset_classify.py
+++ b/scripts/tests/test_readset_classify.py
@@ -1,0 +1,177 @@
+"""Guards for `scripts/lib/readset_classify.py`.
+
+🔴 EVERY CASE BELOW IS A BUG THIS CLASSIFIER ACTUALLY SHIPPED, not an imagined
+one. The classifier exists to replace a regex that over-classified test files as
+"repo-wide scanners" (`claudedocs/handoff-ci-speedup.md`), and its first three
+drafts each reproduced that same failure in a new disguise:
+
+  1. matched the bare tool name, so `git init -q /tmp/x` read as a repo scan;
+  2. matched a read verb anywhere in argv, so a stub binary invoked as
+     `/tmp/.../bw --nointeraction status` read as a repo scan;
+  3. same, so `bash -c '<script mentioning git log>'` read as a repo scan —
+     matching the SCRIPT TEXT, which is precisely the regex's original sin.
+
+A classifier built to fix over-classification that over-classifies is worse than
+no classifier, because its number reads as measured. These pin the acquittals.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SPEC = importlib.util.spec_from_file_location(
+    "readset_classify", REPO_ROOT / "scripts" / "lib" / "readset_classify.py")
+rc = importlib.util.module_from_spec(_SPEC)
+sys.modules["readset_classify"] = rc
+_SPEC.loader.exec_module(rc)
+
+
+def _verdict(*execs):
+    return rc._exec_verdict(set(execs))
+
+
+# --------------------------------------------------------- positive controls
+
+def test_git_ls_files_at_repo_root_IS_a_scan():
+    """The one that must still fire, or every acquittal below is vacuous."""
+    scans, opaque = _verdict("git ls-files\t@.")
+    assert scans == ["git ls-files"], (scans, opaque)
+
+
+def test_a_direct_tree_scanner_at_repo_root_IS_a_scan():
+    scans, _ = _verdict("rg --files\t@.")
+    assert scans == ["rg --files"]
+
+
+# --------------------------------------------------------- the three bugs
+
+def test_git_init_on_a_tmp_path_is_NOT_a_scan():
+    """BUG 1: matched the tool name `git`, ignoring the subcommand.
+
+    `init` creates a repo somewhere else; it reads nothing here.
+    """
+    scans, opaque = _verdict("git init -q /tmp/fixture-repo\t@<inherited>")
+    assert scans == [], scans
+    assert opaque == [], opaque
+
+
+def test_a_read_verb_with_an_operand_OUTSIDE_the_repo_is_acquitted():
+    """Reaches the OPERAND acquittal, which nothing else here does.
+
+    🔴 Added after a mutation sweep: deleting that acquittal left all 11 other
+    tests GREEN. `git init /tmp/x` never reaches it — the subcommand check
+    acquits `init` first — so the guard was unreachable and the suite was
+    asserting nothing about it. This uses a REAL scanner (`grep`, which would
+    otherwise be scored a scan) pointed at a path outside the tree.
+    """
+    scans, _ = _verdict("grep -r needle /tmp/somewhere-else\t@.")
+    assert scans == [], scans
+
+
+def test_a_stub_binary_outside_the_repo_is_NOT_a_scan():
+    """BUG 2: `status` is a git read verb, so a stub named anything matched.
+
+    The executable lives in a tmp fixture dir — whatever it reads, it is not
+    this tree, and argv[0] was excluded from the operand check.
+    """
+    scans, _ = _verdict("/tmp/pytest-0/bw-stub/bw --nointeraction status\t@.")
+    assert scans == []
+
+
+def test_a_SCANNER_binary_living_outside_the_repo_is_acquitted():
+    """Reaches the argv[0] acquittal — nothing else here does.
+
+    🔴 Mutation sweep: deleting that guard left all 12 other tests green. The
+    stub-binary test above never reaches it, because `bw` is not a recognised
+    scanner and is dropped one branch earlier. This uses a basename that IS a
+    scanner (`grep`) at a path outside the tree, with an operand that would
+    otherwise pass, so argv[0] is the only thing left that can acquit it.
+    """
+    scans, _ = _verdict("/tmp/fixtures/bin/grep -r needle .\t@.")
+    assert scans == [], scans
+
+
+def test_a_git_WRITE_subcommand_at_repo_root_is_not_a_scan():
+    """Reaches the git-subcommand check — nothing else here does.
+
+    🔴 Mutation sweep: forcing that check to True left all 12 other tests
+    green, because `git init -q /tmp/x` is acquitted by the OPERAND rule first.
+    A write verb with no outside operand is the only way in.
+    """
+    scans, _ = _verdict("git commit -m msg\t@.")
+    assert scans == [], scans
+
+
+def test_bash_dash_c_is_OPAQUE_not_a_scan():
+    """BUG 3: a read verb inside the SCRIPT TEXT counted as an operation.
+
+    The correct answer is not "scan" and not "clear" — it is UNKNOWN, and it
+    must land in its own bucket so nobody reads it as measured.
+    """
+    scans, opaque = _verdict("bash -c set -e; git log --oneline | head\t@.")
+    assert scans == [], scans
+    assert len(opaque) == 1, opaque
+
+
+# --------------------------------------------------------- cwd / -C acquittals
+
+def test_a_scan_outside_the_repo_is_acquitted():
+    scans, _ = _verdict("git ls-files\t@<outside-repo>")
+    assert scans == []
+
+
+def test_dash_C_at_an_outside_path_is_acquitted_BY_THE_OPERAND_RULE():
+    """Behaviour pin. The acquittal is the operand rule, NOT a `-C` rule.
+
+    🔴 There used to be a dedicated `-C` branch and this test was written as if
+    it covered it. A mutation sweep disabled that branch and this test stayed
+    GREEN — because `/tmp/fixture` is an absolute operand outside the repo, so
+    the operand rule had already rejected it. The branch was dead code and is
+    gone; the behaviour it claimed to provide is real and still pinned here.
+    """
+    scans, _ = _verdict("git -C /tmp/fixture ls-files\t@.")
+    assert scans == []
+
+
+def test_dash_C_into_a_repo_SUBDIR_is_still_a_scan_of_this_tree():
+    """The case a re-added `-C` rule must not break: it is a real scan."""
+    scans, _ = _verdict("git -C scripts ls-files\t@.")
+    assert scans == ["git -C scripts ls-files"], scans
+
+
+# --------------------------------------------------------- bucket assignment
+
+def test_reading_the_repo_root_makes_a_file_always_run():
+    merged = {"scripts/tests/test_x.py": {"paths": {"."}, "execs": set()}}
+    out = rc.classify(merged)
+    assert out["scripts/tests/test_x.py"]["always_run"] is True
+
+
+def test_own_directory_reads_do_not_count_as_a_dependency():
+    """Importing yourself is not a dependency on the rest of the tree."""
+    merged = {"scripts/tests/test_x.py": {
+        "paths": {"scripts/tests/test_x.py", "scripts/tests/helper.txt"},
+        "execs": set()}}
+    out = rc.classify(merged)["scripts/tests/test_x.py"]
+    assert out["always_run"] is False
+    assert out["opaque"] is False
+    assert out["n_paths"] == 0, out["sample_paths"]
+
+
+def test_an_external_read_becomes_a_trigger_prefix():
+    merged = {"scripts/tests/test_x.py": {
+        "paths": {"nix/pkgs/foo.nix", "scripts/lib/bar.sh"}, "execs": set()}}
+    out = rc.classify(merged)["scripts/tests/test_x.py"]
+    assert out["always_run"] is False
+    assert set(out["triggers"]) == {"nix/pkgs", "scripts/lib"}
+
+
+def test_opaque_does_not_silently_become_always_run():
+    """UNMEASURED must stay visible as its own bucket, per RULES.md."""
+    merged = {"scripts/tests/test_x.py": {
+        "paths": {"scripts/lib/a.sh"},
+        "execs": {"bash -c echo hi\t@."}}}
+    out = rc.classify(merged)["scripts/tests/test_x.py"]
+    assert out["always_run"] is False
+    assert out["opaque"] is True

--- a/scripts/tests/test_readset_classify.py
+++ b/scripts/tests/test_readset_classify.py
@@ -359,6 +359,32 @@ def test_dash_C_remains_the_ONE_acquittal_and_still_works():
     assert len(scans3) == 1, scans3
 
 
+def test_a_dash_C_inside_SCRIPT_TEXT_does_not_acquit_an_opaque_child():
+    """🔴 AUDIT R4-F1 — the defect class, FIFTH occurrence.
+
+    `_effective_cwd` scanned the whole token list before the head was known, so
+    any argv merely CONTAINING `-C` was acquitted — including one where `-C`
+    sits inside the shell script being interpreted. That is this module's own
+    original sin (reading an option-shaped token out of a string as evidence
+    about scope), surviving inside the one acquittal kept for being
+    unambiguous. It is only unambiguous for a command whose grammar defines it.
+    """
+    scans, opaque = _verdict(
+        "bash -c SHA=$(git -C /tmp/fx rev-parse HEAD); echo $SHA\t@.")
+    assert scans == [], scans
+    assert len(opaque) == 1, opaque
+
+
+def test_a_dash_C_that_is_ANOTHER_programs_flag_does_not_acquit():
+    """🔴 AUDIT R4-F1, second shape: `-C` as an unrelated flag of a repo script."""
+    for argv in ("bash scripts/run-tests.sh -C /tmp/outdir",
+                 "python3 -m pytest scripts/tests -C /tmp/out",
+                 "node scripts/x.mjs -C /tmp/out"):
+        scans, opaque = _verdict(f"{argv}\t@.")
+        assert scans == [], (argv, scans)
+        assert len(opaque) == 1, (argv, opaque)
+
+
 def test_a_relative_read_escaping_via_dotdot_is_not_recorded_in_repo(monkeypatch):
     """🟢 AUDIT R3-F4. `../../devrc-sibling/x` yielded prefix `scripts/..`."""
     monkeypatch.chdir(rp.REPO_ROOT / "scripts")

--- a/scripts/tests/test_readset_classify.py
+++ b/scripts/tests/test_readset_classify.py
@@ -103,17 +103,20 @@ def test_git_init_on_a_tmp_path_is_NOT_a_scan():
     assert opaque == [], opaque
 
 
-def test_a_read_verb_with_an_operand_OUTSIDE_the_repo_is_acquitted():
-    """Reaches the OPERAND acquittal, which nothing else here does.
+def test_a_scanner_with_an_outside_operand_is_OVER_classified_on_purpose():
+    """🔴 POLICY, and this assertion was REVERSED in round 3.
 
-    🔴 Added after a mutation sweep: deleting that acquittal left all 11 other
-    tests GREEN. `git init /tmp/x` never reaches it — the subcommand check
-    acquits `init` first — so the guard was unreachable and the suite was
-    asserting nothing about it. This uses a REAL scanner (`grep`, which would
-    otherwise be scored a scan) pointed at a path outside the tree.
+    It used to assert that an outside operand acquits the command. Deciding
+    that from argv needs a parser per tool — `grep`'s first operand is a
+    PATTERN, an option's value is not a path the command reads from, and four
+    successive defects came out of guessing. The module's stated rule is that
+    ambiguity resolves to ALWAYS-RUN, so a recognised scanner at a repo cwd is
+    now scored a scan unless `-C` says otherwise. Over-classification is the
+    safe direction; measured cost is 13 files moving OPAQUE -> ALWAYS-RUN and
+    ZERO change to `scoped`, so the published ceiling is unaffected.
     """
     scans, _ = _verdict("grep -r needle /tmp/somewhere-else\t@.")
-    assert scans == [], scans
+    assert len(scans) == 1, scans
 
 
 def test_a_stub_binary_outside_the_repo_is_NOT_a_scan():
@@ -169,14 +172,16 @@ def test_a_scan_outside_the_repo_is_acquitted():
     assert scans == []
 
 
-def test_dash_C_at_an_outside_path_is_acquitted_BY_THE_OPERAND_RULE():
-    """Behaviour pin. The acquittal is the operand rule, NOT a `-C` rule.
+def test_dash_C_at_an_outside_path_is_acquitted():
+    """Behaviour pin, and its NAME has been wrong twice — a name is a claim.
 
-    🔴 There used to be a dedicated `-C` branch and this test was written as if
-    it covered it. A mutation sweep disabled that branch and this test stayed
-    GREEN — because `/tmp/fixture` is an absolute operand outside the repo, so
-    the operand rule had already rejected it. The branch was dead code and is
-    gone; the behaviour it claimed to provide is real and still pinned here.
+    Round 1: a dedicated `-C` branch existed and this test was written as if it
+    covered it; a mutation sweep disabled the branch and this stayed GREEN,
+    because the OPERAND rule acquitted `/tmp/fixture` first. The branch was
+    dead code and was deleted, and the name was changed to credit the operand
+    rule. Round 3 then deleted the OPERAND rule (four defects came out of
+    guessing scope from operands) and restored a real `-C` rule — so the name
+    was wrong again, in the other direction. It now names no mechanism.
     """
     scans, _ = _verdict("git -C /tmp/fixture ls-files\t@.")
     assert scans == []
@@ -297,12 +302,68 @@ def test_bash_running_a_repo_script_over_THE_REPO_is_opaque_not_scoped():
     assert scans == [] and len(opaque) == 1, (scans, opaque)
 
 
-def test_an_outside_operand_still_acquits_a_RECOGNISED_scanner():
-    """The narrowing must survive being moved inside the recognised arms."""
+def test_only_dash_C_acquits_a_RECOGNISED_command_now():
+    """🔴 Round-3 policy: `-C` is the ONE acquittal; operands no longer acquit.
+
+    The first assertion was reversed in round 3 for the reason above.
+    """
     scans, opaque = _verdict("grep -r needle /tmp/elsewhere\t@.")
-    assert scans == [] and opaque == [], (scans, opaque)
+    assert len(scans) == 1 and opaque == [], (scans, opaque)
     scans2, _ = _verdict("git -C /tmp/fixture ls-files\t@.")
     assert scans2 == [], scans2
+
+
+def test_the_clean_whitelists_are_PINNED_two_way():
+    """🟡 AUDIT R3-F3. Spot-checks are not coverage for a whitelist.
+
+    `_HARMLESS` and `_GIT_WRITERS` are sets where a WRONG MEMBER IS SILENTLY
+    CLEAN. Round 2 added member spot-checks; a later sweep then showed dropping
+    `stash` or `echo` still survived a full green suite — 3 of 21 and 1 of 10
+    members actually covered. Pinning the exact sets, so adding or removing any
+    member fails here and has to be argued for.
+    """
+    assert rc._HARMLESS == frozenset({
+        "true", "false", "echo", "printf", "sleep", "uname",
+        "id", "whoami", "hostname", "date"}), sorted(rc._HARMLESS)
+    assert rc._GIT_WRITERS == frozenset({
+        "init", "add", "commit", "config", "checkout", "branch", "tag",
+        "push", "fetch", "clone", "remote", "reset", "rm", "mv", "stash",
+        "switch", "restore", "update-ref", "symbolic-ref", "gc",
+        "worktree"}), sorted(rc._GIT_WRITERS)
+
+
+def test_an_option_VALUE_pointing_outside_no_longer_acquits_a_scan():
+    """🔴 AUDIT R3-F1 — the same defect class, fourth occurrence.
+
+    An option's value counted as an operand, so a genuine scan of THIS tree
+    scored clean whenever any absolute outside path appeared anywhere in argv.
+    All of these read this repo:
+    """
+    for argv in ("git ls-files --exclude-from /tmp/ex",
+                 "find . -newer /tmp/stamp",
+                 "grep -rf /tmp/patterns .",
+                 "git grep -f /tmp/pats -- scripts",
+                 "git log --oneline -- scripts /tmp/x"):
+        scans, _ = _verdict(f"{argv}\t@.")
+        assert len(scans) == 1, (argv, scans)
+
+
+def test_dash_C_remains_the_ONE_acquittal_and_still_works():
+    """The single surviving acquittal — unambiguous, unlike an operand."""
+    scans, _ = _verdict("git -C /tmp/fixture ls-files\t@.")
+    assert scans == [], scans
+    root = str(rc.REPO_ROOT)
+    scans2, _ = _verdict(f"git -C {root} ls-files\t@.")
+    assert len(scans2) == 1, scans2
+    scans3, _ = _verdict("git -C scripts ls-files\t@.")
+    assert len(scans3) == 1, scans3
+
+
+def test_a_relative_read_escaping_via_dotdot_is_not_recorded_in_repo(monkeypatch):
+    """🟢 AUDIT R3-F4. `../../devrc-sibling/x` yielded prefix `scripts/..`."""
+    monkeypatch.chdir(rp.REPO_ROOT / "scripts")
+    assert rp._rel("../../devrc-sibling/x.py") is None
+    assert rp._rel("../nix/home.nix") == "nix/home.nix"
 
 
 def test_test_and_which_are_NOT_adjudicated_harmless():


### PR DESCRIPTION
Rank 2 of `claudedocs/handoff-ci-speedup.md`. That doc flags its own input 🔴 **NOT TRUSTWORTHY** — a regex called 32/139 files "repo-wide scanners" and over-classifies, flagging `test_drift_check.py` on a line where `git ls-files` sits inside a **fixture string**. It asked for empirical measurement. This is it.

> ⚠️ **This description was corrected after an adversarial audit** — see [the correction comment](https://github.com/innovation-upstream/devrc/pull/1120#issuecomment-5471441437). The original said 22/18/93 and a 1.49x ceiling. Both were wrong.

## Method

Read-set tracing: a `sys.addaudithook` records what each test file opens, lists, scans and spawns. Attributed to **both** collection and runtest, because module-level reads are real — several files read `nix/home.nix` at import, which a runtest-only hook loses. Timing from a **separate untraced run** so hook overhead is not in the numbers.

## Result — all 144 files classified

🔴 **Two denominators, named.** 144 files classified; 133 have timing pytest will show (`--durations` hides sub-5ms). Conflating them is what produced the original wrong table.

| bucket | files | of which timed | seconds | share of timed |
|---|---|---|---|---|
| ALWAYS-RUN (proven) | 27 | 27 | 185.5s | 14.3% |
| **OPAQUE** (unmeasured) | 61 | 60 | **1010.2s** | **78.1%** |
| scoped (provably skippable) | 56 | 46 | 97.6s | 7.5% |
| total | **144** | **133** | 1293.3s | |

**Best-case ceiling for a perfect path→target map: 1.08x.** Estimate history: 3x → 1.7x → uncertain → 1.49x → **1.08x measured**. The handoff estimated rank 3 at "~1.7x alone, ~3.6x after"; neither is reachable.

**Timing cross-check:** 1293.3s visible + ~74s pytest hides ≈ 1367s, and the handoff independently quotes 1367s by another route.

## 🔴 The recommendation this produces: do not build rank 3 yet

Only **7.5%** of suite time is provably skippable. **78.1%** is OPAQUE — subprocess reads the tracer cannot see. A mapping built today buys ~8% and inherits 61 unmeasured files as chances to skip a test that should have run. Making the opaque children legible is the prerequisite, and it decides more than any directory split.

`test_drift_check.py` — the file the handoff named as the regex's false positive — is **OPAQUE**, not ALWAYS-RUN. "Unproven" is more honest than either prior label.

## Blind spots, stated

- **Reads inside a subprocess** — the whole OPAQUE bucket.
- 🔴 **Stat-only dependencies are invisible.** CPython raises no audit event for `os.stat`/`Path.exists()` (measured, 3.12.14). A guard depending only on `(REPO_ROOT/"x.sh").exists()` records an empty read set. The corpus contains this shape.
- **Symlinks not followed** (`_rel` avoids `resolve()` so the hook cannot re-enter).
- **A test depending on a file it never reads** — no read-tracer can see it.
- **One run** — single-observation read sets.

## This classifier reproduced the bug it exists to fix — seven times

Each matched *characters* or an *enumeration* rather than the operation: bare tool name (`git init /tmp/x`); a read verb anywhere in argv (a stub `bw … status`); the same off **script text** in `bash -c`; first non-flag token as git subcommand (`git -C scripts ls-files` → subcommand "scripts", acquitted); OPAQUE keyed on literal `-c`; argv[0] in `/nix/store` acquitting real scans; and cwd required to be exactly `.`.

A mutation sweep caught three and showed **three guards were unreachable**. An audit caught the rest on real corpus files. 🔴 **Then the fix round introduced its own regression** — a separator-terminated prefix made REPO_ROOT compare as outside the repo, acquitting `git -C <REPO_ROOT> ls-files`; ALWAYS-RUN fell 22 → 9, caught only by diffing the two classification runs.

## Tests

27 guards in `scripts/tests/test_readset_classify.py`, each pinning a defect these files actually shipped, each **watched red** against pre-fix code under `PYTHONDONTWRITEBYTECODE=1`. Two pre-existing tests had assertions **inverted** because they encoded behaviour the audit proved wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5swnZSyv5Ae6LPBhJ2gPM