### PR TITLE
fix(clawgate-guard): a stale file at the --body-file path shadowed the heredoc about to overwrite it

### DIFF
--- a/scripts/claude-hooks/clawgate-task-interview-guard.py
+++ b/scripts/claude-hooks/clawgate-task-interview-guard.py
@@ -240,6 +240,39 @@ def heredoc_bodies(text):
     A body with no terminator line runs to end-of-text, which is bash's own
     behaviour and the direction that keeps the text visible.
     """
+    return [body for body, _ in _heredoc_spans(text)]
+
+
+# `cat > /tmp/body.md <<'EOF'` — the redirect sits on the operator's own line,
+# BEFORE the `<<`. Anchored at the end because that prefix is all we are handed.
+_REDIRECT_TARGET = re.compile(r">>?\s*(?P<path>[^\s;&|<>]+)\s*$")
+
+
+def heredoc_bodies_writing(text, path):
+    """Bodies of the heredocs on `text` whose own line redirects to `path`.
+
+    🔴 Pins a RELATIONSHIP — heredoc-writes-this-file — not either side alone.
+    `heredoc_bodies` answers "is there a body anywhere", which cannot distinguish
+    a heredoc writing the file under discussion from one writing a DIFFERENT file
+    on the same line. Only the former licenses ignoring what is on disk.
+    """
+    want = os.path.expanduser(path).strip("'\"")
+    out = []
+    for body, prefix in _heredoc_spans(text):
+        m = _REDIRECT_TARGET.search(prefix)
+        if not m:
+            continue
+        if os.path.expanduser(m.group("path").strip("'\"")) == want:
+            out.append(body)
+    return out
+
+
+def _heredoc_spans(text):
+    """[(body, the operator's own line up to the `<<`)] — the single parser.
+
+    Split out so the redirect-target reader above and `heredoc_bodies` cannot
+    drift apart: one rule, one place.
+    """
     bodies, n = [], len(text)
     # `cmd <<A <<B` opens TWO heredocs on ONE line, and bash reads their bodies
     # back to back in the order the operators appear — B's body starts where A's
@@ -285,7 +318,8 @@ def heredoc_bodies(text):
             i = nxt
         consumed.append((start, i))
         cursor = i
-        bodies.append("\n".join(lines))
+        line_start = text.rfind("\n", 0, m.start()) + 1
+        bodies.append(("\n".join(lines), text[line_start:m.start()]))
     return bodies
 
 
@@ -527,6 +561,19 @@ def _resolve_file(value, text):
         return (inner, None) if inner else ([], UNRESOLVED_STDIN)
     if opaque_path(value):
         return [], UNRESOLVED_OPAQUE
+    # 🔴 A heredoc on this same command line that REDIRECTS TO THIS PATH is about
+    # to overwrite it, and PreToolUse runs BEFORE the command — so the bytes on
+    # disk right now are the stale previous occupant, and the heredoc is the body
+    # the task will actually carry. Reading the file whenever the read happens to
+    # succeed made the verdict a property of the HOST rather than of the command:
+    # an unrelated 21 KB leftover at the shared path `/tmp/body.md` made this gate
+    # DENY a command whose heredoc carried perfectly good criteria.
+    # Replacing rather than aggregating is what keeps it correct in BOTH
+    # directions — a stale file that DOES have the heading must not rescue a
+    # heredoc that lacks it, which is the false ALLOW this gate exists to prevent.
+    over = heredoc_bodies_writing(text, value)
+    if over:
+        return over, None
     try:
         return [_read_body_file(value)], None
     except Exception:

--- a/scripts/claude-hooks/tests/test_clawgate_task_interview_guard.py
+++ b/scripts/claude-hooks/tests/test_clawgate_task_interview_guard.py
@@ -435,6 +435,43 @@ def test_a_body_file_written_by_a_heredoc_WITHOUT_criteria_is_denied():
     assert denied_missing(cmd)
 
 
+def _heredoc_over(path, body):
+    return ("cat > %s <<'EOF'\n%s\nEOF\n"
+            "clawgatectl task create --title T --body-file %s" % (path, body, path))
+
+
+def test_a_STALE_file_at_the_path_cannot_HIDE_the_heredoc_overwriting_it(tmp_path):
+    """REGRESSION. PreToolUse runs BEFORE the command, so a file that exists at the
+    `--body-file` path right now is the previous occupant the heredoc is about to
+    destroy. Reading it instead of the heredoc made the verdict a property of the
+    HOST: an unrelated leftover at the shared path `/tmp/body.md` denied a command
+    whose heredoc carried perfectly good criteria."""
+    p = tmp_path / "body.md"
+    p.write_text(NO_AC)
+    assert allowed(_heredoc_over(p, AC))
+
+
+def test_a_STALE_file_WITH_criteria_cannot_RESCUE_a_heredoc_that_lacks_them(tmp_path):
+    """The same relationship in the direction that matters more: the task will carry
+    the heredoc, so a heading found only in the doomed on-disk copy is a false ALLOW
+    — exactly what this gate exists to prevent."""
+    p = tmp_path / "body.md"
+    p.write_text(AC)
+    assert denied_missing(_heredoc_over(p, NO_AC))
+
+
+def test_a_heredoc_writing_a_DIFFERENT_file_does_not_speak_for_this_one(tmp_path):
+    """The guard keys on the relationship, not on 'a heredoc exists somewhere'. The
+    body-file here is its own readable file with no criteria, and the heredoc on the
+    line writes somewhere else entirely."""
+    body = tmp_path / "body.md"
+    body.write_text(NO_AC)
+    other = tmp_path / "notes.md"
+    cmd = ("cat > %s <<'EOF'\n%s\nEOF\n"
+           "clawgatectl task create --title T --body-file %s" % (other, AC, body))
+    assert denied_missing(cmd)
+
+
 # =========================================================================== #
 # 4. BODY SOURCE: heredoc
 # =========================================================================== #


### PR DESCRIPTION
`/tmp/body.md` on the workbench — 21 KB, written by an unrelated session on 2026-09-03 — was making this gate **deny commands that carried perfectly good acceptance criteria**, and making one of its own tests fail. The verdict was a property of the host, not of the command.

## The bug

PreToolUse runs **before** the command. So when a heredoc writes the body file and the create call names that same path, the bytes on disk are the *previous occupant the heredoc is about to destroy*. `_resolve_file` consulted the heredoc **only in its `except` branch** — so whenever the read succeeded, the stale file won and the body the operator actually typed was never seen.

Both comments already described the intended behaviour:

- `_resolve_file`: *"The file may be about to be written by a heredoc earlier on the same command line, which this gate CAN read."*
- `body_candidates`: *"a command may legitimately name a `--body-file` that a heredoc on the same line is about to write"*

The implementation acted on that only on failure — a docstring naming a relationship while the body inspects one side.

Same command, only the path varied:

```
allowed=False  /tmp/body.md                      <- exists on this host
allowed=True   /tmp/body-does-not-exist-9f3a.md  <- a clean host
```

## Replace, not aggregate

Adding the heredoc as an *extra* candidate fixes the false DENY and opens a false ALLOW in the other direction: a stale file that **does** carry the heading would rescue a heredoc that lacks it — and the task ends up carrying the heredoc. So a heredoc redirecting to **this** path wins outright and the on-disk copy is not read at all.

`heredoc_bodies_writing` pins the **relationship** (heredoc-writes-this-file), not either side: "a heredoc exists somewhere on the line" cannot tell a heredoc writing this file from one writing a different file, and only the former licenses ignoring the disk. Both readers share one parser (`_heredoc_spans`) so they cannot drift apart.

## Tests

| test | before | after |
|---|---|---|
| stale file *without* criteria must not **hide** a heredoc with them | RED | green |
| stale file *with* criteria must not **rescue** a heredoc without them | RED | green |
| a heredoc writing a **different** file does not speak for this one | green | green |

The first two were watched red at `origin/main` 46264622 and are genuine regression coverage. **The third passed before the change, so it is an invariant guard, not regression coverage** — labelled, not counted.

All three use `tmp_path`; no test in this file now depends on what sits at a shared `/tmp` path.

## Verification

Reproduced the original symptom: `test_a_body_file_written_by_a_heredoc_on_the_same_line_is_read` now passes **with the poisoning `/tmp/body.md` still on disk, unmodified** — I did not delete another session's file to make a test go green. Full guard suite 313 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpLuEa493HRNfePka1E65z
