### PR TITLE
feat(workhost): reach a dev host over whichever path is up, and say so

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1386,6 +1386,20 @@ in
   # `scripts/lib/` must not be deployed, same rule as opencode's `lib/`.
   home.file.".local/bin/cairn".source =
     config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/cairn";
+
+  # `workhost` — reach a dev host over whichever network path (LAN / nebula /
+  # tailscale) is actually up, reporting the state of all three every time. On
+  # PATH as a bare command because it is meant to stand in front of `ssh`, and
+  # is invoked from any cwd and from inside other repos.
+  #
+  # mkOutOfStoreSymlink, matching the CLIs above. It does not reach into
+  # `scripts/lib/` today, so the hard `__file__`-resolution reason that makes it
+  # mandatory for `cairn` does not yet apply — but the address table in it is
+  # operational state that gets corrected the moment a path moves, and a store
+  # copy would leave the tree edited and the command stale until the next
+  # `home-manager switch`. Symlinking keeps the checkout authoritative.
+  home.file.".local/bin/workhost".source =
+    config.lib.file.mkOutOfStoreSymlink "${workspace}/devrc/scripts/workhost";
   # Claude Code hooks managed here (the script only — the settings.json
   # registration is per-host/unmanaged, as for bash-guard.py above, whose script
   # is likewise managed now). audit-pr-nudge fires

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,7 +84,7 @@ Click actions for those blocks:
 |---|---|
 | `airvpn-updown` | tunnel PostUp/PostDown helper — the killswitch + split-tunnel |
 | `airvpn-sudo` | privileged helper for the AirVPN block (via a NOPASSWD sudo rule) |
-| `workhost` | reach a dev host over whichever path (LAN / nebula / tailscale) is up; probes all three in parallel every run and reports `ok` / `unreachable` / `not-configured` per path |
+| `workhost` | reach a dev host over whichever path (LAN / nebula / tailscale) is up; probes all three in parallel every run and reports `ok` / `unreachable` / `untrusted-key` / `not-configured` per path. `untrusted-key` means ssh refused the host key for the `HostKeyAlias`, not that the box is down — `workhost ssh --accept-key` trusts it once, interactively |
 
 ## Media
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,6 +84,7 @@ Click actions for those blocks:
 |---|---|
 | `airvpn-updown` | tunnel PostUp/PostDown helper — the killswitch + split-tunnel |
 | `airvpn-sudo` | privileged helper for the AirVPN block (via a NOPASSWD sudo rule) |
+| `workhost` | reach a dev host over whichever path (LAN / nebula / tailscale) is up; probes all three in parallel every run and reports `ok` / `unreachable` / `not-configured` per path |
 
 ## Media
 

--- a/scripts/tests/mutants-workhost.sh
+++ b/scripts/tests/mutants-workhost.sh
@@ -52,23 +52,24 @@ restore() { cp -a "$T/script.orig" "$SCRIPT"; }
 
 FAILURES=0
 ROWS=0
-# 89 tests collect today; one is deselected below. The floor sits well under
-# that so it catches a suite that failed to collect, not routine growth.
-MIN_TESTS=80
+# 139 tests collect today, NONE deselected. The floor sits well under that so it
+# catches a suite that failed to collect, not routine growth. (This number is
+# re-derived, not remembered: `python3 -m pytest --collect-only -q` on the suite.)
+MIN_TESTS=125
 
-# `test_workhost_is_tracked_by_git` asserts about the REAL repository, so it
-# cannot pass against a .git-less copy. It is a delivery guard, not a behaviour
-# guard, and no mutant below targets it — excluding it cannot hide a killer.
-# Nodeids are reported RELATIVE to rootdir, so the deselect must be relative
-# too — an absolute one silently matches nothing and the row reads as a red
-# baseline rather than as a filter that failed to apply.
+# 🔴 No deselect. An earlier version of this file excluded
+# `test_workhost_is_tracked_by_git` and justified it with "it asserts about the
+# REAL repository, so it cannot pass against a .git-less copy". That stopped
+# being true at 041cd4db, which gave the test two arms — with `.git` it asks git,
+# without `.git` it asserts the file is present at all, which is the flake's
+# tracked-files-only copy proving the same thing. It passes here, so the
+# exclusion is gone rather than left carrying a stale reason.
 RELSUITE="scripts/tests/test_workhost.py"
-DESELECT="--deselect $RELSUITE::test_workhost_is_tracked_by_git"
 
 failing() {
   local out n f total
   out="$(cd "$ROOT" && PYTHONDONTWRITEBYTECODE=1 python3 -m pytest "$RELSUITE" \
-    $DESELECT -q --no-header --tb=no -p no:cacheprovider 2>/dev/null)"
+    -q --no-header --tb=no -p no:cacheprovider 2>/dev/null)"
   # Read the CONTENT, never an exit code: count the runner's own result lines.
   n="$(sed -n 's/^\([0-9]*\) passed.*/\1/p;s/^[0-9]* failed, \([0-9]*\) passed.*/\1/p' <<<"$out" | tail -1)"
   f="$(sed -n 's/^\([0-9]*\) failed.*/\1/p' <<<"$out" | tail -1)"
@@ -154,7 +155,7 @@ printf '\n== path selection and precedence ==\n'
 run 'precedence-reversed'       test_best_available_path_is_selected \
   's@^PATH_ORDER = ("lan", "nebula", "tailscale")@PATH_ORDER = ("tailscale", "nebula", "lan")@'
 run 'forced-path-falls-back'    test_forcing_a_down_path_fails_and_does_not_fall_back \
-  's@^        if result.state != OK:@        if False:@'
+  's@^        if result.state not in acceptable:@        if False:@'
 
 printf '\n== running ON the target must exec locally ==\n'
 run 'local-detection-disabled'  test_runs_locally_when_the_nebula_address_is_ours \
@@ -189,6 +190,72 @@ run 'report-pollutes-stdout'    test_the_report_goes_to_stderr_so_stdout_stays_p
   's@report_stream = sys.stdout if reporting_verb else sys.stderr@report_stream = sys.stdout@'
 run 'json-drops-local-field'    test_json_shape_field_by_field \
   's@^        "local": local,$@@'
+
+printf '\n== the fourth state: an untrusted host key is not an unreachable host ==\n'
+run 'untrusted-key-collapsed'   test_untrusted_key_is_its_own_json_value \
+  's@^UNTRUSTED_KEY = "untrusted-key"@UNTRUSTED_KEY = "unreachable"@'
+run 'hostkey-missing-unclassified' test_a_host_key_refusal_is_untrusted_key_not_unreachable \
+  's@^    if HOSTKEY_MISSING_MARKER in stderr:@    if False:@'
+# The OTHER direction: ssh exits 255 for auth failure too, so a classifier that
+# calls everything a host-key problem is just the old conflation reversed.
+run 'auth-called-a-key-problem'  test_an_auth_failure_is_unreachable_not_untrusted_key \
+  's@^    return UNREACHABLE, None, False@    return UNTRUSTED_KEY, "host key for alias %r not in known_hosts", False@'
+run 'changed-key-loses-its-detail' test_a_changed_host_key_is_untrusted_key_with_its_own_detail \
+  's@^            "host key for alias %r CHANGED since it was trusted",@            "host key for alias %r not in known_hosts",@'
+run 'probe-gains-tofu'          test_the_probe_never_enables_tofu \
+  's@\["ssh", "-o", "BatchMode=yes"\]@["ssh", "-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new"]@'
+
+printf '\n== the report names the cause and the way out ==\n'
+run 'advice-block-silenced'     test_the_report_names_the_cause_and_the_way_out \
+  's@^    untrusted = \[r for r in results if r.state == UNTRUSTED_KEY\]@    untrusted = []@'
+run 'advice-fires-when-fine'    test_no_advice_is_printed_when_a_path_is_actually_usable \
+  's@^    if chosen is not None:@    if False:@'
+run 'changed-key-offered-tofu'  test_a_changed_key_is_not_offered_the_accept_key_shortcut \
+  's@^    unseen = \[r for r in untrusted if not r.key_changed\]@    unseen = list(untrusted)@'
+
+printf '\n== the bootstrap escape hatch, and its limits ==\n'
+run 'accept-key-inert'          test_accept_key_lets_an_untrusted_path_be_used \
+  's@^    acceptable = (OK, UNTRUSTED_KEY) if accept_key else (OK,)@    acceptable = (OK,)@'
+run 'accept-key-too-wide'       test_accept_key_does_not_make_an_unreachable_path_usable \
+  's@^    acceptable = (OK, UNTRUSTED_KEY) if accept_key else (OK,)@    acceptable = (OK, UNTRUSTED_KEY, UNREACHABLE) if accept_key else (OK,)@'
+
+printf '\n== a forward that reports success must actually forward ==\n'
+run 'forward-bind-failure-ok'   test_forward_builds_a_dash_L_tunnel \
+  's@return cmd + FORWARD_FAILURE_OPTS + opts + \[address\]@return cmd + opts + [address]@'
+run 'kubectl-bind-failure-ok'   test_the_kubectl_tunnel_also_exits_on_a_failed_bind \
+  's@^            + FORWARD_FAILURE_OPTS$@            + []@'
+run 'forward-spec-unvalidated'  test_forward_with_no_spec_is_refused_rather_than_forwarding_nothing \
+  's@^        validate_forward_spec(spec)@        pass@'
+run 'forward-shape-unchecked'   test_forward_rejects_a_spec_that_is_not_a_port_forward \
+  's@^        if len(parts) != 3 or not parts\[0\].isdigit() or not parts\[2\].isdigit():@        if False:@'
+run 'forward-rejects-bind-addr' test_forward_accepts_an_explicit_bind_address \
+  's@^        if len(parts) == 4:@        if False:@'
+
+printf '\n== the wrong machine is worse than no machine ==\n'
+run 'lan-fallback-unconditional' test_the_lan_address_alone_does_not_prove_we_are_the_target \
+  's@^    if host.lan and not host.nebula and host.lan in local:@    if host.lan and host.lan in local:@'
+run 'lan-fallback-removed'      test_the_lan_address_is_accepted_when_the_host_has_no_nebula_address \
+  's@^    if host.lan and not host.nebula and host.lan in local:@    if False:@'
+
+printf '\n== crashing is not reporting ==\n'
+run 'local-kubectl-crash'       test_kubectl_without_a_local_kubectl_exits_127_not_a_traceback \
+  's@^            return 127$@            raise@'
+run 'tailscale-non-object'      test_a_non_object_tailscale_status_is_not_configured_not_a_crash \
+  's@^    if not isinstance(status, dict):@    if False:@'
+run 'missing-ssh-blamed-on-net' test_no_ssh_binary_is_not_configured_not_unreachable \
+  's@^            path, NOT_CONFIGURED, address, "no ssh binary on PATH", elapsed()@            path, UNREACHABLE, address, "no ssh binary on PATH", elapsed()@'
+run 'env-timeout-unguarded'     test_a_junk_workhost_timeout_warns_and_still_runs \
+  's@^    except (TypeError, ValueError):@    except ():@'
+run 'env-timeout-always-default' test_a_valid_workhost_timeout_is_still_honoured \
+  's@^    return value$@    return default@'
+run 'timeout-help-hides-the-var' test_the_timeout_flag_documents_the_env_var \
+  's@(default: %g, or \$WORKHOST_TIMEOUT)@(default: %g)@'
+
+printf '\n== --dry-run prints what actually runs ==\n'
+run 'dry-run-space-joined'      test_dry_run_quotes_arguments_containing_spaces \
+  's@^        sys.stdout.write(shlex.join(cmd) + "\\n")$@        sys.stdout.write(" ".join(cmd) + "\\n")@'
+run 'kubectl-hides-placeholder' test_the_kubectl_dry_run_admits_its_port_is_a_placeholder \
+  's@is a placeholder@is chosen later@'
 
 printf '\n== the positive control: a mutant already known to be covered ==\n'
 run 'already-caught-control'    test_no_path_reachable_exits_3 \

--- a/scripts/tests/mutants-workhost.sh
+++ b/scripts/tests/mutants-workhost.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Mutation battery for `scripts/workhost` — every guard in
+# `scripts/tests/test_workhost.py` broken on purpose, so the claim "these tests
+# would have caught it" can be RE-DERIVED rather than believed.
+#
+#   bash scripts/tests/mutants-workhost.sh          # exit 0 only if ALL rows ok
+#
+# 🔴 IT NEVER TOUCHES YOUR WORKING TREE. The target is copied into a mktemp -d
+#    and mutated there; a final sha256 check proves the copy was restored.
+# 🔴 EVERY MUTANT NAMES THE TEST THAT MUST KILL IT. Dying to a different test is
+#    a failure (WRONG-KILLER), because that means the guard you think covers the
+#    behaviour is not the one doing the work.
+# 🔴 EVERY MUTATION IS DIFFED BEFORE IT RUNS. A sed that silently matched
+#    nothing would score SURVIVED and read as a coverage hole that is not there.
+# 🔴 PYTHONDONTWRITEBYTECODE=1 IS LOAD-BEARING, NOT HYGIENE. CPython validates a
+#    cached module on source mtime-in-whole-SECONDS + size, so a same-length edit
+#    landing in the same second as the last import is invisible: the test imports
+#    the ORIGINAL bytecode and the mutant is scored SURVIVED WITHOUT EVER HAVING
+#    RUN. Every mutant here is applied by rewriting the file in place, so this
+#    trap is live.
+# 🔴 THREE CONTROLS, ALL MANDATORY:
+#      * the unmutated baseline must be GREEN, or the run aborts;
+#      * a MIN_TESTS floor, so a suite that never collected cannot read as clean;
+#      * a positive control (a mutant known to be covered) AND a SURVIVES control
+#        (a comment-only, behaviour-free edit that must kill nothing, proving the
+#        harness keys on behaviour rather than on text).
+#
+# SCOPE: this file is a claim about the mutants enumerated below and nothing
+# else. Add a row when you add a guard.
+set -uo pipefail
+CDPATH=
+D="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+SRC="$(cd "$D/../.." && pwd)"
+
+T="$(mktemp -d /tmp/workhost-mut-XXXXXX)"; trap 'rm -rf "$T"' EXIT
+ROOT="$T/tree"
+mkdir -p "$ROOT/scripts/tests" "$ROOT/nix"
+cp -a "$SRC/scripts/workhost"                "$ROOT/scripts/"     # cp -a keeps the exec bit
+cp -a "$SRC/scripts/testlib"                 "$ROOT/scripts/"
+cp -a "$SRC/scripts/tests/test_workhost.py"  "$ROOT/scripts/tests/"
+# The delivery test reads this file; copying it keeps the baseline green without
+# weakening the row set.
+cp -a "$SRC/nix/home.nix"                    "$ROOT/nix/"
+[ -e "$ROOT/.git" ] && { echo "🔴 the copy carries a .git — refusing to run"; exit 2; }
+find "$ROOT" -name __pycache__ -type d -prune -exec rm -rf {} + 2>/dev/null
+
+SCRIPT="$ROOT/scripts/workhost"
+SUITE="$ROOT/scripts/tests/test_workhost.py"
+cp -a "$SCRIPT" "$T/script.orig"
+ORIG_SHA="$(sha256sum "$T/script.orig" | cut -d' ' -f1)"
+restore() { cp -a "$T/script.orig" "$SCRIPT"; }
+
+FAILURES=0
+ROWS=0
+# 89 tests collect today; one is deselected below. The floor sits well under
+# that so it catches a suite that failed to collect, not routine growth.
+MIN_TESTS=80
+
+# `test_workhost_is_tracked_by_git` asserts about the REAL repository, so it
+# cannot pass against a .git-less copy. It is a delivery guard, not a behaviour
+# guard, and no mutant below targets it — excluding it cannot hide a killer.
+# Nodeids are reported RELATIVE to rootdir, so the deselect must be relative
+# too — an absolute one silently matches nothing and the row reads as a red
+# baseline rather than as a filter that failed to apply.
+RELSUITE="scripts/tests/test_workhost.py"
+DESELECT="--deselect $RELSUITE::test_workhost_is_tracked_by_git"
+
+failing() {
+  local out n f total
+  out="$(cd "$ROOT" && PYTHONDONTWRITEBYTECODE=1 python3 -m pytest "$RELSUITE" \
+    $DESELECT -q --no-header --tb=no -p no:cacheprovider 2>/dev/null)"
+  # Read the CONTENT, never an exit code: count the runner's own result lines.
+  n="$(sed -n 's/^\([0-9]*\) passed.*/\1/p;s/^[0-9]* failed, \([0-9]*\) passed.*/\1/p' <<<"$out" | tail -1)"
+  f="$(sed -n 's/^\([0-9]*\) failed.*/\1/p' <<<"$out" | tail -1)"
+  total=$(( ${n:-0} + ${f:-0} ))
+  if [ "$total" -lt "$MIN_TESTS" ]; then
+    echo "__HARNESS_BROKE__ only $total test(s) ran (floor $MIN_TESTS)"
+    return
+  fi
+  sed -n 's/^FAILED [^:]*::\([A-Za-z0-9_]*\).*/\1/p' <<<"$out" | sort -u
+}
+
+run() { # run <name> <expected killer | SURVIVES> <sed-expr>
+  local name="$1" expect="$2" expr="$3" got
+  ROWS=$((ROWS+1))
+  restore
+  sed "$expr" "$SCRIPT" > "$T/m"
+  if cmp -s "$T/m" "$SCRIPT"; then
+    printf '  🔴 %-34s MUTATION DID NOT APPLY (sed matched nothing)\n' "$name"
+    FAILURES=$((FAILURES+1)); restore; return
+  fi
+  cat "$T/m" > "$SCRIPT"          # NOT cp -a: that carried the wrong mode once
+  got="$(failing)"
+  restore
+
+  if grep -q '__HARNESS_BROKE__' <<<"$got"; then
+    printf '  🔴 %-34s HARNESS BROKE: %s\n' "$name" "$(tr '\n' ' ' <<<"$got")"
+    FAILURES=$((FAILURES+1)); return
+  fi
+
+  if [ "$expect" = "SURVIVES" ]; then
+    if [ -z "$got" ]; then
+      printf '  ok %-34s survived, as designed (behaviour-free edit)\n' "$name"
+    else
+      printf '  🔴 %-34s SURVIVES control KILLED by: %s\n' "$name" "$(tr '\n' ' ' <<<"$got")"
+      FAILURES=$((FAILURES+1))
+    fi
+    return
+  fi
+
+  if [ -z "$got" ]; then
+    printf '  🔴 %-34s SURVIVED — no test failed\n' "$name"
+    FAILURES=$((FAILURES+1)); return
+  fi
+  if grep -qx "$expect" <<<"$got"; then
+    printf '  ok %-34s killed by %s\n' "$name" "$expect"
+  else
+    printf '  🔴 %-34s WRONG-KILLER — died to: %s (wanted %s)\n' \
+      "$name" "$(tr '\n' ' ' <<<"$got")" "$expect"
+    FAILURES=$((FAILURES+1))
+  fi
+}
+
+printf 'mutating a COPY at %s (your worktree is untouched)\n' "$ROOT"
+printf 'baseline (must be empty): '
+b="$(failing)"
+if [ -z "$b" ]; then echo "clean"; else echo "🔴 ALREADY RED: $(tr '\n' ' ' <<<"$b")"; exit 1; fi
+
+printf '\n== known_hosts identity: the alias must be on every ssh-family call ==\n'
+run 'hostkeyalias-dropped'      test_host_key_alias_is_set_for_every_path_and_verb \
+  's@opts = \["-o", "HostKeyAlias=%s" % host.name\]@opts = []@'
+run 'rsync-loses-the-alias'     test_rsync_threads_the_alias_through_dash_e \
+  's@ssh_cmd = " ".join(\["ssh"\] + opts)@ssh_cmd = "ssh"@'
+
+printf '\n== the probe must be a real auth handshake, not a port check ==\n'
+run 'batchmode-dropped'         test_probe_is_a_real_ssh_session_not_a_port_check \
+  's@\["ssh", "-o", "BatchMode=yes"\]@["ssh"]@'
+run 'connect-timeout-dropped'   test_timeout_reaches_ssh_as_connect_timeout \
+  's@opts += \["-o", "ConnectTimeout=%d" % max(1, int(connect_timeout))\]@pass@'
+
+printf '\n== three states, never two ==\n'
+run 'not-configured-collapsed'  test_tailscale_absent_is_not_configured \
+  's@^NOT_CONFIGURED = "not-configured"@NOT_CONFIGURED = "unreachable"@'
+run 'absent-tailnet-guessed'    test_tailnet_without_this_host_is_not_configured \
+  's@return None, "%s is not in the tailnet" % name@return "203.0.113.1", ""@'
+
+printf '\n== the exit-code contract ==\n'
+run 'remote-exit-swallowed'     test_remote_exit_code_passes_through_unchanged \
+  's@return subprocess.run(cmd).returncode@subprocess.run(cmd); return 0@'
+run 'no-path-code-is-not-3'     test_no_path_reachable_exits_3 \
+  's@^EXIT_NO_PATH = 3@EXIT_NO_PATH = 1@'
+
+printf '\n== path selection and precedence ==\n'
+run 'precedence-reversed'       test_best_available_path_is_selected \
+  's@^PATH_ORDER = ("lan", "nebula", "tailscale")@PATH_ORDER = ("tailscale", "nebula", "lan")@'
+run 'forced-path-falls-back'    test_forcing_a_down_path_fails_and_does_not_fall_back \
+  's@^        if result.state != OK:@        if False:@'
+
+printf '\n== running ON the target must exec locally ==\n'
+run 'local-detection-disabled'  test_runs_locally_when_the_nebula_address_is_ours \
+  's@^    local = is_local_host(host)@    local = False@'
+run 'nebula-addr-not-consulted' test_runs_locally_when_the_nebula_address_is_ours \
+  's@^    if host.nebula and host.nebula in local:@    if False:@'
+
+printf '\n== probing is parallel and bounded ==\n'
+run 'probing-made-serial'       test_probes_run_in_parallel_not_in_series \
+  's@max_workers=len(PATH_ORDER)@max_workers=1@'
+run 'probe-timeout-dropped'     test_timeout_is_honoured \
+  's@^            timeout=timeout,$@            timeout=None,@'
+
+printf '\n== verb construction ==\n'
+run 'tmux-loses-its-pty'        test_tmux_requests_a_pty \
+  's@return \["ssh", "-t"\] + opts@return ["ssh"] + opts@'
+run 'scp-colon-not-substituted' test_scp_substitutes_the_address_for_a_leading_colon \
+  's@^        if arg.startswith(":"):@        if False:@'
+run 'kubectl-tunnel-mistarget'  test_kubectl_tunnel_targets_the_hosts_apiserver_port \
+  's@"%d:127.0.0.1:%d" % (kube_port, host.kube_port)@"%d:0.0.0.0:%d" % (kube_port, host.kube_port)@'
+
+printf '\n== the local-exec branch of each verb ==\n'
+run 'local-scp-drops-the-colon'  test_scp_becomes_a_local_copy_on_the_target \
+  's@stripped = \[a\[1:\] if a.startswith(":") else a for a in args\]@stripped = list(args)@'
+run 'local-tmux-loses-session'   test_tmux_attaches_locally_on_the_target \
+  's@            return \["tmux", "new-session", "-A", "-s"\] + session@            return ["tmux", "new-session"]@'
+run 'local-forward-silently-ok'  test_forward_is_refused_on_the_target_itself \
+  's@        raise ValueError("`forward` is meaningless on the target host itself")@        return ["true"]@'
+
+printf '\n== stream discipline and the JSON contract ==\n'
+run 'report-pollutes-stdout'    test_the_report_goes_to_stderr_so_stdout_stays_pipeable \
+  's@report_stream = sys.stdout if reporting_verb else sys.stderr@report_stream = sys.stdout@'
+run 'json-drops-local-field'    test_json_shape_field_by_field \
+  's@^        "local": local,$@@'
+
+printf '\n== the positive control: a mutant already known to be covered ==\n'
+run 'already-caught-control'    test_no_path_reachable_exits_3 \
+  's@^EXIT_NO_PATH = 3@EXIT_NO_PATH = 9@'
+
+printf '\n== the SURVIVES control: a behaviour-free edit must kill NOTHING ==\n'
+run 'comment-only-edit'         SURVIVES \
+  's@^# Exit codes$@# Exit-codes@'
+
+printf '\n== the script was restored byte-identical ==\n'
+NOW_SHA="$(sha256sum "$SCRIPT" | cut -d' ' -f1)"
+if [ "$NOW_SHA" = "$ORIG_SHA" ]; then
+  printf '  ok sha256 %s\n' "$NOW_SHA"
+else
+  printf '  🔴 RESTORE FAILED (%s != %s)\n' "$NOW_SHA" "$ORIG_SHA"
+  FAILURES=$((FAILURES+1))
+fi
+
+printf '\nscope: %d mutant(s), enumerated in this file. NOT a claim about any\n' "$ROWS"
+printf '       guard this file does not name — add a row when you add a guard.\n'
+if [ "$FAILURES" -eq 0 ]; then
+  echo "ALL OK (for the $ROWS mutant(s) above)"; exit 0
+fi
+echo "$FAILURES of $ROWS row(s) not ok"; exit 1

--- a/scripts/tests/mutants-workhost.sh
+++ b/scripts/tests/mutants-workhost.sh
@@ -38,9 +38,11 @@ mkdir -p "$ROOT/scripts/tests" "$ROOT/nix"
 cp -a "$SRC/scripts/workhost"                "$ROOT/scripts/"     # cp -a keeps the exec bit
 cp -a "$SRC/scripts/testlib"                 "$ROOT/scripts/"
 cp -a "$SRC/scripts/tests/test_workhost.py"  "$ROOT/scripts/tests/"
-# The delivery test reads this file; copying it keeps the baseline green without
-# weakening the row set.
+# The delivery test reads nix/home.nix and the README-claims test reads
+# scripts/README.md; copying both keeps the baseline green without weakening the
+# row set. Neither is a mutation target — no row below touches them.
 cp -a "$SRC/nix/home.nix"                    "$ROOT/nix/"
