### PR TITLE
feat(session-manager): publish an authoritative `repo` per tmux window, resolved on the OWNING host (rank 21)

### DIFF
--- a/claude/skills/session-manager/SKILL.md
+++ b/claude/skills/session-manager/SKILL.md
@@ -33,6 +33,7 @@ column — **how it is counted**) are different, and `caveats.kind_scope` carrie
 | `--no-ch` | skip ClickHouse — drops the **largest non-row block** (17.4 KB below), which answers a different question |
 | `--no-capture` | skip the pane scrape; **every** `waiting_probable` AND `unsent_prompt` becomes `null` (both roll-ups `null`, never `0`) |
 | `--no-ledger` | skip the ledger read → **no age, no session id** on any row |
+| `--no-repo` | skip the per-host repo probe; every `repo` becomes `null` with `repo_status: skipped` — never `not_a_repo` |
 | `--fuzzyclaw` | the task-file join, **OFF by default** (see below) |
 
 `--json`, `--no-fuzzyclaw`, `--plain`, `--stale-threshold`, `--lines`, and what each drops:

--- a/claude/skills/session-manager/reference/payload-contract.md
+++ b/claude/skills/session-manager/reference/payload-contract.md
@@ -227,6 +227,46 @@ repo resolve to the SAME label, so quote both. New non-scratch sessions get a re
 at creation from `scripts/tmux-autoname-session.sh`; `label` is what covers the ones that
 predate it.
 
+## 🔴 `repo` — the PROJECT key, and it is not `label`
+
+`label` answers "where is this" for an OPERATOR (the leaf of the cwd, or a codename).
+`repo` answers "which project is this" for a CONSUMER: the **MAIN CLONE** of the pane's
+cwd, so **every linked worktree of a repo carries ONE name**. That is a thing no string
+operation on `path` can produce — a worktree called `clawgate-extension` is a worktree of
+`homelab-talos`, and `ht-r11-930492` is not derivable from `homelab-talos` at all.
+
+Its consumer is clawgate's tmux page, whose `projectOf()` prefers `repo` when non-empty,
+falls back to the LEAF of `path`, then to `Other`. Before this field existed the leaf won
+every time, so each worktree formed its own project group.
+
+🔴 **IT IS RESOLVED ON THE HOST THAT OWNS THE DIRECTORY**, by one batched `sh -c` per host
+over the same SSH transport as the tmux calls — `git rev-parse --path-format=absolute
+--git-common-dir`, whose parent directory is the main clone. Roughly half these rows come
+off the laptop, and a LOCAL `git rev-parse` would answer about whatever happens to sit at
+that path on the workbench, or about nothing. `--show-toplevel` is the wrong flag: on a
+linked worktree it returns the worktree itself, so it cannot group two worktrees at all.
+
+🔴 **`repo_status` IS WHAT MAKES A NULL `repo` READABLE.** Never read a null as "not in a
+repo" without it:
+
+| `repo_status` | means |
+|---|---|
+| `ok` | resolved; `repo` names the main clone. The ONLY status carrying a name. |
+| `not_a_repo` | MEASURED: the owning host says this path is not in a work tree (or its common dir cannot be honestly named — a bare repo, a submodule). |
+| `home` | MEASURED and deliberately withheld: the main clone IS the owning host's `$HOME`. `projectOf()` routes an unparented shell to `Other`, and `repo` is the branch it PREFERS, so a name here would override that guard. |
+| `no_path` | the pane reported no cwd. |
+| `missing` | the probe answered for this host but not for this path (a partial reply). |
+| `unmeasured` | **nobody looked** — the probe failed, timed out, or came back without its sentinel. NOT a measured absence. |
+| `skipped` | `--no-repo`. |
+
+Per host, `repos_measured` / `repos_status` / `repos_error` / `repos_paths` /
+`repos_resolved` / `repos_unparseable` are the FOURTH independent measurement beside
+`reachable`, `windows_measured` and `captures_measured`. The counts are integers only when
+`repos_measured` is true; otherwise they are null, never 0.
+
+Measured on the live fleet 2026-09-03: 90 of 92 windows resolved (laptop 31/32, workbench
+59/60); the two that did not are `/home/zach` and a non-repo directory, both `not_a_repo`.
+
 ## The caveats are in the OUTPUT, not just in this file
 
 `report["caveats"]` (structured) + one footer line each in the table, printed

--- a/claude/skills/session-manager/reference/payload-contract.md
+++ b/claude/skills/session-manager/reference/payload-contract.md
@@ -22,6 +22,7 @@ _Moved verbatim out of `SKILL.md` on 2026-08-21, when the body was cut from 23,2
 | `--pane-preview` | publish each Claude pane's **visible screen** as `pane_preview`. Costs no extra tmux work (the capture already runs — `waiting`/`unsent` are derived from it and it used to throw the screen away), but makes the document **2.63x** larger: measured live back to back, 122,731 B without / 322,204 B with. Off by default for that reason; `--lean` drops it, so do not pass both |
 | `--fuzzyclaw` / `--no-fuzzyclaw` | the task-file join is **OFF by default** (see below) |
 | `--no-ledger` | skip the per-host agent-ledger read. Rows then have **no age and no session id** — the #419 view, reproducible on demand |
+| `--no-repo` | skip the per-host repo probe (one batched `sh -c` per host, the FIFTH ssh call). Every row's `repo` becomes `null` with `repo_status: **skipped**` and every per-host `repos_*` count becomes `null` — never `not_a_repo`, never `0`. This is the cost control for the probe; the field is otherwise ON by default |
 | `--plain` | `tail` only: strip ANSI at the source instead of `sed`-ing it out |
 | `--stale-threshold <secs>` | default 3600; `age >= threshold` is stale |
 | `--lines N` | `tail` scrollback depth (default 100) |
@@ -252,17 +253,30 @@ repo" without it:
 | `repo_status` | means |
 |---|---|
 | `ok` | resolved; `repo` names the main clone. The ONLY status carrying a name. |
-| `not_a_repo` | MEASURED: the owning host says this path is not in a work tree (or its common dir cannot be honestly named — a bare repo, a submodule). |
+| `not_a_repo` | MEASURED: the owning host's `git` exited **128** for this path — it is not in a work tree (or its common dir cannot be honestly named: a bare repo, a submodule). 🔴 It requires that exit status. Until 2026-09-04 every OTHER failure — `git` timing out, `git` absent, an unknown flag — arrived here too, so a real repo could read as a measured absence. |
 | `home` | MEASURED and deliberately withheld: the main clone IS the owning host's `$HOME`. `projectOf()` routes an unparented shell to `Other`, and `repo` is the branch it PREFERS, so a name here would override that guard. |
 | `no_path` | the pane reported no cwd. |
-| `missing` | the probe answered for this host but not for this path (a partial reply). |
-| `unmeasured` | **nobody looked** — the probe failed, timed out, or came back without its sentinel. NOT a measured absence. |
+| `missing` | the probe answered for this host but not for this path — a partial reply, or a record refused because it carried a character `str.splitlines()` would treat as a line break. |
+| `unmeasured` | **nobody looked.** TWO granularities, and both are real: the whole HOST's probe failed / timed out / came back without its sentinel, **or** THIS path's `git` exited non-zero for a reason that is not 128 (the per-path `timeout` fired, `git` is not installed, the flag is unsupported). NOT a measured absence either way. |
 | `skipped` | `--no-repo`. |
 
 Per host, `repos_measured` / `repos_status` / `repos_error` / `repos_paths` /
 `repos_resolved` / `repos_unparseable` are the FOURTH independent measurement beside
 `reachable`, `windows_measured` and `captures_measured`. The counts are integers only when
 `repos_measured` is true; otherwise they are null, never 0.
+
+🔴 **A host can be honestly `repos_measured: true` while one of its ROWS is `unmeasured`,
+and reading only the host block hides that.** The probe answering is a fact about the
+probe; each path's `git` exit status is a separate fact about that path.
+`repos_resolved` counts `ok` rows and nothing else, so a per-path `unmeasured` can never
+inflate it — but `repos_paths - repos_resolved` is **not** a count of non-repo panes.
+
+🔴 **The whole collection is bounded by `COLLECT_BUDGET` (70 s), not by the per-call
+timeouts.** `tmux-snapshot-push.sh` wraps the collector in `timeout 90`, and rc 124 there
+is `exit 3` — no snapshot for EITHER host. Five reads per host plus the ClickHouse query
+sum past that, so a read with no budget left is **not attempted** and its host reports
+`unmeasured` with an error naming the budget. That is a read that did not happen, and it
+is published as one.
 
 Measured on the live fleet 2026-09-03: 90 of 92 windows resolved (laptop 31/32, workbench
 59/60); the two that did not are `/home/zach` and a non-repo directory, both `not_a_repo`.

--- a/claude/skills/session-manager/reference/payload-contract.md
+++ b/claude/skills/session-manager/reference/payload-contract.md
@@ -278,14 +278,18 @@ sum past that, so a read with no budget left is **not attempted** and its host r
 `unmeasured` with an error naming the budget. That is a read that did not happen, and it
 is published as one. *(Both numbers above are pinned to `COLLECT_BUDGET` / `COLLECT_CAP` by
 `test_the_contract_docs_budget_numbers_are_PINNED_to_the_constants`; the count of five
-reads and their ORDER are pinned by
-`test_the_per_host_call_ORDER_puts_the_optional_probe_LAST`.)*
+reads and their ORDER by
+`test_the_repo_probe_is_issued_AFTER_every_other_read_on_every_host`.)*
 
-🔴 **ORDER MATTERS AND IT IS PART OF THE CONTRACT.** The reads share one deadline, so the
-LAST call on the LAST host is the one that starves. The **agent ledger is read before the
-repo probe**, because the probe is the optional one (`--no-repo`) while a starved ledger
-costs every row on that host `age_secs`, its `stale` bucket and `claude_session_id`. With
-both hosts at their bounds, the laptop's `repo` is the field that is dropped — deliberately.
+🔴 **ORDER MATTERS AND IT IS PART OF THE CONTRACT.** One deadline spans ALL hosts, so the
+LAST call issued is the one that starves. The repo probe is therefore a **second pass over
+the hosts**: every pre-existing read — panes, windows, capture, ledger — is issued for
+EVERY host before the probe is issued for ANY host. The probe is the read a consumer can
+turn off (`--no-repo`) with the payload still whole, while a starved ledger silently costs
+every row on that host `age_secs`, its `stale` bucket and `claude_session_id`. Moving the
+probe later *within* a host is not enough and was measured so: the local host's own 15 s
+probe alone pushed the remote host past the deadline. With both hosts at their bounds it is
+the laptop's `repo` that is dropped — deliberately.
 
 ⚠ **There is no current fleet measurement of the resolve rate.** The only one taken (90 of
 92 windows, 2026-09-03) was measured under protocol **V1**, which collapsed every `git`

--- a/claude/skills/session-manager/reference/payload-contract.md
+++ b/claude/skills/session-manager/reference/payload-contract.md
@@ -281,6 +281,17 @@ is published as one. *(Both numbers above are pinned to `COLLECT_BUDGET` / `COLL
 reads and their ORDER by
 `test_the_repo_probe_is_issued_AFTER_every_other_read_on_every_host`.)*
 
+🔴 **The ClickHouse read's own timeout is CLAMPED to `COLLECT_CH_RESERVE` (15 s), and the
+clamp is PUBLISHED.** `CHConn.from_env` resolves `CLICKHOUSE_HTTP_TIMEOUT` out of the
+collector's per-HOST env file, so an operator can configure a value the budget arithmetic
+cannot afford — and this is the one place in the collector that CHANGES a number instead of
+measuring one. `clickhouse.timeout_secs` is what the read actually ran with;
+`clickhouse.timeout_clamped_from` is the configured value it was reduced FROM, and is
+**`null` when nothing was reduced**. Both are `null` when no client carrying a timeout was
+built (`skipped`, `unavailable`, an injected double) — unmeasured, which is not the same
+claim as "not clamped". Without them a 60 s setting produced a 15 s read that read as an
+ordinary ClickHouse timeout, and the operator debugs ClickHouse.
+
 🔴 **ORDER MATTERS AND IT IS PART OF THE CONTRACT.** One deadline spans ALL hosts, so the
 LAST call issued is the one that starves. The repo probe is therefore a **second pass over
 the hosts**: every pre-existing read — panes, windows, capture, ledger — is issued for

--- a/claude/skills/session-manager/reference/payload-contract.md
+++ b/claude/skills/session-manager/reference/payload-contract.md
@@ -253,11 +253,11 @@ repo" without it:
 | `repo_status` | means |
 |---|---|
 | `ok` | resolved; `repo` names the main clone. The ONLY status carrying a name. |
-| `not_a_repo` | MEASURED: the owning host's `git` exited **128** for this path — it is not in a work tree (or its common dir cannot be honestly named: a bare repo, a submodule). 🔴 It requires that exit status. Until 2026-09-04 every OTHER failure — `git` timing out, `git` absent, an unknown flag — arrived here too, so a real repo could read as a measured absence. |
+| `not_a_repo` | MEASURED: `git` ANSWERED for this path and what it answered does not name a clone. 🔴 **TWO exit statuses reach it, not one** — **128** (git: not in a work tree) *and* **0 with a common dir whose parent is not a clone root** (empty, a bare repo `/srv/foo.git`, a submodule `<super>/.git/modules/<n>`); naming those would publish a confident wrong group, so they fail soft here. This cell used to say it "requires" 128, which contradicted its own parenthetical and was measured false. What it excludes is a **failure** to measure: until 2026-09-04 `git` timing out, `git` absent or an unknown flag arrived here too, so a real repo could read as a measured absence. |
 | `home` | MEASURED and deliberately withheld: the main clone IS the owning host's `$HOME`. `projectOf()` routes an unparented shell to `Other`, and `repo` is the branch it PREFERS, so a name here would override that guard. |
 | `no_path` | the pane reported no cwd. |
-| `missing` | the probe answered for this host but not for this path — a partial reply, or a record refused because it carried a character `str.splitlines()` would treat as a line break. |
-| `unmeasured` | **nobody looked.** TWO granularities, and both are real: the whole HOST's probe failed / timed out / came back without its sentinel, **or** THIS path's `git` exited non-zero for a reason that is not 128 (the per-path `timeout` fired, `git` is not installed, the flag is unsupported). NOT a measured absence either way. |
+| `missing` | the probe answered for this host but not for this path — a partial reply, or a record refused because it carried a character `str.splitlines()` would treat as a line break. 🔴 Such a record also **poisons every record after it**: once a non-`\n` line break is inside a record, no later boundary in that reply is knowable, so the rest of the host's paths are `missing` too. Honest and bounded — never a wrong name. |
+| `unmeasured` | **nobody looked.** TWO granularities, and both are real: the whole HOST's probe failed / timed out / came back without its sentinel, **or** THIS path's `git` exited non-zero for a reason that is not 128 — the per-path `timeout` fired (124), `git` is not installed (127), the flag is unsupported (129), or the probe itself **refused to transmit** a common dir containing a newline (**201**, `REPO_PROBE_RC_NEWLINE` — see `missing` for the sibling case the parser refuses). NOT a measured absence either way. |
 | `skipped` | `--no-repo`. |
 
 Per host, `repos_measured` / `repos_status` / `repos_error` / `repos_paths` /
@@ -276,10 +276,22 @@ timeouts.** `tmux-snapshot-push.sh` wraps the collector in `timeout 90`, and rc 
 is `exit 3` — no snapshot for EITHER host. Five reads per host plus the ClickHouse query
 sum past that, so a read with no budget left is **not attempted** and its host reports
 `unmeasured` with an error naming the budget. That is a read that did not happen, and it
-is published as one.
+is published as one. *(Both numbers above are pinned to `COLLECT_BUDGET` / `COLLECT_CAP` by
+`test_the_contract_docs_budget_numbers_are_PINNED_to_the_constants`; the count of five
+reads and their ORDER are pinned by
+`test_the_per_host_call_ORDER_puts_the_optional_probe_LAST`.)*
 
-Measured on the live fleet 2026-09-03: 90 of 92 windows resolved (laptop 31/32, workbench
-59/60); the two that did not are `/home/zach` and a non-repo directory, both `not_a_repo`.
+🔴 **ORDER MATTERS AND IT IS PART OF THE CONTRACT.** The reads share one deadline, so the
+LAST call on the LAST host is the one that starves. The **agent ledger is read before the
+repo probe**, because the probe is the optional one (`--no-repo`) while a starved ledger
+costs every row on that host `age_secs`, its `stale` bucket and `claude_session_id`. With
+both hosts at their bounds, the laptop's `repo` is the field that is dropped — deliberately.
+
+⚠ **There is no current fleet measurement of the resolve rate.** The only one taken (90 of
+92 windows, 2026-09-03) was measured under protocol **V1**, which collapsed every `git`
+failure into `not_a_repo` — i.e. under the exact bug the rc field was added to fix — so its
+`not_a_repo` counts are not comparable to what V2 publishes. It has been struck rather than
+carried forward; re-measure under V2 before quoting a rate.
 
 ## The caveats are in the OUTPUT, not just in this file
 

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -3470,9 +3470,10 @@ in
   #
   # ⚠ THE PER-RUN COST IS MORE THAN ONE SSH, and this comment used to say "~720
   # ssh round trips a day" as though it were. `session-manager --json` makes up
-  # to FOUR ssh invocations to the laptop per run (list-panes, list-windows, the
-  # capture batch, the ledger read) with no ControlMaster, so it is nearer
-  # ~2,880 handshakes/day; it also runs one ClickHouse query per run (~720/day),
+  # to FIVE ssh invocations to the laptop per run (list-panes, list-windows, the
+  # capture batch, the repo probe, the ledger read) with no ControlMaster, so it
+  # is nearer ~3,600 handshakes/day; it also runs one ClickHouse query per run
+  # (~720/day),
   # which the old figure omitted entirely. Store side: ~720 upserts/day of
   # ~100 KB jsonb onto a two-row table, i.e. real TOAST/WAL churn for data that
   # currently has no reader. If that cost ever matters, `--lean` is the lever —

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -201,11 +201,32 @@ and the roll-ups a caller usually wants are:
                                         which skill owns each
 
 Each row carries: kind, host, session, window_index, window_id, window_name,
-codename, label, label_source, hotkey, hotkey_display, pane_id, path, command,
+codename, label, label_source, hotkey, hotkey_display, pane_id, path, repo,
+repo_status, command,
 task, claude, busy, age_secs, age_source, status, waiting_probable,
 waiting_signals, waiting_status, unsent_prompt, unsent_prompt_status,
 pane_preview, pane_preview_status, claude_session_id, runtime, ledger,
 fuzzyclaw, panes. The row ledger is pinned by a test.
+
+🔴 `repo` IS THE PROJECT KEY, AND IT IS RESOLVED ON THE HOST THAT OWNS THE
+DIRECTORY
+---------------------------------------------------------------------------
+`label` answers "where is this" for an operator: the LEAF of the pane's cwd, or
+a scratch-slot codename. `repo` answers "which project is this" for a consumer:
+the MAIN CLONE, via `git rev-parse --git-common-dir` — so every linked worktree
+of a repo carries ONE name and they group together. `--show-toplevel` cannot do
+this (it returns the worktree itself), and no string operation on `path` can
+either: `ht-r11-930492` is not derivable from `homelab-talos`.
+
+It is resolved by ONE batched `sh -c` per host over the same SSH transport as
+the tmux calls, because half these rows come off the laptop and a local
+`git rev-parse` would answer about whatever sits at that path HERE. `repo_status`
+carries the provenance — `ok`, `not_a_repo`, `home`, `no_path`, `missing`,
+`unmeasured`, `skipped` — so a null `repo` never reads as "not in a repo" when
+nothing was measured. `$HOME` is deliberately NOT a project (`home`): the
+consumer routes an unparented shell to `Other`, and `repo` is the branch it
+prefers, so emitting one here would override that guard. See `REPO_STATUSES`,
+`REPO_PROBE_SCRIPT` and per host `repos_measured` / `repos_status`.
 
 🔴 `waiting_probable` AND `unsent_prompt` ARE TWO SIGNALS, NOT ONE
 --------------------------------------------------------------------------
@@ -433,6 +454,107 @@ TMUX_PANES_ARGV = ("tmux", "list-panes", "-a", "-F", PANE_FORMAT)
 # across a reboot (the laptop's server sits at pid 2509).
 WINDOW_FORMAT = "#{window_id}|#{window_index}|#{pid}|#{start_time}|#{session_name}"
 TMUX_WINDOWS_ARGV = ("tmux", "list-windows", "-a", "-F", WINDOW_FORMAT)
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE REPO PROBE — ONE BATCHED CALL PER HOST, RUN ON THE HOST THAT OWNS THE
+# DIRECTORY.
+# --------------------------------------------------------------------------- #
+# `label_from_path` states the constraint this exists to honour: a pane's `path`
+# is A STRING FROM ANOTHER MACHINE, so a LOCAL `git rev-parse` against it would
+# answer about whatever happens to sit at that path on THIS host, or about
+# nothing. Half these rows come off the laptop. So the resolution travels over
+# the same `run_tmux` seam the tmux calls already use and runs where the
+# directory lives.
+#
+# 🔴 `--git-common-dir`, NOT `--show-toplevel`. Measured 2026-09-03 on the
+# workbench: for a LINKED WORKTREE, `--show-toplevel` returns the worktree
+# itself, so it does not resolve the very case this feature exists for — two
+# worktrees of one repo would still form two groups. `--git-common-dir` returns
+# the MAIN clone's git dir from every worktree of a repo:
+#   /home/zach/workspace/devrc-agentlock            -> /home/zach/workspace/devrc/.git
+#   <repo>/.claude/worktrees/agent-a9b63c26c9c44cd46 -> /home/zach/workspace/devrc/.git
+#   <repo>/scripts (a plain subdir)                  -> /home/zach/workspace/devrc/.git
+#   /tmp, /home/zach                                 -> exit 128, no output
+# `--path-format=absolute` is load-bearing: without it the answer is relative to
+# the queried directory and `os.path.dirname` names the wrong thing.
+#
+# 🔴 ONE INVOCATION FOR THE WHOLE HOST. `WINDOW_FORMAT`'s comment records that
+# `list-windows` was folded into an existing call rather than costing a fifth
+# SSH round trip, because the pusher already makes up to four per run with no
+# ControlMaster. This is that fifth call, so it is batched: every unique path on
+# a host goes into ONE `sh -c`. N round trips for N panes was never on the table.
+#
+# 🔴 PATHS ARRIVE AS POSITIONAL PARAMETERS, NEVER INTERPOLATED INTO THE SCRIPT.
+# `sh -c <script> <argv0> path...` puts them in `"$@"`, so the script TEXT is a
+# constant and a path containing `;`, `$(…)`, a backtick, a quote or a newline
+# is data. Verified 2026-09-03 through the real `ssh_wrap`/`shlex.join` path
+# against `/tmp/we ird;$(echo pwned)`id`` — empty result, nothing executed.
+#
+# 🔴 THE OUTPUT IS KEYED BY INPUT INDEX, NOT BY ECHOING THE PATH BACK. A path
+# holding a tab or a newline would corrupt a `path<TAB>repo` line format; a
+# 1-based sequence number cannot. A line whose first field is not an integer is
+# counted `unparseable` and the rest still align.
+#
+# 🔴 THE SENTINEL CARRIES THE HOST'S OWN `$HOME`, and that coupling is the same
+# one-call-one-instant argument `agent_ledger.read_command` makes for the tmux
+# pid. It is the POSITIVE CONTROL — without it, "the probe ran and no pane is in
+# a repo" and "something swallowed the output" are the same empty bytes — AND it
+# is the value `repo_from_common_dir` needs to refuse to name `$HOME` as a
+# project. It must be the OWNING host's `$HOME`, which is exactly what a local
+# `HOME` constant could not supply for a laptop row.
+REPO_PROBE_SENTINEL = "SM_REPO_V1"
+REPO_PROBE_SCRIPT = (
+    'echo "%s $HOME"\n'
+    # `timeout` is coreutils and present on both hosts, but a probe that dies
+    # on a host without it would take the whole host's repo field with it. The
+    # unquoted `$T` word-splits, which is the intent and is POSIX sh behaviour
+    # (this runs under `sh`, never zsh — see RULES.md on zsh not splitting).
+    'if command -v timeout >/dev/null 2>&1; then T="timeout 3"; else T=""; fi\n'
+    'n=0\n'
+    'for p do\n'
+    '  n=$((n+1))\n'
+    '  d=$($T git -C "$p" rev-parse --path-format=absolute '
+    '--git-common-dir 2>/dev/null) || d=""\n'
+    '  printf \'%%s\\t%%s\\n\' "$n" "$d"\n'
+    'done\n'
+    'exit 0\n' % REPO_PROBE_SENTINEL)
+# Its own budget, above SSH_TIMEOUT: this call fans out over every unique path
+# on the host and each `git` is bounded at 3s by the script itself, so the
+# worst realistic case is slower than a single `list-panes`. The pusher's own
+# 90s cap still bounds the whole run.
+REPO_PROBE_TIMEOUT = 25.0
+
+# 🔴 THE PER-ROW DISCRIMINANT, enumerated here so a consumer can branch on the
+# set and a test can assert it is exactly this — the same contract
+# `WAITING_STATUSES` / `UNSENT_STATUSES` / `PREVIEW_STATUSES` carry.
+#
+# `repo` is `None` on every status except `ok`. The four not-`ok`-not-`null`
+# reasons are NOT interchangeable, and collapsing any of them into "no repo"
+# republishes the silent zero this whole file exists to refuse:
+#
+#   ok           — resolved; `repo` names the MAIN clone of the pane's cwd.
+#   not_a_repo   — MEASURED: the owning host says this path is not inside a git
+#                  work tree (or its common dir cannot honestly be named — a
+#                  bare repo, a submodule's `…/.git/modules/<n>`). A real
+#                  measured absence.
+#   home         — MEASURED, and deliberately withheld. The resolved main clone
+#                  IS the owning host's `$HOME`. `projectOf()` in clawgate
+#                  routes `/home/zach` and `/root` to `Other` precisely so every
+#                  unparented shell does not form a project called `zach`;
+#                  publishing a `repo` here would OVERRIDE that guard from the
+#                  producer side, because `repo` is the branch it prefers.
+#   no_path      — the pane reported no cwd, so there was nothing to resolve.
+#   missing      — the probe answered for this host but not for THIS path (a
+#                  truncated or partial reply). Measured host, unmeasured path.
+#   unmeasured   — the probe did not answer on this host at all: it failed,
+#                  timed out, found no shell, or came back without its
+#                  sentinel. 🔴 THIS MUST NEVER RENDER AS `not_a_repo`. A failed
+#                  resolution that looked like a measurement would tell a reader
+#                  "none of these panes is in a repo" about a look that never
+#                  happened.
+#   skipped      — `--no-repo`. Nothing was asked.
+REPO_STATUSES = ("ok", "not_a_repo", "home", "no_path", "missing",
+                 "unmeasured", "skipped")
 
 FUZZYCLAW_DIR = os.path.join(HOME, ".tmux", "tasks")
 SCRATCH_SLOTS_DEPLOYED = os.path.join(HOME, ".config", "tmux", "scratch-slots.sh")
@@ -1451,6 +1573,174 @@ def label_from_path(path, home=None):
     return os.path.basename(p) or None
 
 
+# --------------------------------------------------------------------------- #
+# REPO RESOLUTION — pure; the impure half is one `run_tmux` call per host
+# --------------------------------------------------------------------------- #
+def repo_probe_argv(paths):
+    """The ONE argv that resolves every path on a host. PURE.
+
+    `("sh", "-c", REPO_PROBE_SCRIPT, "sm-repo-probe", *paths)` — the script text
+    is a CONSTANT and the paths are positional parameters, so nothing a path
+    contains can become shell syntax. `ssh_wrap`'s `shlex.join` then quotes the
+    whole argv for the remote hop, exactly as it does for the tmux format
+    string.
+
+    `"sm-repo-probe"` is `$0`: `sh -c` consumes the first operand as the shell's
+    own name, so omitting it would silently eat the FIRST PATH. It is spelled as
+    a recognisable name rather than `sh` so it is identifiable in a `ps` on
+    either host.
+    """
+    return ("sh", "-c", REPO_PROBE_SCRIPT, "sm-repo-probe", *[str(p) for p in paths])
+
+
+def parse_repo_probe(raw, paths) -> dict:
+    """Probe stdout -> `{"measured", "home", "common_dirs", "seen", "unparseable"}`.
+
+    `common_dirs` is `{path: common_dir_or_None}`, keyed back to the INPUT list
+    by the 1-based sequence number each line carries.
+
+    🔴 `measured` IS THE POSITIVE CONTROL and it comes off the sentinel, never
+    off the row count. A host whose panes are all outside a work tree and a host
+    whose probe was swallowed both produce output with no common dirs in it;
+    only the sentinel tells them apart. When `measured` is False, `home` is None
+    and `common_dirs` is empty — the caller must publish `unmeasured`, never
+    `not_a_repo`.
+
+    🔴 A SENTINEL WITH NO `$HOME` IS NOT A SENTINEL. The home is half the
+    protocol, not a bonus field: without it `repo_from_common_dir` cannot refuse
+    to name `$HOME` as a project, and the honest options are then "publish a
+    repo called `zach` for every unparented shell" or "carry a guard that can
+    never fire". Both are worse than declining the whole host, so a bare
+    sentinel is `measured: False` — the caller publishes `unmeasured`, and the
+    guard downstream has no unreachable branch.
+
+    A line whose first field is not an integer, or whose index is outside the
+    input list, is counted `unparseable` and skipped. That is the disposition a
+    common dir containing a newline lands in: it costs that one path its answer
+    and leaves every other index correct.
+    """
+    lines = (raw or "").splitlines()
+    head = next((ln for ln in lines
+                 if ln.strip().split(None, 1)[:1] == [REPO_PROBE_SENTINEL]),
+                None)
+    unmeasured = {"measured": False, "home": None, "common_dirs": {},
+                  "seen": None, "unparseable": None}
+    if head is None:
+        return unmeasured
+    parts = head.strip().split(None, 1)
+    home = parts[1] if len(parts) > 1 else ""
+    if not home:
+        return unmeasured
+    paths = list(paths)
+    out, seen, unparseable = {}, 0, 0
+    started = False
+    for line in lines:
+        if not started:
+            started = line is head
+            continue
+        if not line.strip():
+            continue
+        seen += 1
+        idx, sep, common = line.partition("\t")
+        if not sep or not idx.strip().isdigit():
+            unparseable += 1
+            continue
+        i = int(idx.strip()) - 1
+        if i < 0 or i >= len(paths):
+            unparseable += 1
+            continue
+        out[paths[i]] = common.strip() or None
+    return {"measured": True, "home": home, "common_dirs": out,
+            "seen": seen, "unparseable": unparseable}
+
+
+def repo_from_common_dir(common_dir, home) -> dict:
+    """`git rev-parse --git-common-dir` output -> `{"repo", "status"}`. PURE.
+
+    `status` is one of `REPO_STATUSES`; `repo` is a name only when `ok`.
+
+    🔴 THE MAIN CLONE IS THE PARENT OF THE COMMON DIR, and that is the whole
+    mechanism. Every linked worktree of a repo reports the SAME common dir —
+    the main clone's `.git` — so two worktrees resolve to one name, which is the
+    grouping this exists to fix. The leaf of the pane's own path cannot do that:
+    `ht-r11-930492` is not derivable from any string operation on
+    `homelab-talos`, and guessing is worse than the honest split.
+
+    🔴 IT ONLY NAMES A REPO WHEN THE COMMON DIR IS LITERALLY `.git`. A bare repo
+    (`/srv/foo.git`) and a submodule (`<super>/.git/modules/<name>`) both have a
+    common dir whose parent is NOT a clone root — `/srv` and `<super>/.git/modules`
+    — so naming one would publish a confident wrong group. `not_a_repo` instead:
+    fail soft, never guess.
+
+    🔴 `$HOME` IS NOT A PROJECT, and this is the producer-side half of a guard
+    that already exists in the consumer. `projectOf()` routes `/home/zach` and
+    `/root` to `Other` so an unparented shell does not form a project called
+    `zach` — but `repo` is the branch `projectOf()` prefers, so a `repo` emitted
+    here would OVERRIDE it. `home` must therefore be the OWNING host's `$HOME`
+    (it arrives on the probe's sentinel line), never this process's — and it is
+    REQUIRED, with no default, because `parse_repo_probe` refuses a sentinel
+    that carries none. A default of `None` would make this guard skippable, and
+    a guard that can be skipped by forgetting an argument is the one that gets
+    skipped.
+    """
+    d = (common_dir or "").strip()
+    if not d:
+        return {"repo": None, "status": "not_a_repo"}
+    d = d.rstrip("/") or "/"
+    if os.path.basename(d) != ".git":
+        return {"repo": None, "status": "not_a_repo"}
+    root = os.path.dirname(d)
+    if os.path.normpath(root) == os.path.normpath(home):
+        return {"repo": None, "status": "home"}
+    name = os.path.basename(root.rstrip("/"))
+    if not name:
+        return {"repo": None, "status": "not_a_repo"}
+    return {"repo": name, "status": "ok"}
+
+
+def build_repo_index(parsed, paths) -> dict:
+    """`{path: {"repo", "status"}}` for a host whose probe was MEASURED.
+
+    Returning `None` for an unmeasured host is the CALLER's job, and it is the
+    discriminant: `fold_windows` renders `repo_index=None` as `unmeasured` on
+    every row of that host. Handing back a dict of `not_a_repo` entries instead
+    would publish a failed probe as a measurement, which is the one substitution
+    this file exists to refuse.
+    """
+    if not parsed.get("measured"):
+        return None
+    home = parsed.get("home")
+    common = parsed.get("common_dirs") or {}
+    out = {}
+    for p in paths:
+        if p not in common:
+            # The probe answered for this host, and did not answer for this
+            # path. Its own status — not folded into `not_a_repo`.
+            out[p] = {"repo": None, "status": "missing"}
+        else:
+            out[p] = repo_from_common_dir(common[p], home=home)
+    return out
+
+
+def row_repo(path, repo_index, host_status="unmeasured") -> dict:
+    """One row's `{"repo", "repo_status"}`. PURE, and the ONE writer of the pair.
+
+    `repo_index is None` means the host's probe did not answer (or was not run):
+    every row gets `host_status` — `unmeasured` or `skipped` — and a null repo.
+    A dict means it DID answer, so a null repo there carries a measured reason.
+    """
+    if not (path or "").strip():
+        # Asked-or-not, there was nothing to resolve. This beats the host
+        # status because it is a fact about the PANE, not about the probe.
+        return {"repo": None, "repo_status": "no_path"}
+    if repo_index is None:
+        return {"repo": None, "repo_status": host_status}
+    hit = repo_index.get(path)
+    if hit is None:
+        return {"repo": None, "repo_status": "missing"}
+    return {"repo": hit.get("repo"), "repo_status": hit.get("status")}
+
+
 def resolve_label(session, path, slots=None, home=None) -> dict:
     """`{"label": str, "label_source": one of LABEL_SOURCES, "hotkey": str|None}`.
 
@@ -2174,7 +2464,8 @@ def fold_windows(panes, host, slots=None, task_index=None,
                  threshold=DEFAULT_STALE_THRESHOLD, now=None,
                  slot_window_ids=None, captures=None,
                  capture_status="skipped", ledger_index=None,
-                 pane_preview=False) -> list:
+                 pane_preview=False, repo_index=None,
+                 repo_status="unmeasured") -> list:
     """Collapse panes into one row per (session, window_index).
 
     A window is `claude` if ANY of its panes is; the row's task/busy/pane_id
@@ -2236,6 +2527,14 @@ def fold_windows(panes, host, slots=None, task_index=None,
     fact, not the host's. A non-Claude row is `not_claude`: only Claude panes are
     captured, so `waiting_probable: False` on a bare zsh would be a verdict
     about a pane nobody looked at.
+
+    🔴 `repo_index` IS `None`-VS-`{}` FOR THE SAME REASON, one signal over.
+    `None` means this host's repo probe did not answer (or was not run), so
+    every row is `repo_status: repo_status` (`unmeasured` / `skipped`) with a
+    null `repo`. A dict means it DID answer, so a null `repo` there is a
+    MEASUREMENT — `not_a_repo`, `home` or `no_path` — and says which. The
+    resolution itself happened on the host that OWNS the directory; see
+    `REPO_PROBE_SCRIPT` for why it cannot happen here.
     """
     now = time.time() if now is None else now
     slots = slots or {}
@@ -2274,6 +2573,8 @@ def fold_windows(panes, host, slots=None, task_index=None,
         busy = busy_from_title(lead.get("title", ""))
         is_claude = any(pane_is_claude(p) for p in members)
         lab = resolve_label(session, lead.get("path", ""), slots)
+        rep = row_repo(lead.get("path", ""), repo_index,
+                       host_status=repo_status)
         # 🔴 The waiting fields, resolved through the None-vs-{} distinction
         # above. `probable` is None on every path where nothing was scraped.
         #
@@ -2349,6 +2650,23 @@ def fold_windows(panes, host, slots=None, task_index=None,
             "hotkey_display": hotkey_display(lab["hotkey"]),
             "pane_id": lead.get("pane_id"),
             "path": lead.get("path", ""),
+            # 🔴 THE AUTHORITATIVE PROJECT KEY, RESOLVED ON THE OWNING HOST.
+            # `label` answers "where is this" for an OPERATOR and is the leaf of
+            # the cwd; `repo` answers "which project is this" for a CONSUMER and
+            # is the MAIN CLONE, so every worktree of one repo carries one name.
+            # They are different questions and neither replaces the other — a
+            # pane three directories deep gets a useless `label` and a correct
+            # `repo`, and a scratch slot's codename beats the cwd for `label`
+            # while never touching `repo`.
+            #
+            # 🔴 `repo_status` MAKES THE NULL READABLE, the same pair
+            # `unsent_prompt`/`unsent_prompt_status` is. `null` + `not_a_repo`
+            # is "the owning host looked and this path is not in a work tree";
+            # `null` + `unmeasured` is "nobody looked". A consumer that reads
+            # the first as the second — or the second as the first — is reading
+            # a fabricated measurement. See `REPO_STATUSES`.
+            "repo": rep["repo"],
+            "repo_status": rep["repo_status"],
             "command": lead.get("command", ""),
             "task": strip_status_glyph(lead.get("title", "")),
             "claude": is_claude,
@@ -2951,7 +3269,8 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
            claude_only=False, use_capture=True, capture_nonce=None,
            clawgate_reader=None, clawgate_path=None,
            use_ledger=True, ledger_outputs=None, pane_preview=False,
-           match=None, match_path=False, prefilter_index_map=False) -> dict:
+           match=None, match_path=False, prefilter_index_map=False,
+           use_repo=True, repo_outputs=None) -> dict:
     """Build the whole report. Every source is injectable, so this is the
     function the hermetic suite exercises end-to-end.
 
@@ -2984,6 +3303,14 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
     SSH transport as the tmux calls, so a laptop row gets an age and a session id
     the same way a workbench row does. `ledger_outputs` injects that stdout per
     host for the hermetic suite.
+
+    🔴 `use_repo` DEFAULTS TO TRUE AND IS READ PER HOST FOR THE SAME REASON.
+    `repo` cannot be derived here at all — see `REPO_PROBE_SCRIPT`. It is a
+    FIFTH `sh -c` per host over the same SSH transport, batched into one call
+    for every unique pane path on that host, and `--no-repo` turns it off for a
+    caller that would rather have the round trip back. Off, every row is
+    `repo_status: skipped` with a null `repo` — never `not_a_repo`.
+    `repo_outputs` injects that stdout per host for the hermetic suite.
     """
     now = time.time() if now is None else now
     local_host = local_host or local_host_label()
@@ -3073,6 +3400,9 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
     raw_panes, slot_ids = {}, {}
     captures, capture_status = {}, {}
     ledger_res = {}
+    # 🔴 `None` is the DISCRIMINANT, exactly as it is for `captures`. `None` =
+    # this host's probe did not answer or was not run; a dict = it answered.
+    repo_index, repo_host_status, repo_stats = {}, {}, {}
     for host in hosts:
         panes_res = run_tmux(TMUX_PANES_ARGV, host, local_host, runner=runner)
         wins_res = run_tmux(TMUX_WINDOWS_ARGV, host, local_host, runner=runner)
@@ -3107,6 +3437,87 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
                 capture_status[host] = "ok"
             else:
                 captures[host], capture_status[host] = None, "error"
+
+        # --- 🔴 the repo probe: ONE `sh -c` per host, EVERY unique pane path --
+        # It runs on the host that OWNS the directories. `label_from_path`
+        # states why that is not optional: `path` is a string from another
+        # machine, and resolving a laptop path here would answer about whatever
+        # happens to sit at that path on the workbench. See REPO_PROBE_SCRIPT.
+        #
+        # DEDUPED and SORTED before the call: ~93 live windows share far fewer
+        # distinct cwds, and the order is fixed so the argv is reproducible.
+        repo_paths = sorted({p.get("path", "").strip()
+                             for p in host_panes if (p.get("path") or "").strip()})
+        if not use_repo:
+            repo_index[host], repo_host_status[host] = None, "skipped"
+            repo_stats[host] = {"measured": False, "status": "skipped",
+                                "error": None, "paths": None, "resolved": None,
+                                "unparseable": None}
+        elif not panes_res["reachable"]:
+            # No paths were measured, so there is nothing to resolve and the
+            # probe is not attempted — the same reasoning the ledger read uses
+            # for a host that answered neither tmux call. `unmeasured`, and the
+            # reason says the read was never attempted rather than implying it
+            # was tried and failed.
+            repo_index[host], repo_host_status[host] = None, "unmeasured"
+            repo_stats[host] = {
+                "measured": False, "status": "unmeasured",
+                "error": "`tmux list-panes` did not answer on this host, so no "
+                         "pane path was measured and the repo probe was not "
+                         "attempted",
+                "paths": None, "resolved": None, "unparseable": None}
+        elif not repo_paths:
+            # 🔴 MEASURED AND GENUINELY EMPTY, `{}` and not None — the same
+            # distinction `captures` draws. We know every pane on this host and
+            # none of them reported a cwd, so there was nothing to ask about.
+            # Publishing `unmeasured` here would call a complete enumeration a
+            # failure.
+            repo_index[host], repo_host_status[host] = {}, "unmeasured"
+            repo_stats[host] = {"measured": True, "status": "ok", "error": None,
+                                "paths": 0, "resolved": 0, "unparseable": 0}
+        else:
+            if repo_outputs is not None:
+                raw_repo = repo_outputs.get(host)
+                repo_read = {"reachable": raw_repo is not None,
+                             "stdout": raw_repo or "",
+                             "error": None if raw_repo is not None
+                             else "no injected repo probe output for this host"}
+            else:
+                repo_read = run_tmux(repo_probe_argv(repo_paths), host,
+                                     local_host, runner=runner,
+                                     timeout=REPO_PROBE_TIMEOUT)
+            if not repo_read["reachable"]:
+                repo_index[host], repo_host_status[host] = None, "unmeasured"
+                repo_stats[host] = {
+                    "measured": False, "status": "error",
+                    "error": repo_read.get("error") or "unknown error",
+                    "paths": len(repo_paths), "resolved": None,
+                    "unparseable": None}
+            else:
+                parsed_repo = parse_repo_probe(repo_read["stdout"], repo_paths)
+                idx = build_repo_index(parsed_repo, repo_paths)
+                repo_index[host] = idx
+                repo_host_status[host] = "unmeasured"
+                if idx is None:
+                    # 🔴 IT ANSWERED WITHOUT ITS SENTINEL, so the output is not
+                    # evidence about this host's repos at all — the same verdict
+                    # `_host_ledger` reaches for a ledger read with no sentinel.
+                    # An empty stdout from a swallowed command and a host where
+                    # nothing resolved are the same bytes.
+                    repo_stats[host] = {
+                        "measured": False, "status": "no_sentinel",
+                        "error": "the repo probe answered without its "
+                                 f"`{REPO_PROBE_SENTINEL}` line on {host} — "
+                                 "output not trusted",
+                        "paths": len(repo_paths), "resolved": None,
+                        "unparseable": None}
+                else:
+                    repo_stats[host] = {
+                        "measured": True, "status": "ok", "error": None,
+                        "paths": len(repo_paths),
+                        "resolved": sum(1 for v in idx.values()
+                                        if v.get("status") == "ok"),
+                        "unparseable": parsed_repo["unparseable"]}
         # 🔴 The two calls are INDEPENDENT measurements. `reachable`/`error`
         # describe list-panes; `windows_measured`/`windows_error` describe
         # list-windows. Reading one off the other is how a failed list-windows
@@ -3150,6 +3561,20 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
             "captures_status": capture_status[host],
             "captures_seen": (len(captures[host])
                               if captures[host] is not None else None),
+            # A FOURTH independent measurement, reported separately for the
+            # same reason the other three are separate from each other. 🔴 THIS
+            # IS THE HOST-LEVEL DISCRIMINANT constraint that stops a failed repo
+            # probe from reading as "none of these panes is in a repo":
+            # `repos_measured: false` means no row on this host carries a repo
+            # BECAUSE NOBODY LOOKED, and `repos_status` names which of the four
+            # ways that happened (`skipped` / `unmeasured` / `error` /
+            # `no_sentinel`). `repos_resolved` is an integer ONLY when measured.
+            "repos_measured": repo_stats[host]["measured"],
+            "repos_status": repo_stats[host]["status"],
+            "repos_error": repo_stats[host]["error"],
+            "repos_paths": repo_stats[host]["paths"],
+            "repos_resolved": repo_stats[host]["resolved"],
+            "repos_unparseable": repo_stats[host]["unparseable"],
         }
         # --- the agent activity ledger, ONE `sh -c` per host -----------------
         # 🔴 Read HERE, inside the per-host loop, and filtered against THIS
@@ -3258,7 +3683,11 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
             capture_status=capture_status.get(host, "skipped"),
             # Per host, unlike fuzzyclaw's local-only index above.
             ledger_index=(ledger_res.get(host) or {}).get("index"),
-            pane_preview=pane_preview)
+            pane_preview=pane_preview,
+            # Per host, like the ledger — the resolution happened on the machine
+            # that owns these directories.
+            repo_index=repo_index.get(host),
+            repo_status=repo_host_status.get(host, "unmeasured"))
 
     # --- 🔴 --claude-only: drop the shells, and COUNT what was dropped -------
     # The summary then describes the RENDERED set, which is the safe direction:
@@ -4098,6 +4527,17 @@ LEAN_ROW_FIELDS = (
     # a confident answer sending the operator to the wrong live window.
     "hotkey_display",
     # what it is working on, and WHICH agent is doing it
+    # 🔴 `repo` IS THE PROJECT KEY AND IT IS NOT DUPLICATION OF `path` OR
+    # `label`. It is the MAIN CLONE, resolved on the owning host, so two
+    # worktrees of one repo carry one name — which no string operation on
+    # `path` can produce. Its consumer (clawgate's `projectOf()`) prefers it
+    # over the path leaf precisely because the leaf splits a worktree off into
+    # its own group. `repo_status` rides with it for the same reason
+    # `label_source` rides with `label` and `age_source` with `age_secs`: it is
+    # PROVENANCE, and this view's rule is that provenance never goes. Without
+    # it, `repo: null` from a probe that never ran and `repo: null` from a pane
+    # genuinely outside a work tree are one value.
+    "repo", "repo_status",
     "path", "task", "runtime",
     # what state it is in
     "claude", "busy", "status", "age_secs", "age_source",
@@ -4122,6 +4562,11 @@ LEAN_ROW_FIELDS = (
 LEAN_HOST_FIELDS = (
     "reachable", "error", "windows_measured", "windows_error",
     "captures_measured", "captures_status", "captures_seen",
+    # The repo probe's own provenance. `repos_measured` + `repos_status` are
+    # what make a host of `repo: null` rows readable; the two counts are what
+    # make "0 resolved" readable against how many paths were asked about.
+    "repos_measured", "repos_status", "repos_error",
+    "repos_paths", "repos_resolved", "repos_unparseable",
 )
 
 
@@ -4618,6 +5063,13 @@ def build_parser():
                    help="skip the per-host pane capture. Every row's "
                         "waiting_probable is then null (never false) and "
                         "summary.waiting.probable is null, never 0.")
+    p.add_argument("--no-repo", action="store_true",
+                   help="skip the per-host repo probe — one batched `sh -c` "
+                        "per host that resolves each pane's cwd to its MAIN "
+                        "clone (so worktrees of one repo share a name). Every "
+                        "row's `repo` is then null with `repo_status: "
+                        "skipped`, never `not_a_repo`, and the host reports "
+                        "`repos_measured: false`.")
     # 🔴 OPT-IN, and the flag is the whole cost control. See the comment block
     # at PREVIEW_STATUSES for the measurement: the text is already captured, so
     # this costs no extra tmux work, but it makes the document 2.63x larger and
