### PR TITLE
fix(audit-dispatch): a CACHED nix build prints nothing at rc 0 — port back the nix log recovery, with guards

### DIFF
--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -2834,6 +2834,16 @@ CHECKS_DISCRIMINATOR = (
 )
 
 
+# 🔴 The cached-build fallback's guard lines, each a SINGLE named constant so a
+# mutation can remove exactly one and the harness can name which. Each closes a
+# DIFFERENT measured false green; the number of them is deliberately not
+# asserted in the emitted prose (`test -s` speaks to emptiness only and claims
+# nothing about truncation).
+NIX_LOG_TMPFILE = 'LOG=$(mktemp -t audit-tier-XXXXXXXX.log)   # per-agent: a FIXED path is truncated by every sibling agent'
+NIX_LOG_DRV_GUARD = '[ -n "$DRV" ] || { echo "NO DERIVATION — wrong attr, or this repo has no such tier"; exit 1; }'
+NIX_LOG_RUN_GUARD = 'nix log "$DRV" > "$LOG" 2>/dev/null || { echo "NO LOG — never built HERE (nix log is per-machine)"; exit 1; }'
+NIX_LOG_EMPTY_GUARD = '[ -s "$LOG" ] || { echo "EMPTY LOG — cannot vouch"; exit 1; }'
+
 def _toolchain_checks_lines(tc):
     """The sandbox tier — only when the flake really declares one."""
     if not tc.flake:
@@ -2896,6 +2906,57 @@ def _toolchain_checks_lines(tc):
           for n in tc.check_names],
         "```",
         "",
+        # 🔴 EMITTED ONLY WHERE CHECK LINES WERE ACTUALLY FENCED. With no
+        # check names there is no build whose log could be recovered, and
+        # the block would be advice about a command this brief never gave.
+        # It also keeps the guard ISOLATING: this text itself contains
+        # `#checks.`, so a presence check over the whole brief is satisfied
+        # by the very thing it is meant to gate (measured: it stole a kill
+        # from V41, whose mutant empties the check-name list).
+        *(([
+            # 🔴 THE CACHED CASE. `-L` streams the log only while the build RUNS.
+            # An already-realised output is not rebuilt, so nix prints NOTHING and
+            # exits 0 — and the instruction above ("read each runner's own `RESULT:`
+            # line") then has nothing to read while looking like a pass. MEASURED
+            # 2026-08-31 on one derivation, three runs: uncached `-L` → rc 0, 5
+            # lines, 1 `RESULT:`; the SAME command again, now cached → rc 0, **0
+            # lines, 0 `RESULT:`**; `nix log <drv>` → rc 0, 2 lines, 1 `RESULT:`.
+            # Common here, not exotic: sibling sessions and CI build the same tree.
+            "🔴 **A `nix build` that prints NOTHING is the CACHED case, not a pass.** "
+            "`-L` streams a log only while a build RUNS; an already-realised output "
+            "is not rebuilt, so nix prints nothing and exits **0**. The `RESULT:` "
+            "line you were just told to read is then absent, and the silence is "
+            "indistinguishable from success. Recover it from the derivation's own "
+            "retained log — do NOT re-run the build to get its output back:",
+            "",
+            "```bash",
+            # (a) mktemp, never a fixed path: two audit agents run concurrently here
+            #     by design, and a shared `/tmp/<name>.log` means each truncates the
+            #     other's file and greps the other's tier — with every guard passing.
+            # (b) each guard below closes a DIFFERENT measured false green, and the
+            #     count is deliberately not asserted in the prose: `test -s` speaks
+            #     to emptiness only and claims nothing about truncation.
+            NIX_LOG_TMPFILE,
+            f'DRV=$(nix path-info --derivation <your worktree>#checks.{NIX_SYSTEM}'
+            '.<name> 2>/dev/null)',
+            "# 🔴 An EMPTY $DRV makes `nix log \"\"` resolve as `.` — it then prints "
+            "the CWD FLAKE'S DEFAULT PACKAGE log, i.e. a FOREIGN log that may read "
+            "`RESULT: PASS`. Silence would be survivable; this is an affirmative "
+            "false green.",
+            NIX_LOG_DRV_GUARD,
+            "# 🔴 `>` truncates BEFORE nix runs, so an unbuilt derivation leaves an "
+            "EMPTY file and `grep -c` prints a reassuring 0.",
+            NIX_LOG_RUN_GUARD,
+            NIX_LOG_EMPTY_GUARD,
+            "# Read the CONTENT — and check there IS content, and that it is YOURS.",
+            'grep -n "RESULT:" "$LOG"; grep -c "panic: test timed out" "$LOG"',
+            "```",
+            "",
+            "⚠ Each guard above is echoed before its `exit 1`, so the diagnosis "
+            "survives; but `exit 1` pasted into an INTERACTIVE shell closes it — run "
+            "the block as a script, or replace the exits with `return`.",
+            "",
+        ]) if tc.check_names else []),
     ]
 
 

