### PR TITLE
feat(clawgate-deeplink): mint /tasks/<id>, not /tasks#task-<id> — DO NOT MERGE until clawgate ships the route

### DIFF
--- a/scripts/collector/mention_scan.py
+++ b/scripts/collector/mention_scan.py
@@ -47,17 +47,31 @@ import re
 # --------------------------------------------------------------------------- #
 # URL templates
 # --------------------------------------------------------------------------- #
-# clawgate serves a real, server-rendered browser UI at GET /tasks (see
-# internal/api/server.go, `s.handleIndex`), and every task card carries a stable
-# DOM id `task-<id>` — `internal/ui/notes.go`, `ID("task-"+ids)`, pinned by
-# `internal/ui/notes_test.go` as "stable card id for outerHTML swaps". So the
-# fragment is a real anchor for any task the list renders.
+# clawgate serves a server-rendered PAGE PER TASK at `GET /tasks/{id}`
+# (`internal/api/server.go` → `handleTaskDetail`), which loads the task by id and
+# renders it whatever the board is currently showing. So the deeplink is a PATH.
 #
-# ⚠ HONEST SCOPE: an anchor only scrolls to a card that is ON the page. A task
-# filtered out of the list (archived, or in a collapsed section the server did
-# not render) leaves the browser at the top of /tasks. That is a graceful
-# degradation — the page you wanted, not the wrong page — and it is why the
-# fragment is appended rather than relied upon.
+# 🔴 THE OLD `…/tasks#task-<id>` FRAGMENT IS DEAD AS A CONSTRUCTOR — it must not
+# come back, and this paragraph replaces one that documented its limits as an
+# accepted cost. That comment described a hazard the page CLOSES, and a stale
+# note about a closed hazard is how a maintainer later deletes the thing that
+# closed it. The limit it recorded: an anchor only scrolls to a card already ON
+# the page, so a task that was filtered out, archived, or inside a collapsed
+# section left the browser at the top of /tasks. `/tasks/<id>` has no such
+# precondition — the server renders the task itself.
+#
+# ⚠ HONEST SCOPE, restated for the page. This module cannot tell a real id from a
+# typo — `#370` in agent output is five characters, not a lookup — so it does not
+# claim the URL RESOLVES, only that if the task exists the page shows it. What
+# changed is the failure mode, and not uniformly for the better: a bad id now
+# gets whatever clawgate answers for an id it does not hold, instead of silently
+# landing on the board. Do not describe that as strictly safer.
+#
+# 🔴 ORDERING: this URL is only correct against a clawgate that serves the route.
+# Deploy the clawgate carrying `GET /tasks/{id}` BEFORE anything here reaches a
+# machine, or every mention click 404s. Old `#task-N` links already out in the
+# world (ClickUp comments, activity.events, docs) are clawgate's problem to
+# redirect, not this module's — nothing here should mint one either way.
 CLAWGATE_TASKS_URL = "https://clawgate.zacx.dev/tasks"
 CLICKUP_TASK_URL = "https://app.clickup.com/t/{id}"
 # `/issues/<n>` is deliberate and not a bug: GitHub redirects /issues/<n> to
@@ -177,9 +191,10 @@ def _github_url(full_repo: str | None, num: str) -> str:
 
 
 def clawgate_url(task_id: str) -> str:
-    """The clawgate task's browser URL: the real /tasks page, anchored on the
-    task card's own stable DOM id."""
-    return f"{CLAWGATE_TASKS_URL}#task-{task_id}"
+    """The clawgate task's browser URL: `https://clawgate.zacx.dev/tasks/<id>`,
+    the server-rendered details page for that one task. NO fragment — see the
+    URL-templates block above for why the old `#task-<id>` anchor is gone."""
+    return f"{CLAWGATE_TASKS_URL}/{task_id}"
 
 
 def _resolve_repo(owner: str | None, repo: str, repos: dict | None) -> str:

--- a/scripts/initiatives/tasks.py
+++ b/scripts/initiatives/tasks.py
@@ -417,9 +417,12 @@ def task_view(task: dict, base_url: str = "") -> dict:
     """One clawgate task → the small dict the board renders: `{id, title, status, open, url}`.
 
     `title` prefers the (newer) `title` field and falls back to `directory`, which is how
-    every current producer smuggles the title through (tag spec §9). `url` deep-links to the
-    task's card in clawgate (`{base}/tasks#task-<id>` — the card element carries
-    `id="task-<id>"`); it is "" when there's no id or no base. Pure, never raises."""
+    every current producer smuggles the title through (tag spec §9). `url` deep-links to
+    clawgate's server-rendered task page, `{base}/tasks/<id>` (`GET /tasks/{id}` →
+    `handleTaskDetail`) — a PATH, never a `#task-<id>` fragment: the fragment only resolved
+    for a card the board had already rendered, so a filtered, archived or collapsed task
+    landed at the top of /tasks. It is "" when there's no id or no base. Pure, never
+    raises."""
     t = task or {}
     tid = t.get("id")
     if isinstance(tid, bool) or not isinstance(tid, int):
@@ -431,7 +434,7 @@ def task_view(task: dict, base_url: str = "") -> dict:
         "title": title,
         "status": str(t.get("status") or ""),
         "open": is_open(t),
-        "url": f"{base}/tasks#task-{tid}" if (base and tid is not None) else "",
+        "url": f"{base}/tasks/{tid}" if (base and tid is not None) else "",
     }
 
 

--- a/scripts/initiatives/tests/test_dispatch.py
+++ b/scripts/initiatives/tests/test_dispatch.py
@@ -426,4 +426,4 @@ def test_dispatched_task_joins_back_and_ARMS_the_guard_end_to_end():
     linked = tasks.group_by_slug([created], "http://cg.test:30302")
     assert list(linked) == ["initiative-task-links"] == [view["slug"]]
     assert tasks.open_task_count(linked[view["slug"]]) == 1      # → the guard arms
-    assert linked[view["slug"]][0]["url"] == "http://cg.test:30302/tasks#task-4242"
+    assert linked[view["slug"]][0]["url"] == "http://cg.test:30302/tasks/4242"

--- a/scripts/initiatives/tests/test_tasks.py
+++ b/scripts/initiatives/tests/test_tasks.py
@@ -127,7 +127,31 @@ def test_task_view_shape_and_clawgate_deep_link():
     v = tasks.task_view(_task(42, ["initiative:a"], status="in_progress", directory="do the thing"),
                         "http://cg.test:30302/")
     assert v == {"id": 42, "title": "do the thing", "status": "in_progress", "open": True,
-                 "url": "http://cg.test:30302/tasks#task-42"}
+                 "url": "http://cg.test:30302/tasks/42"}
+
+
+def test_task_view_url_is_a_page_path_with_NO_fragment():
+    """🔴 Regression guard against a partial revert to `{base}/tasks#task-<id>`.
+    The fragment only ever resolved for a card the board had already rendered
+    (filtered, archived or collapsed tasks landed at the top of /tasks); the
+    server-rendered `GET /tasks/{id}` page has no such precondition. Pinned as an
+    ABSENCE — `…/tasks/42#task-42` would satisfy an `endswith` check on the new
+    form — and the WHOLE string is pinned above, so a reword cannot walk it."""
+    v = tasks.task_view(_task(42), "http://cg.test:30302")
+    assert "#" not in v["url"], v["url"]
+    assert v["url"] == "http://cg.test:30302/tasks/42"
+
+
+def test_task_view_round_trips_a_multi_digit_id():
+    """Ids of four distinct digit-lengths, none a prefix or suffix of another, so
+    a mutant that slices or reformats the id cannot produce the expected string."""
+    for tid, expected in ((7, "http://cg.test:30302/tasks/7"),
+                          (42, "http://cg.test:30302/tasks/42"),
+                          (370, "http://cg.test:30302/tasks/370"),
+                          (10593, "http://cg.test:30302/tasks/10593")):
+        v = tasks.task_view(_task(tid), "http://cg.test:30302/")
+        assert v["url"] == expected, tid
+        assert v["id"] == tid
 
 
 def test_task_view_prefers_title_over_directory_when_present():
@@ -235,7 +259,7 @@ def test_linked_tasks_map_fetches_once_then_groups():
     assert len(calls) == 1                                # ONE read, not one per card
     assert list(got) == ["alpha"]
     assert [t["id"] for t in got["alpha"]] == [1, 2]
-    assert got["alpha"][0]["url"] == "http://cg.test:30302/tasks#task-1"
+    assert got["alpha"][0]["url"] == "http://cg.test:30302/tasks/1"
 
 
 def test_linked_tasks_map_returns_empty_map_on_any_failure():

--- a/scripts/initiatives/tests/test_viewer.py
+++ b/scripts/initiatives/tests/test_viewer.py
@@ -5252,7 +5252,31 @@ def _tv(tid, status="open", title=None, with_url=True):
     """A linked-task view as `tasks.task_view` produces it."""
     return {"id": tid, "title": title or f"task {tid}", "status": status,
             "open": status in ("open", "in_progress", "ready_for_review"),
-            "url": f"http://cg.test:30302/tasks#task-{tid}" if with_url else ""}
+            "url": f"http://cg.test:30302/tasks/{tid}" if with_url else ""}
+
+
+def test_the_linked_task_fixture_matches_what_tasks_task_view_really_produces():
+    """🔴 SEAM GUARD, not a regression test — it is green at the base ref too, and
+    is labelled so rather than counted as deeplink coverage.
+
+    `_tv`'s docstring CLAIMS it is "a linked-task view as `tasks.task_view`
+    produces it", and nothing checked that claim: every URL in this file was a
+    hand-written literal, so the whole linked-task section stayed green through a
+    change to the real constructor. That is the failure mode where each side is
+    verified in isolation and the SEAM is owned by nobody. This pins the
+    RELATIONSHIP — the fixture and the producer must agree field-for-field — so
+    the deeplink assertions below become real coverage instead of a self-portrait."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    import tasks  # noqa: PLC0415
+
+    for tid, status in ((7, "open"), (42, "in_progress"), (370, "complete"),
+                        (10593, "ready_for_review")):
+        real = tasks.task_view({"id": tid, "title": f"task {tid}", "status": status},
+                               "http://cg.test:30302")
+        assert real == _tv(tid, status=status), (tid, status)
+    # …and the no-URL variant of the fixture is the producer's own no-base answer
+    assert tasks.task_view({"id": 7, "title": "task 7", "status": "open"})["url"] == \
+        _tv(7, with_url=False)["url"] == ""
 
 
 def test_build_model_attaches_linked_tasks_by_exact_slug():
