### PR TITLE
feat(main-green): a deadman that reports a RED main, because nothing else does (rank 22)

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3371,10 +3371,19 @@ in
         # remote; `gnutar`/`gzip` are what nix shells out to while building.
         "PATH=${lib.makeBinPath [ pkgs.nix pkgs.git pkgs.openssh pkgs.bash pkgs.coreutils pkgs.gawk pkgs.gnused pkgs.gnugrep pkgs.util-linux pkgs.gnutar pkgs.gzip ]}"
         "HOME=%h"
-        # A user unit inherits none of the login shell's nix setup. `nix build
-        # <path>#<attr>` is flake syntax and fails without these two features,
-        # which would make every run COULD NOT MEASURE.
-        "NIX_CONFIG=experimental-features = nix-command flakes"
+        # 🔴 NO `NIX_CONFIG` HERE, DELIBERATELY. A user unit inherits none of the
+        # login shell's nix setup and `nix build <path>#<attr>` is flake syntax,
+        # so the features must come from somewhere — but NOT from this list.
+        # `Environment=` is WHITESPACE-SPLIT by systemd (the same hazard this
+        # file already documents for CPU_MON_IGNORE above), and MEASURED with
+        # `systemd-analyze verify`, `NIX_CONFIG=experimental-features =
+        # nix-command flakes` yields three "Invalid environment assignment,
+        # ignoring:" lines and sets NIX_CONFIG to the bare word
+        # `experimental-features` — which makes nix hard-error `syntax error in
+        # configuration line` on EVERY invocation. That is worse than omitting
+        # it, because this host's /etc/nix/nix.conf already enables both.
+        # The script passes `--extra-experimental-features` on the command line
+        # instead, where there is nothing for a unit file to re-parse.
       ];
       ExecStart = "${pkgs.bash}/bin/bash %h/workspace/devrc/scripts/main-green-check.sh";
       X-Restart-Triggers = [ "${../scripts/main-green-check.sh}" ];

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -77,6 +77,14 @@ let
   # (2) is why this flag waited: a timer alerting into a paused queue is WORSE than no
   # timer, because it manufactures the appearance of coverage.
   enableDriftDeadman = true;
+
+  # Main-green deadman master switch (scripts/main-green-check.sh) — gates ONLY
+  # whether the TIMER is wired into timers.target. The unit file exists either
+  # way, so `systemctl --user start main-green-check` works by hand regardless.
+  # 🔴 Set this false to silence the new alert without reverting anything: it is
+  # a NEW source of `notify-failure@`, which is the one toast class deliberately
+  # wired to defeat do-not-disturb.
+  enableMainGreenDeadman = true;
   # tmux-snapshot pusher master switch (scripts/tmux-snapshot-push.sh) — feeds
   # clawgate's cross-host tmux read model. Gates ONLY whether the timer is wired into
   # timers.target; the SERVICE definition is always emitted, so
@@ -3313,6 +3321,84 @@ in
       # but is wired into nothing, so no routine `ship.sh` can silently start a
       # timer nobody has supervised once.
       WantedBy = lib.optionals (serverMode && enableDriftDeadman) [ "timers.target" ];
+    };
+  };
+
+  # ── IS origin/main ACTUALLY GREEN? (scripts/main-green-check.sh) ─────────────
+  # Branch protection on this repo is OFF by a live operator decision, so a
+  # commit can land straight on `main` with nothing running against it. MEASURED
+  # 2026-09-03: that happened TWICE IN ONE SESSION (`a720d30d`, `a451abc0`, both
+  # one-line direct pushes titled "espanso"), `main` was red for hours each time,
+  # and BOTH times the only detector was a human running the gate by hand,
+  # incidentally. drift-check answers "is a host still receiving changes?"; this
+  # answers the independent question "is what they are receiving any good?".
+  #
+  # 🔴 IT RUNS THE HERMETIC TIER, AND THAT IS A MEASUREMENT, NOT A PREFERENCE.
+  # On one tree (main + #1261) the dev-host tier reported 4 failures and the nix
+  # sandbox tier reported 0 — all four were `subprocess.TimeoutExpired` at a
+  # fixed 300s cap while the box sat at load 22-29, with an UNTOUCHED target
+  # inflating 4.49s -> 177.26s in the same window. Wiring a DND-bypassing toast
+  # to the tier that emits those would build the permanently-red gate
+  # `claude/RULES.md` calls worse than no gate.
+  systemd.user.services.main-green-check = {
+    Unit = {
+      Description = "Is the current tip of origin/main actually green?";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+      OnFailure = [ "notify-failure@%n.service" ];
+    };
+    Service = {
+      Type = "oneshot";
+      # 🔴 rc 11 (COULD NOT MEASURE) IS A SUCCESS TO systemd, AND rc 12 IS NOT.
+      # A network blip must not fire the DND-bypassing toast — but a deadman
+      # that can go blind in silence has the same shape as the bug it was built
+      # to catch, so the script ladders consecutive unmeasured runs and exits 12
+      # once it has been unable to look for ~24h. 11 is quiet and recorded; 12
+      # is loud. (drift-check's rc 18 is the precedent: "setting no code was
+      # right per run and wrong forever".)
+      # rc 10 = RED REPRODUCED and rc 12 = BLIND both fail the unit on purpose.
+      SuccessExitStatus = 11;
+      # Two attempts x two tiers. The pytests derivation alone ran 18 min on a
+      # loaded box, so a 420s budget like drift-check's would kill this mid-build
+      # and report a timeout as a failure — an alarm about the alarm.
+      TimeoutStartSec = 5400;
+      Environment = [
+        # 🔴 `nix` IS THE WHOLE JOB. Without it on PATH every run reports COULD
+        # NOT MEASURE, the ladder escalates to 12, and the toast fires about the
+        # unit rather than about main — from a unit that looks correct. That is
+        # the exact silent shape drift-check's iproute2/python3/gh notes record.
+        # `flock` (util-linux) is the single-flight; `openssh` is for a git+ssh
+        # remote; `gnutar`/`gzip` are what nix shells out to while building.
+        "PATH=${lib.makeBinPath [ pkgs.nix pkgs.git pkgs.openssh pkgs.bash pkgs.coreutils pkgs.gawk pkgs.gnused pkgs.gnugrep pkgs.util-linux pkgs.gnutar pkgs.gzip ]}"
+        "HOME=%h"
+        # A user unit inherits none of the login shell's nix setup. `nix build
+        # <path>#<attr>` is flake syntax and fails without these two features,
+        # which would make every run COULD NOT MEASURE.
+        "NIX_CONFIG=experimental-features = nix-command flakes"
+      ];
+      ExecStart = "${pkgs.bash}/bin/bash %h/workspace/devrc/scripts/main-green-check.sh";
+      X-Restart-Triggers = [ "${../scripts/main-green-check.sh}" ];
+    };
+  };
+
+  # 4-hourly. Bounded by the incident it exists for: `main` was red "for hours"
+  # twice. The run is CHEAP when nothing landed — the verdict is memoized on the
+  # sha, so a fire against an unchanged `main` exits having built nothing — which
+  # is what makes a 4h cadence affordable when a real run costs ~20 min. It also
+  # sets the blind ladder's clock: 6 consecutive unmeasured runs is ~24h.
+  # No Persistent — it only applies to OnCalendar timers, not monotonic ones.
+  systemd.user.timers.main-green-check = {
+    Unit = {
+      Description = "Periodic timer for the origin/main green deadman";
+    };
+    Timer = {
+      OnStartupSec = "15min";
+      OnUnitActiveSec = "4h";
+    };
+    Install = {
+      # Same shape as drift-check: the master switch acts HERE and only here, so
+      # no routine `ship.sh` can silently start a timer nobody has supervised.
+      WantedBy = lib.optionals (serverMode && enableMainGreenDeadman) [ "timers.target" ];
     };
   };
 

--- a/scripts/main-green-check.sh
+++ b/scripts/main-green-check.sh
@@ -120,7 +120,21 @@ die() { say "$*"; exit "$RC_USAGE"; }
 # last real verdict. "I could not look today" and "main was red when I last
 # looked" are different facts and the second must survive the first.
 STREAK_FILE="$CACHE_ROOT/blind-streak"
-read_streak()  { [ -f "$STREAK_FILE" ] && cat "$STREAK_FILE" 2>/dev/null || echo 0; }
+# 🔴 SANITISED, AND THE BLAST RADIUS OF NOT DOING SO WAS NOT THE LADDER. An
+# unvalidated value reaches `$(( ... + 1 ))`; a non-integer makes that a bash
+# ARITHMETIC SYNTAX ERROR, which aborts `unmeasured_exit` WITHOUT exiting — and
+# every call site is inside an `if ... fi`, so the script CONTINUES past a guard
+# that just fired. Measured with a streak file of `1 2`: a failed clone was
+# announced and then ignored, the run gated an EMPTY sha, and it exited 10
+# reporting `RED, REPRODUCED — origin/main  failed BOTH attempts` with a blank
+# author. A corrupt counter turned a total failure to fetch into a DND-defeating
+# accusation about `main`.
+read_streak() {
+  local s=0
+  [ -f "$STREAK_FILE" ] && s="$(cat "$STREAK_FILE" 2>/dev/null || echo 0)"
+  case "$s" in ''|*[!0-9]*) s=0 ;; esac
+  echo "$s"
+}
 reset_streak() { echo 0 >"$STREAK_FILE" 2>/dev/null || true; }
 unmeasured_exit() {
   local n
@@ -143,7 +157,10 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --force)  FORCE=1 ;;   # ignore the memo and re-run even on an unchanged sha
     --status) STATUS_ONLY=1 ;;
-    -h|--help) sed -n '2,80p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    # 🔴 The range is the WHOLE header, computed from where it ends. A literal
+    # `2,80p` silently truncated --help the moment the header grew past line 80,
+    # hiding --force, --status and half the exit-code ladder.
+    -h|--help) sed -n "2,95p" "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) die "unknown argument: $1" ;;
   esac
   shift
@@ -159,8 +176,28 @@ mkdir -p "$CACHE_ROOT" "$LOGDIR" || die "cannot create $CACHE_ROOT"
 # CONCURRENT pair produced two FALSE failures that a sequential pair did not).
 exec 9>"$LOCK" || die "cannot open $LOCK"
 if ! flock -n 9; then
-  say "another run holds the lock — nothing to do"
-  exit "$RC_GREEN"
+  # 🔴 A FAILED `flock` IS NOT PROOF OF CONTENTION — VALIDATE THE INSTRUMENT.
+  # `flock -n` returns non-zero for ENOLCK (a filesystem without working locks:
+  # NFS without lockd, some overlay/9p mounts), a missing binary and EBADF, and
+  # none of those is another run holding the lock. This arm used to answer
+  # `exit 0` GREEN for all of them: silent, permanent, a systemd success, and it
+  # never touches the blind ladder — the "goes blind in silence" shape the
+  # ladder exists to close, reached through a different door.
+  #
+  # POSITIVE CONTROL: take a lock NOBODY holds. If that works, `flock` works
+  # here and the failure above really was contention. If it does not, we have
+  # measured nothing and must say so.
+  _probe="$CACHE_ROOT/.flock-probe.$$"
+  if ( exec 8>"$_probe" && flock -n 8 ) 2>/dev/null; then
+    rm -f "$_probe"
+    say "another run holds the lock — nothing to do"
+    exit "$RC_GREEN"
+  fi
+  rm -f "$_probe"
+  say "COULD NOT MEASURE — flock failed on a lock NOBODY holds, so 'another run"
+  say "  holds the lock' cannot be distinguished from a broken lock. Reporting"
+  say "  GREEN here would be a silent, permanent, systemd-success pass."
+  unmeasured_exit
 fi
 
 # ── where do we look? the remote the OPERATOR pushes to, read from their repo ──
@@ -248,7 +285,18 @@ run_tier() {
     "$MAIN_GREEN_GATE_CMD" "$CLONE" "$tier" >"$log" 2>&1
     return $?
   fi
-  nix build "$CLONE#checks.x86_64-linux.$tier" -L --no-link >"$log" 2>&1
+  # 🔴 THE FLAG LIVES HERE, NOT IN THE UNIT'S `Environment=`. The first draft
+  # passed it as `NIX_CONFIG=experimental-features = nix-command flakes`, and
+  # systemd WHITESPACE-SPLITS `Environment=` — a hazard nix/home.nix already
+  # documents ~1100 lines above that edit. Measured with `systemd-analyze
+  # verify`: three "Invalid environment assignment, ignoring:" lines, leaving
+  # NIX_CONFIG as the bare word `experimental-features`, which makes nix itself
+  # hard-error `syntax error in configuration line` on EVERY invocation — worse
+  # than omitting it, since this host's /etc/nix/nix.conf already enables both.
+  # On the command line there is nothing for a unit file to re-parse, and the
+  # script works identically by hand, from systemd, or from cron.
+  nix --extra-experimental-features "nix-command flakes" \
+      build "$CLONE#checks.x86_64-linux.$tier" -L --no-link >"$log" 2>&1
   return $?
 }
 