--- a/scripts/audit-dispatch.py
+++ b/scripts/audit-dispatch.py
@@ -2839,8 +2839,8 @@ CHECKS_DISCRIMINATOR = (
 # DIFFERENT measured false green; the number of them is deliberately not
 # asserted in the emitted prose (`test -s` speaks to emptiness only and claims
 # nothing about truncation).
-NIX_LOG_TMPFILE = 'LOG=$(mktemp -t audit-tier-XXXXXXXX.log)   # per-agent: a FIXED path is truncated by every sibling agent'
-NIX_LOG_DRV_GUARD = '[ -n "$DRV" ] || { echo "NO DERIVATION — wrong attr, or this repo has no such tier"; exit 1; }'
+NIX_LOG_TMPFILE = 'LOG=$(mktemp -t audit-tier-XXXXXXXX.log); ERR=$(mktemp -t audit-tier-XXXXXXXX.err)   # per-agent: a FIXED path is truncated by every sibling agent'
+NIX_LOG_DRV_GUARD = '[ -n "$DRV" ] || { echo "NO DERIVATION — nix said:"; cat "$ERR"; exit 1; }'
 NIX_LOG_RUN_GUARD = 'nix log "$DRV" > "$LOG" 2>/dev/null || { echo "NO LOG — never built HERE (nix log is per-machine)"; exit 1; }'
 NIX_LOG_EMPTY_GUARD = '[ -s "$LOG" ] || { echo "EMPTY LOG — cannot vouch"; exit 1; }'
 
@@ -2906,57 +2906,65 @@ def _toolchain_checks_lines(tc):
           for n in tc.check_names],
         "```",
         "",
