### PR TITLE
feat(espanso-detect): a snippet's declared search_terms outbid another's LABEL — a cosmetic reword must not shadow a search route

### DIFF
--- a/claude/skills/espanso-audit/SKILL.md
+++ b/claude/skills/espanso-audit/SKILL.md
@@ -117,9 +117,15 @@ prune anything from a run that printed one.
   trigger, every **label word**, and every `search_term`, so `'bench'` ⊂
   `'workbench'`, `'la'` ⊂ `'nebula'`, `'ask'` ⊂ `'task'`. A `:cgt` labelled
   "task" would have silently hijacked all 58 of `:acq`'s `'ask'` fires. Two
-  consequences: (a) when two snippets both spell the same word, **no**
-  `search_terms` edit makes a bare query resolve — one of them must stop
-  spelling it; (b) always gate with `--replay --config <candidate>` and **diff
+  consequences: (a) when two snippets both **DECLARE** the same word (in
+  `search_terms` or the trigger), **no** `search_terms` edit makes a bare query
+  resolve — one of them must stop spelling it, or the word needs an
+  `_AMBIGUOUS_TERM_OWNER` entry. 🔴 **But a snippet that spells the word only in
+  its LABEL no longer competes**: `_attribute` gives DECLARED matches precedence
+  over label-only ones, so the fix for that case IS a `search_terms` edit — add
+  the word to the snippet that should own it. The picker still lists both rows
+  either way; precedence is attribution-only. (b) always gate with
+  `--replay --config <candidate>` and **diff
   it against the deployed config for REGRESSIONS**, not just for new
   resolutions. Validate that diff with a planted mutant before believing a
   clean result.

--- a/scripts/collector/keylog/espanso_detect.py
+++ b/scripts/collector/keylog/espanso_detect.py
@@ -80,13 +80,18 @@ ESPANSO_SEARCH_WM_CLASS = ".espanso-wrapped"
 # direct-to-main commit that RED-ed `main`): ':acq' grew the LABEL "ask
 # clarifying questions and recommend improvements and anything useful to
 # include", and `_token_matches` reads the label, so both terms started matching
-# ':acq' as well as ':rna'. Note the asymmetry that decides the owner — the two
-# terms are ':rna''s declared INTERFACE (they are literally two of its six
-# `search_terms`, and its label is "Recommend next actions"), whereas on ':acq'
-# the word is incidental PROSE inside a sentence about asking questions. The
-# picker listing both rows is fine and wanted; attribution has one honest
-# answer. The label is the operator's and stays as written — this table is the
-# designed place to say so without editing either snippet.
+# ':acq' as well as ':rna'. #1247 gave them entries here. 🔴 THOSE TWO ENTRIES
+# ARE NOW DELETED, because the asymmetry that chose ':rna' as their owner is a
+# GENERAL rule, not a per-term fact: the terms are ':rna''s declared INTERFACE
+# (two of its six `search_terms`; its label is "Recommend next actions") whereas
+# on ':acq' the word is incidental PROSE. That is what `_attribute`'s
+# declared-interface precedence now decides on its own — MEASURED against the
+# live config with the entries removed, both still resolve to ':rna', and the
+# owner branch is not even REACHED for them (the declared-narrowed set is a
+# single snippet, so `_attribute` returns before the lookup). An entry nothing
+# can reach is dead code, so they went rather than staying as decoration.
+# Re-add them only if ':acq' ever DECLARES 'recom' in its own `search_terms` —
+# that would be a real collision, and then this table is again the right answer.
 #
 # 🔴 BLIND SPOT, MEASURED — THE LOOKUP IS AN EXACT-STRING MATCH, SO PREFIXES OF
 # AN OWNED TERM ARE NOT OWNED. `_term_matches` is a SUBSTRING test, so a typed
@@ -106,13 +111,23 @@ ESPANSO_SEARCH_WM_CLASS = ".espanso-wrapped"
 # prefix-aware lookup can re-point terms the exact form never touched, so it
 # needs its own mutation battery.
 #
-# 🔴 STILL ACCEPTED, and the 'recom' entries below do NOT close it — re-measured
-# 2026-09-02 against the live config: "rec", "reco" and "recomm" all match
-# BOTH ':acq' and ':rna' and all three still resolve to None, because only the
-# two exact strings keyed below are owned. This is the same blind spot, not a
-# new one, and it is recorded here so the next reader does not mistake the two
-# entries for prefix coverage. The decision is unchanged for the same reason:
-# widening it is a mechanism change, not a table entry.
+# 🔴 SINCE THE DECLARED-INTERFACE PRECEDENCE STEP (see `_attribute`), THIS TABLE
+# ONLY ARBITRATES REAL COLLISIONS — `search_terms` vs `search_terms`. A term one
+# snippet DECLARES and another merely spells in its LABEL is now settled by
+# precedence before the lookup is reached, so no entry is needed for that class.
+# 'ask'/'clarify' are the genuine case and still need it: ':acq' and ':dacq' BOTH
+# declare them (':dacq' spells "clarifying", which "clarify" is a substring of),
+# so precedence narrows nothing and the table is what decides.
+#
+# 🔴 STILL ACCEPTED FOR THE TABLE — but note that precedence closes the prefix
+# case for the LABEL-COLLISION class, and does so exactly because it is a
+# mechanism rather than an enumeration. Re-measured 2026-09-02 with precedence
+# in place: "rec"/"reco"/"recomm"/"recomme"/"recommen" all now resolve to ':rna'
+# where every one of them was None before, and no table entry names any of them.
+# 'clar' remains None: ':acq' and ':dacq' BOTH declare it, so precedence has
+# nothing to narrow and the exact-string lookup is still the only hatch. That is
+# the residual blind spot, and it is unchanged — widening the lookup is still a
+# mechanism change, not a table entry, and would need its own mutation battery.
 #
 # Same measurement, recorded so it is not re-litigated: "clarifying" has been
 # typed ZERO times, so it gets no entry — an owner justified by intuition rather
@@ -120,8 +135,6 @@ ESPANSO_SEARCH_WM_CLASS = ".espanso-wrapped"
 _AMBIGUOUS_TERM_OWNER = {
     "ask": ":acq",
     "clarify": ":acq",
-    "recom": ":rna",
-    "recommend": ":rna",
 }
 
 
@@ -336,6 +349,32 @@ class EspansoDetector:
         # contain it. This is consulted ONLY on the already-ambiguous branch, so
         # it can never re-point a term that resolves uniquely today; the tie is
         # broken only when EXACTLY ONE candidate is named outright.
