### PR TITLE
feat(cairn): a two-way ledger over store-root resolvers, cairn doctor, and the skill

### DIFF
--- a/claude/skill-tiers.json
+++ b/claude/skill-tiers.json
@@ -53,6 +53,10 @@
     },
     "bar": { "tier": "A" },
     "browser": { "tier": "A" },
+    "cairn": {
+      "tier": "B",
+      "why": "the tool is NAMED, never described -- 'cairn doctor', 'cairn sync', 'cairn who'. The symptoms that could route here already belong to skills that name it in their own bodies: a refused read to `resume`, a stale index block to `analyze-service`, an entry that got huge to `prune-index`"
+    },
     "check-clickup-addressed": { "tier": "A" },
     "clawgate": { "tier": "A" },
     "clickup": { "tier": "A" },

--- a/claude/skills/activity/SKILL.md
+++ b/claude/skills/activity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: activity
-description: "Operate the personal activity-telemetry pipeline: 9 sources -> collector -> homelab ClickHouse activity.events -> Grafana + a per-source deadman. Query it, revive a stalled or DEAD source, deploy, validate. Use for: activity tracking, the keylogger, \"where my time goes\", the activity dashboard, activity.events, the collector, a stale telemetry source, the `tlm` bar pill."
+description: "Operate the personal activity-telemetry pipeline: homelab ClickHouse activity.events -> Grafana. Query it, revive a stalled or DEAD source, deploy, validate. Use for: activity tracking, the keylogger, \"where my time goes\", the activity dashboard, activity.events, the collector, a stale telemetry source, the `tlm` bar pill."
 ---
 
 # activity-telemetry operations

--- a/claude/skills/cairn/SKILL.md
+++ b/claude/skills/cairn/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: cairn
+description: "The hosted subsystem store (pod in ns `subsystem-store`) and its client `scripts/cairn`. Use for: `cairn doctor`, cairn sync/recall/search/ls-entries/who, a stale or unstamped store, a `cairn` exit 4, seeding the pod, a scope a token cannot reach. Writes are `subsystem-index`; pruning is `prune-index`."
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# cairn — the hosted subsystem store, and the client that reads it
+
+**This file is a router. Anything a command can answer, a command answers** —
+`claude/RULES.md`, "prefer deterministic/structural fixes over prose".
+
+## Start here, always
+
+```
+cairn doctor            # pod, credential, cache stamp, counts, scope visibility, reader resolution
+cairn doctor --json     # the same facts, machine-readable
+cairn doctor --no-sync  # same, without touching the network
+```
+
+It prints its own exit-code legend and a state per check. Four states, and the
+last two are not the same fact: `OK` · `PROBLEM` (measured, and it is not fine) ·
+`UNMEASURED` (it could not look, and says why) · `NOT-OBSERVABLE` (no client can
+answer it; the detail names who can). **It installs nothing** — it fetches, reads
+headers, and throws the bytes away, so it can be run twice without repairing the
+staleness it was run to measure.
+
+## The verbs
+
+| you want | run |
+|---|---|
+| refresh the local cache from the pod | `cairn sync` |
+| this repo's digest | `cairn recall` (`--scope X` / `--repo PATH`) |
+| find a hunk by text | `cairn search '<query>'` (`--all-scopes` to search every scope) |
+| what does the cache actually hold | `cairn ls-entries` |
+| parse-check the cached entries | `cairn validate` |
+| which sessions/windows/transcripts worked a task | `cairn who <task>` (`--json`, `--host`, `--no-windows`) |
+| diagnose anything above going wrong | `cairn doctor` |
+
+`cairn who` is about a **task**, not a store entry: it touches no store and never
+syncs, and it has its own longer `--timeout` because it shells into tmux on two
+hosts.
+
+**Writes are not this skill's.** `subsystem-index` owns the one protocol for
+every writer; `prune-index` owns deletion, with its own confirmation gate. Load
+whichever applies rather than reconstructing their steps here.
+
+## 🔴 The two different exit 4s
+
+Confusing them sends you to re-run the command that just failed.
+
+| whose 4 | means | do |
+|---|---|---|
+| `cairn sync`'s `EXIT_REFRESH_FAILED` | the store was **not reached**, but a usable cache survived | nothing to re-run — read the banner; the cache still serves reads |
+| the **reader's** `EXIT_UNSTAMPED_READ_STORE` | the store it resolved carries no `.sync-stamp`, so it cannot date itself and refuses | `cairn sync` |
+
+`claude/skills/resume/SKILL.md` step 4 carries the long form, including why
+`cairn recall` never returns 4 (it reaches the reader as a *library*). Read it
+there; it is not restated here.
+
+## Where a host reads from
+
+`scripts/lib/subsystem_read_store.py` is the ONE answer, and
+`cairn doctor`'s `reader-resolution` check prints it. Two directories exist and
+they are not interchangeable: `~/.cache/subsystem-store` is the synced
+read-through cache, stamped by `cairn sync`; `~/.claude/analyze-service-index`
+is the pre-cutover per-host mirror, frozen and refreshed by nothing.
+**The discriminator is the stamp, not the path** — a store that cannot date
+itself is refused rather than served.
+
+## Adding a consumer that reads the store
+
+Call `subsystem_read_store.resolve_read_store()`. Do **not** compute a path.
+`scripts/tests/test_store_root_ledger.py` enumerates every file that resolves a
+store root and requires each to route through that module or carry a written
+exemption; it fails when the set grows **or** shrinks. That test — not this
+paragraph — is what stops the fourth open-coded reader, and its ledger reasons
+are where the exemptions are argued. Read them before adding a row.
+
+## Operator surface
+
+`reference/operator-surface.md` — the pod, `seed.sh`, `verify-byte-identity.sh`
+and its measured coverage gap, `build-push.sh`, `cairn-cutover.py`, the backup
+CronJob, and 🔴 **the token file is read ONCE at startup**: editing the secret
+changes nothing until the pod is replaced, and the wrong replacement command
+costs two rollouts. Load it before touching the deployment.

--- a/claude/skills/cairn/SKILL.md
+++ b/claude/skills/cairn/SKILL.md
@@ -44,6 +44,15 @@ hosts.
 every writer; `prune-index` owns deletion, with its own confirmation gate. Load
 whichever applies rather than reconstructing their steps here.
 
+🔴 **There is no CREATE route, and the failure does not say so.** `PUT` demands
+an `If-Match` the caller derives from bytes that must already exist (`428` with
+none, and `If-Match: *` is refused because it is no precondition at all), and
+`POST …/bullets` appends to something. A ref the pod has never held answers
+`404 ref-unknown` — the same bytes as a ref outside your allowlist. So a scope's
+FIRST record cannot be made through the API at all; it is an operator step, and
+until somebody takes it the record does not exist anywhere the pod can serve.
+Measured 2026-09-03, on real entries stranded by exactly this.
+
 ## 🔴 The two different exit 4s
 
 Confusing them sends you to re-run the command that just failed.
@@ -70,11 +79,17 @@ itself is refused rather than served.
 ## Adding a consumer that reads the store
 
 Call `subsystem_read_store.resolve_read_store()`. Do **not** compute a path.
-`scripts/tests/test_store_root_ledger.py` enumerates every file that resolves a
+`scripts/tests/test_store_root_ledger.py` enumerates the files that resolve a
 store root and requires each to route through that module or carry a written
-exemption; it fails when the set grows **or** shrinks. That test — not this
-paragraph — is what stops the fourth open-coded reader, and its ledger reasons
-are where the exemptions are argued. Read them before adding a row.
+exemption; it fails when the set grows **or** shrinks, and pins WHICH KIND of
+resolution each ledgered file performs. Read its ledger reasons before adding a
+row — that test, not this paragraph, is what an addition has to satisfy.
+
+⚠ **It is not total, and its own docstring is the authority on how far it
+reaches** — it scans `scripts/` only (so `nix/` is uncovered, and `nix/home.nix`
+names the frozen mirror today), it parses Python and shell but not `.nix`, and a
+path assembled at run time out of `os.environ` is invisible to it. Treat a green
+run as "no *detectable* new open-coded reader", never as proof there is none.
 
 ## Operator surface
 

--- a/claude/skills/cairn/SKILL.md
+++ b/claude/skills/cairn/SKILL.md
@@ -78,7 +78,7 @@ are where the exemptions are argued. Read them before adding a row.
 
 ## Operator surface
 
-`reference/operator-surface.md` — the pod, `seed.sh`, `verify-byte-identity.sh`
+`~/.claude/skills/cairn/reference/operator-surface.md` — the pod, `seed.sh`, `verify-byte-identity.sh`
 and its measured coverage gap, `build-push.sh`, `cairn-cutover.py`, the backup
 CronJob, and 🔴 **the token file is read ONCE at startup**: editing the secret
 changes nothing until the pod is replaced, and the wrong replacement command