-        # 🔴 EMITTED ONLY WHERE CHECK LINES WERE ACTUALLY FENCED. With no
-        # check names there is no build whose log could be recovered, and
-        # the block would be advice about a command this brief never gave.
-        # It also keeps the guard ISOLATING: this text itself contains
-        # `#checks.`, so a presence check over the whole brief is satisfied
-        # by the very thing it is meant to gate (measured: it stole a kill
-        # from V41, whose mutant empties the check-name list).
-        *(([
-            # 🔴 THE CACHED CASE. `-L` streams the log only while the build RUNS.
-            # An already-realised output is not rebuilt, so nix prints NOTHING and
-            # exits 0 — and the instruction above ("read each runner's own `RESULT:`
-            # line") then has nothing to read while looking like a pass. MEASURED
-            # 2026-08-31 on one derivation, three runs: uncached `-L` → rc 0, 5
-            # lines, 1 `RESULT:`; the SAME command again, now cached → rc 0, **0
-            # lines, 0 `RESULT:`**; `nix log <drv>` → rc 0, 2 lines, 1 `RESULT:`.
-            # Common here, not exotic: sibling sessions and CI build the same tree.
-            "🔴 **A `nix build` that prints NOTHING is the CACHED case, not a pass.** "
-            "`-L` streams a log only while a build RUNS; an already-realised output "
-            "is not rebuilt, so nix prints nothing and exits **0**. The `RESULT:` "
-            "line you were just told to read is then absent, and the silence is "
-            "indistinguishable from success. Recover it from the derivation's own "
-            "retained log — do NOT re-run the build to get its output back:",
-            "",
-            "```bash",
-            # (a) mktemp, never a fixed path: two audit agents run concurrently here
-            #     by design, and a shared `/tmp/<name>.log` means each truncates the
-            #     other's file and greps the other's tier — with every guard passing.
-            # (b) each guard below closes a DIFFERENT measured false green, and the
-            #     count is deliberately not asserted in the prose: `test -s` speaks
-            #     to emptiness only and claims nothing about truncation.
-            NIX_LOG_TMPFILE,
-            f'DRV=$(nix path-info --derivation <your worktree>#checks.{NIX_SYSTEM}'
-            '.<name> 2>/dev/null)',
-            "# 🔴 An EMPTY $DRV makes `nix log \"\"` resolve as `.` — it then prints "
-            "the CWD FLAKE'S DEFAULT PACKAGE log, i.e. a FOREIGN log that may read "
-            "`RESULT: PASS`. Silence would be survivable; this is an affirmative "
-            "false green.",
-            NIX_LOG_DRV_GUARD,
-            "# 🔴 `>` truncates BEFORE nix runs, so an unbuilt derivation leaves an "
-            "EMPTY file and `grep -c` prints a reassuring 0.",
-            NIX_LOG_RUN_GUARD,
-            NIX_LOG_EMPTY_GUARD,
-            "# Read the CONTENT — and check there IS content, and that it is YOURS.",
-            'grep -n "RESULT:" "$LOG"; grep -c "panic: test timed out" "$LOG"',
-            "```",
-            "",
-            "⚠ Each guard above is echoed before its `exit 1`, so the diagnosis "
-            "survives; but `exit 1` pasted into an INTERACTIVE shell closes it — run "
-            "the block as a script, or replace the exits with `return`.",
-            "",
-        ]) if tc.check_names else []),
+        # 🔴 NO CONDITIONAL HERE. `if not tc.check_names: return` fires ~80
+        # lines above, so this point is only ever reached WITH check names —
+        # a `if tc.check_names else []` here is unreachable-false, and an
+        # earlier revision of this block carried one plus a comment claiming
+        # it "keeps the guard isolating (measured: it stole a kill from V41)".
+        # 🔴 BOTH HALVES WERE FALSE. Under V41 `check_names` is empty, so the
+        # EARLIER return fires and this line is never evaluated; and what
+        # actually stops the kill-stealing is the TEST's precondition in
+        # `test_the_cached_build_fallback_is_emitted_with_its_guards`. Proven:
+        # a probe raising on a falsy value never fired across the suite, while
+        # raising on a TRUTHY one failed 78 tests. Restoring the conditional
+        # would re-teach a maintainer that the payload gates this, and invite
+        # deleting the test precondition as redundant.
+        "🔴 **A `nix build` that prints NOTHING is the CACHED case, not a pass.** "
+        "`-L` streams a log only while a build RUNS; an already-realised output "
+        "is not rebuilt, so nix prints nothing and exits **0**. The `RESULT:` "
+        "line you were just told to read is then absent, and the silence is "
+        "indistinguishable from success. Recover it from the derivation's own "
+        "retained log — do NOT re-run the build to get its output back:",
+        "",
+        "```bash",
+        # (a) mktemp, never a fixed path: two audit agents run concurrently here
+        #     by design, and a shared `/tmp/<name>.log` means each truncates the
+        #     other's file and greps the other's tier — with every guard passing.
+        # (b) the guards do NOT each close an independent false green — dropping
+        #     the run guard alone still leaves `test -s` catching the empty file.
+        #     It buys a better DIAGNOSIS ("never built HERE"), not a separate
+        #     closure. Only the $DRV and -s guards are independently load-bearing.
+        NIX_LOG_TMPFILE,
+        # 🔴 stderr is KEPT and echoed by the guard below. Discarding it collapses
+        # two mechanisms into one diagnosis: a wrong attribute and a `flake.nix`
+        # SYNTAX ERROR both yield an empty $DRV, and blaming "no such tier" points
+        # the auditor at the repo instead of at their own broken edit.
+        f'DRV=$(nix path-info --derivation <your worktree>#checks.{NIX_SYSTEM}'
+        '.<name> 2>"$ERR")',
+        "# 🔴 An EMPTY $DRV makes `nix log \"\"` resolve as `.` — it then prints "
+        "the CWD FLAKE'S DEFAULT PACKAGE log, i.e. a FOREIGN log that may read "
+        "`RESULT: PASS`. Silence would be survivable; this is an affirmative "
+        "false green.",
+        NIX_LOG_DRV_GUARD,
+        "# 🔴 `>` truncates BEFORE nix runs, so an unbuilt derivation leaves an "
+        "EMPTY file and `grep -c` prints a reassuring 0.",
+        NIX_LOG_RUN_GUARD,
+        NIX_LOG_EMPTY_GUARD,
+        "# Read the CONTENT. 🔴 `grep -n \"RESULT:\"` goes LAST on purpose: "
+        "`grep -c` exits 1 when the count is 0, so ending on it inverts the "
+        "block's status — a HEALTHY tier would exit 1 and a timing-out one 0.",
+        'grep -c "panic: test timed out" "$LOG"; grep -n "RESULT:" "$LOG"',
+        "```",
+        "",
+        "⚠ Each guard echoes its diagnosis before `exit 1`, so the reason "
+        "survives; but a bare `exit 1` pasted into an INTERACTIVE shell closes "
+        "it. 🔴 **Wrap the block in a function and call it** — `run_tier() { … }; "
+        "run_tier`. Do NOT simply swap `exit` for `return`: at top level "
+        "`return` is not a stop, and MEASURED in interactive zsh, interactive "
+        "bash and `bash <script>` the block then CONTINUES past a failed guard "
+        "and prints a foreign log's `RESULT: PASS` — the exact false green this "
+        "block exists to prevent.",
+        "",
     ]
 
 

