### PR TITLE
fix(handoff-index): a repo this run could not read IN FULL is not a repo it may DELETE

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -2997,7 +2997,25 @@ in
         # frozen — a permanently-red gate, which trains everyone to click
         # through. It now refuses only when ALL repos are unmeasured, when the
         # measured subset yields zero rows, or when `--prune` (never passed
-        # here) meets an unmeasured repo.
+        # here) meets an INCOMPLETE repo.
+        # 🔴 THE THIRD CONDITION SAYS *INCOMPLETE*, NOT *UNMEASURED*, AND THE
+        # WIDENING IS REAL: a repo whose mainline lists a doc `git show` cannot
+        # produce resolves fine and is not unmeasured, yet a run that could not
+        # read it in full may not delete its rows. This sentence read
+        # `unmeasured` for one commit after the code had moved.
+        # 🔴 AND A FOURTH STATE EXISTS THAT IS *NOT* A REFUSAL — the one this
+        # host is most likely to reach. When NOT ONE configured repo was read in
+        # full (say three absent checkouts plus one corrupt blob) the delete
+        # scope is EMPTY, so the run DOWNGRADES to a plain upsert: it writes
+        # every row that did read, deletes nothing, prints `🔴 REBUILD
+        # DOWNGRADED TO AN UPSERT` plus the PARTIAL warning, and exits 0. That
+        # is deliberate rather than lenient — it was a refusal for exactly one
+        # commit, and on this unit's own argv that refusal turned "index
+        # refreshed, standing warning" into "nothing written, toast every 6h
+        # until a human repairs an object store", i.e. the permanently-red gate
+        # again, in a state the paragraph above calls SUPPORTED. The cost it
+        # does buy: with no DELETE, a section REMOVED from a doc keeps its stale
+        # row until some repo reads in FULL again.
       ] ++ lib.mapAttrsToList (n: v: "${n}=${v}")
         (import ./agent-handles.nix { home = "%h"; }).repos;
       # nix-shell pulls psycopg2 (the _db.py write path). git/kubectl come from

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3015,9 +3015,34 @@ in
         # commit, and on this unit's own argv that refusal turned "index
         # refreshed, standing warning" into "nothing written, toast every 6h
         # until a human repairs an object store", i.e. the permanently-red gate
-        # again, in a state the paragraph above calls SUPPORTED. The cost it
-        # does buy: with no DELETE, a section REMOVED from a doc keeps its stale
-        # row until some repo reads in FULL again.
+        # again, in a state the paragraph above calls SUPPORTED.
+        # 🔴 AND THE COST IT DOES BUY IS WHOLE DOCUMENTS, NOT A TRAILING
+        # ORDINAL. This paragraph used to describe the residue as one removed
+        # section's stale row (the dead wording is not repeated here — a test
+        # bans it), which reads as trailing-ordinal drift and understates the
+        # blast radius: the DELETE is per-repo-LABEL and the upsert key is
+        # (repo, slug, section, ordinal). Nothing is LOST — the stale half is
+        # simply a corpus queries still answer FROM. The next sentence is
+        # `handoff_index.DOWNGRADE_COST` VERBATIM: one constant, three surfaces
+        # (this comment and the module's two printers), pinned as a whole
+        # normalised string by
+        # test_the_home_nix_cost_paragraph_IS_the_sentence_the_run_prints. Do
+        # not re-word it here — edit the constant and this comment together, or
+        # the suite fails.
+        #
+        # EVERY row this run did not re-derive persists until some repo reads in
+        # FULL again — not just a section removed from a doc, but ALL rows of a
+        # doc DELETED from the repo, and for a RENAMED doc both the old and the
+        # new slug's rows, which a search returns side by side as two documents.
+        # ⚠ A DOWNGRADED RUN EXITS 0 AND THIS UNIT HAS NO `SuccessExitStatus` BY
+        # DESIGN. A distinct rc (drift-check's rc 16 idiom) was considered and
+        # rejected: this file is switch-delivered while `handoff_index.py` is
+        # git-delivered (the unit's start command below runs the WORKING TREE
+        # copy of it), so the two
+        # would skew on a pull-without-switch and put the unit back to a failure
+        # toast 4x/day in the state this very paragraph calls SUPPORTED. The
+        # machine-readable channel is `--json`'s `rebuild_would_be_downgraded`.
+        # See `main`'s note at the downgrade site.
       ] ++ lib.mapAttrsToList (n: v: "${n}=${v}")
         (import ./agent-handles.nix { home = "%h"; }).repos;
       # nix-shell pulls psycopg2 (the _db.py write path). git/kubectl come from

--- a/scripts/lib/handoff_index.py
+++ b/scripts/lib/handoff_index.py
@@ -118,8 +118,11 @@ CONTRACT SUMMARY
     identity_collisions(rows)                 -> tuple[str, ...]        PURE
     unset_repo_handles(env=None)              -> tuple[str, ...]
     prune_config_refusal(unset)               -> str | None             PURE
+    incomplete_kind(derivation)               -> str | None             PURE
     incomplete_reason(derivation)             -> str | None             PURE
     may_replace_stored_rows(derivation)       -> bool                   PURE
+    authority_label_collisions(derivations)   -> tuple[str, ...]        PURE
+    rebuild_downgrade_reason(derivations)     -> str | None             PURE
     rebuild_refusal(derivations, rows, ..)    -> str | None             PURE
     partial_scope_warnings(derivations)       -> tuple[str, ...]        PURE
     rebuild_delete_labels(derivs, stored, ..) -> tuple[str, ...]        PURE
