### PR TITLE
docs(handoff): ferdium-server SHIPPED and verified live — plus a gateway outage from a landmine that had been armed for days

### DIFF
--- a/claudedocs/handoff-ferdium-server.md
+++ b/claudedocs/handoff-ferdium-server.md
@@ -4,25 +4,28 @@
 Deploy Ferdium Server (self-hosted multi-messenger backend) on the homelab Talos cluster, exposed at `ferdium.zacx.dev` behind Authelia, so the Ferdium desktop client can sync without a cloud account.
 
 ## State now
-- **Branch / PR**: devrc `fix/ferdium-client-packages` → **PR #1240 OPEN** (client packages). devrc `docs/handoff-ferdium-server-pickup` → **PR #1241 OPEN** (this doc). homelab-infra `feat/ferdium-server` → **PR #647 OPEN**, commit `71c7d475`, rebased onto `origin/trunk` `8cfa319d` — 16 files, +633/-2. **Not merged. Nothing applied to any cluster or node.**
-- **Clawgate task**: none recorded. `clawgate_handoff.sh resolve` exited 5 (0 tasks for this session). That cannot distinguish "touched no task" from "wrong session id", so no `clawgate-task:` field was written — it is not a clean bill of health.
+**SHIPPED AND VERIFIED LIVE.** Ferdium Server is deployed on the homelab cluster, reachable at `ferdium.zacx.dev` behind Authelia, and the desktop client + fonts are on both hosts.
 
-### What's DONE
-- **Ranks 1-5 built and staged as homelab-infra PR #647.** Homelab app dir (`namespace`/`pvc`/`deployment`/`service`/`kustomization`) + Flux root Kustomization, both nginx gateway blocks, production Service/Endpoints + IngressRoute + DNS Ingress, and the Authelia `one_factor` rule for `user:zach`.
-- **Landed the client-side packages that were deployed but never committed** — devrc PR #1240. The prior version of this doc marked that step done with a ✅: the `home-manager switch` had genuinely succeeded (`~/.nix-profile/bin/ferdium` resolves) but the `nix/graphical.nix` edit was **in no commit**, so the laptop was never going to receive it and any `git checkout` would have erased it while the built store path kept resolving. **"Deployed" and "committed" are independent claims and only one had been made.**
-- Verified that edit by **evaluation, not parsing**: `nix eval` of `homeConfigurations.zach.config.home.packages` returns all five packages **and `deep-search`** — the real check, since the list now opens with `with pkgs;` whose scope reaches across the `++ lib.optional (!isLaptop)` tail. Measured on the workbench (`isLaptop = false`) only.
-- **Port 8117 verified free on both gateway configs** (8116 is the highest in that band on each; positive-controlled against 8115), and the PR diff independently confirmed to move **exactly one token** in the relay deny-list and add exactly two `listen` lines with their matching `proxy_pass` — no other port moved.
-- Confirmed the PR diff contains **no `cam` / `clowden4077` / argon2 hash** — the unrelated uncommitted Authelia user stayed out.
-- Base clone `~/workspace/devrc` fast-forwarded `30b0e7dc → 946a51f0`; it had never received this doc.
-- Claimed under the shared-queue lock as **`ferdium-server-1`** — `claim-work --release ferdium-server-1` once #647 merges.
+| Merged | What |
+|---|---|
+| devrc **#1240** (`146770ef`) | client packages that were deployed but never committed |
+| devrc **#1241** | prior handoff update |
+| homelab-infra **#647** (`59ba0f11`) | Ferdium Server manifests, both gateways, Authelia rule, relay firewall |
+| homelab-infra **#651** | INCIDENT FIX — two dead promptver upstreams crashing the gateway |
 
-### Two additions beyond the original plan, both required
-1. **`8117` added to the `diffsona` arm of `k0s/host-firewall/relay-firewall.sh`** — see Gotchas. Without it the port is internet-open past Authelia.
-2. **`nebula` root Kustomization now `dependsOn: [comic-flex-pwa, ferdium]`**, matching the `:8115` precedent — the gateway nginx config has no `resolver`, so a missing Service arms a latent gateway-WIDE outage rather than failing at apply time.
+**Open, not merged:** homelab-infra **#653** — mounts the gateway nginx config as a directory instead of `subPath`. Deliberately unmerged: applying it rolls the gateway pod on each cluster, which is an outage window the operator schedules.
 