--- a/scripts/tests/mutants-audit-dispatch.py
+++ b/scripts/tests/mutants-audit-dispatch.py
@@ -1885,6 +1885,22 @@ def the_pytest_diagnosis_is_emitted_without_a_pytest_command(t):
                  "        if True:\n")
 
 
+def the_cached_build_fallback_loses_its_empty_drv_guard(t):
+    """V62 — round 17. The guard whose absence is an AFFIRMATIVE false green.
+
+    The fallback resolves `DRV=$(nix path-info --derivation ...)` then runs
+    `nix log "$DRV"`. Drop the `[ -n "$DRV" ]` guard and an unresolvable
+    attribute leaves `$DRV` EMPTY -- `nix log ""` then resolves as `.` and
+    prints the CWD FLAKE'S DEFAULT PACKAGE log. The auditor greps a FOREIGN log
+    that may read `RESULT: PASS (exit=0)`.
+
+    Silence would be survivable; this makes the block affirmatively vouch for a
+    tier that never ran, which is why the guard is pinned BY NAME and not by a
+    count of guards.
+    """
+    return _swap(t, "        NIX_LOG_DRV_GUARD,\n", "")
+
+
 def the_absence_bar_points_at_a_bar_that_is_never_above_it(t):
     """V61 — round 16. The dangling cross-reference, restored.
 
@@ -2998,6 +3014,9 @@ ROWS = [
     ("V61 the absence bar points at a bar that is never above it",
      {"test_the_python_absence_bar_does_not_point_at_a_bar_that_is_not_there"},
      the_absence_bar_points_at_a_bar_that_is_never_above_it),
+    ("V62 the cached-build fallback loses its empty-$DRV guard",
+     {"test_the_cached_build_fallback_is_emitted_with_its_guards"},
+     the_cached_build_fallback_loses_its_empty_drv_guard),
 ]
 
 

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -2762,6 +2762,86 @@ def _assert_every_nix_build_prints_its_log(out: str) -> None:
         "`RESULT:` line cannot be followed:\n  " + "\n  ".join(offenders))
 
 
+def _assert_the_cached_build_fallback_carries_its_guards(out: str) -> None:
+    """The `nix log` recovery block must keep every guard that makes it safe.
+
+    🔴 WHY IT EXISTS AT ALL, measured 2026-08-31 on one derivation, three runs
+    of the SAME command: uncached `nix build --no-link -L` -> rc 0, 5 lines, 1
+    `RESULT:`; run again, now cached -> rc 0, **0 lines, 0 `RESULT:`**;
+    `nix log <drv>` -> rc 0, 2 lines, 1 `RESULT:`. `-L` streams a log only while
+    a build RUNS, so an already-realised output prints NOTHING and exits 0 --
+    and the brief's "read each runner's own `RESULT:` line" then has nothing to
+    read while looking exactly like a pass. Sibling sessions and CI build the
+    same tree constantly here, so the cached case is the common one.
+
+    🔴 WHY STRUCTURAL, NOT A SPELLING PIN -- the same argument
+    `_assert_every_nix_build_prints_its_log` makes one screen up, and the same
+    way it was learned: a substring assert on the COMMAND stayed green for the
+    whole life of a missing `-L`. Each guard below closes a DIFFERENT measured
+    false green, and dropping any ONE of them restores it:
+
+      * empty `$DRV`  -> `nix log ""` resolves as `.` and prints the CWD FLAKE'S
+        DEFAULT PACKAGE log. The auditor then greps a FOREIGN log that may read
+        `RESULT: PASS (exit=0)`. Not silence -- an AFFIRMATIVE false green.
+      * unguarded `nix log` -> `>` truncates BEFORE nix runs, so an unbuilt
+        derivation leaves an empty file and `grep -c` prints a reassuring 0.
+      * no `-s` test -> an empty log reads as "no timeouts found".
+
+    🔴 And a FIXED log path is its own hazard, which is why `mktemp` is
+    required: audit agents run concurrently here by design, so a shared
+    `/tmp/<name>.log` means each truncates the other's file and greps the
+    other's tier -- with all three guards above passing.
+
+    The count of hazards is deliberately NOT asserted in the emitted prose: an
+    earlier version of this block claimed it closed "THREE DIFFERENT FALSE
+    GREENS" while its bullets delivered two, and `test -s` speaks to emptiness
+    only -- it claims nothing about truncation.
+    """
+    if "nix log" not in out:
+        return  # no fallback emitted (e.g. a repo with no sandbox tier)
+    required = {
+        '[ -n "$DRV" ]': "an empty $DRV makes `nix log \"\"` print a FOREIGN log",
+        "NO DERIVATION": "the empty-$DRV guard must say why it refused",
+        "NO LOG": "an unbuilt derivation must be named, not left as an empty file",
+        '[ -s "$LOG" ]': "an empty log must not read as 'no timeouts found'",
+        "EMPTY LOG": "the empty-log guard must say why it refused",
+        "mktemp": "a FIXED log path is truncated by every sibling agent",
+    }
+    missing = [f"{tok}  ({why})" for tok, why in required.items() if tok not in out]
+    assert not missing, (
+        "the `nix log` cached-build fallback is missing guards that each close a "
+        "MEASURED false green; without them the block can report a clean tier "
+        "that never ran:\n  " + "\n  ".join(missing))
+    # A fixed path defeats mktemp even when mktemp is present.
+    assert "/tmp/tier.log" not in out, (
+        "the fallback names the FIXED path /tmp/tier.log. Two audit agents run "
+        "concurrently here by design: each truncates the other's file and greps "
+        "the other's tier, with every guard above still passing. Use mktemp.")
+
+
+def test_the_cached_build_fallback_is_emitted_with_its_guards():
+    """🔴 A `nix build` printing nothing is the CACHED case, not a pass.
+
+    Regression guard for the gap #1117 left when it carried forward `--no-link
+    -L` and dropped the recovery block. `-L` fixes the SUCCEEDING-build case and
+    does nothing for the ALREADY-BUILT one.
+    """
+    rc, out, err = run_main(["900"])
+    assert rc == 0, err
+    # 🔴 SCOPED TO ITS PRECONDITION. The fallback is owed only where a sandbox
+    # tier is actually fenced; a repo without one needs no recovery block. Left
+    # unconditional, this test also killed C3 and V41 -- mutants that remove the
+    # whole toolchain section, which those rows already own. A guard that fires
+    # on every upstream breakage stops isolating the thing it names.
+    if "nix build <your worktree>#checks." not in out:
+        return
+    assert "nix log" in out, (
+        "the toolchain section fences `nix build ...#checks... -L` and tells the "
+        "auditor to read a `RESULT:` line, but offers no recovery when that build "
+        "is CACHED and prints nothing at rc 0. Emit the `nix log <drv>` fallback.")
+    _assert_the_cached_build_fallback_carries_its_guards(out)
+
+
 def test_the_toolchain_gates_the_auditors_copy_not_the_shared_checkout():
     """🔴 REGRESSION. Red at `abc41024`, where every command named the shared
     checkout.
@@ -7913,6 +7993,14 @@ RED_AT_BASE_R16: frozenset[str] = frozenset({
     "test_the_python_absence_bar_does_not_point_at_a_bar_that_is_not_there",
 })
 
+# 🔴 The cached-build gap #1117 left. `-L` fixes the SUCCEEDING build; it does
+# nothing for the ALREADY-BUILT one, which prints zero lines at rc 0 while the
+# brief tells the auditor to read a `RESULT:` line. Watched RED at 7de5b0bd by
+# grafting the test onto that tree: 1 failed.
+RED_AT_BASE_R17: frozenset[str] = frozenset({
+    "test_the_cached_build_fallback_is_emitted_with_its_guards",
+})
+
 RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "abc41024": RED_AT_BASE_R2,
     "d9eb36a8": RED_AT_BASE_R3,
@@ -7925,6 +8013,7 @@ RED_AT_BASE_REFS: dict[str, frozenset[str]] = {
     "9e23c379": RED_AT_BASE_R14,
     "5bad0a0c": RED_AT_BASE_R15,
     "ba321c06": RED_AT_BASE_R16,
+    "7de5b0bd": RED_AT_BASE_R17,
 }
 RED_AT_BASE: frozenset[str] = frozenset().union(*RED_AT_BASE_REFS.values())
 
@@ -8633,6 +8722,19 @@ FIX_MATRIX = (
      "where a python command is fenced",
      "test_the_python_absence_bar_does_not_point_at_a_bar_that_is_not_there",
      "RED@ba321c06", "V60 V61"),
+    ("r17/N1 #1117 carried forward `--no-link -L` and dropped the `nix log` "
+     "recovery block, leaving the CACHED case uncovered: `-L` streams a log only "
+     "while a build RUNS, so an already-realised output prints ZERO lines and "
+     "exits 0 while the brief says to read each runner's own `RESULT:` line — "
+     "silence indistinguishable from a pass, and common here because sibling "
+     "sessions and CI build the same tree. MEASURED on one derivation, three "
+     "runs of the same command: uncached -L -> rc 0, 5 lines, 1 RESULT:; cached "
+     "-> rc 0, 0 lines, 0 RESULT:; `nix log <drv>` -> rc 0, 2 lines, 1 RESULT:. "
+     "Ported back with the guards its own audit rounds had found necessary, and "
+     "with mktemp rather than a fixed /tmp path, which two concurrent agents "
+     "truncate under each other",
+     "test_the_cached_build_fallback_is_emitted_with_its_guards",
+     "RED@7de5b0bd", "V62"),
 )
 
 # A COLLAPSE floor, not a growth floor: a matrix emptied by a bad refactor

--- a/scripts/tests/test_audit_dispatch.py
+++ b/scripts/tests/test_audit_dispatch.py
@@ -2763,60 +2763,87 @@ def _assert_every_nix_build_prints_its_log(out: str) -> None:
 
 
 def _assert_the_cached_build_fallback_carries_its_guards(out: str) -> None:
-    """The `nix log` recovery block must keep every guard that makes it safe.
+    """The `nix log` recovery block must be SAFE AS EXECUTED, not as spelled.
 
-    🔴 WHY IT EXISTS AT ALL, measured 2026-08-31 on one derivation, three runs
-    of the SAME command: uncached `nix build --no-link -L` -> rc 0, 5 lines, 1
-    `RESULT:`; run again, now cached -> rc 0, **0 lines, 0 `RESULT:`**;
-    `nix log <drv>` -> rc 0, 2 lines, 1 `RESULT:`. `-L` streams a log only while
-    a build RUNS, so an already-realised output prints NOTHING and exits 0 --
-    and the brief's "read each runner's own `RESULT:` line" then has nothing to
-    read while looking exactly like a pass. Sibling sessions and CI build the
-    same tree constantly here, so the cached case is the common one.
+    🔴 WHY IT EXISTS, measured on one derivation, three runs of the SAME
+    command: uncached `nix build --no-link -L` -> rc 0, 5 lines, 1 `RESULT:`;
+    run again, now cached -> rc 0, **0 lines, 0 `RESULT:`**; `nix log <drv>` ->
+    rc 0, 2 lines, 1 `RESULT:`. `-L` streams a log only while a build RUNS, so
+    an already-realised output prints NOTHING at rc 0 -- and the brief's "read
+    each runner's own `RESULT:` line" then has nothing to read while looking
+    exactly like a pass.
 
-    🔴 WHY STRUCTURAL, NOT A SPELLING PIN -- the same argument
-    `_assert_every_nix_build_prints_its_log` makes one screen up, and the same
-    way it was learned: a substring assert on the COMMAND stayed green for the
-    whole life of a missing `-L`. Each guard below closes a DIFFERENT measured
-    false green, and dropping any ONE of them restores it:
-
-      * empty `$DRV`  -> `nix log ""` resolves as `.` and prints the CWD FLAKE'S
-        DEFAULT PACKAGE log. The auditor then greps a FOREIGN log that may read
-        `RESULT: PASS (exit=0)`. Not silence -- an AFFIRMATIVE false green.
-      * unguarded `nix log` -> `>` truncates BEFORE nix runs, so an unbuilt
-        derivation leaves an empty file and `grep -c` prints a reassuring 0.
-      * no `-s` test -> an empty log reads as "no timeouts found".
-
-    🔴 And a FIXED log path is its own hazard, which is why `mktemp` is
-    required: audit agents run concurrently here by design, so a shared
-    `/tmp/<name>.log` means each truncates the other's file and greps the
-    other's tier -- with all three guards above passing.
-
-    The count of hazards is deliberately NOT asserted in the emitted prose: an
-    earlier version of this block claimed it closed "THREE DIFFERENT FALSE
-    GREENS" while its bullets delivered two, and `test -s` speaks to emptiness
-    only -- it claims nothing about truncation.
+    🔴 THIS CHECK USED TO BE A SPELLING PIN AND THREE MUTANTS WALKED IT. It
+    tested six substrings against the WHOLE brief, under a docstring claiming
+    it was structural. Measured, each surviving a fully green 127-test suite:
+      * dropping `; exit 1` from the $DRV guard -- every token still present, and
+        the rendered block then printed `NO DERIVATION` and CONTINUED to a
+        foreign log's `RESULT: PASS (exit=0)`;
+      * `LOG=/tmp/audit-tier.log  # prefer mktemp here: ...` -- the WORD mktemp
+        survived in a comment, and the pinned literal `/tmp/tier.log` was absent;
+      * demoting every guard out of the ```bash fence into prose.
+    A guard that reads as coverage while providing none is worse than none, so
+    this now slices the FENCE and asserts each guard as a WHOLE LINE, in order,
+    each terminating in `exit 1; }`.
     """
