### PR TITLE
fix(seed): refuse to overwrite a pod entry whose bytes differ — the cutover inverted the authority

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -118,7 +118,7 @@
       gateTools = [
         gatePyEnv pkgs.bash pkgs.ripgrep pkgs.git pkgs.util-linux pkgs.jq
         pkgs.gnugrep pkgs.curl pkgs.nodejs pkgs.nix pkgs.opencode pkgs.logrotate
-        pkgs.rsync pkgs.zsh pkgs.age
+        pkgs.rsync pkgs.zsh pkgs.age pkgs.dash
       ];
     in
     {

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -479,10 +479,24 @@ cd "$ROOT" || { echo "run-tests: cannot cd to ROOT=$ROOT" >&2; exit 3; }
 #           cannot occur in. Both hosts run zsh as the login shell, and
 #           flake.nix's `gateTools` carries it for the sandbox.
 #
+# dash:     scripts/tests/test_subsystem_store_api.py
+#           (TestTheSeedProbeAnswersSurviveTheRealPodShell, 5 tests). The SAME
+#           shape as zsh above, one layer out. `seed.sh`'s pod probe runs in the
+#           store-api pod, whose `/bin/sh` is dash (`Dockerfile`:
+#           `FROM python:3.12-slim` -> Debian); dash's `echo` INTERPRETS
+#           backslash escapes and bash's does not. Every test in that file drives
+#           a fake `kubectl` that runs the probe under THIS host's shell, so the
+#           whole suite is structurally blind to the difference — and the
+#           difference is a SILENT one (the two sides' join keys diverge and a
+#           pod entry that DIFFERS is overwritten as though it were new).
+#           Measured 2026-09-05: without dash on PATH all 5 skipped, which is
+#           the "green having measured the one shell the defect cannot occur in"
+#           failure the zsh note describes. They FAIL rather than skip now.
+#
 # 🔴 `python` is listed as well as `python3` because THIS SCRIPT invokes
 # `python -m pytest`, not `python3`. Asserting only `python3` checked a binary
 # the runner never calls.
-REQUIRED_TOOLS=(bash curl node rg git awk jq grep setsid python python3 nix-instantiate opencode logrotate rsync zsh)
+REQUIRED_TOOLS=(bash curl node rg git awk jq grep setsid python python3 nix-instantiate opencode logrotate rsync zsh dash)
 missing_tools=()
 for t in "${REQUIRED_TOOLS[@]}"; do
   command -v "$t" >/dev/null 2>&1 || missing_tools+=("$t")

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -1,10 +1,22 @@
 #!/usr/bin/env bash
 # Seed the cluster store from the LOCAL one. Phase 1 (proposal §4).
 #
-# 🔴 THE LOCAL STORE IS AUTHORITATIVE, AND THIS SCRIPT NEVER WRITES TO IT.
-# `~/.claude/analyze-service-index/` is client-confidential, not re-derivable by
-# re-running recon, and phase 1's whole premise is "local stays authoritative and
-# untouched".
+# 🔴 THE LOCAL STORE IS *NOT* AUTHORITATIVE ANY MORE — THE POD IS. This header
+# said the opposite until 2026-09-04, and the sentence outlived the fact by the
+# whole life of the Cairn cutover, which made the hosted store canonical and
+# froze `~/.claude/analyze-service-index/` to a per-host mirror.
+#
+# What still holds, unchanged: THIS SCRIPT NEVER WRITES TO THE LOCAL STORE. It is
+# client-confidential and not re-derivable by re-running recon, so it is read
+# ONLY, for the reasons enumerated below.
+#
+# What CHANGED is the direction of the risk. The push can no longer be reasoned
+# about as "authoritative source refreshing a derivative": it is a DERIVATIVE
+# overwriting the AUTHORITY, and the extract adds and overwrites but never
+# deletes. That is why the pre-flight before the tar refuses any staged entry
+# whose bytes differ from the pod's — measured 2026-09-02/03, a re-seed would
+# have reverted five pod-newer bullets, two of them `OPEN:` -> `RESOLVED`
+# closures, and reported success.
 #
 # ⚠ This block used to open "THE LOCAL STORE IS THE ONLY COPY … has no
 # off-machine backup". Both halves are now false — daily age-encrypted bundles go
@@ -38,6 +50,7 @@ STORE=""
 STAGE=""
 PUSH=""
 DEST="/data"
+ALLOW_OVERWRITE=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -45,6 +58,7 @@ while [[ $# -gt 0 ]]; do
     --stage) STAGE="${2:?--stage needs a path}"; shift 2 ;;
     --push)  PUSH="${2:?--push needs <namespace>/<deployment>}"; shift 2 ;;
     --dest)  DEST="${2:?--dest needs a path}"; shift 2 ;;
+    --allow-overwrite) ALLOW_OVERWRITE=1; shift ;;
     -h|--help) sed -n '2,26p' "$0"; exit 0 ;;
     *) echo "seed: unknown argument: $1" >&2; exit 2 ;;
   esac
@@ -308,6 +322,79 @@ echo "seed: pushing $STAGE -> $ns/$pod:$DEST"
 # of the archive, and the push would land content with no date on it while
 # reporting OK. It is not `*.md`, so it does not disturb the entry counts the
 # mismatch guard below compares.
