### PR TITLE
feat(hooks): warn when a `git add` stages a file this session did not create

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1329,6 +1329,16 @@ in
   home.file.".claude/hooks/search-tool-nudge.py" = {
     source = ../scripts/claude-hooks/search-tool-nudge.py;
   };
+  # git-add-provenance-nudge fires PostToolUse on Bash and warns when a `git add`
+  # staged an untracked file whose mtime PREDATES the session — i.e. another
+  # effort's uncommitted work swept into your index, which is how half a feature
+  # gets committed. Deliberately NOT a guard_core check: that layer has no warn
+  # tier, and in this repo staging a NEW file is mandatory (the flake omits
+  # untracked paths), so a blocking version would fire on the deploy path for
+  # every new skill, hook and test — the permanently-red shape RULES.md rejects.
+  home.file.".claude/hooks/git-add-provenance-nudge.py" = {
+    source = ../scripts/claude-hooks/git-add-provenance-nudge.py;
+  };
   # claude-notify is the turn-finished notifier: on UserPromptSubmit/Stop/SubagentStop
   # it fires a desktop toast (or, headless, a clawgate phone push as FALLBACK) when a
   # turn ran >= threshold (default 60s). Telemetry shows Claude runs mostly on the

--- a/scripts/claude-hooks/git-add-provenance-nudge.py
+++ b/scripts/claude-hooks/git-add-provenance-nudge.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""PostToolUse nudge: a `git add` staged an untracked file this session did not
+create — i.e. somebody else's uncommitted work, swept into your index.
+
+--------------------------------------------------------------------------- #
+THE INCIDENT
+--------------------------------------------------------------------------- #
+MEASURED 2026-08-30. An opencode session was adding two packages to
+`nix/pkgs/default.nix`. Its `home-manager switch` failed, because a DIFFERENT
+session's uncommitted `nix/graphical.nix` edit referenced `scripts/memory-detail`
+via `home.file`, and a flake build copies TRACKED files only. The session ran:
+
+    git -C ~/workspace/devrc add scripts/memory-detail && home-manager switch …
+
+The switch then succeeded, and the session recorded the workaround as the
+diagnosis: "the file exists but isn't tracked by git". The MECHANISM was right.
+The SCOPE was wrong — that script was 181 lines of an unrelated, in-flight bar
+feature belonging to another effort, and staging it made it a candidate for the
+next commit. The session's own handoff then told the next reader to commit
+`nix/pkgs/default.nix` + `scripts/memory-detail` together, which would have
+landed half of someone else's feature: the script without its `nix/graphical.nix`
+wiring and without its 20 tests.
+
+--------------------------------------------------------------------------- #
+WHY THIS IS A NUDGE AND NOT A `bash-guard` DENIAL
+--------------------------------------------------------------------------- #
+🔴 `guard_core` HAS NO WARN TIER — `evaluate()` returns a reason (DENY) or None.
+A check there is a BLOCK, and blocking this would be wrong twice over:
+
+  * `git add <path>` is the SAFE form the rules already steer you to;
+    `check_git_add_all` exists to push callers toward exactly this spelling, and
+    a guard that then blocks the safe spelling contradicts its own sibling.
+  * in THIS repo staging a new file is MANDATORY, not optional — `CLAUDE.md`:
+    "A NEW file must be `git add`ed or the flake silently omits it from the
+    deploy." A false positive would block the deploy path for every new skill,
+    reference doc, extension file, hook and test. `claude/RULES.md` calls a
+    permanently-red gate worse than no gate, because it trains you to click
+    through.
+
+Staging is also trivially reversible (`git restore --staged`), so acting AFTER
+the fact costs nothing. PostToolUse it is.
+
+--------------------------------------------------------------------------- #
+🔴 WHY IT ASKS GIT INSTEAD OF PARSING THE COMMAND
+--------------------------------------------------------------------------- #
+The obvious build is to parse the `git add` operands. That means re-deriving
+`guard_core`'s argv handling — global-option hops (`git -C X add`), quoting,
+`--`, subshells — a predicate `claude/RULES.md` says is "typically wrong at N−1"
+of the sites that open-code it.
+
+None of it is needed. This hook fires AFTER the command, so the index already
+holds the answer: `git diff --cached --name-only --diff-filter=A` lists exactly
+the paths staged as ADDED, which is precisely "was untracked, now staged". The
+command text is used for ONE thing — deciding whether this call was plausibly a
+`git add` at all — and being loose there is free: a false trigger just runs a
+read-only query that finds nothing and stays silent.
+
+--------------------------------------------------------------------------- #
+🔴 WHAT "THIS SESSION DID NOT CREATE" MEANS, AND WHAT IT CANNOT MEAN
+--------------------------------------------------------------------------- #
+The signal is mtime older than the session's earliest transcript timestamp.
+
+That is a HEURISTIC and it is deliberately biased toward SILENCE:
+
+  * a RESUMED session keeps its old transcript records, so its earliest
+    timestamp can predate the current run by days. Every file written in between
+    then reads as "mine" and is NOT flagged. False NEGATIVE — the safe
+    direction, and the reason this is not tightened to the current run.
+  * a file the operator wrote by hand just before asking for it to be committed
+    is "not created by this session" and WOULD be flagged. That is why the text
+    asks rather than asserts, and why nothing is blocked.
+  * `cp -a`, `git checkout` and a restore-from-backup all preserve or rewrite
+    mtimes in ways this cannot see.
+
+So the message must never say "this is not yours". It says the file predates the
+session and asks you to confirm — the same shape as the incident, where one
+glance at `git status` would have shown a second unrelated dirty file.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+#: Loose on purpose — see the module docstring. A false trigger costs one
+#: read-only `git diff --cached` that returns nothing.
+_GIT_ADD = re.compile(r"\bgit\b[^\n|;&]*\badd\b")
+
+#: `git -C <dir>` / `git --git-dir=…` hop. Used only to pick WHICH repo to ask;
+#: unresolvable means "fall back to cwd", never "guess".
+_DASH_C = re.compile(r"\bgit\s+(?:-[^\s]+\s+)*-C\s+([^\s;|&]+)")
+
+#: Cap the report. A `git add` of 40 new files is a legitimate bulk import and a
+#: 40-line nudge is noise; the count still tells the whole story.
+_SHOWN_MAX = 8
+
+#: 🔴 THE ON-DISK NAME, ONE PLACE. Per-hook directory, matching
+#: `claude-shell-env-nudge`'s convention rather than a shared `claude-hooks/`
+#: bucket: `test_on_disk_artifact_names.py` pins every hook's storage names from
+#: BOTH sides, and a shared directory makes "whose file is this" unanswerable
+#: when one hook's entries have to be cleared.
+CACHE_DIR = "~/.cache/claude-git-add-provenance"
+
+_TIMEOUT = 5
+
+
+def _git(repo: str, *args: str) -> str | None:
+    """Read-only git, or None. NEVER raises into the hook."""
+    try:
+        p = subprocess.run(
+            ("git", "-C", repo, *args),
+            capture_output=True, text=True, timeout=_TIMEOUT,
+        )
+    except Exception:
+        return None
+    if p.returncode != 0:
+        return None
+    return p.stdout
+
+
+def _session_start(transcript_path: str | None) -> float | None:
+    """Epoch seconds of the session's earliest transcript timestamp, or None.
+
+    🔴 None means DO NOT NUDGE. Without a clock every staged-new file looks
+    equally old, and the hook would fire on every legitimate new-file add — the
+    permanently-red shape the docstring rejects. Silence is the fail direction.
+    """
+    if not transcript_path:
+        return None
+    try:
+        with open(transcript_path, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                try:
+                    rec = json.loads(line)
+                except Exception:
+                    continue
+                ts = rec.get("timestamp")
+                if not ts:
+                    continue
+                # The first RECORD is a `leafUuid` summary carrying no
+                # timestamp, so this scans rather than reading line 1 — measured
+                # at claude-code 2.1.232, where the first timestamped record was
+                # line 5.
+                return datetime.fromisoformat(
+                    ts.replace("Z", "+00:00")
+                ).astimezone(timezone.utc).timestamp()
+    except Exception:
+        return None
+    return None
+
+
+def _repo_dir(cmd: str, cwd: str | None) -> str | None:
+    base = cwd or os.getcwd()
+    m = _DASH_C.search(cmd)
+    if m:
+        cand = os.path.expanduser(m.group(1).strip("'\""))
+        if not os.path.isabs(cand):
+            cand = os.path.join(base, cand)
+        if os.path.isdir(cand):
+            return cand
+        # An unresolvable -C (a variable, a typo) falls back rather than
+        # guessing: the worst case is a query against the wrong repo, which
+        # finds nothing and stays silent.
+    return base if os.path.isdir(base) else None
+
+
+def foreign_staged(repo: str, started: float) -> list[tuple[str, float]]:
+    """`(path, mtime)` for each ADDED-to-index path whose mtime predates `started`.
+
+    `--diff-filter=A` is the whole predicate: a path is listed exactly when the
+    index has it and HEAD does not, i.e. it was untracked and is now staged.
+    A path staged and then deleted from disk is skipped — `os.stat` fails and it
+    carries no evidence either way.
+    """
+    out = _git(repo, "diff", "--cached", "--name-only", "--diff-filter=A", "-z")
+    if not out:
+        return []
+    found: list[tuple[str, float]] = []
+    for rel in out.split("\0"):
+        if not rel:
+            continue
+        try:
+            mtime = os.stat(os.path.join(repo, rel)).st_mtime
+        except OSError:
+            continue
+        if mtime < started:
+            found.append((rel, mtime))
+    return found
+
+
+def _already_nudged(session: str, repo: str, rel: str) -> bool:
+    """Once per (session, repo, path). Re-reporting the same file on every
+    subsequent `git add` in the session is how a nudge becomes wallpaper."""
+    if not session:
+        return False
+    try:
+        d = os.path.expanduser(CACHE_DIR)
+        os.makedirs(d, exist_ok=True)
+        # Sanitised, for `shell-env-nudge`'s reason: a session id is opaque and
+        # goes into a filename, so anything that is not clearly safe becomes `_`.
+        safe = "".join(c if c.isalnum() or c in "_.-" else "_" for c in session)
+        f = os.path.join(d, safe)
+        key = f"{repo}\0{rel}"
+        seen: set[str] = set()
+        if os.path.exists(f):
+            with open(f, encoding="utf-8") as fh:
+                seen = set(fh.read().split("\n"))
+        if key in seen:
+            return True
+        with open(f, "a", encoding="utf-8") as fh:
+            fh.write(key + "\n")
+        return False
+    except Exception:
+        return False
+
+
+def build_nudge(rows: list[tuple[str, float]], started: float) -> str:
+    shown = rows[:_SHOWN_MAX]
+    elided = len(rows) - len(shown)
+    lines = []
+    for rel, mtime in shown:
+        age = started - mtime
+        if age >= 86400:
+            when = f"{age / 86400:.1f}d before this session"
+        elif age >= 3600:
+            when = f"{age / 3600:.1f}h before this session"
+        else:
+            when = f"{age / 60:.0f}m before this session"
+        lines.append(f"  • {rel}  (last written {when})")
+    if elided:
+        lines.append(f"  … and {elided} more")
+    return (
+        f"git-add provenance: {len(rows)} newly-staged file(s) were last written "
+        f"BEFORE this session started, so they were probably not created by this "
+        f"session's work:\n"
+        + "\n".join(lines)
+        + "\n  If they belong to another effort, unstage them — `git restore "
+        "--staged <path>` — and commit only your own paths. Staging someone "
+        "else's in-flight file makes it a candidate for your next commit, which "
+        "lands half a feature: the file without whatever else it needs.\n"
+        "  ⚠ mtime is a heuristic, not proof of authorship. If these ARE yours "
+        "(edited before a resume, restored from a copy), carry on — this is a "
+        "question, not a refusal, and nothing was blocked."
+    )
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    try:
+        if data.get("tool_name") != "Bash":
+            sys.exit(0)
+        cmd = (data.get("tool_input") or {}).get("command", "")
+        if not cmd or not _GIT_ADD.search(cmd):
+            sys.exit(0)
+        cwd = data.get("cwd")
+        cwd = cwd if isinstance(cwd, str) and cwd else None
+        repo = _repo_dir(cmd, cwd)
+        if not repo:
+            sys.exit(0)
+        started = _session_start(data.get("transcript_path"))
+        if started is None:
+            sys.exit(0)     # no clock ⇒ no nudge; see `_session_start`
+        rows = foreign_staged(repo, started)
+        session = data.get("session_id") or ""
+        rows = [r for r in rows if not _already_nudged(session, repo, r[0])]
+        if not rows:
+            sys.exit(0)     # SILENT — no reassuring "0 foreign files" line
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": build_nudge(rows, started),
+            }
+        }))
+    except Exception:
+        pass
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/claude-hooks/register-nudge-hook.py
+++ b/scripts/claude-hooks/register-nudge-hook.py
@@ -87,7 +87,8 @@ REJECTED with a warning and the resolved fallback is used instead — see
 `hook_python`, which also explains why it falls back rather than hard-failing.
 
 Registers (APPEND surface):