+cp -a "$SRC/scripts/README.md"               "$ROOT/scripts/"
 [ -e "$ROOT/.git" ] && { echo "🔴 the copy carries a .git — refusing to run"; exit 2; }
 find "$ROOT" -name __pycache__ -type d -prune -exec rm -rf {} + 2>/dev/null
 
@@ -52,10 +54,10 @@ restore() { cp -a "$T/script.orig" "$SCRIPT"; }
 
 FAILURES=0
 ROWS=0
-# 139 tests collect today, NONE deselected. The floor sits well under that so it
+# 158 tests collect today, NONE deselected. The floor sits well under that so it
 # catches a suite that failed to collect, not routine growth. (This number is
 # re-derived, not remembered: `python3 -m pytest --collect-only -q` on the suite.)
-MIN_TESTS=125
+MIN_TESTS=140
 
 # 🔴 No deselect. An earlier version of this file excluded
 # `test_workhost_is_tracked_by_git` and justified it with "it asserts about the
@@ -256,6 +258,32 @@ run 'dry-run-space-joined'      test_dry_run_quotes_arguments_containing_spaces 
   's@^        sys.stdout.write(shlex.join(cmd) + "\\n")$@        sys.stdout.write(" ".join(cmd) + "\\n")@'
 run 'kubectl-hides-placeholder' test_the_kubectl_dry_run_admits_its_port_is_a_placeholder \
   's@is a placeholder@is chosen later@'
+
+printf '\n== a string that names a command is a claim about the parser ==\n'
+run 'accept-key-not-hoisted'    test_the_advice_names_a_command_the_parser_actually_accepts \
+  's@^    hoisted = \[t for t in verb_args if t in HOISTED_FLAGS\]@    hoisted = []@'
+run 'hoist-too-wide'            test_only_declared_flags_are_hoisted \
+  's@^HOISTED_FLAGS = ("--accept-key",)@HOISTED_FLAGS = ("--accept-key", "--json", "--dry-run")@'
+run 'hoist-leaves-the-flag'     test_a_hoisted_flag_is_removed_from_the_remote_argv_and_said_so \
+  's@^    return \[t for t in verb_args if t not in HOISTED_FLAGS\], hoisted@    return list(verb_args), hoisted@'
+run 'hoist-is-silent'           test_a_hoisted_flag_is_removed_from_the_remote_argv_and_said_so \
+  's@^    if hoisted:@    if False:@'
+run 'hoist-notice-always-fires' test_nothing_is_said_when_no_flag_was_hoisted \
+  's@^    if hoisted:@    if True:@'
+# The advice string itself: name a command the parser cannot accept and the
+# "actually parses" guard must go red. A substring grep for `--accept-key`
+# would still be GREEN here, which is why that is not what the guard does.
+run 'advice-names-a-non-command' test_every_workhost_command_the_tool_prints_actually_parses \
+  's@^ACCEPT_KEY_ADVICE_COMMAND = "workhost ssh --accept-key"@ACCEPT_KEY_ADVICE_COMMAND = "workhost ssh --accept-keys"@'
+run 'manual-line-loses-alias'   test_the_manual_ssh_line_uses_the_options_the_tool_itself_uses \
+  's@^        manual = " ".join(\["ssh"\] + ssh_options(host) + \[unseen\[0\].address\])@        manual = " ".join(["ssh", unseen[0].address])@'
+run 'ssh-keygen-names-address'  test_the_changed_key_advice_removes_the_alias_not_an_address \
+  's@^            % (host.name, host.name, host.name)@            % (host.name, host.name, changed[0].address)@'
+run 'forward-example-invalid'   test_the_forward_example_is_a_spec_the_validator_itself_accepts \
+  's@(e.g. `workhost forward 8080:localhost:80`); with none it would @(e.g. `workhost forward 8080`); with none it would @'
+
+run 'select-message-drops-cmd'  test_every_workhost_command_the_tool_prints_actually_parses \
+  's@"client (run `%s` once to trust it, interactively)"@"client (re-run with --accept-key)"@'
 
 printf '\n== the positive control: a mutant already known to be covered ==\n'
 run 'already-caught-control'    test_no_path_reachable_exits_3 \

--- a/scripts/tests/mutants-workhost.sh
+++ b/scripts/tests/mutants-workhost.sh
@@ -273,7 +273,7 @@ run 'hoist-notice-always-fires' test_nothing_is_said_when_no_flag_was_hoisted \
 # The advice string itself: name a command the parser cannot accept and the
 # "actually parses" guard must go red. A substring grep for `--accept-key`
 # would still be GREEN here, which is why that is not what the guard does.
-run 'advice-names-a-non-command' test_every_workhost_command_the_tool_prints_actually_parses \
+run 'advice-names-a-non-command' test_every_workhost_command_the_tool_prints_parses_as_intended \
   's@^ACCEPT_KEY_ADVICE_COMMAND = "workhost ssh --accept-key"@ACCEPT_KEY_ADVICE_COMMAND = "workhost ssh --accept-keys"@'
 run 'manual-line-loses-alias'   test_the_manual_ssh_line_uses_the_options_the_tool_itself_uses \
   's@^        manual = " ".join(\["ssh"\] + ssh_options(host) + \[unseen\[0\].address\])@        manual = " ".join(["ssh", unseen[0].address])@'
@@ -282,7 +282,7 @@ run 'ssh-keygen-names-address'  test_the_changed_key_advice_removes_the_alias_no
 run 'forward-example-invalid'   test_the_forward_example_is_a_spec_the_validator_itself_accepts \
   's@(e.g. `workhost forward 8080:localhost:80`); with none it would @(e.g. `workhost forward 8080`); with none it would @'
 
-run 'select-message-drops-cmd'  test_every_workhost_command_the_tool_prints_actually_parses \
+run 'select-message-drops-cmd'  test_every_workhost_command_the_tool_prints_parses_as_intended \
   's@"client (run `%s` once to trust it, interactively)"@"client (re-run with --accept-key)"@'
 
 printf '\n== the positive control: a mutant already known to be covered ==\n'

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -1513,6 +1513,27 @@ PINNED_PATH_CLOBBERS = {
         "unfindable. A prepending version measured a live call to the real "
         "board on this host while the nix sandbox (which has no clawgatectl) "
         "measured the intended case: two tiers, opposite blind spots"),
+    "test_workhost.py": (
+        '"PATH"' + ': str(bindir)',
+        "justified by ENUMERATION, like test_standup_local_health.py above, and "
+        "it is the first entry whose replacement directory deliberately "
+        "CONTAINS launcher names: ssh, scp, rsync, tmux and kubectl are all "
+        "present. They are STUBS the file itself writes via "
+        "testlib.mockbin.write_exec, never the real binaries, and that is the "
+        "whole point — workhost's job is to shell out to ssh, so the suite has "
+        "to answer those calls without a network. The invariant is LIVE, not "
+        "prose: test_the_stub_path_contains_only_declared_stubs asserts the "
+        "directory's contents are a subset of SANDBOX_BINARIES, that no "
+        "launcher-shaped entry is a symlink, and that each one's body contains "
+        "this suite's own WH_LOGDIR marker — so a real binary leaking in fails "
+        "a test rather than rotting a comment. 🔴 REPLACING is required, not "
+        "stylistic, in BOTH directions: the `not-configured` assertions depend "
+        "on `tailscale` being genuinely ABSENT and no amount of PREPENDING can "
+        "make a binary unfindable if one is later installed; and the real `ip` "
+        "on workbench reports the nebula address 10.42.0.30, so a prepended "
+        "PATH would let the host's true identity leak into the tests that must "
+        "believe they are remote, silently exercising the local-exec branch and "
+        "passing for the wrong reason"),
     "test_devshell_satisfies_required_tools.py": (
         '{"PATH"' + ': str(stub)',
         "a clobber justified by ENUMERATION rather than emptiness, and the "

--- a/scripts/tests/test_workhost.py
+++ b/scripts/tests/test_workhost.py
@@ -1655,34 +1655,57 @@ def _drop_kubectl(bindir):
 #: `workhost …` command. Enumerated by reading every emitted string literal in
 #: the script (the `sys.std*.write` / `ValueError` / `parser.error` call sites),
 #: not by memory. Add a row when you add such a string.
+#:
+#: 🔴 `expect` is what the command must parse **TO**, not merely that it parses.
+#: That distinction is load-bearing, and it was found by the mutation battery
+#: rather than by inspection: the first version of this ledger asserted only
+#: "it parses", and mutating the advice to `workhost ssh --accept-keys`
+#: SURVIVED it. `--accept-keys` is not a workhost option, so `split_argv` drops
+#: it into the VERB's arguments and the global half parses perfectly cleanly —
+#: which is the exact shape of the bug this whole section exists to catch,
+#: sailing through a guard written to catch it. A guard that reads as coverage
+#: while providing none is worse than no guard, because it stops anyone looking.
+#:
+#: `expect` keys:
+#:   "workhost_flags" — every `-`-prefixed token belongs to WORKHOST, so none may
+#:                      be left in verb_args, and the named opts must be set.
+#:   "verb_flags"     — the flags are meant for the verb's own tool; verb_args
+#:                      must equal this list exactly.
+#:   "verb"           — the verb the command must resolve to.
 ADVICE_SCENARIOS = [
-    # (id, sandbox kwargs, argv, prep)
+    # (id, sandbox kwargs, argv, prep, expect)
     ("untrusted-key-report",
-     dict(ok_addrs=(), hostkey_missing=(LAN, NEBULA)), ("path",), None),
+     dict(ok_addrs=(), hostkey_missing=(LAN, NEBULA)), ("path",), None,
+     {"verb": "ssh", "workhost_flags": {"accept_key": True}}),
     ("untrusted-key-action-verb",
-     dict(ok_addrs=(), hostkey_missing=(LAN, NEBULA)), ("run", "true"), None),
+     dict(ok_addrs=(), hostkey_missing=(LAN, NEBULA)), ("run", "true"), None,
+     {"verb": "ssh", "workhost_flags": {"accept_key": True}}),
     # --json suppresses the text advice block, so the ONLY backticked command
     # left on stderr is select_path's own error. Without this row that message
     # would be covered only in aggregate — i.e. not at all, because the advice
     # block would satisfy the assertion on its behalf.
     ("untrusted-key-json-only",
-     dict(ok_addrs=(), hostkey_missing=(LAN, NEBULA)), ("--json", "run", "true"), None),
-    ("forward-no-spec", dict(ok_addrs=(LAN,)), ("forward",), None),
-    ("forward-bad-spec", dict(ok_addrs=(LAN,)), ("forward", "8080"), None),
+     dict(ok_addrs=(), hostkey_missing=(LAN, NEBULA)), ("--json", "run", "true"), None,
+     {"verb": "ssh", "workhost_flags": {"accept_key": True}}),
+    ("forward-no-spec", dict(ok_addrs=(LAN,)), ("forward",), None,
+     {"verb": "forward", "verb_flags": ["8080:localhost:80"]}),
+    ("forward-bad-spec", dict(ok_addrs=(LAN,)), ("forward", "8080"), None,
+     {"verb": "ssh", "verb_flags": ["-N", "-L", "8080"]}),
     ("no-local-kubectl",
      dict(ok_addrs=(LAN,), tunnel=True), ("--timeout", "8", "kubectl", "get", "nodes"),
-     _drop_kubectl),
+     _drop_kubectl, {"verb": "kubectl", "verb_flags": []}),
 ]
 
 
 @pytest.mark.parametrize(
-    "kwargs,argv,prep", [(k, a, p) for _, k, a, p in ADVICE_SCENARIOS],
-    ids=[i for i, _, _, _ in ADVICE_SCENARIOS],
+    "kwargs,argv,prep,expect", [(k, a, p, e) for _, k, a, p, e in ADVICE_SCENARIOS],
+    ids=[i for i, _, _, _, _ in ADVICE_SCENARIOS],
 )
