### PR TITLE
fix(nogit_plugin): serialise the config control — a retry only randomises a collision it cannot remove

### DIFF
--- a/scripts/testlib/nogit_plugin.py
+++ b/scripts/testlib/nogit_plugin.py
@@ -99,6 +99,8 @@ see (an atexit hook, a lingering thread, a fixture finalizer).
 """
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import os
 import random
 import shutil
@@ -164,6 +166,38 @@ LOCK_TIMEOUT = 5
 CONTROL_OK = "emitted"
 CONTROL_UNCONTAINED = "WITHHELD-UNCONTAINED"
 
+# 🔴 THE CROSS-PROCESS MUTEX THAT MAKES THE RETRY LOOP A FALLBACK RATHER THAN THE
+# PLAN. Every session sharing one guard dir fires the control write above; git's
+# own `<cfg>.lock` is exclusive and NON-blocking, so the losers exit 255
+# immediately and the retry loop is a thundering herd racing to re-collide. It
+# only wins while the write is faster than the backoff: MEASURED on this box,
+# 96 concurrent writers to an empty guard file produced 3 exhaustions, 160
+# produced 74, and 16 writers against a config large enough to make one write
+# outlast the jitter produced 11. The operator's box is the loaded case, and
+# GUARD 10 read the exhaustion as `control=unmeasured` — the guard unable to run
+# its own positive control, which the runner correctly refuses to score as a
+# pass.
+#
+# So the writers are SERIALISED here instead, on an advisory `flock` every
+# participant takes before invoking git. There is no collision left to back off
+# from, and nothing about the guard's accounting moves: the redirect still names
+# the ONE file `run-tests.sh` exported (checked for equality at its GUARD 10
+# evaluation), and the control keys still accumulate in that ONE file where
+# `_nogit_controls()` counts them one-per-session.
+#
+# 🔴 `.pylock`, NEVER `.lock`: `<cfg>.lock` is git's OWN lock file name, and
+# creating it ourselves would make every `git config --global` write in the run
+# fail outright — the guard's positive control silenced by the thing meant to
+# protect it.
+#
+# The lock is advisory and released by the kernel when the holder's fd closes,
+# so a killed worker cannot wedge the run. Acquisition is bounded: on timeout the
+# write proceeds UNLOCKED, which is exactly the pre-serialisation behaviour, and
+# the retry loop below is still there to catch it.
+CONFIG_LOCK_SUFFIX = ".pylock"
+CONFIG_LOCK_WAIT = 60.0
+CONFIG_LOCK_POLL = 0.005
+
 # The protocol probe. `.invalid` is reserved by RFC 2606 and can never resolve,
 # so if the allowlist is NOT in effect this fails at DNS — a DIFFERENT error,
 # which is exactly what makes the two states distinguishable. Nothing leaves the
@@ -181,6 +215,59 @@ REFUSAL_TOKEN = "not allowed"
 def guard_config_path(guard_dir: Path) -> Path:
     """The throwaway file `git config --global` writes to under this guard."""
     return Path(guard_dir) / CONFIG_NAME
+
+
+def guard_config_lock_path(guard_dir: Path) -> Path:
+    """The advisory lock serialising this guard's `git config --global` writes.
+
+    A SIBLING of the config file, never the config file itself and never git's
+    own `<cfg>.lock` — see CONFIG_LOCK_SUFFIX. Nothing reads it; it exists only
+    to be flock'd.
+    """
+    return Path(guard_dir) / (CONFIG_NAME + CONFIG_LOCK_SUFFIX)
+
+
+@contextlib.contextmanager
+def _config_write_lock(guard_dir: Path, wait: float = CONFIG_LOCK_WAIT):
+    """Hold the guard dir's config mutex for one `git config --global` write.
+
+    Yields True if the lock is held, False if it could not be taken — and False
+    is not a failure path: the caller writes anyway, because an unserialised
+    write is the behaviour that shipped before this lock existed and the retry
+    loop still covers it. FAILING here must never turn into `unmeasured`, which
+    is the verdict this whole change exists to stop producing.
+
+    Polled `LOCK_NB` rather than a blocking `LOCK_EX` so the wait is BOUNDED. A
+    blocking acquire against a holder that wedged would hang the session inside
+    a session-scoped autouse fixture, i.e. hang the target with no output.
+    """
+    fh = None
+    held = False
+    try:
+        try:
+            Path(guard_dir).mkdir(parents=True, exist_ok=True)
+            fh = guard_config_lock_path(guard_dir).open("a+")
+        except OSError:
+            fh = None
+        if fh is not None:
+            deadline = time.monotonic() + wait
+            while True:
+                try:
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    held = True
+                    break
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        break
+                    time.sleep(CONFIG_LOCK_POLL)
+        yield held
+    finally:
+        if fh is not None:
+            if held:
+                with contextlib.suppress(OSError):
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+            with contextlib.suppress(OSError):
+                fh.close()
 
 
 def install(guard_dir: Path) -> Path:
@@ -251,14 +338,24 @@ def config_control(guard_dir: Path) -> tuple[str, str]:
     key = f"{CONTROL_SECTION}.{CONTROL_PREFIX}{os.getpid()}"
     token = f"nogit-{os.getpid()}"
 
-    # 🔴 RETRY ONLY ON LOCK CONTENTION. Under pytest-xdist every worker runs its
-    # own session and fires this control, and they all write the SAME guard file
-    # — git takes an exclusive `<cfg>.lock` per write, so the losers exit 255
-    # with "could not lock config file". MEASURED: 8 concurrent
-    # `git config --global` writes to one file -> 4 exit 0, 4 exit 255 with that
-    # message. Before the retry, GUARD 10 reported `control=unmeasured` for 16 of
-    # 27 targets — the guard could not run its own positive control, which it
-    # correctly refuses to score as a pass.
+    # 🔴 RETRY ONLY ON LOCK CONTENTION — DEFENCE IN DEPTH, NOT THE MECHANISM.
+    # Under pytest-xdist every worker runs its own session and fires this
+    # control, and they all write the SAME guard file — git takes an exclusive
+    # `<cfg>.lock` per write, so the losers exit 255 with "could not lock config
+    # file". MEASURED: 8 concurrent `git config --global` writes to one file ->
+    # 4 exit 0, 4 exit 255 with that message. Before the retry, GUARD 10 reported
+    # `control=unmeasured` for 16 of 27 targets — the guard could not run its own
+    # positive control, which it correctly refuses to score as a pass.
+    #
+    # The retry ALONE was not enough, and was never going to be: it randomises a
+    # collision instead of removing one, so it holds only while a write finishes
+    # inside the backoff window. On a loaded box it does not, and GUARD 10 went
+    # back to `unmeasured` (measured on `scripts/validation/tests`). The
+    # `_config_write_lock` below is what removes the collision; this loop is KEPT
+    # because it covers the contention the lock cannot see — a writer that never
+    # took it (a test in the target firing its own `git config --global`, a
+    # concurrent process reaching the same file, a session that failed to open
+    # the lock at all).
     #
     # The retry is deliberately NARROW: any other non-zero exit still returns
     # "unmeasured" on the first try. Widening it to all failures would convert a
@@ -268,7 +365,14 @@ def config_control(guard_dir: Path) -> tuple[str, str]:
         # A SHORT timeout, not _git's 30s default: this is one tiny local write,
         # and it is now retried, so the worst case is LOCK_RETRIES * timeout. At
         # 30s that is 3 minutes per session spent discovering a stuck lock.
-        wrote = _git(["config", "--global", key, token], timeout=LOCK_TIMEOUT)
+        #
+        # The mutex is held around the git invocation ONLY — never across the
+        # backoff sleep below. Sleeping under it would make every OTHER
+        # participant wait out a delay incurred for a writer that is not
+        # participating, which is the shape that turns a mutex into the stall it
+        # was added to prevent.
+        with _config_write_lock(guard_dir):
+            wrote = _git(["config", "--global", key, token], timeout=LOCK_TIMEOUT)
         if wrote is None:
             return "unmeasured", "git is not runnable from this session"
         if wrote.returncode == 0:

--- a/scripts/testlib/nogit_plugin.py
+++ b/scripts/testlib/nogit_plugin.py
@@ -100,6 +100,7 @@ see (an atexit hook, a lingering thread, a fixture finalizer).
 from __future__ import annotations
 
 import contextlib
+import errno
 import fcntl
 import os
 import random
@@ -192,8 +193,19 @@ CONTROL_UNCONTAINED = "WITHHELD-UNCONTAINED"
 #
 # The lock is advisory and released by the kernel when the holder's fd closes,
 # so a killed worker cannot wedge the run. Acquisition is bounded: on timeout the
-# write proceeds UNLOCKED, which is exactly the pre-serialisation behaviour, and
+# WRITE proceeds UNLOCKED, which is exactly the pre-serialisation behaviour, and
 # the retry loop below is still there to catch it.
+#
+# 🔴 THE *WRITE* DEGRADES TO PRE-SERIALISATION BEHAVIOUR; THE *TIME* DOES NOT —
+# and the retry loop's own comment below states a worst case that this constant
+# invalidated. Serialising inside the retry makes the ceiling
+#   LOCK_RETRIES * (CONFIG_LOCK_WAIT + LOCK_TIMEOUT) + jitter
+#   = 6 * (60 + 5) + 0.75 ≈ 391s
+# against ≈31s before. That is inside a session-scoped autouse fixture, so it is
+# a per-session stall, not a per-test one. It does not threaten `gate.sh`'s
+# 3600s tier cap — the hazard is an operator reasoning from the stale figure and
+# concluding a session cannot stall for minutes. Re-derive this product if you
+# change ANY of the three constants.
 CONFIG_LOCK_SUFFIX = ".pylock"
 CONFIG_LOCK_WAIT = 60.0
 CONFIG_LOCK_POLL = 0.005
@@ -228,7 +240,7 @@ def guard_config_lock_path(guard_dir: Path) -> Path:
 
 
 @contextlib.contextmanager
-def _config_write_lock(guard_dir: Path, wait: float = CONFIG_LOCK_WAIT):
+def _config_write_lock(guard_dir: Path, wait: float | None = None):
     """Hold the guard dir's config mutex for one `git config --global` write.
 
     Yields True if the lock is held, False if it could not be taken — and False
