### PR TITLE
fix(discord-embed-ext): cap inline enlarged media to the VIEWPORT, declaratively

### DIFF
--- a/scripts/discord-embed-ext/README.md
+++ b/scripts/discord-embed-ext/README.md
@@ -52,6 +52,51 @@ earlier version of this file described the cap walk as the whole mechanism
 while enlarged media stayed visibly cropped; the pair above is what the
 extension actually does.
 
+## Uncapping is bounded by the VIEWPORT, not unbounded
+
+Removing Discord's cap is not the same as having no cap. Until 0.3.1 the
+element was left `max-width: 100%; max-height: none`, which overflowed the
+window by two independent routes:
+
+* **vertically**, by construction — `max-height: none` means a tall image runs
+  off the bottom of the window on *every* enlarge, no resize required;
+* **horizontally**, because `100%` resolves against the container whose own
+  `max-width` this same function has just set to `none`, so the effective bound
+  was an ancestor chain that need not be viewport-bounded at all.
+
+0.3.1 replaces those with `max-width: min(100%, 96vw)` and `max-height: 92vh`.
+
+* **Both halves of the width rule are load-bearing.** `100%` keeps media inside
+  Discord's message column, which is much narrower than the window; `96vw` keeps
+  it inside the window when the column is not. Measured in Brave/Chromium 144 at
+  a 1000px window, the same declaration rendered 400.00px inside a 400px column
+  and 960.00px inside a 2000px one.
+* **The cap is expressed in CSS viewport units and there is no `resize`
+  listener.** The engine re-evaluates `vw`/`vh` on resize itself, so there is no
+  listener to leak and no cached pixel value to go stale.
+* **Under 100 on purpose.** `vw` includes the gutter a classic vertical
+  scrollbar occupies. Measured in the same engine with a scrolling document:
+  `innerWidth` 1000 against `documentElement.clientWidth` 985 — a 15px gutter — so
+  a `100vw` box rendered 1000.00px and grew a *horizontal* scrollbar. `96vw` did
+  not. A test named for this trap fails if anyone rounds it up.
+* **`vh`, not `dvh`, deliberately.** `dvh` tracks a retracting mobile toolbar and
+  would relayout media mid-scroll; on desktop Brave — the only place this content
+  script runs — the two are identical.
+
+🔴 **Accepted tradeoff: enlarge now does LESS for portrait media than it used
+to.** A tall image is capped to 92vh and letterboxed (`object-fit: contain` was
+already set, and the aspect ratio is preserved — a 200×2000 image measured
+58.88 × 588.80). Previously it rendered at full height and simply ran off the
+screen. That is the intended behaviour, not a regression.
+
+The cap goes on the **element only**. The container keeps its `max-width: none;
+max-height: none; width: auto; height: auto` and gets no viewport cap of its
+own: with `auto` sizing it tracks its content, so bounding the media bounds the
+wrapper too. Measured — wrapper 592.80px against a 588.80px image, a 4px inline
+baseline gap rather than an open box, inside a 640px viewport. Capping the
+container as well would be redundant at best, and at worst re-imposes a
+constraint on Discord's own layout box that the uncapping just removed.
+
 The last one is a heuristic and the most likely thing to rot. It has a
 `MESSAGE_WALK_DEPTH` of 15 and falls back to treating the media as its own only
 sibling, so the failure mode is "navigation does nothing", never a crash.

--- a/scripts/discord-embed-ext/README.md
+++ b/scripts/discord-embed-ext/README.md
@@ -84,20 +84,37 @@ window by two independent routes:
   script runs — the two are identical.
 
 🔴 **Accepted tradeoff: enlarge now does LESS for portrait media than it used
-to.** A tall image is capped to 92vh and letterboxed (`object-fit: contain` was
-already set, and the aspect ratio is preserved — a 200×2000 image measured
-58.88 × 588.80). Previously it rendered at full height and simply ran off the
-screen. That is the intended behaviour, not a regression.
+to.** A tall image is capped to 92vh with its aspect ratio preserved — a
+200×2000 image measured 58.88 × 588.80. Previously it rendered at full height
+and simply ran off the screen. That is the intended behaviour, not a regression.
+
+⚠ **The ratio is preserved by the replaced-element sizing algorithm, NOT by
+`object-fit: contain`.** In the ordinary block case the box ratio already
+equals the intrinsic one, and the render measured identical with `contain`,
+with `fill`, and with the declaration removed. Keep it anyway: where the box
+ratio differs from the content's — `display:flex; flex-direction:column` gives
+614.39 × 588.80 for the same image — `fill` squashes and `contain` letterboxes.
+No behavioural test in this suite can observe that; only the structural
+declaration-set assertion holds it.
+
+⚠ **"Viewport" means the WINDOW, not the visible message area.** Discord insets
+the scroller by a channel header and a composer, so a 92vh image is still taller
+than what you can see — you scroll to its bottom. Measured on a synthetic
+Discord-shaped layout (1200×800, 48px header, 68px composer): scroller visible
+height 684px, a 1000×3000 image capped to 736px. Much better than the shipped
+`max-height: none` (2000px in a 640px viewport), but not "fits on screen".
+`ENLARGED_MAX_VH` is the single lever if fitting matters more than size.
 
 The cap goes on the **element only**. The container keeps its `max-width: none;
 max-height: none; width: auto; height: auto` and gets no viewport cap of its
 own: with `auto` sizing it tracks its content, so bounding the media bounds the
-wrapper too. Measured — wrapper 592.80px against a 588.80px image, a 4px inline
-baseline gap rather than an open box, inside a 640px viewport. Capping the
-container as well would be redundant at best, and at worst re-imposes a
-constraint on Discord's own layout box that the uncapping just removed.
+wrapper too. Measured — wrapper 588.80px against a 588.80px image, i.e. the
+container tracks the media exactly with no open box, inside a 640px viewport.
+Capping the container as well would be redundant at best, and at worst
+re-imposes a constraint on Discord's own layout box that the uncapping just
+removed.
 