-def test_every_workhost_command_the_tool_prints_actually_parses(
-    tmp_path, kwargs, argv, prep
+def test_every_workhost_command_the_tool_prints_parses_as_intended(
+    tmp_path, kwargs, argv, prep, expect
 ):
-    """Not "contains a plausible string" — actually run it through the parser.
+    """Every printed command, fed back through the real pipeline and checked
+    against what it is SUPPOSED to mean.
 
     Positive control is built in: the assertion below fails if NO command was
     found, so a scenario whose message stops naming a command cannot pass by
@@ -1697,7 +1720,19 @@ def test_every_workhost_command_the_tool_prints_actually_parses(
 
     mod = load_workhost()
     for command in commands:
-        parse_as_workhost(mod, command)  # raises/asserts if it does not parse
+        verb, verb_args, opts = parse_as_workhost(mod, command)
+        assert verb == expect["verb"], (command, verb, expect["verb"])
+
+        if "workhost_flags" in expect:
+            for attr, value in expect["workhost_flags"].items():
+                assert getattr(opts, attr) is value, (command, attr, getattr(opts, attr))
+            leftover = [t for t in verb_args if t.startswith("-")]
+            assert leftover == [], (
+                "%r: %r was handed to the verb instead of being parsed by "
+                "workhost — that is the defect, not a detail" % (command, leftover))
+
+        if "verb_flags" in expect:
+            assert verb_args == expect["verb_flags"], (command, verb_args)
 
 
 def test_the_advice_names_a_command_the_parser_actually_accepts(tmp_path):

--- a/scripts/tests/test_workhost.py
+++ b/scripts/tests/test_workhost.py
@@ -1,0 +1,964 @@
+#!/usr/bin/env python3
+"""Hermetic tests for `scripts/workhost`.
+
+NO REAL NETWORK AND NO REAL SSH. Every binary workhost shells out to — ssh,
+scp, rsync, tmux, kubectl, tailscale, ip — is a stub written by
+`testlib.mockbin` into a tmp dir, and PATH is set to THAT DIR ALONE. Setting
+PATH to only the stub dir is deliberate rather than prepending it: the
+`not-configured` tests assert on the ABSENCE of a `tailscale` binary, and a
+prepend would let a real tailscale installed on the dev host later silently
+turn those assertions into a different test. The stub dir is the whole world.
+
+The `ip` stub is load-bearing for the same reason in the other direction: this
+suite is developed ON workbench, where the real `ip` reports 10.42.0.30 and
+workhost would correctly conclude it is already on the target. Without a stub,
+every "remote" test would exercise the local branch and pass for the wrong
+reason.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "scripts"))
+
+from testlib import mockbin  # noqa: E402
+
+WORKHOST = REPO / "scripts" / "workhost"
+
+LAN = "192.168.50.250"
+NEBULA = "10.42.0.30"
+# 100.64.0.0/10 is the CGNAT range tailscale really uses, and is RFC6598
+# private — safe to commit, and pinned as safe by test_no_public_ips.py.
+TS = "100.64.0.5"
+
+RS = "\x1e"  # record separator between logged invocations
+
+#: Absolute paths captured from the REAL environment once, so the stubs can use
+#: them while PATH itself stays restricted to the stub dir. A stub that reached
+#: for a bare `cat` would exit 127 under that restricted PATH and be scored as
+#: "the feature is broken" rather than "the harness is" — which is exactly what
+#: happened on the first run of this file.
+REAL_SLEEP = shutil.which("sleep") or "/bin/sleep"
+REAL_CAT = shutil.which("cat") or "/bin/cat"
+REAL_DATE = shutil.which("date") or "/bin/date"
+REAL_BASH = shutil.which("bash")
+REAL_CP = shutil.which("cp")
+
+
+# ---------------------------------------------------------------------------
+# Stub bodies
+# ---------------------------------------------------------------------------
+
+def _logging_prologue() -> str:
+    """Record this invocation's exact argv under $WH_LOGDIR, NUL-delimited.
+
+    One file PER PROCESS (`$$`), not one shared file. The three probes run
+    concurrently by design, and concurrent appends to a single file interleave
+    mid-record: the first version of this harness produced argv lists like
+    `['-o','-o','BatchMode=yes','BatchMode=yes',...]` and the resulting failures
+    read as tool bugs. Pids are unique among live processes, so a per-pid file
+    cannot interleave; a later process reusing a pid simply appends another
+    record, which the separator already handles.
+
+    NUL-delimited so an argument containing spaces, quotes or newlines
+    round-trips byte-exactly — the whole point of the forwarding tests.
+    """
+    return (
+        'if [ -n "${WH_LOGDIR:-}" ]; then\n'
+        '  { printf \'%s\\000\' "${0##*/}"; for a in "$@"; do printf \'%s\\000\' "$a"; done; '
+        "printf '\\036'; } "
+        '>> "$WH_LOGDIR/$$"\n'
+        "fi\n"
+    )
+
+
+#: A stub ssh faithful enough to test against: it strips ssh's own options the
+#: way ssh does, gates on whether the address is in $WH_OK_ADDRS (exiting 255,
+#: which is what real ssh exits on a connection/auth failure), and otherwise
+#: EXECUTES the remaining arguments joined by spaces — exactly ssh's own
+#: semantics. That last part is what makes the exit-code passthrough tests real
+#: rather than a mock returning a canned number.
+SSH_STUB = (
+    _logging_prologue()
+    # Bracket the delay with timestamps so concurrency can be proven by INTERVAL
+    # OVERLAP rather than by total wall time. Overlap is load-independent:
+    # serial execution cannot produce overlapping intervals at any load, whereas
+    # a wall-time budget fails on a busy box and would have to be widened until
+    # it stopped meaning anything.
+    + 'if [ -n "${WH_TIMEDIR:-}" ]; then printf \'S %%s\\n\' "$(%s +%%s.%%N)" >> "$WH_TIMEDIR/$$"; fi\n'
+    % REAL_DATE
+    + 'if [ -n "${WH_DELAY:-}" ]; then %s "$WH_DELAY"; fi\n' % REAL_SLEEP
+    + 'if [ -n "${WH_TIMEDIR:-}" ]; then printf \'E %%s\\n\' "$(%s +%%s.%%N)" >> "$WH_TIMEDIR/$$"; fi\n'
+    % REAL_DATE
+    + """
+LSPEC=""
+for a in "$@"; do
+  case "$a" in *:127.0.0.1:*) LSPEC="$a" ;; esac
+done
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o|-L) shift 2 ;;
+    -N|-t) shift ;;
+    -*) shift ;;
+    *) break ;;
+  esac
+done
+ADDR="${1:-}"
+[ $# -gt 0 ] && shift
+[ "${1:-}" = "--" ] && shift
+
+ok=1
+for a in ${WH_OK_ADDRS:-}; do
+  [ "$a" = "$ADDR" ] && ok=0
+done
+[ $ok -eq 0 ] || exit 255
+
+if [ -n "$LSPEC" ] && [ -n "${WH_TUNNEL:-}" ]; then
+  PORT="${LSPEC%%:*}"
+  exec "$WH_PYTHON" -c 'import socket,sys,time
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1", int(sys.argv[1])))
+s.listen(5)
+time.sleep(60)' "$PORT"
+fi
+
+[ $# -eq 0 ] && exit 0
+exec /bin/sh -c "$*"
+"""
+)
+
+#: Generic recorder for the verbs that are not ssh itself.
+RECORDER_STUB = _logging_prologue() + 'exit "${WH_RC:-0}"\n'
+
+
+def _tailscale_stub(peers: str) -> str:
+    return _logging_prologue() + "%s <<'JSON'\n%s\nJSON\n" % (REAL_CAT, peers)
+
+
+def _ip_stub(addresses) -> str:
+    lines = "".join(
+        "1: eth0    inet %s/24 brd 10.0.0.255 scope global eth0\n" % a for a in addresses
+    )
+    return "%s <<'EOF'\n%sEOF\n" % (REAL_CAT, lines)
+
+
+# ---------------------------------------------------------------------------
+# Sandbox
+# ---------------------------------------------------------------------------
+
+
+def sandbox(
+    tmp_path,
+    ok_addrs=(),
+    local_addrs=("10.9.9.9",),
+    tailscale=None,
+    delay=None,
+    tunnel=False,
+):
+    """Build a stub-only PATH and the env that drives it.
+
+    ``tailscale`` is None for "no tailscale binary exists at all", or a list of
+    peer dicts for a tailnet that does exist. Those two are different states and
+    the tests below assert they stay different.
+    """
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    log = tmp_path / "argv.d"
+    log.mkdir(exist_ok=True)
+    timedir = tmp_path / "times.d"
+    timedir.mkdir(exist_ok=True)
+
+    mockbin.write_exec(bindir / "ssh", SSH_STUB)
+    for name in ("scp", "rsync", "tmux", "kubectl"):
+        mockbin.write_exec(bindir / name, RECORDER_STUB)
+    mockbin.write_exec(bindir / "ip", _ip_stub(local_addrs))
+
+    if tailscale is not None:
+        status = {"Self": {"HostName": "someclient", "TailscaleIPs": ["100.64.0.2"]}}
+        status["Peer"] = {"nodekey:%d" % i: p for i, p in enumerate(tailscale)}
+        mockbin.write_exec(bindir / "tailscale", _tailscale_stub(json.dumps(status)))
+
+    # Real tools the stubs and the local-exec branch genuinely need, reached by
+    # absolute path so PATH can stay restricted to the stub dir.
+    for real, name in ((REAL_BASH, "bash"), (REAL_CP, "cp")):
+        if real and not (bindir / name).exists():
+            os.symlink(real, bindir / name)
+
+    env = {
+        "PATH": str(bindir),
+        "HOME": str(tmp_path),
+        "SHELL": "/bin/sh",
+        "WH_LOGDIR": str(log),
+        "WH_TIMEDIR": str(timedir),
+        "WH_OK_ADDRS": " ".join(ok_addrs),
+        "WH_PYTHON": sys.executable,
+    }
+    if delay is not None:
+        env["WH_DELAY"] = str(delay)
+    if tunnel:
+        env["WH_TUNNEL"] = "1"
+    return bindir, log, env
+
+
+def run(env, *args, timeout=60):
+    return subprocess.run(
+        [sys.executable, str(WORKHOST), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )
+
+
+def invocations(log: Path):
+    """Every recorded invocation, as a list of exact argv lists.
+
+    Files are read oldest-first so that the few assertions which index into the
+    list (`[0]`) see roughly call order.
+    """
+    if not log.exists():
+        return []
+    out = []
+    for path in sorted(log.iterdir(), key=lambda p: p.stat().st_mtime):
+        raw = path.read_text(encoding="utf-8", errors="replace")
+        for record in raw.split(RS):
+            if not record:
+                continue
+            args = [a for a in record.split("\0") if a != ""]
+            if args:
+                out.append(args)
+    return out
+
+
+def non_probe(log: Path):
+    """Invocations that are not the `… true` probe."""
+    return [a for a in invocations(log) if a[-1] != "true"]
+
+
+def peer(name, ip=TS):
+    return {"HostName": name, "DNSName": "%s.example.test." % name, "TailscaleIPs": [ip]}
+
+
+# ---------------------------------------------------------------------------
+# 1. Path selection across the probe matrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ok,expected",
+    [
+        ((LAN, NEBULA, TS), "lan"),
+        ((LAN, NEBULA), "lan"),
+        ((LAN,), "lan"),
+        ((NEBULA, TS), "nebula"),
+        ((NEBULA,), "nebula"),
+        ((TS,), "tailscale"),
+    ],
+)
+def test_best_available_path_is_selected(tmp_path, ok, expected):
+    """Precedence is LAN > nebula > tailscale, whatever subset is up."""
+    _, _, env = sandbox(tmp_path, ok_addrs=ok, tailscale=[peer("workbench")])
+    r = run(env, "--json", "path")
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert json.loads(r.stdout)["selected"] == expected, (ok, r.stdout)
+
+
+def test_no_path_reachable_exits_3(tmp_path):
+    """Exit 3 is the distinct 'I could not reach the box at all' code."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(), tailscale=[peer("workbench")])
+    r = run(env, "path")
+    assert r.returncode == 3, (r.returncode, r.stdout, r.stderr)
+
+
+def test_no_path_reachable_exits_3_for_an_action_verb(tmp_path):
+    _, log, env = sandbox(tmp_path, ok_addrs=())
+    r = run(env, "run", "echo", "hi")
+    assert r.returncode == 3, (r.returncode, r.stdout, r.stderr)
+    assert non_probe(log) == [], "no command should be attempted with no path up"
+
+
+def test_all_three_paths_are_probed_every_time(tmp_path):
+    """The tool reports the state of ALL paths, not just the first that works."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,), tailscale=[peer("workbench")])
+    r = run(env, "--json", "path")
+    paths = {p["path"] for p in json.loads(r.stdout)["paths"]}
+    assert paths == {"lan", "nebula", "tailscale"}, r.stdout
+
+
+# ---------------------------------------------------------------------------
+# 2. Three states, never two
+# ---------------------------------------------------------------------------
+
+
+def test_tailscale_absent_is_not_configured(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,), tailscale=None)
+    r = run(env, "--json", "path")
+    ts = [p for p in json.loads(r.stdout)["paths"] if p["path"] == "tailscale"][0]
+    assert ts["state"] == "not-configured", r.stdout
+    assert ts["address"] is None, r.stdout
+    assert "binary" in ts["detail"], ts["detail"]
+
+
+def test_tailscale_present_but_down_is_unreachable_not_not_configured(tmp_path):
+    """THE central distinction. Same absence of a connection, different cause.
+
+    Collapsing these two into one 'failed' state is the defect this tool exists
+    to avoid, so the two must not merely differ in prose — they must differ in
+    the machine-readable state field.
+    """
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,), tailscale=[peer("workbench")])
+    r = run(env, "--json", "path")
+    ts = [p for p in json.loads(r.stdout)["paths"] if p["path"] == "tailscale"][0]
+    assert ts["state"] == "unreachable", r.stdout
+    assert ts["address"] == TS, r.stdout
+
+
+def test_the_two_tailscale_failures_produce_different_output(tmp_path):
+    """Belt and braces: the two runs must not be byte-identical."""
+    _, _, absent_env = sandbox(tmp_path / "a", ok_addrs=(LAN,), tailscale=None)
+    _, _, down_env = sandbox(tmp_path / "b", ok_addrs=(LAN,), tailscale=[peer("workbench")])
+    (tmp_path / "a").mkdir(exist_ok=True)
+    (tmp_path / "b").mkdir(exist_ok=True)
+    absent = run(absent_env, "path").stdout
+    down = run(down_env, "path").stdout
+    assert absent != down, "absent and down rendered identically"
+    assert "not-configured" in absent and "unreachable" in down
+
+
+def test_tailnet_without_this_host_is_not_configured(tmp_path):
+    """A tailnet that exists but does not carry this host is still 'not yet
+    configured' — a different fix from 'the tunnel is down'."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,), tailscale=[peer("someone-else")])
+    r = run(env, "--json", "path")
+    ts = [p for p in json.loads(r.stdout)["paths"] if p["path"] == "tailscale"][0]
+    assert ts["state"] == "not-configured", r.stdout
+    assert "not in the tailnet" in ts["detail"], ts["detail"]
+
+
+def test_tailscale_lights_up_with_no_code_change(tmp_path):
+    """The requirement that tailscale works the day it is deployed."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(TS,), tailscale=[peer("workbench")])
+    r = run(env, "--json", "path")
+    payload = json.loads(r.stdout)
+    ts = [p for p in payload["paths"] if p["path"] == "tailscale"][0]
+    assert ts["state"] == "ok", r.stdout
+    assert payload["selected"] == "tailscale", r.stdout
+
+
+# ---------------------------------------------------------------------------
+# 3. Exit-code passthrough
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("code", [0, 1, 42, 7])
+def test_remote_exit_code_passes_through_unchanged(tmp_path, code):
+    """A tool that swallows remote exit codes is unusable in a script."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "run", "exit %d" % code)
+    assert r.returncode == code, (code, r.returncode, r.stdout, r.stderr)
+
+
+def test_run_false_exits_1(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "run", "false")
+    assert r.returncode == 1, (r.returncode, r.stdout, r.stderr)
+
+
+def test_exit_3_is_distinguishable_from_a_remote_failure(tmp_path):
+    """Both are non-zero; they must not be the same non-zero."""
+    _, _, up = sandbox(tmp_path / "u", ok_addrs=(LAN,))
+    (tmp_path / "u").mkdir(exist_ok=True)
+    _, _, down = sandbox(tmp_path / "d", ok_addrs=())
+    (tmp_path / "d").mkdir(exist_ok=True)
+    assert run(up, "run", "exit 1").returncode == 1
+    assert run(down, "run", "exit 1").returncode == 3
+
+
+# ---------------------------------------------------------------------------
+# 4. HostKeyAlias on every path x every ssh-based verb
+# ---------------------------------------------------------------------------
+
+SSH_BASED = [
+    ("ssh", []),
+    ("run", ["uptime"]),
+    ("tmux", []),
+    ("scp", ["./a.txt", ":/tmp/a.txt"]),
+    ("rsync", ["-a", "./d/", ":/tmp/d/"]),
+    ("forward", ["8080:localhost:80"]),
+    ("kubectl", ["get", "pods"]),
+]
+
+
+@pytest.mark.parametrize("path,addr", [("lan", LAN), ("nebula", NEBULA), ("tailscale", TS)])
+@pytest.mark.parametrize("verb,args", SSH_BASED, ids=[v for v, _ in SSH_BASED])
+def test_host_key_alias_is_set_for_every_path_and_verb(tmp_path, path, addr, verb, args):
+    """One machine, three addresses, ONE known_hosts entry.
+
+    Without HostKeyAlias each path accrues its own known_hosts entry keyed on
+    the address, and the day an address is reused for a different machine the
+    operator hits a host-key-mismatch wall. Measured on the dev host before this
+    tool existed: two raw-address entries for a single machine already present.
+    """
+    _, _, env = sandbox(tmp_path, ok_addrs=(addr,), tailscale=[peer("workbench")])
+    r = run(env, "--path", path, "--dry-run", verb, *args)
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert "HostKeyAlias=workbench" in r.stdout, (verb, path, r.stdout)
+    assert addr in r.stdout, (verb, path, r.stdout)
+
+
+def test_rsync_threads_the_alias_through_dash_e(tmp_path):
+    """rsync opens its OWN ssh, so the options must reach it via -e or the
+    alias is silently lost for exactly this verb."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "--dry-run", "rsync", "-a", "./d/", ":/tmp/d/")
+    assert "-e ssh -o HostKeyAlias=workbench" in r.stdout, r.stdout
+
+
+def test_the_probe_itself_carries_the_alias(tmp_path):
+    """Probing without the alias would pollute known_hosts on every run, which
+    is the same defect one layer down."""
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    run(env, "path")
+    probes = [a for a in invocations(log) if a[-1] == "true"]
+    assert probes, "no probe was recorded"
+    for argv in probes:
+        assert "HostKeyAlias=workbench" in argv, argv
+
+
+# ---------------------------------------------------------------------------
+# 5. The probe is a real auth handshake
+# ---------------------------------------------------------------------------
+
+
+def test_probe_is_a_real_ssh_session_not_a_port_check(tmp_path):
+    """A port that accepts a connection is not a session you can open.
+
+    Measured on this fleet: both addresses complete TCP and the SSH transport
+    layer and then fail auth with `Permission denied`, exiting 255. A TCP probe
+    calls that reachable; only running a command over BatchMode proves it.
+    """
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    run(env, "path")
+    probes = [a for a in invocations(log) if a[-1] == "true"]
+    assert len(probes) >= 2, invocations(log)
+    for argv in probes:
+        assert argv[0] == "ssh", argv
+        assert "BatchMode=yes" in argv, argv
+        assert argv[-1] == "true", argv
+
+
+def test_an_ssh_that_fails_auth_is_unreachable_not_ok(tmp_path):
+    """The stub exits 255 exactly as real ssh does on auth failure."""
+    _, _, env = sandbox(tmp_path, ok_addrs=())
+    r = run(env, "--json", "path")
+    states = {p["path"]: p["state"] for p in json.loads(r.stdout)["paths"]}
+    assert states["lan"] == "unreachable", r.stdout
+    assert states["nebula"] == "unreachable", r.stdout
+
+
+# ---------------------------------------------------------------------------
+# 6. Local vs remote execution
+# ---------------------------------------------------------------------------
+
+
+def test_runs_locally_when_the_nebula_address_is_ours(tmp_path):
+    """On the target host, exec locally instead of SSHing to ourselves."""
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,), local_addrs=(NEBULA,))
+    r = run(env, "run", "echo", "hello-local")
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert r.stdout.strip() == "hello-local", r.stdout
+    assert non_probe(log) == [], "should not have opened an ssh session to itself"
+
+
+def test_runs_locally_when_the_lan_address_is_ours(tmp_path):
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,), local_addrs=(LAN,))
+    r = run(env, "run", "echo", "hello-local")
+    assert r.stdout.strip() == "hello-local", r.stdout
+    assert non_probe(log) == [], non_probe(log)
+
+
+def test_runs_remotely_when_no_address_is_ours(tmp_path):
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,), local_addrs=("10.9.9.9",))
+    r = run(env, "run", "echo", "hello-remote")
+    assert r.stdout.strip() == "hello-remote", r.stdout
+    remote = non_probe(log)
+    assert remote and remote[0][0] == "ssh", remote
+    assert LAN in remote[0], remote
+
+
+def test_hostname_is_not_the_discriminator(tmp_path):
+    """Both NixOS hosts report the hostname `nixos`, so a hostname-based check
+    would make one machine believe it is the other. Proven by making the
+    ADDRESSES say remote while the hostname stays whatever the host's really is:
+    the tool must go over the wire regardless."""
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,), local_addrs=("10.9.9.9",))
+    env["HOSTNAME"] = "workbench"
+    r = run(env, "run", "echo", "x")
+    assert non_probe(log), "went local on a hostname match; addresses said remote"
+
+
+def test_local_exec_still_works_when_no_path_is_reachable(tmp_path):
+    """You do not need a network path to the machine you are sitting on.
+
+    This is a regression guard: the first implementation returned exit 3 here,
+    which made `workhost` unusable on workbench itself.
+    """
+    _, _, env = sandbox(tmp_path, ok_addrs=(), local_addrs=(NEBULA,))
+    r = run(env, "run", "echo", "still-works")
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert r.stdout.strip() == "still-works", r.stdout
+
+
+def test_scp_becomes_a_local_copy_on_the_target(tmp_path):
+    """The leading `:` still means "the host", which is now just here."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,), local_addrs=(NEBULA,))
+    src = tmp_path / "src.txt"
+    src.write_text("payload", encoding="utf-8")
+    dst = tmp_path / "dst.txt"
+    r = run(env, "scp", str(src), ":%s" % dst)
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert dst.read_text(encoding="utf-8") == "payload", "local scp did not copy"
+
+
+def test_tmux_attaches_locally_on_the_target(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,), local_addrs=(NEBULA,))
+    r = run(env, "--dry-run", "tmux", "work")
+    assert r.stdout.strip() == "tmux new-session -A -s work", r.stdout
+
+
+def test_bare_ssh_on_the_target_is_a_local_shell(tmp_path):
+    """SSHing to yourself to get a shell is theatre; run the shell."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,), local_addrs=(NEBULA,))
+    env["SHELL"] = "/bin/sh"
+    r = run(env, "--dry-run", "ssh")
+    assert r.stdout.strip() == "/bin/sh", r.stdout
+
+
+def test_forward_is_refused_on_the_target_itself(tmp_path):
+    """Forwarding a port to yourself would hang on an ssh that never returns,
+    so it fails loudly instead."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,), local_addrs=(NEBULA,))
+    r = run(env, "forward", "8080:localhost:80")
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+    assert "meaningless" in r.stderr, r.stderr
+
+
+def test_path_verb_reports_local_and_exits_zero_on_the_target(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(), local_addrs=(NEBULA,))
+    r = run(env, "--json", "path")
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert json.loads(r.stdout)["local"] is True, r.stdout
+
+
+# ---------------------------------------------------------------------------
+# 7. --path forcing
+# ---------------------------------------------------------------------------
+
+
+def test_forcing_a_down_path_fails_and_does_not_fall_back(tmp_path):
+    """Silently using a different path would defeat the flag entirely."""
+    _, log, env = sandbox(tmp_path, ok_addrs=(NEBULA,))
+    r = run(env, "--path", "lan", "run", "echo", "nope")
+    assert r.returncode == 3, (r.returncode, r.stdout, r.stderr)
+    assert "lan" in r.stderr and "unreachable" in r.stderr, r.stderr
+    assert non_probe(log) == [], "fell back to another path"
+
+
+def test_forcing_a_not_configured_path_fails_clearly(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,), tailscale=None)
+    r = run(env, "--path", "tailscale", "run", "echo", "nope")
+    assert r.returncode == 3, (r.returncode, r.stdout, r.stderr)
+    assert "not-configured" in r.stderr, r.stderr
+
+
+def test_forcing_an_up_path_uses_exactly_that_path(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN, NEBULA))
+    r = run(env, "--path", "nebula", "--dry-run", "ssh")
+    assert NEBULA in r.stdout and LAN not in r.stdout, r.stdout
+
+
+def test_forcing_a_path_overrides_local_exec(tmp_path):
+    """Asking explicitly for the wire is a request to use the wire."""
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,), local_addrs=(NEBULA,))
+    r = run(env, "--path", "lan", "run", "echo", "over-the-wire")
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert non_probe(log), "forced path was ignored in favour of local exec"
+
+
+# ---------------------------------------------------------------------------
+# 8. --json shape
+# ---------------------------------------------------------------------------
+
+
+def test_json_shape_field_by_field(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(NEBULA,), tailscale=None)
+    r = run(env, "--json", "path")
+    payload = json.loads(r.stdout)
+
+    assert payload["host"] == "workbench"
+    assert payload["selected"] == "nebula"
+    assert payload["local"] is False
+    assert isinstance(payload["paths"], list) and len(payload["paths"]) == 3
+
+    by_path = {p["path"]: p for p in payload["paths"]}
+    assert set(by_path) == {"lan", "nebula", "tailscale"}
+
+    assert by_path["lan"]["state"] == "unreachable"
+    assert by_path["lan"]["address"] == LAN
+    assert by_path["nebula"]["state"] == "ok"
+    assert by_path["nebula"]["address"] == NEBULA
+    assert by_path["tailscale"]["state"] == "not-configured"
+    assert by_path["tailscale"]["address"] is None
+
+    for entry in payload["paths"]:
+        assert set(entry) == {"path", "state", "address", "detail", "elapsed_ms"}
+        assert isinstance(entry["elapsed_ms"], int)
+        assert isinstance(entry["detail"], str)
+
+
+def test_json_selected_is_null_when_nothing_is_up(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=())
+    r = run(env, "--json", "path")
+    assert json.loads(r.stdout)["selected"] is None, r.stdout
+
+
+def test_flags_after_a_reporting_verb_are_honoured(tmp_path):
+    """`workhost path --json` is what people actually type."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "path", "--json")
+    json.loads(r.stdout)  # raises if the flag was swallowed
+
+
+# ---------------------------------------------------------------------------
+# 9. Parallelism and --timeout
+# ---------------------------------------------------------------------------
+
+
+def probe_intervals(timedir: Path):
+    """(start, end) for each stub invocation that recorded timestamps."""
+    spans = []
+    for path in sorted(timedir.iterdir()):
+        start = end = None
+        for line in path.read_text(encoding="utf-8").splitlines():
+            kind, _, value = line.partition(" ")
+            if kind == "S":
+                start = float(value)
+            elif kind == "E":
+                end = float(value)
+        if start is not None and end is not None:
+            spans.append((start, end))
+    return spans
+
+
+def test_probes_run_in_parallel_not_in_series(tmp_path):
+    """All three probes must be in flight AT THE SAME MOMENT.
+
+    Asserted by interval OVERLAP, not by total wall time. That distinction is
+    the point: a wall-time budget ("3x1s probes in under 2.2s") fails on a
+    loaded box and the only ways to make it pass again are to widen the margin
+    until it asserts nothing or to re-run until green. Overlap has no such
+    failure mode — SERIAL EXECUTION CANNOT PRODUCE OVERLAPPING INTERVALS AT ANY
+    LOAD, because probe 2 does not start until probe 1 has returned. Load can
+    stretch the intervals; it cannot make disjoint ones overlap.
+
+    Serial probing would put three timeouts in front of every command, which is
+    the difference between a tool you put in front of ssh and one you do not.
+    """
+    delay = 1.0
+    _, log, env = sandbox(
+        tmp_path, ok_addrs=(LAN, NEBULA, TS), tailscale=[peer("workbench")], delay=delay
+    )
+    r = run(env, "--timeout", "10", "path")
+
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert len([a for a in invocations(log) if a[-1] == "true"]) == 3, invocations(log)
+
+    spans = probe_intervals(tmp_path / "times.d")
+    assert len(spans) == 3, spans
+    # A single instant at which all three were running: the latest start still
+    # precedes the earliest end.
+    latest_start = max(s for s, _ in spans)
+    earliest_end = min(e for _, e in spans)
+    assert latest_start < earliest_end, (
+        "probes did not overlap — looks serial. spans=%r" % (spans,)
+    )
+
+
+def test_timeout_is_honoured(tmp_path):
+    """A hung path must not hang the tool.
+
+    Asserted structurally rather than on wall time. The stub sleeps 10s while
+    the probe is given 1s; the `timed out` detail is reachable ONLY through
+    subprocess.TimeoutExpired, so seeing it proves the deadline fired and the
+    10s sleep was abandoned. Were the timeout dropped, the probe would instead
+    wait out the sleep and report `ok` — a different state, not a slower one.
+    """
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,), delay=10)
+    r = run(env, "--timeout", "1", "--json", "path")
+
+    states = {p["path"]: p for p in json.loads(r.stdout)["paths"]}
+    assert states["lan"]["state"] == "unreachable", r.stdout
+    assert "timed out" in states["lan"]["detail"], states["lan"]["detail"]
+
+
+def test_timeout_reaches_ssh_as_connect_timeout(tmp_path):
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    run(env, "--timeout", "7", "path")
+    probes = [a for a in invocations(log) if a[-1] == "true"]
+    assert probes
+    assert "ConnectTimeout=7" in probes[0], probes[0]
+
+
+# ---------------------------------------------------------------------------
+# 10. Argument forwarding, including spaces and quotes
+# ---------------------------------------------------------------------------
+
+NASTY = 'a b "c" \'d\' $e `f` \\g'
+
+
+def test_ssh_forwards_arguments_verbatim(tmp_path):
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    run(env, "ssh", "-N", NASTY)
+    argv = non_probe(log)[0]
+    assert NASTY in argv, argv
+
+
+@pytest.mark.parametrize("verb", ["scp", "rsync", "tmux", "kubectl"])
+def test_verbs_forward_arguments_verbatim(tmp_path, verb):
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,), tunnel=True)
+    run(env, "--timeout", "5", verb, NASTY)
+    recorded = [a for a in invocations(log) if a[0] == verb or a[0] == "ssh"]
+    flat = [arg for argv in recorded for arg in argv]
+    assert NASTY in flat, recorded
+
+
+def test_run_joins_arguments_the_way_ssh_does(tmp_path):
+    """`run` mirrors plain ssh: trailing args are joined and handed to the
+    remote shell. That is what makes `run 'exit 42'` work AND `run ls -la`."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "run", "echo", "one", "two")
+    assert r.stdout.strip() == "one two", r.stdout
+
+
+def test_run_preserves_a_quoted_argument_end_to_end(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "run", "printf '%s' 'a b'")
+    assert r.stdout == "a b", repr(r.stdout)
+
+
+def test_scp_substitutes_the_address_for_a_leading_colon(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(NEBULA,))
+    r = run(env, "--dry-run", "scp", "./local.txt", ":/tmp/remote.txt")
+    assert "%s:/tmp/remote.txt" % NEBULA in r.stdout, r.stdout
+    assert "./local.txt" in r.stdout, r.stdout
+
+
+def test_forward_builds_a_dash_L_tunnel(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "--dry-run", "forward", "8080:localhost:80")
+    assert "-N" in r.stdout and "-L 8080:localhost:80" in r.stdout, r.stdout
+
+
+def test_tmux_requests_a_pty(tmp_path):
+    """tmux attach without a PTY fails; -t is not optional here."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "--dry-run", "tmux")
+    assert r.stdout.startswith("ssh -t "), r.stdout
+
+
+# ---------------------------------------------------------------------------
+# 11. kubectl
+# ---------------------------------------------------------------------------
+
+
+def test_kubectl_runs_through_a_tunnel_to_the_hosts_loopback(tmp_path):
+    """The nebula address is NOT in the k3s serving cert's SANs (measured), so
+    a `--server=https://<address>:6443` rewrite is TLS-invalid over that path.
+    Tunnelling to the host's own loopback keeps the cert valid over every path.
+    """
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,), tunnel=True)
+    r = run(env, "--timeout", "8", "kubectl", "get", "nodes")
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+
+    kube = [a for a in invocations(log) if a[0] == "kubectl"]
+    assert kube, invocations(log)
+    argv = kube[0]
+    assert "--server" in argv, argv
+    server = argv[argv.index("--server") + 1]
+    assert server.startswith("https://127.0.0.1:"), server
+    assert argv[-2:] == ["get", "nodes"], argv
+
+
+def test_kubectl_tunnel_targets_the_hosts_apiserver_port(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "--dry-run", "kubectl", "get", "pods")
+    assert ":127.0.0.1:6443" in r.stdout, r.stdout
+    assert "-N" in r.stdout, r.stdout
+
+
+def test_kubectl_runs_directly_when_on_the_target(tmp_path):
+    """On the host itself the kubeconfig's 127.0.0.1:6443 is already correct."""
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,), local_addrs=(NEBULA,))
+    r = run(env, "kubectl", "get", "nodes")
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    kube = [a for a in invocations(log) if a[0] == "kubectl"]
+    assert kube == [["kubectl", "get", "nodes"]], kube
+
+
+# ---------------------------------------------------------------------------
+# 12. Streams, hosts and usage
+# ---------------------------------------------------------------------------
+
+
+def test_stdout_carries_only_the_remote_output_in_the_quiet_case(tmp_path):
+    """Note what this does NOT prove: in the quiet case no report is emitted at
+    all, so it says nothing about WHICH stream a report would go to. The two
+    tests below are the ones that pin that — a mutation battery caught this one
+    passing vacuously against a report_stream mutant."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "run", "echo", "payload")
+    assert r.stdout == "payload\n", repr(r.stdout)
+    assert "workhost:" not in r.stdout, r.stdout
+
+
+def test_the_report_goes_to_stderr_so_stdout_stays_pipeable(tmp_path):
+    """With the report actually emitted, stdout must still be only the payload."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "-v", "run", "echo", "payload")
+    assert r.stdout == "payload\n", repr(r.stdout)
+    assert "workhost: workbench" in r.stderr, r.stderr
+
+
+def test_the_json_report_also_goes_to_stderr_for_an_action_verb(tmp_path):
+    """`workhost --json run …` must not corrupt the command's own stdout."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "--json", "run", "echo", "payload")
+    assert r.stdout == "payload\n", repr(r.stdout)
+    assert json.loads(r.stderr)["selected"] == "lan", r.stderr
+
+
+def test_the_report_goes_to_stdout_for_the_path_verb(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "path")
+    assert "workhost: workbench" in r.stdout, r.stdout
+
+
+def test_check_is_an_alias_for_path(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    a = run(env, "--json", "path").stdout
+    b = run(env, "--json", "check").stdout
+    assert json.loads(a)["selected"] == json.loads(b)["selected"]
+    assert json.loads(b)["host"] == "workbench"
+
+
+def test_ssh_is_the_default_verb(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    bare = run(env, "--dry-run").stdout
+    explicit = run(env, "--dry-run", "ssh").stdout
+    assert bare == explicit, (bare, explicit)
+    assert bare.startswith("ssh "), bare
+
+
+def test_unknown_host_exits_2_and_names_the_known_ones(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "-H", "nosuchhost", "path")
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+    assert "workbench" in r.stderr, r.stderr
+
+
+def test_unknown_verb_is_a_usage_error(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "frobnicate")
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+
+
+def test_workhost_host_env_var_selects_the_host(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    env["WORKHOST_HOST"] = "nosuchhost"
+    r = run(env, "path")
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+    assert "nosuchhost" in r.stderr, r.stderr
+
+
+def test_dash_H_beats_the_env_var(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    env["WORKHOST_HOST"] = "nosuchhost"
+    r = run(env, "-H", "workbench", "path")
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+
+
+def test_flags_after_an_action_verb_go_to_the_verb_not_to_workhost(tmp_path):
+    """`workhost run --json` must send --json to the remote command."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "run", "echo", "--json")
+    assert r.stdout.strip() == "--json", r.stdout
+    assert "{" not in r.stdout, r.stdout
+
+
+def test_no_traceback_on_any_tested_path(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=())
+    for args in (["path"], ["run", "true"], ["--json", "check"], ["--dry-run", "ssh"]):
+        r = run(env, *args)
+        assert "Traceback" not in r.stderr, (args, r.stderr)
+
+
+# ---------------------------------------------------------------------------
+# 13. The host table stays a table
+# ---------------------------------------------------------------------------
+
+
+def test_only_real_hosts_are_in_the_table():
+    """Inventing an address for a host nobody has measured produces a confident
+    wrong connection, which is worse than the host being absent."""
+    src = WORKHOST.read_text(encoding="utf-8")
+    body = src.split("HOSTS = {", 1)[1].split("\n}", 1)[0]
+    assert '"workbench"' in body
+    for absent in ("laptop", "production", "homelab"):
+        assert '"%s": Host(' % absent not in body, "%s got invented into the table" % absent
+
+
+def test_adding_a_host_is_a_table_entry_not_a_code_fork():
+    """The verbs must be driven by the Host dataclass, not by host name."""
+    src = WORKHOST.read_text(encoding="utf-8")
+    build = src.split("def build_remote_command", 1)[1].split("\ndef ", 1)[0]
+    assert "workbench" not in build, "the command builder special-cases a host name"
+
+
+# ---------------------------------------------------------------------------
+# 14. Delivery
+# ---------------------------------------------------------------------------
+
+
+def test_workhost_is_executable():
+    """home.file executable=true is not enough — the tree bit is what ships."""
+    assert os.access(WORKHOST, os.X_OK), "%s is not executable" % WORKHOST
+
+
+def test_workhost_is_deployed_by_home_manager():
+    """A CLI that is not on PATH is not delivered."""
+    nix = (REPO / "nix" / "home.nix").read_text(encoding="utf-8")
+    assert '.local/bin/workhost' in nix, "workhost is not wired onto PATH in nix/home.nix"
+    assert "devrc/scripts/workhost" in nix, "the symlink does not point at the script"
+
+
+def test_workhost_is_tracked_by_git():
+    """The flake silently omits an untracked file, so a green switch can still
+    ship nothing."""
+    r = subprocess.run(
+        ["git", "-C", str(REPO), "ls-files", "--error-unmatch", "scripts/workhost"],
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, "scripts/workhost is not git-tracked: %s" % r.stderr

--- a/scripts/tests/test_workhost.py
+++ b/scripts/tests/test_workhost.py
@@ -42,6 +42,20 @@ TS = "100.64.0.5"
 
 RS = "\x1e"  # record separator between logged invocations
 
+#: Every executable `sandbox()` may place on the stub PATH. Asserted live by
+#: test_the_stub_path_contains_only_declared_stubs, so this set cannot rot away
+#: from what sandbox() actually writes — which is what lets
+#: scripts/tests/test_no_real_launchers.py pin this file's PATH clobber by
+#: ENUMERATION rather than by prose.
+SANDBOX_BINARIES = {
+    "ssh", "scp", "rsync", "tmux", "kubectl", "ip", "tailscale",  # stubs we write
+    "bash", "cp",                                                 # real, by symlink
+}
+
+#: Names in the above set that are also real launchers on this host. They are
+#: present ONLY as stubs this file writes; the assertion below proves it.
+SANDBOX_FAKED_LAUNCHERS = {"ssh", "scp", "rsync", "tmux", "kubectl"}
+
 #: Absolute paths captured from the REAL environment once, so the stubs can use
 #: them while PATH itself stays restricted to the stub dir. A stub that reached
 #: for a bare `cat` would exit 127 under that restricted PATH and be scored as
@@ -939,6 +953,37 @@ def test_adding_a_host_is_a_table_entry_not_a_code_fork():
 # ---------------------------------------------------------------------------
 # 14. Delivery
 # ---------------------------------------------------------------------------
+
+
+def test_the_stub_path_contains_only_declared_stubs(tmp_path):
+    """The live invariant behind this file's PATH clobber.
+
+    `sandbox()` REPLACES PATH rather than prepending to it, which
+    scripts/tests/test_no_real_launchers.py pins as a deliberate site. Replacing
+    is required, not stylistic: the `not-configured` assertions depend on
+    `tailscale` being genuinely ABSENT, and no amount of PREPENDING can make a
+    binary unfindable if one is ever installed on the dev host. The real `ip` is
+    the mirror image — on workbench it reports the nebula address, so a
+    prepended PATH would let the host's true identity leak into tests that must
+    believe they are remote.
+
+    What makes that safe is enumeration: the directory holds only the names
+    below, and every launcher-shaped one among them is a stub THIS FILE wrote.
+    Asserted here rather than asserted in prose, so it cannot rot.
+    """
+    bindir, _, _ = sandbox(tmp_path, ok_addrs=(LAN,), tailscale=[peer("workbench")])
+    names = {p.name for p in bindir.iterdir()}
+
+    assert names <= SANDBOX_BINARIES, "undeclared binary on the stub PATH: %s" % (
+        names - SANDBOX_BINARIES,
+    )
+    # Every launcher-shaped name is a regular file we wrote inside tmp_path —
+    # never a symlink or copy reaching a real system binary.
+    for name in SANDBOX_FAKED_LAUNCHERS & names:
+        path = bindir / name
+        assert not path.is_symlink(), "%s escapes to a real binary" % name
+        body = path.read_text(encoding="utf-8", errors="replace")
+        assert "WH_LOGDIR" in body, "%s is not one of this file's stubs" % name
 
 
 def test_workhost_is_executable():

--- a/scripts/tests/test_workhost.py
+++ b/scripts/tests/test_workhost.py
@@ -21,6 +21,7 @@ import importlib.machinery
 import importlib.util
 import json
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -324,6 +325,41 @@ def non_probe(log: Path):
 
 def peer(name, ip=TS):
     return {"HostName": name, "DNSName": "%s.example.test." % name, "TailscaleIPs": [ip]}
+
+
+#: Every backticked `workhost …` command the tool prints. A string that names a
+#: command is a CLAIM ABOUT THE PARSER, and one of them was false — see
+#: test_every_workhost_command_the_tool_prints_actually_parses.
+WORKHOST_COMMAND_RE = re.compile(r"`(workhost [^`]*)`")
+
+
+def printed_workhost_commands(*streams):
+    out = []
+    for text in streams:
+        out += WORKHOST_COMMAND_RE.findall(text or "")
+    return out
+
+
+def parse_as_workhost(mod, command):
+    """Feed a printed command back through the REAL argument pipeline.
+
+    Returns ``(verb, verb_args, opts)``. This is the pin that a substring grep
+    cannot be: `--accept-key` was present in the advice text the whole time it
+    was being silently discarded by the parser, so any test that only looked
+    for the substring passed against the broken behaviour.
+    """
+    tokens = shlex.split(command)
+    assert tokens and tokens[0] == "workhost", command
+    # Indexed rather than unpacked so the arity of split_argv's return is not
+    # itself part of the assertion. Against the PRE-FIX source (a 3-tuple) this
+    # test must go red on the CLAIM — `accept_key` is False — not on a
+    # ValueError from unpacking, which would be red for a harness reason and
+    # would prove nothing about the guard.
+    parts = mod.split_argv(tokens[1:])
+    globals_, verb, verb_args = parts[0], parts[1], parts[2]
+    opts = mod.build_parser().parse_args(globals_)
+    assert verb in mod.VERBS, (command, verb)
+    return verb, verb_args, opts
 
 
 def load_workhost():
@@ -1586,3 +1622,256 @@ def test_the_kubectl_dry_run_admits_its_port_is_a_placeholder(tmp_path):
     r = run(env, "--dry-run", "kubectl", "get", "pods")
     assert "-L 0:127.0.0.1:6443" in r.stdout, r.stdout
     assert "placeholder" in r.stderr, r.stderr
+
+
+# ---------------------------------------------------------------------------
+# 18. A string that names a command is a claim about the parser
+# ---------------------------------------------------------------------------
+#
+# 🔴 Why this section exists. The advice added for the untrusted-key state read
+# "run `workhost ssh --accept-key` once to trust it" — and that exact command
+# DID NOT WORK. Flags after an action verb belong to the verb, so `--accept-key`
+# fell into ssh's pass-through args, was never parsed, and the run exited 3 with
+# "re-run with --accept-key to trust it once" — the flag the operator had just
+# passed. Measured on a fresh client with a real sshd:
+#
+#   workhost --accept-key ssh   -> reached real ssh, host-key prompt. WORKS.
+#   workhost ssh --accept-key   -> rc 3, "re-run with --accept-key". LOOPS.
+#
+# The same "cannot bootstrap itself" defect one layer up, hitting exactly when
+# the operator is most stuck and least able to guess the other word order.
+#
+# A test that grepped the advice for the substring `--accept-key` would have
+# been GREEN against that, because the substring was there the whole time. So
+# these tests pin the ADVICE and the PARSER to each other: the printed command
+# is extracted from real output and fed back through `split_argv` + the parser.
+
+
+def _drop_kubectl(bindir):
+    (bindir / "kubectl").unlink()
+
+
+#: The LEDGER of every situation in which workhost prints a backticked
+#: `workhost …` command. Enumerated by reading every emitted string literal in
+#: the script (the `sys.std*.write` / `ValueError` / `parser.error` call sites),
+#: not by memory. Add a row when you add such a string.
+ADVICE_SCENARIOS = [
+    # (id, sandbox kwargs, argv, prep)
+    ("untrusted-key-report",
+     dict(ok_addrs=(), hostkey_missing=(LAN, NEBULA)), ("path",), None),
+    ("untrusted-key-action-verb",
+     dict(ok_addrs=(), hostkey_missing=(LAN, NEBULA)), ("run", "true"), None),
+    # --json suppresses the text advice block, so the ONLY backticked command
+    # left on stderr is select_path's own error. Without this row that message
+    # would be covered only in aggregate — i.e. not at all, because the advice
+    # block would satisfy the assertion on its behalf.
+    ("untrusted-key-json-only",
+     dict(ok_addrs=(), hostkey_missing=(LAN, NEBULA)), ("--json", "run", "true"), None),
+    ("forward-no-spec", dict(ok_addrs=(LAN,)), ("forward",), None),
+    ("forward-bad-spec", dict(ok_addrs=(LAN,)), ("forward", "8080"), None),
+    ("no-local-kubectl",
+     dict(ok_addrs=(LAN,), tunnel=True), ("--timeout", "8", "kubectl", "get", "nodes"),
+     _drop_kubectl),
+]
+
+
+@pytest.mark.parametrize(
+    "kwargs,argv,prep", [(k, a, p) for _, k, a, p in ADVICE_SCENARIOS],
+    ids=[i for i, _, _, _ in ADVICE_SCENARIOS],
+)
+def test_every_workhost_command_the_tool_prints_actually_parses(
+    tmp_path, kwargs, argv, prep
+):
+    """Not "contains a plausible string" — actually run it through the parser.
+
+    Positive control is built in: the assertion below fails if NO command was
+    found, so a scenario whose message stops naming a command cannot pass by
+    matching nothing. That reassuring zero is exactly how this guard would rot.
+    """
+    bindir, _, env = sandbox(tmp_path, **kwargs)
+    if prep is not None:
+        prep(bindir)
+    r = run(env, *argv)
+    commands = printed_workhost_commands(r.stdout, r.stderr)
+    assert commands, (argv, r.stdout, r.stderr)
+
+    mod = load_workhost()
+    for command in commands:
+        parse_as_workhost(mod, command)  # raises/asserts if it does not parse
+
+
+def test_the_advice_names_a_command_the_parser_actually_accepts(tmp_path):
+    """🔴 THE pairing guard: the advice must yield `accept_key=True`.
+
+    Extracted from real output, parsed by the real pipeline. If the advice is
+    reworded into a form the parser drops, or the hoist is removed, this goes
+    red — neither side can move without the other.
+    """
+    _, _, env = sandbox(tmp_path, ok_addrs=(), hostkey_missing=(LAN, NEBULA))
+    r = run(env, "path")
+    commands = [c for c in printed_workhost_commands(r.stdout) if "--accept-key" in c]
+    assert commands, r.stdout
+
+    mod = load_workhost()
+    for command in commands:
+        verb, verb_args, opts = parse_as_workhost(mod, command)
+        assert opts.accept_key is True, (command, verb, verb_args)
+        # And it must not ALSO still be sitting in the verb's pass-through args,
+        # which would mean it reaches the remote command as a literal argument.
+        assert "--accept-key" not in verb_args, (command, verb_args)
+
+
+def test_following_the_printed_advice_actually_connects(tmp_path):
+    """End to end: take the command the tool printed and RUN it.
+
+    The stub refuses the unknown key under BatchMode and proceeds without it,
+    exactly as ssh does, so this is green only if the advised invocation really
+    reaches an interactive connection.
+    """
+    _, log, env = sandbox(tmp_path, ok_addrs=(), hostkey_missing=(LAN, NEBULA))
+    stuck = run(env, "path")
+    assert stuck.returncode == 3, (stuck.returncode, stuck.stdout)
+
+    commands = [c for c in printed_workhost_commands(stuck.stdout) if "--accept-key" in c]
+    assert commands, stuck.stdout
+    tokens = shlex.split(commands[0])[1:]  # drop the `workhost` argv[0]
+
+    followed = run(env, *tokens)
+    assert followed.returncode == 0, (tokens, followed.returncode, followed.stderr)
+    remote = non_probe(log)
+    assert remote and LAN in remote[0], remote
+    assert "BatchMode=yes" not in remote[0], remote[0]
+
+
+def test_every_workhost_command_in_the_readme_parses_and_means_what_it_says():
+    """The same class one file over. `scripts/README.md` also tells the reader
+    to run `workhost ssh --accept-key`, and that instruction was false for
+    exactly as long as the advice block's was — a doc is not exempt from being
+    a claim about the parser."""
+    readme = (REPO / "scripts" / "README.md").read_text(encoding="utf-8")
+    commands = printed_workhost_commands(readme)
+    assert commands, "scripts/README.md no longer names any workhost command"
+
+    mod = load_workhost()
+    for command in commands:
+        verb, verb_args, opts = parse_as_workhost(mod, command)
+        if "--accept-key" in command:
+            assert opts.accept_key is True, (command, verb, verb_args)
+            assert "--accept-key" not in verb_args, (command, verb_args)
+
+
+def test_the_forward_example_is_a_spec_the_validator_itself_accepts(tmp_path):
+    """The no-spec error names an example. An example the validator would
+    reject is the same class of false claim one step further in."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "forward")
+    commands = [c for c in printed_workhost_commands(r.stderr) if " forward " in c]
+    assert commands, r.stderr
+
+    mod = load_workhost()
+    for command in commands:
+        verb, verb_args, _ = parse_as_workhost(mod, command)
+        assert verb == "forward", command
+        mod.validate_forward_spec(verb_args)  # raises ValueError if it lied
+
+
+def test_the_manual_ssh_line_uses_the_options_the_tool_itself_uses(tmp_path):
+    """The `or: ssh …` fallback is derived from `ssh_options`, not spelled
+    beside it. Advice that omitted the alias would tell the operator to create
+    the second known_hosts entry this tool exists to prevent."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(), hostkey_missing=(LAN, NEBULA))
+    r = run(env, "path")
+
+    mod = load_workhost()
+    expected = " ".join(
+        ["ssh"] + mod.ssh_options(mod.HOSTS["workbench"]) + [LAN]
+    )
+    assert expected in r.stdout, (expected, r.stdout)
+
+
+def test_the_changed_key_advice_removes_the_alias_not_an_address(tmp_path):
+    """`ssh-keygen -R` keyed on an address deletes the wrong line — or none —
+    because HostKeyAlias is what the offending entry is keyed on."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(), hostkey_changed=(LAN, NEBULA))
+    r = run(env, "path")
+
+    mod = load_workhost()
+    alias = [
+        o.split("=", 1)[1]
+        for o in mod.ssh_options(mod.HOSTS["workbench"])
+        if o.startswith("HostKeyAlias=")
+    ]
+    assert alias, mod.ssh_options(mod.HOSTS["workbench"])
+    assert "ssh-keygen -R %s" % alias[0] in r.stdout, r.stdout
+    assert "ssh-keygen -R %s" % LAN not in r.stdout, r.stdout
+    assert "ssh-keygen -R %s" % NEBULA not in r.stdout, r.stdout
+
+
+# ---------------------------------------------------------------------------
+# 19. --accept-key works in BOTH argument positions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ("--accept-key", "run", "echo", "bootstrapped"),
+        ("run", "--accept-key", "echo", "bootstrapped"),
+        ("run", "echo", "bootstrapped", "--accept-key"),
+    ],
+    ids=["before-verb", "after-verb", "trailing"],
+)
+def test_accept_key_is_honoured_in_either_position(tmp_path, argv):
+    """Operators will type it AFTER the verb, because that is the form the tool
+    prints and because it reads naturally."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(), hostkey_missing=(LAN,))
+    r = run(env, *argv)
+    assert r.returncode == 0, (argv, r.returncode, r.stdout, r.stderr)
+    assert r.stdout.strip() == "bootstrapped", (argv, r.stdout)
+
+
+def test_a_hoisted_flag_is_removed_from_the_remote_argv_and_said_so(tmp_path):
+    """Hoisting changes what the remote command receives, so it is audible.
+    Silently dropping it is the one behaviour that is not acceptable."""
+    _, log, env = sandbox(tmp_path, ok_addrs=(), hostkey_missing=(LAN,))
+    r = run(env, "run", "--accept-key", "echo", "hi")
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert "taken as a workhost flag" in r.stderr, r.stderr
+
+    # The notice names the verb it was NOT passed to; that name is a claim too.
+    mod = load_workhost()
+    named = re.findall(r"not passed to `([^`]*)`", r.stderr)
+    assert named, r.stderr
+    for verb in named:
+        assert verb in mod.VERBS, (verb, mod.VERBS)
+
+    remote = non_probe(log)
+    assert remote, remote
+    assert "--accept-key" not in remote[0], remote[0]
+
+
+def test_nothing_is_said_when_no_flag_was_hoisted(tmp_path):
+    """The notice must not fire on an ordinary run, or it is noise that trains
+    people to ignore it."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "run", "echo", "hi")
+    assert "taken as a workhost flag" not in r.stderr, r.stderr
+
+
+def test_only_declared_flags_are_hoisted(tmp_path):
+    """The positional rule still holds for everything else: `workhost run
+    --json` must send `--json` to the REMOTE command, not switch workhost into
+    JSON mode. Hoisting is a narrow, enumerated exception."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "run", "echo", "--json", "--dry-run", "--verbose")
+    assert r.stdout.strip() == "--json --dry-run --verbose", r.stdout
+    assert "{" not in r.stdout, r.stdout
+
+
+def test_a_quoted_accept_key_still_reaches_the_remote_shell(tmp_path):
+    """The named escape for the one case hoisting costs: `run` joins its args
+    and hands them to the remote shell, so quoting keeps the flag as text."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "run", "echo one --accept-key two")
+    assert r.stdout.strip() == "one --accept-key two", r.stdout
+    assert "taken as a workhost flag" not in r.stderr, r.stderr

--- a/scripts/tests/test_workhost.py
+++ b/scripts/tests/test_workhost.py
@@ -1000,10 +1000,36 @@ def test_workhost_is_deployed_by_home_manager():
 
 def test_workhost_is_tracked_by_git():
     """The flake silently omits an untracked file, so a green switch can still
-    ship nothing."""
-    r = subprocess.run(
-        ["git", "-C", str(REPO), "ls-files", "--error-unmatch", "scripts/workhost"],
-        capture_output=True,
-        text=True,
-    )
-    assert r.returncode == 0, "scripts/workhost is not git-tracked: %s" % r.stderr
+    ship nothing.
+
+    🔴 NOT a skipif, and NOT one assertion. This suite runs in TWO TIERS and they
+    are blind in opposite directions: the dev shell has the repo's `.git`, the
+    nix sandbox does not (its source is copied in, so `git -C REPO ls-files`
+    exits 128 `not a git repository`). An earlier version asserted only the git
+    form; it was green in the dev shell and RED in CI, which is precisely the
+    failure this file is supposed to be able to see rather than suffer.
+
+    So each tier asserts the strongest claim IT can make, and neither is vacuous:
+
+    * `.git` present  -> ask git directly whether the path is tracked.
+    * `.git` absent   -> we are inside the sandbox, whose source came from the
+      flake. The flake copies TRACKED files only, so the file being HERE AT ALL
+      is the tracked-ness proof for this tier. An untracked `scripts/workhost`
+      would simply not exist in the sandbox and this arm goes red.
+    """
+    has_git_metadata = (REPO / ".git").exists()
+
+    if has_git_metadata:
+        r = subprocess.run(
+            ["git", "-C", str(REPO), "ls-files", "--error-unmatch", "scripts/workhost"],
+            capture_output=True,
+            text=True,
+        )
+        assert r.returncode == 0, (
+            "scripts/workhost is not git-tracked, so the flake will omit it and a "
+            "green `home-manager switch` would ship nothing: %s" % r.stderr)
+    else:
+        assert WORKHOST.is_file(), (
+            "scripts/workhost is absent from a checkout with no .git — i.e. from "
+            "the nix sandbox, whose source is the flake's TRACKED-files-only copy. "
+            "That means the file is untracked and the flake dropped it.")

--- a/scripts/tests/test_workhost.py
+++ b/scripts/tests/test_workhost.py
@@ -17,8 +17,11 @@ reason.
 """
 from __future__ import annotations
 
+import importlib.machinery
+import importlib.util
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -115,8 +118,12 @@ SSH_STUB = (
     % REAL_DATE
     + """
 LSPEC=""
+BATCH=""
 for a in "$@"; do
-  case "$a" in *:127.0.0.1:*) LSPEC="$a" ;; esac
+  case "$a" in
+    *:127.0.0.1:*) LSPEC="$a" ;;
+    BatchMode=yes) BATCH=1 ;;
+  esac
 done
 
 while [ $# -gt 0 ]; do
@@ -135,7 +142,43 @@ ok=1
 for a in ${WH_OK_ADDRS:-}; do
   [ "$a" = "$ADDR" ] && ok=0
 done
-[ $ok -eq 0 ] || exit 255
+
+# Real ssh exits 255 for EVERY connection-level failure — auth, DNS, timeout
+# and host key alike. A stub that only ever exits 255 therefore cannot tell
+# those apart, and a suite built on it ASSERTS the conflation: `255` is all it
+# can ever see. So the three cases are separated the only way real ssh
+# separates them, by the MESSAGE, and each is reachable from a test.
+if [ $ok -ne 0 ]; then
+  # A key that CHANGED is refused whether or not there is a human at the
+  # keyboard: real ssh does not offer to accept it, it tells you to remove the
+  # offending known_hosts line.
+  for a in ${WH_HOSTKEY_CHANGED_ADDRS:-}; do
+    if [ "$a" = "$ADDR" ]; then
+      printf '@@@ WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED! @@@\\n' >&2
+      printf 'IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!\\n' >&2
+      printf 'Host key verification failed.\\n' >&2
+      exit 255
+    fi
+  done
+  # A key never seen before is refused under BatchMode and ACCEPTED
+  # interactively — which is the whole mechanism --accept-key relies on, so the
+  # stub has to model the difference rather than exit 255 unconditionally.
+  for a in ${WH_HOSTKEY_MISSING_ADDRS:-}; do
+    if [ "$a" = "$ADDR" ]; then
+      if [ -n "$BATCH" ]; then
+        printf 'The authenticity of host %s cannot be established.\\n' "$ADDR" >&2
+        printf 'Host key verification failed.\\n' >&2
+        exit 255
+      fi
+      ok=0
+    fi
+  done
+fi
+
+if [ $ok -ne 0 ]; then
+  printf 'someone@%s: Permission denied (publickey,password).\\n' "$ADDR" >&2
+  exit 255
+fi
 
 if [ -n "$LSPEC" ] && [ -n "${WH_TUNNEL:-}" ]; then
   PORT="${LSPEC%%:*}"
@@ -177,14 +220,27 @@ def sandbox(
     ok_addrs=(),
     local_addrs=("10.9.9.9",),
     tailscale=None,
+    tailscale_raw=None,
     delay=None,
     tunnel=False,
+    hostkey_missing=(),
+    hostkey_changed=(),
+    ssh=True,
 ):
     """Build a stub-only PATH and the env that drives it.
 
     ``tailscale`` is None for "no tailscale binary exists at all", or a list of
     peer dicts for a tailnet that does exist. Those two are different states and
-    the tests below assert they stay different.
+    the tests below assert they stay different. ``tailscale_raw`` writes an
+    arbitrary JSON body instead, for the valid-but-not-an-object cases.
+
+    ``hostkey_missing`` / ``hostkey_changed`` list addresses for which the ssh
+    stub reproduces ssh's two host-key refusals. They are separate from
+    ``ok_addrs`` on purpose: an address in neither set gets an AUTH failure, so
+    the three ways of exiting 255 are all reachable and can be pinned apart.
+
+    ``ssh=False`` writes no ssh stub at all — the "no ssh binary on PATH" case,
+    which is the client-side mirror of `tailscale` being absent.
     """
     tmp_path.mkdir(parents=True, exist_ok=True)
     bindir = tmp_path / "bin"
@@ -194,12 +250,15 @@ def sandbox(
     timedir = tmp_path / "times.d"
     timedir.mkdir(exist_ok=True)
 
-    mockbin.write_exec(bindir / "ssh", SSH_STUB)
+    if ssh:
+        mockbin.write_exec(bindir / "ssh", SSH_STUB)
     for name in ("scp", "rsync", "tmux", "kubectl"):
         mockbin.write_exec(bindir / name, RECORDER_STUB)
     mockbin.write_exec(bindir / "ip", _ip_stub(local_addrs))
 
-    if tailscale is not None:
+    if tailscale_raw is not None:
+        mockbin.write_exec(bindir / "tailscale", _tailscale_stub(tailscale_raw))
+    elif tailscale is not None:
         status = {"Self": {"HostName": "someclient", "TailscaleIPs": ["100.64.0.2"]}}
         status["Peer"] = {"nodekey:%d" % i: p for i, p in enumerate(tailscale)}
         mockbin.write_exec(bindir / "tailscale", _tailscale_stub(json.dumps(status)))
@@ -217,6 +276,8 @@ def sandbox(
         "WH_LOGDIR": str(log),
         "WH_TIMEDIR": str(timedir),
         "WH_OK_ADDRS": " ".join(ok_addrs),
+        "WH_HOSTKEY_MISSING_ADDRS": " ".join(hostkey_missing),
+        "WH_HOSTKEY_CHANGED_ADDRS": " ".join(hostkey_changed),
         "WH_PYTHON": sys.executable,
     }
     if delay is not None:
@@ -263,6 +324,27 @@ def non_probe(log: Path):
 
 def peer(name, ip=TS):
     return {"HostName": name, "DNSName": "%s.example.test." % name, "TailscaleIPs": [ip]}
+
+
+def load_workhost():
+    """Import `scripts/workhost` as a module, freshly, for unit-level checks.
+
+    Used ONLY where the CLI cannot reach the branch — i.e. where the input is a
+    `Host` that deliberately does not exist in the shipped table. A fresh module
+    object each call so a test that rebinds a function cannot leak into another.
+    """
+    loader = importlib.machinery.SourceFileLoader("workhost_under_test", str(WORKHOST))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    mod = importlib.util.module_from_spec(spec)
+    # @dataclass resolves `cls.__module__` through sys.modules while the class
+    # body executes, so the module must be registered BEFORE exec_module or the
+    # decorator dies on a None lookup. Popped again so nothing leaks.
+    sys.modules[loader.name] = mod
+    try:
+        loader.exec_module(mod)
+    finally:
+        sys.modules.pop(loader.name, None)
+    return mod
 
 
 # ---------------------------------------------------------------------------
@@ -390,14 +472,63 @@ def test_run_false_exits_1(tmp_path):
     assert r.returncode == 1, (r.returncode, r.stdout, r.stderr)
 
 
-def test_exit_3_is_distinguishable_from_a_remote_failure(tmp_path):
-    """Both are non-zero; they must not be the same non-zero."""
+@pytest.mark.parametrize("code", [1, 2, 42])
+def test_exit_3_is_distinguishable_from_a_remote_failure(tmp_path, code):
+    """Both are non-zero; for these codes they are not the same non-zero.
+
+    Parametrised over more than one remote code on purpose. The single-value
+    version of this test carried a name — and backed a docstring — far wider
+    than what it proved: `[1]` alone says nothing about 3, which is exactly
+    where the claim breaks. See the two collision tests below, which pin the
+    boundary rather than let the name imply it does not exist.
+    """
     _, _, up = sandbox(tmp_path / "u", ok_addrs=(LAN,))
     (tmp_path / "u").mkdir(exist_ok=True)
     _, _, down = sandbox(tmp_path / "d", ok_addrs=())
     (tmp_path / "d").mkdir(exist_ok=True)
-    assert run(up, "run", "exit 1").returncode == 1
-    assert run(down, "run", "exit 1").returncode == 3
+    assert run(up, "run", "exit %d" % code).returncode == code
+    assert run(down, "run", "exit %d" % code).returncode == 3
+
+
+def test_exit_3_collides_with_a_remote_exit_3_and_json_disambiguates(tmp_path):
+    """🔴 The honest boundary of the exit-code contract.
+
+    `EXIT_NO_PATH = 3` is conventional, not reserved: a remote command that
+    chooses `exit 3` produces the same status as "no path to the box". The
+    docstring in `scripts/workhost` used to claim 3 was "distinct from any
+    remote exit code", which is wider than the code. This test is what stops
+    that claim regrowing, and names the channel that IS unambiguous — `--json`,
+    where `selected` is null exactly when no path was usable.
+    """
+    _, _, up = sandbox(tmp_path / "u", ok_addrs=(LAN,))
+    (tmp_path / "u").mkdir(exist_ok=True)
+    _, _, down = sandbox(tmp_path / "d", ok_addrs=())
+    (tmp_path / "d").mkdir(exist_ok=True)
+
+    a = run(up, "--json", "run", "exit 3")
+    b = run(down, "--json", "run", "exit 3")
+    assert a.returncode == 3 and b.returncode == 3, (a.returncode, b.returncode)
+
+    # The no-path run also writes a `workhost: …` line after the report, so the
+    # JSON is decoded off the front rather than from the whole stream.
+    decode = json.JSONDecoder().raw_decode
+    assert decode(a.stderr)[0]["selected"] == "lan", a.stderr
+    assert decode(b.stderr)[0]["selected"] is None, b.stderr
+
+
+def test_usage_exit_2_collides_with_a_remote_exit_2(tmp_path):
+    """The second collision the PR body used to gloss over.
+
+    Discriminated by the `workhost:` prefix on stderr, which a remote command's
+    own failure never produces.
+    """
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    remote = run(env, "run", "exit 2")
+    usage = run(env, "-H", "nosuchhost", "run", "exit 2")
+
+    assert remote.returncode == 2 and usage.returncode == 2
+    assert "workhost:" not in remote.stderr, remote.stderr
+    assert "workhost: unknown host" in usage.stderr, usage.stderr
 
 
 # ---------------------------------------------------------------------------
@@ -437,7 +568,10 @@ def test_rsync_threads_the_alias_through_dash_e(tmp_path):
     alias is silently lost for exactly this verb."""
     _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
     r = run(env, "--dry-run", "rsync", "-a", "./d/", ":/tmp/d/")
-    assert "-e ssh -o HostKeyAlias=workbench" in r.stdout, r.stdout
+    # `--dry-run` shlex-joins now, so the -e value is printed as ONE quoted
+    # argument — which is what it is. Asserting the quoted form rather than a
+    # bare substring keeps the guard honest about what actually gets exec'd.
+    assert "-e 'ssh -o HostKeyAlias=workbench" in r.stdout, r.stdout
 
 
 def test_the_probe_itself_carries_the_alias(tmp_path):
@@ -496,11 +630,49 @@ def test_runs_locally_when_the_nebula_address_is_ours(tmp_path):
     assert non_probe(log) == [], "should not have opened an ssh session to itself"
 
 
-def test_runs_locally_when_the_lan_address_is_ours(tmp_path):
+def test_the_lan_address_alone_does_not_prove_we_are_the_target(tmp_path):
+    """🔴 THE HAZARD, pinned — not merely that the fallback fires.
+
+    A LAN address is unique within ONE SUBNET, so a laptop on a network that
+    hands it 192.168.50.250 used to satisfy `is_local_host(workbench)`. Then
+    `workhost run 'kubectl delete ns prod'` executed on the LAPTOP, exited 0,
+    and in the quiet path printed nothing that said workbench was never
+    touched: the same silent wrong-machine execution the hostname check was
+    rejected to prevent, one layer down.
+
+    workbench HAS a nebula address in the table, so its LAN address is no
+    longer accepted as self-identification. The tool must go over the wire.
+    """
     _, log, env = sandbox(tmp_path, ok_addrs=(LAN,), local_addrs=(LAN,))
-    r = run(env, "run", "echo", "hello-local")
-    assert r.stdout.strip() == "hello-local", r.stdout
-    assert non_probe(log) == [], non_probe(log)
+    r = run(env, "run", "echo", "hello")
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    remote = non_probe(log)
+    assert remote, "ran LOCALLY on a bare LAN-address match — wrong machine"
+    assert remote[0][0] == "ssh", remote
+    assert LAN in remote[0], remote
+
+
+def test_the_lan_address_is_accepted_when_the_host_has_no_nebula_address(tmp_path):
+    """The tightening above is conditional, not a removal.
+
+    Driven through the module rather than the CLI because HOSTS deliberately
+    holds exactly one real host and that host HAS a nebula address — inventing a
+    second table entry to test with is the thing `test_only_real_hosts_are_in_
+    the_table` forbids. So the branch is exercised on a Host built in the test.
+    """
+    mod = load_workhost()
+    addrs = {LAN, "10.9.9.9"}
+    mod.local_ipv4_addresses = lambda: addrs
+
+    with_nebula = mod.Host(name="w", lan=LAN, nebula=NEBULA)
+    without_nebula = mod.Host(name="w", lan=LAN)
+
+    assert mod.is_local_host(with_nebula) is False
+    assert mod.is_local_host(without_nebula) is True
+
+    # And the nebula address alone still identifies us, table entry or not.
+    mod.local_ipv4_addresses = lambda: {NEBULA}
+    assert mod.is_local_host(with_nebula) is True
 
 
 def test_runs_remotely_when_no_address_is_ours(tmp_path):
@@ -780,9 +952,66 @@ def test_scp_substitutes_the_address_for_a_leading_colon(tmp_path):
 
 
 def test_forward_builds_a_dash_L_tunnel(tmp_path):
+    """The WHOLE argv, not just `-N` and `-L`.
+
+    The earlier version asserted only that those two tokens appeared. That is
+    satisfied by an ssh which binds nothing and stays alive anyway, because
+    `ExitOnForwardFailure` defaults to `no` — so `forward 8080:…` against an
+    already-bound 8080 blocked forever with no verdict while the operator
+    believed the tunnel was up. Pinning the exact argv is what makes the fix
+    un-droppable.
+    """
     _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
     r = run(env, "--dry-run", "forward", "8080:localhost:80")
-    assert "-N" in r.stdout and "-L 8080:localhost:80" in r.stdout, r.stdout
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert shlex.split(r.stdout) == [
+        "ssh",
+        "-N",
+        "-L", "8080:localhost:80",
+        "-o", "ExitOnForwardFailure=yes",
+        "-o", "HostKeyAlias=workbench",
+        "-o", "ConnectTimeout=5",
+        LAN,
+    ], r.stdout
+
+
+def test_forward_with_no_spec_is_refused_rather_than_forwarding_nothing(tmp_path):
+    """`spec = list(args)` was never validated, so a bare `workhost forward`
+    built a fully authenticated `ssh -N` with ZERO `-L` flags and idled until
+    killed — success-shaped, and under `--dry-run` it printed a plausible
+    command. Nothing about that told the operator they had forwarded nothing."""
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "forward")
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+    assert "forwards nothing" in r.stderr, r.stderr
+    assert non_probe(log) == [], "opened a session despite forwarding nothing"
+
+
+@pytest.mark.parametrize("spec", ["8080", "8080:localhost", "http:localhost:80", ""])
+def test_forward_rejects_a_spec_that_is_not_a_port_forward(tmp_path, spec):
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "--dry-run", "forward", spec)
+    assert r.returncode == 2, (spec, r.returncode, r.stdout, r.stderr)
+    assert r.stdout == "", r.stdout
+    assert non_probe(log) == [], non_probe(log)
+
+
+def test_forward_accepts_an_explicit_bind_address(tmp_path):
+    """The narrow shape check must not reject the four-field form."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "--dry-run", "forward", "127.0.0.1:8080:localhost:80")
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert "-L 127.0.0.1:8080:localhost:80" in r.stdout, r.stdout
+
+
+def test_the_kubectl_tunnel_also_exits_on_a_failed_bind(tmp_path):
+    """Same defect, and worse: `free_local_port()` picks a port and lets go of
+    it, so a thief can take it before ssh binds. Without this option ssh would
+    survive the failed bind, the readiness probe would connect to the THIEF, and
+    `kubectl --server` would be aimed at an unrelated local service."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "--dry-run", "kubectl", "get", "pods")
+    assert "-o ExitOnForwardFailure=yes" in r.stdout, r.stdout
 
 
 def test_tmux_requests_a_pty(tmp_path):
@@ -1033,3 +1262,327 @@ def test_workhost_is_tracked_by_git():
             "scripts/workhost is absent from a checkout with no .git — i.e. from "
             "the nix sandbox, whose source is the flake's TRACKED-files-only copy. "
             "That means the file is untracked and the flake dropped it.")
+
+
+# ---------------------------------------------------------------------------
+# 15. The fourth state: an untrusted host key is not an unreachable host
+# ---------------------------------------------------------------------------
+#
+# 🔴 Why this section exists at all. `-o HostKeyAlias=workbench` makes ssh look
+# up `workbench` in known_hosts and IGNORE the address entries, and the probe
+# runs `BatchMode=yes` while `StrictHostKeyChecking` defaults to `ask`. So on any
+# client that has never trusted that alias — the laptop, i.e. the ONLY machine
+# where this tool does anything, since on workbench it takes the local branch —
+# every path reported `unreachable` on a perfectly healthy network and every
+# verb refused with exit 3. The tool could not bootstrap itself, and said the
+# network was down.
+#
+# Reproduced live twice before the fix: a fresh client with an empty known_hosts
+# running the exact probe argv got `Host key verification failed.` and wrote
+# ZERO bytes to known_hosts; this dev host, with the alias present at line 369 of
+# 370, got `Permission denied (publickey,…)` instead. The only reason it looked
+# fine here is a known_hosts line appended during development.
+#
+# The stub can now produce all three ways of exiting 255 — auth, key-missing,
+# key-changed — so these are pinned APART rather than conflated, in BOTH
+# directions.
+
+
+def states(r):
+    return {p["path"]: p for p in json.loads(r.stdout)["paths"]}
+
+
+def test_a_host_key_refusal_is_untrusted_key_not_unreachable(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(), hostkey_missing=(LAN, NEBULA))
+    r = run(env, "--json", "path")
+    by_path = states(r)
+    assert by_path["lan"]["state"] == "untrusted-key", r.stdout
+    assert by_path["nebula"]["state"] == "untrusted-key", r.stdout
+    assert by_path["lan"]["address"] == LAN, r.stdout
+    assert "known_hosts" in by_path["lan"]["detail"], by_path["lan"]["detail"]
+
+
+def test_an_auth_failure_is_unreachable_not_untrusted_key(tmp_path):
+    """The other direction. ssh exits 255 for auth failure AND for a host-key
+    refusal, so a classifier keyed on the exit status would call both the same
+    thing — which is what the suite used to assert."""
+    _, _, env = sandbox(tmp_path, ok_addrs=())
+    r = run(env, "--json", "path")
+    by_path = states(r)
+    assert by_path["lan"]["state"] == "unreachable", r.stdout
+    assert by_path["nebula"]["state"] == "unreachable", r.stdout
+    assert "Permission denied" in by_path["lan"]["detail"], by_path["lan"]["detail"]
+
+
+def test_the_two_ssh_255_failures_are_told_apart_in_one_run(tmp_path):
+    """Both in the SAME invocation, so no ordering or environment difference can
+    be what separates them: LAN gets the host-key refusal, nebula the auth one.
+    """
+    _, _, env = sandbox(tmp_path, ok_addrs=(), hostkey_missing=(LAN,))
+    r = run(env, "--json", "path")
+    by_path = states(r)
+    assert by_path["lan"]["state"] == "untrusted-key", r.stdout
+    assert by_path["nebula"]["state"] == "unreachable", r.stdout
+
+
+def test_a_changed_host_key_is_untrusted_key_with_its_own_detail(tmp_path):
+    """Same state, different and more alarming cause: a key that CHANGED is a
+    reinstall or an interception, never a first contact."""
+    _, _, changed = sandbox(tmp_path / "c", ok_addrs=(), hostkey_changed=(LAN,))
+    (tmp_path / "c").mkdir(exist_ok=True)
+    _, _, missing = sandbox(tmp_path / "m", ok_addrs=(), hostkey_missing=(LAN,))
+    (tmp_path / "m").mkdir(exist_ok=True)
+
+    c = states(run(changed, "--json", "path"))["lan"]
+    m = states(run(missing, "--json", "path"))["lan"]
+
+    assert c["state"] == "untrusted-key" and m["state"] == "untrusted-key"
+    assert "CHANGED" in c["detail"], c["detail"]
+    assert c["detail"] != m["detail"], (c["detail"], m["detail"])
+
+
+def test_untrusted_key_is_its_own_json_value(tmp_path):
+    """Not folded into `unreachable`, and not invented as a detail string on an
+    existing state — a machine consumer must be able to branch on it."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(), hostkey_missing=(LAN, NEBULA))
+    r = run(env, "--json", "path")
+    values = {p["state"] for p in json.loads(r.stdout)["paths"]}
+    assert "untrusted-key" in values, r.stdout
+    assert "unreachable" not in values, r.stdout
+
+
+def test_the_report_names_the_cause_and_the_way_out(tmp_path):
+    """A state name alone still leaves the operator to work out that ssh will
+    never prompt, because the PROBE is the thing running BatchMode."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(), hostkey_missing=(LAN, NEBULA))
+    r = run(env, "path")
+    assert r.returncode == 3, (r.returncode, r.stdout, r.stderr)
+    assert "untrusted-key" in r.stdout, r.stdout
+    assert "not in known_hosts" in r.stdout, r.stdout
+    assert "workhost ssh --accept-key" in r.stdout, r.stdout
+    assert "ssh -o HostKeyAlias=workbench %s" % LAN in r.stdout, r.stdout
+
+
+def test_a_changed_key_is_not_offered_the_accept_key_shortcut(tmp_path):
+    """`--accept-key` is the wrong answer to a key that changed — real ssh does
+    not offer to accept one, it tells you to remove the offending line."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(), hostkey_changed=(LAN, NEBULA))
+    r = run(env, "path")
+    assert "ssh-keygen -R workbench" in r.stdout, r.stdout
+    assert "--accept-key" not in r.stdout, r.stdout
+
+
+def test_no_advice_is_printed_when_a_path_is_actually_usable(tmp_path):
+    """The advice block must not fire on a run that worked."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(NEBULA,), hostkey_missing=(LAN,))
+    r = run(env, "path")
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert "--accept-key" not in r.stdout, r.stdout
+
+
+def test_an_action_verb_refuses_and_says_why_when_only_the_key_blocks(tmp_path):
+    _, log, env = sandbox(tmp_path, ok_addrs=(), hostkey_missing=(LAN, NEBULA))
+    r = run(env, "run", "echo", "hi")
+    assert r.returncode == 3, (r.returncode, r.stdout, r.stderr)
+    assert "host key is not trusted" in r.stderr, r.stderr
+    assert "--accept-key" in r.stderr, r.stderr
+    assert non_probe(log) == [], non_probe(log)
+
+
+# --- the bootstrap escape hatch --------------------------------------------
+
+
+def test_accept_key_lets_an_untrusted_path_be_used(tmp_path):
+    """The stub models the real mechanism rather than a canned success: under
+    `BatchMode=yes` it refuses the unknown key exactly as ssh does, and without
+    BatchMode it proceeds, as ssh does once a human answers the prompt. So this
+    test is only green if `--accept-key` actually causes an interactive (no
+    BatchMode) connection to be attempted."""
+    _, log, env = sandbox(tmp_path, ok_addrs=(), hostkey_missing=(LAN,))
+    r = run(env, "--accept-key", "run", "echo", "bootstrapped")
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert r.stdout.strip() == "bootstrapped", r.stdout
+    remote = non_probe(log)
+    assert remote and LAN in remote[0], remote
+    assert "BatchMode=yes" not in remote[0], remote[0]
+
+
+def test_accept_key_does_not_make_an_unreachable_path_usable(tmp_path):
+    """It widens the acceptable set by exactly one state. A down path stays
+    down, or the flag would be a way to paper over a real outage."""
+    _, log, env = sandbox(tmp_path, ok_addrs=())
+    r = run(env, "--accept-key", "run", "echo", "nope")
+    assert r.returncode == 3, (r.returncode, r.stdout, r.stderr)
+    assert non_probe(log) == [], non_probe(log)
+
+
+def test_accept_key_still_prefers_a_path_that_is_already_ok(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(NEBULA,), hostkey_missing=(LAN,))
+    r = run(env, "--accept-key", "--json", "path")
+    assert json.loads(r.stdout)["selected"] == "nebula", r.stdout
+
+
+def test_forcing_an_untrusted_path_needs_the_opt_in(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(), hostkey_missing=(LAN,))
+    refused = run(env, "--path", "lan", "run", "echo", "x")
+    assert refused.returncode == 3, (refused.returncode, refused.stderr)
+    assert "untrusted-key" in refused.stderr, refused.stderr
+
+    allowed = run(env, "--path", "lan", "--accept-key", "run", "echo", "x")
+    assert allowed.returncode == 0, (allowed.returncode, allowed.stderr)
+
+
+def test_the_probe_never_enables_tofu(tmp_path):
+    """TOFU was explicitly rejected: a probe that silently accepts a new host
+    key trusts the machine on the operator's behalf, every run, with no record
+    that a decision was made."""
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    run(env, "path")
+    probes = [a for a in invocations(log) if a[-1] == "true"]
+    assert probes, "no probe was recorded"
+    for argv in probes:
+        joined = " ".join(argv)
+        assert "StrictHostKeyChecking" not in joined, argv
+        assert "accept-new" not in joined, argv
+
+
+def test_accept_key_cannot_reach_the_probe(tmp_path):
+    """The opt-in must be structurally unable to leak into the probe: the probe
+    argv is byte-identical with and without the flag."""
+    _, plain_log, plain = sandbox(tmp_path / "p", ok_addrs=(), hostkey_missing=(LAN,))
+    (tmp_path / "p").mkdir(exist_ok=True)
+    _, opt_log, opted = sandbox(tmp_path / "o", ok_addrs=(), hostkey_missing=(LAN,))
+    (tmp_path / "o").mkdir(exist_ok=True)
+
+    run(plain, "path")
+    run(opted, "--accept-key", "path")
+
+    def probe_argvs(log):
+        return sorted(tuple(a) for a in invocations(log) if a[-1] == "true")
+
+    assert probe_argvs(plain_log) == probe_argvs(opt_log), (
+        probe_argvs(plain_log),
+        probe_argvs(opt_log),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 16. Failing loudly instead of crashing
+# ---------------------------------------------------------------------------
+
+
+def test_kubectl_without_a_local_kubectl_exits_127_not_a_traceback(tmp_path):
+    """The irony this guard preserves: `workhost kubectl` tunnels PRECISELY so
+    it can use the LOCAL kubectl, because the remote non-login shell on NixOS
+    frequently has none — and the newly-depended-on local binary was the one
+    unhandled case. `main`'s FileNotFoundError->127 guard sits on the other
+    branch, so this died with a bare traceback and exit 1."""
+    bindir, _, env = sandbox(tmp_path, ok_addrs=(LAN,), tunnel=True)
+    (bindir / "kubectl").unlink()
+    r = run(env, "--timeout", "8", "kubectl", "get", "nodes")
+    assert r.returncode == 127, (r.returncode, r.stdout, r.stderr)
+    assert "Traceback" not in r.stderr, r.stderr
+    assert "kubectl" in r.stderr and "LOCAL" in r.stderr, r.stderr
+
+
+@pytest.mark.parametrize("body", ["null", "[]", '"nope"', "3"])
+def test_a_non_object_tailscale_status_is_not_configured_not_a_crash(tmp_path, body):
+    """`null` and `[]` are VALID JSON and have no `.get()`. The AttributeError
+    escaped as a traceback and exit 1 from every verb — `path` included, whose
+    whole job is to REPORT a broken path rather than crash on one."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,), tailscale_raw=body)
+    r = run(env, "--json", "path")
+    assert r.returncode == 0, (body, r.returncode, r.stdout, r.stderr)
+    assert "Traceback" not in r.stderr, r.stderr
+    ts = states(r)["tailscale"]
+    assert ts["state"] == "not-configured", r.stdout
+    assert "non-object" in ts["detail"], ts["detail"]
+
+
+def test_no_ssh_binary_is_not_configured_not_unreachable(tmp_path):
+    """A missing ssh CLIENT is the same shape of problem as a missing
+    `tailscale` binary, which the tool already calls `not-configured`. Calling
+    it `unreachable` blamed the network for a missing package — and was
+    asymmetric with the tool's own argument that the two must never be folded
+    together."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,), ssh=False)
+    r = run(env, "--json", "path")
+    assert "Traceback" not in r.stderr, r.stderr
+    by_path = states(r)
+    assert by_path["lan"]["state"] == "not-configured", r.stdout
+    assert by_path["nebula"]["state"] == "not-configured", r.stdout
+    assert "no ssh binary" in by_path["lan"]["detail"], by_path["lan"]["detail"]
+
+
+def test_a_junk_workhost_timeout_warns_and_still_runs(tmp_path):
+    """`WORKHOST_TIMEOUT=10s` used to raise ValueError while BUILDING the
+    parser, so EVERY invocation of every verb crashed — `--help` included — and
+    nothing on screen named the variable."""
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    env["WORKHOST_TIMEOUT"] = "10s"
+    r = run(env, "path")
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert "Traceback" not in r.stderr, r.stderr
+    assert "WORKHOST_TIMEOUT" in r.stderr, r.stderr
+    probes = [a for a in invocations(log) if a[-1] == "true"]
+    assert probes and "ConnectTimeout=5" in probes[0], probes
+
+
+@pytest.mark.parametrize("bad", ["", "-1", "0", "abc"])
+def test_every_unusable_workhost_timeout_degrades_to_the_default(tmp_path, bad):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    env["WORKHOST_TIMEOUT"] = bad
+    r = run(env, "path")
+    assert r.returncode == 0, (bad, r.returncode, r.stdout, r.stderr)
+    assert "Traceback" not in r.stderr, r.stderr
+
+
+def test_a_valid_workhost_timeout_is_still_honoured(tmp_path):
+    """The guard degrades the unusable values only — it must not swallow the
+    variable's actual purpose."""
+    _, log, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    env["WORKHOST_TIMEOUT"] = "7"
+    run(env, "path")
+    probes = [a for a in invocations(log) if a[-1] == "true"]
+    assert probes and "ConnectTimeout=7" in probes[0], probes
+
+
+def test_the_timeout_flag_documents_the_env_var(tmp_path):
+    """`--host` names `$WORKHOST_HOST` in its help; `--timeout` did not name
+    `$WORKHOST_TIMEOUT`, so the variable that could break every run was
+    undiscoverable from the tool itself."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "--help")
+    assert "$WORKHOST_TIMEOUT" in r.stdout, r.stdout
+
+
+# ---------------------------------------------------------------------------
+# 17. --dry-run prints what actually runs
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_quotes_arguments_containing_spaces(tmp_path):
+    """A bare space-join prints a command that is NOT what runs the moment an
+    argument contains a space: `run 'a b'` printed `… -- a b`, which pastes as
+    two arguments. --dry-run's only value is that the printed line and the
+    executed argv are the same thing."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "--dry-run", "run", "echo a b")
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert shlex.split(r.stdout)[-1] == "echo a b", r.stdout
+
+
+def test_dry_run_round_trips_a_nasty_argument(tmp_path):
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "--dry-run", "ssh", NASTY)
+    assert shlex.split(r.stdout)[-1] == NASTY, r.stdout
+
+
+def test_the_kubectl_dry_run_admits_its_port_is_a_placeholder(tmp_path):
+    """`main` passes `kube_port=0` for the dry run because the real port comes
+    from `free_local_port()` at run time. `-L 0:…` reads as a command you could
+    paste; it is not one."""
+    _, _, env = sandbox(tmp_path, ok_addrs=(LAN,))
+    r = run(env, "--dry-run", "kubectl", "get", "pods")
+    assert "-L 0:127.0.0.1:6443" in r.stdout, r.stdout
+    assert "placeholder" in r.stderr, r.stderr

--- a/scripts/workhost
+++ b/scripts/workhost
@@ -491,9 +491,14 @@ def select_path(results: list, forced: Optional[str], accept_key: bool = False) 
                 return result, ""
 
     if any(r.state == UNTRUSTED_KEY for r in results):
+        # Names the whole command, not just the flag. "re-run with --accept-key"
+        # was what an operator saw AFTER passing --accept-key (it sat in the
+        # verb's args, unparsed), so the message read as a contradiction. It is
+        # covered by the same parser pin as the report's advice block.
         return None, (
             "no path to the host is usable: its host key is not trusted by this "
-            "client (re-run with --accept-key to trust it once, interactively)"
+            "client (run `%s` once to trust it, interactively)"
+            % ACCEPT_KEY_ADVICE_COMMAND
         )
     return None, "no path to the host is reachable"
 
@@ -521,6 +526,21 @@ def report_text(host: Host, results: list, chosen, stream, local: bool = False) 
     stream.flush()
 
 
+#: The EXACT command the advice tells a stuck operator to run.
+#:
+#: 🔴 A string that names a command is a claim about the parser, and this one
+#: was false: written after the verb, `--accept-key` fell into the verb's
+#: pass-through args and was never parsed, so following the printed instruction
+#: produced "re-run with --accept-key" — the flag just passed — forever. It is
+#: hoisted now (see HOISTED_FLAGS), and
+#: `test_the_advice_names_a_command_the_parser_actually_accepts` feeds THIS
+#: string back through `split_argv` + the parser and asserts it yields
+#: `accept_key=True`, so a reword of either side that breaks the pairing is red.
+#: Grepping the advice for the substring `--accept-key` would NOT have caught
+#: it — that passed against the broken behaviour.
+ACCEPT_KEY_ADVICE_COMMAND = "workhost ssh --accept-key"
+
+
 def write_untrusted_key_advice(host: Host, results: list, chosen, stream) -> None:
     """Name the real cause and the way out, when a host key is what blocks.
 
@@ -542,6 +562,10 @@ def write_untrusted_key_advice(host: Host, results: list, chosen, stream) -> Non
     unseen = [r for r in untrusted if not r.key_changed]
 
     if changed:
+        # `ssh-keygen -R` must name the ALIAS, not an address: HostKeyAlias is
+        # what the offending known_hosts entry is keyed on, so removing the
+        # address would delete the wrong line (or none) and leave the operator
+        # hitting the same wall. Pinned by a test against ssh_options().
         stream.write(
             "  -> the host key for alias '%s' CHANGED since it was trusted.\n"
             "     if %s was reinstalled:  ssh-keygen -R %s   then re-run.\n"
@@ -549,9 +573,14 @@ def write_untrusted_key_advice(host: Host, results: list, chosen, stream) -> Non
             % (host.name, host.name, host.name)
         )
     if unseen:
+        # The manual line is DERIVED from the options the tool itself uses, not
+        # spelled out beside them, so it cannot drift into advice that omits the
+        # alias — which would create a second known_hosts entry keyed on the
+        # address and re-introduce the sprawl HostKeyAlias exists to prevent.
+        manual = " ".join(["ssh"] + ssh_options(host) + [unseen[0].address])
         stream.write(
-            "  -> run `workhost ssh --accept-key` once to trust it,\n"
-            "     or: ssh -o HostKeyAlias=%s %s\n" % (host.name, unseen[0].address)
+            "  -> run `%s` once to trust it,\n"
+            "     or: %s\n" % (ACCEPT_KEY_ADVICE_COMMAND, manual)
         )
 
 
@@ -621,6 +650,17 @@ def validate_forward_spec(spec: list) -> None:
         if len(parts) == 4:
             parts = parts[1:]  # drop the optional bind address
         if len(parts) != 3 or not parts[0].isdigit() or not parts[2].isdigit():
+            # The escape hatch is a claim about ssh's argument parser, so it was
+            # MEASURED rather than assumed. OpenSSH_10.2p1 permutes: flags
+            # written after the destination are still parsed as options, up to
+            # the first non-option token, which becomes the remote command.
+            # Controls: `-L bogusspec` before AND after the destination both
+            # give "Bad local forwarding specification"; putting a command
+            # first (`… host echo -L bogusspec`) does not; and with no `-L` the
+            # error does not appear at all. So `workhost ssh -N -L <spec>`,
+            # which builds `ssh <opts> <address> -N -L <spec>`, really does
+            # forward. Scope: that ssh version — an ancient ssh that does not
+            # permute would make this suggestion wrong.
             raise ValueError(
                 "forward spec %r is not [bind:]port:host:hostport; for ssh's "
                 "other -L spellings use `workhost ssh -N -L %s`" % (item, item)
@@ -820,9 +860,36 @@ REPORTING_VERBS = ("path", "check")
 #: Global options that consume a following token as their value.
 VALUE_OPTS = ("-H", "--host", "--path", "--timeout")
 
+#: 🔴 Flags hoisted back to workhost even when written AFTER an action verb.
+#:
+#: `--accept-key` is here because the tool PRINTS `workhost ssh --accept-key` as
+#: the way out of an untrusted host key, and under the plain positional rule
+#: that exact string was swallowed by the verb's pass-through args and never
+#: parsed: the operator followed the printed instruction, got told to "re-run
+#: with --accept-key" — the flag they had just passed — and looped. That is the
+#: "cannot bootstrap itself" defect one layer up, hitting at the moment the
+#: operator is most stuck. Measured on a fresh client: `workhost --accept-key
+#: ssh` reached real ssh and prompted; `workhost ssh --accept-key` exited 3.
+#:
+#: The cost is named rather than hidden: a remote command that genuinely wants
+#: a literal `--accept-key` argument no longer receives it as its own token.
+#: `hoist_bootstrap_flags` therefore RETURNS what it took so `main` can say so
+#: on stderr — silently dropping it is the one behaviour that is not
+#: acceptable. The escape is the ordinary one for `run`, which joins and hands
+#: to the remote shell: quote it, `workhost run 'tool --accept-key'`.
+HOISTED_FLAGS = ("--accept-key",)
+
+
+def hoist_bootstrap_flags(verb_args: list) -> tuple:
+    """Return ``(remaining_verb_args, hoisted)`` for HOISTED_FLAGS."""
+    hoisted = [t for t in verb_args if t in HOISTED_FLAGS]
+    if not hoisted:
+        return list(verb_args), []
+    return [t for t in verb_args if t not in HOISTED_FLAGS], hoisted
+
 
 def split_argv(argv: list) -> tuple:
-    """Split raw argv into ``(global_tokens, verb, verb_args)``.
+    """Split raw argv into ``(global_tokens, verb, verb_args, hoisted)``.
 
     The rule is positional and therefore unambiguous: **flags before the verb
     belong to workhost, everything after the verb belongs to the verb.** That
@@ -831,9 +898,12 @@ def split_argv(argv: list) -> tuple:
     command, not switch workhost into JSON mode. argparse's own REMAINDER gets
     this right by accident and wrong at the edges, so the split is explicit.
 
-    Reporting verbs are the one exception: they take no arguments, so flags
+    Two exceptions, both narrow. Reporting verbs take no arguments, so flags
     after them are hoisted back into the global set rather than silently
-    ignored.
+    ignored. And `HOISTED_FLAGS` — today only `--accept-key` — are hoisted from
+    ANY verb's arguments, because the tool prints them in that position itself;
+    see the comment on that tuple. ``hoisted`` is returned rather than
+    swallowed so the caller can report what it took.
     """
     globals_ = []
     verb = None
@@ -856,9 +926,11 @@ def split_argv(argv: list) -> tuple:
 
     if verb in REPORTING_VERBS:
         globals_ += verb_args
-        verb_args = []
+        return globals_, verb, [], []
 
-    return globals_, verb, verb_args
+    verb_args, hoisted = hoist_bootstrap_flags(verb_args)
+    globals_ += hoisted
+    return globals_, verb, verb_args, hoisted
 
 
 DEFAULT_TIMEOUT = 5.0
@@ -944,7 +1016,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv=None) -> int:
     raw = list(sys.argv[1:]) if argv is None else list(argv)
