### PR TITLE
feat(opencode): rig-control skill + command + 34 tests

### DIFF
--- a/claude/skills/rig-control/SKILL.md
+++ b/claude/skills/rig-control/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: rig-control
+description: "Operate the rig-control RGB gradient system — sleep/wake toggle, smooth time-of-day gradient, color schedule editing, timer management. Use for: rig-control, RGB lighting, chassis RGB, openrgb, the gradient, sleep/wake mode, color schedule, rig-control-fade, the bar toggle, monitor blackout/restore."
+---
+
+# rig-control — RGB gradient + monitor blackout
+
+Smooth time-of-day RGB gradient on the MSI motherboard chassis headers (device 2),
+with automated sleep/wake scheduling and monitor blackout/restore via DDC-CI.
+
+## Prereq guard — run this first
+
+```bash
+which openrgb >/dev/null 2>&1 || { echo "openrgb not found — rig-control is workbench-only"; exit 1; }
+```
+
+Laptop has no openrgb. All commands below are workbench-only.
+
+## Quick reference
+
+| Script | What it does |
+|---|---|
+| `rig-control.sh` | Main script: sleep/wake/blackout/restore + fade-in on wake |
+| `rig-control-fade` | One-shot gradient updater: reads config, interpolates RGB, calls openrgb. `--print` for current color |
+| `rig-control-colors.conf` | Color waypoints (edit to change schedule) |
+| `rig-control-toggle` | Bar click handler: reads state, calls wake or sleep |
+| `i3blocks-rigcontrol` | Icon-only render (☀/🌙). Click handling is in nix block definition |
+
+## State & timers
+
+```bash
+# Current state
+cat "$HOME/.cache/rig-control/state"                # → "awake" or "sleeping"
+
+# Active timers
+systemctl --user list-timers rig-control-* --no-pager
+# → rig-control-fade.timer   (every 60s — gradient)
+# → rig-control-sleep.timer  (02:30 daily)
+# → rig-control-wake.timer   (10:15 daily)
+```
+
+## Toggle sleep/wake
+
+```bash
+rig-control.sh sleep && cat ~/.cache/rig-control/state   # → sleeping
+rig-control.sh wake  && cat ~/.cache/rig-control/state   # → awake
+```
+
+`sleep` = RGB off (000000) + monitor blackout. `wake` = fade-in from black (~30s ramp) + monitor restore.
+
+## Test gradient
+
+```bash
+~/workspace/devrc/scripts/rig-control-fade --print   # → current interpolated hex color (e.g. "FF6347")
+```
+
+## Edit color schedule
+
+File: `scripts/rig-control-colors.conf`
+
+Format: `HH:MM RRGGBB` (comments and blank lines ignored). Linear interpolation between waypoints. Wraps at midnight.
+
+Current schedule:
+```
+10:00 FFA500  # amber
+11:00 FFBF00  # golden
+12:00 00CED1  # turquoise
+14:00 1E90FF  # blue
+16:00 9400D3  # violet
+17:00 FF69B4  # pink
+18:00 FF6347  # tomato (sunset)
+20:00 FF4500  # orange-red
+22:00 FF0000  # red
+00:00 8B0000  # dark red (carries through sleep)
+```
+
+Example — add a 13:00 green waypoint:
+```
+12:00 00CED1  # turquoise
+13:00 00FF00  # green
+14:00 1E90FF  # blue
+```
+
+After editing, deploy: `~/workspace/devrc/scripts/ship.sh`
+
+## Timer management
+
+```bash
+# Restart the gradient timer (e.g. after config change)
+systemctl --user restart rig-control-fade.timer
+
+# Check last fade run
+journalctl --user -u rig-control-fade -n 5 --no-pager
+
+# Manually trigger one gradient update
+systemctl --user start rig-control-fade.service
+```
+
+## Gotchas
+
+- **i3status-rust does NOT pass `$BLOCK_BUTTON`**: click handling MUST go in `[[block.click]]` nix config, not in the script.
+- **`(( )) && cmd` leaks exit code 1 under `set -e`**: use `if (( )); then ... fi` instead. This killed `do_wake()` after `fade_in()`.
+- **`date +%H` is zero-padded**: use `%-H` for case patterns like `0|1|2`.
+- **DDC/CI can fail at timer time**: `do_wake()` uses `restore || notify ... || true` so RGB stays on even if monitor restore fails.
+- **`openrgb --device 2`**: device 2 is the MSI motherboard chassis headers. Keyboard/mouse are never touched.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `scripts/rig-control.sh` | Main script |
+| `scripts/rig-control-fade` | Gradient updater |
+| `scripts/rig-control-colors.conf` | Color waypoints |
+| `scripts/rig-control-toggle` | Bar click handler |
+| `scripts/i3blocks-rigcontrol` | Icon renderer |
+| `nix/graphical.nix` | 6 systemd units: sleep/wake/fade timers + services |

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1977,6 +1977,10 @@ in
     config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/dl-router/SKILL.md";
   home.file.".config/opencode/skills/dl-router/dl-route".source =
     config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/dl-router/dl-route";
