### PR TITLE
feat(break-glass): the escape hatch as a script that REFUSES to exit 0 unless the read-back matches — verified end-to-end on real main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,19 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   gh api -X PUT /repos/$R/branches/main/protection --input $S/restore.json     # 3. CLOSE
   gh api /repos/$R/branches/main/protection > $S/after.json                    # 4. READ BACK
   ```
+  **`scripts/break-glass-merge.sh --yes [--pr N]` does all four and REFUSES to exit 0
+  unless the read-back matches the capture key-by-key.** Prefer it over typing the
+  four steps: it cannot forget step 4, it never issues a `PATCH`, and its restore is
+  ONE function called on both the normal path and the EXIT trap — so the trap can
+  never hold a command that has not just been exercised, which is precisely how a
+  restore failed before. Called with no `--pr` it opens the window, merges nothing
+  and closes it; that self-test is the SAME code path as a real run, only the payload
+  differs. 🔴 **VERIFIED END-TO-END AGAINST THIS REPO'S `main`, 2026-09-01T01:50Z** —
+  real DELETE, real PUT, all 11 keys read back identical to a capture taken
+  independently beforehand. rc: 0 ok · 3 bad capture · 4 open failed · 5 merge failed ·
+  **6 RESTORE FAILED (main may be unprotected)** · 7 read-back mismatch.
+  ⚠ It still merges through an OPEN window, so anything with auto-merge armed can land
+  ungated while it runs — check `gh pr list --json autoMergeRequest` first.
   🔴 **Step 4 is not optional, and step 1 is what makes it possible.** A PARTIAL `PUT`
   succeeds and silently drops every key you omitted — `enforce_admins`, force-push and
   deletion settings included — so `PUT` returning 200 is a claim about the REQUEST, never

--- a/scripts/break-glass-merge.sh
+++ b/scripts/break-glass-merge.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# break-glass-merge — open `main`'s required-status-check window, optionally
+# merge a PR through it, then CLOSE it and PROVE it closed.
+#
+# WHY THIS EXISTS
+# ---------------
+# `innovation-upstream/devrc` requires `tekton/devrc-pytests` +
+# `tekton/devrc-nodetests` on `main` with `enforce_admins: true`. When Tekton is
+# down or wedged, NOTHING merges and there is no admin override. The escape
+# hatch is to delete the `required_status_checks` sub-resource, merge, and put
+# protection back.
+#
+# That hatch is documented in CLAUDE.md as prose. Prose is what went wrong:
+# MEASURED over three uses on 2026-08-29/30, `DELETE` opened the window and
+# `PATCH` could NOT close it — two restores failed, one of them inside an EXIT
+# trap that fired exactly as designed and still left `main` open, because the
+# untested command was *inside* the safety net.
+#
+# THE THREE FACTS THIS SCRIPT IS BUILT AROUND
+# -------------------------------------------
+#  1. `PATCH .../protection/required_status_checks` **404s** once the
+#     sub-resource is deleted (`Required status checks not enabled`). It updates
+#     checks that EXIST; it cannot recreate a deleted sub-resource. So this
+#     script never issues a PATCH against protection. Closing the window needs a
+#     full `PUT` of the WHOLE protection object.
+#  2. A PARTIAL `PUT` returns **200** and silently drops every key it does not
+#     carry — `enforce_admins`, force-push and deletion settings included. So
+#     "the PUT returned 200" is a claim about the REQUEST, never about the
+#     protection. All 11 keys are load-bearing, and the `app_id` pinning inside
+#     `checks` is what binds a restored context to Tekton rather than to any app
+#     that can post the same name.
+#  3. Therefore the READ-BACK IS NOT OPTIONAL, and neither is capturing first.
+#     Without the step-1 capture you cannot restore at all.
+#
+# 🔴 THE SAFETY-NET LESSON, ENCODED STRUCTURALLY
+# ----------------------------------------------
+# `restore_and_verify` is called on the NORMAL path and from the EXIT trap. It
+# is ONE function, so the trap can never contain a command that has not just
+# been exercised by an ordinary run. The historical failure was a trap holding
+# an untested `PATCH`; that shape is now unrepresentable here.
+#
+# 🔴 NOTHING IS REDIRECTED TO /dev/null. The 2026-08-30 restore looked "silent"
+# only because the idiom around it was `>/dev/null 2>&1`, which discarded the
+# very message naming the cause. Every API error is printed.
+#
+# SELF-TEST MODE
+# --------------
+# Called with no `--pr`, this opens the window, merges NOTHING, and closes it.
+# That is deliberately the SAME code path as a real break-glass run — only the
+# payload differs. The dangerous half (DELETE / PUT / read-back) is exercised
+# identically, which is what makes a real run trustworthy: it is not a mode that
+# has never run.
+#
+# EXIT CODES
+#   0  window opened and closed; read-back FAITHFUL key-by-key (+ merge ok)
+#   2  usage / environment error                        — nothing touched
+#   3  capture missing, malformed or incomplete         — nothing touched
+#   4  opening the window failed                        — nothing touched
+#   5  the merge failed (window was still closed + verified afterwards)
+#   6  🔴 RESTORE FAILED — `main` MAY BE UNPROTECTED. Manual action required.
+#   7  🔴 read-back does NOT match the capture — protection differs.
+set -euo pipefail
+
+REPO_DEFAULT="innovation-upstream/devrc"
+BRANCH_DEFAULT="main"
+
+# --- BEGIN CAPTURE_JQ ---
+# The projection of a protection object into the exact 11-key body the PUT
+# endpoint accepts. ONE definition, two consumers: the capture and the
+# read-back both use it, so a drift between them is unrepresentable. Its
+# fidelity is pinned by scripts/tests/test_break_glass_merge.py, which runs
+# THIS string (extracted from THIS file) through the real jq.
+CAPTURE_JQ='{
+  required_status_checks:{strict:.required_status_checks.strict,
+    checks:[.required_status_checks.checks[]|{context,app_id}]},
+  enforce_admins:.enforce_admins.enabled,
+  required_pull_request_reviews, restrictions,
+  required_linear_history:.required_linear_history.enabled,
+  allow_force_pushes:.allow_force_pushes.enabled,
+  allow_deletions:.allow_deletions.enabled,
+  block_creations:.block_creations.enabled,
+  required_conversation_resolution:.required_conversation_resolution.enabled,
+  lock_branch:.lock_branch.enabled,
+  allow_fork_syncing:.allow_fork_syncing.enabled}'
+# --- END CAPTURE_JQ ---
+
+# Every key the PUT body must carry.
+#
+# 🔴 SPLIT BY WHAT A VALID VALUE IS, not merely by presence. `has()` alone is
+# VACUOUS here and a mutation sweep proved it: the projection above names all
+# eleven keys unconditionally, so jq emits `allow_force_pushes: null` for a
+# source object that lacks it, and `has("allow_force_pushes")` is still TRUE.
+# A guard that can never fire reads as coverage while providing none — worse
+# than no guard, because it stops anyone looking. What actually distinguishes a
+# usable capture is the VALUE: the eight booleans must be booleans, or the
+# restore PUTs a null over a setting and GitHub takes its own default.
+BOOL_KEYS=(
+  enforce_admins required_linear_history allow_force_pushes allow_deletions
+  block_creations required_conversation_resolution lock_branch
+  allow_fork_syncing
+)
+# Legitimately null on this repo, but REQUIRED by the endpoint — so presence,
+# not truthiness, is the right check for exactly these two.
+NULLABLE_KEYS=(required_pull_request_reviews restrictions)
+
+REQUIRED_KEYS=(required_status_checks "${BOOL_KEYS[@]}" "${NULLABLE_KEYS[@]}")
+
+REPO="$REPO_DEFAULT"
+BRANCH="$BRANCH_DEFAULT"
+PR=""
+ASSUME_YES=0
+WORKDIR=""
+
+die() { printf '%s\n' "break-glass: $*" >&2; exit "${2:-2}"; }
+say() { printf '%s\n' "break-glass: $*" >&2; }
+
+usage() {
+  cat >&2 <<'EOF'
+usage: break-glass-merge.sh [--pr N] [--repo OWNER/NAME] [--branch NAME]
+                            [--workdir DIR] --yes
+
+  --pr N       merge PR N while the window is open. Omit to run the
+               self-test: open the window, merge nothing, close it.
+  --yes        required. This writes to branch protection.
+
+Exit codes: 0 ok · 2 usage · 3 bad capture · 4 open failed · 5 merge failed
+            6 RESTORE FAILED (main may be unprotected) · 7 read-back mismatch
+EOF
+  exit 2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --pr)      PR="${2:-}";      shift 2 || usage ;;
+    --repo)    REPO="${2:-}";    shift 2 || usage ;;
+    --branch)  BRANCH="${2:-}";  shift 2 || usage ;;
+    --workdir) WORKDIR="${2:-}"; shift 2 || usage ;;
+    --yes)     ASSUME_YES=1;     shift ;;
+    -h|--help) usage ;;
+    *)         say "unknown argument: $1"; usage ;;
+  esac
+done
+
+[ "$ASSUME_YES" = 1 ] || { say "refusing to touch branch protection without --yes"; usage; }
+[ -n "$REPO" ] && [ -n "$BRANCH" ] || usage
+if [ -n "$PR" ]; then
+  case "$PR" in (*[!0-9]*|"") die "--pr must be a number, got: $PR" ;; esac
+fi
+
+command -v gh   >/dev/null 2>&1 || die "gh not on PATH"
+command -v jq   >/dev/null 2>&1 || die "jq not on PATH"
+command -v diff >/dev/null 2>&1 || die "diff not on PATH"
+
+if [ -z "$WORKDIR" ]; then
+  WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/break-glass.XXXXXX")"
+fi
+mkdir -p "$WORKDIR"
+CAPTURE="$WORKDIR/restore.json"
+AFTER="$WORKDIR/after.json"
+
+PROT="/repos/$REPO/branches/$BRANCH/protection"
+WINDOW_OPEN=0
+RESTORE_DONE=0
+VERDICT=0
+
+# ---------------------------------------------------------------- capture ---
+# Step 1. Without this the window cannot be closed at all, so it runs BEFORE
+# anything is deleted and its result is validated before anything is deleted.
+capture() {
+  say "capturing $BRANCH protection -> $CAPTURE"
+  if ! gh api "$PROT" --jq "$CAPTURE_JQ" > "$CAPTURE"; then
+    die "could not read $PROT — refusing to open a window I could not close" 3
+  fi
+  [ -s "$CAPTURE" ] || die "capture is EMPTY — refusing to proceed" 3
+  jq -e . "$CAPTURE" >/dev/null 2>&1 || die "capture is not valid JSON — refusing" 3
+
+  # NOTE: there is deliberately NO `has()` check for NULLABLE_KEYS here. The
+  # projection names every key unconditionally, so jq emits them even when the
+  # source object lacks them and `has()` is ALWAYS true — a check that cannot
+  # fail. A sweep caught it (`nullable-presence-loop-removed` SURVIVED with the
+  # loop deleted, i.e. the loop was doing nothing). That invariant belongs to
+  # the FILTER and is pinned there, by
+  # test_break_glass_merge.py::test_the_capture_projection_runs_under_real_jq.
+  local k
+  for k in "${BOOL_KEYS[@]}"; do
+    jq -e ".[\"$k\"] | type == \"boolean\"" "$CAPTURE" >/dev/null \
+      || die "capture's '$k' is $(jq -c ".[\"$k\"]" "$CAPTURE"), not a boolean — restoring it would PUT a null and let GitHub pick the default" 3
+  done
+  jq -e '.required_status_checks | type == "object"' "$CAPTURE" >/dev/null \
+    || die "capture has no required_status_checks object — nothing to restore" 3
+  local n
+  n="$(jq -r '.required_status_checks.checks | length' "$CAPTURE")"
+  [ "$n" -gt 0 ] 2>/dev/null \
+    || die "capture has ZERO required checks — that is already an open window, not a captured one" 3
+  jq -e '[.required_status_checks.checks[] | select(.app_id == null)] | length == 0' "$CAPTURE" >/dev/null \
+    || die "a captured check has a null app_id — restoring it would bind the context to ANY app" 3
+  say "capture OK: ${#REQUIRED_KEYS[@]} keys, $n required check(s), all app_id-pinned"
+}
+
+# ------------------------------------------------------- restore + verify ---
+# 🔴 Called on the normal path AND from the EXIT trap. One function, so the
+# trap cannot hold an untested command. Idempotent via RESTORE_DONE.
+restore_and_verify() {
+  [ "$RESTORE_DONE" = 1 ] && return 0
+  RESTORE_DONE=1
+
+  # A full PUT of the WHOLE object. Never PATCH: PATCH cannot recreate a
+  # deleted sub-resource and 404s with "Required status checks not enabled".
+  say "closing the window: PUT $PROT (full object, ${#REQUIRED_KEYS[@]} keys)"
+  if ! gh api -X PUT "$PROT" --input "$CAPTURE"; then
+    say "🔴 RESTORE FAILED — '$BRANCH' MAY BE UNPROTECTED RIGHT NOW."
+    say "🔴 restore by hand:  gh api -X PUT $PROT --input $CAPTURE"
+    VERDICT=6
+    return 1
+  fi
+  WINDOW_OPEN=0
+
+  # The read-back is the only thing that can distinguish "the PUT returned 200"
+  # from "the protection is what it was". Same projection as the capture.
+  say "reading protection back"
+  if ! gh api "$PROT" --jq "$CAPTURE_JQ" > "$AFTER"; then
+    say "🔴 could not read protection back — cannot confirm the restore landed"
+    VERDICT=7
+    return 1
+  fi
+
+  local before_n after_n
+  before_n="$(jq -S -c . "$CAPTURE")"
+  after_n="$(jq -S -c . "$AFTER")"
+  if [ "$before_n" = "$after_n" ]; then
+    say "read-back FAITHFUL — every one of the ${#REQUIRED_KEYS[@]} keys matches the capture"
+    local k
+    for k in "${REQUIRED_KEYS[@]}"; do
+      say "  ok  $k"
+    done
+    return 0
+  fi
+
+  say "🔴 read-back MISMATCH — protection differs from the capture:"
+  diff <(jq -S . "$CAPTURE") <(jq -S . "$AFTER") >&2 || true
+  local k bv av
+  for k in "${REQUIRED_KEYS[@]}"; do
+    bv="$(jq -S -c ".[\"$k\"]" "$CAPTURE")"
+    av="$(jq -S -c ".[\"$k\"]" "$AFTER")"
+    if [ "$bv" = "$av" ]; then say "  ok    $k"; else say "  DIFF  $k: $bv -> $av"; fi
+  done
+  VERDICT=7
+  return 1
+}
+
+on_exit() {
+  local rc=$?
+  if [ "$WINDOW_OPEN" = 1 ] && [ "$RESTORE_DONE" = 0 ]; then
+    say "trap: the window is still open — restoring"
+    restore_and_verify || true
+  fi
+  if [ "$VERDICT" != 0 ]; then exit "$VERDICT"; fi
+  exit "$rc"
+}
+trap on_exit EXIT
+
+# ------------------------------------------------------------------- run ---
+say "repo=$REPO branch=$BRANCH pr=${PR:-<none, self-test>}"
+capture
+
+say "opening the window: DELETE $PROT/required_status_checks"
+if ! gh api -X DELETE "$PROT/required_status_checks"; then
+  die "could not delete required_status_checks — window NOT opened, nothing to restore" 4
+fi
+WINDOW_OPEN=1
+say "window is OPEN — $BRANCH has no required status checks right now"
+
+MERGE_RC=0
+if [ -n "$PR" ]; then
+  say "merging PR #$PR"
+  if ! gh pr merge "$PR" --repo "$REPO" --squash; then
+    say "merge of #$PR FAILED — closing the window anyway"
+    MERGE_RC=5
+  else
+    say "merged #$PR"
+  fi
+else
+  say "self-test: merging nothing; the window closes immediately"
+fi
+
+restore_and_verify || true
+
+if [ "$VERDICT" != 0 ]; then exit "$VERDICT"; fi
+if [ "$MERGE_RC" != 0 ]; then exit "$MERGE_RC"; fi
+say "DONE — window opened and closed, protection verified identical to capture"
+say "capture kept at: $CAPTURE"
+exit 0

--- a/scripts/tests/test_break_glass_merge.py
+++ b/scripts/tests/test_break_glass_merge.py
@@ -1,0 +1,387 @@
+"""`scripts/break-glass-merge.sh` must CLOSE the window it opens, and prove it.
+
+The script automates the escape hatch CLAUDE.md documents in prose: delete
+`main`'s `required_status_checks`, merge, put protection back. The prose version
+failed twice in real use on 2026-08-29/30 -- `PATCH` cannot recreate a deleted
+sub-resource (it 404s `Required status checks not enabled`), and a PARTIAL `PUT`
+returns 200 while silently dropping every key it omits. One of those failures
+happened INSIDE an EXIT trap that fired exactly as designed, because the
+untested command was in the safety net.
+
+So the properties worth pinning are behavioural, not textual:
+
+  * a capture that is empty / malformed / missing a key / already-open must
+    REFUSE, before anything is deleted (rc 3);
+  * a failed restore must be LOUD and rc 6, never a quiet success;
+  * a restore that lands a PARTIAL object must be caught by the READ-BACK and
+    reported key-by-key (rc 7) -- this is the 200-means-nothing hazard;
+  * the happy path must exit 0 only when the read-back matches key-by-key.
+
+🔴 The `gh` stub here SHELLS OUT TO REAL `jq` for every `--jq` filter, and the
+filter it runs is extracted from the script itself. A stubbed binary whose
+`--jq` never runs would leave the capture projection -- the thing that decides
+which keys survive a restore -- exercised by NOTHING. That trap is documented in
+this repo and is the reason for `test_the_capture_projection_runs_under_real_jq`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO / "scripts" / "break-glass-merge.sh"
+
+# The raw shape `GET /branches/<b>/protection` returns: booleans arrive wrapped
+# in `{"enabled": ...}`, which is exactly why the projection exists.
+RAW_PROTECTION = {
+    "required_status_checks": {
+        "strict": False,
+        "checks": [
+            {"context": "tekton/devrc-pytests", "app_id": 4320115},
+            {"context": "tekton/devrc-nodetests", "app_id": 4320115},
+        ],
+    },
+    "enforce_admins": {"enabled": True},
+    "required_pull_request_reviews": None,
+    "restrictions": None,
+    "required_linear_history": {"enabled": False},
+    "allow_force_pushes": {"enabled": False},
+    "allow_deletions": {"enabled": False},
+    "block_creations": {"enabled": False},
+    "required_conversation_resolution": {"enabled": False},
+    "lock_branch": {"enabled": False},
+    "allow_fork_syncing": {"enabled": False},
+}
+
+ELEVEN_KEYS = sorted(RAW_PROTECTION)
+
+GH_STUB = r'''#!/usr/bin/env python3
+"""A `gh` good enough to exercise the script's real control flow.
+
+State lives in $BG_STATE/protection.json in the RAW api shape. `--jq` filters
+are handed to the REAL jq, so the script's own projection is what runs.
+"""
+import json, os, subprocess, sys
+
+state = os.environ["BG_STATE"]
+mode = os.environ.get("BG_STUB_MODE", "ok")
+prot = os.path.join(state, "protection.json")
+log = os.path.join(state, "calls.log")
+
+argv = sys.argv[1:]
+with open(log, "a") as fh:
+    fh.write(" ".join(argv) + "\n")
+
+
+def load():
+    with open(prot) as fh:
+        return json.load(fh)
+
+
+def run_jq(filt, obj):
+    p = subprocess.run(["jq", "-c", filt], input=json.dumps(obj),
+                       capture_output=True, text=True)
+    if p.returncode != 0:
+        sys.stderr.write(p.stderr)
+        sys.exit(1)
+    sys.stdout.write(p.stdout)
+
+
+def wrap(body):
+    """PUT body (projected) -> RAW api shape, as GitHub would store it."""
+    out = {"required_status_checks": body.get("required_status_checks"),
+           "required_pull_request_reviews": body.get("required_pull_request_reviews"),
+           "restrictions": body.get("restrictions")}
+    for k in ("enforce_admins", "required_linear_history", "allow_force_pushes",
+              "allow_deletions", "block_creations",
+              "required_conversation_resolution", "lock_branch",
+              "allow_fork_syncing"):
+        if k in body:
+            out[k] = {"enabled": body[k]}
+    return out
+
+
+if argv[:1] == ["pr"]:
+    sys.exit(1 if mode == "merge_fails" else 0)
+
+if argv[0] != "api":
+    sys.exit(2)
+
+rest = argv[1:]
+method = "GET"
+if "-X" in rest:
+    i = rest.index("-X")
+    method = rest[i + 1]
+    del rest[i:i + 2]
+
+inp = None
+if "--input" in rest:
+    i = rest.index("--input")
+    inp = rest[i + 1]
+    del rest[i:i + 2]
+
+filt = None
+if "--jq" in rest:
+    i = rest.index("--jq")
+    filt = rest[i + 1]
+    del rest[i:i + 2]
+
+path = rest[0]
+
+if method == "GET":
+    if not os.path.exists(prot):
+        sys.stderr.write("Branch not protected\n")
+        sys.exit(1)
+    obj = load()
+    run_jq(filt, obj) if filt else sys.stdout.write(json.dumps(obj))
+    sys.exit(0)
+
+if method == "DELETE":
+    if mode == "delete_fails":
+        sys.stderr.write("could not delete\n")
+        sys.exit(1)
+    obj = load()
+    obj.pop("required_status_checks", None)
+    with open(prot, "w") as fh:
+        json.dump(obj, fh)
+    sys.exit(0)
+
+if method == "PUT":
+    if mode == "put_fails":
+        sys.stderr.write("PUT rejected\n")
+        sys.exit(1)
+    with open(inp) as fh:
+        body = json.load(fh)
+    if mode == "partial_put":
+        # The documented hazard: 200, but a key silently absent.
+        body.pop("enforce_admins", None)
+    with open(prot, "w") as fh:
+        json.dump(wrap(body), fh)
+    sys.exit(0)
+
+sys.exit(2)
+'''
+
+
+@pytest.fixture
+def env(tmp_path):
+    """A PATH whose `gh` is the stub, plus a state dir the test can inspect."""
+    if shutil.which("jq") is None:
+        pytest.skip("jq not on PATH")
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    gh = bindir / "gh"
+    gh.write_text(GH_STUB)
+    gh.chmod(0o755)
+
+    state = tmp_path / "state"
+    state.mkdir()
+    (state / "protection.json").write_text(json.dumps(RAW_PROTECTION))
+
+    class _Runner:
+        """Callable so tests read `env(...)`, with `.state` for inspection."""
+
+        state = None
+
+        def __call__(self, *args, mode="ok", raw=None):
+            if raw is not None:
+                (state / "protection.json").write_text(json.dumps(raw))
+            e = dict(os.environ)
+            e["PATH"] = f"{bindir}{os.pathsep}" + e["PATH"]
+            e["BG_STATE"] = str(state)
+            e["BG_STUB_MODE"] = mode
+            return subprocess.run(
+                [str(SCRIPT), "--yes", "--workdir", str(tmp_path / "wd"), *args],
+                capture_output=True, text=True, env=e, timeout=120,
+            )
+
+    runner = _Runner()
+    runner.state = state
+    return runner
+
+
+def _protection(env):
+    return json.loads((env.state / "protection.json").read_text())
+
+
+# --------------------------------------------------------------- happy path
+
+
+def test_the_self_test_opens_the_window_and_closes_it(env):
+    r = env()
+    assert r.returncode == 0, r.stderr
+    assert "read-back FAITHFUL" in r.stderr, r.stderr
+    # The window is SHUT again, with both contexts and their app_id pinning.
+    after = _protection(env)
+    assert [c["context"] for c in after["required_status_checks"]["checks"]] == [
+        "tekton/devrc-pytests",
+        "tekton/devrc-nodetests",
+    ]
+    assert {c["app_id"] for c in after["required_status_checks"]["checks"]} == {4320115}
+    assert after["enforce_admins"] == {"enabled": True}
+
+
+def test_the_window_really_was_open_in_between(env):
+    """🔴 POSITIVE CONTROL. Every other assertion here is about the state
+    AFTERWARDS, which a script that did nothing at all would also satisfy. This
+    one proves the DELETE actually landed, so the restore is restoring
+    something."""
+    r = env()
+    assert r.returncode == 0, r.stderr
+    calls = (env.state / "calls.log").read_text()
+    assert "-X DELETE" in calls and "required_status_checks" in calls, calls
+    assert "-X PUT" in calls, calls
+    # ...and the DELETE preceded the PUT.
+    assert calls.index("-X DELETE") < calls.index("-X PUT"), calls
+
+
+def test_it_never_PATCHes_protection(env):
+    """PATCH 404s once the sub-resource is deleted. It must not be reachable."""
+    env()
+    assert "-X PATCH" not in (env.state / "calls.log").read_text()
+    assert "-X PATCH" not in SCRIPT.read_text()
+
+
+# ------------------------------------------------- refusals, before any harm
+
+
+@pytest.mark.parametrize(
+    "raw,because",
+    [
+        ({}, "an empty object has none of the eleven keys"),
+        (
+            {**RAW_PROTECTION, "required_status_checks": {"strict": False, "checks": []}},
+            "zero required checks is an ALREADY-OPEN window, not a capture",
+        ),
+        (
+            {
+                **RAW_PROTECTION,
+                "required_status_checks": {
+                    "strict": False,
+                    "checks": [{"context": "tekton/devrc-pytests", "app_id": None}],
+                },
+            },
+            "a null app_id would rebind the context to ANY app that can post it",
+        ),
+        (
+            # 🔴 REACHES THE REQUIRED_KEYS LOOP AND NOTHING ELSE. Every other
+            # case here is ALSO caught by the zero-checks guard, which runs
+            # later -- so with only those, deleting the loop entirely left the
+            # suite green (measured: mutant `required-keys-loop-removed`
+            # SURVIVED). This capture has two app_id-pinned checks, so it walks
+            # past every other guard; it is missing exactly one of the other ten
+            # keys. That is the production hazard: a capture PUT back without
+            # `allow_force_pushes` silently turns force-pushes on.
+            {k: v for k, v in RAW_PROTECTION.items() if k != "allow_force_pushes"},
+            "a capture missing one key would silently drop it on the restore",
+        ),
+    ],
+)
+def test_a_bad_capture_REFUSES_before_deleting_anything(env, raw, because):
+    r = env(raw=raw)
+    assert r.returncode == 3, f"{because}: {r.stderr}"
+    calls = (env.state / "calls.log").read_text()
+    assert "-X DELETE" not in calls, f"{because} -- but it deleted anyway: {calls}"
+
+
+def test_a_failed_DELETE_touches_nothing(env):
+    r = env(mode="delete_fails")
+    assert r.returncode == 4, r.stderr
+    assert "-X PUT" not in (env.state / "calls.log").read_text()
+    assert _protection(env)["required_status_checks"]["checks"], "checks were lost"
+
+
+# ------------------------------------------------------- the loud failures
+
+
+def test_a_failed_restore_is_rc6_and_says_main_may_be_unprotected(env):
+    r = env(mode="put_fails")
+    assert r.returncode == 6, r.stderr
+    assert "RESTORE FAILED" in r.stderr, r.stderr
+    # It must hand over the exact manual command, with the capture path.
+    assert "-X PUT" in r.stderr and "--input" in r.stderr, r.stderr
+    assert "MAY BE UNPROTECTED" in r.stderr, r.stderr
+
+
+def test_a_PARTIAL_put_is_caught_by_the_readback_not_by_the_200(env):
+    """🔴 THE HEADLINE HAZARD. The PUT 'succeeds'; a key is silently gone. Only
+    the read-back can tell, and it must name WHICH key."""
+    r = env(mode="partial_put")
+    assert r.returncode == 7, r.stderr
+    assert "MISMATCH" in r.stderr, r.stderr
+    assert "DIFF  enforce_admins" in r.stderr, r.stderr
+
+
+def test_a_failed_merge_still_closes_the_window(env):
+    r = env("--pr", "123", mode="merge_fails")
+    assert r.returncode == 5, r.stderr
+    assert "read-back FAITHFUL" in r.stderr, r.stderr
+    assert _protection(env)["required_status_checks"]["checks"], "window left open"
+
+
+# --------------------------------------------- the projection, under real jq
+
+
+def _capture_jq() -> str:
+    """The filter the script actually uses -- ONE definition, two consumers."""
+    src = SCRIPT.read_text()
+    m = re.search(
+        r"# --- BEGIN CAPTURE_JQ ---(.*?)# --- END CAPTURE_JQ ---", src, re.S
+    )
+    assert m, "the CAPTURE_JQ markers are gone; this guard would silently test nothing"
+    body = m.group(1)
+    m2 = re.search(r"CAPTURE_JQ='(.*?)'", body, re.S)
+    assert m2, "CAPTURE_JQ is no longer a single-quoted assignment"
+    return m2.group(1)
+
+
+def test_the_capture_projection_runs_under_real_jq():
+    """A stub's `--jq` never running is a documented way to leave the projection
+    untested. This runs the script's own filter through real jq."""
+    if shutil.which("jq") is None:
+        pytest.skip("jq not on PATH")
+    p = subprocess.run(
+        ["jq", "-c", _capture_jq()],
+        input=json.dumps(RAW_PROTECTION), capture_output=True, text=True,
+    )
+    assert p.returncode == 0, p.stderr
+    got = json.loads(p.stdout)
+
+    assert sorted(got) == ELEVEN_KEYS, "the PUT body must carry all eleven keys"
+    # Presence, not truthiness: these two are legitimately null and REQUIRED.
+    assert got["required_pull_request_reviews"] is None
+    assert got["restrictions"] is None
+    # Booleans must be UNWRAPPED from {"enabled": ...} for the PUT body.
+    assert got["enforce_admins"] is True
+    assert got["allow_force_pushes"] is False
+    # app_id pinning survives, or a restored context binds to any app.
+    assert got["required_status_checks"]["checks"] == [
+        {"context": "tekton/devrc-pytests", "app_id": 4320115},
+        {"context": "tekton/devrc-nodetests", "app_id": 4320115},
+    ]
+
+
+def test_the_projection_guard_can_actually_FAIL():
+    """🔴 VACUITY CONTROL. If the assertion above passes against a filter that
+    DROPS enforce_admins, it is asserting nothing -- which is the exact defect
+    (a silently-dropped key) the whole script exists to catch."""
+    if shutil.which("jq") is None:
+        pytest.skip("jq not on PATH")
+    mutant = _capture_jq().replace("enforce_admins:.enforce_admins.enabled,", "")
+    assert mutant != _capture_jq(), "the mutation did not apply; control is inert"
+    p = subprocess.run(
+        ["jq", "-c", mutant],
+        input=json.dumps(RAW_PROTECTION), capture_output=True, text=True,
+    )
+    assert p.returncode == 0, p.stderr
+    assert sorted(json.loads(p.stdout)) != ELEVEN_KEYS, (
+        "a filter missing enforce_admins still produced all eleven keys -- "
+        "the projection test cannot detect a dropped key"
+    )


### PR DESCRIPTION
Rank 6 of the clipboard-research handoff. It was deliberately **not** built before: shipping an *untested* command into a break-glass path is the exact failure rank 2 corrects, and it cannot be proven end-to-end without opening the protection window on `main`. Operator decision this session was to open it.

## 🔴 Verified end-to-end against the real `main`

`2026-09-01T01:50Z` — real `DELETE`, real `PUT`, script exit **0**.

The script's own read-back is a control that shares the step under doubt, so the verdict comes from a **capture taken independently before any of this existed**:

```
INDEPENDENT key-by-key diff (pre-session capture vs now):
  ok    allow_deletions ... allow_force_pushes ... enforce_admins
  ok    required_status_checks ... restrictions        (all 11)