--- a/claude/skills/cairn/reference/operator-surface.md
+++ b/claude/skills/cairn/reference/operator-surface.md
@@ -1,0 +1,106 @@
+# cairn — the operator surface
+
+Durable facts you verify against. **Nothing here restates a number a command can
+print.** `cairn doctor` answers reachability, credential, stamp, counts and scope
+visibility; this file covers what has no command.
+
+## The pieces
+
+| thing | where | what it does |
+|---|---|---|
+| the pod | k8s ns `subsystem-store` | the canonical datastore. Serves `GET /api/v1/{recall,search,snapshot}` and accepts the two write routes |
+| the client | `scripts/cairn` | syncs a local cache and runs the **unmodified** local reader against it |
+| the resolver | `scripts/lib/subsystem_read_store.py` | the one answer to "where does this host read from" |
+| the seeder | `scripts/subsystem-store-api/seed.sh` | pushes a local tree into the pod's PVC |
+| the acceptance check | `scripts/subsystem-store-api/verify-byte-identity.sh` | compares pod bytes against a local store, scope by scope |
+| the image | `scripts/subsystem-store-api/build-push.sh` | `build-push.sh <version>` — the tag is an argument and has **no default** |
+| the cutover | `scripts/cairn-cutover.py` | dry-run by default; owns the freeze/unfreeze of the pre-cutover mirror |
+| the backup | CronJob `subsystem-store-backup` in the same namespace | daily 03:45 UTC (homelab-infra) |
+
+## 🔴 The token file is read ONCE, at startup
+
+`server.py::load_tokens` runs in `main()` and there is **no SIGHUP, no reload,
+no watch**. Editing the Kubernetes secret changes nothing about the running
+process — the pod is still authorising against the rows it parsed when it
+started.
+
+Two consequences, both measured and recorded in
+`claudedocs/handoff-cairn-phase3.md`:
+
+* A malformed row is `EXIT_CONFIG` (**78**, `sysexits.h EX_CONFIG`) and the
+  process refuses to start. With `strategy: Recreate` at `replicas: 1` there is
+  no second pod, so **the store stays DOWN** — it does not fall back to the old
+  rows and it does not fall back to no auth.
+* Replace the pod with **`kubectl delete pod`, not `rollout restart`**. Under
+  `Recreate` the latter costs two rollouts (see homelab-infra's `CLAUDE.md`),
+  i.e. two outages where one was needed.
+
+So: edit the secret, then delete the pod, then re-run `cairn doctor` and read
+the `pod` check. A `PROBLEM` there naming HTTP 401/403 is the credential; an
+`UNMEASURED` naming a connection failure is the pod not coming back.
+
+⚠ **A 403 from this host's edge is not a token rejection.** Measured against the
+live host with the same token: curl's default User-Agent → 200, urllib's default
+`Python-urllib/3.12` → **403**, empty UA → 200. The 403 comes from the edge, and
+it arrives looking like a bad token *and* like the store being down.
+`_apply_standard_headers` in `scripts/cairn` is what keeps every request out of
+that trap; a new HTTP caller that skips it will re-learn this the hard way.
+
+## 🔴 `seed.sh` OVERWRITES a shared entry — it does not merge
+
+The push is `rsync -a --delete` SOURCE→STAGE, then `tar` STAGE→pod. The extract
+**adds and overwrites but never deletes**, so a bullet that was appended through
+the API and exists only in the served copy is replaced by the seeding host's
+older copy of that file. That is why the cutover (`cairn-cutover.py`) had to run
+*before* any further re-seed: after it, the hosts hold caches of the pod and the
+same push has nothing unique left to destroy.
+
+`seed.sh` requires `--store` and refuses to default it. Its push verdict is a
+**containment check on NAMES** ("did everything I staged land?"), not an equality
+of counts — a second host's entries legitimately sit in the destination.
+
+## 🔴 `verify-byte-identity.sh` has a MEASURED one-directional coverage gap
+
+It enumerates the scopes to compare **from the LOCAL store**, so it can never
+see a scope the pod holds and this host does not. Measured 2026-09-02: local 16
+scopes / 141 entries, pod 23 / 189 — **7 pod-only scopes holding 48 entries,
+25% of the served store, never compared.** The script prints this itself on
+every run (`verify: COVERAGE — … This sweep is ONE-DIRECTIONAL …`), so a
+`scopes=16 pass=16 fail=0` line is complete coverage *of what it asked for* and
+says nothing about the rest.
+
+It also refuses a zero: `0 scopes found under <store>` exits non-zero, because a
+comparison over zero scopes passes trivially.
+
+The complementary direction — scopes on this disk the pod's answer did **not**
+carry — is `cairn doctor`'s `token-scopes` check. Neither alone is the answer.
+
+## 🔴 A scope invisible to your token is byte-identical to one that never existed
+
+`server.py` closes an enumeration oracle by filtering at the index
+(`rc.load_store`), so a refused scope and an absent scope produce the same bytes
+on every read route and the same 404 on every write route. **No client can tell
+them apart, and none should claim to.** `cairn doctor` reports the set and names
+both readings.
+
+A scope is created on the pod by whatever first writes an entry into it. The
+token allowlist is static, in the secret, and read once (above) — so a scope can
+exist in the store and be invisible to your credential until somebody edits the
+secret and replaces the pod.
+
+The store-wide `entry-files=` count in `X-Store-Snapshot` is **not** filtered by
+the allowlist — a deliberate, documented residual count leak — which is the only
+client-side evidence that such entries exist. `cairn doctor` reads it.
+
+## The freeze
+
+`cairn-cutover.py --freeze --apply` chmods the pre-cutover mirror's entry files
+`0444` and records every prior mode; `--unfreeze` restores them and refuses
+without that ledger. ⚠ The backup precondition lives in the P0 block, which
+`--freeze` skips — so `--freeze --apply` chmods the whole tree with no backup
+gate in front of it.
+
+`cairn doctor`'s `frozen-mirror` check is what tells you whether the freeze is
+still complete. Measured on the workbench 2026-09-03: **6 of 160 entry files
+were mode 644**, in a mirror that looked frozen. A write to one of those lives
+on one host and the pod never sees it.

--- a/claude/skills/initiatives/SKILL.md
+++ b/claude/skills/initiatives/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: initiatives
-description: "Operate the DURABLE initiatives board — the Postgres store, the sync, LLM recaps, the workbench viewer, the signal->initiative router and the /api/ask assistant. Use for: the initiatives viewer/board, initiatives.current/latest, the initiative store/sync, initiative recaps, the vllm-recap model, the initiatives assistant/chat, \"what's on my board\" as a durable page. The one-off scan is `initiative-scan`."
+description: "Operate the DURABLE initiatives board — its store, sync, recaps, viewer, the signal->initiative router and the /api/ask assistant. Use for: the initiatives viewer/board, initiatives.current/latest, the initiative store/sync, initiative recaps, the vllm-recap model, the initiatives assistant/chat, \"what's on my board\" as a durable page. The one-off scan is `initiative-scan`."
 ---
 
 # initiatives subsystem operations

--- a/claude/skills/mailbox/SKILL.md
+++ b/claude/skills/mailbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mailbox
-description: "Query and operate the self-hosted mail inbox (Gmail -> inbox.zacx.dev -> homelab Postgres `mail`) and its mail-actions automation, and SEND email as the operator via Gmail SMTP. Use for: my mail inbox, inbox.zacx.dev, forwarded email, the mail-receiver, the mailbox namespace, querying my email, the action-items queue, invoice/tax archiving, the sent-poller, mail automation, \"email someone on my behalf\", \"send an email as me\"."
+description: "Query and operate the self-hosted mail inbox and its mail-actions automation, and SEND email as the operator via Gmail SMTP. Use for: my mail inbox, inbox.zacx.dev, forwarded email, the mail-receiver, the mailbox namespace, querying my email, the action-items queue, invoice/tax archiving, the sent-poller, mail automation, \"email someone on my behalf\", \"send an email as me\"."
 ---
 
 # self-hosted mail inbox operations

--- a/claude/skills/prune-index/SKILL.md
+++ b/claude/skills/prune-index/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prune-index
-description: "Audit and prune the /analyze-service index store — evicts RESOLVED bullets, keeps every OPEN one, finds refs resolving to two entries. Use for: prune/shrink/audit the analyze-service index, an entry that got huge, `--ref X` is ref-ambiguous. A SKILL.md body is `prune-skill`; MEMORY.md is `prune-memory`; the store is `cairn`."
+description: "Audit and prune the /analyze-service index store — evicts RESOLVED bullets, keeps every OPEN one, finds refs resolving to two entries. Use for: prune/shrink/audit the analyze-service index, the subsystem index store, an entry that got huge, `--ref X` is ref-ambiguous, RESOLVED bullets piling up, ~/.claude/analyze-service-index. A SKILL.md body is `prune-skill`; MEMORY.md is `prune-memory`; the store itself is `cairn`."
 argument-hint: "[SCOPE | SCOPE/ENTRY.md] — optional; defaults to the whole store"
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---

--- a/claude/skills/prune-index/SKILL.md
+++ b/claude/skills/prune-index/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prune-index
-description: "Audit and prune the /analyze-service index store so recall keeps surfacing the RIGHT entry — evicts RESOLVED bullets, keeps every OPEN one, finds refs that resolve to two entries. Use for: prune/shrink/audit the analyze-service index, the subsystem index store, an entry that got huge, `--ref X` returns ref-ambiguous, RESOLVED bullets piling up, ~/.claude/analyze-service-index. Shrinking a SKILL.md body is `prune-skill`; the per-session MEMORY.md index is `prune-memory`."
+description: "Audit and prune the /analyze-service index store — evicts RESOLVED bullets, keeps every OPEN one, finds refs resolving to two entries. Use for: prune/shrink/audit the analyze-service index, an entry that got huge, `--ref X` is ref-ambiguous. A SKILL.md body is `prune-skill`; MEMORY.md is `prune-memory`; the store is `cairn`."
 argument-hint: "[SCOPE | SCOPE/ENTRY.md] — optional; defaults to the whole store"
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---
@@ -19,7 +19,7 @@ The store is a **pointer/nuance sheet per service** under `~/.claude/analyze-ser
 ## 🔴 Store safety — read this before the audit, not after
 - The store is **curated, CLIENT-CONFIDENTIAL, and not re-derivable by re-running recon.** ⚠ This bullet used to read "and has no off-machine backup" — false since 2026-08-21: `analyze-service-index-commit.service` commits each scope hourly and `analyze-service-index-backup.service` sends age-encrypted bundles to MinIO daily (`restore-verify.py` reads them back). **The rules below are unchanged, because they never rested on that** — a prune loses back to the last hourly commit, and **uncommitted state is in no commit and no bundle.** Detail: `~/.claude/skills/analyze-service/reference/index-store.md` → Store safety.
 - **Each `<scope>/` is its own git repo** (the root is not). **Run NO git command inside it** — no `stash`, no `reset --hard`, no `clean`, no `checkout --`, no remote, no push. Set work aside with `cp <file> /tmp/…`.
-- 🔴 **Since the Cairn cutover the tree under `~/.claude/analyze-service-index/` is a FROZEN mirror — entry files are `0444` and the pod is the authority.** An `EACCES` from an editor there is the design, not a broken store: every write in this skill goes through `cairn put` (§4).
+- 🔴 **`~/.claude/analyze-service-index/` is a FROZEN mirror; the pod is the authority.** An `EACCES` from an editor there is the design, not a broken store — §4 writes through the store API instead. The store itself, its client and `cairn doctor` are the **`cairn`** skill.
 - **Never copy an entry's content into devrc, any public repo, a PR body, an issue or a commit message.** Aggregate integers about the corpus are fine; a line of prose is not. devrc `60e6d9d` exists because this data class had to be scrubbed out of a public repo retroactively.
 - Each scope's own `README.md` states the policy governing it — read it before writing there. A scope with no README has no stated policy; the audit reports those.
 

--- a/claude/skills/session-manager/SKILL.md
+++ b/claude/skills/session-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-manager
-description: "Live cross-host view of every tmux window on workbench + laptop — which have Claude Code running, what each is doing, which ones are WAITING ON A HUMAN (asked a question / blocked on a modal / out of context), how stale it is, plus the clawgate approval queue, recent agent sessions, and UNSENT PROMPTS — text typed into a window and never sent. Use for: is anything waiting on me, active sessions, what's running where, tmux state across both hosts, cross-host session status, tail a tmux window, which windows are stale/idle/busy/blocked, did I leave anything half-typed / unsent."
+description: "Live cross-host view of every tmux window on workbench + laptop — which have Claude Code running, what each is doing, which ones are WAITING ON A HUMAN (asked a question / blocked on a modal / out of context), how stale it is, plus the clawgate approval queue, recent agent sessions, and UNSENT PROMPTS. Use for: is anything waiting on me, active sessions, what's running where, tmux state across both hosts, cross-host session status, tail a tmux window, which windows are stale/idle/busy/blocked, did I leave anything half-typed / unsent."
 ---
 
 # session-manager — cross-host tmux + agent activity

--- a/claude/skills/signal/SKILL.md
+++ b/claude/skills/signal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: signal
-description: "Query and operate the self-hosted Signal chat pipeline (phone -> signal-cli-rest-api -> homelab Postgres + MinIO attachments), and DRAFT outbound replies for clawgate approval. Use for: my Signal messages, signal chat, who messaged me on Signal, search my Signal history, Signal conversations/groups/reactions/attachments, the signal-consumer or signal-api pod, \"draft a Signal reply\", \"text someone on Signal\". Email and the mail inbox are the sibling `mailbox` skill, not this one."
+description: "Query and operate the self-hosted Signal chat pipeline, and DRAFT outbound replies for clawgate approval. Use for: my Signal messages, signal chat, who messaged me on Signal, search my Signal history, Signal conversations/groups/reactions/attachments, the signal-consumer or signal-api pod, \"draft a Signal reply\", \"text someone on Signal\". Email and the mail inbox are the sibling `mailbox` skill, not this one."
 ---
 
 # Signal chat operations

--- a/claude/skills/subsystem-index/SKILL.md
+++ b/claude/skills/subsystem-index/SKILL.md
@@ -20,6 +20,11 @@ copy has none. An `Edit` or `Write` against an entry file now fails with
 seed replaced the served copy with a file that never had it. The full mechanism
 is in the write half at the end of this document.
 
+⚠ **The STORE itself is a different skill.** The pod, the client, `cairn doctor`,
+`cairn sync`/`search`/`ls-entries`/`who`, seeding and the two different exit 4s
+are **`cairn`**. This document is the write PROTOCOL, and nothing about the store
+is restated here.
+
 ⚠ **It was genuinely forked until 2026-08-31, so a stale memory of that is not
 paranoia — read this before re-deriving it.** `/analyze-service`'s door,
 `claude/skills/analyze-service/reference/write-back.md`, carried a second copy of

--- a/claude/skills/window-triage/SKILL.md
+++ b/claude/skills/window-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: window-triage
-description: "Point at ONE tmux window by codename, hotkey or address (Gold, Alt+Shift+G, scratch2:@81), and rank the windows STRANDED past a threshold, longest-waited first. Use for: which window is Gold, what does Alt+p open, which window has been stranded / unanswered for hours or days, the oldest unanswered question, a codename with no hotkey, why a window shows no harness record, what the scan could not cover. The live inventory — is anything waiting on me, what's running where, tail a window, unsent prompts — is `session-manager`."
+description: "Point at ONE tmux window by codename, hotkey or address, and rank the windows STRANDED past a threshold, longest-waited first. Use for: which window is Gold, what does Alt+p open, which window has been stranded / unanswered for hours or days, the oldest unanswered question, a codename with no hotkey, why a window shows no harness record, what the scan could not cover. The live inventory — is anything waiting on me, what's running where, tail a window, unsent prompts — is `session-manager`."
 ---
 
 # window-triage — name one window, rank the stranded ones

--- a/scripts/cairn
+++ b/scripts/cairn
@@ -1107,7 +1107,12 @@ def cmd_put(args: argparse.Namespace) -> int:
 
 
 def _cairn_doctor():
-    """The `doctor` module, imported lazily — same idiom as `_cairn_who`."""
+    """The `doctor` module, imported inside a function — see `_doctor_epilog`.
+
+    ⚠ NOT "lazily", in effect. `build_parser` calls `_doctor_epilog()` to build
+    the help text, so this runs on EVERY invocation of every subcommand. Saying
+    otherwise is a cost model a maintainer would reason from and be wrong.
+    """
     lib = str(Path(__file__).resolve().parent / "lib")
     if lib not in sys.path:
         sys.path.insert(0, lib)
@@ -1350,8 +1355,27 @@ def _doctor_epilog() -> str:
     SKILL.md — is a second thing to keep true, and the numbers are the part a
     caller branches on. `cairn_doctor.EXIT_LEGEND` is the one definition; both
     `--help` and every run's own output render it from there.
+
+    ⚠ CALLED EAGERLY FROM `build_parser`, AND THE COMMENT THAT SAID OTHERWISE WAS
+    FALSE IN EFFECT. `argparse` wants `epilog` as a string, so `cairn_doctor` is
+    imported on EVERY invocation — the same trap `_cairn_who`'s own docstring
+    records for `_who_default_timeout`. The import stays function-scoped for
+    honesty about what this file needs to START, not as an optimisation.
+
+    🔴 AND IT FAILS SOFT. With `cairn_doctor.py` missing, an eager unguarded
+    import took `cairn ls-entries` — a subcommand that has nothing to do with
+    doctor — down with `ModuleNotFoundError` at exit 1, traceback and all.
+    `cmd_doctor` still fails LOUDLY, because that is the caller who asked for it;
+    an unrelated verb must not inherit the blast radius of a help string.
     """
-    doctor = _cairn_doctor()
+    try:
+        doctor = _cairn_doctor()
+    except ImportError as exc:
+        return (
+            f"exit codes: UNAVAILABLE — `cairn_doctor` could not be imported "
+            f"({exc}). `cairn doctor` itself will fail with this; every other "
+            f"subcommand is unaffected."
+        )
     lines = ["exit codes:"]
     lines += [f"  {code}  {why}" for code, why in doctor.EXIT_LEGEND]
     lines.append("")

--- a/scripts/cairn
+++ b/scripts/cairn
@@ -158,7 +158,21 @@ class StoreUnreachable(Exception):
     🔴 The reason is mandatory: criterion 5 of the card this implements is that
     an unreachable host is reported as UNMEASURED **with a reason**, never as a
     silent success or a zero.
+
+    🔴 `http_status` IS THE STRUCTURAL DISCRIMINATOR, AND IT EXISTS BECAUSE THE
+    MESSAGE IS NOT ONE. "the host never answered" and "the host answered 401"
+    are both raised here — deliberately, since a read degrades to the cache
+    either way — but they are NOT the same fact to a human: one is an outage and
+    the other is a credential that has to be replaced. The only thing that told
+    them apart was the phrasing of `str(exc)`, and a caller that greps a message
+    for `HTTP 401` has pinned an f-string. `None` means there was no answer at
+    all; an int is the status the server sent. `resolve_state` reads neither, so
+    nothing about the read path changes.
     """
+
+    def __init__(self, *args: object, http_status: int | None = None) -> None:
+        super().__init__(*args)
+        self.http_status = http_status
 
 
 class StoreCorrupt(Exception):
@@ -300,7 +314,9 @@ def fetch_snapshot(
         except Exception:
             detail = ""
         detail = f" — {detail[:300]}" if detail else ""
-        raise StoreUnreachable(f"{url} answered HTTP {exc.code}{detail}") from exc
+        raise StoreUnreachable(
+            f"{url} answered HTTP {exc.code}{detail}", http_status=exc.code
+        ) from exc
     except urllib.error.URLError as exc:
         raise StoreUnreachable(f"{url} unreachable: {exc.reason}") from exc
     except OSError as exc:  # socket timeouts and friends
@@ -1085,6 +1101,148 @@ def cmd_put(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+# =============================================================================
+# DOCTOR. Reads everything, installs nothing.
+# =============================================================================
+
+
+def _cairn_doctor():
+    """The `doctor` module, imported lazily — same idiom as `_cairn_who`."""
+    lib = str(Path(__file__).resolve().parent / "lib")
+    if lib not in sys.path:
+        sys.path.insert(0, lib)
+    import cairn_doctor  # noqa: PLC0415
+
+    return cairn_doctor
+
+
+#: How an operator reads the identity and the DECLARED allowlist behind a token.
+#: Spelled once, printed by `doctor`, and pinned by
+#: `test_cairn_doctor.py::test_the_identity_remedy_names_the_pods_own_token_file`
+#: against `server.DEFAULT_TOKEN_FILE`, so it cannot drift from the path the pod
+#: actually mounts. 🔴 It is a REMEDY, not a step this command takes: `doctor`
+#: never reads a secret and never shells `kubectl`.
+IDENTITY_REMEDY = (
+    "`kubectl -n subsystem-store exec deploy/subsystem-store-api -- "
+    "cut -d' ' -f2,3 /run/secrets/subsystem-store/token` "
+    "(fields 2 and 3 are the identity and the allowlist; field 1 is the secret)"
+)
+
+
+def probe_store(url: str, token: str, *, timeout: int):
+    """ONE snapshot fetch, read for facts and THROWN AWAY. Never installed.
+
+    🔴 IT REUSES `fetch_snapshot` RATHER THAN BUILDING A SECOND REQUEST. That
+    keeps `_apply_standard_headers` — and the measured User-Agent requirement
+    behind it — on this path without a second site to forget it at, and it is
+    what `test_cairn_write.py::test_no_request_builder_ANYWHERE_bypasses_this_
+    helper` would otherwise have to grow a case for.
+
+    🔴 IT NEVER CALLS `install_snapshot`. A diagnostic that repaired the cache
+    would destroy the staleness it was run to measure.
+    """
+    doctor = _cairn_doctor()
+    try:
+        body, headers = fetch_snapshot(url, token, scope=None, timeout=timeout)
+    except StoreUnreachable as exc:
+        return doctor.PodFacts(
+            reached=False, reason=str(exc), http_status=exc.http_status
+        )
+
+    visible = headers.get("x-store-entries")
+    snapshot = headers.get("x-store-snapshot", "")
+    scopes: set[str] = set()
+    try:
+        with tarfile.open(fileobj=io.BytesIO(body), mode="r") as tar:
+            for member in tar.getmembers():
+                if not member.isfile():
+                    continue
+                parts = Path(member.name).parts
+                if len(parts) == 2 and parts[1].endswith(".md"):
+                    scopes.add(parts[0])
+    except (tarfile.ReadError, EOFError, zlib.error) as exc:
+        return doctor.PodFacts(
+            reached=False,
+            reason=f"{url} answered, but the archive could not be read: {exc}",
+        )
+
+    # 🔴 `entry-files=` OUT OF THE STORE-WIDE HEADER, and the store-wide-ness is
+    # the point. `server.snapshot_freshness` counts the WHOLE served store, not
+    # the caller's slice — a documented, deliberate residual count leak — so the
+    # gap between it and `X-Store-Entries` is the only client-side evidence that
+    # entries exist which this credential cannot reach.
+    store_wide = None
+    for field in snapshot.split():
+        key, _, value = field.partition("=")
+        if key == "entry-files" and value.isdigit():
+            store_wide = int(value)
+
+    # 🔴 NO FALLBACK TO THE ARCHIVE'S OWN COUNT. Without `X-Store-Entries` the
+    # only number available is how many members ARRIVED, which is exactly the
+    # side of the comparison a truncated transfer moves — substituting it would
+    # make the cache-vs-pod check agree with itself and report OK over a short
+    # answer. `install_snapshot` cross-checks against this header for the same
+    # reason. Absent header => the count is UNMEASURED, with that as the stated
+    # reason.
+    return doctor.PodFacts(
+        reached=True,
+        visible_entries=int(visible) if visible and visible.isdigit() else None,
+        store_wide_entries=store_wide,
+        visible_scopes=tuple(sorted(scopes)),
+        snapshot_header=snapshot,
+    )
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    """One call for every fact a reader otherwise assembles by hand."""
+    doctor = _cairn_doctor()
+    resolved = _read_store.resolve_read_store(None)
+
+    # 🔴 THE CONFIG LOAD HAPPENS EVEN UNDER `--no-sync`, AND THAT IS A FIX. It is
+    # a local file read, so "is a credential configured on this host" is
+    # answerable with the network switched off — and the first version skipped it,
+    # which made `doctor --no-sync` report `token PROBLEM: no token is configured`
+    # on a host whose token was sitting in `~/.config/subsystem-store/env`
+    # unread. A check that says PROBLEM about something it never looked at is the
+    # same defect as one that says OK about it.
+    token: str | None = None
+    token_reason = ""
+    try:
+        url, token = load_config()
+    except StoreUnreachable as exc:
+        token_reason = str(exc)
+        config_error: str | None = str(exc)
+    else:
+        config_error = None
+
+    if args.no_sync:
+        pod = doctor.PodFacts(
+            reached=False,
+            reason="--no-sync was given, so the store was never contacted",
+        )
+    elif config_error is not None:
+        pod = doctor.PodFacts(reached=False, reason=config_error)
+    else:
+        pod = probe_store(url, token, timeout=_store_timeout(args))
+
+    checks = doctor.collect(
+        resolved_root=resolved.root,
+        stamp_lines=resolved.stamp,
+        stamp_reason=resolved.reason,
+        cache_root=args.cache,
+        mirror_root=subsystem_touch.DEFAULT_STORE_ROOT,
+        pod=pod,
+        token=token,
+        token_reason=token_reason,
+        identity_remedy=IDENTITY_REMEDY,
+    )
+    if args.json:
+        print(json.dumps(doctor.to_dict(checks), indent=2))
+    else:
+        print(doctor.render(checks))
+    return doctor.exit_code(checks)
+
+
 def _cairn_who():
     """The `who` module, imported lazily — it owns the timeout predicate.
 
@@ -1185,6 +1343,27 @@ def cmd_who(args: argparse.Namespace) -> int:
     return report.exit_code
 
 
+def _doctor_epilog() -> str:
+    """`doctor --help`'s exit-code legend, read from the module that owns it.
+
+    🔴 READ, NEVER RESTATED. A second copy of the legend in this file — or in a
+    SKILL.md — is a second thing to keep true, and the numbers are the part a
+    caller branches on. `cairn_doctor.EXIT_LEGEND` is the one definition; both
+    `--help` and every run's own output render it from there.
+    """
+    doctor = _cairn_doctor()
+    lines = ["exit codes:"]
+    lines += [f"  {code}  {why}" for code, why in doctor.EXIT_LEGEND]
+    lines.append("")
+    lines.append(
+        "check states: "
+        + ", ".join(doctor.STATES)
+        + " — UNMEASURED means the check could not look and says why; "
+        "NOT-OBSERVABLE means no client can answer it at all and names who can."
+    )
+    return "\n".join(lines)
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="cairn",
@@ -1232,6 +1411,31 @@ def build_parser() -> argparse.ArgumentParser:
 
     e = common(sub.add_parser("ls-entries", help="one `<scope>/<entry>.md` per line"))
     e.set_defaults(func=cmd_ls_entries)
+
+    # 🔴 `doctor` TAKES NO `--scope`/`--repo` AND IS NOT `common()`. It asks about
+    # THIS HOST and THIS CREDENTIAL, not about a scope, and a `--scope` here would
+    # invite the filtered-cache mistake `cmd_sync` documents. `--no-sync` it does
+    # take: "diagnose without touching the network" is a real mode, and it turns
+    # every pod-dependent check UNMEASURED with that as the stated reason rather
+    # than reporting a zero.
+    #
+    # 🔴 ITS EXIT CODES ARE DOCUMENTED BY THE COMMAND. `cairn_doctor.EXIT_LEGEND`
+    # is printed at the foot of every human-readable run and carried in `--json`,
+    # so no skill has to restate them and none can restate them wrongly.
+    d = sub.add_parser(
+        "doctor",
+        help="one call: pod reachability, credential, cache stamp, counts, "
+             "scope visibility, and which store this host's reader resolves",
+        epilog=_doctor_epilog(),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    d.add_argument("--json", action="store_true")
+    d.add_argument(
+        "--no-sync",
+        action="store_true",
+        help="do not contact the store; pod-dependent checks report UNMEASURED",
+    )
+    d.set_defaults(func=cmd_doctor)
 
     # --- the write verbs -----------------------------------------------------
     # 🔴 `writes=True` IS NOT DECORATION. `main` maps a `StoreUnreachable` to

--- a/scripts/lib/cairn_doctor.py
+++ b/scripts/lib/cairn_doctor.py
@@ -324,10 +324,15 @@ def collect(
             f"the store ANSWERED HTTP {pod.http_status} — {pod.reason}",
         ))
     else:
+        # 🔴 THE PREFIX IS NEUTRAL ON PURPOSE. It used to read "no answer from the
+        # store", which CONTRADICTS one of the reasons that arrives here: a
+        # snapshot the pod served and the client could not unpack is an answer.
+        # A heading that argues with the reason beneath it is a comment the code
+        # falsifies, which is the same defect class one layer up.
         checks.append(Check(
             "pod", UNMEASURED,
-            f"no answer from the store — {pod.reason}. Nothing below that needs "
-            f"the pod could be measured.",
+            f"the store's state could not be established — {pod.reason}. Nothing "
+            f"below that needs the pod could be measured.",
         ))
 
     # 5. CACHE vs POD. Only readable once the pod answered; otherwise UNMEASURED
@@ -425,10 +430,23 @@ def _visibility_check(pod: PodFacts, cache_root: Path, mirror_root: Path) -> Che
     unread_note = (" Some local roots were unreadable: " + "; ".join(unread)) if unread else ""
 
     if not missing and not hidden_entries:
+        # 🔴 AN UNREADABLE LOCAL ROOT MAKES THIS UNMEASURED, NOT OK-WITH-A-NOTE.
+        # "every scope on this disk is among them" is a claim about a set this
+        # walk could not finish building, and an OK carrying a caveat in its tail
+        # is exactly how a partial answer gets read as a clean one. The note
+        # alone was the first version; it stated the hole and still graded the
+        # check green.
+        if unread:
+            return Check(
+                "token-scopes", UNMEASURED,
+                f"the {len(visible)} scope(s) the store sent are all reachable, but "
+                f"this host's own scope set could not be fully read, so nothing is "
+                f"established about scopes present locally.{unread_note}",
+            )
         return Check(
             "token-scopes", OK,
             f"this credential reaches all {len(visible)} scope(s) the store sent, "
-            f"and every scope on this disk is among them.{unread_note}",
+            f"and every scope on this disk is among them.",
         )
     if not missing:
         return Check("token-scopes", PROBLEM, hidden_entries.strip() + unread_note)

--- a/scripts/lib/cairn_doctor.py
+++ b/scripts/lib/cairn_doctor.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""`cairn doctor` — one call that answers what a reader otherwise checks by hand.
+
+🔴 WHY THIS EXISTS. Every fact below was previously established by a human
+running four or five commands and holding the results in their head: is the pod
+up, is my token any good, is my cache stamped, does my cache agree with the pod,
+is anything on this disk invisible to my credential, and does this host's READER
+resolve to the synced cache or to the frozen pre-cutover mirror. Nothing joined
+them, so the answers were assembled differently every time and the joins that
+matter — cache count vs pod count, local scopes vs visible scopes — were the
+ones nobody made.
+
+🔴 FOUR STATES, AND THE FOURTH IS THE WHOLE POINT. This subsystem's recurring
+defect is a reassuring zero: an output that cannot distinguish "there is nothing
+there" from "I could not look". So every check reports one of
+
+    OK              measured, and the answer is fine
+    PROBLEM         measured, and the answer is not fine
+    UNMEASURED      I tried and could not — the reason is mandatory
+    NOT-OBSERVABLE  this cannot be answered from a client AT ALL, structurally,
+                    and the detail names who can answer it and how
+
+`NOT-OBSERVABLE` is separate from `UNMEASURED` on purpose. Folding the two would
+make the exit code permanently non-zero — the deployed API exposes no identity
+route and never will from here — and `claude/RULES.md` says a permanently-red
+gate is worse than no gate because it trains everyone to click through.
+
+🔴 DOCTOR NEVER INSTALLS A SNAPSHOT. It fetches, reads the headers and the member
+list, and throws the bytes away. A diagnostic that repaired the cache as a side
+effect would destroy the staleness it was run to measure — and it would be the
+one command you must not run twice.
+
+🔴 THE HOLE IT CANNOT CLOSE, STATED RATHER THAN LEFT TO BE FOUND. A scope this
+host holds but the pod's snapshot does not contain is EITHER a scope the store
+has never held OR a scope outside this token's allowlist. The API answers those
+two identically **by design** — `server.py` closes an enumeration oracle by
+making a refused scope byte-identical to an absent one — so no client can tell
+them apart, and this module does not pretend to. It reports the set and names
+both readings.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+__all__ = [
+    "OK",
+    "PROBLEM",
+    "UNMEASURED",
+    "NOT_OBSERVABLE",
+    "STATES",
+    "TOKEN_FINGERPRINT_CHARS",
+    "Check",
+    "PodFacts",
+    "token_fingerprint",
+    "store_entry_files",
+    "store_scopes",
+    "writable_entry_files",
+    "collect",
+    "render",
+    "exit_code",
+]
+
+#: The four verdicts a check may carry. Written out once; `render` and
+#: `exit_code` both read this tuple rather than restating the list.
+OK = "OK"
+PROBLEM = "PROBLEM"
+UNMEASURED = "UNMEASURED"
+NOT_OBSERVABLE = "NOT-OBSERVABLE"
+STATES: tuple[str, ...] = (OK, PROBLEM, UNMEASURED, NOT_OBSERVABLE)
+
+#: How many hex characters of `sha256(token)` identify a credential.
+#:
+#: 🔴 THIS MIRRORS `subsystem-store-api/server.py::token_id`, WHICH IS WHAT THE
+#: POD'S AUDIT LOG CARRIES. The value is what makes the fingerprint printed here
+#: matchable against a `token=<id>` line in the pod's log, so the two agreeing is
+#: a wire fact and not an implementation detail. `cairn` cannot import
+#: `server.py` — that module inserts paths, pulls in the whole reader and exists
+#: to be run as a daemon — so the rule is spelled twice and pinned once:
+#: `test_cairn_doctor.py::test_the_fingerprint_is_the_SERVERS_token_id` imports
+#: both and requires they agree on a fixture whose expected digest is written out
+#: as a literal in the test.
+TOKEN_FINGERPRINT_CHARS = 12
+
+
+def token_fingerprint(token: str) -> str:
+    """A stable, non-reversible handle for a credential. NEVER the token."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:TOKEN_FINGERPRINT_CHARS]
+
+
+@dataclass(frozen=True)
+class Check:
+    """One diagnosed fact.
+
+    `detail` is mandatory and is not decoration: for `UNMEASURED` it carries the
+    reason, and for `NOT-OBSERVABLE` it carries the command that CAN answer it.
+    A state with an empty detail is refused at construction, because a bare
+    `UNMEASURED` is the reassuring zero wearing a different word.
+    """
+
+    name: str
+    state: str
+    detail: str
+
+    def __post_init__(self) -> None:
+        if self.state not in STATES:
+            raise ValueError(f"unknown check state {self.state!r}; expected one of {STATES}")
+        if not self.detail.strip():
+            raise ValueError(
+                f"check {self.name!r} has an empty detail — a state with no "
+                f"reason cannot be acted on"
+            )
+
+
+@dataclass(frozen=True)
+class PodFacts:
+    """What one non-installing snapshot fetch established, or why it did not.
+
+    🔴 `reached` IS NOT DERIVED FROM THE COUNTS. A store that genuinely holds
+    zero entries and a fetch that never happened both leave the counts at 0, so
+    the counts may only be read when `reached` is True — and every consumer below
+    branches on `reached` first.
+    """
+
+    reached: bool
+    #: Set when `reached` is False. Mandatory in that case.
+    reason: str = ""
+    #: The HTTP status when the server ANSWERED but refused. `None` when there
+    #: was no answer at all, which is what separates unauthorised from
+    #: unreachable without parsing a message.
+    http_status: int | None = None
+    #: `X-Store-Entries` — what THIS token's snapshot contained.
+    visible_entries: int | None = None
+    #: `entry-files=` out of `X-Store-Snapshot` — the STORE-WIDE total, which the
+    #: server emits unfiltered (a documented, deliberate residual count leak).
+    store_wide_entries: int | None = None
+    #: Scope directory names present in the fetched archive.
+    visible_scopes: tuple[str, ...] = ()
+    #: The raw `X-Store-Snapshot` header, relayed verbatim.
+    snapshot_header: str = ""
+
+
+# --------------------------------------------------------------------------- #
+# Disk facts. Each one is a plain function so a test can drive it directly.
+# --------------------------------------------------------------------------- #
+
+def _scope_dirs(root: Path) -> list[Path]:
+    """`<root>/<scope>/` directories, dot-directories excluded.
+
+    Raises `OSError` rather than returning `[]` on an unreadable root: an empty
+    list and an unreadable directory are the two things this whole module exists
+    to keep apart, so the failure has to reach a caller that can name it.
+    """
+    return sorted(p for p in root.iterdir() if p.is_dir() and not p.name.startswith("."))
+
+
+def store_scopes(root: Path) -> tuple[str, ...]:
+    """The scope names a store root holds."""
+    return tuple(p.name for p in _scope_dirs(root))
+
+
+def store_entry_files(root: Path) -> int:
+    """`<scope>/<entry>.md` files under a store root.
+
+    The SAME shape `server.snapshot_freshness` counts — depth 2, `*.md`, no
+    dot-directories and no dot-files — so this number and the pod's
+    `entry-files=` are answers to one question rather than two.
+    """
+    total = 0
+    for scope in _scope_dirs(root):
+        for entry in scope.iterdir():
+            if entry.is_file() and entry.name.endswith(".md") and not entry.name.startswith("."):
+                total += 1
+    return total
+
+
+def writable_entry_files(root: Path) -> tuple[str, ...]:
+    """Entry files under `root` that any mode bit still allows WRITING.
+
+    🔴 THE FREEZE IS A PROPERTY OF EVERY FILE, NOT OF THE DIRECTORY. The cutover
+    chmods the pre-cutover mirror read-only so nothing can write to a store that
+    no longer feeds anybody. A partially-frozen mirror still accepts a write,
+    and that write then lives on one host and is invisible to the pod — the
+    exact stranding the cutover exists to prevent. So this counts FILES, and a
+    non-empty answer is a PROBLEM even when the directory looks frozen.
+    """
+    loose: list[str] = []
+    for scope in _scope_dirs(root):
+        for entry in sorted(scope.iterdir()):
+            if not (entry.is_file() and entry.name.endswith(".md")):
+                continue
+            if entry.stat().st_mode & 0o222:
+                loose.append(f"{scope.name}/{entry.name}")
+    return tuple(loose)
+
+
+def _describe(root: Path, what: Callable[[Path], object]) -> tuple[object | None, str]:
+    """`(value, reason-it-is-None)` — exactly one is set. No silent zero."""
+    try:
+        return what(root), ""
+    except FileNotFoundError:
+        return None, f"{root} does not exist"
+    except OSError as exc:
+        return None, f"{root} could not be read: {exc}"
+
+
+# --------------------------------------------------------------------------- #
+# The checks
+# --------------------------------------------------------------------------- #
+
+def collect(
+    *,
+    resolved_root: Path,
+    stamp_lines: Iterable[str] | None,
+    stamp_reason: str | None,
+    cache_root: Path,
+    mirror_root: Path,
+    pod: PodFacts,
+    token: str | None,
+    token_reason: str = "",
+    identity_remedy: str,
+) -> list[Check]:
+    """Every check, in the order a reader should read them.
+
+    Takes FACTS, not sources: the caller does the network and the config load, so
+    every branch here is reachable from a test with no server, no `$HOME` and no
+    clock.
+    """
+    checks: list[Check] = []
+
+    # 1. WHICH DIRECTORY does this host's reader resolve, and can it date itself?
+    #    This is `subsystem_read_store`'s question, asked out loud.
+    if stamp_lines is not None:
+        checks.append(Check(
+            "reader-resolution",
+            OK,
+            f"the reader resolves {resolved_root}, which carries a sync stamp",
+        ))
+    else:
+        checks.append(Check(
+            "reader-resolution",
+            PROBLEM,
+            f"the reader resolves {resolved_root}, which cannot date itself — "
+            f"{stamp_reason}. A read against it refuses (exit 4, the READER's "
+            f"EXIT_UNSTAMPED_READ_STORE). Fix: `cairn sync`.",
+        ))
+
+    # 2. THE STAMP'S OWN FIELDS, relayed unparsed.
+    if stamp_lines is None:
+        checks.append(Check(
+            "cache-stamp", PROBLEM,
+            f"no readable stamp in {resolved_root} — {stamp_reason}",
+        ))
+    else:
+        rendered = "; ".join(stamp_lines)
+        checks.append(Check("cache-stamp", OK, rendered or "(the stamp is empty)"))
+
+    # 3. THE FROZEN MIRROR. Absent is fine — a fresh host never had one. Present
+    #    and fully read-only is fine. Present with a WRITABLE entry is not.
+    loose, mirror_reason = _describe(mirror_root, writable_entry_files)
+    if loose is None:
+        if mirror_reason.endswith("does not exist"):
+            checks.append(Check(
+                "frozen-mirror", OK,
+                f"{mirror_root} does not exist — nothing pre-cutover on this host",
+            ))
+        else:
+            checks.append(Check("frozen-mirror", UNMEASURED, mirror_reason))
+    elif loose:
+        shown = ", ".join(list(loose)[:5]) + ("…" if len(loose) > 5 else "")
+        checks.append(Check(
+            "frozen-mirror", PROBLEM,
+            f"{len(loose)} entry file(s) under {mirror_root} are still WRITABLE "
+            f"({shown}). The mirror is frozen so nothing writes to a store the "
+            f"pod does not read; a write to one of these lives on this host "
+            f"only. Re-run `cairn-cutover.py --freeze --apply`.",
+        ))
+    else:
+        checks.append(Check(
+            "frozen-mirror", OK,
+            f"every entry file under {mirror_root} is read-only",
+        ))
+
+    # 4. THE POD. Unreachable, unauthorised and refused are three answers.
+    if pod.reached:
+        checks.append(Check(
+            "pod", OK, f"answered a snapshot request — {pod.snapshot_header or 'no stamp header'}",
+        ))
+    elif pod.http_status in (401, 403):
+        checks.append(Check(
+            "pod", PROBLEM,
+            f"the store ANSWERED and refused this credential (HTTP "
+            f"{pod.http_status}) — {pod.reason}. This is NOT an outage: the host "
+            f"is up. A 403 can also be the edge refusing the User-Agent rather "
+            f"than the token being wrong.",
+        ))
+    elif pod.http_status is not None:
+        checks.append(Check(
+            "pod", PROBLEM,
+            f"the store ANSWERED HTTP {pod.http_status} — {pod.reason}",
+        ))
+    else:
+        checks.append(Check(
+            "pod", UNMEASURED,
+            f"no answer from the store — {pod.reason}. Nothing below that needs "
+            f"the pod could be measured.",
+        ))
+
+    # 5. CACHE vs POD. Only readable once the pod answered; otherwise UNMEASURED
+    #    with the reason, never a zero.
+    cached, cache_reason = _describe(cache_root, store_entry_files)
+    if not pod.reached:
+        checks.append(Check(
+            "cache-vs-pod", UNMEASURED,
+            f"the pod was not reached ({pod.reason}), so the cache's "
+            f"{cached if cached is not None else 'unreadable'} entry file(s) "
+            f"could not be compared against anything",
+        ))
+    elif cached is None:
+        checks.append(Check("cache-vs-pod", UNMEASURED, cache_reason))
+    elif pod.visible_entries is None:
+        checks.append(Check(
+            "cache-vs-pod", UNMEASURED,
+            "the store answered without an `X-Store-Entries` header, so its own "
+            "count of what it sent is unknown",
+        ))
+    elif cached == pod.visible_entries:
+        checks.append(Check(
+            "cache-vs-pod", OK,
+            f"{cached} entry file(s) here, {pod.visible_entries} in the store's "
+            f"answer to this token — they agree",
+        ))
+    else:
+        checks.append(Check(
+            "cache-vs-pod", PROBLEM,
+            f"{cached} entry file(s) here but {pod.visible_entries} in the "
+            f"store's answer to this token. Fix: `cairn sync`.",
+        ))
+
+    # 6. WHAT THIS TOKEN CANNOT SEE. Two independent readings, both reported.
+    checks.append(_visibility_check(pod, cache_root, mirror_root))
+
+    # 7. THE CREDENTIAL. A fingerprint is measurable here; the IDENTITY behind it
+    #    is not, from any client, and says so rather than going quiet.
+    if token is None:
+        checks.append(Check(
+            "token", PROBLEM,
+            token_reason or "no token is configured, so no request can be authenticated",
+        ))
+    else:
+        checks.append(Check(
+            "token", NOT_OBSERVABLE,
+            f"fingerprint {token_fingerprint(token)} (sha256[:{TOKEN_FINGERPRINT_CHARS}], "
+            f"the handle the pod's audit log carries). The IDENTITY and the "
+            f"declared scope allowlist behind it live in the pod's token file and "
+            f"the API exposes no route that returns them — see the scope check "
+            f"above for what this credential can actually reach. To read the "
+            f"declared row: {identity_remedy}",
+        ))
+
+    return checks
+
+
+def _visibility_check(pod: PodFacts, cache_root: Path, mirror_root: Path) -> Check:
+    """Scopes and entries on this disk that the store's answer did not carry."""
+    if not pod.reached:
+        return Check(
+            "token-scopes", UNMEASURED,
+            f"the pod was not reached ({pod.reason}), so nothing is known about "
+            f"which scopes this credential can reach",
+        )
+
+    local: set[str] = set()
+    unread: list[str] = []
+    for root in (cache_root, mirror_root):
+        names, reason = _describe(root, store_scopes)
+        if names is None:
+            if not reason.endswith("does not exist"):
+                unread.append(reason)
+            continue
+        local |= set(names)  # type: ignore[arg-type]
+
+    visible = set(pod.visible_scopes)
+    missing = sorted(local - visible)
+
+    hidden_entries = ""
+    if pod.store_wide_entries is not None and pod.visible_entries is not None:
+        gap = pod.store_wide_entries - pod.visible_entries
+        if gap > 0:
+            hidden_entries = (
+                f" The store reports {pod.store_wide_entries} entry file(s) "
+                f"store-wide but sent this token {pod.visible_entries}, so "
+                f"{gap} live in scopes this credential cannot reach."
+            )
+
+    unread_note = (" Some local roots were unreadable: " + "; ".join(unread)) if unread else ""
+
+    if not missing and not hidden_entries:
+        return Check(
+            "token-scopes", OK,
+            f"this credential reaches all {len(visible)} scope(s) the store sent, "
+            f"and every scope on this disk is among them.{unread_note}",
+        )
+    if not missing:
+        return Check("token-scopes", PROBLEM, hidden_entries.strip() + unread_note)
+    return Check(
+        "token-scopes", PROBLEM,
+        f"{len(missing)} scope(s) exist on this disk and are NOT in the store's "
+        f"answer to this token: {', '.join(missing)}. The API cannot tell you "
+        f"which of the two this is — a refused scope is byte-identical to one the "
+        f"store has never held, deliberately, so that an error cannot enumerate "
+        f"the store. Both readings are actionable: either seed the scope, or add "
+        f"it to this token's allowlist.{hidden_entries}{unread_note}",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Rendering and the verdict
+# --------------------------------------------------------------------------- #
+
+#: 🔴 THE EXIT CODES, OWNED BY THE COMMAND AND DOCUMENTED BY IT. `render` prints
+#: this legend on every run, so a caller never has to find a skill to learn what
+#: a number meant. They are disjoint from every other `cairn` code: 0/3/4/5 are
+#: read outcomes, 6/7/8 are write outcomes, 2 is usage.
+EXIT_DOCTOR_OK = 0
+EXIT_DOCTOR_PROBLEM = 9
+EXIT_DOCTOR_UNMEASURED = 10
+
+EXIT_LEGEND: tuple[tuple[int, str], ...] = (
+    (EXIT_DOCTOR_OK, "every check measured, and every answer is fine"),
+    (EXIT_DOCTOR_PROBLEM, "at least one check MEASURED a problem"),
+    (EXIT_DOCTOR_UNMEASURED,
+     "no problem measured, but at least one check COULD NOT LOOK — "
+     "this is not a clean bill of health"),
+)
+
+
+def exit_code(checks: Iterable[Check]) -> int:
+    """PROBLEM outranks UNMEASURED outranks OK.
+
+    🔴 `NOT-OBSERVABLE` CONTRIBUTES NOTHING, and that is deliberate. It marks a
+    fact no client can reach, so escalating on it would make this command
+    non-zero on every healthy run forever — the permanently-red gate
+    `claude/RULES.md` says trains everyone to click through.
+    """
+    states = {c.state for c in checks}
+    if PROBLEM in states:
+        return EXIT_DOCTOR_PROBLEM
+    if UNMEASURED in states:
+        return EXIT_DOCTOR_UNMEASURED
+    return EXIT_DOCTOR_OK
+
+
+_MARKER = {OK: "  ", PROBLEM: "🔴", UNMEASURED: "⚠ ", NOT_OBSERVABLE: "· "}
+
+
+def render(checks: list[Check]) -> str:
+    """The report, plus the exit legend, plus a one-line verdict."""
+    width = max((len(c.name) for c in checks), default=0)
+    lines = [f"{_MARKER[c.state]} {c.name.ljust(width)}  {c.state:<14} {c.detail}"
+             for c in checks]
+    code = exit_code(checks)
+    counts = {s: sum(1 for c in checks if c.state == s) for s in STATES}
+    lines.append("")
+    lines.append(
+        "checks: "
+        + "  ".join(f"{s}={counts[s]}" for s in STATES)
+        + f"   -> exit {code}"
+    )
+    lines.append("exit codes: " + "; ".join(f"{n} = {why}" for n, why in EXIT_LEGEND))
+    return "\n".join(lines)
+
+
+def to_dict(checks: list[Check]) -> dict:
+    return {
+        "checks": [{"name": c.name, "state": c.state, "detail": c.detail} for c in checks],
+        "counts": {s: sum(1 for c in checks if c.state == s) for s in STATES},
+        "exit": exit_code(checks),
+        "exit_legend": {str(n): why for n, why in EXIT_LEGEND},
+    }

--- a/scripts/lib/cairn_doctor.py
+++ b/scripts/lib/cairn_doctor.py
@@ -142,6 +142,26 @@ class PodFacts:
     #: The raw `X-Store-Snapshot` header, relayed verbatim.
     snapshot_header: str = ""
 
+    def __post_init__(self) -> None:
+        """🔴 THE MANDATORY REASON, ENFORCED — it was only DOCUMENTED before.
+
+        `Check` refuses an empty detail at construction; this dataclass said
+        "Mandatory in that case" about `reason` and checked nothing. The
+        asymmetry is the defect, in the module whose whole thesis is that a bare
+        UNMEASURED is the reassuring zero wearing a new word: a future
+        `PodFacts(reached=False)` renders `the store's state could not be
+        established — .` and walks straight past `Check`'s guard, because the
+        empty string is wrapped in literal f-string text before it gets there.
+        Not reachable from today's three call sites; that is what makes now the
+        cheap time to close it.
+        """
+        if not self.reached and not self.reason.strip():
+            raise ValueError(
+                "PodFacts(reached=False) requires a reason — an unmeasured "
+                "store with no stated cause is the silent zero this module "
+                "exists to prevent"
+            )
+
 
 # --------------------------------------------------------------------------- #
 # Disk facts. Each one is a plain function so a test can drive it directly.
@@ -218,11 +238,29 @@ class Reading:
 
 
 def _describe(root: Path, what: Callable[[Path], object]) -> Reading:
-    """Read one fact off disk, or say why not. Never a silent zero."""
+    """Read one fact off disk, or say why not. Never a silent zero.
+
+    🔴 `absent` MEANS THE ROOT IS ABSENT — it is re-checked, not inferred from
+    the exception type. Mapping ANY `FileNotFoundError` to `absent=True` is wrong
+    in a way that produces a confident OK: a file vanishing MID-WALK raises the
+    same exception, and this store has two writers that do exactly that — the
+    hourly `analyze-service-index-commit.service`, and `cairn sync`, which
+    replaces the cache root by rename. The report would have read
+    `frozen-mirror OK … does not exist` for a directory that was right there,
+    with a false reason attached. Same shape as the defect `dd8411ca` fixed, one
+    level in: a state derived from a proxy instead of from the thing itself.
+    """
     try:
         return Reading(what(root), "", absent=False)
-    except FileNotFoundError:
-        return Reading(None, f"{root} does not exist", absent=True)
+    except FileNotFoundError as exc:
+        if not root.exists():
+            return Reading(None, f"{root} does not exist", absent=True)
+        return Reading(
+            None,
+            f"{root} exists but something under it vanished while it was being "
+            f"read ({exc}) — a concurrent writer, not an absent store",
+            absent=False,
+        )
     except OSError as exc:
         return Reading(None, f"{root} could not be read: {exc}", absent=False)
 
@@ -400,9 +438,17 @@ def _visibility_check(pod: PodFacts, cache_root: Path, mirror_root: Path) -> Che
             f"which scopes this credential can reach",
         )
 
