### PR TITLE
fix(CLAUDE): the break-glass hands over the DELETE — give it the restore that actually works

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,8 +171,50 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   `.github/workflows`, so the marker stays `other`.
   🔴 **`enforce_admins: true` is LIVE now** — it protected nothing while nothing was
   required. If Tekton is down or wedged, NOTHING merges and there is no admin override.
-  The escape hatch, deliberately written down because you will want it under pressure:
-  `gh api -X DELETE /repos/innovation-upstream/devrc/branches/main/protection/required_status_checks`
+  The escape hatch, deliberately written down because you will want it under pressure —
+  🔴 **and it does NOT round-trip. Read all four steps before you run step 2.** MEASURED
+  over three uses on 2026-08-29/30: `DELETE` opens the window and **`PATCH` cannot close
+  it**, so two restores failed — one of them inside an EXIT trap that fired exactly as
+  designed and still left `main` open, because the untested command was *inside* the
+  safety net. `PATCH …/required_status_checks` **404s `Required status checks not
+  enabled`**: it updates checks that exist, it cannot recreate a deleted sub-resource.
+  Closing the window needs a full `PUT` of the WHOLE protection object.
+  ```bash
+  R=innovation-upstream/devrc; S=<scratchpad>          # 1. CAPTURE FIRST — without this
+  gh api /repos/$R/branches/main/protection --jq '{    #    you cannot restore at all.
+    required_status_checks:{strict:.required_status_checks.strict,
+      checks:[.required_status_checks.checks[]|{context,app_id}]},
+    enforce_admins:.enforce_admins.enabled,
+    required_pull_request_reviews, restrictions,
+    required_linear_history:.required_linear_history.enabled,
+    allow_force_pushes:.allow_force_pushes.enabled,
+    allow_deletions:.allow_deletions.enabled,
+    block_creations:.block_creations.enabled,
+    required_conversation_resolution:.required_conversation_resolution.enabled,
+    lock_branch:.lock_branch.enabled,
+    allow_fork_syncing:.allow_fork_syncing.enabled}' > $S/restore.json
+  gh api -X DELETE /repos/$R/branches/main/protection/required_status_checks   # 2. OPEN
+  gh api -X PUT /repos/$R/branches/main/protection --input $S/restore.json     # 3. CLOSE
+  gh api /repos/$R/branches/main/protection > $S/after.json                    # 4. READ BACK
+  ```
+  🔴 **Step 4 is not optional, and step 1 is what makes it possible.** A PARTIAL `PUT`
+  succeeds and silently drops every key you omitted — `enforce_admins`, force-push and
+  deletion settings included — so `PUT` returning 200 is a claim about the REQUEST, never
+  about the protection. Diff `after` against the step-1 capture **key by key** and report
+  which keys matched; `restore: OK` printed by your own trap is not evidence. All 11 keys
+  are load-bearing: `required_status_checks`, `enforce_admins`,
+  `required_pull_request_reviews` and `restrictions` are *required* by the endpoint (the
+  last two are legitimately `null` here), and the `app_id` pinning inside `checks` is what
+  makes the restored context bind to Tekton rather than to any app that can post the name.
+  ⚠ **Not measured, so do not reach for it under pressure:** whether `PUT` with
+  `required_status_checks: null` opens the window symmetrically was never tried — the
+  `DELETE`/`PUT` asymmetry above is what has actually been run.
+  🔴 **The backstop is a DETECTOR, not a restore:** `drift-check.sh` rc 24 reports an
+  unprotected `main`, on a timer that repeats every `OnUnitActiveSec=6h` — so detection
+  lags by up to a full interval, and only where the deadman is actually wired in
+  (`serverMode && enableDriftDeadman`; the timer runs on the workbench). It catches a
+  botched restore after the fact; it does not undo one, and it is not a substitute for
+  step 4.
   ⚠ **`strict` is FALSE on purpose.** `strict: true` would force every PR to be up to date
   with `main` before merging — correct in principle, and unworkable here: `main` moved 11+
   times in one session and each move would re-queue a ~20-minute gate for every open PR.

--- a/claudedocs/handoff-clipboard-research.md
+++ b/claudedocs/handoff-clipboard-research.md
@@ -18,31 +18,27 @@ Research modern best practices for clipboard and terminal clipboard interaction 
 
 ## State now
 
