### PR TITLE
docs(browser-bridge): site notes for comic-flex — the CSP trap, two lanes, and the flows

### DIFF
--- a/scripts/browser-bridge/reference/sites/_index.json
+++ b/scripts/browser-bridge/reference/sites/_index.json
@@ -2,11 +2,11 @@
   "_comment": [
     "Registry for per-site reference docs. `sites` maps a HOST SUFFIX to a filename in this directory.",
     "A host matches a key when it IS the key, or ENDS WITH '.' + the key. So an apex and any",
-    "subdomain of it both resolve, while `notexample.test` and `example.test.evil.invalid` do NOT — the",
+    "subdomain of it both resolve, while `notexample.test` and `example.test.evil.invalid` do NOT \u2014 the",
     "match is on label boundaries, never a substring. When several keys match, the LONGEST wins, so a",
     "more specific entry beats a broader catch-all for the same apex.",
     "Keys are lowercase bare hostnames: no scheme, no port, no path, no leading dot.",
-    "The key set here and the *.md file set in this directory must be IDENTICAL — an orphan entry and",
+    "The key set here and the *.md file set in this directory must be IDENTICAL \u2014 an orphan entry and",
     "an unregistered file are both errors, pinned both ways by tests/test_site_notes.py.",
     "server.py reads this to emit `site_notes` on a matching result envelope; a missing or malformed",
     "file degrades to no site_notes and never breaks a browser op."
@@ -14,6 +14,8 @@
   "sites": {
     "civit.ai": "civit.ai.md",
     "civitai.com": "civitai.com.md",
+    "comic-flex.homelab.lan": "comic-flex.homelab.lan.md",
+    "comics.zacx.dev": "comics.zacx.dev.md",
     "vetr.com": "vetr.com.md"
   }
 }

--- a/scripts/browser-bridge/reference/sites/comic-flex.homelab.lan.md
+++ b/scripts/browser-bridge/reference/sites/comic-flex.homelab.lan.md
@@ -1,0 +1,24 @@
+# comic-flex.homelab.lan — the LAN lane of comic-flex
+
+**Load this when:** a result envelope named this file in `site_notes` · you are
+driving the comic-flex PWA over the LAN · a `js`/`eval` came back `null` here.
+
+🔴 **The flows, selectors and traps live in one place:
+`reference/sites/comics.zacx.dev.md`. Read that.** This host is the same app on
+the same image; only the two facts below differ, and both change what a pass means.
+
+1. 🔴 **No Authelia.** Plain `http://comic-flex.homelab.lan` is open on the LAN —
+   `GET /ui/status` and `POST /api/next` both answer `200` with no login. This is
+   the lane to drive. Reaching for the public host out of habit is what produced
+   two "the feature is broken" reports that were really `302`s to Authelia.
+2. 🔴 **A service worker NEVER registers here.** Plain HTTP that is not `localhost`
+   is not a secure context, so this lane is **structurally blind** to every
+   service-worker and stale-cache bug. A clean pass here is not evidence about
+   caching. For a secure context without Authelia, `kubectl port-forward` and use
+   `http://localhost:<port>`.
+
+And the one that fakes a broken tool, repeated here because it is why sessions
+stop: **`js` and `eval` return `null` on this app** — its CSP withholds
+`unsafe-eval`. The bridge is fine. Control: `js '1+1'` on `example.com` returns
+`2` in the same instance. Use `text` / `html` / `text --annotated` to read and the
+trusted `click` op to drive; neither needs page scripting.