+# --- 🔴 REFUSE TO OVERWRITE A POD ENTRY WHOSE BYTES DIFFER ------------------- #
+# THE CUTOVER INVERTED THE AUTHORITY AND THIS SCRIPT WAS NEVER UPDATED. The tar
+# extract below "adds and overwrites but never deletes" — which was safe while
+# the LOCAL store was authoritative, and is silent data loss now that the pod is.
+# A shared entry whose pod copy has moved on (a bullet appended through
+# `cairn append`, an `OPEN:` rewritten `RESOLVED <sha>:`) is replaced by this
+# host's older copy, and the verdict below still prints OK because the NAME
+# landed.
+#
+# MEASURED 2026-09-02/03 on the real store: of 25 bullets present locally but not
+# on the pod, FIVE were the pod being NEWER — including two `OPEN:` -> `RESOLVED`
+# closures carrying ~20 lines of later corrections. A re-seed would have reverted
+# all five and reported success.
+#
+# 🔴 WHY THIS IS A PRE-FLIGHT AND NOT A LOUDER VERDICT. The existing containment
+# check runs AFTER the extract, so by the time it can speak the bytes are gone.
+# The only useful place for this question is before the push.
+#
+# 🔴 WHY IT COMPARES BYTES AND NOT MTIME OR "NEWNESS". We cannot order two copies
+# — a local edit not yet pushed and a pod edit not yet pulled both read as
+# "different". Post-cutover the pod is the authority, so ANY difference means
+# this push would overwrite the authoritative copy with a derivative. That is
+# exactly what must not happen silently, so difference is the right predicate and
+# it needs no clock.
+#
+# 🔴 IT ASKS THE POD ABOUT `$staged_list` AND ADDS NO THIRD `find`. Reusing the
+# one list `_shippable_entries` already wrote keeps this comparison on the SAME
+# population as the verdict below — the symlink case in that function is what
+# happens when two walks are allowed to disagree — and leaves
+# `test_the_two_find_expressions_are_IDENTICAL` pinning exactly two listings.
+# `test -f` on the pod yields the INTERSECTION for free: a staged path the pod
+# does not have is a pure addition and cannot clobber anything.
+_clobber_f="$_seed_tmp/clobber"; : > "$_clobber_f"
+if [[ -s "$staged_list" ]]; then
+  _local_h="$_seed_tmp/local-h"; _remote_h="$_seed_tmp/remote-h"
+  ( cd "$STAGE" && xargs -r sha256sum ) < "$staged_list" \
+    | awk '{print $2" "$1}' | LC_ALL=C sort > "$_local_h"
+  # `test -f … && sha256sum …` per path: absent on the pod ⇒ no line ⇒ not in the
+  # join ⇒ a pure addition. `-r` so an empty list runs nothing.
+  # 🔴 `|| :` IS LOAD-BEARING, NOT DEFENSIVE. `xargs` exits 123 when ANY child
+  # exits non-zero, and a staged path the pod does not have is the ORDINARY case
+  # — the pure addition this whole script exists to perform. Without it the
+  # probe returns 123, `set -euo pipefail` aborts, and seeding a genuinely new
+  # entry dies with exit 123 and an EMPTY stderr. Measured: all four tests in
+  # this class failed that way, including the two that must pass.
+  # `_ {}` passes the path as "$1" rather than interpolating it into the inner
+  # script, so a path is never re-parsed as shell text.
+  kubectl -n "$ns" exec -i "$pod" -- \
+    sh -c "cd '$DEST' && xargs -r -I{} sh -c 'test -f \"\$1\" && sha256sum \"\$1\" || :' _ {}" \
+    < "$staged_list" \
+    | awk '{print $2" "$1}' | LC_ALL=C sort > "$_remote_h"
+  # 🔴 `LC_ALL=C` on the join too, for the reason spelled out at the `comm` below:
+  # GNU join order-checks in the AMBIENT locale, and C-sorted input is "not
+  # sorted" to a join running under en_US.UTF-8 — which is this host.
+  LC_ALL=C join "$_local_h" "$_remote_h" | awk '$2 != $3 {print $1}' > "$_clobber_f"
+fi
+_n_clobber=$(wc -l < "$_clobber_f" | tr -d ' ')
+
+if [[ "$_n_clobber" -gt 0 && "$ALLOW_OVERWRITE" != "1" ]]; then
+  echo "seed: REFUSING — $_n_clobber staged entry file(s) EXIST ON THE POD WITH DIFFERENT BYTES." >&2
+  sed 's/^/  /' "$_clobber_f" >&2
+  echo "seed: the pod is the authority since the Cairn cutover; this push would replace its copy" >&2
+  echo "seed:   with this host's, and the verdict would still say OK because the NAME landed." >&2
+  echo "seed: reconcile first (\`cairn sync\`, then \`cairn put\` the merged bytes), or pass" >&2
+  echo "seed:   --allow-overwrite if you have decided this host's copy should win." >&2
+  echo "seed: NOTHING WAS PUSHED." >&2
+  exit 8
+fi
+if [[ "$_n_clobber" -gt 0 ]]; then
+  echo "seed: WARNING --allow-overwrite given; REPLACING $_n_clobber pod entry file(s) with this host's copy:"
+  sed 's/^/  /' "$_clobber_f"
+fi
+
 members=()
 for d in "$STAGE"/*/; do members+=("$(basename "$d")"); done
 members+=(".seed-stamp")

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -23,9 +23,13 @@
 # per-scope `.git` repositories, one measurably divergent (pod
 # `devrc/.git/refs/heads/trunk` = 68aef530, this host = e2f21cf8). A push that
 # passes this guard still rewinds that ref. Widening the comparison is the real
-# fix; until then the limit is stated rather than left to read as a guarantee — measured 2026-09-02/03, a re-seed would
-# have reverted five pod-newer bullets, two of them `OPEN:` -> `RESOLVED`
-# closures, and reported success.
+# fix; until then the limit is stated rather than left to read as a guarantee
+# this guard does not make.
+#
+# WHAT THE GUARD DOES COVER, measured 2026-09-02/03 on the real store: a re-seed
+# would have reverted five pod-newer BULLETS, two of them `OPEN:` -> `RESOLVED`
+# closures, and reported success. Those live in entry files, which is the
+# population above.
 #
 # ⚠ This block used to open "THE LOCAL STORE IS THE ONLY COPY … has no
 # off-machine backup". Both halves are now false — daily age-encrypted bundles go
@@ -72,7 +76,15 @@ while [[ $# -gt 0 ]]; do
     --push)  PUSH="${2:?--push needs <namespace>/<deployment>}"; shift 2 ;;
     --dest)  DEST="${2:?--dest needs a path}"; shift 2 ;;
     --allow-overwrite) ALLOW_OVERWRITE=1; shift ;;
-    -h|--help) sed -n '2,26p' "$0"; exit 0 ;;
+    -h|--help)
+      # 🔴 PRINT THE WHOLE LEADING COMMENT BLOCK, NOT A LINE RANGE. It was
+      # `sed -n '2,26p'`, and a line range rots the moment the header grows:
+      # this round's additions pushed line 26 into the middle of a clause, so
+      # `--help` ended mid-sentence. And the Usage block has ALWAYS sat BELOW
+      # that window, so `--allow-overwrite` was "documented in Usage" in a place
+      # `--help` could not reach. Stopping at the first non-comment line cannot
+      # drift.
+      awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; exit 0 ;;
     *) echo "seed: unknown argument: $1" >&2; exit 2 ;;
   esac
 done

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -13,8 +13,17 @@
 # What CHANGED is the direction of the risk. The push can no longer be reasoned
 # about as "authoritative source refreshing a derivative": it is a DERIVATIVE
 # overwriting the AUTHORITY, and the extract adds and overwrites but never
-# deletes. That is why the pre-flight before the tar refuses any staged entry
-# whose bytes differ from the pod's — measured 2026-09-02/03, a re-seed would
+# deletes. That is why the pre-flight before the tar refuses any staged ENTRY
+# FILE whose bytes differ from the pod's
+#
+# 🔴 AND THAT IS ~12% OF WHAT THE PUSH OVERWRITES — SAY SO. MEASURED on the live
+# pod 2026-09-04: 1,755 files under /data, of which 211 are the depth-2
+# `<scope>/<entry>.md` this guard compares. The tar members are whole scope
+# DIRECTORIES, so the push also carries every depth-3+ path — including FIFTEEN
+# per-scope `.git` repositories, one measurably divergent (pod
+# `devrc/.git/refs/heads/trunk` = 68aef530, this host = e2f21cf8). A push that
+# passes this guard still rewinds that ref. Widening the comparison is the real
+# fix; until then the limit is stated rather than left to read as a guarantee — measured 2026-09-02/03, a re-seed would
 # have reverted five pod-newer bullets, two of them `OPEN:` -> `RESOLVED`
 # closures, and reported success.
 #
@@ -39,6 +48,10 @@
 # Usage:
 #   seed.sh --store <src> --stage <dir>            # stage only (what tests drive)
 #   seed.sh --store <src> --stage <dir> --push <ns>/<deploy> [--dest /data]
+#   … --allow-overwrite   proceed even when staged entries differ from the pod's
+#                         copy. DELIBERATE override: the pre-flight refuses by
+#                         default because the pod is authoritative post-cutover.
+#                         It still PRINTS what it replaced.
 #
 # The two halves are split on purpose: staging is hermetic and testable, pushing
 # needs a cluster. A green stage says nothing about the push, so the script
@@ -306,7 +319,7 @@ fi
 pod=$(kubectl -n "$ns" get pod -l "app=$deploy" -o jsonpath='{.items[0].metadata.name}')
 [[ -n "$pod" ]] || { echo "seed: no pod for app=$deploy in ns=$ns" >&2; exit 6; }
 
-echo "seed: pushing $STAGE -> $ns/$pod:$DEST"
+echo "seed: preparing push $STAGE -> $ns/$pod:$DEST"
 # 🔴 THE MEMBER LIST IS THE SCOPE DIRECTORIES, NOT `.`, AND THE EXTRACT DROPS
 # OWNER AND MODE. MEASURED, not defensive: `tar -cf - .` puts a `./` member in
 # the archive, and the pod runs as UID 65532 against a PVC root the kubelet
@@ -355,38 +368,84 @@ echo "seed: pushing $STAGE -> $ns/$pod:$DEST"
 # `test -f` on the pod yields the INTERSECTION for free: a staged path the pod
 # does not have is a pure addition and cannot clobber anything.
 _clobber_f="$_seed_tmp/clobber"; : > "$_clobber_f"
+_n_present=0
+_n_answered=0
 if [[ -s "$staged_list" ]]; then
   _local_h="$_seed_tmp/local-h"; _remote_h="$_seed_tmp/remote-h"
-  ( cd "$STAGE" && xargs -r sha256sum ) < "$staged_list" \
+  _probe_raw="$_seed_tmp/probe-raw"
+  # 🔴 `-I{}` ON THE LOCAL SIDE TOO, MATCHING THE REMOTE. Bare `xargs sha256sum`
+  # word-splits and parses quotes: a staged `sc/two words.md` became two missing
+  # arguments (rc 123) and `sc/it's.md` an unmatched quote (rc 1) — both with NO
+  # `seed:` line, the failure shape the `|| :` note below exists to prevent,
+  # reintroduced on the other side. Base handled both at rc 0.
+  ( cd "$STAGE" && xargs -r -I{} sha256sum {} ) < "$staged_list" \
     | awk '{print $2" "$1}' | LC_ALL=C sort > "$_local_h"
-  # `test -f … && sha256sum …` per path: absent on the pod ⇒ no line ⇒ not in the
-  # join ⇒ a pure addition. `-r` so an empty list runs nothing.
-  # 🔴 `|| :` IS LOAD-BEARING, NOT DEFENSIVE. `xargs` exits 123 when ANY child
-  # exits non-zero, and a staged path the pod does not have is the ORDINARY case
-  # — the pure addition this whole script exists to perform. Without it the
-  # probe returns 123, `set -euo pipefail` aborts, and seeding a genuinely new
-  # entry dies with exit 123 and an EMPTY stderr. Measured: all four tests in
-  # this class failed that way, including the two that must pass.
-  # `_ {}` passes the path as "$1" rather than interpolating it into the inner
-  # script, so a path is never re-parsed as shell text.
+  # 🔴 EVERY PATH IS ANSWERED — a hash, ABSENT, or UNREADABLE. The probe used to
+  # emit a line only for files the pod HAS, so "the pod holds none of them" and
+  # "the probe never ran" were the same observation (zero lines, rc 0) and the
+  # guard read both as "nothing differs". MEASURED in review: with a silenced
+  # probe the push destroyed the pod's newer bytes and printed `seed: OK`. It is
+  # REACHABLE: this is the only command whose input reaches the pod over stdin,
+  # and `xargs -r` on a stream that closed early is silence at rc 0 BY DESIGN.
+  #
+  # 🔴 REFUSING ON "0 PRESENT" WAS THE WRONG FIX. A pod holding none of the
+  # staged entries is the ORDINARY first-seed case — measured, that rule failed
+  # 18 legitimate tests. The answerable question is whether the probe SAW the
+  # whole list, so ABSENT is an answer and a MISSING line is the fault.
+  #
+  # 🔴 `|| :` IS LOAD-BEARING: `xargs` exits 123 when any child does, and a path
+  # the pod lacks is ordinary. Dropping it kills 21 tests. ⚠ It also swallows a
+  # read error — hence UNREADABLE, which cannot equal a hex digest, so such an
+  # entry always lands in the clobber set and is refused rather than replaced.
+  # `_ {}` passes the path as "$1" so it is never re-parsed as shell text.
   kubectl -n "$ns" exec -i "$pod" -- \
-    sh -c "cd '$DEST' && xargs -r -I{} sh -c 'test -f \"\$1\" && sha256sum \"\$1\" || :' _ {}" \
+    sh -c "cd '$DEST' && xargs -r -I{} sh -c 'if [ -f \"\$1\" ]; then sha256sum \"\$1\" 2>/dev/null || echo \"UNREADABLE  \$1\"; else echo \"ABSENT  \$1\"; fi' _ {}" \
     < "$staged_list" \
-    | awk '{print $2" "$1}' | LC_ALL=C sort > "$_remote_h"
-  # 🔴 `LC_ALL=C` on the join too, for the reason spelled out at the `comm` below:
-  # GNU join order-checks in the AMBIENT locale, and C-sorted input is "not
-  # sorted" to a join running under en_US.UTF-8 — which is this host.
+    | awk '{print $2" "$1}' | LC_ALL=C sort > "$_probe_raw"
+  _n_answered=$(wc -l < "$_probe_raw" | tr -d ' ')
+  LC_ALL=C grep -v ' ABSENT$' "$_probe_raw" > "$_remote_h" || :
+  _n_present=$(wc -l < "$_remote_h" | tr -d ' ')
+  # 🔴 `LC_ALL=C` on the join too. GNU join order-checks in the AMBIENT locale,
+  # so C-sorted input is "not sorted" to a join under en_US.UTF-8 — this host.
+  # MEASURED: it MISSES the differing pair AND exits 1, which `set -e` turns
+  # into a run with no verdict. Needs an unpairable line plus a README/lowercase
+  # adjacency, which the real store is full of.
   LC_ALL=C join "$_local_h" "$_remote_h" | awk '$2 != $3 {print $1}' > "$_clobber_f"
 fi
 _n_clobber=$(wc -l < "$_clobber_f" | tr -d ' ')
+
+# 🔴 PRINTED ON EVERY PATH, NOT ONLY ON REFUSAL — this file's own silent-zero
+# rule ("a bare 0 from a run that walked nothing reads exactly like a genuinely
+# empty store"), applied to the guard itself.
+echo "seed: PRE-FLIGHT staged=$staged_entries answered=$_n_answered present_on_pod=$_n_present differing=$_n_clobber"
+if [[ "$_n_answered" -ne "$staged_entries" ]]; then
+  echo "seed: PRE-FLIGHT COULD NOT COMPARE — asked the pod about $staged_entries staged entries, got $_n_answered answers." >&2
+  echo "seed:   Every path is answered (a hash, ABSENT, or UNREADABLE), so a SHORT reply means the" >&2
+  echo "seed:   probe did not see the whole list — stdin is piped to the pod, and a stream that" >&2
+  echo "seed:   closes early is silence at rc 0, indistinguishable from 'nothing differs'." >&2
+  echo "seed: NOTHING WAS PUSHED." >&2
+  exit 9
+fi
 
 if [[ "$_n_clobber" -gt 0 && "$ALLOW_OVERWRITE" != "1" ]]; then
   echo "seed: REFUSING — $_n_clobber staged entry file(s) EXIST ON THE POD WITH DIFFERENT BYTES." >&2
   sed 's/^/  /' "$_clobber_f" >&2
   echo "seed: the pod is the authority since the Cairn cutover; this push would replace its copy" >&2
   echo "seed:   with this host's, and the verdict would still say OK because the NAME landed." >&2
-  echo "seed: reconcile first (\`cairn sync\`, then \`cairn put\` the merged bytes), or pass" >&2
-  echo "seed:   --allow-overwrite if you have decided this host's copy should win." >&2
+  # 🔴 THE REMEDY NAMED HERE MUST BE ONE THAT CAN CLEAR THE REFUSAL. This first
+  # read "reconcile first (`cairn sync`, then `cairn put` …)". MEASURED: neither
+  # touches what this guard compares — `cairn sync` refreshes
+  # ~/.cache/subsystem-store, NOT the --store tree, and `cairn put` writes the
+  # POD, moving it FURTHER from the mirror. The mirror is frozen read-only by
+  # cairn-cutover.py P5. A refusal whose prescribed fix cannot work is how
+  # --allow-overwrite becomes the habitual invocation.
+  echo "seed: 🔴 A PUSH IS PROBABLY NO LONGER THE RIGHT VERB FROM THIS HOST. The local tree is a" >&2
+  echo "seed:   FROZEN pre-cutover mirror; the pod has moved on via \`cairn append\`/\`cairn put\`." >&2
+  echo "seed:   No shipped tool refreshes the mirror FROM the pod, so this will not clear itself" >&2
+  echo "seed:   and re-running changes nothing." >&2
+  echo "seed:   To publish specific local content, send it entry-by-entry: \`cairn put\` (replace)" >&2
+  echo "seed:   or \`cairn create\` (new) — those go through the API and cannot silently revert." >&2
+  echo "seed:   --allow-overwrite is for a DELIBERATE decision that this host's staged copy wins." >&2
   echo "seed: NOTHING WAS PUSHED." >&2
   exit 8
 fi

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -378,8 +378,23 @@ if [[ -s "$staged_list" ]]; then
   # arguments (rc 123) and `sc/it's.md` an unmatched quote (rc 1) — both with NO
   # `seed:` line, the failure shape the `|| :` note below exists to prevent,
   # reintroduced on the other side. Base handled both at rc 0.
-  ( cd "$STAGE" && xargs -r -I{} sha256sum {} ) < "$staged_list" \
-    | awk '{print $2" "$1}' | LC_ALL=C sort > "$_local_h"
+  # 🔴 `-d '\n'`, NOT JUST `-I{}`. `-I{}` stops WORD-SPLITTING but leaves
+  # `xargs`'s INPUT QUOTE PARSING on, so a staged `sc/it's.md` still died with
+  # `xargs: unmatched single quote`, rc 1, no `seed:` line — byte-identical to
+  # base. An earlier round claimed `-I{}` fixed the quote case; MEASURED, it did
+  # not, and the claim shipped without being re-run. Only `-d` (or `-0`) turns
+  # the quote parsing off.
+  #
+  # 🔴 AND THE KEY IS TAB-SEPARATED, because `awk '{print $2" "$1}'` rebuilt the
+  # line from FIELDS and so truncated any path at its first blank. MEASURED: two
+  # BYTE-IDENTICAL entries `sc/two words.md` and `sc/two other.md` both collapsed
+  # to key `sc/two`, the join degenerated into a cross-product, and the guard
+  # printed `differing=2` and refused — naming `sc/two` twice, a path that does
+  # not exist. A confident false refusal whose only offered remedy is
+  # `--allow-overwrite` is worse than the crash it replaced. `sub()` strips the
+  # digest and its separator and leaves the REST OF THE LINE intact.
+  ( cd "$STAGE" && xargs -r -d '\n' -I{} sha256sum {} ) < "$staged_list" \
+    | awk '{h=$1; sub(/^[^ ]+ +/,""); print $0"\t"h}' | LC_ALL=C sort > "$_local_h"
   # 🔴 EVERY PATH IS ANSWERED — a hash, ABSENT, or UNREADABLE. The probe used to
   # emit a line only for files the pod HAS, so "the pod holds none of them" and
   # "the probe never ran" were the same observation (zero lines, rc 0) and the
@@ -393,24 +408,35 @@ if [[ -s "$staged_list" ]]; then
   # 18 legitimate tests. The answerable question is whether the probe SAW the
   # whole list, so ABSENT is an answer and a MISSING line is the fault.
   #
-  # 🔴 `|| :` IS LOAD-BEARING: `xargs` exits 123 when any child does, and a path
-  # the pod lacks is ordinary. Dropping it kills 21 tests. ⚠ It also swallows a
-  # read error — hence UNREADABLE, which cannot equal a hex digest, so such an
-  # entry always lands in the clobber set and is refused rather than replaced.
+  # 🔴 THE INNER `sh` MUST EXIT 0 FOR EVERY PATH: `xargs` exits 123 when any child
+  # does, and a path the pod lacks is ordinary. The `if/else` is what guarantees
+  # that now — an earlier revision used a bare `|| :` and this comment still
+  # described it two rounds after it was replaced. UNREADABLE cannot equal a hex
+  # digest, so such an entry always lands in the clobber set rather than being
+  # silently treated as a pure addition.
   # `_ {}` passes the path as "$1" so it is never re-parsed as shell text.
   kubectl -n "$ns" exec -i "$pod" -- \
-    sh -c "cd '$DEST' && xargs -r -I{} sh -c 'if [ -f \"\$1\" ]; then sha256sum \"\$1\" 2>/dev/null || echo \"UNREADABLE  \$1\"; else echo \"ABSENT  \$1\"; fi' _ {}" \
+    sh -c "cd '$DEST' && xargs -r -d '\n' -I{} sh -c 'if [ -f \"\$1\" ]; then sha256sum \"\$1\" 2>/dev/null || echo \"UNREADABLE  \$1\"; else echo \"ABSENT  \$1\"; fi' _ {}" \
     < "$staged_list" \
-    | awk '{print $2" "$1}' | LC_ALL=C sort > "$_probe_raw"
+    | awk '{h=$1; sub(/^[^ ]+ +/,""); print $0"\t"h}' | LC_ALL=C sort > "$_probe_raw"
   _n_answered=$(wc -l < "$_probe_raw" | tr -d ' ')
-  LC_ALL=C grep -v ' ABSENT$' "$_probe_raw" > "$_remote_h" || :
+  # 🔴 `|| [ $? -eq 1 ]`, NOT `|| :`. `grep -v` exits 1 on NO MATCH (the ordinary
+  # first-seed case, so it must be tolerated) and 2 on an I/O ERROR. `|| :`
+  # swallowed both: an error left `_remote_h` empty, the join empty, `differing=0`
+  # and the push proceeding — the silent-zero shape this round exists to remove,
+  # one line below the gate that removes it.
+  LC_ALL=C grep -v "$(printf '\t')ABSENT$" "$_probe_raw" > "$_remote_h" || [ $? -eq 1 ]
   _n_present=$(wc -l < "$_remote_h" | tr -d ' ')
   # 🔴 `LC_ALL=C` on the join too. GNU join order-checks in the AMBIENT locale,
   # so C-sorted input is "not sorted" to a join under en_US.UTF-8 — this host.
   # MEASURED: it MISSES the differing pair AND exits 1, which `set -e` turns
   # into a run with no verdict. Needs an unpairable line plus a README/lowercase
   # adjacency, which the real store is full of.
-  LC_ALL=C join "$_local_h" "$_remote_h" | awk '$2 != $3 {print $1}' > "$_clobber_f"
+  # `-t` a literal TAB so the key is the whole path, spaces included — join's
+  # default whitespace splitting would re-introduce exactly the truncation the
+  # `awk` above was fixed to stop.
+  LC_ALL=C join -t "$(printf '\t')" "$_local_h" "$_remote_h" \
+    | awk -F'\t' '$2 != $3 {print $1}' > "$_clobber_f"
 fi
 _n_clobber=$(wc -l < "$_clobber_f" | tr -d ' ')
 

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -63,11 +63,22 @@
 #   9   the pod's probe answered FEWER paths than were asked about, so the
 #       comparison could not be made. No override — an unanswered path is
 #       indistinguishable from one that matched.
-#   10  a staged path contains characters outside `[A-Za-z0-9._/-]`. No override
-#       either, and the pattern is not meant to be relaxed: the comparison that
-#       protects the pod moves paths as TEXT between two different shells, and a
-#       name outside that set can make a DIFFERING entry look brand-new. Rename
-#       the entry. Measured 2026-09-05: 0 of 348 live entries are affected.
+#   10  a staged entry NAME this push cannot compare safely. No override either,
+#       and the rules are not meant to be relaxed: the comparison that protects
+#       the pod moves paths as TEXT between two different shells, so a name
+#       outside them can make a DIFFERING entry look brand-new. Three rules,
+#       each closing a measured hole rather than a hypothetical one:
+#         * characters outside `[A-Za-z0-9._/-]`;
+#         * a component STARTING with `-`, which reaches `sha256sum` as an
+#           option (`invalid option -- 'd'`, rc 123, no `seed:` line);
+#         * a NEWLINE anywhere. It is this list's OWN record separator, so a
+#           looser check sees two halves that each look legitimate and reports
+#           `rejected=0`. Caught because the pattern REQUIRES a `<scope>/<entry>`
+#           shape: a filename cannot contain `/`, so the second half of a split
+#           never has one and is always rejected.
+#       Rename the entry. Measured 2026-09-05 across both live stores: 373
+#       entry files, 0 affected by any of the three. 🔴 THAT COUNT MOVES — it
+#       read 348 earlier the same day; re-measure rather than citing it.
 #
 # The two halves are split on purpose: staging is hermetic and testable, pushing
 # needs a cluster. A green stage says nothing about the push, so the script
@@ -379,14 +390,50 @@ fi
 # `--push` re-stages from `--store` on every run, so the check runs before every
 # transfer that exists.
 _odd_f="$_seed_tmp/odd-names"
-LC_ALL=C grep -nvE '^[A-Za-z0-9._/-]+$' "$staged_list" > "$_odd_f" || [ $? -eq 1 ]
+# 🔴 `-` IS IN THE CLASS AND IS ALSO THE OPTION CHARACTER. A path is safe to
+# COMPARE with a leading dash but not safe to PASS: a scope named `-dashscope`
+# reaches `sha256sum` as `-d…` and the run dies `invalid option -- 'd'` at
+# rc 123 with no `seed:` line — round 1's exact failure shape, re-reached
+# through the guard that claimed to remove the class (MEASURED 2026-09-05).
+# `sha256sum --` below is the mechanism fix; this is the policy one, and both
+# are kept because the mechanism is one edit away from being lost again.
+# 🔴 THE REQUIRED `/` IS WHAT CATCHES A NEWLINE — and it does so WITHOUT a
+# third `find`. `$staged_list` is
+# newline-delimited, so a file named `na<NL>me.md` is written as TWO lines; a
+# looser pattern passes BOTH halves and reports `rejected=0` for the one
+# character that breaks every consumer downstream. MEASURED against the first
+# version of this guard, with decoys making both halves resolve: `rejected=0`,
+# `differing=0`, `seed: OK`, rc 0 — while REPLACING the pod's newer copy.
+#
+# Requiring a well-formed `<scope>/<entry>` closes it by construction: a
+# FILENAME CANNOT CONTAIN `/`, so the SECOND half of any split never has one and
+# is always rejected, whatever the first half looks like.
+#
+# 🔴 AN EARLIER VERSION ALSO ANCHORED `\.md$` and this comment credited THAT
+# with catching the newline. It did not, and the mutation matrix said so:
+# dropping the anchor killed no test, because the slash rule had already decided
+# every case. `find` only ever emits `*.md`, so the anchor could never change a
+# verdict — a redundant clause carrying a false explanation, which is worse than
+# no clause. Removed. The first attempt at this counted `-print0` records
+# instead and added a THIRD walk — which `test_the_two_find_expressions_are_
+# IDENTICAL` correctly failed, because two walks that disagree is the bug this
+# file already carries a scar from.
+#
+# 🔴 THE PATTERN MATCHES WHAT IS SAFE AND `-v` REJECTS THE REST, so it must
+# describe a WHOLE well-formed path, never an alternation of hazards: written as
+# `'…$|^-|/-'` an added `^-` arm makes a leading-dash path MATCH, which under
+# `-v` marks it SAFE — the guard inverted by the edit meant to strengthen it.
+# Each of the two components must therefore START with a non-dash character and
+# continue in the class. `_shippable_entries` is `-mindepth 2 -maxdepth 2`, so
+# there is exactly one `/`.
+LC_ALL=C grep -nvE '^[A-Za-z0-9._][A-Za-z0-9._-]*/[A-Za-z0-9._][A-Za-z0-9._-]*$' "$staged_list" > "$_odd_f" || [ $? -eq 1 ]
 _n_odd=$(wc -l < "$_odd_f" | tr -d ' ')
 # Printed on EVERY path, not only on rejection — this file's own silent-zero
 # rule: a bare 0 from a check that walked nothing reads exactly like a clean one.
 echo "seed: NAME-CHECK staged=$staged_entries rejected=$_n_odd"
 if [[ "$_n_odd" -gt 0 ]]; then
   echo "seed: REFUSING — $_n_odd staged entry path(s) contain characters this push cannot" >&2