-The last one is a heuristic and the most likely thing to rot. It has a
+The message-boundary walk is a heuristic and the most likely thing to rot. It has a
 `MESSAGE_WALK_DEPTH` of 15 and falls back to treating the media as its own only
 sibling, so the failure mode is "navigation does nothing", never a crash.
 

--- a/scripts/discord-embed-ext/extension/embed_enlarge.js
+++ b/scripts/discord-embed-ext/extension/embed_enlarge.js
@@ -45,6 +45,16 @@
   // LARGE viewport — stable, and numerically identical to `dvh` on desktop
   // Brave, which is the only place this content script runs. Revisit only if
   // this manifest ever matches a mobile browser.
+  // ⚠ `vh` IS THE WINDOW, NOT THE VISIBLE MESSAGE AREA. Discord insets the
+  // scroller by a channel header and a composer, so a 92vh image is still
+  // taller than what you can see and you will scroll to its bottom. That is a
+  // large improvement on `max-height: none` (2000px in a 640px viewport,
+  // measured) but it is NOT "now fits on screen", and the README must not say
+  // so. MEASURED on a synthetic Discord-shaped layout, 1200x800 with a 48px
+  // header and a 68px composer: scroller visible height 684px, a 1000x3000
+  // image capped to 736px. NOT measured against the live client. If fitting
+  // matters more than size, this constant is the single lever — ~85 rather
+  // than 92.
   var ENLARGED_MAX_VH = 92;
   // 🔴 BOTH HALVES, OR THE MEDIA ESCAPES SIDEWAYS. `100%` alone was the bug: it
   // resolves against the container, whose own max-width applyOverride sets to
@@ -293,10 +303,15 @@
       // box, and re-imposing a max-height on a flex parent can squeeze the
       // media the uncapping just freed. MEASURED, not reasoned: rendering this
       // exact four-declaration set on a wrapper around a 92vh-capped 200x2000
-      // image in Brave/Chromium 144 gave wrapper height 592.80px against image
-      // height 588.80px — a 4px inline baseline gap, not an open box — and
-      // 592.80 <= the 640px viewport. There is nothing here for a container cap
-      // to fix.
+      // image in Brave/Chromium 144 gave wrapper height 588.80px against image
+      // height 588.80px — the container tracks the media exactly, no open box —
+      // and 588.80 <= the 640px viewport. There is nothing here for a container
+      // cap to fix.
+      //
+      // (An earlier version of this comment said 592.80 against 588.80 and
+      // called the 4px an inline baseline gap. That figure does not reproduce:
+      // re-measured at 0px in three line-height contexts. The decision it
+      // supports is unchanged and in fact stronger.)
       var ccs = container.style;
       ccs.setProperty("max-width", "none", "important");
       ccs.setProperty("max-height", "none", "important");
@@ -307,11 +322,22 @@
     // 🔴 THE VIEWPORT CAP. `max-height: none` here was the vertical overflow by
     // construction: any tall image ran off the bottom of the window, resize or
     // no resize. `max-width: 100%` was the horizontal half — see the
-    // ENLARGED_MAX_WIDTH header. object-fit: contain below is what makes a
-    // capped portrait image letterbox instead of squashing. MEASURED: a
-    // 200x2000 image under these declarations rendered 58.88 x 588.80 in
-    // Brave/Chromium 144 — the 1:10 ratio intact — where the shipped
-    // `max-height: none` rendered it 2000px tall against a 640px viewport.
+    // ENLARGED_MAX_WIDTH header. MEASURED: a 200x2000 image under these
+    // declarations rendered 58.88 x 588.80 in Brave/Chromium 144 — the 1:10
+    // ratio intact — where the shipped `max-height: none` rendered it 2000px
+    // tall against a 640px viewport.
+    //
+    // 🔴 `object-fit: contain` IS NOT WHAT PRESERVES THAT RATIO — do not cite
+    // it as the reason, and do not delete it as useless either. In the ordinary
+    // BLOCK case the box ratio already equals the intrinsic ratio (58.88 x 10 =
+    // 588.80), so the replaced-element auto/max-constraint algorithm does the
+    // work: MEASURED identical at 58.88 x 588.80 with `contain`, with `fill`,
+    // and with the declaration deleted outright. It becomes load-bearing where
+    // the box ratio DIFFERS from the content's — same engine, same image,
+    // inside `display:flex; flex-direction:column` the box is 614.39 x 588.80,
+    // and there `fill` squashes while `contain` letterboxes. Kept for that
+    // case; no behavioural test in this suite can observe it, so only the
+    // structural declaration-set assertion holds the line.
     el.style.setProperty("max-width", ENLARGED_MAX_WIDTH, "important");
     el.style.setProperty("max-height", ENLARGED_MAX_HEIGHT, "important");
     el.style.setProperty("width", "auto", "important");

--- a/scripts/discord-embed-ext/extension/embed_enlarge.js
+++ b/scripts/discord-embed-ext/extension/embed_enlarge.js
@@ -13,6 +13,57 @@
   var MAX_WALK_DEPTH = 8;
   var WIDTH_THRESHOLD = 500;
   var HEIGHT_THRESHOLD = 400;