@@ -250,13 +262,33 @@ def _config_write_lock(guard_dir: Path, wait: float = CONFIG_LOCK_WAIT):
         except OSError:
             fh = None
         if fh is not None:
+            # 🔴 READ THE MODULE ATTRIBUTE, do not bind it as a default argument.
+            # A default is captured at IMPORT, so `monkeypatch.setattr(mod,
+            # "CONFIG_LOCK_WAIT", 0.2)` had no effect while its neighbours
+            # LOCK_RETRIES / LOCK_TIMEOUT / CONFIG_LOCK_SUFFIX all honoured it —
+            # an inconsistency that silently cost a measurement (a run set to
+            # 0.2s took 60.4s). An explicit `wait=` argument still wins.
+            if wait is None:
+                wait = CONFIG_LOCK_WAIT
             deadline = time.monotonic() + wait
             while True:
                 try:
                     fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                     held = True
                     break
-                except OSError:
+                except OSError as exc:
+                    # 🔴 ONLY contention is worth waiting out. `flock` reports a
+                    # held lock as EWOULDBLOCK/EAGAIN; anything else — ENOLCK on
+                    # a filesystem without lock support, EPERM under a
+                    # restrictive seccomp — will NEVER succeed, so polling it
+                    # burns the whole CONFIG_LOCK_WAIT per acquire, silently,
+                    # every session. MEASURED with flock forced to ENOLCK:
+                    # held=False after the full wait rather than immediately.
+                    # Not reachable on today's hosts (the guard dir is a local
+                    # `mktemp -d` in every tier), which is why this fails fast
+                    # rather than escalating.
+                    if exc.errno not in (errno.EWOULDBLOCK, errno.EAGAIN):
+                        break
                     if time.monotonic() >= deadline:
                         break
                     time.sleep(CONFIG_LOCK_POLL)
@@ -362,16 +394,21 @@ def config_control(guard_dir: Path) -> tuple[str, str]:
     # genuinely broken control into a slow green, which is the exact failure this
     # guard exists to prevent.
     for attempt in range(LOCK_RETRIES):
-        # A SHORT timeout, not _git's 30s default: this is one tiny local write,
-        # and it is now retried, so the worst case is LOCK_RETRIES * timeout. At
-        # 30s that is 3 minutes per session spent discovering a stuck lock.
+        # A SHORT timeout, not _git's 30s default: this is one tiny local write.
+        # 🔴 THE WORST CASE IS NO LONGER `LOCK_RETRIES * timeout`. That sentence
+        # stood here through the commit that added the mutex and was wrong by
+        # ~13x: serialising INSIDE the retry means each attempt can also wait
+        # out CONFIG_LOCK_WAIT first, so the ceiling is
+        #   LOCK_RETRIES * (CONFIG_LOCK_WAIT + LOCK_TIMEOUT) + jitter ≈ 391s,
+        # not ≈31s. See the CONFIG_LOCK_WAIT block above for the full derivation
+        # and why the wrong number is the hazard rather than the duration.
         #
         # The mutex is held around the git invocation ONLY — never across the
         # backoff sleep below. Sleeping under it would make every OTHER
         # participant wait out a delay incurred for a writer that is not
         # participating, which is the shape that turns a mutex into the stall it
         # was added to prevent.