@@ -263,7 +311,32 @@ tier_verdict() {
     [ "$rc" -eq 0 ] && echo green || echo disagree
     return
   fi
-  [ "$rc" -eq 0 ] && echo noverdict || echo red
+
+  # ── no `RESULT:` line at all ────────────────────────────────────────────────
+  # 🔴 A NON-ZERO EXIT WITH NO VERDICT IS A BROKEN GATE, NOT A BROKEN `main`.
+  # This arm used to return `red`, and that is the worst answer this file can
+  # give: the red path names the commit's AUTHOR and fires a do-not-disturb-
+  # defeating toast saying "main is broken RIGHT NOW", with an EMPTY "Failing
+  # tests:" list. Measured — a `nix` that cannot start (see the NIX_CONFIG
+  # incident in nix/home.nix) exits 1 silently and produced exactly that
+  # accusation against an innocent commit, every 4h, memoized so it repeated.
+  # A genuinely failing suite cannot reach here: it exits non-zero AND prints
+  # `RESULT: FAIL`, which the first arm catches.
+  if [ "$rc" -ne 0 ]; then echo noverdict; return; fi
+
+  # ── rc 0 and no verdict — TWO DIFFERENT FACTS, and they must not be merged ──
+  # 🔴 EMPTY output is the CACHED case, and it is GREEN. `-L` streams a log only
+  # while a build RUNS; an already-realised derivation is not rebuilt, so nix
+  # prints nothing and exits 0. That is not an absence of evidence — a check
+  # derivation RUNS the suite, so nix exiting 0 means it built, which means the
+  # tests passed. Treating it as "no verdict" made the MODAL path report COULD
+  # NOT MEASURE: devrc/CLAUDE.md tells every merger to build these same two
+  # derivations on the merged tree before merging, so the tip this deadman
+  # checks is usually already realised — six such runs ladder to a BLIND toast
+  # about a perfectly green `main`, and `--force` was broken by construction.
+  #
+  # NON-EMPTY output with no verdict is a TRUNCATED run and stays unmeasured.
+  [ -s "$log" ] && echo noverdict || echo cached
 }
 
 # 🔴 SETS A GLOBAL; it does NOT echo its verdict.
@@ -280,11 +353,20 @@ attempt_all_tiers() {
     run_tier "$tier" "$attempt"; rc=$?
     v="$(tier_verdict "$LOGDIR/${tier}.attempt${attempt}.log" "$rc")"
     say "  attempt $attempt · $tier · rc=$rc · verdict=$v"
+    # 🔴 EVERY DOWNGRADE-TO-UNMEASURED IS GUARDED BY `overall = green`, AND THE
+    # MISSING GUARD ON `disagree` MADE THE VERDICT ORDER-DEPENDENT. Measured:
+    # pytests `RESULT: FAIL` + nodetests status/content disagreement resolved to
+    # rc 11 — a systemd SUCCESS, no toast — while the same two tiers in the
+    # other order resolved to rc 10. A genuinely red `main` was reported as
+    # nothing at all, which is the one outcome this whole file exists to
+    # prevent. `red` outranks `unmeasured`: not knowing about ONE tier cannot
+    # unlearn what another tier positively measured.
     case "$v" in
       red)       overall=red ;;
+      cached)    say "  ↳ $tier was already realised — nix rebuilt nothing, which for a check derivation IS a pass" ;;
       disagree)  say "  🔴 status/content DISAGREE on $tier — not resolving that in favour of the reassuring side"
-                 overall=unmeasured ;;
-      noverdict) say "  🔴 $tier exited 0 but printed no RESULT: line — a truncated run is not a pass"
+                 [ "$overall" = green ] && overall=unmeasured ;;
+      noverdict) say "  🔴 $tier printed no RESULT: line — a truncated or failed-to-start run is not a pass"
                  [ "$overall" = green ] && overall=unmeasured ;;
     esac
   done

--- a/scripts/main-green-check.sh
+++ b/scripts/main-green-check.sh
@@ -202,6 +202,13 @@ while [ $# -gt 0 ]; do
     # next edit. `set -uo pipefail` is the first line after the header.
     -h|--help)
       _hdr=$(grep -n '^set -uo pipefail' "${BASH_SOURCE[0]}" | head -1 | cut -d: -f1)
+      # 🔴 A ZERO THAT MEANS NOTHING IS THE FAILURE THIS FILE ARGUES AGAINST, and
+      # the computed range introduced one. Reword the sentinel and `grep` matches
+      # nothing, `_hdr` is empty, `$(( _hdr - 1 ))` is -1, and `sed -n "2,-1p"`
+      # errors to stderr while --help prints ZERO lines and exits 0. MEASURED.
+      # The literal it replaced merely TRUNCATED the help; this deleted it and
+      # reported success. Refuse instead.
+      [ -n "$_hdr" ] || die "cannot locate the end of the header (the 'set -uo pipefail' sentinel moved)"
       sed -n "2,$(( _hdr - 1 ))p" "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
       exit 0 ;;
     *) die "unknown argument: $1" ;;

--- a/scripts/main-green-check.sh
+++ b/scripts/main-green-check.sh
@@ -87,6 +87,12 @@
 #       copied rather than reinvented. A single measured run resets the streak.
 #    2  usage / precondition problem in this script.
 #
+# ── OPTIONS ───────────────────────────────────────────────────────────────────
+#   --force    ignore the memo and re-run even when the tip has not moved.
+#   --status   print the last recorded verdict and exit. Does not take the lock,
+#              so it works while a run is in flight.
+#   -h/--help  this header.
+#
 # TEST SEAM: MAIN_GREEN_GATE_CMD overrides the gate invocation (it is passed the
 # checkout path and the tier name). MAIN_GREEN_CACHE overrides the cache root.
 # MAIN_GREEN_REMOTE overrides which remote is cloned. All three exist so the
@@ -102,12 +108,20 @@ RC_BLIND=12
 RC_USAGE=2
 
 BLIND_ESCALATE="${MAIN_GREEN_BLIND_ESCALATE:-6}"
+# 🔴 CONTENTION IS ALSO A NON-MEASUREMENT, and round 1 left this door open while
+# its own comment condemned the whole class. A lock held by a hand-run that hung
+# makes every fire print "another run holds the lock" and exit 0 — silent, a
+# systemd success, touching no ladder — so the deadman can be blind indefinitely
+# with nothing saying so. Lower than BLIND_ESCALATE because a legitimately
+# overlapping run resolves within one or two intervals.
+CONTENTION_ESCALATE="${MAIN_GREEN_CONTENTION_ESCALATE:-3}"
 
 CACHE_ROOT="${MAIN_GREEN_CACHE:-$HOME/.cache/main-green}"
 CLONE="$CACHE_ROOT/repo"
 STATE="$CACHE_ROOT/state"
 LOCK="$CACHE_ROOT/lock"
 LOGDIR="$CACHE_ROOT/logs"
+CONTENTION_FILE="$CACHE_ROOT/contention-streak"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRC_REPO="$(dirname "$SCRIPT_DIR")"
@@ -129,12 +143,27 @@ STREAK_FILE="$CACHE_ROOT/blind-streak"
 # reporting `RED, REPRODUCED — origin/main  failed BOTH attempts` with a blank
 # author. A corrupt counter turned a total failure to fetch into a DND-defeating
 # accusation about `main`.
-read_streak() {
-  local s=0
-  [ -f "$STREAK_FILE" ] && s="$(cat "$STREAK_FILE" 2>/dev/null || echo 0)"
+read_count() {
+  local f="$1" s=0
+  [ -f "$f" ] && s="$(cat "$f" 2>/dev/null || echo 0)"
+  # 🔴 DO NOT STRIP INTERNAL WHITESPACE. An earlier draft did, and it turned the
+  # corrupt value `1 2` into a perfectly plausible `12` — making a garbage
+  # counter look like a real streak. `$(cat ...)` already drops trailing
+  # newlines; anything else containing a space is corrupt and reads as 0.
   case "$s" in ''|*[!0-9]*) s=0 ;; esac
+  # 🔴 A DIGITS-ONLY CHECK IS NARROWER THAN THE HAZARD. `08` and `09` ARE all
+  # digits and sail through the case above — and bash reads a leading zero as
+  # OCTAL, so `$(( 08 + 1 ))` is `value too great for base`: the SAME arithmetic
+  # abort the sanitiser exists to stop. MEASURED at 31864127 with a streak of
+  # `08`: the clone failed, the fetch failed, the sha was EMPTY, and the run
+  # printed `✅ GREEN — origin/main  passed both sandbox tiers` and exited 0.
+  # A deadman reporting a green it never measured is worse than no deadman.
+  # A length cap first, because a huge literal overflows the same arithmetic.
+  [ "${#s}" -gt 6 ] && s=0
+  s=$(( 10#$s ))          # force base ten; 10#08 == 8
   echo "$s"
 }
+read_streak() { read_count "$STREAK_FILE"; }
 reset_streak() { echo 0 >"$STREAK_FILE" 2>/dev/null || true; }
 unmeasured_exit() {
   local n
@@ -157,10 +186,14 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --force)  FORCE=1 ;;   # ignore the memo and re-run even on an unchanged sha
     --status) STATUS_ONLY=1 ;;
-    # 🔴 The range is the WHOLE header, computed from where it ends. A literal
-    # `2,80p` silently truncated --help the moment the header grew past line 80,
-    # hiding --force, --status and half the exit-code ladder.
-    -h|--help) sed -n "2,95p" "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    # 🔴 COMPUTED FROM WHERE THE HEADER ENDS, not a literal. A hardcoded range
+    # silently truncates --help the moment the header grows past it — which had
+    # already happened once (`2,80p`), and "bump the constant" re-rots on the
+    # next edit. `set -uo pipefail` is the first line after the header.
+    -h|--help)
+      _hdr=$(grep -n '^set -uo pipefail' "${BASH_SOURCE[0]}" | head -1 | cut -d: -f1)
+      sed -n "2,$(( _hdr - 1 ))p" "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
     *) die "unknown argument: $1" ;;
   esac
   shift
@@ -174,6 +207,15 @@ mkdir -p "$CACHE_ROOT" "$LOGDIR" || die "cannot create $CACHE_ROOT"
 # runs would fight over the clone and over the state file, and two nix builds of
 # the same derivation contend in the store (devrc/CLAUDE.md records that a
 # CONCURRENT pair produced two FALSE failures that a sequential pair did not).
+# 🔴 BEFORE THE LOCK, DELIBERATELY. `--status` only READS the recorded
+# verdict, and the moment you most want it is while a 20-minute run is in
+# flight — which is precisely when taking the lock first would block it.
+if [ "$STATUS_ONLY" = "1" ]; then
+  if [ -f "$STATE" ]; then say "last verdict:"; sed 's/^/  /' "$STATE"
+  else say "no verdict recorded yet"; fi
+  exit "$RC_GREEN"
+fi
+
 exec 9>"$LOCK" || die "cannot open $LOCK"
 if ! flock -n 9; then
   # 🔴 A FAILED `flock` IS NOT PROOF OF CONTENTION — VALIDATE THE INSTRUMENT.
@@ -190,7 +232,16 @@ if ! flock -n 9; then
   _probe="$CACHE_ROOT/.flock-probe.$$"
   if ( exec 8>"$_probe" && flock -n 8 ) 2>/dev/null; then
     rm -f "$_probe"
-    say "another run holds the lock — nothing to do"
+    _cn=$(( $(read_count "$CONTENTION_FILE") + 1 ))
+    echo "$_cn" >"$CONTENTION_FILE" 2>/dev/null || true
+    if [ "$_cn" -ge "$CONTENTION_ESCALATE" ]; then
+      say "🔴 $_cn consecutive runs skipped for CONTENTION — a lock held that long"
+      say "  has made this deadman blind, and exiting 0 would keep it silent."
+      say "  Look for a hand-run or a wedged run holding $LOCK."
+      unmeasured_exit
+    fi
+    say "another run holds the lock — nothing to do" \
+        "($_cn consecutive; escalates at $CONTENTION_ESCALATE)"
     exit "$RC_GREEN"
   fi
   rm -f "$_probe"
@@ -199,6 +250,8 @@ if ! flock -n 9; then
   say "  GREEN here would be a silent, permanent, systemd-success pass."
   unmeasured_exit
 fi
+
+rm -f "$CONTENTION_FILE" 2>/dev/null || true   # we hold the lock: not contended
 
 # ── where do we look? the remote the OPERATOR pushes to, read from their repo ──
 # A read. Never a write. If this script is run from somewhere without a git
@@ -213,11 +266,6 @@ fi
 read_state() { [ -f "$STATE" ] && cat "$STATE" || echo ""; }
 state_field() { read_state | awk -v k="$1" '$1==k {print $2; exit}'; }
 
-if [ "$STATUS_ONLY" = "1" ]; then
-  if [ -f "$STATE" ]; then say "last verdict:"; sed 's/^/  /' "$STATE"
-  else say "no verdict recorded yet"; fi
-  exit "$RC_GREEN"
-fi
 
 # ── keep the private clone current ────────────────────────────────────────────
 if [ ! -d "$CLONE/.git" ]; then
@@ -295,8 +343,15 @@ run_tier() {
   # than omitting it, since this host's /etc/nix/nix.conf already enables both.
   # On the command line there is nothing for a unit file to re-parse, and the
   # script works identically by hand, from systemd, or from cron.
+  # 🔴 `--no-warn-dirty` IS LOAD-BEARING FOR THE CACHED ARM, not cosmetic. A
+  # dirty tree makes nix emit `warning: Git tree '...' is dirty` — measured at
+  # 141 bytes — which makes a CACHED build's output NON-empty, so it reads as a
+  # truncated run (UNMEASURED) and ladders to BLIND about a green `main`. The
+  # detached clone should never be dirty, and `--no-link` is what keeps it that
+  # way (a `result` symlink would dirty it); this makes the inference hold even
+  # if something does dirty it.
   nix --extra-experimental-features "nix-command flakes" \
-      build "$CLONE#checks.x86_64-linux.$tier" -L --no-link >"$log" 2>&1
+      build "$CLONE#checks.x86_64-linux.$tier" -L --no-link --no-warn-dirty >"$log" 2>&1
   return $?
 }
 

