### PR TITLE
fix(espanso-detect): declare :rna the owner of recom/recommend — unbreaks main, RED since a720d30d

### DIFF
--- a/scripts/collector/keylog/espanso_detect.py
+++ b/scripts/collector/keylog/espanso_detect.py
@@ -76,6 +76,18 @@ ESPANSO_SEARCH_WM_CLASS = ".espanso-wrapped"
 # because "ask"/"clarify" is how the dispatch snippet is actually searched for.
 # ':acq' ("ask clarifying questions") is what a bare 'ask' MEANS.
 #
+# 'recom'/'recommend' arrived the same way on 2026-09-02 (a720d30d, a one-line
+# direct-to-main commit that RED-ed `main`): ':acq' grew the LABEL "ask
+# clarifying questions and recommend improvements and anything useful to
+# include", and `_token_matches` reads the label, so both terms started matching
+# ':acq' as well as ':rna'. Note the asymmetry that decides the owner — the two
+# terms are ':rna''s declared INTERFACE (they are literally two of its six
+# `search_terms`, and its label is "Recommend next actions"), whereas on ':acq'
+# the word is incidental PROSE inside a sentence about asking questions. The
+# picker listing both rows is fine and wanted; attribution has one honest
+# answer. The label is the operator's and stays as written — this table is the
+# designed place to say so without editing either snippet.
+#
 # 🔴 BLIND SPOT, MEASURED — THE LOOKUP IS AN EXACT-STRING MATCH, SO PREFIXES OF
 # AN OWNED TERM ARE NOT OWNED. `_term_matches` is a SUBSTRING test, so a typed
 # prefix reaches both snippets and lands on the ambiguous branch, where
@@ -94,12 +106,22 @@ ESPANSO_SEARCH_WM_CLASS = ".espanso-wrapped"
 # prefix-aware lookup can re-point terms the exact form never touched, so it
 # needs its own mutation battery.
 #
+# 🔴 STILL ACCEPTED, and the 'recom' entries below do NOT close it — re-measured
+# 2026-09-02 against the live config: "rec", "reco" and "recomm" all match
+# BOTH ':acq' and ':rna' and all three still resolve to None, because only the
+# two exact strings keyed below are owned. This is the same blind spot, not a
+# new one, and it is recorded here so the next reader does not mistake the two
+# entries for prefix coverage. The decision is unchanged for the same reason:
+# widening it is a mechanism change, not a table entry.
+#
 # Same measurement, recorded so it is not re-litigated: "clarifying" has been
 # typed ZERO times, so it gets no entry — an owner justified by intuition rather
 # than the search stream is exactly what this comment exists to prevent.
 _AMBIGUOUS_TERM_OWNER = {
     "ask": ":acq",
     "clarify": ":acq",
+    "recom": ":rna",
+    "recommend": ":rna",
 }
 
 

--- a/scripts/collector/keylog/tests/test_espanso_detect.py
+++ b/scripts/collector/keylog/tests/test_espanso_detect.py
@@ -518,7 +518,14 @@ ACQ_BASE = {"matches": [
      "label": "Process feedback: dispatch subagent + elicit scope",
      "search_terms": ["ask", "clarifying", "feedback", "dispatch", "process",
                       "elicit", "scope", "include"]},
-    {"trigger": ":acq", "replace": "...", "label": "ask clarifying questions",
+    # 🔴 2026-09-02: the LABEL grew "and recommend improvements and anything
+    # useful to include" in a720d30d. Mirrored here for the same reason the
+    # 2026-08-29 note above gives — a fixture that lags the file it claims to
+    # mirror asserts the past. This label is exactly what made 'recom' ambiguous
+    # against ':rna' on the live config; see the FIX 6 block below.
+    {"trigger": ":acq", "replace": "...",
+     "label": "ask clarifying questions and recommend improvements and "
+              "anything useful to include",
      "search_terms": ["ask", "clarify", "clarifying", "questions"]},
 ]}
 
@@ -682,6 +689,95 @@ def test_naming_a_trigger_still_beats_the_declared_owner(monkeypatch):
     monkeypatch.setitem(ED._AMBIGUOUS_TERM_OWNER, "acq", ":dacq")
     d = _det_for(ACQ_BASE)
     assert d._attribute("acq") == ":acq"
