### PR TITLE
docs(handoff): mention-detection session close — ranks 8/9 added, 7 de-risked, and the flake has a reproducer

### DIFF
--- a/claudedocs/handoff-mention-detection.md
+++ b/claudedocs/handoff-mention-detection.md
@@ -18,52 +18,43 @@ Detect clawgate/GitHub/ClickUp references in agent output, emit telemetry, and m
 them clickable in the terminal the way a URL already is. **SHIPPED AND VERIFIED LIVE.**
 
 ## State now
-🔴 **RANKS 1, 3, 4, 5 AND 6 ARE CLOSED. RANK 2 IS OWNED BY ANOTHER EFFORT — hand over, do
-not work it here.** The only genuinely open item is rank 7 below.
+🔴 **RANKS 1–6 ARE CLOSED. RANK 2 IS OWNED ELSEWHERE. Open: 7 (a decision), 8, 9.**
+Nothing in this effort is blocked on work; everything left is blocked on a human.
 
-🔴 **RANK 6 WAS NOT A DEFECT — clawgate #463 is REFUTED, and this doc asserted its premise
-as fact for a day.** "60 of 248 cards unreachable by any scroll" was a measurement
-artifact. Do not re-derive it; the evidence is under rank 6.
+- Branch `main`, clean apart from two untracked scratch files (`output.txt`,
+  `scripts/diagnose-nix-disk.sh`). 🔴 `nix/pkgs/default.nix` is **no longer dirty** — devrc
+  **#1135** merged 2026-08-31T23:16Z, so the "dirty AND in the artifact" warning `ship.sh`
+  printed on five consecutive runs is resolved. It was never unsaved work; it was that PR
+  applied in the tree.
+- **clawgate 0.8.20 is LIVE** — `clawgatectl health` → `{"status":"ok","version":"0.8.20"}`,
+  pod `clawgate-58b4c8fd57-8cm49`, trunk `eed7db5a`. It carries the #468 fix.
 
-- Branch: `main`. `origin/main` was `e0e29e7b` when this doc was created; it is `e0f35ce2`
-  as of 2026-08-30 and moved **six times during this session's own gate runs**, which is
-  why every merge here re-checked the merged tree rather than trusting a branch-green.
-- **clawgate 0.8.19 is LIVE** (`clawgatectl health`), pin commit `8503620a` on
-  `homelab-infra` trunk, carrying the `#task-N` deeplink fix. Verified against the
-  deployed pod, not a fixture.
+**Merged this session (later half):**
+- `innovation-upstream/devrc#1099` → `6bf866fe` — rank 5, the "UNGATED by CI" correction
+- `innovation-upstream/devrc#1155` → `74b427d5` — rank 5 close-out
+- `innovation-upstream/devrc#1168` → `d07c0c06` — rank 6 refutation
+- `innovation-upstream/devrc#1175` → `7f1c81c9` — rank 7 measurement + the `claim-work` lesson
+- `innovation-upstream/devrc#1181` → `0c333846` — the store-api flake: named cause + reproducer
+- `ZacxDev/homelab-infra#613` → `7087eb37` — clawgate #468, the deeplink handler
+- `eed7db5a` in homelab-infra — the 0.8.20 pin bump (the deploy itself)
 
-**Merged this session:**
-- `innovation-upstream/devrc#1086` — the two unverified alacritty interactions, verified
-  off-screen (rank 1)
-- `ZacxDev/homelab-infra#564` → squash `9ff37992` — `taskHashScript()`, the deeplink fix
-- `8503620a` in **homelab-infra** — the 0.8.19 pin bump (the deploy itself)
-- `innovation-upstream/devrc#1131` → squash `e0f35ce2` — ranks 1/3/4 closed, rank 2's
-  diagnosis and hand-over
-- `innovation-upstream/devrc#1099` → squash `6bf866fe` — rank 5, the "UNGATED by CI"
-  correction. **Merged, content-verified, shipped to both hosts and consumer-verified.**
+**Deploy/verify status, stated separately:**
+- devrc: all five PRs shipped to **both hosts** via `ship.sh`, each run verified per-host.
+- clawgate: 0.8.20 built, smoke-tested, pushed, reconciled, and **verified at the consumer** —
+  `data-task-hash-opened` now EXISTS on the live board (it was absent on 0.8.19), which is
+  what proves the new code is running rather than the version string alone.
+- 🔴 **But the #468 handler is a NO-OP on the live board today** — it reports `"0"`, i.e. it
+  found nothing closed to open. See rank 8; the fix is insurance there, not a repair.
 
 **Still open, with owners:**