+        # 🔴 DECLARED-INTERFACE PRECEDENCE. `_token_matches` reads three sources:
+        # the trigger, the `search_terms` list, and the human-readable `label`.
+        # The first two are the snippet's DECLARED interface — an authored claim
+        # that this word means this snippet. The label is a DESCRIPTION, and it
+        # is prose the operator rewords freely. So a snippet that names the term
+        # in its declared interface outbids one that only happens to SPELL it in
+        # a sentence. Measured motivation (2026-09-02, a720d30d): ':acq' grew the
+        # label "ask clarifying questions and recommend improvements and anything
+        # useful to include", which made 'recom'/'recommend' — two of ':rna''s
+        # six declared `search_terms` — ambiguous and unattributable, reddening
+        # `test_live_existing_resolutions_not_made_ambiguous` on `main`. A
+        # cosmetic reword must not shadow another snippet's declared route.
+        #
+        # This can only ever SHRINK the candidate set, so it cannot invent a
+        # resolution or re-point a term that already resolves uniquely (that
+        # branch returned above). When NO candidate matches declaredly the set is
+        # left alone: with nothing but labels to go on there is no basis to
+        # prefer one, and narrowing to the empty set would lose the answer that
+        # `_names_trigger` or `_AMBIGUOUS_TERM_OWNER` can still give. Naming a
+        # trigger outright implies a declared match (`token in trig`), so the
+        # tie-break below can never be the thing this drops.
+        declared = [trig for trig in matched if self._term_matches_declared(t, trig)]
+        if declared:
+            matched = declared
+            if len(matched) == 1:
+                return matched[0]
         exact = [trig for trig in matched if self._names_trigger(t, trig)]
         if len(exact) == 1:
             return exact[0]
@@ -372,15 +411,41 @@ class EspansoDetector:
         meta = self.ts.meta.get(trig) or {}
         return all(self._token_matches(tok, trig, meta) for tok in tokens)
 
+    def _term_matches_declared(self, term, trig):
+        """`_term_matches`, but WITHOUT consulting the label.
+
+        i.e. every token reaches `trig` through its DECLARED interface — the
+        trigger string or an entry in `search_terms`. Used only by `_attribute`'s
+        precedence step; the picker (`_term_matches`) keeps reading the label, so
+        a label-matched row is still LISTED, it just stops out-bidding a declared
+        one for the single name telemetry records.
+
+        Same rule as `_term_matches`, same helper, one flag — deliberately not a
+        second copy of the substring logic.
+        """
+        tokens = (term or "").split()
+        if not tokens:
+            return False
+        meta = self.ts.meta.get(trig) or {}
+        return all(self._token_matches(tok, trig, meta, use_label=False)
+                   for tok in tokens)
+
     @staticmethod
-    def _token_matches(token, trig, meta):
-        """One token vs one snippet, by the original (pre-2026-08-05) rules."""
+    def _token_matches(token, trig, meta, *, use_label=True):
+        """One token vs one snippet, by the original (pre-2026-08-05) rules.
+
+        `use_label=False` restricts the test to the snippet's declared interface
+        (trigger + `search_terms`). The default keeps every existing caller —
+        `_term_matches`, and `espanso-usage.py`'s reachability probe, which calls
+        this positionally — on the original three-source behaviour.
+        """
         if token in trig.lower():
             return True
-        label = (meta.get("label") or "").lower()
-        for w in _WORD_RE.findall(label):
-            if token in w:
-                return True
+        if use_label:
+            label = (meta.get("label") or "").lower()
+            for w in _WORD_RE.findall(label):
+                if token in w:
+                    return True
         for st in meta.get("search_terms") or []:
             if isinstance(st, str) and token in st.lower():
                 return True

--- a/scripts/collector/keylog/espanso_detect.py
+++ b/scripts/collector/keylog/espanso_detect.py
@@ -339,16 +339,6 @@ class EspansoDetector:
         matched = [trig for trig in self.ts.triggers if self._term_matches(t, trig)]
         if len(matched) == 1:
             return matched[0]
-        # Matching is by SUBSTRING (see `_token_matches`), so a term can match a
-        # snippet it merely occurs INSIDE. When ":acq" was split into ":dacq" +
-        # ":acq" on 2026-08-28 the bare term "acq" started matching BOTH
-        # (`"acq" in ":dacq"` is True) and every such fire was recorded
-        # UNATTRIBUTED. A term that NAMES one snippet outright — it equals that
-        # trigger, with or without the leading ":" — is not ambiguous about
-        # which snippet it means, so that snippet wins over the ones that merely
-        # contain it. This is consulted ONLY on the already-ambiguous branch, so
-        # it can never re-point a term that resolves uniquely today; the tie is
-        # broken only when EXACTLY ONE candidate is named outright.
         # 🔴 DECLARED-INTERFACE PRECEDENCE. `_token_matches` reads three sources:
         # the trigger, the `search_terms` list, and the human-readable `label`.
         # The first two are the snippet's DECLARED interface — an authored claim
@@ -375,6 +365,18 @@ class EspansoDetector:
             matched = declared
             if len(matched) == 1:
                 return matched[0]
+        # Matching is by SUBSTRING (see `_token_matches`), so a term can match a
+        # snippet it merely occurs INSIDE. When ":acq" was split into ":dacq" +
+        # ":acq" on 2026-08-28 the bare term "acq" started matching BOTH
+        # (`"acq" in ":dacq"` is True) and every such fire was recorded
+        # UNATTRIBUTED. A term that NAMES one snippet outright — it equals that
+        # trigger, with or without the leading ":" — is not ambiguous about
+        # which snippet it means, so that snippet wins over the ones that merely
+        # contain it. This is consulted ONLY on the already-ambiguous branch, so
+        # it can never re-point a term that resolves uniquely today; the tie is
+        # broken only when EXACTLY ONE candidate is named outright. (It now runs
+        # over the declared-narrowed set — which cannot drop a named candidate,
+        # since naming implies declaring.)
         exact = [trig for trig in matched if self._names_trigger(t, trig)]
         if len(exact) == 1:
             return exact[0]

--- a/scripts/collector/keylog/tests/test_espanso_detect.py
+++ b/scripts/collector/keylog/tests/test_espanso_detect.py
@@ -698,24 +698,29 @@ def test_naming_a_trigger_still_beats_the_declared_owner(monkeypatch):
 # matching ':acq' as well as ':rna' and BOTH went to None, turning
 # `test_live_existing_resolutions_not_made_ambiguous` red on `main`.
 #
