### PR TITLE
test(store-api): the CI hang is a 60s READ timeout, not an RST — the backlog elimination is re-made on a connection count, and `fetch` now names the mechanism

### DIFF
--- a/claudedocs/handoff-cairn-phase3.md
+++ b/claudedocs/handoff-cairn-phase3.md
@@ -98,6 +98,156 @@ with **zero steps executed** after a 60-minute `TaskRunTimeout`, starved by a si
   carries `39eec8a5 docs(handoff): … analyzed Tekton CI pipeline throughput, identified
   bottlenecks`, and a `ci-speedup-1` claim is live. Read that before starting fresh.
 
+### The CI failure was a **TIMEOUT**, not an RST — and that breaks the backlog elimination's premise while a *different* measurement still rules the backlog out
+
+**New datum (2026-08-31).** `devrc-ci-ddrxx`, revision `857fc3f5`, node `talos-xr6-r7p`:
+`TestTheActorComesFromTheTOKEN::test_a_FORGED_actor_in_the_body_is_DISCARDED[record1-…-dana]`
+failed on **gw1** with a bare `TimeoutError` and no assertion executed. Chain:
+`post_bullet` → `fetch` → `urlopen(req, timeout=timeout)` → `http.client` →
+`socket.py:720`. **Line 720 of this Python (3.12.14) is `return self._sock.recv_into(b)`
+inside `SocketIO.readinto`** — read, verbatim, from the interpreter the gate uses. So this
+is a **READ** timeout on a connection the client had already established and written to,
+not a connect timeout. `HANG_TIMEOUT` was already `60.0` at that revision, so a localhost
+round-trip went unanswered for **more than 60 s**.
+
+🔴 **The premise of the entries above does not transfer.** Both ruled accept-queue overflow
+out with *"`tcp_abort_on_overflow = 0`, so overflow drops SYNs and yields a **timeout**,
+never an RST"*. That argument was made to explain an **RST**. Applied to a **TIMEOUT** it
+runs backwards: a timeout is precisely what that sysctl predicts. **The elimination as
+written is void for this observation** — do not carry it forward as if it covered both.
+
+**The backlog is nonetheless ruled out here, on a measurement instead of an inference.**
+
+- **The failing test opens exactly ONE connection.** Counted at `verify_request`, which
+  socketserver calls once per accepted connection: `{port: 1}`. `urllib` sends
+  `Connection: close` (measured off the wire), so `post_bullet` is one request on one
+  connection.
+- **The accept queue it would have to overflow is 128 deep**, read off the live socket
+  (`ss -lntH` Send-Q on the real `build_server` socket), not off the constant.
+  Overflow needs >128 *simultaneous* pending connections. **1 vs 128 is arithmetic, not
+  judgement.**
+- Instrument validated before either number was quoted: requested backlog 5 → reported 5,
+  128 → 128, 100000 → **4096** (the somaxconn truncation, observed). The reader moves with
+  the request; a 128 is not a constant it always prints.
+
+**`somaxconn` does NOT truncate the 128 in the sandbox — the suspicion is measured false.**
+Read inside a real nix build sandbox netns on the dev host, and inside both a pod netns and
+a fresh `unshare -n` on the CI node:
+
+| | dev host | dev-host nix sandbox | CI node `talos-xr6-r7p` (pod netns **and** fresh netns) |
+|---|---|---|---|
+| `net.core.somaxconn` | 4096 | **4096** | **4096** |
+| `tcp_abort_on_overflow` | 0 | 0 | 0 |
+| `tcp_max_syn_backlog` | 4096 | 4096 | 2048 |
+| `tcp_synack_retries` | 5 | 5 | 5 |
+
+`430fe3e1`'s fix is fully in force in CI. Nothing about the sandbox weakens it.
+
+### CPU starvation is quantitatively too small — which retires the premise `HANG_TIMEOUT = 60` rests on
+
+`HANG_TIMEOUT` was raised 15 → 60 on the stated cause *"a 10-minute parallel suite competing
+with a saturated cluster"*. **Measured against that story and it does not hold.**
+
+Load–latency curve using the suite's **own** `running()` / `post_bullet()` (so the server,
+token record, store layout, framing and teardown are identical to the failing test), pinned
+to a 2-CPU cpuset with spinners on the same cores. Clock brackets the POST only —
+`running()`'s teardown costs up to `serve_forever`'s 0.5 s poll interval and would otherwise
+floor every sample. All 1250 round-trips answered **200**:
+
+| spinners on 2 CPUs | oversubscription | p50 | p99 | **max** | >60 s |
+|---|---|---|---|---|---|
+| 0 | 1× | 0.014 s | 0.435 s | 0.558 s | 0 |
+| 8 | 5× | 0.032 s | 0.061 s | 0.105 s | 0 |
+| 32 | 17× | 0.144 s | 0.340 s | 0.394 s | 0 |
+| 96 | 49× | 0.446 s | 0.924 s | 1.033 s | 0 |
+| 192 | **97×** | 1.001 s | 2.573 s | **2.984 s** | **0** |
+
+Negative control: a POST to a socket nothing ever accepts raised `TimeoutError` at 3.01 s
+against a 3.00 s bound — the timer can fire and be seen.
+
+**97× CPU oversubscription buys 2.98 s. The CI node was at 2.1×** (`node_load1` max 34.00 on
+16 CPUs; PSI cpu-some max 0.266). CPU contention is off by roughly three orders of magnitude
+from a 60 s stall. 🔴 **So `HANG_TIMEOUT = 60` is not wrong, but its stated justification is
+— and raising it further would buy nothing against whatever this actually is.**
+
+### The leading candidate: two unbounded `fsync`s inside the request
+
+`server.py:_replace_bytes` issues **two** `fsync`s per append — the file (`os.fsync`, 2012)
+then the parent directory (`_fsync_dir`, 1976) — **inside the handler, before the response is
+written**. `fsync` blocks in uninterruptible D-state, is bounded by nothing, and **burns no
+CPU**, which is exactly why it is invisible in the CPU metrics above. 🔴 **The handler's
+`timeout = 15` does NOT bound it**: that is a SOCKET timeout and does not reach a syscall.
+
+**Sufficiency demonstrated, frame for frame.** Stalling one `fsync` past the client's bound
+reproduces the CI traceback exactly — `fetch` → `urlopen` → `http.client` →
+`socket.py:720, in readinto / return self._sock.recv_into(b)` → `TimeoutError: timed out`.
+Control: with the stall removed the same request answers **200 in 0.056 s**, so the harness
+can pass and the failure is caused by the stall.
+
+**The node's I/O was in fact saturated during that step** (Prometheus, 06:25–06:55Z, n=31,
+node-exporter `192.168.50.191:9100`):
+
+- PSI io **full** `rate(node_pressure_io_stalled[2m])` mean **0.128**, **max 0.586** — at the
+  peak, 58.6 % of wall time *no* task on the node could progress on I/O. That is **2.2×**
+  larger than the CPU some-stall, and full is the more severe class.
+- `node_procs_blocked` (D-state) **max 37**; `sda` utilisation **max 0.996**, weighted queue
+  time max **64.1**, write await **max 1.264 s**.
+- Three discrete saturation episodes fall inside the step: **06:32–06:34** (the worst),
+  06:36:30–06:38:30, 06:45–06:47. Five concurrent `devrc-ci-*-gate-pod`s were on the node;
+  `ddrxx` wrote ~1/5 of the load — mostly a victim.
+- **Memory is affirmatively ruled out**: PSI memory max 0.004 (0.4 %), ≥10.87 GB available
+  throughout.
+- Clean negative control for the instrument: the 04:25Z window with **zero** CI pods reads
+  sda util 1.3 %, io-full 0.14 %. The saturation is caused by CI concurrency.
+
+### 🔴 What is NOT established — read this before quoting the section above
+
+- **No 60-second I/O operation was observed.** The worst per-op latency in the window is
+  **1.264 s**, and the 0.586 io-full figure is a duty cycle over a minute, not a contiguous
+  stall. Sufficiency (a stalled `fsync` produces this exact traceback) is **not** attribution.
+- **The same I/O picture appears in every comparison window** — −6 h, −12 h and −24 h are
+  statistically indistinguishable from the incident window, and those runs did not fail. So
+  saturation is a *necessary-condition candidate*, not a discriminating cause. It cannot
+  separate "the filesystem stalled this request" from a rival that merely coincided with
+  routine CI load.
+- **The discriminating signal is client-side and CI does not currently emit it**: whether the
+  60 s expiry landed inside 06:32–06:34 / 06:36–06:38 / 06:45–06:47, and *which* frame the
+  server thread was in. Prometheus cannot answer either.
+- Whether the historical `ConnectionResetError` (the entries above) and this `TimeoutError`
+  are one mechanism or two **remains open**. They have different shapes and only the RST one
+  has a located hypothesis (`_consume_body`'s five undrained arms).
+
+### What shipped instead of a fix — and why it is not one
+
+🔴 **No drain, no retry, no bound was moved.** The failure carries no information about
+*which side* blocked, and that — not the flake's rarity — is why this has stayed open:
+**a client-side read timeout is the observable that the most mechanisms share, so on its own
+it identifies none of them.**
+
+`fetch` now catches `TimeoutError`, prints `_why_the_server_did_not_answer()` to stderr and
+**re-raises unchanged**. The report dumps every live thread's stack and emits a greppable
+`MECHANISM = …` verdict — `SERVER_BLOCKED_IN_FSYNC`, `SERVER_BLOCKED_ON_ENTRY_LOCK`,
+`SERVER_BLOCKED_IN_AUDIT_SINK`, `SERVER_BLOCKED_ELSEWHERE`, `NEVER_ACCEPTED`,
+`NO_SERVER_THREAD_ALIVE`, or `AMBIGUOUS(…)` when two stuck handlers disagree. A hung test
+still fails, exactly as loudly. **The next occurrence in CI names its own mechanism.**
+
+⚠ **Labelled honestly: `TestAHungRoundTripSAYSWhichSideBlocked` is an INVARIANT GUARD on the
+reporter, not regression coverage for the flake.** The flake has never been made to
+reproduce and no test claims otherwise. Its evidence is the mutation matrix (baseline 4
+passed; drop the fsync rule → the fsync arm alone fails; drop the entry-lock rules → that arm
+alone fails; make the verdict a true constant → the discrimination control **and**
+`NEVER_ACCEPTED` fail; make `fetch` swallow the timeout → three arms fail on
+`DID NOT RAISE`; make the handler drain inert → two arms fail; positive control with no rules
+at all → caught).
+
+🔴 **Two traps paid for while writing it, both worth not re-paying.** `post_bullet` forwards
+`**payload` into the JSON **body**, so a `timeout=` passed to it is sent to the server as a
+field and the request silently waits the full `HANG_TIMEOUT` — the test then passes while
+measuring nothing. And a test that wedges a handler **must drain it**: handler threads are
+daemons that `shutdown()`/`server_close()` never join, so one left parked leaks into later
+tests and the reporter attributes *its* mechanism to somebody else's hang. That happened
+here and is why the headline reports `AMBIGUOUS` rather than picking a handler.
+
 ## Next steps (ranked)
 
 🔴 **Numbering is UNCHANGED on purpose** — the rank is half a claim's identity

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -66,6 +66,7 @@ import sys
 import textwrap
 import threading
 import time
+import traceback
 import urllib.error
 import urllib.request
 from contextlib import contextmanager
@@ -296,6 +297,139 @@ def running(
         thread.join(timeout=10)
 
 
+# 🔴 WHICH SIDE WAS BLOCKED, AND ON WHAT. Ordered innermost-first: the first
+# token found scanning a stuck handler's frames from the innermost outward wins,
+# so `fsync` reached from inside `_replace_bytes` reports as FSYNC and not as the
+# entry lock it is holding on the way in.
+_HUNG_SERVER_RULES: tuple[tuple[str, str], ...] = (
+    ("fsync", "SERVER_BLOCKED_IN_FSYNC"),
+    ("flock", "SERVER_BLOCKED_ON_ENTRY_LOCK"),
+    ("_EntryLock", "SERVER_BLOCKED_ON_ENTRY_LOCK"),
+    ("_audit_lock", "SERVER_BLOCKED_IN_AUDIT_SINK"),
+    ("self.audit(", "SERVER_BLOCKED_IN_AUDIT_SINK"),
+)
+
+
+def _why_the_server_did_not_answer() -> str:
+    """Every live thread's stack, plus a one-line `MECHANISM =` verdict.
+
+    🔴 DIAGNOSTICS, NOT A MITIGATION. Nothing here retries, drains, or moves a
+    bound, and the `TimeoutError` is re-raised unchanged — a test that hung
+    still fails, exactly as loudly. What this adds is the one fact the bare
+    exception cannot carry, and whose absence is why the store-api hang stayed
+    open for weeks: **a client-side read timeout is the observable that the
+    most mechanisms share, so on its own it identifies none of them.**
+
+    The rivals, every one of which surfaces identically as `TimeoutError` at
+    `socket.py:720` (`SocketIO.readinto` -> `recv_into`):
+
+      * **the handler parked in `fsync`.** `server.py:_replace_bytes` issues
+        TWO — the file, then the parent directory — INSIDE the request and
+        BEFORE the response is written. `fsync` blocks in uninterruptible
+        D-state, is bounded by nothing, and burns no CPU, so it is invisible in
+        CPU/PSI-cpu metrics. The handler's `timeout = 15` does NOT bound it:
+        that is a SOCKET timeout and does not reach a syscall.
+      * **the handler parked on the entry `flock`** (also unbounded).
+      * **the handler parked in the audit sink** — `_audit_lock` is a CLASS
+        attribute and therefore process-global across every server in the
+        worker.
+      * **the connection was never ACCEPTED** — accept-queue overflow, or the
+        `serve_forever` thread simply not scheduled. Distinguished from all of
+        the above by there being no handler thread at all.
+
+    The verdict is emitted as a `MECHANISM = ...` line so a CI log can be
+    grepped for it without a human reading the stacks, the same shape the
+    transport investigation in `claudedocs/handoff-cairn-phase3.md` used.
+    """
+    frames = sys._current_frames()
+    main_ident = threading.main_thread().ident
+    handlers: list[tuple[str, list[str]]] = []
+    accept_loop_parked = False
+    report: list[str] = []
+
+    for thread in threading.enumerate():
+        frame = frames.get(thread.ident)
+        if frame is None or thread.ident == main_ident:
+            continue
+        stack = traceback.format_stack(frame)
+        report.append(
+            f"--- thread {thread.name!r} daemon={thread.daemon} ---\n" + "".join(stack)
+        )
+        blob = "".join(stack)
+        # `process_request_thread` is socketserver's per-connection worker, so
+        # its presence is what makes a thread a HANDLER rather than the accept
+        # loop. A thread can be both only if `serve_forever` ran inline, which
+        # `running()` never does.
+        if "process_request_thread" in blob:
+            handlers.append((thread.name, stack))
+        elif "serve_forever" in blob:
+            accept_loop_parked = True
+
+    # 🔴 EVERY handler is classified, not the first one found — and if they
+    # DISAGREE the headline says so instead of picking one. `ThreadingHTTPServer`
+    # runs daemon handler threads that `shutdown()`/`server_close()` do NOT join,
+    # so a thread stuck in an EARLIER test is still alive here and would
+    # otherwise be reported as this request's mechanism. That is not
+    # hypothetical: it happened while writing the tests for this function, and a
+    # confident wrong verdict is worse than none.
+    per_handler: list[str] = []
+    for name, stack in handlers:
+        found = "BLOCKED_ELSEWHERE"
+        for line in reversed(stack):          # innermost frame first
+            hit = next(
+                (m for token, m in _HUNG_SERVER_RULES if token in line), None
+            )
+            if hit:
+                found = hit
+                break
+        per_handler.append(f"{name}={found}")
+
+    distinct = {entry.split("=", 1)[1] for entry in per_handler}
+    if len(distinct) == 1:
+        verdict = distinct.pop()
+    elif len(distinct) > 1:
+        verdict = "AMBIGUOUS(" + ",".join(sorted(distinct)) + ")"
+    elif accept_loop_parked:
+        # No handler exists at all, so the connection was never accepted. That
+        # names the FAMILY — accept-queue overflow or an unscheduled accept loop
+        # — and deliberately does not choose between them; the listening
+        # socket's own queue depth is what separates those two.
+        verdict = "NEVER_ACCEPTED"
+    else:
+        verdict = "NO_SERVER_THREAD_ALIVE"
+
+    return (
+        f"\nMECHANISM = {verdict}   "
+        f"(handler threads={len(handlers)} [{' '.join(per_handler) or '-'}], "
+        f"accept loop parked={accept_loop_parked})\n"
+        + "".join(report)
+    )
+
+
+def _await_no_handler_threads(bound: float = HANG_TIMEOUT) -> int:
+    """Block until no `process_request_thread` is alive. Returns what is left.
+
+    🔴 A TEST THAT DELIBERATELY WEDGES A HANDLER MUST DRAIN IT. Handler threads
+    are daemons and `running()`'s teardown does not join them, so one left
+    parked leaks into every later test in this worker — where
+    `_why_the_server_did_not_answer` will see it and report ITS mechanism for
+    somebody else's hang. Bounded, and the count is returned rather than
+    asserted so the caller decides what a leftover means.
+    """
+    deadline = time.monotonic() + bound
+    while time.monotonic() < deadline:
+        alive = [
+            t for t in threading.enumerate()
+            if "process_request_thread" in t.name
+        ]
+        if not alive:
+            return 0
+        time.sleep(0.02)
+    return len(
+        [t for t in threading.enumerate() if "process_request_thread" in t.name]
+    )
+
+
 def fetch(
     url: str,
     *,
@@ -333,6 +467,30 @@ def fetch(
             return resp.status, dict(resp.headers), resp.read()
     except urllib.error.HTTPError as exc:
         return exc.code, dict(exc.headers), exc.read()
+    except TimeoutError:
+        # 🔴 RE-RAISED UNCHANGED — this is a report, not a recovery. The dump is
+        # taken HERE, while the server is still blocked, because by the time the
+        # exception reaches the test the `with running(...)` teardown has torn
+        # down the very threads whose stacks answer the question.
+        #
+        # ⚠ `TimeoutError` IS THE READ PHASE, and that is why this clause is
+        # narrow rather than an `except OSError`. `urllib` wraps only
+        # `h.request()`, so a CONNECT-phase timeout arrives as `URLError` and
+        # already names its own phase; letting it past unhandled keeps the two
+        # distinguishable in the log instead of collapsing them into one report.
+        #
+        # 🔴 THE REPORTER MAY NEVER REPLACE THE FAILURE IT DESCRIBES. ~200 call
+        # sites share this helper; if `_why_the_server_did_not_answer` ever
+        # raised, that exception would propagate INSTEAD of the `TimeoutError`
+        # and every hang in the module would report as a defect in the
+        # diagnostic. A best-effort report is worth having; a diagnostic that
+        # can rewrite the diagnosis is not.
+        try:
+            report = _why_the_server_did_not_answer()
+        except Exception as diag_exc:  # noqa: BLE001 — see above
+            report = f"\nMECHANISM = REPORTER_FAILED ({diag_exc!r})\n"
+        print(report, file=sys.stderr, flush=True)
+        raise
 
 
 def _raw_request(host: str, path: str, headers: list[tuple[str, str]]) -> int:
@@ -15129,3 +15287,169 @@ class TestTheListenBacklogIsDeepEnoughForThisServersOwnConcurrency:
             )
         finally:
             httpd.server_close()
+
+
+class TestAHungRoundTripSAYSWhichSideBlocked:
+    """🔴 THE INSTRUMENT, NOT A FIX — and the distinction is the whole point.
+
+    `test_a_FORGED_actor_in_the_body_is_DISCARDED` failed in CI (`devrc-ci-ddrxx`,
+    revision `857fc3f5`) with a bare `TimeoutError` out of `socket.py:720` and
+    nothing else. Nothing in that traceback says whether the server was blocked,
+    and if so on what — which is why the investigation in
+    `claudedocs/handoff-cairn-phase3.md` ran for weeks against an observable that
+    every candidate mechanism produces identically.
+
+    These tests do NOT make the flake reproduce, do NOT retry and do NOT move a
+    bound. They pin that `_why_the_server_did_not_answer` can TELL THE RIVALS
+    APART, because a classifier that answered `SERVER_BLOCKED_IN_FSYNC` to every
+    hang would be worse than no classifier: it would end the investigation with
+    a confident wrong answer.
+
+    ⚠ LABELLED HONESTLY: these are INVARIANT GUARDS on the reporter, not
+    regression coverage for the flake. The flake has never been made to
+    reproduce, and no test here claims otherwise. Each arm's own evidence is the
+    mutation matrix in the PR body — the arm's rule deleted from
+    `_HUNG_SERVER_RULES` and the test watched to fail with its own message.
+    """
+
+    # Deliberately far apart: the client must give up while the server is still
+    # stuck, or the report is taken after the block has cleared and says nothing.
+    # Kept SMALL because each test pays `SERVER_STALL` twice over — once waiting
+    # for the client to give up, once draining the wedged handler.
+    CLIENT_BOUND = 0.25
+    SERVER_STALL = 1.2
+
+    def _hang_and_report(self, store, monkeypatch, where: str) -> str:
+        """Drive one POST into a server deliberately stuck at `where`.
+
+        Returns the reporter's own text, captured by calling it at the moment
+        the client gives up — the same instant `fetch` calls it in anger.
+        """
+        # 🔴 Every arm starts from a clean thread table. Without this, a handler
+        # wedged by the PREVIOUS arm is still alive and the verdict below is
+        # about that one — the exact mis-attribution these tests exist to
+        # prevent, and the reason the headline reports AMBIGUOUS on disagreement.
+        assert _await_no_handler_threads(HANG_TIMEOUT) == 0, (
+            "a handler thread from an earlier test is still parked, so this "
+            "arm's verdict would not be about this arm's request"
+        )
+        stalled = threading.Event()
+
+        def _stall(*_a, **_k):
+            stalled.set()
+            time.sleep(self.SERVER_STALL)
+
+        if where == "fsync":
+            # 🔴 `_fsync_dir`, not `os.fsync`: patching the stdlib's `os.fsync`
+            # is process-global and would stall any OTHER thread that happened
+            # to fsync during this test. This module-level function is reached
+            # only from `_replace_bytes`, so the blast radius is exactly the
+            # request under test.
+            monkeypatch.setattr(api, "_fsync_dir", _stall)
+        elif where == "entry-lock":
+            class _StallingLock:
+                def __init__(self, _path):
+                    pass
+
+                def __enter__(self):
+                    _stall()
+                    return self
+
+                def __exit__(self, *_exc):
+                    return None
+
+            monkeypatch.setattr(api, "_EntryLock", _StallingLock)
+        else:                                    # pragma: no cover - typo guard
+            raise AssertionError(f"unknown stall site {where!r}")
+
+        with running(store, tokens=(ZACH,)) as (base, _audit):
+            # 🔴 `fetch` DIRECTLY, not `post_bullet`. `post_bullet` forwards
+            # `**payload` into the JSON BODY, so a `timeout=` passed to it is
+            # silently sent to the server as a field instead of bounding the
+            # client — the request then waits the full HANG_TIMEOUT, the stall
+            # elapses, and the test passes while measuring nothing. Cost one
+            # debugging round; do not "simplify" this back.
+            with pytest.raises(TimeoutError):
+                fetch(
+                    bullets_url(base, ALLOW_SCOPE),
+                    token=ZACH_TOKEN,
+                    method="POST",
+                    timeout=self.CLIENT_BOUND,
+                    data=json.dumps(
+                        {"text": BULLET_A, "session": SESSION_A}
+                    ).encode("utf-8"),
+                )
+            assert stalled.is_set(), (
+                "the server never reached the stall site, so the hang under "
+                "test was NOT the one this test set up — the report below "
+                "would be about some other mechanism"
+            )
+            try:
+                return _why_the_server_did_not_answer()
+            finally:
+                # Drain OUR wedged handler before handing back, so the leak
+                # this arm created cannot be inherited by the next one.
+                _await_no_handler_threads(HANG_TIMEOUT)
+
+    def test_a_stall_in_the_FSYNC_region_is_NAMED(self, scoped_store, monkeypatch):
+        """`_replace_bytes` fsyncs the file AND the parent directory inside the
+        request, before the response is written. Both are unbounded: the
+        handler's `timeout = 15` is a SOCKET timeout and does not reach a
+        syscall."""
+        report = self._hang_and_report(scoped_store, monkeypatch, "fsync")
+        assert "MECHANISM = SERVER_BLOCKED_IN_FSYNC" in report, report
+        assert "_fsync_dir" in report, (
+            "the verdict was right but the stacks do not name the blocking "
+            "frame, so a reader still cannot check the verdict"
+        )
+
+    def test_a_stall_on_the_ENTRY_LOCK_reads_DIFFERENTLY(
+        self, scoped_store, monkeypatch
+    ):
+        """🔴 THE DISCRIMINATION CONTROL. A reporter that said FSYNC to every
+        hang would pass the test above and be worthless. This one hangs the
+        server somewhere ELSE and requires the verdict to MOVE."""
+        report = self._hang_and_report(scoped_store, monkeypatch, "entry-lock")
+        assert "MECHANISM = SERVER_BLOCKED_ON_ENTRY_LOCK" in report, report
+        assert "SERVER_BLOCKED_IN_FSYNC" not in report, (
+            "a hang that is not in fsync was reported as fsync — the verdict "
+            "is a constant, not a measurement"
+        )
+
+    def test_a_request_that_is_NEVER_ACCEPTED_reads_as_NEVER_ACCEPTED(
+        self, scoped_store
+    ):
+        """The rival family the backlog work was about: no handler thread exists
+        at all, because the connection was never accepted.
+
+        Modelled with a real parked `serve_forever` (from `running`) plus a
+        second socket that is listening and never accepted — which is exactly
+        the state an accept-queue overflow leaves the client in.
+        """
+        assert _await_no_handler_threads(HANG_TIMEOUT) == 0, (
+            "a handler thread from an earlier test is still parked — this arm "
+            "asserts there is NO handler, so a leftover would fail it for the "
+            "wrong reason"
+        )
+        with running(scoped_store, tokens=(ZACH,)) as (_base, _audit):
+            with socket.socket() as never:
+                never.bind(("127.0.0.1", 0))
+                never.listen(1)
+                url = f"http://127.0.0.1:{never.getsockname()[1]}/api/v1/status"
+                with pytest.raises(TimeoutError):
+                    fetch(url, token=ZACH_TOKEN, timeout=self.CLIENT_BOUND)
+                report = _why_the_server_did_not_answer()
+        assert "MECHANISM = NEVER_ACCEPTED" in report, report
+        assert "handler threads=0" in report, report
+
+    def test_the_reporter_is_a_REPORT_and_changes_no_OUTCOME(self, scoped_store):
+        """🔴 The property that makes this safe to add to a helper 200+ call
+        sites share: a healthy round-trip is untouched, and a hung one still
+        RAISES. `fetch` swallowing the timeout to print a nice message would be
+        the suppression this investigation is explicitly forbidden to ship."""
+        with running(scoped_store, tokens=(ZACH,)) as (base, _audit):
+            code, headers, _b = post_bullet(
+                base, ZACH_TOKEN, ALLOW_SCOPE, text=BULLET_B, session=SESSION_B,
+            )
+        assert code == 200, (code, headers)
+        assert headers["X-Store-Status"] == "appended"


### PR DESCRIPTION
## TL;DR

The long-open `test_subsystem_store_api.py` flake failed in CI as a **60 s READ timeout**, not
the `ConnectionResetError` the open investigation was chasing. That difference matters,
because the handoff's elimination of accept-queue overflow was reasoned *from an RST*:

> `net.ipv4.tcp_abort_on_overflow = 0` on this host (measured), so overflow **drops SYNs and
> yields a timeout, never an RST**.

Applied to a **timeout**, that argument runs backwards — a timeout is exactly what the sysctl
predicts. **The elimination as written is void for this observation.**

So I re-made it on a measurement, and then measured the two rival explanations. Result:
**diagnosed, not fixed.** No drain, no retry, no bound moved. What ships is the instrument
that makes the next occurrence name its own mechanism.

## What was measured

**1. The accept queue is ruled out — by arithmetic, not by a sysctl.**

- The failing test opens **exactly 1 connection**. Counted at `verify_request` (socketserver
  calls it once per accepted connection): `{port: 1}`. `urllib` sends `Connection: close`,
  measured off the wire.
- The queue it would have to overflow is **128 deep**, read off the live `build_server`
  socket with `ss -lntH`, not off the constant. Overflow needs >128 *simultaneous* pending
  connections.
- Instrument validated first: requested 5 → reported 5, 128 → 128, 100000 → **4096** (the
  somaxconn truncation, observed). The reader moves with the request.

**2. `somaxconn` does NOT truncate the 128 in the sandbox — measured false.**

| | dev host | dev-host nix sandbox | CI node `talos-xr6-r7p` (pod netns **and** fresh `unshare -n`) |
|---|---|---|---|
| `net.core.somaxconn` | 4096 | **4096** | **4096** |
| `tcp_abort_on_overflow` | 0 | 0 | 0 |
| `tcp_max_syn_backlog` | 4096 | 4096 | 2048 |
| `tcp_synack_retries` | 5 | 5 | 5 |

`430fe3e1`'s fix is fully in force in CI.

**3. CPU starvation is ~3 orders of magnitude too small — which retires the premise
`HANG_TIMEOUT = 60` rests on.**

Load–latency curve using the suite's **own** `running()` / `post_bullet()`, pinned to a 2-CPU
cpuset with spinners on the same cores. All 1250 round-trips answered 200:

| spinners on 2 CPUs | oversubscription | p50 | p99 | **max** | >60 s |
|---|---|---|---|---|---|
| 0 | 1× | 0.014 s | 0.435 s | 0.558 s | 0 |
| 8 | 5× | 0.032 s | 0.061 s | 0.105 s | 0 |
| 32 | 17× | 0.144 s | 0.340 s | 0.394 s | 0 |
| 96 | 49× | 0.446 s | 0.924 s | 1.033 s | 0 |
| 192 | **97×** | 1.001 s | 2.573 s | **2.984 s** | **0** |

Negative control: a POST to a never-accepted socket raised `TimeoutError` at 3.01 s against a
3.00 s bound. **97× oversubscription buys 2.98 s; the CI node was at 2.1×** (`node_load1` max
34.00 on 16 CPUs, PSI cpu-some max 0.266).

**4. Leading candidate: two unbounded `fsync`s inside the request.**

`_replace_bytes` fsyncs the file (2012) then the parent directory (1976) **before the response
is written**. `fsync` blocks in D-state, is bounded by nothing, and burns no CPU — invisible
in every metric above. The handler's `timeout = 15` does **not** bound it; that is a socket
timeout and does not reach a syscall.

Stalling one `fsync` reproduces the CI traceback **frame for frame**
(`fetch` → `urlopen` → `http.client` → `socket.py:720, in readinto` →
`return self._sock.recv_into(b)` → `TimeoutError`). Control: without the stall the same
request answers **200 in 0.056 s**.

The node's I/O really was saturated during that step: PSI io **full** max **0.586**
(2.2× the CPU some-stall), `procs_blocked` max **37**, `sda` util max 0.996, write await max
**1.264 s**, in three episodes inside the step. Memory is affirmatively ruled out (PSI ≤0.4 %,
≥10.87 GB free). Negative control: the 04:25Z window with zero CI pods reads 1.3 % util.

## 🔴 What is NOT established

- **No 60-second I/O operation was observed.** Worst per-op latency is 1.264 s. Sufficiency
  is not attribution.
- **The same I/O picture appears at −6 h, −12 h and −24 h**, in windows that did not fail. So
  saturation is a necessary-condition candidate, not a discriminating cause.
- **The flake was never reproduced**, in ~1250 controlled round-trips plus a full-file run.
- Whether the historical `ConnectionResetError` and this `TimeoutError` are one mechanism or
  two remains open.

## What ships

`fetch` catches `TimeoutError`, prints `_why_the_server_did_not_answer()` to stderr, and
**re-raises unchanged**. A hung test still fails, exactly as loudly. The report dumps every
live thread's stack and emits a greppable `MECHANISM = …` verdict:
`SERVER_BLOCKED_IN_FSYNC` / `…_ON_ENTRY_LOCK` / `…_IN_AUDIT_SINK` / `…_ELSEWHERE` /
`NEVER_ACCEPTED` / `NO_SERVER_THREAD_ALIVE` / `AMBIGUOUS(…)`.

This is the direct answer to why the investigation stalled: **a client-side read timeout is
the observable that the most mechanisms share, so on its own it identifies none of them.**

## Test matrix — labelled honestly

⚠ `TestAHungRoundTripSAYSWhichSideBlocked` is an **INVARIANT GUARD on the reporter, not
regression coverage for the flake.** The flake has never been made to reproduce and nothing
here claims otherwise. Its evidence is the mutation sweep (`PYTHONDONTWRITEBYTECODE=1`
throughout, results read from per-test lines rather than an exit code):

| mutant | outcome |
|---|---|
| *baseline* | **4 passed** |
| drop the `fsync` rule | 1 failed — the fsync arm **alone** |
| drop both entry-lock rules | 1 failed — the entry-lock arm **alone** |
| make the verdict a true constant | 2 failed — the **discrimination control** and `NEVER_ACCEPTED` |
| make `fetch` swallow the timeout | 3 failed, all on `DID NOT RAISE TimeoutError` |
| make the handler drain inert | 2 failed — the clean-start assertions |
| **positive control** (no rules at all) | 2 failed — the harness does run these tests |

🔴 The first attempt at the constant-verdict mutant patched a branch whose body immediately
recomputed `verdict`, so it was an **equivalent mutant that proved nothing**. Caught by
reading the output rather than the exit code, and redone anchored on the return.

Whole file: **645 passed** (641 pre-existing + 4 new).

## Two traps paid for here

- `post_bullet` forwards `**payload` into the JSON **body**, so a `timeout=` passed to it is
  sent to the server as a field and the request silently waits the full `HANG_TIMEOUT` — the
  test then passes while measuring nothing.
- A test that wedges a handler **must drain it**. Handler threads are daemons that
  `shutdown()`/`server_close()` never join, so one left parked leaks into later tests and the
  reporter attributes *its* mechanism to somebody else's hang. That happened while writing
  these tests, and it is why the headline reports `AMBIGUOUS` on disagreement rather than
  picking a handler.

⚠ **The branch name (`fix/store-api-accept-queue-timeout`) predates the finding** and is
misleading: the accept queue is ruled out, not fixed.