+
+
+# -- FIX 6: an incidental LABEL word colliding with another snippet's interface -
+# 2026-09-02. `a720d30d` — a one-line direct-to-main commit — gave ':acq' the
+# label "ask clarifying questions and recommend improvements and anything useful
+# to include". `_token_matches` reads the label, so 'recom'/'recommend' began
+# matching ':acq' as well as ':rna' and BOTH went to None, turning
+# `test_live_existing_resolutions_not_made_ambiguous` red on `main`.
+#
+# The operator's ruling was to keep the label and relax the gate, so the fix is
+# a DECLARED owner — the same hatch as FIX 5, used for the case it was designed
+# for. The asymmetry that makes ':rna' the honest owner: 'recom' and 'recommend'
+# are two of its six declared `search_terms` and its label is "Recommend next
+# actions", while on ':acq' the word is incidental prose. Neither snippet is
+# NAMED by either term, so `_names_trigger` cannot rescue them.
+#
+# 🔴 WHICH OF THESE ARE REGRESSION COVERAGE, measured at 778dbd2d (the tree the
+# bug is live on) with these tests in place and only the two table entries
+# removed:
+#   RED at base  — test_declared_owner_resolves_the_recommend_terms,
+#                  test_recommend_terms_resolve_on_the_live_config
+#   GREEN at base — test_recommend_terms_still_reach_both_picker_rows (an
+#                  INVARIANT GUARD: the picker never consulted the table, so it
+#                  cannot fail on its own) and
+#                  test_declared_owner_cannot_invent_an_rna_resolution (it
+#                  guards `owner in matched`, which FIX 5 already exercised).
+#                  Both were mutation-checked instead — see the PR body.
+RNA_ACQ_BASE = {"matches": [
+    {"trigger": ":acq", "replace": "...",
+     "label": "ask clarifying questions and recommend improvements and "
+              "anything useful to include",
+     "search_terms": ["ask", "clarify", "clarifying", "questions"]},
+    {"trigger": ":rna", "replace": "...", "label": "Recommend next actions",
+     "search_terms": ["recommend", "recom", "next", "actions", "rank",
+                      "leverage"]},
+]}
+
+
+def test_declared_owner_resolves_the_recommend_terms():
+    # RED without the ':rna' entries: both are None, because ':acq''s label
+    # spells "recommend" and 'recom' is a substring of it.
+    d = _det_for(RNA_ACQ_BASE)
+    assert d._term_matches("recom", ":acq") is True      # the incidental label
+    assert d._term_matches("recom", ":rna") is True      # the real interface
+    assert d._names_trigger("recom", ":rna") is False    # no outright naming
+    assert d._names_trigger("recom", ":acq") is False
+    assert d._attribute("recom") == ":rna"
+    assert d._attribute("recommend") == ":rna"
+
+
+def test_recommend_terms_still_reach_both_picker_rows():
+    # The point of the table: attribution gets one answer, the picker keeps BOTH
+    # rows. If this shrinks to one, the fix has become the label edit the
+    # operator declined.
+    d = _det_for(RNA_ACQ_BASE)
+    for term in ("recom", "recommend"):
+        assert {t for t in d.ts.triggers if d._term_matches(term, t)} == {
+            ":acq", ":rna"}, term
+
+
+def test_declared_owner_cannot_invent_an_rna_resolution(monkeypatch):
+    # 🔴 The honesty half, pinned for THESE terms specifically: a declaration
+    # whose owner is not among the matched snippets must go INERT (None), never
+    # return the declared owner. Point both terms at a snippet neither reaches
+    # and the answer must be None, not ':dacq'.
+    d = _det_for(RNA_ACQ_BASE)
+    assert ":dacq" not in d.ts.triggers
+    for term in ("recom", "recommend"):
+        monkeypatch.setitem(ED._AMBIGUOUS_TERM_OWNER, term, ":dacq")
+    for term in ("recom", "recommend"):
+        assert [t for t in d.ts.triggers if d._term_matches(term, t)] != []
+        assert d._attribute(term) is None, term
+
+
+def test_recommend_terms_resolve_on_the_live_config():
+    # The hermetic fixture above can drift from nix/home.nix; this reads the
+    # real file. ANTI-VACUITY: an empty trigger set would pass vacuously, so
+    # assert both snippets are actually present and actually collide.
+    d = _live_det()
+    assert ":acq" in d.ts.triggers and ":rna" in d.ts.triggers
+    for term in ("recom", "recommend"):
+        assert sorted(t for t in d.ts.triggers
+                      if d._term_matches(term, t)) == [":acq", ":rna"], term
+        assert d._attribute(term) == ":rna", term
+    # The collision comes from the LABEL, not from ':acq''s search_terms — if
+    # that stops being true this test is no longer covering the reported bug.
+    assert "recommend" in d.ts.meta[":acq"]["label"].lower()
+    assert not any("recom" in s.lower()
+                   for s in d.ts.meta[":acq"].get("search_terms") or [])
 
 
 def test_every_declared_owner_names_a_real_live_trigger():