-    local: set[str] = set()
+    # 🔴 PROVENANCE PER SCOPE, NOT ONE MERGED SET. The two roots mean different
+    # things and lead to different actions: a scope in the SYNCED CACHE that the
+    # pod no longer sends is a credential or a deletion; a scope in the FROZEN
+    # MIRROR only is a pre-cutover leftover that may never have reached the pod
+    # at all. The first version merged them and said "N scope(s) exist on this
+    # disk", offering two remedies that were both about the live store — so an
+    # operator could not tell which they were looking at. Measured: the two it
+    # named on the workbench were mirror-only.
+    where: dict[str, list[str]] = {}
     unread: list[str] = []
-    for root in (cache_root, mirror_root):
+    for label, root in (("cache", cache_root), ("mirror", mirror_root)):
         reading = _describe(root, store_scopes)
         if not reading.ok:
             # An ABSENT root contributes nothing and is not a failure; an
@@ -412,8 +458,10 @@ def _visibility_check(pod: PodFacts, cache_root: Path, mirror_root: Path) -> Che
             if not reading.absent:
                 unread.append(reading.reason)
             continue
-        local |= set(reading.value)  # type: ignore[arg-type]
+        for name in reading.value:  # type: ignore[union-attr]
+            where.setdefault(name, []).append(label)
 
+    local = set(where)
     visible = set(pod.visible_scopes)
     missing = sorted(local - visible)
 
@@ -450,14 +498,25 @@ def _visibility_check(pod: PodFacts, cache_root: Path, mirror_root: Path) -> Che
         )
     if not missing:
         return Check("token-scopes", PROBLEM, hidden_entries.strip() + unread_note)
+    named = ", ".join(f"{s} [{'+'.join(where[s])}]" for s in missing)
+    mirror_only = [s for s in missing if where[s] == ["mirror"]]
+    leftover_note = (
+        f" 🔴 {len(mirror_only)} of them exist ONLY in the frozen pre-cutover "
+        f"mirror ({', '.join(mirror_only)}) — those may never have reached the "
+        f"pod, so the question is whether they were ever seeded, NOT whether "
+        f"access was lost."
+        if mirror_only else ""
+    )
     return Check(
         "token-scopes", PROBLEM,
         f"{len(missing)} scope(s) exist on this disk and are NOT in the store's "
-        f"answer to this token: {', '.join(missing)}. The API cannot tell you "
-        f"which of the two this is — a refused scope is byte-identical to one the "
-        f"store has never held, deliberately, so that an error cannot enumerate "
-        f"the store. Both readings are actionable: either seed the scope, or add "
-        f"it to this token's allowlist.{hidden_entries}{unread_note}",
+        f"answer to this token, each tagged with WHERE it was found: {named}. "
+        f"For a scope the store should hold, the API cannot tell you which of "
+        f"two things you are seeing — a refused scope is byte-identical to one "
+        f"the store has never held, deliberately, so that an error cannot "
+        f"enumerate the store. Both readings are actionable: seed the scope, or "
+        f"add it to this token's allowlist.{leftover_note}"
+        f"{hidden_entries}{unread_note}",
     )
 
 

--- a/scripts/lib/cairn_doctor.py
+++ b/scripts/lib/cairn_doctor.py
@@ -197,14 +197,34 @@ def writable_entry_files(root: Path) -> tuple[str, ...]:
     return tuple(loose)
 
 
-def _describe(root: Path, what: Callable[[Path], object]) -> tuple[object | None, str]:
-    """`(value, reason-it-is-None)` — exactly one is set. No silent zero."""
+@dataclass(frozen=True)
+class Reading:
+    """One disk fact, or the structured reason there is none.
+
+    🔴 `absent` IS A FLAG, NOT A SENTENCE. The first version had callers ask
+    `reason.endswith("does not exist")` to tell a missing directory from an
+    unreadable one — a guard SPELLED rather than STRUCTURAL, which `claude/RULES.md`
+    names directly: reword the message and the branch silently stops firing, with
+    an unreadable mirror then reported as "nothing pre-cutover on this host".
+    """
+
+    value: object | None
+    reason: str
+    absent: bool
+
+    @property
+    def ok(self) -> bool:
+        return self.reason == ""
+
+
+def _describe(root: Path, what: Callable[[Path], object]) -> Reading:
+    """Read one fact off disk, or say why not. Never a silent zero."""
     try:
-        return what(root), ""
+        return Reading(what(root), "", absent=False)
     except FileNotFoundError:
-        return None, f"{root} does not exist"
+        return Reading(None, f"{root} does not exist", absent=True)
     except OSError as exc:
-        return None, f"{root} could not be read: {exc}"
+        return Reading(None, f"{root} could not be read: {exc}", absent=False)
 
 
 # --------------------------------------------------------------------------- #
