### PR TITLE
feat(drift-check): rc 24 fires on DISAGREEMENT with a declared expectation; rc 25 catches the declaration going stale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,8 +166,16 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   `protected: true`. A PR merges with both Tekton checks red, or with none posted at all.
   🔴 **DELIBERATE AND CURRENT — not drift, and not yours to "restore".** The operator turned
   it off because the gate was slowing work down; it stays off until the Tekton capacity
-  issue is addressed, which a different session owns. `drift-check.sh` rc 24 will report an
-  unprotected `main` every run in the meantime: that report is EXPECTED, not a finding.
+  issue is addressed, which a different session owns. 🔴 **That decision is now DECLARED IN
+  CODE, and the declaration is load-bearing.** `bp_declared_off_reason()` in
+  `scripts/drift-check.sh` names this repo with the reason above, so rc 24 fires on
+  DISAGREEMENT rather than on the bare state: declared-off/live-off is printed plainly and
+  sets no code (it exited 24 on every 6-hourly fire before that — 5 DND-bypassing toasts in
+  3 days), while an UNDECLARED unprotected `main` is still the alarm, unchanged. 🔴 **When
+  protection is restored, DELETE that arm in the same change** — a declaration left saying
+  "off" over a live gate DISARMS rc 24, which is `drift-check.sh` rc 25 and toasts until it
+  is removed. The declaration is deliberately not env-overridable and has no ledger path: a
+  run must not be able to excuse itself.
   ⚠ **Tekton still RUNS** — both checks post on a PR head, they just do not gate. That is
   exactly why the marker stays `other`: it records that something runs at merge time, never
   that it blocks. There is still no `.github/workflows`.
@@ -224,7 +232,10 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   lags by up to a full interval, and only where the deadman is actually wired in
   (`serverMode && enableDriftDeadman`; the timer runs on the workbench). It catches a
   botched restore after the fact; it does not undo one, and it is not a substitute for
-  step 4.
+  step 4. ⚠ **And it is only armed for a repo whose declared expectation is ON** — while
+  the arm above declares this repo's gate off, a botched restore lands in the same cell as
+  the intended state and passes silently. That is the price of the declaration, and it is
+  why deleting the arm is part of restoring protection rather than a follow-up.
   ⚠ **`strict` is FALSE on purpose.** `strict: true` would force every PR to be up to date
   with `main` before merging — correct in principle, and unworkable here: `main` moved 11+
   times in one session and each move would re-queue a ~20-minute gate for every open PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,10 +175,11 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   `nix/home.nix`'s `zz_notify_failure_bypass` block — do not restate it; it was wrong at
   every copy.) 🔴 **When protection is restored, DELETE that arm in the same change** — a
   declaration left saying "off" over a live gate DISARMS rc 24, which is `drift-check.sh`
-  rc 25 and toasts until it is removed. **A PARTIAL restore fires rc 25 too**: put the
-  required checks back and omit `enforce_admins` — the exact shape step 4 below warns a
-  partial `PUT` produces — and the checks existing again is evidence the declaration is
-  stale, so it is a finding rather than agreement. The declaration is deliberately not
+  rc 25 and toasts until it is removed. **A HALF-finished restore fires rc 25 too**, in
+  either spelling: required checks back with `enforce_admins` omitted (the exact shape step 4
+  below warns a partial `PUT` produces), or an ACTIVE ruleset listing a check but keeping
+  `bypass_actors`. A gate existing again is evidence the declaration is stale, so both are
+  findings rather than agreement. The declaration is deliberately not
   env-overridable and has no ledger path: a run must not be able to excuse itself. ⚠ The
   SUBJECT can still be redirected (`DRIFT_PROTECT_SLUG`), but the run prints the slug it
   asked about, so that silence names a repo nobody chose.
@@ -238,13 +239,16 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   lags by up to a full interval, and only where the deadman is actually wired in
   (`serverMode && enableDriftDeadman`; the timer runs on the workbench). It catches a
   botched restore after the fact; it does not undo one, and it is not a substitute for
-  step 4. ⚠ **And while this repo's gate is DECLARED off, rc 24 cannot fire for it** — a
-  restore that is later undone lands in the same cell as the intended state. Two things
-  narrow that: a PARTIAL restore (checks back, `enforce_admins` dropped — the failure step 4
-  exists for) fires **rc 25**, not silence; and a completed restore fires rc 25 until the
-  declaration is deleted. What is genuinely uncovered is a full restore, the declaration
-  deleted, and a *later* deletion — which is ordinary rc 24 again. Deleting the arm is part
-  of restoring protection, not a follow-up.
+  step 4. ⚠ **And while this repo's gate is DECLARED off, rc 24 cannot fire for it.** What
+  narrows that is rc 25, which fires on any OFF state carrying evidence a gate was
+  re-established: a completed restore, a PARTIAL one (checks back, `enforce_admins` dropped —
+  the failure step 4 exists for), and an ACTIVE ruleset that lists a check but keeps bypass
+  actors. 🔴 **The one state still uncovered is a ruleset parked in `evaluate`/`disabled`
+  mode** — not a gate anybody built, and indistinguishable at the endpoint drift-check reads
+  from the org-level evaluate rollout it must not fire on. (Closable, not structural:
+  `ruleset_source_type` is on `/rules/branches/main` and is simply not read yet.) Note a full
+  restore followed by a *later* deletion is NOT uncovered — deleting the declaration is part
+  of restoring protection, and after that it is ordinary rc 24 again.
   ⚠ **`strict` is FALSE on purpose.** `strict: true` would force every PR to be up to date
   with `main` before merging — correct in principle, and unworkable here: `main` moved 11+
   times in one session and each move would re-queue a ~20-minute gate for every open PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,12 +170,18 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   CODE, and the declaration is load-bearing.** `bp_declared_off_reason()` in
   `scripts/drift-check.sh` names this repo with the reason above, so rc 24 fires on
   DISAGREEMENT rather than on the bare state: declared-off/live-off is printed plainly and
-  sets no code (it exited 24 on every 6-hourly fire before that — 5 DND-bypassing toasts in
-  3 days), while an UNDECLARED unprotected `main` is still the alarm, unchanged. 🔴 **When
-  protection is restored, DELETE that arm in the same change** — a declaration left saying
-  "off" over a live gate DISARMS rc 24, which is `drift-check.sh` rc 25 and toasts until it
-  is removed. The declaration is deliberately not env-overridable and has no ledger path: a
-  run must not be able to excuse itself.
+  sets no code, while an UNDECLARED unprotected `main` is still the alarm, unchanged. (The
+  measured breach rate against the DND-bypass justification is stated ONCE, in
+  `nix/home.nix`'s `zz_notify_failure_bypass` block — do not restate it; it was wrong at
+  every copy.) 🔴 **When protection is restored, DELETE that arm in the same change** — a
+  declaration left saying "off" over a live gate DISARMS rc 24, which is `drift-check.sh`
+  rc 25 and toasts until it is removed. **A PARTIAL restore fires rc 25 too**: put the
+  required checks back and omit `enforce_admins` — the exact shape step 4 below warns a
+  partial `PUT` produces — and the checks existing again is evidence the declaration is
+  stale, so it is a finding rather than agreement. The declaration is deliberately not
+  env-overridable and has no ledger path: a run must not be able to excuse itself. ⚠ The
+  SUBJECT can still be redirected (`DRIFT_PROTECT_SLUG`), but the run prints the slug it
+  asked about, so that silence names a repo nobody chose.
   ⚠ **Tekton still RUNS** — both checks post on a PR head, they just do not gate. That is
   exactly why the marker stays `other`: it records that something runs at merge time, never
   that it blocks. There is still no `.github/workflows`.
@@ -232,10 +238,13 @@ Repo-level facts that are NOT in any skill — they live here on purpose:
   lags by up to a full interval, and only where the deadman is actually wired in
   (`serverMode && enableDriftDeadman`; the timer runs on the workbench). It catches a
   botched restore after the fact; it does not undo one, and it is not a substitute for
-  step 4. ⚠ **And it is only armed for a repo whose declared expectation is ON** — while
-  the arm above declares this repo's gate off, a botched restore lands in the same cell as
-  the intended state and passes silently. That is the price of the declaration, and it is
-  why deleting the arm is part of restoring protection rather than a follow-up.
+  step 4. ⚠ **And while this repo's gate is DECLARED off, rc 24 cannot fire for it** — a
+  restore that is later undone lands in the same cell as the intended state. Two things
+  narrow that: a PARTIAL restore (checks back, `enforce_admins` dropped — the failure step 4
+  exists for) fires **rc 25**, not silence; and a completed restore fires rc 25 until the
+  declaration is deleted. What is genuinely uncovered is a full restore, the declaration
+  deleted, and a *later* deletion — which is ordinary rc 24 again. Deleting the arm is part
+  of restoring protection, not a follow-up.
   ⚠ **`strict` is FALSE on purpose.** `strict: true` would force every PR to be up to date
   with `main` before merging — correct in principle, and unworkable here: `main` moved 11+
   times in one session and each move would re-queue a ~20-minute gate for every open PR.

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -539,15 +539,36 @@ in
       # opt-in subset — justified by the measured firing rate (7 activations in
       # ~6 months of laptop journal, 1 in 9 days of workbench journal), which is
       # far too low to make DND feel broken.
-      # ⚠ THAT RATE IS A MEASUREMENT WITH A DATE, AND IT HAS BEEN BREACHED ONCE.
-      # 2026-08-30..09-02: drift-check.service exited 24 on every 6-hourly fire —
-      # 5 failures in 3 days through this rule — because the branch-protection
-      # arm reported a merge gate the operator had deliberately turned off. The
-      # justification above is what the breach was measured AGAINST, not
-      # something the breach retired; it was closed in the SCRIPT (see the rc 24 /
-      # rc 25 note in the drift-check block below), not by narrowing this rule.
-      # Anything wired to OnFailure=notify-failure@ inherits this bypass, so a
-      # unit that can fail on a standing condition breaches it again.
+      #
+      # 🔴 THAT RATE IS A MEASUREMENT WITH A DATE, IT IS CURRENTLY BREACHED BY
+      # ~32×, AND THIS IS THE ONE PLACE THE ARITHMETIC IS STATED. Measured from
+      # `journalctl --user -u drift-check.service`, 2026-08-25..2026-09-03:
+      #   32 unit failures in 9 days — every one of them through THIS rule —
+      #   against a justification of ~1 firing in 9 days. That is 32×, not the
+      #   "three orders of magnitude" an earlier wording claimed at three
+      #   different sites; 4/day against 1-per-9-days is 36× (~1.6 orders), and
+      #   no restatement of it was ever right. Verdicts in that window:
+      #   rc 10 ×13, rc 17 ×11, rc 24 ×5, rc 12 ×2, rc 8 ×1.
+      # Do not restate this number elsewhere — point here. It was wrong at every
+      # copy, in both directions, and a figure nobody can locate is a figure
+      # nobody re-measures.
+      #
+      # 🔴 AND THE BREACH IS NOT CLOSED. The rc-24 arm (see the drift-check block
+      # below) was the STRUCTURALLY PERMANENT contributor — the one finding that
+      # could never be repaired because nobody intended to repair it — and it is
+      # fixed. It was not the only one: rc 24 was the verdict on only 5 of those
+      # 32 runs, all inside a single 24-hour span, and on all 5 at least one other
+      # DRIFT finding was co-present (`local main is BEHIND` on 5 of 5, `BUILT
+      # SOURCE homelab-talos/containers/clawgate is NOT current` on 4 of 5).
+      # Removing rc 24 lowers those runs to rc 17 or rc 10 — still non-zero, still
+      # OnFailure, still a toast through this rule, still ~4×/day. 🔴 A reader who
+      # stops here concludes the breach was closed and stops looking, which is the
+      # exact "learns to ignore the one alert that must keep its meaning" outcome
+      # this rule's scope argument exists to prevent. rc 17 and rc 10 on this
+      # fleet are a separate, still-open job.
+      #
+      # Anything wired to OnFailure=notify-failure@ inherits this bypass, so any
+      # unit that can fail on a STANDING condition breaches it again.
       # Deliberately NOT keyed on
       # `urgency = critical`: other tools send critical toasts, and those must
       # still respect DND.
@@ -2893,28 +2914,49 @@ in
   # 🔴 rc 24 AND rc 25 DO TOAST, AND rc 24 IS THE THIRD WAY INTO THE SAME
   # HAZARD — reached, this time, by a finding that was TRUE. This ledger did not
   # list rc 24 when it landed, and that omission is what let the following
-  # happen. MEASURED 2026-09-02: the branch-protection arm exited 24 on every
-  # fire (5 failures in 3 days, `Result=exit-code`, `ExecMainStatus=24`) because
-  # the merge gate on innovation-upstream/devrc is off — DELIBERATELY, until the
-  # Tekton capacity issue is addressed, which a different session owns. A true
-  # finding about a state nobody intends to change is a permanently-red gate
-  # exactly like a false one, and at 4×/day it is three orders of magnitude past
-  # the ~1-in-9-days rate this file uses to justify the DND bypass.
+  # happen. MEASURED 2026-09-02 (`Result=exit-code`, `ExecMainStatus=24`): the
+  # merge gate on innovation-upstream/devrc is off — DELIBERATELY, until the
+  # Tekton capacity issue is addressed, which a different session owns — and the
+  # arm reported it as drift on every run that reached it. A true finding about a
+  # state nobody intends to change is a permanently-red gate exactly like a false
+  # one. The breach arithmetic against the DND-bypass justification is stated
+  # ONCE, in the `zz_notify_failure_bypass` block above; do not restate it here.
+  #
+  # ⚠ AND FIXING THIS DOES NOT STOP THE TOASTS ON THIS HOST. rc 24 was the
+  # verdict on only 5 of the 32 failures in that window, and every one of those 5
+  # had another DRIFT finding co-present, so they now land on rc 17 or rc 10 —
+  # still non-zero, still OnFailure. What is closed is the contributor that could
+  # never be repaired, not the rate. See the block above.
   #
   # 🔴 THE FIX IS NOT SuccessExitStatus, AND THAT IS WHY THIS PIN STILL READS 16
   # ALONE. Excusing rc 24 would silence the only thing that catches a BOTCHED
   # BREAK-GLASS RESTORE — the 2026-08-29 shape where DELETE opened the window,
   # the restore trap RAN, and PATCH could not close it. So the SCRIPT changed
   # instead: `bp_declared_off_reason()` in drift-check.sh declares the expected
-  # state per repo, in reviewable source that no environment can flip, and rc 24
+  # state per repo, in reviewable source no environment can flip (the SUBJECT can
+  # still be redirected with DRIFT_PROTECT_SLUG — but the run prints the slug it
+  # asked about, so that silence names a repo the operator never chose; see the
+  # script's header), and rc 24
   # now fires on DISAGREEMENT — declared-off/live-off is reported plainly and
-  # sets no code, while declared-on/live-off is the alarm, unchanged. rc 25 is
+  # sets no code, while declared-on/live-off is the alarm, unchanged. A PARTIAL
+  # restore (required checks back, enforce_admins still false) is rc 25, not
+  # agreement: the checks existing again is evidence the declaration is stale,
+  # and that is the exact state a partial PUT produces. rc 25 is
   # the mirror: declared OFF, live ON, i.e. the declaration has gone stale and
   # rc 24 is DISARMED by it. Both are real divergences with real fixes (restore
   # the protection; delete the declaration), so both must reach OnFailure, and
   # the excuse list stays at exactly one code. rc 25 has no escalation ladder on
   # purpose — its repair is a one-line edit by whoever restored the protection,
-  # so unlike rc 13/16/18 it is closable the moment it is seen.
+  # so unlike the LADDER codes rc 13/18/23 it is closable the moment it is seen.
+  # (rc 13 = DRIFT_UNREACHABLE_ESCALATE, rc 18 = DRIFT_UNMEASURED_ESCALATE and
+  # _FETCH_ESCALATE, rc 23 = DRIFT_NIXDIRT_ESCALATE. An earlier wording named
+  # "rc 13/16/18" here: rc 16 has NO ladder and is the single code on
+  # SuccessExitStatus, so naming it muddled the very paragraph arguing about the
+  # excuse list, and it disagreed with drift-check.sh's own correct list.)
+  # ⚠ The unit's ExecStart is `%h/workspace/devrc/scripts/drift-check.sh` — the
+  # WORKING TREE — so that one-line repair takes effect on a merge + pull and
+  # needs no home-manager switch. The X-Restart-Triggers below only re-run the
+  # unit; they are not what makes the edit live.
   #
   # 🔴 AND IT DOES NOT MOVE TimeoutStartSec. The budget below is a function of
   # what the script FETCHES; the rc 18 ladder adds no fetch and no ssh — it reads

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -2988,10 +2988,11 @@ in
       # the readers, and the timer runs every 6h — so the DND-bypassing alert
       # would fire 4× a day, forever, on a run where nothing is wrong. The DND
       # bypass is justified in this file by a MEASURED rate of ~1 firing in 9