@@ -197,8 +200,14 @@ __all__ = [
     "identity_collisions",
     "unset_repo_handles",
     "prune_config_refusal",
+    "INCOMPLETE_KINDS",
+    "INCOMPLETE_UNMEASURED",
+    "INCOMPLETE_UNREADABLE",
+    "incomplete_kind",
     "incomplete_reason",
     "may_replace_stored_rows",
+    "authority_label_collisions",
+    "rebuild_downgrade_reason",
     "rebuild_refusal",
     "partial_scope_warnings",
     "rebuild_delete_labels",
@@ -1622,6 +1631,44 @@ def import_maildb():
 # --------------------------------------------------------------------------- #
 
 
+#: 🔴 THE ENUMERATED KINDS OF INCOMPLETENESS. They are constants rather than
+#: literals at each site because `rebuild_plan_lines` PARTITIONS the configured
+#: repos on this value, and a partition keyed on a string literal silently loses
+#: a repo the day a third kind is added: it matches no branch, appears in no
+#: bucket, and the operator counts the labels, finds one missing, and has no way
+#: to learn why. `incomplete_kinds_are_partitioned` is the check that says so
+#: instead.
+INCOMPLETE_UNMEASURED = "unmeasured"
+INCOMPLETE_UNREADABLE = "docs-unreadable"
+INCOMPLETE_KINDS = (INCOMPLETE_UNMEASURED, INCOMPLETE_UNREADABLE)
+
+
+def incomplete_kind(d: RepoDerivation) -> str | None:
+    """WHICH KIND of incompleteness withholds authority over `d.label` — or `None`.
+
+    🔴 THE KIND IS SPLIT OUT OF `incomplete_reason` BECAUSE ONE CONSUMER NEEDS TO
+    BRANCH ON IT AND WAS RE-DERIVING IT FROM THE RAW FIELDS. `rebuild_plan_lines`
+    sorts every configured repo into three buckets, and it read
+    `d.unmeasured is not None` for one and `d.unmeasured is None and d.unreadable`
+    for the other — the exact "predicate open-coded at N sites" shape
+    `incomplete_reason`'s own docstring says the four spellings came from, still
+    present at the one site that most needed it. Recovering the kind by matching
+    on the REASON STRING would be worse again: the reason for an unmeasured repo
+    is `d.unmeasured` itself, a free-form token, so any such match is a guard on
+    WORDS.
+
+    So the kind is the structural value and the reason is derived FROM it. A
+    third kind therefore has exactly one place to be added, and
+    `rebuild_plan_lines` reports an unenumerated one rather than dropping it.
+
+    PURE."""
+    if d.unmeasured:
+        return INCOMPLETE_UNMEASURED
+    if d.unreadable:
+        return INCOMPLETE_UNREADABLE
+    return None
+
+
 def incomplete_reason(d: RepoDerivation) -> str | None:
     """WHY this run cannot speak for `d.label`'s stored rows — `None` if it can.
 
@@ -1679,13 +1726,14 @@ def incomplete_reason(d: RepoDerivation) -> str | None:
     was read buys nothing the delete scope does not already buy.
 
     PURE, so the whole authority decision is testable without a database."""
-    if d.unmeasured:
+    kind = incomplete_kind(d)
+    if kind is None:
+        return None
+    if kind == INCOMPLETE_UNMEASURED:
         return d.unmeasured
-    if d.unreadable:
-        # The counts are in the reason because "1 of 40" and "40 of 40" are very
-        # different operator situations and the label alone cannot say which.
-        return f"docs-unreadable ({len(d.unreadable)} of {len(d.unreadable) + d.docs})"
-    return None
+    # The counts are in the reason because "1 of 40" and "40 of 40" are very
+    # different operator situations and the label alone cannot say which.
+    return f"docs-unreadable ({len(d.unreadable)} of {len(d.unreadable) + d.docs})"
 
 
 def may_replace_stored_rows(d: RepoDerivation) -> bool:
@@ -1695,6 +1743,104 @@ def may_replace_stored_rows(d: RepoDerivation) -> bool:
     question the DELETE actually asks. Never re-derive either of these from the
     underlying fields — see `incomplete_reason`'s note on the four spellings."""
     return incomplete_reason(d) is None
+
+
+def authority_label_collisions(
+    derivations: Sequence[RepoDerivation],
+) -> tuple[str, ...]:
+    """Labels claimed by BOTH a replaceable derivation and an incomplete one. PURE.
+
+    🔴 AUTHORITY IS DEMONSTRATED PER *DERIVATION* AND EXERCISED PER *LABEL*, AND
+    THOSE ARE NOT THE SAME KEY. `rebuild_delete_labels` returns LABELS and
+    `DELETE_SQL` binds LABELS, so when two derivations share one label — the
+    `~/a/proj` vs `~/b/proj` case `identity_collisions` names explicitly — a
+    single healthy twin grants authority over BOTH twins' rows.
+
+    MEASURED, two checkouts named `protorepo` under different parents, the right
+    one's doc blobs removed, `--rebuild --write`: `DELETE params
+    [[['protorepo']]]`, 21 INSERTs all from the healthy twin, rc 0 — the broken
+    twin's rows deleted with nothing to replace them. Identical before the
+    incomplete-read widening, so this is not a regression it introduced.
+    `identity_collisions` cannot see it either: unreadable docs produce no
+    sections, so nothing collides at the SECTION level.
+
+    ⚠ THIS FUNCTION DOES NOT FIX THAT. The structural fix — keying authority on
+    something a label cannot alias — moves the delete scope, the stored key and
+    `handoff_search`'s scoping together, and is its own round. What it fixes is
+    the REPORT: without it this run printed "Their existing rows are left
+    untouched … this run destroyed nothing it could not replace" and "kept their
+    old rows" ABOUT ROWS IT HAD JUST DELETED, and listed the label under both
+    DELETE and KEPT in the pre-flight. A silent wrong is better than a stated
+    wrong: a stated wrong is what stops the next reader looking."""
+    ok = {d.label for d in derivations if may_replace_stored_rows(d)}
+    bad = {d.label for d in derivations if incomplete_reason(d)}
+    return tuple(sorted(ok & bad))
+
+
+def rebuild_downgrade_reason(
+    derivations: Sequence[RepoDerivation],
+) -> str | None:
+    """WHY a `--rebuild` must drop its DELETE and write as a plain upsert. PURE.
+
+    🔴 A DOWNGRADE RATHER THAN A REFUSAL, AND THE DIFFERENCE IS A TOAST 4×/DAY
+    FOREVER. When not ONE configured repo was read in full the delete scope is
+    EMPTY, and `PostgresSectionStore.write` RAISES on an empty rebuild scope by
+    design — so this state has to be handled somewhere. The round that found it
+    made it `rebuild_refusal`'s fourth arm, rc 4. MEASURED on the TIMER's own
+    argv (`--rebuild --write`, unscoped) with 1 of 4 handles present and the
+    present repo carrying ONE corrupt blob of three docs, across three commits of
+    one file:
+
+        pre-widening : rc 0  DELETE ['<label>'] + 18 INSERTs
+        that arm     : rc 4  SQL kinds []        nothing written at all
+        here         : rc 0  no DELETE           + 18 INSERTs
+
+    Three absent checkouts is not a broken machine: `nix/home.nix` states in as
+    many words that a handle pointing at an absent checkout is SUPPORTED, and
+    that the price is a standing PARTIAL warning. `OnFailure=notify-failure@%n
+    .service` on a 6h timer then fires until a human repairs an object store, and
+    the index goes stale meanwhile — `claude/RULES.md`'s permanently-red gate,
+    which is the mistake `rebuild_refusal`'s own all-unmeasured arm had to unwind
+    once already.
+
+    🔴 AND THE FALLBACK IS NOT AN INVENTION — IT IS THE REMEDY THE REFUSAL ITSELF
+    NAMED. That arm's text ended "Re-running WITHOUT --rebuild is a real remedy
+    here: it upserts those N row(s) and deletes nothing." A remedy only a human
+    can type is not a remedy for a unit, so the run takes it: rebuild off,
+    delete scope empty, every row that DID read upserted. It is strictly
+    non-destructive — an ON CONFLICT insert refreshes without destroying — so
+    downgrading cannot lose a row the refusal would have kept.
+
+    ⚠ WHAT THE DOWNGRADE DOES NOT BUY, STATED RATHER THAN DISCOVERED: a section
+    REMOVED from a doc keeps its stale high-ordinal row, because that is exactly
+    what the DELETE is for (`PostgresSectionStore.write`'s closing note). The run
+    says so, and says it on the success line, because "wrote N section row(s)"
+    otherwise reads as a completed rebuild.
+
+    Returns `None` when the rebuild may keep its DELETE. It is `main`'s SINGLE
+    spelling of that decision — the scope is computed only when this returns
+    `None` — so an empty scope can never reach `write()` and the two cannot
+    drift. `TestARebuildWithNothingReadInFullIsDowngradedNotRefused` pins the
+    equivalence against `rebuild_delete_labels`' actual return."""
+    if not derivations:
+        return None
+    if any(may_replace_stored_rows(d) for d in derivations):
+        return None
+    detail = ", ".join(f"{d.label} ({incomplete_reason(d)})" for d in derivations)
+    return (
+        f"REBUILD DOWNGRADED TO AN UPSERT: not ONE of the {len(derivations)} "
+        f"repo(s) was read COMPLETELY — {detail}. A rebuild DELETES a repo's rows "
+        f"before re-deriving them, so it may only run for repos this run can "
+        f"REPLACE, and there are none: the delete scope would be EMPTY. This is "
+        f"NOT 'the corpus is empty' — the documents that DID read are still "
+        f"upserted, and an ON CONFLICT insert REFRESHES without destroying, so "
+        f"NOTHING was deleted and no stored row was lost. What the skipped DELETE "
+        f"would have bought and this run does not: a section REMOVED from a doc "
+        f"keeps its stale row until some repo reads in FULL again. Where the "
+        f"reason is a doc that would not read, `git ls-tree` lists a path `git "
+        f"show` cannot produce, which means an incomplete object store — try "
+        f"`git fsck` and re-fetch."
+    )
 
 
 def rebuild_refusal(
@@ -1784,6 +1930,27 @@ def rebuild_refusal(
     # in `bad` and this guard is structurally blind to it. The narrowest configs
     # yield zero unmeasured repos, i.e. this guard is weakest exactly where the
     # risk is highest. `main` runs the config-width guard first.
+    #
+    # 🔴 THE OPENER IS A DISJUNCTION ("UNMEASURED or INCOMPLETE") RATHER THAN A
+    # CONDITIONAL, so it is true in every state this arm fires in and there is no
+    # second spelling to drift. The per-repo `detail` carries which of the two it
+    # actually was, which is the fact the operator acts on.
+    #
+    # 🔴 AND THE TWO HALVES OF THE DISJUNCTION ARE REFUSED FOR TWO DIFFERENT
+    # REASONS, WHICH THE MESSAGE HAS TO SAY RATHER THAN COLLAPSE. The widening
+    # first shipped claiming an unreadable repo is "refused for the same reason it
+    # is kept out of the delete scope: this run has nothing to put back". That is
+    # false twice: `--prune` never puts back the disappeared labels' rows — it
+    # exists to delete them — and the incomplete repo is already outside
+    # `measured`, so its OWN rows are safe with or without this arm. The renamed
+    # -checkout ambiguity the arm was built for cannot arise from an unreadable
+    # doc either: the ref resolved, the directory is present, the label is
+    # unchanged. The real reason is narrower and is worth stating plainly — a run
+    # that could not read its own corpus in FULL cannot vouch for the corpus at
+    # all, and `--prune` is the one act whose scope is decided by what this run
+    # did NOT find. Being conservative on a destructive operator flag is cheap;
+    # `--prune` is typed by a human and is never in the unit's argv, so this arm
+    # cannot become the permanently-red gate the ALL-unmeasured arm nearly did.
     if prune and bad:
         detail = ", ".join(f"{d.label} ({incomplete_reason(d)})" for d in bad)
         return (
@@ -1793,15 +1960,14 @@ def rebuild_refusal(
             f"every repo is the table's spelling; an unmeasured repo (a renamed or "
             f"missing checkout) is precisely where those can differ, and the rows it "
             f"would collect may be that same repo under its old label. A repo whose "
-            f"docs would not READ is refused for the same reason it is kept out of the "
-            f"delete scope: this run has nothing to put back. Fix the handles and the "
-            f"object store so every repo reads in FULL, then re-run --prune — or drop "
-            f"--prune, which deletes only what this run read COMPLETELY."
+            f"docs would not READ is refused for a DIFFERENT reason, stated so it is "
+            f"not mistaken for that one: it raises no spelling ambiguity and its own "
+            f"rows are already safe, but --prune decides what to DESTROY from what "
+            f"this run did NOT find, and a run that could not read its corpus in FULL "
+            f"cannot vouch for the corpus at all. Fix the handles and the object store "
+            f"so every repo reads in FULL, then re-run --prune — or drop --prune, "
+            f"which deletes only what this run read COMPLETELY."
         )
-    # 🔴 THE OPENER IS A DISJUNCTION ("UNMEASURED or INCOMPLETE") RATHER THAN A
-    # CONDITIONAL, so it is true in every state this arm fires in and there is no
-    # second spelling to drift. The per-repo `detail` carries which of the two it
-    # actually was, which is the fact the operator acts on.
     if derivations and len(unmeasured) == len(derivations):
         detail = ", ".join(f"{d.label} ({d.unmeasured})" for d in unmeasured)
         return (
@@ -1821,36 +1987,17 @@ def rebuild_refusal(
             "corpus is empty' — it is a corpus that could not be read. Nothing is "
             "deleted and nothing is written."
         )
-    # 🔴 THE ARM THAT MAKES AN EMPTY DELETE SCOPE A REFUSAL RATHER THAN A CRASH.
-    # It fires when NOT ONE repo was read in full — the arms above have already
-    # taken the all-unmeasured and zero-rows cases, so reaching here means at
-    # least one repo resolved AND contributed rows AND still could not be
-    # replaced, i.e. every repo is partially readable. Before `incomplete_reason`
-    # widened the scope predicate, "not every repo is unmeasured" implied "at
-    # least one label is in the delete scope"; it no longer does, and
-    # `PostgresSectionStore.write` RAISES on an empty rebuild scope by design. A
-    # traceback out of the 6h timer is a worse report than a refusal that names
-    # the repos and a remedy.
-    #
-    # 🔴 THE REMEDY IS TRUE BECAUSE OF THE ORDERING, NOT BECAUSE IT WAS ASSERTED.
-    # "Re-run without --rebuild and it writes" is exactly the sentence the
-    # all-unmeasured arm above had to retract as FALSE in its own state. Here the
-    # zero-rows arm has already returned for every derivation with no rows, so
-    # `rows` is non-empty by construction and the row count is printed from it.
-    if derivations and len(bad) == len(derivations):
-        detail = ", ".join(f"{d.label} ({incomplete_reason(d)})" for d in bad)
-        return (
-            f"REFUSING --rebuild: not ONE of the {len(derivations)} repo(s) was read "
-            f"COMPLETELY — {detail}. A rebuild DELETES a repo's rows before "
-            f"re-deriving them, so it may only run for repos this run can REPLACE, "
-            f"and there are none: the delete scope would be EMPTY. This is NOT 'the "
-            f"corpus is empty' — {len(rows)} row(s) WERE derived, from the documents "
-            f"that did read. Where the reason is a doc that would not read, `git "
-            f"ls-tree` lists a path `git show` cannot produce, which means an "
-            f"incomplete object store — try `git fsck` and re-fetch. Re-running "
-            f"WITHOUT --rebuild is a real remedy here: it upserts those "
-            f"{len(rows)} row(s) and deletes nothing."
-        )
+    # 🔴 "NOT ONE REPO WAS READ IN FULL" IS DELIBERATELY *NOT* AN ARM HERE, AND IT
+    # WAS ONE FOR EXACTLY ONE COMMIT. Reaching this point means at least one repo
+    # resolved AND rows came back, but possibly no repo is REPLACEABLE — which
+    # makes the delete scope empty, and `PostgresSectionStore.write` RAISES on an
+    # empty rebuild scope by design. Refusing was the first answer and it was
+    # wrong for the TIMER: measured on the unit's own argv with three absent
+    # checkouts (a state `nix/home.nix` documents as SUPPORTED) plus one corrupt
+    # blob, it turned rc 0 + a written index into rc 4 + nothing written, i.e. a
+    # notify-failure toast every 6h until a human repairs an object store.
+    # `rebuild_downgrade_reason` takes the remedy this arm's own text named —
+    # write, but without the DELETE — and `main` reads it. See that function.
     return None
 
 
@@ -1879,7 +2026,7 @@ def partial_scope_warnings(derivations: Sequence[RepoDerivation]) -> tuple[str, 
 
     It is true now, and true STRUCTURALLY rather than by inspection: the
     disappeared-set is behind an explicit `--prune`, and `rebuild_refusal`
-    refuses any `--prune` run with an unmeasured repo. So whenever this warning
+    refuses any `--prune` run with an INCOMPLETE repo. So whenever this warning
     fires AND a write happens, the delete scope is exactly the MEASURED labels.
     `TestThePartialPromiseIsKept` pins that as a relationship between the two
     functions rather than trusting either one's own docstring.
@@ -1897,23 +2044,70 @@ def partial_scope_warnings(derivations: Sequence[RepoDerivation]) -> tuple[str, 
     one, which contributes every row it could read (an ON CONFLICT insert
     refreshes without destroying, so there is no reason to throw those away).
     Keeping the phrase would have made this warning false in exactly the state it
-    was widened to cover."""
+    was widened to cover.
+
+    🔴 THE ALL-BAD SHORT-CIRCUIT IS GONE, AND ITS REMOVAL IS A CORRECTION TO A
+    CLAIM MADE ONE COMMIT AGO. `rebuild_delete_labels` says this function "says so
+    on every output path"; it did not. It returned `()` when EVERY repo was
+    incomplete and deferred to `rebuild_refusal` — which `main` consults only
+    under `--rebuild`. MEASURED on HEAD, two repos each with one unreadable doc,
+    `--write` WITHOUT `--rebuild`: `partial_scope_warnings() == ()`, `wrote 24
+    section row(s)`, rc 0, and the word PARTIAL nowhere on stdout. The hole
+    pre-dated the widening; the CLAIM did not, and a false claim is the sentence
+    that stops the next person looking. It is now a WRITING state besides, since
+    `rebuild_downgrade_reason` proceeds where the fourth refusal arm stopped, so
+    silence there is not a deferral to anything.
+
+    The old worry — saying it twice in two voices is how one of them stops being
+    read — is answered by making the two say different things: this one is a
+    SCOPE statement ("no repo's rows were replaced"), the refusal is a REFUSAL
+    with a remedy, and the all-bad variant below cannot be mistaken for the mixed
+    one because it names no `ok` list at all.
+
+    🔴 THE "LEFT UNTOUCHED" PROMISE IS CONDITIONAL, BECAUSE AUTHORITY IS PER
+    DERIVATION AND THE DELETE IS PER LABEL. Two configured repos can share one
+    label (`~/a/proj` and `~/b/proj`), and a healthy twin then grants a DELETE
+    over the broken twin's rows. See `authority_label_collisions`, which is the
+    residual this qualification exists to stop MIS-STATING."""
     bad = [d for d in derivations if incomplete_reason(d)]
-    if not bad or len(bad) == len(derivations):
-        # All-bad is `rebuild_refusal`'s case, not this one; saying it twice in two
-        # voices is how one of them stops being read.
+    if not bad:
+        # A per-run "0 repos missing" buries the real ones — `untracked_warnings`'
+        # reason. This is the ONLY suppression left.
         return ()
     detail = ", ".join(f"{d.label} ({incomplete_reason(d)})" for d in bad)
     ok = ", ".join(d.label for d in derivations if may_replace_stored_rows(d))
+    shared = authority_label_collisions(derivations)
+    kept = (
+        "Their existing rows are left untouched (the rebuild delete is scoped to "
+        "what was read in FULL), so this run destroyed nothing it could not "
+        "replace."
+        if not shared else
+        f"🔴 EXCEPT WHERE A LABEL IS SHARED: {', '.join(shared)} is ALSO produced "
+        f"by a derivation that WAS read in full, and the delete binds LABELS, not "
+        f"derivations — so those rows ARE deleted and replaced by the other "
+        f"checkout's alone. Every OTHER named repo's rows are left untouched (the "
+        f"rebuild delete is scoped to what was read in FULL)."
+    )
+    if not ok:
+        return (
+            f"🔴 NOTHING WAS READ COMPLETELY — all {len(derivations)} configured "
+            f"repo(s) were incomplete, so this run speaks for none of them: "
+            f"{detail}. No repo's stored rows were replaced: with nothing read in "
+            f"FULL the delete scope is EMPTY, so a --rebuild is DOWNGRADED to a "
+            f"plain upsert and a plain run never deletes — every stored row is "
+            f"either refreshed by a document that DID read or left exactly as it "
+            f"was. An unscoped "
+            f"query's silence is NOT evidence these repos are silent, and a "
+            f"section REMOVED from a doc keeps its stale row until some repo "
+            f"reads in FULL again.",
+        )
     return (
         f"🔴 PARTIAL INDEX — {len(bad)} of {len(derivations)} configured repo(s) "
         f"were NOT read completely, so this run does not speak for them: {detail}. "
         f"Read in FULL, and therefore rebuilt, covers only: {ok}. A query scoped to "
         f"a repo that contributed nothing will return an EMPTY "
         f"SCOPE, and an unscoped query's silence is NOT evidence those repos are "
-        f"silent. Their existing rows are left untouched (the rebuild delete is "
-        f"scoped to what was read in FULL), so this run destroyed nothing it could "
-        f"not replace.",
+        f"silent. " + kept,
     )
 
 
@@ -1986,14 +2180,16 @@ def rebuild_delete_labels(
         `rebuild_refusal`'s
         partial-tolerance safe: the absent `$CIVITAI` keeps its rows.
       * `prune` — an operator act, never the timer's. `rebuild_refusal` refuses a
-        `--prune` run in which ANY repo came back unmeasured, which is what makes
-        the two-spellings collision above unreachable: it REQUIRES a
-        configured-but-unmeasured label.
+        `--prune` run in which ANY repo came back INCOMPLETE — unmeasured OR
+        holding a doc that would not read; the arm widened with the scope
+        predicate and this bullet said `unmeasured` for one commit after it did.
+        That is what makes the two-spellings collision above unreachable: it
+        REQUIRES a configured-but-unmeasured label.
 
     🔴 THE INVARIANT THAT MAKES `partial_scope_warnings` TRUE: whenever that
-    warning fires (some repos measured, some did not) and the run is allowed to
+    warning fires (some repos read in full, some not) and the run is allowed to
     write, the returned scope is exactly `measured`. Scoped and default runs
-    return `measured` outright; a `--prune` run with any unmeasured repo never
+    return `measured` outright; a `--prune` run with any INCOMPLETE repo never
     reaches a write. Pinned as a seam test, not left as prose.
 
     🔴 THE EXPOSURE THAT USED TO BE RECORDED HERE IS CLOSED, AND CLOSING IT MOVED
@@ -2026,7 +2222,32 @@ def rebuild_delete_labels(
     PRESERVED, not lost, every readable doc is still upserted, and
     `partial_scope_warnings` says so on every output path — which is strictly the
     conservative direction. `--prune` additionally refuses while any repo is
-    incomplete, for the reason `rebuild_refusal`'s prune arm gives.
+    incomplete, for the reason `rebuild_refusal`'s prune arm gives. When NO repo
+    is replaceable this returns `()` and `rebuild_downgrade_reason` turns the run
+    into an upsert rather than letting `write` raise on the empty scope.
+
+    ⚠ "SAYS SO ON EVERY OUTPUT PATH" IS TRUE NOW AND WAS NOT WHEN IT WAS FIRST
+    WRITTEN. `partial_scope_warnings` returned `()` when EVERY repo was
+    incomplete, so a `--write` run without `--rebuild` printed no PARTIAL notice
+    at all. The suppression is gone; the claim is kept because it is now the
+    property, not because it was asserted.
+
+    🔴 THE RESIDUAL, RECORDED HERE RATHER THAN ONLY IN A REVIEW THREAD: THIS SCOPE
+    IS A SET OF *LABELS*, AND TWO DERIVATIONS CAN SHARE ONE. `may_replace_stored_
+    rows` is evaluated per DERIVATION; `DELETE_SQL` binds per LABEL. So
+    `--repo ~/left/protorepo --repo ~/right/protorepo` with the right twin's doc
+    blob removed yields scope `('protorepo',)` from the healthy twin and deletes
+    BOTH twins' rows, re-inserting only the healthy one's — MEASURED, rc 0.
+    `identity_collisions` does not catch it, because unreadable docs produce no
+    sections to collide.
+
+    ⚠ DELIBERATELY NOT FIXED IN THIS ROUND, and the reason is scope, not doubt:
+    keying authority on something a label cannot alias moves this scope, the
+    stored key and `handoff_search`'s `--repo` scoping together. What this round
+    DID fix is the false REPORT it produced — see `authority_label_collisions`.
+    Until then this is the honest statement of what the scope covers: a label one
+    checkout read in FULL is a label this run will DELETE, even where a DIFFERENT
+    checkout spells itself the same and could not be read.
 
     PURE, so the whole decision is testable without a database."""
     measured = {d.label for d in derivations if may_replace_stored_rows(d)}
@@ -2131,7 +2352,8 @@ def orphan_label_warning(labels: Sequence[str]) -> tuple[str, ...]:
 
 
 def rebuild_plan_lines(
-    derivations: Sequence[RepoDerivation], *, scoped: bool, prune: bool, write: bool
+    derivations: Sequence[RepoDerivation], *, scoped: bool, prune: bool, write: bool,
+    downgraded: bool = False,
 ) -> tuple[str, ...]:
     """What a `--rebuild` would DELETE, as far as this run can know it. PURE.
 
@@ -2188,18 +2410,71 @@ def rebuild_plan_lines(
     # in neither list, so a reader counts the labels, finds one missing, and has
     # no way to learn why. The pre-flight is the operator's only view of what a
     # run destroys, so a repo it silently omits is the same defect one layer up.
-    measured = tuple(sorted(d.label for d in derivations if may_replace_stored_rows(d)))
-    kept = tuple(sorted(d.label for d in derivations if d.unmeasured is not None))
+    #
+    # 🔴 AND THE BUCKETS ARE A PARTITION ON `incomplete_kind`, NOT THREE HAND-ROLLED
+    # PREDICATES OVER THE RAW FIELDS. This was the one consolidated site that still
+    # re-derived: `measured` went through `may_replace_stored_rows` while `kept`
+    # read `d.unmeasured is not None` and `incomplete` read `d.unmeasured is None
+    # and d.unreadable`. Teach `incomplete_reason` a THIRD kind — the case its own
+    # docstring says the design exists for — and a repo drops out of all three
+    # buckets while `partial_scope_warnings` still names it, so the plan and the
+    # warning disagree about the same run. Bucketing on the kind makes that
+    # impossible to write; the `unenumerated` line makes it impossible to hide.
+    by_kind: dict[str | None, list[RepoDerivation]] = {}
+    for d in derivations:
+        by_kind.setdefault(incomplete_kind(d), []).append(d)
+    measured = tuple(sorted(d.label for d in by_kind.get(None, ())))
+    kept = tuple(sorted(d.label for d in by_kind.get(INCOMPLETE_UNMEASURED, ())))
     incomplete = tuple(sorted(
         f"{d.label} ({incomplete_reason(d)})"
-        for d in derivations if d.unmeasured is None and d.unreadable))
+        for d in by_kind.get(INCOMPLETE_UNREADABLE, ())))
+    unenumerated = tuple(sorted(
+        f"{d.label} ({incomplete_reason(d)})"
+        for kind, ds in by_kind.items() if kind not in (None, *INCOMPLETE_KINDS)
+        for d in ds))
+    # 🔴 `downgraded` IS `main`'s ACTUAL DECISION, PASSED IN, NOT RE-DERIVED HERE.
+    # `measured` being empty is the same condition, and computing it twice is how
+    # a plan comes to describe a run that did not happen — the defect the
+    # gate-ordering note above records. It is a flag rather than a second call to
+    # `rebuild_downgrade_reason` for the reason `orphan_labels` takes the BOUND
+    # SCOPE rather than an `args.prune` flag: one decision, one owner.
+    header = (
+        "## rebuild delete scope — SKIPPED (the --rebuild is DOWNGRADED to an "
+        "upsert; NOTHING is deleted)" if downgraded else "## rebuild delete scope"
+    )
     out = [
-        "## rebuild delete scope",
+        header,
         f"  DELETE (read in FULL, will be re-derived): {', '.join(measured) or '(none)'}",
         f"  KEPT (configured but UNMEASURED): {', '.join(kept) or '(none)'}",
         f"  KEPT (resolved, but a doc would not READ — this run cannot replace "
         f"their rows): {', '.join(incomplete) or '(none)'}",
     ]
+    if unenumerated:
+        # The partition, asserted where an operator can see it rather than in a
+        # comment: a kind this plan does not enumerate must be REPORTED, never
+        # silently dropped out of all three buckets above.
+        out.append(
+            f"  🔴 KEPT (UNCLASSIFIED — `incomplete_kind` returned a kind this "
+            f"plan does not enumerate; the buckets above are NOT a complete view "
+            f"of this run): {', '.join(unenumerated)}"
+        )
+    shared = authority_label_collisions(derivations)
+    if shared:
+        # 🔴 THE ONE PLACE A LABEL CAN HONESTLY APPEAR IN TWO BUCKETS. Authority is
+        # demonstrated per DERIVATION and the DELETE binds LABELS, so a label two
+        # checkouts share is BOTH deleted (on the healthy twin's authority) and
+        # listed as kept (on the broken twin's). Listing it twice with no comment
+        # is the false report; naming the collision is the true one. See
+        # `authority_label_collisions` for why the underlying defect is its own
+        # round.
+        out.append(
+            f"  🔴 SHARED LABEL — {', '.join(shared)} appears ABOVE IN TWO "
+            f"BUCKETS because more than one configured checkout derives it, and "
+            f"only some of them were read in FULL. The DELETE binds the LABEL, so "
+            f"the rows of the checkout(s) that were NOT read are deleted too and "
+            f"replaced by the other's alone. Give the checkouts distinct "
+            f"directory names, or run them in separate --repo invocations."
+        )
     if scoped:
         # 🔴 A SCOPED RUN REPORTS NO ORPHANS EITHER, and saying so here is what
         # keeps this branch distinguishable from the no-prune one below. A mutant
@@ -2386,6 +2661,10 @@ def derivation_json(derivations: Sequence[RepoDerivation]) -> dict:
                 # and the DELETE cannot disagree.
                 "rebuildable": may_replace_stored_rows(d),
                 "incomplete_reason": incomplete_reason(d),
+                # The KIND alongside the reason, for the same reason the reason is
+                # here: the reason for an unmeasured repo is a free-form token, so
+                # a consumer that needs to BRANCH would otherwise match on words.
+                "incomplete_kind": incomplete_kind(d),
                 "disk_scan_complete": d.disk.complete,
                 "disk_paths_seen": len(d.disk.paths),
                 "disk_scan_errors": list(d.disk.errors),
@@ -2652,10 +2931,23 @@ def main(argv: Sequence[str] | None = None, *, open_store=_maildb_store) -> int:
     # that reaches this point proves the `--write` run reaches it too — so "The
     # --write run prints the full bound scope" is now true by construction rather
     # than by hope.
+    # 🔴 THE DOWNGRADE IS DECIDED ONCE, BEFORE THE PLAN PRINTS, AND `rebuild`
+    # MEANS THIS AND NOT `args.rebuild` FROM HERE DOWN. The pre-flight is the
+    # operator's only view of what the run destroys, so it has to describe the run
+    # that is going to happen — a plan headed "rebuild delete scope" above a run
+    # that takes no DELETE is the same defect the gate-ordering above fixed. And
+    # because the delete scope is computed ONLY when `rebuild` is true, an empty
+    # scope can never reach `store.write`, whose `ValueError` on one is the
+    # backstop rather than the mechanism.
+    downgrade = rebuild_downgrade_reason(derivations) if args.rebuild else None
+    rebuild = args.rebuild and downgrade is None
     if args.rebuild:
         say("")
+        if downgrade is not None:
+            say(f"🔴 {downgrade}")
+            say("")
         for line in rebuild_plan_lines(derivations, scoped=scoped, prune=args.prune,
-                                       write=args.write):
+                                       write=args.write, downgraded=downgrade is not None):
             say(line)
 
     if not args.write:
@@ -2676,12 +2968,14 @@ def main(argv: Sequence[str] | None = None, *, open_store=_maildb_store) -> int:
         stored = tuple(store.repos())
         labels = (
             rebuild_delete_labels(derivations, stored, scoped=scoped, prune=args.prune)
-            if args.rebuild else ()
+            if rebuild else ()
         )
-        n = store.write(rows, rebuild=args.rebuild, rebuild_labels=labels)
+        n = store.write(rows, rebuild=rebuild, rebuild_labels=labels)
     scope_note = (
         f" (after DELETE of {len(labels)} repo label(s): {', '.join(labels)} — "
-        f"one transaction)" if args.rebuild else ""
+        f"one transaction)" if rebuild else
+        " (--rebuild DOWNGRADED to an upsert — nothing was deleted)"
+        if downgrade is not None else ""
     )
     partial = partial_scope_warnings(derivations)
     # 🔴 THE SUCCESS LINE ITSELF SAYS PARTIAL. It is the one line a scripted
@@ -2691,8 +2985,20 @@ def main(argv: Sequence[str] | None = None, *, open_store=_maildb_store) -> int:
         # 🔴 NOT "contributed nothing", WHICH IS WHAT THIS SAID AND IS TRUE ONLY
         # OF THE UNMEASURED HALF. A repo kept out of the delete scope because one
         # of its docs would not read still contributes every doc that DID read.
-        + ("\n🔴 THIS INDEX IS PARTIAL — see the PARTIAL INDEX warning above; "
-           "some configured repos were not read COMPLETELY and kept their old rows."
+        #
+        # 🔴 AND NOT "and kept their old rows" EITHER, WHICH IS A CLAIM THIS LINE
+        # CANNOT MAKE. The delete binds LABELS and authority is per DERIVATION, so
+        # a repo that shares its label with a healthy checkout did NOT keep its old
+        # rows — see `authority_label_collisions`. The warning it points at knows
+        # which case this is; the one-liner does not, so it points rather than
+        # asserts.
+        # …and it points at "the warning above" rather than naming it PARTIAL
+        # INDEX: when NOTHING was read completely that warning opens with a
+        # different token, and a pointer at a heading that is not on the page is
+        # how a reader concludes there is no warning to find.
+        + ("\n🔴 THIS INDEX IS PARTIAL — see the 🔴 warning above; some configured "
+           "repos were not read COMPLETELY, and that warning says which of their "
+           "rows were kept."
            if partial else ""))
     for line in partial:
         print(line, file=sys.stderr)

--- a/scripts/lib/handoff_index.py
+++ b/scripts/lib/handoff_index.py
@@ -118,6 +118,8 @@ CONTRACT SUMMARY
     identity_collisions(rows)                 -> tuple[str, ...]        PURE
     unset_repo_handles(env=None)              -> tuple[str, ...]
     prune_config_refusal(unset)               -> str | None             PURE
+    incomplete_reason(derivation)             -> str | None             PURE
+    may_replace_stored_rows(derivation)       -> bool                   PURE
     rebuild_refusal(derivations, rows, ..)    -> str | None             PURE
     partial_scope_warnings(derivations)       -> tuple[str, ...]        PURE
     rebuild_delete_labels(derivs, stored, ..) -> tuple[str, ...]        PURE
@@ -195,6 +197,8 @@ __all__ = [
     "identity_collisions",
     "unset_repo_handles",
     "prune_config_refusal",
+    "incomplete_reason",
+    "may_replace_stored_rows",
     "rebuild_refusal",
     "partial_scope_warnings",
     "rebuild_delete_labels",
@@ -1618,6 +1622,81 @@ def import_maildb():
 # --------------------------------------------------------------------------- #
 
 
+def incomplete_reason(d: RepoDerivation) -> str | None:
+    """WHY this run cannot speak for `d.label`'s stored rows — `None` if it can.
+
+    🔴 THE ONE PREDICATE THAT AUTHORISES DESTROYING A REPO'S ROWS, AND IT EXISTS
+    BECAUSE THE SAME DEFECT SHIPPED FOUR TIMES IN FOUR SPELLINGS. Every one of
+    them was a `--rebuild` deleting rows it could not put back, and every one was
+    a different way of computing "which repos may I destroy":
+
+      1. an unpredicated `TRUNCATE` — authority over the whole table, granted by
+         nothing at all (`rebuild_delete_labels`' opening note).
+      2. the scope taken over the wrong LABEL SET — stored-but-not-configured
+         rows collected on every timer tick, ~62% of the corpus per 6h.
+      3. a refusal that checked whether a repo could be READ when the risk was
+         whether the config was WIDE (`prune_config_refusal`) — the read-failure
+         guard is structurally blind to an unset handle, so it is weakest exactly
+         where the risk is highest.
+      4. this one: the scope keyed on `unmeasured`, which answers "did the ref
+         resolve", while the question the DELETE asks is "did anything come
+         back". A repo whose mainline lists docs git cannot produce resolves
+         fine, so it landed in the scope with nothing to re-insert.
+
+    THE COMMON SHAPE IS NOT "SOMEONE FORGOT A FIELD". It is that authority was
+    granted by a NEGATIVE predicate — the absence of whichever failure had
+    already been seen — instead of by a POSITIVE demonstration that this run
+    holds a complete replacement. A blacklist re-opens the hole for every failure
+    nobody has met yet, which is why four rounds of naming one more failure never
+    converged. So the default is inverted here: a label is authoritative only
+    when this run read the repo IN FULL, and any incompleteness — of any kind,
+    including kinds not yet invented — withholds it.
+
+    🔴 AND IT IS *ONE* FUNCTION BECAUSE THE FOUR SITES ARE THE BUG. `claude/RULES.md`
+    → "one rule, one place": a predicate open-coded at N sites is typically wrong
+    at N−1 of them in the same direction. `rebuild_delete_labels`,
+    `partial_scope_warnings`, `rebuild_refusal` and `rebuild_plan_lines` each
+    re-derived "is this repo good" from whatever field was nearest, and spelling
+    3 above is literally two of those sites disagreeing about which question they
+    were answering. They now read this.
+
+    TWO WAYS TO BE INCOMPLETE, AND THEY ARE KEPT DISTINCT IN THE REASON STRING
+    RATHER THAN COLLAPSED INTO A BOOL, because the remedies are nothing alike:
+
+      * `d.unmeasured` — nothing came back at all: no checkout, no mainline ref,
+        a failed `ls-tree`. Fix the handle or the checkout.
+      * `d.unreadable` — the ref was enumerated and git could not produce the
+        content of at least one doc it lists. Repair the object store.
+
+    ⚠ `unmeasured` IS DELIBERATELY NOT SET FOR THE SECOND CASE, and that is a
+    considered reversal of the obvious fix. Calling a repo that read 39 of 40
+    docs "UNMEASURED" would make that field mean both "nothing came back" and
+    "not everything came back" — the exact conflation this module has now been
+    burned by three times (`handoff_paths_in_ref`'s `None`-vs-`()`, `DiskScan`'s
+    three meanings of `()`, and `docs == 0`'s two mechanisms). It would also
+    throw away the 39 readable docs: they are still upserted, because an
+    ON CONFLICT insert REFRESHES without destroying, and refusing to index what
+    was read buys nothing the delete scope does not already buy.
+
+    PURE, so the whole authority decision is testable without a database."""
+    if d.unmeasured:
+        return d.unmeasured
+    if d.unreadable:
+        # The counts are in the reason because "1 of 40" and "40 of 40" are very
+        # different operator situations and the label alone cannot say which.
+        return f"docs-unreadable ({len(d.unreadable)} of {len(d.unreadable) + d.docs})"
+    return None
+
+
+def may_replace_stored_rows(d: RepoDerivation) -> bool:
+    """Did this run obtain a COMPLETE replacement for `d.label`'s stored rows?
+
+    The positive spelling of `incomplete_reason`, so a call site reads as the
+    question the DELETE actually asks. Never re-derive either of these from the
+    underlying fields — see `incomplete_reason`'s note on the four spellings."""
+    return incomplete_reason(d) is None
+
+
 def rebuild_refusal(
     derivations: Sequence[RepoDerivation],
     rows: Sequence[Section],
@@ -1676,7 +1755,13 @@ def rebuild_refusal(
     fixing the handles as the only route and says why the other is not one. Swept
     with `prune_config_refusal` and `orphan_label_warning`, which had the same
     shape for a different state."""
-    bad = [d for d in derivations if d.unmeasured]
+    # 🔴 `bad` IS EVERY REPO THIS RUN CANNOT REPLACE, NOT EVERY REPO THAT FAILED TO
+    # RESOLVE — see `incomplete_reason`, which owns that decision for all four
+    # sites. `unmeasured` is kept as its own list because two of the arms below
+    # make claims that are true ONLY of that narrower class: "came back
+    # UNMEASURED", and "the N repo(s) that resolved a mainline ref".
+    bad = [d for d in derivations if incomplete_reason(d)]
+    unmeasured = [d for d in derivations if d.unmeasured]
     # 🔴 `--prune` NEEDS THE CONFIG TO BE AUTHORITATIVE ABOUT REPO IDENTITY, AND AN
     # UNMEASURED REPO IS EXACTLY WHERE IT IS NOT. Pruning means "delete every
     # stored label the config does not name" — a claim that the CONFIGURED
@@ -1700,19 +1785,25 @@ def rebuild_refusal(
     # yield zero unmeasured repos, i.e. this guard is weakest exactly where the
     # risk is highest. `main` runs the config-width guard first.
     if prune and bad:
-        detail = ", ".join(f"{d.label} ({d.unmeasured})" for d in bad)
+        detail = ", ".join(f"{d.label} ({incomplete_reason(d)})" for d in bad)
         return (
             f"REFUSING --rebuild --prune: {len(bad)} of {len(derivations)} repo(s) came "
-            f"back UNMEASURED — {detail}. --prune deletes every stored label this "
-            f"config does not name, which is only sound if the config's spelling of "
+            f"back UNMEASURED or INCOMPLETE — {detail}. --prune deletes every stored "
+            f"label this config does not name, which is only sound if the spelling of "
             f"every repo is the table's spelling; an unmeasured repo (a renamed or "
             f"missing checkout) is precisely where those can differ, and the rows it "
-            f"would collect may be that same repo under its old label. Fix the handles "
-            f"so every repo measures, then re-run --prune — or drop --prune, which "
-            f"deletes only what this run MEASURED."
+            f"would collect may be that same repo under its old label. A repo whose "
+            f"docs would not READ is refused for the same reason it is kept out of the "
+            f"delete scope: this run has nothing to put back. Fix the handles and the "
+            f"object store so every repo reads in FULL, then re-run --prune — or drop "
+            f"--prune, which deletes only what this run read COMPLETELY."
         )
-    if derivations and len(bad) == len(derivations):
-        detail = ", ".join(f"{d.label} ({d.unmeasured})" for d in bad)
+    # 🔴 THE OPENER IS A DISJUNCTION ("UNMEASURED or INCOMPLETE") RATHER THAN A
+    # CONDITIONAL, so it is true in every state this arm fires in and there is no
+    # second spelling to drift. The per-repo `detail` carries which of the two it
+    # actually was, which is the fact the operator acts on.
+    if derivations and len(unmeasured) == len(derivations):
+        detail = ", ".join(f"{d.label} ({d.unmeasured})" for d in unmeasured)
         return (
             f"REFUSING --rebuild: ALL {len(derivations)} repo(s) came back "
             f"UNMEASURED — {detail}. A rebuild here would replace a good index with "
@@ -1723,12 +1814,42 @@ def rebuild_refusal(
             f"the silent success this refusal exists to prevent."
         )
     if not rows:
-        measured = len(derivations) - len(bad)
+        measured = len(derivations) - len(unmeasured)
         return (
             "REFUSING --rebuild: the derivation produced ZERO rows from the "
             f"{measured} repo(s) that resolved a mainline ref. That is not 'the "
             "corpus is empty' — it is a corpus that could not be read. Nothing is "
             "deleted and nothing is written."
+        )
+    # 🔴 THE ARM THAT MAKES AN EMPTY DELETE SCOPE A REFUSAL RATHER THAN A CRASH.
+    # It fires when NOT ONE repo was read in full — the arms above have already
+    # taken the all-unmeasured and zero-rows cases, so reaching here means at
+    # least one repo resolved AND contributed rows AND still could not be
+    # replaced, i.e. every repo is partially readable. Before `incomplete_reason`
+    # widened the scope predicate, "not every repo is unmeasured" implied "at
+    # least one label is in the delete scope"; it no longer does, and
+    # `PostgresSectionStore.write` RAISES on an empty rebuild scope by design. A
+    # traceback out of the 6h timer is a worse report than a refusal that names
+    # the repos and a remedy.
+    #
+    # 🔴 THE REMEDY IS TRUE BECAUSE OF THE ORDERING, NOT BECAUSE IT WAS ASSERTED.
+    # "Re-run without --rebuild and it writes" is exactly the sentence the
+    # all-unmeasured arm above had to retract as FALSE in its own state. Here the
+    # zero-rows arm has already returned for every derivation with no rows, so
+    # `rows` is non-empty by construction and the row count is printed from it.
+    if derivations and len(bad) == len(derivations):
+        detail = ", ".join(f"{d.label} ({incomplete_reason(d)})" for d in bad)
+        return (
+            f"REFUSING --rebuild: not ONE of the {len(derivations)} repo(s) was read "
+            f"COMPLETELY — {detail}. A rebuild DELETES a repo's rows before "
+            f"re-deriving them, so it may only run for repos this run can REPLACE, "
+            f"and there are none: the delete scope would be EMPTY. This is NOT 'the "
+            f"corpus is empty' — {len(rows)} row(s) WERE derived, from the documents "
+            f"that did read. Where the reason is a doc that would not read, `git "
+            f"ls-tree` lists a path `git show` cannot produce, which means an "
+            f"incomplete object store — try `git fsck` and re-fetch. Re-running "
+            f"WITHOUT --rebuild is a real remedy here: it upserts those "
+            f"{len(rows)} row(s) and deletes nothing."
         )
     return None
 
@@ -1761,22 +1882,38 @@ def partial_scope_warnings(derivations: Sequence[RepoDerivation]) -> tuple[str, 
     refuses any `--prune` run with an unmeasured repo. So whenever this warning
     fires AND a write happens, the delete scope is exactly the MEASURED labels.
     `TestThePartialPromiseIsKept` pins that as a relationship between the two
-    functions rather than trusting either one's own docstring."""
-    bad = [d for d in derivations if d.unmeasured]
+    functions rather than trusting either one's own docstring.
+
+    🔴 IT SPEAKS FOR EVERY REPO THE RUN IS NOT AUTHORITATIVE FOR, NOT ONLY THE
+    UNMEASURED ONES — `incomplete_reason` owns that set for all four sites. It
+    used to key on `unmeasured` alone, in step with the delete scope, so a repo
+    whose docs would not READ was outside BOTH: it was silently bound to the
+    DELETE and this sentence did not mention it. The two moved together then and
+    they move together now, which is the property `TestThePartialPromiseIsKept`
+    pins.
+
+    🔴 "CONTRIBUTED NOTHING" WAS DROPPED FROM THIS SENTENCE, AND THE DELETION IS
+    THE POINT. It is true of an UNMEASURED repo and false of a partially readable
+    one, which contributes every row it could read (an ON CONFLICT insert
+    refreshes without destroying, so there is no reason to throw those away).
+    Keeping the phrase would have made this warning false in exactly the state it
+    was widened to cover."""
+    bad = [d for d in derivations if incomplete_reason(d)]
     if not bad or len(bad) == len(derivations):
-        # All-unmeasured is `rebuild_refusal`'s case, not this one; saying it twice
-        # in two voices is how one of them stops being read.
+        # All-bad is `rebuild_refusal`'s case, not this one; saying it twice in two
+        # voices is how one of them stops being read.
         return ()
-    detail = ", ".join(f"{d.label} ({d.unmeasured})" for d in bad)
-    ok = ", ".join(d.label for d in derivations if d.unmeasured is None)
+    detail = ", ".join(f"{d.label} ({incomplete_reason(d)})" for d in bad)
+    ok = ", ".join(d.label for d in derivations if may_replace_stored_rows(d))
     return (
         f"🔴 PARTIAL INDEX — {len(bad)} of {len(derivations)} configured repo(s) "
-        f"came back UNMEASURED and contributed NOTHING: {detail}. What was indexed "
-        f"covers only: {ok}. A query scoped to a missing repo will return an EMPTY "
+        f"were NOT read completely, so this run does not speak for them: {detail}. "
+        f"Read in FULL, and therefore rebuilt, covers only: {ok}. A query scoped to "
+        f"a repo that contributed nothing will return an EMPTY "
         f"SCOPE, and an unscoped query's silence is NOT evidence those repos are "
         f"silent. Their existing rows are left untouched (the rebuild delete is "
-        f"scoped to what MEASURED), so this run neither refreshed nor destroyed "
-        f"them.",
+        f"scoped to what was read in FULL), so this run destroyed nothing it could "
+        f"not replace.",
     )
 
 
@@ -1802,8 +1939,10 @@ def rebuild_delete_labels(
 
       * `scoped` — did the caller name repos with `--repo`? A scoped run speaks
         only for what it was pointed at.
-      * `d.unmeasured` — a repo that could not be READ is not a repo whose rows
-        this run may destroy. This is what makes `rebuild_refusal`'s new
+      * `incomplete_reason(d)` — a repo this run did not read IN FULL is not a
+        repo whose rows it may destroy, whether nothing came back (`unmeasured`)
+        or only some of it did (`unreadable`). This is what makes
+        `rebuild_refusal`'s new
         partial-tolerance safe: the absent `$CIVITAI` keeps its rows.
 
     🔴 A REBUILD NEVER DELETES ROWS FOR A REPO IT WAS NOT TOLD ABOUT. THAT IS A
@@ -1841,8 +1980,10 @@ def rebuild_delete_labels(
       * `scoped` — did the caller name repos with `--repo`? A scoped run speaks
         only for what it was pointed at, and `main` rejects `--prune` with
         `--repo` as a usage error rather than guessing.
-      * `d.unmeasured` — a repo that could not be READ is not a repo whose rows
-        this run may destroy. This is what makes `rebuild_refusal`'s
+      * `incomplete_reason(d)` — a repo this run did not read IN FULL is not a
+        repo whose rows it may destroy, whether nothing came back (`unmeasured`)
+        or only some of it did (`unreadable`). This is what makes
+        `rebuild_refusal`'s
         partial-tolerance safe: the absent `$CIVITAI` keeps its rows.
       * `prune` — an operator act, never the timer's. `rebuild_refusal` refuses a
         `--prune` run in which ANY repo came back unmeasured, which is what makes
@@ -1855,33 +1996,40 @@ def rebuild_delete_labels(
     return `measured` outright; a `--prune` run with any unmeasured repo never
     reaches a write. Pinned as a seam test, not left as prose.
 
-    ⚠ OPEN EXPOSURE, RECORDED HERE RATHER THAN ONLY IN A REVIEW THREAD: A REPO
-    THAT *MEASURES* AND WHOSE EVERY DOC IS UNREADABLE HAS ITS ROWS DELETED AND
-    ZERO RE-INSERTED, AT rc 0. `unmeasured` is the only field this scope reads,
-    and it answers "did the ref resolve", not "did anything come back". A repo
-    whose mainline LISTS handoff docs that git cannot produce resolves fine —
-    `unmeasured is None`, `docs == 0` — so it lands in `measured` and is bound to
-    the DELETE with nothing to put back. `RepoDerivation.unreadable` is the field
-    that distinguishes it, and it is derived one function away in `derive_repo`;
-    this scope does not consult it.
+    🔴 THE EXPOSURE THAT USED TO BE RECORDED HERE IS CLOSED, AND CLOSING IT MOVED
+    THE DELETE SCOPE. The note read: a repo that *measures* and whose every doc is
+    UNREADABLE has its rows deleted and ZERO re-inserted, at rc 0. `unmeasured`
+    was the only field this scope read, and it answers "did the ref resolve", not
+    "did anything come back" — so a repo whose mainline LISTS handoff docs git
+    cannot produce (`unmeasured is None`, `docs == 0`) landed in `measured` and
+    was bound to the DELETE with nothing to put back.
 
-    MEASURED on two repos (one healthy, one with every doc blob removed from
-    `.git/objects`), `--rebuild --write`: rc 0, `DELETE … ['plimforthrepo',
-    'zarfrepo']`, two INSERTs, both for `zarfrepo` — the broken repo's rows gone,
-    nothing re-inserted, success reported. It needs a second, healthy repo:
-    alone, the derivation yields zero rows and `rebuild_refusal`'s zero-rows arm
-    stops it, which is why the single-repo path looks safe.
+    RE-MEASURED before the fix, on two repos (one healthy, one with every doc blob
+    removed from `.git/objects`), `--rebuild --write`: rc 0, `DELETE …
+    ['badrepo', 'goodrepo']`, two INSERTs, both for `goodrepo` — the broken
+    repo's rows gone, nothing re-inserted, `partial_scope_warnings() == ()` and no
+    PARTIAL notice on the success line. The only signal was one `⚠ UNREADABLE`
+    stderr line.
 
-    🔴 DELIBERATELY NOT FIXED IN THE ROUND THAT WROTE THIS NOTE, and the reason
-    is scope, not doubt: reading `unreadable` here moves the delete scope, and the
-    same signal is what `handoff_search` splits rc 6 from rc 7 on — so the two
-    have to move together or the two front ends disagree about one fact, which is
-    the failure `run_search`'s own docstring records. It is its own round. Until
-    then this is the honest statement of what the scope covers: a repo this run
-    could not READ is still a repo it will DELETE, provided the ref resolved.
+    🔴 AND THE HAZARD WAS WIDER THAN THE FILING. The report described "every doc
+    unreadable"; MEASURED on ONE repo with 2 committed docs and ONE blob removed:
+    `unmeasured=None docs=1 unreadable=1`, scope `('zarfrepo',)`, rc 0, 2 of 4
+    sections re-inserted — the second doc's stored rows deleted and never
+    replaced, from a run that looks HEALTHIER than the total case because it
+    writes rows. A guard scoped to the total case would have closed the fourth
+    instance and left the shape open, which is what `incomplete_reason` exists to
+    stop: the scope now asks whether this run holds a COMPLETE replacement, and
+    ANY unreadable doc withholds authority.
+
+    ⚠ WHAT THIS COSTS, STATED RATHER THAN DISCOVERED: a single corrupt blob
+    freezes that repo's rows until the object store is repaired. The rows are
+    PRESERVED, not lost, every readable doc is still upserted, and
+    `partial_scope_warnings` says so on every output path — which is strictly the
+    conservative direction. `--prune` additionally refuses while any repo is
+    incomplete, for the reason `rebuild_refusal`'s prune arm gives.
 
     PURE, so the whole decision is testable without a database."""
-    measured = {d.label for d in derivations if d.unmeasured is None}
+    measured = {d.label for d in derivations if may_replace_stored_rows(d)}
     if scoped or not prune:
         return tuple(sorted(measured))
     configured = {d.label for d in derivations}
@@ -2033,12 +2181,24 @@ def rebuild_plan_lines(
     which asserts the plan block is ABSENT from a refusing run of each shape:
     stating the precondition here and not testing it is how the last two rounds
     of this same defect got through."""
-    measured = tuple(sorted(d.label for d in derivations if d.unmeasured is None))
+    # 🔴 THREE BUCKETS, NOT TWO, BECAUSE "NOT IN THE DELETE SCOPE" IS NOT ONE
+    # STATE. A repo can be kept out because NOTHING came back (`unmeasured`) or
+    # because only SOME of it did (`unreadable`) — different causes, different
+    # remedies, and the second one is invisible in a two-bucket plan: it appears
+    # in neither list, so a reader counts the labels, finds one missing, and has
+    # no way to learn why. The pre-flight is the operator's only view of what a
+    # run destroys, so a repo it silently omits is the same defect one layer up.
+    measured = tuple(sorted(d.label for d in derivations if may_replace_stored_rows(d)))
     kept = tuple(sorted(d.label for d in derivations if d.unmeasured is not None))
+    incomplete = tuple(sorted(
+        f"{d.label} ({incomplete_reason(d)})"
+        for d in derivations if d.unmeasured is None and d.unreadable))
     out = [
         "## rebuild delete scope",
-        f"  DELETE (measured, will be re-derived): {', '.join(measured) or '(none)'}",
+        f"  DELETE (read in FULL, will be re-derived): {', '.join(measured) or '(none)'}",
         f"  KEPT (configured but UNMEASURED): {', '.join(kept) or '(none)'}",
+        f"  KEPT (resolved, but a doc would not READ — this run cannot replace "
+        f"their rows): {', '.join(incomplete) or '(none)'}",
     ]
     if scoped:
         # 🔴 A SCOPED RUN REPORTS NO ORPHANS EITHER, and saying so here is what
@@ -2217,6 +2377,15 @@ def derivation_json(derivations: Sequence[RepoDerivation]) -> dict:
                 # first conclusion, which is the false sentence `handoff_search`
                 # rc 7 used to print.
                 "unreadable": list(d.unreadable),
+                # 🔴 THE AUTHORITY DECISION IS PUBLISHED, NOT LEFT TO BE
+                # RE-DERIVED. `unmeasured` and `unreadable` are both here, so a
+                # consumer COULD compute this — and computing it is precisely
+                # how the same predicate came to be spelled four different ways
+                # inside this module. It is the value `rebuild_delete_labels`
+                # actually reads, from `incomplete_reason`, so a machine consumer
+                # and the DELETE cannot disagree.
+                "rebuildable": may_replace_stored_rows(d),
+                "incomplete_reason": incomplete_reason(d),
                 "disk_scan_complete": d.disk.complete,
                 "disk_paths_seen": len(d.disk.paths),
                 "disk_scan_errors": list(d.disk.errors),
@@ -2519,8 +2688,11 @@ def main(argv: Sequence[str] | None = None, *, open_store=_maildb_store) -> int:
     # caller is most likely to read alone, and `wrote 968 section row(s)` reads as
     # a complete index whether or not it is one.
     say(f"\nwrote {n} section row(s) to {TABLE}{scope_note}"
+        # 🔴 NOT "contributed nothing", WHICH IS WHAT THIS SAID AND IS TRUE ONLY
+        # OF THE UNMEASURED HALF. A repo kept out of the delete scope because one
+        # of its docs would not read still contributes every doc that DID read.
         + ("\n🔴 THIS INDEX IS PARTIAL — see the PARTIAL INDEX warning above; "
-           "some configured repos contributed nothing and kept their old rows."
+           "some configured repos were not read COMPLETELY and kept their old rows."
            if partial else ""))
     for line in partial:
         print(line, file=sys.stderr)

--- a/scripts/lib/handoff_index.py
+++ b/scripts/lib/handoff_index.py
@@ -1075,6 +1075,25 @@ def derive_repo(repo: str | Path, *, label: str | None = None) -> RepoDerivation
     # `partial_scope_warnings`' `if not ok:` and `rebuild_plan_lines`'
     # `or '(none)'` — one shape, three sites, `claude/RULES.md`'s "a predicate
     # open-coded at N sites is typically wrong at N−1 of them".
+    #
+    # ⚠ WHAT REMAINS, WITH THE SURFACE COUNT CORRECTED. Those three sites were
+    # DECISIONS, and they are fixed: no branch anywhere now turns on whether a
+    # label renders. What is left is DISPLAY, and it is wider than the two
+    # surfaces the empty-label tests exercise — an empty label prints as a blank
+    # on FOUR human-readable surfaces, MEASURED via `main --repo . --rebuild`
+    # run from a repo root:
+    #   1. `render_derivation`'s per-repo row (`f"  {d.label:<24} …"`) — 24
+    #      blanks, so the row reads as if the ref column were the label;
+    #   2. `rebuild_plan_lines`' DELETE / KEPT buckets;
+    #   3. `partial_scope_warnings`' `detail` and `ok` lists;
+    #   4. `rebuild_downgrade_reason`'s and the refusal arms' `detail`.
+    # 🔴 THE FIX DOES NOT BELONG IN ANY OF THEM. A `d.label or "(unnamed)"` in a
+    # renderer re-introduces the exact falsy-string shape this comment records
+    # being swept out of three decision sites, in the layer that is READ when
+    # those decisions are audited. The cheap correct fix is at `main`: reject or
+    # normalise an empty `--repo` label with RC_USAGE, once, where the label is
+    # minted. Left undone deliberately — it is a DISPLAY defect only, and every
+    # decision above is already rendering-independent.
     name = root.name if label is None else label
     out = RepoDerivation(repo=str(root), label=name)
     if not root.is_dir():
@@ -1664,9 +1683,19 @@ def import_maildb():
 #: this file and a third, a TRUNCATED real name, was found by the checker that
 #: replaced them: every `test_…`/`Test…` name cited anywhere in this module is
 #: now pinned to exist by `TestEveryGuardThisModuleNamesByNameActuallyExists`.
-#: ⚠ ITS BLIND SPOT, STATED: it recognises those two shapes only, so a guard
-#: cited under a bare snake_case name that matches neither is NOT checked — and
-#: one of the two dead citations was exactly that shape. Cite guards by their
+#: ⚠ ITS BLIND SPOT, STATED: it recognises those two PREFIXES only, so a guard
+#: cited under a bare name carrying neither — plain snake_case with no `test_`,
+#: which is exactly what one of the two dead citations was — is NOT checked.
+#: 🔴 AND THE SENTENCE ABOVE USED TO BE THE WHOLE DISCLOSURE, WHICH UNDERSTATED
+#: WHAT THE CODE MISSED. The `test_` arm was spelled `test_[a-z0-9_]+`: that
+#: class cannot cross an uppercase letter, and the trailing `\b` cannot fire
+#: mid-identifier, so a cited `test_…` name containing a CAPITAL matched
+#: NOTHING AT ALL — not a truncated match, no match. Three real citations in
+#: this file were invisible that way, TWO of them added by the very round that
+#: wrote this blind-spot note; none dangled, so the checker stayed green and
+#: would have stayed green through any rename of the three. The class is now
+#: `[A-Za-z0-9_]` and they are covered — see
+#: `test_a_cited_test_name_carrying_a_CAPITAL_is_scanned`. Cite guards by their
 #: real `test_`/`Test` name and the checker covers them.
 INCOMPLETE_UNMEASURED = "unmeasured"
 INCOMPLETE_UNREADABLE = "docs-unreadable"
@@ -1736,7 +1765,7 @@ def incomplete_kind(d: RepoDerivation) -> str | None:
     mis-explained — see that function's closing branch.
 
     PURE."""
-    if d.unmeasured:
+    if d.unmeasured is not None:
         return INCOMPLETE_UNMEASURED
     if d.unreadable:
         return INCOMPLETE_UNREADABLE
@@ -1875,9 +1904,28 @@ def nothing_was_read_completely(derivations: Sequence[RepoDerivation]) -> bool:
     ⚠ `not derivations` is FALSE here, deliberately: a run with no derivations at
     all never reaches a delete scope (`main` exits RC_USAGE on an empty config),
     and "nothing was read completely" over zero repos is the vacuous-truth shape
-    `claude/RULES.md` calls worse than no check. `rebuild_downgrade_reason`'s
-    `if not derivations: return None` is the same guard, kept there because its
-    return type is a REASON and there is no reason to give. PURE."""
+    `claude/RULES.md` calls worse than no check.
+
+    🔴 THE `bool(derivations)` CONJUNCT BELOW IS THE ONLY COPY OF THAT GUARD IN
+    THIS MODULE, AND THIS PARAGRAPH USED TO SAY THE OPPOSITE. It claimed
+    `rebuild_downgrade_reason` "kept" an `if not derivations: return None` of its
+    own — but the commit that consolidated the two spellings had just DELETED it,
+    so `grep -n "if not derivations"` over this file matched THIS SENTENCE and
+    nothing else: a comment asserting a guard lives one function over, where it
+    does not. That is `claude/RULES.md`'s "reads as coverage while providing
+    none", and it is why the conjunct went unguarded — a reader checking the
+    empty-input case found the citation and stopped.
+
+    So it is guarded here now, because everything downstream inherits it: drop
+    `bool(derivations) and` as a redundant simplification and
+    `nothing_was_read_completely([])` flips False→True, which drags
+    `rebuild_downgrade_reason([])` from `None` to a REASON and
+    `derivation_json([])["rebuild_would_be_downgraded"]` from False to True. All
+    three are `__all__` exports and `handoff_search` imports this module, so the
+    blast radius is not `main` — `main` is insulated only because it returns
+    RC_USAGE on an empty config before it ever asks. A mutant dropping the
+    conjunct SURVIVED a full 281-test run; it is now killed by
+    `test_the_empty_derivation_list_is_not_an_all_bad_run`. PURE."""
     return bool(derivations) and not any(
         may_replace_stored_rows(d) for d in derivations)
 
@@ -1910,7 +1958,7 @@ def authority_label_collisions(
     DELETE and KEPT in the pre-flight. A silent wrong is better than a stated
     wrong: a stated wrong is what stops the next reader looking."""
     ok = {d.label for d in derivations if may_replace_stored_rows(d)}
-    bad = {d.label for d in derivations if incomplete_reason(d)}
+    bad = {d.label for d in derivations if incomplete_reason(d) is not None}
     return tuple(sorted(ok & bad))
 
 
@@ -2058,8 +2106,20 @@ def rebuild_refusal(
     # sites. `unmeasured` is kept as its own list because two of the arms below
     # make claims that are true ONLY of that narrower class: "came back
     # UNMEASURED", and "the N repo(s) that resolved a mainline ref".
-    bad = [d for d in derivations if incomplete_reason(d)]
-    unmeasured = [d for d in derivations if d.unmeasured]
+    # 🔴 `is not None`, NOT TRUTHINESS — THE SAME FALSY-STRING SHAPE, SWEPT A
+    # FOURTH TIME. Both `incomplete_reason(d)` and `d.unmeasured` are `str |
+    # None`, and every consumer here used to branch on their truthiness while
+    # their OWNER spells the question `incomplete_reason(d) is None`. Those
+    # agree only while the string is never empty — which is precisely the
+    # "they agree only while X is non-empty" argument that held for
+    # `partial_scope_warnings`' `if not ok:` right up until `--repo .` made X
+    # empty. No producer emits `""` today (the three writers are the literals
+    # `no-such-directory`, `no-mainline-ref` and `ls-tree-failed`), so this
+    # changes no behaviour; it removes the site's ability to disagree with its
+    # owner the day one does. Same edit at `authority_label_collisions`,
+    # `partial_scope_warnings` and `incomplete_kind`.
+    bad = [d for d in derivations if incomplete_reason(d) is not None]
+    unmeasured = [d for d in derivations if d.unmeasured is not None]
     # 🔴 `--prune` NEEDS THE CONFIG TO BE AUTHORITATIVE ABOUT REPO IDENTITY, AND AN
     # UNMEASURED REPO IS EXACTLY WHERE IT IS NOT. Pruning means "delete every
     # stored label the config does not name" — a claim that the CONFIGURED
@@ -2221,7 +2281,7 @@ def partial_scope_warnings(derivations: Sequence[RepoDerivation]) -> tuple[str, 
     label (`~/a/proj` and `~/b/proj`), and a healthy twin then grants a DELETE
     over the broken twin's rows. See `authority_label_collisions`, which is the
     residual this qualification exists to stop MIS-STATING."""
-    bad = [d for d in derivations if incomplete_reason(d)]
+    bad = [d for d in derivations if incomplete_reason(d) is not None]
     if not bad:
         # A per-run "0 repos missing" buries the real ones — `untracked_warnings`'
         # reason. This is the ONLY suppression left.

--- a/scripts/lib/handoff_index.py
+++ b/scripts/lib/handoff_index.py
@@ -121,6 +121,7 @@ CONTRACT SUMMARY
     incomplete_kind(derivation)               -> str | None             PURE
     incomplete_reason(derivation)             -> str | None             PURE
     may_replace_stored_rows(derivation)       -> bool                   PURE
+    nothing_was_read_completely(derivations)  -> bool                   PURE
     authority_label_collisions(derivations)   -> tuple[str, ...]        PURE
     rebuild_downgrade_reason(derivations)     -> str | None             PURE
     rebuild_refusal(derivations, rows, ..)    -> str | None             PURE
@@ -206,6 +207,8 @@ __all__ = [
     "incomplete_kind",
     "incomplete_reason",
     "may_replace_stored_rows",
+    "nothing_was_read_completely",
+    "DOWNGRADE_COST",
     "authority_label_collisions",
     "rebuild_downgrade_reason",
     "rebuild_refusal",
@@ -252,7 +255,8 @@ SECTIONS: tuple[str, ...] = (
 
 #: `handoff_doc.CANONICAL_HEADING_PREFIXES` -> this module's section token.
 #:
-#: 🔴 PINNED TWO-WAY by `test_every_canonical_prefix_has_a_section`: a prefix with
+#: 🔴 PINNED TWO-WAY by `test_every_canonical_prefix_has_a_section_and_vice_versa`:
+#: a prefix with
 #: no mapping fails, and a mapping naming no prefix fails. That is what makes a
 #: future heading added to `handoff_doc` a RED TEST rather than a silently
 #: unindexed section — the failure direction that costs nothing to notice and
@@ -1059,7 +1063,19 @@ def derive_repo(repo: str | Path, *, label: str | None = None) -> RepoDerivation
     silent zero (`git_mainline.resolve_base_ref` returns the ladder for exactly
     this)."""
     root = Path(repo)
-    name = label or root.name
+    # 🔴 `is None`, NOT `or` — A THIRD INSTANCE OF THE SAME FALSY-STRING SHAPE.
+    # `label or root.name` treats an EXPLICITLY SUPPLIED empty label as "not
+    # supplied" and substitutes the directory name, and the signature says the
+    # sentinel is `None`. It is invisible on today's one producer only by
+    # coincidence: `main` labels a repo `Path(r).name`, so `--repo .` passes `""`
+    # and `Path(".").name` is `""` too — the fallback happens to return the same
+    # value. Any other caller passing `""` silently got a different label than it
+    # asked for, which for this module is an AUTHORITY key: the delete scope, the
+    # stored rows and `handoff_search --repo` are all keyed on it. Swept with
+    # `partial_scope_warnings`' `if not ok:` and `rebuild_plan_lines`'
+    # `or '(none)'` — one shape, three sites, `claude/RULES.md`'s "a predicate
+    # open-coded at N sites is typically wrong at N−1 of them".
+    name = root.name if label is None else label
     out = RepoDerivation(repo=str(root), label=name)
     if not root.is_dir():
         out.unmeasured = "no-such-directory"
@@ -1636,11 +1652,49 @@ def import_maildb():
 #: repos on this value, and a partition keyed on a string literal silently loses
 #: a repo the day a third kind is added: it matches no branch, appears in no
 #: bucket, and the operator counts the labels, finds one missing, and has no way
-#: to learn why. `incomplete_kinds_are_partitioned` is the check that says so
-#: instead.
+#: to learn why. `test_every_configured_repo_lands_in_exactly_one_bucket` is the
+#: check that says so instead.
+#:
+#: 🔴 THAT CITATION USED TO NAME A GUARD THAT DOES NOT EXIST (the dead spelling
+#: is not repeated here: the checker below scans this file, so a retraction that
+#: spells it re-creates the dangling citation it retracts). A reader who greps a
+#: named guard and finds nothing concludes there IS no guard — the comment then
+#: reads as coverage while providing none, which `claude/RULES.md` calls worse
+#: than no comment because it stops anyone looking. Two such citations shipped in
+#: this file and a third, a TRUNCATED real name, was found by the checker that
+#: replaced them: every `test_…`/`Test…` name cited anywhere in this module is
+#: now pinned to exist by `TestEveryGuardThisModuleNamesByNameActuallyExists`.
+#: ⚠ ITS BLIND SPOT, STATED: it recognises those two shapes only, so a guard
+#: cited under a bare snake_case name that matches neither is NOT checked — and
+#: one of the two dead citations was exactly that shape. Cite guards by their
+#: real `test_`/`Test` name and the checker covers them.
 INCOMPLETE_UNMEASURED = "unmeasured"
 INCOMPLETE_UNREADABLE = "docs-unreadable"
 INCOMPLETE_KINDS = (INCOMPLETE_UNMEASURED, INCOMPLETE_UNREADABLE)
+
+
+#: 🔴 WHAT A SKIPPED DELETE COSTS — ONE SENTENCE, TWO PRINTERS, AND IT WAS WRONG
+#: IN BOTH. `rebuild_downgrade_reason` and `partial_scope_warnings`' all-bad arm
+#: each carried their own copy reading "a section REMOVED from a doc keeps its
+#: stale row". That reads as trailing-ordinal drift; the DELETE is per-repo-LABEL
+#: and the upsert key is `(repo, slug, section, ordinal)`, so what actually
+#: persists is EVERY row this run did not re-derive — including every row of a
+#: DELETED doc and, for a RENAMED one, both slugs' rows, which `handoff_search`
+#: then returns side by side as two documents. Whole documents, not ordinals.
+#:
+#: It is a constant because it is one claim about one mechanism and it had two
+#: spellings free to drift (`claude/RULES.md` → "one rule, one place"), and
+#: because a mutation sweep walked the runtime copy: the `nix/home.nix` half was
+#: pinned and the printed sentence was not, so a mutant that dropped the cost
+#: entirely SURVIVED a green suite. Pinned now as a WHOLE NORMALISED STRING by
+#: `test_the_downgrade_states_its_FULL_cost_not_just_a_section` — a guard on
+#: WORDS is walkable by rewording, and this text's whole job is to be read.
+DOWNGRADE_COST = (
+    "EVERY row this run did not re-derive persists until some repo reads in "
+    "FULL again — not just a section removed from a doc, but ALL rows of a doc "
+    "DELETED from the repo, and for a RENAMED doc both the old and the new "
+    "slug's rows, which a search returns side by side as two documents."
+)
 
 
 def incomplete_kind(d: RepoDerivation) -> str | None:
@@ -1657,9 +1711,29 @@ def incomplete_kind(d: RepoDerivation) -> str | None:
     is `d.unmeasured` itself, a free-form token, so any such match is a guard on
     WORDS.
 
-    So the kind is the structural value and the reason is derived FROM it. A
-    third kind therefore has exactly one place to be added, and
+    So the kind is the structural value and the reason is derived FROM it, and
     `rebuild_plan_lines` reports an unenumerated one rather than dropping it.
+
+    🔴 A THIRD KIND HAS *THREE* PLACES TO BE ADDED, AND THIS DOCSTRING SAID ONE.
+    The sentence read "a third kind therefore has exactly one place to be added",
+    and it was not an inert overstatement: `incomplete_reason`'s tail was an
+    unguarded `return` of the `docs-unreadable` literal, so a kind added in
+    exactly the one place this text named came back with a CONFIDENT WRONG
+    REASON. MEASURED with a novel kind `blob-checksum-mismatch` on a repo whose
+    `unreadable` is empty and `docs` is 3:
+
+        incomplete_reason -> 'docs-unreadable (0 of 3)'
+        plan              -> 🔴 KEPT (UNCLASSIFIED …): <label> (docs-unreadable (0 of 3))
+        --json            -> incomplete_kind: blob-checksum-mismatch
+                             incomplete_reason: docs-unreadable (0 of 3)
+
+    i.e. the mechanism built so an unenumerated kind is LOUD explained it with
+    the wrong one, in adjacent fields of the same object, and
+    `partial_scope_warnings`, `rebuild_downgrade_reason` and `rebuild_refusal`'s
+    prune arm all inherited the false string. The three places are
+    `INCOMPLETE_KINDS`, this function, and `incomplete_reason`'s branch table.
+    Miss the third now and the kind is REPORTED as unenumerated instead of
+    mis-explained — see that function's closing branch.
 
     PURE."""
     if d.unmeasured:
@@ -1726,14 +1800,38 @@ def incomplete_reason(d: RepoDerivation) -> str | None:
     was read buys nothing the delete scope does not already buy.
 
     PURE, so the whole authority decision is testable without a database."""
+    # 🔴 A BRANCH TABLE WITH NO FALL-THROUGH, BECAUSE THE FALL-THROUGH WAS THE
+    # DEFECT. This ended in a bare `return f"docs-unreadable (…)"` reached by
+    # ELSE — so a kind added to `incomplete_kind` alone (the change
+    # `incomplete_kind`'s own docstring told a reader to make) rendered the
+    # unreadable literal for a repo with NO unreadable docs: `docs-unreadable
+    # (0 of 3)`, published beside `incomplete_kind: blob-checksum-mismatch` in
+    # the same `--json` object. Every kind now has to CLAIM its reason.
     kind = incomplete_kind(d)
     if kind is None:
         return None
     if kind == INCOMPLETE_UNMEASURED:
         return d.unmeasured
-    # The counts are in the reason because "1 of 40" and "40 of 40" are very
-    # different operator situations and the label alone cannot say which.
-    return f"docs-unreadable ({len(d.unreadable)} of {len(d.unreadable) + d.docs})"
+    if kind == INCOMPLETE_UNREADABLE:
+        # The counts are in the reason because "1 of 40" and "40 of 40" are very
+        # different operator situations and the label alone cannot say which.
+        return f"docs-unreadable ({len(d.unreadable)} of {len(d.unreadable) + d.docs})"
+    # 🔴 AN UNENUMERATED KIND IS REPORTED AS ONE, NEVER EXPLAINED AS ANOTHER, AND
+    # IT IS A STRING RATHER THAN A RAISE ON PURPOSE. Raising would turn an
+    # incomplete READ into a crashed unit — `OnFailure=notify-failure@%n.service`
+    # on a 6h timer, the permanently-red gate this module has already had to
+    # unwind twice. Returning a reason keeps `may_replace_stored_rows` FALSE, so
+    # authority is withheld (the conservative direction, which is what
+    # `incomplete_reason`'s "kinds not yet invented" promise is FOR), the repo is
+    # still upserted, and `rebuild_plan_lines` prints it under UNCLASSIFIED with
+    # this text rather than under a bucket it does not belong to.
+    return (
+        f"UNENUMERATED-INCOMPLETENESS-KIND {kind!r} — `incomplete_kind` returned "
+        f"a kind `incomplete_reason` has no branch for, so this run CANNOT say "
+        f"why it may not replace this repo's rows; it withholds authority rather "
+        f"than guess. Add the kind to INCOMPLETE_KINDS and give it a reason "
+        f"branch in `incomplete_reason`."
+    )
 
 
 def may_replace_stored_rows(d: RepoDerivation) -> bool:
@@ -1743,6 +1841,45 @@ def may_replace_stored_rows(d: RepoDerivation) -> bool:
     question the DELETE actually asks. Never re-derive either of these from the
     underlying fields — see `incomplete_reason`'s note on the four spellings."""
     return incomplete_reason(d) is None
+
+
+def nothing_was_read_completely(derivations: Sequence[RepoDerivation]) -> bool:
+    """Is NOT ONE configured repo replaceable — the state that downgrades a rebuild.
+
+    🔴 ONE OWNER, BECAUSE THIS DECISION HAD TWO SPELLINGS AND THEY DISAGREED ON A
+    REACHABLE INPUT. `rebuild_downgrade_reason` asked `any(may_replace_stored_
+    rows(d) …)` — structural, correct. `partial_scope_warnings` asked whether a
+    RENDERED STRING was truthy: it built `ok = ", ".join(d.label for d in … if
+    may_replace_stored_rows(d))` and branched on `if not ok:`. Those agree only
+    while every replaceable label is non-empty, and a label is `Path(r).name`
+    (`main`), so `--repo .` yields `""`.
+
+    MEASURED through `main` with a recording store, `--repo . --repo /y/proj
+    --rebuild --write`, `.` read in FULL and `proj` holding one unreadable doc —
+    ONE run, THREE contradicting statements:
+
+        STORE CALLS: [('write', True, ('',))]   # rebuild=True, DELETE … ANY([''])
+        stderr : 🔴 NOTHING WAS READ COMPLETELY — all 2 configured repo(s) were
+                 incomplete … the delete scope is EMPTY … NOTHING was deleted
+        stdout :   DELETE (read in FULL, will be re-derived): (none)
+        stdout : wrote 3 section row(s) … (after DELETE of 1 repo label(s):  …)
+        rc 0
+
+    The middle one asserts no DELETE happened while a DELETE was bound, and the
+    sentence contradicts ITSELF in isolation ("all 2 … were incomplete" and then
+    naming one). The count is the fact; the string is a rendering of it, and a
+    rendering is free to be falsy for reasons that have nothing to do with the
+    decision. So both call sites read THIS, and the empty-label case cannot make
+    them differ because there is no longer a second place for it to act.
+
+    ⚠ `not derivations` is FALSE here, deliberately: a run with no derivations at
+    all never reaches a delete scope (`main` exits RC_USAGE on an empty config),
+    and "nothing was read completely" over zero repos is the vacuous-truth shape
+    `claude/RULES.md` calls worse than no check. `rebuild_downgrade_reason`'s
+    `if not derivations: return None` is the same guard, kept there because its
+    return type is a REASON and there is no reason to give. PURE."""
+    return bool(derivations) and not any(
+        may_replace_stored_rows(d) for d in derivations)
 
 
 def authority_label_collisions(
@@ -1811,20 +1948,36 @@ def rebuild_downgrade_reason(
     non-destructive — an ON CONFLICT insert refreshes without destroying — so
     downgrading cannot lose a row the refusal would have kept.
 
-    ⚠ WHAT THE DOWNGRADE DOES NOT BUY, STATED RATHER THAN DISCOVERED: a section
-    REMOVED from a doc keeps its stale high-ordinal row, because that is exactly
-    what the DELETE is for (`PostgresSectionStore.write`'s closing note). The run
-    says so, and says it on the success line, because "wrote N section row(s)"
-    otherwise reads as a completed rebuild.
+    ⚠ WHAT THE DOWNGRADE DOES NOT BUY, STATED RATHER THAN DISCOVERED — AND IT IS
+    WIDER THAN "A SECTION". This paragraph used to describe the residue as one
+    removed section's stale high-ordinal row, which reads as trailing-ordinal
+    drift and understates the blast radius by an order of magnitude. The DELETE
+    is per-repo-LABEL and the upsert key is `(repo, slug, section, ordinal)`, so
+    under a downgrade EVERY row this run did not re-derive persists:
+
+      * a section removed from a doc — the trailing-ordinal case, the smallest;
+      * a doc DELETED from the repo — ALL of its rows, since nothing re-derives
+        a slug that no longer exists;
+      * a doc RENAMED — both the old and the new slug's rows, which
+        `handoff_search` returns SIDE BY SIDE as two documents.
+
+    Whole documents, not trailing ordinals. It is still strictly non-destructive
+    and strictly better than the refusal it replaced — nothing is LOST — but the
+    stale half is a corpus a query answers FROM, so the run says it on the
+    success line: "wrote N section row(s)" otherwise reads as a completed
+    rebuild.
 
     Returns `None` when the rebuild may keep its DELETE. It is `main`'s SINGLE
     spelling of that decision — the scope is computed only when this returns
     `None` — so an empty scope can never reach `write()` and the two cannot
-    drift. `TestARebuildWithNothingReadInFullIsDowngradedNotRefused` pins the
-    equivalence against `rebuild_delete_labels`' actual return."""
-    if not derivations:
-        return None
-    if any(may_replace_stored_rows(d) for d in derivations):
+    drift. `TestNoRepoReadInFullIsRefusedNotCrashed::test_the_downgrade_and_the_
+    bound_DELETE_SCOPE_cannot_disagree` pins the equivalence against
+    `rebuild_delete_labels`' actual return. (That citation used to name a class
+    that has never existed — the dead spelling is deliberately NOT repeated here,
+    because `TestEveryGuardThisModuleNamesByNameActuallyExists` scans this file
+    for cited guard names and a retraction that spells the dead one re-creates
+    the dangling citation it is retracting. See `INCOMPLETE_KINDS`' note.)"""
+    if not nothing_was_read_completely(derivations):
         return None
     detail = ", ".join(f"{d.label} ({incomplete_reason(d)})" for d in derivations)
     return (
@@ -1835,8 +1988,7 @@ def rebuild_downgrade_reason(
         f"NOT 'the corpus is empty' — the documents that DID read are still "
         f"upserted, and an ON CONFLICT insert REFRESHES without destroying, so "
         f"NOTHING was deleted and no stored row was lost. What the skipped DELETE "
-        f"would have bought and this run does not: a section REMOVED from a doc "
-        f"keeps its stale row until some repo reads in FULL again. Where the "
+        f"would have bought and this run does not: {DOWNGRADE_COST} Where the "
         f"reason is a doc that would not read, `git ls-tree` lists a path `git "
         f"show` cannot produce, which means an incomplete object store — try "
         f"`git fsck` and re-fetch."
@@ -2088,7 +2240,12 @@ def partial_scope_warnings(derivations: Sequence[RepoDerivation]) -> tuple[str, 
         f"checkout's alone. Every OTHER named repo's rows are left untouched (the "
         f"rebuild delete is scoped to what was read in FULL)."
     )
-    if not ok:
+    # 🔴 THE COUNT, NOT THE TRUTHINESS OF `ok`. `ok` is a RENDERING and a label
+    # can render EMPTY (`Path(".").name`), so `if not ok:` sent a run WITH a
+    # replaceable repo down the all-bad arm and printed "NOTHING WAS DELETED"
+    # over a bound DELETE. `nothing_was_read_completely` is the one owner of this
+    # decision and `rebuild_downgrade_reason` reads the same call — see there.
+    if nothing_was_read_completely(derivations):
         return (
             f"🔴 NOTHING WAS READ COMPLETELY — all {len(derivations)} configured "
             f"repo(s) were incomplete, so this run speaks for none of them: "
@@ -2097,9 +2254,8 @@ def partial_scope_warnings(derivations: Sequence[RepoDerivation]) -> tuple[str, 
             f"plain upsert and a plain run never deletes — every stored row is "
             f"either refreshed by a document that DID read or left exactly as it "
             f"was. An unscoped "
-            f"query's silence is NOT evidence these repos are silent, and a "
-            f"section REMOVED from a doc keeps its stale row until some repo "
-            f"reads in FULL again.",
+            f"query's silence is NOT evidence these repos are silent, and "
+            f"{DOWNGRADE_COST}",
         )
     return (
         f"🔴 PARTIAL INDEX — {len(bad)} of {len(derivations)} configured repo(s) "
@@ -2442,12 +2598,21 @@ def rebuild_plan_lines(
         "## rebuild delete scope — SKIPPED (the --rebuild is DOWNGRADED to an "
         "upsert; NOTHING is deleted)" if downgraded else "## rebuild delete scope"
     )
+    # 🔴 `if <tuple>` — THE BUCKET IS EMPTY OR IT IS NOT; `or '(none)'` ASKED THE
+    # RENDERED STRING INSTEAD. A label is `Path(r).name`, so `--repo .` derives
+    # `""`, and a bucket holding exactly that one label joins to `""` — falsy —
+    # and printed `(none)` for a repo that IS in the DELETE scope. Same root
+    # cause as `partial_scope_warnings`' `if not ok:`; swept together because one
+    # bug printed in two places is how the second copy outlives the fix.
+    def _bucket(labels: tuple[str, ...]) -> str:
+        return ", ".join(labels) if labels else "(none)"
+
     out = [
         header,
-        f"  DELETE (read in FULL, will be re-derived): {', '.join(measured) or '(none)'}",
-        f"  KEPT (configured but UNMEASURED): {', '.join(kept) or '(none)'}",
+        f"  DELETE (read in FULL, will be re-derived): {_bucket(measured)}",
+        f"  KEPT (configured but UNMEASURED): {_bucket(kept)}",
         f"  KEPT (resolved, but a doc would not READ — this run cannot replace "
-        f"their rows): {', '.join(incomplete) or '(none)'}",
+        f"their rows): {_bucket(incomplete)}",
     ]
     if unenumerated:
         # The partition, asserted where an operator can see it rather than in a
@@ -2633,6 +2798,27 @@ def derivation_json(derivations: Sequence[RepoDerivation]) -> dict:
         "warnings": list(warnings),
         "all_clear": not warnings and not blockers,
         "all_clear_blockers": list(blockers),
+        # 🔴 THE RUN-LEVEL DOWNGRADE, PUBLISHED — WITHOUT IT A MACHINE CONSUMER
+        # HAD TO WORD-MATCH `"NOTHING WAS READ COMPLETELY"` OUT OF `warnings`.
+        # That is the guard-on-WORDS this module refuses everywhere else, and it
+        # is the exact reason `incomplete_kind` was split out of
+        # `incomplete_reason` one function up. The per-repo `rebuildable` flags
+        # let a consumer RE-DERIVE this, which is how the same predicate came to
+        # be spelled four ways inside this file; and `all_clear` is False under a
+        # downgrade but is False under a dozen other things too, so it cannot be
+        # branched on. A downgraded run and a clean rebuild are otherwise
+        # INDISTINGUISHABLE to anything not reading prose: both exit 0.
+        #
+        # SUBJUNCTIVE ON PURPOSE. This function is PURE over derivations and has
+        # no argv, so it cannot know whether `--rebuild` was passed; the field
+        # states the property of the DERIVATION that decides the downgrade. Under
+        # `--rebuild` "would be" is "is" — it is the same
+        # `nothing_was_read_completely` call `main` branches on, not a second
+        # spelling of it.
+        #
+        # ⚠ AND THE EXIT CODE IS DELIBERATELY *NOT* PART OF THIS. See `main`'s
+        # note at the downgrade site for why rc stays 0.
+        "rebuild_would_be_downgraded": nothing_was_read_completely(derivations),
         "totals": {
             "docs": sum(d.docs for d in derivations),
             "sections": sum(len(d.sections) for d in derivations),
@@ -2939,6 +3125,36 @@ def main(argv: Sequence[str] | None = None, *, open_store=_maildb_store) -> int:
     # because the delete scope is computed ONLY when `rebuild` is true, an empty
     # scope can never reach `store.write`, whose `ValueError` on one is the
     # backstop rather than the mechanism.
+    #
+    # 🔴 A DOWNGRADED RUN STILL EXITS 0, AND THAT IS A DECISION WITH A NAMED
+    # RESIDUAL RATHER THAN AN OVERSIGHT. The state is "success, but a human
+    # should act", and `scripts/drift-check.sh` has an idiom for exactly that —
+    # rc 16 plus `SuccessExitStatus = 16` on its unit. It was considered and NOT
+    # taken here, for three reasons:
+    #
+    #   * IT WOULD BE A SECOND SPELLING DELIVERED ON A DIFFERENT SCHEDULE. This
+    #     file is git-delivered — the unit's `ExecStart` runs
+    #     `%h/workspace/devrc/scripts/lib/handoff_index.py`, the WORKING TREE —
+    #     while `SuccessExitStatus` arrives only on a `home-manager switch`.
+    #     Between a `git pull` and the next switch the unit would be RED in a
+    #     state `nix/home.nix` calls SUPPORTED: `OnFailure=notify-failure@%n
+    #     .service` on a 6h timer. That is precisely the regression the commit
+    #     above this one exists to undo, re-entered through the deploy gap.
+    #     `nix/home.nix` documents that same working-tree/switch split for
+    #     drift-check in as many words.
+    #   * rc 0 IS NOT A FALSE CLAIM HERE. The run wrote every row it could read
+    #     and destroyed nothing — it is a SUCCESS that is also partial, and the
+    #     partiality already has three louder channels than an integer: the 🔴
+    #     downgrade line on stdout, the PARTIAL warning on stderr and the
+    #     success line, and now `rebuild_would_be_downgraded` in `--json`.
+    #   * IT IS THE REVERSIBLE DIRECTION. Adding the code later is one commit;
+    #     removing it once a caller branches on it is not.
+    #
+    # ⚠ THE RESIDUAL, STATED RATHER THAN LEFT TO BE DISCOVERED: a SHELL consumer
+    # that reads neither the prose nor `--json` still cannot distinguish a
+    # downgraded run from a clean rebuild. `--json` is the supported machine
+    # surface and it now answers structurally; a shell caller that needs the fact
+    # must ask for it there.
     downgrade = rebuild_downgrade_reason(derivations) if args.rebuild else None
     rebuild = args.rebuild and downgrade is None
     if args.rebuild:

--- a/scripts/tests/test_handoff_index.py
+++ b/scripts/tests/test_handoff_index.py
@@ -2092,7 +2092,7 @@ class TestTheDryRunShowsWhatTheRebuildDeletes:
         out = capsys.readouterr().out
         assert rc == hi.RC_OK
         assert "## rebuild delete scope" in out
-        assert "DELETE (measured, will be re-derived): zarfrepo" in out
+        assert "DELETE (read in FULL, will be re-derived): zarfrepo" in out
         assert "KEPT (configured but UNMEASURED): plimforth-renamed" in out
         assert "This list is the COMPLETE delete scope." in out
 
@@ -3646,7 +3646,7 @@ class TestThePlanDescribesTheRunThatActuallyHappens:
     def _plan_absent(self, out, err):
         both = out + err
         assert "## rebuild delete scope" not in both
-        assert "DELETE (measured, will be re-derived)" not in both
+        assert "DELETE (read in FULL, will be re-derived)" not in both
         assert "KEPT (configured but UNMEASURED)" not in both
 
     def test_a_refusing_prune_write_prints_no_plan_promising_a_bound_scope(
@@ -3733,7 +3733,7 @@ class TestThePlanDescribesTheRunThatActuallyHappens:
         out = capsys.readouterr().out
         assert rc == hi.RC_OK
         assert "## rebuild delete scope" in out
-        assert "DELETE (measured, will be re-derived): zarfrepo" in out
+        assert "DELETE (read in FULL, will be re-derived): zarfrepo" in out
 
 
 class TestTheTwoPruneGuardsHaveAFIXEDOrder:
@@ -3872,3 +3872,405 @@ class TestTheUnreadableReportIsMeasuredForMoreThanOneDoc:
         tracked = self._broken_repo(repo, self.A_DOCS[:1])
         _, _, _, unreadable = hs._offline_store([(str(repo), "zarfrepo")])
         assert unreadable == (("zarfrepo", tracked[0]),)
+
+
+# --------------------------------------------------------------------------- #
+# F8 — a repo this run could not read IN FULL is not a repo it may DELETE
+# --------------------------------------------------------------------------- #
+
+
+# 🔴 THREE DOCS, AND THE COUNT IS LOAD-BEARING. Breaking ONE of three makes
+# `docs`, `len(unreadable)` and the total pairwise distinct (2, 1, 3), so a
+# mutant that hardcodes any of those literals — or that keys the guard on
+# `docs == 0` — cannot survive by accident of a fixture where they coincide.
+#
+# 🔴 AND THE THREE BODIES ARE DISTINCT, WHICH IS NOT COSMETIC. Git addresses a
+# blob by the hash of its CONTENT, so two docs with identical text are ONE
+# object: the first draft of this fixture reused `DOC_FULL` twice, and deleting
+# "one" blob took out two documents — `docs` came back 1 instead of 2 and the
+# partial case silently became the total one. A fixture that cannot express the
+# distinction it is built to test is the same vacuous green one level down.
+_TRIAD = {
+    "handoff-glimmerwick-bus.md": DOC_FULL,
+    "handoff-quorlbane-cache.md": DOC_SPARSE,
+    "handoff-fandrelly-probe.md": DOC_FULL.replace(
+        "widget-relay", "fandrelly-probe").replace("quixotry", "snorrelquim"),
+}
+
+
+def _break_doc_blob(repo: Path, path: str) -> None:
+    """Delete the loose object behind ONE doc, leaving the tree entry listed.
+
+    `_break_every_doc_blob`'s mechanism, applied to a single path — the same
+    reason it is git and not a monkeypatch: `git ls-tree` reads the TREE and
+    `git show` reads the BLOB, and only a real object store can show that the
+    two commands disagree."""
+    ref, _ = hi.resolve_mainline(repo)
+    assert ref is not None
+    (repo / ".git" / "objects" / _blob_of(repo, ref, path)[:2]
+     / _blob_of(repo, ref, path)[2:]).unlink()
+
+
+class TestARepoReadIncompletelyIsNotAuthoritativeOverItsRows:
+    """🔴 F8 — REPRODUCED, then fixed. `--rebuild --write` over one healthy repo
+    plus one whose committed doc blobs were removed from `.git/objects` bound
+    BOTH labels to the DELETE, re-inserted only the healthy repo's rows, printed
+    no PARTIAL notice and exited 0. The broken repo resolved its mainline ref, so
+    `unmeasured is None`, and `unmeasured` was the only field the delete scope
+    read.
+
+    MEASURED before the fix, on the exact fixtures below's shape:
+    `partial_scope_warnings() == ()`, `rebuild_refusal() is None`,
+    `DELETE params == [['badrepo', 'goodrepo']]`, rc 0. The only signal anywhere
+    in the run was one `⚠ UNREADABLE` line on stderr.
+
+    🔴 AND THE FILING UNDERSTATED IT. Breaking ONE blob of several produces the
+    same silent deletion from a run that looks HEALTHIER — it writes rows — so
+    the guard is on ANY unreadable doc, not on "every doc unreadable". The
+    ONE-of-three cases below are what separate the two fixes."""
+
+    def test_the_predicate_withholds_authority_and_names_which_kind(self, tmp_path):
+        """PURE, over all three states of one predicate, with the healthy repo as
+        the negative control. Without that control an unconditional
+        `incomplete_reason` would satisfy every other assertion here."""
+        healthy = tmp_path / "glimmerrepo"
+        _write_repo(healthy, _TRIAD)
+        whole = hi.derive_repo(healthy, label="glimmerrepo")
+        assert hi.incomplete_reason(whole) is None
+        assert hi.may_replace_stored_rows(whole) is True
+
+        partial = tmp_path / "quorlrepo"
+        _write_repo(partial, _TRIAD)
+        _break_doc_blob(partial, "claudedocs/handoff-quorlbane-cache.md")
+        d = hi.derive_repo(partial, label="quorlrepo")
+        # The pre-fix state, asserted alongside the new one so the record shows
+        # exactly what was and was not observable: the ref DID resolve.
+        assert d.unmeasured is None
+        assert d.docs == 2
+        assert d.unreadable == ("claudedocs/handoff-quorlbane-cache.md",)
+        assert hi.may_replace_stored_rows(d) is False
+        # The reason names the KIND and the counts — "1 of 40" and "40 of 40" are
+        # different operator situations and the label alone cannot say which.
+        assert hi.incomplete_reason(d) == "docs-unreadable (1 of 3)"
+
+        gone = hi.derive_repo(tmp_path / "fandrellyrepo", label="fandrellyrepo")
+        assert hi.incomplete_reason(gone) == "no-such-directory"
+        assert hi.may_replace_stored_rows(gone) is False
+
+    def test_the_delete_scope_excludes_a_repo_whose_docs_would_not_READ(self, tmp_path):
+        """The scope itself, PURE, as a differential over the ONE variable: two
+        repos built from the SAME fixture, one with a blob removed."""
+        good = tmp_path / "glimmerrepo"
+        bad = tmp_path / "quorlrepo"
+        _write_repo(good, _TRIAD)
+        _write_repo(bad, _TRIAD)
+        _break_every_doc_blob(bad)
+        ds = [hi.derive_repo(good, label="glimmerrepo"),
+              hi.derive_repo(bad, label="quorlrepo")]
+        # 🔴 NOT ("glimmerrepo", "quorlrepo") — which is what this returned
+        # before, with no warning and exit 0.
+        assert hi.rebuild_delete_labels(ds, (), scoped=True) == ("glimmerrepo",)
+
+    def test_ONE_unreadable_doc_of_THREE_also_withholds_authority(self, tmp_path):
+        """🔴 THE WIDEST READING, AND THE MUTANT THIS EXISTS TO KILL. A guard
+        written for the filed symptom — every doc unreadable — would read
+        `d.unreadable and not d.docs` and pass every other test in this class.
+        Here the repo contributed 2 of 3 docs, so a total-only guard puts it back
+        in the scope and its third doc's stored rows are deleted with nothing to
+        replace them."""
+        good = tmp_path / "glimmerrepo"
+        bad = tmp_path / "quorlrepo"
+        _write_repo(good, _TRIAD)
+        _write_repo(bad, _TRIAD)
+        _break_doc_blob(bad, "claudedocs/handoff-fandrelly-probe.md")
+        ds = [hi.derive_repo(good, label="glimmerrepo"),
+              hi.derive_repo(bad, label="quorlrepo")]
+        assert ds[1].docs == 2, "the fixture must be PARTIALLY readable, or this pins nothing"
+        assert hi.rebuild_delete_labels(ds, (), scoped=True) == ("glimmerrepo",)
+
+    def test_what_it_DID_read_is_still_indexed(self, tmp_path):
+        """The boundary the fix must NOT have moved. Withholding the DELETE is
+        not a reason to throw away the docs that read: an ON CONFLICT insert
+        REFRESHES without destroying, so those rows are still contributed. A fix
+        that reclassified the repo as UNMEASURED would drop them, and this is
+        what says so."""
+        bad = tmp_path / "quorlrepo"
+        _write_repo(bad, _TRIAD)
+        _break_doc_blob(bad, "claudedocs/handoff-quorlbane-cache.md")
+        d = hi.derive_repo(bad, label="quorlrepo")
+        assert d.sections, "the readable docs must still produce rows"
+        assert {s.slug for s in d.sections} == {"glimmerwick-bus", "fandrelly-probe"}
+
+    def test_the_bound_DELETE_through_main_names_only_what_was_read_in_FULL(
+            self, tmp_path, capsys):
+        """🔴 THE REGRESSION TEST, END TO END, AND THE ASSERTION IS ON THE BOUND
+        SCOPE. The statement text, the exit code and the row count are IDENTICAL
+        between the correct run and the destructive one — the bound parameters
+        are the only place the difference shows, which is why `RecordingConn`
+        keeps them.
+
+        The table is pre-loaded with both labels so the delete has something real
+        to be wrong about."""
+        good = tmp_path / "glimmerrepo"
+        bad = tmp_path / "quorlrepo"
+        _write_repo(good, _TRIAD)
+        _write_repo(bad, _TRIAD)
+        _break_every_doc_blob(bad)
+
+        conn = StoredReposConn(("glimmerrepo", "quorlrepo"))
+        rc = hi.main(["--repo", str(good), "--repo", str(bad), "--rebuild", "--write"],
+                     open_store=_recording_store(conn))
+        cap = capsys.readouterr()
+        assert rc == hi.RC_OK
+        # 🔴 NOT [[['glimmerrepo', 'quorlrepo']]].
+        assert conn.params_for("DELETE") == [[["glimmerrepo"]]]
+        # …and the run SAYS it is partial, on both the warning path and the one
+        # line a scripted caller is most likely to read alone.
+        assert "🔴 PARTIAL INDEX" in cap.err
+        assert "quorlrepo (docs-unreadable (3 of 3))" in cap.err
+        assert "🔴 THIS INDEX IS PARTIAL" in cap.out
+        # The pre-flight names it in its own bucket rather than omitting it.
+        assert "KEPT (resolved, but a doc would not READ" in cap.out
+
+    def test_a_run_over_only_HEALTHY_repos_deletes_both_and_says_nothing(
+            self, tmp_path, capsys):
+        """The negative control for the test above, over the same shape one blob
+        apart. Without it, the assertions there are satisfied by a scope that
+        withholds authority from everything — which would be a permanently-red
+        rebuild, not a fix."""
+        good = tmp_path / "glimmerrepo"
+        also = tmp_path / "quorlrepo"
+        _write_repo(good, _TRIAD)
+        _write_repo(also, _TRIAD)
+
+        conn = StoredReposConn(("glimmerrepo", "quorlrepo"))
+        rc = hi.main(["--repo", str(good), "--repo", str(also), "--rebuild", "--write"],
+                     open_store=_recording_store(conn))
+        cap = capsys.readouterr()
+        assert rc == hi.RC_OK
+        assert conn.params_for("DELETE") == [[["glimmerrepo", "quorlrepo"]]]
+        assert "PARTIAL" not in cap.out + cap.err
+
+    def test_the_machine_surface_publishes_the_same_decision(self, tmp_path, capsys):
+        """🔴 A CAVEAT SPELLED IN ONE RENDERER IS A CAVEAT THE OTHER DOES NOT
+        HAVE. `--json` is the surface consumed without a human reading it, and a
+        consumer deciding whether a repo's rows are current has to be able to
+        read the SAME value the DELETE read — not re-derive it from `unmeasured`
+        and `unreadable`, which is exactly how this predicate came to be spelled
+        four different ways inside the module."""
+        bad = tmp_path / "quorlrepo"
+        _write_repo(bad, _TRIAD)
+        _break_doc_blob(bad, "claudedocs/handoff-glimmerwick-bus.md")
+        rc = hi.main(["--repo", str(bad), "--json"], open_store=_refusing_store())
+        doc = json.loads(capsys.readouterr().out)
+        assert rc == hi.RC_OK
+        repo = doc["repos"][0]
+        assert repo["unmeasured"] is None
+        assert repo["rebuildable"] is False
+        assert repo["incomplete_reason"] == "docs-unreadable (1 of 3)"
+
+
+class TestThePartialPromiseCoversTheUnreadableRepoToo:
+    """🔴 THE SEAM, RE-PINNED OVER THE STATE THAT BROKE IT. `TestThePartialPromiseIsKept`
+    asserts the PARTIAL sentence and the delete scope cannot contradict each
+    other — and it drove only the UNMEASURED state, because that was the only
+    state either function could see. A repo whose docs would not read was in
+    NEITHER: silently deleted, and unmentioned by the sentence that claims to
+    name every repo this run does not speak for.
+
+    `claude/RULES.md`: a seam guard must pin a RELATIONSHIP, not a component."""
+
+    def _mixed(self, tmp_path):
+        good = tmp_path / "glimmerrepo"
+        partial = tmp_path / "quorlrepo"
+        _write_repo(good, _TRIAD)
+        _write_repo(partial, _TRIAD)
+        _break_doc_blob(partial, "claudedocs/handoff-quorlbane-cache.md")
+        return [hi.derive_repo(good, label="glimmerrepo"),
+                hi.derive_repo(partial, label="quorlrepo")]
+
+    def test_no_repo_the_warning_speaks_for_can_be_in_the_delete_scope(self, tmp_path):
+        """The relationship itself, over every (scoped, prune) combination the
+        run can reach a write in — the delete scope is a SUBSET of the labels
+        this run read in FULL, so no repo the sentence names is in it."""
+        ds = self._mixed(tmp_path)
+        rows = [s for d in ds for s in d.sections]
+        full = {d.label for d in ds if hi.may_replace_stored_rows(d)}
+        spoken_for = {d.label for d in ds if not hi.may_replace_stored_rows(d)}
+
+        partial = hi.partial_scope_warnings(ds)
+        assert partial, "the fixture must actually be partial, or this pins nothing"
+        assert "left untouched" in partial[0]
+        assert "quorlrepo" in partial[0]
+
+        for scoped in (True, False):
+            for prune in (True, False):
+                if hi.rebuild_refusal(ds, rows, prune=prune) is not None:
+                    continue  # this run never reaches a write; the promise holds
+                scope = set(hi.rebuild_delete_labels(ds, ("glimmerrepo", "quorlrepo"),
+                                                     scoped=scoped, prune=prune))
+                assert scope <= full, (scoped, prune, scope)
+                assert not (scope & spoken_for), (scoped, prune, scope)
+
+    def test_the_warning_no_longer_claims_the_repo_contributed_NOTHING(self, tmp_path):
+        """🔴 A SENTENCE THE WIDENING WOULD HAVE MADE FALSE. The warning used to
+        say the repos it names "came back UNMEASURED and contributed NOTHING" —
+        true of an absent checkout, false of a repo that read 2 of its 3 docs and
+        whose rows are in the very transaction that prints it."""
+        ds = self._mixed(tmp_path)
+        assert ds[1].sections, "the fixture must contribute rows, or this pins nothing"
+        text = hi.partial_scope_warnings(ds)[0]
+        assert "contributed NOTHING" not in text
+        assert "were NOT read completely" in text
+
+
+class TestNoRepoReadInFullIsRefusedNotCrashed:
+    """🔴 THE ARM THE WIDER SCOPE MADE NECESSARY. `PostgresSectionStore.write`
+    RAISES on an empty rebuild scope — deliberately, so a caller that forgets the
+    scope cannot get a whole-table wipe as the default — and until now
+    `rebuild_refusal` guaranteed the scope was non-empty: "not every repo is
+    unmeasured" implied "at least one repo is in the scope". With authority
+    withheld from partially-readable repos that implication is gone, and a
+    traceback out of a 6h timer is a worse report than a refusal naming the
+    repos and a remedy."""
+
+    def _all_partial(self, tmp_path):
+        a = tmp_path / "glimmerrepo"
+        b = tmp_path / "quorlrepo"
+        for root in (a, b):
+            _write_repo(root, _TRIAD)
+            _break_doc_blob(root, "claudedocs/handoff-fandrelly-probe.md")
+        return a, b
+
+    def test_a_rebuild_with_nothing_read_in_FULL_refuses_before_the_store_opens(
+            self, tmp_path, capsys):
+        """`_refusing_store()` is the positive control: an assertion on the exit
+        code alone cannot tell a refusal from a write that happened and then
+        returned non-zero. It also proves the empty scope never reaches
+        `write()`, which is where the raise lives."""
+        a, b = self._all_partial(tmp_path)
+        rc = hi.main(["--repo", str(a), "--repo", str(b), "--rebuild", "--write"],
+                     open_store=_refusing_store())
+        err = capsys.readouterr().err
+        assert rc == hi.RC_REFUSED
+        assert "not ONE of the 2 repo(s) was read COMPLETELY" in err
+        assert "the delete scope would be EMPTY" in err
+        # It must NOT reach for the all-unmeasured arm's remedy: both repos
+        # resolved, so "fix the repo handles" would be a confident wrong step.
+        assert "came back UNMEASURED" not in err
+
+    def test_the_remedy_it_names_is_a_run_that_actually_writes(self, tmp_path, capsys):
+        """🔴 A REMEDY IS A CLAIM ABOUT THE STATE IT IS PRINTED IN, and the
+        all-unmeasured arm one screen up had to RETRACT this exact sentence for
+        being false in its own state ("re-run without --rebuild" writes 0 rows
+        when nothing measured). Here the zero-rows arm has already returned for
+        every derivation with no rows, so `rows` is non-empty by construction —
+        and the claim is measured rather than reasoned about."""
+        a, b = self._all_partial(tmp_path)
+        conn = StoredReposConn(("glimmerrepo", "quorlrepo"))
+        rc = hi.main(["--repo", str(a), "--repo", str(b), "--write"],
+                     open_store=_recording_store(conn))
+        out = capsys.readouterr().out
+        assert rc == hi.RC_OK
+        assert conn.kinds().count("INSERT") > 0
+        assert "DELETE" not in conn.kinds()
+        assert "wrote 0 section row(s)" not in out
+
+    def test_the_all_UNMEASURED_arm_still_wins_where_it_applies(self, tmp_path, capsys):
+        """The ladder's ordering, pinned. Both arms fire on "every repo is
+        unusable"; only the narrower one can honestly say `came back UNMEASURED`
+        and send the reader to the handles, so it must be reached first."""
+        rc = hi.main(["--repo", str(tmp_path / "glimmerrepo"),
+                      "--repo", str(tmp_path / "quorlrepo"), "--rebuild", "--write"],
+                     open_store=_refusing_store())
+        err = capsys.readouterr().err
+        assert rc == hi.RC_REFUSED
+        assert "ALL 2 repo(s) came back UNMEASURED" in err
+        assert "was read COMPLETELY" not in err
+
+    def test_a_healthy_rebuild_is_NOT_refused(self, tmp_path, capsys):
+        """The negative control that keeps this from being a permanently-red
+        gate — the mistake `rebuild_refusal`'s all-unmeasured arm had to unwind
+        once already."""
+        good = tmp_path / "glimmerrepo"
+        _write_repo(good, _TRIAD)
+        conn = StoredReposConn(("glimmerrepo",))
+        rc = hi.main(["--repo", str(good), "--rebuild", "--write"],
+                     open_store=_recording_store(conn))
+        assert rc == hi.RC_OK
+        assert "REFUSING" not in capsys.readouterr().err
+        assert conn.params_for("DELETE") == [[["glimmerrepo"]]]
+
+
+class TestPruneRefusesARepoItCannotReplace:
+    """`--prune` widens the delete to every stored label the config does not
+    name. That is only sound if the run can replace what it keeps, so the same
+    predicate gates it — and the message has to stay distinguishable from the
+    config-width guard, which opens with the same six words."""
+
+    def test_prune_refuses_while_a_doc_would_not_read(self, tmp_path, monkeypatch,
+                                                      capsys):
+        """Every handle SET — so `prune_config_refusal` is not what fires — with
+        one checkout carrying a broken blob."""
+        handles = _every_handle_set(tmp_path)
+        broken = Path(handles[hi.REPO_ENV_HANDLES[2]])
+        _break_every_doc_blob(broken)
+        _apply_handles(monkeypatch, handles)
+
+        rc = hi.main(["--rebuild", "--prune", "--write"], open_store=_refusing_store())
+        err = capsys.readouterr().err
+        assert rc == hi.RC_REFUSED
+        assert "came back UNMEASURED or INCOMPLETE" in err
+        assert f"{broken.name} (docs-unreadable (1 of 1))" in err
+        assert "handle(s) are UNSET" not in err
+
+    def test_the_same_config_with_every_doc_readable_still_prunes(
+            self, tmp_path, monkeypatch, capsys):
+        """The differential over the ONE variable — one blob — so nothing else
+        can explain the two outcomes."""
+        _apply_handles(monkeypatch, _every_handle_set(tmp_path))
+        labels = [f"{h.lower()}repo" for h in hi.REPO_ENV_HANDLES]
+        conn = StoredReposConn((*labels, "brindlewick-retired"))
+        rc = hi.main(["--rebuild", "--prune", "--write"],
+                     open_store=_recording_store(conn))
+        assert rc == hi.RC_OK
+        assert "REFUSING" not in capsys.readouterr().err
+        assert conn.params_for("DELETE") == [
+            [sorted([*labels, "brindlewick-retired"])]]
+
+
+class TestTheAuthorityPredicateIsREACHEDByTheDeleteScope:
+    """🔴 PROVING THE GUARD REACHABLE, NOT MERELY BREAKABLE. `claude/RULES.md`: a
+    mutation test still passes when an EARLIER check always wins, so the guard
+    never executes. Here the earlier check is `d.unmeasured`, and every fixture
+    above reaches the `unreadable` clause only because `derive_repo` happens to
+    leave `unmeasured` as `None` for a resolvable repo.
+
+    These drive `RepoDerivation` DIRECTLY — the functions are PURE and public, so
+    this is a supported call, not a contrivance — and construct the one state
+    that can only be answered by the second clause: `unmeasured is None` with
+    `unreadable` non-empty. If a future change made the first clause subsume the
+    second, these fail while everything above stays green."""
+
+    def _d(self, label, *, unmeasured=None, unreadable=()):
+        return hi.RepoDerivation(repo=f"/nowhere/{label}", label=label,
+                                 ref="refs/heads/main", docs=len(unreadable) and 1,
+                                 unmeasured=unmeasured, unreadable=unreadable)
+
+    def test_the_second_clause_alone_decides_a_label(self):
+        only_unreadable = self._d("thackrepo",
+                                  unreadable=("claudedocs/handoff-thack-relay.md",))
+        assert only_unreadable.unmeasured is None      # the earlier check does NOT fire
+        assert hi.incomplete_reason(only_unreadable) is not None
+        assert hi.may_replace_stored_rows(only_unreadable) is False
+
+    def test_the_delete_scope_reads_it_rather_than_re_deriving_it(self):
+        """The scope is the consumer that matters, and it is asserted over a
+        derivation the git layer cannot produce — so the answer comes from the
+        predicate and from nothing else in `derive_repo`."""
+        ds = [self._d("venlorepo"),
+              self._d("thackrepo", unreadable=("claudedocs/handoff-thack-relay.md",))]
+        assert hi.rebuild_delete_labels(ds, (), scoped=True) == ("venlorepo",)
+        # …and with the SAME two derivations minus the unreadable path, both.
+        ds[1] = self._d("thackrepo")
+        assert hi.rebuild_delete_labels(ds, (), scoped=True) == ("thackrepo", "venlorepo")

--- a/scripts/tests/test_handoff_index.py
+++ b/scripts/tests/test_handoff_index.py
@@ -5102,6 +5102,30 @@ class TestTheAllBadArmIsChosenByCOUNTNotByARenderedString:
         assert hi.rebuild_delete_labels(
             ds, (), scoped=True, prune=False) == ("",)
 
+    def test_the_empty_derivation_list_is_not_an_all_bad_run(self):
+        """🔴 THE `bool(derivations)` CONJUNCT, WHICH NOTHING GUARDED. A mutant
+        dropping it — `return not any(may_replace_stored_rows(d) for d in
+        derivations)` — SURVIVED a full 281-test run, because every fixture in
+        this file passes at least one derivation, so no test ever reached the
+        empty input.
+
+        `any()` over an empty sequence is False, so `not any(…)` is the vacuous
+        TRUE the conjunct exists to refuse. Without it
+        `nothing_was_read_completely([])` flips False→True and drags two
+        published surfaces with it, which is why all three are asserted here
+        rather than the predicate alone: the predicate is the cause, and the two
+        derived values are what a caller actually reads. All three are `__all__`
+        exports and `handoff_search` imports this module — `main` is insulated
+        only because it returns RC_USAGE on an empty config before it asks.
+
+        The docstring that let this through is retracted in the module: it cited
+        an `if not derivations: return None` in `rebuild_downgrade_reason` that
+        the same commit had deleted, so a reader checking the empty-input case
+        found a citation and stopped looking."""
+        assert hi.nothing_was_read_completely([]) is False
+        assert hi.rebuild_downgrade_reason([]) is None
+        assert hi.derivation_json([])["rebuild_would_be_downgraded"] is False
+
     def test_the_plan_distinguishes_an_EMPTY_label_from_an_EMPTY_bucket(
             self, tmp_path):
         """The pre-flight half. `', '.join(measured) or '(none)'` printed
@@ -5141,6 +5165,20 @@ class TestTheAllBadArmIsChosenByCOUNTNotByARenderedString:
         _break_doc_blob(other, "claudedocs/handoff-fandrelly-probe.md")
 
         empty = hi.derive_repo(good, label="")
+        # 🔴 THE FIXTURE ASSERTS ITSELF, for the reason `_empty_label_plus_broken`
+        # carries the same line: this is the ONLY case in the matrix below that
+        # is not built from a directory name, and it is the "disagreeing input"
+        # the docstring above says the matrix exists to include. Under a
+        # `derive_repo` revert (`label or root.name`) `empty.label` becomes
+        # `brindlemossrepo`, so `cases[0]` collapses into `cases[2]` and
+        # `cases[1]` into `cases[6]`: a 7-case matrix silently becomes 5, the
+        # disagreeing input is GONE, and the positive control below
+        # (`verdicts == {True, False}`) still passes — so nothing signals it.
+        # MEASURED: under that revert this test passes ALONE.
+        assert empty.label == "", (
+            "derive_repo discarded an explicitly empty label — the matrix below "
+            "has collapsed to duplicate cases and no longer contains the input "
+            "this seam test exists for")
         named = hi.derive_repo(good, label="brindlemossrepo")
         bad1 = hi.derive_repo(broken, label="varkelthornrepo")
         bad2 = hi.derive_repo(other, label="glimmerrepo")
@@ -5216,6 +5254,15 @@ class TestThePlanPlumbingThisRoundAddedIsGuarded:
       * M10 — the `kept` bucket reverted from the KIND to `d.unmeasured is not
         None`. Reverting the sibling `measured` bucket is caught by five tests;
         reverting `kept` was caught by none.
+        ⚠ M10's guard is an INVARIANT GUARD, not regression coverage, and is
+        labelled one here because `claude/RULES.md` requires the distinction to
+        be written down rather than inferred: no shipped bug ever violated it —
+        the two spellings agree on every state a real fixture can build, and the
+        third kind that parts them is monkeypatched into existence. It is
+        therefore correctly ABSENT from this PR's red-at-base matrix (it cannot
+        go red at the base; there is nothing at the base for it to catch), and
+        counting it as a regression test would overstate what this round
+        measured.
       * M11 — the downgrade message drops its stated cost. The `nix/home.nix`
         half was pinned; the sentence the RUN prints was not."""
 
@@ -5429,7 +5476,19 @@ class TestEveryGuardThisModuleNamesByNameActuallyExists:
 
     #: `Test[A-Z]…` avoids matching the ordinary word "Tests"; `test_…` catches
     #: the function form. Both are the shapes this repo names guards in.
-    NAME_RE = re.compile(r"\b(?:Test[A-Z][A-Za-z0-9_]*|test_[a-z0-9_]+)\b")
+    #:
+    #: 🔴 THE `test_` ARM'S CHARACTER CLASS IS `[A-Za-z0-9_]`, NOT `[a-z0-9_]`,
+    #: AND THAT ONE CHARACTER WAS THE WHOLE INSTRUMENT. A lowercase-only class
+    #: cannot cross an uppercase letter, and the trailing `\b` cannot fire
+    #: mid-identifier, so a cited name like
+    #: `test_the_gate_fires_in_DRY_RUN_too` matched NOTHING AT ALL — not a
+    #: truncated prefix this file could notice, no match. Three real citations
+    #: in `handoff_index.py` were invisible that way, TWO of them written by the
+    #: round that added this checker's blind-spot note; none dangled, so the
+    #: whole class stayed green and would have stayed green through a rename.
+    #: This repo names guards in SCREAMING_CASE fragments routinely — the
+    #: uppercase half is not an edge case here, it is the house style.
+    NAME_RE = re.compile(r"\b(?:Test[A-Z][A-Za-z0-9_]*|test_[A-Za-z0-9_]+)\b")
 
     def _dangling(self, source: str) -> list[str]:
         """Names `source` cites that no test file defines.
@@ -5447,7 +5506,18 @@ class TestEveryGuardThisModuleNamesByNameActuallyExists:
 
     def test_no_test_name_cited_in_handoff_index_is_dangling(self):
         source = (REPO_ROOT / "scripts" / "lib" / "handoff_index.py").read_text()
-        assert self._dangling(source) == []
+        dangling = self._dangling(source)
+        assert dangling == [], (
+            f"scripts/lib/handoff_index.py cites {len(dangling)} guard name(s) "
+            f"that nothing under scripts/tests/ defines: {dangling}\n"
+            f"This is a repo-WIDE coupling, so ANY rename or deletion of a "
+            f"guard turns it red from a diff that never touched this file — "
+            f"which is the point: the citation is a claim of coverage, and a "
+            f"reader who greps it and finds nothing concludes the invariant is "
+            f"unguarded. Fix by updating the citation in handoff_index.py (or "
+            f"restoring the name). Do NOT delete the sentence around it — the "
+            f"sentence is the claim; deleting it hides the gap instead of "
+            f"closing it. If the guard was renamed, cite the new name.")
 
     def test_the_checker_actually_finds_the_names_it_is_scanning(self):
         """🔴 THE POSITIVE CONTROL. A checker wired to nothing returns the same
@@ -5471,6 +5541,38 @@ class TestEveryGuardThisModuleNamesByNameActuallyExists:
         assert "test_next_steps_split_per_ranked_item_carrying_the_whole_block" \
             in found
         assert "TestARebuildWithNothingReadInFullIsDowngradedNotRefused" not in found
+
+    def test_a_cited_test_name_carrying_a_CAPITAL_is_scanned(self):
+        """🔴 THE REGRESSION. `NAME_RE`'s `test_` arm was `test_[a-z0-9_]+`,
+        which cannot cross an uppercase letter, and `\\b` cannot fire
+        mid-identifier — so a cited name containing a CAPITAL matched nothing at
+        all. Three such citations were live in `handoff_index.py` and this
+        checker could not see one of them.
+
+        None of them dangled, which is exactly why it was invisible: the class
+        was GREEN, and would have stayed green after any rename of the three.
+        The checker read as coverage over every citation in the module while
+        covering 10 of 13.
+
+        Asserted on the REAL citations rather than a synthetic string, so the
+        test fails if they are renamed to a shape the checker cannot see
+        again."""
+        source = (REPO_ROOT / "scripts" / "lib" / "handoff_index.py").read_text()
+        dewrapped = re.sub(r"_\n[ \t]*#?[ \t]*", "_", source)
+        found = set(self.NAME_RE.findall(dewrapped))
+        for name in (
+                "test_the_downgrade_and_the_bound_DELETE_SCOPE_cannot_disagree",
+                "test_the_downgrade_states_its_FULL_cost_not_just_a_section",
+                "test_the_gate_fires_in_DRY_RUN_too"):
+            assert name in found, (
+                f"{name} is cited in handoff_index.py but NAME_RE did not "
+                f"match it — the capital-carrying blind spot is back")
+        # 🔴 THE DISCRIMINATING HALF. The three above could pass on a regex that
+        # matched only their lowercase PREFIX, which would still leave the
+        # checker unable to report a capital-carrying name as dangling. So feed
+        # it one that does not exist and require the WHOLE name back.
+        bogus = "test_a_GUARD_that_never_EXISTED"
+        assert self._dangling(f"# pinned by `{bogus}` above") == [bogus]
 
     def test_the_checker_can_go_RED(self):
         """🔴 THE NEGATIVE CONTROL. Fed a citation of a guard that does not

--- a/scripts/tests/test_handoff_index.py
+++ b/scripts/tests/test_handoff_index.py
@@ -4448,19 +4448,33 @@ class TestThePlanBucketsArePartitionOnTheKindNotOnTheRawFields:
         — so the kind is monkeypatched, which is a supported call on a PURE public
         function rather than a contrivance.
 
-        Both the kind and the reason are patched together: `may_replace_stored_
-        rows` reads the reason, so patching only the kind would leave the repo in
-        the DELETE bucket and the test would pass for the wrong reason.
+        🔴 ONLY THE **KIND** IS PATCHED, AND PATCHING BOTH IS WHY THIS GUARD WAS
+        STRUCTURALLY BLIND. It used to patch `incomplete_reason` alongside it,
+        justified as "patching only the kind would leave the repo in the DELETE
+        bucket" — MEASURED FALSE: `incomplete_reason` calls `incomplete_kind`, so
+        a patched kind already flows through and `may_replace_stored_rows` is
+        `False` with the kind alone. The pair-patch therefore supplied the very
+        output under test, and it concealed a real defect: `incomplete_reason`'s
+        tail was an unguarded `return` of the `docs-unreadable` literal, so the
+        REAL function answered a novel kind with `docs-unreadable (0 of 3)` for a
+        repo with ZERO unreadable docs. The mechanism built to make an
+        unenumerated kind LOUD explained it with a confident wrong reason, and
+        `--json` published the two in adjacent fields.
 
-        RED at the parent commit: the label appears NOWHERE in the plan."""
+        RED at the parent commit on the reason assertion; at the commit before
+        that, the label appeared NOWHERE in the plan."""
         ds = self._mixed(tmp_path)
-        real_kind, real_reason = hi.incomplete_kind, hi.incomplete_reason
+        real_kind = hi.incomplete_kind
         novel = "blob-checksum-mismatch"
         assert novel not in hi.INCOMPLETE_KINDS
         monkeypatch.setattr(hi, "incomplete_kind", lambda d: (
             novel if d.label == "brindlemossrepo" else real_kind(d)))
-        monkeypatch.setattr(hi, "incomplete_reason", lambda d: (
-            f"{novel} (2 of 3)" if d.label == "brindlemossrepo" else real_reason(d)))
+
+        # The fixture's own numbers, so the assertion below cannot be satisfied
+        # by a coincidence: this repo is HEALTHY — nothing unreadable at all —
+        # which is what makes `docs-unreadable (0 of 3)` a visibly false answer.
+        target = next(d for d in ds if d.label == "brindlemossrepo")
+        assert target.unreadable == () and target.docs == 3
 
         lines = hi.rebuild_plan_lines(ds, scoped=True, prune=False, write=True)
         assert "brindlemossrepo" not in _plan_bucket(lines, "DELETE (read in FULL")
@@ -4469,10 +4483,19 @@ class TestThePlanBucketsArePartitionOnTheKindNotOnTheRawFields:
             "a kind the plan does not enumerate must still be REPORTED")
         unclassified = [ln for ln in lines if "UNCLASSIFIED" in ln]
         assert len(unclassified) == 1
-        assert "brindlemossrepo (blob-checksum-mismatch (2 of 3))" in unclassified[0]
+        assert "brindlemossrepo" in unclassified[0]
         # …and the plan says its own buckets are not a complete view, rather than
         # letting a reader count three lines and believe them.
         assert "NOT a complete view" in unclassified[0]
+        # 🔴 THE HALF THE PAIR-PATCH HID. The reason must not borrow another
+        # kind's explanation — it must name the kind it could not classify.
+        reason = hi.incomplete_reason(target)
+        assert "docs-unreadable" not in reason, (
+            f"an unenumerated kind rendered another kind's reason: {reason!r}")
+        assert novel in reason and "UNENUMERATED" in reason
+        # Authority is still WITHHELD — the conservative direction is what the
+        # "kinds not yet invented" promise is for.
+        assert hi.may_replace_stored_rows(target) is False
 
     def test_no_UNCLASSIFIED_line_when_every_kind_is_enumerated(self, tmp_path):
         """The negative control. Without it the assertion above is satisfied by a
@@ -4938,8 +4961,540 @@ class TestHomeNixDescribesTheGuardTheModuleACTUALLYHAS:
         block = self._block()
         assert "REBUILD DOWNGRADED TO AN UPSERT" in block
         assert "A FOURTH STATE EXISTS THAT IS *NOT* A REFUSAL" in block
-        # …and the cost of the downgrade is stated, not discovered.
-        assert "a section REMOVED from a doc keeps its stale row" in block
+
+    def test_the_home_nix_cost_paragraph_IS_the_sentence_the_run_prints(self):
+        """🔴 THE COST IS ONE CLAIM ON THREE SURFACES, SO IT IS ONE STRING.
+
+        This comment and the module's two printers each carried their own copy,
+        and all three were WRONG in the same direction: "a section REMOVED from a
+        doc keeps its stale row" reads as trailing-ordinal drift, while the DELETE
+        is per-repo-LABEL and the upsert key is `(repo, slug, section, ordinal)`
+        — so what persists under a downgrade is every row the run did not
+        re-derive, whole DELETED documents included, and both slugs of a RENAMED
+        one side by side.
+
+        Pinned by IDENTITY rather than by keywords: `home.nix` must contain the
+        constant VERBATIM (modulo comment markers and wrapping, which `_block`
+        normalises away). Correcting one surface and not the others is then a
+        failing test rather than an audit finding — which is how this defect was
+        found, three copies deep."""
+        assert _norm(hi.DOWNGRADE_COST) in self._block()
+
+    def test_the_retracted_cost_wording_cannot_come_back(self):
+        """The old sentence, banned in the same breath. Without this the pin
+        above is satisfied by a comment that says BOTH — and a paragraph holding
+        a claim and its correction leaves the reader to pick."""
+        assert "a section REMOVED from a doc keeps its stale row" not in self._block()
+        assert "a section REMOVED from a doc keeps its stale row" \
+            not in _norm(hi.rebuild_downgrade_reason.__doc__)
 
     def test_the_retracted_wording_cannot_come_back(self):
         assert "meets an unmeasured repo" not in self._block()
+
+
+# --------------------------------------------------------------------------- #
+# Round 2 of the delta audit — the variant chosen off a RENDERED STRING, the
+# unenumerated-kind fall-through, the unguarded plumbing, and the named guards
+# that had rotted.
+# --------------------------------------------------------------------------- #
+
+
+#: 🔴 THE DOWNGRADE'S COST, WRITTEN OUT HERE RATHER THAN IMPORTED. `_ORPHAN_
+#: SENTENCE`'s reason: a pin that reads the implementation's own constant asserts
+#: it against itself and cannot see a reword. The module, `nix/home.nix` and this
+#: literal are three independent statements of one claim, and the suite fails
+#: unless all three agree.
+_DOWNGRADE_COST = _norm(
+    "EVERY row this run did not re-derive persists until some repo reads in "
+    "FULL again — not just a section removed from a doc, but ALL rows of a doc "
+    "DELETED from the repo, and for a RENAMED doc both the old and the new "
+    "slug's rows, which a search returns side by side as two documents."
+)
+
+
+class TestTheAllBadArmIsChosenByCOUNTNotByARenderedString:
+    """🔴 A VARIANT PICKED OFF A RENDERED STRING, SO A DELETE THAT HAPPENED WAS
+    REPORTED AS NOT HAVING HAPPENED. `partial_scope_warnings` built
+    `ok = ", ".join(d.label for d in derivations if may_replace_stored_rows(d))`
+    and then branched on `if not ok:`. A label is `Path(r).name` (`main`), so
+    `--repo .` derives `""` — and a run whose ONLY replaceable repo is that one
+    joins to `""`, which is falsy, and took the ALL-BAD arm.
+
+    MEASURED at the parent commit through `main` with a recording store,
+    `--repo . --repo <broken> --rebuild --write` — ONE run, THREE contradicting
+    statements about it:
+
+        STORE CALLS: [('write', True, ('',))]   # rebuild=True: a DELETE WAS bound
+        stderr : 🔴 NOTHING WAS READ COMPLETELY — all 2 configured repo(s) were
+                 incomplete … the delete scope is EMPTY … NOTHING was deleted
+        stdout :   DELETE (read in FULL, will be re-derived): (none)
+        stdout : wrote 3 section row(s) … (after DELETE of 1 repo label(s):  …)
+        rc 0
+
+    The middle statement denies a DELETE the first and third record, and the
+    sentence contradicts itself in isolation — "all 2 … were incomplete" and then
+    naming one. The pre-flight's `', '.join(measured) or '(none)'` is the SAME
+    root cause one function over, which is why both are fixed and both are
+    pinned here: one bug printed in two places is how the second copy outlives
+    the fix.
+
+    ⚠ THE FIXTURES USE AN EMPTY LABEL DELIBERATELY. Every pre-existing fixture in
+    this file uses non-empty labels, which is exactly why a full green suite,
+    a mutation sweep and a round-1 audit all missed this: the difference between
+    a COUNT and a rendered string cannot appear while every label renders."""
+
+    def _empty_label_plus_broken(self, tmp_path):
+        """One repo read in FULL whose label renders EMPTY, one partially read.
+
+        🔴 THE FIXTURE ASSERTS ITSELF, because it could not build the state it
+        names. `derive_repo` read `name = label or root.name`, so an EXPLICIT
+        empty label was discarded and replaced by the directory name — the same
+        falsy-string shape as the two defects this class is about, a third site.
+        Without the assertion below every test here would run against a repo
+        labelled `brindlemossrepo` and pass VACUOUSLY, which is precisely how the
+        original defect survived a green suite."""
+        good = tmp_path / "brindlemossrepo"
+        broken = tmp_path / "varkelthornrepo"
+        _write_repo(good, _TRIAD)
+        _write_repo(broken, _TRIAD)
+        _break_doc_blob(broken, "claudedocs/handoff-quorlbane-cache.md")
+        ds = [hi.derive_repo(good, label=""),
+              hi.derive_repo(broken, label="varkelthornrepo")]
+        assert ds[0].label == "", (
+            "derive_repo discarded an explicitly empty label — this fixture "
+            "cannot exercise the defect it was written for")
+        assert hi.may_replace_stored_rows(ds[0]) is True
+        assert hi.may_replace_stored_rows(ds[1]) is False
+        return ds
+
+    def test_an_EMPTY_label_is_what_main_derives_from_repo_dot(self, tmp_path,
+                                                               monkeypatch,
+                                                               capsys):
+        """🔴 REACHABILITY, PROVED THROUGH `main` RATHER THAN ASSERTED. The whole
+        finding rests on a label that renders as nothing being a state a real
+        argv produces, so that is measured here and not reasoned about:
+        `Path(".").name == ""`, and `main` labels a `--repo` with exactly that."""
+        assert Path(".").name == ""
+        repo = tmp_path / "brindlemossrepo"
+        _write_repo(repo, _TRIAD)
+        monkeypatch.chdir(repo)
+        # Driven through `main --json` so the LABEL under test is the one the CLI
+        # derived, not one the test chose.
+        rc = hi.main(["--repo", ".", "--json"])
+        assert rc == hi.RC_OK
+        payload = json.loads(capsys.readouterr().out)
+        assert [r["label"] for r in payload["repos"]] == [""]
+
+    def test_a_replaceable_repo_whose_label_renders_EMPTY_is_not_an_all_bad_run(
+            self, tmp_path):
+        """THE REGRESSION. One repo WAS read in full, so the run is PARTIAL —
+        never "nothing was read completely"."""
+        ds = self._empty_label_plus_broken(tmp_path)
+        assert hi.nothing_was_read_completely(ds) is False
+        assert hi.rebuild_downgrade_reason(ds) is None
+        text = "\n".join(hi.partial_scope_warnings(ds))
+        assert "NOTHING WAS READ COMPLETELY" not in text, (
+            "a run with a replaceable repo took the all-bad arm because that "
+            "repo's label renders as the empty string")
+        assert "PARTIAL INDEX" in text
+        # …and the delete scope really is non-empty, which is the fact the
+        # retracted sentence denied.
+        assert hi.rebuild_delete_labels(
+            ds, (), scoped=True, prune=False) == ("",)
+
+    def test_the_plan_distinguishes_an_EMPTY_label_from_an_EMPTY_bucket(
+            self, tmp_path):
+        """The pre-flight half. `', '.join(measured) or '(none)'` printed
+        `(none)` — "this run deletes nothing" — for a bucket holding one repo
+        whose label renders empty. `(none)` and a blank are now different
+        renderings, because they are different facts."""
+        ds = self._empty_label_plus_broken(tmp_path)
+        lines = hi.rebuild_plan_lines(ds, scoped=True, prune=False, write=True)
+        delete_line = [ln for ln in lines
+                       if ln.strip().startswith("DELETE (read in FULL")][0]
+        assert "(none)" not in delete_line, (
+            "the DELETE bucket is NOT empty — it holds one repo whose label "
+            "renders as the empty string")
+        assert _plan_bucket(lines, "DELETE (read in FULL") == [""]
+        # The negative control: a genuinely empty bucket still says (none), or
+        # the assertion above is satisfied by a plan that never says it.
+        only_broken = [d for d in ds if d.label == "varkelthornrepo"]
+        empty_lines = hi.rebuild_plan_lines(only_broken, scoped=True,
+                                            prune=False, write=True)
+        assert _plan_bucket(empty_lines, "DELETE (read in FULL") == []
+
+    def test_the_two_owners_of_the_downgrade_decision_cannot_disagree(
+            self, tmp_path):
+        """🔴 THE SEAM, AND THE POINT OF THE CONSOLIDATION. `rebuild_downgrade_
+        reason` and `partial_scope_warnings` are two renderings of ONE decision.
+        They were two SPELLINGS of it, and the empty label is an input on which
+        the spellings disagreed. Asserted as a relationship over a fixture matrix
+        that includes the disagreeing input — a structural check over non-empty
+        labels alone is exactly the coverage that already existed."""
+        good = tmp_path / "brindlemossrepo"
+        broken = tmp_path / "varkelthornrepo"
+        other = tmp_path / "glimmerrepo"
+        _write_repo(good, _TRIAD)
+        _write_repo(broken, _TRIAD)
+        _write_repo(other, _TRIAD)
+        _break_doc_blob(broken, "claudedocs/handoff-quorlbane-cache.md")
+        _break_doc_blob(other, "claudedocs/handoff-fandrelly-probe.md")
+
+        empty = hi.derive_repo(good, label="")
+        named = hi.derive_repo(good, label="brindlemossrepo")
+        bad1 = hi.derive_repo(broken, label="varkelthornrepo")
+        bad2 = hi.derive_repo(other, label="glimmerrepo")
+        absent = hi.derive_repo(tmp_path / "sundrellipexrepo",
+                                label="sundrellipexrepo")
+
+        cases = [
+            [empty, bad1],          # the disagreeing input
+            [empty],                # replaceable, and the ONLY label is empty
+            [named, bad1],
+            [bad1, bad2],           # genuinely all-bad
+            [bad1, absent],         # all-bad, both kinds
+            [absent],
+            [named],
+        ]
+        for ds in cases:
+            downgraded = hi.rebuild_downgrade_reason(ds) is not None
+            warned = any("NOTHING WAS READ COMPLETELY" in w
+                         for w in hi.partial_scope_warnings(ds))
+            assert downgraded == warned, [d.label for d in ds]
+            # …and both are the ONE predicate, not a third spelling.
+            assert downgraded == hi.nothing_was_read_completely(ds), \
+                [d.label for d in ds]
+        # The positive control: the matrix must actually contain both verdicts,
+        # or `downgraded == warned` is satisfied by everything being False.
+        verdicts = {hi.nothing_was_read_completely(ds) for ds in cases}
+        assert verdicts == {True, False}
+
+    def test_through_main_the_DELETE_and_every_sentence_about_it_agree(
+            self, tmp_path, monkeypatch, capsys):
+        """🔴 THE MEASURED SHAPE, END TO END, WITH THE RECORDING STORE. The three
+        contradicting statements in this class's docstring came from ONE run, so
+        the regression is pinned as one run: what got BOUND, what the pre-flight
+        planned, what the warning said, and what the success line claimed."""
+        good = tmp_path / "brindlemossrepo"
+        broken = tmp_path / "varkelthornrepo"
+        _write_repo(good, _TRIAD)
+        _write_repo(broken, _TRIAD)
+        _break_doc_blob(broken, "claudedocs/handoff-quorlbane-cache.md")
+        monkeypatch.chdir(good)
+
+        conn = StoredReposConn(("", "varkelthornrepo"))
+        rc = hi.main(["--repo", ".", "--repo", str(broken), "--rebuild",
+                      "--write"], open_store=_recording_store(conn))
+        cap = capsys.readouterr()
+        assert rc == hi.RC_OK
+        bound = conn.params_for("DELETE")
+        assert bound == [[[""]]], bound
+        # 1. The warning must not deny the DELETE that was just bound.
+        assert "NOTHING WAS READ COMPLETELY" not in cap.err + cap.out
+        assert "PARTIAL INDEX" in cap.err
+        # 2. The pre-flight must not report the bound scope as empty.
+        planned = _plan_bucket(cap.out.splitlines(), "DELETE (read in FULL")
+        assert planned == sorted(bound[0][0]) == [""], (planned, bound)
+        # 3. The run took a real rebuild, so it must not claim a downgrade.
+        assert "REBUILD DOWNGRADED" not in cap.out
+        assert "DOWNGRADED to an upsert" not in cap.out
+        assert "after DELETE of 1 repo label(s)" in cap.out
+
+
+class TestThePlanPlumbingThisRoundAddedIsGuarded:
+    """🔴 THREE MUTANTS THAT SURVIVED A FULL GREEN SUITE, TWO OF THEM ON CODE
+    ADDED IN THE ROUND THAT SWEPT FOR THEM. From an independent 13-mutant sweep
+    (fresh tree per mutant, `PYTHONDONTWRITEBYTECODE=1`, a no-op negative control
+    that SURVIVED and a known-caught positive control that DIED):
+
+      * M8 — `rebuild_plan_lines`' header ignores `downgraded`. Nothing in the
+        suite referenced `downgraded=` or the SKIPPED header at all, so the
+        parameter, the header string AND `main`'s call-site argument could each
+        be deleted with the suite green — while the commit message calls the
+        pre-flight "the operator's only view of what the run destroys". The
+        nearest test asserts text from `rebuild_downgrade_reason`, not the plan.
+      * M10 — the `kept` bucket reverted from the KIND to `d.unmeasured is not
+        None`. Reverting the sibling `measured` bucket is caught by five tests;
+        reverting `kept` was caught by none.
+      * M11 — the downgrade message drops its stated cost. The `nix/home.nix`
+        half was pinned; the sentence the RUN prints was not."""
+
+    def _mixed(self, tmp_path):
+        healthy = tmp_path / "brindlemossrepo"
+        broken = tmp_path / "varkelthornrepo"
+        _write_repo(healthy, _TRIAD)
+        _write_repo(broken, _TRIAD)
+        _break_doc_blob(broken, "claudedocs/handoff-quorlbane-cache.md")
+        return [hi.derive_repo(healthy, label="brindlemossrepo"),
+                hi.derive_repo(broken, label="varkelthornrepo"),
+                hi.derive_repo(tmp_path / "sundrellipexrepo",
+                               label="sundrellipexrepo")]
+
+    # ---- M8 ---------------------------------------------------------------- #
+
+    def test_the_plan_HEADER_says_the_DELETE_is_SKIPPED_when_downgraded(
+            self, tmp_path):
+        """M8. A plan headed "rebuild delete scope" above a run that takes no
+        DELETE is the defect the gate-ordering fix already closed once, one line
+        further in: the block is printed, its heading names a DELETE, and the
+        DELETE does not happen."""
+        ds = self._mixed(tmp_path)
+        header = hi.rebuild_plan_lines(ds, scoped=True, prune=False, write=True,
+                                       downgraded=True)[0]
+        assert header == (
+            "## rebuild delete scope — SKIPPED (the --rebuild is DOWNGRADED to "
+            "an upsert; NOTHING is deleted)")
+
+    def test_the_plan_HEADER_is_plain_when_the_DELETE_really_runs(self, tmp_path):
+        """M8's negative control. Without it the assertion above is satisfied by
+        a header that says SKIPPED unconditionally — which would tell an operator
+        that every rebuild deletes nothing."""
+        ds = self._mixed(tmp_path)
+        header = hi.rebuild_plan_lines(ds, scoped=True, prune=False, write=True,
+                                       downgraded=False)[0]
+        assert header == "## rebuild delete scope"
+        # …and the default is the plain one, so a caller that forgets the
+        # argument does not silently claim a downgrade.
+        assert hi.rebuild_plan_lines(
+            ds, scoped=True, prune=False, write=True)[0] == header
+
+    def test_MAIN_passes_the_downgrade_through_to_the_plan_header(
+            self, tmp_path, capsys):
+        """🔴 M8's THIRD SITE. The parameter and the header string are dead
+        unless `main` actually passes its decision in — and `main`'s argument was
+        deletable with the suite green too. Driven end to end so the header an
+        operator sees is the one asserted, over BOTH verdicts."""
+        a = tmp_path / "glimmerrepo"
+        b = tmp_path / "quorlrepo"
+        for root in (a, b):
+            _write_repo(root, _TRIAD)
+            _break_doc_blob(root, "claudedocs/handoff-fandrelly-probe.md")
+        conn = StoredReposConn(("glimmerrepo", "quorlrepo"))
+        rc = hi.main(["--repo", str(a), "--repo", str(b), "--rebuild", "--write"],
+                     open_store=_recording_store(conn))
+        out = capsys.readouterr().out
+        assert rc == hi.RC_OK and "DELETE" not in conn.kinds()
+        assert "## rebuild delete scope — SKIPPED (the --rebuild is DOWNGRADED" \
+            in out
+
+        healthy = tmp_path / "brindlemossrepo"
+        _write_repo(healthy, _TRIAD)
+        conn2 = StoredReposConn(("brindlemossrepo",))
+        rc = hi.main(["--repo", str(healthy), "--rebuild", "--write"],
+                     open_store=_recording_store(conn2))
+        out2 = capsys.readouterr().out
+        assert rc == hi.RC_OK and conn2.params_for("DELETE") == [[["brindlemossrepo"]]]
+        assert "## rebuild delete scope" in out2
+        assert "SKIPPED" not in out2
+
+    # ---- M10 --------------------------------------------------------------- #
+
+    def test_the_UNMEASURED_bucket_is_keyed_on_the_KIND_not_the_raw_field(
+            self, tmp_path, monkeypatch):
+        """M10. `kept` reverted to `d.unmeasured is not None` survives every
+        existing test, because that spelling and `incomplete_kind(d) ==
+        INCOMPLETE_UNMEASURED` agree on every state a plain fixture can build.
+        They part company the moment a THIRD kind claims a repo whose
+        `unmeasured` field is set — which is precisely the future the bucketing
+        was consolidated for, and the raw-field spelling then files that repo
+        under UNMEASURED *and* under UNCLASSIFIED: two mutually exclusive
+        buckets, one repo.
+
+        Only the KIND is patched (see `test_a_THIRD_kind_of_incompleteness_is_
+        REPORTED_not_dropped`), and the target is the ABSENT repo, whose
+        `unmeasured` is a real non-`None` token — so the mutant's predicate is
+        TRUE for it and the correct one is FALSE."""
+        ds = self._mixed(tmp_path)
+        target = next(d for d in ds if d.label == "sundrellipexrepo")
+        assert target.unmeasured is not None, "the mutant's predicate must be TRUE here"
+        real_kind = hi.incomplete_kind
+        novel = "blob-checksum-mismatch"
+        assert novel not in hi.INCOMPLETE_KINDS
+        monkeypatch.setattr(hi, "incomplete_kind", lambda d: (
+            novel if d.label == "sundrellipexrepo" else real_kind(d)))
+
+        lines = hi.rebuild_plan_lines(ds, scoped=True, prune=False, write=True)
+        unmeasured = _plan_bucket(lines, "KEPT (configured but UNMEASURED)")
+        assert unmeasured == [], (
+            "a repo whose KIND is not `unmeasured` must not appear in the "
+            "UNMEASURED bucket, whatever its raw field says")
+        # …and it is reported exactly once, under the bucket it belongs to.
+        assert sum("sundrellipexrepo" in ln for ln in lines) == 1
+        unclassified = [ln for ln in lines if "UNCLASSIFIED" in ln]
+        assert len(unclassified) == 1 and "sundrellipexrepo" in unclassified[0]
+
+    def test_the_UNMEASURED_bucket_still_holds_a_genuinely_unmeasured_repo(
+            self, tmp_path):
+        """M10's negative control — otherwise the assertion above is satisfied by
+        a bucket that is always empty, i.e. a plan that never reports an absent
+        checkout at all."""
+        ds = self._mixed(tmp_path)
+        lines = hi.rebuild_plan_lines(ds, scoped=True, prune=False, write=True)
+        assert _plan_bucket(lines, "KEPT (configured but UNMEASURED)") == [
+            "sundrellipexrepo"]
+
+    # ---- M11 --------------------------------------------------------------- #
+
+    def test_the_downgrade_states_its_FULL_cost_not_just_a_section(self, tmp_path):
+        """M11. The cost sentence is what an operator uses to decide whether a
+        downgraded run is survivable, and it was unpinned at the one surface that
+        prints it. Pinned as a WHOLE NORMALISED STRING, `_ORPHAN_SENTENCE`'s
+        reason: a guard on WORDS is walkable by rewording.
+
+        It is also the sentence that was WRONG — "a section REMOVED from a doc"
+        describes trailing-ordinal drift, and the real residue is whole
+        documents. See `TestHomeNixDescribesTheGuardTheModuleACTUALLYHAS`, which
+        pins the same string in `nix/home.nix`."""
+        a = tmp_path / "glimmerrepo"
+        b = tmp_path / "quorlrepo"
+        for root in (a, b):
+            _write_repo(root, _TRIAD)
+            _break_doc_blob(root, "claudedocs/handoff-fandrelly-probe.md")
+        ds = [hi.derive_repo(a, label="glimmerrepo"),
+              hi.derive_repo(b, label="quorlrepo")]
+        assert _DOWNGRADE_COST in _norm(hi.rebuild_downgrade_reason(ds))
+        # The SAME sentence on the other surface that prints it — one claim, and
+        # the all-bad warning used to carry its own drifting copy.
+        assert _DOWNGRADE_COST in _norm("\n".join(hi.partial_scope_warnings(ds)))
+        # And the module's constant IS that sentence, so `home.nix`'s pin and
+        # this one cannot be satisfied by two different strings.
+        assert _norm(hi.DOWNGRADE_COST) == _DOWNGRADE_COST
+
+
+class TestTheRunLevelDowngradeIsPublishedNotWordMatched:
+    """🔴 A DOWNGRADED RUN AND A CLEAN REBUILD ARE BOTH rc 0, SO A MACHINE
+    CONSUMER HAD ONLY THE PROSE. `derivation_json` published per-repo
+    `rebuildable` and `incomplete_kind` but no RUN-level field, so a `--json`
+    caller had to word-match `"NOTHING WAS READ COMPLETELY"` out of `warnings` —
+    the guard-on-WORDS this module refuses everywhere else, and the exact reason
+    `incomplete_kind` was split out of `incomplete_reason`. `all_clear` is
+    reliably `False` under a downgrade but is `False` under a dozen other things
+    too, so it cannot be branched on."""
+
+    def _all_bad(self, tmp_path):
+        a = tmp_path / "glimmerrepo"
+        b = tmp_path / "quorlrepo"
+        for root in (a, b):
+            _write_repo(root, _TRIAD)
+            _break_doc_blob(root, "claudedocs/handoff-fandrelly-probe.md")
+        return [hi.derive_repo(a, label="glimmerrepo"),
+                hi.derive_repo(b, label="quorlrepo")]
+
+    def test_the_json_carries_the_downgrade_as_a_BOOLEAN(self, tmp_path):
+        ds = self._all_bad(tmp_path)
+        payload = hi.derivation_json(ds)
+        assert payload["rebuild_would_be_downgraded"] is True
+        # It is the SAME decision `main` branches on, not a second spelling.
+        assert payload["rebuild_would_be_downgraded"] == (
+            hi.rebuild_downgrade_reason(ds) is not None)
+
+    def test_a_healthy_run_publishes_FALSE(self, tmp_path):
+        """The negative control. A field that is always True is not a signal —
+        and `all_clear` is False for this run too (it carries warnings), which is
+        exactly why `all_clear` could not serve as the downgrade flag."""
+        healthy = tmp_path / "brindlemossrepo"
+        _write_repo(healthy, _TRIAD)
+        ds = [*self._all_bad(tmp_path),
+              hi.derive_repo(healthy, label="brindlemossrepo")]
+        payload = hi.derivation_json(ds)
+        assert payload["rebuild_would_be_downgraded"] is False
+        assert payload["all_clear"] is False, (
+            "the discriminating claim: `all_clear` cannot tell a downgraded run "
+            "from a merely partial one, which is why this field exists")
+
+    def test_the_field_survives_the_CLI_json_surface(self, tmp_path, capsys):
+        """Through `main --json`, because the field is for the surface an agent
+        reads and a key present only in the pure function is not published."""
+        a = tmp_path / "glimmerrepo"
+        _write_repo(a, _TRIAD)
+        _break_doc_blob(a, "claudedocs/handoff-fandrelly-probe.md")
+        rc = hi.main(["--repo", str(a), "--json"])
+        assert rc == hi.RC_OK
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["rebuild_would_be_downgraded"] is True
+
+
+class TestEveryGuardThisModuleNamesByNameActuallyExists:
+    """🔴 A COMMENT THAT NAMES A GUARD IS A CLAIM OF COVERAGE, AND TWO OF THEM
+    NAMED NOTHING. `INCOMPLETE_KINDS` cited `incomplete_kinds_are_partitioned`
+    and `rebuild_downgrade_reason` cited
+    `TestARebuildWithNothingReadInFullIsDowngradedNotRefused`; neither has ever
+    existed. Both guards DO exist under other names, which is the bad case: a
+    reader greps the cited name, finds nothing, and concludes the invariant is
+    unguarded — so the comment reads as coverage while providing none, which
+    `claude/RULES.md` calls worse than no comment because it stops anyone
+    looking.
+
+    Prose cannot be trusted to stay true, so this is machine-checked."""
+
+    #: `Test[A-Z]…` avoids matching the ordinary word "Tests"; `test_…` catches
+    #: the function form. Both are the shapes this repo names guards in.
+    NAME_RE = re.compile(r"\b(?:Test[A-Z][A-Za-z0-9_]*|test_[a-z0-9_]+)\b")
+
+    def _dangling(self, source: str) -> list[str]:
+        """Names `source` cites that no test file defines.
+
+        🔴 IT DE-WRAPS FIRST. A long guard name does not fit an 79-column
+        comment, and the module wraps one mid-identifier across a `#` line
+        break; scanning the raw text would report that half as dangling. The
+        rule is narrow and mechanical — a line ending in `_` continues into the
+        next line's first token — and a wrap done any OTHER way fails this test,
+        which is the correct outcome: fix the wrap or fix the name."""
+        dewrapped = re.sub(r"_\n[ \t]*#?[ \t]*", "_", source)
+        defined = _defined_test_names()
+        return sorted({n for n in self.NAME_RE.findall(dewrapped)
+                       if n not in defined})
+
+    def test_no_test_name_cited_in_handoff_index_is_dangling(self):
+        source = (REPO_ROOT / "scripts" / "lib" / "handoff_index.py").read_text()
+        assert self._dangling(source) == []
+
+    def test_the_checker_actually_finds_the_names_it_is_scanning(self):
+        """🔴 THE POSITIVE CONTROL. A checker wired to nothing returns the same
+        clean `[]` as a checker over a clean file, so the zero above is worthless
+        until the scan is shown to SEE something.
+
+        The retracted `Test…` name is asserted absent too, so the clean run
+        cannot be reached by it quietly coming back. The other dead citation was
+        bare snake_case, which `NAME_RE` does not recognise at all — that is the
+        checker's stated blind spot (see `INCOMPLETE_KINDS`), and asserting on it
+        here would claim a coverage this instrument does not have."""
+        source = (REPO_ROOT / "scripts" / "lib" / "handoff_index.py").read_text()
+        dewrapped = re.sub(r"_\n[ \t]*#?[ \t]*", "_", source)
+        found = set(self.NAME_RE.findall(dewrapped))
+        assert len(found) >= 5, sorted(found)
+        assert "TestThePlanDescribesTheRunThatActuallyHappens" in found
+        assert "test_every_configured_repo_lands_in_exactly_one_bucket" in found
+        # 🔴 THE WRAPPED CITATION, which is the case the de-wrap exists for: it
+        # is scanned as one name, so the de-wrap is exercised by the real file
+        # and not only by the synthetic case below.
+        assert "test_next_steps_split_per_ranked_item_carrying_the_whole_block" \
+            in found
+        assert "TestARebuildWithNothingReadInFullIsDowngradedNotRefused" not in found
+
+    def test_the_checker_can_go_RED(self):
+        """🔴 THE NEGATIVE CONTROL. Fed a citation of a guard that does not
+        exist, it must report it — otherwise the clean run above is a fact about
+        the instrument, not about the module. Built from the REAL retracted name,
+        not a nonsense token, so it is the shape that actually shipped."""
+        bogus = "TestARebuildWithNothingReadInFullIsDowngradedNotRefused"
+        assert self._dangling(f"# see `{bogus}` for the pin") == [bogus]
+        # …and a wrapped citation of a name that DOES exist is not reported,
+        # which is what the de-wrap is for.
+        assert self._dangling(
+            "# pinned by test_every_configured_repo_lands_in_exactly_\n"
+            "    # one_bucket, which asserts the partition") == []
+
+
+def _defined_test_names() -> set[str]:
+    """Every test module, class and function name `scripts/tests/` defines.
+
+    Module STEMS count too: the module docstring cites `test_handoff_index`,
+    which is a file rather than a callable."""
+    names: set[str] = set()
+    for path in sorted((REPO_ROOT / "scripts" / "tests").rglob("*.py")):
+        names.add(path.stem)
+        for match in re.finditer(r"^\s*(?:def|class)\s+([A-Za-z_][A-Za-z0-9_]*)",
+                                 path.read_text(), re.M):
+            names.add(match.group(1))
+    return names

--- a/scripts/tests/test_handoff_index.py
+++ b/scripts/tests/test_handoff_index.py
@@ -32,6 +32,7 @@ hostname appears.
 from __future__ import annotations
 
 import importlib.util
+import inspect
 import json
 import os
 import re
@@ -4125,14 +4126,36 @@ class TestThePartialPromiseCoversTheUnreadableRepoToo:
 
 
 class TestNoRepoReadInFullIsRefusedNotCrashed:
-    """🔴 THE ARM THE WIDER SCOPE MADE NECESSARY. `PostgresSectionStore.write`
-    RAISES on an empty rebuild scope — deliberately, so a caller that forgets the
-    scope cannot get a whole-table wipe as the default — and until now
-    `rebuild_refusal` guaranteed the scope was non-empty: "not every repo is
-    unmeasured" implied "at least one repo is in the scope". With authority
-    withheld from partially-readable repos that implication is gone, and a
-    traceback out of a 6h timer is a worse report than a refusal naming the
-    repos and a remedy."""
+    """🔴 THE STATE THE WIDER SCOPE MADE REACHABLE, AND THE ANSWER IT GETS —
+    WHICH IS A DOWNGRADE, NOT A REFUSAL. `PostgresSectionStore.write` RAISES on an
+    empty rebuild scope, deliberately, so a caller that forgets the scope cannot
+    get a whole-table wipe as the default; and until the widening
+    `rebuild_refusal` guaranteed the scope was non-empty, because "not every repo
+    is unmeasured" implied "at least one repo is in the scope". That implication
+    is gone.
+
+    🔴 THE FIRST ANSWER WAS A FOURTH REFUSAL ARM AT rc 4, AND IT SHIPPED FOR ONE
+    COMMIT. MEASURED on the TIMER's own argv — `--rebuild --write`, unscoped, one
+    handle pointing at a real checkout with ONE corrupt blob and three pointing at
+    absent ones:
+
+        pre-widening : rc 0   DELETE + 18 INSERTs   index refreshed, PARTIAL
+        that arm     : rc 4   SQL kinds: []         nothing written at all
+        here         : rc 0   no DELETE, 18 INSERTs index refreshed, PARTIAL
+
+    (`test_the_TIMERS_OWN_ARGV_in_the_state_home_nix_calls_SUPPORTED` below is
+    that exact fixture, so the third row is asserted rather than quoted.)
+
+    Three absent checkouts is not a broken machine — `nix/home.nix` states in as
+    many words that it is SUPPORTED and that the price is a standing warning. So
+    the refusal turned a supported state into `OnFailure=notify-failure@%n
+    .service` every 6h until a human repaired an object store, with the index
+    frozen meanwhile: `claude/RULES.md`'s permanently-red gate, which is the
+    mistake this same function's all-unmeasured arm had to unwind once already.
+
+    The fallback is not an invention either — it is the sentence that refusal
+    printed as its own remedy ("Re-running WITHOUT --rebuild is a real remedy
+    here"). A remedy only a human can type is not a remedy for a unit."""
 
     def _all_partial(self, tmp_path):
         a = tmp_path / "glimmerrepo"
@@ -4142,39 +4165,118 @@ class TestNoRepoReadInFullIsRefusedNotCrashed:
             _break_doc_blob(root, "claudedocs/handoff-fandrelly-probe.md")
         return a, b
 
-    def test_a_rebuild_with_nothing_read_in_FULL_refuses_before_the_store_opens(
+    def test_a_rebuild_with_nothing_read_in_FULL_writes_and_deletes_NOTHING(
             self, tmp_path, capsys):
-        """`_refusing_store()` is the positive control: an assertion on the exit
-        code alone cannot tell a refusal from a write that happened and then
-        returned non-zero. It also proves the empty scope never reaches
-        `write()`, which is where the raise lives."""
-        a, b = self._all_partial(tmp_path)
-        rc = hi.main(["--repo", str(a), "--repo", str(b), "--rebuild", "--write"],
-                     open_store=_refusing_store())
-        err = capsys.readouterr().err
-        assert rc == hi.RC_REFUSED
-        assert "not ONE of the 2 repo(s) was read COMPLETELY" in err
-        assert "the delete scope would be EMPTY" in err
-        # It must NOT reach for the all-unmeasured arm's remedy: both repos
-        # resolved, so "fix the repo handles" would be a confident wrong step.
-        assert "came back UNMEASURED" not in err
-
-    def test_the_remedy_it_names_is_a_run_that_actually_writes(self, tmp_path, capsys):
-        """🔴 A REMEDY IS A CLAIM ABOUT THE STATE IT IS PRINTED IN, and the
-        all-unmeasured arm one screen up had to RETRACT this exact sentence for
-        being false in its own state ("re-run without --rebuild" writes 0 rows
-        when nothing measured). Here the zero-rows arm has already returned for
-        every derivation with no rows, so `rows` is non-empty by construction —
-        and the claim is measured rather than reasoned about."""
+        """🔴 THE REGRESSION, END TO END. At the parent commit this argv exited 4
+        with the store never opened; the recording connection is what proves the
+        write now HAPPENS rather than merely that the exit code moved, and
+        `"DELETE" not in kinds` is what proves the downgrade is a downgrade and
+        not a rebuild that got its scope from somewhere else."""
         a, b = self._all_partial(tmp_path)
         conn = StoredReposConn(("glimmerrepo", "quorlrepo"))
-        rc = hi.main(["--repo", str(a), "--repo", str(b), "--write"],
+        rc = hi.main(["--repo", str(a), "--repo", str(b), "--rebuild", "--write"],
                      open_store=_recording_store(conn))
-        out = capsys.readouterr().out
+        cap = capsys.readouterr()
         assert rc == hi.RC_OK
         assert conn.kinds().count("INSERT") > 0
         assert "DELETE" not in conn.kinds()
-        assert "wrote 0 section row(s)" not in out
+        assert "REBUILD DOWNGRADED TO AN UPSERT" in cap.out
+        assert "the delete scope would be EMPTY" in cap.out
+        # It must NOT reach for the all-unmeasured arm's language: both repos
+        # resolved, so "fix the repo handles" would be a confident wrong step.
+        assert "came back UNMEASURED" not in cap.out + cap.err
+        assert "REFUSING" not in cap.err
+        # …and the success line says the rebuild did not happen, because
+        # `wrote N section row(s)` otherwise reads as a completed rebuild.
+        assert "--rebuild DOWNGRADED to an upsert — nothing was deleted" in cap.out
+
+    def test_the_TIMERS_OWN_ARGV_in_the_state_home_nix_calls_SUPPORTED(
+            self, tmp_path, monkeypatch, capsys):
+        """🔴 THE MEASURED SHAPE, REPRODUCED WITH THE UNIT'S ARGV RATHER THAN
+        `--repo`. Scoped runs and unscoped runs take different branches of
+        `rebuild_delete_labels`, and it is the UNSCOPED one the timer takes — so
+        a regression test driven only by `--repo` would not have covered the run
+        that regressed.
+
+        One handle present (a real checkout, one corrupt blob), the rest absent:
+        exactly `nix/home.nix`'s SUPPORTED state plus a repairable object
+        store."""
+        handles = {}
+        present = tmp_path / "brindlemossrepo"
+        _write_repo(present, _TRIAD)
+        _break_doc_blob(present, "claudedocs/handoff-quorlbane-cache.md")
+        handles[hi.REPO_ENV_HANDLES[0]] = str(present)
+        for handle in hi.REPO_ENV_HANDLES[1:]:
+            handles[handle] = str(tmp_path / f"absent-{handle.lower()}")
+        _apply_handles(monkeypatch, handles)
+
+        conn = StoredReposConn(("brindlemossrepo",))
+        rc = hi.main(["--rebuild", "--write"], open_store=_recording_store(conn))
+        cap = capsys.readouterr()
+        assert rc == hi.RC_OK, "a SUPPORTED state must not fire OnFailure 4x/day"
+        # 🔴 THE EXACT ROW COUNT, because "> 0" cannot tell "the two readable docs
+        # were indexed" from "one was". MEASURED at 18 here and at the commit
+        # BEFORE the widening; the refusing commit wrote 0.
+        assert conn.kinds().count("INSERT") == 18
+        assert "DELETE" not in conn.kinds()
+        assert "REBUILD DOWNGRADED TO AN UPSERT" in cap.out
+        # Both kinds of incompleteness are named, with their own reasons.
+        assert "brindlemossrepo (docs-unreadable (1 of 3))" in cap.out
+        assert f"absent-{hi.REPO_ENV_HANDLES[1].lower()} (no-such-directory)" in cap.out
+
+    def test_ONE_repo_read_in_FULL_anywhere_keeps_the_DELETE(self, tmp_path, capsys):
+        """🔴 THE NEGATIVE CONTROL, AND WITHOUT IT EVERY ASSERTION ABOVE IS
+        SATISFIED BY A RUN THAT NEVER DELETES ANYTHING — which would be a
+        permanently-DEAD rebuild rather than a permanently-red one. The same two
+        repos, one blob apart: the second is left intact."""
+        a, b = self._all_partial(tmp_path)
+        healthy = tmp_path / "brindlemossrepo"
+        _write_repo(healthy, _TRIAD)
+        conn = StoredReposConn(("glimmerrepo", "quorlrepo", "brindlemossrepo"))
+        rc = hi.main(["--repo", str(a), "--repo", str(b), "--repo", str(healthy),
+                      "--rebuild", "--write"], open_store=_recording_store(conn))
+        cap = capsys.readouterr()
+        assert rc == hi.RC_OK
+        assert conn.params_for("DELETE") == [[["brindlemossrepo"]]]
+        assert "REBUILD DOWNGRADED" not in cap.out
+
+    def test_the_downgrade_and_the_bound_DELETE_SCOPE_cannot_disagree(self, tmp_path):
+        """🔴 THE SEAM. `main` computes the delete scope ONLY when the downgrade
+        does not fire, so an empty scope can never reach `write()` — and that is a
+        RELATIONSHIP between two functions, not a property of either. Pinned over
+        every (scoped, prune) combination a run can reach a write in, and over
+        BOTH fixtures, so a change that made one of them always-empty or
+        always-none fails here.
+
+        `write()`'s own `ValueError` is the backstop, and it is asserted as the
+        positive control: the thing the seam prevents must actually be fatal, or
+        preventing it proves nothing."""
+        a, b = self._all_partial(tmp_path)
+        healthy = tmp_path / "brindlemossrepo"
+        _write_repo(healthy, _TRIAD)
+        nothing = [hi.derive_repo(a, label="glimmerrepo"),
+                   hi.derive_repo(b, label="quorlrepo")]
+        something = [*nothing, hi.derive_repo(healthy, label="brindlemossrepo")]
+
+        assert hi.rebuild_downgrade_reason(nothing) is not None
+        assert hi.rebuild_downgrade_reason(something) is None
+        for ds in (nothing, something):
+            rows = [s for d in ds for s in d.sections]
+            for scoped in (True, False):
+                for prune in (True, False):
+                    if hi.rebuild_refusal(ds, rows, prune=prune) is not None:
+                        continue  # never reaches a write
+                    scope = hi.rebuild_delete_labels(
+                        ds, ("glimmerrepo", "quorlrepo", "brindlemossrepo"),
+                        scoped=scoped, prune=prune)
+                    downgraded = hi.rebuild_downgrade_reason(ds) is not None
+                    assert downgraded == (scope == ()), (scoped, prune, scope)
+
+        # The positive control for what the seam is FOR.
+        with pytest.raises(ValueError, match="EMPTY delete scope"):
+            hi.PostgresSectionStore(RecordingConn()).write(
+                [s for d in something for s in d.sections],
+                rebuild=True, rebuild_labels=())
 
     def test_the_all_UNMEASURED_arm_still_wins_where_it_applies(self, tmp_path, capsys):
         """The ladder's ordering, pinned. Both arms fire on "every repo is
@@ -4274,3 +4376,570 @@ class TestTheAuthorityPredicateIsREACHEDByTheDeleteScope:
         # …and with the SAME two derivations minus the unreadable path, both.
         ds[1] = self._d("thackrepo")
         assert hi.rebuild_delete_labels(ds, (), scoped=True) == ("thackrepo", "venlorepo")
+
+
+# --------------------------------------------------------------------------- #
+# Round 2 of the incomplete-read authority work — the audit's findings
+# --------------------------------------------------------------------------- #
+
+
+def _plan_bucket(lines, prefix: str) -> list[str]:
+    """The labels listed on the plan line starting with `prefix`.
+
+    🔴 IT PARSES THE OPERATOR'S LINE, NOT A FUNCTION'S RETURN. The whole point of
+    the seam tests below is that the pre-flight and the bound DELETE are two
+    different renderings of one decision, so a helper that re-called
+    `rebuild_delete_labels` would be asserting a value against itself."""
+    hit = [ln for ln in lines if ln.strip().startswith(prefix)]
+    assert len(hit) == 1, f"expected exactly one {prefix!r} line, got {hit}"
+    body = hit[0].split(":", 1)[1].strip()
+    if body == "(none)":
+        return []
+    # Each entry is `label` or `label (reason)` — the label is the first token.
+    return [e.strip().split(" ")[0] for e in body.split(", ")]
+
+
+class TestThePlanBucketsArePartitionOnTheKindNotOnTheRawFields:
+    """🔴 THE ONE CONSOLIDATED SITE THAT STILL RE-DERIVED. `incomplete_reason`
+    exists because the same predicate had been spelled four ways at four sites;
+    `rebuild_plan_lines` was made to read it for ONE of its three buckets and
+    left reading the raw fields for the other two — `d.unmeasured is not None`
+    and `d.unmeasured is None and d.unreadable`.
+
+    That is not a style nit. Those two spellings enumerate the kinds that existed
+    when they were written, and `incomplete_reason`'s own docstring says the
+    design exists so a THIRD kind can be added ("any incompleteness — of any
+    kind, including kinds not yet invented — withholds it"). On the day one is,
+    the repo falls out of all three buckets while `partial_scope_warnings` still
+    names it: the plan and the warning then disagree about the same run, and the
+    plan is the operator's only view of what the run destroys."""
+
+    def _mixed(self, tmp_path):
+        healthy = tmp_path / "brindlemossrepo"
+        broken = tmp_path / "varkelthornrepo"
+        _write_repo(healthy, _TRIAD)
+        _write_repo(broken, _TRIAD)
+        _break_doc_blob(broken, "claudedocs/handoff-quorlbane-cache.md")
+        return [hi.derive_repo(healthy, label="brindlemossrepo"),
+                hi.derive_repo(broken, label="varkelthornrepo"),
+                hi.derive_repo(tmp_path / "sundrellipexrepo",
+                               label="sundrellipexrepo")]
+
+    def test_every_configured_repo_lands_in_exactly_one_bucket(self, tmp_path):
+        """The partition itself, over all three kinds at once. Three labels, three
+        buckets, one each — and the union is the whole config, which is the claim
+        a reader makes when they count the plan's labels."""
+        ds = self._mixed(tmp_path)
+        lines = hi.rebuild_plan_lines(ds, scoped=True, prune=False, write=True)
+        delete = _plan_bucket(lines, "DELETE (read in FULL")
+        unmeasured = _plan_bucket(lines, "KEPT (configured but UNMEASURED)")
+        unreadable = _plan_bucket(lines, "KEPT (resolved, but a doc would not READ")
+        assert delete == ["brindlemossrepo"]
+        assert unmeasured == ["sundrellipexrepo"]
+        assert unreadable == ["varkelthornrepo"]
+        assert sorted(delete + unmeasured + unreadable) == sorted(
+            d.label for d in ds)
+
+    def test_a_THIRD_kind_of_incompleteness_is_REPORTED_not_dropped(
+            self, tmp_path, monkeypatch):
+        """🔴 THE MUTANT-SHAPED FUTURE, DRIVEN DIRECTLY. A new
+        `incomplete_kind` value is exactly the change the raw-field spellings
+        cannot survive, and no fixture built out of `derive_repo` can produce one
+        — so the kind is monkeypatched, which is a supported call on a PURE public
+        function rather than a contrivance.
+
+        Both the kind and the reason are patched together: `may_replace_stored_
+        rows` reads the reason, so patching only the kind would leave the repo in
+        the DELETE bucket and the test would pass for the wrong reason.
+
+        RED at the parent commit: the label appears NOWHERE in the plan."""
+        ds = self._mixed(tmp_path)
+        real_kind, real_reason = hi.incomplete_kind, hi.incomplete_reason
+        novel = "blob-checksum-mismatch"
+        assert novel not in hi.INCOMPLETE_KINDS
+        monkeypatch.setattr(hi, "incomplete_kind", lambda d: (
+            novel if d.label == "brindlemossrepo" else real_kind(d)))
+        monkeypatch.setattr(hi, "incomplete_reason", lambda d: (
+            f"{novel} (2 of 3)" if d.label == "brindlemossrepo" else real_reason(d)))
+
+        lines = hi.rebuild_plan_lines(ds, scoped=True, prune=False, write=True)
+        assert "brindlemossrepo" not in _plan_bucket(lines, "DELETE (read in FULL")
+        blob = "\n".join(lines)
+        assert "brindlemossrepo" in blob, (
+            "a kind the plan does not enumerate must still be REPORTED")
+        unclassified = [ln for ln in lines if "UNCLASSIFIED" in ln]
+        assert len(unclassified) == 1
+        assert "brindlemossrepo (blob-checksum-mismatch (2 of 3))" in unclassified[0]
+        # …and the plan says its own buckets are not a complete view, rather than
+        # letting a reader count three lines and believe them.
+        assert "NOT a complete view" in unclassified[0]
+
+    def test_no_UNCLASSIFIED_line_when_every_kind_is_enumerated(self, tmp_path):
+        """The negative control. Without it the assertion above is satisfied by a
+        plan that prints the unclassified line unconditionally, which would make
+        every healthy run look like it had hit an unknown failure mode."""
+        ds = self._mixed(tmp_path)
+        lines = hi.rebuild_plan_lines(ds, scoped=True, prune=False, write=True)
+        assert not [ln for ln in lines if "UNCLASSIFIED" in ln]
+
+    def test_the_reason_is_derived_FROM_the_kind_not_matched_out_of_it(self):
+        """🔴 THE REASON FOR AN UNMEASURED REPO IS A FREE-FORM TOKEN, so recovering
+        the kind by matching on the reason string would be a guard on WORDS. Pinned
+        as a differential: two derivations whose reasons share no substring, both
+        classified `unmeasured`."""
+        a = hi.RepoDerivation(repo="/x/pellinorerepo", label="pellinorerepo",
+                              unmeasured="no-such-directory")
+        b = hi.RepoDerivation(repo="/x/thistlegrimrepo", label="thistlegrimrepo",
+                              unmeasured="ls-tree-failed")
+        assert hi.incomplete_kind(a) == hi.incomplete_kind(b) == hi.INCOMPLETE_UNMEASURED
+        assert hi.incomplete_reason(a) == "no-such-directory"
+        assert hi.incomplete_reason(b) == "ls-tree-failed"
+        # …and the unreadable kind is the OTHER one, over a derivation whose
+        # `unmeasured` is clear — proving the first clause does not always win.
+        c = hi.RepoDerivation(repo="/x/mockwaitherepo", label="mockwaitherepo",
+                              ref="refs/heads/main", docs=4,
+                              unreadable=("claudedocs/handoff-mockwaithe-lane.md",))
+        assert hi.incomplete_kind(c) == hi.INCOMPLETE_UNREADABLE
+        assert hi.incomplete_reason(c) == "docs-unreadable (1 of 5)"
+
+
+class TestTheReportsAndTheBOUNDDeleteCannotDisagree:
+    """🔴 THREE MUTANTS THAT SURVIVED A FULL GREEN SUITE, AND THE SEAM THAT HELD
+    NONE OF THEM. Each is a revert of one changed expression back to
+    `d.unmeasured is None` — the spelling the widening replaced — and each
+    produces an operator report that CONTRADICTS ITSELF in the same sentence,
+    with 234 tests still passing:
+
+      * `partial_scope_warnings`' `ok` list: "…were NOT read completely…:
+        varkelthornrepo" beside "Read in FULL, and therefore rebuilt, covers only:
+        brindlemossrepo, varkelthornrepo".
+      * `rebuild_plan_lines`' `measured`: "DELETE …: brindlemossrepo,
+        varkelthornrepo" while the bound DELETE is `[['brindlemossrepo']]`, and
+        `varkelthornrepo` also under the mutually-exclusive KEPT bucket.
+      * `rebuild_refusal`'s zero-rows denominator: "ZERO rows from the 0 repo(s)
+        that resolved a mainline ref" when one did.
+
+    The only assertion the suite had on any of them drove the UNMEASURED state,
+    where both spellings agree — `claude/RULES.md`'s "verified in isolation" seam,
+    one function down: every existing test was scoped to a state in which the
+    difference cannot appear."""
+
+    def _mixed(self, tmp_path):
+        healthy = tmp_path / "brindlemossrepo"
+        broken = tmp_path / "varkelthornrepo"
+        _write_repo(healthy, _TRIAD)
+        _write_repo(broken, _TRIAD)
+        _break_doc_blob(broken, "claudedocs/handoff-quorlbane-cache.md")
+        return [hi.derive_repo(healthy, label="brindlemossrepo"),
+                hi.derive_repo(broken, label="varkelthornrepo")]
+
+    def test_the_PARTIAL_warnings_ok_list_names_only_repos_read_in_FULL(
+            self, tmp_path):
+        """MUTANT 1. The `ok` list is the half of the sentence a reader uses to
+        decide which repos the index now covers, and it read `d.unmeasured is
+        None` — so it named the repo the same sentence had just said the run does
+        not speak for."""
+        ds = self._mixed(tmp_path)
+        text = hi.partial_scope_warnings(ds)[0]
+        assert "were NOT read completely" in text and "varkelthornrepo" in text
+        covers = text.split("covers only: ")[1].split(".")[0]
+        assert covers == "brindlemossrepo", (
+            "the two halves of one sentence must not name the same repo")
+
+    def test_the_plan_DELETE_line_names_only_repos_read_in_FULL(self, tmp_path):
+        """MUTANT 2, at the pre-flight. A label in BOTH the DELETE bucket and a
+        mutually-exclusive KEPT bucket is a self-contradicting plan."""
+        ds = self._mixed(tmp_path)
+        lines = hi.rebuild_plan_lines(ds, scoped=True, prune=False, write=True)
+        delete = _plan_bucket(lines, "DELETE (read in FULL")
+        unreadable = _plan_bucket(lines, "KEPT (resolved, but a doc would not READ")
+        assert delete == ["brindlemossrepo"]
+        assert unreadable == ["varkelthornrepo"]
+        assert not set(delete) & set(unreadable)
+
+    def test_the_planned_DELETE_IS_the_scope_that_gets_BOUND(self, tmp_path, capsys):
+        """🔴 THE SEAM THE AUDIT ASKED FOR, AND IT BINDS TWO RENDERINGS RATHER
+        THAN RESTATING ONE. `rebuild_plan_lines`' own trailing sentence calls its
+        list "the COMPLETE delete scope"; nothing held it to the parameters
+        `DELETE_SQL` is actually executed with, which is why mutant 2 survived
+        while an end-to-end test asserting the bound scope was green.
+
+        Driven through `main` so the two values are produced by the run rather
+        than by the test, over a fixture where they CAN differ: one healthy repo,
+        one partially readable, one absent."""
+        healthy = tmp_path / "brindlemossrepo"
+        broken = tmp_path / "varkelthornrepo"
+        _write_repo(healthy, _TRIAD)
+        _write_repo(broken, _TRIAD)
+        _break_doc_blob(broken, "claudedocs/handoff-quorlbane-cache.md")
+        absent = tmp_path / "sundrellipexrepo"
+
+        conn = StoredReposConn(("brindlemossrepo", "varkelthornrepo",
+                                "sundrellipexrepo"))
+        rc = hi.main(["--repo", str(healthy), "--repo", str(broken),
+                      "--repo", str(absent), "--rebuild", "--write"],
+                     open_store=_recording_store(conn))
+        out = capsys.readouterr().out
+        assert rc == hi.RC_OK
+        planned = _plan_bucket(out.splitlines(), "DELETE (read in FULL")
+        bound = conn.params_for("DELETE")
+        assert bound == [[["brindlemossrepo"]]], bound
+        assert planned == sorted(bound[0][0]), (planned, bound)
+        # …and the run's own success line quotes the same scope back.
+        assert "after DELETE of 1 repo label(s): brindlemossrepo" in out
+
+    def test_the_zero_rows_arm_counts_repos_that_RESOLVED_a_ref(self, tmp_path):
+        """MUTANT 3. `measured` here is a count of repos that RESOLVED A MAINLINE
+        REF — that is what the sentence says — so it is `len(derivations) -
+        len(unmeasured)`, not `len(bad)`. Reverting it made the message read "ZERO
+        rows from the 0 repo(s) that resolved a mainline ref" for a run in which
+        one did.
+
+        The fixture is chosen so the three candidate numbers are pairwise
+        distinct: 2 derivations, 1 unmeasured, 2 incomplete — correct answer 1,
+        mutant's answer 0, `len(derivations)` 2."""
+        empty = tmp_path / "brindlemossrepo"
+        _write_repo(empty, {"handoff-varkelthorn-lane.md": DOC_FULL})
+        _break_every_doc_blob(empty)
+        ds = [hi.derive_repo(empty, label="brindlemossrepo"),
+              hi.derive_repo(tmp_path / "sundrellipexrepo",
+                             label="sundrellipexrepo")]
+        assert [d.label for d in ds if d.unmeasured] == ["sundrellipexrepo"]
+        assert [d.label for d in ds if hi.incomplete_reason(d)] == [
+            "brindlemossrepo", "sundrellipexrepo"]
+        refusal = hi.rebuild_refusal(ds, [])
+        assert refusal is not None
+        assert "ZERO rows from the 1 repo(s) that resolved a mainline ref" in refusal
+
+
+class TestThePruneRefusalStatesTheReasonThatActuallyApplies:
+    """🔴 A REMEDY OR A RATIONALE IS A CLAIM ABOUT THE STATE IT IS PRINTED IN.
+    When the `--prune` arm widened to INCOMPLETE repos it explained the new half
+    with the OLD half's reason: "refused for the same reason it is kept out of the
+    delete scope: this run has nothing to put back". That is false twice —
+    `--prune` never puts back the disappeared labels' rows (deleting them is what
+    it is for), and the incomplete repo's own rows are already outside `measured`,
+    so they are safe with or without this arm. The renamed-checkout ambiguity the
+    arm exists for cannot arise from an unreadable doc either: the ref resolved,
+    the directory is present, the label is unchanged.
+
+    The behaviour is kept — conservative on a destructive operator flag is cheap,
+    and `--prune` is never in the unit's argv — so what this pins is the SENTENCE.
+
+    ⚠ IT IS A WORD-LEVEL GUARD, DELIBERATELY AND WITH ITS LIMIT STATED: it pins
+    that one RETRACTED sentence cannot come back and that the true one is present.
+    It cannot tell you a third, differently-worded false rationale is false. What
+    makes that acceptable here is that the retracted sentence is the specific
+    thing an audit found and a reword would otherwise silently restore."""
+
+    def _prune_refusal(self, tmp_path):
+        healthy = tmp_path / "brindlemossrepo"
+        broken = tmp_path / "varkelthornrepo"
+        _write_repo(healthy, _TRIAD)
+        _write_repo(broken, _TRIAD)
+        _break_doc_blob(broken, "claudedocs/handoff-quorlbane-cache.md")
+        ds = [hi.derive_repo(healthy, label="brindlemossrepo"),
+              hi.derive_repo(broken, label="varkelthornrepo")]
+        rows = [s for d in ds for s in d.sections]
+        return hi.rebuild_refusal(ds, rows, prune=True), ds
+
+    def test_it_does_not_claim_the_incomplete_repo_has_nothing_to_put_back(
+            self, tmp_path):
+        refusal, ds = self._prune_refusal(tmp_path)
+        assert refusal is not None
+        text = _norm(refusal)
+        assert "for the same reason it is kept out of the delete scope" not in text
+        assert "this run has nothing to put back" not in text
+
+    def test_it_states_the_reason_that_DOES_apply(self, tmp_path):
+        refusal, _ = self._prune_refusal(tmp_path)
+        text = _norm(refusal)
+        assert "cannot vouch for the corpus at all" in text
+        assert "decides what to DESTROY from what this run did NOT find" in text
+        # …and it says the two halves are refused for DIFFERENT reasons, so the
+        # unmeasured half's spelling-ambiguity rationale is not read as covering
+        # both.
+        assert "refused for a DIFFERENT reason" in text
+
+    def test_the_claim_the_message_makes_about_the_repos_rows_is_TRUE(
+            self, tmp_path):
+        """The behavioural half, so this class is not purely a prose pin: the
+        message says the incomplete repo's own rows are already safe. They are —
+        the same derivations with `--prune` dropped bind a DELETE that excludes
+        it."""
+        _, ds = self._prune_refusal(tmp_path)
+        assert hi.rebuild_delete_labels(
+            ds, ("brindlemossrepo", "varkelthornrepo"),
+            scoped=False, prune=False) == ("brindlemossrepo",)
+
+    def test_a_config_with_every_doc_readable_still_prunes(self, tmp_path,
+                                                          monkeypatch, capsys):
+        """The negative control, one blob apart — without it the assertions above
+        are satisfied by an arm that refuses every `--prune` run."""
+        _apply_handles(monkeypatch, _every_handle_set(tmp_path))
+        labels = [f"{h.lower()}repo" for h in hi.REPO_ENV_HANDLES]
+        conn = StoredReposConn(tuple(labels))
+        rc = hi.main(["--rebuild", "--prune", "--write"],
+                     open_store=_recording_store(conn))
+        assert rc == hi.RC_OK
+        assert "REFUSING" not in capsys.readouterr().err
+
+
+class TestThePartialNoticeReachesEveryOutputPath:
+    """🔴 A CLAIM THAT WAS FALSE IN A REACHABLE STATE, AND IT IS THE SENTENCE THAT
+    STOPS THE NEXT PERSON LOOKING. `rebuild_delete_labels`' cost note says
+    `partial_scope_warnings` "says so on every output path". It did not:
+    `partial_scope_warnings` short-circuited to `()` when EVERY repo was
+    incomplete and deferred to `rebuild_refusal`, which `main` consults only under
+    `--rebuild`.
+
+    MEASURED at the parent commit, two repos each with one unreadable doc,
+    `--write` WITHOUT `--rebuild`: `partial_scope_warnings() == ()`, `wrote 24
+    section row(s)`, rc 0, and the word PARTIAL nowhere on stdout — the only
+    signal was two `⚠ UNREADABLE` lines. The hole pre-dated the widening; the
+    CLAIM did not."""
+
+    def _all_incomplete(self, tmp_path):
+        a = tmp_path / "brindlemossrepo"
+        b = tmp_path / "varkelthornrepo"
+        for root in (a, b):
+            _write_repo(root, _TRIAD)
+            _break_doc_blob(root, "claudedocs/handoff-fandrelly-probe.md")
+        return a, b
+
+    def test_a_plain_WRITE_over_an_all_incomplete_corpus_says_so(
+            self, tmp_path, capsys):
+        """The reproduced hole, through `main`, on the argv that has no
+        `--rebuild` — the one path `rebuild_refusal` never sees."""
+        a, b = self._all_incomplete(tmp_path)
+        conn = StoredReposConn(("brindlemossrepo", "varkelthornrepo"))
+        rc = hi.main(["--repo", str(a), "--repo", str(b), "--write"],
+                     open_store=_recording_store(conn))
+        cap = capsys.readouterr()
+        assert rc == hi.RC_OK
+        assert conn.kinds().count("INSERT") > 0
+        assert "🔴 THIS INDEX IS PARTIAL" in cap.out
+        assert "🔴 NOTHING WAS READ COMPLETELY" in cap.err
+        assert "brindlemossrepo (docs-unreadable (1 of 3))" in cap.err
+
+    def test_the_pure_function_itself_no_longer_returns_empty(self, tmp_path):
+        """Directly, because `main` has three renderers and the defect lives one
+        function below all of them."""
+        a, b = self._all_incomplete(tmp_path)
+        ds = [hi.derive_repo(a, label="brindlemossrepo"),
+              hi.derive_repo(b, label="varkelthornrepo")]
+        assert all(hi.incomplete_reason(d) for d in ds)
+        warnings = hi.partial_scope_warnings(ds)
+        assert len(warnings) == 1
+        # It must not claim an `ok` list it does not have — the mixed sentence's
+        # "covers only: <labels>" would render as "covers only: " here.
+        assert "covers only" not in warnings[0]
+        assert "all 2 configured repo(s) were incomplete" in warnings[0]
+
+    def test_the_JSON_surface_carries_it_too(self, tmp_path, capsys):
+        """`--json` REPLACES the prose renderer, and it is the surface consumed
+        without a human reading it."""
+        a, b = self._all_incomplete(tmp_path)
+        rc = hi.main(["--repo", str(a), "--repo", str(b), "--json"],
+                     open_store=_refusing_store())
+        doc = json.loads(capsys.readouterr().out)
+        assert rc == hi.RC_OK
+        assert any("NOTHING WAS READ COMPLETELY" in w for w in doc["warnings"])
+
+    def test_an_ALL_HEALTHY_run_still_says_nothing(self, tmp_path, capsys):
+        """🔴 THE ONE SUPPRESSION THAT SURVIVES, AND THE CONTROL FOR THE WHOLE
+        CLASS. A per-run "0 repos missing" buries the real ones; removing the
+        all-bad short-circuit must not have removed the empty one."""
+        a = tmp_path / "brindlemossrepo"
+        b = tmp_path / "varkelthornrepo"
+        _write_repo(a, _TRIAD)
+        _write_repo(b, _TRIAD)
+        ds = [hi.derive_repo(a, label="brindlemossrepo"),
+              hi.derive_repo(b, label="varkelthornrepo")]
+        assert hi.partial_scope_warnings(ds) == ()
+        conn = StoredReposConn(("brindlemossrepo", "varkelthornrepo"))
+        rc = hi.main(["--repo", str(a), "--repo", str(b), "--write"],
+                     open_store=_recording_store(conn))
+        cap = capsys.readouterr()
+        assert rc == hi.RC_OK
+        assert "PARTIAL" not in cap.out + cap.err
+        assert "NOTHING WAS READ COMPLETELY" not in cap.out + cap.err
+
+
+class TestASharedLABELIsNotReportedAsPreserved:
+    """🟢 THE DEFECT IS PRE-EXISTING AND STAYS; THE FALSE REPORT ABOUT IT DOES NOT.
+    Authority is demonstrated per DERIVATION and exercised per LABEL, and two
+    configured checkouts can derive one label (`main` uses `Path(raw).name`).
+
+    MEASURED, identical at the parent commit and at the commit before the whole
+    widening: `--repo <left>/protorepo --repo <right>/protorepo --rebuild --write`
+    with the right twin's doc blob removed gives `DELETE params
+    [[['protorepo']]]`, INSERTs only from the healthy twin, rc 0 — the broken
+    twin's rows deleted with nothing to replace them. `identity_collisions` cannot
+    see it: unreadable docs produce no sections, so nothing collides at the
+    section level.
+
+    🔴 WHAT THIS ROUND CHANGED IS THAT THE RUN STOPPED LYING ABOUT IT. The
+    widening newly printed, in that exact state, "Their existing rows are left
+    untouched … this run destroyed nothing it could not replace" and "kept their
+    old rows" — about rows it had just deleted — and listed the label under both
+    DELETE and KEPT with no comment. A silent wrong is recoverable by looking; a
+    stated wrong is what stops anyone looking."""
+
+    def _twins(self, tmp_path):
+        left = tmp_path / "left" / "protorepo"
+        right = tmp_path / "right" / "protorepo"
+        _write_repo(left, _TRIAD)
+        _write_repo(right, _TRIAD)
+        _break_every_doc_blob(right)
+        return left, right
+
+    def test_the_collision_is_detected_per_LABEL(self, tmp_path):
+        left, right = self._twins(tmp_path)
+        ds = [hi.derive_repo(left, label="protorepo"),
+              hi.derive_repo(right, label="protorepo")]
+        assert hi.authority_label_collisions(ds) == ("protorepo",)
+        # The negative control: the SAME two checkouts under distinct labels
+        # collide with nothing, so this is about the label and not about the
+        # broken blob.
+        distinct = [hi.derive_repo(left, label="brindlemossrepo"),
+                    hi.derive_repo(right, label="varkelthornrepo")]
+        assert hi.authority_label_collisions(distinct) == ()
+
+    def test_the_PARTIAL_warning_retracts_the_left_untouched_promise(self, tmp_path):
+        """The false sentence, pinned absent, and the true one pinned present."""
+        left, right = self._twins(tmp_path)
+        ds = [hi.derive_repo(left, label="protorepo"),
+              hi.derive_repo(right, label="protorepo")]
+        text = _norm(hi.partial_scope_warnings(ds)[0])
+        assert "destroyed nothing it could not replace" not in text
+        assert "EXCEPT WHERE A LABEL IS SHARED: protorepo" in text
+        assert "those rows ARE deleted" in text
+
+    def test_the_promise_is_still_made_where_it_is_TRUE(self, tmp_path):
+        """🔴 THE CONTROL THAT KEEPS THE QUALIFICATION FROM SWALLOWING THE CLAIM.
+        With distinct labels the delete really does spare the incomplete repo, and
+        the warning must still say so — otherwise the fix is "delete the promise",
+        which loses the fact an operator needs."""
+        left, right = self._twins(tmp_path)
+        ds = [hi.derive_repo(left, label="brindlemossrepo"),
+              hi.derive_repo(right, label="varkelthornrepo")]
+        text = _norm(hi.partial_scope_warnings(ds)[0])
+        assert "destroyed nothing it could not replace" in text
+        assert "EXCEPT WHERE A LABEL IS SHARED" not in text
+
+    def test_the_preflight_names_the_collision_rather_than_listing_it_twice(
+            self, tmp_path):
+        left, right = self._twins(tmp_path)
+        ds = [hi.derive_repo(left, label="protorepo"),
+              hi.derive_repo(right, label="protorepo")]
+        lines = hi.rebuild_plan_lines(ds, scoped=True, prune=False, write=True)
+        assert _plan_bucket(lines, "DELETE (read in FULL") == ["protorepo"]
+        assert _plan_bucket(
+            lines, "KEPT (resolved, but a doc would not READ") == ["protorepo"]
+        shared = [ln for ln in lines if "SHARED LABEL" in ln]
+        assert len(shared) == 1
+        assert "protorepo" in shared[0]
+        assert "the rows of the checkout(s) that were NOT read are deleted too" \
+            in shared[0]
+
+    def test_through_main_the_residual_is_recorded_and_the_report_is_true(
+            self, tmp_path, capsys):
+        """🔴 THE RESIDUAL IS ASSERTED, NOT WISHED AWAY. The DELETE really does
+        still bind `protorepo`; this test says so, so the day the structural fix
+        lands it fails and forces this class to be re-read rather than leaving a
+        stale 'known issue' comment behind."""
+        left, right = self._twins(tmp_path)
+        conn = StoredReposConn(("protorepo",))
+        rc = hi.main(["--repo", str(left), "--repo", str(right),
+                      "--rebuild", "--write"], open_store=_recording_store(conn))
+        cap = capsys.readouterr()
+        assert rc == hi.RC_OK
+        # THE UNFIXED DEFECT, pinned as-is.
+        assert conn.params_for("DELETE") == [[["protorepo"]]]
+        # …and every sentence the run prints about it is now true.
+        assert "kept their old rows" not in cap.out
+        assert "destroyed nothing it could not replace" not in cap.err
+        assert "🔴 SHARED LABEL" in cap.out
+        assert "EXCEPT WHERE A LABEL IS SHARED" in cap.err
+
+
+class TestTheCommentsSitWithTheCodeTheyDescribe:
+    """🔴 A COMMENT IS A CLAIM TOO, AND A MISPLACED ONE IS READ AS LICENCE. Two
+    strays the audit found, both pinned structurally rather than by eye — a
+    comment moves when someone edits around it, and nothing else in this suite
+    would notice."""
+
+    def test_the_disjunction_note_sits_above_the_arm_whose_opener_IS_one(self):
+        """`"THE OPENER IS A DISJUNCTION ('UNMEASURED or INCOMPLETE')"` describes
+        the `--prune` arm's message. It was left sitting immediately above the
+        ALL-UNMEASURED arm, whose opener is not a disjunction at all — so a
+        maintainer attaching it to the arm below it reads it as licence to widen
+        that arm from `unmeasured` to `bad`, which is precisely the change that
+        makes the timer refuse in a supported state."""
+        src = inspect.getsource(hi.rebuild_refusal)
+        note = src.index("THE OPENER IS A DISJUNCTION")
+        prune_arm = src.index("if prune and bad:")
+        unmeasured_arm = src.index("if derivations and len(unmeasured)")
+        assert note < prune_arm < unmeasured_arm, (
+            "the note must precede the arm it describes, not the next one")
+
+    def test_the_prune_bullet_names_the_condition_the_code_actually_checks(self):
+        """`rebuild_delete_labels`' `prune` bullet still said the refusal fires on
+        a repo that "came back unmeasured" after the arm had widened to
+        INCOMPLETE. The bullet directly above it was updated in the same diff;
+        this one was not.
+
+        Pinned as a behavioural cross-check as well as a word one: the state the
+        stale bullet describes as NOT refusing is driven, and it refuses."""
+        doc = _norm(hi.rebuild_delete_labels.__doc__)
+        assert "refuses a `--prune` run in which ANY repo came back unmeasured" \
+            not in doc
+        assert "refuses a `--prune` run in which ANY repo came back INCOMPLETE" in doc
+        # The behaviour the corrected bullet asserts.
+        d = hi.RepoDerivation(repo="/x/mockwaitherepo", label="mockwaitherepo",
+                              ref="refs/heads/main", docs=2,
+                              unreadable=("claudedocs/handoff-mockwaithe-lane.md",))
+        row = hi.Section("mockwaitherepo", "s", "p", None, None, "goal", 0, "h", "b")
+        assert d.unmeasured is None
+        assert hi.rebuild_refusal([d], [row], prune=True) is not None
+
+
+class TestHomeNixDescribesTheGuardTheModuleACTUALLYHAS:
+    """🔴 `nix/home.nix` IS WHERE AN OPERATOR LEARNS WHAT THE TIMER DOES, and it
+    enumerated the refusal conditions in prose that the module then outgrew. It
+    said the guard "refuses only when ALL repos are unmeasured, when the measured
+    subset yields zero rows, or when `--prune` … meets an unmeasured repo" — the
+    third condition had widened to INCOMPLETE, and a fourth state (nothing read in
+    full) had been added as a REFUSAL, in the same diff.
+
+    `claude/RULES.md`: when the artifact under test IS prose, a guard on WORDS is
+    walkable by rewording — so the enumeration sentence is pinned as a WHOLE
+    normalised string. A cosmetic reword fails this test. That is the price, and
+    it is worth paying for a sentence an operator uses to decide whether a toast
+    means their machine is broken."""
+
+    ENUMERATION = _norm(
+        "It now refuses only when ALL repos are unmeasured, when the measured "
+        "subset yields zero rows, or when `--prune` (never passed here) meets an "
+        "INCOMPLETE repo."
+    )
+
+    def _block(self) -> str:
+        return _norm(_handoff_unit_block().replace("#", " "))
+
+    def test_the_enumeration_sentence_is_exactly_this(self):
+        assert self.ENUMERATION in self._block()
+
+    def test_the_state_it_calls_SUPPORTED_is_documented_as_a_DOWNGRADE(self):
+        """The fourth state, named where the operator reads about the third. A
+        host with absent checkouts plus one corrupt blob does NOT get a refusal,
+        and the comment has to say so or the next reader re-adds one."""
+        block = self._block()
+        assert "REBUILD DOWNGRADED TO AN UPSERT" in block
+        assert "A FOURTH STATE EXISTS THAT IS *NOT* A REFUSAL" in block
+        # …and the cost of the downgrade is stated, not discovered.
+        assert "a section REMOVED from a doc keeps its stale row" in block
+
+    def test_the_retracted_wording_cannot_come_back(self):
+        assert "meets an unmeasured repo" not in self._block()


### PR DESCRIPTION
Closes the exposure `rebuild_delete_labels`' own docstring filed and deliberately
deferred in #1209: **a repo that MEASURES successfully but whose docs git cannot
produce has its rows DELETED and zero re-inserted, at rc 0, with no PARTIAL
notice — on the timer's own argv.**

## The reproduction (re-measured here, not taken from the filing)

`goodrepo` (1 committed handoff doc) + `badrepo` (1 committed doc whose blob was
removed from `.git/objects` — a blobless or partially-fetched clone, an
incomplete object store):

```
badrepo   unmeasured=None  docs=0  unreadable=('claudedocs/handoff-zarfwidget-latch.md',)
partial_scope_warnings()  == ()
rebuild_refusal()         is None
rebuild_delete_labels()   == ('badrepo', 'goodrepo')

main(["--repo", good, "--repo", bad, "--rebuild", "--write"])
  -> rc 0
     DELETE params = [['badrepo', 'goodrepo']]
     INSERT count  = 2          (both goodrepo's)
     "wrote 2 section row(s) to initiatives.handoff_section (after DELETE of 2 repo label(s)…)"
     success line does NOT say PARTIAL
```

The pre-flight actively asserted the opposite: `KEPT (configured but
UNMEASURED): (none)`. The only signal anywhere in the run was one
`⚠ UNREADABLE` line on stderr.

### The filing understated it

Same fixture with **one** blob of **two** removed — a run that looks *healthier*,
because it writes rows:

```
zarfrepo  unmeasured=None  docs=1  unreadable=1
rebuild_delete_labels() == ('zarfrepo',)
  -> rc 0, DELETE [['zarfrepo']], 2 of 4 sections re-inserted
```

The second doc's stored rows are deleted and never replaced. A guard scoped to
the filed symptom ("every doc unreadable") would have closed the fourth instance
and left the shape open — so the guard here is on **any** unreadable doc.

## The four-spelling shape, and whether this closes it

The four are: an unpredicated `TRUNCATE`; a delete scope computed over the wrong
label set; a refusal that checked whether a repo could be *read* when the risk
was whether the config was *wide*; and this one, a scope keyed on `unmeasured`
("did the ref resolve") when the DELETE asks "did anything come back".

**The common shape is not "someone forgot a field."** Authority over the DELETE
was granted by a **negative** predicate — the absence of whichever failure had
already been seen — instead of by a **positive** demonstration that the run holds
a complete replacement for the rows it destroys. A blacklist re-opens the hole
for every failure nobody has met yet, which is why four rounds of naming one more
failure never converged. Spelling 3 is literally two sites disagreeing about
which question they were answering.

So this inverts the default in **one** place:

```python
def incomplete_reason(d: RepoDerivation) -> str | None: ...
def may_replace_stored_rows(d: RepoDerivation) -> bool: ...
```

A label enters the delete scope only when this run read that repo **in full**;
any incompleteness, of any kind including kinds not yet invented, withholds it.
`rebuild_delete_labels`, `partial_scope_warnings`, `rebuild_refusal` and
`rebuild_plan_lines` now **read** that predicate instead of each re-deriving "is
this repo good" from whatever field was nearest.

That is a claim about the shape, so state its limit honestly: it closes the shape
*for the rebuild delete scope*. It does not make every future predicate in this
module positive by construction — what it does is leave exactly one place where
"may I destroy this repo's rows" is decided, so a fifth spelling has to be a
deliberate edit to that function rather than an omission at a new call site.

## Behaviour changes, and which exit codes move

* **The DELETE scope shrinks.** A repo carrying any unreadable doc is out of it.
  Its stored rows are preserved and every doc that *did* read is still upserted
  (`ON CONFLICT … DO UPDATE` refreshes without destroying).
* **`unmeasured` is deliberately NOT set for the unreadable case** — a considered
  departure from the obvious fix, which would have been "reclassify it as
  UNMEASURED and let the existing machinery cover it". Two reasons:
  1. it would make `unmeasured` mean both *"nothing came back"* and *"not
     everything came back"* — the exact conflation this module has already been
     burned by three times (`handoff_paths_in_ref`'s `None`-vs-`()`, `DiskScan`'s
     three meanings of `()`, and `docs == 0`'s two mechanisms);
  2. it would hide 39 readable docs from `--offline` search over one corrupt
     blob, because an UNMEASURED repo contributes zero rows.
* **`handoff_search`'s rc 6 / rc 7 split does NOT move.** The deferral note
  assumed it must ("the two have to move together"), and that coupling exists
  only for the UNMEASURED route. Under this design the search front end reads
  `unmeasured` and `unreadable` separately and already renders both correctly;
  all of its existing rc 6 / rc 7 tests pass unchanged. Neither front end now
  claims a repo measured completely when it did not.
* **`--prune` refuses (rc 4 `RC_REFUSED`) while any repo is incomplete**, for
  the same reason it already refuses an unmeasured one: the run cannot replace
  what it would delete. Message opens `came back UNMEASURED or INCOMPLETE` — a
  disjunction rather than a conditional, so it is true in every state it fires
  in, with the per-repo reason in the detail. Interaction with
  `prune_config_refusal` is unchanged: that guard still runs **first** (config
  width is a precondition for `--prune`'s whole premise) and the two messages
  keep their disjoint discriminating tokens, pinned by the existing matrix test.
* **NEW refusal arm, rc 4**: `not ONE of the N repo(s) was read COMPLETELY`.
  Before this, "not every repo is unmeasured" implied "the delete scope is
  non-empty"; it no longer does, and `PostgresSectionStore.write` **raises** on
  an empty rebuild scope by design. A traceback out of a 6h timer is a worse
  report than a refusal that names the repos and a remedy. It is ordered *after*
  the zero-rows arm so `rows` is non-empty by construction — which is what makes
  its "re-run without `--rebuild` and it writes" remedy true. That is the exact
  sentence the all-unmeasured arm had to retract as false in its own state, so
  it is also asserted behaviourally, not just written down.
* **No legitimate case is newly refused.** A healthy repo, a partially
  unmeasured config, and a complete `--prune` all behave exactly as before —
  each has a negative-control test. The only new refusals require a repo whose
  committed doc git cannot produce, which is a broken object store.
* **Prose / surfaces**: the PARTIAL warning drops `contributed NOTHING` (false
  of a partially readable repo, which contributes rows in the very transaction
  that prints it); the pre-flight grows a **third** bucket, because a repo in
  neither list was invisible to the operator; the success line says `not read
  COMPLETELY`; `--json` publishes `rebuildable` and `incomplete_reason` so a
  machine consumer reads the same value the DELETE reads rather than re-deriving
  it.

### What it costs, stated rather than discovered

A single corrupt blob freezes that repo's rows until the object store is
repaired. The rows are **preserved, not lost**, every readable doc is still
upserted, and the PARTIAL warning says so on every output path — the
conservative direction. If *every* configured repo is incomplete the rebuild
refuses (rc 4), which on the 6h timer means a failure toast; that state is a
broken machine, and the refusal names `git fsck` and re-fetch.

## Tests — red before, green after

Base sha **`a36d3a40`** (the merge base this work started from), new test file
run against the base library:

```
13 failed, 221 passed   @ a36d3a40
234 passed              @ daf87b4a  (this branch, merged with origin/main baa95854)
```

11 of the 13 are the new regression tests. The other 2 are the renamed
pre-flight line (`DELETE (measured…` → `DELETE (read in FULL…`). Six further new
tests are **negative controls / invariant guards** and are green at *both* ends —
labelled as such, not counted as regression coverage.

The end-to-end test asserts the **bound DELETE parameters** through `main`, not
an exit code: the statement text, the row count and the exit code are identical
between the correct run and the destructive one, so the bound scope is the only
place the difference shows.

Fixture note: the first draft of `_TRIAD` reused `DOC_FULL` twice, and because
git addresses a blob by content hash the two docs were **one object** — deleting
"one" blob took out two documents and the partial case silently became the total
one. The three bodies are now distinct, and the counts (`docs=2`,
`unreadable=1`, `total=3`) are pairwise distinct and distinct from every
constant the assertions name.

## Mutation sweep — fresh tree per mutant, `PYTHONDONTWRITEBYTECODE=1`

Mutating the narrowest expression that can be wrong (the `unreadable` clause):

| mutant | result |
|---|---|
| M1 `if d.unreadable:` → `if False:` | **KILLED** (11 tests) |
| M2 → `if d.unreadable and not d.docs:` (the "close the 4th instance only" mutant) | **KILLED** (8 tests) |
| M3 scope reverts to `d.unmeasured is None` | **KILLED** (5 tests) |
| M4 warning reverts to `d.unmeasured` | **KILLED** (3 tests) |
| P positive control — scope → every derived label | **KILLED** (12 tests) |
| N negative control — a true semantic no-op | **SURVIVED**, 234 passed |

**Reachable, not merely breakable.**
`TestTheAuthorityPredicateIsREACHEDByTheDeleteScope` builds a `RepoDerivation`
directly with `unmeasured=None` and `unreadable` non-empty, so the earlier check
provably does not always win — and M2 dies *there*, with this guard's own
assertion (`assert None is not None`, and a delete scope holding the extra
label), not with a different guard's error.

## Verification limits

⚠ **No test in this module reaches a live Postgres.** The store sits behind
`handoff_index.SectionStore`; what is pinned is the SQL text and the bound
parameters, not that a server accepts them. Stated in the test file's own header
already, repeated here because this change is entirely about what a `DELETE`
binds.