-        with _config_write_lock(guard_dir):
+        with _config_write_lock(guard_dir) as held:
             wrote = _git(["config", "--global", key, token], timeout=LOCK_TIMEOUT)
         if wrote is None:
             return "unmeasured", "git is not runnable from this session"
@@ -380,9 +417,33 @@ def config_control(guard_dir: Path) -> tuple[str, str]:
         if LOCK_CONTENTION not in (wrote.stderr or "").lower():
             return "unmeasured", f"git config --global exited {wrote.returncode}"
         if attempt == LOCK_RETRIES - 1:
+            # 🔴 SAY WHICH MECHANISM. Three different causes produce a
+            # BYTE-IDENTICAL "still lock-contended" verdict, and the incident
+            # that motivated the mutex was diagnosed from exactly this string —
+            # so it could not distinguish them, which is the repo's own "an
+            # EMPTY RESULT cannot distinguish two mechanisms" rule:
+            #   (a) genuine contention — the mutex was HELD and writers still
+            #       collided, i.e. a writer that never took the mutex exists;
+            #   (b) the mutex was NOT held (fail-open path), so this is the
+            #       pre-serialisation behaviour and says nothing about (a);
+            #   (c) a STALE `<cfg>.lock` left behind. `_git`'s own
+            #       `timeout=LOCK_TIMEOUT` SIGKILLs git, and git does not remove
+            #       its lockfile on SIGKILL — so ONE timed-out write poisons the
+            #       guard dir for every remaining session, permanently, with
+            #       this same message. Nothing cleans it up.
+            # These fields are what make (a)/(b)/(c) separable in a later
+            # incident. Do NOT delete the stale-lock probe to tidy this up: its
+            # absence is what made the original diagnosis unrecoverable.
+            git_lock = Path(str(cfg) + ".lock")
+            try:
+                stale = git_lock.exists()
+            except OSError:
+                stale = False
             return ("unmeasured",
                     f"git config --global exited {wrote.returncode} — still "
-                    f"lock-contended after {LOCK_RETRIES} attempts")
+                    f"lock-contended after {LOCK_RETRIES} attempts "
+                    f"(mutex={'held' if held else 'NOT-held'}, "
+                    f"stale-git-lock={'PRESENT' if stale else 'absent'})")
         # FULL JITTER, not a pid-derived offset. The first version used
         # `(os.getpid() % 17) / 1000` — at most 16ms against a 50ms step, and
         # two pids congruent mod 17 got IDENTICAL backoff, so the losers

--- a/scripts/testlib/nogit_plugin.py
+++ b/scripts/testlib/nogit_plugin.py
@@ -277,16 +277,29 @@ def _config_write_lock(guard_dir: Path, wait: float | None = None):
                     held = True
                     break
                 except OSError as exc:
-                    # 🔴 ONLY contention is worth waiting out. `flock` reports a
-                    # held lock as EWOULDBLOCK/EAGAIN; anything else — ENOLCK on
-                    # a filesystem without lock support, EPERM under a
-                    # restrictive seccomp — will NEVER succeed, so polling it
-                    # burns the whole CONFIG_LOCK_WAIT per acquire, silently,
-                    # every session. MEASURED with flock forced to ENOLCK:
-                    # held=False after the full wait rather than immediately.
-                    # Not reachable on today's hosts (the guard dir is a local
-                    # `mktemp -d` in every tier), which is why this fails fast
-                    # rather than escalating.
+                    # 🔴 Only CONTENTION is worth polling out: `flock` reports a
+                    # held lock as EWOULDBLOCK/EAGAIN, and waiting is exactly
+                    # right for that. Anything else fails open immediately
+                    # rather than burning the whole CONFIG_LOCK_WAIT per
+                    # acquire, silently, every session.
+                    #
+                    # ⚠ AN EARLIER VERSION OF THIS COMMENT JUSTIFIED THAT WITH
+                    # "ENOLCK means a filesystem without lock support and will
+                    # NEVER succeed". That is WRONG — flock(2) documents ENOLCK
+                    # as "the kernel ran out of memory for allocating lock
+                    # records", i.e. rare and TRANSIENT; and EPERM is not a
+                    # documented flock error at all, reachable only via a seccomp
+                    # filter synthesising it. The behaviour is still the one we
+                    # want, but the trade is a DELIBERATE choice, not a fact
+                    # about the errno: a transient ENOLCK now fails open
+                    # instantly instead of being polled out, and the outer retry
+                    # can then exhaust in under a second. Accepted because it is
+                    # rare, and because a silent 60s stall per session on an
+                    # errno that cannot be waited out is the worse failure.
+                    #
+                    # Neither path is reachable on today's hosts — the guard dir
+                    # is a local `mktemp -d` in every tier — so this rests on the
+                    # man page and code reading, not a live reproduction.
                     if exc.errno not in (errno.EWOULDBLOCK, errno.EAGAIN):
                         break
                     if time.monotonic() >= deadline:
@@ -393,6 +406,16 @@ def config_control(guard_dir: Path) -> tuple[str, str]:
     # "unmeasured" on the first try. Widening it to all failures would convert a
     # genuinely broken control into a slow green, which is the exact failure this
     # guard exists to prevent.
+    #
+    # 🔴 COUNT the acquisitions, do not sample the last one. `held` is rebound
+    # every iteration, so reporting it alone describes ONE attempt while reading
+    # as a property of the whole run: with the mutex free only at the end
+    # ([F,F,F,F,T,T]) the verdict would say "held" while FOUR of six writes ran
+    # unserialised. That is the misdiagnosis this field exists to prevent, in the
+    # costlier direction — it sends the reader hunting a rogue writer that does
+    # not exist. The ratio distinguishes "serialised throughout and still
+    # collided" from "mostly unserialised".
+    held_count = 0
     for attempt in range(LOCK_RETRIES):
         # A SHORT timeout, not _git's 30s default: this is one tiny local write.
         # 🔴 THE WORST CASE IS NO LONGER `LOCK_RETRIES * timeout`. That sentence
@@ -409,6 +432,7 @@ def config_control(guard_dir: Path) -> tuple[str, str]:
         # participating, which is the shape that turns a mutex into the stall it
         # was added to prevent.
         with _config_write_lock(guard_dir) as held:
+            held_count += bool(held)
             wrote = _git(["config", "--global", key, token], timeout=LOCK_TIMEOUT)
         if wrote is None:
             return "unmeasured", "git is not runnable from this session"
@@ -442,7 +466,7 @@ def config_control(guard_dir: Path) -> tuple[str, str]:
             return ("unmeasured",
                     f"git config --global exited {wrote.returncode} — still "
                     f"lock-contended after {LOCK_RETRIES} attempts "
-                    f"(mutex={'held' if held else 'NOT-held'}, "
+                    f"(mutex=held {held_count}/{attempt + 1}, "
                     f"stale-git-lock={'PRESENT' if stale else 'absent'})")
         # FULL JITTER, not a pid-derived offset. The first version used
         # `(os.getpid() % 17) / 1000` — at most 16ms against a 50ms step, and