+  # rig-control: hand-written command (with !` shell injection) overrides the
+  # auto-generated one (which would just copy the skill body verbatim).
+  home.file.".config/opencode/commands/rig-control.md".source =
+    config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/opencode/commands/rig-control.md";
   # 🔴 clickup used to need a mkOutOfStoreSymlink here, pointing opencode's copy at
   # ~/.claude/skills/clickup — the standalone, uncommitted checkout that lived only
   # on this host. Now that the skill is IN `claude/skills/`, the recursive mapping

--- a/scripts/opencode/commands/rig-control.md
+++ b/scripts/opencode/commands/rig-control.md
@@ -1,0 +1,21 @@
+---
+description: "Rig-control: check status, toggle sleep/wake, edit colors, restart timers. Args: (none)=status, sleep, wake, colors, edit, restart."
+---
+
+Rig-control RGB gradient system — workbench only.
+
+Current state:
+!`cat "$HOME/.cache/rig-control/state" 2>/dev/null || echo "no state file"`
+Active timers:
+!`systemctl --user list-timers rig-control-* --no-pager 2>/dev/null || echo "no timers"`
+Current gradient color:
+!`~/workspace/devrc/scripts/rig-control-fade --print 2>/dev/null || echo "cannot read"`
+
+Action requested: $ARGUMENTS
+
+- No args or "status": show the above and summarize.
+- "sleep": run `rig-control.sh sleep`, verify state changed to "sleeping".
+- "wake": run `rig-control.sh wake`, verify state changed to "awake".
+- "colors": show `scripts/rig-control-colors.conf` with current time bracket highlighted.
+- "edit": guide the user through editing the color schedule — show current, ask what to change, remind to `ship.sh` after.
+- "restart": run `systemctl --user restart rig-control-fade.timer` and verify it's active.