@@ -4779,6 +5231,7 @@ def main(argv=None):
                     use_fuzzyclaw=use_fuzzyclaw,
                     use_ledger=not args.no_ledger,
                     use_capture=not args.no_capture,
+                    use_repo=not args.no_repo,
                     threshold=args.stale_threshold,
                     claude_only=args.claude_only,
                     pane_preview=args.pane_preview,

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -1729,6 +1729,22 @@ def row_repo(path, repo_index, host_status="unmeasured") -> dict:
     `repo_index is None` means the host's probe did not answer (or was not run):
     every row gets `host_status` — `unmeasured` or `skipped` — and a null repo.
     A dict means it DID answer, so a null repo there carries a measured reason.
+
+    🔴 THE `missing` BRANCH HERE IS UNREACHABLE FROM `gather`, AND SAYING SO IS
+    THE POINT. `gather` feeds the probe EVERY pane path on the host and
+    `build_repo_index` fills an entry for every one it was given, so a row's
+    lead path is always a key. An unreachable guard reads as a defence and is
+    not one — see the same note in `label_from_path`, where a mutation sweep
+    caught exactly that.
+
+    It is kept rather than deleted because this is a PUBLIC pure function whose
+    contract is `{path: {...}}` -> a row pair, and a caller that hands it a
+    partial index must get `missing` rather than a `KeyError` or, far worse, a
+    silent `not_a_repo`. The status itself IS reachable in the pipeline — via
+    `build_repo_index`, when the probe's reply is SHORTER than its input, which
+    a truncated ssh read genuinely produces. So the STATUS is a real
+    measurement; only this second spelling of it is belt-and-braces. Do not
+    read the branch as evidence the row path is covered.
     """
     if not (path or "").strip():
         # Asked-or-not, there was nothing to resolve. This beats the host

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -495,6 +495,39 @@ TMUX_WINDOWS_ARGV = ("tmux", "list-windows", "-a", "-F", WINDOW_FORMAT)
 # 1-based sequence number cannot. A line whose first field is not an integer is
 # counted `unparseable` and the rest still align.
 #
+# 🔴 …BUT AN INDEX IS ONLY A KEY IF NOTHING ELSE CAN SPELL ONE, and the earlier
+# revision of this comment claimed the opposite of what the code did. It said a
+# newline "costs that one path its answer and leaves every other index correct".
+# MEASURED FALSE 2026-09-03 through this same script under a real `sh`: a
+# directory named `zzz-attacker\n1\t0\t/w/WRONG` makes `git` print a common dir
+# containing a newline, the reply then carries a SECOND record claiming index 1,
+# and index 1 — a genuine repo — resolved to `WRONG`, with `unparseable: 0`. The
+# paths are the operator's own panes on his own hosts, so this is not a security
+# hole; it is a CONFIDENT WRONG ANSWER, which is worse than the honest split
+# this feature replaces. THREE independent defences now, because each closes a
+# different half:
+#   1. the script REFUSES a common dir containing a newline (`case $d in *"$NL"*`
+#      — POSIX, no `tr`, so it cannot be disarmed by a missing coreutils) and
+#      reports `REPO_PROBE_RC_NEWLINE` for that path instead;
+#   2. the parser splits on `"\n"` ONLY, never `str.splitlines()`, which also
+#      splits `\r`, `\x0b`, `\x0c`, `\x1c`-`\x1e`, `\x85`, `\u2028`, `\u2029` —
+#      a reader that splits on MORE characters than the writer joined with is a
+#      forging surface all by itself;
+#   3. a DUPLICATE index is counted `unparseable` and the FIRST answer stands,
+#      so even a forged record cannot overwrite a real one.
+#
+# 🔴 EVERY RECORD CARRIES `git`'s OWN EXIT STATUS, and that is what makes
+# `not_a_repo` a measurement. `d=$(git …) || d=""` collapsed exit 128 (git says:
+# not in a work tree) with 124 (the per-path `timeout` fired), 127 (`git` is not
+# installed) and every other error into ONE empty string, which the parser then
+# published as the MEASURED status `not_a_repo`. Measured twice through the real
+# shipped script: with `git` replaced by a 30s sleep, and with `git` removed from
+# `PATH`, a REAL repo reported `{'repo': None, 'status': 'not_a_repo'}` while the
+# host reported `repos_measured: true`. That is the unmeasured-vs-measured
+# substitution this file exists to refuse, one granularity down from the host
+# level where it was already refused. Only rc 128 is `not_a_repo` now; every
+# other non-zero is the per-path `unmeasured`.
+#
 # 🔴 THE SENTINEL CARRIES THE HOST'S OWN `$HOME`, and that coupling is the same
 # one-call-one-instant argument `agent_ledger.read_command` makes for the tmux
 # pid. It is the POSITIVE CONTROL — without it, "the probe ran and no pane is in
@@ -502,27 +535,119 @@ TMUX_WINDOWS_ARGV = ("tmux", "list-windows", "-a", "-F", WINDOW_FORMAT)
 # is the value `repo_from_common_dir` needs to refuse to name `$HOME` as a
 # project. It must be the OWNING host's `$HOME`, which is exactly what a local
 # `HOME` constant could not supply for a laptop row.
-REPO_PROBE_SENTINEL = "SM_REPO_V1"
+# 🔴 `V2`, AND THE BUMP IS THE PROTOCOL. V1 records were `<idx>\t<common dir>`;
+# V2 records are `<idx>\t<rc>\t<common dir>`. The reader REQUIRES three fields,
+# so a V1 reply would be `unparseable` on every line while still carrying a
+# V1 sentinel — i.e. `measured: true, resolved: 0`, a fabricated measurement.
+# Renaming the sentinel makes that same reply land in `no_sentinel` instead,
+# which is the honest verdict. Both halves ship in this one file and are always
+# in step; the bump costs nothing and removes the one way they could not be.
+REPO_PROBE_SENTINEL = "SM_REPO_V2"
+
+# The per-path bound INSIDE the script, in seconds. A Python constant rather
+# than a number typed into the shell text, so a guard can pin it — a mutation
+# sweep turned `timeout 3` into `timeout 900` and it SURVIVED all 743 tests.
+REPO_PROBE_GIT_TIMEOUT = 3
+# git's own "this is not inside a work tree". The ONLY non-zero status that is a
+# measurement rather than a failure to measure.
+REPO_PROBE_RC_NOT_A_REPO = 128
+# Ours, not git's: the script measured a common dir it refuses to transmit
+# because it contains a newline (see the record-forging note above). Chosen
+# outside git's and `timeout`'s ranges so it cannot collide with a real status.
+REPO_PROBE_RC_NEWLINE = 201
+# 🔴 EVERY CHARACTER `str.splitlines()` TREATS AS A LINE BREAK EXCEPT `\n`.
+# The probe joins records with `\n` and nothing else, so a record holding one of
+# these is a record whose meaning depends on WHICH splitter reads it — and a
+# reader that disagrees with the writer about where a record ends is a forging
+# surface even when neither is buggy. Such a record is refused outright
+# (`unparseable`), which makes the two splitters equivalent on everything the
+# parser accepts. Pinned two-way against `str.splitlines()` itself by
+# `test_the_refused_break_characters_are_DERIVED_from_str_splitlines`.
+REPO_PROBE_RECORD_BREAKERS = ("\r", "\v", "\f", "\x1c", "\x1d", "\x1e",
+                              "\x85", "\u2028", "\u2029")
 REPO_PROBE_SCRIPT = (
     'echo "%s $HOME"\n'
     # `timeout` is coreutils and present on both hosts, but a probe that dies
     # on a host without it would take the whole host's repo field with it. The
     # unquoted `$T` word-splits, which is the intent and is POSIX sh behaviour
     # (this runs under `sh`, never zsh — see RULES.md on zsh not splitting).
-    'if command -v timeout >/dev/null 2>&1; then T="timeout 3"; else T=""; fi\n'
+    'if command -v timeout >/dev/null 2>&1; then T="timeout %d"; else T=""; fi\n'
+    # A literal newline held in a variable, so the `case` pattern below can be
+    # written in POSIX sh with no external command. `tr` would have worked and
+    # would have made this guard evaporate on a host without coreutils — the
+    # exact hazard the `command -v timeout` fallback above exists for.
+    "NL='\n'\n"
     'n=0\n'
     'for p do\n'
     '  n=$((n+1))\n'
+    # 🔴 `rc=$?` ON ITS OWN LINE. `d=$(…) || d=""` would leave `$?` holding the
+    # status of the ASSIGNMENT (always 0), so git's status must be captured
+    # before anything else runs.
     '  d=$($T git -C "$p" rev-parse --path-format=absolute '
-    '--git-common-dir 2>/dev/null) || d=""\n'
-    '  printf \'%%s\\t%%s\\n\' "$n" "$d"\n'
+    '--git-common-dir 2>/dev/null)\n'
+    '  rc=$?\n'
+    '  [ "$rc" -eq 0 ] || d=""\n'
+    '  case $d in *"$NL"*) rc=%d; d="" ;; esac\n'
+    '  printf \'%%s\\t%%s\\t%%s\\n\' "$n" "$rc" "$d"\n'
     'done\n'
-    'exit 0\n' % REPO_PROBE_SENTINEL)
+    'exit 0\n' % (REPO_PROBE_SENTINEL, REPO_PROBE_GIT_TIMEOUT,
+                  REPO_PROBE_RC_NEWLINE))
 # Its own budget, above SSH_TIMEOUT: this call fans out over every unique path
-# on the host and each `git` is bounded at 3s by the script itself, so the
-# worst realistic case is slower than a single `list-panes`. The pusher's own
-# 90s cap still bounds the whole run.
-REPO_PROBE_TIMEOUT = 25.0
+# on the host and each `git` is bounded by the script itself, so the worst
+# realistic case is slower than a single `list-panes`.
+#
+# 🔴 IT IS NOT THE BOUND ON THE RUN — `COLLECT_BUDGET` is. This number used to
+# be 25.0 and the comment said "the pusher's own 90s cap still bounds the whole
+# run", which read as reassurance and was arithmetic nobody had done. See
+# `COLLECT_BUDGET` for the sum that was actually over the cap, and for why a
+# per-call number can never be the answer.
+REPO_PROBE_TIMEOUT = 15.0
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE WHOLE-COLLECTION DEADLINE. `scripts/tmux-snapshot-push.sh` wraps this
+# script in `timeout 90` (`TMUX_PUSH_COLLECT_TIMEOUT`), and rc 124 there is NOT
+# a degraded field: it is `exit 3`, no snapshot pushed for EITHER host, and a
+# read model that silently stops advancing — this codebase's documented worst
+# failure mode.
+#
+# 🔴 A PER-CALL NUMBER CANNOT BOUND A RUN, AND ADDING THE FIFTH CALL IS WHAT
+# PROVED IT. Every per-call budget is a bound on ONE call; the run is their SUM,
+# and nothing was summing them. Worst case = every call returning at, not past,
+# its own bound (a command that finishes at 11.99s exits 0 — `subprocess`'s
+# timeout only kills, it does not shorten), plus the ClickHouse read:
+#
+#   leg                     calls                            seconds
+#   remote (ssh)            panes+windows+capture+ledger      4 x 12.0 = 48.0
+#   remote (ssh)            repo probe                            15.0
+#   local                   panes+windows+capture+ledger      4 x  5.0 = 20.0
+#   local                   repo probe                            15.0
+#   ClickHouse              chquery.CHConn.timeout                15.0
+#                                                            ---------------
+#                                                                  113.0  > 90
+#
+# ⚠ AND THE FIFTH CALL IS NOT THE WHOLE STORY: the same sum at the BASE of this
+# branch — four calls, no probe — is 48 + 20 + 15 = 83, i.e. already inside 90
+# by only 7 seconds. An audit that omitted ClickHouse read that as 68 and 22
+# seconds of headroom. So sizing the probe to fit would have meant a budget of
+# 3.5s, which is not a probe; the envelope had to become explicit instead.
+#
+# So the bound is a DEADLINE, enforced in `run_tmux` — the one place that starts
+# a subprocess — rather than a table of constants that must be re-summed by hand
+# every time a call is added. A call that would run past the deadline is given
+# only the time that remains; one with no time left is not started at all and
+# its host reports `unmeasured` with a reason, which is the honest verdict and
+# the one this file already publishes for every other read that did not happen.
+# The sixth call is covered the day it is written, with no arithmetic.
+COLLECT_CAP = 90.0          # `TMUX_PUSH_COLLECT_TIMEOUT` in tmux-snapshot-push.sh
+COLLECT_CH_RESERVE = 15.0   # chquery.CHConn.timeout, spent AFTER the host loop
+COLLECT_MARGIN = 5.0        # interpreter start, fuzzyclaw + cache reads, render
+COLLECT_BUDGET = 70.0       # = COLLECT_CAP - COLLECT_CH_RESERVE - COLLECT_MARGIN
+# The floor a clamped call still gets. A `timeout=0` would make `subprocess`
+# raise instantly on every remaining host, turning "we ran out of time" into a
+# storm of look-alike failures; a call is either given a usable slice or is not
+# attempted, and the two are different reports.
+COLLECT_MIN_SLICE = 0.5
+# --------------------------------------------------------------------------- #
 
 # 🔴 THE PER-ROW DISCRIMINANT, enumerated here so a consumer can branch on the
 # set and a test can assert it is exactly this — the same contract
@@ -536,7 +661,9 @@ REPO_PROBE_TIMEOUT = 25.0
 #   not_a_repo   — MEASURED: the owning host says this path is not inside a git
 #                  work tree (or its common dir cannot honestly be named — a
 #                  bare repo, a submodule's `…/.git/modules/<n>`). A real
-#                  measured absence.
+#                  measured absence, and it now REQUIRES git to have said so:
+#                  the probe carries `git`'s exit status per path and only
+#                  `REPO_PROBE_RC_NOT_A_REPO` lands here.
 #   home         — MEASURED, and deliberately withheld. The resolved main clone
 #                  IS the owning host's `$HOME`. `projectOf()` in clawgate
 #                  routes `/home/zach` and `/root` to `Other` precisely so every
@@ -1595,16 +1722,24 @@ def repo_probe_argv(paths):
 
 
 def parse_repo_probe(raw, paths) -> dict:
-    """Probe stdout -> `{"measured", "home", "common_dirs", "seen", "unparseable"}`.
+    """Probe stdout -> `{"measured", "home", "answers", "seen", "unparseable"}`.
 
-    `common_dirs` is `{path: common_dir_or_None}`, keyed back to the INPUT list
-    by the 1-based sequence number each line carries.
+    `answers` is `{path: {"rc": int, "common": str|None}}`, keyed back to the
+    INPUT list by the 1-based sequence number each record carries. `rc` is the
+    OWNING host's `git` exit status for that path, and it is what makes
+    `not_a_repo` a measurement rather than a shrug — see `build_repo_index`.
+
+    🔴 THE KEY IS `answers`, NOT `common_dirs`, AND THE RENAME IS DELIBERATE. A
+    common dir alone cannot distinguish "git says this is not a work tree" from
+    "git never ran", and the old name invited a reader to treat `None` as the
+    former. Renaming it means no consumer can keep reading the old shape by
+    accident; a missed call site is an AttributeError, not a wrong answer.
 
     🔴 `measured` IS THE POSITIVE CONTROL and it comes off the sentinel, never
     off the row count. A host whose panes are all outside a work tree and a host
     whose probe was swallowed both produce output with no common dirs in it;
     only the sentinel tells them apart. When `measured` is False, `home` is None
-    and `common_dirs` is empty — the caller must publish `unmeasured`, never
+    and `answers` is empty — the caller must publish `unmeasured`, never
     `not_a_repo`.
 
     🔴 A SENTINEL WITH NO `$HOME` IS NOT A SENTINEL. The home is half the
@@ -1615,16 +1750,29 @@ def parse_repo_probe(raw, paths) -> dict:
     sentinel is `measured: False` — the caller publishes `unmeasured`, and the
     guard downstream has no unreachable branch.
 
-    A line whose first field is not an integer, or whose index is outside the
-    input list, is counted `unparseable` and skipped. That is the disposition a
-    common dir containing a newline lands in: it costs that one path its answer
-    and leaves every other index correct.
+    A record whose index or rc is not an integer, or whose index is outside the
+    input list, is counted `unparseable` and skipped.
+
+    🔴 A DUPLICATE INDEX IS `unparseable` AND THE FIRST ANSWER STANDS. This
+    branch is not hygiene — it is the third of the three defences described at
+    `REPO_PROBE_SCRIPT` against a common dir forging a second record. A plain
+    assignment here let the LAST record for an index win, so a forged one
+    landing after the genuine one replaced a real repo with a confident wrong
+    name while `unparseable` reported 0. First-wins alone is not sufficient
+    either (a forged record for a LATER index arrives before its genuine one),
+    which is why the script refuses the newline at the source and the split
+    below is on `"\n"` and nothing else.
     """
-    lines = (raw or "").splitlines()
+    # 🔴 `.split("\n")`, NEVER `.splitlines()`. The writer joins records with
+    # `\n`; `splitlines()` ALSO splits on `\r`, `\x0b`, `\x0c`, `\x1c`-`\x1e`,
+    # `\x85`, `\u2028` and `\u2029`, so it would break a record apart on
+    # characters the script never used as a separator — a reader that splits on
+    # more than the writer joined with is a record-forging surface by itself.
+    lines = (raw or "").split("\n")
     head = next((ln for ln in lines
                  if ln.strip().split(None, 1)[:1] == [REPO_PROBE_SENTINEL]),
                 None)
-    unmeasured = {"measured": False, "home": None, "common_dirs": {},
+    unmeasured = {"measured": False, "home": None, "answers": {},
                   "seen": None, "unparseable": None}
     if head is None:
         return unmeasured
@@ -1642,16 +1790,30 @@ def parse_repo_probe(raw, paths) -> dict:
         if not line.strip():
             continue
         seen += 1
-        idx, sep, common = line.partition("\t")
-        if not sep or not idx.strip().isdigit():
+        if any(ch in line for ch in REPO_PROBE_RECORD_BREAKERS):
+            # A record whose extent depends on WHICH line splitter reads it.
+            # Refusing it costs that path its answer (`missing`) and cannot cost
+            # any OTHER path a wrong one. See REPO_PROBE_RECORD_BREAKERS.
+            unparseable += 1
+            continue
+        fields = line.split("\t", 2)
+        if len(fields) != 3:
+            unparseable += 1
+            continue
+        idx, code, common = fields
+        if not idx.strip().isdigit() or not code.strip().isdigit():
             unparseable += 1
             continue
         i = int(idx.strip()) - 1
         if i < 0 or i >= len(paths):
             unparseable += 1
             continue
-        out[paths[i]] = common.strip() or None
-    return {"measured": True, "home": home, "common_dirs": out,
+        if paths[i] in out:
+            unparseable += 1
+            continue
+        out[paths[i]] = {"rc": int(code.strip()),
+                         "common": common.strip() or None}
+    return {"measured": True, "home": home, "answers": out,
             "seen": seen, "unparseable": unparseable}
 
 
@@ -1711,15 +1873,32 @@ def build_repo_index(parsed, paths) -> dict:
     if not parsed.get("measured"):
         return None
     home = parsed.get("home")
-    common = parsed.get("common_dirs") or {}
+    answers = parsed.get("answers") or {}
     out = {}
     for p in paths:
-        if p not in common:
+        ans = answers.get(p)
+        if ans is None:
             # The probe answered for this host, and did not answer for this
             # path. Its own status — not folded into `not_a_repo`.
             out[p] = {"repo": None, "status": "missing"}
+        elif ans["rc"] == 0:
+            out[p] = repo_from_common_dir(ans["common"], home=home)
+        elif ans["rc"] == REPO_PROBE_RC_NOT_A_REPO:
+            # 🔴 GIT SAID SO, so this is a measurement. Every OTHER non-zero
+            # status is a failure to measure and falls through below.
+            out[p] = {"repo": None, "status": "not_a_repo"}
         else:
-            out[p] = repo_from_common_dir(common[p], home=home)
+            # 🔴 THE PER-PATH `unmeasured`, and the whole point of carrying rc.
+            # 124 (the per-path `timeout` fired), 127 (`git` is not installed),
+            # 129 (this git does not know `--path-format`) and
+            # `REPO_PROBE_RC_NEWLINE` all used to arrive here as an empty string
+            # and be published as the MEASURED status `not_a_repo`. The host
+            # meanwhile reported `repos_measured: true`, so nothing anywhere in
+            # the payload said a look had failed.
+            #
+            # It cannot inflate `repos_resolved`: that counts `status == "ok"`
+            # and this is not it, by construction rather than by convention.
+            out[p] = {"repo": None, "status": "unmeasured"}
     return out
 
 
@@ -1730,12 +1909,25 @@ def row_repo(path, repo_index, host_status="unmeasured") -> dict:
     every row gets `host_status` — `unmeasured` or `skipped` — and a null repo.
     A dict means it DID answer, so a null repo there carries a measured reason.
 
+    🔴 THE LOOKUP KEY IS `.strip()`ed, AND THAT IS A SEAM, NOT A NICETY.
+    `gather` builds the probe's input as `p["path"].strip()`; `parse_panes`
+    stores tmux's field UNSTRIPPED. Each side was individually fine and the pair
+    was broken: a pane whose `pane_current_path` carries a trailing space had
+    its repo resolved under the stripped spelling, counted in `repos_resolved`,
+    and then looked up here under the raw one — a MISS. The row published
+    `repo_status: missing` (the branch the note below calls unreachable) while
+    the host's own count said the answer existed. Measured through real
+    `gather()` with a pane path of `'/home/zach/workspace/oddname '`. One
+    `.strip()`, and the two halves address the same key.
+
     🔴 THE `missing` BRANCH HERE IS UNREACHABLE FROM `gather`, AND SAYING SO IS
     THE POINT. `gather` feeds the probe EVERY pane path on the host and
     `build_repo_index` fills an entry for every one it was given, so a row's
     lead path is always a key. An unreachable guard reads as a defence and is
     not one — see the same note in `label_from_path`, where a mutation sweep
-    caught exactly that.
+    caught exactly that. ⚠ That claim was FALSE until the `.strip()` above
+    landed — the branch was reachable, by the seam it describes, and the commit
+    asserting it was unreachable is what sent an audit looking.
 
     It is kept rather than deleted because this is a PUBLIC pure function whose
     contract is `{path: {...}}` -> a row pair, and a caller that hands it a
@@ -1752,7 +1944,7 @@ def row_repo(path, repo_index, host_status="unmeasured") -> dict:
         return {"repo": None, "repo_status": "no_path"}
     if repo_index is None:
         return {"repo": None, "repo_status": host_status}
-    hit = repo_index.get(path)
+    hit = repo_index.get((path or "").strip())
     if hit is None:
         return {"repo": None, "repo_status": "missing"}
     return {"repo": hit.get("repo"), "repo_status": hit.get("status")}
@@ -3172,12 +3364,27 @@ def _host_ledger(read_result, live_windows, host) -> dict:
             "no_window": filt["no_window"]}
 
 
-def run_tmux(argv, host, local_host, runner=None, timeout=None):
+def run_tmux(argv, host, local_host, runner=None, timeout=None,
+             deadline=None, clock=None):
     """Run a tmux argv on `host`, locally or over SSH.
 
     Returns {"reachable", "error", "stdout", "no_server"}. A non-zero exit whose
     stderr says "no server running" is REACHABLE with empty output — see the
     silent-zero note in the header.
+
+    🔴 `deadline` IS THE WHOLE-COLLECTION BOUND, ENFORCED HERE BECAUSE THIS IS
+    THE ONE PLACE THAT STARTS A SUBPROCESS. A monotonic instant, not a duration.
+    Every call's own timeout is a bound on ONE call; the run is their SUM, and
+    with five calls per host plus the ClickHouse read that sum is over the
+    pusher's `timeout 90` — see `COLLECT_BUDGET` for the arithmetic. Clamping at
+    each call site would be the same predicate open-coded five times and would
+    be wrong at the sixth; clamping here covers a call nobody has written yet.
+
+    A call with less than `COLLECT_MIN_SLICE` left is NOT STARTED, and says so:
+    `reachable: False` with an error naming the budget. That is a read that did
+    not happen, which is the fact this file publishes as `unmeasured` — never as
+    an empty measurement. `deadline=None` (every caller outside `gather`,
+    `tail` included) keeps the old unbounded behaviour exactly.
 
     🔴 `no_server` is the discriminant that case CANNOT be recovered from
     afterwards. For a whole-host scan "reachable host, zero windows" is the
@@ -3193,6 +3400,16 @@ def run_tmux(argv, host, local_host, runner=None, timeout=None):
         cmd, tmo = list(argv), (timeout or LOCAL_TIMEOUT)
     else:
         cmd, tmo = ssh_wrap(argv), (timeout or SSH_TIMEOUT)
+    if deadline is not None:
+        left = deadline - (clock or time.monotonic)()
+        if left < COLLECT_MIN_SLICE:
+            return {"reachable": False, "stdout": "", "no_server": False,
+                    "stderr": "",
+                    "error": (f"the {COLLECT_BUDGET:g}s collection budget was "
+                              "exhausted before this read was attempted — it "
+                              "was NOT run, so nothing here was measured "
+                              "(see COLLECT_BUDGET)")}
+        tmo = min(tmo, left)
     try:
         rc, out, err = runner(cmd, tmo)
     except Exception as e:  # noqa: BLE001 — timeout / OSError / anything
@@ -3287,9 +3504,18 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
            clawgate_reader=None, clawgate_path=None,
            use_ledger=True, ledger_outputs=None, pane_preview=False,
            match=None, match_path=False, prefilter_index_map=False,
-           use_repo=True, repo_outputs=None) -> dict:
+           use_repo=True, repo_outputs=None,
+           collect_budget=COLLECT_BUDGET, clock=None) -> dict:
     """Build the whole report. Every source is injectable, so this is the
     function the hermetic suite exercises end-to-end.
+
+    🔴 `collect_budget` BOUNDS THE HOST LOOP AS A WHOLE, and `clock` is its
+    seam. Five `run_tmux` calls per host, each with its own timeout, sum past
+    the pusher's `timeout 90` — see `COLLECT_BUDGET`. A monotonic deadline is
+    computed once here and handed to every read; a read with no budget left is
+    not attempted and its host reports the honest `unmeasured`. `clock` is a
+    monotonic-seconds callable so a test can spend the budget without spending
+    the wall clock. `collect_budget=None` disables the deadline entirely.
 
     🔴 `ch_client_factory` defaults to None and is resolved to `make_ch_client`
     AT CALL TIME, not bound as a default argument. A default of
@@ -3406,6 +3632,16 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
         "summary": {},
     }
 
+    # 🔴 ONE deadline for the WHOLE host loop, taken before the first read. Not
+    # per host and not per call: the pusher's cap is on the run, so the budget
+    # has to be too. See `COLLECT_BUDGET`.
+    _clock = clock or time.monotonic
+    deadline = None if collect_budget is None else _clock() + collect_budget
+
+    def _read(argv, host, **kw):
+        return run_tmux(argv, host, local_host, runner=runner,
+                        deadline=deadline, clock=_clock, **kw)
+
     # --- per host: ONE tmux call each for panes and for live window ids ------
     # 🔴 `None`, not `set()`. An empty set is a MEASURED "this host has no
     # windows"; None is "we never asked, or the answer never came back". The two
@@ -3421,8 +3657,8 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
     # this host's probe did not answer or was not run; a dict = it answered.
     repo_index, repo_host_status, repo_stats = {}, {}, {}
     for host in hosts:
-        panes_res = run_tmux(TMUX_PANES_ARGV, host, local_host, runner=runner)
-        wins_res = run_tmux(TMUX_WINDOWS_ARGV, host, local_host, runner=runner)
+        panes_res = _read(TMUX_PANES_ARGV, host)
+        wins_res = _read(TMUX_WINDOWS_ARGV, host)
         raw_panes[host] = panes_res["stdout"]
 
         # --- 🔴 the capture batch: ONE tmux call per host, CLAUDE PANES ONLY --
@@ -3446,8 +3682,7 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
             # none of them is Claude. `{}`, not None.
             captures[host], capture_status[host] = {}, "ok"
         else:
-            cap_res = run_tmux(capture_argv(claude_ids, capture_nonce),
-                               host, local_host, runner=runner)
+            cap_res = _read(capture_argv(claude_ids, capture_nonce), host)
             if cap_res["reachable"]:
                 captures[host] = parse_captures(cap_res["stdout"],
                                                 capture_nonce)
@@ -3463,6 +3698,13 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
         #
         # DEDUPED and SORTED before the call: ~93 live windows share far fewer
         # distinct cwds, and the order is fixed so the argv is reproducible.
+        #
+        # 🔴 `.strip()` HERE IS HALF OF A KEY, AND `row_repo` HOLDS THE OTHER
+        # HALF. `parse_panes` stores tmux's `pane_current_path` unstripped, so
+        # the index built here is keyed on the STRIPPED spelling; a row looking
+        # itself up under the raw one misses. Both sides were individually
+        # correct and the pair was broken — do not change either without the
+        # other. Pinned as a relationship, not as two component tests.
         repo_paths = sorted({p.get("path", "").strip()
                              for p in host_panes if (p.get("path") or "").strip()})
         if not use_repo:
@@ -3489,6 +3731,14 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
             # none of them reported a cwd, so there was nothing to ask about.
             # Publishing `unmeasured` here would call a complete enumeration a
             # failure.
+            #
+            # ⚠ THE `"unmeasured"` BESIDE THE `{}` IS INERT, AND THE COMMENT
+            # ABOVE USED TO READ AS IF IT WERE NOT. `repo_host_status` is the
+            # fallback `row_repo` uses ONLY when `repo_index` is None; a `{}`
+            # index means every row takes its own per-path status instead — and
+            # on this branch every pane reported no cwd, so each one is
+            # `no_path`. Kept (rather than left unset) so the two dicts always
+            # carry the same key set; read as a placeholder, not a verdict.
             repo_index[host], repo_host_status[host] = {}, "unmeasured"
             repo_stats[host] = {"measured": True, "status": "ok", "error": None,
                                 "paths": 0, "resolved": 0, "unparseable": 0}
@@ -3500,9 +3750,8 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
                              "error": None if raw_repo is not None
                              else "no injected repo probe output for this host"}
             else:
-                repo_read = run_tmux(repo_probe_argv(repo_paths), host,
-                                     local_host, runner=runner,
-                                     timeout=REPO_PROBE_TIMEOUT)
+                repo_read = _read(repo_probe_argv(repo_paths), host,
+                                  timeout=REPO_PROBE_TIMEOUT)
             if not repo_read["reachable"]:
                 repo_index[host], repo_host_status[host] = None, "unmeasured"
                 repo_stats[host] = {
@@ -3514,6 +3763,8 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
                 parsed_repo = parse_repo_probe(repo_read["stdout"], repo_paths)
                 idx = build_repo_index(parsed_repo, repo_paths)
                 repo_index[host] = idx
+                # Only consulted when `idx is None` (the no-sentinel branch
+                # below); with a real index every row carries its own status.
                 repo_host_status[host] = "unmeasured"
                 if idx is None:
                     # 🔴 IT ANSWERED WITHOUT ITS SENTINEL, so the output is not
@@ -3624,8 +3875,7 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
                             "error": None if raw_led is not None
                             else "no injected ledger output for this host"}
             else:
-                led_read = run_tmux(AL.read_argv(), host, local_host,
-                                    runner=runner)
+                led_read = _read(AL.read_argv(), host)
             ledger_res[host] = _host_ledger(led_read, live, host)
         if host == local_host:
             local_live_windows = live

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -1772,6 +1772,10 @@ def _is_ascii_int(s) -> bool:
     `²` and `①`; `int()` rejects both. Anywhere those two predicates are
     open-coded apart, the gap is an unhandled `ValueError` on a path a docstring
     promised would be `unparseable`.
+
+    ⚠ ONE-WAY, and deliberately so: this is a strict SUBSET of what `int()`
+    accepts (`int('١٢')` is 12; this returns False). See the call site in
+    `parse_repo_probe` for why that is correct and must not be "fixed".
     """
     return isinstance(s, str) and s.strip().isascii() and s.strip().isdigit()
 
@@ -1897,8 +1901,20 @@ def parse_repo_probe(raw, paths) -> dict:
         # promises `unparseable`. The blast radius is what makes a one-word bug
         # worth a comment: `gather` does not catch it, `tmux-snapshot-push.sh`
         # turns any traceback into `exit 3`, and that is NO snapshot for EITHER
-        # host. `isascii() and isdigit()` is exactly the set `int()` accepts
-        # without a sign, so the guard and the conversion can no longer disagree.
+        # host.
+        #
+        # 🔴 `isascii() and isdigit()` is a deliberate SUBSET of what `int()`
+        # accepts, NOT the same set — and the difference is the whole reason
+        # this comment exists. `int()` also takes non-ASCII decimal digits
+        # (`'١٢'`, `'１２'`, `'۱'`, `'٠'`, `'᱀'` all convert); this guard refuses
+        # every one of them, on purpose. The field it validates is `$n` out of
+        # the probe's POSIX arithmetic, which is ASCII by construction, so a
+        # non-ASCII digit here is a corrupted reply and not an index.
+        # ⚠ DO NOT "simplify" this to `try: int(x) / except ValueError` to make
+        # the validator and the converter agree — that widens the accepted
+        # index/rc alphabet to every Unicode decimal digit with nothing going
+        # red. What must not disagree is narrower: everything this guard
+        # ACCEPTS, `int()` converts.
         if not _is_ascii_int(idx) or not _is_ascii_int(code):
             unparseable += 1
             continue
@@ -3568,6 +3584,21 @@ def make_ch_client(env_file=ACTIVITY_ENV, opener=None):
     return _chq.CHClient(_chq.CHConn.from_env(env), opener=opener)
 
 
+def _ch_timeout(client):
+    """The HTTP timeout this client carries, or None when it carries none (an
+    injected test double, or a non-numeric attribute). PURE.
+
+    🔴 THE ONE READER of that attribute, so the clamp and the field that
+    PUBLISHES the clamp cannot disagree about what they saw. A `bool` is an
+    `int` in Python and is not a timeout; it is refused here rather than
+    silently compared against the reserve.
+    """
+    t = getattr(getattr(client, "conn", None), "timeout", None)
+    if not isinstance(t, (int, float)) or isinstance(t, bool):
+        return None
+    return t
+
+
 def _clamp_ch_timeout(client, reserve=COLLECT_CH_RESERVE):
     """Hold the ClickHouse client to `COLLECT_CH_RESERVE`. Returns the timeout
     in force, or None when this client carries none (an injected test double).
@@ -3580,13 +3611,12 @@ def _clamp_ch_timeout(client, reserve=COLLECT_CH_RESERVE):
     lowered value is left alone (it only buys headroom); only an over-run is
     clamped.
     """
-    conn = getattr(client, "conn", None)
-    t = getattr(conn, "timeout", None)
-    if not isinstance(t, (int, float)) or isinstance(t, bool):
+    t = _ch_timeout(client)
+    if t is None:
         return None
     if t > reserve:
-        conn.timeout = float(reserve)
-    return conn.timeout
+        client.conn.timeout = float(reserve)
+    return client.conn.timeout
 
 
 def ch_query(client, sql) -> dict:
@@ -3697,8 +3727,14 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
         "local_host": local_host,
         "stale_threshold_secs": threshold,
         "hosts": {},
+        # `timeout_secs` / `timeout_clamped_from` are None here and in the
+        # `unavailable` branch below for the same reason every other count in
+        # this file is: no client was ever built, so nothing was clamped AND
+        # nothing was measured. A `0` or a `false` would be a fabricated
+        # reading of the operator's env file.
         "clickhouse": {"status": "skipped", "rows": [], "error": None,
-                       "code": None, "sql": ch_sql if use_ch else None},
+                       "code": None, "sql": ch_sql if use_ch else None,
+                       "timeout_secs": None, "timeout_clamped_from": None},
         # 🔴 Every count here is None, not 0. Under `--no-fuzzyclaw` NOTHING was
         # measured — the directory is never read — so a `files_live: 0` is a
         # fabricated measurement of exactly the class the `unmeasured` status
@@ -4309,14 +4345,37 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
         except Exception as e:  # noqa: BLE001
             report["clickhouse"] = {"status": "unavailable", "rows": [],
                                     "error": f"{type(e).__name__}: {e}",
-                                    "code": None, "sql": ch_sql}
+                                    "code": None, "sql": ch_sql,
+                                    "timeout_secs": None,
+                                    "timeout_clamped_from": None}
         if client is not None:
-            # 🔴 The reserve, ENFORCED on the client that spends it. See
-            # `_clamp_ch_timeout` — without this the budget arithmetic is a
-            # belief about a per-host env file this process never checks.
-            _clamp_ch_timeout(client)
+            # 🔴 The reserve, ENFORCED on the client that spends it — and then
+            # PUBLISHED. See `_clamp_ch_timeout` — without the enforcement the
+            # budget arithmetic is a belief about a per-host env file this
+            # process never checks.
+            #
+            # 🔴 THE FIELDS ARE THE OTHER HALF, AND THEY ARE NOT DECORATION.
+            # This is the ONE place in this file that CHANGES a number instead
+            # of measuring one and publishing it, and it changes a number an
+            # operator SET. An operator who put `CLICKHOUSE_HTTP_TIMEOUT=60` in
+            # `~/.config/activity-collector/env` because their read is slow got
+            # a 15 s read, an ordinary-looking timeout in the block below, and
+            # an env file still saying 60 — i.e. they debug ClickHouse. The
+            # override is now visible in the payload: `timeout_secs` is what
+            # the read actually ran with, and `timeout_clamped_from` is the
+            # configured value it was reduced FROM, or None when nothing was
+            # reduced. Both are None when the client carries no timeout at all,
+            # which is "not measured" and not "not clamped".
+            configured = _ch_timeout(client)
+            in_force = _clamp_ch_timeout(client)
             res = ch_query(client, ch_sql)
             res["sql"] = ch_sql
+            res["timeout_secs"] = in_force
+            res["timeout_clamped_from"] = (
+                configured
+                if (configured is not None and in_force is not None
+                    and configured > in_force)
+                else None)
             report["clickhouse"] = res
 
     report["summary"] = summarize(report)

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -1590,7 +1590,8 @@ def repo_probe_argv(paths):
     a recognisable name rather than `sh` so it is identifiable in a `ps` on
     either host.
     """
-    return ("sh", "-c", REPO_PROBE_SCRIPT, "sm-repo-probe", *[str(p) for p in paths])
+    return ("sh", "-c", REPO_PROBE_SCRIPT, "sm-repo-probe",
+            *[str(p) for p in paths])
 
 
 def parse_repo_probe(raw, paths) -> dict:

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -3929,7 +3929,7 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
     #
     # Pinned as a RELATIONSHIP by
     # `test_the_repo_probe_is_issued_AFTER_every_other_read_on_every_host` (the
-    # order) and `test_the_BUDGET_starves_the_repo_probe_and_never_the_ledger`
+    # order) and `test_the_BUDGET_starves_the_repo_probe_and_NEVER_the_ledger`
     # (the consequence). Both fail if a SIXTH read is inserted ahead of the
     # ledger, which is the shape this regression arrived in.
     for host in hosts:

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -504,17 +504,33 @@ TMUX_WINDOWS_ARGV = ("tmux", "list-windows", "-a", "-F", WINDOW_FORMAT)
 # and index 1 — a genuine repo — resolved to `WRONG`, with `unparseable: 0`. The
 # paths are the operator's own panes on his own hosts, so this is not a security
 # hole; it is a CONFIDENT WRONG ANSWER, which is worse than the honest split
-# this feature replaces. THREE independent defences now, because each closes a
-# different half:
+# this feature replaces. FOUR defences now — and they are LAYERED, NOT
+# INDEPENDENT. An earlier revision of this comment called them "three
+# independent defences … each closes a different half", which is false in the
+# way that matters: defence 1 is the ONLY cover for a bare `\n`, so a maintainer
+# who reads "independent" and drops it as redundant re-opens the whole hole
+# through the shipped path. Read the coverage, never the count:
 #   1. the script REFUSES a common dir containing a newline (`case $d in *"$NL"*`
 #      — POSIX, no `tr`, so it cannot be disarmed by a missing coreutils) and
-#      reports `REPO_PROBE_RC_NEWLINE` for that path instead;
+#      reports `REPO_PROBE_RC_NEWLINE` for that path instead.
+#      🔴 SOLE COVER for a bare `\n`, and nothing downstream can take it over:
+#      two well-formed records are two well-formed records to any parser;
 #   2. the parser splits on `"\n"` ONLY, never `str.splitlines()`, which also
 #      splits `\r`, `\x0b`, `\x0c`, `\x1c`-`\x1e`, `\x85`, `\u2028`, `\u2029` —
 #      a reader that splits on MORE characters than the writer joined with is a
-#      forging surface all by itself;
-#   3. a DUPLICATE index is counted `unparseable` and the FIRST answer stands,
-#      so even a forged record cannot overwrite a real one.
+#      forging surface all by itself. Covers a LONE break character;
+#   3. a record carrying any of those characters POISONS THE REMAINDER OF THE
+#      REPLY: it and every line after it are counted `unparseable`. This covers
+#      the TWO-character `<break><newline>` sequence, which defence 2 alone does
+#      NOT — measured with per-line refusal only, a reply whose first record
+#      ended `…/w/a/.git` + CR and was followed by `3<TAB>0<TAB>/w/forged/.git`
+#      had the CR fragment refused and the second fragment ACCEPTED, and `/w/c`
+#      resolved to `forged` with `unparseable: 2`. Adjacency-based narrowings of
+#      this rule ("refuse the NEXT line too") are walkable — CR, space, newline;
+#   4. a DUPLICATE index is counted `unparseable` and the FIRST answer stands,
+#      so a forged record cannot overwrite a real one that already landed. It
+#      does NOT cover a forged record for a LATER index — that one arrives
+#      first, which is exactly why 1-3 exist.
 #
 # 🔴 EVERY RECORD CARRIES `git`'s OWN EXIT STATUS, and that is what makes
 # `not_a_repo` a measurement. `d=$(git …) || d=""` collapsed exit 128 (git says:
@@ -638,6 +654,20 @@ REPO_PROBE_TIMEOUT = 15.0
 # its host reports `unmeasured` with a reason, which is the honest verdict and
 # the one this file already publishes for every other read that did not happen.
 # The sixth call is covered the day it is written, with no arithmetic.
+#
+# 🔴 `COLLECT_CH_RESERVE` IS ENFORCED, NOT ASSUMED — `_clamp_ch_timeout` applies
+# it to the client `gather` actually uses. It was a bare assumption until
+# 2026-09-04, and the assumption was reachable: the reserve and its guard both
+# read `chquery.CHConn.timeout`'s CLASS DEFAULT, while `CHConn.from_env` resolves
+# `CLICKHOUSE_HTTP_TIMEOUT` out of `~/.config/activity-collector/env` at RUNTIME.
+# A host setting it to 90 (a value this repo records having tried) passed every
+# test and would still have spent 90s after a 70s host loop, i.e. rc 124 in the
+# pusher and NO snapshot for either host. Measured: the key is not set on the
+# workbench today, so this closes a live gap rather than a live break.
+#
+# ⚠ RESIDUAL, STATED BECAUSE IT IS NOT CLOSED: `urlopen`'s timeout is per socket
+# operation, not a total for the request, so a pathological connect-then-stall
+# can still exceed the reserve. `COLLECT_MARGIN` is the only slack against that.
 COLLECT_CAP = 90.0          # `TMUX_PUSH_COLLECT_TIMEOUT` in tmux-snapshot-push.sh
 COLLECT_CH_RESERVE = 15.0   # chquery.CHConn.timeout, spent AFTER the host loop
 COLLECT_MARGIN = 5.0        # interpreter start, fuzzyclaw + cache reads, render
@@ -658,12 +688,22 @@ COLLECT_MIN_SLICE = 0.5
 # republishes the silent zero this whole file exists to refuse:
 #
 #   ok           — resolved; `repo` names the MAIN clone of the pane's cwd.
-#   not_a_repo   — MEASURED: the owning host says this path is not inside a git
-#                  work tree (or its common dir cannot honestly be named — a
-#                  bare repo, a submodule's `…/.git/modules/<n>`). A real
-#                  measured absence, and it now REQUIRES git to have said so:
-#                  the probe carries `git`'s exit status per path and only
-#                  `REPO_PROBE_RC_NOT_A_REPO` lands here.
+#   not_a_repo   — MEASURED: `git` ANSWERED for this path, and what it answered
+#                  does not name a clone. 🔴 TWO rc's reach it, not one, and an
+#                  earlier revision of this line said "only
+#                  `REPO_PROBE_RC_NOT_A_REPO` lands here" — false, and false in
+#                  the direction that gets code deleted as unreachable:
+#                    · rc `REPO_PROBE_RC_NOT_A_REPO` — git says this path is not
+#                      inside a work tree;
+#                    · rc 0 with a common dir whose parent is not a clone root —
+#                      an empty answer, a bare repo (`/srv/foo.git`), or a
+#                      submodule (`<super>/.git/modules/<n>`). Naming one would
+#                      publish a confident wrong group, so it fails soft here.
+#                      These are the three rc-0 returns in
+#                      `repo_from_common_dir`; they are REACHABLE.
+#                  What `not_a_repo` still excludes is the thing this branch
+#                  exists for: a FAILURE to measure. Every non-zero rc that is
+#                  not `REPO_PROBE_RC_NOT_A_REPO` is the per-path `unmeasured`.
 #   home         — MEASURED, and deliberately withheld. The resolved main clone
 #                  IS the owning host's `$HOME`. `projectOf()` in clawgate
 #                  routes `/home/zach` and `/root` to `Other` precisely so every
@@ -1721,6 +1761,18 @@ def repo_probe_argv(paths):
             *[str(p) for p in paths])
 
 
+def _is_ascii_int(s) -> bool:
+    """True exactly when `int(s.strip())` is a non-negative ASCII integer. PURE.
+
+    🔴 THE ONE WRITER OF "IS THIS FIELD AN INTEGER", because the alternative is
+    a validator and a converter that disagree. `str.isdigit()` alone is True for
+    `²` and `①`; `int()` rejects both. Anywhere those two predicates are
+    open-coded apart, the gap is an unhandled `ValueError` on a path a docstring
+    promised would be `unparseable`.
+    """
+    return isinstance(s, str) and s.strip().isascii() and s.strip().isdigit()
+
+
 def parse_repo_probe(raw, paths) -> dict:
     """Probe stdout -> `{"measured", "home", "answers", "seen", "unparseable"}`.
 
@@ -1750,18 +1802,30 @@ def parse_repo_probe(raw, paths) -> dict:
     sentinel is `measured: False` — the caller publishes `unmeasured`, and the
     guard downstream has no unreachable branch.
 
-    A record whose index or rc is not an integer, or whose index is outside the
-    input list, is counted `unparseable` and skipped.
+    A record whose index or rc is not an ASCII integer (`_is_ascii_int`), or
+    whose index is outside the input list, is counted `unparseable` and skipped.
 
     🔴 A DUPLICATE INDEX IS `unparseable` AND THE FIRST ANSWER STANDS. This
-    branch is not hygiene — it is the third of the three defences described at
+    branch is not hygiene — it is one layer of the defence described at
     `REPO_PROBE_SCRIPT` against a common dir forging a second record. A plain
     assignment here let the LAST record for an index win, so a forged one
     landing after the genuine one replaced a real repo with a confident wrong
     name while `unparseable` reported 0. First-wins alone is not sufficient
     either (a forged record for a LATER index arrives before its genuine one),
-    which is why the script refuses the newline at the source and the split
-    below is on `"\n"` and nothing else.
+    which is why the script refuses the newline at the source, the split below
+    is on `"\n"` and nothing else, and a record carrying any OTHER line-break
+    character poisons the remainder of the reply.
+
+    🔴 THIS PARSER IS NOT SELF-SUFFICIENT AGAINST A BARE `\\n`, AND SAYING SO IS
+    THE POINT. A common dir holding a plain newline splits into two well-formed
+    records here, and the second can claim any index. Nothing in this function
+    can tell that apart from two genuine records — only the SCRIPT can, because
+    only the script knows the string came back from one `git`. The script's
+    `case $d in *"$NL"*` guard (`REPO_PROBE_RC_NEWLINE`) is therefore
+    LOAD-BEARING, not belt-and-braces: delete it and this function is forgeable
+    through the shipped path. What this function does own is every OTHER
+    line-break character, which the script passes through as data because they
+    are not newlines and it is right not to touch them.
     """
     # 🔴 `.split("\n")`, NEVER `.splitlines()`. The writer joins records with
     # `\n`; `splitlines()` ALSO splits on `\r`, `\x0b`, `\x0c`, `\x1c`-`\x1e`,
@@ -1783,6 +1847,9 @@ def parse_repo_probe(raw, paths) -> dict:
     paths = list(paths)
     out, seen, unparseable = {}, 0, 0
     started = False
+    # Set the moment a record carries a character `str.splitlines()` would treat
+    # as a line break: from there on this reply's record boundaries are unknown.
+    poisoned = False
     for line in lines:
         if not started:
             started = line is head
@@ -1790,10 +1857,29 @@ def parse_repo_probe(raw, paths) -> dict:
         if not line.strip():
             continue
         seen += 1
-        if any(ch in line for ch in REPO_PROBE_RECORD_BREAKERS):
-            # A record whose extent depends on WHICH line splitter reads it.
-            # Refusing it costs that path its answer (`missing`) and cannot cost
-            # any OTHER path a wrong one. See REPO_PROBE_RECORD_BREAKERS.
+        if poisoned or any(ch in line for ch in REPO_PROBE_RECORD_BREAKERS):
+            # 🔴 A BREAKER POISONS THE REST OF THE REPLY, AND REFUSING ONLY THE
+            # LINE IT LANDED ON WAS MEASURED FORGEABLE. `\r\n` is TWO characters:
+            # the `\n` ends the line, so the breaker guard sees — and refuses —
+            # only the FIRST fragment, while the second is a well-formed record
+            # that can claim any index it likes and win on first-come. Measured
+            # against `SM_REPO_V2 /home/op\n1\t0\t/w/a/.git\r\n3\t0\t/w/forged/
+            # .git\n2\t0\t/w/b/.git\n3\t0\t/w/c/.git\n`: `/w/c` resolved to
+            # `forged` with `unparseable: 2`.
+            #
+            # 🔴 AND "REFUSE THE NEXT LINE TOO" IS WALKABLE — do not narrow this
+            # to that. A trailing byte after the breaker (`…\r \n…`) puts the
+            # breaker mid-line while the `\n` still starts an attacker-controlled
+            # record, so any rule keyed on ADJACENCY has a spelling that evades
+            # it. Once a character the writer never used as a separator is inside
+            # a record, NO later boundary in this reply is knowable, so every
+            # line after it is refused too.
+            #
+            # The cost is bounded and honest: this path and every path after it
+            # report `missing` — a measured host with unmeasured paths — and no
+            # path anywhere gets a WRONG answer. Each refused line is COUNTED, so
+            # `repos_unparseable` says how much was dropped.
+            poisoned = True
             unparseable += 1
             continue
         fields = line.split("\t", 2)
@@ -1801,7 +1887,16 @@ def parse_repo_probe(raw, paths) -> dict:
             unparseable += 1
             continue
         idx, code, common = fields
-        if not idx.strip().isdigit() or not code.strip().isdigit():
+        # 🔴 `.isascii()` FIRST, AND IT IS NOT A NICETY. `str.isdigit()` is True
+        # for `²`, `①` and every other Unicode digit-ish character, while `int()`
+        # accepts only a subset of them — so `"²".isdigit()` passes this guard
+        # and `int("²")` two lines down raises `ValueError`, where the docstring
+        # promises `unparseable`. The blast radius is what makes a one-word bug
+        # worth a comment: `gather` does not catch it, `tmux-snapshot-push.sh`
+        # turns any traceback into `exit 3`, and that is NO snapshot for EITHER
+        # host. `isascii() and isdigit()` is exactly the set `int()` accepts
+        # without a sign, so the guard and the conversion can no longer disagree.
+        if not _is_ascii_int(idx) or not _is_ascii_int(code):
             unparseable += 1
             continue
         i = int(idx.strip()) - 1
@@ -3470,6 +3565,27 @@ def make_ch_client(env_file=ACTIVITY_ENV, opener=None):
     return _chq.CHClient(_chq.CHConn.from_env(env), opener=opener)
 
 
+def _clamp_ch_timeout(client, reserve=COLLECT_CH_RESERVE):
+    """Hold the ClickHouse client to `COLLECT_CH_RESERVE`. Returns the timeout
+    in force, or None when this client carries none (an injected test double).
+
+    🔴 THE RESERVE IS PART OF THE BUDGET ARITHMETIC, SO IT HAS TO BE A BOUND AND
+    NOT A BELIEF. `COLLECT_BUDGET = COLLECT_CAP - COLLECT_CH_RESERVE -
+    COLLECT_MARGIN` is only true while the CH read really costs at most the
+    reserve, and `CHConn.from_env` reads `CLICKHOUSE_HTTP_TIMEOUT` from the
+    collector's env file — a per-HOST value no test in this repo can see. A
+    lowered value is left alone (it only buys headroom); only an over-run is
+    clamped.
+    """
+    conn = getattr(client, "conn", None)
+    t = getattr(conn, "timeout", None)
+    if not isinstance(t, (int, float)) or isinstance(t, bool):
+        return None
+    if t > reserve:
+        conn.timeout = float(reserve)
+    return conn.timeout
+
+
 def ch_query(client, sql) -> dict:
     """Run one query, returning a STATUS-DISCRIMINATED result.
 
@@ -3653,6 +3769,10 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
     raw_panes, slot_ids = {}, {}
     captures, capture_status = {}, {}
     ledger_res = {}
+    # Parsed once in pass 1 and re-read by the repo probe in pass 2, rather than
+    # re-parsed there: `parse_panes` is pure, so a second call would be a second
+    # copy of the same derivation and a place for the two to drift.
+    host_panes_by = {}
     # 🔴 `None` is the DISCRIMINANT, exactly as it is for `captures`. `None` =
     # this host's probe did not answer or was not run; a dict = it answered.
     repo_index, repo_host_status, repo_stats = {}, {}, {}
@@ -3670,6 +3790,7 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
         # answer; `{}` means it ran and this host had no Claude panes. The two
         # are different facts and `fold_windows` renders them differently.
         host_panes = parse_panes(panes_res["stdout"])
+        host_panes_by[host] = host_panes
         claude_ids = [p["pane_id"] for p in host_panes
                       if pane_is_claude(p) and p.get("pane_id")]
         if not use_capture:
@@ -3690,6 +3811,130 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
             else:
                 captures[host], capture_status[host] = None, "error"
 
+        # --- 🔴 CALL ORDER IS PART OF THE BUDGET, NOT A STYLE CHOICE ---------
+        # Every read shares ONE deadline (`COLLECT_BUDGET`) spanning ALL hosts,
+        # so the LAST call issued is the one that starves. That makes the order
+        # a ranking of what this collector is willing to lose, and this loop
+        # holds only the reads it is NOT willing to lose. The repo probe is in a
+        # SECOND pass below — see the block comment there for the measurement.
+        #
+        # 🔴 A SIXTH READ ADDED HERE COMES OUT OF THE LEDGER'S BUDGET. The
+        # four below already spend 68s of the 70s at their bounds, so anything
+        # inserted ahead of the ledger starves it. That is a test failure, not a
+        # silent regression:
+        # `test_the_repo_probe_is_issued_AFTER_every_other_read_on_every_host`
+        # pins this sequence exactly.
+        #
+        # 🔴 The two calls are INDEPENDENT measurements. `reachable`/`error`
+        # describe list-panes; `windows_measured`/`windows_error` describe
+        # list-windows. Reading one off the other is how a failed list-windows
+        # became invisible.
+        windows_measured = bool(wins_res["reachable"])
+        live = parse_windows(wins_res["stdout"]) if windows_measured else None
+        slot_ids[host] = slots_to_window_ids(live) if live is not None else None
+        # The tmux SERVER identity, from the SAME rows list-windows already
+        # returned — see WINDOW_FORMAT for why it rides along instead of costing
+        # a fifth ssh call. Unmeasured when list-windows itself did not answer:
+        # deriving it from a failed call is how an unmeasured value becomes a
+        # confident one.
+        if windows_measured:
+            tmux_server_id, tmux_server_id_reason = parse_tmux_server_id(
+                wins_res["stdout"])
+        else:
+            tmux_server_id, tmux_server_id_reason = None, (
+                "list-windows did not answer on this host")
+
+        # --- the agent activity ledger, ONE `sh -c` per host -----------------
+        # 🔴 Read HERE, inside the per-host loop, and filtered against THIS
+        # host's `live` windows and THIS host's tmux server pid — the pid arrives
+        # on the ledger's own sentinel line, from the same instant as the records
+        # it validates. Reusing the local host's window set for a remote host
+        # would drop every remote record on a window-id space that has nothing to
+        # do with it, and would do so silently.
+        if not use_ledger:
+            ledger_res[host] = {"status": "skipped", "records": [],
+                                "error": None}
+        elif not (panes_res["reachable"] or wins_res["reachable"]):
+            # 🔴 NOT AN OPTIMISATION DRESSED AS A MEASUREMENT. This host answered
+            # NEITHER tmux call, so it is down; issuing a third command buys one
+            # more `ConnectTimeout=4` on every scan of an offline laptop and can
+            # only return the same failure. The status is still `error` — nothing
+            # was measured and no count is published — and the reason SAYS the
+            # read was never attempted rather than implying it was tried and
+            # failed, which are different facts about the host.
+            ledger_res[host] = _host_ledger(
+                {"reachable": False,
+                 "error": "host answered neither tmux call; the ledger read "
+                          "was not attempted"},
+                live, host)
+        else:
+            if ledger_outputs is not None:
+                raw_led = ledger_outputs.get(host)
+                led_read = {"reachable": raw_led is not None,
+                            "stdout": raw_led or "",
+                            "error": None if raw_led is not None
+                            else "no injected ledger output for this host"}
+            else:
+                led_read = _read(AL.read_argv(), host)
+            ledger_res[host] = _host_ledger(led_read, live, host)
+
+        report["hosts"][host] = {
+            "reachable": bool(panes_res["reachable"]),
+            "error": panes_res["error"],
+            "ssh_target": None if host == local_host else LAPTOP_SSH_TARGET,
+            "windows": [],
+            "windows_measured": windows_measured,
+            "windows_error": wins_res["error"],
+            # 🔴 THE STABILITY SENTINEL for anything that PERSISTS a window id.
+            # tmux hands out `@0` again after a server restart, so a stored
+            # `@41` silently designates a different window; a consumer may trust
+            # a stored id only while this token is unchanged. Opaque — compare
+            # it for equality, never render it as a time (WINDOW_FORMAT records
+            # a host that reported a start_time 5.6 years wrong).
+            # Exactly one of these two is non-None, always.
+            "tmux_server_id": tmux_server_id,
+            "tmux_server_id_reason": tmux_server_id_reason,
+            "live_window_ids": (sorted(live) if live is not None else None),
+            # A THIRD independent measurement, reported separately from the
+            # other two for the same reason they are separate from each other:
+            # `list-panes` succeeding says nothing about whether the capture
+            # batch answered.
+            "captures_measured": captures[host] is not None,
+            "captures_status": capture_status[host],
+            "captures_seen": (len(captures[host])
+                              if captures[host] is not None else None),
+        }
+
+        if host == local_host:
+            local_live_windows = live
+            local_windows_error = wins_res["error"]
+
+    # --- 🔴 SECOND PASS: the repo probe, AFTER every OTHER read --------------
+    # 🔴 A SEPARATE LOOP ON PURPOSE. Folding it back into the loop above is
+    # the regression it exists to prevent, and "just move it earlier within the
+    # host" was MEASURED INSUFFICIENT: with both hosts at their bounds the LOCAL
+    # host's own 15s probe alone pushed the remote host past the 70s deadline, so
+    # the laptop lost its ledger whether the probe ran fourth or fifth on the
+    # workbench. The reads share ONE deadline across ALL hosts, so the ranking has
+    # to be across all hosts too.
+    #
+    # THE RULE: every read that existed before `repo` did — panes, windows,
+    # capture, ledger — is issued for EVERY host before the probe is issued for
+    # ANY host. The probe is the one read a consumer can turn off (`--no-repo`)
+    # and the payload stays whole; a starved ledger silently costs every row on
+    # that host `age_secs`, its `stale` bucket and `claude_session_id`, which are
+    # the three fields `use_ledger=True` was made the default to restore. So when
+    # the budget runs out, the optional field is the one that loses — by
+    # construction, not by luck.
+    #
+    # Pinned as a RELATIONSHIP by
+    # `test_the_repo_probe_is_issued_AFTER_every_other_read_on_every_host` (the
+    # order) and `test_the_BUDGET_starves_the_repo_probe_and_never_the_ledger`
+    # (the consequence). Both fail if a SIXTH read is inserted ahead of the
+    # ledger, which is the shape this regression arrived in.
+    for host in hosts:
+        host_panes = host_panes_by[host]
+        panes_reachable = report["hosts"][host]["reachable"]
         # --- 🔴 the repo probe: ONE `sh -c` per host, EVERY unique pane path --
         # It runs on the host that OWNS the directories. `label_from_path`
         # states why that is not optional: `path` is a string from another
@@ -3712,7 +3957,7 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
             repo_stats[host] = {"measured": False, "status": "skipped",
                                 "error": None, "paths": None, "resolved": None,
                                 "unparseable": None}
-        elif not panes_res["reachable"]:
+        elif not panes_reachable:
             # No paths were measured, so there is nothing to resolve and the
             # probe is not attempted — the same reasoning the ledger read uses
             # for a host that answered neither tmux call. `unmeasured`, and the
@@ -3786,100 +4031,26 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
                         "resolved": sum(1 for v in idx.values()
                                         if v.get("status") == "ok"),
                         "unparseable": parsed_repo["unparseable"]}
-        # 🔴 The two calls are INDEPENDENT measurements. `reachable`/`error`
-        # describe list-panes; `windows_measured`/`windows_error` describe
-        # list-windows. Reading one off the other is how a failed list-windows
-        # became invisible.
-        windows_measured = bool(wins_res["reachable"])
-        live = parse_windows(wins_res["stdout"]) if windows_measured else None
-        slot_ids[host] = slots_to_window_ids(live) if live is not None else None
-        # The tmux SERVER identity, from the SAME rows list-windows already
-        # returned — see WINDOW_FORMAT for why it rides along instead of costing
-        # a fifth ssh call. Unmeasured when list-windows itself did not answer:
-        # deriving it from a failed call is how an unmeasured value becomes a
-        # confident one.
-        if windows_measured:
-            tmux_server_id, tmux_server_id_reason = parse_tmux_server_id(
-                wins_res["stdout"])
-        else:
-            tmux_server_id, tmux_server_id_reason = None, (
-                "list-windows did not answer on this host")
-        report["hosts"][host] = {
-            "reachable": bool(panes_res["reachable"]),
-            "error": panes_res["error"],
-            "ssh_target": None if host == local_host else LAPTOP_SSH_TARGET,
-            "windows": [],
-            "windows_measured": windows_measured,
-            "windows_error": wins_res["error"],
-            # 🔴 THE STABILITY SENTINEL for anything that PERSISTS a window id.
-            # tmux hands out `@0` again after a server restart, so a stored
-            # `@41` silently designates a different window; a consumer may trust
-            # a stored id only while this token is unchanged. Opaque — compare
-            # it for equality, never render it as a time (WINDOW_FORMAT records
-            # a host that reported a start_time 5.6 years wrong).
-            # Exactly one of these two is non-None, always.
-            "tmux_server_id": tmux_server_id,
-            "tmux_server_id_reason": tmux_server_id_reason,
-            "live_window_ids": (sorted(live) if live is not None else None),
-            # A THIRD independent measurement, reported separately from the
-            # other two for the same reason they are separate from each other:
-            # `list-panes` succeeding says nothing about whether the capture
-            # batch answered.
-            "captures_measured": captures[host] is not None,
-            "captures_status": capture_status[host],
-            "captures_seen": (len(captures[host])
-                              if captures[host] is not None else None),
-            # A FOURTH independent measurement, reported separately for the
-            # same reason the other three are separate from each other. 🔴 THIS
-            # IS THE HOST-LEVEL DISCRIMINANT constraint that stops a failed repo
-            # probe from reading as "none of these panes is in a repo":
-            # `repos_measured: false` means no row on this host carries a repo
-            # BECAUSE NOBODY LOOKED, and `repos_status` names which of the four
-            # ways that happened (`skipped` / `unmeasured` / `error` /
-            # `no_sentinel`). `repos_resolved` is an integer ONLY when measured.
+        # A FOURTH independent measurement, reported separately for the same
+        # reason the other three are separate from each other. 🔴 THIS IS THE
+        # HOST-LEVEL DISCRIMINANT constraint that stops a failed repo probe from
+        # reading as "none of these panes is in a repo": `repos_measured: false`
+        # means no row on this host carries a repo BECAUSE NOBODY LOOKED, and
+        # `repos_status` names which of the four ways that happened (`skipped` /
+        # `unmeasured` / `error` / `no_sentinel`). `repos_resolved` is an integer
+        # ONLY when measured.
+        #
+        # `update`, not part of the literal above, because these six keys are the
+        # only ones this second pass owns — and the pass exists so the probe runs
+        # last. They stay LAST in the entry either way.
+        report["hosts"][host].update({
             "repos_measured": repo_stats[host]["measured"],
             "repos_status": repo_stats[host]["status"],
             "repos_error": repo_stats[host]["error"],
             "repos_paths": repo_stats[host]["paths"],
             "repos_resolved": repo_stats[host]["resolved"],
             "repos_unparseable": repo_stats[host]["unparseable"],
-        }
-        # --- the agent activity ledger, ONE `sh -c` per host -----------------
-        # 🔴 Read HERE, inside the per-host loop, and filtered against THIS
-        # host's `live` windows and THIS host's tmux server pid — the pid arrives
-        # on the ledger's own sentinel line, from the same instant as the records
-        # it validates. Reusing the local host's window set for a remote host
-        # would drop every remote record on a window-id space that has nothing to
-        # do with it, and would do so silently.
-        if not use_ledger:
-            ledger_res[host] = {"status": "skipped", "records": [],
-                                "error": None}
-        elif not (panes_res["reachable"] or wins_res["reachable"]):
-            # 🔴 NOT AN OPTIMISATION DRESSED AS A MEASUREMENT. This host answered
-            # NEITHER tmux call, so it is down; issuing a third command buys one
-            # more `ConnectTimeout=4` on every scan of an offline laptop and can
-            # only return the same failure. The status is still `error` — nothing
-            # was measured and no count is published — and the reason SAYS the
-            # read was never attempted rather than implying it was tried and
-            # failed, which are different facts about the host.
-            ledger_res[host] = _host_ledger(
-                {"reachable": False,
-                 "error": "host answered neither tmux call; the ledger read "
-                          "was not attempted"},
-                live, host)
-        else:
-            if ledger_outputs is not None:
-                raw_led = ledger_outputs.get(host)
-                led_read = {"reachable": raw_led is not None,
-                            "stdout": raw_led or "",
-                            "error": None if raw_led is not None
-                            else "no injected ledger output for this host"}
-            else:
-                led_read = _read(AL.read_argv(), host)
-            ledger_res[host] = _host_ledger(led_read, live, host)
-        if host == local_host:
-            local_live_windows = live
-            local_windows_error = wins_res["error"]
+        })
 
     # --- 🔴 the intersection guard, then the pane<->task join ----------------
     if use_fuzzyclaw:
@@ -4137,6 +4308,10 @@ def gather(hosts=HOST_NAMES, local_host=None, runner=None, use_ch=True,
                                     "error": f"{type(e).__name__}: {e}",
                                     "code": None, "sql": ch_sql}
         if client is not None:
+            # 🔴 The reserve, ENFORCED on the client that spends it. See
+            # `_clamp_ch_timeout` — without this the budget arithmetic is a
+            # belief about a per-host env file this process never checks.
+            _clamp_ch_timeout(client)
             res = ch_query(client, ch_sql)
             res["sql"] = ch_sql
             report["clickhouse"] = res

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -662,8 +662,11 @@ REPO_PROBE_TIMEOUT = 15.0
 # `CLICKHOUSE_HTTP_TIMEOUT` out of `~/.config/activity-collector/env` at RUNTIME.
 # A host setting it to 90 (a value this repo records having tried) passed every
 # test and would still have spent 90s after a 70s host loop, i.e. rc 124 in the
-# pusher and NO snapshot for either host. Measured: the key is not set on the
-# workbench today, so this closes a live gap rather than a live break.
+# pusher and NO snapshot for either host. Measured 2026-09-04 on BOTH hosts —
+# workbench and laptop, neither sets the key — so this closes a live gap rather
+# than a live break. ⚠ That measurement is a fact about TODAY's env files, which
+# is exactly why the reserve is a BOUND and not a note: an operator can set the
+# key on either host tomorrow and nothing in this repo would see it.
 #
 # ⚠ RESIDUAL, STATED BECAUSE IT IS NOT CLOSED: `urlopen`'s timeout is per socket
 # operation, not a total for the request, so a pathological connect-then-stall

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -1471,6 +1471,27 @@ PINNED_PATH_CLOBBERS = {
         "condition at all. 🔴 It removes python3 and everything else — the test "
         "asserts only the hook's exit status and that the message file is "
         "byte-identical, both of which are independent of what else is on PATH"),
+    "test_session_manager.py": (
+        '"PATH"' + ': binp, "HOME": home',
+        "session-manager's repo probe guards its own `git`/`timeout` absence, "
+        "and three §R tests measure what it does when one of them is genuinely "
+        "missing on the OWNING host: `git` gone (the record must carry rc 127 "
+        "and land in the per-path `unmeasured`, never the MEASURED "
+        "`not_a_repo`), `timeout` gone (the host must still resolve its repos "
+        "rather than lose the field), and a hung `git` WITH `timeout` present "
+        "(the per-path bound must hold). 🔴 REPLACING is required to reach any "
+        "of those: both binaries are present on the dev host AND inside the "
+        "sandbox, so no amount of PREPENDING can make one unfindable and a "
+        "prepending version would measure the environment instead of the "
+        "script. All three go through ONE helper, `_r_path_only`, so this "
+        "single needle covers every site rather than pinning whichever the "
+        "scan reaches first. The directory is CONSTRUCTED by `_r_only_bin` in "
+        "tmp_path — one symlink per NAMED tool, and it asserts its own "
+        "contents are exactly that set — so it holds at most {sh, timeout, "
+        "git} plus a fake `git` written by `testlib.mockbin.write_exec`. No "
+        "HAZARD_VOCABULARY name is reachable through it: no systemd-run, "
+        "systemctl, notify-send, rofi, yad, xdotool, i3-msg, openrgb, espanso, "
+        "home-manager or nixos-rebuild"),
     "test_rig_control.py": (
         '"PATH"' + ': "/usr/bin/false"',
         "deliberately makes yad unfindable; /usr/bin/false holds no binaries, so "

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -13925,6 +13925,31 @@ def test_the_contract_docs_budget_numbers_are_PINNED_to_the_constants():
         % (m.group(1), sm.COLLECT_CAP))
 
 
+def test_every_TEST_NAME_the_contract_cites_actually_EXISTS():
+    """🔴 A DOC THAT NAMES A GUARD IS MAKING A CLAIM ABOUT COVERAGE, and a name
+    that resolves to nothing is the worst kind: it reads as "this is pinned" and
+    stops the next person looking. This guard was written because the round-3
+    fix introduced exactly that — the contract cited
+    `test_the_per_host_call_ORDER_puts_the_optional_probe_LAST`, a name that had
+    been changed during the same change and never existed in the suite.
+
+    Resolved against the module's own symbol table, so a rename that misses the
+    doc fails here rather than rotting silently.
+    """
+    cited = set(re.findall(r"`(test_[A-Za-z0-9_]+)`", _contract_text()))
+    assert cited, "the contract cites no test names at all any more"
+    here = set(globals())
+    missing = sorted(n for n in cited if n not in here)
+    assert not missing, (
+        "payload-contract.md cites test(s) that do not exist in "
+        "test_session_manager.py: %r" % missing)
+    # POSITIVE CONTROL on the extraction: it really pulled real names out, and
+    # it can also SEE a name that is absent.
+    assert "test_the_contract_docs_budget_numbers_are_PINNED_to_the_constants" \
+        in cited, sorted(cited)
+    assert "test_definitely_not_defined_anywhere" not in here
+
+
 def test_the_contract_carries_NO_V1_ERA_FLEET_MEASUREMENT_as_current():
     """🔴 A MEASUREMENT TAKEN UNDER THE BUG IS NOT EVIDENCE ABOUT THE FIX. The
     contract carried "Measured on the live fleet 2026-09-03: 90 of 92 windows

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -12288,6 +12288,36 @@ def test_build_repo_index_gives_a_SHORT_reply_the_missing_status():
         "/w/c": {"repo": None, "status": "missing"}}
 
 