--- a/scripts/browser-bridge/reference/sites/comics.zacx.dev.md
+++ b/scripts/browser-bridge/reference/sites/comics.zacx.dev.md
@@ -1,0 +1,205 @@
+# comics.zacx.dev — comic-flex: two lanes, a CSP that fakes a broken bridge, and a passkey nobody can automate
+
+**Load this when:** a result envelope named this file in `site_notes` · you are
+about to drive or read `comics.zacx.dev` or `comic-flex.homelab.lan` · a `js`/`eval`
+came back `null` here · you are about to report that the bridge or the profile is
+broken · you need the pause/next/busy-card flows · you are about to log in or out
+of Authelia on the operator's live profile.
+
+Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`.
+Mechanism stays in the mechanism files: throttling and `wake` →
+`reference/spa-wake.md`; hit-testing → `reference/css-hit-test.md`; proving a read
+is the live authenticated session → `reference/auth-pages.md`. This file is only
+what is true of **comic-flex**.
+
+App context: `homelab-talos/containers/comic-flex-pwa/`, the `comic-flex` Claude
+skill, and `claudedocs/handoff-comic-flex.md`. The Pi program is a separate repo,
+`github.com/ZacxDev/comic-flex`.
+
+---
+
+## 🔴 `js` AND `eval` RETURN `null` HERE. THE BRIDGE IS FINE.
+
+The app deliberately withholds `unsafe-eval` in its CSP, so the injected script is
+blocked and **every** `js` expression — including `1+1` — comes back
+`"value": null` with `ok: true` and no error. The Authelia login page
+(`login.zacx.dev`) does the same.
+
+**Measured 2026-09-03, with the control that settles it:**
+
+| target | `js '1+1'` |
+|---|---|
+| `example.com` (control) | **`value: 2`** |
+| `comic-flex.homelab.lan` | `value: null` |
+| `login.zacx.dev` | `value: null` |
+
+🔴 **A session burned a whole attempt concluding "the `js`/`eval` subcommands are
+INERT for this profile" from a `null` here.** They are not. It is site CSP — trap
+2 in the core skill, the same as GitHub. **Never re-derive that.** If you need the
+control again, run `js '1+1'` on `example.com` in the same instance; a `2` there
+and a `null` here is CSP, not tooling.
+
+**What works instead, all verified on this app:**
+
+| need | use | why it survives CSP |
+|---|---|---|
+| read the DOM | `text`, `text --annotated`, `html` | injects no script |
+| click anything | `click <selector>` | **trusted CDP input**, not page JS |
+| type | `type`, `key` | same |
+| see it | `screenshot` | CDP capture |
+
+So there is **no** check on this app that needs page scripting. The "something must
+click and we cannot click" blocker recorded in older handoffs is dead.
+
+---
+
+## TWO LANES. Pick one before the first op — they differ in what they can SEE.
+
+| lane | host | auth | service worker |
+|---|---|---|---|
+| **A — LAN** | `http://comic-flex.homelab.lan` | **none** | 🔴 **never registers** |
+| **B — public** | `https://comics.zacx.dev` | Authelia passkey | registers |
+
+🔴 **Lane A is STRUCTURALLY BLIND to every service-worker and cache bug.** A SW
+needs a secure context; plain HTTP that is not `localhost` is not one, so no worker
+ever installs on the LAN host. A clean Lane A pass says nothing about a stale-shell
+bug. If you need a secure context without Authelia, `kubectl port-forward` and use
+`http://localhost:<port>` — that **is** a secure context.
+
+🔴 **Lane A is the right lane for everything else.** It is the same app, the same
+`app.js`, no login, no redirects, and no chance of disturbing the operator's
+session. Older attempts failed by reaching for Lane B out of habit, getting `302`/
+`303` to Authelia, and reporting the feature broken.
+
+## 🔴 Authelia: a human gate, and one you can permanently break
+
+- Login is a **passkey**. It needs a physical authenticator touch. **No agent can
+  log in here.** If Lane B returns `login.zacx.dev`, the session is gone and only
+  the operator can restore it — say so and stop; do not hunt for a workaround.
+- 🔴 **NEVER visit `https://login.zacx.dev/logout`, and never click Sign out.** A
+  dispatched agent did exactly that "to test session expiry", ended the operator's
+  session, and blocked its own remaining objectives.
+- Timeouts (`clusters/production/flux-system/charts/authelia/authelia.yaml`):
+  `inactivity: 5m` · `expiration: 1h` · `remember_me: 1M`.
+  🔴 **Remember-me beats inactivity.** With the box ticked the session survives an
+  idle wait, so an expiry test can neither pass nor fail — a 6-minute idle that
+  stays authenticated is the setting **working**. Any expiry test needs a session
+  established with remember-me **unchecked**, which only the operator can do.
+- The header htmx does not send is what gets a clean status:
+  plain GET → `302` · `HX-Request: true` → `302` · `Accept: */*` → `302` ·
+  **`X-Requested-With: XMLHttpRequest` → `401`**. `app.js` adds that header via
+  `htmx:configRequest` and turns the 401 into a reload.
+
+---
+
+## The page, by selector (verified on image `0.3.3`)
+
+Control page `/` — ids are `#hero`, `#countdown`, `#status`.
+
+| control | selector | note |
+|---|---|---|
+| play/pause transport | `#status button[hx-post="/api/toggle"]` | also `button[aria-label*="slideshow"]` |
+| next page | `#status button[hx-post="/api/next"]` | `aria-label="Next page"` |
+| previous page | `#status button[hx-post="/api/prev"]` | |
+| layout (3 buttons) | `#status button[hx-post="/api/viewmode"]` | portrait / landscape / landscape-two |
+| nav | `header nav a[href="/browse"]`, `/search`, `/settings` | `hx-boost`ed |
+
+**The glyph, which is the whole of the W1 bug:**
+
+| state | `aria-label` | SVG children |
+|---|---|---|
+| playing | `Pause the slideshow` | **2 `<rect>`**, 0 `<polygon>` |
+| paused | `Resume the slideshow` | 0 `<rect>`, **1 `<polygon>`** |
+| scanning | — | `iconIndexing()`, a three-dot ellipsis — a distinct THIRD glyph, never "still shows pause" |
+
+Read the glyph without page JS:
+
+```bash
+BB=~/workspace/devrc/scripts/browser-bridge/browser
+$BB --instance work --tab <id> html --max-bytes 200000 --wake \
+  | python3 -c 'import json,sys,re; h=json.load(sys.stdin)["result"]["data"]["html"]; \
+b=re.search(r"<button[^>]*aria-label=\"(Pause|Resume)[^\"]*\".*?</button>",h,re.S); \
+print("MISSING") if not b else print(b.group(1), "rect",b.group(0).count("<rect"), "polygon",b.group(0).count("<polygon"))'
+```
+
+🔴 **Scope the count to the BUTTON, never to the `#status` card.** The card holds
+the layout icons too, so a whole-card count reads `rect 11 polygon 2` while the
+slideshow is *playing* — compare that against the 2-rect/0-polygon row above and
+you get a confident false "the glyph is wrong". Measured 2026-09-03. The regex
+above is anchored on the transport button's own `aria-label`, and prints
+`MISSING` rather than a zero if it fails to match — a zero from a regex that
+matched nothing is the same trap one level down.
+
+🔴 **The server is the arbiter, and it is a different question from the render.**
+Compare the browser against the server *at the same moment*:
+
+```bash
+curl -s http://comic-flex.homelab.lan/ui/status | grep -oE 'aria-label="(Pause|Resume)[^"]*"'
+```
+
+- server `Resume` + browser triangle ⇒ no bug.
+- server `Resume` + browser two bars ⇒ **client-side**; check the worker and caches.
+- server `Pause` ⇒ the Pi never paused. A different defect — the round trip, not
+  the render. Say which; do not call it the glyph bug.
+
+---
+
+## FLOW: the "display is busy" card (503 backpressure)
+
+🔴 **The busy card is reachable ONLY in a command response.** `GET /api/state`
+cannot 503, so `/ui/status` will never show it and polling for it forever proves
+nothing. Something must issue a command while the Pi's queue is full.
+
+The Pi accepts `maxQueuedMutations = 64` plus one in flight; beyond that it returns
+`503` + `Retry-After: 1`, and the PWA must classify that as backpressure rather
+than a dead device.
+
+```bash
+# terminal — saturate (this DOES turn ~65 real pages on the physical display)
+for i in $(seq 1 150); do curl -s -o /dev/null -X POST http://comic-flex.homelab.lan/api/next & done
+
+# bridge, WHILE that runs — trusted click, then read the card
+$BB --instance work --tab <id> click '#status button[hx-post="/api/next"]'
+$BB --instance work --tab <id> text '#status' --wake
+```
+
+- **PASS:** the card reads *"The Pi is catching up… Press it again in a moment."*
+- **FAIL:** *"Cannot reach the Pi"* — that is the exact defect #623 fixed.
+
+## FLOW: pause, read the glyph, resume
+
+```bash
+$BB --instance work --tab <id> click '#status button[hx-post="/api/toggle"]'   # pause
+# ... read the glyph (above) and compare against the server curl ...
+$BB --instance work --tab <id> click '#status button[hx-post="/api/toggle"]'   # 🔴 RESUME
+```
+
+🔴 **It is a physical display in the operator's home. Always resume.** Confirm with
+the server curl reading `Pause the slideshow` again before you finish.
+
+## FLOW: service worker + cache inspection (Lane B or localhost only)
+
+`Application → Service Workers` / `Cache Storage` are devtools surfaces the bridge
+does not expose. What the bridge *can* do is register what the page sees; the
+caches to expect are `comic-flex-shell-v3` and `comic-flex-thumbs-v2` and
+**nothing else**.
+
+🔴 **`comic-flex-shell-v2` present = the answer.** It is the poisoned cache from the
+old `hx-boost` defect (an `hx-boost` nav is an XHR with `request.mode === 'cors'`,
+never `'navigate'`, so `isNavigationRequest()` was false and HTML documents got
+cached). The current worker must never store a page URL — any entry in
+`comic-flex-shell-v3` whose URL is `/`, `/browse` or `/search` rather than
+`/static/...` is the bug.
+
+---
+
+## Two more that have each cost a session
+
+- 🔴 **Never diagnose a comic-flex OUTAGE from a browser read.** Use the Pi's own
+  health, `/api/state`, pod status, or an anonymous `curl`. `status` in
+  `scripts/comic-flex.sh` reads `config.yaml` **on disk** — runtime truth is
+  `/api/state`.
+- **A client-side validation error renders "Cannot reach the Pi" / 502.** Every
+  non-`BusyError` failure takes that branch, so an over-long queue or a garbage
+  `/api/interval` blames the device for a request the PWA rejected locally. Known,
+  filed; do not report it as the device being down.


