### PR TITLE
fix(session-trailer): a single-paragraph message got a stamp git does not read as a trailer

### DIFF
--- a/scripts/lib/session_trailer.py
+++ b/scripts/lib/session_trailer.py
@@ -404,6 +404,18 @@ def _ends_in_trailer_block(body: str) -> bool:
     if start == 0:
         return False                 # the last paragraph IS the subject's
     para = lines[start:]
+    if not para:
+        # 🔴 `body` is `rstrip("\n")`, which strips NEWLINES and not a final line
+        # of spaces or tabs. Such a line is falsy under `.strip()`, so the scan
+        # above never moves, `start == len(lines)`, and this slice is EMPTY —
+        # `para[0]` then raised IndexError. Measured: `"fix: v\n\nbody\n   \n"`
+        # stamped fine BEFORE this predicate existed and raised after, so it is
+        # a STRICT regression, and the hook's broad `except` swallowed it into a
+        # commit that succeeded carrying no trailer, with nothing logged.
+        # Reachable via `--cleanup=verbatim` and from any direct library caller;
+        # git's own cleanup strips such lines before the hook on the `-m` path.
+        # A trailing blank paragraph is not a trailer block, so: do not join.
+        return False
     if not _TRAILER_LINE_RE.match(para[0]):
         return False                 # a block cannot open on a continuation
     return all(_TRAILER_LINE_RE.match(text)

--- a/scripts/lib/session_trailer.py
+++ b/scripts/lib/session_trailer.py
@@ -362,6 +362,54 @@ def has_trailer(message: str, key: str = TRAILER_KEY) -> bool:
     return bool(_trailer_lines(message, key))
 
 
+# `Key: value` at column 0 — the shape of a trailer LINE. Not the shape of a
+# trailer BLOCK, which is what `_ends_in_trailer_block` decides.
+_TRAILER_LINE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9-]*:\s")
+# git folds an indented line into the PREVIOUS trailer's value, so it belongs to
+# the block rather than ending it. Measured: `Co-Authored-By: A\n    <a@b.c>` is
+# one trailer to `git interpret-trailers --parse`, not a trailer plus prose.
+_TRAILER_CONTINUATION_RE = re.compile(r"^[ \t]")
+
+
+def _ends_in_trailer_block(body: str) -> bool:
+    """Would git let a new trailer JOIN `body`'s last paragraph?
+
+    🔴 THE TAIL LINE ALONE CANNOT ANSWER THIS, and asking it that way is the bug
+    this replaces. The old test was `re.match(r"^[A-Za-z][A-Za-z0-9-]*:\\s", tail)`
+    on the LAST LINE only — which is TRUE of a conventional-commit SUBJECT
+    (`fix: one line only`). A single-paragraph message therefore got its trailer
+    glued straight onto line 2 with no blank line, and git then read the whole
+    thing as one subject paragraph: `git interpret-trailers --parse` returned
+    NOTHING, and a real commit's `%(trailers:key=Claude-Session-Id)` was EMPTY.
+    Whole commits were silently unresolvable — the failure the trailer exists to
+    prevent.
+
+    git's actual rule, measured against `git interpret-trailers` 2.55.0 rather
+    than inferred, is a property of the LAST PARAGRAPH:
+
+      * it must not BE the first paragraph — git never reads the subject
+        paragraph as trailers, so `fix: x\\nNote: y\\n` gets a blank line;
+      * every line in it must be a trailer line (or an indented continuation),
+        so `Some prose here.\\nNote: something` gets a blank line too.
+
+    Conservative where it differs: git also accepts `Key:value` with no space,
+    and we do not. Being stricter only ever ADDS the blank line, which still
+    yields a paragraph git parses as trailers — it can cost a sibling trailer
+    its block, never cost us our own.
+    """
+    lines = _lines(body)
+    start = len(lines)
+    while start > 0 and lines[start - 1].strip():
+        start -= 1
+    if start == 0:
+        return False                 # the last paragraph IS the subject's
+    para = lines[start:]
+    if not _TRAILER_LINE_RE.match(para[0]):
+        return False                 # a block cannot open on a continuation
+    return all(_TRAILER_LINE_RE.match(text)
+               or _TRAILER_CONTINUATION_RE.match(text) for text in para[1:])
+
+
 def append_trailer(message: str, session_id: str, key: str = TRAILER_KEY) -> str:
     """Return `message` carrying exactly one `key: session_id` trailer.
 
@@ -404,8 +452,6 @@ def append_trailer(message: str, session_id: str, key: str = TRAILER_KEY) -> str
     if not body:
         return line + "\n"
     # A trailer is separated from prose by a blank line, but must not gain one
-    # when the message already ends in a trailer block.
-    tail = _lines(body)[-1]
-    is_trailer_tail = bool(re.match(r"^[A-Za-z][A-Za-z0-9-]*:\s", tail))
-    sep = "\n" if is_trailer_tail else "\n\n"
+    # when the message already ends in a trailer block git would let it join.
+    sep = "\n" if _ends_in_trailer_block(body) else "\n\n"
     return body + sep + line + "\n"

--- a/scripts/tests/test_session_trailer.py
+++ b/scripts/tests/test_session_trailer.py
@@ -35,12 +35,18 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 REPO = Path(__file__).resolve().parents[2]
 MODULE = REPO / "scripts" / "lib" / "session_trailer.py"
+
+sys.path.insert(0, str(REPO / "scripts"))
+
+from testlib import hermetic_git  # noqa: E402
 
 
 def _load():
@@ -483,3 +489,139 @@ class TestTheStateFileModeSurvivesALeftoverTemp:
         common = str(tmp_path)
         assert st.record("s", 4243, root=common, reader=LIVE) is True
         assert oct(os.stat(st.state_file(4243, common)).st_mode)[-3:] == "600"
+
+
+# ---------------------------------------------------------------------------
+# 🔴 GIT ITSELF IS THE ORACLE. Every guard above asserts that the trailer TEXT
+# is somewhere in the message — which was TRUE of all three message shapes while
+# git recognised the trailer in only two of them, so this whole file passed
+# straight through the defect. The guards below assert the property that
+# actually matters: `git interpret-trailers --parse` returns the stamp. None of
+# them derives its expectation from `append_trailer`'s own formatting.
+# ---------------------------------------------------------------------------
+GIT_ENV = hermetic_git.hermetic_git_env()
+
+
+def _git_parsed_trailers(message: str) -> str:
+    """What GIT reads as this message's trailer block — never our own parser."""
+    return subprocess.run(
+        ["git", "interpret-trailers", "--parse"],
+        input=message, capture_output=True, text=True, env=GIT_ENV).stdout
+
+
+class TestGitParsesTheStampedTrailer:
+    """🔴 REGRESSION for the single-paragraph shape; INVARIANT GUARDS for the rest.
+
+    MEASURED at `a5bc5df6` (2026-08-30): `append_trailer("fix: one line only\\n",
+    …)` returned `'fix: one line only\\nClaude-Session-Id: …\\n'` — no blank line
+    — and `git interpret-trailers --parse` returned `''`. Confirmed on a real
+    commit object, whose `%(trailers:key=Claude-Session-Id,valueonly)` was EMPTY.
+    The cause was a separator test that looked at the LAST LINE alone, which a
+    conventional-commit SUBJECT satisfies: `fix: one line only` matches
+    `^[A-Za-z][A-Za-z0-9-]*:\\s`.
+
+    ⚠ THE SPLIT BELOW IS MEASURED, NOT ASSERTED. Each shape was run through
+    `append_trailer` at `a5bc5df6` AND at HEAD, and its verdict read off `git
+    interpret-trailers --parse`; `REGRESSION` is exactly the set that came back
+    RED at base. Everything in `INVARIANT` was GREEN there, so it is NOT
+    regression coverage — it is here because the obvious WRONG fix (always
+    appending "\\n\\n") greens every RED shape while splitting an existing
+    trailer block, which is the shape every agent commit in this repo has.
+    """
+
+    # RED at a5bc5df6, GREEN at HEAD. All four share one cause: the old test
+    # looked at the LAST LINE, and `fix: …` / `Note: …` satisfy it wherever they
+    # sit — so the stamp was glued onto a paragraph git reads as prose.
+    REGRESSION = [
+        ("single-line", "fix: one line only\n"),
+        ("prose-then-trailerish", "fix: x\n\nSome prose here.\nNote: something\n"),
+        ("trailerish-second-line", "fix: x\nNote: right after the subject\n"),
+        ("subject-and-blank-only", "fix: x\n\n"),
+    ]
+    # GREEN at a5bc5df6 too — invariant guards, pinning what must not break.
+    INVARIANT = [
+        ("with-body", "fix: x\n\nbody here.\n"),
+        ("existing-trailer", "fix: x\n\nbody.\n\nCo-Authored-By: A <a@b.c>\n"),
+        ("agent-shape", "fix: x\n\nbody.\n\nCo-Authored-By: A <a@b.c>\n"
+                        "Claude-Session: https://example.invalid/s/1\n"),
+        ("subject-no-colon", "subject with no colon at all\n"),
+        # 🔴 THE MUTATION-SWEEP FIXTURE. Every other shape here is decided by
+        # the paragraph's FIRST line, so dropping the check that the WHOLE
+        # paragraph is trailers SURVIVED a fully green run. git does not read
+        # this last paragraph as a block (measured), so the stamp must be
+        # separated from it or git parses nothing.
+        ("trailerish-then-prose",
+         "fix: x\n\nbody\n\nCo-Authored-By: A <a@b.c>\nplain prose line\n"),
+        ("continuation-line", "fix: x\n\nbody\n\nCo-Authored-By: A\n    <a@b.c>\n"),
+    ]
+
+    @pytest.mark.parametrize("name,message", REGRESSION + INVARIANT)
+    def test_git_reads_the_stamp_as_a_trailer(self, name, message):
+        out = st.append_trailer(message, "SID-42")
+        assert "Claude-Session-Id: SID-42" in _git_parsed_trailers(out), (
+            f"git does not read the stamp as a trailer for the {name} shape; "
+            f"the stamped message was {out!r}")
+
+    @pytest.mark.parametrize("name,message", [
+        ("existing-trailer", "fix: x\n\nbody.\n\nCo-Authored-By: A <a@b.c>\n"),
+        ("continuation-line", "fix: x\n\nbody\n\nCo-Authored-By: A\n    <a@b.c>\n"),
+    ])
+    def test_a_sibling_trailer_keeps_its_block(self, name, message):
+        """🔴 The always-"\\n\\n" fix passes the test above and fails this one: a
+        blank line inserted INSIDE a trailer block leaves git parsing only the
+        half after it, so `Co-Authored-By` stops being a trailer at all.
+
+        MEASURED per shape at `a5bc5df6`: `existing-trailer` KEPT its sibling
+        (invariant guard), `continuation-line` LOST it (regression) — the old
+        tail test saw the indented `    <a@b.c>` as prose and split the block.
+        """
+        parsed = _git_parsed_trailers(st.append_trailer(message, "SID-42"))
+        assert "Co-Authored-By: A <a@b.c>" in parsed, (
+            f"the {name} shape lost its sibling trailer; git parsed {parsed!r}")
+        assert "Claude-Session-Id: SID-42" in parsed
+
+    def test_the_oracle_can_report_absence(self):
+        """🔴 NEGATIVE CONTROL. Without it, a `--parse` wired to nothing would
+        make every assertion above vacuous. The input is the exact broken output
+        `a5bc5df6` produced, handed to git directly."""
+        assert _git_parsed_trailers(
+            "fix: one line only\nClaude-Session-Id: SID-42\n") == ""
+
+    def test_the_oracle_can_report_a_trailer(self):
+        """POSITIVE CONTROL: a hand-written, literally-correct message, so the
+        expectation is not derived from `append_trailer`."""
+        assert "Claude-Session-Id: SID-42" in _git_parsed_trailers(
+            "fix: x\n\nbody.\n\nClaude-Session-Id: SID-42\n")
+
+
+class TestTheSeparatorIsChosenFromTheLastParagraph:
+    """The unit behind the property above, pinned as LITERAL expected strings so
+    the shapes are legible without running git."""
+
+    def test_a_single_paragraph_message_gains_a_blank_line(self):
+        assert st.append_trailer("fix: one line only\n", "SID-42") == (
+            "fix: one line only\n\nClaude-Session-Id: SID-42\n")
+
+    def test_a_trailer_block_is_joined_with_no_blank_line(self):
+        assert st.append_trailer(
+            "fix: x\n\nCo-Authored-By: A <a@b.c>\n", "SID-42") == (
+            "fix: x\n\nCo-Authored-By: A <a@b.c>\nClaude-Session-Id: SID-42\n")
+
+    def test_a_trailerish_line_in_the_subject_paragraph_is_not_a_block(self):
+        """git never reads the FIRST paragraph as trailers, however it looks."""
+        assert st._ends_in_trailer_block("fix: x\nNote: right after") is False
+
+    def test_a_mixed_last_paragraph_is_not_a_block(self):
+        assert st._ends_in_trailer_block(
+            "fix: x\n\nSome prose here.\nNote: something") is False
+
+    def test_a_paragraph_that_only_STARTS_as_trailers_is_not_a_block(self):
+        """🔴 The discriminating case: judging the paragraph by its first line
+        alone SURVIVED a fully green suite until this fixture existed."""
+        assert st._ends_in_trailer_block(
+            "fix: x\n\nbody\n\nCo-Authored-By: A <a@b.c>\nplain prose line"
+        ) is False
+
+    def test_an_indented_continuation_stays_inside_the_block(self):
+        assert st._ends_in_trailer_block(
+            "fix: x\n\nbody\n\nCo-Authored-By: A\n    <a@b.c>") is True