+def test_row_repos_missing_branch_is_UNREACHABLE_from_gather_and_says_so():
+    """🔴 A GUARD NOBODY CAN REACH IS NOT A DEFENCE — so this pins WHICH of the
+    two spellings of `missing` is live, rather than letting the row-level one
+    read as coverage it does not provide.
+
+    `gather` feeds the probe EVERY pane path on a host and `build_repo_index`
+    fills an entry for each one, so a row's lead path is always a key and
+    `row_repo`'s `missing` branch never executes in the pipeline. The STATUS is
+    still real — `build_repo_index` produces it whenever the reply is SHORTER
+    than its input, which a truncated ssh read genuinely does.
+    """
+    # (a) the row-level branch: reachable only by hand, and it is CORRECT there
+    assert sm.row_repo("/w/a", {}) == {"repo": None, "repo_status": "missing"}
+    # (b) ...and NOT reachable through gather: every lead path is probed. Feed a
+    # host three panes at three paths and assert none comes back `missing`.
+    panes = "\n".join([
+        "%1|1|s|1|w|/w/one|claude|t",
+        "%2|2|s|2|w|/w/two|zsh|t",
+        "%3|3|s|3|w|/w/three|zsh|t"])
+    rep = base_gather(runner=make_runner(
+        local_panes=panes,
+        local_repo=repo_out("/w/one/.git", "", "/w/three/.git")))
+    got = {r["repo_status"] for r in rep["hosts"]["workbench"]["windows"]}
+    assert "missing" not in got, got
+    assert got == {"ok", "not_a_repo"}
+    # (c) the docstring SAYS it is unreachable, so the claim travels with the
+    # code rather than living only here.
+    assert "UNREACHABLE FROM `gather`" in sm.row_repo.__doc__
+
+
 def test_build_repo_index_returns_NONE_for_an_unmeasured_probe():
     """🔴 NOT a dict of `not_a_repo` entries. That substitution — a failed probe
     rendered as a completed measurement — is the worst outcome available here,

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -31,6 +31,7 @@ import importlib.util
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 
@@ -274,15 +275,46 @@ SLOTS_FIXTURE = {
 }
 
 
+def repo_out(*common_dirs, home="/home/zach", sentinel=None):
+    """The bytes a host's repo probe actually returns.
+
+    The sentinel line carrying that host's OWN `$HOME`, then one
+    `<1-based index>\\t<common dir>` line per input path, in input order. The
+    paths are NOT echoed back — the index is the key, which is what makes a
+    path containing a tab or a newline harmless.
+
+    🔴 RENDERED, NOT TYPED, for the same reason the window fixtures are: a
+    hand-typed body encodes a reader's belief about the format instead of the
+    format itself.
+    """
+    head = "%s %s" % (sentinel or sm.REPO_PROBE_SENTINEL, home) if home \
+        else (sentinel or sm.REPO_PROBE_SENTINEL)
+    rows = ["%d\t%s" % (i, d or "")
+            for i, d in enumerate(common_dirs, start=1)]
+    return "\n".join([head] + rows) + "\n"
+
+
+# The DEFAULT probe answers, one per host, matching each host's sorted-unique
+# pane paths. Workbench: `/home/zach/tmp` (no repo), `/home/zach/workspace/
+# repo-alpha` (a repo). Laptop: `/home/zach/workspace/naida` (a repo, and its
+# common dir is the LAPTOP's — the workbench has no such checkout, which is the
+# whole point of resolving on the owning host).
+WORKBENCH_REPO_OUT = repo_out("", "/home/zach/workspace/repo-alpha/.git")
+LAPTOP_REPO_OUT = repo_out("/home/zach/workspace/naida/.git")
+
+
 def make_runner(local_panes=WORKBENCH_PANES, local_windows=WORKBENCH_WINDOWS,
                 remote_panes=LAPTOP_PANES, remote_windows=LAPTOP_WINDOWS,
                 local_capture="local captured output\n",
                 remote_capture="remote captured output\n",
+                local_repo=WORKBENCH_REPO_OUT, remote_repo=LAPTOP_REPO_OUT,
                 remote_rc=0, remote_err="", local_rc=0, local_err="",
                 local_windows_rc=None, local_windows_err=None,
                 remote_windows_rc=None, remote_windows_err=None,
                 local_capture_rc=None, local_capture_err=None,
                 remote_capture_rc=None, remote_capture_err=None,
+                local_repo_rc=None, local_repo_err=None,
+                remote_repo_rc=None, remote_repo_err=None,
                 calls=None):
     """A fake `_default_runner` that answers PER SUBCOMMAND. Records argv.
 
@@ -295,9 +327,19 @@ def make_runner(local_panes=WORKBENCH_PANES, local_windows=WORKBENCH_WINDOWS,
     cannot pin which one a fact came from — so it certifies nothing about that
     fact's provenance, however many tests are green.
 
-    `*_windows_rc` / `*_capture_rc` (and their `_err` twins) default to the
-    host-wide `*_rc` / `*_err`, so every existing call site keeps its exact
-    meaning. Pass them to fail EXACTLY ONE subcommand.
+    `*_windows_rc` / `*_capture_rc` / `*_repo_rc` (and their `_err` twins)
+    default to the host-wide `*_rc` / `*_err`, so every existing call site keeps
+    its exact meaning. Pass them to fail EXACTLY ONE subcommand.
+
+    🔴 THE REPO PROBE IS A FOURTH DISTINGUISHABLE CALL, NOT FOLDED INTO `panes`.
+    It was, briefly, and the fall-through was silent: the probe argv matched
+    neither `list-windows` nor `capture-pane`, so the fixture answered it with
+    the PANES output, `parse_repo_probe` found no sentinel, and every host
+    reported `repos_measured: false` while the suite stayed green. That is
+    exactly the blind spot the paragraph above was written about, one call
+    later. It is keyed on the probe's own sentinel, which is IN the script text
+    — so a rename of the sentinel breaks the fixture loudly rather than
+    silently re-creating the fall-through.
     """
     calls = calls if calls is not None else []
 
@@ -317,6 +359,10 @@ def make_runner(local_panes=WORKBENCH_PANES, local_windows=WORKBENCH_WINDOWS,
         ("remote", "capture"): (_or(remote_capture_rc, remote_rc),
                                 remote_capture,
                                 _or(remote_capture_err, remote_err)),
+        ("local", "repo"): (_or(local_repo_rc, local_rc), local_repo,
+                            _or(local_repo_err, local_err)),
+        ("remote", "repo"): (_or(remote_repo_rc, remote_rc), remote_repo,
+                             _or(remote_repo_err, remote_err)),
     }
 
     def runner(argv, timeout):
@@ -324,7 +370,8 @@ def make_runner(local_panes=WORKBENCH_PANES, local_windows=WORKBENCH_WINDOWS,
         where = "remote" if (argv and argv[0] == "ssh") else "local"
         joined = " ".join(argv)
         what = ("windows" if "list-windows" in joined else
-                "capture" if "capture-pane" in joined else "panes")
+                "capture" if "capture-pane" in joined else
+                "repo" if sm.REPO_PROBE_SENTINEL in joined else "panes")
         rc, out, err = table[(where, what)]
         return (rc, "", err) if rc != 0 else (0, out, "")
 
@@ -353,6 +400,17 @@ def test_make_runner_can_distinguish_the_two_subprocesses():
     # capture-pane is a THIRD distinguishable call, not folded into panes
     cap = make_runner(local_capture="scrollback\n")
     assert cap(sm.tail_argv("scratch7:3"), 5)[1] == "scrollback\n"
+    # 🔴 ...and the repo probe is a FOURTH. Both directions, on the SAME runner,
+    # so this cannot pass by the probe silently receiving the panes answer —
+    # which is what it did before this arm existed.
+    probe = sm.repo_probe_argv(["/home/zach/workspace/repo-alpha"])
+    rep = make_runner(local_repo="PROBE-OUT\n")
+    assert rep(list(probe), 5)[1] == "PROBE-OUT\n"
+    assert rep(list(sm.TMUX_PANES_ARGV), 5)[1] == WORKBENCH_PANES
+    # ...and it can fail ALONE, while panes on the same host stay green.
+    only = make_runner(local_repo_rc=1, local_repo_err="probe blew up")
+    assert only(list(probe), 5) == (1, "", "probe blew up")
+    assert only(list(sm.TMUX_PANES_ARGV), 5)[0] == 0
 
 
 # Captured BEFORE any test monkeypatches sm.gather — otherwise a test that
@@ -1907,7 +1965,9 @@ def test_json_golden_schema_and_values():
     assert set(wb) == {"reachable", "error", "ssh_target", "windows",
                        "live_window_ids", "windows_measured", "windows_error",
                        "tmux_server_id", "tmux_server_id_reason",
-                       "captures_measured", "captures_status", "captures_seen"}
+                       "captures_measured", "captures_status", "captures_seen",
+                       "repos_measured", "repos_status", "repos_error",
+                       "repos_paths", "repos_resolved", "repos_unparseable"}
     assert wb["ssh_target"] is None
     assert wb["live_window_ids"] == ["@41", "@52", "@63"]
     assert wb["windows_measured"] is True
@@ -1946,6 +2006,15 @@ def test_json_golden_schema_and_values():
         "hotkey_display": "Alt+Shift+S",
         "pane_id": "%11",
         "path": "/home/zach/workspace/repo-alpha",
+        # 🔴 THE PROJECT KEY, and it is NOT the label. This row's `label` is
+        # `Grove` (the slot table won tier 1) and its path leaf is
+        # `repo-alpha` — three different strings for three different
+        # questions, so a mutant that sourced `repo` from either of the other
+        # two cannot satisfy this golden. The value comes from the WORKBENCH's
+        # probe answer (`/home/zach/workspace/repo-alpha/.git`), so this
+        # asserts the common dir reached the row through the real parser.
+        "repo": "repo-alpha",
+        "repo_status": "ok",
         "command": "claude",
         "task": "Working on alpha",
         "claude": True,
@@ -6774,6 +6843,13 @@ def test_the_row_FIELD_LEDGER_fails_when_it_grows_or_shrinks():
         # it wrong against a live fleet — see `sm.hotkey_display`.
         "hotkey_display",
         "pane_id", "path",
+        # 🔴 The PROJECT key and its provenance. `repo` is the MAIN CLONE,
+        # resolved on the host that owns the directory, so two worktrees of one
+        # repo share it — which `path`'s leaf structurally cannot do.
+        # `repo_status` rides with it because `repo: null` from a probe that
+        # never ran and `repo: null` from a pane outside a work tree are the
+        # same value and completely different facts. See `sm.REPO_STATUSES`.
+        "repo", "repo_status",
         "command",
         "task", "claude", "busy", "age_secs", "age_source", "status",
         "waiting_probable", "waiting_signals", "waiting_status",
@@ -7369,6 +7445,11 @@ def test_the_LEAN_row_field_ledger_fails_when_it_grows_or_shrinks():
         # `Alt+Shift+V`; dropping it here puts the derivation back where it
         # already failed.
         "hotkey_display",
+        # 🔴 The project key. This view's consumer is the one that GROUPS, and
+        # grouping on `label` yields codename pseudo-groups while grouping on
+        # the `path` leaf splits every worktree off on its own. `repo_status`
+        # is provenance, and provenance never goes from this view.
+        "repo", "repo_status",
         "path", "task", "runtime", "claude", "busy", "status", "age_secs",
         "age_source",
         "waiting_probable", "waiting_signals", "waiting_status",
@@ -7557,6 +7638,10 @@ def test_the_LEAN_HOST_field_ledger_fails_when_it_grows_or_shrinks():
     assert set(sm.LEAN_HOST_FIELDS) == {
         "reachable", "error", "windows_measured", "windows_error",
         "captures_measured", "captures_status", "captures_seen",
+        # The repo probe's own provenance — a FOURTH independent measurement,
+        # and the only thing that makes a host of `repo: null` rows readable.
+        "repos_measured", "repos_status", "repos_error",
+        "repos_paths", "repos_resolved", "repos_unparseable",
     }
     assert lean["lean_host_fields"] == list(sm.LEAN_HOST_FIELDS)
     for host, h in lean["hosts"].items():
@@ -11957,3 +12042,671 @@ def test_the_flag_reaches_gather_and_is_OFF_in_its_signature():
     p = sm.build_parser()
     assert p.parse_args(["scan", "--json"]).pane_preview is False
     assert p.parse_args(["scan", "--json", "--pane-preview"]).pane_preview is True
+
+
+# =========================================================================== #
+# §R — `repo`: THE PROJECT KEY, RESOLVED ON THE HOST THAT OWNS THE DIRECTORY
+#
+# 🔴 THE DEFECT THIS SECTION EXISTS FOR. clawgate's tmux page groups windows by
+# project through ONE seam, `projectOf()`: `repo` if non-empty -> the LEAF of
+# `path` -> `Other`. The producer published no `repo`, so the leaf won every
+# time and a git WORKTREE formed its own project group — `ht-r11-930492` sat
+# apart from `homelab-talos`, which on a worktree-heavy box is most of the long
+# tail. No string operation on `path` can fix that: `ht-r11-930492` is not
+# derivable from `homelab-talos`, and guessing is worse than the honest split.
+#
+# 🔴 AND IT CANNOT BE RESOLVED HERE. `label_from_path`'s docstring already
+# states why: `path` is A STRING FROM ANOTHER MACHINE — roughly half these rows
+# come off the laptop over ssh — so a local `git rev-parse` would answer about
+# whatever happens to sit at that path on THIS host, or about nothing. The
+# resolution therefore travels over the same per-host `run_tmux` seam the tmux
+# calls use, batched into ONE `sh -c` per host.
+# =========================================================================== #
+
+# 🔴 NOT a skipif, the same rule `test_git_repo_isolation.py` states for itself:
+# `git` is in run-tests.sh's REQUIRED_TOOLS and in the flake's pytests check, so
+# its absence is an ERROR. A skipped worktree test reports the closing condition
+# of this whole feature as met without ever measuring it.
+import shutil  # noqa: E402 — beside the guard it exists for
+
+if shutil.which("git") is None:  # pragma: no cover - the gate puts git on PATH
+    raise RuntimeError(
+        "git is not on PATH. Add it to REQUIRED_TOOLS in scripts/run-tests.sh "
+        "and to the pytests check in flake.nix rather than skipping §R.")
+
+_R_GIT_ENV = {
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_TERMINAL_PROMPT": "0",
+    "GIT_AUTHOR_NAME": "repo probe",
+    "GIT_AUTHOR_EMAIL": "repo-probe@example.invalid",
+    "GIT_COMMITTER_NAME": "repo probe",
+    "GIT_COMMITTER_EMAIL": "repo-probe@example.invalid",
+}
+
+
+def _r_env(**extra):
+    e = dict(os.environ)
+    e.update(_R_GIT_ENV)
+    e.update({k: str(v) for k, v in extra.items()})
+    return e
+
+
+def _r_mkrepo(path):
+    """A real committed repo at `path`."""
+    os.makedirs(str(path), exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", "main", str(path)],
+                   check=True, capture_output=True, env=_r_env())
+    with open(os.path.join(str(path), "f.txt"), "w", encoding="utf-8") as fh:
+        fh.write("base\n")
+    subprocess.run(["git", "-C", str(path), "add", "f.txt"],
+                   check=True, capture_output=True, env=_r_env())
+    subprocess.run(["git", "-C", str(path), "commit", "-qm", "base"],
+                   check=True, capture_output=True, env=_r_env())
+    return str(path)
+
+
+def _r_probe(paths, home, cwd=None):
+    """Run the REAL `repo_probe_argv` through a REAL `sh`, parsed by the REAL
+    parser.
+
+    🔴 THE SHIPPING INSTRUMENT, NOT A COPY OF IT — the same argument
+    `agent_ledger._dir_expr` makes for its `abs_dir` hook: a hand-copied command
+    in a test validates the copy while the one that ships stays unexercised.
+    """
+    proc = subprocess.run(list(sm.repo_probe_argv(paths)),
+                          capture_output=True, text=True,
+                          env=_r_env(HOME=home), cwd=cwd, timeout=60)
+    return proc, sm.parse_repo_probe(proc.stdout, paths)
+
+
+# --------------------------------------------------------------------------- #
+# §R.1 — the pure resolution. Literal expectations, never derived from the impl.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("common_dir,home,repo,status", [
+    # the ordinary case: a clone at /w/devrc
+    ("/home/zach/workspace/devrc/.git", "/home/zach", "devrc", "ok"),
+    # trailing slash: `/w/devrc/.git/` and `/w/devrc/.git` are one directory
+    ("/home/zach/workspace/devrc/.git/", "/home/zach", "devrc", "ok"),
+    # surrounding whitespace is stripped — the probe prints a bare line, but a
+    # value arriving with a stray \r must not become a repo called `.git\r`
+    ("  /home/zach/workspace/devrc/.git  ", "/home/zach", "devrc", "ok"),
+    # 🔴 $HOME IS NOT A PROJECT. The consumer routes an unparented shell to
+    # `Other`; `repo` is the branch it PREFERS, so a name here overrides that.
+    ("/home/zach/.git", "/home/zach", None, "home"),
+    # ...and it is a NORMALISED comparison, not a string equality: a `$HOME`
+    # with a trailing slash is the same directory.
+    ("/home/zach/.git", "/home/zach/", None, "home"),
+    # ...and it is the OWNING host's home. `/root` is home on a host that says
+    # so, and an ordinary directory name on one that does not.
+    ("/root/.git", "/root", None, "home"),
+    ("/root/.git", "/home/zach", "root", "ok"),
+    # not in a work tree at all: the probe prints an empty field
+    ("", "/home/zach", None, "not_a_repo"),
+    (None, "/home/zach", None, "not_a_repo"),
+    ("   ", "/home/zach", None, "not_a_repo"),
+    # 🔴 A BARE REPO's common dir is the repo itself, so its parent is NOT a
+    # clone root. Naming `srv` here would publish a confident wrong group.
+    ("/srv/foo.git", "/home/zach", None, "not_a_repo"),
+    # 🔴 A SUBMODULE's common dir is <super>/.git/modules/<name>, whose parent
+    # is `modules`. Fail soft, never guess.
+    ("/home/zach/workspace/super/.git/modules/sub", "/home/zach", None,
+     "not_a_repo"),
+    # the filesystem root: dirname is `/`, whose basename is empty
+    ("/.git", "/home/zach", None, "not_a_repo"),
+])
+def test_repo_from_common_dir_pure_cases(common_dir, home, repo, status):
+    """🔴 LITERAL expectations, never derived from the implementation — the whole
+    point of a pure seam is that its contract can be written down before the
+    code and read against it afterwards."""
+    assert sm.repo_from_common_dir(common_dir, home) == {"repo": repo,
+                                                         "status": status}
+
+
+def test_repo_from_common_dir_takes_home_with_NO_DEFAULT():
+    """🔴 THE GUARD MUST NOT BE SKIPPABLE BY FORGETTING AN ARGUMENT.
+
+    An earlier draft had `home=None`, which made the `$HOME` branch silently
+    inert at any call site that omitted it — and the call site that matters is
+    inside a loop over every path on a host. A required parameter turns that
+    into a TypeError the suite catches, instead of a wrong group in production.
+    """
+    import inspect
+    p = inspect.signature(sm.repo_from_common_dir).parameters["home"]
+    assert p.default is inspect.Parameter.empty
+    with pytest.raises(TypeError):
+        sm.repo_from_common_dir("/home/zach/workspace/devrc/.git")
+
+
+def test_every_repo_status_a_row_can_carry_is_ENUMERATED():
+    """🔴 The set IS the contract, and `REPO_STATUSES` is where it is written.
+    Both directions: a status the code emits but the tuple does not name is a
+    value no consumer can branch on."""
+    assert set(sm.REPO_STATUSES) == {
+        "ok", "not_a_repo", "home", "no_path", "missing", "unmeasured",
+        "skipped"}
+    for cd, home in [("/home/zach/workspace/devrc/.git", "/home/zach"),
+                     ("/home/zach/.git", "/home/zach"),
+                     ("", "/home/zach"), ("/srv/foo.git", "/home/zach")]:
+        assert sm.repo_from_common_dir(cd, home)["status"] in sm.REPO_STATUSES
+    for path, idx, host_status in [
+            ("", None, "unmeasured"),
+            ("/p", None, "unmeasured"), ("/p", None, "skipped"),
+            ("/p", {}, "unmeasured"),
+            ("/p", {"/p": {"repo": "x", "status": "ok"}}, "unmeasured")]:
+        assert sm.row_repo(path, idx, host_status=host_status)["repo_status"] \
+            in sm.REPO_STATUSES
+
+
+# --------------------------------------------------------------------------- #
+# §R.2 — the batch parser
+# --------------------------------------------------------------------------- #
+def test_parse_repo_probe_reads_the_sentinel_the_home_and_every_row():
+    paths = ["/w/a", "/w/b", "/w/c"]
+    out = sm.parse_repo_probe(
+        repo_out("/w/a/.git", "", "/w/c/.git", home="/home/op"), paths)
+    assert out["measured"] is True
+    assert out["home"] == "/home/op"
+    assert out["common_dirs"] == {"/w/a": "/w/a/.git", "/w/b": None,
+                                  "/w/c": "/w/c/.git"}
+    assert out["seen"] == 3
+    assert out["unparseable"] == 0
+
+
+def test_parse_repo_probe_with_NO_sentinel_is_unmeasured_not_empty():
+    """🔴 THE POSITIVE CONTROL. A host where nothing resolved and a host whose
+    probe was swallowed produce output with no common dirs in it either way;
+    only the sentinel tells them apart. `measured: False` and EVERY count None,
+    never 0 — a 0 here is the fabricated measurement this file refuses."""
+    out = sm.parse_repo_probe("1\t/w/a/.git\n2\t\n", ["/w/a", "/w/b"])
+    assert out == {"measured": False, "home": None, "common_dirs": {},
+                   "seen": None, "unparseable": None}
+    assert sm.parse_repo_probe("", ["/w/a"])["measured"] is False
+    assert sm.parse_repo_probe(None, ["/w/a"])["measured"] is False
+
+
+def test_a_sentinel_carrying_NO_home_is_refused_as_unmeasured():
+    """🔴 THE HOME IS HALF THE PROTOCOL. Accepting a bare sentinel would leave
+    `repo_from_common_dir` no way to refuse `$HOME` as a project, so the choice
+    would be between publishing a repo called `zach` for every unparented shell
+    and carrying a guard that can never fire. Declining the host is the honest
+    third option."""
+    assert sm.parse_repo_probe(sm.REPO_PROBE_SENTINEL + "\n1\t/w/a/.git\n",
+                               ["/w/a"])["measured"] is False
+    assert sm.parse_repo_probe(sm.REPO_PROBE_SENTINEL + "   \n1\t/w/a/.git\n",
+                               ["/w/a"])["measured"] is False
+    # ...while the SAME bytes with a home ARE measured, so this is a claim about
+    # the home and not about the rest of the line.
+    assert sm.parse_repo_probe(sm.REPO_PROBE_SENTINEL + " /h\n1\t/w/a/.git\n",
+                               ["/w/a"])["measured"] is True
+
+
+@pytest.mark.parametrize("bad,why", [
+    ("no-tab-at-all", "a line with no tab separator"),
+    ("x\t/w/a/.git", "a non-integer index"),
+    ("\t/w/a/.git", "an empty index"),
+    ("99\t/w/a/.git", "an index past the end of the input list"),
+    ("0\t/w/a/.git", "a 0 index — the protocol is 1-based"),
+    ("-1\t/w/a/.git", "a negative index"),
+])
+def test_parse_repo_probe_counts_a_malformed_line_and_keeps_the_rest(bad, why):
+    """A partial or corrupted reply must cost exactly the lines it corrupts. The
+    1-based index is what buys that: nothing silently re-aligns."""
+    paths = ["/w/a", "/w/b"]
+    raw = "%s /home/op\n%s\n2\t/w/b/.git\n" % (sm.REPO_PROBE_SENTINEL, bad)
+    out = sm.parse_repo_probe(raw, paths)
+    assert out["measured"] is True, why
+    assert out["unparseable"] == 1, why
+    assert out["seen"] == 2, why
+    # the GOOD line still landed, on the RIGHT path
+    assert out["common_dirs"] == {"/w/b": "/w/b/.git"}, why
+
+
+def test_a_path_holding_a_TAB_or_a_NEWLINE_still_round_trips():
+    """🔴 THE PATH IS NEVER ECHOED BACK, and this is why. A `path<TAB>repo` line
+    format is corrupted by either character; a 1-based sequence number is not.
+    tmux hands us `pane_current_path` off a remote machine and nothing
+    validates it."""
+    paths = ["/w/tab\there", "/w/new\nline", "/w/plain"]
+    out = sm.parse_repo_probe(
+        repo_out("/w/x/.git", "/w/y/.git", "/w/z/.git", home="/home/op"), paths)
+    assert out["common_dirs"] == {"/w/tab\there": "/w/x/.git",
+                                  "/w/new\nline": "/w/y/.git",
+                                  "/w/plain": "/w/z/.git"}
+
+
+def test_build_repo_index_gives_a_SHORT_reply_the_missing_status():
+    """🔴 `missing` IS ITS OWN FACT. The host answered; this path did not. Folding
+    it into `not_a_repo` publishes "the owning host looked and this is not a work
+    tree" about a path the reply never mentioned."""
+    paths = ["/w/a", "/w/b", "/w/c"]
+    parsed = sm.parse_repo_probe(
+        repo_out("/w/a/.git", "", home="/home/op"), paths)  # two rows, three paths
+    assert sm.build_repo_index(parsed, paths) == {
+        "/w/a": {"repo": "a", "status": "ok"},
+        "/w/b": {"repo": None, "status": "not_a_repo"},
+        "/w/c": {"repo": None, "status": "missing"}}
+
+
+def test_build_repo_index_returns_NONE_for_an_unmeasured_probe():
+    """🔴 NOT a dict of `not_a_repo` entries. That substitution — a failed probe
+    rendered as a completed measurement — is the worst outcome available here,
+    because it reads as "none of these panes is in a repo"."""
+    parsed = sm.parse_repo_probe("garbage with no sentinel\n", ["/w/a"])
+    assert sm.build_repo_index(parsed, ["/w/a"]) is None
+
+
+# --------------------------------------------------------------------------- #
+# §R.3 — 🔴 THE CLOSING CONDITION: two worktrees of one repo carry ONE name.
+#        Against REAL git, through the REAL shipped probe command.
+# --------------------------------------------------------------------------- #
+def test_TWO_WORKTREES_OF_ONE_REPO_RESOLVE_TO_THE_SAME_REPO(tmp_path):
+    """🔴 THIS IS THE FEATURE. Everything else in §R is scaffolding around it.
+
+    A real clone plus two real linked worktrees, resolved by the real
+    `REPO_PROBE_SCRIPT` under a real `sh` and a real `git`. All must carry ONE
+    repo name — the MAIN clone's — though their own directory leaves are
+    different strings, which is exactly the split the operator sees today
+    (`ht-r11-930492` apart from `homelab-talos`).
+
+    🔴 AND THE CONTROL IS IN THE SAME TEST: `label_from_path` — the producer's
+    OTHER path-derived field, and what `projectOf()` falls back to without
+    `repo` — gives all four DIFFERENT answers on the same four paths. Without
+    that line this could pass against an implementation that grouped by nothing.
+    """
+    home = str(tmp_path / "home")
+    os.makedirs(home)
+    main = _r_mkrepo(tmp_path / "ws" / "homelab-talos")
+    wt1 = str(tmp_path / "ws" / "ht-r11-930492")
+    wt2 = str(tmp_path / "ws" / "ht-r19-114477")
+    for wt, br in ((wt1, "r11"), (wt2, "r19")):
+        subprocess.run(
+            ["git", "-C", main, "worktree", "add", "-q", "-b", br, wt],
+            check=True, capture_output=True, env=_r_env())
+    sub = os.path.join(main, "sub", "deeper")   # a plain subdirectory too
+    os.makedirs(sub)
+
+    paths = [main, wt1, wt2, sub]
+    proc, parsed = _r_probe(paths, home)
+    assert proc.returncode == 0, proc.stderr
+    assert parsed["measured"] is True, proc.stdout
+    assert parsed["home"] == home
+    idx = sm.build_repo_index(parsed, paths)
+
+    assert [idx[p]["repo"] for p in paths] == ["homelab-talos"] * 4, (
+        "two worktrees of one repo must carry ONE repo name — that IS the "
+        "closing condition of this feature.\nprobe stdout:\n" + proc.stdout)
+    assert [idx[p]["status"] for p in paths] == ["ok"] * 4
+    # 🔴 THE CONTROL. The field this REPLACES splits them four ways.
+    assert [sm.label_from_path(p, home=home) for p in paths] == [
+        "homelab-talos", "ht-r11-930492", "ht-r19-114477", "deeper"]
+
+
+def test_the_real_probe_answers_not_a_repo_OUTSIDE_any_repo(tmp_path):
+    """The measured-absence half, against real git. A path genuinely not in a
+    work tree comes back `not_a_repo` — and the probe still exits 0, because a
+    missing repo is an ANSWER, not a failure."""
+    home = str(tmp_path / "home")
+    os.makedirs(home)
+    loose = str(tmp_path / "loose")
+    os.makedirs(loose)
+    repo = _r_mkrepo(tmp_path / "ws" / "alpha")
+    paths = [loose, repo]
+    proc, parsed = _r_probe(paths, home, cwd=str(tmp_path))
+    assert proc.returncode == 0, proc.stderr
+    idx = sm.build_repo_index(parsed, paths)
+    assert idx[loose] == {"repo": None, "status": "not_a_repo"}
+    # 🔴 THE POSITIVE CONTROL IN THE SAME RUN: a real repo in the same batch
+    # resolves. A probe wired to nothing would answer `not_a_repo` for both.
+    assert idx[repo] == {"repo": "alpha", "status": "ok"}
+
+
+def test_the_real_probe_refuses_to_name_the_OWNING_HOSTS_HOME(tmp_path):
+    """🔴 END TO END, because this guard is what stops every unparented shell
+    from forming a project called `zach`. `$HOME` IS a real repo here and the
+    probe resolves it — the resolver still declines to name it."""
+    home = _r_mkrepo(tmp_path / "home")
+    paths = [home]
+    proc, parsed = _r_probe(paths, home)
+    assert proc.returncode == 0, proc.stderr
+    # the probe DID resolve it, so the refusal below is the resolver's rather
+    # than a failure to measure
+    assert parsed["common_dirs"][home] == os.path.join(home, ".git")
+    assert sm.build_repo_index(parsed, paths)[home] == {"repo": None,
+                                                        "status": "home"}
+    # ...and the mirror image: the SAME directory against a DIFFERENT home is an
+    # ordinary repo. So `home` is a comparison, not a name rule.
+    other = sm.build_repo_index(
+        sm.parse_repo_probe(repo_out(os.path.join(home, ".git"),
+                                     home="/somewhere/else"), paths), paths)
+    assert other[home] == {"repo": os.path.basename(home), "status": "ok"}
+
+
+def test_a_HOSTILE_path_cannot_become_shell_syntax(tmp_path):
+    """🔴 PANE PATHS COME FROM tmux ON A REMOTE MACHINE. They are interpolated
+    into nothing: `sh -c <constant script> <argv0> path...` puts them in `"$@"`.
+
+    The canary is a real file the injected command WOULD create. A probe built
+    by string concatenation creates it; this one must not — and the run must
+    still be a clean `exit 0` with well-formed rows.
+    """
+    home = str(tmp_path / "home")
+    os.makedirs(home)
+    canary = str(tmp_path / "PWNED")
+    hostile = ["/w/a;touch %s" % canary,
+               "/w/b$(touch %s)" % canary,
+               "/w/c`touch %s`" % canary,
+               "/w/d'\"; touch %s; #" % canary,
+               "/w/e\ntouch %s" % canary,
+               "/w/f | touch %s" % canary]
+    repo = _r_mkrepo(tmp_path / "ws" / "alpha")
+    paths = [*hostile, repo]
+    proc, parsed = _r_probe(paths, home, cwd=str(tmp_path))
+    assert proc.returncode == 0, proc.stderr
+    assert not os.path.exists(canary), (
+        "a pane path became shell syntax — the probe interpolated it into the "
+        "command instead of passing it as a positional parameter")
+    idx = sm.build_repo_index(parsed, paths)
+    for p in hostile:
+        assert idx[p] == {"repo": None, "status": "not_a_repo"}, p
+    # 🔴 THE POSITIVE CONTROL, IN THE SAME BATCH. Without it, a probe that had
+    # simply died on the first hostile path would satisfy every assertion above
+    # by answering `not_a_repo` for everything.
+    assert idx[repo] == {"repo": "alpha", "status": "ok"}
+
+
+def test_the_probe_script_TEXT_is_a_constant_and_never_holds_a_path():
+    """The structural half of the test above: paths are argv, and the script that
+    ships is the same bytes for every call."""
+    a = sm.repo_probe_argv(["/w/one", "/w/two"])
+    b = sm.repo_probe_argv(["/totally/different"])
+    assert a[:3] == ("sh", "-c", sm.REPO_PROBE_SCRIPT)
+    assert b[:3] == ("sh", "-c", sm.REPO_PROBE_SCRIPT)
+    assert "/w/one" not in sm.REPO_PROBE_SCRIPT
+    # 🔴 `$0` IS CONSUMED BY `sh -c`. Without an explicit argv0 the FIRST PATH
+    # becomes the shell's name and is silently dropped from `"$@"`.
+    assert a[3] == "sm-repo-probe"
+    assert list(a[4:]) == ["/w/one", "/w/two"]
+
+
+def test_the_probe_asks_git_for_the_COMMON_dir_not_the_TOPLEVEL():
+    """🔴 THE ONE FLAG THAT MAKES THIS WORK. `--show-toplevel` returns the
+    WORKTREE on a linked worktree, so it cannot group two worktrees at all —
+    the exact bug rank 21 exists to fix, silently reintroduced. And
+    `--path-format=absolute` is what makes `dirname` name the clone root rather
+    than a relative fragment."""
+    assert "--git-common-dir" in sm.REPO_PROBE_SCRIPT
+    assert "--path-format=absolute" in sm.REPO_PROBE_SCRIPT
+    assert "--show-toplevel" not in sm.REPO_PROBE_SCRIPT
+
+
+def test_ssh_wrap_QUOTES_a_hostile_path_for_the_remote_hop():
+    """The second quoting layer. `ssh_wrap`'s `shlex.join` is what stands between
+    a pane path and the REMOTE shell's parser."""
+    hostile = "/w/a;touch /tmp/PWNED"
+    remote = sm.ssh_wrap(sm.repo_probe_argv([hostile]))[-1]
+    # it round-trips: the remote shell re-splits it into exactly our argv
+    assert shlex.split(remote) == list(sm.repo_probe_argv([hostile]))
+
+
+# --------------------------------------------------------------------------- #
+# §R.4 — 🔴 IT RESOLVES ON THE OWNING HOST. The whole reason for the design.
+# --------------------------------------------------------------------------- #
+def test_the_SAME_path_on_TWO_HOSTS_resolves_from_EACH_HOSTS_OWN_answer():
+    """🔴 THE CONSTRAINT THIS FEATURE IS BUILT AROUND, pinned as a RELATIONSHIP.
+
+    One path string, two hosts, two different repos — because the two machines
+    genuinely have different things at that path. A local `git rev-parse` could
+    not produce this at all: it would give BOTH rows the workbench's answer, or
+    neither. So the assertion is that the two rows DISAGREE, which no
+    single-source implementation can satisfy.
+    """
+    shared = "/home/zach/workspace/thing"
+    panes = f"%1|1|s-wb|1|w|{shared}|claude|t"
+    rep = base_gather(runner=make_runner(
+        local_panes=panes, remote_panes=panes.replace("s-wb", "s-lt"),
+        local_repo=repo_out("/home/zach/workspace/thing/.git"),
+        remote_repo=repo_out("/home/zach/clones/other-name/.git")))
+    wb = rep["hosts"]["workbench"]["windows"][0]
+    lt = rep["hosts"]["laptop"]["windows"][0]
+    assert wb["path"] == lt["path"] == shared
+    assert wb["repo"] == "thing"
+    assert lt["repo"] == "other-name"
+    assert wb["repo"] != lt["repo"], (
+        "both hosts resolved to one name — the probe is not running per host")
+    assert wb["repo_status"] == lt["repo_status"] == "ok"
+
+
+def test_each_hosts_HOME_comes_from_ITS_OWN_sentinel():
+    """🔴 "THE OWNING HOST'S `$HOME`, NOT YOURS." A laptop whose home is
+    `/home/other` must have ITS home compared against ITS paths — using the
+    workbench's would let a laptop `$HOME` shell be published as a project."""
+    panes = "%1|1|s|1|w|/home/other|claude|t"
+    rep = base_gather(runner=make_runner(
+        local_panes="%9|9|s2|1|w|/home/zach|claude|t",
+        local_repo=repo_out("/home/zach/.git", home="/home/zach"),
+        remote_panes=panes,
+        remote_repo=repo_out("/home/other/.git", home="/home/other")))
+    wb = rep["hosts"]["workbench"]["windows"][0]
+    lt = rep["hosts"]["laptop"]["windows"][0]
+    assert (wb["repo"], wb["repo_status"]) == (None, "home")
+    assert (lt["repo"], lt["repo_status"]) == (None, "home")
+    # 🔴 THE MUTATION CONTROL: swap the two homes and both become ordinary
+    # repos. So the `home` verdicts above are a comparison against the sentinel
+    # — not a hardcoded `/home/zach`, and not a refusal to resolve.
+    swapped = base_gather(runner=make_runner(
+        local_panes="%9|9|s2|1|w|/home/zach|claude|t",
+        local_repo=repo_out("/home/zach/.git", home="/home/other"),
+        remote_panes=panes,
+        remote_repo=repo_out("/home/other/.git", home="/home/zach")))
+    assert swapped["hosts"]["workbench"]["windows"][0]["repo"] == "zach"
+    assert swapped["hosts"]["laptop"]["windows"][0]["repo"] == "other"
+
+
+# --------------------------------------------------------------------------- #
+# §R.5 — ONE CALL PER HOST. Not one per path.
+# --------------------------------------------------------------------------- #
+def test_the_probe_is_ONE_batched_call_per_host_over_every_unique_path():
+    """🔴 THE COST CONSTRAINT, MEASURED RATHER THAN ASSERTED. `WINDOW_FORMAT`'s
+    comment records that the pusher already makes up to four ssh calls per run
+    with no ControlMaster; this is the fifth. N round trips for N panes was
+    never acceptable — the box carries ~93 live windows.
+
+    Also asserts the argv is DEDUPED and SORTED: two panes of one window share a
+    cwd, and the workbench fixture has exactly that.
+    """
+    calls = []
+    rep = base_gather(runner=make_runner(calls=calls))
+    probes = [c for c in calls if any(sm.REPO_PROBE_SENTINEL in a for a in c)]
+    assert len(probes) == 2, [c[:2] for c in calls]
+    local = [c for c in probes if c[0] != "ssh"][0]
+    remote = [c for c in probes if c[0] == "ssh"][0]
+    # the local call's paths are the tail of the argv, after `sh -c <script> $0`
+    assert local[4:] == ["/home/zach/tmp", "/home/zach/workspace/repo-alpha"]
+    # 🔴 DEDUPED: WORKBENCH_PANES holds THREE panes, two of which share
+    # `/home/zach/workspace/repo-alpha`.
+    assert len(local[4:]) == len(set(local[4:])) == 2
+    assert len(sm.parse_panes(WORKBENCH_PANES)) == 3
+    # the remote call goes through ssh_wrap, so its paths live inside the joined
+    # command string
+    assert shlex.split(remote[-1])[4:] == ["/home/zach/workspace/naida"]
+    assert rep["hosts"]["workbench"]["repos_paths"] == 2
+    assert rep["hosts"]["laptop"]["repos_paths"] == 1
+
+
+def test_no_repo_makes_ZERO_probe_calls():
+    """The flag is the cost control, so it must remove the round trip — not
+    merely discard the answer."""
+    calls = []
+    base_gather(runner=make_runner(calls=calls), use_repo=False)
+    assert [c for c in calls
+            if any(sm.REPO_PROBE_SENTINEL in a for a in c)] == []
+
+
+def test_a_host_with_no_pane_paths_is_MEASURED_and_makes_no_call():
+    """`{}` and not `None`, the same distinction `captures` draws. We know every
+    pane on this host and none reported a cwd, so there was nothing to ask —
+    calling that `unmeasured` reports a complete enumeration as a failure. And
+    an empty probe would buy a round trip for no paths."""
+    calls = []
+    rep = base_gather(runner=make_runner(
+        calls=calls, remote_panes="%21|1|s|1|w||claude|t"))
+    lt = rep["hosts"]["laptop"]
+    assert lt["repos_measured"] is True
+    assert lt["repos_status"] == "ok"
+    assert (lt["repos_paths"], lt["repos_resolved"]) == (0, 0)
+    assert [c for c in calls
+            if c[0] == "ssh" and sm.REPO_PROBE_SENTINEL in c[-1]] == []
+    # the row still says WHY it has no repo, and it is a fact about the PANE
+    assert lt["windows"][0]["repo"] is None
+    assert lt["windows"][0]["repo_status"] == "no_path"
+
+
+# --------------------------------------------------------------------------- #
+# §R.6 — 🔴 UNMEASURED IS NOT EMPTY. A failed probe must never read as
+#        "these panes are not in repos".
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("kw,host_status", [
+    ({"remote_repo_rc": 1, "remote_repo_err": "ssh: connect timed out"},
+     "error"),
+    ({"remote_repo": "1\t/home/zach/workspace/naida/.git\n"}, "no_sentinel"),
+    ({"remote_repo": ""}, "no_sentinel"),
+    ({"remote_repo": "sh: git: not found\n"}, "no_sentinel"),
+])
+def test_a_failed_probe_is_UNMEASURED_on_every_row_never_not_a_repo(
+        kw, host_status):
+    """🔴 THE SUBSTITUTION THIS REFUSES. A probe that failed, timed out, or came
+    back without its sentinel produces the same empty answer a host of non-repo
+    panes would. Rendering the first as the second publishes "the owning host
+    looked and none of these panes is in a repo" about a look that never
+    happened.
+
+    Note the mirror in the same assertion: the WORKBENCH, whose probe DID
+    answer, still carries a real repo. So this is a per-host verdict, not the
+    run giving up.
+    """
+    rep = base_gather(runner=make_runner(**kw))
+    lt = rep["hosts"]["laptop"]
+    assert lt["repos_measured"] is False
+    assert lt["repos_status"] == host_status
+    assert lt["repos_error"], "an unmeasured host must say WHY"
+    # 🔴 EVERY COUNT IS None, NEVER 0 — a 0 here is a fabricated measurement.
+    assert lt["repos_resolved"] is None
+    assert lt["repos_unparseable"] is None
+    for row in lt["windows"]:
+        assert row["repo"] is None
+        assert row["repo_status"] == "unmeasured", (
+            "a failed probe rendered as a measurement")
+    wb = rep["hosts"]["workbench"]
+    assert wb["repos_measured"] is True
+    assert wb["windows"][0]["repo"] == "repo-alpha"
+
+
+def test_no_repo_reports_SKIPPED_on_the_row_and_the_host_never_not_a_repo():
+    """`--no-repo` means nothing was asked. `skipped` is its own status for the
+    same reason `--no-capture` gets one: "you did not ask" and "asked, found
+    nothing" are different facts."""
+    rep = base_gather(use_repo=False)
+    for host in ("workbench", "laptop"):
+        h = rep["hosts"][host]
+        assert h["repos_measured"] is False
+        assert h["repos_status"] == "skipped"
+        assert h["repos_paths"] is None and h["repos_resolved"] is None
+        assert h["windows"], host
+        for row in h["windows"]:
+            assert (row["repo"], row["repo_status"]) == (None, "skipped")
+
+
+def test_an_unreachable_host_says_the_probe_was_NEVER_ATTEMPTED():
+    """The same reasoning the ledger read uses: a host that did not answer
+    `list-panes` has no measured paths, so a probe could only buy another
+    ConnectTimeout. The reason must SAY the read was not attempted rather than
+    imply it was tried and failed — different facts about the host."""
+    calls = []
+    rep = base_gather(runner=make_runner(calls=calls, remote_rc=255,
+                                         remote_err="ssh: no route to host"))
+    lt = rep["hosts"]["laptop"]
+    assert lt["repos_measured"] is False
+    assert lt["repos_status"] == "unmeasured"
+    assert "not attempted" in lt["repos_error"]
+    assert [c for c in calls
+            if c[0] == "ssh" and sm.REPO_PROBE_SENTINEL in c[-1]] == []
+
+
+def test_a_MEASURED_host_publishes_real_counts():
+    """The other side of every None above. When it IS measured the integers are
+    real, and `repos_resolved` counts only the `ok` rows."""
+    wb = base_gather()["hosts"]["workbench"]
+    assert wb["repos_measured"] is True
+    assert wb["repos_status"] == "ok"
+    assert wb["repos_error"] is None
+    # two unique paths; one is `/home/zach/tmp`, which is not a repo
+    assert (wb["repos_paths"], wb["repos_resolved"]) == (2, 1)
+    assert wb["repos_unparseable"] == 0
+    by_path = {r["path"]: r for r in wb["windows"]}
+    assert by_path["/home/zach/tmp"]["repo"] is None
+    assert by_path["/home/zach/tmp"]["repo_status"] == "not_a_repo"
+    assert by_path["/home/zach/workspace/repo-alpha"]["repo"] == "repo-alpha"
+
+
+# --------------------------------------------------------------------------- #
+# §R.7 — the field reaches the WIRE, in both views, and the flag reaches gather
+# --------------------------------------------------------------------------- #
+def test_repo_and_repo_status_survive_the_LEAN_projection():
+    """🔴 THE PRODUCER'S FIELD LIST IS WHAT ACTUALLY SHIPS THE KEY. The Go
+    decoder is permissive — an absent `repo` decodes to `""` and `projectOf()`
+    silently falls back to the path leaf, which IS the pre-change behaviour. So
+    a `repo` computed and then dropped by the lean projection is an INERT
+    feature that looks shipped."""
+    assert "repo" in sm.LEAN_ROW_FIELDS
+    assert "repo_status" in sm.LEAN_ROW_FIELDS
+    lean = lean_of(base_gather())
+    row = lean["hosts"]["workbench"]["windows"][0]
+    assert row["repo"] == "repo-alpha"
+    assert row["repo_status"] == "ok"
+    assert "repo" in lean["lean_row_fields"]
+    # the host-level discriminant rides along, or a lean reader cannot tell a
+    # host of nulls from a host nobody probed
+    assert lean["hosts"]["workbench"]["repos_measured"] is True
+    assert lean["hosts"]["workbench"]["repos_status"] == "ok"
+
+
+def test_repo_is_JSON_SERIALISABLE_and_present_on_every_row():
+    """The wire, end to end: whatever `--json` writes is what clawgate ingests."""
+    blob = json.loads(json.dumps(base_gather(), default=str))
+    rows = [r for h in blob["hosts"].values() for r in h["windows"]]
+    assert rows, "fixture produced no rows"
+    for r in rows:
+        assert "repo" in r and "repo_status" in r
+        assert r["repo_status"] in sm.REPO_STATUSES
+        # `repo` is a name ONLY on `ok`; every other status carries a null
+        assert (r["repo"] is not None) == (r["repo_status"] == "ok"), r
+
+
+def test_the_flag_reaches_gather_and_the_probe_is_ON_by_default():
+    """🔴 A flag parsed and never passed is the shape that ships an inert
+    feature — the same wiring guard `--pane-preview` carries. And `use_repo`
+    must default to TRUE: the point of rank 21 is that the field IS published,
+    so an opt-in would ship the seam dead a second time."""
+    import inspect
+    assert inspect.signature(sm.gather).parameters["use_repo"].default is True
+    p = sm.build_parser()
+    assert p.parse_args(["scan", "--json"]).no_repo is False
+    assert p.parse_args(["scan", "--json", "--no-repo"]).no_repo is True
+    with open(_SCRIPT, encoding="utf-8") as fh:
+        src = fh.read()
+    assert "use_repo=not args.no_repo" in src, (
+        "main() does not pass the flag through to gather()")
+
+
+def test_fold_windows_takes_the_index_PER_HOST_not_globally():
+    """The seam, pinned structurally. A single module-level index would be the
+    exact bug this feature exists to avoid — one host's answers applied to the
+    other host's paths."""
+    import inspect
+    params = inspect.signature(sm.fold_windows).parameters
+    assert params["repo_index"].default is None
+    assert params["repo_status"].default == "unmeasured"
+    with open(_SCRIPT, encoding="utf-8") as fh:
+        src = fh.read()
+    assert "repo_index=repo_index.get(host)" in src

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -32,6 +32,7 @@ import json
 import os
 import re
 import shlex
+import pathlib
 import subprocess
 import sys
 import time
@@ -39,6 +40,8 @@ import time
 import pytest
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.abspath(os.path.join(_HERE, os.pardir)))
+from testlib import mockbin  # noqa: E402
 _SCRIPT = os.path.normpath(os.path.join(_HERE, "..", "session-manager"))
 
 # session-manager has no .py extension -> load it by explicit path.
