### PR TITLE
docs(handoff): ci-speedup ranks 1 and 2 merged — and the measurement says DON'T build rank 3 (1.02x)

### DIFF
--- a/claudedocs/handoff-ci-speedup.md
+++ b/claudedocs/handoff-ci-speedup.md
@@ -16,20 +16,25 @@ Non-blocking: if it exits non-zero, print the stderr line and carry on.
 Cut the devrc-ci gate from ~25 min. This session **refuted the previous handoff's diagnosis**, spent the cluster levers, reverted them, and shipped the first devrc-side mechanism.
 
 ## State now
-- **PR #1073** `feat/ci-impact-analysis` — `--targets` subset selection for `run-tests.sh`. Head `bf4e904f`, both Tekton checks SUCCESS at that sha. **A fix round for the round-1 audit is UNCOMMITTED in the worktree `/home/zach/workspace/devrc-ci-impact`** (+413/-13 across `scripts/run-tests.sh` and `scripts/tests/test_run_tests_targets.py`).
-- **homelab-infra `trunk`** — three commits landed and two were reverted. Net config delta for the night: the devrc-ci gate budget 45m → 60m (`29ccfd69`) and nothing else.
-- `claim-work ci-speedup-1` is HELD by this session. Release it or take it over.
+- **Ranks 1 and 2 are DONE and merged.** Nothing in flight; no branch of this effort is open.
+- **PR #1073** `feat/ci-impact-analysis` — `--targets` subset selection for `run-tests.sh`. **MERGED `809486fa`**, verified by content on `origin/main` (48 `ONLY_TARGETS`/`DEVRC_TARGETS` refs; `scripts/tests/test_run_tests_targets.py` present). Four audit rounds closed before merge.
+- **PR #1081** — this handoff doc's prior update. **MERGED `a6554bf2`**.
+- **PR #1120** `feat/measure-test-readsets` — rank 2, the read-set measurement. **MERGED `90deea1d`**, verified by content. Five audit rounds.
+- **Cluster: baseline**, except the devrc-ci gate budget 45m→60m (`29ccfd69`), which is still in place and was deliberately kept.
+- **Claims `ci-speedup-1` and `ci-speedup-2` are still HELD** — release them if you are not continuing this effort (`claim-work --release <slug>`).
+- **Open issues filed by this effort:** #1094 (two guard-thinness findings from #1073's round-4 audit), #1123, #1124 (both below).
 
-### What's DONE
-1. **`23887675`** `requests.cpu` 2→4 (equality with the limit) — **reverted by `bb62668f`**.
-2. **`29ccfd69`** gate budget 45m→60m, `tasks` 55→70m, `pipeline` 1h10m→1h25m — **KEPT**.
-3. **`6bec075e`** per-node hostPath /nix cache + node unpin — **reverted by `7839ef54`**.
-4. **PR #1073** opened; round-1 adversarial audit run and all 10 findings fixed (uncommitted).
-5. **PR #1041 closed** as superseded (another session closed it concurrently; I added the measurement it lacked).
+### The rank-2 result, in one table
+All 144 test files in `scripts/tests` classified by read-set trace; timing from a separate untraced run.
 
-### IN FLIGHT
-- Dev-host + sandbox tier run of the fix round (`scratchpad/full6.log`, `sandbox3.log`). Sandbox passed on the *pre-F9* tree: 18841 collected / 0 failed.
-- **Not yet done on #1073**: commit the fix round, push, post the round-1 `audit-claims` block with `--audited bf4e904f`, dispatch the **blind** delta re-audit.
+| bucket | files | timed | seconds | share |
+|---|---|---|---|---|
+| ALWAYS-RUN (proven to read the tree) | 28 | 28 | 193.6s | 15.0% |
+| **OPAQUE (read set UNKNOWN)** | 75 | 74 | 1078.3s | 83.4% |
+| scoped (provably bounded) | 41 | 31 | 21.4s | 1.7% |
+
+**Ceiling for a perfect path→target mapping: 1.02x. 98.3% of the suite must run on any change.**
+Full write-up, blind spots and the ten-entry defect ledger: `claudedocs/measurement-scripts-tests-readsets.md`.
 
 ## Open investigations — live diagnosis state
 
@@ -85,12 +90,49 @@ Cut the devrc-ci gate from ~25 min. This session **refuted the previous handoff'
 - **Consequence:** no static node choice stays correct. Also `talos-jkj-deb` is a control-plane node **and is untainted**.
 - **Next probe:** sample free-CPU-by-request every 5 min for an hour before sizing anything on it.
 
