### PR TITLE
fix(browser-agent): don't warm opencode before argv validation; stub the two argv tests

### DIFF
--- a/scripts/browser-bridge/browser-agent
+++ b/scripts/browser-bridge/browser-agent
@@ -348,22 +348,6 @@ OCJSON
   return 1
 }
 
-_oc_ver="$(oc_warm_version)"
-if oc_is_warm "$_oc_ver" || oc_bootstrap "$_oc_ver"; then
-  OC_ISOLATED=1
-else
-  echo "browser-agent: WARNING: could not warm the isolated opencode config dir '$OC_CONFIG_DIR' (opencode $_oc_ver, timeout ${OC_WARM_TIMEOUT}s). Falling back to the GLOBAL opencode config — this run works but costs ~7.7k extra input tokens PER REQUEST (x\$STEPS) for an AGENTS.md this agent cannot act on. Fix: make '$OC_CONFIG_DIR' writable and re-run ONCE with network available (the warm step needs to npm-install @opencode-ai/plugin into it)." >&2
-fi
-
-# Fail loud if an instruction file ever appears here — that would silently
-# reintroduce the whole cost this isolation exists to remove.
-for _stray in "$OC_CONFIG_DIR/AGENTS.md" "$OC_CONFIG_DIR/CLAUDE.md"; do
-  [ -e "$_stray" ] && die "unexpected instruction file at '$_stray' — the isolated opencode config dir must stay free of AGENTS.md/CLAUDE.md (that is the entire point; see the comment above). Remove it."
-done
-
-if [ "$OC_ISOLATED" = 1 ]; then
-  export OPENCODE_CONFIG_DIR="$OC_CONFIG_DIR"
-fi
 
 # Emit a compact schema result on stdout and exit (0 for ok/partial, 1 for
 # blocked). NEVER prints raw page content — only the structured schema.
@@ -428,6 +412,42 @@ case "$TIMEOUT" in (*[!0-9]*|"") die "--timeout must be a positive integer of se
 [ -r "$TOOL_JS" ] || die "custom tool not found: $TOOL_JS"
 [ -r "$TOOL_IMPL" ] || die "custom tool impl not found: $TOOL_IMPL"
 [ -r "$PARSER" ] || die "parser not found: $PARSER"
+
+# --- opencode isolation bootstrap -------------------------------------------- #
+# 🔴 DELIBERATELY BELOW ARGV VALIDATION. This warms an isolated opencode config
+# dir by npm-installing @opencode-ai/plugin, which needs the NETWORK. It used to
+# run at script load, ABOVE the `--dry-run`/goal parsing, so EVERY invocation paid
+# it -- including ones that die two steps later at `a goal is required`, having
+# never used the dir.
+#
+# That is not just waste, it broke CI: the devrc-pytests nix build sandbox has NO
+# network, so the warm stalled to OC_WARM_TIMEOUT (90s) + OC_LOCK_BUDGET (+30s)
+# and the browser-bridge tests that invoke `agent` blew their 300s budget.
+# Measured 2026-09-04 under `unshare -rn`: 287.68s against a 300s ceiling, which
+# is why it failed intermittently and never reproduced for anyone with network.
+#
+# Moving it here changes NO behaviour for a run that proceeds -- every path that
+# reaches opencode still passes through this -- it only stops runs that are about
+# to `die` on their arguments from doing network I/O first. The `command -v
+# "$OPENCODE_BIN"` preflight noted above still runs BEFORE this, so the ordering
+# constraint it documents (preflight before the bootstrap can rm -rf the cache)
+# is preserved.
+_oc_ver="$(oc_warm_version)"
+if oc_is_warm "$_oc_ver" || oc_bootstrap "$_oc_ver"; then
+  OC_ISOLATED=1
+else
+  echo "browser-agent: WARNING: could not warm the isolated opencode config dir '$OC_CONFIG_DIR' (opencode $_oc_ver, timeout ${OC_WARM_TIMEOUT}s). Falling back to the GLOBAL opencode config — this run works but costs ~7.7k extra input tokens PER REQUEST (x\$STEPS) for an AGENTS.md this agent cannot act on. Fix: make '$OC_CONFIG_DIR' writable and re-run ONCE with network available (the warm step needs to npm-install @opencode-ai/plugin into it)." >&2
+fi
+
+# Fail loud if an instruction file ever appears here — that would silently
+# reintroduce the whole cost this isolation exists to remove.
+for _stray in "$OC_CONFIG_DIR/AGENTS.md" "$OC_CONFIG_DIR/CLAUDE.md"; do
+  [ -e "$_stray" ] && die "unexpected instruction file at '$_stray' — the isolated opencode config dir must stay free of AGENTS.md/CLAUDE.md (that is the entire point; see the comment above). Remove it."
+done
+
+if [ "$OC_ISOLATED" = 1 ]; then
+  export OPENCODE_CONFIG_DIR="$OC_CONFIG_DIR"
+fi
 
 # (The `command -v "$OPENCODE_BIN"` preflight that used to live here has been
 # HOISTED to just under `die()`, above the config-dir bootstrap — see the 🔴

