### PR TITLE
fix(browser-agent): release the warm lock when a run is killed — the trap was armed ~100 lines too late

### DIFF
--- a/scripts/browser-bridge/browser-agent
+++ b/scripts/browser-bridge/browser-agent
@@ -230,62 +230,56 @@ _oc_lock_refuse() {   # <token> <detail>
   echo "browser-agent: warm-lock-refused:$1 — $2 Falling back to the GLOBAL opencode config." >&2
 }
 
-# 🔴 THE HOLDER'S PID, WRITTEN INSIDE THE LOCK. Without it an ORPHANED lock — one
-# whose holder was killed — is indistinguishable from a live one, so every later
-# run pays the FULL `OC_LOCK_BUDGET` (~120 s on defaults) before the blind steal
-# below can clear it. MEASURED 2026-09-03: a killed run left this directory
-# behind and the next `browser-agent --dry-run` was still stalled at 300 s, which
-# reads as a hang with no error and — because the orphan is machine-global — made
-# a CONCURRENT agent's unrelated branch look red. With the pid recorded, a dead
-# holder is detected on the FIRST pass and stolen immediately.
+# 🔴 WHY A RELEASE TRAP EXISTS HERE AND NOT AT THE SCRIPT'S `trap _cleanup_all`
+# LINE. That one is installed ~100 lines BELOW the call site that holds this
+# lock, so the ENTIRE bootstrap window ran with no handler — and `_cleanup_all`
+# never touched the lock anyway. A run killed in that window (the common case:
+# this script's own `--timeout` process-group kill, or a Ctrl-C) left the
+# directory behind, and every later run then paid the FULL `OC_LOCK_BUDGET`
+# (~120 s on defaults) before the blind steal below could clear it.
 #
-# 🔴 IT IS A FILE INSIDE THE LOCK DIRECTORY, WHICH MAKES THE LOCK NON-EMPTY, AND
-# THAT IS LOAD-BEARING FOR THE STEAL. `rmdir` refuses a non-empty directory, so
-# every steal path must remove THIS file explicitly and nothing else. That is
-# deliberate: a lock carrying any OTHER content was not written by us, so the
-# `rmdir` still fails and we still refuse rather than deleting a stranger's
-# state — the behaviour `test_a_lock_a_holder_never_frees_...` pins.
-OC_LOCK_PID_FILE="$OC_LOCK/pid"
+# 🔴 SCOPE, STATED HONESTLY: this closes the ORDINARY-KILL half only. A SIGKILL
+# runs no trap, so a hard-killed run still orphans the lock. Detecting THAT
+# needs the holder's identity in the lock, and the obvious version is UNSAFE —
+# an unowned delete-then-recreate steal lets two contenders that BOTH judge the
+# holder dead BOTH acquire (reproduced 2026-09-03; two concurrent
+# `rm -rf node_modules` on one tree is worse than the stall it removes). It
+# wants an atomic primitive (`flock`, whose lock the kernel drops on death),
+# never a pid file bolted onto `mkdir`. Deliberately NOT attempted here.
 OC_LOCK_HELD=0
 
-# Claim a lock we have just created: record the pid, then arm a release trap.
-# 🔴 THE TRAP IS ARMED HERE, NOT AT THE SCRIPT'S `trap _cleanup_all` LINE. That
-# one is installed ~100 lines BELOW the call site that holds this lock, so the
-# entire bootstrap window ran with NO handler and an INT/TERM there orphaned the
-# directory. `_cleanup_all` also never touched the lock. Arming it at the moment
-# of acquisition is what closes the ordinary-kill half; the pid check closes the
-# SIGKILL half, which no trap can reach.
+# Claim a lock we have just created, and arm its release.
+# 🔴 THE HANDLER MUST EXIT, NOT RETURN. A bash trap handler runs and execution
+# RESUMES — measured on 5.3.15. Returning would turn a TERM during the lock wait
+# or the warm into "released the lock and carried on bootstrapping
+# UNSERIALISED", the corruption this lock exists to prevent, and would make
+# `browser agent` un-interruptible there. Before this change no trap was armed
+# in that window at all, so INT/TERM killed the process by default; these
+# handlers preserve that while adding the release.
 _oc_lock_claim() {
   OC_LOCK_HELD=1
-  echo "$$" > "$OC_LOCK_PID_FILE" 2>/dev/null || true
-  trap '_oc_lock_release' EXIT INT TERM
+  trap '_oc_lock_release; exit 130' INT
+  trap '_oc_lock_release; exit 143' TERM
+  trap '_oc_lock_release' EXIT
   return 0
 }
 
-# Release a lock WE hold. Safe to call when we do not: it is a no-op then, so the
-# trap cannot delete a lock a later run legitimately took.
+# 🔴 IT DOES NOT DISARM THE TRAPS, AND THAT IS THE POINT OF THIS COMMENT. An
+# earlier version ended with `trap - EXIT INT TERM`, which looks like tidy
+# symmetry and SWALLOWS A PENDING SIGNAL: a TERM delivered while the warm's
+# opencode is the foreground command is DEFERRED (bash runs no handler until
+# that command returns), the normal-path release then resets the disposition,
+# and the queued TERM is discarded — the wrapper runs to completion and exits 0
+# having been asked to die. MEASURED by this change's own
+# `test_the_release_handler_EXITS_rather_than_resuming`: rc 0 after a TERM.
+# Leaving them armed is correct and cheaper — after release `OC_LOCK_HELD=0`
+# makes the release a no-op, so a later signal just takes the `exit 130`/`143`,
+# which IS the disposition a TERM should have. The script's own
+# `trap _cleanup_all EXIT INT TERM` overwrites them further down.
 _oc_lock_release() {
   [ "$OC_LOCK_HELD" = "1" ] || return 0
   OC_LOCK_HELD=0
-  rm -f "$OC_LOCK_PID_FILE" 2>/dev/null
   rmdir "$OC_LOCK" 2>/dev/null
-  trap - EXIT INT TERM
-  return 0
-}
-
-# Is the recorded holder gone? STRICT: only a pid file that EXISTS, parses as a
-# pid, and names a process that is not alive answers yes.
-# 🔴 A MISSING pid file is NOT staleness — it is the instant between another
-# run's `mkdir` and its `echo $$`, and stealing there would break the very
-# mutual exclusion this lock provides. Absent ⇒ wait, which is the old
-# behaviour and the safe one.
-_oc_lock_holder_is_dead() {
-  local pid
-  pid=$(cat "$OC_LOCK_PID_FILE" 2>/dev/null) || return 1
-  case "$pid" in (""|*[!0-9]*) return 1;; esac
-  # `kill -0` succeeds for a zombie, which is fine: a zombie's lock will be
-  # released by its parent's trap, and treating it as alive only costs a wait.
-  kill -0 "$pid" 2>/dev/null && return 1
   return 0
 }
 
