### PR TITLE
docs(handoff): quiesce-workload closed out — guard shipped and verified live, and the quiesce had a second consequence nobody knew about

### DIFF
--- a/claudedocs/handoff-quiesce-workload.md
+++ b/claudedocs/handoff-quiesce-workload.md
@@ -14,21 +14,31 @@ Non-blocking: if it exits non-zero, print the stderr line and carry on.
 Wrap the repeated "suspend a Flux kustomization + scale deployment to 0" workflow into a deterministic script + agent skill, so it's a one-liner instead of a 6-step investigation.
 
 ## State now
-- Branch: `main` (clean, at `origin/main`)
-- PR: #1066 merged → `c8223366`
-- Shipped to both hosts via `ship.sh` — workbench + laptop converged at `c8223366`
-- Dogfood validation: all 7 checks passed
+- Branch: `main` (devrc) / `trunk` (homelab-infra) — both clean, both merged and shipped.
+- **devrc #1084 MERGED** as `fc353c67` — the dependents pre-flight guard. Verified by content on `origin/main`, not ancestry.
+- **homelab-infra #594 MERGED** as `450df373` — the quiesce declared in git. ⚠ The homelab remote is **`ZacxDev/homelab-infra`**, NOT `innovation-upstream/homelab-talos`.
+- Shipped to BOTH hosts (`ship.sh`): workbench + laptop converged and `✅ VERIFIED` at `fc353c67`.
+- Deployed skill confirmed current via `readlink -f` into `/nix/store/...-devrc-claude-skills/quiesce-workload/SKILL.md`.
 
 ### What's DONE
-- `scripts/quiesce-workload.sh` — suspend kustomization + scale to 0 + verify
-- `scripts/resume-workload.sh` — unsuspend + scale back up
-- `claude/skills/quiesce-workload/SKILL.md` — agent investigation logic (PID → cgroup → pod UID → cluster → kustomization)
-- `claude/skill-tiers.json` — entry added as tier B
-- opencode command auto-generated via `generate-commands.py` at `~/.config/opencode/commands/quiesce-workload.md`
+- `scripts/quiesce-workload.sh` — dependents pre-flight BEFORE the suspend. **exit 5** = dependents exist (named); **exit 6** = could NOT determine them (separate on purpose — a failed list query returns the same empty set an undepended-on kustomization does); `--force` overrides either and prints what it overrode.
+- `scripts/resume-workload.sh` — names the dependents that were wedged; says plainly when it could not list them.
+- `scripts/tests/test_quiesce_workload_dependents.py` — 9 hermetic tests, fake `kubectl`/`flux` via `testlib.mockbin.write_exec`. Assert the RELATIONSHIP (`flux suspend` never runs) by reading sentinel files, not the warning prose. **Red/green: 7 failed 2 passed at `bc0809f6`; 9 passed at HEAD.** Re-measured after the fakes were rewritten bash→POSIX sh. The 2 passing on both sides are labelled INVARIANT GUARDS in the file, not regression coverage.
+- homelab-infra: `stash-sense` Kustomization `suspend: true`; `stash-sense-fingerprint-kick` CronJob `suspend: true`; `aggregator`'s `dependsOn` left ALONE with a comment saying the wedge is expected.
+- Live CronJob patched imperatively to match git (see the ordering gotcha below).
 
-### What's NOT in scope
-- CronJobs matching the same workload (e.g. `stash-sense-fingerprint-kick-*`) — they were already Completed, not consuming resources
-- The actual stash-sense workload remains quiesced (suspended + scaled to 0) — resume when ready
+### Live cluster state (workbench, measured 2026-08-31)
+```
+stash-sense-fingerprint-kick   suspend=true   last fired 2026-08-30T09:00:00Z
+stash-sense    (Kustomization) suspend=true   Ready=True
+aggregator     (Kustomization) Ready=False/DependencyNotReady   ← BY DESIGN
+stash-sense    (Deployment)    0/0 replicas
+```
+
+### Verified vs not
+- Guard verified **LIVE** on the real incident case: `quiesce-workload.sh workbench media-stack stash-sense` → exit 5, names `flux-system/aggregator`, suspends nothing.
+- The **happy path** (proceeds when nothing depends on the target) is covered by TESTS ONLY — verifying it live means actually suspending a real workload.
+- The fingerprint-kick suppression is verified **by state** (`suspend=true`). Its symptom — a daily false-green no-op — next would have fired at **04:00 UTC 2026-09-01**; absence is observable then, not before.
 
 ## Open investigations — live diagnosis state
 
