### PR TITLE
fix(subsystem-store-api): the byte-identity verifier compared an MTIME-ORDERED render — it could not pass for any scope with more than two entries

### DIFF
--- a/claudedocs/plan-cairn-phase1-cutover.md
+++ b/claudedocs/plan-cairn-phase1-cutover.md
@@ -603,7 +603,7 @@ answer. A green from an unvalidated instrument is a claim about the instrument.
 
 | instrument | negative control | positive control |
 |---|---|---|
-| `verify-byte-identity.sh` | one entry mutated by a single character → **FAIL, naming the scope** | identical stores → **PASS**, printing `raw-diff-lines`/`store-root-lines` beside the verdict |
+| `verify-byte-identity.sh` | one entry mutated by a single character → **FAIL, naming the scope**; the same mutation under a shuffled mtime order → still FAIL; an entry on one side only → FAIL **naming the ref** | identical stores → **PASS**; identical stores whose entry-file **mtimes are in a different order** → **PASS** (the mtime-ordering red), printing `raw-diff-lines`/`store-root-lines`/`index-order-lines`/`entries` beside the verdict |
 | the backup precondition | absent CronJob, absent `kubectl`, unparseable JSON, unparseable timestamp, and a `lastSuccessfulTime` that is **absent** → all refuse with their own sentence | a fresh timestamp passes and prints the measured age beside the ceiling; the boundary is measured from **both** sides (35.5 h passes, 36.5 h refuses) |
 | the write-route probe | a `405 read-only` server → reported as an **operator** problem | a `400 bad-request` server → reported as deployed. The probe body is `{}`, refused by the server's validator *before* any ref is resolved, so it cannot write |
 | the freeze | `probe_writable` returns `writable` at 0644 and `refused` at 0444, on the same file, twice | a partially-applied freeze (one file left writable) exits 16 **and** restores every mode bit |

--- a/scripts/cairn-cutover.py
+++ b/scripts/cairn-cutover.py
@@ -1550,13 +1550,39 @@ def _acceptance(args: argparse.Namespace, cache_dir: Path) -> int:
     about the push and this is a claim about the STATE.
 
     `verify-byte-identity.sh` is then run unmodified over every scope. Its own
