### PR TITLE
fix(claim-work): a lettered sub-rank was DISCARDED, so every one of them minted the same lock (rank 13)

### DIFF
--- a/claude/skills/handoff/reference/shared-queue.md
+++ b/claude/skills/handoff/reference/shared-queue.md
@@ -230,13 +230,28 @@ The lock is inert exactly where contention is highest.
 ⚠ **Do not "fix" this by hand-writing a slug** (`claim-work tmux-webapp-8c …`).
 The slug's whole job is that both sessions derive the *same* string from the same
 doc and rank; a hand-typed one is a lock only against someone who typed it
-identically. Until the derivation is fixed, bundle the lettered items under one
-claim and say so in the subject.
+identically.
 
-**Closing condition:** `--slug-for <doc> 8c` returns a slug distinct from
-`--slug-for <doc> 8d` **and** from `--slug-for <doc> 8`, pinned by a test. The
-rank still must not swallow a following flag, so the widened pattern has to keep
-refusing anything beginning with `-`.
+### ✅ FIXED 2026-09-01 — the closing condition is met and pinned
+
+`--slug-for <doc> 8c` now returns `<doc>-8c`, distinct from `8d` and from `8`,
+and a following flag is still not swallowed. Measured before the fix on the real
+handoff doc: `8c` and `8d` **both** printed the bare `tmux-webapp`.
+
+Two things beyond the literal condition, because widening the pattern alone
+would have fixed the instance and left the class:
+
+- **An unparseable rank is now a USAGE ERROR (rc 2), not a silent drop.** The
+  hazard was never the spelling `8c` — it was a rank the caller typed and the
+  script ignored at exit 0. `8-c`, `8.1` and `part2` would each still have
+  derived the bare doc slug under a merely-wider regex.
+- **The rank is case-folded**, for the reason the base already is: `8C` and `8c`
+  are one item, and `validate_slug` is lowercase-only, so an unfolded `8C` would
+  not merely split the namespace — it would be rc 2 at claim time.
+
+Pinned by `scripts/tests/test_claim_work.py`; seven of the eight cases were
+watched RED on the pre-change `origin/main`, and the eighth is labelled in place
+as an invariant guard rather than counted as regression coverage.
 
 ## Producing side
 

--- a/claudedocs/handoff-tmux-webapp.md
+++ b/claudedocs/handoff-tmux-webapp.md
@@ -9,7 +9,7 @@ and an **attention queue** that surfaces sessions needing a human so Zach can ju
 
 ## Status
 
-**Ranks 1–8 are ✅ DONE, all sub-items included. Ranks 10–16 are OPEN.** The live-refresh work
+**Ranks 1–8, 13 and 16 are ✅ DONE. Ranks 10, 11, 12, 14, 15 are OPEN.** The live-refresh work
 (`ZacxDev/homelab-infra#611`) is DONE, merged, and **deployed as 0.8.21** — see below.
 
 🔴 **DO NOT READ A VERSION FROM THIS DOC — `clawgatectl health` is the only authority.**
@@ -216,8 +216,10 @@ re-points every live claim. A finished item stays in place marked ✅ DONE; take
 OPEN one. *History:* a 2026-08-26 renumbering superseded an earlier 1–7 list, so a slug minted
 before that date may name a different item — do not renumber again without releasing live claims.
 
-🔴 **AND THE LOCK CANNOT TELL 8a/8b/8c/8d APART — see rank 13.** `--slug-for … 8c` returns the
-BARE slug `tmux-webapp`. Prefer plain integer ranks until 13 lands.
+✅ **THE LOCK CAN NOW TELL 8a/8b/8c/8d APART — rank 13 landed 2026-09-01.**
+`--slug-for … 8c` returns `tmux-webapp-8c`, distinct from `8d` and from `8`. The old advice
+("prefer plain integer ranks") is retired. An unparseable rank is now rc 2 rather than a silent
+drop, so a typo’d rank can no longer collapse two items onto one lock in silence.
 
 1. ✅ **DONE 2026-08-27** — the idle reaper had never fired because it COULD NOT (`time.NewTicker`
    delivers its first tick one whole interval in). `ZacxDev/homelab-infra#457`, 0.8.7.