-      # days; 4/day is three orders of magnitude past that, and it is exactly
-      # the "permanently-red gate trains you to click through the one alert that
-      # must keep its meaning" hazard the unreachable-remote note below already
-      # refuses. The script's own header refuses it for rc 13 for the same
+      # days — see the `zz_notify_failure_bypass` block for that measurement and
+      # the arithmetic against it, which is stated ONCE and nowhere else. This is
+      # exactly the "permanently-red gate trains you to click through the one
+      # alert that must keep its meaning" hazard the unreachable-remote note
+      # below already refuses. The script's own header refuses it for rc 13 for the same
       # reason. Correct about a printed LINE, wrong about an EXIT CODE.
       #
       # NOTHING IS HIDDEN. The script still exits 16, still prints the

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -538,7 +538,17 @@ in
       # `notify-send -a notify-failure`. That is ALL unit-failure toasts, not an
       # opt-in subset — justified by the measured firing rate (7 activations in
       # ~6 months of laptop journal, 1 in 9 days of workbench journal), which is
-      # far too low to make DND feel broken. Deliberately NOT keyed on
+      # far too low to make DND feel broken.
+      # ⚠ THAT RATE IS A MEASUREMENT WITH A DATE, AND IT HAS BEEN BREACHED ONCE.
+      # 2026-08-30..09-02: drift-check.service exited 24 on every 6-hourly fire —
+      # 5 failures in 3 days through this rule — because the branch-protection
+      # arm reported a merge gate the operator had deliberately turned off. The
+      # justification above is what the breach was measured AGAINST, not
+      # something the breach retired; it was closed in the SCRIPT (see the rc 24 /
+      # rc 25 note in the drift-check block below), not by narrowing this rule.
+      # Anything wired to OnFailure=notify-failure@ inherits this bypass, so a
+      # unit that can fail on a standing condition breaches it again.
+      # Deliberately NOT keyed on
       # `urgency = critical`: other tools send critical toasts, and those must
       # still respect DND.
       zz_notify_failure_bypass = {
@@ -2879,6 +2889,32 @@ in
   # 17 it is a real divergence with a real fix, so it is NOT excused on
   # SuccessExitStatus (which `test_only_16_is_excused_from_failing_the_unit`
   # pins to exactly one code).
+  #
+  # 🔴 rc 24 AND rc 25 DO TOAST, AND rc 24 IS THE THIRD WAY INTO THE SAME
+  # HAZARD — reached, this time, by a finding that was TRUE. This ledger did not
+  # list rc 24 when it landed, and that omission is what let the following
+  # happen. MEASURED 2026-09-02: the branch-protection arm exited 24 on every
+  # fire (5 failures in 3 days, `Result=exit-code`, `ExecMainStatus=24`) because
+  # the merge gate on innovation-upstream/devrc is off — DELIBERATELY, until the
+  # Tekton capacity issue is addressed, which a different session owns. A true
+  # finding about a state nobody intends to change is a permanently-red gate
+  # exactly like a false one, and at 4×/day it is three orders of magnitude past
+  # the ~1-in-9-days rate this file uses to justify the DND bypass.
+  #
+  # 🔴 THE FIX IS NOT SuccessExitStatus, AND THAT IS WHY THIS PIN STILL READS 16
+  # ALONE. Excusing rc 24 would silence the only thing that catches a BOTCHED
+  # BREAK-GLASS RESTORE — the 2026-08-29 shape where DELETE opened the window,
+  # the restore trap RAN, and PATCH could not close it. So the SCRIPT changed
+  # instead: `bp_declared_off_reason()` in drift-check.sh declares the expected
+  # state per repo, in reviewable source that no environment can flip, and rc 24
+  # now fires on DISAGREEMENT — declared-off/live-off is reported plainly and
+  # sets no code, while declared-on/live-off is the alarm, unchanged. rc 25 is
+  # the mirror: declared OFF, live ON, i.e. the declaration has gone stale and
+  # rc 24 is DISARMED by it. Both are real divergences with real fixes (restore
+  # the protection; delete the declaration), so both must reach OnFailure, and
+  # the excuse list stays at exactly one code. rc 25 has no escalation ladder on
+  # purpose — its repair is a one-line edit by whoever restored the protection,
+  # so unlike rc 13/16/18 it is closable the moment it is seen.
   #
   # 🔴 AND IT DOES NOT MOVE TimeoutStartSec. The budget below is a function of
   # what the script FETCHES; the rc 18 ladder adds no fetch and no ssh — it reads

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -2951,6 +2951,16 @@ bp_slug_of() { # bp_slug_of <remote-url> -> owner/repo, or "" if not GitHub
 # 🔴 NOT ENV-OVERRIDABLE, and neither is a path to it. The whole point of a
 # declaration is that the run cannot write it. See the header.
 #
+# ⚠ WHAT "OFF" MEANS HERE IS NARROWER THAN THE WORD. The verdict block excuses a
+# declared-off gate only while NOTHING has re-established one; an OFF state that
+# carries evidence somebody did — required checks back with enforce_admins false,
+# or an ACTIVE ruleset listing a check but with bypass actors — is rc 25, not
+# agreement. So a repo whose HALF-gate is deliberate (checks present, admins
+# knowingly unbound) cannot be silenced by this list: it would be permanently
+# rc 25. That is latent — no such repo exists today — and it is gated by the
+# two-way ledger in the suite, which forces any second entry through a human
+# diff where this note is one line up. Do not build for it; do read this first.
+#
 # Written as `if [ "$1" = <slug> ]` rather than a `case`, for the same reason
 # perhost_reason below is: the suite's reverse PATH tokenizer reads a lowercase
 # `case` ARM LABEL as a command word, and putting the slug in ARGUMENT position

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -521,10 +521,21 @@
 # a different session owns. A checker that keys on the bare state fires on every
 # 6-hourly run for as long as that decision stands: `drift-check.service`'s
 # OnFailure is `notify-failure@`, the ONE toast class deliberately wired to bypass
-# do-not-disturb, and nix/home.nix justifies that bypass by a MEASURED rate of ~1
-# firing in 9 days. 5 failures in 3 days is three orders of magnitude past it, and
-# the outcome is not "the operator is informed" — it is the operator learning to
-# ignore the one alert that has to keep its meaning.
+# do-not-disturb. The measured breach rate and the arithmetic against the rate
+# that justifies that bypass are stated ONCE, in nix/home.nix's
+# `zz_notify_failure_bypass` block — the same number lived at three sites and was
+# wrong at all three. The outcome is not "the operator is informed"; it is the
+# operator learning to ignore the one alert that has to keep its meaning.
+#
+# ⚠ AND THIS CHANGE DOES NOT MAKE THE TOASTS STOP ON THIS HOST. Measured from
+# `journalctl --user -u drift-check.service`, 2026-08-25..09-03: 32 unit failures
+# in 9 days, of which rc 24 was the VERDICT on exactly 5 — all inside one 24-hour
+# span — and on all 5 at least one other DRIFT finding was co-present (`local main
+# is BEHIND` on 5 of 5, `BUILT SOURCE … is NOT current` on 4 of 5). Removing rc 24
+# lowers those runs to rc 17 or rc 10: still non-zero, still OnFailure, still the
+# DND-bypassing toast. What this closes is the STRUCTURALLY PERMANENT contributor
+# — the one finding that could never be repaired because nobody intended to —
+# not the toast rate, which is owned by rc 17 and rc 10 and is a separate job.
 #
 # 🔴 AND EXCUSING IT IS NOT THE FIX EITHER, because rc 24 is the only thing that
 # catches a BOTCHED BREAK-GLASS RESTORE — the measured 2026-08-29 shape, where
@@ -535,6 +546,9 @@
 #   declared ON,  live OFF  ->  rc 24. The botched-restore alarm, preserved whole.
 #   declared ON,  live ON   ->  no code. The gate is up.
 #   declared OFF, live OFF  ->  no code. Reported plainly, as an intended state.
+#                               EXCEPT a PARTIAL restore (required checks back,
+#                               enforce_admins false) -> rc 25; see the verdict
+#                               block for why that is staleness, not agreement.
 #   declared OFF, live ON   ->  rc 25. The declaration is stale, and a stale
 #                               "off" DISARMS rc 24 — see the code list above.
 #   gh cannot answer        ->  COULD NOT MEASURE, no code, unchanged. A
@@ -553,11 +567,24 @@
 # path either. It is `bp_declared_off_reason` and nothing else, which means the
 # only way to disarm this arm is a diff a human reviews.
 #
-# ⚠ DRIFT_PROTECT_SLUG is NOT that hole, and the distinction matters. It changes
-# WHICH repo is asked about, never what is expected of it: point it anywhere and
-# the answer is still read out of the enumeration, and an unenumerated slug is
-# expected ON. It cannot turn a finding off — it can only ask a different
-# question, which is why the suite is allowed to have it.
+# ⚠ DRIFT_PROTECT_SLUG IS A DIFFERENT HOLE, AND AN EARLIER REVISION OF THIS
+# PARAGRAPH DENIED IT EXISTED. It said the variable "cannot turn a finding off".
+# That is FALSE and was demonstrated: point the arm at a repo whose main IS gated
+# and the run exits 0 with `expected ON … and live ON`, under exactly the "a unit
+# file, a shell profile or a stray export" threat model used three lines above to
+# reject a hypothetical DRIFT_PROTECT_EXPECT. An env var can silence this alarm.
+#
+# The defensible distinction is a narrower one, and it is the reason the suite is
+# allowed to have this variable: the run PRINTS THE SLUG IT ASKED ABOUT, on every
+# line of the finding and of the pass. So a silence produced this way is NOT
+# indistinguishable from a real pass — the journal names a subject the operator
+# never chose, which is the tell. An EXPECTATION override would leave the correct
+# subject in place and change only the verdict, and nothing in the output would
+# differ from a healthy run. Redirecting the subject is loud; flipping the
+# expectation is silent. That is the whole of it — not that one is harmless.
+#
+# It is also not forwarded over the ssh hop (the arm runs in the driver only),
+# so it cannot be used to make the far host lie about a repo.
 #
 # ⚠ KNOWN AND ACCEPTED: rc 25 has NO escalation ladder — it fires on the first
 # run that sees the disagreement, unlike rc 13/18/23. That is deliberate and it
@@ -565,7 +592,7 @@
 # declaration is never a state anybody has decided to keep, and closing it is a
 # one-line edit to the enumeration below by whoever restored the protection. An
 # alarm whose repair is in the operator's hand and takes a minute is closable;
-# the 4x/day toast it can produce lasts exactly as long as they leave it.
+# the toast it can produce lasts exactly as long as they leave it.
 #
 # ── UNREACHABLE IS NOT DRIFT (the alerting policy) ────────────────────────────
 # 🔴 The timer runs on the WORKBENCH ONLY (gated on the ~/.server-mode marker in
@@ -3190,19 +3217,35 @@ elif [ -z "$BP_EXPECT_WHY" ]; then
     # reads a lowercase `case` ARM LABEL as a command word, so `enforce-admins)`
     # arrives at test_the_unit_path_table_accounts_for_every_command_the_scripts_run
     # as a binary nobody can name. Same reason perhost_reason is spelled this way.
+    #
+    # 🔴 EVERY OFF KIND IS BRANCHED ON EXPLICITLY, INCLUDING THE LAST ONE. An
+    # earlier revision let `classic-zero` fall through to a bare
+    # `[ "$BP_PROT" = true ]` heuristic, which made the value DEAD: deleting the
+    # assignment changed nothing, and a mutation that removed it SURVIVED the
+    # whole suite. Harmless for the three kinds that exist — and exactly how a
+    # FOURTH kind, added later, would silently inherit break-glass repair text
+    # written for a state it is not in. The `*` arm below is a refusal, not a
+    # default. Pinned two-way by
+    # test_every_BP_OFF_KIND_assigned_is_branched_on_in_the_verdict.
     if [ "$BP_OFF_KIND" = enforce-admins ]; then
       echo "[protect]   fix: PUT /repos/$BP_SLUG/branches/main/protection with enforce_admins true."
     elif [ "$BP_OFF_KIND" = ruleset-nonbinding ]; then
       echo "[protect]   fix: set enforcement=active and remove the bypass actors on one of them."
-    elif [ "$BP_PROT" = true ]; then
-      echo "[protect]   protected=true: the protection object stands and required_status_checks"
-      echo "[protect]   was deleted out of it — the exact break-glass shape. 🔴 PATCH CANNOT"
-      echo "[protect]   restore it; it returns non-zero and changes nothing. Use a full PUT of"
-      echo "[protect]   /repos/$BP_SLUG/branches/main/protection, then READ IT BACK — a restore"
-      echo "[protect]   that has never been run is a hypothesis, and that is how this was missed."
+    elif [ "$BP_OFF_KIND" = classic-zero ]; then
+      if [ "$BP_PROT" = true ]; then
+        echo "[protect]   protected=true: the protection object stands and required_status_checks"
+        echo "[protect]   was deleted out of it — the exact break-glass shape. 🔴 PATCH CANNOT"
+        echo "[protect]   restore it; it returns non-zero and changes nothing. Use a full PUT of"
+        echo "[protect]   /repos/$BP_SLUG/branches/main/protection, then READ IT BACK — a restore"
+        echo "[protect]   that has never been run is a hypothesis, and that is how this was missed."
+      else
+        echo "[protect]   protected=false: there is no protection object at all, so this is a"
+        echo "[protect]   create rather than a restore. Same endpoint, full PUT, read it back."
+      fi
     else
-      echo "[protect]   protected=false: there is no protection object at all, so this is a"
-      echo "[protect]   create rather than a restore. Same endpoint, full PUT, read it back."
+      echo "[protect]   ⚠ NO SPECIFIC REPAIR — this run measured an OFF kind ('$BP_OFF_KIND')"
+      echo "[protect]   the verdict block does not know, so it will not guess one. Read the"
+      echo "[protect]   live state below and add the kind to the chain in drift-check.sh."
     fi
     # 🔴 The DIAGNOSTIC must be runnable in the state it is printed in. The
     # protection endpoint 404s with `Branch not protected` exactly when
@@ -3221,25 +3264,70 @@ elif [ -z "$BP_EXPECT_WHY" ]; then
   fi
 else
   # Declared OFF in bp_declared_off_reason(), in this file, in a diff a human read.
-  if [ "$BP_LIVE" = off ]; then
+  #
+  # 🔴 A PARTIAL RESTORE IS A STALE DECLARATION, NOT AGREEMENT — and reading it
+  # as agreement was a REGRESSION this arm shipped with. `enforce-admins` means
+  # required status checks EXIST again on this repo's own protection object and
+  # only admin enforcement is missing. The declared state is the one where those
+  # checks were DELETED; checks being back is positive evidence that somebody has
+  # started restoring, so the declaration no longer describes reality.
+  #
+  # 🔴 IT IS ALSO THE FAILURE MODE devrc/CLAUDE.md DOCUMENTS AS MEASURED: a
+  # partial `PUT …/branches/main/protection` silently drops every key it omits,
+  # `enforce_admins` among them. Restore-with-omission then lands on exactly this
+  # state, and reading it as agreement means NO toast, so nobody deletes the
+  # declaration and rc 24 stays disarmed over a half-restored gate indefinitely.
+  # Before the declaration existed, that same state fired rc 24.
+  #
+  # ⚠ `ruleset-nonbinding` deliberately does NOT get this treatment, and the
+  # asymmetry is argued rather than convenient. `/rules/branches/main` returns the
+  # rules of EVERY applying ruleset, repo- and ORG-level mixed (see the loop
+  # above), and an org ruleset parked in `evaluate` mode is the standard org
+  # rollout pattern — nothing this repo created and nothing its operator can
+  # remove. Firing rc 25 on it would be a permanently-red gate on a state nobody
+  # can close, which is the one thing this arm refuses everywhere else. It stays
+  # in the agreement cell and converts to rc 25 the moment any ruleset actually
+  # BINDS (BP_LIVE=on).
+  # ⚠ KNOWN BOUND, stated rather than hidden: a REPO-level ruleset the operator
+  # created and left in evaluate mode is indistinguishable from the org case at
+  # the endpoint this arm reads, so it too stays quiet. `ruleset_source_type` on
+  # /rules/branches/main is the field that would separate them; it is not read
+  # today, and closing this needs that read plus its own tests.
+  if [ "$BP_LIVE" = off ] && [ "$BP_OFF_KIND" != enforce-admins ]; then
     echo "[protect] DECLARED OFF, and live OFF — expectation and reality agree. No rc is set."
     echo "[protect]   why: $BP_EXPECT_WHY"
-    echo "[protect]   🔴 The alarm is QUIET, not DISABLED: it fires the moment the two disagree."
-    echo "[protect]   Restore protection and this becomes rc 25 until the declaration is deleted."
+    echo "[protect]   🔴 The alarm is QUIET, not DISABLED. It fires as rc 25 as soon as the"
+    echo "[protect]   gate is re-established — including a PARTIAL restore that puts the"
+    echo "[protect]   required checks back and omits enforce_admins."
     echo "[protect]   ⚠ Nothing gates a merge to $BP_SLUG main while this stands — run both"
     echo "[protect]   tiers of the gate yourself, on the MERGED tree, and name the base sha."
   else
     echo "[protect] 🔴 DRIFT — STALE DECLARATION. drift-check.sh declares the merge gate on"
-    echo "[protect]   $BP_SLUG main OFF, and it is LIVE ON."
+    if [ "$BP_OFF_KIND" = enforce-admins ]; then
+      echo "[protect]   $BP_SLUG main OFF, and its required status checks are BACK — a PARTIAL"
+      echo "[protect]   restore, with enforce_admins still FALSE. The declared state was the one"
+      echo "[protect]   where those checks had been DELETED; they exist again, so the"
+      echo "[protect]   declaration no longer describes this repo. 🔴 This is the shape a"
+      echo "[protect]   partial PUT produces — it silently drops every key it omits — and"
+      echo "[protect]   before the declaration existed it fired rc 24."
+      echo "[protect]   fix, BOTH halves: PUT the WHOLE protection object with enforce_admins"
+      echo "[protect]   true and read it back, AND delete the $BP_SLUG arm from"
+      echo "[protect]   bp_declared_off_reason(). Finishing one and not the other leaves this"
+      echo "[protect]   red (checks half-bound) or silent (declaration stale) respectively."
+    else
+      echo "[protect]   $BP_SLUG main OFF, and it is LIVE ON."
+      echo "[protect]   fix: delete the $BP_SLUG arm from bp_declared_off_reason() in"
+      echo "[protect]   scripts/drift-check.sh, and correct any prose that still says the gate is"
+      echo "[protect]   off (devrc/CLAUDE.md carries such a paragraph). It is a one-line edit."
+    fi
     echo "[protect]   declared: $BP_EXPECT_WHY"
     echo "[protect]   🔴 This DISARMS rc 24. While the declaration stands, a gate that is"
     echo "[protect]   removed again — the measured 2026-08-29 break-glass shape, where DELETE"
     echo "[protect]   opened the window and PATCH could not close it — passes SILENTLY, because"
     echo "[protect]   declared-off/live-off is exactly the cell above this one. Nothing is lost"
     echo "[protect]   yet; what is lost is the ability to notice when it next goes down."
-    echo "[protect]   fix: delete the $BP_SLUG arm from bp_declared_off_reason() in"
-    echo "[protect]   scripts/drift-check.sh, and correct any prose that still says the gate is"
-    echo "[protect]   off (devrc/CLAUDE.md carries such a paragraph). It is a one-line edit."
+    echo "[protect]   ⚠ The unit runs the WORKING TREE (%h/workspace/devrc/scripts/drift-check.sh),"
+    echo "[protect]   so that edit takes effect on a merge + pull — no home-manager switch."
     echo "[protect]   read the live state: gh api /repos/$BP_SLUG/branches/main/protection"
     note_rc 25
   fi

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -97,7 +97,8 @@
 #   * 19, 20 and 21 are RESERVED to ship.sh here and must not be taken as DRIFT
 #     codes. 22 is now TAKEN by this script (skillOverrides disagree with the
 #     tier ledger), 23 by the nix-read untracked ladder and 24 by the
-#     branch-protection arm, so the next free code for this script is 25.
+#     branch-protection arm, and 25 by the stale-protection-declaration arm, so
+#     the next free code for this script is 26.
 #   * anything this script adds above 21 is reserved back the other way; ship.sh
 #     documents this in its own header for the same reason.
 #
@@ -166,14 +167,26 @@
 #       artifact by the next switch. Measured 2026-08-25: one such file had sat
 #       on the workbench for ~3 weeks with every check green. See "UNTRACKED IN A
 #       NIX-READ PATH" below. It ranks between rc 15 and rc 12 — see severity().
-#   24  DRIFT — `main` ON THE CANONICAL REMOTE HAS NO REQUIRED STATUS CHECKS, so
-#       the gate every change to this fleet passes through is OFF. 🔴 The FOURTH
-#       kind of parity, and the first three are all blind to it: they ask whether
-#       the two hosts match `origin/main`, and this asks whether `origin/main` is
-#       still a thing worth matching. Both hosts can be byte-identical, every
-#       symlink resolve, every built source be current — and `main` be a branch
-#       anyone can push anything to. See "BRANCH PROTECTION" below. It ranks
-#       between rc 8 and rc 17 — see severity().
+#   24  DRIFT — `main` ON THE CANONICAL REMOTE HAS NO REQUIRED STATUS CHECKS
+#       WHILE THIS SCRIPT DECLARES THAT IT SHOULD, so the gate every change to
+#       this fleet passes through is OFF and nobody said it should be. 🔴 The
+#       FOURTH kind of parity, and the first three are all blind to it: they ask
+#       whether the two hosts match `origin/main`, and this asks whether
+#       `origin/main` is still a thing worth matching. Both hosts can be
+#       byte-identical, every symlink resolve, every built source be current —
+#       and `main` be a branch anyone can push anything to. 🔴 IT IS A
+#       DISAGREEMENT, NOT A BARE STATE: a gate the operator has DECLARED off (see
+#       bp_declared_off_reason) is reported and sets no code. See "BRANCH
+#       PROTECTION" below. It ranks between rc 8 and rc 17 — see severity().
+#   25  DRIFT — THE DECLARATION IS STALE: this script declares the merge gate on
+#       `main` OFF and it is LIVE ON. Not the same hazard as rc 24 and not its
+#       inverse — it is the rc-24 ALARM ITSELF BEING DISARMED. While the
+#       declaration says "off", an rc-24 finding is excused by construction, so a
+#       protection object that is removed again — the measured 2026-08-29
+#       break-glass shape — passes SILENTLY. The gate is up, nothing is lost yet,
+#       and the detector for the second-most-severe code in this table is
+#       switched off. See "THE DECLARED EXPECTATION" below. It ranks between rc 17
+#       and rc 14 — see severity().
 #   16  ACTIONABLE, not drift — the fuzzyclaw PHASE-2 GATE has OPENED: zero rows
 #       still take their `age_secs` from fuzzyclaw alone, so the readers can be
 #       removed. See "THE FUZZYCLAW PHASE-2 GATE" below. It is the LEAST severe
@@ -499,6 +512,61 @@
 # left main unprotected despite a restore trap that ran: the rollback path had
 # never been executed once.
 #
+# ── THE DECLARED EXPECTATION (rc 24 / rc 25) ──────────────────────────────────
+# 🔴 THE ARM FIRES ON DISAGREEMENT, NOT ON THE BARE STATE. Measured 2026-09-02:
+# `required_status_checks` is absent from the protection object and
+# `enforce_admins` is false on innovation-upstream/devrc — and that is a DECISION,
+# not drift. The operator turned the Tekton merge gate off because it was slowing
+# work down, and it stays off until the Tekton capacity issue is addressed, which
+# a different session owns. A checker that keys on the bare state fires on every
+# 6-hourly run for as long as that decision stands: `drift-check.service`'s
+# OnFailure is `notify-failure@`, the ONE toast class deliberately wired to bypass
+# do-not-disturb, and nix/home.nix justifies that bypass by a MEASURED rate of ~1
+# firing in 9 days. 5 failures in 3 days is three orders of magnitude past it, and
+# the outcome is not "the operator is informed" — it is the operator learning to
+# ignore the one alert that has to keep its meaning.
+#
+# 🔴 AND EXCUSING IT IS NOT THE FIX EITHER, because rc 24 is the only thing that
+# catches a BOTCHED BREAK-GLASS RESTORE — the measured 2026-08-29 shape, where
+# DELETE opened the window, the restore trap RAN, and `PATCH` could not close it.
+# devrc/CLAUDE.md calls this arm "a DETECTOR, not a restore". So the expectation
+# is DECLARED, and the alarm fires on the delta:
+#
+#   declared ON,  live OFF  ->  rc 24. The botched-restore alarm, preserved whole.
+#   declared ON,  live ON   ->  no code. The gate is up.
+#   declared OFF, live OFF  ->  no code. Reported plainly, as an intended state.
+#   declared OFF, live ON   ->  rc 25. The declaration is stale, and a stale
+#                               "off" DISARMS rc 24 — see the code list above.
+#   gh cannot answer        ->  COULD NOT MEASURE, no code, unchanged. A
+#                               reassuring zero here is still the failure mode.
+#
+# 🔴 THE DECLARATION LIVES IN THIS FILE, AND IT IS NOT ENV-OVERRIDABLE. Same
+# reasoning, and the same shape, as the settings.json per-host allowlist below:
+# an enumeration of literal `if [ "$1" = <slug> ]` arms, each carrying its own
+# reason, that FAILS CLOSED — a slug nobody has argued about gets no reason and
+# is therefore expected ON. A `DRIFT_PROTECT_EXPECT` variable would let a unit
+# file, a shell profile or a stray export declare the gate off from outside
+# review, and the resulting silence would be indistinguishable from a real pass:
+# the run would be excused by the very environment it is supposed to police. A
+# FILE PATH override is the same hole one level out — pointing the arm at a
+# different ledger flips the expectation just as completely — so there is no
+# path either. It is `bp_declared_off_reason` and nothing else, which means the
+# only way to disarm this arm is a diff a human reviews.
+#
+# ⚠ DRIFT_PROTECT_SLUG is NOT that hole, and the distinction matters. It changes
+# WHICH repo is asked about, never what is expected of it: point it anywhere and
+# the answer is still read out of the enumeration, and an unenumerated slug is
+# expected ON. It cannot turn a finding off — it can only ask a different
+# question, which is why the suite is allowed to have it.
+#
+# ⚠ KNOWN AND ACCEPTED: rc 25 has NO escalation ladder — it fires on the first
+# run that sees the disagreement, unlike rc 13/18/23. That is deliberate and it
+# is the trade this arm makes: unlike the state rc 24 now excuses, a stale
+# declaration is never a state anybody has decided to keep, and closing it is a
+# one-line edit to the enumeration below by whoever restored the protection. An
+# alarm whose repair is in the operator's hand and takes a minute is closable;
+# the 4x/day toast it can produce lasts exactly as long as they leave it.
+#
 # ── UNREACHABLE IS NOT DRIFT (the alerting policy) ────────────────────────────
 # 🔴 The timer runs on the WORKBENCH ONLY (gated on the ~/.server-mode marker in
 # nix/home.nix), so its remote leg always ssh's to the LAPTOP — a machine that is
@@ -524,18 +592,19 @@
 # is reading a timer's output, so the single number it hands to systemd must be
 # the worst thing found, or an un-pushed workbench could hide behind a merely
 # behind laptop. Severity order (worst first):
-#     8 > 24 > 17 > 14 > 13 > 18 > 6 > 2 > 4 > 3 > 12 > 23 > 15 > 10 > 22 > 16
+#     8 > 24 > 17 > 25 > 14 > 13 > 18 > 6 > 2 > 4 > 3 > 12 > 23 > 15 > 10 > 22 > 16
 # 🔴 THAT ORDER IS THE severity() TABLE, NOT THE DIGITS — it never was monotonic
 # (14 outranks 13 outranks 18 outranks 6 outranks 4), 17 is not "less severe
 # than 16" because it is larger, 23 outranks 15 while 22 ranks second-LAST, and
-# 24 — the LARGEST digit here — ranks SECOND, directly under rc 8. Reading this
-# ladder off the numbers gets that one exactly backwards. Every code below 16
+# 24 — the LARGEST digit here — ranks SECOND, directly under rc 8, while 25 —
+# larger still — ranks FOURTH. Reading this ladder off the numbers gets both of
+# those exactly backwards. Every code below 16
 # that is still free (5, 7, 9,
 # 11) is reserved to a ship.sh meaning this script does not take, so a new DRIFT
 # code has nowhere to go but upward; its rank is stated in severity() and here.
 # 🔴 UPWARD IS NOT EMPTY EITHER: ship.sh owns 19 (hosts-disagree), 20
-# (superseded) and 21 (usage), and this script has now taken 22, 23 and 24, so
-# the next free DRIFT code is 25, not 19. See the reciprocal
+# (superseded) and 21 (usage), and this script has now taken 22, 23, 24 and 25,
+# so the next free DRIFT code is 26, not 19. See the reciprocal
 # reservation under EXIT CODES above — that collision was one increment away.
 # (6 and 2 are both unreachable through this path today — the script exits each
 # directly, before any per-host leg runs — but the order is documented for every
@@ -938,6 +1007,24 @@ severity() {
     #   that said otherwise. It also carries the AHEAD case — un-pushed commits in
     #   a repo whose code this host compiles — which is rc 8's loss class.
     17) echo 67 ;;
+    # 25 (this script declares main's merge gate OFF and it is LIVE ON) sits
+    # between 17 and 14, and the digit — the largest in this table — says the
+    # opposite, as it does for 24 two arms up.
+    #   BELOW 17, by this table's own published principle: "a hazard that has
+    #   already cost something outranks one that is merely open" (the argument
+    #   for 8 over 24). rc 17's measured failure had ALREADY shipped a binary
+    #   that ran, exited 0 and silently did nothing. Here the gate is UP and
+    #   nothing has been lost; what is lost is the ability to notice when it
+    #   next goes down.
+    #   ABOVE 14, by this table's other published principle: 14 is LOUD at the
+    #   moment of use ("command not found") and announces itself. This is silent
+    #   by construction — it is the rc-24 detector being switched off, so its
+    #   whole failure mode is that nothing says anything. A code whose symptom
+    #   is an ABSENCE of alerts must outrank one that alerts on its own.
+    #   ⚠ NOT ranked directly under 24 even though it is the same instrument.
+    #   Sorting the two halves adjacently is tidiness, not severity, and the two
+    #   principles above both place it here.
+    25) echo 66 ;;
     # 14 (a host's managed symlinks resolve to nothing) sits between 8 and 13.
     # It is BELOW 8 because rc 8 means work exists on exactly one machine and a
     # careless fix destroys it, whereas a broken deployment is repaired by a
@@ -2819,6 +2906,39 @@ bp_slug_of() { # bp_slug_of <remote-url> -> owner/repo, or "" if not GitHub
   esac
 }
 
+# ── THE DECLARED EXPECTATION ──────────────────────────────────────────────────
+# See "THE DECLARED EXPECTATION" in the header for the truth table and for why
+# this is a function in this file rather than an env var or a ledger path.
+#
+# 🔴 IT IS AN ENUMERATION, NOT A PATTERN, AND IT FAILS CLOSED. Every declared-off
+# repo is a literal arm carrying its own reason. A repo nobody has thought about
+# falls through, gets NO reason, and is therefore expected to be GATED — so a new
+# remote, or a rename of this one, is drift by default and has to be argued onto
+# this list by a human, in a diff. An empty return here is the SAFE answer: it
+# keeps rc 24 armed.
+#
+# 🔴 NOT ENV-OVERRIDABLE, and neither is a path to it. The whole point of a
+# declaration is that the run cannot write it. See the header.
+#
+# Written as `if [ "$1" = <slug> ]` rather than a `case`, for the same reason
+# perhost_reason below is: the suite's reverse PATH tokenizer reads a lowercase
+# `case` ARM LABEL as a command word, and putting the slug in ARGUMENT position
+# keeps that guard's accounting honest instead of widening its ledger.
+bp_declared_off_reason() { # <owner/repo> -> why main's merge gate is DECLARED off, or "" if it must be ON
+  if [ "$1" = innovation-upstream/devrc ]; then
+    # DECLARED 2026-09-02. The operator turned the Tekton merge gate off because
+    # it was slowing work down; it stays off until the Tekton capacity issue is
+    # addressed, which a DIFFERENT SESSION owns. Not drift, and not this
+    # deadman's to restore. Tekton still RUNS and still posts both checks on a PR
+    # head — they simply do not gate — so the local two-tier run is the only
+    # pre-merge evidence there is while this stands. Delete this arm the moment
+    # protection is restored; leaving it is rc 25, because it disarms rc 24.
+    echo "operator decision 2026-09-02: the Tekton merge gate is off until the Tekton capacity issue is addressed (a different session owns that)"
+  else
+    echo ""
+  fi
+}
+
 echo "=== branch protection on the canonical remote (main) ==="
 # 🔴 THE OVERRIDE EXISTS FOR THE SUITE, and it is not a convenience. The
 # derivation reads the SAME `origin` the git leg fetches from, so a test that
@@ -2838,6 +2958,20 @@ if [ -z "$BP_SLUG" ]; then
   BP_URL="$(git -C "$DRIFT_REPO" ls-remote --get-url origin 2>/dev/null)"
   BP_SLUG="$(bp_slug_of "$BP_URL")"
 fi
+# 🔴 THE MEASUREMENT AND THE VERDICT ARE SEPARATED ON PURPOSE, and it is not
+# tidying. Every branch below decides ONE thing — is the gate live ON, live OFF,
+# or unmeasured — and prints the FACTS it measured. Nothing below calls note_rc.
+# The alarm, the repair instructions and the exit code are decided ONCE, at the
+# bottom, against the declared expectation. The previous shape had `note_rc 24`
+# at THREE sites, and a predicate open-coded at N sites is the shape that
+# regenerates the same bug at every one of them: adding the expectation to two of
+# the three would have left an arm that still fires on a declared-off gate,
+# looking correct at both of the sites anyone would think to read.
+#
+# `unknown` is the initial value, so a branch that forgets to decide degrades to
+# COULD NOT MEASURE — no rc — rather than to a verdict.
+BP_LIVE=unknown
+BP_OFF_KIND=""
 if [ -z "$BP_SLUG" ] && [ -z "$BP_URL" ]; then
   echo "[protect] COULD NOT MEASURE — no origin remote readable in $DRIFT_REPO."
   echo "[protect]   This is NOT 'main is protected'. No rc is set."
@@ -2891,14 +3025,14 @@ EOF
     case "$BP_ENF" in
       true)
         echo "[protect]   enforce_admins=true — the checks bind admins too."
