### PR TITLE
feat(bar): memory block left-click opens top RAM consumers view

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -63,7 +63,7 @@ let
     critical_mem = 92;
     interval = 10;
     click = [
-      { button = "left"; cmd = btopCmd; }
+      { button = "left"; cmd = "alacritty --class float,float -o window.dimensions.columns=100 -o window.dimensions.lines=25 -e ${scriptsDir}/memory-detail"; }
     ];
   };
   # Bar shows "/" only; left-click opens a rofi gauge list of all real filesystems
@@ -445,6 +445,11 @@ lib.mkIf isNixOS {
   # disk-explore: the disk block's right-click — ncdu on the fullest real mount.
   home.file.".config/i3status-rust/scripts/disk-explore" = {
     source = ../scripts/disk-explore;
+    executable = true;
+  };
+  # memory-detail: the memory block's left-click — top RAM consumers float.
+  home.file.".config/i3status-rust/scripts/memory-detail" = {
+    source = ../scripts/memory-detail;
     executable = true;
   };
   home.file.".config/i3status-rust/scripts/i3blocks-rigcontrol" = {

--- a/scripts/memory-detail
+++ b/scripts/memory-detail
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Top-RAM-consumers view for the i3status-rust `memory` block (left-click).
+
+The bar pill shows used-as-size; a left-click opens THIS float terminal — a
+summary header (total/used/free + swap) and the top 15 processes sorted by RSS.
+Reads /proc/meminfo and `ps aux`; no external deps, no network.
+
+Everything is best-effort — a launcher must never crash loudly.
+
+The pure/mockable logic (parse /proc/meminfo, parse ps, format) is factored
+out and unit-tested in scripts/tests/test_memory_detail.py; `--dump` prints
+the output without opening a terminal.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+TOP_N = 15
+
+
+# --------------------------------------------------------------------------- #
+# Pure / mockable logic (unit-tested against fixtures — NO subprocess)
+# --------------------------------------------------------------------------- #
+def human(n) -> str:
+    """Compact human size from a byte count: '957M', '1.8T', '641G'."""
+    try:
+        n = float(n)
+    except (TypeError, ValueError):
+        return "?"
+    for unit in ("B", "K", "M", "G", "T", "P"):
+        if n < 1024 or unit == "P":
+            if unit == "B":
+                return "%dB" % int(n)
+            return ("%.1f%s" % (n, unit)).replace(".0%s" % unit, unit)
+        n /= 1024.0
+    return "?"
+
+
+def parse_meminfo(text: str) -> dict:
+    """Parse /proc/meminfo into {key: bytes}.  Keys with 'kB' are converted."""
+    info = {}
+    for line in text.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        key = parts[0].rstrip(":")
+        try:
+            val = int(parts[1])
+        except ValueError:
+            continue
+        if len(parts) >= 3 and parts[2] == "kB":
+            val *= 1024
+        info[key] = val
+    return info
+
+
+def parse_ps(text: str) -> list:
+    """Parse `ps aux` into [{pid, user, rss, pct_mem, command}].
+
+    rss is in KB (ps default).  Sorted by rss descending; malformed rows
+    are dropped.
+    """
+    procs = []
+    for line in text.splitlines():
+        parts = line.split(None, 10)
+        if len(parts) < 11 or parts[0] == "USER":
+            continue
+        try:
+            pid = int(parts[1])
+            rss = int(parts[5])
+            pct_mem = float(parts[3])
+        except (ValueError, IndexError):
+            continue
+        procs.append({
+            "pid": pid,
+            "user": parts[0],
+            "rss": rss * 1024,  # convert to bytes
+            "pct_mem": pct_mem,
+            "command": parts[10],
+        })
+    procs.sort(key=lambda p: p["rss"], reverse=True)
+    return procs
+
+
+def format_summary(info: dict) -> str:
+    """One-line summary: 'RAM: 12.3G / 31.2G (39%)  Swap: 1.2G / 8.0G (15%)'."""
+    total = info.get("MemTotal", 0)
+    avail = info.get("MemAvailable", info.get("MemFree", 0))
+    used = total - avail if total else 0
+    pct = round(100 * used / total) if total else 0
+
+    swap_total = info.get("SwapTotal", 0)
+    swap_free = info.get("SwapFree", 0)
+    swap_used = swap_total - swap_free if swap_total else 0
+    swap_pct = round(100 * swap_used / swap_total) if swap_total else 0
+
+    ram = "RAM: %s / %s (%d%%)" % (human(used), human(total), pct)
+    swap = "Swap: %s / %s (%d%%)" % (human(swap_used), human(swap_total), swap_pct)
+    return "%s  %s" % (ram, swap)
+
+
+def format_table(procs: list, n: int = TOP_N) -> str:
+    """Formatted table of top-N processes by RSS.
+
+    Columns: PID  USER  RSS  %MEM  COMMAND (truncated to fit).
+    """
+    if not procs:
+        return "  (no processes)"
+    rows = procs[:n]
+    # column widths
+    pid_w = max(len(str(p["pid"])) for p in rows)
+    user_w = max(len(p["user"]) for p in rows)
+    rss_w = max(len(human(p["rss"])) for p in rows)
+
+    lines = []
+    hdr = "  %-*s  %-*s  %*s  %%MEM  COMMAND" % (pid_w, "PID", user_w, "USER", rss_w, "RSS")
+    lines.append(hdr)
+    lines.append("  " + "-" * len(hdr))
+    for p in rows:
+        rss = human(p["rss"]).rjust(rss_w)
+        cmd = p["command"]
+        if len(cmd) > 40:
+            cmd = cmd[:37] + "..."
+        lines.append("  %-*d  %-*s  %s  %5.1f  %s"
+                      % (pid_w, p["pid"], user_w, p["user"], rss, p["pct_mem"], cmd))
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# Side-effecting (subprocess / terminal — not unit-tested)
+# --------------------------------------------------------------------------- #
+def read_meminfo() -> dict:
+    try:
+        with open("/proc/meminfo") as f:
+            return parse_meminfo(f.read())
+    except Exception:
+        return {}
+
+
+def read_ps() -> list:
+    try:
+        out = subprocess.run(
+            ["ps", "aux"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            text=True, timeout=10).stdout
+    except Exception:
+        return []
+    return parse_ps(out)
+
+
+def main(argv=None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    info = read_meminfo()
+    procs = read_ps()
+    header = format_summary(info)
+    table = format_table(procs)
+    output = "%s\n\n%s" % (header, table)
+
+    if "--dump" in argv:
+        print(output)
+        return 0
+
+    # Float terminal: write to a temp file, then exec less so the user can
+    # scroll/search.  The script process becomes less — it stays alive until
+    # the user presses 'q', keeping the alacritty window open.
+    try:
+        import os, tempfile
+        fd, path = tempfile.mkstemp(prefix="memdetail_", suffix=".txt")
+        with os.fdopen(fd, "w") as f:
+            f.write(output + "\n")
+        os.execvp("less", ["less", "-N", path])
+    except Exception:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:   # a launcher must never crash loudly
+        sys.exit(0)

--- a/scripts/tests/test_memory_detail.py
+++ b/scripts/tests/test_memory_detail.py
@@ -1,0 +1,199 @@
+"""Unit tests for scripts/memory-detail — the float-terminal RAM consumers view.
+
+All OFFLINE: alacritty/ps/proc are never touched. The pure logic is tested:
+  - /proc/meminfo parse (key extraction, kB→bytes, missing keys),
+  - `ps aux` parse (pid/rss/pct_mem, sorting, malformed rows),
+  - summary line formatting,
+  - table formatting (column alignment, truncation, empty input),
+and the `--dump` CLI path is exercised via subprocess.
+
+    run:  pytest scripts/tests/test_memory_detail.py
+"""
+import importlib.machinery
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+
+
+def _load(name, modname):
+    loader = importlib.machinery.SourceFileLoader(modname, str(SCRIPTS / name))
+    spec = importlib.util.spec_from_loader(modname, loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+md = _load("memory-detail", "memory_detail")
+
+GB = 1024 ** 3
+MB = 1024 ** 2
+
+# Representative /proc/meminfo (trimmed to the keys the script reads).
+MEMINFO_SAMPLE = """\
+MemTotal:       129426460 kB
+MemFree:         8186488 kB
+MemAvailable:   18312412 kB
+Buffers:         5578052 kB
+Cached:         45070828 kB
+SwapTotal:      90598500 kB
+SwapFree:        7823460 kB
+"""
+
+# Representative `ps aux` output (header + a few processes).
+PS_SAMPLE = """\
+USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root           1  0.1  0.0  31348 14412 ?        Ss   Aug04  50:46 /run/current-system/systemd/lib/systemd/systemd
+zach       1234  2.3 12.5 8901234 16384000 ?    Sl   Aug04 120:00 /nix/store/abc-chrome/chrome --type=gpu-process
+zach       5678  0.5  3.2 4500000 4194304 ?     Sl   Aug04  30:00 /nix/store/def-firefox/firefox --contentproc
+nixbld     9999  0.0  0.0      0     0 ?        Z    Aug04   0:00 [kworker/u32:0]
+"""
+
+
+# --------------------------------------------------------------------------- #
+# parse_meminfo
+# --------------------------------------------------------------------------- #
+def test_parse_meminfo_extracts_keys():
+    info = md.parse_meminfo(MEMINFO_SAMPLE)
+    assert "MemTotal" in info
+    assert "MemFree" in info
+    assert "SwapTotal" in info
+
+
+def test_parse_meminfo_converts_kb_to_bytes():
+    info = md.parse_meminfo(MEMINFO_SAMPLE)
+    # MemTotal: 129426460 kB → 129426460 * 1024
+    assert info["MemTotal"] == 129426460 * 1024
+
+
+def test_parse_meminfo_ignores_non_numeric():
+    text = "MemTotal:       notanumber kB\n"
+    info = md.parse_meminfo(text)
+    assert "MemTotal" not in info
+
+
+def test_parse_meminfo_empty():
+    assert md.parse_meminfo("") == {}
+
+
+# --------------------------------------------------------------------------- #
+# parse_ps
+# --------------------------------------------------------------------------- #
+def test_parse_ps_extracts_procs():
+    procs = md.parse_ps(PS_SAMPLE)
+    # header + 4 data lines, but the zombie [kworker] has RSS=0 and is still valid
+    assert len(procs) == 4
+
+
+def test_parse_ps_sorts_by_rss_desc():
+    procs = md.parse_ps(PS_SAMPLE)
+    rss_values = [p["rss"] for p in procs]
+    assert rss_values == sorted(rss_values, reverse=True)
+
+
+def test_parse_ps_converts_rss_kb_to_bytes():
+    procs = md.parse_ps(PS_SAMPLE)
+    chrome = next(p for p in procs if "chrome" in p["command"])
+    assert chrome["rss"] == 16384000 * 1024  # 16384000 KB → bytes
+
+
+def test_parse_ps_skips_header():
+    procs = md.parse_ps(PS_SAMPLE)
+    assert all(p["pid"] != 0 for p in procs)
+
+
+def test_parse_ps_skips_malformed():
+    bad = "USER PID %CPU %MEM VSZ RSS TTY STAT START TIME COMMAND\n" \
+          "root xyz 0.0 0.0 0 0 ? Ss Aug04 0:00 cmd\n"
+    assert md.parse_ps(bad) == []
+
+
+def test_parse_ps_empty():
+    assert md.parse_ps("") == []
+
+
+# --------------------------------------------------------------------------- #
+# human
+# --------------------------------------------------------------------------- #
+def test_human_scales_units():
+    assert md.human(500) == "500B"
+    assert md.human(1536) == "1.5K"
+    assert md.human(2 * GB) == "2G"
+    assert md.human(1.8 * (1024**4)).endswith("T")
+
+
+def test_human_bad_input():
+    assert md.human(None) == "?"
+    assert md.human("x") == "?"
+
+
+# --------------------------------------------------------------------------- #
+# format_summary
+# --------------------------------------------------------------------------- #
+def test_format_summary_shows_ram_and_swap():
+    info = md.parse_meminfo(MEMINFO_SAMPLE)
+    s = md.format_summary(info)
+    assert "RAM:" in s
+    assert "Swap:" in s
+    assert "%" in s
+
+
+def test_format_summary_ram_used_is_total_minus_available():
+    info = md.parse_meminfo(MEMINFO_SAMPLE)
+    s = md.format_summary(info)
+    # MemTotal - MemAvailable = used
+    total = info["MemTotal"]
+    avail = info["MemAvailable"]
+    used = total - avail
+    assert md.human(used) in s
+
+
+def test_format_summary_missing_keys():
+    s = md.format_summary({})
+    assert "RAM: 0B / 0B (0%)" in s
+
+
+# --------------------------------------------------------------------------- #
+# format_table
+# --------------------------------------------------------------------------- #
+def test_format_table_headers():
+    procs = md.parse_ps(PS_SAMPLE)
+    table = md.format_table(procs)
+    assert "PID" in table
+    assert "USER" in table
+    assert "RSS" in table
+    assert "%MEM" in table
+    assert "COMMAND" in table
+
+
+def test_format_table_truncates_long_commands():
+    procs = [{"pid": 1, "user": "root", "rss": GB, "pct_mem": 1.0,
+              "command": "a" * 100}]
+    table = md.format_table(procs)
+    assert "..." in table
+    assert "a" * 100 not in table
+
+
+def test_format_table_empty():
+    assert "(no processes)" in md.format_table([])
+
+
+def test_format_table_respects_n():
+    procs = md.parse_ps(PS_SAMPLE)
+    table = md.format_table(procs, n=2)
+    # only 2 data rows (plus header + separator)
+    lines = [l for l in table.splitlines() if l.strip() and not l.strip().startswith("-")]
+    assert len(lines) == 3  # header + 2 data rows
+
+
+# --------------------------------------------------------------------------- #
+# --dump CLI (offline, no terminal)
+# --------------------------------------------------------------------------- #
+def test_dump_cli_prints_output():
+    r = subprocess.run([sys.executable, str(SCRIPTS / "memory-detail"), "--dump"],
+                       stdout=subprocess.PIPE, text=True, timeout=15)
+    assert r.returncode == 0
+    assert "RAM:" in r.stdout
+    assert "Swap:" in r.stdout


### PR DESCRIPTION
Replace btop with a focused float terminal showing RAM/swap summary + top 15 processes grouped by command, sorted by RSS.

- New script RAM: 64.8G / 123.4G (53%)  Swap: 40.4G / 86.4G (47%)

  PID      USER     RSS  %MEM  COMMAND
  --------------------------------------
  1455621  zach    3.2G    2.6  S:\steamapps\common\Warhammer 40,000 ...
  1230113  zach    1.9G    1.5  /nix/store/k3nz3s314bipvqbcbw3faq823h...
  3479968  root    1.1G    0.8  /nix/store/b6v3r7yxic6x8nrip8jpgajwyr...
  4025325  zach  992.1M    0.7  tmux
  1944439  zach  917.7M    0.7  opencode
  1017301  zach  894.2M    0.7  opencode
  152918   root  720.7M    0.5  python3 ./ComfyUI/main.py --listen --...
  2522139  zach  650.6M    0.5  opencode
  3879217  zach  636.1M    0.5  opencode --prompt read session ses_fe...
  2639146  zach  622.7M    0.4  opencode
  3422513  zach  570.2M    0.4  claude
  1819160  zach  532.2M    0.4  opencode
  4054398  zach  531.4M    0.4  claude
  3556082  zach  511.3M    0.4  claude
  880738   zach  491.5M    0.3  claude (stdlib only, no deps)
- 20 unit tests in 
- Deployed via , unconditional on both hosts
- : retargeted  + added  entry