@@ -12983,15 +12986,10 @@ def test_the_REAL_probe_reports_a_per_path_failure_rather_than_not_a_repo(
     _, parsed = _r_probe([repo], home)
     assert sm.build_repo_index(parsed, [repo])[repo] == {"repo": "alpha",
                                                          "status": "ok"}
-    nogit = str(tmp_path / "nogit-bin")
-    os.makedirs(nogit)
-    for tool in ("sh", "timeout"):
-        src = _r_which(tool)
-        assert src, tool
-        os.symlink(src, os.path.join(nogit, tool))
+    binp = _r_only_bin(tmp_path, "nogit-bin", "sh", "timeout")
     proc = subprocess.run(list(sm.repo_probe_argv([repo])),
                           capture_output=True, text=True, timeout=60,
-                          env={"PATH": nogit, "HOME": home})
+                          env=_r_path_only(binp, home))
     assert proc.returncode == 0, proc.stderr
     parsed = sm.parse_repo_probe(proc.stdout, [repo])
     assert parsed["measured"] is True, proc.stdout
@@ -13298,6 +13296,39 @@ def _r_which(tool):
                           capture_output=True, text=True).stdout.strip() or None
 
 
+def _r_only_bin(tmp_path, name, *tools):
+    """A PATH holding EXACTLY `tools`, symlinked, and nothing else.
+
+    🔴 PATH IS REPLACED, NOT PREPENDED, AND THAT IS THE MEASUREMENT. The three
+    tests below assert what the probe does when `git` or `timeout` is ABSENT on
+    the owning host, and no amount of PREPENDING can make a binary unfindable —
+    both are on PATH in the sandbox and on the dev host, so a prepending version
+    would measure the environment instead of the script. Pinned in
+    `test_no_real_launchers.py`'s PINNED_PATH_CLOBBERS with that justification;
+    the directory is CONSTRUCTED here, one symlink per named tool, so its
+    contents are asserted rather than audited and no launcher this repo treats
+    as hazardous is reachable through it.
+    """
+    binp = tmp_path / name
+    binp.mkdir()
+    for tool in tools:
+        src = _r_which(tool)
+        assert src, tool
+        os.symlink(src, str(binp / tool))
+    assert sorted(p.name for p in binp.iterdir()) == sorted(tools)
+    return str(binp)
+
+
+def _r_path_only(binp, home):
+    """The env for a probe run whose PATH is REPLACED by `binp`.
+
+    🔴 ONE SPELLING FOR ALL THREE CALL SITES, on purpose. `PINNED_PATH_CLOBBERS`
+    matches a file by ONE needle, so three hand-written dict literals would pin
+    whichever one the scan reached first and leave the others unjustified.
+    """
+    return {"PATH": binp, "HOME": home}
+
+
 def test_the_probe_script_BOUNDS_EACH_git_call(tmp_path):
     """🔴 TWO SWEEP SURVIVORS IN ONE BEHAVIOURAL GUARD. `T="timeout 3"` ->
     `T="timeout 900"` SURVIVED all 743 tests, and so did deleting the
@@ -13311,24 +13342,19 @@ def test_the_probe_script_BOUNDS_EACH_git_call(tmp_path):
     """
     home = str(tmp_path / "home")
     os.makedirs(home)
