### PR TITLE
fix(subsystem-touch): the proposal HEADERS still advertised a confirm gate that was retired twice

### DIFF
--- a/scripts/lib/subsystem_touch.py
+++ b/scripts/lib/subsystem_touch.py
@@ -4589,7 +4589,7 @@ def render_text(report: TouchReport) -> str:
 
     if report.known:
         out.append("")
-        out.append("KNOWN ENTRIES (propose a dated journal line, confirm-gated):")
+        out.append("KNOWN ENTRIES (propose a dated journal line; SHOW the diff, then write):")
         for m in report.known:
             fname = report.entry_files.get(m.entry.ref, m.entry.filename)
             out.append(f"  - {m.entry.ref}  ->  {report.scope}/{fname}  ({m.path_count} paths)")
@@ -4669,7 +4669,10 @@ def render_text(report: TouchReport) -> str:
 
     if report.nominations:
         out.append("")
-        out.append("NO ENTRY (propose a MINIMAL new entry, confirm-gated — pick at most one):")
+        out.append(
+            "NO ENTRY (propose a MINIMAL new entry; SHOW the diff, then write "
+            "— pick at most one):"
+        )
         for n in report.nominations:
             shape = "one place in the tree" if n.coherent else "spread across directories"
             if n.fans_out:

--- a/scripts/tests/test_service_recon.py
+++ b/scripts/tests/test_service_recon.py
@@ -169,7 +169,9 @@ def _tree_hash(root: Path) -> str:
 
 class TestReconNeverWrites:
     """The store is curated, client-confidential and not re-derivable by re-running
-    recon. The only writers are the two confirm-gated ones in the skills.
+    recon. The only writers are the two diff-first ones in the skills, which since
+    2026-08-31 follow ONE append protocol (`claude/skills/subsystem-index/SKILL.md`).
+    They were confirm-gated too until the y/N was retired; the diff is still shown.
     (Was "has no off-machine backup" — false; it is backed up hourly/daily. See
     `claude/skills/analyze-service/reference/index-store.md` -> "Store safety".)"""
 

--- a/scripts/tests/test_subsystem_recall.py
+++ b/scripts/tests/test_subsystem_recall.py
@@ -3592,7 +3592,8 @@ class TestSkillDocsArePinned:
         ),
         (
             "do not go create an entry",
-            "writing is /handoff's confirm-gated job, not this step's",
+            "writing is /handoff's job at the END of a session, not this step's "
+            "(it shows a diff; the y/N was retired 2026-08-15)",
         ),
         ("sensitivity=", "the store is client-confidential and this repo is PUBLIC"),
         # --- the digest, and the claim it replaced -------------------------

--- a/scripts/tests/test_subsystem_touch.py
+++ b/scripts/tests/test_subsystem_touch.py
@@ -12183,3 +12183,77 @@ class TestTheStoreIsPerHost:
         bad.write_text("not-a-machine-id\n", encoding="utf-8")
         monkeypatch.setattr(hi, "MACHINE_ID_FILES", (str(bad),))
         assert hi.machine_id() is None