-- **Rank 1 is DONE and CLOSED OUT.** `drift-check.sh` gained **rc 24**, an
-  unprotected-`main` detector: merged **#1065 → `ebbe5eaa`**, and this handoff
-  merged **#1116 → `db790e08`**. Both hosts converged and **compared** at
-  **`e9437342`** (`ship: converged + verified — 2 hosts compared, both at …`).
-- **Verified live under the real systemd unit**, not by reading files —
-  `systemctl --user start drift-check` then the journal:
-  ```
-  [protect] innovation-upstream/devrc main: 2 required status check(s) — tekton/devrc-pytests,tekton/devrc-nodetests
-  [protect]   enforce_admins=true — the checks bind admins too.
-  drift-check: no drift on the host(s) CHECKED: workbench (local), laptop (remote)
-  ```
-  `gh` resolves on the unit's own `Environment` PATH on **both** hosts. The timer
-  runs on the **workbench only**, so that host is the one that matters.
-- **Side work that unblocked this:** **#1069** re-pinned the skill-tier
-  measurements — `main` was RED for every open PR until it landed. The
-  `TARGET_FLOORS` three-way conflict was resolved by measuring the merged tree,
-  not by taking a side.
-- **Also fixed:** the laptop's `homelab-talos` was 31 commits behind with **1
-  touching `containers/clawgate`**, the subtree `clawgatectl` compiles from.
-  Fast-forwarded + re-switched; both hosts' built sources now CURRENT.
-  ⚠ `clawgatectl --version` read **0.8.18 before and after** — the version string
-  was not the signal, the deadman was.
-- Claims released (`clipboard-research-1`, `quiesce-workload-rescue`,
-  `skill-tier-measurement-repin`); this session's worktrees and `refs/audit/*`
-  removed.
+- **Rank 2 is BUILT, committed and pushed — NOT merged.** Branch
+  `fix/break-glass-restore-recipe`, commit **`b22c1d78`**, based on `53f523ed`.
+  No PR opened yet; the full gate was still running when this doc was written.
+  Files: `CLAUDE.md` (the escape-hatch note), `scripts/tests/test_break_glass_note.py` (new).
+- **What it changes.** The break-glass note handed over
+  `gh api -X DELETE …/branches/main/protection/required_status_checks` and said
+  nothing about closing the window. It now carries the four-step round trip:
+  **capture → open → full `PUT` → read back**, with the capture command run live
+  against the real endpoint and verified to emit all **11** keys the `PUT`
+  requires, in the shape of the restore that actually worked on 2026-08-30.
+- **Rank 1 (rc 24) remains DONE** — #1065 → `ebbe5eaa`, verified live under the
+  real systemd unit. Unchanged by this session.
+- **Verification of the new guard:** red at `53f523ed` with the real finding
+  (`carries no -X PUT`), green at `b22c1d78`; mutation sweep **7/7 killed**,
+  control green, under `PYTHONDONTWRITEBYTECODE=1`.
+- ⚠ **Not merged, not deployed, not shipped.** `CLAUDE.md` is repo-root prose so
+  no `home-manager switch` is needed for it to take effect, but the branch is
+  not on `main` yet — nothing reading `main` sees the corrected note.
+- Claim `clipboard-research-2` is **HELD, not released** (this session still
+  owns rank 2 until the PR lands). Worktrees `devrc-breakglass` and
+  `devrc-baseglass` are still on disk and must be removed at close-out.
 
 ## Research findings — clipboard/terminal clipboard best practices (2025-2026)
 
@@ -145,6 +141,10 @@ of by a human happening to look.
 
 ## Next steps (ranked)
 
+🔴 **Numbering is deliberately STABLE across this update** — rank is half a
+`claim-work` slug's identity, so item 2 is marked done in place rather than
+removed and the rest are not renumbered.
+
 **Closed by this effort — kept so a resume does not re-open them:**
 - ~~adopt `set clipboard=unnamedplus`~~ — **DECLINED 2026-08-29**: it routes every
   `d`/`c`/`x`/`s` through the `+` register, so `dd` clobbers the system clipboard.
@@ -156,27 +156,25 @@ of by a human happening to look.
 - ~~**Add an unprotected-`main` arm to `scripts/drift-check.sh`**~~ — **SHIPPED
   2026-08-30** as rc 24, #1065 → `ebbe5eaa`, verified live under the real unit.
 
-1. **Give the rc-24 arm an UNMEASURED ladder** (devrc). It now has THREE
+1. **Give the rc-24 arm an UNMEASURED ladder** (devrc). It has THREE
    could-not-measure states, and a lapsed/expired `gh` token leaves it blind