### PR DESCRIPTION
## `main` is RED, and has been since `a720d30d`. This unbreaks it.

`test_espanso_detect.py::test_live_existing_resolutions_not_made_ambiguous` fails on `main`:

```
AssertionError: search terms regressed (term -> (expected, actual, matching snippets)):
  {'recom': (':rna', None, [':acq', ':rna']), 'recommend': (':rna', None, [':acq', ':rna'])}
```

Bisected with controls at both ends: **passes at `146770ef`, fails at `a720d30d`** and at every later `main`, including the current tip `778dbd2d`.

`a720d30d` ("espanso", a one-line direct-to-main commit) changed exactly one line — `:acq`'s **label**:

```diff
-{ trigger = ":acq"; ... label = "ask clarifying questions"; ... }
+{ trigger = ":acq"; ... label = "ask clarifying questions and recommend improvements and anything useful to include"; ... }
```

`_token_matches` matches against the label's words, so `recom`/`recommend` began matching `:acq` as well as `:rna`. `_attribute` then saw two candidates and returned `None` — every such espanso fire recorded UNATTRIBUTED.

## The fix: relax the gate, via the mechanism designed for exactly this

The operator's ruling was that the gate is overly strict — **`:acq`'s label stays as written, `:rna`'s `search_terms` stay, `nix/home.nix` is untouched.**

So this adds two entries to `_AMBIGUOUS_TERM_OWNER`, which is consulted **only** on the already-ambiguous branch and **only** over snippets the term genuinely matches:

```python
 _AMBIGUOUS_TERM_OWNER = {
     "ask": ":acq",
     "clarify": ":acq",
+    "recom": ":rna",
+    "recommend": ":rna",
 }
```

**Why `:rna` is the honest owner, not a coin flip.** Measured against the live config:

| | `:acq` | `:rna` |
|---|---|---|
| label | "ask clarifying questions **and recommend improvements**…" | "**Recommend** next actions" |
| `search_terms` | `ask, clarify, clarifying, questions` | `recommend, recom, next, actions, rank, leverage` |
| role of the word | incidental **prose** inside a sentence about asking questions | two of its six declared **interface** terms |

Neither snippet is NAMED by either term (`_names_trigger("recom", …)` is `False` for both), so the naming tie-break cannot rescue them. This is precisely the case the table's own comment describes: *"a term may be spelled on two snippets ON PURPOSE, for the picker's sake"*. The picker still lists **both** rows — that is the point of the table: attribution gets one answer without trading away a real search route.

### What this does NOT do
- 🔴 **`_EXISTING_RESOLUTIONS` is untouched** — no row deleted, `>= 26` floor not lowered. That table's docstring calls deleting the row that broke "exactly the regression this guard exists to catch".
- **`nix/home.nix` is untouched.** Neither the label nor any `search_terms` were edited.

## Red / green matrix — base `778dbd2d` (= `origin/main` at time of work)

| tree | result |
|---|---|
| base `778dbd2d`, unmodified | **RED** — `1 failed, 56 passed` (the reported failure, reproduced verbatim) |
| base `778dbd2d` + these tests, **fix reverted** (mutation M1) | **RED** — `3 failed, 58 passed`; both new regression tests fail with **their own assertions** |
| this branch `b0b4caf7` | **GREEN** — `61 passed` |