@@ -5477,7 +5501,7 @@ def test_render_html_ships_the_linked_task_css_and_guard_css():
     assert ".linked-task .lt-status{" in html and ".linked-task.open .lt-status{" in html
     assert ".dispatch-btn.guarded{" in html and ".dispatch-btn.armed{" in html
     # the data reaches the page through the SAME JSON island as everything else
-    assert '"open_task_count": 1' in html and "tasks#task-1" in html
+    assert '"open_task_count": 1' in html and "tasks/1" in html
 
 
 # --- 🔴 the clawgate read must NOT hold DataProvider._lock ------------------- #

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -87,13 +87,26 @@ def test_a_bare_number_with_no_repo_context_offers_only_clawgate():
     picker for a choice that does not exist."""
     _span, cands = MO.resolve("#370")
     assert [(c["platform"], c["url"]) for c in cands] == [
-        ("clawgate", "https://clawgate.zacx.dev/tasks#task-370")]
+        ("clawgate", "https://clawgate.zacx.dev/tasks/370")]
+
+
+def test_the_clawgate_candidate_opens_a_page_not_a_fragment():
+    """🔴 Regression guard against a partial revert to `…/tasks#task-<n>`. The
+    fragment form only resolved for a card the board had already rendered; the
+    details page at `/tasks/{id}` has no such precondition, so a `#` reappearing
+    anywhere in the openable URL is a defect, not a cosmetic difference. Pinned
+    as an ABSENCE because `…/tasks/370#task-370` would satisfy a substring or
+    `endswith` check on the new form."""
+    _span, (clawgate,) = MO.resolve("#370")
+    assert clawgate["platform"] == "clawgate"
+    assert "#" not in clawgate["url"], clawgate["url"]
+    assert clawgate["url"].endswith("/tasks/370")
 
 
 def test_a_bare_number_with_a_repo_context_offers_both():
     _span, cands = MO.resolve("#370", default_repo="civitai/talos-infra")
     assert [(c["platform"], c["url"]) for c in cands] == [
-        ("clawgate", "https://clawgate.zacx.dev/tasks#task-370"),
+        ("clawgate", "https://clawgate.zacx.dev/tasks/370"),
         ("github", "https://github.com/civitai/talos-infra/issues/370"),
     ]
 
@@ -136,7 +149,7 @@ def test_picker_rows_show_the_platform_and_the_url():
     rows = MO.picker_rows(cands)
     assert len(rows) == 2
     assert rows[0].startswith("clawgate task 370 ")
-    assert rows[0].endswith("https://clawgate.zacx.dev/tasks#task-370")
+    assert rows[0].endswith("https://clawgate.zacx.dev/tasks/370")
     assert rows[1].endswith("https://github.com/civitai/talos-infra/issues/370")
 
 
@@ -180,7 +193,7 @@ def test_an_ambiguous_click_prints_every_candidate():
     r = _run("--print", "--no-discovery", "--default-repo", "civitai/talos-infra", "#370")
     assert r.returncode == 0, r.stderr
     assert r.stdout.splitlines() == [
-        "https://clawgate.zacx.dev/tasks#task-370",
+        "https://clawgate.zacx.dev/tasks/370",
         "https://github.com/civitai/talos-infra/issues/370",
     ]
 
@@ -239,7 +252,16 @@ def test_an_ambiguous_click_measures_then_shows_the_picker(spy):
     assert spy[0] == "tmux"
     assert "discover" in spy
     assert ("pick", 2) in spy
-    assert spy[-1] == ("open", "https://clawgate.zacx.dev/tasks#task-370")
+    assert spy[-1] == ("open", "https://clawgate.zacx.dev/tasks/370")
+
+
+def test_a_multi_digit_clawgate_id_round_trips_to_the_click(spy):
+    """A five-digit id must arrive at `open` INTACT — the widest id the bare-`#`
+    pattern admits (`_NUM = \\d{1,5}`), and distinct from every other id in this
+    file, so a mutant that truncates the id or reuses a neighbouring value cannot
+    land on the expected string by accident."""
+    assert MO.main(["#10593"]) == 0
+    assert spy[-1] == ("open", "https://clawgate.zacx.dev/tasks/10593")
 
 
 def test_a_dismissed_picker_opens_nothing_and_is_not_an_error(spy, monkeypatch):

--- a/scripts/tests/test_mention_scan.py
+++ b/scripts/tests/test_mention_scan.py
@@ -141,12 +141,41 @@ def test_bare_hash_number_returns_a_candidate_for_both_platforms():
     assert {c["end"] for c in cands} == {len("fixed in #370")}
 
 
-def test_the_clawgate_candidate_anchors_on_the_task_cards_own_dom_id():
-    """clawgate DOES have a browser UI (GET /tasks -> handleIndex) and each card
-    carries `id="task-<n>"` — internal/ui/notes.go, `ID("task-"+ids)`, pinned by
-    its own notes_test.go as a stable card id."""
+def test_the_clawgate_candidate_points_at_the_task_details_page():
+    """clawgate serves a real, server-rendered page per task at `GET /tasks/{id}`
+    (internal/api/server.go, `s.handleTaskDetail`), so the candidate is a PATH,
+    not a fragment on the board."""
     (clawgate, _github) = MS.scan_mentions("#370")
-    assert clawgate["url"] == "https://clawgate.zacx.dev/tasks#task-370"
+    assert clawgate["url"] == "https://clawgate.zacx.dev/tasks/370"
+
+
+def test_the_clawgate_url_carries_NO_fragment():
+    """🔴 The regression guard for a partial revert. `#task-<id>` was the old
+    pattern and it resolved only for a card the board had already rendered; the
+    details page has no such precondition. A `#` anywhere in the URL means some
+    caller is back on the fragment, so pin its ABSENCE rather than only pinning
+    the new string — a half-reverted `…/tasks/370#task-370` passes an `endswith`
+    check and fails this one."""
+    (clawgate, _github) = MS.scan_mentions("#370")
+    assert "#" not in clawgate["url"], clawgate["url"]
+    assert "#" not in MS.clawgate_url("370")
+    assert not MS.CLAWGATE_TASKS_URL.endswith("/")
+
+
+def test_the_clawgate_url_round_trips_a_multi_digit_id():
+    """The id is interpolated whole, never truncated or re-parsed. Distinct
+    digit-counts, and no digit repeated across the cases, so a mutation that
+    slices or reformats the id cannot land on the expected string by accident."""
+    for ident, expected in (
+        ("7", "https://clawgate.zacx.dev/tasks/7"),
+        ("42", "https://clawgate.zacx.dev/tasks/42"),
+        ("370", "https://clawgate.zacx.dev/tasks/370"),
+        ("10593", "https://clawgate.zacx.dev/tasks/10593"),
+    ):
+        assert MS.clawgate_url(ident) == expected
+        (clawgate, _github) = MS.scan_mentions(f"#{ident}")
+        assert clawgate["url"] == expected, ident
+        assert clawgate["id"] == ident
 
 
 def test_a_bare_number_gets_a_github_url_only_from_a_supplied_repo():


### PR DESCRIPTION
## 🔴 DO NOT MERGE YET — clawgate must ship first

These URLs **404 against the live clawgate (0.8.21)**. `GET /tasks/{id}` does not exist yet; a
separate agent is implementing it in `homelab-talos` right now. **The clawgate carrying that route
must be built, pinned and deployed BEFORE this merges** — otherwise every mention click, every
Alacritty `#N` hint and every initiatives-board linked-task link lands on a 404 instead of the
board it used to land on.

Merge order: **clawgate deploy → verify `/tasks/<id>` serves → merge this → `scripts/ship.sh`.**

---

## What changes

clawgate is gaining a real server-rendered task details page at `GET /tasks/{id}`, so the canonical
deeplink stops being a fragment on the board and becomes a path:

```
- https://clawgate.zacx.dev/tasks#task-<id>
+ https://clawgate.zacx.dev/tasks/<id>
```

Two constructors in this repo, both changed:

| File | What |
|---|---|
| `scripts/collector/mention_scan.py` | `clawgate_url()` — the canonical one. Feeds BOTH the activity collector's mention events (`collector/claude/session-tailer.py`) and the Alacritty hint handler (`scripts/mention-open.py`), which is the whole reason it is one module. |
| `scripts/initiatives/tasks.py` | `task_view()`'s `url` — the initiatives board's linked-task deeplink. |

### The sweep

`rg --no-ignore` (not the ugrep-wrapped `grep`, which honours `.gitignore`) for `#task-`,
`/tasks#`, `clawgate.zacx.dev` and `30302` across the whole repo. **No third constructor exists.**
Every other hit is one of:

- the `/api/tasks` **machine** endpoint (`scripts/mail-actions/clawgate.py`,
  `scripts/repo-cos/clawgate.py`, `scripts/lib/clawgate_handoff.sh`) — unaffected, different route;
- a **board-root** opener with no task id (`nix/graphical.nix:281`, `scripts/bar-status-poll`,
  `scripts/tmux-snapshot-push.sh`, `githooks/audit-on-push.sh`) — unaffected;
- prose in `claudedocs/` and `claude/skills/` — historical records, deliberately not rewritten.

### The comment rewrite is the point, not decoration

`mention_scan.py:50-60` carried a "⚠ HONEST SCOPE" paragraph documenting that an anchor only
scrolls to a card **already on the page**, so a filtered / archived / collapsed task degraded to
the top of `/tasks`. The details page **closes that hazard**, which makes the paragraph false — and
a stale note about a closed hazard is how a maintainer later deletes the thing that closed it.

It is replaced with a scope statement that is true of the page, **including the part that did not
get better**: a bad id now gets whatever clawgate answers for an id it does not hold, instead of
silently landing on the board. The new comment also carries the deploy-ordering constraint above,
so the next reader learns it from the code and not from this PR description.

`tasks.py`'s `task_view` docstring got the same treatment.

---

## Test coverage

**Every assertion was watched RED before the change and green after.** Base `a720d30d`
(`origin/main`), HEAD `acdce599`.

```
red  @ a720d30d : 15 failed, 156 passed   (test expectations updated, source untouched)
green@ acdce599 : 171 passed
```

The 15: 3 in `test_mention_scan.py`, 7 in `test_mention_open.py`, 4 in
`initiatives/tests/test_tasks.py`, 1 in `initiatives/tests/test_dispatch.py`.

### Updated (literals that pinned the old form)

`test_mention_scan.py`, `test_mention_open.py` (×5), `initiatives/tests/test_tasks.py` (×2),
`test_dispatch.py` (×1), `test_viewer.py` (×2).

### New

- **`test_the_clawgate_url_carries_NO_fragment`**, **`test_task_view_url_is_a_page_path_with_NO_fragment`**,
  **`test_the_clawgate_candidate_opens_a_page_not_a_fragment`** — pin the **absence** of `#`. This
  is the regression guard for a partial revert: `…/tasks/370#task-370` satisfies a substring or
  `endswith` check on the new form and fails only these three.
- **multi-digit round-trip** tests in both modules — ids `7 / 42 / 370 / 10593`, four distinct digit
  lengths, none a prefix or suffix of another, so a slicing or reformatting mutant cannot land on
  the expected string by accident. `10593` is the widest the bare-`#` pattern admits (`_NUM = \d{1,5}`).
- **`test_the_linked_task_fixture_matches_what_tasks_task_view_really_produces`** — ⚠ labelled a
  **SEAM guard, not regression coverage**: it is green at the base ref too, and is not counted
  toward the red→green matrix.

  It exists because `test_viewer.py`'s `_tv` helper *claims in its docstring* to be "a linked-task
  view as `tasks.task_view` produces it" and **nothing checked that claim** — every URL in that
  1,000-line linked-task section was a hand-written literal. Consequence, measured: changing the
  real constructor left the whole section green. Two surfaces each tested in isolation, the seam
  owned by nobody. The guard now pins the relationship field-for-field, which is what makes the
  deeplink assertions there real coverage instead of a self-portrait.

### Mutation-tested, not assumed

Run with `PYTHONDONTWRITEBYTECODE=1` (same-length edits landing in the same whole second are
invisible to CPython's mtime-keyed `.pyc` cache, which scores a mutant SURVIVED without running
it). Unmutated **positive control 91/91 green before and after** the sweep.

| # | Mutation | Result |
|---|---|---|
| M1 | `clawgate_url` full revert to `#task-` | **10 killed** |
| M2 | partial revert `…/tasks/{id}#task-{id}` | **10 killed**, incl. all three no-fragment guards |
| M3 | id truncated to 2 chars (`task_id[:2]`) | **9 killed**, incl. the multi-digit guards |
| M4 | `task_view` partial revert | **4 killed** |
| M5 | `tasks.py` reverted, `test_viewer` fixture NOT | the seam guard **alone** goes red |

M2 is the one that matters: it is the only mutation a naive "does the URL end with `/370`" test
would survive.

---

## Out of scope, flagged not fixed

`homelab-talos` `scripts/clickup-mirror/writeback.py:639` emits `{base}/tasks#{tid}` — note the
**missing `task-` prefix**, so that anchor has never resolved against the card DOM id `task-<id>`.
It is latent, not live (`clawgate_public_url` defaults to `""` and nothing sets it). It is in the
other repo and belongs to that side of the cutover.

## Not verified

- I have **not** exercised a real `GET /tasks/<id>` — the route does not exist yet. Every claim
  here is about what this repo *constructs*, never about what clawgate *serves*.
- The `psycopg2`-dependent tests in `scripts/initiatives/tests/` fail on a bare host `python3`
  (`ModuleNotFoundError`) in files this PR does not touch; they pass under the authoritative nix
  gate, which supplies the dependency.

---

## Authoritative gate

`nix build .#checks.x86_64-linux.pytests` on the committed tree (`acdce599`):

```
TOTAL collected=20498  passed=20494  skipped=3  failed=1   (floor: 18404 over 30 targets)

  PASS  scripts/tests                (collected=11498 passed=11498 skipped=0 floor=10269)
  PASS  scripts/initiatives/tests    (collected=787   passed=787   skipped=0 floor=745)
  FAIL  scripts/collector/keylog/tests (collected=101 passed=100 failed=1)
  …28 further targets PASS
```

`scripts/run-tests.sh --check-floors` (GUARD 3a): **PASS**.

### The one failure is base-inherited, and was controlled for

`test_live_existing_resolutions_not_made_ambiguous` — an espanso search-term guard:

```
search terms regressed: {'recom': (':rna', None, [':acq', ':rna']),
                         'recommend': (':rna', None, [':acq', ':rna'])}
```

Not a load flake and not reasoned away — **run at `origin/main` (5a82aaa9) in a detached
worktree, where it fails with the byte-identical payload.** This branch touches nothing under
`scripts/collector/keylog/`, `nix/` or the espanso snippets, and `rg` finds no path from keylog to
either changed module. Someone should fix it, but it is not this PR's.

### Merged-tree caveat

The gate ran on this branch at base `a720d30d`. `origin/main` has since advanced by three
**docs-only** commits (`CLAUDE.md` + two `claudedocs/*.md`, no Python). GitHub reports
`MERGEABLE` / `CLEAN`. Because this PR cannot merge until clawgate ships the route anyway, **re-run
the gate on the merged tree at merge time** — by then main will have moved further, and one of
those commits touches `CLAUDE.md`, which `test_doc_path_rot.py` reads.