--- a/scripts/browser-bridge/tests/test_browser_tab_ref.py
+++ b/scripts/browser-bridge/tests/test_browser_tab_ref.py
@@ -497,23 +497,55 @@ def test_POSITIVE_CONTROL_the_missing_goal_error_is_producible(bridge):
         f"assertions below are vacuous. stderr was: {r.stderr!r}")
 
 
-def test_the_free_text_list_covers_agent_too(bridge):
+def test_the_free_text_list_covers_agent_too(bridge, tmp_path):
     """A TRAILING bw:// is a GOAL for `agent`, not a route.
 
     Dropping `agent` from REF_FREE_TEXT_SUBCOMMANDS SURVIVED an audit's mutation
-    because nothing exercised it. The discriminator is deterministic and needs no
-    backend: with `agent` on the list the reference survives as the goal, so
-    `browser-agent` gets one; with `agent` dropped, the token is stripped out as
-    routing and the agent is left with NO goal at all — which it refuses by name,
-    before any network work.
+    because nothing exercised it. With `agent` on the list the reference survives
+    as the goal and reaches browser-agent; with `agent` dropped, the token is
+    stripped out as routing and the agent is handed NO goal at all.
+
+    🔴 Driven against a STUB browser-agent that echoes its argv, and that is a
+    correctness change as well as a speed one.
+
+    It used to assert the ABSENCE of two error strings from the REAL
+    browser-agent, which meant a unit test of argv routing spun up an entire
+    opencode agent session to find out. That cost ~10s with network and, in the
+    devrc-pytests nix sandbox which has NONE, stalled on the config-dir warm hard
+    enough to blow the 300s budget — measured 287.68s under `unshare -rn`, the
+    thin margin being why it failed intermittently and never reproduced locally.
+    (browser-agent no longer warms before argv validation, which fixes the
+    no-goal case above; this test passes a goal, so only a stub avoids the agent.)
+
+    Asserting the goal ARRIVED is also strictly stronger than asserting two
+    errors did not appear: an absence pair passes if the wording changes, if the
+    agent dies earlier for an unrelated reason, or if the stub never runs. The
+    mutation this exists to catch — `agent` off REF_FREE_TEXT_SUBCOMMANDS — still
+    fails it, because the reference would then never reach argv at all.
+
+    The real error strings stay covered by the positive control above, which runs
+    the REAL browser-agent and is cheap because it dies at goal validation.
     """
-    r = bridge.run("agent", "--dry-run", CANONICAL)
-    assert "a goal is required" not in r.stderr, (
-        "the trailing reference was consumed as a route, leaving no goal: "
-        + r.stderr)
-    assert "agent cannot honour" not in r.stderr, (
-        "a TRAILING reference must be text for `agent`, not a refused route: "
-        + r.stderr)
+    stub_dir = tmp_path / "stub-free-text"
+    stub_dir.mkdir()
+    (stub_dir / "browser").write_text(CLI.read_text(encoding="utf-8"),
+                                      encoding="utf-8")
+    # write_exec owns the shebang — see the note at the BB_* stubs below; a
+    # hand-written `#!/usr/bin/env bash` is ENOENT in the nix build sandbox.
+    mockbin.write_exec(stub_dir / "browser-agent",
+                       'printf "ARGV=[%s]\\n" "$*"\n')
+
+    r = subprocess.run(
+        ["bash", str(stub_dir / "browser"), "agent", "--dry-run", CANONICAL],
+        env=bridge.env_for_stub(),
+        capture_output=True, text=True, timeout=CLI_TIMEOUT_S)
+
+    assert "ARGV=[" in r.stdout, (
+        f"the stub agent never ran, so this test proves nothing: "
+        f"{r.stdout!r} / {r.stderr!r}")
+    assert CANONICAL in r.stdout, (
+        "the trailing reference did not survive as the goal — it was consumed "
+        f"as routing, so browser-agent was handed none. stdout: {r.stdout!r}")
 
 
 # --------------------------------------------------------------------------- #
@@ -648,7 +680,7 @@ def test_agent_refuses_a_tab_from_ANY_source(bridge, argv, env, source):
     assert bridge.bodies == [], f"nothing may be dispatched: {bridge.bodies}"
 
 