VERDICT: IDENTICAL to the capture taken before any of this ran
```

**Nothing merged through the open window.** It was open a few seconds; afterwards `#1191` and `#1169` were both still open and blocked, and `#1192` had merged at `01:47:57Z` with both checks `SUCCESS` — over two minutes *before* the window opened.

## What it encodes — three measured failures

* **Never `PATCH`.** `PATCH .../required_status_checks` 404s (`Required status checks not enabled`) once the sub-resource is deleted; it updates checks that exist and cannot recreate one. Only a full `PUT` of the whole object closes the window.
* **A PARTIAL `PUT` returns 200 and silently drops every key it omits** — `enforce_admins`, force-push and deletion settings included. So the read-back is not optional, and a mismatch is reported **key-by-key**.
* **`restore_and_verify` is ONE function**, called on the normal path *and* from the `EXIT` trap. A restore failed before inside a trap that fired exactly as designed, because the untested command was in the safety net. That shape is now unrepresentable.

Nothing is redirected to `/dev/null`: the 2026-08-30 restore only *looked* silent because `>/dev/null 2>&1` discarded the message naming the cause.

**Self-test mode** (no `--pr`) opens the window, merges nothing, closes it — deliberately the *same* code path as a real run, only the payload differs. The dangerous half is not a mode that has never executed.