--- a/scripts/tests/test_opencode_rig_control.py
+++ b/scripts/tests/test_opencode_rig_control.py
@@ -1,0 +1,256 @@
+"""Tests for the rig-control opencode skill and command.
+
+WHAT IS UNDER TEST
+
+  1. Skill SKILL.md validity — frontmatter (name, description), body sections,
+     name-directory match, description length bounds.
+  2. Command .md validity — frontmatter, template has $ARGUMENTS placeholder,
+     shell output injection via backtick syntax.
+  3. Referenced scripts exist in the repo.
+  4. Color schedule file is parseable and non-empty.
+  5. Skill + command are consistent — command references the same scripts the
+     skill documents.
+
+    run:  python -m pytest scripts/tests/test_opencode_rig_control.py -q
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+
+SKILL_DIR = Path.home() / ".config" / "opencode" / "skills" / "rig-control"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+COMMAND_DIR = Path.home() / ".config" / "opencode" / "commands"
+COMMAND_MD = COMMAND_DIR / "rig-control.md"
+
+# Scripts referenced in the skill
+SCRIPTS = [
+    "scripts/rig-control.sh",
+    "scripts/rig-control-fade",
+    "scripts/rig-control-colors.conf",
+    "scripts/rig-control-toggle",
+    "scripts/i3blocks-rigcontrol",
+]
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _parse_frontmatter(text: str) -> dict[str, str]:
+    """Extract YAML frontmatter from a markdown file."""
+    m = re.match(r"^---\n(.+?)\n---", text, re.DOTALL)
+    if not m:
+        return {}
+    fm = {}
+    for line in m.group(1).splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m2 = re.match(r'^(\w[\w-]*):\s*"((?:[^"\\]|\\.)*)"\s*$', line)
+        if m2:
+            fm[m2.group(1)] = m2.group(2)
+            continue
+        m2 = re.match(r"^(\w[\w-]*):\s*'([^']*)'\s*$", line)
+        if m2:
+            fm[m2.group(1)] = m2.group(2)
+            continue
+        m2 = re.match(r"^(\w[\w-]*):\s*(.+?)\s*$", line)
+        if m2:
+            fm[m2.group(1)] = m2.group(2)
+    return fm
+
+
+# --------------------------------------------------------------------------- #
+# skill tests
+# --------------------------------------------------------------------------- #
+class TestSkillFrontmatter:
+    def test_skill_file_exists(self):
+        assert SKILL_MD.exists(), f"Skill file not found: {SKILL_MD}"
+
+    def test_has_frontmatter(self):
+        text = SKILL_MD.read_text()
+        assert text.startswith("---"), "SKILL.md must start with YAML frontmatter"
+
+    def test_name_matches_directory(self):
+        fm = _parse_frontmatter(SKILL_MD.read_text())
+        assert fm.get("name") == "rig-control", (
+            f"Skill name {fm.get('name')!r} must match directory name 'rig-control'"
+        )
+
+    def test_name_format(self):
+        fm = _parse_frontmatter(SKILL_MD.read_text())
+        name = fm.get("name", "")
+        assert re.match(r"^[a-z0-9]+(-[a-z0-9]+)*$", name), (
+            f"Name {name!r} must be lowercase alphanumeric with single-hyphen separators"
+        )
+
+    def test_description_exists(self):
+        fm = _parse_frontmatter(SKILL_MD.read_text())
+        assert "description" in fm, "SKILL.md must have a description"
+        assert len(fm["description"]) > 0, "description must not be empty"
+
+    def test_description_length(self):
+        fm = _parse_frontmatter(SKILL_MD.read_text())
+        desc = fm.get("description", "")
+        assert len(desc) <= 1024, (
+            f"description is {len(desc)} chars, max is 1024"
+        )
+
+
+class TestSkillBody:
+    def _body(self) -> str:
+        text = SKILL_MD.read_text()
+        m = re.match(r"^---\n(.+?)\n---\n(.*)", text, re.DOTALL)
+        return m.group(2) if m else ""
+
+    def test_has_prereq_guard(self):
+        body = self._body()
+        assert "which openrgb" in body, "Body must include openrgb prereq guard"
+
+    def test_has_quick_reference(self):
+        body = self._body()
+        assert "rig-control.sh" in body, "Body must reference rig-control.sh"
+        assert "rig-control-fade" in body, "Body must reference rig-control-fade"
+
+    def test_has_state_section(self):
+        body = self._body()
+        assert "rig-control/state" in body, "Body must reference state file"
+        assert "list-timers" in body, "Body must reference timer listing"
+
+    def test_has_toggle_section(self):
+        body = self._body()
+        assert "rig-control.sh sleep" in body, "Body must document sleep toggle"
+        assert "rig-control.sh wake" in body, "Body must document wake toggle"
+
+    def test_has_gradient_section(self):
+        body = self._body()
+        assert "--print" in body, "Body must document --print flag"
+
+    def test_has_color_schedule_section(self):
+        body = self._body()
+        assert "rig-control-colors.conf" in body, "Body must reference color config"
+        assert "HH:MM RRGGBB" in body, "Body must document color format"
+
+    def test_has_gotchas(self):
+        body = self._body()
+        assert "BLOCK_BUTTON" in body, "Body must mention i3status-rust click gotcha"
+        assert "set -e" in body, "Body must mention (( )) && gotcha"
+        assert "device 2" in body, "Body must mention openrgb device 2"
+
+    def test_has_files_table(self):
+        body = self._body()
+        assert "nix/graphical.nix" in body, "Body must reference nix unit definitions"
+
+
+class TestSkillScriptsExist:
+    @pytest.mark.parametrize("script", SCRIPTS)
+    def test_script_exists(self, script):
+        path = REPO / script
+        assert path.exists(), f"Referenced script not found: {script}"
+
+
+class TestColorSchedule:
+    def test_colors_conf_exists(self):
+        path = REPO / "scripts/rig-control-colors.conf"
+        assert path.exists(), "rig-control-colors.conf not found"
+
+    def test_colors_conf_parseable(self):
+        path = REPO / "scripts/rig-control-colors.conf"
+        lines = path.read_text().splitlines()
+        parsed = 0
+        for line in lines:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split()
+            assert len(parts) >= 2, f"Bad line: {line!r}"
+            time_str, hex_str = parts[0], parts[1]
+            assert re.match(r"^\d{1,2}:\d{2}$", time_str), f"Bad time: {time_str!r}"
+            assert re.match(r"^[0-9A-Fa-f]{6}$", hex_str), f"Bad hex: {hex_str!r}"
+            parsed += 1
+        assert parsed >= 3, f"Expected at least 3 waypoints, got {parsed}"
+
+
+# --------------------------------------------------------------------------- #
+# command tests
+# --------------------------------------------------------------------------- #
+class TestCommandFrontmatter:
+    def test_command_file_exists(self):
+        assert COMMAND_MD.exists(), f"Command file not found: {COMMAND_MD}"
+
+    def test_has_frontmatter(self):
+        text = COMMAND_MD.read_text()
+        assert text.startswith("---"), "Command must start with YAML frontmatter"
+
+    def test_has_description(self):
+        fm = _parse_frontmatter(COMMAND_MD.read_text())
+        assert "description" in fm, "Command must have a description"
+        assert len(fm["description"]) > 0, "description must not be empty"
+
+    def test_description_length(self):
+        fm = _parse_frontmatter(COMMAND_MD.read_text())
+        desc = fm.get("description", "")
+        assert len(desc) <= 1024, (
+            f"description is {len(desc)} chars, max is 1024"
+        )
+
+
+class TestCommandBody:
+    def _body(self) -> str:
+        text = COMMAND_MD.read_text()
+        m = re.match(r"^---\n(.+?)\n---\n(.*)", text, re.DOTALL)
+        return m.group(2) if m else ""
+
+    def test_has_arguments_placeholder(self):
+        body = self._body()
+        assert "$ARGUMENTS" in body, "Command template must use $ARGUMENTS"
+
+    def test_has_shell_injection(self):
+        body = self._body()
+        assert "!`" in body, "Command must inject shell output via backtick syntax"
+
+    def test_injects_state(self):
+        body = self._body()
+        assert "rig-control/state" in body, "Command must inject state file"
+
+    def test_injects_timers(self):
+        body = self._body()
+        assert "list-timers" in body, "Command must inject timer listing"
+
+    def test_injects_gradient(self):
+        body = self._body()
+        assert "rig-control-fade" in body, "Command must inject gradient color"
+
+    def test_documents_actions(self):
+        body = self._body()
+        for action in ["sleep", "wake", "colors", "edit", "restart"]:
+            assert action in body, f"Command must document action: {action}"
+
+
+# --------------------------------------------------------------------------- #
+# consistency: skill and command agree
+# --------------------------------------------------------------------------- #
+class TestConsistency:
+    def test_skill_and_command_both_reference_rig_control_sh(self):
+        skill_body = SKILL_MD.read_text()
+        cmd_body = COMMAND_MD.read_text()
+        assert "rig-control.sh" in skill_body
+        assert "rig-control.sh" in cmd_body
+
+    def test_skill_and_command_both_reference_rig_control_fade(self):
+        skill_body = SKILL_MD.read_text()
+        cmd_body = COMMAND_MD.read_text()
+        assert "rig-control-fade" in skill_body
+        assert "rig-control-fade" in cmd_body
+
+    def test_skill_name_matches_command_name(self):
+        skill_fm = _parse_frontmatter(SKILL_MD.read_text())
+        cmd_name = COMMAND_MD.stem  # filename without .md
+        assert skill_fm.get("name") == cmd_name, (
+            f"Skill name {skill_fm.get('name')!r} != command name {cmd_name!r}"
+        )


### PR DESCRIPTION
New opencode skill for the rig-control RGB gradient system.

**Files:**
-  — full subsystem reference (prereq guard, state, toggle, gradient, color editing, timers, gotchas, files)
-  — hand-written command with `!` shell injection for live state/timer/color output
-  — 34 tests (frontmatter, body, scripts, color schedule, command template, consistency)
-  — `mkOutOfStoreSymlink` override for the command (like browser and dl-router)

**Why hand-written command:** The auto-generated command from `generate-commands.py` would just copy the skill body verbatim, losing the `!` backtick syntax that executes shell commands and injects live output. The hand-written version shows real state, timers, and gradient color.

**Validated:** Blind dogfood dispatch — all 4 commands succeeded (openrgb check, state read, timers, gradient color).

**Next steps:** Tier in `claude/skill-tiers.json` (tier A — must auto-fire from RGB/lighting symptoms).