+        BP_LIVE=on
         ;;
       false)
-        echo "[protect] 🔴 DRIFT — $BP_SLUG main requires $BP_N check(s) but enforce_admins is FALSE."
+        echo "[protect]   $BP_SLUG main requires $BP_N check(s) but enforce_admins is FALSE."
         echo "[protect]   Half a gate. An admin — the actor in both 2026-08-29 occurrences — can"
         echo "[protect]   push straight to main past every required check. This is the mechanism"
         echo "[protect]   that would have let 837d3fde through even with the checks present."
-        echo "[protect]   fix: PUT /repos/$BP_SLUG/branches/main/protection with enforce_admins true."
-        note_rc 24
+        BP_LIVE=off; BP_OFF_KIND=enforce-admins
         ;;
       *)
         echo "[protect]   enforce_admins=UNKNOWN — the protection endpoint did not answer."
@@ -2993,6 +3127,7 @@ EOF
         echo "[protect] $BP_SLUG main: 0 classic required checks, but ruleset $BP_GATE_ID gates it"
         echo "[protect]   (enforcement=active, 0 bypass actors, and its required_status_checks rule"
         echo "[protect]   lists at least one check). The gate is ON, by the newer mechanism."
+        BP_LIVE=on
       elif [ "$BP_SEEN" = 0 ] || [ "$BP_UNREADABLE" -gt 0 ] || [ "$BP_CAPPED" = 1 ]; then
         # 🔴 NOT DRIFT. No ruleset was PROVEN to gate, but one we could not read
         # may. "Unprotected" and "protected by a ruleset I could not examine" are