--- a/scripts/tests/test_nogit_isolation.py
+++ b/scripts/tests/test_nogit_isolation.py
@@ -57,6 +57,20 @@ WHAT IS REGRESSION COVERAGE HERE AND WHAT IS NOT (RULES.md asks for the label):
     203a5582, green at HEAD — the matrix is in the test's own docstring.
     `test_the_control_mutex_is_never_gits_own_lock_file` is the INVARIANT GUARD
     beside it, on the one rename that would silence the control entirely.
+  * `test_the_exhaustion_verdict_counts_acquisitions_it_does_not_sample_one` is
+    REGRESSION coverage for the verdict describing ONE retry attempt while
+    reading as the whole run — `held` is rebound each iteration, so a bare
+    boolean said `mutex=held` on a run where most writes went unserialised, and
+    the reader then hunts a rogue writer that does not exist. It pins BOTH sides
+    of the ratio (`0/6` with the mutex taken from the test process, `6/6` with it
+    free) because pinning only the zero leaves a mutant that hardcodes the
+    numerator alive — measured, it SURVIVED before the second half existed.
+  * `test_CONFIG_LOCK_WAIT_is_read_at_call_time_not_captured_at_import` is
+    REGRESSION coverage for a silent trap rather than a wrong answer: `wait` was
+    a default argument, captured at import, so monkeypatching the module
+    attribute did nothing while its three neighbours honoured it. Asserted by
+    ELAPSED TIME, which is the observable the trap moves — 60.28s with the bug
+    against its 5s bound, 0.30s without.
   * the plugin-flag set pin, the lever pins, the two-way token pin and the
     accounting-site count are INVARIANT GUARDS. The bug never violated them; they
     exist so the enforcement point cannot be narrowed to nothing by an edit that
