### PR TITLE
fix(cpu-monitor): split CPU_MON_TEMP_THRESHOLD host-conditional (92 laptop / 88 workbench)

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -2193,8 +2193,23 @@ in
       # PATH must be explicit: a user service does not inherit the login shell PATH.
       Environment = [
         "PATH=${lib.makeBinPath [ pkgs.coreutils pkgs.gawk pkgs.procps pkgs.gnugrep pkgs.libnotify ]}"
-        # This laptop runs hot at idle (cooling needs attention); warn early.
-        "CPU_MON_TEMP_THRESHOLD=88"
+        # HOST-CONDITIONAL, deliberately. The laptop runs hot at idle (cooling
+        # needs attention) and toasted constantly at 88; the workbench does not,
+        # and keeps the earlier warning. This was a single shared `88` with that
+        # laptop-specific sentence attached to it, and the laptop consequently
+        # carried `88 -> 92` as an UNCOMMITTED local edit — which blocked EVERY
+        # `ship.sh` fast-forward to that host (rc 7), silently, until an
+        # unrelated ship happened to run. A shared value here regenerates that
+        # edit; expressing the difference is what stops it.
+        #
+        # `isLaptop` is this file's host discriminator (defined in the `let`
+        # block above). Its documented fail-OPEN is BENIGN here, unlike on the
+        # keylog-ptrace and backup-prefix uses that had to reject it: a host
+        # that is a laptop without an intel_backlight evaluates false and gets
+        # 88 — the LOWER, earlier-warning threshold, i.e. exactly today's
+        # shipped behaviour. The failure direction is more alerting, never a
+        # silently laxer one.
+        "CPU_MON_TEMP_THRESHOLD=${if isLaptop then "92" else "88"}"
         # Raise thresholds to reduce alert noise (2026-08-05).
         "CPU_MON_THRESHOLD=48"
         "CPU_MON_RUNAWAY_PCT=95"

--- a/scripts/tests/test_cpu_monitor_temp_threshold.py
+++ b/scripts/tests/test_cpu_monitor_temp_threshold.py
@@ -1,0 +1,150 @@
+"""cpu-monitor's temperature threshold must resolve to DIFFERENT values per host.
+
+WHY THIS FILE EXISTS. `CPU_MON_TEMP_THRESHOLD` was a single shared `88` in
+`nix/home.nix`, carrying the comment "This laptop runs hot at idle (cooling
+needs attention); warn early" — host-specific prose bolted to a host-agnostic
+line. The laptop consequently carried `88 -> 92` as an UNCOMMITTED LOCAL EDIT,
+which blocked every `ship.sh` fast-forward to that host (rc 7): the documented
+"a skipped host silently stops receiving every future change while still looking
+healthy" failure. It was found only because an unrelated ship happened to run.
+
+So the invariant under test is not "the value is 92". It is that the expression
+in `nix/home.nix` RESOLVES DIFFERENTLY on the two hosts — because a value that
+can only be spelled once is a value the operator will re-edit locally, and the
+ship will block again. A conditional that silently yields one value on both
+hosts is the exact failure mode here, and in a diff it looks identical to
+success.
+
+HOW THIS DRIVES REAL CODE: the deployed expression is read out of
+`nix/home.nix` (never restated here) and evaluated by `nix-instantiate --eval`
+under an injected `isLaptop = true` and `isLaptop = false`. Two controls keep
+that harness honest:
+
+  * `test_the_harness_reports_SAME_for_a_constant` — NEGATIVE control. A harness
+    that fabricated a difference would make the real assertion pass for the
+    wrong reason.
+  * `test_the_harness_can_observe_a_difference` — POSITIVE control on the eval
+    plumbing itself.
+
+And `test_home_nix_still_binds_isLaptop_to_the_backlight_probe` is a SEAM guard
+(an invariant guard, not regression coverage — it did not fail before this
+change): the harness INJECTS `isLaptop`, so a rename in `home.nix` would leave
+these tests green over an expression production can no longer evaluate.
+"""
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+HOME_NIX = ROOT / "nix" / "home.nix"
+
+# The value each host must end up with. Stated here as literals on purpose: a
+# test that derived them from the implementation would assert nothing.
+LAPTOP_TEMP_THRESHOLD = "92"
+WORKBENCH_TEMP_THRESHOLD = "88"
+
+
+def _deployed_expression():
+    """The Nix expression for the CPU_MON_TEMP_THRESHOLD list element, verbatim.
+
+    Taken as the whole (stripped) source line, so an antiquotation containing
+    its own double quotes survives — a `"[^"]*"` regex would truncate it at the
+    first inner quote and silently hand back half an expression.
+    """
+    lines = [ln.strip() for ln in HOME_NIX.read_text().splitlines()
+             if "CPU_MON_TEMP_THRESHOLD=" in ln and not ln.strip().startswith("#")]
+    assert len(lines) == 1, (
+        "expected exactly one non-comment CPU_MON_TEMP_THRESHOLD line in "
+        "nix/home.nix, found %d: %r — the seam moved" % (len(lines), lines))
+    expr = lines[0].rstrip(",")
+    assert expr.startswith('"') and expr.endswith('"'), (
+        "the CPU_MON_TEMP_THRESHOLD line is not a self-contained Nix string "
+        "literal (%r); this harness can no longer evaluate it in isolation"
+        % expr)
+    return expr
+
+
+def _eval(expr, is_laptop):
+    if not shutil.which("nix-instantiate"):
+        pytest.fail(
+            "nix-instantiate not on PATH. This test is the only thing proving "
+            "the threshold is genuinely host-conditional rather than one shared "
+            "value wearing a conditional's clothes; a skip here is exactly how "
+            "it collapses back. Run under the flake gate, where nix-instantiate "
+            "is a declared required tool."
+        )
+    wrapped = "let isLaptop = %s; in %s" % ("true" if is_laptop else "false", expr)
+    p = subprocess.run(
+        ["nix-instantiate", "--eval", "--strict", "--json", "-E", wrapped],
+        capture_output=True, text=True, cwd=ROOT, timeout=180,
+    )
+    assert p.returncode == 0, (
+        "nix eval failed for isLaptop=%s on %r:\n%s" % (is_laptop, expr, p.stderr))
+    return json.loads(p.stdout)
+
+
+def test_the_harness_can_observe_a_difference():
+    """POSITIVE CONTROL on the eval plumbing: it must be capable of returning
+    two different strings, or 'the values differ' below could never be trusted
+    to have measured anything."""
+    probe = '"X=${if isLaptop then "A" else "B"}"'
+    assert _eval(probe, True) == "X=A"
+    assert _eval(probe, False) == "X=B"
+
+
+def test_the_harness_reports_SAME_for_a_constant():
+    """NEGATIVE CONTROL. A harness that fabricated a difference — e.g. by
+    leaking the injected boolean into its output — would make the real
+    assertion pass while the deployed value was still shared."""
+    probe = '"X=88"'
+    assert _eval(probe, True) == _eval(probe, False) == "X=88"
+
+
+def test_the_deployed_threshold_differs_between_the_two_hosts():
+    """🔴 THE POINT OF THE FILE. One shared value is what stranded the laptop's
+    local edit and blocked ship.sh; if these two ever collapse to one string
+    again, that recurs."""
+    expr = _deployed_expression()
+    laptop = _eval(expr, True)
+    workbench = _eval(expr, False)
+    assert laptop != workbench, (
+        "CPU_MON_TEMP_THRESHOLD resolves to %r on BOTH hosts. It is a single "
+        "shared value again — the laptop will carry its own threshold as an "
+        "uncommitted edit and every ship.sh fast-forward to it will be skipped "
+        "(rc 7)." % laptop)
+
+
+def test_each_host_gets_its_own_measured_threshold():
+    expr = _deployed_expression()
+    assert _eval(expr, True) == "CPU_MON_TEMP_THRESHOLD=" + LAPTOP_TEMP_THRESHOLD
+    assert _eval(expr, False) == "CPU_MON_TEMP_THRESHOLD=" + WORKBENCH_TEMP_THRESHOLD
+
+
+def test_the_workbench_keeps_the_EARLIER_warning():
+    """Direction guard. `isLaptop` is a backlight probe and fails OPEN — an
+    unrecognised host evaluates false. That is only acceptable while the false
+    branch is the LOWER (earlier-warning) number; inverting the arms would give
+    every unknown host a silently laxer threshold."""
+    assert int(WORKBENCH_TEMP_THRESHOLD) < int(LAPTOP_TEMP_THRESHOLD)
+    expr = _deployed_expression()
+    assert int(_eval(expr, False).split("=")[1]) < int(_eval(expr, True).split("=")[1])
+
+
+def test_home_nix_still_binds_isLaptop_to_the_backlight_probe():
+    """INVARIANT GUARD (not regression coverage — it did not fail before this
+    change). The tests above INJECT `isLaptop`; production gets it from the
+    `let` block. If that binding is renamed or removed, `home.nix` breaks while
+    every assertion here stays green over an expression nothing can evaluate."""
+    src = HOME_NIX.read_text()
+    assert re.search(
+        r'^\s*isLaptop = builtins\.pathExists "/sys/class/backlight/', src, re.M), (
+        "nix/home.nix no longer binds `isLaptop` to the backlight probe. The "
+        "CPU_MON_TEMP_THRESHOLD expression references that name, and this "
+        "file's harness injects it — so the seam is now unverified.")
+    assert "isLaptop" in _deployed_expression(), (
+        "the CPU_MON_TEMP_THRESHOLD expression no longer references isLaptop, "
+        "so this file is pinning a discriminator the deployed value ignores.")

--- a/scripts/tests/test_cpu_monitor_temp_threshold.py
+++ b/scripts/tests/test_cpu_monitor_temp_threshold.py
@@ -135,10 +135,19 @@ def test_the_workbench_keeps_the_EARLIER_warning():
 
 
 def test_home_nix_still_binds_isLaptop_to_the_backlight_probe():
-    """INVARIANT GUARD (not regression coverage — it did not fail before this
-    change). The tests above INJECT `isLaptop`; production gets it from the
-    `let` block. If that binding is renamed or removed, `home.nix` breaks while
-    every assertion here stays green over an expression nothing can evaluate."""
+    """Two halves, with two different statuses — stated so neither is
+    over-claimed.
+
+    The first assertion is an INVARIANT GUARD: `isLaptop` was already bound to
+    the backlight probe before this change, so it was green at base. It is here
+    because the tests above INJECT `isLaptop`; a rename in `home.nix` would
+    break production while every assertion in this file stayed green over an
+    expression nothing can evaluate.
+
+    The second is REGRESSION COVERAGE: at base the deployed expression was the
+    bare literal `"CPU_MON_TEMP_THRESHOLD=88"` and did not mention `isLaptop`
+    at all, so it was RED there.
+    """
     src = HOME_NIX.read_text()
     assert re.search(
         r'^\s*isLaptop = builtins\.pathExists "/sys/class/backlight/', src, re.M), (


### PR DESCRIPTION
## The problem is the SHAPE, not the number

`nix/home.nix` had a single shared line inside `systemd.user.services.cpu-monitor`:

```nix
# This laptop runs hot at idle (cooling needs attention); warn early.
"CPU_MON_TEMP_THRESHOLD=88"
```

Host-specific prose attached to a host-agnostic value. The laptop therefore carried
`88 -> 92` as an **uncommitted local edit**, which blocked **every** `ship.sh`
fast-forward to that host with **rc 7** — the documented *"a skipped host silently
stops receiving every future change while still looking healthy"* failure. It was
found only because an unrelated ship happened to run.

So the fix is not "set it to 92" (that moves the workbench too). A value that can only
be spelled once is a value that gets re-edited locally and blocks the ship again.
**Making the difference expressible is what stops the recurrence.**

## Mechanism: `isLaptop` — already in this file, not introduced here

```nix
"CPU_MON_TEMP_THRESHOLD=${if isLaptop then "92" else "88"}"
```

`isLaptop = builtins.pathExists "/sys/class/backlight/intel_backlight"` is defined in
this file's `let` block (`nix/home.nix:144`) and evaluated per-host under `--impure`.
Already used at `nix/home.nix:202` (`_module.args.isLaptop`, threaded into
`graphical.nix` for battery/backlight vs rig-control/DDC) and at `nix/home.nix:4296`
(`ASIB_HOST=${if isLaptop then "laptop" else "workbench"}-%m`) — the same
`if isLaptop then … else …` shape this change uses.

**Not `serverMode`**: that is an operator-role marker (`~/.server-mode`), and keying on
it would give every non-workbench host the **higher, laxer** threshold.

`isLaptop` fails **OPEN** — the documented reason the keylog-ptrace and backup-prefix
sites had to reject it. That direction is **benign here**: an unrecognised host
evaluates `false` and gets **88**, the lower/earlier-warning number, i.e. exactly
today's shipped behaviour. The failure mode is more alerting, never a silently laxer
threshold. A test pins that direction so inverting the arms goes red.

## Evidence

**Both values resolve** — expression read out of the file, not restated:

```
expr : "CPU_MON_TEMP_THRESHOLD=${if isLaptop then "92" else "88"}"
isLaptop=true  (laptop)    -> "CPU_MON_TEMP_THRESHOLD=92"
isLaptop=false (workbench) -> "CPU_MON_TEMP_THRESHOLD=88"
```

Live probe on the workbench: `/sys/class/backlight` is empty, `pathExists` -> `false`
-> **88**. No behaviour change on the workbench.

`nix-instantiate --parse nix/home.nix` : **OK**.

**Red at base `a451abc0`** (`scripts/tests/test_cpu_monitor_temp_threshold.py` copied
onto a detached worktree at that sha): **4 failed, 2 passed**. The 2 that passed are
the harness controls, which must pass at base. Green at HEAD: **6 passed**.
Related suites unaffected: `test_cpu_monitor_ignore` + `test_cpu_monitor_volume` +
`test_bar_status` = **557 passed**.

**Mutation battery** (isolated `git archive` copy, no shared `.git`,
`PYTHONDONTWRITEBYTECODE=1`, control green before and after). Every mutant died on the
**intended test's own assertion**, at its own line:

| # | mutant | verdict | killed by |
|---|---|---|---|
| control | unmutated | 6 passed | — |
| M1 | both arms `88` (the "same value on both hosts" mode) | **KILLED** | `..._differs_between_the_two_hosts` — *"resolves to … on BOTH hosts"* (L114) |
| M2 | arms **swapped** (laptop 88 / workbench 92) | **KILLED** | `..._each_host_gets_its_own_...` (L123) + direction guard `assert 92 < 88` (L134). The "differ" test correctly **passed** — the values do differ — so no test kills for the wrong reason |
| M3 | conditional removed, bare literal (= base) | **KILLED** | 4 tests, matching the red-at-base result exactly |
| M4 | a **second live** `CPU_MON_TEMP_THRESHOLD` line after a correct-looking first one (systemd last-wins -> 88 on both) | **KILLED** | the extraction guard's own *"expected exactly one … found 2"* (L60) |

## Tests

New `scripts/tests/test_cpu_monitor_temp_threshold.py` reads the deployed expression
out of `nix/home.nix` (never restates it) and evaluates it under injected
`isLaptop=true/false` via `nix-instantiate --eval`. It carries:

- a **positive control** (the eval harness can return two different strings),
- a **negative control** (it reports SAME for a constant — so a harness fabricating a
  difference cannot green the real assertion),
- a **direction guard** pinning the fail-open branch to the lower number,
- a **seam guard** on the `isLaptop` binding the harness injects. Its two assertions
  are labelled separately in the docstring: the binding half is an **invariant guard**
  (green at base); the "expression references `isLaptop`" half is **regression
  coverage** (red at base).

`nix-instantiate` missing is a `pytest.fail`, not a skip — a skip is how a conditional
silently collapses back to one shared value.

## Subsumes `laptop/cpu-mon-temp-92`

Branch `laptop/cpu-mon-temp-92` (`44ebd9c6`) preserved the raw laptop edit and its
message explicitly deferred this decision ("Needs either that agreement or a
host-conditional split"). It sets the **shared** line to `92`, which would raise the
workbench too. This PR gives the laptop the 92 it wanted while leaving the workbench at
88, so **that branch should be deleted once this merges** — it is not in `main` (verified
by content: `origin/main:nix/home.nix` still reads the shared `88`), and landing it after
this would reintroduce the shared value.

## Not run here (owner's gate)

`nix build .#checks…`, `scripts/gate.sh` and `home-manager switch` were deliberately not
run — the coordinator owns the gate and the deploy. Note `nix/home.nix` has **not moved**
between base `a451abc0` and `origin/main` (`aa155d53`), but three open PRs touch this
file, so the **merged-tree** run is still the gate that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