-    if "nix log" not in out:
-        return  # no fallback emitted (e.g. a repo with no sandbox tier)
-    required = {
-        '[ -n "$DRV" ]': "an empty $DRV makes `nix log \"\"` print a FOREIGN log",
-        "NO DERIVATION": "the empty-$DRV guard must say why it refused",
-        "NO LOG": "an unbuilt derivation must be named, not left as an empty file",
-        '[ -s "$LOG" ]': "an empty log must not read as 'no timeouts found'",
-        "EMPTY LOG": "the empty-log guard must say why it refused",
-        "mktemp": "a FIXED log path is truncated by every sibling agent",
-    }
-    missing = [f"{tok}  ({why})" for tok, why in required.items() if tok not in out]
-    assert not missing, (
-        "the `nix log` cached-build fallback is missing guards that each close a "
-        "MEASURED false green; without them the block can report a clean tier "
-        "that never ran:\n  " + "\n  ".join(missing))
-    # A fixed path defeats mktemp even when mktemp is present.
-    assert "/tmp/tier.log" not in out, (
-        "the fallback names the FIXED path /tmp/tier.log. Two audit agents run "
-        "concurrently here by design: each truncates the other's file and greps "
-        "the other's tier, with every guard above still passing. Use mktemp.")
+    fences = re.findall(r"```bash\n(.*?)```", out, re.S)
+    blocks = [f for f in fences if "nix log" in f]
+    assert len(blocks) == 1, (
+        f"expected exactly ONE fenced bash block containing `nix log`, found "
+        f"{len(blocks)}. The guards below are asserted INSIDE that fence; prose "
+        "outside it is not executed by anyone.")
+    lines = [ln.strip() for ln in blocks[0].splitlines()
+             if ln.strip() and not ln.strip().startswith("#")]
+
+    # The log path must come from a command substitution, never a literal: audit
+    # agents run concurrently here by design, so a fixed path means each
+    # truncates the other's file and greps the other's tier, all guards passing.
+    assert any(re.match(r"LOG=\$\(mktemp\b", ln) for ln in lines), (
+        "the log path is not assigned from `$(mktemp ...)`. A FIXED path is "
+        "truncated by every sibling agent; a comment mentioning mktemp is not "
+        "the same as using it:\n  " + "\n  ".join(lines))
+
+    # Each guard must be a whole executable line that STOPS. `exit 1` is what
+    # makes a failed guard a stop rather than a note; without it the block
+    # continues into `nix log ""` and prints a FOREIGN log.
+    required = [
+        (r'^\[ -n "\$DRV" \]', "an empty $DRV makes `nix log \"\"` print the CWD "
+                                "flake's DEFAULT PACKAGE log — an affirmative "
+                                "false green, not silence"),
+        (r'^nix log "\$DRV" >', "`>` truncates BEFORE nix runs, so an unbuilt "
+                               "derivation must be named, not left as an empty file"),
+        (r'^\[ -s "\$LOG" \]', "an empty log must not read as 'no timeouts found'"),
+    ]
+    positions = []
+    for pattern, why in required:
+        hit = [i for i, ln in enumerate(lines) if re.match(pattern, ln)]
+        assert hit, (
+            f"the fenced block has no line matching {pattern!r} — {why}.\n  "
+            + "\n  ".join(lines))
+        i = hit[0]
+        assert "exit 1" in lines[i], (
+            f"this guard does not STOP, so a failure becomes a note and the "
+            f"block continues into the very false green it exists to close:\n"
+            f"  {lines[i]}")
+        positions.append(i)
+    assert positions == sorted(positions), (
+        "the guards are out of order: $DRV must be checked before `nix log` "
+        "runs, and the log's emptiness after it. Order:\n  "
+        + "\n  ".join(lines))
+
+    # 🔴 The verdict grep must NOT be last: `grep -c` exits 1 when the count is
+    # 0, so ending on it INVERTS the block's status — measured, a healthy tier
+    # exited 1 and a timing-out one exited 0.
+    # 🔴 The LAST COMMAND, not the last LINE. A line may chain several commands
+    # with `;`, and only the final one sets `$?`. An earlier draft of this very
+    # assertion matched the start of the line and failed on a block whose last
+    # COMMAND was already correct — narrower than its own description, the shape
+    # this module exists to catch.
+    last_cmd = lines[-1].split(";")[-1].strip()
+    assert not re.match(r'^grep -c\b', last_cmd), (
+        "the block's LAST COMMAND is `grep -c`, which exits 1 when the count is "
+        "0 — so a HEALTHY tier reports failure and a timing-out one reports "
+        f"success. Put the `RESULT:` grep last.\n  last command: {last_cmd}")
 
 
 def test_the_cached_build_fallback_is_emitted_with_its_guards():