-    global_tokens, verb, verb_args = split_argv(raw)
+    global_tokens, verb, verb_args, hoisted = split_argv(raw)
 
     parser = build_parser()
     opts = parser.parse_args(global_tokens)
@@ -955,6 +1027,15 @@ def main(argv=None) -> int:
     if verb not in VERBS:
         parser.error("unknown verb %r (expected one of: %s)" % (verb, ", ".join(VERBS)))
     opts.verb = verb
+
+    if hoisted:
+        # Audible, because it changes what the remote command receives. Not a
+        # warning to be silenced: it fires only when the operator wrote one of
+        # these flags after the verb, which is the form the tool itself prints.
+        sys.stderr.write(
+            "workhost: %s taken as a workhost flag, not passed to `%s`\n"
+            % (" ".join(hoisted), verb)
+        )
 
     host = HOSTS.get(opts.host)
     if host is None:

--- a/scripts/workhost
+++ b/scripts/workhost
@@ -6,16 +6,24 @@ Which of them works depends on where the client is sitting right now. This tool
 probes every path in parallel on every invocation, reports the state of all of
 them, and then connects over the best one available.
 
-Three states per path, never two:
+Four states per path, never two:
 
     ok              the path answered a real SSH auth handshake
     unreachable     an address is known for this path, but it did not answer
