### PR TITLE
fix(dl-router): reach the Discord original by rewriting the proxy URL, not by reading a link that is never there

### DIFF
--- a/scripts/dl-router/SKILL.md
+++ b/scripts/dl-router/SKILL.md
@@ -205,24 +205,38 @@ media = [
 ]
 ```
 
-An image's own `src` is often a **downscaled copy from a resizing proxy**.
-🔴 **Do NOT expect the original on a wrapping `<a>` — on the chat site this was
-built for there is no wrapping anchor at all.** MEASURED 2026-09-03 on the live
-client, 3 image attachments across 2 channels and 2 message shapes: the number
-of ancestor `<a>` elements between the image and its message was **0 of 3**. The
-origin anchor exists in the same message but as a **sibling**, and a browser
-fills the context menu's `linkUrl` only from an ANCESTOR link — so a rule that
-waits for one waits forever.
+An image's own `src` is often a **downscaled copy from a resizing proxy**, which
+is why the anchor accessor goes FIRST in the list above: it is how this rule
+reaches the original. 🔴 **That accessor is a DESCENDANT query and it does not
+need a wrapping `<a>`.** `safeQuery` resolves each `element` with
+`container.querySelectorAll` (`player_buttons.js`), so an anchor that is merely
+somewhere inside `container` — a SIBLING of the image, which is the live shape —
+resolves fine. Do not delete it on the strength of the context-menu note below:
+🔴 **the player-button path does NOT rewrite anything.** `playerDownload` hands
+its `mediaUrl` straight to the download API and never calls
+`originalFromPreview()`, so for THIS path the anchor accessor is the only route
+to the original.
 
-🔴 **Rewriting the proxy URL's host IS the supported route, and the rule here
-used to say the opposite.** It claimed the two hosts carry different signature
-parameters; they do not. Measured for one asset: the proxy URL carries the
-signature parameters **plus** the resize knobs, with the signature **values
-byte-identical** to the origin anchor's, so the rewrite keeps a valid signature.
-Probed with both controls — the message's own origin anchor **206**, the
-rewritten URL **206**, the same URL with the signature stripped **fails**.
-`originalFromPreview()` in `route_core.js` is the one implementation; do not
-open-code a second.
+### The "Save to library…" CONTEXT MENU is a different path with a different rule
+
+🔴 **Scoped to `info.linkUrl`, and it does NOT apply to the `media` list above.**
+A browser fills a context menu's `linkUrl` only from an ANCESTOR link, and on
+the chat site this was built for an image attachment has none. MEASURED
+2026-09-03 on the live client, 3 image attachments across 2 channels and 2
+message shapes: ancestor `<a>` elements between the image and its message,
+**0 of 3**. The origin anchor is a sibling — reachable by a descendant query,
+invisible to `linkUrl`. So the menu path cannot wait for a link and must
+rewrite instead.
+
+🔴 **For the menu path, rewriting the proxy URL's host IS the supported route,
+and this file used to say the opposite.** It claimed the two hosts carry
+different signature parameters; they do not. Measured for one asset: the proxy
+URL carries the signature parameters **plus** the resize knobs, with the
+signature **values byte-identical** to the origin anchor's, so the rewrite keeps
+a valid signature. Probed with both controls — the message's own origin anchor
+**206**, the rewritten URL **206**, the same URL with the signature stripped
+**fails**. `originalFromPreview()` in `route_core.js` is the one implementation
+**of the rewrite**; do not open-code a second.
 
 ⚠ **A video's `src` is USUALLY the origin already, but that is not guaranteed
 and was measured at zero points** — every video in the live route log was

--- a/scripts/dl-router/SKILL.md
+++ b/scripts/dl-router/SKILL.md
@@ -205,11 +205,29 @@ media = [
 ]
 ```
 
-An image's own `src` is often a **downscaled copy from a resizing proxy**, with
-the original on the wrapping `<a>`; a video's `src` already *is* the original.
-🔴 **Never reach the original by rewriting a proxy URL's host** — the two hosts
-carry different signature parameters, so the rewrite drops a signature belonging
-to the other host. The anchor's href is already signed for where it points.
+An image's own `src` is often a **downscaled copy from a resizing proxy**.
+🔴 **Do NOT expect the original on a wrapping `<a>` — on the chat site this was
+built for there is no wrapping anchor at all.** MEASURED 2026-09-03 on the live
+client, 3 image attachments across 2 channels and 2 message shapes: the number
+of ancestor `<a>` elements between the image and its message was **0 of 3**. The
+origin anchor exists in the same message but as a **sibling**, and a browser
+fills the context menu's `linkUrl` only from an ANCESTOR link — so a rule that
+waits for one waits forever.
+
+🔴 **Rewriting the proxy URL's host IS the supported route, and the rule here
+used to say the opposite.** It claimed the two hosts carry different signature
+parameters; they do not. Measured for one asset: the proxy URL carries the
+signature parameters **plus** the resize knobs, with the signature **values
+byte-identical** to the origin anchor's, so the rewrite keeps a valid signature.
+Probed with both controls — the message's own origin anchor **206**, the
+rewritten URL **206**, the same URL with the signature stripped **fails**.
+`originalFromPreview()` in `route_core.js` is the one implementation; do not
+open-code a second.
+
+⚠ **A video's `src` is USUALLY the origin already, but that is not guaranteed
+and was measured at zero points** — every video in the live route log was
+already on the origin host, so the rewrite simply does not fire for them. It
+*will* fire on a proxy-host video src, and that shape is unverified.
 
 **Important details**
 - The media URL is **signed and rotates** — `player_buttons.js` reads it **at

--- a/scripts/dl-router/SKILL.md
+++ b/scripts/dl-router/SKILL.md
@@ -209,9 +209,13 @@ An image's own `src` is often a **downscaled copy from a resizing proxy**, which
 is why the anchor accessor goes FIRST in the list above: it is how this rule
 reaches the original. 🔴 **That accessor is a DESCENDANT query and it does not
 need a wrapping `<a>`.** `safeQuery` resolves each `element` with
-`container.querySelectorAll` (`player_buttons.js`), so an anchor that is merely
-somewhere inside `container` — a SIBLING of the image, which is the live shape —
-resolves fine. Do not delete it on the strength of the context-menu note below:
+`container.querySelectorAll` (`player_buttons.js`), so the anchor only has to be
+a descendant of `container` — it does not have to be an ancestor of the image.
+⚠ **Confirm your `container` actually encloses it.** What was measured is the
+NEGATIVE half only (0 ancestor `<a>` of 3); the origin anchor was nine levels
+away from the image, and whether it falls inside any particular `container`
+selector has never been measured. Do not delete this accessor on the strength
+of the context-menu note below:
 🔴 **the player-button path does NOT rewrite anything.** `playerDownload` hands
 its `mediaUrl` straight to the download API and never calls
 `originalFromPreview()`, so for THIS path the anchor accessor is the only route
@@ -242,6 +246,14 @@ a valid signature. Probed with both controls — the message's own origin anchor
 and was measured at zero points** — every video in the live route log was
 already on the origin host, so the rewrite simply does not fire for them. It
 *will* fire on a proxy-host video src, and that shape is unverified.