+
+
+# =============================================================================
+# THE PRINTED PROPOSAL MUST NOT ADVERTISE A GATE THAT NO LONGER EXISTS
+#
+# 🔴 THE MEASURED DEFECT. The append y/N was retired on 2026-08-15 and again,
+# everywhere, on 2026-08-31 — and both proposal HEADERS went on printing
+# "confirm-gated" for months afterwards. That is the one place it actually
+# misleads: an operator reading the tool's own output is told a prompt will
+# stand between the proposal and the store, and none will. Every other stale
+# mention lived in a docstring; these two were user-visible.
+#
+# 🔴 THIS IS NOT A PHRASE BAN. It reads the RENDERED OUTPUT of the real code
+# path, so it cannot be satisfied by rewording a comment, and it deliberately
+# does not police the word elsewhere: `prune-index` keeps its y/N on purpose
+# (a cut is a deletion, and the evidence that retired the prompt was measured on
+# an APPEND), and the dated retractions that quote the old wording must stay
+# findable as retractions. Scope is exactly the two headers this tool prints.
+# =============================================================================
+
+
+class TestTheProposalHeadersDoNotClaimAConfirmGate:
+    def _headers(self, store: Path) -> str:
+        """Both proposal headers through the real renderer, in one string.
+
+        KNOWN ENTRIES needs a path that resolves to an existing entry; NO ENTRY
+        needs one that resolves to none. Rendering both is the positive control:
+        if a future refactor stops emitting either header, the assertions below
+        would pass vacuously, so their presence is asserted first.
+        """
+        known = st.render_text(_report(self.KNOWN_PATHS, store))
+        # Two paths in ONE unseen directory: the shape `nominate()` requires
+        # (min_paths) and the same fixture the resolution tests use for a
+        # brand-new scope.
+        nominate = st.render_text(
+            _report(["apps/roster/a.yaml", "apps/roster/b.yaml"], store,
+                    scope="brand-new-repo")
+        )
+        return known + "\n" + nominate
+
+    KNOWN_PATHS = ["scripts/collector/a.py", "scripts/collector/b.py"]
+
+    def test_neither_header_advertises_a_confirm_gate(self, store: Path) -> None:
+        text = self._headers(store)
+        assert "KNOWN ENTRIES" in text, (
+            "positive control: the KNOWN ENTRIES header did not render, so the "
+            "assertion below would pass vacuously"
+        )
+        assert "NO ENTRY" in text, (
+            "positive control: the NO ENTRY header did not render, so the "
+            "assertion below would pass vacuously"
+        )
+        for line in text.splitlines():
+            if line.startswith(("KNOWN ENTRIES", "NO ENTRY")):
+                assert "confirm-gated" not in line.lower(), (
+                    "a proposal header still advertises a confirm gate. The "
+                    "append y/N was retired 2026-08-15 and again everywhere on "
+                    "2026-08-31; the write SHOWS a diff and then writes. "
+                    f"Header: {line!r}"
+                )
+
+    def test_the_headers_say_what_DOES_happen(self, store: Path) -> None:
+        """Removing a false claim is not the same as stating the true one.
+
+        Without this, deleting the words 'confirm-gated' and stopping would pass
+        the test above while leaving the operator with no idea whether a diff is
+        shown before the write.
+        """
+        text = self._headers(store)
+        for line in text.splitlines():
+            if line.startswith(("KNOWN ENTRIES", "NO ENTRY")):
+                assert "SHOW the diff" in line, (
+                    f"header states no write contract at all: {line!r}"
+                )


### PR DESCRIPTION
## The defect

The append `y/N` was retired on **2026-08-15** and again, everywhere, on **2026-08-31** (#1170). Both of `render_text`'s proposal headers went on printing `confirm-gated` through *both* retirements:

```
KNOWN ENTRIES (propose a dated journal line, confirm-gated):
NO ENTRY (propose a MINIMAL new entry, confirm-gated — pick at most one):
```

🔴 **These two are the ones that actually mislead.** Every other stale mention lives in a docstring or a comment; these are what an **operator** reads at the moment the tool proposes a write. They promise a prompt will stand between the proposal and the store, and none will.

#1170's own audit named both sites as 🟡 3. Neither #1170 nor #1186 fixed them.

They now say what **does** happen — `SHOW the diff, then write` — rather than deleting the false clause and leaving no contract at all.

## Two more, found by sweeping rather than by fixing what was reported

- `test_service_recon.py` — *"the only writers are the two confirm-gated ones in the skills"*. Written by me on 2026-08-30; stale one day later.
- `test_subsystem_recall.py` — the rationale beside a pinned substring still called `/handoff`'s write confirm-gated. The **pin** (`"do not go create an entry"`) is unaffected; the explanation next to it was wrong.

## What the sweep deliberately left alone

"Stale" is not the same as "contains the word":

| left alone | why | sites |
|---|---|---|
| `prune-index` | keeps its y/N **on purpose** — a cut is a DELETION, and the evidence that retired the prompt (*"the answer was always `y`"*) was measured on an APPEND | 6 |
| dated retractions quoting the old wording | must stay findable **as retractions**, or the next reader re-derives the claim | 7 |
| `index-store.md:29` | inside the hashed `resolver-rules` region; #1170 already corrects it out-of-band for exactly that reason | 1 |

## New guard — on the rendered OUTPUT, not on the word

`TestTheProposalHeadersDoNotClaimAConfirmGate` builds both headers through the real `render_text` path, so it cannot be satisfied by rewording a comment — and it polices only those two lines. A blanket phrase ban would fire on all fourteen accurate sites above.

Two assertions, because **removing a false claim is not the same as stating the true one**: the first fails if a header advertises a gate, the second fails if a header states no write contract at all.

⚠ **Its positive control earned its keep immediately.** The first fixture (`["totally/unrelated/thing.py"] * 2`) produced no `NO ENTRY` header at all — `nominate()` needs two paths in one unseen directory — so half the guard would have passed **vacuously**. The control caught it before the guard was ever trusted.

## Verification

- **RED at base `76bb7507`**, both tests, each with its own message — `header states no write contract at all: 'KNOWN ENTRIES (propose a dated journal line, confirm-gated):'`
- **GREEN at HEAD**
- **1553 tests green** across `test_subsystem_touch`, `test_subsystem_recall`, `test_service_recon`, `test_index_append_protocol`

⚠ Full `gate.sh` and the sandbox tier not yet run on this branch — will post both before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)