@@ -3013,23 +3148,53 @@ EOF
         [ -n "$BP_WHY" ] && echo "[protect]     examined and not binding:$BP_WHY"
         echo "[protect]   NOT read as protected, and NOT as drift. No rc is set."
       else
-        echo "[protect] 🔴 DRIFT — $BP_SLUG main has 0 classic required checks, and NONE of its"
+        echo "[protect] $BP_SLUG main has 0 classic required checks, and NONE of its"
         echo "[protect]   $BP_RULES required-checks rule(s) binds:$BP_WHY"
         echo "[protect]   A ruleset in evaluate/disabled mode REPORTS and does not block; one with"
         echo "[protect]   bypass actors is the ruleset spelling of enforce_admins=false, letting"
         echo "[protect]   whoever is listed push straight past every check — the mechanism behind"
         echo "[protect]   837d3fde. Either way nothing gates main."
-        echo "[protect]   fix: set enforcement=active and remove the bypass actors on one of them."
-        note_rc 24
+        BP_LIVE=off; BP_OFF_KIND=ruleset-nonbinding
       fi
     else
-    echo "[protect] 🔴 DRIFT — $BP_SLUG main has ZERO required status checks (protected=$BP_PROT),"
+    echo "[protect] $BP_SLUG main has ZERO required status checks (protected=$BP_PROT),"
     echo "[protect]   by CLASSIC protection and by RULESETS alike — both were checked."
-    echo "[protect]   The gate every change to this fleet passes through is OFF: anything can"
-    echo "[protect]   land on main, and both hosts converge to main. Measured TWICE on"
-    echo "[protect]   2026-08-29, once leaving a DIRECT PUSH on main that required checks"
-    echo "[protect]   would have rejected. Neither was detected by anything but a human."
-    if [ "$BP_PROT" = true ]; then
+    BP_LIVE=off; BP_OFF_KIND=classic-zero
+    fi
+  fi
+fi
+
+# ── THE VERDICT: THE DECLARED EXPECTATION AGAINST WHAT WAS MEASURED ───────────
+# The ONLY place this arm sets a code. See "THE DECLARED EXPECTATION" in the
+# header for the truth table and the argument for each cell.
+BP_EXPECT_WHY="$(bp_declared_off_reason "$BP_SLUG")"
+if [ "$BP_LIVE" = unknown ]; then
+  # 🔴 UNCHANGED, AND IT MUST STAY THAT WAY. Every path that reaches here has
+  # already printed its own COULD NOT MEASURE line and its own reason. It sets no
+  # code in EITHER direction: an unread gate is not a gate that is on, and it is
+  # not a stale declaration either. A gh that cannot answer is the one input whose
+  # natural failure looks exactly like a finding, so it never becomes one.
+  :
+elif [ -z "$BP_EXPECT_WHY" ]; then
+  # Expected ON — the default for every repo not enumerated in
+  # bp_declared_off_reason. This is the arm that was measured on 2026-08-29.
+  if [ "$BP_LIVE" = on ]; then
+    echo "[protect]   expected ON (not declared off in drift-check.sh) and live ON. No rc."
+  else
+    echo "[protect] 🔴 DRIFT — the merge gate on $BP_SLUG main is OFF, and NOTHING DECLARES"
+    echo "[protect]   IT OFF. The gate every change to this fleet passes through is down:"
+    echo "[protect]   anything can land on main, and both hosts converge to main. Measured"
+    echo "[protect]   TWICE on 2026-08-29, once leaving a DIRECT PUSH on main that required"
+    echo "[protect]   checks would have rejected. Neither was detected by anything but a human."
+    # Written as an if-chain, not a `case`: the suite's reverse PATH tokenizer
+    # reads a lowercase `case` ARM LABEL as a command word, so `enforce-admins)`
+    # arrives at test_the_unit_path_table_accounts_for_every_command_the_scripts_run
+    # as a binary nobody can name. Same reason perhost_reason is spelled this way.
+    if [ "$BP_OFF_KIND" = enforce-admins ]; then
+      echo "[protect]   fix: PUT /repos/$BP_SLUG/branches/main/protection with enforce_admins true."
+    elif [ "$BP_OFF_KIND" = ruleset-nonbinding ]; then
+      echo "[protect]   fix: set enforcement=active and remove the bypass actors on one of them."
+    elif [ "$BP_PROT" = true ]; then
       echo "[protect]   protected=true: the protection object stands and required_status_checks"
       echo "[protect]   was deleted out of it — the exact break-glass shape. 🔴 PATCH CANNOT"
       echo "[protect]   restore it; it returns non-zero and changes nothing. Use a full PUT of"
@@ -3050,8 +3215,33 @@ EOF
       echo "[protect]   (…/branches/main/protection 404s 'Branch not protected' in this state)"
     fi
     echo "[protect]   rulesets, the other mechanism: gh api /repos/$BP_SLUG/rules/branches/main"
+    echo "[protect]   🔴 If this is INTENDED, it belongs in bp_declared_off_reason() in this"
+    echo "[protect]   script, with its reason — not silenced from the environment."
     note_rc 24
-    fi
+  fi
+else
+  # Declared OFF in bp_declared_off_reason(), in this file, in a diff a human read.
+  if [ "$BP_LIVE" = off ]; then
+    echo "[protect] DECLARED OFF, and live OFF — expectation and reality agree. No rc is set."
+    echo "[protect]   why: $BP_EXPECT_WHY"
+    echo "[protect]   🔴 The alarm is QUIET, not DISABLED: it fires the moment the two disagree."
+    echo "[protect]   Restore protection and this becomes rc 25 until the declaration is deleted."
+    echo "[protect]   ⚠ Nothing gates a merge to $BP_SLUG main while this stands — run both"
+    echo "[protect]   tiers of the gate yourself, on the MERGED tree, and name the base sha."
+  else
+    echo "[protect] 🔴 DRIFT — STALE DECLARATION. drift-check.sh declares the merge gate on"
+    echo "[protect]   $BP_SLUG main OFF, and it is LIVE ON."
+    echo "[protect]   declared: $BP_EXPECT_WHY"
+    echo "[protect]   🔴 This DISARMS rc 24. While the declaration stands, a gate that is"
+    echo "[protect]   removed again — the measured 2026-08-29 break-glass shape, where DELETE"
+    echo "[protect]   opened the window and PATCH could not close it — passes SILENTLY, because"
+    echo "[protect]   declared-off/live-off is exactly the cell above this one. Nothing is lost"
+    echo "[protect]   yet; what is lost is the ability to notice when it next goes down."
+    echo "[protect]   fix: delete the $BP_SLUG arm from bp_declared_off_reason() in"
+    echo "[protect]   scripts/drift-check.sh, and correct any prose that still says the gate is"
+    echo "[protect]   off (devrc/CLAUDE.md carries such a paragraph). It is a one-line edit."
+    echo "[protect]   read the live state: gh api /repos/$BP_SLUG/branches/main/protection"
+    note_rc 25
   fi
 fi
 echo
@@ -3221,12 +3411,17 @@ if [ "$rc" != 0 ]; then
   echo "       (nix reads the path, but the flake filtered the untracked file OUT of the"
   echo "       artifact — unsaved work, not a deployed one). A host whose nix-read set came EMPTY"
   echo "       is COULD NOT MEASURE, never rc23. (ranks between rc15 and rc12; see severity() )"
-  echo "  rc24=main on the canonical remote has ZERO required status checks — the merge gate"
-  echo "       is OFF for the branch both hosts converge to. protected=true means the checks"
-  echo "       were deleted out of a standing protection object (PATCH cannot restore it; PUT"
-  echo "       the whole thing and read it back). A gh that cannot answer is COULD NOT"
-  echo "       MEASURE, never rc24. (ranks between rc8 and rc17 — the LARGEST digit here"
-  echo "       ranks SECOND; see severity() )"
+  echo "  rc24=main on the canonical remote has ZERO required status checks AND nothing"
+  echo "       declares it off — the merge gate is OFF for the branch both hosts converge to."
+  echo "       protected=true means the checks were deleted out of a standing protection"
+  echo "       object (PATCH cannot restore it; PUT the whole thing and read it back). A gate"
+  echo "       DECLARED off in bp_declared_off_reason() is reported and sets no code. A gh"
+  echo "       that cannot answer is COULD NOT MEASURE, never rc24. (ranks between rc8 and"
+  echo "       rc17 — the LARGEST digit here ranks SECOND; see severity() )"
+  echo "  rc25=STALE DECLARATION: drift-check.sh declares main's merge gate OFF and it is LIVE"
+  echo "       ON. Not rc24's inverse — it DISARMS rc24, because declared-off/live-off is"
+  echo "       excused, so a gate removed again would pass silently. fix: delete that arm from"
+  echo "       bp_declared_off_reason(). (ranks between rc17 and rc14; see severity() )"
 fi
 [ -n "$UNCHECKED" ] && echo "drift-check: NOT checked: $UNCHECKED"
 exit "$rc"

--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -546,9 +546,13 @@
 #   declared ON,  live OFF  ->  rc 24. The botched-restore alarm, preserved whole.
 #   declared ON,  live ON   ->  no code. The gate is up.
 #   declared OFF, live OFF  ->  no code. Reported plainly, as an intended state.
-#                               EXCEPT a PARTIAL restore (required checks back,
-#                               enforce_admins false) -> rc 25; see the verdict
-#                               block for why that is staleness, not agreement.
+#                               EXCEPT an OFF state carrying evidence a gate was
+#                               RE-ESTABLISHED — required checks back with
+#                               enforce_admins false, or an ACTIVE ruleset
+#                               listing a check but with bypass actors -> rc 25.
+#                               See the verdict block for why that is staleness
+#                               rather than agreement, and for the one OFF kind
+#                               (evaluate/disabled rulesets) still excluded.
 #   declared OFF, live ON   ->  rc 25. The declaration is stale, and a stale
 #                               "off" DISARMS rc 24 — see the code list above.
 #   gh cannot answer        ->  COULD NOT MEASURE, no code, unchanged. A
@@ -3130,7 +3134,14 @@ EOF
       # The rules list checks. Now ask whether ANY ruleset holding one actually
       # BINDS — active, with no bypass actors. Every id is examined, because one
       # non-binding ruleset among several says nothing about the others.
+      # 🔴 BP_RS_BYPASSED IS NOT BOOKKEEPING — IT SPLITS TWO STATES THIS LOOP
+      # USED TO REPORT AS ONE. A ruleset that is ACTIVE and lists a required
+      # check IS a gate; bypass actors only mean somebody can step around it.
+      # A ruleset in evaluate/disabled mode is not a gate at all. Both used to
+      # collapse into one OFF kind, and under a declaration that made the first
+      # one silent — see the verdict block's asymmetry note.
       BP_GATED=0; BP_GATE_ID=""; BP_UNREADABLE=0; BP_SEEN=0; BP_CAPPED=0; BP_WHY=""
+      BP_RS_BYPASSED=0
       for BP_ID in $(printf '%s' "$BP_RULE_IDS" | tr ',' ' '); do
         BP_SEEN=$((BP_SEEN + 1))
         if [ "$BP_SEEN" -gt "$DRIFT_GH_RULESET_MAX" ]; then BP_CAPPED=1; break; fi
@@ -3146,6 +3157,7 @@ EOF
           BP_WHY="$BP_WHY $BP_ID=enforcement:$BP_RS_ENF"
         elif [ "$BP_RS_BYPASS" -gt 0 ]; then
           BP_WHY="$BP_WHY $BP_ID=bypass-actors:$BP_RS_BYPASS"
+          BP_RS_BYPASSED=1
         else
           BP_GATED=1; BP_GATE_ID="$BP_ID"; break
         fi
@@ -3181,7 +3193,20 @@ EOF
         echo "[protect]   bypass actors is the ruleset spelling of enforce_admins=false, letting"
         echo "[protect]   whoever is listed push straight past every check — the mechanism behind"
         echo "[protect]   837d3fde. Either way nothing gates main."