### PR DESCRIPTION
Five agent attempts at the comic-flex browser trip failed on **tooling**, never on the feature. The most expensive one concluded `js`/`eval` were **INERT for this profile** after seeing `1+1 -> value: null`, and that finding is what downgraded the whole trip to "a human must click".

**Re-measured — it does not reproduce:**

| target | `js '1+1'` |
|---|---|
| `example.com` (control, same instance) | **`value: 2`** |
| the comic-flex app | `value: null` |
| `login.zacx.dev` | `value: null` |

It is **site CSP** (the app deliberately withholds `unsafe-eval`; Authelia's portal does the same), which blocks the *injected script* and nothing else. `text`/`html` read fine, and the **trusted `click`** op drives fine (`"trusted": true, "via": "mouse"`) — that is what unblocked the trip, which then ran and closed two open questions.

## What these notes record

- The **control that settles the CSP question**, so nobody re-derives "the tool is inert".
- **Two lanes and what each can SEE** — the LAN lane is plain HTTP, so a service worker never registers and it is *structurally blind* to stale-shell bugs. A clean pass there is not evidence about caching.
- **Selectors, and the glyph ground truth scoped to the BUTTON.** A whole-`#status`-card count reads `rect 11` while the slideshow is *playing*; compared against a button-scoped table that produces a confident false "the glyph is wrong" — and it did mislead the dispatched agent into a self-contradictory verdict. The one-liner is anchored on the button's own `aria-label` and prints `MISSING` rather than a zero when it fails to match.
- The **busy-card** and **pause/resume** flows, including "always resume — it is a physical display".
- The **Authelia rails**: passkey login cannot be automated, `remember_me` (1M) beats `inactivity` (5m) so an expiry test needs remember-me unchecked, and **never visit the logout URL** — an earlier attempt ended the operator's session that way.

## Verification

- `test_site_notes.py` **71 passed**.
- **Negative-controlled**: an injected orphan key turns 2 tests RED; restoring returns 71 green. The gate is not insensitive.
- **Verified live**: a `context` op returns `site_notes: "reference/sites/comic-flex.homelab.lan.md"` with no server restart, so the notes reach future runs automatically.

Docs only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YZD1xdzr8MbqHKc2mu1Wk