### PR DESCRIPTION
Rank 4 of the audit-pr-ladder handoff — the `nix log` recovery block #1117 deferred to "its own PR and its own round".

## First: is it still needed?

The handoff item allowed closing this as *"a named reader records that the fallback is not coming back"*, so I checked before porting. **It is needed.** Measured on one derivation, three runs of the *same* command:

| run | rc | lines | `RESULT:` |
|---|---|---|---|
| uncached, `-L` | 0 | 5 | 1 |
| **cached, `-L`** | **0** | **0** | **0** |
| `nix log <drv>` | 0 | 2 | 1 |

`#1117` carried forward `--no-link -L`, which fixes the **succeeding** build. It does nothing for the **already-built** one: nix prints nothing and exits **0**, while the brief tells the auditor to "read each runner's own `RESULT:` line". The silence is indistinguishable from a pass. Sibling sessions and CI build the same tree constantly here, so the cached case is the common one.

## The four acceptance criteria (measured by #1133's round 3, recorded in the handoff)

1. **No stderr parenthetical.** The old block claimed `nix path-info`'s stderr was discarded by the `>` two lines down. That `>` belongs to a different command and redirects stdout; the flake error lands on the terminal. It also contradicted the same block's correct "`-L` writes to stderr" rule 28 lines above.
2. **`mktemp`, not a fixed `/tmp/tier.log`.** Audit agents run concurrently here by design; a shared path means each truncates the other's file and greps the other's tier — with every guard still passing.
3. **A structural guard.** `_assert_the_cached_build_fallback_carries_its_guards` checks each guard by name. A substring assert on the *command* stayed green for the entire life of a missing `-L`; this is the same argument its sibling `_assert_every_nix_build_prints_its_log` makes.
4. **The hazard count is not asserted in the prose.** The old block claimed "THREE DIFFERENT FALSE GREENS" while its bullets delivered two, and `test -s` speaks to emptiness only — it claims nothing about truncation.