-### Deploy / verify status
-- **Client**: deployed on the workbench and now committed; **not** on the laptop until #1240 merges and `scripts/ship.sh` runs.
-- **Server**: staged only. Not merged, not reconciled, not deployed, not verified. No cluster or node has been touched.
+### Verified live (each with the control that makes it a claim)
+- **Full relay chain** prod nginx `127.0.0.1:8117` → nebula → homelab nginx → `ferdium.ferdium.svc:80` → pod `:3333` returns `{"api":"success","db":"success"}`.
+- **`ferdium.zacx.dev` unauthenticated → HTTP 302 → `login.zacx.dev`.** Authelia is in the path; a 200 would have been the finding.
+- **8117 is DROPPED from the public internet while listening.** Three-way control from off-mesh: 8117 = 6041ms timeout, 8114 (known-guarded) = 6016ms timeout, 8118 (unguarded, closed) = 50ms RST. The new port behaves like an established guarded port and unlike an unguarded one — measured both before and after nginx began binding it.
+- **Laptop received the client**: `ferdium`, 2 colour-emoji fonts, 24 Liberation fonts. It had none before; that was the whole point of #1240.
+- `ship.sh`: both hosts at `146770ef`, both switched, 0 dangling / 0 stale managed artifacts each.
+
+### 🔴 Verified-ADJACENT, NOT verified — do not upgrade these
+- **`{"api":"success","db":"success"}` is HARDCODED.** `HealthController` returns it with an upstream `TODO` and never queries the database. It proves the ROUTE, not the DB, not sync.
+- **A Ready pod is not evidence sync works**, for the same reason.
+- **The desktop client's background sync through Authelia is UNTESTED.** See Open investigations.
 
 ## Architecture (researched, not yet implemented)
 
@@ -34,26 +37,18 @@ Ferdium client → Cloudflare → production nebula gateway (10.0.0.2)
 Authelia runs on the production cluster. Cloudflare handles TLS termination. The homelab nebula gateway proxies traffic to internal services.
 
 ## Next steps (ranked)