-        BP_LIVE=off; BP_OFF_KIND=ruleset-nonbinding
+        # 🔴 TWO OFF KINDS, NOT ONE. "Either way nothing gates main" is true of
+        # the EXIT CODE and false of what the state TELLS YOU: an active ruleset
+        # listing a check is a gate somebody built, and one in evaluate mode is
+        # not. Only the first is evidence that a declared-off gate has been
+        # restored. A single kind here made the bypass-actors case silent under a
+        # declaration while its exact classic twin (enforce_admins=false) fired.
+        # If ANY examined ruleset was active-with-bypass, that is the finding —
+        # a non-enforcing sibling alongside it does not soften it.
+        BP_LIVE=off
+        if [ "$BP_RS_BYPASSED" = 1 ]; then
+          BP_OFF_KIND=ruleset-bypassed
+        else
+          BP_OFF_KIND=ruleset-inactive
+        fi
       fi
     else
     echo "[protect] $BP_SLUG main has ZERO required status checks (protected=$BP_PROT),"
@@ -3195,6 +3220,21 @@ fi
 # The ONLY place this arm sets a code. See "THE DECLARED EXPECTATION" in the
 # header for the truth table and the argument for each cell.
 BP_EXPECT_WHY="$(bp_declared_off_reason "$BP_SLUG")"
+# 🔴 ONE PREDICATE, ONE PLACE: does this OFF state carry positive evidence that a
+# gate was RE-ESTABLISHED on this repo? That is the whole discriminator the
+# declared-OFF branch turns on, and open-coding it into that `if` is how it came
+# to cover `enforce-admins` and miss `ruleset-bypassed` — two spellings of one
+# state, by this file's own account 100 lines up ("one with bypass actors is the
+# ruleset spelling of enforce_admins=false").
+#   YES — required checks exist in the classic protection object with
+#         enforce_admins false, or an ACTIVE ruleset lists a check but has
+#         bypass actors. Somebody built a gate; some actor can step around it.
+#   NO  — no checks anywhere (classic-zero), or every ruleset holding a check is
+#         in evaluate/disabled mode (ruleset-inactive). Nothing was built.
+BP_RESTORED_GATE=0
+if [ "$BP_OFF_KIND" = enforce-admins ] || [ "$BP_OFF_KIND" = ruleset-bypassed ]; then
+  BP_RESTORED_GATE=1
+fi
 if [ "$BP_LIVE" = unknown ]; then
   # 🔴 UNCHANGED, AND IT MUST STAY THAT WAY. Every path that reaches here has
   # already printed its own COULD NOT MEASURE line and its own reason. It sets no
@@ -3229,8 +3269,10 @@ elif [ -z "$BP_EXPECT_WHY" ]; then
     # test_every_BP_OFF_KIND_assigned_is_branched_on_in_the_verdict.
     if [ "$BP_OFF_KIND" = enforce-admins ]; then
       echo "[protect]   fix: PUT /repos/$BP_SLUG/branches/main/protection with enforce_admins true."
-    elif [ "$BP_OFF_KIND" = ruleset-nonbinding ]; then
-      echo "[protect]   fix: set enforcement=active and remove the bypass actors on one of them."
+    elif [ "$BP_OFF_KIND" = ruleset-bypassed ]; then
+      echo "[protect]   fix: remove the bypass actors from the active ruleset named above."
+    elif [ "$BP_OFF_KIND" = ruleset-inactive ]; then
+      echo "[protect]   fix: set enforcement=active on one of the rulesets named above."
     elif [ "$BP_OFF_KIND" = classic-zero ]; then
       if [ "$BP_PROT" = true ]; then
         echo "[protect]   protected=true: the protection object stands and required_status_checks"
@@ -3279,26 +3321,45 @@ else
   # declaration and rc 24 stays disarmed over a half-restored gate indefinitely.
   # Before the declaration existed, that same state fired rc 24.
   #
-  # ⚠ `ruleset-nonbinding` deliberately does NOT get this treatment, and the
-  # asymmetry is argued rather than convenient. `/rules/branches/main` returns the
-  # rules of EVERY applying ruleset, repo- and ORG-level mixed (see the loop
-  # above), and an org ruleset parked in `evaluate` mode is the standard org
-  # rollout pattern — nothing this repo created and nothing its operator can
-  # remove. Firing rc 25 on it would be a permanently-red gate on a state nobody
-  # can close, which is the one thing this arm refuses everywhere else. It stays
-  # in the agreement cell and converts to rc 25 the moment any ruleset actually
-  # BINDS (BP_LIVE=on).
-  # ⚠ KNOWN BOUND, stated rather than hidden: a REPO-level ruleset the operator
-  # created and left in evaluate mode is indistinguishable from the org case at
-  # the endpoint this arm reads, so it too stays quiet. `ruleset_source_type` on
-  # /rules/branches/main is the field that would separate them; it is not read
-  # today, and closing this needs that read plus its own tests.
-  if [ "$BP_LIVE" = off ] && [ "$BP_OFF_KIND" != enforce-admins ]; then
+  # 🔴 AND THE RULESET SPELLING OF IT COUNTS THE SAME — `ruleset-bypassed`. An
+  # EARLIER REVISION EXCLUDED THE WHOLE RULESET CLASS AND THAT WAS TOO WIDE. An
+  # ACTIVE ruleset whose required_status_checks rule lists a check IS a gate
+  # somebody built; bypass actors only mean a listed actor can step around it —
+  # which the loop above calls, in this file's own words, "the ruleset spelling
+  # of enforce_admins=false". Excluding it made the LIKELY repair path silent:
+  # this file's own header calls a ruleset "the most likely next repair of THIS
+  # repo", so the realistic sequence is an operator restoring by ruleset and
+  # leaving an admin or an app in `bypass_actors` — the exact state F3 exists to
+  # catch, going quiet indefinitely under the declaration.
+  #
+  # ⚠ `ruleset-inactive` — every ruleset holding a check parked in
+  # evaluate/disabled — is what remains excluded, and THAT asymmetry is the
+  # argued one. Evaluate mode is not a gate at all: it is explicitly a
+  # non-enforcing dry run, so it is not evidence anybody restored anything.
+  # `/rules/branches/main` also returns the rules of EVERY applying ruleset,
+  # repo- and ORG-level mixed, and an org ruleset parked in evaluate is the
+  # standard org rollout — nothing this repo created or can remove. Firing on it
+  # would be a permanently-red gate on a state nobody can close. It stays in the
+  # agreement cell and converts to rc 25 the moment a ruleset BINDS (BP_LIVE=on)
+  # or turns out to be active-with-bypass.
+  # ⚠ KNOWN BOUND, and now genuinely narrow: a REPO-level ruleset the operator
+  # created and left in EVALUATE mode is indistinguishable, at the endpoint this
+  # arm reads today, from the org rollout above — so it stays quiet. That is
+  # CLOSABLE, not structural: `ruleset_source_type` IS present on
+  # /rules/branches/main (measured on astral-sh/uv: `Organization` for the org
+  # ruleset, `Repository` for the required_status_checks one). It is not read
+  # today, and closing it needs that read plus its own tests. Because it is
+  # closable, it cannot carry an exclusion any wider than this one.
+  if [ "$BP_LIVE" = off ] && [ "$BP_RESTORED_GATE" = 0 ]; then
     echo "[protect] DECLARED OFF, and live OFF — expectation and reality agree. No rc is set."
     echo "[protect]   why: $BP_EXPECT_WHY"
-    echo "[protect]   🔴 The alarm is QUIET, not DISABLED. It fires as rc 25 as soon as the"
-    echo "[protect]   gate is re-established — including a PARTIAL restore that puts the"
-    echo "[protect]   required checks back and omits enforce_admins."
+    echo "[protect]   🔴 The alarm is QUIET, not DISABLED. It fires as rc 25 as soon as a gate"
+    echo "[protect]   is re-established on this repo — a full restore, a PARTIAL one that puts"
+    echo "[protect]   the required checks back and omits enforce_admins, or an ACTIVE ruleset"
+    echo "[protect]   listing a check but carrying bypass actors (the ruleset spelling of the"
+    echo "[protect]   same half-gate)."
+    echo "[protect]   ⚠ It stays quiet for a ruleset parked in evaluate/disabled mode — that is"
+    echo "[protect]   not a gate anybody built. See the asymmetry note in this script."
     echo "[protect]   ⚠ Nothing gates a merge to $BP_SLUG main while this stands — run both"
     echo "[protect]   tiers of the gate yourself, on the MERGED tree, and name the base sha."
   else
@@ -3314,6 +3375,17 @@ else
       echo "[protect]   true and read it back, AND delete the $BP_SLUG arm from"
       echo "[protect]   bp_declared_off_reason(). Finishing one and not the other leaves this"
       echo "[protect]   red (checks half-bound) or silent (declaration stale) respectively."
+    elif [ "$BP_OFF_KIND" = ruleset-bypassed ]; then
+      echo "[protect]   $BP_SLUG main OFF, and an ACTIVE ruleset now lists a required check —"
+      echo "[protect]   a PARTIAL restore by the RULESET mechanism, with bypass actors still"
+      echo "[protect]   set:$BP_WHY"
+      echo "[protect]   Somebody built a gate on this branch; listed actors can step around it."
+      echo "[protect]   🔴 That is the ruleset spelling of enforce_admins=false, and this script"
+      echo "[protect]   calls a ruleset 'the most likely next repair of THIS repo' — so this is"
+      echo "[protect]   the LIKELY shape of a half-finished restore, not an exotic one."
+      echo "[protect]   fix, BOTH halves: remove the bypass actors from that ruleset, AND delete"
+      echo "[protect]   the $BP_SLUG arm from bp_declared_off_reason(). Finishing one and not the"
+      echo "[protect]   other leaves this red (gate half-bound) or silent (declaration stale)."
     else
       echo "[protect]   $BP_SLUG main OFF, and it is LIVE ON."
       echo "[protect]   fix: delete the $BP_SLUG arm from bp_declared_off_reason() in"

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -171,14 +171,14 @@
 # 🔴 THE LADDER IS SHARED WITH scripts/drift-check.sh, RECIPROCALLY. That script
 # is the passive deadman for the same fleet and deliberately uses the same
 # vocabulary, so a number must not mean two things across the pair. It owns
-# 10, 14, 15, 16, 17, 18, 22, 23 and 24 — DRIFT meanings this script does not
-# take — and reserves them here; this script owns 5, 7, 9, 11, 19, 20 and 21 and
-# they are reserved there. Its header says "a new DRIFT code has nowhere to go
-# but upward", which points the next one at 19 unless the reservation is written
-# down on both sides: so the next free code for THIS script is 25, and so is the
-# next free code for that one.
+# 10, 14, 15, 16, 17, 18, 22, 23, 24 and 25 — DRIFT meanings this script does
+# not take — and reserves them here; this script owns 5, 7, 9, 11, 19, 20 and 21
+# and they are reserved there. Its header says "a new DRIFT code has nowhere to
+# go but upward", which points the next one at 19 unless the reservation is
+# written down on both sides: so the next free code for THIS script is 26, and so
+# is the next free code for that one.
 #
-# RESERVED-TO-DRIFT-CHECK: 10 14 15 16 17 18 22 23 24
+# RESERVED-TO-DRIFT-CHECK: 10 14 15 16 17 18 22 23 24 25
 #
 # That line is a LEDGER, machine-read, not a comment: it must equal exactly the
 # set of codes drift-check.sh can return and this script cannot, so it fails when

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -7016,11 +7016,23 @@ def test_every_BP_OFF_KIND_assigned_is_branched_on_in_the_verdict():
     )
 
 
-def test_an_unrecognised_OFF_kind_refuses_to_guess_a_repair(fleet):
-    """The `else` arm of the repair chain is a REFUSAL, not a default. Driven by
-    pointing the arm at a state whose kind the chain does know, then asserting the
-    known repair is what prints — the refusal text must not appear for a kind that
-    IS handled, or the arm would be printing 'I do not know' over a state it does.
+def test_a_KNOWN_off_kind_does_not_take_the_unrecognised_arm(fleet):
+    """⚠ NAMED FOR WHAT IT CHECKS, AND NOT FOR WHAT IT CANNOT.
+
+    The repair chain's `else` arm is a refusal rather than a default — but it is
+    UNREACHABLE from any input, by construction: every value BP_OFF_KIND can hold
+    is branched on, which is exactly what
+    `test_every_BP_OFF_KIND_assigned_is_branched_on_in_the_verdict` asserts as a
+    two-way ledger. No fixture can drive it without mutating the script, so
+    nothing here exercises it, and this test is GREEN AT BASE — an invariant
+    guard, not regression coverage.
+
+    An earlier name ("…refuses_to_guess_a_repair") claimed it covered that arm.
+    It did not, and that is the same defect the audit found in the
+    DRIFT_PROTECT_SLUG test: a name asserting more than the body. What is pinned
+    here is the negative — a kind that IS handled must not print "I do not know"
+    over a state the chain understands. The ledger test is what keeps the `else`
+    arm unreachable; if it ever becomes reachable, that test goes red first.
     """
     rc, out = _protect(fleet, "--no-remote", gh=GATE_IS_LIVE_OFF)
     assert rc == 24, out

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -6623,20 +6623,38 @@ def test_an_UNDECLARED_repo_with_no_gate_still_fires_rc24(fleet):
     assert "bp_declared_off_reason" in out, out
 
 
-def test_enforce_admins_false_on_a_DECLARED_off_repo_sets_no_rc(fleet):
+def test_the_enforce_admins_site_REACHES_the_verdict_under_a_declaration(fleet):
     """🔴 REACHABILITY, on the second of the two places the arm decides LIVE OFF.
 
-    Required checks present but enforce_admins FALSE is half a gate, and the arm
-    calls that OFF. On a declared-off repo it must therefore be excused like any
-    other off — if only the zero-checks path consulted the declaration, this
-    input would fire rc 24 on the very repo the operator declared off.
+    ⚠ THIS TEST ASSERTED THE OPPOSITE UNTIL ROUND 1 OF THE AUDIT. It said a
+    declared-off repo with enforce_admins=false "sets no rc" — reading a half-
+    restored gate as agreement, which was a REGRESSION against pre-declaration
+    behaviour and let a partial `PUT` disarm rc 24 silently. The semantics now
+    live in `test_a_PARTIAL_restore_under_a_declaration_is_rc25_not_agreement`;
+    what survives here is the STRUCTURAL claim that test cannot make on its own:
+    this site must SET BP_LIVE, or control short-circuits at the `unknown` arm
+    and the run prints no verdict at all — passing an rc-0 assertion for the
+    entirely wrong reason.
     """
     fleet.catch_up()
     _gh_router(fleet, branch="true 2 alpha-check,bravo-check", protection="false")
     rc, out = fleet.check("--no-remote", DRIFT_PROTECT_SLUG=DECLARED_OFF_SLUG)
-    assert rc == 0, f"half a gate on a declared-off repo still fired: {rc}\n{out}"
     assert "enforce_admins is FALSE" in out, "the wrong branch ran\n" + out
-    assert "DECLARED OFF, and live OFF" in out, out
+    # BP_LIVE was set, so the verdict block ran rather than short-circuiting.
+    # 🔴 Read the arm's OWN lines, not the whole run: an earlier version of this
+    # assertion grepped the tail of stdout for "COULD NOT MEASURE" and matched the
+    # rc-23/rc-24 LEGEND, i.e. a guard on a word another feature spells.
+    plines = [ln for ln in out.splitlines() if ln.startswith("[protect]")]
+    assert plines, "the arm printed nothing at all\n" + out
+    assert not any("COULD NOT MEASURE" in ln for ln in plines), (
+        "the enforce_admins site did not set BP_LIVE — the arm reported it as "
+        "unmeasured\n" + "\n".join(plines)
+    )
+    assert any("STALE DECLARATION" in ln for ln in plines), (
+        "the verdict block did not run — control short-circuited at the unknown "
+        "arm\n" + "\n".join(plines)
+    )
+    assert rc == 25, f"the verdict block was not reached with a live=off state: {rc}\n{out}"
 
 
 # --- cell 2: declared ON, live ON ------------------------------------------- #
@@ -6770,13 +6788,15 @@ def test_the_declaration_cannot_be_set_from_the_environment(fleet):
     assert rc == 24, f"an env var declared the gate off: {rc}\n{out}"
 
 
-def test_DRIFT_PROTECT_SLUG_changes_the_subject_and_never_the_expectation(fleet):
-    """⚠ THE ONE OVERRIDE THAT REMAINS, and the distinction that makes it safe.
+def test_a_declaration_applies_to_its_own_slug_and_not_to_a_neighbour(fleet):
+    """The enumeration is keyed on the slug, so two subjects in the same run's
+    vocabulary must get different verdicts from the SAME live answer.
 
-    It selects WHICH repo is asked about; the expectation is still looked up in
-    the enumeration, and an unenumerated slug is expected ON. So it cannot turn a
-    finding off — pointing it at a repo nobody declared still fires rc 24 on an
-    ungated main, which is exactly what the rest of this file relies on.
+    ⚠ This test used to be called `…_changes_the_subject_and_never_the_expectation`
+    and asserted only these two lines, while its name claimed the env var cannot
+    turn a finding off. It can — see
+    `test_DRIFT_PROTECT_SLUG_changes_the_SUBJECT_and_the_run_names_it`, which
+    exercises that and pins the property that actually holds.
     """
     rc, out = _protect(fleet, "--no-remote", gh=GATE_IS_LIVE_OFF)
     assert rc == 24, out
