### PR TITLE
fix(subsystem-audit): the THIRD frozen read surface — the one whose output drives deletions (rank 20)

### DIFF
--- a/claudedocs/handoff-analyze-service-index-backup.md
+++ b/claudedocs/handoff-analyze-service-index-backup.md
@@ -448,8 +448,13 @@ nix-shell -p 'python3.withPackages(p:[p.minio])' --run \
 systemctl --user list-timers analyze-service-index-backup.timer --all
 systemctl --user show analyze-service-index-backup.service -p Result
 
-# the index store's own verdict
-python3 ~/workspace/devrc/scripts/subsystem-audit.py
+# the index store's own verdict — 🔴 sync FIRST, and note the `stamp:` line it prints.
+# Bare (no --store) now resolves to the cairn-synced cache, never the frozen
+# `~/.claude/analyze-service-index` mirror, and REFUSES with exit 4 if that cache
+# carries no `.sync-stamp`. `;` not `&&`: `cairn sync` exits 4 when the pod is
+# unreachable but a usable cache survives, and the audit of a stamped-but-stale
+# cache is still worth reading — the stamp says how stale.
+cairn sync; python3 ~/workspace/devrc/scripts/subsystem-audit.py
 ```
 
 🔴 **The web-vault paste check is `age-keygen -y <file> | sha256sum | cut -c1-16` →

--- a/scripts/lib/subsystem_read_store.py
+++ b/scripts/lib/subsystem_read_store.py
@@ -54,6 +54,7 @@ __all__ = [
     "resolve_read_store",
     "stamp_header",
     "REMEDY",
+    "EXIT_UNSTAMPED_READ_STORE",
     "refusal_message",
 ]
 
@@ -65,6 +66,35 @@ SYNC_STAMP = ".sync-stamp"
 
 #: The one-command remedy, spelled once so every refusal quotes the same thing.
 REMEDY = "cairn sync"
+
+#: The exit code a CLI returns when its DEFAULT resolution landed on a store that
+#: cannot date itself. THE one definition — it lives beside `refusal_message` and
+#: `REMEDY` because it is the third part of one wire contract: the message a human
+#: reads, the command they type, and the number a script branches on.
+#:
+#: 🔴 IT IS SHARED BY MORE THAN ONE TOOL, WHICH IS WHY IT MOVED HERE. It was
+#: declared in `subsystem_recall` alone. `subsystem-audit.py` then grew the same
+#: refusal, and a second `= 4` would have been two literals nobody reconciles —
+#: the shape `claude/RULES.md` ("One rule, one place") names, and the shape this
+#: whole module exists to close for the cache path and the stamp filename. A
+#: caller that sees 4 from EITHER host-local read surface must be able to act on
+#: it with one rule.
+#:
+#: 🔴 A CODE OF ITS OWN, and `subsystem_recall._exit_for`'s "don't mint a fourth
+#: code" argument does NOT cover it. That argument is about statuses whose
+#: documented handling is identical to 3's ("the store is broken; recall was
+#: unavailable"). This one has a DIFFERENT remedy — one command, `cairn sync` —
+#: and a caller that cannot tell it from 3 cannot act on it. 3 says "nothing
+#: readable is there"; 4 says "what is there cannot date itself, and here is how
+#: to fix that in one step".
+#:
+#: ⚠ `scripts/cairn`'s own `EXIT_REFRESH_FAILED` is ALSO 4 and means the opposite
+#: thing (the store was not reached but a usable cache survived, i.e. re-running
+#: `cairn sync` is the command that just failed). The collision is real and
+#: deliberate-by-accident; `test_subsystem_read_store.py::
+#: test_cairns_exit_4_is_SYNC_ONLY_and_is_not_the_readers_refusal` pins that
+#: cairn's 4 never escapes `cmd_sync`, which is what keeps the two tellable apart.
+EXIT_UNSTAMPED_READ_STORE = 4
 
 #: How a rendered stamp line is introduced, wherever a reader sees one.
 #:

--- a/scripts/lib/subsystem_recall.py
+++ b/scripts/lib/subsystem_recall.py
@@ -307,6 +307,12 @@ from subsystem_resolver import extract_sections as _extract_sections  # noqa: E4
 # has no `.sync-stamp` and never will. A refusal in the library would take down
 # the pod and `scripts/cairn` with it.
 import subsystem_read_store as _read_store  # noqa: E402