+### browser-bridge test_server.py: spool rows leak across tests under xdist (issue #1124)
+- **Symptom + exact repro:** intermittent. `scripts/browser-bridge/tests/test_server.py::test_instances_and_poll_still_do_not_emit` (line 2452) and `::test_an_absent_origin_header_is_not_the_same_as_an_empty_one` (line 3636), both on worker `gw0`, in the **sandbox tier only** (`nix build .#checks.x86_64-linux.pytests`). Not reproducible on demand.
+- **Observed (with values):**
+  - `AssertionError: assert [{'source': 'browser-bridge', 'kind': 'cmd', 'text': 'x.test', 'duration_ms': '1', ...}] == []` — a row belonging to a *different* test found in this test's own `tmp_path` spool dir.
+  - `KeyError: 'session'` — the second test unpacked a row it did not cause.
+  - Control, unmodified `origin/main`, same tier: **PASS 890/890.**
+  - Reproduction on the same tree that failed: **PASS 890/890.** So 2 of 3 observations green.
+  - Wall time is NOT the discriminator: browser-bridge took **388.6s on main vs 396.6s on the failing tree** — within 2%, so this is not load-inflation of one test.
+- **Ruled out:** load/saturation (per the 2% wall-time delta above, and every other target ran *faster* in the sandbox tier that day); PR #1073 causing it (the failing file is untouched by it).
+- **Leading hypothesis:** a spool-row selection race. This exact family has been patched **three times** — #549, #891, #1074 (`the origin-token test asserted an ORDER the spool never promised`) — and #891/#1074 both targeted the second failing test specifically.
+- **Next probe:** run this file ≥50 times in the sandbox tier and count cross-test rows, to get a flake RATE. A single green run is exactly what the three prior fixes had.
+
+### test_git_repo_isolation.py: the co-tenant probe counts an unreaped git child (issue #1123)
+- **Symptom + exact repro:** `test_live_cotenants_does_not_count_this_process`, sandbox tier. Passes 3/3 in isolation.
+- **Observed (with values):** `AssertionError: the probe counted our own process (or an ancestor) as a co-tenant` / `assert ['103583:git'] == []`. The test builds a fixture repo with git subprocesses, chdirs in, then asserts `live_cotenants([git_dir]) == []` — and caught a `git` child of its own fixture setup.
+- **Ruled out:** attribution to PR #1120 — unmodified `origin/main` fails the same tier the same day (on a *different* test), and #1120 touches none of these files.
+- **Leading hypothesis:** the probe counts **zombies**. Same class as the documented `test_timeout_reaps_the_whole_process_group` case in `CLAUDE.md`: `os.kill(pid, 0)` succeeds on a zombie and a build container's PID 1 does not reap.
+- **Next probe:** read `/proc/<pid>/stat` state in `live_cotenants` and confirm state `Z` for the offending pid during a failing run.
+
+### Is the local sandbox tier trustworthy on the workbench? UNRESOLVED
+- **Symptom:** `nix build .#checks.x86_64-linux.pytests` failed on three consecutive runs on 2026-08-30, on **two different tests**, including on unmodified `origin/main`.
+- **Observed (with values):** `error: SQLite database '/build/home/.local/share/nix/root/nix/var/nix/db/db.sqlite' is busy`, surfacing as `AssertionError: nix cannot evaluate /build/src/nix/home.nix` in `TestSkillDocsArePinned::test_the_pinned_docs_are_the_DEPLOYED_ones`. Byte-identical on `origin/main` and on a feature branch. Later the same night the same command ran **green** twice.
+- **Ruled out:** any specific PR — the control on unmodified `origin/main` is red.
+- **Leading hypothesis:** nix store contention from *other* concurrent users on the box. `CLAUDE.md` documents this symptom for one operator building two derivations at once; these runs were sequential, so the contention is external.
+- **Next probe:** before believing any local sandbox RED, re-run it against unmodified `origin/main` in the same window. Tekton is the authority; the local tier is not.
+
 ## Next steps (ranked)