-def test_agent_without_any_tab_is_untouched(bridge):
+def test_agent_without_any_tab_is_untouched(bridge, tmp_path):
     """INVARIANT GUARD: the refusal is scoped to a ROUTING VARIABLE, not to `agent`.
 
     A guard widened onto the subcommand rather than the state would break the
@@ -659,10 +691,34 @@ def test_agent_without_any_tab_is_untouched(bridge):
     This replaces a near-duplicate (`test_agent_still_works_with_an_explicit_
     instance`) that had identical input and the same two assertions, differing
     only in its failure text.
+
+    Driven against a STUB browser-agent, matching the routing-refusal tests
+    directly below, which is where this case belongs anyway. It previously ran the
+    REAL agent — a full opencode session — purely to observe that two error
+    strings were absent: 10.5s with network, and in the devrc-pytests nix sandbox
+    (no network) a 90s config-warm stall plus the global-config fallback. Reaching
+    the stub at all is the positive statement of the same invariant: if the guard
+    widened onto the subcommand, the CLI would refuse before exec and `ARGV=[`
+    would never appear.
     """
-    r = bridge.run("--instance", "main", "agent", "--dry-run", "do a thing")
-    assert "agent cannot honour" not in r.stderr, r.stderr
-    assert "a goal is required" not in r.stderr, r.stderr
+    stub_dir = tmp_path / "stub-untouched"
+    stub_dir.mkdir()
+    (stub_dir / "browser").write_text(CLI.read_text(encoding="utf-8"),
+                                      encoding="utf-8")
+    mockbin.write_exec(stub_dir / "browser-agent",
+                       'printf "ARGV=[%s]\\n" "$*"\n')
+
+    r = subprocess.run(
+        ["bash", str(stub_dir / "browser"), "--instance", "main",
+         "agent", "--dry-run", "do a thing"],
+        env=bridge.env_for_stub(),
+        capture_output=True, text=True, timeout=CLI_TIMEOUT_S)
+
+    assert "ARGV=[" in r.stdout, (
+        "the agent was refused before exec, so a legitimate `--instance main "
+        f"agent` no longer works: {r.stdout!r} / {r.stderr!r}")
+    assert "do a thing" in r.stdout, (
+        f"the goal did not reach browser-agent. stdout: {r.stdout!r}")
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Unblocks `tekton/devrc-pytests`, which has been red on **4 of the last 6 PRs** on a repo with `enforce_admins`.

## Root cause

`browser-agent` warms an isolated opencode config dir by npm-installing `@opencode-ai/plugin`. That block ran at **script load** — above argv parsing, and far above `[ -n "$GOAL" ] || die "a goal is required"`. So every invocation paid a network round trip, **including ones that die two steps later having never used the dir**.

`devrc-pytests` runs in a nix build sandbox with **no network**, where the warm stalls to `OC_WARM_TIMEOUT` (90s) + `OC_LOCK_BUDGET` (+30s).

Reproduced under `unshare -rn`: **287.68s against a 300s ceiling.** That thin margin is why it failed intermittently and never reproduced for anyone running the suite with network. CI reported `TimeoutExpired … returncode -9` plus the warm warning on exactly the two tests that invoke `agent` — matching the verdict’s `failed=2`.

## Two changes

**1. Move the warm below argv validation.** No behaviour change for a run that proceeds — every path reaching opencode still passes through it. It only stops runs that are about to `die` on their arguments from doing network I/O first. The `command -v "$OPENCODE_BIN"` preflight still runs before the bootstrap, preserving the ordering constraint documented there.

**2. Drive both agent tests against the stub `browser-agent`** already used by their neighbours. `--dry-run` does **not** avoid opencode — `BROWSER_AGENT_DRY_RUN` is passed as an env var into `setsid "$OPENCODE_BIN"`, so the agent genuinely runs and the flag only stops it *acting*. A unit test of argv routing was launching an LLM agent to find out whether a token survived.

This is a **correctness** improvement too. Both tests asserted the *absence* of error strings; both now assert **positively** that the goal reached `browser-agent`. An absence pair passes if the wording changes, if the agent dies earlier for an unrelated reason, or if the stub never runs. The real error strings stay covered by `test_..._is_reachable`, which still runs the real `browser-agent` and is now cheap because it dies at goal validation before the warm.

## Rejected first attempt (recorded so it is not retried)

Setting `BROWSER_AGENT_WARM_TIMEOUT=1` in the fixture. Measured — it made the tests **3.5× slower** with network (22.14s → 77.81s), because killing the warm forces the expensive global-config fallback that CI already pays anyway. It traded one stall for another.

## Verification

Both tests were **mutation-tested**, not merely observed green:

| mutation | result |
|---|---|
| drop `agent` from `REF_FREE_TEXT_SUBCOMMANDS` | first test **FAILS** |
| widen the tab guard onto the subcommand | second test **FAILS** |

Both restored clean afterwards.

| measurement | before | after |
|---|---|---|
| no-network control (same harness) | 287.68s | **1.05s** |
| `test_browser_tab_ref.py` | 74–80s | **27.60s**, 54 passed |
| full `scripts/browser-bridge/tests/` | — | **890 passed** |

Also verified directly: `browser-agent --dry-run` with no goal now exits 2 with `a goal is required`, emits **no** warm warning, and creates **no** config dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aHWYAKJvN3ewGjJ2eKiN9