### PR TITLE
fix(store-api): the hang guard SAMPLED its own arming instead of waiting for it — CI scheduling failed it, not the code

### DIFF
--- a/scripts/ci-repro/README.md
+++ b/scripts/ci-repro/README.md
@@ -304,3 +304,81 @@ assertions (`assert data, "the request got no response at all"`) already say wha
 actually happened. They are also far less exposed, since both are answered by the
 pre-auth 401 path before any disk work. Converting them means restructuring two
 unrelated tests, so it was left out of the fix rather than done quietly.
+
+---
+
+## `slow_arm.py` — a GUARD that could not reach its own stall site in CI
+
+**What it answers.** `TestAHungRoundTripSAYSWhichSideBlocked` failed in CI
+(`devrc-ci-dpmck`, PR #1147, `collected=20075 passed=20071`) with
+
+```
+AssertionError: the server never reached the stall site, so the hang under test
+was NOT the one this test set up — the report below would be about a DIFFERENT hang
+assert False
+ +  where False = is_set()
+```
+
+The precondition did the right thing — it refused to report a verdict when its own
+setup had not landed. The problem was that the setup **did not reliably land**, so the
+guard failed where the code was fine: a flake with a better error message, blocking
+every PR exactly as the original one did.
+
+**The mechanism.** The precondition was `assert stalled.is_set()`, sampled at the
+instant the client's `timeout=CLIENT_BOUND` (**0.25 s**) expired. Within those 250 ms
+the server had to accept the connection, spawn a handler thread, parse the request,
+authenticate, meter, resolve the path, read the entry **and** reach `_fsync_dir`. On an
+idle dev host that takes a few ms. Under the CI node's concurrency it does not always.
+
+There was a second, quieter race in the same helper: the report had to be taken before
+the fixed `SERVER_STALL` (1.2 s) sleep elapsed, or the verdict described a server that
+had already unblocked.
+
+**The fix is synchronisation, not a bigger number.** `SERVER_STALL` is **gone**. The
+caller now `stalled.wait(HANG_TIMEOUT)`s for the stall site to be reached, and the
+handler is then held by a second Event until the report has been taken. Neither side
+guesses the other's timing, so there is no pair of bounds left to tune. It is also
+*faster*: the control run went 4.19 s → 3.06 s, because nothing sleeps 1.2 s any more.
+
+**Usage.**
+
+```bash
+# control — shim inert, same command line
+PYTHONPATH=scripts/ci-repro python3 -m pytest scripts/tests/test_subsystem_store_api.py \
+  -q -p slow_arm -k TestAHungRoundTripSAYSWhichSideBlocked
+
+# reproduction — 0.5 s on the request path, against a 0.25 s CLIENT_BOUND
+SLOW_ARM_S=0.5 PYTHONPATH=scripts/ci-repro python3 -m pytest \
+  scripts/tests/test_subsystem_store_api.py -q -p slow_arm --slow-arm-selftest \
+  -k TestAHungRoundTripSAYSWhichSideBlocked
+```
+
+| run | at parent commit | at HEAD |
+|---|---|---|
+| control | `4 passed` | `4 passed` |
+| armed `SLOW_ARM_S=0.5` | **`2 failed, 2 passed`** | **`4 passed`** |
+| armed `SLOW_ARM_S=3.0` (12x the bound) | — | `4 passed` |
+
+Both arms of the class fail at the parent commit, which confirms the defect is in the
+shared `_hang_and_report` helper rather than in one test.
+
+⚠ **The guard can still go RED — proved by mutation, not by assertion.** A `wait()`
+that masked a real regression would be worse than the flake:
+
+| mutant | result |
+|---|---|
+| `_replace_bytes` no longer calls `_fsync_dir` | RED — `Failed: DID NOT RAISE TimeoutError` (the server stops stalling entirely) |
+| handler parked *before* the stall site for longer than `HANG_TIMEOUT` (`SLOW_ARM_S=90`) | RED — `the server never reached the 'fsync' stall site within 60s`, after 91 s |
+| `("fsync", …)` removed from `_HUNG_SERVER_RULES` | RED — `MECHANISM = BLOCKED_ELSEWHERE`, so the classifier is still genuinely under test |
+
+The middle row is the important one: the client still times out, but the stall site is
+genuinely never reached — exactly the case a `wait()` could have swallowed. It does not.
+
+⚠ **NOT reproduced by natural scheduling on the dev host, and that is stated rather
+than glossed.** Pinned to ONE core with `-n 4`, then with 27 CPU hogs plus three
+fsync-looping `dd` writers on that core, the pre-fix guard still passed **5/5** on the
+class and **650/650** on the full file at 2.5x wall-clock inflation (81 s → 207 s). This
+is a 24-core host with fast NVMe; the arming path is a few ms of CPU, so a ~50x
+slowdown would be needed to miss 250 ms. The deterministic injection above reproduces
+the exact failure and the mutation matrix bounds the fix — but the *natural* CI
+scheduling failure was not reproduced here.

--- a/scripts/ci-repro/slow_arm.py
+++ b/scripts/ci-repro/slow_arm.py
@@ -1,0 +1,97 @@
+"""Delay the server's REQUEST PATH, to reproduce the guard-arming flake.
+
+Not a test. Loaded with `-p slow_arm`; `scripts/ci-repro/` is outside
+`scripts/tests/` so `run-tests.sh` never collects it.
+
+WHAT THIS REPRODUCES
+--------------------
+`TestAHungRoundTripSAYSWhichSideBlocked` stalls the server at a chosen site and
+asserts the client gave up while it was stuck. Its precondition is
+
+    assert stalled.is_set()
+
+sampled at the instant the client's `timeout=CLIENT_BOUND` (0.25 s) expires.
+That is an INSTANTANEOUS sample of a race: within those 250 ms the server must
+accept the connection, spawn a handler thread, parse the request, authenticate,
+meter, resolve the path, read the entry AND reach `_fsync_dir`. On an idle dev
+host it does so in a few ms. Under the CI node's concurrency it does not always,
+and the guard then fails with
+
+    AssertionError: the server never reached the stall site, so the hang under
+    test was NOT the one this test set up
+
+which is a true statement about the RUN and a false accusation of the CODE.
+
+This shim makes that deterministic by delaying the request path BEFORE the stall
+site, which is what a contended CI node does by scheduling rather than by sleep.
+It does not touch the stall itself, so the mechanism under test is unchanged —
+only the arrival time at it.
+
+USAGE
+-----
+    SLOW_ARM_S=0.5 python3 -m pytest scripts/tests/test_subsystem_store_api.py \
+        -p slow_arm --slow-arm-selftest -k TestAHungRoundTripSAYSWhichSideBlocked
+
+`SLOW_ARM_S` — seconds to delay each write request before the handler runs.
+Unset or 0 makes the plugin inert, so the same command line is the control. Any
+value above the suite's `CLIENT_BOUND` (0.25) should arm the failure.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+
+def _delay() -> float:
+    raw = os.environ.get("SLOW_ARM_S", "").strip()
+    return float(raw) if raw else 0.0
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--slow-arm-selftest",
+        action="store_true",
+        help="fail loudly unless the shim attached and its delay is observable",
+    )
+
+
+def pytest_collection_finish(session):
+    delay = _delay()
+    module = sys.modules.get("subsystem_store_server")
+
+    if session.config.getoption("--slow-arm-selftest"):
+        # 🔴 The instrument's own controls, both watched to fire.
+        assert module is not None, (
+            "subsystem_store_server is not in sys.modules — the store-api test "
+            "module was never imported, so this shim patched NOTHING and the "
+            "result below is a fact about the collection filter, not the server"
+        )
+        assert delay > 0, (
+            f"SLOW_ARM_S={os.environ.get('SLOW_ARM_S')!r} gives {delay}s — the "
+            "shim would be inert, making this a control rather than a repro"
+        )
+
+    if module is None or delay <= 0:
+        return
+
+    handler = module.StoreRequestHandler
+    real = handler._write
+
+    def slow_write(self, *args, **kwargs):
+        # BEFORE the handler body, so the delay lands on the way TO the stall
+        # site rather than inside it.
+        time.sleep(delay)
+        return real(self, *args, **kwargs)
+
+    handler._write = slow_write
+    handler.do_POST = handler.do_PUT = handler.do_PATCH = handler.do_DELETE = slow_write
+    print(f"\nslow_arm: PATCHED _write +{delay}s", file=sys.stderr)
+
+
+def pytest_report_header(config):
+    delay = _delay()
+    if delay <= 0:
+        return "slow_arm: INERT (SLOW_ARM_S unset or 0) — this is a CONTROL run"
+    return f"slow_arm: ARMED, {delay}s before each write request"

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -149,9 +149,15 @@ ROOT = Path(__file__).resolve().parents[2]
 #     already shipped one wrong citation.
 #     So it evidences an fsync exceeding 0.25 s, and the advice below about not
 #     raising HANG_TIMEOUT does not address the bound that actually failed
-#     there. That 0.25/1.2 pair is the same "bound tighter than the thing it
-#     discriminates" shape as commit f4a3d69b; it is UNFIXED and unflagged
-#     elsewhere.
+#     there. That 0.25/1.2 pair was the same "bound tighter than the thing it
+#     discriminates" shape as commit f4a3d69b.
+#     ✅ FIXED — and the pair is GONE rather than retuned. `SERVER_STALL` no
+#     longer exists and nothing samples `stalled.is_set()`: the caller WAITS for
+#     the stall site to be reached, and the handler is then held by an Event
+#     until the report has been taken. Retuning the two numbers was the obvious
+#     fix and would have been wrong — ANY fixed pair is a bet on the scheduler,
+#     and this one was lost in CI while winning on every dev host. Do not
+#     reintroduce a fixed stall duration here; the guard below pins that.
 #
 # 🔴 Do NOT raise this constant again in response to a recurrence. Read the
 # per-hung-call arithmetic directly below — the bound is not the lever, and the
@@ -7332,6 +7338,97 @@ def test_the_drain_guard_catches_the_sweep_it_exists_to_catch():
     blocking = [(ln, a) for ln, a in _drain_bounds(blocking_mutant) if a == "None"]
     assert len(blocking) == 1, (
         f"a `settimeout(None)` drain — block forever — was not detected: {blocking!r}"
+    )
+
+
+def _sampled_event_preconditions(source: "str | None" = None) -> "list[tuple[int, str]]":
+    """Every `assert <event>.is_set()` — a PRECONDITION that samples a race.
+
+    🔴 THE SHAPE, NOT THE SPELLING. `is_set()` is not banned: `await_audit`
+    calls it twice, inside a deadline-bounded polling loop, which is correct and
+    must stay legal. What cannot be legal is using it as the TEST OF AN ASSERT,
+    because that reads a background thread's progress at one instant and fails
+    the build if the thread has not got there yet — a claim about the scheduler
+    wearing the words of a claim about the code.
+
+    That is exactly how `TestAHungRoundTripSAYSWhichSideBlocked` failed in CI on
+    PRs whose diff could not reach it: within `CLIENT_BOUND` (0.25 s) the server
+    had to accept, spawn, parse, authenticate, meter, resolve and read before
+    reaching the stall site. Idle dev host: a few ms, so it passed 5/5 even
+    pinned to one core under 27 CPU hogs. Contended CI node: not always.
+
+    The fix is `.wait(HANG_TIMEOUT)`, which is strictly stronger — it still
+    fails when the site is genuinely never reached (proved by mutation), and it
+    stops failing when the site is merely reached late.
+    """
+    src = source if source is not None else Path(__file__).read_text()
+    bad = []
+    for node in ast.walk(ast.parse(src)):
+        if not isinstance(node, ast.Assert):
+            continue
+        test = node.test
+        if (
+            isinstance(test, ast.Call)
+            and getattr(test.func, "attr", None) == "is_set"
+        ):
+            bad.append((node.lineno, ast.unparse(test)))
+    return bad
+
+
+def test_no_precondition_SAMPLES_an_event_instead_of_WAITING_for_it():
+    """🔴 A precondition that samples a race is a flake with a good error message.
+
+    It blocks every PR exactly as a real defect would, while saying the code is
+    wrong — the most expensive possible failure, because the accusation is
+    specific and false.
+    """
+    sampled = _sampled_event_preconditions()
+    assert not sampled, (
+        f"these assertions SAMPLE an Event instead of waiting on it: {sampled}. "
+        "Use `assert ev.wait(HANG_TIMEOUT)` — it still fails when the event is "
+        "never set, and stops failing when it is merely set late. See "
+        "`_hang_and_report`."
+    )
+
+
+def test_the_sampled_event_DETECTOR_can_actually_see_one():
+    """🔴 The positive control. Without it a clean zero above is
+    indistinguishable from a walk that matches nothing — and this detector is
+    narrow by design (asserts only), so "it found none" is very easy to get for
+    the wrong reason.
+    """
+    src = Path(__file__).read_text()
+    assert _sampled_event_preconditions(src) == [], "fixture drift: one is already present"
+
+    # Re-introduce exactly the form that was removed.
+    #
+    # 🔴 THE ANCHOR IS BUILT BY CONCATENATION, NOT WRITTEN AS ONE LITERAL, and
+    # that is load-bearing rather than style. Spelled whole, this string would
+    # appear TWICE in the file — once here and once in the code it targets — and
+    # `replace(..., 1)` would hit THIS line first. It did: the mutation applied
+    # (so `mutant != src` passed), the guard reported zero, and the test failed
+    # with an empty list while the real code was untouched. Split like this, the
+    # file contains exactly one copy, which the assertion below pins.
+    target = "            armed = stalled" + ".wait(HANG_TIMEOUT)"
+    assert src.count(target) == 1, (
+        f"the anchor is no longer unique ({src.count(target)} copies) — a "
+        "count=1 replace would mutate the wrong one and this control would pass "
+        "while testing nothing"
+    )
+    mutant = src.replace(target, "            assert stalled" + ".is_set()", 1)
+    assert mutant != src, "the mutation did not apply — this test is vacuous"
+    found = _sampled_event_preconditions(mutant)
+    assert len(found) == 1 and found[0][1] == "stalled.is_set()", (
+        f"re-introducing the sampled precondition did not surface it: {found!r}"
+    )
+
+    # 🔴 AND THE NEGATIVE HALF: the legal uses must NOT be flagged, or the guard
+    # is unleaveable and someone will delete it. `await_audit` calls `is_set()`
+    # in a loop and in an assignment; neither is an assert test.
+    assert "closed.is_set()" in src, "fixture drift: await_audit no longer calls is_set"
+    assert not [f for f in _sampled_event_preconditions(src) if "closed" in f[1]], (
+        "the legal polling-loop use of is_set() was flagged — this guard would "
+        "be permanently red and would train people to delete it"
     )
 
 
@@ -15696,12 +15793,12 @@ class TestAHungRoundTripSAYSWhichSideBlocked:
     `_HUNG_SERVER_RULES` and the test watched to fail with its own message.
     """
 
-    # Deliberately far apart: the client must give up while the server is still
-    # stuck, or the report is taken after the block has cleared and says nothing.
-    # Kept SMALL because each test pays `SERVER_STALL` twice over — once waiting
-    # for the client to give up, once draining the wedged handler.
+    # 🔴 THE CLIENT BOUND, AND NOTHING ELSE. There is deliberately no
+    # `SERVER_STALL` any more — see `_hang_and_report`. The stall is now held
+    # open by an Event until the report has been taken, so its duration is
+    # DECIDED by this test rather than guessed in advance, and the pair of
+    # bounds that had to be "far apart" no longer has to be anything.
     CLIENT_BOUND = 0.25
-    SERVER_STALL = 1.2
 
     def _hang_and_report(self, store, monkeypatch, where: str) -> str:
         """Drive one POST into a server deliberately stuck at `where`.
@@ -15718,10 +15815,28 @@ class TestAHungRoundTripSAYSWhichSideBlocked:
             "arm's verdict would not be about this arm's request"
         )
         stalled = threading.Event()
+        released = threading.Event()
 
         def _stall(*_a, **_k):
             stalled.set()
-            time.sleep(self.SERVER_STALL)
+            # 🔴 HELD UNTIL THE REPORT HAS BEEN TAKEN, not for a fixed span.
+            # The old form slept `SERVER_STALL` (1.2 s) and the caller sampled
+            # `stalled.is_set()` the instant the client gave up at
+            # `CLIENT_BOUND` (0.25 s) — two independent races against one
+            # unsynchronised handler:
+            #   (a) ARMING: within 250 ms the server had to accept, spawn a
+            #       thread, parse, authenticate, meter, resolve and read before
+            #       reaching this line. Idle dev host: a few ms. Contended CI
+            #       node: not always — and the guard then blamed the CODE for a
+            #       SCHEDULING outcome.
+            #   (b) REPORTING: if the stack walk took longer than the remaining
+            #       sleep, the handler unblocked mid-report and the verdict was
+            #       about a server that was no longer stuck.
+            # Both disappear once the two sides synchronise instead of racing:
+            # the caller WAITS for this line to be reached, and this line waits
+            # for the caller to be done. Bounded so a defect cannot park a
+            # handler forever and wedge the drain below.
+            released.wait(HANG_TIMEOUT)
 
         if where == "fsync":
             # 🔴 `_fsync_dir`, not `os.fsync`: patching the stdlib's `os.fsync`
@@ -15763,14 +15878,32 @@ class TestAHungRoundTripSAYSWhichSideBlocked:
                         {"text": BULLET_A, "session": SESSION_A}
                     ).encode("utf-8"),
                 )
-            assert stalled.is_set(), (
-                "the server never reached the stall site, so the hang under "
-                "test was NOT the one this test set up — the report below "
-                "would be about some other mechanism"
-            )
+            # 🔴 WAIT FOR THE ARMING — DO NOT SAMPLE IT. `stalled.is_set()` here
+            # was an instantaneous read of a race the server had no obligation
+            # to have won yet, so a slow-to-schedule handler failed the guard
+            # with "the server never reached the stall site" while the code was
+            # fine. Waiting cannot mask a real regression: if the stall site is
+            # genuinely never reached — the fix stops calling `_fsync_dir`, or
+            # the request is rejected before the write path — this returns False
+            # and the assertion below still fires, just on evidence instead of
+            # on timing. It costs a PASSING run nothing: the event is normally
+            # already set by the time the client has given up.
+            armed = stalled.wait(HANG_TIMEOUT)
             try:
+                assert armed, (
+                    f"the server never reached the {where!r} stall site within "
+                    f"{HANG_TIMEOUT:g}s, so the hang under test was NOT the one "
+                    "this test set up — the report would be about some other "
+                    "mechanism. This is now a WAITED verdict, not a sampled "
+                    "one, so it is a claim about the SERVER rather than about "
+                    "scheduling: the handler never got to the stall site at all."
+                )
                 return _why_the_server_did_not_answer()
             finally:
+                # 🔴 RELEASE FIRST, THEN DRAIN — and in `finally`, so a failed
+                # assertion above cannot leave the handler parked for the full
+                # bound and strand the next arm's precondition.
+                released.set()
                 # Drain OUR wedged handler before handing back, so the leak
                 # this arm created cannot be inherited by the next one.
                 _await_no_handler_threads(HANG_TIMEOUT)


### PR DESCRIPTION
`TestAHungRoundTripSAYSWhichSideBlocked` fails in CI on PRs whose diff cannot reach it (`devrc-ci-dpmck`, PR #1147, `collected=20075 passed=20071`):

```
AssertionError: the server never reached the stall site, so the hang under test
was NOT the one this test set up — the report below would be about a DIFFERENT hang
assert False
 +  where False = is_set()
```

The precondition did exactly the right thing: it refused to emit a verdict when its own setup had not landed. The problem is that the setup **does not reliably land in CI**, so it fails where the code is fine — a flake with a better error message, blocking every PR just as the original one did. Not weakened here.

## ⚠ Attribution — this is not from #1190

The report attributed this to a guard added by #1190. It is not:

```
$ git log -S "def test_a_stall_in_the_FSYNC_region_is_NAMED" -- scripts/tests/test_subsystem_store_api.py
ef71733b  test(store-api): the CI hang is a 60s READ timeout, not an RST … (#1172)

$ git show 634c328a -- scripts/tests/test_subsystem_store_api.py | grep -c test_a_stall_in_the_FSYNC_region_is_NAMED
0
```

`TestAHungRoundTripSAYSWhichSideBlocked` came from **#1172**; #1190 touches it zero times. And #1190's own class uses no Events at all — `Event` 0, `is_set` 0, `.wait(` 0; it drives a stub TCP server with a bounded reader. Recorded because "the last PR did it" is the reading that sends the next person to the wrong commit — the same failure mode this file keeps fixing. #1181's comment block already named this exact test failing on this exact assertion and marked it **UNFIXED**; that note is now updated rather than left contradicting the code.

## Root cause: a precondition that SAMPLES a race

```python
CLIENT_BOUND = 0.25
SERVER_STALL = 1.2
...
with pytest.raises(TimeoutError):
    fetch(..., timeout=self.CLIENT_BOUND)
assert stalled.is_set()          # <- instantaneous sample
```

`stalled` is set by the server on entry to the stall site. The assert reads it **at the instant the client gives up — 250 ms in**. Within those 250 ms the server must accept the connection, spawn a handler thread, parse the request, authenticate, meter, resolve the path, read the entry **and** reach `_fsync_dir`. Idle dev host: a few ms. Contended CI node: not always.

A second, quieter race sat in the same helper: the report had to be taken before the fixed 1.2 s sleep elapsed, or the verdict described a server that had already unblocked.

Neither is a bound that wants retuning. **Any** fixed pair is a bet on the scheduler, and this one won on every dev host while losing in CI.

## The fix: synchronise, don't guess

`SERVER_STALL` is **deleted**. The two sides now wait for each other:

* the caller `stalled.wait(HANG_TIMEOUT)`s for the stall site to be **reached** instead of sampling whether it has been;
* the handler is then held at the stall site by a second Event until the report has been taken, and released in a `finally`.

No duration is guessed anywhere, so there is no pair of bounds left to tune. It is also **faster** — the control run went `4.19 s → 3.06 s`, because nothing sleeps 1.2 s any more.

I did **not** add a skip. A skip was offered as an option, but it is strictly worse here: waiting already fails when the site is genuinely never reached (proved below), so skipping would only trade a false red for a silent hole.

## The reproduction

`scripts/ci-repro/slow_arm.py` — a pytest plugin that delays the request path *before* the stall site, which is what a contended node does by scheduling. `--slow-arm-selftest` fails unless the shim attached and the delay is non-zero.

```bash
# control — shim inert, same command line
PYTHONPATH=scripts/ci-repro python3 -m pytest scripts/tests/test_subsystem_store_api.py \
  -q -p slow_arm -k TestAHungRoundTripSAYSWhichSideBlocked

# reproduction — 0.5 s against a 0.25 s CLIENT_BOUND
SLOW_ARM_S=0.5 PYTHONPATH=scripts/ci-repro python3 -m pytest \
  scripts/tests/test_subsystem_store_api.py -q -p slow_arm --slow-arm-selftest \
  -k TestAHungRoundTripSAYSWhichSideBlocked
```

| run | at parent commit | at HEAD |
|---|---|---|
| control | `4 passed` | `4 passed` |
| armed `SLOW_ARM_S=0.5` | **`2 failed, 2 passed`** | **`4 passed`** |
| armed `SLOW_ARM_S=3.0` (12x the bound) | — | `4 passed` |

Pre-fix it fails at `:15766` with the CI message verbatim, and **both** arms fail — confirming the defect is in the shared `_hang_and_report` helper, not in one test.

## 🔴 The guard can still go RED — by mutation, not by assertion

A `wait()` that swallowed a real regression would be worse than the flake it removed.

| mutant | result |
|---|---|
| `_replace_bytes` no longer calls `_fsync_dir` | **RED** — `Failed: DID NOT RAISE TimeoutError` |
| handler parked *before* the stall site past `HANG_TIMEOUT` (`SLOW_ARM_S=90`) | **RED** — `the server never reached the 'fsync' stall site within 60s`, after 91 s |
| `("fsync", …)` dropped from `_HUNG_SERVER_RULES` | **RED** — `MECHANISM = BLOCKED_ELSEWHERE` |

Row 2 is the one that matters: the client still times out, but the stall site is genuinely never reached — precisely the case a `wait()` could have masked. It does not. Row 3 also shows the release-gate's `threading.py` frames do not perturb the classifier: with the rule present the verdict is `SERVER_BLOCKED_IN_FSYNC`, without it `BLOCKED_ELSEWHERE`.

## The sweep — the shape, across the file

Not a spot-fix. An AST walk for the shape, and it is the *shape* that is banned, not the spelling:

| site | verdict |
|---|---|
| `_hang_and_report` `assert stalled.is_set()` | 🔴 the defect — fixed |
| `await_audit` `closed.is_set()` x2 | ✅ legal — inside a deadline-bounded polling loop, one a loop short-circuit and one a message decoration; neither is an assert test |

**Exactly one** site had the defect. New guard `test_no_precondition_SAMPLES_an_event_instead_of_WAITING_for_it` pins it, with a positive control that re-introduces the removed form and a **negative** half asserting `await_audit`'s legal uses are *not* flagged — otherwise the guard would be permanently red and would train people to delete it.

I deliberately did **not** add `wait` to `_HANG_DETECTOR_BOUND_ARG`: nine legitimate `.wait(timeout=…)` sites use literal bounds, so that would turn `test_no_hang_detector_is_still_bound_by_a_LITERAL` permanently red — the exact "permanently-red gate" failure the rules warn about.

⚠ **A trap caught in my own control, recorded rather than quietly fixed.** The positive control's `src.replace(anchor, …, 1)` hit *its own fixture string* first, because the anchor appeared twice in the file. The mutation applied, the detector reported zero, and the control failed with an empty list while the real code was untouched — a control that could just as easily have passed for the wrong reason. The anchor is now built by concatenation so only one copy exists, with `src.count(target) == 1` asserted.

## ⚠ What I could NOT reproduce

**The natural CI scheduling failure did not reproduce on this host**, and the fix does not rest on it. Attempts, all with the pre-fix file:

| condition | result |
|---|---|
| pinned to 1 core, `-n 4`, 5 iterations | 4 passed each |
| + 27 CPU hogs and 3 fsync-looping `dd` writers on that core, 5 iterations | 4 passed each |
| + full file, `-n 4`, same load, 2 iterations | 650 passed each, 2.5x wall-clock inflation (81 s → 207 s) |

Affinity propagation was verified (`sched_getaffinity → [0]`) so the constraint was real. This is a 24-core host with fast NVMe and the arming path is a few ms of CPU, so missing a 250 ms budget needs roughly a 50x slowdown. So: the mechanism is established by **deterministic injection plus Event semantics**, and bounded by the mutation matrix — not by an observed natural recurrence. Labelled that way on purpose.

## Counts

| suite | before | after |
|---|---|---|
| `test_subsystem_store_api.py` (`-n 4`) | 650 passed, 80.2 s | **652 passed, 81.5 s** |
| `scripts/tests` entire (`-n 4`) | 11090 passed | **11103 passed, 411.6 s, rc 0** |
| sibling gates (`test_run_tests_targets` + the two captured-text guards + `test_ci_claim_matches_reality`) | — | 230 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