-   **forever** while the deadman reads clean — verbatim the rc-18 lesson this same
-   file already records ("a scope that can never be evaluated escalated NEVER").
-   The `enforce_admins` half additionally needs repo-**admin**, which is the
-   credential most likely to lapse. Files: `scripts/drift-check.sh` (reuse the
+   **forever** while the deadman reads clean — verbatim the rc-18 lesson this
+   repo already records ("a scope that can never be evaluated escalated NEVER").
+   The `enforce_admins` half additionally needs repo-**admin**, the credential
+   most likely to lapse. Files: `scripts/drift-check.sh` (reuse the
    `u_streak_bump`/`_streak_file_bump` machinery), `scripts/tests/test_drift_check.py`.
    forcing: none
-2. **Correct `devrc/CLAUDE.md`'s break-glass note** (devrc). It hands over
-   `gh api -X DELETE …/required_status_checks` verbatim and says **nothing about
-   restoring** — and the obvious `PATCH` back **silently fails**, which is why the
-   2026-08-29 break-glass left `main` unprotected despite an EXIT-trap restore that
-   ran. It must carry the full `PUT` payload and say the restore has to be READ
-   BACK. Files: `CLAUDE.md`.
-   forcing: incident — the 2026-08-29 double unprotection; occurrence 1's restore
+2. ~~**Correct `devrc/CLAUDE.md`'s break-glass note**~~ — **BUILT 2026-08-30,
+   IN FLIGHT: branch `fix/break-glass-restore-recipe` @ `b22c1d78`, no PR yet.**
+   Close it out: confirm the gate, open the PR, merge, then
+   `claim-work --release clipboard-research-2` and remove both worktrees.
+   forcing: incident — the 2026-08-29/30 unprotections; occurrence 1's restore
    trap executed and still left main open, occurrence 2 left a direct push
    (`837d3fde`) on main that required checks would have rejected.
 3. **Run `/audit-pr 1043`** (devrc) — the one review the clipboard effort never
-   got, and it touches `nix/programs/`, which every `home-manager switch` depends
-   on. Merged, shipped and verified on the real path, so this is confirmation
-   rather than a gate. Files: `nix/programs/`, `.config/nvim/`.
+   got, and it touches `nix/programs/`, which every `home-manager switch`
+   depends on. Merged, shipped and verified on the real path, so this is
+   confirmation rather than a gate. Files: `nix/programs/`, `.config/nvim/`.
    forcing: none
 4. **Consider recording the transferable lesson in `claude/RULES.md`**: *a fixture
    that supplies an environment cannot observe that environment being absent.*
@@ -187,6 +185,15 @@ of by a human happening to look.
    **CLOSED**, so the cost is a test edit, not safety — but `--paginate` is a
    plausible near-term need on `/rules/branches/main`. Files:
    `scripts/tests/test_drift_check.py`.
+   forcing: none
+6. **OFFERED, NOT BUILT — `scripts/break-glass-merge.sh`** (devrc). The
+   deterministic version of the recipe rank 2 just wrote into prose: capture,
+   open, merge, full `PUT`, read back, and **refuse to exit 0 unless the
+   read-back diff matches the capture key-by-key**. Deliberately not built this
+   session: shipping an *untested* command into a break-glass path is precisely
+   the failure rank 2 corrects, and it cannot be tested end-to-end without
+   opening the window on `main`. Needs an operator decision on how to prove it
+   before it is trusted. Files: `scripts/break-glass-merge.sh` (new).
    forcing: none
 
 ## Gotchas / decisions / dead-ends
@@ -392,8 +399,70 @@ It now sits under `## Gotchas`, which appends.
   appends. **Where a durable claim SITS decides whether it survives**, and a
   retraction is the class that must.
 
+### The 2026-08-30 break-glass correction (rank 2)
+
+- 🔴 **`PATCH` does not "silently fail" — it 404s, and the distinction changes
+  the fix.** The prior handoff recorded the symptom as silent. Primary evidence
+  from two sessions says otherwise: `PATCH …/protection/required_status_checks`
+  returns **`Required status checks not enabled`** once the sub-resource is
+  deleted. It *updates checks that exist*; it cannot recreate a deleted
+  sub-resource. What made it look silent is the idiom around it — a restore
+  inside an EXIT trap written `>/dev/null 2>&1`, which discards the very message
+  that names the cause.
+- 🔴 **The bigger hazard is the one the summary omitted: a PARTIAL `PUT`
+  returns 200 and silently drops every key it does not carry** — `enforce_admins`,
+  force-push and deletion settings included. So "the PUT returned 200" is a claim
+  about the REQUEST, never about the protection, and the read-back is not
+  optional. All **11** keys are load-bearing;
+  `required_status_checks`/`enforce_admins`/`required_pull_request_reviews`/`restrictions`
+  are *required* by the endpoint (the last two are legitimately `null` here), and
+  the `app_id` pinning inside `checks` is what binds the restored context to
+  Tekton rather than to any app that can post the same name.
+- ⚠ **NOT MEASURED and deliberately labelled so in `CLAUDE.md`:** whether
+  `PUT` with `required_status_checks: null` opens the window symmetrically. The
+  `DELETE`/`PUT` asymmetry is what has actually been run. Recording an untested
+  alternative as an option is how the original trap got its untested command.
+- 🔴 **A guard's own positive control caught the guard being vacuous — keep the
+  control.** `test_break_glass_note.py` first parsed `gh api` paths with
+  `/repos/[^\s'"]+`, which swallows the closing **backtick**. `CLAUDE.md` writes
+  the DELETE inline in backticks, so the parser saw **no** DELETE in a document
+  that plainly contained one, and the round-trip assertion passed **VACUOUSLY**
+  on exactly the note it exists to reject. The separate
+  `test_the_note_still_offers_the_escape_hatch` control is what failed and
+  exposed it. **A guard over MARKDOWN must be tested against the markdown
+  rendering, not just the bare command.**
+- 🔴 **Two mutants SURVIVED the first sweep; both were fixture gaps, not logic
+  bugs.** `put-accepts-patch` — nothing fed a `PATCH` on the protection
+  **object**, so widening the verb test to `("PUT","PATCH")` went unnoticed and
+  the guard would have accepted a note recommending an unmeasured restore verb.
+  `checks-anchor-dropped` — `…/required_status_checks/contexts` is a real and
+  different endpoint, misclassified as the sub-resource once the `\Z` anchors
+  went. **The sweep only ever tests the mutations you imagined**; the fix was to
+  vary the axes, not to add more mutants of the same shape.
+- **Why the recipe was not re-verified live:** confirming it would mean `PUT`ing
+  protection back over itself on `main`. The step is already measured by a real
+  run (2026-08-30, read-back diffed key-by-key, "FAITHFUL — every key matches"),
+  so a second confirmation buys little against a write to the protection surface
+  that has already gone wrong three times this week. The capture half *was* run
+  live, because it is a read.
+
+### The kickoff block's own path format is a live trap
+
+- 🔴 **A `devrc/claudedocs/…` prefix in a kickoff does NOT resolve, and the
+  failure is quiet in the direction that matters.** `resume-state.sh` matched no
+  such file, **fell back to the newest of 90** handoff docs
+  (`handoff-browser-bridge-architecture-trace.md`) and reconciled a *different
+  initiative* — DRIFT lines, PR states and all. The only tell was the `!! GAPS`
+  banner naming the file it could not find. Re-running with the repo-relative or
+  absolute path reconciled correctly. **Read the gap banner before the DRIFT
+  block**; a clean-looking digest under a fallback is a digest about other work.
+  `/handoff` emits the prefixed form, so this will recur — pass the path as it
+  exists on disk.
+
 ## How to verify
-- 🔴 **The rc-24 arm, under the real unit** — not by reading the file:
+
+- 🔴 **The rc-24 arm, under the real unit** — not by reading the file. Carried
+  forward from the rank-1 close-out; still the only honest check for that arm:
   ```
   systemctl --user start drift-check
   journalctl --user -u drift-check --since '5 minutes ago' | grep '\[protect\]'
@@ -408,5 +477,26 @@ It now sits under `## Gotchas`, which appends.
   env PATH="$P" sh -c 'command -v gh'
   ```
 - **Both hosts agree:** `scripts/ship.sh` must end `2 hosts compared, both at <sha>` —
-  a one-host run says `cross-host agreement NOT COMPARED`, which is a different claim.
-- Neovim off-display, tmux/espanso clipboard: unchanged, see the section above.
+  a one-host run says `cross-host agreement NOT COMPARED`, a different claim.
+- **The break-glass guard, red at base and green at HEAD** — the claim is the
+  MATRIX, not either half:
+  ```bash
+  git -C ~/workspace/devrc worktree add --detach /tmp/bg-base 53f523ed
+  cp <branch>/scripts/tests/test_break_glass_note.py /tmp/bg-base/scripts/tests/
+  PYTHONDONTWRITEBYTECODE=1 nix develop ~/workspace/devrc -c \
+    python3 -m pytest /tmp/bg-base/scripts/tests/test_break_glass_note.py -q
+  # expect: 1 failed (test_the_break_glass_note_round_trips, "carries no -X PUT")
+  PYTHONDONTWRITEBYTECODE=1 nix develop ~/workspace/devrc -c \
+    python3 -m pytest ~/workspace/devrc/scripts/tests/test_break_glass_note.py -q
+  # expect: all passed
+  ```
+- **The vacuity control is the one that matters** — if
+  `test_the_note_still_offers_the_escape_hatch` fails, the round-trip assertion
+  is passing on a document with no DELETE in it and proves nothing.
+- **The `<!-- merge-gate: other -->` marker must survive the edit** — it sits
+  three lines above the changed region and is parsed by
+  `scripts/tests/test_ci_claim_matches_reality.py`, which must stay green.
+- **Both tiers, one at a time** (the dev-host tier is NOT the tier Tekton gates
+  on): `nix develop <repo> --command bash <repo>/scripts/gate.sh --tier both`,
+  then `nix build .#checks.x86_64-linux.pytests` and
+  `.#checks.x86_64-linux.nodetests` **separately**.

--- a/scripts/tests/test_break_glass_note.py
+++ b/scripts/tests/test_break_glass_note.py
@@ -1,0 +1,350 @@
+"""The break-glass note in CLAUDE.md must round-trip, not just open the window.
+
+MEASURED, three times on 2026-08-29/30: the note handed over
+
+    gh api -X DELETE .../branches/main/protection/required_status_checks
+
+and said nothing about restoring. `PATCH .../required_status_checks` 404s
+("Required status checks not enabled") once the sub-resource is gone, so the
+obvious restore fails; two real restores did, one of them inside an EXIT trap
+that fired exactly as designed. Closing the window needs a full `PUT` of the
+whole protection object, and a partial `PUT` succeeds while silently dropping
+every key it omits -- so the restore has to be READ BACK, never trusted.
+
+WHAT THIS GUARD ASSERTS, and it is a RELATIONSHIP rather than a vocabulary:
+if CLAUDE.md hands anyone the DELETE, then the same document must also carry
+
+  1. a CAPTURE of the protection object that REDIRECTS TO A FILE, before the DELETE;
+  2. a full PUT of the protection OBJECT (not the sub-resource), after the DELETE,
+     whose `--input` names THE FILE STEP 1 WROTE;
+  3. a read-back of the protection object after the PUT.
+
+Point 2 is the load-bearing one and the reason this is not a keyword check: a
+note that says "PUT it back" while never telling you to capture first is exactly
+as useless as the note this replaces, because you would have nothing to PUT. The
+linkage is asserted by matching the capture's redirect target against the PUT's
+`--input` argument, so prose can be reworded freely and the guard still holds --
+and cannot pass by spelling the word "restore" somewhere.
+
+It fires ONLY when the DELETE is present. Removing the escape hatch entirely is
+a legitimate edit and this test does not forbid it; what it forbids is handing
+over the destructive half alone.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+CLAUDE_MD = REPO / "CLAUDE.md"
+
+# A `gh api` invocation may span several physical lines (the capture's --jq
+# program does). Split the document on the invocations themselves so each chunk
+# holds one whole command, including a redirect that lands lines later.
+_GH_SPLIT = re.compile(r"gh api\b")
+_VERB = re.compile(r"\A\s*-X\s+([A-Z]+)\b")
+# Markdown wraps commands in backticks, and CLAUDE.md writes most of its
+# one-liners that way -- including the break-glass DELETE this guard exists for.
+# A path regex that swallows the closing backtick makes the parser blind to
+# exactly the document shape being policed: the round-trip assertion then passes
+# VACUOUSLY. Caught by test_the_note_still_offers_the_escape_hatch against the
+# pre-change CLAUDE.md, which is why that control is not decoration.
+_PATH = re.compile(r"(/repos/[^\s'\"`]+)")
+_PATH_TRAILING = "`.,;:)]}>"
+_INPUT = re.compile(r"--input\s+(\S+)")
+_REDIRECT = re.compile(r">\s*(\S+\.json)\b")
+
+# The protection OBJECT vs the required_status_checks SUB-RESOURCE. The whole
+# incident is that these two are not interchangeable.
+_OBJECT = re.compile(r"/branches/[^/\s]+/protection\Z")
+_CHECKS = re.compile(r"/branches/[^/\s]+/protection/required_status_checks\Z")
+
+
+class GhCall:
+    __slots__ = ("verb", "path", "input_file", "redirect_file", "offset")
+
+    def __init__(self, verb, path, input_file, redirect_file, offset):
+        self.verb = verb
+        self.path = path
+        self.input_file = input_file
+        self.redirect_file = redirect_file
+        self.offset = offset
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics only
+        return f"<gh api -X {self.verb} {self.path} @{self.offset}>"
+
+    @property
+    def on_object(self) -> bool:
+        return bool(self.path and _OBJECT.search(self.path))
+
+    @property
+    def on_checks(self) -> bool:
+        return bool(self.path and _CHECKS.search(self.path))
+
+
+def parse_gh_calls(body: str) -> list[GhCall]:
+    """Every `gh api` invocation in `body`, in document order.
+
+    The verb is None for a plain read (no -X), which is what a read-back is.
+    """
+    calls: list[GhCall] = []
+    marks = list(_GH_SPLIT.finditer(body))
+    for i, m in enumerate(marks):
+        end = marks[i + 1].start() if i + 1 < len(marks) else len(body)
+        chunk = body[m.end() : end]
+        verb_m = _VERB.match(chunk)
+        path_m = _PATH.search(chunk)
+        input_m = _INPUT.search(chunk)
+        redirect_m = _REDIRECT.search(chunk)
+        calls.append(
+            GhCall(
+                verb=verb_m.group(1) if verb_m else None,
+                path=path_m.group(1).rstrip(_PATH_TRAILING) if path_m else None,
+                input_file=input_m.group(1) if input_m else None,
+                redirect_file=redirect_m.group(1) if redirect_m else None,
+                offset=m.start(),
+            )
+        )
+    return calls
+
+
+def audit(body: str) -> list[str]:
+    """Findings against the round-trip contract. Empty list == compliant."""
+    calls = parse_gh_calls(body)
+    deletes = [c for c in calls if c.verb == "DELETE" and c.on_checks]
+    if not deletes:
+        # The escape hatch is not offered; there is nothing to round-trip.
+        return []
+    first_delete = min(c.offset for c in deletes)
+
+    findings: list[str] = []
+
+    puts = [c for c in calls if c.verb == "PUT" and c.on_object and c.offset > first_delete]
+    if not puts:
+        findings.append(
+            "CLAUDE.md hands over `gh api -X DELETE .../protection/required_status_checks` "
+            "but carries no `-X PUT` of the protection OBJECT after it. `PATCH` on the "
+            "sub-resource 404s once it is deleted -- the window cannot be closed with what "
+            "this document currently provides."
+        )
+        return findings
+
+    captures = {
+        c.redirect_file
+        for c in calls
+        if c.verb is None and c.on_object and c.redirect_file and c.offset < first_delete
+    }
+    if not captures:
+        findings.append(
+            "The restoring `PUT` is present but nothing CAPTURES the protection object to a "
+            "file before the DELETE. Without a capture there is no payload to PUT, and a "
+            "partial PUT silently drops the keys it omits."
+        )
+
+    linked = [p for p in puts if p.input_file and p.input_file in captures]
+    if captures and not linked:
+        inputs = sorted({p.input_file for p in puts if p.input_file} or {"<no --input>"})
+        findings.append(
+            "The restoring `PUT` does not read the file the capture wrote: capture writes "
+            f"{sorted(captures)}, PUT reads {inputs}. The restore is not wired to the backup."
+        )
+
+    put_offset = min(p.offset for p in (linked or puts))
+    readbacks = [
+        c for c in calls if c.verb is None and c.on_object and c.offset > put_offset
+    ]
+    if not readbacks:
+        findings.append(
+            "Nothing READS BACK the protection object after the restoring `PUT`. A partial "
+            "PUT returns 200, so the request's own status is not evidence that protection "
+            "was restored."
+        )
+    return findings
+
+
+# --------------------------------------------------------------------------
+# The subject.
+# --------------------------------------------------------------------------
+
+
+def test_claude_md_is_readable() -> None:
+    assert CLAUDE_MD.is_file(), f"no CLAUDE.md at {CLAUDE_MD}"
+    assert CLAUDE_MD.stat().st_size > 1000
+
+
+def test_the_break_glass_note_round_trips() -> None:
+    findings = audit(CLAUDE_MD.read_text(encoding="utf-8"))
+    assert not findings, "CLAUDE.md's break-glass note is one-way:\n  - " + "\n  - ".join(
+        findings
+    )
+
+
+def test_the_note_still_offers_the_escape_hatch() -> None:
+    """Positive control on the SUBJECT: the guard above is not vacuous today.
+
+    `audit()` returns clean for a document that never mentions the DELETE. This
+    pins that CLAUDE.md is not that document, so a green run above is a real
+    round-trip and not an absence of the hazard.
+    """
+    calls = parse_gh_calls(CLAUDE_MD.read_text(encoding="utf-8"))
+    assert [
+        c for c in calls if c.verb == "DELETE" and c.on_checks
+    ], "no break-glass DELETE found in CLAUDE.md -- test_the_break_glass_note_round_trips passes VACUOUSLY"
+
+
+# --------------------------------------------------------------------------
+# Controls on the INSTRUMENT. Until these pass, a green above is a fact about
+# the parser only.
+# --------------------------------------------------------------------------
+
+_DELETE = "gh api -X DELETE /repos/o/r/branches/main/protection/required_status_checks\n"
+_CAPTURE = "gh api /repos/o/r/branches/main/protection --jq '{a:1}' > $S/restore.json\n"
+_PUT = "gh api -X PUT /repos/o/r/branches/main/protection --input $S/restore.json\n"
+_READBACK = "gh api /repos/o/r/branches/main/protection > $S/after.json\n"
+COMPLIANT = _CAPTURE + _DELETE + _PUT + _READBACK
+
+
+def test_negative_control_the_audit_can_go_red() -> None:
+    """Realistic bad inputs, each a shape that has actually been written."""
+    # The note exactly as it stood before this fix: the DELETE, alone.
+    assert audit("The escape hatch:\n" + _DELETE), "a DELETE-only note must be a finding"
+
+    # The restore that was actually attempted, twice, and 404s.
+    patch_only = (
+        _CAPTURE
+        + _DELETE
+        + "gh api -X PATCH /repos/o/r/branches/main/protection/required_status_checks --input $S/restore.json\n"
+        + _READBACK
+    )
+    findings = audit(patch_only)
+    assert findings, "a PATCH on the sub-resource must not satisfy the PUT requirement"
+    assert "no `-X PUT`" in findings[0]
+
+    # A PUT on the sub-resource rather than the object.
+    assert audit(
+        _CAPTURE
+        + _DELETE
+        + "gh api -X PUT /repos/o/r/branches/main/protection/required_status_checks --input $S/restore.json\n"
+        + _READBACK
+    ), "a PUT on the SUB-RESOURCE must not satisfy the object requirement"
+
+    # PATCH on the protection OBJECT. GitHub documents only GET/PUT/DELETE
+    # there, so this is an invented verb -- and accepting it would let the note
+    # recommend an unmeasured restore, which is the whole incident. Without this
+    # case a mutant widening the verb test to `in ("PUT", "PATCH")` SURVIVES.
+    assert audit(
+        _CAPTURE
+        + _DELETE
+        + "gh api -X PATCH /repos/o/r/branches/main/protection --input $S/restore.json\n"
+        + _READBACK
+    ), "PATCH on the protection OBJECT must not satisfy the PUT requirement"
+
+    # PUT present, but nothing captured beforehand -- nothing to restore from.
+    assert audit(_DELETE + _PUT + _READBACK), "a missing capture must be a finding"
+
+    # Capture and PUT both present but not wired together.
+    assert audit(
+        _CAPTURE
+        + _DELETE
+        + "gh api -X PUT /repos/o/r/branches/main/protection --input $S/something-else.json\n"
+        + _READBACK
+    ), "a PUT reading a different file than the capture wrote must be a finding"
+
+    # No read-back: the exact thing that let a failed restore report OK.
+    assert audit(_CAPTURE + _DELETE + _PUT), "a missing read-back must be a finding"
+
+    # Read-back placed BEFORE the restore proves nothing about the restore.
+    assert audit(_CAPTURE + _DELETE + _READBACK + _PUT), "a read-back before the PUT must be a finding"
+
+    # Capture placed AFTER the window is already open captures the broken state.
+    assert audit(_DELETE + _CAPTURE + _PUT + _READBACK), "a capture after the DELETE must be a finding"
+
+
+def test_positive_control_the_audit_passes_a_compliant_note() -> None:
+    """Can it ever return clean? A red-always guard is as useless as a green one."""
+    assert audit(COMPLIANT) == [], "the compliant fixture must produce no findings"
+
+
+def test_the_guard_is_scoped_to_documents_that_offer_the_hatch() -> None:
+    """No DELETE => no obligation. Removing the hatch is a legitimate edit."""
+    assert audit("There is no escape hatch. Ask a human.") == []
+    assert audit(_CAPTURE + _READBACK) == [], "reads alone impose no restore obligation"
+
+
+@pytest.mark.parametrize(
+    "verb,path,expect_object,expect_checks",
+    [
+        (None, "/repos/o/r/branches/main/protection", True, False),
+        ("PUT", "/repos/o/r/branches/main/protection", True, False),
+        ("DELETE", "/repos/o/r/branches/main/protection/required_status_checks", False, True),
+        # A different branch is still the same two shapes.
+        ("PUT", "/repos/o/r/branches/release-1.x/protection", True, False),
+        # Neither: a neighbouring endpoint must not be mistaken for either.
+        (None, "/repos/o/r/branches/main/protection/enforce_admins", False, False),
+        (None, "/repos/o/r/branches/main", False, False),
+        # `.../required_status_checks/contexts` is a REAL and DIFFERENT endpoint
+        # (it drops individual contexts). Both patterns are \Z-anchored so it is
+        # neither; without those anchors this row is misclassified as the
+        # sub-resource and a mutant dropping them SURVIVES.
+        (
+            "DELETE",
+            "/repos/o/r/branches/main/protection/required_status_checks/contexts",
+            False,
+            False,
+        ),
+    ],
+)
+def test_endpoint_classification(verb, path, expect_object, expect_checks) -> None:
+    """The object/sub-resource distinction IS the incident -- pin it directly."""
+    line = f"gh api {'-X ' + verb + ' ' if verb else ''}{path}\n"
+    (call,) = parse_gh_calls(line)
+    assert call.verb == verb
+    assert call.path == path
+    assert call.on_object is expect_object
+    assert call.on_checks is expect_checks
+
+
+@pytest.mark.parametrize(
+    "rendering",
+    [
+        "`gh api -X DELETE /repos/o/r/branches/main/protection/required_status_checks`",
+        "  `gh api -X DELETE /repos/o/r/branches/main/protection/required_status_checks`\n",
+        "run `gh api -X DELETE /repos/o/r/branches/main/protection/required_status_checks`.",
+        "gh api -X DELETE /repos/o/r/branches/main/protection/required_status_checks",
+        "(gh api -X DELETE /repos/o/r/branches/main/protection/required_status_checks)",
+    ],
+)
+def test_a_backticked_command_is_not_invisible(rendering) -> None:
+    """MEASURED against the pre-change CLAUDE.md, which wrote the DELETE inline.
+
+    The path regex originally captured the closing backtick, so `on_checks`
+    (anchored with \\Z) was False and the parser saw NO break-glass DELETE in a
+    document that plainly contained one -- making the round-trip assertion pass
+    vacuously on exactly the note it was written to reject.
+    """
+    (call,) = parse_gh_calls(rendering)
+    assert call.verb == "DELETE"
+    assert call.on_checks, f"DELETE invisible to the parser when written as: {rendering!r}"
+    # ...and the obligation it creates must actually fire.
+    assert audit(rendering), "a backticked DELETE must still demand a restore"
+
+
+def test_multiline_commands_are_parsed_as_one_call() -> None:
+    """The real capture spans 11 lines and its redirect is on the last one.
+
+    A per-line parser reads that as a call with no redirect and reports a
+    missing capture on a compliant document.
+    """
+    multiline = (
+        "gh api /repos/o/r/branches/main/protection --jq '{\n"
+        "  required_status_checks:{strict:.required_status_checks.strict},\n"
+        "  enforce_admins:.enforce_admins.enabled,\n"
+        "  restrictions}' > $S/restore.json\n"
+    ) + _DELETE + _PUT + _READBACK
+    calls = parse_gh_calls(multiline)
+    assert len(calls) == 4, f"expected 4 gh calls, parsed {len(calls)}: {calls}"
+    assert calls[0].redirect_file == "$S/restore.json"
+    assert audit(multiline) == []


### PR DESCRIPTION
The escape-hatch note named `gh api -X DELETE .../branches/main/protection/required_status_checks` and said **nothing about closing the window**. MEASURED over three uses on 2026-08-29/30, **two restores failed** — one inside an EXIT trap that fired exactly as designed, because the untested command was *inside* the safety net.

## The prior handoff's summary understated it, in two ways that change the fix

- **`PATCH` does not "silently fail" — it 404s `Required status checks not enabled`.** It updates checks that *exist*; it cannot recreate a deleted sub-resource. What made it look silent is the idiom around it: a restore written `>/dev/null 2>&1`, discarding the message that names the cause.
- **The bigger hazard was not in the summary at all: a PARTIAL `PUT` returns 200 and silently drops every key it omits** — `enforce_admins`, force-push and deletion settings. So "the PUT returned 200" is a claim about the REQUEST, never about the protection. That is why the read-back is mandatory, not advice.

The note now carries **capture → open → full `PUT` → read back**. The capture command was run live against the real endpoint and verified to emit all **11** keys the `PUT` requires, in the shape of the restore that actually worked on 2026-08-30. The `PUT ... required_status_checks: null` symmetric-open variant is labelled **NOT MEASURED** rather than recommended — recording an untested alternative is how the original trap got its untested command.

## The guard pins a RELATIONSHIP, not vocabulary

`scripts/tests/test_break_glass_note.py`: if the doc offers the DELETE, it must also carry a capture that redirects to a file, a `PUT` of the protection **OBJECT** whose `--input` names **that file**, and a read-back after it. The linkage is matched between the capture's redirect target and the PUT's `--input`, so prose can be reworded freely and the guard cannot be satisfied by spelling "restore" somewhere.

## Verification

- **red at `53f523ed`** with the real finding (`carries no -X PUT`), **green at HEAD**
- **mutation sweep 7/7 killed**, control green, under `PYTHONDONTWRITEBYTECODE=1`
- **all four tiers green**, sandbox derivations built ONE AT A TIME:

| tier | verdict |
|---|---|
| dev-host pytest | `19459 collected, 0 failed` |
| dev-host node | `1441 tests, 0 fail` |
| sandbox `pytests` | `19459 collected, 0 failed` |
| sandbox `nodetests` | `1441 tests, 0 fail` |

19 items from the new file collected **inside** the gated `scripts/tests` target — a standalone green says nothing about whether the gate sees the file.

## Two things this found that I would otherwise have shipped wrong

**The guard was vacuous first, and its own positive control caught it.** `CLAUDE.md` writes the DELETE inline in backticks; the path regex swallowed the trailing backtick, so the parser saw **no** DELETE in a document that plainly contained one — the round-trip assertion passed **VACUOUSLY** on exactly the note it exists to reject. The backticked renderings are now pinned as test cases.

**Two mutants SURVIVED the first sweep**, both fixture gaps rather than logic bugs: `put-accepts-patch` (nothing fed a `PATCH` on the protection *object*, so the guard would have accepted an unmeasured restore verb) and `checks-anchor-dropped` (`.../required_status_checks/contexts` is a real, different endpoint, misclassified without the `\Z` anchors). The fix was to vary the axes, not to add more mutants of the same shape.

## Not verified, deliberately

The `PUT` step was **not** re-exercised live for this PR. It is already measured by a real run (2026-08-30, read-back diffed key-by-key, "FAITHFUL — every key matches"), and a second confirmation would mean writing to `main`'s protection — the surface that has already gone wrong three times this week. The capture half *was* run live, because it is a read.

Also carries the session handoff (`0407bce0`), and files `scripts/break-glass-merge.sh` as **offered-not-built** (rank 6): the deterministic version cannot be proven end-to-end without opening the window on `main`, which is the hazard itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLBHx2WVuDqZZAAYrdfVPd