+
+# The refusal's exit code, imported rather than re-declared. Binding it by value
+# at import is safe in a way `DEFAULT_CACHE_ROOT` is not: it is an `int` nothing
+# repoints, and the whole point is that this number is the SAME one
+# `scripts/subsystem-audit.py` returns.
+from subsystem_read_store import EXIT_UNSTAMPED_READ_STORE  # noqa: E402,F401
 from subsystem_touch import (  # noqa: E402
     STORE_IS_PER_HOST,
     StoreMissingError,
@@ -2990,13 +2996,13 @@ def search_json(report: SearchReport) -> dict:
 
 # --- CLI -----------------------------------------------------------------------
 
-#: 🔴 A CODE OF ITS OWN, and `_exit_for`'s "don't mint a fourth code" argument
-#: does NOT cover it. That argument is about statuses whose documented handling
-#: is identical to 3's ("the store is broken; recall was unavailable"). This one
-#: has a DIFFERENT remedy — one command, `cairn sync` — and a caller that cannot
-#: tell it from 3 cannot act on it. 3 says "nothing readable is there"; 4 says
-#: "what is there cannot date itself, and here is how to fix that in one step".
-EXIT_UNSTAMPED_READ_STORE = 4
+# 🔴 `EXIT_UNSTAMPED_READ_STORE` USED TO BE DECLARED HERE, AND MOVED to
+# `subsystem_read_store` when `scripts/subsystem-audit.py` grew the same refusal:
+# two `= 4` literals in two tools would have been two things to keep in step, with
+# nothing reconciling them. It is imported at the top of this file (beside the
+# resolver itself) and stays reachable as `subsystem_recall.EXIT_UNSTAMPED_READ_STORE`
+# for every existing caller. The reasoning that used to sit here — why it is not
+# folded into 3 — moved with it.
 
 
 class _StoreAction(argparse.Action):

--- a/scripts/subsystem-audit.py
+++ b/scripts/subsystem-audit.py
@@ -59,10 +59,31 @@ CANNOT be performed — a scope whose owning repo is not derivable, a PR ref tha
 would need the network — it is reported as `NOT CHECKED` with its count, never
 folded into a clean total.
 
+WHICH STORE IT READS
+--------------------
+🔴 THE SYNCED CACHE, NOT THE FROZEN MIRROR. Since the Cairn cutover a hosted pod
+is the canonical datastore, `~/.claude/analyze-service-index` is a FROZEN (`0444`)
+per-host mirror that nothing refreshes, and `cairn sync` maintains a read-through
+cache at `~/.cache/subsystem-store`. This tool defaulted to the mirror, which is
+worse here than in a plain reader: its output DRIVES DELETIONS through the
+`prune-index` skill, and a prune computed against a store that is missing entries
+the canonical one has cuts bullets from the wrong bytes. The default now resolves
+through `scripts/lib/subsystem_read_store.read_store_root()` — the one place that
+path is written down, shared with `subsystem_recall` and `service_recon`.
+
+🔴 AND THE DEFAULT REFUSES A STORE THAT CANNOT DATE ITSELF (exit 4), naming
+`cairn sync`. The discriminator is the `.sync-stamp`, not the path, so it also
+catches a cache nobody has ever synced. An EXPLICIT `--store <path>` stays
+PERMISSIVE — that is an operator naming a directory deliberately, and it is what
+`prune-index` prescribes, what every test fixture is, and what a restored backup
+bundle would be. Same contract, same exit code and the same refusal text as
+`subsystem_recall`'s CLI, because a caller must not need two rules.
+
 Usage:
-  subsystem-audit.py                     audit the whole store
+  subsystem-audit.py                     audit the whole store (the synced cache)
   subsystem-audit.py --scope devrc       one scope
-  subsystem-audit.py --store PATH        a different store root (tests use this)
+  subsystem-audit.py --store PATH        a different store root (tests use this;
+                                         explicit ⇒ no stamp requirement)
   --all           list every entry in the size table (default: over-budget only)
   --detail N      entries to render a per-entry lifecycle block for (default 8)
   --check-prs     ALSO verify PR/issue refs with `gh` (network; off by default,
@@ -80,11 +101,13 @@ import os
 import re
 import subprocess
 import sys
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
 
+import subsystem_read_store as _read_store  # noqa: E402
 from subsystem_resolver import (  # noqa: E402
     AmbiguousRefError,
     NUANCE_HEADING,
@@ -98,7 +121,15 @@ from subsystem_resolver import (  # noqa: E402
     resolve_ref_tiered,
 )
 
-DEFAULT_STORE_ROOT = Path.home() / ".claude" / "analyze-service-index"
+# 🔴 `DEFAULT_STORE_ROOT = Path.home() / ".claude" / "analyze-service-index"` USED
+# TO BE DECLARED HERE. It was the pre-cutover mirror, and after the cutover it was
+# a THIRD open-coded read path that #1233 did not reach. Deleted rather than
+# repointed: a constant here would be a second spelling of
+# `subsystem_read_store.DEFAULT_CACHE_ROOT`, and the whole defect is two copies
+# disagreeing. `main()` calls `_read_store.resolve_read_store(None)`, which reads
+# `read_store_root()` at CALL time — one call that both resolves the directory and
+# reads its stamp, and what lets a test repoint the default without touching this
+# file.
 
 # --- budgets -------------------------------------------------------------------
 # 🔴 THESE TWO LITERALS ARE PINNED, NOT OWNED, HERE.
@@ -832,9 +863,17 @@ def render(
     show_all: bool,
     n_detail: int,
     check_prs: bool,
-    out=sys.stdout,
+    out=None,
     acknowledged: dict[str, str] | None = None,
+    stamp: Sequence[str] | None = None,
 ) -> None:
+    # 🔴 `out=sys.stdout` AS A DEFAULT BOUND THE STREAM AT IMPORT TIME. Whatever
+    # `sys.stdout` was when this module loaded is what every default-`out` call
+    # wrote to, forever — so redirecting `sys.stdout` afterwards (a test's
+    # `capsys`, a caller's `redirect_stdout`) silently did nothing, and the only
+    # reason no test saw it is that every existing one passes `out=` explicitly.
+    # Resolved at CALL time instead.
+    out = sys.stdout if out is None else out
     p = lambda *x: print(*x, file=out)  # noqa: E731
     ents = sorted(a.entries, key=lambda e: -e.size)
     n = len(ents)
@@ -844,6 +883,13 @@ def render(
 
     p(f"# /analyze-service index audit — {n} entries in {len(a.scopes)} scope(s)")
     p(f"  store: {a.store_root}")
+    # 🔴 WHICH SNAPSHOT THESE COUNTS ARE ABOUT. Printed UNPARSED and with no age
+    # computed — `cairn.cache_age` owns that arithmetic and a cheaper second answer
+    # here would be a second answer. Nothing is invented when there is no stamp:
+    # an explicitly-named store legitimately has none, and printing "unknown"
+    # would be a claim where the honest output is silence.
+    for line in _read_store.stamp_header(stamp):
+        p(line)
     p(f"\nbudget  target {TARGET:,} B   hard cap {HARD:,} B   per ENTRY")
     p(f"        {BUDGET_JUSTIFICATION}")
     p(f"        constants owned by {BUDGET_OWNER} — read the numbers there")
@@ -1124,7 +1170,20 @@ def render(
 
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description="audit the /analyze-service index store (READ-ONLY)")
-    ap.add_argument("--store", default=str(DEFAULT_STORE_ROOT), help="store root")
+    # 🔴 `None` IS THE SENTINEL, AND THAT IS THE CONTRACT — NOT A DEFAULT VALUE.
+    # "the operator named a directory" and "the operator named nothing" must not
+    # be the same state, because only the second is refused. Comparing the parsed
+    # value against the cache path would NOT answer it: `--store ~/.cache/
+    # subsystem-store` typed by hand is byte-identical to omitting the flag, and
+    # the two behave differently on purpose. (`subsystem_recall` reaches the same
+    # distinction with a custom argparse Action because other code there reads
+    # `args.store` as a `str`; here `main` is the only reader, so the sentinel is
+    # the whole mechanism. Same contract, cheaper spelling.)
+    ap.add_argument(
+        "--store",
+        default=None,
+        help="store root (default: the cairn-synced read cache; explicit ⇒ permissive)",
+    )
     ap.add_argument("--scope", default=None, help="audit one scope only")
     ap.add_argument("--all", action="store_true", help="list every entry, not just over-budget")
     ap.add_argument("--detail", type=int, default=8, help="rows per findings block")
@@ -1132,7 +1191,32 @@ def main(argv=None) -> int:
                     help="also verify PR/issue refs with `gh` (network)")
     args = ap.parse_args(argv)
 
-    root = Path(os.path.expanduser(args.store))
+    store_explicit = args.store is not None
+    read_store = _read_store.resolve_read_store(
+        os.path.expanduser(args.store) if store_explicit else None
+    )
+    root = read_store.root
+
+    # 🔴 THE REFUSAL SITS BEFORE THE `is_dir()` CHECK, ON PURPOSE — otherwise it
+    # is UNREACHABLE for the case that matters most. A host that has never run
+    # `cairn sync` has no `~/.cache/subsystem-store` at all, so `is_dir()` would
+    # win every time and answer `store root not found` — true, but with no remedy
+    # in it, for the one situation whose remedy is a single command. Ordered this
+    # way the two codes divide cleanly: 4 = "the DEFAULT landed somewhere that
+    # cannot date itself; run `cairn sync`", 2 = "you named a path and it is not
+    # a directory".
+    #
+    # 🔴 ONLY THE DEFAULT RESOLUTION IS REFUSED. An explicit `--store <path>` is
+    # the operator naming a directory — `prune-index`'s prescribed commands, a
+    # `cp -a` backup, a restored bundle, every test fixture — and stays permissive
+    # whether or not that directory is stamped.
+    if not store_explicit and not read_store.stamped:
+        print(_read_store.refusal_message("subsystem-audit", read_store), file=sys.stderr)
+        print("  An audit of a frozen mirror does not merely read stale: it is what "
+              "`prune-index`\n  computes DELETIONS from, so its entry list is the "
+              "wrong denominator for a cut.", file=sys.stderr)
+        return _read_store.EXIT_UNSTAMPED_READ_STORE
+
     if not root.is_dir():
         print(f"subsystem-audit: store root not found: {root}\n"
               "  This is `store-missing`, NOT an empty store — nothing was examined.",
@@ -1143,7 +1227,12 @@ def main(argv=None) -> int:
         print(f"subsystem-audit: no scope matched {args.scope!r} in {root}; "
               "nothing was examined.", file=sys.stderr)
         return 2
-    render(a, args.all, args.detail, args.check_prs)
+    # The stamp travels with the counts. Every number below is a measurement of ONE
+    # snapshot, and §6 of `prune-index` compares an OPEN count from one run against
+    # another — two runs of different snapshots is exactly the comparison that
+    # silently means nothing. Rendered through `stamp_header`, so this prints the
+    # same `stamp:` token `subsystem_recall` does rather than a second f-string.
+    render(a, args.all, args.detail, args.check_prs, stamp=read_store.stamp)
     return 0
 
 

--- a/scripts/tests/test_subsystem_read_store.py
+++ b/scripts/tests/test_subsystem_read_store.py
@@ -1636,14 +1636,21 @@ class TestTheAuditorRefusesAnUnstampedDefault:
 
 
 class TestTheAuditorStaysPermissiveOnAnExplicitStore:
-    """🔴 INVARIANT GUARDS, NOT REGRESSION COVERAGE — all three pass on
-    pre-change code and are labelled so.
+    """🔴 THE HALF THE CHANGE MUST NOT MOVE.
 
-    They pin the half of the contract the change must NOT move. Every prescribed
-    invocation of this tool passes `--store` explicitly (`prune-index/SKILL.md`
-    x4), as does every fixture in `test_subsystem_audit.py`, and a `cp -a` backup
-    or a restored bundle is the same case. A refusal that reached them would be a
-    regression dressed as a guard.
+    Every prescribed invocation of this tool passes `--store` explicitly
+    (`prune-index/SKILL.md` x4), as does every fixture in
+    `test_subsystem_audit.py`, and a `cp -a` backup or a restored bundle is the
+    same case. A refusal that reached them would be a regression dressed as a
+    guard.
+
+    🔴 LABELLED HONESTLY, AND THE LABEL IS NOT UNIFORM — measured at
+    `c616b7ae`, not assumed. Two of these three are INVARIANT GUARDS: they pass
+    on pre-change code and are NOT regression coverage. The first is RED at that
+    base, but for a DIFFERENT defect than the store repoint — `render`'s
+    `out=sys.stdout` default bound the stream at import, so `capsys` saw nothing
+    and the content assertion failed. It is regression coverage for THAT fix, and
+    it is the permissive contract only at HEAD.
     """
 
     def test_an_explicit_store_at_an_unstamped_path_still_audits(
@@ -1899,8 +1906,14 @@ class TestTheHandoffPrescriptionReadsTheCache:
         cache survives — its stated contract, not an edge case. Under `&&` the
         audit would then not run at all, during exactly the outage when a
         stamped-but-stale cache is still worth auditing and its stamp is what
-        says how stale. Pinned on the COMMAND, because the `PRESCRIPTION` pin
-        above would be satisfied by an `&&` variant if it were ever relaxed.
+        says how stale.
+
+        🔴 AN INVARIANT GUARD ON THE PIN ITSELF, NOT ON THE DOCUMENT — green at
+        `c616b7ae`, and NOT regression coverage. `PRESCRIPTION` is what the test
+        above compares the file against, so if someone relaxes the pin to an
+        `&&` variant the document check keeps passing and this is the only thing
+        that objects. Guarding the constant a guard is built from, because the
+        document arm cannot see its own expectation change.
         """
         assert "&&" not in self.PRESCRIPTION
         assert f"{rs.REMEDY};" in self.PRESCRIPTION

--- a/scripts/tests/test_subsystem_read_store.py
+++ b/scripts/tests/test_subsystem_read_store.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import ast
 import dataclasses
+import importlib.machinery
 import importlib.util
 import json
 import sys
@@ -147,6 +148,11 @@ WIRE_CONSTANTS: tuple[tuple[object, str, object], ...] = (
     (rs, "SYNC_STAMP", ".sync-stamp"),
     # A COMMAND a human is told to type, by the refusal and by two SKILL.mds.
     (rs, "REMEDY", "cairn sync"),
+    # An EXIT CODE two CLIs return and a script branches on. Not a `str` either,
+    # and the number is written out here rather than read off `subsystem_recall`
+    # — which now imports it — so the pin cannot be satisfied by the two agreeing
+    # with each other while both drifted from the documented contract.
+    (rs, "EXIT_UNSTAMPED_READ_STORE", 4),
     # A DIRECTORY every reader resolves and `scripts/cairn` writes. Not a `str`,
     # which is precisely why the old sweep could not see it.
     (rs, "DEFAULT_CACHE_ROOT", Path.home() / ".cache" / "subsystem-store"),
@@ -1418,3 +1424,483 @@ class TestTheBriefSaysHowFreshItsIndexIs:
         rather than at a reader wondering where the date went."""
         doc = (ROOT / "claude/skills/analyze-service/SKILL.md").read_text(encoding="utf-8")
         assert f"`{rs.STAMP_PREFIX.strip()}` LINES under `index:`" in doc
+
+
+# =============================================================================
+# The THIRD read surface: `scripts/subsystem-audit.py`, whose verb is DELETE.
+# =============================================================================
+#
+# 🔴 #1233 REPOINTED TWO OF THREE. `subsystem_recall`'s CLI and `service_recon`
+# were fixed; `scripts/subsystem-audit.py` kept its own
+# `DEFAULT_STORE_ROOT = ~/.claude/analyze-service-index` and defaulted `--store`
+# to it. It was left out deliberately — it is the tool `prune-index` computes
+# DELETIONS from, so repointing it has its own blast radius — and that is also
+# exactly why it is the worst one to leave: a stale mirror is missing entries the
+# canonical store has, so a cut planned against it is planned against the wrong
+# denominator, and §6 of `prune-index` compares an OPEN count across two runs.
+#
+# The prescribed invocations all pass `--store` explicitly and were never broken;
+# the BARE one in `claudedocs/handoff-analyze-service-index-backup.md` was.
+
+_AUDIT_SRC = ROOT / "scripts" / "subsystem-audit.py"
+
+
+def _fenced_command_lines(doc: str, needle: str) -> list[str]:
+    """Lines inside a ``` fence that mention `needle`, whitespace-normalised.
+
+    🔴 PROSE THAT NAMES A COMMAND IS NOT A PRESCRIPTION OF IT. Both markdown
+    guards below first matched any line containing `subsystem-audit.py`, which
+    swept up sentences like "re-run `scripts/subsystem-audit.py` and read …" —
+    true statements that prescribe no argv and must stay free to be reworded.
+    Only a fenced line is something a reader copies and runs, so only a fenced
+    line can be wrong about `--store`.
+    """
+    out, inside = [], False
+    for line in doc.splitlines():
+        if line.lstrip().startswith("```"):
+            inside = not inside
+            continue
+        if inside and needle in line and not line.lstrip().startswith("#"):
+            out.append(" ".join(line.split()))
+    return out
+
+
+def _python_code_only(src: str) -> str:
+    """`src` with comment lines and every triple-quoted block removed.
+
+    A literal ban has to read CODE. This file's own first attempt stripped the
+    module docstring alone and then failed on prose inside a FUNCTION docstring —
+    a guard going red for a sentence, which is how a literal ban gets deleted
+    rather than fixed. Both quote styles, because either delimits a docstring.
+    """
+    stripped, inside, closer = [], False, ""
+    for line in src.splitlines():
+        rest = line
+        while rest:
+            if inside:
+                idx = rest.find(closer)
+                if idx < 0:
+                    rest = ""
+                    break
+                rest, inside, closer = rest[idx + 3:], False, ""
+                continue
+            hits = [(rest.find(q), q) for q in ('"""', "'''") if rest.find(q) >= 0]
+            if not hits:
+                break
+            at, quote = min(hits)
+            stripped.append(rest[:at])
+            rest, inside, closer = rest[at + 3:], True, quote
+        if not inside and rest and not rest.lstrip().startswith("#"):
+            stripped.append(rest)
+    return "\n".join(stripped)
+
+
+def _load_audit():
+    """`subsystem-audit.py` has a hyphen, so it cannot be imported by name.
+
+    Loaded under a module name of this file's own, NOT the one
+    `test_subsystem_audit.py` uses: two suites sharing a `sys.modules` key would
+    make whichever imported second silently reuse the first's module object.
+    `subsystem_read_store` itself is still shared through `sys.modules`, which is
+    what lets `repointed` reach the auditor at all.
+    """
+    loader = importlib.machinery.SourceFileLoader(
+        "subsystem_audit_under_readstore_test", str(_AUDIT_SRC)
+    )
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[loader.name] = module
+    loader.exec_module(module)
+    return module
+
+
+sa = _load_audit()
+
+#: The auditor's own store-missing code, written out here rather than read off
+#: the module. It is the number the refusal must NOT collide with.
+AUDIT_EXIT_STORE_MISSING = 2
+
+
+class TestTheAuditorResolvesThroughTheSharedResolver:
+    def test_the_default_reads_the_repointed_cache_and_names_it(
+        self, tmp_path: Path, repointed, capsys
+    ) -> None:
+        """🔴 THE HEADLINE. With no `--store`, the auditor reads whatever
+        `read_store_root()` resolves to — so repointing the resolver moves it,
+        which is only true if it stopped carrying a path of its own.
+
+        Asserted through the OUTPUT, not by reading a constant back off the
+        module: `store: <path>` is the line a human uses to answer "which store
+        did this audit?", and it is the one that was wrong.
+        """
+        store = repointed(_store(tmp_path, stamped=True))
+        assert sa.main([]) == 0
+        out = capsys.readouterr().out
+        assert f"  store: {store}" in out
+        # …and it really audited THAT store, rather than printing its name over
+        # somebody else's counts.
+        assert "collector" in out
+
+    def test_the_default_is_NOT_the_frozen_mirror(
+        self, tmp_path: Path, repointed, capsys
+    ) -> None:
+        """Pinned two-way, the same as the resolver's own default test: where it
+        points, and where it must not. The mirror is named through
+        `subsystem_touch` — the module that legitimately owns that path — so this
+        cannot be satisfied by the auditor agreeing with a copy of its own."""
+        repointed(_store(tmp_path, stamped=True))
+        assert sa.main([]) == 0
+        out = capsys.readouterr().out
+        assert f"  store: {st.DEFAULT_STORE_ROOT}" not in out
+        assert "analyze-service-index" not in out
+
+
+class TestTheAuditorRefusesAnUnstampedDefault:
+    def test_an_unstamped_DEFAULT_is_refused_and_audits_nothing(
+        self, tmp_path: Path, repointed, capsys
+    ) -> None:
+        """🔴 Non-zero exit, and — the half that matters — no report a reader
+        could act on. An audit that still printed its counts would be an
+        advisory, and `prune-index` step 1 says to stop when the verdict is
+        clean: a clean verdict computed off a frozen mirror is the failure."""
+        repointed(_store(tmp_path, stamped=False))
+        assert sa.main([]) == 4
+        cap = capsys.readouterr()
+        assert "REFUSING" in cap.err
+        assert rs.REMEDY in cap.err
+        assert cap.out.strip() == ""
+        assert "index audit" not in cap.out
+
+    def test_the_refusal_names_DELETION_as_the_stake(
+        self, tmp_path: Path, repointed, capsys
+    ) -> None:
+        """This tool is not just another reader, and its refusal says so — a
+        reader who has seen the recall refusal must not read this one as the
+        same, weaker fact."""
+        repointed(_store(tmp_path, stamped=False))
+        assert sa.main([]) == 4
+        err = capsys.readouterr().err
+        assert "DELETIONS" in err
+        assert "prune-index" in err
+
+    def test_the_exit_code_is_the_SAME_number_BOTH_read_surfaces_return(
+        self, tmp_path: Path, repointed, capsys
+    ) -> None:
+        """🔴 ONE VOCABULARY, OR A CALLER NEEDS TWO RULES.
+
+        The literal is written out here, and the two tools are compared to it
+        rather than to each other — two modules agreeing while both drifted from
+        the documented contract is the failure this file has already seen five
+        times. `2` is asserted distinct because it is this auditor's OWN
+        store-missing code, and a refusal that returned it would be
+        indistinguishable from "you named a path that is not a directory".
+        """
+        repointed(_store(tmp_path, stamped=False))
+        assert sa.main([]) == 4
+        capsys.readouterr()
+        assert rs.EXIT_UNSTAMPED_READ_STORE == 4
+        assert rc.EXIT_UNSTAMPED_READ_STORE == 4
+        assert rc.main(["--scope", SCOPE]) == 4
+        capsys.readouterr()
+        assert 4 != AUDIT_EXIT_STORE_MISSING
+        assert 4 != 0
+
+    def test_the_guard_is_REACHABLE_the_store_missing_check_does_not_win(
+        self, tmp_path: Path, repointed, capsys
+    ) -> None:
+        """🔴 REACHABILITY, and this one is not hypothetical — it is the ONLY
+        case a fresh host produces.
+
+        A host that has never run `cairn sync` has no `~/.cache/subsystem-store`
+        at all. `root.is_dir()` sits in this same function and answers that with
+        `store root not found`, which is TRUE and carries no remedy. Placed
+        after it, the refusal would be dead code for the exact population it
+        exists to serve. So the input here is a default that does not exist, and
+        the assertion is that the answer is 4 with `cairn sync` in it — never 2.
+        """
+        repointed(tmp_path / "never-synced")
+        assert sa.main([]) == rs.EXIT_UNSTAMPED_READ_STORE
+        err = capsys.readouterr().err
+        assert rs.REMEDY in err
+        assert "store root not found" not in err
+
+    def test_the_same_command_succeeds_once_the_store_is_stamped(
+        self, tmp_path: Path, repointed, capsys
+    ) -> None:
+        """The positive half of the reachability pair: same argv, same store
+        contents, stamp present ⇒ exit 0 and a real audit. Without this, a
+        `main` that refused everything would pass every test above."""
+        repointed(_store(tmp_path, stamped=True))
+        assert sa.main([]) == 0
+        assert "index audit" in capsys.readouterr().out
+
+
+class TestTheAuditorStaysPermissiveOnAnExplicitStore:
+    """🔴 INVARIANT GUARDS, NOT REGRESSION COVERAGE — all three pass on
+    pre-change code and are labelled so.
+
+    They pin the half of the contract the change must NOT move. Every prescribed
+    invocation of this tool passes `--store` explicitly (`prune-index/SKILL.md`
+    x4), as does every fixture in `test_subsystem_audit.py`, and a `cp -a` backup
+    or a restored bundle is the same case. A refusal that reached them would be a
+    regression dressed as a guard.
+    """
+
+    def test_an_explicit_store_at_an_unstamped_path_still_audits(
+        self, tmp_path: Path, repointed, capsys
+    ) -> None:
+        # The default is repointed at an unstamped store too, so a pass here
+        # cannot come from the default happening to be fine.
+        repointed(_store(tmp_path / "default", stamped=False))
+        elsewhere = _store(tmp_path / "named", stamped=False)
+        assert sa.main(["--store", str(elsewhere)]) == 0
+        cap = capsys.readouterr()
+        assert "collector" in cap.out
+        assert "REFUSING" not in cap.err
+
+    def test_an_explicit_MISSING_store_is_store_missing_not_the_refusal(
+        self, tmp_path: Path, repointed, capsys
+    ) -> None:
+        """The two codes divide on WHO named the path. `store-missing` still
+        answers an operator who typed one, and the remedy for that is not
+        `cairn sync`."""
+        repointed(_store(tmp_path / "default", stamped=True))
+        assert sa.main(["--store", str(tmp_path / "nope")]) == AUDIT_EXIT_STORE_MISSING
+        err = capsys.readouterr().err
+        assert "store root not found" in err
+        assert rs.REMEDY not in err
+
+    def test_the_prescribed_skill_commands_all_name_a_store(self) -> None:
+        """The premise of this whole class, pinned rather than recalled. If
+        `prune-index` ever stops passing `--store`, the permissive arm above
+        stops describing the prescribed path and the refusal starts reaching
+        it — and nothing else would say so."""
+        doc = (ROOT / "claude/skills/prune-index/SKILL.md").read_text(encoding="utf-8")
+        calls = _fenced_command_lines(doc, "subsystem-audit.py")
+        # POSITIVE CONTROL: the fence walk really found commands, so an
+        # all-pass loop below is not a loop over nothing.
+        assert len(calls) >= 4, calls
+        for line in calls:
+            assert "--store" in line, f"prune-index now invokes the auditor bare: {line!r}"
+
+
+class TestTheAuditCarriesTheSnapshotItMeasured:
+    """🔴 THE PRESCRIBED PATH IS EXPLICIT, SO THE REFUSAL NEVER FIRES ON IT.
+
+    Repointing the default fixes the bare invocation and nothing else. What the
+    prescribed `--store ~/.cache/subsystem-store` run gains is this: the counts
+    now print the snapshot they were measured against. `prune-index` §6 compares
+    an OPEN count from a run before the cut with one after, and two runs of
+    DIFFERENT snapshots is precisely the comparison that silently means nothing —
+    the same shape as the completeness claim that started all this.
+    """
+
+    def test_the_stamp_prints_between_the_store_line_and_the_budget_block(
+        self, tmp_path: Path, repointed, capsys
+    ) -> None:
+        """Every line, and POSITIONED. A freshness fact printed below the size
+        table dates a page the reader has already believed."""
+        repointed(_store(tmp_path, stamped=True))
+        assert sa.main([]) == 0
+        lines = capsys.readouterr().out.splitlines()
+        store_at = next(i for i, ln in enumerate(lines) if ln.startswith("  store: "))
+        budget_at = next(i for i, ln in enumerate(lines) if ln.startswith("budget "))
+        for i, line in enumerate(STAMP_LINES):
+            assert lines[store_at + 1 + i] == f"  stamp: {line}", lines[:12]
+        assert store_at + len(STAMP_LINES) < budget_at
+
+    def test_the_stamp_prefix_is_the_ONE_spelling_ALL_THREE_renderers_use(
+        self, tmp_path: Path, repointed, capsys
+    ) -> None:
+        """🔴 THREE RENDERERS NOW, ONE TOKEN. `analyze-service/SKILL.md` tells a
+        reader to relay "the `stamp:` lines"; that instruction is true of every
+        surface or of none. Compared as RENDERED OUTPUT — the recall CLI's
+        against the auditor's — never by grepping two sources for one f-string.
+        """
+        store = _store(tmp_path, stamped=True)
+        repointed(store)
+        assert rc.main(["--scope", SCOPE]) == 0
+        reader_lines = {
+            ln for ln in capsys.readouterr().out.splitlines() if ln.startswith("  stamp:")
+        }
+        assert sa.main([]) == 0
+        audit_lines = {
+            ln for ln in capsys.readouterr().out.splitlines() if ln.startswith("  stamp:")
+        }
+        assert reader_lines == audit_lines != set()
+        assert audit_lines == {f"{rs.STAMP_PREFIX}{ln}" for ln in STAMP_LINES}
+
+    def test_an_explicitly_named_store_is_dated_when_it_can_be_and_not_when_it_cannot(
+        self, tmp_path: Path, repointed, capsys
+    ) -> None:
+        """🔴 BOTH HALVES, because either alone passes over a renderer that
+        always prints or never does. `--store` is exempt from the refusal, not
+        from the date — and where there is no stamp, nothing is invented."""
+        repointed(_store(tmp_path / "default", stamped=True))
+        fresh = _store(tmp_path / "fresh", stamped=True)
+        bare = _store(tmp_path / "bare", stamped=False)
+
+        assert sa.main(["--store", str(fresh)]) == 0
+        dated = capsys.readouterr().out
+        for line in STAMP_LINES:
+            assert f"{rs.STAMP_PREFIX}{line}" in dated, line
+
+        assert sa.main(["--store", str(bare)]) == 0
+        undated = capsys.readouterr().out
+        assert rs.STAMP_PREFIX not in undated
+        assert "index audit" in undated
+
+    def test_NO_AGE_IS_COMPUTED_by_the_auditor_either(
+        self, tmp_path: Path, repointed, capsys
+    ) -> None:
+        """`cairn.cache_age` owns that arithmetic. Asserted behaviourally — the
+        stamp's own epoch is echoed, never converted — because a structural
+        `import time` ban cannot apply here: this auditor legitimately shells
+        `git` and has other clock-free reasons to hold none."""
+        repointed(_store(tmp_path, stamped=True))
+        assert sa.main([]) == 0
+        assert "  stamp: synced=1788363567" in capsys.readouterr().out
+
+
+class TestTheAuditorHoldsNoSecondCopyOfTheReadStoreFacts:
+    def test_it_IMPORTS_the_resolver_rather_than_declaring_one(self) -> None:
+        """The one-line structural claim behind every behavioural test above."""
+        assert "import subsystem_read_store" in _AUDIT_SRC.read_text(encoding="utf-8")
+
+    def test_no_MODULE_SCOPE_assignment_anchors_a_path_at_HOME(self) -> None:
+        """🔴 THE SHAPE THE OLD CONSTANT HAD, BANNED BY SHAPE.
+
+        `DEFAULT_STORE_ROOT = Path.home() / ".claude" / "analyze-service-index"`
+        is what this closes, and a ban on that NAME would be walkable by picking
+        another one. What cannot be walked is the shape: a store root written
+        down here at all is a second copy of something the resolver owns.
+
+        Scoped to MODULE SCOPE deliberately — `workspace_roots()` calls
+        `Path.home()` inside a function for an unrelated purpose, and a
+        whole-file ban would have to exempt it by name, which is how a guard
+        starts describing less than its docstring.
+        """
+        tree = ast.parse(_AUDIT_SRC.read_text(encoding="utf-8"))
+        offenders = []
+        for node in _module_scope_statements(list(tree.body)):
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            if node.value is None:
+                continue
+            for sub in ast.walk(node.value):
+                if (
+                    isinstance(sub, ast.Call)
+                    and isinstance(sub.func, ast.Attribute)
+                    and sub.func.attr == "home"
+                ):
+                    offenders.extend(
+                        n
+                        for t in (
+                            node.targets if isinstance(node, ast.Assign) else [node.target]
+                        )
+                        for n in _bound_names(t)
+                    )
+        assert offenders == [], (
+            f"`scripts/subsystem-audit.py` declares module-scope {offenders}, "
+            f"anchored at `$HOME`. A store root belongs in "
+            f"`subsystem_read_store`; call `read_store_root()` instead."
+        )
+        # POSITIVE CONTROL: the walk really reached this file's module scope, so
+        # an empty `offenders` means "no such constant", not "no parse".
+        assert "TARGET" in _module_scope_assignments(_AUDIT_SRC), "the sweep saw nothing"
+
+    def test_it_redeclares_NOTHING_the_resolver_defines(self) -> None:
+        """🔴 THE ARM THAT STOPS THE NEXT ONE — an INVARIANT GUARD, labelled.
+
+        It passes on pre-change code (the auditor's old `DEFAULT_STORE_ROOT` is
+        `subsystem_touch`'s name, not this module's), so it is not regression
+        coverage for anything. It is the same two-way pin
+        `test_the_constants_have_exactly_one_definition` puts on `scripts/cairn`,
+        extended to the third consumer: the cache path, the stamp filename, the
+        remedy and the refusal's exit code now have exactly one definition each
+        and THREE importers, and a fourth copy appearing in any of them is the
+        only way this defect comes back in the shape it came back in five times.
+        """
+        assigned = _module_scope_bindings(_AUDIT_SRC)
+        # POSITIVE CONTROL, both collection paths: a constant and a `def`.
+        assert {"TARGET", "audit_store"} <= assigned, sorted(assigned)[:20]
+        swept = _module_scope_bindings(ROOT / "scripts" / "lib" / "subsystem_read_store.py")
+        assert {"SYNC_STAMP", "stamp_header"} <= swept, sorted(swept)
+        clash = assigned & (set(rs.__all__) | swept)
+        assert clash == set(), (
+            f"`scripts/subsystem-audit.py` assigns {sorted(clash)}, which it must "
+            f"IMPORT from `subsystem_read_store` — a second copy is a second thing "
+            f"to keep in step, and the readers cannot see it."
+        )
+
+    def test_it_spells_neither_the_stamp_FILENAME_nor_the_cache_PATH(self) -> None:
+        """It bans the third definition arriving as a bare STRING rather than as
+        a named constant, which the name-clash arm above cannot see.
+
+        MIXED, and split on purpose. `analyze-service-index` is REGRESSION
+        coverage — pre-change code spelled it, in the constant this change
+        deleted. The other two are INVARIANT GUARDS: pre-change code held
+        neither, and they exist so a future edit cannot re-open the hole from the
+        cache side instead of the mirror side.
+
+        Comments and docstrings are stripped, so prose naming any of these — this
+        file's own module docstring names all three — stays free to explain them.
+        """
+        code = _python_code_only(_AUDIT_SRC.read_text(encoding="utf-8"))
+        # REGRESSION: the frozen mirror's own directory name.
+        assert "analyze-service-index" not in code, (
+            "`scripts/subsystem-audit.py` spells the FROZEN MIRROR's path in code. "
+            "That is the constant this change deleted; call `resolve_read_store()`."
+        )
+        # INVARIANT: the cache side of the same fact.
+        for literal in (rs.SYNC_STAMP, rs.DEFAULT_CACHE_ROOT.name):
+            assert literal not in code, (
+                f"`scripts/subsystem-audit.py` spells {literal!r} in code. That is a "
+                f"second definition of a fact `subsystem_read_store` owns."
+            )
+        # POSITIVE CONTROL: the stripping left real code behind to search — and
+        # a control the strip CANNOT satisfy from a docstring, since these two
+        # tokens appear in this file's code and nowhere in its prose.
+        assert "resolve_read_store(" in code
+        assert "def main(" in code
+
+
+class TestTheHandoffPrescriptionReadsTheCache:
+    """🔴 THE ONE BARE INVOCATION IN THE REPO, AND WHY IT MATTERED.
+
+    `claudedocs/handoff-analyze-service-index-backup.md` prescribes the auditor
+    with no `--store`, inside a "verify the backup path" checklist. Before this
+    change that read the frozen mirror; after it, bare is CORRECT — but a bare
+    run with no sync audits whatever the cache last held, which in a backup
+    verification is the wrong claim.
+    """
+
+    #: 🔴 THE WHOLE NORMALISED COMMAND, NOT A KEYWORD. The artifact is prose, and
+    #: a guard on words ("cairn sync appears somewhere in the file") is walkable
+    #: by rewording — `claude/RULES.md`, "a guard can be SPELLED rather than
+    #: STRUCTURAL". A cosmetic edit here fails the test; pay it, and paste the
+    #: new line in.
+    PRESCRIPTION = "cairn sync; python3 ~/workspace/devrc/scripts/subsystem-audit.py"
+
+    def test_the_command_syncs_first_and_takes_the_default_store(self) -> None:
+        doc = (ROOT / "claudedocs" / "handoff-analyze-service-index-backup.md").read_text(
+            encoding="utf-8"
+        )
+        calls = _fenced_command_lines(doc, "subsystem-audit.py")
+        assert calls == [self.PRESCRIPTION], (
+            f"the auditor prescription in handoff-analyze-service-index-backup.md "
+            f"changed to {calls}. Expected exactly {[self.PRESCRIPTION]}."
+        )
+
+    def test_it_is_NOT_chained_with_double_ampersand(self) -> None:
+        """🔴 SAME TRAP `analyze-service/SKILL.md` STEP 1 ALREADY PAID FOR.
+
+        `cairn sync` exits non-zero when the pod is unreachable but a usable
+        cache survives — its stated contract, not an edge case. Under `&&` the
+        audit would then not run at all, during exactly the outage when a
+        stamped-but-stale cache is still worth auditing and its stamp is what
+        says how stale. Pinned on the COMMAND, because the `PRESCRIPTION` pin
+        above would be satisfied by an `&&` variant if it were ever relaxed.
+        """
+        assert "&&" not in self.PRESCRIPTION
+        assert f"{rs.REMEDY};" in self.PRESCRIPTION


### PR DESCRIPTION
Closes **rank 20** of `claudedocs/handoff-cairn-phase3.md`. Base: **`c616b7ae`**.

`scripts/subsystem-audit.py:101` open-coded `DEFAULT_STORE_ROOT = ~/.claude/analyze-service-index` and defaulted `--store` to it. #1233 repointed the other two host-local read surfaces and left this one out on purpose — its output drives **deletions** through `prune-index`, so repointing it has its own blast radius. That is also why it was the worst one to leave: the frozen mirror is missing entries the canonical store has, so a cut planned against it is planned against the wrong denominator, and `prune-index` §6 compares an `OPEN` count from one run against another.

## What changed

- **The constant is deleted, not repointed.** `main()` resolves through `subsystem_read_store.resolve_read_store()`. `resolve_read_store` reads `read_store_root()` at *call* time, so a test can repoint the whole read path with one assignment.
- **An unstamped DEFAULT is refused, exit 4, naming `cairn sync`.** An explicit `--store <path>` stays **permissive** — same contract as `subsystem_recall`'s CLI.
- **The refusal sits before the `is_dir()` check.** Otherwise it is unreachable for the only case a fresh host produces: no `~/.cache/subsystem-store` at all, which `store root not found` answers truthfully and with no remedy in it. `M4` in the sweep below is that ordering, mutated.
- **`EXIT_UNSTAMPED_READ_STORE` moved** from `subsystem_recall` into `subsystem_read_store`, beside `refusal_message` and `REMEDY`. One refusal, one message, one command, one number — a second `= 4` in a second tool is the shape this module exists to close. `subsystem_recall.EXIT_UNSTAMPED_READ_STORE` still resolves, for every existing caller and test.
- **The audit prints the `stamp:` lines** beside `store:`, through the shared `stamp_header()`. This is what the *prescribed* (explicit, hence permissive) invocation actually gains — see below.
- **`claudedocs/handoff-analyze-service-index-backup.md:452`** now syncs first, `;` not `&&`.

## The refusal decision, and the caller evidence

**Refuse the DEFAULT only; stay permissive on an explicit `--store`.**

Every caller was checked (`git grep -n subsystem-audit` across `scripts/`, `claude/skills/`, `claudedocs/`):

| caller | form | effect |
|---|---|---|
| `claude/skills/prune-index/SKILL.md` ×4 (fenced) | `--store $S` / `--store ~/.cache/subsystem-store` | explicit — unaffected |
| `scripts/tests/test_subsystem_audit.py` (every fixture) | `--store <tmp>` | explicit — unaffected |
| `claudedocs/handoff-analyze-service-index-backup.md:452` | **bare** | the one broken caller; fixed here |
| `claudedocs/handoff-*.md` prose, `analyze-service/reference/*.md` | prose, no argv | not invocations |

So refusing the default breaks **zero** prescribed invocations, and refusing an *explicit* store would break at least one existing test (`test_a_missing_store_is_not_an_empty_one`, which expects `store-missing` rc 2 for a named path) plus the legitimate explicit targets: a `cp -a` backup from `prune-index` step 2, a restored bundle from `restore-verify.py`, the pod's `/data`. `claude/RULES.md` — "a refusal that breaks an existing prescribed invocation is its own regression", and "a permanently-red gate is worse than no gate".

⚠ **One correction to the brief's framing, and it is what makes the above defensible.** This tool's verb is not `delete`: it is **READ-ONLY by contract**, enforced by `test_the_audit_source_contains_no_write_call`. It *drives* deletions — a human confirms each cut through `prune-index`, on a diff. The stake is real (a wrong denominator for a cut) but the tool itself writes nothing, so "it deletes, therefore refuse everything" does not follow.

🔴 **And the refusal alone would have been a no-op for the path that is actually prescribed** — which is explicit, hence permissive, hence never refused. That is why the stamp render is in this PR rather than left as polish: it is the only thing the `--store ~/.cache/subsystem-store` run gains. Its counts now carry the snapshot they were measured against, which is what makes §6's before/after `OPEN` comparison mean anything.

## No second definition — grep evidence

```
$ git grep -n 'Path.home() */ *"\.cache"' -- '*.py' 'scripts/cairn' | grep -v ^scripts/tests/
scripts/lib/subsystem_read_store.py:62:DEFAULT_CACHE_ROOT = Path.home() / ".cache" / "subsystem-store"

$ git grep -n '"\.sync-stamp"' -- .            # non-test hits
scripts/lib/subsystem_read_store.py:65:SYNC_STAMP = ".sync-stamp"
```

Exactly one definition each; every other hit is a test pinning the literal by hand (the `WIRE_CONSTANTS` ledger, deliberately independent) or a fixture writing it. `subsystem-audit.py`'s only remaining mention of the frozen mirror is a **comment** — `test_it_spells_neither_the_stamp_FILENAME_nor_the_cache_PATH` strips comments and docstrings and asserts it is absent from the code.

## Red at base / green at HEAD — base `c616b7ae`

Measured on a pristine `git archive c616b7ae` tree with only the test file copied in, and `HOME` pointed at an empty directory so the base run could not read the real client-confidential store. HEAD re-run under the same fake `HOME` for an apples-to-apples comparison.

**18 red at `c616b7ae` → 81 green at HEAD.**

Regression coverage (red at base):

- `test_the_default_reads_the_repointed_cache_and_names_it`
- `test_the_default_is_NOT_the_frozen_mirror`
- `test_an_unstamped_DEFAULT_is_refused_and_audits_nothing`
- `test_the_refusal_names_DELETION_as_the_stake`
- `test_the_exit_code_is_the_SAME_number_BOTH_read_surfaces_return`
- `test_the_guard_is_REACHABLE_the_store_missing_check_does_not_win`
- `test_the_same_command_succeeds_once_the_store_is_stamped`
- `test_the_stamp_prints_between_the_store_line_and_the_budget_block`
- `test_the_stamp_prefix_is_the_ONE_spelling_ALL_THREE_renderers_use`
- `test_an_explicitly_named_store_is_dated_when_it_can_be_and_not_when_it_cannot`
- `test_NO_AGE_IS_COMPUTED_by_the_auditor_either`
- `test_it_IMPORTS_the_resolver_rather_than_declaring_one`
- `test_no_MODULE_SCOPE_assignment_anchors_a_path_at_HOME`
- `test_it_spells_neither_the_stamp_FILENAME_nor_the_cache_PATH` (the `analyze-service-index` arm; its other two arms are invariant, stated in the docstring)
- `test_the_command_syncs_first_and_takes_the_default_store`
- `test_the_constant_equals_its_literal[EXIT_UNSTAMPED_READ_STORE]` and `test_the_ledger_is_two_way_over_the_new_module` (the constant move)
- `test_an_explicit_store_at_an_unstamped_path_still_audits` — 🔴 **red at base for a DIFFERENT defect**, see below. Not coverage of the store repoint.

**Invariant guards — labelled as such in the source, NOT counted as regression coverage** (green at base):

- `test_an_explicit_MISSING_store_is_store_missing_not_the_refusal`
- `test_the_prescribed_skill_commands_all_name_a_store`
- `test_it_redeclares_NOTHING_the_resolver_defines`
- `test_it_is_NOT_chained_with_double_ampersand`

## Mutation sweep — 9/9 killed, 0 survivors

`cp -a` copy with `rm -f <copy>/.git` run **first**, `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` wiped between mutants, anchor-match count asserted `== 1` per mutant (a mutant that did not apply aborts the run rather than scoring SURVIVED), control **green before and after**.

| mutant | verdict | killed by |
|---|---|---|
| **M1** delete the refusal — *positive control* | KILLED | the 4 refusal tests |
| **M2** refuse explicit too | KILLED | `…explicit_store_at_an_unstamped_path_still_audits`, `…explicit_MISSING_store…`, +3 pre-existing |
| **M3** refusal returns `2` | KILLED | `test_the_exit_code_is_the_SAME_number…` +3 |
| **M4** refusal moved *after* `is_dir()` | KILLED | `test_the_guard_is_REACHABLE…` — **and only that test** |
| **M5** default back to the frozen mirror | KILLED | `test_the_default_is_NOT_the_frozen_mirror` +5 |
| **M6** drop the stamp render | KILLED | the 4 stamp tests |
| **M7** `EXIT_UNSTAMPED_READ_STORE = 5` | KILLED | the ledger pin + `test_cairns_exit_4_is_SYNC_ONLY…` +4 |
| **M8** `main` passes `stamp=None` | KILLED | the 4 stamp tests |
| **M9** restore `render(out=sys.stdout)` | KILLED | 7 |

Isolation: M1 is the deliberately-coarse positive control. M2 mutates only the condition, M3 only the returned value, M4 only the statement order — the narrowest expression that can be wrong in each case, so none dies for the enclosing block's reason.

## Two defects found while writing the tests, both fixed here

1. 🔴 **`render(out=sys.stdout)` bound the stream at import.** Whatever `sys.stdout` was when the module loaded is what every default-`out` call wrote to, forever — so `capsys`, or any `redirect_stdout`, silently did nothing. No test saw it because every existing caller passes `out=` explicitly. Probed and confirmed before fixing. Now resolved at call time; `M9` is that regression.
2. A **positive control** in `test_it_spells_neither…` caught a comment of mine claiming `main()` calls `read_store_root()`. It calls `resolve_read_store()`. Comment corrected — the control existed precisely so a clean literal ban could not mean "the strip removed everything".

## Observation, out of scope, not actioned

`scripts/analyze-service-index/backup.py:159` and `scripts/cairn-cutover.py:104` each re-declare `Path.home() / ".claude" / "analyze-service-index"` rather than importing `subsystem_touch.DEFAULT_STORE_ROOT`. That is the **write/backup** side of the same one-rule-one-place question, untouched by rank 20 and by #1233. Recording it rather than widening this PR.

## Gate

Targeted suites only so far — `subsystem_read_store`, `subsystem_audit{,_acknowledged,_budget}`, `cairn_{cli,cutover,who,write}`, `service_recon`, `subsystem_{recall,resolver,store_api,touch}`. **The two-tier merged-tree gate has NOT been run** and is the reviewer's to run; branch protection is off, so nothing here is gated automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPiQDMvSzEQXRwmEHi4ZxK