## Exit codes

`0` ok · `2` usage · `3` bad capture (nothing touched) · `4` open failed (nothing touched) · `5` merge failed (window still closed + verified) · **`6` RESTORE FAILED — main may be unprotected** · `7` read-back mismatch

## Coverage

13 tests. The `gh` stub **shells out to real `jq`** for every `--jq`, and the filter it runs is extracted from the script — a stubbed binary whose `--jq` never runs would leave the capture projection, the thing deciding which keys survive a restore, exercised by nothing.

Mutation sweep is **self-checking** (control GREEN + positive control KILLED, else `SWEEP-INVALID`):

| mutant | outcome |
|---|---|
| `put-becomes-patch` | KILLED (5) |
| `readback-skipped` | KILLED (3) |
| `bool-type-loop-removed` | KILLED (1) |
| `zero-checks-guard-removed` | KILLED (1) |
| `appid-guard-removed` | KILLED (1) |
| `restore-failure-swallowed` | KILLED (1) |
| **positive control** `delete-removed` | KILLED (2) |

`survivors=none`.

## 🔴 Two guards the sweep found VACUOUS — fixed, not annotated

* The `REQUIRED_KEYS` `has()` loop **could never fire**: the projection names all 11 keys unconditionally, so jq emits `null` for a missing source key and `has()` is always true. Replaced with a **type** check on the 8 booleans, which is the real hazard — restoring a `null` lets GitHub pick its own default.
* The `NULLABLE_KEYS` `has()` loop was vacuous for the same reason and is **deleted**; that invariant belongs to the filter and is pinned by `test_the_capture_projection_runs_under_real_jq`.

The fixture that kills the type check is the *only* case that reaches it — every other bad-capture case is also caught by the later zero-checks guard, which is why deleting the loop first left the suite green. That is the "an earlier/later check always wins" trap, caught by isolating the mutation.

## Scope

`CLAUDE.md` gains a pointer to the script beside the four-step recipe (kept — the script does not replace knowing what it does). `test_break_glass_note.py` and `test_ci_claim_matches_reality.py` stay green; the `<!-- merge-gate: other -->` marker is untouched.

⚠ It still merges through an **open window**, so anything with auto-merge armed can land ungated while it runs. The header and the CLAUDE.md note both say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXp5UYUoZxPVUS6qejBUf7