--- a/scripts/tests/test_session_trailer.py
+++ b/scripts/tests/test_session_trailer.py
@@ -625,3 +625,40 @@ class TestTheSeparatorIsChosenFromTheLastParagraph:
     def test_an_indented_continuation_stays_inside_the_block(self):
         assert st._ends_in_trailer_block(
             "fix: x\n\nbody\n\nCo-Authored-By: A\n    <a@b.c>") is True
+
+
+class TestAWhitespaceOnlyTailDoesNotRaise:
+    """🔴 REGRESSION. `body` is `rstrip("\\n")`, so a final line of SPACES
+    survives; it is falsy under `.strip()`, so the paragraph scan never moves and
+    the slice is EMPTY. Indexing it raised IndexError — and the message was
+    stamped fine BEFORE the paragraph predicate existed, so this is a strict
+    regression, not a pre-existing gap.
+
+    It matters because the failure is SILENT end to end: `prepare_commit_msg.py`
+    calls `append_trailer` outside any try, and the module's broad
+    `except Exception: sys.exit(0)` plus the wrapper's `2>/dev/null` turn the
+    crash into a commit that succeeds carrying no trailer. Nothing is logged.
+    That contradicts the module header's "FAILS OPEN, ALWAYS ... degrades to
+    'no trailer'" — it degraded by crashing, which is a different thing.
+    """
+
+    # Distinct shapes on purpose: after a body, after a trailer block, and a
+    # message that is nothing but whitespace. Each reaches the empty slice by a
+    # different route through the scan.
+    @pytest.mark.parametrize("name,message", [
+        ("spaces-after-body", "fix: v\n\nbody\n   \n"),
+        ("spaces-after-trailer", "subject\n\nCo-Authored-By: A\n  \n"),
+        ("tab-after-body", "fix: v\n\nbody\n\t\n"),
+        ("whitespace-only", "   \n"),
+    ])
+    def test_it_stamps_instead_of_raising(self, name, message):
+        out = st.append_trailer(message, "SID-42")
+        assert "Claude-Session-Id: SID-42" in out
+        # The original body must survive verbatim — a crash-avoidance fix that
+        # silently ate the message would satisfy the assertion above alone.
+        assert out.startswith(message.rstrip("\n"))
+
+    def test_the_predicate_itself_reports_no_block(self):
+        """Pinned separately: a trailing blank paragraph is not a trailer block,
+        so the stamp must be SEPARATED rather than joined to whatever precedes."""
+        assert st._ends_in_trailer_block("fix: v\n\nbody\n   ") is False