@@ -6854,6 +6874,208 @@ def test_the_rc25_legend_is_printed_with_the_verdict(fleet):
     assert rc == 25, out
     assert "rc25=" in out, out
     assert "drift-check: DRIFT (rc=25)" in out, out
+
+
+# --- ROUND 1 AUDIT: the three gaps the payload had ---------------------------- #
+# 🔴 F3 was a REGRESSION, not a missing nicety. Before the declaration existed, a
+# repo with required checks and enforce_admins=false fired rc 24. Under a
+# declaration the first revision read it as "expectation and reality agree", set
+# no code, and printed "Restore protection and this becomes rc 25" — a sentence
+# that was FALSE in exactly that state. devrc/CLAUDE.md documents a partial `PUT`
+# silently dropping every key it omits, `enforce_admins` included, as MEASURED —
+# so restore-with-omission lands here, produces no toast, nobody deletes the
+# declaration, and rc 24 stays disarmed over a half-restored gate indefinitely.
+# --------------------------------------------------------------------------- #
+
+def _slug_aware_gh(fleet, answers, default=None):
+    """A `gh` stub that answers per REPO SLUG as well as per endpoint.
+
+    `answers` maps a slug -> (branch, protection). Needed because the claim that
+    DRIFT_PROTECT_SLUG only changes the SUBJECT is a claim about two DIFFERENT
+    repos giving two different answers — a single-payload stub cannot express it,
+    and the test that carried that claim's name never fed it a second repo.
+    """
+    body = ['case "$*" in']
+    for slug, (branch, protection) in answers.items():
+        body.append('  *"%s/branches/main/protection"*)\n  echo \'%s\'\n  exit 0\n  ;;'
+                    % (slug, protection))
+        body.append('  *"%s/rules/branches/main"*)\n  echo 0\n  exit 0\n  ;;' % slug)
+        body.append('  *"%s/branches/main"*)\n  echo \'%s\'\n  exit 0\n  ;;'
+                    % (slug, branch))
+    if default is None:
+        body.append('  *)\n  exit 1\n  ;;')
+    else:
+        body.append('  *)\n  echo \'%s\'\n  exit 0\n  ;;' % default)
+    body.append('esac')
+    write_exec(fleet.bin / "gh", "\n".join(body) + "\n")
+
+
+# A repo whose main IS gated, and one whose main is NOT. Both are fixture slugs,
+# pairwise distinct from each other, from BP_SLUG and from DECLARED_OFF_SLUG, so
+# no assertion below can pass by matching a constant the script hardcodes.
+GATED_SLUG = "fixture-owner/gated-repo"
+UNGATED_SLUG = "fixture-owner/ungated-repo"
+
+
+def test_a_PARTIAL_restore_under_a_declaration_is_rc25_not_agreement(fleet):
+    """🔴 THE REGRESSION F3 NAMED. Required checks are BACK; enforce_admins is
+    still false. The declared state was the one where those checks had been
+    DELETED, so their existence is evidence the declaration is stale.
+
+    This is the state a partial `PUT …/branches/main/protection` produces —
+    devrc/CLAUDE.md records that as MEASURED, over three uses. Reading it as
+    agreement is a SILENT half-restore: no toast, so nobody deletes the
+    declaration, so rc 24 stays disarmed. Before the declaration existed this
+    exact input fired rc 24.
+    """
+    fleet.catch_up()
+    _gh_router(fleet, branch="true 2 tekton/devrc-pytests,tekton/devrc-nodetests",
+               protection="false")
+    rc, out = fleet.check("--no-remote", DRIFT_PROTECT_SLUG=DECLARED_OFF_SLUG)
+    assert rc == 25, f"a partial restore passed silently under a declaration: {rc}\n{out}"
+    assert "STALE DECLARATION" in out, out
+    assert "PARTIAL" in out, out
+    # 🔴 And the sentence that was false must be gone from THIS state.
+    assert "expectation and reality agree" not in out, (
+        "a half-restored gate is still being reported as agreement\n" + out
+    )
+    # The repair has to name BOTH halves; finishing one leaves the other broken.
+    assert "BOTH halves" in out, out
+
+
+def test_the_agreement_cell_no_longer_promises_something_false(fleet):
+    """The cell-3 report used to say "Restore protection and this becomes rc 25",
+    which was false for a partial restore. It must now describe what actually
+    happens, and the journal is the only place this is ever read."""
+    rc, out = _declared(fleet, "--no-remote", gh=GATE_IS_LIVE_OFF)
+    assert rc == 0, out
+    assert "PARTIAL restore" in out, (
+        "the agreement cell does not say that a partial restore also fires\n" + out
+    )
+
+
+def test_a_NONBINDING_RULESET_under_a_declaration_stays_in_the_agreement_cell(fleet):
+    """⚠ THE ARGUED ASYMMETRY, pinned so it cannot drift into "we forgot".
+
+    `/rules/branches/main` returns the rules of every APPLYING ruleset, repo- and
+    ORG-level mixed, and an org ruleset parked in `evaluate` mode is the standard
+    org rollout pattern — nothing this repo created or can remove. Firing rc 25 on
+    it would be a permanently-red gate on a state nobody can close. Unlike the
+    enforce_admins case, it carries no evidence that anyone restored anything on
+    THIS repo, so it stays quiet and converts to rc 25 the moment a ruleset binds.
+    """
+    fleet.catch_up()
+    _gh_router(fleet, branch="true 0 ", rules="1 20260903", ruleset="evaluate 0")
+    rc, out = fleet.check("--no-remote", DRIFT_PROTECT_SLUG=DECLARED_OFF_SLUG)
+    assert rc == 0, f"a non-binding ruleset fired under a declaration: {rc}\n{out}"
+    assert "DECLARED OFF, and live OFF" in out, out
+    assert "STALE DECLARATION" not in out, out
+
+
+def test_an_UNDECLARED_partial_restore_is_still_rc24(fleet):
+    """The other half of F3: nothing about the fix may weaken the alarm for a
+    repo nobody declared. Same input, unenumerated slug."""
+    fleet.catch_up()
+    _gh_router(fleet, branch="true 2 alpha-check,bravo-check", protection="false")
+    rc, out = fleet.check("--no-remote", DRIFT_PROTECT_SLUG=BP_SLUG)
+    assert rc == 24, f"a half gate on an undeclared repo stopped firing: {rc}\n{out}"
+    assert "enforce_admins is FALSE" in out, out
+
+
+# --- F6: BP_OFF_KIND was a variable that read as exhaustively branched -------- #
+def test_every_BP_OFF_KIND_assigned_is_branched_on_in_the_verdict():
+    """🔴 A TWO-WAY LEDGER over a value that was DEAD, and whose deadness was the
+    sole survivor of a 15-mutant sweep.
+
+    `classic-zero` was assigned and never compared: the repair chain branched on
+    the other two kinds and then fell through to a bare `[ "$BP_PROT" = true ]`
+    heuristic, so deleting the assignment changed nothing. Harmless for the three
+    kinds that exist — and exactly how a FOURTH, added later, would silently
+    inherit break-glass repair text written for a state it is not in.
+
+    Asserted as SETS, so it fails when a kind is ASSIGNED without a branch and
+    when a branch names a kind nothing assigns.
+    """
+    src = "\n".join(ln for ln in DRIFT.read_text().splitlines()
+                    if not ln.strip().startswith("#"))
+    assigned = set(re.findall(r"BP_OFF_KIND=([A-Za-z][A-Za-z0-9-]*)", src))
+    compared = set(re.findall(r'\[\s*"\$BP_OFF_KIND"\s*(?:!=|=)\s*([A-Za-z][A-Za-z0-9-]*)\s*\]', src))
+    # POSITIVE CONTROL for both parsers: a ledger computed from an empty set is
+    # satisfied by an empty ledger, in silence.
+    assert len(assigned) >= 3, f"the assignment parser is reading almost nothing: {assigned}"
+    assert len(compared) >= 3, f"the comparison parser is reading almost nothing: {compared}"
+    assert assigned == compared, (
+        f"BP_OFF_KIND values assigned={sorted(assigned)} but branched on "
+        f"={sorted(compared)}. A kind with no branch falls through to repair text "
+        f"written for a different state."
+    )
+    # ...and the literal set, written out HERE, so a fourth kind has to be argued
+    # for rather than merely spelled consistently in two places.
+    assert assigned == {"classic-zero", "enforce-admins", "ruleset-nonbinding"}, (
+        f"the OFF-kind vocabulary changed: {sorted(assigned)}"
+    )
+
+
+def test_an_unrecognised_OFF_kind_refuses_to_guess_a_repair(fleet):
+    """The `else` arm of the repair chain is a REFUSAL, not a default. Driven by
+    pointing the arm at a state whose kind the chain does know, then asserting the
+    known repair is what prints — the refusal text must not appear for a kind that
+    IS handled, or the arm would be printing 'I do not know' over a state it does.
+    """
+    rc, out = _protect(fleet, "--no-remote", gh=GATE_IS_LIVE_OFF)
+    assert rc == 24, out
+    assert "NO SPECIFIC REPAIR" not in out, (
+        "a KNOWN off kind took the unrecognised-kind arm\n" + out
+    )
+    assert "no protection object at all" in out or "PATCH CANNOT" in out, out
+
+
+# --- F2: the test that carried a claim its body never exercised -------------- #
+def test_DRIFT_PROTECT_SLUG_changes_the_SUBJECT_and_the_run_names_it(fleet):
+    """⚠ THE CLAIM, CORRECTED. An earlier version of this test asserted only that
+    an UNENUMERATED slug still fires — which never touched the interesting case,
+    while its name claimed the variable "never turns a finding off". It does:
+    point the arm at a repo whose main IS gated and the run exits 0.
+
+    The defensible property is narrower and is what is asserted here: the run
+    PRINTS THE SLUG IT ASKED ABOUT, so a silence produced this way names a repo
+    the operator never chose. An EXPECTATION override would leave the correct
+    subject in place and change only the verdict — nothing in the output would
+    differ from a healthy run. Redirecting the subject is loud; flipping the
+    expectation is silent.
+    """
+    fleet.catch_up()
+    _slug_aware_gh(fleet, {
+        UNGATED_SLUG: ("false 0 ", "false"),
+        GATED_SLUG: ("true 2 alpha-check,bravo-check", "true"),
+    })
+    rc_bad, out_bad = fleet.check("--no-remote", DRIFT_PROTECT_SLUG=UNGATED_SLUG)
+    assert rc_bad == 24, f"the ungated fixture repo did not fire: {rc_bad}\n{out_bad}"
+    assert UNGATED_SLUG in out_bad, out_bad
+
+    rc_ok, out_ok = fleet.check("--no-remote", DRIFT_PROTECT_SLUG=GATED_SLUG)
+    # 🔴 THE HONEST HALF: the env var DID silence it. Asserted, not denied.
+    assert rc_ok == 0, f"expected the gated fixture repo to be a clean pass: {rc_ok}\n{out_ok}"
+    # ...and the tell that makes that acceptable, which is the whole argument.
+    assert GATED_SLUG in out_ok, (
+        "the run did not name the subject it was redirected to — the silence would "
+        "then be indistinguishable from a real pass\n" + out_ok
+    )
+    assert UNGATED_SLUG not in out_ok, out_ok
+
+
+def test_the_expectation_is_still_read_from_the_enumeration_for_any_subject(fleet):
+    """The complement: redirecting the subject does not redirect the EXPECTATION.
+    Both fixture repos are unenumerated, so both are expected ON — the gated one
+    passes because it is gated, not because anything declared it off."""
+    fleet.catch_up()
+    _slug_aware_gh(fleet, {GATED_SLUG: ("true 2 alpha-check,bravo-check", "true")})
+    rc, out = fleet.check("--no-remote", DRIFT_PROTECT_SLUG=GATED_SLUG)
+    assert rc == 0, out
+    assert "expected ON (not declared off in drift-check.sh) and live ON" in out, (
+        "the pass did not come from the expectation enumeration\n" + out
+    )
+    assert "DECLARED OFF" not in out, out
 
 
 

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -6485,6 +6485,378 @@ def test_rc24_is_ranked_between_rc8_and_rc17_in_the_severity_table():
     )
 
 