-🔴 Ranks 1-7 keep their original numbering on purpose — the rank is half a `claim-work` slug's identity and re-ranking silently re-points live claims. Ranks 1-5 are now all carried by **PR #647**.
+🔴 Ranks 1-7 from the previous version are **ALL CLOSED** (all landed in #647). They keep their numbers rather than being re-cut, because a rank is half a `claim-work` slug's identity. The claim `ferdium-server-1` is RELEASED. New work starts at 8.
 
-1. **STAGED as homelab-infra PR #647** — review and merge it. `/audit-pr 647` is worth running first: it carries an Authelia access-control rule and an internet-facing relay port. Merging IS deploying.
-   forcing: user
-2. (in #647) homelab nebula gateway block, `listen 10.42.0.10:8117` → `ferdium.ferdium.svc.cluster.local:80`.
-   forcing: user
-3. (in #647) production `homelab-ferdium` Service + Endpoints and the `listen 0.0.0.0:8117` → `10.42.0.10:8117` block.
-   forcing: user
-4. (in #647) `ferdium-ingress.yaml` — IngressRoute + external-dns DNS Ingress.
-   forcing: user
-5. (in #647) `ferdium.zacx.dev` → `one_factor` for `user:zach` in Authelia.
-   forcing: user
-6. **After merging #647: copy `k0s/host-firewall/relay-firewall.sh` to the relay node and apply it.** 🔴 That file is NOT Flux-reconciled, so the merge does not deliver it — until this is done, `8117` is open on the node's public interface, bypassing Authelia. Then `flux reconcile`, verify pod health, and check `https://ferdium.zacx.dev` 302s to `login.zacx.dev`.
+8. Open the Ferdium desktop client → custom server `https://ferdium.zacx.dev` → register the account → then flip `IS_REGISTRATION_ENABLED` to `false` in `clusters/homelab/apps/ferdium/deployment.yaml` and let Flux reconcile. 🔴 **The flag is `true` right now**; Authelia is the only thing standing in front of an open signup form. Watch for the sync gap in Open investigations while doing this.
    forcing: security
-7. Open the Ferdium desktop client → custom server URL → register → then flip `IS_REGISTRATION_ENABLED` to `false` and redeploy. **Watch for background sync failing with 302s while a browser works** — that is the untested forward-auth gap in Gotchas, and the fix is a scoped bypass, not deleting the Authelia rule.
-   forcing: user
-8. Merge devrc **PR #1240** and run `scripts/ship.sh` so the laptop receives the client packages.
-   forcing: regression
-9. Digest-pin `ferdium/ferdium-server:latest` — upstream publishes no version tag, so the deployed image can change under a reconcile.
-   forcing: none
+9. Merge homelab-infra **#653** (subPath → directory mount) during a window where a brief mesh interruption per cluster is acceptable. Until then every future gateway nginx change still requires a pod restart, and each restart re-runs startup resolution — the exact mechanism behind this session's outage.
+   forcing: incident — the 2026-09-02 gateway CrashLoopBackOff; #651 cleared the known trigger, this removes the blindness that hid it
+10. Digest-pin `ferdium/ferdium-server:latest` in the deployment. Upstream publishes no version tag, so the running image can change under any reconcile or restart with no diff in git.
+    forcing: none
+11. Commit or discard `nix/programs/alacritty/default.nix`, uncommitted in `~/workspace/devrc` and **baked into the workbench's built generation**. `ship.sh` reports both hosts at the same sha while the workbench's artifact is `origin/main` PLUS that file, so the two machines are not actually identical. Also untracked there: `output.txt`, `scripts/diagnose-disk-accounting.sh`, `scripts/diagnose-nix-disk.sh`.
+    forcing: regression
+12. Consider a gate asserting every `proxy_pass … .svc.cluster.local` in both gateway configs resolves to a Service defined in the repo. This session found the promptver pair by checking all 37 by hand; nothing would have caught it at PR time. Deterministic, cheap, and it closes the class rather than the instance.
+    forcing: none
 
 ## Ferdium Server config (reference)
 
@@ -103,26 +98,59 @@ Port: 3333 (container) → 8117 (nebula gateway) → homelab Service port 80.
 - **`ferdium/ferdium-server:latest` is a mutable tag** — upstream publishes no version tag. A digest pin is an owed follow-up.
 - **`scripts-tests` was already red on `origin/trunk`** before any of this work: a pristine baseline worktree produced byte-identical verdict lines (`files_run=54 tests_ran=1316`, same failed/broken sets). Do not attribute it to the ferdium diff.
 
+- 🔴 **`subPath` ConfigMap mounts NEVER update, and that is how a gateway config stays wrong for days while every check is green.** kubelet refreshes whole-volume mounts only. The homelab gateway served a config resolved BEFORE the promptver teardown for 2d3h: Flux reconciled green, the pod was healthy, traffic flowed. The error existed only at restart. **Anything that reads the running system cannot see this class of defect** — compare the ConfigMap to the file in the container, not to the reconcile status. Fix open as #653.
+- 🔴 **nginx resolves static `proxy_pass` hostnames AT STARTUP and refuses to boot if one fails** (no `resolver` directive in these configs). So **deleting a service means deleting its gateway block IN THE SAME CHANGE** — leaving one behind breaks nothing today and arms the gateway to fail the next time its pod is replaced, for reasons that look unrelated to whoever restarts it. Cost on 2026-09-02: `nginx-proxy` CrashLoopBackOff, ~6 min across every mesh-relayed service.
+- 🔴 **Prefer `nginx -s reload` over replacing the gateway pod.** A reload validates the config and keeps the existing workers if it is bad; a restart re-runs startup resolution with no fallback. That difference is what turns one dead upstream into a gateway-wide outage. (Requires #653 first — with `subPath`, a reload re-reads the same frozen file.)
+- 🔴 **A PR can be red for a reason that is not in its diff: check how far behind the base is.** #647's `scripts-tests` failure was entirely because it branched off `8cfa319d`, the last commit before **#646 "fix(ci): unbreak trunk"** landed as `ccbd6b81`. A rebase fixed it with zero code change. The tell was that OTHER open PRs (#645, #639) were passing the same leg.
+- 🔴 **An agent's "the gate is red on trunk too" can be true of ITS tier and false of CI's.** The manifest agent ran the suite on the dev host, where ~30 tests were `missing-module-yaml` and never executed; CI ran 1581 tests where the dev host ran 756. Its conclusion was directionally right and its evidence could not support it. **Read the CI tier's own log** — here, via the Tekton PipelineRun pod: find the run by `gitrevision` param, then `kubectl logs -n tekton-ci <pipelinerun-pod> --all-containers`.
+- 🔴 **Two probes in this session returned confident numbers while measuring nothing, and both were caught only by a control.** (a) A `bash /dev/tcp` port check returned the identical result for a guarded port, an unguarded port and 443 — it discriminated nothing; `nc -vz` with timing separated DROP (6s timeout) from RST (50ms) cleanly. (b) A `grep -c 8117 /etc/nginx/conf.d/default.conf` returned 0 — but so did `grep -c 8115`, and comics demonstrably works, so the file was simply not the one nginx reads (`/etc/nginx/nginx.conf`, via `subPath`). **Always include a value the instrument MUST find.**
+- **`ferdium/ferdium-server:latest` first run clones a recipes repo**, so readiness legitimately takes ~2 min after a 2m7s image pull. A `connection refused` readiness probe during that window is expected, not a defect.
+- **`APP_KEY` is deliberately unset** — setting it on a fresh volume takes the entrypoint's `else` branch, which `cat`s a nonexistent file, and the env-schema check then rejects the empty key.
+- **No WebSockets** in Ferdium Server — no `ws`/`socket.io` dependency, no upgrade handler; sync is plain REST on `/v1/...`. Neither nginx block carries `Upgrade` headers, deliberately.
+- **Storage class is `openebs-nvme-1tb`**, chosen over `local-path` because of that provisioner's open SIGKILL investigation.
+- **`k0s/host-firewall/relay-firewall.sh` is NOT Flux-reconciled** — it reaches the node via `k0sctl` (`k0s/diffsona.yaml` copies it to `/root/` and runs `systemctl enable --now relay-firewall.service`). This session applied it by `scp` + `systemctl restart`, verified from a fresh SSH connection. **Merging a change to that file deploys nothing.**
+- **An 81xx port on the production relay is internet-open unless it is in the `diffsona` deny-list.** That list is the only filter on the node's public interface. Measured precedent (`8102`): a SYN was answered from the host 71µs later, straight past Authelia. Guard the port BEFORE the `listen` block goes live — the documented 8115/8116 ordering.
+
 ## How to verify
 ```bash
-# Client half — the packages resolve from the committed source, and the
-# conditional tail survived the `with pkgs;` widening (this is the real check):
-nix eval --impure --raw \
-  '/home/zach/workspace/devrc#homeConfigurations.zach.config.home.packages' \
+# 1. Client half — packages resolve from committed source, and the conditional
+#    tail survived the `with pkgs;` widening (deep-search is the real check):
+nix eval --impure --raw '/home/zach/workspace/devrc#homeConfigurations.zach.config.home.packages' \
   --apply 'ps: builtins.concatStringsSep "\n" (map (p: p.name or "?") ps)' \
   | grep -E 'ferdium|noto|liberation|deep-search'
+ssh zach@192.168.50.155 'ls -l ~/.nix-profile/bin/ferdium'   # the laptop half
 
-# Client half — actually delivered to BOTH hosts (not just built):
-git -C /home/zach/workspace/devrc log --oneline -1 origin/main -- nix/graphical.nix
-scripts/drift-check.sh          # read every per-host line, never the final verdict
+# 2. Server half — the pod, and the FULL relay chain (Authelia bypassed):
+KUBECONFIG=$KC_HOMELAB kubectl -n ferdium get pods            # Running, 1/1
+KP=~/workspace/homelab-talos/production-kubeconfig
+P=$(KUBECONFIG=$KP kubectl -n nebula get pods -l app=nebula-gateway -o jsonpath='{.items[0].metadata.name}')
+KUBECONFIG=$KP kubectl -n nebula exec $P -c nginx -- \
+  wget -qO- --timeout=15 http://127.0.0.1:8117/health
+#   -> {"api":"success","db":"success"}  🔴 HARDCODED — proves the route, not the DB.
 
-# Server half — ONLY meaningful after the manifest PR is merged and reconciled:
-flux reconcile kustomization ferdium -n flux-system          # homelab cluster
-KUBECONFIG=$KC_HOMELAB kubectl -n ferdium get pods           # expect Running
-curl -sS -o /dev/null -w '%{http_code}\n' https://ferdium.zacx.dev/
-#   expect a 302 to login.zacx.dev while unauthenticated — a 200 here would mean
-#   the Authelia middleware is NOT in the path, which is a finding, not a pass.
+# 3. The edge MUST redirect. A 200 here means Authelia is not in the path:
+curl -sSI https://ferdium.zacx.dev/ | grep -iE '^(HTTP|location)'
+#   -> HTTP/2 302 ; location: https://login.zacx.dev/?rd=...
 
-# End to end: Ferdium desktop -> custom server -> https://ferdium.zacx.dev
-# -> register -> add the WhatsApp recipe. Nothing short of this proves the goal.
+# 4. 🔴 The security check. 8117 listens on the relay and must NOT be reachable
+#    from the internet. Read all three — one alone proves nothing:
+nix-shell -p netcat-openbsd --run 'for p in 8117 8114 8118; do
+  nc -vz -w 6 5.161.118.55 $p; done'
+#   8117 timeout (dropped) · 8114 timeout (guarded control) · 8118 refused (unguarded control)
+
+# 5. Collateral: the gateway fronts everything. All three must be 302.
+for h in clawgate.zacx.dev comics.zacx.dev auditloop.zacx.dev; do
+  curl -sS -o /dev/null -w "$h %{http_code}\n" https://$h/; done
+
+# 6. End to end, the only thing that proves the GOAL — nothing above does:
+#    Ferdium desktop -> custom server https://ferdium.zacx.dev -> register
+#    -> add the WhatsApp recipe -> confirm sync survives an idle period.
 ```
+## Open investigations — live diagnosis state
+### Does the Ferdium desktop client's background sync survive the Authelia forward-auth gate?
+- **Symptom + exact repro:** unknown — not yet exercised. Open the Ferdium desktop client → set custom server `https://ferdium.zacx.dev` → register → add a recipe → leave it running and watch whether sync keeps working after the Authelia session goes idle.
+- **Observed (with values):** the browser path is confirmed good — unauthenticated `HEAD /` returns `HTTP/2 302`, `location: https://login.zacx.dev/?rd=https%3A%2F%2Fferdium.zacx.dev%2F&rm=HEAD`. The backend behind that gate is confirmed reachable: `{"api":"success","db":"success"}` from inside the prod gateway, bypassing Authelia. So both halves work; only their COMBINATION with a non-browser client is untested. via: measurement
+- **Ruled out:** "the relay chain is broken" — eliminated by the in-cluster `/health` fetch through `127.0.0.1:8117` returning 200 with a JSON body. via: measurement
+- **Ruled out:** "Authelia is not actually gating the host" — eliminated by the unauthenticated 302 to `login.zacx.dev` carrying the correct `rd=` parameter. via: measurement
+- **Leading hypothesis:** the client is Electron, so its top-level navigation CAN follow the redirect and complete a login in a window; the risk is that its background REST calls to `/v1/...` carry its own bearer token but not the `zacx.dev` Authelia session cookie, and get 302s instead of JSON.
+- **Next probe:** launch the client, register, then watch the gateway access log for 302s on `/v1/` paths: `KUBECONFIG=$KC_HOMELAB kubectl -n nebula logs <gateway-pod> -c nginx-proxy --tail=100 | grep ' /v1/'`. 🔴 **If it fails, the fix is a scoped Authelia bypass for the client's API prefix — NOT deleting the `ferdium.zacx.dev` rule**, which would expose the whole server.


### PR DESCRIPTION
Closes out the ferdium-server effort. Everything is deployed and verified live.

## Merged this session

devrc **#1240** (client packages) · devrc **#1241** (prior handoff) · homelab-infra **#647** (manifests, both gateways, Authelia rule, relay firewall) · homelab-infra **#651** (incident fix).

Open and deliberately unmerged: homelab-infra **#653** — it rolls the gateway pod on each cluster, which is a window you schedule.

## What the doc now records

**Verification with its controls, not just outcomes.** The 8117 internet-facing check is recorded as a three-way probe (new port vs a known-guarded port vs an unguarded closed port) rather than "it's firewalled", because the first two look identical and only the third proves the path reaches the host.

**A section for what is verified-adjacent but NOT verified.** `{"api":"success","db":"success"}` is hardcoded in `HealthController` and never queries the DB — it proves the route. A Ready pod means the same thing. The desktop client's background sync through Authelia is untested and is written up as an open investigation with its ruled-outs and next probe.

## The incident

Restarting the homelab gateway put it in CrashLoopBackOff for ~6 min across every mesh service. **Not caused by ferdium** — `promptver` was torn down days earlier but its `proxy_pass` blocks stayed, and two things hid that: no `resolver` directive (nginx resolves static upstreams at startup), and a `subPath` mount (which never receives ConfigMap updates). The running pod served a config resolved *before* the teardown, so every reconcile and every health check was green and the fault was reachable only by restarting.

Both halves are now written down as rules rather than as a story: deleting a service means deleting its gateway block in the same change, and prefer `nginx -s reload` over replacing the pod because a reload fails safe.

## Two method notes worth keeping

- **A PR can be red for a reason outside its diff.** #647's failure was purely that it branched off the commit before #646 "fix(ci): unbreak trunk". A rebase fixed it with zero code change; the tell was other open PRs passing the same leg.
- **Two probes returned confident numbers while measuring nothing**, both caught only by a control: a `/dev/tcp` check that returned identically for every port, and a config grep against a file nginx does not read — where the control port `8115` also scored 0.