@@ -58,9 +68,41 @@ apply. `aggregator` is the only kustomization that dependsOn `stash-sense`.
 recorded here, and fix the tooling so the next quiesce cannot do this silently
 — `fix/quiesce-dependents-preflight`.
 
+### RESOLVED — `aggregator` wedged by the stash-sense quiesce
+Closed 2026-08-31, but the wedge is still LIVE and INTENTIONAL, so do not "fix" it.
+
+- **Still true:** `aggregator` sits at `DependencyNotReady: dependency 'flux-system/stash-sense' revision is not up to date`, pinned at `trunk@8cb6ff3a`. It is the ONLY genuinely wedged kustomization across both clusters.
+- **Nothing dropped:** 0 of the 70 commits in `8cb6ff3a..f93935de` touch `clusters/workbench/apps/aggregator`. Latent, not lossy.
+- **Two "fixes" measured and REJECTED — this is the part worth not re-deriving:**
+  - *Delete aggregator's `dependsOn` entry.* Wrong: the manifest documents it as real — `/identify/scene` face backend used by the organize step. Deletes a true declaration to make a light go green.
+  - *Declare `replicas: 0` on stash-sense and leave its Kustomization active.* This DOES un-wedge aggregator, because flux's `dependsOn` checks **Kustomization-Ready, not running pods** — which is exactly why it is wrong. Aggregator goes green while the organize step still cannot reach a face backend. A manufactured false green.
+- **Outcome:** the wedge stays as the honest signal; it clears by itself on resume.
+
+### NEW FINDING — the quiesce left a daily job reporting a false green
+- **Symptom:** `stash-sense-fingerprint-kick` ran at `2026-08-30T09:00:00Z`, AFTER the quiesce, and the Job reported `succeeded: 1`. Pod log, verbatim:
+  ```
+  fingerprint generate kick -> HTTP 000
+  stash-sense unreachable (likely mid-pass / NotReady) — soft-skip
+  ```
+- **Mechanism:** the soft-skip in `clusters/workbench/apps/stash-sense/fingerprint-cron.yaml` was written for a TRANSIENT condition (the pod goes NotReady while a CPU-bound pass blocks its event loop). It cannot distinguish that from *deliberately scaled to 0*, so the job burned its full retry window (`--retry 5 --retry-max-time 300`) daily, did nothing, and reported green.
+- **Root shape:** HTTP 000 is an empty result standing in for two different mechanisms; the handler assumes the only one that used to be possible.
+- **Fixed by:** suspending the CronJob. The 000 branch was NOT taught to distinguish the two — that is still open if anyone ever wants this to run with the backend down.
+- **Also still running deliberately:** `aggregator-organize` (4×/day). It currently succeeds only because it finds `0 unorganized staged scene(s)` — it has not yet had to call the dead backend. Left running on purpose: it either degrades to review-routing or fails visibly, both better than silently not organizing.
+
+### DECIDED AGAINST — a drift-check arm reporting non-ready kustomizations
+Proposed, then killed on measurement. Do not rebuild it without a second incident.
+- **Base rate:** depended-upon kustomizations are workbench **4/25 (16%)**, homelab **7/55 (13%)** — so the guard fires ~1 in 7 quiesces.
+- **Detection gap is REAL — five surfaces measured blind:** flux `flux-system-alerts` covers `Kustomization: *` but at `eventSeverity: error` while `DependencyNotReady` is emitted **Normal** (377 events on aggregator, zero notifications); homelab PrometheusRules 46, **0** reference flux/Kustomization; workbench has none; `standup.sh` **0** references; `drift-check.sh` **0** references; **no Grafana flux dashboards** (checked configmaps for `gotk_reconcile_condition`).
+- **Killed anyway, for three measured reasons:** (a) **zero prior incidents** — searched homelab + devrc git history and all of `claudedocs/`, the only hits are this session's own commits; (b) it would be **born permanently red** against a wedge we chose to keep — the exact trap drift-check already hit three times (rc 16, 17, 22); (c) the guard already covers the only path that has ever caused this — all 4 existing suspends were imperative `flux suspend`, 3 predate the script, and those 3 caused **0** wedges because none is in the depended-upon set.
+- **Revisit trigger:** a hand-run `flux suspend` on one of the 11 currently depended-upon kustomizations (`charts`, `clawgate`, `media-stack`, `stash-sense` on workbench; `cert-manager`, `cert-manager-root-ca`, `charts`, `charts-prom-stack`, `minio-operator`, `tekton-config`, `tekton-operator` on homelab). That is the second data point.
+
 ## Next steps (ranked)