+# --------------------------------------------------------------------------- #
+# THE DECLARED EXPECTATION (rc 24 / rc 25)
+#
+# 🔴 THE DESIGN DECISION THESE TESTS EXIST TO PIN. Measured 2026-09-02: the merge
+# gate on innovation-upstream/devrc is OFF, DELIBERATELY — the operator turned it
+# off until the Tekton capacity issue is addressed, which a different session
+# owns. The bare-state arm therefore fired rc 24 on EVERY 6-hourly run (5
+# failures in 3 days, and it would have continued indefinitely), and
+# `drift-check.service`'s OnFailure is the ONE toast class deliberately wired to
+# bypass do-not-disturb — nix/home.nix justifies that bypass by a MEASURED rate
+# of ~1 firing in 9 days. That is the permanently-red gate `claude/RULES.md`
+# refuses, arrived at from a third direction: not a broken instrument and not a
+# false positive, but a TRUE finding about a state nobody intends to change.
+#
+# 🔴 AND SIMPLY EXCUSING IT IS THE WRONG FIX, because rc 24 is the only thing
+# that catches a BOTCHED BREAK-GLASS RESTORE — the measured 2026-08-29 shape
+# where DELETE opened the window, the restore trap RAN, and PATCH could not close
+# it. So the arm fires on the DISAGREEMENT between a declared expectation and
+# what was measured, and the four cells are tested independently:
+#
+#   declared ON,  live OFF  -> rc 24   (the alarm, preserved whole)
+#   declared ON,  live ON   -> no code
+#   declared OFF, live OFF  -> no code, reported plainly
+#   declared OFF, live ON   -> rc 25   (the declaration is stale, and a stale
+#                                       "off" DISARMS rc 24 — that is the hazard)
+#   gh cannot answer        -> COULD NOT MEASURE, no code, under EITHER declaration
+#
+# 🔴 THE EXPECTATIONS BELOW ARE LITERALS WRITTEN OUT IN THIS FILE, never read
+# back out of drift-check.sh. An assertion built from the module under test is
+# satisfied by that module agreeing with itself, which is the defect class devrc
+# #1233 hit five times in one PR.
+# --------------------------------------------------------------------------- #
+
+# The one repo whose merge gate drift-check.sh declares OFF, spelled out here
+# rather than parsed from the script. Changing the declaration must fail these.
+DECLARED_OFF_SLUG = "innovation-upstream/devrc"
+
+# A `gh` branch-endpoint payload for a branch that IS gated: two classic required
+# checks. stub_gh answers the follow-up /protection call with `true`, so
+# enforce_admins binds and the arm reads the gate as LIVE ON.
+GATE_IS_LIVE_ON = "true 2 alpha-check,bravo-check"
+# ...and one for a standing protection object whose required_status_checks was
+# deleted out of it: the measured 2026-08-29 shape, and the 2026-09-02 one.
+GATE_IS_LIVE_OFF = "true 0 "
+
+
+def _declared(fleet, *args, gh=None, gh_rc=0, **env):
+    """Run the checker with the arm pointed at the DECLARED-OFF slug."""
+    fleet.catch_up()
+    if gh is not None:
+        fleet.stub_gh(gh, exit_code=gh_rc)
+    return fleet.check(*args, DRIFT_PROTECT_SLUG=DECLARED_OFF_SLUG, **env)
+
+
+# --- cell 3: declared OFF, live OFF — the state measured 2026-09-02 --------- #
+def test_a_declared_off_gate_that_is_live_off_sets_no_rc(fleet):
+    """🔴 THE REGRESSION. This exact input exited 24 before the change, on every
+    run, forever. It must now be a clean run that SAYS what it saw."""
+    rc, out = _declared(fleet, "--no-remote", gh=GATE_IS_LIVE_OFF)
+    assert rc == 0, f"a declared-off gate still fired: {rc}\n{out}"
+    assert "DECLARED OFF, and live OFF" in out, out
+    # 🔴 REPORTED, NOT SWALLOWED. The state is still printed, with its reason,
+    # because a difference that is TOLERATED and a difference that was never
+    # LOOKED AT must not read the same way.
+    assert "ZERO required status checks" in out, (
+        "the measured fact was suppressed along with the code\n" + out
+    )
+    assert "Tekton" in out, "the declaration's reason was not printed\n" + out
+    assert "DRIFT" not in out, out
+
+
+def test_a_declared_off_run_says_the_alarm_is_still_armed(fleet):
+    """🔴 A quiet alarm and a disabled alarm are different claims, and the only
+    reader of this output is a journal. The run must say which one it is, or the
+    next person to read it concludes rc 24 was deleted."""
+    rc, out = _declared(fleet, "--no-remote", gh=GATE_IS_LIVE_OFF)
+    assert rc == 0, out
+    assert "QUIET, not DISABLED" in out, out
+    assert "rc 25" in out, "the report does not name what fires if this goes stale\n" + out
+
+
+# --- cell 4: declared OFF, live ON — the STALE DECLARATION ------------------ #
+def test_a_declared_off_gate_that_is_live_ON_is_rc25(fleet):
+    """🔴 THE HAZARD THE DECLARATION CREATES, and why it cannot pass silently.
+
+    Once protection is back, a declaration that still says "off" makes cell 3 —
+    no code — the verdict for a gate that has been REMOVED. The rc-24 alarm is
+    then disarmed, and the botched-restore shape it was built for passes without
+    a sound. Nothing is lost yet; the ability to notice is.
+    """
+    rc, out = _declared(fleet, "--no-remote", gh=GATE_IS_LIVE_ON)
+    assert rc == 25, f"a stale declaration did not fire rc 25: {rc}\n{out}"
+    assert "STALE DECLARATION" in out, out
+    assert "DISARMS rc 24" in out, (
+        "the finding does not say WHY a stale declaration matters\n" + out
+    )
+    # The repair has to name the thing to edit; "fix the declaration" is not one.
+    assert "bp_declared_off_reason" in out, out
+
+
+def test_a_stale_declaration_is_reached_through_the_RULESET_path_too(fleet):
+    """🔴 REACHABILITY, on the second of the two places the arm decides LIVE ON.
+
+    A branch with zero CLASSIC checks that is gated by a ruleset reads ON by a
+    completely different code path. If only the classic path fed the verdict,
+    this input would take the ruleset branch, print "the gate is ON", and then
+    fall through to cell 3 and exit 0 — a stale declaration that passes because
+    the gate happens to be spelled the newer way.
+    """
+    fleet.catch_up()
+    # The live shape measured on astral-sh/uv: `true 0` classically, one active
+    # ruleset with a required_status_checks rule and no bypass actors.
+    _gh_router(fleet, branch="true 0 ", rules="1 20260902", ruleset="active 0")
+    rc, out = fleet.check("--no-remote", DRIFT_PROTECT_SLUG=DECLARED_OFF_SLUG)
+    assert rc == 25, f"the ruleset path did not reach the stale-declaration arm: {rc}\n{out}"
+    assert "STALE DECLARATION" in out, out
+    # The fixture's own ruleset id, distinct from every other constant here — the
+    # classic path cannot print it, so this pins WHICH branch decided LIVE ON.
+    assert "ruleset 20260902 gates it" in out, (
+        "the ruleset branch was not the one that ran\n" + out
+    )
+
+
+# --- cell 1: declared ON (the default), live OFF — the alarm, preserved ----- #
+def test_an_UNDECLARED_repo_with_no_gate_still_fires_rc24(fleet):
+    """🔴 FAILS CLOSED. A repo nobody has argued about is expected to be GATED,
+    so the 2026-08-29 alarm survives the change untouched for every remote but
+    the one enumerated. BP_SLUG is a fixture owner/repo that appears in no
+    declaration."""
+    rc, out = _protect(fleet, "--no-remote", gh=GATE_IS_LIVE_OFF)
+    assert rc == 24, f"the botched-restore alarm was lost: {rc}\n{out}"
+    assert "NOTHING DECLARES" in out, (
+        "the finding does not say that the state is undeclared\n" + out
+    )
+    # ...and it points at the reviewable place to declare it, not at an env var.
+    assert "bp_declared_off_reason" in out, out
+
+
+def test_enforce_admins_false_on_a_DECLARED_off_repo_sets_no_rc(fleet):
+    """🔴 REACHABILITY, on the second of the two places the arm decides LIVE OFF.
+
+    Required checks present but enforce_admins FALSE is half a gate, and the arm
+    calls that OFF. On a declared-off repo it must therefore be excused like any
+    other off — if only the zero-checks path consulted the declaration, this
+    input would fire rc 24 on the very repo the operator declared off.
+    """
+    fleet.catch_up()
+    _gh_router(fleet, branch="true 2 alpha-check,bravo-check", protection="false")
+    rc, out = fleet.check("--no-remote", DRIFT_PROTECT_SLUG=DECLARED_OFF_SLUG)
+    assert rc == 0, f"half a gate on a declared-off repo still fired: {rc}\n{out}"
+    assert "enforce_admins is FALSE" in out, "the wrong branch ran\n" + out
+    assert "DECLARED OFF, and live OFF" in out, out
+
+
+# --- cell 2: declared ON, live ON ------------------------------------------- #
+def test_an_undeclared_repo_with_a_live_gate_says_so_explicitly(fleet):
+    """🔴 REPORT THE PASS ALONGSIDE THE REDS. An arm that only ever prints on a
+    finding is indistinguishable from one wired to nothing."""
+    rc, out = _protect(fleet, "--no-remote", gh=GATE_IS_LIVE_ON)
+    assert rc == 0, f"a gated main was reported as drift: {rc}\n{out}"
+    assert "expected ON" in out and "live ON" in out, out
+    assert "STALE DECLARATION" not in out, out
+
+
+# --- the could-not-measure family, now under a DECLARATION ------------------ #
+def test_a_gh_that_answers_nothing_is_still_could_not_measure_for_a_declared_repo(fleet):
+    """🔴 THE LOAD-BEARING ONE, and the declaration must not have created a
+    second way to manufacture a verdict from an absence.
+
+    An empty `gh` answer is neither "the gate is off" nor "the gate is on", so it
+    is neither cell 3 nor cell 4. It must print a reason and set NO code — and
+    crucially it must NOT print the declared-off report, which would be an
+    affirmative claim about a state nobody read.
+    """
+    rc, out = _declared(fleet, "--no-remote", gh="", gh_rc=1)
+    assert rc == 0, f"an unreadable gh produced a verdict: {rc}\n{out}"
+    assert "[protect] COULD NOT MEASURE" in out, out
+    assert "DECLARED OFF, and live OFF" not in out, (
+        "an absence was reported as agreement with the declaration\n" + out
+    )
+    assert "STALE DECLARATION" not in out, out
+
+
+def test_no_gh_binary_at_all_is_could_not_measure_for_a_declared_repo(fleet):
+    """The other spelling of the same refusal: the binary is simply absent."""
+    rc, out = _declared(fleet, "--no-remote", gh=None)
+    assert rc == 0, out
+    assert "[protect] COULD NOT MEASURE" in out, out
+    assert "DECLARED OFF" not in out, out
+    assert "STALE DECLARATION" not in out, out
+
+
+# --- the declaration itself -------------------------------------------------- #
+def _declaration_body():
+    src = DRIFT.read_text()
+    assert "bp_declared_off_reason() {" in src, (
+        "the declaration function is gone — the expectation is being taken from "
+        "somewhere else now"
+    )
+    return src.split("bp_declared_off_reason() {", 1)[1].split("\n}", 1)[0]
+
+
+def test_the_declaration_names_exactly_the_repos_argued_for():
+    """🔴 A TWO-WAY LEDGER, asserted against a literal in THIS file.
+
+    A repo silently added to the declaration is an rc-24 alarm silently switched
+    off for that remote, and it is the one change to this file that produces no
+    visible symptom at all — the run just goes quiet. So the set is pinned in
+    both directions: an addition fails here, and so does a removal.
+    """
+    slugs = set(re.findall(r'\[\s*"\$1"\s*=\s*(\S+)\s*\]', _declaration_body()))
+    assert slugs == {DECLARED_OFF_SLUG}, (
+        f"drift-check.sh declares the merge gate off for {sorted(slugs)}, and this "
+        f"ledger says {sorted({DECLARED_OFF_SLUG})}. Every entry has to be argued "
+        f"for in a diff a human read."
+    )
+
+
+def test_every_declared_repo_carries_a_written_reason():
+    """An entry with no reason is an expectation nobody can audit later. The
+    reason is also what the run PRINTS, so an empty one produces a report that
+    excuses a finding and declines to say why."""
+    body = _declaration_body()
+    reasons = [r for r in re.findall(r'^\s*echo "([^"]*)"', body, re.M) if r.strip()]
+    assert len(reasons) == 1, (
+        f"expected one non-empty reason for the one declared repo, got {reasons!r}"
+    )
+    assert len(reasons[0]) >= 40, f"the reason is a placeholder, not a reason: {reasons[0]!r}"
+
+
+def test_the_declaration_is_a_pure_function_of_its_argument():
+    """🔴 THE STRUCTURAL HALF of "not env-overridable", and it is wider than a
+    grep for variable names.
+
+    The behavioural test below can only refuse the env var names somebody thought
+    of. This asserts the shape instead: every line of the function is a literal
+    comparison against `$1`, an `echo` of a literal, or block punctuation. No
+    other parameter expansion, no command substitution, no redirection — so the
+    answer cannot come from the environment, from a file, or from a path someone
+    can point elsewhere. A ledger PATH would be the same hole one level out.
+    """
+    allowed = re.compile(
+        r'^(?:'
+        r'(?:el)?if \[ "\$1" = [A-Za-z0-9._/-]+ \]; then'
+        r'|else'
+        r'|fi'
+        r'|echo "[^"$`]*"'
+        r')$'
+    )
+    offenders = []
+    for ln in _declaration_body().splitlines():
+        s = ln.strip()
+        if not s or s.startswith("#"):
+            continue
+        if not allowed.match(s):
+            offenders.append(s)
+    assert offenders == [], (
+        "bp_declared_off_reason takes its answer from something other than its "
+        "own argument and its own literals: %r" % offenders
+    )
+
+
+def test_the_declaration_cannot_be_set_from_the_environment(fleet):
+    """🔴 The behavioural half. An expectation a run can set is an expectation
+    the run can use to excuse itself — the checker would be policed by the same
+    environment it is policing. Every plausible spelling is set to declare the
+    fixture repo off; the alarm must fire anyway.
+    """
+    src = "\n".join(ln for ln in DRIFT.read_text().splitlines()
+                    if not ln.strip().startswith("#"))
+    assert not re.search(r"DRIFT_(PROTECT_EXPECT|EXPECT|DECLAR|GATE)", src), (
+        "the protection expectation reads an environment variable — it must be "
+        "reviewable source, not runtime input"
+    )
+    rc, out = _protect(
+        fleet, "--no-remote", gh=GATE_IS_LIVE_OFF,
+        DRIFT_PROTECT_EXPECT="off",
+        DRIFT_EXPECT_PROTECTION="off",
+        DRIFT_DECLARED_OFF=BP_SLUG,
+        DRIFT_GATE_DECLARED_OFF="1",
+        DRIFT_PROTECT_DECLARATION="/dev/null",
+    )
+    assert rc == 24, f"an env var declared the gate off: {rc}\n{out}"
+
+
+def test_DRIFT_PROTECT_SLUG_changes_the_subject_and_never_the_expectation(fleet):
+    """⚠ THE ONE OVERRIDE THAT REMAINS, and the distinction that makes it safe.
+
+    It selects WHICH repo is asked about; the expectation is still looked up in
+    the enumeration, and an unenumerated slug is expected ON. So it cannot turn a
+    finding off — pointing it at a repo nobody declared still fires rc 24 on an
+    ungated main, which is exactly what the rest of this file relies on.
+    """
+    rc, out = _protect(fleet, "--no-remote", gh=GATE_IS_LIVE_OFF)
+    assert rc == 24, out
+    assert BP_SLUG in out, out
+    rc2, out2 = _declared(fleet, "--no-remote", gh=GATE_IS_LIVE_OFF)
+    assert rc2 == 0, out2
+    assert DECLARED_OFF_SLUG in out2, out2
+
+
+# --- one rule, one place ----------------------------------------------------- #
+def test_the_arm_decides_its_code_in_exactly_one_place():
+    """🔴 THE CONSOLIDATION, pinned. `note_rc 24` used to sit at THREE sites — the
+    zero-classic-checks branch, the enforce_admins branch and the ruleset branch
+    — and a predicate open-coded at N sites is wrong at N-1 of them in the same
+    direction. Adding the declaration to two of three would leave an arm that
+    still fires on a declared-off gate, correct at both of the sites anyone would
+    think to read. Both codes are now decided once, at the bottom, from BP_LIVE.
+    """
+    src = "\n".join(ln for ln in DRIFT.read_text().splitlines()
+                    if not ln.strip().startswith("#"))
+    for code in (24, 25):
+        n = len(re.findall(rf"^\s*note_rc {code}\b", src, re.M))
+        assert n == 1, (
+            f"note_rc {code} is called {n} times; the branch-protection verdict "
+            f"must be decided in exactly one place, against the declaration"
+        )
+
+
+# --- severity ---------------------------------------------------------------- #
+def test_a_stale_declaration_is_outranked_by_unpushed_commits(fleet):
+    """rc 8 is work that exists on exactly one machine and a careless rescue
+    destroys it. A disarmed detector has lost nothing yet."""
+    fleet.catch_up()
+    fleet.add_local_commit("commit the workbench never pushed")
+    fleet.stub_gh(GATE_IS_LIVE_ON)
+    rc, out = fleet.check("--no-remote", DRIFT_PROTECT_SLUG=DECLARED_OFF_SLUG)
+    assert rc == 8, f"rc 25 masked the un-pushed commits: {rc}\n{out}"
+    assert "STALE DECLARATION" in out, "the rc25 finding was lost\n" + out
+
+
+def test_a_stale_declaration_outranks_a_merely_behind_host(fleet):
+    """The fixture clone starts one commit BEHIND (rc 10). A host that just needs
+    a ship must not hide the fact that the merge-gate alarm is switched off."""
+    fleet.stub_gh(GATE_IS_LIVE_ON)                  # no catch_up: still behind
+    rc, out = fleet.check("--no-remote", DRIFT_PROTECT_SLUG=DECLARED_OFF_SLUG)
+    assert rc == 25, f"rc 10 masked the stale declaration: {rc}\n{out}"
+    assert "local main is BEHIND origin/main" in out, "the rc10 finding was lost\n" + out
+
+
+def test_rc25_is_ranked_between_rc17_and_rc14_in_the_severity_table():
+    """🔴 The digit is the LARGEST in the table and its rank is fourth.
+
+    BELOW 17 by this table's own published principle — "a hazard that has already
+    cost something outranks one that is merely open": rc 17's measured failure
+    had already shipped a binary that ran, exited 0 and silently did nothing.
+    ABOVE 14 by the other one: 14 is LOUD at the moment of use, and this is
+    silent by construction — its whole symptom is that nothing says anything.
+    """
+    body = DRIFT.read_text().split("severity() {", 1)[1].split("\n}", 1)[0]
+    body = "\n".join(ln for ln in body.splitlines() if not ln.strip().startswith("#"))
+    ranks = {int(c): int(r) for c, r in re.findall(r"^\s*(\d+)\)\s*echo (\d+)", body, re.M)}
+    assert 25 in ranks, "rc 25 is not ranked in severity(); it would fall to 99, above rc 8"
+    assert ranks[17] > ranks[25] > ranks[14], (
+        "rc 25 is not between rc 17 and rc 14: %r" % {k: ranks[k] for k in (17, 25, 14)}
+    )
+    header = DRIFT.read_text().split("\nset -", 1)[0]
+    assert "17 > 25 > 14" in header, (
+        "the header's severity ladder does not place rc 25 where severity() does"
+    )
+
+
+def test_the_rc25_legend_is_printed_with_the_verdict(fleet):
+    """The journal is the only place this output is ever read."""
+    rc, out = _declared(fleet, "--no-remote", gh=GATE_IS_LIVE_ON)
+    assert rc == 25, out
+    assert "rc25=" in out, out
+    assert "drift-check: DRIFT (rc=25)" in out, out
+
+
+
 # --- passivity, on a surface the git allowlist cannot see -------------------- #
 # 🔴 THE ALLOWLIST, built on the tokenizer this file ALREADY has. A second,
 # private tokenizer was the first attempt and it read ZERO calls: `shlex` on