-  echo "seed:   compare safely. Allowed: A-Z a-z 0-9 . _ - /" >&2
+  echo "seed:   compare safely. Allowed: A-Z a-z 0-9 . _ - / and no component may START with -" >&2
   sed 's/^/  /' "$_odd_f" >&2
   echo "seed:   (each line is <line-number-in-staged-list>:<path>)" >&2
   echo "seed: 🔴 THIS IS NOT A LIMIT YOU SHOULD WIDEN BY RELAXING THE PATTERN. The pre-flight" >&2
@@ -481,7 +528,7 @@ if [[ -s "$staged_list" ]]; then
   # not exist. A confident false refusal whose only offered remedy is
   # `--allow-overwrite` is worse than the crash it replaced. `sub()` strips the
   # digest and its separator and leaves the REST OF THE LINE intact.
-  ( cd "$STAGE" && xargs -r -d '\n' -I{} sha256sum {} ) < "$staged_list" \
+  ( cd "$STAGE" && xargs -r -d '\n' -I{} sha256sum -- {} ) < "$staged_list" \
     | awk '{h=$1; sub(/^[^ ]+ +/,""); print $0"\t"h}' | LC_ALL=C sort > "$_local_h"
   # 🔴 EVERY PATH IS ANSWERED — a hash, ABSENT, or UNREADABLE. The probe used to
   # emit a line only for files the pod HAS, so "the pod holds none of them" and
@@ -517,7 +564,7 @@ if [[ -s "$staged_list" ]]; then
   # silently treated as a pure addition.
   # `_ {}` passes the path as "$1" so it is never re-parsed as shell text.
   kubectl -n "$ns" exec -i "$pod" -- \
-    sh -c "cd '$DEST' && xargs -r -d '\n' -I{} sh -c 'if [ -f \"\$1\" ]; then sha256sum \"\$1\" 2>/dev/null || printf \"UNREADABLE  %s\\n\" \"\$1\"; else printf \"ABSENT  %s\\n\" \"\$1\"; fi' _ {}" \
+    sh -c "cd '$DEST' && xargs -r -d '\n' -I{} sh -c 'if [ -f \"\$1\" ]; then sha256sum -- \"\$1\" 2>/dev/null || printf \"UNREADABLE  %s\\n\" \"\$1\"; else printf \"ABSENT  %s\\n\" \"\$1\"; fi' _ {}" \
     < "$staged_list" \
     | awk '{h=$1; sub(/^[^ ]+ +/,""); print $0"\t"h}' | LC_ALL=C sort > "$_probe_raw"
   _n_answered=$(wc -l < "$_probe_raw" | tr -d ' ')

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -69,8 +69,12 @@
 #       outside them can make a DIFFERING entry look brand-new. Three rules,
 #       each closing a measured hole rather than a hypothetical one:
 #         * characters outside `[A-Za-z0-9._/-]`;
-#         * a component STARTING with `-`, which reaches `sha256sum` as an
-#           option (`invalid option -- 'd'`, rc 123, no `seed:` line);
+#         * a component STARTING with `-`. For the FIRST component this is
+#           measured: `-dashscope/thing.md` reached `sha256sum` as `-d…`
+#           (`invalid option -- 'd'`, rc 123, no `seed:` line). For the SECOND
+#           it is prophylactic — the argv word begins with the scope, so it can
+#           never be read as an option — and is kept only so the rule is one
+#           rule rather than two with an asymmetry nobody will remember;
 #         * a NEWLINE anywhere. It is this list's OWN record separator, so a
 #           looser check sees two halves that each look legitimate and reports
 #           `rejected=0`. Caught because the pattern REQUIRES a `<scope>/<entry>`
@@ -370,7 +374,7 @@ fi
 # exists to prevent. Escaping-symmetry across dash/bash/GNU-coreutils is not
 # something this script can establish, so it stops trying.
 #
-# MEASURED 2026-09-05 across BOTH live stores: 348 entry files, **0** whose path
+# MEASURED 2026-09-05 across BOTH live stores: 373 entry files, **0** whose path
 # leaves `[A-Za-z0-9._/-]`. Entry names are service slugs by construction, and
 # `cairn-cutover.py` — the only programmatic caller — builds its delta tree from
 # that same population. So this rejects nothing that exists and nothing any
@@ -395,8 +399,15 @@ _odd_f="$_seed_tmp/odd-names"
 # reaches `sha256sum` as `-d…` and the run dies `invalid option -- 'd'` at
 # rc 123 with no `seed:` line — round 1's exact failure shape, re-reached
 # through the guard that claimed to remove the class (MEASURED 2026-09-05).
-# `sha256sum --` below is the mechanism fix; this is the policy one, and both
-# are kept because the mechanism is one edit away from being lost again.
+# Two locks, and it is worth being exact about which does the work, because the
+# first version of this note had it BACKWARDS. The POLICY (this pattern) is
+# load-bearing: with `--` present but the policy reverted, `-dashscope/thing.md`
+# pushes at rc 0 printing `seed: OK` — MEASURED. The MECHANISM (`sha256sum --`)
+# is what keeps the failure LOUD if the policy is ever relaxed: without either,
+# the run dies rc 123 with no `seed:` line, which is at least fail-safe. So `--`
+# does not protect the bytes; it protects the diagnostic. Both are kept.
+# 🔴 `--` IS UNREACHABLE WHILE THE POLICY HOLDS, and its mutants SURVIVE the
+# suite by construction. Labelled, not counted as covered.
 # 🔴 THE REQUIRED `/` IS WHAT CATCHES A NEWLINE — and it does so WITHOUT a
 # third `find`. `$staged_list` is
 # newline-delimited, so a file named `na<NL>me.md` is written as TWO lines; a
@@ -409,12 +420,19 @@ _odd_f="$_seed_tmp/odd-names"
 # FILENAME CANNOT CONTAIN `/`, so the SECOND half of any split never has one and
 # is always rejected, whatever the first half looks like.
 #
-# 🔴 AN EARLIER VERSION ALSO ANCHORED `\.md$` and this comment credited THAT
-# with catching the newline. It did not, and the mutation matrix said so:
-# dropping the anchor killed no test, because the slash rule had already decided
-# every case. `find` only ever emits `*.md`, so the anchor could never change a
-# verdict — a redundant clause carrying a false explanation, which is worse than
-# no clause. Removed. The first attempt at this counted `-print0` records
+# 🔴 `\.md$` IS ALSO REQUIRED, AND IT IS NOT REDUNDANT — I REMOVED IT ONCE AND
+# WAS WRONG. The reasoning was "`find` only emits `*.md`, so it can never change
+# a verdict". `-name '*.md'` constrains the BASENAME; this grep runs on LINES,
+# and the whole mechanism here is that a newline turns one path into two lines —
+# of which the one carrying the `/` is precisely the one NOT ending in `.md`.
+# MEASURED on `widget-cfg/na<NL>me.md`: without the anchor the refusal names
+# `2:me.md` ALONE — a path that is not in the store, with the scope never
+# mentioned; with it, `1:widget-cfg/na` AND `2:me.md`. Same exit code either
+# way, so this is not a clobber; it is a correct refusal nobody can act on,
+# which is the shape `test_the_refusal_names_the_offending_path_in_full` exists
+# to forbid. The `/` decides WHETHER to refuse; the anchor decides whether the
+# refusal is USABLE. My mutation missed it because the test asserted only that
+# EITHER half was named — it now requires the scope-bearing one. The first attempt at this counted `-print0` records
 # instead and added a THIRD walk — which `test_the_two_find_expressions_are_
 # IDENTICAL` correctly failed, because two walks that disagree is the bug this
 # file already carries a scar from.
@@ -426,7 +444,7 @@ _odd_f="$_seed_tmp/odd-names"
 # Each of the two components must therefore START with a non-dash character and
 # continue in the class. `_shippable_entries` is `-mindepth 2 -maxdepth 2`, so
 # there is exactly one `/`.
-LC_ALL=C grep -nvE '^[A-Za-z0-9._][A-Za-z0-9._-]*/[A-Za-z0-9._][A-Za-z0-9._-]*$' "$staged_list" > "$_odd_f" || [ $? -eq 1 ]
+LC_ALL=C grep -nvE '^[A-Za-z0-9._][A-Za-z0-9._-]*/[A-Za-z0-9._][A-Za-z0-9._-]*\.md$' "$staged_list" > "$_odd_f" || [ $? -eq 1 ]
 _n_odd=$(wc -l < "$_odd_f" | tr -d ' ')
 # Printed on EVERY path, not only on rejection — this file's own silent-zero
 # rule: a bare 0 from a check that walked nothing reads exactly like a clean one.

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -66,9 +66,15 @@
 #   10  a staged entry NAME this push cannot compare safely. No override either,
 #       and the rules are not meant to be relaxed: the comparison that protects
 #       the pod moves paths as TEXT between two different shells, so a name
-#       outside them can make a DIFFERING entry look brand-new. Three rules,
+#       outside them can make a DIFFERING entry look brand-new. Four rules,
 #       each closing a measured hole rather than a hypothetical one:
 #         * characters outside `[A-Za-z0-9._/-]`;
