### PR TITLE
fix(subsystem-store-api): the byte-identity verifier could not pass at all — canonicalise `host:`, and MEASURE the snapshot block

### DIFF
--- a/scripts/cairn-cutover.py
+++ b/scripts/cairn-cutover.py
@@ -1551,8 +1551,12 @@ def _acceptance(args: argparse.Namespace, cache_dir: Path) -> int:
 
     `verify-byte-identity.sh` is then run unmodified over every scope. Its own
     header documents the two controls that make its green meaningful, and its
-    PASS lines print `raw-diff-lines` and `store-root-lines` beside the verdict
-    so a reader can see the canonicalisation was spent where it claims.
+    PASS lines print `raw-diff-lines` beside the verdict, decomposed into
+    `store-root-lines` + `host-lines` + `snapshot-block-lines` and summed as
+    `accounted-for`, so a reader can see the canonicalisation was spent where it
+    claims. 🔴 THREE named differences, not one: this sentence used to name only
+    the store root, which was already false when `host:` shipped and is exactly
+    the difference that made that script permanently red.
     """
     refreshed = run(
         [sys.executable, str(CAIRN), "--cache", str(cache_dir), "sync"], timeout=120

--- a/scripts/subsystem-store-api/README.md
+++ b/scripts/subsystem-store-api/README.md
@@ -330,14 +330,45 @@ client identity. See "Rate limit, lockout and the client address" below.
 ⚠ `verify-byte-identity.sh` prints a `diff` on failure, and that diff is store
 content. Redirect it to a file on a shared terminal.
 
-## Why byte-identity is asserted "modulo one line"
+## Why byte-identity is asserted "modulo THREE named differences"
 
 `render_text` prints `  store: <root>`, and the pod's root is `/data` while the
 workbench's is `~/.claude/analyze-service-index`. The streams therefore cannot be
-byte-identical, and a verifier that said they were would be lying. The script
-canonicalises exactly that line and `cmp`s the result, and prints beside the
-verdict how many lines differ **with no canonicalisation** and how many of those
-are the store-root line — `2` and `2` for pod-vs-workbench.
+byte-identical, and a verifier that said they were would be lying.
+
+There are **three** such differences, not one, and the second is the one that
+made this script permanently red:
+
+| difference | why it is legitimate | how it is canonicalised |
+|---|---|---|
+| `  store: <root>` | the pod serves a copy at a different path | rewritten to a fixed token **on both sides** |
+| `  host: <id>` | `store_host_line()` names the machine whose disk was read — the store is PER-HOST, and saying so is the entire point of the line | rewritten to a fixed token **on both sides** |
+| the `🔴 SNAPSHOT` block | a transport annotation the server prepends and the local CLI correctly does not emit | removed from the **remote** only |
+
+🔴 **`host:` was added late and nothing stripped it**, so every comparison
+between a workbench and a pod failed by construction — `verify: scopes=16 pass=0
+fail=16` on a store whose content was identical. `claude/RULES.md`: a
+permanently-red gate is worse than no gate.
+
+🔴 **The snapshot block's LENGTH is measured, not assumed.** It used to be
+deleted by an anchored two-line rule, which is the shape *this tree's*
+`server.py` emits — but this script compares against whatever image the pod is
+running, and any other separator arrangement left a residual blank line that no
+rule claimed. The block is now the run of lines at the head of the remote stream
+that are the banner or are blank; it is stripped only if that run **contains**
+the banner, and a server that emits no banner (pre-0.3.0) has nothing removed.
+
+Beside the verdict the script prints how many lines differ **with no
+canonicalisation at all**, decomposed into the three causes and summed as
+`accounted-for` — `raw-diff-lines=7 store-root-lines=2 host-lines=2
+snapshot-block-lines=3 accounted-for=7` is a pod-vs-workbench run against an
+image whose block is three lines. Those numbers are EVIDENCE, not a second gate:
+they can only disagree if a `sed` erased a line that was none of the three,
+which the renderer cannot produce (no entry body renders at two-space
+indentation — measured across all four modes). Gating on them would be an
+unreachable guard counted as coverage. But every canonicalisation rule **must**
+appear in that sum: a rule that erases a difference without a matching count
+widens the blind spot rather than the gate.
 
 ## The token is a SET, and rotation is by overlap
 

--- a/scripts/subsystem-store-api/README.md
+++ b/scripts/subsystem-store-api/README.md
@@ -348,21 +348,29 @@ made this script permanently red:
 🔴 **`host:` was added late and nothing stripped it**, so every comparison
 between a workbench and a pod failed by construction — `verify: scopes=16 pass=0
 fail=16` on a store whose content was identical. `claude/RULES.md`: a
-permanently-red gate is worse than no gate.
+permanently-red gate is worse than no gate. **That rule alone closes it**:
+measured on scope `kubeclaw`, workbench versus the live pod, using the script's
+own expressions — `store:` + banner canonicalised gives **2** differing lines,
+adding `host:` gives **0**.
 
-🔴 **The snapshot block's LENGTH is measured, not assumed.** It used to be
-deleted by an anchored two-line rule, which is the shape *this tree's*
-`server.py` emits — but this script compares against whatever image the pod is
-running, and any other separator arrangement left a residual blank line that no
-rule claimed. The block is now the run of lines at the head of the remote stream
+⚠ **The snapshot block's LENGTH is measured rather than assumed — hardening for
+a version skew that has NOT been observed.** The previous anchored two-line rule
+was *not* broken: it deletes the banner and its blank separator, which is exactly
+what this tree's `server.py` emits. Two structural reasons to measure anyway,
+neither needing a failure to have happened: the deployed image's arrangement is
+not this checkout's to assume, and a fixed-size delete removes lines that never
+enter the accounting below, so **deleted** could not be reconciled against
+**counted**. The block is now the run of lines at the head of the remote stream
 that are the banner or are blank; it is stripped only if that run **contains**
 the banner, and a server that emits no banner (pre-0.3.0) has nothing removed.
 
 Beside the verdict the script prints how many lines differ **with no
 canonicalisation at all**, decomposed into the three causes and summed as
-`accounted-for` — `raw-diff-lines=7 store-root-lines=2 host-lines=2
-snapshot-block-lines=3 accounted-for=7` is a pod-vs-workbench run against an
-image whose block is three lines. Those numbers are EVIDENCE, not a second gate:
+`accounted-for`. A real pod-vs-workbench run reads `store-root-lines=2
+host-lines=2 snapshot-block-lines=2 accounted-for=6`; the three-line block in
+`test_a_POD_SHAPED_remote_PASSES_when_only_the_THREE_permitted_lines_differ` is
+a SYNTHESISED skew, not a shape any deployed image has been seen to emit.
+Those numbers are EVIDENCE, not a second gate:
 they can only disagree if a `sed` erased a line that was none of the three,
 which the renderer cannot produce (no entry body renders at two-space
 indentation — measured across all four modes). Gating on them would be an

--- a/scripts/subsystem-store-api/verify-byte-identity.sh
+++ b/scripts/subsystem-store-api/verify-byte-identity.sh
@@ -3,25 +3,37 @@
 # EVERY scope (proposal §4 phase 1, §5 "byte-identity … `cmp`, not eyeballing").
 #
 # ⚠ IT CANNOT BE A BARE `cmp`, AND SAYING SO IS THE POINT.
-# `subsystem_recall.render_text` emits exactly one line naming the store root:
+# `subsystem_recall.render_text` emits exactly one line naming the store root
+# and exactly one line naming the machine whose disk was read:
 #
-#     store: /data                       (pod)
-#     store: /home/zach/.claude/…        (workbench)
+#     store: /data                       host: subsystem-store-api-…   (pod)
+#     store: /home/zach/.claude/…        host: nixos-<id-prefix>       (workbench)
 #
-# So the two byte streams are provably NOT identical, and a verifier that
-# reported them identical would be lying. What is claimed, precisely:
+# and the server prepends a transport annotation (the SNAPSHOT block) that the
+# local CLI correctly does not emit. So the two byte streams are provably NOT
+# identical, and a verifier that reported them identical would be lying. What is
+# claimed, precisely:
 #
-#   after replacing THAT ONE LINE with a fixed token on both sides, `cmp`
-#   reports the streams byte-identical.
+#   after replacing THOSE TWO LINES with a fixed token on both sides and
+#   removing the remote's SNAPSHOT block, `cmp` reports the streams
+#   byte-identical.
 #
-# Beside that verdict every PASS line prints `raw-diff-lines` and
-# `store-root-lines` — how many lines differ with NO canonicalisation, and how
-# many of those are the store-root line — so a reader can see the excuse was
-# spent on exactly the lines it claims (0/0 same-root, 2/2 pod-vs-workbench).
+# 🔴 THE `host:` RULE IS THE ONE THAT WAS MISSING, AND ITS ABSENCE MADE THIS
+# SCRIPT PERMANENTLY RED. `store_host_line()` shipped when the store became
+# PER-HOST; it names THIS machine, so it differs between the workbench and the
+# pod BY CONSTRUCTION and no run of this script could ever pass again
+# (`verify: scopes=16 pass=0 fail=16` on a store whose content was identical).
+# `claude/RULES.md`: a permanently-red gate is worse than no gate.
+#
+# Beside that verdict every PASS line prints its ACCOUNTING: `raw-diff-lines`
+# (how many lines differ with NO canonicalisation at all) decomposed into
+# `store-root-lines`, `host-lines` and `snapshot-block-lines`, plus the
+# `accounted-for` sum — so a reader can see the excuse was spent on exactly the
+# lines it claims (0/0/0 same-root same-host, 2/2/2 pod-vs-workbench).
 # ⚠ Those numbers are EVIDENCE, not a second gate, and the body of the script
-# says why: the two can only disagree if `sed` erased a non-store line, which
-# the renderer cannot produce. Gating on them would be an unreachable guard
-# counted as coverage.
+# says why: they can only disagree if `sed` erased a line that was none of the
+# three, which the renderer cannot produce. Gating on them would be an
+# unreachable guard counted as coverage.
 #
 # 🔴 CONTROLS. A comparator that always says PASS is indistinguishable from one
 # that works, so this script is exercised BOTH ways in
@@ -49,6 +61,7 @@ URL=""
 TOKEN_FILE=""
 SCOPES=()
 CANON='  store: <canonicalised>'
+CANON_HOST='  host: <canonicalised>'
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -56,7 +69,7 @@ while [[ $# -gt 0 ]]; do
     --url)        URL="${2:?}"; shift 2 ;;
     --token-file) TOKEN_FILE="${2:?}"; shift 2 ;;
     --scope)      SCOPES+=("${2:?}"); shift 2 ;;
-    -h|--help)    sed -n '2,35p' "$0"; exit 0 ;;
+    -h|--help)    sed -n '2,51p' "$0"; exit 0 ;;
     *) echo "verify: unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -144,19 +157,29 @@ for scope in "${SCOPES[@]}"; do
 
   # Claim 2's EVIDENCE, computed before claim 1 so a green cmp is never printed
   # without it: how many lines differ with no canonicalisation at all, and how
-  # many of those are the store-root line.
+  # many of those each named cause accounts for.
   #
   # ⚠ THESE ARE REPORTED, NOT GATED, AND THAT IS DELIBERATE. `raw` can only
-  # differ from `store_lines` if the canonicalisation erased a difference that
-  # was NOT a store-root line — and `sed` only rewrites lines matching
-  # `^  store: `, which MEASURED against the renderer no entry body can produce
-  # (every body line is indented deeper than two spaces, checked in all three
-  # modes). So a gate on `raw -eq $store_lines` could never fire: it would be an
-  # unreachable guard counted as coverage, which `claude/RULES.md` calls out by
-  # name. The numbers are printed instead, so a reader can see that the
-  # canonicalisation excuse was spent on exactly the lines it claims.
+  # exceed the sum below if the canonicalisation erased a difference that was
+  # none of the three named causes — and `sed` only rewrites lines matching
+  # `^  store: ` or `^  host: `, which MEASURED against the renderer no entry
+  # body can produce (every body line is indented FOUR OR MORE spaces — the
+  # section headings at four, their content at six, and a body line that itself
+  # begins `  host: ` renders at eight; checked in all four modes: default,
+  # `--ref`, `--search`, `--list`). So a gate on `raw -eq $accounted` could
+  # never fire: it would be an unreachable guard counted as coverage, which
+  # `claude/RULES.md` calls out by name. The numbers are printed instead, so a
+  # reader can see that the canonicalisation excuse was spent on exactly the
+  # lines it claims.
+  #
+  # 🔴 EVERY CANONICALISATION RULE MUST APPEAR IN THIS SUM. A rule that erases a
+  # difference without a matching count widens the blind spot instead of the
+  # gate — which is why `host_lines` was added in the same commit as the `host:`
+  # sed, and why the snapshot block is counted by the number of lines actually
+  # deleted rather than assumed to be two.
   raw=$(diff "$local_out" "$remote_out" | grep -c '^[<>]' || true)
   store_lines=$(diff "$local_out" "$remote_out" | grep -c '^[<>]   store: ' || true)
+  host_lines=$(diff "$local_out" "$remote_out" | grep -c '^[<>]   host: ' || true)
 
   # 🔴 THE SNAPSHOT BLOCK IS A TRANSPORT ANNOTATION, NOT PART OF THE REPORT.
   # The server prepends one line dating the COPY it serves (plus a blank
@@ -164,31 +187,66 @@ for scope in "${SCOPES[@]}"; do
   # for the measured incident that put it there. The local CLI reads the
   # authoritative store and correctly emits no such line, so leaving it in would
   # make this script FAIL on every scope for a difference that is not about the
-  # render at all — the same excuse the `store:` line above already earns.
+  # render at all — the same excuse the two lines above already earn.
   #
-  # Stripped from the REMOTE only, and by an anchored two-line delete, so it
-  # cannot reach into a report body. An image WITHOUT the stamp is unaffected
-  # (the sed matches nothing), which is what keeps this runnable against 0.2.0.
+  # 🔴 THE BLOCK IS MEASURED, NOT ASSUMED TO BE TWO LINES. The old rule was an
+  # anchored `,+1d` — the banner plus exactly one following line — which is the
+  # shape THIS TREE's `server.py` emits. This script does not compare against
+  # this tree's server; it compares against whatever image the pod is running,
+  # and a separator arrangement of any other size left a residual blank line
+  # that no rule claimed and `cmp` duly failed on. So the block is defined as
+  # the run of lines at the HEAD of the remote stream that are the banner or are
+  # blank, its LENGTH is measured, and exactly that many lines are dropped —
+  # which makes it countable in the accounting above, the thing `,+1d` was not.
+  #
+  # Two narrowings keep this from reaching into a report body:
+  #   * it is a HEAD run only — a banner appearing anywhere else is left alone
+  #     and will fail the comparison, which is correct;
+  #   * the run must CONTAIN the banner, so a remote that merely starts with a
+  #     blank line has nothing stripped (that is a real difference).
+  # An image WITHOUT the stamp is therefore unaffected — the run is empty and
+  # nothing is deleted — which is what keeps this runnable against 0.2.0.
   snapshot_lines=$(grep -c '^🔴 SNAPSHOT, NOT THE SOURCE' "$remote_out" || true)
-  sed "s|^  store: .*|$CANON|" "$local_out"  > "$tmp/l.canon"
-  sed -e '/^🔴 SNAPSHOT, NOT THE SOURCE/,+1d' \
-      -e "s|^  store: .*|$CANON|" "$remote_out" > "$tmp/r.canon"
+  snapshot_block=$(awk '
+    /^🔴 SNAPSHOT, NOT THE SOURCE/ { n++; seen = 1; next }
+    $0 == ""                       { n++; next }
+                                   { exit }
+    END { print (seen ? n + 0 : 0) }
+  ' "$remote_out")
+
+  # 🔴 The SAME two seds on both sides. A canonicalisation applied to one stream
+  # only is not a canonicalisation, it is an edit — and the `store:`/`host:`
+  # rules are only honest because the local render is rewritten too.
+  canon_seds=(-e "s|^  store: .*|$CANON|" -e "s|^  host: .*|$CANON_HOST|")
+  sed "${canon_seds[@]}" "$local_out" > "$tmp/l.canon"
+  remote_seds=("${canon_seds[@]}")
+  # `1,0d` is a sed error, not a no-op, so the delete is only added when the
+  # block is non-empty.
+  if [[ "$snapshot_block" -gt 0 ]]; then
+    remote_seds=(-e "1,${snapshot_block}d" "${remote_seds[@]}")
+  fi
+  sed "${remote_seds[@]}" "$remote_out" > "$tmp/r.canon"
+
+  # Printed beside `raw` so the reader does the subtraction once, here, instead
+  # of in their head on every PASS line.
+  accounted=$((store_lines + host_lines + snapshot_block))
 
   rev=$(awk 'tolower($1)=="x-store-revision:"{print $2}' "$tmp/hdr" | tr -d '\r' | tail -1)
 
   # PASS is `cmp` on the canonicalised streams — the byte-identity claim itself.
-  # The two counts ride along as evidence: 0/0 is the case where both sides read
-  # the SAME root (a local self-check), 2/2 is pod-vs-workbench.
+  # The counts ride along as evidence: 0/0/0 is the case where both sides read
+  # the SAME root on the SAME host (a local self-check), 2/2/2 is
+  # pod-vs-workbench.
   if cmp -s "$tmp/l.canon" "$tmp/r.canon"; then
-    # `snapshot-line` rides along as EVIDENCE, exactly like the two counts above
+    # `snapshot-line` rides along as EVIDENCE, exactly like the counts above
     # and gated for the same reason they are not: a `0` here means the remote
     # served no stamp, which is true and expected against a pre-0.3.0 image, so
     # failing on it would make this script permanently red until a deploy lands
     # (RULES.md). Printed so a reader can see WHICH of the two the green means.
-    echo "PASS scope=$scope bytes=$(wc -c <"$tmp/l.canon") raw-diff-lines=$raw store-root-lines=$store_lines snapshot-line=$snapshot_lines revision=${rev:-unknown}"
+    echo "PASS scope=$scope bytes=$(wc -c <"$tmp/l.canon") raw-diff-lines=$raw store-root-lines=$store_lines host-lines=$host_lines snapshot-line=$snapshot_lines snapshot-block-lines=$snapshot_block accounted-for=$accounted revision=${rev:-unknown}"
     pass=$((pass + 1))
   else
-    echo "FAIL scope=$scope canonicalised-cmp=$(cmp -s "$tmp/l.canon" "$tmp/r.canon" && echo same || echo differs) raw-diff-lines=$raw store-lines=$store_lines"
+    echo "FAIL scope=$scope canonicalised-cmp=$(cmp -s "$tmp/l.canon" "$tmp/r.canon" && echo same || echo differs) raw-diff-lines=$raw store-lines=$store_lines host-lines=$host_lines snapshot-block-lines=$snapshot_block accounted-for=$accounted"
     # 🔴 `|| true` is load-bearing, not decoration. `diff` exits 1 when the files
     # differ — which is ALWAYS true on this branch — and under `set -o pipefail`
     # that status kills the whole script mid-loop, so the remaining scopes are

--- a/scripts/subsystem-store-api/verify-byte-identity.sh
+++ b/scripts/subsystem-store-api/verify-byte-identity.sh
@@ -189,15 +189,29 @@ for scope in "${SCOPES[@]}"; do
   # make this script FAIL on every scope for a difference that is not about the
   # render at all — the same excuse the two lines above already earn.
   #
-  # 🔴 THE BLOCK IS MEASURED, NOT ASSUMED TO BE TWO LINES. The old rule was an
-  # anchored `,+1d` — the banner plus exactly one following line — which is the
-  # shape THIS TREE's `server.py` emits. This script does not compare against
-  # this tree's server; it compares against whatever image the pod is running,
-  # and a separator arrangement of any other size left a residual blank line
-  # that no rule claimed and `cmp` duly failed on. So the block is defined as
-  # the run of lines at the HEAD of the remote stream that are the banner or are
-  # blank, its LENGTH is measured, and exactly that many lines are dropped —
-  # which makes it countable in the accounting above, the thing `,+1d` was not.
+  # 🔴 THE BLOCK IS MEASURED, NOT ASSUMED TO BE TWO LINES — AND THIS IS
+  # HARDENING FOR A SKEW THAT HAS NOT BEEN OBSERVED, NOT A FIX FOR A DEFECT.
+  # ⚠ THE PREVIOUS RULE WAS NOT BROKEN. An anchored `,+1d` deletes the banner
+  # AND its blank separator, which is exactly the arrangement THIS TREE's
+  # `server.py` emits, and `test_every_permitted_difference_is_ACCOUNTED_FOR_
+  # not_merely_small` passes on it — before this change and after. Do not read
+  # this comment as evidence against it and do not go looking for the incident:
+  # there wasn't one. The retraction is recorded in this branch's history.
+  #
+  # Two structural reasons to measure the length anyway, neither of which needs
+  # a failure to have happened:
+  #   * THE LENGTH IS NOT THIS CHECKOUT'S TO ASSUME. This script does not
+  #     compare against this tree's `server.py`; it compares against whatever
+  #     image is DEPLOYED, and a fixed-size delete is a bet that those two are
+  #     the same version. Nothing here can check that bet.
+  #   * DELETED MUST EQUAL COUNTED. `,+1d` removes lines that never enter the
+  #     accounting above, so its removals could not be reconciled against `raw`;
+  #     a measured length can. That is the whole point of the sum, and a rule
+  #     exempt from it is the blind spot the sum exists to close.
+  #
+  # So the block is defined as the run of lines at the HEAD of the remote stream
+  # that are the banner or are blank, its LENGTH is measured, and exactly that
+  # many lines are dropped.
   #
   # Two narrowings keep this from reaching into a report body:
   #   * it is a HEAD run only — a banner appearing anywhere else is left alone

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -4001,6 +4001,118 @@ class TestByteIdentityVerifier:
         assert f"PASS scope={OTHER_SCOPE}" in r.stdout
         assert "pass=3 fail=1" in r.stdout
 
+    def test_LEADING_BLANKS_WITHOUT_the_banner_are_NOT_stripped(
+        self, store: Path, token_file: Path, monkeypatch
+    ):
+        """🔴 THE NARROWING, EXERCISED — not merely asserted in a comment.
+
+        The snapshot block is measured as a run of banner-or-blank lines at the
+        head of the remote stream, and a run that does NOT contain the banner
+        must be left alone: blank lines the server put there for some other
+        reason are a real difference, and a rule that swallowed them would be
+        the "erase a difference it does not claim" failure this whole commit is
+        about.
+
+        Same store on both sides, so `store:` and `host:` are identical and the
+        ONLY difference is two leading blanks. The verifier must FAIL, and its
+        accounting must say `snapshot-block-lines=0` — it stripped nothing, and
+        it says so.
+        """
+        # An image that emits the separator but no banner. `_serve_report` builds
+        # `prose + "\n\n" + text`, so an empty prose is exactly two blank lines.
+        monkeypatch.setattr(api, "snapshot_freshness", lambda root: ("x", ""))
+
+        with running(store) as (base, _):
+            r = run_verify(
+                "--store", str(store), "--url", base, "--token-file", str(token_file)
+            )
+        assert r.returncode == 1, (
+            f"two unexplained leading blank lines were swallowed:\n{r.stdout}"
+        )
+        assert "verify: scopes=4 pass=0 fail=4" in r.stdout
+        for line in r.stdout.splitlines():
+            if line.startswith("FAIL scope="):
+                assert "snapshot-block-lines=0" in line, (
+                    f"the block claimed lines it did not earn: {line}"
+                )
+                assert "raw-diff-lines=2 " in line, (
+                    f"expected exactly the two leading blanks to differ: {line}"
+                )
+
+    def test_a_server_that_serves_NO_SNAPSHOT_BLOCK_at_all_still_PASSES(
+        self, store: Path, token_file: Path
+    ):
+        """🔴 THE 0.2.0 PATH. The stamp shipped in 0.3.0; this script has to keep
+        working against an image that predates it.
+
+        The old rule got that for free — a `sed` address that matches nothing
+        deletes nothing. The measured rule does not: it computes a block LENGTH,
+        and `sed '1,0d'` is an ERROR, not a no-op, so an empty block has to be
+        branched on rather than passed through. That branch is the whole reason
+        this test exists; without it the script would exit non-zero on every
+        scope against a pre-0.3.0 pod and the failure would read as a content
+        difference.
+
+        The stub replays the local CLI's own bytes per scope — a server that
+        renders identically and stamps nothing.
+        """
+        import http.server
+
+        bodies = {}
+        for scope in (SCOPE, OTHER_SCOPE, EMPTY_SCOPE, BROKEN_SCOPE):
+            out = subprocess.run(
+                [sys.executable, str(RECALL_PATH), "--store", str(store),
+                 "--scope", scope],
+                capture_output=True, timeout=HANG_TIMEOUT,
+            )
+            # exit 3 is "nothing readable" — a legitimate render, which the
+            # verifier itself tolerates. Anything harder is a broken fixture.
+            assert out.returncode <= 3, out.stderr.decode()
+            bodies[scope] = out.stdout
+
+        class Unstamped(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):  # noqa: N802
+                body = bodies.get(self.path.rsplit("/", 1)[-1])
+                if body is None:
+                    self.send_response(404)
+                    self.send_header("Content-Length", "0")
+                    self.end_headers()
+                    return
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_args):  # noqa: D102
+                pass
+
+        httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Unstamped)
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        try:
+            r = run_verify(
+                "--store", str(store),
+                "--url", f"http://127.0.0.1:{httpd.server_address[1]}",
+                "--token-file", str(token_file),
+            )
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+            thread.join(timeout=10)
+
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "verify: scopes=4 pass=4 fail=0" in r.stdout
+        # 🔴 And the accounting says WHY it is green: nothing differed and
+        # nothing was canonicalised away. A green with a non-zero block here
+        # would mean the strip invented a block to delete.
+        rows = _evidence_rows(r.stdout)
+        assert len(rows) == 4, f"expected one evidence row per scope:\n{r.stdout}"
+        for row in rows:
+            assert row == {
+                "raw": 0, "store_root": 0, "host": 0,
+                "snapshot": 0, "block": 0, "accounted": 0,
+            }, f"an unstamped identical render was not a clean zero: {row}"
+
     def test_an_UNREACHABLE_pod_FAILS_rather_than_comparing_nothing(
         self, store: Path, token_file: Path
     ):

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -221,6 +221,21 @@ assert resolver.classify_path is api.classify_path, (
     "'what IS this path' is the defect the move was made to prevent"
 )
 
+# 🔴 THE SEAM THAT MAKES A POD-SHAPED `host:` LINE REACHABLE IN-PROCESS.
+# `subsystem_recall` does `from subsystem_touch import store_host_line`, and
+# `store_host_line` calls `store_host()` — a lookup in THIS module's globals, by
+# design (`subsystem_touch.store_host`'s docstring: "one injection point makes
+# the reader and the writer agree"). So patching it here moves what the
+# IN-PROCESS server renders while the local CLI, which `run_verify` starts as a
+# SUBPROCESS, keeps this machine's real identity. That asymmetry is precisely
+# the workbench-vs-pod shape, and nothing else in this harness produces it.
+touch = sys.modules["subsystem_touch"]
+assert hasattr(touch, "store_host"), (
+    "subsystem_touch no longer exposes `store_host` — the byte-identity "
+    "verifier's `host:` canonicalisation is tested through this seam, and a "
+    "rename here would silently turn those tests into same-host self-checks"
+)
+
 
 # =============================================================================
 # Synthetic fixtures — realistic SHAPES, invented names, pairwise-distinct text.
@@ -240,6 +255,14 @@ OTHER_NUANCE = "- 2026-01-03: the sidecar drops its lease during a rollout."
 
 # A token that clears the 43-character floor pinned literally below.
 GOOD_TOKEN = "a" * 20 + "B" * 20 + "c" * 8  # 48 chars
+
+# What `store_host()` returns INSIDE THE POD, in shape: the pod name as the
+# label, and `machine-id-unreadable` because a container image carries no
+# `/etc/machine-id` this reader will accept (`host_identity.MACHINE_ID_UNREADABLE`).
+# Synthetic — an invented replicaset/pod suffix, like every other fixture here.
+# 🔴 IT MUST SHARE NO PREFIX WITH THIS MACHINE'S OWN IDENTITY, or a
+# canonicalisation that matched only a prefix would pass by coincidence.
+POD_HOST = "subsystem-store-api-6f4d8c9b7a-qz2wl-machine-id-unreadable"
 
 
 def _entry(
@@ -3693,6 +3716,52 @@ def run_verify(*args: str) -> subprocess.CompletedProcess:
     )
 
 
+# 🔴 PINNED LITERALLY, PASS LINES ONLY. The field names are spelled here by hand
+# rather than imported or derived, per this file's header: a rename in the
+# script must break these tests, not be absorbed by them. It is anchored on
+# `PASS` because the accounting identity is a claim about a run the comparator
+# called byte-identical; a FAIL line prints a different field set on purpose.
+_EVIDENCE_RE = re.compile(
+    r"^PASS scope=\S+ bytes=\d+ "
+    r"raw-diff-lines=(?P<raw>\d+) "
+    r"store-root-lines=(?P<store_root>\d+) "
+    r"host-lines=(?P<host>\d+) "
+    r"snapshot-line=(?P<snapshot>\d+) "
+    r"snapshot-block-lines=(?P<block>\d+) "
+    r"accounted-for=(?P<accounted>\d+) ",
+    re.MULTILINE,
+)
+
+
+def _evidence_rows(stdout: str) -> list[dict[str, int]]:
+    """Every PASS line's accounting, as ints."""
+    return [
+        {k: int(v) for k, v in m.groupdict().items()}
+        for m in _EVIDENCE_RE.finditer(stdout)
+    ]
+
+
+def _wider_separator(module):
+    """A `snapshot_freshness` whose prose ends in a newline.
+
+    🔴 IT MODELS A DIFFERENT IMAGE, NOT A BROKEN ONE. `_serve_report` builds the
+    body as `prose + "\\n\\n" + text`, so a prose carrying its own trailing
+    newline yields banner + TWO blank separators — a three-line transport
+    annotation instead of this tree's two. The verifier is pointed at a POD, and
+    the pod's `server.py` is whatever was last deployed, not this checkout: a
+    canonicalisation that hardcodes the block's length is a bet on those two
+    being the same version. That bet was lost, and the residue was a single
+    unexplained blank line that `cmp` failed on for every scope.
+    """
+    real = module.snapshot_freshness
+
+    def _wrapped(store_root):
+        header, prose = real(store_root)
+        return header, prose + "\n"
+
+    return _wrapped
+
+
 @pytest.fixture
 def token_file(tmp_path: Path) -> Path:
     path = tmp_path / "token"
