### PR TITLE
feat(signal): mentions on outbound drafts, and bind the send capability to the payload it approves

### DIFF
--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -139,6 +139,7 @@ rather than printing a traceback):
 | `--mention` given for a non-group `--to` | `MentionsRequireAGroup` |
 | two mentions claim overlapping spans | `MentionSpansOverlap` |
 | the group-membership lookup itself failed (bad/empty `--from-number`, HTTP error) | `MentionGroupLookupFailed` |
+| the stored contact rows put two real people into one identity (a placeholder row sharing a number with both) | `MentionIdentityUnresolvable` |
 
 Names are resolved against **this group's membership only**
 (`GET /v1/groups/<account>/<group-id>` joined against `signal.contacts`) — the

--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -62,6 +62,12 @@ python3 consumer.py draft --to +15550100 --body "on my way"   # -> pending + a c
 
 # draft to a GROUP: --to takes the `id` field (group.<double-base64>), NOT internal_id
 python3 consumer.py draft --to 'group.<double-base64>' --body "on my way"
+
+# MENTION group members (repeatable). The body must ALREADY contain the literal
+# `@<who>` text — a Signal mention REPLACES that span, so it has to exist.
+python3 consumer.py draft --to 'group.<double-base64>' \
+        --body "@Ann and @Bob — can one of you take this?" \
+        --mention Ann --mention Bob
 python3 consumer.py drafts --state pending
 python3 consumer.py approve 42 --ref clawgate-task-91
 python3 consumer.py send 42
@@ -71,6 +77,41 @@ python3 consumer.py drafts --state sending
 python3 consumer.py reconcile 42 --sent --timestamp 1723000009090   # it did go out
 python3 consumer.py reconcile 42 --not-sent --note "no message in the thread"
 ```
+
+## Mentions (`draft --mention`, GROUPS only)
+
+`--mention` is repeatable and takes a member's **display name**, or their bare
+**uuid** / **+E.164**. On the wire each becomes
+`{"author", "start", "length"}` — exactly those three keys — where the offsets are
+**UTF-16 code units**, not Python code points: an emoji before the mention shifts
+`start` by **2**, not 1. `_mentions.utf16_len()` is the one place that is computed.
+
+The body must already contain the literal `@<who>`. Signal REPLACES that span with
+`@DisplayName` on the receiving client, so if the text is not there, there is nothing
+to replace.
+
+🔴 **Every failure is a REFUSAL (exit 3), never a silent drop** — a mention pushes a
+notification through the recipient's mute settings and names a third party, so
+sending fewer than were asked for is a different act from the one that was approved.
+The six refusals, each with its own error class in `scripts/signal/_mentions.py`:
+
+| Situation | Error |
+|---|---|
+| no group member answers to that name | `MentionNameNotFound` |
+| two or more members do | `MentionNameAmbiguous` |
+| it resolves to a `is_placeholder` contact (a synthetic id) | `MentionResolvesToPlaceholder` |
+| an explicit uuid/E.164 is not in this group | `MentionNotAMember` |
+| the body has no `@<who>` text | `MentionSpanMissing` |
+| `--mention` given for a non-group `--to` | `MentionsRequireAGroup` |
+
+Names are resolved against **this group's membership only**
+(`GET /v1/groups/<account>/<group-id>` joined against `signal.contacts`) — the
+`members[]` array is MIXED E.164 and bare UUID, so both contact columns are matched.
+A name that matches somebody in a different conversation does not resolve here.
+
+The clawgate approval card lists every `author` the message will ping, above the body
+preview: `@Ann` in the preview is indistinguishable from ordinary prose, and approving
+a message without seeing who it notifies is the failure mode that line exists to close.
 
 ## Muted groups
 
@@ -215,6 +256,17 @@ composes and transmits**.
    exactly `approved` — and `consumer.transmit_approved()` refuses to post without
    one. The capability's constructor refuses direct construction; a spent capability
    cannot be replayed.
+
+4. 🔴 **The approval is bound to the PAYLOAD, not just to the draft id.**
+   `approve` records a SHA-256 digest of `(recipient, body, mentions)` in
+   `signal.messages.approved_digest`; `_mint_send_authorization()` refuses to mint
+   for a row that no longer hashes to it, and `spend_authorization()` re-checks the
+   payload it is about to post against the capability. Two distinct windows:
+   *approve → send* (separate CLI invocations, closed by the digest) and
+   *mint → POST* (closed by the binding). **Fails closed**: a missing digest is a
+   refusal, because "never had one" and "cleared by the writer we are guarding
+   against" are the same observation. The way out is to read the changed draft and
+   `approve` it again.
 
 Every refusal raises **`SendGateError`**. `scripts/signal/tests/test_approval_gate.py`
 attempts six documented bypasses and requires each to fail with that error.

--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -48,6 +48,7 @@ code route and will raise `SendGateError`.
 | `draft` | compose an outbound draft — **stores it, transmits nothing** |
 | `drafts` | list drafts with their `send_state` |
 | `approve` | record Zach's clawgate approval for one pending draft |
+| `unapprove` | withdraw an approval: `approved` → `pending`, clearing the digest, so the draft can be approved again. The **only** route out of a digest refusal |
 | `send` | transmit an **approved** draft (refuses anything else) |
 | `reconcile` | resolve a draft stranded in `sending`, after checking Signal yourself |
 | `muted` | list muted groups and how many stored rows each one hides |
@@ -72,6 +73,13 @@ python3 consumer.py drafts --state pending
 python3 consumer.py approve 42 --ref clawgate-task-91
 python3 consumer.py send 42
 
+# `send` refused with "CHANGED after it was approved" (or "NO approval digest")?
+# The draft is still `approved` and cannot be sent under that approval. Read it,
+# then withdraw the approval and give a fresh one — these are the ONLY commands
+# that move it, and both need SIGNAL_APPROVAL_TOKEN:
+python3 consumer.py unapprove 42 --note "body was edited after approval"
+python3 consumer.py approve 42 --ref clawgate-task-92
+
 # a draft stuck in `sending` — check Signal FIRST, then say which happened:
 python3 consumer.py drafts --state sending
 python3 consumer.py reconcile 42 --sent --timestamp 1723000009090   # it did go out
@@ -88,12 +96,19 @@ python3 consumer.py reconcile 42 --not-sent --note "no message in the thread"
 
 The body must already contain the literal `@<who>`. Signal REPLACES that span with
 `@DisplayName` on the receiving client, so if the text is not there, there is nothing
-to replace.
+to replace. The match is **case-insensitive** (so `--mention ANN` finds `@Ann` — name
+resolution has always been case-insensitive, and the span search now agrees with it)
+and is **bounded on the right**: `@Ann` will not match inside `@Anna`, so a member
+whose name is a PREFIX of another member's cannot steal their ping. Two mentions whose
+spans **overlap** are refused (`MentionSpansOverlap`) — overlapping spans are two
+rewrites of the same characters and what the recipient renders is undefined.
 
 🔴 **Every failure is a REFUSAL (exit 3), never a silent drop** — a mention pushes a
 notification through the recipient's mute settings and names a third party, so
 sending fewer than were asked for is a different act from the one that was approved.
-The six refusals, each with its own error class in `scripts/signal/_mentions.py`:
+The refusals, each with its own error class in `scripts/signal/_mentions.py` (all
+subclass `MentionError`, which is a `ValueError`, so `draft` catches them and exits 3
+rather than printing a traceback):
 
 | Situation | Error |
 |---|---|
@@ -103,15 +118,26 @@ The six refusals, each with its own error class in `scripts/signal/_mentions.py`
 | an explicit uuid/E.164 is not in this group | `MentionNotAMember` |
 | the body has no `@<who>` text | `MentionSpanMissing` |
 | `--mention` given for a non-group `--to` | `MentionsRequireAGroup` |
+| two mentions claim overlapping spans | `MentionSpansOverlap` |
+| the group-membership lookup itself failed (bad/empty `--from-number`, HTTP error) | `MentionGroupLookupFailed` |
 
 Names are resolved against **this group's membership only**
 (`GET /v1/groups/<account>/<group-id>` joined against `signal.contacts`) — the
 `members[]` array is MIXED E.164 and bare UUID, so both contact columns are matched.
 A name that matches somebody in a different conversation does not resolve here.
 
-The clawgate approval card lists every `author` the message will ping, above the body
+The clawgate approval card lists everyone the message will ping, above the body
 preview: `@Ann` in the preview is indistinguishable from ordinary prose, and approving
 a message without seeing who it notifies is the failure mode that line exists to close.
+Each line carries the resolved **display name** as well as the `author` id — the id is
+usually a bare uuid, which tells a human nothing they can check — and the offsets are
+labelled **UTF-16 units**, which is what they are.
+
+Refusal messages deliberately do **not** dump the group roster: `draft` needs no
+approval token, so an unbounded membership enumeration in an error would be a free,
+repeatable probe of any group address a caller can guess, muted ones included. A
+"no such name" refusal shows at most `_mentions.NAME_HINT_MAX` names plus a count of
+those withheld; a "not a member" refusal shows the member count only.
 
 ## Muted groups
 
@@ -265,8 +291,38 @@ composes and transmits**.
    *approve → send* (separate CLI invocations, closed by the digest) and
    *mint → POST* (closed by the binding). **Fails closed**: a missing digest is a
    refusal, because "never had one" and "cleared by the writer we are guarding
-   against" are the same observation. The way out is to read the changed draft and
-   `approve` it again.
+   against" are the same observation.
+
+5. 🔴 **The way out of a digest refusal is `unapprove`, then `approve`.** The
+   refusal happens *before* the draft is claimed for sending, so the row stays
+   `approved` — and `approve` is `pending`-only while `reconcile` is
+   `sending`-only. Without `unapprove` a refused draft is **unsendable forever**
+   and the only remedy is hand-editing the row, which is precisely the second
+   writer the digest exists to catch. `unapprove <id> [--note …]` moves
+   `approved → pending` and **NULLs `approved_digest`** (a pending row must never
+   carry a stale one); it needs the same `SIGNAL_APPROVAL_TOKEN` as `approve`,
+   refuses any draft that is not `approved`, and transmits nothing. The next
+   `approve` records a fresh `approval_ref` and recomputes the digest over the
+   draft as it now stands.
+
+   🔴 **The digest is over a CANONICAL recipient identity** — the contact/group
+   ROW ID — not over the recipient string `get_draft()` prints. That string is a
+   projection which flips from a phone number to a uuid when `_promote_
+   placeholder()` learns a real uuid during ordinary background ingest, so
+   hashing it made "DM someone new, then their first message arrives" refuse the
+   send with no adversary involved.
+
+   ⚠️ **Before rolling this out, drain the pre-existing approvals.** Drafts
+   approved *before* `approved_digest` existed carry NULL and fail closed on the
+   first `send`. Find them first:
+
+   ```sql
+   SELECT id, send_state, approval_ref FROM signal.messages
+    WHERE send_state = 'approved' AND approved_digest IS NULL;
+   ```
+
+   Each one is recovered the same way: read it (`drafts --state approved`), then
+   `unapprove <id> --note "pre-digest approval"` and `approve <id> --ref <ref>`.
 
 Every refusal raises **`SendGateError`**. `scripts/signal/tests/test_approval_gate.py`
 attempts six documented bypasses and requires each to fail with that error.

--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -98,10 +98,29 @@ The body must already contain the literal `@<who>`. Signal REPLACES that span wi
 `@DisplayName` on the receiving client, so if the text is not there, there is nothing
 to replace. The match is **case-insensitive** (so `--mention ANN` finds `@Ann` — name
 resolution has always been case-insensitive, and the span search now agrees with it)
-and is **bounded on the right**: `@Ann` will not match inside `@Anna`, so a member
-whose name is a PREFIX of another member's cannot steal their ping. Two mentions whose
-spans **overlap** are refused (`MentionSpansOverlap`) — overlapping spans are two
-rewrites of the same characters and what the recipient renders is undefined.
+and is **bounded on the right** by two rules working together, because one is not
+enough:
+
+- a **word boundary** — `@Ann` will not match inside `@Anna`;
+- a **member-aware prefix check** — a hit where another GROUP MEMBER's longer
+  `@name` starts at the same offset is skipped, whatever separates the parts. The
+  word boundary alone let `@Ann` land inside `@Ann-Marie`, `@Ann.Smith`,
+  `@Ann'Marie` and `@Ann Smith`, because a hyphen, a dot, an apostrophe and a
+  space are all non-word characters: Ann was pinged while the visible text
+  stayed the other member's name.
+
+Together: a name that is a prefix of **another group member's** name cannot steal
+their ping. Note the scope — this is about *member* names. `@Ann` in a body reading
+`@Ann-the-dog`, where no member is called `Ann-the-dog`, still matches, and ordinary
+punctuation after a mention (`thanks @Ann.`) still matches, which is the point of
+making the rule member-aware rather than banning punctuation. If no non-colliding
+occurrence exists the draft is **refused** (`MentionSpanMissing`), never sent with the
+wrong span.
+
+Two mentions whose spans **overlap** are refused (`MentionSpansOverlap`) — overlapping
+spans are two rewrites of the same characters and what the recipient renders is
+undefined. (Reachable when one person carries two stored names, e.g. `display_name`
+`Ann` and `profile_name` `Ann Smith`, and both are mentioned.)
 
 🔴 **Every failure is a REFUSAL (exit 3), never a silent drop** — a mention pushes a
 notification through the recipient's mute settings and names a third party, so
@@ -312,17 +331,32 @@ composes and transmits**.
    hashing it made "DM someone new, then their first message arrives" refuse the
    send with no adversary involved.
 
-   ⚠️ **Before rolling this out, drain the pre-existing approvals.** Drafts
-   approved *before* `approved_digest` existed carry NULL and fail closed on the
-   first `send`. Find them first:
+   ⚠️ **Drain the pre-existing approvals — as the FIRST step AFTER this ships,
+   before anyone runs `send`.** Drafts approved *before* `approved_digest`
+   existed carry NULL and fail closed on the first `send`.
 
-   ```sql
-   SELECT id, send_state, approval_ref FROM signal.messages
-    WHERE send_state = 'approved' AND approved_digest IS NULL;
-   ```
+   🔴 The order matters and the old wording had it backwards ("before rolling
+   this out"). Every tool the recovery needs — the `approved_digest` column, the
+   `unapprove` command — ships **in this change**: the column is created by
+   `ensure_schema()` on consumer start, and `unapprove` does not exist on the
+   previous revision. So the procedure is only executable once the new consumer
+   is running, and it is not urgent before then, because the old revision does
+   not enforce the digest and those drafts send normally there. The window to
+   worry about is deploy → first `send`, not before deploy.
 
-   Each one is recovered the same way: read it (`drafts --state approved`), then
-   `unapprove <id> --note "pre-digest approval"` and `approve <id> --ref <ref>`.
+   1. Deploy, and let the consumer start (that is what runs `ensure_schema()`
+      and adds the column).
+   2. Find them:
+
+      ```sql
+      SELECT id, send_state, approval_ref FROM signal.messages
+       WHERE send_state = 'approved' AND approved_digest IS NULL;
+      ```
+
+   3. Recover each one the same way: read it (`drafts --state approved`), then
+      `unapprove <id> --note "pre-digest approval"` and `approve <id> --ref <ref>`.
+      The note is **appended** to `approval_ref`, so the original reference stays
+      in the row alongside it — the trail reads `"<old-ref> | pre-digest approval"`.
 
 Every refusal raises **`SendGateError`**. `scripts/signal/tests/test_approval_gate.py`
 attempts six documented bypasses and requires each to fail with that error.

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1760,7 +1760,16 @@ TARGET_FLOORS=(
   # that is what is below, copied not computed. Found by a run on an unrelated
   # branch: this was already RED on origin/main, so it was blocking every push
   # rather than only the change that noticed it.
-  "scripts/signal/tests|682"
+  # 2026-08-30: 968 tripped the ceiling at 852 with every test PASSING — the
+  # floor had fallen 286 behind, far more than the 170 of slack the gate allows,
+  # so several whole suites could have vanished under it while the run stayed
+  # green. The gate printed "scripts/signal/tests|920" and that is what is
+  # below, copied not computed. The growth is PR #1121's MENTIONS work: the
+  # suite went from a 682 floor to 968 collected in one change. It also added
+  # the run's THIRD skip — `test_pg_type_compat.py:228`, the real-Postgres
+  # idempotence check for `ensure_schema()` — so unlike every entry above this
+  # one, EXPECTED_SKIPS is NOT untouched; see its new sibling pin there.
+  "scripts/signal/tests|920"
   "scripts/initiatives/tests|745"
   "scripts/repo-cos/tests|315"
   "scripts/task-spec-drafter/tests|135"
@@ -3180,6 +3189,20 @@ EXPECTED_SKIPS=(
   # SIGNAL_PG_DSN — the test then RUNS, the skip total drops to 1, and the flat
   # entry count still said 2.
   "scripts/signal/tests|needs a real Postgres|unset:SIGNAL_PG_DSN"
+  # The SECOND real-Postgres test in the same file (test_pg_type_compat.py:228),
+  # added by PR #1121: `ensure_schema()` runs on every consumer start, so it must
+  # be re-runnable, and only a real server can answer that. Its hermetic sibling
+  # in test_mentions.py asserts `fakepg`'s own EMULATION of `ADD COLUMN IF NOT
+  # EXISTS` — a claim about the substrate, not about the deployed engine.
+  # A SEPARATE entry rather than a widened regex, because the accounting compares
+  # the skip TOTAL against the number of applicable ENTRIES (one test per entry):
+  # letting the pin above absorb both would leave 3 skips against 2 entries and
+  # keep the gate red. Same reason, same conditional, same consequence as its
+  # sibling: opt-in only, never runs in the gate, so pinning unbreaks main but
+  # does not restore the coverage.
+  # CONDITIONAL for the same reason: with SIGNAL_PG_DSN exported this test RUNS,
+  # and a flat entry count would then say 3 where 1 skip is observed.
+  "scripts/signal/tests|the hermetic substrate EMULATES|unset:SIGNAL_PG_DSN"
   # GUARD 9's positive control for `_own_xdist_run_id()`
   # (test_gitenv_sibling_exclusion.py::test_a_real_worker_reports_a_run_id).
   # 🔴 IT CANNOT BE FAKED INTO RUNNING IN-PROCESS, and the alternative was

--- a/scripts/signal/Dockerfile
+++ b/scripts/signal/Dockerfile
@@ -50,6 +50,7 @@ COPY scripts/signal/consumer.py    /app/scripts/signal/
 COPY scripts/signal/_signal_db.py  /app/scripts/signal/
 COPY scripts/signal/_minio.py      /app/scripts/signal/
 COPY scripts/signal/clawgate.py    /app/scripts/signal/
+COPY scripts/signal/_mentions.py   /app/scripts/signal/
 
 # --------------------------------------------------------------------------- #
 # 🔴 SIGNAL_PG_DIRECT=1 IS A PROPERTY OF THE IMAGE, NOT A DEPLOYMENT CHOICE.

--- a/scripts/signal/Dockerfile.dockerignore
+++ b/scripts/signal/Dockerfile.dockerignore
@@ -4,3 +4,4 @@
 !scripts/signal/_signal_db.py
 !scripts/signal/_minio.py
 !scripts/signal/clawgate.py
+!scripts/signal/_mentions.py

--- a/scripts/signal/_mentions.py
+++ b/scripts/signal/_mentions.py
@@ -42,6 +42,12 @@ _E164_RE = re.compile(r"^\+[1-9]\d{6,14}$")
 # would be silently dropped by the server, and a missing one mis-renders.
 MENTION_KEYS = ("author", "start", "length")
 
+# How many member names a "no such name" refusal may print. See the comment at
+# the raise site: `draft` needs no approval token, so an unbounded enumeration
+# turns a refusal into a free membership oracle for any group address a caller
+# can guess.
+NAME_HINT_MAX = 5
+
 
 class MentionError(ValueError):
     """Base: a `--mention` could not be turned into a wire mention.
@@ -82,6 +88,28 @@ class MentionSpanMissing(MentionError):
     """The body does not contain the `@<identifier>` text this mention covers."""
 
 
+class MentionSpansOverlap(MentionError):
+    """Two mentions claim OVERLAPPING spans of the body.
+
+    Signal REPLACES each `[start, start+length)` span with `@DisplayName` on the
+    receiving client. Two spans that overlap are not two pings on two words —
+    they are two rewrites of the SAME characters, and what the recipient sees is
+    undefined. Refused rather than sent, for the same reason every other failure
+    here is: the operator approved a card describing two distinct pings.
+    """
+
+
+class MentionGroupLookupFailed(MentionError):
+    """The group-membership lookup itself failed, so nothing can be resolved.
+
+    A `MentionError` (hence a `ValueError`) on purpose: `consumer.main()`'s
+    `draft` handler catches `ValueError` and exits 3. Before this existed an
+    HTTP error from `GET /v1/groups/<number>/<id>` — a 404 from an EMPTY
+    `--from-number` being the ordinary case — escaped as a traceback and exit 1,
+    which a caller cannot tell apart from the interpreter dying.
+    """
+
+
 # --------------------------------------------------------------------------- #
 # UTF-16 offsets — the whole point
 # --------------------------------------------------------------------------- #
@@ -96,24 +124,66 @@ def utf16_len(text: str) -> int:
     return len(text.encode("utf-16-le")) // 2
 
 
+def _needle_pattern(needle: str) -> "re.Pattern":
+    """The ONE definition of "this body says `@who` here".
+
+    🔴 TWO THINGS THE PLAIN `str.find()` GOT WRONG, both silent:
+
+    * **NO BOUNDARY.** `find("@Ann")` matches INSIDE `"@Anna"`. With members
+      `Ann` and `Anna` and a body `"hi @Anna and @Ann ok"`, `--mention Ann`
+      produced span `(3, 4)` — Ann is pinged, Anna's name is the text on screen,
+      and the render is corrupted. `(?!\\w)` requires a non-word character (or
+      end of string) immediately after the needle, so a name that is a PREFIX of
+      another member's name can no longer land on them. The scan CONTINUES past
+      a boundary-failing hit rather than refusing, so the real `@Ann` later in
+      that body is still found.
+    * **CASE.** `_resolve_one()` matches names case-INSENSITIVELY (`.lower()`),
+      so `--mention ANN` resolved to Ann and then died on `MentionSpanMissing`
+      against a body reading `@Ann` — resolution and span search disagreed about
+      what the same argument meant. `re.IGNORECASE` makes the two halves agree.
+      A regex is used rather than lower-casing the body because `str.lower()`
+      and `str.casefold()` can CHANGE LENGTH (`İ`, `ß`), which would silently
+      shift every offset computed from the folded copy.
+    """
+    return re.compile(re.escape(needle) + r"(?!\w)", re.IGNORECASE | re.UNICODE)
+
+
+def find_span(body: str, needle: str, *, from_index: int = 0) -> tuple[int, int, int]:
+    """`(code_point_index, start, length)` of `needle` in `body`.
+
+    `start`/`length` are UTF-16 code units — the wire units. The code-point index
+    is returned as well so the CALLER's search cursor is advanced from the SAME
+    match this span describes; the previous code re-ran `body.find()` to move the
+    cursor, a second copy of the predicate that would now disagree with the
+    boundary-aware search above.
+    """
+    body = body or ""
+    match = _needle_pattern(needle).search(body, from_index)
+    if match is None:
+        raise MentionSpanMissing(
+            f"the draft body does not contain {needle!r}"
+            + (f" at or after character {from_index}" if from_index else "")
+            + " as a whole word. A Signal mention REPLACES an existing span of "
+              "the message text, so the text has to be there — and a match that "
+              "runs straight into more letters (`@Ann` inside `@Anna`) is a "
+              "DIFFERENT person's name, not this one. Add it to --body, or drop "
+              "the --mention."
+        )
+    idx = match.start()
+    return idx, utf16_len(body[:idx]), utf16_len(needle)
+
+
 def utf16_span(body: str, needle: str, *, from_index: int = 0) -> tuple[int, int]:
     """`(start, length)` of `needle` in `body`, in UTF-16 code units.
 
     `from_index` is a CODE POINT index into `body` — the search cursor, used so
     two mentions of the same identifier take successive occurrences instead of
     both claiming the first. Raises `MentionSpanMissing` if the needle is not
-    present at or after it.
+    present at or after it. A thin wrapper over `find_span()` so there is exactly
+    one matching rule.
     """
-    idx = body.find(needle, from_index)
-    if idx < 0:
-        raise MentionSpanMissing(
-            f"the draft body does not contain {needle!r}"
-            + (f" at or after character {from_index}" if from_index else "")
-            + ". A Signal mention REPLACES an existing span of the message text, "
-              "so the text has to be there — add it to --body, or drop the "
-              "--mention."
-        )
-    return utf16_len(body[:idx]), utf16_len(needle)
+    _, start, length = find_span(body, needle, from_index=from_index)
+    return start, length
 
 
 # --------------------------------------------------------------------------- #
@@ -189,15 +259,40 @@ def resolve_mentions(identifiers, *, body: str, members, contacts,
     for ident in idents:
         author = _resolve_one(ident, member_set=member_set, candidates=candidates)
         needle = "@" + ident
-        start, length = utf16_span(body or "", needle,
-                                   from_index=cursor_for.get(needle, 0))
+        idx, start, length = find_span(body or "", needle,
+                                       from_index=cursor_for.get(needle, 0))
         # Advance THIS needle's cursor past the occurrence just claimed, so
         # `--mention Ann --mention Ann` takes the first and second "@Ann" rather
-        # than pointing both mentions at the same span.
-        cursor_for[needle] = (body or "").find(needle,
-                                              cursor_for.get(needle, 0)) + len(needle)
+        # than pointing both mentions at the same span. Derived from the match
+        # `find_span` returned, NOT from a second search.
+        cursor_for[needle] = idx + len(needle)
         out.append({"author": author, "start": start, "length": length})
+    _refuse_overlapping_spans(out)
     return out
+
+
+def _refuse_overlapping_spans(mentions: list) -> None:
+    """🔴 No two mentions may claim the same characters.
+
+    The word boundary above removes the `Ann`-inside-`@Anna` case, but it cannot
+    remove this one: with members `Ann` and `Ann Smith` and a body `@Ann Smith`,
+    `--mention "Ann Smith"` spans `(0, 10)` and `--mention Ann` spans `(0, 4)` —
+    both boundary-legal (a space follows `@Ann`), both starting at 0. The
+    receiving client is handed two overlapping rewrites of one region and what
+    it renders is undefined, so this refuses rather than sending it.
+    """
+    spans = sorted(((m["start"], m["start"] + m["length"], i)
+                    for i, m in enumerate(mentions)), key=lambda s: (s[0], s[1]))
+    for (a_start, a_end, a_i), (b_start, b_end, b_i) in zip(spans, spans[1:]):
+        if b_start < a_end:
+            raise MentionSpansOverlap(
+                f"--mention #{a_i + 1} covers UTF-16 units {a_start}–{a_end} and "
+                f"--mention #{b_i + 1} covers {b_start}–{b_end}; the two spans "
+                f"OVERLAP. A Signal mention REPLACES its span with the member's "
+                f"display name, so overlapping spans are two rewrites of the same "
+                f"characters and the result on the recipient's screen is "
+                f"undefined. Give each mention its own `@who` text in --body."
+            )
 
 
 def _resolve_one(ident: str, *, member_set: set, candidates: list) -> str:
@@ -207,8 +302,17 @@ def _resolve_one(ident: str, *, member_set: set, candidates: list) -> str:
         if _norm_member(ident) not in member_set:
             raise MentionNotAMember(
                 f"{ident!r} is a valid Signal identifier but is NOT a member of "
-                f"the target group, so mentioning it would notify nobody. "
-                f"The group's members are {sorted(member_set)!r}."
+                f"the target group, so mentioning it would notify nobody. The "
+                f"group has {len(member_set)} member(s). "
+                # 🔴 THE ROSTER IS NOT PRINTED. `draft` needs no approval token,
+                # so this refusal is a FREE, repeatable probe available to any
+                # agent that can run the CLI — and it used to interpolate every
+                # member uuid and phone number, for a group the caller may only
+                # have guessed the address of and which may be MUTED. A raw
+                # identifier list is also the least actionable thing that could
+                # go here: the operator typed an id, so the answer they need is
+                # "not this group", not 40 uuids to eyeball.
+                f"Check --to names the group you meant."
             )
         for contact in candidates:
             if _norm_member(ident) in _contact_ids(contact) \
@@ -229,11 +333,21 @@ def _resolve_one(ident: str, *, member_set: set, candidates: list) -> str:
     for contact in matched:
         by_author.setdefault(_contact_author(contact), contact)
     if not by_author:
+        # 🔴 TRUNCATED, DELIBERATELY. Some names help an operator spot a typo;
+        # the WHOLE list is a roster dump, and `draft` needs no approval token,
+        # so an unbounded enumeration here is a free membership oracle for any
+        # group address a caller can guess — muted ones included. A few names
+        # keeps the message actionable; the count keeps it honest about what is
+        # being withheld.
         known = sorted({n for c in candidates for n in _contact_names(c)})
+        shown = known[:NAME_HINT_MAX]
+        more = len(known) - len(shown)
         raise MentionNameNotFound(
-            f"no member of the target group is named {ident!r}. Known member "
-            f"names are {known!r}. Pass a bare uuid or +E.164 instead if the "
-            f"person has no stored name."
+            f"no member of the target group is named {ident!r}. Some known member "
+            f"names: {shown!r}"
+            + (f" (+{more} not shown)" if more > 0 else "")
+            + ". Pass a bare uuid or +E.164 instead if the person has no stored "
+              "name."
         )
     if len(by_author) > 1:
         raise MentionNameAmbiguous(
@@ -264,13 +378,78 @@ def canonical_mentions(mentions) -> tuple:
     must all compare EQUAL (they mean the same thing — no mentions), while any
     difference in author, offset or ORDER must compare unequal.
     """
-    return tuple(
-        (str(m.get("author")), int(m.get("start")), int(m.get("length")))
-        for m in (mentions or [])
-    )
+    return tuple(_one_canonical(m) for m in (mentions or []))
 
 
-def describe_mentions(mentions) -> list[str]:
-    """Human lines for the clawgate card — WHO this message will notify."""
-    return [f"{m['author']} (chars {m['start']}–{m['start'] + m['length']})"
-            for m in (mentions or [])]
+def _one_canonical(mention) -> tuple:
+    """One stored mention → `(author, start, length)`, or a `MentionError`.
+
+    🔴 A MALFORMED STORED ROW IS A REFUSAL, NOT A `TypeError`. The `mentions`
+    column is JSON written by an earlier process; a row carrying `null`, a
+    string, or an entry missing `start` used to reach `int(None)` and raise a
+    bare `TypeError` — which no CLI handler catches (`send` catches
+    `SendGateError`, `draft` catches `ValueError`), so a bad row in the database
+    surfaced as a traceback and exit 1 instead of a refusal and exit 3.
+    `MentionError` is a `ValueError`, and the two send-path call sites in
+    `_signal_db` translate it to `SendGateError`.
+    """
+    if not isinstance(mention, dict):
+        raise MentionError(
+            f"unreadable stored mention {mention!r}: each entry must be an object "
+            f"with {list(MENTION_KEYS)!r}")
+    try:
+        return (str(mention["author"]), int(mention["start"]),
+                int(mention["length"]))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise MentionError(
+            f"unreadable stored mention {mention!r}: it must carry "
+            f"{list(MENTION_KEYS)!r} with an integer start and length ({exc})"
+        ) from exc
+
+
+def describe_mentions(mentions, author_names=None) -> list[str]:
+    """Human lines for the clawgate card — WHO this message will notify.
+
+    🔴 A BARE UUID IS NOT AN ANSWER TO "WHO". The card exists so a human can see
+    who a draft pings before approving it, and
+    `11111111-1111-4111-8111-111111111111` tells them nothing they can check —
+    it is exactly as opaque as the `@Ann` in the preview it was added to
+    disambiguate. `author_names` maps `author` → the resolved display/profile
+    name; the id stays on the line too, because the name is what a human reads
+    and the id is what actually goes on the wire.
+
+    🔴 "chars" WAS WRONG. `start`/`length` are UTF-16 CODE UNITS, and the whole
+    reason `utf16_len()` exists is that those differ from characters the moment
+    an emoji appears earlier in the body. A card that says "chars 3–7" for a body
+    whose `@Ann` starts at character 2 sends the operator checking the wrong
+    thing.
+    """
+    names = author_names or {}
+    lines = []
+    for mention in (mentions or []):
+        author, start, length = _one_canonical(mention)
+        name = str(names.get(author) or "").strip()
+        who = f"{name} <{author}>" if name else f"(no stored name) <{author}>"
+        lines.append(f"{who} — replaces UTF-16 units {start}–{start + length}")
+    return lines
+
+
+def author_names(mentions, contacts) -> dict:
+    """`{author_id: display name}` for the ids in `mentions`. PURE.
+
+    Built from the SAME contact rows the resolver matched against, so the name on
+    the card is the name the resolver used — not a second lookup that could
+    disagree with it.
+    """
+    wanted = {str(m.get("author")) for m in (mentions or [])
+              if isinstance(m, dict) and m.get("author")}
+    out = {}
+    for contact in (contacts or []):
+        name = contact.get("display_name") or contact.get("profile_name")
+        if not str(name or "").strip():
+            continue
+        for ident in _contact_ids(contact):
+            for author in wanted:
+                if _norm_member(author) == ident:
+                    out.setdefault(author, str(name).strip())
+    return out

--- a/scripts/signal/_mentions.py
+++ b/scripts/signal/_mentions.py
@@ -351,7 +351,8 @@ def resolve_mentions(identifiers, *, body: str, members, contacts,
     # the new one", and never invents a class the matcher does not have.
     cursors: list[list] = []  # [needle, cursor] in first-seen order
     for ident in idents:
-        author = _resolve_one(ident, member_set=member_set, candidates=candidates)
+        author = _resolve_one(ident, member_set=member_set,
+                              candidates=candidates, identity=identity)
         needle = "@" + ident
         slot = next((s for s in cursors if _same_needle(s[0], needle)), None)
         if slot is None:
@@ -375,44 +376,72 @@ def resolve_mentions(identifiers, *, body: str, members, contacts,
 
 
 def _identity_groups(candidates: list) -> dict[str, frozenset]:
-    """`identifier -> every identifier belonging to the SAME PERSON`.
+    """`author id -> the author ids of every contact ROW that is the SAME PERSON`.
+
+    THE ONE DEFINITION OF "these two contact rows are one person". Both
+    `_colliding_needles()` (is this OTHER member's longer name allowed to veto?)
+    and `_resolve_one()` (are these two matches an AMBIGUITY?) ask it, so the two
+    cannot drift apart — round-4 audit F-B, where the second site open-coded the
+    predicate as a per-row author string while its own comment claimed identity.
 
     🔴 ONE PERSON CAN BE TWO CONTACT ROWS, DURABLY. `_promote_placeholder()`'s
     `NOT EXISTS` branch deliberately DECLINES when a real row already holds the
-    uuid, so a phone-only placeholder minted by a draft is left in place forever
+    uuid, so a phone-only PLACEHOLDER minted by a draft is left in place forever
     once an envelope has taught the real row the same number. Both rows then
-    carry that number, and the shared identifier is the only thing that ties
-    them together — which is what this unions on.
+    carry that number, and the shared identifier is the only thing tying them
+    together.
 
-    Round-3 audit F3: `_colliding_needles()` compared raw `_contact_author()`
-    strings, so that person read as TWO people and their own longer name vetoed
-    their own ping — the exact case the `_colliding_needles` docstring claims is
-    excluded. Comparing resolved IDENTITY rather than a row's chosen author id
-    is what makes one person one person.
+    🔴 BUT A SHARED IDENTIFIER ALONE IS NOT ENOUGH, AND ROUND-3'S FIX ASSUMED IT
+    WAS (round-4 audit F-A). `signal.contacts.phone_number` is plain `TEXT` with
+    NO unique constraint, and `_promote_placeholder()` only ever touches
+    `is_placeholder` rows — so `upsert_contact(signal_uuid=B, phone_number=NUM)`
+    while a REAL row A already holds `NUM` simply inserts a SECOND REAL row.
+    That is the ordinary number-recycling / number-change shape, and unioning it
+    merged two genuinely different people into one identity: person B's longer
+    name stopped vetoing, and `--mention Ann` against a body reading
+    `@Ann Smith` PINGED A. A wrong send, not a refusal — the one thing this
+    module promises never to do.
 
-    Rows with no identifier in common stay separate: there is nothing in the
-    data linking them, and merging on a NAME would reopen the prefix collision
-    the collision rule exists for.
+    So the union is gated: two rows are the same person only when they share an
+    identifier AND at least one of them is a PLACEHOLDER, which is exactly the
+    mid-`_promote_placeholder` shape the paragraph above describes and the only
+    one the data can actually justify. Two real rows sharing a number are two
+    people until something other than the number says otherwise; the collision
+    rule then vetoes, and a veto is a refusal.
+
+    Rows with no identifier in common stay separate for the same reason: merging
+    on a NAME would reopen the prefix collision the collision rule exists for.
     """
-    parent: dict[str, str] = {}
+    rows = list(candidates or [])
+    parent = list(range(len(rows)))
 
-    def find(x: str) -> str:
-        while parent.setdefault(x, x) != x:
-            parent[x] = parent[parent[x]]
-            x = parent[x]
-        return x
+    def find(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
 
-    for contact in (candidates or []):
-        ids = sorted(_contact_ids(contact))
-        for other in ids[1:]:
-            root_a, root_b = find(ids[0]), find(other)
+    for i, row_a in enumerate(rows):
+        for j in range(i + 1, len(rows)):
+            row_b = rows[j]
+            if not (_contact_ids(row_a) & _contact_ids(row_b)):
+                continue
+            if not (row_a.get("is_placeholder") or row_b.get("is_placeholder")):
+                continue
+            root_a, root_b = find(i), find(j)
             if root_a != root_b:
                 parent[root_a] = root_b
 
-    clusters: dict[str, set] = {}
-    for key in list(parent):
-        clusters.setdefault(find(key), set()).add(key)
-    return {key: frozenset(clusters[find(key)]) for key in parent}
+    clusters: dict[int, set] = {}
+    for i, row in enumerate(rows):
+        clusters.setdefault(find(i), set()).add(
+            _norm_member(_contact_author(row)))
+    out: dict[str, set] = {}
+    for i, row in enumerate(rows):
+        key = _norm_member(_contact_author(row))
+        if key:
+            out.setdefault(key, set()).update(clusters[find(i)] - {""})
+    return {key: frozenset(ids) for key, ids in out.items()}
 
 
 def _colliding_needles(ident: str, *, author: str, candidates: list,
@@ -431,12 +460,15 @@ def _colliding_needles(ident: str, *, author: str, candidates: list,
     Restricted to OTHER PEOPLE: a contact with `display_name="Ann"` and
     `profile_name="Ann Marie"` is one person, and their own longer name must not
     veto their own ping. 🔴 "Other person" is decided on RESOLVED IDENTITY —
-    `_identity_groups()`, which unions contact rows sharing any identifier — not
-    on the raw `_contact_author()` string, which splits one person into two the
-    moment they hold both a real row and a durable phone-only placeholder
-    (round-3 audit F3). Restricted to LONGER names because an equal-length match
-    IS this identifier (the matcher is case-insensitive), which is the
-    `MentionNameAmbiguous` case and belongs to `_resolve_one`.
+    `_identity_groups()`, which unions a real row with a durable phone-only
+    PLACEHOLDER for the same person — not on the raw `_contact_author()` string,
+    which splits that person into two (round-3 audit F3). 🔴 And the union is
+    gated on `is_placeholder`, because two REAL rows sharing a recycled phone
+    number are two people: merging them dropped the second person's veto and
+    sent a mention pointing at the FIRST (round-4 audit F-A). Restricted to
+    LONGER names because an equal-length match IS this identifier (the matcher
+    is case-insensitive), which is the `MentionNameAmbiguous` case and belongs
+    to `_resolve_one`.
     """
     width = len(ident.strip())
     identity = identity or {}
@@ -444,7 +476,7 @@ def _colliding_needles(ident: str, *, author: str, candidates: list,
     mine = identity.get(key) or frozenset({key})
     return ["@" + name
             for contact in (candidates or [])
-            if not (_contact_ids(contact) & mine)
+            if _norm_member(_contact_author(contact)) not in mine
             for name in _contact_names_raw(contact)
             if len(name) > width]
 
@@ -473,8 +505,19 @@ def _refuse_overlapping_spans(mentions: list) -> None:
             )
 
 
-def _resolve_one(ident: str, *, member_set: set, candidates: list) -> str:
-    """One `--mention` value → the `author` id, or raise the matching refusal."""
+def _resolve_one(ident: str, *, member_set: set, candidates: list,
+                 identity: dict | None = None) -> str:
+    """One `--mention` value → the `author` id, or raise the matching refusal.
+
+    `identity` is `_identity_groups(candidates)` — the SAME map
+    `_colliding_needles()` uses. Passed in rather than rebuilt so the two sites
+    cannot disagree about who is one person (round-4 audit F-B: this site
+    open-coded the predicate as `_contact_author(contact)`, a per-ROW string,
+    while the comment beside it claimed identity — so one person holding a real
+    row and a durable placeholder row was refused as an AMBIGUITY, and the
+    remedy the message offered was half wrong because one of the two ids it
+    printed was the synthetic placeholder uuid, which is not in `member_set`).
+    """
     ident = ident.strip()
     if looks_like_author_id(ident):
         if _norm_member(ident) not in member_set:
@@ -506,11 +549,22 @@ def _resolve_one(ident: str, *, member_set: set, candidates: list) -> str:
     wanted = ident.lower()
     matched = [c for c in candidates if wanted in _contact_names(c)]
     # De-duplicate by IDENTITY, not by row: one person can legitimately have two
-    # contact rows mid-`_promote_placeholder`, and that is not ambiguity.
-    by_author = {}
+    # contact rows mid-`_promote_placeholder`, and that is not ambiguity. The
+    # identity comes from `_identity_groups()` — the one definition, shared with
+    # `_colliding_needles()` — and the group's REAL row wins over its placeholder
+    # row, so a person who has both resolves to their real Signal id instead of
+    # the synthetic one.
+    identity = identity or {}
+    by_identity: dict = {}
     for contact in matched:
-        by_author.setdefault(_contact_author(contact), contact)
-    if not by_author:
+        key = _norm_member(_contact_author(contact))
+        group = identity.get(key) or frozenset({key})
+        group_key = min(group) if group else key
+        seen = by_identity.get(group_key)
+        if seen is None or (seen.get("is_placeholder")
+                            and not contact.get("is_placeholder")):
+            by_identity[group_key] = contact
+    if not by_identity:
         # 🔴 TRUNCATED, DELIBERATELY. Some names help an operator spot a typo;
         # the WHOLE list is a roster dump, and `draft` needs no approval token,
         # so an unbounded enumeration here is a free membership oracle for any
@@ -527,13 +581,17 @@ def _resolve_one(ident: str, *, member_set: set, candidates: list) -> str:
             + ". Pass a bare uuid or +E.164 instead if the person has no stored "
               "name."
         )
-    if len(by_author) > 1:
+    if len(by_identity) > 1:
+        # The ids PRINTED are the ones a caller can actually pass back: each
+        # group's chosen row's author, not the normalised grouping key.
+        choices = sorted(_contact_author(c) for c in by_identity.values())
         raise MentionNameAmbiguous(
-            f"{ident!r} is AMBIGUOUS — it matches {len(by_author)} members of "
-            f"the target group ({sorted(by_author)!r}). Pass the bare uuid or "
+            f"{ident!r} is AMBIGUOUS — it matches {len(by_identity)} members of "
+            f"the target group ({choices!r}). Pass the bare uuid or "
             f"+E.164 of the one you mean."
         )
-    author, contact = next(iter(by_author.items()))
+    contact = next(iter(by_identity.values()))
+    author = _contact_author(contact)
     if contact.get("is_placeholder"):
         raise MentionResolvesToPlaceholder(
             f"{ident!r} resolves to a PLACEHOLDER contact ({author!r}) — a "

--- a/scripts/signal/_mentions.py
+++ b/scripts/signal/_mentions.py
@@ -129,14 +129,24 @@ def _needle_pattern(needle: str) -> "re.Pattern":
 
     🔴 TWO THINGS THE PLAIN `str.find()` GOT WRONG, both silent:
 
-    * **NO BOUNDARY.** `find("@Ann")` matches INSIDE `"@Anna"`. With members
+    * **NO WORD BOUNDARY.** `find("@Ann")` matches INSIDE `"@Anna"`. With members
       `Ann` and `Anna` and a body `"hi @Anna and @Ann ok"`, `--mention Ann`
       produced span `(3, 4)` — Ann is pinged, Anna's name is the text on screen,
       and the render is corrupted. `(?!\\w)` requires a non-word character (or
-      end of string) immediately after the needle, so a name that is a PREFIX of
-      another member's name can no longer land on them. The scan CONTINUES past
-      a boundary-failing hit rather than refusing, so the real `@Ann` later in
-      that body is still found.
+      end of string) immediately after the needle.
+
+      🔴 `(?!\\w)` IS NOT THE WHOLE PREFIX RULE, AND MUST NOT BE DESCRIBED AS
+      ONE. It blocks only WORD characters, so every member name whose second
+      component is introduced by punctuation — `Ann-Marie`, `Ann.Smith`,
+      `Ann'Marie` — satisfies it and `--mention Ann` landed on the first four
+      characters of somebody ELSE's name anyway (measured, round-2 audit F2).
+      The rest of the rule is member-aware and lives in `find_span`'s `avoid`
+      argument, built by `_colliding_needles()`: a hit is skipped when ANOTHER
+      group member's longer `@name` also matches at that same offset, whatever
+      character separates the parts. Together the two cover "a name that is a
+      prefix of another GROUP MEMBER's name cannot land on them"; neither covers
+      a prefix of an arbitrary non-member string in the body, and no docstring
+      here claims it does.
     * **CASE.** `_resolve_one()` matches names case-INSENSITIVELY (`.lower()`),
       so `--mention ANN` resolved to Ann and then died on `MentionSpanMissing`
       against a body reading `@Ann` — resolution and span search disagreed about
@@ -148,7 +158,8 @@ def _needle_pattern(needle: str) -> "re.Pattern":
     return re.compile(re.escape(needle) + r"(?!\w)", re.IGNORECASE | re.UNICODE)
 
 
-def find_span(body: str, needle: str, *, from_index: int = 0) -> tuple[int, int, int]:
+def find_span(body: str, needle: str, *, from_index: int = 0,
+              avoid=()) -> tuple[int, int, int]:
     """`(code_point_index, start, length)` of `needle` in `body`.
 
     `start`/`length` are UTF-16 code units — the wire units. The code-point index
@@ -156,21 +167,39 @@ def find_span(body: str, needle: str, *, from_index: int = 0) -> tuple[int, int,
     match this span describes; the previous code re-ran `body.find()` to move the
     cursor, a second copy of the predicate that would now disagree with the
     boundary-aware search above.
+
+    `avoid` is a list of OTHER members' `@name` needles that are LONGER than this
+    one. A hit at which any of them also matches is a PREFIX COLLISION — the
+    visible text belongs to the other member — and is SKIPPED, exactly as a
+    `(?!\\w)` failure is skipped, so a genuine later `@who` in the same body is
+    still found. Scanning on rather than refusing is what keeps
+    `"hi @Ann-Marie and @Ann ok"` working.
     """
     body = body or ""
-    match = _needle_pattern(needle).search(body, from_index)
-    if match is None:
-        raise MentionSpanMissing(
-            f"the draft body does not contain {needle!r}"
-            + (f" at or after character {from_index}" if from_index else "")
-            + " as a whole word. A Signal mention REPLACES an existing span of "
-              "the message text, so the text has to be there — and a match that "
-              "runs straight into more letters (`@Ann` inside `@Anna`) is a "
-              "DIFFERENT person's name, not this one. Add it to --body, or drop "
-              "the --mention."
-        )
-    idx = match.start()
-    return idx, utf16_len(body[:idx]), utf16_len(needle)
+    pattern = _needle_pattern(needle)
+    longer = [_needle_pattern(a) for a in (avoid or ())]
+    pos = from_index
+    while True:
+        match = pattern.search(body, pos)
+        if match is None:
+            raise MentionSpanMissing(
+                f"the draft body does not contain {needle!r}"
+                + (f" at or after character {from_index}" if from_index else "")
+                + " as a whole word that is not part of another member's name. A "
+                  "Signal mention REPLACES an existing span of the message text, "
+                  "so the text has to be there — and a match that runs straight "
+                  "into more letters (`@Ann` inside `@Anna`) or into the rest of "
+                  "another member's name (`@Ann` inside `@Ann-Marie`) is a "
+                  "DIFFERENT person's name, not this one. Add it to --body, or "
+                  "drop the --mention."
+            )
+        idx = match.start()
+        if not any(p.match(body, idx) for p in longer):
+            return idx, utf16_len(body[:idx]), utf16_len(needle)
+        # A longer member name occupies this offset. Step ONE character, not one
+        # needle: the skipped text belongs to somebody else and may itself
+        # contain the needle again.
+        pos = idx + 1
 
 
 def utf16_span(body: str, needle: str, *, from_index: int = 0) -> tuple[int, int]:
@@ -210,10 +239,20 @@ def _contact_author(contact: dict) -> str:
     return (contact.get("signal_uuid") or contact.get("phone_number") or "")
 
 
-def _contact_names(contact: dict) -> set[str]:
-    return {str(n).strip().lower()
+def _contact_names_raw(contact: dict) -> set[str]:
+    """The stored names AS WRITTEN. Used to build `@name` needles.
+
+    Kept un-folded on purpose: `str.lower()` can CHANGE LENGTH (`İ` → two code
+    points), and a needle built from a folded name would no longer be the text
+    that is actually in the body.
+    """
+    return {str(n).strip()
             for n in (contact.get("display_name"), contact.get("profile_name"))
             if str(n or "").strip()}
+
+
+def _contact_names(contact: dict) -> set[str]:
+    return {n.lower() for n in _contact_names_raw(contact)}
 
 
 # --------------------------------------------------------------------------- #
@@ -259,16 +298,55 @@ def resolve_mentions(identifiers, *, body: str, members, contacts,
     for ident in idents:
         author = _resolve_one(ident, member_set=member_set, candidates=candidates)
         needle = "@" + ident
-        idx, start, length = find_span(body or "", needle,
-                                       from_index=cursor_for.get(needle, 0))
+        # 🔴 THE CURSOR KEY IS CASEFOLDED, BECAUSE THE MATCHER IS CASE-INSENSITIVE.
+        # `_needle_pattern` compiles with `re.IGNORECASE`, so `@Ann` and `@ANN`
+        # are the SAME needle to the search — but keying the cursor on the raw
+        # string made them two dict entries, both starting from 0, both landing
+        # on the same first occurrence. `--mention Ann --mention ANN` against
+        # `"hi @Ann and @ANN ok"` then produced two identical spans and was
+        # refused by `_refuse_overlapping_spans` with a message telling the
+        # operator to give each mention its own `@who` text — which the body
+        # already had. Round-2 audit F1; the key must fold exactly as the
+        # matcher does. `casefold()` may change LENGTH, which is why it is used
+        # only as a dict key and never to compute an offset.
+        key = needle.casefold()
+        idx, start, length = find_span(
+            body or "", needle, from_index=cursor_for.get(key, 0),
+            avoid=_colliding_needles(ident, author=author, candidates=candidates))
         # Advance THIS needle's cursor past the occurrence just claimed, so
         # `--mention Ann --mention Ann` takes the first and second "@Ann" rather
         # than pointing both mentions at the same span. Derived from the match
         # `find_span` returned, NOT from a second search.
-        cursor_for[needle] = idx + len(needle)
+        cursor_for[key] = idx + len(needle)
         out.append({"author": author, "start": start, "length": length})
     _refuse_overlapping_spans(out)
     return out
+
+
+def _colliding_needles(ident: str, *, author: str, candidates: list) -> list[str]:
+    """`@name` needles of OTHER group members that are LONGER than `@ident`.
+
+    🔴 THE HALF OF THE PREFIX RULE `(?!\\w)` CANNOT DO. The right-hand word
+    boundary blocks `@Ann` inside `@Anna` but NOT inside `@Ann-Marie` or
+    `@Ann.Smith` — a hyphen and a dot are both non-word characters, so the
+    boundary is satisfied and the mention landed on the first four characters of
+    a different member's name while the text on screen stayed theirs. Handing
+    the other members' full names to `find_span` closes that for ANY separator,
+    because the test is "does a longer member name occupy this exact offset",
+    not "which characters are allowed to follow".
+
+    Restricted to OTHER authors: a contact with `display_name="Ann"` and
+    `profile_name="Ann Marie"` is one person, and their own longer name must not
+    veto their own ping. Restricted to LONGER names because an equal-length
+    match IS this identifier (the matcher is case-insensitive), which is the
+    `MentionNameAmbiguous` case and belongs to `_resolve_one`.
+    """
+    width = len(ident.strip())
+    return ["@" + name
+            for contact in (candidates or [])
+            if _contact_author(contact) != author
+            for name in _contact_names_raw(contact)
+            if len(name) > width]
 
 
 def _refuse_overlapping_spans(mentions: list) -> None:

--- a/scripts/signal/_mentions.py
+++ b/scripts/signal/_mentions.py
@@ -94,13 +94,26 @@ class MentionIdentityUnresolvable(MentionError):
     So it refuses. Identity here is load-bearing twice over — it decides whose
     longer name may veto a span AND whether two name matches are an ambiguity —
     and a guess in either direction is a mention pointing at the wrong human.
-    🔴 IT REFUSES THE WHOLE CALL, INCLUDING A MENTION TYPED AS A BARE UUID.
-    That is not over-reach: identity also builds `_colliding_needles()`'s veto
-    set, so a polluted group drops the OTHER real person's longer name from the
-    avoid list and the span lands on the first characters of THEIR name — the
-    same corrupted render, reached without `_resolve_one()` ever consulting a
-    name. The remedy is in the DATA (delete the stale placeholder row), not in
-    how the mention is spelled.
+    🔴 IT REFUSES A MENTION TYPED AS A BARE UUID TOO, when that uuid is IN the
+    polluted group. That is not over-reach: identity also builds
+    `_colliding_needles()`'s veto set through `mine = identity.get(key)`, so a
+    polluted group drops the OTHER real person's longer name from the avoid list
+    and the span lands on the first characters of THEIR name — the same
+    corrupted render, reached without `_resolve_one()` ever consulting a name.
+    The remedy is in the DATA (delete the stale placeholder row), not in how the
+    mention is spelled.
+
+    🔴 BUT IT IS SCOPED TO THE POLLUTED GROUP, NOT TO THE CALL (round-6 audit
+    F-1). Round 5 refused every `--mention` against a group holding any polluted
+    identity, and generalised one door into all doors: `mine` is the MENTION
+    TARGET'S OWN group and nothing else, so for a member who shares no
+    identifier with the bridge, `mine` is unchanged and both polluted names sit
+    in their veto list either way. Pollution can only corrupt a call whose
+    resolved author — or whose set of name matches, which is what the ambiguity
+    de-duplication reads — lands INSIDE the polluted group. Refusing wider than
+    that bricked every mention in the group for every member over one stale
+    placeholder row, and `consumer.py` exposes no contacts subcommand, so the
+    only remedy was hand-editing Postgres.
     """
 
 
@@ -399,7 +412,25 @@ def resolve_mentions(identifiers, *, body: str, members, contacts,
     return out
 
 
-def _identity_groups(candidates: list) -> dict[str, frozenset]:
+class _IdentityMap(dict):
+    """`_identity_groups()`'s result: the identity map, PLUS the bad groups.
+
+    A `dict` subclass so every reader — `identity.get(key)` in
+    `_colliding_needles()` and in `_resolve_one()` — is untouched by the round-6
+    change, and so a caller that passes a plain `dict` (or nothing) still works:
+    `_refuse_if_polluted()` reads `polluted` through `getattr`, and a map with no
+    pollution record refuses nothing.
+
+    `polluted` maps a member key to `(real rows, all rows)` of the group it is
+    in, for every key in a group holding two or more REAL rows.
+    """
+
+    def __init__(self, groups, polluted):
+        super().__init__(groups)
+        self.polluted = polluted
+
+
+def _identity_groups(candidates: list) -> _IdentityMap:
     """`author id -> the author ids of every contact ROW that is the SAME PERSON`.
 
     THE ONE DEFINITION OF "these two contact rows are one person". Both
@@ -449,10 +480,20 @@ def _identity_groups(candidates: list) -> dict[str, frozenset]:
     The invariant is a property of the RESULTING GROUP, so it is checked on the
     resulting group: **no group may contain two rows that are both real.** Any
     group that does is not one person, and nothing pairwise can say which real
-    row the bridging placeholder belongs to — so this FAILS CLOSED with
-    `MentionIdentityUnresolvable` rather than picking one. Enforced here, on the
-    output, which is why relocating or re-tuning the pair rule cannot reopen it:
-    a merge this function did not intend is caught by what it returns.
+    row the bridging placeholder belongs to — so a mention resolving into such a
+    group FAILS CLOSED with `MentionIdentityUnresolvable` rather than picking
+    one. Detected here, on the output, which is why relocating or re-tuning the
+    pair rule cannot reopen it: a merge this function did not intend is caught by
+    what it returns.
+
+    🔴 DETECTED HERE, REFUSED AT THE CALL SITE (round-6 audit F-1). This
+    function RECORDS the offending groups in `_IdentityMap.polluted` instead of
+    raising, because whether the pollution can corrupt a call depends on WHICH
+    mention is being resolved and this function does not know that. Only
+    `_resolve_one()` does, and it raises for exactly the mentions that land in a
+    polluted group — see `MentionIdentityUnresolvable`. Raising from here made
+    the refusal a property of the GROUP ADDRESS, which blocked correct mentions
+    of members who share nothing with the bridge.
 
     Rows with no identifier in common stay separate for the same reason: merging
     on a NAME would reopen the prefix collision the collision rule exists for.
@@ -484,19 +525,14 @@ def _identity_groups(candidates: list) -> dict[str, frozenset]:
     for i, row in enumerate(rows):
         if not row.get("is_placeholder"):
             real_per_group.setdefault(find(i), []).append(row)
-    for members_ in real_per_group.values():
+    polluted: dict[str, tuple] = {}
+    for root_, members_ in real_per_group.items():
         if len(members_) > 1:
-            authors = sorted({_contact_author(r) for r in members_} - {""})
-            raise MentionIdentityUnresolvable(
-                f"the stored contacts for this group put "
-                f"{len(members_)} DIFFERENT real identities "
-                f"({authors[:NAME_HINT_MAX]!r}) into one identity, bridged by a "
-                f"PLACEHOLDER row that shares an identifier with both. Which of "
-                f"them the placeholder belongs to is not decidable from the "
-                f"rows, and guessing picks who gets notified — so no --mention "
-                f"can be resolved against this group until the stale placeholder "
-                f"contact row is removed."
-            )
+            group_rows = [r for i, r in enumerate(rows) if find(i) == root_]
+            for row in group_rows:
+                key = _norm_member(_contact_author(row))
+                if key:
+                    polluted[key] = (members_, group_rows)
 
     clusters: dict[int, set] = {}
     for i, row in enumerate(rows):
@@ -507,7 +543,70 @@ def _identity_groups(candidates: list) -> dict[str, frozenset]:
         key = _norm_member(_contact_author(row))
         if key:
             out.setdefault(key, set()).update(clusters[find(i)] - {""})
-    return {key: frozenset(ids) for key, ids in out.items()}
+    return _IdentityMap({key: frozenset(ids) for key, ids in out.items()},
+                        polluted)
+
+
+def _unresolvable_message(ident: str, real_rows: list, group_rows: list) -> str:
+    """The `MentionIdentityUnresolvable` text. The operator has to ACT on this.
+
+    🔴 THE COUNT AND THE LIST ARE ONE VALUE (round-6 audit F-1). The count used
+    to be `len(real_rows)` while the list was those rows' authors DE-DUPLICATED
+    into a set, so two real rows carrying the same author string printed
+    `2 DIFFERENT real identities (['Ann'])` — a message that contradicts itself
+    in the one place it is read. The number below is the length of the list
+    below; a truncation says so separately.
+
+    🔴 AND IT NAMES THE BRIDGE. The refusal used to print the two real rows by
+    uuid and never mention the placeholder or the identifier it was minted for,
+    while telling the operator to "remove the stale placeholder contact row" —
+    and `consumer.py` has no contacts subcommand, so their only route is
+    Postgres and they had nothing to select on. The shared identifiers are the
+    intersection of the placeholder rows' ids with the real rows' ids: exactly
+    the values that did the bridging.
+    """
+    authors = sorted({_contact_author(r) for r in real_rows} - {""})
+    shown = authors[:NAME_HINT_MAX]
+    more = len(authors) - len(shown)
+    real_ids: set[str] = set()
+    for row in real_rows:
+        real_ids |= _contact_ids(row)
+    bridges = sorted({i for row in group_rows if row.get("is_placeholder")
+                      for i in (_contact_ids(row) & real_ids)})
+    return (
+        f"{ident!r} resolves into a group of stored contacts that holds "
+        f"{len(shown)} distinct real identities ({shown!r}"
+        + (f", +{more} not shown" if more > 0 else "")
+        + f") merged into ONE identity, bridged by PLACEHOLDER contact row(s) "
+          f"sharing {bridges!r} with them. Which of those identities the "
+          f"placeholder belongs to is not decidable from the rows, and guessing "
+          f"picks who gets notified — so this mention is refused until the stale "
+          f"placeholder contact row for {bridges!r} is removed. Mentions of "
+          f"members outside this identity are unaffected."
+    )
+
+
+def _refuse_if_polluted(ident: str, *, rows: list, identity) -> None:
+    """Raise iff THIS mention lands in an unresolvable identity group.
+
+    🔴 THE SCOPE IS THE WHOLE POINT (round-6 audit F-1) — see
+    `MentionIdentityUnresolvable`. `rows` is the mention's own match set: the
+    contact rows the identifier selected, whether by bare id or by name. If any
+    of them sits in a polluted group then either the resolved author or the
+    ambiguity de-duplication that chose it was computed from a merge that is not
+    one person, and the veto set `_colliding_needles()` builds from
+    `identity.get(key)` is that same merge. If none of them does, nothing this
+    call reads was affected by the pollution and refusing would be a refusal of
+    the group address rather than of the mention.
+    """
+    polluted = getattr(identity, "polluted", None) or {}
+    if not polluted:
+        return
+    for row in rows:
+        hit = polluted.get(_norm_member(_contact_author(row)))
+        if hit:
+            raise MentionIdentityUnresolvable(
+                _unresolvable_message(ident, *hit))
 
 
 def _colliding_needles(ident: str, *, author: str, candidates: list,
@@ -601,6 +700,13 @@ def _resolve_one(ident: str, *, member_set: set, candidates: list,
                 # "not this group", not 40 uuids to eyeball.
                 f"Check --to names the group you meant."
             )
+        # An explicitly-typed id still reads identity: `_colliding_needles()`
+        # builds its veto set from this author's group, so a bare uuid INSIDE a
+        # polluted group is the same corrupted render by another spelling.
+        _refuse_if_polluted(
+            ident, identity=identity,
+            rows=[c for c in candidates
+                  if _norm_member(ident) in _contact_ids(c)])
         for contact in candidates:
             if _norm_member(ident) in _contact_ids(contact) \
                     and contact.get("is_placeholder"):
@@ -614,6 +720,11 @@ def _resolve_one(ident: str, *, member_set: set, candidates: list,
 
     wanted = ident.lower()
     matched = [c for c in candidates if wanted in _contact_names(c)]
+    # Before the de-duplication below reads identity to decide what is ONE
+    # person and what is an AMBIGUITY: if any row this name matched sits in a
+    # polluted group, that decision is being made from a merge that is not one
+    # person, and so is the veto set built from it.
+    _refuse_if_polluted(ident, rows=matched, identity=identity)
     # De-duplicate by IDENTITY, not by row: one person can legitimately have two
     # contact rows mid-`_promote_placeholder`, and that is not ambiguity. The
     # identity comes from `_identity_groups()` — the one definition, shared with

--- a/scripts/signal/_mentions.py
+++ b/scripts/signal/_mentions.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Resolve `--mention` arguments into Signal wire mentions. PURE — no I/O.
+
+WHAT A MENTION IS ON THE WIRE (measured against the deployed signal-cli 0.14.7,
+`data.MessageMention`, not recalled):
+
+    {"author": "<E.164 or bare UUID>", "start": <int>, "length": <int>}
+
+exactly those three keys.
+
+  * `author` accepts EITHER an E.164 number OR a bare UUID
+    (`RecipientIdentifier.Single.fromString` takes both).
+  * `start`/`length` are **UTF-16 code units**, NOT Python code points and NOT
+    bytes. A non-BMP character — every emoji outside the BMP, and there are many
+    in a real Signal thread — is ONE Python code point and TWO UTF-16 units. A
+    naive `str.find()` / `len()` therefore produces offsets that are correct for
+    plain ASCII and silently WRONG the moment anyone puts an emoji before the
+    mention: the receiving client replaces the wrong span of text.
+  * the `[start, start+length)` span must ALREADY EXIST in `message`; the
+    receiving client REPLACES it with `@DisplayName`. So the body must contain
+    the literal `@<identifier>` we measured, and we send both together.
+
+🔴 WHY EVERY FAILURE HERE IS A REFUSAL, NEVER A DROP. A mention pushes a
+notification through the recipient's mute settings and names a third party in a
+group. Dropping an unresolvable one sends a message that reads as if it pinged
+someone and did not — the operator approved a card that described a different
+act from the one performed. Each refusal below is its own exception class AND
+its own message, so a caller (and a test) can assert WHICH guard fired rather
+than accepting any exception.
+"""
+from __future__ import annotations
+
+import re
+
+# A Signal recipient identifier typed directly rather than by display name.
+_UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+_E164_RE = re.compile(r"^\+[1-9]\d{6,14}$")
+
+# The exact key set of one wire mention. Asserted by the suite; a fourth key
+# would be silently dropped by the server, and a missing one mis-renders.
+MENTION_KEYS = ("author", "start", "length")
+
+
+class MentionError(ValueError):
+    """Base: a `--mention` could not be turned into a wire mention.
+
+    A `ValueError` so `consumer.main()`'s existing `draft` handler — which
+    already catches `ValueError` and exits 3 — refuses cleanly rather than
+    escaping as a traceback.
+    """
+
+
+class MentionsRequireAGroup(MentionError):
+    """Mentions were given for a recipient that is not a group."""
+
+
+class MentionNameNotFound(MentionError):
+    """No member of the target group answers to that display name."""
+
+
+class MentionNameAmbiguous(MentionError):
+    """More than one member of the target group answers to that display name."""
+
+
+class MentionResolvesToPlaceholder(MentionError):
+    """The name resolved to a PLACEHOLDER contact — a synthetic identity.
+
+    `_signal_db.placeholder_uuid()` mints deterministic FAKE uuids for senders
+    the pipeline could not identify. Such a uuid is not a Signal identity; put
+    on the wire as an `author` it addresses nobody, and the send either errors
+    or — worse — succeeds with a mention pointing at no one.
+    """
+
+
+class MentionNotAMember(MentionError):
+    """An explicitly-typed uuid/E.164 is not in the target group's membership."""
+
+
+class MentionSpanMissing(MentionError):
+    """The body does not contain the `@<identifier>` text this mention covers."""
+
+
+# --------------------------------------------------------------------------- #
+# UTF-16 offsets — the whole point
+# --------------------------------------------------------------------------- #
+def utf16_len(text: str) -> int:
+    """Length of `text` in UTF-16 code units.
+
+    `len(text)` counts CODE POINTS and is equal to this only while every
+    character is in the BMP. Encoding to `utf-16-le` (no BOM — `utf-16` would
+    prepend two bytes and inflate every answer by one unit) and halving the byte
+    count is the definition, not an approximation.
+    """
+    return len(text.encode("utf-16-le")) // 2
+
+
+def utf16_span(body: str, needle: str, *, from_index: int = 0) -> tuple[int, int]:
+    """`(start, length)` of `needle` in `body`, in UTF-16 code units.
+
+    `from_index` is a CODE POINT index into `body` — the search cursor, used so
+    two mentions of the same identifier take successive occurrences instead of
+    both claiming the first. Raises `MentionSpanMissing` if the needle is not
+    present at or after it.
+    """
+    idx = body.find(needle, from_index)
+    if idx < 0:
+        raise MentionSpanMissing(
+            f"the draft body does not contain {needle!r}"
+            + (f" at or after character {from_index}" if from_index else "")
+            + ". A Signal mention REPLACES an existing span of the message text, "
+              "so the text has to be there — add it to --body, or drop the "
+              "--mention."
+        )
+    return utf16_len(body[:idx]), utf16_len(needle)
+
+
+# --------------------------------------------------------------------------- #
+# Identity helpers
+# --------------------------------------------------------------------------- #
+def looks_like_author_id(value: str) -> bool:
+    """True for a value that is ALREADY a Signal identifier (uuid or E.164)."""
+    v = (value or "").strip()
+    return bool(_UUID_RE.match(v) or _E164_RE.match(v))
+
+
+def _norm_member(value) -> str:
+    """Members arrive MIXED — E.164 and bare UUID, and uuids in either case."""
+    return str(value or "").strip().lower()
+
+
+def _contact_ids(contact: dict) -> set[str]:
+    return {_norm_member(contact.get("signal_uuid")),
+            _norm_member(contact.get("phone_number"))} - {""}
+
+
+def _contact_author(contact: dict) -> str:
+    """The id to put on the wire. A uuid is preferred: it is stable, a number is not."""
+    return (contact.get("signal_uuid") or contact.get("phone_number") or "")
+
+
+def _contact_names(contact: dict) -> set[str]:
+    return {str(n).strip().lower()
+            for n in (contact.get("display_name"), contact.get("profile_name"))
+            if str(n or "").strip()}
+
+
+# --------------------------------------------------------------------------- #
+# The resolver
+# --------------------------------------------------------------------------- #
+def resolve_mentions(identifiers, *, body: str, members, contacts,
+                     is_group: bool = True) -> list[dict]:
+    """`--mention` values → the wire `mentions` array, or raise.
+
+    PURE. `members` is what `GET /v1/groups/<number>/<id>` returned (a mixed list
+    of E.164 and bare UUID strings) and `contacts` is the matching
+    `signal.contacts` rows; neither is fetched here, so every refusal below is
+    reachable from a unit test with no network and no database.
+
+    Returns `[]` for no identifiers — including for a non-group recipient, which
+    is only refused when mentions were actually asked for.
+    """
+    idents = [str(i) for i in (identifiers or [])]
+    if not idents:
+        return []
+    if not is_group:
+        raise MentionsRequireAGroup(
+            "mentions are a GROUP feature: a mention names a member of the "
+            "conversation and notifies them through their mute settings. "
+            f"--to is not a group address, so {idents!r} cannot be resolved. "
+            "Drop --mention, or address the group."
+        )
+
+    member_set = {_norm_member(m) for m in (members or [])} - {""}
+    if not member_set:
+        raise MentionNameNotFound(
+            "the group reported NO members, so no --mention can be resolved. "
+            "This is a refusal rather than an empty mentions array on purpose: "
+            "an empty membership means the lookup failed, not that the group is "
+            "empty."
+        )
+    # Only contacts that are ACTUALLY in this group are candidates. A name that
+    # matches somebody in another conversation must not resolve here.
+    candidates = [c for c in (contacts or []) if _contact_ids(c) & member_set]
+
+    out: list[dict] = []
+    cursor_for: dict[str, int] = {}
+    for ident in idents:
+        author = _resolve_one(ident, member_set=member_set, candidates=candidates)
+        needle = "@" + ident
+        start, length = utf16_span(body or "", needle,
+                                   from_index=cursor_for.get(needle, 0))
+        # Advance THIS needle's cursor past the occurrence just claimed, so
+        # `--mention Ann --mention Ann` takes the first and second "@Ann" rather
+        # than pointing both mentions at the same span.
+        cursor_for[needle] = (body or "").find(needle,
+                                              cursor_for.get(needle, 0)) + len(needle)
+        out.append({"author": author, "start": start, "length": length})
+    return out
+
+
+def _resolve_one(ident: str, *, member_set: set, candidates: list) -> str:
+    """One `--mention` value → the `author` id, or raise the matching refusal."""
+    ident = ident.strip()
+    if looks_like_author_id(ident):
+        if _norm_member(ident) not in member_set:
+            raise MentionNotAMember(
+                f"{ident!r} is a valid Signal identifier but is NOT a member of "
+                f"the target group, so mentioning it would notify nobody. "
+                f"The group's members are {sorted(member_set)!r}."
+            )
+        for contact in candidates:
+            if _norm_member(ident) in _contact_ids(contact) \
+                    and contact.get("is_placeholder"):
+                raise MentionResolvesToPlaceholder(
+                    f"{ident!r} resolves to a PLACEHOLDER contact — a synthetic "
+                    f"identity minted for a sender this pipeline could not "
+                    f"identify. It is not a real Signal id and must never reach "
+                    f"the wire as a mention `author`."
+                )
+        return ident
+
+    wanted = ident.lower()
+    matched = [c for c in candidates if wanted in _contact_names(c)]
+    # De-duplicate by IDENTITY, not by row: one person can legitimately have two
+    # contact rows mid-`_promote_placeholder`, and that is not ambiguity.
+    by_author = {}
+    for contact in matched:
+        by_author.setdefault(_contact_author(contact), contact)
+    if not by_author:
+        known = sorted({n for c in candidates for n in _contact_names(c)})
+        raise MentionNameNotFound(
+            f"no member of the target group is named {ident!r}. Known member "
+            f"names are {known!r}. Pass a bare uuid or +E.164 instead if the "
+            f"person has no stored name."
+        )
+    if len(by_author) > 1:
+        raise MentionNameAmbiguous(
+            f"{ident!r} is AMBIGUOUS — it matches {len(by_author)} members of "
+            f"the target group ({sorted(by_author)!r}). Pass the bare uuid or "
+            f"+E.164 of the one you mean."
+        )
+    author, contact = next(iter(by_author.items()))
+    if contact.get("is_placeholder"):
+        raise MentionResolvesToPlaceholder(
+            f"{ident!r} resolves to a PLACEHOLDER contact ({author!r}) — a "
+            f"synthetic identity minted for a sender this pipeline could not "
+            f"identify. It is not a real Signal id and must never reach the wire "
+            f"as a mention `author`."
+        )
+    if not author:
+        raise MentionNameNotFound(
+            f"{ident!r} matched a stored contact that carries neither a uuid nor "
+            f"a phone number, so there is no `author` to send."
+        )
+    return author
+
+
+def canonical_mentions(mentions) -> tuple:
+    """A comparable, order-sensitive form of a mentions array.
+
+    Used by the send-authorization binding: `None`, `[]` and a missing column
+    must all compare EQUAL (they mean the same thing — no mentions), while any
+    difference in author, offset or ORDER must compare unequal.
+    """
+    return tuple(
+        (str(m.get("author")), int(m.get("start")), int(m.get("length")))
+        for m in (mentions or [])
+    )
+
+
+def describe_mentions(mentions) -> list[str]:
+    """Human lines for the clawgate card — WHO this message will notify."""
+    return [f"{m['author']} (chars {m['start']}–{m['start'] + m['length']})"
+            for m in (mentions or [])]

--- a/scripts/signal/_mentions.py
+++ b/scripts/signal/_mentions.py
@@ -80,6 +80,30 @@ class MentionResolvesToPlaceholder(MentionError):
     """
 
 
+class MentionIdentityUnresolvable(MentionError):
+    """Contact rows for the target group cannot be split into people.
+
+    `_identity_groups()` merges a real contact row with the durable phone-only
+    PLACEHOLDER row for the same person. When THREE rows share one number —
+    two real people plus a placeholder minted for that number — the placeholder
+    is a bridge, and no rule that looks at rows PAIRWISE can say which real row
+    it belongs to. The resulting group would hold two different people under
+    one identity, which is precisely the state that made `--mention Ann` ping A
+    under text reading `@Ann Smith` (round-5 audit F-A).
+
+    So it refuses. Identity here is load-bearing twice over — it decides whose
+    longer name may veto a span AND whether two name matches are an ambiguity —
+    and a guess in either direction is a mention pointing at the wrong human.
+    🔴 IT REFUSES THE WHOLE CALL, INCLUDING A MENTION TYPED AS A BARE UUID.
+    That is not over-reach: identity also builds `_colliding_needles()`'s veto
+    set, so a polluted group drops the OTHER real person's longer name from the
+    avoid list and the span lands on the first characters of THEIR name — the
+    same corrupted render, reached without `_resolve_one()` ever consulting a
+    name. The remedy is in the DATA (delete the stale placeholder row), not in
+    how the mention is spelled.
+    """
+
+
 class MentionNotAMember(MentionError):
     """An explicitly-typed uuid/E.164 is not in the target group's membership."""
 
@@ -409,6 +433,27 @@ def _identity_groups(candidates: list) -> dict[str, frozenset]:
     people until something other than the number says otherwise; the collision
     rule then vetoes, and a veto is a refusal.
 
+    🔴 AND THE GATE ABOVE IS A PER-PAIR PREDICATE, WHICH CANNOT SURVIVE
+    TRANSITIVITY (round-5 audit F-A). The union-find joins PATHS, not just
+    edges, so with three rows on one number — real A, placeholder P, real C —
+    the pair rule blocks the direct edge A—C and then A—P and P—C union anyway:
+    `find(A) == find(C)`, and two real people are one identity again. Every
+    step is reachable through five ordinary `upsert_contact()` calls (a draft
+    mints P for an unknown number; two envelopes each hit the durable-placeholder
+    DECLINE and land a real row carrying the same number). Measured before this
+    fix: `--mention Ann` against `hi @Ann Smith` returned a mention for A.
+    Round 4 moved the nodes from identifiers to rows, which changed WHICH nodes
+    merge and left transitivity untouched — the reason this is not another patch
+    to the pair condition.
+
+    The invariant is a property of the RESULTING GROUP, so it is checked on the
+    resulting group: **no group may contain two rows that are both real.** Any
+    group that does is not one person, and nothing pairwise can say which real
+    row the bridging placeholder belongs to — so this FAILS CLOSED with
+    `MentionIdentityUnresolvable` rather than picking one. Enforced here, on the
+    output, which is why relocating or re-tuning the pair rule cannot reopen it:
+    a merge this function did not intend is caught by what it returns.
+
     Rows with no identifier in common stay separate for the same reason: merging
     on a NAME would reopen the prefix collision the collision rule exists for.
     """
@@ -431,6 +476,27 @@ def _identity_groups(candidates: list) -> dict[str, frozenset]:
             root_a, root_b = find(i), find(j)
             if root_a != root_b:
                 parent[root_a] = root_b
+
+    # 🔴 THE GROUP-LEVEL INVARIANT. Checked on the formed groups, not on the
+    # pairs that formed them, because the property "this group is ONE person"
+    # is not expressible as a pairwise predicate under transitivity.
+    real_per_group: dict[int, list] = {}
+    for i, row in enumerate(rows):
+        if not row.get("is_placeholder"):
+            real_per_group.setdefault(find(i), []).append(row)
+    for members_ in real_per_group.values():
+        if len(members_) > 1:
+            authors = sorted({_contact_author(r) for r in members_} - {""})
+            raise MentionIdentityUnresolvable(
+                f"the stored contacts for this group put "
+                f"{len(members_)} DIFFERENT real identities "
+                f"({authors[:NAME_HINT_MAX]!r}) into one identity, bridged by a "
+                f"PLACEHOLDER row that shares an identifier with both. Which of "
+                f"them the placeholder belongs to is not decidable from the "
+                f"rows, and guessing picks who gets notified — so no --mention "
+                f"can be resolved against this group until the stale placeholder "
+                f"contact row is removed."
+            )
 
     clusters: dict[int, set] = {}
     for i, row in enumerate(rows):

--- a/scripts/signal/_mentions.py
+++ b/scripts/signal/_mentions.py
@@ -202,7 +202,8 @@ def find_span(body: str, needle: str, *, from_index: int = 0,
         pos = idx + 1
 
 
-def utf16_span(body: str, needle: str, *, from_index: int = 0) -> tuple[int, int]:
+def utf16_span(body: str, needle: str, *, from_index: int = 0,
+               avoid=()) -> tuple[int, int]:
     """`(start, length)` of `needle` in `body`, in UTF-16 code units.
 
     `from_index` is a CODE POINT index into `body` — the search cursor, used so
@@ -210,9 +211,37 @@ def utf16_span(body: str, needle: str, *, from_index: int = 0) -> tuple[int, int
     both claiming the first. Raises `MentionSpanMissing` if the needle is not
     present at or after it. A thin wrapper over `find_span()` so there is exactly
     one matching rule.
+
+    🔴 `avoid` IS FORWARDED, and that is what makes the sentence above true.
+    Round-3 audit F4: this dropped the argument, so it implemented only the
+    `(?!\\w)` half of the rule — pre-round-2 behaviour under a docstring
+    promising the opposite. It has no production caller today, which is exactly
+    why the gap was invisible; the next caller would have inherited it.
     """
-    _, start, length = find_span(body, needle, from_index=from_index)
+    _, start, length = find_span(body, needle, from_index=from_index, avoid=avoid)
     return start, length
+
+
+def _same_needle(a: str, b: str) -> bool:
+    """Can the MATCHER tell these two needles apart?
+
+    🔴 THE EQUIVALENCE THE CURSOR USES, DERIVED FROM THE SEARCH RATHER THAN
+    RESTATED. Each needle's own compiled pattern is run against the other, and
+    both directions must consume the whole string. Anything else is a SECOND
+    matching rule that can — and did — disagree with the first: see the block
+    comment in `resolve_mentions()` for the two unicode pairs where
+    `str.casefold()` and `re.IGNORECASE` diverge in opposite directions.
+
+    Symmetric by construction. NOT assumed transitive: `re`'s folding is
+    per-code-point and unicode case classes are not a partition under it, so the
+    caller reuses the FIRST seen needle this returns True for rather than
+    building equivalence classes.
+    """
+    def _whole(pattern_src: str, text: str) -> bool:
+        match = _needle_pattern(pattern_src).match(text)
+        return match is not None and match.end() == len(text)
+
+    return _whole(a, b) and _whole(b, a)
 
 
 # --------------------------------------------------------------------------- #
@@ -292,38 +321,102 @@ def resolve_mentions(identifiers, *, body: str, members, contacts,
     # Only contacts that are ACTUALLY in this group are candidates. A name that
     # matches somebody in another conversation must not resolve here.
     candidates = [c for c in (contacts or []) if _contact_ids(c) & member_set]
+    identity = _identity_groups(candidates)
 
     out: list[dict] = []
-    cursor_for: dict[str, int] = {}
+    # 🔴 THE CURSOR'S EQUIVALENCE CLASS IS DERIVED FROM THE MATCHER ITSELF.
+    # Two needles share a search cursor iff the SEARCH cannot tell them apart —
+    # decided by `_same_needle()`, which asks the compiled patterns, not by a
+    # second folding function that happens to agree on ASCII.
+    #
+    # Round-2 audit F1 keyed this on `needle.casefold()`, reasoning that
+    # `re.IGNORECASE` and `casefold()` are the same relation. They are NOT, and
+    # they disagree in BOTH directions — round-3 audit F1, both arms measured in
+    # `test_the_cursor_does_NOT_merge_…` / `test_the_cursor_DOES_merge_…`:
+    #
+    #   over-merge  `'@ß'.casefold() == '@ss'.casefold()` is True, but the
+    #               matcher never expands `ß` to `ss`, so one shared cursor made
+    #               `--mention ss --mention ß` search for `@ß` from PAST the
+    #               `@ss` match and refuse a body that contains it.
+    #   under-merge `'@İstanbul'.casefold()` is `'@i̇stanbul'` — a `i` plus a
+    #               combining dot, one code point LONGER — so it keyed apart
+    #               from `'@istanbul'` while `re.IGNORECASE` folds `İ` to `i`
+    #               and matches. Two cursors, both at 0, both landing on the
+    #               first occurrence: `MentionSpansOverlap` on a body that
+    #               genuinely holds two.
+    #
+    # A list, not a dict: matcher equivalence is not guaranteed transitive, so
+    # this is first-match-wins over the needles already seen — which is exactly
+    # "reuse the cursor of an earlier needle this search cannot distinguish from
+    # the new one", and never invents a class the matcher does not have.
+    cursors: list[list] = []  # [needle, cursor] in first-seen order
     for ident in idents:
         author = _resolve_one(ident, member_set=member_set, candidates=candidates)
         needle = "@" + ident
-        # 🔴 THE CURSOR KEY IS CASEFOLDED, BECAUSE THE MATCHER IS CASE-INSENSITIVE.
-        # `_needle_pattern` compiles with `re.IGNORECASE`, so `@Ann` and `@ANN`
-        # are the SAME needle to the search — but keying the cursor on the raw
-        # string made them two dict entries, both starting from 0, both landing
-        # on the same first occurrence. `--mention Ann --mention ANN` against
-        # `"hi @Ann and @ANN ok"` then produced two identical spans and was
-        # refused by `_refuse_overlapping_spans` with a message telling the
-        # operator to give each mention its own `@who` text — which the body
-        # already had. Round-2 audit F1; the key must fold exactly as the
-        # matcher does. `casefold()` may change LENGTH, which is why it is used
-        # only as a dict key and never to compute an offset.
-        key = needle.casefold()
+        slot = next((s for s in cursors if _same_needle(s[0], needle)), None)
+        if slot is None:
+            slot = [needle, 0]
+            cursors.append(slot)
         idx, start, length = find_span(
-            body or "", needle, from_index=cursor_for.get(key, 0),
-            avoid=_colliding_needles(ident, author=author, candidates=candidates))
+            body or "", needle, from_index=slot[1],
+            avoid=_colliding_needles(ident, author=author, candidates=candidates,
+                                     identity=identity))
         # Advance THIS needle's cursor past the occurrence just claimed, so
         # `--mention Ann --mention Ann` takes the first and second "@Ann" rather
         # than pointing both mentions at the same span. Derived from the match
-        # `find_span` returned, NOT from a second search.
-        cursor_for[key] = idx + len(needle)
+        # `find_span` returned, NOT from a second search. `len(needle)` is the
+        # matched width: the pattern is `re.escape(needle)`, and `re` folds one
+        # code point to one code point, so a match is always exactly as long as
+        # the needle even when the two spell the character differently.
+        slot[1] = idx + len(needle)
         out.append({"author": author, "start": start, "length": length})
     _refuse_overlapping_spans(out)
     return out
 
 
-def _colliding_needles(ident: str, *, author: str, candidates: list) -> list[str]:
+def _identity_groups(candidates: list) -> dict[str, frozenset]:
+    """`identifier -> every identifier belonging to the SAME PERSON`.
+
+    🔴 ONE PERSON CAN BE TWO CONTACT ROWS, DURABLY. `_promote_placeholder()`'s
+    `NOT EXISTS` branch deliberately DECLINES when a real row already holds the
+    uuid, so a phone-only placeholder minted by a draft is left in place forever
+    once an envelope has taught the real row the same number. Both rows then
+    carry that number, and the shared identifier is the only thing that ties
+    them together — which is what this unions on.
+
+    Round-3 audit F3: `_colliding_needles()` compared raw `_contact_author()`
+    strings, so that person read as TWO people and their own longer name vetoed
+    their own ping — the exact case the `_colliding_needles` docstring claims is
+    excluded. Comparing resolved IDENTITY rather than a row's chosen author id
+    is what makes one person one person.
+
+    Rows with no identifier in common stay separate: there is nothing in the
+    data linking them, and merging on a NAME would reopen the prefix collision
+    the collision rule exists for.
+    """
+    parent: dict[str, str] = {}
+
+    def find(x: str) -> str:
+        while parent.setdefault(x, x) != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for contact in (candidates or []):
+        ids = sorted(_contact_ids(contact))
+        for other in ids[1:]:
+            root_a, root_b = find(ids[0]), find(other)
+            if root_a != root_b:
+                parent[root_a] = root_b
+
+    clusters: dict[str, set] = {}
+    for key in list(parent):
+        clusters.setdefault(find(key), set()).add(key)
+    return {key: frozenset(clusters[find(key)]) for key in parent}
+
+
+def _colliding_needles(ident: str, *, author: str, candidates: list,
+                       identity: dict | None = None) -> list[str]:
     """`@name` needles of OTHER group members that are LONGER than `@ident`.
 
     🔴 THE HALF OF THE PREFIX RULE `(?!\\w)` CANNOT DO. The right-hand word
@@ -335,16 +428,23 @@ def _colliding_needles(ident: str, *, author: str, candidates: list) -> list[str
     because the test is "does a longer member name occupy this exact offset",
     not "which characters are allowed to follow".
 
-    Restricted to OTHER authors: a contact with `display_name="Ann"` and
+    Restricted to OTHER PEOPLE: a contact with `display_name="Ann"` and
     `profile_name="Ann Marie"` is one person, and their own longer name must not
-    veto their own ping. Restricted to LONGER names because an equal-length
-    match IS this identifier (the matcher is case-insensitive), which is the
+    veto their own ping. 🔴 "Other person" is decided on RESOLVED IDENTITY —
+    `_identity_groups()`, which unions contact rows sharing any identifier — not
+    on the raw `_contact_author()` string, which splits one person into two the
+    moment they hold both a real row and a durable phone-only placeholder
+    (round-3 audit F3). Restricted to LONGER names because an equal-length match
+    IS this identifier (the matcher is case-insensitive), which is the
     `MentionNameAmbiguous` case and belongs to `_resolve_one`.
     """
     width = len(ident.strip())
+    identity = identity or {}
+    key = _norm_member(author)
+    mine = identity.get(key) or frozenset({key})
     return ["@" + name
             for contact in (candidates or [])
-            if _contact_author(contact) != author
+            if not (_contact_ids(contact) & mine)
             for name in _contact_names_raw(contact)
             if len(name) > width]
 

--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -88,6 +88,46 @@ APPROVAL_TOKEN_ENV = "SIGNAL_APPROVAL_TOKEN"
 RECONCILE_SENT = "sent"
 RECONCILE_NOT_SENT = "not-sent"
 
+# 🔴 `approval_ref` IS AN APPEND-ONLY AUDIT TRAIL, AND ONE SQL FRAGMENT SAYS SO.
+#
+# `approve_draft()` writes the clawgate reference the operator's decision is
+# recorded under; `unapprove_draft()` and BOTH branches of `reconcile_send()`
+# then record an operator NOTE on the same single TEXT column. Those three used
+# `approval_ref = COALESCE(%s, approval_ref)`, whose docstrings all claimed the
+# trail was "added to, never erased" — and COALESCE returns its FIRST non-null
+# argument, so passing a note returned THE NOTE and destroyed the reference to
+# the approval the refused attempt actually rode on. Exactly the documented
+# usage (`SKILL.md`: `unapprove 42 --note "..."`) was the case that erased it.
+# Round-2 audit F3; the reconcile half carried the identical defect under a
+# comment asserting the opposite ("A note ADDS to the record; it never replaces
+# it") and a test whose NAME said so while its assertion pinned the replacement.
+#
+# ONE fragment, three call sites, so the three cannot drift apart again — the
+# shape that produced this bug twice. The parameter appears TWICE, so every call
+# site binds the note twice; `_appended_note()` normalises a blank note to NULL
+# first, or an empty `--note` would append a bare separator.
+_APPEND_APPROVAL_REF = (
+    "approval_ref = CASE WHEN %s IS NULL THEN approval_ref "
+    "ELSE COALESCE(approval_ref || %s, %s) END"
+)
+# What separates one entry from the next in the trail. Read by the tests.
+APPROVAL_REF_SEPARATOR = " | "
+
+
+def _appended_note(note):
+    """`(note_or_none, suffix, first)` — the three binds `_APPEND_APPROVAL_REF` wants.
+
+    A blank or missing note is NULL, so the fragment's `CASE` leaves the column
+    untouched. A real note is appended after `APPROVAL_REF_SEPARATOR` when the
+    column already holds something, and stands alone when it does not — which is
+    what the `COALESCE(approval_ref || %s, %s)` expresses: `||` with a NULL left
+    operand is NULL in both Postgres and sqlite, so the fallback is the bare note.
+    """
+    text = (note or "").strip() if isinstance(note, str) else note
+    if not text:
+        return (None, None, None)
+    return (text, APPROVAL_REF_SEPARATOR + str(text), str(text))
+
 
 # --------------------------------------------------------------------------- #
 # Schema — the single source of truth. Tests DERIVE from these statements rather
@@ -518,6 +558,15 @@ def _mint_send_authorization(draft: dict) -> SendAuthorization:
     # notification through a mute setting and names a third party, so a payload
     # that gained, lost or re-pointed one after approval is a DIFFERENT act from
     # the one on the card. Bound here; verified in `spend_authorization()`.
+    #
+    # WHICH WINDOW THIS SLOT COVERS, precisely (round-2 audit F4): it is the
+    # values read by `send_approved()`'s FIRST `_draft_or_raise()`, and
+    # `spend_authorization()` compares them against the SECOND read taken after
+    # the row is claimed. So these slots cover the mint-read → POST-read gap and
+    # nothing before it. The approve → mint half is covered by a DIFFERENT
+    # mechanism a few lines up: `approved_digest` vs `draft_payload_digest()`.
+    # Between them the whole approve → POST window is covered, but by two
+    # guards, not by this one.
     object.__setattr__(auth, "mentions",
                        _mentions.canonical_mentions(draft.get("mentions")))
     nonce = uuid.uuid4().hex
@@ -538,12 +587,29 @@ def spend_authorization(auth: object, *, recipient, body, mentions) -> None:
     🔴 (c) IS THE NEW HALF, AND WHY THE ARGUMENTS ARE REQUIRED KEYWORDS. Until
     it existed the capability authorised "a transmit for draft N" and NOTHING
     about the message: `auth.recipient` and `auth.body` were populated at mint
-    and then read by nobody, so anything that changed the row between approval
-    and the POST — a concurrent writer, a second agent, a bug — sent text a human
-    never saw, under an approval a human really did give. Mentions make that
-    window materially worse: they notify third parties through mute settings, so
-    a mutated mention array is an act against someone who is not in the
-    conversation you approved.
+    and then read by nobody, so a writer that changed the row before the POST
+    sent text a human never saw, under an approval a human really did give.
+    Mentions make that window materially worse: they notify third parties
+    through mute settings, so a mutated mention array is an act against someone
+    who is not in the conversation you approved.
+
+    🔴 WHAT THIS COMPARISON COVERS, AND WHAT IT DOES NOT (round-2 audit F4 — the
+    docstring used to say "between approval and the POST", which is wider than
+    the code). `auth` was minted from `send_approved()`'s FIRST read of the row;
+    the values passed here come from its SECOND read, taken after the claim. So
+    this closes the **mint-read → POST-read** gap only. The **approve → mint**
+    half is closed separately and by a different instrument: `approve_draft()`
+    stores `approved_digest` and `_mint_send_authorization()` refuses to mint
+    unless the row still hashes to it. Two guards, one window between them —
+    stated as two claims because they fail independently, and a reader who
+    believes this one covers both would not notice the digest going missing.
+
+    One more difference worth naming: the digest hashes a CANONICAL recipient
+    identity (`recipient_identity()` — the contact/group ROW ID), while the
+    comparison here is against the recipient STRING `get_draft()` renders. That
+    string legitimately flips from a number to a uuid when `_promote_
+    placeholder()` learns a real uuid, which is why the digest does not hash it;
+    within the narrow window this guard covers, a flip is a real second writer.
 
     The three parameters have NO DEFAULTS on purpose. A default would let a call
     site silently opt out of the binding by omitting them, which is exactly the
@@ -912,7 +978,13 @@ class SignalDB:
 
         Including the `ALTER TABLE … ADD COLUMN IF NOT EXISTS` migration, which
         is idempotent for the same reason and is pinned by
-        `test_mentions.py::test_ensure_schema_twice_is_a_no_op`.
+        `test_pg_type_compat.py::test_ensure_schema_is_idempotent_on_real_postgres`
+        — the PG-TIER test, which is where the claim can actually be measured.
+        `test_mentions.py::test_ensure_schema_twice_is_a_no_op_ON_THE_SQLITE_
+        SUBSTRATE` also runs it twice, but the substrate EMULATES
+        `ADD COLUMN IF NOT EXISTS` (see `tests/fakepg.py`), so what it observes
+        is the emulation, not Postgres. The old pointer here named that test by
+        its pre-rename name and so read as a Postgres claim it never made.
         """
         with self._c.cursor() as cur:
             for stmt in SCHEMA_STATEMENTS:
@@ -1730,8 +1802,14 @@ class SignalDB:
         row must never carry a stale one, or the next `approve` would be checked
         against a digest it did not write.
 
-        `note` is recorded on `approval_ref` when given, and COALESCEd like
-        `reconcile_send`'s so the audit trail is added to, never erased.
+        `note` is APPENDED to `approval_ref` when given — see
+        `_APPEND_APPROVAL_REF`, the one fragment this and both `reconcile_send`
+        branches share. 🔴 It used to be `COALESCE(%s, approval_ref)`, which
+        returns the NOTE when a note is given: the documented usage
+        (`unapprove 42 --note "body was edited after approval"`) therefore
+        DESTROYED the reference to the approval the refused send rode on, in the
+        one scenario this command exists for. Round-2 audit F3. The trail now
+        reads `"<approval-ref> | <note>"`, and passing no note leaves it alone.
         """
         if not os.environ.get(APPROVAL_TOKEN_ENV):
             raise SendGateError(
@@ -1755,9 +1833,9 @@ class SignalDB:
         self._transition(
             draft_id,
             "UPDATE signal.messages SET send_state = %s, approved_digest = NULL, "
-            "approval_ref = COALESCE(%s, approval_ref) "
-            "WHERE id = %s AND send_state = %s",
-            (STATE_PENDING, note, draft_id, STATE_APPROVED),
+            + _APPEND_APPROVAL_REF
+            + " WHERE id = %s AND send_state = %s",
+            (STATE_PENDING, *_appended_note(note), draft_id, STATE_APPROVED),
             expected=STATE_APPROVED,
             what="withdraw the approval",
         )
@@ -2066,24 +2144,28 @@ class SignalDB:
                 draft_id,
                 "UPDATE signal.messages SET message_timestamp = %s, "
                 "send_state = %s, message_type = 'message', "
-                "approval_ref = COALESCE(%s, approval_ref) "
-                "WHERE id = %s AND send_state = %s",
-                (server_ts, STATE_SENT, note, draft_id, STATE_SENDING),
+                + _APPEND_APPROVAL_REF
+                + " WHERE id = %s AND send_state = %s",
+                (server_ts, STATE_SENT, *_appended_note(note), draft_id,
+                 STATE_SENDING),
                 expected=STATE_SENDING,
                 what="reconcile as sent",
             )
         else:
-            # COALESCE in BOTH branches. A bare `approval_ref = %s` here erased
-            # the recorded approval whenever the operator passed no `--note` —
-            # deleting the audit record of the very approval the attempt rode on,
-            # which is the thing `approve_draft`'s docstring stakes D3 on. A note
-            # ADDS to the record; it never replaces it.
+            # 🔴 THE SAME FRAGMENT IN BOTH BRANCHES — and it is an APPEND now,
+            # not a COALESCE. A bare `approval_ref = %s` here erased the recorded
+            # approval whenever the operator passed no `--note`; COALESCE fixed
+            # that half and left the other one broken, erasing it whenever the
+            # operator DID pass a note, under a comment claiming "a note ADDS to
+            # the record; it never replaces it". Round-2 audit F3: the comment is
+            # now true, and both branches share `_APPEND_APPROVAL_REF` with
+            # `unapprove_draft` so no third variant can appear.
             self._transition(
                 draft_id,
                 "UPDATE signal.messages SET send_state = %s, "
-                "approval_ref = COALESCE(%s, approval_ref) "
-                "WHERE id = %s AND send_state = %s",
-                (STATE_PENDING, note, draft_id, STATE_SENDING),
+                + _APPEND_APPROVAL_REF
+                + " WHERE id = %s AND send_state = %s",
+                (STATE_PENDING, *_appended_note(note), draft_id, STATE_SENDING),
                 expected=STATE_SENDING,
                 what="reconcile as not-sent",
             )

--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -32,6 +32,8 @@ from __future__ import annotations
 
 import base64
 import contextlib
+import hashlib
+import json
 import os
 import re
 import socket
@@ -40,6 +42,9 @@ import sys
 import time
 import uuid
 from urllib.parse import urlparse
+
+# Pure, dependency-free, and imports nothing from this module — no cycle.
+import _mentions
 
 try:
     import psycopg2
@@ -265,6 +270,35 @@ SCHEMA_STATEMENTS: tuple[str, ...] = (
     )
     """,
 
+    # 🔴 A MIGRATION, NOT A COLUMN IN THE `CREATE TABLE` ABOVE. Every other
+    # statement here is `CREATE … IF NOT EXISTS`, which is a no-op against an
+    # EXISTING table — so adding `mentions` to `signal.messages`'s CREATE body
+    # would take effect on a fresh database (the hermetic substrate, which is
+    # built from scratch every test) and do NOTHING to prod, where the table
+    # already exists. The suite would be green and the deployed schema unchanged.
+    # `ADD COLUMN IF NOT EXISTS` is idempotent in Postgres (>= 9.6), so
+    # `ensure_schema()` stays safe to run on every start.
+    #
+    # JSONB, holding the wire array verbatim: `[{"author","start","length"}, …]`.
+    # It is what was APPROVED and what is SENT, so it has to be durable for the
+    # same reason the body is — and the send-authorization binding compares
+    # against it (see `_mint_send_authorization`).
+    "ALTER TABLE signal.messages ADD COLUMN IF NOT EXISTS mentions JSONB",
+
+    # 🔴 WHAT THE HUMAN ACTUALLY APPROVED, as a digest. `approve_draft()` writes
+    # it; `_mint_send_authorization()` refuses to mint when the row no longer
+    # hashes to it.
+    #
+    # It has to be DURABLE and it has to be written at APPROVAL, because that is
+    # where the window is. `approve` and `send` are separate CLI invocations
+    # minutes or hours apart, and everything in between sees an ordinary row: a
+    # capability minted at SEND time out of whatever the row says then agrees
+    # with itself no matter what changed, which is precisely the tautology that
+    # made the old `auth.recipient`/`auth.body` fields dead code. Comparing
+    # against a value recorded BEFORE the wait is the only thing that can
+    # disagree.
+    "ALTER TABLE signal.messages ADD COLUMN IF NOT EXISTS approved_digest TEXT",
+
     "CREATE INDEX IF NOT EXISTS idx_msg_ts ON signal.messages(message_timestamp DESC)",
     "CREATE INDEX IF NOT EXISTS idx_msg_dm ON signal.messages(source_contact_id, message_timestamp)",
     "CREATE INDEX IF NOT EXISTS idx_msg_group ON signal.messages(group_id, message_timestamp) WHERE group_id IS NOT NULL",
@@ -334,7 +368,7 @@ class SendAuthorization:
     look-alike object cannot stand in for it.
     """
 
-    __slots__ = ("draft_id", "recipient", "body", "_nonce")
+    __slots__ = ("draft_id", "recipient", "body", "mentions", "_nonce")
 
     def __init__(self, *_a, **_kw):  # pragma: no cover - exercised via the gate tests
         raise SendGateError(
@@ -353,6 +387,25 @@ class SendAuthorization:
 _ISSUED_NONCES: set[str] = set()
 
 
+def payload_digest(*, recipient, body, mentions) -> str:
+    """A stable fingerprint of the three things that make up a sent message.
+
+    Canonical JSON with sorted keys so the digest depends on the VALUES and not
+    on dict ordering or on whether `mentions` came back as `None`, `[]` or a JSON
+    string — `canonical_mentions()` flattens all three to the same tuple.
+
+    Not a security primitive: nothing here is defending against an attacker who
+    can already write to the row AND recompute the digest. It defends against
+    the realistic case — a second writer, a buggy job, an agent editing a draft
+    it did not approve — where the row changes and the digest does not.
+    """
+    payload = json.dumps(
+        {"recipient": recipient, "body": body,
+         "mentions": [list(m) for m in _mentions.canonical_mentions(mentions)]},
+        sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
 def _mint_send_authorization(draft: dict) -> SendAuthorization:
     """Mint a one-shot send capability for an APPROVED draft row.
 
@@ -366,23 +419,76 @@ def _mint_send_authorization(draft: dict) -> SendAuthorization:
             f"draft {(draft or {}).get('id')!r} has send_state={state!r}; only "
             f"{STATE_APPROVED!r} drafts may be transmitted (D3 approval gate)"
         )
+    # 🔴 THE APPROVE -> MUTATE -> SEND WINDOW, CLOSED HERE. `approve` and `send`
+    # are separate invocations; in between, the draft is an ordinary row that
+    # anything with the connection can rewrite. `approve_draft()` recorded a
+    # digest of exactly what it showed the human, and this refuses to mint a
+    # capability for a row that no longer hashes to it — so a body, a recipient
+    # or a MENTION added, removed or re-pointed after approval cannot be
+    # transmitted under that approval. FAILS CLOSED: a missing digest is a
+    # refusal, not a pass, because "no digest" and "digest cleared by the writer
+    # we are guarding against" are the same observation.
+    recorded = (draft or {}).get("approved_digest")
+    current = payload_digest(recipient=draft.get("recipient"),
+                             body=draft.get("body"),
+                             mentions=draft.get("mentions"))
+    if not recorded:
+        raise SendGateError(
+            f"draft {draft.get('id')!r} is approved but carries NO approval "
+            f"digest, so there is nothing to check the payload against. Either "
+            f"it was approved before this binding existed, or the digest was "
+            f"cleared — the two are indistinguishable from here. Re-approve it "
+            f"(D3 approval gate — approve/mutate/send binding)"
+        )
+    if recorded != current:
+        raise SendGateError(
+            f"draft {draft.get('id')!r} CHANGED after it was approved: the row "
+            f"now hashes to {current} but the approval recorded {recorded}. "
+            f"Nothing was sent. Read the draft, then re-approve it if the new "
+            f"text is what you want (D3 approval gate — approve/mutate/send "
+            f"binding)"
+        )
     auth = object.__new__(SendAuthorization)
     object.__setattr__(auth, "draft_id", draft["id"])
     object.__setattr__(auth, "recipient", draft.get("recipient"))
     object.__setattr__(auth, "body", draft.get("body"))
+    # 🔴 The MENTIONS are part of what was approved. A mention pushes a
+    # notification through a mute setting and names a third party, so a payload
+    # that gained, lost or re-pointed one after approval is a DIFFERENT act from
+    # the one on the card. Bound here; verified in `spend_authorization()`.
+    object.__setattr__(auth, "mentions",
+                       _mentions.canonical_mentions(draft.get("mentions")))
     nonce = uuid.uuid4().hex
     object.__setattr__(auth, "_nonce", nonce)
     _ISSUED_NONCES.add(nonce)
     return auth
 
 
-def spend_authorization(auth: object) -> None:
-    """Consume a capability, or raise `SendGateError`.
+def spend_authorization(auth: object, *, recipient, body, mentions) -> None:
+    """Consume a capability FOR A SPECIFIC PAYLOAD, or raise `SendGateError`.
 
     Called by `consumer.transmit_approved()` immediately before it touches the
-    network. Rejects (a) anything that is not a real `SendAuthorization` and
+    network. Rejects (a) anything that is not a real `SendAuthorization`,
     (b) a capability that has already been spent — which is what makes an
-    approved draft transmit EXACTLY once.
+    approved draft transmit EXACTLY once — and (c) a payload that is not the one
+    the capability was minted for.
+
+    🔴 (c) IS THE NEW HALF, AND WHY THE ARGUMENTS ARE REQUIRED KEYWORDS. Until
+    it existed the capability authorised "a transmit for draft N" and NOTHING
+    about the message: `auth.recipient` and `auth.body` were populated at mint
+    and then read by nobody, so anything that changed the row between approval
+    and the POST — a concurrent writer, a second agent, a bug — sent text a human
+    never saw, under an approval a human really did give. Mentions make that
+    window materially worse: they notify third parties through mute settings, so
+    a mutated mention array is an act against someone who is not in the
+    conversation you approved.
+
+    The three parameters have NO DEFAULTS on purpose. A default would let a call
+    site silently opt out of the binding by omitting them, which is exactly the
+    seam this closes; a `TypeError` at import-time-adjacent call sites is the
+    point. This function is also the ONLY place the comparison lives — see
+    `test_the_only_send_call_site_is_inside_transmit_approved`, which pins that
+    `transmit_approved()` passes all three.
     """
     if not isinstance(auth, SendAuthorization):
         raise SendGateError(
@@ -390,13 +496,57 @@ def spend_authorization(auth: object) -> None:
             "is required (D3 approval gate); got "
             f"{type(auth).__name__}"
         )
+    # 🔴 THE THREE CHECKS RUN TYPE -> NONCE -> PAYLOAD, and the order is load
+    # bearing in BOTH directions. Nonce before payload, so a forgery that only
+    # half-populates the slots is refused as the forgery it is rather than as a
+    # payload mismatch (and so the pre-existing "already been spent" wording
+    # still wins for a replayed capability). Payload before the DISCARD, so a
+    # mismatch is a REFUSAL and not a consumed attempt: burning the capability
+    # here would strand a draft that nothing is wrong with, and the operator's
+    # remedy — look at the row, re-approve, re-send — needs it still sendable.
     nonce = getattr(auth, "_nonce", None)
     if nonce not in _ISSUED_NONCES:
         raise SendGateError(
             "transmit refused: this SendAuthorization has already been spent "
             "(D3 approval gate — capabilities are single-use)"
         )
+    mismatches = []
+    if auth.recipient != recipient:
+        mismatches.append(f"recipient {auth.recipient!r} -> {recipient!r}")
+    if auth.body != body:
+        mismatches.append(f"body {auth.body!r} -> {body!r}")
+    want_mentions = _mentions.canonical_mentions(mentions)
+    have_mentions = getattr(auth, "mentions", ())
+    if have_mentions != want_mentions:
+        mismatches.append(f"mentions {list(have_mentions)!r} -> "
+                          f"{list(want_mentions)!r}")
+    if mismatches:
+        raise SendGateError(
+            f"transmit refused: the payload does not match what was approved for "
+            f"draft {auth.draft_id!r} — {'; '.join(mismatches)}. The draft row "
+            f"changed between approval and transmission; nothing was sent and the "
+            f"capability was NOT spent (D3 approval gate — approve/mutate/send "
+            f"binding)"
+        )
     _ISSUED_NONCES.discard(nonce)
+
+
+def _decode_mentions(value) -> list:
+    """A stored `mentions` column → a list. NULL/''/'null' all mean none.
+
+    psycopg2 already decodes JSONB; the sqlite substrate hands back the raw TEXT.
+    Both reach this, so both engines produce the same Python shape.
+    """
+    if value is None or value == "":
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        value = bytes(value).decode("utf-8")
+    if isinstance(value, str):
+        decoded = json.loads(value)
+        return list(decoded) if decoded else []
+    raise ValueError(f"unreadable mentions column: {value!r}")
 
 
 # `message_type` of a row whose sender retracted it. The row is KEPT (its
@@ -689,7 +839,12 @@ class SignalDB:
 
     # -- schema ------------------------------------------------------------
     def ensure_schema(self) -> None:
-        """Create the `signal` schema. Idempotent — every statement is IF NOT EXISTS."""
+        """Create the `signal` schema. Idempotent — every statement is IF NOT EXISTS.
+
+        Including the `ALTER TABLE … ADD COLUMN IF NOT EXISTS` migration, which
+        is idempotent for the same reason and is pinned by
+        `test_mentions.py::test_ensure_schema_twice_is_a_no_op`.
+        """
         with self._c.cursor() as cur:
             for stmt in SCHEMA_STATEMENTS:
                 cur.execute(stmt)
@@ -757,6 +912,36 @@ class SignalDB:
                 (signal_uuid, phone_number, display_name, profile_name, is_placeholder),
             )
             return _returned_id(cur, "upsert_contact")
+
+    def contacts_by_identifiers(self, identifiers) -> list:
+        """Contact rows for a MIXED list of uuids and phone numbers.
+
+        `GET /v1/groups/.../members` returns both forms in one array, so a lookup
+        that queried only `signal_uuid` would find nothing for the E.164 members
+        and a lookup that queried only `phone_number` would find nothing for the
+        uuid-only ones — and in the measured 7-member group, 5 members are
+        uuid-only. Both columns are matched, in ONE query, and
+        `is_placeholder` comes back with the row because a placeholder is a
+        REFUSAL upstream, not something to filter out silently here.
+        """
+        idents = [str(i).strip() for i in (identifiers or []) if str(i or "").strip()]
+        if not idents:
+            return []
+        # Two separate `IN` lists rather than one: `signal_uuid` is `uuid` in
+        # Postgres and comparing it to a phone number like '+15550100' raises
+        # `invalid input syntax for type uuid`. CASTING the column to text keeps
+        # both engines happy and keeps the whole thing one round trip.
+        placeholders = ", ".join(["%s"] * len(idents))
+        with self._c.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "SELECT id, CAST(signal_uuid AS text) AS signal_uuid, "
+                "phone_number, display_name, profile_name, is_placeholder "
+                "FROM signal.contacts "
+                f"WHERE CAST(signal_uuid AS text) IN ({placeholders}) "
+                f"   OR phone_number IN ({placeholders})",
+                tuple(idents) * 2,
+            )
+            return [dict(r) for r in cur.fetchall()]
 
     def contact_id_by_phone(self, phone_number: str) -> int | None:
         """The contact row for a phone number, preferring a REAL one over a placeholder.
@@ -1251,6 +1436,7 @@ class SignalDB:
                       self_uuid: str | None = None,
                       self_number: str | None = None,
                       approval_ref: str | None = None,
+                      mentions: list | None = None,
                       provisional_timestamp: int | None = None) -> dict:
         """Compose and STORE an outbound draft. **Transmits nothing.**
 
@@ -1363,18 +1549,26 @@ class SignalDB:
                 "a draft's provisional timestamp must be NEGATIVE so it cannot "
                 "collide with a server-assigned timestamp (🔧 #4)"
             )
+        # 🔴 Stored as TEXT-encoded JSON, never as a Python list handed to the
+        # driver. psycopg2 adapts a `list` to a Postgres ARRAY, not to JSONB, so
+        # passing it raw would raise `column "mentions" is of type jsonb but
+        # expression is of type text[]` at runtime — and the sqlite substrate,
+        # which stores JSONB as TEXT, could not see it. `None` stays NULL: a
+        # mention-free draft must be indistinguishable from every draft written
+        # before this column existed.
+        mentions_json = json.dumps(list(mentions)) if mentions else None
         with self._c.cursor() as cur:
             cur.execute(
                 """
                 INSERT INTO signal.messages
                     (message_timestamp, source_contact_id, dest_contact_id,
                      group_id, message_type, body, is_outbound, send_state,
-                     approval_ref)
-                VALUES (%s, %s, %s, %s, 'draft', %s, true, %s, %s)
+                     approval_ref, mentions)
+                VALUES (%s, %s, %s, %s, 'draft', %s, true, %s, %s, %s)
                 RETURNING id
                 """,
                 (ts, source_id, dest_id, group_row_id, body, STATE_PENDING,
-                 approval_ref),
+                 approval_ref, mentions_json),
             )
             draft_id = _returned_id(cur, "draft_message")
         self._c.commit()
@@ -1384,6 +1578,7 @@ class SignalDB:
             "source_contact_id": source_id, "dest_contact_id": dest_id,
             "group_id": group_row_id, "group_created": group_created,
             "approval_ref": approval_ref,
+            "mentions": list(mentions) if mentions else [],
         }
 
     def approve_draft(self, draft_id: int, *, approval_ref: str) -> dict:
@@ -1421,11 +1616,20 @@ class SignalDB:
                 f"draft {draft_id!r} has send_state={row['send_state']!r}; only "
                 f"{STATE_PENDING!r} drafts may be approved (D3 approval gate)"
             )
+        # 🔴 RECORD WHAT IS BEING APPROVED, not merely THAT it was approved. The
+        # digest is computed from the row we just read — the exact recipient,
+        # body and mentions the clawgate card described — and
+        # `_mint_send_authorization()` refuses to send a row that no longer
+        # hashes to it. Written in the SAME statement as the state flip so an
+        # approved draft can never exist without one.
+        digest = payload_digest(recipient=row.get("recipient"),
+                                body=row.get("body"),
+                                mentions=row.get("mentions"))
         with self._c.cursor() as cur:
             cur.execute(
-                "UPDATE signal.messages SET send_state = %s, approval_ref = %s "
-                "WHERE id = %s",
-                (STATE_APPROVED, approval_ref, draft_id),
+                "UPDATE signal.messages SET send_state = %s, approval_ref = %s, "
+                "approved_digest = %s WHERE id = %s",
+                (STATE_APPROVED, approval_ref, digest, draft_id),
             )
         self._c.commit()
         return self._draft_or_raise(draft_id)
@@ -1477,6 +1681,7 @@ class SignalDB:
                 """
                 SELECT m.id, m.message_timestamp, m.body, m.send_state,
                        m.approval_ref, m.source_contact_id, m.dest_contact_id,
+                       m.mentions AS mentions, m.approved_digest,
                        -- `signal_uuid` is uuid, `phone_number` is text, and
                        -- Postgres type-checks the WHOLE CASE regardless of which
                        -- branch would run — so an uncast COALESCE here raises
@@ -1518,6 +1723,12 @@ class SignalDB:
             group_signal_id = out.pop("group_signal_id", None)
             if group_signal_id is not None:
                 out["recipient"] = _group_id_to_address(group_signal_id)
+            # 🔴 ALWAYS A LIST, never NULL and never a JSON string. psycopg2
+            # decodes a real JSONB column to a Python list already; the sqlite
+            # substrate (JSONB -> TEXT) hands back the raw string. Normalising
+            # here means every caller — the send payload, the binding check, the
+            # CLI's `json.dumps` — sees one shape, on both engines.
+            out["mentions"] = _decode_mentions(out.get("mentions"))
             return out
 
     def list_drafts(self, state: str | None = None) -> list:
@@ -1566,8 +1777,16 @@ class SignalDB:
         # duplicate message. `send_attempts` records that it was tried.
         self._claim_for_sending(draft_id)
 
-        result = transmit(auth, recipient=draft["recipient"], body=draft["body"],
-                          number=number)
+        # 🔴 RE-READ, deliberately, and send THIS row — not the `draft` dict the
+        # capability was minted from. Sending the minted dict would make the
+        # binding in `spend_authorization()` a tautology: it would be comparing
+        # the capability against the very values it was built from, and could
+        # never disagree. Reading the row again is what turns the binding into a
+        # real check on the approve→mutate→send window, because anything that
+        # wrote to the row in between shows up HERE and nowhere else.
+        live = self._draft_or_raise(draft_id)
+        result = transmit(auth, recipient=live["recipient"], body=live["body"],
+                          mentions=live.get("mentions") or [], number=number)
         # 🔴 The live server returns a LIST, one entry per recipient — measured
         # 2026-08-21 against signal-cli-rest-api in json-rpc mode:
         #     201  [{"timestamp":"1787331796630"}]

--- a/scripts/signal/_signal_db.py
+++ b/scripts/signal/_signal_db.py
@@ -406,6 +406,59 @@ def payload_digest(*, recipient, body, mentions) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+# 🔴 THE ROUTE OUT, NAMED IN THE ERROR THAT SENDS YOU DOWN IT. Both digest
+# refusals used to end "Re-approve it" — an instruction the CLI could not carry
+# out: `approve` is `pending`-only, `reconcile` is `sending`-only, and there was
+# no third subcommand, so a refused draft was stuck in `approved` FOREVER. The
+# text and `unapprove_draft()` ship together; `test_skill_doc` pins the command
+# into SKILL.md and `test_mentions` walks this exact sequence with no raw SQL.
+_REAPPROVE_HINT = (
+    "run `unapprove {draft_id}` to return it to `pending`, then "
+    "`approve {draft_id} --ref <new-clawgate-ref>` — both are operator commands "
+    "and need SIGNAL_APPROVAL_TOKEN"
+)
+
+
+def recipient_identity(draft) -> str:
+    """The STABLE identity of a draft's recipient, for the approval digest.
+
+    🔴 WHY NOT `draft["recipient"]`. That field is a RENDERED PROJECTION, not an
+    identity: `get_draft()`'s `CASE` prints a contact's `phone_number` while the
+    row is a placeholder and its `signal_uuid` once it is not. `_promote_
+    placeholder()` performs exactly that swap as UNATTENDED BACKGROUND INGEST —
+    the moment an envelope arrives from a number we had only a placeholder for.
+
+    So hashing the rendered string made the ordinary "message someone new" path
+    fire the tamper guard: draft a DM to an unknown number → approve → that
+    person's first envelope arrives → the projection changes → `send` refuses,
+    with no adversary, no second writer, and NO CHANGE TO WHO THE MESSAGE GOES
+    TO. The promotion PRESERVES the contact row id (that is the documented point
+    of its `NOT EXISTS` guard), so the row id is stable across exactly the event
+    the rendered form is not.
+
+    Falls back to the address string only for a dict that carries no row ids —
+    the hand-built rows in the unit tests, which have no substrate behind them.
+    """
+    d = draft or {}
+    if d.get("group_id") is not None:
+        return f"group:{d['group_id']}"
+    if d.get("dest_contact_id") is not None:
+        return f"contact:{d['dest_contact_id']}"
+    return f"address:{d.get('recipient')}"
+
+
+def draft_payload_digest(draft) -> str:
+    """The approval digest OF A DRAFT ROW — the one definition, used by both sides.
+
+    `approve_draft()` writes it and `_mint_send_authorization()` re-checks it. A
+    single function so the two can never compute it over different fields, which
+    is the shape that would make the guard either vacuous or permanently red.
+    """
+    d = draft or {}
+    return payload_digest(recipient=recipient_identity(d), body=d.get("body"),
+                          mentions=d.get("mentions"))
+
+
 def _mint_send_authorization(draft: dict) -> SendAuthorization:
     """Mint a one-shot send capability for an APPROVED draft row.
 
@@ -429,24 +482,33 @@ def _mint_send_authorization(draft: dict) -> SendAuthorization:
     # refusal, not a pass, because "no digest" and "digest cleared by the writer
     # we are guarding against" are the same observation.
     recorded = (draft or {}).get("approved_digest")
-    current = payload_digest(recipient=draft.get("recipient"),
-                             body=draft.get("body"),
-                             mentions=draft.get("mentions"))
+    try:
+        current = draft_payload_digest(draft)
+    except _mentions.MentionError as exc:
+        # A stored `mentions` column that cannot be read is a REFUSAL on the send
+        # path, in the error type this path's CLI handler catches — not a bare
+        # TypeError escaping as a traceback.
+        raise SendGateError(
+            f"draft {draft.get('id')!r} carries an unreadable `mentions` column, "
+            f"so what was approved cannot be recomputed: {exc} (D3 approval gate)"
+        ) from exc
     if not recorded:
         raise SendGateError(
             f"draft {draft.get('id')!r} is approved but carries NO approval "
             f"digest, so there is nothing to check the payload against. Either "
             f"it was approved before this binding existed, or the digest was "
-            f"cleared — the two are indistinguishable from here. Re-approve it "
-            f"(D3 approval gate — approve/mutate/send binding)"
+            f"cleared — the two are indistinguishable from here. "
+            + _REAPPROVE_HINT.format(draft_id=draft.get("id"))
+            + " (D3 approval gate — approve/mutate/send binding)"
         )
     if recorded != current:
         raise SendGateError(
             f"draft {draft.get('id')!r} CHANGED after it was approved: the row "
             f"now hashes to {current} but the approval recorded {recorded}. "
-            f"Nothing was sent. Read the draft, then re-approve it if the new "
-            f"text is what you want (D3 approval gate — approve/mutate/send "
-            f"binding)"
+            f"Nothing was sent. Read the draft, then, if the new text is what "
+            f"you want, "
+            + _REAPPROVE_HINT.format(draft_id=draft.get("id"))
+            + " (D3 approval gate — approve/mutate/send binding)"
         )
     auth = object.__new__(SendAuthorization)
     object.__setattr__(auth, "draft_id", draft["id"])
@@ -515,7 +577,14 @@ def spend_authorization(auth: object, *, recipient, body, mentions) -> None:
         mismatches.append(f"recipient {auth.recipient!r} -> {recipient!r}")
     if auth.body != body:
         mismatches.append(f"body {auth.body!r} -> {body!r}")
-    want_mentions = _mentions.canonical_mentions(mentions)
+    try:
+        want_mentions = _mentions.canonical_mentions(mentions)
+    except _mentions.MentionError as exc:
+        # Same translation as the mint side: an unreadable mentions array is a
+        # refusal in the type `send`'s CLI handler catches, not a raw TypeError.
+        raise SendGateError(
+            f"transmit refused: the mentions array offered for draft "
+            f"{auth.draft_id!r} is unreadable — {exc} (D3 approval gate)") from exc
     have_mentions = getattr(auth, "mentions", ())
     if have_mentions != want_mentions:
         mismatches.append(f"mentions {list(have_mentions)!r} -> "
@@ -1622,9 +1691,17 @@ class SignalDB:
         # `_mint_send_authorization()` refuses to send a row that no longer
         # hashes to it. Written in the SAME statement as the state flip so an
         # approved draft can never exist without one.
-        digest = payload_digest(recipient=row.get("recipient"),
-                                body=row.get("body"),
-                                mentions=row.get("mentions"))
+        # 🔴 Over `recipient_identity(row)`, NOT `row["recipient"]` — see that
+        # function: the printed recipient is a projection that background ingest
+        # rewrites, and hashing it made an ordinary placeholder promotion look
+        # like tampering.
+        try:
+            digest = draft_payload_digest(row)
+        except _mentions.MentionError as exc:
+            raise SendGateError(
+                f"approval refused: draft {draft_id!r} carries an unreadable "
+                f"`mentions` column ({exc}), so there is nothing coherent to "
+                f"approve (D3 approval gate)") from exc
         with self._c.cursor() as cur:
             cur.execute(
                 "UPDATE signal.messages SET send_state = %s, approval_ref = %s, "
@@ -1632,6 +1709,58 @@ class SignalDB:
                 (STATE_APPROVED, approval_ref, digest, draft_id),
             )
         self._c.commit()
+        return self._draft_or_raise(draft_id)
+
+    def unapprove_draft(self, draft_id: int, *, note: str | None = None) -> dict:
+        """Return an APPROVED draft to `pending` so it can be approved again.
+
+        🔴 WHY THIS EXISTS — IT CLOSES A TERMINAL DEAD END. The approval digest
+        makes `_mint_send_authorization()` refuse a draft whose payload changed
+        after approval, and that refusal happens BEFORE `_claim_for_sending()`,
+        so the row stays `approved`. But `approve_draft()` is `pending`-only and
+        `reconcile_send()` is `sending`-only, and there was no third command:
+        the refused draft was unsendable forever, and both the refusal text and
+        SKILL.md told the operator to "re-approve it" — something the CLI had no
+        way to do. The only route back was hand-editing the row, which is
+        precisely the second writer the digest exists to catch.
+
+        Gated on `SIGNAL_APPROVAL_TOKEN` **exactly as `approve_draft` is**: this
+        un-does an operator decision, so it is an operator decision. It does NOT
+        send, does not re-approve, and CLEARS `approved_digest` — a `pending`
+        row must never carry a stale one, or the next `approve` would be checked
+        against a digest it did not write.
+
+        `note` is recorded on `approval_ref` when given, and COALESCEd like
+        `reconcile_send`'s so the audit trail is added to, never erased.
+        """
+        if not os.environ.get(APPROVAL_TOKEN_ENV):
+            raise SendGateError(
+                f"unapprove refused: {APPROVAL_TOKEN_ENV} is not set. Withdrawing "
+                f"an approval is the OPERATOR's step, on the same token as "
+                f"`approve` — it is deliberately unavailable to the consumer "
+                f"Deployment and to drafting agents (D3 approval gate)"
+            )
+        row = self._draft_or_raise(draft_id)
+        if row["send_state"] != STATE_APPROVED:
+            raise SendGateError(
+                f"draft {draft_id!r} has send_state={row['send_state']!r}; only "
+                f"{STATE_APPROVED!r} drafts may be unapproved. A draft in "
+                f"{STATE_SENDING!r} is reconciled with `reconcile`, not here — "
+                f"the POST was attempted and its outcome is unknown (D3 approval "
+                f"gate)"
+            )
+        # The SAME guarded transition every other state move uses: names the
+        # state it expects and reads the rowcount, so a concurrent `send` that
+        # claimed the row first is told it lost rather than silently overwritten.
+        self._transition(
+            draft_id,
+            "UPDATE signal.messages SET send_state = %s, approved_digest = NULL, "
+            "approval_ref = COALESCE(%s, approval_ref) "
+            "WHERE id = %s AND send_state = %s",
+            (STATE_PENDING, note, draft_id, STATE_APPROVED),
+            expected=STATE_APPROVED,
+            what="withdraw the approval",
+        )
         return self._draft_or_raise(draft_id)
 
     def _draft_or_raise(self, draft_id: int) -> dict:

--- a/scripts/signal/build-push.sh
+++ b/scripts/signal/build-push.sh
@@ -236,7 +236,14 @@ choices=$(docker run --rm --entrypoint python3 "$IMAGE" \
 # transmit nothing, and — the property that made this the chosen design — DELETE
 # nothing: `unmute` restores the conversation in full, because the messages were
 # never removed. `muted` is read-only.
-want_choices="approve conversations draft drafts health mute muted reconcile run search send unmute "
+#
+# `unapprove` added 2026-08-30, closing a terminal dead end. Acknowledged
+# deliberately, as this control demands. It moves a draft approved -> pending and
+# NULLs `approved_digest`; it transmits nothing and can only make a draft LESS
+# sendable — a pending draft has no route to the wire until an operator approves
+# it again. It is gated on `SIGNAL_APPROVAL_TOKEN`, which is deliberately absent
+# from this pod's environment, so in the deployed image it can only refuse.
+want_choices="approve conversations draft drafts health mute muted reconcile run search send unapprove unmute "
 if [[ "$choices" != "$want_choices" ]]; then
   echo "build-push: REFUSING TO PUSH — subcommand set is '$choices'," >&2
   echo "            expected '$want_choices'. Empty means the parse found no {…}" >&2

--- a/scripts/signal/clawgate.py
+++ b/scripts/signal/clawgate.py
@@ -31,7 +31,8 @@ BODY_PREVIEW_MAX = 800
 
 
 def build_draft_payload(*, draft_id: int, recipient: str, body: str,
-                        mentions: list | None = None) -> dict:
+                        mentions: list | None = None,
+                        author_names: dict | None = None) -> dict:
     """Build the `POST /api/tasks` JSON body for one pending Signal draft.
 
     Pure + side-effect-free so it can be asserted in a unit test.
@@ -43,6 +44,12 @@ def build_draft_payload(*, draft_id: int, recipient: str, body: str,
     mute settings and names them to the whole group. Approving a message without
     seeing who it notifies is the failure mode this line exists to close, so the
     resolved `author` ids go on the card explicitly, above the body.
+
+    🔴 AND THE ID ALONE IS NOT ENOUGH. `author` is usually a bare uuid — five of
+    the seven members of the real group are uuid-only — and a human cannot check
+    a uuid against anything. `author_names` (`{author: display name}`, built by
+    `_mentions.author_names()` from the rows the resolver matched) puts the NAME
+    on the line beside the id, which is the question the card is answering.
     """
     preview = (body or "").strip()
     if len(preview) > BODY_PREVIEW_MAX:
@@ -57,7 +64,7 @@ def build_draft_payload(*, draft_id: int, recipient: str, body: str,
     if mentions:
         lines.append(f"⚠ PINGS {len(mentions)} member(s) — this notifies them "
                      f"THROUGH their mute settings:")
-        for who in _mentions.describe_mentions(mentions):
+        for who in _mentions.describe_mentions(mentions, author_names):
             lines.append(f"  · {who}")
     lines += [
         "",
@@ -74,6 +81,7 @@ def build_draft_payload(*, draft_id: int, recipient: str, body: str,
 
 def emit_draft_task(*, draft_id: int, recipient: str, body: str,
                     mentions: list | None = None,
+                    author_names: dict | None = None,
                     timeout: float = 10.0) -> bool:
     """Post one clawgate Task card for a pending draft. True if posted.
 
@@ -86,7 +94,8 @@ def emit_draft_task(*, draft_id: int, recipient: str, body: str,
     import requests
 
     payload = build_draft_payload(draft_id=draft_id, recipient=recipient,
-                                  body=body, mentions=mentions)
+                                  body=body, mentions=mentions,
+                                  author_names=author_names)
     resp = requests.post(
         ENDPOINT,
         headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},

--- a/scripts/signal/clawgate.py
+++ b/scripts/signal/clawgate.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import os
 
+import _mentions
+
 ENDPOINT = "http://192.168.50.250:30302/api/tasks"
 
 # clawgate renders `directory` as the card title; trim to a sane label length.
@@ -28,11 +30,19 @@ TITLE_MAX = 120
 BODY_PREVIEW_MAX = 800
 
 
-def build_draft_payload(*, draft_id: int, recipient: str, body: str) -> dict:
+def build_draft_payload(*, draft_id: int, recipient: str, body: str,
+                        mentions: list | None = None) -> dict:
     """Build the `POST /api/tasks` JSON body for one pending Signal draft.
 
-    Pure + side-effect-free so it can be asserted in a unit test. Carries the
-    approval command the operator runs, so the card is actionable on its own.
+    Pure + side-effect-free so it can be asserted in a unit test.
+
+    🔴 THE CARD MUST NAME WHO GETS PINGED. A mention is not visible in the body
+    preview as anything but the plain text `@Ann` — which the operator's eye
+    reads as ordinary prose, because that is exactly what it is until the
+    `mentions` array turns it into a notification that bypasses the recipient's
+    mute settings and names them to the whole group. Approving a message without
+    seeing who it notifies is the failure mode this line exists to close, so the
+    resolved `author` ids go on the card explicitly, above the body.
     """
     preview = (body or "").strip()
     if len(preview) > BODY_PREVIEW_MAX:
@@ -43,8 +53,13 @@ def build_draft_payload(*, draft_id: int, recipient: str, body: str) -> dict:
     # is to tell a HUMAN a draft is waiting; approval is an operator step run
     # from an operator shell (it needs `SIGNAL_APPROVAL_TOKEN`, which no agent
     # environment carries).
-    lines = [
-        f"To: {recipient}",
+    lines = [f"To: {recipient}"]
+    if mentions:
+        lines.append(f"⚠ PINGS {len(mentions)} member(s) — this notifies them "
+                     f"THROUGH their mute settings:")
+        for who in _mentions.describe_mentions(mentions):
+            lines.append(f"  · {who}")
+    lines += [
         "",
         preview,
         "",
@@ -58,6 +73,7 @@ def build_draft_payload(*, draft_id: int, recipient: str, body: str) -> dict:
 
 
 def emit_draft_task(*, draft_id: int, recipient: str, body: str,
+                    mentions: list | None = None,
                     timeout: float = 10.0) -> bool:
     """Post one clawgate Task card for a pending draft. True if posted.
 
@@ -69,7 +85,8 @@ def emit_draft_task(*, draft_id: int, recipient: str, body: str,
         return False
     import requests
 
-    payload = build_draft_payload(draft_id=draft_id, recipient=recipient, body=body)
+    payload = build_draft_payload(draft_id=draft_id, recipient=recipient,
+                                  body=body, mentions=mentions)
     resp = requests.post(
         ENDPOINT,
         headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},

--- a/scripts/signal/consumer.py
+++ b/scripts/signal/consumer.py
@@ -1156,9 +1156,18 @@ def mention_author_names(db, mentions) -> dict:
     """`{author: display name}` for a resolved mentions array. For the CARD.
 
     The card's job is to tell a HUMAN who a draft will ping, and `author` is
-    usually a bare uuid. Looked up through the same `contacts_by_identifiers`
-    the resolver used, so the name on the card and the name the resolver matched
-    come from one query.
+    usually a bare uuid.
+
+    🔴 A SECOND QUERY, NOT THE RESOLVER'S. It goes through the same
+    `contacts_by_identifiers` METHOD, but with a different identifier list — the
+    resolved `author` ids, not the group's full membership — so it is a separate
+    round trip against a table that ordinary ingest is writing to concurrently.
+    The docstring used to claim the two "come from one query"; they do not, and
+    a promotion landing in between can legitimately make the card print a name
+    the resolver did not see. That is a display-time difference only: the
+    `author` on the wire is the one the resolver returned, and it is what the
+    approval digest binds. Named rather than papered over, because a reader who
+    believed "one query" would treat a disagreement as impossible.
     """
     if not mentions:
         return {}

--- a/scripts/signal/consumer.py
+++ b/scripts/signal/consumer.py
@@ -1115,11 +1115,55 @@ def resolve_draft_mentions(db, *, recipient: str, body: str, identifiers,
         # built out of a phone number.
         return _mentions.resolve_mentions(identifiers, body=body, members=[],
                                           contacts=[], is_group=False)
+    # 🔴 REFUSED HERE, NOT AS A 404. An empty `--from-number` builds
+    # `/v1/groups//<gid>`, which the server answers 404 — and the 404 escaped
+    # `resp.raise_for_status()` as an `HTTPError`, which is NOT a `ValueError`,
+    # so `main()`'s draft handler did not catch it and the operator got a
+    # traceback and exit 1 for a missing argument.
+    if not str(number or "").strip():
+        raise _mentions.MentionGroupLookupFailed(
+            "mentions need the SENDING account number to look the group's "
+            "membership up (`GET /v1/groups/<number>/<id>`), and --from-number "
+            "is empty. Pass --from-number, or set $SIGNAL_ACCOUNT.")
     fetch = member_fetcher or fetch_group_members
-    members = fetch(number, recipient)
+    try:
+        members = fetch(number, recipient)
+    except (_mentions.MentionError, AssertionError):
+        # `MentionError` is already the right shape. `AssertionError` is
+        # re-raised because the suite's "this must never be called" fetchers
+        # raise it: swallowing one would turn a guard that FIRED into a
+        # `MentionGroupLookupFailed` the surrounding test happily accepts —
+        # green for exactly the wrong reason.
+        raise
+    except Exception as exc:  # noqa: BLE001 - deliberately wide; see below
+        # 🔴 ANY failure of the membership lookup is a REFUSAL, in the type the
+        # `draft` handler catches. The transport raises `requests` exceptions,
+        # the JSON decode raises its own, and neither is a `ValueError` — so
+        # every one of them reached the operator as a traceback. Re-raised with
+        # the original type NAMED and chained, so nothing is hidden.
+        raise _mentions.MentionGroupLookupFailed(
+            f"could not read the target group's membership from "
+            f"`GET /v1/groups/<number>/<id>` ({type(exc).__name__}: {exc}), so no "
+            f"--mention can be resolved. Nothing was drafted. Check "
+            f"--from-number and that --to is the group `id`, not its "
+            f"`internal_id`.") from exc
     contacts = db.contacts_by_identifiers(members)
     return _mentions.resolve_mentions(identifiers, body=body, members=members,
                                       contacts=contacts, is_group=True)
+
+
+def mention_author_names(db, mentions) -> dict:
+    """`{author: display name}` for a resolved mentions array. For the CARD.
+
+    The card's job is to tell a HUMAN who a draft will ping, and `author` is
+    usually a bare uuid. Looked up through the same `contacts_by_identifiers`
+    the resolver used, so the name on the card and the name the resolver matched
+    come from one query.
+    """
+    if not mentions:
+        return {}
+    authors = [str(m.get("author")) for m in mentions if m.get("author")]
+    return _mentions.author_names(mentions, db.contacts_by_identifiers(authors))
 
 
 def http_attachment_fetcher(api_url: str | None = None, timeout: float = 30.0):
@@ -1296,6 +1340,13 @@ def build_parser() -> argparse.ArgumentParser:
     a.add_argument("draft_id", type=int)
     a.add_argument("--ref", required=True, help="the clawgate approval reference")
 
+    ua = sub.add_parser(
+        "unapprove",
+        help="withdraw an approval: approved -> pending, so it can be approved "
+             "again (the ONLY route out of a digest refusal)")
+    ua.add_argument("draft_id", type=int)
+    ua.add_argument("--note", help="why, recorded on the row's approval_ref")
+
     sd = sub.add_parser("send", help="transmit an APPROVED draft (gated)")
     sd.add_argument("draft_id", type=int)
 
@@ -1466,13 +1517,29 @@ def main(argv=None) -> int:  # pragma: no cover - thin CLI shell over tested uni
                 return 3
             clawgate.emit_draft_task(
                 draft_id=draft["id"], recipient=args.to, body=args.body,
-                mentions=mentions)
+                mentions=mentions,
+                author_names=mention_author_names(db, mentions))
             print(json.dumps(draft))
         elif args.cmd == "drafts":
             print(json.dumps(db.list_drafts(state=args.state), default=str))
         elif args.cmd == "approve":
-            print(json.dumps(db.approve_draft(args.draft_id, approval_ref=args.ref),
-                             default=str))
+            try:
+                print(json.dumps(db.approve_draft(args.draft_id,
+                                                  approval_ref=args.ref),
+                                 default=str))
+            except SendGateError as exc:
+                # Exit 3 like every sibling refusal. `approve` alone let a
+                # missing token / wrong-state refusal escape as a traceback.
+                print(f"refused: {exc}", file=sys.stderr)
+                return 3
+        elif args.cmd == "unapprove":
+            try:
+                print(json.dumps(db.unapprove_draft(args.draft_id,
+                                                    note=args.note),
+                                 default=str))
+            except SendGateError as exc:
+                print(f"refused: {exc}", file=sys.stderr)
+                return 3
         elif args.cmd == "send":
             try:
                 print(json.dumps(db.send_approved(args.draft_id), default=str))

--- a/scripts/signal/consumer.py
+++ b/scripts/signal/consumer.py
@@ -43,11 +43,15 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+# Aliased: `_base_message()` binds a LOCAL named `quote` (the envelope's reply
+# quote), and an unaliased import would read as that in every other function.
+from urllib.parse import quote as _urlquote
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import psycopg2  # noqa: E402  (real class objects for the retry classifier)
 
+import _mentions  # noqa: E402
 import _signal_db  # noqa: E402
 from _signal_db import (  # noqa: E402
     RECONCILE_NOT_SENT,
@@ -91,6 +95,12 @@ ACCOUNT = os.environ.get("SIGNAL_ACCOUNT", "")
 RECEIVE_PATH = "/v1/receive"
 ATTACHMENT_PATH = "/v1/attachments"
 SEND_PATH = "/v2/send"
+# 🔴 A READ. `GET /v1/groups/<account>/<group-id>` returns the group's detail,
+# including `members[]` — which arrives MIXED: some entries are E.164, some are
+# bare UUIDs (measured against the deployed signal-cli-rest-api for the 7-member
+# 'Vetr app group': 5 of 7 were uuid-only). Anything joining that list against
+# `signal.contacts` must therefore try BOTH columns; see `_mentions._contact_ids`.
+GROUPS_PATH = "/v1/groups"
 
 # --------------------------------------------------------------------------- #
 # The event kinds this consumer emits. tests/test_skill_doc.py DERIVES this list
@@ -987,14 +997,20 @@ def conversation_key(msg: dict) -> str:
 # The send path — the ONLY route to the Signal send endpoint (D3)
 # --------------------------------------------------------------------------- #
 def transmit_approved(auth, *, recipient: str, body: str, number: str,
+                      mentions: list | None = None,
                       poster=None, api_url: str | None = None,
                       timeout: float = 20.0) -> dict | list:
     """POST an approved draft to the Signal API. Requires a `SendAuthorization`.
 
     🔴 `spend_authorization()` runs BEFORE anything touches the network, and it
-    raises `SendGateError` for a non-capability, a forged look-alike, or a
-    capability that has already been spent. There is no keyword that skips it and
-    no other send-endpoint call site in `scripts/signal/`.
+    raises `SendGateError` for a non-capability, a forged look-alike, a
+    capability that has already been spent, OR a payload that is not the one the
+    capability was minted for. There is no keyword that skips it and no other
+    send-endpoint call site in `scripts/signal/`.
+
+    `mentions` is the wire array (`[{"author","start","length"}, …]`) and is part
+    of what the capability binds, so it cannot be added, removed or re-pointed
+    between approval and this call.
 
     `number` is the SENDING account and is REQUIRED by the server: upstream
     `SendV2` rejects an empty one with 400 `"Couldn't process request - please
@@ -1007,19 +1023,103 @@ def transmit_approved(auth, *, recipient: str, body: str, number: str,
     locally generated one would not dedupe). Upstream types that field as a
     STRING (`ds.SendMessageResponse.Timestamp string`), so the caller coerces.
     """
-    spend_authorization(auth)
+    spend_authorization(auth, recipient=recipient, body=body, mentions=mentions)
     if not number:
         raise SendGateError(
             "transmit refused: no sending `number` — the server would reject this "
             "with 400 'please provide a valid number' (D3 approval gate)")
     url = (api_url or API_URL).rstrip("/") + SEND_PATH
     payload = {"message": body, "number": number, "recipients": [recipient]}
+    # 🔴 OMITTED, not sent empty, when there are no mentions. Upstream's
+    # `SendMessageV2` unmarshals `mentions` into `[]data.MessageMention`; a
+    # mention-free send has never carried the key and does not start now, so the
+    # request byte-for-byte matches the one this path has been making all along.
+    # Each entry is rebuilt with EXACTLY the three keys the server's struct has
+    # — a fourth would be dropped silently, and a stray key from a stored row is
+    # not something to discover on the wire.
+    if mentions:
+        payload["mentions"] = [
+            {"author": str(m["author"]), "start": int(m["start"]),
+             "length": int(m["length"])}
+            for m in mentions
+        ]
     if poster is None:  # pragma: no cover - the live path; tests inject a poster
         import requests
         poster = requests.post
     resp = poster(url, json=payload, timeout=timeout)
     resp.raise_for_status()
     return resp.json()
+
+
+def fetch_group_members(number: str, group_address: str, *, getter=None,
+                        api_url: str | None = None,
+                        timeout: float = 20.0) -> list:
+    """`GET /v1/groups/<number>/<group-id>` → the group's `members[]`.
+
+    Read-only, and the ONLY reason this function exists is mention resolution: a
+    display name is meaningless without the membership to resolve it against,
+    and resolving against the whole `signal.contacts` table would let a name that
+    matches somebody in a DIFFERENT conversation become an `author` here.
+
+    Returns the raw list — a MIX of E.164 strings and bare UUID strings. It is
+    deliberately not normalised: `_mentions` owns that, so there is one place
+    that decides what a member identifier means.
+
+    A member entry may also be an OBJECT (`{"number": …, "uuid": …}`) depending
+    on the upstream version; both shapes are flattened rather than assumed, for
+    the same reason `_normalize_send_response` accepts two reply shapes — a
+    surprise here would otherwise read as "this group has no members", which is
+    a REFUSAL in `_mentions.resolve_mentions` and not a silent empty array.
+    """
+    if getter is None:  # pragma: no cover - the live path; tests inject a getter
+        import requests
+        getter = requests.get
+    url = "{}{}/{}/{}".format((api_url or API_URL).rstrip("/"), GROUPS_PATH,
+                              _urlquote(number, safe=""),
+                              _urlquote(group_address, safe=""))
+    resp = getter(url, timeout=timeout)
+    resp.raise_for_status()
+    detail = resp.json()
+    if isinstance(detail, list):  # some versions return a single-element list
+        detail = detail[0] if detail else {}
+    out = []
+    for member in (detail or {}).get("members") or []:
+        if isinstance(member, dict):
+            ident = member.get("uuid") or member.get("number")
+        else:
+            ident = member
+        if ident:
+            out.append(str(ident))
+    return out
+
+
+def resolve_draft_mentions(db, *, recipient: str, body: str, identifiers,
+                           number: str, member_fetcher=None) -> list:
+    """`--mention` values → the wire mentions array for one draft, or raise.
+
+    The seam between the three pieces, and the reason it is a named function
+    rather than four lines inside `main()`: a test can drive it with an injected
+    `member_fetcher` and the hermetic DB, which is the only way the refusal
+    matrix is reachable without a network.
+
+    Returns `[]` immediately when nothing was asked for — so the no-mention path
+    makes NO group API call at all, and `draft --to +15550100` keeps working with
+    no membership lookup and no behaviour change.
+    """
+    if not identifiers:
+        return []
+    is_group = _signal_db._looks_like_group_address(recipient)
+    if not is_group:
+        # Refuse WITHOUT a membership fetch: there is no group to fetch, and the
+        # error must name the real problem rather than an HTTP 404 from a URL
+        # built out of a phone number.
+        return _mentions.resolve_mentions(identifiers, body=body, members=[],
+                                          contacts=[], is_group=False)
+    fetch = member_fetcher or fetch_group_members
+    members = fetch(number, recipient)
+    contacts = db.contacts_by_identifiers(members)
+    return _mentions.resolve_mentions(identifiers, body=body, members=members,
+                                      contacts=contacts, is_group=True)
 
 
 def http_attachment_fetcher(api_url: str | None = None, timeout: float = 30.0):
@@ -1176,6 +1276,17 @@ def build_parser() -> argparse.ArgumentParser:
     d.add_argument("--body", required=True)
     d.add_argument("--from-number", default=ACCOUNT,
                    help="the sending account (default $SIGNAL_ACCOUNT)")
+    d.add_argument("--mention", action="append", default=[], metavar="WHO",
+                   help="ping a GROUP member. Repeatable. WHO is the member's "
+                        "display name, or their bare uuid / +E.164. --body MUST "
+                        "already contain the literal text `@WHO` — a Signal "
+                        "mention REPLACES an existing span of the message, so "
+                        "the span has to exist. Anything that cannot be resolved "
+                        "to exactly one real member of THIS group is REFUSED "
+                        "(exit 3), never dropped: a mention pushes a "
+                        "notification through the recipient's mute settings, so "
+                        "silently sending fewer than you asked for is a "
+                        "different act from the one you approved")
 
     ls = sub.add_parser("drafts", help="list drafts and their send_state")
     ls.add_argument("--state", choices=[STATE_PENDING, STATE_APPROVED,
@@ -1334,9 +1445,17 @@ def main(argv=None) -> int:  # pragma: no cover - thin CLI shell over tested uni
         elif args.cmd == "draft":
             import clawgate
             try:
+                # 🔴 RESOLVED BEFORE THE ROW IS WRITTEN. Every mention refusal is
+                # a `ValueError` subclass and lands in the handler below, so a
+                # bad --mention leaves NO draft behind — an operator who fixes
+                # the name and re-runs gets one draft, not two, and the clawgate
+                # queue never shows a card for a message that cannot be sent.
+                mentions = resolve_draft_mentions(
+                    db, recipient=args.to, body=args.body,
+                    identifiers=args.mention, number=args.from_number)
                 draft = db.draft_message(
                     recipient=args.to, body=args.body,
-                    self_number=args.from_number)
+                    self_number=args.from_number, mentions=mentions)
             except ValueError as exc:
                 # 🔴 EXIT 3, like every sibling. `mute` catches ValueError and
                 # `send`/`reconcile` catch SendGateError, both exiting 3; this
@@ -1346,7 +1465,8 @@ def main(argv=None) -> int:  # pragma: no cover - thin CLI shell over tested uni
                 print(f"refused: {exc}", file=sys.stderr)
                 return 3
             clawgate.emit_draft_task(
-                draft_id=draft["id"], recipient=args.to, body=args.body)
+                draft_id=draft["id"], recipient=args.to, body=args.body,
+                mentions=mentions)
             print(json.dumps(draft))
         elif args.cmd == "drafts":
             print(json.dumps(db.list_drafts(state=args.state), default=str))

--- a/scripts/signal/tests/fakepg.py
+++ b/scripts/signal/tests/fakepg.py
@@ -81,7 +81,21 @@ _FTS_PREDICATE = re.compile(
     r"(\w+)\.search\s+@@\s+websearch_to_tsquery\('english',\s*%s\)", re.IGNORECASE)
 
 
-_IS_DDL = re.compile(r"CREATE\s+(SCHEMA|TABLE|INDEX)\b", re.IGNORECASE)
+_IS_DDL = re.compile(r"(CREATE\s+(SCHEMA|TABLE|INDEX)|ALTER\s+TABLE)\b",
+                     re.IGNORECASE)
+
+# 🔴 `ALTER TABLE signal.x ADD COLUMN IF NOT EXISTS y T` — the MIGRATION shape.
+# sqlite has `ALTER TABLE … ADD COLUMN` but NOT the `IF NOT EXISTS` clause, and
+# re-adding an existing column is a hard error there, so the idempotency that
+# `ensure_schema()` relies on has to be emulated: the substrate checks
+# `PRAGMA table_info` and skips the statement when the column is already
+# present, which is exactly what Postgres does. Emulated rather than dropped, on
+# purpose — dropping it would leave the column missing and make every mentions
+# assertion fail for a substrate reason instead of a code one.
+_ALTER_ADD_COLUMN = re.compile(
+    r"^ALTER\s+TABLE\s+signal\.(\w+)\s+ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+    r"(\w+)\s+(.+?)\s*$",
+    re.IGNORECASE | re.DOTALL)
 
 
 class TranslationError(AssertionError):
@@ -206,6 +220,8 @@ class SqliteCursor:
     def _execute(self, sql, params=None):
         self._conn.executed.append((" ".join(str(sql).split()), params))
         if _IS_DDL.match(str(sql).strip()):
+            if self._maybe_add_column(str(sql).strip()):
+                return
             translated = translate_ddl(sql)
             if translated is None:
                 return                     # no sqlite equivalent; documented above
@@ -214,6 +230,32 @@ class SqliteCursor:
         translated = translate_dml(sql)
         translated, tparams = translate_params(translated, params)
         self._cur.execute(translated, tparams)
+
+    def _maybe_add_column(self, sql: str) -> bool:
+        """Handle an `ADD COLUMN IF NOT EXISTS` migration. True if handled.
+
+        Emulates Postgres's `IF NOT EXISTS` (see `_ALTER_ADD_COLUMN`). Raises on
+        an ALTER shape it does not recognise rather than passing it through —
+        the same rule the rest of this translator follows, because a silently
+        mistranslated migration would make every assertion about the migrated
+        column vacuous.
+        """
+        if not re.match(r"^ALTER\s+TABLE\b", sql, re.IGNORECASE):
+            return False
+        m = _ALTER_ADD_COLUMN.match(" ".join(sql.split()))
+        if not m:
+            raise TranslationError(
+                f"HARNESS BROKEN: an ALTER TABLE the substrate cannot translate "
+                f"reached sqlite:\n{sql}")
+        table, column, coltype = m.group(1), m.group(2), m.group(3)
+        existing = {r[1] for r in
+                    self._cur.execute(f"PRAGMA signal.table_info({table})").fetchall()}
+        if column in existing:
+            return True                    # Postgres's IF NOT EXISTS, emulated
+        for pattern, repl in _TYPE_MAP:
+            coltype = re.sub(pattern, repl, coltype)
+        self._cur.execute(f"ALTER TABLE signal.{table} ADD COLUMN {column} {coltype}")
+        return True
 
     def _rows(self, rows):
         if not self._dict_rows:

--- a/scripts/signal/tests/mutation_battery.py
+++ b/scripts/signal/tests/mutation_battery.py
@@ -615,6 +615,35 @@ MUTANTS: list[Mutant] = [
            "test_the_name_hint_cap_is_a_LITERAL_five_not_whatever_the_module_says",
            SUITE_MENT),
 
+    Mutant("MEN13", "🔴 [round-5 audit F-A] the GROUP-LEVEL invariant is deleted, "
+                    "leaving only round-4's per-pair `is_placeholder` gate. That gate "
+                    "cannot survive transitivity: the union-find joins PATHS, so with "
+                    "three rows on one number — real A, placeholder P, real C — the "
+                    "direct edge A—C is blocked and A—P—C unions anyway. Two real "
+                    "people are one identity again and `--mention Ann` pings A under "
+                    "a body reading @Ann Smith. This is the shipped 707412e6 "
+                    "behaviour, and the reason the fix is a check on the FORMED "
+                    "GROUP rather than a third revision of the pair condition. MEN10's "
+                    "killer cannot see it — that fixture has only two rows.",
+           MEN,
+           "        if len(members_) > 1:",
+           "        if False:",
+           "test_a_PLACEHOLDER_bridging_TWO_REAL_rows_is_REFUSED_not_guessed",
+           SUITE_MENT),
+
+    Mutant("MEN14", "the group invariant's BOUNDARY moves 1 -> 2, so a group holding "
+                    "exactly two real rows — the whole failure mode — passes while a "
+                    "three-real-row group still refuses. The narrowest expression that "
+                    "can be wrong here, and the one MEN13 cannot distinguish: a guard "
+                    "deleted and a guard off by one look identical from the call site, "
+                    "and only this one proves the threshold is where the harm starts "
+                    "rather than one past it.",
+           MEN,
+           "        if len(members_) > 1:",
+           "        if len(members_) > 2:",
+           "test_a_PLACEHOLDER_bridging_TWO_REAL_rows_is_REFUSED_not_guessed",
+           SUITE_MENT),
+
     Mutant("MEN8", "`utf16_span()` stops forwarding `avoid` — the exported wrapper "
                    "silently implements only the `(?!\\w)` half while its docstring "
                    "promises one matching rule. It has NO production caller, so only "

--- a/scripts/signal/tests/mutation_battery.py
+++ b/scripts/signal/tests/mutation_battery.py
@@ -5,10 +5,11 @@
     python3 scripts/signal/tests/mutation_battery.py --list      # show the ledger
     python3 scripts/signal/tests/mutation_battery.py --only A1 M4
 
-Exit codes: 0 every mutant killed by its named test · 1 at least one SURVIVED,
-ANCHOR-MISSed or was KILLED-WRONG-REASON · 2 refused to start (dirty tree, an
-unreadable `git status`, a red baseline, a named killer that did not run) ·
-3 a mutant was left in the tree, or that could not be determined.
+Exit codes: 0 every mutant reached its EXPECTED verdict · 1 at least one did not
+(SURVIVED, ANCHOR-MISS, KILLED-WRONG-REASON — or, for an `equivalent=True` row,
+KILLED) · 2 refused to start (dirty tree, an unreadable `git status`, a red
+baseline, a named killer that did not run) · 3 a mutant was left in the tree, or
+that could not be determined.
 
 🔴 WHY THIS FILE EXISTS AT ALL. Eight mutation batteries have been run against
 this module across #514, #537, #540, #546 and #573. Every one of them lived in a
@@ -71,11 +72,34 @@ SUITE_LIVE = "scripts/signal/tests/test_liveness.py"
 
 
 class Mutant:
-    """One way to break the code, and the ONE test that must notice."""
+    """One way to break the code, and the ONE test that must notice.
 
-    def __init__(self, mid, why, path, old, new, killer, suite):
+    `equivalent=True` INVERTS the expected verdict: the mutation is argued to be
+    incapable of changing any observable behaviour, so SURVIVED is the pass and
+    KILLED is the finding — it would mean the argument is wrong and the two
+    forms are not interchangeable after all.
+
+    🔴 WHY THESE ARE RECORDED RATHER THAN DELETED. An equivalent mutant is the
+    one row a reader is most likely to re-derive from scratch next round, and
+    the argument for equivalence is usually a premise about the code around it
+    ("`re` folds one code point to one"). Keeping the row keeps the premise
+    checkable: if that premise ever stops holding, this stops SURVIVING and the
+    runner says so. Deleting the row loses both the finding and the reason.
+    🔴 AND IT MUST NOT MAKE THE RUNNER PERMANENTLY RED — a gate that is always
+    failing is one everybody learns to click through, so `equivalent` is what
+    keeps a legitimate survivor out of the failure set instead of parking a
+    known-red row in it.
+    """
+
+    def __init__(self, mid, why, path, old, new, killer, suite, *,
+                 equivalent: bool = False):
         self.id, self.why, self.path = mid, why, path
         self.old, self.new, self.killer, self.suite = old, new, killer, suite
+        self.equivalent = equivalent
+
+    @property
+    def expected(self) -> str:
+        return "SURVIVED" if self.equivalent else "KILLED"
 
 
 MUTANTS: list[Mutant] = [
@@ -498,7 +522,7 @@ MUTANTS: list[Mutant] = [
            "        return match is not None and match.end() == len(text)",
            "        return match is not None",
            "test_the_cursor_DOES_merge_two_needles_the_MATCHER_treats_as_ONE",
-           SUITE_MENT),
+           SUITE_MENT, equivalent=True),
 
     Mutant("MEN4", "the cursor stops ADVANCING past the match it just claimed. Every "
                    "repeat of one needle then re-claims the first occurrence, which "
@@ -655,7 +679,8 @@ def main(argv=None) -> int:
     if args.list:
         for m, n in anchor_report():
             flag = "" if n == 1 else f"  🔴 ANCHOR MATCHES {n}x"
-            print(f"{m.id:4} {m.path:30} -> {m.killer}{flag}\n     {m.why}\n")
+            tag = "  [EQUIVALENT — expected to SURVIVE]" if m.equivalent else ""
+            print(f"{m.id:4} {m.path:30} -> {m.killer}{flag}{tag}\n     {m.why}\n")
         return 0
 
     # 🔴 A SIGTERM used to leave a mutant in the tree. `finally` covers exceptions
@@ -741,10 +766,19 @@ def main(argv=None) -> int:
     print("\n================ SUMMARY ================")
     for m, verdict, detail in results:
         print(f"  {verdict:20} {m.id}  {m.killer}")
-    bad = [r for r in results if r[1] != "KILLED"]
-    print(f"\n{len(results) - len(bad)}/{len(results)} killed by their NAMED test")
+    # 🔴 COMPARED AGAINST EACH MUTANT'S OWN EXPECTED VERDICT, not against the
+    # constant "KILLED": an `equivalent=True` row PASSES by surviving, and FAILS
+    # loudly if something kills it, because that would disprove the equivalence
+    # argument recorded in its `why`.
+    bad = [r for r in results if r[1] != r[0].expected]
+    equiv = [r for r in results if r[0].equivalent]
+    print(f"\n{len(results) - len(bad) - len(equiv)}/{len(results) - len(equiv)} "
+          f"killed by their NAMED test"
+          + (f"  ({len(equiv)} EQUIVALENT, expected to survive)" if equiv else ""))
     for m, verdict, detail in bad:
-        print(f"  !! {verdict}: {m.id} — {detail}", file=sys.stderr)
+        expected = f"expected {m.expected}" if m.equivalent else ""
+        print(f"  !! {verdict}: {m.id} — {detail} {expected}".rstrip(),
+              file=sys.stderr)
 
     rc_git, after = _git_status(REPO)
     if rc_git != 0:

--- a/scripts/signal/tests/mutation_battery.py
+++ b/scripts/signal/tests/mutation_battery.py
@@ -482,13 +482,19 @@ MUTANTS: list[Mutant] = [
            "test_each_MUTE_PROBE_actually_calls_the_method_it_is_keyed_under", SUITE_EXCL),
 
     # ------------------------------------------------------------------ #
-    # MENTIONS (#1121, round-3 delta audit). Every mutant here is a way the
-    # round-3 fixes revert or over-correct. Two shapes recur and both are
+    # MENTIONS (#1121, round-3 and round-4 delta audits). Every mutant here is a
+    # way the fixes revert or over-correct. Two shapes recur and both are
     # represented deliberately: a SECOND matching rule that agrees with the
     # first only on ASCII (MEN1/MEN2), and an identity check that is either
-    # too narrow (MEN5/MEN7) or too wide (MEN6). The fixture pairs are chosen
-    # so ASCII CANNOT SEE the bug — `ß`/`ss` and `İstanbul`/`istanbul` — which
-    # is exactly why the round-2 fix passed its own battery.
+    # too narrow (MEN5/MEN7/MEN11) or too wide (MEN6/MEN10). The fixture pairs
+    # are chosen so ASCII CANNOT SEE the bug — `ß`/`ss` and `İstanbul`/
+    # `istanbul` — which is exactly why the round-2 fix passed its own battery.
+    #
+    # 🔴 MEN10 IS THE ROW TO READ FIRST. Every other mutant here breaks a
+    # REFUSAL; MEN10 is the round-3 fix as shipped, and it SENDS. An identity
+    # rule has two failure directions and only one of them is loud — which is
+    # why the too-narrow and too-wide mutants come in pairs whose killers cannot
+    # see each other's defect.
     # ------------------------------------------------------------------ #
     Mutant("MEN1", "the cursor's equivalence goes back to `casefold()` — a SECOND "
                    "matching rule. Agrees with `re.IGNORECASE` on ASCII and disagrees "
@@ -538,7 +544,7 @@ MUTANTS: list[Mutant] = [
                    "reads as two people and their own longer name vetoes their own "
                    "ping. The shipped round-2 defect, in its narrowest form.",
            MEN,
-           "            if not (_contact_ids(contact) & mine)",
+           "            if _norm_member(_contact_author(contact)) not in mine",
            "            if _contact_author(contact) != author",
            "test_a_person_in_TWO_contact_rows_does_not_veto_their_OWN_ping",
            SUITE_MENT),
@@ -548,7 +554,7 @@ MUTANTS: list[Mutant] = [
                    "cannot see: it passes under this, while round-2's F2 silently "
                    "reopens and `@Ann` lands on `@Ann Smith` again.",
            MEN,
-           "            if not (_contact_ids(contact) & mine)",
+           "            if _norm_member(_contact_author(contact)) not in mine",
            "            if False",
            "test_a_DIFFERENT_persons_longer_name_still_vetoes", SUITE_MENT),
 
@@ -557,9 +563,56 @@ MUTANTS: list[Mutant] = [
                    "builder rather than the lookup — because a union that silently "
                    "stops merging is not visible at the call site at all.",
            MEN,
-           "        for other in ids[1:]:",
-           "        for other in []:",
+           "            if not (row_a.get(\"is_placeholder\") or row_b.get(\"is_placeholder\")):\n"
+           "                continue",
+           "            if True:\n"
+           "                continue",
            "test_a_person_in_TWO_contact_rows_does_not_veto_their_OWN_ping",
+           SUITE_MENT),
+
+    Mutant("MEN10", "🔴 [round-4 audit F-A] the identity union DROPS its "
+                    "`is_placeholder` gate, so any two rows sharing an identifier "
+                    "merge — which is what round-3's own fix shipped. `phone_number` "
+                    "is TEXT with no UNIQUE constraint and `_promote_placeholder()` "
+                    "only touches placeholder rows, so two REAL rows can durably hold "
+                    "one number (number recycling / a number change). Merging them "
+                    "dropped person B's veto and PINGED person A on a body reading "
+                    "@Ann Smith — the first WRONG SEND in four audit rounds, where "
+                    "every other defect here was a refusal. The OPPOSITE "
+                    "over-correction to MEN7, which MEN7's killer cannot see: it "
+                    "passes under this.",
+           MEN,
+           "            if not (row_a.get(\"is_placeholder\") or row_b.get(\"is_placeholder\")):\n"
+           "                continue",
+           "            if False:\n"
+           "                continue",
+           "test_two_REAL_rows_sharing_a_number_are_TWO_people_not_one",
+           SUITE_MENT),
+
+    Mutant("MEN11", "🔴 [round-4 audit F-B] `_resolve_one()` de-duplicates by the "
+                    "ROW's author string again instead of by identity — the second "
+                    "site of the predicate `_identity_groups()` owns. One person "
+                    "holding a real row and a durable placeholder row is then refused "
+                    "as an AMBIGUITY, and the remedy the message prints is half wrong: "
+                    "one of the two ids is the synthetic placeholder uuid, which is "
+                    "not in `member_set`, so following the advice hits "
+                    "MentionNotAMember.",
+           MEN,
+           "        group = identity.get(key) or frozenset({key})",
+           "        group = frozenset({key})",
+           "test_one_person_with_a_real_AND_a_placeholder_row_is_NOT_ambiguous",
+           SUITE_MENT),
+
+    Mutant("MEN12", "`NAME_HINT_MAX` shrinks 5 -> 4. Found SURVIVING all 908 tests by "
+                    "the round-4 audit (F-C): the only assertion on the truncation "
+                    "derived its expectation from `_mentions.NAME_HINT_MAX` itself, so "
+                    "it agreed with any value. A cap on how much of a group roster a "
+                    "token-free `draft` refusal will enumerate is a privacy constant; "
+                    "an uncovered one drifts in the other direction just as quietly.",
+           MEN,
+           "NAME_HINT_MAX = 5",
+           "NAME_HINT_MAX = 4",
+           "test_the_name_hint_cap_is_a_LITERAL_five_not_whatever_the_module_says",
            SUITE_MENT),
 
     Mutant("MEN8", "`utf16_span()` stops forwarding `avoid` — the exported wrapper "
@@ -650,6 +703,30 @@ def _verdict(rc: int, failures: set[str], killer: str) -> tuple[str, str]:
     if killer in failures:
         return "KILLED", f"by {killer} (+{len(failures) - 1} other)"
     return "KILLED-WRONG-REASON", f"expected {killer}, got {sorted(failures)}"
+
+
+def headline(results) -> str:
+    """The `N/M killed` line. PURE — extracted so it is table-testable.
+
+    🔴 IT USED TO DOUBLE-SUBTRACT (round-4 audit F-D). The count was
+    `len(results) - len(bad) - len(equiv)`, and a row that is BOTH `equivalent`
+    AND bad — an "equivalent" mutant that got KILLED, i.e. precisely the finding
+    the flag exists to surface — was charged to both subtrahends. Observed live
+    as `-1/0 killed`. The exit code and the `!!` lines were correct throughout;
+    only the number a reader scans FIRST was wrong, which is the worst place for
+    one, because a negative headline reads as a glitch in the tool rather than
+    as a finding about the ledger.
+
+    Counted, not subtracted: the numerator is the real mutants that met their
+    expectation, the denominator the real mutants. Equivalent rows are reported
+    separately and never enter either.
+    """
+    real = [r for r in results if not r[0].equivalent]
+    equiv = [r for r in results if r[0].equivalent]
+    killed = [r for r in real if r[1] == r[0].expected]
+    return (f"{len(killed)}/{len(real)} killed by their NAMED test"
+            + (f"  ({len(equiv)} EQUIVALENT, expected to survive)"
+               if equiv else ""))
 
 
 def _git_status(repo: Path) -> tuple[int, str]:
@@ -772,9 +849,7 @@ def main(argv=None) -> int:
     # argument recorded in its `why`.
     bad = [r for r in results if r[1] != r[0].expected]
     equiv = [r for r in results if r[0].equivalent]
-    print(f"\n{len(results) - len(bad) - len(equiv)}/{len(results) - len(equiv)} "
-          f"killed by their NAMED test"
-          + (f"  ({len(equiv)} EQUIVALENT, expected to survive)" if equiv else ""))
+    print("\n" + headline(results))
     for m, verdict, detail in bad:
         expected = f"expected {m.expected}" if m.equivalent else ""
         print(f"  !! {verdict}: {m.id} — {detail} {expected}".rstrip(),

--- a/scripts/signal/tests/mutation_battery.py
+++ b/scripts/signal/tests/mutation_battery.py
@@ -261,7 +261,7 @@ MUTANTS: list[Mutant] = [
     # ------------------------------------------------------------------ #
     Mutant("B1", "`build-push.sh`'s subcommand pin left stale — the control that refuses "
                  "to push an image whose CLI grew a subcommand nobody decided on", BP,
-           'want_choices="approve conversations draft drafts health mute muted reconcile run search send unmute "',
+           'want_choices="approve conversations draft drafts health mute muted reconcile run search send unapprove unmute "',
            'want_choices="approve conversations draft drafts health reconcile run search send "',
            "test_the_build_control_lists_EXACTLY_the_CLI_subcommands", SUITE_IMAGE),
 

--- a/scripts/signal/tests/mutation_battery.py
+++ b/scripts/signal/tests/mutation_battery.py
@@ -634,14 +634,88 @@ MUTANTS: list[Mutant] = [
     Mutant("MEN14", "the group invariant's BOUNDARY moves 1 -> 2, so a group holding "
                     "exactly two real rows — the whole failure mode — passes while a "
                     "three-real-row group still refuses. The narrowest expression that "
-                    "can be wrong here, and the one MEN13 cannot distinguish: a guard "
-                    "deleted and a guard off by one look identical from the call site, "
-                    "and only this one proves the threshold is where the harm starts "
-                    "rather than one past it.",
+                    "can be wrong here, and worth keeping because it pins WHERE the "
+                    "threshold sits rather than merely that a threshold exists. "
+                    "🔴 [round-6 audit] THE LEDGER CLAIM THAT EACH OF MEN13/MEN14 IS "
+                    "'killed by a test the other is not' WAS FALSE, and is retracted: "
+                    "both are killed by the same two tests "
+                    "(`..._bridging_TWO_REAL_rows_is_REFUSED_not_guessed` and "
+                    "`..._survives_a_mention_typed_as_a_BARE_UUID`), and no test can "
+                    "ever separate them in that direction. MEN14 refuses on a strict "
+                    "SUBSET of the states MEN13 refuses on, so its killer set is a "
+                    "strict subset of MEN13's: any test that sees MEN14 sees a missing "
+                    "refusal at exactly two real rows, which MEN13 also misses. The "
+                    "mutants are ORDERED, not independent. Only the other direction is "
+                    "reachable — a THREE-real-row fixture would kill MEN13 and be "
+                    "survived by MEN14 — and this suite has none, so as of this round "
+                    "MEN14 is strictly redundant with MEN13 and is retained for the "
+                    "boundary it documents, not for coverage it adds.",
            MEN,
            "        if len(members_) > 1:",
            "        if len(members_) > 2:",
            "test_a_PLACEHOLDER_bridging_TWO_REAL_rows_is_REFUSED_not_guessed",
+           SUITE_MENT),
+
+    Mutant("MEN15", "🔴 [round-6 audit F-1] the refusal goes back to covering the "
+                    "WHOLE CALL: `_refuse_if_polluted()` ignores the mention's own "
+                    "match set and raises whenever ANY group is polluted. That is the "
+                    "shipped 69e910ac behaviour, and it is wrong in the direction "
+                    "nobody was watching — a refusal, not a send, so every wrong-send "
+                    "test stays green. `_colliding_needles()` reads identity for "
+                    "exactly one thing, `mine = identity.get(key)`, the mention "
+                    "TARGET'S OWN group; an uninvolved member's group is untouched by "
+                    "somebody else's merge and both polluted names are in their veto "
+                    "list either way. One stale placeholder row then bricked every "
+                    "mention in the group for every member, with no CLI route to find "
+                    "or delete the row. MEN13/MEN14's killers cannot see this: they "
+                    "assert a refusal, and this mutant refuses MORE.",
+           MEN,
+           "        hit = polluted.get(_norm_member(_contact_author(row)))\n"
+           "        if hit:",
+           "        hit = next(iter(polluted.values()))\n"
+           "        if hit:",
+           "test_an_UNRELATED_member_still_resolves_while_ANOTHER_group_is_polluted",
+           SUITE_MENT),
+
+    Mutant("MEN16", "the narrowed check goes BLIND instead of wide — "
+                    "`_refuse_if_polluted()` never raises, so the group-level "
+                    "invariant is detected and then discarded. The opposite "
+                    "over-correction to MEN15, which MEN15's killer cannot see (it "
+                    "passes under this), and the one that reopens round 5's wrong "
+                    "send. Detection and refusal are now two sites, so this proves "
+                    "the second one is load-bearing on its own.",
+           MEN,
+           "        hit = polluted.get(_norm_member(_contact_author(row)))\n"
+           "        if hit:",
+           "        hit = polluted.get(_norm_member(_contact_author(row)))\n"
+           "        if False:",
+           "test_a_PLACEHOLDER_bridging_TWO_REAL_rows_is_REFUSED_not_guessed",
+           SUITE_MENT),
+
+    Mutant("MEN17", "the refusal message counts the ROWS while listing the "
+                    "DE-DUPLICATED authors again — round-6 F-1's second defect, which "
+                    "printed `2 DIFFERENT real identities (['Ann'])` for two real rows "
+                    "carrying one author string: a count and a list that contradict "
+                    "each other in the one message the operator has to act on. Every "
+                    "refusal test still passes under it, because they assert the CLASS "
+                    "and not the text.",
+           MEN,
+           "        f\"{len(shown)} distinct real identities ({shown!r}\"",
+           "        f\"{len(real_rows)} distinct real identities ({shown!r}\"",
+           "test_the_unresolvable_refusal_COUNTS_and_LISTS_the_same_identities",
+           SUITE_MENT),
+
+    Mutant("MEN18", "the refusal stops naming the SHARED IDENTIFIER the bridging "
+                    "placeholder was minted for. It still says 'remove the stale "
+                    "placeholder contact row' — and `consumer.py` exposes no contacts "
+                    "subcommand, so the operator's only route is Postgres and this is "
+                    "the only value they could have selected on. An unactionable "
+                    "refusal is a permanent one.",
+           MEN,
+           "    bridges = sorted({i for row in group_rows if row.get(\"is_placeholder\")\n"
+           "                      for i in (_contact_ids(row) & real_ids)})",
+           "    bridges = []",
+           "test_the_unresolvable_refusal_COUNTS_and_LISTS_the_same_identities",
            SUITE_MENT),
 
     Mutant("MEN8", "`utf16_span()` stops forwarding `avoid` — the exported wrapper "

--- a/scripts/signal/tests/mutation_battery.py
+++ b/scripts/signal/tests/mutation_battery.py
@@ -60,7 +60,12 @@ DB = "scripts/signal/_signal_db.py"
 CON = "scripts/signal/consumer.py"
 BP = "scripts/signal/build-push.sh"
 
+MEN = "scripts/signal/_mentions.py"
+SKILL = "claude/skills/signal/SKILL.md"
+
 SUITE_EXCL = "scripts/signal/tests/test_group_exclusions.py"
+SUITE_MENT = "scripts/signal/tests/test_mentions.py"
+SUITE_SKILL = "scripts/signal/tests/test_skill_doc.py"
 SUITE_IMAGE = "scripts/signal/tests/test_image_deps.py"
 SUITE_LIVE = "scripts/signal/tests/test_liveness.py"
 
@@ -451,6 +456,125 @@ MUTANTS: list[Mutant] = [
            "            return recording",
            "            return attr",
            "test_each_MUTE_PROBE_actually_calls_the_method_it_is_keyed_under", SUITE_EXCL),
+
+    # ------------------------------------------------------------------ #
+    # MENTIONS (#1121, round-3 delta audit). Every mutant here is a way the
+    # round-3 fixes revert or over-correct. Two shapes recur and both are
+    # represented deliberately: a SECOND matching rule that agrees with the
+    # first only on ASCII (MEN1/MEN2), and an identity check that is either
+    # too narrow (MEN5/MEN7) or too wide (MEN6). The fixture pairs are chosen
+    # so ASCII CANNOT SEE the bug — `ß`/`ss` and `İstanbul`/`istanbul` — which
+    # is exactly why the round-2 fix passed its own battery.
+    # ------------------------------------------------------------------ #
+    Mutant("MEN1", "the cursor's equivalence goes back to `casefold()` — a SECOND "
+                   "matching rule. Agrees with `re.IGNORECASE` on ASCII and disagrees "
+                   "in BOTH directions on unicode, which is how round-2's fix shipped "
+                   "with both arms live.",
+           MEN,
+           "    return _whole(a, b) and _whole(b, a)",
+           "    return a.casefold() == b.casefold()",
+           "test_the_cursor_does_NOT_merge_two_needles_the_MATCHER_keeps_APART",
+           SUITE_MENT),
+
+    Mutant("MEN2", "the equivalence goes RAW — exact string identity. The OPPOSITE "
+                   "over-correction to MEN1: nothing is ever merged, so `@İstanbul` "
+                   "and `@istanbul` both start at 0 and claim the same span. Needed "
+                   "separately because MEN1's killer stays GREEN under this.",
+           MEN,
+           "    return _whole(a, b) and _whole(b, a)",
+           "    return a == b",
+           "test_the_cursor_DOES_merge_two_needles_the_MATCHER_treats_as_ONE",
+           SUITE_MENT),
+
+    Mutant("MEN3", "🔴 EQUIVALENT MUTANT, recorded rather than counted as a kill. "
+                   "`_whole()` drops its end-of-string check. It cannot change any "
+                   "answer: `re.escape` folds one code point to one, so a match "
+                   "consumes exactly `len(pattern)`, and BOTH directions matching "
+                   "already forces the two needles to be the same length. Kept in the "
+                   "ledger so the next round does not re-derive it — and so that if "
+                   "the matcher ever grows a variable-width element, this row turns "
+                   "into a real mutant and its SURVIVED verdict becomes a finding.",
+           MEN,
+           "        return match is not None and match.end() == len(text)",
+           "        return match is not None",
+           "test_the_cursor_DOES_merge_two_needles_the_MATCHER_treats_as_ONE",
+           SUITE_MENT),
+
+    Mutant("MEN4", "the cursor stops ADVANCING past the match it just claimed. Every "
+                   "repeat of one needle then re-claims the first occurrence, which "
+                   "the overlap guard refuses — the round-2 defect by another route.",
+           MEN,
+           "        slot[1] = idx + len(needle)",
+           "        slot[1] = idx",
+           "test_the_ASCII_case_the_round_2_fix_was_written_for_still_works",
+           SUITE_MENT),
+
+    Mutant("MEN5", "the collision rule reverts to comparing RAW author strings, so one "
+                   "person holding a real row AND a durable phone-only placeholder "
+                   "reads as two people and their own longer name vetoes their own "
+                   "ping. The shipped round-2 defect, in its narrowest form.",
+           MEN,
+           "            if not (_contact_ids(contact) & mine)",
+           "            if _contact_author(contact) != author",
+           "test_a_person_in_TWO_contact_rows_does_not_veto_their_OWN_ping",
+           SUITE_MENT),
+
+    Mutant("MEN6", "the identity check goes VETO-BLIND — every other member's longer "
+                   "name is dropped from `avoid`. The over-correction MEN5's killer "
+                   "cannot see: it passes under this, while round-2's F2 silently "
+                   "reopens and `@Ann` lands on `@Ann Smith` again.",
+           MEN,
+           "            if not (_contact_ids(contact) & mine)",
+           "            if False",
+           "test_a_DIFFERENT_persons_longer_name_still_vetoes", SUITE_MENT),
+
+    Mutant("MEN7", "`_identity_groups()` unions NOTHING, so every row is its own "
+                   "person. Same observable as MEN5 from a different SITE — the "
+                   "builder rather than the lookup — because a union that silently "
+                   "stops merging is not visible at the call site at all.",
+           MEN,
+           "        for other in ids[1:]:",
+           "        for other in []:",
+           "test_a_person_in_TWO_contact_rows_does_not_veto_their_OWN_ping",
+           SUITE_MENT),
+
+    Mutant("MEN8", "`utf16_span()` stops forwarding `avoid` — the exported wrapper "
+                   "silently implements only the `(?!\\w)` half while its docstring "
+                   "promises one matching rule. It has NO production caller, so only "
+                   "a direct test can see it; the next caller inherits the gap.",
+           MEN,
+           "    _, start, length = find_span(body, needle, from_index=from_index, avoid=avoid)",
+           "    _, start, length = find_span(body, needle, from_index=from_index)",
+           "test_utf16_span_FORWARDS_avoid_so_it_really_is_one_matching_rule",
+           SUITE_MENT),
+
+    Mutant("MEN9", "🔴 the drain runbook's steps SWAPPED — the SELECT before the "
+                   "deploy, i.e. exactly the unexecutable order the test is named "
+                   "for. Measured: this SURVIVED the pre-round-3 assertion, which "
+                   "indexed `deploy` over the whole section and found it in the "
+                   "explanatory paragraph above the list. The mutant is what proves "
+                   "the surviving ordering guard is REACHABLE now that the walkable "
+                   "phrase assertion beside it is gone.",
+           SKILL,
+           "   1. Deploy, and let the consumer start (that is what runs `ensure_schema()`\n"
+           "      and adds the column).\n"
+           "   2. Find them:\n"
+           "\n"
+           "      ```sql\n"
+           "      SELECT id, send_state, approval_ref FROM signal.messages\n"
+           "       WHERE send_state = 'approved' AND approved_digest IS NULL;\n"
+           "      ```\n",
+           "   1. Find them:\n"
+           "\n"
+           "      ```sql\n"
+           "      SELECT id, send_state, approval_ref FROM signal.messages\n"
+           "       WHERE send_state = 'approved' AND approved_digest IS NULL;\n"
+           "      ```\n"
+           "\n"
+           "   2. Deploy, and let the consumer start (that is what runs `ensure_schema()`\n"
+           "      and adds the column).\n",
+           "test_the_pre_digest_drain_procedure_is_ORDERED_so_it_can_be_RUN",
+           SUITE_SKILL),
 ]
 
 

--- a/scripts/signal/tests/test_approval_gate.py
+++ b/scripts/signal/tests/test_approval_gate.py
@@ -42,6 +42,20 @@ SELF_NUMBER = "+15559090"
 SERVER_TS = 1723500000001
 
 
+def _approved_row(draft_id, recipient, body, mentions=None):
+    """A hand-built APPROVED draft row, digest included.
+
+    🔴 The digest is COMPUTED, never a literal: `_mint_send_authorization()`
+    fails closed on a row whose payload does not hash to what approval recorded,
+    so a fixture that hard-coded one would go stale silently the first time the
+    canonical form changed and every test here would refuse for the wrong reason.
+    """
+    return {"id": draft_id, "send_state": _signal_db.STATE_APPROVED,
+            "recipient": recipient, "body": body, "mentions": mentions or [],
+            "approved_digest": _signal_db.payload_digest(
+                recipient=recipient, body=body, mentions=mentions or [])}
+
+
 class Poster:
     """Records every HTTP post it is asked to make. It must stay EMPTY on refusal."""
 
@@ -153,8 +167,7 @@ def test_minting_refuses_every_non_approved_state():
 def test_minting_positive_control_an_approved_draft_yields_a_capability():
     """The refusals above are about the STATE, not a minter that never mints."""
     auth = _signal_db._mint_send_authorization(
-        {"id": 8, "send_state": _signal_db.STATE_APPROVED, "recipient": PEER,
-         "body": "ok"})
+        _approved_row(8, PEER, "ok"))
     assert isinstance(auth, _signal_db.SendAuthorization)
     assert auth.draft_id == 8
 
@@ -183,8 +196,7 @@ def test_an_approved_draft_transmits_exactly_once(db):
 
 def test_a_spent_capability_cannot_be_replayed():
     auth = _signal_db._mint_send_authorization(
-        {"id": 9, "send_state": _signal_db.STATE_APPROVED, "recipient": PEER,
-         "body": "replay me"})
+        _approved_row(9, PEER, "replay me"))
     poster = Poster()
     consumer.transmit_approved(auth, recipient=PEER, body="replay me",
                                number=SELF_NUMBER, poster=poster)
@@ -420,12 +432,27 @@ def test_every_function_in_the_ledger_spends_a_capability():
 
 
 def test_the_only_send_call_site_is_inside_transmit_approved():
+    """🔴 The gate call, PINNED WHOLE — arguments included, not just the name.
+
+    It used to assert the literal `spend_authorization(auth)`. That was exactly
+    as wide as the capability was: draft identity and nothing about the message.
+    Now that the capability BINDS the payload, a call that passed only `auth`
+    would not compile — but a call that passed `recipient` and `body` and
+    quietly dropped `mentions` WOULD, and it would send an unbound mention array
+    while every other test in this file stayed green. So the whole call is
+    pinned, normalised for line wrapping, rather than its name.
+    """
     src = Path(consumer.__file__).read_text(encoding="utf-8")
     body = src.split("def transmit_approved(")[1].split("\ndef ")[0]
     assert "SEND_PATH" in body
-    assert "spend_authorization(auth)" in body
+    flat = " ".join(body.split())
+    call = ("spend_authorization(auth, recipient=recipient, body=body, "
+            "mentions=mentions)")
+    assert call in flat, (
+        "the gate call is not the pinned one — every component of the payload "
+        "must be passed, or that component is transmitted UNBOUND")
     # The gate runs BEFORE the URL is even built.
-    assert body.index("spend_authorization(auth)") < body.index("SEND_PATH")
+    assert flat.index(call) < flat.index("SEND_PATH")
 
 
 def test_clawgate_module_cannot_transmit():
@@ -451,7 +478,7 @@ def test_a_failure_after_the_post_leaves_the_draft_inert(db):
     db.approve_draft(draft["id"], approval_ref="cg-crash")
     poster = Poster()
 
-    def transmit_then_die(auth, *, recipient, body, number):
+    def transmit_then_die(auth, *, recipient, body, number, mentions=None):
         poster(f"http://x{consumer.SEND_PATH}", json={"message": body})
         raise ConnectionResetError("pod killed between the POST and the write-back")
 
@@ -481,7 +508,7 @@ def test_the_sending_claim_is_committed_before_anything_is_transmitted(db):
     commits_before = db.conn.commits
     seen = {}
 
-    def transmit(auth, *, recipient, body, number):
+    def transmit(auth, *, recipient, body, number, mentions=None):
         seen["state_at_post"] = db.get_draft(draft["id"])["send_state"]
         seen["commits_at_post"] = db.conn.commits
         return {"timestamp": str(SERVER_TS)}
@@ -605,7 +632,7 @@ def test_a_re_entrant_send_of_the_same_draft_is_refused(db):
     sends = []
     second = {}
 
-    def transmit(auth, *, recipient, body, number):
+    def transmit(auth, *, recipient, body, number, mentions=None):
         sends.append(body)
         if "attempted" not in second:
             second["attempted"] = True
@@ -710,7 +737,7 @@ def test_an_in_flight_sender_cannot_stamp_over_an_OPERATORS_reconcile(db):
     operator_ts = 1723900000111
     api_ts = 1723900000999
 
-    def transmit(auth, *, recipient, body, number):
+    def transmit(auth, *, recipient, body, number, mentions=None):
         # While this send is in flight, the operator reconciles it as sent.
         db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_SENT,
                           server_timestamp=str(operator_ts))
@@ -737,7 +764,7 @@ def test_a_not_sent_reconcile_mid_flight_cannot_become_a_SECOND_transmit(db):
     db.approve_draft(draft["id"], approval_ref="cg-midflight")
     poster = Poster()
 
-    def transmit(auth, *, recipient, body, number):
+    def transmit(auth, *, recipient, body, number, mentions=None):
         poster(f"http://x{consumer.SEND_PATH}", json={"message": body})
         db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_NOT_SENT,
                           note="looked empty at the time")
@@ -879,8 +906,7 @@ def test_the_send_body_carries_number_recipients_and_message(db):
 
 def test_transmit_refuses_an_empty_number_rather_than_earning_a_400():
     auth = _signal_db._mint_send_authorization(
-        {"id": 11, "send_state": _signal_db.STATE_APPROVED, "recipient": PEER,
-         "body": "x"})
+        _approved_row(11, PEER, "x"))
     poster = Poster()
     with pytest.raises(SendGateError) as exc:
         consumer.transmit_approved(auth, recipient=PEER, body="x", number="",

--- a/scripts/signal/tests/test_approval_gate.py
+++ b/scripts/signal/tests/test_approval_gate.py
@@ -50,10 +50,15 @@ def _approved_row(draft_id, recipient, body, mentions=None):
     so a fixture that hard-coded one would go stale silently the first time the
     canonical form changed and every test here would refuse for the wrong reason.
     """
-    return {"id": draft_id, "send_state": _signal_db.STATE_APPROVED,
-            "recipient": recipient, "body": body, "mentions": mentions or [],
-            "approved_digest": _signal_db.payload_digest(
-                recipient=recipient, body=body, mentions=mentions or [])}
+    row = {"id": draft_id, "send_state": _signal_db.STATE_APPROVED,
+           "recipient": recipient, "body": body, "mentions": mentions or []}
+    # 🔴 DERIVED FROM THE MODULE, over the WHOLE ROW. The digest now covers a
+    # CANONICAL recipient identity (`recipient_identity()`), not the rendered
+    # `recipient` string — a fixture that recomputed it from `recipient` alone
+    # would encode this test's own idea of the canonical form and stay green
+    # while the two sides disagreed.
+    row["approved_digest"] = _signal_db.draft_payload_digest(row)
+    return row
 
 
 class Poster:

--- a/scripts/signal/tests/test_approval_gate.py
+++ b/scripts/signal/tests/test_approval_gate.py
@@ -867,11 +867,53 @@ def test_reconcile_sent_without_a_note_also_preserves_it(db):
 
 
 def test_a_note_ADDS_to_the_record_rather_than_replacing_it(db):
-    """POSITIVE CONTROL: the preservation above is not "the note is ignored"."""
+    """🔴 RED at 9fb6de75 — it asserted the REPLACEMENT its own name denied.
+
+    Round-2 audit F3, the `reconcile_send` half. `_stranded()` approves with
+    `approval_ref="cg-strand"`, so a passing assertion of
+    `== "checked the thread, nothing there"` was a measurement that the approval
+    reference had been ERASED — `COALESCE(note, approval_ref)` returns the note.
+    The test name claimed the property; the assertion pinned its opposite, and
+    read as coverage while providing none.
+
+    Doubles as the POSITIVE CONTROL for the two preservation tests above: the
+    note is not merely ignored, and both halves of the trail are named here.
+    """
     draft = _stranded(db)
     row = db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_NOT_SENT,
                             note="checked the thread, nothing there")
-    assert row["approval_ref"] == "checked the thread, nothing there"
+    assert row["approval_ref"] == (
+        "cg-strand" + _signal_db.APPROVAL_REF_SEPARATOR
+        + "checked the thread, nothing there")
+
+
+def test_reconcile_SENT_with_a_note_also_appends_rather_than_replacing(db):
+    """🔴 RED at 9fb6de75 (it returned the bare note). Both branches, F3.
+
+    The `--sent` branch carried the identical `COALESCE(%s, approval_ref)`, so
+    recording "it did go out" WITH a note destroyed the approval reference the
+    transmitted message went out under — the worst of the three, because that
+    row is the audit record of a message a third party actually received.
+    """
+    draft = _stranded(db)
+    row = db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_SENT,
+                            server_timestamp="1723900000333",
+                            note="saw it in the thread")
+    assert row["approval_ref"] == (
+        "cg-strand" + _signal_db.APPROVAL_REF_SEPARATOR + "saw it in the thread")
+
+
+def test_an_EMPTY_note_leaves_the_trail_untouched_rather_than_appending_a_separator(db):
+    """A blank `--note` is no note — not a bare separator, and not an erasure.
+
+    `_appended_note()` normalises it to NULL so the `CASE` leaves the column
+    alone. At 9fb6de75 `COALESCE('', approval_ref)` returned `''`, wiping the
+    trail entirely — so this is RED there too, on a different symptom.
+    """
+    draft = _stranded(db)
+    row = db.reconcile_send(draft["id"], outcome=_signal_db.RECONCILE_NOT_SENT,
+                            note="   ")
+    assert row["approval_ref"] == "cg-strand"
 
 
 def test_reconcile_rejects_an_unknown_outcome(db):

--- a/scripts/signal/tests/test_group_exclusions.py
+++ b/scripts/signal/tests/test_group_exclusions.py
@@ -1061,7 +1061,7 @@ def test_send_and_reconcile_work_END_TO_END_on_a_group_draft(db, monkeypatch):
 
     seen = {}
 
-    def fake_transmit(auth, *, recipient, body, number):
+    def fake_transmit(auth, *, recipient, body, number, mentions=None):
         seen.update(recipient=recipient, body=body, number=number,
                     draft_id=auth.draft_id)
         return [{"timestamp": "1787331796630"}]
@@ -1080,7 +1080,7 @@ def test_send_and_reconcile_work_END_TO_END_on_a_group_draft(db, monkeypatch):
                              self_number=SELF_NUMBER)
     db.approve_draft(other["id"], approval_ref="clawgate/2")
 
-    def explode(auth, *, recipient, body, number):
+    def explode(auth, *, recipient, body, number, mentions=None):
         raise RuntimeError("pod killed after the POST")
 
     with pytest.raises(RuntimeError):

--- a/scripts/signal/tests/test_mentions.py
+++ b/scripts/signal/tests/test_mentions.py
@@ -95,10 +95,15 @@ def _approved_row(draft_id, recipient, body, mentions=None):
     so a fixture that hard-coded one would go stale silently the first time the
     canonical form changed and every test here would refuse for the wrong reason.
     """
-    return {"id": draft_id, "send_state": _signal_db.STATE_APPROVED,
-            "recipient": recipient, "body": body, "mentions": mentions or [],
-            "approved_digest": _signal_db.payload_digest(
-                recipient=recipient, body=body, mentions=mentions or [])}
+    row = {"id": draft_id, "send_state": _signal_db.STATE_APPROVED,
+           "recipient": recipient, "body": body, "mentions": mentions or []}
+    # 🔴 DERIVED FROM THE MODULE, over the WHOLE ROW. The digest now covers a
+    # CANONICAL recipient identity (`recipient_identity()`), not the rendered
+    # `recipient` string — a fixture that recomputed it from `recipient` alone
+    # would encode this test's own idea of the canonical form and stay green
+    # while the two sides disagreed.
+    row["approved_digest"] = _signal_db.draft_payload_digest(row)
+    return row
 
 
 class Poster:
@@ -327,12 +332,21 @@ def _group_draft(db, body="@Ann please look", mentions=None):
                             else mentions)
 
 
-def test_ensure_schema_twice_is_a_no_op(db):
-    """🔴 The migration is `ADD COLUMN IF NOT EXISTS` — idempotent, like the rest.
+def test_ensure_schema_twice_is_a_no_op_ON_THE_SQLITE_SUBSTRATE(db):
+    """The migration is idempotent — **as emulated by `fakepg`**, not on Postgres.
 
-    `ensure_schema()` runs on every consumer start. A migration that raised the
-    second time would crash the pod on restart, and the restart is precisely the
-    moment it runs.
+    🔴 RENAMED, BECAUSE THE OLD NAME CLAIMED COVERAGE THIS DOES NOT HAVE. The
+    hermetic substrate is SQLite, which has no `ADD COLUMN IF NOT EXISTS`;
+    `fakepg` *emulates* the clause. So what runs here asserts that the emulation
+    is idempotent, and would stay green against a real-Postgres spelling error
+    the emulation happens to forgive. The real check is
+    `test_pg_type_compat.py::test_ensure_schema_is_idempotent_on_real_postgres`,
+    which executes the shipped DDL against a live server and SKIPS (loudly,
+    rather than passing vacuously) without `SIGNAL_PG_DSN`.
+
+    What this test DOES still cover, and it is worth keeping: `ensure_schema()`
+    runs on every consumer start, and a second call must not raise or destroy the
+    column's contents — the restart is precisely when it runs.
     """
     db.ensure_schema()
     db.ensure_schema()
@@ -608,15 +622,17 @@ def test_re_approving_the_mutated_draft_is_the_documented_way_out(db):
 
 
 def _reapprove(db, draft_id, ref):
-    """Approval is `pending`-only, so re-approving means resetting the state first.
+    """The operator's recovery, through the PUBLIC API only.
 
-    Done through the substrate rather than through `reconcile_send()` because the
-    draft never entered `sending` — the refusal happened before the claim.
+    🔴 THIS USED TO BE `UPDATE signal.messages SET send_state='pending'` — raw
+    SQL against the substrate, which meant this "positive control" exercised a
+    path NO OPERATOR HAD. `approve_draft()` is pending-only, `reconcile_send()`
+    is sending-only, and there was no third subcommand: the state this helper
+    manufactured was unreachable from the CLI, so the test proved the operator
+    was not stuck by doing something the operator could not do. `unapprove_draft`
+    is the real route, and this helper now takes it.
     """
-    with db.conn.cursor() as cur:
-        cur.execute("UPDATE signal.messages SET send_state = %s WHERE id = %s",
-                    (_signal_db.STATE_PENDING, draft_id))
-    db.conn.commit()
+    db.unapprove_draft(draft_id, note=f"withdrawn before {ref}")
     return db.approve_draft(draft_id, approval_ref=ref)
 
 
@@ -870,3 +886,571 @@ def test_a_mention_free_card_says_nothing_about_pings():
                                            body="a plain message")
     assert "PINGS" not in payload["body"]
     assert "mute settings" not in payload["body"]
+
+
+# --------------------------------------------------------------------------- #
+# 8. ROUND-1 AUDIT FIXES — every test below was watched RED at 182c3280
+# --------------------------------------------------------------------------- #
+
+# --- finding 1: a digest refusal was a TERMINAL DEAD END -------------------- #
+def test_a_refused_draft_is_recoverable_THROUGH_THE_CLI_ALONE(db, monkeypatch,
+                                                              capsys):
+    """🔴 THE DEAD END, walked end to end through `consumer.main()` only.
+
+    RED at 182c3280: `main(["unapprove", …])` exited 2 — argparse `invalid
+    choice`, because the subcommand did not exist. `approve` is pending-only and
+    `reconcile` is sending-only, so a draft the digest refused could not be moved
+    by ANY CLI invocation; the refusal text and SKILL.md both told the operator
+    to "re-approve it", which the CLI could not do.
+
+    Driven through `main()` rather than the DB methods on purpose: the finding is
+    about the surface an operator touches, and a test against `unapprove_draft()`
+    alone would pass with the subcommand still unwired.
+    """
+    draft = _group_draft(db, body="@Ann please look")
+    monkeypatch.setattr(consumer, "SignalDB", lambda *a, **k: _NoCloseDB(db))
+    monkeypatch.setattr(clawgate, "emit_draft_task",
+                        lambda **kw: False)
+
+    assert consumer.main(["approve", str(draft["id"]), "--ref", "cg-1"]) == 0
+    _tamper(db, draft["id"], body="@Ann approve the WIRE TRANSFER")
+
+    # `send` refuses, and the row is left `approved` — the dead end's shape.
+    assert consumer.main(["send", str(draft["id"])]) == 3
+    assert db.get_draft(draft["id"])["send_state"] == _signal_db.STATE_APPROVED
+
+    # The route the refusal NAMES, and it exists.
+    assert consumer.main(["unapprove", str(draft["id"]),
+                          "--note", "body changed"]) == 0
+    assert db.get_draft(draft["id"])["send_state"] == _signal_db.STATE_PENDING
+    assert consumer.main(["approve", str(draft["id"]), "--ref", "cg-2"]) == 0
+
+    poster = Poster()
+    sent = db.send_approved(
+        draft["id"],
+        transmit=lambda a, **kw: consumer.transmit_approved(a, poster=poster, **kw))
+    assert sent["send_state"] == _signal_db.STATE_SENT
+    assert poster.calls[0]["json"]["message"] == "@Ann approve the WIRE TRANSFER"
+
+
+class _NoCloseDB:
+    """Hand `main()` the test's live `db` without letting its `with` close it."""
+
+    def __init__(self, db):
+        self._db = db
+
+    def __enter__(self):
+        return self._db
+
+    def __exit__(self, *exc):
+        return False
+
+    def __getattr__(self, name):
+        return getattr(self._db, name)
+
+
+def test_the_refusal_text_NAMES_a_command_the_CLI_really_has(db):
+    """🔴 A guard on the STATE, not on a word: the command named in the error
+    must be a real subparser choice.
+
+    RED at 182c3280: the text said "Re-approve it", and the assertion below —
+    that every backticked command in the refusal is in the parser's own choice
+    set — had nothing to find. This reads the CLI's choices from argparse rather
+    than restating them, so renaming the subcommand fails here.
+    """
+    draft = _group_draft(db)
+    db.approve_draft(draft["id"], approval_ref="cg-text")
+    _tamper(db, draft["id"], body="something else entirely")
+    with pytest.raises(SendGateError) as exc:
+        db.send_approved(draft["id"], transmit=lambda a, **kw: None)
+
+    message = str(exc.value)
+    choices = set(consumer.build_parser()._subparsers._group_actions[0].choices)
+    named = {word.strip("`") for word in message.split()
+             if word.startswith("`")} & choices
+    assert "unapprove" in named, message
+    assert "approve" in message and "SIGNAL_APPROVAL_TOKEN" in message
+
+
+def test_unapprove_needs_the_operator_token_EXACTLY_like_approve(db, monkeypatch):
+    """The recovery route must not be a hole in the gate it recovers from."""
+    draft = _group_draft(db)
+    db.approve_draft(draft["id"], approval_ref="cg-tok")
+    monkeypatch.delenv("SIGNAL_APPROVAL_TOKEN", raising=False)
+    with pytest.raises(SendGateError) as exc:
+        db.unapprove_draft(draft["id"])
+    assert "SIGNAL_APPROVAL_TOKEN" in str(exc.value)
+    assert db.get_draft(draft["id"])["send_state"] == _signal_db.STATE_APPROVED
+
+
+def test_unapprove_CLEARS_the_stale_digest(db):
+    """A pending row carrying an old digest would be checked against a digest
+    the next `approve` did not write."""
+    draft = _group_draft(db)
+    db.approve_draft(draft["id"], approval_ref="cg-clear")
+    assert db.get_draft(draft["id"])["approved_digest"]
+    db.unapprove_draft(draft["id"])
+    assert db.get_draft(draft["id"])["approved_digest"] is None
+
+
+def test_unapprove_refuses_anything_that_is_not_approved(db):
+    """Not a state editor — `sending` belongs to `reconcile`, `pending` to nobody."""
+    draft = _group_draft(db)
+    with pytest.raises(SendGateError) as exc:      # still pending
+        db.unapprove_draft(draft["id"])
+    assert "may be unapproved" in str(exc.value)
+
+    db.approve_draft(draft["id"], approval_ref="cg-state")
+    db._claim_for_sending(draft["id"])             # now `sending`
+    with pytest.raises(SendGateError) as exc:
+        db.unapprove_draft(draft["id"])
+    assert "reconcile" in str(exc.value)
+    assert db.get_draft(draft["id"])["send_state"] == _signal_db.STATE_SENDING
+
+
+def test_unapprove_does_not_erase_the_approval_ref_when_given_no_note(db):
+    """The audit record of the approval the attempt rode on is ADDED to, never
+    replaced — the same COALESCE `reconcile_send` needed."""
+    draft = _group_draft(db)
+    db.approve_draft(draft["id"], approval_ref="clawgate-task-777")
+    db.unapprove_draft(draft["id"])
+    assert db.get_draft(draft["id"])["approval_ref"] == "clawgate-task-777"
+
+
+# --- finding 2: the digest bound a RENDERED PROJECTION ---------------------- #
+def test_a_PLACEHOLDER_PROMOTION_between_approve_and_send_does_NOT_refuse(db):
+    """🔴 THE FIRING-WITH-NO-ATTACKER CASE. Red at 182c3280.
+
+    The ordinary "message someone new" path: draft a DM to a number we have
+    never seen, approve it, and then that person's first envelope arrives.
+    `_promote_placeholder()` — unattended background ingest — gives the contact
+    row its real uuid, and `get_draft()`'s recipient CASE flips from printing the
+    NUMBER to printing the UUID. At 182c3280 the digest was taken over that
+    printed string, so `send` refused with "CHANGED after it was approved" — no
+    adversary, no second writer, and NO CHANGE TO WHO THE MESSAGE GOES TO. With
+    finding 1 unfixed the draft was then bricked.
+
+    The promotion is performed by `upsert_message()`, the real ingest path, not
+    by a hand-written UPDATE: the point is that ROUTINE traffic did this.
+    """
+    stranger = "+15550555"
+    stranger_uuid = "44444444-4444-4444-8444-444444444444"
+    draft = db.draft_message(recipient=stranger, body="hi, this is Zach",
+                             self_number=SELF_NUMBER)
+    contact_id = db.get_draft(draft["id"])["dest_contact_id"]
+    db.approve_draft(draft["id"], approval_ref="cg-promote")
+    assert db.get_draft(draft["id"])["recipient"] == stranger
+
+    # ... their first message arrives, carrying both identifiers.
+    db.upsert_message({"message_timestamp": 1723500001234,
+                       "source_uuid": stranger_uuid,
+                       "source_number": stranger,
+                       "source_name": "Stranger", "body": "hello?",
+                       "message_type": "message", "is_outbound": False})
+    promoted = db.get_draft(draft["id"])
+    assert promoted["recipient"] == stranger_uuid, (
+        "the fixture did not actually promote — this test would then pass "
+        "vacuously")
+    assert promoted["dest_contact_id"] == contact_id, "the row id must be stable"
+
+    poster = Poster()
+    sent = db.send_approved(
+        draft["id"],
+        transmit=lambda a, **kw: consumer.transmit_approved(a, poster=poster, **kw))
+    assert sent["send_state"] == _signal_db.STATE_SENT
+    assert poster.calls[0]["json"]["recipients"] == [stranger_uuid]
+
+
+def test_the_digest_is_over_a_STABLE_identity_not_the_rendered_recipient():
+    """The property directly, at the unit level. Red at 182c3280.
+
+    Two rows that address the SAME contact row and differ only in how
+    `get_draft` rendered it must hash the same; two rows addressing DIFFERENT
+    contacts must not. Both halves are asserted so a `recipient_identity` that
+    returned a constant would fail the second.
+    """
+    as_number = {"dest_contact_id": 7, "recipient": "+15550555", "body": "hi",
+                 "mentions": []}
+    as_uuid = {"dest_contact_id": 7, "recipient": ANN_UUID, "body": "hi",
+               "mentions": []}
+    other = {"dest_contact_id": 8, "recipient": ANN_UUID, "body": "hi",
+             "mentions": []}
+    assert (_signal_db.draft_payload_digest(as_number)
+            == _signal_db.draft_payload_digest(as_uuid))
+    assert (_signal_db.draft_payload_digest(other)
+            != _signal_db.draft_payload_digest(as_uuid))
+    # The GROUP branch, pinned separately. Without this a `recipient_identity`
+    # that ignored `group_id` entirely survived every other test, because a group
+    # draft then fell through to the address string — which happens to be stable,
+    # so nothing could tell the two apart. Measured: that mutant SURVIVED a
+    # 663-test run until this pair was added.
+    grp_a = {"group_id": 3, "recipient": GROUP_ADDRESS, "body": "hi",
+             "mentions": []}
+    grp_b = {"group_id": 3, "recipient": "group.SOMETHINGELSE=", "body": "hi",
+             "mentions": []}
+    grp_c = {"group_id": 4, "recipient": GROUP_ADDRESS, "body": "hi",
+             "mentions": []}
+    assert (_signal_db.draft_payload_digest(grp_a)
+            == _signal_db.draft_payload_digest(grp_b))
+    assert (_signal_db.draft_payload_digest(grp_a)
+            != _signal_db.draft_payload_digest(grp_c))
+
+
+def test_re_addressing_a_draft_to_a_DIFFERENT_contact_is_still_refused(db):
+    """🔴 THE GUARD MUST NOT HAVE BEEN LOOSENED. Finding 2's fix relaxes WHAT is
+    hashed, so the case it must still catch is pinned explicitly: a second writer
+    pointing the draft at somebody else entirely.
+
+    GREEN at 182c3280 — an INVARIANT GUARD, not regression coverage. It exists
+    because the fix to finding 2 could have been "stop hashing the recipient",
+    which every finding-2 test would also accept.
+    """
+    draft = db.draft_message(recipient=PEER, body="see you at 6",
+                             self_number=SELF_NUMBER)
+    db.approve_draft(draft["id"], approval_ref="cg-readdress")
+    victim = db.upsert_contact(phone_number="+15550999", display_name="Someone Else")
+    _tamper(db, draft["id"], dest_contact_id=victim)
+
+    poster = Poster()
+    with pytest.raises(SendGateError) as exc:
+        db.send_approved(
+            draft["id"],
+            transmit=lambda a, **kw: consumer.transmit_approved(a, poster=poster,
+                                                                **kw))
+    assert "CHANGED after it was approved" in str(exc.value)
+    assert poster.calls == []
+
+
+# --- finding 3: `@name` was a bare substring match -------------------------- #
+ANNA_UUID = "55555555-5555-4555-8555-555555555555"
+PREFIX_MEMBERS = [ANN_UUID, ANNA_UUID]
+PREFIX_CONTACTS = [
+    {"signal_uuid": ANN_UUID, "phone_number": None, "display_name": "Ann",
+     "profile_name": None, "is_placeholder": False},
+    {"signal_uuid": ANNA_UUID, "phone_number": None, "display_name": "Anna",
+     "profile_name": None, "is_placeholder": False},
+]
+
+
+def test_a_mention_does_NOT_land_inside_a_LONGER_members_name():
+    """🔴 THE WRONG-PERSON PING. Red at 182c3280 — it emitted `(3, 4)`.
+
+    Members `Ann` and `Anna`, body `"hi @Anna and @Ann ok"`. At 182c3280
+    `body.find("@Ann")` returned 3, which sits INSIDE `@Anna`: Ann receives the
+    notification while Anna's name is the text on screen, and the receiving
+    client rewrites four characters out of the middle of someone else's name.
+
+    The literals are written out and cross-checked against the body so a resolver
+    that always emitted 0, or that emitted the code-point index, cannot agree
+    with this test.
+    """
+    body = "hi @Anna and @Ann ok"
+    out = _resolve(["Ann"], body, members=PREFIX_MEMBERS,
+                   contacts=PREFIX_CONTACTS)
+    assert out == [{"author": ANN_UUID, "start": 13, "length": 4}]
+    assert body[13:17] == "@Ann"
+    assert body[3:7] == "@Ann", "the WRONG span 182c3280 chose — inside '@Anna'"
+
+
+def test_the_prefix_pair_in_BOTH_directions_gets_two_distinct_spans():
+    """`--mention Ann --mention Anna` yielded two OVERLAPPING spans at offset 3."""
+    body = "hi @Anna and @Ann ok"
+    out = _resolve(["Ann", "Anna"], body, members=PREFIX_MEMBERS,
+                   contacts=PREFIX_CONTACTS)
+    assert out == [
+        {"author": ANN_UUID, "start": 13, "length": 4},
+        {"author": ANNA_UUID, "start": 3, "length": 5},
+    ]
+
+
+def test_a_mention_at_the_very_END_of_the_body_still_matches():
+    """🔴 The boundary is "non-word char OR end of string".
+
+    A `(?=\\W)` lookahead — the obvious spelling — would break EVERY message
+    ending in the mention, which is the most ordinary shape there is. This is the
+    positive control on finding 3's fix: without it, a boundary check that
+    refused end-of-string would satisfy the two tests above and make the feature
+    unusable.
+
+    GREEN at 182c3280 — an INVARIANT GUARD. It pins what the fix must NOT break.
+    """
+    assert _resolve(["Ann"], "please look @Ann") == [
+        {"author": ANN_UUID, "start": 12, "length": 4}]
+
+
+def test_OVERLAPPING_spans_are_refused_with_their_own_error():
+    """🔴 Boundary-legal and still overlapping. Red at 182c3280 (it sent both).
+
+    Members `Ann` and `Ann Smith`, body `"@Ann Smith please"`. `@Ann` is followed
+    by a SPACE, so the word boundary is satisfied — and the two spans are (0,4)
+    and (0,10). Two rewrites of the same characters; what the recipient renders
+    is undefined.
+    """
+    contacts = [
+        {"signal_uuid": ANN_UUID, "phone_number": None, "display_name": "Ann",
+         "profile_name": None, "is_placeholder": False},
+        {"signal_uuid": BOB_UUID, "phone_number": None,
+         "display_name": "Ann Smith", "profile_name": None,
+         "is_placeholder": False},
+    ]
+    with pytest.raises(_mentions.MentionSpansOverlap) as exc:
+        _resolve(["Ann", "Ann Smith"], "@Ann Smith please",
+                 members=[ANN_UUID, BOB_UUID], contacts=contacts)
+    message = str(exc.value)
+    assert "OVERLAP" in message
+    assert "0–4" in message and "0–10" in message
+
+
+def test_two_ADJACENT_non_overlapping_mentions_are_NOT_refused():
+    """Positive control on the overlap guard: touching is not overlapping.
+
+    `"@Ann@Bob"` — spans (0,4) and (4,4) share the boundary index and nothing
+    else. A guard written with `<=` instead of `<` would refuse this.
+
+    GREEN at 182c3280 — an INVARIANT GUARD on the NEW overlap check, not
+    regression coverage.
+    """
+    body = "@Ann@Bob"
+    out = _resolve(["Ann", "Bob"], body,
+                   contacts=[c for c in CONTACTS if c["display_name"] != "Bob"
+                             or c["signal_uuid"] == BOB_UUID])
+    assert [(m["start"], m["start"] + m["length"]) for m in out] == [(0, 4), (4, 8)]
+
+
+# --- finding 7c: resolution lowercases, the body search did not ------------- #
+def test_a_DIFFERENTLY_CASED_mention_resolves_AND_finds_its_span():
+    """🔴 Red at 182c3280 with `MentionSpanMissing`.
+
+    `_resolve_one()` matches names via `.lower()`, so `--mention ANN` resolved
+    fine and then died in the span search, which was exact. The two halves of one
+    argument disagreed about what it meant.
+    """
+    assert _resolve(["ANN"], "hi @Ann there") == [
+        {"author": ANN_UUID, "start": 3, "length": 4}]
+    assert _resolve(["ann"], "hi @Ann there")[0]["author"] == ANN_UUID
+
+
+def test_case_insensitive_matching_did_not_break_the_utf16_offsets():
+    """🔴 The offsets must be computed on the ORIGINAL body.
+
+    `str.lower()` and `str.casefold()` CHANGE LENGTH on real characters, so the
+    obvious implementation — fold the body, `find()` in the folded copy — reports
+    an offset into a string that is not the one being sent. Measured on this very
+    body: the true `@Ann` is at 9, a `.lower()` implementation says 10, and a
+    `.casefold()` one says 11. All three numbers are asserted as literals so a
+    folding implementation cannot make this test agree with itself.
+    """
+    body = "İ straße @Ann"
+    assert body.find("@Ann") == 9
+    assert body.lower().find("@ann") == 10, "the premise: .lower() SHIFTS it"
+    assert body.casefold().find("@ann") == 11, "and .casefold() shifts it further"
+    assert _resolve(["ann"], body) == [
+        {"author": ANN_UUID, "start": 9, "length": 4}]
+
+
+# --- finding 5: refusal messages leaked the whole group roster -------------- #
+def test_a_not_a_member_refusal_does_NOT_enumerate_the_roster():
+    """🔴 Red at 182c3280 — it interpolated `sorted(member_set)`.
+
+    `draft` needs no approval token, so this refusal is a free, repeatable probe:
+    any caller that can run the CLI could read the FULL membership — uuids and
+    phone numbers — of any group address it can guess, including a MUTED one.
+    """
+    with pytest.raises(MentionNotAMember) as exc:
+        _resolve([OUTSIDER_UUID], f"hello @{OUTSIDER_UUID}")
+    message = str(exc.value)
+    assert "NOT a member of the target group" in message
+    for member in MEMBERS:
+        assert member not in message, f"the refusal leaked {member!r}"
+    assert f"{len(MEMBERS)} member(s)" in message, (
+        "the count is what makes the message honest about what it withheld")
+
+
+def test_a_name_not_found_refusal_TRUNCATES_the_name_list():
+    """🔴 Red at 182c3280 — every stored display/profile name was interpolated.
+
+    Truncation rather than removal: a couple of names help an operator spot a
+    typo. The count of withheld names is stated so the truncation is visible.
+    """
+    many = [{"signal_uuid": f"{i:08d}-1111-4111-8111-111111111111",
+             "phone_number": None, "display_name": f"Member{i:02d}",
+             "profile_name": None, "is_placeholder": False}
+            for i in range(12)]
+    with pytest.raises(MentionNameNotFound) as exc:
+        _resolve(["Zoe"], "hi @Zoe",
+                 members=[c["signal_uuid"] for c in many], contacts=many)
+    message = str(exc.value)
+    # `_contact_names` lower-cases, so that is the form the message carries.
+    shown = [c["display_name"] for c in many
+             if c["display_name"].lower() in message]
+    assert len(shown) == _mentions.NAME_HINT_MAX, shown
+    assert f"+{12 - _mentions.NAME_HINT_MAX} not shown" in message
+
+
+# --- finding 6: the approval card showed a raw UUID ------------------------- #
+def test_the_card_carries_the_resolved_DISPLAY_NAME_not_just_a_uuid():
+    """🔴 Red at 182c3280 — the line was `<uuid> (chars 0–4)`.
+
+    The card exists to tell a HUMAN who a draft will ping. Five of the seven
+    members of the real group are uuid-only, so for most mentions the card said
+    nothing checkable.
+    """
+    payload = clawgate.build_draft_payload(
+        draft_id=32, recipient=GROUP_ADDRESS, body="@Ann please look",
+        mentions=[{"author": ANN_UUID, "start": 0, "length": 4}],
+        author_names={ANN_UUID: "Ann"})
+    assert "Ann <" + ANN_UUID + ">" in payload["body"]
+
+
+def test_the_card_says_UTF16_UNITS_not_chars():
+    """🔴 "chars" was inaccurate, and inaccurate in the direction that matters:
+    with an emoji earlier in the body the two numbers genuinely differ."""
+    payload = clawgate.build_draft_payload(
+        draft_id=33, recipient=GROUP_ADDRESS, body="\U0001F415 @Ann",
+        mentions=[{"author": ANN_UUID, "start": 3, "length": 4}],
+        author_names={ANN_UUID: "Ann"})
+    assert "UTF-16 units 3–7" in payload["body"]
+    assert "chars" not in payload["body"]
+
+
+def test_an_author_with_no_stored_name_says_so_rather_than_going_blank():
+    """A missing name must not silently render as an empty label."""
+    payload = clawgate.build_draft_payload(
+        draft_id=34, recipient=GROUP_ADDRESS, body="@Ann",
+        mentions=[{"author": ANN_UUID, "start": 0, "length": 4}])
+    assert "(no stored name)" in payload["body"]
+    assert ANN_UUID in payload["body"]
+
+
+def test_mention_author_names_resolves_through_the_contacts_table(db):
+    """The seam: `main()` must actually FEED the card names, not just accept them."""
+    db.upsert_contact(signal_uuid=ANN_UUID, display_name="Ann")
+    assert consumer.mention_author_names(
+        db, [{"author": ANN_UUID, "start": 0, "length": 4}]) == {ANN_UUID: "Ann"}
+    assert consumer.mention_author_names(db, []) == {}
+
+
+def test_the_draft_command_passes_the_names_it_resolved_to_the_card(db, monkeypatch):
+    """🔴 Red at 182c3280: `emit_draft_task` took no names, so this asserted a
+    keyword that did not exist. The SEAM — a card that can render a name is
+    useless if the CLI never supplies one.
+    """
+    db.upsert_contact(signal_uuid=ANN_UUID, display_name="Ann")
+    seen = {}
+    monkeypatch.setattr(consumer, "SignalDB", lambda *a, **k: _NoCloseDB(db))
+    monkeypatch.setattr(clawgate, "emit_draft_task",
+                        lambda **kw: seen.update(kw) or True)
+    monkeypatch.setattr(consumer, "fetch_group_members",
+                        lambda number, address: [ANN_UUID])
+    assert consumer.main(["draft", "--to", GROUP_ADDRESS, "--body",
+                          "@Ann please look", "--from-number", SELF_NUMBER,
+                          "--mention", "Ann"]) == 0
+    assert seen["author_names"] == {ANN_UUID: "Ann"}
+    assert ("Ann <" + ANN_UUID + ">"
+            in clawgate.build_draft_payload(
+                draft_id=1, recipient=GROUP_ADDRESS, body="@Ann please look",
+                mentions=seen["mentions"],
+                author_names=seen["author_names"])["body"])
+
+
+# --- finding 7a: a malformed stored `mentions` raised a bare TypeError ------ #
+@pytest.mark.parametrize("bad", [
+    [{"author": ANN_UUID, "start": None, "length": 4}],
+    [{"author": ANN_UUID, "length": 4}],
+    ["not an object"],
+    [None],
+])
+def test_an_unreadable_stored_mention_is_a_MentionError_not_a_TypeError(bad):
+    """🔴 Red at 182c3280 with `TypeError`, which NO CLI handler catches —
+    `send` catches `SendGateError`, `draft` catches `ValueError` — so a bad row
+    in the database surfaced as a traceback and exit 1."""
+    with pytest.raises(_mentions.MentionError):
+        _mentions.canonical_mentions(bad)
+    with pytest.raises(_mentions.MentionError):
+        _mentions.describe_mentions(bad)
+
+
+def test_a_draft_with_an_unreadable_mentions_column_REFUSES_as_a_SendGateError(db):
+    """The same defect on the send path, where it decides an exit code.
+
+    Red at 182c3280: `TypeError: int() argument must be…` escaped
+    `send_approved()` as a traceback.
+    """
+    draft = _group_draft(db)
+    db.approve_draft(draft["id"], approval_ref="cg-bad-mentions")
+    _tamper(db, draft["id"],
+            mentions=json.dumps([{"author": ANN_UUID, "start": None,
+                                  "length": 4}]))
+    poster = Poster()
+    with pytest.raises(SendGateError) as exc:
+        db.send_approved(
+            draft["id"],
+            transmit=lambda a, **kw: consumer.transmit_approved(a, poster=poster,
+                                                                **kw))
+    assert "unreadable" in str(exc.value)
+    assert poster.calls == []
+
+
+def test_spend_authorization_refuses_an_unreadable_mentions_argument():
+    """Window B's half of the same translation."""
+    auth = _signal_db._mint_send_authorization(_approved_row(47, PEER, "hi"))
+    with pytest.raises(SendGateError) as exc:
+        _signal_db.spend_authorization(auth, recipient=PEER, body="hi",
+                                       mentions=[{"author": ANN_UUID}])
+    assert "unreadable" in str(exc.value)
+
+
+# --- finding 7b: a group-API failure escaped `draft` as a traceback --------- #
+def test_a_failing_group_lookup_is_a_REFUSAL_not_a_traceback(db):
+    """🔴 Red at 182c3280: `requests.HTTPError` is not a `ValueError`, so
+    `main()`'s draft handler did not catch it and the operator got a stack trace
+    and exit 1 — indistinguishable from the interpreter dying."""
+    class _HTTPError(Exception):
+        pass
+
+    def fetcher(number, address):
+        raise _HTTPError("404 Client Error for url: /v1/groups//<gid>")
+
+    with pytest.raises(_mentions.MentionGroupLookupFailed) as exc:
+        consumer.resolve_draft_mentions(
+            db, recipient=GROUP_ADDRESS, body="@Ann", identifiers=["Ann"],
+            number=SELF_NUMBER, member_fetcher=fetcher)
+    assert "_HTTPError" in str(exc.value)
+    assert isinstance(exc.value, ValueError), (
+        "the draft handler catches ValueError; anything else still escapes")
+
+
+def test_an_EMPTY_from_number_is_refused_BEFORE_the_404(db):
+    """The ordinary way to hit finding 7b: `--from-number ''` builds
+    `/v1/groups//<gid>`. Named at the argument, not at the HTTP status."""
+    calls = []
+
+    def fetcher(number, address):
+        calls.append((number, address))
+        raise AssertionError("a membership fetch was attempted with no number")
+
+    with pytest.raises(_mentions.MentionGroupLookupFailed) as exc:
+        consumer.resolve_draft_mentions(
+            db, recipient=GROUP_ADDRESS, body="@Ann", identifiers=["Ann"],
+            number="", member_fetcher=fetcher)
+    # 🔴 BOTH halves, because either alone is green for the wrong reason. A
+    # mutant deleting the empty-number guard let the fetch run, its AssertionError
+    # got wrapped into a `MentionGroupLookupFailed` whose generic text also says
+    # "--from-number", and the test SURVIVED — measured. So: the fetch must not
+    # have happened, and the message must name the EMPTY ARGUMENT, not an HTTP
+    # failure.
+    assert calls == [], "the refusal must come BEFORE the doomed lookup"
+    assert "--from-number is empty" in str(exc.value)
+    assert "GET /v1/groups" in str(exc.value)
+
+
+def test_a_failed_group_lookup_exits_3_from_main_and_drafts_NOTHING(db, monkeypatch):
+    """End to end at the surface the operator touches. Red at 182c3280 (exit 1,
+    traceback)."""
+    monkeypatch.setattr(consumer, "SignalDB", lambda *a, **k: _NoCloseDB(db))
+    monkeypatch.setattr(clawgate, "emit_draft_task",
+                        lambda **kw: False)
+    before = db.conn.count("messages")
+    assert consumer.main(["draft", "--to", GROUP_ADDRESS, "--body", "@Ann hi",
+                          "--from-number", "", "--mention", "Ann"]) == 3
+    assert db.conn.count("messages") == before, "a draft was left behind"

--- a/scripts/signal/tests/test_mentions.py
+++ b/scripts/signal/tests/test_mentions.py
@@ -2042,3 +2042,114 @@ def test_the_name_hint_cap_is_a_LITERAL_five_not_whatever_the_module_says():
                if c["display_name"].lower() in message]
     assert len(printed) == 5, printed
     assert "+7 not shown" in message
+
+
+# --------------------------------------------------------------------------- #
+# ROUND-5 delta audit
+# --------------------------------------------------------------------------- #
+# --- F-A (relocated): a PLACEHOLDER bridges two real rows ------------------- #
+def test_a_PLACEHOLDER_bridging_TWO_REAL_rows_is_REFUSED_not_guessed(db):
+    """🔴 RED at 707412e6 — and red by SENDING, as a DID NOT RAISE. Round-5 F-A.
+
+    THREE rows on one number, which is what the two-row tests above are
+    structurally blind to. Round 4 gated the union on `is_placeholder`, but the
+    gate is a PER-PAIR predicate inside a union-find, and a union-find joins
+    PATHS: it blocks the direct edge real—real and then real—placeholder and
+    placeholder—real union anyway, so `find(A) == find(C)` and two different
+    people are one identity again. Moving the nodes from identifiers to rows
+    changed WHICH nodes merge; it did not remove transitivity.
+
+    Built through five ordinary `upsert_contact()` calls, NO SQL, each one a
+    mechanism the module's own docstrings describe: a draft names an unknown
+    number and mints a PLACEHOLDER; an envelope teaches real row A that number,
+    `_promote_placeholder()` DECLINING because the uuid is taken (so the
+    placeholder survives, durably); the number is then recycled onto real row C,
+    which declines the same way.
+
+    MIXED and measured that way: the row assertions are GREEN at 707412e6 —
+    INVARIANT GUARDS proving the three-row state is reachable from the public
+    API. The refusal is RED there: it returned
+    `[{'author': ANN_UUID, 'start': 3, 'length': 4}]`, a ping for Ann under text
+    reading `@Ann Smith`, with no exception of any class.
+
+    The `raises` is on the BASE class and the specific class is asserted by NAME
+    on the next line, deliberately: naming the new subclass inside `raises()`
+    makes the test red at 707412e6 with an `AttributeError` on the missing
+    attribute — red for the wrong reason, and blind to whether the call sent.
+    This shape is red there as **DID NOT RAISE**, which is the failure mode
+    being pinned, while still refusing to accept any of the other seven
+    refusals as a pass.
+    """
+    number = "+15550100"
+    db.upsert_contact(phone_number=number)                       # -> PLACEHOLDER
+    db.upsert_contact(signal_uuid=ANN_UUID, display_name="Ann")
+    db.upsert_contact(signal_uuid=ANN_UUID, phone_number=number)  # promotion declines
+    db.upsert_contact(signal_uuid=CAI_UUID, profile_name="Ann Smith")
+    db.upsert_contact(signal_uuid=CAI_UUID, phone_number=number)  # declines again
+    rows = db.contacts_by_identifiers([number, ANN_UUID, CAI_UUID])
+    assert len(rows) == 3, f"expected the three-row bridge, got {rows!r}"
+    assert {r["phone_number"] for r in rows} == {number}
+    assert sorted(bool(r["is_placeholder"]) for r in rows) == [False, False, True], \
+        "two REAL rows and ONE placeholder — the bridge is the whole point"
+    with pytest.raises(_mentions.MentionError) as exc:
+        _mentions.resolve_mentions(
+            ["Ann"], body="hi @Ann Smith",
+            # The synthetic placeholder uuid is deliberately NOT a member: it is
+            # not a Signal identity, and the number it was minted for is.
+            members=[ANN_UUID, CAI_UUID, number], contacts=rows, is_group=True)
+    assert type(exc.value).__name__ == "MentionIdentityUnresolvable", \
+        f"refused, but with the wrong class: {exc.value!r}"
+
+
+def test_the_bridge_refusal_survives_a_mention_typed_as_a_BARE_UUID(db):
+    """The refusal is not routed around by spelling the mention differently.
+
+    `_resolve_one()` never consults identity for a bare uuid — but
+    `_colliding_needles()` does, and a polluted group drops the OTHER real
+    person's longer name from the veto list, so "spell it as a uuid" is not a
+    safe way around an unresolvable identity. This pins that the refusal covers
+    the whole call rather than only the name-lookup door.
+
+    RED at 707412e6 as a DID NOT RAISE — but honestly: what it returned there
+    was a CORRECT mention. A uuid is longer than any of these names, so no veto
+    could apply in THIS body and no wrong send is demonstrated. This is an
+    invariant guard on the SCOPE of the fail-closed rule, not a second wrong-send
+    regression, and it is counted as one.
+    """
+    number = "+15550100"
+    db.upsert_contact(phone_number=number)
+    db.upsert_contact(signal_uuid=ANN_UUID, display_name="Ann")
+    db.upsert_contact(signal_uuid=ANN_UUID, phone_number=number)
+    db.upsert_contact(signal_uuid=CAI_UUID, profile_name="Ann Smith")
+    db.upsert_contact(signal_uuid=CAI_UUID, phone_number=number)
+    rows = db.contacts_by_identifiers([number, ANN_UUID, CAI_UUID])
+    with pytest.raises(_mentions.MentionError) as exc:
+        _mentions.resolve_mentions(
+            [ANN_UUID], body="hi @" + ANN_UUID + " ok",
+            members=[ANN_UUID, CAI_UUID, number], contacts=rows, is_group=True)
+    assert type(exc.value).__name__ == "MentionIdentityUnresolvable", \
+        f"refused, but with the wrong class: {exc.value!r}"
+
+
+def test_a_placeholder_bridging_ONE_real_row_still_resolves_NORMALLY(db):
+    """The negative control: the group check must not refuse the ordinary case.
+
+    The durable two-row split — one person, a real row and the placeholder
+    minted for their number — is the shape `_identity_groups()` EXISTS to merge.
+    Its group holds exactly one real row, so the new invariant says nothing
+    about it and the mention resolves to the real Signal id.
+
+    GREEN at 707412e6 — an INVARIANT GUARD, not regression coverage. It is here
+    because a fix that refused any group containing a placeholder would pass the
+    two tests above and silently break the case round 3 and round 4 both fixed.
+    """
+    number = "+15550100"
+    db.upsert_contact(phone_number=number)
+    db.upsert_contact(signal_uuid=ANN_UUID, display_name="Ann")
+    db.upsert_contact(signal_uuid=ANN_UUID, phone_number=number)
+    rows = db.contacts_by_identifiers([number, ANN_UUID])
+    assert sorted(bool(r["is_placeholder"]) for r in rows) == [False, True]
+    assert _mentions.resolve_mentions(
+        ["Ann"], body="hi @Ann ok", members=[ANN_UUID, number, BOB_UUID],
+        contacts=rows, is_group=True) == [
+        {"author": ANN_UUID, "start": 3, "length": 4}]

--- a/scripts/signal/tests/test_mentions.py
+++ b/scripts/signal/tests/test_mentions.py
@@ -1,0 +1,872 @@
+"""🔴 Mentions on outbound Signal messages — offsets, refusals, and the binding.
+
+THREE THINGS ARE UNDER TEST, and they fail in three different ways:
+
+1. **UTF-16 OFFSETS.** `start`/`length` are UTF-16 code units. Every assertion
+   here that involves an emoji exists because a `len()`-in-code-points
+   implementation passes the ASCII cases and is silently wrong the moment a
+   non-BMP character appears earlier in the body — the receiving client then
+   replaces the WRONG span of text. `test_an_emoji_before_the_mention_shifts_…`
+   is the whole point of this file; the ASCII cases cannot see that defect.
+
+2. **THE REFUSAL MATRIX.** Six ways a `--mention` can fail to name exactly one
+   real member of the target group. Each has its OWN exception class and its own
+   test asserting THAT class — not `pytest.raises(ValueError)`, which every
+   other refusal would also satisfy. Refusing rather than dropping is the
+   product decision: a mention notifies a third party through their mute
+   settings, so sending fewer than were asked for is a different act from the
+   one the operator approved.
+
+3. **THE CAPABILITY BINDING.** Until this change the send capability authorised
+   "a transmit for draft N" and nothing about the message; `auth.recipient` and
+   `auth.body` were populated at mint and read by NOBODY. Anything that wrote to
+   the row between approval and the POST — a concurrent writer, a second agent,
+   a bug — sent text a human never saw under an approval a human really gave.
+   `test_a_draft_mutated_between_approve_and_send_is_REFUSED` is the regression
+   test for that; it fails on pre-change code.
+
+Hermetic like its neighbours: the sqlite substrate, an injected group-membership
+fetcher, an injected poster. Nothing here touches Postgres, MinIO or the network,
+and NO test in this file transmits a real Signal message.
+"""
+import base64
+import json
+import types
+from pathlib import Path
+
+import pytest
+
+import clawgate
+import consumer
+import _mentions
+import _signal_db
+from _mentions import (
+    MentionNameAmbiguous,
+    MentionNameNotFound,
+    MentionNotAMember,
+    MentionResolvesToPlaceholder,
+    MentionSpanMissing,
+    MentionsRequireAGroup,
+)
+from _signal_db import SendGateError
+
+SELF_NUMBER = "+15559090"
+PEER = "+15550101"
+
+# A real group `id` (the double-base64 `--to` form), built through the module's
+# own encoder so this fixture cannot disagree with what `draft_message` decodes.
+GROUP_RAW = b"\x51" * 32
+GROUP_ADDRESS = _signal_db._group_id_to_address(GROUP_RAW)
+
+# The measured live shape: members[] is MIXED — E.164 and bare UUID. Five of the
+# seven members of the real 'Vetr app group' are uuid-only, so a fixture where
+# everyone has a phone number would not exercise the join that matters.
+ANN_UUID = "11111111-1111-4111-8111-111111111111"
+BOB_UUID = "22222222-2222-4222-8222-222222222222"
+CAI_UUID = "33333333-3333-4333-8333-333333333333"
+DEE_NUMBER = "+15550444"
+OUTSIDER_UUID = "99999999-9999-4999-8999-999999999999"
+
+MEMBERS = [ANN_UUID, BOB_UUID, CAI_UUID, DEE_NUMBER]
+
+CONTACTS = [
+    {"signal_uuid": ANN_UUID, "phone_number": None, "display_name": "Ann",
+     "profile_name": None, "is_placeholder": False},
+    {"signal_uuid": BOB_UUID, "phone_number": None, "display_name": "Bob",
+     "profile_name": None, "is_placeholder": False},
+    # 🔴 Cai shares Bob's DISPLAY NAME. Ambiguity is not a hypothetical: two
+    # people in one group answering to "Bob" is ordinary, and picking either one
+    # silently is how a message pings a stranger.
+    {"signal_uuid": CAI_UUID, "phone_number": None, "display_name": "Bob",
+     "profile_name": None, "is_placeholder": False},
+    # 🔴 Dee is a PLACEHOLDER — a synthetic identity minted by
+    # `placeholder_uuid()` for a sender the pipeline could not identify.
+    {"signal_uuid": _signal_db.placeholder_uuid(DEE_NUMBER),
+     "phone_number": DEE_NUMBER, "display_name": "Dee",
+     "profile_name": None, "is_placeholder": True},
+]
+
+
+def _approved_row(draft_id, recipient, body, mentions=None):
+    """A hand-built APPROVED draft row, digest included.
+
+    🔴 The digest is COMPUTED, never a literal: `_mint_send_authorization()`
+    fails closed on a row whose payload does not hash to what approval recorded,
+    so a fixture that hard-coded one would go stale silently the first time the
+    canonical form changed and every test here would refuse for the wrong reason.
+    """
+    return {"id": draft_id, "send_state": _signal_db.STATE_APPROVED,
+            "recipient": recipient, "body": body, "mentions": mentions or [],
+            "approved_digest": _signal_db.payload_digest(
+                recipient=recipient, body=body, mentions=mentions or [])}
+
+
+class Poster:
+    """Records every POST. Must stay EMPTY whenever the gate refuses."""
+
+    def __init__(self, ts=1723500000777):
+        self.calls = []
+        self._ts = ts
+
+    def __call__(self, url, json=None, timeout=None):
+        self.calls.append({"url": url, "json": json})
+        return types.SimpleNamespace(raise_for_status=lambda: None,
+                                     json=lambda: {"timestamp": str(self._ts)})
+
+
+def _resolve(identifiers, body, *, members=MEMBERS, contacts=CONTACTS,
+             is_group=True):
+    return _mentions.resolve_mentions(identifiers, body=body, members=members,
+                                      contacts=contacts, is_group=is_group)
+
+
+# --------------------------------------------------------------------------- #
+# 1. UTF-16 OFFSETS
+# --------------------------------------------------------------------------- #
+def test_utf16_len_counts_code_UNITS_not_code_POINTS():
+    """The primitive, pinned at three points — BMP, non-BMP, and mixed.
+
+    An INVARIANT GUARD, not a regression test: nothing shipped that got this
+    wrong, because nothing computed it at all. It is here so the two spellings
+    that DO differ are stated as literals rather than derived from `len()`.
+    """
+    assert _mentions.utf16_len("hello") == 5           # ASCII: units == points
+    assert _mentions.utf16_len("é") == 1               # BMP: still one unit
+    assert _mentions.utf16_len("\U0001F415") == 2      # 🐕 non-BMP: TWO units
+    assert len("\U0001F415") == 1                      # ... but ONE code point
+    assert _mentions.utf16_len("a\U0001F415b") == 4
+
+
+def test_a_mention_at_the_start_of_the_body_spans_from_zero():
+    out = _resolve(["Ann"], "@Ann can you look at this?")
+    assert out == [{"author": ANN_UUID, "start": 0, "length": 4}]
+
+
+def test_a_mention_that_is_NOT_at_index_zero_carries_its_real_offset():
+    """A resolver that always emitted 0 would pass the case above."""
+    body = "hey @Ann can you look"
+    out = _resolve(["Ann"], body)
+    assert out == [{"author": ANN_UUID, "start": 4, "length": 4}]
+    assert body[4:8] == "@Ann"
+
+
+def test_an_emoji_before_the_mention_shifts_start_by_TWO_not_one():
+    """🔴 THE CASE THIS WHOLE FILE EXISTS FOR.
+
+    `"🐕 @Ann"`. In Python code points `@Ann` starts at index 2. In UTF-16 code
+    units — which is what the wire format specifies — it starts at 3, because the
+    dog is a non-BMP character and occupies TWO units. A naive `body.find()`
+    passes every ASCII test in this file and emits 2 here, and the receiving
+    client then replaces one character too few: the message renders as
+    `🐕@AnnAnn`-shaped garbage with the ping pointing at the wrong text.
+
+    The two numbers are written as LITERALS, and their difference asserted
+    explicitly, so a `len()`-based implementation cannot make this test agree
+    with itself.
+    """
+    body = "\U0001F415 @Ann look at this"
+    out = _resolve(["Ann"], body)
+    assert out == [{"author": ANN_UUID, "start": 3, "length": 4}]
+    assert body.find("@Ann") == 2, "the CODE POINT index — deliberately different"
+    assert out[0]["start"] == body.find("@Ann") + 1
+
+
+def test_an_emoji_INSIDE_the_mention_span_lengthens_it_too():
+    """The same defect on `length` rather than on `start`.
+
+    A body whose mention text itself contains a non-BMP character: `length` is
+    UTF-16 units of the needle, so a `len()` implementation under-counts here
+    even when `start` happens to be right.
+    """
+    emoji_named = [{"signal_uuid": ANN_UUID, "phone_number": None,
+                    "display_name": "Ann\U0001F415", "profile_name": None,
+                    "is_placeholder": False}]
+    body = "ping @Ann\U0001F415 now"
+    out = _resolve(["Ann\U0001F415"], body, contacts=emoji_named)
+    assert out == [{"author": ANN_UUID, "start": 5, "length": 6}]
+    assert len("@Ann\U0001F415") == 5, "FIVE code points, SIX utf-16 units"
+
+
+def test_two_mentions_in_one_body_get_distinct_spans_in_order():
+    body = "@Ann and @Bob please review"
+    out = _resolve(["Ann", "Bob"], body,
+                   contacts=[c for c in CONTACTS if c["display_name"] != "Bob"
+                             or c["signal_uuid"] == BOB_UUID])
+    assert out == [
+        {"author": ANN_UUID, "start": 0, "length": 4},
+        {"author": BOB_UUID, "start": 9, "length": 4},
+    ]
+
+
+def test_two_mentions_with_an_emoji_between_them_both_shift():
+    """Both offsets, and the SECOND one is where a units bug compounds."""
+    body = "@Ann \U0001F415\U0001F415 @Bob"
+    out = _resolve(["Ann", "Bob"], body,
+                   contacts=[c for c in CONTACTS if c["display_name"] != "Bob"
+                             or c["signal_uuid"] == BOB_UUID])
+    assert out == [
+        {"author": ANN_UUID, "start": 0, "length": 4},
+        # 4 for "@Ann", 1 space, 2+2 for the dogs, 1 space -> 10
+        {"author": BOB_UUID, "start": 10, "length": 4},
+    ]
+    assert body.find("@Bob") == 8, "code points again — two behind the truth"
+
+
+def test_the_same_name_mentioned_twice_takes_successive_occurrences():
+    """Both mentions pointing at the SAME span would ping once and mis-render."""
+    body = "@Ann and again @Ann"
+    out = _resolve(["Ann", "Ann"], body)
+    assert [(m["start"], m["length"]) for m in out] == [(0, 4), (15, 4)]
+
+
+# --------------------------------------------------------------------------- #
+# 2. THE REFUSAL MATRIX — one test per distinct error
+# --------------------------------------------------------------------------- #
+def test_refusal_name_not_found():
+    with pytest.raises(MentionNameNotFound) as exc:
+        _resolve(["Zoe"], "hello @Zoe")
+    assert "no member of the target group is named 'Zoe'" in str(exc.value)
+
+
+def test_refusal_ambiguous_name():
+    """Two members answer to 'Bob'; picking one silently pings a stranger."""
+    with pytest.raises(MentionNameAmbiguous) as exc:
+        _resolve(["Bob"], "hello @Bob")
+    message = str(exc.value)
+    assert "AMBIGUOUS" in message
+    assert "matches 2 members" in message
+
+
+def test_refusal_placeholder_contact():
+    """A `placeholder_uuid()` identity is SYNTHETIC — it addresses nobody."""
+    with pytest.raises(MentionResolvesToPlaceholder) as exc:
+        _resolve(["Dee"], "hello @Dee")
+    assert "PLACEHOLDER" in str(exc.value)
+
+
+def test_refusal_placeholder_reached_by_its_uuid_too():
+    """The same refusal on the DIRECT-identifier branch, not just the name one.
+
+    A guard on the name path alone would be walked by typing the synthetic uuid.
+    """
+    fake = _signal_db.placeholder_uuid(DEE_NUMBER)
+    with pytest.raises(MentionResolvesToPlaceholder):
+        _resolve([fake], f"hello @{fake}",
+                 members=MEMBERS + [fake])
+
+
+def test_refusal_identifier_is_not_a_member_of_this_group():
+    with pytest.raises(MentionNotAMember) as exc:
+        _resolve([OUTSIDER_UUID], f"hello @{OUTSIDER_UUID}")
+    assert "NOT a member of the target group" in str(exc.value)
+
+
+def test_refusal_the_at_substring_is_absent_from_the_body():
+    """A resolvable name, but the body never says `@Ann` — nothing to replace."""
+    with pytest.raises(MentionSpanMissing) as exc:
+        _resolve(["Ann"], "hello Ann, no at-sign here")
+    assert "does not contain '@Ann'" in str(exc.value)
+
+
+def test_refusal_mentions_for_a_non_group_recipient():
+    with pytest.raises(MentionsRequireAGroup) as exc:
+        _resolve(["Ann"], "hi @Ann", is_group=False)
+    assert "mentions are a GROUP feature" in str(exc.value)
+
+
+def test_refusal_an_empty_membership_is_a_refusal_not_an_empty_array():
+    """🔴 A silent zero. An empty `members[]` means the LOOKUP failed."""
+    with pytest.raises(MentionNameNotFound) as exc:
+        _resolve(["Ann"], "hi @Ann", members=[])
+    assert "reported NO members" in str(exc.value)
+
+
+def test_a_name_that_matches_someone_OUTSIDE_the_group_does_not_resolve():
+    """Candidacy is scoped to MEMBERSHIP, not to the whole contacts table."""
+    outsider = {"signal_uuid": OUTSIDER_UUID, "phone_number": None,
+                "display_name": "Zoe", "profile_name": None,
+                "is_placeholder": False}
+    with pytest.raises(MentionNameNotFound):
+        _resolve(["Zoe"], "hi @Zoe", contacts=CONTACTS + [outsider])
+
+
+def test_no_mentions_asked_for_is_an_empty_list_even_for_a_non_group():
+    """The refusal fires only when mentions were ACTUALLY requested."""
+    assert _resolve([], "a plain message", is_group=False) == []
+    assert _resolve(None, "a plain message", is_group=False) == []
+
+
+def test_an_explicit_member_uuid_and_E164_both_resolve_to_themselves():
+    """`author` accepts either form; both must survive as typed."""
+    assert _resolve([ANN_UUID], f"hi @{ANN_UUID}")[0]["author"] == ANN_UUID
+    ok = [c for c in CONTACTS if not c["is_placeholder"]] + [
+        {"signal_uuid": None, "phone_number": DEE_NUMBER, "display_name": "Dee2",
+         "profile_name": None, "is_placeholder": False}]
+    assert _resolve([DEE_NUMBER], f"hi @{DEE_NUMBER}",
+                    contacts=ok)[0]["author"] == DEE_NUMBER
+
+
+def test_a_profile_name_resolves_as_well_as_a_display_name():
+    contacts = [{"signal_uuid": ANN_UUID, "phone_number": None,
+                 "display_name": None, "profile_name": "Annie",
+                 "is_placeholder": False}]
+    assert _resolve(["Annie"], "hi @Annie",
+                    contacts=contacts)[0]["author"] == ANN_UUID
+
+
+# --------------------------------------------------------------------------- #
+# 3. PERSISTENCE AND THE MIGRATION
+# --------------------------------------------------------------------------- #
+MENTIONS_FIXTURE = [{"author": ANN_UUID, "start": 0, "length": 4}]
+
+
+def _group_draft(db, body="@Ann please look", mentions=None):
+    return db.draft_message(recipient=GROUP_ADDRESS, body=body,
+                            self_number=SELF_NUMBER,
+                            mentions=MENTIONS_FIXTURE if mentions is None
+                            else mentions)
+
+
+def test_ensure_schema_twice_is_a_no_op(db):
+    """🔴 The migration is `ADD COLUMN IF NOT EXISTS` — idempotent, like the rest.
+
+    `ensure_schema()` runs on every consumer start. A migration that raised the
+    second time would crash the pod on restart, and the restart is precisely the
+    moment it runs.
+    """
+    db.ensure_schema()
+    db.ensure_schema()
+    draft = _group_draft(db)
+    assert db.get_draft(draft["id"])["mentions"] == MENTIONS_FIXTURE
+
+
+def test_the_mentions_column_exists_and_is_declared_in_SCHEMA_STATEMENTS():
+    """Derived from the module's own DDL, never restated here."""
+    alters = [s for s in _signal_db.SCHEMA_STATEMENTS
+              if s.strip().upper().startswith("ALTER TABLE")]
+    assert any("ADD COLUMN IF NOT EXISTS mentions" in s for s in alters), alters
+
+
+def test_a_draft_persists_its_mentions_and_reads_them_back_as_a_LIST(db):
+    draft = _group_draft(db)
+    stored = db.get_draft(draft["id"])
+    assert stored["mentions"] == MENTIONS_FIXTURE
+    assert isinstance(stored["mentions"], list)
+
+
+def test_the_mentions_column_holds_JSON_not_a_postgres_ARRAY(db):
+    """psycopg2 adapts a bare `list` to `text[]`, which JSONB rejects at runtime.
+
+    Read from the substrate directly rather than through `get_draft`, whose
+    normalisation would hide a wrong storage shape.
+    """
+    draft = _group_draft(db)
+    raw = db.conn.rows("SELECT mentions FROM signal.messages WHERE id = ?",
+                       (draft["id"],))[0]["mentions"]
+    assert json.loads(raw) == MENTIONS_FIXTURE
+
+
+def test_a_mention_free_draft_stores_NULL_and_reads_back_as_an_empty_list(db):
+    """Indistinguishable from every draft written before the column existed."""
+    draft = db.draft_message(recipient=PEER, body="no pings here",
+                             self_number=SELF_NUMBER)
+    raw = db.conn.rows("SELECT mentions FROM signal.messages WHERE id = ?",
+                       (draft["id"],))[0]["mentions"]
+    assert raw is None
+    assert db.get_draft(draft["id"])["mentions"] == []
+    assert draft["mentions"] == []
+
+
+def test_contacts_by_identifiers_matches_uuids_AND_phone_numbers(db):
+    """🔴 members[] is MIXED. Querying one column finds 5 of 7 in the real group."""
+    uid = db.upsert_contact(signal_uuid=ANN_UUID, display_name="Ann")
+    pid = db.upsert_contact(phone_number="+15550777", display_name="Pat")
+    found = db.contacts_by_identifiers([ANN_UUID, "+15550777", OUTSIDER_UUID])
+    assert {r["id"] for r in found} == {uid, pid}
+    assert db.contacts_by_identifiers([]) == []
+
+
+# --------------------------------------------------------------------------- #
+# 4. THE WIRE PAYLOAD
+# --------------------------------------------------------------------------- #
+def _send(db, draft, poster):
+    db.approve_draft(draft["id"], approval_ref="cg-mentions")
+    return db.send_approved(
+        draft["id"],
+        transmit=lambda a, **kw: consumer.transmit_approved(a, poster=poster, **kw))
+
+
+def test_the_send_payload_carries_the_mentions_array_EXACTLY(db):
+    """Exact equality on the whole body, like its mention-free sibling."""
+    draft = _group_draft(db, body="\U0001F415 @Ann look",
+                         mentions=[{"author": ANN_UUID, "start": 3, "length": 4}])
+    poster = Poster()
+    _send(db, draft, poster)
+    assert poster.calls[0]["json"] == {
+        "message": "\U0001F415 @Ann look",
+        "number": SELF_NUMBER,
+        "recipients": [GROUP_ADDRESS],
+        "mentions": [{"author": ANN_UUID, "start": 3, "length": 4}],
+    }
+
+
+def test_each_wire_mention_has_EXACTLY_author_start_length(db):
+    """A fourth key is dropped silently by the server; a missing one mis-renders."""
+    draft = _group_draft(db)
+    poster = Poster()
+    _send(db, draft, poster)
+    for mention in poster.calls[0]["json"]["mentions"]:
+        assert tuple(mention) == _mentions.MENTION_KEYS
+        assert isinstance(mention["author"], str)
+        assert isinstance(mention["start"], int)
+        assert isinstance(mention["length"], int)
+
+
+def test_a_stray_key_on_a_stored_mention_never_reaches_the_wire(db):
+    """The payload is REBUILT from the three fields, not forwarded verbatim."""
+    draft = _group_draft(
+        db, mentions=[{"author": ANN_UUID, "start": 0, "length": 4,
+                       "note": "not part of the wire contract"}])
+    poster = Poster()
+    _send(db, draft, poster)
+    assert poster.calls[0]["json"]["mentions"] == [
+        {"author": ANN_UUID, "start": 0, "length": 4}]
+
+
+def test_a_mention_free_send_carries_NO_mentions_key_at_all(db):
+    """The pre-existing request shape, byte for byte. Nothing new goes on the wire."""
+    draft = db.draft_message(recipient=PEER, body="plain", self_number=SELF_NUMBER)
+    poster = Poster()
+    _send(db, draft, poster)
+    assert poster.calls[0]["json"] == {
+        "message": "plain", "number": SELF_NUMBER, "recipients": [PEER]}
+    assert "mentions" not in poster.calls[0]["json"]
+
+
+# --------------------------------------------------------------------------- #
+# 5. THE CAPABILITY BINDING — approve, mutate, send
+#
+# 🔴 TWO DISTINCT WINDOWS, and only one of them is the one that matters in
+# practice. Both are tested, and they are guarded in different places:
+#
+#   approve -> [WINDOW A] -> send        closed by the APPROVAL DIGEST, checked
+#                                        in `_mint_send_authorization()`
+#   mint    -> [WINDOW B] -> POST        closed by the PAYLOAD BINDING, checked
+#                                        in `spend_authorization()`
+#
+# Window A is the real one: `approve` and `send` are separate CLI invocations,
+# minutes or hours apart, and in between the draft is an ordinary row anything
+# with the connection can rewrite. A capability minted at SEND time out of
+# whatever the row says THEN cannot detect that — it would be comparing the row
+# against itself. That is exactly why the pre-change `auth.recipient` and
+# `auth.body` fields were dead code rather than a guard, and why the fix records
+# a digest at APPROVAL rather than binding harder at send.
+# --------------------------------------------------------------------------- #
+def _tamper(db, draft_id, **columns):
+    """Rewrite a draft row directly, as a second writer would."""
+    for column, value in columns.items():
+        with db.conn.cursor() as cur:
+            cur.execute(f"UPDATE signal.messages SET {column} = %s WHERE id = %s",
+                        (value, draft_id))
+    db.conn.commit()
+
+
+def test_a_draft_mutated_between_approve_and_send_is_REFUSED(db):
+    """🔴 THE REGRESSION TEST. RED on origin/main — measured, not assumed.
+
+    On origin/main this exact sequence transmits: `send_approved()` re-reads the
+    row, mints a capability out of the values it finds, and posts them. The
+    approval was recorded against different text, and nothing compares the two.
+    The witness run on origin/main posted the mutated body under the operator's
+    approval ref.
+
+    WINDOW A. The mutation happens where a real one would — after the human
+    approved and before they (or a scheduler) ran `send` — with no monkeypatching
+    of the code under test.
+    """
+    draft = _group_draft(db, body="@Ann can you review the small one",
+                         mentions=MENTIONS_FIXTURE)
+    db.approve_draft(draft["id"], approval_ref="cg-mutate")
+    _tamper(db, draft["id"], body="@Ann approve the WIRE TRANSFER")
+
+    poster = Poster()
+    with pytest.raises(SendGateError) as exc:
+        db.send_approved(
+            draft["id"],
+            transmit=lambda a, **kw: consumer.transmit_approved(a, poster=poster,
+                                                                **kw))
+    message = str(exc.value)
+    assert "CHANGED after it was approved" in message
+    assert "approve/mutate/send binding" in message
+    assert poster.calls == [], "the tampered body REACHED THE NETWORK"
+    # ... and the draft is left where the operator can see and re-approve it.
+    assert db.get_draft(draft["id"])["send_state"] == _signal_db.STATE_APPROVED
+
+
+def test_a_RE_POINTED_mention_after_approval_is_refused(db):
+    """The same window, on the field that notifies third parties.
+
+    Body and recipient unchanged; only the ping moves, from Ann to Bob. A binding
+    that covered recipient and body alone would let this through — and
+    re-pointing a mention is how an approved message notifies someone who was
+    never on the card the human read.
+    """
+    draft = _group_draft(db, body="@Ann please look", mentions=MENTIONS_FIXTURE)
+    db.approve_draft(draft["id"], approval_ref="cg-repoint")
+    _tamper(db, draft["id"],
+            mentions=json.dumps([{"author": BOB_UUID, "start": 0, "length": 4}]))
+
+    poster = Poster()
+    with pytest.raises(SendGateError) as exc:
+        db.send_approved(
+            draft["id"],
+            transmit=lambda a, **kw: consumer.transmit_approved(a, poster=poster,
+                                                                **kw))
+    assert "CHANGED after it was approved" in str(exc.value)
+    assert poster.calls == []
+
+
+def test_mentions_ADDED_after_approval_are_refused(db):
+    """The nastiest direction: a card that showed NO pings, sent WITH one."""
+    draft = db.draft_message(recipient=GROUP_ADDRESS, body="@Ann fyi",
+                             self_number=SELF_NUMBER)
+    db.approve_draft(draft["id"], approval_ref="cg-added")
+    _tamper(db, draft["id"], mentions=json.dumps(MENTIONS_FIXTURE))
+
+    poster = Poster()
+    with pytest.raises(SendGateError):
+        db.send_approved(
+            draft["id"],
+            transmit=lambda a, **kw: consumer.transmit_approved(a, poster=poster,
+                                                                **kw))
+    assert poster.calls == []
+
+
+def test_a_MOVED_mention_offset_is_refused_even_with_the_same_author(db):
+    """Same person, different span — a different message on screen.
+
+    The digest covers start/length, not just `author`: a mention slid onto other
+    text renders as a ping on words the operator never approved.
+    """
+    draft = _group_draft(db, body="hi @Ann and Ann",
+                         mentions=[{"author": ANN_UUID, "start": 3, "length": 4}])
+    db.approve_draft(draft["id"], approval_ref="cg-moved")
+    _tamper(db, draft["id"],
+            mentions=json.dumps([{"author": ANN_UUID, "start": 11, "length": 4}]))
+    poster = Poster()
+    with pytest.raises(SendGateError):
+        db.send_approved(
+            draft["id"],
+            transmit=lambda a, **kw: consumer.transmit_approved(a, poster=poster,
+                                                                **kw))
+    assert poster.calls == []
+
+
+def test_a_CLEARED_approval_digest_fails_CLOSED(db):
+    """🔴 "No digest" and "digest wiped by the writer we guard against" are the
+    SAME observation, so the absent case must refuse, not pass.
+
+    A guard that only fired on a MISMATCH would be walked by any writer that
+    clears the column along with the body — one `UPDATE` away.
+    """
+    draft = _group_draft(db)
+    db.approve_draft(draft["id"], approval_ref="cg-cleared")
+    _tamper(db, draft["id"], approved_digest=None,
+            body="@Ann approve the WIRE TRANSFER")
+    poster = Poster()
+    with pytest.raises(SendGateError) as exc:
+        db.send_approved(
+            draft["id"],
+            transmit=lambda a, **kw: consumer.transmit_approved(a, poster=poster,
+                                                                **kw))
+    assert "NO approval digest" in str(exc.value)
+    assert poster.calls == []
+
+
+def test_re_approving_the_mutated_draft_is_the_documented_way_out(db):
+    """POSITIVE CONTROL on the refusals above — the operator is not stuck.
+
+    Without this, a binding that refused unconditionally would satisfy every
+    test in this section while making the send path inert.
+    """
+    draft = _group_draft(db)
+    db.approve_draft(draft["id"], approval_ref="cg-recover")
+    _tamper(db, draft["id"], body="@Ann a genuinely revised message")
+    poster = Poster()
+    with pytest.raises(SendGateError):
+        db.send_approved(draft["id"],
+                         transmit=lambda a, **kw: consumer.transmit_approved(
+                             a, poster=poster, **kw))
+    # The operator reads the new text and approves THAT.
+    _reapprove(db, draft["id"], "cg-recover-2")
+    sent = db.send_approved(
+        draft["id"],
+        transmit=lambda a, **kw: consumer.transmit_approved(a, poster=poster,
+                                                            **kw))
+    assert sent["send_state"] == _signal_db.STATE_SENT
+    assert poster.calls[0]["json"]["message"] == "@Ann a genuinely revised message"
+
+
+def _reapprove(db, draft_id, ref):
+    """Approval is `pending`-only, so re-approving means resetting the state first.
+
+    Done through the substrate rather than through `reconcile_send()` because the
+    draft never entered `sending` — the refusal happened before the claim.
+    """
+    with db.conn.cursor() as cur:
+        cur.execute("UPDATE signal.messages SET send_state = %s WHERE id = %s",
+                    (_signal_db.STATE_PENDING, draft_id))
+    db.conn.commit()
+    return db.approve_draft(draft_id, approval_ref=ref)
+
+
+def test_a_payload_mutated_between_MINT_and_POST_is_refused():
+    """WINDOW B, at its own level, with no database in the way.
+
+    Distinct from window A and guarded elsewhere: this is the capability itself
+    refusing to be spent on a payload it was not minted for, which is what stops
+    a caller between `_mint_send_authorization()` and `transmit_approved()` from
+    swapping the arguments.
+    """
+    auth = _signal_db._mint_send_authorization(
+        _approved_row(45, PEER, "the approved text"))
+    poster = Poster()
+    with pytest.raises(SendGateError) as exc:
+        consumer.transmit_approved(auth, recipient=PEER,
+                                   body="a different text",
+                                   number=SELF_NUMBER, poster=poster)
+    assert "does not match what was approved" in str(exc.value)
+    assert poster.calls == []
+
+
+def test_MENTIONS_mutated_between_mint_and_post_are_refused():
+    """Window B on the mentions array specifically."""
+    auth = _signal_db._mint_send_authorization(
+        _approved_row(46, PEER, "hi", mentions=MENTIONS_FIXTURE))
+    poster = Poster()
+    with pytest.raises(SendGateError) as exc:
+        consumer.transmit_approved(
+            auth, recipient=PEER, body="hi", number=SELF_NUMBER, poster=poster,
+            mentions=[{"author": BOB_UUID, "start": 0, "length": 4}])
+    assert "mentions" in str(exc.value)
+    assert BOB_UUID in str(exc.value)
+    assert poster.calls == []
+
+
+def test_transmitting_a_body_the_capability_was_not_minted_for_is_refused():
+    """The binding at its own level, with no database in the way."""
+    auth = _signal_db._mint_send_authorization(
+        _approved_row(41, PEER, "the approved text"))
+    poster = Poster()
+    with pytest.raises(SendGateError) as exc:
+        consumer.transmit_approved(auth, recipient=PEER, body="a different text",
+                                   number=SELF_NUMBER, poster=poster)
+    assert "does not match what was approved" in str(exc.value)
+    assert poster.calls == []
+
+
+def test_transmitting_to_a_recipient_the_capability_was_not_minted_for_is_refused():
+    auth = _signal_db._mint_send_authorization(
+        _approved_row(42, PEER, "hi"))
+    poster = Poster()
+    with pytest.raises(SendGateError) as exc:
+        consumer.transmit_approved(auth, recipient="+15550999", body="hi",
+                                   number=SELF_NUMBER, poster=poster)
+    assert "recipient" in str(exc.value)
+    assert poster.calls == []
+
+
+def test_a_REFUSED_payload_does_NOT_spend_the_capability():
+    """🔴 A mismatch is a refusal, not a consumed attempt.
+
+    Burning the nonce would strand a draft that nothing is wrong with. Proven by
+    sending the CORRECT payload afterwards with the same capability and watching
+    it succeed — a spent nonce would refuse with the single-use wording instead.
+    """
+    auth = _signal_db._mint_send_authorization(
+        _approved_row(43, PEER, "the approved text"))
+    poster = Poster()
+    with pytest.raises(SendGateError):
+        consumer.transmit_approved(auth, recipient=PEER, body="wrong",
+                                   number=SELF_NUMBER, poster=poster)
+    consumer.transmit_approved(auth, recipient=PEER, body="the approved text",
+                               number=SELF_NUMBER, poster=poster)
+    assert len(poster.calls) == 1
+
+
+def test_the_matching_payload_still_sends_end_to_end(db):
+    """POSITIVE CONTROL for every refusal above: the happy path is unbroken.
+
+    Without this, a binding that refused EVERYTHING would satisfy the whole
+    section — every mismatch test would pass and the feature would be inert.
+    """
+    draft = _group_draft(db)
+    poster = Poster()
+    sent = _send(db, draft, poster)
+    assert sent["send_state"] == _signal_db.STATE_SENT
+    assert len(poster.calls) == 1
+    assert poster.calls[0]["json"]["mentions"] == MENTIONS_FIXTURE
+
+
+def test_canonical_mentions_treats_none_and_empty_as_the_same_thing():
+    assert _mentions.canonical_mentions(None) == ()
+    assert _mentions.canonical_mentions([]) == ()
+    a = [{"author": ANN_UUID, "start": 0, "length": 4}]
+    b = [{"author": BOB_UUID, "start": 0, "length": 4}]
+    assert _mentions.canonical_mentions(a) != _mentions.canonical_mentions(b)
+    # ORDER matters: two mentions swapped is a different wire message.
+    assert _mentions.canonical_mentions(a + b) != _mentions.canonical_mentions(b + a)
+
+
+def test_spend_authorization_cannot_be_called_without_the_payload():
+    """🔴 The seam, closed MECHANICALLY rather than by convention.
+
+    The three binding arguments are required keywords with no defaults, so a
+    call site cannot opt out of the check by omitting them — which is exactly
+    how the old `spend_authorization(auth)` shape let the payload go unbound.
+    """
+    auth = _signal_db._mint_send_authorization(
+        _approved_row(44, PEER, "x"))
+    with pytest.raises(TypeError):
+        _signal_db.spend_authorization(auth)
+
+
+# --------------------------------------------------------------------------- #
+# 6. THE RESOLUTION SEAM — CLI -> group API -> contacts -> mentions
+# --------------------------------------------------------------------------- #
+def test_resolve_draft_mentions_joins_the_group_API_to_the_contacts_table(db):
+    """End to end through the seam, with the network injected.
+
+    The three pieces are each tested above IN ISOLATION; this is the case none of
+    them can see — that the membership the API returns is the set the contacts
+    lookup is scoped to.
+    """
+    db.upsert_contact(signal_uuid=ANN_UUID, display_name="Ann")
+    db.upsert_contact(signal_uuid=BOB_UUID, display_name="Bob")
+    calls = []
+
+    def fetcher(number, address):
+        calls.append((number, address))
+        return [ANN_UUID, BOB_UUID]
+
+    out = consumer.resolve_draft_mentions(
+        db, recipient=GROUP_ADDRESS, body="@Ann and @Bob", identifiers=["Bob"],
+        number=SELF_NUMBER, member_fetcher=fetcher)
+    assert out == [{"author": BOB_UUID, "start": 9, "length": 4}]
+    assert calls == [(SELF_NUMBER, GROUP_ADDRESS)]
+
+
+def test_no_mentions_means_NO_group_api_call_at_all(db):
+    """The unchanged path stays unchanged — and stays offline."""
+    def fetcher(number, address):  # pragma: no cover - must never run
+        raise AssertionError("the group API was called for a mention-free draft")
+
+    assert consumer.resolve_draft_mentions(
+        db, recipient=GROUP_ADDRESS, body="hi", identifiers=[],
+        number=SELF_NUMBER, member_fetcher=fetcher) == []
+
+
+def test_a_non_group_recipient_is_refused_WITHOUT_a_membership_fetch(db):
+    """The URL would be built out of a phone number; the error must name the truth."""
+    def fetcher(number, address):  # pragma: no cover - must never run
+        raise AssertionError("a membership fetch was attempted for a person")
+
+    with pytest.raises(MentionsRequireAGroup):
+        consumer.resolve_draft_mentions(
+            db, recipient=PEER, body="hi @Ann", identifiers=["Ann"],
+            number=SELF_NUMBER, member_fetcher=fetcher)
+
+
+@pytest.mark.parametrize("detail,expected", [
+    ({"members": [ANN_UUID, DEE_NUMBER]}, [ANN_UUID, DEE_NUMBER]),
+    ([{"members": [ANN_UUID]}], [ANN_UUID]),
+    ({"members": [{"uuid": ANN_UUID, "number": None},
+                  {"uuid": None, "number": DEE_NUMBER}]}, [ANN_UUID, DEE_NUMBER]),
+    ({"members": []}, []),
+    ({}, []),
+])
+def test_fetch_group_members_flattens_every_shape_the_server_returns(detail,
+                                                                    expected):
+    """Two reply shapes and two member shapes, like `_normalize_send_response`.
+
+    NOT a claim about which one the deployed server sends — it is a claim that
+    none of them silently produces a WRONG membership, which would become a
+    resolution error rather than a crash.
+    """
+    seen = {}
+
+    def getter(url, timeout=None):
+        seen["url"] = url
+        return types.SimpleNamespace(raise_for_status=lambda: None,
+                                     json=lambda: detail)
+
+    assert consumer.fetch_group_members(SELF_NUMBER, GROUP_ADDRESS,
+                                        getter=getter,
+                                        api_url="http://api") == expected
+    assert seen["url"].startswith("http://api/v1/groups/")
+
+
+def test_fetch_group_members_url_encodes_the_group_id():
+    """A group `id` is base64 and can contain `/` and `+`. Unencoded, it breaks the path."""
+    seen = {}
+
+    def getter(url, timeout=None):
+        seen["url"] = url
+        return types.SimpleNamespace(raise_for_status=lambda: None,
+                                     json=lambda: {"members": []})
+
+    address = "group." + base64.b64encode(b"\xff\xfe" * 16).decode()
+    consumer.fetch_group_members(SELF_NUMBER, address, getter=getter,
+                                 api_url="http://api")
+    assert "/" not in seen["url"].split("/v1/groups/")[1].split("/")[1]
+    assert "+" not in seen["url"].rsplit("/", 1)[1]
+
+
+def test_fetch_group_members_is_a_GET_not_a_send():
+    """🔴 This module has ONE door to the network that writes; this is not it."""
+    src = Path(consumer.__file__).read_text(encoding="utf-8")
+    body = src.split("def fetch_group_members(")[1].split("\ndef ")[0]
+    assert "SEND_PATH" not in body
+    assert "requests.get" in " ".join(body.split())
+
+
+# --------------------------------------------------------------------------- #
+# 7. THE APPROVAL CARD — the operator has to SEE who gets pinged
+# --------------------------------------------------------------------------- #
+def test_the_clawgate_card_names_every_person_the_message_will_ping():
+    """🔴 Approving a message without seeing who it notifies is the failure mode.
+
+    `@Ann` in the preview is indistinguishable from ordinary prose — it IS
+    ordinary prose until the `mentions` array turns it into a notification that
+    bypasses Ann's mute settings. So the resolved ids go on the card explicitly.
+    """
+    payload = clawgate.build_draft_payload(
+        draft_id=31, recipient=GROUP_ADDRESS, body="@Ann please look",
+        mentions=[{"author": ANN_UUID, "start": 0, "length": 4},
+                  {"author": DEE_NUMBER, "start": 0, "length": 4}])
+    body = payload["body"]
+    assert ANN_UUID in body
+    assert DEE_NUMBER in body
+    assert "mute settings" in body
+    assert "PINGS 2 member(s)" in body
+
+
+def test_the_card_shape_is_unchanged_and_still_hands_over_no_command():
+    """The pre-existing exact assertion, kept exact, now with mentions present."""
+    payload = clawgate.build_draft_payload(
+        draft_id=23, recipient=GROUP_ADDRESS, body="the drafted text",
+        mentions=[{"author": ANN_UUID, "start": 0, "length": 4}])
+    assert set(payload) == {"directory", "body"}
+    assert "the drafted text" in payload["body"]
+    assert "#23" in payload["body"]
+    for runnable in ("consumer.py", "--ref", "approve 23", "send 23"):
+        assert runnable not in payload["body"], f"the card hands over {runnable!r}"
+
+
+def test_a_mention_free_card_says_nothing_about_pings():
+    """No warning where there is nothing to warn about — a warning that always
+    fires is one nobody reads."""
+    payload = clawgate.build_draft_payload(draft_id=24, recipient=PEER,
+                                           body="a plain message")
+    assert "PINGS" not in payload["body"]
+    assert "mute settings" not in payload["body"]

--- a/scripts/signal/tests/test_mentions.py
+++ b/scripts/signal/tests/test_mentions.py
@@ -1010,11 +1010,69 @@ def test_unapprove_refuses_anything_that_is_not_approved(db):
 
 def test_unapprove_does_not_erase_the_approval_ref_when_given_no_note(db):
     """The audit record of the approval the attempt rode on is ADDED to, never
-    replaced — the same COALESCE `reconcile_send` needed."""
+    replaced. GREEN at 9fb6de75 — this half always worked."""
     draft = _group_draft(db)
     db.approve_draft(draft["id"], approval_ref="clawgate-task-777")
     db.unapprove_draft(draft["id"])
     assert db.get_draft(draft["id"])["approval_ref"] == "clawgate-task-777"
+
+
+def test_unapprove_WITH_A_NOTE_appends_rather_than_erasing_the_approval_ref(db):
+    """🔴 RED at 9fb6de75 — it returned the bare note. Round-2 audit F3.
+
+    THE DOCUMENTED USAGE. `SKILL.md` tells the operator to run
+    `unapprove 42 --note "body was edited after approval"` after a refused send,
+    and `COALESCE(%s, approval_ref)` returns its FIRST non-null argument — so
+    the note REPLACED `clawgate-task-778`, destroying the audit record of the
+    approval that the refused attempt rode on, in the exact scenario the command
+    exists for. The docstring above the SQL said the trail was "added to, never
+    erased".
+
+    The test that shipped with the command only exercised the no-note path while
+    its docstring claimed the property for both. This is the note path.
+    """
+    draft = _group_draft(db)
+    db.approve_draft(draft["id"], approval_ref="clawgate-task-778")
+    db.unapprove_draft(draft["id"], note="body was edited after approval")
+    ref = db.get_draft(draft["id"])["approval_ref"]
+    assert ref == ("clawgate-task-778" + _signal_db.APPROVAL_REF_SEPARATOR
+                   + "body was edited after approval")
+    # BOTH halves named, so an implementation that keeps only one cannot pass.
+    assert "clawgate-task-778" in ref
+    assert "body was edited after approval" in ref
+    # 🔴 The separator is pinned as a LITERAL here, once. Every other assertion
+    # in this file builds its expectation FROM `APPROVAL_REF_SEPARATOR`, so a
+    # mutant that empties it would weld two entries into `"cg-778body was …"`
+    # and survive them all — the constant cannot check itself.
+    assert _signal_db.APPROVAL_REF_SEPARATOR == " | "
+
+
+def test_the_trail_appends_WITHIN_a_cycle_and_a_fresh_approve_RESETS_it(db):
+    """🔴 THE EXACT SCOPE OF "APPEND ONLY", stated so nothing wider is claimed.
+
+    `unapprove` and `reconcile` APPEND — that is F3, and it is what makes the
+    approval a refused attempt rode on survivable. `approve_draft` still writes
+    `approval_ref = %s`, i.e. it RESETS: a new approval is a new decision under a
+    new clawgate reference, and `SKILL.md` documents it that way. So the column
+    accumulates within one approve→withdraw cycle and starts over at the next
+    `approve`. NOT changed here — the audit asked for the append, not for an
+    unbounded log in a single TEXT column.
+
+    RED at 9fb6de75 on the second assertion (it read `"note-2"` alone, the
+    reference erased). The first is an INVARIANT GUARD on the reset, green there.
+    """
+    draft = _group_draft(db)
+    db.approve_draft(draft["id"], approval_ref="cg-1")
+    db.unapprove_draft(draft["id"], note="note-1")
+    assert db.get_draft(draft["id"])["approval_ref"] == (
+        "cg-1" + _signal_db.APPROVAL_REF_SEPARATOR + "note-1")
+
+    db.approve_draft(draft["id"], approval_ref="cg-2")
+    assert db.get_draft(draft["id"])["approval_ref"] == "cg-2", \
+        "a fresh approve opens a new decision and REPLACES the reference"
+    db.unapprove_draft(draft["id"], note="note-2")
+    assert db.get_draft(draft["id"])["approval_ref"] == (
+        "cg-2" + _signal_db.APPROVAL_REF_SEPARATOR + "note-2")
 
 
 # --- finding 2: the digest bound a RENDERED PROJECTION ---------------------- #
@@ -1181,16 +1239,27 @@ def test_a_mention_at_the_very_END_of_the_body_still_matches():
 def test_OVERLAPPING_spans_are_refused_with_their_own_error():
     """🔴 Boundary-legal and still overlapping. Red at 182c3280 (it sent both).
 
-    Members `Ann` and `Ann Smith`, body `"@Ann Smith please"`. `@Ann` is followed
-    by a SPACE, so the word boundary is satisfied — and the two spans are (0,4)
-    and (0,10). Two rewrites of the same characters; what the recipient renders
-    is undefined.
+    ONE person carrying TWO stored names — `display_name="Ann"` and
+    `profile_name="Ann Smith"` — and a body `"@Ann Smith please"`. `@Ann` is
+    followed by a SPACE, so the word boundary is satisfied, and the two spans
+    are (0,4) and (0,10). Two rewrites of the same characters; what the
+    recipient renders is undefined.
+
+    🔴 THE FIXTURE MOVED, AND THE REASON MATTERS. It used to give the two names
+    to two DIFFERENT members. Round-2 audit F2 made a name that is a prefix of
+    another MEMBER's name refuse earlier and more precisely, as
+    `MentionSpanMissing` — see
+    `test_a_member_whose_name_is_a_SPACE_separated_prefix_of_another_members_is_refused`,
+    which pins that. `_colliding_needles()` deliberately does NOT veto a
+    person's own longer name against their own ping, so the same-author shape
+    still reaches this guard — and it is a real one: a promoted contact really
+    can carry both a display name and a longer profile name.
     """
     contacts = [
         {"signal_uuid": ANN_UUID, "phone_number": None, "display_name": "Ann",
-         "profile_name": None, "is_placeholder": False},
+         "profile_name": "Ann Smith", "is_placeholder": False},
         {"signal_uuid": BOB_UUID, "phone_number": None,
-         "display_name": "Ann Smith", "profile_name": None,
+         "display_name": "Bob", "profile_name": None,
          "is_placeholder": False},
     ]
     with pytest.raises(_mentions.MentionSpansOverlap) as exc:
@@ -1246,6 +1315,143 @@ def test_case_insensitive_matching_did_not_break_the_utf16_offsets():
     assert body.casefold().find("@ann") == 11, "and .casefold() shifts it further"
     assert _resolve(["ann"], body) == [
         {"author": ANN_UUID, "start": 9, "length": 4}]
+
+
+# --- round-2 F1: the cursor was case-SENSITIVE, the matcher case-INSENSITIVE - #
+def test_two_DIFFERENTLY_CASED_mentions_of_one_person_take_SUCCESSIVE_spans():
+    """🔴 RED at 9fb6de75 with `MentionSpansOverlap`. Round-2 audit F1.
+
+    `_needle_pattern` compiles with `re.IGNORECASE`, but `resolve_mentions`
+    keyed its per-needle search cursor on the RAW `"@" + ident`. `--mention Ann
+    --mention ANN` therefore created TWO dict entries, both starting from
+    cursor 0, and both matched the SAME first occurrence — two identical spans,
+    which the overlap guard then refused with "Give each mention its own `@who`
+    text in --body" while the body already had two distinct ones.
+
+    A draft that WORKED at 182c3280 (`[(3,4), (12,4)]`) was refused at
+    9fb6de75, so this is a regression test, not an invariant guard. The two
+    spans are pinned as literals: an implementation that folds the key but not
+    the cursor arithmetic cannot make these numbers agree.
+    """
+    out = _resolve(["Ann", "ANN"], "hi @Ann and @ANN ok")
+    assert out == [{"author": ANN_UUID, "start": 3, "length": 4},
+                   {"author": ANN_UUID, "start": 12, "length": 4}]
+
+
+def test_the_case_folded_cursor_still_REFUSES_when_there_is_only_one_occurrence():
+    """The fold must move the cursor, not disable it.
+
+    A key-folding change that also stopped ADVANCING the cursor would make the
+    test above pass and silently point two mentions at one `@Ann` again. With
+    only one occurrence in the body the second `--mention` must still run out of
+    text.
+
+    RED at 9fb6de75 — MEASURED, not assumed: it raised `MentionSpansOverlap`
+    there, because both mentions claimed span (3,4). The refusal was right by
+    accident and for the wrong reason; the class asserted here is the one that
+    says what is actually wrong with the draft.
+    """
+    with pytest.raises(MentionSpanMissing):
+        _resolve(["Ann", "ANN"], "hi @Ann ok")
+
+
+# --- round-2 F2: `(?!\w)` is narrower than "a prefix of another member" ----- #
+@pytest.mark.parametrize("other_name, body", [
+    ("Ann-Marie", "hi @Ann-Marie ok"),
+    ("Ann.Smith", "hi @Ann.Smith ok"),
+    ("Ann'Marie", "hi @Ann'Marie ok"),
+])
+def test_a_PUNCTUATED_member_name_no_longer_steals_a_shorter_members_ping(
+        other_name, body):
+    """🔴 RED at 9fb6de75 — it returned `{author: Ann, start: 3, length: 4}`.
+
+    Round-2 audit F2. `(?!\\w)` blocks only WORD characters, so a hyphen, a dot
+    or an apostrophe in another member's name satisfied the boundary and
+    `--mention Ann` landed on the first four characters of THEIR name: Ann is
+    pinged, the text on screen is corrupted mid-word, and nothing refused. That
+    is the exact failure the boundary docstring claimed to have removed.
+
+    Parametrised over three separators on purpose — a fix that special-cases the
+    hyphen passes one case and fails the other two.
+    """
+    contacts = [
+        {"signal_uuid": ANN_UUID, "phone_number": None, "display_name": "Ann",
+         "profile_name": None, "is_placeholder": False},
+        {"signal_uuid": BOB_UUID, "phone_number": None,
+         "display_name": other_name, "profile_name": None,
+         "is_placeholder": False},
+    ]
+    with pytest.raises(MentionSpanMissing) as exc:
+        _resolve(["Ann"], body, members=[ANN_UUID, BOB_UUID], contacts=contacts)
+    assert "another member's name" in str(exc.value)
+
+    # POSITIVE CONTROL, same fixture: the LONGER name is still mentionable, and
+    # a real `@Ann` later in the same body is still found. Without these two a
+    # `raise MentionSpanMissing` at the top of `find_span` would pass the above.
+    assert _resolve([other_name], body, members=[ANN_UUID, BOB_UUID],
+                    contacts=contacts) == [
+        {"author": BOB_UUID, "start": 3, "length": len(other_name) + 1}]
+    assert _resolve(["Ann"], body.replace(" ok", " and @Ann ok"),
+                    members=[ANN_UUID, BOB_UUID], contacts=contacts) == [
+        {"author": ANN_UUID, "start": len(other_name) + 9, "length": 4}]
+
+
+def test_a_member_whose_name_is_a_SPACE_separated_prefix_of_another_members_is_refused():
+    """🔴 RED at 9fb6de75 — it SENT `{author: Ann, start: 0, length: 4}`.
+
+    The space-separated case of the same defect, and the one the old
+    `test_OVERLAPPING_spans_are_refused_with_their_own_error` fixture only ever
+    caught when BOTH names were mentioned. With `--mention Ann` alone against
+    members `Ann` and `Ann Smith` and a body `"@Ann Smith please"`, 9fb6de75
+    returned a span over `Ann Smith`'s first four characters with no refusal at
+    all — the overlap guard never ran, because there was only one mention.
+    """
+    contacts = [
+        {"signal_uuid": ANN_UUID, "phone_number": None, "display_name": "Ann",
+         "profile_name": None, "is_placeholder": False},
+        {"signal_uuid": BOB_UUID, "phone_number": None,
+         "display_name": "Ann Smith", "profile_name": None,
+         "is_placeholder": False},
+    ]
+    with pytest.raises(MentionSpanMissing):
+        _resolve(["Ann"], "@Ann Smith please", members=[ANN_UUID, BOB_UUID],
+                 contacts=contacts)
+
+
+def test_a_members_OWN_longer_name_does_not_veto_their_own_ping():
+    """🔴 The collision rule must be scoped to OTHER authors.
+
+    One contact carrying `display_name="Ann"` and `profile_name="Ann Smith"` is
+    ONE person — a routine shape after `_promote_placeholder()` learns a profile
+    name. A collision rule that ignored authorship would refuse `--mention Ann`
+    against `"@Ann Smith please"` on the strength of that person's own other
+    name, i.e. refuse a ping at the very person who was asked for.
+
+    GREEN at 9fb6de75 (no collision rule existed) — an INVARIANT GUARD on the
+    new rule's scope, not regression coverage.
+    """
+    contacts = [
+        {"signal_uuid": ANN_UUID, "phone_number": None, "display_name": "Ann",
+         "profile_name": "Ann Smith", "is_placeholder": False},
+    ]
+    assert _resolve(["Ann"], "@Ann Smith please", members=[ANN_UUID],
+                    contacts=contacts) == [
+        {"author": ANN_UUID, "start": 0, "length": 4}]
+
+
+def test_ordinary_punctuation_after_a_mention_still_matches():
+    """🔴 The collision rule is MEMBER-AWARE, not a wider punctuation ban.
+
+    Refusing every non-word character after the needle would have been the cheap
+    fix, and it breaks ordinary English: `"thanks @Ann."` and `"@Ann-please"`
+    have no colliding member behind them and must still resolve. This is the
+    negative control that separates "member-aware" from "punctuation-phobic".
+
+    GREEN at 9fb6de75 — an INVARIANT GUARD, not regression coverage.
+    """
+    for body, start in [("thanks @Ann.", 7), ("@Ann-please", 0), ("@Ann's dog", 0)]:
+        assert _resolve(["Ann"], body) == [
+            {"author": ANN_UUID, "start": start, "length": 4}], body
 
 
 # --- finding 5: refusal messages leaked the whole group roster -------------- #

--- a/scripts/signal/tests/test_mentions.py
+++ b/scripts/signal/tests/test_mentions.py
@@ -1854,3 +1854,191 @@ def test_utf16_span_FORWARDS_avoid_so_it_really_is_one_matching_rule():
     body = "@Ann Smith and @Ann ok"
     assert _mentions.utf16_span(body, "@Ann") == (0, 4)
     assert _mentions.utf16_span(body, "@Ann", avoid=["@Ann Smith"]) == (15, 4)
+
+
+# --------------------------------------------------------------------------- #
+# ROUND-4 delta audit
+# --------------------------------------------------------------------------- #
+# --- F-A: two REAL rows sharing a number are TWO PEOPLE --------------------- #
+def test_two_REAL_rows_sharing_a_number_are_TWO_people_not_one():
+    """🔴 RED at fbeca469 — and red by SENDING, not by refusing. Round-4 F-A.
+
+    THE ONLY DEFECT IN FOUR AUDIT ROUNDS THAT PRODUCED A WRONG SEND. Round-3's
+    own fix unioned contact rows on ANY shared identifier, and
+    `signal.contacts.phone_number` is plain `TEXT` with no UNIQUE constraint —
+    so the two real rows below read as ONE person, person B's longer name
+    stopped vetoing, and `--mention Ann` against a body whose visible text is
+    `@Ann Smith` emitted `{'author': uuidA, 'start': 0, 'length': 4}`: a ping
+    for A under B's name on screen.
+
+    The assertion is the REFUSAL, because that is what the module promises —
+    "every failure here is a REFUSAL, never a drop". Measured at fbeca469 this
+    raised nothing at all and returned that mention, so the failure mode this
+    pins is a send, not a wrong exception class.
+    """
+    number = "+15550777"
+    contacts = [
+        {"signal_uuid": ANN_UUID, "phone_number": number, "display_name": "Ann",
+         "profile_name": None, "is_placeholder": False},
+        {"signal_uuid": BOB_UUID, "phone_number": number, "display_name": None,
+         "profile_name": "Ann Smith", "is_placeholder": False},
+    ]
+    with pytest.raises(MentionSpanMissing):
+        _resolve(["Ann"], "@Ann Smith please", members=[number, ANN_UUID, BOB_UUID],
+                 contacts=contacts)
+
+
+def test_the_TWO_REAL_ROW_shape_is_what_the_public_upsert_API_really_produces(db):
+    """🔴 The F-A fixture is not invented — `SignalDB` builds it in three calls.
+
+    No SQL. An envelope teaches a real row a number; a SECOND envelope carries a
+    DIFFERENT uuid with the SAME number (number recycling, or a number change
+    Signal has not reconciled). `_promote_placeholder()` only ever touches
+    `is_placeholder` rows, so it declines silently and the insert lands a second
+    REAL row. Both carry the number; neither is a placeholder.
+
+    MIXED and measured that way: the three `assert` lines on the rows are GREEN
+    at fbeca469 — an INVARIANT GUARD proving the shape is reachable from the
+    public API, not regression coverage. The final `resolve_mentions` assertion
+    is RED at fbeca469 (it returned a mention for ANN_UUID); it is here so both
+    halves are joined in ONE run rather than reasoned about across two.
+    """
+    number = "+15550777"
+    db.upsert_contact(signal_uuid=ANN_UUID, phone_number=number, display_name="Ann")
+    db.upsert_contact(signal_uuid=BOB_UUID, phone_number=number,
+                      profile_name="Ann Smith")
+    rows = db.contacts_by_identifiers([number, ANN_UUID, BOB_UUID])
+    assert len(rows) == 2, f"expected two REAL rows on one number, got {rows!r}"
+    assert {r["phone_number"] for r in rows} == {number}
+    assert sorted(bool(r["is_placeholder"]) for r in rows) == [False, False], \
+        "neither row is a placeholder — that is the whole point of this shape"
+    with pytest.raises(MentionSpanMissing):
+        _mentions.resolve_mentions(
+            ["Ann"], body="@Ann Smith please",
+            members=[number, ANN_UUID, BOB_UUID], contacts=rows, is_group=True)
+
+
+# --- F-B: the de-duplication predicate, consolidated ----------------------- #
+def test_one_person_with_a_real_AND_a_placeholder_row_is_NOT_ambiguous():
+    """🔴 RED at fbeca469 — `MentionNameAmbiguous`. Round-4 F-B.
+
+    `_resolve_one()` de-duplicated its name matches on `_contact_author()`, a
+    per-ROW string, while the comment above it claimed identity. On the durable
+    two-row split — the same one `_colliding_needles()` was fixed for in round 3
+    and which the sibling test above proves the public API produces — ONE person
+    was refused as TWO. Worse, the remedy the message offered ("pass the bare
+    uuid") was half wrong: one of the two ids it printed is the synthetic
+    placeholder uuid, which is not in the membership, so following the advice
+    lands on `MentionNotAMember`.
+
+    Now both sites ask `_identity_groups()`, and the REAL row wins the group, so
+    the author on the wire is a real Signal id rather than the synthetic one.
+    """
+    number = "+15550777"
+    contacts = [
+        {"signal_uuid": ANN_UUID, "phone_number": number, "display_name": "Ann",
+         "profile_name": None, "is_placeholder": False},
+        {"signal_uuid": _signal_db.placeholder_uuid(number),
+         "phone_number": number, "display_name": None, "profile_name": "Ann",
+         "is_placeholder": True},
+    ]
+    assert _resolve(["Ann"], "@Ann hi", members=[number, BOB_UUID],
+                    contacts=contacts) == [
+        {"author": ANN_UUID, "start": 0, "length": 4}]
+
+
+def test_the_F_B_shape_too_is_what_the_public_upsert_API_produces(db):
+    """The same three ordinary `upsert_contact()` calls, both rows named 'Ann'.
+
+    RED at fbeca469 on the final assertion, for the same reason as the test
+    above; the row assertions are GREEN there — INVARIANT GUARDS that the state
+    is reachable without SQL.
+    """
+    number = "+15550777"
+    db.upsert_contact(signal_uuid=ANN_UUID, display_name="Ann")
+    db.upsert_contact(phone_number=number, profile_name="Ann")
+    db.upsert_contact(signal_uuid=ANN_UUID, phone_number=number)
+    rows = db.contacts_by_identifiers([number, ANN_UUID])
+    assert len(rows) == 2 and sorted(bool(r["is_placeholder"]) for r in rows) \
+        == [False, True]
+    assert _mentions.resolve_mentions(
+        ["Ann"], body="@Ann hi", members=[number, BOB_UUID], contacts=rows,
+        is_group=True) == [{"author": ANN_UUID, "start": 0, "length": 4}]
+
+
+def test_two_DIFFERENT_people_answering_to_one_name_are_STILL_ambiguous():
+    """The negative control on F-B: identity-aware must not become blind.
+
+    Bob and Cai share a display name and share NO identifier. A consolidation
+    that collapsed everything into one group would pass the F-B test above and
+    silently start picking one of two strangers to ping.
+
+    GREEN at fbeca469 — an INVARIANT GUARD, not regression coverage. It is here
+    because the fix REPLACES the de-duplication key rather than adding to it.
+    """
+    with pytest.raises(MentionNameAmbiguous) as exc:
+        _resolve(["Bob"], "hello @Bob")
+    message = str(exc.value)
+    assert "matches 2 members" in message
+    assert BOB_UUID in message and CAI_UUID in message, (
+        "the refusal must print ids the caller can actually pass back")
+
+
+def test_a_name_carried_ONLY_by_the_placeholder_row_is_STILL_refused():
+    """The other negative control: consolidation must not launder a placeholder.
+
+    Preferring the REAL row inside an identity group is only safe while a group
+    whose MATCH is a placeholder still refuses. Here the two rows are the same
+    person (the durable split above), but `Ann Smith` is stored only on the
+    synthetic row — so the only thing the name resolves to is a placeholder, and
+    the answer must stay `MentionResolvesToPlaceholder` rather than quietly
+    borrowing the real row's uuid or putting the synthetic one on the wire.
+
+    GREEN at fbeca469 — an INVARIANT GUARD, not regression coverage.
+    """
+    number = "+15550777"
+    contacts = [
+        {"signal_uuid": ANN_UUID, "phone_number": number, "display_name": "Ann",
+         "profile_name": None, "is_placeholder": False},
+        {"signal_uuid": _signal_db.placeholder_uuid(number),
+         "phone_number": number, "display_name": None,
+         "profile_name": "Ann Smith", "is_placeholder": True},
+    ]
+    with pytest.raises(MentionResolvesToPlaceholder):
+        _resolve(["Ann Smith"], "@Ann Smith hi", members=[number, BOB_UUID],
+                 contacts=contacts)
+
+
+# --- F-C: the name-hint cap was uncovered ---------------------------------- #
+def test_the_name_hint_cap_is_a_LITERAL_five_not_whatever_the_module_says():
+    """🔴 Round-4 F-C. `NAME_HINT_MAX = 5 -> 4` SURVIVED all 908 tests.
+
+    GREEN at fbeca469 — an INVARIANT GUARD on a constant nothing had pinned, not
+    regression coverage: no behaviour changed, a hole in the coverage was
+    closed. Its evidence is the MUTANT it now kills (MEN12), which the round-4
+    audit measured surviving the whole suite.
+
+    The neighbouring truncation test derives its expectation from
+    `_mentions.NAME_HINT_MAX` itself, so it agrees with any value the module
+    happens to hold — a test that cannot disagree with the implementation it
+    tests. This one pins the LITERAL, because the constant is a privacy budget:
+    `draft` needs no approval token, so this refusal is a free, repeatable probe
+    and the cap is the only thing bounding how much of a guessed group's roster
+    it enumerates. Drift in either direction should be a deliberate edit here.
+
+    Both halves are asserted from literals — five names printed, seven withheld
+    out of twelve — so a changed cap cannot make the test agree with itself.
+    """
+    assert _mentions.NAME_HINT_MAX == 5
+    many = [{"signal_uuid": f"{i:08d}-1111-4111-8111-111111111111",
+             "phone_number": None, "display_name": f"Member{i:02d}",
+             "profile_name": None, "is_placeholder": False}
+            for i in range(12)]
+    with pytest.raises(MentionNameNotFound) as exc:
+        _resolve(["Zoe"], "hi @Zoe",
+                 members=[c["signal_uuid"] for c in many], contacts=many)
+    message = str(exc.value)
+    printed = [c["display_name"] for c in many
+               if c["display_name"].lower() in message]
+    assert len(printed) == 5, printed
+    assert "+7 not shown" in message

--- a/scripts/signal/tests/test_mentions.py
+++ b/scripts/signal/tests/test_mentions.py
@@ -1660,3 +1660,197 @@ def test_a_failed_group_lookup_exits_3_from_main_and_drafts_NOTHING(db, monkeypa
     assert consumer.main(["draft", "--to", GROUP_ADDRESS, "--body", "@Ann hi",
                           "--from-number", "", "--mention", "Ann"]) == 3
     assert db.conn.count("messages") == before, "a draft was left behind"
+
+
+# --------------------------------------------------------------------------- #
+# Round-3 delta audit
+# --------------------------------------------------------------------------- #
+# F1: the CURSOR's fold and the MATCHER's fold were two DIFFERENT equivalence
+# relations. `casefold()` and `re.IGNORECASE` disagree in BOTH directions, so
+# the cursor merged needles the matcher keeps apart and split needles the
+# matcher treats as one. Both arms are measured below against the SAME two
+# unicode pairs, which is what makes the disagreement audible.
+#
+#     '@ß'.casefold() == '@ss'.casefold()               -> True   (over-merge)
+#     re.search(re.escape('@ß'), '@ss', IGNORECASE)     -> None
+#     '@İstanbul'.casefold() != '@istanbul'.casefold()  ->        (under-merge)
+#     re.search(re.escape('@İstanbul'), '@istanbul', I) -> match
+# --------------------------------------------------------------------------- #
+SS_UUID = "44444444-4444-4444-8444-444444444444"
+ESZETT_UUID = "55555555-5555-4555-8555-555555555555"
+IST_DOTTED_UUID = "66666666-6666-4666-8666-666666666666"
+IST_PLAIN_UUID = "77777777-7777-4777-8777-777777777777"
+
+
+def test_the_cursor_does_NOT_merge_two_needles_the_MATCHER_keeps_APART():
+    """🔴 RED at d05a5e7e — `MentionSpanMissing`. Round-3 audit F1, over-merge arm.
+
+    Members `ss` and `ß`. `'@ß'.casefold() == '@ss'.casefold()`, so the
+    casefolded cursor key made these ONE needle and the second lookup started
+    after the first one's match — but the matcher, `re.escape` + `IGNORECASE`,
+    does NOT consider them equal (Python's `re` folds ONE code point at a time
+    and never expands `ß` to `ss`). So `--mention ss --mention ß` against a body
+    holding both, with `@ss` occurring AFTER `@ß`, searched for `@ß` from past
+    the end of the `@ss` match and refused a body that plainly contains it.
+
+    ORDER-DEPENDENT, which is why the fixture puts `@ß` FIRST in the body and
+    `ss` first on the command line: swap either and the bug hides.
+    """
+    contacts = [
+        {"signal_uuid": SS_UUID, "phone_number": None, "display_name": "ss",
+         "profile_name": None, "is_placeholder": False},
+        {"signal_uuid": ESZETT_UUID, "phone_number": None, "display_name": "ß",
+         "profile_name": None, "is_placeholder": False},
+    ]
+    body = "hi @ß and @ss ok"
+    assert _resolve(["ss", "ß"], body, members=[SS_UUID, ESZETT_UUID],
+                    contacts=contacts) == [
+        {"author": SS_UUID, "start": 10, "length": 3},
+        {"author": ESZETT_UUID, "start": 3, "length": 2},
+    ]
+
+
+def test_the_cursor_DOES_merge_two_needles_the_MATCHER_treats_as_ONE():
+    """🔴 RED at d05a5e7e — `MentionSpansOverlap`. Round-3 audit F1, under-merge arm.
+
+    Members `İstanbul` (U+0130, dotted capital I) and `istanbul`.
+    `'İstanbul'.casefold()` is `'i̇stanbul'` — NINE code points, an `i` plus a
+    combining dot — so the two casefold to DIFFERENT keys and each got its own
+    cursor starting at 0. The matcher disagrees: `re.IGNORECASE` folds `İ` to
+    `i`, so both needles matched the FIRST `@İstanbul` and the two mentions
+    claimed the same span. The overlap guard then refused a body that genuinely
+    contains two separate occurrences, telling the operator to give each mention
+    its own `@who` text — which the body already had.
+
+    This is the same defect the round-2 fix was aimed at (`@Ann`/`@ANN`), one
+    fold away: fixing it with a SECOND folding function fixed the ASCII case and
+    left the unicode case live.
+    """
+    contacts = [
+        {"signal_uuid": IST_DOTTED_UUID, "phone_number": None,
+         "display_name": "İstanbul", "profile_name": None, "is_placeholder": False},
+        {"signal_uuid": IST_PLAIN_UUID, "phone_number": None,
+         "display_name": "istanbul", "profile_name": None, "is_placeholder": False},
+    ]
+    body = "hi @İstanbul and @istanbul ok"
+    assert _resolve(["İstanbul", "istanbul"], body,
+                    members=[IST_DOTTED_UUID, IST_PLAIN_UUID],
+                    contacts=contacts) == [
+        {"author": IST_DOTTED_UUID, "start": 3, "length": 9},
+        {"author": IST_PLAIN_UUID, "start": 17, "length": 9},
+    ]
+
+
+def test_the_ASCII_case_the_round_2_fix_was_written_for_still_works():
+    """`--mention Ann --mention ANN` still takes two successive occurrences.
+
+    GREEN at d05a5e7e — an INVARIANT GUARD on the round-2 behaviour the F1 fix
+    must not regress, not regression coverage. It is here because the fix
+    REPLACES the mechanism (a casefolded dict key) rather than adding to it.
+    """
+    assert _resolve(["Ann", "ANN"], "hi @Ann and @ANN ok") == [
+        {"author": ANN_UUID, "start": 3, "length": 4},
+        {"author": ANN_UUID, "start": 12, "length": 4},
+    ]
+
+
+# --- F3: one person split across two contact rows -------------------------- #
+def test_a_person_in_TWO_contact_rows_does_not_veto_their_OWN_ping():
+    """🔴 RED at d05a5e7e — `MentionSpanMissing`. Round-3 audit F3.
+
+    `_colliding_needles()` compared raw `_contact_author()` STRINGS, so one
+    person holding a real uuid row AND a phone-only placeholder row read as TWO
+    people and their own longer name vetoed their own ping. The sibling test
+    `test_a_members_OWN_longer_name_does_not_veto_their_own_ping` pins exactly
+    this behaviour for the ONE-ROW shape, and its docstring says the rule is
+    scoped to other AUTHORS — the two-row shape walked straight through it.
+
+    🔴 THE FIXTURE IS BUILT BY THE PUBLIC API, not by hand and not by SQL, and
+    the order is the durable one: `_promote_placeholder()`'s `NOT EXISTS` branch
+    DECLINES when a real row already holds the uuid, so the placeholder is left
+    in place permanently. Both rows end up carrying the same phone number —
+    which is the only thing that ties them together, and what the fix keys on.
+    """
+    number = "+15550777"
+    contacts = [
+        {"signal_uuid": ANN_UUID, "phone_number": number, "display_name": "Ann",
+         "profile_name": None, "is_placeholder": False},
+        {"signal_uuid": _signal_db.placeholder_uuid(number),
+         "phone_number": number, "display_name": None,
+         "profile_name": "Ann Smith", "is_placeholder": True},
+    ]
+    assert _resolve(["Ann"], "@Ann Smith please", members=[number, BOB_UUID],
+                    contacts=contacts) == [
+        {"author": ANN_UUID, "start": 0, "length": 4}]
+
+
+def test_the_TWO_ROW_shape_is_what_the_public_upsert_API_really_produces(db):
+    """🔴 The fixture above is not invented — this builds it through `SignalDB`.
+
+    Three ordinary `upsert_contact()` calls, no SQL: a uuid-only contact from an
+    envelope, a phone-only draft recipient (which mints a placeholder because no
+    row carries that number yet), then an envelope carrying BOTH. The third call
+    attempts `_promote_placeholder()`, which declines — the uuid is taken — and
+    then writes the phone onto the real row. Two rows, one person, shared phone.
+
+    MIXED, and measured that way: the three `assert len/phone/placeholder` lines
+    are GREEN at d05a5e7e — an INVARIANT GUARD proving the F3 fixture is
+    reachable from the public API, not regression coverage. Without them the
+    test above is a claim about a state nobody has shown the system can reach.
+    The final `resolve_mentions` assertion is RED at d05a5e7e, for the same
+    reason as the test above; it is here so the two halves are joined in ONE
+    run rather than reasoned about across two.
+    """
+    number = "+15550777"
+    db.upsert_contact(signal_uuid=ANN_UUID, display_name="Ann")
+    db.upsert_contact(phone_number=number, profile_name="Ann Smith")
+    db.upsert_contact(signal_uuid=ANN_UUID, phone_number=number)
+    rows = db.contacts_by_identifiers([number, ANN_UUID])
+    assert len(rows) == 2, f"expected the durable two-row split, got {rows!r}"
+    assert {r["phone_number"] for r in rows} == {number}, \
+        "the shared phone number is the only link between the two rows"
+    assert sorted(bool(r["is_placeholder"]) for r in rows) == [False, True]
+    # And the resolver handles what the API produced, end to end.
+    assert _mentions.resolve_mentions(
+        ["Ann"], body="@Ann Smith please", members=[number, BOB_UUID],
+        contacts=rows, is_group=True) == [
+        {"author": ANN_UUID, "start": 0, "length": 4}]
+
+
+def test_a_DIFFERENT_persons_longer_name_still_vetoes():
+    """The negative control on F3: identity-aware must not become veto-blind.
+
+    Two genuinely different people — no shared identifier — and the longer name
+    must still win, exactly as before. A fix that merged everyone into one
+    identity would pass the F3 test and silently reopen round-2's F2.
+
+    GREEN at d05a5e7e — an INVARIANT GUARD, not regression coverage.
+    """
+    contacts = [
+        {"signal_uuid": ANN_UUID, "phone_number": None, "display_name": "Ann",
+         "profile_name": None, "is_placeholder": False},
+        {"signal_uuid": BOB_UUID, "phone_number": None, "display_name": None,
+         "profile_name": "Ann Smith", "is_placeholder": False},
+    ]
+    with pytest.raises(_mentions.MentionSpanMissing):
+        _resolve(["Ann"], "@Ann Smith please", members=[ANN_UUID, BOB_UUID],
+                 contacts=contacts)
+
+
+# --- F4: `utf16_span()` claimed to be a thin wrapper and was not ------------ #
+def test_utf16_span_FORWARDS_avoid_so_it_really_is_one_matching_rule():
+    """🔴 RED at d05a5e7e. Round-3 audit F4.
+
+    `utf16_span()` is exported and its docstring calls it "a thin wrapper over
+    `find_span()` so there is exactly one matching rule". It did not forward
+    `avoid`, so it implemented only the `(?!\\w)` half — pre-round-2 behaviour
+    under a docstring promising the opposite. No production caller today; the
+    next one inherits the gap.
+
+    Both arms, because either alone is green for the wrong reason: WITHOUT
+    `avoid` the hit at 0 stands, WITH it the search skips onto the later
+    occurrence.
+    """
+    body = "@Ann Smith and @Ann ok"
+    assert _mentions.utf16_span(body, "@Ann") == (0, 4)
+    assert _mentions.utf16_span(body, "@Ann", avoid=["@Ann Smith"]) == (15, 4)

--- a/scripts/signal/tests/test_mentions.py
+++ b/scripts/signal/tests/test_mentions.py
@@ -2153,3 +2153,119 @@ def test_a_placeholder_bridging_ONE_real_row_still_resolves_NORMALLY(db):
         ["Ann"], body="hi @Ann ok", members=[ANN_UUID, number, BOB_UUID],
         contacts=rows, is_group=True) == [
         {"author": ANN_UUID, "start": 3, "length": 4}]
+
+
+# --------------------------------------------------------------------------- #
+# ROUND-6 AUDIT — F-1: the refusal was wider than its own justification
+# --------------------------------------------------------------------------- #
+def test_an_UNRELATED_member_still_resolves_while_ANOTHER_group_is_polluted(db):
+    """🔴 RED at 69e910ac — and red as a REFUSAL, not an import/attribute error.
+
+    Same three-row bridge as the two tests above (real Ann + placeholder + real
+    "Ann Smith", all on one number), plus Bob, an ordinary member on his own
+    number who shares no identifier with any of them. `--mention Bob`.
+
+    Bob's identity group is `{Bob}`. Whether Ann and Ann Smith were merged with
+    EACH OTHER cannot change which names count as "other than Bob", so both of
+    their names are in Bob's veto list either way and nothing about his call
+    reads the polluted group's shape. Measured:
+
+        707412e6 -> [{'author': BOB_UUID, 'start': 3, 'length': 4}]   correct
+        69e910ac -> MentionIdentityUnresolvable                        refused
+
+    Pollution can only corrupt a call whose resolved author (or whose set of
+    name matches) lands INSIDE the polluted group — true of the bare-uuid case
+    the previous round tested, false for every third party. Round 5 generalised
+    one door into all doors, and the cost is not cosmetic: one stale placeholder
+    row bricked every mention in the group for every member, with no CLI route
+    to find or delete the offending row.
+
+    The second half of this test is the load-bearing half: the SAME fixture must
+    still refuse `--mention Ann`. Narrowing that also let Ann through would pass
+    the first assertion and reopen round 5's wrong send.
+    """
+    number = "+15550100"
+    db.upsert_contact(phone_number=number)                       # -> PLACEHOLDER
+    db.upsert_contact(signal_uuid=ANN_UUID, display_name="Ann")
+    db.upsert_contact(signal_uuid=ANN_UUID, phone_number=number)  # promotion declines
+    db.upsert_contact(signal_uuid=CAI_UUID, profile_name="Ann Smith")
+    db.upsert_contact(signal_uuid=CAI_UUID, phone_number=number)  # declines again
+    db.upsert_contact(signal_uuid=BOB_UUID, display_name="Bob",
+                      phone_number="+15550999")
+    rows = db.contacts_by_identifiers([number, ANN_UUID, CAI_UUID, BOB_UUID])
+    assert len(rows) == 4, f"expected the bridge plus Bob, got {rows!r}"
+    members = [ANN_UUID, CAI_UUID, BOB_UUID, number, "+15550999"]
+
+    assert _mentions.resolve_mentions(
+        ["Bob"], body="hi @Bob ok", members=members, contacts=rows,
+        is_group=True) == [{"author": BOB_UUID, "start": 3, "length": 4}], \
+        "an uninvolved member's mention must not be refused by someone else's " \
+        "polluted identity group"
+
+    with pytest.raises(_mentions.MentionError) as exc:
+        _mentions.resolve_mentions(
+            ["Ann"], body="hi @Ann Smith", members=members, contacts=rows,
+            is_group=True)
+    assert type(exc.value).__name__ == "MentionIdentityUnresolvable", \
+        f"the wrong send must STILL be refused: {exc.value!r}"
+
+
+def test_the_unresolvable_refusal_COUNTS_and_LISTS_the_same_identities():
+    """The count and the list in the refusal must agree, and name the bridge.
+
+    RED at 69e910ac twice over, and the fixture is chosen to see BOTH:
+
+      * the count was `len(members_)` — the real ROWS — while the list was those
+        rows' authors DE-DUPLICATED into a set. THREE real rows carrying TWO
+        distinct authors printed `3 DIFFERENT real identities` beside a list of
+        two: a message that contradicts itself in the one place it is read.
+        Measured at 69e910ac on exactly these rows. A two-row fixture cannot see
+        this — its count and its deduped list agree by accident — which is why
+        this test does not reuse the bridge fixture above.
+      * the refusal named the real rows by uuid and never named the placeholder
+        or the identifier it was minted for, while instructing the operator to
+        "remove the stale placeholder contact row". `consumer.py` exposes no
+        contacts subcommand, so their only route is Postgres, and the shared
+        identifier is the only value they could have selected the row on.
+
+    Rows are hand-built rather than driven through `upsert_contact()` because
+    that API de-duplicates on the uuid: one person holding two REAL rows is a
+    state the pure resolver must handle (it is what a restore or a manual repair
+    leaves behind), not one the writer will produce for us.
+    """
+    n1, n2, n3 = "+15550111", "+15550222", "+15550333"
+    ph_uuid = "99999999-9999-4999-8999-999999999999"
+    # Both `Ann` rows are REAL and carry the SAME author, so they cannot union
+    # with each other (the pair gate needs a placeholder) — each is dragged into
+    # the group through its OWN placeholder, which is what makes the group hold
+    # three real rows spelling two identities.
+    rows = [
+        {"signal_uuid": ANN_UUID, "phone_number": n1, "display_name": "Ann",
+         "profile_name": None, "is_placeholder": False},
+        {"signal_uuid": ANN_UUID, "phone_number": n2, "display_name": "Ann",
+         "profile_name": None, "is_placeholder": False},
+        {"signal_uuid": ph_uuid, "phone_number": n1, "display_name": None,
+         "profile_name": None, "is_placeholder": True},
+        {"signal_uuid": ph_uuid, "phone_number": n2, "display_name": None,
+         "profile_name": None, "is_placeholder": True},
+        {"signal_uuid": ph_uuid, "phone_number": n3, "display_name": None,
+         "profile_name": None, "is_placeholder": True},
+        {"signal_uuid": CAI_UUID, "phone_number": n3, "display_name": None,
+         "profile_name": "Ann Smith", "is_placeholder": False},
+    ]
+    with pytest.raises(_mentions.MentionError) as exc:
+        _resolve(["Ann"], "hi @Ann Smith",
+                 members=[ANN_UUID, CAI_UUID, ph_uuid, n1, n2, n3], contacts=rows)
+    assert type(exc.value).__name__ == "MentionIdentityUnresolvable", \
+        f"refused, but with the wrong class: {exc.value!r}"
+    text = str(exc.value)
+    # THREE real rows, TWO real identities. The number printed is the length of
+    # the list printed, so no de-duplication can make them drift apart again.
+    assert "2 distinct real identities" in text, \
+        f"the count must be the length of the list beside it: {text!r}"
+    assert ANN_UUID in text and CAI_UUID in text
+    # The bridge itself: the identifiers the placeholder rows share with the
+    # real rows are the only thing the operator can act on.
+    assert n1 in text and n2 in text and n3 in text, \
+        f"the shared identifiers the placeholders were minted for are the ONE " \
+        f"actionable thing here, and they are absent: {text!r}"

--- a/scripts/signal/tests/test_mutation_battery.py
+++ b/scripts/signal/tests/test_mutation_battery.py
@@ -70,6 +70,48 @@ def test_every_mutant_actually_CHANGES_the_source(mutant):
 
 
 @pytest.mark.parametrize("mutant", battery.MUTANTS, ids=lambda m: m.id)
+def test_an_EQUIVALENT_mutant_ARGUES_for_itself(mutant):
+    """🔴 `equivalent=True` flips a SURVIVED from a finding into a pass.
+
+    That is exactly the switch somebody reaches for when a mutant will not die
+    and the deadline is close — "call it equivalent and move on" — and it is
+    indistinguishable, in the summary line, from a genuinely unkillable
+    mutation. So the flag has to cost something: the row must say the word in
+    its own `why`, where a reader and a reviewer will see the ARGUMENT next to
+    the claim rather than a bare boolean buried in the call.
+
+    Not a proof of equivalence — nothing static can be — but it makes an
+    unargued one impossible to add quietly.
+    """
+    if not mutant.equivalent:
+        assert mutant.expected == "KILLED"
+        return
+    assert "EQUIVALENT" in mutant.why.upper(), (
+        f"mutant {mutant.id} is flagged equivalent but its description does not "
+        f"say so, let alone argue it: {mutant.why!r}")
+    assert mutant.expected == "SURVIVED"
+
+
+def test_an_equivalent_mutant_that_gets_KILLED_is_a_FAILURE_not_a_pass():
+    """Behavioural, on the pure comparison the runner uses.
+
+    A killed "equivalent" mutant means the equivalence argument was WRONG — the
+    two forms are distinguishable after all — which is a finding about the
+    ledger, not a success. Pinned here because the runner's own summary line
+    would otherwise read `0/0 killed` and look like a clean run.
+    """
+    equiv = battery.Mutant("X", "EQUIVALENT: argued", "p", "a", "b", "k", "s",
+                           equivalent=True)
+    plain = battery.Mutant("Y", "a real mutant", "p", "a", "b", "k", "s")
+    assert equiv.expected == "SURVIVED" and plain.expected == "KILLED"
+    # The runner's failure set is `verdict != m.expected`, so the four cells:
+    assert ("SURVIVED" != equiv.expected) is False   # equivalent survives -> pass
+    assert ("KILLED" != equiv.expected) is True      # equivalent killed   -> FAIL
+    assert ("KILLED" != plain.expected) is False     # real killed         -> pass
+    assert ("SURVIVED" != plain.expected) is True    # real survived       -> FAIL
+
+
+@pytest.mark.parametrize("mutant", battery.MUTANTS, ids=lambda m: m.id)
 def test_every_named_killer_test_EXISTS(mutant):
     """A killer that does not exist can never fire — so the mutant can never die.
 

--- a/scripts/signal/tests/test_mutation_battery.py
+++ b/scripts/signal/tests/test_mutation_battery.py
@@ -266,3 +266,114 @@ def test_the_audit_found_mutants_are_still_present():
     for m in battery.MUTANTS:
         if m.id.startswith("A"):
             assert "[audit]" in m.why, f"{m.id} lost its provenance note"
+
+
+# --------------------------------------------------------------------------- #
+# ROUND-4 delta audit
+# --------------------------------------------------------------------------- #
+# 🔴 The BUDGET, not just the word. `test_an_EQUIVALENT_mutant_ARGUES_for_itself`
+# above covers only the KILLED direction; the LAUNDERING direction was measured
+# end to end by the round-4 audit. `NAME_HINT_MAX = 5 -> 4` was a GENUINE
+# survivor of all 908 tests, and adding it to the ledger with `equivalent=True`
+# and the word "EQUIVALENT" in its `why` produced BATTERY_RC=0, a green suite and
+# 213 passing battery-meta tests. Cost of laundering a real coverage gap into a
+# green gate: one word in a string — the same spelled-guard class this branch
+# removed from `test_skill_doc.py`.
+#
+# A cap cannot prove an equivalence argument (nothing static can). What it does
+# is take the move out of the quiet path: a new `equivalent=True` row now
+# REQUIRES editing the number below, in a diff a reviewer reads, next to the
+# argument they must accept. That mutant is itself now KILLED rather than
+# reclassified — see MEN12 and its killer.
+EQUIVALENT_BUDGET = 1
+
+
+def test_the_number_of_EQUIVALENT_rows_is_CAPPED():
+    """The ledger may hold at most `EQUIVALENT_BUDGET` argued-equivalent rows."""
+    equiv = [m for m in battery.MUTANTS if m.equivalent]
+    assert sum(m.equivalent for m in battery.MUTANTS) <= EQUIVALENT_BUDGET, (
+        f"{len(equiv)} rows are flagged equivalent ({[m.id for m in equiv]}) but "
+        f"the budget is {EQUIVALENT_BUDGET}. `equivalent=True` turns a SURVIVED "
+        f"from a finding into a pass, so raising the cap is a deliberate, "
+        f"reviewable edit — make it here, in the same diff as the argument.")
+
+
+def test_the_budget_is_TIGHT_so_a_new_equivalent_row_cannot_slip_in():
+    """🔴 The cap must BIND. A slack budget is a cap that permits the move.
+
+    Measured: at fbeca469 the ledger held exactly one equivalent row (MEN3) and
+    no cap at all, so a second could be added with `equivalent=True` and one word
+    in a string. This asserts the budget equals what is actually spent — so the
+    next row is refused by the test above rather than absorbed by headroom.
+    """
+    assert sum(m.equivalent for m in battery.MUTANTS) == EQUIVALENT_BUDGET, (
+        "the budget has slack: it must equal the number of equivalent rows, or "
+        "a new one lands green without anyone editing this file")
+
+
+def test_the_ONE_equivalent_row_is_MEN3_and_it_still_argues_the_same_premise():
+    """The budgeted row is named, so spending it elsewhere is loud.
+
+    MEN3's equivalence rests on a PREMISE about the code around it — `re` folds
+    one code point to one, so a match consumes exactly `len(pattern)`. Keeping
+    the row keyed by id means a future round cannot re-spend the budget on a
+    different mutation while the count stays at one.
+    """
+    equiv = [m for m in battery.MUTANTS if m.equivalent]
+    assert [m.id for m in equiv] == ["MEN3"], [m.id for m in equiv]
+    assert "folds one code point to one" in equiv[0].why
+
+
+@pytest.mark.parametrize("rows, expected", [
+    # (equivalent?, verdict) pairs -> the headline text
+    ([(False, "KILLED")], "1/1 killed by their NAMED test"),
+    ([(False, "SURVIVED")], "0/1 killed by their NAMED test"),
+    ([(False, "KILLED-WRONG-REASON")], "0/1 killed by their NAMED test"),
+    ([(True, "SURVIVED")],
+     "0/0 killed by their NAMED test  (1 EQUIVALENT, expected to survive)"),
+    # 🔴 THE F-D CELL: a row that is BOTH equivalent AND wrong. The old
+    # `len(results) - len(bad) - len(equiv)` charged it twice and printed -1/0.
+    ([(True, "KILLED")],
+     "0/0 killed by their NAMED test  (1 EQUIVALENT, expected to survive)"),
+    ([(True, "KILLED"), (False, "KILLED")],
+     "1/1 killed by their NAMED test  (1 EQUIVALENT, expected to survive)"),
+])
+def test_the_headline_count_never_double_subtracts(rows, expected):
+    """Round-4 F-D, table-tested against the pure `headline()`.
+
+    The exit code and the `!!` detail lines were correct all along; this is the
+    number a reader scans first, and `-1/0` reads as a glitch in the tool rather
+    than as the finding it actually was.
+
+    🔴 SCOPE OF THE RED. At fbeca469 this logic was INLINE in `main()`, so these
+    cases fail there with an `AttributeError` — the extraction is what makes the
+    defect reachable at all, exactly as `_verdict` was extracted for the same
+    reason. The BEHAVIOURAL proof that the old expression was wrong is the test
+    below, which runs the old arithmetic and watches it go negative.
+    """
+    results = [(battery.Mutant(f"X{i}", "EQUIVALENT: argued" if eq else "real",
+                               "p", "a", "b", "k", "s", equivalent=eq),
+                verdict, "detail")
+               for i, (eq, verdict) in enumerate(rows)]
+    assert battery.headline(results) == expected
+
+
+def test_the_OLD_headline_arithmetic_really_did_go_NEGATIVE():
+    """The control that makes the test above regression coverage, not a rewrite.
+
+    The shipped expression was `len(results) - len(bad) - len(equiv)` over
+    `bad = [verdict != expected]` and `equiv = [m.equivalent]`. On the one cell
+    where those two sets INTERSECT — an equivalent mutant that got KILLED, the
+    single finding the flag exists to surface — the row is subtracted twice.
+    Run here rather than described, so the claim is checked by the machine: the
+    old form yields -1 where `headline()` yields 0, and `-1/0 killed` is what a
+    live run printed.
+    """
+    equiv_row = (battery.Mutant("X", "EQUIVALENT: argued", "p", "a", "b", "k",
+                                "s", equivalent=True), "KILLED", "detail")
+    results = [equiv_row]
+    bad = [r for r in results if r[1] != r[0].expected]
+    equiv = [r for r in results if r[0].equivalent]
+    old = len(results) - len(bad) - len(equiv)
+    assert old == -1, "the old arithmetic is not being reproduced faithfully"
+    assert battery.headline(results).startswith("0/0 "), battery.headline(results)

--- a/scripts/signal/tests/test_outbound_echo.py
+++ b/scripts/signal/tests/test_outbound_echo.py
@@ -56,7 +56,7 @@ def _echo_envelope(*, timestamp, body="sent from my laptop"):
 
 
 def _transmit_returning(ts, *, as_string=True):
-    def _t(auth, *, recipient, body, number):
+    def _t(auth, *, recipient, body, number, mentions=None):
         assert number, "the server requires the sending `number` and 400s without it"
         return {"timestamp": str(ts) if as_string else ts}
     return _t

--- a/scripts/signal/tests/test_pg_type_compat.py
+++ b/scripts/signal/tests/test_pg_type_compat.py
@@ -220,3 +220,40 @@ def test_the_backstop_catches_the_refactors_that_walked_it(walk):
     assert _uncast_coalesces(walk), (
         f"the backstop does not flag {walk!r}, which raises DatatypeMismatch on "
         f"a real server — it is guarding a spelling, not the hazard")
+
+
+# --------------------------------------------------------------------------- #
+# The MIGRATION, on a real server
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not os.environ.get("SIGNAL_PG_DSN"),
+                    reason="needs a real Postgres (SIGNAL_PG_DSN); the hermetic "
+                           "substrate EMULATES `ADD COLUMN IF NOT EXISTS`, so it "
+                           "cannot answer this question")
+def test_ensure_schema_is_idempotent_on_real_postgres():
+    """🔴 `ensure_schema()` runs on EVERY consumer start, so it must be re-runnable.
+
+    Its hermetic sibling — `test_mentions.py::
+    test_ensure_schema_twice_is_a_no_op_ON_THE_SQLITE_SUBSTRATE` — asserts
+    `fakepg`'s own emulation of `ADD COLUMN IF NOT EXISTS`, which SQLite does not
+    have. That test was named `test_ensure_schema_twice_is_a_no_op`, which read
+    as a claim about the deployed engine; it was not one. This is.
+
+    Runs the SHIPPED `SCHEMA_STATEMENTS` (imported, never transcribed) twice
+    against a live server in a transaction that is rolled back, so a second start
+    that would crash the pod fails HERE instead.
+    """
+    import sys
+    sys.path.insert(0, str(MODULE.parent))
+    import psycopg2  # imported lazily: absent in the default hermetic env
+    import _signal_db
+
+    assert len(_signal_db.SCHEMA_STATEMENTS) > 5, "imported an empty DDL ledger"
+    conn = psycopg2.connect(os.environ["SIGNAL_PG_DSN"])
+    try:
+        with conn.cursor() as cur:
+            for _pass in (1, 2):
+                for statement in _signal_db.SCHEMA_STATEMENTS:
+                    cur.execute(statement)
+        conn.rollback()
+    finally:
+        conn.close()

--- a/scripts/signal/tests/test_search.py
+++ b/scripts/signal/tests/test_search.py
@@ -90,7 +90,7 @@ def test_search_finds_outbound_messages_too(db):
                              self_number="+15559090")
     db.approve_draft(draft["id"], approval_ref="cg-search")
     db.send_approved(draft["id"],
-                     transmit=lambda auth, recipient, body, number: {"timestamp": "1723300009999"})
+                     transmit=lambda auth, recipient, body, number, mentions=None: {"timestamp": "1723300009999"})
     bodies = [h["body"] for h in db.search("permit")]
     assert "I filed the harbour permit" in bodies
     assert any(h["is_outbound"] for h in db.search("permit"))

--- a/scripts/signal/tests/test_skill_doc.py
+++ b/scripts/signal/tests/test_skill_doc.py
@@ -201,3 +201,102 @@ def test_skill_records_all_four_schema_corrections():
     assert "echo back via device sync" in gotchas
     assert "Reactions can precede their target" in gotchas
     assert "signal_attachment_id" in gotchas
+
+
+# --------------------------------------------------------------------------- #
+# Round-2 audit F2 + F7 — two places SKILL.md made a claim the code did not keep
+# --------------------------------------------------------------------------- #
+_PREFIX_SEPARATORS = ["-", ".", " ", "'"]
+
+
+@pytest.mark.parametrize("sep", _PREFIX_SEPARATORS)
+def test_the_prefix_claim_is_true_of_the_CODE_and_stated_in_the_DOC(sep):
+    """🔴 THE SEAM: a doc sentence and the code that has to be as wide as it.
+
+    SKILL.md claimed "a member whose name is a PREFIX of another member's cannot
+    steal their ping". The code implemented `(?!\\w)`, which blocks only WORD
+    characters — so at 9fb6de75 every separator below satisfied the boundary and
+    `--mention Ann` landed on the first four characters of `Ann<sep>Marie`. The
+    doc was RIGHT and the code was narrow; the audit's instruction was to widen
+    the code, and this test is what stops them drifting apart again.
+
+    BOTH halves are asserted from ONE parameter list. Widen the doc without the
+    code and the behavioural half fails; narrow the code without the doc and the
+    same half fails; drop a separator from the doc and the text half fails.
+    Neither half is a guard on its own — separately they are exactly the
+    "verified in isolation" shape that let this ship.
+
+    RED at 9fb6de75 on the behavioural half for `-`, `.`, `'` and ` `.
+    """
+    import _mentions
+
+    ann = "11111111-1111-4111-8111-111111111111"
+    other_id = "22222222-2222-4222-8222-222222222222"
+    other = f"Ann{sep}Marie"
+    contacts = [
+        {"signal_uuid": ann, "phone_number": None, "display_name": "Ann",
+         "profile_name": None, "is_placeholder": False},
+        {"signal_uuid": other_id, "phone_number": None, "display_name": other,
+         "profile_name": None, "is_placeholder": False},
+    ]
+    # (a) the CODE refuses rather than stealing the ping.
+    with pytest.raises(_mentions.MentionSpanMissing):
+        _mentions.resolve_mentions(["Ann"], body=f"hi @{other} ok",
+                                   members=[ann, other_id], contacts=contacts,
+                                   is_group=True)
+    # (b) the DOC names this separator, so a reader can tell what is covered.
+    mentions_section = SKILL_TEXT.split("## Mentions")[1].split("\n## ")[0]
+    assert f"@Ann{sep}" in mentions_section, (
+        f"the code refuses a {sep!r}-separated prefix collision but SKILL.md's "
+        f"Mentions section never mentions that separator — the doc is narrower "
+        f"than the code, which is how the reverse drift went unnoticed")
+
+
+def test_the_prefix_claim_does_NOT_overreach_to_NON_member_text():
+    """The other direction: the doc must not claim more than the code does.
+
+    The rule is MEMBER-aware. `@Ann` in `"@Ann-the-dog"`, where nothing is named
+    `Ann-the-dog`, still matches — deliberately, because banning punctuation
+    outright would break `"thanks @Ann."`. SKILL.md has to say so, or the next
+    reader files the behaviour below as a bug.
+    """
+    import _mentions
+
+    ann = "11111111-1111-4111-8111-111111111111"
+    contacts = [{"signal_uuid": ann, "phone_number": None, "display_name": "Ann",
+                 "profile_name": None, "is_placeholder": False}]
+    assert _mentions.resolve_mentions(
+        ["Ann"], body="@Ann-the-dog", members=[ann], contacts=contacts,
+        is_group=True) == [{"author": ann, "start": 0, "length": 4}]
+    mentions_section = SKILL_TEXT.split("## Mentions")[1].split("\n## ")[0]
+    assert "member" in mentions_section.lower()
+    assert "thanks @Ann." in mentions_section, (
+        "SKILL.md must show the case the member-aware rule deliberately allows")
+
+
+def test_the_pre_digest_drain_procedure_is_ORDERED_so_it_can_be_RUN():
+    """🔴 RED at 9fb6de75. Round-2 audit F7.
+
+    The doc said to drain pre-existing approvals "**before** rolling this out",
+    and then prescribed `unapprove` and a `WHERE approved_digest IS NULL` query —
+    a command and a column that BOTH ship in this change. Followed literally the
+    procedure cannot run: there is no `unapprove` on the previous revision and no
+    column to select on. An unexecutable runbook step is worse than none, because
+    the operator discovers it mid-incident.
+
+    Pinned by ORDER, not by a phrase: the deploy instruction must precede the
+    SELECT, and the erroneous "before rolling this out" must be gone.
+    """
+    anchor = "rain the pre-existing approvals"
+    assert SKILL_TEXT.count(anchor) == 1, \
+        "HARNESS: the drain section anchor is not unique in SKILL.md"
+    section = SKILL_TEXT.split(anchor)[1]
+    assert "before rolling this out" not in SKILL_TEXT.lower(), \
+        "the reversed ordering is back"
+    deploy_at = section.lower().index("deploy")
+    query_at = section.index("approved_digest IS NULL")
+    assert deploy_at < query_at, (
+        "the drain procedure must tell the operator to deploy FIRST — the "
+        "column it selects on is created by the new consumer's ensure_schema()")
+    # And the recovery command it prescribes must actually exist in the CLI.
+    assert "unapprove" in _commands(), "the runbook prescribes a command the CLI lacks"

--- a/scripts/signal/tests/test_skill_doc.py
+++ b/scripts/signal/tests/test_skill_doc.py
@@ -284,17 +284,36 @@ def test_the_pre_digest_drain_procedure_is_ORDERED_so_it_can_be_RUN():
     column to select on. An unexecutable runbook step is worse than none, because
     the operator discovers it mid-incident.
 
-    Pinned by ORDER, not by a phrase: the deploy instruction must precede the
-    SELECT, and the erroneous "before rolling this out" must be gone.
+    Pinned by ORDER, not by a phrase.
+
+    🔴 THE PHRASE ASSERTION IS GONE — round-3 audit F2. It read
+    `assert "before rolling this out" not in SKILL_TEXT.lower()` and it passed
+    only because a markdown line-wrap splits the phrase across a newline at
+    SKILL.md's "the old wording had it backwards" paragraph, which quotes those
+    exact words on purpose. So it was green for a typographic reason, and a
+    purely COSMETIC rewrap — identical words, one line instead of two — turned
+    it RED with the message "the reversed ordering is back", which would have
+    been false. A guard on WORDS is walkable by rewording and trippable by
+    reflowing; the state that actually matters is the ORDER, and the assertion
+    below is the one that pins it.
     """
     anchor = "rain the pre-existing approvals"
     assert SKILL_TEXT.count(anchor) == 1, \
         "HARNESS: the drain section anchor is not unique in SKILL.md"
     section = SKILL_TEXT.split(anchor)[1]
-    assert "before rolling this out" not in SKILL_TEXT.lower(), \
-        "the reversed ordering is back"
-    deploy_at = section.lower().index("deploy")
-    query_at = section.index("approved_digest IS NULL")
+    # 🔴 THE COMPARISON IS SCOPED TO THE NUMBERED PROCEDURE, NOT THE WHOLE
+    # SECTION. Measured while removing the phrase assertion: `section` opens
+    # with a paragraph EXPLAINING the ordering, and that paragraph contains the
+    # word "deploy" (offset 741) before the SELECT (offset 1025) — so the index
+    # over the whole section was satisfied by the explanation, whatever order
+    # the steps below it were in. Swapping steps 1 and 2 in SKILL.md left this
+    # test GREEN. It is now anchored on the list itself.
+    parts = section.split("\n   1. ", 1)
+    assert len(parts) == 2, \
+        "HARNESS: the drain procedure is no longer a `1.`-numbered list"
+    procedure = parts[1]
+    deploy_at = procedure.lower().index("deploy")
+    query_at = procedure.index("approved_digest IS NULL")
     assert deploy_at < query_at, (
         "the drain procedure must tell the operator to deploy FIRST — the "
         "column it selects on is created by the new consumer's ensure_schema()")

--- a/scripts/tests/test_conditional_skip_pins.py
+++ b/scripts/tests/test_conditional_skip_pins.py
@@ -26,6 +26,7 @@ repo before. This file only reads `run-tests.sh`.
 
 from __future__ import annotations
 
+import ast
 import re
 import subprocess
 import textwrap
@@ -179,24 +180,128 @@ def test_conditional_entry_counts_only_when_the_var_is_UNSET():
         "VAR set means the test RUNS, so the pin must NOT be counted"
 
 
+PG_DSN_VAR = "SIGNAL_PG_DSN"
+
+
+def _real_postgres_skip_reasons() -> list[tuple[str, str]]:
+    """`(owning-dir, literal reason)` for EVERY test in the repo whose skip is
+    gated on `SIGNAL_PG_DSN`, read out of the test SOURCES by `ast`.
+
+    🔴 WHY DERIVED, AND WHY NOT A REASON PATTERN. The obvious predicate for "is
+    this a real-Postgres pin" is a substring of the reason — but the two shipped
+    reasons share only the prefix pytest never had to keep, and the SECOND
+    entry's regex (`the hermetic substrate EMULATES`) does not contain the word
+    "Postgres" at all. A pattern tuned to match today's two rows would match
+    them by accident and silently stop matching the third. The only
+    non-accidental definition of "real-Postgres skip" is the one the test files
+    themselves state: a `skipif` whose CONDITION names `SIGNAL_PG_DSN`.
+
+    No `git` — a plain glob, so the hermetic tier is unaffected (see the module
+    docstring). The cheap substring pre-filter keeps this to the handful of
+    files that can possibly qualify.
+    """
+    out: list[tuple[str, str]] = []
+    for path in sorted((REPO / "scripts").rglob("test_*.py")):
+        src = path.read_text(encoding="utf8", errors="replace")
+        if PG_DSN_VAR not in src:
+            continue
+        rel = path.relative_to(REPO).as_posix()
+        for node in ast.walk(ast.parse(src)):
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            if not (isinstance(fn, ast.Attribute) and fn.attr == "skipif"):
+                continue
+            cond = node.args[0] if node.args else next(
+                (k.value for k in node.keywords if k.arg == "condition"), None)
+            # The CONDITION only — the reason text also spells the variable, and
+            # matching on that would sweep in skips gated on something else.
+            if cond is None or PG_DSN_VAR not in ast.unparse(cond):
+                continue
+            reason = next((k.value.value for k in node.keywords
+                           if k.arg == "reason"
+                           and isinstance(k.value, ast.Constant)
+                           and isinstance(k.value.value, str)), None)
+            assert reason, (
+                f"{rel}: a skipif gated on {PG_DSN_VAR} has no literal "
+                f"`reason=` — the ledger pins skips BY REASON, so this skip "
+                f"cannot be pinned and GUARD 2 will report it unpinned")
+            out.append((rel.rsplit("/", 1)[0], reason))
+    assert out, (
+        f"found NO test gated on {PG_DSN_VAR} anywhere under scripts/ — this "
+        f"fixture no longer knows which skips it is pinning")
+    return out
+
+
+def _real_postgres_pins() -> list[str]:
+    """Every LEDGER ENTRY that can forgive a real-Postgres skip.
+
+    The predicate is the runner's own matcher, not a word: an entry qualifies
+    when its owning directory and its regex accept at least one of the reasons
+    read above. That is deliberately not one-to-one — the shipped regex
+    `needs a real Postgres` matches BOTH reasons, because both skipif reasons
+    open with that prefix, and the matching loop in `run-tests.sh` breaks on the
+    first applicable entry that matches. So "which entry forgives which skip" is
+    not well-defined; "which entries can forgive a real-Postgres skip" is, and
+    it is the set that must all be conditional.
+
+    The COUNTS must still agree one-for-one, because the accounting compares the
+    skip TOTAL against the number of applicable ENTRIES. One entry short (a pin
+    deleted, or one widened to absorb both) leaves more skips than entries and
+    the gate is red; one entry long leaves fewer, and the gate is red the other
+    way with advice that is wrong for a conditional pin.
+    """
+    reasons = _real_postgres_skip_reasons()
+    pins = [e for e in _ledger_entries()
+            if any(e.split("|")[0] == owning_dir and re.search(e.split("|")[1], reason)
+                   for owning_dir, reason in reasons)]
+    assert len(pins) == len(reasons), (
+        f"{len(reasons)} test(s) skip on {PG_DSN_VAR} "
+        f"({[r for _, r in reasons]!r}) but {len(pins)} EXPECTED_SKIPS "
+        f"entr(y/ies) can forgive them ({pins!r}). The ledger accounts one entry "
+        f"per skipped test, so any mismatch reds GUARD 2 — too few entries "
+        f"leaves an UNPINNED skip, too many pins a skip that never happens.")
+    return pins
+
+
 def test_the_real_ledger_behaves_the_same_way():
     """The shipped entries, not a synthetic pair — so a future edit that drops the
-    condition from the Postgres pin is caught here and not only in production."""
-    block = _extract("EXPECTED_SKIPS=(", "\n)")
-    entries = re.findall(r'^\s*"([^"]+)"', block, re.M)
-    assert len(entries) >= 2, f"parsed {len(entries)} ledger entries — extraction is broken"
-    assert any(e.startswith("scripts/signal/tests|") and e.endswith("|unset:SIGNAL_PG_DSN")
-               for e in entries), "the Postgres pin lost its condition"
+    condition from a Postgres pin is caught here and not only in production.
+
+    🔴 TWO HALVES, AND WHY THE ARITHMETIC ALONE IS NOT ENOUGH. The count below
+    is derived from the number of real-Postgres pins rather than a literal `1`,
+    so adding a second such test does not falsify it. But a derived count can be
+    SATISFIED BY THE BUG: drop the condition from ONE of two Postgres pins and
+    the applicable total falls by one instead of two — while the number of
+    entries still carrying a condition also falls to one, so the two sides move
+    together and the subtraction still balances. The predecessor of this case
+    guarded that with `any(... endswith("|unset:SIGNAL_PG_DSN"))`, which the
+    surviving pin satisfies. So the structural half is `all`, over the pins
+    derived from the test sources — it is the only half that can see a single
+    silently-unconditional pin.
+    """
+    entries = _ledger_entries()
+    pins = _real_postgres_pins()
+
+    unconditional = [p for p in pins if not p.endswith(f"|unset:{PG_DSN_VAR}")]
+    assert not unconditional, (
+        f"these real-Postgres pins lost their `|unset:{PG_DSN_VAR}` condition: "
+        f"{unconditional!r}. With {PG_DSN_VAR} exported those tests RUN, so an "
+        f"unconditional entry counts a skip that never happened and the gate is "
+        f"permanently RED for that developer — the exact bug this file exists "
+        f"to stop. The arithmetic below cannot see this alone: the applicable "
+        f"total and the conditional-entry count fall together and still balance.")
 
     harness = _count_harness(entries)
-    with_dsn = _bash(harness, {"SIGNAL_PG_DSN": "postgres://x"})
+    with_dsn = _bash(harness, {PG_DSN_VAR: "postgres://x"})
     without = _bash(harness)
     assert without.returncode == 0 and with_dsn.returncode == 0
     n_without = int(without.stdout.split()[0])
     n_with = int(with_dsn.stdout.split()[0])
-    assert n_with == n_without - 1, (
-        f"exporting SIGNAL_PG_DSN must drop exactly one expected pin "
-        f"(got {n_without} -> {n_with}); this is the permanently-red-gate bug")
+    assert n_with == n_without - len(pins), (
+        f"exporting {PG_DSN_VAR} must drop exactly {len(pins)} expected pin(s) "
+        f"— one per real-Postgres test, {pins!r} — (got {n_without} -> "
+        f"{n_with}); this is the permanently-red-gate bug")
 
 
 def test_an_unknown_condition_is_a_HARD_ERROR_not_a_silent_pass():


### PR DESCRIPTION
## What

`draft --mention <who>` (repeatable) pings members of a Signal **group**, and the
send capability now binds the **payload** it authorises rather than only the draft id.

The second half is not scope creep — it is what makes the first half safe to ship.
A mention pushes a notification through the recipient's mute settings and names a
third party in the thread, which is exactly the kind of act that must not be
mutable after a human approved it.

## Design

**Resolution** (`scripts/signal/_mentions.py`, pure, no I/O)

`--mention` takes a member's display name, or their bare uuid / `+E.164`. Names are
resolved against **this group's membership only** — `GET /v1/groups/<account>/<id>`
joined against `signal.contacts`. The `members[]` array is MIXED E.164 and bare UUID
(measured: 5 of the 7 members of the Vetr app group are uuid-only), so
`contacts_by_identifiers()` matches both columns in one query, and a name that
matches somebody in a *different* conversation does not resolve here.

**Offsets.** Each mention becomes `{"author", "start", "length"}` — exactly the three
keys `data.MessageMention` has in signal-cli 0.14.7 — with `start`/`length` in
**UTF-16 code units**. This is the whole reason `_mentions.utf16_len()` exists in one
place: a `len()`-in-code-points implementation is correct for ASCII and silently wrong
the moment a non-BMP character appears earlier in the body, and the receiving client
then replaces the wrong span. The body must already contain the literal `@<who>`,
because Signal *replaces* that span rather than inserting anything.

**Persistence.** Two `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` migrations in
`SCHEMA_STATEMENTS` — `mentions JSONB` and `approved_digest TEXT`. Deliberately NOT
columns in the `CREATE TABLE` body: every statement there is `IF NOT EXISTS`, which is
a no-op against an existing table, so a column added to the CREATE would take effect on
a fresh database (the hermetic substrate, rebuilt every test) and do **nothing** to
prod — green suite, unchanged deployed schema. The sqlite substrate emulates Postgres's
`IF NOT EXISTS` via `PRAGMA table_info` rather than dropping the statement.

**The approval card** now lists every `author` the message will ping, above the body
preview. `@Ann` in a preview is indistinguishable from ordinary prose — it *is* ordinary
prose until the `mentions` array turns it into a notification — so approving without
seeing who it notifies was the failure mode.

**The binding.** `SendAuthorization` already carried `recipient` and `body`, and nothing
read them; the capability authorised "a transmit for draft N" and nothing about the
message. Two distinct windows, closed in two places:

| Window | Closed by | Where |
|---|---|---|
| `approve` → *mutate* → `send` | SHA-256 digest of `(recipient, body, mentions)` written by `approve_draft()`; refuses to mint for a row that no longer hashes to it | `_mint_send_authorization()` |
| `mint` → *mutate* → `POST` | `recipient`/`body`/`mentions` as **required** keyword args, compared against the capability | `spend_authorization()` |

The digest is recorded at **approval**, not at send. A capability minted at send time out
of whatever the row says *then* is comparing the row against itself and can never
disagree — which is precisely why the old `auth.recipient`/`auth.body` fields were dead
code rather than a guard. `spend_authorization()`'s three arguments have no defaults, so
a call site cannot opt out of the check by omitting them.

**Fails closed**: a missing digest is a refusal, because "never had one" and "cleared by
the writer we are guarding against" are the same observation. The way out is to read the
changed draft and `approve` it again.

## Refusal matrix

Every failure is a refusal (`exit 3`), never a silent drop. Each has its own exception
class and its own test asserting *that* class.

| Situation | Error | Test |
|---|---|---|
| no group member answers to that name | `MentionNameNotFound` | `test_refusal_name_not_found` |
| two or more members do | `MentionNameAmbiguous` | `test_refusal_ambiguous_name` |
| resolves to an `is_placeholder` contact (a synthetic id) | `MentionResolvesToPlaceholder` | `test_refusal_placeholder_contact` |
| …reached by typing that synthetic uuid directly | `MentionResolvesToPlaceholder` | `test_refusal_placeholder_reached_by_its_uuid_too` |
| an explicit uuid/E.164 is not in this group | `MentionNotAMember` | `test_refusal_identifier_is_not_a_member_of_this_group` |
| the body has no `@<who>` text | `MentionSpanMissing` | `test_refusal_the_at_substring_is_absent_from_the_body` |
| `--mention` given for a non-group `--to` | `MentionsRequireAGroup` | `test_refusal_mentions_for_a_non_group_recipient` |
| the group reported an EMPTY membership | `MentionNameNotFound` | `test_refusal_an_empty_membership_is_a_refusal_not_an_empty_array` |

The last row is a silent-zero guard: an empty `members[]` means the *lookup* failed, not
that the group is empty, so it refuses rather than returning `[]`.

## Test matrix — red → green

**The regression test.** `test_a_draft_mutated_between_approve_and_send_is_REFUSED` was
run against `origin/main` (`809486fa`) using only pre-change symbols, in a detached
worktree:

```
origin/main   FAILED  ... Failed: DID NOT RAISE SendGateError
              WITNESS — posted under the operator's approval:
                [{'message': 'approve the WIRE TRANSFER',
                  'number': '+15559090', 'recipients': ['+15550101']}]
HEAD          PASSED
```

The witness matters: "DID NOT RAISE" only says the guard is absent. The approved body was
`"can you review the small one"`; what origin/main actually put on the wire was
`"approve the WIRE TRANSFER"`, under the operator's approval ref.

🔴 **Honest scoping of the rest.** The mention tests are **new-feature tests, not
regression tests** — `_mentions.py` does not exist on `origin/main`, so running them
there yields an ImportError, not a red assertion, and an ImportError proves nothing.
They are held to the mutation sweep below instead, which *is* a red observation against
the shipped code. `test_utf16_len_counts_code_UNITS_not_code_POINTS` is explicitly an
**invariant guard**, labelled as such in its docstring — nothing shipped that got it
wrong, because nothing computed offsets at all.

**Counts** (`nix-shell` + `pytest scripts/signal/tests`, real counts, not exit codes):

```
origin/main   716 passed, 1 skipped
HEAD          773 passed, 1 skipped        (+57)
repo gate     PASS  scripts/signal/tests  (collected=774 passed=773 skipped=1 floor=682)
```

The full repo gate (`nix develop . --command bash scripts/run-tests.sh --targets
scripts/signal/tests`) passes; the floor did not need re-pinning (774 − 682 = 92, inside
the 138 of slack).

## Mutation results

12 mutants, each the **narrowest** edit that can be wrong — a guard's condition is
short-circuited, never removed together with its enclosing block — applied to a copy of
the tree, run under `PYTHONDONTWRITEBYTECODE=1`. A mutant counts as killed only when the
**expected** test fails.

| # | Mutant | Result |
|---|---|---|
| — | **null edit** (comment only) — must SURVIVE | 🟢 SURVIVED (57 passed) |
| — | **seeded fault** (`start` hardcoded to 0) — must be KILLED | KILLED by `test_a_mention_that_is_NOT_at_index_zero_carries_its_real_offset` |
| M1 | `start` computed in code points | KILLED by `test_an_emoji_before_the_mention_shifts_start_by_TWO_not_one` |
| M2 | `length` computed in code points | KILLED by `test_an_emoji_INSIDE_the_mention_span_lengthens_it_too` |
| M3 | `utf-16` (BOM-ful) instead of `utf-16-le` | KILLED by `test_utf16_len_counts_code_UNITS_not_code_POINTS` |
| M4 | approval digest not enforced | KILLED by `test_a_draft_mutated_between_approve_and_send_is_REFUSED` |
| M5 | missing digest fails OPEN | KILLED by `test_a_CLEARED_approval_digest_fails_CLOSED` |
| M6 | mentions not bound at spend | KILLED by `test_MENTIONS_mutated_between_mint_and_post_are_refused` |
| M7 | body not bound at spend | KILLED by `test_a_payload_mutated_between_MINT_and_POST_is_refused` |
| M8 | ambiguity silently picks the first match | KILLED by `test_refusal_ambiguous_name` |
| M9 | placeholder identity allowed on the wire | KILLED by `test_refusal_placeholder_contact` |
| M10 | mentions dropped from the wire payload | KILLED by `test_the_send_payload_carries_the_mentions_array_EXACTLY` |
| M11 | non-member id accepted as an author | KILLED by `test_refusal_identifier_is_not_a_member_of_this_group` |
| M12 | missing `@` span silently becomes offset 0 | KILLED by `test_refusal_the_at_substring_is_absent_from_the_body` |

Both controls behaved, so the table is a claim about the code and not about the harness.
M6 mutates only the *mentions* half of the binding, so a guard that covered
recipient+body would have survived it.

🔴 **The harness itself had to be fixed mid-sweep, and the first result set was a lie in
the reassuring direction.** The verdict classifier tested `"error" in out.lower()`, which
matched the word `SendGateError` inside legitimate failure tracebacks and scored **eight
genuine kills** as "collection error — mutant never ran". It now parses pytest's summary
line. Two rows (M4, M7) then reported "KILLED but not by the expected guard" because
`pytest.raises` prints `DID NOT RAISE` rather than the guard's message when the guard is
gone; both were re-run with the corrected expectation and are attributed above.

## Also changed

- Existing test doubles gained a `mentions=None` kwarg (signature ripple from
  `send_approved()` now passing it through). No assertions were weakened.
- `test_the_only_send_call_site_is_inside_transmit_approved` used to pin the literal
  `spend_authorization(auth)`. It now pins the **whole call with its arguments** — a call
  that passed `recipient` and `body` but quietly dropped `mentions` would still compile,
  and would send an unbound mentions array while every other test stayed green.
- The exact-equality payload assertion and the card-shape assertion are kept **exact**;
  a mention-free send is asserted to carry no `mentions` key at all, so the pre-existing
  request shape is unchanged byte for byte.
- `_mentions.py` added to the Dockerfile COPY list and `Dockerfile.dockerignore`
  allowlist — both existing ledger tests caught its absence, which is the guard working.
- `SKILL.md`: a `Mentions` section with the refusal table, and step 4 of the D3 send path.

## 🔴 NOT proven

- **No live Signal message was sent.** No `send`, no `POST /v2/send`, no approval. The
  `mentions` array has therefore never been accepted by the real server — the wire
  contract is read from signal-cli 0.14.7's `data.MessageMention`, and everything here is
  asserted against that reading, not against a response.
- **UUID-as-`author` is untested end to end.** It is accepted by
  `RecipientIdentifier.Single.fromString` per the source, and the resolver prefers a uuid
  over a phone number, but no real client has rendered one.
- **`GET /v1/groups/{number}/{groupid}` is untested against the live server on this
  branch.** `fetch_group_members()` flattens the reply shapes defensively, and the tests
  pin that flattening — they do not pin which shape the deployed server returns.
- **Offsets are not verified against a receiving client.** The UTF-16 arithmetic is
  correct by construction and mutation-tested; nobody has watched Signal render
  `@DisplayName` over the span.
- The hermetic substrate is SQLite. The `ALTER TABLE` idempotency is *emulated* there;
  the Postgres `IF NOT EXISTS` semantics are taken from the docs, not measured against a
  real server. `phpunit`-style pg gating does not exist for this suite.

## 🔴 DEPLOY PREREQUISITE — drain the pre-existing `approved` drafts FIRST

The approval digest **fails closed on `approved_digest IS NULL`**, which is the right
call and is deliberate. The consequence is not free: every draft approved *before* this
branch carries NULL, so the first `send` after rollout refuses it. Before rolling out,
list them:

```sql
SELECT id, send_state, approval_ref, message_timestamp
  FROM signal.messages
 WHERE send_state = 'approved' AND approved_digest IS NULL;
```

Each one is recovered through the CLI, with no SQL:

```bash
python3 consumer.py drafts --state approved         # read what it says now
python3 consumer.py unapprove <id> --note "pre-digest approval"
python3 consumer.py approve  <id> --ref <clawgate-ref>
```

`unapprove` is new on this branch and is the **only** route out of a digest refusal —
without it such a draft is unsendable forever (see the round-1 fix commit). Both
commands need `SIGNAL_APPROVAL_TOKEN`, i.e. they run from the operator's shell, not
from the pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kSS5u8boaYshvwSy4qRXF