--- a/scripts/tests/test_drift_check.py
+++ b/scripts/tests/test_drift_check.py
@@ -6491,13 +6491,16 @@ def test_rc24_is_ranked_between_rc8_and_rc17_in_the_severity_table():
 # 🔴 THE DESIGN DECISION THESE TESTS EXIST TO PIN. Measured 2026-09-02: the merge
 # gate on innovation-upstream/devrc is OFF, DELIBERATELY — the operator turned it
 # off until the Tekton capacity issue is addressed, which a different session
-# owns. The bare-state arm therefore fired rc 24 on EVERY 6-hourly run (5
-# failures in 3 days, and it would have continued indefinitely), and
-# `drift-check.service`'s OnFailure is the ONE toast class deliberately wired to
-# bypass do-not-disturb — nix/home.nix justifies that bypass by a MEASURED rate
-# of ~1 firing in 9 days. That is the permanently-red gate `claude/RULES.md`
-# refuses, arrived at from a third direction: not a broken instrument and not a
-# false positive, but a TRUE finding about a state nobody intends to change.
+# owns. The bare-state arm therefore reported it as DRIFT on every run that
+# reached it, and would have indefinitely, while `drift-check.service`'s
+# OnFailure is the ONE toast class deliberately wired to bypass do-not-disturb.
+# That is the permanently-red gate `claude/RULES.md` refuses, arrived at from a
+# third direction: not a broken instrument and not a false positive, but a TRUE
+# finding about a state nobody intends to change.
+# ⚠ The breach rate and the arithmetic against the bypass's justification are
+# stated ONCE, in nix/home.nix's `zz_notify_failure_bypass` block. Do not restate
+# them here — an earlier wording of this very comment carried a wrong count and a
+# wrong multiple, which is why that rule exists.
 #
 # 🔴 AND SIMPLY EXCUSING IT IS THE WRONG FIX, because rc 24 is the only thing
 # that catches a BOTCHED BREAK-GLASS RESTORE — the measured 2026-08-29 shape
@@ -6943,33 +6946,108 @@ def test_a_PARTIAL_restore_under_a_declaration_is_rc25_not_agreement(fleet):
     assert "BOTH halves" in out, out
 
 
-def test_the_agreement_cell_no_longer_promises_something_false(fleet):
-    """The cell-3 report used to say "Restore protection and this becomes rc 25",
-    which was false for a partial restore. It must now describe what actually
-    happens, and the journal is the only place this is ever read."""
+def test_the_agreement_cell_promises_exactly_what_the_arm_does(fleet):
+    """🔴 THE REPORT IS A CLAIM, AND THE JOURNAL IS THE ONLY PLACE IT IS READ.
+
+    Cell 3 used to say "Restore protection and this becomes rc 25" — false for a
+    partial restore, which set no code. It was corrected once for the
+    enforce_admins spelling and was then false again for the ruleset spelling.
+
+    So this pins the RELATIONSHIP rather than a phrase: the agreement cell must
+    name every state that DOES fire (both half-gate spellings) and the one that
+    does NOT (evaluate/disabled). A guard on a single word is walkable by
+    rewording, and this sentence has been reworded twice.
+    """
     rc, out = _declared(fleet, "--no-remote", gh=GATE_IS_LIVE_OFF)
     assert rc == 0, out
-    assert "PARTIAL restore" in out, (
-        "the agreement cell does not say that a partial restore also fires\n" + out
+    cell = "\n".join(ln for ln in out.splitlines() if ln.startswith("[protect]"))
+    for fires in ("enforce_admins", "bypass actors"):
+        assert fires in cell, (
+            f"the agreement cell does not say a {fires!r} half-gate also fires\n" + cell
+        )
+    assert "evaluate" in cell, (
+        "the agreement cell does not say which state it stays quiet for\n" + cell
     )
 
 
-def test_a_NONBINDING_RULESET_under_a_declaration_stays_in_the_agreement_cell(fleet):
-    """⚠ THE ARGUED ASYMMETRY, pinned so it cannot drift into "we forgot".
+def test_an_INACTIVE_ruleset_under_a_declaration_stays_in_the_agreement_cell(fleet):
+    """⚠ THE ARGUED ASYMMETRY, and it is now narrow enough to be argued.
 
-    `/rules/branches/main` returns the rules of every APPLYING ruleset, repo- and
-    ORG-level mixed, and an org ruleset parked in `evaluate` mode is the standard
-    org rollout pattern — nothing this repo created or can remove. Firing rc 25 on
-    it would be a permanently-red gate on a state nobody can close. Unlike the
-    enforce_admins case, it carries no evidence that anyone restored anything on
-    THIS repo, so it stays quiet and converts to rc 25 the moment a ruleset binds.
+    ⚠ THIS TEST USED TO GENERALISE OVER "a nonbinding ruleset" WHILE ITS BODY
+    EXERCISED ONLY `evaluate` — the docstring-claims-a-relationship,
+    body-inspects-one-side shape. The other sub-state, `active` with
+    `bypass_actors > 0`, landed in the same OFF kind and was SILENT under a
+    declaration while its exact classic twin (enforce_admins=false) fired. It now
+    fires rc 25; see the sibling test. This one is scoped to what it checks.
+
+    Evaluate/disabled is not a gate anybody built — it is explicitly a
+    non-enforcing dry run — so it is not evidence that a declared-off gate was
+    restored. `/rules/branches/main` also returns the rules of every APPLYING
+    ruleset, repo- and ORG-level mixed, and an org ruleset parked in evaluate is
+    the standard rollout: firing on it would be a permanently-red gate on a state
+    nobody can close. It converts to rc 25 the moment a ruleset binds.
     """
     fleet.catch_up()
     _gh_router(fleet, branch="true 0 ", rules="1 20260903", ruleset="evaluate 0")
     rc, out = fleet.check("--no-remote", DRIFT_PROTECT_SLUG=DECLARED_OFF_SLUG)
-    assert rc == 0, f"a non-binding ruleset fired under a declaration: {rc}\n{out}"
+    assert rc == 0, f"an inactive ruleset fired under a declaration: {rc}\n{out}"
     assert "DECLARED OFF, and live OFF" in out, out
     assert "STALE DECLARATION" not in out, out
+
+
+def test_an_ACTIVE_ruleset_with_BYPASS_ACTORS_under_a_declaration_is_rc25(fleet):
+    """🔴 THE OTHER HALF, and by this script's own account the LIKELY one.
+
+    drift-check.sh calls a ruleset "the most likely next repair of THIS repo", so
+    the realistic sequence is: the operator restores the gate with a repo ruleset
+    and leaves an admin or an app in `bypass_actors`. The ruleset is ACTIVE and
+    lists a required check — somebody built a gate — and the script's own loop
+    calls bypass actors "the ruleset spelling of enforce_admins=false".
+
+    Reading that as agreement made the deadman go quiet indefinitely on exactly
+    the state F3 exists to catch, while the classic spelling of the identical
+    state fired rc 25 three lines earlier.
+    """
+    fleet.catch_up()
+    # ACTIVE, one required-checks rule, 2 bypass actors. Fixture ruleset id is
+    # distinct from every other constant in this file.
+    _gh_router(fleet, branch="true 0 ", rules="1 20260904", ruleset="active 2")
+    rc, out = fleet.check("--no-remote", DRIFT_PROTECT_SLUG=DECLARED_OFF_SLUG)
+    assert rc == 25, f"an active-but-bypassed ruleset passed silently: {rc}\n{out}"
+    assert "STALE DECLARATION" in out, out
+    assert "PARTIAL restore by the RULESET mechanism" in out, out
+    # The finding must name the actual bypass count it measured, not just "some".
+    assert "20260904=bypass-actors:2" in out, out
+    assert "expectation and reality agree" not in out, (
+        "a half-restored ruleset gate is still reported as agreement\n" + out
+    )
+    assert "BOTH halves" in out, out
+
+
+def test_an_ACTIVE_bypassed_ruleset_on_an_UNDECLARED_repo_is_still_rc24(fleet):
+    """The alarm for a repo nobody declared must not move. Same input, fixture
+    slug — this was rc 24 before the declaration existed and must stay so."""
+    fleet.catch_up()
+    _gh_router(fleet, branch="true 0 ", rules="1 20260904", ruleset="active 2")
+    rc, out = fleet.check("--no-remote", DRIFT_PROTECT_SLUG=BP_SLUG)
+    assert rc == 24, f"an active-but-bypassed ruleset stopped firing rc 24: {rc}\n{out}"
+    assert "NOTHING DECLARES" in out, out
+    assert "remove the bypass actors" in out, out
+
+
+def test_a_bypassed_ruleset_ALONGSIDE_an_inactive_one_is_still_rc25(fleet):
+    """🔴 A NON-ENFORCING SIBLING DOES NOT SOFTEN THE FINDING. Both rulesets are
+    examined; one is evaluate-mode, one is active-with-bypass. The verdict must
+    be decided by the one that IS a gate, not by whichever the loop saw last."""
+    fleet.catch_up()
+    _gh_router(fleet, branch="true 0 ", rules="2 20260903,20260904",
+               ruleset={"20260903": "evaluate 0", "20260904": "active 2"})
+    rc, out = fleet.check("--no-remote", DRIFT_PROTECT_SLUG=DECLARED_OFF_SLUG)
+    assert rc == 25, f"an inactive sibling suppressed the finding: {rc}\n{out}"
+    assert "STALE DECLARATION" in out, out
+    # ...and both reasons are still reported, so the operator sees the whole set.
+    assert "20260903=enforcement:evaluate" in out, out
+    assert "20260904=bypass-actors:2" in out, out
 
 
 def test_an_UNDECLARED_partial_restore_is_still_rc24(fleet):
@@ -7011,7 +7089,8 @@ def test_every_BP_OFF_KIND_assigned_is_branched_on_in_the_verdict():
     )
     # ...and the literal set, written out HERE, so a fourth kind has to be argued
     # for rather than merely spelled consistently in two places.
-    assert assigned == {"classic-zero", "enforce-admins", "ruleset-nonbinding"}, (
+    assert assigned == {"classic-zero", "enforce-admins",
+                        "ruleset-bypassed", "ruleset-inactive"}, (
         f"the OFF-kind vocabulary changed: {sorted(assigned)}"
     )
 


### PR DESCRIPTION
## The problem, measured

`drift-check.service` exits **24** on every fire. Measured on the workbench 2026-09-02:

- `systemctl --user show drift-check.service` → `Result=exit-code`, `ExecMainStatus=24`
- 5 failures in 3 days, on a 6h `OnUnitActiveSec` timer — it would have continued indefinitely
- live API: `required_status_checks` absent from the protection object, `enforce_admins: false`, while `GET /branches/main` still reports `protected: true`

The unit's `OnFailure` is `notify-failure@%n.service` — the **one** toast class deliberately wired to bypass do-not-disturb (`zz_notify_failure_bypass`, `override_pause_level = 100`). `nix/home.nix` justifies that bypass by a **measured rate of ~1 firing in 9 days**. 4/day is three orders of magnitude past it.

But the finding is **true**: the merge gate really is off. It is off *deliberately* — until the Tekton capacity issue is addressed, which a different session owns. So this is a permanently-red gate reached by a third route: not a broken instrument, not a false positive, but a true finding about a state nobody intends to change.

And rc 24 could not simply be excused: it is the only thing that catches a **botched break-glass restore** — the measured 2026-08-29 shape where `DELETE` opened the window, the restore trap *ran*, and `PATCH` could not close the sub-resource.

## The design

The arm now fires on the **disagreement** between a declared expectation and what it measured:

| declared | live | verdict |
|---|---|---|
| ON | OFF | **rc 24** — the alarm, preserved whole |
| ON | ON | no code |
| OFF | OFF | no code; reported plainly, with the reason |
| OFF | ON | **rc 25** — STALE DECLARATION |
| — | `gh` cannot answer | COULD NOT MEASURE, no code, under **either** declaration |

### Why `expected=off / live=on` is rc 25 and not silence

A stale "off" **disarms rc 24**. Declared-off/live-off is the excused cell, so once protection is restored and the declaration still says off, a gate that is removed *again* lands in that same cell and passes silently — the botched-restore detector is switched off while the thing it detects is live again. Nothing is lost yet; what is lost is the ability to notice.

It ranks **between rc 17 and rc 14**, derived from this table's own two published principles:

- **below 17** — *"a hazard that has already cost something outranks one that is merely open"* (severity()'s own argument for 8 > 24). rc 17's measured failure had already shipped a binary that ran, exited 0 and silently did nothing. Here the gate is **up**.
- **above 14** — 14 is LOUD at the moment of use (`command not found`); this is silent by construction, since its whole symptom is that nothing says anything.

No escalation ladder, deliberately: unlike rc 13/16/18, its repair is a one-line edit by whoever restored the protection, so it is closable the moment it is seen.

### Where the declaration lives

`bp_declared_off_reason()` in `scripts/drift-check.sh` — an enumeration of literal `if [ "$1" = <slug> ]` arms, each carrying its reason, in the same shape and for the same stated reason as the `settings.json` per-host allowlist. It **fails closed** (an unenumerated repo is expected ON), and there is **no env override and no ledger path**: an expectation a run can set is one the run can use to excuse itself.

`DRIFT_PROTECT_SLUG` is not that hole — it changes *which* repo is asked about, never what is expected of it, so it cannot turn a finding off.

### One rule, one place

`note_rc 24` used to sit at **three** sites. Each branch now decides only `BP_LIVE=on|off` and prints its measured facts; the alarm, the repair text and the code are decided **once**, at the bottom. Adding the declaration to two of the three would have left an arm that still fires on a declared-off gate, correct at both sites anyone would think to read.

## Verification

**Live, before/after** (`--no-remote`, real `gh`, real remote):

- base `bf5516fc`: `rc=24`, `🔴 DRIFT — … ZERO required status checks`
- HEAD: rc 24 gone; prints `DECLARED OFF, and live OFF — expectation and reality agree. No rc is set.` with the reason. (Run still exits 10 — the base clone is a commit behind. Pre-existing, unrelated.)

**19 new tests**, 16 red at base `bf5516fc` / green at HEAD. 3 are **invariant guards** (green at base, labelled as such): the two COULD-NOT-MEASURE-under-a-declaration cases and the env-override refusal — the discipline pre-existed; these pin that the declaration did not create a second way to manufacture a verdict from an absence.

**Mutation sweep**: 7 targeted mutants + 1 positive control, each in a fresh `git archive HEAD` tree (no `.git` at all), `PYTHONDONTWRITEBYTECODE=1`, control green before and after, each mutation asserted to apply exactly once. Results in the PR thread.

`test_only_16_is_excused_from_failing_the_unit` is **untouched and green** — rc 24 and rc 25 are real divergences with real fixes and must reach `OnFailure`, so the excuse list stays at exactly one code.

## Prose fixed in the same commit

- `nix/home.nix` — the "what does/does not toast" ledger did not list rc 24 **at all**, which is what let this happen. rc 24 and rc 25 are now entered with the measurement.
- `nix/home.nix` — the dunst DND-bypass comment's `~1 firing in 9 days` justification is annotated with the breach it was measured against and what closed it.
- `CLAUDE.md` — the paragraph claiming rc 24 "will report an unprotected main every run: that report is EXPECTED, not a finding" is now false and is replaced; it also now says that **deleting the declaration is part of restoring protection**, not a follow-up.

The `<!-- merge-gate: other -->` marker is untouched and still the only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPiQDMvSzEQXRwmEHi4ZxK