--- a/scripts/tests/test_session_trailer.py
+++ b/scripts/tests/test_session_trailer.py
@@ -642,9 +642,13 @@ class TestAWhitespaceOnlyTailDoesNotRaise:
     'no trailer'" — it degraded by crashing, which is a different thing.
     """
 
-    # Distinct shapes on purpose: after a body, after a trailer block, and a
-    # message that is nothing but whitespace. Each reaches the empty slice by a
-    # different route through the scan.
+    # Four CONTENT shapes on ONE route, not four routes — measured, because the
+    # first wording of this comment claimed route diversity that is structurally
+    # impossible. An empty slice requires `start == len(lines)`, i.e. the scan
+    # loop ran ZERO iterations; any route where it moves leaves `para` non-empty.
+    # Instrumented: all four give loop-iterations=0. They vary what PRECEDES the
+    # blank tail (body, trailer block, nothing), which is what could plausibly
+    # change the separator decision — not the path into the guard.
     @pytest.mark.parametrize("name,message", [
         ("spaces-after-body", "fix: v\n\nbody\n   \n"),
         ("spaces-after-trailer", "subject\n\nCo-Authored-By: A\n  \n"),
@@ -659,6 +663,17 @@ class TestAWhitespaceOnlyTailDoesNotRaise:
         assert out.startswith(message.rstrip("\n"))
 
     def test_the_predicate_itself_reports_no_block(self):
-        """Pinned separately: a trailing blank paragraph is not a trailer block,
-        so the stamp must be SEPARATED rather than joined to whatever precedes."""
+        """INVARIANT GUARD, not a regression guard — and the distinction is
+        measured, because the first wording of this docstring overclaimed it.
+
+        It does NOT pin a git-visible correctness property: against git 2.55.0,
+        joining and separating parse IDENTICALLY for every whitespace-tail shape,
+        because git treats a whitespace-only line as a paragraph separator. No
+        separator choice here can save a preceding `Co-Authored-By`, and our own
+        stamp parses either way.
+
+        What it does pin is BYTE-IDENTITY with base `a5bc5df6`, which is the
+        strong result: `False` is what makes the output of this whole class match
+        pre-regression behaviour exactly.
+        """
         assert st._ends_in_trailer_block("fix: v\n\nbody\n   ") is False


### PR DESCRIPTION
Closes the remaining defect on clawgate cg#365. The session-id trailer is ARMED and live on
both hosts, so this was producing unreadable stamps in production, not hypothetically.

## The defect

On a **single-paragraph** commit message the stamp was appended with no blank line, so git
did not parse it as a trailer at all — the id was present as text and invisible to every
standard trailer consumer:

```
$ git commit -m "test: does a real commit carry the trailer"
test: does a real commit carry the trailer
Claude-Session-Id: 8cdbb099-…          <-- no blank line

$ git log -1 --format='%(trailers:key=Claude-Session-Id,valueonly)'
                                        <-- EMPTY
```

That is exactly cg#365's closing condition ("git blame a line → resolve the session → wake
it") failing, and failing silently.

## Root cause — the old code tried, and its test was wrong

It judged the separator from the **last line**:

```python
tail = _lines(body)[-1]
is_trailer_tail = bool(re.match(r"^[A-Za-z][A-Za-z0-9-]*:\s", tail))
```

A conventional-commit subject matches that regex. `fix: one line only` looked like a
trailer block, so the stamp was glued on with no separator.

## The fix

The separator is now decided by the **last paragraph**, matching what git actually does:

```python
sep = "\n" if _ends_in_trailer_block(body) else "\n\n"
```

A paragraph is a trailer block only if it is not the subject paragraph *and* every line in
it is a trailer line or an indented continuation. The rule was derived by probing
`git interpret-trailers` 2.55.0 across 19 shapes rather than inferred from docs. Where it
differs it is stricter than git — being stricter only ever *adds* a blank line, which still
yields a paragraph git parses.

> ⚠ **Corrected after audit round 1 (see the PR comment for the measurements).** An earlier
> revision of this line called the divergence "deliberately conservative (git accepts
> `Key:value` with no space; this does not)". That named **one** class where there are
> **five**, and omitted the largest — `Key:` with an empty value. Over a 1688-message
> differential fuzz: 209 shapes where this loses a sibling trailer that base kept, vs 29 the
> other way. **Real-world impact over the last 600 `origin/main` messages is zero** (devrc's
> trailer paragraphs are uniformly well-formed), and the change still takes "git cannot parse
> our stamp" from 6 to 2 there — but the original wording read as coverage it did not have.

## Red at base, green at HEAD

`single-line`: **RED at `a5bc5df6`, GREEN at HEAD**, verified on a real commit object with
everything else held identical:

```
base   'test: … trailer\nClaude-Session-Id: SID-42\n'    -> %(trailers:…) = (empty)
head   'test: … trailer\n\nClaude-Session-Id: SID-42\n'  -> %(trailers:…) = SID-42
```

Four shapes were red at base, not one: `single-line`, `prose-then-trailerish`,
`trailerish-second-line`, `subject-and-blank-only`. Six more are invariant guards (labelled
as such in the test file — they pin behaviour the bug never violated and are **not**
regression coverage).

**A second regression this closes:** on `continuation-line`
(`Co-Authored-By: A\n    <a@b.c>`) the old last-line test read the indented continuation as
prose and split the block, **losing the sibling `Co-Authored-By` trailer**. It survives now.

## Verification, done independently of the implementation

- The oracle is `git interpret-trailers --parse`, carrying **both controls as committed
  tests**: a negative control fed the exact broken base output (must parse to `''`), and a
  positive control fed a known-good message. Without them a `--parse` wired to nothing
  would make every assertion vacuous. Subprocesses run under a hermetic git env so a stray
  global `trailer.*` config cannot move the answer.
- **Mutation sweep, re-run independently rather than taken on report**, under
  `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` cleared between mutants:

  | mutant | result |
  |---|---|
  | always `"\n\n"` (the plausible wrong fix — splits an existing trailer block) | KILLED — sibling-trailer test |
  | revert to the old last-line check (the original bug) | KILLED — `test_a_single_paragraph_message_gains_a_blank_line` |
  | drop the whole-paragraph check | KILLED — `test_a_paragraph_that_only_STARTS_as_trailers_is_not_a_block` |

  Each dies by a **specifically named test**, not merely "a test failed".

## Existing tests

Nothing modified or deleted. None encoded the buggy output — they assert the trailer *text*
is present, true in every shape, which is precisely why the suite passed through this defect
for its whole life.

## Known-open, deliberately not fixed here

- **`append_trailer("")` has the same shape and is left as is**: it returns a one-line
  message git also does not parse as a trailer. Reachable only via
  `commit --allow-empty-message`, so widening the change into it was not worth the risk.
  Measured and recorded in the commit message; not covered by a test.

## Not run

Focused dev-host suites only (189 passed across the trailer/hook/hermetic-git tests, plus
136 across the repo-wide scanners). **The `nix build .#checks…` sandbox tier — the one the
merge actually gates on — was not run here**, and CLAUDE.md documents that the two tiers
legitimately disagree. Tekton will be the first run of that tier on this branch.

