### PR TITLE
docs(handoff): mention-detection session close — front matter, forcing fields, and the open queue

### DIFF
--- a/claudedocs/handoff-mention-detection.md
+++ b/claudedocs/handoff-mention-detection.md
@@ -1,3 +1,6 @@
+---
+clawgate-task: 440
+---
 # Handoff: mention-detection — 2026-08-30
 
 ## Run this first — the index, one read-only command
@@ -15,92 +18,41 @@ Detect clawgate/GitHub/ClickUp references in agent output, emit telemetry, and m
 them clickable in the terminal the way a URL already is. **SHIPPED AND VERIFIED LIVE.**
 
 ## State now
-🔴 **ALL FOUR RANKS ARE NOW CLOSED EXCEPT RANK 2 (CI capacity).** Ranks 1 and 3 shipped;
-rank 4 is closed **as obsolete** — read its entry before re-opening it, the reasoning is
-the deliverable. What is genuinely still open is listed under "Still open" below.
+🔴 **RANKS 1, 3 AND 4 ARE CLOSED. RANK 2 IS OWNED BY ANOTHER EFFORT — hand over, do not
+work it here.** The genuinely open items are ranks 5–7 below.
 
-- Branch: `main`, clean. `origin/main` was `e0e29e7b` when this doc was written and is
-  `ac64ccb4` as of 2026-08-30 — the moves since are other threads' work, none touching
-  the mention feature. It moved **four times during this session's own gate runs**, which
-  is why every merge here re-checked the merged tree rather than trusting a branch-green.
-- **clawgate is 0.8.19 live** (`clawgatectl health`), pin commit `8503620a` on
-  `homelab-infra` trunk, carrying the `#task-N` deeplink fix.
+- Branch: `main`. `origin/main` was `e0e29e7b` when this doc was created; it is `e0f35ce2`
+  as of 2026-08-30 and moved **six times during this session's own gate runs**, which is
+  why every merge here re-checked the merged tree rather than trusting a branch-green.
+- **clawgate 0.8.19 is LIVE** (`clawgatectl health`), pin commit `8503620a` on
+  `homelab-infra` trunk, carrying the `#task-N` deeplink fix. Verified against the
+  deployed pod, not a fixture.
+
+**Merged this session:**
+- `innovation-upstream/devrc#1086` — the two unverified alacritty interactions, verified
+  off-screen (rank 1)
+- `ZacxDev/homelab-infra#564` → squash `9ff37992` — `taskHashScript()`, the deeplink fix
+- `8503620a` in **homelab-infra** — the 0.8.19 pin bump (the deploy itself)
+- `innovation-upstream/devrc#1131` → squash `e0f35ce2` — ranks 1/3/4 closed, rank 2's
+  diagnosis and hand-over
 
 **Still open, with owners:**
