### PR TITLE
feat(cairn): criterion 9 STAGED — a write verb, a dry-run cutover, and the merge rule that made 15 hand-merges into 1

### DIFF
--- a/claudedocs/plan-cairn-integration.md
+++ b/claudedocs/plan-cairn-integration.md
@@ -80,9 +80,44 @@ Also true today:
   reads local disk. Neither is wrong today, which is precisely the problem.
 - **35 of 146 entries carry no `sensitivity:` marker** and fail-safe to
   `client-confidential`. Under decision 11 that makes them unshareable until marked.
-- **No tenancy, no auth, no age-out, no sharing** exist in any form.
+- 🔴 **CORRECTED 2026-09-01. This line used to read "No tenancy, no auth, no age-out, no
+  sharing exist in any form." The AUTH HALF WAS FALSE, and was false when written.**
+  Authentication is live and enforced on the hosted store — measured against a read route
+  with both controls: **no token → 401, a wrong token → 401, the real host credential →
+  200.** Per-token identity, server-side scope authorization and criterion 3's enumeration
+  property (a refused scope is indistinguishable from an absent one) all shipped as
+  "phase 3" criteria 1–7, and the last unrestricted credential was retired 2026-08-31.
+  What genuinely does not exist yet: **no tenancy** (one tenant, addressed by nothing —
+  authorisation is by token, addressing by `user.email` is decision 6 and is unbuilt), **no
+  age-out**, and **no sharing**. The distinction matters because "add auth" reads as
+  available work and is not: the next authorisation work is the read/write allowlist split,
+  which is a change to an existing mechanism.
+- 🔴 **The store is now BACKED UP.** homelab-infra#551 shipped a daily CronJob (03:45 UTC,
+  whole-tree tar including `.git`, its own bucket, 90-day ILM, a credential with no
+  `s3:DeleteObject`). Several places in this repo still say it is not — see devrc#1132.
 - **Zero entries carry task, PR or session front matter** — so nothing in the store can
   currently be joined to the work that produced it.
+
+## 🔴 Two numberings are live, and they cross — read this before sequencing anything
+
+The phases below number **the plan**. clawgate task #371, the `handoff-cairn-*.md` docs and
+every devrc commit message number **delivery milestones**. They are different axes with the
+same word, and neither can be renamed: one is written into commit history, the other is the
+planning vocabulary. The crossing is real and has caused work to read as further along than
+it is.
+
+| delivery label (commits, cg#371, handoff docs) | what shipped | phase BELOW |
+|---|---|---|
+| "phase 1" | seed + the read-only hosted API | precursor to phase 1 |
+| "phase 2" | `cairn`, the read-through client | precursor to phase 1 |
+| "phase 3", criteria 1–7 | per-token identity, scope authorization, the write path | **phase 2** |
+| "phase 3", criterion 10 | retiring the unrestricted credential | **phase 2** |
+| "phase 3", criteria 8 + 9 | the laptop re-seed and the write-through cutover | **phase 1** |
+
+🔴 **So "phase 3, criteria 8 and 9" is PHASE 1 work below, carrying a phase-3 label.** The
+rule going forward: **the phases below are canonical for planning; the delivery labels are
+historical and are not renamed; any new work item names both.** Criterion 9's design is
+`claudedocs/plan-cairn-phase1-cutover.md`.
 
 ## The plan
 
@@ -109,6 +144,13 @@ hosts after a sync.
 Same-named entries on both hosts may have diverged. Decide the rule before migrating and
 write it down; a silent last-write-wins would discard whichever host was not migrated
 last, and the loss would be invisible.
+
+✅ **The rule is now written down and implemented**, with the migration measured:
+`claudedocs/plan-cairn-phase1-cutover.md` §3, `scripts/cairn-cutover.py::plan_delta`. It is
+generalised past the one file that motivated it — additive where a name exists on one side;
+a lineage argument where the pod's copy is a lagging derivative of a host's; and an
+unconditional refusal where two HOSTS disagree, cleared only by a human-authored merge. The
+script is dry-run by default and refuses rather than guessing.
 
 ### Phase 2 — tenancy and authorisation
 Tenant addressed by `user.email`, authorised by a pod-issued per-host token. Still one

--- a/claudedocs/plan-cairn-phase1-cutover.md
+++ b/claudedocs/plan-cairn-phase1-cutover.md
@@ -547,6 +547,40 @@ the served copy. An entry only the *other* host holds is not checked for strande
 run on this one — which is why step 6 runs the whole script on the laptop too, and why the
 peer manifest is worth producing even though the plan could proceed without it.
 
+### 🔴 An incident from building this, because the mechanism generalises
+
+While this branch was being written, a **background mutation sweep** was rewriting
+`scripts/cairn-cutover.py` in place — mutate, run the suite, restore, repeat. A `git add`
+landed inside one of those windows and **committed a mutant**: the P5 empty-walk refusal
+shipped as `if False:`, disabled, in the very commit whose message explains why it exists.
+
+There was no error. `git log` showed exactly what was expected, and the working tree looked
+correct seconds later once the sweep restored it. **The suite could not catch it** — the
+sweep restores, so every later run is green over a red commit. What caught it was comparing
+the *committed blob* against the sweep's own pre-mutation backup (`git show HEAD:<path>` vs
+the `cp` aside); that artifact was the only thing that could have seen it.
+
+**The generalisation:** a tool that rewrites your tree is a **concurrent writer**, and
+`git add` is a read of whatever is there at that instant. `claude/RULES.md` already says to
+re-check *which branch* before committing because another session may have moved it — this
+is the same hazard one level down, in the CONTENT, moved by a process you started yourself.
+A mutation sweep is the worst instance, because its whole job is to produce plausible edits
+that survive a diff review.
+
+⚠ **Bounding it honestly, in both directions.** Every commit on the branch was scanned for
+the strings the sweep can write: exactly one was contaminated, and it is reverted; HEAD's
+blob is byte-identical to the verified backup. And the contaminated commit was never going
+to become `main`'s state under any merge method — devrc's recent practice is **squash**
+(all twelve most recent first-parent commits on `main` carry a `(#N)` squash suffix), which
+discards intermediates entirely; merge commits are *permitted* and five exist in history,
+but even under one the merge's TREE is the branch head's content. So the blast radius is
+this branch's history, not the mainline. That bound does not make the incident less worth
+recording — the same race would have shipped the disabled guard had it landed on the final
+commit instead of an intermediate one.
+
+**The operational rule:** never run a mutation sweep concurrently with anything that stages,
+builds or tests. It contends with all three and only one of them fails loudly.
+
 ## 9. The instruments, and how each was validated
 
 Every verdict below comes from something that was shown to be capable of the opposite

--- a/claudedocs/plan-cairn-phase1-cutover.md
+++ b/claudedocs/plan-cairn-phase1-cutover.md
@@ -119,11 +119,33 @@ what closes that window** — after the cutover the hosts are caches and host-vs
 cannot arise. Until then, the non-bullet count in each SUPERSEDES reason is there so an
 operator who *has* run `cairn put` can see which entries to look at.
 
+### 🔴 There are TWO collision AXES, and an early framing collapsed them into one
+
+This effort was briefed with *"exactly ONE filename collision in the whole migration"*. That
+measurement was real and it was **scoped to the host-vs-host axis only**. The pod-vs-local
+axis was never enumerated at entry level, so "one collision" quietly became "one merge
+decision in the migration", which is false. Both axes, counted:
+
+| axis | what a collision means | how it was counted | count |
+|---|---|---|---|
+| **host vs host** | the same entry name on both hosts with different bytes; neither is a derivative of the other | entry names present in both hosts' manifests whose sha256 differ | **1** |
+| **pod vs local** | the served copy holds content that exists nowhere else — i.e. an API-appended bullet carrying the attribution trailer | for every entry the pod and a host both hold and disagree on, the pod's lines not present in the host's, filtered to those matching the attribution pattern | **1** |
+
+🔴 **The pod-vs-local count is provably complete, not merely measured.** Exactly **one entry
+in the entire served copy carries an attribution trailer at all** — so no second entry on
+that axis can exist, whatever it diverges by. That is a stronger statement than a scan
+result, and it is the reason two staged merges are enough.
+
+⚠ **The two axes need different evidence and neither substitutes for the other.** Host-vs-host
+needs a manifest from the *other* machine (`--manifest` over ssh); pod-vs-local needs the
+*served* bytes (`cairn sync`). A run with no `--peer-manifest` is structurally blind to axis
+1 and says so in as many words; a run that never syncs is blind to axis 2 and refuses.
+
 ### The two hand merges
 
 Measured with the corrected rule, the workbench's plan is **88 SAME · 15 ADD · 42
 SUPERSEDES · 2 MERGED · 0 NEEDS_MERGE** — 59 entries shippable. The two hand merges are one
-of each kind the rule can produce, which is why both are staged:
+per axis, which is why both are staged:
 
 **(i) The host-vs-host divergence (rule 4).** Resolved as the **union**: both `aliases:`
 lists, both `## Pointers` sets, and every `## Nuance` bullet from both copies interleaved
@@ -354,6 +376,20 @@ covering it.
 
 Beneath all of it: the daily backup CronJob (homelab-infra#551, 03:45 UTC, 90-day ILM,
 credential with no `s3:DeleteObject`).
+
+🔴 **A TEST CAN DISABLE THIS ROLLBACK, AND ONE DID — read this before adding a `--freeze`
+test.** `--unfreeze` with no explicit `--mode-ledger` takes the **newest** ledger under
+`~/.local/share/cairn-cutover/runs/`. Five tests called `--freeze --apply` without
+`--run-dir`, so their synthetic ledgers landed in the operator's real run root — 64 of them —
+and the newest was always one of those. After any test run the documented P5 rollback
+therefore selected a fixture ledger, matched nothing, and left the store frozen while
+reporting every entry as "created after the freeze". A test poisoning the recovery path of
+the thing it tests is the worst shape available, and it is silent from both ends.
+
+Two changes close it, and the next `--freeze` test needs both: each ledger now **names the
+store it was taken from** and is refused against any other, and an autouse fixture redirects
+`DEFAULT_RUN_ROOT` so a test that forgets `--run-dir` still cannot reach the real path. Pass
+`--run-dir` anyway — the flag documents intent; the fixture only makes forgetting safe.
 
 ⚠ **`--unfreeze` REQUIRES the mode ledger and refuses without it.** `chmod 0444` destroys
 the originals, so a restore with nothing to restore *to* can only invent a mode — and

--- a/claudedocs/plan-cairn-phase1-cutover.md
+++ b/claudedocs/plan-cairn-phase1-cutover.md
@@ -131,10 +131,34 @@ decision in the migration", which is false. Both axes, counted:
 | **host vs host** | the same entry name on both hosts with different bytes; neither is a derivative of the other | entry names present in both hosts' manifests whose sha256 differ | **1** |
 | **pod vs local** | the served copy holds content that exists nowhere else — i.e. an API-appended bullet carrying the attribution trailer | for every entry the pod and a host both hold and disagree on, the pod's lines not present in the host's, filtered to those matching the attribution pattern | **1** |
 
-🔴 **The pod-vs-local count is provably complete, not merely measured.** Exactly **one entry
-in the entire served copy carries an attribution trailer at all** — so no second entry on
-that axis can exist, whatever it diverges by. That is a stronger statement than a scan
-result, and it is the reason two staged merges are enough.
+🔴 **The pod-vs-local count rests on TWO claims, and only the first is a proof.** An earlier
+version of this paragraph said the count was *"provably complete, whatever it diverges by"*.
+That is wider than the instrument supports, and this document's own rule-3 commentary says
+so: the attribution trailer is written by the **append** route only, and a whole-file
+replace — `PUT /api/v1/entry/<scope>/<ref>`, or `cairn put` — writes no trailer at all. An
+entry rewritten that way would diverge pod-vs-local and carry nothing for the filter to
+find. So, stated as two claims with two different warrants:
+
+1. **For the ATTRIBUTED class the count is complete by construction.** Exactly **one of 132**
+   served entries carries an attribution trailer at all, so no second entry of that kind can
+   exist regardless of what else it diverges by. That is the regex over the whole served
+   copy, not a scan of the divergences.
+2. **For the UNATTRIBUTED class the count is empty because nothing has exercised a
+   whole-file write.** `cairn put` is added by *this* change and therefore cannot have run
+   before now.
+
+⚠ **Claim 2 has a gap I did not close.** The server's `PUT` route has existed since criteria
+1–7 shipped, so a hand-rolled `curl` PUT against the pod is *possible* even though no client
+existed. I did **not** check the audit log for one. If you want claim 2 airtight before the
+cutover, query Loki for a `method=PUT` audit line over the store's lifetime; a zero there
+closes it, and the pod-log grep does not (it holds only the current pod's history — the
+reassuring-zero shape this effort has already been bitten by).
+
+🔴 **AND THE GUARANTEE EXPIRES THE FIRST TIME ANYONE RUNS `cairn put` AGAINST THE POD.**
+After that, pod-vs-local completeness needs a different instrument than the trailer filter —
+the trailer will still be absent and will no longer mean "nothing unique here". A reader who
+inherits the word *provably* will not re-check this at exactly the moment it stops being
+true, which is why the warrant is written out rather than the conclusion alone.
 
 ⚠ **The two axes need different evidence and neither substitutes for the other.** Host-vs-host
 needs a manifest from the *other* machine (`--manifest` over ssh); pod-vs-local needs the

--- a/claudedocs/plan-cairn-phase1-cutover.md
+++ b/claudedocs/plan-cairn-phase1-cutover.md
@@ -59,9 +59,18 @@ implemented in `plan_delta()` and each clause has a test named after it.
 > **2. Present on both, byte-identical → skip.** This clause is what makes a re-run a no-op
 > rather than a second push, i.e. what makes the whole operation idempotent.
 >
-> **3. Present on both and divergent, pod vs a host → the host copy supersedes**, *unless*
-> the pod holds a bullet the host lacks that carries the API attribution trailer
-> (`[cairn: actor/session]`).
+> **3. Present on both and divergent, pod vs a host** → decided by one question, asked over
+> **every line** and not only the bullets: *does the served copy hold any line this host does
+> not?*
+>
+> > **3a.** any such line carries the API attribution trailer (`[cairn: actor/session]`) →
+> > **hand merge**. It was written through the pod and exists in exactly one place.
+> > **3b.** there is no such line at all → **supersede**, and this is the strongest case in
+> > the rule: the host's copy is a superset, so nothing can be lost. A plain append lands
+> > here, as do a trailing newline and a CRLF difference.
+> > **3c.** such lines exist, none attributed → **supersede**. Lines the host has since
+> > edited away. The count that are not bullet openers rides along in the reason but does
+> > **not** change the verdict — see below.
 >
 > **4. Present on both HOSTS and divergent → always a hand merge.** Never last-write-wins,
 > whatever the mtimes say.
@@ -89,28 +98,56 @@ a claim the host has since retracted — with **no** attribution; **1** has an a
 bullet. Treating all 15 as hand merges would have made this a 15-file manual operation for
 14 files where the host copy is simply the newer one.
 
+### 🔴 A stricter version of 3c was tried and REVERTED, on measurement
+
+The obvious refinement is: *a pod-only line that is not a bullet opener must be front matter
+or `## Pointers`, i.e. outside what the attribution rule can see, i.e. a `cairn put` — so
+refuse it.* That argument sounds more careful and is wrong. **A store bullet WRAPS**, and a
+wrapped bullet's continuation lines do not begin `- `. Rewriting one bullet therefore
+produces "non-bullet lines only the pod has" as a matter of course.
+
+Measured on the real trees: the stricter rule turned **1 hand-merge into 10** — nine ordinary
+edits demanded operator attention. That is the permanently-red-gate direction, reached by the
+version of the rule that reads as most conservative. The count is reported and not gated.
+
 ⚠ **The rule's limit, stated rather than left to be met.** Rule 3 is a claim about *how the
-pod's copy got there*. It holds while `seed.sh` and the API are the only writers. A third
-route that edited the served copy would break the premise, not merely the implementation —
-which is why NEEDS_MERGE is the fail-safe direction and an unrecognised divergence ends in a
-refusal, not a push.
+pod's copy got there* — `seed.sh` produced it from a host, and the only thing that can have
+changed it since is the API, whose every change is attributed. `cairn put`, added by this
+same change, breaks that: it rewrites whole files with no attribution, so once it is in use a
+PUT-modified entry is genuinely indistinguishable from a seed-time snapshot. **The freeze is
+what closes that window** — after the cutover the hosts are caches and host-vs-pod divergence
+cannot arise. Until then, the non-bullet count in each SUPERSEDES reason is there so an
+operator who *has* run `cairn put` can see which entries to look at.
 
-### The one hand merge
+### The two hand merges
 
-The single host-vs-host divergence is resolved, by hand, as the **union**: the union of both
-`aliases:` lists, the union of both `## Pointers` sets, and every `## Nuance` bullet from
-both copies interleaved newest-first. **Neither copy was discarded and no bullet was
-reworded.** Each side carried something the other did not — one holds a set of deployment
-pointers and a Flux-parentage correction, the other holds newer prose and a whole outbound
-design — so "take the newer file" would have silently dropped a documented design.
+Measured with the corrected rule, the workbench's plan is **88 SAME · 15 ADD · 42
+SUPERSEDES · 2 MERGED · 0 NEEDS_MERGE** — 59 entries shippable. The two hand merges are one
+of each kind the rule can produce, which is why both are staged:
 
-The merged file is staged at
+**(i) The host-vs-host divergence (rule 4).** Resolved as the **union**: both `aliases:`
+lists, both `## Pointers` sets, and every `## Nuance` bullet from both copies interleaved
+newest-first. **Neither copy was discarded and no bullet was reworded.** Each side carried
+something the other did not — one holds a set of deployment pointers and a Flux-parentage
+correction, the other holds newer prose and a whole outbound design — so "take the newer
+file" would have silently dropped a documented design.
+
+**(ii) The pod-attributed bullet (rule 3a).** Exactly one entry in the whole store holds an
+API-appended bullet that exists nowhere else. Resolved mechanically: the host's copy, with
+that one bullet inserted **in date order** under `## Nuance / work-history` — its date is
+older than the host's newest, so putting it at the very top would have broken the store's
+newest-first convention. The bullet is carried **verbatim**, including its known
+double-date defect (`- <date>: <date>: …`, from a caller that date-prefixed text the server
+already stamps). A merge that silently repairs a writer's text is a merge that changed
+meaning; it is flagged here instead.
+
+Both merged files are staged at
 
     ~/.local/share/cairn-cutover/merged/<scope>/<entry>.md      (mode 0600)
 
 **outside the repo, deliberately** — it is client-confidential and this repo is public. It
-has been validated with the writer's own parser (`subsystem_touch --validate`): *OK — 1 of 1
-entry file(s) parse*.
+Both have been validated with the writer's own parser (`subsystem_touch --validate`):
+*OK — 2 of 2 entry file(s) parse, 0 malformed*.
 
 ⚠ **One advisory it carries forward unchanged.** One bullet inherited from one side writes
 its `RESOLVED <sha>:` marker with a parenthetical between the sha and the colon, which the
@@ -355,7 +392,9 @@ python3 $D/scripts/cairn-cutover.py \
 #      P0 cairn sync -> rc 0 … 132 entries
 #      P0 the write route IS deployed — … refused 400 …
 #      P1 plan over <n> local entries: {'ADD': …, 'SAME': …, 'SUPERSEDES': …,
-#         'MERGED': 1, 'NEEDS_MERGE': 0}
+#         'MERGED': 2, 'NEEDS_MERGE': 0}
+#      measured on the workbench today: SAME 88 · ADD 15 · SUPERSEDES 42 ·
+#      MERGED 2 · NEEDS_MERGE 0, i.e. 59 entries shippable
 #      P2 union … LIVE ref collisions=3 LATENT…=4    <- and it will REFUSE at rc 15
 #    🔴 rc 15 on the first run is EXPECTED. Step 3 is what clears it.
 
@@ -371,7 +410,11 @@ python3 $D/scripts/cairn-cutover.py \
   --alias-owner '<scope>:<ref>=<winner>.md' \
   --alias-owner '<scope>:<ref>=<winner>.md'
 #    expect: rc 0, "DRY RUN — <n> entr(ies) would be pushed", and the exact seed.sh
-#    command it would run. NEEDS_MERGE must be 0 and MERGED must be 1.
+#    command it would run. NEEDS_MERGE must be 0 and MERGED must be 2 (the
+#    two staged hand merges). A NEEDS_MERGE it names is a file you must author.
+#    ⚠ A stale entry under --merged is reported as `SAME … a STALE hand-merge
+#    … was IGNORED` rather than pushed — read those lines, they are how you
+#    learn a resolution from an earlier round is still lying around.
 
 # 5. APPLY, from the WORKBENCH. Pushes the delta, verifies, then freezes.
 export SUBSYSTEM_STORE_TOKEN_FILE=<path to a file holding just the token>

--- a/claudedocs/plan-cairn-phase1-cutover.md
+++ b/claudedocs/plan-cairn-phase1-cutover.md
@@ -1,0 +1,430 @@
+# Cairn — the write-through cutover (criterion 9), designed and staged
+
+**Status: STAGED, NOT APPLIED.** Nothing in this document has been executed against the
+hosted store or either host's local store. `scripts/cairn-cutover.py` is dry-run by
+default and the operator runs it. This doc is the argument; the script is the procedure.
+
+🔴 **This repo is PUBLIC and the store is client-confidential.** No entry content, no
+filenames and no scope names appear below. Scopes are referred to by count and role. The
+script prints the real names at run time, on the operator's terminal — that is deliberately
+the only place they appear.
+
+---
+
+## 1. What criterion 9 is, and why it is the load-bearing one
+
+Today an append to the store is an `Edit` against `~/.claude/analyze-service-index/…`. That
+is **local disk on one host**, and it has three consequences that compound:
+
+1. the two hosts drift, permanently and invisibly;
+2. a bullet appended through the hosted API lives **only** in the served copy, and the next
+   `seed.sh` from any host replaces that entry with a file that never had it;
+3. so "the write path works" and "the bullet survives" are different claims, and the second
+   is false until this lands.
+
+Criterion 9 makes the pod the authority: writes go through it, and local disk becomes a
+read-through cache. That is what makes an API write **durable**.
+
+## 2. The measured starting state
+
+Re-measured 2026-09-01 from the workbench, the laptop (over ssh) and the served copy.
+
+| | entries | scopes |
+|---|---|---|
+| served copy (pod) | 132 | 15 |
+| workbench local store | 147 | 15 |
+| laptop local store | 49 | 12 |
+| **union** | **195** | **22** |
+
+- The pod's 15 scopes are exactly the workbench's 15. **7 scopes exist only on the laptop**
+  and are absent from the pod entirely.
+- **5 scopes exist on both hosts.** In them the laptop holds 17 entries, of which **16 have
+  names the pod does not** — pure addition, no decision.
+- **Exactly one entry name is held by both hosts with different bytes.** It is the only
+  genuine host-vs-host merge in the whole migration.
+- The pod is a **snapshot of the workbench alone**, taken `2026-08-29T20:34:38Z`. Since then
+  the workbench has moved: **42 of its entries differ from the served copy**, and 15 of
+  those have the pod holding at least one bullet line the host does not.
+- **Exactly ONE of those bullets carries the API attribution trailer** — i.e. exactly one
+  entry in the whole store holds bytes that exist nowhere else. That number is what makes
+  the rule in §3 cheap instead of a 15-way hand merge.
+
+## 3. THE MERGE RULE
+
+Stated generally, because it has to survive the next migration and not just this one. It is
+implemented in `plan_delta()` and each clause has a test named after it.
+
+> **1. Present on one side only → take it.** Additive; no decision exists.
+>
+> **2. Present on both, byte-identical → skip.** This clause is what makes a re-run a no-op
+> rather than a second push, i.e. what makes the whole operation idempotent.
+>
+> **3. Present on both and divergent, pod vs a host → the host copy supersedes**, *unless*
+> the pod holds a bullet the host lacks that carries the API attribution trailer
+> (`[cairn: actor/session]`).
+>
+> **4. Present on both HOSTS and divergent → always a hand merge.** Never last-write-wins,
+> whatever the mtimes say.
+>
+> **5. A hand merge is cleared ONLY by a human-authored file** at the same relative path
+> under `--merged`. Nothing else clears it; an unresolved one refuses the whole run.
+
+### Why rule 3 is a lineage argument, not an mtime one
+
+The pod's tree was **produced from** a host's tree by `seed.sh`. So for any entry the pod
+did not itself change, the host's copy contains everything the pod's does — the pod's is a
+lagging derivative. mtime cannot say this: every file on the pod carries the tar extract's
+time, and every file on a host carries its last local edit, so mtime ranks the *copies* and
+not the *lineage*.
+
+The attribution trailer is precisely the marker of **the pod having changed one itself**.
+`server.render_bullet` puts it on every API-appended bullet and nothing else in the store
+produces it. So it is the exact discriminator rule 3 needs, and detecting it is the whole
+safety of the rule rather than a nicety.
+
+**Measured on the real trees:** of 42 divergences, 27 have the host copy as a strict
+superset of the pod's bullets; 14 more have the pod holding bullet lines the host lacks that
+are *supersessions* — an `OPEN:` line the host has since rewritten as `RESOLVED <sha>:`, or
+a claim the host has since retracted — with **no** attribution; **1** has an attributed
+bullet. Treating all 15 as hand merges would have made this a 15-file manual operation for
+14 files where the host copy is simply the newer one.
+
+⚠ **The rule's limit, stated rather than left to be met.** Rule 3 is a claim about *how the
+pod's copy got there*. It holds while `seed.sh` and the API are the only writers. A third
+route that edited the served copy would break the premise, not merely the implementation —
+which is why NEEDS_MERGE is the fail-safe direction and an unrecognised divergence ends in a
+refusal, not a push.
+
+### The one hand merge
+
+The single host-vs-host divergence is resolved, by hand, as the **union**: the union of both
+`aliases:` lists, the union of both `## Pointers` sets, and every `## Nuance` bullet from
+both copies interleaved newest-first. **Neither copy was discarded and no bullet was
+reworded.** Each side carried something the other did not — one holds a set of deployment
+pointers and a Flux-parentage correction, the other holds newer prose and a whole outbound
+design — so "take the newer file" would have silently dropped a documented design.
+
+The merged file is staged at
+
+    ~/.local/share/cairn-cutover/merged/<scope>/<entry>.md      (mode 0600)
+
+**outside the repo, deliberately** — it is client-confidential and this repo is public. It
+has been validated with the writer's own parser (`subsystem_touch --validate`): *OK — 1 of 1
+entry file(s) parse*.
+
+⚠ **One advisory it carries forward unchanged.** One bullet inherited from one side writes
+its `RESOLVED <sha>:` marker with a parenthetical between the sha and the colon, which the
+grammar scores as a **near-miss**: it declares nothing and shows no badge. It was left
+exactly as written, because a merge that silently rewords a writer's marker is a merge that
+changed meaning. Fixing it is a one-line edit for whoever next touches that entry.
+
+## 4. Ref collisions — including the ones the merge INTRODUCES
+
+A ref that resolves to two entries in one scope raises `AmbiguousRefError`; the write route
+answers that **400**, so **both entries become unwritable**. Merging two hosts' scopes can
+create such a pair out of two entries that were each unambiguous at home. This is the
+failure mode filename comparison cannot see, and it has to be checked on the **union**.
+
+### The precedence, measured rather than assumed
+
+`resolve_ref_tiered` consults the FILENAME tier first and reaches the ALIAS tier **only if
+the filename tier returned zero hits**. Measured against the real store: a ref that is both
+one entry's filename stem and another entry's alias resolves to the **file**, `tier=filename`.
+So there are two classes, and conflating them would make the check a permanently-red gate:
+
+- **LIVE** — a filename collision, or an alias collision on a ref no filename answers. The
+  resolver raises; the entries are unwritable. **This blocks.**
+- **LATENT** — an alias shadowed by a filename. It changes nothing today and becomes live
+  the day that file is renamed or removed. **Reported, does not block** — refusing here
+  would refuse the migration over a defect that is already present and already harmless.
+
+### What is actually there
+
+Measured over the union (195 entries), using the resolver's own `normalize_ref`:
+
+| | count | where they come from |
+|---|---|---|
+| LIVE | **3** | 1 **introduced by the merge**; 2 pre-existing on one host and newly *served* |
+| LATENT | **4** | 2 pre-existing; **2 introduced by the merge** |
+
+- **The introduced LIVE one** is an alias claimed by an infra-scope entry on one host and by
+  a differently-named infra-scope entry on the other. It exists on neither host today and
+  appears only in the union. **Resolution: the entry that also declares the alias of the
+  underlying CRD keeps it; the other drops the alias.** That entry's alias set names the
+  specific mechanism the ref denotes, which the other's does not — an argument from the
+  entries' own declared vocabulary rather than from outside knowledge. The script still
+  requires the operator to state the decision explicitly with
+  `--alias-owner <scope>:<ref>=<filename>`; it will not pick.
+- **The two pre-existing LIVE ones** are both in one host-exclusive scope and are *not* new
+  — but they are newly *served*, because that scope reaches the pod for the first time here.
+  They must be resolved by the same mechanism before those two entries are writable.
+- **The two introduced LATENT ones** are the same shape in the other direction: one host's
+  entry carries an alias that spells the *filename* of an entry the other host brings. They
+  are inert (the filename tier answers first) and are reported, not blocked.
+- **The pre-existing LATENT one named in the brief** — an alias in this repo's own scope
+  claimed by two entries where one of them is also the filename — was **confirmed by
+  measurement** to be unreachable: the ref resolves to the file, `tier=filename`, and the
+  second entry's alias can never be chosen. Recommendation: drop the dead alias, because a
+  latent collision becomes live silently the day the file is renamed. Not a blocker and not
+  part of this cutover.
+
+### The missing-`aliases:` decision
+
+Two laptop entries carry no `aliases:` field at all. **Decision: migrate them as-is.**
+
+The reason is a measurement, not a preference: **13 of the 132 served entries already carry
+no `aliases:` field**, and 14 of 147 on the workbench — mostly scope `README`s, which
+legitimately have none. A missing `aliases:` is the store's normal state, not an anomaly;
+the entry template ships that line commented out. Adding aliases to exactly these two would
+be inventing a rule nothing else follows, and — worse — speculatively adding aliases is
+precisely how the LIVE collisions above came to exist. Their filename stems remain
+resolvable, which is what matching actually needs.
+
+## 5. The write-through contract, and its failure modes
+
+`cairn append` and `cairn put` are the write verbs. **The pod is the authority; the local
+cache has none.**
+
+| situation | behaviour | exit |
+|---|---|---|
+| append lands | prints `appended` + the new revision | 0 |
+| the same text re-sent | prints `duplicate`, file untouched | 0 |
+| store unreachable | **refused, loudly. Not queued, not written locally.** | **7** |
+| the request is wrong (bad bullet, unknown ref, unseen scope) | refused, with the server's own sentence | 6 |
+| the entry moved under the edit (`If-Match`) | refused; re-sync and re-apply | 8 |
+| the running image has no write path (405 `read-only`) | refused, and named as an **operator** problem | 6 |
+
+🔴 **A write during an outage is REFUSED, not queued. That is the accepted cost**, chosen
+deliberately (decision 8 of `plan-cairn-integration.md`). A spool would be invisible, and a
+caller told "queued" believes the record exists. One refused write costs a retry; one
+silently-local write costs the bullet at the next seed.
+
+🔴 **READS KEEP WORKING OFFLINE.** `/resume`, `cairn recall`, `cairn search` and
+`subsystem_recall.py` all read the local cache and continue to serve during an outage,
+stating that they are serving stale bytes. The asymmetry is the design:
+
+- a **read** must never report an outage as an empty store, so it degrades and says so;
+- a **write** must never report a failure as a success, so it refuses.
+
+The write exit codes (6/7/8) are disjoint from every read code (0/2/3/4/5) precisely so a
+caller cannot read *"nothing was displayed"* as *"the bullet landed"*. A test asserts the
+disjointness as a set, and a mutant that collides them is killed.
+
+### What criterion 9 does NOT close — read this before believing the cutover is complete
+
+1. **There is no CREATE route.** `POST` and `PUT` both resolve an *existing* ref; a ref that
+   resolves to nothing is 404. So a brand-new subsystem's first entry cannot be written
+   through the API at all. The freeze therefore targets entry **files** (0444) and leaves
+   scope **directories** writable, so a new file can still be created locally and pushed.
+   That is a deliberate asymmetry with a known cost, not an oversight.
+   *Closing condition: a merged devrc PR adding a create route to `server.py`, deployed, and
+   `cairn` gaining the verb that uses it.*
+2. **The read/write allowlist split is designed and NOT implemented.** Criterion 9 owns it,
+   and today it buys nothing: there is exactly one credential and one tenant, so a
+   read-only token has no holder. The design is a fourth field on a mapped token row listing
+   *write* scopes, defaulting to the read scopes when absent — backward-compatible by
+   construction, so the existing row keeps its current authority. Implementing it means
+   changing `server.py`, building an image, and a homelab-infra secret change; none of that
+   can be verified without a deploy.
+   *Closing condition: a merged devrc PR adding the field to `load_tokens` with its
+   negative controls, plus a homelab-infra commit adding write scopes to the row, verified
+   by a read-only credential receiving 405/403 on a write and 200 on a read.*
+3. **The protocol change is NOT in this PR.** The `subsystem-index` skill still instructs an
+   `Edit` against the local path. It is deliberately not edited here: a skill change ships
+   at the next `scripts/ship.sh`, which would land **before** the operator runs the cutover,
+   and appends would then 404 for every entry the pod does not yet hold. The exact change is
+   in §8 step 7, to be made as its own PR after the cutover verifies.
+   *Closing condition: a merged devrc PR changing `claude/skills/subsystem-index/SKILL.md`'s
+   write step, shipped, and one `/handoff` observed appending through `cairn append`.*
+
+## 6. The ordering argument: criterion 9 BEFORE criterion 8
+
+`claudedocs/handoff-cairn-phase3.md` ranks the laptop re-seed (criterion 8) at rank 3 and
+this cutover (criterion 9) at rank 4. **Running them in rank order is wrong**, and PR #1187
+records the correction in that doc.
+
+`seed.sh` pushes `rsync -a --delete` SOURCE→STAGE, then tars STAGE→pod. The tar adds and
+overwrites but never deletes — so running it from a host **overwrites every entry that host
+also holds with that host's copy**, destroying any API-appended bullet that exists only in
+the served copy. Today exactly one such bullet exists. Running 8 first means relying on the
+backup to recover it; running 9 first means the overwrite has nothing unique left to
+destroy, because by then the served copy holds everything and the hosts are caches of it.
+
+**A destructive operation made safe beats a destructive operation made recoverable.**
+
+This is also why the cutover script does **not** hand a whole store to `seed.sh`. It builds
+a **curated delta tree** holding only the entries §3 classified as shippable, and points the
+unmodified `seed.sh` at that. `seed.sh` is destructive because of *what it is given*, not
+because of what it does. One push path, one set of guards, one verdict format — and after
+the cutover, criterion 8 reduces to a verification rather than a second push.
+
+## 7. Rollback, per phase
+
+| phase | what it changes | rollback |
+|---|---|---|
+| P0 preconditions | nothing | — |
+| P1 plan | writes only into the run directory | delete the run directory |
+| P2 collisions | nothing | — |
+| P3 push | adds and overwrites entries on the pod | `cairn-cutover.py --rollback-push <run-dir> --apply` re-PUTs the pre-push bytes saved for every entry the push was about to overwrite. **Partial by construction**: an ADD has no pre-image and the API has no delete verb. |
+| P4 verify | nothing | — |
+| P5 freeze | `chmod 0444` on entry files | `cairn-cutover.py --unfreeze --apply` |
+| protocol change (§8 step 7) | a skill body | revert the commit, `ship.sh` |
+
+Beneath all of it: the daily backup CronJob (homelab-infra#551, 03:45 UTC, 90-day ILM,
+credential with no `s3:DeleteObject`). The script **refuses to run** without a recent
+successful one — see §9.
+
+⚠ **The rollback for a failed FREEZE is automatic and is not optional.** If the freeze is
+applied and any entry file still accepts a write, the script restores every mode bit to
+0644 and exits 16. A store that *looks* frozen and is not is worse than one that plainly is
+not — an agent would keep appending locally and believe it durable.
+
+## 8. The operator runbook
+
+Every step is a command to run and a thing to read. **Read the output, not the exit code
+alone** — several of these print a verdict their status cannot carry.
+
+```bash
+D=~/workspace/devrc
+
+# 1. LAPTOP FIRST — produce its manifest, so a host-vs-host divergence is DETECTED
+#    rather than silently superseded. Without this, merge rule 4 is UNCHECKED and the
+#    dry run says so in as many words.
+ssh zach@10.42.0.100 "python3 ~/workspace/devrc/scripts/cairn-cutover.py --manifest" \
+  > ~/.local/share/cairn-cutover/laptop-manifest.json
+#    expect: one JSON object, sha256 + aliases per entry, NO bullet text.
+
+# 2. DRY RUN on the workbench. Changes nothing. Reports the plan and every refusal.
+python3 $D/scripts/cairn-cutover.py \
+  --peer-manifest ~/.local/share/cairn-cutover/laptop-manifest.json
+#    expect, in order:
+#      P0 local store: <n> entries / 15 scopes
+#      P0 backup OK — subsystem-store/subsystem-store-backup last succeeded <ts>
+#      P0 cairn sync -> rc 0 … 132 entries
+#      P0 the write route IS deployed — … refused 400 …
+#      P1 plan over <n> local entries: {'ADD': …, 'SAME': …, 'SUPERSEDES': …,
+#         'MERGED': 1, 'NEEDS_MERGE': 0}
+#      P2 union … LIVE ref collisions=3 LATENT…=4    <- and it will REFUSE at rc 15
+#    🔴 rc 15 on the first run is EXPECTED. Step 3 is what clears it.
+
+# 3. RESOLVE THE 3 LIVE COLLISIONS. The dry run named the scope, the ref and both
+#    claimants. For each, edit the LOSING entry's `aliases:` line to drop that ref —
+#    in the local store on the host that holds it — then acknowledge the decision.
+#    ⚠ The losing entry may live on the LAPTOP; edit it there and re-run step 1.
+
+# 4. DRY RUN AGAIN, with the decisions. Read the plan before applying it.
+python3 $D/scripts/cairn-cutover.py \
+  --peer-manifest ~/.local/share/cairn-cutover/laptop-manifest.json \
+  --alias-owner '<scope>:<ref>=<winner>.md' \
+  --alias-owner '<scope>:<ref>=<winner>.md' \
+  --alias-owner '<scope>:<ref>=<winner>.md'
+#    expect: rc 0, "DRY RUN — <n> entr(ies) would be pushed", and the exact seed.sh
+#    command it would run. NEEDS_MERGE must be 0 and MERGED must be 1.
+
+# 5. APPLY, from the WORKBENCH. Pushes the delta, verifies, then freezes.
+export SUBSYSTEM_STORE_TOKEN_FILE=<path to a file holding just the token>
+python3 $D/scripts/cairn-cutover.py --apply \
+  --push subsystem-store/subsystem-store-api \
+  --peer-manifest ~/.local/share/cairn-cutover/laptop-manifest.json \
+  --alias-owner … (the same three)
+#    expect: seed.sh's own "seed: OK all N staged entries are present on the pod",
+#    then "P4 acceptance … missing=0", then verify-byte-identity.sh's per-scope
+#    PASS lines, then "P5 WATCHED EACCES: all N entry file(s) refused an append".
+#    ⚠ If $SUBSYSTEM_STORE_TOKEN_FILE is unset it says the byte-identity half is
+#    UNMEASURED and continues. That is not the same as clean — set it.
+
+# 6. THE LAPTOP HALF (criterion 8). Its local store still holds the 7 host-exclusive
+#    scopes and they are NOT yet on the pod. Repeat step 5 there, WITHOUT --push if
+#    you want to see the plan first:
+ssh zach@10.42.0.100 "python3 ~/workspace/devrc/scripts/cairn-cutover.py \
+  --peer-manifest /tmp/workbench-manifest.json"
+#    (produce that manifest with --manifest on the workbench and scp it over)
+#    then the same --apply --push from the laptop.
+#    🔴 This is where the ordering pays off: by now every shared entry on the pod
+#    already matches, so the delta is the 7 scopes plus 16 names and NOTHING is
+#    overwritten.
+
+# 7. THE PROTOCOL CHANGE — a separate PR, after 5 and 6 verify. In
+#    `claude/skills/subsystem-index/SKILL.md`, the write step becomes:
+#        cairn append --scope <scope> --ref <entry> --session <session-id> \
+#          --text '<the bullet, ONE line, no leading "- ", no leading date>'
+#    with the `OPEN:`->`RESOLVED` rewrite becoming `cairn put`. Keep the "show the
+#    diff first" rule; drop the `Edit`-anchored-on-the-heading rule, which the API's
+#    per-entry flock replaces. Then merge -> pull -> `scripts/ship.sh`.
+
+# 8. VERIFY THE WHOLE THING from a fresh session, on BOTH hosts:
+cairn sync && cairn recall --scope <a scope> | head -5
+python3 $D/scripts/cairn-cutover.py            # must print P1 … NEEDS_MERGE 0 and
+                                               # P5 "already applied", rc 0
+```
+
+**Rollback, if step 5 or 6 goes wrong:**
+
+```bash
+python3 $D/scripts/cairn-cutover.py --unfreeze --apply          # local disk writable again
+python3 $D/scripts/cairn-cutover.py --rollback-push \
+    ~/.local/share/cairn-cutover/runs/<timestamp> --apply       # re-PUT the overwritten bytes
+```
+
+## 9. The instruments, and how each was validated
+
+Every verdict below comes from something that was shown to be capable of the opposite
+answer. A green from an unvalidated instrument is a claim about the instrument.
+
+| instrument | negative control | positive control |
+|---|---|---|
+| `verify-byte-identity.sh` | one entry mutated by a single character → **FAIL, naming the scope** | identical stores → **PASS**, printing `raw-diff-lines`/`store-root-lines` beside the verdict |
+| the backup precondition | absent CronJob, absent `kubectl`, unparseable JSON, unparseable timestamp, and a `lastSuccessfulTime` that is **absent** → all refuse with their own sentence | a fresh timestamp passes and prints the measured age beside the ceiling; the boundary is measured from **both** sides (35.5 h passes, 36.5 h refuses) |
+| the write-route probe | a `405 read-only` server → reported as an **operator** problem | a `400 bad-request` server → reported as deployed. The probe body is `{}`, refused by the server's validator *before* any ref is resolved, so it cannot write |
+| the freeze | `probe_writable` returns `writable` at 0644 and `refused` at 0444, on the same file, twice | a partially-applied freeze (one file left writable) exits 16 **and** restores every mode bit |
+| the mutation sweep | baseline green (67) before any mutant is scored; a known-fatal mutant is killed | 16/16 mutants killed, each by the **named** test; originals restored and re-verified green |
+
+🔴 **The backup precondition refuses on every way of NOT getting an answer**, not only on a
+stale answer. devrc PR #1132 exists because fifteen places in this repo asserted this
+store's backup state and were wrong about it, in both directions across its life. A missing
+`status.lastSuccessfulTime` is reported as **COULD NOT MEASURE**, never as "0 hours ago".
+
+⚠ **What the backup gate does NOT establish, said out loud:** that the backup is
+*restorable*. `lastSuccessfulTime` is the CronJob controller's record that a Job exited 0.
+Restore-testing is homelab-infra#551's business; this is a liveness gate, not a drill.
+
+## 10. Two documents corrected
+
+**(a) `plan-cairn-integration.md` said "No tenancy, no auth, no age-out, no sharing exist in
+any form."** The auth half is **false and was false when written**. Measured with both
+controls against a read route: no token → **401**, wrong token → **401**, the real host
+credential → **200**. Per-token identity, server-side scope authorization and the
+enumeration property all shipped, and the last unrestricted credential was retired
+2026-08-31. Corrected in place, with the measurement.
+
+**(b) There are two live phase numberings, and they cross.** The plan document numbers
+*phases of the plan*; clawgate #371, the handoff docs and every commit message number
+*delivery milestones*. They are not the same axis and neither can be renamed — one is in
+commit messages, the other is the planning vocabulary.
+
+| delivery label (commits, cg#371, handoff docs) | what shipped | plan-document phase |
+|---|---|---|
+| "phase 1" | seed + read-only hosted API | (precursor to plan phase 1) |
+| "phase 2" | `cairn`, the read-through client | (precursor to plan phase 1) |
+| "phase 3", criteria 1–7 | per-token identity, scope authorization, the write path | **plan phase 2** |
+| "phase 3", criterion 10 | retiring the unrestricted credential | **plan phase 2** |
+| "phase 3", criteria 8 + 9 | the re-seed and **this cutover** | **plan phase 1** |
+
+🔴 **So "phase 3 criteria 8/9" is plan PHASE 1 work carrying a phase-3 label**, which is
+exactly why it reads as further along than it is. The rule going forward, recorded in the
+plan document: **the plan document's phases are canonical for planning; the delivery labels
+are historical and are not renamed; any new work item names both.**
+
+## 11. What is left after this
+
+In the order they should be done, each with the condition that closes it:
+
+1. **The protocol change** (§5 item 3) — a devrc PR editing the `subsystem-index` skill's
+   write step, shipped, and one `/handoff` observed appending through `cairn append`.
+2. **A create route** (§5 item 1) — a merged devrc PR adding it to `server.py`, deployed,
+   and `cairn` gaining the verb.
+3. **The read/write allowlist split** (§5 item 2) — a merged devrc PR plus a homelab-infra
+   secret change, verified by a read-only credential getting a refusal on a write and 200 on
+   a read.
+4. **Drop the dead aliases** — the 4 LATENT collisions. Each is a one-line edit; each
+   becomes live the day its shadowing filename is renamed.

--- a/claudedocs/plan-cairn-phase1-cutover.md
+++ b/claudedocs/plan-cairn-phase1-cutover.md
@@ -570,13 +570,28 @@ that survive a diff review.
 ⚠ **Bounding it honestly, in both directions.** Every commit on the branch was scanned for
 the strings the sweep can write: exactly one was contaminated, and it is reverted; HEAD's
 blob is byte-identical to the verified backup. And the contaminated commit was never going
-to become `main`'s state under any merge method — devrc's recent practice is **squash**
-(all twelve most recent first-parent commits on `main` carry a `(#N)` squash suffix), which
-discards intermediates entirely; merge commits are *permitted* and five exist in history,
-but even under one the merge's TREE is the branch head's content. So the blast radius is
-this branch's history, not the mainline. That bound does not make the incident less worth
-recording — the same race would have shipped the disabled guard had it landed on the final
-commit instead of an intermediate one.
+to become `main`'s state under any merge method. devrc's recent practice is **squash** —
+the twelve most recent first-parent commits on `main` all carry a `(#N)` squash suffix — and
+a squash discards intermediates entirely. But merge commits are permitted and **common in
+this repo's history: 49 on first-parent at the time of writing**, of which 30 are GitHub PR
+merges and 19 are *local* merges (`Merge branch 'main' of …`, `Merge remote-tracking branch
+…`) — a different animal, and worth not lumping together. Under any of them the merge's
+TREE is still the branch head's content. So the blast radius is this branch's history, not
+the mainline.
+
+🔴 **AND THE COUNTER-BOUND, so the paragraph above cannot be read as "we were fine": the
+same race would have shipped the disabled guard had it landed on the FINAL commit instead of
+an intermediate one. Only the ordering prevented that, not the mechanism.** We were fine by
+luck.
+
+⚠ **That merge count was WRONG in this document's first draft, and the way it was wrong is
+the same class of defect as the incident it describes.** It read "five exist in history",
+taken from `git log --merges --oneline origin/main -5` — a command whose `-5` *is the
+number that came back*. The length of a list truncated by your own flag is not a population
+count, and it reads as measured precisely because it is specific. The same shape as
+`gh pr view --json files` silently capping at 100, and of a `grep | head` whose zero means
+"the pattern was not in the first N". **Ask what bounded the output before quoting its
+size.**
 
 **The operational rule:** never run a mutation sweep concurrently with anything that stages,
 builds or tests. It contends with all three and only one of them fails loudly.

--- a/claudedocs/plan-cairn-phase1-cutover.md
+++ b/claudedocs/plan-cairn-phase1-cutover.md
@@ -140,12 +140,23 @@ So there are two classes, and conflating them would make the check a permanently
 
 ### What is actually there
 
-Measured over the union (195 entries), using the resolver's own `normalize_ref`:
+Measured over the union (195 entries), using the resolver's own `normalize_ref` **and its
+own `split_kind`**:
 
 | | count | where they come from |
 |---|---|---|
 | LIVE | **3** | 1 **introduced by the merge**; 2 pre-existing on one host and newly *served* |
 | LATENT | **4** | 2 pre-existing; **2 introduced by the merge** |
+
+⚠ **An earlier count of these same numbers was a FLOOR, not a count**, and the correction is
+worth keeping. The checker first split `<slug>.<kind>.md` with a hand-rolled
+`stem.split(".")` instead of importing `split_kind`, which registered only kind-less files
+under their slug. But `resolve_ref_tiered` matches a bare ref against `e.slug` with **no
+kind constraint**, so `svc` reaches `svc.md` *and* `svc.process.md` and raises — a live
+ambiguity making both entries unwritable, and the checker returned nothing for it.
+Re-measured after importing the resolver's own splitter: the union happens to hold no such
+pair, so the table above is unchanged — but it is now a count rather than a lower bound, and
+the difference was invisible until the splitter was shared.
 
 - **The introduced LIVE one** is an alias claimed by an infra-scope entry on one host and by
   a differently-named infra-scope entry on the other. It exists on neither host today and
@@ -279,17 +290,41 @@ the cutover, criterion 8 reduces to a verification rather than a second push.
 
 | phase | what it changes | rollback |
 |---|---|---|
-| P0 preconditions | nothing | — |
+| P0 preconditions | **a run directory (0700) holding a full copy of the store, and one non-mutating POST** — see below | delete the run directory |
 | P1 plan | writes only into the run directory | delete the run directory |
 | P2 collisions | nothing | — |
 | P3 push | adds and overwrites entries on the pod | `cairn-cutover.py --rollback-push <run-dir> --apply` re-PUTs the pre-push bytes saved for every entry the push was about to overwrite. **Partial by construction**: an ADD has no pre-image and the API has no delete verb. |
 | P4 verify | nothing | — |
-| P5 freeze | `chmod 0444` on entry files | `cairn-cutover.py --unfreeze --apply` |
+| P5 freeze | records every entry's mode, then `chmod 0444` | `cairn-cutover.py --unfreeze --apply` restores **the recorded modes**, not a normalised 0644 |
 | protocol change (§8 step 7) | a skill body | revert the commit, `ship.sh` |
 
+⚠ **"A dry run changes nothing" is not literally true, and the two exceptions are worth
+knowing.** P0 runs on every non-`--freeze` invocation, including a dry run, and it (a)
+creates `~/.local/share/cairn-cutover/runs/<ts>/cache/` — **mode 0700, and holding a full
+plaintext copy of the client-confidential store** — which accumulates one per run with no
+cleanup, and (b) sends one `POST` to the live pod. That POST cannot write anything (§9), but
+it is metered and it lands in the audit log. Nothing on either host's store, and nothing
+already on the pod, is modified.
+
+🔴 **The backup precondition gates the CUTOVER, not every mode of this script.** It lives in
+the P0 block, which `--freeze`, `--unfreeze`, `--rollback-push` and `--manifest` all skip.
+That is right for three of them — `--manifest` reads, and the two rollbacks are what you
+reach for *after* something went wrong. It is a real gap for **`--freeze --apply`**, which
+chmods every entry file in the store with no backup check, no store comparison and no
+acceptance run. It is reversible (`--unfreeze --apply`, from the mode ledger the freeze
+writes) and it is a documented single-phase escape hatch — but do not read §9's table as
+covering it.
+
 Beneath all of it: the daily backup CronJob (homelab-infra#551, 03:45 UTC, 90-day ILM,
-credential with no `s3:DeleteObject`). The script **refuses to run** without a recent
-successful one — see §9.
+credential with no `s3:DeleteObject`).
+
+⚠ **`--unfreeze` REQUIRES the mode ledger and refuses without it.** `chmod 0444` destroys
+the originals, so a restore with nothing to restore *to* can only invent a mode — and
+inventing 0644 for an entry that was 0600 is a permission **widening** on
+client-confidential content, performed by the recovery path and called a rollback. The
+freeze therefore writes `<run-dir>/.cairn-cutover-modes.json` (0600) before it changes
+anything, and an entry created *after* the freeze — possible, since scope directories stay
+writable — is reported and **left alone**, never guessed at.
 
 ⚠ **The rollback for a failed FREEZE is automatic and is not optional.** If the freeze is
 applied and any entry file still accepts a write, the script restores every mode bit to
@@ -371,17 +406,43 @@ ssh zach@10.42.0.100 "python3 ~/workspace/devrc/scripts/cairn-cutover.py \
 
 # 8. VERIFY THE WHOLE THING from a fresh session, on BOTH hosts:
 cairn sync && cairn recall --scope <a scope> | head -5
-python3 $D/scripts/cairn-cutover.py            # must print P1 … NEEDS_MERGE 0 and
-                                               # P5 "already applied", rc 0
+python3 $D/scripts/cairn-cutover.py \
+  --peer-manifest ~/.local/share/cairn-cutover/laptop-manifest.json
+#    expect rc 0 and, in the P1 line, NEEDS_MERGE 0 with an EMPTY delta:
+#      "P1 plan over <n> local entries: {'ADD': 0, 'SAME': <n>, 'SUPERSEDES': 0,
+#       'MERGED': 0, 'NEEDS_MERGE': 0}"
+#      "DRY RUN — 0 entr(ies) would be pushed …"
+#    🔴 A DRY RUN DOES NOT REACH P5 — it returns at the end of P3, by design, so
+#    it prints no P5 line at all. An earlier version of this step said to expect
+#    `P5 "already applied"`, which no dry run can emit; the obvious "fix" is to
+#    add --apply, which re-enters the push path. Check the freeze separately,
+#    read-only:
+python3 $D/scripts/cairn-cutover.py --freeze   # dry run of phase 5 ALONE
+#    expect: "P5 every entry file already refuses a write — the freeze is
+#             already applied. This is the idempotent re-run.", rc 0
 ```
 
 **Rollback, if step 5 or 6 goes wrong:**
 
 ```bash
-python3 $D/scripts/cairn-cutover.py --unfreeze --apply          # local disk writable again
+# restore each entry to the mode the freeze RECORDED (not a normalised 0644):
+python3 $D/scripts/cairn-cutover.py --unfreeze --apply
+#   it uses the newest ~/.local/share/cairn-cutover/runs/*/.cairn-cutover-modes.json;
+#   pass --mode-ledger <path> to pick one. With NO ledger it REFUSES rather than
+#   inventing a mode — that refusal is correct, not an obstacle.
+
+# re-PUT the served bytes of every entry the push overwrote:
 python3 $D/scripts/cairn-cutover.py --rollback-push \
-    ~/.local/share/cairn-cutover/runs/<timestamp> --apply       # re-PUT the overwritten bytes
+    ~/.local/share/cairn-cutover/runs/<timestamp> --apply
+#   PARTIAL BY CONSTRUCTION: an ADD has no pre-image and the API has no delete
+#   verb, so this undoes overwrites only. It derives a fresh If-Match, so it
+#   REFUSES rather than clobbering a third party's later write.
 ```
+
+⚠ **What the acceptance check does NOT cover.** `comm -23` compares **this host** against
+the served copy. An entry only the *other* host holds is not checked for strandedness by a
+run on this one — which is why step 6 runs the whole script on the laptop too, and why the
+peer manifest is worth producing even though the plan could proceed without it.
 
 ## 9. The instruments, and how each was validated
 
@@ -394,7 +455,17 @@ answer. A green from an unvalidated instrument is a claim about the instrument.
 | the backup precondition | absent CronJob, absent `kubectl`, unparseable JSON, unparseable timestamp, and a `lastSuccessfulTime` that is **absent** → all refuse with their own sentence | a fresh timestamp passes and prints the measured age beside the ceiling; the boundary is measured from **both** sides (35.5 h passes, 36.5 h refuses) |
 | the write-route probe | a `405 read-only` server → reported as an **operator** problem | a `400 bad-request` server → reported as deployed. The probe body is `{}`, refused by the server's validator *before* any ref is resolved, so it cannot write |
 | the freeze | `probe_writable` returns `writable` at 0644 and `refused` at 0444, on the same file, twice | a partially-applied freeze (one file left writable) exits 16 **and** restores every mode bit |
-| the mutation sweep | baseline green (67) before any mutant is scored; a known-fatal mutant is killed | 16/16 mutants killed, each by the **named** test; originals restored and re-verified green |
+| the mutation sweep | baseline green before any mutant is scored; a known-fatal mutant is killed | **28/28** killed, each by the **named** test; originals restored and re-verified green |
+
+⚠ **The sweep took five rounds, and three of them found a defect in the sweep or in the
+guards rather than in the code.** Recorded because the pattern is the norm here, not bad
+luck: round 1 found two guards that could not be reached (one unreachable behind an earlier
+return — labelled, not counted; one predicate inseparable from its neighbour — **deleted**);
+round 3 found the sweep's own parser matching `0 failed for another reason` out of the
+script's stderr instead of pytest's summary line, scoring a killed mutant as SURVIVED; round
+4 found two guards whose tests pinned membership rather than behaviour (a status table row
+could point at the wrong exit code, and `main` could discard the probe's own code, both
+invisibly). Only round 5 returned clean, which is what ended it.
 
 🔴 **The backup precondition refuses on every way of NOT getting an answer**, not only on a
 stale answer. devrc PR #1132 exists because fifteen places in this repo asserted this

--- a/claudedocs/plan-cairn-phase1-cutover.md
+++ b/claudedocs/plan-cairn-phase1-cutover.md
@@ -237,6 +237,23 @@ disjointness as a set, and a mutant that collides them is killed.
    *Closing condition: a merged devrc PR changing `claude/skills/subsystem-index/SKILL.md`'s
    write step, shipped, and one `/handoff` observed appending through `cairn append`.*
 
+### What else touches the local store, and what the freeze does to each
+
+Checked, because a freeze is only safe if you know every writer. Three timers/tools reach
+that tree:
+
+| toucher | what it does | effect of a 0444 entry file |
+|---|---|---|
+| `analyze-service-index-commit.timer` (hourly) | `git init` / `git add` / `git commit` per scope | **unaffected.** It writes only into `<scope>/.git/`, which stays 0755, and it rewrites no working-tree byte (measured, and stated in the skill's own reference). Reading a 0444 file is what `git add` needs. |
+| `analyze-service-index-backup.timer` (6-hourly) | reads the tree, encrypts, uploads | **unaffected** — read-only over the tree. |
+| the `subsystem-index` / `analyze-service` append protocol | `Edit` on an entry | **EACCES.** Intended: that is the hazard being closed. It moves to `cairn append` in §8 step 7. |
+| the `prune-index` skill | evicts RESOLVED bullets — a whole-file rewrite | **EACCES.** Not covered by step 7's append change: pruning is a `cairn put`, and that skill needs its own follow-up. Named here so it is not discovered as a mystery permission error. |
+
+🔴 **`prune-index` is the writer most likely to be forgotten**, because it runs rarely and
+its failure will arrive weeks later looking like a broken store rather than a completed
+migration. Its closing condition is the same shape as step 7's: a merged devrc PR routing
+its rewrite through `cairn put`, shipped, and one prune observed landing on the pod.
+
 ## 6. The ordering argument: criterion 9 BEFORE criterion 8
 
 `claudedocs/handoff-cairn-phase3.md` ranks the laptop re-seed (criterion 8) at rank 3 and
@@ -426,5 +443,8 @@ In the order they should be done, each with the condition that closes it:
 3. **The read/write allowlist split** (§5 item 2) — a merged devrc PR plus a homelab-infra
    secret change, verified by a read-only credential getting a refusal on a write and 200 on
    a read.
-4. **Drop the dead aliases** — the 4 LATENT collisions. Each is a one-line edit; each
+4. **Route `prune-index` through `cairn put`** (§5's table) — a merged devrc PR, shipped, and
+   one prune observed landing on the pod. Lowest urgency and highest surprise value: it runs
+   rarely, so its EACCES will arrive weeks after the cutover looking like a broken store.
+5. **Drop the dead aliases** — the 4 LATENT collisions. Each is a one-line edit; each
    becomes live the day its shadowing filename is renamed.

--- a/scripts/cairn
+++ b/scripts/cairn
@@ -42,6 +42,15 @@ never absorbed into "served from cache"; an outage is benign and that is not.
 Beyond those, a report exits with the READER's own code, so a scope whose
 entries are all malformed still exits non-zero as it always did.
 
+🔴 AND THE WRITE VERBS ARE THE MIRROR IMAGE — `append` and `put` DO NOT DEGRADE.
+The table above exists because a read must never report an outage as an empty
+store. A write has the opposite obligation: there is no cache to answer from and
+no such thing as a stale write, so an unreachable store is a REFUSED write at
+exit 7, never a queued one and never a local one. Codes 6/7/8 (refused /
+unreachable / precondition-failed) are disjoint from every read code precisely so
+a caller cannot read "nothing was displayed" as "the bullet landed". The pod is
+the authority; this cache has none. See the WRITE PATH block below the readers.
+
 CONFIG: `~/.config/subsystem-store/env` (mode 0600) — `SUBSYSTEM_STORE_URL`,
 `SUBSYSTEM_STORE_TOKEN`. Environment variables of the same name win, so a test
 can point this at a throwaway server without touching the file. See SECRETS.md.
@@ -51,6 +60,7 @@ from __future__ import annotations
 
 import argparse
 import fcntl
+import hashlib
 import io
 import json
 import os
@@ -64,6 +74,7 @@ import urllib.request
 import zlib
 from pathlib import Path
 from typing import Sequence
+from urllib.parse import quote
 
 sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
 import subsystem_recall as rc  # noqa: E402
@@ -94,6 +105,33 @@ EXIT_REFRESH_FAILED = 4
 # The server answered with something we refuse to install. Distinct from every
 # other code so it can never be read as an outage or as a clean run.
 EXIT_CORRUPT = 5
+
+# --- WRITE codes. Deliberately distinct from every READ code above. ----------
+#
+# 🔴 A WRITE HAS NO CACHE TO FALL BACK ON, AND THAT ASYMMETRY IS THE CONTRACT.
+# `recall`'s job is to answer, so an outage degrades to a stale answer that says
+# it is stale, at exit 0. A write's job is to make a durable record; there is no
+# such thing as a stale write, and a queued one is a write the caller believes
+# landed. So `append`/`put` FAIL LOUDLY when the store cannot be reached — the
+# accepted cost of decision 8 in `claudedocs/plan-cairn-integration.md`, stated
+# there and stated again here so a future reader cannot mistake it for an
+# oversight and "fix" it by adding a spool.
+#
+# 6 = the STORE refused the request and the caller must change it (4xx that is
+#     not a precondition failure): a malformed bullet, an unknown ref, a scope
+#     this credential may not see. Retrying byte-for-byte cannot help.
+EXIT_WRITE_REFUSED = 6
+# 7 = the write did NOT happen and the reason is not the caller's request — the
+#     host was unreachable, or the server could not read its own store (503).
+#     Distinct from 6 because a retry is exactly the right response to this one
+#     and exactly the wrong response to that one.
+EXIT_WRITE_UNREACHABLE = 7
+# 8 = the precondition failed (412): the entry moved under the revision this
+#     write was based on. Its own code because the remedy is unique — re-sync,
+#     re-derive the revision, re-apply the edit — and because collapsing it into
+#     6 would invite a blind retry that either 412s forever or, with `If-Match`
+#     dropped, silently overwrites somebody else's change.
+EXIT_WRITE_PRECONDITION = 8
 
 STATE_LIVE = "live"
 STATE_CACHED = "cached"
@@ -159,6 +197,29 @@ def load_config(path: Path | None = None) -> tuple[str, str]:
     return url.rstrip("/"), token  # type: ignore[union-attr,return-value]
 
 
+def _apply_standard_headers(req: "urllib.request.Request", token: str) -> None:
+    """The two headers EVERY request to this host must carry, in ONE place.
+
+    🔴 A User-Agent IS REQUIRED, and urllib's default is actively refused.
+    MEASURED 2026-08-25 against the live host, same token, same path, three
+    requests differing ONLY in this header:
+        curl's default UA    -> 200
+        `Python-urllib/3.12` -> 403      <-- urllib's default
+        empty UA             -> 200
+    The 403 comes from the edge, not the app, so it is NOT a token rejection and
+    NOT the store being down — but it arrives looking like both.
+
+    🔴 THIS EXISTS AS A FUNCTION BECAUSE THE WRITE PATH WOULD OTHERWISE HAVE TO
+    RE-LEARN IT. When `fetch_snapshot` was the only caller the header was a line
+    inside it; adding `append`/`put` made that line a rule with two more sites,
+    and a rule at three sites is the shape `claude/RULES.md` says regenerates
+    the same bug at N-1 of them. `test_every_request_builder_sets_the_UA` pins
+    that no request leaves this file without going through here.
+    """
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("User-Agent", "subsystem-store-client/1")
+
+
 def fetch_snapshot(
     url: str, token: str, *, scope: str | None, timeout: int
 ) -> tuple[bytes, dict[str, str]]:
@@ -175,18 +236,11 @@ def fetch_snapshot(
         raise StoreUnreachable(f"refusing to fetch {url}: {bad}")
     target = f"{url}/api/v1/snapshot" + (f"?scope={scope}" if scope else "")
     req = urllib.request.Request(target, method="GET")
-    req.add_header("Authorization", f"Bearer {token}")
-    # 🔴 A User-Agent IS REQUIRED, and the default one is actively refused.
-    # MEASURED 2026-08-25 against the live host, same token, same path, three
-    # requests differing ONLY in this header:
-    #     curl's default UA    -> 200
-    #     `Python-urllib/3.12` -> 403      <-- urllib's default
-    #     empty UA             -> 200
-    # The 403 comes from the edge, not the app, so it is NOT a token rejection
-    # and NOT the store being down — but it arrives looking like both. Without
-    # this line every Python client of `store.zacx.dev` is blocked, which is
-    # exactly the shape of bug that gets diagnosed as "the store is broken".
-    req.add_header("User-Agent", "subsystem-store-client/1")
+    # Auth + the mandatory User-Agent. See `_apply_standard_headers` for the
+    # measurement that makes the UA load-bearing; without it every Python client
+    # of this host is blocked, which is exactly the shape of bug that gets
+    # diagnosed as "the store is broken".
+    _apply_standard_headers(req, token)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             # 🔴 RETURN THE MESSAGE, NEVER A DICT BUILT FROM IT.
@@ -731,6 +785,246 @@ def cmd_validate(args: argparse.Namespace) -> int:
     return worst
 
 
+# =============================================================================
+# THE WRITE PATH (criterion 9). Everything above this line reads.
+# =============================================================================
+#
+# 🔴 WRITE-THROUGH, NO SPOOL, NO CACHE FALLBACK. The pod is the authority; the
+# local cache is a read-through copy with no authority of its own. A write that
+# cannot reach the pod is REFUSED, loudly, at a non-zero exit — it is never
+# queued, never written to the cache, and never reported as done. `/resume` and
+# every other READ keeps working offline off the cache; only writes stop. That
+# asymmetry is decision 8 in `claudedocs/plan-cairn-integration.md` and the
+# reason it is acceptable is that a refused write costs one retry while a
+# silently-local write costs the bullet the next `seed.sh` overwrites.
+#
+# 🔴 THE ACTOR IS NOT SENT AND CANNOT BE. `server._append_bullet` derives it
+# from the token that authenticated and DISCARDS any `actor` key in the body.
+# This client therefore does not have an `--actor` flag: offering one would
+# imply a control the caller does not have.
+
+
+class WriteRefused(Exception):
+    """The store answered, and the answer is a refusal. Carries its own code.
+
+    🔴 SEPARATE FROM `StoreUnreachable` FOR THE SAME REASON `StoreCorrupt` IS.
+    "I could not ask" and "I asked and was told no" have different remedies —
+    retry vs change the request — and a client that collapses them turns a
+    permanently-malformed bullet into an infinite retry, or a transient outage
+    into "the store rejected this, give up".
+    """
+
+    def __init__(self, exit_code: int, status: str, detail: str) -> None:
+        super().__init__(detail)
+        self.exit_code = exit_code
+        self.status = status
+        self.detail = detail
+
+
+# HTTP status -> (our exit code, whether the caller should retry unchanged).
+# 🔴 A TABLE, NOT AN `if` LADDER, so `test_every_documented_server_status_maps`
+# can walk it against the statuses `server.py` actually emits on a write route.
+# An unmapped code is NOT silently treated as success: `_classify` falls through
+# to EXIT_WRITE_REFUSED and says the code was unrecognised, which is loud and
+# wrong-in-the-safe-direction (the caller is told the write did not land).
+_WRITE_STATUS_EXITS: dict[int, int] = {
+    400: EXIT_WRITE_REFUSED,        # malformed body / ambiguous ref
+    401: EXIT_WRITE_REFUSED,        # no or bad credential
+    403: EXIT_WRITE_REFUSED,        # edge refusal (see the User-Agent note)
+    404: EXIT_WRITE_REFUSED,        # scope-unknown or ref-unknown
+    405: EXIT_WRITE_REFUSED,        # read-only image: the write path is NOT deployed
+    412: EXIT_WRITE_PRECONDITION,   # If-Match named a revision the entry no longer has
+    422: EXIT_WRITE_REFUSED,        # entry-shape: no `## Nuance / work-history`
+    428: EXIT_WRITE_REFUSED,        # precondition required (a PUT with no If-Match)
+    429: EXIT_WRITE_UNREACHABLE,    # rate limited — a retry IS the right response
+    503: EXIT_WRITE_UNREACHABLE,    # the server could not read its own store
+}
+
+
+def _classify(code: int, status: str, detail: str) -> WriteRefused:
+    exit_code = _WRITE_STATUS_EXITS.get(code)
+    if exit_code is None:
+        return WriteRefused(
+            EXIT_WRITE_REFUSED,
+            status or f"http-{code}",
+            f"unrecognised HTTP {code} on a write route — treating the write as "
+            f"NOT LANDED: {detail}",
+        )
+    return WriteRefused(exit_code, status or f"http-{code}", detail)
+
+
+def send_write(
+    url: str,
+    token: str,
+    *,
+    method: str,
+    path: str,
+    body: bytes,
+    timeout: int,
+    extra_headers: dict[str, str] | None = None,
+) -> tuple[dict[str, str], bytes]:
+    """One request against a write route. Returns `(headers, body)` on 200.
+
+    Raises `WriteRefused` on any non-200 the server produced, and
+    `StoreUnreachable` when there was no answer at all. Nothing else escapes.
+    """
+    bad = _cairn_who().unbounded_timeout_reason(timeout)
+    if bad:
+        # 🔴 THE SAME REFUSAL THE READ PATH MAKES, FOR THE SAME REASON. A
+        # `timeout=None` reaches `urlopen` as NO timeout, and an unbounded WRITE
+        # is strictly worse than an unbounded read: the request may already have
+        # been applied, so a caller that eventually gives up cannot tell whether
+        # it landed.
+        raise StoreUnreachable(f"refusing to write to {url}: {bad}")
+    target = f"{url}{path}"
+    req = urllib.request.Request(target, data=body, method=method)
+    _apply_standard_headers(req, token)
+    req.add_header("Content-Type", "application/json")
+    for name, value in (extra_headers or {}).items():
+        req.add_header(name, value)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            # `resp.headers` returned as the Message, never `dict(...)` — see
+            # `fetch_snapshot` for the measured case-folding incident.
+            return resp.headers, resp.read()
+    except urllib.error.HTTPError as exc:
+        try:
+            detail = exc.read().decode("utf-8", "replace").strip().replace("\n", "; ")
+        except Exception:
+            detail = ""
+        status = exc.headers.get("X-Store-Status", "") if exc.headers else ""
+        raise _classify(exc.code, status, detail[:400] or f"HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise StoreUnreachable(f"{url} unreachable: {exc.reason}") from exc
+    except OSError as exc:
+        raise StoreUnreachable(f"{url} unreachable: {exc}") from exc
+
+
+def _write_scope(args: argparse.Namespace) -> str | None:
+    """The scope a write targets, or None having already printed why."""
+    try:
+        scope = args.scope or scope_for_repo(args.repo)
+    except Exception as exc:
+        print(
+            f"cairn: could not derive a scope from {args.repo!r}: {exc}\n"
+            f"       pass --scope explicitly.",
+            file=sys.stderr,
+        )
+        return None
+    if not scope:
+        print("cairn: --scope is required (no scope could be derived)", file=sys.stderr)
+        return None
+    return scope
+
+
+def cmd_append(args: argparse.Namespace) -> int:
+    """`POST /api/v1/entry/<scope>/<ref>/bullets` — append ONE dated bullet.
+
+    🔴 THIS IS THE VERB CRITERION 9 ROUTES `subsystem-index` THROUGH. Before it
+    existed the skill's append was an `Edit` against `~/.claude/analyze-service-
+    index/<scope>/<entry>.md`, which is local-only: the bullet lived on one host
+    and the next `seed.sh` from any host replaced the served copy with a file
+    that never had it. This makes the append land where the authority is.
+
+    🔴 DO NOT DATE-PREFIX `--text`. The server prepends `- <date>: ` itself; the
+    first production append through this route reads `- 2026-08-29: 2026-08-29:
+    …` because a caller did.
+    """
+    scope = _write_scope(args)
+    if scope is None:
+        return EXIT_USAGE
+    url, token = load_config()
+    payload = json.dumps({"text": args.text, "session": args.session}).encode("utf-8")
+    quoted = f"/api/v1/entry/{quote(scope, safe='')}/{quote(args.ref, safe='')}/bullets"
+    headers, body = send_write(
+        url, token, method="POST", path=quoted, body=payload,
+        timeout=_store_timeout(args),
+    )
+    status = headers.get("X-Store-Status", "unknown")
+    revision = (headers.get("ETag") or "").strip('"')
+    # 🔴 `duplicate` IS PRINTED, NOT SWALLOWED, and it exits 0. The server
+    # recognises a bullet by CONTENT HASH, so a re-POST after a timeout is
+    # idempotent — which is the property that makes a retry safe. But a caller
+    # told nothing would read "appended" into a run that wrote nothing, and the
+    # store's own idempotency note says a genuinely new bullet whose text is
+    # byte-identical to an existing one is silently NOT appended. Saying which
+    # of the two happened is the whole difference.
+    print(
+        f"cairn: {status} scope={scope} ref={args.ref} revision={revision or 'unknown'}"
+    )
+    sys.stdout.write(body.decode("utf-8", "replace"))
+    return EXIT_OK
+
+
+def cmd_put(args: argparse.Namespace) -> int:
+    """`PUT /api/v1/entry/<scope>/<ref>` — whole-file replace behind `If-Match`.
+
+    🔴 WHY A WHOLE-FILE VERB EXISTS AT ALL, given that `append` is the safe one:
+    the `subsystem-index` protocol also mandates rewriting an existing bullet's
+    `OPEN:` marker to `RESOLVED <sha>:` **in the same edit**, and updating
+    `## Pointers`. Neither is an append. Without this verb, freezing the local
+    store read-only would make those two operations impossible rather than
+    merely relocated — the cutover would REGRESS a documented protocol step.
+
+    🔴 THE REVISION IS DERIVED FROM A **LIVE** SYNC, NEVER FROM `--no-sync`.
+    `server.entry_revision` is `sha256(file bytes)[:16]`, so the cache can
+    compute it offline — which is exactly what makes a stale cache dangerous
+    here in a way it is not for a read: an edit based on bytes that moved is a
+    lost update, and the `If-Match` is what turns that into a 412 instead of a
+    silent overwrite. Deriving it from a cache we did not just refresh would
+    still be *correct* (the server compares against its own copy) but it wastes
+    the operator's edit on a guaranteed 412. `--if-match` is accepted for the
+    case where the caller already holds the value.
+    """
+    scope = _write_scope(args)
+    if scope is None:
+        return EXIT_USAGE
+    revision = args.if_match
+    if not revision:
+        state, detail, hint = resolve_state(
+            args.cache, no_sync=False, scope=None, timeout=_store_timeout(args)
+        )
+        if state != STATE_LIVE:
+            # 🔴 NOT "served from cache". A read may degrade; deriving a
+            # precondition from bytes we could not confirm is the one case where
+            # the cache is worse than nothing.
+            print(
+                f"🔴 cairn: refusing to PUT — could not refresh the cache, so the "
+                f"revision would be derived from bytes that may have moved "
+                f"({detail}). Pass --if-match explicitly if you already hold it.",
+                file=sys.stderr,
+            )
+            return hint if hint is not None else EXIT_WRITE_UNREACHABLE
+        matches = sorted(args.cache.glob(f"{scope}/{args.ref}.md")) or sorted(
+            args.cache.glob(f"{scope}/{args.ref}.*.md")
+        )
+        if len(matches) != 1:
+            print(
+                f"cairn: cannot derive a revision — {len(matches)} cached file(s) "
+                f"match {scope}/{args.ref}. Pass --if-match, or use the entry's "
+                f"exact filename stem as --ref.",
+                file=sys.stderr,
+            )
+            return EXIT_USAGE
+        revision = hashlib.sha256(matches[0].read_bytes()).hexdigest()[:16]
+        print(f"cairn: derived If-Match {revision} from the live snapshot", file=sys.stderr)
+    url, token = load_config()
+    payload = args.file.read_bytes()
+    quoted = f"/api/v1/entry/{quote(scope, safe='')}/{quote(args.ref, safe='')}"
+    headers, body = send_write(
+        url, token, method="PUT", path=quoted, body=payload,
+        timeout=_store_timeout(args),
+        extra_headers={"If-Match": f'"{revision}"'},
+    )
+    new_rev = (headers.get("ETag") or "").strip('"')
+    print(
+        f"cairn: {headers.get('X-Store-Status', 'unknown')} scope={scope} "
+        f"ref={args.ref} revision={new_rev or 'unknown'}"
+    )
+    sys.stdout.write(body.decode("utf-8", "replace"))
+    return EXIT_OK
+
+
 def _cairn_who():
     """The `who` module, imported lazily — it owns the timeout predicate.
 
@@ -876,6 +1170,49 @@ def build_parser() -> argparse.ArgumentParser:
     e = common(sub.add_parser("ls-entries", help="one `<scope>/<entry>.md` per line"))
     e.set_defaults(func=cmd_ls_entries)
 
+    # --- the write verbs -----------------------------------------------------
+    # 🔴 `writes=True` IS NOT DECORATION. `main` maps a `StoreUnreachable` to
+    # exit 3 ("store-unreachable, no cache"), which is a READ verdict and reads
+    # as "nothing was shown". For a write the honest code is 7 — the record was
+    # NOT made — and the two must not share a number, because the whole point of
+    # write-through is that a caller can tell a failed write from a stale read.
+    # 🔴 NEITHER TAKES `--no-sync`. It would be meaningless on `append` and
+    # actively harmful on `put` (see that function on deriving a precondition
+    # from bytes we did not confirm), so it is absent rather than refused.
+    ap = sub.add_parser(
+        "append",
+        help="append ONE dated, attributed bullet to an entry (writes to the pod)",
+    )
+    ap.add_argument("--scope", default=None)
+    ap.add_argument("--repo", default=".")
+    ap.add_argument("--ref", required=True, help="the entry: a filename stem or an alias")
+    ap.add_argument(
+        "--text", required=True,
+        help="the bullet, ONE line, with NO leading `- ` and NO leading date — "
+             "the server adds both",
+    )
+    # 🔴 REQUIRED, WITH NO DEFAULT AND NO ENV FALLBACK. The server refuses a
+    # request without it (400), and criterion 4 is that every appended bullet
+    # records the actor AND the session. A default would be a value nobody
+    # chose, attached to a durable record; an env fallback would silently
+    # attribute one agent's bullet to whatever the shell last exported.
+    ap.add_argument("--session", required=True, help="the writing session's id")
+    ap.set_defaults(func=cmd_append, writes=True)
+
+    pu = sub.add_parser(
+        "put", help="replace a whole entry behind an If-Match precondition"
+    )
+    pu.add_argument("--scope", default=None)
+    pu.add_argument("--repo", default=".")
+    pu.add_argument("--ref", required=True)
+    pu.add_argument("--file", type=Path, required=True, help="the new entry bytes")
+    pu.add_argument(
+        "--if-match", default=None, dest="if_match",
+        help="the entry revision this edit is based on; derived from a LIVE "
+             "sync when omitted",
+    )
+    pu.set_defaults(func=cmd_put, writes=True)
+
     # 🔴 `who` TOUCHES NO STORE AND NO CACHE. It is the first cairn subcommand
     # about a different noun — a TASK, not a subsystem entry — so it takes none
     # of the `common()` flags and never syncs. It is here rather than in its own
@@ -911,6 +1248,18 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.no_sync = False
     try:
         return args.func(args)
+    except WriteRefused as exc:
+        # 🔴 THE STORE ANSWERED, AND THE ANSWER IS NO. Printed with the server's
+        # own `X-Store-Status`, because that token is what distinguishes the four
+        # 404s from each other (`scope-unknown` vs `ref-unknown`) and a 405
+        # (`read-only`) — which is the one that means "the write path is not
+        # deployed on the running image", i.e. an operator problem and not a
+        # caller problem, and which reads exactly like a wrong URL.
+        print(
+            f"🔴 cairn: the store REFUSED the write [{exc.status}] — {exc.detail}",
+            file=sys.stderr,
+        )
+        return exc.exit_code
     except StoreCorrupt as exc:
         # 🔴 LOUD, and never absorbed into "served from cache". A server that
         # ships a link, a traversal member, a duplicate, or a count disagreeing
@@ -919,6 +1268,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"🔴 cairn: REFUSED the archive — {exc}", file=sys.stderr)
         return EXIT_CORRUPT
     except StoreUnreachable as exc:
+        # 🔴 A WRITE AND A READ DO NOT SHARE A CODE HERE. Exit 3 is
+        # "store-unreachable, no cache" — a statement about what was DISPLAYED.
+        # On a write nothing was displayed and, more importantly, nothing was
+        # RECORDED; a caller that reads 3 as "the read came back empty" would
+        # carry on believing the bullet landed. `writes` is set by the write
+        # subparsers only, so this cannot drift with a new read verb.
+        if getattr(args, "writes", False):
+            print(
+                f"🔴 cairn: the write did NOT happen — {exc}\n"
+                f"          Nothing was queued and nothing was written locally. "
+                f"Re-run when the store is reachable.",
+                file=sys.stderr,
+            )
+            return EXIT_WRITE_UNREACHABLE
         # Reached only by a config failure outside `resolve_state`; still named.
         print(f"🔴 cairn: {STATE_NO_CACHE} — {exc}", file=sys.stderr)
         return EXIT_UNREACHABLE_NO_CACHE

--- a/scripts/cairn
+++ b/scripts/cairn
@@ -213,8 +213,17 @@ def _apply_standard_headers(req: "urllib.request.Request", token: str) -> None:
     RE-LEARN IT. When `fetch_snapshot` was the only caller the header was a line
     inside it; adding `append`/`put` made that line a rule with two more sites,
     and a rule at three sites is the shape `claude/RULES.md` says regenerates
-    the same bug at N-1 of them. `test_every_request_builder_sets_the_UA` pins
-    that no request leaves this file without going through here.
+    the same bug at N-1 of them.
+
+    🔴 THE GUARD IS `test_cairn_write.py::TestTheRequestItself::
+    test_no_request_builder_ANYWHERE_bypasses_this_helper` — an AST scan over
+    this file AND `cairn-cutover.py`, asserting every function that constructs a
+    `urllib.request.Request` also calls this helper. An earlier version of this
+    sentence named a test that **did not exist**, which is worse than naming
+    none: it reads as coverage and stops anyone looking. It was written while
+    the only real check was a behavioural one on the append path, so a new read
+    verb building its own request was unguarded by the very line claiming to
+    guard it.
     """
     req.add_header("Authorization", f"Bearer {token}")
     req.add_header("User-Agent", "subsystem-store-client/1")
@@ -837,7 +846,18 @@ _WRITE_STATUS_EXITS: dict[int, int] = {
     422: EXIT_WRITE_REFUSED,        # entry-shape: no `## Nuance / work-history`
     428: EXIT_WRITE_REFUSED,        # precondition required (a PUT with no If-Match)
     429: EXIT_WRITE_UNREACHABLE,    # rate limited — a retry IS the right response
+    # 🔴 500 IS A RETRY, NOT A "FIX YOUR REQUEST". `server._backstop` turns any
+    # unhandled handler exception into a 500, so it IS reachable on a write
+    # route. It was absent here and fell through to `_classify`'s "unrecognised"
+    # arm, which is EXIT_WRITE_REFUSED — telling the caller to change a
+    # byte-identical request that would very likely succeed on a retry. The
+    # fallthrough was labelled "wrong-in-the-safe-direction", and that is true
+    # for landed/not-landed and FALSE for retry/don't-retry, which is the exact
+    # distinction 6 and 7 exist to carry.
+    500: EXIT_WRITE_UNREACHABLE,
+    502: EXIT_WRITE_UNREACHABLE,    # a bad gateway is the edge, not the request
     503: EXIT_WRITE_UNREACHABLE,    # the server could not read its own store
+    504: EXIT_WRITE_UNREACHABLE,
 }
 
 
@@ -988,13 +1008,26 @@ def cmd_put(args: argparse.Namespace) -> int:
             # 🔴 NOT "served from cache". A read may degrade; deriving a
             # precondition from bytes we could not confirm is the one case where
             # the cache is worse than nothing.
+            #
+            # 🔴 AND NOT `hint`. This returned `hint if hint is not None else
+            # EXIT_WRITE_UNREACHABLE`, and `resolve_state` sets `hint` to
+            # EXIT_UNREACHABLE_NO_CACHE (3) exactly when there is NO cache —
+            # which is the FIRST run on a fresh host, i.e. the commonest way to
+            # get here. So the one code this whole file insists a write must
+            # never return was returned by a write, on its likeliest path, while
+            # four separate comments and the design doc said it could not
+            # happen. `hint` is a READ verdict — "this is what a reader should
+            # exit with" — and it has no meaning for a write. Measured before
+            # the fix: put with no cache -> 3, put with a cache -> 7, append
+            # with no cache -> 7.
             print(
                 f"🔴 cairn: refusing to PUT — could not refresh the cache, so the "
                 f"revision would be derived from bytes that may have moved "
-                f"({detail}). Pass --if-match explicitly if you already hold it.",
+                f"({detail}). Nothing was queued and nothing was written locally. "
+                f"Pass --if-match explicitly if you already hold it.",
                 file=sys.stderr,
             )
-            return hint if hint is not None else EXIT_WRITE_UNREACHABLE
+            return EXIT_WRITE_UNREACHABLE
         matches = sorted(args.cache.glob(f"{scope}/{args.ref}.md")) or sorted(
             args.cache.glob(f"{scope}/{args.ref}.*.md")
         )
@@ -1008,8 +1041,17 @@ def cmd_put(args: argparse.Namespace) -> int:
             return EXIT_USAGE
         revision = hashlib.sha256(matches[0].read_bytes()).hexdigest()[:16]
         print(f"cairn: derived If-Match {revision} from the live snapshot", file=sys.stderr)
+    # 🔴 READ THE FILE BEFORE THE NETWORK, NOT AFTER. This came after
+    # `resolve_state` — a full snapshot download — so `--file` naming a path that
+    # does not exist spent the whole sync and then died on an unguarded
+    # `FileNotFoundError` at exit 1: a code in neither the read table nor the
+    # write table, reached by the commonest typo this verb has.
+    try:
+        payload = args.file.read_bytes()
+    except OSError as exc:
+        print(f"cairn: cannot read --file {args.file}: {exc}", file=sys.stderr)
+        return EXIT_USAGE
     url, token = load_config()
-    payload = args.file.read_bytes()
     quoted = f"/api/v1/entry/{quote(scope, safe='')}/{quote(args.ref, safe='')}"
     headers, body = send_write(
         url, token, method="PUT", path=quoted, body=payload,

--- a/scripts/cairn
+++ b/scripts/cairn
@@ -999,6 +999,21 @@ def cmd_put(args: argparse.Namespace) -> int:
     scope = _write_scope(args)
     if scope is None:
         return EXIT_USAGE
+    # 🔴 READ THE FILE BEFORE THE NETWORK — AND "BEFORE THE NETWORK" MEANS ABOVE
+    # `resolve_state`, NOT ABOVE `load_config`. The first attempt at this fix
+    # moved the read up only as far as the config load, which is a local file
+    # read, so the full snapshot download still ran first: a missing `--file`
+    # went on reporting the STORE AS UNREACHABLE (rc 7) instead of "cannot read
+    # --file" (rc 2). The comment claimed the ordering, and the test that
+    # asserted it did so in its NAME while its body checked only the exit code
+    # and the sentence — both of which held with the read left where it was. A
+    # guard's description claiming coverage its body does not provide is the
+    # shape that stops anyone looking.
+    try:
+        payload = args.file.read_bytes()
+    except OSError as exc:
+        print(f"cairn: cannot read --file {args.file}: {exc}", file=sys.stderr)
+        return EXIT_USAGE
     revision = args.if_match
     if not revision:
         state, detail, hint = resolve_state(
@@ -1041,16 +1056,6 @@ def cmd_put(args: argparse.Namespace) -> int:
             return EXIT_USAGE
         revision = hashlib.sha256(matches[0].read_bytes()).hexdigest()[:16]
         print(f"cairn: derived If-Match {revision} from the live snapshot", file=sys.stderr)
-    # 🔴 READ THE FILE BEFORE THE NETWORK, NOT AFTER. This came after
-    # `resolve_state` — a full snapshot download — so `--file` naming a path that
-    # does not exist spent the whole sync and then died on an unguarded
-    # `FileNotFoundError` at exit 1: a code in neither the read table nor the
-    # write table, reached by the commonest typo this verb has.
-    try:
-        payload = args.file.read_bytes()
-    except OSError as exc:
-        print(f"cairn: cannot read --file {args.file}: {exc}", file=sys.stderr)
-        return EXIT_USAGE
     url, token = load_config()
     quoted = f"/api/v1/entry/{quote(scope, safe='')}/{quote(args.ref, safe='')}"
     headers, body = send_write(

--- a/scripts/cairn-cutover.py
+++ b/scripts/cairn-cutover.py
@@ -1371,7 +1371,7 @@ def main(argv: list[str] | None = None) -> int:
     # ---- P5 the freeze ----------------------------------------------------
     before = survey(args.store)
     say(f"P5 before the freeze: {before}")
-    if before["examined"] == 0:
+    if False:
         return refuse(RC_COULD_NOT_MEASURE, (
             "the freeze walked 0 entry files. A '0 writable' from a walk that "
             "visited nothing is not a frozen store."

--- a/scripts/cairn-cutover.py
+++ b/scripts/cairn-cutover.py
@@ -43,14 +43,25 @@ destructive operation into an idempotent one instead of relying on a restore.
 
 PHASES AND THEIR ROLLBACKS
 --------------------------
-  P0  preconditions            — read-only; nothing to roll back
+  P0  preconditions            — creates a 0700 run dir holding a full copy of the
+                                 store, and sends ONE non-mutating POST (see
+                                 `write_route_deployed`). Nothing on either store
+                                 is modified. Roll back by deleting the run dir.
   P1  plan the delta           — read-only; writes only into the run directory
   P2  ref-collision check      — read-only
   P3  push the delta           — rollback: `--rollback-push <run-dir>` re-PUTs the
                                  pre-push bytes this script saved for every entry
                                  it was about to overwrite
   P4  acceptance + byte check  — read-only
-  P5  freeze local disk        — rollback: `--unfreeze`
+  P5  freeze local disk        — records every mode, then chmods. Rollback:
+                                 `--unfreeze`, which RESTORES the recorded modes
+                                 and refuses without the ledger.
+
+⚠ THE BACKUP PRECONDITION GATES THE CUTOVER, NOT EVERY MODE. It lives in the P0
+block, which `--freeze`, `--unfreeze`, `--rollback-push` and `--manifest` skip.
+Right for the last three; a real gap for `--freeze --apply`, which chmods the
+whole store on its own. It is reversible and single-purpose, but do not read the
+precondition as covering it.
 The skill/protocol half of the cutover (routing `subsystem-index` writes through
 `cairn append`) is a DOCUMENT change and is rolled back by reverting its commit;
 this script neither applies nor reverts it, and says so rather than implying it
@@ -108,12 +119,24 @@ RC_USAGE = 2
 RC_ROOT = 9                 # running as root makes the EACCES evidence vacuous
 RC_BACKUP = 10              # no recent SUCCESSFUL backup, or it could not be measured
 RC_UNREACHABLE = 11         # the store could not be read
+# 12 — THE 405 ARM AND NOTHING ELSE. Every other falsy result of the probe is
+# RC_COULD_NOT_MEASURE. This used to answer all of them, so an unreachable pod
+# during P0 was reported as "the running image is read-only" and sent the
+# operator to redeploy the store over a network blip.
 RC_NO_WRITE_ROUTE = 12      # the RUNNING image has no write path (405 read-only)
 RC_NO_STORE = 13            # the local store is missing or holds no scopes
 RC_UNRESOLVED_DIVERGENCE = 14   # two copies disagree and no merged file resolves it
 RC_REF_COLLISION = 15       # a ref would resolve to two entries in the union
 RC_FREEZE_INEFFECTIVE = 16  # the freeze was applied and a write STILL succeeded
-RC_ACCEPTANCE = 17          # `comm -23` did not print zero lines
+# 17 — THE PUSH/VERIFY FAMILY. Deliberately one code with a stated scope rather
+# than a code per site: it means "the entries this host holds are not, or cannot
+# be shown to be, on the pod, and NOTHING WAS FROZEN". Three sites reach it —
+# `seed.sh` exiting non-zero, `comm -23` printing lines, and a failed
+# `--rollback-push` restore — and all three leave the operator in the same place
+# with the same next step (read the verdict lines above, re-run). The ledger used
+# to describe only the `comm -23` site, which is the defect: a code's comment
+# must cover every site that returns it or the comment is the narrower claim.
+RC_ACCEPTANCE = 17
 RC_COULD_NOT_MEASURE = 18   # an instrument did not answer; never folded into a pass
 
 # 🔴 THE DISCRIMINATOR THIS WHOLE MERGE RULE TURNS ON. `server.render_bullet`
@@ -140,7 +163,7 @@ ATTRIBUTION = re.compile(
 # reader that does not exist — it would miss a collision the write route hits,
 # and invent one it does not. There is no version of this worth having twice.
 sys.path.insert(0, str(HERE / "lib"))
-from subsystem_resolver import normalize_ref  # noqa: E402
+from subsystem_resolver import normalize_ref, split_kind  # noqa: E402
 
 
 # =============================================================================
@@ -268,7 +291,7 @@ def backup_precondition(
 
 def write_route_deployed(
     *, url: str, token: str, scope: str, timeout: int = 20
-) -> tuple[bool, str]:
+) -> tuple[bool, str | None, str]:
     """Does the RUNNING image carry the write path? `(ok, sentence)`.
 
     🔴 THE PROBE IS A DELIBERATELY MALFORMED BODY, AND THAT IS WHAT MAKES IT
@@ -287,43 +310,56 @@ def write_route_deployed(
     ⚠ 400 IS THE PASS HERE. That inversion is stated because it reads wrong at a
     glance and a future reader "fixing" it to `== 200` would make the check
     unsatisfiable — the same shape as a guard that can never fire.
+
+    🔴 RETURNS `(ok, rc_on_failure, sentence)` — THREE STATES, NOT TWO. Every
+    falsy result used to be answered by the caller with `RC_NO_WRITE_ROUTE`,
+    which is documented as "the RUNNING image has no write path (405
+    read-only)". So an UNREACHABLE pod during P0 was reported as "the image is
+    read-only", sending the operator to redeploy the store over a network blip.
+    Only the 405 arm means that; everything else is `RC_COULD_NOT_MEASURE`,
+    which exists and was going unused.
     """
     target = f"{url.rstrip('/')}/api/v1/entry/{scope}/__cutover_probe__/bullets"
     req = urllib.request.Request(target, data=b"{}", method="POST")
-    req.add_header("Authorization", f"Bearer {token}")
-    # See `cairn._apply_standard_headers`: urllib's default UA is 403'd by the edge.
-    req.add_header("User-Agent", "subsystem-store-client/1")
+    # 🔴 THE CLI'S OWN HELPER, NOT A FOURTH COPY. This hand-rolled the two
+    # headers, in the same change whose `_apply_standard_headers` docstring
+    # argues that a rule at three sites regenerates the same bug at N-1 of them.
+    # A drifted copy here would be 403'd by the edge and reported as
+    # "the image is read-only" — an operator sent to redeploy over a header.
+    _cairn()._apply_standard_headers(req, token)
     req.add_header("Content-Type", "application/json")
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return False, (
-                f"the probe was ANSWERED {resp.status}, and the only expected answers "
-                f"are 400 (route present) or 405 (route absent). Treating this as "
-                f"UNMEASURED rather than guessing."
+            return False, RC_COULD_NOT_MEASURE, (
+                f"COULD NOT MEASURE the write route: the probe was ANSWERED "
+                f"{resp.status}, and the only expected answers are 400 (route "
+                f"present) or 405 (route absent). Not guessing."
             )
     except urllib.error.HTTPError as exc:
         status = exc.headers.get("X-Store-Status", "") if exc.headers else ""
         if exc.code == 400:
-            return True, (
+            return True, None, (
                 f"the write route IS deployed — the malformed-body probe was refused "
                 f"400 [{status or 'bad-request'}], which only a server that DISPATCHED "
                 f"the POST can answer"
             )
         if exc.code == 405:
-            return False, (
+            return False, RC_NO_WRITE_ROUTE, (
                 f"the RUNNING image is READ-ONLY — POST answered 405 [{status}]. This "
                 f"is an operator problem, not a caller problem: deploy an image "
                 f"carrying the write path before cutting over, or every append after "
                 f"the freeze fails with nowhere to land."
             )
-        return False, (
+        return False, RC_COULD_NOT_MEASURE, (
             f"COULD NOT MEASURE the write route: the probe answered {exc.code} "
             f"[{status}]. 401 means the credential; 403 means the edge."
         )
     except urllib.error.URLError as exc:
-        return False, f"COULD NOT MEASURE the write route: {url} unreachable: {exc.reason}"
+        return False, RC_COULD_NOT_MEASURE, (
+            f"COULD NOT MEASURE the write route: {url} unreachable: {exc.reason}")
     except OSError as exc:
-        return False, f"COULD NOT MEASURE the write route: {url} unreachable: {exc}"
+        return False, RC_COULD_NOT_MEASURE, (
+            f"COULD NOT MEASURE the write route: {url} unreachable: {exc}")
 
 
 # =============================================================================
@@ -464,17 +500,28 @@ def plan_delta(
     for rel, facts in sorted(local.items()):
         src = store_root / rel
         override = (merged_dir / rel) if merged_dir else None
-        if rel not in pod:
-            plan.items.append(Item(rel, ADD, "not present in the served copy", src))
-            continue
-        if pod[rel].sha256 == facts.sha256:
-            plan.items.append(Item(rel, SAME, "byte-identical to the served copy", src))
-            continue
+
+        # 🔴 THE HAND-AUTHORED RESOLUTION IS CONSULTED FIRST, BEFORE EVERY OTHER
+        # CLAUSE. It used to sit third, below the ADD and SAME returns, which
+        # made it UNREACHABLE for any entry the pod does not hold — so an
+        # operator who had written a merge for a host-only entry watched it be
+        # silently ignored in favour of the local copy. A human decision must
+        # not be overridden by a classifier; if it exists, it wins.
         if override is not None and override.is_file():
             plan.items.append(
                 Item(rel, MERGED, f"resolved by hand at {override}", override)
             )
             continue
+
+        # 🔴 THE PEER CHECK IS SECOND, AND IT USED TO BE FIFTH — BELOW `ADD`.
+        # That ordering made merge rule 4 ("host vs host divergent -> ALWAYS a
+        # hand merge, never last-write-wins") FALSE for every entry the pod does
+        # not yet hold, which is precisely the population this migration is
+        # about: the host-exclusive scopes reach the pod for the first time here,
+        # so `rel not in pod` is true for all of them and the ADD return fired
+        # first. The result was first-host-to-run-wins, silently, with no
+        # operator decision — the exact failure the rule is written to forbid,
+        # committed by the code that states it.
         if peer is not None and rel in peer and peer[rel].sha256 != facts.sha256:
             plan.items.append(Item(
                 rel, NEEDS_MERGE,
@@ -484,6 +531,13 @@ def plan_delta(
                 src,
             ))
             continue
+
+        if rel not in pod:
+            plan.items.append(Item(rel, ADD, "not present in the served copy", src))
+            continue
+        if pod[rel].sha256 == facts.sha256:
+            plan.items.append(Item(rel, SAME, "byte-identical to the served copy", src))
+            continue
         pod_only = [b for b in pod[rel].bullets if b not in facts.bullets]
         attributed = [b for b in pod_only if ATTRIBUTION.search(b)]
         if attributed:
@@ -492,6 +546,35 @@ def plan_delta(
                 f"the served copy holds {len(attributed)} API-appended bullet(s) this "
                 f"host does not — that content exists nowhere else and a push would "
                 f"overwrite it. Author a resolution at <merged>/{rel}.",
+                src,
+            ))
+            continue
+        # 🔴 A DIVERGENCE WITH **NO** POD-ONLY BULLETS IS UNRECOGNISED, NOT
+        # SUPERSEDED. The bytes differ and the bullet lists do not, so whatever
+        # moved is OUTSIDE the region this rule can see — front matter, `## What
+        # it is`, `## Pointers`, or a bullet's continuation lines. The attribution
+        # scan says nothing about any of them, so classifying it SUPERSEDES
+        # printed "the served copy holds 0 bullet line(s) this host lacks and
+        # NONE is API-attributed" as the JUSTIFICATION FOR OVERWRITING IT — a
+        # vacuous truth offered as evidence from a scan that examined nothing.
+        #
+        # 🔴 AND THE WRITER THAT PRODUCES EXACTLY THIS SHAPE IS `cairn put`,
+        # WHICH THIS SAME CHANGE ADDS. Its stated reasons to exist are updating
+        # `## Pointers` and rewriting an `OPEN:` marker — both outside the bullet
+        # set, both invisible here. So rule 3's premise ("seed.sh and the API are
+        # the only writers, and the API's changes are attributed") is not broken
+        # by some hypothetical third route; it is broken by this file's sibling.
+        # NEEDS_MERGE is the fail-safe direction this module already declares.
+        if not pod_only:
+            plan.items.append(Item(
+                rel, NEEDS_MERGE,
+                "divergent, but the served copy holds NO bullet line this host "
+                "lacks — so whatever differs is outside the region the "
+                "attribution rule can see (front matter, `## What it is`, "
+                "`## Pointers`, or a bullet's continuation lines). A whole-file "
+                "`cairn put` produces exactly this shape. Unrecognised, therefore "
+                f"refused rather than overwritten. Diff them and resolve at "
+                f"<merged>/{rel}.",
                 src,
             ))
             continue
@@ -544,30 +627,51 @@ def ref_collisions(union: dict[str, EntryFacts]) -> list[Collision]:
     per_scope: dict[str, list[tuple[str, str | None, set[str], str]]] = {}
     for rel, facts in union.items():
         scope, filename = rel.split("/", 1)
-        stem = filename[:-3]
-        parts = stem.split(".")
-        slug, kind = (parts[0], parts[1]) if len(parts) > 1 else (stem, None)
+        stem = filename[:-3] if filename.endswith(".md") else filename
+        # 🔴 THE RESOLVER'S OWN `split_kind`, IMPORTED. The first version was
+        # `parts = stem.split("."); slug, kind = (parts[0], parts[1]) if …` — a
+        # SECOND SPELLING, inside a function whose comment insists a collision
+        # check must never model a different reader than the resolver. It was
+        # wrong in both directions: `split_kind` treats a trailing dot-segment as
+        # a kind ONLY if it is in `KINDS`, so `foo.notes.md` has slug
+        # `foo.notes` here and slug `foo` there (a FALSE collision, the
+        # permanently-red-gate direction), while `a.b.c.md` silently discarded
+        # `c`. See `test_a_KIND_QUALIFIED_file_collides_with_its_bare_sibling`
+        # for the case it MISSED, which is the one that matters.
+        slug, kind = split_kind(normalize_ref(stem))
         per_scope.setdefault(scope, []).append(
-            (normalize_ref(slug), kind, {normalize_ref(a) for a in facts.aliases}, filename)
+            (slug, kind, {normalize_ref(a) for a in facts.aliases}, filename)
         )
     found: list[Collision] = []
     for scope, entries in sorted(per_scope.items()):
-        slugs: dict[str, set[str]] = {}
+        # 🔴 WHAT A FILENAME-TIER REF ACTUALLY REACHES — and the bare-slug row is
+        # the whole fix. `resolve_ref_tiered` matches a ref with NO kind against
+        # `e.slug` alone, **with no kind constraint**, so `svc` hits `svc.md` AND
+        # `svc.process.md` and raises `AmbiguousRefError`. Registering only
+        # kind-less files (the first version) made that pair invisible: measured,
+        # the resolver raised on 2 candidates while this returned `[]` — the
+        # exact condition P2 exists to detect, missed. `repo-cos.process` is the
+        # resolver docstring's own worked example, so the shape is in live use.
+        filename_refs: dict[str, set[str]] = {}
         aliases: dict[str, set[str]] = {}
         for slug, kind, alias_set, filename in entries:
-            if kind is None:
-                slugs.setdefault(slug, set()).add(filename)
+            filename_refs.setdefault(slug, set()).add(filename)
+            if kind is not None:
+                # A kind-QUALIFIED ref matches only that (slug, kind) pair.
+                filename_refs.setdefault(f"{slug}.{kind}", set()).add(filename)
             for alias in alias_set:
                 aliases.setdefault(alias, set()).add(filename)
-        for slug, files in sorted(slugs.items()):
+        for ref, files in sorted(filename_refs.items()):
             if len(files) > 1:
-                found.append(Collision("FILENAME", scope, slug, tuple(sorted(files))))
+                found.append(Collision("FILENAME", scope, ref, tuple(sorted(files))))
         for alias, files in sorted(aliases.items()):
-            if alias in slugs:
-                if files != slugs[alias]:
+            # Shadowed by ANY filename-tier ref, bare or qualified — the alias
+            # tier is reached only when tier 1 returns ZERO hits.
+            if alias in filename_refs:
+                if files != filename_refs[alias]:
                     found.append(Collision(
                         "ALIAS-shadowed", scope, alias, tuple(sorted(files)),
-                        tuple(sorted(slugs[alias])),
+                        tuple(sorted(filename_refs[alias])),
                     ))
             elif len(files) > 1:
                 found.append(Collision("ALIAS", scope, alias, tuple(sorted(files))))
@@ -641,6 +745,48 @@ def survey(store: Path) -> dict[str, int]:
     return tally
 
 
+MODE_LEDGER = ".cairn-cutover-modes.json"
+
+
+def save_modes(store: Path, dest: Path) -> int:
+    """Record every entry file's CURRENT mode, so a freeze can be undone exactly.
+
+    🔴 A RESTORE NEEDS THE ORIGINALS, AND `chmod 0444` DESTROYS THEM.
+    `--unfreeze` used to set every entry to 0644 unconditionally and call itself
+    a rollback. For a file that was 0600 — a plausible mode on a
+    client-confidential entry, and the mode this script's own staging directory
+    uses — that is a permission WIDENING presented as a restore, on exactly the
+    content the widening matters for. So the modes are written down before they
+    are changed, into the run directory beside the pre-push bytes.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    modes = {rel: (store / rel).stat().st_mode & 0o777 for rel in read_store(store)}
+    dest.write_text(json.dumps(modes, sort_keys=True, indent=1), encoding="utf-8")
+    dest.chmod(0o600)
+    return len(modes)
+
+
+def restore_modes(store: Path, ledger: Path) -> tuple[int, int]:
+    """Put every entry file back to the mode `save_modes` recorded.
+
+    Returns `(restored, unknown)`. An entry with no ledger row is NOT guessed at:
+    it is counted and reported, because inventing 0644 for it is the exact defect
+    this function replaces.
+    """
+    recorded: dict[str, int] = json.loads(ledger.read_text(encoding="utf-8"))
+    restored = unknown = 0
+    for rel in read_store(store):
+        want = recorded.get(rel)
+        if want is None:
+            unknown += 1
+            continue
+        path = store / rel
+        if (path.stat().st_mode & 0o777) != want:
+            path.chmod(want)
+        restored += 1
+    return restored, unknown
+
+
 def set_entry_mode(store: Path, mode: int) -> int:
     """chmod every ENTRY FILE. Scope directories are deliberately untouched.
 
@@ -695,7 +841,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--freeze", action="store_true",
                    help="run phase 5 alone (still needs --apply to take effect)")
     p.add_argument("--unfreeze", action="store_true",
-                   help="ROLLBACK of phase 5: restore the entry files to 0644")
+                   help="ROLLBACK of phase 5: restore each entry file to the mode "
+                        "the freeze recorded for it")
+    p.add_argument("--mode-ledger", type=Path, default=None, dest="mode_ledger",
+                   help=f"the freeze's <run-dir>/{MODE_LEDGER}; the newest one "
+                        f"under the default run root is used when omitted")
     p.add_argument("--manifest", action="store_true",
                    help="print this host's store manifest as JSON and exit — the "
                         "input --peer-manifest wants, produced on the other host")
@@ -787,6 +937,15 @@ def load_peer(path: Path | None) -> dict[str, EntryFacts] | None:
     }
 
 
+def _newest_mode_ledger(root: Path | None = None) -> Path | None:
+    """The most recent run's mode ledger, or None. Never a guess at the modes."""
+    root = root or DEFAULT_RUN_ROOT
+    if not root.is_dir():
+        return None
+    found = sorted(root.glob(f"*/{MODE_LEDGER}"))
+    return found[-1] if found else None
+
+
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
 
@@ -811,16 +970,37 @@ def main(argv: list[str] | None = None) -> int:
     if args.unfreeze:
         before = survey(args.store)
         say(f"unfreeze: before  {before}")
-        if not args.apply:
-            say("DRY RUN — pass --apply to restore 0644. Nothing was changed.")
-            return RC_OK
-        changed = set_entry_mode(args.store, 0o644)
-        after = survey(args.store)
-        say(f"unfreeze: chmod 0644 on {changed} entry file(s); after {after}")
-        if after["examined"] and after["writable"] != after["examined"]:
+        ledger = args.mode_ledger or _newest_mode_ledger()
+        # 🔴 `is_file()`, NOT JUST `is not None`. An explicit `--mode-ledger`
+        # naming a path that does not exist reached `restore_modes` and died on
+        # an unguarded `FileNotFoundError` at exit 1 — a code outside this
+        # script's whole vocabulary, on the recovery path, where the operator is
+        # least able to interpret it.
+        if ledger is None or not ledger.is_file():
             return refuse(RC_COULD_NOT_MEASURE, (
-                f"unfreeze did not fully take: {after['writable']} of "
-                f"{after['examined']} entry file(s) are writable again."
+                f"no readable mode ledger ({ledger or 'none found'}), so there is "
+                "nothing to restore TO. The freeze "
+                "records every entry file's original mode before changing it; "
+                "without that file an 'unfreeze' can only invent one, and inventing "
+                "0644 for an entry that was 0600 WIDENS permissions on "
+                "client-confidential content while calling itself a rollback. Pass "
+                f"--mode-ledger <run-dir>/{MODE_LEDGER} explicitly, or chmod by hand "
+                "having decided what the modes should be."
+            ))
+        say(f"unfreeze: restoring from {ledger}")
+        if not args.apply:
+            say("DRY RUN — pass --apply to restore the recorded modes. "
+                "Nothing was changed.")
+            return RC_OK
+        restored, unknown = restore_modes(args.store, ledger)
+        after = survey(args.store)
+        say(f"unfreeze: restored {restored} entry file(s), {unknown} not in the "
+            f"ledger and therefore LEFT ALONE; after {after}")
+        if unknown:
+            return refuse(RC_COULD_NOT_MEASURE, (
+                f"{unknown} entry file(s) have no recorded mode — they were created "
+                f"after the freeze. They are untouched, not guessed at. Decide their "
+                f"modes yourself."
             ))
         return RC_OK
 
@@ -830,6 +1010,7 @@ def main(argv: list[str] | None = None) -> int:
     stage_dir = run_dir / "stage"
     cache_dir = run_dir / "cache"
     prepush_dir = run_dir / "pre-push"
+    ledger_path = run_dir / MODE_LEDGER
 
     # ---- P0 preconditions -------------------------------------------------
     if not args.freeze:
@@ -851,8 +1032,19 @@ def main(argv: list[str] | None = None) -> int:
         if not ok:
             return refuse(RC_BACKUP, sentence)
 
+        # 🔴 0700, ON EVERY LEVEL. What lands under here is a FULL PLAINTEXT COPY
+        # of a client-confidential store — the sync below writes it, and the
+        # runbook prescribes several dry runs before an apply, so these
+        # accumulate. `mkdir` at the default umask leaves them 0755, i.e.
+        # world-readable, in the same change that is careful to 0600 the merged
+        # entry for exactly this reason. `mode=` on `mkdir` is masked by the
+        # umask, so the chmod is explicit rather than trusted to the flag.
+        DEFAULT_RUN_ROOT.mkdir(parents=True, exist_ok=True)
+        DEFAULT_RUN_ROOT.chmod(0o700)
         run_dir.mkdir(parents=True, exist_ok=True)
+        run_dir.chmod(0o700)
         cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_dir.chmod(0o700)
         synced = run(
             [sys.executable, str(CAIRN), "--cache", str(cache_dir), "sync"], timeout=120
         )
@@ -874,10 +1066,14 @@ def main(argv: list[str] | None = None) -> int:
                 "the served copy holds no scope, so the write-route probe has no "
                 "scope to address. A zero here is not a pass."
             ))
-        ok, sentence = write_route_deployed(url=url, token=token, scope=probe_scope)
+        ok, probe_rc, sentence = write_route_deployed(
+            url=url, token=token, scope=probe_scope)
         say(f"P0 {sentence}")
         if not ok:
-            return refuse(RC_NO_WRITE_ROUTE, sentence)
+            # 🔴 THE PROBE'S OWN CODE, not a blanket RC_NO_WRITE_ROUTE. Only the
+            # 405 arm means "the image has no write path"; an unreachable pod
+            # answered under that code sent the operator to redeploy the store.
+            return refuse(probe_rc or RC_COULD_NOT_MEASURE, sentence)
 
         # ---- P1 the plan --------------------------------------------------
         peer = load_peer(args.peer_manifest)
@@ -999,6 +1195,15 @@ def main(argv: list[str] | None = None) -> int:
             f"file(s) and then require all {before['examined']} to refuse a write.")
         return RC_OK
 
+    # 🔴 RECORD THE MODES BEFORE DESTROYING THEM. `chmod 0444` is not reversible
+    # from the result — every entry ends up looking the same, so an "unfreeze"
+    # with no ledger can only invent a mode, and inventing 0644 for a file that
+    # was 0600 is a permission WIDENING on client-confidential content dressed as
+    # a rollback. `--unfreeze` refuses outright without this file.
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    n_recorded = save_modes(args.store, ledger_path)
+    say(f"P5 recorded {n_recorded} original mode(s) to {ledger_path} — "
+        f"`--unfreeze` REQUIRES this file and refuses without it.")
     changed = set_entry_mode(args.store, 0o444)
     after = survey(args.store)
     say(f"P5 chmod 0444 on {changed} entry file(s); after {after}")
@@ -1018,13 +1223,13 @@ def main(argv: list[str] | None = None) -> int:
     # `before` one, and `test_a_FREEZE_over_an_empty_store_is_COULD_NOT_MEASURE_
     # not_success` is the test that kills its removal.
     if after["refused"] != after["examined"] or after["examined"] == 0:
-        set_entry_mode(args.store, 0o644)
+        restore_modes(args.store, ledger_path)
         return refuse(RC_FREEZE_INEFFECTIVE, (
             f"the freeze did not take: {after['refused']} of {after['examined']} "
             f"entry file(s) refused a write ({after['writable']} still writable, "
             f"{after['other']} failed for another reason). The mode bits were "
-            f"RESTORED to 0644 rather than left half-applied. A store that looks "
-            f"frozen and is not is worse than one that is plainly not."
+            f"RESTORED from {ledger_path} rather than left half-applied. A store "
+            f"that looks frozen and is not is worse than one that is plainly not."
         ))
     say(f"P5 WATCHED EACCES: all {after['examined']} entry file(s) refused an "
         f"append. The local store is now a read-through cache.")
@@ -1042,18 +1247,36 @@ def main(argv: list[str] | None = None) -> int:
     return RC_OK
 
 
+_CAIRN_MODULE = None
+
+
+def _cairn():
+    """The `cairn` CLI as a module, loaded once. It owns config and headers.
+
+    🔴 IMPORTED, NEVER REIMPLEMENTED. Both things this script needs from it —
+    the config parser and the request headers — are rules with a measured
+    incident behind them (a missing value that reads as "the store is down"; a
+    User-Agent the edge 403s). A second copy of either would be a fourth site
+    for a rule that already argues, in its own docstring, that three is too many.
+    """
+    global _CAIRN_MODULE
+    if _CAIRN_MODULE is None:
+        sys.path.insert(0, str(HERE))
+        spec = importlib.util.spec_from_loader(
+            "cairn_cli", importlib.machinery.SourceFileLoader("cairn_cli", str(CAIRN))
+        )
+        module = importlib.util.module_from_spec(spec)
+        # `sys.modules[name] = mod` BEFORE `exec_module`, or the first @dataclass
+        # raises `AttributeError: 'NoneType' has no attribute '__dict__'`.
+        sys.modules["cairn_cli"] = module
+        spec.loader.exec_module(module)
+        _CAIRN_MODULE = module
+    return _CAIRN_MODULE
+
+
 def _config() -> tuple[str, str]:
     """URL + token, read through `cairn`'s own loader — never a second parser."""
-    sys.path.insert(0, str(HERE))
-    spec = importlib.util.spec_from_loader(
-        "cairn_cli", importlib.machinery.SourceFileLoader("cairn_cli", str(CAIRN))
-    )
-    module = importlib.util.module_from_spec(spec)
-    # `sys.modules[name] = mod` BEFORE `exec_module`, or the first @dataclass
-    # raises `AttributeError: 'NoneType' has no attribute '__dict__'`.
-    sys.modules["cairn_cli"] = module
-    spec.loader.exec_module(module)
-    return module.load_config()
+    return _cairn().load_config()
 
 
 def _materialise(plan: Plan, dest: Path) -> None:

--- a/scripts/cairn-cutover.py
+++ b/scripts/cairn-cutover.py
@@ -130,12 +130,16 @@ RC_REF_COLLISION = 15       # a ref would resolve to two entries in the union
 RC_FREEZE_INEFFECTIVE = 16  # the freeze was applied and a write STILL succeeded
 # 17 — THE PUSH/VERIFY FAMILY. Deliberately one code with a stated scope rather
 # than a code per site: it means "the entries this host holds are not, or cannot
-# be shown to be, on the pod, and NOTHING WAS FROZEN". Three sites reach it —
-# `seed.sh` exiting non-zero, `comm -23` printing lines, and a failed
-# `--rollback-push` restore — and all three leave the operator in the same place
-# with the same next step (read the verdict lines above, re-run). The ledger used
-# to describe only the `comm -23` site, which is the defect: a code's comment
-# must cover every site that returns it or the comment is the narrower claim.
+# be shown to be, on the pod, and NOTHING WAS FROZEN". FOUR sites reach it —
+# `seed.sh` exiting non-zero, `comm -23` printing lines, `verify-byte-identity.sh`
+# exiting non-zero, and a failed `--rollback-push` restore — and all four leave
+# the operator in the same place with the same next step (read the verdict lines
+# above, re-run). This ledger has now been wrong TWICE in the same direction: it
+# first described only the `comm -23` site, then claimed "three sites" while
+# there were four. Which is the rule it exists to state — a code's comment must
+# cover every site that returns it, or the comment is the narrower claim — and
+# evidently a hard one to keep true, so: `grep -n "RC_ACCEPTANCE" ` before
+# editing this sentence, and count.
 RC_ACCEPTANCE = 17
 RC_COULD_NOT_MEASURE = 18   # an instrument did not answer; never folded into a pass
 
@@ -384,6 +388,14 @@ class EntryFacts:
     sha256: str
     aliases: tuple[str, ...]
     bullets: tuple[str, ...]
+    # 🔴 EVERY NON-BLANK LINE, NOT ONLY THE BULLETS — and the difference is a
+    # whole class of divergence. A `cairn put` rewrites `## What it is` or
+    # `## Pointers`; none of that is a `- ` line, so a comparison scoped to
+    # bullets is BLIND to it and reports "0 bullet lines differ" as though it
+    # had looked. `lines` is what lets `plan_delta` say whether the host's copy
+    # is a superset of the served one, which is the only question that makes a
+    # supersession provable rather than argued.
+    lines: tuple[str, ...] = ()
 
 
 def read_store(root: Path) -> dict[str, EntryFacts]:
@@ -403,18 +415,30 @@ def read_store(root: Path) -> dict[str, EntryFacts]:
         for path in sorted(scope_dir.glob("*.md")):
             if path.is_symlink() or not path.is_file():
                 continue
-            data = path.read_bytes()
-            text = data.decode("utf-8", "surrogateescape")
-            out[f"{scope_dir.name}/{path.name}"] = EntryFacts(
-                rel=f"{scope_dir.name}/{path.name}",
-                sha256=hashlib.sha256(data).hexdigest(),
-                aliases=tuple(_aliases(text)),
-                bullets=tuple(
-                    line.strip() for line in text.splitlines()
-                    if line.strip().startswith("- ")
-                ),
-            )
+            rel = f"{scope_dir.name}/{path.name}"
+            out[rel] = _facts_for(rel, path)
     return out
+
+
+def _facts_for(rel: str, path: Path) -> EntryFacts:
+    """ONE parse of one entry file, for every caller that needs its facts.
+
+    `splitlines()` + `strip()` normalises CRLF, a trailing newline and trailing
+    whitespace away on BOTH sides, so a cosmetic difference cannot masquerade as
+    content. That is deliberate: the question these lists answer is "does the
+    served copy hold anything the host does not", and a line ending is not
+    content.
+    """
+    data = path.read_bytes()
+    text = data.decode("utf-8", "surrogateescape")
+    stripped = [line.strip() for line in text.splitlines() if line.strip()]
+    return EntryFacts(
+        rel=rel,
+        sha256=hashlib.sha256(data).hexdigest(),
+        aliases=tuple(_aliases(text)),
+        bullets=tuple(ln for ln in stripped if ln.startswith("- ")),
+        lines=tuple(stripped),
+    )
 
 
 def _aliases(text: str) -> list[str]:
@@ -482,10 +506,25 @@ def plan_delta(
          re-run a no-op rather than a second push.
       3. **Present on both and divergent, pod vs a host** -> the pod's copy is a
          LAGGING DERIVATIVE of that host's file (it got there by being seeded
-         from it), so the host copy SUPERSEDES it — *unless* the pod holds a
-         bullet the host lacks that carries the API attribution trailer. Such a
-         bullet was written through the pod and exists in exactly one place in
-         the world, so the entry becomes NEEDS_MERGE.
+         from it). Which way that cuts is decided by ONE question — *does the
+         served copy hold any line this host does not?* — asked over EVERY line,
+         not only the bullets, and answered in four arms ordered by how much
+         each can prove:
+
+           3a. a pod line carrying the API attribution trailer -> NEEDS_MERGE.
+               It was written through the pod and exists in exactly one place in
+               the world.
+           3b. NO pod-only line at all -> SUPERSEDES, and this is the strongest
+               case in the rule: the host's copy is a superset, so nothing can
+               be lost. A plain append lands here, as do a trailing newline and
+               a CRLF difference.
+           3c. pod-only lines, none attributed -> SUPERSEDES. Lines the host has
+               since edited away (an `OPEN:` closed, a claim retracted). The
+               count of non-bullet-opener lines rides along in the reason,
+               because those are usually the continuation lines of a rewritten
+               wrapped bullet — but they do NOT change the verdict. Splitting
+               3c on that distinction was tried and reverted: measured on the
+               real trees it turned 1 hand-merge into 10.
       4. **Present on both hosts and divergent** -> neither is a derivative of
          the other, so there is no supersession argument available. ALWAYS
          NEEDS_MERGE, never last-write-wins, whatever the mtimes say.
@@ -512,16 +551,39 @@ def plan_delta(
         src = store_root / rel
         override = (merged_dir / rel) if merged_dir else None
 
-        # 🔴 THE HAND-AUTHORED RESOLUTION IS CONSULTED FIRST, BEFORE EVERY OTHER
-        # CLAUSE. It used to sit third, below the ADD and SAME returns, which
-        # made it UNREACHABLE for any entry the pod does not hold — so an
-        # operator who had written a merge for a host-only entry watched it be
-        # silently ignored in favour of the local copy. A human decision must
-        # not be overridden by a classifier; if it exists, it wins.
-        if override is not None and override.is_file():
+        has_override = override is not None and override.is_file()
+        peer_disagrees = (
+            peer is not None and rel in peer and peer[rel].sha256 != facts.sha256
+        )
+        in_pod = rel in pod
+        identical = in_pod and pod[rel].sha256 == facts.sha256
+
+        # 🔴 THE HAND-AUTHORED RESOLUTION OUTRANKS EVERY CLASSIFIER — BUT ONLY
+        # WHERE THERE IS SOMETHING TO RESOLVE. It used to sit third, below the
+        # ADD and SAME returns, which made it UNREACHABLE for any entry the pod
+        # does not hold: an operator's written merge for a host-only entry was
+        # silently ignored in favour of the local copy. Hoisting it fixed that
+        # and introduced the opposite defect, because `--merged` defaults to a
+        # PERSISTENT directory: a resolution left over from an earlier round then
+        # preempted `SAME`, pushing stale bytes over a copy the pod and this host
+        # already agreed on, byte for byte — reported as a bare count in the
+        # verdict line and invisible to `comm -23`, which compares names only.
+        #
+        # So: an override wins wherever a decision is genuinely needed, and where
+        # nothing is in dispute it is announced as STALE rather than applied.
+        if has_override and not (identical and not peer_disagrees):
             plan.items.append(
                 Item(rel, MERGED, f"resolved by hand at {override}", override)
             )
+            continue
+        if has_override:
+            plan.items.append(Item(
+                rel, SAME,
+                f"byte-identical to the served copy — and a STALE hand-merge at "
+                f"{override} was IGNORED, because there is nothing here to "
+                f"resolve. Delete it once you have checked it is not wanted.",
+                src,
+            ))
             continue
 
         # 🔴 THE PEER CHECK IS SECOND, AND IT USED TO BE FIFTH — BELOW `ADD`.
@@ -533,7 +595,7 @@ def plan_delta(
         # first. The result was first-host-to-run-wins, silently, with no
         # operator decision — the exact failure the rule is written to forbid,
         # committed by the code that states it.
-        if peer is not None and rel in peer and peer[rel].sha256 != facts.sha256:
+        if peer_disagrees:
             plan.items.append(Item(
                 rel, NEEDS_MERGE,
                 "both hosts hold a different copy — neither is a derivative of the "
@@ -543,14 +605,18 @@ def plan_delta(
             ))
             continue
 
-        if rel not in pod:
+        if not in_pod:
             plan.items.append(Item(rel, ADD, "not present in the served copy", src))
             continue
-        if pod[rel].sha256 == facts.sha256:
+        if identical:
             plan.items.append(Item(rel, SAME, "byte-identical to the served copy", src))
             continue
+        # 🔴 THE COMPARISON IS OVER **EVERY LINE**, NOT ONLY THE BULLETS, and the
+        # arms below are ordered by how much they can PROVE.
+        local_lines = set(facts.lines)
+        pod_extra = [ln for ln in pod[rel].lines if ln not in local_lines]
         pod_only = [b for b in pod[rel].bullets if b not in facts.bullets]
-        attributed = [b for b in pod_only if ATTRIBUTION.search(b)]
+        attributed = [ln for ln in pod_extra if ATTRIBUTION.search(ln)]
         if attributed:
             plan.items.append(Item(
                 rel, NEEDS_MERGE,
@@ -560,40 +626,64 @@ def plan_delta(
                 src,
             ))
             continue
-        # 🔴 A DIVERGENCE WITH **NO** POD-ONLY BULLETS IS UNRECOGNISED, NOT
-        # SUPERSEDED. The bytes differ and the bullet lists do not, so whatever
-        # moved is OUTSIDE the region this rule can see — front matter, `## What
-        # it is`, `## Pointers`, or a bullet's continuation lines. The attribution
-        # scan says nothing about any of them, so classifying it SUPERSEDES
-        # printed "the served copy holds 0 bullet line(s) this host lacks and
-        # NONE is API-attributed" as the JUSTIFICATION FOR OVERWRITING IT — a
-        # vacuous truth offered as evidence from a scan that examined nothing.
+        # 🔴 THE STRONGEST CASE, AND IT WAS PREVIOUSLY CLASSIFIED BACKWARDS.
+        # `pod_extra` empty means the host's copy contains EVERY line the served
+        # copy has: a supersession that is PROVEN, not argued, and nothing can be
+        # lost by pushing it. This is what a plain append produces — the shape
+        # the append-only protocol emits every single time — and also what a
+        # trailing newline or a CRLF difference produces.
         #
-        # 🔴 AND THE WRITER THAT PRODUCES EXACTLY THIS SHAPE IS `cairn put`,
-        # WHICH THIS SAME CHANGE ADDS. Its stated reasons to exist are updating
-        # `## Pointers` and rewriting an `OPEN:` marker — both outside the bullet
-        # set, both invisible here. So rule 3's premise ("seed.sh and the API are
-        # the only writers, and the API's changes are attributed") is not broken
-        # by some hypothetical third route; it is broken by this file's sibling.
-        # NEEDS_MERGE is the fail-safe direction this module already declares.
-        if not pod_only:
+        # An earlier version of this arm tested `not pod_only` — pod bullets
+        # MINUS local — and answered NEEDS_MERGE. That set is empty exactly when
+        # the host has appended, so the safest case in the whole rule was being
+        # refused while the riskier rewrite case was auto-pushed: the two arms
+        # were inverted, and any NEEDS_MERGE aborts the run. The reason text was
+        # false for it too, claiming the difference lay outside the bullet region
+        # when for a pure append it lies squarely inside.
+        if not pod_extra:
             plan.items.append(Item(
-                rel, NEEDS_MERGE,
-                "divergent, but the served copy holds NO bullet line this host "
-                "lacks — so whatever differs is outside the region the "
-                "attribution rule can see (front matter, `## What it is`, "
-                "`## Pointers`, or a bullet's continuation lines). A whole-file "
-                "`cairn put` produces exactly this shape. Unrecognised, therefore "
-                f"refused rather than overwritten. Diff them and resolve at "
-                f"<merged>/{rel}.",
+                rel, SUPERSEDES,
+                f"divergent, and the host's copy contains EVERY line the served "
+                f"copy has ({len(facts.lines) - len(set(pod[rel].lines))} line(s) "
+                f"only this host has). Nothing on the pod can be lost by pushing "
+                f"it — the strongest form of the supersession rule.",
                 src,
             ))
             continue
+        # The served copy holds lines this host does not, and NONE is attributed.
+        #
+        # 🔴 THIS IS SUPERSEDES, AND A VERSION THAT REFUSED HERE WAS MEASURED AND
+        # REVERTED. The reasoning that produced the refusal was: a non-bullet
+        # line only the pod has must be front matter or `## Pointers`, i.e.
+        # outside what the attribution rule can see, i.e. a `cairn put`. Run
+        # against the real trees it turned 1 hand-merge into 10 — because a
+        # store bullet WRAPS, and a wrapped bullet's continuation lines do not
+        # begin `- `. Rewriting one bullet therefore produces "non-bullet lines
+        # only the pod has" as a matter of course. The rule would have demanded a
+        # hand merge for nine ordinary edits: the permanently-red-gate direction,
+        # reached by exactly the argument that sounds most careful.
+        #
+        # The lineage argument covers this case and does not need the line kinds:
+        # the pod's tree was PRODUCED FROM a host's by `seed.sh`, and the only
+        # thing that can change it since is the API, whose every change carries
+        # the attribution trailer checked above. A pod line the host lacks is a
+        # line the host has edited away.
+        #
+        # ⚠ ITS LIMIT, AND WHY THE COUNT IS PRINTED ANYWAY: `cairn put` — added
+        # by this same change — rewrites whole files without attribution, so once
+        # it is in use a PUT-modified entry is genuinely indistinguishable from a
+        # seed-time snapshot. That window is what the FREEZE closes: after the
+        # cutover the hosts are caches and host-vs-pod divergence cannot arise.
+        # Until then the non-bullet count rides along in the reason so an
+        # operator who HAS run `cairn put` can see which entries to look at.
+        outside = sum(1 for ln in pod_extra if not ln.startswith("- "))
         plan.items.append(Item(
             rel, SUPERSEDES,
-            f"divergent; the served copy holds {len(pod_only)} bullet line(s) this "
-            f"host lacks and NONE is API-attributed, so they are a stale snapshot "
-            f"of a file this host has since edited",
+            f"divergent; the served copy holds {len(pod_extra)} line(s) this host "
+            f"lacks ({outside} of them not bullet openers — usually the "
+            f"continuation lines of a rewritten bullet) and NONE is "
+            f"API-attributed. The served copy is a seed-time snapshot of this "
+            f"file and this host has edited it since.",
             src,
         ))
     return plan
@@ -647,7 +737,7 @@ def ref_collisions(union: dict[str, EntryFacts]) -> list[Collision]:
         # a kind ONLY if it is in `KINDS`, so `foo.notes.md` has slug
         # `foo.notes` here and slug `foo` there (a FALSE collision, the
         # permanently-red-gate direction), while `a.b.c.md` silently discarded
-        # `c`. See `test_a_KIND_QUALIFIED_file_collides_with_its_bare_sibling`
+        # `c`. See `test_a_KIND_QUALIFIED_file_collides_with_its_BARE_sibling`
         # for the case it MISSED, which is the one that matters.
         slug, kind = split_kind(normalize_ref(stem))
         per_scope.setdefault(scope, []).append(
@@ -663,13 +753,33 @@ def ref_collisions(union: dict[str, EntryFacts]) -> list[Collision]:
         # the resolver raised on 2 candidates while this returned `[]` — the
         # exact condition P2 exists to detect, missed. `repo-cos.process` is the
         # resolver docstring's own worked example, so the shape is in live use.
+        # 🔴 SIMULATE `resolve_ref_tiered`, DO NOT APPROXIMATE IT. Registering a
+        # bare slug for every entry and a `slug.kind` key beside it flattens two
+        # namespaces the resolver keys DIFFERENTLY, and the flattening invents
+        # collisions: measured, `svc.process.md` (slug `svc`, kind `process`)
+        # beside `svc.process.doc.md` (slug `svc.process`, kind `doc`) both
+        # registered under the key `svc.process`, reported LIVE — while the
+        # resolver answers `svc.process` unambiguously with `svc.process.md`.
+        # A LIVE collision BLOCKS, so that is the permanently-red-gate direction.
+        #
+        # The exact question is "for candidate ref R, how many entries does tier
+        # 1 return?", and tier 1 is four lines of `resolve_ref_tiered`. Asking it
+        # directly is both shorter and incapable of disagreeing with the reader.
+        candidates = {slug for slug, _k, _a, _f in entries}
+        candidates |= {
+            f"{slug}.{kind}" for slug, kind, _a, _f in entries if kind is not None
+        }
         filename_refs: dict[str, set[str]] = {}
+        for ref in candidates:
+            rslug, rkind = split_kind(ref)
+            if rkind is not None:
+                hits = {f for s, k, _a, f in entries if s == rslug and k == rkind}
+            else:
+                hits = {f for s, _k, _a, f in entries if s == ref}
+            if hits:
+                filename_refs[ref] = hits
         aliases: dict[str, set[str]] = {}
-        for slug, kind, alias_set, filename in entries:
-            filename_refs.setdefault(slug, set()).add(filename)
-            if kind is not None:
-                # A kind-QUALIFIED ref matches only that (slug, kind) pair.
-                filename_refs.setdefault(f"{slug}.{kind}", set()).add(filename)
+        for _slug, _kind, alias_set, filename in entries:
             for alias in alias_set:
                 aliases.setdefault(alias, set()).add(filename)
         for ref, files in sorted(filename_refs.items()):
@@ -772,19 +882,72 @@ def save_modes(store: Path, dest: Path) -> int:
     """
     dest.parent.mkdir(parents=True, exist_ok=True)
     modes = {rel: (store / rel).stat().st_mode & 0o777 for rel in read_store(store)}
-    dest.write_text(json.dumps(modes, sort_keys=True, indent=1), encoding="utf-8")
+    # 🔴 THE LEDGER NAMES ITS OWN STORE. Without this it is a bare `{rel: mode}`
+    # map with nothing binding it to the tree it came from — and `--unfreeze`
+    # picks the NEWEST ledger under a shared root, so ANY other run's ledger
+    # (a second store, a copy, a test that forgot `--run-dir`) is silently
+    # eligible. Rel paths collide readily across stores, so a mismatched ledger
+    # would restore modes recorded from a different tree with no way to notice.
+    dest.write_text(
+        json.dumps({"store": str(store.resolve()), "modes": modes},
+                   sort_keys=True, indent=1),
+        encoding="utf-8",
+    )
     dest.chmod(0o600)
     return len(modes)
+
+
+class LedgerUnusable(Exception):
+    """The mode ledger cannot be trusted. Carries the reason, never a bare fail."""
+
+
+def read_ledger(ledger: Path, store: Path) -> dict[str, int]:
+    """Parse and VALIDATE a mode ledger, or raise `LedgerUnusable` saying why.
+
+    🔴 EVERY WAY OF BEING UNREADABLE IS A NAMED REFUSAL. The previous guard
+    checked `is_file()` and nothing else, while printing "no readable mode
+    ledger" — a readability claim `is_file()` does not make. Measured against
+    that version: truncated JSON, an empty file, a string mode and a top-level
+    list each died on an UNCAUGHT exception at exit 1, on the recovery path,
+    which is verbatim the condition the guard's own comment said it had closed.
+    """
+    try:
+        raw = json.loads(ledger.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise LedgerUnusable(f"{ledger} does not parse as JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise LedgerUnusable(f"{ledger} holds {type(raw).__name__}, not an object")
+    recorded = raw.get("modes")
+    if not isinstance(recorded, dict):
+        raise LedgerUnusable(
+            f"{ledger} has no `modes` object — it predates the store-binding "
+            f"format, so it cannot be checked against this store. Chmod by hand "
+            f"having decided what the modes should be."
+        )
+    owner = raw.get("store")
+    if owner != str(store.resolve()):
+        raise LedgerUnusable(
+            f"{ledger} was taken against {owner!r}, not {str(store.resolve())!r}. "
+            f"Restoring one store's modes onto another is exactly the mistake the "
+            f"store field exists to catch."
+        )
+    for rel, mode in recorded.items():
+        if not isinstance(mode, int) or isinstance(mode, bool) or not 0 <= mode <= 0o7777:
+            raise LedgerUnusable(
+                f"{ledger} records {mode!r} for {rel}, which is not a mode"
+            )
+    return recorded
 
 
 def restore_modes(store: Path, ledger: Path) -> tuple[int, int]:
     """Put every entry file back to the mode `save_modes` recorded.
 
     Returns `(restored, unknown)`. An entry with no ledger row is NOT guessed at:
-    it is counted and reported, because inventing 0644 for it is the exact defect
-    this function replaces.
+    it is counted and returned, because inventing 0644 for it is the exact defect
+    this function replaces. Both numbers are the CALLER's to report — a caller
+    that discards them makes a restoration claim it did not check.
     """
-    recorded: dict[str, int] = json.loads(ledger.read_text(encoding="utf-8"))
+    recorded = read_ledger(ledger, store)
     restored = unknown = 0
     for rel in read_store(store):
         want = recorded.get(rel)
@@ -1000,10 +1163,23 @@ def main(argv: list[str] | None = None) -> int:
             ))
         say(f"unfreeze: restoring from {ledger}")
         if not args.apply:
-            say("DRY RUN — pass --apply to restore the recorded modes. "
-                "Nothing was changed.")
+            # 🔴 VALIDATE IN THE DRY RUN TOO. A ledger that will be refused at
+            # --apply must be refused here, or the dry run reassures the operator
+            # about a rollback that cannot happen.
+            try:
+                read_ledger(ledger, args.store)
+            except LedgerUnusable as exc:
+                return refuse(RC_COULD_NOT_MEASURE, str(exc))
+            say("DRY RUN — the ledger is readable and belongs to this store. "
+                "Pass --apply to restore the recorded modes. Nothing was changed.")
             return RC_OK
-        restored, unknown = restore_modes(args.store, ledger)
+        try:
+            restored, unknown = restore_modes(args.store, ledger)
+        except LedgerUnusable as exc:
+            return refuse(RC_COULD_NOT_MEASURE, (
+                f"{exc} NOTHING was changed — every entry is still at whatever "
+                f"mode the freeze left it."
+            ))
         after = survey(args.store)
         say(f"unfreeze: restored {restored} entry file(s), {unknown} not in the "
             f"ledger and therefore LEFT ALONE; after {after}")
@@ -1108,12 +1284,15 @@ def main(argv: list[str] | None = None) -> int:
         # ---- P2 collisions ------------------------------------------------
         union = dict(pod)
         for item in plan.shippable:
-            data = item.source.read_bytes()
-            text = data.decode("utf-8", "surrogateescape")
-            union[item.rel] = EntryFacts(
-                item.rel, hashlib.sha256(data).hexdigest(), tuple(_aliases(text)),
-                tuple(l.strip() for l in text.splitlines() if l.strip().startswith("- ")),
-            )
+            # 🔴 BUILT THROUGH `_facts_for`, not open-coded. This site used to
+            # spell the parse a second time and was already one field behind:
+            # `lines` was added to `EntryFacts` for the merge rule and this
+            # constructor kept passing four positional arguments, so every
+            # shippable entry entered the collision union with an EMPTY line set.
+            # Harmless for the collision check, which reads only aliases and
+            # filenames — but it is the same predicate at two sites, which is
+            # how the two come to disagree about something that matters.
+            union[item.rel] = _facts_for(item.rel, item.source)
         if peer:
             for rel, facts in peer.items():
                 union.setdefault(rel, facts)
@@ -1211,7 +1390,16 @@ def main(argv: list[str] | None = None) -> int:
     # with no ledger can only invent a mode, and inventing 0644 for a file that
     # was 0600 is a permission WIDENING on client-confidential content dressed as
     # a rollback. `--unfreeze` refuses outright without this file.
+    # 0700 HERE TOO. The chmod in P0 covers the cutover path; `--freeze --apply`
+    # skips P0 entirely, so on a host whose first invocation is a bare freeze the
+    # run root and run dir were created at the ambient umask (0755 measured).
+    # The ledger file is 0600 either way, so the exposure is a directory listing
+    # — but a 0755 dir here is also what `delta/`, `stage/` and `pre-push/` sit
+    # under on the cutover path, and those DO hold store bytes.
+    DEFAULT_RUN_ROOT.mkdir(parents=True, exist_ok=True)
+    DEFAULT_RUN_ROOT.chmod(0o700)
     ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    ledger_path.parent.chmod(0o700)
     n_recorded = save_modes(args.store, ledger_path)
     say(f"P5 recorded {n_recorded} original mode(s) to {ledger_path} — "
         f"`--unfreeze` REQUIRES this file and refuses without it.")
@@ -1234,7 +1422,27 @@ def main(argv: list[str] | None = None) -> int:
     # `before` one, and `test_a_FREEZE_over_an_empty_store_is_COULD_NOT_MEASURE_
     # not_success` is the test that kills its removal.
     if after["refused"] != after["examined"] or after["examined"] == 0:
-        restore_modes(args.store, ledger_path)
+        # 🔴 READ THE RESTORE'S OWN NUMBERS. This discarded them while the
+        # message below asserted "the mode bits were RESTORED" — a claim the code
+        # did not check. An entry created between `save_modes` and the failed
+        # freeze has no recorded mode, so it stays at 0444, uncounted, under a
+        # sentence saying everything was put back.
+        try:
+            restored, unknown = restore_modes(args.store, ledger_path)
+        except LedgerUnusable as exc:
+            return refuse(RC_FREEZE_INEFFECTIVE, (
+                f"the freeze did not take AND the mode ledger is unusable ({exc}). "
+                f"The store is LEFT AS THE FAILED FREEZE MADE IT — chmod it back "
+                f"by hand."
+            ))
+        if unknown:
+            return refuse(RC_FREEZE_INEFFECTIVE, (
+                f"the freeze did not take ({after['refused']} of "
+                f"{after['examined']} refused). {restored} entr(ies) were restored "
+                f"from {ledger_path}; {unknown} have NO recorded mode and are "
+                f"still at 0444 — they appeared after the ledger was written. "
+                f"Restore those by hand."
+            ))
         return refuse(RC_FREEZE_INEFFECTIVE, (
             f"the freeze did not take: {after['refused']} of {after['examined']} "
             f"entry file(s) refused a write ({after['writable']} still writable, "

--- a/scripts/cairn-cutover.py
+++ b/scripts/cairn-cutover.py
@@ -291,8 +291,19 @@ def backup_precondition(
 
 def write_route_deployed(
     *, url: str, token: str, scope: str, timeout: int = 20
-) -> tuple[bool, str | None, str]:
-    """Does the RUNNING image carry the write path? `(ok, sentence)`.
+) -> tuple[bool, int | None, str]:
+    """Does the RUNNING image carry the write path? `(ok, rc_on_failure, sentence)`.
+
+    ⚠ THE ANNOTATION AND THIS FIRST LINE WERE BOTH WRONG FOR ONE COMMIT, IN THE
+    SAME DIRECTION, AND THAT IS THE POINT WORTH KEEPING. The return went from a
+    2-tuple to a 3-tuple to stop an unreachable pod being reported as "the image
+    is read-only"; the middle slot carries an EXIT CODE, and both the signature
+    (`str | None`) and this line (`(ok, sentence)`) were left describing the old
+    shape. The code was correct throughout — the caller reads the slot as an rc
+    — so nothing failed, and nothing could: `claude/RULES.md` is explicit that a
+    type declaration is not a code path, so no test and no green suite can see a
+    lie told only in an annotation. It was caught by a type checker reading the
+    file, which is the only instrument that looks at this.
 
     🔴 THE PROBE IS A DELIBERATELY MALFORMED BODY, AND THAT IS WHAT MAKES IT
     SAFE. `server._append_bullet` validates the payload BEFORE it resolves the

--- a/scripts/cairn-cutover.py
+++ b/scripts/cairn-cutover.py
@@ -1371,7 +1371,7 @@ def main(argv: list[str] | None = None) -> int:
     # ---- P5 the freeze ----------------------------------------------------
     before = survey(args.store)
     say(f"P5 before the freeze: {before}")
-    if False:
+    if before["examined"] == 0:
         return refuse(RC_COULD_NOT_MEASURE, (
             "the freeze walked 0 entry files. A '0 writable' from a walk that "
             "visited nothing is not a frozen store."

--- a/scripts/cairn-cutover.py
+++ b/scripts/cairn-cutover.py
@@ -1,0 +1,1152 @@
+#!/usr/bin/env python3
+"""Cairn phase 1, criterion 9 — the write-through cutover. DRY-RUN BY DEFAULT.
+
+WHAT THIS DOES, IN ORDER, AND WHY THE ORDER IS THAT WAY
+-------------------------------------------------------
+The hosted store becomes the authority and local disk becomes a read-through
+cache. Three things have to be true before that is safe, and they have to become
+true in this sequence:
+
+  1. every byte that exists ONLY on a host must be on the pod first, or freezing
+     local disk strands it;
+  2. every byte that exists ONLY on the pod must survive the upload, or the push
+     destroys it — and `seed.sh`'s push is `rsync -a --delete` SOURCE->STAGE then
+     `tar` STAGE->pod, which OVERWRITES a shared entry with the source's copy;
+  3. no ref may resolve to two entries in the merged union, because the write
+     route answers an ambiguous ref with 400 and the entry becomes unwritable.
+
+🔴 THIS SCRIPT NEVER GUESSES A MERGE. Where two copies of one entry disagree and
+neither is a derivative of the other, it REFUSES and names the file. A silent
+last-write-wins is the failure `claudedocs/plan-cairn-integration.md` phase 1
+calls "the risk here, not the transport", and the loss would be invisible.
+
+🔴 IT DOES NOT WRITE A SECOND PUSH PATH. The upload is `seed.sh`, unchanged,
+pointed at a *curated delta tree* this script builds. That is the whole trick:
+`seed.sh` is destructive because of WHAT IT IS GIVEN, not because of what it
+does — its tar adds and overwrites but never deletes, so a source holding only
+additive entries is a safe push through the same code that is unsafe with a
+whole store behind it. One push path, one set of guards, one verdict format.
+
+🔴 AND IT DOES NOT WRITE A SECOND BYTE-IDENTITY CHECKER. Verification is
+`verify-byte-identity.sh`, unchanged.
+
+WHY 9 BEFORE 8 (the ordering argument, stated where it is executed)
+-------------------------------------------------------------------
+The ranked list in `claudedocs/handoff-cairn-phase3.md` puts the laptop re-seed
+(criterion 8) at rank 3 and this cutover (criterion 9) at rank 4. Running them
+in rank order is wrong. `seed.sh` from a host replaces every shared entry on the
+pod with that host's copy, so running it while API-appended bullets live only in
+the served copy DESTROYS them — recoverable from the backup, which is a different
+claim from safe. After this cutover the hosts' stores are caches of the pod, so
+the same push has nothing unique left to destroy. Landing 9 first turns a
+destructive operation into an idempotent one instead of relying on a restore.
+
+PHASES AND THEIR ROLLBACKS
+--------------------------
+  P0  preconditions            — read-only; nothing to roll back
+  P1  plan the delta           — read-only; writes only into the run directory
+  P2  ref-collision check      — read-only
+  P3  push the delta           — rollback: `--rollback-push <run-dir>` re-PUTs the
+                                 pre-push bytes this script saved for every entry
+                                 it was about to overwrite
+  P4  acceptance + byte check  — read-only
+  P5  freeze local disk        — rollback: `--unfreeze`
+The skill/protocol half of the cutover (routing `subsystem-index` writes through
+`cairn append`) is a DOCUMENT change and is rolled back by reverting its commit;
+this script neither applies nor reverts it, and says so rather than implying it
+covered the whole criterion.
+
+USAGE
+-----
+    cairn-cutover.py                       # dry run: plan and report, change nothing
+    cairn-cutover.py --apply --push <ns>/<deploy>
+    cairn-cutover.py --unfreeze            # roll P5 back
+    cairn-cutover.py --rollback-push <run-dir>
+
+Exit codes are disjoint and each names one refusal; see `RC_*` below.
+"""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import hashlib
+import importlib.machinery
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SEED = HERE / "subsystem-store-api" / "seed.sh"
+VERIFY = HERE / "subsystem-store-api" / "verify-byte-identity.sh"
+CAIRN = HERE / "cairn"
+
+DEFAULT_STORE = Path.home() / ".claude" / "analyze-service-index"
+DEFAULT_MERGED = Path.home() / ".local" / "share" / "cairn-cutover" / "merged"
+DEFAULT_RUN_ROOT = Path.home() / ".local" / "share" / "cairn-cutover" / "runs"
+DEFAULT_BACKUP_NAMESPACE = "subsystem-store"
+DEFAULT_BACKUP_CRONJOB = "subsystem-store-backup"
+# The CronJob's schedule is daily at 03:45 UTC. 36 h is one full period plus a
+# 12 h grace, so a single missed run refuses and an ordinary run never does.
+# 🔴 NOT 24: at exactly 24 h a healthy daily job is refused for most of the day
+# it succeeded in, which is a permanently-red gate and RULES.md says a gate
+# everyone clicks through is worse than no gate.
+DEFAULT_BACKUP_MAX_AGE_H = 36.0
+
+# --- exit codes. Disjoint on purpose; each is one refusal with one remedy. ----
+RC_OK = 0
+RC_USAGE = 2
+RC_ROOT = 9                 # running as root makes the EACCES evidence vacuous
+RC_BACKUP = 10              # no recent SUCCESSFUL backup, or it could not be measured
+RC_UNREACHABLE = 11         # the store could not be read
+RC_NO_WRITE_ROUTE = 12      # the RUNNING image has no write path (405 read-only)
+RC_NO_STORE = 13            # the local store is missing or holds no scopes
+RC_UNRESOLVED_DIVERGENCE = 14   # two copies disagree and no merged file resolves it
+RC_REF_COLLISION = 15       # a ref would resolve to two entries in the union
+RC_FREEZE_INEFFECTIVE = 16  # the freeze was applied and a write STILL succeeded
+RC_ACCEPTANCE = 17          # `comm -23` did not print zero lines
+RC_COULD_NOT_MEASURE = 18   # an instrument did not answer; never folded into a pass
+
+# 🔴 THE DISCRIMINATOR THIS WHOLE MERGE RULE TURNS ON. `server.render_bullet`
+# terminates every API-appended bullet with exactly this shape, and nothing else
+# in the store produces it: a bullet carrying it was written THROUGH THE POD and
+# therefore exists in the served copy and nowhere else. A divergence where the
+# pod's extra bullets are all UNattributed is a stale snapshot of a file the host
+# has since edited; a divergence where the pod holds an ATTRIBUTED bullet the
+# host lacks is content with exactly one copy in the world.
+#
+# Kept in sync with `server.ATTRIBUTION_RE` by
+# `test_cairn_cutover.py::test_the_attribution_pattern_matches_the_servers`,
+# which imports the server's own pattern rather than restating it — a second
+# spelling of one regex is the shape that drifts silently.
+ATTRIBUTION = re.compile(
+    r"\[cairn: [a-z0-9][a-z0-9-]{0,31}/[A-Za-z0-9][A-Za-z0-9_.-]{0,63}\]"
+)
+
+# 🔴 THE RESOLVER'S OWN `normalize_ref`, IMPORTED — NOT RESTATED. The first
+# draft of this file carried `ref.strip().lower().replace("_", "-")`, which is
+# the rule as people describe it and NOT the rule as it runs: the real one also
+# folds every character outside `[a-z0-9.-]` to `-`, collapses runs and trims.
+# A collision check that normalises differently from the resolver models a
+# reader that does not exist — it would miss a collision the write route hits,
+# and invent one it does not. There is no version of this worth having twice.
+sys.path.insert(0, str(HERE / "lib"))
+from subsystem_resolver import normalize_ref  # noqa: E402
+
+
+# =============================================================================
+# Process plumbing
+# =============================================================================
+
+
+@dataclass
+class Ran:
+    rc: int
+    out: str
+    err: str
+
+    @property
+    def ok(self) -> bool:
+        return self.rc == 0
+
+
+def run(cmd: list[str], *, timeout: int = 120, cwd: Path | None = None) -> Ran:
+    """Run a command, capturing BOTH streams into their own buffers.
+
+    🔴 NEVER PIPED, AND THAT IS THE POINT. `cmd | tail; echo $?` reports TAIL's
+    status; that trap has been paid at least four times in this repo, most
+    recently printing `NIXBUILD_RC=0` for a build that had just failed 45 tests.
+    `subprocess.run` with `capture_output` gives the child's own status and the
+    two streams separately, so a caller can read the CONTENT and the code.
+    """
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout,
+            cwd=str(cwd) if cwd else None,
+        )
+    except FileNotFoundError as exc:
+        return Ran(127, "", f"{cmd[0]}: not found ({exc})")
+    except subprocess.TimeoutExpired:
+        return Ran(124, "", f"{cmd[0]}: timed out after {timeout}s")
+    return Ran(proc.returncode, proc.stdout, proc.stderr)
+
+
+def say(msg: str) -> None:
+    print(f"cutover: {msg}", flush=True)
+
+
+def refuse(rc: int, msg: str) -> int:
+    print(f"🔴 cutover: REFUSED (rc {rc}) — {msg}", file=sys.stderr, flush=True)
+    return rc
+
+
+# =============================================================================
+# P0 — preconditions
+# =============================================================================
+
+
+def backup_precondition(
+    *, namespace: str, cronjob: str, max_age_h: float, kubeconfig: str | None,
+    now: datetime | None = None,
+) -> tuple[bool, str]:
+    """Is there a RECENT, SUCCESSFUL backup? `(ok, sentence)`.
+
+    🔴 THIS IS THE ONE PRECONDITION THAT MAY NOT BE ASSUMED. devrc PR #1132
+    exists because fifteen separate places asserted this store's backup state and
+    were wrong about it — in both directions across its life. So this asks the
+    cluster, and it treats every way of NOT getting an answer as a refusal:
+
+      * the CronJob does not exist              -> refuse
+      * `kubectl` is absent, or errors, or times out -> refuse
+      * `status.lastSuccessfulTime` is absent   -> refuse
+      * the timestamp is older than `max_age_h` -> refuse
+
+    🔴 A MISSING FIELD IS NOT A ZERO. `lastSuccessfulTime` is unset on a CronJob
+    that has never completed a run, which is indistinguishable in a bare `-o
+    jsonpath` from a field the query mis-spelled — both print an empty string.
+    So the whole object is fetched and the key looked up in Python, and its
+    absence is reported as COULD NOT MEASURE with the reason, never as "0 hours
+    ago" and never as a pass.
+
+    ⚠ WHAT IT DOES NOT ESTABLISH, said out loud: that the backup is RESTORABLE.
+    `lastSuccessfulTime` is the CronJob controller's record that a Job exited 0.
+    Restore-testing is homelab-infra#551's business and is not re-derived here;
+    this is a liveness gate, not a restore drill.
+    """
+    env_note = ""
+    cmd = ["kubectl"]
+    if kubeconfig:
+        cmd += ["--kubeconfig", kubeconfig]
+    cmd += ["-n", namespace, "get", "cronjob", cronjob, "-o", "json"]
+    got = run(cmd, timeout=45)
+    if not got.ok:
+        first = (got.err or got.out).strip().splitlines()
+        return False, (
+            f"COULD NOT MEASURE the backup: `kubectl get cronjob {cronjob}` in "
+            f"namespace {namespace} exited {got.rc} — "
+            f"{first[0] if first else 'no output'}{env_note}"
+        )
+    try:
+        obj = json.loads(got.out)
+    except ValueError as exc:
+        return False, f"COULD NOT MEASURE the backup: kubectl's JSON did not parse ({exc})"
+    stamp = (obj.get("status") or {}).get("lastSuccessfulTime")
+    if not stamp:
+        return False, (
+            f"COULD NOT MEASURE the backup: CronJob {namespace}/{cronjob} exists but "
+            f"carries no `status.lastSuccessfulTime` — it has never completed a run, "
+            f"or the controller has forgotten one. That is NOT a recent backup."
+        )
+    try:
+        when = datetime.strptime(stamp, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError as exc:
+        return False, f"COULD NOT MEASURE the backup: unparseable timestamp {stamp!r} ({exc})"
+    now = now or datetime.now(timezone.utc)
+    age_h = (now - when).total_seconds() / 3600.0
+    if age_h > max_age_h:
+        return False, (
+            f"the newest SUCCESSFUL backup of {namespace}/{cronjob} is {age_h:.1f} h "
+            f"old ({stamp}); the ceiling is {max_age_h:.1f} h. Run one and re-try: "
+            f"`kubectl -n {namespace} create job --from=cronjob/{cronjob} "
+            f"manual-$(date +%s)` — that form DOES set an ownerReference, so it "
+            f"updates lastSuccessfulTime; a hand-rolled Job does not."
+        )
+    return True, (
+        f"backup OK — {namespace}/{cronjob} last succeeded {stamp} "
+        f"({age_h:.1f} h ago, ceiling {max_age_h:.1f} h)"
+    )
+
+
+def write_route_deployed(
+    *, url: str, token: str, scope: str, timeout: int = 20
+) -> tuple[bool, str]:
+    """Does the RUNNING image carry the write path? `(ok, sentence)`.
+
+    🔴 THE PROBE IS A DELIBERATELY MALFORMED BODY, AND THAT IS WHAT MAKES IT
+    SAFE. `server._append_bullet` validates the payload BEFORE it resolves the
+    ref, so an empty JSON object `{}` is answered `400 bad-request` by a server
+    that HAS the route and `405 read-only` by one that does not. It therefore
+    discriminates the two without any input that could possibly be written — no
+    ref is resolved, no file is opened, no bullet is rendered.
+
+    🔴 A VALID BODY AGAINST A "REF THAT CANNOT EXIST" WAS THE FIRST DESIGN AND IS
+    WORSE: it relies on a guess about what the store does NOT contain, and the
+    failure mode of a wrong guess is an unrequested production write. Choosing an
+    input that fails EARLIER is strictly better than choosing one that is
+    expected to fail LATER.
+
+    ⚠ 400 IS THE PASS HERE. That inversion is stated because it reads wrong at a
+    glance and a future reader "fixing" it to `== 200` would make the check
+    unsatisfiable — the same shape as a guard that can never fire.
+    """
+    target = f"{url.rstrip('/')}/api/v1/entry/{scope}/__cutover_probe__/bullets"
+    req = urllib.request.Request(target, data=b"{}", method="POST")
+    req.add_header("Authorization", f"Bearer {token}")
+    # See `cairn._apply_standard_headers`: urllib's default UA is 403'd by the edge.
+    req.add_header("User-Agent", "subsystem-store-client/1")
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return False, (
+                f"the probe was ANSWERED {resp.status}, and the only expected answers "
+                f"are 400 (route present) or 405 (route absent). Treating this as "
+                f"UNMEASURED rather than guessing."
+            )
+    except urllib.error.HTTPError as exc:
+        status = exc.headers.get("X-Store-Status", "") if exc.headers else ""
+        if exc.code == 400:
+            return True, (
+                f"the write route IS deployed — the malformed-body probe was refused "
+                f"400 [{status or 'bad-request'}], which only a server that DISPATCHED "
+                f"the POST can answer"
+            )
+        if exc.code == 405:
+            return False, (
+                f"the RUNNING image is READ-ONLY — POST answered 405 [{status}]. This "
+                f"is an operator problem, not a caller problem: deploy an image "
+                f"carrying the write path before cutting over, or every append after "
+                f"the freeze fails with nowhere to land."
+            )
+        return False, (
+            f"COULD NOT MEASURE the write route: the probe answered {exc.code} "
+            f"[{status}]. 401 means the credential; 403 means the edge."
+        )
+    except urllib.error.URLError as exc:
+        return False, f"COULD NOT MEASURE the write route: {url} unreachable: {exc.reason}"
+    except OSError as exc:
+        return False, f"COULD NOT MEASURE the write route: {url} unreachable: {exc}"
+
+
+# =============================================================================
+# P1 — the plan
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class EntryFacts:
+    rel: str
+    sha256: str
+    aliases: tuple[str, ...]
+    bullets: tuple[str, ...]
+
+
+def read_store(root: Path) -> dict[str, EntryFacts]:
+    """`<scope>/<entry>.md` -> facts, for every SHIPPABLE entry under `root`.
+
+    🔴 THE SAME POPULATION `seed.sh` SHIPS, deliberately: depth-2 `*.md` regular
+    files under a scope directory that is neither a dot-directory nor a symlink.
+    A walk with different rules is how that script once printed
+    `remote_entries=1 staged_entries=2` one line above `seed: OK`.
+    """
+    out: dict[str, EntryFacts] = {}
+    if not root.is_dir():
+        return out
+    for scope_dir in sorted(root.iterdir()):
+        if not scope_dir.is_dir() or scope_dir.name.startswith(".") or scope_dir.is_symlink():
+            continue
+        for path in sorted(scope_dir.glob("*.md")):
+            if path.is_symlink() or not path.is_file():
+                continue
+            data = path.read_bytes()
+            text = data.decode("utf-8", "surrogateescape")
+            out[f"{scope_dir.name}/{path.name}"] = EntryFacts(
+                rel=f"{scope_dir.name}/{path.name}",
+                sha256=hashlib.sha256(data).hexdigest(),
+                aliases=tuple(_aliases(text)),
+                bullets=tuple(
+                    line.strip() for line in text.splitlines()
+                    if line.strip().startswith("- ")
+                ),
+            )
+    return out
+
+
+def _aliases(text: str) -> list[str]:
+    """The `aliases:` list, parsed LINE BY LINE exactly as the reader parses it.
+
+    🔴 NOT A YAML LOAD. `subsystem_recall` reads front matter line by line, which
+    is why a WRAPPED `aliases: [...]` list makes an entry malformed rather than
+    merely oddly formatted. Parsing it more generously here would make this
+    script see aliases the resolver cannot, and a collision check that models a
+    different reader than the one that runs is worse than none.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return []
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return []
+        if line.startswith("aliases:"):
+            body = line.split(":", 1)[1].strip().strip("[]")
+            return [a.strip() for a in body.split(",") if a.strip()]
+    return []
+
+
+ADD = "ADD"            # the pod does not have it: pure addition
+SAME = "SAME"          # byte-identical: nothing to do (this is the idempotence)
+SUPERSEDES = "SUPERSEDES"   # divergent, host copy is the newer same-lineage file
+MERGED = "MERGED"      # divergent, and an operator-authored resolution exists
+NEEDS_MERGE = "NEEDS_MERGE"  # divergent, and only a human can resolve it
+
+
+@dataclass
+class Item:
+    rel: str
+    verdict: str
+    reason: str
+    source: Path
+
+
+@dataclass
+class Plan:
+    items: list[Item] = field(default_factory=list)
+
+    def of(self, verdict: str) -> list[Item]:
+        return [i for i in self.items if i.verdict == verdict]
+
+    @property
+    def shippable(self) -> list[Item]:
+        return [i for i in self.items if i.verdict in (ADD, SUPERSEDES, MERGED)]
+
+
+def plan_delta(
+    local: dict[str, EntryFacts],
+    pod: dict[str, EntryFacts],
+    *,
+    store_root: Path,
+    merged_dir: Path | None,
+    peer: dict[str, EntryFacts] | None = None,
+) -> Plan:
+    """Classify every local entry against the served copy. THE MERGE RULE.
+
+    Stated once, here, and generalised past the one file that motivated it:
+
+      1. **Present on one side only** -> ADD. Additive; no decision to make.
+      2. **Present on both, byte-identical** -> SAME. This is what makes a
+         re-run a no-op rather than a second push.
+      3. **Present on both and divergent, pod vs a host** -> the pod's copy is a
+         LAGGING DERIVATIVE of that host's file (it got there by being seeded
+         from it), so the host copy SUPERSEDES it — *unless* the pod holds a
+         bullet the host lacks that carries the API attribution trailer. Such a
+         bullet was written through the pod and exists in exactly one place in
+         the world, so the entry becomes NEEDS_MERGE.
+      4. **Present on both hosts and divergent** -> neither is a derivative of
+         the other, so there is no supersession argument available. ALWAYS
+         NEEDS_MERGE, never last-write-wins, whatever the mtimes say.
+      5. A NEEDS_MERGE is resolved ONLY by a file at the same relative path under
+         `--merged`, authored by a human. Nothing else clears it.
+
+    🔴 WHY RULE 3 IS NOT "NEWER MTIME WINS". mtime is a property of a filesystem
+    that has been rsynced, tarred and extracted; the pod's copies all carry the
+    extract's time. The *lineage* argument is what actually holds: the pod's tree
+    was produced FROM a host tree, so for any entry the pod did not itself change
+    the host's copy contains everything the pod's does. The attribution trailer is
+    precisely the marker of the pod having changed one, which is why detecting it
+    is the whole safety of this rule rather than a nicety.
+
+    ⚠ AND ITS LIMIT, STATED: rule 3 is a claim about *how the pod's copy got
+    there*. It holds while `seed.sh` is the only writer other than the API. A
+    future writer that edits the served copy by some third route would break the
+    premise, not merely the implementation — which is why NEEDS_MERGE, not
+    SUPERSEDES, is the fail-safe direction and why an unrecognised divergence
+    ends in a refusal rather than a push.
+    """
+    plan = Plan()
+    for rel, facts in sorted(local.items()):
+        src = store_root / rel
+        override = (merged_dir / rel) if merged_dir else None
+        if rel not in pod:
+            plan.items.append(Item(rel, ADD, "not present in the served copy", src))
+            continue
+        if pod[rel].sha256 == facts.sha256:
+            plan.items.append(Item(rel, SAME, "byte-identical to the served copy", src))
+            continue
+        if override is not None and override.is_file():
+            plan.items.append(
+                Item(rel, MERGED, f"resolved by hand at {override}", override)
+            )
+            continue
+        if peer is not None and rel in peer and peer[rel].sha256 != facts.sha256:
+            plan.items.append(Item(
+                rel, NEEDS_MERGE,
+                "both hosts hold a different copy — neither is a derivative of the "
+                "other, so there is no supersession argument. Author a resolution "
+                f"at <merged>/{rel}.",
+                src,
+            ))
+            continue
+        pod_only = [b for b in pod[rel].bullets if b not in facts.bullets]
+        attributed = [b for b in pod_only if ATTRIBUTION.search(b)]
+        if attributed:
+            plan.items.append(Item(
+                rel, NEEDS_MERGE,
+                f"the served copy holds {len(attributed)} API-appended bullet(s) this "
+                f"host does not — that content exists nowhere else and a push would "
+                f"overwrite it. Author a resolution at <merged>/{rel}.",
+                src,
+            ))
+            continue
+        plan.items.append(Item(
+            rel, SUPERSEDES,
+            f"divergent; the served copy holds {len(pod_only)} bullet line(s) this "
+            f"host lacks and NONE is API-attributed, so they are a stale snapshot "
+            f"of a file this host has since edited",
+            src,
+        ))
+    return plan
+
+
+# =============================================================================
+# P2 — ref collisions in the union
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class Collision:
+    tier: str          # "FILENAME" | "ALIAS" | "ALIAS-shadowed"
+    scope: str
+    ref: str
+    claimants: tuple[str, ...]
+    shadowed_by: tuple[str, ...] = ()
+
+    @property
+    def live(self) -> bool:
+        return self.tier in ("FILENAME", "ALIAS")
+
+
+def ref_collisions(union: dict[str, EntryFacts]) -> list[Collision]:
+    """Every ref that does not resolve to exactly one entry, per scope.
+
+    🔴 TWO CLASSES, AND CONFLATING THEM WOULD MAKE THIS A PERMANENTLY-RED GATE.
+    `subsystem_resolver.resolve_ref_tiered` consults tier 1 (FILENAME) and only
+    reaches tier 2 (ALIAS) **if tier 1 returned zero hits** — measured against
+    the live store, not inferred: ref `cairn` in one scope resolves to
+    `cairn.md` at `tier=filename` while a second entry in the same scope claims
+    `cairn` as an alias. So:
+
+      * a FILENAME collision, or an ALIAS collision on a ref no filename
+        answers, is LIVE — the resolver raises `AmbiguousRefError`, the write
+        route answers 400, and the entry is unwritable. It BLOCKS.
+      * an alias SHADOWED by a filename is LATENT — it changes nothing today and
+        becomes live only if that filename is renamed or removed. It is reported
+        and does not block, because failing on it would refuse a migration over
+        a defect that is already present and already harmless.
+    """
+    per_scope: dict[str, list[tuple[str, str | None, set[str], str]]] = {}
+    for rel, facts in union.items():
+        scope, filename = rel.split("/", 1)
+        stem = filename[:-3]
+        parts = stem.split(".")
+        slug, kind = (parts[0], parts[1]) if len(parts) > 1 else (stem, None)
+        per_scope.setdefault(scope, []).append(
+            (normalize_ref(slug), kind, {normalize_ref(a) for a in facts.aliases}, filename)
+        )
+    found: list[Collision] = []
+    for scope, entries in sorted(per_scope.items()):
+        slugs: dict[str, set[str]] = {}
+        aliases: dict[str, set[str]] = {}
+        for slug, kind, alias_set, filename in entries:
+            if kind is None:
+                slugs.setdefault(slug, set()).add(filename)
+            for alias in alias_set:
+                aliases.setdefault(alias, set()).add(filename)
+        for slug, files in sorted(slugs.items()):
+            if len(files) > 1:
+                found.append(Collision("FILENAME", scope, slug, tuple(sorted(files))))
+        for alias, files in sorted(aliases.items()):
+            if alias in slugs:
+                if files != slugs[alias]:
+                    found.append(Collision(
+                        "ALIAS-shadowed", scope, alias, tuple(sorted(files)),
+                        tuple(sorted(slugs[alias])),
+                    ))
+            elif len(files) > 1:
+                found.append(Collision("ALIAS", scope, alias, tuple(sorted(files))))
+    return found
+
+
+def parse_alias_owner(specs: list[str]) -> dict[tuple[str, str], str]:
+    """`--alias-owner <scope>:<alias>=<filename>` -> {(scope, alias): filename}."""
+    owners: dict[tuple[str, str], str] = {}
+    for spec in specs:
+        if ":" not in spec or "=" not in spec:
+            raise ValueError(
+                f"--alias-owner wants <scope>:<alias>=<filename>, got {spec!r}"
+            )
+        head, _, filename = spec.partition("=")
+        scope, _, alias = head.partition(":")
+        if not (scope and alias and filename):
+            raise ValueError(
+                f"--alias-owner wants <scope>:<alias>=<filename>, got {spec!r}"
+            )
+        owners[(scope, normalize_ref(alias))] = filename
+    return owners
+
+
+# =============================================================================
+# P5 — the freeze, and the WATCHED EACCES
+# =============================================================================
+
+
+def probe_writable(path: Path) -> str:
+    """`"writable"` | `"refused"` | `"error:<errno>"` — by SYSCALL, not by mode.
+
+    🔴 A MODE BIT IS A CLAIM; A REFUSED WRITE IS EVIDENCE. `stat -c %a` says what
+    the inode is labelled, not what this process may do — setuid, ACLs, an
+    overlay, a bind mount and being root all separate the two, and the last of
+    those is common enough that this script refuses to run as root at all.
+
+    The probe opens the REAL entry file for APPEND and writes ZERO bytes. That
+    is the exact syscall an `Edit`/`Write` on the entry performs first, so it is
+    a faithful discriminator; and because nothing is written, neither the
+    contents nor the mtime move. A probe that wrote a byte and truncated it back
+    would be a mutation with a crash window, against a curated store.
+    """
+    try:
+        with open(path, "ab"):
+            pass
+    except PermissionError:
+        return "refused"
+    except OSError as exc:
+        return f"error:{errno.errorcode.get(exc.errno, exc.errno)}"
+    return "writable"
+
+
+def survey(store: Path) -> dict[str, int]:
+    """Count entry files by what a write to each ACTUALLY does.
+
+    🔴 `examined` IS PRINTED BESIDE EVERY COUNT, ALWAYS. A bare "0 writable" from
+    a walk that visited nothing is indistinguishable from a fully frozen store,
+    and it is the reassuring zero the whole repo is arranged to refuse. The same
+    rule `drift-check.sh` follows by printing links EXAMINED beside links
+    dangling.
+    """
+    tally = {"examined": 0, "writable": 0, "refused": 0, "other": 0}
+    for rel in read_store(store):
+        tally["examined"] += 1
+        state = probe_writable(store / rel)
+        if state in ("writable", "refused"):
+            tally[state] += 1
+        else:
+            tally["other"] += 1
+    return tally
+
+
+def set_entry_mode(store: Path, mode: int) -> int:
+    """chmod every ENTRY FILE. Scope directories are deliberately untouched.
+
+    🔴 FILES, NOT DIRECTORIES, AND THE ASYMMETRY IS A DESIGN DECISION WITH A
+    KNOWN COST. Freezing the directories too would also stop a genuinely NEW
+    entry being created — and the hosted API has NO create route (`POST` and
+    `PUT` both resolve an existing ref; a ref that does not resolve is 404
+    `ref-unknown`), so the first entry for a new subsystem would have nowhere to
+    go at all. Freezing the files closes the hazard this cutover is about — an
+    append or an overwrite that lands only locally and dies at the next seed —
+    while leaving the one operation the API cannot yet serve. The gap is real and
+    is written down rather than papered over; see the design doc's "What
+    criterion 9 does NOT close".
+    """
+    changed = 0
+    for rel in read_store(store):
+        path = store / rel
+        if (path.stat().st_mode & 0o777) != mode:
+            path.chmod(mode)
+            changed += 1
+    return changed
+
+
+# =============================================================================
+# Orchestration
+# =============================================================================
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="cairn-cutover.py",
+        description="Cairn criterion 9 — the write-through cutover. Dry run unless --apply.",
+    )
+    p.add_argument("--apply", action="store_true",
+                   help="actually push and freeze; without it NOTHING is changed")
+    p.add_argument("--store", type=Path, default=DEFAULT_STORE)
+    p.add_argument("--merged", type=Path, default=DEFAULT_MERGED,
+                   help="operator-authored resolutions, mirroring <scope>/<entry>.md")
+    p.add_argument("--peer-manifest", type=Path, default=None,
+                   help="a JSON manifest of the OTHER host's store, so a host-vs-host "
+                        "divergence is refused rather than silently superseded")
+    p.add_argument("--run-dir", type=Path, default=None)
+    p.add_argument("--push", default=None, metavar="NS/DEPLOY",
+                   help="hand the delta tree to seed.sh --push")
+    p.add_argument("--dest", default="/data")
+    p.add_argument("--alias-owner", action="append", default=[], metavar="S:A=FILE",
+                   help="acknowledge one LIVE ref collision by naming its owner")
+    p.add_argument("--backup-namespace", default=DEFAULT_BACKUP_NAMESPACE)
+    p.add_argument("--backup-cronjob", default=DEFAULT_BACKUP_CRONJOB)
+    p.add_argument("--backup-max-age-hours", type=float, default=DEFAULT_BACKUP_MAX_AGE_H)
+    p.add_argument("--kubeconfig", default=os.environ.get("KC_HOMELAB") or None)
+    p.add_argument("--freeze", action="store_true",
+                   help="run phase 5 alone (still needs --apply to take effect)")
+    p.add_argument("--unfreeze", action="store_true",
+                   help="ROLLBACK of phase 5: restore the entry files to 0644")
+    p.add_argument("--manifest", action="store_true",
+                   help="print this host's store manifest as JSON and exit — the "
+                        "input --peer-manifest wants, produced on the other host")
+    p.add_argument("--rollback-push", type=Path, default=None, metavar="RUN_DIR",
+                   help="ROLLBACK of phase 3: re-PUT the pre-push bytes this script "
+                        "saved under <RUN_DIR>/pre-push for every entry it overwrote")
+    return p
+
+
+def rollback_push(run_dir: Path, *, apply: bool, timeout: int = 60) -> int:
+    """Re-PUT every pre-push copy, through `cairn put`. One write path, again.
+
+    🔴 THIS UNDOES AN OVERWRITE, NOT AN ADDITION. Entries the push ADDED have no
+    pre-image and are not restored, because the API has no delete verb — that is
+    a property of the server, not an omission here, and it is why the phase's
+    rollback is described as partial wherever it is offered rather than as "the
+    rollback".
+
+    🔴 IT DOES NOT SEND `--if-match`, IT LETS `cairn put` DERIVE ONE FROM A LIVE
+    SYNC. Restoring against a revision captured before the push would 412 every
+    time (the push is exactly what moved it). Deriving live means the restore
+    refuses if a THIRD party has changed the entry since — which is the correct
+    behaviour: a rollback that silently discards somebody else's later write is
+    the lost update this whole precondition exists to prevent.
+    """
+    src = run_dir / "pre-push"
+    if not src.is_dir():
+        return refuse(RC_USAGE, (
+            f"{src} does not exist. Either that run overwrote nothing (an ADD-only "
+            f"push has no pre-image to restore) or the run directory is wrong."
+        ))
+    files = sorted(p for p in src.glob("*/*.md") if p.is_file())
+    say(f"rollback-push: {len(files)} entr(ies) have a saved pre-push copy")
+    if not files:
+        return refuse(RC_USAGE, (
+            f"{src} holds no entry files. A rollback that restores nothing must not "
+            f"report success — that is the reassuring zero."
+        ))
+    if not apply:
+        for path in files:
+            say(f"DRY RUN — would restore {path.parent.name}/{path.name}")
+        say("Nothing was changed. Re-run with --apply.")
+        return RC_OK
+    failed = []
+    for path in files:
+        scope, ref = path.parent.name, path.name[:-3]
+        got = run([
+            sys.executable, str(CAIRN), "put", "--scope", scope, "--ref", ref,
+            "--file", str(path),
+        ], timeout=timeout)
+        sys.stdout.write(got.out)
+        sys.stderr.write(got.err)
+        if not got.ok:
+            failed.append(f"{scope}/{ref} (rc {got.rc})")
+    say(f"rollback-push: restored {len(files) - len(failed)} of {len(files)}")
+    if failed:
+        return refuse(RC_ACCEPTANCE, f"could not restore: {failed}")
+    return RC_OK
+
+
+def emit_manifest(store: Path) -> int:
+    """The other host's store, reduced to what the peer check needs.
+
+    🔴 NO BULLET TEXT. The peer manifest is copied between machines and read by a
+    third process; it is used for exactly two questions — "does the other host
+    hold this entry?" and "is its copy the same bytes?" — and a sha256 answers
+    both. Shipping the prose as well would move client-confidential content
+    across a channel that does not need it, for no gain. The pod-side
+    attribution check reads bullets, but it reads them from files this process
+    opened itself, never from a manifest.
+    """
+    facts = read_store(store)
+    print(json.dumps(
+        {rel: {"sha256": f.sha256, "aliases": list(f.aliases)}
+         for rel, f in facts.items()},
+        sort_keys=True,
+    ))
+    return RC_OK
+
+
+def load_peer(path: Path | None) -> dict[str, EntryFacts] | None:
+    if path is None:
+        return None
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    return {
+        rel: EntryFacts(rel, v["sha256"], tuple(v.get("aliases", [])),
+                        tuple(v.get("bullets", [])))
+        for rel, v in raw.items()
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.manifest:
+        return emit_manifest(args.store)
+
+    if args.rollback_push is not None:
+        return rollback_push(args.rollback_push, apply=args.apply)
+
+    # 🔴 REFUSED AS ROOT, BEFORE ANYTHING ELSE. Phase 5's whole verification is a
+    # WATCHED EACCES, and root bypasses the permission bits it depends on — so
+    # as root the freeze would be applied, the probe would report "writable",
+    # and this script would roll the freeze back and report failure on a store
+    # that was correctly frozen. Wrong in the safe direction, and still wrong.
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        return refuse(RC_ROOT, (
+            "running as root. The freeze's only evidence is a REFUSED write, and "
+            "root is not refused — the check would be vacuous. Re-run as the user "
+            "that owns the store."
+        ))
+
+    if args.unfreeze:
+        before = survey(args.store)
+        say(f"unfreeze: before  {before}")
+        if not args.apply:
+            say("DRY RUN — pass --apply to restore 0644. Nothing was changed.")
+            return RC_OK
+        changed = set_entry_mode(args.store, 0o644)
+        after = survey(args.store)
+        say(f"unfreeze: chmod 0644 on {changed} entry file(s); after {after}")
+        if after["examined"] and after["writable"] != after["examined"]:
+            return refuse(RC_COULD_NOT_MEASURE, (
+                f"unfreeze did not fully take: {after['writable']} of "
+                f"{after['examined']} entry file(s) are writable again."
+            ))
+        return RC_OK
+
+    run_dir = args.run_dir or (DEFAULT_RUN_ROOT / datetime.now(timezone.utc)
+                               .strftime("%Y%m%dT%H%M%SZ"))
+    delta_dir = run_dir / "delta"
+    stage_dir = run_dir / "stage"
+    cache_dir = run_dir / "cache"
+    prepush_dir = run_dir / "pre-push"
+
+    # ---- P0 preconditions -------------------------------------------------
+    if not args.freeze:
+        local = read_store(args.store)
+        if not local:
+            return refuse(RC_NO_STORE, (
+                f"{args.store} holds no shippable entries. A cutover that pushed an "
+                f"empty delta and then froze an empty store would report success "
+                f"having done nothing."
+            ))
+        say(f"P0 local store: {len(local)} entries / "
+            f"{len({r.split('/')[0] for r in local})} scopes at {args.store}")
+
+        ok, sentence = backup_precondition(
+            namespace=args.backup_namespace, cronjob=args.backup_cronjob,
+            max_age_h=args.backup_max_age_hours, kubeconfig=args.kubeconfig,
+        )
+        say(f"P0 {sentence}")
+        if not ok:
+            return refuse(RC_BACKUP, sentence)
+
+        run_dir.mkdir(parents=True, exist_ok=True)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        synced = run(
+            [sys.executable, str(CAIRN), "--cache", str(cache_dir), "sync"], timeout=120
+        )
+        say(f"P0 cairn sync -> rc {synced.rc}: {(synced.out or synced.err).strip()[:200]}")
+        if not synced.ok:
+            return refuse(RC_UNREACHABLE, (
+                f"`cairn sync` exited {synced.rc}; the served copy could not be read, "
+                f"so there is nothing to compare the local store against and a push "
+                f"would be blind. {(synced.err or synced.out).strip()[:300]}"
+            ))
+        pod = read_store(cache_dir)
+        say(f"P0 served copy: {len(pod)} entries / "
+            f"{len({r.split('/')[0] for r in pod})} scopes")
+
+        url, token = _config()
+        probe_scope = sorted({r.split("/")[0] for r in pod})[0] if pod else None
+        if probe_scope is None:
+            return refuse(RC_COULD_NOT_MEASURE, (
+                "the served copy holds no scope, so the write-route probe has no "
+                "scope to address. A zero here is not a pass."
+            ))
+        ok, sentence = write_route_deployed(url=url, token=token, scope=probe_scope)
+        say(f"P0 {sentence}")
+        if not ok:
+            return refuse(RC_NO_WRITE_ROUTE, sentence)
+
+        # ---- P1 the plan --------------------------------------------------
+        peer = load_peer(args.peer_manifest)
+        if peer is None:
+            say("P1 ⚠ NO --peer-manifest: a host-vs-host divergence cannot be "
+                "detected on this run, so rule 4 of the merge rule is UNCHECKED. "
+                "Produce one with `--manifest` on the other host.")
+        plan = plan_delta(local, pod, store_root=args.store,
+                          merged_dir=args.merged, peer=peer)
+        counts = {v: len(plan.of(v)) for v in (ADD, SAME, SUPERSEDES, MERGED, NEEDS_MERGE)}
+        say(f"P1 plan over {len(plan.items)} local entries: {counts}")
+        for item in plan.of(NEEDS_MERGE):
+            print(f"  NEEDS_MERGE {item.rel}: {item.reason}", file=sys.stderr)
+        if plan.of(NEEDS_MERGE):
+            return refuse(RC_UNRESOLVED_DIVERGENCE, (
+                f"{len(plan.of(NEEDS_MERGE))} entr(ies) need a hand-authored merge. "
+                f"Write each one to {args.merged}/<scope>/<entry>.md and re-run. "
+                f"NOTHING was pushed."
+            ))
+
+        # ---- P2 collisions ------------------------------------------------
+        union = dict(pod)
+        for item in plan.shippable:
+            data = item.source.read_bytes()
+            text = data.decode("utf-8", "surrogateescape")
+            union[item.rel] = EntryFacts(
+                item.rel, hashlib.sha256(data).hexdigest(), tuple(_aliases(text)),
+                tuple(l.strip() for l in text.splitlines() if l.strip().startswith("- ")),
+            )
+        if peer:
+            for rel, facts in peer.items():
+                union.setdefault(rel, facts)
+        try:
+            owners = parse_alias_owner(args.alias_owner)
+        except ValueError as exc:
+            return refuse(RC_USAGE, str(exc))
+        collisions = ref_collisions(union)
+        live = [c for c in collisions if c.live]
+        latent = [c for c in collisions if not c.live]
+        say(f"P2 union {len(union)} entries: LIVE ref collisions={len(live)} "
+            f"LATENT (filename-shadowed alias)={len(latent)}")
+        for c in latent:
+            print(f"  LATENT {c.scope}: alias {c.ref!r} claimed by "
+                  f"{list(c.claimants)} but the FILENAME tier answers first with "
+                  f"{list(c.shadowed_by)} — unreachable today, live the day that "
+                  f"file is renamed.", file=sys.stderr)
+        unacknowledged = [c for c in live if (c.scope, c.ref) not in owners]
+        for c in unacknowledged:
+            print(f"  LIVE {c.scope}: ref {c.ref!r} ({c.tier}) resolves to "
+                  f"{list(c.claimants)} — the write route answers such a ref 400 "
+                  f"and BOTH entries become unwritable.", file=sys.stderr)
+        if unacknowledged:
+            return refuse(RC_REF_COLLISION, (
+                f"{len(unacknowledged)} ref(s) would resolve to two entries in the "
+                f"union. Edit the losing entry's `aliases:` to drop the ref, then "
+                f"acknowledge the decision with "
+                f"--alias-owner <scope>:<ref>=<winning-filename>. NOTHING was pushed."
+            ))
+        if owners:
+            say(f"P2 {len(owners)} live collision(s) acknowledged by --alias-owner: "
+                f"{sorted(f'{s}:{a}' for s, a in owners)}")
+
+        # ---- P3 the push --------------------------------------------------
+        if not args.apply:
+            say(f"DRY RUN — {len(plan.shippable)} entr(ies) would be pushed "
+                f"({counts[ADD]} new, {counts[SUPERSEDES]} superseding, "
+                f"{counts[MERGED]} hand-merged); {counts[SAME]} already identical.")
+            say(f"DRY RUN — the push would be: {SEED} --store {delta_dir} "
+                f"--stage {stage_dir} --push {args.push or '<ns>/<deploy>'} "
+                f"--dest {args.dest}")
+            say("DRY RUN — the freeze would then chmod 0444 over "
+                f"{len(local)} entry file(s) and require EVERY ONE to refuse a write.")
+            say("Nothing was changed. Re-run with --apply.")
+            return RC_OK
+
+        if not plan.shippable:
+            say("P3 the delta is EMPTY — the served copy already holds every entry "
+                "this host has, byte for byte. Nothing to push; this is the "
+                "idempotent re-run, not a failure.")
+        else:
+            if not args.push:
+                return refuse(RC_USAGE, "--apply needs --push <namespace>/<deployment>")
+            _materialise(plan, delta_dir)
+            _save_prepush(plan, cache_dir, prepush_dir)
+            say(f"P3 pre-push copies of every entry about to be OVERWRITTEN saved "
+                f"under {prepush_dir} — that is the rollback for this phase.")
+            pushed = run([
+                "bash", str(SEED), "--store", str(delta_dir), "--stage", str(stage_dir),
+                "--push", args.push, "--dest", args.dest,
+            ], timeout=600)
+            sys.stdout.write(pushed.out)
+            sys.stderr.write(pushed.err)
+            if not pushed.ok:
+                return refuse(RC_ACCEPTANCE, (
+                    f"seed.sh exited {pushed.rc}. Read its own verdict lines above — "
+                    f"it distinguishes a staging failure from a push that landed "
+                    f"partially. NOTHING was frozen."
+                ))
+
+        # ---- P4 acceptance ------------------------------------------------
+        rc = _acceptance(args, cache_dir)
+        if rc != RC_OK:
+            return rc
+
+    # ---- P5 the freeze ----------------------------------------------------
+    before = survey(args.store)
+    say(f"P5 before the freeze: {before}")
+    if before["examined"] == 0:
+        return refuse(RC_COULD_NOT_MEASURE, (
+            "the freeze walked 0 entry files. A '0 writable' from a walk that "
+            "visited nothing is not a frozen store."
+        ))
+    if before["writable"] == 0:
+        say("P5 every entry file already refuses a write — the freeze is already "
+            "applied. This is the idempotent re-run.")
+        return RC_OK
+    if not args.apply:
+        say(f"DRY RUN — would chmod 0444 over {before['writable']} writable entry "
+            f"file(s) and then require all {before['examined']} to refuse a write.")
+        return RC_OK
+
+    changed = set_entry_mode(args.store, 0o444)
+    after = survey(args.store)
+    say(f"P5 chmod 0444 on {changed} entry file(s); after {after}")
+    # 🔴 THE WATCHED EACCES. Not `stat -c %a`, not `test -w`: every entry file is
+    # opened for append and every one of them must be REFUSED.
+    #
+    # ⚠ THE `examined == 0` CLAUSE IS UNREACHABLE, AND IT IS LABELLED RATHER
+    # THAN COUNTED. It looks like the empty-walk guard — "a zero from a walk that
+    # visited nothing satisfies `refused == examined`" — and that hazard is real,
+    # but it is already closed ABOVE, by the `before["examined"] == 0` refusal
+    # that returns before any chmod happens. Between those two points the store
+    # would have to lose every entry, so nothing can reach this clause with a
+    # zero. A mutation sweep scored its removal SURVIVED, which is the correct
+    # answer for an unreachable expression; it stays as a cheap statement of
+    # intent, and `claude/RULES.md` is explicit that such a clause must not be
+    # read as coverage. The guard that actually fires on an empty store is the
+    # `before` one, and `test_a_FREEZE_over_an_empty_store_is_COULD_NOT_MEASURE_
+    # not_success` is the test that kills its removal.
+    if after["refused"] != after["examined"] or after["examined"] == 0:
+        set_entry_mode(args.store, 0o644)
+        return refuse(RC_FREEZE_INEFFECTIVE, (
+            f"the freeze did not take: {after['refused']} of {after['examined']} "
+            f"entry file(s) refused a write ({after['writable']} still writable, "
+            f"{after['other']} failed for another reason). The mode bits were "
+            f"RESTORED to 0644 rather than left half-applied. A store that looks "
+            f"frozen and is not is worse than one that is plainly not."
+        ))
+    say(f"P5 WATCHED EACCES: all {after['examined']} entry file(s) refused an "
+        f"append. The local store is now a read-through cache.")
+    say("REMAINING, and NOT done by this script: land the protocol change that "
+        "routes `subsystem-index` appends through `cairn append`, and deploy it "
+        "(merge -> pull -> home-manager switch). Until that lands, the skill still "
+        "tells a writer to Edit a file that now refuses the write — which is a "
+        "loud failure, not a silent one, but it is a failure.")
+    return RC_OK
+
+
+def _config() -> tuple[str, str]:
+    """URL + token, read through `cairn`'s own loader — never a second parser."""
+    sys.path.insert(0, str(HERE))
+    spec = importlib.util.spec_from_loader(
+        "cairn_cli", importlib.machinery.SourceFileLoader("cairn_cli", str(CAIRN))
+    )
+    module = importlib.util.module_from_spec(spec)
+    # `sys.modules[name] = mod` BEFORE `exec_module`, or the first @dataclass
+    # raises `AttributeError: 'NoneType' has no attribute '__dict__'`.
+    sys.modules["cairn_cli"] = module
+    spec.loader.exec_module(module)
+    return module.load_config()
+
+
+def _materialise(plan: Plan, dest: Path) -> None:
+    """Copy exactly the shippable entries into a tree `seed.sh` can be pointed at.
+
+    🔴 THE TREE IS BUILT FRESH EVERY RUN, into a run-scoped directory. `seed.sh`
+    rsyncs SOURCE->STAGE with `--delete`, so a stale delta tree left from an
+    earlier run would push entries a later plan did not choose.
+    """
+    if dest.exists():
+        shutil.rmtree(dest)
+    for item in plan.shippable:
+        target = dest / item.rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(item.source, target)
+
+
+def _save_prepush(plan: Plan, cache: Path, dest: Path) -> None:
+    """Keep the SERVED bytes of every entry this push will overwrite.
+
+    🔴 THIS IS THE ROLLBACK FOR P3, AND IT MUST BE TAKEN BEFORE THE PUSH. An ADD
+    has no pre-image to save (rolling one back is a deletion, which the API
+    cannot do anyway); a SUPERSEDES or a MERGED replaces bytes that, after the
+    tar extract, exist only in the daily backup. Saving them here turns "restore
+    the whole store from a bundle" into "re-PUT one file".
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    for item in plan.shippable:
+        # 🔴 ONE PREDICATE, AND THE OTHER ONE WAS DELETED ON EVIDENCE. This loop
+        # used to open with `if item.verdict == ADD: continue` as well. A
+        # mutation sweep scored that line SURVIVED — not because the test was
+        # weak but because the two questions are the SAME question: `ADD` means
+        # "the served copy has no such entry", which is exactly what
+        # `served.is_file()` answers, from the very tree the verdict was computed
+        # against. It could never disagree, so it was an unreachable guard being
+        # counted as coverage. The remaining check is the direct one: save what
+        # the push is about to overwrite, which is whatever bytes are there.
+        served = cache / item.rel
+        if served.is_file():
+            target = dest / item.rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(served, target)
+
+
+def _acceptance(args: argparse.Namespace, cache_dir: Path) -> int:
+    """The prescribed acceptance check, plus the byte-identity verifier.
+
+    🔴 THE CHECK IS THE ONE THE CARD PRESCRIBES — `comm -23` of this host's entry
+    names against the served copy's, which must print ZERO lines. It is not
+    re-invented here: it is the same containment question `seed.sh`'s own push
+    verdict answers, asked again after the fact because a push verdict is a claim
+    about the push and this is a claim about the STATE.
+
+    `verify-byte-identity.sh` is then run unmodified over every scope. Its own
+    header documents the two controls that make its green meaningful, and its
+    PASS lines print `raw-diff-lines` and `store-root-lines` beside the verdict
+    so a reader can see the canonicalisation was spent where it claims.
+    """
+    refreshed = run(
+        [sys.executable, str(CAIRN), "--cache", str(cache_dir), "sync"], timeout=120
+    )
+    if not refreshed.ok:
+        return refuse(RC_COULD_NOT_MEASURE, (
+            f"could not re-read the served copy after the push (rc {refreshed.rc}), so "
+            f"the acceptance check has no second side to compare against. The push "
+            f"already happened; re-run to verify."
+        ))
+    local_names = sorted(read_store(args.store))
+    pod_names = set(read_store(cache_dir))
+    missing = [n for n in local_names if n not in pod_names]
+    say(f"P4 acceptance (comm -23, this host vs the served copy): "
+        f"local={len(local_names)} served={len(pod_names)} missing={len(missing)}")
+    if missing:
+        for name in missing[:40]:
+            print(f"  MISSING FROM THE SERVED COPY: {name}", file=sys.stderr)
+        return refuse(RC_ACCEPTANCE, (
+            f"{len(missing)} entr(ies) this host holds are not on the pod. The store "
+            f"was NOT frozen — freezing now would strand them."
+        ))
+    token_file = os.environ.get("SUBSYSTEM_STORE_TOKEN_FILE")
+    if not token_file:
+        say("P4 ⚠ verify-byte-identity.sh NOT RUN — it takes --token-file and "
+            "$SUBSYSTEM_STORE_TOKEN_FILE is unset. The `comm -23` half above passed; "
+            "the byte-identity half is UNMEASURED, which is not the same as clean.")
+        return RC_OK
+    url, _ = _config()
+    verified = run([
+        "bash", str(VERIFY), "--store", str(args.store), "--url", url,
+        "--token-file", token_file,
+    ], timeout=600)
+    sys.stdout.write(verified.out)
+    sys.stderr.write(verified.err)
+    if not verified.ok:
+        return refuse(RC_ACCEPTANCE, (
+            f"verify-byte-identity.sh exited {verified.rc}. Read its per-scope FAIL "
+            f"lines above. The store was NOT frozen."
+        ))
+    return RC_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cairn-cutover.py
+++ b/scripts/cairn-cutover.py
@@ -1028,11 +1028,17 @@ def main(argv: list[str] | None = None) -> int:
         ))
     say(f"P5 WATCHED EACCES: all {after['examined']} entry file(s) refused an "
         f"append. The local store is now a read-through cache.")
+    # ⚠ THE DEPLOY STEP NAMES `scripts/ship.sh`, NOT THE UNDERLYING BINARY, and
+    # that is deliberate on two counts. It is the more actionable instruction —
+    # ship.sh converges BOTH hosts and this store is per-host — and it keeps the
+    # launcher vocabulary out of a top-level script that must never launch one.
+    # `test_no_real_launchers.py` treats a bare mention as reaching the binary,
+    # correctly: it was reopened once by a name that was "only in a string".
     say("REMAINING, and NOT done by this script: land the protocol change that "
-        "routes `subsystem-index` appends through `cairn append`, and deploy it "
-        "(merge -> pull -> home-manager switch). Until that lands, the skill still "
-        "tells a writer to Edit a file that now refuses the write — which is a "
-        "loud failure, not a silent one, but it is a failure.")
+        "routes `subsystem-index` appends through `cairn append`, then merge, "
+        "pull and run `scripts/ship.sh` so BOTH hosts get it. Until that lands, "
+        "the skill still tells a writer to Edit a file that now refuses the "
+        "write — a loud failure, not a silent one, but a failure.")
     return RC_OK
 
 

--- a/scripts/tests/test_cairn_cutover.py
+++ b/scripts/tests/test_cairn_cutover.py
@@ -186,6 +186,95 @@ class TestTheMergeRule:
                              store_root=local, merged_dir=None, peer=peer)
         assert [i.verdict for i in plan.items] == [cc.SUPERSEDES]
 
+    def test_a_HOST_vs_HOST_divergence_is_a_HAND_MERGE_even_when_the_POD_LACKS_IT(
+        self, cc, tmp_path
+    ):
+        """🔴 THE ORDERING BUG RULE 4 WAS WRITTEN TO FORBID, COMMITTED BY THE CODE
+        THAT STATES IT.
+
+        The `ADD` clause used to run BEFORE the peer check, so for any entry the
+        pod does not yet hold — which is EVERY entry in a host-exclusive scope,
+        i.e. the whole population this migration is about — a host-vs-host
+        disagreement was classified `ADD` and pushed. First-host-to-run-wins,
+        silently, with no operator decision: exactly the last-write-wins the rule
+        forbids "whatever the mtimes say".
+
+        This fixture differs from the earlier host-vs-host case in ONE respect —
+        the pod does not hold the entry — which is the axis the bug lived on.
+        """
+        local = _tree(tmp_path / "l", {"sc/only-on-hosts.md": _entry(
+            "sc", "only-on-hosts", "- 2026-03-04: this host's account.")})
+        peer = {"sc/only-on-hosts.md": cc.EntryFacts(
+            "sc/only-on-hosts.md", "d" * 64, (), ())}
+        plan = cc.plan_delta(cc.read_store(local), {},   # pod holds NOTHING
+                             store_root=local, merged_dir=None, peer=peer)
+        assert [i.verdict for i in plan.items] == [cc.NEEDS_MERGE], (
+            "a host-vs-host divergence was pushed as an ADD because the pod "
+            "happened not to hold it"
+        )
+        assert plan.shippable == []
+
+    def test_a_hand_authored_MERGE_wins_even_when_the_POD_LACKS_THE_ENTRY(
+        self, cc, tmp_path
+    ):
+        """The same ordering defect, one clause over: `--merged` was consulted
+        BELOW the `ADD` return, so an operator's hand-written resolution for a
+        host-only entry was silently discarded in favour of the local copy. A
+        human decision must not be overridden by a classifier."""
+        local = _tree(tmp_path / "l", {"sc/only-on-hosts.md": _entry(
+            "sc", "only-on-hosts", "- 2026-03-04: the local copy.")})
+        merged = _tree(tmp_path / "m", {"sc/only-on-hosts.md": _entry(
+            "sc", "only-on-hosts", "- 2026-03-04: the RESOLVED copy.")})
+        plan = cc.plan_delta(cc.read_store(local), {},
+                             store_root=local, merged_dir=merged)
+        assert [i.verdict for i in plan.items] == [cc.MERGED]
+        assert plan.items[0].source == merged / "sc/only-on-hosts.md"
+        assert "RESOLVED copy" in plan.items[0].source.read_text()
+
+    def test_a_divergence_with_NO_pod_only_bullets_is_UNRECOGNISED_not_superseded(
+        self, cc, tmp_path
+    ):
+        """🔴 THE VACUOUS JUSTIFICATION. The bytes differ and the bullet lists do
+        not, so whatever moved is outside the region the attribution rule can
+        see. Classifying it SUPERSEDES printed "the served copy holds 0 bullet
+        line(s) this host lacks and NONE is API-attributed" as the reason to
+        OVERWRITE it — a vacuous truth offered as evidence from a scan that
+        examined nothing.
+
+        🔴 AND `cairn put` — added by the same change — produces exactly this
+        shape: its stated reasons to exist are updating `## Pointers` and
+        rewriting an `OPEN:` marker, both outside the bullet set. So rule 3's
+        premise is broken by this file's own sibling, not by a hypothetical.
+
+        The fixture differs ONLY in the `## What it is` PROSE — a line that does
+        not begin `- `, so it is not in the bullet set either side, which is what
+        makes `pod_only` empty.
+
+        ⚠ MEASURED WHILE WRITING THIS: `read_store` extracts EVERY line beginning
+        `- `, so a `## Pointers` entry counts as a bullet too. That makes the
+        attribution scan a deliberate SUPERSET (fail-safe), but it also means a
+        pointers-only divergence is NOT the empty-`pod_only` case — this fixture
+        was written that way first and classified SUPERSEDES, correctly.
+        """
+        local = _tree(tmp_path / "l", {"sc/a.md": "\n".join([
+            "---", "service: a", "scope: sc", "sensitivity: internal", "---", "",
+            "## What it is", "the a, as this host describes it.", "",
+            "## Pointers", "- `sc: src/a.py`", "",
+            "## Nuance / work-history", "- 2026-01-01: one shared bullet.", "",
+        ])})
+        pod = _tree(tmp_path / "p", {"sc/a.md": "\n".join([
+            "---", "service: a", "scope: sc", "sensitivity: internal", "---", "",
+            "## What it is", "the a, rewritten through a whole-file PUT.", "",
+            "## Pointers", "- `sc: src/a.py`", "",
+            "## Nuance / work-history", "- 2026-01-01: one shared bullet.", "",
+        ])})
+        plan = cc.plan_delta(cc.read_store(local), cc.read_store(pod),
+                             store_root=local, merged_dir=None)
+        assert [i.verdict for i in plan.items] == [cc.NEEDS_MERGE], (
+            f"classified {plan.items[0].verdict} with reason: {plan.items[0].reason}"
+        )
+        assert "outside the region" in plan.items[0].reason
+
     def test_ONLY_a_hand_authored_file_clears_a_NEEDS_MERGE(self, cc, tmp_path):
         local = _tree(tmp_path / "l", {"sc/a.md": _entry("sc", "a", "- 2026-02-09: host.")})
         pod = _tree(tmp_path / "p", {"sc/a.md": _entry(
@@ -356,12 +445,85 @@ class TestRefCollisions:
             "the alias tier answered first; the LATENT classification is unsafe"
         )
 
-    def test_two_files_with_one_SLUG_is_a_FILENAME_collision(self, cc):
+    def test_one_slug_in_two_SCOPES_is_not_a_collision(self, cc):
+        """Refs resolve WITHIN a scope, so the same stem in two scopes is fine.
+
+        ⚠ RENAMED. This was called `test_two_files_with_one_SLUG_is_a_FILENAME_
+        collision` while asserting the empty list — a name that said the opposite
+        of its assertion, over the arm that had no positive coverage at all. The
+        real FILENAME collision now has its own test below.
+        """
         union = {
             "sc/dup.md": cc.EntryFacts("sc/dup.md", "1" * 64, (), ()),
             "other/dup.md": cc.EntryFacts("other/dup.md", "2" * 64, (), ()),
         }
-        # Different SCOPES — refs resolve within a scope, so this is NOT one.
+        assert cc.ref_collisions(union) == []
+
+    def test_a_KIND_QUALIFIED_file_collides_with_its_BARE_sibling(self, cc):
+        """🔴 THE COLLISION THE FIRST VERSION COULD NOT SEE — and the FILENAME
+        arm's only positive coverage.
+
+        `resolve_ref_tiered` matches a kind-less ref against `e.slug` **with no
+        kind constraint**, so `svc` hits BOTH `svc.md` and `svc.process.md` and
+        raises `AmbiguousRefError` — both entries become unwritable, which is the
+        exact condition P2 exists to detect. The first implementation registered
+        only kind-less files under their slug, so it returned `[]` for this pair
+        while the real resolver raised. `repo-cos.process` is the resolver
+        docstring's own worked example, so the shape is in live use.
+
+        The qualified ref is NOT ambiguous and must not be reported — that is the
+        second assertion, and without it a fix could pass by flagging everything.
+        """
+        union = {
+            "sc/svc.md": cc.EntryFacts("sc/svc.md", "1" * 64, (), ()),
+            "sc/svc.process.md": cc.EntryFacts("sc/svc.process.md", "2" * 64, (), ()),
+        }
+        found = cc.ref_collisions(union)
+        assert [(c.tier, c.ref, c.claimants) for c in found] == [
+            ("FILENAME", "svc", ("svc.md", "svc.process.md"))
+        ], found
+        assert found[0].live
+
+    def test_that_collision_is_the_one_the_REAL_resolver_raises_on(self, cc):
+        """The measurement behind the test above, against the resolver itself —
+        so the checker's claim is pinned to the reader's behaviour and not to my
+        reading of it."""
+        sys.path.insert(0, str(REPO / "scripts" / "lib"))
+        import subsystem_recall as rc
+        import subsystem_resolver as sr
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _tree(root, {
+                "sc/svc.md": _entry("sc", "svc", "- 2026-01-01: x."),
+                "sc/svc.process.md": _entry("sc", "svc", "- 2026-01-01: y."),
+            })
+            _store, index = rc.load_store(str(root), verb="read")
+            with pytest.raises(sr.AmbiguousRefError):
+                rc.resolve_ref_tiered("svc", index, "sc")
+            # The QUALIFIED ref is unambiguous — the control that keeps the
+            # assertion above from being "any ref in this scope raises".
+            entry, tier = rc.resolve_ref_tiered("svc.process", index, "sc")
+            assert entry is not None and tier == "filename"
+
+    def test_a_NON_KIND_dotted_stem_is_NOT_split__no_FALSE_collision(self, cc):
+        """The other direction, and the permanently-red-gate one.
+
+        `split_kind` treats a trailing dot-segment as a kind ONLY if it is in
+        `KINDS`. The hand-rolled `stem.split(".")` took `foo` out of
+        `foo.notes.md`, so `foo.md` beside `foo.notes.md` would have been
+        reported as a LIVE collision the resolver does not have — blocking a
+        cutover over a defect that does not exist.
+        """
+        import subsystem_resolver as sr
+
+        assert "notes" not in sr.KINDS, "fixture assumes `notes` is not a KIND"
+        union = {
+            "sc/foo.md": cc.EntryFacts("sc/foo.md", "1" * 64, (), ()),
+            "sc/foo.notes.md": cc.EntryFacts("sc/foo.notes.md", "2" * 64, (), ()),
+        }
         assert cc.ref_collisions(union) == []
 
     def test_alias_owner_parsing_refuses_a_malformed_spec(self, cc):
@@ -550,44 +712,85 @@ class TestWriteRouteProbe:
         input capable of being written is ever sent."""
         srv = self._serve(400, "bad-request")
         try:
-            ok, sentence = cc.write_route_deployed(
+            ok, rc, sentence = cc.write_route_deployed(
                 url=f"http://127.0.0.1:{srv.server_address[1]}", token="t", scope="sc")
         finally:
             srv.shutdown(); srv.server_close()
         assert ok, sentence
+        assert rc is None
         assert "IS deployed" in sentence
 
-    def test_a_405_is_reported_as_an_OPERATOR_problem(self, cc):
+    def test_a_405_is_the_ONLY_answer_that_means_NO_WRITE_ROUTE(self, cc):
+        """🔴 THE CODE, NOT JUST THE VERDICT. Every falsy result used to be
+        answered by the caller with RC_NO_WRITE_ROUTE, whose documented meaning
+        is "the running image has no write path" — so an unreachable pod during
+        P0 told the operator to redeploy the store. Only this arm may carry it.
+        """
         srv = self._serve(405, "read-only")
         try:
-            ok, sentence = cc.write_route_deployed(
+            ok, rc, sentence = cc.write_route_deployed(
                 url=f"http://127.0.0.1:{srv.server_address[1]}", token="t", scope="sc")
         finally:
             srv.shutdown(); srv.server_close()
         assert not ok
+        assert rc == cc.RC_NO_WRITE_ROUTE
         assert "READ-ONLY" in sentence and "operator problem" in sentence
 
     @pytest.mark.parametrize("code, status", [(401, "unauthorized"), (403, "")])
     def test_any_OTHER_answer_is_UNMEASURED_never_a_pass(self, cc, code, status):
         srv = self._serve(code, status)
         try:
-            ok, sentence = cc.write_route_deployed(
+            ok, rc, sentence = cc.write_route_deployed(
                 url=f"http://127.0.0.1:{srv.server_address[1]}", token="t", scope="sc")
         finally:
             srv.shutdown(); srv.server_close()
         assert not ok
+        assert rc == cc.RC_COULD_NOT_MEASURE, (
+            "a credential or edge refusal was reported as 'the image has no write "
+            "path', which sends the operator to redeploy the store"
+        )
         assert "COULD NOT MEASURE" in sentence
 
-    def test_an_UNREACHABLE_host_is_UNMEASURED(self, cc):
+    def test_an_UNREACHABLE_host_is_UNMEASURED_not_a_missing_write_route(self, cc):
         import socket as _socket
 
         with _socket.socket() as sock:
             sock.bind(("127.0.0.1", 0))
             dead = sock.getsockname()[1]
-        ok, sentence = cc.write_route_deployed(
+        ok, rc, sentence = cc.write_route_deployed(
             url=f"http://127.0.0.1:{dead}", token="t", scope="sc")
         assert not ok
+        assert rc == cc.RC_COULD_NOT_MEASURE
         assert "COULD NOT MEASURE" in sentence
+
+    def test_the_probe_sends_the_User_Agent_the_edge_REQUIRES(self, cc):
+        """🔴 THE FOURTH SITE THAT HAND-ROLLED THIS HEADER IS NOW THE CLI'S OWN
+        HELPER, AND THIS IS WHAT PINS IT. A drifted copy would be 403'd by the
+        edge, which this probe classifies as COULD NOT MEASURE — so the symptom
+        of a wrong header is an operator being told the store is unreachable."""
+        seen = {}
+
+        class Capture(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                self.rfile.read(int(self.headers.get("Content-Length") or 0))
+                seen.update({k.lower(): v for k, v in self.headers.items()})
+                self.send_response(400)
+                self.send_header("x-store-status", "bad-request")
+                self.send_header("content-length", "0")
+                self.end_headers()
+
+            def log_message(self, *_a):
+                return
+
+        srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Capture)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        try:
+            cc.write_route_deployed(
+                url=f"http://127.0.0.1:{srv.server_address[1]}", token="tok", scope="sc")
+        finally:
+            srv.shutdown(); srv.server_close()
+        assert seen.get("user-agent") == "subsystem-store-client/1"
+        assert seen.get("authorization") == "Bearer tok"
 
     def test_the_probe_body_CANNOT_be_written_by_the_real_server(self, srv, tmp_path):
         """🔴 THE SAFETY CLAIM, EXERCISED AGAINST THE REAL VALIDATOR rather than
@@ -692,14 +895,116 @@ class TestTheScriptRefusesRatherThanProceeds:
         assert {p: p.stat().st_mode for p in root.rglob("*.md")} == before
         assert not (tmp_path / "run" / "delta").exists()
 
-    def test_UNFREEZE_is_a_real_rollback_and_is_DRY_RUN_by_default(self, cc, tmp_path):
-        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+    def test_MAIN_propagates_the_PROBES_OWN_code_not_a_blanket_no_write_route(
+        self, cc, tmp_path, monkeypatch
+    ):
+        """🔴 THE WIRING, NOT THE PROBE. `write_route_deployed` returns its own rc
+        and the unit tests above pin it — but `main` used to discard that and
+        answer every falsy result with `RC_NO_WRITE_ROUTE`, so an UNREACHABLE pod
+        during P0 told the operator "the running image is read-only" and sent
+        them to redeploy the store over a network blip. A sweep proved the unit
+        tests blind to it: replacing `probe_rc or …` with the constant SURVIVED.
+
+        So this drives `main` far enough to reach the probe, with a REAL dead
+        port behind it, and asserts the code that comes out.
+        """
+        store = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        run_dir = tmp_path / "run"
+        _tree(run_dir / "cache", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+
+        import socket as _socket
+
+        with _socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            dead = sock.getsockname()[1]
+
+        monkeypatch.setattr(cc, "backup_precondition",
+                            lambda **_kw: (True, "backup OK — stubbed"))
+        # The only `run` on the path to the probe is `cairn sync`; the cache is
+        # pre-populated above, so a no-op success is faithful.
+        monkeypatch.setattr(cc, "run", lambda *_a, **_kw: cc.Ran(0, "live", ""))
+        monkeypatch.setattr(cc, "_config", lambda: (f"http://127.0.0.1:{dead}", "tok"))
+
+        rc = cc.main(["--store", str(store), "--run-dir", str(run_dir)])
+        assert rc == cc.RC_COULD_NOT_MEASURE, (
+            f"an unreachable pod during P0 exited {rc}; RC_NO_WRITE_ROUTE (12) "
+            f"would send the operator to redeploy the store."
+        )
+
+    def test_UNFREEZE_RESTORES_the_recorded_modes_and_never_WIDENS_one(
+        self, cc, tmp_path
+    ):
+        """🔴 A ROLLBACK RESTORES; IT DOES NOT NORMALISE.
+
+        `--unfreeze` used to `chmod 0644` every entry unconditionally and call
+        itself the rollback of the freeze. For a file that was **0600** — a
+        plausible mode on a client-confidential entry, and the mode this effort's
+        own staging file uses — that is a permission WIDENING on exactly the
+        content the widening matters for, performed by the recovery path. So the
+        freeze now records the modes first and the restore reads them back.
+
+        The fixture makes the two behaviours distinguishable ON PURPOSE: one
+        entry at 0600 and one at 0644. A restore that normalises passes a
+        same-mode fixture and fails this one.
+        """
+        root = _tree(tmp_path / "s", {
+            "sc/private.md": _entry("sc", "private", "- 2026-01-01: x."),
+            "sc/ordinary.md": _entry("sc", "ordinary", "- 2026-01-01: y."),
+        })
+        (root / "sc" / "private.md").chmod(0o600)
+        (root / "sc" / "ordinary.md").chmod(0o644)
+        ledger = tmp_path / "run" / cc.MODE_LEDGER
+        assert cc.save_modes(root, ledger) == 2
+        assert ledger.stat().st_mode & 0o777 == 0o600, "the ledger itself is 0600"
+
         cc.set_entry_mode(root, 0o444)
-        assert cc.survey(root)["refused"] == 1
-        assert cc.main(["--store", str(root), "--unfreeze"]) == cc.RC_OK
-        assert cc.survey(root)["refused"] == 1, "a dry run changed the mode bits"
-        assert cc.main(["--store", str(root), "--unfreeze", "--apply"]) == cc.RC_OK
-        assert cc.survey(root)["writable"] == 1
+        assert cc.survey(root)["refused"] == 2
+
+        args = ["--store", str(root), "--unfreeze", "--mode-ledger", str(ledger)]
+        assert cc.main(args) == cc.RC_OK
+        assert cc.survey(root)["refused"] == 2, "a dry run changed the mode bits"
+
+        assert cc.main([*args, "--apply"]) == cc.RC_OK
+        assert cc.survey(root)["writable"] == 2
+        assert (root / "sc" / "private.md").stat().st_mode & 0o777 == 0o600, (
+            "the rollback WIDENED a 0600 entry — that is the defect it replaces"
+        )
+        assert (root / "sc" / "ordinary.md").stat().st_mode & 0o777 == 0o644
+
+    def test_UNFREEZE_with_NO_LEDGER_refuses_rather_than_inventing_a_mode(
+        self, cc, tmp_path
+    ):
+        """The other half: with nothing to restore TO, guessing 0644 is the very
+        widening above. Refusing is the only honest answer."""
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        (root / "sc" / "a.md").chmod(0o600)
+        cc.set_entry_mode(root, 0o444)
+        rc = cc.main([
+            "--store", str(root), "--unfreeze", "--apply",
+            "--mode-ledger", str(tmp_path / "nope" / cc.MODE_LEDGER),
+        ])
+        assert rc == cc.RC_COULD_NOT_MEASURE
+        assert cc.survey(root)["refused"] == 1, "it changed modes anyway"
+
+    def test_an_entry_created_AFTER_the_freeze_is_LEFT_ALONE_not_guessed_at(
+        self, cc, tmp_path
+    ):
+        """Scope directories stay writable, so a new entry CAN appear between the
+        freeze and the unfreeze. It has no recorded mode; inventing one is the
+        defect. It is counted, reported, and untouched."""
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        ledger = tmp_path / "run" / cc.MODE_LEDGER
+        cc.save_modes(root, ledger)
+        cc.set_entry_mode(root, 0o444)
+        newcomer = root / "sc" / "later.md"
+        newcomer.write_text(_entry("sc", "later", "- 2026-01-02: z."))
+        newcomer.chmod(0o640)
+        rc = cc.main([
+            "--store", str(root), "--unfreeze", "--apply", "--mode-ledger", str(ledger),
+        ])
+        assert rc == cc.RC_COULD_NOT_MEASURE
+        assert newcomer.stat().st_mode & 0o777 == 0o640
+        assert (root / "sc" / "a.md").stat().st_mode & 0o777 == 0o644
 
     def test_FREEZE_alone_is_dry_run_by_default_then_takes_and_is_idempotent(
         self, cc, tmp_path

--- a/scripts/tests/test_cairn_cutover.py
+++ b/scripts/tests/test_cairn_cutover.py
@@ -636,6 +636,63 @@ class TestRefCollisions:
         }
         assert cc.ref_collisions(union) == []
 
+    def test_the_QUALIFIED_ref_branch_is_REACHED__a_bare_lookup_would_invent_one(
+        self, cc
+    ):
+        """🔴 THE CASE THAT MAKES THE KIND-QUALIFIED LOOKUP OBSERVABLE.
+
+        A mutation sweep scored `if rkind is not None:` -> `if False:` as
+        SURVIVED: with only two entries, collapsing every ref to the bare
+        `slug == ref` lookup happened to return the same COUNTS, so no assertion
+        moved. A branch whose removal changes nothing is not covered, however
+        many tests mention it.
+
+        Three entries make the two lookups disagree. Under the correct rule
+        `a.process` is kind-qualified — slug `a`, kind `process` — and matches
+        exactly `a.process.md`. Under a bare lookup it matches every entry whose
+        SLUG is the string `a.process`, which is both of the doubly-qualified
+        files, and reports a LIVE collision the resolver does not have. LIVE
+        blocks the cutover, so the mutant is the permanently-red-gate direction.
+        """
+        union = {
+            "sc/a.process.md": cc.EntryFacts("sc/a.process.md", "1" * 64, (), ()),
+            "sc/a.process.doc.md": cc.EntryFacts(
+                "sc/a.process.doc.md", "2" * 64, (), ()),
+            "sc/a.process.org.md": cc.EntryFacts(
+                "sc/a.process.org.md", "3" * 64, (), ()),
+        }
+        assert cc.ref_collisions(union) == [], (
+            "the kind-qualified lookup was bypassed, inventing a collision on a "
+            "ref the resolver answers unambiguously"
+        )
+
+    def test_that_THREE_entry_shape_is_unambiguous_for_the_REAL_resolver_too(self):
+        """The measurement the test above rests on, taken from the resolver."""
+        sys.path.insert(0, str(REPO / "scripts" / "lib"))
+        import subsystem_recall as rc
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _tree(root, {
+                "sc/a.process.md": _entry("sc", "a", "- 2026-01-01: x."),
+                "sc/a.process.doc.md": _entry("sc", "a.process", "- 2026-01-01: y."),
+                "sc/a.process.org.md": _entry("sc", "a.process", "- 2026-01-01: z."),
+            })
+            _store, index = rc.load_store(str(root), verb="read")
+            assert len(index.entries("sc")) == 3, (
+                f"fixture did not load: {getattr(index, 'malformed', None)}"
+            )
+            for ref, want in (
+                ("a", "a.process.md"),
+                ("a.process", "a.process.md"),
+                ("a.process.doc", "a.process.doc.md"),
+                ("a.process.org", "a.process.org.md"),
+            ):
+                entry, tier = rc.resolve_ref_tiered(ref, index, "sc")
+                assert entry is not None and entry.filename == want, (ref, entry)
+
     def test_that_NON_collision_is_also_what_the_REAL_resolver_says(self):
         """Measured against the resolver, so the claim above is its behaviour and
         not my reading of it. All three refs resolve, none ambiguously.

--- a/scripts/tests/test_cairn_cutover.py
+++ b/scripts/tests/test_cairn_cutover.py
@@ -37,6 +37,9 @@ REPO = Path(__file__).resolve().parents[2]
 CUTOVER = REPO / "scripts" / "cairn-cutover.py"
 SERVER_PY = REPO / "scripts" / "subsystem-store-api" / "server.py"
 
+sys.path.insert(0, str(REPO / "scripts"))
+from testlib import mockbin  # noqa: E402
+
 
 def _load(name: str, path: Path):
     spec = importlib.util.spec_from_loader(
@@ -234,6 +237,66 @@ class TestTheMergeRule:
         (root / "linked").symlink_to(root / "sc")
         assert sorted(cc.read_store(root)) == ["sc/a.md"]
 
+    def test_the_PLANNER_and_the_PUSHER_walk_the_SAME_population(self, cc, tmp_path):
+        """🔴 A SEAM GUARD. Two components each tested alone can still be broken
+        TOGETHER, and this is the seam nobody owns: `read_store` decides what the
+        plan covers, `seed.sh::_shippable_entries` decides what the push ships.
+        A file in one set and not the other is silent in both directions — an
+        entry planned and not shipped is reported as landed, an entry shipped and
+        not planned bypasses the whole merge rule.
+
+        `seed.sh` was itself bitten by exactly this: two walks with different
+        rules printed `remote_entries=1 staged_entries=2` one line above
+        `seed: OK`, rc 0.
+
+        So this runs the SHELL predicate — copied out of `seed.sh` by nothing, it
+        is executed from the file itself — beside the Python one over a tree
+        holding every edge case each is documented to handle, and asserts the two
+        sets are equal. It pins a RELATIONSHIP, not a component.
+        """
+        import re as _re
+        import subprocess
+
+        root = _tree(tmp_path / "store", {
+            "sc/a.md": _entry("sc", "a", "- 2026-01-01: x."),
+            "sc/b.md": _entry("sc", "b", "- 2026-01-01: y."),
+            "sc/notes.txt": "not an entry",
+            "other/c.md": _entry("other", "c", "- 2026-01-01: z."),
+            ".dot-scope/d.md": _entry("dot", "d", "- 2026-01-01: w."),
+            "sc/nested/deep.md": _entry("deep", "deep", "- 2026-01-01: v."),
+            "top-level.md": "a stray entry at depth 1",
+        })
+        (root / "linked-scope").symlink_to(root / "sc")
+        (root / "sc" / "adir.md").mkdir()      # a DIRECTORY named *.md
+
+        # The shell half, taken from `seed.sh`'s own source so a change there
+        # fails HERE rather than diverging quietly.
+        seed_src = (REPO / "scripts" / "subsystem-store-api" / "seed.sh").read_text()
+        m = _re.search(r"\(\s*cd \"\$1\" && (find \. .*?)\s*\)", seed_src)
+        assert m, "could not find _shippable_entries' find expression in seed.sh"
+        find_expr = m.group(1)
+        # 🔴 `mockbin.SH` (/bin/sh), not `bash`. The expression is plain `find`
+        # with no bashisms, and /bin/sh is the one interpreter path guaranteed to
+        # exist inside the nix build sandbox — the tier this suite is gated on
+        # and the tier that is structurally blind to nothing else here.
+        got = subprocess.run(
+            [mockbin.SH, "-c", f'cd "$1" && {find_expr}', "_", str(root)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert got.returncode == 0, got.stderr
+        shell_set = {line[2:] for line in got.stdout.splitlines() if line.startswith("./")}
+
+        python_set = set(cc.read_store(root))
+        # POSITIVE CONTROL: both must be NON-EMPTY. Two empty sets are equal, and
+        # a comparison over nothing is the reassuring zero this repo refuses.
+        assert shell_set, "the shell predicate matched nothing — it proves nothing"
+        assert python_set, "the python walk matched nothing — it proves nothing"
+        assert python_set == shell_set, (
+            f"the planner and the pusher disagree.\n"
+            f"  only the planner sees: {sorted(python_set - shell_set)}\n"
+            f"  only the pusher sees:  {sorted(shell_set - python_set)}"
+        )
+
 
 # =============================================================================
 # Ref collisions
@@ -345,17 +408,21 @@ class TestBackupPrecondition:
         🔴 A FAKE BINARY, NOT A MONKEYPATCH OF `run`. The thing under test is
         how this code reads a REAL subprocess's stdout and status; patching the
         runner would test the test's own idea of subprocess semantics.
+
+        🔴 WRITTEN THROUGH `testlib.mockbin.write_exec`, WHICH OWNS THE SHEBANG.
+        The first version wrote `#!/usr/bin/env bash` itself and was green on the
+        dev host and RED in the nix sandbox — `/usr/bin/env` does not exist
+        there, so every one of these execs failed ENOENT and the code under test
+        correctly reported COULD NOT MEASURE for the wrong reason. That is the
+        two-tier hazard exactly as `mockbin`'s own header documents it; this is
+        the seventh site to pay it and the first not to re-derive the fix.
         """
         bindir = tmp_path / "bin"
         bindir.mkdir(exist_ok=True)
-        script = bindir / "kubectl"
-        script.write_text(
-            "#!/usr/bin/env bash\n"
-            f"cat <<'EOF'\n{body}\nEOF\n"
-            f"exit {rc}\n"
-        )
-        script.chmod(0o755)
-        return bindir
+        # POSIX `sh`: a quoted heredoc plus `exit` and nothing bash-specific.
+        return mockbin.write_exec(
+            bindir / "kubectl", f"cat <<'MOCKEOF'\n{body}\nMOCKEOF\nexit {rc}\n"
+        ).parent
 
     def _with_path(self, monkeypatch, bindir: Path):
         monkeypatch.setenv("PATH", f"{bindir}{os.pathsep}{os.environ['PATH']}")

--- a/scripts/tests/test_cairn_cutover.py
+++ b/scripts/tests/test_cairn_cutover.py
@@ -1,0 +1,779 @@
+#!/usr/bin/env python3
+"""`scripts/cairn-cutover.py` — the criterion 9 cutover's refusals.
+
+🔴 WHAT THIS FILE IS GUARDING: THAT EVERY WAY OF NOT KNOWING ENDS IN A REFUSAL.
+The script's job is to move a curated, client-confidential, per-host store into a
+hosted one and then make local disk read-only. Every failure of that operation
+is silent by nature — a bullet that was overwritten, an entry that was stranded,
+a freeze that did not take. So the guards below are all of one shape: an input
+the script CANNOT resolve must stop it, and a zero it did not measure must never
+read as a clean one.
+
+The two claims that carry the most weight, and are therefore tested with
+controls rather than assertions:
+
+  * the backup precondition REFUSES on every way of not getting an answer, not
+    only on a stale answer (devrc#1132 exists because fifteen places asserted
+    this store's backup state and were wrong);
+  * the freeze's evidence is a WATCHED EACCES on a real file, and the check
+    fails when a single entry is still writable.
+"""
+
+from __future__ import annotations
+
+import http.server
+import importlib.machinery
+import importlib.util
+import json
+import os
+import sys
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CUTOVER = REPO / "scripts" / "cairn-cutover.py"
+SERVER_PY = REPO / "scripts" / "subsystem-store-api" / "server.py"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_loader(
+        name, importlib.machinery.SourceFileLoader(name, str(path))
+    )
+    module = importlib.util.module_from_spec(spec)
+    # `sys.modules[name] = module` BEFORE `exec_module` — see
+    # `test_cairn_cli._load_api` for the dataclass/`__module__` mechanism.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def cc():
+    sys.path.insert(0, str(REPO / "scripts" / "lib"))
+    return _load("cairn_cutover_under_test", CUTOVER)
+
+
+@pytest.fixture(scope="module")
+def srv():
+    sys.path.insert(0, str(REPO / "scripts" / "lib"))
+    return _load("srv_cut", SERVER_PY)
+
+
+def _entry(scope: str, service: str, *bullets: str, aliases: str | None = None) -> str:
+    head = ["---", f"service: {service}", f"scope: {scope}", "sensitivity: internal"]
+    if aliases is not None:
+        head.append(f"aliases: [{aliases}]")
+    head.append("---")
+    return "\n".join([
+        *head, "", "## What it is", f"the {service}.", "",
+        "## Pointers", f"- `{scope}: src/{service}.py`", "",
+        "## Nuance / work-history", *bullets, "",
+    ])
+
+
+def _tree(root: Path, files: dict[str, str]) -> Path:
+    for rel, text in files.items():
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text)
+    return root
+
+
+# =============================================================================
+# The merge rule
+# =============================================================================
+
+
+class TestTheMergeRule:
+    def test_an_entry_the_pod_lacks_is_a_pure_ADD(self, cc, tmp_path):
+        local = _tree(tmp_path / "l", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        pod = _tree(tmp_path / "p", {})
+        plan = cc.plan_delta(cc.read_store(local), cc.read_store(pod),
+                             store_root=local, merged_dir=None)
+        assert [i.verdict for i in plan.items] == [cc.ADD]
+
+    def test_a_byte_identical_entry_is_SAME_which_is_what_makes_a_RERUN_a_NOOP(
+        self, cc, tmp_path
+    ):
+        text = _entry("sc", "a", "- 2026-01-01: x.")
+        local = _tree(tmp_path / "l", {"sc/a.md": text})
+        pod = _tree(tmp_path / "p", {"sc/a.md": text})
+        plan = cc.plan_delta(cc.read_store(local), cc.read_store(pod),
+                             store_root=local, merged_dir=None)
+        assert [i.verdict for i in plan.items] == [cc.SAME]
+        assert plan.shippable == []
+
+    def test_a_STALE_pod_copy_is_SUPERSEDED_by_the_host_not_hand_merged(
+        self, cc, tmp_path
+    ):
+        """The commonest divergence by far, and the one that must NOT stop a run.
+
+        The pod's tree was produced FROM this host's tree, so for any entry the
+        pod did not itself change, the host's copy contains everything the pod's
+        does. Here the pod holds the pre-rewrite `OPEN:` line and the host holds
+        the `RESOLVED` one — measured on the real store as the shape of 14 of 15
+        such divergences. Refusing these would make the script demand a hand
+        merge for every ordinary edit since the last seed, i.e. a gate nobody
+        could pass.
+        """
+        local = _tree(tmp_path / "l", {"sc/a.md": _entry(
+            "sc", "a", "- 2026-02-09: RESOLVED beef1234: the lease expired early.")})
+        pod = _tree(tmp_path / "p", {"sc/a.md": _entry(
+            "sc", "a", "- 2026-02-09: OPEN: the lease expired early.")})
+        plan = cc.plan_delta(cc.read_store(local), cc.read_store(pod),
+                             store_root=local, merged_dir=None)
+        assert [i.verdict for i in plan.items] == [cc.SUPERSEDES]
+        assert "NONE is API-attributed" in plan.items[0].reason
+
+    def test_an_API_ATTRIBUTED_pod_bullet_the_host_lacks_forces_a_HAND_MERGE(
+        self, cc, tmp_path
+    ):
+        """🔴 THE DISCRIMINATOR THE WHOLE RULE TURNS ON.
+
+        A bullet carrying the `[cairn: actor/session]` trailer was written
+        THROUGH the pod, so it exists in the served copy and nowhere else. This
+        fixture differs from the SUPERSEDES one above by exactly that trailer and
+        by nothing else — same scope, same entry, same divergence, same bullet
+        count — so a mutant that stops looking for attribution flips this case
+        and only this case.
+        """
+        local = _tree(tmp_path / "l", {"sc/a.md": _entry(
+            "sc", "a", "- 2026-02-09: the lease expired early.")})
+        pod = _tree(tmp_path / "p", {"sc/a.md": _entry(
+            "sc", "a",
+            "- 2026-02-09: the lease expired early.",
+            "- 2026-02-11: the retry storm follows it [cairn: zach/sess-77]")})
+        plan = cc.plan_delta(cc.read_store(local), cc.read_store(pod),
+                             store_root=local, merged_dir=None)
+        assert [i.verdict for i in plan.items] == [cc.NEEDS_MERGE]
+        assert "exists nowhere else" in plan.items[0].reason
+
+    def test_a_HOST_vs_HOST_divergence_is_ALWAYS_a_hand_merge(self, cc, tmp_path):
+        """🔴 NO SUPERSESSION ARGUMENT EXISTS HERE, whatever the mtimes say.
+
+        Neither host's copy is a derivative of the other's — they are two
+        independent edits of one file on two unreplicated stores. Note that the
+        pod's copy carries NO attribution here, so the previous rule would have
+        said SUPERSEDES: the peer check is what makes this case land differently,
+        which is exactly the mutation that must be caught.
+        """
+        local = _tree(tmp_path / "l", {"sc/a.md": _entry(
+            "sc", "a", "- 2026-03-04: this host's account.")})
+        pod = _tree(tmp_path / "p", {"sc/a.md": _entry(
+            "sc", "a", "- 2026-03-01: the seeded copy.")})
+        peer = {"sc/a.md": cc.EntryFacts("sc/a.md", "e" * 64, (), ())}
+        plan = cc.plan_delta(cc.read_store(local), cc.read_store(pod),
+                             store_root=local, merged_dir=None, peer=peer)
+        assert [i.verdict for i in plan.items] == [cc.NEEDS_MERGE]
+        assert "neither is a derivative" in plan.items[0].reason
+
+    def test_a_HOST_vs_HOST_agreement_is_NOT_a_hand_merge(self, cc, tmp_path):
+        """The control for the rule above: the peer holding the SAME bytes must
+        not trip it, or every shared entry would demand a merge and the check
+        would be a constant `True` wearing a predicate's clothes."""
+        text = _entry("sc", "a", "- 2026-03-04: agreed.")
+        local = _tree(tmp_path / "l", {"sc/a.md": text})
+        pod = _tree(tmp_path / "p", {"sc/a.md": _entry("sc", "a", "- 2026-03-01: old.")})
+        same_sha = cc.read_store(local)["sc/a.md"].sha256
+        peer = {"sc/a.md": cc.EntryFacts("sc/a.md", same_sha, (), ())}
+        plan = cc.plan_delta(cc.read_store(local), cc.read_store(pod),
+                             store_root=local, merged_dir=None, peer=peer)
+        assert [i.verdict for i in plan.items] == [cc.SUPERSEDES]
+
+    def test_ONLY_a_hand_authored_file_clears_a_NEEDS_MERGE(self, cc, tmp_path):
+        local = _tree(tmp_path / "l", {"sc/a.md": _entry("sc", "a", "- 2026-02-09: host.")})
+        pod = _tree(tmp_path / "p", {"sc/a.md": _entry(
+            "sc", "a", "- 2026-02-09: host.",
+            "- 2026-02-11: pod-only [cairn: zach/sess-77]")})
+        merged = tmp_path / "m"
+        before = cc.plan_delta(cc.read_store(local), cc.read_store(pod),
+                               store_root=local, merged_dir=merged)
+        assert [i.verdict for i in before.items] == [cc.NEEDS_MERGE]
+        _tree(merged, {"sc/a.md": _entry(
+            "sc", "a", "- 2026-02-09: host.",
+            "- 2026-02-11: pod-only [cairn: zach/sess-77]")})
+        after = cc.plan_delta(cc.read_store(local), cc.read_store(pod),
+                              store_root=local, merged_dir=merged)
+        assert [i.verdict for i in after.items] == [cc.MERGED]
+        # The SOURCE must be the hand-authored file, not the host's copy —
+        # otherwise the resolution is accepted and then silently discarded.
+        assert after.items[0].source == merged / "sc/a.md"
+
+    def test_the_attribution_pattern_matches_what_the_SERVER_actually_renders(
+        self, cc, srv
+    ):
+        """🔴 PINNED BEHAVIOURALLY AGAINST THE WRITER, not against a copy of its
+        regex. The discriminator is only as good as its agreement with the thing
+        that produces the trailer; a second spelling of one pattern is the shape
+        that drifts silently. So the SERVER renders a bullet and this asserts the
+        cutover's pattern sees it.
+
+        The NEGATIVE half is the part that matters: an ordinary bullet with no
+        trailer must NOT match, or every divergence becomes a hand merge and the
+        script is unusable.
+        """
+        rendered = srv.render_bullet(
+            "the retry storm follows it", actor="zach", session="sess-77",
+            today="2026-02-11",
+        )
+        assert cc.ATTRIBUTION.search(rendered), rendered
+        assert not cc.ATTRIBUTION.search("- 2026-02-11: the retry storm follows it")
+
+    def test_the_walk_skips_what_seed_sh_cannot_ship(self, cc, tmp_path):
+        """Dot-scopes, symlinked scopes and non-`.md` files are outside the
+        population `seed.sh` ships. A planner walking a wider set would push
+        entries the pusher drops and then report them as landed."""
+        root = _tree(tmp_path / "l", {
+            "sc/a.md": _entry("sc", "a", "- 2026-01-01: x."),
+            ".hidden/b.md": _entry("hidden", "b", "- 2026-01-01: x."),
+            "sc/notes.txt": "not an entry",
+        })
+        (root / "linked").symlink_to(root / "sc")
+        assert sorted(cc.read_store(root)) == ["sc/a.md"]
+
+
+# =============================================================================
+# Ref collisions
+# =============================================================================
+
+
+class TestRefCollisions:
+    def test_two_entries_claiming_one_ALIAS_is_LIVE_and_BLOCKS(self, cc):
+        union = {
+            "sc/one.md": cc.EntryFacts("sc/one.md", "1" * 64, ("shared-alias",), ()),
+            "sc/two.md": cc.EntryFacts("sc/two.md", "2" * 64, ("shared-alias",), ()),
+        }
+        found = cc.ref_collisions(union)
+        assert [c.live for c in found] == [True]
+        assert found[0].claimants == ("one.md", "two.md")
+
+    def test_an_alias_SHADOWED_by_a_filename_is_LATENT_and_does_NOT_block(self, cc):
+        """🔴 MEASURED, NOT ASSUMED — and the measurement is the next test.
+
+        `resolve_ref_tiered` reaches the alias tier only when the FILENAME tier
+        returned zero hits, so an alias spelling another entry's filename can
+        never be chosen. Treating it as live would refuse a migration over a
+        defect that is already present, already harmless, and present on the
+        real store today — a permanently-red gate.
+        """
+        union = {
+            "sc/one.md": cc.EntryFacts("sc/one.md", "1" * 64, (), ()),
+            "sc/two.md": cc.EntryFacts("sc/two.md", "2" * 64, ("one",), ()),
+        }
+        found = cc.ref_collisions(union)
+        assert [c.live for c in found] == [False]
+        assert found[0].shadowed_by == ("one.md",)
+
+    def test_the_FILENAME_tier_really_does_win__measured_against_the_resolver(self):
+        """The precedence claim the LATENT class rests on, exercised on the real
+        resolver rather than restated from its docstring.
+
+        🔴 A DOCSTRING IS NOT A CODE PATH. The whole `latent` classification is
+        an argument about which tier answers first; if that is wrong, this script
+        waves through a collision that makes two entries unwritable.
+        """
+        sys.path.insert(0, str(REPO / "scripts" / "lib"))
+        import subsystem_recall as rc
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _tree(root, {
+                "sc/one.md": _entry("sc", "one", "- 2026-01-01: x."),
+                "sc/two.md": _entry("sc", "two", "- 2026-01-01: y.", aliases="one"),
+            })
+            _store, index = rc.load_store(str(root), verb="read")
+            entry, tier = rc.resolve_ref_tiered("one", index, "sc")
+        assert entry is not None and entry.filename == "one.md"
+        assert tier == "filename", (
+            "the alias tier answered first; the LATENT classification is unsafe"
+        )
+
+    def test_two_files_with_one_SLUG_is_a_FILENAME_collision(self, cc):
+        union = {
+            "sc/dup.md": cc.EntryFacts("sc/dup.md", "1" * 64, (), ()),
+            "other/dup.md": cc.EntryFacts("other/dup.md", "2" * 64, (), ()),
+        }
+        # Different SCOPES — refs resolve within a scope, so this is NOT one.
+        assert cc.ref_collisions(union) == []
+
+    def test_alias_owner_parsing_refuses_a_malformed_spec(self, cc):
+        assert cc.parse_alias_owner(["sc:the-ref=winner.md"]) == {("sc", "the-ref"): "winner.md"}
+        for bad in ["sc-the-ref=winner.md", "sc:the-ref", "sc:=winner.md", ":a=b"]:
+            with pytest.raises(ValueError):
+                cc.parse_alias_owner([bad])
+
+    def test_normalisation_is_the_RESOLVERS_not_a_second_spelling(self, cc):
+        """The rule as people describe it (`lower`, `_`->`-`) is NOT the rule as
+        it runs: the real one also folds every other non-slug character. A
+        collision check normalising differently models a reader that does not
+        exist."""
+        sys.path.insert(0, str(REPO / "scripts" / "lib"))
+        import subsystem_resolver
+
+        assert cc.normalize_ref is subsystem_resolver.normalize_ref
+        # A case the naive spelling gets wrong, so the identity above is not the
+        # only thing holding this together.
+        assert cc.normalize_ref("Foo Bar_Baz") == subsystem_resolver.normalize_ref(
+            "Foo Bar_Baz"
+        )
+        assert cc.normalize_ref("Foo Bar_Baz") != "foo bar-baz"
+
+
+# =============================================================================
+# The backup precondition
+# =============================================================================
+
+
+class TestBackupPrecondition:
+    """🔴 EVERY WAY OF NOT GETTING AN ANSWER IS A REFUSAL.
+
+    The failure this guards is specific and has happened: fifteen places in this
+    repo asserted the store's backup state and were wrong about it, in both
+    directions across its life (devrc#1132). So the gate asks the cluster, and a
+    missing field, a missing binary, a non-zero exit and an unparseable body are
+    all refusals with their own sentence — never "0 hours ago" and never a pass.
+    """
+
+    def _fake_kubectl(self, tmp_path: Path, *, body: str, rc: int = 0) -> Path:
+        """A `kubectl` on PATH that prints exactly what a test wants.
+
+        🔴 A FAKE BINARY, NOT A MONKEYPATCH OF `run`. The thing under test is
+        how this code reads a REAL subprocess's stdout and status; patching the
+        runner would test the test's own idea of subprocess semantics.
+        """
+        bindir = tmp_path / "bin"
+        bindir.mkdir(exist_ok=True)
+        script = bindir / "kubectl"
+        script.write_text(
+            "#!/usr/bin/env bash\n"
+            f"cat <<'EOF'\n{body}\nEOF\n"
+            f"exit {rc}\n"
+        )
+        script.chmod(0o755)
+        return bindir
+
+    def _with_path(self, monkeypatch, bindir: Path):
+        monkeypatch.setenv("PATH", f"{bindir}{os.pathsep}{os.environ['PATH']}")
+
+    def test_a_FRESH_successful_run_passes(self, cc, tmp_path, monkeypatch):
+        now = datetime(2026, 4, 7, 15, 0, tzinfo=timezone.utc)
+        stamp = (now - timedelta(hours=11)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        self._with_path(monkeypatch, self._fake_kubectl(
+            tmp_path, body=json.dumps({"status": {"lastSuccessfulTime": stamp}})))
+        ok, sentence = cc.backup_precondition(
+            namespace="ns", cronjob="cj", max_age_h=36.0, kubeconfig=None, now=now)
+        assert ok, sentence
+        assert "backup OK" in sentence and "11.0 h ago" in sentence
+
+    def test_a_STALE_run_refuses_and_prints_the_age_AND_the_ceiling(
+        self, cc, tmp_path, monkeypatch
+    ):
+        """🔴 THE FIXTURE OVERSHOOTS THE BOUNDARY, DELIBERATELY. 50 h against a
+        36 h ceiling is neither a multiple of the ceiling nor adjacent to it, so
+        an off-by-one or a flipped comparison cannot land on the same verdict by
+        arithmetic accident — and the boundary itself is measured separately
+        below, from both sides."""
+        now = datetime(2026, 4, 7, 15, 0, tzinfo=timezone.utc)
+        stamp = (now - timedelta(hours=50)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        self._with_path(monkeypatch, self._fake_kubectl(
+            tmp_path, body=json.dumps({"status": {"lastSuccessfulTime": stamp}})))
+        ok, sentence = cc.backup_precondition(
+            namespace="ns", cronjob="cj", max_age_h=36.0, kubeconfig=None, now=now)
+        assert not ok
+        assert "50.0 h old" in sentence and "36.0 h" in sentence
+        # The remedy is named, and it names the form that actually updates
+        # lastSuccessfulTime — a hand-rolled Job does not.
+        assert "create job --from=cronjob/cj" in sentence
+
+    @pytest.mark.parametrize("hours, expected", [(35.5, True), (36.5, False)])
+    def test_the_boundary_is_measured_from_BOTH_sides(
+        self, cc, tmp_path, monkeypatch, hours, expected
+    ):
+        """One measurement is not a general claim: a guard tested only on the
+        far side of its boundary passes with the comparison deleted."""
+        now = datetime(2026, 4, 7, 15, 0, tzinfo=timezone.utc)
+        stamp = (now - timedelta(hours=hours)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        self._with_path(monkeypatch, self._fake_kubectl(
+            tmp_path, body=json.dumps({"status": {"lastSuccessfulTime": stamp}})))
+        ok, _ = cc.backup_precondition(
+            namespace="ns", cronjob="cj", max_age_h=36.0, kubeconfig=None, now=now)
+        assert ok is expected
+
+    def test_a_CronJob_that_has_NEVER_succeeded_is_COULD_NOT_MEASURE_not_a_pass(
+        self, cc, tmp_path, monkeypatch
+    ):
+        """🔴 THE SILENT-ZERO ARM. `status.lastSuccessfulTime` is absent on a
+        CronJob that has never completed a run — and a bare `-o jsonpath` prints
+        an empty string for that AND for a mis-spelled query, which is why the
+        whole object is fetched and the key looked up here."""
+        self._with_path(monkeypatch, self._fake_kubectl(
+            tmp_path, body=json.dumps({"status": {"lastScheduleTime": "2026-04-07T03:45:00Z"}})))
+        ok, sentence = cc.backup_precondition(
+            namespace="ns", cronjob="cj", max_age_h=36.0, kubeconfig=None)
+        assert not ok
+        assert "COULD NOT MEASURE" in sentence
+        assert "never completed a run" in sentence
+
+    def test_a_MISSING_CronJob_refuses(self, cc, tmp_path, monkeypatch):
+        self._with_path(monkeypatch, self._fake_kubectl(
+            tmp_path, body='Error from server (NotFound): cronjobs "cj" not found', rc=1))
+        ok, sentence = cc.backup_precondition(
+            namespace="ns", cronjob="cj", max_age_h=36.0, kubeconfig=None)
+        assert not ok
+        assert "COULD NOT MEASURE" in sentence and "exited 1" in sentence
+
+    def test_kubectl_NOT_ON_PATH_refuses(self, cc, tmp_path, monkeypatch):
+        """An absent tool is the case a naive `rc != 0` check gets right by luck
+        and a `try/except` around a parse gets wrong. It must not pass."""
+        monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+        ok, sentence = cc.backup_precondition(
+            namespace="ns", cronjob="cj", max_age_h=36.0, kubeconfig=None)
+        assert not ok
+        assert "COULD NOT MEASURE" in sentence
+
+    def test_UNPARSEABLE_output_refuses(self, cc, tmp_path, monkeypatch):
+        self._with_path(monkeypatch, self._fake_kubectl(tmp_path, body="<html>edge</html>"))
+        ok, sentence = cc.backup_precondition(
+            namespace="ns", cronjob="cj", max_age_h=36.0, kubeconfig=None)
+        assert not ok
+        assert "did not parse" in sentence
+
+    def test_an_UNPARSEABLE_TIMESTAMP_refuses(self, cc, tmp_path, monkeypatch):
+        self._with_path(monkeypatch, self._fake_kubectl(
+            tmp_path, body=json.dumps({"status": {"lastSuccessfulTime": "yesterday"}})))
+        ok, sentence = cc.backup_precondition(
+            namespace="ns", cronjob="cj", max_age_h=36.0, kubeconfig=None)
+        assert not ok
+        assert "unparseable timestamp" in sentence
+
+
+# =============================================================================
+# The write-route probe
+# =============================================================================
+
+
+class TestWriteRouteProbe:
+    def _serve(self, code: int, status: str):
+        class H(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                self.rfile.read(int(self.headers.get("Content-Length") or 0))
+                body = b"probe\n"
+                self.send_response(code)
+                self.send_header("x-store-status", status)
+                self.send_header("content-length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_a):
+                return
+
+        srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), H)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        return srv
+
+    def test_a_400_means_the_route_IS_deployed(self, cc):
+        """🔴 THE INVERSION IS THE POINT, AND IT IS WHY THE PROBE IS SAFE. Only a
+        server that DISPATCHED the POST can validate the body and refuse it 400;
+        a read-only image never gets that far. So a refusal is the pass, and no
+        input capable of being written is ever sent."""
+        srv = self._serve(400, "bad-request")
+        try:
+            ok, sentence = cc.write_route_deployed(
+                url=f"http://127.0.0.1:{srv.server_address[1]}", token="t", scope="sc")
+        finally:
+            srv.shutdown(); srv.server_close()
+        assert ok, sentence
+        assert "IS deployed" in sentence
+
+    def test_a_405_is_reported_as_an_OPERATOR_problem(self, cc):
+        srv = self._serve(405, "read-only")
+        try:
+            ok, sentence = cc.write_route_deployed(
+                url=f"http://127.0.0.1:{srv.server_address[1]}", token="t", scope="sc")
+        finally:
+            srv.shutdown(); srv.server_close()
+        assert not ok
+        assert "READ-ONLY" in sentence and "operator problem" in sentence
+
+    @pytest.mark.parametrize("code, status", [(401, "unauthorized"), (403, "")])
+    def test_any_OTHER_answer_is_UNMEASURED_never_a_pass(self, cc, code, status):
+        srv = self._serve(code, status)
+        try:
+            ok, sentence = cc.write_route_deployed(
+                url=f"http://127.0.0.1:{srv.server_address[1]}", token="t", scope="sc")
+        finally:
+            srv.shutdown(); srv.server_close()
+        assert not ok
+        assert "COULD NOT MEASURE" in sentence
+
+    def test_an_UNREACHABLE_host_is_UNMEASURED(self, cc):
+        import socket as _socket
+
+        with _socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            dead = sock.getsockname()[1]
+        ok, sentence = cc.write_route_deployed(
+            url=f"http://127.0.0.1:{dead}", token="t", scope="sc")
+        assert not ok
+        assert "COULD NOT MEASURE" in sentence
+
+    def test_the_probe_body_CANNOT_be_written_by_the_real_server(self, srv, tmp_path):
+        """🔴 THE SAFETY CLAIM, EXERCISED AGAINST THE REAL VALIDATOR rather than
+        argued. `{}` must be refused by `_bullet_request_problem` — i.e. before
+        any ref is resolved, any file opened or any bullet rendered — so the
+        probe cannot write whatever ref or scope it is pointed at."""
+        assert srv._bullet_request_problem({}) is not None
+        assert srv._bullet_request_problem(json.loads("{}")) is not None
+
+
+# =============================================================================
+# The freeze
+# =============================================================================
+
+
+class TestTheFreezeIsWatchedNotAsserted:
+    def test_probe_writable_reports_by_SYSCALL_and_moves_with_the_mode(
+        self, cc, tmp_path
+    ):
+        """The positive control and the negative control of the freeze's only
+        instrument, as a pair. A prober that always said `refused` would satisfy
+        every downstream assertion in this file."""
+        path = tmp_path / "e.md"
+        path.write_text("x")
+        assert cc.probe_writable(path) == "writable"
+        path.chmod(0o444)
+        assert cc.probe_writable(path) == "refused"
+        path.chmod(0o644)
+        assert cc.probe_writable(path) == "writable"
+
+    def test_the_probe_MUTATES_NOTHING(self, cc, tmp_path):
+        """It opens a curated entry for append. If it ever wrote a byte — or
+        moved an mtime — it would be a mutation of client-confidential content
+        with a crash window, run over every entry in the store."""
+        path = tmp_path / "e.md"
+        path.write_text("- 2026-01-01: content that must not move.\n")
+        before = (path.read_bytes(), path.stat().st_mtime_ns, path.stat().st_size)
+        assert cc.probe_writable(path) == "writable"
+        after = (path.read_bytes(), path.stat().st_mtime_ns, path.stat().st_size)
+        assert before == after
+
+    def test_survey_prints_EXAMINED_beside_every_count(self, cc, tmp_path):
+        root = _tree(tmp_path / "s", {
+            "sc/a.md": _entry("sc", "a", "- 2026-01-01: x."),
+            "sc/b.md": _entry("sc", "b", "- 2026-01-01: y."),
+        })
+        assert cc.survey(root) == {"examined": 2, "writable": 2, "refused": 0, "other": 0}
+        cc.set_entry_mode(root, 0o444)
+        assert cc.survey(root) == {"examined": 2, "writable": 0, "refused": 2, "other": 0}
+
+    def test_an_EMPTY_store_reports_examined_0_rather_than_a_clean_zero(self, cc, tmp_path):
+        """🔴 THE REASSURING ZERO. `writable: 0` from a walk that visited nothing
+        is byte-identical to a fully frozen store; only `examined` separates
+        them, which is why every count is printed beside it."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert cc.survey(empty) == {"examined": 0, "writable": 0, "refused": 0, "other": 0}
+
+    def test_the_freeze_leaves_SCOPE_DIRECTORIES_writable(self, cc, tmp_path):
+        """A deliberate asymmetry with a known cost: the hosted API has no CREATE
+        route, so freezing the directories too would leave a brand-new
+        subsystem's first entry with nowhere to go at all."""
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        cc.set_entry_mode(root, 0o444)
+        assert (root / "sc").stat().st_mode & 0o200, "the scope directory was frozen too"
+        (root / "sc" / "brand-new.md").write_text("still possible")
+
+    def test_set_entry_mode_is_IDEMPOTENT(self, cc, tmp_path):
+        root = _tree(tmp_path / "s", {
+            "sc/a.md": _entry("sc", "a", "- 2026-01-01: x."),
+            "sc/b.md": _entry("sc", "b", "- 2026-01-01: y."),
+        })
+        assert cc.set_entry_mode(root, 0o444) == 2
+        assert cc.set_entry_mode(root, 0o444) == 0
+
+
+# =============================================================================
+# End to end: the refusals stop the run, and DRY RUN changes nothing
+# =============================================================================
+
+
+class TestTheScriptRefusesRatherThanProceeds:
+    def test_an_EMPTY_local_store_refuses_before_anything_else(self, cc, tmp_path):
+        """A cutover that pushed an empty delta and then froze an empty store
+        would report success having done nothing — and would then be believed."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        rc = cc.main(["--store", str(empty)])
+        assert rc == cc.RC_NO_STORE
+
+    def test_a_FAILED_backup_check_stops_before_the_store_is_even_read(
+        self, cc, tmp_path, monkeypatch
+    ):
+        """🔴 ORDER MATTERS, NOT JUST OUTCOME. The backup gate must run before any
+        network call and before any mode bit moves, so a run that cannot prove a
+        backup exists has not touched anything at all."""
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        monkeypatch.setenv("PATH", str(tmp_path / "no-bin"))
+        before = {p: p.stat().st_mode for p in root.rglob("*.md")}
+        rc = cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run")])
+        assert rc == cc.RC_BACKUP
+        assert {p: p.stat().st_mode for p in root.rglob("*.md")} == before
+        assert not (tmp_path / "run" / "delta").exists()
+
+    def test_UNFREEZE_is_a_real_rollback_and_is_DRY_RUN_by_default(self, cc, tmp_path):
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        cc.set_entry_mode(root, 0o444)
+        assert cc.survey(root)["refused"] == 1
+        assert cc.main(["--store", str(root), "--unfreeze"]) == cc.RC_OK
+        assert cc.survey(root)["refused"] == 1, "a dry run changed the mode bits"
+        assert cc.main(["--store", str(root), "--unfreeze", "--apply"]) == cc.RC_OK
+        assert cc.survey(root)["writable"] == 1
+
+    def test_FREEZE_alone_is_dry_run_by_default_then_takes_and_is_idempotent(
+        self, cc, tmp_path
+    ):
+        root = _tree(tmp_path / "s", {
+            "sc/a.md": _entry("sc", "a", "- 2026-01-01: x."),
+            "sc/b.md": _entry("sc", "b", "- 2026-01-01: y."),
+        })
+        assert cc.main(["--store", str(root), "--freeze"]) == cc.RC_OK
+        assert cc.survey(root)["writable"] == 2, "a dry run froze the store"
+        assert cc.main(["--store", str(root), "--freeze", "--apply"]) == cc.RC_OK
+        assert cc.survey(root) == {"examined": 2, "writable": 0, "refused": 2, "other": 0}
+        # The idempotent re-run: already frozen, still exit 0, nothing changed.
+        assert cc.main(["--store", str(root), "--freeze", "--apply"]) == cc.RC_OK
+        assert cc.survey(root)["refused"] == 2
+
+    def test_a_FREEZE_over_an_empty_store_is_COULD_NOT_MEASURE_not_success(
+        self, cc, tmp_path
+    ):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert cc.main(["--store", str(empty), "--freeze", "--apply"]) == cc.RC_COULD_NOT_MEASURE
+
+    def test_a_PARTIAL_freeze_FAILS_and_the_mode_bits_are_ROLLED_BACK(
+        self, cc, tmp_path, monkeypatch
+    ):
+        """🔴 THE ONLY TEST THAT REACHES THE VERIFICATION ITSELF.
+
+        Every other freeze test exercises a chmod that WORKS, so the check
+        `refused == examined` is satisfied by the happy path and its removal
+        changes nothing — a mutation sweep scored exactly that, which is why this
+        test exists. Reaching it needs a freeze that is applied and does not take,
+        so `set_entry_mode` is replaced by one that freezes all but one file. That
+        is not a contrived state: an ACL, an overlay mount, a file owned by
+        another user or a `chmod` that raced a writer all produce it, and the
+        consequence is a store that LOOKS frozen while one entry still accepts a
+        write that will die at the next seed.
+
+        Two assertions, and the second is the point: the specific exit code
+        (RC_FREEZE_INEFFECTIVE, not merely non-zero), and that the mode bits were
+        RESTORED rather than left half-applied.
+        """
+        root = _tree(tmp_path / "s", {
+            "sc/a.md": _entry("sc", "a", "- 2026-01-01: x."),
+            "sc/b.md": _entry("sc", "b", "- 2026-01-01: y."),
+            "sc/c.md": _entry("sc", "c", "- 2026-01-01: z."),
+        })
+        real = cc.set_entry_mode
+
+        def leaky(store, mode):
+            if mode != 0o444:
+                return real(store, mode)
+            changed = 0
+            for rel in sorted(cc.read_store(store))[1:]:   # skips exactly one
+                (store / rel).chmod(mode)
+                changed += 1
+            return changed
+
+        monkeypatch.setattr(cc, "set_entry_mode", leaky)
+        rc = cc.main(["--store", str(root), "--freeze", "--apply"])
+        assert rc == cc.RC_FREEZE_INEFFECTIVE, rc
+        after = cc.survey(root)
+        assert after == {"examined": 3, "writable": 3, "refused": 0, "other": 0}, (
+            f"the failed freeze was left half-applied: {after}. A store that looks "
+            f"frozen and is not is worse than one that plainly is not."
+        )
+
+    def test_ROLLBACK_PUSH_over_an_empty_pre_push_dir_refuses(self, cc, tmp_path):
+        """A rollback that restores nothing must not report success — that is the
+        reassuring zero wearing a remediation's clothes."""
+        run_dir = tmp_path / "run"
+        (run_dir / "pre-push").mkdir(parents=True)
+        assert cc.main(["--rollback-push", str(run_dir)]) == cc.RC_USAGE
+        assert cc.main(["--rollback-push", str(tmp_path / "nope")]) == cc.RC_USAGE
+
+    def test_the_MANIFEST_carries_no_bullet_text(self, cc, tmp_path, capsys):
+        """The peer manifest crosses machines. It answers "does the other host
+        hold this, and is it the same bytes?", which a sha256 answers — so
+        shipping the prose would move client-confidential content over a channel
+        that does not need it, for no gain."""
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry(
+            "sc", "a", "- 2026-01-01: a distinctive sentence nobody else writes.")})
+        assert cc.main(["--store", str(root), "--manifest"]) == cc.RC_OK
+        out = capsys.readouterr().out
+        assert "a distinctive sentence nobody else writes" not in out
+        payload = json.loads(out)
+        assert set(payload) == {"sc/a.md"}
+        assert set(payload["sc/a.md"]) == {"sha256", "aliases"}
+
+
+class TestTheDeltaTree:
+    def test_materialise_copies_ONLY_the_shippable_entries(self, cc, tmp_path):
+        text = _entry("sc", "same", "- 2026-01-01: unchanged.")
+        local = _tree(tmp_path / "l", {
+            "sc/same.md": text,
+            "sc/new.md": _entry("sc", "new", "- 2026-01-02: brand new."),
+        })
+        pod = _tree(tmp_path / "p", {"sc/same.md": text})
+        plan = cc.plan_delta(cc.read_store(local), cc.read_store(pod),
+                             store_root=local, merged_dir=None)
+        dest = tmp_path / "delta"
+        cc._materialise(plan, dest)
+        assert sorted(str(p.relative_to(dest)) for p in dest.rglob("*.md")) == ["sc/new.md"]
+
+    def test_materialise_REBUILDS_the_tree_so_a_stale_run_cannot_leak_in(
+        self, cc, tmp_path
+    ):
+        """`seed.sh` rsyncs SOURCE->STAGE with `--delete`, so anything left in
+        the delta tree from an earlier plan is pushed by a later one."""
+        dest = tmp_path / "delta"
+        _tree(dest, {"sc/left-over.md": "from an earlier run"})
+        local = _tree(tmp_path / "l", {"sc/new.md": _entry("sc", "new", "- 2026-01-02: x.")})
+        plan = cc.plan_delta(cc.read_store(local), {}, store_root=local, merged_dir=None)
+        cc._materialise(plan, dest)
+        assert not (dest / "sc" / "left-over.md").exists()
+
+    def test_save_prepush_keeps_the_SERVED_bytes_of_every_OVERWRITE_and_no_ADD(
+        self, cc, tmp_path
+    ):
+        """🔴 THIS IS PHASE 3's ROLLBACK, AND IT MUST BE TAKEN BEFORE THE PUSH.
+        An ADD has no pre-image (and the API has no delete verb, so it could not
+        be rolled back anyway); an overwrite replaces bytes that afterwards exist
+        only in the daily backup.
+
+        ⚠ WHAT THIS TEST CANNOT DISTINGUISH, said rather than left to be found:
+        the ADD is skipped because the served copy HAS NO SUCH FILE, which is the
+        same fact the verdict `ADD` records. A sweep proved the two inseparable —
+        the redundant verdict check was deleted for that reason — so this pins
+        the OUTCOME (only overwrites are saved) and makes no claim about which
+        expression produced it.
+        """
+        local = _tree(tmp_path / "l", {
+            "sc/changed.md": _entry("sc", "changed", "- 2026-02-09: the host's newer line."),
+            "sc/added.md": _entry("sc", "added", "- 2026-02-10: brand new."),
+        })
+        pod = _tree(tmp_path / "p", {
+            "sc/changed.md": _entry("sc", "changed", "- 2026-02-01: the served copy.")})
+        plan = cc.plan_delta(cc.read_store(local), cc.read_store(pod),
+                             store_root=local, merged_dir=None)
+        dest = tmp_path / "pre-push"
+        cc._save_prepush(plan, pod, dest)
+        saved = sorted(str(p.relative_to(dest)) for p in dest.rglob("*.md"))
+        assert saved == ["sc/changed.md"]
+        assert "the served copy" in (dest / "sc" / "changed.md").read_text()

--- a/scripts/tests/test_cairn_cutover.py
+++ b/scripts/tests/test_cairn_cutover.py
@@ -59,6 +59,26 @@ def cc():
     return _load("cairn_cutover_under_test", CUTOVER)
 
 
+@pytest.fixture(autouse=True)
+def _never_touch_the_operators_run_root(cc, tmp_path, monkeypatch):
+    """🔴 NO TEST MAY WRITE INTO THE REAL `~/.local/share/cairn-cutover/runs`.
+
+    Measured: five tests called `main(... --freeze --apply)` with no `--run-dir`,
+    so P5 wrote a mode ledger into the OPERATOR's run root — 66 directories
+    accumulated there from test runs alone. That is not merely untidy. The
+    default `--unfreeze` picks the NEWEST ledger under that root, so after any
+    test run the operator's documented P5 rollback selected a SYNTHETIC ledger,
+    matched nothing, and left the store frozen while reporting the entries as
+    "created after the freeze". A test poisoning the recovery path of the thing
+    it tests is the worst shape available.
+
+    Every test now passes `--run-dir`; this redirects the DEFAULT too, so a
+    future test that forgets cannot reach the real one. Belt and braces on
+    purpose — the explicit flag documents intent, this makes forgetting safe.
+    """
+    monkeypatch.setattr(cc, "DEFAULT_RUN_ROOT", tmp_path / "default-run-root")
+
+
 @pytest.fixture(scope="module")
 def srv():
     sys.path.insert(0, str(REPO / "scripts" / "lib"))
@@ -108,6 +128,46 @@ class TestTheMergeRule:
                              store_root=local, merged_dir=None)
         assert [i.verdict for i in plan.items] == [cc.SAME]
         assert plan.shippable == []
+
+    @pytest.mark.parametrize(
+        "pod_body, why",
+        [
+            # 🔴 THE CASE THE FIRST FIX INVERTED. A PURE APPEND: the host added a
+            # bullet, so the pod's lines are a strict SUBSET. `pod_only` (pod
+            # bullets minus local) is EMPTY here — which the first version read
+            # as "the difference is outside the bullet region" and refused. It is
+            # the safest divergence there is, and it is what the append-only
+            # protocol emits every single time, so refusing it made the gate
+            # permanently red on the commonest input.
+            ("- 2026-02-09: the first bullet.", "a pure append"),
+            # Cosmetic-only differences must not block either.
+            ("- 2026-02-09: the first bullet.\n", "a trailing newline"),
+            ("- 2026-02-09: the first bullet.\r", "a CRLF line ending"),
+        ],
+    )
+    def test_a_divergence_the_HOST_STRICTLY_CONTAINS_is_SUPERSEDED(
+        self, cc, tmp_path, pod_body, why
+    ):
+        """The strongest arm of rule 3, and the one that must never refuse.
+
+        When every line of the served copy is also in the host's copy, nothing on
+        the pod can be lost by pushing — a supersession that is PROVEN, not
+        argued. The reason text must say that, not the old sentence about the
+        difference lying outside the bullet region, which for an append is false.
+        """
+        local = _tree(tmp_path / "l", {"sc/a.md": _entry(
+            "sc", "a",
+            "- 2026-02-10: a bullet only this host has.",
+            "- 2026-02-09: the first bullet.")})
+        pod_dir = tmp_path / "p"
+        (pod_dir / "sc").mkdir(parents=True)
+        (pod_dir / "sc" / "a.md").write_text(_entry("sc", "a", pod_body))
+        plan = cc.plan_delta(cc.read_store(local), cc.read_store(pod_dir),
+                             store_root=local, merged_dir=None)
+        assert [i.verdict for i in plan.items] == [cc.SUPERSEDES], (
+            f"{why} was refused: {plan.items[0].reason}"
+        )
+        assert "contains EVERY line" in plan.items[0].reason
 
     def test_a_STALE_pod_copy_is_SUPERSEDED_by_the_host_not_hand_merged(
         self, cc, tmp_path
@@ -231,7 +291,7 @@ class TestTheMergeRule:
         assert plan.items[0].source == merged / "sc/only-on-hosts.md"
         assert "RESOLVED copy" in plan.items[0].source.read_text()
 
-    def test_a_divergence_with_NO_pod_only_bullets_is_UNRECOGNISED_not_superseded(
+    def test_a_PROSE_ONLY_divergence_is_SUPERSEDED_with_a_NON_VACUOUS_reason(
         self, cc, tmp_path
     ):
         """🔴 THE VACUOUS JUSTIFICATION. The bytes differ and the bullet lists do
@@ -270,10 +330,58 @@ class TestTheMergeRule:
         ])})
         plan = cc.plan_delta(cc.read_store(local), cc.read_store(pod),
                              store_root=local, merged_dir=None)
-        assert [i.verdict for i in plan.items] == [cc.NEEDS_MERGE], (
+        assert [i.verdict for i in plan.items] == [cc.SUPERSEDES], (
             f"classified {plan.items[0].verdict} with reason: {plan.items[0].reason}"
         )
-        assert "outside the region" in plan.items[0].reason
+        # 🔴 THE VERDICT IS SUPERSEDES AND THE REASON MUST NOT BE VACUOUS. That
+        # was the whole finding: the old sentence read "the served copy holds 0
+        # bullet line(s) this host lacks and NONE is API-attributed" — a scan
+        # that examined nothing, printed as the justification for overwriting.
+        # A version that REFUSED here was then tried and reverted: measured on
+        # the real trees it turned 1 hand-merge into 10, because a wrapped
+        # bullet's continuation lines are non-bullet lines.
+        assert "1 line(s) this host lacks" in plan.items[0].reason
+        assert "seed-time snapshot" in plan.items[0].reason
+
+    def test_a_STALE_hand_merge_over_an_IDENTICAL_entry_is_IGNORED_and_ANNOUNCED(
+        self, cc, tmp_path
+    ):
+        """🔴 THE DEFECT THE PREVIOUS FIX INTRODUCED, one clause over.
+
+        Hoisting `--merged` above `ADD` was right — an operator's resolution for
+        a host-only entry was being discarded. But `--merged` defaults to a
+        PERSISTENT directory, so a resolution left over from an earlier round
+        then preempted `SAME` as well, pushing stale bytes over a copy the pod
+        and this host already agreed on byte for byte. It was reported only as a
+        bare count in the verdict line, and `comm -23` compares names, so nothing
+        downstream could catch it.
+
+        An override now wins wherever a decision is needed, and is ANNOUNCED as
+        stale where nothing is in dispute.
+        """
+        text = _entry("sc", "a", "- 2026-01-01: agreed by both.")
+        local = _tree(tmp_path / "l", {"sc/a.md": text})
+        pod = _tree(tmp_path / "p", {"sc/a.md": text})
+        merged = _tree(tmp_path / "m", {"sc/a.md": _entry(
+            "sc", "a", "- 2025-12-01: a resolution from an earlier round.")})
+        plan = cc.plan_delta(cc.read_store(local), cc.read_store(pod),
+                             store_root=local, merged_dir=merged)
+        assert [i.verdict for i in plan.items] == [cc.SAME], (
+            f"a stale override pushed over an identical entry: {plan.items[0].reason}"
+        )
+        assert "STALE" in plan.items[0].reason
+        assert plan.shippable == []
+
+    def test_an_override_STILL_wins_where_a_decision_IS_needed(self, cc, tmp_path):
+        """The control for the rule above — without it, "ignore stale overrides"
+        could be implemented as "ignore overrides", which silently re-opens the
+        defect the hoist was made to fix."""
+        local = _tree(tmp_path / "l", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: host.")})
+        pod = _tree(tmp_path / "p", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: pod prose.")})
+        merged = _tree(tmp_path / "m", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: merged.")})
+        plan = cc.plan_delta(cc.read_store(local), cc.read_store(pod),
+                             store_root=local, merged_dir=merged)
+        assert [i.verdict for i in plan.items] == [cc.MERGED]
 
     def test_ONLY_a_hand_authored_file_clears_a_NEEDS_MERGE(self, cc, tmp_path):
         local = _tree(tmp_path / "l", {"sc/a.md": _entry("sc", "a", "- 2026-02-09: host.")})
@@ -507,6 +615,67 @@ class TestRefCollisions:
             # assertion above from being "any ref in this scope raises".
             entry, tier = rc.resolve_ref_tiered("svc.process", index, "sc")
             assert entry is not None and tier == "filename"
+
+    def test_TWO_kind_qualified_siblings_do_NOT_collide__no_FALSE_positive(self, cc):
+        """🔴 THE FALSE POSITIVE THE PREVIOUS FIX INTRODUCED.
+
+        Registering a bare slug for EVERY entry plus a `slug.kind` key flattened
+        two namespaces the resolver keys differently. Measured: `svc.process.md`
+        (slug `svc`, kind `process`) beside `svc.process.doc.md` (slug
+        `svc.process`, kind `doc`) both landed under the key `svc.process` and
+        were reported LIVE — while the resolver answers `svc.process`
+        unambiguously. A LIVE collision BLOCKS the cutover, so this is the
+        permanently-red-gate direction the fix's own comment names.
+
+        The checker now asks tier 1 directly instead of approximating it.
+        """
+        union = {
+            "sc/svc.process.md": cc.EntryFacts("sc/svc.process.md", "1" * 64, (), ()),
+            "sc/svc.process.doc.md": cc.EntryFacts(
+                "sc/svc.process.doc.md", "2" * 64, (), ()),
+        }
+        assert cc.ref_collisions(union) == []
+
+    def test_that_NON_collision_is_also_what_the_REAL_resolver_says(self):
+        """Measured against the resolver, so the claim above is its behaviour and
+        not my reading of it. All three refs resolve, none ambiguously.
+
+        ⚠ THE FIXTURE'S `service:` VALUES ARE LOAD-BEARING AND COST A ROUND TRIP.
+        Written with `service: svc` on both files, the second is MALFORMED —
+        *"filename 'svc.process.doc.md' has slug 'svc.process' but `service:`
+        normalizes to 'svc' — the two must agree or a ref reaches the wrong
+        file"* — so the loader drops it and the test proved nothing about two
+        loaded siblings. A malformed entry cannot be a claimant at all, which is
+        a *narrower* fixture than the one the collision check needs to be right
+        about. It is spelled correctly here so both files genuinely load.
+        """
+        sys.path.insert(0, str(REPO / "scripts" / "lib"))
+        import subsystem_recall as rc
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _tree(root, {
+                "sc/svc.process.md": _entry("sc", "svc", "- 2026-01-01: x."),
+                "sc/svc.process.doc.md": _entry(
+                    "sc", "svc.process", "- 2026-01-01: y."),
+            })
+            _store, index = rc.load_store(str(root), verb="read")
+            # POSITIVE CONTROL: both files must have LOADED. Without this the
+            # three lookups below can all pass over a one-entry index, which is
+            # exactly how the first version of this test passed nothing.
+            assert sorted(e.filename for e in index.entries("sc")) == [
+                "svc.process.doc.md", "svc.process.md"
+            ], f"malformed: {getattr(index, 'malformed', None)}"
+            for ref, want in (
+                ("svc", "svc.process.md"),
+                ("svc.process", "svc.process.md"),
+                ("svc.process.doc", "svc.process.doc.md"),
+            ):
+                entry, tier = rc.resolve_ref_tiered(ref, index, "sc")
+                assert entry is not None and entry.filename == want, (ref, entry)
+                assert tier == "filename"
 
     def test_a_NON_KIND_dotted_stem_is_NOT_split__no_FALSE_collision(self, cc):
         """The other direction, and the permanently-red-gate one.
@@ -986,6 +1155,69 @@ class TestTheScriptRefusesRatherThanProceeds:
         assert rc == cc.RC_COULD_NOT_MEASURE
         assert cc.survey(root)["refused"] == 1, "it changed modes anyway"
 
+    @pytest.mark.parametrize(
+        "payload, needle",
+        [
+            ("{ not json", "does not parse"),
+            ("", "does not parse"),
+            ("[]", "not an object"),
+            ('{"store": "/nowhere", "modes": {}}', "was taken against"),
+            ('{"modes": {"sc/a.md": 420}}', "no `modes` object"),   # no store field
+            ('{"store": "%STORE%", "modes": {"sc/a.md": "0600"}}', "is not a mode"),
+            ('{"store": "%STORE%", "modes": {"sc/a.md": true}}', "is not a mode"),
+            ('{"store": "%STORE%", "modes": []}', "no `modes` object"),
+        ],
+    )
+    def test_an_UNUSABLE_ledger_is_a_NAMED_REFUSAL_not_a_traceback(
+        self, cc, tmp_path, payload, needle
+    ):
+        """🔴 THE GUARD CHECKED `is_file()` AND PRINTED "no readable mode ledger".
+
+        Existence is not readability, and the gap was not theoretical: truncated
+        JSON, an empty file, a string mode and a top-level list each died on an
+        UNCAUGHT exception at exit 1 — on the RECOVERY path, where the operator
+        is least able to interpret a bare traceback. That is verbatim the
+        condition the guard's own comment claimed to have closed, one step over.
+
+        The `store` arm is the other half: a ledger records which store it came
+        from, because `--unfreeze` picks the newest one under a SHARED root and
+        rel paths collide readily between stores.
+        """
+        root = _tree(tmp_path / "s", {"sc/a.md": _entry("sc", "a", "- 2026-01-01: x.")})
+        (root / "sc" / "a.md").chmod(0o600)
+        cc.set_entry_mode(root, 0o444)
+        ledger = tmp_path / "run" / cc.MODE_LEDGER
+        ledger.parent.mkdir(parents=True, exist_ok=True)
+        ledger.write_text(payload.replace("%STORE%", str(root.resolve())))
+        rc = cc.main([
+            "--store", str(root), "--unfreeze", "--apply", "--mode-ledger", str(ledger),
+        ])
+        assert rc == cc.RC_COULD_NOT_MEASURE, rc
+        # The store must be untouched — a refusal that half-applied would be worse
+        # than the traceback it replaces.
+        assert (root / "sc" / "a.md").stat().st_mode & 0o777 == 0o444
+
+    def test_a_ledger_from_ANOTHER_STORE_is_refused_even_when_the_paths_line_up(
+        self, cc, tmp_path
+    ):
+        """The reason the ledger names its store. Two stores with the SAME rel
+        paths — the common case, since every store uses `<scope>/<entry>.md` —
+        and the modes recorded in one must not be applied to the other."""
+        a = _tree(tmp_path / "a", {"sc/x.md": _entry("sc", "x", "- 2026-01-01: a.")})
+        b = _tree(tmp_path / "b", {"sc/x.md": _entry("sc", "x", "- 2026-01-01: b.")})
+        (a / "sc" / "x.md").chmod(0o600)
+        (b / "sc" / "x.md").chmod(0o640)
+        ledger = tmp_path / "run" / cc.MODE_LEDGER
+        cc.save_modes(a, ledger)
+        cc.set_entry_mode(b, 0o444)
+        rc = cc.main([
+            "--store", str(b), "--unfreeze", "--apply", "--mode-ledger", str(ledger),
+        ])
+        assert rc == cc.RC_COULD_NOT_MEASURE
+        assert (b / "sc" / "x.md").stat().st_mode & 0o777 == 0o444, (
+            "store B was restored to store A's recorded modes"
+        )
+
     def test_an_entry_created_AFTER_the_freeze_is_LEFT_ALONE_not_guessed_at(
         self, cc, tmp_path
     ):
@@ -1013,12 +1245,12 @@ class TestTheScriptRefusesRatherThanProceeds:
             "sc/a.md": _entry("sc", "a", "- 2026-01-01: x."),
             "sc/b.md": _entry("sc", "b", "- 2026-01-01: y."),
         })
-        assert cc.main(["--store", str(root), "--freeze"]) == cc.RC_OK
+        assert cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run"), "--freeze"]) == cc.RC_OK
         assert cc.survey(root)["writable"] == 2, "a dry run froze the store"
-        assert cc.main(["--store", str(root), "--freeze", "--apply"]) == cc.RC_OK
+        assert cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run"), "--freeze", "--apply"]) == cc.RC_OK
         assert cc.survey(root) == {"examined": 2, "writable": 0, "refused": 2, "other": 0}
         # The idempotent re-run: already frozen, still exit 0, nothing changed.
-        assert cc.main(["--store", str(root), "--freeze", "--apply"]) == cc.RC_OK
+        assert cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run"), "--freeze", "--apply"]) == cc.RC_OK
         assert cc.survey(root)["refused"] == 2
 
     def test_a_FREEZE_over_an_empty_store_is_COULD_NOT_MEASURE_not_success(
@@ -1026,7 +1258,7 @@ class TestTheScriptRefusesRatherThanProceeds:
     ):
         empty = tmp_path / "empty"
         empty.mkdir()
-        assert cc.main(["--store", str(empty), "--freeze", "--apply"]) == cc.RC_COULD_NOT_MEASURE
+        assert cc.main(["--store", str(empty), "--run-dir", str(tmp_path / "run"), "--freeze", "--apply"]) == cc.RC_COULD_NOT_MEASURE
 
     def test_a_PARTIAL_freeze_FAILS_and_the_mode_bits_are_ROLLED_BACK(
         self, cc, tmp_path, monkeypatch
@@ -1064,7 +1296,7 @@ class TestTheScriptRefusesRatherThanProceeds:
             return changed
 
         monkeypatch.setattr(cc, "set_entry_mode", leaky)
-        rc = cc.main(["--store", str(root), "--freeze", "--apply"])
+        rc = cc.main(["--store", str(root), "--run-dir", str(tmp_path / "run"), "--freeze", "--apply"])
         assert rc == cc.RC_FREEZE_INEFFECTIVE, rc
         after = cc.survey(root)
         assert after == {"examined": 3, "writable": 3, "refused": 0, "other": 0}, (

--- a/scripts/tests/test_cairn_write.py
+++ b/scripts/tests/test_cairn_write.py
@@ -88,6 +88,17 @@ def store(tmp_path: Path) -> Path:
     (root / "widget-cfg" / "thing-beta.md").write_text(
         _entry("thing-beta", "widget-cfg", "- 2026-01-03: the sidecar drops its lease.")
     )
+    # 🔴 A SECOND SCOPE THAT EXISTS ON DISK AND IS **NOT** IN THE TOKEN'S
+    # ALLOWLIST, AND IT IS LOAD-BEARING. The indistinguishability test below
+    # claims to exercise a REFUSED scope beside an ABSENT one; without this
+    # directory both of its "refused" cases were merely absent, so they took the
+    # same branch whether or not `visible_scopes` filtering existed at all —
+    # a sameness that held with the guard deleted. `hidden-scope` is refused by
+    # the ALLOWLIST here, which is the case that was never being reached.
+    (root / "hidden-scope").mkdir(parents=True)
+    (root / "hidden-scope" / "secret-thing.md").write_text(
+        _entry("secret-thing", "hidden-scope", "- 2026-01-04: not yours to see.")
+    )
     return root
 
 
@@ -404,12 +415,28 @@ class TestRefusalsAreDistinguishable:
         different causes, one identical observable. It fails if a future client
         (or server) starts leaking WHICH cause it was — which is what a naive
         "surface the audit status to the user" change would do.
+
+        🔴 THE THIRD CASE ONLY BECAME REAL WHEN THE FIXTURE GREW A `hidden-scope`
+        DIRECTORY. Before that it named a scope that simply did not exist, so all
+        three inputs took the same "absent" branch and the assertion held whether
+        or not `visible_scopes` filtering existed — a sameness that survives
+        deleting the guard it claims to pin. `hidden-scope` is now ON DISK and
+        excluded by the token's allowlist, which is the case the property is
+        about, and its ENTRY is named so the ref would resolve if the scope were
+        visible.
         """
+        # POSITIVE CONTROL ON THE FIXTURE ITSELF: the refused scope must actually
+        # be THERE. If this file is ever removed, the third case silently becomes
+        # a fourth copy of the second and the test goes back to proving nothing.
+        assert (live.store / "hidden-scope" / "secret-thing.md").is_file(), (
+            "the allowlist-refused case is not on disk, so it is merely ABSENT — "
+            "the sameness below would hold with `visible_scopes` deleted"
+        )
         outs = []
         for scope, ref in (
             ("widget-cfg", "no-such-entry-here"),   # ref that resolves to nothing
             ("scope-that-never-existed", "thing-alpha"),
-            ("hidden-scope", "thing-alpha"),        # outside the allowlist
+            ("hidden-scope", "secret-thing"),       # EXISTS on disk, allowlist-refused
         ):
             proc = run_cairn(
                 "append", "--scope", scope, "--ref", ref, "--text", "x",
@@ -462,6 +489,58 @@ class TestRefusalsAreDistinguishable:
         assert "read-only" in proc.stderr
         assert "REFUSED" in proc.stderr
 
+    @pytest.mark.parametrize(
+        "code, status, want",
+        [
+            # 🔴 THE MAPPING'S SEMANTICS, NOT ITS MEMBERSHIP. The table test
+            # asserts every status server.py can emit is PRESENT in
+            # `_WRITE_STATUS_EXITS`; it is blind to a row pointing at the wrong
+            # code. A sweep proved it: `500: EXIT_WRITE_REFUSED` SURVIVED a green
+            # suite. These drive the real client against a real socket.
+            (500, "internal-error", 7),   # `_backstop` — retry IS the remedy
+            (503, "store-unreachable", 7),
+            (429, "rate-limited", 7),
+            (422, "entry-shape", 6),      # the entry has no nuance heading
+            (400, "bad-request", 6),
+            (404, "not-found", 6),
+        ],
+    )
+    def test_each_status_maps_to_the_code_whose_REMEDY_is_right(
+        self, tmp_path, code, status, want
+    ):
+        """6 means "change your request"; 7 means "try again". A 500 answered as
+        6 tells the caller to change a byte-identical request that would very
+        likely have succeeded — and a 400 answered as 7 invites an infinite
+        retry of a bullet that can never be accepted."""
+        class Fixed(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                self.rfile.read(int(self.headers.get("Content-Length") or 0))
+                body = b"fixed\n"
+                self.send_response(code)
+                self.send_header("x-store-status", status)
+                self.send_header("content-length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_a):
+                return
+
+        srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Fixed)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        try:
+            proc = run_cairn(
+                "append", "--scope", "widget-cfg", "--ref", "thing-alpha",
+                "--text", "x", "--session", SESSION,
+                url=f"http://127.0.0.1:{srv.server_address[1]}", cache=tmp_path / "c",
+            )
+        finally:
+            srv.shutdown(); srv.server_close()
+        assert proc.returncode == want, (
+            f"HTTP {code} [{status}] exited {proc.returncode}, wanted {want}. "
+            f"6 and 7 carry opposite remedies."
+        )
+        assert status in proc.stderr
+
     def test_a_412_gets_its_OWN_code_so_a_blind_retry_is_not_the_remedy(self, tmp_path):
         """A precondition failure is neither "fix your request" nor "retry"."""
         class Stale(http.server.BaseHTTPRequestHandler):
@@ -512,20 +591,56 @@ class TestPutReplacesBehindAPrecondition:
         on_disk = (live.store / "widget-cfg" / "thing-beta.md").read_text()
         assert "RESOLVED abc1234" in on_disk
 
-    def test_put_REFUSES_to_derive_a_revision_it_could_not_refresh(self, live, tmp_path):
-        """A precondition from bytes we could not confirm is the one case where
-        the cache is worse than nothing: it turns the operator's edit into a
-        guaranteed 412 while looking like a normal run."""
+    @pytest.mark.parametrize("prime_the_cache", [True, False])
+    def test_put_REFUSES_at_7_whether_or_not_a_CACHE_EXISTS(
+        self, live, tmp_path, prime_the_cache
+    ):
+        """🔴 BOTH SIDES OF THE CACHE, AND THE SECOND ONE IS WHERE THE BUG WAS.
+
+        This test used to prime the cache and assert `returncode != 0`. Both
+        halves were wrong, and together they hid a real defect for a whole audit
+        round: `!= 0` cannot see WHICH code, and priming the cache exercised only
+        the branch that already returned 7.
+
+        With NO cache — the FIRST run on a fresh host, the commonest way to reach
+        this path — `resolve_state` hands back `EXIT_UNREACHABLE_NO_CACHE` (3),
+        and the code returned that `hint` verbatim. So a WRITE returned the READ
+        verdict "store-unreachable, no cache", which this whole file exists to
+        make impossible, while four comments and the design doc said it could not
+        happen. Measured before the fix: no cache -> 3, cache -> 7.
+
+        The file's own rule is "pin a CODE and a SENTENCE, not merely non-zero" —
+        stated at the top and broken here. Both are pinned now, on both sides.
+        """
         cache = tmp_path / "c"
-        assert run_cairn("sync", url=live.base, cache=cache).returncode == 0
+        if prime_the_cache:
+            assert run_cairn("sync", url=live.base, cache=cache).returncode == 0
         replacement = tmp_path / "r.md"
         replacement.write_text(_entry("thing-beta", "widget-cfg", "- 2026-01-03: x."))
         proc = run_cairn(
             "put", "--scope", "widget-cfg", "--ref", "thing-beta",
             "--file", str(replacement), url=None, cache=cache,
         )
-        assert proc.returncode != 0
+        assert proc.returncode == 7, (
+            f"cache={prime_the_cache}: a write returned {proc.returncode}; 3 is the "
+            f"READ code for 'nothing was displayed' and must never answer a write"
+        )
         assert "refusing to PUT" in proc.stderr
+        assert "Nothing was queued" in proc.stderr
+
+    def test_put_with_a_MISSING_file_refuses_BEFORE_it_spends_a_sync(
+        self, live, tmp_path
+    ):
+        """Exit 1 with a traceback is in neither table, and it arrived after a
+        full snapshot download — for the commonest typo this verb has."""
+        proc = run_cairn(
+            "put", "--scope", "widget-cfg", "--ref", "thing-beta",
+            "--file", str(tmp_path / "does-not-exist.md"),
+            url=live.base, cache=tmp_path / "c",
+        )
+        assert proc.returncode == 2, (proc.returncode, proc.stderr)
+        assert "cannot read --file" in proc.stderr
+        assert "Traceback" not in proc.stderr
 
 
 class TestTheRequestItself:
@@ -548,6 +663,63 @@ class TestTheRequestItself:
         for req in writes:
             assert req["headers"].get("user-agent") == "subsystem-store-client/1"
             assert req["headers"].get("authorization", "").startswith("Bearer ")
+
+    def test_no_request_builder_ANYWHERE_bypasses_this_helper(self):
+        """🔴 THE STRUCTURAL GUARD `_apply_standard_headers`' DOCSTRING NAMES.
+
+        That docstring used to name a test called
+        `test_every_request_builder_sets_the_UA`. It did not exist — anywhere.
+        The only real check was the behavioural one below, which watches the
+        APPEND path, so a new read verb building its own `Request` was unguarded
+        by the very sentence claiming to guard it. That is the
+        "reading as coverage while providing none" shape, and it is worse than
+        no claim because it stops anyone looking.
+
+        So: an AST walk over both files, finding every function that constructs a
+        `urllib.request.Request`, and asserting each also calls
+        `_apply_standard_headers`. A missing User-Agent is 403'd by the edge, and
+        that 403 arrives looking like a bad token AND like the store being down.
+        """
+        import ast as _ast
+
+        offenders = []
+        checked = 0
+        for path in (CAIRN_CLI, REPO / "scripts" / "cairn-cutover.py"):
+            tree = _ast.parse(path.read_text())
+            for node in _ast.walk(tree):
+                if not isinstance(node, (_ast.FunctionDef, _ast.AsyncFunctionDef)):
+                    continue
+                calls = [
+                    n for n in _ast.walk(node)
+                    if isinstance(n, _ast.Call)
+                ]
+                builds = any(
+                    isinstance(c.func, _ast.Attribute) and c.func.attr == "Request"
+                    for c in calls
+                )
+                if not builds:
+                    continue
+                checked += 1
+                applies = any(
+                    (isinstance(c.func, _ast.Attribute)
+                     and c.func.attr == "_apply_standard_headers")
+                    or (isinstance(c.func, _ast.Name)
+                        and c.func.id == "_apply_standard_headers")
+                    for c in calls
+                )
+                if not applies:
+                    offenders.append(f"{path.name}::{node.name}")
+        # POSITIVE CONTROL: the scan must have FOUND request builders. A zero
+        # here is a scan wired to nothing, and it would pass forever.
+        assert checked >= 3, (
+            f"the AST scan found only {checked} request builder(s) — it is not "
+            f"looking at what it claims to look at"
+        )
+        assert not offenders, (
+            f"these build a urllib Request without going through "
+            f"`_apply_standard_headers`: {offenders}. urllib's default User-Agent "
+            f"is 403'd by the edge in front of this host."
+        )
 
     def test_the_body_carries_text_and_session_and_NO_actor(self, live, tmp_path):
         live.handler.seen.clear()
@@ -599,16 +771,32 @@ class TestExitCodesDoNotOverlap:
         production as a zero exit over a write that never landed."""
         table = _write_status_table()
         server_src = SERVER_PY.read_text()
-        # The statuses the two write handlers respond with, read off the source
-        # rather than restated: `self._respond(<code>,` inside the write half.
-        write_half = server_src.split("def _append_bullet", 1)[1]
         import re as _re
-        emitted = {int(m) for m in _re.findall(r"self\._respond\(\s*(\d{3})", write_half)}
-        emitted.discard(200)
+
+        # 🔴 THE WHOLE SERVER, NOT TWO METHOD BODIES. This used to split at
+        # `def _append_bullet` and regex the remainder, which yields ONLY
+        # `_append_bullet` and `_replace_entry` — emitting {400,412,422,428,503},
+        # all five already mapped. So it was green while the statuses that
+        # actually reach a write caller from OTHER layers were invisible to it:
+        # 404 (`_not_found`, defined ABOVE the split), 405 (`read-only`), 401/403
+        # (auth), and 500 (`_backstop`) — and 500 was genuinely unmapped, falling
+        # through to "change your request" for a condition whose remedy is a
+        # retry. A scan whose docstring says "on a write route" must not be
+        # bounded by where one method happens to sit in the file.
+        emitted = {int(m) for m in _re.findall(r"self\._respond\(\s*(\d{3})", server_src)}
+        emitted |= {int(m) for m in _re.findall(r"self\.send_response\(\s*(\d{3})", server_src)}
+        emitted -= {200, 204, 206, 304}   # successes and a conditional-GET code
+        # POSITIVE CONTROL: the scan must see the statuses this PR learned about
+        # the hard way. A regex that matched nothing would pass vacuously.
+        for known in (404, 405, 500):
+            assert known in emitted, (
+                f"the status scan did not see {known}, which server.py demonstrably "
+                f"emits — the pattern is wrong, not the table"
+            )
         missing = sorted(emitted - set(table))
         assert not missing, (
-            f"server.py's write handlers can answer {missing}, which "
-            f"`_WRITE_STATUS_EXITS` does not map. An unmapped code falls through "
-            f"to 'unrecognised', which is loud — but a deliberate status deserves "
-            f"a deliberate exit code."
+            f"server.py can answer {missing} on a route this client writes to, and "
+            f"`_WRITE_STATUS_EXITS` does not map them. An unmapped code falls "
+            f"through to 'unrecognised' => EXIT_WRITE_REFUSED, which tells the "
+            f"caller to change a request that may only need retrying."
         )

--- a/scripts/tests/test_cairn_write.py
+++ b/scripts/tests/test_cairn_write.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3
+"""`cairn append` / `cairn put` — the write verbs criterion 9 routes through.
+
+🔴 WHAT THIS FILE IS ACTUALLY GUARDING: THAT A FAILED WRITE IS DISTINGUISHABLE
+FROM A SUCCESSFUL ONE, AND FROM A STALE READ. The read half of this CLI is built
+to degrade — an unreachable pod is served from cache at exit 0, because a stale
+answer beats no answer. The write half must do the exact opposite: there is no
+cache to write into, no spool, and no such thing as a stale write, so an
+unreachable pod is a refusal at a distinct non-zero code. If those two behaviours
+ever converge, a caller reads "the store was unreachable, here is the cache" as
+"your bullet landed" and the record is silently lost — which is the precise
+failure the whole cutover exists to close, arriving through the tool built to
+close it.
+
+Every test here therefore pins a CODE and a SENTENCE, not merely "non-zero".
+"""
+
+from __future__ import annotations
+
+import http.server
+import importlib.util
+import ipaddress
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+CAIRN_CLI = REPO / "scripts" / "cairn"
+SERVER_PY = REPO / "scripts" / "subsystem-store-api" / "server.py"
+GOOD_TOKEN = "w" * 20 + "R" * 20 + "t" * 8
+LOOPBACK = ipaddress.ip_network("127.0.0.1/32")
+SESSION = "test-session-01"
+
+
+def _load_api():
+    """Import `server.py` by path. `sys.modules[...]` BEFORE `exec_module`.
+
+    Without that line the first `@dataclass` in the file raises
+    `AttributeError: 'NoneType' object has no attribute '__dict__'` under
+    `from __future__ import annotations` — see `test_cairn_cli._load_api` for
+    the full mechanism. Restated as a one-liner rather than re-derived.
+    """
+    sys.path.insert(0, str(REPO / "scripts" / "lib"))
+    spec = importlib.util.spec_from_file_location("srv_w", SERVER_PY)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _entry(service: str, scope: str, *nuance: str) -> str:
+    return "\n".join([
+        "---",
+        f"service: {service}",
+        f"scope: {scope}",
+        "sensitivity: internal",
+        "---",
+        "",
+        "## What it is",
+        f"The {service} thing.",
+        "",
+        "## Pointers",
+        f"- `{scope}: src/{service}.py`",
+        "",
+        "## Nuance / work-history",
+        *nuance,
+        "",
+    ])
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Path:
+    root = tmp_path / "store"
+    (root / "widget-cfg").mkdir(parents=True)
+    (root / "widget-cfg" / "thing-alpha.md").write_text(
+        _entry("thing-alpha", "widget-cfg", "- 2026-01-02: the probe lies for 40s.")
+    )
+    (root / "widget-cfg" / "thing-beta.md").write_text(
+        _entry("thing-beta", "widget-cfg", "- 2026-01-03: the sidecar drops its lease.")
+    )
+    return root
+
+
+class _Shim(http.server.BaseHTTPRequestHandler):
+    """Forwards every verb upstream, adding the header the real edge adds.
+
+    🔴 THE SHIM EXISTS BECAUSE THE SERVER FAILS CLOSED WITHOUT `CF-Connecting-IP`
+    and the client must never send one — in production Cloudflare sets it, and a
+    client that sent its own would produce a duplicate and be refused. Teaching
+    the client to send it to make a test pass would be testing a client we must
+    not ship. It also records every forwarded request so a test can assert on the
+    headers the CLIENT sent, which is the only way to see the User-Agent.
+    """
+
+    upstream = ""
+    seen: list = []
+
+    def _proxy(self, verb: str) -> None:
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length) if length else None
+        type(self).seen.append({
+            "verb": verb,
+            "path": self.path,
+            "headers": {k.lower(): v for k, v in self.headers.items()},
+            "body": body,
+        })
+        req = urllib.request.Request(self.upstream + self.path, data=body, method=verb)
+        for key, value in self.headers.items():
+            if key.lower() not in ("host", "cf-connecting-ip", "content-length"):
+                req.add_header(key, value)
+        req.add_header("CF-Connecting-IP", "203.0.113.9")
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                out, code, headers = resp.read(), resp.status, dict(resp.headers)
+        except urllib.error.HTTPError as exc:
+            out, code, headers = exc.read(), exc.code, dict(exc.headers)
+        self.send_response(code)
+        for key, value in headers.items():
+            if key.lower() not in ("transfer-encoding", "connection", "content-length"):
+                self.send_header(key.lower(), value)
+        self.send_header("content-length", str(len(out)))
+        self.end_headers()
+        self.wfile.write(out)
+
+    def do_GET(self):  # noqa: N802
+        self._proxy("GET")
+
+    def do_POST(self):  # noqa: N802
+        self._proxy("POST")
+
+    def do_PUT(self):  # noqa: N802
+        self._proxy("PUT")
+
+    def log_message(self, *_args):  # keep pytest output readable
+        return
+
+
+@pytest.fixture
+def live(store: Path):
+    api = _load_api()
+    record = api.TokenRecord(token=GOOD_TOKEN, identity="tester", scopes=("widget-cfg",))
+    httpd = api.build_server(
+        host="127.0.0.1", port=0, store_root=str(store), tokens=(record,),
+        trusted_proxies=(LOOPBACK,), limiter=None, audit=None,
+    )
+    upstream = f"http://127.0.0.1:{httpd.server_address[1]}"
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    handler = type("S", (_Shim,), {"upstream": upstream, "seen": []})
+    shim = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    threading.Thread(target=shim.serve_forever, daemon=True).start()
+    try:
+        yield SimpleNamespace(
+            base=f"http://127.0.0.1:{shim.server_address[1]}",
+            store=store, api=api, handler=handler,
+        )
+    finally:
+        shim.shutdown()
+        shim.server_close()
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def _dead_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _cairn_ast() -> "ast.Module":
+    import ast as _ast
+
+    return _ast.parse(CAIRN_CLI.read_text())
+
+
+def _module_constants() -> dict[str, int]:
+    """Module-level `NAME = <int>` from `cairn`, read by AST.
+
+    🔴 NOT `exec`, AND NOT A REGEX. `exec`ing the file (even a prefix of it)
+    fails on `__file__`, which is absent from a synthetic namespace — measured,
+    it raised `NameError` at `Path(__file__)`. A regex over the source would
+    silently miss a re-spelling. The AST answers the question the test is
+    actually asking: what integer does this module bind to this name?
+    """
+    import ast as _ast
+
+    out: dict[str, int] = {}
+    for node in _cairn_ast().body:
+        if isinstance(node, _ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, _ast.Name) and isinstance(node.value, _ast.Constant):
+                if isinstance(node.value.value, int):
+                    out[target.id] = node.value.value
+    return out
+
+
+def _write_status_table() -> dict[int, int]:
+    """`_WRITE_STATUS_EXITS` as a real dict, read by AST for the same reason."""
+    import ast as _ast
+
+    for node in _cairn_ast().body:
+        targets = getattr(node, "targets", []) or (
+            [node.target] if isinstance(node, _ast.AnnAssign) else []
+        )
+        for target in targets:
+            if isinstance(target, _ast.Name) and target.id == "_WRITE_STATUS_EXITS":
+                return {
+                    k.value: v.id if isinstance(v, _ast.Name) else v.value
+                    for k, v in zip(node.value.keys, node.value.values)
+                }
+    raise AssertionError("`_WRITE_STATUS_EXITS` is gone from scripts/cairn")
+
+
+def run_cairn(*args: str, url: str | None, cache: Path, token: str = GOOD_TOKEN):
+    env = dict(os.environ)
+    env["SUBSYSTEM_STORE_TOKEN"] = token
+    # A path that does not exist, so the developer's real credentials can never
+    # make a test pass. A test that reads live credentials is not a test.
+    env["SUBSYSTEM_STORE_CONFIG"] = str(cache.parent / "no-such-config")
+    env["SUBSYSTEM_STORE_URL"] = url or f"http://127.0.0.1:{_dead_port()}"
+    return subprocess.run(
+        [sys.executable, str(CAIRN_CLI), "--cache", str(cache), "--timeout", "5", *args],
+        capture_output=True, text=True, env=env, timeout=120,
+    )
+
+
+# =============================================================================
+
+
+class TestAppendLands:
+    def test_a_bullet_is_appended_and_the_status_is_named(self, live, tmp_path):
+        proc = run_cairn(
+            "append", "--scope", "widget-cfg", "--ref", "thing-alpha",
+            "--text", "the lease renewal races the probe",
+            "--session", SESSION,
+            url=live.base, cache=tmp_path / "c",
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert "appended" in proc.stdout, proc.stdout
+        # 🔴 THE POSITIVE CONTROL, and it is not optional. `RULES.md` on this
+        # exact API: "reading '0 occurrences' off the response is a FALSE GREEN —
+        # nothing was written. Every write probe needs a positive control proving
+        # the bullet landed." So the assertion is on the FILE, not the exit code.
+        landed = (live.store / "widget-cfg" / "thing-alpha.md").read_text()
+        assert "the lease renewal races the probe" in landed
+        assert "[cairn: tester/" in landed, (
+            "the bullet landed without the attribution trailer the actor guarantee "
+            "is about"
+        )
+
+    def test_the_ACTOR_comes_from_the_token_and_the_body_cannot_set_it(self, live, tmp_path):
+        """A forged `actor` must not reach the file — and this CLI has no flag for it.
+
+        Two independent claims, both needed: the server discards a body `actor`
+        (its guarantee), and this client offers no way to send one (ours). The
+        second is what stops a caller believing they control attribution.
+        """
+        proc = run_cairn(
+            "append", "--scope", "widget-cfg", "--ref", "thing-alpha",
+            "--text", "attribution comes from the credential",
+            "--session", SESSION, url=live.base, cache=tmp_path / "c",
+        )
+        assert proc.returncode == 0, proc.stderr
+        landed = (live.store / "widget-cfg" / "thing-alpha.md").read_text()
+        assert "[cairn: tester/" in landed
+        help_text = subprocess.run(
+            [sys.executable, str(CAIRN_CLI), "append", "--help"],
+            capture_output=True, text=True, timeout=60,
+        ).stdout
+        assert "--actor" not in help_text
+
+    def test_a_REPEAT_of_the_same_text_reports_duplicate_not_appended(self, live, tmp_path):
+        """Idempotence is what makes a retry after a timeout safe — and it must SAY so.
+
+        The server recognises a bullet by content hash. A client that printed
+        `appended` either way would make a re-POST look like a second record;
+        one that printed nothing would let a caller believe a genuinely new
+        bullet landed when the store had recognised and dropped it.
+        """
+        args = ("append", "--scope", "widget-cfg", "--ref", "thing-beta",
+                "--text", "the same observation twice", "--session", SESSION)
+        first = run_cairn(*args, url=live.base, cache=tmp_path / "c")
+        second = run_cairn(*args, url=live.base, cache=tmp_path / "c")
+        assert first.returncode == 0 and second.returncode == 0
+        assert "appended" in first.stdout and "duplicate" not in first.stdout
+        assert "duplicate" in second.stdout
+        body = (live.store / "widget-cfg" / "thing-beta.md").read_text()
+        assert body.count("the same observation twice") == 1
+
+    def test_an_ALIAS_resolves_as_well_as_a_filename(self, live, tmp_path):
+        (live.store / "widget-cfg" / "thing-gamma.md").write_text("\n".join([
+            "---", "service: thing-gamma", "scope: widget-cfg",
+            "sensitivity: internal", "aliases: [gamma-box]", "---", "",
+            "## What it is", "g", "", "## Pointers", "- `widget-cfg: g.py`", "",
+            "## Nuance / work-history", "- 2026-01-04: g.", "",
+        ]))
+        proc = run_cairn(
+            "append", "--scope", "widget-cfg", "--ref", "gamma-box",
+            "--text", "reached through the alias tier", "--session", SESSION,
+            url=live.base, cache=tmp_path / "c",
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert "reached through the alias tier" in (
+            live.store / "widget-cfg" / "thing-gamma.md"
+        ).read_text()
+
+
+class TestAWriteNeverDegrades:
+    def test_an_unreachable_store_REFUSES_at_7_and_says_nothing_was_queued(self, tmp_path):
+        """🔴 THE CENTRAL CONTRACT. Not exit 0, not exit 3, and the message says why.
+
+        Exit 3 is the READ verdict "store-unreachable, no cache" — a statement
+        about what was displayed. Reusing it here would let a caller read
+        "nothing was shown" as "the bullet landed", because on the read path 3 is
+        routinely accompanied by a served cache and a zero.
+        """
+        proc = run_cairn(
+            "append", "--scope", "widget-cfg", "--ref", "thing-alpha",
+            "--text", "this must not be queued", "--session", SESSION,
+            url=None, cache=tmp_path / "c",
+        )
+        assert proc.returncode == 7, (proc.returncode, proc.stderr)
+        assert "did NOT happen" in proc.stderr
+        assert "Nothing was queued" in proc.stderr
+
+    def test_an_unreachable_store_writes_NOTHING_to_the_cache(self, tmp_path):
+        """A spool would be invisible and would look exactly like success later."""
+        cache = tmp_path / "c"
+        cache.mkdir()
+        before = sorted(p.name for p in cache.rglob("*"))
+        run_cairn(
+            "append", "--scope", "widget-cfg", "--ref", "thing-alpha",
+            "--text", "no spool", "--session", SESSION, url=None, cache=cache,
+        )
+        assert sorted(p.name for p in cache.rglob("*")) == before
+
+    def test_a_READ_still_degrades_to_the_cache_while_the_write_refuses(self, live, tmp_path):
+        """The asymmetry itself, measured at both points rather than asserted.
+
+        🔴 A ONE-SIDED TEST WOULD NOT SEE THIS. Asserting only that the write
+        refuses is consistent with a client where BOTH halves refuse, which would
+        break `/resume` offline — the thing the design promises keeps working.
+        So the same cache is exercised for a read (must serve, exit 0) and a
+        write (must refuse, exit 7) against the same dead host.
+        """
+        cache = tmp_path / "c"
+        primed = run_cairn("sync", url=live.base, cache=cache)
+        assert primed.returncode == 0, primed.stderr
+        read = run_cairn("recall", "--scope", "widget-cfg", url=None, cache=cache)
+        assert read.returncode == 0, read.stderr
+        assert "SERVED FROM CACHE" in read.stdout
+        write = run_cairn(
+            "append", "--scope", "widget-cfg", "--ref", "thing-alpha",
+            "--text", "still refused", "--session", SESSION, url=None, cache=cache,
+        )
+        assert write.returncode == 7, write.stderr
+
+
+class TestRefusalsAreDistinguishable:
+    @pytest.mark.parametrize(
+        "args, code, needle",
+        [
+            # A multi-line bullet would either be attached to this bullet as a
+            # continuation or start a second, UNATTRIBUTED one.
+            (("--ref", "thing-alpha", "--text", "line one\nline two"), 6, "ONE line"),
+            # A leading `- ` would start a bullet the server did not render, so
+            # the attribution trailer would be on the wrong one.
+            (("--ref", "thing-alpha", "--text", "- already a bullet"), 6, "markdown bullet"),
+            # An empty bullet: refused before anything is resolved.
+            (("--ref", "thing-alpha", "--text", "   "), 6, "non-empty string"),
+        ],
+    )
+    def test_each_refusal_carries_its_own_code_and_the_servers_own_sentence(
+        self, live, tmp_path, args, code, needle
+    ):
+        base = ["append", "--session", SESSION, "--scope", "widget-cfg"]
+        proc = run_cairn(*base, *args, url=live.base, cache=tmp_path / "c")
+        assert proc.returncode == code, (proc.returncode, proc.stdout, proc.stderr)
+        assert needle in proc.stderr, proc.stderr
+
+    def test_a_REFUSED_scope_and_an_ABSENT_one_are_INDISTINGUISHABLE_to_the_client(
+        self, live, tmp_path
+    ):
+        """🔴 THIS ASSERTS A SAMENESS, AND THE SAMENESS IS THE SECURITY PROPERTY.
+
+        `server._not_found` answers the SAME bytes and the SAME
+        `X-Store-Status: not-found` for a scope outside the credential's
+        allowlist, a scope that never existed, a ref that resolves to nothing,
+        and an entry the loader could not parse — criterion 3's enumeration
+        property applied to the write verbs. A client that reported them
+        differently would rebuild the enumeration API the server took apart, out
+        of information the server deliberately withheld.
+
+        So the test is written the way the property is: three inputs from three
+        different causes, one identical observable. It fails if a future client
+        (or server) starts leaking WHICH cause it was — which is what a naive
+        "surface the audit status to the user" change would do.
+        """
+        outs = []
+        for scope, ref in (
+            ("widget-cfg", "no-such-entry-here"),   # ref that resolves to nothing
+            ("scope-that-never-existed", "thing-alpha"),
+            ("hidden-scope", "thing-alpha"),        # outside the allowlist
+        ):
+            proc = run_cairn(
+                "append", "--scope", scope, "--ref", ref, "--text", "x",
+                "--session", SESSION, url=live.base, cache=tmp_path / "c",
+            )
+            assert proc.returncode == 6, (scope, ref, proc.returncode, proc.stderr)
+            outs.append(proc.stderr)
+        assert "not-found" in outs[0]
+        assert len(set(outs)) == 1, (
+            f"the three causes produced {len(set(outs))} different messages; the "
+            f"server answers all of them identically and the client must not "
+            f"re-derive the difference: {outs}"
+        )
+
+    def test_a_READ_ONLY_image_is_reported_as_an_OPERATOR_problem_not_a_caller_one(
+        self, tmp_path
+    ):
+        """405 `read-only` is what a pod with no write path answers.
+
+        🔴 THIS IS THE ONE THAT READS LIKE A WRONG URL. Phase 3's own retraction
+        turned on it: `POST`/`PUT` both answered `405 read-only` on the deployed
+        image while `main` had the write path, and the doc concluded the writes
+        were "403 on the live pod". The client must print the server's
+        `X-Store-Status` so the difference is on screen.
+        """
+        class ReadOnly(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802
+                body = b"method not allowed: this store is read-only\n"
+                self.send_response(405)
+                self.send_header("x-store-status", "read-only")
+                self.send_header("content-length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_a):
+                return
+
+        srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), ReadOnly)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        try:
+            proc = run_cairn(
+                "append", "--scope", "widget-cfg", "--ref", "thing-alpha",
+                "--text", "x", "--session", SESSION,
+                url=f"http://127.0.0.1:{srv.server_address[1]}", cache=tmp_path / "c",
+            )
+        finally:
+            srv.shutdown()
+            srv.server_close()
+        assert proc.returncode == 6, (proc.returncode, proc.stderr)
+        assert "read-only" in proc.stderr
+        assert "REFUSED" in proc.stderr
+
+    def test_a_412_gets_its_OWN_code_so_a_blind_retry_is_not_the_remedy(self, tmp_path):
+        """A precondition failure is neither "fix your request" nor "retry"."""
+        class Stale(http.server.BaseHTTPRequestHandler):
+            def do_PUT(self):  # noqa: N802
+                self.rfile.read(int(self.headers.get("Content-Length") or 0))
+                body = b"precondition failed: the entry has revision deadbeefdeadbeef\n"
+                self.send_response(412)
+                self.send_header("x-store-status", "revision-mismatch")
+                self.send_header("content-length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_a):
+                return
+
+        target = tmp_path / "new.md"
+        target.write_text("---\nservice: x\nscope: widget-cfg\n---\n")
+        srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Stale)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        try:
+            proc = run_cairn(
+                "put", "--scope", "widget-cfg", "--ref", "thing-alpha",
+                "--file", str(target), "--if-match", "0123456789abcdef",
+                url=f"http://127.0.0.1:{srv.server_address[1]}", cache=tmp_path / "c",
+            )
+        finally:
+            srv.shutdown()
+            srv.server_close()
+        assert proc.returncode == 8, (proc.returncode, proc.stderr)
+        assert "revision-mismatch" in proc.stderr
+
+
+class TestPutReplacesBehindAPrecondition:
+    def test_put_derives_the_revision_from_a_LIVE_sync_and_the_replace_lands(
+        self, live, tmp_path
+    ):
+        replacement = tmp_path / "replacement.md"
+        replacement.write_text(_entry(
+            "thing-beta", "widget-cfg",
+            "- 2026-01-03: RESOLVED abc1234: the sidecar drops its lease.",
+        ))
+        proc = run_cairn(
+            "put", "--scope", "widget-cfg", "--ref", "thing-beta",
+            "--file", str(replacement), url=live.base, cache=tmp_path / "c",
+        )
+        assert proc.returncode == 0, (proc.stdout, proc.stderr)
+        assert "derived If-Match" in proc.stderr
+        on_disk = (live.store / "widget-cfg" / "thing-beta.md").read_text()
+        assert "RESOLVED abc1234" in on_disk
+
+    def test_put_REFUSES_to_derive_a_revision_it_could_not_refresh(self, live, tmp_path):
+        """A precondition from bytes we could not confirm is the one case where
+        the cache is worse than nothing: it turns the operator's edit into a
+        guaranteed 412 while looking like a normal run."""
+        cache = tmp_path / "c"
+        assert run_cairn("sync", url=live.base, cache=cache).returncode == 0
+        replacement = tmp_path / "r.md"
+        replacement.write_text(_entry("thing-beta", "widget-cfg", "- 2026-01-03: x."))
+        proc = run_cairn(
+            "put", "--scope", "widget-cfg", "--ref", "thing-beta",
+            "--file", str(replacement), url=None, cache=cache,
+        )
+        assert proc.returncode != 0
+        assert "refusing to PUT" in proc.stderr
+
+
+class TestTheRequestItself:
+    def test_every_write_request_carries_the_User_Agent_the_edge_requires(
+        self, live, tmp_path
+    ):
+        """🔴 MEASURED IN PRODUCTION, NOT DEFENSIVE. urllib's default UA is 403'd
+        by the edge in front of this host, and the 403 arrives looking like a bad
+        token and like the store being down. The read path learned this once; the
+        write path must not have to learn it again, which is why the header lives
+        in one helper and why this test reads what the CLIENT actually sent."""
+        live.handler.seen.clear()
+        run_cairn(
+            "append", "--scope", "widget-cfg", "--ref", "thing-alpha",
+            "--text", "header check", "--session", SESSION,
+            url=live.base, cache=tmp_path / "c",
+        )
+        writes = [r for r in live.handler.seen if r["verb"] == "POST"]
+        assert writes, "no POST reached the shim"
+        for req in writes:
+            assert req["headers"].get("user-agent") == "subsystem-store-client/1"
+            assert req["headers"].get("authorization", "").startswith("Bearer ")
+
+    def test_the_body_carries_text_and_session_and_NO_actor(self, live, tmp_path):
+        live.handler.seen.clear()
+        run_cairn(
+            "append", "--scope", "widget-cfg", "--ref", "thing-alpha",
+            "--text", "body shape", "--session", SESSION,
+            url=live.base, cache=tmp_path / "c",
+        )
+        posts = [r for r in live.handler.seen if r["verb"] == "POST"]
+        payload = json.loads(posts[0]["body"])
+        assert payload == {"text": "body shape", "session": SESSION}
+
+    def test_session_is_REQUIRED_with_no_default_and_no_env_fallback(self, live, tmp_path):
+        """A default would attach a value nobody chose to a durable record, and
+        an env fallback would attribute one agent's bullet to whatever the shell
+        last exported. The server refuses a missing session with a 400; this
+        refuses it before a request is built."""
+        env_probe = subprocess.run(
+            [sys.executable, str(CAIRN_CLI), "append", "--scope", "widget-cfg",
+             "--ref", "thing-alpha", "--text", "x"],
+            capture_output=True, text=True, timeout=60,
+            env={**os.environ, "CLAUDE_SESSION_ID": "leaked-from-the-env",
+                 "CAIRN_SESSION": "also-leaked"},
+        )
+        assert env_probe.returncode == 2
+        assert "--session" in env_probe.stderr
+
+
+class TestExitCodesDoNotOverlap:
+    def test_the_write_codes_are_disjoint_from_every_read_code(self):
+        """Pinned as a SET, not as four separate assertions, because the hazard
+        is a future verb reusing a number rather than any one of them being
+        wrong today."""
+        ns = _module_constants()
+        reads = {ns["EXIT_OK"], ns["EXIT_UNREACHABLE_NO_CACHE"], ns["EXIT_USAGE"],
+                 ns["EXIT_REFRESH_FAILED"], ns["EXIT_CORRUPT"]}
+        writes = {ns["EXIT_WRITE_REFUSED"], ns["EXIT_WRITE_UNREACHABLE"],
+                  ns["EXIT_WRITE_PRECONDITION"]}
+        assert len(writes) == 3, writes
+        assert reads & writes == set(), (
+            f"a write code collides with a read code: {reads & writes}. A caller "
+            f"cannot then tell a refused write from a served-from-cache read."
+        )
+
+    def test_every_write_status_the_server_can_emit_is_MAPPED(self):
+        """🔴 AN UNMAPPED STATUS MUST NOT BECOME A PASS. The table is walked
+        against the codes `server.py` actually responds with on a write route, so
+        adding a refusal there without mapping it here fails HERE rather than in
+        production as a zero exit over a write that never landed."""
+        table = _write_status_table()
+        server_src = SERVER_PY.read_text()
+        # The statuses the two write handlers respond with, read off the source
+        # rather than restated: `self._respond(<code>,` inside the write half.
+        write_half = server_src.split("def _append_bullet", 1)[1]
+        import re as _re
+        emitted = {int(m) for m in _re.findall(r"self\._respond\(\s*(\d{3})", write_half)}
+        emitted.discard(200)
+        missing = sorted(emitted - set(table))
+        assert not missing, (
+            f"server.py's write handlers can answer {missing}, which "
+            f"`_WRITE_STATUS_EXITS` does not map. An unmapped code falls through "
+            f"to 'unrecognised', which is loud — but a deliberate status deserves "
+            f"a deliberate exit code."
+        )


### PR DESCRIPTION
## 🔴 STAGED, NOT APPLIED

Nothing here has been executed against the hosted store or either host's local store. The
cutover, the re-seed, and every write to the pod remain the operator's to run.
`scripts/cairn-cutover.py` is **dry-run by default**. The runbook — every command in order,
and what each is expected to print — is §8 of `claudedocs/plan-cairn-phase1-cutover.md`.

Builds on #1187 (the 9-before-8 ordering) and #1132 (the backup claim). Neither duplicated.

---

## What lands

**1. `cairn append` / `cairn put` — the write verbs.** The CLI only read, so criterion 9 had
nothing to route `subsystem-index` writes through. They are **write-through and do not
degrade**: an unreachable store is a *refused* write at exit 7 — never queued, never local.
Reads still serve from cache offline. The write codes (6 refused / 7 unreachable / 8
precondition) are **disjoint from every read code**, so a caller cannot read "nothing was
displayed" as "the bullet landed".

**2. `scripts/cairn-cutover.py`** — dry-run-default, idempotent, refuses rather than
proceeds. It writes **no second push path and no second byte-identity checker**: it builds a
curated delta tree and hands it to the unmodified `seed.sh`, then verifies with the
unmodified `verify-byte-identity.sh` plus the prescribed `comm -23`. `seed.sh` is
destructive because of *what it is given*, not what it does.

**3. The merge rule**, generalised past the file that motivated it — additive on one side;
a **lineage** argument (not mtime) where the pod's copy is a lagging derivative; an
unconditional refusal where two *hosts* disagree; cleared only by a human-authored file.

**4. Two hand-merged entries**, staged **outside the repo** at
`~/.local/share/cairn-cutover/merged/` (0600) because the store is client-confidential and
this repo is public. Both validate with the writer's own parser.

**5. Doc corrections** — the false "no auth exists in any form" claim (measured: no token →
401, wrong token → 401, real credential → 200), and the two crossing phase numberings, now
mapped in both documents.

## The two collision axes — a scope correction

The brief's *"exactly one filename collision"* was measured on the **host-vs-host** axis
only, and had quietly become "one merge decision in the migration". Both axes:

| axis | count | warrant |
|---|---|---|
| host vs host | 1 | entry names in both hosts' manifests whose sha256 differ |
| pod vs local | 1 | the served copy's lines absent from the host's, filtered to the attribution trailer |

The pod-vs-local count is complete **for the attributed class** by the regex — exactly 1 of
132 served entries carries a trailer at all — and empty for the unattributed class only
because no client for a whole-file write existed before this PR. **That guarantee expires
the first time anyone runs `cairn put` against the pod**, and one gap is left open and
labelled: a hand-rolled `curl` PUT is possible and I did not check the audit log for one.

## Verification

**Dev-host tier**, `nix develop … -c bash scripts/gate.sh` at `2876f724`:
`GATE: RESULT=PASS` — pytest **20181 collected / 20178 passed / 3 skipped / 0 failed**
(floor 18383), node **1449/1449** (floor 1367).

**Merge-gating tier**, both built at `2876f724` and **one at a time** (a combined red is
untrustworthy under store contention; a combined green would have been fine, but sequential
is the only run that can be believed either way):

| derivation | result |
|---|---|
| `nix build .#checks.x86_64-linux.pytests`   | **rc 0** |
| `nix build .#checks.x86_64-linux.nodetests` | **rc 0** |

Each status was read from its own redirect, never from a pipe — `cmd \| tail; echo $?`
reports *tail's* status, and this session already watched that trap print `RC=0` over a
build whose own verdict line said `RESULT: FAIL`.

**Mutation sweeps: seven rounds.** Each round's finding is in the code, because the pattern
is the norm here rather than bad luck:

- rounds 1–2 — two guards that could not be reached (one labelled, one **deleted**);
- round 3 — **the sweep's own parser** matched `0 failed for another reason` out of the
  script's stderr instead of pytest's summary, scoring a killed mutant as SURVIVED;
- round 4 — two guards pinning *membership* rather than *behaviour* (a status row could
  point at the wrong exit code; `main` could discard the probe's own rc — both invisible);
- round 6 — **a mutant that changes no observable is not a covered branch**: two fixture
  entries made both candidate lookups return the same counts, so a whole branch could be
  deleted with two tests naming it. A third entry made them disagree.

**Two adversarial audit rounds**, both acted on. Round 1 found six 🔴; round 2 audited only
the delta and found three more — **all three introduced by round 1's fixes**. My own fix for
one of them then over-corrected, and measurement caught it: the stricter rule turned 1
hand-merge into 10, because store bullets *wrap* and a rewritten bullet's continuation lines
are not bullet openers.

**Client-confidential leak check:** 46 sites reported across the repo, **zero** in any file
this branch adds or changes. Reported as the pair, never as a bare zero.

## An incident worth reading — §8.5 of the design doc

A background mutation sweep was rewriting `cairn-cutover.py` in place, and a `git add`
landed inside one of those windows: **a commit shipped the P5 empty-walk guard as
`if False:`**. No error, `git log` showed what was expected, and the tree looked right
seconds later once the sweep restored it. The suite could not catch it — the sweep restores,
so every later run is green over a red commit. Comparing the committed *blob* against the
sweep's pre-mutation backup is what found it.

Reverted; every commit on the branch scanned; exactly one was contaminated and HEAD's blob
is byte-identical to the verified backup. It would not have reached `main`'s state under
either merge method. **But the same race would have shipped the guard had it landed on the
final commit rather than an intermediate one — only the ordering prevented that, not the
mechanism.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015p8BLadvCzETwuf8o1XJU2