+#         * an entry named exactly `.md`. `find -name '*.md'` DOES emit
+#           `<scope>/.md`, and the `\.md$` anchor requires a non-empty stem
+#           before it — so this arm arrived WITH that anchor and is its only
+#           new refusal class (measured over 66,822 name pairs). It is listed
+#           because an operator hitting it violates none of the other three
+#           and would otherwise read a message that does not describe them;
 #         * a component STARTING with `-`. For the FIRST component this is
 #           measured: `-dashscope/thing.md` reached `sha256sum` as `-d…`
 #           (`invalid option -- 'd'`, rc 123, no `seed:` line). For the SECOND
@@ -81,7 +87,7 @@
 #           shape: a filename cannot contain `/`, so the second half of a split
 #           never has one and is always rejected.
 #       Rename the entry. Measured 2026-09-05 across both live stores: 373
-#       entry files, 0 affected by any of the three. 🔴 THAT COUNT MOVES — it
+#       entry files, 0 affected by any of the four. 🔴 THAT COUNT MOVES — it
 #       read 348 earlier the same day; re-measure rather than citing it.
 #
 # The two halves are split on purpose: staging is hermetic and testable, pushing
@@ -375,6 +381,8 @@ fi
 # something this script can establish, so it stops trying.
 #
 # MEASURED 2026-09-05 across BOTH live stores: 373 entry files, **0** whose path
+# (re-measured hours later: 374 — 🔴 THIS COUNT MOVES, re-take it rather than
+# citing this line)
 # leaves `[A-Za-z0-9._/-]`. Entry names are service slugs by construction, and
 # `cairn-cutover.py` — the only programmatic caller — builds its delta tree from
 # that same population. So this rejects nothing that exists and nothing any
@@ -424,7 +432,16 @@ _odd_f="$_seed_tmp/odd-names"
 # WAS WRONG. The reasoning was "`find` only emits `*.md`, so it can never change
 # a verdict". `-name '*.md'` constrains the BASENAME; this grep runs on LINES,
 # and the whole mechanism here is that a newline turns one path into two lines —
-# of which the one carrying the `/` is precisely the one NOT ending in `.md`.
+# and the one carrying the `/` USUALLY does not end in `.md`.
+#
+# 🔴 "USUALLY", NOT "ALWAYS" — this said "precisely" first, and that is false
+# whenever the stem ITSELF contains `.md`: for `widget-cfg/a.md<NL>b.md` the
+# leading half is well-formed, so the refusal names only `b.md` and the scope
+# goes unmentioned after all. MEASURED over the split-line model: shapes whose
+# scope-bearing half is NOT named fall from 60 without the anchor to 6 with it.
+# So the anchor is a 10x improvement in the DIAGNOSTIC, not a closure. The
+# REFUSAL is unaffected either way — 0 newline shapes are accepted, with or
+# without it — which is why this is a diagnostic argument and not a safety one.
 # MEASURED on `widget-cfg/na<NL>me.md`: without the anchor the refusal names
 # `2:me.md` ALONE — a path that is not in the store, with the scope never
 # mentioned; with it, `1:widget-cfg/na` AND `2:me.md`. Same exit code either
@@ -451,7 +468,9 @@ _n_odd=$(wc -l < "$_odd_f" | tr -d ' ')
 echo "seed: NAME-CHECK staged=$staged_entries rejected=$_n_odd"
 if [[ "$_n_odd" -gt 0 ]]; then
   echo "seed: REFUSING — $_n_odd staged entry path(s) contain characters this push cannot" >&2
-  echo "seed:   compare safely. Allowed: A-Z a-z 0-9 . _ - / and no component may START with -" >&2
+  echo "seed:   compare safely. A staged path must read <scope>/<entry>.md where both" >&2
+  echo "seed:   components use only [A-Za-z0-9._-], neither STARTS with -, and the entry" >&2
+  echo "seed:   has a non-empty stem before .md (a file named exactly '.md' is refused)." >&2
   sed 's/^/  /' "$_odd_f" >&2
   echo "seed:   (each line is <line-number-in-staged-list>:<path>)" >&2
   echo "seed: 🔴 THIS IS NOT A LIMIT YOU SHOULD WIDEN BY RELAXING THE PATTERN. The pre-flight" >&2

--- a/scripts/subsystem-store-api/seed.sh
+++ b/scripts/subsystem-store-api/seed.sh
@@ -57,6 +57,18 @@
 #                         default because the pod is authoritative post-cutover.
 #                         It still PRINTS what it replaced.
 #
+# Exit codes that mean "nothing was pushed", and they are NOT interchangeable:
+#   8   a staged entry EXISTS ON THE POD WITH DIFFERENT BYTES. The pod is the
+#       authority; `--allow-overwrite` is the deliberate override.
+#   9   the pod's probe answered FEWER paths than were asked about, so the
+#       comparison could not be made. No override — an unanswered path is
+#       indistinguishable from one that matched.
+#   10  a staged path contains characters outside `[A-Za-z0-9._/-]`. No override
+#       either, and the pattern is not meant to be relaxed: the comparison that
+#       protects the pod moves paths as TEXT between two different shells, and a
+#       name outside that set can make a DIFFERING entry look brand-new. Rename
+#       the entry. Measured 2026-09-05: 0 of 348 live entries are affected.
+#
 # The two halves are split on purpose: staging is hermetic and testable, pushing
 # needs a cluster. A green stage says nothing about the push, so the script
 # prints them as separate lines and never one combined verdict.
@@ -79,12 +91,20 @@ while [[ $# -gt 0 ]]; do
     -h|--help)
       # 🔴 PRINT THE WHOLE LEADING COMMENT BLOCK, NOT A LINE RANGE. It was
       # `sed -n '2,26p'`, and a line range rots the moment the header grows:
-      # this round's additions pushed line 26 into the middle of a clause, so
+      # a later round's additions pushed line 26 into the middle of a clause, so
       # `--help` ended mid-sentence. And the Usage block has ALWAYS sat BELOW
       # that window, so `--allow-overwrite` was "documented in Usage" in a place
-      # `--help` could not reach. Stopping at the first non-comment line cannot
-      # drift.
-      awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; exit 0 ;;
+      # `--help` could not reach.
+      #
+      # 🔴 A BLANK LINE IS PART OF THE HEADER, NOT THE END OF IT. The first
+      # version of this stopped at the first non-`#` line, which a blank line
+      # IS — so one blank inserted for readability silently cut `--help` from
+      # 61 lines to 31 and took `--allow-overwrite` with it (MEASURED
+      # 2026-09-05). That is the same defect the line range had, re-spelled, so
+      # "cannot drift" was false as written. Blank lines are now passed through
+      # and only a real non-comment line stops it. `test_seed_help_*` pins both
+      # halves, because this claim has now been wrong twice with no test.
+      awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} /^[[:space:]]*$/{print; next} {exit}' "$0"; exit 0 ;;
     *) echo "seed: unknown argument: $1" >&2; exit 2 ;;
   esac
 done
@@ -321,6 +341,62 @@ if [[ -z "$PUSH" ]]; then
   exit 0
 fi
 
+# 🔴 BOUND THE DOMAIN — DO NOT HARDEN THE PARSER. Every path below travels as
+# TEXT through `xargs`, `sha256sum`, `awk`, `sort` and `join`, on TWO machines
+# whose tools do not agree on how text is escaped, and three audit rounds each
+# fixed one delimiter and re-broke the next:
+#
+#   round 1  bare `xargs`           a space split the args        -> rc 123
+#   round 2  `-I{}`                 a space TRUNCATED the join key at 0x20
+#   round 3  `-d '\n'` + TAB key    a TAB truncates it at 0x09, and the POD's
+#                                   `/bin/sh` is dash, whose `echo` turns the
+#                                   two characters `\t` in a NAME into a real
+#                                   TAB on one side only
+#
+# The last one is the dangerous shape: the two sides' keys diverge, the row
+# drops out of the join, and a pod entry that DIFFERS is pushed over as though
+# it were a pure addition — silently, which is the exact defect this pre-flight
+# exists to prevent. Escaping-symmetry across dash/bash/GNU-coreutils is not
+# something this script can establish, so it stops trying.
+#
+# MEASURED 2026-09-05 across BOTH live stores: 348 entry files, **0** whose path
+# leaves `[A-Za-z0-9._/-]`. Entry names are service slugs by construction, and
+# `cairn-cutover.py` — the only programmatic caller — builds its delta tree from
+# that same population. So this rejects nothing that exists and nothing any
+# caller produces; it removes the whole class from the comparison below.
+#
+# 🔴 REJECT, NEVER SANITISE. A rewritten name would push one entry's bytes over
+# a DIFFERENT entry's path. Refusing is the only safe direction.
+#
+# 🔴 ON THE PUSH HALF, DELIBERATELY — this sat above the `--push` early-return
+# first, and that was wrong twice over. The hazard is ENTIRELY in the pod
+# comparison: staging is hermetic, local, and never moves a name between two
+# shells. Refusing there would also have broken
+# `test_a_scope_name_containing_a_BACKSLASH_ESCAPE_counts_correctly`, a
+# STAGE-ONLY test pinning that the per-scope count survives a scope named
+# `a\tb` — coverage of a real awk-ENVIRON fix that has nothing to do with this
+# guard, and which a name check has no business deleting. There is no bypass:
+# `--push` re-stages from `--store` on every run, so the check runs before every
+# transfer that exists.
+_odd_f="$_seed_tmp/odd-names"
+LC_ALL=C grep -nvE '^[A-Za-z0-9._/-]+$' "$staged_list" > "$_odd_f" || [ $? -eq 1 ]
+_n_odd=$(wc -l < "$_odd_f" | tr -d ' ')
+# Printed on EVERY path, not only on rejection — this file's own silent-zero
+# rule: a bare 0 from a check that walked nothing reads exactly like a clean one.
+echo "seed: NAME-CHECK staged=$staged_entries rejected=$_n_odd"
+if [[ "$_n_odd" -gt 0 ]]; then
+  echo "seed: REFUSING — $_n_odd staged entry path(s) contain characters this push cannot" >&2
+  echo "seed:   compare safely. Allowed: A-Z a-z 0-9 . _ - /" >&2
+  sed 's/^/  /' "$_odd_f" >&2
+  echo "seed:   (each line is <line-number-in-staged-list>:<path>)" >&2
+  echo "seed: 🔴 THIS IS NOT A LIMIT YOU SHOULD WIDEN BY RELAXING THE PATTERN. The pre-flight" >&2
+  echo "seed:   that protects the pod's bytes compares paths as TEXT across two shells; a name" >&2
+  echo "seed:   outside this set can make an entry that DIFFERS look like a new one and be" >&2
+  echo "seed:   overwritten with no warning. Rename the entry instead." >&2
+  echo "seed: NOTHING WAS PUSHED." >&2
+  exit 10
+fi
+
 ns="${PUSH%%/*}"
 deploy="${PUSH##*/}"
 if [[ "$ns" == "$PUSH" || -z "$ns" || -z "$deploy" ]]; then
@@ -420,6 +496,19 @@ if [[ -s "$staged_list" ]]; then
   # 18 legitimate tests. The answerable question is whether the probe SAW the
   # whole list, so ABSENT is an answer and a MISSING line is the fault.
   #
+  # 🔴 `printf`, NEVER `echo`, FOR THE TWO HAND-WRITTEN ANSWERS. The pod's
+  # `/bin/sh` is dash (`Dockerfile`: `FROM python:3.12-slim` -> Debian), and
+  # dash's `echo` INTERPRETS backslash escapes while bash's does not. MEASURED
+  # 2026-09-05 on the same input: a name containing the two characters `\t` came
+  # back with a REAL TAB from dash and a literal `\t` from bash; `\n` split the
+  # answer across two lines; `\c` truncated it AND swallowed the NEXT path's
+  # answer. Every test in this repo drives a fake `kubectl` that runs this
+  # command under bash, so the suite is structurally blind to all three.
+  # `printf '%s'` does not interpret its argument, and reproduces bash's output
+  # under dash exactly. The NAME-CHECK above already makes these unreachable;
+  # this is the second lock, because that one is a policy and this is a fact
+  # about the two shells.
+  #
   # 🔴 THE INNER `sh` MUST EXIT 0 FOR EVERY PATH: `xargs` exits 123 when any child
   # does, and a path the pod lacks is ordinary. The `if/else` is what guarantees
   # that now — an earlier revision used a bare `|| :` and this comment still
@@ -428,7 +517,7 @@ if [[ -s "$staged_list" ]]; then
   # silently treated as a pure addition.
   # `_ {}` passes the path as "$1" so it is never re-parsed as shell text.
   kubectl -n "$ns" exec -i "$pod" -- \
-    sh -c "cd '$DEST' && xargs -r -d '\n' -I{} sh -c 'if [ -f \"\$1\" ]; then sha256sum \"\$1\" 2>/dev/null || echo \"UNREADABLE  \$1\"; else echo \"ABSENT  \$1\"; fi' _ {}" \
+    sh -c "cd '$DEST' && xargs -r -d '\n' -I{} sh -c 'if [ -f \"\$1\" ]; then sha256sum \"\$1\" 2>/dev/null || printf \"UNREADABLE  %s\\n\" \"\$1\"; else printf \"ABSENT  %s\\n\" \"\$1\"; fi' _ {}" \
     < "$staged_list" \
     | awk '{h=$1; sub(/^[^ ]+ +/,""); print $0"\t"h}' | LC_ALL=C sort > "$_probe_raw"
   _n_answered=$(wc -l < "$_probe_raw" | tr -d ' ')

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -18679,31 +18679,38 @@ class TestTheSeedPreFlightCannotBeSILENTLYSKIPPED:
 
 
 class TestTheSeedPreFlightJoinIsLocaleSafe:
-    """🔴 `LC_ALL=C` ON THE `join`, GUARDED — the mutant SURVIVED all 40 seed tests.
+    """🔴 `LC_ALL=C` ON THE `join`, GUARDED — the mutant SURVIVED all 40 seed tests
+    when the auditor measured it, and survived my FIRST attempt at this test too.
 
     GNU `join` order-checks in the AMBIENT locale, so C-sorted input is "not
-    sorted" to a join running under en_US.UTF-8 — which is this host. MEASURED:
-    it both MISSES the differing pair and exits 1, which `set -euo pipefail`
-    turns into a run with no verdict at all.
+    sorted" to a join under en_US.UTF-8 — which is this host. It both MISSES the
+    differing pair and exits 1, which `set -euo pipefail` turns into a run with
+    no verdict at all.
 