@@ -3780,15 +3849,25 @@ class TestByteIdentityVerifier:
         comment is a claim too"; a name is louder than a comment.
 
         The replacement is STRONGER than a bumped constant. It asserts the raw
-        difference is FULLY DECOMPOSED by its two named causes:
+        difference is FULLY DECOMPOSED by its named causes:
 
-            raw == store_root_lines + 2 * snapshot_lines
+            raw == store_root_lines + host_lines + snapshot_block_lines
 
-        (the block contributes its prose line AND its blank separator, and both
-        appear one-sided in the diff). An unexplained differing line therefore
-        still fails — which a hardcoded `raw-diff-lines=4` would not, since it
-        would go on passing if a store-root line vanished and some other
-        difference appeared in its place.
+        An unexplained differing line therefore still fails — which a hardcoded
+        `raw-diff-lines=4` would not, since it would go on passing if a
+        store-root line vanished and some other difference appeared in its
+        place.
+
+        🔴 `host_lines` JOINED THE SUM WITH THE `host:` CANONICALISATION, in the
+        same commit, and that ordering is the point: a rule that erases a
+        difference without a matching count widens the blind spot rather than
+        the gate. Here both sides run on this machine, so `host_lines` is 0 and
+        the identity is unchanged from the two-cause version — the case where it
+        is 2 is `test_a_POD_SHAPED_remote_PASSES_when_only_the_THREE_permitted_
+        lines_differ` below, which is where that term is actually exercised.
+        `snapshot_block_lines` replaces `2 * snapshot_lines`: the block's LENGTH
+        is now measured rather than assumed, so a served image whose separator
+        arrangement is not this tree's is still fully accounted for.
         """
         served = tmp_path / "served-elsewhere"
         subprocess.run(
@@ -3800,20 +3879,127 @@ class TestByteIdentityVerifier:
             )
         assert r.returncode == 0, r.stdout + r.stderr
 
-        rows = re.findall(
-            r"raw-diff-lines=(\d+) store-root-lines=(\d+) snapshot-line=(\d+)",
-            r.stdout,
-        )
-        assert rows, f"the verifier printed no evidence triples:\n{r.stdout}"
-        for raw, store_root, snapshot in rows:
-            assert int(raw) == int(store_root) + 2 * int(snapshot), (
-                f"unaccounted differing lines: raw={raw} "
-                f"store-root={store_root} snapshot={snapshot}"
+        rows = _evidence_rows(r.stdout)
+        assert rows, f"the verifier printed no evidence rows:\n{r.stdout}"
+        for row in rows:
+            assert row["raw"] == row["store_root"] + row["host"] + row["block"], (
+                f"unaccounted differing lines: {row}"
             )
-        # …and the two causes are each genuinely PRESENT, or the identity above
-        # is satisfiable by a run that compared nothing (0 == 0 + 2*0).
-        assert any(int(s) == 1 for _r, _sr, s in rows), "no snapshot line observed"
-        assert any(int(sr) == 2 for _r, sr, _s in rows), "no store-root line observed"
+            # The script's own arithmetic, read back rather than re-derived —
+            # a printed `accounted-for` that disagreed with its own parts would
+            # be a reader-facing lie even while the identity above held.
+            assert row["accounted"] == row["store_root"] + row["host"] + row["block"], (
+                f"the printed accounted-for does not equal its own parts: {row}"
+            )
+        # …and the causes exercised here are genuinely PRESENT, or the identity
+        # above is satisfiable by a run that compared nothing (0 == 0 + 0 + 0).
+        assert any(row["snapshot"] == 1 for row in rows), "no snapshot line observed"
+        assert any(row["block"] == 2 for row in rows), (
+            "no snapshot BLOCK observed — this tree's server emits the banner "
+            "plus exactly one blank separator, so a 2 is the expected length"
+        )
+        assert any(row["store_root"] == 2 for row in rows), "no store-root line observed"
+        # Both sides are this machine, so the host line must be IDENTICAL here.
+        # A non-zero would mean the harness accidentally diverged the two hosts,
+        # which would make the pod-shaped test below prove nothing new.
+        assert all(row["host"] == 0 for row in rows), (
+            f"the local self-check saw a host-line difference: {rows}"
+        )
+
+    def test_a_POD_SHAPED_remote_PASSES_when_only_the_THREE_permitted_lines_differ(
+        self, store: Path, tmp_path: Path, token_file: Path, monkeypatch
+    ):
+        """🔴 THE REGRESSION. This is the run that could not pass at all.
+
+        Every earlier test in this class compares two renders produced ON THE
+        SAME MACHINE, so their `host:` lines are byte-identical and the verifier
+        never had to canonicalise one. Against the actual pod they are different
+        BY CONSTRUCTION — `store_host_line()` names the machine whose disk was
+        read, and that is the entire reason it exists — so the comparator was
+        structurally unable to return anything but FAIL, on every scope, for a
+        store whose content was identical. `claude/RULES.md`: a permanently-red
+        gate is worse than no gate.
+
+        Three differences are set up here and NOTHING else:
+
+          * `store:`  — the served copy lives at a different root;
+          * `host:`   — the server renders a pod identity, the CLI subprocess
+                        this machine's;
+          * the SNAPSHOT block — and deliberately NOT in this tree's shape. The
+            served prose carries an extra separator, so the block is THREE lines
+            rather than two. The verifier does not compare against this tree's
+            `server.py`; it compares against whatever image the pod runs, and
+            the old anchored two-line delete left a residual blank line that no
+            rule claimed. Measuring the block is what makes any arrangement
+            work — and what makes it countable in the accounting.
+
+        The negative control is the next test, not a comment: the same three
+        permitted differences plus ONE mutated character must still FAIL.
+        """
+        served = tmp_path / "served-elsewhere"
+        subprocess.run(
+            ["cp", "-a", str(store), str(served)], check=True, capture_output=True
+        )
+        monkeypatch.setattr(touch, "store_host", lambda: POD_HOST)
+        monkeypatch.setattr(api, "snapshot_freshness", _wider_separator(api))
+
+        with running(served) as (base, _):
+            r = run_verify(
+                "--store", str(store), "--url", base, "--token-file", str(token_file)
+            )
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "verify: scopes=4 pass=4 fail=0" in r.stdout
+
+        rows = _evidence_rows(r.stdout)
+        assert len(rows) == 4, f"expected one evidence row per scope:\n{r.stdout}"
+        for row in rows:
+            # 🔴 EACH PERMITTED DIFFERENCE PRESENT AND COUNTED. Asserting only
+            # the PASS would be satisfied by a canonicalisation that flattened
+            # the whole stream.
+            assert row["store_root"] == 2, f"no store-root difference: {row}"
+            assert row["host"] == 2, f"no host-line difference: {row}"
+            assert row["block"] == 3, (
+                f"the served banner + TWO blank separators were not measured "
+                f"as a 3-line block: {row}"
+            )
+            assert row["raw"] == row["store_root"] + row["host"] + row["block"], (
+                f"unaccounted differing lines: {row}"
+            )
+            assert row["accounted"] == row["raw"], (
+                f"the printed accounted-for does not cover the raw diff: {row}"
+            )
+
+    def test_a_POD_SHAPED_remote_STILL_FAILS_on_a_real_content_difference(
+        self, store: Path, tmp_path: Path, token_file: Path, monkeypatch
+    ):
+        """🔴 The control for the test above. Same three permitted differences,
+        plus a single changed character inside one entry.
+
+        Without this, "the pod-shaped run passes" is equally true of a verifier
+        that stopped comparing anything — which is exactly the failure mode a
+        wider canonicalisation introduces, and the reason the new rules are
+        counted rather than merely applied.
+        """
+        served = tmp_path / "served-elsewhere"
+        subprocess.run(
+            ["cp", "-a", str(store), str(served)], check=True, capture_output=True
+        )
+        path = served / SCOPE / "thing-alpha.md"
+        path.write_text(path.read_text().replace("40s", "41s"))
+
+        monkeypatch.setattr(touch, "store_host", lambda: POD_HOST)
+        monkeypatch.setattr(api, "snapshot_freshness", _wider_separator(api))
+
+        with running(served) as (base, _):
+            r = run_verify(
+                "--store", str(store), "--url", base, "--token-file", str(token_file)
+            )
+        assert r.returncode == 1, r.stdout + r.stderr
+        assert f"FAIL scope={SCOPE}" in r.stdout
+        # Attributed, not a blanket red: the other scopes differ by the three
+        # permitted lines ONLY and still pass.
+        assert f"PASS scope={OTHER_SCOPE}" in r.stdout
+        assert "pass=3 fail=1" in r.stdout
 
     def test_an_UNREACHABLE_pod_FAILS_rather_than_comparing_nothing(
         self, store: Path, token_file: Path

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -3744,14 +3744,17 @@ def _evidence_rows(stdout: str) -> list[dict[str, int]]:
 def _wider_separator(module):
     """A `snapshot_freshness` whose prose ends in a newline.
 