## Design notes

Guards are **named constants**, so a mutant can remove exactly one and the harness can say which. New mutant **V62** removes the empty-`$DRV` guard, whose absence is an *affirmative* false green rather than silence: `nix log ""` resolves as `.` and prints the cwd flake's **default package** log, which may read `RESULT: PASS (exit=0)`.

🔴 **The block is emitted only where check lines were actually fenced.** Not cosmetic — with no check names it is advice about a command the brief never gave, and its own text contains `#checks.`, which made a presence check circular. Measured: it stole a kill from **V41**, whose mutant empties the check-name list.

## Verification

- **Watched RED at `7de5b0bd`** by grafting the test onto that tree (1 failed). Registered as `RED_AT_BASE_R17` with fix-matrix row `r17/N1`.
- **Mutant harness: 138 rows, all as expected**; V62 killed by *exactly* its named test.
- **Dev-host tier:** `GATE: RESULT=PASS exit=0` (pytest + node).
- **Sandbox tier** — the one the merge gates on — built one at a time: `devrc-pytests RESULT: PASS (exit=0)` (1468 lines), `devrc-nodetests RESULT: PASS (exit=0)` (8833 lines), 0 timeouts. Base `7de5b0bd`.

Three defects of mine were caught by this repo's own ledgers rather than by me, and are worth noting for anyone reviewing: I named a mutant `V62` that did not exist (the fix-matrix ledger refused it); my guard was over-broad and stole kills from C3 and V41; and my precondition was circular. All fixed above.