-    It needs two things at once, which is why the existing UTF-8 test could not
-    reach it: an UNPAIRABLE line (GNU join arms the order check only after one)
-    AND an adjacency where C and locale order disagree — `<scope>/README.md`
-    beside a lowercase sibling, which the real store is full of."""
+    🔴 WHY THE FIRST VERSION OF THIS TEST WAS VACUOUS, recorded because the shape
+    is easy to repeat: it planted the `README.md`/lowercase adjacency on the POD.
+    But the probe answers exactly the STAGED paths, so `_remote_h` can only ever
+    contain staged entries — a pod-only file never reaches the join, and the
+    adjacency had no effect. The inversion must be between two STAGED paths.
+
+    Two conditions must hold at once, which is what makes this fiddly: an
+    UNPAIRABLE line (GNU join arms the order check only after one — here the
+    entry the pod does NOT have) and an adjacency where C and en_US disagree
+    (`README.md` sorts BEFORE `backblaze.md` under C, AFTER under en_US)."""
 
     def test_a_differing_entry_is_still_caught_under_a_UTF8_locale(
         self, store: Path, tmp_path: Path, fake_cluster
     ):
         env, dest = fake_cluster
+        # BOTH must be STAGED — that is what puts them on both sides of the join.
+        (store / SCOPE / "README.md").write_text(_entry("README", SCOPE))
+        (store / SCOPE / "backblaze.md").write_text(_entry("backblaze", SCOPE))
+
         d = dest / SCOPE; d.mkdir(parents=True, exist_ok=True)
-        # the adjacency that inverts between C and en_US
-        (d / "README.md").write_text("---\nservice: readme\n---\n")
-        # the DIFFERING entry the guard must still refuse
-        pod_alpha = d / "thing-alpha.md"
-        pod_alpha.write_text("---\nservice: thing-alpha\n---\nPOD NEWER\n")
-        # an unpairable line on the pod arms GNU join's order check
-        other = dest / "a-scope-only-the-laptop-has"; other.mkdir(exist_ok=True)
-        (other / "from-the-other-host.md").write_text("---\nservice: x\n---\n")
+        # `backblaze.md` DIFFERS on the pod -> must be refused.
+        (d / "backblaze.md").write_text("---\nservice: backblaze\n---\nPOD NEWER\n")
+        # `README.md` is ABSENT on the pod -> the unpairable line that arms the
+        # order check. `thing-alpha.md` absent too; harmless.
 
         r = run_seed(
             "--store", str(store), "--stage", str(tmp_path / "stage"),
@@ -18712,7 +18719,8 @@ class TestTheSeedPreFlightJoinIsLocaleSafe:
         )
 
         assert r.returncode == 8, (
-            "under a UTF-8 ambient locale the join either missed the differing "
-            f"pair or died on an order check: rc={r.returncode}\n{r.stdout}\n{r.stderr}"
+            "under a UTF-8 ambient locale the join either MISSED the differing "
+            "pair or died on an order check — `LC_ALL=C` on the join is what "
+            f"stops both: rc={r.returncode}\n{r.stdout}\n{r.stderr}"
         )
-        assert f"{SCOPE}/thing-alpha.md" in r.stderr, r.stderr
+        assert f"{SCOPE}/backblaze.md" in r.stderr, r.stderr

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -2816,6 +2816,12 @@ case "$sub" in
     ;;
   exec)
     if [ "${1:-}" = "-i" ]; then shift; fi