-    not-configured  no address exists for this path at all (yet)
+    untrusted-key   the address answered, but ssh refused the HOST KEY
+    not-configured  no address (or no client binary) exists for this path yet
 
-Collapsing the last two is the defect this tool exists to avoid: "nothing
-happened" is the observable that the most causes share, so it identifies none
-of them. `tailscale` is wired up today and reports `not-configured` until a
-tailnet actually exists; it lights up with no code change once it does.
+Collapsing these is the defect this tool exists to avoid: "nothing happened" is
+the observable that the most causes share, so it identifies none of them.
+`tailscale` is wired up today and reports `not-configured` until a tailnet
+actually exists; it lights up with no code change once it does.
+
+`untrusted-key` was added because the tool could not bootstrap itself. The
+probe runs with `BatchMode=yes`, and `StrictHostKeyChecking` defaults to `ask`,
+so on a client whose `known_hosts` has no entry for the HostKeyAlias every path
+fails closed on a perfectly healthy network — and, folded into `unreachable`,
+it read as "the box is down" while every verb refused with exit 3. It is now
+its own state, with `--accept-key` as the one-shot way out (see below).
 
 Adding a host is a new entry in HOSTS below, not a code change.
 """
@@ -25,6 +33,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
 import shutil
 import socket
 import subprocess
@@ -38,8 +47,20 @@ from typing import Optional
 # Exit codes
 # ---------------------------------------------------------------------------
 
-#: No usable path to the host. Distinct from any remote exit code so a script
-#: can tell "I could not reach the box" apart from "the command failed".
+#: No usable path to the host.
+#:
+#: 🔴 This is a CONVENTIONAL sentinel, NOT a reserved one. An earlier version of
+#: this comment claimed it was "distinct from any remote exit code"; that claim
+#: was wider than the code and is retracted. `workhost run 'exit 3'` over a
+#: working path also exits 3, and the usage/unknown-host code 2 likewise
+#: collides with a remote `exit 2`. Nothing in the 0-255 range is safe from a
+#: remote command that chooses it, short of giving up passthrough entirely.
+#:
+#: So the exit code is a HINT, and `--json` is the machine-readable channel:
+#: `selected` is `null` exactly when no path was usable, whatever the remote
+#: command did. Tests `test_exit_3_collides_with_a_remote_exit_3_*` and
+#: `test_usage_exit_2_collides_with_a_remote_exit_2` pin both collisions so this
+#: comment cannot quietly get wider than the code again.
 EXIT_NO_PATH = 3
 
 # ---------------------------------------------------------------------------
@@ -48,7 +69,16 @@ EXIT_NO_PATH = 3
 
 OK = "ok"
 UNREACHABLE = "unreachable"
+UNTRUSTED_KEY = "untrusted-key"
 NOT_CONFIGURED = "not-configured"
+
+#: ssh's own wording for the two host-key refusals, matched against the probe's
+#: stderr. Matched on ssh's message rather than on the exit status because ssh
+#: exits 255 for EVERY connection-level failure — auth, DNS, timeout and host
+#: key alike — so the status cannot tell them apart and the suite used to
+#: ASSERT that conflation.
+HOSTKEY_MISSING_MARKER = "Host key verification failed"
+HOSTKEY_CHANGED_MARKER = "REMOTE HOST IDENTIFICATION HAS CHANGED"
 
 #: Connection preference, best first. LAN is lowest-latency, nebula works from
 #: anywhere the mesh is up, tailscale is the future fallback.
@@ -112,6 +142,11 @@ class PathResult:
     #: operator never has to guess which of them they are looking at.
     detail: str = ""
     elapsed_ms: int = 0
+    #: Internal only, and deliberately NOT in as_dict(): a machine consumer gets
+    #: the state plus the detail text, which is enough. This flag exists so the
+    #: text report can offer the RIGHT way out — `--accept-key` trusts a key
+    #: that was never seen, and is the wrong advice for one that CHANGED.
+    key_changed: bool = field(default=False, repr=False, compare=False)
 
     def as_dict(self) -> dict:
         return {
@@ -174,16 +209,27 @@ def is_local_host(host: Host) -> bool:
     An address bound to a local interface is a genuinely unique property. The
     nebula mesh address is the stronger of the two signals, because mesh
     addresses are unique across the whole mesh by construction, whereas a LAN
-    address is only unique within one subnet — two different homes could both
-    hand out 192.168.50.250. We accept the LAN address as a fallback so that a
-    host whose nebula interface is down still recognises itself.
+    address is only unique within ONE SUBNET — two different homes could both
+    hand out 192.168.50.250.
+
+    🔴 So the LAN address is accepted ONLY when the host table names no nebula
+    address for this host. An unconditional LAN fallback re-created, one layer
+    down, exactly the hazard the hostname check was rejected to prevent: a
+    laptop on a network that happens to hand it 192.168.50.250 would run
+    `workhost run 'kubectl delete ns prod'` LOCALLY, exit 0, and print nothing
+    that says it never touched workbench. Silent, successful, wrong machine.
+
+    The cost of the tightening is named rather than hidden: a host that HAS a
+    nebula address but whose nebula interface is down no longer recognises
+    itself, and SSHes to itself over the LAN instead. That is a slow success —
+    the same safe direction `local_ipv4_addresses()` already degrades in.
     """
     local = local_ipv4_addresses()
     if not local:
         return False
     if host.nebula and host.nebula in local:
         return True
