### PR TITLE
docs(browser-bridge): civitai.com — mid-rollout reads need buildId, or a negative is worthless

### DIFF
--- a/scripts/browser-bridge/reference/sites/civitai.com.md
+++ b/scripts/browser-bridge/reference/sites/civitai.com.md
@@ -4,7 +4,8 @@
 about to act on civitai.com **as a particular user** · you need to know WHICH
 account a Brave profile holds · a `/apps` read looks empty, stale, or shows
 entries that 404 · you are about to conclude civitai "leaked scope" or "is
-broken" from a browser read.
+broken" from a browser read · you are checking whether a change that shipped in
+the last hour is live (read `buildId` — a negative read mid-rollout is worthless).
 
 Core: `~/workspace/devrc/scripts/browser-bridge/SKILL.md`.
 Mechanism files stay authoritative for mechanism: throttling and `wake` →
@@ -179,6 +180,51 @@ Cards arrive via tRPC, and a hidden tab is throttled (mechanism:
 Use `document.body.innerText.length` as a **sanity floor** — about **221 chars**
 means the page shell rendered and the content did **not**. Assert the floor;
 never read an empty rail as "this account has no apps".
+
+## 🔴 Verifying a just-shipped change: read `buildId`, or a NEGATIVE read is worthless
+
+**Load this before concluding a newly-released feature "isn't live yet".**
+
+dp-prod rolls with `maxUnavailable: 0` and warmup-gated readiness, so for
+**minutes to tens of minutes** after a promotion the SSR pool serves BOTH images
+at once. Measured 2026-09-04: 159 → 35 pods still on the old image over the ~12
+min following promotion, and still not drained when the check ended.
+
+That window has an asymmetry which is easy to miss:
+
+- a **positive** read (the new behaviour is present) is conclusive the instant it
+  appears — only the new code can produce it;
+- a **negative** is NOT. *"The feature is correctly off for this input"* and
+  *"this request hit a still-serving old pod"* explain it equally well, and
+  nothing on the page distinguishes them.
+
+Measured harm: `/apps/run/sensei` returned a bare iframe `src` **twice** before
+returning the init fragment on the third try. Either of the first two, reported,
+is a false regression against a feature that was already working.
+
+**The discriminator is one field, read in the SAME expression as your
+measurement** — `window.__NEXT_DATA__.buildId`. Two different values across reads
+IS the mixed fleet, observed rather than inferred:
+
+```bash
+BB=~/workspace/devrc/scripts/browser-bridge/browser
+$BB --instance work --tab "$TAB" js '(function(){var f=document.querySelector("iframe");var s=f?f.getAttribute("src"):null;return JSON.stringify({build:(window.__NEXT_DATA__||{}).buildId,frag:s&&s.indexOf("civitai-block=v1")>-1,src:s})})()'
+```
+
+An absence carrying the **new** buildId is a fact about the feature; one carrying
+the **old** buildId is a fact about pod scheduling. Retry until the buildId is the
+new one, rather than waiting out the whole drain — that is what let three negative
+controls close while the roll was still less than half done.
+
+🔴 **And validate the instrument before believing any negative: find an input
+that is ALREADY live on the old image and assert your read sees it there.** For
+the App Blocks init fragment that was `app-requests` — allowlisted a release
+earlier, so it carries the fragment on *both* images, which proves the read
+technique works independently of the rollout under test. Without such a control,
+*"I saw nothing"* is indistinguishable from *"my selector was wrong"*.
+
+Generalises past App Blocks: it applies to any civitai.com read taken to confirm
+a change that shipped in the last hour.
 
 ## Selectors on civitai
 


### PR DESCRIPTION
## What

Adds one section to the civitai.com browser site-notes: **verifying a change that shipped in the last hour needs `window.__NEXT_DATA__.buildId`, or a negative read is worthless.**

## Why

dp-prod rolls with `maxUnavailable: 0` and warmup-gated readiness, so the SSR pool serves **both** images for minutes to tens of minutes after a promotion. That creates an asymmetry it is easy to walk into:

- a **positive** read is conclusive the instant it appears — only the new code can produce the new behaviour;
- a **negative** is not. *"The feature is correctly off for this input"* and *"this request hit a still-serving old pod"* explain it equally well, and nothing on the page distinguishes them.

## Measured

Verifying the App Blocks init fragment on 2026-09-04 (talos-infra rank 12):

- `/apps/run/sensei` returned a bare iframe `src` **twice** before returning the fragment on the third try. Either of the first two, reported, would have been a false regression against a feature that was already working.
- 159 → 35 pods still on the old image over the ~12 min following promotion, still not drained when the check ended.
- The two buildIds observed in the same session: old `Ajz92IGm40itKNukqHyKx`, new `sJvycp0L-dU0vJv3qu-x0`.

## The two techniques recorded

1. **Read `buildId` in the SAME expression as the measurement.** An absence carrying the *new* buildId is a fact about the feature; one carrying the *old* buildId is a fact about pod scheduling. This let three negative controls close while the roll was still less than half done, instead of waiting out the drain.
2. **Validate the instrument with an input already live on the old image.** Here that was `app-requests` (allowlisted a release earlier), which carries the fragment on *both* images — proving the read technique works independently of the rollout under test. Without such a control, "I saw nothing" is indistinguishable from "my selector was wrong".

## Scope

Docs-only — no change to `browser-bridge` behaviour. The technique itself was exercised against real Brave during the session that produced it. The header's "Load this when" list is updated so the section is reachable rather than only findable by scrolling.
