### PR TITLE
docs(activity): the vacuous-predicate mechanism, and two figures that were wrong

### DIFF
--- a/claude/skills/activity/SKILL.md
+++ b/claude/skills/activity/SKILL.md
@@ -75,16 +75,27 @@ Per-source detail that matters when querying:
   stream), `session-summary` (Layer A rollups), `session-insight` (Layer B facets).
   🔴 **"Was skill X ever used?" — do NOT hand-write SQL or grep `text` for the name.**
   The `session-summary` payload carries `skills_used` / `skills_invoked` /
-  `commands_typed` (skill→count maps, forward-only, **first rows 2026-08-04** —
-  re-measured 2026-09-04, earliest non-empty value `{"manage-spend-exporter":76}` on
-  the workbench; the previously recorded 2026-08-29 was 25 days late), and the
+  `commands_typed` (skill→count maps, forward-only; earliest non-empty row
+  **2026-08-04**, `{"manage-spend-exporter":76}` on the workbench — but see the
+  UNDERCOUNT bullet below: that date is when the field first appears, NOT when it
+  became reliable, and the previously recorded 2026-08-29 was neither), and the
   owning entry point is **`find-session --skill NAME`** — not this skill and not
   `adoption-scan`, which sees only the 9 `invocation.py` emitters and cannot see a skill
   at all. Measured 2026-08-29: keyword-searching `signal` returned **678** sessions
-  against **6** real uses — **all 6 on the laptop** (re-measured 2026-09-04 over all
-  time; the earlier "5 of them" was one short) — so a grep, or a one-host search,
-  answers the reverse of the truth. Report "no recorded use since <date>", never
-  "never used".
+  against **10** real uses (**9 laptop / 1 workbench**, re-measured 2026-09-04 over all
+  time) — so a grep, or a one-host search, answers the reverse of the truth. Report
+  "no recorded use since <date>", never "never used".
+  🔴 **`skills_used` IN CLICKHOUSE UNDERCOUNTS — it is NOT the authoritative surface,
+  and querying it instead of `find-session` is how a correct-looking SQL answer comes
+  back 40% low.** Measured 2026-09-04 for `signal`: `find-session --skill signal`
+  (transcript-derived, every reachable host, no peer unanswered) returns **10** sessions;
+  the ClickHouse `skills_used` map returns **6**, and the 6 are a strict SUBSET. The 4 it
+  misses are NOT an ingestion gap — each HAS `session-summary` rows (9–19 of them) with
+  an **empty** `skills_used`, and all 4 started 2026-08-19 → 2026-08-25. So attribution
+  coverage is **partial well after** the field's 2026-08-04 first appearance. **The
+  transcripts are the defining surface and `skills_used` is a derived one** — enumerating
+  the derived surface and reporting it as usage is the same sampling-vs-enumerating error
+  the rule above is about, just one layer in.
   🔴 **The mechanism that makes hand-written SQL fail SILENTLY, and why the rule above
   is not merely a preference: `JSONExtractString(payload,'skills_used','<name>') IS NOT
   NULL` IS ALWAYS TRUE.** ClickHouse returns `''` for a missing key, never `NULL`, so

--- a/claude/skills/activity/SKILL.md
+++ b/claude/skills/activity/SKILL.md
@@ -75,13 +75,28 @@ Per-source detail that matters when querying:
   stream), `session-summary` (Layer A rollups), `session-insight` (Layer B facets).
   🔴 **"Was skill X ever used?" — do NOT hand-write SQL or grep `text` for the name.**
   The `session-summary` payload carries `skills_used` / `skills_invoked` /
-  `commands_typed` (skill→count maps, forward-only, **first rows 2026-08-29**), and the
+  `commands_typed` (skill→count maps, forward-only, **first rows 2026-08-04** —
+  re-measured 2026-09-04, earliest non-empty value `{"manage-spend-exporter":76}` on
+  the workbench; the previously recorded 2026-08-29 was 25 days late), and the
   owning entry point is **`find-session --skill NAME`** — not this skill and not
   `adoption-scan`, which sees only the 9 `invocation.py` emitters and cannot see a skill
   at all. Measured 2026-08-29: keyword-searching `signal` returned **678** sessions