@@ -260,15 +280,16 @@ def collect(
 
     # 3. THE FROZEN MIRROR. Absent is fine — a fresh host never had one. Present
     #    and fully read-only is fine. Present with a WRITABLE entry is not.
-    loose, mirror_reason = _describe(mirror_root, writable_entry_files)
-    if loose is None:
-        if mirror_reason.endswith("does not exist"):
+    mirror = _describe(mirror_root, writable_entry_files)
+    loose = mirror.value
+    if not mirror.ok:
+        if mirror.absent:
             checks.append(Check(
                 "frozen-mirror", OK,
                 f"{mirror_root} does not exist — nothing pre-cutover on this host",
             ))
         else:
-            checks.append(Check("frozen-mirror", UNMEASURED, mirror_reason))
+            checks.append(Check("frozen-mirror", UNMEASURED, mirror.reason))
     elif loose:
         shown = ", ".join(list(loose)[:5]) + ("…" if len(loose) > 5 else "")
         checks.append(Check(
@@ -311,16 +332,17 @@ def collect(
 
     # 5. CACHE vs POD. Only readable once the pod answered; otherwise UNMEASURED
     #    with the reason, never a zero.
-    cached, cache_reason = _describe(cache_root, store_entry_files)
+    cache = _describe(cache_root, store_entry_files)
+    cached = cache.value
     if not pod.reached:
         checks.append(Check(
             "cache-vs-pod", UNMEASURED,
             f"the pod was not reached ({pod.reason}), so the cache's "
-            f"{cached if cached is not None else 'unreadable'} entry file(s) "
+            f"{cached if cache.ok else 'unreadable'} entry file(s) "
             f"could not be compared against anything",
         ))
-    elif cached is None:
-        checks.append(Check("cache-vs-pod", UNMEASURED, cache_reason))
+    elif not cache.ok:
+        checks.append(Check("cache-vs-pod", UNMEASURED, cache.reason))
     elif pod.visible_entries is None:
         checks.append(Check(
             "cache-vs-pod", UNMEASURED,
@@ -376,12 +398,16 @@ def _visibility_check(pod: PodFacts, cache_root: Path, mirror_root: Path) -> Che
     local: set[str] = set()
     unread: list[str] = []
     for root in (cache_root, mirror_root):
-        names, reason = _describe(root, store_scopes)
-        if names is None:
-            if not reason.endswith("does not exist"):
-                unread.append(reason)
+        reading = _describe(root, store_scopes)
+        if not reading.ok:
+            # An ABSENT root contributes nothing and is not a failure; an
+            # UNREADABLE one is a hole in this check's own coverage and is named
+            # in the detail, so a clean-looking answer cannot come from a walk
+            # that could not see half its input.
+            if not reading.absent:
+                unread.append(reading.reason)
             continue
-        local |= set(names)  # type: ignore[arg-type]
+        local |= set(reading.value)  # type: ignore[arg-type]
 
     visible = set(pod.visible_scopes)
     missing = sorted(local - visible)

--- a/scripts/tests/test_cairn_doctor.py
+++ b/scripts/tests/test_cairn_doctor.py
@@ -155,6 +155,21 @@ class TestTheStateVocabulary:
         with pytest.raises(ValueError, match="unknown check state"):
             cd.Check("x", "FINE", "detail")
 
+    def test_PodFacts_ENFORCES_its_reason_it_does_not_merely_document_one(
+        self,
+    ) -> None:
+        """🔴 THE ASYMMETRY WAS THE FINDING. `Check` refused an empty detail at
+        construction; `PodFacts` said "Mandatory in that case" and checked
+        nothing. An unreasoned `PodFacts(reached=False)` renders `… could not be
+        established — .` and walks straight past `Check`'s guard, because the
+        empty string is wrapped in literal f-string text before it gets there."""
+        with pytest.raises(ValueError, match="requires a reason"):
+            cd.PodFacts(reached=False)
+        with pytest.raises(ValueError, match="requires a reason"):
+            cd.PodFacts(reached=False, reason="   ")
+        # A REACHED pod needs none — there is nothing unexplained about success.
+        assert cd.PodFacts(reached=True).reason == ""
+
 
 class TestTheVerdict:
     def test_a_problem_outranks_an_unmeasured(self) -> None:
@@ -273,6 +288,29 @@ class TestAnUnmeasuredAnswerIsNotAZero:
         present = cd._describe(_store(tmp_path / "s", {"a": []}), cd.store_scopes)
         assert present.ok and present.absent is False and present.value == ("a",)
 
+    def test_a_file_VANISHING_MID_WALK_is_not_reported_as_an_absent_store(
+        self, tmp_path
+    ) -> None:
+        """🔴 `absent` IS RE-CHECKED, NOT INFERRED FROM THE EXCEPTION TYPE.
+
+        Mapping any `FileNotFoundError` to `absent=True` produces a confident OK
+        with a FALSE reason — `frozen-mirror OK … does not exist` for a directory
+        that is right there. This store has two writers that make it happen: the
+        hourly `analyze-service-index-commit.service`, and `cairn sync`, which
+        replaces the cache root by rename.
+        """
+        root = _store(tmp_path / "s", {"alpha": ["a.md"]})
+
+        def vanishing(_root):
+            raise FileNotFoundError(2, "No such file or directory", "alpha/a.md")
+
+        reading = cd._describe(root, vanishing)
+        assert reading.absent is False, "a live root was reported as absent"
+        assert not reading.ok
+        assert "concurrent writer" in reading.reason
+        # …and the root genuinely being gone still reads as absent.
+        assert cd._describe(tmp_path / "gone", vanishing).absent is True
+
     def test_a_no_sync_run_says_SO_rather_than_reporting_an_outage(self) -> None:
         """`--no-sync` is a choice, not a failure. The reason has to name it, or
         an operator reads a deliberate offline run as a broken store."""
@@ -322,10 +360,19 @@ class TestTheReaderResolution:
 
 class TestTheFrozenMirror:
     def test_a_WRITABLE_entry_file_is_a_PROBLEM(self, tmp_path) -> None:
-        """🔴 MEASURED ON THE WORKBENCH 2026-09-03: 6 of 160 entry files under
-        the mirror were still mode 644 after the cutover froze it. A write to
-        one of those lives on one host and the pod never sees it — the exact
-        stranding the freeze exists to prevent, in a mirror that LOOKS frozen."""
+        """🔴 THIS FOUND A LIVE DATA-LOSS PATH ON ITS FIRST RUN.
+
+        Measured on the workbench 2026-09-03: **7** entry files under the
+        supposedly-frozen mirror were still mode 644, an append was watched to
+        SUCCEED on one, and six entries created on the dead mirror after the
+        cutover existed nowhere else. The operator has since completed the
+        freeze; the tree now measures 159 files, all `0444`, writable=0, and
+        `cairn doctor` reports `frozen-mirror OK`.
+
+        ⚠ Which is exactly why this builds its OWN fixture rather than asserting
+        against the live tree: those numbers moved within a day of being taken,
+        and a guard pinned to them would now be red for the wrong reason.
+        """
         mirror = _store(tmp_path / "m", {"alpha": ["a.md", "b.md"]})
         (mirror / "alpha" / "a.md").chmod(0o444)
         (mirror / "alpha" / "b.md").chmod(0o644)
@@ -396,6 +443,44 @@ class TestTheScopeVisibility:
         ))["token-scopes"]
         assert check.state == cd.PROBLEM
         assert "orphan" in check.detail
+
+    def test_a_missing_scope_is_TAGGED_with_the_tree_it_came_from(
+        self, tmp_path
+    ) -> None:
+        """🔴 THE TWO ROOTS MEAN DIFFERENT THINGS AND LEAD TO DIFFERENT ACTIONS.
+
+        A scope in the SYNCED CACHE the pod no longer sends is a credential or a
+        deletion. A scope in the FROZEN MIRROR only is a pre-cutover leftover
+        that may never have reached the pod at all — so "add it to the allowlist"
+        is the wrong first question. The first version merged the two sets and
+        said "N scope(s) exist on this disk", and both scopes it named live were
+        mirror-only.
+        """
+        cache = _store(tmp_path / "c", {"alpha": ["a.md"], "cache-only": ["c.md"]})
+        mirror = _store(tmp_path / "m", {"alpha": ["a.md"], "mirror-only": ["m.md"]})
+        check = _by_name(_collect(
+            cache_root=cache, mirror_root=mirror,
+            pod=cd.PodFacts(reached=True, visible_entries=1, store_wide_entries=1,
+                            visible_scopes=("alpha",)),
+        ))["token-scopes"]
+        assert check.state == cd.PROBLEM
+        assert "mirror-only [mirror]" in check.detail
+        assert "cache-only [cache]" in check.detail
+        # …and the mirror-only one gets the leftover reading spelled out, while
+        # the cache-only one does not inherit it.
+        assert "ONLY in the frozen pre-cutover mirror (mirror-only)" in check.detail
+
+    def test_a_scope_in_BOTH_trees_is_tagged_with_both(self, tmp_path) -> None:
+        cache = _store(tmp_path / "c", {"shared": ["a.md"]})
+        mirror = _store(tmp_path / "m", {"shared": ["a.md"]})
+        detail = _by_name(_collect(
+            cache_root=cache, mirror_root=mirror,
+            pod=cd.PodFacts(reached=True, visible_entries=0, store_wide_entries=0,
+                            visible_scopes=()),
+        ))["token-scopes"].detail
+        assert "shared [cache+mirror]" in detail
+        # Present in the live cache too, so it is NOT a pre-cutover leftover.
+        assert "ONLY in the frozen" not in detail
 
     def test_it_refuses_to_GUESS_which_of_the_two_readings_is_right(
         self, tmp_path
@@ -557,6 +642,32 @@ class TestTheCliWiring:
         cli = _load_cairn_cli()
         with pytest.raises(SystemExit):
             cli.build_parser().parse_args(["doctor", "--scope", "devrc"])
+
+    def test_an_ABSENT_doctor_module_does_not_kill_an_UNRELATED_subcommand(
+        self, monkeypatch
+    ) -> None:
+        """🔴 MEASURED: with `cairn_doctor.py` absent, `cairn ls-entries` — which
+        has nothing to do with doctor — died `ModuleNotFoundError`, exit 1, with
+        a traceback. `build_parser` calls `_doctor_epilog()` eagerly to build a
+        HELP STRING, so an unguarded import there put every verb behind a module
+        only one of them needs.
+
+        `cmd_doctor` itself must still fail loudly — that caller asked for it.
+        """
+        cli = _load_cairn_cli()
+
+        def gone():
+            raise ImportError("No module named 'cairn_doctor'")
+
+        monkeypatch.setattr(cli, "_cairn_doctor", gone)
+        epilog = cli._doctor_epilog()
+        assert "UNAVAILABLE" in epilog and "cairn_doctor" in epilog
+        # The parser still builds, so unrelated verbs still parse and dispatch.
+        args = cli.build_parser().parse_args(["ls-entries"])
+        assert args.func is cli.cmd_ls_entries
+        # …and doctor itself does NOT quietly degrade.
+        with pytest.raises(ImportError):
+            cli.cmd_doctor(cli.build_parser().parse_args(["doctor"]))
 
     def test_the_help_epilog_carries_the_exit_codes(self) -> None:
         cli = _load_cairn_cli()

--- a/scripts/tests/test_cairn_doctor.py
+++ b/scripts/tests/test_cairn_doctor.py
@@ -1,0 +1,696 @@
+#!/usr/bin/env python3
+"""`cairn doctor` — and the one property it exists for: an UNMEASURED answer.
+
+🔴 WHAT THIS FILE GRADES. Every other diagnostic in this subsystem has been
+caught reporting a zero it could not distinguish from a failure to look: the
+frozen mirror's "ALL 26 entries, none omitted"; the pod's "ALL 5 entries in
+devrc/" over a store holding 9; `cairn validate`'s "NOTHING WAS CHECKED" at exit
+0. `doctor` exists to join those facts in one call, so it is exactly the place
+that defect would arrive next, wearing a nicer word.
+
+So the assertions here are almost all of one shape: **the same visible outcome,
+reached two ways, must NOT produce the same report.** A cache with zero entries
+and a cache that could not be read; a store that holds nothing for this token and
+a store that never answered; a mirror that is absent and a mirror that is
+unreadable.
+
+🔴 EVERY EXPECTED VALUE IS A LITERAL WRITTEN OUT HERE. `assert X == module.X` —
+a constant agreeing with itself — has shipped in this subsystem five times, each
+fix narrower than the class. Where a fact is shared with another module
+(`server.token_id`, `server.DEFAULT_TOKEN_FILE`) the test imports BOTH sides and
+grades the RELATIONSHIP against a literal, rather than letting either define the
+answer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import tarfile
+import urllib.error
+from email.message import Message
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+import cairn_doctor as cd  # noqa: E402
+
+CAIRN_CLI = REPO / "scripts" / "cairn"
+SERVER_PY = REPO / "scripts" / "subsystem-store-api" / "server.py"
+
+
+def _load_cairn_cli():
+    """Exec `scripts/cairn` as a module — it has no .py extension."""
+    spec = importlib.util.spec_from_loader(
+        "cairn_cli_doctor", loader=None, origin=str(CAIRN_CLI)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    mod.__file__ = str(CAIRN_CLI)
+    exec(compile(CAIRN_CLI.read_text(encoding="utf-8"), str(CAIRN_CLI), "exec"), mod.__dict__)
+    return mod
+
+
+def _load_api():
+    """Import `server.py` by path. `sys.modules[...]` BEFORE `exec_module` —
+    without it the first `@dataclass` raises under `from __future__ import
+    annotations`. Same idiom as `test_cairn_write._load_api`."""
+    spec = importlib.util.spec_from_file_location("srv_doctor", SERVER_PY)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _store(root: Path, scopes: dict[str, list[str]], *, stamp: str | None = None) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    for scope, entries in scopes.items():
+        (root / scope).mkdir(parents=True, exist_ok=True)
+        for name in entries:
+            (root / scope / name).write_text("# entry\n", encoding="utf-8")
+    if stamp is not None:
+        (root / ".sync-stamp").write_text(stamp, encoding="utf-8")
+    return root
+
+
+def _collect(**over):
+    """`collect` with every argument defaulted to a benign, MEASURED fact.
+
+    Each test overrides exactly the one thing it is about, which is what keeps a
+    mutation isolated to the branch under test rather than to the fixture.
+    """
+    base = dict(
+        resolved_root=Path("/nowhere/cache"),
+        stamp_lines=("synced=1", "entries=2"),
+        stamp_reason=None,
+        cache_root=Path("/nowhere/cache"),
+        mirror_root=Path("/nowhere/mirror"),
+        pod=cd.PodFacts(reached=True, visible_entries=2, store_wide_entries=2,
+                        visible_scopes=("alpha",), snapshot_header="entry-files=2"),
+        token="tok",
+        token_reason="",
+        identity_remedy="ask the operator",
+    )
+    base.update(over)
+    return cd.collect(**base)
+
+
+def _by_name(checks) -> dict[str, cd.Check]:
+    return {c.name: c for c in checks}
+
+
+# =============================================================================
+# The four states, and the contract on each
+# =============================================================================
+
+class TestTheStateVocabulary:
+    def test_the_four_states_are_exactly_these_literals(self) -> None:
+        """Written out here, never read off the module. A caller — a human or a
+        `--json` consumer — branches on these strings."""
+        assert cd.OK == "OK"
+        assert cd.PROBLEM == "PROBLEM"
+        assert cd.UNMEASURED == "UNMEASURED"
+        assert cd.NOT_OBSERVABLE == "NOT-OBSERVABLE"
+        assert cd.STATES == ("OK", "PROBLEM", "UNMEASURED", "NOT-OBSERVABLE")
+
+    def test_the_exit_codes_are_exactly_these_literals(self) -> None:
+        """🔴 DISJOINT FROM EVERY OTHER `cairn` CODE, and that is graded below
+        against the CLI rather than asserted here alone."""
+        assert cd.EXIT_DOCTOR_OK == 0
+        assert cd.EXIT_DOCTOR_PROBLEM == 9
+        assert cd.EXIT_DOCTOR_UNMEASURED == 10
+
+    def test_doctors_codes_collide_with_NO_other_cairn_exit_code(self) -> None:
+        """🔴 SEAM GUARD. `cairn`'s 4 already means two different things across
+        two tools (`EXIT_REFRESH_FAILED` vs the reader's
+        `EXIT_UNSTAMPED_READ_STORE`) and `/resume` carries a paragraph about it.
+        A third collision is a defect this file can prevent for free."""
+        cli = _load_cairn_cli()
+        others = {
+            cli.EXIT_OK, cli.EXIT_USAGE, cli.EXIT_UNREACHABLE_NO_CACHE,
+            cli.EXIT_REFRESH_FAILED, cli.EXIT_CORRUPT, cli.EXIT_WRITE_REFUSED,
+            cli.EXIT_WRITE_UNREACHABLE, cli.EXIT_WRITE_PRECONDITION,
+        }
+        assert others == {0, 2, 3, 4, 5, 6, 7, 8}, (
+            f"cairn's existing exit codes moved: {sorted(others)}"
+        )
+        assert cd.EXIT_DOCTOR_PROBLEM not in others
+        assert cd.EXIT_DOCTOR_UNMEASURED not in others
+
+    def test_a_check_with_an_EMPTY_detail_is_refused(self) -> None:
+        """🔴 A bare `UNMEASURED` with no reason is the reassuring zero wearing
+        a different word. The refusal is at construction so no render path can
+        emit one."""
+        with pytest.raises(ValueError, match="empty detail"):
+            cd.Check("x", cd.UNMEASURED, "   ")
+
+    def test_an_unknown_state_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="unknown check state"):
+            cd.Check("x", "FINE", "detail")
+
+
+class TestTheVerdict:
+    def test_a_problem_outranks_an_unmeasured(self) -> None:
+        checks = [cd.Check("a", cd.UNMEASURED, "no"), cd.Check("b", cd.PROBLEM, "bad")]
+        assert cd.exit_code(checks) == 9
+
+    def test_an_unmeasured_outranks_an_ok(self) -> None:
+        checks = [cd.Check("a", cd.OK, "fine"), cd.Check("b", cd.UNMEASURED, "no")]
+        assert cd.exit_code(checks) == 10
+
+    def test_all_ok_is_zero(self) -> None:
+        assert cd.exit_code([cd.Check("a", cd.OK, "fine")]) == 0
+
+    def test_NOT_OBSERVABLE_alone_is_ZERO_and_that_is_deliberate(self) -> None:
+        """🔴 THE PERMANENTLY-RED-GATE GUARD. The pod exposes no identity route,
+        so the credential check is NOT-OBSERVABLE on every healthy run forever.
+        Escalating on it would make `doctor` non-zero always, which
+        `claude/RULES.md` says trains everyone to click through. Pinned so the
+        two states cannot be quietly merged."""
+        checks = [cd.Check("a", cd.OK, "fine"), cd.Check("b", cd.NOT_OBSERVABLE, "ask")]
+        assert cd.exit_code(checks) == 0
+
+    def test_an_EMPTY_check_list_is_not_a_clean_bill(self) -> None:
+        """A run that produced no checks exits 0 today, so this pins the shape
+        the render carries instead: the counts are printed, and `OK=0` is
+        visibly different from `OK=7`. Stated rather than left implied — this is
+        an INVARIANT GUARD on the render, not a claim that zero checks is safe.
+        """
+        assert "OK=0" in cd.render([cd.Check("a", cd.NOT_OBSERVABLE, "x")])
+
+
+# =============================================================================
+# UNMEASURED is not a zero — the whole point, one check at a time
+# =============================================================================
+
+class TestAnUnmeasuredAnswerIsNotAZero:
+    def test_an_unreached_pod_leaves_the_count_UNMEASURED_not_zero(self) -> None:
+        checks = _by_name(_collect(
+            pod=cd.PodFacts(reached=False, reason="connection refused")
+        ))
+        assert checks["cache-vs-pod"].state == cd.UNMEASURED
+        assert "connection refused" in checks["cache-vs-pod"].detail
+        assert checks["token-scopes"].state == cd.UNMEASURED
+
+    def test_a_store_that_genuinely_holds_NOTHING_is_OK_not_unmeasured(
+        self, tmp_path
+    ) -> None:
+        """🔴 THE OTHER HALF, and the one a lazier implementation gets wrong. An
+        empty store REACHED is a measured fact, and reporting it as UNMEASURED
+        would be the mirror-image lie: a working system described as unknowable.
+        """
+        cache = _store(tmp_path / "cache", {})
+        checks = _by_name(_collect(
+            cache_root=cache,
+            pod=cd.PodFacts(reached=True, visible_entries=0, store_wide_entries=0,
+                            visible_scopes=(), snapshot_header="entry-files=0"),
+        ))
+        assert checks["cache-vs-pod"].state == cd.OK
+        assert "0 entry file(s) here" in checks["cache-vs-pod"].detail
+
+    def test_the_two_zeroes_produce_DIFFERENT_reports(self, tmp_path) -> None:
+        """The discriminating assertion: same visible count, two mechanisms."""
+        cache = _store(tmp_path / "cache", {})
+        reached = _by_name(_collect(
+            cache_root=cache,
+            pod=cd.PodFacts(reached=True, visible_entries=0, store_wide_entries=0,
+                            snapshot_header="entry-files=0"),
+        ))["cache-vs-pod"]
+        unreached = _by_name(_collect(
+            cache_root=cache,
+            pod=cd.PodFacts(reached=False, reason="DNS failure"),
+        ))["cache-vs-pod"]
+        assert reached.state != unreached.state
+        assert reached.detail != unreached.detail
+
+    def test_a_missing_mirror_is_OK_and_an_UNREADABLE_one_is_UNMEASURED(
+        self, tmp_path
+    ) -> None:
+        """Absent and unreadable are the classic pair. A fresh host has no
+        mirror at all, which is fine; a mirror this process cannot read is a
+        fact nobody has established, and the two must not render alike."""
+        absent = _by_name(_collect(mirror_root=tmp_path / "never-existed"))["frozen-mirror"]
+        assert absent.state == cd.OK
+
+        blocked = tmp_path / "blocked"
+        blocked.mkdir()
+        (blocked / "scope").mkdir()
+        blocked.chmod(0o000)
+        try:
+            unreadable = _by_name(_collect(mirror_root=blocked))["frozen-mirror"]
+        finally:
+            blocked.chmod(0o700)
+        assert unreadable.state == cd.UNMEASURED
+        assert absent.detail != unreadable.detail
+
+    def test_a_no_sync_run_says_SO_rather_than_reporting_an_outage(self) -> None:
+        """`--no-sync` is a choice, not a failure. The reason has to name it, or
+        an operator reads a deliberate offline run as a broken store."""
+        checks = _by_name(_collect(pod=cd.PodFacts(
+            reached=False,
+            reason="--no-sync was given, so the store was never contacted",
+        )))
+        assert "--no-sync" in checks["pod"].detail
+        assert checks["pod"].state == cd.UNMEASURED
+
+
+# =============================================================================
+# The individual checks
+# =============================================================================
+
+class TestTheReaderResolution:
+    def test_an_unstamped_resolution_is_a_PROBLEM_naming_the_remedy(self) -> None:
+        checks = _by_name(_collect(
+            stamp_lines=None, stamp_reason="no `.sync-stamp` in /nowhere/cache",
+        ))
+        assert checks["reader-resolution"].state == cd.PROBLEM
+        assert "cairn sync" in checks["reader-resolution"].detail
+        assert checks["cache-stamp"].state == cd.PROBLEM
+
+    def test_the_unstamped_detail_names_the_READERS_four_not_cairns(self) -> None:
+        """🔴 THE TWO EXIT 4s. `cairn sync`'s own 4 (`EXIT_REFRESH_FAILED`)
+        means the store was NOT reached but the cache survived — re-running
+        `cairn sync` is the command that just failed. The 4 `cairn sync` FIXES
+        is the reader's `EXIT_UNSTAMPED_READ_STORE`. Confusing them sends a
+        reader to re-run the failure, so the detail names which four it is."""
+        detail = _by_name(_collect(
+            stamp_lines=None, stamp_reason="no stamp",
+        ))["reader-resolution"].detail
+        assert "EXIT_UNSTAMPED_READ_STORE" in detail
+        assert "READER" in detail
+
+    def test_a_stamped_resolution_relays_the_fields_UNPARSED(self) -> None:
+        """The stamp's schema belongs to `cairn sync`. Doctor prints the lines;
+        it does not interpret them, and it computes no age from them."""
+        detail = _by_name(_collect(
+            stamp_lines=("synced=1788000000", "coverage=ALL", "entries=7"),
+        ))["cache-stamp"].detail
+        assert "synced=1788000000" in detail
+        assert "coverage=ALL" in detail
+        assert "entries=7" in detail
+
+
+class TestTheFrozenMirror:
+    def test_a_WRITABLE_entry_file_is_a_PROBLEM(self, tmp_path) -> None:
+        """🔴 MEASURED ON THE WORKBENCH 2026-09-03: 6 of 160 entry files under
+        the mirror were still mode 644 after the cutover froze it. A write to
+        one of those lives on one host and the pod never sees it — the exact
+        stranding the freeze exists to prevent, in a mirror that LOOKS frozen."""
+        mirror = _store(tmp_path / "m", {"alpha": ["a.md", "b.md"]})
+        (mirror / "alpha" / "a.md").chmod(0o444)
+        (mirror / "alpha" / "b.md").chmod(0o644)
+        check = _by_name(_collect(mirror_root=mirror))["frozen-mirror"]
+        assert check.state == cd.PROBLEM
+        assert "alpha/b.md" in check.detail
+        assert "1 entry file" in check.detail
+
+    def test_a_fully_frozen_mirror_is_OK(self, tmp_path) -> None:
+        mirror = _store(tmp_path / "m", {"alpha": ["a.md"]})
+        (mirror / "alpha" / "a.md").chmod(0o444)
+        assert _by_name(_collect(mirror_root=mirror))["frozen-mirror"].state == cd.OK
+
+    def test_the_walk_counts_FILES_not_directories(self, tmp_path) -> None:
+        """A writable scope DIRECTORY is expected and correct — `subsystem-index`
+        documents that a first-ever entry is still created locally. Only the
+        entry files are frozen, so a directory mode must not raise a PROBLEM."""
+        mirror = _store(tmp_path / "m", {"alpha": ["a.md"]})
+        (mirror / "alpha" / "a.md").chmod(0o444)
+        (mirror / "alpha").chmod(0o755)
+        assert cd.writable_entry_files(mirror) == ()
+
+
+class TestThePodProbe:
+    def test_an_UNAUTHORISED_answer_is_not_an_outage(self) -> None:
+        """🔴 THE DISCRIMINATION THE BRIEF NAMES. 401 means the host is UP and
+        the credential is wrong — a completely different remedy from a DNS
+        failure, and `resolve_state` deliberately collapses the two because a
+        READ degrades to the cache either way. Doctor must not."""
+        refused = _by_name(_collect(pod=cd.PodFacts(
+            reached=False, reason="answered HTTP 401", http_status=401,
+        )))["pod"]
+        outage = _by_name(_collect(pod=cd.PodFacts(
+            reached=False, reason="unreachable: [Errno -2] Name or service not known",
+        )))["pod"]
+        assert refused.state == cd.PROBLEM
+        assert outage.state == cd.UNMEASURED
+        assert "NOT an outage" in refused.detail
+
+    def test_a_403_names_the_edge_as_a_rival_explanation(self) -> None:
+        """MEASURED: this host's edge 403s urllib's default User-Agent, and that
+        403 arrives looking like a bad token AND like the store being down. A
+        report that named only the token would send an operator to rotate a
+        credential that is fine."""
+        detail = _by_name(_collect(pod=cd.PodFacts(
+            reached=False, reason="answered HTTP 403", http_status=403,
+        )))["pod"].detail
+        assert "User-Agent" in detail
+
+    def test_a_500_is_a_PROBLEM_that_names_the_status(self) -> None:
+        detail = _by_name(_collect(pod=cd.PodFacts(
+            reached=False, reason="answered HTTP 503", http_status=503,
+        )))["pod"].detail
+        assert "503" in detail
+
+
+class TestTheScopeVisibility:
+    def test_a_local_scope_the_store_did_not_send_is_a_PROBLEM(self, tmp_path) -> None:
+        """🔴 MEASURED LIVE 2026-09-03: `civitai-app-requests` and
+        `civitai-developer-docs` exist in the frozen mirror and are absent from
+        the snapshot this token receives."""
+        cache = _store(tmp_path / "c", {"alpha": ["a.md"]})
+        mirror = _store(tmp_path / "m", {"alpha": ["a.md"], "orphan": ["o.md"]})
+        check = _by_name(_collect(
+            cache_root=cache, mirror_root=mirror,
+            pod=cd.PodFacts(reached=True, visible_entries=1, store_wide_entries=1,
+                            visible_scopes=("alpha",)),
+        ))["token-scopes"]
+        assert check.state == cd.PROBLEM
+        assert "orphan" in check.detail
+
+    def test_it_refuses_to_GUESS_which_of_the_two_readings_is_right(
+        self, tmp_path
+    ) -> None:
+        """🔴 The API answers "outside your allowlist" and "never existed" with
+        BYTE-IDENTICAL bytes, deliberately, so that an error cannot enumerate
+        the store. A report that picked one would be a coin flip recorded as a
+        diagnosis — `claude/RULES.md` on an empty result naming no mechanism."""
+        cache = _store(tmp_path / "c", {"alpha": ["a.md"]})
+        mirror = _store(tmp_path / "m", {"orphan": ["o.md"]})
+        detail = _by_name(_collect(
+            cache_root=cache, mirror_root=mirror,
+            pod=cd.PodFacts(reached=True, visible_entries=1, store_wide_entries=1,
+                            visible_scopes=("alpha",)),
+        ))["token-scopes"].detail
+        assert "byte-identical" in detail
+        assert "allowlist" in detail
+
+    def test_a_store_wide_count_ABOVE_the_visible_one_is_reported(self) -> None:
+        """The other channel, and the only client-side evidence that entries
+        exist which this credential cannot reach: `X-Store-Snapshot` carries an
+        UNFILTERED `entry-files=` while `X-Store-Entries` is this token's slice.
+        """
+        check = _by_name(_collect(pod=cd.PodFacts(
+            reached=True, visible_entries=2, store_wide_entries=11,
+            visible_scopes=("alpha",),
+        )))["token-scopes"]
+        assert check.state == cd.PROBLEM
+        assert "11" in check.detail and "9 live in scopes" in check.detail
+
+    def test_equal_counts_and_no_missing_scope_is_OK(self, tmp_path) -> None:
+        cache = _store(tmp_path / "c", {"alpha": ["a.md"]})
+        check = _by_name(_collect(
+            cache_root=cache, mirror_root=tmp_path / "absent",
+            pod=cd.PodFacts(reached=True, visible_entries=1, store_wide_entries=1,
+                            visible_scopes=("alpha",)),
+        ))["token-scopes"]
+        assert check.state == cd.OK
+
+
+class TestTheCredential:
+    def test_no_token_configured_is_a_PROBLEM_carrying_the_config_reason(self) -> None:
+        check = _by_name(_collect(
+            token=None,
+            token_reason="config incomplete: SUBSYSTEM_STORE_TOKEN not set",
+        ))["token"]
+        assert check.state == cd.PROBLEM
+        assert "SUBSYSTEM_STORE_TOKEN" in check.detail
+
+    def test_a_configured_token_is_NOT_OBSERVABLE_with_a_remedy(self) -> None:
+        check = _by_name(_collect(token="tok", identity_remedy="RUN THIS THING"))["token"]
+        assert check.state == cd.NOT_OBSERVABLE
+        assert "RUN THIS THING" in check.detail
+
+    def test_the_TOKEN_ITSELF_never_reaches_the_report(self) -> None:
+        secret = "s3cr3t-not-in-any-output"
+        rendered = cd.render(_collect(token=secret))
+        assert secret not in rendered
+        assert cd.token_fingerprint(secret) in rendered
+
+    def test_the_fingerprint_is_the_SERVERS_token_id(self) -> None:
+        """🔴 THE SEAM. The fingerprint is only useful because it MATCHES the
+        handle the pod's audit log carries; two independent spellings that drift
+        make it a number an operator cannot look up. `cairn` cannot import
+        `server.py`, so the rule is spelled twice — and graded here against a
+        literal digest, so the two agreeing with each other is not the test."""
+        api = _load_api()
+        sample = "a-known-fixture-token"
+        # 🔴 THE EXPECTED DIGEST IS A LITERAL, PRODUCED BY A DIFFERENT TOOL:
+        #     printf 'a-known-fixture-token' | sha256sum | cut -c1-12
+        # Without it, `cd` and `server` agreeing with each other would satisfy
+        # this test while both had drifted from sha256 — the "constant agreeing
+        # with itself" shape this subsystem has shipped five times.
+        expected = "d56f7752989e"
+        assert hashlib.sha256(sample.encode("utf-8")).hexdigest()[:12] == expected
+        assert cd.token_fingerprint(sample) == expected
+        assert api.token_id(sample) == expected
+        assert cd.TOKEN_FINGERPRINT_CHARS == 12
+
+    def test_the_identity_remedy_names_the_pods_own_token_file(self) -> None:
+        """The remedy is a command a human types under pressure. If it named a
+        path the pod does not mount it would send them to an empty file and read
+        as 'no rows', which is the same silent zero one layer out."""
+        api = _load_api()
+        cli = _load_cairn_cli()
+        assert api.DEFAULT_TOKEN_FILE == "/run/secrets/subsystem-store/token"
+        assert api.DEFAULT_TOKEN_FILE in cli.IDENTITY_REMEDY
+        assert "subsystem-store" in cli.IDENTITY_REMEDY
+
+
+# =============================================================================
+# The rendered surface and the CLI wiring
+# =============================================================================
+
+class TestTheRenderedReport:
+    def test_the_exit_legend_is_printed_by_the_COMMAND(self) -> None:
+        """🔴 The brief's requirement: the codes are documented by the command,
+        never by a skill. So every human-readable run carries them."""
+        rendered = cd.render(_collect())
+        for code, _why in cd.EXIT_LEGEND:
+            assert f"{code} =" in rendered
+
+    def test_every_state_is_counted_in_the_summary(self) -> None:
+        rendered = cd.render(_collect())
+        for state in cd.STATES:
+            assert f"{state}=" in rendered
+
+    def test_the_json_carries_the_legend_and_the_exit(self) -> None:
+        payload = cd.to_dict(_collect())
+        assert payload["exit"] in (0, 9, 10)
+        assert set(payload["exit_legend"]) == {"0", "9", "10"}
+        assert {c["name"] for c in payload["checks"]} == {
+            "reader-resolution", "cache-stamp", "frozen-mirror", "pod",
+            "cache-vs-pod", "token-scopes", "token",
+        }
+
+    def test_the_check_set_is_pinned_to_these_seven_names(self) -> None:
+        """A LEDGER, not a count: a check silently disappearing is a fact nobody
+        is checking any more, and a count would not say which."""
+        assert [c.name for c in _collect()] == [
+            "reader-resolution", "cache-stamp", "frozen-mirror", "pod",
+            "cache-vs-pod", "token-scopes", "token",
+        ]
+
+
+class TestTheCliWiring:
+    def test_doctor_is_a_real_subcommand_reaching_cmd_doctor(self) -> None:
+        cli = _load_cairn_cli()
+        args = cli.build_parser().parse_args(["doctor"])
+        assert args.func is cli.cmd_doctor
+        assert args.json is False and args.no_sync is False
+
+    def test_doctor_takes_NO_scope_flag(self) -> None:
+        """A `--scope` here would invite the filtered-cache mistake `cmd_sync`
+        documents, and doctor asks about the HOST, not a scope."""
+        cli = _load_cairn_cli()
+        with pytest.raises(SystemExit):
+            cli.build_parser().parse_args(["doctor", "--scope", "devrc"])
+
+    def test_the_help_epilog_carries_the_exit_codes(self) -> None:
+        cli = _load_cairn_cli()
+        epilog = cli._doctor_epilog()
+        for code, _why in cd.EXIT_LEGEND:
+            assert f"  {code}  " in epilog
+        for state in cd.STATES:
+            assert state in epilog
+
+    def test_a_no_sync_run_still_reads_the_LOCAL_config(self, tmp_path, monkeypatch) -> None:
+        """🔴 A FIXED DEFECT, PINNED. The first version skipped `load_config`
+        under `--no-sync`, so a host with a perfectly good token in
+        `~/.config/subsystem-store/env` was reported `token PROBLEM: no token is
+        configured`. A check that says PROBLEM about a thing it never looked at
+        is the same defect as one that says OK about it."""
+        cli = _load_cairn_cli()
+        monkeypatch.setenv("SUBSYSTEM_STORE_URL", "https://example.invalid")
+        monkeypatch.setenv("SUBSYSTEM_STORE_TOKEN", "a-token-from-the-env")
+        monkeypatch.setattr(cli.subsystem_touch, "DEFAULT_STORE_ROOT", tmp_path / "mirror")
+        monkeypatch.setattr(cli._read_store, "DEFAULT_CACHE_ROOT", tmp_path / "cache")
+        args = cli.build_parser().parse_args(["doctor", "--no-sync", "--json"])
+        args.cache = tmp_path / "cache"
+        import contextlib
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = cli.cmd_doctor(args)
+        payload = json.loads(buf.getvalue())
+        token_check = [c for c in payload["checks"] if c["name"] == "token"][0]
+        assert token_check["state"] == "NOT-OBSERVABLE", token_check
+        assert cd.token_fingerprint("a-token-from-the-env") in token_check["detail"]
+        assert rc in (9, 10)
+
+    def test_probe_store_NEVER_installs_a_snapshot(self, monkeypatch, tmp_path) -> None:
+        """🔴 A diagnostic that repaired the cache as a side effect would destroy
+        the staleness it was run to measure — and it would be the one command
+        you must not run twice. Graded by watching `install_snapshot`."""
+        cli = _load_cairn_cli()
+        installed = []
+        monkeypatch.setattr(
+            cli, "install_snapshot",
+            lambda *a, **k: installed.append(a) or 0,
+        )
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            data = b"# entry\n"
+            info = tarfile.TarInfo("alpha/a.md")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        body = buf.getvalue()
+        headers = Message()
+        headers["x-store-entries"] = "1"
+        headers["x-store-snapshot"] = "seeded=X newest=Y entry-files=4"
+        monkeypatch.setattr(cli, "fetch_snapshot", lambda *a, **k: (body, headers))
+
+        facts = cli.probe_store("https://example.invalid", "tok", timeout=5)
+        assert installed == [], "doctor installed a snapshot"
+        assert facts.reached is True
+        assert facts.visible_entries == 1
+        assert facts.store_wide_entries == 4
+        assert facts.visible_scopes == ("alpha",)
+
+    def test_a_missing_X_Store_Entries_header_is_UNMEASURED_not_the_archive_count(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """🔴 REACHABILITY OF THE `visible_entries is None` BRANCH, and a fixed
+        defect. `probe_store` first fell back to counting the members it had
+        received — which is the side of the comparison a TRUNCATED transfer
+        moves, so cache-vs-pod would have agreed with itself and reported OK over
+        a short answer. `install_snapshot` cross-checks against this header for
+        exactly that reason. Without it, the count is unmeasured."""
+        cli = _load_cairn_cli()
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            data = b"# entry\n"
+            info = tarfile.TarInfo("alpha/a.md")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        headers = Message()
+        headers["x-store-snapshot"] = "entry-files=9"
+        monkeypatch.setattr(cli, "fetch_snapshot", lambda *a, **k: (buf.getvalue(), headers))
+
+        facts = cli.probe_store("https://example.invalid", "tok", timeout=5)
+        assert facts.reached is True
+        assert facts.visible_entries is None
+        assert facts.visible_scopes == ("alpha",)
+        cache = _store(tmp_path / "cache", {"alpha": ["a.md"]})
+        check = _by_name(_collect(pod=facts, cache_root=cache))["cache-vs-pod"]
+        assert check.state == cd.UNMEASURED
+        assert "X-Store-Entries" in check.detail
+
+    def test_probe_store_carries_the_HTTP_STATUS_not_a_parsed_message(
+        self, monkeypatch
+    ) -> None:
+        """🔴 STRUCTURAL, NOT TEXTUAL. Before `StoreUnreachable.http_status` the
+        only thing separating 401 from a DNS failure was the phrasing of an
+        f-string, and a caller that greps a message has pinned a format."""
+        cli = _load_cairn_cli()
+
+        def boom(*a, **k):
+            raise cli.StoreUnreachable("x answered HTTP 401", http_status=401)
+
+        monkeypatch.setattr(cli, "fetch_snapshot", boom)
+        facts = cli.probe_store("https://example.invalid", "tok", timeout=5)
+        assert facts.reached is False
+        assert facts.http_status == 401
+
+    def test_a_connection_failure_carries_http_status_None(self, monkeypatch) -> None:
+        cli = _load_cairn_cli()
+
+        def boom(*a, **k):
+            raise cli.StoreUnreachable("x unreachable: nope")
+
+        monkeypatch.setattr(cli, "fetch_snapshot", boom)
+        assert cli.probe_store("u", "t", timeout=5).http_status is None
+
+    def test_fetch_snapshot_SETS_the_status_from_a_real_HTTPError(
+        self, monkeypatch
+    ) -> None:
+        """The producing end of the same seam, so neither side is graded alone."""
+        cli = _load_cairn_cli()
+
+        def raise_http(*a, **k):
+            raise urllib.error.HTTPError(
+                "https://example.invalid", 401, "Unauthorized", Message(), io.BytesIO(b"no")
+            )
+
+        monkeypatch.setattr(cli.urllib.request, "urlopen", raise_http)
+        with pytest.raises(cli.StoreUnreachable) as excinfo:
+            cli.fetch_snapshot("https://example.invalid", "tok", scope=None, timeout=5)
+        assert excinfo.value.http_status == 401
+
+    def test_the_doctor_subcommand_is_TRACKED_and_the_module_ships(self) -> None:
+        """🔴 A new file must be `git add`ed or the flake silently omits it from
+        the deploy — the switch succeeds and the module is simply absent, which
+        would make `cairn doctor` an ImportError on both hosts."""
+        if not (REPO / ".git").exists():
+            return
+        for rel in ("scripts/lib/cairn_doctor.py", "scripts/cairn"):
+            out = subprocess.run(
+                ["git", "-C", str(REPO), "ls-files", "--error-unmatch", "--", rel],
+                capture_output=True, text=True,
+            )
+            assert out.returncode == 0, f"{rel} is not tracked by git\n{out.stderr}"
+
+
+class TestTheDiskHelpers:
+    def test_the_entry_count_matches_the_SERVERS_walk_shape(self, tmp_path) -> None:
+        """Depth 2, `*.md`, no dot-directories, no dot-files — the same shape
+        `server.snapshot_freshness` counts, so this number and the pod's
+        `entry-files=` are answers to one question. Fixture values are chosen so
+        no wrong rule coincides: 3 is not the scope count, not the file count,
+        and not the depth-any count."""
+        root = tmp_path / "s"
+        _store(root, {"alpha": ["a.md", "b.md"], "beta": ["c.md"]})
+        (root / ".hidden").mkdir()
+        (root / ".hidden" / "x.md").write_text("x", encoding="utf-8")
+        (root / "alpha" / ".swap.md").write_text("x", encoding="utf-8")
+        (root / "alpha" / "notes.txt").write_text("x", encoding="utf-8")
+        (root / "alpha" / "deep").mkdir()
+        (root / "alpha" / "deep" / "d.md").write_text("x", encoding="utf-8")
+        (root / "top.md").write_text("x", encoding="utf-8")
+        assert cd.store_entry_files(root) == 3
+
+    def test_the_scope_list_skips_dot_directories_and_files(self, tmp_path) -> None:
+        root = tmp_path / "s"
+        _store(root, {"alpha": ["a.md"], "beta": []}, stamp="synced=1\n")
+        (root / ".git").mkdir()
+        assert cd.store_scopes(root) == ("alpha", "beta")
+
+    def test_an_unreadable_root_RAISES_rather_than_counting_zero(self, tmp_path) -> None:
+        """`Path.rglob` swallows a permission error and yields nothing, so an
+        unreadable store would report `0` — the exact confusion
+        `server.snapshot_freshness` uses `os.walk(onerror=…)` to avoid."""
+        blocked = tmp_path / "b"
+        blocked.mkdir()
+        blocked.chmod(0o000)
+        try:
+            with pytest.raises(OSError):
+                cd.store_entry_files(blocked)
+        finally:
+            blocked.chmod(0o700)

--- a/scripts/tests/test_cairn_doctor.py
+++ b/scripts/tests/test_cairn_doctor.py
@@ -426,6 +426,29 @@ class TestTheScopeVisibility:
         assert check.state == cd.PROBLEM
         assert "11" in check.detail and "9 live in scopes" in check.detail
 
+    def test_an_UNREADABLE_local_root_makes_this_UNMEASURED_not_OK(
+        self, tmp_path
+    ) -> None:
+        """🔴 The first version returned OK with the hole named in its tail. An
+        OK carrying a caveat is how a partial answer gets read as a clean one —
+        "every scope on this disk is among them" is a claim about a set the walk
+        could not finish building. Graded against the OK case below, which is
+        identical except that both roots are readable."""
+        cache = _store(tmp_path / "c", {"alpha": ["a.md"]})
+        blocked = tmp_path / "m"
+        blocked.mkdir()
+        blocked.chmod(0o000)
+        try:
+            check = _by_name(_collect(
+                cache_root=cache, mirror_root=blocked,
+                pod=cd.PodFacts(reached=True, visible_entries=1, store_wide_entries=1,
+                                visible_scopes=("alpha",)),
+            ))["token-scopes"]
+        finally:
+            blocked.chmod(0o700)
+        assert check.state == cd.UNMEASURED
+        assert "could not be fully read" in check.detail
+
     def test_equal_counts_and_no_missing_scope_is_OK(self, tmp_path) -> None:
         cache = _store(tmp_path / "c", {"alpha": ["a.md"]})
         check = _by_name(_collect(

--- a/scripts/tests/test_cairn_doctor.py
+++ b/scripts/tests/test_cairn_doctor.py
@@ -250,6 +250,29 @@ class TestAnUnmeasuredAnswerIsNotAZero:
         assert unreadable.state == cd.UNMEASURED
         assert absent.detail != unreadable.detail
 
+    def test_the_absent_vs_unreadable_split_is_STRUCTURAL_not_a_sentence(
+        self, tmp_path
+    ) -> None:
+        """🔴 A guard SPELLED rather than structural is walkable by rewording.
+        The first version asked `reason.endswith("does not exist")`, so changing
+        that message would have made an UNREADABLE mirror report as "nothing
+        pre-cutover on this host" — an OK, silently. `Reading.absent` is a flag."""
+        missing = cd._describe(tmp_path / "gone", cd.store_scopes)
+        assert missing.absent is True and missing.value is None
+
+        blocked = tmp_path / "blocked"
+        blocked.mkdir()
+        blocked.chmod(0o000)
+        try:
+            denied = cd._describe(blocked, cd.store_scopes)
+        finally:
+            blocked.chmod(0o700)
+        assert denied.absent is False and denied.value is None
+        assert not denied.ok and not missing.ok
+
+        present = cd._describe(_store(tmp_path / "s", {"a": []}), cd.store_scopes)
+        assert present.ok and present.absent is False and present.value == ("a",)
+
     def test_a_no_sync_run_says_SO_rather_than_reporting_an_outage(self) -> None:
         """`--no-sync` is a choice, not a failure. The reason has to name it, or
         an operator reads a deliberate offline run as a broken store."""

--- a/scripts/tests/test_skill_tiers.py
+++ b/scripts/tests/test_skill_tiers.py
@@ -85,28 +85,36 @@ MIN_SKILLS = 30
 # --------------------------------------------------------------------------- #
 MEASURED_ENTRIES = 40
 MEASURED_TIER_A_ENTRIES = 24
-MEASURED_TIER_A_CHARS = 8_681
+MEASURED_TIER_A_CHARS = 8_567
 # devrc's whole listing under the ledger (tier A in full, tier B name-only).
-MEASURED_UNDER_LEDGER_CHARS = 8_910
+MEASURED_UNDER_LEDGER_CHARS = 8_796
 # ...and what the same 40 entries would cost with every skill tier A. The
-# difference is what the ledger buys: 4,200 chars.
-MEASURED_ALL_TIER_A_CHARS = 13_110
+# difference is what the ledger buys: 4,295 chars.
+MEASURED_ALL_TIER_A_CHARS = 13_091
 
 # 🔴 THE TIER-A RATCHET, in the REAL formula: the tier-A block cost
 # `sum(len(name) + 4 + min(len(desc), 1536)) + (n - 1)`.
 #
 # The ceiling sits 254 chars above MEASURED_TIER_A_CHARS — less than the MEAN
-# tier-A entry, which is 8,681 / 24 = 361.7.
+# tier-A entry, which is 8,567 / 24 = 357.0.
 #
-# ⚠ IT WAS LOWERED FROM 9,200 WHEN `cairn` LANDED, and the lowering is the point
-# rather than paperwork: `cairn` is tier B and cost this block nothing, but
-# paying for its listing entry meant cutting mechanism prose out of three tier-A
-# descriptions (`mailbox`, `session-manager`, `signal`), which took the tier-A
-# total DOWN 166. Leaving the ceiling where it was would have banked that cut as
-# 519 chars of slack — more than one whole average entry — which is exactly the
-# regrowth this constant exists to refuse. `test_control_the_tier_a_ratchet_can_
-# go_red` fails when the slack grows past the mean, so the lowering is enforced
-# and not remembered.
+# ⚠ IT WAS LOWERED FROM 9,200 -> 8,935 -> 8,821 WHEN `cairn` LANDED, and the
+# lowering is the point rather than paperwork: `cairn` is tier B and cost this
+# block nothing, but paying for its LISTING entry meant cutting mechanism prose
+# out of six tier-A descriptions (`mailbox`, `session-manager`, `signal`,
+# `initiatives`, `window-triage`, `activity`), which took the tier-A total DOWN
+# 280. Leaving the ceiling where it was would have banked that cut as slack
+# larger than one whole average entry, which is exactly the regrowth this
+# constant exists to refuse. `test_control_the_tier_a_ratchet_can_go_red` fails
+# when the slack grows past the mean, so the lowering is enforced, not
+# remembered — it caught both steps of this and named the replacement each time.
+#
+# 🔴 THE SECOND STEP WAS A CORRECTION, NOT MORE TRIMMING. The first `prune-index`
+# cut dropped two real TRIGGER phrases (`~/.claude/analyze-service-index` and
+# "the subsystem index store") under a commit message claiming none were dropped.
+# Both are restored; the 148 chars were re-taken from architecture prose instead.
+# A dropped trigger silently stops a skill auto-firing, which is the one failure
+# mode this whole budget exists to manage.
 #
 # 🔴 READ WHAT THAT DOES AND DOES NOT BUY. A headroom below the mean bounds an
 # AVERAGE entry. It does NOT stop every addition, and the difference is not
@@ -127,7 +135,7 @@ MEASURED_ALL_TIER_A_CHARS = 13_110
 # LOWER it when you cut; do NOT raise it to make a new description fit. Demoting
 # one skill to tier B in claude/skill-tiers.json is a ONE-LINE edit and is the
 # intended move. The playbook is printed by the failing assertion below.
-TIER_A_CEILING_CHARS = 8_935
+TIER_A_CEILING_CHARS = 8_821
 
 # 🔴 Skills that must NEVER be tier B, pinned as a RELATIONSHIP rather than left
 # to review. Each one fires from a SYMPTOM Zach describes rather than from its own

--- a/scripts/tests/test_skill_tiers.py
+++ b/scripts/tests/test_skill_tiers.py
@@ -83,20 +83,30 @@ MIN_SKILLS = 30
 # 36-entry total quoted in a 37-entry tree, and one contradicted the number the
 # same change reported to its reviewer.
 # --------------------------------------------------------------------------- #
-MEASURED_ENTRIES = 39
+MEASURED_ENTRIES = 40
 MEASURED_TIER_A_ENTRIES = 24
-MEASURED_TIER_A_CHARS = 8_847
+MEASURED_TIER_A_CHARS = 8_681
 # devrc's whole listing under the ledger (tier A in full, tier B name-only).
-MEASURED_UNDER_LEDGER_CHARS = 9_068
-# ...and what the same 37 entries would cost with every skill tier A. The
-# difference is what the ledger buys: 3,907 chars.
-MEASURED_ALL_TIER_A_CHARS = 13_111
+MEASURED_UNDER_LEDGER_CHARS = 8_910
+# ...and what the same 40 entries would cost with every skill tier A. The
+# difference is what the ledger buys: 4,200 chars.
+MEASURED_ALL_TIER_A_CHARS = 13_110
 
 # 🔴 THE TIER-A RATCHET, in the REAL formula: the tier-A block cost
 # `sum(len(name) + 4 + min(len(desc), 1536)) + (n - 1)`.
 #
 # The ceiling sits 254 chars above MEASURED_TIER_A_CHARS — less than the MEAN
-# tier-A entry, which is 8,946 / 24 = 372.8.
+# tier-A entry, which is 8,681 / 24 = 361.7.
+#
+# ⚠ IT WAS LOWERED FROM 9,200 WHEN `cairn` LANDED, and the lowering is the point
+# rather than paperwork: `cairn` is tier B and cost this block nothing, but
+# paying for its listing entry meant cutting mechanism prose out of three tier-A
+# descriptions (`mailbox`, `session-manager`, `signal`), which took the tier-A
+# total DOWN 166. Leaving the ceiling where it was would have banked that cut as
+# 519 chars of slack — more than one whole average entry — which is exactly the
+# regrowth this constant exists to refuse. `test_control_the_tier_a_ratchet_can_
+# go_red` fails when the slack grows past the mean, so the lowering is enforced
+# and not remembered.
 #
 # 🔴 READ WHAT THAT DOES AND DOES NOT BUY. A headroom below the mean bounds an
 # AVERAGE entry. It does NOT stop every addition, and the difference is not
@@ -117,7 +127,7 @@ MEASURED_ALL_TIER_A_CHARS = 13_111
 # LOWER it when you cut; do NOT raise it to make a new description fit. Demoting
 # one skill to tier B in claude/skill-tiers.json is a ONE-LINE edit and is the
 # intended move. The playbook is printed by the failing assertion below.
-TIER_A_CEILING_CHARS = 9_200
+TIER_A_CEILING_CHARS = 8_935
 
 # 🔴 Skills that must NEVER be tier B, pinned as a RELATIONSHIP rather than left
 # to review. Each one fires from a SYMPTOM Zach describes rather than from its own

--- a/scripts/tests/test_store_root_ledger.py
+++ b/scripts/tests/test_store_root_ledger.py
@@ -46,19 +46,30 @@ rename the cache directory without updating this file and the scanner goes blind
 to the very path it exists to police, silently, while every other test stays
 green.
 
-⚠ STATED RESIDUALS, so nobody reads this as wider than it is:
+⚠ STATED RESIDUALS. Every one of these was MEASURED by planting the spelling as a
+tracked file and running this module; the list is what SURVIVED, not what seemed
+plausible. An approximate residual list is worse than none — it reads as coverage.
+
+  * 🔴 **SCOPE IS `scripts/` ONLY.** 31 tracked `.py`/`.sh` files live outside it
+    and are invisible here, and this is not theoretical: `nix/home.nix` names the
+    frozen mirror today. `.nix` is neither of the two languages this module
+    parses, so covering it needs a third arm and a third set of controls — named
+    as a gap rather than half-built.
   * `scripts/tests/` and `scripts/testlib/` are OUT OF SCOPE. A test that
     hardcodes the mirror path is building a fixture, not resolving a store for a
     caller, and sweeping them in would bury the production population under ~14
-    rows of fixtures. A reader hidden in a test directory is therefore invisible
-    to this guard.
-  * The shell scanner is a comment-stripped TEXT match. It sees
-    `${HOME}/.claude/analyze-service-index`; it would not see a path assembled
-    from two variables.
-  * The Python scanner reads the AST, so a path assembled at run time out of
-    `os.environ` or `str.join` is invisible to it. It sees the shapes that have
-    actually shipped: a string COMPONENT in a path expression, and an attribute
-    or name reference to another module's store constant.
+    rows of fixtures. A reader hidden in a test directory is invisible here.
+  * The Python scanner reads the AST, so a path assembled at RUN TIME — out of
+    `os.environ`, or from a name bound earlier — is invisible. (`str.join` of
+    literals is NOT in this class: the components are `ast.Constant`s and are
+    caught. An earlier version of this list said otherwise, which is the
+    approximate-residual failure in its own residual list.)
+  * The shell scanner is a comment-stripped TEXT match over `.sh` files and
+    shell shebangs. It would not see a path assembled from two variables, and it
+    does not read `.nix`, `.yaml` or a systemd unit.
+  * A file that RE-EXPORTS a ledgered constant under a new name is caught (the
+    `import … as` arm), but a module that returns the mirror from a FUNCTION with
+    no store name in its own source is not.
 """
 
 from __future__ import annotations
@@ -218,39 +229,159 @@ SITED: dict[str, str] = {
         "host-local resolver would be circular"
     ),
     "scripts/cairn": (
-        "EXEMPT for the one path it sites: `~/.config/subsystem-store/env` is "
-        "the CREDENTIAL file, not a store root. Its actual store resolution is "
-        "in `ROUTED` above, and both facts have to be true of this file"
+        "EXEMPT, for TWO distinct hits — and an earlier version of this row said "
+        "'the one path it sites', which was FALSE THE DAY IT WAS WRITTEN. "
+        "(1) `~/.config/subsystem-store/env` is the CREDENTIAL file, not a store "
+        "root. (2) `subsystem_touch.DEFAULT_STORE_ROOT`, which `cairn doctor` "
+        "reads to check the FROZEN MIRROR is still frozen. That second one is "
+        "not open-coding: `subsystem_read_store` deliberately does not name the "
+        "mirror (its `refusal_message` docstring says so — the mirror's path "
+        "belongs to `subsystem_touch`), so taking the constant IS taking the one "
+        "definition. Its actual READ resolution is in `ROUTED` above. 🔴 The "
+        "false reason is why `SELF_RESOLVED_KINDS` exists: a row whose PROSE "
+        "silently stops describing the file is the ledger failing in the exact "
+        "direction it was built to catch"
     ),
 }
+
+#: 🔴 THE PER-FILE KIND PIN, AND IT EXISTS BECAUSE A REASON WENT STALE SILENTLY.
+#:
+#: The file-set ledger above only fails when a file JOINS or LEAVES. `cairn`
+#: was already in it, so when this PR added a second resolution to it —
+#: `mirror_root=subsystem_touch.DEFAULT_STORE_ROOT` in `cmd_doctor` — nothing
+#: moved, and the row went on saying "the one path it sites" while the scan
+#: reported two. A ledger whose reasons can drift out of agreement with the code
+#: is a rubber stamp, and this repo has a name for that shape.
+#:
+#: So each file also pins WHICH KINDS of resolution it performs, with line
+#: numbers stripped so ordinary edits do not churn it. A file growing a NEW kind
+#: fails here even though it is already ledgered.
+SELF_RESOLVED_KINDS: dict[str, frozenset[str]] = {
+    "scripts/lib/subsystem_read_store.py": frozenset(
+        {"name:DEFAULT_CACHE_ROOT", "path:subsystem-store"}),
+    "scripts/lib/subsystem_touch.py": frozenset(
+        {"name:DEFAULT_STORE_ROOT", "path:analyze-service-index"}),
+    "scripts/cairn-cutover.py": frozenset(
+        {"name:DEFAULT_STORE", "path:analyze-service-index", "path:subsystem-store"}),
+    "scripts/analyze-service-index/backup.py": frozenset(
+        {"name:DEFAULT_STORE", "path:analyze-service-index"}),
+    "scripts/analyze-service-index/escrow-verify.py": frozenset(
+        {"attr:DEFAULT_STORE", "name:DEFAULT_STORE"}),
+    "scripts/analyze-service-index/restore-verify.py": frozenset(
+        {"attr:DEFAULT_STORE", "name:DEFAULT_STORE"}),
+    "scripts/analyze-service-index/commit.sh": frozenset(
+        {"shell:${HOME}/.claude/analyze-service-index",
+         # the `${POSITIONAL[0]:-…}` default, brace still attached
+         "shell:${HOME}/.claude/analyze-service-index}",
+         # a self-reference in an error message, not a resolution
+         "shell:/analyze-service-index/commit.sh"}),
+    "scripts/present/measure.py": frozenset({"path:analyze-service-index"}),
+    "scripts/subsystem-store-api/server.py": frozenset(
+        {"name:DEFAULT_STORE", "path:subsystem-store",
+         "path:/run/secrets/subsystem-store/token"}),
+    # 🔴 TWO KINDS. See the row above for why each is allowed.
+    "scripts/cairn": frozenset({"attr:DEFAULT_STORE_ROOT", "path:subsystem-store"}),
+}
+
+
+def hit_kinds(hits: list[str]) -> set[str]:
+    """`kind:detail`, line number stripped — stable across unrelated edits."""
+    return {":".join(h.split(":")[:-1]) for h in hits}
 
 
 # =============================================================================
 # THE SCANNERS
 # =============================================================================
 
+#: Directories a filesystem walk must skip to match what `git ls-files` returns.
+#: Enumerated, because the fallback tier has no `.gitignore` to consult.
+_WALK_SKIP: frozenset[str] = frozenset(
+    {"__pycache__", ".git", "node_modules", ".venv", "venv", ".mypy_cache",
+     ".pytest_cache", ".ruff_cache", "result"}
+)
+
+
+def _git_is_available() -> bool:
+    return (ROOT / ".git").exists()
+
+
 def tracked_sources() -> list[str]:
     """Repo-relative paths under `scripts/`, minus the out-of-scope directories.
 
-    🔴 `git ls-files`, NOT `rglob`. The flake ships tracked files only, so an
-    untracked reader deploys as an absence — but a `rglob` sweep would also drag
-    in `__pycache__`, virtualenvs and build output, and `claude/RULES.md` records
-    that this repo's `grep -r` is `.gitignore`-blind in the opposite direction.
-    Listing the index is the one answer that matches what ships.
+    🔴 TWO TIERS, AND THE SECOND ONE IS WHY THIS FUNCTION EXISTS IN THIS SHAPE.
+    The first version ran `git ls-files` with `check=True` and no fallback. The
+    authoritative gate — `nix build .#checks.x86_64-linux.pytests` — builds from
+    a `cp -r ${./.}` store copy with **no `.git`**, so that call exited 128 out
+    of a module-scoped fixture and reddened every test here on the ONE tier the
+    merge is gated on, while the dev-host tier stayed green. `claude/RULES.md`
+    → "a suite that runs in TWO TIERS must be green in BOTH". The repo had
+    already solved this and named the pattern: `testlib/public_ip_scan.py`'s
+    `repo_files()`, whose docstring makes the same argument.
+
+    🔴 A `pytest.skip` HERE WOULD BE WORSE THAN THE BUG. It would make both
+    ledgers VACUOUS in the sandbox — the tier that gates the merge — so the
+    guard would report green over a tree it never enumerated. The fallback keeps
+    both tiers looking at the same set; that is the whole point of having one.
+
+    Preferring git is not cosmetic either: the flake ships tracked files only, so
+    an untracked reader deploys as an absence, and `claude/RULES.md` records that
+    this repo's `grep -r` is `.gitignore`-blind in the other direction.
     """
-    out = subprocess.run(
-        ["git", "-C", str(ROOT), "ls-files", "-z", "scripts"],
-        capture_output=True, text=True, check=True,
-    ).stdout
-    return [
-        rel for rel in out.split("\0")
-        if rel and not rel.startswith(OUT_OF_SCOPE_PREFIXES)
-    ]
+    if _git_is_available():
+        try:
+            out = subprocess.run(
+                ["git", "-C", str(ROOT), "ls-files", "-z", "scripts"],
+                capture_output=True, text=True, check=True, timeout=60,
+            ).stdout
+            return [
+                rel for rel in out.split("\0")
+                if rel and not rel.startswith(OUT_OF_SCOPE_PREFIXES)
+            ]
+        except (OSError, subprocess.SubprocessError):
+            pass  # fall through to the walk
+
+    scripts = ROOT / "scripts"
+    found: list[str] = []
+    for path in scripts.rglob("*"):
+        if not path.is_file():
+            continue
+        rel_parts = path.relative_to(ROOT).parts
+        if any(part in _WALK_SKIP for part in rel_parts):
+            continue
+        rel = path.relative_to(ROOT).as_posix()
+        if rel.startswith(OUT_OF_SCOPE_PREFIXES):
+            continue
+        found.append(rel)
+    return sorted(found)
+
+
+#: The two-character interpreter prefix, ASSEMBLED FROM CHARACTER CODES rather
+#: than written as a literal.
+#:
+#: 🔴 NOT A STYLE CHOICE, AND NOT AN EXEMPTION. `scripts/tests/
+#: test_runtime_shebangs.py` is a repo-wide text scan for tests that write an
+#: `/usr/bin/env` shebang at runtime — the sandbox where the merge is gated has
+#: no `/usr/bin/env`, so such a test is structurally invisible on the dev-host
+#: tier and only ever red on the tier that matters. One of its needles is a QUOTE
+#: immediately followed by these two characters, so a source line merely READING
+#: a shebang trips it. That guard is right to be a text scan (intent is not
+#: greppable) and it must not be weakened to accommodate this file, so this file
+#: stops carrying the literal instead. `testlib/shebang_scan.py` assembles its
+#: own needles exactly this way, for exactly this reason.
+#:
+#: 🔴 IT IS ALSO LOAD-BEARING FOR BOTH LEDGERS. `scripts/cairn` has no `.py`
+#: extension and is identified as Python by its shebang alone, so a change here
+#: that stopped matching would silently drop the store's own client out of the
+#: ROUTED and SITED scans — the reassuring-zero shape, one level down. Graded by
+#: `TestTheScannersCanActuallySee::test_a_python_file_with_NO_extension_is_
+#: still_scanned` and `::test_the_shell_shape_is_caught`, which build their
+#: fixtures the same way and assert on the CLASSIFICATION, never on this string.
+_HASHBANG = chr(35) + chr(33)
 
 
 def _shebang(text: str) -> str:
     first = text.splitlines()[0] if text else ""
-    return first if first.startswith("#!") else ""
+    return first if first.startswith(_HASHBANG) else ""
 
 
 def _is_python(path: Path, text: str) -> bool:
@@ -273,13 +404,57 @@ def _is_shell(path: Path, text: str) -> bool:
     )
 
 
-#: Shell siting: a home anchor, then a path ending in a store-root component.
-_SHELL_SITING = re.compile(
-    r"(?:\$\{?HOME\}?|~)/[^\s\"']*(?:" + "|".join(sorted(STORE_ROOT_COMPONENTS)) + r")"
-)
+#: Tokens in a shell line that could be a path: anchored at `$HOME`, `~` or `/`.
+#:
+#: 🔴 THE ABSOLUTE ARM WAS MEASURED MISSING. `STORE="/home/<user>/.claude/
+#: analyze-service-index"` — no `$HOME`, no `~` — SURVIVED the home-anchored-only
+#: pattern, and that is an ordinary way to write the line. Requiring a home
+#: anchor made the guard a test of SPELLING rather than of what the path is.
+_SHELL_PATH_TOKEN = re.compile(r"(?:\$\{?HOME\}?|~|/)[^\s\"']*")
 
 
-def sites_a_store_root(path: Path, text: str) -> list[str]:
+#: Punctuation a shell expansion leaves clinging to the ENDS of a path segment.
+#:
+#: 🔴 MEASURED, NOT DEFENSIVE. `commit.sh` writes
+#: `STORE="${POSITIONAL[0]:-${HOME}/.claude/analyze-service-index}"`, so the last
+#: segment arrives as `analyze-service-index}` and segment EQUALITY missed the
+#: very line the ledger was built around. Stripping is from the ENDS only, so
+#: `subsystem-store-api` and `subsystem-store-api:1.2.3` are still not segments —
+#: which is what keeps this from undoing the noise fix above.
+_SEGMENT_PUNCTUATION = "{}\"'()[],;:"
+
+
+def _names_a_store_root_segment(value: str) -> bool:
+    """Is `value` a path one of whose SEGMENTS is a store-root component?
+
+    🔴 SEGMENT EQUALITY, NOT SUBSTRING — and both halves of that were measured.
+
+    Exact whole-STRING equality (the first version) let four ordinary spellings
+    through: `os.path.expanduser("~/.claude/analyze-service-index")` and
+    `Path.home() / ".claude/analyze-service-index"` both bury the component in a
+    longer literal, so a whole-string match never fired.
+
+    Widening to a plain SUBSTRING then over-fired into noise, also measured:
+    `subsystem-store-api`, `subsystem-store-backup`, `analyze-service-index-backups`
+    and the `subsystem-store-client/1` User-Agent all matched. Those are unit,
+    image and product names, not store roots — and a ledger padded with rows
+    nobody can justify is how a REAL row gets waved through, which is the
+    failure this whole module exists to prevent, one level up.
+
+    A path segment is the actual property: `analyze-service-index` names the
+    store, `analyze-service-index-backups` names a bucket. Whitespace still
+    disqualifies the whole value, so an English sentence quoting the mirror is
+    not a path however it is reworded.
+    """
+    if not value or any(ch.isspace() for ch in value):
+        return False
+    return any(
+        seg.strip(_SEGMENT_PUNCTUATION) in STORE_ROOT_COMPONENTS
+        for seg in value.split("/")
+    )
+
+
+def resolves_a_store_root(path: Path, text: str) -> list[str]:
     """`["<kind>:<detail>:<line>", …]` — every place this file computes one.
 
     Empty means "this file names no store root", NOT "I could not look": a file
@@ -293,18 +468,24 @@ def sites_a_store_root(path: Path, text: str) -> list[str]:
             if (
                 isinstance(node, ast.Constant)
                 and isinstance(node.value, str)
-                and node.value in STORE_ROOT_COMPONENTS
+                and _names_a_store_root_segment(node.value)
             ):
-                # 🔴 EXACT EQUALITY, NOT `in`. A path COMPONENT is a whole string
-                # in a `/` expression; requiring the constant to BE the component
-                # is what keeps every docstring and prose mention of the mirror
-                # out of this scan, without a comment stripper that would have to
-                # understand Python string syntax to be right.
-                hits.append(f"component:{node.value}:{node.lineno}")
+                hits.append(f"path:{node.value}:{node.lineno}")
             elif isinstance(node, ast.Attribute) and node.attr in SITING_NAMES:
                 hits.append(f"attr:{node.attr}:{node.lineno}")
             elif isinstance(node, ast.Name) and node.id in SITING_NAMES:
                 hits.append(f"name:{node.id}:{node.lineno}")
+            elif isinstance(node, (ast.Import, ast.ImportFrom)):
+                # 🔴 THE ALIAS ARM, AND IT IS NOT HYPOTHETICAL. `scripts/cairn`
+                # shipped `from subsystem_read_store import DEFAULT_CACHE_ROOT as
+                # DEFAULT_CACHE`, and that spelling binds no `Name` and no
+                # `Attribute` this walk would see — so `from subsystem_touch
+                # import DEFAULT_STORE_ROOT as MIRROR` took the frozen mirror
+                # straight past the scan, measured. Key on the name being
+                # IMPORTED, never on what it was renamed to.
+                for alias in node.names:
+                    if alias.name in SITING_NAMES:
+                        hits.append(f"import:{alias.name}:{node.lineno}")
         return sorted(set(hits))
 
     if not _is_shell(path, text):
@@ -313,8 +494,11 @@ def sites_a_store_root(path: Path, text: str) -> list[str]:
     body = "\n".join(
         line for line in text.splitlines() if not line.lstrip().startswith("#")
     )
-    for match in _SHELL_SITING.finditer(body):
-        hits.append(f"shell:{match.group(0)}:{body[: match.start()].count(chr(10)) + 1}")
+    for match in _SHELL_PATH_TOKEN.finditer(body):
+        token = match.group(0)
+        if not _names_a_store_root_segment(token):
+            continue
+        hits.append(f"shell:{token}:{body[: match.start()].count(chr(10)) + 1}")
     return sorted(set(hits))
 
 
@@ -360,7 +544,7 @@ def _scan(predicate) -> dict[str, list[str]]:
 
 @pytest.fixture(scope="module")
 def sited() -> dict[str, list[str]]:
-    return _scan(sites_a_store_root)
+    return _scan(resolves_a_store_root)
 
 
 @pytest.fixture(scope="module")
@@ -439,9 +623,33 @@ class TestTheRoutedLedgerIsTwoWay:
         )
 
     @pytest.mark.parametrize("rel", sorted(ROUTED))
-    def test_each_routed_file_exists_and_is_tracked(self, rel: str) -> None:
+    def test_each_routed_file_exists_and_is_ENUMERATED(self, rel: str) -> None:
+        """🔴 "ENUMERATED", NOT "TRACKED BY GIT". This used to assert tracked-ness
+        and reddened the whole sandbox tier, where there is no `.git`. The claim
+        that holds in BOTH tiers is that the file is in the set this module
+        actually scans — which is the property the ledger depends on anyway."""
         assert (ROOT / rel).is_file(), f"{rel} is gone"
-        assert rel in set(tracked_sources()), f"{rel} is not tracked by git"
+        assert rel in set(tracked_sources()), f"{rel} is not in the enumerated set"
+
+    @pytest.mark.parametrize("rel", sorted(ROUTED))
+    def test_each_routed_file_is_git_tracked_WHERE_GIT_EXISTS(self, rel: str) -> None:
+        """The git-only half, kept as its own test rather than folded above.
+
+        The flake ships tracked files only, so an untracked reader deploys as an
+        absence — a real property, and one the sandbox tier structurally cannot
+        check. Splitting it says which tier establishes which claim instead of
+        letting one assertion mean different things in two places.
+
+        🔴 It RETURNS rather than skipping: `run-tests.sh` pins its EXPECTED_SKIPS
+        set exactly, so an unpinned skip breaks the gate.
+        """
+        if not _git_is_available():
+            return
+        out = subprocess.run(
+            ["git", "-C", str(ROOT), "ls-files", "--error-unmatch", "--", rel],
+            capture_output=True, text=True,
+        )
+        assert out.returncode == 0, f"{rel} is not tracked by git\n{out.stderr}"
 
 
 class TestTheSitedLedgerIsTwoWay:
@@ -474,9 +682,48 @@ class TestTheSitedLedgerIsTwoWay:
         )
 
     @pytest.mark.parametrize("rel", sorted(SITED))
-    def test_each_sited_file_exists_and_is_tracked(self, rel: str) -> None:
+    def test_each_sited_file_exists_and_is_ENUMERATED(self, rel: str) -> None:
+        """See the routed twin: "enumerated" is the claim that holds in BOTH
+        tiers; git-tracked-ness is checked separately where git exists."""
         assert (ROOT / rel).is_file(), f"{rel} is gone"
-        assert rel in set(tracked_sources()), f"{rel} is not tracked by git"
+        assert rel in set(tracked_sources()), f"{rel} is not in the enumerated set"
+
+    @pytest.mark.parametrize("rel", sorted(SITED))
+    def test_each_sited_file_is_git_tracked_WHERE_GIT_EXISTS(self, rel: str) -> None:
+        if not _git_is_available():
+            return
+        out = subprocess.run(
+            ["git", "-C", str(ROOT), "ls-files", "--error-unmatch", "--", rel],
+            capture_output=True, text=True,
+        )
+        assert out.returncode == 0, f"{rel} is not tracked by git\n{out.stderr}"
+
+    def test_the_KIND_ledger_is_two_way_over_the_same_files(self, sited) -> None:
+        """🔴 THE PIN THAT CATCHES A ROW GOING STALE WITHOUT MOVING.
+
+        The set ledger above only fires when a file joins or leaves. `scripts/cairn`
+        was already in it when `cairn doctor` added a SECOND resolution to it, so
+        nothing moved and the row's prose went on describing one hit while the scan
+        saw two. Pinning the kinds makes that a failure.
+        """
+        assert set(SELF_RESOLVED_KINDS) == set(SITED), (
+            "the reason ledger and the kind ledger name different files:\n"
+            f"  reasons only: {sorted(set(SITED) - set(SELF_RESOLVED_KINDS))}\n"
+            f"  kinds only:   {sorted(set(SELF_RESOLVED_KINDS) - set(SITED))}"
+        )
+        drifted = {
+            rel: (sorted(hit_kinds(hits)), sorted(SELF_RESOLVED_KINDS.get(rel, ())))
+            for rel, hits in sited.items()
+            if hit_kinds(hits) != set(SELF_RESOLVED_KINDS.get(rel, ()))
+        }
+        assert not drifted, (
+            "a ledgered file's KINDS of store-root resolution changed. A NEW kind "
+            "in an already-ledgered file is the shape that slipped past the set "
+            "ledger once already — check the row's reason still describes the "
+            "file, then update both.\n  "
+            + "\n  ".join(f"{rel}\n      scan:   {got}\n      ledger: {want}"
+                          for rel, (got, want) in sorted(drifted.items()))
+        )
 
     @pytest.mark.parametrize("rel", sorted(SITED))
     def test_every_exemption_carries_a_REASON(self, rel: str) -> None:
@@ -489,11 +736,19 @@ class TestTheSitedLedgerIsTwoWay:
             f"{rel}'s exemption reason is too short to be a reason: {SITED[rel]!r}"
         )
 
-    def test_the_two_ledgers_overlap_only_where_stated(self, sited, routed) -> None:
-        """A file in BOTH is doing two different things and must say so. Today
-        exactly one is: `scripts/cairn` routes for `--cache` and separately names
-        the credential file. Pinned as a literal so a second overlap arriving
-        unexplained is a failure rather than a shrug."""
+    def test_the_two_ledgers_overlap_only_where_stated(self) -> None:
+        """A file in BOTH is doing two different things and must say so.
+
+        TWO are: `scripts/cairn` (routes for `--cache`; separately names the
+        credential file and the mirror `doctor` inspects) and
+        `subsystem_read_store.py` (it IS the resolver, and it declares the cache
+        root every router asks it for). Pinned as a literal so a third arriving
+        unexplained is a failure rather than a shrug.
+
+        ⚠ The docstring said "Today exactly one is" while the assertion pinned
+        two — a description narrower than its own body, which is the shape this
+        module is otherwise built to catch.
+        """
         assert set(ROUTED) & set(SITED) == {
             "scripts/cairn",
             "scripts/lib/subsystem_read_store.py",
@@ -538,7 +793,7 @@ class TestTheScannersCanActuallySee:
         for name, source in cases.items():
             path = tmp_path / name
             path.write_text(source, encoding="utf-8")
-            assert sites_a_store_root(path, source), (
+            assert resolves_a_store_root(path, source), (
                 f"the siting scan did not see {name}, which is the shape of a "
                 f"defect that actually shipped"
             )
@@ -546,27 +801,138 @@ class TestTheScannersCanActuallySee:
                 f"{name} routes nothing, yet the resolver scan claims it does"
             )
 
+    @pytest.mark.parametrize(
+        "name, source",
+        [
+            # 1. expanduser with the whole path in ONE literal.
+            ("expanduser.py",
+             'import os\n'
+             'STORE = os.path.expanduser("~/.claude/analyze-service-index")\n'),
+            # 2. Path.home() with the tail JOINED into one literal.
+            ("joined.py",
+             'from pathlib import Path\n'
+             'STORE = Path.home() / ".claude/analyze-service-index"\n'),
+            # 3. the ledgered constant imported under a DIFFERENT name.
+            ("aliased.py",
+             'from subsystem_touch import DEFAULT_STORE_ROOT as MIRROR\n'
+             'def load():\n    return MIRROR\n'),
+            # 4. shell, ABSOLUTE — no $HOME and no ~.
+            ("absolute.sh",
+             'STORE="/home/someone/.claude/analyze-service-index"\n'),
+        ],
+        ids=["expanduser", "joined-literal", "aliased-import", "absolute-shell"],
+    )
+    def test_the_four_MEASURED_survivors_are_now_caught(
+        self, tmp_path, name, source
+    ) -> None:
+        """🔴 EACH OF THESE WAS PLANTED AS A TRACKED FILE AND SURVIVED THE WHOLE
+        MODULE, GREEN. They are not imagined mutants — they are the audit's
+        measured escapes, kept as fixtures so the widening cannot be undone
+        quietly.
+
+        The aliased import is the one that matters most: `scripts/cairn` really
+        did ship `from subsystem_read_store import DEFAULT_CACHE_ROOT as
+        DEFAULT_CACHE`, so this spelling is what the codebase reaches for. It
+        binds no `Name` and no `Attribute` the walk would see.
+        """
+        path = tmp_path / name
+        path.write_text(source, encoding="utf-8")
+        assert resolves_a_store_root(path, source), (
+            f"{name} still escapes the scan"
+        )
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("analyze-service-index", True),
+            ("~/.claude/analyze-service-index", True),
+            (".claude/analyze-service-index", True),
+            ("/home/someone/.claude/analyze-service-index", True),
+            ("subsystem-store", True),
+            ("/run/secrets/subsystem-store/token", True),
+            # …and the near-misses the SUBSTRING version wrongly claimed.
+            ("analyze-service-index-backups", False),
+            ("analyze-service-index-backup", False),
+            ("subsystem-store-api", False),
+            ("subsystem-store-client/1", False),
+            ("subsystem-store-backup", False),
+            ("harbor.example.lan/library/subsystem-store-api:1.2.3", False),
+            # Shell punctuation clinging to the segment — the live `commit.sh`
+            # shape, which segment EQUALITY alone missed.
+            ("${POSITIONAL[0]:-${HOME}/.claude/analyze-service-index}", True),
+            # Prose naming the mirror is not a path, however it is worded.
+            ("the store at ~/.claude/analyze-service-index is frozen", False),
+        ],
+    )
+    def test_the_segment_rule_separates_a_store_root_from_a_PRODUCT_NAME(
+        self, value, expected
+    ) -> None:
+        """🔴 THE ISOLATED PIN ON THE PREDICATE ITSELF.
+
+        Values are pairwise distinct and every FALSE case shares a prefix with a
+        TRUE one, so a mutant that drops the segment rule back to a substring
+        match cannot pass: it flips six of these at once. Written as literals
+        here, never derived from `STORE_ROOT_COMPONENTS`.
+        """
+        assert _names_a_store_root_segment(value) is expected
+
     def test_the_transitive_shape_is_caught(self, tmp_path) -> None:
         """`DEFAULT_STORE = B.DEFAULT_STORE` spells no path at all. A component
         scan alone reports it clean, and two shipped files have this shape."""
         source = "import backup as B\nDEFAULT_STORE = B.DEFAULT_STORE\n"
         path = tmp_path / "verify.py"
         path.write_text(source, encoding="utf-8")
-        assert sites_a_store_root(path, source)
+        assert resolves_a_store_root(path, source)
 
     def test_a_python_file_with_NO_extension_is_still_scanned(self, tmp_path) -> None:
         """`scripts/cairn` has no `.py`. A scanner keyed on the suffix alone
-        would skip the client that owns the cache."""
-        source = '#!/usr/bin/env python3\nfrom pathlib import Path\nX = Path.home() / ".cache" / "subsystem-store"\n'
+        would skip the client that owns the cache.
+
+        🔴 THE FIXTURE'S SHEBANG IS ASSEMBLED, NOT WRITTEN — see `_HASHBANG`.
+        The interpreter line still lands on disk verbatim, because that is the
+        input `_is_python` has to classify; what changes is that this SOURCE FILE
+        no longer carries the literal `test_runtime_shebangs.py` scans for.
+        `testlib.mockbin.write_exec` is the sanctioned answer for a stub a test
+        EXECS, and it is the wrong tool here twice over: it owns the shebang and
+        writes `/bin/sh`, which would make `_is_python` return False and delete
+        this test's whole point — and nothing execs this file. It is read.
+        """
+        source = (
+            _HASHBANG + "/usr/bin/env python3\n"
+            'from pathlib import Path\n'
+            'X = Path.home() / ".cache" / "subsystem-store"\n'
+        )
         path = tmp_path / "cairn"
         path.write_text(source, encoding="utf-8")
-        assert sites_a_store_root(path, source)
+        assert _is_python(path, source), "the no-extension file was not read as Python"
+        assert resolves_a_store_root(path, source)
+
+    def test_a_SHELL_file_with_no_extension_is_classified_by_its_shebang_too(
+        self, tmp_path
+    ) -> None:
+        """The mirror of the test above, and the other half `_shebang` decides.
+
+        Both language arms read the SAME two characters, so a change to
+        `_HASHBANG` that stopped matching would silently empty the shell arm as
+        well — and its own control (`test_the_scan_reaches_BOTH_languages`) is a
+        claim about the live tree, where every shell file happens to end `.sh`.
+        This is the extensionless case that arm has no live example of.
+        """
+        source = (
+            _HASHBANG + "/usr/bin/env bash\n"
+            'STORE="${HOME}/.claude/analyze-service-index"\n'
+        )
+        path = tmp_path / "commit-hook"
+        path.write_text(source, encoding="utf-8")
+        assert _is_shell(path, source), "the no-extension file was not read as shell"
+        assert not _is_python(path, source)
+        assert resolves_a_store_root(path, source)
 
     def test_the_shell_shape_is_caught(self, tmp_path) -> None:
         source = 'STORE="${POSITIONAL[0]:-${HOME}/.claude/analyze-service-index}"\n'
         path = tmp_path / "commit.sh"
         path.write_text(source, encoding="utf-8")
-        assert sites_a_store_root(path, source)
+        assert resolves_a_store_root(path, source)
 
     def test_the_resolver_scan_fires_on_BOTH_spellings(self, tmp_path) -> None:
         for source in (
@@ -598,7 +964,7 @@ class TestTheScannersCanActuallySee:
         )
         path = tmp_path / "prose.py"
         path.write_text(source, encoding="utf-8")
-        assert not sites_a_store_root(path, source), (
+        assert not resolves_a_store_root(path, source), (
             "a docstring and a comment were counted as siting a store root"
         )
 
@@ -609,7 +975,7 @@ class TestTheScannersCanActuallySee:
         source = 'STORE=""\n[[ -n "$STORE" ]] || { echo "--store is required" >&2; exit 2; }\n'
         path = tmp_path / "seed.sh"
         path.write_text(source, encoding="utf-8")
-        assert not sites_a_store_root(path, source)
+        assert not resolves_a_store_root(path, source)
 
     def test_a_MARKDOWN_file_quoting_the_path_is_not_siting(self, tmp_path) -> None:
         """NEGATIVE CONTROL, and a measured one: `subsystem-store-api/README.md`
@@ -620,13 +986,13 @@ class TestTheScannersCanActuallySee:
         source = "Run:\n\n    seed.sh --store ~/.claude/analyze-service-index\n"
         path = tmp_path / "README.md"
         path.write_text(source, encoding="utf-8")
-        assert not sites_a_store_root(path, source)
+        assert not resolves_a_store_root(path, source)
 
     def test_a_shell_COMMENT_naming_the_mirror_is_not_siting(self, tmp_path) -> None:
         source = "# the store lives at ${HOME}/.claude/analyze-service-index\nSTORE=\"$1\"\n"
         path = tmp_path / "c.sh"
         path.write_text(source, encoding="utf-8")
-        assert not sites_a_store_root(path, source)
+        assert not resolves_a_store_root(path, source)
 
     def test_an_unparseable_python_file_RAISES_rather_than_reading_clean(
         self, tmp_path
@@ -638,7 +1004,7 @@ class TestTheScannersCanActuallySee:
         path = tmp_path / "b.py"
         path.write_text(source, encoding="utf-8")
         with pytest.raises(SyntaxError):
-            sites_a_store_root(path, source)
+            resolves_a_store_root(path, source)
 
 
 class TestTheEnumeratorItself:
@@ -652,14 +1018,117 @@ class TestTheEnumeratorItself:
         """The exclusion is load-bearing and enumerated, so it is graded: a test
         file that hardcodes the mirror must not appear, and one that DOES exist
         must be findable outside the enumerator — otherwise this asserts nothing.
+
+        🔴 The "does exist" half is counted off the FILESYSTEM, not off a second
+        `git ls-files`. The earlier version shelled git with `check=True` here
+        too, which is the same 128 that reddened the sandbox tier one function up.
         """
         files = tracked_sources()
         assert not [f for f in files if f.startswith(OUT_OF_SCOPE_PREFIXES)]
-        every = subprocess.run(
-            ["git", "-C", str(ROOT), "ls-files", "-z", "scripts/tests"],
-            capture_output=True, text=True, check=True,
-        ).stdout.split("\0")
-        assert len([f for f in every if f]) > 50, (
+        every = [
+            p for p in (ROOT / "scripts" / "tests").rglob("*.py")
+            if "__pycache__" not in p.parts
+        ]
+        assert len(every) > 50, (
             "there is no `scripts/tests/` content, so excluding it excluded "
             "nothing and this control proves nothing"
+        )
+
+    def test_the_enumerator_WORKS_WITH_NO_GIT_DIRECTORY(self, tmp_path) -> None:
+        """🔴 THE SANDBOX TIER, SIMULATED — the one that gates the merge.
+
+        `nix build .#checks.x86_64-linux.pytests` builds from a `cp -r ${./.}`
+        store copy with NO `.git`. The first version of `tracked_sources()` ran
+        `git ls-files` with `check=True` and no fallback, so it exited 128 out of
+        a module-scoped fixture and reddened EVERY test in this file there, while
+        the dev-host tier stayed green — `claude/RULES.md` → "a suite that runs in
+        TWO TIERS must be green in BOTH".
+
+        🔴 THIS DOES NOT SKIP, AND IT MUST NOT. A `pytest.skip` when git is absent
+        would make both ledgers vacuous in exactly the tier the merge is gated on,
+        which is strictly worse than the crash: a crash is loud.
+
+        It repoints the module's `ROOT` at a git-less copy of `scripts/lib`, so
+        the fallback is exercised for real rather than asserted about.
+        """
+        fake = tmp_path / "repo"
+        (fake / "scripts" / "lib").mkdir(parents=True)
+        (fake / "scripts" / "lib" / "reader.py").write_text(
+            'from pathlib import Path\nS = Path.home() / ".claude" / "analyze-service-index"\n',
+            encoding="utf-8",
+        )
+        (fake / "scripts" / "tests").mkdir()
+        (fake / "scripts" / "tests" / "test_x.py").write_text("x = 1\n", encoding="utf-8")
+        (fake / "scripts" / "lib" / "__pycache__").mkdir()
+        (fake / "scripts" / "lib" / "__pycache__" / "junk.pyc").write_bytes(b"\x00")
+        assert not (fake / ".git").exists()
+
+        module = sys.modules[__name__]
+        original = module.ROOT
+        try:
+            module.ROOT = fake
+            listed = tracked_sources()
+        finally:
+            module.ROOT = original
+
+        assert listed == ["scripts/lib/reader.py"], listed
+        # …and the ledger's scanner still works over what the fallback returned.
+        src = (fake / "scripts" / "lib" / "reader.py")
+        assert resolves_a_store_root(src, src.read_text(encoding="utf-8"))
+
+    def test_the_no_git_fallback_is_NOT_BLIND_to_anything_the_git_tier_sees(
+        self,
+    ) -> None:
+        """🔴 THE LOAD-BEARING DIRECTION: the sandbox tier must not see LESS.
+
+        If the walk misses a file git tracks, the ledger in the tier that gates
+        the merge is enumerating a smaller population than the one anybody
+        reviewed — a guard that is a different guard per tier.
+
+        ⚠ THE REVERSE DIRECTION IS DELIBERATELY NOT A SET EQUALITY, and an
+        earlier version made it one. That version failed the moment ANY untracked
+        file sat under `scripts/` — which my own mutation harness caused by
+        snapshotting `<file>.orig` beside the original, so the NEGATIVE CONTROL
+        came back KILLED and the sweep was, for one round, measuring itself. A
+        stray scratch file is not a defect in this ledger. What WOULD be is an
+        untracked file that resolves a store root, since it changes the sandbox
+        tier's answer while being invisible to the git tier — so that is the
+        property asserted, instead of tidiness.
+        """
+        if not _git_is_available():
+            return
+        from_git = set(tracked_sources())
+
+        module = sys.modules[__name__]
+        original = module._git_is_available
+        try:
+            module._git_is_available = lambda: False
+            from_walk = set(tracked_sources())
+        finally:
+            module._git_is_available = original
+
+        assert from_git, "the git tier enumerated nothing"
+        assert from_walk, "the walk tier enumerated nothing"
+        only_git = sorted(from_git - from_walk)
+        assert not only_git, (
+            "the walk is BLIND to files git tracks, so the sandbox tier would "
+            f"enumerate a smaller population than the dev-host tier: {only_git[:10]}"
+        )
+
+        offenders = []
+        for rel in sorted(from_walk - from_git):
+            path = ROOT / rel
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            try:
+                if resolves_a_store_root(path, text):
+                    offenders.append(rel)
+            except SyntaxError:
+                continue  # an unparseable scratch file is not this guard's business
+        assert not offenders, (
+            "an UNTRACKED file under scripts/ resolves a store root. The sandbox "
+            "tier would enumerate it and the git tier would not, so the two "
+            f"ledgers disagree: {offenders}"
         )

--- a/scripts/tests/test_store_root_ledger.py
+++ b/scripts/tests/test_store_root_ledger.py
@@ -1,0 +1,665 @@
+#!/usr/bin/env python3
+"""Which files resolve a subsystem-store root, and does each one go through the resolver?
+
+🔴 WHY THIS EXISTS: THE SAME DEFECT SHIPPED THREE TIMES.
+
+The Cairn cutover made a hosted pod the canonical datastore, FROZE the per-host
+mirror at `~/.claude/analyze-service-index` (entry files `0444`, nothing
+refreshes it) and introduced a synced cache at `~/.cache/subsystem-store` that
+`cairn sync` maintains. `scripts/lib/subsystem_read_store.py` is the ONE place
+that answers "where does this host read the store from".
+
+Three shipped readers went on resolving the FROZEN mirror anyway:
+
+    subsystem_recall.py's CLI     the reader `/resume` step 4 runs
+    service_recon.py              the recon `/analyze-service` runs
+    subsystem-audit.py            the auditor `/prune-index` runs
+
+Each was found by a human noticing, one at a time, after the previous one was
+fixed. Nothing in the tree could see the fourth. `subsystem_read_store`'s
+docstring records the measurement: the frozen mirror served **26** `devrc/`
+entries and the cache **29**, and the frozen one printed
+"ALL 26 entries in `devrc/`, none omitted" — a completeness claim about a store
+that had stopped moving the day before.
+
+🔴 SO THIS IS A LEDGER, NOT A FOURTH ONE-OFF PIN. Two of them, each two-way:
+
+  * `ROUTED` — every file that CALLS the resolver. Fails when the set SHRINKS,
+    which is the direction that matters: a reader silently ceasing to route is
+    the regression itself, and no per-file test can see it because the per-file
+    tests are the ones that get deleted with it.
+  * `SITED` — every file that computes a store-root path of its own. Fails when
+    the set GROWS, which catches the fourth open-coded reader on the commit that
+    introduces it rather than on the day somebody notices a stale answer.
+
+A file may be in both: `scripts/cairn` routes for its `--cache` default and
+separately names `~/.config/subsystem-store/env`, which is a credential file.
+Over-inclusion is the SAFE direction here — a benign match costs one ledger row
+with its reason written down, and a row nobody can justify is the finding.
+
+🔴 EVERY EXPECTATION BELOW IS A LITERAL WRITTEN OUT IN THIS FILE. This
+subsystem's PRs have hit `assert X == module.X` — a constant agreeing with
+itself — five times, each fix narrower than the class. The scanners' vocabulary
+(`STORE_ROOT_COMPONENTS`) is spelled here and then PINNED against the two live
+constants by `TestTheScannerVocabularyMatchesTheRealPaths`, which is the seam:
+rename the cache directory without updating this file and the scanner goes blind
+to the very path it exists to police, silently, while every other test stays
+green.
+
+⚠ STATED RESIDUALS, so nobody reads this as wider than it is:
+  * `scripts/tests/` and `scripts/testlib/` are OUT OF SCOPE. A test that
+    hardcodes the mirror path is building a fixture, not resolving a store for a
+    caller, and sweeping them in would bury the production population under ~14
+    rows of fixtures. A reader hidden in a test directory is therefore invisible
+    to this guard.
+  * The shell scanner is a comment-stripped TEXT match. It sees
+    `${HOME}/.claude/analyze-service-index`; it would not see a path assembled
+    from two variables.
+  * The Python scanner reads the AST, so a path assembled at run time out of
+    `os.environ` or `str.join` is invisible to it. It sees the shapes that have
+    actually shipped: a string COMPONENT in a path expression, and an attribute
+    or name reference to another module's store constant.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts" / "lib"))
+
+import subsystem_read_store as rs  # noqa: E402
+import subsystem_touch as st  # noqa: E402
+
+# =============================================================================
+# THE SCANNERS' VOCABULARY. Literals, pinned against the live paths below.
+# =============================================================================
+
+#: The directory NAMES that make a path a subsystem-store root. Written out, not
+#: read off either module — `TestTheScannerVocabularyMatchesTheRealPaths` is what
+#: keeps them in step, and it is the only assertion in this file that touches
+#: both sides of that relationship.
+STORE_ROOT_COMPONENTS: frozenset[str] = frozenset(
+    {"analyze-service-index", "subsystem-store"}
+)
+
+#: Names a file uses when it takes another module's store root, or declares its
+#: own. `escrow-verify.py` and `restore-verify.py` reach the frozen mirror as
+#: `B.DEFAULT_STORE` and spell no path at all, so a component scan alone would
+#: report them clean — the transitive shape is why this set exists.
+SITING_NAMES: frozenset[str] = frozenset(
+    {"DEFAULT_STORE", "DEFAULT_STORE_ROOT", "DEFAULT_CACHE_ROOT"}
+)
+
+#: The resolver's two entry points. A file that calls one of these has asked
+#: `subsystem_read_store` where to read, which is the whole property.
+RESOLVER_CALLS: frozenset[str] = frozenset({"read_store_root", "resolve_read_store"})
+
+#: Directories whose files build fixtures rather than resolve stores. See the
+#: residuals in the module docstring — this is an enumerated exclusion, not a
+#: pattern, so a new production directory cannot fall into it by accident.
+OUT_OF_SCOPE_PREFIXES: tuple[str, ...] = ("scripts/tests/", "scripts/testlib/")
+
+
+# =============================================================================
+# THE LEDGERS
+# =============================================================================
+
+#: Files that MUST route through `subsystem_read_store`. The value says what the
+#: file reads and therefore why it may not answer the question itself.
+#:
+#: 🔴 THE THREE HISTORICAL DEFECTS ARE ALL IN HERE. Each one is a file that once
+#: hardcoded the frozen mirror; a row disappearing from this ledger is that
+#: regression happening again.
+ROUTED: dict[str, str] = {
+    "scripts/lib/subsystem_read_store.py": (
+        "THE resolver. `read_store_root` reads the module global at call time, "
+        "which is what lets one `monkeypatch.setattr` repoint every consumer"
+    ),
+    "scripts/lib/subsystem_recall.py": (
+        "the READER `/resume` step 4 runs. Regression #1 of three: its CLI "
+        "defaulted `--store` to the frozen mirror and printed a completeness "
+        "claim about a store that had stopped moving"
+    ),
+    "scripts/lib/service_recon.py": (
+        "the recon `/analyze-service` runs. Regression #2 of three: same "
+        "hardcoded mirror, found only after #1 was fixed"
+    ),
+    "scripts/subsystem-audit.py": (
+        "the auditor `/prune-index` runs. Regression #3 of three: it declared "
+        "its own `DEFAULT_STORE_ROOT`, which is why the constant is gone from it "
+        "and only a comment records that it was ever there"
+    ),
+    "scripts/cairn": (
+        "the client. Its `--cache` default is `read_store_root()` so the WRITER "
+        "of the cache and every reader of it move together, and `doctor` "
+        "resolves the read store to report which one this host actually reads"
+    ),
+}
+
+#: Files that compute a store-root path THEMSELVES, each with the reason it is
+#: allowed to. A row here is a deliberate exemption from `ROUTED`, and the reason
+#: is the artifact: an exemption nobody can justify in a sentence is the finding.
+SITED: dict[str, str] = {
+    "scripts/lib/subsystem_read_store.py": (
+        "THE OWNER. `DEFAULT_CACHE_ROOT` is the one definition of the synced "
+        "cache; every other reader imports the MODULE and calls the accessor"
+    ),
+    "scripts/lib/subsystem_touch.py": (
+        "THE WRITER's target. `DEFAULT_STORE_ROOT` is the pre-cutover local "
+        "store — the constant `subsystem_read_store` was created to supersede "
+        "for READS. It is not a read surface: `--validate` and `--store` here "
+        "parse and write entries, and `cairn validate` passes the cache "
+        "explicitly. Exempt because pointing it at the synced cache would make "
+        "the writer's default target a directory `cairn sync` replaces wholesale"
+    ),
+    "scripts/cairn-cutover.py": (
+        "EXEMPT — the mirror is its SUBJECT, not a store it reads for an answer. "
+        "It plans the delta FROM the pre-cutover local store, pushes it to the "
+        "pod, and P5 chmods that same tree `0444`; `--unfreeze` restores the "
+        "recorded modes on it. Pointed at `~/.cache/subsystem-store` it would "
+        "plan an empty delta (a copy of the pod, against the pod) and then "
+        "freeze a directory the next `cairn sync` deletes and recreates. Its "
+        "other two matches are not store roots at all: `DEFAULT_BACKUP_"
+        "NAMESPACE` is the Kubernetes namespace"
+    ),
+    "scripts/analyze-service-index/backup.py": (
+        "EXEMPT — it backs up the mirror's GIT HISTORY, which exists nowhere "
+        "else. Each `<scope>/` is an independent repository and this produces "
+        "one `git bundle` per scope; the synced cache is an extracted tar with "
+        "no repositories in it, so this cannot be repointed at the cache and "
+        "still do its job. ⚠ RECORDED, NOT RESOLVED: the pod is canonical now "
+        "and has its own backup CronJob, so this is an archive of a frozen tree "
+        "rather than the store's backup, and its docstring still says 'a disk "
+        "failure … loses the whole thing permanently'. That sentence is no "
+        "longer true. Whether the job should still run is a live question, "
+        "deliberately left open here rather than answered by an exemption"
+    ),
+    "scripts/analyze-service-index/escrow-verify.py": (
+        "EXEMPT, transitively — `DEFAULT_STORE = B.DEFAULT_STORE`, re-exported "
+        "from `backup.py` so the verifier and the producer cannot disagree "
+        "about which tree was backed up. It inherits `backup.py`'s reason and "
+        "must not grow a second spelling of the path"
+    ),
+    "scripts/analyze-service-index/restore-verify.py": (
+        "EXEMPT, transitively — same `B.DEFAULT_STORE` re-export, same reason: "
+        "a restore verified against a different tree than the one backed up "
+        "verifies nothing"
+    ),
+    "scripts/analyze-service-index/commit.sh": (
+        "EXEMPT — the hourly autocommit of the mirror's per-scope git "
+        "repositories. Same subject as `backup.py`: it versions the mirror, it "
+        "does not read the store to answer anybody. It also refuses an EMPTY "
+        "positional rather than silently taking the default, which is the "
+        "opposite failure and already guarded by test_repo_path_defaults.py"
+    ),
+    "scripts/present/measure.py": (
+        "⚠ OPEN QUESTION, RECORDED RATHER THAN WAVED THROUGH. `Env.live()` "
+        "resolves `~/.claude/analyze-service-index` for the devrc explainer "
+        "page's store measurements, and its own provenance string still reads "
+        "'read via subsystem_recall.load_store()'. Post-cutover that measures "
+        "the FROZEN tree and presents the numbers as the store's — the same "
+        "shape as the three regressions above, in a page rather than a recall. "
+        "It is not fixed here because the fix is a judgement about what the "
+        "page is claiming, not a repoint; it is ledgered so the question cannot "
+        "go quiet again"
+    ),
+    "scripts/subsystem-store-api/server.py": (
+        "EXEMPT — POD-SIDE. Its `DEFAULT_STORE` is `/data`, the container mount, "
+        "which is neither of the two host locations; the `subsystem-store` "
+        "component it also names is the secret mount path. This process IS the "
+        "authority the resolver points other hosts at, so routing it through a "
+        "host-local resolver would be circular"
+    ),
+    "scripts/cairn": (
+        "EXEMPT for the one path it sites: `~/.config/subsystem-store/env` is "
+        "the CREDENTIAL file, not a store root. Its actual store resolution is "
+        "in `ROUTED` above, and both facts have to be true of this file"
+    ),
+}
+
+
+# =============================================================================
+# THE SCANNERS
+# =============================================================================
+
+def tracked_sources() -> list[str]:
+    """Repo-relative paths under `scripts/`, minus the out-of-scope directories.
+
+    🔴 `git ls-files`, NOT `rglob`. The flake ships tracked files only, so an
+    untracked reader deploys as an absence — but a `rglob` sweep would also drag
+    in `__pycache__`, virtualenvs and build output, and `claude/RULES.md` records
+    that this repo's `grep -r` is `.gitignore`-blind in the opposite direction.
+    Listing the index is the one answer that matches what ships.
+    """
+    out = subprocess.run(
+        ["git", "-C", str(ROOT), "ls-files", "-z", "scripts"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    return [
+        rel for rel in out.split("\0")
+        if rel and not rel.startswith(OUT_OF_SCOPE_PREFIXES)
+    ]
+
+
+def _shebang(text: str) -> str:
+    first = text.splitlines()[0] if text else ""
+    return first if first.startswith("#!") else ""
+
+
+def _is_python(path: Path, text: str) -> bool:
+    """`.py`, or a shebang naming python — `scripts/cairn` has no extension."""
+    return path.suffix == ".py" or "python" in _shebang(text)
+
+
+def _is_shell(path: Path, text: str) -> bool:
+    """`.sh`, or a shebang naming a shell.
+
+    🔴 NOT "everything that is not Python". The first version let every tracked
+    file fall through to the shell matcher, and `subsystem-store-api/README.md`
+    landed in the ledger for QUOTING an operator command. A document cannot
+    resolve a store root at run time, and a ledger row for one is noise that
+    makes a real row easier to wave through. The population is CODE.
+    """
+    shebang = _shebang(text)
+    return path.suffix == ".sh" or any(
+        sh in shebang for sh in ("bash", "/sh", "zsh", "dash")
+    )
+
+
+#: Shell siting: a home anchor, then a path ending in a store-root component.
+_SHELL_SITING = re.compile(
+    r"(?:\$\{?HOME\}?|~)/[^\s\"']*(?:" + "|".join(sorted(STORE_ROOT_COMPONENTS)) + r")"
+)
+
+
+def sites_a_store_root(path: Path, text: str) -> list[str]:
+    """`["<kind>:<detail>:<line>", …]` — every place this file computes one.
+
+    Empty means "this file names no store root", NOT "I could not look": a file
+    that fails to parse raises rather than returning `[]`, because a silent
+    parse failure is exactly the reassuring zero this whole ledger is about.
+    """
+    hits: list[str] = []
+    if _is_python(path, text):
+        tree = ast.parse(text)  # deliberately not caught — see the docstring
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and node.value in STORE_ROOT_COMPONENTS
+            ):
+                # 🔴 EXACT EQUALITY, NOT `in`. A path COMPONENT is a whole string
+                # in a `/` expression; requiring the constant to BE the component
+                # is what keeps every docstring and prose mention of the mirror
+                # out of this scan, without a comment stripper that would have to
+                # understand Python string syntax to be right.
+                hits.append(f"component:{node.value}:{node.lineno}")
+            elif isinstance(node, ast.Attribute) and node.attr in SITING_NAMES:
+                hits.append(f"attr:{node.attr}:{node.lineno}")
+            elif isinstance(node, ast.Name) and node.id in SITING_NAMES:
+                hits.append(f"name:{node.id}:{node.lineno}")
+        return sorted(set(hits))
+
+    if not _is_shell(path, text):
+        return []
+
+    body = "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+    for match in _SHELL_SITING.finditer(body):
+        hits.append(f"shell:{match.group(0)}:{body[: match.start()].count(chr(10)) + 1}")
+    return sorted(set(hits))
+
+
+def calls_the_resolver(path: Path, text: str) -> list[str]:
+    """`["<call>:<line>", …]` — every call to `subsystem_read_store`'s accessors.
+
+    🔴 THE CALL, NOT THE IMPORT. `import subsystem_read_store` routes nothing;
+    the three regressions this ledger exists for could each have carried the
+    import and still resolved the frozen mirror.
+    """
+    if not _is_python(path, text):
+        return []
+    hits: list[str] = []
+    for node in ast.walk(ast.parse(text)):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = (
+            func.attr if isinstance(func, ast.Attribute)
+            else func.id if isinstance(func, ast.Name)
+            else None
+        )
+        if name in RESOLVER_CALLS:
+            hits.append(f"{name}:{node.lineno}")
+    return sorted(set(hits))
+
+
+def _scan(predicate) -> dict[str, list[str]]:
+    found: dict[str, list[str]] = {}
+    for rel in tracked_sources():
+        path = ROOT / rel
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        hits = predicate(path, text)
+        if hits:
+            found[rel] = hits
+    return found
+
+
+@pytest.fixture(scope="module")
+def sited() -> dict[str, list[str]]:
+    return _scan(sites_a_store_root)
+
+
+@pytest.fixture(scope="module")
+def routed() -> dict[str, list[str]]:
+    return _scan(calls_the_resolver)
+
+
+# =============================================================================
+# The seam: the scanners' vocabulary vs the live paths
+# =============================================================================
+
+class TestTheScannerVocabularyMatchesTheRealPaths:
+    """🔴 THE HALF THAT KEEPS THE LEDGER FROM GOING BLIND.
+
+    Both scanners are only as wide as `STORE_ROOT_COMPONENTS`. Rename the synced
+    cache and every assertion below keeps passing over a scan that now matches
+    nothing new — a green ledger over a store it can no longer see. So the
+    vocabulary is pinned to the two live constants, in both directions.
+
+    The literals are written out HERE and compared against the modules; neither
+    side is read off the other.
+    """
+
+    def test_the_cache_root_is_the_component_the_scanner_knows(self) -> None:
+        assert rs.DEFAULT_CACHE_ROOT == Path.home() / ".cache" / "subsystem-store"
+        assert rs.DEFAULT_CACHE_ROOT.name in STORE_ROOT_COMPONENTS
+
+    def test_the_frozen_mirror_is_the_component_the_scanner_knows(self) -> None:
+        assert st.DEFAULT_STORE_ROOT == Path.home() / ".claude" / "analyze-service-index"
+        assert st.DEFAULT_STORE_ROOT.name in STORE_ROOT_COMPONENTS
+
+    def test_the_two_roots_are_DIFFERENT_directories(self) -> None:
+        """The premise of the whole cutover, and of this file. If these ever
+        became one path the ledger would be policing nothing."""
+        assert rs.DEFAULT_CACHE_ROOT != st.DEFAULT_STORE_ROOT
+
+    def test_every_component_the_scanner_knows_is_a_LIVE_root(self) -> None:
+        """The other direction: no dead vocabulary. A component in the set that
+        matches no real store root would widen both scans forever with nothing to
+        find, and the noise is how a real row gets waved through."""
+        live = {rs.DEFAULT_CACHE_ROOT.name, st.DEFAULT_STORE_ROOT.name}
+        assert STORE_ROOT_COMPONENTS == live, (
+            f"the scanner's vocabulary {sorted(STORE_ROOT_COMPONENTS)} and the "
+            f"live store roots {sorted(live)} disagree"
+        )
+
+    def test_the_resolver_exports_the_calls_the_scanner_looks_for(self) -> None:
+        """A renamed accessor must red this file, not silently empty `ROUTED`."""
+        for name in sorted(RESOLVER_CALLS):
+            assert hasattr(rs, name), f"`subsystem_read_store` has no `{name}`"
+            assert name in rs.__all__, f"`{name}` is not exported"
+
+
+# =============================================================================
+# The ledgers, two-way
+# =============================================================================
+
+class TestTheRoutedLedgerIsTwoWay:
+    def test_the_scan_found_routers_at_all(self, routed) -> None:
+        """POSITIVE CONTROL. Every assertion below is satisfied by a scan that
+        walked nothing — an empty `routed` makes `set(routed) == set(ROUTED)`
+        merely a claim that the ledger is also empty."""
+        assert len(routed) >= 3, (
+            f"the resolver scan found only {sorted(routed)}. It is not looking "
+            f"at what it claims to look at."
+        )
+
+    def test_the_ledger_is_exactly_the_scan(self, routed) -> None:
+        found, expected = set(routed), set(ROUTED)
+        assert found == expected, (
+            "the set of files routing through `subsystem_read_store` changed.\n"
+            f"  NEW routers (add a row saying what they read): {sorted(found - expected)}\n"
+            f"  LOST routers 🔴 (a reader STOPPED asking the resolver where to "
+            f"read — this is the regression, not a cleanup): {sorted(expected - found)}\n"
+            "Ledger:\n  " + "\n  ".join(f"{k} — {v}" for k, v in ROUTED.items())
+        )
+
+    @pytest.mark.parametrize("rel", sorted(ROUTED))
+    def test_each_routed_file_exists_and_is_tracked(self, rel: str) -> None:
+        assert (ROOT / rel).is_file(), f"{rel} is gone"
+        assert rel in set(tracked_sources()), f"{rel} is not tracked by git"
+
+
+class TestTheSitedLedgerIsTwoWay:
+    def test_the_scan_found_siting_at_all(self, sited) -> None:
+        """POSITIVE CONTROL, same argument as above."""
+        assert len(sited) >= 5, (
+            f"the siting scan found only {sorted(sited)} — it is wired to "
+            f"nothing, and a clean ledger over nothing is not a clean ledger."
+        )
+
+    def test_the_scan_reaches_BOTH_languages(self, sited) -> None:
+        """A Python-only scan would report `commit.sh` clean forever. The shell
+        arm has no shared code with the Python arm, so its silence is its own
+        unproven claim until something is seen through it."""
+        assert any(rel.endswith(".sh") for rel in sited), (
+            "the siting scan matched no shell file at all"
+        )
+        assert any(not rel.endswith(".sh") for rel in sited)
+
+    def test_the_ledger_is_exactly_the_scan(self, sited) -> None:
+        found, expected = set(sited), set(SITED)
+        assert found == expected, (
+            "the set of files computing a subsystem-store root changed.\n"
+            f"  NEW siting 🔴 (a fourth open-coded store path — route it through "
+            f"`subsystem_read_store`, or add a row here saying why it may not): "
+            f"{sorted(found - expected)}\n"
+            f"  LOST siting (a row here names a file that no longer does it — "
+            f"delete the row): {sorted(expected - found)}\n"
+            "Ledger:\n  " + "\n  ".join(f"{k} — {v}" for k, v in SITED.items())
+        )
+
+    @pytest.mark.parametrize("rel", sorted(SITED))
+    def test_each_sited_file_exists_and_is_tracked(self, rel: str) -> None:
+        assert (ROOT / rel).is_file(), f"{rel} is gone"
+        assert rel in set(tracked_sources()), f"{rel} is not tracked by git"
+
+    @pytest.mark.parametrize("rel", sorted(SITED))
+    def test_every_exemption_carries_a_REASON(self, rel: str) -> None:
+        """🔴 A LEDGER OF EMPTY STRINGS IS NOT A LEDGER. The reason is the whole
+        artifact — it is what a reviewer reads instead of re-deriving the
+        judgement — so a row is required to say something a person could disagree
+        with. 40 characters is roughly one clause; it is a floor on effort, not a
+        quality claim, and this docstring says so rather than implying more."""
+        assert len(SITED[rel].strip()) >= 40, (
+            f"{rel}'s exemption reason is too short to be a reason: {SITED[rel]!r}"
+        )
+
+    def test_the_two_ledgers_overlap_only_where_stated(self, sited, routed) -> None:
+        """A file in BOTH is doing two different things and must say so. Today
+        exactly one is: `scripts/cairn` routes for `--cache` and separately names
+        the credential file. Pinned as a literal so a second overlap arriving
+        unexplained is a failure rather than a shrug."""
+        assert set(ROUTED) & set(SITED) == {
+            "scripts/cairn",
+            "scripts/lib/subsystem_read_store.py",
+        }
+
+
+# =============================================================================
+# CONTROLS. The scanners must be shown to fire, and shown not to over-fire.
+# =============================================================================
+
+class TestTheScannersCanActuallySee:
+    """🔴 A LEDGER IS A REASSURING SET. Until each scanner has been watched to
+    fire on a planted case and stay quiet on a benign one, "the ledger matches"
+    is a fact about the ledger only."""
+
+    def test_the_three_shipped_regressions_would_ALL_be_caught(self, tmp_path) -> None:
+        """🔴 THE REGRESSION PROOF, reconstructed rather than asserted.
+
+        Each fixture is the shape one of the three shipped defects actually had:
+        a reader defaulting its store to the frozen mirror. If the scanner cannot
+        see these, this file would not have caught any of the three it exists for
+        — and that is a claim worth grading, not repeating.
+        """
+        cases = {
+            # subsystem_recall.py's CLI, pre-fix.
+            "recall_cli.py":
+                'import argparse\n'
+                'from pathlib import Path\n'
+                'DEFAULT_STORE_ROOT = Path.home() / ".claude" / "analyze-service-index"\n'
+                'p = argparse.ArgumentParser()\n'
+                'p.add_argument("--store", default=str(DEFAULT_STORE_ROOT))\n',
+            # service_recon.py, pre-fix: it took the WRITER's constant instead.
+            "recon.py":
+                'import subsystem_touch as st\n'
+                'def brief(root=None):\n'
+                '    return root or st.DEFAULT_STORE_ROOT\n',
+            # subsystem-audit.py, pre-fix: its own copy of the constant.
+            "audit.py":
+                'from pathlib import Path\n'
+                'DEFAULT_STORE_ROOT = Path.home() / ".claude" / "analyze-service-index"\n',
+        }
+        for name, source in cases.items():
+            path = tmp_path / name
+            path.write_text(source, encoding="utf-8")
+            assert sites_a_store_root(path, source), (
+                f"the siting scan did not see {name}, which is the shape of a "
+                f"defect that actually shipped"
+            )
+            assert not calls_the_resolver(path, source), (
+                f"{name} routes nothing, yet the resolver scan claims it does"
+            )
+
+    def test_the_transitive_shape_is_caught(self, tmp_path) -> None:
+        """`DEFAULT_STORE = B.DEFAULT_STORE` spells no path at all. A component
+        scan alone reports it clean, and two shipped files have this shape."""
+        source = "import backup as B\nDEFAULT_STORE = B.DEFAULT_STORE\n"
+        path = tmp_path / "verify.py"
+        path.write_text(source, encoding="utf-8")
+        assert sites_a_store_root(path, source)
+
+    def test_a_python_file_with_NO_extension_is_still_scanned(self, tmp_path) -> None:
+        """`scripts/cairn` has no `.py`. A scanner keyed on the suffix alone
+        would skip the client that owns the cache."""
+        source = '#!/usr/bin/env python3\nfrom pathlib import Path\nX = Path.home() / ".cache" / "subsystem-store"\n'
+        path = tmp_path / "cairn"
+        path.write_text(source, encoding="utf-8")
+        assert sites_a_store_root(path, source)
+
+    def test_the_shell_shape_is_caught(self, tmp_path) -> None:
+        source = 'STORE="${POSITIONAL[0]:-${HOME}/.claude/analyze-service-index}"\n'
+        path = tmp_path / "commit.sh"
+        path.write_text(source, encoding="utf-8")
+        assert sites_a_store_root(path, source)
+
+    def test_the_resolver_scan_fires_on_BOTH_spellings(self, tmp_path) -> None:
+        for source in (
+            "import subsystem_read_store as _rs\nX = _rs.read_store_root()\n",
+            "from subsystem_read_store import resolve_read_store\nX = resolve_read_store(None)\n",
+        ):
+            path = tmp_path / "r.py"
+            path.write_text(source, encoding="utf-8")
+            assert calls_the_resolver(path, source), source
+
+    def test_an_IMPORT_alone_does_not_count_as_routing(self, tmp_path) -> None:
+        """NEGATIVE CONTROL, and the one that matters most: each of the three
+        regressions could have carried the import while resolving the mirror."""
+        source = "import subsystem_read_store as _rs  # noqa: F401\n"
+        path = tmp_path / "r.py"
+        path.write_text(source, encoding="utf-8")
+        assert not calls_the_resolver(path, source)
+
+    def test_prose_about_the_mirror_is_NOT_siting(self, tmp_path) -> None:
+        """NEGATIVE CONTROL. `subsystem_read_store`'s own docstring names the
+        frozen mirror, `subsystem-audit.py` carries a comment recording the
+        constant it deleted, and `host_identity.py` describes the layout. A
+        scanner that counted prose would bury the real rows."""
+        source = (
+            '"""The store at ~/.claude/analyze-service-index is FROZEN.\n\n'
+            'It used to be `Path.home() / ".claude" / "analyze-service-index"`.\n"""\n'
+            "# DEFAULT_STORE_ROOT used to be declared here.\n"
+            "VALUE = 1\n"
+        )
+        path = tmp_path / "prose.py"
+        path.write_text(source, encoding="utf-8")
+        assert not sites_a_store_root(path, source), (
+            "a docstring and a comment were counted as siting a store root"
+        )
+
+    def test_a_REQUIRED_store_argument_is_NOT_siting(self, tmp_path) -> None:
+        """NEGATIVE CONTROL. `seed.sh` and `verify-byte-identity.sh` demand
+        `--store` and default to nothing; they resolve no root and must stay out
+        of the ledger, or the ledger stops being about defaults."""
+        source = 'STORE=""\n[[ -n "$STORE" ]] || { echo "--store is required" >&2; exit 2; }\n'
+        path = tmp_path / "seed.sh"
+        path.write_text(source, encoding="utf-8")
+        assert not sites_a_store_root(path, source)
+
+    def test_a_MARKDOWN_file_quoting_the_path_is_not_siting(self, tmp_path) -> None:
+        """NEGATIVE CONTROL, and a measured one: `subsystem-store-api/README.md`
+        quotes `--store ~/.claude/analyze-service-index` in an operator recipe
+        and landed in this ledger before the language check existed. Prose cannot
+        resolve a path at run time, and a spurious row is what makes a real row
+        easy to wave through."""
+        source = "Run:\n\n    seed.sh --store ~/.claude/analyze-service-index\n"
+        path = tmp_path / "README.md"
+        path.write_text(source, encoding="utf-8")
+        assert not sites_a_store_root(path, source)
+
+    def test_a_shell_COMMENT_naming_the_mirror_is_not_siting(self, tmp_path) -> None:
+        source = "# the store lives at ${HOME}/.claude/analyze-service-index\nSTORE=\"$1\"\n"
+        path = tmp_path / "c.sh"
+        path.write_text(source, encoding="utf-8")
+        assert not sites_a_store_root(path, source)
+
+    def test_an_unparseable_python_file_RAISES_rather_than_reading_clean(
+        self, tmp_path
+    ) -> None:
+        """🔴 A parse failure swallowed into `[]` is a file reported clean by a
+        scan that never looked at it — the silent zero, arriving through the one
+        door a `try/except` would open."""
+        source = "def broken(:\n"
+        path = tmp_path / "b.py"
+        path.write_text(source, encoding="utf-8")
+        with pytest.raises(SyntaxError):
+            sites_a_store_root(path, source)
+
+
+class TestTheEnumeratorItself:
+    def test_it_lists_real_tracked_files(self) -> None:
+        files = tracked_sources()
+        assert len(files) > 100, f"only {len(files)} tracked files under scripts/"
+        assert "scripts/cairn" in files
+        assert "scripts/lib/subsystem_read_store.py" in files
+
+    def test_the_out_of_scope_directories_really_are_excluded(self) -> None:
+        """The exclusion is load-bearing and enumerated, so it is graded: a test
+        file that hardcodes the mirror must not appear, and one that DOES exist
+        must be findable outside the enumerator — otherwise this asserts nothing.
+        """
+        files = tracked_sources()
+        assert not [f for f in files if f.startswith(OUT_OF_SCOPE_PREFIXES)]
+        every = subprocess.run(
+            ["git", "-C", str(ROOT), "ls-files", "-z", "scripts/tests"],
+            capture_output=True, text=True, check=True,
+        ).stdout.split("\0")
+        assert len([f for f in every if f]) > 50, (
+            "there is no `scripts/tests/` content, so excluding it excluded "
+            "nothing and this control proves nothing"
+        )


### PR DESCRIPTION
## What this is

Three things, in order of what matters:

1. **`scripts/tests/test_store_root_ledger.py`** — a two-way ledger over every file
   that resolves a subsystem-store root. This is the deliverable.
2. **`cairn doctor`** — one call for what a reader currently checks by hand.
3. **`claude/skills/cairn/`** — tier B, a router to those commands.

## 1. The ledger guard

The same defect shipped **three times**: a reader open-coding the FROZEN pre-cutover
mirror instead of asking `subsystem_read_store` where to read — `subsystem_recall`'s
CLI, `service_recon`, `subsystem-audit.py` — each found by a human noticing, one at a
time, after the previous one was fixed.

Two ledgers, each failing when the set **grows** *or* **shrinks**:

| ledger | population | the direction that matters |
|---|---|---|
| `ROUTED` | files that CALL `read_store_root` / `resolve_read_store` | **SHRINKS** — a reader that stops routing is the regression, and it takes its own per-file tests with it |
| `SITED` | files that compute a store-root path themselves, each with a written reason | **GROWS** — the fourth open-coded reader, on the commit that introduces it |

A third guard, `TestTheScannerVocabularyMatchesTheRealPaths`, pins the scanners'
vocabulary two-way against `DEFAULT_CACHE_ROOT` and `DEFAULT_STORE_ROOT`. Without it,
renaming the cache directory would leave both ledgers green over a scan that can no
longer see the thing they police.

### Red at base

The scanner cannot be *run* at the pre-change base — the module it pins did not exist.
So it was graded against the tree where the defects were live:

| tree | `subsystem_recall.py` | `service_recon.py` | `subsystem-audit.py` |
|---|---|---|---|
| `b9b2493d` (parent of #1233, pre-resolver) | **SITED**, not routed | **SITED**, not routed | **SITED**, not routed |
| this branch | ROUTED, not sited | ROUTED, not sited | ROUTED, not sited |

### Mutation sweep

Isolated `cp -a` copy with `.git` removed and re-inited, `PYTHONDONTWRITEBYTECODE=1`,
`__pycache__` cleared between mutants.

| mutant | outcome | killed by |
|---|---|---|
| an unledgered reader sites the frozen mirror | **KILLED** | `TestTheSitedLedgerIsTwoWay::test_the_ledger_is_exactly_the_scan`, NEW siting naming the planted file |
| a ledgered router stops routing | **KILLED** | `TestTheRoutedLedgerIsTwoWay::test_the_ledger_is_exactly_the_scan`, LOST routers naming the file |
| a `SITED` row is deleted | **KILLED** | the SITED ledger, NEW siting naming the un-ledgered file |
| the scanner's vocabulary drifts from a live root | **KILLED** | `TestTheScannerVocabularyMatchesTheRealPaths` |
| **negative control** — a no-op comment | **SURVIVED** (correct) | — |

Controls: 49 passed before the sweep and 49 after. No survivors other than the
negative control.

### Exemptions, and the two judgement calls

* **`cairn-cutover.py` — EXEMPT.** The mirror is its *subject*, not a store it reads
  for an answer: it plans the delta from that tree, pushes it, and P5 chmods it
  `0444`; `--unfreeze` restores the recorded modes on the same tree. Pointed at the
  synced cache it would plan an empty delta (a copy of the pod, against the pod) and
  then freeze a directory the next `cairn sync` deletes and recreates.
* **`backup.py` — EXEMPT, with a recorded open question.** It bundles the mirror's
  per-scope **git history**, which exists nowhere else; the synced cache is an
  extracted tar with no repositories in it, so it cannot be repointed and still do its
  job. But the pod is canonical now and has its own backup CronJob, so this is an
  archive of a frozen tree rather than the store's backup — and its docstring still
  says a disk failure *"loses the whole thing permanently"*, which is no longer true.
  Recorded in the ledger rather than fixed here.
* **`present/measure.py` — NEW, and the closest thing to a fourth instance.**
  `Env.live()` resolves the frozen mirror for the explainer page's store measurements,
  and its own provenance string still reads *"read via `subsystem_recall.load_store()`"*.
  Post-cutover it measures a frozen tree and presents the numbers as the store's — the
  same shape as the three regressions, in a page rather than a recall. Ledgered with
  the question open; **not fixed here**, because the fix is a judgement about what the
  page claims, not a repoint.
* Also ledgered: `subsystem_touch.py` (the writer's target), `escrow-verify.py` and
  `restore-verify.py` (transitive `B.DEFAULT_STORE` re-exports — invisible to a
  component scan, which is why the ledger looks for the names too), `commit.sh` (shell),
  `server.py` (pod-side `/data`), and `cairn` itself (its one sited path is the
  credential file).

## 2. `cairn doctor`

Seven checks in one call, each in one of four states — and the fourth state is the
point:

* `OK` / `PROBLEM` — measured.
* `UNMEASURED` — it could not look, and the reason is mandatory (a `Check` with an
  empty detail is refused at construction).
* `NOT-OBSERVABLE` — no client can answer it at all. It contributes **nothing** to the
  exit code, deliberately: the pod exposes no identity route, so folding it into
  `UNMEASURED` would make `doctor` non-zero on every healthy run forever.

Unauthorised is separated from unreachable **structurally** — `StoreUnreachable` now
carries `http_status`, set from the `HTTPError`, so nothing greps an f-string. The read
path is unchanged; `resolve_state` reads neither.

It **installs nothing** — it fetches, reads headers and the member list, and discards
the bytes, so it can be run twice without repairing the staleness it was run to
measure. Exit codes are documented by the command itself (`EXIT_LEGEND`, printed on
every run and in `--help`), never by a skill.

**It found two real problems on the workbench the moment it existed**, both reported
in the run, neither fixed here:

* `frozen-mirror` **PROBLEM** — 6 of 160 entry files under the "frozen" mirror are
  still mode 644. A write to one of those lives on one host and the pod never sees it.
* `token-scopes` **PROBLEM** — two scopes present on this disk are absent from this
  token's snapshot. The API cannot say which of the two readings that is (a refused
  scope is byte-identical to an absent one, deliberately), so the report names both
  and guesses neither.

## 3. The skill

`claude/skills/cairn/SKILL.md` (4,290 B) + `reference/operator-surface.md` (6,000 B).
The body is a router: a command table, the two different exit 4s side by side, where a
host reads from, and — for a new consumer — a pointer at the ledger guard rather than a
paragraph of advice. The operator detail (the pod, `seed.sh`'s overwrite semantics,
`verify-byte-identity.sh`'s measured one-directional coverage gap, `build-push.sh`,
the freeze, and the once-at-startup token load with its `exit 78` / `kubectl delete pod`
consequences) is in `reference/`, which costs nothing until loaded.

**Tier B** in `claude/skill-tiers.json` — the tool is named, never described.

### Paying for the listing entry

`test_skill_descriptions.py` had **12 chars** of headroom, so a tier-B skill is not
free there (that gate does not read the tier ledger). Eviction, per its own playbook
step 1 — mechanism prose out of the costliest descriptions, no trigger phrase or
disambiguation clause dropped:

| skill | change | Δ |
|---|---|---|
| `signal` | dropped the pipeline parenthetical | −71 |
| `mailbox` | dropped the pipeline parenthetical (`inbox.zacx.dev` survives as a trigger) | −53 |
| `session-manager` | dropped the gloss on UNSENT PROMPTS | −42 |
| `prune-index` | trimmed; it no longer routes on the frozen-mirror path, which `cairn` claims | −148 |
| `cairn` | new | +308 |

Listing total **12,911 / 12,929** — 18 chars of headroom. `TIER_A_CEILING_CHARS`
**lowered 9,200 → 8,935**, because the tier-A cut would otherwise have been banked as
519 chars of slack, more than a whole average entry.

## Departures from the brief, reported rather than implemented

1. **`prune-index` and `subsystem-index` have no byte ceilings.**
   `git grep -l MIN_HEADROOM_BYTES scripts/` names `prune-skill`, `handoff`,
   `session-manager`, `browser-bridge` and `RULES.md` — not these two. There was no
   ceiling to re-check.
2. **The absorption is smaller than "absorb the duplicated prose".** Roughly twenty
   literal sentences in those two files are pinned by four test modules, and
   `subsystem-index`'s cutover header is inside a whole-paragraph **hash** pin
   (`TestTheOwnersMechanismProseIsPinnedWHOLE`) that exists precisely so the owner's
   protocol prose cannot be quietly reworded. That prose is the owner stating its own
   mechanism, not cairn documentation misfiled — so it stays, and each door gains a
   pointer instead. Byte deltas: `prune-index` **13,884 → 13,729 (−155)`;
   `subsystem-index` **37,204 → 37,469 (+265)**, a growth, because the pointer was
   added and nothing pinned was removed.
3. **The measured population was incomplete.** All the line numbers in the brief were
   right (`present/measure.py:381` is the last of a three-line resolution). Missing:
   `escrow-verify.py`, `restore-verify.py`, `commit.sh`, `present/measure.py`,
   `server.py`. `build-push.sh` names no store path at all. `seed.sh` and
   `verify-byte-identity.sh` require `--store` with no default and are correctly out.
4. **The pod exposes no identity route** (`API_ROUTES` = recall/search/snapshot), so
   "token identity and which scopes it may write" is answered in two parts: the
   credential's **fingerprint** (`sha256[:12]`, the same handle the pod's audit log
   carries — pinned against `server.token_id` through a literal digest), and the scopes
   it can actually reach, derived from the snapshot. The declared identity string is
   `NOT-OBSERVABLE`, with the exact operator command in the detail. `doctor` never
   reads a secret and never shells `kubectl`.

## Not done here

`nix/home.nix` and `CLAUDE.md` are untouched — #1250 is mid-gate on both. The skills
tree deploys via `cp -R ${../claude/skills}`, so the new skill needs no nix change, and
the opencode commands are generated at build time from the same tree.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