-# The operator's ruling was to keep the label and relax the gate, so the fix is
-# a DECLARED owner — the same hatch as FIX 5, used for the case it was designed
-# for. The asymmetry that makes ':rna' the honest owner: 'recom' and 'recommend'
-# are two of its six declared `search_terms` and its label is "Recommend next
-# actions", while on ':acq' the word is incidental prose. Neither snippet is
-# NAMED by either term, so `_names_trigger` cannot rescue them.
+# The operator's ruling was to keep the label and relax the gate, so #1247's fix
+# was a DECLARED owner — the same hatch as FIX 5. The asymmetry that made ':rna'
+# the honest owner: 'recom' and 'recommend' are two of its six declared
+# `search_terms` and its label is "Recommend next actions", while on ':acq' the
+# word is incidental prose. Neither snippet is NAMED by either term, so
+# `_names_trigger` cannot rescue them.
+#
+# 🔴 THAT ASYMMETRY IS NOW A RULE, NOT TWO TABLE ROWS — see FIX 7 below. The two
+# entries have been DELETED: with declared-interface precedence in `_attribute`
+# they are unreachable (the declared-narrowed candidate set for these terms is a
+# single snippet, so `_attribute` returns before the owner lookup), and this repo
+# does not keep entries nothing can reach. The tests in this section therefore
+# still pin the RESOLUTION — which is the contract that matters and must not
+# regress — while no longer claiming the table is what produces it.
 #
 # 🔴 WHICH OF THESE ARE REGRESSION COVERAGE, measured at 778dbd2d (the tree the
 # bug is live on) with these tests in place and only the two table entries
 # removed:
-#   RED at base  — test_declared_owner_resolves_the_recommend_terms,
+#   RED at base  — test_precedence_resolves_the_recommend_terms,
 #                  test_recommend_terms_resolve_on_the_live_config
 #   GREEN at base — test_recommend_terms_still_reach_both_picker_rows (an
 #                  INVARIANT GUARD: the picker never consulted the table, so it