-1. **Use the skill for future quiesces** — `/quiesce-workload <name or PID>` in opencode, or `bash scripts/quiesce-workload.sh <cluster> <namespace> <kustomization>` directly
-2. **Resume stash-sense when ready** — `bash ~/workspace/devrc/scripts/resume-workload.sh workbench media-stack stash-sense`. This also un-wedges `aggregator`; the resume script now names it so the recovery is checkable.
+1. **Resume stash-sense when the resource pressure passes** — `bash ~/workspace/devrc/scripts/resume-workload.sh workbench media-stack stash-sense`, then revert BOTH `suspend: true` values in homelab-infra (`clusters/workbench/flux-system/kustomizations/system/stash-sense.yaml` and `clusters/workbench/apps/stash-sense/fingerprint-cron.yaml`). Un-wedges `aggregator` by itself; the resume script names the dependents to re-check.
+   forcing: none
+2. **Confirm the fingerprint-kick suppression held** — after 04:00 UTC 2026-09-01, `KUBECONFIG=$KC_WORKBENCH kubectl get jobs -n media-stack | grep fingerprint` should show NO job newer than `2026-08-30T09:00:00Z`. This is the one claim in this doc verified by state rather than by symptom.
+   forcing: none
+3. **Optional: teach the HTTP 000 branch to distinguish NotReady from scaled-to-0** in `fingerprint-cron.yaml`. Blocked on a design question, not effort: the job runs in `curlimages/curl` with no kubectl, so checking replicas/endpoints needs a ServiceAccount + a different image. Only worth it if a kick job should ever run against a deliberately-quiesced backend.
+   forcing: none
 
 ## Gotchas / decisions / dead-ends
 - The kustomization name may not match the deployment name exactly — the skill teaches the agent to check `spec.targetRef`
@@ -68,21 +110,31 @@ recorded here, and fix the tooling so the next quiesce cannot do this silently
 - The listing ceiling test initially failed (over by 247 chars) — shortened the description to fit
 - Tekton gate was pending for ~10 minutes — temporarily removed branch protection to merge, then restored it
 
