### PR TITLE
docs(handoff): rank 4 (criterion 9) should be done BEFORE rank 3 (criterion 8's laptop half)

### DIFF
--- a/claudedocs/handoff-cairn-phase3.md
+++ b/claudedocs/handoff-cairn-phase3.md
@@ -271,11 +271,19 @@ here and is why the headline reports `AMBIGUOUS` rather than picking a handler.
    still stands — the push is `rsync -a --delete` SOURCE→STAGE then tar STAGE→pod, so every
    entry the laptop also holds is overwritten with the laptop's copy, destroying API-appended
    bullets that exist only in the served copy. Recoverable via #551's backup, not harmless.
+   🔴 **So do rank 4 FIRST.** Criterion 9 makes API writes durable, which *removes* this
+   hazard rather than managing it — after it, the overwrite has nothing unique to destroy.
+   Running 3 first means relying on the backup to recover; running 4 first turns a
+   destructive operation into a safe one.
    forcing: none
 4. **Criterion 9 — the cutover.** `subsystem-index` writes through `cairn`; the local store
    becomes a read-only cache (`stat -c %a` = 444, EACCES *watched*, not assumed). 🔴 This is
    what makes an API write DURABLE — until it lands, every appended bullet is one `seed.sh`
    from gone. The read/write **allowlist split** is this criterion's own job.
+   🔴 **Do this BEFORE rank 3**, despite the lower rank. Rank 3 runs `seed.sh` from the
+   laptop, whose `rsync -a --delete` push overwrites every shared entry with the laptop's
+   copy. This criterion is what makes the API-appended bullets durable, so landing it first
+   is what makes rank 3 non-destructive instead of backup-dependent.
    forcing: none
 5. **Verify criteria 1, 2, 5, 6, 7 against the POD**, not just in tests. Criterion 4 is done
    there; 2's denied-scope arm is done for WRITES (404 `scope-unknown`) but not for the three


### PR DESCRIPTION
## What

Adds the *sequencing* conclusion to `claudedocs/handoff-cairn-phase3.md` → `## Next steps (ranked)`, on **both** rank 3 and rank 4 so it is visible whichever one a session draws.

## Why

Rank 3 runs `seed.sh` from the laptop. That push is `rsync -a --delete` SOURCE→STAGE then tar STAGE→pod, so every entry the laptop also holds is overwritten with the laptop's copy — destroying API-appended bullets that exist only in the served copy.

Criterion 9 (rank 4) makes API writes durable, which **removes** that hazard rather than merely managing it. Doing 4 first turns a destructive operation into a safe one; doing 3 first means relying on #551's backup to recover.

The doc already carried the destructive-overwrite warning on rank 3, so this integrates the conclusion into it rather than restating the mechanism.

## Mechanics

`Next steps (ranked)` is a REPLACE bucket, so the delta had to reproduce all ten items. The eight untouched items were extracted verbatim from `origin/main` rather than retyped.

- **No renumbering** — the rank is half a claim's identity.
- **Rank 2 retained** (closed item kept so claim slugs keep resolving).
- All ten items carry a `forcing:` line.
- The tool's dry run reported **no** "DROPS N line(s) that look DURABLE" warning; the diff is purely additive (+8 lines, zero deletions).

## Verification

Ten ranked items present, each with a parsed `forcing:` kind; ranks 1, 2 and 5–10 byte-identical to `origin/main`; ranks 3 and 4 changed as intended. Instruments were controlled — the `forcing:` regex was shown able to report MISSING, the item counter shown to move when an item is removed, and the section parser shown to fail loudly (rc=128) on a wrong path rather than silently returning empty.

Written via `scripts/lib/handoff_doc.py --confirm --push`.