-    binp = str(tmp_path / "slowbin")
-    os.makedirs(binp)
-    sh, sleep = _r_which("sh"), _r_which("sleep")
-    assert sh and sleep
-    for tool in ("sh", "timeout"):
-        src = _r_which(tool)
-        assert src, tool
-        os.symlink(src, os.path.join(binp, tool))
-    fake_git = os.path.join(binp, "git")
-    with open(fake_git, "w", encoding="utf-8") as fh:
-        fh.write("#!%s\nexec %s 60\n" % (sh, sleep))
-    os.chmod(fake_git, 0o755)
+    binp = _r_only_bin(tmp_path, "slowbin", "sh", "timeout")
+    sleep = _r_which("sleep")
+    assert sleep
+    # 🔴 `mockbin.write_exec` OWNS THE SHEBANG. A hand-written `#!` here is the
+    # `/usr/bin/env` hazard `test_runtime_shebangs.py` exists to catch, and it
+    # is invisible on the dev host — only the nix sandbox has no `/usr/bin/env`.
+    mockbin.write_exec(pathlib.Path(binp) / "git", "exec %s 60\n" % sleep)
 
     bound = sm.REPO_PROBE_GIT_TIMEOUT
     t0 = time.monotonic()
     proc = subprocess.run(list(sm.repo_probe_argv(["/w/one"])),
                           capture_output=True, text=True, timeout=45,
-                          env={"PATH": binp, "HOME": home})
+                          env=_r_path_only(binp, home))
     wall = time.monotonic() - t0
     assert proc.returncode == 0, proc.stderr
     assert wall < bound + 12, (
@@ -13360,16 +13386,11 @@ def test_the_probe_still_ANSWERS_on_a_host_with_no_timeout_binary(tmp_path):
     home = str(tmp_path / "home")
     os.makedirs(home)
     repo = _r_mkrepo(tmp_path / "ws" / "alpha")
-    binp = str(tmp_path / "notimeout")
-    os.makedirs(binp)
-    for tool in ("sh", "git"):
-        src = _r_which(tool)
-        assert src, tool
-        os.symlink(src, os.path.join(binp, tool))
+    binp = _r_only_bin(tmp_path, "notimeout", "sh", "git")
     assert not os.path.exists(os.path.join(binp, "timeout"))
     proc = subprocess.run(list(sm.repo_probe_argv([repo])),
                           capture_output=True, text=True, timeout=60,
-                          env={"PATH": binp, "HOME": home})
+                          env=_r_path_only(binp, home))
     assert proc.returncode == 0, proc.stderr
     parsed = sm.parse_repo_probe(proc.stdout, [repo])
     assert sm.build_repo_index(parsed, [repo])[repo] == {"repo": "alpha",

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -12534,6 +12534,43 @@ def test_the_probe_is_ONE_batched_call_per_host_over_every_unique_path():
     assert rep["hosts"]["laptop"]["repos_paths"] == 1
 
 
+def test_the_probe_gets_its_OWN_timeout_budget_not_the_tmux_one():
+    """🔴 FOUND BY A MUTATION SWEEP, WHICH THIS GUARD DID NOT PREVIOUSLY COVER.
+    Replacing `timeout=REPO_PROBE_TIMEOUT` with `timeout=None` SURVIVED a fully
+    green suite: `run_tmux` then falls back to `SSH_TIMEOUT`/`LOCAL_TIMEOUT`, so
+    the probe is still bounded — by the budget sized for ONE `tmux list-panes`.
+
+    That is not a cosmetic difference. This call fans out over every unique path
+    on a host and each `git` is bounded at 3s by the script itself, so on a box
+    with ~93 windows the 5s local budget is reached long before the answer is.
+    The failure mode is silent in exactly the wrong direction: the host times
+    out, goes `repos_measured: false`, and every row loses its repo — a real
+    measurement replaced by an unmeasured one because of a constant.
+
+    Pinned as a RELATIONSHIP (`> SSH_TIMEOUT`), not as a literal, so tuning the
+    number does not require editing a test that would then pin nothing.
+    """
+    seen = []
+    inner = make_runner()
+
+    def recording(argv, timeout):
+        seen.append((list(argv), timeout))
+        return inner(argv, timeout)
+
+    base_gather(runner=recording)
+    probes = [(a, t) for a, t in seen
+              if any(sm.REPO_PROBE_SENTINEL in x for x in a)]
+    assert len(probes) == 2, [a[:2] for a, _ in seen]
+    for argv, timeout in probes:
+        assert timeout == sm.REPO_PROBE_TIMEOUT, argv[:2]
+    # ...and the two tmux calls still get the ORDINARY budget, so this is a
+    # claim about the probe rather than about every call growing one.
+    panes = [(a, t) for a, t in seen if "list-panes" in " ".join(a)]
+    assert panes and all(t != sm.REPO_PROBE_TIMEOUT for _, t in panes)
+    # the budget is BIGGER than a single tmux call's, which is the whole point
+    assert sm.REPO_PROBE_TIMEOUT > sm.SSH_TIMEOUT > sm.LOCAL_TIMEOUT
+
+
 def test_no_repo_makes_ZERO_probe_calls():
     """The flag is the cost control, so it must remove the round trip — not
     merely discard the answer."""

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -323,6 +323,38 @@ WORKBENCH_REPO_OUT = repo_out("", "/home/zach/workspace/repo-alpha/.git")
 LAPTOP_REPO_OUT = repo_out("/home/zach/workspace/naida/.git")
 
 
+def classify_call(argv):
+    """`argv` -> `(where, what)`; `where` is local/remote, `what` names the read.
+
+    🔴 ONE WRITER, because two consumers need the SAME answer: `make_runner`
+    decides which fixture output to hand back, and the call-ORDER guards decide
+    which read a recorded argv was. Open-coded twice, they would drift, and the
+    order guard would then be pinning a sequence of its own invention.
+
+    An argv it cannot name RAISES — never a fall-through to `panes`. That
+    default silently answered the repo probe, and later the ledger read, with
+    the panes output while the suite stayed green.
+    """
+    where = "remote" if (argv and argv[0] == "ssh") else "local"
+    joined = " ".join(argv)
+    if "list-windows" in joined:
+        what = "windows"
+    elif "capture-pane" in joined:
+        what = "capture"
+    elif sm.REPO_PROBE_SENTINEL in joined:
+        what = "repo"
+    elif sm.AL.SENTINEL in joined:
+        what = "ledger"
+    elif "list-panes" in joined:
+        what = "panes"
+    else:
+        raise AssertionError(
+            "make_runner cannot classify this argv, so it must not answer "
+            "it: %r. Add an arm to the table — do not let it fall through "
+            "to the panes output." % (list(argv),))
+    return where, what
+
+
 def make_runner(local_panes=WORKBENCH_PANES, local_windows=WORKBENCH_WINDOWS,
                 remote_panes=LAPTOP_PANES, remote_windows=LAPTOP_WINDOWS,
                 local_capture="local captured output\n",
@@ -404,27 +436,7 @@ def make_runner(local_panes=WORKBENCH_PANES, local_windows=WORKBENCH_WINDOWS,
     def runner(argv, timeout):
         calls.append(list(argv))
         budget.append((list(argv), timeout))
-        where = "remote" if (argv and argv[0] == "ssh") else "local"
-        joined = " ".join(argv)
-        if "list-windows" in joined:
-            what = "windows"
-        elif "capture-pane" in joined:
-            what = "capture"
-        elif sm.REPO_PROBE_SENTINEL in joined:
-            what = "repo"
-        elif sm.AL.SENTINEL in joined:
-            what = "ledger"
-        elif "list-panes" in joined:
-            what = "panes"
-        else:
-            # 🔴 NO `else: "panes"`. See the docstring — that fall-through is
-            # the fixture defect this whole harness exists to refuse, and it has
-            # now bitten twice (the repo probe, then the ledger read). A call
-            # this fixture cannot NAME is a call it cannot answer for.
-            raise AssertionError(
-                "make_runner cannot classify this argv, so it must not answer "
-                "it: %r. Add an arm to the table — do not let it fall through "
-                "to the panes output." % (list(argv),))
+        where, what = classify_call(argv)
         rc, out, err = table[(where, what)]
         return (rc, "", err) if rc != 0 else (0, out, "")
 
@@ -13051,46 +13063,185 @@ def test_a_DUPLICATE_index_is_unparseable_and_the_FIRST_answer_stands():
     assert out["answers"]["/w/b"] == {"rc": 0, "common": "/w/b/.git"}
 
 
-@pytest.mark.parametrize("sep,name", [
-    ("\r", "carriage return"), ("\x0b", "vertical tab"), ("\x0c", "form feed"),
-    ("\x1c", "file separator"), ("\x85", "next line"),
-    ("\u2028", "line separator"), ("\u2029", "paragraph separator"),
-])
-def test_the_parser_splits_on_NEWLINE_ONLY_never_str_splitlines(sep, name):
+@pytest.mark.parametrize("tail", ["", "\n"], ids=["lone", "then-newline"])
+@pytest.mark.parametrize("sep", sm.REPO_PROBE_RECORD_BREAKERS,
+                         ids=lambda c: "U+%04X" % ord(c))
+def test_the_parser_splits_on_NEWLINE_ONLY_never_str_splitlines(sep, tail):
     """🔴 A READER THAT SPLITS ON MORE CHARACTERS THAN THE WRITER JOINED WITH IS
     A FORGING SURFACE BY ITSELF. The script's record separator is `\\n`;
-    `str.splitlines()` also breaks on seven other characters, any of which can
-    appear in a directory name. With `splitlines()` the string below becomes TWO
-    records — and the forged index is a LATER one, which is the case the
-    duplicate-index guard cannot cover: a forged record for an index whose
-    genuine record has not arrived yet lands FIRST and wins, and the real one is
-    then rejected as the duplicate. Under `splitlines()` `/w/c` resolves to
-    `forged`.
+    `str.splitlines()` also breaks on every character in
+    `REPO_PROBE_RECORD_BREAKERS`, any of which can appear in a directory name.
+    With `splitlines()` the string below becomes TWO records — and the forged
+    index is a LATER one, which is the case the duplicate-index guard cannot
+    cover: a forged record for an index whose genuine record has not arrived yet
+    lands FIRST and wins, and the real one is then rejected as the duplicate.
 
-    Splitting on `"\\n"` alone is only HALF the answer, and measuring it is what
-    showed that: the injection then stays inside index 1's own field, where
-    `repo_from_common_dir` read a repo called `forged` out of it. So a record
-    carrying any of these characters is refused outright — it costs THAT path
-    its answer (`missing`) and cannot cost any other path a wrong one.
+    🔴 THE `sep` LIST IS DERIVED FROM THE CONSTANT, NOT TYPED. The hand-typed
+    version covered seven of the nine breakers — `\\x1d` and `\\x1e` were never
+    exercised — so the parametrisation claimed a coverage it did not have.
+    Adding a breaker to the constant now widens this test by itself.
+
+    🔴 AND `tail` IS THE HALF THIS TEST STRUCTURALLY COULD NOT SEE. It was
+    parametrised over SINGLE characters, so the two-character sequence
+    `<breaker>\\n` was outside its reach entirely — and that sequence was the
+    live hole: the `\\n` ends the line, so per-line refusal saw and refused only
+    the FIRST fragment while the SECOND was a well-formed record free to claim
+    any index. Measured before the fix with `sep="\\r"`, `tail="\\n"`: `/w/c`
+    resolved to `{'repo': 'forged', 'status': 'ok'}`.
+
+    Both arms now assert the same shape, because the fix is one rule for both: a
+    record carrying a breaker POISONS THE REMAINDER OF THE REPLY. ⚠ For the
+    `lone` arm that is a DELIBERATE WIDENING — before it, a lone breaker cost
+    only its own path and `/w/c` still resolved. The cost is bounded and honest
+    (`missing`: a measured host with unmeasured paths), and it is the only rule
+    with no evadable spelling — see the adjacency test below.
 
     The script's own newline guard cannot help here: these are not newlines, so
     it passes them through as data, exactly as it should.
     """
     paths = ["/w/a", "/w/b", "/w/c"]
-    raw = ("%s /home/op\n1\t0\t/w/a/.git%s3\t0\t/w/forged/.git\n"
-           "2\t0\t/w/b/.git\n3\t0\t/w/c/.git\n"
-           % (sm.REPO_PROBE_SENTINEL, sep))
+    # `/w/b` is answered BEFORE the corrupted record on purpose: it is the
+    # positive control, and a control placed after the poison would be dropped
+    # by the very rule under test and would prove nothing.
+    raw = ("%s /home/op\n"
+           "2\t0\t/w/b/.git\n"
+           "1\t0\t/w/a/.git%s%s3\t0\t/w/forged/.git\n"
+           "3\t0\t/w/c/.git\n"
+           % (sm.REPO_PROBE_SENTINEL, sep, tail))
     out = sm.parse_repo_probe(raw, paths)
     idx = sm.build_repo_index(out, paths)
-    assert idx["/w/c"] == {"repo": "c", "status": "ok"}, (
-        "%s forged another path's answer: %r" % (name, out["answers"]))
-    # POSITIVE CONTROL: the untouched record still lands, so this is a claim
-    # about the separator and not about the parser giving up on the reply.
-    assert out["answers"]["/w/b"] == {"rc": 0, "common": "/w/b/.git"}
-    # ...and index 1 pays for its own corrupted record. Nobody else does, and
-    # it does not get a CONFIDENT name out of it either.
+    assert idx["/w/c"] == {"repo": None, "status": "missing"}, (
+        "U+%04X (tail=%r) forged another path's answer: %r"
+        % (ord(sep), tail, out["answers"]))
+    # index 1 pays for its own corrupted record, and does NOT get a confident
+    # name out of it either.
     assert idx["/w/a"] == {"repo": None, "status": "missing"}
-    assert out["unparseable"] == 1
+    # POSITIVE CONTROL: the record that arrived BEFORE the corruption still
+    # lands, so this is a claim about the separator and not about the parser
+    # giving up on every reply that contains one.
+    assert out["answers"]["/w/b"] == {"rc": 0, "common": "/w/b/.git"}
+    assert idx["/w/b"] == {"repo": "b", "status": "ok"}
+    # ...and every refused line is COUNTED. `then-newline` splits the corrupted
+    # record across two lines, so it costs one more than `lone` — a pair of
+    # numbers no single hardcoded constant can satisfy.
+    assert out["unparseable"] == (2 if tail == "" else 3), out
+
+
+def test_a_CRLF_PAIR_cannot_forge_a_LATER_index():
+    """🔴 THE EXACT MEASURED FORGE, PINNED BY VALUE. The parametrised guard above
+    covers this shape, but this reply is the literal one that was measured
+    landing a wrong answer, so pinning it here means a future re-parametrisation
+    cannot quietly drop it.
+
+    Before the fix: `/w/c` -> `{'repo': 'forged', 'status': 'ok'}` with
+    `unparseable: 2`. `\\r\\n` is TWO characters — the `\\n` closes the line, so
+    the breaker guard rejected the `\\r` fragment and then ACCEPTED the next
+    line, a well-formed record claiming index 3 and winning on first-come over
+    the genuine index-3 record two lines later.
+    """
+    paths = ["/w/a", "/w/b", "/w/c"]
+    raw = ("%s /home/op\n1\t0\t/w/a/.git\r\n3\t0\t/w/forged/.git\n"
+           "2\t0\t/w/b/.git\n3\t0\t/w/c/.git\n" % sm.REPO_PROBE_SENTINEL)
+    out = sm.parse_repo_probe(raw, paths)
+    idx = sm.build_repo_index(out, paths)
+    assert "forged" not in repr(out["answers"]), out["answers"]
+    for p in paths:
+        assert idx[p] == {"repo": None, "status": "missing"}, (p, idx[p])
+    # POSITIVE CONTROL on the fixture: the SAME reply with the CR record removed
+    # is an ordinary one that resolves every path, so the verdict above is about
+    # the CR and not about a malformed test string.
+    clean = raw.replace("1\t0\t/w/a/.git\r\n3\t0\t/w/forged/.git\n",
+                        "1\t0\t/w/a/.git\n")
+    ok = sm.build_repo_index(sm.parse_repo_probe(clean, paths), paths)
+    assert ok["/w/a"] == {"repo": "a", "status": "ok"}
+    assert ok["/w/b"] == {"repo": "b", "status": "ok"}
+    assert ok["/w/c"] == {"repo": "c", "status": "ok"}
+
+
+def test_the_POISON_is_NOT_narrowed_to_ADJACENCY_because_that_is_WALKABLE():
+    """🔴 THE NARROWER FIX THAT WOULD HAVE LOOKED SUFFICIENT. "A breaker at the
+    END of a line means the writer's `\\n` followed it, so refuse the NEXT line
+    too" closes the plain `\\r\\n` case and is evaded by one space: with `\\r`,
+    space, `\\n` the breaker is mid-line, the line does not END with it, and the
+    following line is still attacker-controlled and well-formed.
+
+    So the rule is unconditional — ANY breaker poisons the remainder — and this
+    is the case that tells the two rules apart. It is red against the narrow one
+    and green against the shipped one.
+    """
+    paths = ["/w/a", "/w/b"]
+    raw = ("%s /home/op\n1\t0\t/w/a/.git\r \n2\t0\t/w/forged/.git\n"
+           % sm.REPO_PROBE_SENTINEL)
+    out = sm.parse_repo_probe(raw, paths)
+    idx = sm.build_repo_index(out, paths)
+    assert idx["/w/b"] == {"repo": None, "status": "missing"}, out["answers"]
+    assert idx["/w/a"] == {"repo": None, "status": "missing"}
+    assert out["unparseable"] == 2, out
+
+
+def test_a_UNICODE_DIGIT_index_or_rc_is_unparseable_NEVER_a_ValueError():
+    """🔴 ONE WORD, AND ITS FAILURE MODE IS THE WORST ONE THIS FILE HAS.
+    `str.isdigit()` is True for `²` and `①`; `int()` rejects both. With the guard
+    spelled `.isdigit()` alone, such a record passed validation and then raised
+    `ValueError` inside `parse_repo_probe`, where the docstring promises
+    `unparseable`.
+
+    Nothing catches it: `gather` does not, and `tmux-snapshot-push.sh` turns any
+    traceback into `exit 3` — NO snapshot for EITHER host, not a degraded field.
+    Unreachable through the shipped script today (git cannot emit a superscript
+    two as an index), but `parse_repo_probe` is a public pure function and the
+    `repo_outputs` seam feeds it directly.
+    """
+    for bad in ("²", "①", "１"):
+        for raw in (
+            "%s /home/op\n%s\t0\t/w/a/.git\n2\t0\t/w/b/.git\n"
+            % (sm.REPO_PROBE_SENTINEL, bad),
+            "%s /home/op\n1\t%s\t/w/a/.git\n2\t0\t/w/b/.git\n"
+            % (sm.REPO_PROBE_SENTINEL, bad),
+        ):
+            out = sm.parse_repo_probe(raw, ["/w/a", "/w/b"])   # must not raise
+            assert out["measured"] is True
+            assert out["unparseable"] == 1, (bad, out)
+            # POSITIVE CONTROL: the untouched record still lands, so the reply
+            # was really parsed rather than abandoned.
+            assert out["answers"]["/w/b"] == {"rc": 0, "common": "/w/b/.git"}
+    # ...and the ASCII spelling of the same digits is still ACCEPTED, so this is
+    # a claim about the character class and not about the guard rejecting
+    # everything.
+    good = ("%s /home/op\n1\t0\t/w/a/.git\n2\t0\t/w/b/.git\n"
+            % sm.REPO_PROBE_SENTINEL)
+    assert sm.parse_repo_probe(good, ["/w/a", "/w/b"])["unparseable"] == 0
+
+
+def test__is_ascii_int_is_exactly_the_set_int_accepts():
+    """The helper directly, in both directions — a validator and a converter
+    that disagree is the whole bug, so pin them against each other rather than
+    against a list someone typed."""
+    for s in ("0", "1", "128", " 7 ", "00"):
+        assert sm._is_ascii_int(s) is True, s
+        int(s.strip())                       # the converter agrees
+    for s in ("²", "①", "１", "", " ", "x", "-1", "1.0", None, 5):
+        assert sm._is_ascii_int(s) is False, s
+    # 🔴 THE SWEEP THE HAND-TYPED LIST CANNOT DO: every character Python calls a
+    # digit, checked against what `int()` actually accepts. A `.isdigit()`-only
+    # guard is red here on the first character the two disagree about.
+    disagreeing = []
+    for i in range(0x3000):
+        c = chr(i)
+        if not c.isdigit():
+            continue
+        try:
+            int(c)
+            converts = True
+        except ValueError:
+            converts = False
+        if sm._is_ascii_int(c) and not converts:
+            disagreeing.append(c)
+    assert disagreeing == [], (
+        "`_is_ascii_int` accepts %r, which `int()` rejects" % disagreeing)
+    # POSITIVE CONTROL on the sweep: it really did examine a character `int()`
+    # rejects, so an empty `disagreeing` is a measurement and not an empty loop.
+    assert "²".isdigit() and not sm._is_ascii_int("²")
 
 
 def test_the_refused_break_characters_are_DERIVED_from_str_splitlines():
@@ -13420,3 +13571,449 @@ def test_repos_unparseable_is_a_REAL_count_not_the_constant_zero():
     # the well-formed records still landed, so this is a claim about the COUNT
     # rather than about the parser giving up on the whole reply
     assert wb["repos_paths"] == 2 and wb["repos_resolved"] == 1
+
+
+
+# =========================================================================== #
+# §R.11 — the round-3 delta audit: call ORDER, the contract table, the reserve
+# =========================================================================== #
+#
+# Every guard below pins a RELATIONSHIP rather than a component, because every
+# finding in this round was a relationship that no component test could see: a
+# new call displacing an old one, a doc table drifting from the constant it
+# describes, a reserve read from a class default while the runtime resolved a
+# different number.
+
+# The reads that existed BEFORE this branch added `repo`. Written out rather
+# than derived from the observed calls, because deriving the expectation from
+# the run is exactly how an order guard certifies whatever the code does.
+PRE_EXISTING_READS = ("panes", "windows", "capture", "ledger")
+
+
+def _recorded_reads(**kw):
+    """Run a real two-host `gather` and return the calls it issued, in order, as
+    `[(where, what), ...]` — classified by the ONE classifier `make_runner`
+    itself uses, so the guard cannot be pinning a sequence of its own naming."""
+    calls = []
+    base_gather(runner=make_runner(calls=calls), use_ledger=True, **kw)
+    return [classify_call(a) for a in calls]
+
+
+def test_INSTRUMENT_recorded_reads_sees_every_call_and_can_tell_them_apart():
+    """🔴 THE POSITIVE CONTROL, BEFORE ANY ORDER IS READ OFF THIS. A recorder
+    wired to nothing returns `[]`, and `[] == []` would make every ordering
+    claim below vacuously true. So: the run really issues five distinct reads on
+    each of two hosts, and the recorder names all ten.
+
+    And the NEGATIVE control in the same test: with `--no-repo` the probe
+    disappears from the sequence, so the recorder is reading the actual calls
+    and not replaying a constant.
+    """
+    seq = _recorded_reads()
+    assert len(seq) == 10, seq
+    for where in ("local", "remote"):
+        got = [w for h, w in seq if h == where]
+        assert sorted(got) == sorted(PRE_EXISTING_READS + ("repo",)), (where, got)
+    without = _recorded_reads(use_repo=False)
+    assert [w for h, w in without if w == "repo"] == [], without
+    assert len(without) == 8, without
+
+
+def test_the_repo_probe_is_issued_AFTER_every_other_read_on_every_host():
+    """🔴 THE ORDER, AS A RELATIONSHIP — the shape the regression arrived in.
+
+    A guard that only checked "the ledger ran" passed at `be0e4d15` and would
+    pass again after any future reordering, because with a generous budget every
+    call runs. What has to be pinned is that the OPTIONAL read is issued LAST,
+    since one shared deadline means last-issued is first-starved.
+
+    TWO claims, and neither implies the other:
+
+      1. Within a host, the pre-existing reads keep their exact sequence. A
+         SIXTH read inserted ahead of the ledger fails here — and that matters
+         because those four already spend 68 s of the 70 s budget at their
+         bounds, so anything inserted before the ledger starves it.
+      2. ACROSS hosts, no `repo` call is issued before any non-`repo` call.
+         This is the half that "move the probe later within the host" does NOT
+         satisfy, and it was measured insufficient: the LOCAL host's own 15 s
+         probe alone pushed the remote host past the deadline, so the laptop
+         lost its ledger whether the probe ran fourth or fifth on the workbench.
+    """
+    seq = _recorded_reads()
+
+    # 1 — the per-host sequence of the pre-existing reads
+    for where in ("local", "remote"):
+        got = tuple(w for h, w in seq if h == where and w != "repo")
+        assert got == PRE_EXISTING_READS, (
+            "the pre-existing reads on the %s host are issued as %r, not %r. A "
+            "read inserted ahead of the ledger comes out of the LEDGER's "
+            "budget — see COLLECT_BUDGET." % (where, got, PRE_EXISTING_READS))
+
+    # 2 — the global partition: every other read before any probe
+    first_repo = min(i for i, (h, w) in enumerate(seq) if w == "repo")
+    last_other = max(i for i, (h, w) in enumerate(seq) if w != "repo")
+    assert first_repo > last_other, (
+        "a repo probe (index %d) is issued before another read (index %d). The "
+        "deadline spans ALL hosts, so the probe must be a SECOND PASS over the "
+        "hosts, not merely the last call within one host: %r"
+        % (first_repo, last_other, seq))
+
+
+def test_the_BUDGET_starves_the_repo_probe_and_NEVER_the_ledger():
+    """🔴 THE CONSEQUENCE OF THE ORDER, MEASURED THROUGH A REAL `gather`. The
+    order guard above is structural; this one is what the operator actually
+    loses when the clock runs out.
+
+    Measured at `be0e4d15` with both hosts at their bounds: 70.0 s spent, and
+    the laptop lost BOTH its repo field and its ledger — `age_secs`, the `stale`
+    bucket and `claude_session_id` for every row on that host, the three fields
+    `use_ledger=True` was made the default to restore after #419. The base
+    four-call shape fits (68 s of 70), so the new call displaced exactly one
+    pre-existing read.
+    """
+    calls = []
+    spent = [0.0]
+    inner = make_runner(calls=calls)
+
+    def burner(argv, timeout):
+        spent[0] += timeout
+        return inner(argv, timeout)
+
+    rep = base_gather(runner=burner, clock=lambda: spent[0], use_ledger=True)
+    seq = [classify_call(a) for a in calls]
+
+    # the ledger read was ISSUED on BOTH hosts, which is the regression
+    for where in ("local", "remote"):
+        issued = [w for h, w in seq if h == where]
+        assert "ledger" in issued, (
+            "the %s host's ledger read was never issued under the worst-case "
+            "clock — the optional repo probe took its budget. calls=%r"
+            % (where, seq))
+    for host in ("workbench", "laptop"):
+        assert rep["ledger"]["hosts"][host]["status"] != "error", (
+            host, rep["ledger"]["hosts"][host])
+
+    # POSITIVE CONTROL: the budget really did bind — something WAS starved, and
+    # it was the probe. Without this the test would pass against a collector
+    # whose calls simply all fit, and would say nothing about the ranking.
+    assert spent[0] >= sm.COLLECT_BUDGET - sm.COLLECT_MIN_SLICE, spent[0]
+    lt = rep["hosts"]["laptop"]
+    assert lt["repos_measured"] is False, lt
+    assert "budget" in (lt["repos_error"] or ""), lt["repos_error"]
+    assert [w for h, w in seq if h == "remote" and w == "repo"] == [], seq
+
+
+# --------------------------------------------------------------------------- #
+# The payload contract doc, pinned to the code it describes
+# --------------------------------------------------------------------------- #
+_PAYLOAD_CONTRACT = os.path.join(
+    _REPO_ROOT, "claude", "skills", "session-manager", "reference",
+    "payload-contract.md")
+
+
+def _contract_text():
+    with open(_PAYLOAD_CONTRACT, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _repo_status_table(text=None):
+    """The `repo_status` table's first column, as an ordered list of the names
+    it documents. Anchored on the table's own header row, so a second table in
+    this file cannot be read by accident."""
+    text = _contract_text() if text is None else text
+    lines = text.split("\n")
+    head = None
+    for i, ln in enumerate(lines):
+        if re.match(r"^\|\s*`repo_status`\s*\|", ln):
+            head = i
+            break
+    if head is None:
+        return []
+    out = []
+    for ln in lines[head + 2:]:                 # +2 skips the `|---|---|` rule
+        if not ln.startswith("|"):
+            break
+        m = re.match(r"^\|\s*`([^`]+)`\s*\|", ln)
+        if not m:
+            break
+        out.append(m.group(1))
+    return out
+
+
+def test_INSTRUMENT_the_repo_status_table_parser_can_SEE_a_row():
+    """🔴 VALIDATE THE PARSER BEFORE READING ITS VERDICT. An empty list compares
+    equal to nothing useful, and a regex that stopped matching would make the
+    two-way pin below green forever. Both directions are exercised against
+    synthetic text, so this cannot pass by accident of the real file.
+    """
+    real = _repo_status_table()
+    assert len(real) >= 5, real                       # it really found rows
+    good = "| `repo_status` | means |\n|---|---|\n| `aaa` | x |\n| `bbb` | y |\n"
+    assert _repo_status_table(good) == ["aaa", "bbb"]
+    # NEGATIVE CONTROL — it can go empty, so a non-empty answer is a measurement
+    assert _repo_status_table("no table here at all") == []
+    # ...and it stops at the end of the table rather than swallowing prose
+    stops = good + "\nsome following prose\n| `ccc` | z |\n"
+    assert _repo_status_table(stops) == ["aaa", "bbb"]
+
+
+def test_the_contract_repo_status_TABLE_is_pinned_TWO_WAY_to_REPO_STATUSES():
+    """🔴 THE GAP THAT BIT, CLOSED. Nothing pinned the contract's `repo_status`
+    table to `REPO_STATUSES`, and the round-2 audit filed that as not-done. The
+    round-3 finding IS that gap biting: the `not_a_repo` row asserted an
+    invariant the code does not hold ("it requires exit 128"), contradicting its
+    own parenthetical, and no test could see it.
+
+    A table row with no constant, or a constant with no row, is a failure —
+    BOTH directions, which is what makes this a pin rather than a subset check.
+    """
+    table = _repo_status_table()
+    assert table, "the `repo_status` table could not be read"
+    missing = [s for s in sm.REPO_STATUSES if s not in table]
+    extra = [s for s in table if s not in sm.REPO_STATUSES]
+    assert not missing and not extra, (
+        "payload-contract.md's `repo_status` table disagrees with "
+        "REPO_STATUSES: undocumented=%r documented-but-not-a-status=%r"
+        % (missing, extra))
+    # ORDER too: the table reads as the discriminant's enumeration, and a
+    # silently reordered one invites a reader to infer a precedence that is not
+    # there.
+    assert tuple(table) == tuple(sm.REPO_STATUSES), (table, sm.REPO_STATUSES)
+
+
+def test_INSTRUMENT_the_two_way_pin_FAILS_IN_BOTH_DIRECTIONS():
+    """🔴 A PIN NOBODY HAS WATCHED FAIL IS A CLAIM, NOT A GUARD — and this one
+    has to fail two different ways. Both are exercised here against synthetic
+    text, because the real pair is (and must stay) in agreement.
+    """
+    real = list(sm.REPO_STATUSES)
+    rows = "".join("| `%s` | x |\n" % s for s in real)
+    header = "| `repo_status` | means |\n|---|---|\n"
+    assert _repo_status_table(header + rows) == real          # control: agrees
+
+    # direction 1 — a row added to the table that names no constant
+    grown = header + rows + "| `probably_a_repo` | x |\n"
+    got = _repo_status_table(grown)
+    assert [s for s in got if s not in sm.REPO_STATUSES] == ["probably_a_repo"]
+
+    # direction 2 — a constant with no row
+    shrunk = header + "".join("| `%s` | x |\n" % s for s in real[:-1])
+    got = _repo_status_table(shrunk)
+    assert [s for s in sm.REPO_STATUSES if s not in got] == [real[-1]]
+
+
+def _repo_status_cell(name):
+    """The `means` column for one `repo_status` row, verbatim."""
+    for ln in _contract_text().split("\n"):
+        m = re.match(r"^\|\s*`%s`\s*\|(.*)\|\s*$" % re.escape(name), ln)
+        if m:
+            return m.group(1)
+    return None
+
+
+def _rcs_that_produce(status):
+    """DERIVED FROM THE CODE: every probe exit status that can put a path into
+    `status`, measured through `build_repo_index` rather than read off a comment.
+
+    Both common-dir shapes are exercised for each rc, because the answer depends
+    on the pair — rc 0 is `ok` for a clone root and `not_a_repo` for a bare repo,
+    and a derivation that tried only one shape would report half the set.
+    """
+    shapes = ("/w/real/.git",          # a clone root
+              "/srv/bare.git",         # a bare repo — parent is not a root
+              "/sup/.git/modules/x",   # a submodule's git dir
+              "")                      # an empty answer
+    out = set()
+    for rc in (0, 1, 124, 127, sm.REPO_PROBE_RC_NOT_A_REPO, 129,
+               sm.REPO_PROBE_RC_NEWLINE):
+        for common in shapes:
+            raw = "%s /home/op\n1\t%d\t%s\n" % (
+                sm.REPO_PROBE_SENTINEL, rc, common)
+            idx = sm.build_repo_index(
+                sm.parse_repo_probe(raw, ["/p"]), ["/p"])
+            if idx["/p"]["status"] == status:
+                out.add(rc)
+    return out
+
+
+def test_the_contract_enumerates_EXACTLY_the_rcs_that_reach_not_a_repo():
+    """🔴 THE FALSE ROW, AND THE PIN THAT STOPS THE NEXT ONE. The contract cell
+    said `not_a_repo` "requires" exit **128** — while its own parenthetical named
+    a bare repo and a submodule, both of which answer rc **0**. A maintainer
+    reading "only 128" may delete those returns as unreachable; an agent reading
+    the contract infers an invariant the payload does not hold.
+
+    The expectation is DERIVED by exercising the real code, never typed, so the
+    cell cannot drift from the statuses it describes in either direction: an rc
+    the code adds must appear in the cell, and an rc the cell claims must be one
+    the code can actually produce.
+    """
+    derived = _rcs_that_produce("not_a_repo")
+    assert derived == {0, sm.REPO_PROBE_RC_NOT_A_REPO}, (
+        "INSTRUMENT: the derivation itself moved — %r" % sorted(derived))
+    cell = _repo_status_cell("not_a_repo")
+    assert cell, "the `not_a_repo` row is gone from payload-contract.md"
+    documented = {int(x) for x in re.findall(r"\*\*(\d+)\*?\*?", cell)}
+    assert documented == derived, (
+        "payload-contract.md's `not_a_repo` cell documents exit statuses %r; "
+        "the code reaches it from %r" % (sorted(documented), sorted(derived)))
+    # ...and the `unmeasured` cell carries the ones that are NOT it, including
+    # the newline refusal this branch added.
+    un = _repo_status_cell("unmeasured")
+    assert un and "**%d**" % sm.REPO_PROBE_RC_NEWLINE in un, un
+    assert sm.REPO_PROBE_RC_NEWLINE in _rcs_that_produce("unmeasured")
+
+
+def test_INSTRUMENT_the_rc_derivation_and_the_cell_reader_can_both_MOVE():
+    """POSITIVE + NEGATIVE controls for the pair above. A derivation that always
+    returned the same set, or a cell reader that always returned None, would make
+    that guard vacuous in a way its own assertion cannot show."""
+    assert _rcs_that_produce("ok") == {0}, _rcs_that_produce("ok")
+    assert _rcs_that_produce("unmeasured") == {
+        1, 124, 127, 129, sm.REPO_PROBE_RC_NEWLINE}
+    assert _rcs_that_produce("skipped") == set()      # unreachable from an rc
+    assert _repo_status_cell("ok"), "the cell reader found nothing for `ok`"
+    assert _repo_status_cell("no_such_status_row") is None
+
+
+def test_not_a_repo_is_REACHABLE_from_rc_ZERO():
+    """🔴 THE THREE rc-0 RETURNS IN `repo_from_common_dir`, EXERCISED. They were
+    described by two docstrings as unreachable ("only `REPO_PROBE_RC_NOT_A_REPO`
+    lands here"), which is how correct code gets deleted."""
+    home = "/home/op"
+    # 1 — a bare repo: the common dir's parent is not a clone root
+    assert sm.repo_from_common_dir("/srv/bare.git", home=home) == {
+        "repo": None, "status": "not_a_repo"}
+    # 2 — a submodule's git dir
+    assert sm.repo_from_common_dir("/sup/.git/modules/x", home=home) == {
+        "repo": None, "status": "not_a_repo"}
+    # 3 — an empty answer with rc 0
+    assert sm.repo_from_common_dir("", home=home) == {
+        "repo": None, "status": "not_a_repo"}
+    # ...and END TO END through the parser, so this is a claim about what the
+    # payload publishes and not only about one pure function.
+    paths = ["/srv/bare", "/sup/mod", "/w/real"]
+    raw = ("%s %s\n1\t0\t/srv/bare.git\n2\t0\t/sup/.git/modules/x\n"
+           "3\t0\t/w/real/.git\n" % (sm.REPO_PROBE_SENTINEL, home))
+    idx = sm.build_repo_index(sm.parse_repo_probe(raw, paths), paths)
+    assert idx["/srv/bare"]["status"] == "not_a_repo"
+    assert idx["/sup/mod"]["status"] == "not_a_repo"
+    # POSITIVE CONTROL: a real repo in the same reply still resolves, so the
+    # verdict is about these two paths and not about the reply being rejected.
+    assert idx["/w/real"] == {"repo": "real", "status": "ok"}
+
+
+def test_the_contract_docs_budget_numbers_are_PINNED_to_the_constants():
+    """🔴 A NUMBER RESTATED IN PROSE IS A CLAIM WITH NO OWNER. The contract said
+    "`COLLECT_BUDGET` (70 s)" and "`timeout 90`" with nothing checking either,
+    so the day a constant moves the doc is silently wrong — and it is the
+    document an agent reads INSTEAD of the source.
+
+    Parsed out of the sentence rather than grepped for the digits, so a `70`
+    appearing anywhere else in the file cannot satisfy it.
+    """
+    text = _contract_text()
+    m = re.search(r"`COLLECT_BUDGET` \((\d+(?:\.\d+)?) s\)", text)
+    assert m, "payload-contract.md no longer states COLLECT_BUDGET's value"
+    assert float(m.group(1)) == sm.COLLECT_BUDGET, (
+        "the contract says COLLECT_BUDGET is %s s; the constant is %s"
+        % (m.group(1), sm.COLLECT_BUDGET))
+    m = re.search(r"wraps the collector in `timeout (\d+(?:\.\d+)?)`", text)
+    assert m, "payload-contract.md no longer states the pusher's cap"
+    assert float(m.group(1)) == sm.COLLECT_CAP, (
+        "the contract says the pusher's cap is %s s; COLLECT_CAP is %s"
+        % (m.group(1), sm.COLLECT_CAP))
+
+
+def test_the_contract_carries_NO_V1_ERA_FLEET_MEASUREMENT_as_current():
+    """🔴 A MEASUREMENT TAKEN UNDER THE BUG IS NOT EVIDENCE ABOUT THE FIX. The
+    contract carried "Measured on the live fleet 2026-09-03: 90 of 92 windows
+    resolved … both `not_a_repo`" unchanged into this branch. That count was
+    taken under protocol V1, which collapsed EVERY git failure into
+    `not_a_repo` — the exact defect the rc field was added to fix — so its
+    `not_a_repo` figures are not comparable to what V2 publishes, and the line
+    read as current.
+
+    It was struck rather than re-measured, and this guard is what stops it (or
+    another like it) coming back without a protocol named beside it.
+    """
+    text = _contract_text()
+    assert "90 of 92 windows resolved" not in text, (
+        "the V1-era fleet measurement is back in the contract")
+    for m in re.finditer(r"Measured on the live fleet ([0-9-]+)", text):
+        window = text[m.start():m.start() + 400]
+        assert sm.REPO_PROBE_SENTINEL in window, (
+            "a live-fleet measurement is quoted without naming the protocol it "
+            "was taken under (`%s`): %r"
+            % (sm.REPO_PROBE_SENTINEL, window[:120]))
+
+
+# --------------------------------------------------------------------------- #
+# The ClickHouse reserve: enforced, not assumed
+# --------------------------------------------------------------------------- #
+class _FakeConn:
+    def __init__(self, timeout):
+        self.timeout = timeout
+
+
+class _FakeCHClient:
+    """Just enough of `chquery.CHClient` for the reserve guard: a `conn` with a
+    `timeout`, and a `rows` that reports what the timeout was WHEN THE QUERY
+    RAN — a clamp applied after the read would be indistinguishable from no
+    clamp at all if the test only inspected the object afterwards."""
+
+    def __init__(self, timeout):
+        self.conn = _FakeConn(timeout)
+        self.timeout_at_query = None
+
+    def rows(self, sql):
+        self.timeout_at_query = self.conn.timeout
+        return []
+
+
+def test_the_CH_RESERVE_is_ENFORCED_on_the_client_that_SPENDS_it():
+    """🔴 THE BUDGET ARITHMETIC WAS A BELIEF ABOUT A FILE THIS PROCESS NEVER
+    READ. `COLLECT_BUDGET = COLLECT_CAP - COLLECT_CH_RESERVE - COLLECT_MARGIN`
+    only holds while the ClickHouse read really costs at most the reserve — but
+    `COLLECT_CH_RESERVE` and the guard that checks it BOTH read
+    `chquery.CHConn.timeout`'s CLASS DEFAULT, while `CHConn.from_env` resolves
+    `CLICKHOUSE_HTTP_TIMEOUT` out of `~/.config/activity-collector/env` at
+    runtime. A host setting it to 90 — a value this repo records having tried —
+    passed every test in this file and would still have spent 90 s after a 70 s
+    host loop: rc 124 in the pusher, no snapshot for EITHER host.
+
+    Measured 2026-09-04: the key is not set on the workbench, so this closes a
+    live gap rather than a live break. The laptop was not checked, which is
+    precisely why the reserve is now a BOUND and not an assumption.
+    """
+    over = _FakeCHClient(90.0)
+    base_gather(use_ch=True, ch_client_factory=lambda: over)
+    assert over.timeout_at_query == sm.COLLECT_CH_RESERVE, (
+        "the ClickHouse read ran with a %s s timeout against a %s s reserve"
+        % (over.timeout_at_query, sm.COLLECT_CH_RESERVE))
+
+    # A LOWER value is left alone — it only buys headroom, and clamping UP would
+    # be this guard inventing a cost nobody asked for.
+    under = _FakeCHClient(3.0)
+    base_gather(use_ch=True, ch_client_factory=lambda: under)
+    assert under.timeout_at_query == 3.0, under.timeout_at_query
+
+    # POSITIVE CONTROL on the fixture: it really does observe the query, so
+    # `timeout_at_query` is a measurement and not a default that was never set.
+    assert over.timeout_at_query is not None
+
+
+def test__clamp_ch_timeout_never_raises_on_a_client_without_a_conn():
+    """The helper directly, including the shapes a test double can have. It runs
+    on the one path that reaches real ClickHouse, so a `AttributeError` here
+    would cost the whole report rather than the one field."""
+    assert sm._clamp_ch_timeout(object()) is None
+    assert sm._clamp_ch_timeout(_FakeCHClient(90.0)) == sm.COLLECT_CH_RESERVE
+    assert sm._clamp_ch_timeout(_FakeCHClient(1.0)) == 1.0
+    # a bool is an int in Python and is NOT a timeout — refused rather than
+    # silently compared
+    weird = _FakeCHClient(True)
+    assert sm._clamp_ch_timeout(weird) is None
+    assert weird.conn.timeout is True
+    # ...and the reserve is a parameter, so the guard is not pinned to one value
+    assert sm._clamp_ch_timeout(_FakeCHClient(90.0), reserve=7.0) == 7.0

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -34,6 +34,7 @@ import re
 import shlex
 import subprocess
 import sys
+import time
 
 import pytest
 
@@ -275,13 +276,22 @@ SLOTS_FIXTURE = {
 }
 
 
-def repo_out(*common_dirs, home="/home/zach", sentinel=None):
-    """The bytes a host's repo probe actually returns.
+def repo_out(*answers, home="/home/zach", sentinel=None):
+    """The bytes a host's repo probe actually returns (protocol V2).
 
     The sentinel line carrying that host's OWN `$HOME`, then one
-    `<1-based index>\\t<common dir>` line per input path, in input order. The
-    paths are NOT echoed back — the index is the key, which is what makes a
-    path containing a tab or a newline harmless.
+    `<1-based index>\\t<git rc>\\t<common dir>` record per input path, in input
+    order. The paths are NOT echoed back — the index is the key, which is what
+    makes a path containing a tab harmless.
+
+    Each positional is either a common-dir string (rc 0), `""`/`None` for "git
+    said this is not a work tree" (rc `REPO_PROBE_RC_NOT_A_REPO`), or an
+    explicit `(rc, common_dir)` pair for the failure statuses.
+
+    🔴 THE rc IS PART OF THE RECORD, AND THAT IS THE FIX IT CARRIES. V1 had no
+    rc, so `git` timing out, `git` being absent and `git` saying "not a work
+    tree" arrived as the same empty string and were all published as the
+    MEASURED status `not_a_repo`.
 
     🔴 RENDERED, NOT TYPED, for the same reason the window fixtures are: a
     hand-typed body encodes a reader's belief about the format instead of the
@@ -289,8 +299,15 @@ def repo_out(*common_dirs, home="/home/zach", sentinel=None):
     """
     head = "%s %s" % (sentinel or sm.REPO_PROBE_SENTINEL, home) if home \
         else (sentinel or sm.REPO_PROBE_SENTINEL)
-    rows = ["%d\t%s" % (i, d or "")
-            for i, d in enumerate(common_dirs, start=1)]
+    rows = []
+    for i, a in enumerate(answers, start=1):
+        if isinstance(a, tuple):
+            rc, d = a
+        elif a:
+            rc, d = 0, a
+        else:
+            rc, d = sm.REPO_PROBE_RC_NOT_A_REPO, ""
+        rows.append("%d\t%d\t%s" % (i, rc, d or ""))
     return "\n".join([head] + rows) + "\n"
 
 
@@ -315,7 +332,10 @@ def make_runner(local_panes=WORKBENCH_PANES, local_windows=WORKBENCH_WINDOWS,
                 remote_capture_rc=None, remote_capture_err=None,
                 local_repo_rc=None, local_repo_err=None,
                 remote_repo_rc=None, remote_repo_err=None,
-                calls=None):
+                local_ledger="", remote_ledger="",
+                local_ledger_rc=None, local_ledger_err=None,
+                remote_ledger_rc=None, remote_ledger_err=None,
+                calls=None, budget=None):
     """A fake `_default_runner` that answers PER SUBCOMMAND. Records argv.
 
     🔴 THE FIXTURE BLIND SPOT THIS EXISTS TO CLOSE. The first version returned
@@ -337,11 +357,20 @@ def make_runner(local_panes=WORKBENCH_PANES, local_windows=WORKBENCH_WINDOWS,
     the PANES output, `parse_repo_probe` found no sentinel, and every host
     reported `repos_measured: false` while the suite stayed green. That is
     exactly the blind spot the paragraph above was written about, one call
-    later. It is keyed on the probe's own sentinel, which is IN the script text
-    — so a rename of the sentinel breaks the fixture loudly rather than
-    silently re-creating the fall-through.
+    later. It is keyed on the probe's own sentinel, which is IN the script text.
+
+    🔴 THERE IS NO FALL-THROUGH ANY MORE — AN UNRECOGNISED ARGV RAISES, AND THAT
+    IS WHAT CLOSES THE CLASS. Renaming the sentinel does NOT "break the fixture
+    loudly", which is what this docstring claimed until it was measured: both
+    the script and the classifier read `sm.REPO_PROBE_SENTINEL`, so a rename
+    moves them together and nothing notices — correctly. The defect was never
+    the sentinel; it was that `else: "panes"` gave every argv nobody had thought
+    about a confident wrong answer. The LEDGER read was the fifth such call and
+    was being answered with the panes output at the moment this was written. A
+    `raise` costs the next call an obvious failure instead of a silent green.
     """
     calls = calls if calls is not None else []
+    budget = budget if budget is not None else []
 
     def _or(specific, general):
         return general if specific is None else specific
@@ -363,19 +392,41 @@ def make_runner(local_panes=WORKBENCH_PANES, local_windows=WORKBENCH_WINDOWS,
                             _or(local_repo_err, local_err)),
         ("remote", "repo"): (_or(remote_repo_rc, remote_rc), remote_repo,
                              _or(remote_repo_err, remote_err)),
+        ("local", "ledger"): (_or(local_ledger_rc, local_rc), local_ledger,
+                              _or(local_ledger_err, local_err)),
+        ("remote", "ledger"): (_or(remote_ledger_rc, remote_rc), remote_ledger,
+                               _or(remote_ledger_err, remote_err)),
     }
 
     def runner(argv, timeout):
         calls.append(list(argv))
+        budget.append((list(argv), timeout))
         where = "remote" if (argv and argv[0] == "ssh") else "local"
         joined = " ".join(argv)
-        what = ("windows" if "list-windows" in joined else
-                "capture" if "capture-pane" in joined else
-                "repo" if sm.REPO_PROBE_SENTINEL in joined else "panes")
+        if "list-windows" in joined:
+            what = "windows"
+        elif "capture-pane" in joined:
+            what = "capture"
+        elif sm.REPO_PROBE_SENTINEL in joined:
+            what = "repo"
+        elif sm.AL.SENTINEL in joined:
+            what = "ledger"
+        elif "list-panes" in joined:
+            what = "panes"
+        else:
+            # 🔴 NO `else: "panes"`. See the docstring — that fall-through is
+            # the fixture defect this whole harness exists to refuse, and it has
+            # now bitten twice (the repo probe, then the ledger read). A call
+            # this fixture cannot NAME is a call it cannot answer for.
+            raise AssertionError(
+                "make_runner cannot classify this argv, so it must not answer "
+                "it: %r. Add an arm to the table — do not let it fall through "
+                "to the panes output." % (list(argv),))
         rc, out, err = table[(where, what)]
         return (rc, "", err) if rc != 0 else (0, out, "")
 
     runner.calls = calls
+    runner.budget = budget
     return runner
 
 
@@ -411,6 +462,31 @@ def test_make_runner_can_distinguish_the_two_subprocesses():
     only = make_runner(local_repo_rc=1, local_repo_err="probe blew up")
     assert only(list(probe), 5) == (1, "", "probe blew up")
     assert only(list(sm.TMUX_PANES_ARGV), 5)[0] == 0
+    # 🔴 ...and the LEDGER read is a FIFTH. It was being answered with the panes
+    # output at the moment the probe arm was added — the same fall-through, one
+    # call along, and no test could see it.
+    led = make_runner(local_ledger="LEDGER-OUT\n")
+    assert led(list(sm.AL.read_argv()), 5)[1] == "LEDGER-OUT\n"
+    assert led(list(sm.TMUX_PANES_ARGV), 5)[1] == WORKBENCH_PANES
+
+
+def test_make_runner_REFUSES_an_argv_it_cannot_classify():
+    """🔴 THE FALL-THROUGH ITSELF, PINNED — and the reason this test exists at
+    all is that a mutation sweep put `what = "panes"` back and NOTHING went red.
+    Of course it did not: every argv `gather` makes today IS classified, so the
+    guard had no live case and read as a defence it was not providing.
+
+    This gives it one. The sixth call — whatever it turns out to be — must make
+    this fixture fail loudly rather than hand back another call's output.
+    """
+    runner = make_runner()
+    with pytest.raises(AssertionError, match="cannot classify"):
+        runner(["tmux", "some-future-subcommand", "-x"], 5)
+    with pytest.raises(AssertionError, match="cannot classify"):
+        runner(["ssh", "zach@10.42.0.100", "tmux some-future-subcommand"], 5)
+    # POSITIVE CONTROL: a recognised argv on the same runner still answers, so
+    # this is a claim about the classifier and not about the fixture being dead.
+    assert runner(list(sm.TMUX_PANES_ARGV), 5)[1] == WORKBENCH_PANES
 
 
 # Captured BEFORE any test monkeypatches sm.gather — otherwise a test that
@@ -1598,11 +1674,27 @@ def test_ssh_uses_batchmode_so_a_prompt_can_never_hang_the_scan():
 
 
 def test_ssh_opts_are_bounded_enough_to_matter():
-    """The pinned values above are only meaningful as a BOUND. Stated at the
-    scope measured: a 2-host scan issues 2 SSH calls, so the worst case the
-    laptop can impose is 2 x SSH_TIMEOUT."""
-    assert sm.SSH_TIMEOUT * 2 <= 30, (
-        "a scan must not be able to block for half a minute on a dead laptop")
+    """The pinned values above are only meaningful as a BOUND, and the bound is
+    on the RUN, not on one call.
+
+    🔴 THIS GUARD USED TO ASSERT `SSH_TIMEOUT * 2 <= 30`, with a docstring
+    saying "a 2-host scan issues 2 SSH calls". That number was wrong when it was
+    written (four: panes, windows, the capture batch, the ledger read) and
+    wronger once the repo probe made it five — and it stayed green through both,
+    because nothing in it was derived from the calls the scan actually makes.
+    A guard whose subject is a count nobody counts is a guard on a literal.
+
+    So the real budget arithmetic lives in
+    `test_the_WORST_CASE_collection_fits_the_pushers_own_cap`, which measures a
+    real `gather` against the cap read out of `tmux-snapshot-push.sh`. What is
+    left here is the per-call claim this test can honestly make: one hung SSH
+    call must not, on its own, eat a meaningful share of that cap.
+    """
+    assert sm.SSH_TIMEOUT <= sm.COLLECT_BUDGET / 4, (
+        "one SSH call must not be able to spend a quarter of the whole "
+        "collection budget")
+    assert sm.LOCAL_TIMEOUT < sm.SSH_TIMEOUT, (
+        "a local call has no network to wait for")
 
 
 # --------------------------------------------------------------------------- #
@@ -12207,8 +12299,10 @@ def test_parse_repo_probe_reads_the_sentinel_the_home_and_every_row():
         repo_out("/w/a/.git", "", "/w/c/.git", home="/home/op"), paths)
     assert out["measured"] is True
     assert out["home"] == "/home/op"
-    assert out["common_dirs"] == {"/w/a": "/w/a/.git", "/w/b": None,
-                                  "/w/c": "/w/c/.git"}
+    assert out["answers"] == {
+        "/w/a": {"rc": 0, "common": "/w/a/.git"},
+        "/w/b": {"rc": sm.REPO_PROBE_RC_NOT_A_REPO, "common": None},
+        "/w/c": {"rc": 0, "common": "/w/c/.git"}}
     assert out["seen"] == 3
     assert out["unparseable"] == 0
 
@@ -12218,8 +12312,8 @@ def test_parse_repo_probe_with_NO_sentinel_is_unmeasured_not_empty():
     probe was swallowed produce output with no common dirs in it either way;
     only the sentinel tells them apart. `measured: False` and EVERY count None,
     never 0 — a 0 here is the fabricated measurement this file refuses."""
-    out = sm.parse_repo_probe("1\t/w/a/.git\n2\t\n", ["/w/a", "/w/b"])
-    assert out == {"measured": False, "home": None, "common_dirs": {},
+    out = sm.parse_repo_probe("1\t0\t/w/a/.git\n2\t128\t\n", ["/w/a", "/w/b"])
+    assert out == {"measured": False, "home": None, "answers": {},
                    "seen": None, "unparseable": None}
     assert sm.parse_repo_probe("", ["/w/a"])["measured"] is False
     assert sm.parse_repo_probe(None, ["/w/a"])["measured"] is False
@@ -12231,35 +12325,38 @@ def test_a_sentinel_carrying_NO_home_is_refused_as_unmeasured():
     would be between publishing a repo called `zach` for every unparented shell
     and carrying a guard that can never fire. Declining the host is the honest
     third option."""
-    assert sm.parse_repo_probe(sm.REPO_PROBE_SENTINEL + "\n1\t/w/a/.git\n",
+    assert sm.parse_repo_probe(sm.REPO_PROBE_SENTINEL + "\n1\t0\t/w/a/.git\n",
                                ["/w/a"])["measured"] is False
-    assert sm.parse_repo_probe(sm.REPO_PROBE_SENTINEL + "   \n1\t/w/a/.git\n",
+    assert sm.parse_repo_probe(sm.REPO_PROBE_SENTINEL + "   \n1\t0\t/w/a/.git\n",
                                ["/w/a"])["measured"] is False
     # ...while the SAME bytes with a home ARE measured, so this is a claim about
     # the home and not about the rest of the line.
-    assert sm.parse_repo_probe(sm.REPO_PROBE_SENTINEL + " /h\n1\t/w/a/.git\n",
+    assert sm.parse_repo_probe(sm.REPO_PROBE_SENTINEL + " /h\n1\t0\t/w/a/.git\n",
                                ["/w/a"])["measured"] is True
 
 
 @pytest.mark.parametrize("bad,why", [
     ("no-tab-at-all", "a line with no tab separator"),
-    ("x\t/w/a/.git", "a non-integer index"),
-    ("\t/w/a/.git", "an empty index"),
-    ("99\t/w/a/.git", "an index past the end of the input list"),
-    ("0\t/w/a/.git", "a 0 index — the protocol is 1-based"),
-    ("-1\t/w/a/.git", "a negative index"),
+    ("1\t/w/a/.git", "a V1 two-field record — the rc field is not optional"),
+    ("x\t0\t/w/a/.git", "a non-integer index"),
+    ("\t0\t/w/a/.git", "an empty index"),
+    ("1\tx\t/w/a/.git", "a non-integer rc"),
+    ("1\t\t/w/a/.git", "an empty rc"),
+    ("99\t0\t/w/a/.git", "an index past the end of the input list"),
+    ("0\t0\t/w/a/.git", "a 0 index — the protocol is 1-based"),
+    ("-1\t0\t/w/a/.git", "a negative index"),
 ])
 def test_parse_repo_probe_counts_a_malformed_line_and_keeps_the_rest(bad, why):
     """A partial or corrupted reply must cost exactly the lines it corrupts. The
     1-based index is what buys that: nothing silently re-aligns."""
     paths = ["/w/a", "/w/b"]
-    raw = "%s /home/op\n%s\n2\t/w/b/.git\n" % (sm.REPO_PROBE_SENTINEL, bad)
+    raw = "%s /home/op\n%s\n2\t0\t/w/b/.git\n" % (sm.REPO_PROBE_SENTINEL, bad)
     out = sm.parse_repo_probe(raw, paths)
     assert out["measured"] is True, why
     assert out["unparseable"] == 1, why
     assert out["seen"] == 2, why
     # the GOOD line still landed, on the RIGHT path
-    assert out["common_dirs"] == {"/w/b": "/w/b/.git"}, why
+    assert out["answers"] == {"/w/b": {"rc": 0, "common": "/w/b/.git"}}, why
 
 
 def test_a_path_holding_a_TAB_or_a_NEWLINE_still_round_trips():
@@ -12270,9 +12367,9 @@ def test_a_path_holding_a_TAB_or_a_NEWLINE_still_round_trips():
     paths = ["/w/tab\there", "/w/new\nline", "/w/plain"]
     out = sm.parse_repo_probe(
         repo_out("/w/x/.git", "/w/y/.git", "/w/z/.git", home="/home/op"), paths)
-    assert out["common_dirs"] == {"/w/tab\there": "/w/x/.git",
-                                  "/w/new\nline": "/w/y/.git",
-                                  "/w/plain": "/w/z/.git"}
+    assert out["answers"] == {"/w/tab\there": {"rc": 0, "common": "/w/x/.git"},
+                              "/w/new\nline": {"rc": 0, "common": "/w/y/.git"},
+                              "/w/plain": {"rc": 0, "common": "/w/z/.git"}}
 
 
 def test_build_repo_index_gives_a_SHORT_reply_the_missing_status():
@@ -12401,7 +12498,8 @@ def test_the_real_probe_refuses_to_name_the_OWNING_HOSTS_HOME(tmp_path):
     assert proc.returncode == 0, proc.stderr
     # the probe DID resolve it, so the refusal below is the resolver's rather
     # than a failure to measure
-    assert parsed["common_dirs"][home] == os.path.join(home, ".git")
+    assert parsed["answers"][home] == {"rc": 0,
+                                       "common": os.path.join(home, ".git")}
     assert sm.build_repo_index(parsed, paths)[home] == {"repo": None,
                                                         "status": "home"}
     # ...and the mirror image: the SAME directory against a DIFFERENT home is an
@@ -12777,3 +12875,527 @@ def test_fold_windows_takes_the_index_PER_HOST_not_globally():
     with open(_SCRIPT, encoding="utf-8") as fh:
         src = fh.read()
     assert "repo_index=repo_index.get(host)" in src
+
+
+# --------------------------------------------------------------------------- #
+# §R.8 — 🔴 THE SEAMS. Every defect below was found by an adversarial audit of
+#        §R.1-§R.7, and every one of them lived BETWEEN two components that were
+#        each individually correct and individually tested. A guard here pins a
+#        RELATIONSHIP; a guard on either component alone is what let these ship.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("rc,status,why", [
+    (0, "ok", "git answered — the only rc that can carry a name"),
+    (sm.REPO_PROBE_RC_NOT_A_REPO, "not_a_repo",
+     "git's own 'not inside a work tree'. The ONLY measured absence."),
+    (124, "unmeasured", "the per-path `timeout` fired — nobody looked"),
+    (127, "unmeasured", "`git` is not installed on the owning host"),
+    (129, "unmeasured", "this git does not understand `--path-format`"),
+    (sm.REPO_PROBE_RC_NEWLINE, "unmeasured",
+     "the script refused a common dir holding a newline"),
+])
+def test_only_gits_OWN_not_a_repo_rc_reads_as_a_measured_absence(rc, status, why):
+    """🔴 THE SUBSTITUTION §R.6 REFUSES AT HOST GRANULARITY, ONE LEVEL DOWN.
+
+    `d=$(git …) || d=""` collapsed EVERY failure into one empty string, and an
+    empty string was published as the MEASURED status `not_a_repo` — "the owning
+    host looked and this path is not in a work tree" about a look that never
+    happened. Measured twice through the real shipped script (git replaced by a
+    30s sleep; git removed from PATH): a REAL repo reported
+    `{'repo': None, 'status': 'not_a_repo'}`.
+
+    The rc travels in the record so this is a claim about what GIT said, not
+    about what the string looked like afterwards.
+    """
+    paths = ["/w/only"]
+    parsed = sm.parse_repo_probe(
+        repo_out((rc, "/w/only/.git" if rc == 0 else ""), home="/home/op"),
+        paths)
+    assert parsed["measured"] is True, why
+    assert sm.build_repo_index(parsed, paths)["/w/only"]["status"] == status, why
+
+
+def test_a_path_that_could_not_be_measured_is_unmeasured_while_the_HOST_is_OK():
+    """🔴 THE RELATIONSHIP, NOT EITHER COMPONENT. The host's provenance block
+    and the row's status are two writers describing one probe, and the defect
+    was that they disagreed silently: the host said `repos_measured: true,
+    repos_status: ok` (true — the probe DID answer) while a row whose `git` had
+    timed out said `not_a_repo` (false — nothing measured it). Both halves are
+    asserted in ONE test, against ONE run, because separately each was already
+    green.
+
+    The `ok` row in the same host is the positive control: a probe that had
+    simply failed would make every row `unmeasured` and satisfy half of this.
+    """
+    rep = base_gather(runner=make_runner(
+        # workbench paths, sorted: `/home/zach/tmp`, `/home/zach/workspace/repo-alpha`
+        local_repo=repo_out((124, ""), "/home/zach/workspace/repo-alpha/.git")))
+    wb = rep["hosts"]["workbench"]
+    # the HOST is honestly measured — the probe answered
+    assert wb["repos_measured"] is True
+    assert wb["repos_status"] == "ok"
+    by_path = {r["path"]: r for r in wb["windows"]}
+    # ...and the PATH is honestly unmeasured, rather than borrowing the host's ok
+    assert by_path["/home/zach/tmp"]["repo"] is None
+    assert by_path["/home/zach/tmp"]["repo_status"] == "unmeasured", (
+        "a per-path failure to measure was published as a measured absence")
+    # THE POSITIVE CONTROL, same host, same probe, same run
+    assert by_path["/home/zach/workspace/repo-alpha"]["repo"] == "repo-alpha"
+    assert by_path["/home/zach/workspace/repo-alpha"]["repo_status"] == "ok"
+
+
+def test_a_per_path_unmeasured_can_never_inflate_repos_resolved():
+    """`repos_resolved` counts `ok` and nothing else. A per-path `unmeasured`
+    that landed in it would say a look succeeded because a look was attempted.
+
+    Three paths, three DIFFERENT dispositions, so no single wrong rule (count
+    the records, count the non-empty commons, count everything) produces 1.
+    """
+    panes = "\n".join([
+        "%1|9001|s|1|w1|/w/resolved|zsh|t1",
+        "%2|9002|s|2|w2|/w/timedout|zsh|t2",
+        "%3|9003|s|3|w3|/w/notarepo|zsh|t3",
+    ])
+    wins = window_rows(("@1", "1", "s"), ("@2", "2", "s"), ("@3", "3", "s"))
+    rep = base_gather(runner=make_runner(
+        local_panes=panes, local_windows=wins,
+        # sorted unique: /w/notarepo, /w/resolved, /w/timedout
+        local_repo=repo_out("", "/w/resolved/.git", (124, ""))))
+    wb = rep["hosts"]["workbench"]
+    assert wb["repos_paths"] == 3
+    assert wb["repos_resolved"] == 1, "only the `ok` path resolved"
+    got = {r["path"]: r["repo_status"] for r in wb["windows"]}
+    assert got == {"/w/resolved": "ok", "/w/timedout": "unmeasured",
+                   "/w/notarepo": "not_a_repo"}
+
+
+def test_the_REAL_probe_reports_a_per_path_failure_rather_than_not_a_repo(
+        tmp_path):
+    """🔴 THE SAME CLAIM AGAINST THE SHIPPING INSTRUMENT, not the fixture. A
+    REAL repo, resolved by the REAL script under a real `sh` — once with `git`
+    on PATH and once without. Same directory, same script, two different
+    answers, and the failing one must not be the measured word.
+    """
+    home = str(tmp_path / "home")
+    os.makedirs(home)
+    repo = _r_mkrepo(tmp_path / "ws" / "alpha")
+    # POSITIVE CONTROL FIRST: with git present this path IS a repo, so the
+    # `unmeasured` below cannot be "that directory was never a repo anyway".
+    _, parsed = _r_probe([repo], home)
+    assert sm.build_repo_index(parsed, [repo])[repo] == {"repo": "alpha",
+                                                         "status": "ok"}
+    nogit = str(tmp_path / "nogit-bin")
+    os.makedirs(nogit)
+    for tool in ("sh", "timeout"):
+        src = _r_which(tool)
+        assert src, tool
+        os.symlink(src, os.path.join(nogit, tool))
+    proc = subprocess.run(list(sm.repo_probe_argv([repo])),
+                          capture_output=True, text=True, timeout=60,
+                          env={"PATH": nogit, "HOME": home})
+    assert proc.returncode == 0, proc.stderr
+    parsed = sm.parse_repo_probe(proc.stdout, [repo])
+    assert parsed["measured"] is True, proc.stdout
+    assert sm.build_repo_index(parsed, [repo])[repo] == {
+        "repo": None, "status": "unmeasured"}, (
+            "`git` absent from the owning host published a MEASURED "
+            "`not_a_repo` about a real repo.\nprobe stdout:\n" + proc.stdout)
+
+
+def test_a_common_dir_holding_a_NEWLINE_cannot_forge_ANOTHER_paths_answer(
+        tmp_path):
+    """🔴 THE CLAIM THAT WAS FALSE. Two docstrings said a newline "costs that one
+    path its answer and leaves every other index correct". Demonstrated false
+    end to end with real git, real `sh` and the real `REPO_PROBE_SCRIPT`: a
+    directory named `zzz-attacker\\n1\\t0\\t<other>` makes the probe emit a SECOND
+    record claiming index 1, and index 1 — a genuine repo — resolved to the
+    attacker's string with `repos_unparseable` reporting 0.
+
+    Not a security hole (the paths are the operator's own panes on his own
+    hosts) and precisely for that reason worth closing: a CONFIDENT WRONG repo
+    is worse than the honest per-worktree split this feature replaces.
+
+    The victim sorts FIRST so its genuine record is emitted before the forged
+    one — the ordering under which "first answer wins" alone would still have
+    saved it. The forged index is checked by NAME, not merely by "is not None".
+    """
+    home = str(tmp_path / "home")
+    os.makedirs(home)
+    ws = tmp_path / "ws"
+    wrong = _r_mkrepo(ws / "WRONG-REPO")
+    victim = _r_mkrepo(ws / "aaa-victim")
+    attacker = _r_mkrepo(ws / ("zzz-attacker\n1\t0\t%s" % wrong))
+    paths = [victim, attacker]
+    proc, parsed = _r_probe(paths, home)
+    assert proc.returncode == 0, proc.stderr
+    assert parsed["measured"] is True, proc.stdout
+    idx = sm.build_repo_index(parsed, paths)
+    assert idx[victim] == {"repo": "aaa-victim", "status": "ok"}, (
+        "a directory NAME forged another path's answer.\nprobe stdout:\n"
+        + proc.stdout)
+    # and the attacker's OWN path pays for it, honestly — not `not_a_repo`,
+    # because its common dir was measured and simply cannot be transmitted
+    assert idx[attacker] == {"repo": None, "status": "unmeasured"}
+
+
+def test_a_DUPLICATE_index_is_unparseable_and_the_FIRST_answer_stands():
+    """The parser-side half of the defence above, at the record level. A plain
+    assignment let the LAST record for an index win, which is how a forged
+    record placed after a genuine one replaced a real repo — and `unparseable`
+    reported 0, so nothing in the payload said anything was wrong."""
+    paths = ["/w/a", "/w/b"]
+    raw = "%s /home/op\n1\t0\t/w/real/.git\n1\t0\t/w/forged/.git\n2\t0\t/w/b/.git\n" \
+        % sm.REPO_PROBE_SENTINEL
+    out = sm.parse_repo_probe(raw, paths)
+    assert out["answers"]["/w/a"] == {"rc": 0, "common": "/w/real/.git"}
+    assert out["unparseable"] == 1, "a duplicate index must be COUNTED, not silent"
+    assert out["seen"] == 3
+    # the untouched index is unaffected — this costs exactly the forged record
+    assert out["answers"]["/w/b"] == {"rc": 0, "common": "/w/b/.git"}
+
+
+@pytest.mark.parametrize("sep,name", [
+    ("\r", "carriage return"), ("\x0b", "vertical tab"), ("\x0c", "form feed"),
+    ("\x1c", "file separator"), ("\x85", "next line"),
+    ("\u2028", "line separator"), ("\u2029", "paragraph separator"),
+])
+def test_the_parser_splits_on_NEWLINE_ONLY_never_str_splitlines(sep, name):
+    """🔴 A READER THAT SPLITS ON MORE CHARACTERS THAN THE WRITER JOINED WITH IS
+    A FORGING SURFACE BY ITSELF. The script's record separator is `\\n`;
+    `str.splitlines()` also breaks on seven other characters, any of which can
+    appear in a directory name. With `splitlines()` the string below becomes TWO
+    records — and the forged index is a LATER one, which is the case the
+    duplicate-index guard cannot cover: a forged record for an index whose
+    genuine record has not arrived yet lands FIRST and wins, and the real one is
+    then rejected as the duplicate. Under `splitlines()` `/w/c` resolves to
+    `forged`.
+
+    Splitting on `"\\n"` alone is only HALF the answer, and measuring it is what
+    showed that: the injection then stays inside index 1's own field, where
+    `repo_from_common_dir` read a repo called `forged` out of it. So a record
+    carrying any of these characters is refused outright — it costs THAT path
+    its answer (`missing`) and cannot cost any other path a wrong one.
+
+    The script's own newline guard cannot help here: these are not newlines, so
+    it passes them through as data, exactly as it should.
+    """
+    paths = ["/w/a", "/w/b", "/w/c"]
+    raw = ("%s /home/op\n1\t0\t/w/a/.git%s3\t0\t/w/forged/.git\n"
+           "2\t0\t/w/b/.git\n3\t0\t/w/c/.git\n"
+           % (sm.REPO_PROBE_SENTINEL, sep))
+    out = sm.parse_repo_probe(raw, paths)
+    idx = sm.build_repo_index(out, paths)
+    assert idx["/w/c"] == {"repo": "c", "status": "ok"}, (
+        "%s forged another path's answer: %r" % (name, out["answers"]))
+    # POSITIVE CONTROL: the untouched record still lands, so this is a claim
+    # about the separator and not about the parser giving up on the reply.
+    assert out["answers"]["/w/b"] == {"rc": 0, "common": "/w/b/.git"}
+    # ...and index 1 pays for its own corrupted record. Nobody else does, and
+    # it does not get a CONFIDENT name out of it either.
+    assert idx["/w/a"] == {"repo": None, "status": "missing"}
+    assert out["unparseable"] == 1
+
+
+def test_the_refused_break_characters_are_DERIVED_from_str_splitlines():
+    """🔴 THE LEDGER IS PINNED TWO-WAY AGAINST THE SPLITTER IT DESCRIBES. A
+    hand-typed list of "characters `splitlines()` breaks on" is a belief about
+    the runtime, and the guard above would go quietly narrower than its own
+    docstring the day that belief was wrong. Derived here from `str.splitlines`
+    itself, so the constant cannot drift from the thing it is protecting
+    against — in EITHER direction."""
+    derived = {chr(i) for i in range(0x3000)
+               if len(("a" + chr(i) + "b").splitlines()) > 1 and chr(i) != "\n"}
+    assert set(sm.REPO_PROBE_RECORD_BREAKERS) == derived, (
+        "REPO_PROBE_RECORD_BREAKERS disagrees with str.splitlines(): "
+        "missing=%r extra=%r"
+        % (sorted(derived - set(sm.REPO_PROBE_RECORD_BREAKERS)),
+           sorted(set(sm.REPO_PROBE_RECORD_BREAKERS) - derived)))
+    # ...and `\n` is deliberately NOT in it: that IS the record separator, and
+    # the script refuses it at the source with its own rc.
+    assert "\n" not in sm.REPO_PROBE_RECORD_BREAKERS
+
+
+def test_a_pane_path_with_a_TRAILING_SPACE_still_finds_its_OWN_repo():
+    """🔴 THE SEAM COMMIT 5d722f2f CLAIMED WAS CLOSED. `gather` builds the probe
+    input as `path.strip()`; `parse_panes` stores tmux's field UNSTRIPPED; the
+    row looked itself up with the raw spelling. Each side was individually
+    correct. Measured through real `gather()`: a pane at
+    `'/home/zach/workspace/oddname '` had its repo resolved and COUNTED in
+    `repos_resolved`, and then published `repo_status: missing` — the branch
+    `row_repo`'s own docstring asserts is unreachable.
+
+    🔴 PINNED AS A RELATIONSHIP: every path the host counted as resolved is a
+    path some ROW carries. A component test on either half stays green while
+    the pair is broken, which is why neither caught it.
+    """
+    panes = "\n".join([
+        "%1|9101|s|1|w1|/w/oddname |zsh|t1",
+        "%2|9102|s|2|w2|/w/plain|zsh|t2",
+    ])
+    wins = window_rows(("@1", "1", "s"), ("@2", "2", "s"))
+    rep = base_gather(runner=make_runner(
+        local_panes=panes, local_windows=wins,
+        # sorted unique STRIPPED paths: /w/oddname, /w/plain
+        local_repo=repo_out("/w/oddname/.git", "/w/plain/.git")))
+    wb = rep["hosts"]["workbench"]
+    by_path = {r["path"]: r for r in wb["windows"]}
+    assert by_path["/w/oddname "]["repo"] == "oddname", (
+        "the row could not find the answer the probe resolved for it")
+    assert by_path["/w/oddname "]["repo_status"] == "ok"
+    # 🔴 THE RELATIONSHIP: the host's count and the rows agree.
+    carried = sum(1 for r in wb["windows"] if r["repo_status"] == "ok")
+    assert wb["repos_resolved"] == carried == 2, (
+        "`repos_resolved` counted an answer no row uses")
+    assert not any(r["repo_status"] == "missing" for r in wb["windows"])
+
+
+# --------------------------------------------------------------------------- #
+# §R.9 — 🔴 THE RUN HAS A BUDGET, AND IT IS THE SUM OF THE CALLS. The pusher
+#        wraps this collector in `timeout 90`; rc 124 there is `exit 3` and NO
+#        snapshot for EITHER host, not a degraded field.
+# --------------------------------------------------------------------------- #
+def _pusher_collect_cap():
+    """The cap READ OUT OF THE PUSHER, never restated here.
+
+    🔴 A test that hardcoded 90 would keep passing after someone tightened the
+    pusher, which is the direction that breaks the fleet.
+    """
+    path = os.path.join(os.path.dirname(_SCRIPT), "tmux-snapshot-push.sh")
+    with open(path, encoding="utf-8") as fh:
+        src = fh.read()
+    m = re.search(r'COLLECT_TIMEOUT="\$\{TMUX_PUSH_COLLECT_TIMEOUT:-(\d+)\}"',
+                  src)
+    assert m, "could not read the collector cap out of tmux-snapshot-push.sh"
+    return float(m.group(1))
+
+
+def _ch_client_timeout():
+    """The ClickHouse read's own budget, READ from the client library. It is
+    spent AFTER the host loop and inside the same `timeout 90`, and an audit
+    that omitted it computed 22s of headroom where there were 7."""
+    sys.path.insert(0, os.path.join(os.path.dirname(_SCRIPT), "validation"))
+    import chquery
+    return float(chquery.CHConn.timeout)
+
+
+def test_the_pusher_cap_and_the_ch_reserve_are_READ_not_ASSERTED():
+    """INSTRUMENT CHECK for the two helpers above, before any verdict is read
+    off them. Both parse a file this test file does not own; a regex that stopped
+    matching would make the guard below vacuous rather than red."""
+    assert _pusher_collect_cap() > 0
+    assert _ch_client_timeout() > 0
+    # ...and the constants the collector reasons with agree with those sources.
+    assert sm.COLLECT_CAP == _pusher_collect_cap()
+    assert sm.COLLECT_CH_RESERVE == _ch_client_timeout()
+    assert sm.COLLECT_BUDGET == (sm.COLLECT_CAP - sm.COLLECT_CH_RESERVE
+                                 - sm.COLLECT_MARGIN)
+
+
+def _spend_the_whole_budget(**kw):
+    """Run a real two-host `gather` under a FAKE monotonic clock in which every
+    call takes exactly its own timeout. Returns `(seconds_spent, report)`.
+
+    🔴 THIS IS THE WORST CASE MEASURED, NOT MODELLED. `subprocess`'s timeout
+    kills a call, it does not shorten one, so a command finishing at 11.99s
+    exits 0 — a whole run of those is a legal outcome, not a pathology.
+    """
+    spent = [0.0]
+    inner = make_runner()
+
+    def burner(argv, timeout):
+        spent[0] += timeout
+        return inner(argv, timeout)
+
+    rep = base_gather(runner=burner, clock=lambda: spent[0],
+                      use_ledger=True, **kw)
+    return spent[0], rep
+
+
+def test_the_WORST_CASE_collection_fits_the_pushers_own_cap():
+    """🔴 DERIVED FROM A REAL `gather`, NOT FROM A COUNT SOMEONE TYPED. The
+    guard this replaces asserted `SSH_TIMEOUT * 2 <= 30` and said in its own
+    docstring that "a 2-host scan issues 2 SSH calls". That was wrong when it
+    was written (four) and wronger after the repo probe made it five, and it
+    stayed green through both — a bound on a call count nobody was counting.
+
+    🔴 AND THE NEGATIVE CONTROL IS IN THE SAME TEST: the same run with
+    `collect_budget=None` is over the cap. Without that line this could pass
+    against a collector whose calls simply happen to be cheap, and would say
+    nothing about whether the deadline does any work.
+    """
+    cap, ch = _pusher_collect_cap(), _ch_client_timeout()
+
+    unbounded, _ = _spend_the_whole_budget(collect_budget=None)
+    assert unbounded + ch > cap, (
+        "NEGATIVE CONTROL FAILED: the calls this collector makes no longer sum "
+        "past the pusher's cap (%.1fs tmux + %.1fs ClickHouse vs %.1fs), so "
+        "this test is not measuring the deadline any more. Either the deadline "
+        "is now unnecessary — delete it and this guard together — or the fake "
+        "clock stopped reaching the calls." % (unbounded, ch, cap))
+
+    worst, rep = _spend_the_whole_budget()
+    assert worst + ch <= cap, (
+        "worst-case collection is %.1fs of tmux + %.1fs of ClickHouse against "
+        "the pusher's %.1fs cap. `timeout 90` there is exit 3 and NO snapshot "
+        "for EITHER host — not a degraded field." % (worst, ch, cap))
+    # it got far enough to NEED the deadline, so it is not green by doing nothing
+    assert worst > sm.SSH_TIMEOUT, worst
+    assert rep["hosts"]["workbench"]["repos_measured"] is True, (
+        "POSITIVE CONTROL: the run must still have measured something")
+
+
+def test_the_STARVED_host_reports_unmeasured_rather_than_an_empty_measurement():
+    """The other half of the deadline: what the payload says about the reads it
+    did not make. A budget that silently published `repos_resolved: 0` for a
+    host it never asked would be the exact substitution §R.6 exists to refuse,
+    arriving through the timeout instead of through the probe."""
+    worst, rep = _spend_the_whole_budget()
+    lt = rep["hosts"]["laptop"]                 # scanned second, so it starves
+    assert lt["repos_measured"] is False
+    assert lt["repos_resolved"] is None and lt["repos_unparseable"] is None
+    assert "budget" in (lt["repos_error"] or ""), lt["repos_error"]
+    for row in lt["windows"]:
+        assert (row["repo"], row["repo_status"]) == (None, "unmeasured")
+    # POSITIVE CONTROL: the host scanned FIRST spent the budget doing real work
+    assert rep["hosts"]["workbench"]["repos_measured"] is True
+    assert rep["hosts"]["workbench"]["repos_resolved"] == 1
+
+
+def test_a_read_with_NO_budget_left_is_NOT_ATTEMPTED_and_says_which():
+    """The `run_tmux` half, directly. A starved call must not be started with a
+    zero timeout — that would turn "we ran out of time" into a storm of
+    look-alike spawn failures — and its error must name the budget so a reader
+    can tell it from a host that was actually down."""
+    calls = []
+
+    def runner(argv, timeout):
+        calls.append((list(argv), timeout))
+        return 0, "should never be used", ""
+
+    res = sm.run_tmux(["tmux", "ls"], "laptop", "workbench", runner=runner,
+                      deadline=100.0, clock=lambda: 100.0)
+    assert calls == [], "a call with no budget left was still started"
+    assert res["reachable"] is False
+    assert "budget" in res["error"]
+    assert res["stdout"] == ""
+    # POSITIVE CONTROL: the same call WITH budget runs, and is CLAMPED to what
+    # is left rather than given its nominal timeout.
+    res = sm.run_tmux(["tmux", "ls"], "laptop", "workbench", runner=runner,
+                      deadline=103.0, clock=lambda: 100.0)
+    assert res["reachable"] is True
+    assert len(calls) == 1 and calls[0][1] == 3.0, calls
+    # ...and with plenty of budget it keeps its OWN timeout, so the clamp is a
+    # ceiling and not a replacement.
+    sm.run_tmux(["tmux", "ls"], "laptop", "workbench", runner=runner,
+                deadline=1000.0, clock=lambda: 100.0)
+    assert calls[-1][1] == sm.SSH_TIMEOUT, calls
+
+
+# --------------------------------------------------------------------------- #
+# §R.10 — the constants a mutation sweep walked straight past
+# --------------------------------------------------------------------------- #
+def _r_which(tool):
+    return subprocess.run(["sh", "-c", "command -v %s || true" % tool],
+                          capture_output=True, text=True).stdout.strip() or None
+
+
+def test_the_probe_script_BOUNDS_EACH_git_call(tmp_path):
+    """🔴 TWO SWEEP SURVIVORS IN ONE BEHAVIOURAL GUARD. `T="timeout 3"` ->
+    `T="timeout 900"` SURVIVED all 743 tests, and so did deleting the
+    `command -v timeout` guard so `T=""` always. Both are the same hole: nothing
+    ever watched the bound HOLD.
+
+    A `git` that never returns, on PATH, through the real script. Either mutant
+    makes this run for the fake git's full sleep instead of the bound. Asserted
+    on WALL TIME and on the reported rc, so a script that printed the right
+    number without waiting could not pass either.
+    """
+    home = str(tmp_path / "home")
+    os.makedirs(home)
+    binp = str(tmp_path / "slowbin")
+    os.makedirs(binp)
+    sh, sleep = _r_which("sh"), _r_which("sleep")
+    assert sh and sleep
+    for tool in ("sh", "timeout"):
+        src = _r_which(tool)
+        assert src, tool
+        os.symlink(src, os.path.join(binp, tool))
+    fake_git = os.path.join(binp, "git")
+    with open(fake_git, "w", encoding="utf-8") as fh:
+        fh.write("#!%s\nexec %s 60\n" % (sh, sleep))
+    os.chmod(fake_git, 0o755)
+
+    bound = sm.REPO_PROBE_GIT_TIMEOUT
+    t0 = time.monotonic()
+    proc = subprocess.run(list(sm.repo_probe_argv(["/w/one"])),
+                          capture_output=True, text=True, timeout=45,
+                          env={"PATH": binp, "HOME": home})
+    wall = time.monotonic() - t0
+    assert proc.returncode == 0, proc.stderr
+    assert wall < bound + 12, (
+        "the per-path `timeout %s` did not bound a hung git: %.1fs elapsed"
+        % (bound, wall))
+    parsed = sm.parse_repo_probe(proc.stdout, ["/w/one"])
+    assert parsed["answers"]["/w/one"]["rc"] == 124, (
+        "a killed git must report `timeout`'s own 124, so the path lands in "
+        "`unmeasured` rather than in the measured `not_a_repo`. stdout: %r"
+        % proc.stdout)
+    assert sm.build_repo_index(parsed, ["/w/one"])["/w/one"]["status"] \
+        == "unmeasured"
+
+
+def test_the_per_path_bound_is_INSIDE_the_calls_own_budget():
+    """The arithmetic the number above has to satisfy, pinned as a relationship.
+    A per-path bound at or above the whole call's budget means the FIRST hung
+    path eats the entire probe and the host loses every other answer — which is
+    exactly what `timeout 900` would have done, silently."""
+    assert sm.REPO_PROBE_GIT_TIMEOUT < sm.REPO_PROBE_TIMEOUT
+    assert ("timeout %d" % sm.REPO_PROBE_GIT_TIMEOUT) in sm.REPO_PROBE_SCRIPT
+
+
+def test_the_probe_still_ANSWERS_on_a_host_with_no_timeout_binary(tmp_path):
+    """The other side of the `command -v` fallback: a host without coreutils
+    `timeout` must still resolve its repos rather than lose the whole field.
+    Without this, "the guard is unnecessary" and "the guard is broken" look the
+    same."""
+    home = str(tmp_path / "home")
+    os.makedirs(home)
+    repo = _r_mkrepo(tmp_path / "ws" / "alpha")
+    binp = str(tmp_path / "notimeout")
+    os.makedirs(binp)
+    for tool in ("sh", "git"):
+        src = _r_which(tool)
+        assert src, tool
+        os.symlink(src, os.path.join(binp, tool))
+    assert not os.path.exists(os.path.join(binp, "timeout"))
+    proc = subprocess.run(list(sm.repo_probe_argv([repo])),
+                          capture_output=True, text=True, timeout=60,
+                          env={"PATH": binp, "HOME": home})
+    assert proc.returncode == 0, proc.stderr
+    parsed = sm.parse_repo_probe(proc.stdout, [repo])
+    assert sm.build_repo_index(parsed, [repo])[repo] == {"repo": "alpha",
+                                                         "status": "ok"}, (
+        "a host without `timeout` lost its repo field entirely. stdout: %r"
+        % proc.stdout)
+
+
+def test_repos_unparseable_is_a_REAL_count_not_the_constant_zero():
+    """🔴 A SWEEP SURVIVOR, AND THE REASON IT SURVIVED. Hardcoding
+    `repos_unparseable` to `0` passed all 743 tests, because every fixture that
+    reached it could only ever produce 0 — one test asserted `is None` and
+    another `== 0`. A fixture whose value can only equal the constant cannot see
+    a mutant that hardcodes the literal.
+
+    So: feed a reply the constant CANNOT equal, and watch the number move. TWO
+    corrupted records, not one, so a mutant hardcoding `1` dies too.
+    """
+    paths_out = "%s /home/zach\ngarbage-with-no-tabs\n1\t%d\t\n" \
+        "77\t0\t/w/out-of-range/.git\n2\t0\t/home/zach/workspace/repo-alpha/.git\n" \
+        % (sm.REPO_PROBE_SENTINEL, sm.REPO_PROBE_RC_NOT_A_REPO)
+    wb = base_gather(runner=make_runner(local_repo=paths_out))["hosts"]["workbench"]
+    assert wb["repos_measured"] is True
+    assert wb["repos_unparseable"] == 2, (
+        "`repos_unparseable` is not counting anything — it survived being "
+        "replaced by the literal 0")
+    # the well-formed records still landed, so this is a claim about the COUNT
+    # rather than about the parser giving up on the whole reply
+    assert wb["repos_paths"] == 2 and wb["repos_resolved"] == 1

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -13925,28 +13925,40 @@ def test_the_contract_docs_budget_numbers_are_PINNED_to_the_constants():
         % (m.group(1), sm.COLLECT_CAP))
 
 
-def test_every_TEST_NAME_the_contract_cites_actually_EXISTS():
-    """🔴 A DOC THAT NAMES A GUARD IS MAKING A CLAIM ABOUT COVERAGE, and a name
-    that resolves to nothing is the worst kind: it reads as "this is pinned" and
-    stops the next person looking. This guard was written because the round-3
-    fix introduced exactly that — the contract cited
-    `test_the_per_host_call_ORDER_puts_the_optional_probe_LAST`, a name that had
-    been changed during the same change and never existed in the suite.
+def test_every_TEST_NAME_the_docs_and_the_SCRIPT_cite_actually_EXISTS():
+    """🔴 A DOC OR COMMENT THAT NAMES A GUARD IS MAKING A CLAIM ABOUT COVERAGE,
+    and a name resolving to nothing is the worst kind: it reads as "this is
+    pinned" and stops the next person looking.
 
-    Resolved against the module's own symbol table, so a rename that misses the
-    doc fails here rather than rotting silently.
+    Written because the round-3 fix introduced exactly that TWICE in one change
+    — the contract cited `test_the_per_host_call_ORDER_puts_the_optional_probe_
+    LAST` (renamed mid-change, never in the suite) and the script's own
+    second-pass comment cited the budget guard with the wrong casing. 🔴 BOTH
+    SURFACES ARE CHECKED, because the first version of this guard read the doc
+    only and was blind to the comment two files away that had the same defect.
+
+    Resolved against the module's own symbol table, so a rename that misses
+    either surface fails here rather than rotting silently.
     """
-    cited = set(re.findall(r"`(test_[A-Za-z0-9_]+)`", _contract_text()))
-    assert cited, "the contract cites no test names at all any more"
+    with open(_SCRIPT, encoding="utf-8") as fh:
+        script = fh.read()
     here = set(globals())
-    missing = sorted(n for n in cited if n not in here)
-    assert not missing, (
-        "payload-contract.md cites test(s) that do not exist in "
-        "test_session_manager.py: %r" % missing)
-    # POSITIVE CONTROL on the extraction: it really pulled real names out, and
-    # it can also SEE a name that is absent.
-    assert "test_the_contract_docs_budget_numbers_are_PINNED_to_the_constants" \
-        in cited, sorted(cited)
+    surfaces = {"payload-contract.md": _contract_text(),
+                "scripts/session-manager": script}
+    seen_total = 0
+    for label, text in surfaces.items():
+        cited = set(re.findall(r"`(test_[A-Za-z0-9_]+)`", text))
+        assert cited, "%s cites no test names at all any more" % label
+        seen_total += len(cited)
+        missing = sorted(n for n in cited if n not in here)
+        assert not missing, (
+            "%s cites test(s) that do not exist in test_session_manager.py: %r"
+            % (label, missing))
+    # POSITIVE CONTROL on the extraction: it really pulled real names out of
+    # BOTH surfaces, and it can also see a name that is absent.
+    assert seen_total >= 4, seen_total
+    assert "test_the_repo_probe_is_issued_AFTER_every_other_read_on_every_host" \
+        in re.findall(r"`(test_[A-Za-z0-9_]+)`", script)
     assert "test_definitely_not_defined_anywhere" not in here
 
 

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -13213,10 +13213,19 @@ def test_a_UNICODE_DIGIT_index_or_rc_is_unparseable_NEVER_a_ValueError():
     assert sm.parse_repo_probe(good, ["/w/a", "/w/b"])["unparseable"] == 0
 
 
-def test__is_ascii_int_is_exactly_the_set_int_accepts():
-    """The helper directly, in both directions — a validator and a converter
-    that disagree is the whole bug, so pin them against each other rather than
-    against a list someone typed."""
+def test__is_ascii_int_accepts_only_what_int_converts():
+    """The helper directly, in the ONE direction it actually pins: everything
+    the guard ACCEPTS, `int()` converts. A validator and a converter that
+    disagree *that* way is the whole bug, so sweep it rather than assert against
+    a list someone typed.
+
+    🔴 THE NAME USED TO SAY "is exactly the set `int()` accepts" AND THAT WAS
+    MEASURED FALSE — by this very body, whose negative list asserts
+    `_is_ascii_int("１") is False` while `int("１") == 12`. The converse
+    direction is deliberately NOT pinned; see
+    `test_the_ascii_int_guard_is_documented_as_a_SUBSET_not_an_equivalence`
+    for the subset that is intended and why widening it would be a bug.
+    """
     for s in ("0", "1", "128", " 7 ", "00"):
         assert sm._is_ascii_int(s) is True, s
         int(s.strip())                       # the converter agrees
@@ -13242,6 +13251,73 @@ def test__is_ascii_int_is_exactly_the_set_int_accepts():
     # POSITIVE CONTROL on the sweep: it really did examine a character `int()`
     # rejects, so an empty `disagreeing` is a measurement and not an empty loop.
     assert "²".isdigit() and not sm._is_ascii_int("²")
+
+
+def test_the_ascii_int_guard_is_documented_as_a_SUBSET_not_an_equivalence():
+    """🔴 A FALSE EQUIVALENCE CLAIM THAT LICENSED A WRONG REFACTOR.
+
+    `parse_repo_probe` used to state that `isascii() and isdigit()` "is exactly
+    the set `int()` accepts without a sign", and the helper's own test carried
+    that sentence in its NAME. Measured false in the other direction: `int()`
+    also converts non-ASCII decimal digits — `'١٢'`, `'１２'`, `'۱'`, `'٠'`,
+    `'᱀'` — every one of which this guard rejects.
+
+    The hazard is not the wording. A maintainer who believes the two sets are
+    equal replaces the guard with `try: int(x) / except ValueError` to remove
+    the duplication, and that widens the accepted index/rc alphabet to every
+    Unicode decimal digit **with nothing going red** — the existing sweep only
+    checks guard-accepts ⇒ int-accepts, which such a rewrite satisfies.
+
+    So this pins the measurement AND the claim: the subset is real, it is
+    stated as a subset on both surfaces a maintainer reads, and the false
+    equivalence is gone from both.
+
+    ⚠ RESIDUAL, STATED RATHER THAN HIDDEN: the second half is a guard on WORDS,
+    so a *reworded* equivalence claim would walk it. What it cannot walk is the
+    first half, which is a measurement, and the requirement that each surface
+    still say SUBSET.
+    """
+    import inspect
+
+    # --- 1. THE MEASUREMENT: `int()` really is strictly wider -----------------
+    wider = []
+    for i in range(0x3000):
+        c = chr(i)
+        try:
+            int(c)
+        except (ValueError, TypeError):
+            continue
+        if not sm._is_ascii_int(c):
+            wider.append(c)
+    assert len(wider) >= 100, (
+        "the sweep found only %d characters `int()` accepts and the guard "
+        "refuses — it is not measuring the subset" % len(wider))
+    for c in "١٢۱٠᱀":
+        assert c in wider, c
+    # ...and multi-character strings too, which is the shape the probe emits.
+    for s in ("١٢", "１２"):
+        assert int(s) == 12 and sm._is_ascii_int(s) is False, s
+
+    # --- 2. THE CLAIM, on both surfaces a maintainer reads --------------------
+    FALSE = "exactly the set `int()` accepts"
+    surfaces = {
+        "parse_repo_probe (the call site)":
+            inspect.getsource(sm.parse_repo_probe),
+        "_is_ascii_int (the helper)":
+            inspect.getsource(sm._is_ascii_int),
+    }
+    for where, src in surfaces.items():
+        assert FALSE not in src, (
+            "%s still claims the guard is `%s` — it is a strict subset"
+            % (where, FALSE))
+        assert "SUBSET" in src, (
+            "%s no longer states that the guard is a deliberate SUBSET of what "
+            "`int()` accepts; without it the next reader re-derives the wrong "
+            "refactor" % where)
+    # The TEST NAME is a surface too — it is what a reader greps for to find out
+    # what the helper guarantees, and it carried the false claim verbatim.
+    named = [n for n in globals() if "exactly_the_set_int_accepts" in n]
+    assert named == [], named
 
 
 def test_the_refused_break_characters_are_DERIVED_from_str_splitlines():
@@ -14039,6 +14115,81 @@ def test_the_CH_RESERVE_is_ENFORCED_on_the_client_that_SPENDS_it():
     # POSITIVE CONTROL on the fixture: it really does observe the query, so
     # `timeout_at_query` is a measurement and not a default that was never set.
     assert over.timeout_at_query is not None
+
+
+def _ch_factory_that_raises():
+    raise RuntimeError("no CLICKHOUSE_URL")
+
+
+def test_the_CH_TIMEOUT_CLAMP_is_PUBLISHED_and_never_SILENT():
+    """🔴 THE ONE PLACE IN THIS FILE THAT CHANGES A NUMBER INSTEAD OF PUBLISHING
+    ONE. `gather` called `_clamp_ch_timeout(client)` and DISCARDED the return,
+    so the whole event was invisible: an operator who set
+    `CLICKHOUSE_HTTP_TIMEOUT=60` in `~/.config/activity-collector/env` because
+    their read is slow got a 15 s read, an ordinary-looking timeout in the
+    `clickhouse` block, and an env file still saying 60 — i.e. they debug
+    ClickHouse, which is not where the 15 came from.
+
+    The whole discipline of this file is that a read which did not happen is
+    published as one. A read that happened under a budget the operator did not
+    choose is the same claim, and it now carries the same two fields in EVERY
+    branch — so a consumer never has to tell an absent key from a null one.
+    """
+    # CLAMPED: the configured value is named, and `timeout_secs` is what the
+    # read actually ran with. 60 and 3 are both distinct from the reserve, so
+    # neither assertion can be satisfied by the constant alone.
+    over = _FakeCHClient(60.0)
+    ch = base_gather(use_ch=True, ch_client_factory=lambda: over)["clickhouse"]
+    assert ch["timeout_secs"] == sm.COLLECT_CH_RESERVE, ch
+    assert ch["timeout_clamped_from"] == 60.0, ch
+    # POSITIVE CONTROL on the fixture: the clamp really was in force AT THE
+    # QUERY, so the published pair describes the read and not an object.
+    assert over.timeout_at_query == sm.COLLECT_CH_RESERVE
+
+    # NOT CLAMPED: stated positively as `None`, never as the configured value
+    # repeated back. A `>=` in place of the `>` is red here.
+    under = _FakeCHClient(3.0)
+    ch = base_gather(use_ch=True, ch_client_factory=lambda: under)["clickhouse"]
+    assert ch["timeout_secs"] == 3.0, ch
+    assert ch["timeout_clamped_from"] is None, ch
+
+    # NO TIMEOUT AT ALL (an injected double): UNMEASURED on both, which is not
+    # the same claim as "not clamped" — hence both null rather than a 0.
+    ch = base_gather(use_ch=True,
+                     ch_client_factory=lambda: FakeCH(rows=[CH_ROW]))["clickhouse"]
+    assert ch["status"] == "ok", ch
+    assert ch["timeout_secs"] is None and ch["timeout_clamped_from"] is None, ch
+
+    # ...and the KEYS are present in every other branch too — `skipped` (no
+    # client is ever built) and `unavailable` (the factory raised).
+    for label, kw in (("skipped", dict(use_ch=False)),
+                      ("unavailable",
+                       dict(use_ch=True,
+                            ch_client_factory=_ch_factory_that_raises))):
+        ch = base_gather(**kw)["clickhouse"]
+        assert ch["status"] == label, ch
+        assert "timeout_secs" in ch and "timeout_clamped_from" in ch, (label, ch)
+        assert ch["timeout_secs"] is None, (label, ch)
+        assert ch["timeout_clamped_from"] is None, (label, ch)
+
+
+def test__ch_timeout_is_the_ONE_reader_of_the_clients_timeout():
+    """The accessor the clamp and the published field share, so the two can
+    never disagree about what they saw. A `bool` is an `int` and is refused."""
+    import inspect
+
+    assert sm._ch_timeout(object()) is None
+    assert sm._ch_timeout(FakeCH()) is None            # no `conn` at all
+    assert sm._ch_timeout(_FakeCHClient(90.0)) == 90.0
+    assert sm._ch_timeout(_FakeCHClient(True)) is None
+    assert sm._ch_timeout(_FakeCHClient("30")) is None
+    # ...and the clamp reads THROUGH it rather than open-coding the same
+    # `getattr` chain a second time — that duplication is what let the reserve
+    # and the published value drift apart in the first place.
+    src = inspect.getsource(sm._clamp_ch_timeout)
+    assert "_ch_timeout(client)" in src, src
+    assert "getattr(" not in src, (
+        "`_clamp_ch_timeout` reads the client's timeout itself again", src)
 
 
 def test__clamp_ch_timeout_never_raises_on_a_client_without_a_conn():

--- a/scripts/tests/test_session_manager.py
+++ b/scripts/tests/test_session_manager.py
@@ -14019,9 +14019,10 @@ def test_the_CH_RESERVE_is_ENFORCED_on_the_client_that_SPENDS_it():
     passed every test in this file and would still have spent 90 s after a 70 s
     host loop: rc 124 in the pusher, no snapshot for EITHER host.
 
-    Measured 2026-09-04: the key is not set on the workbench, so this closes a
-    live gap rather than a live break. The laptop was not checked, which is
-    precisely why the reserve is now a BOUND and not an assumption.
+    Measured 2026-09-04 on BOTH hosts — `~/.config/activity-collector/env` on
+    the workbench and on the laptop, neither sets the key — so this closes a
+    live gap rather than a live break. That is a fact about today's env files,
+    which is precisely why the reserve is now a BOUND and not an assumption.
     """
     over = _FakeCHClient(90.0)
     base_gather(use_ch=True, ch_client_factory=lambda: over)


### PR DESCRIPTION
Rank 21 of `claudedocs/handoff-tmux-webapp.md`. **devrc-only** — the consumer half
already shipped in `ZacxDev/homelab-infra#660` and no Go file is touched.

## What this fixes

clawgate's tmux page groups windows by project through ONE seam, `projectOf()`
(`internal/ui/tmux.go:322`): **`repo` if non-empty → the LEAF of `path` → `Other`**.
The producer published no `repo`, so the leaf won every time and a git **worktree formed
its own project group** — a worktree directory named `clawgate-extension` sat apart from
the `homelab-talos` windows it belongs with.

`scripts/session-manager` now publishes an authoritative **`repo`** on every window row.

## The mechanism, and why it is not the obvious one

`git rev-parse --path-format=absolute --git-common-dir`, whose **parent directory is the
MAIN clone**.

🔴 **`--show-toplevel` is the wrong flag** and would have shipped an inert fix: on a linked
worktree it returns *the worktree itself*, so it cannot group two worktrees at all.
Measured 2026-09-03 on the workbench — `devrc-agentlock`, `<repo>/.claude/worktrees/agent-…`
and `<repo>/scripts` all report `/home/zach/workspace/devrc/.git`; `/tmp` and `/home/zach`
exit 128 with no output.

## The four constraints this is shaped by

1. **It resolves on the host that OWNS the directory.** `label_from_path` already states
   why that is not optional — `path` is a string from another machine, so a local
   `git rev-parse` answers about whatever sits at that path *here*. The probe rides the
   existing per-host `run_tmux` / `ssh_wrap` seam. **Proven live below.**
2. **ONE batched call per host.** Every unique pane path on a host goes into ONE `sh -c`
   (deduped and sorted). `--no-repo` removes it entirely.
3. **No injection surface.** The script text is a **constant**; paths arrive as `"$@"`
   positional parameters after an explicit `$0`.
4. **Unmeasured is not empty.** `repo_status` (`ok` / `not_a_repo` / `home` / `no_path` /
   `missing` / `unmeasured` / `skipped`) plus per-host `repos_measured` / `repos_status` /
   `repos_error` / `repos_paths` / `repos_resolved` / `repos_unparseable`. Counts are
   integers only when measured; otherwise null, never 0.

`$HOME` is deliberately **not** a project (`home`): `projectOf()` routes an unparented shell
to `Other`, and `repo` is the branch it *prefers*, so naming it here would override that
guard from the producer side.

---

# ROUND 2 — five 🟡 audit findings, all measured, all closed

An adversarial audit of the first three commits found five 🟡 issues. Four were real
defects reproducible through the shipped code; the fifth was three constants nothing
pinned. `SM_REPO_V1` → **`SM_REPO_V2`**: records are now
`<index>\t<git rc>\t<common dir>`.

## The per-finding matrix — reproduced RED at `5d722f2f`, clean at HEAD

Measured by a driver that loads a given `scripts/session-manager` and drives the **real
shipped functions** (`repo_probe_argv` → real `sh` → `parse_repo_probe` →
`build_repo_index`), never a copy of them.

| | at `5d722f2f` | at HEAD |
|---|---|---|
| **F1** git absent from PATH, a **real** repo | `{'repo': None, 'status': 'not_a_repo'}`, host `repos_measured: true` — **a measured absence about a look that never happened** | `{'repo': None, 'status': 'unmeasured'}` |
| **F2** a dir named `zzz-attacker\n1\t<other>`, victim = a real repo | victim resolves to **`WRONG-REPO`**, `repos_unparseable: 0` | victim resolves to `aaa-victim`; the attacker's own path is `unmeasured` |
| **F3** `row_repo('/w/oddname ', {'/w/oddname': ok})` | `{'repo': None, 'repo_status': 'missing'}` | `{'repo': 'oddname', 'repo_status': 'ok'}` |
| **F4** worst-case collection vs the pusher's 90 s cap | nominal **118 s** + 15 s ClickHouse, **no bound** | bounded at **70 s** + 15 s = 85 s |
| **F5a** per-path `timeout` bound | correct, **unpinned** — `timeout 900` SURVIVED 743 tests | pinned behaviourally (a real hung `git`, asserted on wall time) |
| **F5b** `repos_unparseable` | correct, **unpinned** — the literal `0` SURVIVED 743 tests | pinned by a fixture producing **2** |

🔴 **F5 is a mutation matrix, not a defect matrix, and saying so is the point.** Those
constants were *right*; nothing watched them. A red/green "before" for them would have
been a fabrication — the sweep below is the evidence.

## What each fix is

**F1 — only git's own 128 is a measurement.** `d=$(git …) || d=""` collapsed exit 128
(git says: not a work tree) with 124 (the per-path `timeout` fired), 127 (`git` absent),
129 (an unknown flag) and everything else into one empty string, published as the MEASURED
status `not_a_repo`. Records now carry `git`'s rc; only 128 is `not_a_repo` and every other
non-zero is a **per-path `unmeasured`**. It cannot inflate `repos_resolved`, which counts
`status == "ok"` by construction rather than by convention. The `payload-contract.md` row
claiming "timed out" already landed in `unmeasured` was false; it is now true.

**F2 — three defences, because each closes a different half.** The audit's claim that a
newline "costs that one path its answer and leaves every other index correct" was measured
false end to end. (a) The script refuses a common dir holding a newline — POSIX
`case $d in *"$NL"*`, no `tr`, so a host without coreutils cannot disarm it. (b) The parser
splits on `"\n"` **only**: `str.splitlines()` also breaks on eight other characters, all
legal in a Linux directory name, and a reader that splits on more than the writer joined
with is a forging surface by itself — a record carrying one of them is refused outright.
(c) A **duplicate index** is counted `unparseable` and the first answer stands. Measured:
(b) alone was insufficient — the injection then stayed inside its own field and
`repo_from_common_dir` read a repo called `forged` out of it, which is why (b) refuses
rather than merely contains. Both docstrings now say what the code does.

**F3 — one `.strip()`, and the seam closes.** `gather` builds the probe input stripped;
`parse_panes` stores tmux's field raw; the row looked itself up raw. `repos_resolved`
counted an answer no row could use, and the row published the `missing` that commit
`5d722f2f`'s own docstring asserts is unreachable. The guard pins the **relationship** —
every path counted resolved is a path some row carries — because a test on either half
stays green while the pair is broken.

**F4 — the bound is a deadline, not a table of constants.**
🔴 **The brief's arithmetic omitted ClickHouse, and that changes the fix.**
`chquery.CHConn.timeout` is **15 s**, spent inside the same `timeout 90`. So the BASE of
this branch was at **83 s of 90**, not 68 — 7 s of headroom, not 22 — and sizing the probe
to fit would have needed a budget of **≤ 3.5 s**, which is not a probe. The envelope had
to become explicit instead:

| leg | calls | seconds |
|---|---|---|
| remote (ssh) | panes + windows + capture + ledger | 4 × 12.0 = 48.0 |
| remote (ssh) | repo probe | 15.0 |
| local | panes + windows + capture + ledger | 4 × 5.0 = 20.0 |
| local | repo probe | 15.0 |
| ClickHouse | `chquery.CHConn.timeout` | 15.0 |
| | | **113.0 > 90** |

`COLLECT_BUDGET = 70.0` (`= COLLECT_CAP 90 − COLLECT_CH_RESERVE 15 − COLLECT_MARGIN 5`) is
enforced as a **monotonic deadline inside `run_tmux`** — the one place that starts a
subprocess — so the *sixth* call is covered the day it is written, with no arithmetic. A
read with no budget left is **not attempted** and its host reports `unmeasured` with an
error naming the budget; that is a read that did not happen, published as one.
`REPO_PROBE_TIMEOUT` 25.0 → 15.0.

The vacuous guard is replaced. `test_ssh_opts_are_bounded_enough_to_matter` asserted
`SSH_TIMEOUT * 2 <= 30` over a docstring saying "a 2-host scan issues 2 SSH calls" — wrong
when written (four) and wronger at five, green through both. The budget guard now runs a
**real `gather`** under a fake monotonic clock in which every call takes its full timeout,
reads the cap out of `tmux-snapshot-push.sh` and the reserve out of `chquery`, and carries
the **unbounded run as its negative control** so it cannot pass against a collector whose
calls merely happen to be cheap.

**F5 / F9 / F10 — the harness.** `make_runner`'s classifier no longer falls through to
`panes`; it raises — and the sweep proved a `raise` with no live case is not a guard, so
`test_make_runner_REFUSES_an_argv_it_cannot_classify` gives it one. That fall-through was
answering the **ledger** read with the panes output at the moment the repo arm was added:
the same defect, one call along. F10's claim that "a rename of the sentinel breaks the
fixture loudly" was measured false — both sides read the same constant, so a rename moves
them together, correctly — and is corrected to name the real defect.

**F6** `--no-repo` added to the flag tables in both `payload-contract.md` and `SKILL.md`.
**F7/F8** the two inert `repo_host_status` assignments now carry comments saying they are
placeholders consulted only when the index is `None`, instead of reading as verdicts.
Also `nix/home.nix` still said the pusher makes FOUR ssh calls per run.

## Mutation sweep — 17/17 killed, no survivors

Isolated tree copy (`.git` removed **and asserted absent** — a worktree's `.git` is a
file), `PYTHONDONTWRITEBYTECODE=1`, `__pycache__` purged before every run, tree restored
**by hash** between mutants, control **GREEN at 775** on both ends, and a positive control
(`REPO_STATUSES` drops `home`) killed in the same batch.

| mutant | verdict | killed by |
|---|---|---|
| `elif rc == 128` → `elif rc != 0` | KILLED | `test_only_gits_OWN_not_a_repo_rc_reads_as_a_measured_absence` |
| the record stops carrying `rc=$?` | KILLED | `test_the_REAL_probe_reports_a_per_path_failure_rather_than_not_a_repo` |
| the script's newline `case` removed | KILLED | `test_a_common_dir_holding_a_NEWLINE_cannot_forge_ANOTHER_paths_answer` |
| duplicate-index rejection removed | KILLED | `test_a_DUPLICATE_index_is_unparseable_and_the_FIRST_answer_stands` |
| `split("\n")` → `splitlines()` | KILLED | `test_the_parser_splits_on_NEWLINE_ONLY_never_str_splitlines` |
| record-breaker rejection removed | KILLED | ” |
| the breaker ledger narrowed to `("\r",)` | KILLED | ” |
| `repo_index.get(path.strip())` → `.get(path)` | KILLED | `test_a_pane_path_with_a_TRAILING_SPACE_still_finds_its_OWN_repo` |
| `COLLECT_BUDGET` 70 → 100 | KILLED | `test_the_pusher_cap_and_the_ch_reserve_are_READ_not_ASSERTED` |
| `gather` stops computing a deadline | KILLED | `test_the_WORST_CASE_collection_fits_the_pushers_own_cap` |
| `run_tmux` stops clamping to it | KILLED | `test_a_read_with_NO_budget_left_is_NOT_ATTEMPTED_and_says_which` |
| a starved call is started anyway | KILLED | `test_the_STARVED_host_reports_unmeasured_rather_than_an_empty_measurement` |
| **`timeout 3` → `timeout 900`** (the original survivor) | KILLED | `test_the_probe_script_BOUNDS_EACH_git_call` |
| **`command -v timeout` guard deleted** (the original survivor) | KILLED | ” |
| **`repos_unparseable` hardcoded `0`** (the original survivor) | KILLED | `test_repos_unparseable_is_a_REAL_count_not_the_constant_zero` |
| `make_runner` falls through to `panes` again | KILLED | `test_make_runner_REFUSES_an_argv_it_cannot_classify` |
| POSITIVE CONTROL: `REPO_STATUSES` drops `home` | KILLED | `test_every_repo_status_a_row_can_carry_is_ENUMERATED` |

🔴 **The FIRST run of this sweep was invalid in two places and said so.** A mutant that
made the module unimportable produced a *collection error*, not a `FAILED` line, and the
harness scored it **SURVIVED** — a wrong verdict from a wrong parse, exactly the
instrument-before-verdict trap. Another mutant's pattern matched **0 times** because it was
typed with escape sequences the file spells literally. The harness now reports
`INVALID(collection error)` distinctly, every pattern is asserted to match exactly once
before the run, and both mutants were rebuilt and re-run.

## Tests

**775 in the file** (743 before this round), 32 added. Every guard for F1–F3 pins a
**relationship**, not a component, because both defects were seams where each side was
individually correct: F1's host provenance and its rows are asserted in ONE test against
ONE run; F3 asserts `repos_resolved` equals the number of rows actually carrying a repo.
The real-`git` tests use the shipped `REPO_PROBE_SCRIPT` under a real `sh`, including a
real attacker-named directory and a real hung `git`.

## Gates — BOTH tiers, on the MERGED tree

Head `be0e4d15`. 🔴 **Every result below is on the tree that merges `origin/main` =
`2882d2c7`** (merge commit `904fc0d4`); `origin/main` is verified an ancestor of the gated
HEAD. ⚠ **`origin/main` moved to `d8fe0bce` AFTER the gates finished** — that commit
(`/tmp` churn retention + a disk-accounting script) is **not** in any run below. It touches
`nix/system/`, `scripts/diagnose-disk-accounting.sh` and
`scripts/tests/test_tmp_churn_retention.py`, none of which this branch touches, but that is
an argument, not a measurement. Whoever merges must re-gate.

### Sandbox tier — THE ONE THAT GATES, built one at a time

| derivation | verdict | store path |
|---|---|---|
| `checks.x86_64-linux.pytests` | **PASS** | `/nix/store/fhzla5qhxlg2w5gzr88h5937i1sh0qi8-devrc-pytests` |
| `checks.x86_64-linux.nodetests` | **PASS** | `/nix/store/13k3is5w7z6cbr525wdfrq08g12smsbk-devrc-nodetests` |

Neither was piped and each was built alone, so the exit status is readable.

🔴 **`pytests` was RED on its FIRST run and I am reporting that, not just the green.**
One failure, `test_git_repo_isolation.py::test_live_cotenants_sees_another_process_in_the_repo`,
asserting `['128282:git'] == []` — "a brand-new tmp repo already has tenants?". The
discriminating control was a re-run of the **identical derivation**
(`63738pfy08flzq21nh5q194r0klx41s4-devrc-pytests.drv`, same hash both times, so byte-identical
inputs): **green**, 12,157/12,157 in `scripts/tests`. Mechanism: that test's `_GIT_ENV` pins
`GIT_CONFIG_SYSTEM` but not `gc.auto`, so its own `_mkrepo` `git commit` can leave a detached
background `git` whose cwd is the fresh repo; under load it outlives the commit and
`live_cotenants` sees it. Unreachable from this diff — `git diff 2882d2c7..HEAD` over
`scripts/tests/test_git_repo_isolation.py`, `scripts/lib/` and `scripts/testlib/` is **0 lines**.
I did not fix it; it is a pre-existing race in a file this branch does not touch.

### Dev-host tier — `scripts/gate.sh --tier both`

- **node: PASS** — 5 suites, 41 files, **1,449 tests**, 0 failed.
- **pytest: 21,152 passed of 21,160 collected** (floor 18,404), **5 failed across 3 targets**.

🔴 **Two of those five were MINE, they were correct, and they are fixed** — repo-level
ledger guards that only the full gate runs, not the per-file loop I had been using:

| guard | what it caught | fix |
|---|---|---|
| `test_no_real_launchers.py::test_every_path_clobbering_site_is_pinned` | the three §R.10 tests REPLACE `PATH` (they must: both `git` and `timeout` are present in both tiers, so prepending cannot make one absent) | pinned in `PINNED_PATH_CLOBBERS` with that justification; all three now go through ONE `_r_path_only` helper so the ledger's single needle covers every site, and `_r_only_bin` CONSTRUCTS the dir and asserts its own contents |
| `test_runtime_shebangs.py::test_no_test_writes_a_usr_bin_env_shebang_at_runtime` | the hung-`git` stub wrote its own `#!` | written through `testlib.mockbin.write_exec`, which owns the shebang. **This is the two-tier hazard**: invisible on the dev host, only the sandbox has no `/usr/bin/env` |

The other three are **inherited and absent from the sandbox tier**, which is the evidence
they are host environment rather than code: `scripts/browser-bridge/tests` 2 failed / 888
passed (`subprocess.TimeoutExpired` after 300 s, `could not warm the isolated opencode
config dir` — the warm step needs network; that target took **726 s, 51% of the run**) and
`test_clawgate_task_interview_guard.py` 1 failed / 309 passed. All three are **890/890** and
**310/310** in the sandbox. Three sibling agents were running the same gate concurrently at
load ~21 while this ran.

⚠ The dev-host run above is at merge commit `904fc0d4`; the two ledger fixes landed in
`be0e4d15` on top of it and were verified by running the three affected files directly
(861 passed) and by the sandbox tier, which **is green at `be0e4d15`**. I did not re-run the
full dev-host tier after that commit — the sandbox tier is the one that gates, and it covers
the same suite.

## 🔴 What contradicts the brief

1. **The F4 arithmetic was incomplete and the recommended fix was therefore not
   available.** The brief's table (base 68 s / HEAD 118 s) omits the ClickHouse read the
   collector makes on every run. With it, base is 83 s and the headroom was 7 s, not 22 —
   and "a smaller probe budget" would have meant ≤ 3.5 s. A whole-run deadline replaces it.
2. **F2's fix needed a third defence the brief did not name.** Rejecting duplicate indices
   and stripping newlines still left `str.splitlines()` splitting on eight characters the
   writer never used as a separator; measured, a `\x0b` in a common dir forged a *later*
   index's answer, which duplicate rejection cannot cover.
3. **F9's `raise` was a guard with no reachable case.** It SURVIVED its own mutant on the
   first sweep — correctly, since every argv `gather` makes today is classified. It is
   worth keeping, but only with a test that reaches it, which is now there.
4. **Nothing else in the brief was contradicted.** F1, F2 and F3 reproduced exactly as
   described, including F2 resolving the victim to `WRONG-REPO` with `unparseable: 0`.

## Live fleet, under the V2 protocol

`./scripts/session-manager scan --json --lean --no-ch --no-capture`, both hosts, run from
this worktree at the V2 protocol (before the two test-only ledger commits, which cannot
reach it):

| | laptop | workbench |
|---|---|---|
| `reachable` / `repos_measured` / `repos_status` | true / true / `ok` | true / true / `ok` |
| unique paths probed → resolved | 9 → 8 | 7 → 6 |
| `repos_unparseable` | **0** | **0** |
| rows | 33 (`ok` 32, `not_a_repo` 1) | 62 (`ok` 61, `not_a_repo` 1) |

**93 of 95 rows carry a repo**; the two that do not are genuinely not work trees and say
`not_a_repo` — a status that now REQUIRES git to have exited 128, which is the F1 fix
observed on the wire. Groups: `datapacket-talos` 40, `civitai-gpu-fleet` 14, `devrc` 13,
`homelab-talos` 13, `vetr` 5, `naida-ai` 2.

🔴 **The closing condition, on the live fleet:** exactly one row has a path leaf that is not
its repo — the laptop's `/home/zach/workspace/clawgate-extension` → **`homelab-talos`**.
That is the worktree the old leaf-only grouping split off, and it is resolved **on the
laptop**, which is the only machine where that path exists.

## 🔴 Corrections to this PR body's earlier claims

- **`origin/main` was NOT still `a7dac5bd`, and it had moved several times.** The earlier
  text said "origin/main was `a7dac5bd` at branch point and had not moved, so this branch
  *is* the merged tree", and repeated it for the sandbox tier. That is stale: `main` went
  `a7dac5bd` → `1d2c4bd6` → `2882d2c7`. **Every gate result above is on the tree produced
  by merging `2882d2c7`**, and the merged sha is named beside it.
- The earlier "743 total in the file" and "18/18 killed" figures describe the first three
  commits, not this branch. Current: **775 tests, 17/17 mutants killed**.

## 🔴 What is still NOT verified

**The UI half of the closing condition.** Per the original dispatching session's
measurement (not re-measured here), the deployed clawgate is 0.8.23 and does not carry
#660's grouping. Two worktrees carrying the same `repo` **on the wire** is verified; "they
group together in the UI" is not.

Not re-measured this round: behaviour on a host that genuinely lacks `timeout(1)`. The
guard for it runs against a synthesised PATH holding only `sh` and `git`, which is a
different claim from a real host, and I say so rather than call it covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBBKq7rVU9BkakDWM9YGYd


---

# ROUND 3 — the delta audit's five findings, all closed

Head `6aaf9cf5` (four commits on top of `be0e4d15`). Gated on the MERGED tree
`33079a6b` (`d86b4e45` = `origin/main` × `6aaf9cf5`).

The last three commits are **self-audit of this round's own prose**, both found by
re-reading the diff rather than by a tool: the contract cited a test name that had been
renamed mid-change and never existed, and then the guard written to catch that was blind to
`scripts/session-manager`'s own comments — which had the same defect, one casing off. Both
surfaces are now resolved against the module's symbol table. The third re-measured NF-6's
own claim: the finding recorded "not set on the workbench; the laptop was not checked", so
the laptop was checked — neither host sets `CLICKHOUSE_HTTP_TIMEOUT`.

## 🔴 The brief's prescribed fix for NF-3 was measured INSUFFICIENT

NF-3 said "read the ledger BEFORE the probe". Doing exactly that changes **nothing** at
the worst case, and the measurement is why:

```
be0e4d15                          ledger-before-probe (within the host)
local  panes   5.0  at= 5.0       local  panes   5.0  at= 5.0
local  windows 5.0  at=10.0       local  windows 5.0  at=10.0
local  capture 5.0  at=15.0       local  capture 5.0  at=15.0
local  repo   15.0  at=30.0       local  ledger  5.0  at=20.0
local  ledger  5.0  at=35.0       local  repo   15.0  at=35.0   <- same total
remote panes  12.0  at=47.0       remote panes  12.0  at=47.0
remote windows12.0  at=59.0       remote windows12.0  at=59.0
remote capture11.0  at=70.0       remote capture11.0  at=70.0
remote repo    STARVED            remote repo    STARVED
remote ledger  STARVED            remote ledger  STARVED        <- still starved
```

The deadline spans **all hosts**, so the *local* host's own 15 s probe alone pushes the
remote host past 70 s. Re-ordering inside one host cannot help.

**What actually fixes it:** the probe becomes a **SECOND PASS over the hosts**. Every read
that existed before this branch — panes, windows, capture, ledger — is issued for EVERY
host before the probe is issued for ANY host.

```
local panes/windows/capture/ledger  at=20.0
remote panes/windows/capture/ledger at=68.0   <- both ledgers RAN
local  repo   2.0 (clamped)         at=70.0
remote repo   STARVED                          <- the OPTIONAL field loses
```

## Per-finding matrix — every guard watched RED at `be0e4d15`

| finding | guard | at `be0e4d15` | at `6aaf9cf5` |
|---|---|---|---|
| **NF-3** order | `test_the_repo_probe_is_issued_AFTER_every_other_read_on_every_host` | **RED** | green |
| **NF-3** consequence | `test_the_BUDGET_starves_the_repo_probe_and_NEVER_the_ledger` | **RED** | green |
| **NF-2** rc-0 route documented | `test_the_contract_enumerates_EXACTLY_the_rcs_that_reach_not_a_repo` | **RED** | green |
| **NF-2** two-way pin | `test_the_contract_repo_status_TABLE_is_pinned_TWO_WAY_to_REPO_STATUSES` | green* | green |
| **NF-1** `\r\n` forge | `test_a_CRLF_PAIR_cannot_forge_a_LATER_index` | **RED** | green |
| **NF-1** widened parametrisation | `test_the_parser_splits_on_NEWLINE_ONLY_never_str_splitlines` (18 cases) | **RED ×18** | green |
| **NF-1** adjacency is walkable | `test_the_POISON_is_NOT_narrowed_to_ADJACENCY_because_that_is_WALKABLE` | **RED** | green |
| **NF-4** unicode digit | `test_a_UNICODE_DIGIT_index_or_rc_is_unparseable_NEVER_a_ValueError` | **RED** | green |
| **NF-4** helper vs `int()` | `test__is_ascii_int_is_exactly_the_set_int_accepts` | **RED** | green |
| **NF-7c** V1 measurement struck | `test_the_contract_carries_NO_V1_ERA_FLEET_MEASUREMENT_as_current` | **RED** | green |
| **NF-7b** budget numbers pinned | `test_the_contract_docs_budget_numbers_are_PINNED_to_the_constants` | green* | green |
| **NF-6** reserve enforced | `test_the_CH_RESERVE_is_ENFORCED_on_the_client_that_SPENDS_it` | **RED** | green |
| **NF-6** helper | `test__clamp_ch_timeout_never_raises_on_a_client_without_a_conn` | **RED** | green |
| *(self-audit)* every cited test name resolves, in BOTH the doc and the script | `test_every_TEST_NAME_the_docs_and_the_SCRIPT_cite_actually_EXISTS` | **RED** on each surface's own defect | green |

Total at `be0e4d15` with this commit's test file: **28 failed, 775 passed**.
At `6aaf9cf5`: **804 passed** in this file, and **12,184 passed / 1 skipped** across the
whole of `scripts/tests` on the dev host (18:48) — no collateral breakage anywhere.

`*` = green at `be0e4d15` **and that is correct** — these two close a gap rather than fix a
regression. There was no pin, so nothing could be red; both were watched failing against
deliberate mutants instead (below).

## The two-way pin, watched failing in BOTH directions

| mutant | killed by |
|---|---|
| a row **added** to the contract table with no constant (`probably_a_repo`) | `…TABLE_is_pinned_TWO_WAY_to_REPO_STATUSES` |
| a constant **added** to `REPO_STATUSES` with no row (`invented`) | `…TABLE_is_pinned_TWO_WAY_to_REPO_STATUSES` |

The second was initially green *for the wrong reason* — a pre-existing enumeration test
caught it first — so it was re-scored with a `-k` selecting only this guard.

## Mutation results — 24 mutants, 0 survived, 0 invalid

**Sweep 1 (broad, 17 mutants, all KILLED):** poison flag not set / not read / not counted;
`isascii` dropped; `_is_ascii_int` always true; the guard bypassed; the CH clamp not called
/ inert / inverted; the pass-2 host order reversed; the doc's budget number, cap number,
V1 measurement, table row and rc cell; `REPO_STATUSES` grown; plus a known-caught positive
control (`REPO_PROBE_RC_NOT_A_REPO` 128→127).

**Sweep 2 (5 isolated mutants, each scored against its OWN named guard, dying on an
`AssertionError` and not a traceback):**

| mutant | guard that killed it |
|---|---|
| the probe folded back into loop 1 (the faithful regression) | order **and** budget guards |
| **a SIXTH `_read` inserted ahead of the ledger** | order guard |
| `REPO_STATUSES` grew with no doc row | two-way pin |
| a doc row added with no constant | two-way pin |
| the rc cell drops the rc-0 route | rc-enumeration guard |

**Sweep 3 (2 mutants):** the contract citing the old, never-existing test name; and the
script's second-pass comment citing the budget guard with the wrong casing (the ORIGINAL
defect, restored on purpose). Both killed by
`test_every_TEST_NAME_the_docs_and_the_SCRIPT_cite_actually_EXISTS`.

Method: `cp -a` copy with `rm -f <copy>/.git`; `PYTHONDONTWRITEBYTECODE=1` **and**
`__pycache__` purged per mutant; every pattern asserted to match exactly once; restore
verified by SHA-256; collection errors scored INVALID; the verdict reader itself given a
control (it must report SURVIVED / KILLED-BY-ANOTHER-TEST / KILLED-FOR-THE-WRONG-REASON on
synthetic input); control green at the full file before **and** after each sweep.

## Judgement calls

**NF-6 — took "enforce", not "document".** `_clamp_ch_timeout` holds the ClickHouse client
to `COLLECT_CH_RESERVE` at the one place that spends it. Making `COLLECT_BUDGET` read the
runtime value would make the whole budget host-dependent and computed from a file read at
import; clamping is the deterministic version of the same claim, and it converts
`COLLECT_BUDGET = CAP - RESERVE - MARGIN` from a belief into an invariant. A *lower*
`CLICKHOUSE_HTTP_TIMEOUT` is left alone — it only buys headroom. ⚠ The residual the finding
names is stated in the source and not closed: `urlopen`'s timeout is per socket operation,
so a connect-then-stall can still exceed the reserve; `COLLECT_MARGIN` is the only slack.
Re-measured 2026-09-04 on **both** hosts: neither sets the key. That is a fact about
today's env files, which is exactly why it is now a bound and not a note.

**NF-5 — deliberately NOT fixed; NF-1 wins.** A CRLF-carrying reply loses the whole field
(every row `missing`). It is unreachable — `SSH_OPTS:411` allocates no pty — and the
failure direction is honest. Fixing it means accepting a trailing `\r` as transport noise,
which is *precisely* NF-1's forging vector: the measured forge is a record ending in `\r`
followed by an attacker-controlled line. Hardening and forgiving the same byte are not
compatible, and a wrong `repo` is worse than a missing one. Recorded in the contract's
`missing` cell.

**Commit message "eight" vs "nine" breakers — left as is.** The commit is public on a
shared branch and an amend means a force-push that would rewrite a reviewed history for one
word. The *code* was already right; the *test* was the thing actually covering seven of
nine, and that is fixed properly — the parametrisation is now **derived from
`REPO_PROBE_RECORD_BREAKERS`**, so the count can no longer be wrong anywhere.

## What NF-1's fix actually is, and what it deliberately is not

A record carrying a `str.splitlines()` break character now **poisons the remainder of the
reply** — it and every line after it are `unparseable`, so those paths report `missing`.

Narrower rules were considered and rejected as *walkable*:

* "refuse the next line too" (adjacency) — evaded by `\r`, space, `\n`, which puts the
  breaker mid-line while the newline still starts an attacker-controlled record. There is a
  test for this exact string.
* index-equals-position — would close the bare-`\n` case too, but only reduces it from
  "forge any path" to "forge the next path", and it makes the duplicate-index defence
  structurally unreachable, deleting a pinned behaviour for a partial win.

⚠ **Residual, stated rather than papered over:** `parse_repo_probe` is still forgeable
through a bare `\n` if fed directly (the `repo_outputs` seam). Nothing in a parser can tell
two well-formed records apart from one record that was split. Only the **script** can, and
it does (`case $d in *"$NL"*` → rc 201). The "THREE **independent** defences" comment was
therefore false in the direction that gets code deleted; it now reads FOUR **layered**
defences with defence 1 marked **SOLE COVER** for a bare newline.

## Round-3 close-out — two 🟢 findings fixed (`f1568d4f`)

The audit ladder ended clean: round 3 found no regression and returned only these two.
Both are minimal; neither changes the happy path.

### 1. A false equivalence claim that licensed a wrong refactor

`parse_repo_probe` stated that `isascii() and isdigit()` is *"exactly the set `int()`
accepts without a sign"*, and the helper's test carried that sentence in its **name**
(`test__is_ascii_int_is_exactly_the_set_int_accepts`).

**Measured false.** `int()` also converts non-ASCII decimal digits — `'١٢'`, `'１２'`,
`'۱'`, `'٠'`, `'᱀'`, **100+ characters below U+3000** — every one of which the guard
rejects. The test's own body already contradicted its name: it asserts
`_is_ascii_int("１") is False` while `int("１") == 12`. The existing sweep only pins
*guard-accepts ⇒ int-accepts*, which is the one direction a wrong refactor preserves.

**The hazard:** a maintainer who believes the two sets are equal replaces the guard with
`try: int(x) / except ValueError` to remove the duplication, widening the accepted
index/rc alphabet to every Unicode decimal digit **with nothing going red**.

**Fixed:** the comment now states the SUBSET and *why it is correct* — the field is `$n`
out of the probe's POSIX arithmetic, ASCII by construction, so a non-ASCII digit is a
corrupted reply and not an index. The helper's docstring carries the same one-way note.
The test is renamed `test__is_ascii_int_accepts_only_what_int_converts`, which is what
its body pins. **No behaviour change.**

### 2. The CH-reserve clamp was silent

`gather` called `_clamp_ch_timeout(client)` and **discarded the return**. This is the one
place in a file whose stated discipline is *"a read that did not happen is published as
one"* that **changes** a number instead of measuring and publishing it — and it changes a
number the operator set. An operator who put `CLICKHOUSE_HTTP_TIMEOUT=60` in
`~/.config/activity-collector/env` because their CH read is slow got a 15 s read, an
ordinary-looking timeout in the `clickhouse` block, and an env file still saying 60 —
i.e. they debug ClickHouse, which is not where the 15 came from.

**Fixed:** `report["clickhouse"]` now carries

| key | meaning |
|---|---|
| `timeout_secs` | what the read actually ran with |
| `timeout_clamped_from` | the configured value it was reduced **from**; `null` when nothing was reduced |

Both are present in **every** branch (`ok`, `skipped`, `unavailable`) and `null` when no
client carrying a timeout was built — unmeasured, which is not the same claim as "not
clamped", so a consumer never has to tell an absent key from a null one. The `getattr`
chain is factored into `_ch_timeout`, **the one reader**, so the clamp and the field that
publishes it cannot disagree about what they saw. `payload-contract.md` documents both.

### Red/green matrix — every guard watched RED at `6aaf9cf5`

| guard | red at `6aaf9cf5` (its own assertion) | green at `f1568d4f` |
|---|---|---|
| `test_the_ascii_int_guard_is_documented_as_a_SUBSET_not_an_equivalence` | AssertionError: *parse_repo_probe (the call site) still claims the guard is `exactly the set int() accepts` — it is a strict subset* | ✅ |
| …its **name-half**, isolated (old test file + new guard, new script) | `AssertionError: ['test__is_ascii_int_is_exactly_the_set_int_accepts']` | ✅ |
| `test_the_CH_TIMEOUT_CLAMP_is_PUBLISHED_and_never_SILENT` | `KeyError: 'timeout_secs'` | ✅ |
| `test__ch_timeout_is_the_ONE_reader_of_the_clients_timeout` | `AttributeError: module 'session_manager' has no attribute '_ch_timeout'` | ✅ |

⚠ **Residual, stated rather than hidden:** the second half of fix 1's guard is a guard on
**words**, so a *reworded* equivalence claim would walk it. What it cannot walk is the
first half, which is a measurement (the 100+ character sweep), and the requirement that
each surface still say SUBSET.

### The ladder's evidence, re-confirmed after the change

| claim | how | result |
|---|---|---|
| the two-way contract pin fails in **both** directions | added a `bogus_status` row to the real table; separately deleted the `home` row | ✅ red both ways, by the pin's **own** message: `documented-but-not-a-status=['bogus_status']` / `undocumented=['home']` |
| `_is_ascii_int` reverted to bare `.isdigit()` still kills its two tests | mutated the helper in an isolated `cp -a` copy | ✅ `test_a_UNICODE_DIGIT_index_or_rc_is_unparseable_NEVER_a_ValueError` dies with the exact `ValueError: invalid literal for int() with base 10: '²'` it exists to prevent; `test__is_ascii_int_accepts_only_what_int_converts` dies on `_is_ascii_int('²') is False` |
| `test_the_repo_probe_is_issued_AFTER_every_other_read_on_every_host` still dies when a probe `_read` moves into pass 1 | inserted `_read(repo_probe_argv([...]), host, …)` after `wins_res` | ✅ red on its **own** claim 2: `a repo probe (index 2) is issued before another read (index 9)` |

Mutation protocol: `cp -a` copy with `rm -f <copy>/.git` first, `PYTHONDONTWRITEBYTECODE=1`,
`__pycache__` purged per mutant, every mutant restored **by md5 hash**, control run green
before each battery. The real worktree's hashes were re-checked unchanged afterwards.

## Both tiers, on the MERGED tree `18601071` (= `origin/main` `d86b4e45` × head `f1568d4f`)

`origin/main` re-fetched immediately before gating; it was still `d86b4e45`. The merge was
clean — the only overlap is a comment block in `nix/home.nix` (four→five ssh invocations),
read and confirmed coherent rather than assumed from a clean `git merge`.

🔴 **Sandbox tier — the one that gates. Built ONE AT A TIME, both green.** Numbers read
from the derivation logs (`-L`), not from an exit code:

| derivation | result |
|---|---|
| `nix build .#checks.x86_64-linux.pytests` | `RESULT: PASS (exit=0)` — **collected 21,261, passed 21,258, skipped 3, failed 0** (floor 18,404 = sum of 30 per-target floors); `panic: test timed out` × **0** |
| `nix build .#checks.x86_64-linux.nodetests` | `RESULT: PASS (exit=0)` — suites 5, files 41, **tests 1,449, pass 1,449, fail 0, skipped 0** (floor 1,367); `not ok` × **0**, `panic: test timed out` × **0** |

Neither was the cached-and-silent case: pytests emitted 1,505 log lines, nodetests 437 KB
of TAP, both from a real `building '…drv'`.

**Dev-host tier — `scripts/gate.sh --tier both`:** `GATE: RESULT=FAIL exit=1`, node
**PASS** (1,449/1,449), pytest **21,257 passed / 1 failed** of 21,261 collected.

| dev-host failure | attribution (my own control, not an inherited claim) | sandbox |
|---|---|---|
| `test_a_body_file_written_by_a_heredoc_on_the_same_line_is_read` | `/tmp/body.md` **exists on this host** — 21,181 B, mtime 2026-09-03 19:41, content is another session's PR body about a "mute-review queue". The test writes a heredoc to that path; the guard reads the real file instead. | `test_clawgate_task_interview_guard.py` **310 collected, 310 passed, 0 failed** |

The second historically-known dev-host failure (the browser-bridge test whose stderr names
a missing npm-install) **did not occur this run** — `scripts/browser-bridge/tests` was
890/890 in the dev-host tier and 890/890 in the sandbox. No other failures appeared.

Neither failure is reachable from this diff, which touches `scripts/session-manager`, its
test file and one skill reference doc. `scripts/tests` itself is **12,258 collected /
12,258 passed / 0 failed** in both tiers.

⚠ Branch protection on `main` is **declared off** in this repo, so these two local tiers are
the only gate — run on the merged tree `18601071`, base `d86b4e45`, tiers named above.