+    # $FAKE_PROBE_SILENT makes the PRE-FLIGHT probe (the only exec that runs
+    # sha256sum) answer with silence at rc 0 — the shape a stdin stream that
+    # closes early produces. Default off: every other test is unaffected.
+    if [ -n "${FAKE_PROBE_SILENT:-}" ]; then
+      case "$*" in *sha256sum*) exit 0 ;; esac
+    fi
     if [ $# -gt 0 ]; then shift; fi
     if [ "${1:-}" = "--" ]; then shift; fi
     n=$#
@@ -18611,3 +18617,102 @@ class TestSeedRefusesToOverwriteANewerPodEntry:
         assert pod_file.read_text() == (store / SCOPE / "thing-alpha.md").read_text(), (
             "--allow-overwrite was given, so this host's copy must actually win"
         )
+
+
+class TestTheSeedPreFlightCannotBeSILENTLYSKIPPED:
+    """🔴 AN EMPTY PROBE RESULT MUST NOT READ AS "NOTHING DIFFERS".
+
+    The pre-flight asks the pod about the staged paths over STDIN
+    (`kubectl exec -i … < "$staged_list"`). `xargs -r` on a stream that closes
+    early is silence at rc 0 BY DESIGN — so a probe that never ran and a pod
+    that holds none of the entries were the same observation, and the guard read
+    both as "nothing to refuse".
+
+    MEASURED during review of this PR: with a probe returning silence, the push
+    overwrote the pod's newer bytes and printed `seed: OK`, rc 0 — the exact
+    defect the guard exists to prevent, with the guard installed.
+
+    The fix is not "refuse when 0 are present" — that is the ordinary first-seed
+    case and it failed 18 legitimate tests. The probe answers EVERY path (a hash,
+    `ABSENT`, or `UNREADABLE`), so the answerable question is whether it SAW the
+    whole list."""
+
+    def _push(self, store: Path, tmp_path: Path, env, *extra):
+        return run_seed(
+            "--store", str(store), "--stage", str(tmp_path / "stage"),
+            "--push", "ns/app", *extra, env=env,
+        )
+
+    def test_a_probe_that_answers_NOTHING_refuses_instead_of_pushing(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 THE REGRESSION. The pod holds a NEWER copy; the probe is silenced.
+        Before the self-verifying probe this pushed and printed OK."""
+        env, dest = fake_cluster
+        d = dest / SCOPE; d.mkdir(parents=True, exist_ok=True)
+        pod_file = d / "thing-alpha.md"
+        newer = "---\nservice: thing-alpha\n---\nPOD NEWER\n"
+        pod_file.write_text(newer)
+
+        r = self._push(store, tmp_path, {**env, "FAKE_PROBE_SILENT": "1"})
+
+        assert pod_file.read_text() == newer, (
+            "THE POD'S BYTES WERE REPLACED by a push whose pre-flight answered "
+            "nothing — silence was read as 'nothing differs'."
+        )
+        assert r.returncode == 9, f"{r.stdout}\n{r.stderr}"
+        assert "COULD NOT COMPARE" in r.stderr, r.stderr
+
+    def test_the_preflight_counts_are_printed_on_the_SUCCESS_path_too(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """A number printed only in the failure branch cannot be read as
+        evidence on a run that passed — the silent-zero rule this file already
+        states for `staged_scopes`, applied to the guard itself."""
+        env, dest = fake_cluster
+        r = self._push(store, tmp_path, env)
+        assert r.returncode == 0, f"{r.stdout}\n{r.stderr}"
+        assert "seed: PRE-FLIGHT staged=" in r.stdout, (
+            f"the pre-flight said nothing on a clean run: {r.stdout}"
+        )
+        assert "answered=" in r.stdout and "present_on_pod=" in r.stdout, r.stdout
+
+
+class TestTheSeedPreFlightJoinIsLocaleSafe:
+    """🔴 `LC_ALL=C` ON THE `join`, GUARDED — the mutant SURVIVED all 40 seed tests.
+
+    GNU `join` order-checks in the AMBIENT locale, so C-sorted input is "not
+    sorted" to a join running under en_US.UTF-8 — which is this host. MEASURED:
+    it both MISSES the differing pair and exits 1, which `set -euo pipefail`
+    turns into a run with no verdict at all.
+
+    It needs two things at once, which is why the existing UTF-8 test could not
+    reach it: an UNPAIRABLE line (GNU join arms the order check only after one)
+    AND an adjacency where C and locale order disagree — `<scope>/README.md`
+    beside a lowercase sibling, which the real store is full of."""
+
+    def test_a_differing_entry_is_still_caught_under_a_UTF8_locale(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        env, dest = fake_cluster
+        d = dest / SCOPE; d.mkdir(parents=True, exist_ok=True)
+        # the adjacency that inverts between C and en_US
+        (d / "README.md").write_text("---\nservice: readme\n---\n")
+        # the DIFFERING entry the guard must still refuse
+        pod_alpha = d / "thing-alpha.md"
+        pod_alpha.write_text("---\nservice: thing-alpha\n---\nPOD NEWER\n")
+        # an unpairable line on the pod arms GNU join's order check
+        other = dest / "a-scope-only-the-laptop-has"; other.mkdir(exist_ok=True)
+        (other / "from-the-other-host.md").write_text("---\nservice: x\n---\n")
+
+        r = run_seed(
+            "--store", str(store), "--stage", str(tmp_path / "stage"),
+            "--push", "ns/app",
+            env={**env, "LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"},
+        )
+
+        assert r.returncode == 8, (
+            "under a UTF-8 ambient locale the join either missed the differing "
+            f"pair or died on an order check: rc={r.returncode}\n{r.stdout}\n{r.stderr}"
+        )
+        assert f"{SCOPE}/thing-alpha.md" in r.stderr, r.stderr

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -18488,3 +18488,117 @@ class TestTheSitingRULESThemselvesArePinned:
             "default 64Mi /dev/shm, so every store would fall back to disk and this "
             "module would be inert with the suite green"
         )
+
+
+class TestSeedRefusesToOverwriteANewerPodEntry:
+    """🔴 THE CUTOVER INVERTED THE AUTHORITY AND `seed.sh` WAS NEVER UPDATED.
+
+    The extract "adds and overwrites but never deletes" — safe while the LOCAL
+    store was authoritative, silent data loss now that the pod is. A shared entry
+    whose pod copy has moved on (a bullet appended via `cairn append`, an `OPEN:`
+    rewritten `RESOLVED <sha>:`) was replaced by this host's older copy, and the
+    verdict still printed OK because the NAME landed.
+
+    MEASURED 2026-09-02/03 on the real store: of 25 bullets present locally but
+    not on the pod, FIVE were the pod being NEWER — two of them `OPEN:` ->
+    `RESOLVED` closures with ~20 lines of later corrections. A re-seed would have
+    reverted all five and reported success.
+
+    🔴 The guard is a PRE-FLIGHT. The pre-existing containment check runs after
+    the extract, so by the time it can speak the bytes are gone.
+    """
+
+    def _push(self, store: Path, tmp_path: Path, env, *extra):
+        return run_seed(
+            "--store", str(store),
+            "--stage", str(tmp_path / "stage"),
+            "--push", "ns/app",
+            *extra,
+            env=env,
+        )
+
+    @staticmethod
+    def _pod_copy(dest: Path, body: str) -> Path:
+        """The pod's copy of the SAME entry the store fixture ships."""
+        d = dest / SCOPE
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / "thing-alpha.md"
+        p.write_text(body)
+        return p
+
+    def test_a_pod_copy_with_DIFFERENT_bytes_refuses_and_pushes_NOTHING(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 THE REGRESSION. Red before this change: the push overwrote the pod
+        and exited 0 with `seed: OK`.
+
+        The assertion that matters is not the exit code — it is that the pod's
+        bytes are UNTOUCHED. A guard that refused after clobbering would satisfy
+        an exit-code-only test while losing exactly the content it exists to
+        protect."""
+        env, dest = fake_cluster
+        newer = "---\nservice: thing-alpha\n---\n\n## Nuance / work-history\n- 2026-09-03: RESOLVED abc1234: closed on the pod.\n"
+        pod_file = self._pod_copy(dest, newer)
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 8, (
+            f"expected exit 8 (refused), got {r.returncode}.\n{r.stdout}\n{r.stderr}"
+        )
+        assert pod_file.read_text() == newer, (
+            "THE POD'S BYTES WERE REPLACED. The guard must run BEFORE the extract; "
+            "refusing afterwards is the data loss it exists to prevent."
+        )
+        assert "NOTHING WAS PUSHED" in r.stderr, r.stderr
+        assert f"{SCOPE}/thing-alpha.md" in r.stderr, (
+            "the refusal must NAME the entries it protected, or the operator "
+            f"cannot reconcile them: {r.stderr}"
+        )
+
+    def test_IDENTICAL_bytes_on_the_pod_are_not_a_clobber(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """The discriminator. A guard that fired on mere PRESENCE would refuse
+        every ordinary re-seed and be turned off within a day."""
+        env, dest = fake_cluster
+        same = (store / SCOPE / "thing-alpha.md").read_text()
+        self._pod_copy(dest, same)
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 0, (
+            f"an identical pod copy is not an overwrite: {r.stdout}\n{r.stderr}"
+        )
+        assert "seed: OK" in r.stdout
+
+    def test_an_entry_ABSENT_from_the_pod_is_a_pure_addition(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """The other half of the discriminator, and the case that makes seeding
+        useful at all. `test -f` on the pod yields the intersection for free: a
+        staged path the pod does not have cannot clobber anything."""
+        env, dest = fake_cluster
+        assert not (dest / SCOPE / "thing-alpha.md").exists()
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 0, f"{r.stdout}\n{r.stderr}"
+        assert (dest / SCOPE / "thing-alpha.md").exists(), "the addition did not land"
+
+    def test_allow_overwrite_proceeds_AND_names_what_it_replaced(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """The override is deliberate, not a silent bypass: it still prints which
+        entries it replaced, because 'I chose this' and 'I did not notice' must
+        not look the same in a log read afterwards."""
+        env, dest = fake_cluster
+        pod_file = self._pod_copy(dest, "---\nservice: thing-alpha\n---\nDIFFERENT\n")
+
+        r = self._push(store, tmp_path, env, "--allow-overwrite")
+
+        assert r.returncode == 0, f"{r.stdout}\n{r.stderr}"
+        assert "WARNING --allow-overwrite" in r.stdout, r.stdout
+        assert f"{SCOPE}/thing-alpha.md" in r.stdout, r.stdout
+        assert pod_file.read_text() == (store / SCOPE / "thing-alpha.md").read_text(), (
+            "--allow-overwrite was given, so this host's copy must actually win"
+        )

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -18542,12 +18542,17 @@ class TestSeedRefusesToOverwriteANewerPodEntry:
 
         r = self._push(store, tmp_path, env)
 
-        assert r.returncode == 8, (
-            f"expected exit 8 (refused), got {r.returncode}.\n{r.stdout}\n{r.stderr}"
-        )
+        # 🔴 THE BYTES ASSERTION COMES FIRST, DELIBERATELY. Asserting the exit
+        # code first makes the red-at-base run fail on the CODE (0 vs 8) and
+        # never reach the bytes — so the matrix would prove the flag is absent,
+        # not that the content was destroyed. Ordered this way, red at base is
+        # red because THE POD WAS CLOBBERED, which is the defect.
         assert pod_file.read_text() == newer, (
             "THE POD'S BYTES WERE REPLACED. The guard must run BEFORE the extract; "
             "refusing afterwards is the data loss it exists to prevent."
+        )
+        assert r.returncode == 8, (
+            f"expected exit 8 (refused), got {r.returncode}.\n{r.stdout}\n{r.stderr}"
         )
         assert "NOTHING WAS PUSHED" in r.stderr, r.stderr
         assert f"{SCOPE}/thing-alpha.md" in r.stderr, (
@@ -18588,7 +18593,11 @@ class TestSeedRefusesToOverwriteANewerPodEntry:
     def test_allow_overwrite_proceeds_AND_names_what_it_replaced(
         self, store: Path, tmp_path: Path, fake_cluster
     ):
-        """The override is deliberate, not a silent bypass: it still prints which
+        """⚠ NOT REGRESSION COVERAGE. This is red at base only because
+        `--allow-overwrite` does not exist there ("unknown argument", exit 2) —
+        which pins that the flag is new, not that any defect was fixed.
+
+        The override is deliberate, not a silent bypass: it still prints which
         entries it replaced, because 'I chose this' and 'I did not notice' must
         not look the same in a log read afterwards."""
         env, dest = fake_cluster

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -18724,3 +18724,94 @@ class TestTheSeedPreFlightJoinIsLocaleSafe:
             f"stops both: rc={r.returncode}\n{r.stdout}\n{r.stderr}"
         )
         assert f"{SCOPE}/backblaze.md" in r.stderr, r.stderr
+
+
+class TestTheSeedPreFlightSurvivesAwkwardPaths:
+    """🔴 A ROUND-1 CLAIM SHIPPED UNVERIFIED, AND BOTH HALVES WERE WRONG.
+
+    It said `-I{}` made a path with a space or a quote survive. Measured by the
+    round-2 audit:
+
+    * QUOTE — `-I{}` stops WORD-SPLITTING but leaves xargs's INPUT QUOTE PARSING
+      on, so `sc/it's.md` still died `xargs: unmatched single quote`, rc 1, with
+      no `seed:` line — byte-identical to base. Only `-d` (or `-0`) disables it.
+    * SPACE — it stopped aborting and started LYING. `awk '{print $2" "$1}'`
+      rebuilt the line from FIELDS, truncating the key at the first blank, so two
+      BYTE-IDENTICAL entries collapsed to one key, the join degenerated into a
+      cross-product, and the guard refused with `differing=2`, naming a path that
+      does not exist. A confident false refusal whose only offered remedy is
+      `--allow-overwrite` is worse than the crash it replaced.
+
+    Neither had a test, which is how the claim survived being written down. The
+    real store's entry names are service slugs, so this is latent — but `seed.sh`
+    reads a directory an operator or agent writes into freely.
+    """
+
+    def _push(self, store: Path, tmp_path: Path, env, *extra):
+        return run_seed(
+            "--store", str(store), "--stage", str(tmp_path / "stage"),
+            "--push", "ns/app", *extra, env=env,
+        )
+
+    def test_a_path_with_a_SPACE_that_is_IDENTICAL_is_not_reported_as_differing(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 THE FALSE-REFUSAL REGRESSION. Two identical entries whose names
+        share a first word: before the tab-separated key these collapsed to one
+        join key and were both reported as differing."""
+        env, dest = fake_cluster
+        a = _entry("two-words", SCOPE)
+        b = _entry("two-other", SCOPE)
+        (store / SCOPE / "two words.md").write_text(a)
+        (store / SCOPE / "two other.md").write_text(b)
+        d = dest / SCOPE; d.mkdir(parents=True, exist_ok=True)
+        (d / "two words.md").write_text(a)      # byte-identical
+        (d / "two other.md").write_text(b)      # byte-identical
+
+        r = self._push(store, tmp_path, env)
+
+        assert "differing=0" in r.stdout, (
+            "identical entries were reported as differing — the join key was "
+            f"truncated at the first blank:\n{r.stdout}\n{r.stderr}"
+        )
+        assert r.returncode == 0, f"{r.stdout}\n{r.stderr}"
+
+    def test_a_path_with_a_SPACE_that_DIFFERS_is_still_caught_and_named_in_full(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """The other direction: the fix must not buy a clean `differing=0` by
+        losing the ability to see a real difference. The refusal must also name
+        the WHOLE path — a truncated name is not actionable."""
+        env, dest = fake_cluster
+        (store / SCOPE / "two words.md").write_text(_entry("two-words", SCOPE))
+        d = dest / SCOPE; d.mkdir(parents=True, exist_ok=True)
+        (d / "two words.md").write_text("---\nservice: two-words\n---\nPOD NEWER\n")
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 8, f"{r.stdout}\n{r.stderr}"
+        assert f"{SCOPE}/two words.md" in r.stderr, (
+            f"the refusal named a truncated path, which nobody can act on: {r.stderr}"
+        )
+
+    def test_a_path_with_a_QUOTE_does_not_abort_the_run(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 Red before `-d '\\n'`: `xargs: unmatched single quote`, rc 1, and NOT
+        one `seed:` line — the operator gets a bare failure with no diagnostic,
+        which is the shape this guard's comments claim to have removed."""
+        env, dest = fake_cluster
+        body = _entry("its", SCOPE)
+        (store / SCOPE / "it's.md").write_text(body)
+        d = dest / SCOPE; d.mkdir(parents=True, exist_ok=True)
+        (d / "it's.md").write_text(body)        # identical: must NOT refuse
+
+        r = self._push(store, tmp_path, env)
+
+        assert "unmatched single quote" not in r.stderr, (
+            f"xargs still parses quotes in its INPUT: {r.stderr}"
+        )
+        assert "seed: PRE-FLIGHT" in r.stdout, (
+            f"the run died before the pre-flight could say anything: {r.stdout}\n{r.stderr}"
+        )
+        assert r.returncode == 0, f"{r.stdout}\n{r.stderr}"

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -18923,6 +18923,29 @@ class TestTheSeedNameCheckRejectsPathsItCannotCompareSafely:
         )
         assert (dest / SCOPE / "dl-router.md").exists()
 
+    def test_an_entry_named_exactly_dot_md_is_refused(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 THE FOURTH RULE, which arrived as a SIDE EFFECT of the `\\.md$`
+        anchor and which nothing stated. `find -name '*.md'` DOES emit
+        `<scope>/.md` (verified), and the anchor needs a non-empty stem before
+        it — so the base accepted this name and HEAD refuses it. Pinned because
+        an undocumented refusal class is how an operator ends up reading a
+        message that describes none of the rules they broke."""
+        env, dest = fake_cluster
+        (store / SCOPE / ".md").write_text(_entry("dotmd", SCOPE))
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 10, f"{r.stdout}\n{r.stderr}"
+        assert f"{SCOPE}/.md" in r.stderr, r.stderr
+        # the message must actually describe THIS rule, not only the other three
+        assert "stem" in r.stderr, (
+            "the refusal does not mention the empty-stem rule, so the operator "
+            f"is told they broke a rule they did not break: {r.stderr}"
+        )
+        assert not (dest / SCOPE).exists() or not any((dest / SCOPE).iterdir())
+
     def test_the_refusal_names_the_offending_path_in_full(
         self, store: Path, tmp_path: Path, fake_cluster
     ):
@@ -18986,7 +19009,7 @@ class TestTheSeedProbeAnswersSurviveTheRealPodShell:
     # 🔴 READ THE COMMAND OUT OF `seed.sh`, NEVER RESTATE IT. The first version
     # of this class hardcoded a COPY of the probe, so it proved that `printf`
     # behaves under dash — true no matter what the script does. MEASURED: with
-    # the copy, reverting `seed.sh` to `echo` left all 5 tests GREEN. Extracting
+    # the copy, reverting `seed.sh` to `echo` left every test in this class GREEN. Extracting
     # the real inner script is what makes the mutant die.
     @staticmethod
     def _probe_script() -> str:
@@ -19047,6 +19070,25 @@ class TestTheSeedProbeAnswersSurviveTheRealPodShell:
         raw = re.search(r"-I\{\} sh -c '(.+?)' _ \{\}", SEED_PATH.read_text(), re.S)
         assert raw and ('\\"' in raw.group(1) or "\\\\" in raw.group(1)), (
             "the raw source carries no escapes, so this test proves nothing"
+        )
+
+    @pytest.mark.parametrize(
+        "name",
+        ["sc/tab\\there.md", "sc/new\\nline.md", "sc/cut\\chere.md", "sc/plain.md"],
+    )
+    def test_dash_and_bash_produce_BYTE_IDENTICAL_answers(self, name):
+        dash = _require_dash()
+
+        def run(shell):
+            return subprocess.run(
+                [shell, "-c", self._probe_script(), "_", name],
+                capture_output=True, text=True, timeout=30,
+            ).stdout
+
+        assert run(dash) == run("bash"), (
+            f"the pod's shell and the test harness's shell disagree on {name!r} — "
+            "this is the silent-clobber route: the two sides' join keys diverge "
+            "and a DIFFERING pod entry reads as a pure addition"
         )
 
     def test_the_UNREADABLE_arm_is_exercised_too(self, tmp_path: Path):

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -18726,25 +18726,26 @@ class TestTheSeedPreFlightJoinIsLocaleSafe:
         assert f"{SCOPE}/backblaze.md" in r.stderr, r.stderr
 
 
-class TestTheSeedPreFlightSurvivesAwkwardPaths:
-    """🔴 A ROUND-1 CLAIM SHIPPED UNVERIFIED, AND BOTH HALVES WERE WRONG.
+class TestTheSeedNameCheckRejectsPathsItCannotCompareSafely:
+    """🔴 THREE ROUNDS EACH FIXED ONE DELIMITER AND RE-BROKE THE NEXT.
 
-    It said `-I{}` made a path with a space or a quote survive. Measured by the
-    round-2 audit:
+    Round 1 `xargs` bare (a space split the args, rc 123); round 2 `-I{}` (a
+    space TRUNCATED the join key at 0x20); round 3 `-d '\\n'` + a TAB-separated
+    key (a TAB truncates it at 0x09). Each fix was correct about the case it
+    named and moved the boundary rather than removing it.
 
-    * QUOTE — `-I{}` stops WORD-SPLITTING but leaves xargs's INPUT QUOTE PARSING
-      on, so `sc/it's.md` still died `xargs: unmatched single quote`, rc 1, with
-      no `seed:` line — byte-identical to base. Only `-d` (or `-0`) disables it.
-    * SPACE — it stopped aborting and started LYING. `awk '{print $2" "$1}'`
-      rebuilt the line from FIELDS, truncating the key at the first blank, so two
-      BYTE-IDENTICAL entries collapsed to one key, the join degenerated into a
-      cross-product, and the guard refused with `differing=2`, naming a path that
-      does not exist. A confident false refusal whose only offered remedy is
-      `--allow-overwrite` is worse than the crash it replaced.
+    The dangerous shape is not the false refusal — that is loud and fail-safe —
+    it is the SILENT one: the pod's `/bin/sh` is dash, whose `echo` turns the two
+    characters `\\t` in a NAME into a real TAB on the pod side only, while every
+    test here runs the probe under bash. The two sides' keys then diverge, the
+    row drops out of the join, and an entry the pod holds with DIFFERENT bytes is
+    pushed over as though it were a pure addition.
 
-    Neither had a test, which is how the claim survived being written down. The
-    real store's entry names are service slugs, so this is latent — but `seed.sh`
-    reads a directory an operator or agent writes into freely.
+    So the domain is bounded instead of the parser hardened. MEASURED 2026-09-05
+    across both live stores: 348 entry files, 0 outside `[A-Za-z0-9._/-]`. These
+    tests pin BOTH directions — that ordinary slugs still push (or the guard
+    would be switched off within a day), and that each awkward shape is refused
+    with nothing pushed.
     """
 
     def _push(self, store: Path, tmp_path: Path, env, *extra):
@@ -18753,65 +18754,257 @@ class TestTheSeedPreFlightSurvivesAwkwardPaths:
             "--push", "ns/app", *extra, env=env,
         )
 
-    def test_a_path_with_a_SPACE_that_is_IDENTICAL_is_not_reported_as_differing(
+    # ---- the guard must NOT over-fire: ordinary names still push -------------
+
+    def test_ordinary_slug_names_are_not_rejected_and_the_push_proceeds(
         self, store: Path, tmp_path: Path, fake_cluster
     ):
-        """🔴 THE FALSE-REFUSAL REGRESSION. Two identical entries whose names
-        share a first word: before the tab-separated key these collapsed to one
-        join key and were both reported as differing."""
+        """🔴 THE OVER-FIRING CONTROL. A name check that refused real entries
+        would be disabled immediately, so this is the assertion that makes the
+        rest of the class meaningful. It also pins `rejected=0` as a number
+        rather than a substring: a check that walked NOTHING also prints 0."""
         env, dest = fake_cluster
-        a = _entry("two-words", SCOPE)
-        b = _entry("two-other", SCOPE)
-        (store / SCOPE / "two words.md").write_text(a)
-        (store / SCOPE / "two other.md").write_text(b)
-        d = dest / SCOPE; d.mkdir(parents=True, exist_ok=True)
-        (d / "two words.md").write_text(a)      # byte-identical
-        (d / "two other.md").write_text(b)      # byte-identical
+        for slug in ("dl-router", "tests", "subsystem_store.api", "a.b-c_d"):
+            (store / SCOPE / f"{slug}.md").write_text(_entry(slug, SCOPE))
 
         r = self._push(store, tmp_path, env)
 
-        assert "differing=0" in r.stdout, (
-            "identical entries were reported as differing — the join key was "
-            f"truncated at the first blank:\n{r.stdout}\n{r.stderr}"
+        m = re.search(r"seed: NAME-CHECK staged=(\d+) rejected=(\d+)", r.stdout)
+        assert m, f"the name check printed no line at all:\n{r.stdout}"
+        staged, rejected = int(m.group(1)), int(m.group(2))
+        assert rejected == 0, (
+            f"ordinary slugs were rejected: {r.stdout}\n{r.stderr}"
+        )
+        # 🔴 POSITIVE CONTROL ON THE COUNT ITSELF. `rejected=0` is also what a
+        # check that walked NOTHING prints, so pin that it saw the entries — the
+        # four written here plus whatever the fixture provides.
+        assert staged >= 4, (
+            f"the name check reported {staged} staged entries but 4 were written "
+            f"here alone — it did not see the list:\n{r.stdout}"
         )
         assert r.returncode == 0, f"{r.stdout}\n{r.stderr}"
+        assert (dest / SCOPE / "dl-router.md").exists(), "the push did not land"
 
-    def test_a_path_with_a_SPACE_that_DIFFERS_is_still_caught_and_named_in_full(
-        self, store: Path, tmp_path: Path, fake_cluster
+    # ---- each awkward shape is refused, and NOTHING is pushed ---------------
+
+    @pytest.mark.parametrize(
+        "name,label",
+        [
+            ("two words.md", "SPACE — truncated the key at 0x20 in round 2"),
+            ("ta\tbbed.md", "TAB — truncates it at 0x09 after round 3's fix"),
+            ("it's.md", "QUOTE — aborted xargs rc 1 with no diagnostic"),
+            ("back\\slash.md", "BACKSLASH — GNU sha256sum escapes the line, the "
+                               "hand-written answer does not, so the keys diverge"),
+            ("dash-eats\\there.md", "the two characters \\t — dash's echo emits a "
+                                    "REAL TAB, bash a literal; the SILENT case"),
+        ],
+    )
+    def test_an_unsafe_name_is_refused_with_nothing_pushed(
+        self, store: Path, tmp_path: Path, fake_cluster, name, label
     ):
-        """The other direction: the fix must not buy a clean `differing=0` by
-        losing the ability to see a real difference. The refusal must also name
-        the WHOLE path — a truncated name is not actionable."""
         env, dest = fake_cluster
-        (store / SCOPE / "two words.md").write_text(_entry("two-words", SCOPE))
-        d = dest / SCOPE; d.mkdir(parents=True, exist_ok=True)
-        (d / "two words.md").write_text("---\nservice: two-words\n---\nPOD NEWER\n")
+        (store / SCOPE / name).write_text(_entry("odd", SCOPE))
 
         r = self._push(store, tmp_path, env)
 
-        assert r.returncode == 8, f"{r.stdout}\n{r.stderr}"
+        assert r.returncode == 10, f"{label}\n{r.stdout}\n{r.stderr}"
+        m = re.search(r"seed: NAME-CHECK staged=(\d+) rejected=(\d+)", r.stdout)
+        assert m, f"{label}: the name check printed no line:\n{r.stdout}"
+        assert int(m.group(2)) == 1, (
+            f"{label}: expected exactly the one bad name to be rejected, got "
+            f"{m.group(2)}\n{r.stdout}"
+        )
+        assert int(m.group(1)) > 1, (
+            f"{label}: only the bad entry was staged, so this test would pass "
+            f"even against a check that rejects everything:\n{r.stdout}"
+        )
+        assert "NOTHING WAS PUSHED" in r.stderr, f"{label}\n{r.stderr}"
+        # 🔴 THE BYTES, NOT JUST THE EXIT CODE. Asserting rc alone would pass for
+        # a guard that refused AFTER the tar — which is the defect the pre-flight
+        # was built to fix, and it would look identical from the exit code.
+        assert not (dest / SCOPE).exists() or not any((dest / SCOPE).iterdir()), (
+            f"{label}: the refusal happened AFTER something reached the pod: "
+            f"{list((dest / SCOPE).iterdir())}"
+        )
+
+    def test_the_refusal_names_the_offending_path_in_full(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """A truncated name is not actionable — the whole point of the class of
+        bugs this replaces was refusals naming paths that do not exist."""
+        env, _ = fake_cluster
+        (store / SCOPE / "two words.md").write_text(_entry("odd", SCOPE))
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 10, f"{r.stdout}\n{r.stderr}"
         assert f"{SCOPE}/two words.md" in r.stderr, (
-            f"the refusal named a truncated path, which nobody can act on: {r.stderr}"
+            f"the refusal did not name the full path: {r.stderr}"
         )
 
-    def test_a_path_with_a_QUOTE_does_not_abort_the_run(
+    def test_the_override_flag_does_NOT_bypass_the_name_check(
         self, store: Path, tmp_path: Path, fake_cluster
     ):
-        """🔴 Red before `-d '\\n'`: `xargs: unmatched single quote`, rc 1, and NOT
-        one `seed:` line — the operator gets a bare failure with no diagnostic,
-        which is the shape this guard's comments claim to have removed."""
+        """🔴 `--allow-overwrite` is an override for the BYTES question (exit 8),
+        where the operator can genuinely know better. It must not reach this one:
+        an unsafe name means the comparison cannot be TRUSTED, so proceeding
+        would push under exactly the ambiguity the flag pretends to resolve."""
         env, dest = fake_cluster
-        body = _entry("its", SCOPE)
-        (store / SCOPE / "it's.md").write_text(body)
-        d = dest / SCOPE; d.mkdir(parents=True, exist_ok=True)
-        (d / "it's.md").write_text(body)        # identical: must NOT refuse
+        (store / SCOPE / "two words.md").write_text(_entry("odd", SCOPE))
 
-        r = self._push(store, tmp_path, env)
+        r = self._push(store, tmp_path, env, "--allow-overwrite")
 
-        assert "unmatched single quote" not in r.stderr, (
-            f"xargs still parses quotes in its INPUT: {r.stderr}"
+        assert r.returncode == 10, (
+            f"--allow-overwrite bypassed the name check:\n{r.stdout}\n{r.stderr}"
         )
-        assert "seed: PRE-FLIGHT" in r.stdout, (
-            f"the run died before the pre-flight could say anything: {r.stdout}\n{r.stderr}"
+        assert not (dest / SCOPE).exists() or not any((dest / SCOPE).iterdir())
+
+
+def _require_dash() -> str:
+    """🔴 FAIL, NEVER SKIP. The pod's shell is dash and the harness's is bash;
+    a tier without dash is structurally blind to every defect that lives in the
+    difference, and a skip there reports safety it never measured. MEASURED
+    2026-09-05: all 5 tests in this class skipped silently before `dash` was
+    added to `REQUIRED_TOOLS` and `flake.nix`'s `gateTools`.
+    """
+    dash = shutil.which("dash")
+    assert dash is not None, (
+        "dash is not on PATH. It is in REQUIRED_TOOLS and gateTools precisely "
+        "so this cannot be skipped — the pod runs dash, the fake kubectl runs "
+        "bash, and the gap between them is a SILENT clobber."
+    )
+    return dash
+
+
+class TestTheSeedProbeAnswersSurviveTheRealPodShell:
+    """🔴 THE HARNESS RUNS THE POD'S COMMAND UNDER BASH; THE POD IS DASH.
+
+    `Dockerfile: FROM python:3.12-slim` -> Debian -> `/bin/sh` is dash, and
+    dash's `echo` INTERPRETS backslash escapes while bash's does not. Every test
+    in this file drives a fake `kubectl` that runs the probe locally, so the
+    suite is structurally blind to the difference. These tests exercise the two
+    hand-written answer lines under `dash` DIRECTLY, which is the only way to see
+    it without a cluster.
+    """
+
+    # 🔴 READ THE COMMAND OUT OF `seed.sh`, NEVER RESTATE IT. The first version
+    # of this class hardcoded a COPY of the probe, so it proved that `printf`
+    # behaves under dash — true no matter what the script does. MEASURED: with
+    # the copy, reverting `seed.sh` to `echo` left all 5 tests GREEN. Extracting
+    # the real inner script is what makes the mutant die.
+    @staticmethod
+    def _probe_script() -> str:
+        src = SEED_PATH.read_text()
+        m = re.search(r"-I\{\} sh -c '(.+?)' _ \{\}", src, re.S)
+        assert m, (
+            "could not find the pod probe's inner `sh -c` in seed.sh — this test "
+            "reads the real command, so a shape change must fail loudly rather "
+            "than silently test nothing"
         )
-        assert r.returncode == 0, f"{r.stdout}\n{r.stderr}"
+        # the inner script is embedded in a double-quoted shell string, so its
+        # own quotes are backslash-escaped in the source
+        return m.group(1).replace('\\"', '"').replace("\\$", "$")
+
+    def test_the_probe_command_really_is_the_one_under_test(self):
+        """POSITIVE CONTROL on the extractor itself: an empty or wrong match
+        would make every test below vacuous."""
+        script = self._probe_script()
+        assert "ABSENT" in script and "UNREADABLE" in script, script
+        assert "sha256sum" in script, script
+
+    @pytest.mark.parametrize(
+        "name",
+        ["sc/tab\\there.md", "sc/new\\nline.md", "sc/cut\\chere.md", "sc/plain.md"],
+    )
+    def test_dash_and_bash_produce_BYTE_IDENTICAL_answers(self, name):
+        dash = _require_dash()
+
+        def run(shell):
+            return subprocess.run(
+                [shell, "-c", self._probe_script(), "_", name],
+                capture_output=True, text=True, timeout=30,
+            ).stdout
+
+        assert run(dash) == run("bash"), (
+            f"the pod's shell and the test harness's shell disagree on {name!r} — "
+            "this is the silent-clobber route: the two sides' join keys diverge "
+            "and a DIFFERING pod entry reads as a pure addition"
+        )
+
+    def test_the_control_shows_echo_WOULD_have_disagreed(self):
+        """🔴 POSITIVE CONTROL. Without it, the test above is indistinguishable
+        from one whose shells cannot disagree about anything — it would pass just
+        as happily against a name with no escapes in it."""
+        dash = _require_dash()
+        broken = 'echo "ABSENT  $1"'
+        name = "sc/tab\\there.md"
+
+        def run(shell):
+            return subprocess.run(
+                [shell, "-c", broken, "_", name],
+                capture_output=True, text=True, timeout=30,
+            ).stdout
+
+        assert run(dash) != run("bash"), (
+            "the control did not reproduce the `echo` asymmetry, so this test "
+            "file cannot see the defect it claims to guard"
+        )
+
+
+class TestSeedHelpIsCompleteAndCannotDrift:
+    """🔴 THE `--help` CLAIM HAS NOW BEEN WRONG TWICE, WITH NO TEST BOTH TIMES.
+
+    First `sed -n '2,26p'` — a line range over a header that grows, so additions
+    pushed the window into the middle of a clause and the Usage block had ALWAYS
+    sat below it. Then `awk … {exit}` on the first non-comment line — which a
+    BLANK line is, so one blank inserted for readability cut `--help` from 61
+    lines to 31 and took `--allow-overwrite` with it (MEASURED 2026-09-05).
+    """
+
+    def test_help_reaches_the_usage_block_and_ends_on_a_terminator(self):
+        r = run_seed("--help")
+
+        assert r.returncode == 0, r.stderr
+        assert "--allow-overwrite" in r.stdout, (
+            "`--help` does not reach the Usage block — the only place an "
+            f"operator looks:\n{r.stdout}"
+        )
+        assert "Usage:" in r.stdout, r.stdout
+        last = r.stdout.rstrip().splitlines()[-1].rstrip()
+        assert last.endswith((".", ":", "!")), (
+            f"`--help` ends mid-sentence on: {last!r}"
+        )
+
+    def test_help_documents_every_exit_code_the_script_can_refuse_with(self):
+        """A refusal code an operator cannot look up is a bare number."""
+        r = run_seed("--help")
+        for code in ("8", "9", "10"):
+            assert f"\n  {code} " in r.stdout or f"\n  {code}  " in r.stdout, (
+                f"exit {code} is not documented in --help:\n{r.stdout}"
+            )
+
+    def test_a_BLANK_LINE_in_the_header_does_not_truncate_help(self, tmp_path: Path):
+        """🔴 THE REGRESSION, as a mutation rather than an assertion about the
+        current text: inject a blank comment-free line into the header and the
+        output must not shrink."""
+        src = SEED_PATH.read_text().splitlines(keepends=True)
+        cut = next(i for i, l in enumerate(src) if l.startswith("# Usage:"))
+        mutated = tmp_path / "seed-with-blank.sh"
+        mutated.write_text("".join(src[:cut]) + "\n" + "".join(src[cut:]))
+
+        def help_of(path):
+            return subprocess.run(
+                ["bash", str(path), "--help"],
+                capture_output=True, text=True, timeout=120,
+            ).stdout
+
+        original, injected = help_of(SEED_PATH), help_of(mutated)
+
+        assert "--allow-overwrite" in injected, (
+            "one blank line in the header truncated `--help` and took the Usage "
+            f"block with it:\n{injected}"
+        )
+        assert len(injected.splitlines()) >= len(original.splitlines()), (
+            f"help shrank from {len(original.splitlines())} to "
+            f"{len(injected.splitlines())} lines"
+        )

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -18827,6 +18827,77 @@ class TestTheSeedNameCheckRejectsPathsItCannotCompareSafely:
             f"{list((dest / SCOPE).iterdir())}"
         )
 
+    def test_a_NEWLINE_in_an_entry_name_is_refused_and_nothing_is_pushed(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 THE HOLE THE FIRST NAME-CHECK HAD, and it was the silent kind.
+        `$staged_list` is newline-delimited, so `na<NL>me.md` is written as TWO
+        lines and EACH HALF matches the allowed class — `rejected=0`. MEASURED
+        against that guard, with decoys making both halves resolve: the run
+        printed `rejected=0`, `differing=0`, `seed: OK`, rc 0, and REPLACED the
+        pod's newer copy. Caught now by matching the WHOLE shape `<scope>/<entry>.md`: a
+        filename cannot contain `/`, so the second half never has one."""
+        env, dest = fake_cluster
+        (store / SCOPE / "na\nme.md").write_text(_entry("odd", SCOPE))
+        # the decoys that made the silent version reachable — both halves of the
+        # split resolve to real files, so nothing downstream errors
+        (store / SCOPE / "na").mkdir(exist_ok=True)
+        (store / "me.md").write_text("x")
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 10, (
+            f"a newline in an entry name was not refused:\n{r.stdout}\n{r.stderr}"
+        )
+        assert "NOTHING WAS PUSHED" in r.stderr, r.stderr
+        # 🔴 NAME A HALF OF THE SPLIT. The whole defect was that both halves
+        # looked legitimate, so the refusal must demonstrably have SEEN one.
+        assert f"{SCOPE}/na" in r.stderr or "me.md" in r.stderr, (
+            f"the refusal did not name either half of the split: {r.stderr}"
+        )
+        assert not (dest / SCOPE).exists() or not any((dest / SCOPE).iterdir()), (
+            "bytes reached the pod despite the refusal"
+        )
+
+    def test_a_component_STARTING_with_a_dash_is_refused(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 `-` IS INSIDE THE ALLOWED CLASS AND IS THE OPTION CHARACTER. A
+        scope named `-dashscope` passed the first name check and then reached
+        `sha256sum` as an option: `invalid option -- 'd'`, rc 123, and NOT one
+        `seed:` line — round 1's exact failure shape, re-reached through the
+        guard that claimed to have removed the class."""
+        env, dest = fake_cluster
+        odd = store / "-dashscope"
+        odd.mkdir()
+        (odd / "thing.md").write_text(_entry("thing", "dashscope"))
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 10, (
+            f"a leading-dash scope was not refused (rc 123 = it reached "
+            f"sha256sum as an option):\n{r.stdout}\n{r.stderr}"
+        )
+        assert "-dashscope/thing.md" in r.stderr, r.stderr
+        assert not (dest / "-dashscope").exists()
+
+    def test_a_dash_INSIDE_a_name_is_still_allowed(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """The over-firing control for the rule above: `dl-router.md` is the
+        single most common shape in the real store. Rejecting an interior dash
+        would refuse most of it."""
+        env, dest = fake_cluster
+        (store / SCOPE / "dl-router.md").write_text(_entry("dl-router", SCOPE))
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 0, (
+            f"an interior dash was refused — this rule is about the FIRST "
+            f"character only:\n{r.stdout}\n{r.stderr}"
+        )
+        assert (dest / SCOPE / "dl-router.md").exists()
+
     def test_the_refusal_names_the_offending_path_in_full(
         self, store: Path, tmp_path: Path, fake_cluster
     ):
@@ -18903,7 +18974,21 @@ class TestTheSeedProbeAnswersSurviveTheRealPodShell:
         )
         # the inner script is embedded in a double-quoted shell string, so its
         # own quotes are backslash-escaped in the source
-        return m.group(1).replace('\\"', '"').replace("\\$", "$")
+        # 🔴 `\\\\` FIRST, THEN THE REST. The inner script is embedded in a
+        # DOUBLE-QUOTED shell string, so `\\"` -> `"`, `\\$` -> `$` and
+        # `\\\\` -> `\\`. Omitting the last one left the extracted text
+        # `printf "…%s\\\\n"` where the pod's `sh` actually receives
+        # `printf "…%s\\n"` — the outputs happen to agree because the shell
+        # collapses it again, so nothing measured was wrong, but the class
+        # docstring claims this IS the command and it was not.
+        inner = m.group(1)
+        out, i = [], 0
+        while i < len(inner):
+            if inner[i] == "\\" and i + 1 < len(inner) and inner[i + 1] in '\\"$':
+                out.append(inner[i + 1]); i += 2
+            else:
+                out.append(inner[i]); i += 1
+        return "".join(out)
 
     def test_the_probe_command_really_is_the_one_under_test(self):
         """POSITIVE CONTROL on the extractor itself: an empty or wrong match
@@ -18930,6 +19015,38 @@ class TestTheSeedProbeAnswersSurviveTheRealPodShell:
             "this is the silent-clobber route: the two sides' join keys diverge "
             "and a DIFFERING pod entry reads as a pure addition"
         )
+
+    def test_the_UNREADABLE_arm_is_exercised_too(self, tmp_path: Path):
+        """🔴 THE OTHER ARM. Every fixture above names a path that does NOT
+        exist, so `[ -f "$1" ]` is always false and only the ABSENT branch ever
+        ran — a mutant confined to the UNREADABLE `printf` SURVIVED the whole
+        suite (measured). This reaches it: the file exists, so `[ -f ]` is true,
+        and it is unreadable, so `sha256sum` fails into the fallback."""
+        dash = _require_dash()
+        d = tmp_path / "sc"; d.mkdir()
+        target = d / "unreadable\\there.md"
+        target.write_text("x")
+        target.chmod(0o000)
+        try:
+            name = str(target)
+
+            def run(shell):
+                return subprocess.run(
+                    [shell, "-c", self._probe_script(), "_", name],
+                    capture_output=True, text=True, timeout=30,
+                ).stdout
+
+            got_dash, got_bash = run(dash), run("bash")
+            assert "UNREADABLE" in got_dash, (
+                f"the UNREADABLE arm was never reached, so this test proves "
+                f"nothing about it: {got_dash!r}"
+            )
+            assert got_dash == got_bash, (
+                "the pod's shell and the harness's disagree on the UNREADABLE "
+                f"answer: {got_dash!r} vs {got_bash!r}"
+            )
+        finally:
+            target.chmod(0o644)
 
     def test_the_control_shows_echo_WOULD_have_disagreed(self):
         """🔴 POSITIVE CONTROL. Without it, the test above is indistinguishable

--- a/scripts/tests/test_subsystem_store_api.py
+++ b/scripts/tests/test_subsystem_store_api.py
@@ -18742,7 +18742,8 @@ class TestTheSeedNameCheckRejectsPathsItCannotCompareSafely:
     pushed over as though it were a pure addition.
 
     So the domain is bounded instead of the parser hardened. MEASURED 2026-09-05
-    across both live stores: 348 entry files, 0 outside `[A-Za-z0-9._/-]`. These
+    across both live stores: 373 entry files, 0 outside `[A-Za-z0-9._/-]` (the
+    count MOVES — it read 348 hours earlier the same day). These
     tests pin BOTH directions — that ordinary slugs still push (or the guard
     would be switched off within a day), and that each awkward shape is refused
     with nothing pushed.
@@ -18841,7 +18842,7 @@ class TestTheSeedNameCheckRejectsPathsItCannotCompareSafely:
         (store / SCOPE / "na\nme.md").write_text(_entry("odd", SCOPE))
         # the decoys that made the silent version reachable — both halves of the
         # split resolve to real files, so nothing downstream errors
-        (store / SCOPE / "na").mkdir(exist_ok=True)
+        (store / SCOPE / "na").write_text("decoy")   # a FILE: a directory makes it crash
         (store / "me.md").write_text("x")
 
         r = self._push(store, tmp_path, env)
@@ -18850,10 +18851,17 @@ class TestTheSeedNameCheckRejectsPathsItCannotCompareSafely:
             f"a newline in an entry name was not refused:\n{r.stdout}\n{r.stderr}"
         )
         assert "NOTHING WAS PUSHED" in r.stderr, r.stderr
-        # 🔴 NAME A HALF OF THE SPLIT. The whole defect was that both halves
-        # looked legitimate, so the refusal must demonstrably have SEEN one.
-        assert f"{SCOPE}/na" in r.stderr or "me.md" in r.stderr, (
-            f"the refusal did not name either half of the split: {r.stderr}"
+        # 🔴 NAME **BOTH** HALVES, and the scope-bearing one especially. An
+        # `or` here is what let me delete the `\.md$` anchor and see no test
+        # fail: without it the refusal says only `me.md` — not a path in the
+        # store, scope never mentioned — which is a correct refusal nobody can
+        # act on.
+        assert f"{SCOPE}/na" in r.stderr, (
+            "the refusal never named the SCOPE-bearing half, so the operator "
+            f"cannot tell which entry to rename: {r.stderr}"
+        )
+        assert "me.md" in r.stderr, (
+            f"the refusal did not name the trailing half either: {r.stderr}"
         )
         assert not (dest / SCOPE).exists() or not any((dest / SCOPE).iterdir()), (
             "bytes reached the pod despite the refusal"
@@ -18880,6 +18888,23 @@ class TestTheSeedNameCheckRejectsPathsItCannotCompareSafely:
         )
         assert "-dashscope/thing.md" in r.stderr, r.stderr
         assert not (dest / "-dashscope").exists()
+
+    def test_an_ENTRY_name_starting_with_a_dash_is_refused_too(
+        self, store: Path, tmp_path: Path, fake_cluster
+    ):
+        """🔴 THE SECOND COMPONENT'S HALF OF THE RULE, which had NO test — its
+        mutant survived the whole file. Unlike the scope case this one is
+        prophylactic (the argv word starts with the scope, so `sc/-x.md` can
+        never be read as an option); it is pinned so the rule stays ONE rule
+        instead of two with an asymmetry nobody remembers."""
+        env, dest = fake_cluster
+        (store / SCOPE / "-thing.md").write_text(_entry("thing", SCOPE))
+
+        r = self._push(store, tmp_path, env)
+
+        assert r.returncode == 10, f"{r.stdout}\n{r.stderr}"
+        assert f"{SCOPE}/-thing.md" in r.stderr, r.stderr
+        assert not (dest / SCOPE).exists() or not any((dest / SCOPE).iterdir())
 
     def test_a_dash_INSIDE_a_name_is_still_allowed(
         self, store: Path, tmp_path: Path, fake_cluster
@@ -18935,7 +18960,7 @@ def _require_dash() -> str:
     """🔴 FAIL, NEVER SKIP. The pod's shell is dash and the harness's is bash;
     a tier without dash is structurally blind to every defect that lives in the
     difference, and a skip there reports safety it never measured. MEASURED
-    2026-09-05: all 5 tests in this class skipped silently before `dash` was
+    2026-09-05: every test in this class skipped silently before `dash` was
     added to `REQUIRED_TOOLS` and `flake.nix`'s `gateTools`.
     """
     dash = shutil.which("dash")
@@ -18997,23 +19022,31 @@ class TestTheSeedProbeAnswersSurviveTheRealPodShell:
         assert "ABSENT" in script and "UNREADABLE" in script, script
         assert "sha256sum" in script, script
 
-    @pytest.mark.parametrize(
-        "name",
-        ["sc/tab\\there.md", "sc/new\\nline.md", "sc/cut\\chere.md", "sc/plain.md"],
-    )
-    def test_dash_and_bash_produce_BYTE_IDENTICAL_answers(self, name):
-        dash = _require_dash()
+    def test_the_extractor_LEAVES_NO_ESCAPES_BEHIND(self):
+        """🔴 GROUND TRUTH ON THE UNESCAPING, not substrings. The control above
+        is a SPELLED guard — three words — and is structurally blind to an
+        escaping error: reverting the `\\\\` unescape survived the whole file.
 
-        def run(shell):
-            return subprocess.run(
-                [shell, "-c", self._probe_script(), "_", name],
-                capture_output=True, text=True, timeout=30,
-            ).stdout
-
-        assert run(dash) == run("bash"), (
-            f"the pod's shell and the test harness's shell disagree on {name!r} — "
-            "this is the silent-clobber route: the two sides' join keys diverge "
-            "and a DIFFERING pod entry reads as a pure addition"
+        The inner script is embedded in a DOUBLE-QUOTED shell string, so by the
+        time the pod's `sh` sees it every `\\\\`, `\\"` and `\\$` has been
+        collapsed once. A correctly-extracted script therefore contains NO
+        double backslash and NO backslash-quote — if it does, the extractor
+        stopped early and every dash test above is measuring a command the pod
+        never runs.
+        """
+        script = self._probe_script()
+        assert "\\\\" not in script, (
+            "the extracted script still contains a DOUBLE backslash, so the "
+            f"unescaping is incomplete: {script!r}"
+        )
+        assert '\\"' not in script, (
+            f"the extracted script still contains an escaped quote: {script!r}"
+        )
+        # positive control: the RAW source span really does carry the escapes
+        # this test asserts are gone, so it cannot pass by matching nothing.
+        raw = re.search(r"-I\{\} sh -c '(.+?)' _ \{\}", SEED_PATH.read_text(), re.S)
+        assert raw and ('\\"' in raw.group(1) or "\\\\" in raw.group(1)), (
+            "the raw source carries no escapes, so this test proves nothing"
         )
 
     def test_the_UNREADABLE_arm_is_exercised_too(self, tmp_path: Path):
@@ -19023,6 +19056,17 @@ class TestTheSeedProbeAnswersSurviveTheRealPodShell:
         suite (measured). This reaches it: the file exists, so `[ -f ]` is true,
         and it is unreadable, so `sha256sum` fails into the fallback."""
         dash = _require_dash()
+        # 🔴 `chmod 000` DOES NOT BLOCK ROOT, so under uid 0 this arm cannot be
+        # constructed at all. Both tiers this repo gates on are non-root
+        # (dev host = uid 1000; the nix sandbox runs as nixbld) — MEASURED — so
+        # this says WHY rather than skipping, which would report coverage it
+        # never had.
+        assert os.geteuid() != 0, (
+            "this tier runs as root, so no file can be made unreadable and the "
+            "UNREADABLE arm of the pod probe cannot be exercised here. That is "
+            "a gap in the tier, not a passing test — do not convert this to a "
+            "skip."
+        )
         d = tmp_path / "sc"; d.mkdir()
         target = d / "unreadable\\there.md"
         target.write_text("x")


### PR DESCRIPTION
## The defect

`seed.sh` pushes local → pod and its extract **"adds and overwrites but never deletes"**. That was
safe while the local store was authoritative. Since the Cairn cutover the **pod** is, and the same
push is a *derivative overwriting the authority*: a shared entry whose pod copy has moved on — a
bullet appended via `cairn append`, an `OPEN:` rewritten `RESOLVED <sha>:` — is replaced by this
host's older copy, and the verdict still prints `seed: OK` because the **name** landed.

**MEASURED 2026-09-02/03 on the real store:** of 25 bullets present locally but not on the pod,
**five were the pod being newer** — including two `OPEN:` → `RESOLVED` closures carrying ~20 lines
of later corrections. A re-seed would have reverted all five and reported success.

## The guard

A **pre-flight before the tar**. For exactly the paths in `$staged_list`, ask the pod whether it
holds different bytes; refuse with **exit 8, pushing nothing**, and name them.
`--allow-overwrite` proceeds and still prints what it replaced.

- 🔴 **Pre-flight, not a louder verdict.** The existing containment check runs *after* the extract,
  so by the time it can speak the bytes are gone.
- 🔴 **Bytes, not mtime or "newness".** Two copies cannot be ordered — a local edit not yet pushed
  and a pod edit not yet pulled both read as different. Post-cutover the pod is the authority, so
  *any* difference means this push overwrites it with a derivative. No clock needed.
- 🔴 **No third `find`.** It reuses the list `_shippable_entries` already wrote, so this comparison
  and the verdict are one population rather than two walks that agree by luck — and
  `test_the_two_find_expressions_are_IDENTICAL` still pins exactly two listings. `test -f` on the
  pod yields the intersection for free: a staged path the pod lacks is a pure addition.

**Header corrected.** It opened `🔴 THE LOCAL STORE IS AUTHORITATIVE` — false since the cutover, and
the sentence outlived the fact for the whole life of it. What still holds (this script never
*writes* to the local store) is kept, and separated from what changed.

## Two things the tests caught in my own work

**`|| :` in the probe is load-bearing.** `xargs` exits 123 when any child exits non-zero, and a
staged path the pod does *not* have is the ordinary case. Without it the probe returned 123,
`set -euo pipefail` aborted, and **seeding a genuinely new entry died with exit 123 and an empty
stderr** — the guard against data loss breaking the script's primary function. All four tests
failed that way, including the two that must pass.

**Red-at-base was proving the wrong thing.** Asserting the exit code before the bytes made the base
run fail on `0 vs 8` and never reach the clobber assertion. Reordered, red at base is now
`THE POD'S BYTES WERE REPLACED`.

## Test matrix — base `46264622`

| test | at base | class |
|---|---|---|
| different bytes → refuses, **pod untouched** | **RED** (on the bytes) | regression |
| identical bytes → proceeds | green | invariant guard |
| absent from pod → proceeds, addition lands | green | invariant guard |
| `--allow-overwrite` names what it replaced | red — *only because the flag is new* | **not** regression coverage, labelled |

The two invariant guards are the ones that matter for over-firing: a guard that fired on mere
*presence*, or that broke pure additions, would be switched off within a day.

`test_subsystem_store_api.py`: **717 passed**.

## Not verified

Neither gate tier has run on this branch yet, and nothing has been exercised against the **live**
pod — the tests drive a fake `kubectl` whose `exec` rewrites `/data` to a temp dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRZVCFV6DDGs1pZwmCrHJo