### PR TITLE
feat(graphical): land the Ferdium client + font packages that were deployed but never committed

### DIFF
--- a/nix/graphical.nix
+++ b/nix/graphical.nix
@@ -406,7 +406,22 @@ lib.mkIf isNixOS {
   # as a bare `deep-search` from any terminal. It execs the live script symlinked
   # into scriptsDir below (same file HM manages), pinned to a python3 with the
   # stdlib it needs (urllib/json/argparse) — no secret enters the nix store.
-  home.packages = [ pkgs.nerd-fonts.jetbrains-mono ]
+  #
+  # Ferdium: multi-messenger desktop client (WhatsApp, Telegram, Slack, Discord,
+  # 400+ recipes). Its login prompt is bypassed by pointing it at a self-hosted
+  # Ferdium Server — see claudedocs/handoff-ferdium-server.md.
+  #
+  # Fonts: WhatsApp Web renders poorly without noto-fonts + colour emoji, and
+  # liberation_ttf supplies the Segoe UI metrics it expects. `noto-fonts-emoji`
+  # was RENAMED to `noto-fonts-color-emoji` in current nixpkgs — the old name
+  # fails the switch with an attribute error, not a warning.
+  home.packages = with pkgs; [
+    nerd-fonts.jetbrains-mono
+    ferdium
+    noto-fonts
+    noto-fonts-color-emoji
+    liberation_ttf
+  ]
     ++ lib.optional (!isLaptop) (pkgs.writeShellScriptBin "deep-search" ''
       exec ${pkgs.python3}/bin/python3 ${scriptsDir}/deep-search "$@"
     '');


### PR DESCRIPTION
## What

Five packages — `ferdium`, `noto-fonts`, `noto-fonts-color-emoji`, `liberation_ttf`, and the pre-existing `nerd-fonts.jetbrains-mono` — moved into an explicit `home.packages` list in `nix/graphical.nix`.

## Why this is a fix, not a feature

The `ferdium` addition was **deployed but never committed.** It went into the workbench's live home-manager profile during the ferdium-server planning session and the switch succeeded — `~/.nix-profile/bin/ferdium` resolves right now. The edit then sat uncommitted in the shared `~/workspace/devrc` working tree.

Two consequences, both silent:

- **The laptop was never going to get it.** `ship.sh` converges hosts to `origin/main`; a change that is in no commit is in no convergence.
- **Any `git checkout` in that clone would have erased it** with no warning, and the deployed binary would have kept resolving afterwards, so nothing would have looked wrong.

`claudedocs/handoff-ferdium-server.md` records this step as done with a ✅. That was true of the deploy and false of the repo — the two claims are independent and only one had been made.

## The nixpkgs rename

`noto-fonts-emoji` is `noto-fonts-color-emoji` in current nixpkgs. The old name fails a switch with an attribute error rather than a warning, so it is commented at the site.

## Verification

`nix eval` of `homeConfigurations.zach.config.home.packages` on this branch:

```
nerd-fonts-jetbrains-mono-3.5.0+2.304
ferdium-7.1.2
noto-fonts-2026.08.01
noto-fonts-color-emoji-2.051
liberation-fonts-2.1.5
deep-search
```

`deep-search` in that output is the actual regression check, not decoration. The list now opens with `with pkgs;`, and that scope extends across the `++ lib.optional (!isLaptop)` tail — a shadowed `lib` would have silently dropped the wrapper. It survived.

**Scope of that measurement:** the workbench, `isLaptop = false`. The laptop branch of the conditional was not evaluated here. `nix-instantiate --parse` also passes, but parsing would not have caught the scope hazard.

**Not verified:** no `home-manager switch` was run from this branch. The packages are already live on the workbench from the original uncommitted edit, so this PR does not change workbench behaviour — it changes whether the laptop ever receives it.

Refs: `claudedocs/handoff-ferdium-server.md`