### PR TITLE
fix(store-siting): the entry census was a syntactic sweep and six shapes walked through it — measure the real store instead (round-7 audit)

### DIFF
--- a/scripts/testlib/store_siting.py
+++ b/scripts/testlib/store_siting.py
@@ -42,6 +42,10 @@ docstring claimed that.** Two residual windows, both real and both narrower than
 free-space floor above rather than closed by it:
   * a tmpfs that passes the checks and then FILLS mid-run — a concurrent writer, or a
     suite far larger than these stores — surfaces ENOSPC where disk would have passed.
+    Half of that is now closed and half is not, and the halves are different in kind:
+    a store of OURS growing past what `_MIN_FREE_BYTES` was sized for is caught by
+    `_check_store_budget`, which walks the real tree at teardown; a CONCURRENT writer
+    filling the mount is not, and cannot be from in here.
   * a run killed by SIGKILL (a gate timeout, `panic: test timed out`) skips the
     `finally`, so `/dev/shm/devrc-store-*` survives; on a persistent container
     `/dev/shm` repeated kills accumulate toward the first case. Nothing reaps them.
@@ -70,40 +74,97 @@ _DEFAULT_CANDIDATE = "/dev/shm"
 # one exist.
 _MOUNTS_PATH = "/proc/mounts"
 
-# The largest store this suite builds, in tmpfs PAGE-ALLOCATED bytes.
-#
-# 🔴 DERIVED, NOT TRUSTED: this literal is checked against the fixture that produces
-# it by `test_store_siting_ledger.py::test_the_largest_store_constant_still_covers_
-# the_biggest_fixture`, which reads the `range(N)` out of `test_cairn_cli.py`. Without
-# that, growing the fixture silently re-opens the ENOSPC hazard with every guard green
-# — MEASURED by an audit: `range(303)` -> `range(1200)`, all guards pass, and a
-# /dev/shm of 4500k then dies `Errno 28`. A constant checked only against another
-# constant is not a guard.
-#
-# Measured 2026-09-01 against the REAL fixture (`_populate_source_store` + 303 bulk
-# entries = 306 files, on tmpfs): apparent **74,613 B**, page-allocated
-# **1,253,376 B**, ratio **16.80x**. Confirmed four independent ways — `sum(st_size)`,
-# `st_blocks*512`, `du -sB1`, and the `/dev/shm` statvfs used-delta — all agreeing.
-#
-# 🔴 TWO EARLIER REVISIONS OF THIS COMMENT WERE MEASUREMENTS OF SOMETHING ELSE, and
-# the second was mine correcting the first. "53,985 B / 23x" came from a SYNTHETIC
-# store, not this fixture. "72,602 B / 1,265,664 B / 17.4x" then double-counted
-# DIRECTORY pages: tmpfs directories cost zero, and 1,253,376 + 3*4096 = 1,265,664
-# exactly. In a module whose subject is a number being wrong, three revisions were
-# needed to get this one right — which is why the value below is DERIVED and pinned
-# rather than transcribed.
-#
-# 🔴 APPARENT BYTES UNDERSTATE TMPFS COST ~17x. tmpfs charges whole 4 KiB pages, so
-# entry COUNT drives this, not text size; a floor reasoned from `st_size` lands an
-# order of magnitude low.
-#
-# The value is the DERIVED requirement, not the single-fixture measurement: the
-# ratchet sums every ledgered file's fixtures (conservative — under `-n 4 --dist
-# loadfile` they do not all hold stores at once) and adds slack pages.
-_LARGEST_STORE_BYTES = 1875968
+# tmpfs charges whole 4 KiB pages per file, and directories cost nothing. Both halves
+# are load-bearing: an earlier revision of the measurement below double-counted
+# directory pages and landed 12,288 B high (1,253,376 + 3*4096 = 1,265,664 exactly).
+_PAGE_BYTES = 4096
 