-#                  cannot fail on its own) and
-#                  test_declared_owner_cannot_invent_an_rna_resolution (it
-#                  guards `owner in matched`, which FIX 5 already exercised).
-#                  Both were mutation-checked instead — see the PR body.
+#                  cannot fail on its own). Mutation-checked instead.
 RNA_ACQ_BASE = {"matches": [
     {"trigger": ":acq", "replace": "...",
      "label": "ask clarifying questions and recommend improvements and "
@@ -727,10 +732,13 @@ RNA_ACQ_BASE = {"matches": [
 ]}
 
 
-def test_declared_owner_resolves_the_recommend_terms():
-    # RED without the ':rna' entries: both are None, because ':acq''s label
-    # spells "recommend" and 'recom' is a substring of it.
+def test_precedence_resolves_the_recommend_terms():
+    # RED on the pre-precedence detector with the two ':rna' table entries
+    # removed: both are None, because ':acq''s label spells "recommend" and
+    # 'recom' is a substring of it. GREEN here with NO table entry for either.
     d = _det_for(RNA_ACQ_BASE)
+    assert "recom" not in ED._AMBIGUOUS_TERM_OWNER
+    assert "recommend" not in ED._AMBIGUOUS_TERM_OWNER
     assert d._term_matches("recom", ":acq") is True      # the incidental label
     assert d._term_matches("recom", ":rna") is True      # the real interface
     assert d._names_trigger("recom", ":rna") is False    # no outright naming
@@ -749,18 +757,26 @@ def test_recommend_terms_still_reach_both_picker_rows():
             ":acq", ":rna"}, term
 
 
-def test_declared_owner_cannot_invent_an_rna_resolution(monkeypatch):
-    # 🔴 The honesty half, pinned for THESE terms specifically: a declaration
-    # whose owner is not among the matched snippets must go INERT (None), never
-    # return the declared owner. Point both terms at a snippet neither reaches
-    # and the answer must be None, not ':dacq'.
+def test_the_recommend_terms_owe_nothing_to_the_owner_table(monkeypatch):
+    """🔴 THE LOAD-BEARING CONTROL, made permanent.
+
+    #1247 resolved these two terms with `_AMBIGUOUS_TERM_OWNER` entries. FIX 7
+    deleted them, claiming precedence does the work on its own. This proves the
+    claim can never quietly stop being true: point the table at a DIFFERENT
+    snippet for both terms and the answer must still be ':rna'.
+
+    It is not a restatement of the test above — that one runs with an empty
+    table, this one runs with a table actively arguing for the wrong answer, so
+    it fails if precedence is ever moved BELOW the owner lookup rather than
+    above it. (Ordering, not existence, is what it pins.)
+    """
     d = _det_for(RNA_ACQ_BASE)
-    assert ":dacq" not in d.ts.triggers
     for term in ("recom", "recommend"):
-        monkeypatch.setitem(ED._AMBIGUOUS_TERM_OWNER, term, ":dacq")
+        monkeypatch.setitem(ED._AMBIGUOUS_TERM_OWNER, term, ":acq")
     for term in ("recom", "recommend"):
-        assert [t for t in d.ts.triggers if d._term_matches(term, t)] != []
-        assert d._attribute(term) is None, term
+        assert ED._AMBIGUOUS_TERM_OWNER[term] == ":acq"
+        assert ":acq" in [t for t in d.ts.triggers if d._term_matches(term, t)]
+        assert d._attribute(term) == ":rna", term
 
 
 def test_recommend_terms_resolve_on_the_live_config():
@@ -769,6 +785,9 @@ def test_recommend_terms_resolve_on_the_live_config():
     # assert both snippets are actually present and actually collide.
     d = _live_det()
     assert ":acq" in d.ts.triggers and ":rna" in d.ts.triggers
+    # ...and on the LIVE config too, no owner entry is doing this (FIX 7).
+    assert "recom" not in ED._AMBIGUOUS_TERM_OWNER
+    assert "recommend" not in ED._AMBIGUOUS_TERM_OWNER
     for term in ("recom", "recommend"):
         assert sorted(t for t in d.ts.triggers
                       if d._term_matches(term, t)) == [":acq", ":rna"], term
@@ -815,6 +834,248 @@ def test_the_declared_owner_table_is_actually_load_bearing():
         "no _AMBIGUOUS_TERM_OWNER entry resolves an actually-ambiguous live "
         "term — the table is inert and asserts nothing: "
         + repr(dict(ED._AMBIGUOUS_TERM_OWNER)))
+
+
+# -- FIX 7: DECLARED-INTERFACE PRECEDENCE ------------------------------------ #
+# The general form of FIX 6. `_token_matches` reads three sources: the trigger,
+# `search_terms`, and the human-readable `label`. The first two are a CLAIM ("this
+# word means this snippet"); the label is a DESCRIPTION the operator rewords
+# freely. Before this, a reword could silently shadow another snippet's declared
+# route and the only remedy was a hand-written `_AMBIGUOUS_TERM_OWNER` row per
+# collision — one row per false collision, forever. So: on the ambiguous branch,
+# a snippet that reaches the term through its DECLARED interface out-bids one
+# that reaches it only through its label.
+#
+# 🔴 THESE FIXTURES ARE DELIBERATELY NOT THE LIVE CONFIG. FIX 6's live guards
+# already cover the reported incident; these must keep testing the RULE after
+# nix/home.nix changes, so every word below is invented. Every field is pairwise
+# distinct and none equals a constant the assertions name.
+#
+# 🔴 RED/GREEN MATRIX, measured with PYTHONDONTWRITEBYTECODE=1 against base
+# bf5516fc — and measured TWICE, because running these tests unchanged at base
+# mostly raises `AttributeError: _term_matches_declared`, which is API absence,
+# NOT evidence the behaviour was wrong. So each test's BEHAVIOURAL assertion (its
+# `_attribute` / `_term_matches` outcome alone) was also evaluated directly
+# against the base detector. What that measured:
+#
+#   GENUINELY RED at base — the behaviour, not the API, differs:
+#     test_label_only_match_does_not_shadow_a_declared_term      None -> ':wid'
+#     test_precedence_narrows_three_candidates_to_the_declared_one None -> ':wid'
+#     test_precedence_requires_every_token_declared              None -> ':nub'
+#     test_the_recommend_terms_owe_nothing_to_the_owner_table   ':acq' -> ':rna'
+#       (the only one that is red at base as an ordinary pytest failure too —
+#        base returns the owner ':acq' where HEAD returns ':rna')
+#
+#   RED at base ONLY WITH #1247's TWO ENTRIES REMOVED — i.e. red on the tree that
+#   reddened `main`, which is the regression they were written for and the same
+#   framing #1247's own matrix used:
+#     test_precedence_resolves_the_recommend_terms                None -> ':rna'
+#     test_recommend_terms_resolve_on_the_live_config             None -> ':rna'
+#   With base's table intact they are GREEN at base — the entries produced the
+#   same answer. That is the point of deleting them: the answer now comes from
+#   the rule, and these two tests keep the ANSWER pinned either way.
+#
+#   GREEN at base (INVARIANT GUARDS, labelled as such below; they pin behaviour
+#   precedence must NOT change, so by construction they cannot be regression
+#   coverage) — leaves_a_genuine_collision_to_the_owner_table,
+#   is_inert_when_every_match_is_label_only,
+#   never_repoints_a_unique_label_only_match, does_not_reach_the_picker,
+#   naming_a_trigger_outright_survives_precedence. Mutation-checked instead.
+#   test_token_matches_default_still_reads_the_label is an API-CONTRACT guard for
+#   espanso-usage.py's positional caller, not a behaviour claim about either
+#   tree; it can only fail on a signature change.
+
+# One term, 'glimmer', reachable three different ways. Only ':wid' DECLARES it.
+PRECEDENCE_BASE = {"matches": [
+    {"trigger": ":wid", "replace": "...", "label": "Sparkle report",
+     "search_terms": ["glimmer", "sheen"]},
+    {"trigger": ":pfx", "replace": "...",
+     "label": "notes on glimmer as observed downstream",   # incidental PROSE
+     "search_terms": ["downstream", "notes"]},
+]}
+
+
+def test_label_only_match_does_not_shadow_a_declared_term():
+    """🔴 THE REGRESSION TEST. RED at bf5516fc, GREEN here."""
+    d = _det_for(PRECEDENCE_BASE)
+    # Both are genuinely matched — this is the ambiguity that used to be fatal.
+    assert d._term_matches("glimmer", ":wid") is True
+    assert d._term_matches("glimmer", ":pfx") is True
+    # ...and neither is NAMED by the term, so the FIX-5 tie-break cannot rescue
+    # it, and no table entry exists for it. Precedence is the ONLY thing that can
+    # produce an answer here.
+    assert d._names_trigger("glimmer", ":wid") is False
+    assert d._names_trigger("glimmer", ":pfx") is False
+    assert "glimmer" not in ED._AMBIGUOUS_TERM_OWNER
+    # The asymmetry precedence reads.
+    assert d._term_matches_declared("glimmer", ":wid") is True
+    assert d._term_matches_declared("glimmer", ":pfx") is False
+    assert d._attribute("glimmer") == ":wid"
+
+
+def test_precedence_narrows_three_candidates_to_the_declared_one():
+    """A SECOND POINT ON THE DIMENSION — two candidates is the boundary case.
+
+    One measurement is not a general claim: with only two snippets the narrowed
+    set is a singleton whichever way the code slices it. Three matches, TWO of
+    them label-only, is the middle of the range and the case a mutant that
+    narrows by 'drop the last match' would survive.
+    """
+    base = {"matches": [
+        {"trigger": ":wid", "replace": "...", "label": "Sparkle report",
+         "search_terms": ["glimmer", "sheen"]},
+        {"trigger": ":pfx", "replace": "...",
+         "label": "notes on glimmer as observed downstream",
+         "search_terms": ["downstream", "notes"]},
+        {"trigger": ":qzz", "replace": "...",
+         "label": "a glimmer of an idea, filed for later",
+         "search_terms": ["idea", "filed"]},
+    ]}
+    d = _det_for(base)
+    assert sorted(t for t in d.ts.triggers
+                  if d._term_matches("glimmer", t)) == [":pfx", ":qzz", ":wid"]
+    assert [t for t in d.ts.triggers
+            if d._term_matches_declared("glimmer", t)] == [":wid"]
+    assert d._attribute("glimmer") == ":wid"
+
+
+def test_precedence_requires_every_token_declared():
+    """Multi-word: a term is a declared match only if EVERY token is declared.
+
+    RED at bf5516fc. ':vex' declares 'lantern' but reaches 'harbor' only through
+    its label, so it is NOT a declared match for the two-token query, and ':nub'
+    — which declares both — takes it.
+    """
+    base = {"matches": [
+        {"trigger": ":vex", "replace": "...",
+         "label": "harbor lights at dusk",
+         "search_terms": ["lantern", "dusk"]},
+        {"trigger": ":nub", "replace": "...", "label": "Quay inventory",
+         "search_terms": ["harbor", "lantern"]},
+    ]}
+    d = _det_for(base)
+    assert d._term_matches("harbor lantern", ":vex") is True   # label + terms
+    assert d._term_matches("harbor lantern", ":nub") is True
+    assert d._term_matches_declared("harbor lantern", ":vex") is False
+    assert d._term_matches_declared("harbor lantern", ":nub") is True
+    assert d._attribute("harbor lantern") == ":nub"
+    # ...and the single token ':vex' DOES declare stays symmetric, so the
+    # all()-over-tokens really is per-token and not a whole-term shortcut.
+    assert d._term_matches_declared("lantern", ":vex") is True
+
+
+def test_precedence_leaves_a_genuine_collision_to_the_owner_table():
+    """🔴 INVARIANT GUARD (green at base) — precedence must NOT take the table's
+    job. When BOTH snippets declare the term there is nothing to narrow, so the
+    answer stays None unless an owner is declared. This is the 'ask'/'clarify'
+    shape, in fixture form: if precedence ever started picking a winner among
+    two declared snippets, the live owner table would become unreachable and the
+    highest-traffic term in the config would silently re-point.
+    """
+    base = {"matches": [
+        {"trigger": ":vex", "replace": "...", "label": "Harbour lights",
+         "search_terms": ["lantern", "dusk"]},
+        {"trigger": ":nub", "replace": "...", "label": "Quay inventory",
+         "search_terms": ["lantern", "crates"]},
+    ]}
+    d = _det_for(base)
+    assert d._term_matches_declared("lantern", ":vex") is True
+    assert d._term_matches_declared("lantern", ":nub") is True
+    assert d._attribute("lantern") is None
+    # ...and the table still decides it, over the narrowed-to-nothing set.
+    ED._AMBIGUOUS_TERM_OWNER["lantern"] = ":nub"
+    try:
+        assert d._attribute("lantern") == ":nub"
+    finally:
+        del ED._AMBIGUOUS_TERM_OWNER["lantern"]
+
+
+def test_precedence_is_inert_when_every_match_is_label_only():
+    """🔴 INVARIANT GUARD (green at base). With nothing but labels to go on there
+    is no basis to prefer one snippet, so the set is left alone and the answer is
+    still None. A mutant that narrows to the (empty) declared set would return
+    None here too — which is why the owner-table half below is asserted: it
+    proves the candidate set SURVIVED the narrowing step rather than being
+    emptied by it.
+    """
+    base = {"matches": [
+        {"trigger": ":vex", "replace": "...", "label": "a lantern by the door",
+         "search_terms": ["dusk"]},
+        {"trigger": ":nub", "replace": "...", "label": "lantern oil, spare",
+         "search_terms": ["crates"]},
+    ]}
+    d = _det_for(base)
+    assert d._term_matches_declared("lantern", ":vex") is False
+    assert d._term_matches_declared("lantern", ":nub") is False
+    assert d._attribute("lantern") is None
+    ED._AMBIGUOUS_TERM_OWNER["lantern"] = ":vex"
+    try:
+        assert d._attribute("lantern") == ":vex", (
+            "the declared-narrowing step emptied the candidate set, so "
+            "`owner in matched` can no longer find a legitimately-matched owner")
+    finally:
+        del ED._AMBIGUOUS_TERM_OWNER["lantern"]
+
+
+def test_precedence_never_repoints_a_unique_label_only_match():
+    """🔴 INVARIANT GUARD (green at base). `('rig', ':sshwn')` and
+    `('portable', ':sshln')` resolve through their LABEL by design on the live
+    config. Precedence runs only on the ambiguous branch, so a term with exactly
+    one match must be untouched even when that match is label-only.
+    """
+    base = {"matches": [
+        {"trigger": ":vex", "replace": "...", "label": "the lantern room",
+         "search_terms": ["dusk"]},
+        {"trigger": ":nub", "replace": "...", "label": "Quay inventory",
+         "search_terms": ["crates"]},
+    ]}
+    d = _det_for(base)
+    assert [t for t in d.ts.triggers if d._term_matches("lantern", t)] == [":vex"]
+    assert d._term_matches_declared("lantern", ":vex") is False
+    assert d._attribute("lantern") == ":vex"
+
+
+def test_precedence_does_not_reach_the_picker():
+    """🔴 INVARIANT GUARD (green at base). espanso lists EVERY match as a row and
+    the user picks one; narrowing is an ATTRIBUTION concept only. If this shrinks
+    to one row, precedence has become the label edit the operator declined.
+    """
+    d = _det_for(PRECEDENCE_BASE)
+    assert {t for t in d.ts.triggers
+            if d._term_matches("glimmer", t)} == {":wid", ":pfx"}
+
+
+def test_naming_a_trigger_outright_survives_precedence():
+    """Naming implies declaring (`token in trig`), so the FIX-5 tie-break can
+    never be the candidate precedence drops. Pinned rather than argued.
+    """
+    base = {"matches": [
+        {"trigger": ":lantern", "replace": "...", "label": "Quay inventory",
+         "search_terms": ["crates"]},
+        {"trigger": ":xlanterny", "replace": "...", "label": "Dock roster",
+         "search_terms": ["lantern", "roster"]},
+    ]}
+    d = _det_for(base)
+    assert d._term_matches_declared("lantern", ":lantern") is True
+    assert d._term_matches_declared("lantern", ":xlanterny") is True
+    assert d._names_trigger("lantern", ":lantern") is True
+    assert d._attribute("lantern") == ":lantern"
+
+
+def test_token_matches_default_still_reads_the_label():
+    """`_token_matches` is called POSITIONALLY by espanso-usage.py's
+    reachability probe (`det._token_matches(tok, "", meta)`). The new flag is
+    keyword-only WITH a default, so that caller must be unaffected — a
+    three-source match by default, declared-only on request.
+    """
+    meta = {"label": "a lantern by the door", "search_terms": ["dusk"]}
+    assert ED.EspansoDetector._token_matches("lantern", ":vex", meta) is True
+    assert ED.EspansoDetector._token_matches(
+        "lantern", ":vex", meta, use_label=False) is False
+    assert ED.EspansoDetector._token_matches(
+        "dusk", ":vex", meta, use_label=False) is True
+    # The empty-trigger call shape espanso-usage.py actually uses.
+    assert ED.EspansoDetector._token_matches("lantern", "", meta) is True
 
 
 # --------------------------------------------------------------------------- #
@@ -1048,10 +1309,14 @@ _AUDIT_2026_08_19_RESOLUTIONS = [
     ("rig", ":sshwn"), ("portable", ":sshln"),
     ("loose", ":alo"), ("tests", ":pdt"), ("pick up", ":cgt"),
 ]
-# NOT listed: bare "wor". It stays ambiguous with :mt, whose label says
-# "parallel WORK while that runs" — and it was never a query he typed (the
-# measured one is the two-token "ssh wor"). Asserting it would have been an
-# expectation invented from the fix rather than read off the search stream.
+# NOT listed: bare "wor". It was never a query he typed (the measured one is the
+# two-token "ssh wor"), so asserting it would be an expectation invented from a
+# fix rather than read off the search stream. ⚠ The reason this comment used to
+# give — "it stays ambiguous with :mt" — is NO LONGER TRUE as of the FIX 7
+# declared-interface precedence: ':mt' reaches "wor" only through its label
+# ("parallel WORK while that runs") while ':sshwl' DECLARES "workbench", so bare
+# "wor" now resolves to ':sshwl'. It stays off this table for the unchanged
+# reason (nobody types it), not for the stale one.
 
 
 def test_live_audit_2026_08_19_resolutions():

--- a/scripts/session-analysis/tests/test_espanso_usage.py
+++ b/scripts/session-analysis/tests/test_espanso_usage.py
@@ -760,8 +760,24 @@ def test_bad_source_is_rejected():
 # nothing is FATAL, and deliberate losses are stated with --accept.
 _A = {"trigger": ":aa", "replace": "alpha text", "label": "Alpha thing",
       "search_terms": ["alpha", "firstword"]}
+# 🔴 ':bb' DECLARING "thing" IS LOAD-BEARING FIXTURE ISOLATION — do not prune it,
+# and if you replace it, replace it with another word that is ALSO in ':bb''s
+# label. Why: `_probe_universe` includes single-character prefixes, and 't' is a
+# prefix of the label word "thing" that BOTH snippets carry, while also being a
+# substring of ':aa''s declared "firstword". Under the detector's declared-
+# interface precedence that made ':aa' out-bid ':bb' for the probe 't' in the
+# before-config, and ':bb' win it after ':aa' is stripped — a genuine
+# `moved_expansion`, which is FATAL and deliberately NOT acknowledgeable with
+# --accept, so it drowned the axis
+# `test_gate_exit_codes_accept_semantics_and_that_it_lints` exists to pin.
+# Declaring the word on ':bb' too makes both snippets declared for that probe, so
+# precedence narrows nothing and 't' is ambiguous exactly as the fixture author
+# assumed. It must be a word that is ALSO in the label because `_mut` REPLACES
+# `search_terms` wholesale in two tests below — a word living only in
+# `search_terms` would vanish there and be graded as a LOST QUERY. (Measured: the
+# first attempt at this used a search_terms-only word and did exactly that.)
 _B = {"trigger": ":bb", "replace": "bravo text", "label": "Bravo thing",
-      "search_terms": ["bravo"]}
+      "search_terms": ["bravo", "thing"]}
 
 
 def _mut(base, trig, **changes):