+- 🔴 **A CronJob inside the app dir of a SUSPENDED Kustomization can never receive its own `suspend: true`.** flux does not reconcile a suspended Kustomization, so the git change is inert and the live job keeps firing. Caught in review of my own PR. The live object must be patched imperatively: `kubectl -n media-stack patch cronjob stash-sense-fingerprint-kick -p '{"spec":{"suspend":true}}'`. The file is the record for whenever the Kustomization resumes.
+- 🔴 **`flux reconcile kustomization flux-system` makes healthy dependents look broken.** Right after the merge, 4 kustomizations that had been Ready went `DependencyNotReady`. Not damage — re-applying every Kustomization object bumps generations and dependents report `DependencyNotReady` while their dependency re-reconciles. **Control that settled it:** the untouched homelab cluster churns identically. My pre-merge baseline was a SINGLE sample, which is how normal churn reads as a regression.
+- 🔴 **LAG vs WEDGE — the discriminator, because they look identical in one sample.** *Lag*: the dependency is reconciling and advancing → clears in an interval or two (homelab `cert-manager`/`element-web` looked persistent across 3 samples and were just lag on a fast-moving trunk). *Wedge*: the dependency is SUSPENDED so its revision can never advance → permanent. Only `aggregator` is a wedge.
+- ⚠ **The homelab remote is `ZacxDev/homelab-infra`.** A sweep against `innovation-upstream/homelab-talos` returns a **404 that reads exactly like "no duplicates"**. Bit me once this session.
+- ⚠ **`nix build a b` piped to `tail` reports `tail`'s exit code.** `TIER2_EXIT=0` for a build whose status was never read. Redirect, don't pipe.
+- **`test_runtime_shebangs` will reject a test that writes its own `#!/usr/bin/env` stub** — `/usr/bin/env` does not exist in the nix build sandbox. Use `testlib.mockbin.write_exec`, and write POSIX `sh` bodies: on NixOS `/bin/sh` IS bash, so `[[ ]]` passes here and fails in the sandbox.
+- **A merged-tree gate failure may be someone else's known flake.** `test_an_absent_origin_header_is_not_the_same_as_an_empty_one` failed once; devrc #1074 fixes that exact test and its own message records it as observed "on an UNCHANGED tree". Control: pristine `origin/main` 836 passed ×2 (~237s) vs merged tree 836 passed ×2 (~242s).
+- **Trunk protection:** `ZacxDev/homelab-infra` has NO branch protection on this plan (403 — needs Pro/public). Merge = live deploy with no gate. The #594 diff was deliberately a functional no-op on the live cluster to make that safe.
+
 ## How to verify
 ```bash
-# Check skill is deployed
-ls ~/.claude/skills/quiesce-workload/SKILL.md
+# 1. The guard refuses on the real case (exit 5, names the dependent) — LIVE
+bash ~/workspace/devrc/scripts/quiesce-workload.sh workbench media-stack stash-sense; echo "EXIT=$?"
 
-# Check scripts are executable
-ls -la ~/workspace/devrc/scripts/{quiesce,resume}-workload.sh
+# 2. The tests, incl. the red/green matrix's green side
+nix develop ~/workspace/devrc -c python3 -m pytest \
+  ~/workspace/devrc/scripts/tests/test_quiesce_workload_dependents.py -q      # 9 passed
 
-# Check opencode command exists
-ls ~/.config/opencode/commands/quiesce-workload.md
+# 3. Live cluster state matches what git declares
+KUBECONFIG=$KC_WORKBENCH kubectl get cronjob stash-sense-fingerprint-kick -n media-stack \
+  -o jsonpath='{.spec.suspend}'                                               # true
+KUBECONFIG=$KC_WORKBENCH kubectl get kustomization stash-sense aggregator -n flux-system \
+  -o custom-columns=NAME:.metadata.name,SUSPEND:.spec.suspend,READY:.status.conditions[0].status
+  # stash-sense true/True ; aggregator <none>/False  <- aggregator False is CORRECT
 
-# Verify listing ceiling
-nix develop ~/workspace/devrc -c python3 -m pytest ~/workspace/devrc/scripts/tests/test_skill_descriptions.py -q
-
-# Test usage
-bash ~/workspace/devrc/scripts/quiesce-workload.sh
-bash ~/workspace/devrc/scripts/resume-workload.sh
+# 4. Only aggregator is genuinely wedged (everything else is lag)
+KUBECONFIG=$KC_WORKBENCH flux get kustomization -n flux-system | grep -v True
 ```


### PR DESCRIPTION
Updates the canonical `claudedocs/handoff-quiesce-workload.md` in place (one doc per effort).

**What changed since the doc was written:**
- devrc #1084 merged as `fc353c67` — the dependents pre-flight guard. Gated on BOTH tiers against the MERGED tree; shipped to both hosts; verified LIVE (exit 5 on the real incident case, naming `flux-system/aggregator`).
- homelab-infra #594 merged as `450df373` — the quiesce is now declared in git. It had been suspended imperatively, so the intent lived nowhere.
- **New finding:** the quiesce left `stash-sense-fingerprint-kick` firing daily against a scaled-to-0 backend, logging `HTTP 000 … soft-skip` and reporting `succeeded: 1`. Suspended.
- **A detector arm was proposed, measured, and decided AGAINST** — zero prior incidents, it would be born permanently red, and the guard already covers the only path that has ever caused this. The measurements are recorded so it isn't re-proposed blind.
- **Two tempting un-wedge 'fixes' rejected** as false greens: deleting `aggregator`'s `dependsOn` (the dependency is real), and declaring `replicas: 0` (flux checks Kustomization-Ready, not running pods).

All 3 ranked next steps declare `forcing: none` — honest: nothing external is forcing them. The effort is complete; what remains are decisions.

Subsystem index also updated: one bullet on `devrc/quiesce-workload`, one new `homelab-talos/stash-sense` entry.