-# Free space a candidate must have before we will site a store on it: the measured
-# peak above, with better than 3x margin.
+# The peak page-allocated footprint any store in this suite has been MEASURED to reach.
+#
+# 🔴 THIS IS A MEASUREMENT, AND IT IS NOT WHAT MAKES THE BUDGET HONEST. Rounds 4-6 tried
+# to keep `_LARGEST_STORE_BYTES` truthful by DERIVING it from a syntactic sweep of the
+# ledgered test files — counting `write_text` calls and `range(N)` loops. Every revision
+# of that sweep was walked through by a shape it could not see: two write loops in one
+# test, nested loops summed instead of multiplied (`for a in range(4): for b in
+# range(300)` reported 304 for 1,200 real files), `range(303)` respelled as
+# `range(0, 303)`, a for-loop rewritten as a list comprehension, a loop body extracted
+# into a helper. Each of those under-reported SILENTLY with the whole suite green —
+# re-arming the ENOSPC hazard through the guard added to prevent it.
+#
+# A syntactic sweep can only ever see the shapes its author imagined. So the enforcement
+# moved to `_check_store_budget` below, which WALKS THE REAL STORE at teardown and
+# raises when it exceeds the budget. That cannot be fooled by a spelling, a nesting or a
+# refactor, because it is not reading the source at all.
+#
+# Measured 2026-09-02 by `store_root` itself over a full run of the three ledgered files
+# (`scripts/tests/test_{subsystem_store_api,cairn_write,cairn_cli}.py`): **448 stores**
+# walked, largest 1,253,376 B / 306 entries, second largest 176,128 B / 43 entries. The
+# peak is `test_cairn_cli.py`'s concurrency fixture — `_populate_source_store`'s 3 seed
+# entries + 303 bulk entries = 306 files, apparent 74,613 B — a 16.8x ratio, confirmed
+# four independent ways (`sum(st_size)`, `st_blocks*512`, `du -sB1`, and the `/dev/shm`
+# statvfs used-delta).
+#
+# ⚠ SAY WHAT WAS MEASURED, because this constant has been wrong twice by being a
+# measurement of something else. The raw `PEAK_STORE_BYTES` from that run reads
+# 1,884,160 — bigger than the number below — and that peak is the ledger suite's OWN
+# deliberately-over-budget probe, not a fixture. 1,253,376 is the largest store the
+# suite builds in the course of testing something else, which is what this constant is
+# for. The gap to the runner-up (176,128) is 7x, so the peak is not a close call.
+#
+# 🔴 APPARENT BYTES UNDERSTATE TMPFS COST ~17x. Entry COUNT drives this, not text size;
+# a floor reasoned from `st_size` lands an order of magnitude low.
+_MEASURED_PEAK_STORE_BYTES = 1253376
+
+# Headroom the budget carries over that measured peak.
+#
+# 🔴 THE PREVIOUS VALUE HAD ZERO SLACK AND THAT MADE IT A TRIPWIRE, NOT A BUDGET.
+# `_LARGEST_STORE_BYTES` was 1,875,968 = (442 + 16) * 4096, where 442 was the sweep's
+# own output — so the required value and the constant were the same number and the gate
+# sat exactly on its own boundary. Appending a single unrelated five-byte scratch write
+# to a ledgered file turned the required merge check RED, on a machine with no store,
+# no server and no tmpfs involved. Measured base rate: that derived requirement moved
+# SIX times in nineteen commits, three of them on one day.
+#
+# 1.5x is chosen so a fixture can grow by half again — the kind of change an author
+# makes without thinking about tmpfs — before anyone has to touch a constant, while
+# still leaving `_MIN_FREE_BYTES` (4 MiB) more than 2x above the budget. It is pinned
+# by `test_store_siting_ledger.py::test_the_budget_keeps_real_HEADROOM_over_the_
+# measured_peak`, so shrinking the slack to buy room is a visible act, not a quiet one.
+_BUDGET_HEADROOM = 1.5
+
+# The budget: no store this suite builds may page-allocate more than this.
+#
+# 🔴 ENFORCED AT RUNTIME, against the real directory tree, by `_check_store_budget`.
+# It is not a floor reasoned from source and it is not checked against another constant:
+# every store `store_root` yields is walked at teardown and compared to this number, so
+# a fixture that grows past it fails LOUDLY on the test that grew it, whatever spelling
+# the growth arrived in.
+#
+# 🔴 COMPUTED, NOT TRANSCRIBED — and that is not tidiness. Written as the literal
+# 1,880,064 it would be a THIRD number that can disagree with the two above it, so
+# `_BUDGET_HEADROOM = 1.5` could read 1.5 while the budget carried 1.26x and nothing
+# would notice. That is the same defect as the "better than 3x margin" comment one
+# constant further down, which was false for a whole round. Rounded UP to a whole page
+# because a budget is a page count.
+_LARGEST_STORE_BYTES = (
+    -(-int(_MEASURED_PEAK_STORE_BYTES * _BUDGET_HEADROOM) // _PAGE_BYTES) * _PAGE_BYTES
+)  # 1,880,064 at the two values above — a snapshot, not a second definition
+
+# Free space a candidate must have before we will site a store on it: the budget above,
+# with better than 2x margin. 🔴 **2x IS THE CLAIM AND IT IS THE CLAIM A TEST READS**
+# (`test_the_free_space_floor_keeps_the_MARGIN_its_comment_claims`). Today the ratio
+# happens to be 2.23x (4,194,304 / 1,880,064), and that figure is a SNAPSHOT — do not
+# promote it to the guarantee, because a snapshot in this position is precisely what
+# went stale last time.
+#
+# ⚠ The margin used to be stated as "better than 3x" and round 6 falsified that without
+# updating the sentence — it was 2.24x by then, and had been 3.18x when written. The
+# fix is not a better sentence — it is that the RATIO IS NOW READ BY A TEST.
+# `test_the_floor_CONSTANT_clears_the_largest_store_this_suite_builds` in
+# `test_subsystem_store_api.py` enforces the bare inequality;
+# `test_store_siting_ledger.py::test_the_free_space_floor_keeps_the_MARGIN_its_comment_
+# claims` enforces the 2x promised above. A prose margin nothing reads is how the "3x"
+# survived being false, and rewording it would have left that mechanism intact.
 #
 # 🔴 THIS WAS 1 MiB FOR EXACTLY ONE COMMIT AND THAT WAS A REGRESSION — BELOW the peak.
 # It was lowered from 8 MiB on the strength of an observation that 8 MiB rejects a
@@ -195,6 +256,90 @@ def tmpfs_dir() -> Path | None:
     return None
 
 
+class StoreBudgetExceeded(AssertionError):
+    """A store grew past `_LARGEST_STORE_BYTES`, so `_MIN_FREE_BYTES` is now a lie.
+
+    An `AssertionError` on purpose: this is a failed invariant of the test suite, not
+    an environment problem, and pytest should report it as a failure rather than an
+    internal error.
+    """
+
+
+# The peak any store has reached in THIS process, and where. Written by
+# `_check_store_budget`, read by the ledger tests as the positive control that the
+# measurement is wired to something: a budget checker that walks nothing reports a
+# reassuring zero for every store in the suite, which is indistinguishable from a
+# suite that builds no stores at all.
+PEAK_STORE_BYTES = 0
+PEAK_STORE_ENTRIES = 0
+PEAK_STORE_PATH = ""
+
+
+def page_allocated_bytes(root: Path) -> tuple[int, int]:
+    """`(entries, page-allocated bytes)` for the tree under `root`.
+
+    Files only. Directories are excluded because tmpfs charges nothing for them —
+    measured, and an earlier revision of `_LARGEST_STORE_BYTES` was 12,288 B high
+    precisely for counting three of them.
+
+    A missing root is `(0, 0)`: a caller may take a root and never create it, and
+    that is not a budget violation. An unreadable entry is skipped rather than
+    raising — the walk is a measurement, and it must not be the thing that fails a
+    test whose store was fine.
+
+    Every file costs AT LEAST one page, including an empty one. That overstates a
+    zero-byte file, which tmpfs charges no data pages for, and it is the deliberate
+    direction: under-reporting is what re-arms ENOSPC, and these stores hold no empty
+    files anyway. `lstat`, not `stat`, so a symlink is measured as the link it is
+    rather than followed — the suite plants broken ones on purpose.
+    """
+    entries = 0
+    total = 0
+    for dirpath, _dirnames, filenames in os.walk(root, onerror=lambda _e: None):
+        for filename in filenames:
+            try:
+                size = os.lstat(os.path.join(dirpath, filename)).st_size
+            except OSError:
+                continue
+            entries += 1
+            pages = max(1, -(-size // _PAGE_BYTES))
+            total += pages * _PAGE_BYTES
+    return entries, total
+
+
+def _check_store_budget(root: Path) -> None:
+    """Walk the store that was just used and fail if it broke the budget.
+
+    🔴 THIS IS THE ENFORCEMENT, AND IT REPLACES A SYNTACTIC SWEEP OF THE TEST FILES.
+    See `_MEASURED_PEAK_STORE_BYTES` for the six shapes that walked through that
+    sweep. Reading the directory rather than the source removes the whole class:
+    there is no spelling of a write loop that produces files this cannot see.
+
+    It runs on BOTH branches of `store_root` — tmpfs and the `tmp_path` fallback —
+    on purpose. Enforcing only on tmpfs would make the guard structurally blind on
+    exactly the machines that have no tmpfs, so a fixture could grow unchecked on a
+    developer's box and only fail once it reached a host where it mattered.
+    """
+    global PEAK_STORE_BYTES, PEAK_STORE_ENTRIES, PEAK_STORE_PATH
+    entries, allocated = page_allocated_bytes(root)
+    if allocated > PEAK_STORE_BYTES:
+        PEAK_STORE_BYTES = allocated
+        PEAK_STORE_ENTRIES = entries
+        PEAK_STORE_PATH = str(root)
+    if allocated <= _LARGEST_STORE_BYTES:
+        return
+    raise StoreBudgetExceeded(
+        f"store {root} page-allocates {allocated:,} bytes across {entries:,} entries, "
+        f"over the _LARGEST_STORE_BYTES budget of {_LARGEST_STORE_BYTES:,}. tmpfs "
+        f"charges whole {_PAGE_BYTES}-byte pages per file, so entry COUNT drives this "
+        "and apparent size understates it ~17x. This is the ENOSPC hazard, not a "
+        "bookkeeping nit: _MIN_FREE_BYTES "
+        f"({_MIN_FREE_BYTES:,}) is what decides whether a tmpfs is accepted, and it "
+        "was sized against that budget. Either shrink the fixture, or raise BOTH "
+        "constants together and re-check the margin."
+    )
+
+
 @contextlib.contextmanager
 def store_root(tmp_path: Path, name: str = "store") -> Generator[Path]:
     """Yield a store root sited off the contended disk when that is possible.
@@ -205,24 +350,37 @@ def store_root(tmp_path: Path, name: str = "store") -> Generator[Path]:
     Cleanup is the reason this is a context manager rather than a function: pytest
     auto-cleans `tmp_path`, but a tmpfs directory is not pytest's to clean and tmpfs
     is RAM, so leaking one per test would hold memory for the whole run.
+
+    On the way out it also MEASURES the store against `_LARGEST_STORE_BYTES` — see
+    `_check_store_budget`. That check is skipped when the body is already raising:
+    a budget violation reported over the top of the real failure would replace the
+    error the author needs to read with one about a constant.
     """
     base = tmpfs_dir()
-    if base is None:
-        yield tmp_path / name
-        return
+    holder: Path | None = None
+    if base is not None:
+        try:
+            holder = Path(tempfile.mkdtemp(prefix="devrc-store-", dir=str(base)))
+        except OSError:
+            # The candidate passed every check above and still would not give us a
+            # directory (it filled between the probe and here, hit a quota, or went
+            # read-only). Falling back reproduces the pre-tmpfs behaviour for THIS
+            # call — which is the contract for this branch, and not the absolute
+            # "never worse than disk" the module docstring above retracts.
+            holder = None
+    root = (tmp_path if holder is None else holder) / name
+    body_raised = False
     try:
-        holder = Path(tempfile.mkdtemp(prefix="devrc-store-", dir=str(base)))
-    except OSError:
-        # The candidate passed every check above and still would not give us a
-        # directory (it filled between the probe and here, hit a quota, or went
-        # read-only). Falling back reproduces the pre-tmpfs behaviour for THIS
-        # call — which is the contract for this branch, and not the absolute
-        # "never worse than disk" the module docstring above retracts.
-        yield tmp_path / name
-        return
-    try:
-        yield holder / name
+        yield root
+    except BaseException:
+        body_raised = True
+        raise
     finally:
-        # Best-effort: a tmpfs leak costs RAM for the run, but raising in teardown
-        # would turn a passing test red for a cleanup problem.
-        shutil.rmtree(holder, ignore_errors=True)
+        try:
+            if not body_raised:
+                _check_store_budget(root)
+        finally:
+            if holder is not None:
+                # Best-effort: a tmpfs leak costs RAM for the run, but raising in
+                # teardown would turn a passing test red for a cleanup problem.
+                shutil.rmtree(holder, ignore_errors=True)

--- a/scripts/testlib/store_siting.py
+++ b/scripts/testlib/store_siting.py
@@ -105,11 +105,19 @@ _PAGE_BYTES = 4096
 # statvfs used-delta).
 #
 # ⚠ SAY WHAT WAS MEASURED, because this constant has been wrong twice by being a
-# measurement of something else. The raw `PEAK_STORE_BYTES` from that run reads
-# 1,884,160 — bigger than the number below — and that peak is the ledger suite's OWN
-# deliberately-over-budget probe, not a fixture. 1,253,376 is the largest store the
-# suite builds in the course of testing something else, which is what this constant is
-# for. The gap to the runner-up (176,128) is 7x, so the peak is not a close call.
+# measurement of something else. The largest store that run saw AT ALL was 1,884,160 B
+# / 460 entries — bigger than the number below — and that one is the ledger suite's OWN
+# deliberately-over-budget probe (`_OVER_BUDGET_ENTRIES`), not a fixture. 1,253,376 is
+# the largest store the suite builds in the course of testing something else, which is
+# what this constant is for. The gap to the runner-up (176,128) is 7x, so the peak is
+# not a close call.
+#
+# ⚠ THAT WAS A ONE-OFF, HAND-RUN MEASUREMENT AND NOTHING RE-RUNS IT. There is no
+# instrumentation left in this module that records a peak; re-deriving this constant
+# means adding a print to `_check_store_budget` and running the three ledgered files
+# again. What IS automated is the other direction: `_check_store_budget` fails loudly
+# when a real store exceeds the budget below, so this number going stale LOW is caught
+# and this number going stale HIGH only wastes headroom.
 #
 # 🔴 APPARENT BYTES UNDERSTATE TMPFS COST ~17x. Entry COUNT drives this, not text size;
 # a floor reasoned from `st_size` lands an order of magnitude low.
@@ -132,7 +140,25 @@ _MEASURED_PEAK_STORE_BYTES = 1253376
 # measured_peak`, so shrinking the slack to buy room is a visible act, not a quiet one.
 _BUDGET_HEADROOM = 1.5
 
-# The budget: no store this suite builds may page-allocate more than this.
+# The budget: no ONE store this suite builds may page-allocate more than this.
+#
+# 🔴 SAY WHICH POPULATION — THIS NUMBER STOPPED BEING A SUM AND NOTHING SAID SO.
+# `main`'s predecessor constant was documented as the sum over every ledgered file's
+# fixtures, with the note that under `-n 4 --dist loadfile` they do not all hold stores
+# at once, i.e. it was deliberately conservative about CONCURRENCY. This value is a
+# single measured PEAK x `_BUDGET_HEADROOM`, and `_check_store_budget` enforces it
+# PER STORE. Two consequences, both real:
+#   * adding a second large fixture no longer moves this number at all. Only a single
+#     store growing past the budget does. That is the whole point of the move — the
+#     old sum moved six times in nineteen commits on edits that touched no store — but
+#     it means this constant is NOT an estimate of what the suite holds in RAM.
+#   * the gated tier runs `-n 4 --dist loadfile`, so up to `PYTEST_JOBS` stores can be
+#     live on one `/dev/shm` simultaneously, each permitted this much. `_MIN_FREE_BYTES`
+#     below is a margin over ONE store, not over four.
+# It is not a regression in VALUE today — 1,880,064 slightly exceeds the old sum of
+# 1,875,968 — and `tmpfs_dir()` re-reads `statvfs` on EVERY `store_root` entry, so the
+# free-space floor is a live check against whatever the other workers have already
+# taken rather than a static reservation. What is gone is the modelling, not the check.
 #
 # 🔴 ENFORCED AT RUNTIME, against the real directory tree, by `_check_store_budget`.
 # It is not a floor reasoned from source and it is not checked against another constant:
@@ -151,7 +177,13 @@ _LARGEST_STORE_BYTES = (
 )  # 1,880,064 at the two values above — a snapshot, not a second definition
 
 # Free space a candidate must have before we will site a store on it: the budget above,
-# with better than 2x margin. 🔴 **2x IS THE CLAIM AND IT IS THE CLAIM A TEST READS**
+# with better than 2x margin — over ONE store. 🔴 IT IS NOT A MARGIN OVER A PARALLEL
+# RUN, and the budget above says why: `PYTEST_JOBS` xdist workers (4 in the gated
+# sandbox) may each hold a store this large at the same moment on one `/dev/shm`.
+# What keeps that honest is not this constant but the fact that `tmpfs_dir()`
+# consults `statvfs` afresh at every `store_root` entry, so a worker arriving after the
+# others have filled the mount sees the reduced free space and falls back to disk.
+# 🔴 **2x IS THE CLAIM AND IT IS THE CLAIM A TEST READS**
 # (`test_the_free_space_floor_keeps_the_MARGIN_its_comment_claims`). Today the ratio
 # happens to be 2.23x (4,194,304 / 1,880,064), and that figure is a SNAPSHOT — do not
 # promote it to the guarantee, because a snapshot in this position is precisely what
@@ -265,14 +297,19 @@ class StoreBudgetExceeded(AssertionError):
     """
 
 
-# The peak any store has reached in THIS process, and where. Written by
-# `_check_store_budget`, read by the ledger tests as the positive control that the
-# measurement is wired to something: a budget checker that walks nothing reports a
-# reassuring zero for every store in the suite, which is indistinguishable from a
-# suite that builds no stores at all.
-PEAK_STORE_BYTES = 0
-PEAK_STORE_ENTRIES = 0
-PEAK_STORE_PATH = ""
+# 🔴 THERE USED TO BE THREE `PEAK_STORE_*` MODULE GLOBALS HERE AND THEIR COMMENT WAS
+# FALSE. It said they were "read by the ledger tests as the positive control that the
+# measurement is wired to something"; nothing in this repo read them — `git grep`
+# across the whole branch found only the lines that WROTE them. They were deleted
+# rather than given a reader, because the reachability claim they pretended to make is
+# already made properly, by two tests that were mutation-verified:
+#   * `test_store_root_INVOKES_the_budget_check_on_the_root_it_yielded` — the check is
+#     actually called on the root `store_root` yielded (a checker that walks nothing
+#     reports a reassuring zero, indistinguishable from a suite that builds no stores);
+#   * `test_a_store_over_the_budget_RAISES_with_the_budget_checks_own_message` — it can
+#     go red, on THIS check's own wording rather than on "something failed".
+# A global that a run leaves holding the ledger suite's own over-budget probe would
+# have been the wrong number to read anyway — see `_MEASURED_PEAK_STORE_BYTES` above.
 
 
 def page_allocated_bytes(root: Path) -> tuple[int, int]:
@@ -320,12 +357,7 @@ def _check_store_budget(root: Path) -> None:
     exactly the machines that have no tmpfs, so a fixture could grow unchecked on a
     developer's box and only fail once it reached a host where it mattered.
     """
-    global PEAK_STORE_BYTES, PEAK_STORE_ENTRIES, PEAK_STORE_PATH
     entries, allocated = page_allocated_bytes(root)
-    if allocated > PEAK_STORE_BYTES:
-        PEAK_STORE_BYTES = allocated
-        PEAK_STORE_ENTRIES = entries
-        PEAK_STORE_PATH = str(root)
     if allocated <= _LARGEST_STORE_BYTES:
         return
     raise StoreBudgetExceeded(

--- a/scripts/tests/test_store_siting_ledger.py
+++ b/scripts/tests/test_store_siting_ledger.py
@@ -224,10 +224,10 @@ def test_every_ledgered_file_IMPORTS_AND_CALLS_the_shared_siting_at_least_once()
     true thing.
 
     `scoped_store` is fixed. The residual gap is recorded and NOT closed here:
-    `test_subsystem_store_api.py` still builds store roots inline from
-    `tmp_path / "store"` at the sites `_DISK_ROOTED_SITES` counts below, each in one
-    or two tests rather than a shared fixture. That count is asserted so it can only
-    go DOWN — see the next test.
+    `test_subsystem_store_api.py` still builds store roots inline from `tmp_path` at
+    the sites `_DISK_ROOTED_SITES` counts below — 20 of them spelled `tmp_path /
+    "store"` and 13 not — each in one or two tests rather than a shared fixture. That
+    count is asserted so it can only go DOWN — see the next test.
     """
     offenders = []
     for name in sorted(EXPECTED_SERVER_TESTS):
@@ -273,13 +273,24 @@ def test_the_scan_can_actually_SEE_a_build_server_call():
 # rather than a rushed refactor.
 # 🔴 33, UP FROM 20, AND NOT ONE SITE WAS ADDED. The predicate below stopped being
 # spelled, and 13 inline disk-backed store roots that had always been there became
-# visible. Every one of them was a REAL store served by `running(...)`:
-# `served = tmp_path / "served"` (a `cp -a` of the store fixture, written into, then
-# served — five sites), `served-elsewhere` (three), `stage` (two, the output of
-# `run_seed` served back), `big`, `at-the-cap`, `unambiguous`, and two
-# `running(tmp_path / "absent")`. The last pair is the only debatable entry: an
-# absent store writes nothing and fsyncs nothing, so counting it errs WIDE — the
-# safe direction for a ratchet, and not worth a second spelled exception to avoid.
+# visible. Every one of them was a REAL store served by `running(...)`. The
+# breakdown, RE-MEASURED 2026-09-02 and summing to 13 — an earlier revision of this
+# comment said "five" `served` and summed to 15, which is the sort of arithmetic
+# nobody re-does:
+#
+#     served              3    a `cp -a` of the store fixture, written into, served
+#     served-elsewhere    3
+#     stage               2    the output of `run_seed`, served back
+#     absent              2    `running(tmp_path / "absent")`
+#     big                 1
+#     at-the-cap          1
+#     unambiguous         1
+#                        --
+#                        13   + the 20 `store`/`name`/`kind` sites = 33
+#
+# The `absent` pair is the only debatable entry: an absent store writes nothing and
+# fsyncs nothing, so counting it errs WIDE — the safe direction for a ratchet, and not
+# worth a second spelled exception to avoid.
 #
 # 🔴 SO THIS NUMBER MOVING UP IS NOT ALWAYS DEBT ARRIVING. The assertion below cannot
 # tell "13 new store sites were written" from "the predicate got 13 sites wider", and
@@ -289,10 +300,23 @@ _DISK_ROOTED_SITES = 33
 
 # Directory names that make a `tmp_path / "<name>"` a store root ON SIGHT, with no
 # need for it to flow anywhere. MEASURED 2026-09-02: of the 33 counted sites, 26 flow
-# into a store consumer and would be caught without this set — but 7 are built and
-# used without ever reaching `_build_store`/`running`/`build_server`, so deleting it
-# would lose those seven. It is a residual shortcut, not the test; the flow-based arm
-# in `_index_store_root_uses` is what makes the predicate structural.
+# into a store consumer and would be caught without this set; 7 are counted ONLY by
+# this set, so deleting it would lose those seven.
+#
+# 🔴 BUT DO NOT READ THOSE 7 AS "SITES THAT GENUINELY DO NOT FLOW ANYWHERE" — an
+# earlier revision of this comment said exactly that and it is false of all seven. They
+# are every `tmp_path / "store"` at :11310, :11765, :13099, :14086, :14201, :14227 and
+# :14803 of `test_subsystem_store_api.py`, and they split two ways, each one a MASKED
+# GAP in the flow arm rather than a shortcut:
+#   * :11310 and :13099 are `root = tmp_path / "store"` in a `_phases` helper whose
+#     NESTED `present()`/`absent()` closures call `_build_store(root, …)` — a consumer
+#     `_ROOT_CONSUMERS` names. They are invisible only because `_walk_scope` stops at a
+#     nested function boundary, so no single scope sees both the binding and the call.
+#   * the other five reach `api.append_bullet` / `api.rc.load_index` — real store
+#     consumers that `_ROOT_CONSUMERS` simply does not name (see its own comment: the
+#     set closes renames, not GROWTH into a new consumer name).
+# So `_ROOT_NAMES` is currently propping up the flow arm on this file. Deleting it
+# would not "lose seven non-flowing sites", it would expose two structural gaps.
 _ROOT_NAMES = {"store", "src"}
 
 
@@ -346,13 +370,26 @@ def _is_disk_rooted_store_expr(node: ast.AST) -> bool:
     return False
 
 
-# The calls that CONSUME a store root. A callee name is a real referent — the
-# function being invoked — so this is not the "spelled guard" hazard the binding set
-# below used to be; renaming `_build_store` renames its definition too.
+# The calls that CONSUME a store root.
+#
+# 🔴 THIS SET CLOSES RENAMES AND NOT GROWTH, AND ONLY THE FIRST HALF USED TO BE SAID.
+# The rename argument holds: a callee name is a real referent — the function being
+# invoked — so renaming `_build_store` renames its definition too and the set follows.
+# (The set it replaced, `_ROOT_BINDINGS`, keyed on the name of the VARIABLE a root was
+# bound to, which no rename follows. That set is deleted; `test_the_site_index_keys_on_
+# USE_not_on_the_variables_NAME` is the control that killed it.)
+#
+# But a ratchet's job is to notice GROWTH, and growth arrives as a NEW consumer name,
+# which no rename argument covers. Measured with this file's own control probe:
+# `running(served)` counts 1 and `serve_store(served)` — same expression, same copy,
+# same writes — counts 0. So only half the spelled-guard class is closed here, and
+# `_ROOT_NAMES` above records what that already costs on the real file today.
 _ROOT_CONSUMERS = {"_build_store", "running", "build_server"}
 # Wrappers a path is handed through on its way into a consumer. `str(root)` is the
-# live shape: `build_server(..., store_root=str(store))`.
-_PATH_WRAPPERS = {"str", "fspath", "os.fspath", "Path"}
+# live shape: `build_server(..., store_root=str(store))`. Bare names only: `_unwrap`
+# matches an `ast.Attribute` on its `.attr`, so `os.fspath(x)` is matched by the
+# `"fspath"` entry and a dotted `"os.fspath"` entry could never match anything.
+_PATH_WRAPPERS = {"str", "fspath", "Path"}
 _STORE_ROOT_PARENTS: dict[int, bool] = {}
 
 
@@ -435,9 +472,19 @@ def _walk_scope(scope: ast.AST):
 def _assignments(scope: ast.AST):
     """`(dotted-target, value)` for every binding form that can hold a store root.
 
-    🔴 The four shapes past a plain `x = …` are here because an audit walked each of
-    them through the previous index: a tuple target, an attribute target, a walrus,
-    and a helper that RETURNS the root instead of binding it.
+    The shapes past a plain `x = …` that THIS function handles are: an annotated
+    assignment (`ast.AnnAssign`), a walrus (`ast.NamedExpr`), a `with … as` target
+    (`ast.withitem`), and a tuple/list target on any of them.
+
+    🔴 SAY WHICH ONES ARE HERE. A previous revision of this docstring listed four
+    shapes as "here" and two of them were not: a helper that RETURNS the root is
+    resolved in `_index_store_root_uses` via `flowing_callees`, not by any binding
+    form; and it omitted `ast.withitem`, which the body below does handle. The walrus
+    IS here, but it is an INVARIANT guard rather than regression coverage — it already
+    counted before this function existed, because a consumer's argument is walked
+    recursively, so the nested `tmp_path / name` was reached without the binding ever
+    being resolved. `test_the_site_index_sees_the_BINDING_FORMS_a_plain_assignment_is_
+    not`'s docstring says the same thing, and the two used to disagree.
     """
     for node in _walk_scope(scope):
         pairs: list[tuple[ast.AST, ast.AST]] = []
@@ -768,9 +815,24 @@ def test_one_tests_store_root_does_not_vouch_for_ANOTHERS_scratch_directory():
     authors of not using `store_root()` for things that are not stores. Round 3's
     audit called exactly that "a false accusation", and `main` then hit it.
 
-    ⚠ This pins the SCOPING, not a hazard anyone has been bitten by twice: the count
-    over the real file is 20 either way today. It is here so the docstring's
-    per-function claim is checked rather than asserted.
+    ⚠ THE SCOPING IS NOT FREE, AND THIS DOCSTRING USED TO SAY IT WAS. It read "the
+    count over the real file is 20 either way today" — wrong in both halves. MEASURED
+    2026-09-02 on `test_subsystem_store_api.py`: **per-scope 33, file-wide 39**. The
+    scoping suppresses SIX sites, and they are not one kind:
+
+      * four `tmp_path / "stage"` (:2658, :3619, :3647, :3750) are stage directories
+        handed to `seed.sh` as a `--stage` SUBPROCESS argument and never served
+        in-process. File-wide indexing would count them only by colliding with the
+        genuinely-served `stage` at :5710/:5726 — precisely the false accusation this
+        scoping exists to prevent. Here the scoping is RIGHT.
+      * two — `ordered-served` (:3945) and `ambig-served` (:4294) — ARE real
+        disk-backed store roots, `cp -a`'d and served in-process. File-wide would
+        count them for the right reason by accident. They are missed for a different
+        reason entirely, recorded and NOT closed: see
+        `test_a_store_root_bound_in_a_pytest_FIXTURE_is_NOT_counted` below.
+
+    So file-wide indexing is not "the same answer, more cheaply" — it is four false
+    accusations bought with two accidental catches, which is why it stays rejected.
     """
     probe = (
         "def test_a(tmp_path, name):\n"
@@ -785,6 +847,88 @@ def test_one_tests_store_root_does_not_vouch_for_ANOTHERS_scratch_directory():
         f"counted {_count_disk_rooted(probe)} store roots in a module with one store "
         "and one scratch directory. The index is resolving names across function "
         "boundaries, so an unrelated local called `root` is being counted as a store."
+    )
+
+
+def test_a_store_root_bound_in_a_pytest_FIXTURE_is_NOT_counted():
+    """🔴 A KNOWN, MEASURED RESIDUAL — THIS IS A GAP GUARD, NOT COVERAGE.
+
+    Read the name literally: it asserts the ratchet CANNOT see a store root bound
+    inside a `@pytest.fixture` and served in a test that requests it. That is a hole,
+    it is recorded here so it cannot be rediscovered as news, and it is pinned so that
+    CLOSING it fails this test and forces whoever closes it to delete this guard and
+    move `_DISK_ROOTED_SITES` in the same commit.
+
+    Fixture-binding is this file's dominant idiom, so the hole is not exotic. TWO LIVE
+    INSTANCES on `test_subsystem_store_api.py`, both real `cp -a` copies of a store,
+    written into, and served in-process by the real store server:
+
+      * `served = tmp_path / "ordered-served"` in the `shuffled_pair` fixture (:3945),
+        served at :4392 and four more `running(served)` sites;
+      * `served = tmp_path / "ambig-served"` in the `ambiguous_pair` fixture (:4294),
+        served at :4758 and one more.
+
+    🔴 WHY IT IS NOT CLOSED, stated rather than implied. The flow arm is scoped per
+    function (`_walk_scope` stops at a function boundary), and a pytest fixture crosses
+    exactly that boundary through pytest's own name-injection, which is not a Python
+    binding the AST can see. Following it would mean a NEW cross-scope resolver:
+    fixture def -> fixture name -> parameter of a consuming scope -> and, for both live
+    instances, the ELEMENT POSITION in a returned tuple that the consumer destructures
+    (`local, served = shuffled_pair`). File-wide indexing is not the shortcut: it was
+    measured (see the scoping test above) to buy these two catches at the cost of four
+    false accusations, and round 3 rejected it for exactly that.
+
+    So the honest statement, which replaces the one this PR shipped: the predicate does
+    NOT cover the flow case generally. It covers the flow case WITHIN ONE FUNCTION
+    SCOPE.
+    """
+    inline = (
+        "def test_probe(tmp_path):\n"
+        "    served = tmp_path / 'served'\n"
+        "    (served / 'scope' / 'e.md').write_text('x')\n"
+        "    running(served)\n"
+    )
+    via_fixture = (
+        "import pytest\n"
+        "@pytest.fixture\n"
+        "def pair(tmp_path):\n"
+        "    served = tmp_path / 'served'\n"
+        "    (served / 'scope' / 'e.md').write_text('x')\n"
+        "    return served\n"
+        "def test_probe(pair):\n"
+        "    running(pair)\n"
+    )
+    # The live shape: the fixture returns a TUPLE and the test destructures it.
+    via_fixture_tuple = (
+        "import pytest\n"
+        "@pytest.fixture\n"
+        "def pair(tmp_path):\n"
+        "    local = tmp_path / 'local'\n"
+        "    served = tmp_path / 'served'\n"
+        "    (served / 'scope' / 'e.md').write_text('x')\n"
+        "    return local, served\n"
+        "def test_probe(pair):\n"
+        "    local, served = pair\n"
+        "    running(served)\n"
+    )
+    # The positive control. Without it a probe that counts nothing for an unrelated
+    # reason (a typo in the template, a consumer name that is not in the set) would
+    # make the two zeros below look like the documented residual when they are not.
+    assert _count_disk_rooted(inline) == 1, (
+        f"the inline form of this probe counts {_count_disk_rooted(inline)}, not 1 — "
+        "this control cannot demonstrate a residual if the shape is uncountable for "
+        "some other reason entirely"
+    )
+    assert _count_disk_rooted(via_fixture) == 0, (
+        "the ratchet now SEES a store root bound in a fixture. That is good news and "
+        "it makes this guard wrong: delete it, re-measure _DISK_ROOTED_SITES (the two "
+        "live instances at test_subsystem_store_api.py:3945 and :4294 will start "
+        "counting), and rewrite the residual in "
+        "test_one_tests_store_root_does_not_vouch_for_ANOTHERS_scratch_directory."
+    )
+    assert _count_disk_rooted(via_fixture_tuple) == 0, (
+        "the tuple-returning fixture form — the shape both live instances actually "
+        "use — is now counted. Same action as above."
     )
 
 
@@ -823,20 +967,25 @@ def test_one_tests_store_root_does_not_vouch_for_ANOTHERS_scratch_directory():
 # that it can go red, that it does so on both siting branches, and that it does not
 # eat the failure of the test it is attached to.
 #
-# MEASURED 2026-09-02 over the three ledgered files: the check ran on **448 stores**,
-# the largest being 1,253,376 B / 306 entries (`test_cairn_cli.py`'s concurrency
-# fixture) and the next largest 176,128 B / 43 entries. So the coverage claim is not a
-# reassuring zero — the instrument was watched observing 448 things, and the peak it
-# reported is the fixture the module docstring has always named.
+# ⚠ WHAT IS AND IS NOT AUTOMATED HERE — an earlier revision of this comment blurred
+# the two. A ONE-OFF, HAND-INSTRUMENTED run over the three ledgered files on 2026-09-02
+# saw the check called on 448 stores, the largest 1,253,376 B / 306 entries
+# (`test_cairn_cli.py`'s concurrency fixture) and the next 176,128 B / 43 entries. That
+# was a manual measurement; the instrumentation it used has been removed, NOTHING
+# re-runs it, and it must not be quoted as a standing positive control. The standing
+# controls are the two tests below, both of which run every time and were
+# mutation-verified: `test_store_root_INVOKES_the_budget_check_on_the_root_it_yielded`
+# (the check is reached at all) and `test_a_store_over_the_budget_RAISES_with_the_
+# budget_checks_own_message` (it can go red, on its own wording).
 #
 # The residual, stated rather than hidden: this is a claim about stores that are
 # actually BUILT by a run. A fixture nobody executes is not measured. The gate runs the
 # whole suite, and `test_every_ledgered_file_IMPORTS_AND_CALLS_the_shared_siting_at_
 # least_once` above is what keeps the ledgered files routed through the seam, so the
 # two together cover the population. A deselected subset run is not that claim. Nor is
-# it a claim about the 20 inline `tmp_path / "store"` sites the FIRST ratchet counts:
-# those never reach `store_root`, live on disk rather than tmpfs, and are that
-# ratchet's business, not this budget's.
+# it a claim about the 33 inline sites the FIRST ratchet counts (20 of them spelled
+# `tmp_path / "store"`, 13 not): those never reach `store_root`, live on disk rather
+# than tmpfs, and are that ratchet's business, not this budget's.
 
 # How much bigger than the measured peak the budget must be. 🔴 THE PREVIOUS BUDGET HAD
 # ZERO SLACK — 1,875,968 was exactly (442 + 16) * 4096 where 442 was the sweep's own

--- a/scripts/tests/test_store_siting_ledger.py
+++ b/scripts/tests/test_store_siting_ledger.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 import ast
 import sys
+
+import pytest
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
@@ -269,8 +271,28 @@ def test_the_scan_can_actually_SEE_a_build_server_call():
 # A scripted mass conversion of these sites was attempted and REVERTED: it silently
 # skipped 9 of 19 signature edits while its own assertion still passed. Hence a ratchet
 # rather than a rushed refactor.
-_DISK_ROOTED_SITES = 20
+# 🔴 33, UP FROM 20, AND NOT ONE SITE WAS ADDED. The predicate below stopped being
+# spelled, and 13 inline disk-backed store roots that had always been there became
+# visible. Every one of them was a REAL store served by `running(...)`:
+# `served = tmp_path / "served"` (a `cp -a` of the store fixture, written into, then
+# served — five sites), `served-elsewhere` (three), `stage` (two, the output of
+# `run_seed` served back), `big`, `at-the-cap`, `unambiguous`, and two
+# `running(tmp_path / "absent")`. The last pair is the only debatable entry: an
+# absent store writes nothing and fsyncs nothing, so counting it errs WIDE — the
+# safe direction for a ratchet, and not worth a second spelled exception to avoid.
+#
+# 🔴 SO THIS NUMBER MOVING UP IS NOT ALWAYS DEBT ARRIVING. The assertion below cannot
+# tell "13 new store sites were written" from "the predicate got 13 sites wider", and
+# they demand opposite actions. Establish WHICH before touching the constant, the same
+# way the DOWN direction already demands.
+_DISK_ROOTED_SITES = 33
 
+# Directory names that make a `tmp_path / "<name>"` a store root ON SIGHT, with no
+# need for it to flow anywhere. MEASURED 2026-09-02: of the 33 counted sites, 26 flow
+# into a store consumer and would be caught without this set — but 7 are built and
+# used without ever reaching `_build_store`/`running`/`build_server`, so deleting it
+# would lose those seven. It is a residual shortcut, not the test; the flow-based arm
+# in `_index_store_root_uses` is what makes the predicate structural.
 _ROOT_NAMES = {"store", "src"}
 
 
@@ -283,7 +305,18 @@ def _is_disk_rooted_store_expr(node: ast.AST) -> bool:
     `(tmp_path / name).write_text(body)` — a scratch file called "wrapped.md" — and the
     ratchet counted 21, demanding an author use `store_root()` for something that is
     not a store. So a Name only counts when the expression is USED as a store root:
-    assigned to a root-ish variable, or passed to `_build_store`/`running`.
+    handed to `_build_store` / `running` / `build_server`, directly or through the
+    variable it was bound to. See `_index_store_root_uses`.
+
+    🔴 AND NEITHER IS A CONSTANT IN A SET OF TWO WORDS. Round 7's audit found the
+    binding-NAME half of this predicate spelled and walked through it with a rename;
+    the DIRECTORY-name half was the same defect, unreported and larger. `served =
+    tmp_path / "served"` is a `cp -a` copy of the store fixture, written into and then
+    handed to `running(...)` — a disk-backed store server by every property that
+    matters, invisible because the directory is not called "store". Measured: 13 such
+    sites, on the same file, at the same moment the ratchet read a confident 20. So the
+    Constant arm now ALSO counts a path that flows into a store consumer, and
+    `_ROOT_NAMES` is the residual on-sight shortcut rather than the whole test.
 
     Quoting and spacing still do not matter: they do not survive parsing.
     """
@@ -293,7 +326,9 @@ def _is_disk_rooted_store_expr(node: ast.AST) -> bool:
         right = node.right
         if isinstance(right, ast.Constant) and right.value in _ROOT_NAMES:
             return True
-        return isinstance(right, ast.Name) and _used_as_a_store_root(node)
+        return isinstance(right, (ast.Name, ast.Constant)) and _used_as_a_store_root(
+            node
+        )
     if (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
@@ -305,45 +340,224 @@ def _is_disk_rooted_store_expr(node: ast.AST) -> bool:
         first = node.args[0]
         if isinstance(first, ast.Constant) and first.value in _ROOT_NAMES:
             return True
-        return isinstance(first, ast.Name) and _used_as_a_store_root(node)
+        return isinstance(first, (ast.Name, ast.Constant)) and _used_as_a_store_root(
+            node
+        )
     return False
 
 
-# Variables a store root is bound to in this suite, and the calls that consume one.
-_ROOT_BINDINGS = {"root", "store", "store_root", "src", "source_store", "scoped"}
+# The calls that CONSUME a store root. A callee name is a real referent — the
+# function being invoked — so this is not the "spelled guard" hazard the binding set
+# below used to be; renaming `_build_store` renames its definition too.
 _ROOT_CONSUMERS = {"_build_store", "running", "build_server"}
+# Wrappers a path is handed through on its way into a consumer. `str(root)` is the
+# live shape: `build_server(..., store_root=str(store))`.
+_PATH_WRAPPERS = {"str", "fspath", "os.fspath", "Path"}
 _STORE_ROOT_PARENTS: dict[int, bool] = {}
+
+
+def _unwrap(expr: ast.AST) -> ast.AST:
+    """Peel `str(...)` / `os.fspath(...)` / `Path(...)` off a path expression."""
+    while isinstance(expr, ast.Call) and expr.args:
+        name = None
+        if isinstance(expr.func, ast.Name):
+            name = expr.func.id
+        elif isinstance(expr.func, ast.Attribute):
+            name = expr.func.attr
+        if name not in _PATH_WRAPPERS:
+            break
+        expr = expr.args[0]
+    return expr
+
+
+def _dotted(expr: ast.AST) -> str | None:
+    """`a`, `self.root`, `cls.x.y` -> the dotted name. Anything else -> None."""
+    parts: list[str] = []
+    cur = expr
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if not isinstance(cur, ast.Name):
+        return None
+    parts.append(cur.id)
+    return ".".join(reversed(parts))
+
+
+def _path_base(expr: ast.AST) -> str | None:
+    """The dotted name a path expression is ROOTED at.
+
+    `root / "store" / f"{x}.md"` -> `root`; `str(self.src / "a")` -> `self.src`.
+    This is what makes the index structural: it asks what a value IS BUILT FROM,
+    never what the variable holding it is called.
+    """
+    cur = _unwrap(expr)
+    while True:
+        if isinstance(cur, ast.BinOp) and isinstance(cur.op, ast.Div):
+            cur = _unwrap(cur.left)
+        elif isinstance(cur, ast.Call) and isinstance(cur.func, ast.Attribute):
+            cur = _unwrap(cur.func.value)
+        else:
+            break
+    return _dotted(cur)
+
+
+_FUNCTION_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+
+
+def _scopes(tree: ast.AST) -> list[ast.AST]:
+    """Every function body, plus the module itself, as separate name scopes.
+
+    Per-scope rather than file-wide: a `root` that flows into `_build_store` in one
+    test must not silently vouch for an unrelated `root` in another.
+    """
+    out: list[ast.AST] = [tree]
+    for node in ast.walk(tree):
+        if isinstance(node, _FUNCTION_NODES):
+            out.append(node)
+    return out
+
+
+def _walk_scope(scope: ast.AST):
+    """`ast.walk`, but STOPPING at a nested function boundary.
+
+    🔴 A plain `ast.walk(module)` descends into every function body, so treating the
+    module as "a scope" would silently make the whole index file-wide and the
+    per-scope claim above a lie. The names inside a function are that function's.
+    """
+    stack = list(ast.iter_child_nodes(scope))
+    while stack:
+        node = stack.pop()
+        yield node
+        if not isinstance(node, _FUNCTION_NODES):
+            stack.extend(ast.iter_child_nodes(node))
+
+
+def _assignments(scope: ast.AST):
+    """`(dotted-target, value)` for every binding form that can hold a store root.
+
+    🔴 The four shapes past a plain `x = …` are here because an audit walked each of
+    them through the previous index: a tuple target, an attribute target, a walrus,
+    and a helper that RETURNS the root instead of binding it.
+    """
+    for node in _walk_scope(scope):
+        pairs: list[tuple[ast.AST, ast.AST]] = []
+        if isinstance(node, ast.Assign):
+            pairs = [(t, node.value) for t in node.targets]
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            pairs = [(node.target, node.value)]
+        elif isinstance(node, ast.NamedExpr):
+            pairs = [(node.target, node.value)]
+        elif isinstance(node, ast.withitem) and node.optional_vars is not None:
+            pairs = [(node.optional_vars, node.context_expr)]
+        for target, value in pairs:
+            if isinstance(target, (ast.Tuple, ast.List)):
+                # `a, b = tmp_path / "store", other` binds elementwise; anything
+                # else (a starred unpack, a call) is credited to every element,
+                # which errs WIDE — the safe direction for a ratchet.
+                elts = value.elts if isinstance(value, (ast.Tuple, ast.List)) else None
+                for i, sub in enumerate(target.elts):
+                    name = _dotted(sub)
+                    if name:
+                        yield name, (elts[i] if elts and i < len(elts) else value)
+                continue
+            name = _dotted(target)
+            if name:
+                yield name, value
 
 
 def _index_store_root_uses(tree: ast.AST) -> None:
     """Record which `tmp_path / X` nodes are USED as a store root.
 
-    Two shapes, both structural: bound to a root-ish name, or handed to a call that
-    takes a store root. Anything else — a scratch file, a token path, a cache dir —
-    is not this ratchet's business.
+    🔴 THIS USED TO BE A SPELLED GUARD AND IT WAS WALKED THROUGH WITH A PAIRED
+    CONTROL. The old index counted a `tmp_path / <Name>` only when the variable it
+    was bound to was in `_ROOT_BINDINGS = {"root", "store", "store_root", "src",
+    "source_store", "scoped"}`. An audit copied a COUNTED site verbatim and renamed
+    the variable to `base_dir`: identical runtime behaviour, identical fsync
+    exposure, and the ratchet stayed at 20 with the suite green. Rename it back to
+    `root` and nothing else, and the same code went red. A guard on a WORD is
+    walkable by anything that can spell a different word.
+
+    So the index now asks what the value FLOWS INTO, never what it is called:
+
+      * an expression handed to a store consumer — positionally OR BY KEYWORD.
+        🔴 The keyword half was missing entirely; `node.keywords` appeared nowhere
+        in this file, and `build_server(..., store_root=str(store))` is the live
+        spelling at nine call sites. Same expression, same behaviour, invisible.
+      * a name that some store-flowing expression is ROOTED at, so
+        `root = tmp_path / name` counts because `_build_store(root / "store", …)`
+        exists in the same scope — with no opinion about the word "root".
+      * a helper whose RETURN value is that expression, when the helper itself is
+        called in a store-flowing position.
+
+    Scoped per function, so one test's `root` cannot vouch for another's.
     """
     _STORE_ROOT_PARENTS.clear()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name) and target.id in _ROOT_BINDINGS:
-                    _STORE_ROOT_PARENTS[id(node.value)] = True
-        elif isinstance(node, ast.AnnAssign):
-            if isinstance(node.target, ast.Name) and node.target.id in _ROOT_BINDINGS:
-                if node.value is not None:
-                    _STORE_ROOT_PARENTS[id(node.value)] = True
-        elif isinstance(node, ast.Call):
+
+    # Which locally-defined functions are called in a store-flowing position?
+    flowing_callees: set[str] = set()
+
+    def mark(expr: ast.AST) -> None:
+        _STORE_ROOT_PARENTS[id(expr)] = True
+        for sub in ast.walk(expr):
+            # `_build_store(root / "store", …)` — the tmp_path expr may be nested.
+            _STORE_ROOT_PARENTS[id(sub)] = True
+
+    for scope in _scopes(tree):
+        flowing_roots: set[str] = set()
+        for node in _walk_scope(scope):
+            if not isinstance(node, ast.Call):
+                continue
             name = None
             if isinstance(node.func, ast.Name):
                 name = node.func.id
             elif isinstance(node.func, ast.Attribute):
                 name = node.func.attr
-            if name in _ROOT_CONSUMERS:
-                for arg in node.args:
-                    _STORE_ROOT_PARENTS[id(arg)] = True
-                    # `_build_store(root / "store", …)` — the tmp_path expr is nested
-                    for sub in ast.walk(arg):
-                        _STORE_ROOT_PARENTS[id(sub)] = True
+            if name not in _ROOT_CONSUMERS:
+                continue
+            for arg in list(node.args) + [kw.value for kw in node.keywords]:
+                mark(arg)
+                base = _path_base(arg)
+                if base:
+                    flowing_roots.add(base)
+                inner = _unwrap(arg)
+                callee = None
+                if isinstance(inner, ast.Call):
+                    if isinstance(inner.func, ast.Name):
+                        callee = inner.func.id
+                    elif isinstance(inner.func, ast.Attribute):
+                        callee = inner.func.attr
+                if callee:
+                    flowing_callees.add(callee)
+        # To a FIXPOINT, because a store root reaches a consumer through a chain:
+        # `holder = tmp_path / name` -> `root = holder / "store"` -> `running(root)`.
+        # One pass sees only the last hop, so the `tmp_path` expression that started
+        # the chain stays uncounted — a silent under-report in a ratchet whose whole
+        # job is to notice growth. The set only grows, so this terminates.
+        bindings = list(_assignments(scope))
+        while True:
+            grew = False
+            for target, value in bindings:
+                if target not in flowing_roots:
+                    continue
+                mark(value)
+                base = _path_base(value)
+                if base and base not in flowing_roots:
+                    flowing_roots.add(base)
+                    grew = True
+            if not grew:
+                break
+
+    if flowing_callees:
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if node.name not in flowing_callees:
+                continue
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Return) and sub.value is not None:
+                    mark(sub.value)
+                elif isinstance(sub, (ast.Yield, ast.YieldFrom)) and sub.value:
+                    mark(sub.value)
 
 
 def _used_as_a_store_root(node: ast.AST) -> bool:
@@ -359,7 +573,12 @@ def test_the_inline_disk_rooted_store_sites_do_not_GROW():
         f"{actual} inline disk-backed store roots, up from {_DISK_ROOTED_SITES}. "
         "Each writes through server.py:_replace_bytes and fsyncs inside the request, "
         "so a new one rejoins the contention-flake population. Use "
-        "testlib.store_siting.store_root() instead."
+        "testlib.store_siting.store_root() instead. 🔴 BUT FIRST check WHICH happened, "
+        "because this direction is ambiguous too: did someone WRITE new inline store "
+        "sites, or did _is_disk_rooted_store_expr get WIDER and start seeing sites "
+        "that were always there? Round 7 was the second — 20 -> 33 with no site added, "
+        "because the predicate stopped keying on the directory being spelled 'store'. "
+        "Raising the constant is right for a widening and wrong for new debt."
     )
     # 🔴 NO SLACK, and no `or actual == 0` escape. The previous version tolerated a
     # drop of up to three and passed unconditionally at zero — so the count could
@@ -375,136 +594,466 @@ def test_the_inline_disk_rooted_store_sites_do_not_GROW():
     )
 
 
-# 🔴 THE SECOND RATCHET, AND IT CLOSES THE ONE HOLE THE FIRST ONE'S OWN LESSON NAMES.
-# `store_siting._LARGEST_STORE_BYTES` is the peak a store reaches on tmpfs, and
-# `_MIN_FREE_BYTES` must clear it. Round 4 asserted one constant against the other —
-# two literals sixteen lines apart in one file, checked by a test whose NAME claims to
-# know "the largest store this suite builds" while its body knows nothing about the
-# suite. An audit measured the consequence: grow the concurrency fixture from
-# `range(303)` to `range(1200)`, touch neither constant, and every guard stays green
-# while a /dev/shm of 4500k dies `OSError: [Errno 28]` — the ENOSPC hazard this whole
-# module exists to close, re-armed through the guard added to prevent it.
+def _count_disk_rooted(source: str) -> int:
+    """The ratchet's own counter, run over a probe module."""
+    tree = ast.parse(source)
+    _index_store_root_uses(tree)
+    return sum(1 for n in ast.walk(tree) if _is_disk_rooted_store_expr(n))
+
+
+# A counted site, verbatim in shape, with the binding NAME as the only variable.
+# `tmp_path / kind` is the live shape at two sites in `test_subsystem_store_api.py`.
+_RENAME_PROBE = """
+def test_probe(tmp_path, kind):
+    {var} = tmp_path / kind
+    store = _build_store({var} / "store", {{}})
+    running(store)
+"""
+
+
+def test_the_site_index_keys_on_USE_not_on_the_variables_NAME():
+    """🔴 THE PAIRED CONTROL THAT KILLED THE PREVIOUS INDEX.
+
+    Two modules that differ in exactly one character sequence — the name of a local
+    variable — and in nothing else. Same expression, same call, same fsync exposure,
+    same behaviour at runtime. The old index consulted `_ROOT_BINDINGS = {"root",
+    "store", "store_root", "src", "source_store", "scoped"}`, so `root` counted and
+    `base_dir` did not: a new disk-backed store site could be added invisibly by
+    choosing a word the set had not thought of.
+
+    Reading a rename as a coverage change is the definition of a spelled guard.
+    """
+    named_root = _count_disk_rooted(_RENAME_PROBE.format(var="root"))
+    renamed = _count_disk_rooted(_RENAME_PROBE.format(var="base_dir"))
+    assert named_root == 1, (
+        f"the probe's own shape is not counted at all ({named_root}) — this control "
+        "cannot detect a rename if it detects nothing"
+    )
+    assert renamed == named_root, (
+        f"renaming the variable moved the count {named_root} -> {renamed}. The index "
+        "is keying on the WORD again, not on what the value flows into."
+    )
+
+
+def test_the_site_index_does_not_key_on_the_DIRECTORY_being_spelled_store():
+    """The Constant-arm mirror of the rename control above, and it found more.
+
+    `served = tmp_path / "served"` is a `cp -a` of the store fixture, written into and
+    then handed to `running(...)`. It is a disk-backed store server by every property
+    that matters and differs from a counted site in one thing: the word in the path.
+    Thirteen such sites existed on `test_subsystem_store_api.py` while the ratchet
+    read a confident 20.
+
+    The `served` half of this pair is REGRESSION coverage — measured 0 before, 1 now.
+    """
+    template = (
+        "def test_probe(tmp_path):\n"
+        "    served = tmp_path / '{name}'\n"
+        "    (served / 'scope' / 'e.md').write_text('x')\n"
+        "    running(served)\n"
+    )
+    spelled_store = _count_disk_rooted(template.format(name="store"))
+    spelled_served = _count_disk_rooted(template.format(name="served"))
+    assert spelled_store == 1, spelled_store
+    assert spelled_served == spelled_store, (
+        f"a store directory called 'store' counts {spelled_store}, the identical one "
+        f"called 'served' counts {spelled_served}. Same copy, same writes, same "
+        "`running()`, same fsyncs — only the word differs."
+    )
+
+
+def test_a_path_that_is_never_used_as_a_store_still_does_NOT_count():
+    """The other side of that widening, and it is the one that keeps it honest.
+
+    Widening the Constant arm to "any word" would re-create the false accusation round
+    3 measured: `(tmp_path / name).write_text(body)` for a scratch file, counted as a
+    store an author must convert. Flowing into a store consumer is the whole
+    discriminator, so a cache directory and a scratch file must still be invisible.
+    """
+    probe = (
+        "def test_probe(tmp_path):\n"
+        "    cache = tmp_path / 'cache'\n"
+        "    (tmp_path / 'wrapped.md').write_text('body')\n"
+        "    _extract(body, tmp_path / 'copy')\n"
+        "    cache.mkdir()\n"
+    )
+    assert _count_disk_rooted(probe) == 0, (
+        f"counted {_count_disk_rooted(probe)} store roots in a module with none. A "
+        "cache dir, a scratch file and a non-consumer call are not stores, and "
+        "demanding store_root() for them is the false accusation round 3 measured."
+    )
+
+
+def test_a_store_root_passed_BY_KEYWORD_counts_like_a_positional_one():
+    """🔴 `node.keywords` APPEARED NOWHERE IN THIS FILE.
+
+    `_index_store_root_uses` walked `node.args` only, so `build_server(store_root=X)`
+    — the spelling used at nine live call sites in `test_subsystem_store_api.py` —
+    was invisible while the identical expression passed positionally was counted.
+    Python does not distinguish them; neither may this.
+    """
+    positional = _count_disk_rooted(
+        "def test_probe(tmp_path, name):\n    build_server(tmp_path / name)\n"
+    )
+    keyword = _count_disk_rooted(
+        "def test_probe(tmp_path, name):\n"
+        "    build_server(host='127.0.0.1', store_root=str(tmp_path / name))\n"
+    )
+    assert positional == 1, positional
+    assert keyword == positional, (
+        f"positional counted {positional}, keyword counted {keyword}. Same value, "
+        "same consumer, same disk-backed store — only the calling convention differs."
+    )
+
+
+def test_the_site_index_sees_the_BINDING_FORMS_a_plain_assignment_is_not():
+    """Tuple targets, attribute targets, the walrus, and a helper that RETURNS the
+    root. Each was reproduced as a way to bind a store root that the old index did
+    not look at — so each is a way to add a site the ratchet would not count.
+
+    Named individually rather than asserted as a total, because a single number here
+    would let three of the four regress unnoticed behind one that still works.
+
+    ⚠ THREE OF THESE FOUR ARE REGRESSION COVERAGE; THE WALRUS IS AN INVARIANT GUARD.
+    Measured against the previous index: tuple target 0, attribute target 0, returned
+    from a helper 0 — all three uncounted, all three now 1. The walrus case already
+    counted, for an unrelated reason (the consumer's argument is walked recursively,
+    so the nested `tmp_path / name` was reached without the binding ever being
+    resolved). It is kept because it pins that behaviour, not because it caught
+    anything, and it must not be tallied as a fourth fix.
+    """
+    shapes = {
+        "tuple target": (
+            "def test_probe(tmp_path, name):\n"
+            "    root, other = tmp_path / name, 1\n"
+            "    running(root / 'store')\n"
+        ),
+        "attribute target": (
+            "class T:\n"
+            "    def test_probe(self, tmp_path, name):\n"
+            "        self.holder = tmp_path / name\n"
+            "        running(self.holder / 'store')\n"
+        ),
+        "walrus": (
+            "def test_probe(tmp_path, name):\n"
+            "    running((root := tmp_path / name) / 'store')\n"
+        ),
+        "two-hop chain": (
+            "def test_probe(tmp_path, name):\n"
+            "    holder = tmp_path / name\n"
+            "    root = holder / 'store'\n"
+            "    running(root)\n"
+        ),
+        "returned from a helper": (
+            "def _make(tmp_path, name):\n"
+            "    return tmp_path / name\n"
+            "def test_probe(tmp_path, name):\n"
+            "    running(_make(tmp_path, name))\n"
+        ),
+    }
+    missed = {k: _count_disk_rooted(v) for k, v in shapes.items()}
+    missed = {k: n for k, n in missed.items() if n != 1}
+    assert not missed, (
+        f"these binding forms hold a store root the ratchet cannot see: {missed}. "
+        "Each is a way to add an inline disk-backed store while the count stays flat."
+    )
+
+
+def test_one_tests_store_root_does_not_vouch_for_ANOTHERS_scratch_directory():
+    """The index is scoped per function, and this is what makes that a fact.
+
+    Both functions below bind a name to `tmp_path / name`. In the first it becomes a
+    store; in the second it is a scratch directory that merely happens to reuse the
+    word. A file-wide index counts BOTH — which is how a ratchet starts accusing
+    authors of not using `store_root()` for things that are not stores. Round 3's
+    audit called exactly that "a false accusation", and `main` then hit it.
+
+    ⚠ This pins the SCOPING, not a hazard anyone has been bitten by twice: the count
+    over the real file is 20 either way today. It is here so the docstring's
+    per-function claim is checked rather than asserted.
+    """
+    probe = (
+        "def test_a(tmp_path, name):\n"
+        "    root = tmp_path / name\n"
+        "    running(root / 'store')\n"
+        "\n"
+        "def test_b(tmp_path, name):\n"
+        "    root = tmp_path / name\n"
+        "    root.mkdir()\n"
+    )
+    assert _count_disk_rooted(probe) == 1, (
+        f"counted {_count_disk_rooted(probe)} store roots in a module with one store "
+        "and one scratch directory. The index is resolving names across function "
+        "boundaries, so an unrelated local called `root` is being counted as a store."
+    )
+
+
+# 🔴 THE SECOND GUARD — AND IT NO LONGER READS THE SOURCE AT ALL.
 #
-# So the requirement is DERIVED from the fixture that produces it.
-_STORE_PAGE_BYTES = 4096
-# Directories, and slack for a fixture that grows by a few files rather than a loop.
-_FIXTURE_SLACK_PAGES = 16
+# `store_siting._LARGEST_STORE_BYTES` is the budget a store must stay under, and
+# `_MIN_FREE_BYTES` is sized against it. Rounds 4-6 tried to keep that budget honest by
+# DERIVING it from a syntactic sweep of the ledgered test files — counting `write_text`
+# calls and `range(N)` loops — because a constant checked only against another constant
+# is not a guard. The reasoning was right; the instrument was not. Every revision of the
+# sweep was walked through by a shape its author had not imagined, and each one
+# under-reported SILENTLY with the whole suite green:
+#
+#   * nested loops SUMMED instead of multiplied: `for a in range(4): for b in
+#     range(300)` writes 1,200 files and reported 4 + 300 = 304, a 2.7x under-report of
+#     exactly the growth scenario this exists to catch;
+#   * `range(303)` respelled `range(0, 303)` — the scan required exactly one argument,
+#     so the file's whole contribution silently became zero;
+#   * the same loop rewritten as a list comprehension, likewise zero;
+#   * the loop body extracted into a helper, likewise zero;
+#   * `ast.AsyncFor` never in the isinstance tuple at all;
+#   * and the census that fed it counted EVERY `write_text` in the file, so appending
+#     one five-byte scratch write to a test with no store, no server and no tmpfs moved
+#     the derived requirement. It moved six times in nineteen commits.
+#
+# The positive control could not see any of it either: it asserted the total was >= 100,
+# and summing three files floated it over 100 without the ~300-entry fixture being
+# visible at all.
+#
+# 🔴 SO THE ENFORCEMENT MOVED OUT OF THE SCAN AND INTO THE THING ITSELF.
+# `store_siting._check_store_budget` WALKS THE REAL DIRECTORY at teardown of every
+# `store_root(...)` and raises when it exceeds the budget. There is no spelling of a
+# write loop that produces files a directory walk cannot see, so the entire class of
+# defect above is gone rather than patched. What is left to test here is the
+# INSTRUMENT: that the check runs, that it measures pages rather than apparent bytes,
+# that it can go red, that it does so on both siting branches, and that it does not
+# eat the failure of the test it is attached to.
+#
+# MEASURED 2026-09-02 over the three ledgered files: the check ran on **448 stores**,
+# the largest being 1,253,376 B / 306 entries (`test_cairn_cli.py`'s concurrency
+# fixture) and the next largest 176,128 B / 43 entries. So the coverage claim is not a
+# reassuring zero — the instrument was watched observing 448 things, and the peak it
+# reported is the fixture the module docstring has always named.
+#
+# The residual, stated rather than hidden: this is a claim about stores that are
+# actually BUILT by a run. A fixture nobody executes is not measured. The gate runs the
+# whole suite, and `test_every_ledgered_file_IMPORTS_AND_CALLS_the_shared_siting_at_
+# least_once` above is what keeps the ledgered files routed through the seam, so the
+# two together cover the population. A deselected subset run is not that claim. Nor is
+# it a claim about the 20 inline `tmp_path / "store"` sites the FIRST ratchet counts:
+# those never reach `store_root`, live on disk rather than tmpfs, and are that
+# ratchet's business, not this budget's.
+
+# How much bigger than the measured peak the budget must be. 🔴 THE PREVIOUS BUDGET HAD
+# ZERO SLACK — 1,875,968 was exactly (442 + 16) * 4096 where 442 was the sweep's own
+# output, so the required value and the constant were literally the same number and any
+# nudge in either direction turned a required merge check red.
+_MIN_BUDGET_HEADROOM = 1.25
+
+# How much bigger than the budget the free-space floor must be. This is the claim
+# `_MIN_FREE_BYTES`'s comment makes in prose; pinning it here is what stops the prose
+# rotting again. 🔴 It read "better than 3x margin" while the true ratio was 2.24x —
+# falsified by round 6's own change to the other constant, in the same commit, unnoticed.
+_MIN_FLOOR_MARGIN = 2.0
+
+# Entries needed to break the budget, DERIVED from the budget rather than transcribed:
+# one page per file, one file past the limit. Deriving it is the point — a literal here
+# would go stale the moment the budget moved, and would then be testing nothing.
+_OVER_BUDGET_ENTRIES = store_siting._LARGEST_STORE_BYTES // store_siting._PAGE_BYTES + 1
 
 
-def _seeded_entry_count(tree: ast.AST) -> int:
-    """Entries a module writes OUTSIDE any loop — the fixture seed.
+def _fill(root: Path, entries: int) -> None:
+    """`entries` one-page files under `root`, in the `scope/name.md` shape."""
+    scope = root / "a-scope"
+    scope.mkdir(parents=True, exist_ok=True)
+    for i in range(entries):
+        (scope / f"e-{i:04d}.md").write_text(f"entry {i}\n")
 
-    🔴 DERIVED, because `_SEEDED_ENTRIES = 3` was a bare literal about another file's
-    function, pinned by nothing — the exact defect this ratchet exists to prevent,
-    reintroduced inside its own fix. Add 200 seeded entries and a hardcoded 3 is blind
-    to all of them.
+
+def test_store_root_INVOKES_the_budget_check_on_the_root_it_yielded(tmp_path: Path):
+    """Reachability, and it is a different claim from "the check is correct".
+
+    A budget checker that is never called reports nothing for every store in the
+    suite, which is indistinguishable from a suite that builds no stores. This spies
+    on the call rather than the arithmetic, so it stays green under any correct
+    implementation and red the moment `store_root` stops consulting it.
     """
-    loop_writes: set[int] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.For, ast.While, ast.comprehension)):
-            for sub in ast.walk(node) if not isinstance(node, ast.comprehension) else []:
-                loop_writes.add(id(sub))
-    seeded = 0
-    for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr in ("write_text", "write_bytes")
-            and id(node) not in loop_writes
-        ):
-            seeded += 1
-    return seeded
-
-
-def _biggest_fixture_entry_count() -> int | None:
-    """Entries in the largest store fixture across EVERY ledgered file, or None.
-
-    🔴 SUM, NOT MAX, and every ledgered file, not one. Round 5 took the max of one
-    loop in `test_cairn_cli.py`; an audit measured three shapes that under-report
-    SILENTLY — two write loops in one test (reports 303, truth 603), nested loops
-    (203 vs 1003), and a bigger non-`write_text` loop beside the existing one, which
-    passed while the true need was 21 MB against a 4 MiB floor. Under-reporting is the
-    dangerous direction: it re-arms ENOSPC through the guard added to prevent it.
-
-    Returns None rather than 0 when nothing is found: a zero would make the
-    requirement trivially satisfiable, which is the failure mode this exists to stop.
-    """
-    total = 0
-    found_any = False
-    for name in sorted(EXPECTED_SERVER_TESTS):
-        path = TESTS / name
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (OSError, SyntaxError):
-            continue
-        n = _entries_written_by_loops(tree)
-        if n is not None:
-            found_any = True
-            total += n + _seeded_entry_count(tree)
-    return total if found_any else None
-
-
-def _entries_written_by_loops(tree: ast.AST) -> int | None:
-    """Total entries written by `for … in range(<int>)` loops that write files."""
-    total = 0
-    found = False
-    # 🔴 ONLY loops that WRITE ENTRIES. A bare max over every `range(N)` is wrong and
-    # was measured wrong: it picked up an unrelated `range(60_000)` building a string,
-    # demanding a 245 MB floor. The discriminator is a write call in the loop body.
-    # `write_bytes` counts too — round 5 checked only `write_text`, and an audit showed
-    # a `write_bytes` loop beside the existing one passes while needing 21 MB.
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.For):
-            continue
-        it = node.iter
-        if not (
-            isinstance(it, ast.Call)
-            and isinstance(it.func, ast.Name)
-            and it.func.id == "range"
-            and len(it.args) == 1
-            and isinstance(it.args[0], ast.Constant)
-            and isinstance(it.args[0].value, int)
-        ):
-            continue
-        writes = any(
-            isinstance(c, ast.Call)
-            and isinstance(c.func, ast.Attribute)
-            and c.func.attr in ("write_text", "write_bytes")
-            for c in ast.walk(node)
-        )
-        if not writes:
-            continue
-        found = True
-        total += it.args[0].value
-    return total if found else None
-
-
-def test_the_largest_store_constant_still_covers_the_biggest_fixture():
-    entries = _biggest_fixture_entry_count()
-    assert entries is not None, (
-        "could not find the bulk `range(N)` loop in test_cairn_cli.py. That is a "
-        "BROKEN SCAN, not a satisfied requirement — fix the scan rather than the "
-        "constant, or the floor silently stops being checked against anything."
-    )
-    required = entries * _STORE_PAGE_BYTES + _FIXTURE_SLACK_PAGES * _STORE_PAGE_BYTES
-    assert required <= store_siting._LARGEST_STORE_BYTES, (
-        f"the biggest store fixture is now {entries} entries, needing "
-        f"{required:,} page-allocated bytes, but _LARGEST_STORE_BYTES is "
-        f"{store_siting._LARGEST_STORE_BYTES:,}. Raise it AND re-check "
-        f"_MIN_FREE_BYTES ({store_siting._MIN_FREE_BYTES:,}), which must stay above "
-        "it. tmpfs charges whole 4 KiB pages, so entry COUNT drives this, not text "
-        "size — apparent bytes understate the cost ~17x."
+    seen: list[Path] = []
+    real = store_siting._check_store_budget
+    store_siting._check_store_budget = lambda root: seen.append(root)
+    try:
+        with store_siting.store_root(tmp_path) as root:
+            _fill(root, 2)
+            yielded = root
+    finally:
+        store_siting._check_store_budget = real
+    assert seen == [yielded], (
+        f"store_root yielded {yielded} but handed the budget check {seen}. Every "
+        "store the ledgered files build reaches tmpfs through this one call, so a "
+        "check it does not invoke is a check on nothing."
     )
 
 
-def test_the_fixture_scan_can_actually_SEE_a_range_loop():
-    # Positive control: without it, a scan that matched nothing would return None...
-    # which the test above does catch — but a scan that matched only a TINY range
-    # elsewhere would silently under-report and pass. Pin that it finds a big one.
-    entries = _biggest_fixture_entry_count()
-    assert entries is not None and entries >= 100, (
-        f"the fixture scan found {entries} entries — expected the ~300-entry "
-        "concurrency fixture. The scan, not the constant, is what to fix."
+def test_page_allocated_bytes_counts_PAGES_not_apparent_size(tmp_path: Path):
+    """🔴 APPARENT BYTES UNDERSTATE TMPFS COST ~17x, and that is the whole reason
+    this measurement exists rather than a `sum(st_size)`.
+
+    The fixture is built so the four plausible wrong answers are all DISTINCT from the
+    right one, because a fixture that cannot tell them apart survives a mutation that
+    hardcodes any of them. Each line names the mutant it separates, and each of those
+    mutants was RUN and killed here:
+
+      * 7 files of ~9 bytes    -> 7 pages   summing st_size instead reads 5,063 bytes
+      * 1 empty file           -> 1 page    dropping `max(1, …)` reads 9 pages
+      * 1 file of 5,000 bytes  -> 2 pages   `entries * page` reads 9 pages, not 10
+      * 2 directories          -> 0 pages   counting them reads 11 entries and 12 pages
+
+    So the right answer is 9 entries / 10 pages / 40,960 bytes, and 9, 10, 11, 12,
+    4,096, 5,063 and 40,960 are pairwise distinct — no fixture value can coincide with
+    a constant the implementation names.
+    """
+    root = tmp_path / "measured"
+    (root / "one").mkdir(parents=True)
+    (root / "two").mkdir(parents=True)
+    for i in range(7):
+        (root / "one" / f"s-{i}.md").write_text("12345678\n")
+    (root / "one" / "empty.md").write_text("")
+    (root / "two" / "big.md").write_text("z" * 5000)
+
+    entries, allocated = store_siting.page_allocated_bytes(root)
+    apparent = sum(p.stat().st_size for p in root.rglob("*") if p.is_file())
+
+    assert entries == 9, entries
+    assert allocated == 10 * store_siting._PAGE_BYTES, (
+        f"{allocated:,} bytes for 9 files spanning 10 pages — expected "
+        f"{10 * store_siting._PAGE_BYTES:,}"
+    )
+    # The control that makes the claim mean something: the two numbers must DIFFER,
+    # by a lot. If they ever agree, the fixture stopped being able to see the bug.
+    # Measured ratio here is 8.09x (40,960 / 5,063); the bound is 7x deliberately, so
+    # this control is not itself sitting on its own boundary.
+    assert apparent * 7 < allocated, (
+        f"apparent {apparent:,} vs page-allocated {allocated:,} — this fixture no "
+        "longer distinguishes a page count from a byte sum, so it cannot catch the "
+        "mistake it exists for"
+    )
+
+
+def test_a_store_over_the_budget_RAISES_with_the_budget_checks_own_message(
+    tmp_path: Path,
+):
+    """The negative control: the instrument must be able to go red.
+
+    🔴 NOTHING IS MONKEYPATCHED HERE. The predecessor of this guard asserted a floor
+    while monkeypatching the very variable it claimed to bound, so no value of that
+    variable could fail it. This builds a store that genuinely exceeds the REAL
+    `_LARGEST_STORE_BYTES`, and asserts on THIS check's own wording — not merely that
+    something failed, which a different guard's error would also satisfy.
+    """
+    with pytest.raises(store_siting.StoreBudgetExceeded) as excinfo:
+        with store_siting.store_root(tmp_path) as root:
+            _fill(root, _OVER_BUDGET_ENTRIES)
+    message = str(excinfo.value)
+    assert "_LARGEST_STORE_BYTES budget" in message, message
+    assert f"{_OVER_BUDGET_ENTRIES:,} entries" in message, message
+    assert "_MIN_FREE_BYTES" in message, (
+        "the message must name the constant that was sized against this budget — the "
+        "reader's next action is to re-check the free-space floor, not to shrug"
+    )
+
+
+def test_a_store_just_UNDER_the_budget_is_accepted(tmp_path: Path):
+    """The other half of the pair, and it is what stops the guard being a tripwire.
+
+    One page under the limit must pass. Without this, a mutant turning `>` into `>=`
+    — or a budget quietly set to the peak with no slack, which is exactly what F1
+    found — would be invisible: the over-budget test above passes either way.
+    """
+    with store_siting.store_root(tmp_path) as root:
+        _fill(root, _OVER_BUDGET_ENTRIES - 1)
+
+
+def test_the_budget_check_runs_on_the_DISK_FALLBACK_branch_too(
+    tmp_path: Path, monkeypatch
+):
+    """🔴 A GUARD THAT ONLY RUNS WHERE A TMPFS EXISTS IS BLIND ON THE MACHINES THAT
+    HAVE NONE — and those are the machines where a store quietly grows unchecked
+    until it reaches one where it matters.
+
+    The assertion on `root` is the reachability half: without it this test passes on
+    a tmpfs host by taking the branch it claims to be avoiding, and proves nothing.
+    """
+    monkeypatch.setattr(store_siting, "tmpfs_dir", lambda: None)
+    with pytest.raises(store_siting.StoreBudgetExceeded):
+        with store_siting.store_root(tmp_path) as root:
+            assert root == tmp_path / "store", (
+                f"expected the tmp_path fallback, got {root} — this test took the "
+                "tmpfs branch and is not testing the fallback at all"
+            )
+            _fill(root, _OVER_BUDGET_ENTRIES)
+
+
+def test_the_budget_check_does_NOT_mask_the_bodys_own_failure(tmp_path: Path):
+    """A teardown check that overwrites the real error is worse than no check.
+
+    The store here is deliberately over budget AND the body raises. The author needs
+    to read their own failure; a `StoreBudgetExceeded` about a constant would send
+    them to the wrong file entirely.
+    """
+    class Boom(Exception):
+        pass
+
+    with pytest.raises(Boom):
+        with store_siting.store_root(tmp_path) as root:
+            _fill(root, _OVER_BUDGET_ENTRIES)
+            raise Boom("the test's own failure")
+
+
+def test_the_budget_keeps_real_HEADROOM_over_the_measured_peak():
+    """🔴 ZERO SLACK IS A TRIPWIRE, NOT A BUDGET.
+
+    This does not try to prove the peak is right — `_check_store_budget` does that,
+    at runtime, against the real tree. It pins the weaker, true thing: the budget is
+    not sitting exactly on its own requirement, so an ordinary fixture edit cannot
+    turn a required merge check red on arithmetic alone.
+    """
+    peak = store_siting._MEASURED_PEAK_STORE_BYTES
+    budget = store_siting._LARGEST_STORE_BYTES
+    assert store_siting._BUDGET_HEADROOM >= _MIN_BUDGET_HEADROOM, (
+        f"_BUDGET_HEADROOM is {store_siting._BUDGET_HEADROOM}, under the "
+        f"{_MIN_BUDGET_HEADROOM} this pins. Shrinking the slack to buy room under "
+        "the free-space floor is the move that recreates the zero-slack tripwire — "
+        "raise _MIN_FREE_BYTES or shrink the fixture instead."
+    )
+    assert budget >= peak * _MIN_BUDGET_HEADROOM, (
+        f"_LARGEST_STORE_BYTES ({budget:,}) is only {budget / peak:.2f}x the measured "
+        f"peak ({peak:,}); it must be at least {_MIN_BUDGET_HEADROOM}x. A budget set "
+        "to its own requirement goes red on an unrelated edit."
+    )
+    # And the budget must BE what `_BUDGET_HEADROOM` says it is. Without this the
+    # headroom constant is prose: it could read 1.5 beside a budget carrying 1.26x,
+    # which is the same defect as the free-space margin comment one constant below —
+    # a number describing another number, with nothing reading either.
+    page = store_siting._PAGE_BYTES
+    expected = -(-int(peak * store_siting._BUDGET_HEADROOM) // page) * page
+    assert budget == expected, (
+        f"_LARGEST_STORE_BYTES is {budget:,}, but {peak:,} x "
+        f"{store_siting._BUDGET_HEADROOM} rounded up to a page is {expected:,}. One of "
+        "the three constants was edited without the others; they are not independent."
+    )
+
+
+def test_the_free_space_floor_keeps_the_MARGIN_its_comment_claims():
+    """🔴 A COMMENT IS A CLAIM, AND THIS ONE WAS FALSIFIED BY ITS OWN NEIGHBOUR.
+
+    `_MIN_FREE_BYTES`'s comment read "better than 3x margin". It was true (3.18x) when
+    written and false (2.24x) one commit later, because round 6 changed the OTHER
+    constant and left the sentence alone. Nothing could notice: no test read the ratio.
+    Now one does, so the prose and the arithmetic fail together.
+    """
+    margin = store_siting._MIN_FREE_BYTES / store_siting._LARGEST_STORE_BYTES
+    assert margin >= _MIN_FLOOR_MARGIN, (
+        f"_MIN_FREE_BYTES ({store_siting._MIN_FREE_BYTES:,}) is only {margin:.2f}x "
+        f"_LARGEST_STORE_BYTES ({store_siting._LARGEST_STORE_BYTES:,}); its comment "
+        f"claims better than {_MIN_FLOOR_MARGIN}x. Raising the floor collides with "
+        "the measured reason it was lowered from 8 MiB (8 MiB rejects a usable 4 MiB "
+        "tmpfs), so the answer is usually a smaller fixture — and whichever you "
+        "choose, REWRITE THE COMMENT: it states the ratio, and a stale one there has "
+        "already cost a round."
     )
 
 


### PR DESCRIPTION
Round 7 of the store-siting audit ladder. Round 6's delta audit returned **7 findings (4 🔴, 3 🟡)**, six of them in the ratchet rather than the payload. Base: `3d0695c7`; `origin/main` merged in at `946a51f0`.

The findings interact — F5/F6 **widen** the site predicate, F2 **raises** the derived entry requirement, F1 says the budget must stop being a tripwire — so this is one coherent change, not seven patches.

> **Round 2 (2026-09-02)** — the round-1 audit of this PR returned **8 findings**, seven of them claims in this PR's own prose that were FALSE about the code beside them. Commit `5a3d7fe7` corrects them and this body is corrected in place. **No mechanism changed in round 2** — the operator's decision is to land an accurate residual list and end the ladder, not to keep widening a test-only ratchet. The three claims below that were falsified are struck and rewritten: the 13-site enumeration (it summed to 15), the "448 things" positive control (a one-off hand measurement, not a standing control), and one row of the mutation table (it does not reproduce, and cannot). See "Round 2 corrections" at the end.

---

## The central move: the census stopped reading the source

Rounds 4–6 kept `_LARGEST_STORE_BYTES` honest by DERIVING it from a syntactic sweep of the ledgered test files. The reasoning was right — a constant checked against a constant is not a guard — but a syntactic sweep can only ever see the shapes its author imagined, and every revision was walked through by one it had not.

So the enforcement left the scan and moved into the thing itself. **`store_siting._check_store_budget` walks the real directory at every `store_root` teardown** and raises `StoreBudgetExceeded` over budget. There is no spelling of a write loop that produces files a directory walk cannot see, so F2/F3/F4/F9 are **gone rather than patched**.

A ONE-OFF, HAND-INSTRUMENTED run over the three ledgered files saw the check called on **448 stores**, peak **1,253,376 B / 306 entries** (`test_cairn_cli.py`'s concurrency fixture), runner-up **176,128 B / 43 entries** — a 7x gap, so the peak is not a close call.

⚠ **That was a manual measurement and it is NOT the positive control this body originally called it.** The instrumentation it used (three `PEAK_STORE_*` module globals) was read by nothing and has been deleted; nothing re-runs the 448 count. The standing controls on this instrument are two tests that run every time and were mutation-verified: `test_store_root_INVOKES_the_budget_check_on_the_root_it_yielded` (it is reached at all) and `test_a_store_over_the_budget_RAISES_with_the_budget_checks_own_message` (it can go red, on its own wording).

---

## Per-finding disposition (round 6's audit)

| # | Finding | Disposition |
|---|---|---|
| 🔴 F1 | zero headroom on a census of the wrong population | **FIXED** |
| 🔴 F2 | nested loops summed, not multiplied | **FIXED** (census removed) |
| 🔴 F3 | three silent under-report shapes + missing `AsyncFor` | **FIXED** (census removed) |
| 🔴 F4 | the `entries >= 100` positive control is defeated | **FIXED** (control removed with the thing it guarded; replaced per-instrument) |
| 🟡 F5 | `_ROOT_BINDINGS` is SPELLED, not structural | **FIXED — and it was larger than reported** |
| 🟡 F6 | keyword arguments never indexed | **FIXED** |
| 🟡 F7 | the margin comment was falsified by round 6 | **FIXED, and the claim is now machine-read** |
| 🟢 F8 | two stale descriptions of the removed scan | **FIXED** |
| 🟢 F9 | `_seeded_entry_count`'s docstring lies | **FIXED** (function deleted) |

### F1 — zero headroom, wrong population
`_LARGEST_STORE_BYTES` was `1,875,968 = (442 + 16) * 4096`, where 442 was the sweep's own output: **the requirement and the constant were the same number, slack 0 bytes.** And 442 was not a store-entry count — `_seeded_entry_count` counted every `write_text`/`write_bytes` file-wide, scoring `test_cairn_cli.py`'s 3-file fixture as 15.

The budget is now `ceil(measured_peak * 1.5)` to a page — **computed, not transcribed**, so `_BUDGET_HEADROOM` cannot read 1.5 beside a budget carrying 1.26x. The 1.5 is pinned at `>= 1.25`, and the derivation itself is asserted.

⚠ **It also stopped modelling concurrency, and round 2 is where that got written down.** `main`'s constant was a SUM over every ledgered file's fixtures, documented as conservative under `-n 4 --dist loadfile`. This one is a single measured peak enforced **per store**, so adding a second large fixture no longer moves it, and `_MIN_FREE_BYTES` is a margin over ONE store while up to `PYTEST_JOBS` workers may hold one each. Nothing regresses in value (1,880,064 > the old sum 1,875,968) and `tmpfs_dir()` re-reads `statvfs` at every `store_root` entry, so the floor is a live check rather than a static reservation. Both constants now say which population they describe.

### F5 — the spelled predicate was bigger than the audit found
The audit reported the binding-**name** half and reproduced it with a rename. The directory-**name** half was the same defect and nobody had looked: `_ROOT_NAMES = {"store", "src"}` meant

```python
served = tmp_path / "served"          # a `cp -a` of the store fixture
subprocess.run(["cp", "-a", str(store), str(served)], check=True, ...)
path = served / SCOPE / "thing-alpha.md"
path.write_text(...)                  # written into
with running(served) as (base, _):    # and served by the real store server
```

did not count. **Measured: 13 such sites on `test_subsystem_store_api.py` while the ratchet read a confident 20.** The breakdown, **re-measured in round 2 because the original one summed to 15**:

| directory | sites |
|---|---|
| `served` | **3** (this body originally said five) |
| `served-elsewhere` | 3 |
| `stage` (the output of `run_seed`, served back) | 2 |
| `absent` (`running(tmp_path / "absent")`) | 2 |
| `big` | 1 |
| `at-the-cap` | 1 |
| `unambiguous` | 1 |
| **total** | **13** — plus the 20 `store`/`name`/`kind` sites = **33** |

`_DISK_ROOTED_SITES` therefore goes **20 → 33 with not one site added**. The assertion message and the ledger comment now both say the UP direction is ambiguous — "13 sites were written" and "the predicate got 13 sites wider" demand opposite actions — the way the DOWN direction already did.

The other side of that widening is pinned too: a cache dir, a scratch file and a non-consumer call still count **0**, so this is not "count every path", which would re-create the false accusation round 3 measured.

Of the 33, **26 flow into a store consumer and 7 count only via `_ROOT_NAMES`**. ⚠ Round 2 re-measured what those 7 are and the original description of them was wrong — see residual 3.

---

## Red → green matrix

All runs `PYTHONDONTWRITEBYTECODE=1`, `-p no:cacheprovider`, each mutation in a **freshly created isolated tree** (never mutated in place).

### The site predicate (F5, F6) — probes replayed against each ref's own index

| control | `origin/main` | this PR |
|---|---|---|
| rename `root` → `base_dir`, nothing else | 1 vs **0** ❌ | 1 vs 1 ✅ |
| same expression positional vs `store_root=` | 1 vs **0** ❌ | 1 vs 1 ✅ |
| directory named `store` vs `served` | 1 vs **0** ❌ | 1 vs 1 ✅ |
| tuple target | **0** ❌ | 1 ✅ |
| attribute target (`self.holder`) | **0** ❌ | 1 ✅ |
| two-hop chain | **0** ❌ | 1 ✅ |
| returned from a helper | **0** ❌ | 1 ✅ |
| walrus | 1 ✅ | 1 ✅ — **invariant guard, not regression coverage** (it already counted, for an unrelated reason: the consumer's argument is walked recursively) |
| a cache dir / scratch file / non-consumer call | 0 ✅ | 0 ✅ — the no-false-accusation control |
| **the same binding moved into a `@pytest.fixture`** | **0** | **0** — ⚠ **round 2: still 0. NOT closed.** See residual 6 |
| real site count on `test_subsystem_store_api.py` | 20 | 33 |

### Round 2's own matrix

| control | before | after |
|---|---|---|
| `test_a_store_root_bound_in_a_pytest_FIXTURE_is_NOT_counted`, `_ROOT_NAMES` widened to include `"served"` (closes the hole by the spelled route) | — | 🔴 RED with its own message: *"the ratchet now SEES a store root bound in a fixture"* |
| same guard, `"running"` dropped from `_ROOT_CONSUMERS` | — | 🔴 RED on its positive-control assertion first: *"the inline form of this probe counts 0, not 1"* |
| the four affected files, merged tree | 794 passed | **795 passed** (+1, the new gap guard) |

Everything else in round 2 is prose. The one code change with no red→green story is deleting the `PEAK_STORE_*` globals — nothing read them, which is precisely the finding.

### The entry census (F1, F2, F3) — real fixtures, real stores

Each row mutates `test_cairn_cli.py`'s bulk-write loop and then reports **what the ledger suite said at base** vs **what the runtime guard says now**.

| mutation | real files | `origin/main` ledger suite | this PR, running the fixture |
|---|---|---|---|
| *(unmutated)* | 306 | 8 passed | 1 passed |
| one 5-byte scratch write, no store/server/tmpfs | 306 | 🔴 **1 failed** — "now 443 entries, needing 1,880,064… but is 1,875,968" | ✅ 20 passed |
| the same 5 bytes, in `test_cairn_write.py` | 306 | 8 passed — that file's **whole** seed is dropped (F3's LOUD→SILENT half) | ✅ green |
| nested `range(4)`×`range(300)` | 1,203 | red **by one page**, reporting **304** — a 2.7x under-report that only bit because of F1's zero slack | 🔴 caught: **4,927,488 B across 1,203 entries** |
| `range(0, 1200)` | 1,203 | **8 passed — SILENT** | 🔴 caught, same exact count |
| list comprehension, 1,200 | 1,203 | **8 passed — SILENT** | 🔴 caught, same exact count |
| loop body extracted to a helper, 1,200 | 1,203 | **8 passed — SILENT** | 🔴 caught, same exact count |
| plain `range(1200)` — the batch's positive control | 1,203 | red (caught, reporting 1,339) | 🔴 caught |

The positive control being caught **at base** is what says the harness was running the code it edited.

Note the F2 row: fix F1's headroom without fixing F2 and that row goes green at base — the ENOSPC guard silently stops working. That is why this is one change.

---

## Mutation results

Every mutant was required to be killed **by its designated test**, and that test was then re-run **in isolation** and its own message checked — "something went red" was not accepted as a kill. A known-caught positive control rode in the batch.

**17 defect mutants killed by their designated test; one row that was reported as a kill does not reproduce and is corrected below.**

| mutant | verdict |
|---|---|
| `page_allocated_bytes` sums `st_size` instead of pages | KILLED — `test_page_allocated_bytes_counts_PAGES_not_apparent_size` |
| drop `max(1, …)` so an empty file costs nothing | KILLED — same |
| count directories as entries | KILLED — same |
| `<=` → `<` at the budget boundary | KILLED — `test_a_store_just_UNDER_the_budget_is_accepted` |
| `store_root` stops calling `_check_store_budget` | KILLED — `test_store_root_INVOKES_the_budget_check_on_the_root_it_yielded` |
| enforce on the tmpfs branch only | KILLED — `test_the_budget_check_runs_on_the_DISK_FALLBACK_branch_too` |
| guard runs even when the body raised (masks the real failure) | KILLED — `test_the_budget_check_does_NOT_mask_the_bodys_own_failure` |
| budget re-set to the peak (zero headroom, the F1 regression) | KILLED — `test_the_budget_keeps_real_HEADROOM_over_the_measured_peak` |
| `_BUDGET_HEADROOM` below the pinned 1.25 floor | KILLED — same |
| ~~budget re-literalised so it can disagree with the headroom~~ | 🔴 **CORRECTED — SURVIVES, and must.** See below |
| `_MIN_FREE_BYTES` lowered so the margin drops under 2x | KILLED — `test_the_free_space_floor_keeps_the_MARGIN_its_comment_claims` |
| index stops walking `node.keywords` | KILLED — `test_a_store_root_passed_BY_KEYWORD_counts_like_a_positional_one` |
| index reverts to a spelled name set | KILLED — `test_the_site_index_keys_on_USE_not_on_the_variables_NAME` |
| Constant arm reverts to `_ROOT_NAMES`-only | KILLED — `test_the_site_index_does_not_key_on_the_DIRECTORY_being_spelled_store` |
| Constant arm counts every constant (the false accusation) | KILLED — `test_a_path_that_is_never_used_as_a_store_still_does_NOT_count` |
| index leaks names across function scopes | KILLED — `test_one_tests_store_root_does_not_vouch_for_ANOTHERS_scratch_directory` |
| index drops the fixpoint (multi-hop chains) | KILLED — `test_the_site_index_sees_the_BINDING_FORMS_a_plain_assignment_is_not` |
| **positive control**: `_PAGE_BYTES = 1` | KILLED — the batch was running the code it edited |

🔴 **The corrected row.** Replacing the computed `_LARGEST_STORE_BYTES` with the literal `1880064` was reported as KILLED. Re-run in an isolated tree under `PYTHONDONTWRITEBYTECODE=1`: **20 passed — it SURVIVES.** It must: at today's constants the literal *equals* the computed value, so the two programs are semantically identical and no test can separate them. The harness was validated on the same tree in the same session — `_BUDGET_HEADROOM 1.5 → 1.1` is KILLED by `test_the_budget_keeps_real_HEADROOM_over_the_measured_peak`, the very test the row credited — so this is a mis-scored row, not a broken sweep. **The hazard the row claimed to cover is still genuinely closed**, by that test's `budget == expected` assertion: a headroom reading 1.5 beside a budget carrying 1.26x fails it. What is not true is that the re-literalisation mutant demonstrates it.

**Two further rows that are not kills, reported because a sweep that hides them is not a sweep:**

* `_BUDGET_HEADROOM = 1.5 → 1.3` **SURVIVES, and that is correct.** 1.3 is still above the pinned 1.25 floor, and because the budget is *computed* from the headroom the two cannot disagree — so this is a legal value, not a defect.
* One earlier run reported `ANCHOR matched 2 times` for that mutant — the harness saying **the mutation never applied**, not that it survived. Fixed and re-run rather than counted.

---

## What I could NOT close — stated, not hidden

1. **The runtime guard is a claim about stores that are actually BUILT by a run.** A fixture nobody executes is not measured. The gate runs the whole suite and `test_every_ledgered_file_IMPORTS_AND_CALLS_the_shared_siting_at_least_once` keeps the ledgered files routed through the seam, so together they cover the population — but a deselected subset run is not that claim, and I have written that into the source rather than left it implied.

2. **`_MEASURED_PEAK_STORE_BYTES` is still a transcribed measurement, and nothing re-runs it.** It sets a *lower* bound on the budget (budget ≥ peak × 1.5); the *upper* bound on reality is the runtime guard, which cannot be fooled. So a real store growing to 1.4× the peak is silent — under budget, and correctly so. Round 2 deleted the `PEAK_STORE_*` instrumentation that produced the number, so re-deriving it means adding a print and re-running the three ledgered files; the source now says so.

3. **`_ROOT_NAMES` is still a spelled set, and it is doing more work than "a shortcut".** 🔴 **This body originally called its 7 sites "built and used without ever reaching a consumer this file knows about". Round 2 measured them and that is false of all seven.** They are every `tmp_path / "store"` at :11310, :11765, :13099, :14086, :14201, :14227, :14803 of `test_subsystem_store_api.py`, and they split into two *masked gaps*:
   * :11310 and :13099 are `root = tmp_path / "store"` in a `_phases` helper whose NESTED `present()`/`absent()` closures call `_build_store(root, …)` — a consumer `_ROOT_CONSUMERS` **does** name. Invisible only because `_walk_scope` stops at a nested function boundary, so no one scope sees both the binding and the call.
   * the other five reach `api.append_bullet` / `api.rc.load_index` — real store consumers `_ROOT_CONSUMERS` does not name.

   Widening `_ROOT_NAMES` to "any constant" is still measured-and-rejected (it re-creates round 3's false accusation), but deleting it would not "lose seven non-flowing sites" — it would expose two structural gaps.

4. **`_ROOT_CONSUMERS` closes RENAMES, not GROWTH.** The rename argument is sound: a callee name is a real referent, so renaming `_build_store` renames its definition too. But a ratchet's job is to notice growth, and growth arrives as a NEW consumer name. Measured with this PR's own control probe: `running(served)` counts **1**, `serve_store(served)` counts **0** — same expression, same copy, same writes. Only half the spelled-guard class is closed, and residual 3 is what that already costs on the real file.

5. **The 20 → 33 sites are now visible debt, not converted.** This PR does not convert them to `store_root()` — a scripted mass conversion was attempted in an earlier round and silently skipped 9 of 19 edits while its own assertion passed. The ratchet records them.

6. 🔴 **A store root bound in a `@pytest.fixture` is NOT counted — this replaces the residual this body used to disclose.** Measured with this PR's own paired control: `served = tmp_path / "served"` written into and handed to `running(...)` counts **1** inline and **0** when the identical binding moves into a fixture. Fixture-binding is the dominant idiom in this file. **Two live instances**, both real `cp -a` copies of a store, written into and served in-process:
   * `served = tmp_path / "ordered-served"` — fixture `shuffled_pair` (:3945), served at :4392 and four more `running(served)` sites;
   * `served = tmp_path / "ambig-served"` — fixture `ambiguous_pair` (:4294), served at :4758 and one more.

   Not closed, deliberately. A pytest fixture crosses the scope boundary through pytest's own name injection, which is not a Python binding an AST can see; and **both live instances return a TUPLE the consumer destructures** (`local, served = shuffled_pair`), so following it needs a new cross-scope resolver *plus* tuple-element tracking. **File-wide indexing is not the shortcut**: measured on the real file, per-scope counts **33** and file-wide **39**, and of those six extra sites four are `tmp_path / "stage"` (:2658, :3619, :3647, :3750) that are `--stage` arguments to a `seed.sh` SUBPROCESS, never served in-process — file-wide counts them only by colliding with the genuinely-served `stage` at :5710/:5726, which is round 3's false accusation exactly. Two accidental catches for four false accusations.

   Pinned by a new gap guard, `test_a_store_root_bound_in_a_pytest_FIXTURE_is_NOT_counted`, so closing the hole fails the suite and forces this residual and `_DISK_ROOTED_SITES` to move in the same commit. **The honest statement of what the predicate covers is therefore: the flow case WITHIN ONE FUNCTION SCOPE — not the flow case generally.**

7. **The budget does not cover a concurrent writer filling the mount.** That half of the module docstring's residual window is still open and cannot be closed from inside this module; the docstring now says which half moved and which did not.

---

## Round 2 corrections — what this body used to say

| claim as written | measured | fix |
|---|---|---|
| the 13 sites enumerate to `served ×5 + served-elsewhere ×3 + stage ×2 + big + at-the-cap + unambiguous + absent ×2` | that sums to **15**, and `served` occurs **3** times | breakdown re-measured; now a table that sums to 13 |
| "the instrument was watched observing 448 things" — offered as a positive control | a **one-off hand measurement** using globals nothing read; the suite never re-runs it | reframed as a manual measurement; the two standing, mutation-verified controls are named instead, and the dead globals are deleted |
| mutation table: "budget re-literalised so it can disagree with the headroom \| KILLED" | **SURVIVES** (20 passed) and must — the literal equals the computed value | row corrected; the hazard's real guard named; harness validated on the same tree |
| residual 3: the 7 `_ROOT_NAMES`-only sites "never reach a consumer this file knows about" | false of **all seven** — 2 reach `_build_store` across a nested-function boundary, 5 reach `api.append_bullet` / `api.rc.load_index` | rewritten as two masked gaps |
| the disclosed residual was about `_ROOT_NAMES` coverage | the larger, undisclosed one is fixture-bound roots | residual 6 added, pinned by a gap guard |

Also corrected in the source, without a body claim to match: `_ROOT_CONSUMERS`'s comment overclaimed (residual 4 now states the growth half); `_assignments`'s docstring listed four binding shapes as "here" when the helper-return case lives in `flowing_callees` and `ast.withitem` — which the body handles — was unmentioned; `"os.fspath"` removed from `_PATH_WRAPPERS`, where it could never match (`_unwrap` compares `expr.func.attr`, i.e. `"fspath"`); a stale "the 20 inline `tmp_path / \"store\"` sites" now reads 33.

---

## Tier — name it, because "the gate passed" is true of one run, one tier, one base

**Dev-host `pytest` tier**, the four affected files, merged tree (`origin/main` `946a51f0` merged in), commit `5a3d7fe7`: **795 passed, rc 0**. Round 7's baseline was 794; the +1 is the new gap guard. Command: `nix develop -c env PYTHONDONTWRITEBYTECODE=1 python3 -m pytest <4 files> -q -p no:cacheprovider`.

**`nix build` sandbox tier** — the one Tekton runs and the merge is gated on — `pytests` and `nodetests` built **one at a time**, never combined (a combined invocation contends on the nix store and produces false failures). Results posted as a comment on this PR. **A dev-host green is not a claim about that tier**, and the two are structurally different environments.

⚠ Whether either check actually *blocks* is branch protection, not something this PR can assert — and #1232 is open reporting that `main` is protected in name only. Check it rather than reading a green tick as a gate.