-    if host.lan and host.lan in local:
+    if host.lan and not host.nebula and host.lan in local:
         return True
     return False
 
@@ -224,6 +270,13 @@ def resolve_tailscale(host: Host) -> tuple:
         status = json.loads(proc.stdout)
     except (ValueError, TypeError):
         return None, "tailscale status returned unparseable JSON"
+
+    # `null`, `[]` and `"x"` are all VALID JSON and all lack .get(), so parsing
+    # successfully is not the same as getting an object. Without this the
+    # AttributeError escapes as a traceback and exit 1 from EVERY verb — `path`
+    # included, whose entire job is to report a broken path rather than crash.
+    if not isinstance(status, dict):
+        return None, "tailscale status returned non-object JSON"
 
     peers = status.get("Peer") or {}
     candidates = list(peers.values())
@@ -293,12 +346,43 @@ def probe_command(host: Host, address: str, timeout: float) -> list:
     that "ok" and the subsequent connect then fails in the operator's face.
     Running `true` over a BatchMode session is the cheapest thing that proves
     the whole stack, auth included.
+
+    🔴 The probe deliberately carries NO `StrictHostKeyChecking` override. TOFU
+    was considered and rejected: a probe that silently accepts a new host key
+    trusts the machine on the operator's behalf, every run, with no record that
+    a decision was made. `BatchMode=yes` therefore fails closed on an untrusted
+    key — which is correct, and is why `probe_path` classifies that failure as
+    its own state and `--accept-key` exists as an explicit, human-driven
+    escape. `--accept-key` never reaches this function: it changes only which
+    already-probed path `select_path` is allowed to return, so the probe argv
+    is byte-identical with and without it.
     """
     return (
         ["ssh", "-o", "BatchMode=yes"]
         + ssh_options(host, connect_timeout=timeout)
         + [address, "true"]
     )
+
+
+def classify_ssh_failure(stderr: str) -> tuple:
+    """Map a failed probe's stderr onto ``(state, detail_suffix, key_changed)``.
+
+    ``detail_suffix`` is None for anything that is not a host-key refusal, in
+    which case the caller keeps ssh's own last line as the detail.
+    """
+    if HOSTKEY_CHANGED_MARKER in stderr:
+        return (
+            UNTRUSTED_KEY,
+            "host key for alias %r CHANGED since it was trusted",
+            True,
+        )
+    if HOSTKEY_MISSING_MARKER in stderr:
+        return (
+            UNTRUSTED_KEY,
+            "host key for alias %r not in known_hosts",
+            False,
+        )
+    return UNREACHABLE, None, False
 
 
 # ---------------------------------------------------------------------------
@@ -328,7 +412,16 @@ def probe_path(host: Host, path: str, timeout: float) -> PathResult:
         return PathResult(
             path, UNREACHABLE, address, "probe timed out after %gs" % timeout, elapsed()
         )
-    except (FileNotFoundError, OSError) as exc:
+    except FileNotFoundError:
+        # No ssh CLIENT at all is the same shape of problem as no `tailscale`
+        # binary, which resolve_tailscale() already calls not-configured. Calling
+        # it `unreachable` here would have blamed the network for a missing
+        # package, and would have been asymmetric with the tool's own argument
+        # that those two states must never be folded together.
+        return PathResult(
+            path, NOT_CONFIGURED, address, "no ssh binary on PATH", elapsed()
+        )
+    except OSError as exc:
         return PathResult(path, UNREACHABLE, address, "ssh failed: %s" % exc, elapsed())
 
     if proc.returncode == 0:
@@ -336,7 +429,12 @@ def probe_path(host: Host, path: str, timeout: float) -> PathResult:
 
     stderr = (proc.stderr or b"").decode("utf-8", "replace").strip()
     last = stderr.splitlines()[-1] if stderr else "ssh exited %d" % proc.returncode
-    return PathResult(path, UNREACHABLE, address, last, elapsed())
+
+    # ssh exits 255 for auth failure AND for a host-key refusal, so the status
+    # cannot separate them; only the message can.
+    state, template, changed = classify_ssh_failure(stderr)
+    detail = template % host.name if template else last
+    return PathResult(path, state, address, detail, elapsed(), key_changed=changed)
 
 
 def probe_all(host: Host, timeout: float) -> list:
@@ -352,15 +450,31 @@ def probe_all(host: Host, timeout: float) -> list:
         return [f.result() for f in futures]
 
 
-def select_path(results: list, forced: Optional[str]) -> tuple:
-    """Pick the path to connect over. Returns ``(chosen, error_message)``."""
+def select_path(results: list, forced: Optional[str], accept_key: bool = False) -> tuple:
+    """Pick the path to connect over. Returns ``(chosen, error_message)``.
+
+    ``accept_key`` is the bootstrap escape hatch and widens the set of
+    ACCEPTABLE states by exactly one: `untrusted-key` becomes selectable. It
+    does nothing else — in particular it does not touch the probe (see
+    ``probe_command``) and it never makes an `unreachable` path selectable, so
+    it cannot be used to paper over a genuinely down path.
+
+    A selected `untrusted-key` path is then connected over by the ORDINARY
+    action command, which carries no `BatchMode`. Real ssh therefore does what
+    it always does with an unknown host key on an interactive terminal: it
+    prints the fingerprint and asks a human. That is the deliberate difference
+    from `StrictHostKeyChecking=accept-new`, which was rejected — this way the
+    trust decision is still made by a person, once, and `known_hosts` records
+    that it happened.
+    """
     by_name = {r.path: r for r in results}
+    acceptable = (OK, UNTRUSTED_KEY) if accept_key else (OK,)
 
     if forced:
         result = by_name.get(forced)
         if result is None:
             return None, "unknown path %r" % forced
-        if result.state != OK:
+        if result.state not in acceptable:
             # Forcing a path and silently using a different one would defeat
             # the entire purpose of the flag, so this is a hard failure.
             return None, "forced path %r is %s (%s)" % (
@@ -370,11 +484,17 @@ def select_path(results: list, forced: Optional[str]) -> tuple:
             )
         return result, ""
 
-    for name in PATH_ORDER:
-        result = by_name.get(name)
-        if result is not None and result.state == OK:
-            return result, ""
+    for state in acceptable:
+        for name in PATH_ORDER:
+            result = by_name.get(name)
+            if result is not None and result.state == state:
+                return result, ""
 
+    if any(r.state == UNTRUSTED_KEY for r in results):
+        return None, (
+            "no path to the host is usable: its host key is not trusted by this "
+            "client (re-run with --accept-key to trust it once, interactively)"
+        )
     return None, "no path to the host is reachable"
 
 
@@ -397,7 +517,42 @@ def report_text(host: Host, results: list, chosen, stream, local: bool = False) 
                 result.detail,
             )
         )
+    write_untrusted_key_advice(host, results, chosen, stream)
     stream.flush()
+
+
+def write_untrusted_key_advice(host: Host, results: list, chosen, stream) -> None:
+    """Name the real cause and the way out, when a host key is what blocks.
+
+    Without this, the report reads `untrusted-key` and stops — which is better
+    than the `unreachable` it used to say, but still leaves the operator to
+    work out that ssh will never prompt because the PROBE runs BatchMode. The
+    two causes get different advice on purpose: a key that was never seen is
+    trusted with one interactive connection, whereas a key that CHANGED is
+    either a reinstall or an attack and `--accept-key` is the wrong answer to
+    both.
+    """
+    if chosen is not None:
+        return
+    untrusted = [r for r in results if r.state == UNTRUSTED_KEY]
+    if not untrusted:
+        return
+
+    changed = [r for r in untrusted if r.key_changed]
+    unseen = [r for r in untrusted if not r.key_changed]
+
+    if changed:
+        stream.write(
+            "  -> the host key for alias '%s' CHANGED since it was trusted.\n"
+            "     if %s was reinstalled:  ssh-keygen -R %s   then re-run.\n"
+            "     if it was not, STOP — this is what an interception looks like.\n"
+            % (host.name, host.name, host.name)
+        )
+    if unseen:
+        stream.write(
+            "  -> run `workhost ssh --accept-key` once to trust it,\n"
+            "     or: ssh -o HostKeyAlias=%s %s\n" % (host.name, unseen[0].address)
+        )
 
 
 def report_json(host: Host, results: list, chosen, stream, local: bool = False) -> None:
@@ -429,6 +584,47 @@ def substitute_address(args: list, address: str) -> list:
         else:
             out.append(arg)
     return out
+
+
+#: `-L` binds are best-effort by default: `ExitOnForwardFailure` defaults to
+#: `no` (measured from `man ssh_config` on this host), so ssh happily stays
+#: alive with ZERO working forwards. `workhost forward 8080:…` against an
+#: already-bound 8080 then blocks forever with no verdict, while the operator
+#: believes the tunnel is up and their connections reach whatever unrelated
+#: process owns the port. `yes` turns that into a loud, immediate exit.
+FORWARD_FAILURE_OPTS = ["-o", "ExitOnForwardFailure=yes"]
+
+
+def validate_forward_spec(spec: list) -> None:
+    """Reject a `forward` invocation that would forward nothing.
+
+    `spec = list(args)` was previously used unchecked, so `workhost forward`
+    with no arguments built a fully authenticated `ssh -N` with no `-L` at all
+    and idled until killed — a success-shaped no-op, and under `--dry-run` it
+    printed a command that looked plausible.
+
+    The shape check is deliberately narrow: `[bind:]port:host:hostport`, the
+    form this verb exists for. ssh's rarer `-L` spellings (unix sockets,
+    bracketed IPv6 literals) are not rejected as unsupported by ssh — they are
+    simply out of scope here, and the error says so and names the escape hatch,
+    because a wrong-but-plausible guess is worse than a refusal that points
+    somewhere.
+    """
+    if not spec:
+        raise ValueError(
+            "`forward` needs at least one FORWARD_SPEC "
+            "(e.g. `workhost forward 8080:localhost:80`); with none it would "
+            "open a session that forwards nothing and never returns"
+        )
+    for item in spec:
+        parts = item.split(":")
+        if len(parts) == 4:
+            parts = parts[1:]  # drop the optional bind address
+        if len(parts) != 3 or not parts[0].isdigit() or not parts[2].isdigit():
+            raise ValueError(
+                "forward spec %r is not [bind:]port:host:hostport; for ssh's "
+                "other -L spellings use `workhost ssh -N -L %s`" % (item, item)
+            )
 
 
 def build_remote_command(host: Host, verb: str, address: str, args: list,
@@ -464,15 +660,17 @@ def build_remote_command(host: Host, verb: str, address: str, args: list,
 
     if verb == "forward":
         spec = list(args)
+        validate_forward_spec(spec)
         cmd = ["ssh", "-N"]
         for item in spec:
             cmd += ["-L", item]
-        return cmd + opts + [address]
+        return cmd + FORWARD_FAILURE_OPTS + opts + [address]
 
     if verb == "kubectl":
-        # See kubectl_command() — this is only the tunnel half.
+        # See run_kubectl_via_tunnel() — this is only the tunnel half.
         return (
             ["ssh", "-N", "-L", "%d:127.0.0.1:%d" % (kube_port, host.kube_port)]
+            + FORWARD_FAILURE_OPTS
             + opts
             + [address]
         )
@@ -511,6 +709,16 @@ def build_local_command(host: Host, verb: str, args: list) -> list:
 
 
 def free_local_port() -> int:
+    """Ask the kernel for an unused loopback port, then let go of it.
+
+    🔴 This is inherently racy — between the close here and ssh's bind, anything
+    on the box can take the port. The mitigation is not in this function: the
+    tunnel carries `ExitOnForwardFailure=yes`, so a thief makes ssh EXIT rather
+    than sit there forwarding nothing, and the readiness loop below re-checks
+    that the tunnel is still alive AFTER its connect succeeds. Without both, a
+    connect to the thief would satisfy the probe and `kubectl --server` would be
+    pointed at an unrelated local service.
+    """
     sock = socket.socket()
     try:
         sock.bind(("127.0.0.1", 0))
@@ -542,7 +750,7 @@ def run_kubectl_via_tunnel(host: Host, address: str, args: list, timeout: float,
     tunnel_cmd = build_remote_command(host, "kubectl", address, [], timeout, kube_port=port)
 
     if verbose:
-        sys.stderr.write("workhost: tunnel %s\n" % " ".join(tunnel_cmd))
+        sys.stderr.write("workhost: tunnel %s\n" % shlex.join(tunnel_cmd))
 
     tunnel = subprocess.Popen(
         tunnel_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
@@ -564,14 +772,33 @@ def run_kubectl_via_tunnel(host: Host, address: str, args: list, timeout: float,
             finally:
                 probe.close()
 
+        # A successful connect proves SOMETHING is listening, not that it is
+        # ours. If ssh has exited by now, ExitOnForwardFailure says the bind
+        # lost the race and what answered belongs to somebody else.
+        if ready and tunnel.poll() is not None:
+            ready = False
+
         if not ready:
             sys.stderr.write("workhost: kubectl tunnel to %s did not come up\n" % host.name)
             return EXIT_NO_PATH
 
         kube_cmd = ["kubectl", "--server", "https://127.0.0.1:%d" % port] + list(args)
         if verbose:
-            sys.stderr.write("workhost: exec %s\n" % " ".join(kube_cmd))
-        return subprocess.run(kube_cmd).returncode
+            sys.stderr.write("workhost: exec %s\n" % shlex.join(kube_cmd))
+        try:
+            return subprocess.run(kube_cmd).returncode
+        except FileNotFoundError:
+            # The irony worth keeping visible: this verb tunnels precisely so it
+            # can use the LOCAL kubectl, because the remote non-login shell on
+            # NixOS frequently has none — and the newly-depended-on local binary
+            # was the one unhandled case, dying with a bare traceback and exit 1
+            # while `main`'s FileNotFoundError->127 guard sat on the other
+            # branch. 127 is the shell's own "command not found".
+            sys.stderr.write(
+                "workhost: no `kubectl` on the LOCAL PATH — `workhost kubectl` "
+                "tunnels to %s and runs kubectl HERE, so it needs one\n" % host.name
+            )
+            return 127
     finally:
         tunnel.terminate()
         try:
@@ -634,6 +861,39 @@ def split_argv(argv: list) -> tuple:
     return globals_, verb, verb_args
 
 
+DEFAULT_TIMEOUT = 5.0
+
+
+def env_timeout(default: float = DEFAULT_TIMEOUT) -> float:
+    """`$WORKHOST_TIMEOUT`, or ``default`` if it is not a usable number.
+
+    This used to be `float(os.environ.get("WORKHOST_TIMEOUT", "5"))` evaluated
+    while BUILDING the parser, so a plausible `WORKHOST_TIMEOUT=10s` in a shell
+    profile raised ValueError before argparse existed: every invocation of every
+    verb crashed with a traceback, including `--help`, and nothing on screen
+    named the variable. Degrading to the default with one warning line is the
+    only behaviour that leaves the tool usable while still being audible.
+    """
+    raw = os.environ.get("WORKHOST_TIMEOUT")
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        sys.stderr.write(
+            "workhost: ignoring WORKHOST_TIMEOUT=%r (not a number of seconds); "
+            "using %g\n" % (raw, default)
+        )
+        return default
+    if value <= 0:
+        sys.stderr.write(
+            "workhost: ignoring WORKHOST_TIMEOUT=%r (must be > 0); using %g\n"
+            % (raw, default)
+        )
+        return default
+    return value
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="workhost",
@@ -660,8 +920,18 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--timeout",
         type=float,
-        default=float(os.environ.get("WORKHOST_TIMEOUT", "5")),
-        help="per-path probe timeout in seconds (default: 5)",
+        default=env_timeout(),
+        help="per-path probe timeout in seconds (default: %g, or $WORKHOST_TIMEOUT)"
+        % DEFAULT_TIMEOUT,
+    )
+    parser.add_argument(
+        "--accept-key",
+        action="store_true",
+        help=(
+            "bootstrap: let an untrusted-key path be used, so ssh can ask you "
+            "about the host key interactively. Never affects the probe, and "
+            "never makes an unreachable path usable."
+        ),
     )
     parser.add_argument(
         "--dry-run",
@@ -704,7 +974,7 @@ def main(argv=None) -> int:
     local = is_local_host(host)
 
     results = probe_all(host, opts.timeout)
-    chosen, error = select_path(results, opts.path)
+    chosen, error = select_path(results, opts.path, accept_key=opts.accept_key)
 
     # The report goes to stderr for action verbs so piped stdout carries only
     # the remote command's own output. For `path`/`check` the report IS the
@@ -736,22 +1006,40 @@ def main(argv=None) -> int:
             cmd = build_remote_command(
                 host, verb, chosen.address, list(opts.args), opts.timeout, kube_port=0
             )
-            sys.stdout.write(" ".join(cmd) + "\n")
+            # The real local port comes from free_local_port() at run time, so
+            # there is no honest number to print here. Say so on stderr rather
+            # than let `-L 0:…` read as a command you could paste.
+            sys.stderr.write(
+                "workhost: (dry-run) the local port is chosen at run time; "
+                "the 0 in `-L 0:...` is a placeholder\n"
+            )
+            sys.stdout.write(shlex.join(cmd) + "\n")
             return 0
         return run_kubectl_via_tunnel(
             host, chosen.address, list(opts.args), opts.timeout, opts.verbose
         )
     else:
-        cmd = build_remote_command(
-            host, verb, chosen.address, list(opts.args), opts.timeout
-        )
+        try:
+            cmd = build_remote_command(
+                host, verb, chosen.address, list(opts.args), opts.timeout
+            )
+        except ValueError as exc:
+            # `forward` rejects a spec that would forward nothing. Same exit
+            # code and same shape as the local branch's refusal above, so the
+            # two do not have to be told apart by the caller.
+            sys.stderr.write("workhost: %s\n" % exc)
+            return 2
 
+    # shlex.join, not " ".join: a bare space-join prints a command that is NOT
+    # what runs the moment any argument contains a space — `run 'a b'` printed
+    # `ssh … -- a b`, which pastes as two arguments. --dry-run's whole value is
+    # that the printed line and the executed argv are the same thing.
     if opts.dry_run:
-        sys.stdout.write(" ".join(cmd) + "\n")
+        sys.stdout.write(shlex.join(cmd) + "\n")
         return 0
 
     if opts.verbose:
-        sys.stderr.write("workhost: exec %s\n" % " ".join(cmd))
+        sys.stderr.write("workhost: exec %s\n" % shlex.join(cmd))
 
     try:
         return subprocess.run(cmd).returncode

--- a/scripts/workhost
+++ b/scripts/workhost
@@ -1,0 +1,766 @@
+#!/usr/bin/env python3
+"""workhost — reach a dev host over whichever network path is actually up.
+
+One machine is reachable by several addresses (LAN, nebula mesh, tailscale).
+Which of them works depends on where the client is sitting right now. This tool
+probes every path in parallel on every invocation, reports the state of all of
+them, and then connects over the best one available.
+
+Three states per path, never two:
+
+    ok              the path answered a real SSH auth handshake
+    unreachable     an address is known for this path, but it did not answer
+    not-configured  no address exists for this path at all (yet)
+
+Collapsing the last two is the defect this tool exists to avoid: "nothing
+happened" is the observable that the most causes share, so it identifies none
+of them. `tailscale` is wired up today and reports `not-configured` until a
+tailnet actually exists; it lights up with no code change once it does.
+
+Adding a host is a new entry in HOSTS below, not a code change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+
+#: No usable path to the host. Distinct from any remote exit code so a script
+#: can tell "I could not reach the box" apart from "the command failed".
+EXIT_NO_PATH = 3
+
+# ---------------------------------------------------------------------------
+# Path states
+# ---------------------------------------------------------------------------
+
+OK = "ok"
+UNREACHABLE = "unreachable"
+NOT_CONFIGURED = "not-configured"
+
+#: Connection preference, best first. LAN is lowest-latency, nebula works from
+#: anywhere the mesh is up, tailscale is the future fallback.
+PATH_ORDER = ("lan", "nebula", "tailscale")
+
+
+# ---------------------------------------------------------------------------
+# Host table
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Host:
+    """A machine, plus every address that machine answers on.
+
+    ``lan`` and ``nebula`` are static literals. ``tailscale`` is deliberately
+    NOT a literal: it is resolved at runtime by asking the ``tailscale`` binary,
+    so the day a tailnet is deployed this table needs no edit.
+    """
+
+    name: str
+    lan: Optional[str] = None
+    nebula: Optional[str] = None
+    #: Node name to look for in `tailscale status`. Defaults to ``name``.
+    tailscale_name: Optional[str] = None
+    #: Port the host's apiserver listens on, on the host's own loopback.
+    kube_port: int = 6443
+
+    def static_addresses(self) -> list:
+        return [a for a in (self.lan, self.nebula) if a]
+
+
+#: Only `workbench` is fully specified today. `laptop` and `production` are not
+#: in here because inventing addresses for them would be a guess, and a guess in
+#: an address table is worse than an absence — it produces a confident wrong
+#: connection. `homelab` is Talos and has no SSH at all, so it is not a
+#: candidate for this tool by construction.
+HOSTS = {
+    "workbench": Host(
+        name="workbench",
+        lan="192.168.50.250",
+        nebula="10.42.0.30",
+        kube_port=6443,
+    ),
+}
+
+DEFAULT_HOST = "workbench"
+
+
+# ---------------------------------------------------------------------------
+# Probe results
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PathResult:
+    path: str
+    state: str
+    address: Optional[str] = None
+    #: Human-readable reason, always set for the two non-ok states so the
+    #: operator never has to guess which of them they are looking at.
+    detail: str = ""
+    elapsed_ms: int = 0
+
+    def as_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "state": self.state,
+            "address": self.address,
+            "detail": self.detail,
+            "elapsed_ms": self.elapsed_ms,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Am I already on the target host?
+# ---------------------------------------------------------------------------
+
+
+def local_ipv4_addresses() -> set:
+    """Every IPv4 address bound to a local interface.
+
+    Shells out to `ip -4 -o addr show` rather than using a Python-native
+    interface enumeration so the behaviour is fakeable on PATH in tests: the
+    tested code path and the production code path are then the same one.
+
+    If `ip` is unavailable we return an empty set, which degrades to "assume
+    not local" — i.e. connect over SSH. That is the safe direction: an
+    unnecessary SSH hop is a slow success, whereas a wrong "I am the target"
+    would run the operator's command on the wrong machine.
+    """
+    try:
+        proc = subprocess.run(
+            ["ip", "-4", "-o", "addr", "show"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return set()
+    if proc.returncode != 0:
+        return set()
+
+    addrs = set()
+    for line in proc.stdout.splitlines():
+        fields = line.split()
+        # `2: eth0    inet 192.168.50.250/24 brd ... scope global ...`
+        for i, tok in enumerate(fields):
+            if tok == "inet" and i + 1 < len(fields):
+                addrs.add(fields[i + 1].split("/")[0])
+    return addrs
+
+
+def is_local_host(host: Host) -> bool:
+    """True when this process is already running on ``host``.
+
+    Deliberately NOT based on `hostname`. Both NixOS hosts in this fleet report
+    the hostname `nixos` — that is measured, not assumed, and it is the same
+    finding `scripts/lib/host_identity.py` exists to encode. Keying on hostname
+    would make the laptop believe it is workbench and silently exec commands on
+    the wrong machine, which is the worst available failure: it succeeds.
+
+    An address bound to a local interface is a genuinely unique property. The
+    nebula mesh address is the stronger of the two signals, because mesh
+    addresses are unique across the whole mesh by construction, whereas a LAN
+    address is only unique within one subnet — two different homes could both
+    hand out 192.168.50.250. We accept the LAN address as a fallback so that a
+    host whose nebula interface is down still recognises itself.
+    """
+    local = local_ipv4_addresses()
+    if not local:
+        return False
+    if host.nebula and host.nebula in local:
+        return True
+    if host.lan and host.lan in local:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Address resolution per path
+# ---------------------------------------------------------------------------
+
+
+def resolve_tailscale(host: Host) -> tuple:
+    """Resolve ``host``'s tailscale address.
+
+    Returns ``(address, detail)``. ``address`` is None when the path is
+    genuinely not configured, and ``detail`` then says which flavour of
+    not-configured it is — no binary at all, versus a tailnet that exists but
+    does not carry this host. Those are different problems with different
+    fixes, so they get different messages.
+    """
+    name = host.tailscale_name or host.name
+
+    if shutil.which("tailscale") is None:
+        return None, "no tailscale binary on PATH"
+
+    try:
+        proc = subprocess.run(
+            ["tailscale", "status", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, "tailscale status failed: %s" % exc
+
+    if proc.returncode != 0:
+        return None, "tailscale status exited %d" % proc.returncode
+
+    try:
+        status = json.loads(proc.stdout)
+    except (ValueError, TypeError):
+        return None, "tailscale status returned unparseable JSON"
+
+    peers = status.get("Peer") or {}
+    candidates = list(peers.values())
+    myself = status.get("Self")
+    if isinstance(myself, dict):
+        candidates.append(myself)
+
+    for peer in candidates:
+        if not isinstance(peer, dict):
+            continue
+        hostname = peer.get("HostName") or ""
+        dnsname = peer.get("DNSName") or ""
+        if hostname == name or dnsname.split(".")[0] == name:
+            ips = peer.get("TailscaleIPs") or []
+            for ip in ips:
+                if ":" not in ip:  # prefer IPv4
+                    return ip, ""
+            if ips:
+                return ips[0], ""
+            return None, "%s is in the tailnet but has no address" % name
+
+    return None, "%s is not in the tailnet" % name
+
+
+def resolve_path(host: Host, path: str) -> tuple:
+    """Return ``(address, detail)`` for ``path`` on ``host``."""
+    if path == "lan":
+        if host.lan:
+            return host.lan, ""
+        return None, "no LAN address in the host table"
+    if path == "nebula":
+        if host.nebula:
+            return host.nebula, ""
+        return None, "no nebula address in the host table"
+    if path == "tailscale":
+        return resolve_tailscale(host)
+    raise ValueError("unknown path: %s" % path)
+
+
+# ---------------------------------------------------------------------------
+# SSH command construction
+# ---------------------------------------------------------------------------
+
+
+def ssh_options(host: Host, connect_timeout: Optional[float] = None) -> list:
+    """The `-o` flags every ssh-family invocation must carry.
+
+    `HostKeyAlias` is the load-bearing one. Without it, one machine reached by
+    three different addresses accumulates three separate `known_hosts` entries,
+    and the day one of those addresses is reused for a different machine the
+    operator hits a host-key-mismatch wall with no obvious cause. Pinning the
+    alias to the host's NAME means all three paths share one entry — the
+    machine's identity is the machine, not the route you took to it.
+    """
+    opts = ["-o", "HostKeyAlias=%s" % host.name]
+    if connect_timeout is not None:
+        opts += ["-o", "ConnectTimeout=%d" % max(1, int(connect_timeout))]
+    return opts
+
+
+def probe_command(host: Host, address: str, timeout: float) -> list:
+    """The probe is a REAL auth handshake, not a TCP connect to port 22.
+
+    A port that accepts a connection is not a session you can open: measured on
+    this fleet, both addresses complete the TCP and SSH transport layers and
+    then fail auth with `Permission denied`, exiting 255. A port probe calls
+    that "ok" and the subsequent connect then fails in the operator's face.
+    Running `true` over a BatchMode session is the cheapest thing that proves
+    the whole stack, auth included.
+    """
+    return (
+        ["ssh", "-o", "BatchMode=yes"]
+        + ssh_options(host, connect_timeout=timeout)
+        + [address, "true"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Probing
+# ---------------------------------------------------------------------------
+
+
+def probe_path(host: Host, path: str, timeout: float) -> PathResult:
+    started = time.monotonic()
+
+    def elapsed():
+        return int((time.monotonic() - started) * 1000)
+
+    address, detail = resolve_path(host, path)
+    if address is None:
+        return PathResult(path, NOT_CONFIGURED, None, detail, elapsed())
+
+    cmd = probe_command(host, address, timeout)
+    try:
+        proc = subprocess.run(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return PathResult(
+            path, UNREACHABLE, address, "probe timed out after %gs" % timeout, elapsed()
+        )
+    except (FileNotFoundError, OSError) as exc:
+        return PathResult(path, UNREACHABLE, address, "ssh failed: %s" % exc, elapsed())
+
+    if proc.returncode == 0:
+        return PathResult(path, OK, address, "", elapsed())
+
+    stderr = (proc.stderr or b"").decode("utf-8", "replace").strip()
+    last = stderr.splitlines()[-1] if stderr else "ssh exited %d" % proc.returncode
+    return PathResult(path, UNREACHABLE, address, last, elapsed())
+
+
+def probe_all(host: Host, timeout: float) -> list:
+    """Probe every path concurrently.
+
+    Concurrency is the point: three sequential probes against a host whose LAN
+    path is down would cost 3x the timeout on every single invocation, which
+    would make the tool too slow to put in front of `ssh`. Wall time is ~one
+    timeout, not three.
+    """
+    with ThreadPoolExecutor(max_workers=len(PATH_ORDER)) as pool:
+        futures = [pool.submit(probe_path, host, p, timeout) for p in PATH_ORDER]
+        return [f.result() for f in futures]
+
+
+def select_path(results: list, forced: Optional[str]) -> tuple:
+    """Pick the path to connect over. Returns ``(chosen, error_message)``."""
+    by_name = {r.path: r for r in results}
+
+    if forced:
+        result = by_name.get(forced)
+        if result is None:
+            return None, "unknown path %r" % forced
+        if result.state != OK:
+            # Forcing a path and silently using a different one would defeat
+            # the entire purpose of the flag, so this is a hard failure.
+            return None, "forced path %r is %s (%s)" % (
+                forced,
+                result.state,
+                result.detail or "no detail",
+            )
+        return result, ""
+
+    for name in PATH_ORDER:
+        result = by_name.get(name)
+        if result is not None and result.state == OK:
+            return result, ""
+
+    return None, "no path to the host is reachable"
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def report_text(host: Host, results: list, chosen, stream, local: bool = False) -> None:
+    stream.write("workhost: %s%s\n" % (host.name, " (this machine)" if local else ""))
+    for result in results:
+        marker = "*" if chosen is not None and result.path == chosen.path else " "
+        stream.write(
+            "%s %-10s %-16s %-15s %s\n"
+            % (
+                marker,
+                result.path,
+                result.address or "-",
+                result.state,
+                result.detail,
+            )
+        )
+    stream.flush()
+
+
+def report_json(host: Host, results: list, chosen, stream, local: bool = False) -> None:
+    payload = {
+        "host": host.name,
+        "local": local,
+        "selected": chosen.path if chosen is not None else None,
+        "paths": [r.as_dict() for r in results],
+    }
+    stream.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    stream.flush()
+
+
+# ---------------------------------------------------------------------------
+# Verbs
+# ---------------------------------------------------------------------------
+
+
+def substitute_address(args: list, address: str) -> list:
+    """Rewrite a leading ``:`` in an argument into ``<address>:``.
+
+    So `workhost scp ./a.txt :/tmp/a.txt` targets the host over whichever path
+    won, without the caller ever having to name an address.
+    """
+    out = []
+    for arg in args:
+        if arg.startswith(":"):
+            out.append("%s%s" % (address, arg))
+        else:
+            out.append(arg)
+    return out
+
+
+def build_remote_command(host: Host, verb: str, address: str, args: list,
+                         timeout: float, kube_port: int = 0) -> list:
+    """The argv workhost would execute to reach ``host`` over ``address``."""
+    opts = ssh_options(host, connect_timeout=timeout)
+
+    if verb == "ssh":
+        return ["ssh"] + opts + [address] + list(args)
+
+    if verb == "run":
+        # Mirrors plain ssh semantics exactly: ssh joins its trailing arguments
+        # with spaces and hands the result to the remote login shell. That is
+        # what makes `workhost run 'exit 42'` exit 42 and `workhost run ls -la`
+        # also work, and it means anyone who already knows ssh knows this.
+        return ["ssh"] + opts + [address, "--"] + list(args)
+
+    if verb == "tmux":
+        # -t forces a PTY; without it tmux refuses to attach.
+        session = list(args) or []
+        remote = ["tmux", "new-session", "-A", "-s"] + (session or ["main"])
+        return ["ssh", "-t"] + opts + [address, "--"] + remote
+
+    if verb == "scp":
+        return ["scp"] + opts + substitute_address(list(args), address)
+
+    if verb == "rsync":
+        # rsync needs the ssh options threaded through -e, otherwise it opens
+        # its own ssh without HostKeyAlias and re-creates the very known_hosts
+        # sprawl this tool exists to prevent.
+        ssh_cmd = " ".join(["ssh"] + opts)
+        return ["rsync", "-e", ssh_cmd] + substitute_address(list(args), address)
+
+    if verb == "forward":
+        spec = list(args)
+        cmd = ["ssh", "-N"]
+        for item in spec:
+            cmd += ["-L", item]
+        return cmd + opts + [address]
+
+    if verb == "kubectl":
+        # See kubectl_command() — this is only the tunnel half.
+        return (
+            ["ssh", "-N", "-L", "%d:127.0.0.1:%d" % (kube_port, host.kube_port)]
+            + opts
+            + [address]
+        )
+
+    raise ValueError("unknown verb: %s" % verb)
+
+
+def build_local_command(host: Host, verb: str, args: list) -> list:
+    """The argv workhost would execute when already sitting on the target."""
+    if verb in ("ssh", "tmux"):
+        if verb == "tmux":
+            session = list(args) or ["main"]
+            return ["tmux", "new-session", "-A", "-s"] + session
+        # `workhost ssh` on the target is a shell on the target: that is the
+        # login shell, not an ssh connection to ourselves.
+        return [os.environ.get("SHELL", "/bin/sh")]
+
+    if verb == "run":
+        # Same joining rule as the remote branch, so `run 'exit 42'` exits 42
+        # identically whether or not you happen to be on the box.
+        return ["bash", "-c", " ".join(args)]
+
+    if verb == "kubectl":
+        return ["kubectl"] + list(args)
+
+    if verb in ("scp", "rsync"):
+        stripped = [a[1:] if a.startswith(":") else a for a in args]
+        return ([verb] if verb == "rsync" else ["cp"]) + stripped
+
+    if verb == "forward":
+        # Forwarding to yourself is a no-op, and pretending otherwise would
+        # hang the operator on an ssh that never returns.
+        raise ValueError("`forward` is meaningless on the target host itself")
+
+    raise ValueError("unknown verb: %s" % verb)
+
+
+def free_local_port() -> int:
+    sock = socket.socket()
+    try:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+def run_kubectl_via_tunnel(host: Host, address: str, args: list, timeout: float,
+                           verbose: bool) -> int:
+    """Run a LOCAL kubectl against the host's apiserver through an SSH tunnel.
+
+    Why a tunnel rather than rewriting the kubeconfig server address:
+
+    The k3s serving certificate on workbench carries SANs for `127.0.0.1` and
+    `192.168.50.250` but NOT for the nebula address `10.42.0.30` (measured from
+    the live cert). So a naive `--server=https://<address>:6443` rewrite is
+    TLS-valid over the LAN path and TLS-INVALID over nebula — it would work
+    until the day the LAN path is the one that is down, and then fail with a
+    certificate error that looks nothing like a routing problem.
+
+    Tunnelling to the host's own loopback sidesteps that entirely: kubectl
+    connects to `127.0.0.1`, which IS in the SANs, so the certificate verifies
+    over every path without ever disabling verification. It also uses the local
+    kubectl binary, which avoids depending on the remote non-login shell having
+    kubectl on PATH — on NixOS it frequently does not.
+    """
+    port = free_local_port()
+    tunnel_cmd = build_remote_command(host, "kubectl", address, [], timeout, kube_port=port)
+
+    if verbose:
+        sys.stderr.write("workhost: tunnel %s\n" % " ".join(tunnel_cmd))
+
+    tunnel = subprocess.Popen(
+        tunnel_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+    try:
+        deadline = time.monotonic() + timeout
+        ready = False
+        while time.monotonic() < deadline:
+            if tunnel.poll() is not None:
+                break
+            probe = socket.socket()
+            probe.settimeout(0.25)
+            try:
+                probe.connect(("127.0.0.1", port))
+                ready = True
+                break
+            except OSError:
+                time.sleep(0.05)
+            finally:
+                probe.close()
+
+        if not ready:
+            sys.stderr.write("workhost: kubectl tunnel to %s did not come up\n" % host.name)
+            return EXIT_NO_PATH
+
+        kube_cmd = ["kubectl", "--server", "https://127.0.0.1:%d" % port] + list(args)
+        if verbose:
+            sys.stderr.write("workhost: exec %s\n" % " ".join(kube_cmd))
+        return subprocess.run(kube_cmd).returncode
+    finally:
+        tunnel.terminate()
+        try:
+            tunnel.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            tunnel.kill()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+VERBS = ("ssh", "scp", "tmux", "run", "path", "check", "forward", "rsync", "kubectl")
+
+#: Verbs that only report and take no arguments of their own. Flags written
+#: after these are hoisted back to workhost, so `workhost path --json` works.
+REPORTING_VERBS = ("path", "check")
+
+#: Global options that consume a following token as their value.
+VALUE_OPTS = ("-H", "--host", "--path", "--timeout")
+
+
+def split_argv(argv: list) -> tuple:
+    """Split raw argv into ``(global_tokens, verb, verb_args)``.
+
+    The rule is positional and therefore unambiguous: **flags before the verb
+    belong to workhost, everything after the verb belongs to the verb.** That
+    matters because `ssh`, `run`, `rsync` and `kubectl` all forward arbitrary
+    flags of their own — `workhost run --json` must send `--json` to the remote
+    command, not switch workhost into JSON mode. argparse's own REMAINDER gets
+    this right by accident and wrong at the edges, so the split is explicit.
+
+    Reporting verbs are the one exception: they take no arguments, so flags
+    after them are hoisted back into the global set rather than silently
+    ignored.
+    """
+    globals_ = []
+    verb = None
+    i = 0
+    while i < len(argv):
+        tok = argv[i]
+        if tok in VALUE_OPTS:
+            globals_ += argv[i : i + 2]
+            i += 2
+            continue
+        if tok.startswith("-"):
+            # Covers --host=x, -Hx and bare flags alike: one token, one append.
+            globals_.append(tok)
+            i += 1
+            continue
+        verb = tok
+        i += 1
+        break
+    verb_args = list(argv[i:])
+
+    if verb in REPORTING_VERBS:
+        globals_ += verb_args
+        verb_args = []
+
+    return globals_, verb, verb_args
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="workhost",
+        description="Reach a dev host over whichever network path is up.",
+        epilog=(
+            "verbs: %s\n"
+            "Global flags must come BEFORE the verb; everything after the verb "
+            "is passed to it." % ", ".join(VERBS)
+        ),
+    )
+    parser.add_argument(
+        "-H",
+        "--host",
+        default=os.environ.get("WORKHOST_HOST", DEFAULT_HOST),
+        help="target host name (default: %s, or $WORKHOST_HOST)" % DEFAULT_HOST,
+    )
+    parser.add_argument(
+        "--path",
+        choices=PATH_ORDER,
+        default=None,
+        help="force a specific path instead of picking the best available",
+    )
+    parser.add_argument("--json", action="store_true", help="emit the path report as JSON")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=float(os.environ.get("WORKHOST_TIMEOUT", "5")),
+        help="per-path probe timeout in seconds (default: 5)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the command that would run instead of running it",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="explain what is happening")
+    return parser
+
+
+def main(argv=None) -> int:
+    raw = list(sys.argv[1:]) if argv is None else list(argv)
+    global_tokens, verb, verb_args = split_argv(raw)
+
+    parser = build_parser()
+    opts = parser.parse_args(global_tokens)
+    opts.args = verb_args
+
+    if verb is None:
+        verb = "ssh"
+    if verb not in VERBS:
+        parser.error("unknown verb %r (expected one of: %s)" % (verb, ", ".join(VERBS)))
+    opts.verb = verb
+
+    host = HOSTS.get(opts.host)
+    if host is None:
+        sys.stderr.write(
+            "workhost: unknown host %r (known: %s)\n" % (opts.host, ", ".join(sorted(HOSTS)))
+        )
+        return 2
+
+    verb = "path" if opts.verb == "check" else opts.verb
+    reporting_verb = verb == "path"
+
+    # Answered BEFORE the path requirement: if we are already standing on the
+    # target, no network path is needed to run anything. Probing still happens
+    # and is still reported — the tool's promise is to tell you the state of
+    # every path on every invocation — but an all-unreachable report is not a
+    # failure when the destination is the machine you are typing on.
+    local = is_local_host(host)
+
+    results = probe_all(host, opts.timeout)
+    chosen, error = select_path(results, opts.path)
+
+    # The report goes to stderr for action verbs so piped stdout carries only
+    # the remote command's own output. For `path`/`check` the report IS the
+    # product, so it goes to stdout.
+    report_stream = sys.stdout if reporting_verb else sys.stderr
+    if opts.json:
+        report_json(host, results, chosen, report_stream, local)
+    elif reporting_verb or opts.verbose or (chosen is None and not local):
+        report_text(host, results, chosen, report_stream, local)
+
+    if reporting_verb:
+        return 0 if (chosen is not None or local) else EXIT_NO_PATH
+
+    # An explicitly forced path is a request to go over the wire, so it is
+    # honoured even on the target host: silently running locally instead would
+    # be exactly the "silent fallback" the flag exists to forbid.
+    if chosen is None and not (local and opts.path is None):
+        sys.stderr.write("workhost: %s\n" % error)
+        return EXIT_NO_PATH
+
+    if local and opts.path is None:
+        try:
+            cmd = build_local_command(host, verb, list(opts.args))
+        except ValueError as exc:
+            sys.stderr.write("workhost: %s\n" % exc)
+            return 2
+    elif verb == "kubectl":
+        if opts.dry_run:
+            cmd = build_remote_command(
+                host, verb, chosen.address, list(opts.args), opts.timeout, kube_port=0
+            )
+            sys.stdout.write(" ".join(cmd) + "\n")
+            return 0
+        return run_kubectl_via_tunnel(
+            host, chosen.address, list(opts.args), opts.timeout, opts.verbose
+        )
+    else:
+        cmd = build_remote_command(
+            host, verb, chosen.address, list(opts.args), opts.timeout
+        )
+
+    if opts.dry_run:
+        sys.stdout.write(" ".join(cmd) + "\n")
+        return 0
+
+    if opts.verbose:
+        sys.stderr.write("workhost: exec %s\n" % " ".join(cmd))
+
+    try:
+        return subprocess.run(cmd).returncode
+    except FileNotFoundError as exc:
+        sys.stderr.write("workhost: %s\n" % exc)
+        return 127
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`workhost` reaches a dev host over whichever network path is actually working, and reports the state of **all** of them on every invocation.

```
$ workhost path
workhost: workbench
  lan        192.168.50.250   untrusted-key   host key for alias 'workbench' not in known_hosts
  nebula     10.42.0.30       untrusted-key   host key for alias 'workbench' not in known_hosts
  tailscale  -                not-configured  no tailscale binary on PATH
  -> run `workhost ssh --accept-key` once to trust it,
     or: ssh -o HostKeyAlias=workbench 192.168.50.250
```

## Design decisions

**Four states per path, never two.** `ok` / `unreachable` / `untrusted-key` / `not-configured`. Collapsing them is the defect the tool exists to avoid — "nothing happened" is the observable the most causes share, so it identifies none of them. Tailscale is implemented *now* and reports `not-configured`; it lights up with no code change once a tailnet exists, because its address is resolved at runtime from `tailscale status --json` rather than hardcoded. A tailnet that exists but does not carry the host is also `not-configured`, with a different `detail` — a different problem with a different fix. A missing `ssh` client is `not-configured` too, for the same reason: blaming the network for a missing package is the same fold one layer down.

**`untrusted-key`, and why the tool could not bootstrap itself.** `-o HostKeyAlias=<hostname>` makes ssh look up the ALIAS in `known_hosts` and *ignore* the address entries, and the probe runs `BatchMode=yes` while `StrictHostKeyChecking` defaults to `ask`. On a client that has never trusted that alias — the laptop, i.e. the only machine where this tool does anything, since on workbench it takes the local branch — **all three paths reported `unreachable` on a perfectly healthy network and every verb refused with exit 3.** `select_path` gates every verb (and `--path`) on `state == ok`, so no invocation ever reached the interactive ssh that *would* have prompted.

Reproduced twice before fixing: a fresh client with an empty `known_hosts` running the exact probe argv got `Host key verification failed.` and wrote **zero bytes** to `known_hosts`; this dev host got `Permission denied (publickey,…)` instead — and only because `workbench ssh-ed25519 …` sits at `known_hosts` line 369 of 370, appended during this PR's own development.

So it is its own state, classified from the probe's **stderr** (ssh exits 255 for auth, DNS, timeout *and* host key alike, so the status cannot tell them apart), with `REMOTE HOST IDENTIFICATION HAS CHANGED` sharing the state but carrying its own detail and its own advice — `ssh-keygen -R`, never `--accept-key`, because ssh does not offer to accept a key that changed.

**TOFU was rejected; `--accept-key` is the escape hatch instead.** The probe gains **no** `StrictHostKeyChecking` override: a probe that silently accepts a new host key trusts the machine on the operator's behalf, every run, with no record that a decision was made. `--accept-key` widens the set of *acceptable states* by exactly one — `untrusted-key` becomes selectable, `unreachable` never does — and touches nothing else. The selected path is then connected over by the ordinary action command, which carries no `BatchMode`, so real ssh prints the fingerprint and asks a human once. The probe argv is byte-identical with and without the flag, and a test pins that.

🔴 **And the escape hatch has to be reachable by the route the tool prints.** It was not. The advice said `workhost ssh --accept-key`, and *that exact command did not work*: flags after an action verb belong to the verb, so `--accept-key` landed in ssh's pass-through args, was never parsed, and the run exited 3 saying **"re-run with `--accept-key`"** — the flag just passed. Measured on a fresh client against a real sshd:

```
workhost --accept-key ssh   -> reached real ssh, host-key prompt path. WORKS.
workhost ssh --accept-key   -> rc 3, "re-run with --accept-key".      LOOPS.
```

The same "cannot bootstrap itself" defect one layer up, landing exactly when the operator is most stuck and least able to guess the other word order. `--accept-key` is now hoisted back to workhost from any verb's arguments (`HOISTED_FLAGS`, a one-entry enumerated exception — `workhost run --json` still sends `--json` to the remote command), and because hoisting removes the token from the remote argv, `main` says so on stderr rather than dropping it silently. The escape for a remote command that genuinely wants the literal flag is the ordinary one for `run`: quote it.

**A string that names a command is a claim about the parser.** Every such string was re-checked, enumerated by walking the script's own `sys.std*.write` / `ValueError` / `parser.error` call sites rather than from memory: `select_path`'s error named a *flag* (it is the message seen while looping) and now names the whole command; the no-spec `forward` error's example is asserted to be a spec `validate_forward_spec` itself accepts; the changed-key advice's `ssh-keygen -R <name>` must name the **HostKeyAlias**, not an address, or it deletes the wrong `known_hosts` line; the `or: ssh …` fallback is now *derived* from `ssh_options()` instead of spelled beside it; and `scripts/README.md` named the same broken form and was false for exactly as long.

The `forward` error's `workhost ssh -N -L <spec>` suggestion was **suspected** of being false too — ssh's synopsis puts options before the destination, and workhost appends verb args after it. Measured instead of assumed, on **OpenSSH_10.2p1**, with four controls: `-L bogusspec` before *and* after the destination both give `Bad local forwarding specification`; putting a command first (`… host echo -L bogusspec`) suppresses it; and with no `-L` it never appears. ssh permutes up to the first non-option token, so the suggestion is correct and was kept — with the measurement and its version scope in a comment.

**The probe is a real auth handshake, not a TCP connect.** Measured on this fleet: both addresses complete the TCP *and* SSH transport layers and then fail auth with `Permission denied`, exiting 255. A port probe calls that reachable and the subsequent connect fails in the operator's face. The probe is `ssh -o BatchMode=yes … true`.

**`-o HostKeyAlias=<hostname>` on every ssh/scp/rsync/forward/tunnel invocation.** One machine reached by three addresses otherwise accrues three `known_hosts` entries, and a later address reuse produces a host-key-mismatch wall — `known_hosts` on the dev host already had **two raw-address entries for this single machine** before the tool existed. `rsync` gets the options threaded through `-e`, since it opens its own ssh and would otherwise silently lose the alias. The cost of the alias is exactly the bootstrap problem above, which is now named rather than suffered.

**Always probe all three, in parallel, bounded by `--timeout`.** Serial probing would put three timeouts in front of every command. Failures go to **stderr** so piped stdout carries only the remote command's output; for `path`/`check` the report *is* the product, so it goes to stdout.

**A `forward` that reports success must actually forward.** `ExitOnForwardFailure` defaults to **`no`** (measured from `man ssh_config` on this host), so ssh stayed alive after a failed local bind: `workhost forward 8080:…` against an already-bound 8080 blocked forever with no verdict while the operator believed the tunnel was up and their connections reached an unrelated process. `spec = list(args)` was never validated either, so a bare `workhost forward` built a fully authenticated session with **zero** `-L` flags and idled until killed. Both tunnels now carry `-o ExitOnForwardFailure=yes`, the spec is validated as `[bind:]port:host:hostport` (with the error naming `workhost ssh -N -L …` for ssh's rarer spellings), and the forward test pins the **whole argv** rather than the presence of two tokens.

**Exit-code contract, honestly scoped.** `3` = no path reachable — a **conventional** sentinel, not a reserved one. `workhost run 'exit 3'` over a working path also exits 3, and the usage/unknown-host code `2` likewise collides with a remote `exit 2`. Nothing in 0–255 is safe from a remote command that picks it, short of abandoning passthrough. So the exit code is a hint and **`--json` is the machine-readable channel**: `selected` is `null` exactly when no path was usable. Both collisions have their own tests, so the claim cannot get wider than the code again. (An earlier revision of this PR and of the source docstring said 3 was "distinct from any remote exit code"; that was wrong and is retracted.)

**Local exec detection uses an interface address, not `hostname`.** `hostname` is `nixos` on more than one machine in this fleet — the same measured fact `scripts/lib/host_identity.py` exists to encode — so it would make the laptop believe it is workbench and silently run commands on the wrong machine. The nebula mesh address is the discriminator, unique across the mesh by construction.

🔴 **The LAN address is accepted only when the host table names no nebula address for that host.** An unconditional LAN fallback re-created the rejected hazard one layer down: a LAN address is unique within **one subnet**, so a laptop on a network that hands it `192.168.50.250` satisfied `is_local_host(workbench)` and ran `workhost run 'kubectl delete ns prod'` on **itself**, exit 0, printing nothing in the quiet path that said workbench was never touched. Named cost of the tightening: a host that *has* a nebula address but whose nebula interface is down no longer recognises itself and SSHes to itself over the LAN — a slow success, the same safe direction `local_ipv4_addresses()` already degrades in.

**`kubectl` uses an SSH tunnel, not a server rewrite.** Measured from the live k3s serving certificate: its SANs contain `127.0.0.1` and `192.168.50.250` but **not** the nebula address `10.42.0.30`. A `--server=https://<address>:6443` rewrite is TLS-valid over LAN and TLS-*invalid* over nebula — it would work right up until the LAN path is the one that is down. Tunnelling to the host's own loopback keeps the cert valid over *every* path, and uses the local kubectl rather than depending on the remote non-login shell having one (on NixOS it frequently does not). The irony that follows: the newly-depended-on **local** binary was the one unhandled case — missing `kubectl` died with a bare traceback and exit 1, because `main`'s `FileNotFoundError -> 127` guard sits on the other branch. It now exits 127 with a message. `free_local_port()` is inherently racy, so the tunnel additionally re-checks that ssh is still alive *after* the readiness probe connects; without that plus `ExitOnForwardFailure`, a connect to a port thief would satisfy the probe and `kubectl --server` would be aimed at an unrelated local service.

**Host table, not a code fork.** `HOSTS` has one real entry. `laptop`/`production` are deliberately absent rather than guessed. `homelab` is Talos and has no SSH.

**Failing loudly beats crashing.** `tailscale status --json` printing valid-but-non-object JSON (`null`, `[]`) raised `AttributeError` and exit 1 from **every** verb, `path` included — whose whole job is to report a broken path rather than crash on one. `WORKHOST_TIMEOUT=10s` raised `ValueError` while *building the parser*, so every invocation crashed including `--help`, with nothing on screen naming the variable; it now warns once and falls back, and `--timeout`'s help names the variable the way `--host` names `$WORKHOST_HOST`. `--dry-run` uses `shlex.join`, so an argument containing a space prints as the argv that actually runs, and the kubectl dry run says on stderr that its `-L 0:…` port is a placeholder chosen at run time.

## Test matrix

`scripts/tests/test_workhost.py` — **158 tests, hermetic**: no real network, no real ssh. Every binary (`ssh`, `scp`, `rsync`, `tmux`, `kubectl`, `tailscale`, `ip`) is a `testlib.mockbin` stub and `PATH` is set to **that dir alone** — a prepend would let a real tailscale installed later silently change what the `not-configured` tests assert. The `ip` stub is equally load-bearing in the other direction: this suite is developed *on* workbench, so without it every "remote" test would take the local branch and pass for the wrong reason. The `ssh` stub strips ssh's options the way ssh does and then **executes** the remaining args, so exit-code passthrough is real rather than a canned number.

🔴 **The stub used to exit 255 for every failure, so the suite ASSERTED the ssh-255 conflation** — nothing in it could tell an auth failure from a host-key refusal, which is precisely the bug F1 turned out to be. It now produces all three: `Permission denied` for auth, `Host key verification failed` for a key never seen, and the `REMOTE HOST IDENTIFICATION HAS CHANGED` block for a key that changed. It also models the mechanism `--accept-key` depends on rather than a canned success: under `BatchMode=yes` it refuses the unknown key as ssh does, and *without* BatchMode it proceeds, as ssh does once a human answers. So `test_accept_key_lets_an_untrusted_path_be_used` is green only if the flag really causes an interactive attempt.

Covered: path selection across the probe matrix incl. all-fail and precedence; the four-state distinction in both directions (absent vs present-but-down vs tailnet-without-this-host vs untrusted key vs auth failure); the `--accept-key` opt-in and its two limits (cannot reach the probe, cannot revive an `unreachable` path); the advice block and its changed-key variant; exit-code passthrough plus both collisions; `HostKeyAlias` on every path × every ssh-based verb; local vs remote exec, including the wrong-machine hazard pinned as a hazard; `--path` forcing; `--json` shape field by field; concurrency; `--timeout` and every unusable `$WORKHOST_TIMEOUT`; forward-spec validation; argument forwarding incl. spaces and quotes; stream discipline; delivery.

One test is driven through the module rather than the CLI: `test_the_lan_address_is_accepted_when_the_host_has_no_nebula_address`. `HOSTS` deliberately holds exactly one real host and that host *has* a nebula address, so the conditional branch is unreachable from argv — and inventing a second table entry to test with is the thing `test_only_real_hosts_are_in_the_table` forbids.

**Neither concurrency nor the timeout is asserted on wall-clock time.** Concurrency is proven by **interval overlap** — the stubs timestamp entry and exit, and the test asserts the latest start precedes the earliest end. Serial execution cannot produce overlapping intervals *at any load*. The `--timeout` test is likewise structural: the stub sleeps 10s against a 1s deadline, and the `timed out` detail is reachable only via `subprocess.TimeoutExpired`, so a dropped timeout changes the reported **state** rather than the duration.

### Red-then-green

Two rounds, each measured with the *new* test file against the *previous* `scripts/workhost`, in a `.git`-less `cp -a` copy under `PYTHONDONTWRITEBYTECODE=1`.

| round | base | result at base | at HEAD |
|---|---|---|---|
| the five audit findings | `041cd4db` | **37 failed, 102 passed** | 139 passed |
| the unreachable escape hatch | `65f68594` | **9 failed, 149 passed** | **158 passed** |

Round 2's nine are the fix item by item: all three `untrusted-key` rows of the printed-command ledger, the advice/parser pairing test, the follow-the-advice end-to-end test, the README claim, both after-the-verb `--accept-key` positions, and the hoist notice.

🔴 **Red for the right reason, checked.** `split_argv`'s return is *indexed*, not unpacked, in the test helper — against the pre-fix 3-tuple an unpacking `ValueError` would have turned the pairing test red for a harness reason and proved nothing. The observed failure is the claim: `('workhost ssh --accept-key', 'ssh', ['--accept-key'])` — `accept_key` false, flag stranded in the verb's args.

**Named honestly as invariant guards, NOT regression coverage** — these pass against the base too, because they pin behaviour the fix had to preserve, or a claim rather than a behaviour change. Each is still killed by a mutant below, which is what makes it non-vacuous: `test_an_auth_failure_is_unreachable_not_untrusted_key`, `test_the_probe_never_enables_tofu`, `test_no_advice_is_printed_when_a_path_is_actually_usable`, `test_forward_accepts_an_explicit_bind_address`, `test_a_valid_workhost_timeout_is_still_honoured`, `test_exit_3_is_distinguishable_from_a_remote_failure`, both exit-code collision tests, `test_only_declared_flags_are_hoisted`, `test_nothing_is_said_when_no_flag_was_hoisted`, and `test_accept_key_is_honoured_in_either_position[before-verb]`.


### Mutation battery — every test watched to fail

`scripts/tests/mutants-workhost.sh`: mutates a **copy** in `mktemp -d`, diffs each mutation before running it, scores on pytest's `FAILED …::<test>` *content* rather than an exit code, enforces a `MIN_TESTS` floor, runs under `PYTHONDONTWRITEBYTECODE=1`, and verifies the copy is restored byte-identical.

**59/59 rows ok** (was 24), each killed by the test it names, **no survivors**. Positive control killed; SURVIVES control survived. Groups added across both rounds:

| group | mutants |
|---|---|
| the fourth state | `untrusted-key-collapsed`, `hostkey-missing-unclassified`, `auth-called-a-key-problem`, `changed-key-loses-its-detail`, `probe-gains-tofu` |
| cause + way out | `advice-block-silenced`, `advice-fires-when-fine`, `changed-key-offered-tofu` |
| the escape hatch and its limits | `accept-key-inert`, `accept-key-too-wide` |
| a forward that forwards | `forward-bind-failure-ok`, `kubectl-bind-failure-ok`, `forward-spec-unvalidated`, `forward-shape-unchecked`, `forward-rejects-bind-addr` |
| wrong machine | `lan-fallback-unconditional`, `lan-fallback-removed` |
| crashing is not reporting | `local-kubectl-crash`, `tailscale-non-object`, `missing-ssh-blamed-on-net`, `env-timeout-unguarded`, `env-timeout-always-default`, `timeout-help-hides-the-var` |
| --dry-run prints what runs | `dry-run-space-joined`, `kubectl-hides-placeholder` |
| **a string that names a command** | `accept-key-not-hoisted`, `hoist-too-wide`, `hoist-leaves-the-flag`, `hoist-is-silent`, `hoist-notice-always-fires`, `advice-names-a-non-command`, `manual-line-loses-alias`, `ssh-keygen-names-address`, `forward-example-invalid`, `select-message-drops-cmd` |

🔴 **The battery earned its keep again, on a guard added in this very PR.** `advice-names-a-non-command` — which rewrites the advice to `workhost ssh --accept-keys` — came back **WRONG-KILLER**: it died to the two pairing tests but *not* to the ledger test whose whole job is to check every printed command. Measured directly:

```
workhost ssh --accept-key    globals=['--accept-key']  verb_args=[]                 accept_key=True
workhost ssh --accept-keys   globals=[]                verb_args=['--accept-keys']  accept_key=False
```

`--accept-keys` is not a workhost option, so `split_argv` hands it to the **verb** and the global half parses perfectly cleanly. The ledger asserted only *"it parses"* — so it was green on the exact shape of the defect it exists to catch. It now declares what each printed command must parse **TO**: `workhost_flags` rows assert the named options are set *and* that no `-`-prefixed token was left in the verb's arguments; `verb_flags` rows assert the verb args exactly, for the commands whose flags really are meant for the verb's own tool. Renamed to `test_every_workhost_command_the_tool_prints_parses_as_intended` so the name is no wider than the body. A guard that reads as coverage while providing none is worse than none, because it stops anyone looking.

Two stale claims in the battery's own header are corrected, since the file's stated purpose is that its claims be re-derivable: the test count (said 89, was 96, is now 158) and the `--deselect` of `test_workhost_is_tracked_by_git`, justified as "cannot pass against a `.git`-less copy" — which stopped being true at 041cd4db, when that test grew a second arm. The deselect is **removed** rather than left carrying a dead reason.


## Gate

`nix develop <worktree> --command bash scripts/gate.sh --tier pytest --set hermetic`

`GATE: RESULT=FAIL exit=1` — **`TOTAL collected=21234 passed=21230 skipped=3 failed=1`**. The wrapper reported exit code **0** while the gate itself had failed, so the verdict was read from the log CONTENT rather than the status. **`scripts/tests` itself: PASS, collected=12231 passed=12231** (floor 10269) — which is exactly the 158-test workhost file, confirming that target ran the final content.

The one failure is **`scripts/claude-hooks/tests/test_clawgate_task_interview_guard.py::test_a_body_file_written_by_a_heredoc_on_the_same_line_is_read`**, and it is **not this PR's**. Attributed by running that file at three points:

| tree | result |
|---|---|
| `origin/main` (`f75c92d4`) | **passes** |
| `041cd4db` — this PR's head before any of this work | **fails** |
| this PR's head | **fails** |

So it is red on the branch and green on main: the branch is **30 commits behind**, and main carries `8c27c5cf` (#1303) — *"a stale file at the `--body-file` path shadowed the heredoc about to overwrite it — the verdict was a property of the HOST"* — which the branch does not. It is a host-state-dependent guard already fixed upstream; **merging main will clear it, and that merge is deliberately not part of these commits.**

⚠️ An earlier revision of this PR body called this failure *"pre-existing red, verified failing on an untouched `origin/main` checkout"*. That is **false** — main fixed it. Corrected rather than carried forward.

**Both tiers, run explicitly** (this PR already produced one CI-only failure from the `.git` asymmetry): dev shell with `.git` present — **158 passed**; `cp -a` copy with `.git` removed — **158 passed**.

`test_no_public_ips.py` / `test_no_client_hostnames.py` / `test_no_real_launchers.py` re-run after staging, since the first two enumerate `git ls-files` and cannot see an unstaged file — **110 passed**. `test_no_real_launchers.py` went red once during the first round: a `systemctl` example in a docstring made `workhost` a new reacher of an acknowledged-but-unstubbed binary. It is a **text** scan and the example was illustrative rather than a guarantee, so the example was changed instead of the ledger.


## Not verified

- 🔴 **The fix to the escape hatch has NOT been run against a real ssh.** What *was* verified live, on a fresh client with empty known_hosts against the real workbench sshd: that `041cd4db` reports `unreachable — Host key verification failed.` while `65f68594` reports `untrusted-key` with the advice block, and that `workhost --accept-key ssh` (flag **before** the verb) reaches real ssh and enters the host-key prompt path. The thing this round changed — `--accept-key` written **after** the verb — is covered hermetically only.
- The `REMOTE HOST IDENTIFICATION HAS CHANGED` path has never been seen live, only reproduced from ssh's own message text.
- The `workhost ssh -N -L <spec>` escape hatch was measured against **OpenSSH_10.2p1** only. An ssh old enough not to permute options after the destination would make that suggestion wrong; that version boundary was not bisected.
- **No real tailnet exists**, so the tailscale path is implemented and hermetically tested against a faked binary only.
- The `kubectl` tunnel is tested against a stub ssh that really binds the port, and the cert-SAN reasoning is measured — but it has not been run against the live apiserver from a remote client.
- `ExitOnForwardFailure` is set from a documented default read out of `man ssh_config` on this host; the *behaviour change* (ssh exiting on a failed bind) has not been observed against real ssh, only asserted on the argv. The `free_local_port()` thief race was likewise not induced.
- The tailscale JSON parsing was checked against the authoritative struct in `ipn/ipnstate/ipnstate.go` rather than against a running daemon.
- These tests were developed on a shared, loaded host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