+
+  // 🔴 THE FOUR BELOW ARE A VIEWPORT CAP, NOT THE TWO DETECTION THRESHOLDS
+  // ABOVE. WIDTH_THRESHOLD/HEIGHT_THRESHOLD are px numbers findContainer
+  // compares an ANCESTOR'S COMPUTED cap against, to RECOGNISE Discord's 400x300
+  // box so it can be removed. ENLARGED_* is the bound WE then impose on the
+  // media. Same shape, opposite direction: one reads, one writes. Do not reuse,
+  // extend or fold one into the other.
+  //
+  // 🔴 EXPRESSED IN CSS VIEWPORT UNITS, WITH NO resize LISTENER, DELIBERATELY.
+  // The engine re-evaluates vw/vh on every window resize itself, so there is no
+  // listener to leak, no cached px value to go stale and no rAF thrash. A
+  // JS-computed px cap would need one, and would need the fake DOM to grow a
+  // viewport it does not model. This is the whole design: keep it declarative.
+  //
+  // 🔴 UNDER 100 ON PURPOSE — NOT A ROUNDING CHOICE, AND NOT SIMPLIFIABLE.
+  // `100vw` is the width of the initial containing block, which INCLUDES the
+  // gutter a classic vertical scrollbar sits in, so a `100vw` element overflows
+  // horizontally and grows a HORIZONTAL scrollbar on any page that has a classic
+  // vertical one. MEASURED 2026-09-04 in the engine this actually ships against
+  // (Brave/Chromium 144, headless, 1000px window, `overflow-y: scroll` document):
+  // innerWidth 1000, documentElement.clientWidth 985 — a 15px gutter. A `100vw`
+  // box rendered 1000.00px against 985px of usable width and pushed
+  // scrollWidth past clientWidth; the 96vw box rendered 960.00px and did not.
+  // The remaining margin is also the only breathing room between the media and
+  // the window edge, because unclipAncestors() has just stripped every ancestor
+  // clip that would otherwise have supplied one.
+  var ENLARGED_MAX_VW = 96;
+  // 🔴 `vh`, NOT `dvh`, AS A DECISION RATHER THAN AN OMISSION. `dvh` tracks a
+  // retracting browser toolbar, so it RELAYOUTS media mid-scroll; `vh` is the
+  // LARGE viewport — stable, and numerically identical to `dvh` on desktop
+  // Brave, which is the only place this content script runs. Revisit only if
+  // this manifest ever matches a mobile browser.
+  var ENLARGED_MAX_VH = 92;
+  // 🔴 BOTH HALVES, OR THE MEDIA ESCAPES SIDEWAYS. `100%` alone was the bug: it
+  // resolves against the container, whose own max-width applyOverride sets to
+  // `none` just above the write site, so the effective horizontal bound became an
+  // ancestor chain that need not be viewport-bounded. But `96vw` alone is a
+  // DIFFERENT bug — Discord's message column is much narrower than the window,
+  // so a viewport-only cap lets media spill out of the column and across the
+  // sidebar. min() takes whichever is smaller: the column when the column is
+  // narrow, the viewport when it is not. MEASURED in Brave/Chromium 144 at a
+  // 1000px window: computed max-width resolves to `min(100%, 960px)`, and the
+  // SAME declaration rendered 400.00px inside a 400px column and 960.00px inside
+  // a 2000px one — both halves demonstrably load-bearing, at two points.
+  //
+  // Built by concatenation so the number appears exactly ONCE, above. A second
+  // hardcoded `96vw`/`92vh` literal anywhere in this file is what lets the
+  // constant and its use drift apart, and the suite forbids it.
+  var ENLARGED_MAX_WIDTH = "min(100%, " + ENLARGED_MAX_VW + "vw)";
+  var ENLARGED_MAX_HEIGHT = ENLARGED_MAX_VH + "vh";
+
   var DEBOUNCE_MS = 100;
   var ATTR_ENLARGED = "data-dee-enlarged";
   // Holds the ancestor's PRIOR inline overflow so forget() can put it back —
@@ -233,6 +284,19 @@
     var unclipped = unclipAncestors(el);
     var removed = false;
     if (container) {
+      // 🔴 THE CONTAINER IS UNCAPPED AND STAYS UNCAPPED — the viewport cap goes
+      // on the ELEMENT only, and that is a decision, not an oversight. With
+      // width/height forced to `auto` the container is sized by its content, so
+      // once the media inside is bounded the container is bounded with it and
+      // no empty box is left behind; a second cap here would be redundant at
+      // best. At worst it is harmful: this container is Discord's own layout
+      // box, and re-imposing a max-height on a flex parent can squeeze the
+      // media the uncapping just freed. MEASURED, not reasoned: rendering this
+      // exact four-declaration set on a wrapper around a 92vh-capped 200x2000
+      // image in Brave/Chromium 144 gave wrapper height 592.80px against image
+      // height 588.80px — a 4px inline baseline gap, not an open box — and
+      // 592.80 <= the 640px viewport. There is nothing here for a container cap
+      // to fix.
       var ccs = container.style;
       ccs.setProperty("max-width", "none", "important");
       ccs.setProperty("max-height", "none", "important");
@@ -240,8 +304,16 @@
       ccs.setProperty("height", "auto", "important");
       removed = true;
     }
-    el.style.setProperty("max-width", "100%", "important");
-    el.style.setProperty("max-height", "none", "important");
+    // 🔴 THE VIEWPORT CAP. `max-height: none` here was the vertical overflow by
+    // construction: any tall image ran off the bottom of the window, resize or
+    // no resize. `max-width: 100%` was the horizontal half — see the
+    // ENLARGED_MAX_WIDTH header. object-fit: contain below is what makes a
+    // capped portrait image letterbox instead of squashing. MEASURED: a
+    // 200x2000 image under these declarations rendered 58.88 x 588.80 in
+    // Brave/Chromium 144 — the 1:10 ratio intact — where the shipped
+    // `max-height: none` rendered it 2000px tall against a 640px viewport.
+    el.style.setProperty("max-width", ENLARGED_MAX_WIDTH, "important");
+    el.style.setProperty("max-height", ENLARGED_MAX_HEIGHT, "important");
     el.style.setProperty("width", "auto", "important");
     el.style.setProperty("height", "auto", "important");
     el.style.setProperty("object-fit", "contain", "important");