-    header documents the two controls that make its green meaningful, and its
-    PASS lines print `raw-diff-lines` beside the verdict, decomposed into
-    `store-root-lines` + `host-lines` + `snapshot-block-lines` and summed as
-    `accounted-for`, so a reader can see the canonicalisation was spent where it
-    claims. 🔴 THREE named differences, not one: this sentence used to name only
-    the store root, which was already false when `host:` shipped and is exactly
-    the difference that made that script permanently red.
+    header documents the controls that make its green meaningful, and its PASS
+    lines print `raw-diff-lines` beside the verdict, decomposed into
+    `store-root-lines` + `host-lines` + `snapshot-block-lines` +
+    `index-order-lines` and summed as `accounted-for`, so a reader can see the
+    canonicalisation was spent where it claims. 🔴 FOUR named differences, not
+    one: this sentence used to name only the store root, which was already
+    false when `host:` shipped, and it still named three after `index-order`
+    joined — each omission being exactly the kind of difference that made that
+    script permanently red.
+
+    🔴 IT NO LONGER COMPARES THE WHOLE-SCOPE DIGEST, AND P4's READING CHANGES
+    WITH IT. The reader's index is newest-first by entry-file MTIME and the
+    digest's one featured body is chosen the same way, while the transport
+    (`seed.sh`: `rsync` to a stage, `tar` into the pod) carries no mtime — so
+    the old whole-scope `cmp` failed on stores that were byte-identical
+    (measured 2026-09-01 against the live pod: `scopes=5 pass=1 fail=4`, the
+    lone PASS being the only two-entry scope). It now compares, per scope, the
+    `mode=list` render with its index ROWS sorted, the entry SET via `comm`,
+    and then EACH entry's own single-ref render. A `FAIL … entry SET differs`
+    names the refs.
+
+    ⚠ THE SET ARM IS AN ACCEPTANCE CHECK, AND IT IS ONLY ONE HERE. After this
+    cutover the pod is canonical and each host's store is a read-through cache
+    that may legitimately lag — measured the same day, scope `devrc` at 26
+    entries locally against 29 on the pod, with nothing wrong. Run at P4,
+    immediately after the push, a set difference means the push was lossy; run
+    at an arbitrary moment it may only mean the cache is behind. The arm is
+    deliberately not weakened for that: a check that tolerated a missing entry
+    could not detect a half-copied seed, which is the one thing P4 exists for.
+
+    ⚠ AND IT IS NOW N+1 REQUESTS PER SCOPE, not 1. A 50-entry scope issues 51.
+    The `timeout=600` below is what bounds that; the whole real store measured
+    at ~400 entries, and one local `--ref` render costs ~73 ms.
     """
     refreshed = run(
         [sys.executable, str(CAIRN), "--cache", str(cache_dir), "sync"], timeout=120

--- a/scripts/subsystem-store-api/README.md
+++ b/scripts/subsystem-store-api/README.md
@@ -39,7 +39,7 @@ Replication happens over this API; those tests are untouched.
 | `Dockerfile` | image, built from the **repo root** as context (the modules live in `scripts/lib`) |
 | `build-push.sh` | build + push to Harbor. Refuses to push if `/data` in the image is non-empty |
 | `seed.sh` | `rsync` the local store into a stage, optionally `tar`-push it into the pod. Never writes to the source |
-| `verify-byte-identity.sh` | the phase-1 acceptance comparator: pod digest vs local CLI digest, per scope |
+| `verify-byte-identity.sh` | the phase-1 acceptance comparator, per scope: the `mode=list` render (index rows as a **sorted set**), the entry **set** by `comm`, then **each entry's** own single-ref render |
 
 Manifests: `homelab-talos` → `clusters/homelab/apps/subsystem-store/`.
 
@@ -330,20 +330,53 @@ client identity. See "Rate limit, lockout and the client address" below.
 ⚠ `verify-byte-identity.sh` prints a `diff` on failure, and that diff is store
 content. Redirect it to a file on a shared terminal.
 
-## Why byte-identity is asserted "modulo THREE named differences"
+## Why byte-identity is asserted "modulo FOUR named differences"
 
 `render_text` prints `  store: <root>`, and the pod's root is `/data` while the
 workbench's is `~/.claude/analyze-service-index`. The streams therefore cannot be
 byte-identical, and a verifier that said they were would be lying.
 
-There are **three** such differences, not one, and the second is the one that
-made this script permanently red:
+There are **four** such differences, not one, and the second and fourth are the
+two that each made this script permanently red in turn:
 
 | difference | why it is legitimate | how it is canonicalised |
 |---|---|---|
 | `  store: <root>` | the pod serves a copy at a different path | rewritten to a fixed token **on both sides** |
 | `  host: <id>` | `store_host_line()` names the machine whose disk was read — the store is PER-HOST, and saying so is the entire point of the line | rewritten to a fixed token **on both sides** |
 | the `🔴 SNAPSHOT` block | a transport annotation the server prepends and the local CLI correctly does not emit | removed from the **remote** only |
+| the INDEX row **order** | the index is newest-first by entry-file **mtime**, and the transport (`rsync` to a stage, `tar` into the pod) does not carry mtime | index rows compared as a **sorted set** on both sides; everything else in the stream compared verbatim, in order |
+
+🔴 **The fourth is why it no longer compares the whole-scope digest at all.**
+The digest also picks its one featured BODY by mtime (`select_featured`'s
+most-recent fallback), so on a multi-entry scope two byte-identical stores
+render a different index order *and* a different featured entry. Measured
+2026-09-01 against the live pod: `scopes=5 pass=1 fail=4`, the lone PASS being
+the only two-entry scope, and the `cli` scope's entire unaccounted difference
+being one row's POSITION. Instead, per scope:
+
+1. the **`mode=list` render** — no body, so no mtime-selected featured entry —
+   with the index rows sorted and the rest compared verbatim;
+2. the **entry SET**, by `comm` over the refs the two index blocks list. A ref
+   on one side only FAILS and names it;
+3. **each entry's own bytes**, as its `--ref` / `?ref=` render — a narrowing
+   that prints no index, so it carries no order. There is no route serving raw
+   entry bytes; the API only ever returns renders.
+
+⚠ **A scope whose index PAGINATES is refused, not partly compared.** Past
+`LISTING_PAGE_SIZE` both the page membership and the ref column's width are
+mtime-derived, and the refs past page 1 are never read — so page 1 is not
+comparable and a PASS over it would be a partial check reported as a clean one.
+No scope in the store is near the cap today (largest measured: 50 entries).
+
+⚠ **The set arm is an acceptance check for the moment right after a push.**
+Post-cutover the pod is canonical and each host's store is a read-through cache
+that may legitimately lag — measured 2026-09-01, scope `devrc` at 26 entries
+locally against 29 on the pod, with nothing wrong. `cairn-cutover.py` runs this
+at P4, immediately after the push, which is where a set difference means the
+push was lossy. It is deliberately not weakened for the lagging-cache case: a
+check that shrugged at a missing entry could not detect a half-copied seed.
+
+⚠ **It is now N+1 requests per scope**, not 1 — a 50-entry scope issues 51.
 
 🔴 **`host:` was added late and nothing stripped it**, so every comparison
 between a workbench and a pod failed by construction — `verify: scopes=16 pass=0
@@ -365,18 +398,32 @@ that are the banner or are blank; it is stripped only if that run **contains**
 the banner, and a server that emits no banner (pre-0.3.0) has nothing removed.
 
 Beside the verdict the script prints how many lines differ **with no
-canonicalisation at all**, decomposed into the three causes and summed as
-`accounted-for`. A real pod-vs-workbench run reads `store-root-lines=2
-host-lines=2 snapshot-block-lines=2 accounted-for=6`; the three-line block in
+canonicalisation at all**, decomposed into the four causes and summed as
+`accounted-for`:
+
+```
+raw-diff-lines == store-root-lines + host-lines + snapshot-block-lines + index-order-lines
+```
+
+🔴 **The counts are SUMS over every stream compared for the scope** — one
+scope-level `mode=list` render plus one single-ref render per entry — so
+against a pod-shaped remote `store-root-lines` reads `2 * (1 + entries)`, not a
+flat 2. `entries=` is printed for exactly that reason and one more: a scope
+that compared no bodies must be readable as one, the same rule `drift-check.sh`
+follows by printing links EXAMINED beside links dangling.
+
+`index-order-lines` is **measured, not assumed** — it is the diff reduction the
+row sort actually bought (differing lines after the `store:`/`host:`/snapshot
+canonicalisation, minus what still differs once the rows are sorted). A rule
+that erased a difference without a matching count would widen the blind spot
+rather than the gate, which is why it joined the sum in the same commit as the
+sort. The three-line block in
 `test_a_POD_SHAPED_remote_PASSES_when_only_the_THREE_permitted_lines_differ` is
 a SYNTHESISED skew, not a shape any deployed image has been seen to emit.
-Those numbers are EVIDENCE, not a second gate:
-they can only disagree if a `sed` erased a line that was none of the three,
-which the renderer cannot produce (no entry body renders at two-space
-indentation — measured across all four modes). Gating on them would be an
+
+Those numbers are EVIDENCE, not a second gate: gating on them would be an
 unreachable guard counted as coverage. But every canonicalisation rule **must**
-appear in that sum: a rule that erases a difference without a matching count
-widens the blind spot rather than the gate.
+appear in that sum.
 
 ## The token is a SET, and rotation is by overlap
 

--- a/scripts/subsystem-store-api/server.py
+++ b/scripts/subsystem-store-api/server.py
@@ -16,13 +16,23 @@ one thing this file adds to the body is a trailing newline, because the CLI's
 `print()` adds one and the phase-1 acceptance criterion is byte-identity with
 the CLI's stdout.
 
-⚠ THE BODY IS NOT PATH-INDEPENDENT. `render_text` prints `  store: <root>` —
-one line, and the only line in the whole render that names the store root. The
-pod serves from `/data` and the workbench reads `~/.claude/analyze-service-index`,
-so remote and local bytes CANNOT be identical on that line and byte-identity has
-to be asserted modulo exactly it. `verify-byte-identity.sh` does that
-mechanically: it canonicalises that one line on both sides AND asserts the raw
-diff is exactly one line, so a second divergence cannot hide inside the excuse.
+⚠ THE BODY IS NOT PATH-INDEPENDENT, AND IT IS NOT ORDER-INDEPENDENT EITHER.
+`render_text` prints `  store: <root>` and `  host: <id>`; the pod serves from
+`/data` under a pod identity while the workbench reads
+`~/.claude/analyze-service-index` under its own, so remote and local bytes
+CANNOT be identical on those two lines. The server also prepends the `SNAPSHOT`
+block, which the local CLI correctly does not emit. And the INDEX is ordered
+newest-first by entry-file MTIME — metadata the transport does not carry — so
+two byte-identical stores render their rows in a different ORDER and (in the
+default digest) feature a different entry.
+
+`verify-byte-identity.sh` asserts identity modulo exactly those FOUR
+differences, mechanically: it canonicalises the two lines on both sides, strips
+the measured snapshot block from the remote, compares the index rows as a
+SORTED set, and decomposes the raw diff into the four named causes so a fifth
+divergence cannot hide inside the excuse. ⚠ THIS PARAGRAPH USED TO SAY "one
+line … the raw diff is exactly one line", which was already false when `host:`
+shipped and stayed false through two more causes.
 
 PHASE 1 SCOPE — read-only, cluster-internal, no ingress
 -------------------------------------------------------

--- a/scripts/subsystem-store-api/verify-byte-identity.sh
+++ b/scripts/subsystem-store-api/verify-byte-identity.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Phase-1 acceptance criterion: the pod's digest is the local CLI's digest, for
+# Phase-1 acceptance criterion: the pod's store is the local CLI's store, for
 # EVERY scope (proposal §4 phase 1, §5 "byte-identity … `cmp`, not eyeballing").
 #
 # ⚠ IT CANNOT BE A BARE `cmp`, AND SAYING SO IS THE POINT.
@@ -11,36 +11,88 @@
 #
 # and the server prepends a transport annotation (the SNAPSHOT block) that the
 # local CLI correctly does not emit. So the two byte streams are provably NOT
-# identical, and a verifier that reported them identical would be lying. What is
-# claimed, precisely:
+# identical, and a verifier that reported them identical would be lying.
 #
-#   after replacing THOSE TWO LINES with a fixed token on both sides and
-#   removing the remote's SNAPSHOT block, `cmp` reports the streams
-#   byte-identical.
+# 🔴 AND IT CANNOT COMPARE THE WHOLE-SCOPE DIGEST AT ALL — THAT IS THE SECOND
+# THING THAT MADE THIS SCRIPT PERMANENTLY RED, AFTER `host:`.
+# `subsystem_recall` orders its INDEX **newest-first by entry-file mtime**, and
+# picks the digest's one featured BODY the same way (`select_featured`'s
+# most-recent fallback). The transport does not preserve mtime — `seed.sh`
+# `rsync`s into a stage and `tar`s that into the pod — so two stores holding
+# byte-identical entries render their index in a DIFFERENT ORDER and feature a
+# DIFFERENT entry. MEASURED 2026-09-01 against the live pod, store
+# `~/.claude/analyze-service-index`, over a `kubectl port-forward`:
 #
-# 🔴 THE `host:` RULE IS THE ONE THAT WAS MISSING, AND ITS ABSENCE MADE THIS
-# SCRIPT PERMANENTLY RED. `store_host_line()` shipped when the store became
-# PER-HOST; it names THIS machine, so it differs between the workbench and the
-# pod BY CONSTRUCTION and no run of this script could ever pass again
-# (`verify: scopes=16 pass=0 fail=16` on a store whose content was identical).
-# `claude/RULES.md`: a permanently-red gate is worse than no gate.
+#     FAIL scope=devrc            raw-diff-lines=45   accounted-for=6
+#     FAIL scope=cli              raw-diff-lines=8    accounted-for=6
+#     PASS scope=storage-resolver (2 entries)
+#     FAIL scope=homelab-infra    raw-diff-lines=108  accounted-for=6
+#     FAIL scope=datapacket-talos raw-diff-lines=336  accounted-for=6
+#
+# The `cli` scope is the clean isolation — its index ROWS were identical and the
+# only unaccounted difference was one row's POSITION. Every passing scope had 2
+# entries; every failing one had more. `claude/RULES.md`: a permanently-red gate
+# is worse than no gate.
+#
+# 🔴 SO THE CLAIM IS RESTATED AT THE LEVEL IT CAN HOLD. Byte-identity of the
+# RENDER was always a proxy; what phase 1 actually needs is that the pod holds
+# the same entries, with the same bytes. Both halves are compared, per scope:
+#
+#   1. THE SCOPE-LEVEL RENDER, in `mode=list` — no body, so no mtime-selected
+#      featured entry — with the index ROWS compared as a SORTED set and the
+#      rest of the stream compared verbatim. That covers the prose, the status
+#      line, the malformed-file block, the empty-scope notice, and each row's
+#      own content (ref, nuance count, sensitivity, the `🔴 N OPEN` badge).
+#   2. THE ENTRY SET: the refs the two index blocks list, compared with `comm`.
+#      A ref on one side and not the other FAILS and NAMES it.
+#   3. EACH ENTRY'S BYTES, as its own `--ref` / `?ref=` render — a narrowing
+#      that prints no index at all, so it carries no order. There is NO route
+#      serving raw entry bytes; the API only ever returns renders, so "the
+#      entry's bytes" is realised as "the entry's own single-ref render".
+#
+# What is claimed, precisely:
+#
+#   after replacing THOSE TWO LINES with a fixed token on both sides, removing
+#   the remote's SNAPSHOT block, and comparing the index rows as a set rather
+#   than as a sequence, `cmp` reports every compared stream byte-identical —
+#   and the entry sets are equal.
+#
+# 🔴 THE `host:` RULE WAS THE FIRST HALF OF THE RED. `store_host_line()` shipped
+# when the store became PER-HOST; it names THIS machine, so it differs between
+# the workbench and the pod BY CONSTRUCTION and no run of this script could ever
+# pass again (`verify: scopes=16 pass=0 fail=16` on a store whose content was
+# identical). Closing it left the ordering half above, which is why a fix that
+# addressed only `host:` still reported `scopes=5 pass=1 fail=4`.
+#
+# 🔴 WHAT THIS SCRIPT IS AN ACCEPTANCE CHECK *FOR*, AND WHEN IT IS MEANINGFUL.
+# After the phase-1 cutover the POD is canonical and each host's local store is
+# a read-through CACHE that may legitimately lag: MEASURED 2026-09-01, scope
+# `devrc` held 26 entries locally and 29 on the pod, with nothing wrong. So an
+# entry-set difference is an ORDINARY OPERATIONAL STATE in general, and this
+# script is only an acceptance check IMMEDIATELY AFTER A SEED/PUSH — which is
+# exactly where `cairn-cutover.py` runs it (P4). Run it at any other moment and
+# a FAIL on the set arm may be telling you the cache is behind, not that the
+# push was lossy. The set arm is NOT weakened to accommodate that: a check that
+# tolerated a missing entry could not detect a half-copied seed, which is the
+# one thing P4 exists to catch.
 #
 # Beside that verdict every PASS line prints its ACCOUNTING: `raw-diff-lines`
-# (how many lines differ with NO canonicalisation at all) decomposed into
-# `store-root-lines`, `host-lines` and `snapshot-block-lines`, plus the
+# (how many lines differ with NO canonicalisation at all, summed over every
+# stream compared for the scope) decomposed into `store-root-lines`,
+# `host-lines`, `snapshot-block-lines` and `index-order-lines`, plus the
 # `accounted-for` sum — so a reader can see the excuse was spent on exactly the
-# lines it claims (0/0/0 same-root same-host, 2/2/2 pod-vs-workbench).
+# lines it claims. `entries=` says how many per-entry comparisons were made, so
+# a scope that compared no bodies is visible rather than silently green.
 # ⚠ Those numbers are EVIDENCE, not a second gate, and the body of the script
-# says why: they can only disagree if `sed` erased a line that was none of the
-# three, which the renderer cannot produce. Gating on them would be an
-# unreachable guard counted as coverage.
+# says why. Gating on them would be an unreachable guard counted as coverage.
 #
 # 🔴 CONTROLS. A comparator that always says PASS is indistinguishable from one
 # that works, so this script is exercised BOTH ways in
 # `scripts/tests/test_subsystem_store_api.py::TestByteIdentityVerifier`:
 # identical stores -> PASS, one entry mutated by a single character -> FAIL with
-# the scope named. Do not trust a green run of this script that has not been
-# preceded by a red one.
+# the scope named, a shuffled-mtime store -> PASS, an extra entry on one side ->
+# FAIL naming the ref, and a mutation UNDER a shuffle -> FAIL. Do not trust a
+# green run of this script that has not been preceded by a red one.
 #
 # Usage:
 #   verify-byte-identity.sh --store <local-root> --url http://127.0.0.1:8102 \
@@ -63,13 +115,20 @@ SCOPES=()
 CANON='  store: <canonicalised>'
 CANON_HOST='  host: <canonicalised>'
 
+# The header block above, printed for `--help`. Derived rather than a hardcoded
+# line range: the range was `2,51p` and this header has since grown twice, so a
+# literal would silently truncate the argument a reader came for.
+print_help() {
+  awk 'NR == 1 { next } /^#/ { print; next } { exit }' "$0"
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --store)      STORE="${2:?}"; shift 2 ;;
     --url)        URL="${2:?}"; shift 2 ;;
     --token-file) TOKEN_FILE="${2:?}"; shift 2 ;;
     --scope)      SCOPES+=("${2:?}"); shift 2 ;;
-    -h|--help)    sed -n '2,51p' "$0"; exit 0 ;;
+    -h|--help)    print_help; exit 0 ;;
     *) echo "verify: unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -100,8 +159,139 @@ fi
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
+# CF-Connecting-IP keys the server's per-client rate limiter — but ONLY when
+# the request arrives from a peer in `$SUBSYSTEM_STORE_TRUSTED_PROXIES`.
+#
+# ⚠ ON THIS SCRIPT'S USUAL PATH IT IS INERT, AND AN EARLIER VERSION OF THIS
+# COMMENT CLAIMED THE OPPOSITE ("REQUIRED by the server … it must identify
+# itself"). A port-forward presents peer `127.0.0.1` — measured out of the
+# pod's own /proc/net/tcp, both ends loopback, because the kubelet enters the
+# pod's network namespace — which is not the allowlisted address, so the
+# server ignores this header and buckets the request under the peer. Nothing
+# here depends on it and omitting it would work exactly as well.
+#
+# It is still sent, deliberately: point `--url` at the nebula gateway instead
+# of a port-forward and the peer IS trusted, at which point this header
+# becomes the client identity and sending an explicit one is correct. One
+# invocation that behaves the same on both paths beats two.
+#
+# 🔴 The header is only ever TRUSTED because Cloudflare is the sole PUBLIC
+# ingress AND the peer is a named proxy. Neither half alone is enough — that
+# was the phase-1.5b defect.
+#
+# ⚠ THIS IS NOW SENT ONCE PER ENTRY, NOT ONCE PER SCOPE. The per-entry arm
+# issues one request per ref, so a 50-entry scope is 51 requests where it used
+# to be 1. Against the pod that is bucketed under one client: if the limiter is
+# ever tightened, THIS is the caller that will hit it first.
+HTTP_CODE=""
+fetch_remote() {  # $1 = scope, $2 = out file, rest: curl --data-urlencode args
+  local scope="$1" out="$2"
+  shift 2
+  HTTP_CODE=$(curl -sS -o "$out" -D "$tmp/hdr" -w '%{http_code}' \
+                -H "Authorization: Bearer $TOKEN" \
+                -H "CF-Connecting-IP: ${CLIENT_IP:-127.0.0.1}" \
+                --get "$@" \
+                "$URL/api/v1/recall/$scope" < /dev/null || echo "000")
+}
+
+# 🔴 THE SAME TWO SEDS ON BOTH SIDES. A canonicalisation applied to one stream
+# only is not a canonicalisation, it is an edit — and the `store:`/`host:`
+# rules are only honest because the local render is rewritten too.
+#
+# 🔴 THE SNAPSHOT BLOCK IS A TRANSPORT ANNOTATION, NOT PART OF THE REPORT.
+# The server prepends one line dating the COPY it serves (plus a blank
+# separator) to every report — see `server.snapshot_freshness`, and the README
+# for the measured incident that put it there. The local CLI reads the
+# authoritative store and correctly emits no such line, so leaving it in would
+# make this script FAIL on every scope for a difference that is not about the
+# render at all — the same excuse the two lines above already earn.
+#
+# 🔴 THE BLOCK IS MEASURED, NOT ASSUMED TO BE TWO LINES — AND THIS IS
+# HARDENING FOR A SKEW THAT HAS NOT BEEN OBSERVED, NOT A FIX FOR A DEFECT.
+# ⚠ THE PREVIOUS RULE WAS NOT BROKEN. An anchored `,+1d` deletes the banner
+# AND its blank separator, which is exactly the arrangement THIS TREE's
+# `server.py` emits. Do not read this comment as evidence against it and do not
+# go looking for the incident: there wasn't one.
+#
+# Two structural reasons to measure the length anyway, neither of which needs
+# a failure to have happened:
+#   * THE LENGTH IS NOT THIS CHECKOUT'S TO ASSUME. This script does not
+#     compare against this tree's `server.py`; it compares against whatever
+#     image is DEPLOYED, and a fixed-size delete is a bet that those two are
+#     the same version. Nothing here can check that bet.
+#   * DELETED MUST EQUAL COUNTED. `,+1d` removes lines that never enter the
+#     accounting, so its removals could not be reconciled against `raw`; a
+#     measured length can. That is the whole point of the sum, and a rule
+#     exempt from it is the blind spot the sum exists to close.
+#
+# So the block is defined as the run of lines at the HEAD of the remote stream
+# that are the banner or are blank, its LENGTH is measured, and exactly that
+# many lines are dropped.
+#
+# Two narrowings keep this from reaching into a report body:
+#   * it is a HEAD run only — a banner appearing anywhere else is left alone
+#     and will fail the comparison, which is correct;
+#   * the run must CONTAIN the banner, so a remote that merely starts with a
+#     blank line has nothing stripped (that is a real difference).
+# An image WITHOUT the stamp is therefore unaffected — the run is empty and
+# nothing is deleted — which is what keeps this runnable against 0.2.0.
+P_RAW=0; P_STORE=0; P_HOST=0; P_SNAP=0; P_BLOCK=0
+canon_pair() {  # $1 = local raw, $2 = remote raw, $3 = out prefix -> $3.l, $3.r
+  local l="$1" r="$2" o="$3"
+  P_RAW=$(diff "$l" "$r" | grep -c '^[<>]' || true)
+  P_STORE=$(diff "$l" "$r" | grep -c '^[<>]   store: ' || true)
+  P_HOST=$(diff "$l" "$r" | grep -c '^[<>]   host: ' || true)
+  P_SNAP=$(grep -c '^🔴 SNAPSHOT, NOT THE SOURCE' "$r" || true)
+  P_BLOCK=$(awk '
+    /^🔴 SNAPSHOT, NOT THE SOURCE/ { n++; seen = 1; next }
+    $0 == ""                       { n++; next }
+                                   { exit }
+    END { print (seen ? n + 0 : 0) }
+  ' "$r")
+
+  local canon_seds=(-e "s|^  store: .*|$CANON|" -e "s|^  host: .*|$CANON_HOST|")
+  sed "${canon_seds[@]}" "$l" > "$o.l"
+  local remote_seds=("${canon_seds[@]}")
+  # `1,0d` is a sed error, not a no-op, so the delete is only added when the
+  # block is non-empty.
+  if [[ "$P_BLOCK" -gt 0 ]]; then
+    remote_seds=(-e "1,${P_BLOCK}d" "${remote_seds[@]}")
+  fi
+  sed "${remote_seds[@]}" "$r" > "$o.r"
+}
+
+# 🔴 SPLIT THE INDEX ROWS OUT OF THE STREAM — the ONE region whose order is a
+# function of filesystem metadata the transport does not promise.
+#
+# `render_listing` emits `["", <head>, *rows]` and then AT MOST one parenthesised
+# notice (a page-past-the-end, or "N more entries NOT LISTED"), so a row is a
+# line that (a) follows the `INDEX (` head, (b) precedes the next blank line,
+# and (c) does not start with `  (`. Everything else — the caveat, the status
+# line, the MALFORMED block, the empty-scope notice, the head itself with its
+# COUNTS — stays in the frame and is compared VERBATIM, in order.
+#
+# 🔴 THE NARROWING IS THE POINT. Sorting the whole stream would make this
+# comparison a multiset over lines, which passes when a line moves between
+# sections. Only the rows are reordered, because only the rows are ordered by
+# mtime.
+split_index() {  # $1 = in, $2 = frame out, $3 = rows out
+  : > "$2"; : > "$3"
+  awk -v frame="$2" -v rows="$3" '
+    /^INDEX \(/      { inb = 1; print > frame; next }
+    inb && $0 == ""  { inb = 0; print > frame; next }
+    inb && /^  \(/   { print > frame; next }
+    inb              { print > rows;  next }
+                     { print > frame }
+  ' "$1"
+}
+
+diff_lines() {  # $1, $2 -> count of differing lines
+  diff "$1" "$2" | grep -c '^[<>]' || true
+}
+
 pass=0
 fail=0
+entries_compared=0
 
 for scope in "${SCOPES[@]}"; do
   local_out="$tmp/local.$scope"
@@ -110,8 +300,12 @@ for scope in "${SCOPES[@]}"; do
   # Local: the CLI, unmodified. `--scope` is explicit, which also disables the
   # repo focus window — the pod has no repo to derive one from, so comparing
   # against a windowed local run would compare two different questions.
+  #
+  # `--list` is the INDEX ONLY. The default digest would print one entry BODY
+  # chosen by mtime, which is the very metadata the transport does not carry.
   set +e
-  python3 "$RECALL" --store "$STORE" --scope "$scope" > "$local_out" 2>"$tmp/local.err"
+  python3 "$RECALL" --store "$STORE" --scope "$scope" --list \
+      > "$local_out" 2>"$tmp/local.err"
   rc_local=$?
   set -e
   # exit 3 is "nothing readable"; the bytes are still a legitimate render and the
@@ -121,31 +315,9 @@ for scope in "${SCOPES[@]}"; do
     fail=$((fail + 1)); continue
   fi
 
-  # CF-Connecting-IP keys the server's per-client rate limiter — but ONLY when
-  # the request arrives from a peer in `$SUBSYSTEM_STORE_TRUSTED_PROXIES`.
-  #
-  # ⚠ ON THIS SCRIPT'S USUAL PATH IT IS INERT, AND AN EARLIER VERSION OF THIS
-  # COMMENT CLAIMED THE OPPOSITE ("REQUIRED by the server … it must identify
-  # itself"). A port-forward presents peer `127.0.0.1` — measured out of the
-  # pod's own /proc/net/tcp, both ends loopback, because the kubelet enters the
-  # pod's network namespace — which is not the allowlisted address, so the
-  # server ignores this header and buckets the request under the peer. Nothing
-  # here depends on it and omitting it would work exactly as well.
-  #
-  # It is still sent, deliberately: point `--url` at the nebula gateway instead
-  # of a port-forward and the peer IS trusted, at which point this header
-  # becomes the client identity and sending an explicit one is correct. One
-  # invocation that behaves the same on both paths beats two.
-  #
-  # 🔴 The header is only ever TRUSTED because Cloudflare is the sole PUBLIC
-  # ingress AND the peer is a named proxy. Neither half alone is enough — that
-  # was the phase-1.5b defect.
-  code=$(curl -sS -o "$remote_out" -D "$tmp/hdr" -w '%{http_code}' \
-           -H "Authorization: Bearer $TOKEN" \
-           -H "CF-Connecting-IP: ${CLIENT_IP:-127.0.0.1}" \
-           "$URL/api/v1/recall/$scope" || echo "000")
-  if [[ "$code" != "200" ]]; then
-    echo "FAIL scope=$scope remote HTTP $code (body: $(head -c 120 "$remote_out"))"
+  fetch_remote "$scope" "$remote_out" --data-urlencode "mode=list"
+  if [[ "$HTTP_CODE" != "200" ]]; then
+    echo "FAIL scope=$scope remote HTTP $HTTP_CODE (body: $(head -c 120 "$remote_out"))"
     fail=$((fail + 1)); continue
   fi
 
@@ -155,121 +327,179 @@ for scope in "${SCOPES[@]}"; do
     fail=$((fail + 1)); continue
   fi
 
-  # Claim 2's EVIDENCE, computed before claim 1 so a green cmp is never printed
-  # without it: how many lines differ with no canonicalisation at all, and how
-  # many of those each named cause accounts for.
-  #
-  # ⚠ THESE ARE REPORTED, NOT GATED, AND THAT IS DELIBERATE. `raw` can only
-  # exceed the sum below if the canonicalisation erased a difference that was
-  # none of the three named causes — and `sed` only rewrites lines matching
-  # `^  store: ` or `^  host: `, which MEASURED against the renderer no entry
-  # body can produce (every body line is indented FOUR OR MORE spaces — the
-  # section headings at four, their content at six, and a body line that itself
-  # begins `  host: ` renders at eight; checked in all four modes: default,
-  # `--ref`, `--search`, `--list`). So a gate on `raw -eq $accounted` could
-  # never fire: it would be an unreachable guard counted as coverage, which
-  # `claude/RULES.md` calls out by name. The numbers are printed instead, so a
-  # reader can see that the canonicalisation excuse was spent on exactly the
-  # lines it claims.
-  #
-  # 🔴 EVERY CANONICALISATION RULE MUST APPEAR IN THIS SUM. A rule that erases a
-  # difference without a matching count widens the blind spot instead of the
-  # gate — which is why `host_lines` was added in the same commit as the `host:`
-  # sed, and why the snapshot block is counted by the number of lines actually
-  # deleted rather than assumed to be two.
-  raw=$(diff "$local_out" "$remote_out" | grep -c '^[<>]' || true)
-  store_lines=$(diff "$local_out" "$remote_out" | grep -c '^[<>]   store: ' || true)
-  host_lines=$(diff "$local_out" "$remote_out" | grep -c '^[<>]   host: ' || true)
-
-  # 🔴 THE SNAPSHOT BLOCK IS A TRANSPORT ANNOTATION, NOT PART OF THE REPORT.
-  # The server prepends one line dating the COPY it serves (plus a blank
-  # separator) to every report — see `server.snapshot_freshness`, and the README
-  # for the measured incident that put it there. The local CLI reads the
-  # authoritative store and correctly emits no such line, so leaving it in would
-  # make this script FAIL on every scope for a difference that is not about the
-  # render at all — the same excuse the two lines above already earn.
-  #
-  # 🔴 THE BLOCK IS MEASURED, NOT ASSUMED TO BE TWO LINES — AND THIS IS
-  # HARDENING FOR A SKEW THAT HAS NOT BEEN OBSERVED, NOT A FIX FOR A DEFECT.
-  # ⚠ THE PREVIOUS RULE WAS NOT BROKEN. An anchored `,+1d` deletes the banner
-  # AND its blank separator, which is exactly the arrangement THIS TREE's
-  # `server.py` emits, and `test_every_permitted_difference_is_ACCOUNTED_FOR_
-  # not_merely_small` passes on it — before this change and after. Do not read
-  # this comment as evidence against it and do not go looking for the incident:
-  # there wasn't one. The retraction is recorded in this branch's history.
-  #
-  # Two structural reasons to measure the length anyway, neither of which needs
-  # a failure to have happened:
-  #   * THE LENGTH IS NOT THIS CHECKOUT'S TO ASSUME. This script does not
-  #     compare against this tree's `server.py`; it compares against whatever
-  #     image is DEPLOYED, and a fixed-size delete is a bet that those two are
-  #     the same version. Nothing here can check that bet.
-  #   * DELETED MUST EQUAL COUNTED. `,+1d` removes lines that never enter the
-  #     accounting above, so its removals could not be reconciled against `raw`;
-  #     a measured length can. That is the whole point of the sum, and a rule
-  #     exempt from it is the blind spot the sum exists to close.
-  #
-  # So the block is defined as the run of lines at the HEAD of the remote stream
-  # that are the banner or are blank, its LENGTH is measured, and exactly that
-  # many lines are dropped.
-  #
-  # Two narrowings keep this from reaching into a report body:
-  #   * it is a HEAD run only — a banner appearing anywhere else is left alone
-  #     and will fail the comparison, which is correct;
-  #   * the run must CONTAIN the banner, so a remote that merely starts with a
-  #     blank line has nothing stripped (that is a real difference).
-  # An image WITHOUT the stamp is therefore unaffected — the run is empty and
-  # nothing is deleted — which is what keeps this runnable against 0.2.0.
-  snapshot_lines=$(grep -c '^🔴 SNAPSHOT, NOT THE SOURCE' "$remote_out" || true)
-  snapshot_block=$(awk '
-    /^🔴 SNAPSHOT, NOT THE SOURCE/ { n++; seen = 1; next }
-    $0 == ""                       { n++; next }
-                                   { exit }
-    END { print (seen ? n + 0 : 0) }
-  ' "$remote_out")
-
-  # 🔴 The SAME two seds on both sides. A canonicalisation applied to one stream
-  # only is not a canonicalisation, it is an edit — and the `store:`/`host:`
-  # rules are only honest because the local render is rewritten too.
-  canon_seds=(-e "s|^  store: .*|$CANON|" -e "s|^  host: .*|$CANON_HOST|")
-  sed "${canon_seds[@]}" "$local_out" > "$tmp/l.canon"
-  remote_seds=("${canon_seds[@]}")
-  # `1,0d` is a sed error, not a no-op, so the delete is only added when the
-  # block is non-empty.
-  if [[ "$snapshot_block" -gt 0 ]]; then
-    remote_seds=(-e "1,${snapshot_block}d" "${remote_seds[@]}")
-  fi
-  sed "${remote_seds[@]}" "$remote_out" > "$tmp/r.canon"
-
-  # Printed beside `raw` so the reader does the subtraction once, here, instead
-  # of in their head on every PASS line.
-  accounted=$((store_lines + host_lines + snapshot_block))
-
   rev=$(awk 'tolower($1)=="x-store-revision:"{print $2}' "$tmp/hdr" | tr -d '\r' | tail -1)
 
-  # PASS is `cmp` on the canonicalised streams — the byte-identity claim itself.
-  # The counts ride along as evidence: 0/0/0 is the case where both sides read
-  # the SAME root on the SAME host (a local self-check), 2/2/2 is
-  # pod-vs-workbench.
-  if cmp -s "$tmp/l.canon" "$tmp/r.canon"; then
-    # `snapshot-line` rides along as EVIDENCE, exactly like the counts above
-    # and gated for the same reason they are not: a `0` here means the remote
-    # served no stamp, which is true and expected against a pre-0.3.0 image, so
-    # failing on it would make this script permanently red until a deploy lands
-    # (RULES.md). Printed so a reader can see WHICH of the two the green means.
-    echo "PASS scope=$scope bytes=$(wc -c <"$tmp/l.canon") raw-diff-lines=$raw store-root-lines=$store_lines host-lines=$host_lines snapshot-line=$snapshot_lines snapshot-block-lines=$snapshot_block accounted-for=$accounted revision=${rev:-unknown}"
-    pass=$((pass + 1))
-  else
-    echo "FAIL scope=$scope canonicalised-cmp=$(cmp -s "$tmp/l.canon" "$tmp/r.canon" && echo same || echo differs) raw-diff-lines=$raw store-lines=$store_lines host-lines=$host_lines snapshot-block-lines=$snapshot_block accounted-for=$accounted"
+  # 🔴 A PAGINATED INDEX IS REFUSED, NOT PARTIALLY COMPARED. Past
+  # `LISTING_PAGE_SIZE` the reader pages the index, and BOTH the page membership
+  # and the ref column's width (`max(len(ref) for e in report.listing)`, computed
+  # PER PAGE) are then functions of the mtime order. Two byte-identical stores
+  # would put different refs on page 1 and pad them to different widths, so page
+  # 1 is not comparable and the refs beyond it were never read at all. Comparing
+  # page 1 alone would be a partial check reported as a clean one; this says so
+  # instead. Enlarging the reader's page cap, or teaching this script to walk
+  # every page and normalise the padding, are the two ways out — neither is
+  # needed by any scope in the store today (largest measured: 50 entries).
+  paged=$(( $(grep -cE '^INDEX \(.*\(page [0-9]+ of [0-9]+\):$' "$local_out" || true) \
+          + $(grep -cE '^INDEX \(.*\(page [0-9]+ of [0-9]+\):$' "$remote_out" || true) ))
+  if [[ "$paged" -gt 0 ]]; then
+    echo "FAIL scope=$scope index is PAGINATED — this comparator reads ONE index page, and both page membership and the ref column width are mtime-derived, so page 1 is not comparable and the rest was never read. Nothing about this scope was verified."
+    fail=$((fail + 1)); continue
+  fi
+
+  canon_pair "$local_out" "$remote_out" "$tmp/s"
+  raw=$P_RAW; store_lines=$P_STORE; host_lines=$P_HOST
+  snapshot_lines=$P_SNAP; snapshot_block=$P_BLOCK
+  bytes=$(wc -c <"$tmp/s.l")
+
+  split_index "$tmp/s.l" "$tmp/s.l.frame" "$tmp/s.l.rows"
+  split_index "$tmp/s.r" "$tmp/s.r.frame" "$tmp/s.r.rows"
+  LC_ALL=C sort "$tmp/s.l.rows" > "$tmp/s.l.rows.sorted"
+  LC_ALL=C sort "$tmp/s.r.rows" > "$tmp/s.r.rows.sorted"
+
+  # `$1` of a row is its ref — `listing_line` is `  <ref><pad>  <n> nuance …`.
+  # 🔴 THE SET IS TAKEN FROM THE INDEX, NEVER FROM `ls`. A `*.md` file the loader
+  # rejects (no `service:`) is a real file that is NOT indexed and is NOT
+  # `--ref`-addressable; a bare directory listing would demand a comparison the
+  # API cannot answer and report a difference that does not exist. MEASURED: a
+  # `README` sitting in a scope is correctly absent from both index blocks.
+  awk '{print $1}' "$tmp/s.l.rows" | LC_ALL=C sort > "$tmp/s.l.refs"
+  awk '{print $1}' "$tmp/s.r.rows" | LC_ALL=C sort > "$tmp/s.r.refs"
+
+  # 🔴 THE SET ARM RUNS FIRST, AND THAT ORDER IS LOAD-BEARING. The index head
+  # names the entry COUNT, so a set difference of unequal size would also fail
+  # the frame comparison below and a set difference of equal size would fail the
+  # row comparison — either way the set arm would be an unreachable guard
+  # reporting a message nobody ever sees. Running it first makes the NAMED ref
+  # the finding, which is the actionable one.
+  # LC_ALL=C on BOTH the sorts above and the `comm` here: `comm` re-checks the
+  # ordering it was promised, and a locale mismatch between the two makes it
+  # report "file is not in sorted order" — or, worse, silently miss a ref.
+  only_local="$(LC_ALL=C comm -23 "$tmp/s.l.refs" "$tmp/s.r.refs")"
+  only_remote="$(LC_ALL=C comm -13 "$tmp/s.l.refs" "$tmp/s.r.refs")"
+  if [[ -n "$only_local" || -n "$only_remote" ]]; then
+    n_only_local=$(printf '%s' "$only_local" | grep -c . || true)
+    n_only_remote=$(printf '%s' "$only_remote" | grep -c . || true)
+    echo "FAIL scope=$scope entry SET differs local-only=$n_only_local pod-only=$n_only_remote"
+    while IFS= read -r ref; do
+      if [[ -n "$ref" ]]; then echo "  ONLY ON THIS HOST: scope=$scope ref=$ref"; fi
+    done <<< "$only_local"
+    while IFS= read -r ref; do
+      if [[ -n "$ref" ]]; then echo "  ONLY ON THE POD:   scope=$scope ref=$ref"; fi
+    done <<< "$only_remote"
+    fail=$((fail + 1)); continue
+  fi
+
+  frame_diff=$(diff_lines "$tmp/s.l.frame" "$tmp/s.r.frame")
+  # ⚠ `rows_diff` IS NOT INDEPENDENT DETECTION, AND CLAIMING IT WOULD BE THE
+  # "reads as coverage while providing none" failure. Every field on a row is
+  # DERIVED from the entry body — the ref, the nuance count, the sensitivity,
+  # the `🔴 N OPEN` badge — so any difference it can see is also seen, a step
+  # later, by the per-entry arm. Its real job is the ACCOUNTING: `index_order`
+  # below is measured as the diff reduction the SORT bought, so a row
+  # comparison wired to a constant zero would fold a GENUINE row difference
+  # into the reorder excuse and print it as `accounted-for`. It also fails
+  # fast, before N per-entry requests, and attributes the difference to the
+  # index rather than to one body. `test_a_difference_VISIBLE_IN_THE_INDEX_ROW_
+  # is_reported_AS_ONE` pins that — on the count, not on the message, because
+  # a mutant that zeroes this still FAILS via the per-entry arm.
+  rows_diff=$(diff_lines "$tmp/s.l.rows.sorted" "$tmp/s.r.rows.sorted")
+  residual=$((frame_diff + rows_diff))
+
+  # 🔴 THE REORDER RULE IS COUNTED LIKE EVERY OTHER RULE — MEASURED, NOT
+  # ASSUMED. `index-order-lines` is the diff reduction the sort actually bought:
+  # differing lines AFTER the store/host/snapshot canonicalisation, minus what
+  # still differs once the rows are sorted. A rule that erases a difference
+  # without a matching count widens the blind spot instead of the gate, which is
+  # why `host_lines` was added in the same commit as the `host:` sed and why the
+  # snapshot block is counted by lines actually deleted.
+  #
+  # On a PASS the residual is 0 by construction, so `accounted-for` equals `raw`
+  # exactly. The clamp only ever bites on a FAIL, where the identity is not
+  # claimed anyway; a negative count in a sum labelled "accounted for" would be
+  # a reader-facing lie.
+  canon_diff=$(diff_lines "$tmp/s.l" "$tmp/s.r")
+  index_order=$((canon_diff - residual))
+  if (( index_order < 0 )); then index_order=0; fi
+
+  if [[ "$residual" -ne 0 ]]; then
+    accounted=$((store_lines + host_lines + snapshot_block + index_order))
+    echo "FAIL scope=$scope scope-level render differs (frame-lines=$frame_diff sorted-row-lines=$rows_diff) raw-diff-lines=$raw store-root-lines=$store_lines host-lines=$host_lines snapshot-block-lines=$snapshot_block index-order-lines=$index_order accounted-for=$accounted"
     # 🔴 `|| true` is load-bearing, not decoration. `diff` exits 1 when the files
     # differ — which is ALWAYS true on this branch — and under `set -o pipefail`
     # that status kills the whole script mid-loop, so the remaining scopes are
     # never compared and the summary line never prints. Measured: the first
     # negative-control run reported a FAIL and then simply stopped.
-    diff "$local_out" "$remote_out" | head -20 || true
-    fail=$((fail + 1))
+    diff "$tmp/s.l.frame" "$tmp/s.r.frame" | head -20 || true
+    diff "$tmp/s.l.rows.sorted" "$tmp/s.r.rows.sorted" | head -20 || true
+    fail=$((fail + 1)); continue
   fi
+
+  # --- Each entry's own bytes, as its own single-ref render ------------------
+  # A `--ref` run is a NARROWING: it prints that one entry in full and NO index,
+  # so nothing in this stream is ordered by mtime and a plain `cmp` is honest.
+  n_entries=0
+  entry_fail=""
+  while IFS= read -r ref; do
+    [[ -n "$ref" ]] || continue
+    el="$tmp/e.local"; er="$tmp/e.remote"
+    set +e
+    # `</dev/null`: this loop reads the ref list ON STDIN, so a child that read
+    # from stdin would eat the remaining refs and the loop would silently
+    # compare fewer entries than it listed.
+    python3 "$RECALL" --store "$STORE" --scope "$scope" --ref "$ref" \
+        > "$el" 2>"$tmp/local.err" < /dev/null
+    rc_entry=$?
+    set -e
+    if [[ $rc_entry -gt 3 ]]; then
+      entry_fail="local CLI exited $rc_entry for ref=$ref: $(head -1 "$tmp/local.err")"
+      break
+    fi
+    fetch_remote "$scope" "$er" --data-urlencode "ref=$ref"
+    if [[ "$HTTP_CODE" != "200" ]]; then
+      entry_fail="remote HTTP $HTTP_CODE for ref=$ref (body: $(head -c 120 "$er"))"
+      break
+    fi
+    if [[ ! -s "$el" || ! -s "$er" ]]; then
+      entry_fail="empty render for ref=$ref (local=$(wc -c <"$el")B remote=$(wc -c <"$er")B)"
+      break
+    fi
+    canon_pair "$el" "$er" "$tmp/e"
+    raw=$((raw + P_RAW))
+    store_lines=$((store_lines + P_STORE))
+    host_lines=$((host_lines + P_HOST))
+    snapshot_lines=$((snapshot_lines + P_SNAP))
+    snapshot_block=$((snapshot_block + P_BLOCK))
+    bytes=$((bytes + $(wc -c <"$tmp/e.l")))
+    if ! cmp -s "$tmp/e.l" "$tmp/e.r"; then
+      entry_fail="ref=$ref entry bytes differ ($(diff_lines "$tmp/e.l" "$tmp/e.r") canonicalised lines)"
+      cp "$tmp/e.l" "$tmp/e.fail.l"; cp "$tmp/e.r" "$tmp/e.fail.r"
+      break
+    fi
+    n_entries=$((n_entries + 1))
+  done < "$tmp/s.l.refs"
+
+  accounted=$((store_lines + host_lines + snapshot_block + index_order))
+
+  if [[ -n "$entry_fail" ]]; then
+    echo "FAIL scope=$scope $entry_fail"
+    if [[ -f "$tmp/e.fail.l" ]]; then
+      diff "$tmp/e.fail.l" "$tmp/e.fail.r" | head -20 || true
+      rm -f "$tmp/e.fail.l" "$tmp/e.fail.r"
+    fi
+    fail=$((fail + 1)); continue
+  fi
+
+  entries_compared=$((entries_compared + n_entries))
+  # `entries=` is EVIDENCE of the same kind as the counts, and for the same
+  # reason `drift-check.sh` prints links EXAMINED beside links dangling: a scope
+  # whose entry set is empty on both sides compares no bodies, and a green that
+  # compared nothing must be readable as one. `snapshot-line` likewise: a `0`
+  # means the remote served no stamp, which is true and expected against a
+  # pre-0.3.0 image, so failing on it would make this script permanently red
+  # until a deploy lands.
+  echo "PASS scope=$scope entries=$n_entries bytes=$bytes raw-diff-lines=$raw store-root-lines=$store_lines host-lines=$host_lines snapshot-line=$snapshot_lines snapshot-block-lines=$snapshot_block index-order-lines=$index_order accounted-for=$accounted revision=${rev:-unknown}"
+  pass=$((pass + 1))
 done
 
-echo "verify: scopes=${#SCOPES[@]} pass=$pass fail=$fail"
+echo "verify: scopes=${#SCOPES[@]} pass=$pass fail=$fail entries-compared=$entries_compared"
 [[ $fail -eq 0 ]] || exit 1

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -24,9 +24,13 @@ WHAT IS EXERCISED IN BOTH DIRECTIONS, IN-BAND
     near-miss-token watched to be rejected. An auth layer never seen to deny is
     not known to be an auth layer.
   * `TestByteIdentityVerifier` — the phase-1 acceptance comparator run against
-    identical stores (PASS) and against a store differing by ONE character
-    (FAIL, naming the scope). A comparator that always says PASS is
-    indistinguishable from one that works.
+    identical stores (PASS), against identical stores whose entry-file MTIMES
+    are in a different ORDER (PASS — the red it could not pass at all), and
+    against a store differing by ONE character, with and without that shuffle
+    (FAIL, naming the scope and the ref). A comparator that always says PASS is
+    indistinguishable from one that works, and order-independence bought by
+    comparing LESS is the failure mode the shuffled negative control exists to
+    catch.
   * `TestSeedIsNonDestructive` — the tree hasher is shown to CHANGE when the
     source is deliberately modified, before its "unchanged" verdict is believed.
 
@@ -3853,13 +3857,26 @@ def run_verify(*args: str) -> subprocess.CompletedProcess:
 # script must break these tests, not be absorbed by them. It is anchored on
 # `PASS` because the accounting identity is a claim about a run the comparator
 # called byte-identical; a FAIL line prints a different field set on purpose.
+#
+# 🔴 `entries=` AND `index-order-lines=` JOINED WHEN THE COMPARATOR STOPPED
+# COMPARING THE MTIME-ORDERED WHOLE-SCOPE DIGEST. The counts are now SUMS over
+# every stream compared for the scope — one scope-level `mode=list` render plus
+# one single-ref render per entry — so `store_root` reads `2 * (1 + entries)`
+# against a pod-shaped remote rather than a flat 2, and the tests below assert
+# that relationship rather than a constant: a per-entry stream that silently
+# skipped the canonicalisation would otherwise be invisible.
+# `index-order-lines` is the diff reduction the row-sorting rule bought,
+# MEASURED (canonicalised diff minus what still differs once sorted), so the
+# accounting identity is now four-term:
+#     raw == store_root + host + block + order
 _EVIDENCE_RE = re.compile(
-    r"^PASS scope=\S+ bytes=\d+ "
+    r"^PASS scope=\S+ entries=(?P<entries>\d+) bytes=\d+ "
     r"raw-diff-lines=(?P<raw>\d+) "
     r"store-root-lines=(?P<store_root>\d+) "
     r"host-lines=(?P<host>\d+) "
     r"snapshot-line=(?P<snapshot>\d+) "
     r"snapshot-block-lines=(?P<block>\d+) "
+    r"index-order-lines=(?P<order>\d+) "
     r"accounted-for=(?P<accounted>\d+) ",
     re.MULTILINE,
 )
@@ -3903,6 +3920,97 @@ def token_file(tmp_path: Path) -> Path:
     path.write_text(GOOD_TOKEN + "\n")
     path.chmod(0o600)
     return path
+
+
+# =============================================================================
+# 🔴 THE ORDERING FIXTURE — the shape the comparator could not pass at all.
+#
+# `subsystem_recall` orders its INDEX newest-first by entry-file mtime, and the
+# transport (`seed.sh`: `rsync -a --delete` into a stage, then `tar` into the
+# pod) does not carry mtime. So two stores holding IDENTICAL BYTES render their
+# index in a different order — measured against the live pod on 2026-09-01,
+# where every scope with more than two entries failed and the `cli` scope's only
+# unaccounted difference was one row's POSITION.
+#
+# FOUR entries, not two: two entries can only be in one of two orders and the
+# fixture would be one coin-flip away from asserting nothing. Names are pairwise
+# distinct and share no prefix, so a comparison that matched on a prefix cannot
+# pass by coincidence.
+# =============================================================================
+
+ORDER_SCOPE = "cable-tray"
+ORDER_REFS = ("clamp-north", "clamp-south", "duct-east", "duct-west")
+# Stamped oldest-first, so the reader's newest-first index is the REVERSE of
+# this. Chosen so the resulting index order differs from the local one in more
+# than one position — the test asserts that rather than trusting it.
+SHUFFLED_ORDER = ("duct-west", "clamp-north", "duct-east", "clamp-south")
+
+
+def _write_ordered_scope(root: Path) -> None:
+    (root / ORDER_SCOPE).mkdir(parents=True)
+    for ref in ORDER_REFS:
+        (root / ORDER_SCOPE / f"{ref}.md").write_text(
+            _entry(ref, ORDER_SCOPE, nuance=f"- 2026-02-11: {ref} seats on a shim.")
+        )
+
+
+def _stamp(root: Path, order) -> None:
+    """Set every entry file's mtime EXPLICITLY, oldest first.
+
+    🔴 NEVER LET WRITE ORDER STAND IN FOR MTIME ORDER. `cp -a` preserves
+    mtimes, a filesystem can stamp two writes inside one clock tick, and the
+    reader breaks a tie on `ref` — so a fixture that merely wrote its files in
+    some sequence would be asserting a property of this machine's clock instead
+    of a property of the store, and would go quietly vacuous on a faster one.
+    100-second gaps make the order a fact of the fixture.
+    """
+    base = time.time() - 100_000
+    for i, ref in enumerate(order):
+        stamp = base + i * 100
+        os.utime(root / ORDER_SCOPE / f"{ref}.md", (stamp, stamp))
+
+
+def _index_refs(root: Path, scope: str = ORDER_SCOPE) -> list[str]:
+    """The refs the reader's own index lists, IN ORDER, for one store.
+
+    Read out of the CLI rather than off the filesystem: the set arm's claim is
+    about what `subsystem_recall` INDEXES, and a `*.md` the loader rejects is a
+    real file that is not indexed and not `--ref`-addressable.
+    """
+    out = subprocess.run(
+        [sys.executable, str(RECALL_PATH), "--store", str(root), "--scope", scope,
+         "--list"],
+        capture_output=True, text=True, timeout=HANG_TIMEOUT,
+    )
+    assert out.returncode <= 3, out.stderr
+    refs: list[str] = []
+    inside = False
+    for line in out.stdout.splitlines():
+        if line.startswith("INDEX ("):
+            inside = True
+            continue
+        if not inside:
+            continue
+        if not line.strip():
+            break
+        if line.startswith("  ("):
+            continue
+        refs.append(line.split()[0])
+    return refs
+
+
+@pytest.fixture
+def shuffled_pair(tmp_path: Path) -> tuple[Path, Path]:
+    """A local store and a served copy: same bytes, different mtime ORDER."""
+    local = tmp_path / "ordered-local"
+    served = tmp_path / "ordered-served"
+    _write_ordered_scope(local)
+    subprocess.run(
+        ["cp", "-a", str(local), str(served)], check=True, capture_output=True
+    )
+    _stamp(local, ORDER_REFS)
+    _stamp(served, SHUFFLED_ORDER)
+    return local, served
 
 
 class TestByteIdentityVerifier:
@@ -3969,6 +4077,245 @@ class TestByteIdentityVerifier:
         assert "verify: scopes=4" in r.stdout
         assert "pass=3 fail=1" in r.stdout
 
+    # ------------------------------------------------------------------
+    # 🔴 THE ORDERING REGRESSION AND ITS THREE CONTROLS.
+    # ------------------------------------------------------------------
+
+    def test_a_MULTI_ENTRY_scope_in_a_DIFFERENT_MTIME_ORDER_still_PASSES(
+        self, shuffled_pair: tuple[Path, Path], token_file: Path
+    ):
+        """🔴 THE REGRESSION. This is the run that could not pass at all.
+
+        Both stores hold byte-identical entries; only the entry-file MTIMES
+        differ. The reader orders its INDEX newest-first by mtime and picks the
+        digest's one featured BODY the same way, and the transport does not
+        carry mtime — so the old whole-scope `cmp` reported a difference for a
+        store that was identical, on every scope with more than two entries.
+        MEASURED against the live pod on 2026-09-01: `scopes=5 pass=1 fail=4`,
+        the single PASS being the only two-entry scope.
+
+        `claude/RULES.md`: a permanently-red gate is worse than no gate.
+        """
+        local, served = shuffled_pair
+
+        # 🔴 THE FIXTURE'S OWN POSITIVE CONTROL, BEFORE THE COMPARATOR RUNS.
+        # A green below means nothing unless the condition it is about is
+        # actually present: if the two stores happened to render the same
+        # order, this test would pass against the OLD script too and assert
+        # nothing at all.
+        local_order = _index_refs(local)
+        served_order = _index_refs(served)
+        assert len(local_order) == len(ORDER_REFS), (
+            f"the fixture did not produce {len(ORDER_REFS)} indexed entries: "
+            f"{local_order}"
+        )
+        assert local_order != served_order, (
+            f"the fixture produced the SAME index order on both sides "
+            f"({local_order}) — the regression it is about is not reachable"
+        )
+        assert sorted(local_order) == sorted(served_order), (
+            f"the fixture changed the entry SET, not the order: "
+            f"{local_order} vs {served_order}"
+        )
+
+        with running(served) as (base, _):
+            r = run_verify(
+                "--store", str(local), "--url", base, "--token-file", str(token_file)
+            )
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "verify: scopes=1 pass=1 fail=0 entries-compared=4" in r.stdout
+
+        rows = _evidence_rows(r.stdout)
+        assert len(rows) == 1, f"expected one evidence row:\n{r.stdout}"
+        row = rows[0]
+        # Every entry's bytes were actually compared — a comparator that
+        # skipped the per-entry arm would be green here for the wrong reason.
+        assert row["entries"] == len(ORDER_REFS), (
+            f"the per-entry arm compared {row['entries']} of {len(ORDER_REFS)}: {row}"
+        )
+        # 🔴 AND THE REORDER RULE WAS SPENT. A zero here would mean the two
+        # renders agreed without it, i.e. the fixture's divergence never reached
+        # the comparator and this green is about nothing.
+        assert row["order"] > 0, (
+            f"index-order-lines=0 — the sort accounted for nothing, so the "
+            f"ordering difference never reached the comparison: {row}"
+        )
+        assert row["raw"] == (
+            row["store_root"] + row["host"] + row["block"] + row["order"]
+        ), f"unaccounted differing lines: {row}"
+        assert row["accounted"] == row["raw"], (
+            f"the printed accounted-for does not cover the raw diff: {row}"
+        )
+
+    def test_an_entry_on_ONE_SIDE_ONLY_FAILS_and_NAMES_the_scope_and_the_ref(
+        self, shuffled_pair: tuple[Path, Path], token_file: Path
+    ):
+        """🔴 THE SET ARM, IN BOTH DIRECTIONS.
+
+        Order-independence must not become a blanket excuse: an entry that
+        exists on one side and not the other is a real difference, and the
+        message has to name WHICH ref so the reader is not left diffing two
+        stores by hand.
+
+        Both directions, because a `comm -23` written without its `-13` mirror
+        is a guard that is half there and reads as whole.
+
+        ⚠ WHAT A FAILURE HERE MEANS DEPENDS ON WHEN IT RAN. After the phase-1
+        cutover the pod is canonical and each host's store is a read-through
+        cache that may legitimately lag — measured 2026-09-01, scope `devrc` at
+        26 entries locally against 29 on the pod, with nothing wrong. This arm
+        is an ACCEPTANCE check immediately after a seed/push, which is where
+        `cairn-cutover.py` P4 runs it. It is deliberately not weakened to
+        tolerate a lagging cache: a check that shrugged at a missing entry
+        could not detect a half-copied seed, which is the one thing P4 exists
+        for.
+        """
+        local, served = shuffled_pair
+
+        # a) an entry the pod has and this host does not.
+        extra = served / ORDER_SCOPE / "duct-north.md"
+        extra.write_text(
+            _entry("duct-north", ORDER_SCOPE, nuance="- 2026-02-12: a fifth run.")
+        )
+        os.utime(extra, (time.time() - 50_000, time.time() - 50_000))
+        with running(served) as (base, _):
+            r = run_verify(
+                "--store", str(local), "--url", base, "--token-file", str(token_file)
+            )
+        assert r.returncode == 1, r.stdout + r.stderr
+        assert f"FAIL scope={ORDER_SCOPE} entry SET differs" in r.stdout
+        assert f"ONLY ON THE POD:   scope={ORDER_SCOPE} ref=duct-north" in r.stdout
+        assert "local-only=0 pod-only=1" in r.stdout
+
+        # b) the mirror: an entry this host has and the pod does not.
+        extra.unlink()
+        (served / ORDER_SCOPE / "duct-east.md").unlink()
+        with running(served) as (base, _):
+            r = run_verify(
+                "--store", str(local), "--url", base, "--token-file", str(token_file)
+            )
+        assert r.returncode == 1, r.stdout + r.stderr
+        assert f"FAIL scope={ORDER_SCOPE} entry SET differs" in r.stdout
+        assert f"ONLY ON THIS HOST: scope={ORDER_SCOPE} ref=duct-east" in r.stdout
+        assert "local-only=1 pod-only=0" in r.stdout
+
+    def test_a_CONTENT_difference_UNDER_a_SHUFFLED_order_is_STILL_caught(
+        self, shuffled_pair: tuple[Path, Path], token_file: Path
+    ):
+        """🔴 THE CONTROL THAT KEEPS ORDER-INDEPENDENCE FROM BEING AN EXCUSE.
+
+        The same shuffled mtimes as the regression above, PLUS a single changed
+        character inside one entry. A comparator that reached order-independence
+        by comparing less — sorting the whole stream into a multiset, or
+        dropping the per-entry arm — is green here, and that is exactly the
+        failure mode a wider canonicalisation introduces.
+
+        The mutation is inside `## Nuance / work-history`, which the index row
+        does NOT reproduce (the row carries the bullet COUNT, not its text), so
+        the scope-level arm cannot see it: only the per-entry comparison can.
+        """
+        local, served = shuffled_pair
+        path = served / ORDER_SCOPE / "duct-east.md"
+        path.write_text(path.read_text().replace("seats on a shim", "seats on a shin"))
+        # The rewrite stamped `now`; re-stamp so the ordering divergence this
+        # test is about is still present rather than accidentally repaired.
+        _stamp(served, SHUFFLED_ORDER)
+
+        assert _index_refs(local) != _index_refs(served), (
+            "the re-stamp lost the shuffled order, so this is no longer the "
+            "'content difference UNDER a shuffle' case it claims to be"
+        )
+
+        with running(served) as (base, _):
+            r = run_verify(
+                "--store", str(local), "--url", base, "--token-file", str(token_file)
+            )
+        assert r.returncode == 1, r.stdout + r.stderr
+        assert f"FAIL scope={ORDER_SCOPE} ref=duct-east entry bytes differ" in r.stdout
+        assert "verify: scopes=1 pass=0 fail=1" in r.stdout
+
+    def test_a_difference_VISIBLE_IN_THE_INDEX_ROW_is_reported_AS_ONE(
+        self, shuffled_pair: tuple[Path, Path], token_file: Path
+    ):
+        """🔴 THE ROW COMPARISON IS LIVE, AND ITS COUNT IS NOT DECORATION.
+
+        Every field on an index row (`ref`, the nuance COUNT, the sensitivity,
+        the `🔴 N OPEN` badge) is derived from the entry body, so the per-entry
+        arm would catch any row difference too — which makes it easy to write a
+        row comparison that observes NOTHING and never be told. It matters for
+        one specific reason: `index-order-lines` is measured as the diff
+        reduction the row SORT bought, so a row comparison wired to a constant
+        zero would fold a GENUINE row difference into the reorder excuse and
+        report it as `accounted-for`.
+
+        MUTATION-VERIFIED: with `rows_diff` pinned to 0 the run still FAILS —
+        the per-entry arm catches the same entry a step later — so `returncode
+        == 1` proves nothing here. The load-bearing assertion is that the
+        difference was seen BY THE ROW COMPARISON and counted as such.
+
+        The served copy's entry gains a second `## Nuance / work-history`
+        bullet, which moves its row's count from `1 nuance` to `2 nuance`.
+        """
+        local, served = shuffled_pair
+        path = served / ORDER_SCOPE / "clamp-north.md"
+        path.write_text(path.read_text() + "- 2026-02-13: and a second bullet.\n")
+        _stamp(served, SHUFFLED_ORDER)
+
+        with running(served) as (base, _):
+            r = run_verify(
+                "--store", str(local), "--url", base, "--token-file", str(token_file)
+            )
+        assert r.returncode == 1, r.stdout + r.stderr
+        assert f"FAIL scope={ORDER_SCOPE} scope-level render differs" in r.stdout, (
+            f"the index-row difference was not attributed to the index — the "
+            f"row comparison did not fire:\n{r.stdout}"
+        )
+        seen = re.search(r"sorted-row-lines=(\d+)", r.stdout)
+        assert seen, f"the FAIL line printed no sorted-row-lines count:\n{r.stdout}"
+        assert int(seen.group(1)) > 0, (
+            f"sorted-row-lines=0 while the rows genuinely differ — the row "
+            f"comparison is wired to nothing, and the difference would be "
+            f"folded into the index-order excuse:\n{r.stdout}"
+        )
+
+    def test_a_PAGINATED_index_is_REFUSED_rather_than_partially_compared(
+        self, tmp_path: Path, token_file: Path
+    ):
+        """🔴 THE ONE SHAPE THIS COMPARATOR CANNOT ANSWER, SAID OUT LOUD.
+
+        Past `LISTING_PAGE_SIZE` the reader pages its index, and BOTH the page
+        membership and the ref column's width (`max(len(ref) …)` over the
+        entries on THAT page) become functions of the mtime order. Page 1 of two
+        byte-identical stores would then hold different refs padded to different
+        widths, and the refs past page 1 were never read at all — so comparing
+        page 1 would be a partial check reported as a clean one, which is the
+        silent-zero shape this whole file refuses.
+
+        It refuses instead, and the refusal names the scope. No scope in the
+        real store is near the cap today (largest measured: 50 entries), so this
+        is the unobserved case made reachable rather than a reproduction of one
+        that happened.
+        """
+        root = tmp_path / "big"
+        (root / ORDER_SCOPE).mkdir(parents=True)
+        n = api.rc.LISTING_PAGE_SIZE + 1
+        for i in range(n):
+            ref = f"run-{i:04d}"
+            (root / ORDER_SCOPE / f"{ref}.md").write_text(
+                _entry(ref, ORDER_SCOPE, nuance=f"- 2026-02-11: {ref}.")
+            )
+        with running(root) as (base, _):
+            r = run_verify(
+                "--store", str(root), "--url", base, "--token-file", str(token_file)
+            )
+        # 🔴 SAME STORE ON BOTH SIDES — so every other arm would pass, and a
+        # comparator that did not refuse would print a PASS that covered one
+        # page out of two.
+        assert r.returncode == 1, r.stdout + r.stderr
+        assert f"FAIL scope={ORDER_SCOPE} index is PAGINATED" in r.stdout
+        assert "Nothing about this scope was verified." in r.stdout
+        assert "verify: scopes=1 pass=0 fail=1 entries-compared=0" in r.stdout
+
     def test_every_permitted_difference_is_ACCOUNTED_FOR_not_merely_small(
         self, store: Path, tmp_path: Path, token_file: Path
     ):
@@ -4017,23 +4364,49 @@ class TestByteIdentityVerifier:
         rows = _evidence_rows(r.stdout)
         assert rows, f"the verifier printed no evidence rows:\n{r.stdout}"
         for row in rows:
-            assert row["raw"] == row["store_root"] + row["host"] + row["block"], (
-                f"unaccounted differing lines: {row}"
-            )
+            assert row["raw"] == (
+                row["store_root"] + row["host"] + row["block"] + row["order"]
+            ), f"unaccounted differing lines: {row}"
             # The script's own arithmetic, read back rather than re-derived —
             # a printed `accounted-for` that disagreed with its own parts would
             # be a reader-facing lie even while the identity above held.
-            assert row["accounted"] == row["store_root"] + row["host"] + row["block"], (
-                f"the printed accounted-for does not equal its own parts: {row}"
+            assert row["accounted"] == (
+                row["store_root"] + row["host"] + row["block"] + row["order"]
+            ), f"the printed accounted-for does not equal its own parts: {row}"
+            # 🔴 EVERY STREAM CARRIED THE CANONICALISATION, not just the first.
+            # The counts are sums over `1 + entries` streams — the scope-level
+            # `mode=list` render plus one single-ref render per entry — so a
+            # per-entry stream that silently skipped a `sed` shows up as a
+            # count that is short of the multiple, which a bare
+            # `store_root > 0` could not see.
+            streams = 1 + row["entries"]
+            assert row["store_root"] == 2 * streams, (
+                f"the store-root rule was not spent on all {streams} streams: {row}"
+            )
+            assert row["block"] == 2 * streams, (
+                f"the snapshot block was not stripped from all {streams} remote "
+                f"streams: {row}"
+            )
+            assert row["snapshot"] == streams, (
+                f"the banner was not served on all {streams} streams: {row}"
             )
         # …and the causes exercised here are genuinely PRESENT, or the identity
         # above is satisfiable by a run that compared nothing (0 == 0 + 0 + 0).
-        assert any(row["snapshot"] == 1 for row in rows), "no snapshot line observed"
+        assert any(row["snapshot"] >= 1 for row in rows), "no snapshot line observed"
         assert any(row["block"] == 2 for row in rows), (
             "no snapshot BLOCK observed — this tree's server emits the banner "
-            "plus exactly one blank separator, so a 2 is the expected length"
+            "plus exactly one blank separator, so a 2 is the expected length "
+            "for the single-stream (zero-entry) scopes"
         )
         assert any(row["store_root"] == 2 for row in rows), "no store-root line observed"
+        # 🔴 AND THE PER-ENTRY ARM RAN. Every count above is a sum over
+        # `1 + entries` streams, and `entries == 0` satisfies all of them while
+        # comparing no entry bytes at all — the silent zero this file refuses
+        # everywhere else. Two of the four fixture scopes hold no indexed entry
+        # by design, so this is `any`, not `all`.
+        assert any(row["entries"] > 0 for row in rows), (
+            f"no scope compared a single entry body: {rows}"
+        )
         # Both sides are this machine, so the host line must be IDENTICAL here.
         # A non-zero would mean the harness accidentally diverged the two hosts,
         # which would make the pod-shaped test below prove nothing new.
@@ -4094,21 +4467,33 @@ class TestByteIdentityVerifier:
         rows = _evidence_rows(r.stdout)
         assert len(rows) == 4, f"expected one evidence row per scope:\n{r.stdout}"
         for row in rows:
-            # 🔴 EACH PERMITTED DIFFERENCE PRESENT AND COUNTED. Asserting only
-            # the PASS would be satisfied by a canonicalisation that flattened
-            # the whole stream.
-            assert row["store_root"] == 2, f"no store-root difference: {row}"
-            assert row["host"] == 2, f"no host-line difference: {row}"
-            assert row["block"] == 3, (
+            # 🔴 EACH PERMITTED DIFFERENCE PRESENT AND COUNTED, ON EVERY STREAM.
+            # Asserting only the PASS would be satisfied by a canonicalisation
+            # that flattened the whole stream. The multiple is `1 + entries` —
+            # the scope-level `mode=list` render plus one single-ref render per
+            # entry — so a per-entry stream that skipped one of the three rules
+            # fails here rather than passing on the scope-level stream's count.
+            streams = 1 + row["entries"]
+            assert row["store_root"] == 2 * streams, (
+                f"no store-root difference on all {streams} streams: {row}"
+            )
+            assert row["host"] == 2 * streams, (
+                f"no host-line difference on all {streams} streams: {row}"
+            )
+            assert row["block"] == 3 * streams, (
                 f"the served banner + TWO blank separators were not measured "
-                f"as a 3-line block: {row}"
+                f"as a 3-line block on all {streams} streams: {row}"
             )
-            assert row["raw"] == row["store_root"] + row["host"] + row["block"], (
-                f"unaccounted differing lines: {row}"
-            )
+            assert row["raw"] == (
+                row["store_root"] + row["host"] + row["block"] + row["order"]
+            ), f"unaccounted differing lines: {row}"
             assert row["accounted"] == row["raw"], (
                 f"the printed accounted-for does not cover the raw diff: {row}"
             )
+        assert any(row["entries"] > 0 for row in rows), (
+            f"no scope compared a single entry body — the per-entry arm never "
+            f"ran, so the multiples above are all about one stream: {rows}"
+        )
 
     def test_a_POD_SHAPED_remote_STILL_FAILS_on_a_real_content_difference(
         self, store: Path, tmp_path: Path, token_file: Path, monkeypatch
@@ -4194,31 +4579,43 @@ class TestByteIdentityVerifier:
         scope against a pre-0.3.0 pod and the failure would read as a content
         difference.
 
-        The stub replays the local CLI's own bytes per scope — a server that
-        renders identically and stamps nothing.
+        The stub replays the local CLI's own bytes — a server that renders
+        identically and stamps nothing.
+
+        🔴 IT HONOURS `mode` AND `ref`, WHICH IS NOT COSMETIC. The comparator no
+        longer fetches one digest per scope: it asks for `?mode=list` and then
+        `?ref=<name>` per entry. A stub keyed on the path alone would 404 every
+        one of those and this test would pass on the 404 branch, proving nothing
+        about the empty-block path it exists for.
         """
         import http.server
