### PR TITLE
feat(pkgs): add inxi + cpu-x — the CPU-Z equivalents for hardware profiling

### DIFF
--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -54,6 +54,10 @@ with pkgs; [
   # Invoked by scripts/dl-router/fetcher.py as an argv list, never a shell
   # string. See the `dl-router` skill.
   yt-dlp
+
+  # Hardware/system profiling (CPU-Z equivalents on Linux)
+  inxi            # comprehensive system info (CPU/GPU/RAM/disks/network in one shot)
+  cpu-x           # CPU-Z GUI clone — cache speeds, clocks, motherboard, BIOS
 ]
 ++ (import ./lang { inherit pkgs; })
 ++ (import ./tools { inherit pkgs workspace; })


### PR DESCRIPTION
Rank 2 from the `linux-cpu-profiling` handoff. Adds the two packages that answer
"run cpuz" on a Linux host — CPU-Z is Windows-only and there is no nixpkgs
package by that name.

- **`inxi`** — one-shot whole-machine dump. `inxi -Fxz` is the closest match to
  CPU-Z's tab set in scope (CPU/GPU/RAM/disks/network/BIOS).
- **`cpu-x`** — the actual CPU-Z clone: per-cache bandwidth, live clocks,
  motherboard/BIOS, instruction sets. `--dump` works headless.

`fastfetch` was evaluated and dropped — `inxi` covers the same ground in more
detail, so a third package earns nothing.

## Verification

- `nix-instantiate --parse nix/pkgs/default.nix` — ok.
- Every test file that reads `nix/pkgs`: `test_drift_check.py` (431 passed),
  plus `test_run_node_tests_suites.py`, the three `test_analyze_service_index_*`
  files, `test_opencode_engine.py`, `test_clawgatectl_version.py`
  (614 passed together). Run in a worktree off `origin/main` via
  `nix develop -c python3 -m pytest`.
- Both binaries resolve on PATH on the workbench after
  `home-manager switch --flake . --impure`, and return real data.

⚠️ That switch ran from a **dirty tree**, so it is evidence about the deployed
artifact, not about this ref. This commit carries the identical four lines, but
the two claims are separate — the sandbox tier (`nix build
.#checks.x86_64-linux.{pytests,nodetests}`) has **not** been run on this branch,
and neither has the merged tree.

## Scope note

The tree this came out of also held two **unrelated, uncommitted** efforts —
a `scripts/memory-detail` bar feature and a stranded `test_opencode_rig_control.py`.
They are deliberately **not** in this PR; they are preserved on their own
branches. The handoff's own next-step said to commit `scripts/memory-detail`
alongside this change, which would have landed half of someone else's feature
without its `nix/graphical.nix` wiring or its tests.