### PR DESCRIPTION
## The problem

`_token_matches` reads three sources: the **trigger**, the **`search_terms`** list, and the human-readable **`label`**. The first two are a CLAIM — an authored statement that this word means this snippet. The label is a DESCRIPTION the operator rewords freely. So editing a label, pure documentation, silently changed search **routing**.

**Measured incident (2026-09-02, `a720d30d`).** The operator edited `:acq`'s label to *"ask clarifying questions and recommend improvements and anything useful to include"*. Its `replace` and `search_terms` were untouched. The new label contains "recommend", so `:acq` began matching `recom`/`recommend` — two of `:rna`'s six declared `search_terms`. Both went ambiguous, resolved to `None`, and `main` went red on `test_live_existing_resolutions_not_made_ambiguous`. #1247 (`b9b2493d`) patched it with two `_AMBIGUOUS_TERM_OWNER` rows.

That patch is correct, but it treats a **false** collision as a real one — and the remedy was one hand-written row per collision, forever.

## What this changes

One step in `_attribute`, on the already-ambiguous branch only:

```python
declared = [trig for trig in matched if self._term_matches_declared(t, trig)]
if declared:
    matched = declared
    if len(matched) == 1:
        return matched[0]
```

`_term_matches_declared` is `_term_matches` with the label switched off — same helper, one keyword-only flag, deliberately not a second copy of the substring logic. `_token_matches` keeps its three-source default, so `espanso-usage.py`'s positional caller (`det._token_matches(tok, "", meta)`) is unaffected; there is a test pinning that.