@@ -365,6 +437,10 @@
   if (typeof globalThis !== "undefined") {
     globalThis.__DEE__ = {
       MEDIA_URL_RE: MEDIA_URL_RE,
+      ENLARGED_MAX_VW: ENLARGED_MAX_VW,
+      ENLARGED_MAX_VH: ENLARGED_MAX_VH,
+      ENLARGED_MAX_WIDTH: ENLARGED_MAX_WIDTH,
+      ENLARGED_MAX_HEIGHT: ENLARGED_MAX_HEIGHT,
       isMediaElement: isMediaElement,
       findContainer: findContainer,
       findMessageContainer: findMessageContainer,

--- a/scripts/discord-embed-ext/extension/manifest.json
+++ b/scripts/discord-embed-ext/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Discord Embed Enlarge",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Enlarges Discord's native media embeds past their 400x300 cap, with a click-to-open lightbox (zoom, pan, per-message navigation).",
   "permissions": [],
   "content_scripts": [{

--- a/scripts/discord-embed-ext/tests/embed_enlarge.test.mjs
+++ b/scripts/discord-embed-ext/tests/embed_enlarge.test.mjs
@@ -709,8 +709,11 @@ test("REGRESSION: the container override is !important, or Discord's own CSS win
   var css = container.style.cssText;
   assert.match(css, /max-width: none !important/, "container max-width must win");
   assert.match(css, /max-height: none !important/, "container max-height must win");
-  assert.match(img.style.cssText, /max-width: 100% !important/,
-    "and the element side too");
+  // The element's max-width is now the viewport-aware cap, read from the
+  // exported constant so this assertion cannot drift away from the source.
+  assert.ok(img.style.cssText.includes(
+    "max-width: " + DEE.ENLARGED_MAX_WIDTH + " !important"),
+    "and the element side too — got: " + img.style.cssText);
 });
 
 test("SEAM: autoStart both scans what is already there AND subscribes for later", () => {
@@ -884,7 +887,11 @@ test("REGRESSION: applyOverride writes its FULL declaration set, not just the ca
   DEE.applyOverride(img);
 
   var el = img.style.cssText;
-  for (var decl of ["max-width: 100% !important", "max-height: none !important",
+  // max-width/max-height are read from the exported constants: the viewport cap
+  // replaced the old `100%` / `none` pair, and hardcoding the new values here
+  // would just recreate the drift the constants exist to prevent.
+  for (var decl of ["max-width: " + DEE.ENLARGED_MAX_WIDTH + " !important",
+                    "max-height: " + DEE.ENLARGED_MAX_HEIGHT + " !important",
                     "width: auto !important", "height: auto !important",
                     "object-fit: contain !important", "cursor: zoom-in !important"]) {
     assert.ok(el.includes(decl), "element must declare " + decl + " — got: " + el);
@@ -1175,4 +1182,330 @@ test("SEAM: findMessageContainer has ONE definition, and lightbox reads it", () 
     "nor keep its own copy of the walk depth");
   assert.ok(lb.includes("dee.findMessageContainer"),
     "it must consume the shared one");
+});
+
+// ===========================================================================
+// Round 5 — THE VIEWPORT CAP.
+//
+// applyOverride() removes Discord's 400x300 cap, and until this round it left
+// the enlarged media unbounded by TWO independent routes:
+//
+//   vertical   `max-height: none` on the element. Unbounded BY CONSTRUCTION —
+//              a tall image overflowed the window every time, resize or not.
+//   horizontal `max-width: 100%`, which resolves against the container whose
+//              OWN max-width applyOverride sets to `none` just above. The
+//              effective bound was therefore an ancestor chain that need not be
+//              viewport-bounded at all.
+//
+// 🔴 NO resize LISTENER, DELIBERATELY. The cap is CSS viewport units, which the
+// engine re-evaluates on resize for free: nothing to leak, nothing to go stale.
+//
+// 🔴 WHAT THESE TESTS CANNOT SEE. The fake DOM models NO viewport — no
+// innerWidth/innerHeight, no getBoundingClientRect, no layout. So every test
+// below pins the DECLARATIONS applyOverride writes, and that is precisely why
+// the fix is declarative: `92vh` is assertable here, `window.innerHeight * 0.92`
+// would not be. The RENDERED consequences of these declarations were measured
+// separately, in Brave/Chromium 144 over CDP, and are recorded in
+// embed_enlarge.js's own comments. NOTHING BELOW OBSERVES LAYOUT, and no test
+// here should be read as claiming to.
+// ===========================================================================
+
+const EMBED_SRC = readFileSync(
+  new URL("../extension/embed_enlarge.js", import.meta.url), "utf8");
+
+// Strip `//` comments so a source scan reads CODE and never prose — otherwise
+// the trap comment that NAMES `100vw` would trip the guard forbidding `100vw`.
+// The file has no block comments and no bare `//` inside any string or regex
+// literal (MEDIA_URL_RE spells its slashes `\/\/`, which are not adjacent), and
+// the constants test below pins BOTH preconditions instead of trusting them.
+function codeOnly(src) {
+  return src.split("\n").map(function (line) {
+    var i = line.indexOf("//");
+    return i === -1 ? line : line.slice(0, i);
+  }).join("\n");
+}
+
+// A capped Discord embed, enlarged. `naturalWidth`/`naturalHeight` are set so
+// the portrait and landscape cases are genuinely different fixtures rather than
+// the same square image twice.
+function enlargedImg(opts) {
+  DEE.forget();
+  var o = opts || {};
+  var container = new FakeElement("div", { class: "embed" });
+  container.style.setProperty("max-width", "400px", "important");
+  container.style.setProperty("max-height", "300px", "important");
+  var img = new FakeElement("img", {
+    src: o.src || "https://cdn.discordapp.com/attachments/1/2/media.png",
+  });
+  img.naturalWidth = o.naturalWidth === undefined ? 200 : o.naturalWidth;
+  img.naturalHeight = o.naturalHeight === undefined ? 4000 : o.naturalHeight;
+  container.appendChild(img);
+  var res = DEE.applyOverride(img);
+  return { container: container, img: img, res: res };
+}
+
+test("🔴 REGRESSION: a TALL embed is capped to the VIEWPORT, never `max-height: none`", () => {
+  // RED at 2882d2c7 (`max-height: none`), GREEN at HEAD. This is the vertical
+  // route, and it is the one broken by construction: no resize required.
+  var rig = enlargedImg({ naturalWidth: 200, naturalHeight: 4000 });
+  var mh = rig.img.style.getPropertyValue("max-height");
+  assert.notEqual(mh, "none",
+    "`max-height: none` IS the defect — a 200x4000 image runs off the bottom of " +
+    "the window on every enlarge");
+  assert.equal(mh, DEE.ENLARGED_MAX_VH + "vh",
+    "and it must be the exported constant, not a literal free to drift from it");
+  assert.equal(rig.img.style.getPropertyPriority("max-height"), "important",
+    "!important, or the stylesheet that set the original cap wins the cascade back");
+});
+
+test("🔴 REGRESSION: the HORIZONTAL bound is viewport-relative, not a bare `100%`", () => {
+  // The second, independent route. RED at 2882d2c7 (`100%`), GREEN at HEAD.
+  var rig = enlargedImg({ naturalWidth: 6000, naturalHeight: 400 });
+  var mw = rig.img.style.getPropertyValue("max-width");
+  assert.notEqual(mw, "100%",
+    "`100%` resolves against the container, whose own max-width applyOverride " +
+    "set to `none` just above the write site — that is an ancestor chain, not " +
+    "the viewport");
+  assert.ok(mw.includes(DEE.ENLARGED_MAX_VW + "vw"),
+    "the viewport half must be present — got: " + mw);
+  assert.equal(rig.img.style.getPropertyPriority("max-width"), "important",
+    "and !important on this axis too");
+});
+
+test("🔴 the width rule KEEPS its container constraint — `96vw` alone lets media escape the column", () => {
+  // 🔴 A test that only checked for the `vw` half would pass an implementation
+  // that dropped `100%`. Discord's message column is far narrower than the
+  // window, so a viewport-only cap lets media spill out of the column and across
+  // the sidebar — a different bug, not a simplification. Both halves, always.
+  var rig = enlargedImg();
+  var mw = rig.img.style.getPropertyValue("max-width");
+  assert.ok(mw.includes("100%"),
+    "the CONTAINER half must survive, or media escapes the message column — got: " + mw);
+  assert.ok(mw.includes(DEE.ENLARGED_MAX_VW + "vw"),
+    "and the VIEWPORT half, or the original unbounded bug is back — got: " + mw);
+  // Pin the WHOLE normalised string: a guard on individual words is walkable by
+  // rewording the declaration into something that still spells both fragments.
+  assert.equal(mw, "min(100%, " + DEE.ENLARGED_MAX_VW + "vw)",
+    "the exact declaration, so a reword cannot walk this guard");
+});
+
+test("🔴 SEAM: the cap SURVIVES unclipAncestors — ancestors unclipped AND the element capped", () => {
+  // Each half was verified in isolation above and in Round 4's unclip block.
+  // This is the COMBINED state neither one's own fixture ever builds: the two
+  // are written by different branches of applyOverride, in an order whose
+  // comment says the order is load-bearing.
+  DEE.forget();
+  var rig = clipRig({ innerStyle: "overflow: hidden; max-width: 400px" });
+  var res = DEE.applyOverride(rig.img);
+
+  assert.equal(res.removed, true, "precondition: the uncap half found its container");
+  assert.ok(res.unclipped >= 2,
+    "precondition: ancestors really were unclipped — got " + res.unclipped);
+  assert.equal(overflowOf(rig.inner), "visible/important",
+    "precondition: the clip that used to crop the media is gone");
+
+  assert.equal(rig.img.style.getPropertyValue("max-height"), DEE.ENLARGED_MAX_HEIGHT,
+    "the height cap must still be there once the clips are off — unclipping is " +
+    "exactly what lets unbounded media SPILL rather than be cropped");
+  assert.equal(rig.img.style.getPropertyValue("max-width"), DEE.ENLARGED_MAX_WIDTH,
+    "and the width cap with it");
+});
+
+test("🔴 UNDO: reclipAncestors restores the exact prior overflow, and NO cap leaks onto an ancestor", () => {
+  DEE.forget();
+  var rig = clipRig();
+  // Two DIFFERENT prior declarations, so a restore that hardcodes either one is
+  // caught: value and priority are both round-tripped, in both spellings.
+  rig.inner.style.setProperty("overflow", "hidden", "");
+  rig.outer.style.setProperty("overflow", "clip", "important");
+  DEE.applyOverride(rig.img);
+  assert.equal(overflowOf(rig.inner), "visible/important", "precondition: overridden");
+  assert.equal(overflowOf(rig.outer), "visible/important", "precondition: overridden");
+
+  var doc = {
+    querySelectorAll: function (sel) {
+      if (sel.indexOf("data-dee-unclipped") === -1) return [];
+      return [rig.inner, rig.outer, rig.row, rig.scroller, rig.chrome]
+        .filter(function (e) { return e.getAttribute("data-dee-unclipped") !== null; });
+    },
+  };
+  DEE.reclipAncestors(doc);
+  assert.equal(overflowOf(rig.inner), "hidden/",
+    "the exact prior value AND its empty priority");
+  assert.equal(overflowOf(rig.outer), "clip/important",
+    "and `important` where that is what was there");
+
+  // 🔴 THE CAP BELONGS TO THE ELEMENT. An ancestor carrying a viewport cap
+  // would survive every undo path there is — reclipAncestors only knows about
+  // `overflow` — so a leak here is permanent.
+  var VIEWPORT_LITERAL = /\d+v[wh]\b/;
+  assert.ok(VIEWPORT_LITERAL.test("max-height: 92vh"),
+    "positive control: this scanner CAN see a viewport literal, so the zeros " +
+    "below are a measurement and not a wiring failure");
+  for (var anc of [rig.inner, rig.outer, rig.row, rig.scroller, rig.chrome]) {
+    assert.ok(!VIEWPORT_LITERAL.test(String(anc.style.getPropertyValue("max-height") || "")),
+      "no viewport height cap may leak onto an ancestor");
+    assert.ok(!VIEWPORT_LITERAL.test(String(anc.style.getPropertyValue("max-width") || "")),
+      "nor a viewport width cap");
+  }
+  assert.ok(VIEWPORT_LITERAL.test(rig.img.style.getPropertyValue("max-height")),
+    "while the ELEMENT still carries it — otherwise the loop above passes " +
+    "because nothing anywhere was ever capped");
+});
+
+test("🔴 IDEMPOTENT: a second applyOverride neither re-applies the cap nor DRIFTS it", () => {
+  DEE.forget();
+  var container = new FakeElement("div", { class: "embed" });
+  container.style.setProperty("max-width", "400px", "important");
+  var img = new FakeElement("img", {
+    src: "https://cdn.discordapp.com/attachments/1/2/twice.png" });
+  container.appendChild(img);
+
+  DEE.applyOverride(img);
+  assert.equal(img.getAttribute("data-dee-enlarged"), "1", "precondition: marked");
+  assert.equal(img.style.getPropertyValue("max-height"), DEE.ENLARGED_MAX_HEIGHT,
+    "positive control: the FIRST call really did apply the cap");
+
+  // POISON both declarations. "Nothing changed" is unobservable when the second
+  // call would write the same value; moving each to a sentinel first makes a
+  // missing early-return VISIBLE rather than merely harmless. The container's
+  // sentinel is deliberately NOT `400px` — the first call already uncapped it to
+  // `none`, so asserting the original value would fail for the wrong reason.
+  img.style.setProperty("max-height", "1px", "important");
+  container.style.setProperty("max-width", "999px", "important");
+  var res = DEE.applyOverride(img);
+
+  assert.equal(res.ok, true);
+  assert.equal(res.removed, false, "the early return reports no container work");
+  assert.equal(img.style.getPropertyValue("max-height"), "1px",
+    "an already-enlarged element must not have its declarations re-written");
+  assert.equal(img.style.getPropertyValue("max-width"), DEE.ENLARGED_MAX_WIDTH,
+    "and the untouched half stays exactly as the first call left it");
+  assert.equal(container.style.getPropertyValue("max-width"), "999px",
+    "nor may its container be touched a second time");
+});
+
+test("🔴 NEGATIVE, AND REACHABLE: an avatar on the SAME CDN gets no viewport cap", () => {
+  // 🔴 REACHABLE BY CONSTRUCTION, not merely present. This <img> passes every
+  // earlier check in the chain — it is an element, it is an <img>, it sits in a
+  // capped and clipping container, querySelectorAll returns it, and its src IS
+  // on cdn.discordapp.com. The ONLY thing that rejects it is MEDIA_URL_RE's path
+  // prefix, so the guard is proven to EXECUTE rather than to be short-circuited
+  // by something upstream.
+  DEE.forget();
+  var doc = makeDiscordDoc(
+    "<div class='message'>" +
+    "<div class='avatarwrap' style='max-width: 40px; overflow: hidden'>" +
+    "<img src='https://cdn.discordapp.com/avatars/111/222/avatar.png' />" +
+    "</div>" +
+    "<div class='embed' style='max-width: 400px; overflow: hidden'>" +
+    "<img src='https://cdn.discordapp.com/attachments/1/2/real.png' />" +
+    "</div></div>");
+  var avatar = doc.querySelector(".avatarwrap img");
+  var real = doc.querySelector(".embed img");
+  var n = DEE.scan(doc.body);
+
+  // POSITIVE CONTROL first: a zero on the avatar is indistinguishable from a
+  // scan wired to nothing until the number is watched to MOVE on a case that
+  // must produce one.
+  assert.equal(n, 1, "exactly one element matched — the attachment, not the avatar");
+  assert.equal(real.style.getPropertyValue("max-height"), DEE.ENLARGED_MAX_HEIGHT,
+    "positive control: a real attachment in the SAME document IS capped");
+
+  assert.equal(avatar.getAttribute("data-dee-enlarged"), null,
+    "the avatar is never marked");
+  assert.equal(avatar.style.cssText, "",
+    "and carries no declaration at all — got: " + avatar.style.cssText);
+  assert.equal(doc.querySelector(".avatarwrap").style.cssText, "",
+    "nor does its container get uncapped");
+});
+
+test("🔴 TRAP: the cap is NOT `100vw` — `vw` INCLUDES the vertical scrollbar gutter", () => {
+  // 🔴 THIS IS THE TEST THAT STOPS SOMEONE "SIMPLIFYING" 96 TO 100.
+  // MEASURED 2026-09-04 in Brave/Chromium 144 (headless, CDP, 1000px window, a
+  // document with `overflow-y: scroll`): window.innerWidth 1000 but
+  // documentElement.clientWidth 985 — a 15px classic-scrollbar gutter. A `100vw`
+  // box rendered 1000.00px against those 985 usable px and pushed
+  // document scrollWidth (1000) past clientWidth (985): it GREW A HORIZONTAL
+  // SCROLLBAR. The 96vw box rendered 960.00px and did not. Discord's client
+  // always has a vertical scrollbar, so 100vw is a guaranteed overflow there.
+  assert.ok(DEE.ENLARGED_MAX_VW < 100,
+    "100vw overflows horizontally whenever a classic vertical scrollbar exists");
+  assert.ok(DEE.ENLARGED_MAX_VH < 100,
+    "and the height cap keeps the same margin, for the same kind of reason");
+
+  var code = codeOnly(EMBED_SRC);
+  assert.ok(/\b100v[wh]\b/.test("width: 100vw"),
+    "positive control: this pattern CAN match, so the assertion below is a " +
+    "measurement rather than a mis-spelled regex returning a reassuring zero");
+  assert.ok(!/\b100v[wh]\b/.test(code),
+    "no `100vw`/`100vh` may appear in CODE (the trap comment naming it is prose, " +
+    "and codeOnly() strips prose)");
+});
+
+test("🔴 the viewport constants are pinned BOTH ways — no drift, and no second copy", () => {
+  // FORWARD: the declaration strings are DERIVED from the numbers, so the number
+  // and the declaration are incapable of disagreeing.
+  assert.equal(typeof DEE.ENLARGED_MAX_VW, "number");
+  assert.equal(typeof DEE.ENLARGED_MAX_VH, "number");
+  assert.equal(DEE.ENLARGED_MAX_WIDTH, "min(100%, " + DEE.ENLARGED_MAX_VW + "vw)");
+  assert.equal(DEE.ENLARGED_MAX_HEIGHT, DEE.ENLARGED_MAX_VH + "vh");
+
+  // 🔴 AND THE USE MATCHES THE CONSTANT. Everything above is true of a dead
+  // export; only this pins that applyOverride actually writes it.
+  var rig = enlargedImg();
+  assert.equal(rig.img.style.getPropertyValue("max-width"), DEE.ENLARGED_MAX_WIDTH);
+  assert.equal(rig.img.style.getPropertyValue("max-height"), DEE.ENLARGED_MAX_HEIGHT);
+
+  var code = codeOnly(EMBED_SRC);
+
+  // 🔴 INSTRUMENT CHECK — validate codeOnly() before reading any zero from it.
+  // A stripper that mishandled MEDIA_URL_RE's `\/\/` would truncate the file and
+  // every "not found" below would be vacuously true.
+  // NB the regex literal spells its dots escaped (`cdn\.discordapp\.com`), so
+  // the plain-text host is NOT what to look for here — matching on it failed on
+  // the first run of this very assertion, which is the point of having it.
+  assert.ok(code.includes("(attachments|external)"),
+    "the stripper preserved the regex literal it could have eaten");
+  assert.ok(code.includes("var MEDIA_URL_RE"),
+    "and the declaration it belongs to");
+  assert.ok(code.includes("var ENLARGED_MAX_WIDTH"),
+    "and the constant declarations");
+  assert.ok(!code.includes("MESSAGE MEDIA ONLY"),
+    "while genuinely removing prose — otherwise it strips nothing and the " +
+    "`100vw` guard above passes only because it never sees the comment");
+
+  // 🔴 NO SECOND HARDCODED COPY. Both declarations are built by concatenation
+  // from the two numbers, so a viewport literal must not appear in code at all.
+  var LITERAL = /\d+v[wh]\b/g;
+  assert.ok(/\d+v[wh]\b/.test("max-width: 96vw"),
+    "positive control: the scanner can see a literal");
+  var hits = code.match(LITERAL);
+  assert.equal(hits, null,
+    "a hardcoded viewport literal reappeared in code — the constant can now " +
+    "drift away from its use: " + JSON.stringify(hits));
+
+  // Each number is declared exactly ONCE.
+  assert.equal((code.match(/ENLARGED_MAX_VW\s*=/g) || []).length, 1,
+    "ENLARGED_MAX_VW is declared exactly once");
+  assert.equal((code.match(/ENLARGED_MAX_VH\s*=/g) || []).length, 1,
+    "ENLARGED_MAX_VH is declared exactly once");
+
+  // 🔴 REVERSE DIRECTION: the constants are CONSUMED at the write site. Without
+  // this, replacing the setProperty argument with a literal would leave every
+  // assertion above green while the export became decoration.
+  assert.match(code, /setProperty\("max-width",\s*ENLARGED_MAX_WIDTH,\s*"important"\)/,
+    "applyOverride must write the constant, not a literal");
+  assert.match(code, /setProperty\("max-height",\s*ENLARGED_MAX_HEIGHT,\s*"important"\)/,
+    "on both axes");
+
+  // 🔴 AND THEY ARE NOT THE DETECTION THRESHOLDS. WIDTH_THRESHOLD/
+  // HEIGHT_THRESHOLD are px numbers findContainer READS off an ancestor to
+  // recognise Discord's cap; these are viewport units this code WRITES. Same
+  // shape, opposite direction — conflating them is the mistake this pins.
+  assert.notEqual(DEE.ENLARGED_MAX_VW, 500, "not WIDTH_THRESHOLD");
+  assert.notEqual(DEE.ENLARGED_MAX_VH, 400, "not HEIGHT_THRESHOLD");
+  assert.ok(!/(WIDTH|HEIGHT)_THRESHOLD/.test(
+    code.slice(code.indexOf("function applyOverride"))),
+    "applyOverride must never reach for a detection threshold as a size");
 });


### PR DESCRIPTION
## The defect

`applyOverride()` removed Discord's 400×300 cap and left the media **unbounded by two independent routes**:

| route | mechanism |
|---|---|
| **vertical** | `max-height: none` on the element. Unbounded *by construction* — a tall image ran off the bottom of the window on every enlarge, no resize required. |
| **horizontal** | `max-width: 100%`, which resolves against the container whose own `max-width` this same function sets to `none` just above the write site. The effective bound was an ancestor chain that need not be viewport-bounded at all. |

`unclipAncestors()` sets ancestors' `overflow` to `visible`, which is what lets the media *spill* rather than be clipped.

## The fix

`max-width: min(100%, 96vw)` and `max-height: 92vh`, built by concatenation from two exported constants so the number appears exactly once.

**No `resize` listener, deliberately.** The engine re-evaluates `vw`/`vh` on resize itself — nothing to leak, no cached px value to go stale. It is also the only *assertable* form here: `tests/fake_discord_dom.mjs` is a hand-written fake DOM that models **no viewport** (no `innerWidth`/`innerHeight`, no `getBoundingClientRect`, no layout), so `92vh` is directly assertable where `window.innerHeight * 0.92` would not be.

**Both halves of the width rule are load-bearing.** `100%` keeps media inside Discord's message column, which is far narrower than the window; `96vw` keeps it inside the window when the column is not. Dropping either is a bug, in opposite directions — pinned separately.

**Under 100 on purpose.** `vw` includes the vertical scrollbar gutter. Measured in Brave/Chromium 144, headless over CDP, 1000px window with a scrolling document: `innerWidth` 1000 vs `documentElement.clientWidth` **985** — a 15px gutter. A `100vw` box rendered 1000.00px and pushed `scrollWidth` past `clientWidth`, i.e. grew a *horizontal* scrollbar; `96vw` rendered 960.00px and did not. A test named for the trap fails if anyone rounds it up.

**`vh`, not `dvh`** — a commented decision, not an omission. `dvh` tracks a retracting mobile toolbar and would relayout mid-scroll; identical on desktop Brave, the only place this runs.

**Constant naming.** `ENLARGED_MAX_V{W,H}` are deliberately *not* `WIDTH_THRESHOLD`/`HEIGHT_THRESHOLD`. Those are px numbers `findContainer` **reads** off an ancestor to *recognise* Discord's cap; these are viewport units this code **writes**. Same shape, opposite direction — a test pins that `applyOverride` never reaches for a detection threshold as a size.

## Container vs element — element only

The container keeps `max-width/max-height: none; width/height: auto` and gets **no** cap of its own. With `auto` sizing it tracks its content, so bounding the media bounds the wrapper.

**Measured, not reasoned:** the exact four-declaration set around a 92vh-capped 200×2000 image gave wrapper **592.80px** against image **588.80px** — a 4px inline baseline gap, not an open box — inside a 640px viewport. Capping the container too would be redundant at best, and at worst re-imposes a constraint on Discord's own layout box that the uncapping just removed.

## Accepted tradeoff

🔴 Enlarge now does **less** for portrait media: a tall image is capped to 92vh and letterboxed rather than rendering full height and running off screen. `object-fit: contain` was already set and the ratio is preserved (the 200×2000 image measured 58.88 × 588.80). This is the operator's explicit decision, documented in the README.

## Test matrix — red at base, green at HEAD

| tree | sha | result |
|---|---|---|
| base | `2882d2c743069a28a2b9b58119bab97c2bb392fa` | 143 tests, 132 pass, **11 FAIL** |
| HEAD | `e77cbcbd` | 143 tests, **143 pass**, 0 fail |

All 11 failed at base with **their own** assertion, not a neighbour's. 9 are the new guards; 2 are pre-existing tests that pinned the old `100%`/`none` values, updated to read the exported constants rather than new hardcoded literals.

Coverage: both axes pinned separately · the width rule's `100%` half pinned independently of its `96vw` half · the cap surviving `unclipAncestors()` · the undo path restoring the exact prior `overflow` (value **and** priority, in both spellings) with no cap leaking onto an ancestor · idempotence proven by **poisoning** the declaration first so a missing early-return is observable rather than merely harmless · a **reachable** negative guard (an avatar on the same CDN, rejected only by the path prefix, with a positive control proving the harness can see a cap at all) · the `100vw` trap · constants pinned two-way, behind a validated comment-stripper and a positive control.

## Mutation sweep — 14 mutants

Each edit verified to have landed; a no-mutation **control run** confirming the harness can report GREEN; source restored by copy and **checksum-verified** after every run.

- **13 KILLED by their own expected assertion.**
- 1 (hardcoding the literal at the write site) died on an *earlier* assertion in the same test — the no-second-literal scanner saw `96vw` first — which left the structural "writes the constant" guard **unreachable and therefore unproven**. Closed with two behaviour-preserving mutants that inline the *expression* instead of the literal: byte-identical output, no literal for the scanner to find, so only the structural guard can see them. Both KILLED by it.

## Gate — base `2882d2c743069a28a2b9b58119bab97c2bb392fa`

Run on the **final committed tree**, both sandbox tiers **one at a time** (never concurrently):

| tier | command | result |
|---|---|---|
| dev-host node | `node --test 'scripts/discord-embed-ext/tests/*.test.mjs'` | 143/143 pass |
| sandbox nodetests | `nix build .#checks.x86_64-linux.nodetests` | `RESULT: PASS (exit=0)` — discord-embed-ext 143/143 (floor 128); TOTAL 1458 pass / 0 fail across 5 suites |
| sandbox pytests | `nix build .#checks.x86_64-linux.pytests` | rc=0 |

The nodetests derivation hash for this tree (`r8l8n530…`) differs from the earlier run's (`rpc2nd0x…`), so its log is genuinely this tree's and not a stale re-read; the log contains the new test names, so the tier really ran them. `dl-router`'s 537 tests also pass — its `source_hygiene.test.mjs` reads only `scripts/dl-router/extension`, so it cannot reach this extension's emoji.

## ⚠️ Not verified in the live browser

The rendering measurements above come from **headless Brave/Chromium 144 driven over CDP against a synthetic page carrying the exact declaration set** — *not* from the extension loaded in the operator's Brave against real Discord. The fake-DOM tests pin declarations only and observe no layout. manifest `0.3.0` → `0.3.1` so the reload can be confirmed; nothing in the repo asserted `0.3.0` (`embed_enlarge.test.mjs:305` reads the manifest but asserts only `matches`, `permissions`, `host_permissions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BePLrAzQrg983BX2FSdEjR