+
+### Player button details — everything below is about the BUTTON, not the menu
+
+🔴 The heading above closes the context-menu subsection. Without it, this
+block, the troubleshooting list and the DEPLOY ORDER note all read as
+context-menu guidance — and the context-menu path has no rules, no accessors
+and no buttons, so every word of it would be filed under a path it cannot
+apply to.
 
 **Important details**
 - The media URL is **signed and rotates** — `player_buttons.js` reads it **at

--- a/scripts/dl-router/SKILL.md
+++ b/scripts/dl-router/SKILL.md
@@ -251,9 +251,12 @@ already on the origin host, so the rewrite simply does not fire for them. It
 
 🔴 The heading above closes the context-menu subsection. Without it, this
 block, the troubleshooting list and the DEPLOY ORDER note all read as
-context-menu guidance — and the context-menu path has no rules, no accessors
-and no buttons, so every word of it would be filed under a path it cannot
-apply to.
+context-menu guidance — and the context-menu path has no **player** rules, no
+accessors and no buttons, so every word of it would be filed under a path it
+cannot apply to. ⚠ It is not rule-free: the menu path IS governed by
+`[site_rules."<host>".context]`, which `content_capture.js` reads on the
+`contextmenu` event and which decides where a menu download files. If menu
+downloads keep landing in the catch-all, that context rule is the thing to add.
 
 **Important details**
 - The media URL is **signed and rotates** — `player_buttons.js` reads it **at

--- a/scripts/dl-router/SKILL.md
+++ b/scripts/dl-router/SKILL.md
@@ -247,16 +247,21 @@ and was measured at zero points** — every video in the live route log was
 already on the origin host, so the rewrite simply does not fire for them. It
 *will* fire on a proxy-host video src, and that shape is unverified.
 
+⚠ **The menu path has no PLAYER rules — but it is not rule-free.** It is
+governed by `[site_rules."<host>".context]`, which `content_capture.js` reads
+on the `contextmenu` event; those `subject`/`tags` selectors go in first as the
+most specific signal, and the sidecar's `/match` weighs them against the title,
+Open Graph, link text and the url-derived signals. So a context rule does not
+by itself *decide* the directory — it is the strongest lever a config author
+has. 🔴 **If menu downloads keep landing in the catch-all, that context rule is
+the first thing to add.**
+
 ### Player button details — everything below is about the BUTTON, not the menu
 
 🔴 The heading above closes the context-menu subsection. Without it, this
 block, the troubleshooting list and the DEPLOY ORDER note all read as
-context-menu guidance — and the context-menu path has no **player** rules, no
-accessors and no buttons, so every word of it would be filed under a path it
-cannot apply to. ⚠ It is not rule-free: the menu path IS governed by
-`[site_rules."<host>".context]`, which `content_capture.js` reads on the
-`contextmenu` event and which decides where a menu download files. If menu
-downloads keep landing in the catch-all, that context rule is the thing to add.
+context-menu guidance — and the menu path has no player rules, no accessors and
+no buttons, so every word of it would be filed under a path it cannot apply to.
 
 **Important details**
 - The media URL is **signed and rotates** — `player_buttons.js` reads it **at

--- a/scripts/dl-router/config.example.toml
+++ b/scripts/dl-router/config.example.toml
@@ -149,10 +149,12 @@ max_jobs = 4
 # # a sibling <a> INSIDE the container, while a video's `src` is usually the
 # # original already. Put the accessor that resolves the BEST copy first.
 # #
-# # "sibling, inside the container" is exact, and it is why this works: each
-# # `element` is resolved with container.querySelectorAll, a DESCENDANT query,
-# # so the anchor does not have to wrap the image. On the chat site this was
-# # built for it never does -- measured, 0 ancestor <a> of 3 attachments.
+# # This works because each `element` is resolved with
+# # container.querySelectorAll -- a DESCENDANT query -- so the anchor does not
+# # have to wrap the image. On the chat site this was built for it never does:
+# # measured, 0 ancestor <a> of 3 attachments. What was NOT measured is whether
+# # that anchor falls inside any particular `container`; confirm yours encloses
+# # it.
 # #
 # # [site_rules."chat.example.test".player]
 # # container = "[class^=mediaWrapper]"

--- a/scripts/dl-router/config.example.toml
+++ b/scripts/dl-router/config.example.toml
@@ -146,8 +146,13 @@ max_jobs = 4
 # # http(s) hit wins. That exists because `attr` is ONE name, so a single pair
 # # cannot cover a site that posts both an image and a video: the image's own
 # # `src` is often a downscaled copy from a resizing proxy, with the original on
-# # the wrapping <a>, while a video's `src` IS the original. Put the accessor
-# # that resolves the BEST copy first.
+# # a sibling <a> INSIDE the container, while a video's `src` is usually the
+# # original already. Put the accessor that resolves the BEST copy first.
+# #
+# # "sibling, inside the container" is exact, and it is why this works: each
+# # `element` is resolved with container.querySelectorAll, a DESCENDANT query,
+# # so the anchor does not have to wrap the image. On the chat site this was
+# # built for it never does -- measured, 0 ancestor <a> of 3 attachments.
 # #
 # # [site_rules."chat.example.test".player]
 # # container = "[class^=mediaWrapper]"
@@ -156,10 +161,14 @@ max_jobs = 4
 # #   { element = "video", attr = "src" },
 # # ]
 # #
-# # Do NOT try to reach the original by rewriting a proxy URL's host: the two
-# # hosts commonly carry DIFFERENT signature parameters, so a rewritten URL
-# # drops a signature that belonged to the other host. Taking the anchor's own
-# # href works because it is already signed for the host it points at.
+# # This accessor is the ONLY route to the original for the player button:
+# # `playerDownload` downloads the URL the rule resolves and never rewrites it.
+# # (The separate "Save to library..." CONTEXT MENU cannot see a sibling anchor
+# # at all -- a browser fills `linkUrl` only from an ANCESTOR link -- so that
+# # path reaches the original by rewriting the proxy host instead. The two
+# # hosts were measured to carry the SAME signature values, so the rewrite
+# # keeps a valid signature. An earlier version of this comment asserted the
+# # opposite and told you never to rewrite; it was wrong.)
 # #
 # # One malformed accessor rejects the WHOLE rule and renders no button --
 # # keeping the good ones would silently cover only some media on the page,

--- a/scripts/dl-router/config.example.toml
+++ b/scripts/dl-router/config.example.toml
@@ -146,8 +146,8 @@ max_jobs = 4
 # # http(s) hit wins. That exists because `attr` is ONE name, so a single pair
 # # cannot cover a site that posts both an image and a video: the image's own
 # # `src` is often a downscaled copy from a resizing proxy, with the original on
-# # a sibling <a> INSIDE the container, while a video's `src` is usually the
-# # original already. Put the accessor that resolves the BEST copy first.
+# # a sibling <a>, while a video's `src` is usually the original already. Put
+# # the accessor that resolves the BEST copy first.
 # #
 # # This works because each `element` is resolved with
 # # container.querySelectorAll -- a DESCENDANT query -- so the anchor does not