+        from urllib.parse import parse_qs, urlsplit
 
-        bodies = {}
-        for scope in (SCOPE, OTHER_SCOPE, EMPTY_SCOPE, BROKEN_SCOPE):
-            out = subprocess.run(
-                [sys.executable, str(RECALL_PATH), "--store", str(store),
-                 "--scope", scope],
-                capture_output=True, timeout=HANG_TIMEOUT,
-            )
+        def render(scope: str, params: dict[str, list[str]]) -> bytes:
+            argv = [sys.executable, str(RECALL_PATH), "--store", str(store),
+                    "--scope", scope]
+            if params.get("ref"):
+                argv += ["--ref", params["ref"][-1]]
+            elif params.get("mode", [""])[-1] == "list":
+                argv += ["--list"]
+            out = subprocess.run(argv, capture_output=True, timeout=HANG_TIMEOUT)
             # exit 3 is "nothing readable" — a legitimate render, which the
             # verifier itself tolerates. Anything harder is a broken fixture.
             assert out.returncode <= 3, out.stderr.decode()
-            bodies[scope] = out.stdout
+            return out.stdout
+
+        known = {SCOPE, OTHER_SCOPE, EMPTY_SCOPE, BROKEN_SCOPE}
 
         class Unstamped(http.server.BaseHTTPRequestHandler):
             def do_GET(self):  # noqa: N802
