### PR TITLE
fix(cairn tests): name the I/O stall, so a 5s fsync stops reading as a code failure

### DIFF
--- a/scripts/ci-repro/README.md
+++ b/scripts/ci-repro/README.md
@@ -382,3 +382,74 @@ is a 24-core host with fast NVMe; the arming path is a few ms of CPU, so a ~50x
 slowdown would be needed to miss 250 ms. The deterministic injection above reproduces
 the exact failure and the mutation matrix bounds the fix — but the *natural* CI
 scheduling failure was not reproduced here.
+
+---
+
+## `slow_cairn_fsync.py` — the SAME stall, twelve times more sensitive (devrc#1242)
+
+**What it answers.** `tekton/devrc-pytests` fails on
+`test_cairn_write.py::TestAppendLands::test_a_bullet_is_appended_and_the_status_is_named`
+— and, because `--dist loadfile` puts a whole file on one worker, on its siblings in
+the same run — with
+
+```
+AssertionError: 🔴 cairn: the write did NOT happen — http://127.0.0.1:PORT unreachable: timed out
+                Nothing was queued and nothing was written locally.
+assert 7 == 0
+```
+
+🔴 **It is the same fsync mechanism as the store-api half above, but this was VERIFIED
+rather than assumed, and it does not simply inherit that root cause.**
+`test_cairn_write.py` imports `http.server` and stands up its OWN loopback servers; it
+carries no `MECHANISM` classifier of its own. The transfer was established from the CI
+log directly, not by analogy: on `devrc-ci-jfg67` the store root was
+`/tmp/nix-build-devrc-pytests.drv-0/pytest-of-nixbld1/pytest-0/popen-gw1/…` — the step
+container's ephemeral layer, exactly as documented above — and the message names a
+client-side `timed out`, not a refused connection.
+
+🔴 **THE BOUND IS `--timeout 5`, NOT `HANG_TIMEOUT` 60.0.** `run_cairn` passes it to the
+client subprocess, so a single fsync slower than **five seconds** breaches it. That is
+**twelve times tighter** than the store-api half, which is why this file is the more
+frequent casualty of the same contention, and why sizing a reproducer at 65 s here
+would overstate how much latency it takes.
+
+**Why a third instrument.** `slowfsync.c` is `LD_PRELOAD`, which is inherited across
+`exec()` — and here the store server is IN-PROCESS while the cairn client is a
+SUBPROCESS, so preloading would stall both sides and muddy which one timed out.
+Patching `os.fsync` inside the test process stalls exactly the server. No compiler.
+Full usage, controls and measurements are in the plugin's own docstring.
+
+**What changed in the repo, and what did not.**
+
+* `testlib/hang_mechanism.py` (new) gives this suite the `MECHANISM =` verdict the
+  store-api suite already had, and `test_cairn_write.py`'s write assertions now carry
+  it. Under the reproduction the failure reads
+  `MECHANISM = SERVER_BLOCKED_IN_FSYNC (handler threads=2 [...=BLOCKED_ELSEWHERE
+  ...=SERVER_BLOCKED_IN_FSYNC], accept loop parked=True)` plus the store's filesystem.
+  🔴 **DIAGNOSIS, NOT TOLERANCE** — no bound moved, nothing retries, the test fails
+  exactly as before. A gate that reports a code failure for an I/O stall trains
+  everyone to click through, and that was the whole cost.
+* 🔴 **The headline is deliberately NOT a consensus of the handler threads.** Two
+  servers are live here — the store and the shim in front of it — so when a write times
+  out they legitimately disagree: the shim is parked in `urlopen`, the store in
+  `fsync`. Measured. A rule requiring agreement would answer `AMBIGUOUS` for the
+  textbook case the classifier exists to name.
+* 🔴 **`hang_mechanism` scans frames' SOURCE LINES, never their FILENAME**, which is the
+  known-and-unfixed defect `_HUNG_SERVER_RULES` carries above (a worktree named
+  `devrc-fsync` misclassifies every hang there). Pinned by
+  `test_hang_mechanism.py::test_a_checkout_PATH_containing_a_token_does_not_decide_the_verdict`,
+  which was watched to fail when the filename is folded back in. **The store-api
+  classifier was NOT rewired onto the shared module** — it has its own tests and that is
+  its own edit; two copies exist today and that is a known debt, not an oversight.
+* **Nothing here fixes the stall**, and the disk-siting half was already fixed:
+  `b4fde334` (#1219) moved this file's store onto tmpfs. ⚠ **Both reproductions above
+  ran with that mitigation fully in force** (`/dev/shm/devrc-store-…`), so this is a
+  **latency** dependency, not a filesystem one. tmpfs makes a breach far less likely; it
+  does not remove the 5 s bound, and `store_siting` falls back to disk in five
+  documented ways without saying so. The levers for the stall itself remain the infra
+  ones ranked in the store-api section.
+
+⚠ **A PR branched before `b4fde334` still carries the old disk-backed fixture**, because
+branch protection sets `strict: false` and never rebases. Both failures examined here
+(#1209, #1233) were such branches. Rebasing is what picks the mitigation up — the fix
+does not reach an open PR on its own.

--- a/scripts/ci-repro/slow_cairn_fsync.py
+++ b/scripts/ci-repro/slow_cairn_fsync.py
@@ -1,0 +1,131 @@
+"""Stall `os.fsync` IN THE TEST PROCESS — the cairn half of the gate failure.
+
+**What it answers.** `tekton/devrc-pytests` fails on
+`test_cairn_write.py::TestAppendLands::test_a_bullet_is_appended_and_the_status_is_
+named` (and its four siblings, which `--dist loadfile` puts on the same worker) with
+
+```
+AssertionError: 🔴 cairn: the write did NOT happen — http://127.0.0.1:PORT
+                unreachable: timed out
+assert 7 == 0
+```
+
+on PRs whose diff cannot reach it. Measured on `devrc-ci-jfg67` (2026-09-02),
+store root `/tmp/nix-build-devrc-pytests.drv-0/…/popen-gw1/…` — the step
+container's ephemeral layer, the same device the store-api half stalls on.
+
+**Why this is a third instrument and not a duplicate.** `slowfsync.c` above delays
+the FIRST fsync per process by a hardcoded 65 s, sized against the store-api
+suite's `HANG_TIMEOUT` of 60.0. The cairn bound is **`--timeout 5`**, passed by
+`run_cairn` to the client subprocess — **twelve times tighter**, and correspondingly
+far easier for the contended node to breach. Sizing a repro at 65 s here would work
+but would say nothing about how little latency it actually takes.
+
+It also must NOT be `LD_PRELOAD`. In this file the store server runs IN-PROCESS
+while the cairn client is a SUBPROCESS, and `LD_PRELOAD` is inherited across
+`exec()` — so it would stall the client too, muddying which side timed out. Patching
+`os.fsync` in the test process stalls exactly the server, which is the condition
+under test. No compiler needed.
+
+**Usage.**
+
+```bash
+# control — shim attached but inert, same command line
+PYTHONPATH=scripts/ci-repro nix develop . --command python3 -m pytest \
+  scripts/tests/test_cairn_write.py::TestAppendLands -q -s -p slow_cairn_fsync
+
+# reproduction — an 8 s stall against the 5 s client bound
+SLOW_CAIRN_FSYNC_S=8 PYTHONPATH=scripts/ci-repro nix develop . --command python3 \
+  -m pytest scripts/tests/test_cairn_write.py::TestAppendLands -q -s \
+  -p slow_cairn_fsync --slow-cairn-fsync-selftest
+```
+
+**Measured 2026-09-02** on `origin/main` at `946a51f0`, one test:
+
+| run | result |
+|---|---|
+| control (`SLOW_CAIRN_FSYNC_S` unset) | `1 passed in 1.04s`, `intercepted_fsyncs=2` |
+| reproduction (`SLOW_CAIRN_FSYNC_S=8`) | `1 failed in 5.83s`, text identical to CI |
+
+🔴 **The control's `intercepted_fsyncs=2` is the POSITIVE CONTROL and it is not
+decoration.** It proves the append path really does issue the two fsyncs
+`_replace_bytes` is documented to make — the file, then the parent directory —
+inside the request. A zero there would mean the shim patched nothing and the
+reproduction below would be a fact about the collection filter, not about fsync.
+
+⚠ **The store was on TMPFS for both runs** (`/dev/shm/devrc-store-…`), i.e. with
+`testlib.store_siting`'s mitigation fully in force. That is the point: this is a
+LATENCY dependency, not a filesystem one. Siting the store off the contended disk
+makes a breach far less likely; it does not remove the bound, and `store_siting`
+falls back to disk in five documented ways without saying so.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_REAL_FSYNC = os.fsync
+_HITS = {"n": 0}
+
+
+def _delay() -> float:
+    raw = os.environ.get("SLOW_CAIRN_FSYNC_S", "").strip()
+    return float(raw) if raw else 0.0
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--slow-cairn-fsync-selftest",
+        action="store_true",
+        help="fail loudly unless the shim attached and actually intercepted an fsync",
+    )
+
+
+def pytest_configure(config):
+    delay = _delay()
+    if config.getoption("--slow-cairn-fsync-selftest"):
+        assert delay > 0, (
+            f"SLOW_CAIRN_FSYNC_S={os.environ.get('SLOW_CAIRN_FSYNC_S')!r} gives "
+            f"{delay}s — the shim would be inert, making this a CONTROL run and "
+            f"not a reproduction"
+        )
+
+    import time
+
+    def slow_fsync(fd):
+        _HITS["n"] += 1
+        if delay > 0:
+            # Inside the request and before the response is written, exactly where
+            # `server.py:_replace_bytes` issues the real one.
+            time.sleep(delay)
+        return _REAL_FSYNC(fd)
+
+    os.fsync = slow_fsync
+
+
+def pytest_unconfigure(config):
+    os.fsync = _REAL_FSYNC
+    # Always reported, armed or not: a shim that silently failed to attach gives a
+    # clean green that means nothing, and a zero here is how you would see it.
+    print(
+        f"\nslow_cairn_fsync: delay={_delay()}s intercepted_fsyncs={_HITS['n']}",
+        file=sys.stderr,
+    )
+    if config.getoption("--slow-cairn-fsync-selftest"):
+        assert _HITS["n"] > 0, (
+            "the shim intercepted ZERO fsyncs — nothing under test called os.fsync, "
+            "so this run says nothing about the stall it claims to reproduce"
+        )
+
+
+def pytest_report_header(config):
+    delay = _delay()
+    if delay <= 0:
+        return (
+            "slow_cairn_fsync: INERT (SLOW_CAIRN_FSYNC_S unset or 0) "
+            "— this is a CONTROL run"
+        )
+    return (
+        f"slow_cairn_fsync: ARMED, {delay}s per fsync "
+        f"(the cairn client bound is --timeout 5)"
+    )

--- a/scripts/testlib/hang_mechanism.py
+++ b/scripts/testlib/hang_mechanism.py
@@ -1,0 +1,147 @@
+"""Why a server thread did not answer — a `MECHANISM =` verdict for a CI log.
+
+🔴 DIAGNOSTICS, NOT A MITIGATION. Nothing here retries, drains, sleeps, or moves a
+bound. A test that failed still fails, exactly as loudly. What this adds is the one
+fact the bare assertion cannot carry.
+
+The problem it exists for: **a client-side timeout is the observable that the most
+mechanisms share, so on its own it identifies none of them.** `scripts/ci-repro/
+README.md` records the store-api half of this; the cairn half reaches the same dead
+end from the other side. `server.py:_replace_bytes` fsyncs the file and then the
+parent directory INSIDE the request, before the response is written, and fsync blocks
+in uninterruptible D-state bounded by nothing. When that outlasts the client's bound
+the client reports the store UNREACHABLE, and the gate reads
+
+    AssertionError: cairn: the write did NOT happen — ... unreachable: timed out
+    assert 7 == 0
+
+which is a sentence about the write CODE for what was an I/O stall. Measured
+2026-09-02 on `devrc-ci-jfg67`, and reproduced on the dev host with the store on
+**tmpfs** — so this is a latency dependency, not a filesystem one, and siting the
+store off the contended disk (`testlib.store_siting`) shrinks the probability
+without removing it.
+
+🔴 SOURCE LINES ONLY — NEVER THE FILENAME, AND THAT IS A FIX, NOT A STYLE CHOICE.
+`test_subsystem_store_api.py:_HUNG_SERVER_RULES` carries a documented KNOWN DEFECT:
+it matches its tokens against `traceback.format_stack`, which RENDERS EACH FRAME'S
+FILENAME, so a checkout whose PATH contains a token misclassifies every hang —
+confidently and wrongly, which is worse than no verdict. It was reproduced there by
+accident: a worktree named `devrc-fsync` turned an entry-lock stall into
+`SERVER_BLOCKED_IN_FSYNC`. This module classifies on the frame's SOURCE LINE and
+FUNCTION NAME and never on its path, and
+`test_hang_mechanism.py::test_a_checkout_PATH_containing_a_token_does_not_decide_the
+_verdict` pins that.
+"""
+from __future__ import annotations
+
+import sys
+import threading
+import traceback
+import types
+
+# Token -> mechanism, matched against a frame's SOURCE LINE and FUNCTION NAME.
+#
+# Ordered, and the FIRST match on the innermost matching frame wins. These are the
+# unbounded waits a store-server handler can sit in; each blocks in a way no socket
+# timeout reaches, because a socket timeout does not bound a syscall.
+RULES: tuple[tuple[str, str], ...] = (
+    ("fsync", "SERVER_BLOCKED_IN_FSYNC"),
+    ("flock", "SERVER_BLOCKED_ON_ENTRY_LOCK"),
+    ("_EntryLock", "SERVER_BLOCKED_ON_ENTRY_LOCK"),
+    ("_audit_lock", "SERVER_BLOCKED_IN_AUDIT_SINK"),
+)
+
+# socketserver's per-connection worker. Its presence is what makes a thread a
+# HANDLER rather than the accept loop.
+_HANDLER_MARKER = "process_request_thread"
+_ACCEPT_MARKER = "serve_forever"
+
+
+def _frames(frame: types.FrameType) -> list[tuple[str, str]]:
+    """`(function_name, source_line)` for every frame, INNERMOST FIRST.
+
+    The filename is dropped here rather than filtered later, so no caller can
+    reintroduce the path-matching defect this module exists to avoid.
+    """
+    summary = traceback.StackSummary.extract(
+        traceback.walk_stack(frame), capture_locals=False
+    )
+    return [(f.name, f.line or "") for f in summary]
+
+
+def classify(frames: list[tuple[str, str]]) -> str:
+    """The mechanism for ONE thread, from its `(name, source_line)` pairs.
+
+    Scans innermost-first and returns the first rule that matches either half of a
+    frame. `BLOCKED_ELSEWHERE` when the thread is parked somewhere unledgered — a
+    real answer, and deliberately not a guess at which rule was "closest".
+    """
+    for name, line in frames:
+        for token, mechanism in RULES:
+            if token in line or token in name:
+                return mechanism
+    return "BLOCKED_ELSEWHERE"
+
+
+def report(note: str = "") -> str:
+    """A `MECHANISM = ...` headline plus every non-main thread's stack.
+
+    🔴 THE HEADLINE ASKS ONE QUESTION: **is any server thread parked in a known
+    unbounded wait right now?** It is not a consensus of the threads, and it must
+    not be, because two servers are live in these tests — the store server and the
+    shim in front of it — and at the moment a write times out the shim's handler is
+    legitimately parked in `urlopen` waiting on the store. A rule that demanded the
+    handlers AGREE would answer `AMBIGUOUS` for the textbook case this exists to
+    name. So the headline is a ledgered mechanism found on ANY handler — and when
+    several are live at once, the one appearing FIRST IN `RULES`, which is a
+    tie-break for determinism and NOT a claim that it is the more important of
+    them. Every handler's own verdict is printed beside the headline, so a reader
+    can check the choice rather than take it.
+
+    When no handler is parked in a ledgered wait the headline says so
+    (`NO_LEDGERED_STALL`) rather than naming a mechanism it did not observe. That is
+    the honest answer for a stall that had already cleared by the time the assertion
+    ran, and for a genuine code failure — the two are NOT distinguished here, and
+    this docstring does not claim they are.
+    """
+    current = sys._current_frames()
+    main_ident = threading.main_thread().ident
+    handlers: list[tuple[str, str]] = []
+    accept_parked = False
+    stacks: list[str] = []
+
+    for thread in threading.enumerate():
+        frame = current.get(thread.ident)
+        if frame is None or thread.ident == main_ident:
+            continue
+        frames = _frames(frame)
+        blob = " ".join(name for name, _ in frames)
+        stacks.append(
+            f"--- thread {thread.name!r} daemon={thread.daemon} ---\n"
+            + "".join(traceback.format_stack(frame))
+        )
+        if _HANDLER_MARKER in blob:
+            handlers.append((thread.name, classify(frames)))
+        elif _ACCEPT_MARKER in blob:
+            accept_parked = True
+
+    found = {mechanism for _, mechanism in handlers} - {"BLOCKED_ELSEWHERE"}
+    if found:
+        # Deterministic when several ledgered mechanisms are live at once: take the
+        # earliest in RULES, so the verdict does not depend on thread order.
+        order = [m for _, m in RULES]
+        verdict = sorted(found, key=order.index)[0]
+    elif handlers:
+        verdict = "NO_LEDGERED_STALL"
+    elif accept_parked:
+        verdict = "NEVER_ACCEPTED"
+    else:
+        verdict = "NO_SERVER_THREAD_ALIVE"
+
+    per_handler = " ".join(f"{n}={m}" for n, m in handlers) or "-"
+    return (
+        f"\nMECHANISM = {verdict}   "
+        f"(handler threads={len(handlers)} [{per_handler}], "
+        f"accept loop parked={accept_parked})"
+        f"{note}\n" + "".join(stacks)
+    )

--- a/scripts/tests/test_cairn_write.py
+++ b/scripts/tests/test_cairn_write.py
@@ -35,7 +35,7 @@ import pytest
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "scripts"))
-from testlib import store_siting  # noqa: E402
+from testlib import hang_mechanism, store_siting  # noqa: E402
 CAIRN_CLI = REPO / "scripts" / "cairn"
 SERVER_PY = REPO / "scripts" / "subsystem-store-api" / "server.py"
 GOOD_TOKEN = "w" * 20 + "R" * 20 + "t" * 8
@@ -256,6 +256,47 @@ def run_cairn(*args: str, url: str | None, cache: Path, token: str = GOOD_TOKEN)
     )
 
 
+def why_the_write_failed(proc: subprocess.CompletedProcess, live=None) -> str:
+    """The assertion message for a write that was supposed to land.
+
+    🔴 EXIT 7 HERE HAS TWO CAUSES AND THE BARE ASSERTION NAMES NEITHER. `cairn`
+    passes `--timeout 5`, and `server.py:_replace_bytes` fsyncs the file and then
+    the parent directory INSIDE the request, before the response is written. So a
+    single fsync slower than five seconds makes the client report the store
+    UNREACHABLE, and the gate prints
+
+        AssertionError: cairn: the write did NOT happen — ... unreachable: timed out
+        assert 7 == 0
+
+    for an I/O stall — a sentence about this client's code, describing the disk.
+    Measured in CI on `devrc-ci-jfg67` (2026-09-02) and reproduced on the dev host
+    by stalling `os.fsync` past the bound. A gate that reports a code failure for an
+    I/O stall trains everyone to click through, which is the actual cost.
+
+    So the message carries the two facts that separate the causes: whether any
+    server thread is parked in an unbounded wait RIGHT NOW
+    (`testlib.hang_mechanism`), and which filesystem the store was sited on — the
+    standing precondition, since `testlib.store_siting` falls back to disk in five
+    documented ways and says nothing when it does.
+
+    🔴 This is DIAGNOSIS, NOT TOLERANCE. It changes no bound, retries nothing, and
+    the assertion fails exactly as it did before; only the message is wider. It is
+    also NOT a proof of an I/O stall: a stall that had already cleared reads the
+    same as a genuine code failure, and `hang_mechanism.report` says
+    `NO_LEDGERED_STALL` for both rather than guessing between them.
+    """
+    note = ""
+    if live is not None:
+        note = (
+            f"\nstore={live.store} fs={store_siting.mount_fstype(live.store)} "
+            f"(tmpfs = the contended-disk mitigation was in force)"
+        )
+    return (
+        f"exit={proc.returncode}\nstdout: {proc.stdout}\nstderr: {proc.stderr}"
+        + hang_mechanism.report(note)
+    )
+
+
 # =============================================================================
 
 
@@ -267,7 +308,7 @@ class TestAppendLands:
             "--session", SESSION,
             url=live.base, cache=tmp_path / "c",
         )
-        assert proc.returncode == 0, proc.stderr
+        assert proc.returncode == 0, why_the_write_failed(proc, live)
         assert "appended" in proc.stdout, proc.stdout
         # 🔴 THE POSITIVE CONTROL, and it is not optional. `RULES.md` on this
         # exact API: "reading '0 occurrences' off the response is a FALSE GREEN —
@@ -292,9 +333,9 @@ class TestAppendLands:
             "--text", "attribution comes from the credential",
             "--session", SESSION, url=live.base, cache=tmp_path / "c",
         )
-        assert proc.returncode == 0, proc.stderr
-        landed = (live.store / "widget-cfg" / "thing-alpha.md").read_text()
-        assert "[cairn: tester/" in landed
+        assert proc.returncode == 0, why_the_write_failed(proc, live)
+        on_disk = (live.store / "widget-cfg" / "thing-alpha.md").read_text()
+        assert "[cairn: tester/" in on_disk
         help_text = subprocess.run(
             [sys.executable, str(CAIRN_CLI), "append", "--help"],
             capture_output=True, text=True, timeout=60,
@@ -313,7 +354,8 @@ class TestAppendLands:
                 "--text", "the same observation twice", "--session", SESSION)
         first = run_cairn(*args, url=live.base, cache=tmp_path / "c")
         second = run_cairn(*args, url=live.base, cache=tmp_path / "c")
-        assert first.returncode == 0 and second.returncode == 0
+        assert first.returncode == 0, why_the_write_failed(first, live)
+        assert second.returncode == 0, why_the_write_failed(second, live)
         assert "appended" in first.stdout and "duplicate" not in first.stdout
         assert "duplicate" in second.stdout
         body = (live.store / "widget-cfg" / "thing-beta.md").read_text()
@@ -331,7 +373,7 @@ class TestAppendLands:
             "--text", "reached through the alias tier", "--session", SESSION,
             url=live.base, cache=tmp_path / "c",
         )
-        assert proc.returncode == 0, proc.stderr
+        assert proc.returncode == 0, why_the_write_failed(proc, live)
         assert "reached through the alias tier" in (
             live.store / "widget-cfg" / "thing-gamma.md"
         ).read_text()
@@ -598,7 +640,7 @@ class TestPutReplacesBehindAPrecondition:
             "put", "--scope", "widget-cfg", "--ref", "thing-beta",
             "--file", str(replacement), url=live.base, cache=tmp_path / "c",
         )
-        assert proc.returncode == 0, (proc.stdout, proc.stderr)
+        assert proc.returncode == 0, why_the_write_failed(proc, live)
         assert "derived If-Match" in proc.stderr
         on_disk = (live.store / "widget-cfg" / "thing-beta.md").read_text()
         assert "RESOLVED abc1234" in on_disk

--- a/scripts/tests/test_hang_mechanism.py
+++ b/scripts/tests/test_hang_mechanism.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""`testlib.hang_mechanism` — the verdict that separates an I/O stall from a bug.
+
+🔴 WHY THIS NEEDS TESTS OF ITS OWN: A CLASSIFIER THAT ANSWERS THE SAME THING TO
+EVERY HANG IS WORSE THAN NO CLASSIFIER. It reads as evidence, it appears in a CI
+log next to a real failure, and it stops the next person looking. So these pull the
+verdicts APART — each case asserts the mechanism it expects AND that the rival
+verdict is absent, because "contains SERVER_BLOCKED_IN_FSYNC" passes for a function
+that returns that string unconditionally.
+
+The path case is the one that motivated putting this in `testlib` rather than
+copying the store-api classifier: that one matches its tokens against
+`traceback.format_stack`, which renders each frame's FILENAME, so a checkout whose
+path contains a token misclassifies every hang. It is documented there as a known,
+unfixed defect. This module must not inherit it, and a test — not a comment — is
+what keeps that true.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import traceback
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts"))
+from testlib import hang_mechanism  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# classify() — the per-thread verdict, from (function name, source line) pairs.
+# --------------------------------------------------------------------------
+
+
+def test_a_frame_that_calls_fsync_is_named_as_an_fsync_stall():
+    frames = [("_replace_bytes", "os.fsync(fh.fileno())"), ("do_POST", "self._append()")]
+    assert hang_mechanism.classify(frames) == "SERVER_BLOCKED_IN_FSYNC"
+
+
+def test_the_INNERMOST_ledgered_frame_wins_not_an_outer_one():
+    """Innermost-first, because the outer frames are the CALLERS of the wait.
+
+    A stack that entered through the entry lock and is now parked in fsync is an
+    fsync stall; reporting the outermost match would name the lock and send a
+    reader to the wrong subsystem.
+    """
+    frames = [
+        ("_replace_bytes", "os.fsync(fd)"),      # innermost — where it is parked
+        ("_write_entry", "with _EntryLock(path):"),  # outer — how it got there
+    ]
+    verdict = hang_mechanism.classify(frames)
+    assert verdict == "SERVER_BLOCKED_IN_FSYNC"
+    assert verdict != "SERVER_BLOCKED_ON_ENTRY_LOCK"
+
+
+def test_an_unledgered_park_is_BLOCKED_ELSEWHERE_and_not_a_nearest_guess():
+    frames = [("_proxy", "urllib.request.urlopen(req, timeout=15)")]
+    assert hang_mechanism.classify(frames) == "BLOCKED_ELSEWHERE"
+
+
+def test_the_entry_lock_and_the_audit_sink_are_told_APART_from_fsync():
+    """Three ledgered mechanisms, three different answers.
+
+    🔴 Asserting only that each is non-empty would pass for a classifier that
+    answered `SERVER_BLOCKED_IN_FSYNC` to all three — the exact failure this file
+    exists to prevent — so each case also asserts the others are NOT returned.
+    """
+    lock = hang_mechanism.classify([("_write", "with _EntryLock(p):")])
+    audit = hang_mechanism.classify([("_emit", "with self._audit_lock:")])
+    fsync = hang_mechanism.classify([("_replace", "os.fsync(fd)")])
+    assert lock == "SERVER_BLOCKED_ON_ENTRY_LOCK"
+    assert audit == "SERVER_BLOCKED_IN_AUDIT_SINK"
+    assert fsync == "SERVER_BLOCKED_IN_FSYNC"
+    assert len({lock, audit, fsync}) == 3, (
+        "the classifier collapsed three distinct mechanisms onto fewer verdicts"
+    )
+
+
+# --------------------------------------------------------------------------
+# The path defect. This is the reason this module exists separately.
+# --------------------------------------------------------------------------
+
+
+def test_a_checkout_PATH_containing_a_token_does_not_decide_the_verdict():
+    """🔴 THE DEFECT `test_subsystem_store_api.py` DOCUMENTS AS KNOWN AND UNFIXED.
+
+    A worktree named `devrc-fsync` — the likely name for a checkout in which
+    someone is fixing this very flake — turned an unrelated stall into
+    `SERVER_BLOCKED_IN_FSYNC` there, because the tokens are matched against
+    `traceback.format_stack`, which renders each frame's filename.
+
+    This builds exactly that situation: a frame whose FILENAME contains `fsync`
+    and whose source line does not. The control is the first assertion — it proves
+    the token really is present in the rendered stack, so a passing verdict below
+    is the classifier ignoring the path rather than the fixture failing to contain
+    it. Without that control this test would pass against a tree where the setup
+    silently stopped working.
+    """
+    source = "def parked(probe):\n    return probe()\n"
+    namespace: dict = {}
+    exec(compile(source, "/tmp/devrc-fsync/server.py", "exec"), namespace)
+
+    captured: dict = {}
+
+    def probe():
+        frame = sys._getframe()
+        captured["frames"] = hang_mechanism._frames(frame)
+        captured["rendered"] = "".join(traceback.format_stack(frame))
+        return None
+
+    namespace["parked"](probe)
+
+    # CONTROL: the token IS in the rendered stack, via the path alone.
+    assert "fsync" in captured["rendered"], (
+        "the fixture did not put `fsync` into the rendered stack at all, so the "
+        "assertion below would pass vacuously"
+    )
+    # And it is NOT in what the classifier actually reads.
+    for name, line in captured["frames"]:
+        assert "fsync" not in line, f"a source line leaked the path: {line!r}"
+    assert hang_mechanism.classify(captured["frames"]) != "SERVER_BLOCKED_IN_FSYNC", (
+        "a checkout path containing `fsync` decided the verdict — this module has "
+        "re-acquired the defect it was split out to avoid"
+    )
+
+
+# --------------------------------------------------------------------------
+# report() — the headline, against REAL parked threads.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def parked_fsync():
+    """A live thread genuinely blocked inside `os.fsync`, in a handler frame.
+
+    Named `process_request_thread` because that is what `report()` uses to tell a
+    handler from the accept loop — the same marker socketserver produces.
+    """
+    release = threading.Event()
+    started = threading.Event()
+    real_fsync = os.fsync
+
+    def blocking_fsync(fd):
+        started.set()
+        release.wait(30)
+        return None
+
+    def process_request_thread():
+        fd = os.open(os.devnull, os.O_RDONLY)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+    os.fsync = blocking_fsync
+    thread = threading.Thread(target=process_request_thread, daemon=True)
+    thread.start()
+    assert started.wait(30), "the fixture thread never reached the stall site"
+    try:
+        yield
+    finally:
+        release.set()
+        thread.join(30)
+        os.fsync = real_fsync
+        assert not thread.is_alive(), "the parked fixture thread was not reaped"
+
+
+def test_a_REAL_thread_parked_in_fsync_is_reported_as_an_fsync_stall(parked_fsync):
+    report = hang_mechanism.report()
+    assert "MECHANISM = SERVER_BLOCKED_IN_FSYNC" in report, report
+    assert "handler threads=1" in report, report
+
+
+def test_the_headline_NAMES_the_stall_even_when_another_handler_is_elsewhere(
+    parked_fsync,
+):
+    """🔴 THE CASE A CONSENSUS RULE WOULD GET WRONG, AND IT IS THE REAL ONE.
+
+    `test_cairn_write.py` runs TWO servers — the store and the shim in front of it
+    — so when a write times out there are two handler threads and they legitimately
+    disagree: the shim is parked in `urlopen`, the store in `fsync`. Measured on the
+    reproduction: `handler threads=2 [...=BLOCKED_ELSEWHERE ...=SERVER_BLOCKED_IN_
+    FSYNC]`. A rule that required the handlers to agree would answer `AMBIGUOUS` for
+    the textbook case the classifier exists to name.
+    """
+    proceed = threading.Event()
+    entered = threading.Event()
+
+    def process_request_thread():        # a second handler, parked elsewhere
+        entered.set()
+        proceed.wait(30)
+
+    other = threading.Thread(target=process_request_thread, daemon=True)
+    other.start()
+    try:
+        assert entered.wait(30)
+        report = hang_mechanism.report()
+        assert "handler threads=2" in report, report
+        assert "MECHANISM = SERVER_BLOCKED_IN_FSYNC" in report, report
+        assert "AMBIGUOUS" not in report, report
+        assert "BLOCKED_ELSEWHERE" in report, (
+            "the per-handler breakdown must still show the dissenting thread so a "
+            "reader can check the headline rather than take it"
+        )
+    finally:
+        proceed.set()
+        other.join(30)
+        assert not other.is_alive()
+
+
+def test_no_parked_handler_is_NOT_reported_as_a_stall():
+    """🔴 THE VERDICT MUST BE ABLE TO SAY 'I DID NOT SEE ONE'.
+
+    A stall that cleared before the assertion ran, and a genuine code failure, both
+    land here. The classifier does not distinguish them and must not pretend to —
+    naming a mechanism it did not observe is the failure mode that makes a
+    diagnostic worse than none.
+    """
+    report = hang_mechanism.report()
+    assert "SERVER_BLOCKED_IN_FSYNC" not in report, report
+    assert "MECHANISM = " in report, report
+
+
+def test_the_note_is_carried_into_the_report():
+    """The caller's context (store path, filesystem) must survive into the log."""
+    assert "store=/somewhere fs=tmpfs" in hang_mechanism.report(
+        "\nstore=/somewhere fs=tmpfs"
+    )


### PR DESCRIPTION
## The failure

`tekton/devrc-pytests` fails on `test_cairn_write.py::TestAppendLands::test_a_bullet_is_appended_and_the_status_is_named` on PRs whose diff cannot reach it:

```
AssertionError: 🔴 cairn: the write did NOT happen — http://127.0.0.1:PORT unreachable: timed out
                Nothing was queued and nothing was written locally.
assert 7 == 0
```

That is a sentence about the write **client** describing what was a **disk stall**.

## The mechanism — read off the CI log, not inferred by analogy

🔴 **The store-api root cause was NOT assumed to transfer.** `test_cairn_write.py` imports `http.server`, stands up its own loopback servers, imports no store-api `server.py`, and carried no `MECHANISM` classifier — all verified first.

Established from `devrc-ci-jfg67` directly:

* the store root is `/tmp/nix-build-devrc-pytests.drv-0/pytest-of-nixbld1/pytest-0/popen-gw1/…` — the step container's **ephemeral layer**, the same device the store-api half stalls on;
* the client reports `timed out`, not a refused connection;
* `server.py:_replace_bytes` fsyncs the file **and then the parent directory INSIDE the request**, before the response is written;
* `run_cairn` passes **`--timeout 5`**.

So one fsync slower than five seconds is a refusal at exit 7. 🔴 **That bound is twelve times tighter than the store-api half's `HANG_TIMEOUT` of 60.0**, which is why this file is the more frequent casualty of the same node contention.

All **5** failures in that run were exactly the 5 write-success assertions — 4× `TestAppendLands` plus `test_put_derives_the_revision_from_a_LIVE_sync_and_the_replace_lands` (`--dist loadfile` puts the file on one worker). Those are precisely the 5 sites this PR instruments.

## What this changes: the message, and nothing else

🔴 **DIAGNOSIS, NOT TOLERANCE.** No bound moved, nothing retries, no test was made to pass. A gate that reports a code failure for an I/O stall trains everyone to click through — that was the whole cost.

* **`scripts/testlib/hang_mechanism.py`** (new) — a `MECHANISM =` verdict from the live thread stacks, the shape `test_subsystem_store_api.py` already had. The failure now reads:
  ```
  MECHANISM = SERVER_BLOCKED_IN_FSYNC   (handler threads=2 [...=BLOCKED_ELSEWHERE
  ...=SERVER_BLOCKED_IN_FSYNC], accept loop parked=True)
  store=/dev/shm/devrc-store-… fs=tmpfs
  ```
* 🔴 **The headline is deliberately NOT a consensus of the handler threads.** Two servers are live here — the store and the shim in front of it — so on a timeout they legitimately disagree (shim in `urlopen`, store in `fsync`). **Measured**, not anticipated. A rule requiring agreement would answer `AMBIGUOUS` for the textbook case the classifier exists to name.
* 🔴 **It scans frames' SOURCE LINES, never their FILENAME** — the defect `_HUNG_SERVER_RULES` carries as known-and-unfixed, where a worktree named `devrc-fsync` misclassifies every hang. `test_subsystem_store_api.py` was **not** rewired onto the shared module: it has its own tests and that is its own edit. **Two copies exist today; that is known debt, not an oversight.**
* **`scripts/ci-repro/slow_cairn_fsync.py`** (new) — stalls `os.fsync` in the test process. Not `LD_PRELOAD`: the server is in-process while the client is a subprocess, so preloading would stall both sides and muddy which one timed out.

## Evidence

Reproduced on the dev host, text identical to CI:

| run | result |
|---|---|
| control (inert) | `4 passed in 3.69s`, `intercepted_fsyncs=8` |
| armed `SLOW_CAIRN_FSYNC_S=8` | `4 failed in 28.95s` |

`intercepted_fsyncs=8` is the **positive control** — the append path really does issue the two `_replace_bytes` fsyncs per write; a zero would mean the shim patched nothing. Both selftest arms watched to fire (inert-run abort; zero-fsync abort on a `2 passed` selection).

⚠ **The store was on tmpfs for BOTH runs** (`/dev/shm/devrc-store-…`), i.e. with `store_siting`'s mitigation fully in force. **This is a LATENCY dependency, not a filesystem one.** tmpfs makes a breach far less likely; it does not remove the 5 s bound.

### Mutation matrix on the new classifier — every mutant killed, each by the right test

| mutant | killed by |
|---|---|
| filename folded back into the scanned text | path test, with its own message |
| `fsync` rule removed from `RULES` | 5 tests |
| consensus rule (disagreement ⇒ no verdict) | headline test |
| `classify` always answers fsync | 3 tests, incl. the pull-apart |
| outermost frame wins | innermost test |

Run under `PYTHONDONTWRITEBYTECODE=1`; file restored byte-identical to its pre-mutation backup afterwards.

## What is NOT fixed here, and is not claimed

* **The stall itself.** It is node-local device contention; the levers are infra and ranked in the ci-repro README.
* **The disk-siting half was already fixed** by `b4fde334` (#1219).
* ⚠ **A PR branched before `b4fde334` still carries the old disk-backed fixture** — branch protection sets `strict: false`, so nothing rebases it. That is why #1209 and #1233 were still failing; **rebasing is what picks the mitigation up.**
* **Measured, and it is good news:** `store_siting` is genuinely live in CI, not silently falling back. `devrc-ci-826jc` ran rev `946a51f0` (contains the fix and the siting tests) with `failed=0` and only 3 skips (signal×2, repo-cos) — so `test_the_store_fixture_ACTUALLY_lands_on_tmpfs_when_one_exists`, which *skips* when no tmpfs is usable, **ran and passed**.

## Gate

Verdicts in the PR comments below (dev-host tier + both nix check derivations, built one at a time).