-- **Rank 2, CI capacity** — untouched, and it BIT this session repeatedly. Diagnosis
-  added to that rank.
-- **`innovation-upstream/devrc#1099`** — corrects a false 🔴 claim ("the browser layer is
-  UNGATED by CI") in three places. Correct and locally verified (526 tests); **BLOCKED by
-  the flaky gate**, not by its content. Worktree `devrc-clawgate-ci` is deliberately left
-  on disk holding its branch.
-- **clawgate #463** — the board-scroll layout bug found by verifying #440 live.
-- **clawgate #440** — `ready_for_review`, blocked on #463 for its criterion 1.
+- 🔴 **`innovation-upstream/devrc#1099` — OPEN and BLOCKED.** Corrects a false 🔴 claim
+  ("the browser layer is UNGATED by CI") in three places. Correct and locally verified
+  (526 tests). `tekton/devrc-nodetests=success`, `tekton/devrc-pytests=failure` — the
+  flaky `test_subsystem_store_api.py` family, **not** its content. Its worktree
+  `/home/zach/workspace/devrc-clawgate-ci` is deliberately still on disk holding the
+  branch. ⚠ It also edits `claudedocs/handoff-tmux-webapp.md`, which `main` has since
+  touched — **check for a semantic conflict before merging**, a clean git merge is not a
+  clean merge.
+- **clawgate #463** (open) — the board-scroll layout bug; blocks #440's criterion 1.
+- **clawgate #440** — `ready_for_review`, not `complete`, for exactly that reason.
 - **`homelab-infra` base clone cannot fast-forward** — `merge --ff-only` refuses on a
   dirty `flake.nix` (+ `.claude/skills/deploy/SKILL.md`, untracked files); stuck at
-  `93876471` vs trunk `4964d223`. Pre-existing, NOT this session's, and it did not affect
-  the deploy (that went through a clean worktree). Left alone: it is someone's uncommitted
-  work, and this is the silent-drift shape — a base clone that cannot ff stops receiving
-  changes while looking healthy.
-- **Both hosts deployed and converged** (`ship.sh` → `ad5274b6`, cross-host agreement,
-  0 dangling artifacts on either)
-
-**DONE — merged:**
-- `0493e612` (#1011) — the feature. Scanner `scripts/collector/mention_scan.py`;
-  detection folded into the EXISTING `scripts/collector/claude/session-tailer.py`;
-  handler `scripts/mention-open.py`; two hints in
-  `nix/programs/alacritty/default.nix`; tests `scripts/tests/test_mention_scan.py`,
-  `test_mention_open.py`, `test_alacritty_hints.py`
-- `31cd214d` (#1060) — espanso `ask`/`clarify` collision that had `main` red repo-wide.
-  NOT authored here: a competing PR beat this session's #1058, which was **closed** in
-  its favour (see Gotchas)
-- `e0e29e7b` (#1067) — `claudedocs/mention-detection-as-built.md`
-- `686d6ff0` in **homelab-talos** — `tekton-ci` PodSecurity label; live, Flux-reconciled
-
-**VERIFIED LIVE, not inferred:**
-- deployed `alacritty.toml` resolves (`readlink -f`) to a store path carrying BOTH hints
-- hint mode labels all three shapes in a real terminal: `devrc#1011`, `#370`, `868abc123`
-- activating a label DISPATCHES: `#370` raised the rofi picker with both candidates
-- handler resolution: `devrc#1011` → GitHub, `868abc123` → ClickUp, `#282828`/`#ff00ff`
-  **rejected**
-- **operator confirmed `Ctrl+Shift+M` works in a 3-day-old window** — `live_config_reload`
-  picked up the symlink swap; no restart needed (I predicted otherwise; wrong)
-
-**BOTH REMAINING INTERACTIONS NOW VERIFIED (2026-08-30), off-screen.** Driven on an
-isolated `Xvfb :99` — same `alacritty` binary, same DEPLOYED config
-(`/nix/store/9jmni…-alacritty.toml`, reached through a probe `XDG_CONFIG_HOME` holding
-only a symlink to `~/.config/alacritty`, so `readlink -f` lands on the identical store
-file), real XTEST input, zero impact on the operator's screen. Observable was an
-`xdg-open` **capture handler**, not a browser: a probe `XDG_DATA_HOME` +
-`mimeapps.list` binding `x-scheme-handler/http{,s}` to a `.desktop` whose `Exec`
-appends the URL to a log. Both handlers under test — the URL hint's `xdg-open` and
-`mention-open.py`'s (`scripts/mention-open.py:208`) — funnel through it.
-- **`mouse.enabled` — hover underlines.** Pointer over `devrc#1011` → that text alone
-  renders underlined; the URL on the line above and the plain word below do not.
-  Screenshot, not inference.
-- **`mouse.enabled` — plain left-click dispatches.** Click on the hovered
-  `devrc#1011` → `https://github.com/innovation-upstream/devrc/issues/1011` captured.
-- **The mouse path reaches the AMBIGUOUS branch too.** Left-click on a bare `#370`
-  raised the rofi picker with both rows; arrowing to row **2** and pressing Return
-  opened `…/devrc/issues/370` — so the picker resolves by row CONTENT, not by index.
-- **`Ctrl+Shift+O` still works on a plain URL** — the interaction the `hints.enabled`
-  array replacement could have silently killed. Hint mode labelled the URL `j` (and
-  labelled the mention NOT at all, i.e. the `O` binding is scoped to its own hint);
-  pressing `j` captured `https://example.com/URL-HINT-CLICK` — the whole URL, with the
-  terminal's line WRAP reassembled.
-- **Instrument controls, both watched:** positive — a bare `xdg-open` under the probe
-  env captured a line, so the handler can fire at all; negative — hover+click on
-  `plainwordnothint` left the log at its previous length, so a captured line means a
-  hint fired and not ambient activity.
-
-**Still NOT verified:** that these gestures behave the same in Zach's own
-long-running alacritty windows. `live_config_reload` picking up the symlink swap was
-confirmed for `Ctrl+Shift+M` in a 3-day-old window, and the config is the same file,
-but no mouse gesture has been made in one of those windows.
-
-**IN FLIGHT:** `innovation-upstream/devrc#1057` — someone else's rescue PR. This
-session TRIMMED the two superseded mention drafts out of it (`9a09ad58`, plain
-fast-forward). Net diff is now 5 legitimate files (`scripts/cleanup-disk.sh` + its gate
-test + 3 registrations). Not mine to merge.
+  `93876471` vs trunk. **Pre-existing and NOT this session's**; it did not affect the
+  deploy, which went through a clean worktree. Left alone deliberately: it is someone's
+  uncommitted work. It is the silent-drift shape — a base clone that cannot ff stops
+  receiving changes while looking healthy.
 
 ## Open investigations — live diagnosis state
 
@@ -149,173 +101,44 @@ The original diagnosis is kept below because #463 inherits its layout context.
   NOT in the rendered set (tag filter active) must not fail silently.
 
 ## Next steps (ranked)
-1. ~~**Verify the two unverified interactions**~~ — **DONE 2026-08-30**, see "BOTH
-   REMAINING INTERACTIONS NOW VERIFIED" above. Closed by machine observation on an
-   isolated Xvfb rather than by an operator report, because the operator was mid-game
-   when the check came due (see Gotchas). No repo change; nothing left open here.
-2. **CI capacity — the durable fix. STILL OPEN, and it is now failing PRs, not just
-   queueing them.** `ZacxDev/homelab-infra`, `clusters/homelab/apps/tekton-pipelines/`.
-   Gate pods request far more than they use (nodes at 28–36% CPU while 6 gate pods sat
-   `Pending` on `ExceededNodeResources`). Either cap concurrent `devrc-ci` PipelineRuns or
-   right-size the requests. Closing condition: a `devrc-ci` run scheduling promptly with
-   ≥6 others active.
-   **Measured 2026-08-30 on one docs-only PR (#1099), three consecutive runs, three
-   different outcomes, none about the diff:**
-   - run 1 `e1183352` → **`ERROR`**, not failure: `TaskRunTimeout`, *"failed to finish
-     within 1h0m0s"*. ~43 minutes elapsed between run start and the test steps starting
-     (17:58Z→18:41Z), leaving them ~17 min before the TaskRun was killed. Surfaced on the
-     PR as `COULD NOT RUN: pytests — the gate stopped before this leg reported`.
-     🔴 **RETRACTED: an earlier revision of this bullet blamed `seed-nix` for those 43
-     minutes. That was INFERENCE FROM A GAP, never a measurement of the step, and it is
-     WRONG.** Measured across 114 retained TaskRuns, `seed-nix` is `min 0.0s / p50 0.0s /
-     max 129.0s` — a no-op on a warm cache, exactly as its sentinel design intends. The
-     gap is **pod SCHEDULING**: Tekton's TaskRun timeout starts at TaskRun creation and
-     includes `Pending`, and gate pods were separately measured sitting `Pending` 11–12
-     minutes with 5 running + 5 queued. Same root cause, wrong mechanism — and naming the
-     step I happened to be able to see would have sent the next person to optimise a step
-     that costs nothing.
-   - runs 2 and 3 → real verdicts, but red on **`test_subsystem_store_api.py`**, a
-     different test each time. Run 3's failure named its own mechanism (that file's tests
-     are instrumented for exactly this): `MECHANISM = TRANSPORT`, writer #4's POST raised
-     `TimeoutError` at 60.06s. Per-writer elapsed in ONE 8-way race: `0.36s 0.9s 2.03s
-     3.34s 4.93s 6.25s` … then **42.94s** and **60.06s**. The `…was lost` arm — the
-     real-defect arm — did NOT fire, so the entry lock is not implicated.
-   - **ONE dimension, and the premise at the top of this rank is also wrong.** "Gate pods
-     request far more than they use" does not hold: the gate requests 2250m/2752Mi (2 CPU
-     for the xdist pytest step), and `talos-xr6-r7p` measured **90% CPU requested / 91%
-     actual**. It is not over-requesting — it is CONFINED. "Nodes at 28–36%" was true of
-     the three nodes the pods **cannot reach**.
-   - 🔴 **THE ACTUAL CAUSE — a node pin inherited from a node-local PVC.** The shared
-     `nix-store-cache` PVC (`tekton-ci`) is `local-path` / RWO with its PV hard-pinned by
-     nodeAffinity to `talos-xr6-r7p`, so every gate pod inherits
-     `nodeSelector: kubernetes.io/hostname=talos-xr6-r7p`. The scheduler says it plainly:
-     `0/4 nodes are available: 1 Insufficient cpu, 3 node(s) didn't match Pod's node
-     affinity/selector`. Twelve-odd idle cores on the other three nodes are structurally
-     unreachable.
-   - **Control, so this is not a guess:** five open PRs were red simultaneously on
-     different tests concentrated in the store-API suite (the tests that stand up a real
-     HTTP server), while six others passed at 19,292–19,431 collected. Unrelated diffs,
-     different tests, one file family = load, not five regressions.
-   - 🔴 **Do NOT "fix" this by widening `test_subsystem_store_api.py`'s timeouts.** That
-     file's docstring forbids it in terms, and correctly: widening converts the load case
-     into a pass and leaves the defect case looking identical.
-   - Cost driver, for whoever takes it: each append holds `_EntryLock` — a blocking
-     `fcntl.flock(LOCK_EX)`, no timeout — across a read-modify-write with **two `fsync`s**
-     (file, then directory). Eight racers serialise through that on a box running ~19.4k
-     tests under xdist.
-   - 🔴 **"MOVE THE CACHE TO RWX" IS REJECTED — DO NOT RE-DERIVE IT.** Scoped 2026-08-30
-     and it is not a PVC edit, it is "install distributed storage on Talos" first:
-     **0 RWX PVCs of 289, 0 RWX PVs of 298, `kubectl get csidrivers` → none.** Every class
-     (`local-path`, `local-storage`, six `openebs-*`) is node-local by construction, and
-     `ci-priority-classes.yaml:139` already says so. **It was tried and reverted once** —
-     `d149c87f` (#111, 2026-07-16) dropped the cache as unschedulable and recorded RWX as
-     a follow-up *"needing RWX storage or hard node-pinning"*; pinning is the branch that
-     was taken. Costs if anyone revives it: `accessModes`/`storageClassName` are immutable
-     on a bound PVC, so migrating means delete-and-recreate, and with
-     `reclaimPolicy: Delete` + Flux `prune=true` the cache is **destroyed irreversibly** —
-     a revert returns the manifest, not the data. A cold cache is a **correctness**
-     failure, not a slowdown: a recorded ablation produced **43 test failures** on a
-     revision that passes with it. And 5+ concurrent pods write a shared **SQLite** fetcher
-     cache, a git tarball cache, a Go build cache and the nix store's own lock files, with
-     **no locking today** beyond a one-time seed sentinel — cross-node SQLite over NFS is a
-     corruption hazard the current single-node layout simply does not have.
-     Two further measured facts that close it off. The volume actually holds **69 GB across
-     25,664 store paths** — the PVC *requests* 30Gi, but `local-path` sets no quota so it
-     was never enforced — making this a ≥80 GB provision plus a physical 69 GB copy. And
-     🔴 **RWO was never the blocker**: six pods share that PVC concurrently right now,
-     because RWO is per-**NODE**, not per-pod. Flipping the access mode against
-     `local-path` would change nothing — the provisioner still writes a hostPath and still
-     stamps the same `nodeAffinity`. A per-node `hostPath` cache is separately
-     **FORBIDDEN**: Talos enforces PodSecurity `baseline` cluster-wide and a server
-     dry-run returns `violates PodSecurity "baseline:latest": hostPath volumes`.
-   - **The pin is not hurting at NORMAL load** — pod-start p90: `naida 14s`, `remix 15s`,
-     `auditloop 24s`, `devrc 31s`, vs unpinned `clawgate-ci 13s`. It falls over in a
-     BURST (5 running + 5 queued). So the lever is concurrency, not storage.
-   - 🔴 **TWO MORE PLAUSIBLE FIXES ARE ALSO DEAD — both were nearly proposed here, and
-     the arithmetic is what killed them. Do not re-derive either.**
-     - **"Cap concurrent runs / lean on supersede" — NO.** `tekton-supersede` (CronJob,
-       `* * * * *`) ALREADY covers this pipeline: **43** retained `devrc-ci-pipeline` runs
-       carry `ci.zacx.dev/supersede-key`. It cancels older runs sharing a key — same PR,
-       same branch. The 10 pods measured were **10 DISTINCT PRs**, correctly not
-       superseded. Capping would queue genuinely different work; it removes no work.
-       ⚠ A first query for this returned `0` because it used label value `devrc-ci`
-       instead of `devrc-ci-pipeline`. The positive control (a histogram over all
-       pipelines) is what caught it — do not read a bare zero here without one.
-     - **"Do a #396-style static split for `devrc-ci`" — NO, it would make devrc WORSE.**
-       The only viable target node `talos-jkj-deb` has ~4,380m free ⇒ **1–2** concurrent
-       gate pods at 2250m each; devrc currently gets ~**5** on `talos-xr6-r7p`. The split
-       helps the OTHER three pipelines by vacating xr6 and demotes the pipeline it was
-       meant to rescue. (`talos-deu-s2q` is not headroom either: 4 CPU and **99% actual**.)
-   - 🔴 **THE ACTUAL COST DRIVER IS THE WORKLOAD, NOT THE PLACEMENT.** The gate runs
-     **~19,440 collected tests for a three-markdown-file PR**. Storage, scheduling and
-     concurrency are all symptoms of paying that per run, ten runs at a time.
-     **`--targets` subsetting is already MERGED and on `main`** — PR #1073.
-   - 🔴 **THIS RANK IS ALREADY OWNED BY ANOTHER EFFORT. DO NOT BUILD HERE — HAND OVER.**
-     `claudedocs/handoff-ci-speedup.md` is the canonical doc, with live claims
-     **`ci-speedup-1`** (taken 1d ago, "cut devrc-ci pytests step from ~21min") and
-     **`ci-speedup-2`** (taken 3h ago, "empirically measure which test files are repo-wide
-     scanners"). It is well ahead of this rank and its ordering CONTRADICTS the obvious
-     one: a path→target mapper is worth **~1.7x alone but ~3.6x after** `scripts/tests` is
-     decomposed, so decomposition comes FIRST and must be **measured, not classified** (its
-     regex classifier over-classifies and is explicitly untrusted). Its estimate history is
-     **3x → 1.7x → uncertain** — three revisions, which is why it refuses to build the
-     mapper on an estimate.
-     🔴 **It also already TRIED the unpin, and that is the big lever, not the mapper:**
-     unpinned, queue wait **17.2m/22.5m → 0.1m** and wall clock **39.1m median → 17.4m**.
-     Reverted because a `DirectoryOrCreate` hostPath is created **root-owned**, so every
-     test shelling out to nix died — `opening lock file "/nix/var/nix/db/big-lock":
-     Permission denied`, **75 occurrences / 42 tests on every PR**, with PVC-era runs at
-     **0** as the control. Retry is gated on a `chown`/`chmod` probe **on a scratch
-     pipeline**, never on `devrc-ci`.
-   - **What THIS session adds for that owner, not found in their doc** (all measured here,
-     2026-08-30): `tekton-supersede` already covers `devrc-ci` (43 keyed runs) so a
-     concurrency cap removes no work; a #396-style split would DEMOTE devrc (~5 concurrent
-     → 1–2); the cache is **69 GB / 25,664 store paths**, not the 30Gi requested; RWX is
-     absent cluster-wide with positive controls (**0 CSI drivers, 0 RWX of 294 PVs**); and
-     **RWO is per-NODE, not per-pod**, so the access mode was never the lever.
-   - ⚠ **Process note, recorded because it is the reusable part:** this rank was
-     investigated for a full session BEFORE anyone ran `claim-work --list`. Two live claims
-     and a more advanced handoff already existed. Nothing was written to the cluster and
-     the findings above are a genuine contribution, but the sweep costs one command and
-     would have reordered the whole effort. Sweep FIRST — the rule names exactly this.
-   - Affected surface if anyone does touch the cache: **4 pipelines** (`naida-ux-audit`,
-     `remix-ux-audit`, `auditloop-ci`, `devrc-ci`) **+ 4 TriggerTemplate node pins**.
-     `gitops-validate` is already on a separate `nix-store-cache-2`; `clawgate-ci`,
-     `clawgate-e2e`, `clawgate-ux-audit` and `vetr-infra-guards` deliberately use no nix
-     cache and must not be enlisted into one.
-3. ~~**Fix `clawgate` deeplink**~~ — **DONE 2026-08-30.** Closing condition was "#440's 6
-   criteria, verified by a new spec in `e2e/tests/tasks.spec.ts` shown RED before / GREEN
-   after"; measured with the SAME spec file on both sides — **3 failed / 1 passed at
-   `3b90b6ee`, 4 passed after**. Merged `homelab-infra#564`, deployed 0.8.19, verified
-   live (see the closed investigation above). ⚠ The **handoff's** closing condition is
-   met; **#440's own** is not — it sits `ready_for_review` behind the newly-filed #463.
-   Successor item is #463, not this rank.
-4. ~~**Document the branch-protection escape hatch's asymmetry**~~ — **CLOSED AS OBSOLETE
-   2026-08-30. Do not re-open it; the paragraph would be redundant AND slightly harmful.**
-   This rank was written before `#1065` merged. Measured today:
-   - **The exact text it asks for already exists**, at the site an operator actually
-     reads — `scripts/drift-check.sh` (on `main`): *"`gh api -X PATCH
-     …/protection/required_status_checks` CANNOT restore the sub-resource after a DELETE
-     — it returns non-zero and changes nothing. Restoring needs a full `PUT
-     …/branches/main/protection`. That is why the measured break-glass left main
-     unprotected despite a restore trap that ran: the rollback path had never been
-     executed once."*
-   - **A deterministic detector now covers the hazard and is LIVE** — rc 24, merged as
-     `#1065`. `drift-check.timer` is `active`+`enabled`; last run 2026-08-30 12:24 CDT.
-     Its verdict is the **context count**, never the `protected` flag. Prose hoped
-     someone would read it; rc 24 fires 4×/day.
-   - Live protection reads healthy: `enforce_admins: true`, `strict: false`, both
-     contexts present with `app_id` 4320115 pinning.
-   🔴 **And the edit as SPECIFIED is the wrong shape.** `CLAUDE.md` still hands over the
-   `DELETE` with no mention of the asymmetry — but "also document the `PUT`" makes a
-   one-way, hard-to-reverse operation MORE usable, exactly when someone reaches for it
-   under pressure (measured 2026-08-30: the devrc gate failed three consecutive runs of
-   an innocent docs PR). It would also have prevented **neither** measured incident: the
-   first one *had* a restore trap, it *ran*, and main was left unprotected anyway. If
-   anything belongs in `CLAUDE.md` it is one clause saying the DELETE is one-way and that
-   rc 24 watches for it — a pointer to the detector, not a copy of the recipe. That is a
-   materially different edit and needs its own decision, so it was NOT made under this
-   item's authority.
+1. ~~**Verify the two unverified interactions**~~ — **DONE**, merged as `#1086`. Closed by
+   machine observation on an isolated Xvfb, not an operator report.
+   forcing: none — closed, retained only so the rank numbering stays stable.
+2. **CI capacity** — 🔴 **OWNED ELSEWHERE. DO NOT WORK IT HERE.** Canonical doc is
+   `claudedocs/handoff-ci-speedup.md`, with live claims `ci-speedup-1` and `ci-speedup-2`.
+   Its ordering contradicts the obvious one and its unpin measurement dwarfs the mapper —
+   both under "CI capacity" in Gotchas below.
+   forcing: gate — a required check is failing innocent PRs (measured: three consecutive
+   runs of a docs-only PR, none about the diff). Real and external; simply not ours.
+3. ~~**Fix `clawgate` deeplink**~~ — **DONE.** `#564` merged, 0.8.19 deployed, verified
+   live. The handoff's closing condition (a spec RED before / GREEN after) is met;
+   **#440's own is not** — see rank 6.
+   forcing: none — closed.
+4. ~~**Document the branch-protection escape hatch's asymmetry**~~ — **CLOSED AS OBSOLETE.**
+   Read its reasoning before re-opening: the text already exists in `drift-check.sh`, rc 24
+   detects the hazard and is live, and the edit as specified would make a one-way operation
+   more usable. Under "Rank 4" in Gotchas.
+   forcing: none — closed as obsolete, deliberately not done.
+5. **Merge `devrc#1099`** — `innovation-upstream/devrc`, touches
+   `claude/skills/clawgate/SKILL.md`, `claude/skills/clawgate/reference/extension.md`,
+   `claudedocs/handoff-tmux-webapp.md`. Blocked only by the flaky gate. Re-check the
+   merged tree first: `main` has touched `handoff-tmux-webapp.md` since the branch point.
+   Closing condition: merged, verified by content (a squash is never an ancestor).
+   forcing: gate — a required check is red on a test the diff cannot reach, and the PR
+   corrects a 🔴 claim that is actively misleading agents in three files.
+6. **Fix clawgate #463, then close #440** — `ZacxDev/homelab-infra`,
+   `containers/clawgate`. 60 of 248 cards are unreachable by any scroll; #440's criterion 1
+   is unsatisfiable for 24% of the board until it lands. #463 carries 6 criteria and a
+   measurement script shape as its verifier.
+   forcing: none — a real user-facing defect, but nothing external is forcing it and
+   nobody has asked. Do not let its severity read as urgency.
+7. **Decide the `homelab-infra` base clone** — it cannot fast-forward. Someone must say
+   whether the dirty `flake.nix` + `.claude/skills/deploy/SKILL.md` are WIP worth a branch
+   or stale cruft to discard. 🔴 Hash the working copy against that file's recent commits
+   first: byte-identical to an OLDER commit proves a stale orphan, and "restoring" it
+   silently reverts everything since.
+   forcing: none — not blocking today, which is precisely the failure mode: it stops
+   receiving changes while looking healthy.
 
 ## Gotchas / decisions / dead-ends
 - 🔴 **A terminal-UI interaction can be verified WITHOUT taking the operator's screen —
@@ -376,16 +199,121 @@ The original diagnosis is kept below because #463 inherits its layout context.
   pre-existing by a before/after control, NOT caused by #1011. Whether Alacritty still
   honours `chars` in that form is **unverified** — that's Ctrl+Backspace and word-motion.
 
+- 🔴 **CARRIED FORWARD from `State now` before a replace dropped it — rank 1's RESULT, which
+  is a measurement and not status.** Both alacritty interactions verified **off-screen** on
+  an isolated `Xvfb :99`: same binary, same DEPLOYED config
+  (`/nix/store/9jmni…-alacritty.toml`, reached via a probe `XDG_CONFIG_HOME` symlinking
+  `~/.config/alacritty`, so `readlink -f` lands on the identical store file), real XTEST
+  input. **`mouse.enabled` hover** underlines the mention alone — not the URL above it, not
+  the plain word below. **Plain left-click** on `devrc#1011` captured
+  `https://github.com/innovation-upstream/devrc/issues/1011`. **A bare `#370`** raised the
+  rofi picker and **row 2** opened `…/issues/370`, so the picker resolves by row CONTENT,
+  not index. **`Ctrl+Shift+O`** labelled the URL `j` and left the mention unlabelled;
+  activating it captured the whole URL **with the terminal line wrap reassembled**.
+  Controls both watched: positive (a bare `xdg-open` under the probe env fires) and
+  negative (hover+click on plain text leaves the log unchanged).
+  ⚠ Still NOT verified: these gestures in Zach's own long-running alacritty windows.
+- 🔴 **CARRIED FORWARD — the `seed-nix` RETRACTION, so it is not lost with rank 2's old
+  text.** An earlier revision blamed `seed-nix` for the 43 minutes before the test steps
+  started. That was **INFERENCE FROM A GAP, never a measurement of the step, and it is
+  WRONG**: across 114 retained TaskRuns `seed-nix` is `min 0.0s / p50 0.0s / max 129.0s`, a
+  no-op on a warm cache. The gap is **pod SCHEDULING** — Tekton's TaskRun timeout starts at
+  creation and includes `Pending`, and gate pods were measured `Pending` 11–12 min with 5
+  running + 5 queued. Naming the step I could see would have sent the next person to
+  optimise a step that costs nothing.
+- 🔴 **CI capacity (rank 2) — three fixes ruled out with the measurement that killed each.
+  Do not re-derive them.** Moved here from the ranked item so a future `State now` replace
+  cannot drop it.
+  - **RWX migration — DEAD.** Not a PVC edit; "install distributed storage on Talos"
+    first. **0 CSI drivers, 0 RWX PVs of 294, 0 RWX PVCs of 289**, each with a positive
+    control so the zeros are absences and not broken queries. Tried and reverted once
+    already (`d149c87f`, #111). The volume holds **69 GB / 25,664 store paths** (the PVC
+    *requests* 30Gi; `local-path` enforces no quota). 🔴 **RWO was never the blocker** —
+    six pods share it concurrently, because RWO is per-**NODE**, not per-pod. A per-node
+    `hostPath` cache is separately forbidden by Talos PodSecurity `baseline`.
+  - **Concurrency cap — DEAD.** `tekton-supersede` already covers `devrc-ci` (**43** runs
+    carry a supersede key). It cancels older runs sharing a key; the 10 pods measured were
+    **10 distinct PRs**, correctly not superseded. Capping queues real work rather than
+    removing redundant work. ⚠ A first query returned `0` only because it used label value
+    `devrc-ci` instead of `devrc-ci-pipeline` — a positive control over all pipelines
+    caught it. Never read a bare zero here without one.
+  - **#396-style static split — DEAD, and it would DEMOTE the pipeline it was meant to
+    rescue:** the only viable node fits **1–2** concurrent gate pods against the ~**5**
+    devrc gets today. Nearly proposed on the strength of the precedent; arithmetic stopped
+    it.
+  - **The owning effort already tried the UNPIN, and that is the real lever** — queue wait
+    `17.2m/22.5m → 0.1m`, wall clock `39.1m median → 17.4m`. Reverted because a
+    `DirectoryOrCreate` hostPath is created **root-owned**: `opening lock file
+    "/nix/var/nix/db/big-lock": Permission denied`, **75 occurrences / 42 tests per PR**,
+    against **0** in the PVC-era control. Retry is gated on an ownership probe **on a
+    scratch pipeline**, never on `devrc-ci`.
+  - **A path→target mapper is worth ~1.7x alone but ~3.6x after `scripts/tests` is
+    decomposed**, so decomposition comes FIRST and must be **measured** — that effort's
+    regex classifier over-classifies and is explicitly untrusted. Estimate history:
+    **3x → 1.7x → uncertain**.
+- 🔴 **Rank 4 — why the branch-protection paragraph must NOT be written.** The text it asks
+  for already exists at the site an operator reads (`scripts/drift-check.sh`: `PATCH`
+  cannot restore the sub-resource after a `DELETE`; restoring needs a full `PUT`). A
+  deterministic detector covers the hazard and is **live** — rc 24, merged as `#1065`,
+  `drift-check.timer` `active`+`enabled`. And the edit **as specified** would make a
+  one-way operation *more* usable exactly when someone reaches for it under pressure, while
+  preventing **neither** recorded incident — the first one *had* a restore trap, it *ran*,
+  and main was left unprotected anyway.
+- 🔴 **THE PROCESS FAILURE OF THIS SESSION, and it is the reusable part: rank 2 was
+  investigated for a full session before anyone ran `claim-work --list`.** Two live claims
+  (`ci-speedup-1`, 1d old; `ci-speedup-2`, 3h old) and a more advanced handoff already
+  existed. Nothing reached the cluster and no duplicate PR was opened, so the cost was
+  research effort — but the sweep is ONE command and would have reordered the whole effort
+  from the start. Ranks 1 and 3 *were* claimed; rank 2 was not, because it was reached by
+  drifting forward from a finished item rather than by picking one off the list. **The
+  sweep belongs at the moment you START an item, not at the moment you formally adopt it.**
+- 🔴 **Verifying a terminal UI without taking the operator's screen — `Xvfb` + the deployed
+  config + an `xdg-open` capture handler.** (1) `Xvfb :99`, launch the REAL binary so XTEST
+  input is real input; (2) a probe `XDG_CONFIG_HOME` holding **only** `mimeapps.list` and a
+  **symlink** to `~/.config/alacritty`, so the config under test is provably the deployed
+  store file (`readlink -f` it and say so) — copying it would test a copy; (3) a probe
+  `XDG_DATA_HOME` with a `.desktop` whose `Exec` appends `%u` to a log, bound to
+  `x-scheme-handler/http{,s}`, so "it opened the right URL" is a grep instead of a browser
+  tab. Run the positive control BEFORE trusting any silence from it.
+- 🔴 **`PREV_WS` went stale inside two minutes.** Focus/idle were recorded, then a probe
+  window was launched ~2 min later — by which point the focused workspace held a
+  fullscreen game with `xprintidle` at **1 ms**. Restoring to the remembered workspace
+  would have been a SECOND theft. **Re-read focus/idle immediately before the raise, and
+  check `xprintidle` before driving XTEST at all.**
+- 🔴 **Two vacuous-assertion traps in the deeplink e2e, both avoided and both worth
+  reusing.** `toHaveClass(/card-enter/)` cannot fail — *every* card ships with that class.
+  `getAnimations().length` cannot return to zero — the animation fills `both`, so a
+  finished animation stays in the list forever. The spec filters on
+  `playState === 'running'` instead.
+- **My own first draft of the deeplink handler was wrong twice, and the SPEC caught both,
+  not re-reading the code.** (a) "not found" is meaningless until the list has rendered
+  once — the handler ran while parsing the shell, before `#tasks-list` had issued its
+  `hx-trigger="load"` fetch, so every id looked absent: it toasted "not on this board" and
+  dropped the fragment *before the cards existed*. (b) The filter-clear retry re-enters
+  through the settle it triggers, so it needed a once-per-fragment latch.
+- 🔴 **`clawgate-ci` does NOT run Playwright — but `clawgate-e2e`, a SEPARATE check, DOES**
+  (`clawgate e2e passed — 122 tests, 2 skipped` on #564). The skill and `reference/
+  extension.md` said the browser layer was "UNGATED by CI"; that is FALSE and `#1099`
+  corrects it. ⚠ **RUNS is not BLOCKS** — whether `clawgate-e2e` is *required* is
+  unmeasured: `GET /branches/trunk/protection` 403s on that private repo without GitHub
+  Pro.
+
 ## How to verify
 ```bash
-# the shipped scanner + handler, no browser opened
-/nix/store/*-alacritty-mention-open --print '#370'          # -> both candidates
-/nix/store/*-alacritty-mention-open --print 'devrc#1011'    # -> the GitHub issue
-/nix/store/*-alacritty-mention-open --print '#282828'       # -> "no mention in the clicked text"
+# the deeplink, live against the deployed pod (LAN UI is open, no auth)
+curl -sf http://192.168.50.250:30302/ui/tasks | grep -c 'id="task-[0-9]*"'
+clawgatectl health          # must report 0.8.19
 
-# both required tiers, the tier Tekton actually gates on
-cd ~/workspace/devrc && nix build .#checks.x86_64-linux.pytests .#checks.x86_64-linux.nodetests --no-link
+# the alacritty hints, off-screen and without taking the operator's screen:
+#   Xvfb :99 -> real alacritty -> probe XDG_CONFIG_HOME symlinking ~/.config/alacritty
+#   -> probe XDG_DATA_HOME whose .desktop appends %u to a log. Recipe in Gotchas.
+
+# devrc doc subset (the flake devShell carries the gate toolchain; direnv does NOT)
+nix develop ~/workspace/devrc -c python3 -m pytest \
+  ~/workspace/devrc/scripts/tests/test_handoff_doc.py \
+  ~/workspace/devrc/scripts/tests/test_closing_condition_single_source.py -q
 ```
-In a terminal: `Ctrl+Shift+M` labels every mention; `Ctrl+Shift+O` is the URL hint.
-🔴 Read the `TOTAL collected=` / `RESULT:` lines out of `nix log <drv>` — an exit code
-through a pipe is `tail`'s, not the gate's.
+🔴 Run **both** tiers before claiming a merge is safe, and name the tier and base sha:
+`scripts/gate.sh` is the dev host; `nix build .#checks.x86_64-linux.{pytests,nodetests}`
+is what Tekton gates on. **Build them ONE AT A TIME** — a combined invocation contends on
+the nix store and produces false failures.


### PR DESCRIPTION
Session-close update to `claudedocs/handoff-mention-detection.md`, written through `handoff_doc.py` (proposal → confirm → push), not by hand.

- **`clawgate-task: 440`** added as YAML front matter at line 1 — resolved from the board as this session's one `worked` task (the other link, #463, is `created`).
- **Every ranked item now carries a `forcing:` field.** There were **zero**; the write gate refuses without them (`status=unforced`). Five of seven declare `forcing: none` — honestly, since they are closed or nothing external is pushing them — which marks them **not eligible to be worked** by a session drawing from this queue.
- **Ranks 5–7 added** for what is genuinely open: merge `#1099`, fix clawgate `#463` then close `#440`, and decide the `homelab-infra` base clone that cannot fast-forward.
- **Rank 2 demoted to a hand-over pointer.** It is owned by `handoff-ci-speedup.md` with live claims `ci-speedup-1`/`-2`.

## The durable-drop warning, and what I did about it

The tool warned that the `State now` / `Next steps` replace drops 14 lines that look durable. Three of them mattered, so they were **carried forward under the APPEND `Gotchas` heading** rather than lost:

- rank 1's **verification results** (the Xvfb/`xdg-open`-capture measurements, with both controls)
- the **`seed-nix` retraction** — an earlier revision blamed it for 43 minutes; measured across 114 TaskRuns it is `p50 0.0s`, and the gap is pod scheduling
- the **CI-capacity diagnosis**: three fixes ruled out, each with the measurement that killed it

The warning still fires after the carry-forward — it is positional and cannot see that the substance moved. Read the diff, not the count.

**Subsystem index:** two entries appended and validated in the same turn — `homelab-talos/clawgate` (the board-scroll bug as `OPEN:`, plus two vacuous-assertion traps) and `devrc/skills` (a 🔴 skill-body claim that was false in three places). Both `OK — 1 of 1 entry file(s) parse`.