-                body = bodies.get(self.path.rsplit("/", 1)[-1])
-                if body is None:
+                split = urlsplit(self.path)
+                scope = split.path.rsplit("/", 1)[-1]
+                if scope not in known:
                     self.send_response(404)
                     self.send_header("Content-Length", "0")
                     self.end_headers()
                     return
+                body = render(scope, parse_qs(split.query))
                 self.send_response(200)
                 self.send_header("Content-Length", str(len(body)))
                 self.end_headers()
@@ -4249,10 +4646,16 @@ class TestByteIdentityVerifier:
         rows = _evidence_rows(r.stdout)
         assert len(rows) == 4, f"expected one evidence row per scope:\n{r.stdout}"
         for row in rows:
-            assert row == {
+            assert {k: v for k, v in row.items() if k != "entries"} == {
                 "raw": 0, "store_root": 0, "host": 0,
-                "snapshot": 0, "block": 0, "accounted": 0,
+                "snapshot": 0, "block": 0, "order": 0, "accounted": 0,
             }, f"an unstamped identical render was not a clean zero: {row}"
+        # `entries` is deliberately outside that zero: two of the four fixture
+        # scopes hold indexed entries and their bodies WERE compared, and a run
+        # in which nothing was is the silent zero, not the clean one.
+        assert sum(row["entries"] for row in rows) == 2, (
+            f"the per-entry arm did not compare the two indexed entries: {rows}"
+        )
 
     def test_an_UNREACHABLE_pod_FAILS_rather_than_comparing_nothing(
         self, store: Path, token_file: Path


### PR DESCRIPTION
Rank 11 of `claudedocs/handoff-cairn-phase3.md` — "🔴 OPEN — `verify-byte-identity.sh` STILL cannot pass for a multi-entry scope: it is mtime-ordered".

## The defect

`verify-byte-identity.sh` compared the **whole-scope digest**. `subsystem_recall` orders its INDEX newest-first by entry-file **mtime** and picks the digest's one featured BODY the same way (`select_featured`'s most-recent fallback), and the transport (`seed.sh`: `rsync` into a stage, `tar` into the pod) does not carry mtime. So two stores holding byte-identical entries render a different row order **and** a different featured entry.

Measured 2026-09-01 against the live pod over a `kubectl port-forward`, store `~/.claude/analyze-service-index`:

```
FAIL scope=devrc              raw-diff-lines=45  accounted-for=6
FAIL scope=cli                raw-diff-lines=8   accounted-for=6
PASS scope=storage-resolver   (2 entries)
FAIL scope=homelab-infra      raw-diff-lines=108 accounted-for=6
FAIL scope=datapacket-talos   raw-diff-lines=336 accounted-for=6
verify: scopes=5 pass=1 fail=4
```

Every PASS had 2 entries; the `cli` scope's entire unaccounted difference was one row's POSITION. #1214 closed the `host:` half only. Until now the cutover's P4 was a **permanently-red gate** — which `claude/RULES.md` calls worse than no gate.

## What changed

The claim is restated at the level it can hold. Per scope:

1. **the `mode=list` render** — no body, so no mtime-selected featured entry — with the index **rows compared as a sorted set** and the rest of the stream compared verbatim, in order. Only the rows are reordered, because only the rows are ordered by mtime; sorting the whole stream would make it a multiset that passes when a line moves between sections.
2. **the entry SET**, by `comm` over the refs the two index blocks list. A ref on one side only FAILS and **names it**. It runs *before* the row comparison on purpose: the index head names the entry count, so a set difference would otherwise always surface as a render difference and this arm would be an unreachable guard printing a message nobody sees.
3. **each entry's bytes**, as its own `--ref` / `?ref=` render — a narrowing that prints no index, so it carries no order. There is no route serving raw entry bytes; the API only ever returns renders.

A scope whose index **paginates** is REFUSED, not partly compared: past `LISTING_PAGE_SIZE` both the page membership and the ref column's width (`max(len(ref) …)`, computed per page) are mtime-derived, and the refs past page 1 are never read at all. No scope in the store is near the cap today (largest measured: 50 entries).

## Accounting

`index-order-lines` joins the printed sum **in the same commit as the sort** — a rule that erases a difference without a matching count widens the blind spot rather than the gate. It is **measured** (the diff reduction the sort bought), not assumed, and the identity is now four-term and exact on a PASS:

```
raw-diff-lines == store-root-lines + host-lines + snapshot-block-lines + index-order-lines
```

The counts are **sums over every stream compared for the scope**, so a pod-shaped remote reads `store-root-lines = 2 * (1 + entries)`. The tests assert that multiple rather than a constant, so a per-entry stream that skipped a `sed` cannot hide behind the scope-level stream's count. `entries=` is printed for the `drift-check.sh` reason: a scope that compared no bodies must read as one.

The numbers stay **evidence, not a second gate**.

## Test matrix

Both pre-existing controls kept. Five tests added.

**Red at base `66eee1d7`, green at HEAD** — all five. The base failure for the regression test is the defect itself:

```
FAIL scope=cable-tray canonicalised-cmp=differs raw-diff-lines=12 store-lines=2 host-lines=0 snapshot-block-lines=2 accounted-for=4
  7,8d8
  <   duct-west      1 nuance   client-confidential (declared: internal)
  <   duct-east      1 nuance   client-confidential (declared: internal)
  9a10
  >   duct-east      1 nuance   client-confidential (declared: internal)
  10a12
  >   duct-west      1 nuance   client-confidential (declared: internal)
  14c16
  <   ### duct-west  (cable-tray/duct-west.md, …)
  ---
  >   ### clamp-south  (cable-tray/clamp-south.md, …)
```

— rows reordered **and** a different featured entry, on stores whose bytes are identical.

mtimes are set with explicit `os.utime`, never inferred from write order. The regression test carries its **own positive control**: it asserts the two index orders genuinely differ *and* the two sets genuinely match before running the comparator, so it cannot go quietly vacuous.

**Mutation sweep** — 9 narrow mutants, run under `PYTHONDONTWRITEBYTECODE=1`, control green first, **9/9 KILLED**, each by its expected test with that guard's own assertion:

| mutant | guard | verdict |
|---|---|---|
| M1 local row `sort` → `cat` | the reordering rule | KILLED — `MULTI_ENTRY…still_PASSES` |
| M2 `comm -13` → `""` | the set arm's pod-only mirror | KILLED — `ONE_SIDE_ONLY` |
| M3 entry `cmp` → `if false` | per-entry bytes **(positive control)** | KILLED — `ONE_CHARACTER_divergence` + 2 |
| M4 pagination `if` → `if false` | the paginated refusal | KILLED — `PAGINATED_index_is_REFUSED` |
| M5 `residual` drops `frame_diff` | the scope-level frame comparison | KILLED — `LEADING_BLANKS` |
| M6 `index_order=0` | the measured order accounting | KILLED — `MULTI_ENTRY…` (`index-order-lines=0 — the sort accounted for nothing`) |
| M7 per-entry `store_lines` not accumulated | per-stream canonicalisation | KILLED — `POD_SHAPED…PASSES` (`no store-root difference on all 2 streams`) |
| M8 `rows_diff=0` | the index-row content comparison | KILLED — `VISIBLE_IN_THE_INDEX_ROW` |
| M9 `entries=0` | the `entries=` evidence field | KILLED — `ACCOUNTED_FOR` + 2 |

M8 **survived the first sweep** — every field on an index row is derived from the body, so the per-entry arm catches the same difference a step later and `returncode == 1` proves nothing there. A test was added that asserts the difference was seen **by the row comparison** (`sorted-row-lines > 0`), because that count is what keeps a genuine row difference out of the `index-order-lines` excuse. The script now says so where the comparison happens, rather than claiming coverage it does not have.

## Flagged, not fixed

After the phase-1 cutover the **pod is canonical and each host's local store is a read-through cache that can legitimately lag** — measured 2026-09-01, scope `devrc` at 26 entries locally against 29 on the pod, with nothing wrong. So an entry-set difference is an ordinary operational state *in general*, and this script is only a meaningful acceptance check **immediately after a seed/push**, which is exactly where `cairn-cutover.py` runs it (P4). Said plainly in the script header, in the P4 docstring, in the README, and in the set-arm test's docstring.

The set arm is **deliberately not weakened** for it: a check that tolerated a missing entry could not detect a half-copied seed, which is the one thing P4 exists to catch.

⚠ Cost: the verifier is now **N+1 requests per scope**, not 1 (a 50-entry scope issues 51). One local `--ref` render measures ~73 ms; the whole real store is ~400 entries. P4's `timeout=600` is what bounds it.

## Prose updated in the same commit

Nine of eleven findings in this effort's audit ladder were prose contradicting code, so:

- `cairn-cutover.py` P4 docstring — named **three** differences, and did not mention the digest was no longer compared.
- `server.py` header — claimed it "asserts the raw diff is exactly one line", **false since `host:` shipped** and false through two more causes.
- `README.md` — "Why byte-identity is asserted modulo **THREE** named differences" → four, plus the arms, the pagination refusal, the lagging-cache caveat and the request cost.
- `claudedocs/plan-cairn-phase1-cutover.md` — the instrument's control-table row.

## Gates run

See the comment below for the tier + base sha of each run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnDQ8q2rop6dPiDbxX1twi