Adjacent suites on this branch, run separately: `scripts/collector/keylog` **105 passed**, `scripts/session-analysis` **548 passed**, `scripts/collector/opencode` **203 passed**.

Full `scripts/tests` on this tree: **11506 passed, 1 skipped, 0 failed** (1042s). The known `test_subsystem_touch.py::TestCommitNegativeControls::test_the_LENGTH_bound_is_not_vacuous_git_WOULD_have_expanded_it` flake did not fire. That run's shell exit code was `tail`'s, not pytest's — the verdict quoted here is pytest's own summary line, read from the log.

## New tests (FIX 6 block)

Classified honestly, in the file, as the existing FIX 5 block does:

**Regression coverage** (RED at base with the fix reverted):
- `test_declared_owner_resolves_the_recommend_terms` — hermetic fixture; both terms → `:rna`
- `test_recommend_terms_resolve_on_the_live_config` — reads the real `nix/home.nix`; also pins that the collision comes from the **label** and not from `:acq`'s `search_terms`, so the test cannot quietly stop covering the reported bug

**Invariant guards** (GREEN at base — labelled as such, not counted as regression coverage; mutation-checked instead):
- `test_recommend_terms_still_reach_both_picker_rows` — both picker rows stay reachable
- `test_declared_owner_cannot_invent_an_rna_resolution` — the honesty half, pinned for these terms

Also mirrored the new `:acq` label into the `ACQ_BASE` fixture, per that fixture's own 2026-08-29 note that a fixture lagging the file it claims to mirror "asserts the past, and reads as coverage of the present".

## Mutation results

Run in a `cp -a` copy with `rm -f <copy>/.git` executed **first** (a worktree's `.git` is a file pointing at the real gitdir), under `PYTHONDONTWRITEBYTECODE=1`. Control green **before and after** every mutation (`61 passed`). `HOME_NIX` resolves relative to the test file, so the copy genuinely reads its own `nix/home.nix`.

| # | mutation | result | killed by, with its own assertion |
|---|---|---|---|
| M1 | remove both `_AMBIGUOUS_TERM_OWNER` entries | **KILLED** (3 failed) | `test_declared_owner_resolves_the_recommend_terms` (`assert None == ':rna'`), `test_recommend_terms_resolve_on_the_live_config` (`AssertionError: recom`), plus the original gate `test_live_existing_resolutions_not_made_ambiguous` |
| M2 | point both owners at `:kickoff`, a snippet neither term matches | **KILLED** (3 failed) | same three — and critically `_attribute` returns **`None`**, never `:kickoff`: the stale entry goes **inert rather than wrong**, which is what `owner in matched` buys |
| M3 | drop the `owner in matched` clause | **KILLED** (2 failed) | `test_declared_owner_cannot_invent_a_resolution` (pre-existing) **and** the new `test_declared_owner_cannot_invent_an_rna_resolution` — proving the new honesty guard is **reachable** and fails for its own reason, not another guard's |

M2 was also measured directly rather than inferred from a red test:

```
recom:     matches_kickoff=False  matched=[':acq', ':rna']  _attribute -> None
recommend: matches_kickoff=False  matched=[':acq', ':rna']  _attribute -> None
```

## Known limitation, re-measured and recorded (not closed by this PR)

The lookup is an **exact-string** match, so prefixes of an owned term are not owned. Re-measured on the live config: `rec`, `reco` and `recomm` all match **both** snippets and all three still resolve to `None`. This is the **same** blind spot already documented for `clar` — not a new one — and the accepted decision is unchanged: making the lookup prefix-aware is a mechanism change needing its own mutation battery, not a table entry. I extended the existing comment so the next reader does not mistake these two entries for prefix coverage.

Separately noted and **out of scope**: `next` is ambiguous between `:kickoff` and `:rna`. It is pre-existing (unrelated to `a720d30d`, which touched only `:acq`'s label) and is not pinned by any guard.

## Verification scope

Run with `nix develop … -c python3 -m pytest … -q -p no:cacheprovider` on the dev-host tier only. I did **not** run `scripts/gate.sh` or `nix build .#checks…` — another process owns the gate on this box — so the **sandbox tier is unverified by me** and this claim covers one tier, one base (`778dbd2d`), one branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPiQDMvSzEQXRwmEHi4ZxK