@@ -309,18 +303,7 @@ _oc_lock() {  # -> 0 lock HELD, 1 the lock path is unusable (caller must not boo
   # this function is supposed to fall back to. Distinguish, and fail fast: the
   # caller's fallback path is correct and cheap, the wait is neither.
   local deadline=$(( SECONDS + OC_LOCK_BUDGET ))
-  if mkdir "$OC_LOCK" 2>/dev/null; then _oc_lock_claim; return 0; fi
   while ! mkdir "$OC_LOCK" 2>/dev/null; do
-    # 🔴 THE ORPHAN CHECK, BEFORE THE WAIT — not after it. A dead holder's lock
-    # is stolen on the first pass instead of costing the full budget. Ordering
-    # matters: this must come before the `SECONDS -ge deadline` arm, or the
-    # fast path is unreachable whenever the budget is short.
-    if _oc_lock_holder_is_dead; then
-      rm -f "$OC_LOCK_PID_FILE" 2>/dev/null
-      rmdir "$OC_LOCK" 2>/dev/null
-      if mkdir "$OC_LOCK" 2>/dev/null; then _oc_lock_claim; return 0; fi
-      # Someone else won the race to re-create it. Fall through and wait.
-    fi
     if [ ! -d "$OC_LOCK" ]; then
       # Not a directory ⇒ this was not contention. Retry ONCE — the holder may
       # have released it in the instant between the mkdir and this test — and if
@@ -336,12 +319,6 @@ _oc_lock() {  # -> 0 lock HELD, 1 the lock path is unusable (caller must not boo
     if [ "$SECONDS" -ge "$deadline" ]; then
       # Budget spent. Steal what must be a stale lock — but if even that fails,
       # we do NOT hold it, and the caller must not bootstrap as though we did.
-      # 🔴 Remove OUR pid file first, and ONLY that name: a lock we orphaned is
-      # non-empty because of it, so without this line `rmdir` fails and the
-      # blind steal that has always been the last resort here would have
-      # regressed into a refusal. A lock holding anything ELSE still fails the
-      # `rmdir` and still refuses — we do not delete a stranger's state.
-      rm -f "$OC_LOCK_PID_FILE" 2>/dev/null
       rmdir "$OC_LOCK" 2>/dev/null
       mkdir "$OC_LOCK" 2>/dev/null || {
         _oc_lock_refuse timeout "waited ${OC_LOCK_BUDGET}s for the warm lock '$OC_LOCK' and could not take or clear it."

--- a/scripts/browser-bridge/browser-agent
+++ b/scripts/browser-bridge/browser-agent
@@ -206,7 +206,7 @@ oc_bootstrap() {  # <version> -> 0 warm, 1 could not warm
   # minutes first (see `_oc_lock`).
   _oc_lock || return 1
   _oc_bootstrap_locked "$ver"; rc=$?
-  rmdir "$OC_LOCK" 2>/dev/null
+  _oc_lock_release
   return $rc
 }
 
@@ -230,6 +230,65 @@ _oc_lock_refuse() {   # <token> <detail>
   echo "browser-agent: warm-lock-refused:$1 — $2 Falling back to the GLOBAL opencode config." >&2
 }
 
+# 🔴 THE HOLDER'S PID, WRITTEN INSIDE THE LOCK. Without it an ORPHANED lock — one
+# whose holder was killed — is indistinguishable from a live one, so every later
+# run pays the FULL `OC_LOCK_BUDGET` (~120 s on defaults) before the blind steal
+# below can clear it. MEASURED 2026-09-03: a killed run left this directory
+# behind and the next `browser-agent --dry-run` was still stalled at 300 s, which
+# reads as a hang with no error and — because the orphan is machine-global — made
+# a CONCURRENT agent's unrelated branch look red. With the pid recorded, a dead
+# holder is detected on the FIRST pass and stolen immediately.
+#
+# 🔴 IT IS A FILE INSIDE THE LOCK DIRECTORY, WHICH MAKES THE LOCK NON-EMPTY, AND
+# THAT IS LOAD-BEARING FOR THE STEAL. `rmdir` refuses a non-empty directory, so
+# every steal path must remove THIS file explicitly and nothing else. That is
+# deliberate: a lock carrying any OTHER content was not written by us, so the
+# `rmdir` still fails and we still refuse rather than deleting a stranger's
+# state — the behaviour `test_a_lock_a_holder_never_frees_...` pins.
+OC_LOCK_PID_FILE="$OC_LOCK/pid"
+OC_LOCK_HELD=0
+
+# Claim a lock we have just created: record the pid, then arm a release trap.
+# 🔴 THE TRAP IS ARMED HERE, NOT AT THE SCRIPT'S `trap _cleanup_all` LINE. That
+# one is installed ~100 lines BELOW the call site that holds this lock, so the
+# entire bootstrap window ran with NO handler and an INT/TERM there orphaned the
+# directory. `_cleanup_all` also never touched the lock. Arming it at the moment
+# of acquisition is what closes the ordinary-kill half; the pid check closes the
+# SIGKILL half, which no trap can reach.
+_oc_lock_claim() {
+  OC_LOCK_HELD=1
+  echo "$$" > "$OC_LOCK_PID_FILE" 2>/dev/null || true
+  trap '_oc_lock_release' EXIT INT TERM
+  return 0
+}
+
+# Release a lock WE hold. Safe to call when we do not: it is a no-op then, so the
+# trap cannot delete a lock a later run legitimately took.
+_oc_lock_release() {
+  [ "$OC_LOCK_HELD" = "1" ] || return 0
+  OC_LOCK_HELD=0
+  rm -f "$OC_LOCK_PID_FILE" 2>/dev/null
+  rmdir "$OC_LOCK" 2>/dev/null
+  trap - EXIT INT TERM
+  return 0
+}
+
+# Is the recorded holder gone? STRICT: only a pid file that EXISTS, parses as a
+# pid, and names a process that is not alive answers yes.
+# 🔴 A MISSING pid file is NOT staleness — it is the instant between another
+# run's `mkdir` and its `echo $$`, and stealing there would break the very
+# mutual exclusion this lock provides. Absent ⇒ wait, which is the old
+# behaviour and the safe one.
+_oc_lock_holder_is_dead() {
+  local pid
+  pid=$(cat "$OC_LOCK_PID_FILE" 2>/dev/null) || return 1
+  case "$pid" in (""|*[!0-9]*) return 1;; esac
+  # `kill -0` succeeds for a zombie, which is fine: a zombie's lock will be
+  # released by its parent's trap, and treating it as alive only costs a wait.
+  kill -0 "$pid" 2>/dev/null && return 1
+  return 0
+}
+
 _oc_lock() {  # -> 0 lock HELD, 1 the lock path is unusable (caller must not bootstrap)
   # Serialise concurrent runs. Bounded wait, then proceed anyway: a stale lock
   # from a killed run must not wedge every future invocation.
@@ -250,14 +309,25 @@ _oc_lock() {  # -> 0 lock HELD, 1 the lock path is unusable (caller must not boo
   # this function is supposed to fall back to. Distinguish, and fail fast: the
   # caller's fallback path is correct and cheap, the wait is neither.
   local deadline=$(( SECONDS + OC_LOCK_BUDGET ))
+  if mkdir "$OC_LOCK" 2>/dev/null; then _oc_lock_claim; return 0; fi
   while ! mkdir "$OC_LOCK" 2>/dev/null; do
+    # 🔴 THE ORPHAN CHECK, BEFORE THE WAIT — not after it. A dead holder's lock
+    # is stolen on the first pass instead of costing the full budget. Ordering
+    # matters: this must come before the `SECONDS -ge deadline` arm, or the
+    # fast path is unreachable whenever the budget is short.
+    if _oc_lock_holder_is_dead; then
+      rm -f "$OC_LOCK_PID_FILE" 2>/dev/null
+      rmdir "$OC_LOCK" 2>/dev/null
+      if mkdir "$OC_LOCK" 2>/dev/null; then _oc_lock_claim; return 0; fi
+      # Someone else won the race to re-create it. Fall through and wait.
+    fi
     if [ ! -d "$OC_LOCK" ]; then
       # Not a directory ⇒ this was not contention. Retry ONCE — the holder may
       # have released it in the instant between the mkdir and this test — and if
       # a third party grabbed it meanwhile, fall back into the wait loop. Only a
       # path that is STILL neither creatable nor a directory is the permanent
       # error, and that one we refuse instead of sleeping on it.
-      mkdir "$OC_LOCK" 2>/dev/null && return 0
+      mkdir "$OC_LOCK" 2>/dev/null && { _oc_lock_claim; return 0; }
       [ -d "$OC_LOCK" ] || {
         _oc_lock_refuse unwaitable "the warm lock path '$OC_LOCK' cannot be created and is not a directory (ENOSPC/EACCES/EIO, or a stray file at that path), so waiting cannot clear it."
         return 1
@@ -266,6 +336,12 @@ _oc_lock() {  # -> 0 lock HELD, 1 the lock path is unusable (caller must not boo
     if [ "$SECONDS" -ge "$deadline" ]; then
       # Budget spent. Steal what must be a stale lock — but if even that fails,
       # we do NOT hold it, and the caller must not bootstrap as though we did.
+      # 🔴 Remove OUR pid file first, and ONLY that name: a lock we orphaned is
+      # non-empty because of it, so without this line `rmdir` fails and the
+      # blind steal that has always been the last resort here would have
+      # regressed into a refusal. A lock holding anything ELSE still fails the
+      # `rmdir` and still refuses — we do not delete a stranger's state.
+      rm -f "$OC_LOCK_PID_FILE" 2>/dev/null
       rmdir "$OC_LOCK" 2>/dev/null
       mkdir "$OC_LOCK" 2>/dev/null || {
         _oc_lock_refuse timeout "waited ${OC_LOCK_BUDGET}s for the warm lock '$OC_LOCK' and could not take or clear it."
@@ -275,6 +351,7 @@ _oc_lock() {  # -> 0 lock HELD, 1 the lock path is unusable (caller must not boo
     fi
     sleep 0.5
   done
+  _oc_lock_claim
   return 0
 }
 

--- a/scripts/browser-bridge/tests/test_browser_agent.py
+++ b/scripts/browser-bridge/tests/test_browser_agent.py
@@ -1522,7 +1522,13 @@ def test_an_orphaned_lock_with_a_dead_holder_is_stolen_without_waiting(rig):
 
 
 def test_a_lock_whose_holder_is_ALIVE_is_not_stolen_on_the_fast_path(rig):
-    """🔴 THE DISCRIMINATOR, and the reason the test above is not sufficient.
+    """INVARIANT GUARD — it passes at base too, so it is NOT regression coverage.
+    Measured: green at `aba48864` (no pid check exists there, so a live holder is
+    waited for anyway) and green at HEAD. It is kept because it guards the FIX,
+    not the bug: mutating `_oc_lock_holder_is_dead` to `return 0` (always "dead")
+    turns it RED with this assertion, so it is reachable and non-vacuous.
+
+    🔴 THE DISCRIMINATOR, and the reason the test above is not sufficient.
     A steal that fires regardless of the pid would pass the headline test while
     destroying the mutual exclusion the lock exists to provide — two runs would
     `rm -rf` node_modules under each other, the exact corruption `_oc_lock`
@@ -1562,7 +1568,11 @@ def test_a_lock_whose_holder_is_ALIVE_is_not_stolen_on_the_fast_path(rig):
 
 
 def test_a_lock_with_NO_pid_file_is_not_stolen_on_the_fast_path(rig):
-    """🔴 THE RACE THE FAST PATH MUST NOT WIN. Between another run's `mkdir` and
+    """INVARIANT GUARD — green at base `aba48864` and at HEAD, so not regression
+    coverage. Kept because it kills the same `_oc_lock_holder_is_dead -> return 0`
+    mutant with its own assertion.
+
+    🔴 THE RACE THE FAST PATH MUST NOT WIN. Between another run's `mkdir` and
     its `echo $$` the lock exists with no pid file. Reading "no pid" as "dead"
     would steal a lock whose holder is moments from using it. Absent ⇒ wait,
     which is the pre-existing behaviour and the safe one.

--- a/scripts/browser-bridge/tests/test_browser_agent.py
+++ b/scripts/browser-bridge/tests/test_browser_agent.py
@@ -20,6 +20,7 @@ Run: nix-shell -p python312Packages.pytest --run "pytest scripts/browser-bridge/
 import json
 import os
 import shutil
+import signal
 import stat
 import subprocess
 import sys
@@ -502,8 +503,11 @@ def rig(tmp_path):
     # degraded path deletes `rig.oc_config_dir` first.
     _prewarm_oc_config(oc_config_dir, focode)
 
-    def run(args, mode="ok", extra_env=None, timeout=RUN_TIMEOUT, open_fail=False,
-            tabid=TAB_ID, probe_fail=0, stall_cap=None):
+    def _rig_env(mode="ok", extra_env=None, open_fail=False,
+                 tabid=TAB_ID, probe_fail=0):
+        """The rig's environment, extracted so `run` and `spawn` cannot drift.
+        Behaviour-preserving: `run` called this exact block inline before.
+        """
         env = dict(os.environ)
         env.update(
             BROWSER_AGENT_OPENCODE=str(focode),
@@ -528,6 +532,28 @@ def rig(tmp_path):
             env["FRB_OPEN_FAIL"] = "1"
         if extra_env:
             env.update(extra_env)
+        return env
+
+    def spawn(args, mode="ok", extra_env=None, open_fail=False,
+              tabid=TAB_ID, probe_fail=0):
+        """Start the wrapper and hand back the Popen, still running.
+
+        🔴 `start_new_session=True` puts it in its OWN process group, so a
+        test can `killpg` it exactly the way this script's own `--timeout`
+        path does — and, critically, WITHOUT signalling pytest itself.
+        A bare TERM to the wrapper is DEFERRED while bash sits in a
+        foreground command, so the group kill is the only faithful one.
+        The caller owns the process and must reap it.
+        """
+        return subprocess.Popen(
+            [str(WRAPPER), *args],
+            env=_rig_env(mode, extra_env, open_fail, tabid, probe_fail),
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            start_new_session=True)
+
+    def run(args, mode="ok", extra_env=None, timeout=RUN_TIMEOUT, open_fail=False,
+            tabid=TAB_ID, probe_fail=0, stall_cap=None):
+        env = _rig_env(mode, extra_env, open_fail, tabid, probe_fail)
         # Wait on the DETERMINISTIC condition — the process exited — and use the
         # clock only to decide whether "still running" means "hung". `communicate`
         # (unlike `subprocess.run`) does NOT kill the child on expiry, so we can
@@ -576,6 +602,7 @@ def rig(tmp_path):
     rig.oc_config_dir = oc_config_dir
     rig.opencode_bin = focode
     rig.run = run
+    rig.spawn = spawn
     return rig
 
 
@@ -1470,132 +1497,86 @@ def test_the_condition_poll_also_extends_on_a_stalled_machine(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# The ORPHANED warm lock — a holder that was KILLED, not one that is working.
+# The warm lock is RELEASED when a run is killed.
 #
-# 🔴 WHY THESE EXIST. `_oc_lock` has always stolen a stale lock, but only after
-# spending the FULL `OC_LOCK_BUDGET` (default `OC_WARM_TIMEOUT + 30` = ~120 s),
-# because nothing recorded WHO held it: an orphan was indistinguishable from a
-# live holder. MEASURED 2026-09-03 on the workbench — a killed run left the
-# directory behind and the next `browser-agent --dry-run` was still stalled at
-# 300 s. Two costs, and the second is the one that wasted a day: the lock is
-# MACHINE-GLOBAL, so one orphan made a CONCURRENT agent's unrelated branch fail
-# its suite, and re-running the same test on `origin/main` reproduced it —
-# which reads as "main is broken" and is not.
+# 🔴 THE DEFECT. `_oc_lock` takes a machine-global `mkdir` mutex at
+# `~/.cache/browser-agent-opencode-config.lock` and released it only on the
+# normal path. The script's `trap _cleanup_all EXIT INT TERM` is installed ~100
+# lines BELOW the call site that holds it, so the whole bootstrap window ran
+# with NO handler — and `_cleanup_all` never touched the lock anyway. A run
+# killed there (the common case: this script's own `--timeout` process-group
+# kill, or a Ctrl-C) orphaned the directory, and every LATER run then paid the
+# full `OC_LOCK_BUDGET` (~120 s) before the blind steal could clear it.
 #
-# The fix records the holder's pid inside the lock and steals on the FIRST pass
-# when that pid is dead. These tests pin the DISCRIMINATION, not just the steal:
-# a fast steal that cannot tell a live holder from a dead one is a broken lock,
-# not a fixed one.
+# MEASURED 2026-09-03: an orphan left the next `browser-agent --dry-run` still
+# stalled at 300 s, presenting as a hang with no message — and because the lock
+# is machine-global it made a CONCURRENT agent's unrelated suite fail, which
+# reproduced on `origin/main` and read as "main is broken".
+#
+# ⚠ SCOPE: a SIGKILL runs no trap, so it still orphans the lock. Detecting that
+# needs the holder's identity in the lock, and the naive version is UNSAFE —
+# two contenders that both judge the holder dead BOTH acquire (reproduced).
+# Deliberately out of scope here; it wants an atomic primitive, not a pid file.
 # ---------------------------------------------------------------------------
 
 
-def _reaped_pid() -> int:
-    """A pid that is certainly dead AND reaped (so `kill -0` fails)."""
-    p = subprocess.Popen([sys.executable, "-c", ""])
-    p.wait()
-    return p.pid
+def test_a_run_killed_mid_bootstrap_RELEASES_the_warm_lock(rig):
+    """🔴 REGRESSION. Red at base: with no handler armed at acquisition, the
+    lock directory survives the kill and every later run pays the full budget.
 
-
-def test_an_orphaned_lock_with_a_dead_holder_is_stolen_without_waiting(rig):
-    """🔴 THE HEADLINE. Budget is set LONG (120 s) on purpose: with the old code
-    the run cannot finish until it expires, so the rig's own deadline fails the
-    test. Passing therefore proves the steal happened on the FAST path — no
-    clock assertion, no flake, and the two outcomes are separated by ~2 minutes
-    rather than by milliseconds.
-
-    Red at base: the run never completes inside the rig deadline."""
+    The kill is a PROCESS-GROUP TERM because that is what this script's own
+    `--timeout` path sends, and because a bare TERM to the wrapper is DEFERRED
+    while bash sits in a foreground command — measured, and it is why an
+    earlier version of this test observed no release and looked like a code
+    defect when it was a signalling one."""
     shutil.rmtree(rig.oc_config_dir)
     rig.oc_config_dir.mkdir()
     lock = Path(str(rig.oc_config_dir) + ".lock")
-    lock.mkdir()
-    (lock / "pid").write_text(f"{_reaped_pid()}\n")
 
-    r = rig.run(["read the page"], mode="ok",
-                extra_env={"BROWSER_AGENT_LOCK_BUDGET": "120"})
-
-    assert r.returncode == 0, r.stderr
-    assert (rig.oc_config_dir / "opencode.jsonc").exists(), (
-        "the dead holder's lock was not stolen, so the bootstrap never ran — "
-        "this is the ~120 s stall the pid file exists to remove")
-    assert "warm-lock-refused" not in r.stderr, (
-        f"a dead holder must not produce ANY refusal token: {r.stderr}")
-
-
-def test_a_lock_whose_holder_is_ALIVE_is_not_stolen_on_the_fast_path(rig):
-    """INVARIANT GUARD — it passes at base too, so it is NOT regression coverage.
-    Measured: green at `aba48864` (no pid check exists there, so a live holder is
-    waited for anyway) and green at HEAD. It is kept because it guards the FIX,
-    not the bug: mutating `_oc_lock_holder_is_dead` to `return 0` (always "dead")
-    turns it RED with this assertion, so it is reachable and non-vacuous.
-
-    🔴 THE DISCRIMINATOR, and the reason the test above is not sufficient.
-    A steal that fires regardless of the pid would pass the headline test while
-    destroying the mutual exclusion the lock exists to provide — two runs would
-    `rm -rf` node_modules under each other, the exact corruption `_oc_lock`
-    was written to prevent.
-
-    A LIVE holder must fall through to the ordinary wait. The budget is short so
-    the run still finishes; what is asserted is that the blind end-of-budget
-    steal is what took it — the elapsed floor — never the pid fast path.
-
-    🔴 THE FLOOR IS DELIBERATELY BELOW THE BUDGET. bash's `SECONDS` is an
-    INTEGER that ticks on wall-clock second boundaries, so `deadline=$((SECONDS+N))`
-    can elapse in as little as N-1 seconds of real time. Asserting `>= budget`
-    is an expectation derived from READING the code rather than from what it can
-    do, and it fails ~1 run in 1 (measured: 2.7 s against a 3 s budget). The
-    floor only has to separate "waited" from "stole instantly" (~0.5 s), so a
-    5 s budget with a 3 s floor leaves ~2 s of margin on both sides.
-    """
-    shutil.rmtree(rig.oc_config_dir)
-    rig.oc_config_dir.mkdir()
-    lock = Path(str(rig.oc_config_dir) + ".lock")
-    lock.mkdir()
-    holder = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    proc = rig.spawn(["read the page"], mode="ok")
     try:
-        (lock / "pid").write_text(f"{holder.pid}\n")
-        started = time.monotonic()
-        r = rig.run(["read the page"], mode="ok",
-                    extra_env={"BROWSER_AGENT_LOCK_BUDGET": "5"})
-        elapsed = time.monotonic() - started
+        _await(lambda: lock.is_dir(), what="the wrapper to take the warm lock",
+               slice_s=15.0, poll=0.02)
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        proc.wait(timeout=30)
     finally:
-        holder.kill()
-        holder.wait()
+        if proc.poll() is None:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            proc.wait(timeout=10)
 
-    assert r.returncode == 0, r.stderr
-    assert elapsed >= 3.0, (
-        f"took {elapsed:.1f}s for a 5s budget — a LIVE holder's lock was stolen "
-        "on the fast path, so the pid check cannot tell live from dead")
+    assert not lock.exists(), (
+        "the warm lock survived a process-group TERM — every later run now pays "
+        "the full OC_LOCK_BUDGET before the blind steal can clear it, which is "
+        "the ~120 s stall this change removes")
 
 
-def test_a_lock_with_NO_pid_file_is_not_stolen_on_the_fast_path(rig):
-    """INVARIANT GUARD — green at base `aba48864` and at HEAD, so not regression
-    coverage. Kept because it kills the same `_oc_lock_holder_is_dead -> return 0`
-    mutant with its own assertion.
+def test_the_release_handler_EXITS_rather_than_resuming(rig):
+    """🔴 THE REGRESSION THE FIX ITSELF COULD INTRODUCE, and it is not
+    theoretical: a bash trap handler runs and then execution RESUMES (measured
+    on 5.3.15). A handler that only released the lock would turn a TERM during
+    the warm into "released the lock and carried on bootstrapping UNSERIALISED"
+    — the exact corruption the lock exists to prevent — and would also make
+    `browser agent` un-interruptible in that window.
 
-    🔴 THE RACE THE FAST PATH MUST NOT WIN. Between another run's `mkdir` and
-    its `echo $$` the lock exists with no pid file. Reading "no pid" as "dead"
-    would steal a lock whose holder is moments from using it. Absent ⇒ wait,
-    which is the pre-existing behaviour and the safe one.
-
-    🔴 THE FLOOR IS DELIBERATELY BELOW THE BUDGET. bash's `SECONDS` is an
-    INTEGER that ticks on wall-clock second boundaries, so `deadline=$((SECONDS+N))`
-    can elapse in as little as N-1 seconds of real time. Asserting `>= budget`
-    is an expectation derived from READING the code rather than from what it can
-    do, and it fails ~1 run in 1 (measured: 2.7 s against a 3 s budget). The
-    floor only has to separate "waited" from "stole instantly" (~0.5 s), so a
-    5 s budget with a 3 s floor leaves ~2 s of margin on both sides.
-    """
+    INVARIANT GUARD, not regression coverage: at base there is no handler at
+    all, so TERM uses the default disposition and the process dies. Green both
+    sides. It is kept because it is the only thing that fails when the handler
+    stops exiting — dropping `exit 143` leaves every other test green."""
     shutil.rmtree(rig.oc_config_dir)
     rig.oc_config_dir.mkdir()
     lock = Path(str(rig.oc_config_dir) + ".lock")
-    lock.mkdir()  # no pid file — mid-acquisition by someone else
 
-    started = time.monotonic()
-    r = rig.run(["read the page"], mode="ok",
-                extra_env={"BROWSER_AGENT_LOCK_BUDGET": "5"})
-    elapsed = time.monotonic() - started
+    proc = rig.spawn(["read the page"], mode="ok")
+    try:
+        _await(lambda: lock.is_dir(), what="the wrapper to take the warm lock",
+               slice_s=15.0, poll=0.02)
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        rc = proc.wait(timeout=30)
+    finally:
+        if proc.poll() is None:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            proc.wait(timeout=10)
 
-    assert r.returncode == 0, r.stderr
-    assert elapsed >= 3.0, (
-        f"took {elapsed:.1f}s for a 5s budget — a lock with no pid file was "
-        "stolen immediately, which races a holder that has not written its pid yet")
+    assert rc != 0, (
+        f"exited {rc} after a TERM — the handler released the lock and let the "
+        "run CONTINUE unserialised instead of terminating")

--- a/scripts/browser-bridge/tests/test_browser_agent.py
+++ b/scripts/browser-bridge/tests/test_browser_agent.py
@@ -169,6 +169,17 @@ argv = sys.argv[1:]
 # FAKE_OC_ENV (those count/inspect only the real `run`). FAKE_OC_GATE_MODE drives
 # the shape so tests can prove the gate fails closed.
 if argv[:2] == ["debug", "agent"]:
+    # An OPT-IN hold, default 0 so no other test's behaviour moves. This is the
+    # branch the WARM takes (`opencode debug agent build`), and the warm runs
+    # UNDER the lock — so this is the only hook that can widen the window in
+    # which the wrapper holds it. `FAKE_OC_SLEEP`/`mode="slow"` cannot: they are
+    # read ~70 lines below, after this branch has already exited.
+    _dbg = float(os.environ.get("FAKE_OC_DEBUG_SLEEP", "0"))
+    if _dbg:
+        _mk = os.environ.get("FAKE_OC_DEBUG_MARKER")
+        if _mk:                       # announce that we are INSIDE the warm...
+            open(_mk, "w").write("in-warm")
+        time.sleep(_dbg)              # ...and hold it open
     import stat as _stat
     gate = os.environ.get("FAKE_OC_GATE_MODE", "ok")
     if gate == "fail":               # `debug agent` itself errors (bad/unsupported)
@@ -1533,32 +1544,36 @@ def test_a_run_killed_mid_bootstrap_RELEASES_the_warm_lock(rig):
     rig.oc_config_dir.mkdir()
     lock = Path(str(rig.oc_config_dir) + ".lock")
 
-    # 🔴 DETERMINISM, not a sleep-to-be-safe. `mode="slow"` makes the fake
-    # opencode sleep INSIDE the warm — which runs UNDER the lock — so the window
-    # in which the wrapper holds it is seconds wide instead of milliseconds. The
-    # first version of these tests raced it: green alone (33 s suite), and under
-    # the full gate (8 m 45 s) the TERM landed AFTER the release, where the
-    # pre-existing `_cleanup_all` trap absorbs it and the run completes rc 0.
-    # 🔴 For the RELEASE test that race was worse than a flake: a TERM after the
-    # release finds the lock already gone, so `not lock.exists()` passes for the
-    # WRONG REASON. The window is what makes either assertion mean anything.
-    #
-    # ⚠ THE SLEEP IS 5 s, NOT 30 s, AND THE BOUND IS BASH's, NOT TASTE. A trap
-    # handler does not run until the current FOREGROUND command returns, and the
-    # wrapper runs the warm's opencode under its own `setsid` — so `killpg` on
-    # OUR group never reaches it and the handler is deferred for the whole sleep.
-    # At 30 s that exceeded `proc.wait()` and read as "the handler never fired".
-    # 5 s is wide enough to make the window deterministic and short enough that
-    # the deferred handler is observed.
-    proc = rig.spawn(["read the page"], mode="slow",
-                     extra_env={"FAKE_OC_SLEEP": "5",
+    # 🔴 DETERMINISM, via the ONE hook that can provide it. The warm runs
+    # `opencode debug agent build` UNDER the lock, so holding THAT open is what
+    # widens the window in which the wrapper holds the lock.
+    # ⚠ `mode="slow"`/`FAKE_OC_SLEEP` CANNOT do it, and an earlier version of
+    # this comment claimed they did: the fake's `debug agent` branch exits ~70
+    # lines ABOVE where `mode` is read, so that invocation returned in 0.015 s
+    # and these tests completed in 0.03-0.09 s — a 5 s hold was arithmetically
+    # impossible. They passed anyway, on the ~100 ms of bootstrap left after the
+    # claim, which is a margin nobody chose.
+    # 🔴 The margin matters because the failure it guards is SILENT: for the
+    # RELEASE test, a TERM landing after the release finds the lock already gone,
+    # so `not lock.exists()` passes for the WRONG REASON. Measured under the full
+    # gate (8 m 45 s) the first version did exactly that.
+    in_warm = rig.scratch_root / f"in-warm-{os.getpid()}"
+    proc = rig.spawn(["read the page"],
+                     extra_env={"FAKE_OC_DEBUG_SLEEP": "3",
+                                "FAKE_OC_DEBUG_MARKER": str(in_warm),
                                 "BROWSER_AGENT_WARM_TIMEOUT": "30"})
     try:
-        _await(lambda: lock.is_dir(), what="the wrapper to take the warm lock",
+        # 🔴 GATE ON BEING INSIDE THE WARM, NOT ON THE LOCK EXISTING. Waiting for
+        # the lock catches it ~20 ms after `mkdir`, which is BEFORE the warm
+        # starts — so the kill landed in whatever the bootstrap happened to be
+        # doing, on a margin of ~30 ms that nobody chose. The marker is written
+        # by the fake's `debug agent` branch, which IS the warm and DOES run
+        # under the lock, so this makes the window real rather than asserted.
+        _await(lambda: in_warm.exists(), what="the wrapper to enter the warm",
                slice_s=20.0, poll=0.02)
-        assert lock.is_dir(), "precondition: the wrapper must HOLD the lock here"
+        assert lock.is_dir(), "precondition: the warm must run UNDER the lock"
         os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-        proc.wait(timeout=45)
+        proc.communicate(timeout=45)
     finally:
         if proc.poll() is None:
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
@@ -1570,7 +1585,9 @@ def test_a_run_killed_mid_bootstrap_RELEASES_the_warm_lock(rig):
         "the ~120 s stall this change removes")
 
 
-def test_the_release_handler_EXITS_rather_than_resuming(rig):
+@pytest.mark.parametrize("sig,name", [(signal.SIGTERM, "TERM"), (signal.SIGINT, "INT")],
+                         ids=["TERM", "INT"])
+def test_the_release_handler_EXITS_rather_than_resuming(rig, sig, name):
     """🔴 THE REGRESSION THE FIX ITSELF COULD INTRODUCE, and it is not
     theoretical: a bash trap handler runs and then execution RESUMES (measured
     on 5.3.15). A handler that only released the lock would turn a TERM during
@@ -1586,37 +1603,45 @@ def test_the_release_handler_EXITS_rather_than_resuming(rig):
     rig.oc_config_dir.mkdir()
     lock = Path(str(rig.oc_config_dir) + ".lock")
 
-    # 🔴 DETERMINISM, not a sleep-to-be-safe. `mode="slow"` makes the fake
-    # opencode sleep INSIDE the warm — which runs UNDER the lock — so the window
-    # in which the wrapper holds it is seconds wide instead of milliseconds. The
-    # first version of these tests raced it: green alone (33 s suite), and under
-    # the full gate (8 m 45 s) the TERM landed AFTER the release, where the
-    # pre-existing `_cleanup_all` trap absorbs it and the run completes rc 0.
-    # 🔴 For the RELEASE test that race was worse than a flake: a TERM after the
-    # release finds the lock already gone, so `not lock.exists()` passes for the
-    # WRONG REASON. The window is what makes either assertion mean anything.
-    #
-    # ⚠ THE SLEEP IS 5 s, NOT 30 s, AND THE BOUND IS BASH's, NOT TASTE. A trap
-    # handler does not run until the current FOREGROUND command returns, and the
-    # wrapper runs the warm's opencode under its own `setsid` — so `killpg` on
-    # OUR group never reaches it and the handler is deferred for the whole sleep.
-    # At 30 s that exceeded `proc.wait()` and read as "the handler never fired".
-    # 5 s is wide enough to make the window deterministic and short enough that
-    # the deferred handler is observed.
-    proc = rig.spawn(["read the page"], mode="slow",
-                     extra_env={"FAKE_OC_SLEEP": "5",
+    # 🔴 DETERMINISM, via the ONE hook that can provide it. The warm runs
+    # `opencode debug agent build` UNDER the lock, so holding THAT open is what
+    # widens the window in which the wrapper holds the lock.
+    # ⚠ `mode="slow"`/`FAKE_OC_SLEEP` CANNOT do it, and an earlier version of
+    # this comment claimed they did: the fake's `debug agent` branch exits ~70
+    # lines ABOVE where `mode` is read, so that invocation returned in 0.015 s
+    # and these tests completed in 0.03-0.09 s — a 5 s hold was arithmetically
+    # impossible. They passed anyway, on the ~100 ms of bootstrap left after the
+    # claim, which is a margin nobody chose.
+    # 🔴 The margin matters because the failure it guards is SILENT: for the
+    # RELEASE test, a TERM landing after the release finds the lock already gone,
+    # so `not lock.exists()` passes for the WRONG REASON. Measured under the full
+    # gate (8 m 45 s) the first version did exactly that.
+    in_warm = rig.scratch_root / f"in-warm-{os.getpid()}"
+    proc = rig.spawn(["read the page"],
+                     extra_env={"FAKE_OC_DEBUG_SLEEP": "3",
+                                "FAKE_OC_DEBUG_MARKER": str(in_warm),
                                 "BROWSER_AGENT_WARM_TIMEOUT": "30"})
     try:
-        _await(lambda: lock.is_dir(), what="the wrapper to take the warm lock",
+        # 🔴 GATE ON BEING INSIDE THE WARM, NOT ON THE LOCK EXISTING. Waiting for
+        # the lock catches it ~20 ms after `mkdir`, which is BEFORE the warm
+        # starts — so the kill landed in whatever the bootstrap happened to be
+        # doing, on a margin of ~30 ms that nobody chose. The marker is written
+        # by the fake's `debug agent` branch, which IS the warm and DOES run
+        # under the lock, so this makes the window real rather than asserted.
+        _await(lambda: in_warm.exists(), what="the wrapper to enter the warm",
                slice_s=20.0, poll=0.02)
-        assert lock.is_dir(), "precondition: the wrapper must HOLD the lock here"
-        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        assert lock.is_dir(), "precondition: the warm must run UNDER the lock"
+        os.killpg(os.getpgid(proc.pid), sig)
         rc = proc.wait(timeout=45)
+        proc.communicate()
     finally:
         if proc.poll() is None:
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
             proc.wait(timeout=10)
 
     assert rc != 0, (
-        f"exited {rc} after a TERM — the handler released the lock and let the "
-        "run CONTINUE unserialised instead of terminating")
+        f"exited {rc} after a {name} — the handler released the lock and let the "
+        "run CONTINUE unserialised instead of terminating. 🔴 BOTH signals are "
+        "parametrised because guarding only TERM left `exit 130` free: a "
+        "mutation dropping it SURVIVED the whole suite, reintroducing exactly "
+        "the hazard the handler comment marks 🔴.")

--- a/scripts/browser-bridge/tests/test_browser_agent.py
+++ b/scripts/browser-bridge/tests/test_browser_agent.py
@@ -1467,3 +1467,125 @@ def test_the_condition_poll_also_extends_on_a_stalled_machine(monkeypatch):
     _await(lambda: time.monotonic() >= ready,
            what="a condition that resolves after several slices",
            slice_s=0.1, poll=0.01)
+
+
+# ---------------------------------------------------------------------------
+# The ORPHANED warm lock — a holder that was KILLED, not one that is working.
+#
+# 🔴 WHY THESE EXIST. `_oc_lock` has always stolen a stale lock, but only after
+# spending the FULL `OC_LOCK_BUDGET` (default `OC_WARM_TIMEOUT + 30` = ~120 s),
+# because nothing recorded WHO held it: an orphan was indistinguishable from a
+# live holder. MEASURED 2026-09-03 on the workbench — a killed run left the
+# directory behind and the next `browser-agent --dry-run` was still stalled at
+# 300 s. Two costs, and the second is the one that wasted a day: the lock is
+# MACHINE-GLOBAL, so one orphan made a CONCURRENT agent's unrelated branch fail
+# its suite, and re-running the same test on `origin/main` reproduced it —
+# which reads as "main is broken" and is not.
+#
+# The fix records the holder's pid inside the lock and steals on the FIRST pass
+# when that pid is dead. These tests pin the DISCRIMINATION, not just the steal:
+# a fast steal that cannot tell a live holder from a dead one is a broken lock,
+# not a fixed one.
+# ---------------------------------------------------------------------------
+
+
+def _reaped_pid() -> int:
+    """A pid that is certainly dead AND reaped (so `kill -0` fails)."""
+    p = subprocess.Popen([sys.executable, "-c", ""])
+    p.wait()
+    return p.pid
+
+
+def test_an_orphaned_lock_with_a_dead_holder_is_stolen_without_waiting(rig):
+    """🔴 THE HEADLINE. Budget is set LONG (120 s) on purpose: with the old code
+    the run cannot finish until it expires, so the rig's own deadline fails the
+    test. Passing therefore proves the steal happened on the FAST path — no
+    clock assertion, no flake, and the two outcomes are separated by ~2 minutes
+    rather than by milliseconds.
+
+    Red at base: the run never completes inside the rig deadline."""
+    shutil.rmtree(rig.oc_config_dir)
+    rig.oc_config_dir.mkdir()
+    lock = Path(str(rig.oc_config_dir) + ".lock")
+    lock.mkdir()
+    (lock / "pid").write_text(f"{_reaped_pid()}\n")
+
+    r = rig.run(["read the page"], mode="ok",
+                extra_env={"BROWSER_AGENT_LOCK_BUDGET": "120"})
+
+    assert r.returncode == 0, r.stderr
+    assert (rig.oc_config_dir / "opencode.jsonc").exists(), (
+        "the dead holder's lock was not stolen, so the bootstrap never ran — "
+        "this is the ~120 s stall the pid file exists to remove")
+    assert "warm-lock-refused" not in r.stderr, (
+        f"a dead holder must not produce ANY refusal token: {r.stderr}")
+
+
+def test_a_lock_whose_holder_is_ALIVE_is_not_stolen_on_the_fast_path(rig):
+    """🔴 THE DISCRIMINATOR, and the reason the test above is not sufficient.
+    A steal that fires regardless of the pid would pass the headline test while
+    destroying the mutual exclusion the lock exists to provide — two runs would
+    `rm -rf` node_modules under each other, the exact corruption `_oc_lock`
+    was written to prevent.
+
+    A LIVE holder must fall through to the ordinary wait. The budget is short so
+    the run still finishes; what is asserted is that the blind end-of-budget
+    steal is what took it — the elapsed floor — never the pid fast path.
+
+    🔴 THE FLOOR IS DELIBERATELY BELOW THE BUDGET. bash's `SECONDS` is an
+    INTEGER that ticks on wall-clock second boundaries, so `deadline=$((SECONDS+N))`
+    can elapse in as little as N-1 seconds of real time. Asserting `>= budget`
+    is an expectation derived from READING the code rather than from what it can
+    do, and it fails ~1 run in 1 (measured: 2.7 s against a 3 s budget). The
+    floor only has to separate "waited" from "stole instantly" (~0.5 s), so a
+    5 s budget with a 3 s floor leaves ~2 s of margin on both sides.
+    """
+    shutil.rmtree(rig.oc_config_dir)
+    rig.oc_config_dir.mkdir()
+    lock = Path(str(rig.oc_config_dir) + ".lock")
+    lock.mkdir()
+    holder = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        (lock / "pid").write_text(f"{holder.pid}\n")
+        started = time.monotonic()
+        r = rig.run(["read the page"], mode="ok",
+                    extra_env={"BROWSER_AGENT_LOCK_BUDGET": "5"})
+        elapsed = time.monotonic() - started
+    finally:
+        holder.kill()
+        holder.wait()
+
+    assert r.returncode == 0, r.stderr
+    assert elapsed >= 3.0, (
+        f"took {elapsed:.1f}s for a 5s budget — a LIVE holder's lock was stolen "
+        "on the fast path, so the pid check cannot tell live from dead")
+
+
+def test_a_lock_with_NO_pid_file_is_not_stolen_on_the_fast_path(rig):
+    """🔴 THE RACE THE FAST PATH MUST NOT WIN. Between another run's `mkdir` and
+    its `echo $$` the lock exists with no pid file. Reading "no pid" as "dead"
+    would steal a lock whose holder is moments from using it. Absent ⇒ wait,
+    which is the pre-existing behaviour and the safe one.
+
+    🔴 THE FLOOR IS DELIBERATELY BELOW THE BUDGET. bash's `SECONDS` is an
+    INTEGER that ticks on wall-clock second boundaries, so `deadline=$((SECONDS+N))`
+    can elapse in as little as N-1 seconds of real time. Asserting `>= budget`
+    is an expectation derived from READING the code rather than from what it can
+    do, and it fails ~1 run in 1 (measured: 2.7 s against a 3 s budget). The
+    floor only has to separate "waited" from "stole instantly" (~0.5 s), so a
+    5 s budget with a 3 s floor leaves ~2 s of margin on both sides.
+    """
+    shutil.rmtree(rig.oc_config_dir)
+    rig.oc_config_dir.mkdir()
+    lock = Path(str(rig.oc_config_dir) + ".lock")
+    lock.mkdir()  # no pid file — mid-acquisition by someone else
+
+    started = time.monotonic()
+    r = rig.run(["read the page"], mode="ok",
+                extra_env={"BROWSER_AGENT_LOCK_BUDGET": "5"})
+    elapsed = time.monotonic() - started
+
+    assert r.returncode == 0, r.stderr
+    assert elapsed >= 3.0, (
+        f"took {elapsed:.1f}s for a 5s budget — a lock with no pid file was "
+        "stolen immediately, which races a holder that has not written its pid yet")

--- a/scripts/browser-bridge/tests/test_browser_agent.py
+++ b/scripts/browser-bridge/tests/test_browser_agent.py
@@ -1533,12 +1533,32 @@ def test_a_run_killed_mid_bootstrap_RELEASES_the_warm_lock(rig):
     rig.oc_config_dir.mkdir()
     lock = Path(str(rig.oc_config_dir) + ".lock")
 
-    proc = rig.spawn(["read the page"], mode="ok")
+    # 🔴 DETERMINISM, not a sleep-to-be-safe. `mode="slow"` makes the fake
+    # opencode sleep INSIDE the warm — which runs UNDER the lock — so the window
+    # in which the wrapper holds it is seconds wide instead of milliseconds. The
+    # first version of these tests raced it: green alone (33 s suite), and under
+    # the full gate (8 m 45 s) the TERM landed AFTER the release, where the
+    # pre-existing `_cleanup_all` trap absorbs it and the run completes rc 0.
+    # 🔴 For the RELEASE test that race was worse than a flake: a TERM after the
+    # release finds the lock already gone, so `not lock.exists()` passes for the
+    # WRONG REASON. The window is what makes either assertion mean anything.
+    #
+    # ⚠ THE SLEEP IS 5 s, NOT 30 s, AND THE BOUND IS BASH's, NOT TASTE. A trap
+    # handler does not run until the current FOREGROUND command returns, and the
+    # wrapper runs the warm's opencode under its own `setsid` — so `killpg` on
+    # OUR group never reaches it and the handler is deferred for the whole sleep.
+    # At 30 s that exceeded `proc.wait()` and read as "the handler never fired".
+    # 5 s is wide enough to make the window deterministic and short enough that
+    # the deferred handler is observed.
+    proc = rig.spawn(["read the page"], mode="slow",
+                     extra_env={"FAKE_OC_SLEEP": "5",
+                                "BROWSER_AGENT_WARM_TIMEOUT": "30"})
     try:
         _await(lambda: lock.is_dir(), what="the wrapper to take the warm lock",
-               slice_s=15.0, poll=0.02)
+               slice_s=20.0, poll=0.02)
+        assert lock.is_dir(), "precondition: the wrapper must HOLD the lock here"
         os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-        proc.wait(timeout=30)
+        proc.wait(timeout=45)
     finally:
         if proc.poll() is None:
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
@@ -1566,12 +1586,32 @@ def test_the_release_handler_EXITS_rather_than_resuming(rig):
     rig.oc_config_dir.mkdir()
     lock = Path(str(rig.oc_config_dir) + ".lock")
 
-    proc = rig.spawn(["read the page"], mode="ok")
+    # 🔴 DETERMINISM, not a sleep-to-be-safe. `mode="slow"` makes the fake
+    # opencode sleep INSIDE the warm — which runs UNDER the lock — so the window
+    # in which the wrapper holds it is seconds wide instead of milliseconds. The
+    # first version of these tests raced it: green alone (33 s suite), and under
+    # the full gate (8 m 45 s) the TERM landed AFTER the release, where the
+    # pre-existing `_cleanup_all` trap absorbs it and the run completes rc 0.
+    # 🔴 For the RELEASE test that race was worse than a flake: a TERM after the
+    # release finds the lock already gone, so `not lock.exists()` passes for the
+    # WRONG REASON. The window is what makes either assertion mean anything.
+    #
+    # ⚠ THE SLEEP IS 5 s, NOT 30 s, AND THE BOUND IS BASH's, NOT TASTE. A trap
+    # handler does not run until the current FOREGROUND command returns, and the
+    # wrapper runs the warm's opencode under its own `setsid` — so `killpg` on
+    # OUR group never reaches it and the handler is deferred for the whole sleep.
+    # At 30 s that exceeded `proc.wait()` and read as "the handler never fired".
+    # 5 s is wide enough to make the window deterministic and short enough that
+    # the deferred handler is observed.
+    proc = rig.spawn(["read the page"], mode="slow",
+                     extra_env={"FAKE_OC_SLEEP": "5",
+                                "BROWSER_AGENT_WARM_TIMEOUT": "30"})
     try:
         _await(lambda: lock.is_dir(), what="the wrapper to take the warm lock",
-               slice_s=15.0, poll=0.02)
+               slice_s=20.0, poll=0.02)
+        assert lock.is_dir(), "precondition: the wrapper must HOLD the lock here"
         os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-        rc = proc.wait(timeout=30)
+        rc = proc.wait(timeout=45)
     finally:
         if proc.poll() is None:
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)


### PR DESCRIPTION
> **This body was rewritten on 2026-09-04.** The original described a pid-file/steal design that
> a round-1 audit found deploy-blocking and that has since been reverted. It is corrected here
> rather than left standing because **a squash merge defaults the commit message to the body**,
> so the reverted design would otherwise land in `main`'s history. The audit trail is intact in
> the two correction comments below — nothing has been hidden, only superseded.

## The defect

`browser-agent` serialises its opencode-config bootstrap on a `mkdir` mutex at
`~/.cache/browser-agent-opencode-config.lock`. It released the lock only on the normal path.

The script's `trap _cleanup_all EXIT INT TERM` is installed **~100 lines below** the call site
that holds the lock, and `_cleanup_all` never touched the lock anyway — so the entire bootstrap
window ran with **no handler**. A run killed there (the common case: this script's own
`--timeout` process-group kill, or a Ctrl-C) orphaned the directory, and every later run then paid
the full `OC_LOCK_BUDGET` (~120s) before the blind steal could clear it.

**MEASURED 2026-09-03:** an orphan left the next `browser-agent --dry-run` still stalled at 300s —
presenting as a hang with no message. The lock is **machine-global**, so it also made a concurrent
agent's unrelated suite fail, and reproduced on `origin/main`, reading as *"main is broken"*.

## The change

Arm `_oc_lock_release` **at acquisition**. Three lines of `trap`, two call-site swaps.

Handlers `exit 130`/`exit 143` rather than returning: a bash trap handler runs and **execution
resumes**, so a release-only handler would turn a TERM into *"released the lock and carried on
bootstrapping unserialised"* — the corruption the lock exists to prevent — and would make
`browser agent` un-interruptible in that window.

`_oc_lock_release` deliberately does **not** disarm the traps. An earlier revision ended with
`trap - EXIT INT TERM`, which looks like symmetry and **swallows a pending signal**: a TERM
delivered while the warm's opencode is the foreground command is deferred, the normal-path release
resets the disposition, and the queued signal is discarded — measured **rc 0 after a TERM**.

## Scope — stated in the source, not just here

🔴 **This closes the ordinary-kill half only.** A SIGKILL runs no trap, so a hard-killed run still
orphans the lock. Detecting that needs the holder's identity in the lock, and **this PR's own
history is the evidence that the naive version is unsafe**: an unowned delete-then-recreate steal
lets two contenders that both judge the holder dead **both acquire** (reproduced). It wants an
atomic primitive — `flock`, whose lock the kernel drops on death — not a pid file bolted onto
`mkdir`.

## Tests

| test | class | evidence |
|---|---|---|
| `test_a_run_killed_mid_bootstrap_RELEASES_the_warm_lock` | **regression** | 12/12 red at `aba48864`, 12/12 green at head |
| `test_the_release_handler_EXITS_rather_than_resuming[TERM,INT]` | **invariant guard** | green both sides; kills the mutants below |

Mutation battery, re-run rather than asserted:

| mutant | result |
|---|---|
| drop `exit 143` (TERM) | killed |
| drop `exit 130` (INT) | killed — **survived the whole suite** before the guard was parametrised |
| delete all three `trap` lines | killed |

Both tests hold the lock window open **deterministically**: the fake's `debug agent` branch (which
is the warm, and runs under the lock) writes a marker and holds, opt-in via `FAKE_OC_DEBUG_SLEEP`
so no other test's behaviour moves. The kill is gated on that marker, not on the lock merely
existing. **0.03s → 3.12s.** An earlier revision asserted a 5s window that did not exist.

The kill is a **process-group** TERM because that is what this script's own timeout path sends, and
because a bare TERM is deferred while bash sits in a foreground command.

`run`'s environment construction is extracted to `_rig_env` with `spawn` built on it
(`start_new_session=True`, so a test can `killpg` without signalling pytest). Behaviour-preserving;
the audit verified the positional signature matches both call sites.

## NOT verified

- **Neither gate tier has run on this branch.** Not `scripts/gate.sh --tier both`, not the sandbox
  derivations, not the merged tree.
- The full `test_browser_agent.py` currently shows one **unattributed** failure
  (`test_gate_passes_when_browser_only`) in a run taking 103s against 20s earlier, on a box at load
  62/24 cores from other agents' suites. It passes alone in 0.56s. Attribution deferred to a quiet
  box rather than guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRZVCFV6DDGs1pZwmCrHJo