-  against **6** real uses, 5 of them on the *laptop* — so a grep, or a one-host search,
+  against **6** real uses — **all 6 on the laptop** (re-measured 2026-09-04 over all
+  time; the earlier "5 of them" was one short) — so a grep, or a one-host search,
   answers the reverse of the truth. Report "no recorded use since <date>", never
   "never used".
+  🔴 **The mechanism that makes hand-written SQL fail SILENTLY, and why the rule above
+  is not merely a preference: `JSONExtractString(payload,'skills_used','<name>') IS NOT
+  NULL` IS ALWAYS TRUE.** ClickHouse returns `''` for a missing key, never `NULL`, so
+  the predicate selects the WHOLE TABLE and every statistic derived under it becomes a
+  population statistic wearing a skill's name. Measured 2026-09-04, four-arm control on
+  `source='claude' AND kind='session-summary'`: with the predicate **1,946** distinct
+  sessions · predicate REMOVED **1,946** (identical) · `IS NULL` **0** (it can never be
+  false) · the correct `!= ''` test **6**. A shipped analysis reported 1,024 "signal
+  skill" sessions, a 96.5% cache rate and a 40,000% output/input ratio this way; all
+  three were facts about every Claude session on both hosts. **Test membership with
+  `!= ''`, and run the predicate-removed arm as a negative control — if it returns the
+  same count, your filter is inert.**
 - `i3` — `window::focus` + `workspace::focus` → `i3-source`; captures attention even when
   NOT typing. Carries `app`=WM_CLASS + `payload.workspace`.
 - `browser-bridge` — TWO kinds, and the distinction is load-bearing. `kind=cmd` is one row


### PR DESCRIPTION
## Why

The `activity` skill already told readers not to hand-write SQL for "was skill X used?". It did not say **why**, so the rule read as a preference — and a shipped `claudedocs` analysis hand-wrote the SQL anyway and published three numbers that were wrong by the entire population.

## 1. The vacuous predicate (commit `b96737c7`)

`JSONExtractString(payload,'skills_used','<name>') IS NOT NULL` is **always true**. ClickHouse returns `''` for a missing key, never `NULL`. The predicate selects the whole table, and every statistic derived under it becomes a population statistic wearing a skill's name.

Four-arm control, measured 2026-09-04 on `source='claude' AND kind='session-summary'`:

| arm | distinct sessions |
|---|---|
| with the handoff's predicate | 1,946 |
| predicate **removed** | **1,946** (identical — the filter is inert) |
| `IS NULL` (negative control) | **0** (it can never be false) |
| the correct `!= ''` test | 6 |

The published analysis reported 1,024 "signal skill" sessions, a 96.5% cache rate and a 40,000%+ output/input ratio. All three were facts about every Claude session on both hosts.

## 2. `skills_used` undercounts by 40% — including in my own first commit (`c8879ade`)

**The first commit on this branch replaced a wrong host split with another wrong one.** It said "all 6 on the laptop", correcting the skill's "5 of them on the laptop". Both figures came from ClickHouse `skills_used` — a *derived* surface. The defining surface is the transcripts.

Cross-checked against the sanctioned entry point:

| source | sessions |
|---|---|
| `find-session --skill signal` (transcripts, every reachable host) | **10** — 9 laptop / 1 workbench |
| ClickHouse `skills_used` | **6** — a strict subset |

`find-session`'s stderr carried only the opencode caveat and named no unreachable peer, so the 10 is a complete read.

The 4 it misses are **not an ingestion gap**: each *has* `session-summary` rows in ClickHouse — 9, 13, 13 and 19 of them — with an **empty** `skills_used` map, and all 4 started 2026-08-19 → 2026-08-25. So attribution coverage is **partial well after** the field's first appearance on 2026-08-04, and that date marks when the field first appears, not when it became reliable.

This is the same sampling-vs-enumerating error the bullet already warns about, one layer in.

## Scope / limits

Documentation only — one bullet in `claude/skills/activity/SKILL.md`. No code, no behaviour change. `test_doc_path_rot.py`: 77 passed.

The counts are point-in-time reads. The durable claims are the *relationships*: the four arms' equality, and `find-session` ⊋ `skills_used`.

Companion handoff on `main` (`5faf248d`): `claudedocs/handoff-signal-skill-eval.md` — note it still carries the pre-correction "6 / all laptop" figure; being fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GS7vJg4fSS3rbounyRmepL