-    🔴 IT MODELS A DIFFERENT IMAGE, NOT A BROKEN ONE. `_serve_report` builds the
-    body as `prose + "\\n\\n" + text`, so a prose carrying its own trailing
-    newline yields banner + TWO blank separators — a three-line transport
-    annotation instead of this tree's two. The verifier is pointed at a POD, and
-    the pod's `server.py` is whatever was last deployed, not this checkout: a
-    canonicalisation that hardcodes the block's length is a bet on those two
-    being the same version. That bet was lost, and the residue was a single
-    unexplained blank line that `cmp` failed on for every scope.
+    🔴 IT MODELS A DIFFERENT IMAGE, NOT A BROKEN ONE, AND THE SKEW IS
+    SYNTHETIC. `_serve_report` builds the body as `prose + "\\n\\n" + text`, so
+    a prose carrying its own trailing newline yields banner + TWO blank
+    separators — a three-line transport annotation instead of this tree's two.
+
+    ⚠ NO DEPLOYED IMAGE HAS BEEN SEEN TO EMIT THAT. This fixture exists because
+    the verifier is pointed at a POD, and the pod's `server.py` is whatever was
+    last deployed rather than this checkout: hardcoding the block's length is a
+    bet on those two being the same version, and nothing in the script can check
+    that bet. It is the unobserved case made reachable, not a reproduction of
+    one that happened.
     """
     real = module.snapshot_freshness
 
@@ -3927,11 +3930,17 @@ class TestByteIdentityVerifier:
                         this machine's;
           * the SNAPSHOT block — and deliberately NOT in this tree's shape. The
             served prose carries an extra separator, so the block is THREE lines
-            rather than two. The verifier does not compare against this tree's
-            `server.py`; it compares against whatever image the pod runs, and
-            the old anchored two-line delete left a residual blank line that no
-            rule claimed. Measuring the block is what makes any arrangement
-            work — and what makes it countable in the accounting.
+            rather than two.
+
+        ⚠ THAT THIRD DIFFERENCE IS A SYNTHESISED SKEW, AND ONLY THE FIRST TWO
+        ARE PART OF THE REGRESSION. No deployed image has been seen to emit a
+        three-line block, and the old anchored two-line delete was correct for
+        the arrangement this tree emits — `test_every_permitted_difference_is_
+        ACCOUNTED_FOR_not_merely_small` passes on it before and after. The skew
+        is here because the verifier compares against whatever image is
+        DEPLOYED, not this checkout, so a hardcoded length is an unverifiable
+        bet; measuring it also makes the deletion countable in the accounting,
+        which a fixed-size delete never was.
 
         The negative control is the next test, not a comment: the same three
         permitted differences plus ONE mutated character must still FAIL.


### PR DESCRIPTION
## The gate could not pass at all

`scripts/subsystem-store-api/verify-byte-identity.sh` — the phase-1 acceptance
criterion — canonicalised the `  store: ` line and the `🔴 SNAPSHOT` banner, and
not the `  host: ` line. `store_host_line()` shipped when the store became
PER-HOST. It names the machine whose disk was read — that is the entire point of
it — so it differs between a workbench and a pod BY CONSTRUCTION, and nothing
stripped it. The result is `verify: scopes=16 pass=0 fail=16` on a store whose
content is genuinely identical. `claude/RULES.md` calls a permanently-red gate
worse than no gate: it trains everyone to click through, and here it blocks the
cairn phase-1 freeze.

**One defect, one rule, and it closes.** Re-measured with the script's own
expressions on scope `kubeclaw`, workbench versus the live pod:

| canonicalisation | differing lines |
|---|---|
| `store:` + banner (what the script did) | 2 |
| the same, plus `host:` | **0** |

## Retraction — read this before reading the history

⚠ **An earlier revision of this branch asserted a SECOND defect, as measured,
and it does not exist.** It said the anchored `/^🔴 SNAPSHOT…/,+1d` deleted only
the banner and left a residual blank line that `cmp` failed on. `,+1d` is a
RANGE — it deletes the banner *and* its blank separator, exactly the arrangement
this tree's `server.py` emits. The measurement behind the claim had been taken
with a hand-rolled single-line `sed`, so the leftover blank was produced by that
reimplementation rather than by the script.

`claude/RULES.md` twice over: a predicate open-coded at a second site and then
trusted over the original, and a control built out of the very step under
suspicion. The correction is committed as `60dbcce2` rather than edited away
silently, and the five prose sites that stated it are fixed there.

🔴 **Do not read this branch as evidence that `,+1d` is broken.** It is correct
for what this tree emits, and `test_every_permitted_difference_is_ACCOUNTED_FOR_
not_merely_small` — which asserts the block contributes exactly 2 lines —
passes against it both before and after this branch.

## The fix

* `^  host: .*` is rewritten to a fixed token **on both sides**, exactly as
  `^  store: ` already was. This is the whole of the defect.
* The snapshot block's LENGTH is now measured rather than assumed — **hardening
  for a version skew that has NOT been observed**, kept on two structural
  arguments that need no incident: the deployed image's arrangement is not this
  checkout's to assume (the script compares against whatever is running on the
  pod, and a fixed-size delete is a bet nothing here can check), and *deleted
  must equal counted* — `,+1d` removes lines that never enter the accounting,
  so its removals could not be reconciled against `raw-diff-lines` the way a
  measured length can. Two narrowings keep it out of a report body: it is a HEAD
  run only, and the run must **contain** the banner. A server emitting no banner
  is unaffected, which keeps this runnable against 0.2.0.

## The accounting grew with the rules — that is the point

A rule that erases a difference without a matching count widens the blind spot
rather than the gate. Every PASS line now prints `raw-diff-lines` decomposed
into `store-root-lines` + `host-lines` + `snapshot-block-lines`, summed as
`accounted-for`. `snapshot-block-lines` replaces the old `2 * snapshot-line`
assumption for the same reason: a fixed multiplier is an assumption, not a
measurement of what was deleted.

They remain EVIDENCE, not a gate: they can only disagree if a `sed` erased a
line that was none of the three, which the renderer cannot produce — gating on
them would be an unreachable guard counted as coverage.

## Why `^  host: ` is safe to rewrite

Measured, not asserted. Across all four render modes (default, `--ref`,
`--search`, `--list`) the only lines emitted at exactly two spaces are the
header's own. An entry body renders at four spaces or deeper: section headings
at four, their content at six — and a body line that itself literally begins
`  host: ` comes out at eight.

## Tests — red before, green after

`TestByteIdentityVerifier` (13 tests, was 11).

Every earlier test in that class compared two renders produced on the SAME
machine, so their `host:` lines were byte-identical and the verifier never had
to canonicalise one. The class was structurally blind to the defect.

New:

* `test_a_POD_SHAPED_remote_PASSES_when_only_the_THREE_permitted_lines_differ` —
  served copy at a different root, a pod identity patched into the in-process
  server's renderer, and a **synthesised** three-line snapshot block. Asserts
  PASS and that each difference is present and counted.
* `test_a_POD_SHAPED_remote_STILL_FAILS_on_a_real_content_difference` — its
  control. Same permitted differences plus ONE mutated character: must FAIL,
  name the scope, and leave the other scopes green.
* `test_LEADING_BLANKS_WITHOUT_the_banner_are_NOT_stripped` — the narrowing.
* `test_a_server_that_serves_NO_SNAPSHOT_BLOCK_at_all_still_PASSES` — the 0.2.0
  path. `sed '1,0d'` is an error, not a no-op, so an empty block has to be
  branched on rather than passed through.

`test_every_permitted_difference_is_ACCOUNTED_FOR_not_merely_small` moves to the
three-way decomposition.

**RED → GREEN**, new tests against the PRE-FIX verifier (`HEAD~1` of the fix
commit) vs after:

| | pre-fix verifier | after |
|---|---|---|
| `…POD_SHAPED_remote_PASSES…` | FAIL — `assert 1 == 0`, residue is the uncanonicalised `host:` pair | PASS |
| `…POD_SHAPED_remote_STILL_FAILS…` | FAIL — `pass=0 fail=4`, everything red | PASS (`pass=3 fail=1`) |
| `…ACCOUNTED_FOR…` | FAIL — no `host-lines` / `snapshot-block-lines` printed | PASS |
| whole class | **3 failed, 8 passed** | **13 passed** |

## Mutation matrix

Each new rule broken in turn, narrowest expression, one at a time, restored from
git between mutants, `PYTHONDONTWRITEBYTECODE=1`. Every mutant KILLED, and by
**that** rule's own assertion:

| mutant | killed by | its own assertion |
|---|---|---|
| `host:` sed removed (counts kept) | `…POD_SHAPED_remote_PASSES…` | `assert 1 == 0` on the verdict; residue is the `host:` pair, accounting still correct (`host-lines=2 accounted-for=7`) — so it is the RULE that failed, not the count |
| `host_lines` count removed (sed kept) | `…POD_SHAPED_remote_PASSES…` | `no host-line difference: {…'host': 0, …'accounted': 5}` — the run still PASSES the `cmp`; the ACCOUNTING is what goes red. This is the isolation that proves the count is not decorative |
| block hardcoded back to 2 | `…POD_SHAPED_remote_PASSES…` | `snapshot-block-lines=2 accounted-for=6` against `raw-diff-lines=7` |
| "run must contain the banner" removed | `…LEADING_BLANKS…` | `two unexplained leading blank lines were swallowed` — and only that test |
| empty-block branch removed | `…NO_SNAPSHOT_BLOCK…` | FAIL with `raw-diff-lines=0 … accounted-for=0` (the `sed '1,0d'` error) — and only that test |
| **positive control**: `cmp` → `true` | 4 tests incl. the two pre-existing negatives | proves the harness observes this file at all |

## Gate

Base sha `78af92f1`.

* **merge-gating tier, built ONE AT A TIME at `438f8518`** (a combined red is
  untrustworthy; these were sequential):
  * `nix build .#checks.x86_64-linux.pytests` → `RESULT: PASS (exit=0)`,
    `TOTAL collected=20343 passed=20340 skipped=3 failed=0`
    (`scripts/tests` target: `collected=11346 passed=11346`).
  * `nix build .#checks.x86_64-linux.nodetests` → `RESULT: PASS (exit=0)`,
    `TOTAL suites=5 files=41 tests=1449 pass=1449 fail=0`.

  Both read from the runners' own `RESULT:` lines out of `nix log`, not from a
  piped exit code.
* **dev-host tier** — `nix develop <worktree> -c bash scripts/gate.sh`:
  `GATE: RESULT=PASS exit=0`. ⚠ that run started at `c92f0b82` and two
  docs-only commits landed while it ran.
* ⚠ **`60dbcce2` (the retraction) is NOT covered by either tier above.** It is
  prose only — comments, docstrings and README, no executable line changed —
  and `TestByteIdentityVerifier` is 13 passed after it. But that is a scoped
  claim, not a gate run.

`strict` is false on branch protection, so all of these are claims about this
branch, not about the tree the merge creates.

## What I could NOT verify

* **Nothing was run against the live pod or either host's store** from this
  branch — per the brief. The `kubeclaw` re-measurement above was taken by the
  coordinator.
* **One documented narrowing is not exercised**: "a banner appearing anywhere
  other than the head run is left alone". `_serve_report` always prepends, so it
  could not be reached without rewriting the server. It is stated in the comment
  and untested — treat it as a claim, not as coverage.