It can only ever **shrink** the candidate set, so it cannot invent a resolution or re-point a term that already resolves uniquely (that branch returns earlier). When no candidate matches declaredly the set is left alone — with only labels to go on there is no basis to prefer one. Naming a trigger implies declaring it (`token in trig`), so the `_names_trigger` tie-break can never be what this drops.

**The picker is untouched.** `_term_matches` still reads the label, so every row espanso lists is still listed. Precedence is attribution-only — measured: **0** picker-row changes across 735 terms.

## 1. The load-bearing control, and the keep-or-delete decision

**Control** — precedence in place, `"recom"` and `"recommend"` removed from `_AMBIGUOUS_TERM_OWNER`, against the live `nix/home.nix`:

```
table as shipped: {'ask': ':acq', 'clarify': ':acq', 'recom': ':rna', 'recommend': ':rna'}
WITH entries    : {'recom': ':rna', 'recommend': ':rna', 'rec': ':rna', 'ask': ':acq', 'clarify': ':acq'}
removed         : {'recom': ':rna', 'recommend': ':rna'}
WITHOUT entries : {'recom': ':rna', 'recommend': ':rna', 'rec': ':rna', 'ask': ':acq', 'clarify': ':acq'}
CONTROL: PASS — precedence alone resolves both
```

**Decision: DELETED.** Not belt-and-braces — the entries are **structurally unreachable**, which the same run measured directly:

```
recom      matched=[':acq', ':rna'] declared=[':rna']          -> owner branch reachable: False
recommend  matched=[':acq', ':rna'] declared=[':rna']          -> owner branch reachable: False
ask        matched=[':dacq', ':acq'] declared=[':dacq', ':acq'] -> owner branch reachable: True
clarify    matched=[':dacq', ':acq'] declared=[':dacq', ':acq'] -> owner branch reachable: True
```

For `recom`/`recommend` the declared-narrowed set is a single snippet, so `_attribute` **returns before the lookup**. Nothing can reach those two rows. This repo has a documented history of exactly that kind of dead entry, and `test_the_declared_owner_table_is_actually_load_bearing` says the honest fix for an inert entry is to delete it. The condition that would justify re-adding them is written down in the source: `:acq` DECLARING `recom` in its own `search_terms`.

**`_AMBIGUOUS_TERM_OWNER` stays** for real `search_terms`-vs-`search_terms` collisions. `ask`/`clarify` are exactly that — both `:acq` and `:dacq` declare them (`:dacq` spells "clarifying", which "clarify" is a substring of) — so precedence narrows nothing and the table is still what decides. `ask` is the highest-traffic term in the config (58 fires); it resolves to `:acq` before and after.

## 2. Unchanged-resolution evidence

Loaded through the same path the existing test uses (`test_espanso_detect._live_base()`, the `nix/home.nix` scraper) — nothing hand-copied. Term universe: every `search_term`, every label word, every trigger name with and without `:`, every term in the four pinned test tables, **plus every prefix of each** (prefix typing is how the picker is really driven).

Detector at `origin/main` vs detector at HEAD, same live config:

```
snippets:            26
terms enumerated:    735
resolved BEFORE:     523
resolved AFTER:      564
picker-row diffs:    0
attribution diffs:   41
  LOST/CHANGED (was resolved, now different or None): 0
  REPOINTED (resolved -> different snippet):          0
  GAINED (was None, now resolved):                    41
```

**Zero losses, zero re-points, zero picker changes.** Every diff is a term that used to be `None`.

**Instrument validation.** Positive control: run with before == after → `0` on every counter (so the enumerator is not silently comparing nothing). Negative control: an `after` module with the owner lookup disabled → reported exactly 4 diffs, `ask`/`clarify`/`recom`/`recommend`. That also measures something useful on its own — those four terms are the owner table's *entire* live effect.

**The 41 gains**, all previously unattributable:

```
rec reco recomm recomme recommen -> :rna     ku kub kube kubec -> :kuc
inc incl inclu includ include    -> :dacq    pas past paste   -> :kickoff
any anyt anyth anythi anythin anything thi -> :alo
agen agent -> :lr    gp gpu sub -> :subk    wo wor work -> :sshwl
dat -> :eos   dp -> :cdp   fl fle -> :roo   fr -> :hlt   id the -> :mt
po -> :cc    pat -> :dacq
```

Note `rec`/`reco`/`recomm`/`recomme`/`recommen`: that is the **prefix blind spot the two table rows explicitly did NOT close** (the source comment said so, measured). Precedence closes it, precisely because it is a mechanism rather than an enumeration. `clar` deliberately stays `None` — `:acq` and `:dacq` both *declare* it, so it is a genuine collision and the exact-string lookup is still the only hatch. That residual blind spot is unchanged and re-documented.

⚠ Two of the gains are low-value short prefixes (`the` → `:mt`, `id` → `:mt`, `po` → `:cc`). They are gains, not regressions, but they mean telemetry now names a snippet for queries that are close to noise. Flagging rather than hiding it.

## 3. Red → green matrix

Measured **twice**, because running the new tests unchanged at base mostly raises `AttributeError: _term_matches_declared` — API absence, not a behaviour difference. So each test's behavioural assertion (its `_attribute`/`_term_matches` outcome alone) was also evaluated directly against the base detector.

**Genuinely RED at base `bf5516fc`** — behaviour differs, not just the API:

| test | base | HEAD |
|---|---|---|
| `test_label_only_match_does_not_shadow_a_declared_term` | `None` | `:wid` |
| `test_precedence_narrows_three_candidates_to_the_declared_one` | `None` | `:wid` |
| `test_precedence_requires_every_token_declared` | `None` | `:nub` |
| `test_the_recommend_terms_owe_nothing_to_the_owner_table` | `:acq` | `:rna` |

The last one is red at base as an ordinary pytest failure too (`assert ':acq' == ':rna'`).

**RED at base only with #1247's two entries removed** — i.e. red on the tree that reddened `main`, which is the regression they were written for and the same framing #1247's own matrix used: `test_precedence_resolves_the_recommend_terms`, `test_recommend_terms_resolve_on_the_live_config` (`None` → `:rna`).

**GREEN at base — INVARIANT GUARDS**, labelled as such in the source and not counted as regression coverage: `leaves_a_genuine_collision_to_the_owner_table`, `is_inert_when_every_match_is_label_only`, `never_repoints_a_unique_label_only_match`, `does_not_reach_the_picker`, `naming_a_trigger_outright_survives_precedence`. `test_token_matches_default_still_reads_the_label` is an API-contract guard for `espanso-usage.py`'s positional caller.

New tests are built from **invented fixtures**, not the live config, so they keep testing the RULE when `nix/home.nix` changes. Fields are pairwise distinct and none equals a constant the assertions name. `test_precedence_narrows_three_candidates_to_the_declared_one` exists because two candidates is the boundary case — with only two, the narrowed set is a singleton however the code slices it, so a three-candidate case sits in the middle of the range.

Keylog suite: **105 → 114 passed**.

## 4. Mutation battery

Each mutant in a **fresh** temp tree, every run under `PYTHONDONTWRITEBYTECODE=1 -p no:cacheprovider`. The batch carries its own two controls, and each mutant declares which test must kill it — a mutant killed only by some *other* test is reported MIS-KILLED.