--- a/scripts/main-green-check.sh
+++ b/scripts/main-green-check.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+#
+# main-green-check — PASSIVE deadman answering one question, unattended:
+#
+#     "is the CURRENT tip of origin/main actually green?"
+#
+# It REPORTS. It never fixes, never pushes, never reverts.
+#
+# ── WHY THIS EXISTS ───────────────────────────────────────────────────────────
+# Branch protection on this repo is OFF by a live operator decision (see
+# devrc/CLAUDE.md), so a commit can land straight on `main` with nothing running
+# against it. That is not hypothetical and the rate is MEASURED — twice in one
+# session, 2026-09-03:
+#
+#   a720d30d  "espanso", one line, no PR. Changed `:acq`'s label so
+#             `recom`/`recommend` matched two snippets and attribution returned
+#             None. `main` red on BOTH tiers.
+#   a451abc0  "espanso", direct to main, no PR. SWAPPED `:acq`'s `label` and
+#             `replace`, which removed the collision a guard asserted existed and
+#             red-ed `main` a second time.
+#
+# 🔴 BOTH TIMES THE ONLY DETECTOR WAS A HUMAN RUNNING THE GATE BY HAND, HOURS
+# LATER, INCIDENTALLY. That is the gap this closes. `main` being red is not the
+# interesting part — `main` being red *and nobody knowing* is.
+#
+# ── WHY IT RUNS THE REAL SUITE ────────────────────────────────────────────────
+# The second break was a GUARD WHOSE PREMISE DIED, not a regression: the thing it
+# asserted was simply gone at the source. A distilled check ("did attribution
+# regress?") would have sailed past it. Only running what the gate actually runs
+# catches both shapes, so that is what this does.
+#
+# ── WHY IT RUNS THE NIX SANDBOX TIER, NOT THE DEV-HOST TIER ───────────────────
+# 🔴 MEASURED 2026-09-03 on ONE tree (main + #1261), which is the whole argument:
+#
+#   dev-host tier (scripts/gate.sh)   4 failed — 2 in scripts/tests, 2 in
+#                                     scripts/browser-bridge/tests
+#   nix sandbox tier (SAME tree)      collected=21013 passed=21010 failed=0
+#
+# All four dev-host failures were `subprocess.TimeoutExpired` at a fixed 300 s
+# cap with returncode -9 — never an assertion — while the box sat at load 22-29
+# with other sessions' `opencode`/`npm` processes on it. An untouched target
+# (`scripts/collector/tests`, 273 tests) went 4.49 s -> 177.26 s in the same
+# window: a 39x inflation, which is contention's signature and not a defect's.
+#
+# A deadman wired to the tier that emits those would toast on them, and
+# `claude/RULES.md` is explicit that a permanently-red gate is WORSE than no gate
+# because it trains everyone to click through. So this uses the hermetic tier.
+# ⚠ HONESTLY SCOPED: the sandbox runs on the same box and is NOT proven immune to
+# load — it was green under that load ONCE. The retry below is what covers the
+# case where it is not, and a FLAKE verdict is reported rather than hidden.
+#
+# ── HOW IT AVOIDS BEING EXPENSIVE ─────────────────────────────────────────────
+# MEMOIZED ON THE SHA. A verdict is recorded against the exact commit it was
+# computed for; if origin/main has not moved since, this exits immediately having
+# run nothing. `main` moved 5 times during one session, so this is ~1-2 real runs
+# a day rather than one per timer fire.
+#
+# ── PASSIVE MEANS PASSIVE ─────────────────────────────────────────────────────
+# 🔴 This script must NEVER touch the operator's checkout. It maintains its OWN
+# clone under $MAIN_GREEN_CACHE and does every fetch/checkout/build there. The
+# only thing it reads from the invoking repo is `remote get-url origin`, so it
+# asks the same remote the operator pushes to. `scripts/tests/test_main_green_
+# check.py` enforces that statically: every `git -C` in this file must target the
+# cache clone, never $DEVRC.
+#
+# 🔴 It also never creates a worktree in the operator's clone. `git worktree add`
+# writes to the COMMON git dir (refs, config, worktree registry) and is therefore
+# a repo-GLOBAL mutation of a checkout other sessions are using — see
+# claude/RULES.md "Git Workflow". A private clone has none of that reach.
+#
+# ── EXIT CODES ────────────────────────────────────────────────────────────────
+#    0  GREEN — origin/main's tip passed, or was already verified, or a red did
+#       not reproduce (FLAKE). Every 0 prints WHICH of those it is; they are
+#       different facts and are never collapsed.
+#   10  RED, REPRODUCED — ran twice, failed twice. This is the toast.
+#   11  COULD NOT MEASURE — no network, no nix, clone unusable, gate produced no
+#       verdict. 🔴 NOT a pass and NOT a red. A deadman that reports "clean"
+#       when it could not look is the failure mode this whole file exists to
+#       avoid, so this is its own code and it is never folded into 0.
+#   12  BLIND — could not measure N times CONSECUTIVELY (MAIN_GREEN_BLIND_
+#       ESCALATE, default 6 ≈ 24h at a 4h timer).
+#       🔴 WHY THIS EXISTS AS A SEPARATE CODE. Making 11 a systemd success stops
+#       a transient network blip from toasting — and, on its own, lets this
+#       deadman go blind FOREVER in silence, which is the same shape as the bug
+#       it was built to catch. drift-check learned this the hard way (its rc 18:
+#       "setting no code was right per run and wrong forever"), so the ladder is
+#       copied rather than reinvented. A single measured run resets the streak.
+#    2  usage / precondition problem in this script.
+#
+# TEST SEAM: MAIN_GREEN_GATE_CMD overrides the gate invocation (it is passed the
+# checkout path and the tier name). MAIN_GREEN_CACHE overrides the cache root.
+# MAIN_GREEN_REMOTE overrides which remote is cloned. All three exist so the
+# tests can drive every arm hermetically without a 20-minute build; none is read
+# anywhere else, and `scripts/tests/test_main_green_check.py` pins that the
+# PRODUCTION path (no seam set) still resolves the operator's own origin.
+set -uo pipefail
+
+RC_GREEN=0
+RC_RED=10
+RC_UNMEASURED=11
+RC_BLIND=12
+RC_USAGE=2
+
+BLIND_ESCALATE="${MAIN_GREEN_BLIND_ESCALATE:-6}"
+
+CACHE_ROOT="${MAIN_GREEN_CACHE:-$HOME/.cache/main-green}"
+CLONE="$CACHE_ROOT/repo"
+STATE="$CACHE_ROOT/state"
+LOCK="$CACHE_ROOT/lock"
+LOGDIR="$CACHE_ROOT/logs"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_REPO="$(dirname "$SCRIPT_DIR")"
+
+say() { printf 'main-green: %s\n' "$*"; }
+die() { say "$*"; exit "$RC_USAGE"; }
+
+# ── the blind ladder ──────────────────────────────────────────────────────────
+# Kept in its OWN file, deliberately: an unmeasured run must not overwrite the
+# last real verdict. "I could not look today" and "main was red when I last
+# looked" are different facts and the second must survive the first.
+STREAK_FILE="$CACHE_ROOT/blind-streak"
+read_streak()  { [ -f "$STREAK_FILE" ] && cat "$STREAK_FILE" 2>/dev/null || echo 0; }
+reset_streak() { echo 0 >"$STREAK_FILE" 2>/dev/null || true; }
+unmeasured_exit() {
+  local n
+  n=$(( $(read_streak) + 1 ))
+  echo "$n" >"$STREAK_FILE" 2>/dev/null || true
+  say "  consecutive could-not-measure runs: $n (escalates at $BLIND_ESCALATE)"
+  if [ "$n" -ge "$BLIND_ESCALATE" ]; then
+    say "🔴 BLIND — $n consecutive runs could not measure anything."
+    say "  This deadman has been unable to look for that long, so its silence has"
+    say "  meant NOTHING over that whole window. Escalated on purpose: a scope"
+    say "  that can never be evaluated, and never escalates, reads as clean forever."
+    exit "$RC_BLIND"
+  fi
+  exit "$RC_UNMEASURED"
+}
+
+
+FORCE=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --force)  FORCE=1 ;;   # ignore the memo and re-run even on an unchanged sha
+    --status) STATUS_ONLY=1 ;;
+    -h|--help) sed -n '2,80p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+  shift
+done
+STATUS_ONLY="${STATUS_ONLY:-0}"
+
+mkdir -p "$CACHE_ROOT" "$LOGDIR" || die "cannot create $CACHE_ROOT"
+
+# ── single-flight ─────────────────────────────────────────────────────────────
+# A run can take 20 minutes; the timer fires more often than that. Overlapping
+# runs would fight over the clone and over the state file, and two nix builds of
+# the same derivation contend in the store (devrc/CLAUDE.md records that a
+# CONCURRENT pair produced two FALSE failures that a sequential pair did not).
+exec 9>"$LOCK" || die "cannot open $LOCK"
+if ! flock -n 9; then
+  say "another run holds the lock — nothing to do"
+  exit "$RC_GREEN"
+fi
+
+# ── where do we look? the remote the OPERATOR pushes to, read from their repo ──
+# A read. Never a write. If this script is run from somewhere without a git
+# remote we cannot know what to check, and that is UNMEASURED, not clean.
+REMOTE_URL="${MAIN_GREEN_REMOTE:-$(git -C "$SRC_REPO" remote get-url origin 2>/dev/null || true)}"
+if [ -z "$REMOTE_URL" ]; then
+  say "COULD NOT MEASURE — no 'origin' remote on $SRC_REPO, so there is no"
+  say "  branch to check. This is not a clean bill of health."
+  unmeasured_exit
+fi
+
+read_state() { [ -f "$STATE" ] && cat "$STATE" || echo ""; }
+state_field() { read_state | awk -v k="$1" '$1==k {print $2; exit}'; }
+
+if [ "$STATUS_ONLY" = "1" ]; then
+  if [ -f "$STATE" ]; then say "last verdict:"; sed 's/^/  /' "$STATE"
+  else say "no verdict recorded yet"; fi
+  exit "$RC_GREEN"
+fi
+
+# ── keep the private clone current ────────────────────────────────────────────
+if [ ! -d "$CLONE/.git" ]; then
+  say "first run — cloning $REMOTE_URL into $CLONE (this is NOT your checkout)"
+  if ! git clone --quiet "$REMOTE_URL" "$CLONE" 2>"$LOGDIR/clone.err"; then
+    say "COULD NOT MEASURE — clone failed:"
+    sed 's/^/  /' "$LOGDIR/clone.err" | head -5
+    unmeasured_exit
+  fi
+fi
+
+if ! git -C "$CLONE" fetch --quiet origin 2>"$LOGDIR/fetch.err"; then
+  say "COULD NOT MEASURE — fetch failed (network? credentials?):"
+  sed 's/^/  /' "$LOGDIR/fetch.err" | head -5
+  say "  🔴 This is NOT 'main is green'. Nothing was checked."
+  unmeasured_exit
+fi
+
+# The mainline is DERIVED, never hardcoded: this script is meant to be copyable
+# to a repo whose mainline is `trunk`, and a hardcoded `main` would silently
+# check a branch that does not exist and report a reassuring nothing.
+MAINLINE="$(git -C "$CLONE" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+MAINLINE="${MAINLINE:-main}"
+SHA="$(git -C "$CLONE" rev-parse "origin/$MAINLINE" 2>/dev/null || true)"
+if [ -z "$SHA" ]; then
+  say "COULD NOT MEASURE — cannot resolve origin/$MAINLINE in $CLONE"
+  unmeasured_exit
+fi
+SUBJECT="$(git -C "$CLONE" log -1 --format=%s "$SHA" 2>/dev/null | cut -c1-72)"
+
+# ── the memo ──────────────────────────────────────────────────────────────────
+LAST_SHA="$(state_field sha)"
+LAST_VERDICT="$(state_field verdict)"
+if [ "$FORCE" != "1" ] && [ -n "$LAST_SHA" ] && [ "$LAST_SHA" = "$SHA" ]; then
+  case "$LAST_VERDICT" in
+    green|flake)
+      say "GREEN (already verified) — origin/$MAINLINE is still ${SHA:0:8}, verdict=$LAST_VERDICT"
+      say "  nothing was re-run; --force overrides"
+      reset_streak; exit "$RC_GREEN" ;;
+    red)
+      say "🔴 RED (already measured, unchanged) — origin/$MAINLINE ${SHA:0:8} was red and"
+      say "  has not moved since. Nobody has fixed it."
+      say "  subject: $SUBJECT"
+      reset_streak; exit "$RC_RED" ;;
+  esac
+fi
+
+# ── check out the tip, in OUR clone ───────────────────────────────────────────
+if ! git -C "$CLONE" checkout --quiet --detach "$SHA" 2>"$LOGDIR/checkout.err"; then
+  say "COULD NOT MEASURE — cannot check out $SHA in the cache clone:"
+  sed 's/^/  /' "$LOGDIR/checkout.err" | head -5
+  unmeasured_exit
+fi
+
+# ── run one tier, hermetically ────────────────────────────────────────────────
+# 🔴 ONE AT A TIME, never in a single `nix build` invocation. devrc/CLAUDE.md
+# records the measurement: a COMBINED build of both derivations reported 2
+# failures (`SQLite database is busy`, `database is locked`) that the SAME tree
+# built SEQUENTIALLY did not. A combined GREEN is trustworthy; a combined RED is
+# not. So we never create that ambiguity in the first place.
+run_tier() {
+  local tier="$1" attempt="$2" log
+  log="$LOGDIR/${tier}.attempt${attempt}.log"
+  if [ -n "${MAIN_GREEN_GATE_CMD:-}" ]; then
+    "$MAIN_GREEN_GATE_CMD" "$CLONE" "$tier" >"$log" 2>&1
+    return $?
+  fi
+  nix build "$CLONE#checks.x86_64-linux.$tier" -L --no-link >"$log" 2>&1
+  return $?
+}
+
+# The verdict is read from the runner's own RESULT: line where there is one, not
+# from the exit status alone — devrc/CLAUDE.md records four agents reporting
+# `exit 0` over content saying `RESULT: FAIL`. Both must agree, and a build that
+# produced NO verdict at all is UNMEASURED rather than either answer.
+tier_verdict() {
+  local log="$1" rc="$2"
+  if grep -q "RESULT: FAIL" "$log" 2>/dev/null; then echo red; return; fi
+  if grep -q "RESULT: PASS" "$log" 2>/dev/null; then
+    [ "$rc" -eq 0 ] && echo green || echo disagree
+    return
+  fi
+  [ "$rc" -eq 0 ] && echo noverdict || echo red
+}
+
+# 🔴 SETS A GLOBAL; it does NOT echo its verdict.
+# The obvious shape here is `v=$(attempt_all_tiers 1)`, and it is wrong: command
+# substitution captures stdout, so every per-tier progress line — including the
+# DISAGREE and no-verdict warnings, the two most important things this script can
+# say — would be swallowed and thrown away by the caller. The operator would see
+# a bare verdict with no account of how it was reached. Caught by
+# `test_status_and_content_DISAGREEING_...` asserting the warning reaches stdout.
+ATTEMPT_VERDICT=""
+attempt_all_tiers() {
+  local attempt="$1" tier rc v overall=green
+  for tier in pytests nodetests; do
+    run_tier "$tier" "$attempt"; rc=$?
+    v="$(tier_verdict "$LOGDIR/${tier}.attempt${attempt}.log" "$rc")"
+    say "  attempt $attempt · $tier · rc=$rc · verdict=$v"
+    case "$v" in
+      red)       overall=red ;;
+      disagree)  say "  🔴 status/content DISAGREE on $tier — not resolving that in favour of the reassuring side"
+                 overall=unmeasured ;;
+      noverdict) say "  🔴 $tier exited 0 but printed no RESULT: line — a truncated run is not a pass"
+                 [ "$overall" = green ] && overall=unmeasured ;;
+    esac
+  done
+  ATTEMPT_VERDICT="$overall"
+}
+
+say "checking origin/$MAINLINE ${SHA:0:8} — $SUBJECT"
+attempt_all_tiers 1
+FIRST="$ATTEMPT_VERDICT"
+
+VERDICT="$FIRST"
+if [ "$FIRST" = "red" ]; then
+  # 🔴 THE RETRY IS NOT "run until green". It runs EXACTLY ONCE more, and a red
+  # that clears is recorded as a FLAKE rather than as a pass — the distinction is
+  # the whole point, because a flake that is silently swallowed is how a real
+  # break gets absorbed into the noise.
+  say "🔴 red on attempt 1 — re-running ONCE to separate a real break from a load flake"
+  attempt_all_tiers 2
+  SECOND="$ATTEMPT_VERDICT"
+  if [ "$SECOND" = "green" ]; then
+    VERDICT=flake
+  elif [ "$SECOND" = "red" ]; then
+    VERDICT=red
+  else
+    VERDICT=unmeasured
+  fi
+fi
+
+# ── record, then report ───────────────────────────────────────────────────────
+{
+  echo "sha $SHA"
+  echo "verdict $VERDICT"
+  echo "mainline $MAINLINE"
+  echo "when $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} >"$STATE.tmp" && mv "$STATE.tmp" "$STATE"
+
+# A run that reached a verdict — ANY verdict, red included — is a run that could
+# see. Only `unmeasured` leaves the streak standing.
+[ "$VERDICT" = "unmeasured" ] || reset_streak
+
+case "$VERDICT" in
+  green)
+    say "✅ GREEN — origin/$MAINLINE ${SHA:0:8} passed both sandbox tiers"
+    exit "$RC_GREEN" ;;
+  flake)
+    say "✅ GREEN (FLAKE ABSORBED) — ${SHA:0:8} failed attempt 1 and passed attempt 2."
+    say "  Not toasted, and NOT hidden: logs in $LOGDIR. If this recurs on the same"
+    say "  test, it is a timing dependency to fix, not a flake to re-run."
+    exit "$RC_GREEN" ;;
+  red)
+    say "🔴 RED, REPRODUCED — origin/$MAINLINE ${SHA:0:8} failed BOTH attempts."
+    say "  subject: $SUBJECT"
+    say "  author:  $(git -C "$CLONE" log -1 --format='%an <%ae>' "$SHA" 2>/dev/null)"
+    say "  landed:  $(git -C "$CLONE" log -1 --format=%cI "$SHA" 2>/dev/null)"
+    say "  🔴 main is broken RIGHT NOW and branch protection is off, so nothing"
+    say "     else is going to tell you. Failing tests:"
+    sed 's/\x1b\[[0-9;]*m//g' "$LOGDIR"/*.attempt2.log 2>/dev/null \
+      | grep -E "^\s+FAIL\s+|^FAILED" | sed 's/^/    /' | head -12
+    say "  full logs: $LOGDIR"
+    exit "$RC_RED" ;;
+  *)
+    say "COULD NOT MEASURE — the gate did not return a usable verdict for ${SHA:0:8}."
+    say "  🔴 This is NOT 'main is green'. Read $LOGDIR before believing anything."
+    unmeasured_exit ;;
+esac

--- a/scripts/main-green-check.sh
+++ b/scripts/main-green-check.sh
@@ -45,9 +45,19 @@
 # A deadman wired to the tier that emits those would toast on them, and
 # `claude/RULES.md` is explicit that a permanently-red gate is WORSE than no gate
 # because it trains everyone to click through. So this uses the hermetic tier.
-# ⚠ HONESTLY SCOPED: the sandbox runs on the same box and is NOT proven immune to
-# load — it was green under that load ONCE. The retry below is what covers the
-# case where it is not, and a FLAKE verdict is reported rather than hidden.
+# ⚠ HONESTLY SCOPED, AND NOW MEASURED THE OTHER WAY TOO: the sandbox runs on the
+# same box and is NOT immune to load. On 2026-09-03 at load 48 a sandbox run of
+# this very branch failed `test_live_cotenants_does_not_count_this_process` — a
+# test in a family already recorded as flaky, in a subsystem this branch does not
+# touch. The discriminator was wall time, per claude/RULES.md: FIVE untouched
+# targets inflated 11x-20x against the previous passing run of the same tree
+# (task-spec-drafter 4.4s->89.6s, validation 4.6s->81.3s, repo-cos 2.4s->39.6s),
+# while the target that actually failed moved only 1.2x. Load inflates EVERY
+# target; a failed assertion inflates exactly one.
+# 🔴 SO THE RETRY BELOW IS LOAD-BEARING, NOT BELT-AND-BRACES. The hermetic tier
+# is much better than the dev-host one here, not perfect, and a deadman wired to
+# a single hermetic run WOULD have toasted on that. One retry plus a FLAKE
+# verdict that is reported rather than hidden is what makes it usable.
 #
 # ── HOW IT AVOIDS BEING EXPENSIVE ─────────────────────────────────────────────
 # MEMOIZED ON THE SHA. A verdict is recorded against the exact commit it was

--- a/scripts/tests/test_main_green_check.py
+++ b/scripts/tests/test_main_green_check.py
@@ -28,12 +28,17 @@ does while every behavioural test stays green.
 import os
 import re
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from testlib.mockbin import write_exec  # noqa: E402
+
 SCRIPT = ROOT / "scripts" / "main-green-check.sh"
 
 RC_GREEN, RC_RED, RC_UNMEASURED, RC_BLIND, RC_USAGE = 0, 10, 11, 12, 2
@@ -83,12 +88,19 @@ def world(tmp_path):
 
 
 def _stub(world, script_body):
-    """Write a gate stub. It is handed (checkout, tier) exactly as production is."""
-    p = world["tmp"] / "gate-stub.sh"
-    p.write_text("#!/usr/bin/env bash\n"
-                 'echo "$2" >> "$CALLS"\n' + script_body)
-    p.chmod(0o755)
-    return p
+    """Write a gate stub. It is handed (checkout, tier) exactly as production is.
+
+    🔴 THE SHEBANG IS NOT OURS TO WRITE — `testlib.mockbin.write_exec` owns it.
+    The first draft wrote `#!/usr/bin/env bash` by hand, which works on the dev
+    host and does NOT exist inside the nix build sandbox: every stub exec came
+    back `rc=126` (found, not executable), the script correctly reported RED, and
+    9 tests in this file failed in the sandbox tier while all 22 passed on the
+    dev host. `test_no_test_writes_a_usr_bin_env_shebang_at_runtime` is the
+    repo's existing guard for exactly that and caught it as the 10th failure.
+    Bodies must be POSIX sh — write_exec's shebang is /bin/sh, not bash.
+    """
+    return write_exec(world["tmp"] / "gate-stub.sh",
+                      'echo "$2" >> "$CALLS"\n' + script_body)
 
 
 def _run(world, stub, *args, extra_env=None):

--- a/scripts/tests/test_main_green_check.py
+++ b/scripts/tests/test_main_green_check.py
@@ -342,12 +342,16 @@ def test_a_CORRUPT_streak_file_cannot_make_the_guards_FALL_THROUGH(world):
 
 
 # (raw streak file content, the integer the sanitiser MUST read out of it)
-# 🔴 EVERY EXPECTED VALUE IS DISTINCT, AND NONE IS 0 EXCEPT WHERE 0 IS THE POINT.
-# A fixture whose expectation collides with the fall-through value cannot see the
-# mutant: an earlier version of this test asserted only `rc in (11, 12)`, and BOTH
-# the fixed and the broken script land on 11 (the broken one by aborting the
-# arithmetic and failing the `-ge` test), so removing the base-ten coercion
-# SURVIVED a fully green suite. The counter the run records is the discriminator.
+# 🔴 THE COUNTER ALONE IS NOT A SUFFICIENT DISCRIMINATOR, AND AN EARLIER COMMENT
+# HERE CLAIMED IT WAS. It asserted "every expected value is distinct" — false:
+# `1` appears three times, and `1` is EXACTLY what the broken path produces,
+# because an arithmetic abort inside `$(read_streak)` yields an empty string and
+# bash evaluates `$(( + 1 ))` as unary plus == 1 (measured). So deleting the
+# `case` sanitiser SURVIVED a fully green suite even with the counter asserted.
+# A corrupt value cannot expect anything BUT 1 (corrupt -> 0 -> 0+1), so the
+# second discriminator is STDERR: the broken path emits bash's own
+# `arithmetic syntax error` / `value too great for base`, the fixed path is
+# silent. That is the mechanism itself, not a proxy for it.
 CORRUPT_STREAKS = [
     ("1 2", 1),                      # internal space -> corrupt -> 0, so 0+1
     ("08", 9),                       # ALL DIGITS, but octal to bash -> must be 8
@@ -389,6 +393,10 @@ def test_a_CORRUPT_streak_cannot_make_the_guards_FALL_THROUGH(world, corrupt, ex
     assert "GREEN" not in r.stdout, (
         "streak %r produced a GREEN for a tree that was never fetched:\n%s"
         % (corrupt, r.stdout))
+    assert not re.search(r"arithmetic syntax error|value too great for base",
+                         r.stderr), (
+        "streak %r reached bash's arithmetic evaluator uncoerced — the sanitiser "
+        "did not run or did not cover this shape:\n%s" % (corrupt, r.stderr))
     got = (world["cache"] / "blind-streak").read_text().strip()
     assert got == str(expected), (
         "streak %r was read as %r, expected %r — the sanitiser did not coerce "
@@ -415,10 +423,72 @@ def test_repeated_CONTENTION_does_not_report_GREEN_forever(world):
         first = _run(world, stub, extra_env=env)
         second = _run(world, stub, extra_env=env)
     assert first.returncode == RC_GREEN, first.stdout
-    assert second.returncode in (RC_UNMEASURED, RC_BLIND), (
-        "a second consecutive contention still reported GREEN — the deadman can "
-        "be blind indefinitely behind a held lock:\n" + second.stdout)
+    # 🔴 EXACT, NOT `in (...)`. Claim 9 removed a loose `rc in (11, 12)` and this
+    # test reintroduced the same shape in the same commit: with it, a change
+    # making the SECOND contention fire the loud BLIND toast immediately —
+    # instead of laddering quietly through 11, which is the whole point of
+    # `SuccessExitStatus = 11` — was invisible.
+    assert second.returncode == RC_UNMEASURED, (
+        "expected the quiet ladder rung (11), got %d — contention must not jump "
+        "straight to the DND-defeating toast:\n%s"
+        % (second.returncode, second.stdout))
+    assert (world["cache"] / "contention-streak").read_text().strip() == "2"
     assert _calls(world) == [], "sanity: the gate never ran"
+
+
+def test_acquiring_the_lock_CLEARS_the_contention_counter(world):
+    """🔴 UNCOVERED until round 3: two mutants (delete the reset, or set it to 1)
+    both survived a fully green suite.
+
+    Without the reset the counter is cumulative over the process's whole life:
+    three overlaps MONTHS apart, each separated by dozens of clean measured runs,
+    reach the threshold and fire a BLIND toast about a deadman that has been
+    measuring `main` correctly the entire time. That is the permanently-red gate
+    this file's header argues against, arrived at by bookkeeping.
+    """
+    stub = _stub(world, 'echo "RESULT: PASS (exit=0)"; exit 0\n')
+    world["cache"].mkdir(parents=True, exist_ok=True)
+    (world["cache"] / "contention-streak").write_text("2")
+    r = _run(world, stub)
+    assert r.returncode == RC_GREEN, r.stdout + r.stderr
+    leftover = world["cache"] / "contention-streak"
+    assert not leftover.exists() or leftover.read_text().strip() in ("", "0"), (
+        "a run that ACQUIRED the lock left the contention counter standing at "
+        "%r — it accumulates across unrelated outages and eventually toasts"
+        % leftover.read_text())
+
+
+def test_help_prints_the_header_and_REFUSES_if_it_cannot_find_the_end(world):
+    """🔴 The computed range fixed truncation and introduced SILENCE-WITH-RC-0.
+
+    Reword the `set -uo pipefail` sentinel and `grep` matches nothing, `_hdr` is
+    empty, `$(( _hdr - 1 ))` is -1, and `sed -n "2,-1p"` errors to stderr while
+    --help prints ZERO lines and exits 0 — measured. The literal it replaced
+    merely truncated; this deleted the help and reported success, which is the
+    "a zero that means nothing" shape the file's own header condemns.
+
+    Also pins that --help exists at all: a mutant hardcoding `2,60p` — the exact
+    regression the computed range exists to prevent — survived a green suite.
+    """
+    stub = _stub(world, 'exit 0\n')
+    r = _run(world, stub, "--help")
+    assert r.returncode == RC_GREEN, r.stderr
+    assert len(r.stdout.splitlines()) > 80, (
+        "--help rendered %d lines; the header is longer than that, so the range "
+        "is truncating" % len(r.stdout.splitlines()))
+    for needed in ("OPTIONS", "--force", "--status", "BLIND", "COULD NOT MEASURE"):
+        assert needed in r.stdout, "--help no longer reaches %r" % needed
+    assert "set -uo pipefail" not in r.stdout, "the range leaked past the header"
+
+    broken = world["tmp"] / "broken.sh"
+    broken.write_text(SCRIPT.read_text().replace("set -uo pipefail",
+                                                 "set -o pipefail; set -u", 1))
+    b = subprocess.run(["bash", str(broken), "--help"], capture_output=True,
+                       text=True, timeout=60, env={**os.environ,
+                       "MAIN_GREEN_CACHE": str(world["tmp"] / "hc")})
+    assert b.returncode != RC_GREEN, (
+        "with the sentinel moved, --help printed %d lines and still exited 0"
+        % len(b.stdout.splitlines()))
 
 
 def test_status_works_while_a_run_holds_the_lock(world):
@@ -556,6 +626,22 @@ def test_the_shipped_blind_threshold_is_a_sane_default():
     m = re.search(r'BLIND_ESCALATE="\$\{MAIN_GREEN_BLIND_ESCALATE:-(\d+)\}"', src)
     assert m, "the blind-ladder default moved or lost its env override"
     assert 2 <= int(m.group(1)) <= 24, m.group(1)
+
+
+def test_the_shipped_contention_threshold_is_a_sane_default():
+    """The twin of the blind-threshold pin, and round 2 added the second ladder
+    without extending it: mutating the default to 99999 SURVIVED a green suite
+    while, in production, the contention ladder would never fire — the exact
+    "never fires, reads as clean forever" failure the other pin exists for."""
+    src = _code_only(SCRIPT.read_text())
+    m = re.search(r'CONTENTION_ESCALATE="\$\{MAIN_GREEN_CONTENTION_ESCALATE:-(\d+)\}"', src)
+    assert m, "the contention ladder default moved or lost its env override"
+    n = int(m.group(1))
+    assert 2 <= n <= 12, n
+    b = re.search(r'BLIND_ESCALATE="\$\{MAIN_GREEN_BLIND_ESCALATE:-(\d+)\}"', src)
+    assert b and n <= int(b.group(1)), (
+        "contention should escalate no later than blindness: %s vs %s"
+        % (n, b and b.group(1)))
 
 
 def test_the_three_outcomes_have_DISTINCT_exit_codes():

--- a/scripts/tests/test_main_green_check.py
+++ b/scripts/tests/test_main_green_check.py
@@ -349,9 +349,19 @@ def test_a_CORRUPT_streak_file_cannot_make_the_guards_FALL_THROUGH(world):
 # bash evaluates `$(( + 1 ))` as unary plus == 1 (measured). So deleting the
 # `case` sanitiser SURVIVED a fully green suite even with the counter asserted.
 # A corrupt value cannot expect anything BUT 1 (corrupt -> 0 -> 0+1), so the
-# second discriminator is STDERR: the broken path emits bash's own
-# `arithmetic syntax error` / `value too great for base`, the fixed path is
-# silent. That is the mechanism itself, not a proxy for it.
+# second discriminator is STDERR — but it is the SILENCE, not the wording.
+# 🔴 THE FIRST ATTEMPT MATCHED BASH'S MESSAGE TEXT, AND THAT IS A SPELLED GUARD.
+# `arithmetic syntax error` is bash 5.3's English phrasing: 5.2 says `syntax
+# error in expression` (no "arithmetic"), and the message is TRANSLATED —
+# `Arithmetischer Syntaxfehler`, `erreur de syntaxe arithmetique`. MEASURED: with
+# the sanitiser deleted, the suite went 1 failed / 39 passed under en_US and
+# **40 passed under LC_ALL=de_DE.UTF-8**, i.e. a nixpkgs bash bump or a
+# contributor's locale silently restores the exact hole this test exists to
+# close. It also matched only 1 of the 7 rows (`  5` emits a THIRD message,
+# `10#: invalid integer constant`).
+# The fixed path writes NOTHING to stderr for any corrupt shape — measured, 0
+# bytes on all of them — so asserting emptiness is language-independent,
+# version-independent, and strictly stronger. Assert the STATE, never a word.
 CORRUPT_STREAKS = [
     ("1 2", 1),                      # internal space -> corrupt -> 0, so 0+1
     ("08", 9),                       # ALL DIGITS, but octal to bash -> must be 8
@@ -393,10 +403,10 @@ def test_a_CORRUPT_streak_cannot_make_the_guards_FALL_THROUGH(world, corrupt, ex
     assert "GREEN" not in r.stdout, (
         "streak %r produced a GREEN for a tree that was never fetched:\n%s"
         % (corrupt, r.stdout))
-    assert not re.search(r"arithmetic syntax error|value too great for base",
-                         r.stderr), (
-        "streak %r reached bash's arithmetic evaluator uncoerced — the sanitiser "
-        "did not run or did not cover this shape:\n%s" % (corrupt, r.stderr))
+    assert r.stderr == "", (
+        "streak %r produced stderr output. The sanitised path is SILENT for every "
+        "corrupt shape, so anything here means the value reached bash's "
+        "arithmetic evaluator uncoerced:\n%s" % (corrupt, r.stderr))
     got = (world["cache"] / "blind-streak").read_text().strip()
     assert got == str(expected), (
         "streak %r was read as %r, expected %r — the sanitiser did not coerce "
@@ -432,7 +442,9 @@ def test_repeated_CONTENTION_does_not_report_GREEN_forever(world):
         "expected the quiet ladder rung (11), got %d — contention must not jump "
         "straight to the DND-defeating toast:\n%s"
         % (second.returncode, second.stdout))
-    assert (world["cache"] / "contention-streak").read_text().strip() == "2"
+    counter = world["cache"] / "contention-streak"
+    assert counter.exists(), "the contention counter was never written"
+    assert counter.read_text().strip() == "2"
     assert _calls(world) == [], "sanity: the gate never ran"
 
 
@@ -486,9 +498,9 @@ def test_help_prints_the_header_and_REFUSES_if_it_cannot_find_the_end(world):
     b = subprocess.run(["bash", str(broken), "--help"], capture_output=True,
                        text=True, timeout=60, env={**os.environ,
                        "MAIN_GREEN_CACHE": str(world["tmp"] / "hc")})
-    assert b.returncode != RC_GREEN, (
-        "with the sentinel moved, --help printed %d lines and still exited 0"
-        % len(b.stdout.splitlines()))
+    assert b.returncode == RC_USAGE, (
+        "with the sentinel moved, --help should REFUSE with rc %d; got %d and "
+        "%d lines of output" % (RC_USAGE, b.returncode, len(b.stdout.splitlines())))
 
 
 def test_status_works_while_a_run_holds_the_lock(world):

--- a/scripts/tests/test_main_green_check.py
+++ b/scripts/tests/test_main_green_check.py
@@ -255,6 +255,133 @@ def test_an_unreachable_remote_is_UNMEASURED_and_says_it_is_not_a_pass(world):
     assert _calls(world) == [], "nothing may be gated when the tree could not be fetched"
 
 
+def test_a_gate_that_FAILS_with_no_verdict_is_UNMEASURED_not_a_RED_accusation(world):
+    """🔴 RED at 3033a22f. A gate that exits NON-ZERO having printed no `RESULT:`
+    line is a BROKEN GATE, not a broken `main` — a `nix` that cannot start, an
+    OOM, a missing binary. The header and `tier_verdict`'s own comment both said
+    so; the code classified it `red`.
+
+    Why it matters more here than anywhere else: the red arm names the commit's
+    AUTHOR and fires a do-not-disturb-defeating toast saying "main is broken
+    RIGHT NOW", with an empty "Failing tests:" list. Measured at 3033a22f with a
+    stub that exits 1 silently: rc 10, `author: Innocent Author`.
+
+    A genuinely failing suite cannot reach here — it exits non-zero AND prints
+    `RESULT: FAIL`, which the arm above catches.
+    """
+    stub = _stub(world, 'exit 1\n')
+    r = _run(world, stub)
+    assert r.returncode == RC_UNMEASURED, r.stdout + r.stderr
+    assert "RED, REPRODUCED" not in r.stdout, (
+        "a broken gate must not be reported as a broken main:\n" + r.stdout)
+
+
+def test_a_DISAGREEING_tier_cannot_ERASE_a_RED_from_another_tier(world):
+    """🔴 RED at 3033a22f, and it made the verdict ORDER-DEPENDENT.
+
+    `noverdict` was guarded so it could only downgrade a green; `disagree` was
+    not, so it overwrote `red` with `unmeasured`. Measured at 3033a22f: pytests
+    RESULT: FAIL + nodetests status/content disagreement -> rc 11, a systemd
+    SUCCESS, no toast — a genuinely red `main` reported as nothing at all, which
+    is the exact outcome this whole script exists to prevent.
+    """
+    stub = _stub(world, textwrap.dedent('''
+        if [ "$2" = pytests ]; then echo "RESULT: FAIL (exit=1)"; exit 1; fi
+        echo "RESULT: PASS (exit=0)"; exit 1
+    '''))
+    r = _run(world, stub)
+    assert r.returncode == RC_RED, (
+        "a red tier was erased by a disagreeing one:\n" + r.stdout)
+
+
+def test_a_CACHED_gate_run_is_GREEN_not_unmeasured(world):
+    """🔴 RED at 3033a22f — and it is the MODAL case, not an edge one.
+
+    `nix build -L` streams a log only while a build RUNS. An already-realised
+    derivation is not rebuilt, so nix prints NOTHING and exits 0. Since
+    `CLAUDE.md` tells every merger to build these same two derivations on the
+    merged tree before merging, the tip this deadman checks is USUALLY already
+    realised — so the normal path returned `noverdict` -> rc 11, and six of them
+    ladder to a BLIND toast about a perfectly green `main`. `--force` was broken
+    by construction for the same reason.
+
+    A realised check derivation IS the verdict: these derivations RUN the suite,
+    so nix exiting 0 means it built, which means the tests passed. Empty output
+    with rc 0 is therefore GREEN. (Non-empty output with rc 0 and no `RESULT:`
+    line stays UNMEASURED — that is a truncated run, a different fact, pinned by
+    the test above this one.)
+    """
+    stub = _stub(world, 'exit 0\n')          # silent + rc 0 == the cached shape
+    r = _run(world, stub)
+    assert r.returncode == RC_GREEN, r.stdout + r.stderr
+    assert "GREEN" in r.stdout
+
+
+def test_a_CORRUPT_streak_file_cannot_make_the_guards_FALL_THROUGH(world):
+    """🔴 RED at 3033a22f, and the blast radius was much wider than the ladder.
+
+    `read_streak` cat'd an unvalidated file into `$(( ... + 1 ))`. A non-integer
+    makes that a bash ARITHMETIC SYNTAX ERROR, which aborts `unmeasured_exit`
+    WITHOUT exiting — and every one of its call sites is inside an `if ... fi`,
+    so the script CONTINUES past a guard that just fired. Measured at 3033a22f
+    with a streak file of `1 2`: a failed clone was announced and then ignored,
+    the run gated an EMPTY sha, and it exited 10 reporting
+    `RED, REPRODUCED — origin/main  failed BOTH attempts` with a blank author.
+
+    So this is not a ladder nit: a corrupt counter turned a total failure to
+    even fetch into a do-not-disturb-defeating accusation about `main`.
+    """
+    world["cache"].mkdir(parents=True, exist_ok=True)
+    (world["cache"] / "blind-streak").write_text("1 2")
+    stub = _stub(world, 'echo "RESULT: PASS (exit=0)"; exit 0\n')
+    r = _run(world, stub, extra_env={"MAIN_GREEN_REMOTE": str(world["tmp"] / "gone")})
+    assert r.returncode == RC_UNMEASURED, (
+        "a corrupt streak file let the run continue past a failed clone:\n"
+        + r.stdout)
+    assert "RED, REPRODUCED" not in r.stdout
+
+
+def test_a_BROKEN_flock_is_not_reported_as_GREEN(world):
+    """🔴 RED at 3033a22f. `flock -n` returning non-zero for ANY reason — ENOLCK
+    on a filesystem without working locks, a missing binary, EBADF — was
+    indistinguishable from contention, and the answer was `exit 0` GREEN.
+
+    That is silent, permanent, a systemd success, and it never touches the blind
+    ladder — precisely the "goes blind in silence" shape the ladder exists to
+    close, reached by a different door. The fix is a POSITIVE CONTROL: if we
+    cannot take a lock NOBODY holds, we have measured nothing.
+    """
+    fake_bin = world["tmp"] / "fakebin"
+    fake_bin.mkdir(parents=True, exist_ok=True)
+    write_exec(fake_bin / "flock", "exit 1\n")      # always fails, never contention
+    stub = _stub(world, 'echo "RESULT: FAIL (exit=1)"; exit 1\n')
+    r = _run(world, stub, extra_env={"PATH": f"{fake_bin}:{os.environ['PATH']}"})
+    assert r.returncode != RC_GREEN, (
+        "a broken flock reported GREEN and never ran the gate:\n" + r.stdout)
+    assert _calls(world) == [], "sanity: the gate must not have run"
+
+
+def test_single_flight_is_BEHAVIOURAL_not_just_the_word_flock(world):
+    """🔴 The guard this replaces asserted only `"flock" in src`, and a mutant
+    that kept the word while deleting the branch (`if false`) SURVIVED a fully
+    green suite. A guard satisfiable by spelling is not a guard.
+
+    This holds the real lock and asserts the observable consequence: the gate is
+    not invoked.
+    """
+    import fcntl
+    world["cache"].mkdir(parents=True, exist_ok=True)
+    lock = world["cache"] / "lock"
+    stub = _stub(world, 'echo "RESULT: PASS (exit=0)"; exit 0\n')
+    with open(lock, "w") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        r = _run(world, stub)
+    assert r.returncode == RC_GREEN, r.stdout + r.stderr
+    assert _calls(world) == [], (
+        "the gate ran while another process held the lock — single-flight is "
+        "not in force:\n" + r.stdout)
+
+
 def test_repeated_could_not_measure_ESCALATES_to_BLIND(world):
     """🔴 The hole this closes: making rc 11 a systemd success stops a network
     blip from toasting, and on its own lets the deadman go blind FOREVER in
@@ -325,12 +452,17 @@ def test_the_production_path_builds_the_two_sandbox_derivations():
     derivations produced false failures a sequential pair did not.
     """
     src = _code_only(SCRIPT.read_text())
-    assert 'nix build "$CLONE#checks.x86_64-linux.$tier"' in src, (
+    assert 'build "$CLONE#checks.x86_64-linux.$tier"' in src, (
         "the production gate invocation moved; this seam no longer mirrors it")
+    assert '--extra-experimental-features "nix-command flakes"' in src, (
+        "the flake features flag left the COMMAND LINE. It must not move back "
+        "into the unit's Environment=, which systemd whitespace-splits — "
+        "measured to set NIX_CONFIG to the bare word `experimental-features` "
+        "and make every nix invocation hard-error.")
     tiers = re.search(r'for tier in ([a-z ]+); do', src)
     assert tiers and tiers.group(1).split() == ["pytests", "nodetests"], (
         "the tier list moved: %r" % (tiers.group(1) if tiers else None))
-    assert src.count('nix build "$CLONE') == 1, (
+    assert src.count('build "$CLONE') == 1, (
         "more than one nix build invocation — the one-at-a-time property is "
         "what stops the documented store-contention false failures")
 
@@ -361,6 +493,13 @@ def test_the_script_never_touches_the_operators_checkout():
             "scripts/main-green-check.sh runs `git -C $SRC_REPO %s` — the "
             "operator's checkout is READ-ONLY to this script, and the only "
             "permitted read is `remote get-url`." % verb)
+    assert not re.search(r'cd\s+"?\$(SRC_REPO|SCRIPT_DIR)', src), (
+        "the script `cd`s into the operator's checkout — a subsequent bare git "
+        "command then acts on THEIR tree, which the `git -C $SRC_REPO` scan "
+        "above cannot see.")
+    assert not re.search(r'git -C "\$SCRIPT_DIR"', src), (
+        "$SCRIPT_DIR is inside the operator's checkout too — same hazard, "
+        "different spelling.")
     assert "worktree add" not in src, (
         "`git worktree add` writes the COMMON git dir (refs, config, registry), "
         "so it is a repo-GLOBAL mutation of a checkout other sessions share. "
@@ -383,7 +522,9 @@ def test_it_single_flights():
 
 
 def test_the_script_is_executable_and_parses():
-    assert os.access(SCRIPT, os.X_OK), "must be chmod +x or the systemd unit cannot run it"
+    # NOT for systemd's sake — ExecStart is `${pkgs.bash}/bin/bash %h/...`, so
+    # the exec bit is irrelevant there. It is for a human running it directly.
+    assert os.access(SCRIPT, os.X_OK), "chmod +x so it can be run by hand"
     r = subprocess.run(["bash", "-n", str(SCRIPT)], capture_output=True, text=True)
     assert r.returncode == 0, r.stderr
 

--- a/scripts/tests/test_main_green_check.py
+++ b/scripts/tests/test_main_green_check.py
@@ -341,6 +341,130 @@ def test_a_CORRUPT_streak_file_cannot_make_the_guards_FALL_THROUGH(world):
     assert "RED, REPRODUCED" not in r.stdout
 
 
+# (raw streak file content, the integer the sanitiser MUST read out of it)
+# 🔴 EVERY EXPECTED VALUE IS DISTINCT, AND NONE IS 0 EXCEPT WHERE 0 IS THE POINT.
+# A fixture whose expectation collides with the fall-through value cannot see the
+# mutant: an earlier version of this test asserted only `rc in (11, 12)`, and BOTH
+# the fixed and the broken script land on 11 (the broken one by aborting the
+# arithmetic and failing the `-ge` test), so removing the base-ten coercion
+# SURVIVED a fully green suite. The counter the run records is the discriminator.
+CORRUPT_STREAKS = [
+    ("1 2", 1),                      # internal space -> corrupt -> 0, so 0+1
+    ("08", 9),                       # ALL DIGITS, but octal to bash -> must be 8
+    ("09", 10),                      # the other octal-invalid digit
+    ("007", 8),                      # leading zeros, still base ten -> 7
+    ("  5", 1),                      # leading space -> corrupt -> 0
+    ("5\n\n", 6),                   # trailing newlines are not corruption
+    ("9" * 22, 1),                   # overflows the arithmetic -> corrupt -> 0
+]
+
+
+@pytest.mark.parametrize("corrupt,expected", CORRUPT_STREAKS)
+def test_a_CORRUPT_streak_cannot_make_the_guards_FALL_THROUGH(world, corrupt, expected):
+    """🔴 The round-1 sanitiser was NARROWER THAN THE HAZARD it described.
+
+    `case $s in ''|*[!0-9]*) s=0` rejects non-digits — but `08` and `09` ARE all
+    digits, and bash reads a leading zero as OCTAL: `08: value too great for
+    base`. That is the same arithmetic abort, so `unmeasured_exit` again died
+    without exiting and the run continued past a guard that had just fired.
+
+    🔴 REPRODUCED at 31864127, and it is the worst outcome this file can produce:
+    with the clone AND the fetch both failed and the sha EMPTY, it printed
+    `✅ GREEN — origin/main  passed both sandbox tiers` and exited 0. A deadman
+    reporting a green it never measured is strictly worse than no deadman.
+
+    The escalation threshold is pinned high so the RUN's exit code stays 11 for
+    every row; what is asserted is the COUNTER, which is the only thing that
+    separates "sanitised correctly" from "the arithmetic blew up and the guard
+    fell through".
+    """
+    world["cache"].mkdir(parents=True, exist_ok=True)
+    (world["cache"] / "blind-streak").write_text(corrupt)
+    stub = _stub(world, 'echo "RESULT: PASS (exit=0)"; exit 0\n')
+    r = _run(world, stub, extra_env={"MAIN_GREEN_REMOTE": str(world["tmp"] / "gone"),
+                                     "MAIN_GREEN_BLIND_ESCALATE": "99"})
+    assert r.returncode == RC_UNMEASURED, (
+        "streak %r let the run continue past a failed clone:\n%s"
+        % (corrupt, r.stdout))
+    assert "GREEN" not in r.stdout, (
+        "streak %r produced a GREEN for a tree that was never fetched:\n%s"
+        % (corrupt, r.stdout))
+    got = (world["cache"] / "blind-streak").read_text().strip()
+    assert got == str(expected), (
+        "streak %r was read as %r, expected %r — the sanitiser did not coerce "
+        "it to base ten, so the arithmetic aborted and the guard fell through"
+        % (corrupt, got, str(expected)))
+
+
+
+def test_repeated_CONTENTION_does_not_report_GREEN_forever(world):
+    """🔴 Round 1 closed the BROKEN-flock door and left the CONTENTION one open,
+    while its own comment condemned the whole class.
+
+    A held lock — you started a run by hand in a tmux pane and it is still going,
+    or wedged — makes every 4h fire print "another run holds the lock" and exit
+    0: silent, a systemd success, and touching no ladder. The deadman is blind
+    indefinitely and nothing says so. Contention must therefore ladder too.
+    """
+    import fcntl
+    world["cache"].mkdir(parents=True, exist_ok=True)
+    stub = _stub(world, 'echo "RESULT: PASS (exit=0)"; exit 0\n')
+    env = {"MAIN_GREEN_CONTENTION_ESCALATE": "2"}
+    with open(world["cache"] / "lock", "w") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        first = _run(world, stub, extra_env=env)
+        second = _run(world, stub, extra_env=env)
+    assert first.returncode == RC_GREEN, first.stdout
+    assert second.returncode in (RC_UNMEASURED, RC_BLIND), (
+        "a second consecutive contention still reported GREEN — the deadman can "
+        "be blind indefinitely behind a held lock:\n" + second.stdout)
+    assert _calls(world) == [], "sanity: the gate never ran"
+
+
+def test_status_works_while_a_run_holds_the_lock(world):
+    """The OPTIONS block claims `--status` does not block on a run in flight, and
+    a claim in the header is a claim like any other. At round 2 it was FALSE —
+    the lock was taken before the STATUS_ONLY branch — so the moment you most
+    want the last verdict (during a 20-minute run) was the one moment you could
+    not read it. Fixed by ordering, pinned here."""
+    import fcntl
+    world["cache"].mkdir(parents=True, exist_ok=True)
+    (world["cache"] / "state").write_text("sha deadbeef\nverdict green\n")
+    stub = _stub(world, 'echo "RESULT: PASS (exit=0)"; exit 0\n')
+    with open(world["cache"] / "lock", "w") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        r = _run(world, stub, "--status")
+    assert r.returncode == RC_GREEN, r.stdout + r.stderr
+    assert "deadbeef" in r.stdout, r.stdout
+    assert _calls(world) == []
+
+
+def test_the_unit_does_NOT_carry_NIX_CONFIG_in_its_Environment(world):
+    """🔴 The round-1 guard for this read the WRONG FILE.
+
+    Its message said "it must not move back into the unit's `Environment=`" and
+    its body asserted a string in `main-green-check.sh` — it never opened
+    `nix/home.nix`. Both facts could hold at once: the flag on the command line
+    AND `NIX_CONFIG=experimental-features = nix-command flakes` re-added to the
+    unit. The suite would stay fully green while systemd whitespace-split it,
+    nix hard-errored on every invocation, and the deadman laddered to BLIND.
+
+    A docstring naming a RELATIONSHIP whose body inspects ONE SIDE reads as
+    coverage while providing none, which stops anyone looking.
+    """
+    home_nix = (ROOT / "nix" / "home.nix").read_text()
+    block = re.search(r"systemd\.user\.services\.main-green-check = \{.*?\n  \};",
+                      home_nix, re.S)
+    assert block, "the main-green-check unit is gone from nix/home.nix"
+    code = _code_only(block.group(0))
+    assert "NIX_CONFIG" not in code, (
+        "NIX_CONFIG is back in the unit. systemd WHITESPACE-SPLITS Environment=, "
+        "so `experimental-features = nix-command flakes` becomes the bare word "
+        "`experimental-features` and nix hard-errors on every invocation — "
+        "measured with systemd-analyze verify. The flag belongs on the command "
+        "line in main-green-check.sh.")
+
+
 def test_a_BROKEN_flock_is_not_reported_as_GREEN(world):
     """🔴 RED at 3033a22f. `flock -n` returning non-zero for ANY reason — ENOLCK
     on a filesystem without working locks, a missing binary, EBADF — was
@@ -362,7 +486,7 @@ def test_a_BROKEN_flock_is_not_reported_as_GREEN(world):
 
 
 def test_single_flight_is_BEHAVIOURAL_not_just_the_word_flock(world):
-    """🔴 The guard this replaces asserted only `"flock" in src`, and a mutant
+    """🔴 The guard this REPLACED asserted only `"flock" in src`, and a mutant
     that kept the word while deleting the branch (`if false`) SURVIVED a fully
     green suite. A guard satisfiable by spelling is not a guard.
 
@@ -454,6 +578,13 @@ def test_the_production_path_builds_the_two_sandbox_derivations():
     src = _code_only(SCRIPT.read_text())
     assert 'build "$CLONE#checks.x86_64-linux.$tier"' in src, (
         "the production gate invocation moved; this seam no longer mirrors it")
+    for flag in ("-L", "--no-link", "--no-warn-dirty"):
+        assert flag in src, (
+            "%s left the production nix invocation. `--no-link` keeps $CLONE "
+            "clean (a `result` symlink would dirty it) and `--no-warn-dirty` "
+            "keeps a cached build's output EMPTY — a dirty tree emits a warning, "
+            "which makes the cached case non-empty and therefore UNMEASURED, "
+            "laddering to BLIND about a green main." % flag)
     assert '--extra-experimental-features "nix-command flakes"' in src, (
         "the flake features flag left the COMMAND LINE. It must not move back "
         "into the unit's Environment=, which systemd whitespace-splits — "
@@ -493,13 +624,25 @@ def test_the_script_never_touches_the_operators_checkout():
             "scripts/main-green-check.sh runs `git -C $SRC_REPO %s` — the "
             "operator's checkout is READ-ONLY to this script, and the only "
             "permitted read is `remote get-url`." % verb)
-    assert not re.search(r'cd\s+"?\$(SRC_REPO|SCRIPT_DIR)', src), (
-        "the script `cd`s into the operator's checkout — a subsequent bare git "
-        "command then acts on THEIR tree, which the `git -C $SRC_REPO` scan "
-        "above cannot see.")
-    assert not re.search(r'git -C "\$SCRIPT_DIR"', src), (
-        "$SCRIPT_DIR is inside the operator's checkout too — same hazard, "
-        "different spelling.")
+    # 🔴 AN ENUMERATED ALLOWLIST, NOT A PATTERN — a NEW use is a failure by
+    # DEFAULT. Round 1 answered "the guard is walkable" by adding the two
+    # spellings it had been walked with (`cd "$SRC_REPO"`, `git -C
+    # "$SCRIPT_DIR"`), which left `cd "${SRC_REPO}"`, `cd -- "$SRC_REPO"`,
+    # `pushd "$SRC_REPO"` and unquoted `git -C $SCRIPT_DIR` all still open.
+    # Chasing spellings cannot terminate; enumerating the legitimate uses can.
+    ALLOWED_USES = {
+        'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"',
+        'SRC_REPO="$(dirname "$SCRIPT_DIR")"',
+        'REMOTE_URL="${MAIN_GREEN_REMOTE:-$(git -C "$SRC_REPO" remote get-url origin 2>/dev/null || true)}"',
+        'say "COULD NOT MEASURE — no \'origin\' remote on $SRC_REPO, so there is no"',
+    }
+    uses = [ln.strip() for ln in src.splitlines()
+            if "SRC_REPO" in ln or "SCRIPT_DIR" in ln]
+    unlisted = [u for u in uses if u not in ALLOWED_USES]
+    assert not unlisted, (
+        "new use(s) of the operator's checkout path — every one is a chance to "
+        "write to a tree this script must only observe. Add it here ONLY after "
+        "confirming it is read-only:\n  " + "\n  ".join(unlisted))
     assert "worktree add" not in src, (
         "`git worktree add` writes the COMMON git dir (refs, config, registry), "
         "so it is a repo-GLOBAL mutation of a checkout other sessions share. "
@@ -512,13 +655,6 @@ def test_it_derives_the_mainline_instead_of_hardcoding_main():
     src = SCRIPT.read_text()
     assert "symbolic-ref" in src and "refs/remotes/origin/HEAD" in src
 
-
-def test_it_single_flights():
-    """A run can outlast the timer interval; two concurrent runs would fight over
-    the clone AND contend in the nix store, which is a documented source of false
-    failures in this repo."""
-    src = SCRIPT.read_text()
-    assert "flock" in src
 
 
 def test_the_script_is_executable_and_parses():

--- a/scripts/tests/test_main_green_check.py
+++ b/scripts/tests/test_main_green_check.py
@@ -1,0 +1,383 @@
+"""`scripts/main-green-check.sh` — the deadman that reports a red `main`.
+
+WHY THIS FILE EXISTS. Branch protection on this repo is OFF by a live operator
+decision, and on 2026-09-03 two direct-to-main commits (`a720d30d`, `a451abc0`)
+each red-ed `main` for hours. BOTH times the only detector was a human running
+the gate by hand, incidentally. The script under test is that missing detector.
+
+🔴 WHAT THESE TESTS ARE, HONESTLY LABELLED. None of them is regression coverage
+for a bug in the script — the script is new, so nothing here was ever RED at a
+base that contained it. They are:
+
+  * BEHAVIOURAL CONTRACTS on each arm (green / red / flake / unmeasured /
+    memoized), each of which would be green-and-meaningless without...
+  * ...the two CONTROLS below, which is why they come first in the file. A
+    deadman's whole value is that a zero means something, and a harness that
+    cannot go red produces a reassuring zero for a broken world.
+  * one STATIC guard (`test_the_script_never_touches_the_operators_checkout`)
+    pinning a RELATIONSHIP the behavioural tests structurally cannot see: they
+    run against a throwaway remote, so none of them would notice this script
+    growing a `git -C $DEVRC checkout`.
+
+🔴 THE SEAM THESE TESTS DRIVE IS NOT THE PRODUCTION PATH, and that is the danger.
+Every test below sets MAIN_GREEN_GATE_CMD, so none of them ever invokes `nix
+build`. `test_the_production_path_builds_the_two_sandbox_derivations` pins the
+real invocation textually so the seam cannot drift away from what production
+does while every behavioural test stays green.
+"""
+import os
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "main-green-check.sh"
+
+RC_GREEN, RC_RED, RC_UNMEASURED, RC_BLIND, RC_USAGE = 0, 10, 11, 12, 2
+
+
+def _code_only(src):
+    """Executable lines only — comments stripped.
+
+    A static guard that reads prose is walkable by rewording AND breakable by
+    documenting the very hazard it forbids. Both happened here on the first
+    draft, which is why this helper exists rather than a whole-file grep.
+    """
+    out = []
+    for line in src.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def _git(*args, cwd):
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True,
+                          check=True, timeout=60)
+
+
+@pytest.fixture
+def world(tmp_path):
+    """A throwaway origin + a place for the script's private cache.
+
+    Deliberately NOT this repo: these tests must never be able to reach the
+    operator's checkout, and building the fixture out of a real remote would
+    make that reach possible by accident.
+    """
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git("init", "--quiet", "--initial-branch=main", ".", cwd=origin)
+    _git("config", "user.email", "t@example.invalid", cwd=origin)
+    _git("config", "user.name", "T", cwd=origin)
+    (origin / "file.txt").write_text("one\n")
+    _git("add", "file.txt", cwd=origin)
+    _git("commit", "--quiet", "-m", "first commit", cwd=origin)
+
+    cache = tmp_path / "cache"
+    calls = tmp_path / "calls"          # the gate stub appends one line per call
+    return {"origin": origin, "cache": cache, "calls": calls, "tmp": tmp_path}
+
+
+def _stub(world, script_body):
+    """Write a gate stub. It is handed (checkout, tier) exactly as production is."""
+    p = world["tmp"] / "gate-stub.sh"
+    p.write_text("#!/usr/bin/env bash\n"
+                 'echo "$2" >> "$CALLS"\n' + script_body)
+    p.chmod(0o755)
+    return p
+
+
+def _run(world, stub, *args, extra_env=None):
+    env = dict(os.environ)
+    env.update({
+        "MAIN_GREEN_CACHE": str(world["cache"]),
+        "MAIN_GREEN_REMOTE": str(world["origin"]),
+        "MAIN_GREEN_GATE_CMD": str(stub),
+        "CALLS": str(world["calls"]),
+    })
+    env.update(extra_env or {})
+    return subprocess.run(["bash", str(SCRIPT), *args], capture_output=True,
+                          text=True, env=env, timeout=300)
+
+
+def _calls(world):
+    if not world["calls"].exists():
+        return []
+    return world["calls"].read_text().split()
+
+
+def _advance_main(world, msg="second commit"):
+    (world["origin"] / "file.txt").write_text(msg + "\n")
+    _git("add", "file.txt", cwd=world["origin"])
+    _git("commit", "--quiet", "-m", msg, cwd=world["origin"])
+
+
+# ── the two controls ─────────────────────────────────────────────────────────
+
+def test_NEGATIVE_CONTROL_the_harness_can_go_red(world):
+    """🔴 Feed it a gate that MUST fail. If this reports success, every other
+    test in this file is measuring nothing and the deadman is decorative."""
+    stub = _stub(world, 'echo "RESULT: FAIL (exit=1)"; exit 1\n')
+    r = _run(world, stub)
+    assert r.returncode == RC_RED, r.stdout + r.stderr
+    assert "RED, REPRODUCED" in r.stdout
+
+
+def test_POSITIVE_CONTROL_the_harness_can_observe_a_pass(world):
+    """The mirror: a gate that MUST pass has to reach a green verdict, or the
+    red above would be indistinguishable from a script that always fails."""
+    stub = _stub(world, 'echo "RESULT: PASS (exit=0)"; exit 0\n')
+    r = _run(world, stub)
+    assert r.returncode == RC_GREEN, r.stdout + r.stderr
+    assert "GREEN" in r.stdout
+    assert _calls(world) == ["pytests", "nodetests"], "both tiers must run"
+
+
+# ── the arms ─────────────────────────────────────────────────────────────────
+
+def test_a_red_is_retried_EXACTLY_once_and_a_clearing_red_is_a_FLAKE_not_a_pass(world):
+    """A red that clears on retry is recorded as `flake`, never as `green`.
+
+    The distinction is the point: a flake silently relabelled a pass is how a
+    real break gets absorbed into the noise. It must also still exit 0, because
+    toasting on it would make this the permanently-red gate RULES.md forbids.
+    """
+    stub = _stub(world, textwrap.dedent('''
+        n=$(cat "$CALLS" | wc -l)
+        if [ "$n" -le 2 ]; then echo "RESULT: FAIL (exit=1)"; exit 1; fi
+        echo "RESULT: PASS (exit=0)"; exit 0
+    '''))
+    r = _run(world, stub)
+    assert r.returncode == RC_GREEN, r.stdout + r.stderr
+    assert "FLAKE ABSORBED" in r.stdout
+    assert "not hidden" in r.stdout.lower()
+    state = (world["cache"] / "state").read_text()
+    assert "verdict flake" in state, state
+
+
+def test_the_retry_does_NOT_loop_until_green(world):
+    """🔴 The retry runs ONCE. A deadman that retried until green would report a
+    permanently-broken main as clean, which inverts its entire purpose.
+
+    Measured mechanically: with a gate that fails forever, the stub must be
+    invoked exactly 4 times (2 tiers x 2 attempts) and no more.
+    """
+    stub = _stub(world, 'echo "RESULT: FAIL (exit=1)"; exit 1\n')
+    r = _run(world, stub)
+    assert r.returncode == RC_RED
+    assert len(_calls(world)) == 4, _calls(world)
+
+
+def test_a_green_verdict_is_MEMOIZED_on_the_sha_and_reruns_nothing(world):
+    stub = _stub(world, 'echo "RESULT: PASS (exit=0)"; exit 0\n')
+    assert _run(world, stub).returncode == RC_GREEN
+    first = len(_calls(world))
+    r = _run(world, stub)
+    assert r.returncode == RC_GREEN
+    assert "already verified" in r.stdout
+    assert len(_calls(world)) == first, "a memoized run must invoke the gate ZERO more times"
+
+
+def test_the_memo_is_INVALIDATED_when_main_moves(world):
+    """The memo is keyed on the sha, so a new commit must be re-checked — this is
+    the whole mechanism that makes a direct-to-main push get looked at."""
+    stub = _stub(world, 'echo "RESULT: PASS (exit=0)"; exit 0\n')
+    _run(world, stub)
+    before = len(_calls(world))
+    _advance_main(world)
+    r = _run(world, stub)
+    assert r.returncode == RC_GREEN
+    assert len(_calls(world)) == before + 2, "a moved main must re-run both tiers"
+
+
+def test_force_overrides_the_memo(world):
+    stub = _stub(world, 'echo "RESULT: PASS (exit=0)"; exit 0\n')
+    _run(world, stub)
+    before = len(_calls(world))
+    r = _run(world, stub, "--force")
+    assert r.returncode == RC_GREEN
+    assert len(_calls(world)) == before + 2
+
+
+def test_a_RED_main_that_has_not_moved_still_reports_RED(world):
+    """🔴 The memo must not silence an unfixed break. A red that is remembered is
+    still red — reporting `already verified, nothing to do` here would mean the
+    deadman goes quiet precisely while main stays broken."""
+    stub = _stub(world, 'echo "RESULT: FAIL (exit=1)"; exit 1\n')
+    assert _run(world, stub).returncode == RC_RED
+    before = len(_calls(world))
+    r = _run(world, stub)
+    assert r.returncode == RC_RED, r.stdout
+    assert "has not moved" in r.stdout
+    assert len(_calls(world)) == before, "no need to re-run to know it is still red"
+
+
+# ── could-not-measure is its own answer ──────────────────────────────────────
+
+def test_a_gate_that_exits_0_with_NO_verdict_is_UNMEASURED_not_a_pass(world):
+    """A truncated or silently-killed run prints no `RESULT:` line. Reading that
+    as green is the exact failure this repo has hit before (four agents reported
+    `exit 0` over content saying `RESULT: FAIL`)."""
+    stub = _stub(world, 'echo "some output but no verdict line"; exit 0\n')
+    r = _run(world, stub)
+    assert r.returncode == RC_UNMEASURED, r.stdout + r.stderr
+    assert "COULD NOT MEASURE" in r.stdout
+    assert "not" in r.stdout.lower() and "green" in r.stdout.lower()
+
+
+def test_status_and_content_DISAGREEING_is_UNMEASURED_not_resolved_in_favour_of_the_pass(world):
+    stub = _stub(world, 'echo "RESULT: PASS (exit=0)"; exit 1\n')
+    r = _run(world, stub)
+    assert r.returncode == RC_UNMEASURED, r.stdout + r.stderr
+    assert "DISAGREE" in r.stdout
+
+
+def test_an_unreachable_remote_is_UNMEASURED_and_says_it_is_not_a_pass(world):
+    stub = _stub(world, 'echo "RESULT: PASS (exit=0)"; exit 0\n')
+    r = _run(world, stub, extra_env={"MAIN_GREEN_REMOTE": str(world["tmp"] / "nope")})
+    assert r.returncode == RC_UNMEASURED, r.stdout + r.stderr
+    assert _calls(world) == [], "nothing may be gated when the tree could not be fetched"
+
+
+def test_repeated_could_not_measure_ESCALATES_to_BLIND(world):
+    """🔴 The hole this closes: making rc 11 a systemd success stops a network
+    blip from toasting, and on its own lets the deadman go blind FOREVER in
+    silence — the same shape as the bug it exists to catch.
+
+    Threshold lowered to 2 so the test is fast; the DEFAULT is pinned separately
+    below, because a test that only ever exercises an overridden value would not
+    notice the shipped default becoming 0 or 9999.
+    """
+    stub = _stub(world, 'echo "RESULT: PASS (exit=0)"; exit 0\n')
+    env = {"MAIN_GREEN_REMOTE": str(world["tmp"] / "gone"),
+           "MAIN_GREEN_BLIND_ESCALATE": "2"}
+    first = _run(world, stub, extra_env=env)
+    assert first.returncode == RC_UNMEASURED, first.stdout
+    second = _run(world, stub, extra_env=env)
+    assert second.returncode == RC_BLIND, second.stdout
+    assert "BLIND" in second.stdout
+    assert "meant NOTHING" in second.stdout
+
+
+def test_a_measured_run_RESETS_the_blind_streak(world):
+    """One good look clears the ladder — otherwise a single bad week would leave
+    it permanently escalated, which is the red-gate-nobody-reads failure."""
+    stub = _stub(world, 'echo "RESULT: PASS (exit=0)"; exit 0\n')
+    env = {"MAIN_GREEN_REMOTE": str(world["tmp"] / "gone"),
+           "MAIN_GREEN_BLIND_ESCALATE": "2"}
+    assert _run(world, stub, extra_env=env).returncode == RC_UNMEASURED
+    assert (world["cache"] / "blind-streak").read_text().strip() == "1"
+    assert _run(world, stub).returncode == RC_GREEN          # a real measurement
+    assert (world["cache"] / "blind-streak").read_text().strip() == "0"
+
+
+def test_an_unmeasured_run_does_NOT_clobber_the_last_real_verdict(world):
+    """'I could not look today' and 'main was red when I last looked' are
+    different facts, and the second must survive the first — which is why the
+    streak lives in its own file rather than in the state record."""
+    red = _stub(world, 'echo "RESULT: FAIL (exit=1)"; exit 1\n')
+    assert _run(world, red).returncode == RC_RED
+    _run(world, red, extra_env={"MAIN_GREEN_REMOTE": str(world["tmp"] / "gone")})
+    assert "verdict red" in (world["cache"] / "state").read_text()
+
+
+def test_the_shipped_blind_threshold_is_a_sane_default():
+    """Pinned because every behavioural test above OVERRIDES it. A default of 0
+    would escalate on the first blip; a huge one would never escalate at all,
+    which is the exact 'never fires, reads as clean forever' failure."""
+    src = _code_only(SCRIPT.read_text())
+    m = re.search(r'BLIND_ESCALATE="\$\{MAIN_GREEN_BLIND_ESCALATE:-(\d+)\}"', src)
+    assert m, "the blind-ladder default moved or lost its env override"
+    assert 2 <= int(m.group(1)) <= 24, m.group(1)
+
+
+def test_the_three_outcomes_have_DISTINCT_exit_codes():
+    """green / red / unmeasured must never collapse — a deadman whose 'could not
+    look' is spelled the same as 'clean' is worse than no deadman."""
+    assert len({RC_GREEN, RC_RED, RC_UNMEASURED, RC_BLIND, RC_USAGE}) == 5
+
+
+# ── the seam must not drift away from production ─────────────────────────────
+
+def test_the_production_path_builds_the_two_sandbox_derivations():
+    """🔴 Every behavioural test above sets MAIN_GREEN_GATE_CMD, so NONE of them
+    executes the real command. Without this, the seam could be rewired to
+    something that does not exist and the suite would stay fully green.
+
+    Pinned textually, and deliberately including `-L` and the ONE-AT-A-TIME
+    shape: devrc/CLAUDE.md records that a COMBINED `nix build` of both
+    derivations produced false failures a sequential pair did not.
+    """
+    src = _code_only(SCRIPT.read_text())
+    assert 'nix build "$CLONE#checks.x86_64-linux.$tier"' in src, (
+        "the production gate invocation moved; this seam no longer mirrors it")
+    tiers = re.search(r'for tier in ([a-z ]+); do', src)
+    assert tiers and tiers.group(1).split() == ["pytests", "nodetests"], (
+        "the tier list moved: %r" % (tiers.group(1) if tiers else None))
+    assert src.count('nix build "$CLONE') == 1, (
+        "more than one nix build invocation — the one-at-a-time property is "
+        "what stops the documented store-contention false failures")
+
+
+def test_the_script_never_touches_the_operators_checkout():
+    """🔴 A STATIC guard pinning a RELATIONSHIP no behavioural test can see.
+
+    Every test in this file points the script at a throwaway remote, so a
+    `git -C "$SRC_REPO" checkout` added tomorrow would leave all of them green
+    while the deadman started mutating the very checkout it is supposed to only
+    observe. `git worktree add` counts too: it writes the COMMON git dir, so it
+    is repo-global even when it looks local.
+
+    The one allowed read against SRC_REPO is `remote get-url`, enumerated here
+    rather than pattern-matched, so a new verb is a failure by default.
+
+    🔴 SCANS CODE, NOT PROSE. The first version of this guard grepped the whole
+    file for `worktree add` and went red on the COMMENT explaining why
+    `worktree add` is forbidden — a guard walkable by wording rather than one
+    pinning a state. Comment lines are stripped first, so the guard is about
+    what the script DOES.
+    """
+    src = _code_only(SCRIPT.read_text())
+    src_repo_calls = re.findall(r'git -C "\$SRC_REPO" ([a-z-]+(?: [a-z-]+)?)', src)
+    assert src_repo_calls, "expected at least the one read; did the variable get renamed?"
+    for verb in src_repo_calls:
+        assert verb == "remote get-url", (
+            "scripts/main-green-check.sh runs `git -C $SRC_REPO %s` — the "
+            "operator's checkout is READ-ONLY to this script, and the only "
+            "permitted read is `remote get-url`." % verb)
+    assert "worktree add" not in src, (
+        "`git worktree add` writes the COMMON git dir (refs, config, registry), "
+        "so it is a repo-GLOBAL mutation of a checkout other sessions share. "
+        "This script has its own clone precisely to avoid that.")
+
+
+def test_it_derives_the_mainline_instead_of_hardcoding_main():
+    """A hardcoded `main` would silently check a branch that does not exist in a
+    `trunk` repo and report a reassuring nothing."""
+    src = SCRIPT.read_text()
+    assert "symbolic-ref" in src and "refs/remotes/origin/HEAD" in src
+
+
+def test_it_single_flights():
+    """A run can outlast the timer interval; two concurrent runs would fight over
+    the clone AND contend in the nix store, which is a documented source of false
+    failures in this repo."""
+    src = SCRIPT.read_text()
+    assert "flock" in src
+
+
+def test_the_script_is_executable_and_parses():
+    assert os.access(SCRIPT, os.X_OK), "must be chmod +x or the systemd unit cannot run it"
+    r = subprocess.run(["bash", "-n", str(SCRIPT)], capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+
+
+def test_an_unknown_argument_is_a_usage_error_not_a_silent_pass(world):
+    stub = _stub(world, 'echo "RESULT: PASS (exit=0)"; exit 0\n')
+    r = _run(world, stub, "--wat")
+    assert r.returncode == RC_USAGE, r.stdout + r.stderr
+    assert _calls(world) == []


### PR DESCRIPTION
Closes rank 22 of `claudedocs/handoff-cairn-phase3.md`. Claim `cairn-phase3-22`.

## The gap

Branch protection is OFF by a live operator decision, so a commit can land straight on `main` with nothing running against it. **MEASURED 2026-09-03: that happened twice in one session** — `a720d30d` and `a451abc0`, both one-line direct pushes titled `espanso`. `main` was red for hours each time, and **both times the only detector was a human running the gate by hand, incidentally.**

`drift-check` answers *"is a host still receiving changes?"*. This answers the independent question *"is what they are receiving any good?"*.

## What it does

On a 4h timer: fetch, and **if the mainline tip has moved since the last recorded verdict**, run the real suite against it.

| rc | meaning | systemd |
|---|---|---|
| 0 | GREEN — passed / already-verified / red-did-not-reproduce. Each prints **which**. | success |
| 10 | **RED, REPRODUCED** — ran twice, failed twice | fails → toast |
| 11 | COULD NOT MEASURE — quiet, recorded, laddered | success |
| 12 | **BLIND** — 6 consecutive unmeasured runs (~24h) | fails → toast |

## Three design calls, each from a measurement rather than a preference

**It runs the hermetic tier, not `scripts/gate.sh`.** On one tree (main + #1261) the dev-host tier reported **4 failures** and the nix sandbox tier reported **0**. All four were `subprocess.TimeoutExpired` at a fixed 300 s cap while the box sat at load 22–29; an *untouched* target inflated 4.49 s → 177.26 s in the same window. Wiring a DND-bypassing toast to the tier that emits those would build the permanently-red gate `RULES.md` calls worse than no gate.

**rc 11 is a systemd success and rc 12 is not.** Making 11 quiet stops a network blip toasting — and, alone, lets the deadman go blind forever in silence, which is the same shape as the bug it exists to catch. `drift-check`'s rc 18 is the precedent (*"setting no code was right per run and wrong forever"*), so the ladder is copied rather than reinvented. One measured run resets it.

**It runs the whole suite.** The second break was a **guard whose premise died**, not a regression — the collision it asserted was gone at the source. A distilled *"did attribution regress?"* check would have sailed past it.

⚠ Rank 22's own proposed fix — trigger the espanso test when `nix/home.nix` changes — is **void if #1265 lands**, since that deletes all nine live-config tests and `_live_det()`. This design is independent of that.

## Passivity

Never touches your checkout. Its own clone under `~/.cache/main-green`; the only thing it reads from the invoking repo is `remote get-url origin`. `git worktree add` is refused too — that writes the **common** git dir, so it is repo-global even when it looks local.

Both pinned by a static guard that scans **code, not prose**. The first draft grepped the whole file and went red on its own comment explaining why `worktree add` is forbidden — a guard walkable by wording is not a guard.

## Cost

Memoized on the sha, so a fire against an unchanged `main` builds nothing. `main` moved 5 times during one session; this is ~1–2 real runs a day.

## Tests — 22

Two controls first, because a deadman's whole value is that a zero means something: **negative** (feed it a gate that must fail — if that reports success everything else measures nothing) and **positive**.

Mutation matrix, **each mutant killed by its own test, not a neighbour's**:

| mutation | killed by |
|---|---|
| a third attempt is added | `test_the_retry_does_NOT_loop_until_green` |
| flake recorded as green | flake test |
| remembered red exits green | `test_a_RED_main_that_has_not_moved_still_reports_RED` |
| no-verdict treated as a pass | unmeasured test |
| status/content disagreement resolved as a pass | disagree test |
| memo ignores the sha | `test_the_memo_is_INVALIDATED_when_main_moves` |
| script writes to the operator checkout | static guard |
| ladder never escalates / streak never resets | the two ladder tests |

Two earlier mutants are reported as **invalid, not as survivors**: one broke the syntax (dies for the wrong reason) and one was a no-op because an earlier `case` arm always won — the documented "unreachable mutant" trap.

🔴 Every behavioural test sets `MAIN_GREEN_GATE_CMD`, so **none of them runs `nix build`**. `test_the_production_path_builds_the_two_sandbox_derivations` pins the real invocation textually — including its one-at-a-time shape — so the seam cannot drift away from production while the suite stays green.

## What you should look at

**This is a new source of `notify-failure@`, which is the one toast class deliberately wired to defeat do-not-disturb.** `enableMainGreenDeadman` gates only the `timers.target` wiring, so it is one line to silence without reverting anything. It ships **enabled** — say the word and I'll flip the default.

Unit verified by evaluating the flake, not by reading the nix: `SuccessExitStatus=11`, `TimeoutStartSec=5400`, timer `WantedBy=["timers.target"]`, and `nix`/`git`/`flock` confirmed present on the unit PATH by checking the binaries exist (my first check used a wrong regex and said `nix` was missing — the instrument was wrong, not the unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmoTSE38skjjFmvueB9GDy