@@ -272,15 +274,17 @@ BARE slug `tmux-webapp`. Prefer plain integer ranks until 13 lands.
     unreachable**. Full detail in the `clawgate` subsystem-index entry.
     forcing: incident — a shipped, measured defect on the version live on both hosts, filed as
     task #463 by the session that found it.
-13. **`claim-work --slug-for` collapses every LETTERED sub-rank to the bare doc slug.** Repo:
-    `devrc`, `scripts/claim-work.sh:357` — `^[0-9]+$` accepts bare digits only, so `8c` fails it,
-    `SLUG_RANK` stays empty and the argument is left unshifted and ignored: **discarded, not
-    rejected** (no warning, exit 0, well-formed slug). Written up in
-    `claude/skills/handoff/reference/shared-queue.md` (devrc#1163). Closing condition:
-    `--slug-for <doc> 8c` returns a slug distinct from `8d` and from `8`, pinned by a test, while
-    still refusing anything beginning with `-`.
-    forcing: regression — the lock is the protection `/resume` step 6 runs before touching a ranked
-    item, and it does not discriminate a doc's housekeeping tier, where contention is highest.
+13. ✅ **DONE 2026-09-01.** `--slug-for` discarded a lettered sub-rank instead of rejecting it, so
+    `8c`, `8d` and every lettered sub-rank of every rank minted ONE slug — and the collision was
+    reported as **rc 12 “ALREADY YOURS, carry on”**, the one answer that means PROCEED. Measured
+    before the fix on this doc: `8c` and `8d` both printed `tmux-webapp`.
+    🔴 **The pattern was widened AND the class closed:** an unparseable rank (`8-c`, `8.1`,
+    `part2`) is now a usage error, not a silent drop, because the hazard was an ignored rank rather
+    than the spelling `8c`. The rank is also case-folded (`8C` == `8c`; `validate_slug` is
+    lowercase-only, so unfolded it was rc 2 at claim time). 7 of 8 new cases watched RED on the
+    pre-change `origin/main`; the 8th is labelled in place as an invariant guard, not counted as
+    regression coverage.
+    forcing: none
 14. **Pin the settle barrier's PRECONDITION, which nothing currently asserts.** Repo:
     `homelab-talos`, `containers/clawgate/internal/api/push_fanout_ledger_test.go`. Extend the
     ledger to AST-assert that no `notify*`/`pushTask` call appears inside a `go` statement or a
@@ -306,16 +310,19 @@ BARE slug `tmux-webapp`. Prefer plain integer ranks until 13 lands.
     capability is asserted in three places and pinned by nothing.
     forcing: regression — this is the guard's own blind spot in the file it guards, and (a) is the
     shape the guard exists to catch.
-16. **The `clawgate-ci` bats leg has NO collected-test floor** (pre-existing, not introduced by
-    #592). Repo: `homelab-talos`,
-    `clusters/homelab/apps/tekton-pipelines/triggers/clawgate-ci-pipeline.yaml:440`. Measured in
-    the CI image: `bats` on a file with zero tests prints `1..0` and **exits 0**, so a suite that
-    stops collecting reads as a pass — the same hole the pytest and node tiers already close with
-    floors. The leg's own comments at `:409-410` still say "11 tests" and "18 + 11"; the real
-    numbers are 35 + 32 = 67. Closing condition: the leg fails when either suite collects fewer
-    tests than its floor, and the floor is derived from a real run.
-    forcing: gate — a green that cannot distinguish "passed" from "collected nothing" is the
-    documented reassuring-zero class, on the tier that gates this repo's hook changes.
+16. ✅ **DONE 2026-09-01 — `ZacxDev/homelab-infra#618`, squash `b5992890`.** The `hook` leg read
+    only `bats`' exit code, and `bats` on a file with zero `@test` bodies prints `1..0` and exits
+    **0**. Each suite now runs separately against its own floor (34 / 31, from `bats --count`
+    measuring 35 / 32 in the leg's own image). Measured with the mutation verified applied:
+    pre-change `hook leg rc=0` verdict `pass`; post-change `rc=1` verdict `fail` — with `bats`
+    itself exiting 0 in BOTH, so the floor is the only thing that spoke. Floors pinned by
+    `scripts/tests/test_clawgate_ci_hook_floor.py` (extracts the script FROM the manifest;
+    6/6 mutants killed by name). The leg's stale “11 tests” / “18 + 11” comments are gone.
+    ⚠ **Deployed and verified against the DEPLOYED artifact, but no PipelineRun has run it yet** —
+    `clawgate-ci` is path-filtered on `containers/clawgate/**` and this change touched neither, so
+    nothing fired. The next PR touching that path is the end-to-end check: `step-hook` must show
+    TWO plan lines and `floor=34` / `floor=31`. A single `1..67` means the Task did not reconcile.
+    forcing: none
 
 ## Open investigations — live diagnosis state
 
@@ -851,6 +858,28 @@ auditing scaffolding it had itself written. The final comment corrections were m
 than as a round 4, because re-auditing a comment edit is the loop the gate exists to stop.
 
 ## Gotchas
+- 🔴 **A PR THAT CHANGES A TEKTON PIPELINE CANNOT BE VERIFIED BY THAT PIPELINE — its green check
+  is a statement about the OLD leg.** A PipelineRun executes the **deployed Task object in the
+  cluster**, never the manifest on the PR branch. Measured 2026-09-01 on `#618`, which rewrote
+  `clawgate-ci`'s `hook` leg: `tekton/clawgate-ci` went **green**, and reading `step-hook` of run
+  `clawgate-ci-vdcqw` (revision = that PR's own head) showed **one** plan line `1..67` and **zero**
+  `floor=` lines — i.e. the pre-change leg. The new leg would have printed two of each.
+  🔴 **This is the same MERGED ≠ LIVE shape already recorded above for #584's `MIN_PASSED`, and it
+  was walked into by a session holding that note** — because there the symptom was a stale VALUE
+  after merge, and here it is a green CHECK before merge, which reads as evidence rather than as
+  its absence. **Ask which object the run loaded, not whether the check is green.**
+  Three consequences worth knowing before the next one:
+  - **The leg that DOES run PR content is a different one.** `gitops-validate`'s `scripts-tests`
+    step executes the PR's own files, so a test shipped alongside the manifest change is really
+    gated; the manifest change itself is not.
+  - **Verify the DEPLOYED artifact directly instead of waiting.** `kubectl -n tekton-ci get task
+    <name> -o json`, pull the step's `script`, confirm it is byte-identical to what you tested,
+    and run THAT in the step's own image. No cluster write, no GitHub status, and it is evidence
+    about the thing that will actually execute.
+  - ⚠ **A merge may trigger nothing at all.** `clawgate-ci` is path-filtered on
+    `containers/clawgate/**`; #618 touched `clusters/…` and `scripts/tests/`, so no run fired and
+    none ever will for that commit. An empty commit cannot re-trigger a path-filtered pipeline
+    either (see the entry below). Re-running a prior PipelineRun from its own spec is the route.
 - 🔴 **A FAILED `git worktree add` DOES NOT STOP THE NEXT `git -C <path>` — AND I LANDED A
   MERGE ON ANOTHER SESSION'S BRANCH THIS WAY.** `worktree add /home/zach/workspace/devrc-integ`
   failed with `fatal: … already exists` (another session was using that path for

--- a/scripts/claim-work.sh
+++ b/scripts/claim-work.sh
@@ -352,10 +352,32 @@ while [ "$#" -gt 0 ]; do
       MODE=slug-for
       SLUG_DOC="${2:-}"
       shift 2 || die_usage "--slug-for needs a handoff-doc path"
-      # An optional trailing rank, only if it is a bare number — otherwise it is
-      # the next flag and must not be swallowed.
-      if [ "$#" -gt 0 ] && [[ ${1} =~ ^[0-9]+$ ]]; then
-        SLUG_RANK="$1"; shift
+      # An optional trailing rank: a bare number, or a number with a LETTERED
+      # SUB-RANK (`8`, `8c`) — the handoff convention `8a/8b/8c/8d`.
+      #
+      # 🔴 IT USED TO MATCH `^[0-9]+$` ONLY, AND EVERYTHING ELSE WAS DISCARDED
+      # RATHER THAN REJECTED — no warning, exit 0, well-formed slug. So
+      # `--slug-for <doc> 8c` printed the BARE doc slug, which means `8c`, `8d`
+      # and every other lettered sub-rank of every rank in that doc minted ONE
+      # slug. Two sessions on different sub-items then both matched it, and the
+      # second was told **rc 12 — ALREADY YOURS, carry on**: the one answer that
+      # means PROCEED, handed out for a collision. That is the exact outcome
+      # this lock exists to prevent.
+      #
+      # 🔴 SO THE FIX IS NOT ONLY TO WIDEN THE PATTERN. Anything that is not a
+      # flag and not a well-formed rank is now a USAGE ERROR, because a silently
+      # ignored rank is the hazard — `8c` was one instance of it, and `8-c` or
+      # `part2` would still have been dropped in silence.
+      # A flag must still not be swallowed (`--slug-for <doc> --strict`).
+      if [ "$#" -gt 0 ]; then
+        case "$1" in
+          -*) : ;;   # the next flag — leave it for the parser
+          *)
+            [[ ${1} =~ ^[0-9]+[A-Za-z]*$ ]] || die_usage \
+              "--slug-for rank must be a number with an optional lettered sub-rank (e.g. 8, 8c), got '$1'"
+            SLUG_RANK="$1"; shift
+            ;;
+        esac
       fi
       ;;
     --subject)
@@ -405,6 +427,11 @@ derive_slug() {
     | sed -e 's/[^a-z0-9]\{1,\}/-/g' -e 's/^-\{1,\}//' -e 's/-\{1,\}$//')"
   [ -n "$base" ] || return 1
   if [ -n "$rank" ]; then
+    # 🔴 CASE-FOLD THE RANK for the same reason the base is folded above: `8C`
+    # and `8c` are the same item, and two spellings deriving two slugs is no
+    # lock at all. `validate_slug` is lowercase-only anyway, so an unfolded
+    # `8C` would not merely split the namespace — it would be rc 2.
+    rank="$(printf '%s' "$rank" | tr '[:upper:]' '[:lower:]')"
     printf '%s-%s\n' "$base" "$rank"
   else
     printf '%s\n' "$base"

--- a/scripts/tests/test_claim_work.py
+++ b/scripts/tests/test_claim_work.py
@@ -784,6 +784,76 @@ def test_slug_for_normalises_case_and_punctuation():
     assert re.fullmatch(r"[a-z0-9][a-z0-9._-]*", slug), slug
 
 
+def test_slug_for_distinguishes_a_LETTERED_sub_rank():
+    """🔴 EVERY lettered sub-rank used to mint ONE slug, and the collision was
+    reported as rc 12 — the answer that means CARRY ON.
+
+    The parser matched `^[0-9]+$` only. `8c` failed it, so `SLUG_RANK` stayed
+    empty and the argument was left unshifted and ignored: DISCARDED, not
+    rejected — no warning, exit 0, a well-formed slug. Measured before the fix
+    on the real handoff doc: `8c` and `8d` BOTH printed `tmux-webapp`.
+
+    So two sessions working different sub-items derived one lock, and the second
+    was told `rc 12 = ALREADY YOURS, carry on`. Contention is highest exactly on
+    the housekeeping tier where lettered sub-ranks live.
+    """
+    doc = "claudedocs/handoff-x.md"
+    bare = _run("--slug-for", doc).stdout.strip()
+    eight = _run("--slug-for", doc, "8").stdout.strip()
+    c = _run("--slug-for", doc, "8c").stdout.strip()
+    d = _run("--slug-for", doc, "8d").stdout.strip()
+
+    # Pinned as LITERALS, not derived from each other: a test that only asserts
+    # "they differ" passes for a derivation that appends a counter.
+    assert (bare, eight, c, d) == ("x", "x-8", "x-8c", "x-8d"), (bare, eight, c, d)
+    assert len({bare, eight, c, d}) == 4, "two sub-ranks share one lock"
+    for slug in (eight, c, d):
+        assert re.fullmatch(r"[a-z0-9][a-z0-9._-]*", slug), slug
+
+
+def test_slug_for_FOLDS_the_rank_case_so_one_item_is_one_lock():
+    """`8C` and `8c` are the same item. The base is already case-folded for
+    exactly this reason ("two spellings, two slugs, no lock"); the rank was not.
+    Unfolded it would be worse than a split namespace — `validate_slug` is
+    lowercase-only, so `x-8C` is rc 2 at the moment you try to claim it."""
+    doc = "claudedocs/handoff-x.md"
+    assert _run("--slug-for", doc, "8C").stdout.strip() == "x-8c"
+    assert _run("--slug-for", doc, "8C").stdout.strip() == \
+        _run("--slug-for", doc, "8c").stdout.strip()
+
+
+@pytest.mark.parametrize("bad", ["8-c", "part2", "abc", "8.1", "8_c"])
+def test_slug_for_REFUSES_an_unparseable_rank_rather_than_DROPPING_it(bad):
+    """🔴 WIDENING THE PATTERN ALONE WOULD FIX THE INSTANCE AND LEAVE THE CLASS.
+
+    The hazard is a rank that is silently ignored, not the specific spelling
+    `8c`. With only a wider regex, `8-c` and `part2` still derive the bare doc
+    slug and still exit 0 — the same collision, one keystroke away. So anything
+    that is not a flag and not a well-formed rank is now a usage error.
+    """
+    r = _run("--slug-for", "claudedocs/handoff-x.md", bad)
+    assert r.returncode == RC_USAGE, (
+        f"rank {bad!r} was accepted or silently dropped: "
+        f"rc={r.returncode} out={r.stdout.strip()!r}"
+    )
+    # And it must not have printed a slug that a caller would then go and claim.
+    assert r.stdout.strip() != "x", f"printed the bare doc slug for {bad!r}"
+
+
+def test_slug_for_still_does_not_SWALLOW_a_trailing_flag():
+    """⚠ INVARIANT GUARD, NOT REGRESSION COVERAGE — it passes on the pre-change
+    script too, and is labelled so nobody counts it as evidence for the fix.
+
+    Measured: of the cases added with this fix, seven go red at the pre-change
+    `origin/main` and this one does not. It is here because the fix rewrote the
+    branch that protects it — a following flag belongs to the parser, not to the
+    rank — and refusing a bad rank must not turn `--strict` into one.
+    """
+    r = _run("--slug-for", "claudedocs/handoff-x.md", "--strict")
+    assert r.returncode == RC_OK, r.stderr
+    assert r.stdout.strip() == "x", r.stdout
+
+
 # ── a typo must be LOUD, not failed open ─────────────────────────────────────
 
 @pytest.mark.parametrize("bad", [


### PR DESCRIPTION
Rank 13 of the tmux-webapp handoff.

`--slug-for` parsed a trailing rank with `^[0-9]+$`. `8c` failed that, so `SLUG_RANK` stayed
empty and the argument was left unshifted and ignored — **discarded, not rejected**: no warning,
exit 0, a well-formed slug.

**Measured before the fix, on the real handoff doc:**

```
--slug-for <doc> 8    ->  tmux-webapp-8
--slug-for <doc> 8c   ->  tmux-webapp     ← collapsed
--slug-for <doc> 8d   ->  tmux-webapp     ← same slug
```

`8c` and `8d` — and every lettered sub-rank of every rank in that doc — resolved to **one** lock.
Two sessions on different sub-items both matched it, and the second was told
**`rc 12 = ALREADY YOURS, carry on`**: the one answer that means PROCEED, handed out for a
collision. Contention is highest exactly on the housekeeping tier where lettered sub-ranks live.

## Widening the pattern alone would fix the instance and leave the class

The hazard is *a rank the caller typed and the script ignored* — not the spelling `8c`. Under a
merely-wider regex, `8-c`, `8.1` and `part2` still derive the bare doc slug and still exit 0. So
anything that is not a flag and not a well-formed rank is now a **usage error (rc 2)**. A
following flag is still not swallowed.

The rank is also **case-folded**, for the reason the base already is (*"two spellings, two slugs,
no lock"*): `8C` == `8c`. Unfolded it was worse than a split namespace — `validate_slug` is
lowercase-only, so `x-8C` is rc 2 at claim time.

One predicate, one place: `git grep '\^\[0-9\]'` finds this site and `NET_TIMEOUT`, which is
unrelated. Nothing to consolidate.

## Evidence

**Red at base, green at HEAD.** New cases against `origin/main`'s script: **7 failed, 8 passed**.
The 8th (`…does_not_SWALLOW_a_trailing_flag`) passes on pre-change code too, so it is labelled
**in place** as an invariant guard rather than counted as regression coverage — M4 shows it is
nonetheless reachable.

**Mutation battery — 4/4 killed, each by exactly the case that exists for it:**

| mutant | killed by |
|---|---|
| M0 control (unmutated) | 15 passed, nothing red |
| M1 revert the widening | `…distinguishes_a_LETTERED_sub_rank` |
| M2 drop the refusal (restore the silent drop) | `…REFUSES_an_unparseable_rank` |
| M3 drop the rank case-fold | `…FOLDS_the_rank_case` |
| M4 swallow flags too | `…does_not_SWALLOW_a_trailing_flag` |

Script restored from a byte copy and verified by hash, not `git checkout --`.

**Gate: 798 passed** — the full `test_claim_work.py` plus the content gates (captured-text,
captured-markup, public-IPs, client-hostnames) and the doc/size gates (`handoff_doc`,
`skill_descriptions`, `skill_tiers`, `rules_size`), since this touches a skill reference and a
claudedocs file.

## Also in this PR

- **`shared-queue.md`** — the section documenting this as an open limitation now records it
  fixed. The "bundle lettered items under one claim" workaround is retired.
- **`handoff-tmux-webapp.md`** — ranks 13 and 16 marked DONE (16 shipped earlier today as
  `ZacxDev/homelab-infra#618`, squash `b5992890`, and the doc still advertised it as open), the
  status line corrected, and the stale *"prefer plain integer ranks until 13 lands"* note retired.
- **A new gotcha: a PR that changes a Tekton pipeline cannot be verified by that pipeline.** A
  PipelineRun executes the **deployed** Task, so #618's green `clawgate-ci` ran the OLD leg —
  measured on `clawgate-ci-vdcqw` at that PR's own head: one plan line `1..67`, zero `floor=`
  lines. Same MERGED ≠ LIVE shape the doc already recorded for #584, walked into by a session
  holding that note, because there it was a stale value *after* merge and here a green check
  *before* it.

⚠ Note for whoever merges: **#1026** is an open PR from 2026-08-11 that also touches
`claudedocs/handoff-tmux-webapp.md`. It is not a duplicate of this work, but it will conflict, and
it looks stale enough to be worth closing on its own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kRyYxB956h5XfpwoX2sKX