-  * PostToolUse(Bash): audit-pr-nudge.py, shell-env-nudge.py, search-tool-nudge.py
+  * PostToolUse(Bash): audit-pr-nudge.py, shell-env-nudge.py, search-tool-nudge.py,
+    git-add-provenance-nudge.py
   * UserPromptSubmit / Stop / SubagentStop: claude-notify.py (the turn-finished
     notifier — a best-effort side-effect hook, appended alongside any existing
     Stop/clawgate-stop/tmux hooks).
@@ -230,6 +231,7 @@ MANAGED_HOOK_SCRIPTS = frozenset({
     "clawgate-task-interview-guard.py",
     "clawgate-writeback-guard.py",
     "gh-issue-closing-condition-guard.py",
+    "git-add-provenance-nudge.py",
     "handoff-write-guard.py",
     "next-step-nudge.py",
     "search-tool-nudge.py",
@@ -581,6 +583,12 @@ POST_BASH_CMDS = [
     with_python("~/.claude/hooks/audit-pr-nudge.py"),
     with_python("~/.claude/hooks/shell-env-nudge.py"),
     with_python("~/.claude/hooks/search-tool-nudge.py"),
+    # git-add-provenance: warns when a `git add` staged an untracked file whose
+    # mtime predates the session — another effort's in-flight work swept into the
+    # index. PostToolUse, not a guard_core check: staging is reversible, and in this
+    # repo staging a NEW file is mandatory, so a blocking version would fire on the
+    # deploy path for every new skill, hook and test.
+    with_python("~/.claude/hooks/git-add-provenance-nudge.py"),
     # Not a nudge — INSTRUMENTATION. It injects nothing and blocks nothing; on
     # this event it exists only to capture `tool_response.backgroundTaskId`,
     # which names the output file a backgrounded run writes to and appears on NO

--- a/scripts/claude-hooks/tests/test_git_add_provenance_nudge.py
+++ b/scripts/claude-hooks/tests/test_git_add_provenance_nudge.py
@@ -1,0 +1,333 @@
+"""Tests for `scripts/claude-hooks/git-add-provenance-nudge.py`.
+
+The hook warns when a `git add` stages an untracked file whose mtime predates
+the session — somebody else's in-flight work swept into your index.
+
+🔴 THE TEST THAT MATTERS MOST IS THE SILENT ONE.
+`test_a_file_written_during_the_session_is_NOT_flagged` is the false-positive
+control, and it guards the whole reason this is a nudge rather than a
+`guard_core` check: in THIS repo staging a new file is MANDATORY (`CLAUDE.md` —
+"A NEW file must be `git add`ed or the flake silently omits it from the
+deploy"). A hook that fires on ordinary new-file adds would fire on the deploy
+path for every new skill, hook and test, and `claude/RULES.md` calls a
+permanently-red gate worse than no gate.
+
+    run:  python -m pytest scripts/claude-hooks/tests/test_git_add_provenance_nudge.py -q
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOK = Path(__file__).resolve().parents[1] / "git-add-provenance-nudge.py"
+
+#: Session start, and the two sides of it. Pairwise distinct and far apart, so a
+#: mutant that swaps the comparison or drops the offset cannot land on the
+#: boundary and pass by luck.
+T_START = 1_780_000_000.0
+T_BEFORE = T_START - 86_400.0      # a day before the session — foreign
+T_AFTER = T_START + 3_600.0        # an hour into the session — ours
+
+
+def _sh(*args: str, cwd: Path) -> str:
+    return subprocess.run(
+        args, cwd=str(cwd), capture_output=True, text=True, check=True,
+        env=dict(os.environ, GIT_CONFIG_GLOBAL="/dev/null",
+                 GIT_CONFIG_SYSTEM="/dev/null"),
+    ).stdout
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    r.mkdir()
+    _sh("git", "init", "-q", "-b", "main", ".", cwd=r)
+    _sh("git", "config", "user.email", "t@example.invalid", cwd=r)
+    _sh("git", "config", "user.name", "T", cwd=r)
+    (r / "tracked.txt").write_text("one\n", encoding="utf-8")
+    _sh("git", "add", "tracked.txt", cwd=r)
+    _sh("git", "commit", "-qm", "base", cwd=r)
+    return r
+
+
+def transcript(tmp_path: Path, *, timestamped: bool = True) -> Path:
+    """A transcript whose earliest timestamp is `T_START`.
+
+    The first record deliberately carries NO timestamp — that is the real shape
+    at claude-code 2.1.232, where the opening `leafUuid` summary has none and the
+    first timestamped record was line 5. A hook that read line 1 would find no
+    clock and go silent on every real session.
+    """
+    p = tmp_path / "transcript.jsonl"
+    from datetime import datetime, timezone
+    iso = datetime.fromtimestamp(T_START, timezone.utc).isoformat().replace(
+        "+00:00", "Z")
+    rows = [{"type": "summary", "leafUuid": "abc", "sessionId": "s"}]
+    if timestamped:
+        rows.append({"type": "attachment", "timestamp": iso})
+    else:
+        rows.append({"type": "attachment"})
+    p.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    return p
+
+
+def stage(repo: Path, name: str, mtime: float, *, body: str = "x\n") -> None:
+    f = repo / name
+    f.write_text(body, encoding="utf-8")
+    _sh("git", "add", "--", name, cwd=repo)
+    os.utime(f, (mtime, mtime))
+
+
+def run(payload: dict, home: Path) -> tuple[int, str]:
+    p = subprocess.run(
+        [sys.executable, str(HOOK)], input=json.dumps(payload),
+        capture_output=True, text=True,
+        env=dict(os.environ, HOME=str(home)),
+    )
+    return p.returncode, p.stdout.strip()
+
+
+def call(repo: Path, tmp_path: Path, *, session: str = "sess-1",
+         cmd: str = "git add scripts/thing", tool: str = "Bash",
+         timestamped: bool = True, transcript_path: str | None = "auto") -> str:
+    tp = transcript_path
+    if tp == "auto":
+        tp = str(transcript(tmp_path, timestamped=timestamped))
+    payload = {
+        "tool_name": tool,
+        "session_id": session,
+        "cwd": str(repo),
+        "tool_input": {"command": cmd},
+    }
+    if tp is not None:
+        payload["transcript_path"] = tp
+    rc, out = run(payload, tmp_path)
+    assert rc == 0, f"a nudge must never fail the call (rc={rc}, out={out})"
+    return out
+
+
+# --------------------------------------------------------------------------
+# the two directions
+# --------------------------------------------------------------------------
+
+def test_a_file_predating_the_session_IS_flagged(repo: Path, tmp_path: Path):
+    """The incident: `scripts/memory-detail`, 181 lines of another effort's
+    uncommitted work, staged to unblock a `home-manager switch`."""
+    stage(repo, "memory-detail", T_BEFORE)
+    out = call(repo, tmp_path)
+    assert "additionalContext" in out
+    assert "memory-detail" in out
+
+
+def test_a_file_written_during_the_session_is_NOT_flagged(repo: Path, tmp_path: Path):
+    """🔴 THE FALSE-POSITIVE CONTROL. Staging a new file is MANDATORY in this
+    repo — the flake omits untracked paths from the deploy. If this ever fires,
+    the hook is nagging on the correct, required action."""
+    stage(repo, "brand-new.py", T_AFTER)
+    assert call(repo, tmp_path) == ""
+
+
+def test_a_modified_TRACKED_file_is_not_flagged(repo: Path, tmp_path: Path):
+    """`--diff-filter=A` is the predicate. Editing a tracked file and staging it
+    is ordinary work and says nothing about provenance — even with an old mtime,
+    which a checkout or a restore routinely produces."""
+    (repo / "tracked.txt").write_text("two\n", encoding="utf-8")
+    _sh("git", "add", "--", "tracked.txt", cwd=repo)
+    os.utime(repo / "tracked.txt", (T_BEFORE, T_BEFORE))
+    assert call(repo, tmp_path) == ""
+
+
+def test_an_unstaged_untracked_file_is_not_flagged(repo: Path, tmp_path: Path):
+    """Merely EXISTING in the tree is not staging it. The hazard is the index."""
+    f = repo / "someone-elses.py"
+    f.write_text("x\n", encoding="utf-8")
+    os.utime(f, (T_BEFORE, T_BEFORE))
+    assert call(repo, tmp_path) == ""
+
+
+# --------------------------------------------------------------------------
+# the clock — no clock means SILENCE, never "everything is old"
+# --------------------------------------------------------------------------
+
+def test_no_transcript_path_means_no_nudge(repo: Path, tmp_path: Path):
+    """🔴 Without a clock every staged-new file looks equally old, so the
+    fail-open direction is the loud one. Silence is correct here.
+
+    ⚠ THIS PINS BEHAVIOUR, NOT THE GUARD — say so rather than counting it as
+    coverage it does not provide. MEASURED: mutating the hook's
+    `if started is None: sys.exit(0)` to `if False:` leaves all 19 tests GREEN.
+    The removal is masked, because `foreign_staged(repo, None)` then raises
+    `TypeError` on `mtime < None` and `main`'s outer `except Exception: pass`
+    swallows it — the observable result is silence either way.
+
+    The two defences are deliberate and BOTH stay: a nudge may never break the
+    Bash call it observes, so the broad catch cannot be narrowed to make the
+    guard uniquely responsible, and control flow through an exception is not
+    something to rely on. So the guard is belt-and-braces and its mutant
+    SURVIVES BY DESIGN. `claude/RULES.md` asks for that to be labelled, not
+    hidden: what this test proves is that the no-clock path is silent, not that
+    the explicit guard is the thing making it silent."""
+    stage(repo, "memory-detail", T_BEFORE)
+    assert call(repo, tmp_path, transcript_path=None) == ""
+
+
+def test_a_transcript_with_no_timestamp_means_no_nudge(repo: Path, tmp_path: Path):
+    stage(repo, "memory-detail", T_BEFORE)
+    assert call(repo, tmp_path, timestamped=False) == ""
+
+
+def test_an_unreadable_transcript_means_no_nudge(repo: Path, tmp_path: Path):
+    stage(repo, "memory-detail", T_BEFORE)
+    assert call(repo, tmp_path, transcript_path=str(tmp_path / "nope.jsonl")) == ""
+
+
+# --------------------------------------------------------------------------
+# trigger scoping
+# --------------------------------------------------------------------------
+
+def test_a_non_bash_tool_is_silent(repo: Path, tmp_path: Path):
+    stage(repo, "memory-detail", T_BEFORE)
+    assert call(repo, tmp_path, tool="Edit") == ""
+
+
+def test_a_command_that_is_not_a_git_add_is_silent(repo: Path, tmp_path: Path):
+    """The index is dirty in exactly the flagged way; the command is unrelated.
+    Firing here would make every Bash call in a dirty tree carry the nudge."""
+    stage(repo, "memory-detail", T_BEFORE)
+    assert call(repo, tmp_path, cmd="git status -sb") == ""
+
+
+def test_a_git_dash_C_hop_is_followed(repo: Path, tmp_path: Path):
+    """`git -C <dir> add …` is the spelling this repo's CLAUDE.md mandates, so
+    it must not be the spelling the hook is blind to."""
+    stage(repo, "memory-detail", T_BEFORE)
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    out = call(repo, tmp_path, cmd=f"git -C {repo} add scripts/memory-detail")
+    assert "memory-detail" in out
+
+
+# --------------------------------------------------------------------------
+# robustness — a nudge may never break the call it observes
+# --------------------------------------------------------------------------
+
+def test_malformed_stdin_exits_zero_and_says_nothing(tmp_path: Path):
+    p = subprocess.run([sys.executable, str(HOOK)], input="not json",
+                       capture_output=True, text=True,
+                       env=dict(os.environ, HOME=str(tmp_path)))
+    assert p.returncode == 0
+    assert p.stdout.strip() == ""
+
+
+def test_a_cwd_that_is_not_a_repo_is_silent(tmp_path: Path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    rc, out = run({"tool_name": "Bash", "session_id": "s", "cwd": str(plain),
+                   "transcript_path": str(transcript(tmp_path)),
+                   "tool_input": {"command": "git add x"}}, tmp_path)
+    assert rc == 0 and out == ""
+
+
+def test_a_staged_then_deleted_file_does_not_crash(repo: Path, tmp_path: Path):
+    """`os.stat` fails on it; it carries no evidence either way, so it is
+    skipped rather than reported or raised on."""
+    stage(repo, "gone.py", T_BEFORE)
+    (repo / "gone.py").unlink()
+    assert call(repo, tmp_path) == ""
+
+
+# --------------------------------------------------------------------------
+# the message, and not repeating it
+# --------------------------------------------------------------------------
+
+def test_the_same_file_is_reported_only_once_per_session(repo: Path, tmp_path: Path):
+    """Re-reporting on every subsequent `git add` is how a nudge becomes
+    wallpaper and stops being read."""
+    stage(repo, "memory-detail", T_BEFORE)
+    assert "memory-detail" in call(repo, tmp_path, session="dedupe-1")
+    assert call(repo, tmp_path, session="dedupe-1") == ""
+
+
+def test_a_different_session_is_told_again(repo: Path, tmp_path: Path):
+    stage(repo, "memory-detail", T_BEFORE)
+    assert "memory-detail" in call(repo, tmp_path, session="A")
+    assert "memory-detail" in call(repo, tmp_path, session="B")
+
+
+def test_the_message_carries_the_unstage_remedy(repo: Path, tmp_path: Path):
+    """A nudge that names a hazard and no fix is a nag."""
+    stage(repo, "memory-detail", T_BEFORE)
+    assert "git restore --staged" in call(repo, tmp_path)
+
+
+def test_the_message_ASKS_rather_than_asserting_authorship(repo: Path, tmp_path: Path):
+    """🔴 mtime cannot name an author — `cp -a`, a checkout and a restore all
+    move it. The text must not claim the file is someone else's, or a reader
+    acting on it will unstage their own work."""
+    stage(repo, "memory-detail", T_BEFORE)
+    out = json.loads(call(repo, tmp_path))
+    msg = out["hookSpecificOutput"]["additionalContext"]
+    assert "heuristic" in msg
+    assert "nothing was blocked" in msg
+
+
+def test_several_files_are_all_named(repo: Path, tmp_path: Path):
+    for n in ("a-one.py", "b-two.py", "c-three.py"):
+        stage(repo, n, T_BEFORE)
+    out = call(repo, tmp_path)
+    for n in ("a-one.py", "b-two.py", "c-three.py"):
+        assert n in out
+
+
+# --------------------------------------------------------------------------
+# the on-disk footprint — `test_on_disk_artifact_names.py` names this file as
+# where these are pinned, so the entry there is a claim these tests must honour
+# --------------------------------------------------------------------------
+
+def test_the_cache_directory_literal_is_pinned():
+    """🔴 The hook is listed in `PINNED_HERE` over in
+    `test_on_disk_artifact_names.py`, and that entry says the names live here.
+    A rename that nothing asserts on leaves orphaned state under `~/.cache` that
+    nobody can find to clear."""
+    src = HOOK.read_text(encoding="utf-8")
+    assert 'CACHE_DIR = "~/.cache/claude-git-add-provenance"' in src
+
+
+def test_the_session_id_is_sanitised_into_the_filename(repo: Path, tmp_path: Path):
+    """A session id is opaque and goes into a filename. An id containing `/`
+    would otherwise write outside the cache directory."""
+    stage(repo, "memory-detail", T_BEFORE)
+    assert "memory-detail" in call(repo, tmp_path, session="a/../../b c")
+    d = tmp_path / ".cache" / "claude-git-add-provenance"
+    names = [p.name for p in d.iterdir()]
+    assert names == ["a_.._.._b_c"], names
+
+
+def test_the_dedupe_ledger_lands_in_that_directory(repo: Path, tmp_path: Path):
+    stage(repo, "memory-detail", T_BEFORE)
+    call(repo, tmp_path, session="ledger-1")
+    f = tmp_path / ".cache" / "claude-git-add-provenance" / "ledger-1"
+    assert f.is_file()
+    assert "memory-detail" in f.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# 🔴 POSITIVE CONTROL on the instrument itself
+# --------------------------------------------------------------------------
+
+def test_the_diff_filter_A_query_really_does_list_a_staged_new_file(repo: Path):
+    """`claude/RULES.md`: a reassuring zero is indistinguishable from a query
+    wired to nothing. Every silent test above rests on this command returning
+    the file when there IS one — so watch the number move."""
+    before = _sh("git", "diff", "--cached", "--name-only", "--diff-filter=A",
+                 cwd=repo)
+    assert before.strip() == "", "fixture leaked a staged add"
+    stage(repo, "control.py", T_BEFORE)
+    after = _sh("git", "diff", "--cached", "--name-only", "--diff-filter=A",
+                cwd=repo)
+    assert "control.py" in after

--- a/scripts/claude-hooks/tests/test_on_disk_artifact_names.py
+++ b/scripts/claude-hooks/tests/test_on_disk_artifact_names.py
@@ -593,6 +593,13 @@ PINNED_HERE = {
     "shell-env-nudge.py",
     "search-tool-nudge.py",
     "claude-notify.py",          # pinned by test_claude_notify.py + test_notifs.py
+    "git-add-provenance-nudge.py",  # pinned by
+                                 # test_git_add_provenance_nudge.py, which asserts
+                                 # the CACHE_DIR literal and the sanitised
+                                 # per-session filename. It keeps a once-per
+                                 # (session, repo, path) dedupe ledger so the same
+                                 # staged file is not re-reported on every
+                                 # subsequent `git add` in the session.
 }
 OWNS_NO_ON_DISK_STATE = {
     "agent-ledger-hook.py",      # delegates every path to lib/agent_ledger.py

--- a/scripts/claude-hooks/tests/test_register_nudge_hook.py
+++ b/scripts/claude-hooks/tests/test_register_nudge_hook.py
@@ -112,6 +112,7 @@ PY = fake_python("0000000000000000000000000000000-python3-3.12.14")
 NOTIFY = PY + " ~/.claude/hooks/claude-notify.py"
 CLAWGATE_STOP = "/home/zach/.claude/clawgate-stop-hook.sh"
 SEARCH_NUDGE = PY + " ~/.claude/hooks/search-tool-nudge.py"
+PROVENANCE_NUDGE = PY + " ~/.claude/hooks/git-add-provenance-nudge.py"
 NEXT_STEP = PY + " ~/.claude/hooks/next-step-nudge.py"
 TMUX_STOP = "~/.config/tmux/task-hook.sh"
 # 🔴 THE ONE MANAGED COMMAND WITH NO PYTHON IN IT — see scenario 18. It is spelled
@@ -348,11 +349,11 @@ with tempfile.TemporaryDirectory() as tmp:
     post = cmds(d, "PostToolUse")
     WB_EXPANDED = PY + " " + home + "/.claude/hooks/clawgate-writeback-guard.py"
     SHELL_HOMEVAR = PY + " $HOME/.claude/hooks/shell-env-nudge.py"
-    check("8: PostToolUse holds exactly the three migrated hooks plus the three appended ones",
+    check("8: PostToolUse holds exactly the three migrated hooks plus the appended ones",
           set(post) == {PY + " ~/.claude/hooks/audit-pr-nudge.py",
                         SHELL_HOMEVAR, WB_EXPANDED, SEARCH_NUDGE, LEDGER,
-                        BG_CAPTURE, HANDOFF_GUARD})
-    check("8: no hook was double-registered", len(post) == 7)
+                        BG_CAPTURE, HANDOFF_GUARD, PROVENANCE_NUDGE})
+    check("8: no hook was double-registered", len(post) == 8)
     check("8: the $HOME/ spelling was rewritten in place, not re-added",
           post.count(SHELL_HOMEVAR) == 1
           and PY + " ~/.claude/hooks/shell-env-nudge.py" not in post)
@@ -748,6 +749,12 @@ with tempfile.TemporaryDirectory() as tmp:
           entries(d12, "PostToolUse") == [
               ("Bash", AUDIT), ("Bash", SHELL), ("Bash", SEARCH_NUDGE),
               (None, LEDGER), ("Bash", LEDGER), (None, WRITEBACK),
+              # git-add-provenance-nudge was absent from this fixture, so the
+              # healing run APPENDS it. It lands HERE, not at the end: appends
+              # follow the registrar's own POST_BASH_CMDS order, and this entry
+              # sits after search-tool-nudge in that list. The position is the
+              # evidence it was appended in spec order rather than tacked on.
+              ("Bash", PROVENANCE_NUDGE),
               ("Bash", BG_CAPTURE), (None, HANDOFF_GUARD)])
     check("12: Stop healed, keeping the first copy of each and the three survivors",
           entries(d12, "Stop") == [
@@ -924,8 +931,9 @@ for hostile, why, hostile_cwd, expected_reason in HOSTILE_OVERRIDES:
         # 19 -> 20: gh-issue-closing-condition-guard.py joined PRE_BASH_CMDS.
         # 20 -> 22: handoff-write-guard.py joined BOTH PostToolUse and Stop, so
         #           one converged run holds two more commands than it did.
-        check(tag + ": three consecutive runs hold exactly 22 hook commands",
-              counts == [22, 22, 22])
+        # 22 -> 23: git-add-provenance-nudge.py joined POST_BASH_CMDS.
+        check(tag + ": three consecutive runs hold exactly 23 hook commands",
+              counts == [23, 23, 23])
         with open(settings) as f:
             d13 = json.load(f)
         written = [c for ev in d13.get("hooks", {}) for c in cmds(d13, ev)

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -812,6 +812,13 @@ HERMETIC_TARGETS=(
   # no marker), because a scanner that marks everything would satisfy a one-way
   # test while turning the 16 MiB bound into hours of history instead of months.
   scripts/claude-hooks/tests/test_bg_command_capture.py
+  # Same reason again — a FILE, not the directory. git-add-provenance-nudge warns
+  # when a `git add` staged an untracked file whose mtime predates the session.
+  # Its whole value is in the SILENT direction: staging a new file is mandatory in
+  # this repo, so a false positive would nag on the correct, required action. The
+  # false-positive control is gated here rather than left to the ungated
+  # hand-rolled scripts beside it.
+  scripts/claude-hooks/tests/test_git_add_provenance_nudge.py
   # Writer 2 of the agent activity ledger — the OPENCODE half. A Python suite
   # driving real `node`, mirroring scripts/collector/opencode/tests/test_plugin.py
   # (this repo's established way to test an opencode plugin; there is no node
@@ -2093,6 +2100,11 @@ TARGET_FLOORS=(
   # count, not arithmetic — if this line conflicts, re-run the gate on the MERGED
   # tree and copy what it prints rather than reconciling the two sides.
   "scripts/claude-hooks/tests/test_bg_command_capture.py|76"
+  # 2026-08-30, git-add-provenance-nudge lands: 22 collected, floor 21 —
+  # `_suggested_floor 22` = 22 - max(1, 22/20) = 21. Re-measured from the
+  # collected count after the on-disk-name pins were added, not carried over
+  # from the 19 the first draft measured.
+  "scripts/claude-hooks/tests/test_git_add_provenance_nudge.py|21"
   # 2026-08-14, writer 2 (opencode) arrives as a NEW target: 15 collected.
   #   _suggested_floor 15 = 15 - min(50, max(1, 15/20 = 0 -> 1)) = 14.
   #

--- a/scripts/tests/test_transcript_search.py
+++ b/scripts/tests/test_transcript_search.py
@@ -814,6 +814,11 @@ JSONL_GLOB_SITES = {
         (1, "test: lists its own tmp state dir to assert what the hook wrote"),
     ("scripts/claude-hooks/tests/test_search_tool_nudge.py", "OS-WALK"):
         (1, "test: walks its own tmp fixture tree"),
+    ("scripts/claude-hooks/tests/test_git_add_provenance_nudge.py", "DIR-LISTING"):
+        (1, "test: lists its own tmp cache dir to assert the session id was "
+            "sanitised into the filename. The `.jsonl` in the same function is "
+            "the FIXTURE TRANSCRIPT it writes, not a corpus walk — the hook "
+            "reads the single path the payload names and never enumerates."),
 }
 
 _GLOB_ATTRS = {"glob", "rglob", "iglob"}


### PR DESCRIPTION
Recommendation (2) from the mimo-v2.5 session evaluation. A PostToolUse nudge on
Bash: when a `git add` leaves paths staged-as-ADDED whose mtime predates the
session, it names them and offers `git restore --staged`.

## Why

MEASURED 2026-08-30. An opencode session adding two packages to
`nix/pkgs/default.nix` hit a failing `home-manager switch`, because a **different**
session's uncommitted `nix/graphical.nix` edit referenced `scripts/memory-detail`
through `home.file`, and a flake build copies **tracked** files only. It ran:

```
git -C ~/workspace/devrc add scripts/memory-detail && home-manager switch …
```

The switch then succeeded and the session recorded the workaround as the
diagnosis. The *mechanism* was right; the **scope** was wrong — 181 lines of an
unrelated in-flight bar feature were now staged, and its own handoff went on to
tell the next reader to commit that script alongside its own change, which would
have landed half a feature: the file without its `nix/graphical.nix` wiring and
without its 20 tests.

## 🔴 A nudge, not a `guard_core` check — that is the whole design

`guard_core.evaluate()` returns a reason (DENY) or `None`. There is **no warn
tier**, so a check there *blocks*, and blocking would be wrong twice over:

- `git add <path>` is the **safe** form `check_git_add_all` exists to steer
  callers toward. A guard that blocks the safe spelling contradicts its sibling.
- In this repo staging a new file is **mandatory** — `CLAUDE.md`: *"A NEW file
  must be `git add`ed or the flake silently omits it from the deploy."* A false
  positive would fire on the deploy path for every new skill, hook, reference doc
  and test. `RULES.md` calls a permanently-red gate worse than no gate.

Staging is trivially reversible, so acting after the fact costs nothing.

## It asks git rather than parsing the command

Parsing `git add` operands means re-deriving `guard_core`'s argv handling —
global-option hops, quoting, `--`, subshells — the predicate `RULES.md` says is
"typically wrong at N−1" of the sites that open-code it. Firing *after* the
command means the index already holds the answer:
`git diff --cached --name-only --diff-filter=A` is exactly "was untracked, now
staged". The command text decides only whether to look at all, and being loose
there is free — a false trigger runs one read-only query and stays silent.

## The mtime signal is a heuristic, biased toward silence

A **resumed** session keeps old transcript records, so everything written since
reads as "mine" — a false *negative*, the safe direction, and why this is not
tightened to the current run. `cp -a`, a checkout and a restore all move mtimes
in ways it cannot see. So the message **asks** rather than asserting authorship,
and blocks nothing. No clock (no transcript, no timestamp) means **no nudge**,
never "everything looks old".

## Verification

- **22 tests**, including the false-positive control that a file written *during*
  the session is not flagged — the case guarding the mandatory new-file add.
- **Mutation-checked**: removing the mtime comparison is killed by that control;
  dropping `--diff-filter=A` is killed by the modified-tracked-file test.
- ⚠ One mutant **survives by design** and is labelled in the test rather than
  counted as coverage: removing the no-clock guard leaves all tests green,
  because `foreign_staged(repo, None)` then raises `TypeError` and `main`'s outer
  `except Exception: pass` swallows it. Both defences are deliberate — a nudge may
  never break the Bash call it observes — so that test pins the observable
  behaviour, not the guard.
- Dev-host tier: `RESULT: PASS (exit=0)` (19,800 passed after the ledger fixes).
- Sandbox tier, one at a time: `pytests` rc=0, `nodetests` rc=0.

## Three two-way ledgers caught the registration gaps

Registered in all three places a new hook must appear — `nix/home.nix` (deploy),
`register-nudge-hook.py` (activation + its `MANAGED_HOOK_SCRIPTS` ledger), and
`run-tests.sh` (target + floor 21). The on-disk-artifact-name registry, the
registrar's own hook counts (22 → 23), and the `*.jsonl` glob-site ledger each
failed until its entry was added. Worth noting as evidence those ledgers work.

⚠ The merged tree is **not** gated (`strict` is false here).