```
BASELINE (unmutated): failed=[] counts={'passed': 114}

mutant                                                verdict   killed-by
CONTROL-GREEN (no-op)                                 GREEN     (none — as required)
CONTROL-RED (_attribute always None)                  KILLED    29 tests
M1  precedence block deleted                          KILLED    label_only_does_not_shadow (+6)
M2  `if declared:` -> `if False:` (inert)             KILLED    label_only_does_not_shadow (+6)
M3  narrowing assignment neutered                     KILLED    label_only_does_not_shadow (+6)
M4  preference INVERTED (label beats search_terms)    KILLED    label_only_does_not_shadow (+7)
M5  inner `== 1` -> `>= 1` (first wins)               KILLED    leaves_a_genuine_collision_to_the_owner_table (+17)
M6  inner return dropped                              KILLED    label_only_does_not_shadow (+6)
M7  declared-check reads the label after all          KILLED    label_only_does_not_shadow (+8)
M8  declared-check `all` -> `any`                     KILLED    requires_every_token_declared (+0 others)
M9  `if use_label:` -> `if False:`                    KILLED    never_repoints_a_unique_label_only_match (+16)
M10 `use_label` default flipped to False              KILLED    token_matches_default_still_reads_the_label (+16)
M11 precedence moved BELOW the owner lookup           KILLED    owe_nothing_to_the_owner_table (+0 others)

BATTERY: CLEAN — every mutant killed by its own guard
```

**Reachability, not just breakability.** M2 and M3 make the branch inert without removing it, and both die — so the branch executes and its outcome decides the answer; no earlier check wins first. The mutations are isolated to the narrowest expression that can be wrong (M3 changes one assignment; M8 changes one quantifier).

**The killing assertion is the guard's own line**, confirmed with a `-k` filter that ran exactly one test (`1 failed, 69 deselected` each time):

```
M3  >  assert d._attribute("glimmer") == ":wid"
    E  AssertionError: assert None == ':wid'
M8  >  assert d._term_matches_declared("harbor lantern", ":vex") is False
    E  AssertionError: assert True is False
M11 >  assert d._attribute(term) == ":rna", term
    E  AssertionError: recom / assert ':acq' == ':rna'
```

The battery aborts rather than reports when its own baseline is not green — which it did on the first run (a missing `collector` import made the copied tree collect an error), so the abort path is exercised, not assumed.

## 5. A second-order finding, handled

`test_espanso_usage.py::test_gate_exit_codes_accept_semantics_and_that_it_lints` went red. **Diagnosed, not assumed:** the same test passes with the base detector and fails with the new one, so it is caused by this change.

`_probe_universe` includes single-character prefixes. `'t'` is a prefix of the label word `"thing"` that both fixture snippets carry, and also a substring of `:aa`'s declared `"firstword"`. Under precedence, `:aa` out-bids `:bb` for `'t'` before the edit and `:bb` wins after `:aa` is stripped — a real `moved_expansion`, which the gate treats as FATAL and deliberately does not let `--accept` acknowledge. So `--accept thing,firstword` stopped exiting 0.

**The finding is genuine, not a false positive** — `'t'` really does stop reaching `:aa`. The gate is now strictly *more* sensitive, which is a side effect worth having. What was wrong is the fixture's isolation: `:bb` now also DECLARES `"thing"`, so both snippets are declared for that probe, precedence narrows nothing, and `'t'` is ambiguous before the edit exactly as the fixture author assumed.

The word has to live in `:bb`'s **label** as well, because `_mut` replaces `search_terms` wholesale in two other tests. Measured: a first attempt used a `search_terms`-only word and it was graded a LOST QUERY in both, reddening two further tests.

**CONTROL — the fixture edit is neutral, not a patch for this change:** the whole file (76 tests) is green against the **base** detector as well as the new one, so it encodes no assumption about either. Every assertion keeps its exact shape; the partial-acknowledgement-must-fail assertion and both EXPANSION-axis tests still pass, i.e. still bite.

## 6. Comments corrected

Three claims this change falsified, fixed rather than left standing:

- the module's *"'rec', 'reco' and 'recomm' … all still resolve to None"* — they now resolve to `:rna`;
- the test file's *"bare 'wor' … stays ambiguous with `:mt`"* — `:mt` reaches it only through its label, so it now resolves to `:sshwl`. The row stays off the pinned table for the unchanged reason (nobody types it);
- `claude/skills/espanso-audit/SKILL.md`'s *"when two snippets both spell the same word, **no** `search_terms` edit makes a bare query resolve"* — still true when both DECLARE it, false when one spells it only in a label. That is the sentence that would send someone to delete a picker row that no longer needs deleting.

`nix/home.nix` is **not touched** — the operator's label stays exactly as written. That is the whole point.

## Verification

All runs are on the **MERGED tree `d65e0554`**, whose base is `origin/main` = **`2c6b2ac9`**. `origin/main` was re-checked after the last run and had not moved. Each build was run **separately** (a combined `nix build` of both derivations contends on the nix store and yields false failures) and redirected to a file, never piped — the exit status below is the real one, and it is cross-checked against the runners' own `RESULT:` lines.

| tier | command | exit | runner verdict |
|---|---|---|---|
| **sandbox** (the tier Tekton gates on) | `nix build .#checks.x86_64-linux.pytests` | 0 | `RESULT: PASS (exit=0)` — `collected=20602 passed=20599 skipped=3 failed=0` (floor 18404) |
| **sandbox** | `nix build .#checks.x86_64-linux.nodetests` | 0 | `RESULT: PASS (exit=0)` — `suites=5 files=41 tests=1449 pass=1449 fail=0` (floor 1367) |
| **dev-host** | `scripts/gate.sh --tier both` (inside the flake devShell) | 0 | `GATE: RESULT=PASS exit=0`; pytest `20599 passed`, node `1449 pass` |

`grep -c "test timed out"` = 0 in both logs. A dev-host green is a claim about that tier only — hence both are reported.

⚠ A first `gate.sh` attempt outside the devShell exited **3** with `FATAL — required tool(s) missing from PATH: logrotate`. That is the runner's missing-environment code, not a test failure; re-run inside `nix develop` as it instructs, it passes.

⚠ `main` is protected in name only right now, so a Tekton check on this PR is information, not permission. The two-tier run above is the evidence.

Keylog suite alone, merged tree: **114 passed** (105 before this change). Detector consumers' suite (`scripts/session-analysis/tests`): **491 passed**.

## Unresolved / flagged

- Two of the 41 gains (`the` → `:mt`, `id` → `:mt`) are near-noise single/double-character probes. Harmless (they were `None`), but they slightly widen what telemetry names.
- The `clar` prefix blind spot is **unchanged** — both `:acq` and `:dacq` declare it, so this rule cannot help; widening the owner lookup to be prefix-aware remains a separate mechanism change needing its own battery.
- The gate in `espanso-usage.py` is now more sensitive to `moved_expansion` because more probes have a definite attribution. That is a behaviour change in a *tool*, not in the detector's contract, and it is a strictly better signal — but it may surface findings on future config edits that the previous, blinder gate would have passed.