--- a/scripts/dl-router/extension/manifest.json
+++ b/scripts/dl-router/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Media Download Router",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Files downloads into subject directories under a local media library, using page context, via a loopback token-authenticated sidecar. Local-only, authorized personal automation.",
   "permissions": [
     "downloads",

--- a/scripts/dl-router/extension/route_core.js
+++ b/scripts/dl-router/extension/route_core.js
@@ -212,11 +212,72 @@ export function discordAliasKey(channelId) {
 
 // Discord serves one attachment from two hosts: the resizing proxy goes in the
 // <img src>, downscaled to whatever the client asked for and usually
-// re-encoded to webp, while the original sits on the wrapping <a href>. So
-// `info.srcUrl` on an image names A THUMBNAIL, not the file that was posted.
+// re-encoded to webp, while the original is what the message's own
+// cdn.discordapp.com anchor points at. So `info.srcUrl` on an image names A
+// THUMBNAIL, not the file that was posted.
 // (A <video> is unaffected -- its src is already the origin.)
+//
+// THAT ANCHOR IS A SIBLING, NOT AN ANCESTOR -- so Chrome never hands it to
+// us. MEASURED 2026-09-03 on 3 image attachments across 2 channels and 2
+// message shapes (single image, mosaic): the <img> sits under
+// `div[role=button].clickableWrapper`, and the number of ancestor <a> elements
+// between it and the message was 0 of 3, every time. The origin anchor exists
+// in the same message but nine levels away. `info.linkUrl` is populated ONLY
+// from an ancestor link, so on a Discord image right-click it is absent and
+// `preferOriginalUrl` can never reach its swap -- see the note there.
 const DISCORD_PREVIEW_HOST = "media.discordapp.net";
 const DISCORD_ORIGIN_HOST = "cdn.discordapp.com";
+
+// The proxy's resize knobs. Everything else on the URL -- notably the
+// `ex`/`is`/`hm` signature -- is carried across unchanged, because the
+// signature is what authorises the fetch.
+//
+// The empty-named key is real, not defensive: a live proxy URL carried one
+// (Discord emits a stray `&`), and it was in the rewrite that MEASURED 206.
+// Dropping it keeps this function's output byte-identical to what was probed.
+const DISCORD_PREVIEW_RESIZE_PARAMS = ["format", "width", "height", "quality", ""];
+
+/**
+ * The original-quality URL for a Discord PROXY attachment url, else the url
+ * unchanged.
+ *
+ * WHY A REWRITE AND NOT A DOM READ. The origin URL is present on the page, but
+ * only on a sibling anchor the context menu cannot see (above). Reaching it
+ * would need a content script on discord.com keyed to Discord's hashed class
+ * names, which rotate every deploy. Rewriting needs neither.
+ *
+ * THE SIGNATURE IS NOT HOST-BOUND -- this is the measurement the rewrite
+ * rests on, and an earlier session eliminated this whole approach by assuming
+ * the opposite. MEASURED 2026-09-03, from the page context of a live Discord
+ * tab, with both controls:
+ *
+ *   positive control  the message's own cdn anchor .............. 206
+ *   under test        proxy url, host swapped, resize dropped ... 206
+ *   negative control  the same url with `ex`/`is`/`hm` removed ... network error
+ *
+ * The `ex`/`is`/`hm` VALUES were byte-identical between the proxy url and the
+ * cdn anchor for the same asset, so the swap carries a signature that is still
+ * valid. The negative control failed at the network layer rather than with a
+ * readable 403 -- cross-origin, so a non-CORS response is opaque -- which is
+ * enough to discriminate, which is what a control has to do.
+ *
+ * NARROW ON PURPOSE, same discipline as `preferOriginalUrl`: an avatar or an
+ * emoji is served from the same proxy host and must come back untouched, so
+ * this rewrites only what `discordChannelId` recognises as an attachment.
+ */
+export function originalFromPreview(url) {
+  if (hostOf(url) !== DISCORD_PREVIEW_HOST) return url;
+  if (!discordChannelId(url)) return url;
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  parsed.host = DISCORD_ORIGIN_HOST;
+  for (const key of DISCORD_PREVIEW_RESIZE_PARAMS) parsed.searchParams.delete(key);
+  return parsed.toString();
+}
 
 /**
  * The stable ledger identity of a Discord attachment, else "".
@@ -306,28 +367,43 @@ export function ledgerSourceKey(url) {
  * URL cannot be read for pixel size -- so the narrow rule stands until a real
  * instance turns up.
  *
- * NOT OBSERVABLE: nothing records whether this ever fires. The extension has
- * no logging facility and inventing one is out of scope here, so the next
- * reader cannot answer "is this a no-op in production?" from data. Say so
- * rather than implying it has been seen to work.
+ * THE `linkUrl` PATH IS DEAD ON DISCORD ITSELF, and the fallback is what
+ * actually runs. MEASURED 2026-09-03 (see DISCORD_PREVIEW_HOST above): a
+ * Discord image attachment has NO ancestor <a>, so `info.linkUrl` is absent
+ * and every real right-click lands on the `!linkUrl` branch. The swap is kept
+ * because it is still correct wherever a browser does supply a link -- but it
+ * is no longer what makes this function work, so nothing here should be read
+ * as evidence the swap has ever fired.
+ *
+ * Every no-swap exit therefore returns `originalFromPreview(srcUrl)` rather
+ * than `srcUrl`: on a proxy attachment that IS the original, and on anything
+ * else it is `srcUrl` unchanged. That includes the last line's mismatched-path
+ * case, which is the live mosaic shape -- a multi-image message, where the
+ * anchor the menu might offer belongs to a DIFFERENT image than the one
+ * clicked, and the rewrite of the clicked image is strictly better than
+ * handing back its thumbnail.
  */
 export function preferOriginalUrl(srcUrl, linkUrl) {
   if (!srcUrl) return linkUrl || "";
-  if (!linkUrl) return srcUrl;
+  if (!linkUrl) return originalFromPreview(srcUrl);
   if (hostOf(srcUrl) !== DISCORD_PREVIEW_HOST) return srcUrl;
-  if (hostOf(linkUrl) !== DISCORD_ORIGIN_HOST) return srcUrl;
+  if (hostOf(linkUrl) !== DISCORD_ORIGIN_HOST) return originalFromPreview(srcUrl);
   // Both must be attachments, not just Discord-hosted: an avatar or an emoji
   // shares the hosts and must never be swapped for something else.
-  if (!discordChannelId(srcUrl) || !discordChannelId(linkUrl)) return srcUrl;
+  // `originalFromPreview` enforces the same rule on its own input, so an
+  // avatar still comes back untouched here.
+  if (!discordChannelId(srcUrl) || !discordChannelId(linkUrl)) {
+    return originalFromPreview(srcUrl);
+  }
   let src;
   let link;
   try {
     src = new URL(srcUrl);
     link = new URL(linkUrl);
   } catch {
-    return srcUrl;
+    return originalFromPreview(srcUrl);
   }
-  return src.pathname === link.pathname ? linkUrl : srcUrl;
+  return src.pathname === link.pathname ? linkUrl : originalFromPreview(srcUrl);
 }
 
 /**

--- a/scripts/dl-router/extension/route_core.js
+++ b/scripts/dl-router/extension/route_core.js
@@ -215,7 +215,16 @@ export function discordAliasKey(channelId) {
 // re-encoded to webp, while the original is what the message's own
 // cdn.discordapp.com anchor points at. So `info.srcUrl` on an image names A
 // THUMBNAIL, not the file that was posted.
-// (A <video> is unaffected -- its src is already the origin.)
+//
+// A <video> is usually unaffected -- every video in the live route log was
+// ALREADY on the origin host, so the rewrite below does not fire for one.
+// But "usually" is the whole claim: video was measured at ZERO points, this
+// file's own sibling extension treats a proxy-host video src as an ordinary
+// shape, and if one occurs the rewrite DOES fire on it. There is no fallback
+// if that is wrong -- `service_worker.js` hands the result straight to
+// `chrome.downloads.download` with no retry on the original src -- so a wrong
+// rewrite there fails the download rather than degrading. Measure before
+// widening anything here on the strength of the image result.
 //
 // THAT ANCHOR IS A SIBLING, NOT AN ANCESTOR -- so Chrome never hands it to
 // us. MEASURED 2026-09-03 on 3 image attachments across 2 channels and 2
@@ -232,9 +241,18 @@ const DISCORD_ORIGIN_HOST = "cdn.discordapp.com";
 // `ex`/`is`/`hm` signature -- is carried across unchanged, because the
 // signature is what authorises the fetch.
 //
-// The empty-named key is real, not defensive: a live proxy URL carried one
-// (Discord emits a stray `&`), and it was in the rewrite that MEASURED 206.
-// Dropping it keeps this function's output byte-identical to what was probed.
+// THE EMPTY-NAMED KEY DOES NOT DO WHAT AN EARLIER VERSION OF THIS COMMENT
+// CLAIMED, and the correction is the point. It said a live proxy URL carried a
+// stray `&` and that this entry is what removes it. MEASURED: it is not. The
+// urlencoded parser SKIPS empty sequences, so `?&ex=1` parses to `[[ex,1]]`
+// with no empty-named entry to delete -- the stray `&` disappears because
+// `searchParams.delete()` re-serialises the whole query, which happens with or
+// without this entry.
+//
+// It is kept because it DOES bite one shape the parser does keep: `?=value`
+// yields a genuine `["", "value"]` pair, which would otherwise ride onto the
+// origin URL. That shape has never been observed live; this is defensive, and
+// saying so is the difference between a guard and a guard nobody can price.
 const DISCORD_PREVIEW_RESIZE_PARAMS = ["format", "width", "height", "quality", ""];
 
 /**
@@ -359,13 +377,13 @@ export function ledgerSourceKey(url) {
  * preferring `linkUrl` in general would turn every linked thumbnail on every
  * site into a download of wherever the link pointed.
  *
- * KNOWN UNHANDLED VARIANT, stated rather than guessed at: if Discord ever
- * puts a FULL-SIZE PROXY url on the anchor (`media.discordapp.net?width=4096`)
- * instead of the origin, this returns `srcUrl` and the downscaled copy is still
- * what gets saved. Widening to "prefer the anchor whenever the paths match"
- * would cover it, but nothing in the live corpus shows that shape, and a
- * URL cannot be read for pixel size -- so the narrow rule stands until a real
- * instance turns up.
+ * THE VARIANT THIS USED TO CALL UNHANDLED IS NOW HANDLED -- do not widen the
+ * rule to "cover" it. If Discord puts a FULL-SIZE PROXY url on the anchor
+ * (`media.discordapp.net?width=4096`) instead of the origin, that `linkUrl`
+ * fails the origin-host test below, which no longer returns `srcUrl` but
+ * `originalFromPreview(srcUrl)` -- the full-quality origin, i.e. the right
+ * answer. Widening to "prefer the anchor whenever the paths match" would
+ * REPLACE that correct answer with a downscaled proxy copy.
  *
  * THE `linkUrl` PATH IS DEAD ON DISCORD ITSELF, and the fallback is what
  * actually runs. MEASURED 2026-09-03 (see DISCORD_PREVIEW_HOST above): a
@@ -754,7 +772,18 @@ export function correlateCapture(item, captures, opts = {}) {
   const urls = new Set([item?.url, item?.finalUrl].filter(Boolean));
   if (urls.size) {
     for (const c of list) {
-      if ((c.href && urls.has(c.href)) || (c.mediaSrc && urls.has(c.mediaSrc))) {
+      // `downloadUrl` is the THIRD field, and it exists because tier 1 is
+      // otherwise structurally impossible whenever the extension downloads a
+      // url the page never served. `preferOriginalUrl` rewrites a Discord
+      // proxy src to the origin host, so the DownloadItem's url matches
+      // neither `href` nor `mediaSrc` -- both of which hold what was on the
+      // element -- and every Discord attachment fell to tier 3, the tier this
+      // file documents as the fragile one. `onMenuClicked` stamps the url it
+      // actually hands to `chrome.downloads.download` here; the original two
+      // fields are left alone so nothing that reads them changes.
+      if ((c.href && urls.has(c.href))
+        || (c.mediaSrc && urls.has(c.mediaSrc))
+        || (c.downloadUrl && urls.has(c.downloadUrl))) {
         return { capture: c, tier: 1 };
       }
     }

--- a/scripts/dl-router/extension/route_core.js
+++ b/scripts/dl-router/extension/route_core.js
@@ -779,8 +779,15 @@ export function correlateCapture(item, captures, opts = {}) {
       // neither `href` nor `mediaSrc` -- both of which hold what was on the
       // element -- and every Discord attachment fell to tier 3, the tier this
       // file documents as the fragile one. `onMenuClicked` stamps the url it
-      // actually hands to `chrome.downloads.download` here; the original two
-      // fields are left alone so nothing that reads them changes.
+      // resolved here; the original two fields are left alone so nothing that
+      // reads them changes.
+      //
+      // Precisely, because "the url it downloads" is wider than the code: the
+      // stamp runs BEFORE the streaming branch. On the ordinary path that url
+      // does go to `chrome.downloads.download`; for a manifest it goes to the
+      // sidecar's /fetch instead and no DownloadItem is ever created, so the
+      // stamp is inert there rather than wrong. Do not read this as "always a
+      // download".
       if ((c.href && urls.has(c.href))
         || (c.mediaSrc && urls.has(c.mediaSrc))
         || (c.downloadUrl && urls.has(c.downloadUrl))) {

--- a/scripts/dl-router/extension/route_core.js
+++ b/scripts/dl-router/extension/route_core.js
@@ -784,10 +784,18 @@ export function correlateCapture(item, captures, opts = {}) {
       //
       // Precisely, because "the url it downloads" is wider than the code: the
       // stamp runs BEFORE the streaming branch. On the ordinary path that url
-      // does go to `chrome.downloads.download`; for a manifest it goes to the
-      // sidecar's /fetch instead and no DownloadItem is ever created, so the
-      // stamp is inert there rather than wrong. Do not read this as "always a
-      // download".
+      // goes to `chrome.downloads.download`; for a manifest it goes to the
+      // sidecar's /fetch instead and no DownloadItem is ever created.
+      //
+      // THE STAMP IS DECISIVE ON THAT PATH TOO -- do not read "no
+      // DownloadItem" as "no effect". `startFetch` runs its OWN
+      // `correlateCapture` on the same url, and this clause is what binds it.
+      // A stamp also implies the rewrite fired, which implies a cdn attachment
+      // target, which implies `directFile` -- so `streaming` reduces to
+      // `manifest` there, and the fetch correlates at tier 1 against the
+      // capture just stamped. Moving the stamp below the streaming branch, or
+      // dropping this clause as download-only, silently demotes that fetch to
+      // tier 2/3.
       if ((c.href && urls.has(c.href))
         || (c.mediaSrc && urls.has(c.mediaSrc))
         || (c.downloadUrl && urls.has(c.downloadUrl))) {

--- a/scripts/dl-router/extension/service_worker.js
+++ b/scripts/dl-router/extension/service_worker.js
@@ -296,6 +296,35 @@ export function recordCapture(payload, sender) {
   }
 }
 
+/**
+ * Record, on the capture the click came from, the url actually being
+ * downloaded -- so `correlateCapture` tier 1 can still bind them when the two
+ * differ. Returns the capture it stamped, or null.
+ *
+ * IT MATCHES ON `srcUrl`, NOT ON RECENCY, and that is the entire value.
+ * Taking "the newest capture" here would reproduce the tier-3 defect this
+ * exists to remove: in a multi-image message the newest capture is whichever
+ * image the pointer crossed last, which is frequently NOT the one whose menu
+ * was clicked. Matching the clicked element's own src is what makes the
+ * binding deterministic.
+ *
+ * Newest-first among EQUAL matches, because one url can legitimately appear
+ * twice (the same image posted in two messages, or a re-render); the most
+ * recent right-click is the one being served.
+ */
+function stampDownloadUrl(srcUrl, downloadUrl) {
+  if (!srcUrl || !downloadUrl) return null;
+  const list = state.captures;
+  for (let i = list.length - 1; i >= 0; i--) {
+    const c = list[i];
+    if (c.href === srcUrl || c.mediaSrc === srcUrl) {
+      c.downloadUrl = downloadUrl;
+      return c;
+    }
+  }
+  return null;
+}
+
 // --- the pending registry, and why it is PERSISTED -------------------------- //
 /**
  * Write the durable copy. Fire-and-forget everywhere: a failed write costs a
@@ -1401,6 +1430,16 @@ export async function onMenuClicked(info, tab) {
   // on Discord an image's src is a downscaled webp from the resizing proxy.
   const target = preferOriginalUrl(info.srcUrl, info.linkUrl) || info.pageUrl;
   if (!isHttpUrl(target)) return;
+  // KEEP TIER 1 REACHABLE. When the line above rewrote the url, the one we
+  // are about to download is a url the PAGE NEVER SERVED, so the capture taken
+  // on this right-click -- whose `href`/`mediaSrc` hold the element's own src
+  // -- can no longer be matched by `correlateCapture`'s exact-url tier, and
+  // every such download silently falls to tier 3 (most recent capture on the
+  // active tab). In a multi-image message that binds a download to a SIBLING
+  // image's context. Stamping the outgoing url onto the capture it came from
+  // restores the deterministic binding; same trick, and the same reason, as
+  // `playerDownload` synthesising a capture around its media url.
+  if (target !== info.srcUrl) stampDownloadUrl(info.srcUrl, target);
   // A MANIFEST IS ALWAYS A STREAM, including one served from Discord. This
   // test stays OUTSIDE the bypass below on purpose: an `.m3u8` has no single
   // file to save, so letting the bypass reach it would download a ~200-byte

--- a/scripts/dl-router/tests/identity.test.mjs
+++ b/scripts/dl-router/tests/identity.test.mjs
@@ -11,7 +11,8 @@ import {
   carryReferrer, discordAliasKey, discordChannelId, discordSourceKey, hostOf,
   identitySignals,
   kindOf,
-  localContext, localDecide, preferOriginalUrl, subjectPhrases, threadAliasKey,
+  localContext, localDecide, originalFromPreview, preferOriginalUrl,
+  subjectPhrases, threadAliasKey,
   threadSlug,
   titleSubject,
 } from "../extension/route_core.js";
@@ -169,9 +170,15 @@ test("a proxy thumbnail is swapped for the original behind it", () => {
 test("a link to a DIFFERENT asset is never substituted", () => {
   // The whole point of comparing paths: a link that merely wraps an image is
   // not evidence that it is the same thing.
+  //
+  // The result is the CLICKED image's own original, not the link's asset and
+  // not the clicked thumbnail either. This is the live mosaic shape -- a
+  // multi-image message, where the only anchor on offer belongs to a sibling
+  // image -- so `z.png` must not win, and `a.png`'s thumbnail is not the best
+  // answer available for `a.png`.
   const elsewhere
     = `https://cdn.discordapp.com/attachments/${CHANNEL}/222222222222222222/z.png`;
-  assert.equal(preferOriginalUrl(PREVIEW, elsewhere), PREVIEW);
+  assert.equal(preferOriginalUrl(PREVIEW, elsewhere), ORIGINAL);
 });
 
 test("a non-Discord pair is left exactly alone", () => {
@@ -193,8 +200,62 @@ test("a video's own src survives -- there is nothing better to swap to", () => {
 
 test("either URL missing degrades to the other, never to empty", () => {
   assert.equal(preferOriginalUrl("", ORIGINAL), ORIGINAL);
-  assert.equal(preferOriginalUrl(PREVIEW, ""), PREVIEW);
+  // No link: the rewrite is the whole answer, and it is the ORIGINAL. This
+  // assertion used to read `PREVIEW`, which was correct about the code and
+  // wrong about production -- see the next block.
+  assert.equal(preferOriginalUrl(PREVIEW, ""), ORIGINAL);
   assert.equal(preferOriginalUrl("", ""), "");
+});
+
+// --- the seam: Chrome never supplies `linkUrl` on a Discord image ----------- //
+// MEASURED 2026-09-03 against the live client, 3 attachments / 2 channels / 2
+// message shapes: an image attachment has ZERO ancestor <a> elements, so
+// `info.linkUrl` is absent on every real right-click and the swap above cannot
+// fire. These pin the branch that ACTUALLY runs. Red before the rewrite
+// landed: the pre-change function returned `srcUrl` here, i.e. the thumbnail.
+
+test("with no link at all, a proxy attachment still yields the original", () => {
+  assert.equal(
+    preferOriginalUrl(`${PREVIEW}?ex=1&is=2&hm=3&format=webp&width=550&height=733`
+      + "&quality=lossless", ""),
+    `${ORIGINAL}?ex=1&is=2&hm=3`);
+});
+
+test("the signature is carried across the host swap, the resize knobs are not",
+  () => {
+    // Not cosmetic: `ex`/`is`/`hm` authorise the fetch. Measured identical on
+    // both hosts for one asset; stripping them was the negative control and it
+    // failed to load.
+    const out = new URL(originalFromPreview(
+      `${PREVIEW}?ex=aa&is=bb&hm=cc&format=webp&width=550`));
+    assert.equal(out.host, "cdn.discordapp.com");
+    assert.deepEqual([...out.searchParams.keys()].sort(), ["ex", "hm", "is"]);
+    assert.equal(out.searchParams.get("hm"), "cc");
+  });
+
+test("a stray empty-named parameter is dropped too", () => {
+  // A live proxy URL carried one (Discord emits a bare `&`). The measured
+  // rewrite dropped it, so this keeps the output byte-identical to what was
+  // probed rather than merely equivalent.
+  assert.equal(originalFromPreview(`${PREVIEW}?&ex=1&width=550`),
+    `${ORIGINAL}?ex=1`);
+});
+
+test("an avatar with no link is left alone -- the guard is REACHABLE", () => {
+  // The rewrite must not fire on every proxy-host URL, and this case reaches
+  // the guard by a path no earlier check rejects: `linkUrl` absent, proxy
+  // host, but not an attachment.
+  const av = `https://media.discordapp.net/avatars/${CHANNEL}/a.png?size=128`;
+  assert.equal(preferOriginalUrl(av, ""), av);
+  assert.equal(originalFromPreview(av), av);
+});
+
+test("originalFromPreview passes through anything it does not own", () => {
+  assert.equal(originalFromPreview("https://example-site.test/a.png?width=1"),
+    "https://example-site.test/a.png?width=1");
+  assert.equal(originalFromPreview(ORIGINAL), ORIGINAL);
+  assert.equal(originalFromPreview("not a url"), "not a url");
+  assert.equal(originalFromPreview(""), "");
 });
 
 test("a Discord attachment yields a site-scoped channel identity", () => {

--- a/scripts/dl-router/tests/identity.test.mjs
+++ b/scripts/dl-router/tests/identity.test.mjs
@@ -285,6 +285,18 @@ test("an avatar with no link is left alone -- the guard is REACHABLE", () => {
   assert.equal(originalFromPreview(av), av);
 });
 
+test("an ORIGIN-host attachment keeps its query -- the preview-host guard", () => {
+  // Pins the host guard, which survived round 1's sweep unkilled. The reason
+  // it was waved off was wrong in mechanism: DISCORD_CDN_HOSTS holds BOTH
+  // hosts, so `discordChannelId` accepts an origin-host attachment too, and
+  // without the host check this would have its resize knobs stripped -- a URL
+  // rewritten for no reason. Inert today only because origin URLs are not
+  // observed carrying those knobs, and "inert today" is exactly what a guard
+  // is for.
+  assert.equal(originalFromPreview(`${ORIGINAL}?ex=1&width=550`),
+    `${ORIGINAL}?ex=1&width=550`);
+});
+
 test("originalFromPreview passes through anything it does not own", () => {
   assert.equal(originalFromPreview("https://example-site.test/a.png?width=1"),
     "https://example-site.test/a.png?width=1");

--- a/scripts/dl-router/tests/identity.test.mjs
+++ b/scripts/dl-router/tests/identity.test.mjs
@@ -233,13 +233,48 @@ test("the signature is carried across the host swap, the resize knobs are not",
     assert.equal(out.searchParams.get("hm"), "cc");
   });
 
-test("a stray empty-named parameter is dropped too", () => {
-  // A live proxy URL carried one (Discord emits a bare `&`). The measured
-  // rewrite dropped it, so this keeps the output byte-identical to what was
-  // probed rather than merely equivalent.
+test("a bare `&` is dropped -- by re-serialisation, NOT by the `\"\"` entry", () => {
+  // This test used to be named for the `""` entry in the resize list and was
+  // offered as that entry's coverage. It is not: the urlencoded parser SKIPS
+  // empty sequences, so `?&ex=1` never produces an empty-named pair and this
+  // passes with `""` removed from the list entirely. Kept, renamed to say what
+  // it actually pins -- that the rewrite re-serialises the query -- so nobody
+  // reads it as covering the line below.
   assert.equal(originalFromPreview(`${PREVIEW}?&ex=1&width=550`),
     `${ORIGINAL}?ex=1`);
 });
+
+test("an empty-NAMED parameter (`?=value`) is dropped -- the `\"\"` entry's own case",
+  () => {
+    // The shape the parser DOES keep: `?=v` yields a real ["", "v"] pair.
+    // Removing `""` from DISCORD_PREVIEW_RESIZE_PARAMS must fail HERE, which
+    // is what makes that entry mutation-visible; before this test it survived
+    // deletion against a fully green suite.
+    assert.equal(originalFromPreview(`${PREVIEW}?=junk&ex=1&width=550`),
+      `${ORIGINAL}?ex=1`);
+  });
+
+test("a proxy src with a link to a DIFFERENT SITE still yields the original", () => {
+  // The reachable exit that no test covered: srcUrl on the proxy host WITH a
+  // linkUrl that is not the origin host -- any page that hotlinks an
+  // attachment inside an anchor to somewhere else. Reverting that exit to a
+  // bare `srcUrl` passed the whole suite before this existed.
+  assert.equal(
+    preferOriginalUrl(`${PREVIEW}?ex=1&is=2&hm=3&width=550`,
+      "https://example-site.test/page"),
+    `${ORIGINAL}?ex=1&is=2&hm=3`);
+});
+
+test("a proxy src paired with a NON-ATTACHMENT discord link yields the original",
+  () => {
+    // The other uncovered exit: both hosts are right, but the link is not an
+    // attachment (an avatar), so the pair-guard rejects it. The clicked
+    // image's own original is still the best answer available.
+    assert.equal(
+      preferOriginalUrl(`${PREVIEW}?ex=1&width=550`,
+        `https://cdn.discordapp.com/avatars/${CHANNEL}/a.png`),
+      `${ORIGINAL}?ex=1`);
+  });
 
 test("an avatar with no link is left alone -- the guard is REACHABLE", () => {
   // The rewrite must not fire on every proxy-host URL, and this case reaches

--- a/scripts/dl-router/tests/route_core.test.mjs
+++ b/scripts/dl-router/tests/route_core.test.mjs
@@ -102,6 +102,50 @@ test("tier 1 also matches a captured media source", () => {
   assert.equal(out.tier, 1);
 });
 
+test("tier 1 also matches the url the extension REWROTE the download to", () => {
+  // The regression this closes: `preferOriginalUrl` downloads a url the page
+  // never served, so `href`/`mediaSrc` -- which hold the element's own src --
+  // cannot match, and every rewritten Discord download fell to tier 3, the
+  // tier this file documents as the fragile one. Without `downloadUrl` in the
+  // tier-1 set this is tier 0 here (no referrer, no active tab).
+  const captures = [{
+    href: "https://media.example-cdn.test/a.png?width=550",
+    mediaSrc: "https://media.example-cdn.test/a.png?width=550",
+    downloadUrl: "https://origin.example-cdn.test/a.png",
+    pageUrl: "p", ts: 10,
+  }];
+  const out = correlateCapture(
+    { url: "https://origin.example-cdn.test/a.png" }, captures, { now: 20 });
+  assert.equal(out.tier, 1);
+  assert.equal(out.capture.pageUrl, "p");
+});
+
+test("a rewritten download binds to ITS OWN capture, not the most recent one",
+  () => {
+    // The concrete multi-image failure: two images clicked inside the capture
+    // window. Under tier 3 the NEWEST capture wins, so the first image's
+    // routing payload would carry the second image's context. Tier 1 on
+    // `downloadUrl` binds each download to the element it came from -- note
+    // the correct answer here is the OLDER capture.
+    const captures = [
+      {
+        href: "https://media.example-cdn.test/a.png?width=550",
+        downloadUrl: "https://origin.example-cdn.test/a.png",
+        pageUrl: "msg-A", ts: 10,
+      },
+      {
+        href: "https://media.example-cdn.test/b.png?width=550",
+        downloadUrl: "https://origin.example-cdn.test/b.png",
+        pageUrl: "msg-B", ts: 99,
+      },
+    ];
+    const out = correlateCapture(
+      { url: "https://origin.example-cdn.test/a.png" }, captures,
+      { now: 100, activeTabId: 7 });
+    assert.equal(out.tier, 1);
+    assert.equal(out.capture.pageUrl, "msg-A");
+  });
+
 test("tier 2: referrer matches a captured page URL", () => {
   const captures = [{ href: "x", pageUrl: "https://example-site.test/v/1", ts: 5 }];
   const out = correlateCapture(

--- a/scripts/dl-router/tests/service_worker.test.mjs
+++ b/scripts/dl-router/tests/service_worker.test.mjs
@@ -525,7 +525,7 @@ test("the menu saves the original, not the proxy thumbnail in the src", async ()
   // This test SUPPLIES a `linkUrl`, which is why it kept passing while the
   // feature was inert: measured, a Discord image has no ancestor <a>, so a
   // real right-click never carries one -- the case below this one. Keep both:
-  // this exercise the swap, which is still correct wherever a browser does
+  // these exercise the swap, which is still correct wherever a browser does
   // supply a link. The comment here used to say the original sits "on the
   // wrapping <a href>", which is false and is why the swap looked sufficient.
   reset();

--- a/scripts/dl-router/tests/service_worker.test.mjs
+++ b/scripts/dl-router/tests/service_worker.test.mjs
@@ -561,6 +561,54 @@ test("the menu saves the original even when Chrome offers NO link", async () => 
   });
 });
 
+test("a rewritten menu download stamps the CLICKED capture, not the newest",
+  async () => {
+    // Pins the stamp's matching rule. Two images captured in one message; the
+    // OLDER one is right-clicked. Taking "the most recent capture" here would
+    // reproduce the exact tier-3 defect the stamp exists to remove, and would
+    // still leave every assertion about "a capture was stamped" green -- so
+    // this asserts WHICH capture carries the url.
+    reset();
+    const ch = "119283746551234567";
+    const proxyA = `https://media.discordapp.net/attachments/${ch}`
+      + "/998877665544332211/a.png?ex=1&is=2&hm=3&format=webp&width=550";
+    const proxyB = `https://media.discordapp.net/attachments/${ch}`
+      + "/998877665544332299/b.png?ex=1&is=2&hm=3&format=webp&width=550";
+    SW.state.captures = [
+      { href: proxyA, mediaSrc: proxyA, pageUrl: "msg-A", ts: 10 },
+      { href: proxyB, mediaSrc: proxyB, pageUrl: "msg-B", ts: 99 },
+    ];
+    await SW.onMenuClicked({
+      menuItemId: SW.MENU_ID,
+      mediaType: "image",
+      srcUrl: proxyA,
+      pageUrl: "https://discord.com/channels/1/2",
+    }, {});
+
+    const expected = `https://cdn.discordapp.com/attachments/${ch}`
+      + "/998877665544332211/a.png?ex=1&is=2&hm=3";
+    assert.deepEqual(calls.downloads[0], { url: expected });
+    // The clicked capture carries it...
+    assert.equal(SW.state.captures[0].downloadUrl, expected);
+    // ...and the newer, unrelated one is untouched.
+    assert.equal(SW.state.captures[1].downloadUrl, undefined);
+  });
+
+test("an UNREWRITTEN menu download stamps nothing", async () => {
+  // The stamp is gated on the url having actually changed. A plain link
+  // download already matches tier 1 on `href`; writing a redundant field
+  // would be silent state nobody asked for.
+  reset();
+  SW.state.captures = [{
+    href: "https://example-site.test/f.mp4",
+    mediaSrc: "https://example-site.test/f.mp4",
+    pageUrl: "p", ts: 10,
+  }];
+  await SW.onMenuClicked({ menuItemId: SW.MENU_ID,
+    srcUrl: "https://example-site.test/f.mp4" }, {});
+  assert.equal(SW.state.captures[0].downloadUrl, undefined);
+});
+
 test("a Discord video is downloaded directly, never handed to yt-dlp", async () => {
   // `mediaType === "video"` exists for players whose src is a `blob:`. A CDN
   // attachment is a direct file, so that clause would send yt-dlp at

--- a/scripts/dl-router/tests/service_worker.test.mjs
+++ b/scripts/dl-router/tests/service_worker.test.mjs
@@ -518,9 +518,16 @@ test("the menu downloads a plain link", async () => {
 });
 
 test("the menu saves the original, not the proxy thumbnail in the src", async () => {
-  // Discord puts a downscaled webp from its resizing proxy in the <img src>
-  // and the posted file on the wrapping <a href>. Taking `srcUrl` because it
-  // is listed first saves the thumbnail and silently calls it the download.
+  // Discord puts a downscaled webp from its resizing proxy in the <img src>.
+  // Taking `srcUrl` because it is listed first saves the thumbnail and
+  // silently calls it the download.
+  //
+  // This test SUPPLIES a `linkUrl`, which is why it kept passing while the
+  // feature was inert: measured, a Discord image has no ancestor <a>, so a
+  // real right-click never carries one -- the case below this one. Keep both:
+  // this exercise the swap, which is still correct wherever a browser does
+  // supply a link. The comment here used to say the original sits "on the
+  // wrapping <a href>", which is false and is why the swap looked sufficient.
   reset();
   const ch = "119283746551234567";
   const original

--- a/scripts/dl-router/tests/service_worker.test.mjs
+++ b/scripts/dl-router/tests/service_worker.test.mjs
@@ -526,11 +526,17 @@ test("the menu saves the original, not the proxy thumbnail in the src", async ()
   // feature was inert: measured, a Discord image has no ancestor <a>, so a
   // real right-click never carries one -- the case below this one.
   //
-  // Keep both, and keep them for DIFFERENT reasons: THIS test is the only one
-  // that reaches the swap at all, because the one below supplies no `linkUrl`
-  // and therefore cannot. Deleting this one as redundant would remove the
-  // swap branch's only coverage. The swap is still correct wherever a browser
-  // does supply a link, which is why it stays.
+  // Keep both, and keep them for DIFFERENT reasons: of the two menu tests IN
+  // THIS FILE, only THIS one reaches the swap, because the one below supplies
+  // no `linkUrl` and therefore cannot. The swap is still correct wherever a
+  // browser does supply a link, which is why it stays.
+  //
+  // Scoped to this file deliberately. The swap's UNIT coverage lives in
+  // `identity.test.mjs` ("a proxy thumbnail is swapped for the original behind
+  // it"), which predates this PR and kills the swap mutant on its own; this
+  // one covers the same branch through the `onMenuClicked` seam. Two levels,
+  // not a duplicate -- an earlier version of this comment claimed this was the
+  // swap's ONLY coverage, which would have justified deleting the unit test.
   //
   // The comment here used to say the original sits "on the wrapping
   // <a href>", which is false and is why the swap looked sufficient.

--- a/scripts/dl-router/tests/service_worker.test.mjs
+++ b/scripts/dl-router/tests/service_worker.test.mjs
@@ -536,6 +536,31 @@ test("the menu saves the original, not the proxy thumbnail in the src", async ()
   assert.deepEqual(calls.downloads[0], { url: `${original}?ex=1&is=2&hm=3` });
 });
 
+test("the menu saves the original even when Chrome offers NO link", async () => {
+  // THE PRODUCTION PATH, and the one no test owned. MEASURED 2026-09-03: a
+  // Discord image attachment has no ancestor <a>, so `linkUrl` is absent on
+  // every real right-click -- the test above supplies one and therefore only
+  // ever exercised a branch the live client cannot reach. Both suites stayed
+  // green while the shipped feature was inert.
+  //
+  // Asserts the POSITIVE half (which url was downloaded), not merely that
+  // something happened: a menu test that only counts is vacuous, and this file
+  // has been bitten by that twice.
+  reset();
+  const ch = "119283746551234567";
+  await SW.onMenuClicked({
+    menuItemId: SW.MENU_ID,
+    mediaType: "image",
+    srcUrl: `https://media.discordapp.net/attachments/${ch}`
+      + "/998877665544332211/a.png?ex=1&is=2&hm=3&format=webp&width=550",
+    pageUrl: "https://discord.com/channels/1/2",
+  }, {});
+  assert.deepEqual(calls.downloads[0], {
+    url: `https://cdn.discordapp.com/attachments/${ch}`
+      + "/998877665544332211/a.png?ex=1&is=2&hm=3",
+  });
+});
+
 test("a Discord video is downloaded directly, never handed to yt-dlp", async () => {
   // `mediaType === "video"` exists for players whose src is a `blob:`. A CDN
   // attachment is a direct file, so that clause would send yt-dlp at

--- a/scripts/dl-router/tests/service_worker.test.mjs
+++ b/scripts/dl-router/tests/service_worker.test.mjs
@@ -524,10 +524,16 @@ test("the menu saves the original, not the proxy thumbnail in the src", async ()
   //
   // This test SUPPLIES a `linkUrl`, which is why it kept passing while the
   // feature was inert: measured, a Discord image has no ancestor <a>, so a
-  // real right-click never carries one -- the case below this one. Keep both:
-  // these exercise the swap, which is still correct wherever a browser does
-  // supply a link. The comment here used to say the original sits "on the
-  // wrapping <a href>", which is false and is why the swap looked sufficient.
+  // real right-click never carries one -- the case below this one.
+  //
+  // Keep both, and keep them for DIFFERENT reasons: THIS test is the only one
+  // that reaches the swap at all, because the one below supplies no `linkUrl`
+  // and therefore cannot. Deleting this one as redundant would remove the
+  // swap branch's only coverage. The swap is still correct wherever a browser
+  // does supply a link, which is why it stays.
+  //
+  // The comment here used to say the original sits "on the wrapping
+  // <a href>", which is false and is why the swap looked sufficient.
   reset();
   const ch = "119283746551234567";
   const original


### PR DESCRIPTION
`preferOriginalUrl` has been **inert in production since it shipped**. It reads `info.linkUrl`, which Chrome populates only from an **ancestor** `<a>` — and a Discord image attachment has none.

## Measured, against the live client

3 image attachments, 2 channels, 2 message shapes (single image + mosaic):

| | measured |
|---|---|
| `<img src>` host | `media.discordapp.net` — 3/3 |
| ancestor `<a>` around the image | **0 of 3** (`div[role=button].clickableWrapper`) |
| `cdn.discordapp.com` anchor in the message | 3/3, a **sibling at depth 9** |
| same pathname (unambiguous pairing) | true |
| `ex`/`hm`/`is` values across the two hosts | **byte-identical** |

So every real right-click lands on `if (!linkUrl) return srcUrl` and downloads the resized webp thumbnail — the defect #1110 set out to fix, still live for images. Every existing unit test supplied a `linkUrl`, so both suites stayed green over a feature that could not fire: the defect lived in the **seam**, not in either component.

## Why a rewrite, not a DOM read

A prior session eliminated host-rewriting because "the two hosts carry different query params". They do not — the proxy URL carries `ex`/`hm`/`is` **plus** the resize params. Probed from the page context of a live Discord tab, with both controls:

| | status |
|---|---|
| positive control — the message's own cdn anchor | 206 |
| **under test** — proxy url, host swapped, resize params dropped | **206** |
| negative control — same url, signature removed | network error |

That also closes the gap the handoff flagged as never probed: whether a cdn URL without a valid signature actually fails. It does.

Chosen over a content script, which would need a `discord.com` host permission and couple to Discord's hashed class names (they rotate every deploy). `originalFromPreview` is pure and rewrites only what `discordChannelId` recognises as an attachment, so an avatar or emoji on the same proxy host comes back untouched — pinned by a test that reaches that guard by a path no earlier check rejects.

## Behaviour changes, both deliberate

Two existing assertions move toward the clicked image's own original: the no-link case, and the mismatched-path case (the live mosaic shape, where the only anchor on offer belongs to a sibling image).

## Test matrix

The production path is pinned at the service-worker seam, asserting **which URL** was downloaded (not merely that something happened):

- **red** at `aba48864` — downloads `media.discordapp.net/...?format=webp&width=550`
- **green** at HEAD — downloads `cdn.discordapp.com/...?ex=1&is=2&hm=3`

## Gate, both tiers, base `a7dac5bd`

- `nix build .#checks.x86_64-linux.nodetests` — **rc 0**
- `nix build .#checks.x86_64-linux.pytests` — **rc 0** (built one at a time)
- dev-host `gate.sh` node tier — 1455 pass / 0 fail (dl-router 543, was 537)

One earlier pytests run went red on `test_six_writers_with_a_tiny_busy_timeout_still_land_every_row`. Attributed to load, not to this change: the whole 1020-test dl-router target took **391 s** in that run against **115 s** at base — load inflates every test, an assertion inflates one — the test is itself a deliberate 5 ms busy-timeout load reproduction, this diff contains no Python, and a genuine re-run was green.

The dev-host pytest tier also shows 3 failures; all 3 were confirmed to fail identically at base.

`manifest` 0.3.2 -> 0.3.3, because 0.3.2 was never actually loaded by the browser — so the outstanding restart check becomes "`brave://extensions` reads **0.3.3**".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BePLrAzQrg983BX2FSdEjR