@@ -458,10 +472,15 @@ def _fire_controls_concurrently(tmp_path, n=_CONTENDERS,
     # with a `continue` bounds the fixture at n*300 = 4800s — past `gate.sh`'s
     # 3600s tier cap, turning a systemic child hang into `reason=timeout` with NO
     # verdict instead of one clean failure. The budget must also EXCEED the
-    # documented 391s single-control ceiling (LOCK_RETRIES * (CONFIG_LOCK_WAIT +
-    # LOCK_TIMEOUT) + jitter), or a legitimately slow control is killed and
-    # reported as a hang. 600s satisfies both; re-derive it if either constant
-    # moves — and note this, not _CONTENDED_CONFIG_KEYS, is the real cap.
+    # ceiling of a whole `config_control` call, or a legitimately slow control is
+    # killed and reported as a hang. 🔴 THAT IS NOT THE DOCUMENTED 391s: 391 is
+    # the RETRY LOOP's bound (LOCK_RETRIES * (CONFIG_LOCK_WAIT + LOCK_TIMEOUT) +
+    # jitter), and the function then does a post-loop `--get` read-back with
+    # `_git`'s DEFAULT timeout of 30 rather than LOCK_TIMEOUT — so the call's
+    # real ceiling is ≈421s. An earlier revision of this comment said 391 and
+    # told you to re-derive from it, which would come out 30s short. 600s clears
+    # 421; re-derive from 421 if any of those constants moves — and note this,
+    # not _CONTENDED_CONFIG_KEYS, is the real cap.
     budget = 600.0
     deadline = time.monotonic() + budget
     out = []
@@ -476,6 +495,11 @@ def _fire_controls_concurrently(tmp_path, n=_CONTENDERS,
                 # Capture what it DID say. Discarding this for a fixed string
                 # would be the exact failure the payload half of this commit
                 # exists to fix: a verdict that does not name its mechanism.
+                # ⚠ MEASURED: the tail is EMPTY for a child killed before its
+                # single JSON write, because _CONTENDER writes nothing until the
+                # very end. So an empty tail means "killed before it produced
+                # anything", NOT "it had nothing useful to say" — a child that
+                # does emit (verified with a stderr marker) has it captured here.
                 stdout, stderr = p.communicate()
                 out.append({"status": "CHILD-TIMEOUT",
                             "detail": f"killed after the {budget:.0f}s fixture "
@@ -535,7 +559,7 @@ def test_concurrent_sessions_all_emit_their_control_key(tmp_path):
         f"to the session count, so a scattered write reads as a dead redirect.")
 
 
-def test_the_exhaustion_verdict_counts_acquisitions_it_does_not_sample_one(tmp_path):
+def test_the_exhaustion_verdict_counts_acquisitions_it_does_not_sample_one(tmp_path, monkeypatch):
     """🔴 REGRESSION. The verdict must report how MANY attempts held the mutex.
 
     `held` is rebound every retry, so printing it alone describes ONE attempt
@@ -550,10 +574,18 @@ def test_the_exhaustion_verdict_counts_acquisitions_it_does_not_sample_one(tmp_p
     itself really does exit 255 — mechanism (c), which is what makes the
     exhaustion path reachable without racing anything.
     """
+    # 🔴 monkeypatch, NOT `install()`. `install()` rewrites five process-wide
+    # env vars and its own header says it is NEVER UNDONE — so calling it here
+    # leaks this test's redirect into every test that runs after it in the file
+    # (measured: 42 of them), and those tests then verify containment against a
+    # redirect an unrelated test installed rather than the session fixture's.
+    # `_guard_config`'s vacuity assertion cannot detect that. The file already
+    # had the right pattern; this test is what introduced the wrong one.
     guard = tmp_path / "g"
     guard.mkdir()
-    nogit_plugin.install(guard)
     cfg = nogit_plugin.guard_config_path(guard)
+    cfg.write_text("", encoding="utf-8")
+    monkeypatch.setenv(nogit_plugin.CONFIG_ENV, str(cfg))
     Path(str(cfg) + ".lock").write_text("", encoding="utf-8")
 
     holder = nogit_plugin.guard_config_lock_path(guard).open("a+")
@@ -573,8 +605,28 @@ def test_the_exhaustion_verdict_counts_acquisitions_it_does_not_sample_one(tmp_p
     # And the other discriminator still names mechanism (c) beside it.
     assert "stale-git-lock=PRESENT" in detail, detail
 
+    # 🔴 THE NON-ZERO SIDE, and it is not optional. Asserting only `0/6` pins a
+    # value this fixture can ONLY ever produce, so a mutant that hardcodes the
+    # numerator to 0 SURVIVES a green suite — RULES.md's "a fixture derived from
+    # the constant under test cannot see that constant change", walked into
+    # while fixing a mutation-coverage defect. Same stale lock so git still
+    # fails, but WITHOUT holding the mutex, so every acquire succeeds: the
+    # counter must move. This is also mechanism (a) — serialised throughout and
+    # still failing — pinned beside the (b)+(c) case above.
+    guard_a = tmp_path / "a"
+    guard_a.mkdir()
+    cfg_a = nogit_plugin.guard_config_path(guard_a)
+    cfg_a.write_text("", encoding="utf-8")
+    monkeypatch.setenv(nogit_plugin.CONFIG_ENV, str(cfg_a))
+    Path(str(cfg_a) + ".lock").write_text("", encoding="utf-8")
 
-def test_CONFIG_LOCK_WAIT_is_read_at_call_time_not_captured_at_import(tmp_path):
+    status_a, detail_a = nogit_plugin.config_control(guard_a)
+    assert status_a == "unmeasured", (status_a, detail_a)
+    assert (f"mutex=held {nogit_plugin.LOCK_RETRIES}/{nogit_plugin.LOCK_RETRIES}"
+            in detail_a), detail_a
+
+
+def test_CONFIG_LOCK_WAIT_is_read_at_call_time_not_captured_at_import(tmp_path, monkeypatch):
     """🔴 REGRESSION, and it guards a SILENT trap rather than a wrong answer.
 
     `wait` was bound as `wait: float = CONFIG_LOCK_WAIT`, so the value was
@@ -588,9 +640,14 @@ def test_CONFIG_LOCK_WAIT_is_read_at_call_time_not_captured_at_import(tmp_path):
     Measured: ~60.00s with the bug, ~0.30s without — so a 5s bound is nowhere
     near either, and this is not a timing-sensitive test in the flaky sense.
     """
+    # monkeypatch, not `install()` — same reason as the test above: `install()`
+    # is documented as never undone and would leak this redirect into every
+    # later test in the file.
     guard = tmp_path / "g"
     guard.mkdir()
-    nogit_plugin.install(guard)
+    cfg = nogit_plugin.guard_config_path(guard)
+    cfg.write_text("", encoding="utf-8")
+    monkeypatch.setenv(nogit_plugin.CONFIG_ENV, str(cfg))
     lock_path = nogit_plugin.guard_config_lock_path(guard)
     # Hold the mutex from this process so every acquire below must wait it out.
     holder = lock_path.open("a+")

--- a/scripts/tests/test_nogit_isolation.py
+++ b/scripts/tests/test_nogit_isolation.py
@@ -48,6 +48,15 @@ WHAT IS REGRESSION COVERAGE HERE AND WHAT IS NOT (RULES.md asks for the label):
     measured against a scratch HOME, never the operator's.
   * `test_the_control_of_those_mutants_is_green` is the positive control for all
     of them, and pins the accounting line the others read.
+  * `test_concurrent_sessions_all_emit_their_control_key` is REGRESSION coverage
+    for the guard going DARK under its own parallelism: every xdist worker fires
+    the config control at ONE file, git's `<cfg>.lock` is exclusive, and the
+    plugin's retry-with-jitter only wins while a write is faster than the
+    backoff. On a loaded box it is not, GUARD 10 reported `control=unmeasured`,
+    and an unmeasured control is a guard that has proved nothing. Red at
+    203a5582, green at HEAD — the matrix is in the test's own docstring.
+    `test_the_control_mutex_is_never_gits_own_lock_file` is the INVARIANT GUARD
+    beside it, on the one rename that would silence the control entirely.
   * the plugin-flag set pin, the lever pins, the two-way token pin and the
     accounting-site count are INVARIANT GUARDS. The bug never violated them; they
     exist so the enforcement point cannot be narrowed to nothing by an edit that
@@ -56,6 +65,7 @@ WHAT IS REGRESSION COVERAGE HERE AND WHAT IS NOT (RULES.md asks for the label):
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import re
 import shlex
@@ -345,6 +355,149 @@ def test_the_config_control_is_fail_closed_when_the_write_is_not_contained(
     # satisfied by a function that can only ever fail.
     status, detail = nogit_plugin.config_control(tmp_path)
     assert status == nogit_plugin.CONTROL_OK, (status, detail)
+
+
+# --------------------------------------------------------------------------- #
+# The control write under CONCURRENCY
+# --------------------------------------------------------------------------- #
+# The child. A separate PROCESS per session, not a thread: the thing being
+# contended is git's `<cfg>.lock`, a real file lock, and threads in one
+# interpreter would serialise on nothing a thread can see.
+_CONTENDER = '''\
+import importlib.util, json, os, sys, time
+mod_path, guard_dir, go = sys.argv[1], sys.argv[2], sys.argv[3]
+spec = importlib.util.spec_from_file_location("nogit_under_test", mod_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+# Start together. Without the barrier the children stagger by their own import
+# time and the collision this measures never happens.
+while not os.path.exists(go):
+    time.sleep(0.005)
+mod.install(guard_dir)
+status, detail = mod.config_control(guard_dir)
+sys.stdout.write(json.dumps({"status": status, "detail": detail}))
+'''
+
+# 🔴 THE TWO NUMBERS, AND WHY THESE. Both are LOCK-HOLD-WINDOW amplifiers, and
+# together they stand in for the operator's loaded box, where a `git config`
+# write outlasts the plugin's ~0.75s of total backoff. Measured on this host
+# against the PRE-FIX plugin (203a5582):
+#
+#   16 writers, empty guard file .................  0 / 16 failed  (green, useless)
+#   96 writers, empty guard file .................  3 / 96 failed  (red, marginal)
+#  160 writers, empty guard file ................. 74 /160 failed  (red, expensive)
+#   16 writers, 200k-key guard file .............. 10-11 / 16 failed  (red, cheap)
+#
+# The seeded shape is the one committed: it is the only one that is both
+# reliably red at base and cheap enough to run every gate. The seed makes ONE
+# write slow, which is precisely the condition under which a retry-with-backoff
+# loop stops working — it is not a proxy for the bug, it IS the bug's
+# precondition.
+_CONTENDERS = 16
+_CONTENDED_CONFIG_KEYS = 200_000
+
+
+def _fire_controls_concurrently(tmp_path, n=_CONTENDERS,
+                                seed=_CONTENDED_CONFIG_KEYS):
+    """N processes, one shared guard dir, one `config_control` each -> statuses.
+
+    The module under test is the real plugin. `DEVRC_NOGIT_PLUGIN_UNDER_TEST`
+    re-points THE CHILDREN — and only the children — at another copy of the
+    file; this process keeps the real import either way. That is how the RED
+    half of this test's matrix is reproduced against the pre-fix implementation:
+
+        git -C <repo> show 203a5582:scripts/testlib/nogit_plugin.py > /tmp/base.py
+        DEVRC_NOGIT_PLUGIN_UNDER_TEST=/tmp/base.py pytest -k concurrent_sessions
+
+    Nothing here can pollute the runner's ledger: each child calls `install()`
+    on ITS OWN guard dir, so its `GIT_CONFIG_GLOBAL` — and therefore its control
+    key — lands in this tmp_path, never in the run's isolated config where
+    `_nogit_controls()` counts one key per session.
+    """
+    mod_path = os.environ.get("DEVRC_NOGIT_PLUGIN_UNDER_TEST",
+                              nogit_plugin.__file__)
+    child = tmp_path / "contender.py"
+    child.write_text(_CONTENDER, encoding="utf-8")
+    guard = tmp_path / "guard"
+    guard.mkdir()
+    if seed:
+        (guard / nogit_plugin.CONFIG_NAME).write_text(
+            "[devrc-nogit-seed]\n"
+            + "".join(f"\tk{i} = v{i}\n" for i in range(seed)),
+            encoding="utf-8")
+    go = tmp_path / "go"
+    procs = [subprocess.Popen(
+        [sys.executable, str(child), mod_path, str(guard), str(go)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        for _ in range(n)]
+    go.write_text("go", encoding="utf-8")
+    out = []
+    for p in procs:
+        stdout, stderr = p.communicate(timeout=300)
+        try:
+            out.append(json.loads(stdout))
+        except ValueError:
+            out.append({"status": "CHILD-CRASHED",
+                        "detail": (stdout + stderr)[-400:]})
+    return out, guard
+
+
+def test_concurrent_sessions_all_emit_their_control_key(tmp_path):
+    """🔴 REGRESSION. Every session sharing a guard dir must MEASURE its control.
+
+    MEASURED on the operator's box: `scripts/gate.sh --tier pytest` failed GUARD
+    10 with `control=emitted,unmeasured … still lock-contended after 6 attempts`
+    for `scripts/validation/tests`. Under xdist each worker fires this control at
+    the SAME file; git's `<cfg>.lock` is exclusive and non-blocking, so the
+    losers exit 255 and the plugin's retry-with-jitter is a herd racing to
+    re-collide. It holds only while a write is faster than the backoff.
+
+    A session that cannot run its own positive control has proved nothing, and
+    the runner correctly refuses to score that as a pass — so this is a guard
+    going dark, not a cosmetic flake.
+
+    THE MATRIX (RULES.md: a test not watched to fail proves nothing):
+      RED   at 203a5582 — 10 of 16 children `unmeasured`, "still lock-contended
+                          after 6 attempts"
+      GREEN at HEAD     — 16 of 16 `emitted`
+    Reproduce the red half with `DEVRC_NOGIT_PLUGIN_UNDER_TEST`; see
+    `_fire_controls_concurrently`.
+    """
+    results, guard = _fire_controls_concurrently(tmp_path)
+    bad = [r for r in results if r["status"] != nogit_plugin.CONTROL_OK]
+    assert not bad, (
+        f"{len(bad)} of {len(results)} concurrent sessions could not measure "
+        f"their own `git config --global` control:\n"
+        + "\n".join(f"  {r['status']}: {r['detail']}" for r in bad[:5]))
+
+    # The POSITIVE CONTROL for the assertion above: `emitted` is only meaningful
+    # if the keys actually arrived. A control that reported success while the
+    # writes vanished is the reassuring zero this whole guard exists to refuse —
+    # and it is also what a "fix" that silently redirected each session to its
+    # own file would produce here.
+    written = (guard / nogit_plugin.CONFIG_NAME).read_text(encoding="utf-8")
+    landed = written.count(nogit_plugin.CONTROL_PREFIX)
+    assert landed == len(results), (
+        f"{len(results)} sessions reported `{nogit_plugin.CONTROL_OK}` but the "
+        f"ONE shared guard file holds {landed} control key(s). `run-tests.sh`'s "
+        f"`_nogit_controls()` counts them in that single file and pins the count "
+        f"to the session count, so a scattered write reads as a dead redirect.")
+
+
+def test_the_control_mutex_is_never_gits_own_lock_file(tmp_path):
+    """INVARIANT GUARD on the one rename that would silence the whole control.
+
+    `<cfg>.lock` is the file GIT creates to take its own exclusive lock. If this
+    plugin's advisory mutex were ever spelled that way, holding it would make
+    every `git config --global` in the run fail outright — the positive control
+    killed by the mechanism added to protect it. Also pinned: the mutex is a
+    sibling INSIDE the guard dir, never the config file itself.
+    """
+    lock = nogit_plugin.guard_config_lock_path(tmp_path)
+    cfg = nogit_plugin.guard_config_path(tmp_path)
+    assert lock.name != nogit_plugin.CONFIG_NAME + ".lock", (
+        "the control mutex is spelled the same as git's own lock file")
+    assert lock != cfg and lock.parent == tmp_path, (lock, cfg)
 
 
 def test_the_runner_and_the_plugin_agree_on_the_shared_tokens():

--- a/scripts/tests/test_nogit_isolation.py
+++ b/scripts/tests/test_nogit_isolation.py
@@ -371,7 +371,17 @@ mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 # Start together. Without the barrier the children stagger by their own import
 # time and the collision this measures never happens.
+# 🔴 BOUNDED. An unbounded `while not exists(go)` busy-polls FOREVER if the
+# parent dies between spawning us and writing the file — a KeyboardInterrupt, an
+# xdist worker restart, a failed write — leaving N children at 200 polls/s with
+# nothing that will ever release them. The parent also kills us in a finally,
+# but a child must not depend on its parent's cleanup to terminate.
+_deadline = time.monotonic() + 120
 while not os.path.exists(go):
+    if time.monotonic() >= _deadline:
+        sys.stdout.write(json.dumps(
+            {"status": "BARRIER-TIMEOUT", "detail": "parent never released the barrier"}))
+        raise SystemExit(0)
     time.sleep(0.005)
 mod.install(guard_dir)
 status, detail = mod.config_control(guard_dir)
@@ -393,6 +403,14 @@ sys.stdout.write(json.dumps({"status": status, "detail": detail}))
 # write slow, which is precisely the condition under which a retry-with-backoff
 # loop stops working — it is not a proxy for the bug, it IS the bug's
 # precondition.
+# 🔴 THESE TWO ARE A RATIO, NOT A PAIR OF MEASUREMENTS — re-MEASURE them on new
+# hardware, do not merely re-run. The RED half of the matrix needs the serialised
+# writes to outlast the retry loop's maximum jitter budget (~0.75s). Measured
+# here: 0.17s per write against the seeded config, so 16 writers take ~2.7s to
+# drain — comfortably past it. On hardware ~10x faster the drain fits INSIDE the
+# backoff, the base implementation passes, and the reproduction goes vacuous
+# while still looking green. If the base stops going red, that is the first
+# thing to check; raising _CONTENDED_CONFIG_KEYS restores the ratio.
 _CONTENDERS = 16
 _CONTENDED_CONFIG_KEYS = 200_000
 
@@ -430,15 +448,30 @@ def _fire_controls_concurrently(tmp_path, n=_CONTENDERS,
         [sys.executable, str(child), mod_path, str(guard), str(go)],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         for _ in range(n)]
-    go.write_text("go", encoding="utf-8")
+    # 🔴 The finally is what makes the barrier safe from THIS side: a
+    # `communicate` timeout used to propagate and leave the remaining children
+    # running, and an exception between Popen and `go.write_text` left all of
+    # them polling a file that would never appear.
     out = []
-    for p in procs:
-        stdout, stderr = p.communicate(timeout=300)
-        try:
-            out.append(json.loads(stdout))
-        except ValueError:
-            out.append({"status": "CHILD-CRASHED",
-                        "detail": (stdout + stderr)[-400:]})
+    try:
+        go.write_text("go", encoding="utf-8")
+        for p in procs:
+            try:
+                stdout, stderr = p.communicate(timeout=300)
+            except subprocess.TimeoutExpired:
+                p.kill()
+                stdout, stderr = p.communicate()
+                out.append({"status": "CHILD-TIMEOUT", "detail": "exceeded 300s"})
+                continue
+            try:
+                out.append(json.loads(stdout))
+            except ValueError:
+                out.append({"status": "CHILD-CRASHED",
+                            "detail": (stdout + stderr)[-400:]})
+    finally:
+        for p in procs:
+            if p.poll() is None:
+                p.kill()
     return out, guard
 
 

--- a/scripts/tests/test_nogit_isolation.py
+++ b/scripts/tests/test_nogit_isolation.py
@@ -64,6 +64,7 @@ WHAT IS REGRESSION COVERAGE HERE AND WHAT IS NOT (RULES.md asks for the label):
 """
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
 import os
@@ -452,16 +453,33 @@ def _fire_controls_concurrently(tmp_path, n=_CONTENDERS,
     # `communicate` timeout used to propagate and leave the remaining children
     # running, and an exception between Popen and `go.write_text` left all of
     # them polling a file that would never appear.
+    # 🔴 ONE WHOLE-FIXTURE DEADLINE, not a per-child timeout. The children run
+    # CONCURRENTLY but are waited on in sequence, so a per-child `timeout=300`
+    # with a `continue` bounds the fixture at n*300 = 4800s — past `gate.sh`'s
+    # 3600s tier cap, turning a systemic child hang into `reason=timeout` with NO
+    # verdict instead of one clean failure. The budget must also EXCEED the
+    # documented 391s single-control ceiling (LOCK_RETRIES * (CONFIG_LOCK_WAIT +
+    # LOCK_TIMEOUT) + jitter), or a legitimately slow control is killed and
+    # reported as a hang. 600s satisfies both; re-derive it if either constant
+    # moves — and note this, not _CONTENDED_CONFIG_KEYS, is the real cap.
+    budget = 600.0
+    deadline = time.monotonic() + budget
     out = []
     try:
         go.write_text("go", encoding="utf-8")
         for p in procs:
+            remaining = max(1.0, deadline - time.monotonic())
             try:
-                stdout, stderr = p.communicate(timeout=300)
+                stdout, stderr = p.communicate(timeout=remaining)
             except subprocess.TimeoutExpired:
                 p.kill()
+                # Capture what it DID say. Discarding this for a fixed string
+                # would be the exact failure the payload half of this commit
+                # exists to fix: a verdict that does not name its mechanism.
                 stdout, stderr = p.communicate()
-                out.append({"status": "CHILD-TIMEOUT", "detail": "exceeded 300s"})
+                out.append({"status": "CHILD-TIMEOUT",
+                            "detail": f"killed after the {budget:.0f}s fixture "
+                                      f"budget: {((stdout or '') + (stderr or ''))[-400:]}"})
                 continue
             try:
                 out.append(json.loads(stdout))
@@ -515,6 +533,99 @@ def test_concurrent_sessions_all_emit_their_control_key(tmp_path):
         f"ONE shared guard file holds {landed} control key(s). `run-tests.sh`'s "
         f"`_nogit_controls()` counts them in that single file and pins the count "
         f"to the session count, so a scattered write reads as a dead redirect.")
+
+
+def test_the_exhaustion_verdict_counts_acquisitions_it_does_not_sample_one(tmp_path):
+    """🔴 REGRESSION. The verdict must report how MANY attempts held the mutex.
+
+    `held` is rebound every retry, so printing it alone describes ONE attempt
+    while reading as a property of the whole run — with the mutex free only at
+    the end, a run where four of six writes went UNSERIALISED would report
+    `mutex=held`, sending the reader hunting a rogue writer that does not exist.
+    That is the misdiagnosis the field was added to prevent, in the costlier
+    direction, so the ratio is the guard and a bare boolean is the bug.
+
+    Driven to exhaustion the honest way: hold the mutex from this process (so
+    every acquire fails open, giving 0/N) AND plant a stale `<cfg>.lock` so git
+    itself really does exit 255 — mechanism (c), which is what makes the
+    exhaustion path reachable without racing anything.
+    """
+    guard = tmp_path / "g"
+    guard.mkdir()
+    nogit_plugin.install(guard)
+    cfg = nogit_plugin.guard_config_path(guard)
+    Path(str(cfg) + ".lock").write_text("", encoding="utf-8")
+
+    holder = nogit_plugin.guard_config_lock_path(guard).open("a+")
+    original = nogit_plugin.CONFIG_LOCK_WAIT
+    nogit_plugin.CONFIG_LOCK_WAIT = 0.05   # do not wait out our own mutex 6x
+    try:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        status, detail = nogit_plugin.config_control(guard)
+    finally:
+        nogit_plugin.CONFIG_LOCK_WAIT = original
+        holder.close()
+
+    assert status == "unmeasured", (status, detail)
+    # The RATIO, not a boolean. Literal expected value: every acquire failed
+    # open because we held the mutex, across all LOCK_RETRIES attempts.
+    assert f"mutex=held 0/{nogit_plugin.LOCK_RETRIES}" in detail, detail
+    # And the other discriminator still names mechanism (c) beside it.
+    assert "stale-git-lock=PRESENT" in detail, detail
+
+
+def test_CONFIG_LOCK_WAIT_is_read_at_call_time_not_captured_at_import(tmp_path):
+    """🔴 REGRESSION, and it guards a SILENT trap rather than a wrong answer.
+
+    `wait` was bound as `wait: float = CONFIG_LOCK_WAIT`, so the value was
+    captured at IMPORT and `monkeypatch.setattr(mod, "CONFIG_LOCK_WAIT", …)` did
+    nothing — while its three neighbours (LOCK_RETRIES, LOCK_TIMEOUT,
+    CONFIG_LOCK_SUFFIX) all honoured it. Reverting to the default-argument form
+    leaves every other test in this file GREEN, which is exactly why this one
+    exists: it already cost a measurement (a probe set to 0.2s took 60.4s).
+
+    Asserted by ELAPSED TIME, because that is the observable the trap changes.
+    Measured: ~60.00s with the bug, ~0.30s without — so a 5s bound is nowhere
+    near either, and this is not a timing-sensitive test in the flaky sense.
+    """
+    guard = tmp_path / "g"
+    guard.mkdir()
+    nogit_plugin.install(guard)
+    lock_path = nogit_plugin.guard_config_lock_path(guard)
+    # Hold the mutex from this process so every acquire below must wait it out.
+    holder = lock_path.open("a+")
+    try:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        original = nogit_plugin.CONFIG_LOCK_WAIT
+        nogit_plugin.CONFIG_LOCK_WAIT = 0.2
+        try:
+            started = time.monotonic()
+            with nogit_plugin._config_write_lock(guard) as held:
+                pass
+            elapsed = time.monotonic() - started
+        finally:
+            nogit_plugin.CONFIG_LOCK_WAIT = original
+    finally:
+        holder.close()
+
+    assert held is False, "the mutex was held elsewhere; this acquire must fail open"
+    assert elapsed < 5.0, (
+        f"honoured the import-time default instead of the module attribute: "
+        f"waited {elapsed:.2f}s against CONFIG_LOCK_WAIT=0.2")
+
+    # Positive control for the assertion above: an EXPLICIT wait= must still
+    # win, so the test cannot pass by the parameter having been ignored.
+    holder = lock_path.open("a+")
+    try:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        started = time.monotonic()
+        with nogit_plugin._config_write_lock(guard, wait=0.0) as held_explicit:
+            pass
+        explicit_elapsed = time.monotonic() - started
+    finally:
+        holder.close()
+    assert held_explicit is False
+    assert explicit_elapsed < 5.0
 
 
 def test_the_control_mutex_is_never_gits_own_lock_file(tmp_path):


### PR DESCRIPTION
Closes the mechanism behind clawgate cg#445: `scripts/gate.sh --tier pytest` has been permanently red on the workbench for **attribution-only** reasons — GUARD 10 refusing to vouch for itself, which `claude/RULES.md` names as worse than no gate because it trains everyone to click through.

## The mechanism, and a correction to the card

cg#445 attributes this to the git **common dir's** config shared by ~117 worktrees — which frames it as an environmental fact about the box, i.e. unfixable. That is how all **three** prior rediscoveries ended (2026-08-22, 2026-08-28, 2026-08-30).

The contended file is not `.git/config`. It is the guard's own `GIT_CONFIG_GLOBAL` target, and `nogit_plugin.py`'s own comment already said so:

> *every worker runs its own session and fires this control, and they all write the SAME guard file — git takes an exclusive `<cfg>.lock` per write, so the losers exit 255*

The control's key and token are already per-pid, so **only the file lock collides**. `LOCK_RETRIES = 6` with jitter randomises the collision; it cannot remove it, and under enough concurrent workers it exhausts and reports `unmeasured`.

## 🔴 The obvious fix is wrong, and this PR does not ship it

Making the config filename per-pid removes the contention — and **breaks GUARD 10 on every target**, because the shared filename is load-bearing in `scripts/run-tests.sh`, which constructs the path independently in shell as `$NOGIT_CONFIG`:

- **`run-tests.sh:4562`** — `[ "$m_redirect" != "$NOGIT_CONFIG" ]`, an **equality** test. Per-pid names trip *"Something between this script and pytest is re-pointing git's global config"* everywhere.
- **`run-tests.sh:3023`** `_nogit_controls()` — counts `control-*` keys in that **one** file, pinned to the session count at `:4566`. Per-pid files scatter the keys and it reads as *"the redirect is not where global writes land"*.

Neither greps for `guard_config_path`, which is exactly why a Python-symbol search misses them. One path, open-coded in two languages.

## What this ships instead

An advisory `flock` on a **separate** `<guard-dir>/gitconfig.pylock`, held only around the git invocation, never across the backoff sleep. `CONFIG_NAME`, `guard_config_path` and the `GIT_CONFIG_GLOBAL` target are **untouched**, so both bash consumers and the protection half are unchanged.

- 🔴 The mutex suffix is `.pylock`, never `.lock` — that is git's own lock filename for the same file. Pinned by its own test.
- Acquire is a polled `LOCK_EX|LOCK_NB` to a bounded deadline; a blocking acquire inside a session-scoped autouse fixture would hang a target with no output.
- It **fails open** to the pre-existing unlocked write, so it can never itself produce `unmeasured`.
- Retry/jitter kept as defence in depth against writers that never took the mutex.

## Evidence

**RED at `203a5582`, GREEN at HEAD**, same test, same command:

```
GREEN AT HEAD:  2 passed
RED AT BASE:    AssertionError: 10 of 16 concurrent sessions could not measure their own
                `git config --global` control: … still lock-contended after 6 attempts
```

**Re-verified independently of the implementing agent:** removing the serialisation while *keeping* the retry still fails — `11 of 16 concurrent sessions could not measure` — so the fix is the serialisation, not incidental.

**Mutation sweep**, fresh module per mutant, `PYTHONDONTWRITEBYTECODE=1`:

| mutant | result |
|---|---|
| no-op (**positive control**) | SURVIVED — the harness is not killing indiscriminately |
| serialisation removed | KILLED, 10/16, with the lock-contention message |
| mutex named `.lock` | KILLED, 16/16 |
| `CONFIG_LOCK_SUFFIX = ".lock"` in-tree | KILLED by the suffix test, with its own message |

Test fixture note: rather than 160 concurrent writers (measured 74 failures, but expensive), it makes **one write slow** via a 200k-key guard config — the actual precondition under which a backoff loop stops working — and is reliably red at a sixth of the process count.

## The real gate — the original symptom, gone

`gate.sh --tier pytest` on a clean worktree at `f1fa6cfa`:

```
GATE: RESULT=PASS exit=0
TOTAL collected=19784 passed=19781 skipped=3 failed=0   (run=1081s)
scripts/validation/tests  real-config-changed=0/3  config-control=4  protocol=refused
```

The originally-failing target reports `config-control=4` — all four xdist workers measured their own control. Zero GUARD 10 problems.

## Not verified

- **The sandbox tier was not run.** GUARD 10's `NOGIT_REPO_LOCAL` is empty in the nix sandbox, so that tier is not running the same guard — a green there would not be evidence for this.
- One gate run, one base sha; **not gated on the merged tree** against current `main`.
- The gate reported 3 unattributable repo-local deltas from other sessions doing `git branch` in sibling worktrees. Pre-existing, unrelated, not enforced.