### PR TITLE
docs(opencode): preflight scans the brief's PROSE, and naming no path is the unmeasured option

### DIFF
--- a/scripts/opencode/SKILL.md
+++ b/scripts/opencode/SKILL.md
@@ -101,6 +101,18 @@ three options, in order of preference:
 There is no override flag. The failure it prevents is a silent exit 0, which is
 the one shape nobody notices.
 
+🔴 **It scans the brief's PROSE, not only its instructions — so the sentence
+warning the agent OFF a path is itself a path, and gets refused.** Measured
+2026-09-03: a corrected brief opened with *"never write to `/tmp`"*, cited *"the
+previous attempt screenshotted to `/tmp`"*, and quoted `external_directory
+(/tmp/*)` as the evidence. Preflight counted three mentions and refused —
+`rc 3`, `paths examined: 2`, `[brief] /tmp`. It is a textual scan with no notion
+of *"this path is named in order to be forbidden"*, and the refusal reads as
+absurd until you see that. **Write the prohibition without writing the path** —
+"the system temp directory", "any absolute path". That is a fourth fix belonging
+beside the three above, and it is the only one that applies when nothing is
+actually being pointed at.
+
 Read the three verdict lines literally — they are different claims:
 
 - `external paths : none — all N examined resolve under --dir` — checked, clean.
@@ -136,6 +148,13 @@ gate people learn to click through.
   heredoc otherwise dispatches a run that does nothing and exits 0.
 - Assume no follow-up questions are possible. opencode is unattended; every
   `ask` is an auto-reject, not a prompt.
+- 🔴 **If the run will WRITE anything — a screenshot, a dump, a scratch file —
+  say WHERE, as a relative path under `--dir`, and pre-create the directory.**
+  This is the half preflight structurally cannot cover: failure mode 1 above
+  happened with a brief that named **no filesystem path at all**, so there was
+  nothing to refuse and the agent invented the temp path at runtime. `external
+  paths : NOT EXAMINED` is exactly what that brief scored. **Naming no path is
+  not the safe option — it is the unmeasured one.**
 
 ## Files
 


### PR DESCRIPTION
Prose-only additions to the opencode skill, both measured on 2026-09-03 while re-dispatching a browser task.

### 1. `## When preflight refuses` — a fourth fix

The three listed fixes all assume the brief is **pointing at** something outside `--dir`. Preflight also refuses when the brief merely **mentions** such a path in prose — including the sentence telling the agent not to write there.

A corrected brief opened with *"never write to `/tmp`"*, cited *"the previous attempt screenshotted to `/tmp`"*, and quoted `external_directory (/tmp/*)` as the evidence for why. Preflight counted three mentions and refused:

```
🔴 BLOCKED — paths OUTSIDE --dir.
     [brief] /tmp
     [brief] /tmp/   -> /tmp
  paths examined       : 2
rc=3
```

The scan has no notion of *"this path is named in order to be forbidden"*, so the refusal reads as absurd until you know that. Fix: write the prohibition **without writing the path** — "the system temp directory", "any absolute path". Rewording cleared it on the next run.

### 2. `## Writing a brief that lands` — say where the run will write

This is the half preflight structurally **cannot** cover, and it is failure mode 1 in this same file. That dispatch's brief named **no filesystem path at all**, so there was nothing to refuse and it scored `external paths : NOT EXAMINED`. The agent then invented an absolute temp path at runtime, screenshotted successfully (95,705 bytes), and died trying to read its own screenshot back:

```
! permission requested: external_directory (/tmp/*); auto-rejecting
✗ Read /tmp/npm-components-settings.png failed
```

So: if a run will write anything, the brief must say **where**, as a relative path under `--dir`, with the directory pre-created. Naming no path is not the safe option — it is the unmeasured one.

### Verification

- `scripts/tests/test_opencode_config.py` — **640 passed**.
- No behaviour change; `SKILL.md` prose only, +19 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAj8h38AtcpYUw8HJqRcGi