-- **Leftover worktree `/home/zach/workspace/devrc-clawgate-ci`** — held #1099's branch
-  deliberately; that branch is now merged, so `gh pr merge --delete-branch` could not
-  delete the local ref and the worktree is now pure clutter. Left in place rather than
-  removed: it is not this effort's to reap. `git worktree remove` it when convenient.
-- **clawgate #463** — `ready_for_review`, **REFUTED, not fixed.** There is no layout bug;
-  see rank 6. Left at `ready_for_review` rather than `complete` because the status gate
-  permits `complete` only when every AUTHOR-SPECIFIED criterion was validated, and I
-  refuted the premise instead of meeting them. ⚠ The vocabulary has no `closed`/`wontfix`
-  and **dismissing DELETES the task**, so `ready_for_review` is the closed-ish state.
-- **clawgate #468** (open, NEW) — the one real finding split out of #463: `taskHashScript`
-  reaches a card inside the collapsed `Done` section only because **Chromium** auto-expands
-  the `<details>`; the handler never asks. Nothing pins that browser behaviour.
-- **clawgate #440** — still `ready_for_review`. 🔴 **Its recorded blocker is GONE**: #463
-  does not block criterion 1, verified live. Deliberately NOT flipped — a previous session
-  derived and validated its criteria, and grading that is Zach's call, not an agent's.
-- **`homelab-infra` base clone cannot fast-forward** — `merge --ff-only` refuses on a
-  dirty `flake.nix` (+ `.claude/skills/deploy/SKILL.md`, untracked files); stuck at
-  `93876471` vs trunk. **Pre-existing and NOT this session's**; it did not affect the
-  deploy, which went through a clean worktree. Left alone deliberately: it is someone's
-  uncommitted work. It is the silent-drift shape — a base clone that cannot ff stops
-  receiving changes while looking healthy.
+- **clawgate #463** — `ready_for_review`, REFUTED not fixed. No layout bug exists.
+- **clawgate #468** — `ready_for_review`, implemented + merged + deployed. Rank 9.
+- **clawgate #440** — `ready_for_review`; its blocker is refuted. Rank 9.
+- **`rescue/workbench-dirty-tree-2026-08-31`** in homelab-infra — someone's uncommitted work,
+  now safe. Rank 7.
+- ⚠ **A leaked `clawgate-e2e-pg-35881` container, up 42 h** (created 2026-08-30 01:39, so NOT
+  this session's). `deploy.md` records that these starve the box. Left alone deliberately —
+  another session's resource. `docker rm -f clawgate-e2e-pg-35881`.
 
 ## Open investigations — live diagnosis state
 
@@ -143,6 +134,40 @@ must not be lost:
   question to answer first is whether the #465 block can be restored *on top of* the port
   (`git show origin/trunk:flake.nix` holds the good copy of that block).
 
+### The `#task-<id>` deeplink reaches a collapsed-Done card LIVE but not HERMETICALLY
+Not a broken feature — an unexplained divergence that makes "it works" a claim about an
+environment rather than about the code. Both readings are measured; neither is inferred.
+
+- **Symptom + exact repro:** navigate to `http://192.168.50.250:30302/tasks#task-<id>` for a
+  task whose status is `complete` (it lives inside the collapsed `Done` `<details>`). Live it
+  lands. In the e2e harness, with the handler's open removed, it does not.
+- **Observed (with values):**
+  - **LIVE on 0.8.19** (before the fix): `detailsOpen: true`, `inViewport: true`,
+    `viewportRatio: 1`, `hashFocus: "true"`, **`hashOpened: null`** — the attribute did not
+    exist, so nothing in the app opened it.
+  - **LIVE on 0.8.20** (after the fix, same probe, task-407): identical, except
+    **`hashOpened: "0"`** — the attribute now exists (proving the new code runs) and the
+    handler found **nothing closed to open**. The browser had already opened it.
+  - **HERMETIC** (`e2e/tests/tasks.spec.ts`, 24 seeded cards, full mode, Docker, 0 skipped),
+    handler removed: `toBeInViewport` fails — **"viewport ratio 0"**. The card is unreachable.
+    With the handler: `1 passed`.
+- **Ruled out:**
+  - *"the browser never auto-expands"* — killed by the live readings above, twice, on two
+    versions.
+  - *"the handler is what makes it work live"* — killed by `hashOpened: "0"` on 0.8.20.
+  - *"the e2e is skipping"* — killed by `0 skipped` on every leg, with Docker up.
+- **Leading hypothesis:** a timing/size difference. The live board is far taller (252 cards)
+  and settles more slowly, so a native fragment resolution may land AFTER the cards exist,
+  where the hermetic run's deterministic `waitAppSettled` does not give the browser that
+  opportunity. **Untested.**
+- **Next probe, verbatim:** seed the hermetic harness with a board large enough to match the
+  live document height and re-run the mutant leg — if the card becomes reachable without the
+  handler, size/timing is confirmed as the variable:
+  ```bash
+  # in containers/clawgate, after raising seedTasks(server.baseURL, 24) to ~250 in the new spec
+  bash e2e/run.sh tasks.spec.ts -g "opens the collapsed Done section itself"
+  ```
+
 ## Next steps (ranked)
 1. ~~**Verify the two unverified interactions**~~ — **DONE**, merged as `#1086`. Closed by
    machine observation on an isolated Xvfb, not an operator report.
@@ -204,42 +229,51 @@ must not be lost:
      pins that, so a browser change would silently regress deeplinks to every completed
      task — the exact failure #440 existed to remove.
    forcing: none — closed as refuted, with #468 carrying the residue.
-7. **Decide the dirty `homelab-talos` clone** — 🔴 **MEASURED 2026-08-31; the decision is
-   all that is left, and BOTH halves of this item's original premise were WRONG.**
-   - 🔴 **It is NOT diverged.** `HEAD...origin/trunk` = **0 ahead, 1 behind**. There are no
-     un-pushed commits to rescue, and the `merge --ff-only` refusal is caused **solely by
-     the dirty working tree**. The preserve→push→`reset --keep` recipe this item used to
-     prescribe has nothing to operate on. It has also moved since the doc was written
-     (`93876471` → `5c0a6cab`), so "stuck" was stale too.
-   - 🔴 **The dirty files are NOT stale orphans — they are NOVEL.** Both blobs were hashed
-     against **every commit on every branch** (`git rev-list --all`): no match, in this
-     repo or in `datapacket-talos`. So the "byte-identical to an older commit ⇒ safe to
-     restore" escape does not apply, and `git restore` would **destroy real work**.
-   - 🔴 **`flake.nix` (+122/−140) is the dangerous one.** It ports datapacket's PR-status
-     shell hook (`__dp_status_cache`, from datapacket **#956** "feat(dev): cache GitHub
-     status in shell hook") into this dev shell, and in doing so **DELETES #465's
-     dependency-closure block** — the 🔴-commented `pyyaml/pytest/click/requests/numpy/
-     pillow` list whose own comment records that without it the repo's gate emits *"a
-     confident WRONG RED"*. **Committing it as-is silently re-opens #465.**
-   - **`.claude/skills/deploy/SKILL.md` (+25, pure addition)** is worth saving on its own:
-     a 🔴 lesson measured 2026-08-27 deploying `subsystem-store-api:0.4.0` — for a
-     Flux-managed app, bump the manifest in the repo **Flux actually reads**, because the
-     `clusters/homelab/apps/**` trees are byte-identical and bumping the wrong checkout
-     commits and reconciles cleanly while changing nothing that runs.
-   - **Both files share an mtime to ~1ms** (`2026-08-30 19:02:29`) ⇒ ONE bulk write, not
-     two hand edits. ⚠ An mtime still cannot name the writer.
-   - **Untracked:** `go.mod` (21 bytes, `module t`), `opencode.json`, `tests/` (1 file) —
-     all stamped `2026-08-28 19:13:03`, a throwaway scratch Go module. Plus
-     `claudedocs/handoff-limewire-torrent-comps.md` (6.4 KB), which is real unsaved writing.
-   - **Repo naming, now nailed down:** `ZacxDev/homelab-talos` **does not exist**; Flux's
-     `GitRepository` reads `ZacxDev/homelab-infra @ trunk`. The **laptop carries BOTH
-     directory names** (`~/workspace/homelab-talos` *and* `~/workspace/homelab-infra`),
-     both cloning that one repo; the workbench has only `homelab-talos`. One repo, up to
-     three checkouts — which is the actual mechanism behind the SKILL.md warning above.
-   - **Nothing was written.** Operator instruction 2026-08-31 for dirty trees is
-     measure-and-report only: no commit, restore, checkout or delete.
-   forcing: user — the operator asked for this measurement on 2026-08-31 and the
-   disposition of `flake.nix` is now a decision only they can make.
+7. **Decide the dirty `homelab-talos` clone** — 🔴 **MEASURED, and the WORK IS SAFE; only the
+   decision remains.** The bytes are preserved on `rescue/workbench-dirty-tree-2026-08-31`
+   (commit `c40261bc`, pushed to `ZacxDev/homelab-infra`), built via a temporary
+   `GIT_INDEX_FILE` and pushed straight to a remote ref — **no working tree, index or local
+   ref was touched**, verified by before/after checksums. So nothing is at risk from a
+   routine `checkout` any more, and this can wait.
+   - 🔴 **It is NOT diverged** — `0 ahead, 1 behind`; only the dirty tree blocks `--ff-only`.
+     The preserve→push→`reset --keep` recipe has nothing to operate on.
+   - 🔴 **The dirty files are NOVEL, not stale orphans** — both blobs hashed against every
+     commit on every branch (323 origin refs), no match here or in `datapacket-talos`. A
+     `git restore` would destroy real work.
+   - 🔴 **`flake.nix` (+122/−140) is the decision.** It ports datapacket's PR-status shell
+     hook (`__dp_status_cache`, datapacket #956) in and **DELETES #465's dependency-closure
+     block**, whose own comment records that without it the gate emits *"a confident WRONG
+     RED"*. **Do not land it as-is** — restore that block on top first
+     (`git show origin/trunk:flake.nix` has the good copy).
+   - **`.claude/skills/deploy/SKILL.md` (+25, pure addition)** is worth landing on its own
+     merits — a 🔴 lesson **measured 2026-08-27 deploying `subsystem-store-api:0.4.0`**: for a
+     Flux-managed app bump the manifest in the repo Flux ACTUALLY reads, because the
+     `clusters/homelab/apps/**` trees are byte-identical and bumping the wrong checkout commits
+     and reconciles cleanly while changing nothing that runs.
+   - 🔴 **NOTHING WAS WRITTEN to that tree.** The operator's 2026-08-31 instruction for dirty
+     trees is measure-and-report only: no commit, restore, checkout or delete. The rescue used a
+     temporary index and a direct remote-ref push precisely to honour that.
+   - **Untracked scratch deliberately excluded** from the rescue: `go.mod` (21 bytes,
+     `module t`), `opencode.json`, `tests/`, three `__pycache__/`.
+   forcing: user — the operator asked for the measurement; the disposition of `flake.nix` is
+   a decision only they can make, and it is the one thing blocking this.
+
+8. **Explain why the deeplink behaves DIFFERENTLY live vs hermetically** —
+   `ZacxDev/homelab-infra`, `containers/clawgate`. The single unresolved question left by
+   #468. Live (0.8.20) the browser opens the collapsed `Done` section before the handler
+   runs, so `data-task-hash-opened` reads **"0"**; hermetically (e2e, 24 seeded cards) the
+   card is **unreachable** without the handler (`toBeInViewport` → "viewport ratio 0").
+   Both measured. Until this is understood, "the deeplink works" is a claim about an
+   environment, not about the code. Full evidence under Open investigations below.
+   forcing: none — the shipped fix is correct under both readings, so nothing is broken
+   while this stays open. Do not let its interest read as urgency.
+
+9. **Grade clawgate #440 and #468** — both sit at `ready_for_review` and both are blocked on
+   a HUMAN, not on work. #440's recorded blocker (#463) is refuted; #468 is implemented,
+   merged (`7087eb37`) and deployed (0.8.20). 🔴 An agent must not close either: #440's
+   criteria were derived by a previous session, and **#468's were written by this one**, so
+   grading them is self-grading whichever way the `## Acceptance criteria` detector reads.
+   forcing: none — nothing external is waiting on the status flip.
 
 ## Gotchas / decisions / dead-ends
 - 🔴 **A task's own MEASUREMENT can be the artifact — check what your selector can SEE
@@ -480,6 +514,56 @@ must not be lost:
 - 🔴 **GitHub code search is BLIND on `ZacxDev/homelab-infra`** — a positive control for
   `filename:flake.nix` returned `total_count: 0`. An empty code-search result there proves
   nothing. Use `gh api repos/…/git/trees/<ref>?recursive=1`.
+
+- ⚠ **`origin/main` moves several times an hour here** — measured **six times during one earlier
+  session's own gate runs**, and this session re-gated merged trees four times for the same
+  reason. With `strict: false` on branch protection, a green check is a claim about the PR's
+  BRANCH, never about the tree the merge creates, so gating the merged tree stays manual.
+- 🔴 **The store-api CI "flake" is fsync CONTENTION — named, reproducible, and now SHIPPED as
+  a tool.** `scripts/ci-repro/slowfsync.c` + its README (devrc `0c333846`) make it fail on
+  demand on the dev host in ~70 s. Mechanism: `server.py:_replace_bytes` fsyncs BEFORE the
+  response is written, so under disk load the client's `HANG_TIMEOUT` (60 s) expires and the
+  gate reports a **code failure for an I/O stall**; the suite's own classifier prints
+  `MECHANISM = SERVER_BLOCKED_IN_FSYNC` unprompted. **Do not raise `HANG_TIMEOUT` again** and
+  **do not "fix" it with CPU/memory requests** — k8s requests govern CPU and memory, not IOPS.
+- 🔴 **FOUR audit rounds on that PR, and THREE of them found the error in the PREVIOUS
+  round's fix.** R1 found a false storage claim; R2 found my correction was also false
+  (contention set 7, not 12; and the lever still could not move the failing write); R3 found
+  my citation fix had shipped a THIRD wrong line citation, invalidated by its own commit.
+  **Recounting was never the fix.** What held was structural: replace literal numbers with
+  runnable derivation commands, and cite by NAME never by line. Read `scripts/ci-repro/`
+  before quoting any figure in it — it says so about itself.
+- 🔴 **A line citation into a file you are EDITING is a defect generator.** Three instances in
+  one PR. The comment block shifts the lines it cites, so even a fresh recount goes stale
+  before it is committed.
+- 🔴 **`claim-work --subject` is a NO-OP on a claim you already hold** — rc 0, "THIS IS YOURS",
+  old subject silently kept. A refuted premise went on advertising itself to other sessions.
+  Fix: `--release` then re-claim. Recorded in `claude/skills/handoff/reference/shared-queue.md`.
+- 🔴 **Merging clawgate code to `trunk` deploys NOTHING** — the pin is an immutable literal tag
+  with no Flux image automation. #613 merged and changed nothing running until the 0.8.20 pin
+  bump. "Merged" and "deployed" are separate claims; `clawgatectl health` is the arbiter.
+- 🔴 **An instrument that fails QUIET is worse than one that fails loud.** `slowfsync.c`'s
+  first version discarded `sleep()`'s return, so a signal could shorten the stall while
+  printing an identical success line — an under-delivered stall would produce a PASSING run
+  reading as "not reproducible", i.e. it lied in exactly the direction that makes you abandon
+  the investigation. It now reports MEASURED elapsed.
+- 🔴 **Assertion ORDER decides whether a guard can run at all.** In #468's spec the
+  discriminating assertion sat after `toBeInViewport`; under the mutant that check fails first
+  and the guard never executes — green for the wrong reason, and still green if deleted. Put
+  the discriminating assertion FIRST, then the user-visible one.
+- ⚠ **Two `tekton` e2e/gate failures this session were NOT the diff** — devrc's on
+  `test_mkdir_refuses_unsafe_names` / `test_subsystem_store_api.py`, clawgate's on
+  `clawgate health check did not pass on port <N> within 15000ms`. The discriminating control
+  both times: the SAME failure on a DIFFERENT sha's run. Different tests, one shape — a
+  wall-clock bound under CI load.
+- ⚠ **`clawgate-e2e` is NOT a required check on homelab-infra `trunk`** — measured: #613
+  merged with it red (after diagnosing the red as unrelated). "RUNS is not BLOCKS" was
+  previously unmeasured; it is now measured, in the negative.
+- ⚠ **The JS in `taskHashScript` lives inside a Go BACKTICK raw string**, so a backtick in a
+  comment terminates the literal and breaks the build. Caught immediately, but non-obvious.
+- ⚠ **devrc `nix/pkgs/default.nix` was never unsaved work** — it was open PR #1135 applied in
+  the tree. Checking a dirty file against open PRs before "rescuing" it cost one command and
+  avoided inventing a problem. #1135 has since merged.
 
 ## How to verify
 ```bash


### PR DESCRIPTION
Session close for `handoff-mention-detection.md`. Everything left in this effort is blocked on a **human**, not on work.

## What landed
- **#1181** → `0c333846` — the store-api CI "flake" now has a **named cause and a shipped reproducer** (`scripts/ci-repro/`): `SERVER_BLOCKED_IN_FSYNC`, reproducible on the dev host in ~70 s. Four audit rounds; **three found the error in the previous round's fix.**
- **ZacxDev/homelab-infra#613** → `7087eb37`, **deployed as clawgate 0.8.20** (`eed7db5a`) and verified at the consumer.
- Rank 7's uncommitted work is **rescued** to `rescue/workbench-dirty-tree-2026-08-31` with no working tree, index or local ref touched.

## New in this update
- **Rank 8** — the one open question: the deeplink reaches a collapsed-`Done` card **live** but not **hermetically**. Both measured; the cause is unidentified and explicitly not guessed at. Full evidence + a verbatim next probe under Open investigations.
- **Rank 9** — #440 and #468 both need a human to grade. 🔴 An agent must not close either: #468's criteria were written **by this session**, so grading them is self-grading whatever the detector reads.
- Rank 7 rewritten: the decision is all that remains, and **do not land that `flake.nix` port as-is** — it deletes #465's dependency-closure block.

## Corrections to prior state
- `nix/pkgs/default.nix` was **never unsaved work** — it was open PR #1135 applied in the tree; #1135 has since merged, so the "dirty AND in the artifact" warning across five `ship.sh` runs is resolved.
- `clawgate-e2e` is **not** a required check on `trunk` — measured in the negative (#613 merged with it red, after diagnosing the red as unrelated).

## Gate
Landed via `handoff_doc.py` (`status=written` → `status=pushed`). Its warnings were read: the 6 flagged durable lines are each carried forward or superseded — two of them (the 2026-08-27 Flux measurement and the no-writes instruction) I pulled back in explicitly after the first proposal run flagged them. 9 ranked items, 9 `forcing:` tags.

Subsystem index: one entry **corrected** (`homelab-talos/clawgate.md` carried a live `OPEN:` for #463, which this effort **refuted** — now `RESOLVED d07c0c06`), one **created** (`devrc/ci-repro.md`). Both validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sm5tDmE4y8PrpEPdJGaVCC