-1. **Finish PR #1073** (`/home/zach/workspace/devrc-ci-impact`): commit the uncommitted fix round, push, post the round-1 claims block with `--audited bf4e904f`, then dispatch a **BLIND** delta re-audit. The fix round changed ~145 payload lines, so the ladder is live.
-2. **Decompose `scripts/tests`** (devrc) — separate the repo-wide scanners from subsystem-specific tests. This is the gate on everything else: a path→target mapping is worth **~1.7x** alone but **~3.6x** after. Classifier draft measured 32 of 139 files as repo-wide, but see Gotchas — that number is not trustworthy.
-3. **Path→target mapping** (devrc, `scripts/lib/`) — only after 2. Must be fail-safe (unknown path ⇒ run everything) and two-way pinned like `TARGET_FLOORS`.
-4. **Decide `tekton-ci` PodSecurity** (homelab-infra) — `686d6ff0` set `pod-security.kubernetes.io/enforce: privileged` solely to admit the hostPath that is now reverted. It buys nothing today. Another session's commit; ask before unwinding.
-5. **Retry the unpin** only with the nix-store-ownership probe above green on a scratch pipeline first.
+1. **Make the opaque subprocesses legible** (devrc, `scripts/tests/`). This is the ONLY thing that raises rank 3's ceiling above 1.02x. Start with `test_subsystem_store_api.py` and `test_run_tests_floors.py` — they are the two largest OPAQUE contributors. Approach: have them declare their repo reads, or run the child under a tracer, then re-run the measurement in `claudedocs/measurement-scripts-tests-readsets.md`.
+   forcing: none
+2. **Measure the browser-bridge flake rate (#1124).** ≥50 sandbox-tier runs of `test_server.py`, counting cross-test spool rows. It can redden a REQUIRED check at random, and `main` has `enforce_admins: true` with no admin override.
+   forcing: gate
+3. **Fix the zombie-git co-tenant probe (#1123).** Ignore `/proc/<pid>/stat` state `Z` and descendants of the test's own process; add a regression test driven by a deliberately-unreaped child, watched red first. Same gate exposure as item 2.
+   forcing: gate
+4. **Close #1094** — the two guard-thinness findings in `scripts/tests/test_run_tests_targets.py` from #1073's round-4 audit.
+   forcing: none
+5. **Decide the `tekton-ci` PodSecurity label** (homelab-infra). `686d6ff0` set `pod-security.kubernetes.io/enforce: privileged` solely to admit a hostPath that is now reverted, so it buys nothing today. Another session's commit — **ask before unwinding.**
+   forcing: none
+6. **Decide whether to revert the gate budget 45m→60m** (`29ccfd69`, homelab-infra). It was raised to accommodate changes that were themselves reverted.
+   forcing: none
+7. **Retry the node unpin** — ONLY behind the nix-store-ownership probe on a SCRATCH pipeline (never devrc-ci), per the dead-end recorded below.
+   forcing: none
+
+🔴 **DO NOT BUILD the path→target mapping (the old rank 3).** Measured: it buys 1.02x — twenty-one seconds of a 1293-second suite — while inheriting 75 unmeasured files as chances to skip a test that should have run. It is a large, safety-critical mechanism guarding a rounding error. Item 1 is its prerequisite.
 
 ## Gotchas / decisions / dead-ends
 - **xdist is already at 4 workers** — the code caps at `min(nproc, 4)`. Going to 8+ helps but has diminishing returns. The real win is splitting the monolith.
@@ -112,7 +154,31 @@ Cut the devrc-ci gate from ~25 min. This session **refuted the previous handoff'
 - **Pattern worth not repeating:** three times I used CI as the test environment for a change to CI. A scratch pipeline would have caught each in minutes.
 - **CARRIED FORWARD from the replaced `State now`, because it is a measurement and not status:** 120 of 132 files in `scripts/tests/` have **zero cross-file imports**; only 12 share state (nolaunch / launch_log / spool). Confirmed independently for the biggest file — `test_subsystem_store_api.py` has **no session- or module-scoped fixtures** (`store` is `tmp_path`-based), so splitting it is safe. It is just not *useful* until worker count rises (see the `-n4` floor above).
 
+- **CARRIED FORWARD from the replaced `State now` — the homelab-infra cluster ledger, because these are durable shas and not status.** Three commits landed on `trunk` and two were reverted: `23887675` (`requests.cpu` 2→4, equality with the limit) **reverted by `bb62668f`**; `6bec075e` (per-node hostPath `/nix` cache + node unpin) **reverted by `7839ef54`**; `29ccfd69` (gate budget 45m→60m, `tasks` 55→70m, `pipeline` 1h10m→1h25m) **KEPT**. Net config delta of that night is `29ccfd69` and nothing else. Next-step 7 is a retry of the `6bec075e` half. ⚠ The handoff tool did NOT flag these as a durable drop — they were found by reading the REPLACE diff by hand.
+- 🔴 **The rank-2 estimate went 3x → 1.7x → uncertain → 1.49x → 1.08x → 1.01x → 1.02x**, and the three corrections that fixed a DEFECT all moved files OUT of `scoped`. A read-tracer under-records by nature, so anything it cannot see reads as "bounded" and the tool is **optimistic by construction**. Treat any number it produces as an UPPER bound on skippability until someone has tried to break it again.
+- 🔴 **The measurement's classifier reproduced the bug it was built to fix TEN times**, always the same class: reading an option-shaped or path-shaped token out of an argv string as evidence about scope, always failing toward under-classification. Full ledger in `claudedocs/measurement-scripts-tests-readsets.md`. If you extend that classifier, assume you will do it again and mutation-sweep for it.
+- 🔴 **Three of five audit fix rounds on #1120 introduced their own regression.** One (REPO_ROOT comparing as outside the repo, ALWAYS-RUN silently 22→9) was caught only by **diffing two classification runs against each other** — no test caught it. Budget for several rounds and re-audit the delta each time; that is the rule and it paid off five times here.
+- 🔴 **CPython raises NO audit event for `os.stat`/`os.lstat`/`Path.exists()`/`Path.is_dir()`/`os.path.exists`/`Path.resolve()`** (measured on 3.12.14, twice, independently). A tracer that lists `os.stat` as a traced event records nothing while *reading as* coverage.
+- **`strict: false` on `main` means a green Tekton check is a claim about the PR's BRANCH, not the merged tree.** Both #1073 and #1120 were gated on a hand-built integration tree before merge. For #1073 this mattered concretely: `main`'s own `ee5b2b7b` had to re-pin `TARGET_FLOORS` for `scripts/tests` 8217→10269 after a merged tree crossed a bound **neither side crossed alone**.
+- **`main` moved 6+ times during one session** (`bd1572f3` → … → `2a357c01`). Any merged-tree gate result has a shelf life of minutes; state the base sha you gated against.
+- 🔴 **The shared checkout `~/workspace/devrc` gets its branch switched by other sessions mid-work.** Observed twice this session: once found on `docs/handoff-bb-resume-0830`, and a branch cut from it inherited 2 foreign commits. **Run `git branch --show-current` immediately before any commit**, and prefer an isolated worktree.
+- **`claim-work` can render a confident verdict from a degraded read.** Observed: `rc 10 ALREADY CLAIMED — DO NOT start this item` with blank `who:`/`where:`, because its `git` had momentarily vanished from `~/.nix-profile`. Re-running gave `rc 12` (mine). Read the `who:`/`where:` fields, not just the rc.
+- **`resume-state.sh` cannot see a handoff doc that lives on an unmerged branch.** It reported `handoff-read: working-tree copy (identical to origin/main)` — true, and misleading, while the authoritative doc sat on open PR #1081. It compares tree↔`origin/main` only.
+- **A tilde in the `/resume` topic argument does not expand** — `~/workspace/...` resolved nothing and the digest silently fell back to the newest handoff doc (it does flag this as a `!` gap). Pass an absolute path.
+- **CARRIED FORWARD, still true:** 120 of 132 files in `scripts/tests/` have zero cross-file imports; only 12 share state (nolaunch / launch_log / spool). `test_subsystem_store_api.py` has no session- or module-scoped fixtures. Splitting is *safe*; it is just not *useful* (see the 1.02x above).
+
 ## How to verify
-1. **PR #1073, both tiers** — dev-host `nix develop ~/workspace/devrc -c bash <worktree>/scripts/run-tests.sh <worktree>`; sandbox `nix build <worktree>#checks.x86_64-linux.pytests`. Expect `RESULT: PASS`, 0 failed. Name the tier in any claim.
-2. **The subset mechanism is honest:** `nix develop ~/workspace/devrc -c bash <worktree>/scripts/gate.sh --tier pytest` with `DEVRC_TARGETS=scripts/collector/i3/tests` exported — the SUMMARY region gate.sh prints must say `PARTIAL RUN`. Before the fix it read `SUMMARY (hermetic set)` + `GATE: RESULT=PASS` over 13 tests.
-3. **Cluster is back to baseline:** `KUBECONFIG=$KC_HOMELAB kubectl get task devrc-ci-gate -n tekton-ci -o jsonpath='{.spec.volumes}'` must show `persistentVolumeClaim: nix-store-cache`, and `…steps[?(@.name=="pytests")].computeResources.requests.cpu` must be `2`.
+1. **Rank 1 landed:** `git -C ~/workspace/devrc show origin/main:scripts/run-tests.sh | grep -c 'ONLY_TARGETS\|DEVRC_TARGETS'` → non-zero, and `git cat-file -e origin/main:scripts/tests/test_run_tests_targets.py`.
+2. **Rank 2 landed:** `git -C ~/workspace/devrc cat-file -e origin/main:scripts/lib/readset_classify.py` and `…:claudedocs/measurement-scripts-tests-readsets.md`.
+3. **The measurement is reproducible:**
+   ```bash
+   DEVRC_READSET_OUT=/tmp/rs PYTHONPATH=$DEVRC/scripts \
+     nix develop $DEVRC -c python3 -m pytest scripts/tests -q -p no:cacheprovider \
+     -p testlib.nolaunch_plugin -p testlib.spool_plugin \
+     -p testlib.gitenv_plugin -p testlib.nogit_plugin \
+     -p testlib.readset_plugin -n 4 --dist loadfile
+   nix develop $DEVRC -c python3 scripts/lib/readset_classify.py /tmp/rs.*.json
+   ```
+   Expect `measured test files : 144 / ALWAYS-RUN 28 / OPAQUE 75 / scoped 41`.
+4. **The classifier's guards:** `nix develop $DEVRC -c python3 -m pytest scripts/tests/test_readset_classify.py -q -p no:cacheprovider` → 40 passed.
+5. **Cluster is at baseline:** `KUBECONFIG=$KC_HOMELAB kubectl get task devrc-ci-gate -n tekton-ci -o jsonpath='{.spec.volumes}'` must show `persistentVolumeClaim: nix-store-cache`, and `…steps[?(@.name=="pytests")].computeResources.requests.cpu` must be `2`.


### PR DESCRIPTION
Session close for the **ci-speedup** effort. Updates the canonical handoff in place (one doc per effort).

## What landed

| PR | what | commit |
|---|---|---|
| #1073 | `--targets` subset selection for `run-tests.sh` | `809486fa` |
| #1081 | prior update to this doc | `a6554bf2` |
| #1120 | rank 2 — the read-set measurement | `90deea1d` |

All three verified by content on `origin/main`, and both #1073 and #1120 were gated on a **hand-built merged tree**, not just their branch — `strict: false` means a green Tekton check describes the branch only.

## The result that changes the plan

| bucket | files | timed | seconds | share |
|---|---|---|---|---|
| ALWAYS-RUN | 28 | 28 | 193.6s | 15.0% |
| **OPAQUE** | 75 | 74 | 1078.3s | 83.4% |
| scoped | 41 | 31 | 21.4s | 1.7% |

**Ceiling 1.02x; 98.3% of `scripts/tests` must run on any change.** The handoff estimated rank 3 at "~1.7x alone, ~3.6x after" — neither is reachable.

🔴 **The recommendation inverts: DO NOT BUILD the path→target mapping.** It buys 21.4s of a 1293s suite while inheriting 75 unmeasured files as chances to skip a test that should have run. The prerequisite — making the opaque subprocesses legible — is now ranked #1.

## Also in this update

- Three **open investigations** with live diagnosis state: the browser-bridge spool leak (#1124), the zombie-git co-tenant probe (#1123), and whether the local sandbox tier is trustworthy on the workbench at all (unmodified `main` fails it identically).
- Ranked next steps, each carrying a `forcing:` field. **5 of 7 declare `forcing: none`** and are marked not-eligible-to-be-worked; the two carrying `forcing: gate` are the flakes that can redden a required check under `enforce_admins: true` with no admin override.
- Gotchas covering: the estimate's one-directional drift and why this tool is optimistic by construction; the classifier reproducing its own defect class ten times; three of five audit fix rounds introducing their own regression; `os.stat`/`Path.resolve()` raising no audit events; the shared checkout switching branches mid-work; `claim-work` rendering a confident verdict from a degraded read.
- **Carried forward by hand:** the homelab-infra cluster ledger (`23887675`→`bb62668f`, `6bec075e`→`7839ef54`, `29ccfd69` kept). Those shas lived only in the REPLACE'd `State now` section and the handoff tool did **not** flag them as a durable drop — found by reading the diff.

## Note on how this got here

The handoff tool committed while the checkout was sitting on `main`; branch protection correctly rejected the push. Recovered via the documented preserve → verify → `reset --keep` path, so nothing was stranded and `main` is byte-identical to `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5swnZSyv5Ae6LPBhJ2gPM