### PR TITLE
feat(syshealth): on-demand deep system sweep, paid for out of the skill-listing budget

### DIFF
--- a/claude/skill-tiers.json
+++ b/claude/skill-tiers.json
@@ -114,6 +114,10 @@
       "tier": "B",
       "why": "invoked BY `/handoff`, which names it in its own body; its own description says 'rarely run directly', so no symptom needs to route to it"
     },
+    "syshealth": {
+      "tier": "B",
+      "why": "the ledger's tie-break decides it: a mis-route DEGRADES the answer here, it does not take a wrong action -- syshealth is report-only and cannot signal a process, so the worst case is the ad-hoc `ps` sweep that was happening anyway. Genuinely close, and the argument for A is real: the phrasing that produced this skill ('check zombie procs, mem and cpu hogs', 'check load', 'check runaway procs') is symptom-shaped, and name-only cannot catch it. Revisit if a sweep is ever asked for and missed -- promoting it needs an eviction in the same commit"
+    },
     "tekton": { "tier": "A" },
     "ux-audit-loops": {
       "tier": "B",

--- a/claude/skills/initiatives/SKILL.md
+++ b/claude/skills/initiatives/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: initiatives
-description: "Operate the DURABLE initiatives board — its store, sync, recaps, viewer, the signal->initiative router and the /api/ask assistant. Use for: the initiatives viewer/board, initiatives.current/latest, the initiative store/sync, initiative recaps, the vllm-recap model, the initiatives assistant/chat, \"what's on my board\" as a durable page. The one-off scan is `initiative-scan`."
+description: "Operate the durable initiatives board: store, sync, viewer, recaps, assistant. The one-off scan is `initiative-scan`."
 ---
 
 # initiatives subsystem operations

--- a/claude/skills/standup/SKILL.md
+++ b/claude/skills/standup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: standup
-description: "One-shot fleet-wide status sweep across every active repo and cluster — your approved-mergeable/red/conflicting PRs, in-flight deploys and rollouts, and firing alerts split per cluster, as an action-first roll-up. Use for \"standup\", \"fleet status\", \"what's in flight\", \"check everything\", \"what's the state of everything\", or \"merged, what's next\"."
+description: "One-shot fleet sweep: your PRs, in-flight deploys, and firing alerts per cluster, as an action-first roll-up."
 argument-hint: [all|repos|deploys|alerts|state|local|initiatives]
 allowed-tools: Bash, Read
 ---

--- a/claude/skills/syshealth/SKILL.md
+++ b/claude/skills/syshealth/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: syshealth
+description: "One-shot deep system sweep: zombies (traced to the parent not reaping them), CPU/mem hogs, sustained runaways, load, swap. Use for: check procs, zombie processes, what's eating my CPU/memory, why is load so high, runaway process, is the box thrashing."
+argument-hint: "[--systemd] [--fds] [--json] [--cpu-threshold N] [--mem-threshold GIB]"
+allowed-tools: Bash, Read
+---
+
+# /syshealth — on-demand deep system inspection
+
+```bash
+python3 ~/workspace/devrc/scripts/syshealth $ARGUMENTS
+```
+
+Report-only. It never signals a process — a test pins that (`test_the_script_has_no_kill_flag`).
+
+**Exit codes:** `0` clean · `1` warnings · `2` critical (sustained runaway, or memory
+near exhaustion) · `3` could not measure. Read the VERDICT block, which names every
+reason; the code alone does not say which of six rules fired.
+
+## Reading the output
+
+- **ZOMBIES** are grouped by the parent that is not reaping them, because that parent
+  is the fix. 🔴 A zombie whose parent had died would already have been reparented and
+  reaped — so a zombie that persists for days always indicts a **live** parent. The
+  classic cause here is a container whose PID 1 is `sleep infinity`: it never calls
+  `wait()`, so every dead child accumulates. Measured on the workbench 2026-09-04:
+  18 zombies under one such pid, up to 7 days old.
+- **CPU/MEM HOGS** collapse ≥3 siblings under a shared parent into one row (eight
+  pytest workers are one finding, not eight).
+- **RUNAWAYS** require sustained load — a high percentage *and* a real age.
+- Each runaway prints its `cwd` and `ppid` beside a paste-ready `kill` line. Check
+  those first: this box runs parallel agents whose test workers look exactly like a
+  runaway, and killing one reads as a code defect in the branch they were verifying.
+
+## The one thing to know before trusting any %CPU
+
+`ps`'s %CPU is **cpu-time ÷ elapsed, averaged over the process's whole life** — not an
+instantaneous sample. For a process a few milliseconds old the divisor is ~0 and the
+number is meaningless. `--min-age` (default 10s) exists for exactly this and is why
+this script is not four `ps` one-liners: a manual sweep on 2026-09-03 reported a
+"runaway nix store scan at 240%" that was a 20-millisecond `pgrep`, and a 1100% row
+that was the `ps` producing the report. This script excludes itself, its `ps` child
+and its ancestors for the same reason.
+
+## Flags worth knowing
+
+| flag | effect |
+|---|---|
+| `--json` | same verdict, machine-readable; `exit_code` is in the document |
+| `--systemd` | adds failed **user** units (`standup` also covers this) |
+| `--fds` | adds open-FD counts; prints `unreadable` separately — most processes are not ours, and an unmeasured process is never folded into a clean count |
+| `--ignore` | comma-separated substrings never to flag; shares `cpu-monitor.sh`'s default (`anno,logd`) so one `Environment=` value can serve both |
+| `--cpu-threshold` `--mem-threshold` `--load-threshold` `--runaway-pct` `--runaway-age` `--min-age` | retune per host; the values used are echoed into the report |
+
+## Not this skill
+
+- **Always-on alerting** → `scripts/cpu-monitor.sh` (sampling daemon, dunst toasts,
+  cooldowns, daily cap). syshealth sends no notifications and writes no state.
+- **Disk / nix-store / host drift** → `scripts/drift-check.sh`.
+- **Cluster or service health** → `standup`, `obs-read`.

--- a/claude/skills/window-triage/SKILL.md
+++ b/claude/skills/window-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: window-triage
-description: "Point at ONE tmux window by codename, hotkey or address, and rank the windows STRANDED past a threshold, longest-waited first. Use for: which window is Gold, what does Alt+p open, which window has been stranded / unanswered for hours or days, the oldest unanswered question, a codename with no hotkey, why a window shows no harness record, what the scan could not cover. The live inventory — is anything waiting on me, what's running where, tail a window, unsent prompts — is `session-manager`."
+description: "Rank tmux windows stranded longest-first; resolve one by codename or hotkey. Live inventory is `session-manager`."
 ---
 
 # window-triage — name one window, rank the stranded ones

--- a/claudedocs/handoff-syshealth-skill.md
+++ b/claudedocs/handoff-syshealth-skill.md
@@ -14,9 +14,18 @@ Non-blocking: if it exits non-zero, print the stderr line and carry on.
 Create a `syshealth` skill — an on-demand deep system inspection that automates the checks Zach just ran manually (zombie procs, mem/CPU hogs, runaways, load). Complements `cpu-monitor.sh` (always-on shallow alerts) with a one-shot deep sweep.
 
 ## State now
-- Branch: `main` (on `main`, not a feature branch — no commits for this work yet)
-- No PR, no commits — this is pre-implementation, design-only
-- Nothing deployed, nothing verified
+- Branch `feat/syshealth` in worktree `/home/zach/workspace/devrc-syshealth`, cut from
+  `origin/main` at `56c68cc7`. **Nothing committed yet** — all 9 files are STAGED only.
+- 🔴 The branch is **behind origin/main by 2** already. The base MOVED under the gate run,
+  so the merged-tree claim must be re-made against current `origin/main` before merging.
+- No PR yet. Nothing deployed; `home-manager switch` NOT run, so `~/.claude/skills/syshealth`
+  does not exist on either host.
+- Work claim held: `claim-work syshealth-skill-1` (release it when this lands or is abandoned:
+  `claim-work --release syshealth-skill-1`).
+- **No `clawgate-task:` field**: `clawgate_handoff.sh resolve` exited **5** — 0 tasks for this
+  session, with its positive control confirming the board was genuinely read. Per the skill
+  that is NOT a clean bill of health (a wrong session id also answers 200 + empty array), so
+  no field was written and no task was created.
 
 ## Design (solidified this session)
 
@@ -90,11 +99,16 @@ Fixtures: `testlib/mockbin.write_exec()` for stubs, `tmp_path` for temp artifact
 4. Should the skill auto-fire from description ("check procs") or only on explicit `/syshealth`?
 
 ## What needs to happen next (ranked)
-1. Create `scripts/syshealth.sh` — the main script implementing the design above
-2. Create `claude/skills/syshealth/SKILL.md` — skill definition with YAML frontmatter
-3. Create `scripts/tests/test_syshealth.py` — full test suite per the table above
-4. Run `scripts/gate.sh` to verify tests pass and no regressions
-5. `git add` the new files (skill won't deploy without it)
+1. **Finish/re-run `scripts/gate.sh --tier both` inside `nix develop`** and read the
+   per-tier `RESULT:` lines, not the exit code.
+2. **Run the nix check tier, one derivation at a time**:
+   `nix build .#checks.x86_64-linux.pytests` then `.#checks.x86_64-linux.nodetests`.
+3. **Rebase onto current `origin/main`** (already 2 behind) and re-run both tiers on the
+   MERGED tree — the base moved during the run above.
+4. Commit the 9 staged files and open the PR.
+5. After merge: `scripts/ship.sh`, then confirm `~/.claude/skills/syshealth/SKILL.md`
+   resolves on both hosts (`readlink -f`) — merged ≠ deployed.
+6. `claim-work --release syshealth-skill-1`.
 
 ## Gotchas / constraints
 - `cpu-monitor.sh` already handles always-on monitoring — don't duplicate that layer
@@ -104,7 +118,93 @@ Fixtures: `testlib/mockbin.write_exec()` for stubs, `tmp_path` for temp artifact
 - The skill description must fit the 1,536-char per-entry cap and the total listing budget
 
 ## How to verify
-- `nix develop ~/workspace/devrc -c python3 -m pytest scripts/tests/test_syshealth.py -q` — all tests pass
-- `scripts/gate.sh` — full gate green on both tiers
-- Manual: `bash scripts/syshealth.sh` produces readable output on a live system
-- Manual: `bash scripts/syshealth.sh --json` produces valid JSON
+- `nix develop /home/zach/workspace/devrc-syshealth --command bash scripts/gate.sh --tier both`
+- `nix build .#checks.x86_64-linux.pytests` / `.#checks.x86_64-linux.nodetests` — SEPARATELY
+- `python3 scripts/syshealth` → exit 1 on this box today (swap ~57%, 21 zombies, 2 mem hogs)
+- `python3 scripts/syshealth --json | python3 -c "import json,sys; json.load(sys.stdin)"`
+- `python3 scripts/syshealth --systemd --fds` → the FD section must print `unreadable` beside
+  `examined`; a bare "0 dangling"-style zero there is the failure, not the all-clear.
+## What was built (design-only handoff is now superseded)
+Four design questions the previous session left open were answered by the operator:
+**Python, not bash** · **no `--kill` in v1** · **swap/OOM always-on** · **`--systemd` + `--fds`
+opt-in, `--disk` dropped**.
+
+- `scripts/syshealth` — Python, stdlib only, report-only. Sections: overview (load, mem, swap,
+  OOM headroom), zombies, CPU hogs, mem hogs, runaways; `--systemd` / `--fds` opt-in.
+  Exit `0` clean · `1` warnings · `2` critical · `3` could-not-measure.
+- `claude/skills/syshealth/SKILL.md` — tier **B** in `claude/skill-tiers.json`.
+- `scripts/tests/test_syshealth.py` — **98 tests, all green**.
+
+### 🔴 The two design facts worth not re-deriving
+1. **`ps` %CPU is cpu-time ÷ elapsed over the process's WHOLE LIFE, not an instant sample.**
+   That is why `--min-age` (default 10s) exists and why this is not four `ps` one-liners.
+   The 2026-09-03 manual sweep in this doc's own history reported a *"runaway nix store scan
+   at 240%"* that was a **20-millisecond `pgrep`**, and a 1100% row that **was the `ps`
+   producing the report**. The script excludes itself, its `ps` child and its ancestors.
+2. **A persistent zombie always indicts a LIVE parent.** A dead parent's zombies get
+   reparented to init and reaped, so a zombie that survives for days proves its parent is
+   alive and not calling `wait()`. The previous session concluded the opposite ("children of
+   already-dead services") — that is RETRACTED.
+   Measured on the workbench 2026-09-04: **21 zombies under 2 parents**, 18 of them under
+   **pid 2273825 `sleep infinity`**, which is a Kubernetes container's PID 1
+   (`/proc/2273825/cgroup` → `kubepods/besteffort/pod…`). Container PID 1 is not a subreaper
+   and never reaps. The other 3 sit under pid 3716907 `stash`. **This is a real, still-open
+   finding about the box — it is not fixed, and syshealth only reports it.**
+
+## Verification state — READ THIS BEFORE CLAIMING ANYTHING
+- ✅ 98/98 unit + end-to-end tests green (`nix develop … -c python3 -m pytest
+  scripts/tests/test_syshealth.py`).
+- ✅ **Mutation sweep 22/22**: positive control green (unmutated → 98 passed) and 21 mutants
+  each killed by their OWN named test, run under `PYTHONDONTWRITEBYTECODE=1` in a fresh temp
+  copy per mutant. Harness: `/tmp/claude-1000/-home-zach-workspace-devrc/
+  07d75e8f-3dc4-41a7-8a14-5602fce01709/scratchpad/mutate.py` (scratch — **re-create it if you
+  need it again; it is not in the repo**).
+  The sweep found 3 REAL test gaps that a fully green suite had hidden, all now closed:
+  a substring-vs-prefix `is_zombie` mutant; a `group_by_parent` boundary with no fixture
+  landing exactly ON `GROUP_MIN_CHILDREN`; and a zombie-group "oldest age" assertion that was
+  vacuous because `find_zombies` already returns oldest-first (fixed by grouping a REVERSED
+  list, with an assert that the fixture still exercises the ordering).
+- ⏳ **`scripts/gate.sh --tier both` was STILL RUNNING when this was written.** Not verified.
+  First attempt exited 3 — `logrotate` missing from PATH because it ran outside the dev shell;
+  that is the guard working (it refuses to run a suite that would silently skip tests), NOT a
+  code failure. Re-run: `nix develop <worktree> --command bash scripts/gate.sh --tier both`.
+- ❌ **The `nix` check tier has NOT been run at all.** It is the tier Tekton gates on and it
+  is structurally different (builds from a `cp -r` store copy with no `.git`).
+  🔴 Run the two derivations **ONE AT A TIME** — a combined invocation produces false failures.
+
+## The listing-budget work (unplanned, and it is the bigger change)
+Adding any skill reddened `test_skill_descriptions.py`: the listing ratchet was at
+12,861/12,929, i.e. **68 chars of headroom**, and its own comment says the next addition of
+any size reds it on purpose.
+
+**Measurement** (the operator asked for it explicitly): one walk of the Claude Code transcript
+corpus on BOTH hosts, using the three attribution channels `find-session --skill` reads
+(`attributionSkill` auto-fire, `Skill` tool calls, typed `/name`) — **not** the ClickHouse
+`skills_used` map, which the `activity` skill measures ~40% low and whose
+`JSONExtractString(...) IS NOT NULL` predicate matches the whole table.
+Corpus bound: workbench 900 sessions from **2026-08-04**, laptop 170 from **2026-07-12** —
+so "never" means "no recorded use since those dates", NOT all-time.
+
+- 17 of 41 skills zero-use in 10d; **13 with zero across the whole corpus** (4,093 chars).
+- 🔴 **The counter is blind to service/timer-driven use and is EVIDENCE, NOT A VERDICT.**
+  It read 0 for `adoption-scan` (20,494 tool-invocation events), 1 for `dl-router` (a live
+  systemd service) and 0 for `repo-cos` (a weekly timer read as email). The ledger predicted
+  exactly this. Do not delete on a zero.
+- **Paid for syshealth by SHRINKING three never-fired descriptions**, keeping every
+  capability and every `/name`: `window-triage` 507→126, `initiatives` 389→128,
+  `standup` 367→116.
+- Net **−602 chars** vs the pre-change 12,861. Both ratchets re-pinned DOWNWARD:
+  `LISTING_TOTAL_CEILING_CHARS` 12,929→**12,259** (headroom 0 by choice) and
+  `TIER_A_CEILING_CHARS` 8,821→**7,928**, plus the four `MEASURED_*` constants.
+- 🔴 **Correction now recorded in the source: demoting a skill to tier B does NOT relieve the
+  listing ceiling.** `listing_total_chars` sums EVERY entry and never reads
+  `claude/skill-tiers.json`; a comment there implied it did. Only shortening or removing
+  description TEXT moves that number.
+
+## Open questions
+1. The two un-reaping parents are a live finding nobody has acted on — is the
+   `sleep infinity` container (pod `f1a4b8bc-610c-422f-b1ed-c1c0f0dbe395`) meant to be running
+   at all, and does it want `shareProcessNamespace`/an init shim?
+2. `syshealth` is tier B, so it will NOT auto-fire from "check zombie procs" — the exact
+   phrasing that produced it. Promoting it to A needs an eviction in the same commit.
+3. Should `syshealth` become a `bar` pill or a timer? Deliberately out of scope for v1.

--- a/scripts/syshealth
+++ b/scripts/syshealth
@@ -1,0 +1,781 @@
+#!/usr/bin/env python3
+"""On-demand deep system inspection: zombies, CPU/mem hogs, runaways, load, swap.
+
+The COMPLEMENT to `scripts/cpu-monitor.sh`, not a duplicate of it. cpu-monitor is
+the always-on daemon: it samples every 30s, requires a condition to persist
+across consecutive samples, and fires desktop toasts with cooldowns and a daily
+cap. It answers "is something wrong right now, tell me unprompted". This answers
+"I think something is wrong, show me everything, once" — parent-tracked zombies,
+process-tree grouping, ages, and the identity of each offender. Different jobs;
+this one sends no notifications and writes no state.
+
+🔴 WHY A MINIMUM AGE EXISTS (`--min-age`, default 10s) — the whole reason this
+script is not just the four `ps` one-liners it replaces.
+------------------------------------------------------------------------------
+`ps`'s %CPU is not an instantaneous reading. It is cumulative CPU time divided
+by process ELAPSED time, averaged over the process's whole life. For a process
+that has existed for a fraction of a second that divisor is ~0, so the quotient
+is meaningless and enormous. Measured on this box 2026-09-03, from a manual
+sweep whose output is preserved in `claudedocs/handoff-syshealth-skill.md`:
+
+    3733770  400%  00:00  ps -eo pid,ppid,user,%cpu,etime,stat,cmd
+    3733669  240%  00:00  pgrep -o -f find /nix -xdev
+    3250873 1100%  00:00  ps aux --sort=-%cpu
+
+All three are the measurement itself, or its sibling, caught mid-exec. The
+1100% one IS the `ps` that produced the report. A human reading that output
+concluded there was a "runaway nix store scan" at 240% — there was no such
+thing; it was a 20-millisecond `pgrep`. That is the failure mode this guard
+removes: anything younger than `--min-age` cannot be a hog or a runaway,
+because its %CPU is division noise rather than a measurement. Ages are also
+printed beside every flagged row so the reader can see the divisor.
+
+The same reasoning is why the runaway rule needs BOTH a percentage and an age
+(`--runaway-age`, default 600s): a lifetime-average of 90% is only meaningful
+once the lifetime is long enough to average over.
+
+SELF-EXCLUSION. This process, its `ps` child and its ancestors are dropped from
+every section for the same reason — a diagnostic that reports itself as the
+problem is worse than no diagnostic. See `self_pids()`.
+
+Exit codes:
+  0  clean
+  1  warnings   — zombies, high load, hogs, runaways, swap pressure, failed units
+  2  critical   — a sustained runaway, or memory availability near exhaustion
+  3  usage error / could not measure
+
+Usage:
+  syshealth                 human-readable report
+  syshealth --json          machine-readable, same verdict
+  syshealth --systemd       add the failed-user-units section
+  syshealth --fds           add the open-file-descriptor section (walks /proc)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Defaults. Every one is overridable by flag; the env names mirror
+# cpu-monitor.sh's so a host that has already tuned one is not surprised by the
+# other disagreeing with it.
+# ---------------------------------------------------------------------------
+DEF_CPU_THRESHOLD = 50.0     # %CPU at or above which a process is a "hog"
+DEF_MEM_THRESHOLD = 1.0      # RSS in GiB at or above which a process is a "hog"
+DEF_RUNAWAY_PCT = 80.0       # %CPU for the runaway rule (age-gated, see below)
+DEF_RUNAWAY_AGE = 600        # seconds a runaway must have been alive
+DEF_MIN_AGE = 10             # seconds below which %CPU is division noise
+DEF_SWAP_WARN_PCT = 50.0     # swap used% at or above which we warn
+DEF_AVAIL_CRIT_PCT = 5.0     # MemAvailable below this % of MemTotal is critical
+CRIT_RUNAWAY_PCT = 200.0     # a runaway this hot...
+CRIT_RUNAWAY_AGE = 1800      # ...for this long is exit 2
+
+# Commands never to flag — expected heavy hitters whose CPU is not a problem.
+# Case-insensitive SUBSTRING match against the command. Comma-separated, the
+# same shape and the same default as cpu-monitor.sh's CPU_MON_IGNORE, so the two
+# tools can share one value in a service Environment= line.
+DEF_IGNORE = "anno,logd"
+
+# A parent needs at least this many flagged children before we collapse them
+# into one grouped row. Three is the point where the list starts hiding the
+# culprit: two pytest workers read fine individually, eight do not.
+GROUP_MIN_CHILDREN = 3
+
+KIB = 1024
+GIB = 1024 * 1024 * 1024
+
+# `args` goes LAST and every field before it is space-free, so a single
+# maxsplit=8 parse is unambiguous. `comm` is deliberately NOT requested: it can
+# itself contain spaces, which would make the split position depend on the data.
+PS_FORMAT = "pid=,ppid=,user=,pcpu=,pmem=,rss=,etimes=,stat=,args="
+PS_FIELDS = 9
+
+
+@dataclass(frozen=True)
+class Proc:
+    pid: int
+    ppid: int
+    user: str
+    pcpu: float
+    pmem: float
+    rss_kb: int
+    etimes: int          # elapsed seconds since start
+    stat: str
+    args: str
+
+    @property
+    def is_zombie(self) -> bool:
+        # The state letter is always first; what follows are modifier flags
+        # (`s` session leader, `l` multi-threaded, `+` foreground). A zombie can
+        # be "Z" or "Zs" — matching the whole string would miss the latter, and
+        # a substring match would false-positive on a future flag letter.
+        return self.stat[:1] == "Z"
+
+    @property
+    def rss_gib(self) -> float:
+        return (self.rss_kb * KIB) / GIB
+
+    @property
+    def comm(self) -> str:
+        """Short command name derived from args.
+
+        Derived rather than asked of `ps` because requesting `comm=` would
+        reintroduce the split ambiguity PS_FORMAT exists to avoid. A defunct
+        process has no argv, so `ps` renders it `[find] <defunct>` — strip the
+        decoration so the ignore-list and the report both see `find`.
+        """
+        first = self.args.split(" ", 1)[0] if self.args else ""
+        if first.startswith("[") and first.endswith("]"):
+            first = first[1:-1]
+        return os.path.basename(first) or first
+
+
+# ---------------------------------------------------------------------------
+# Parsing — pure, so the tests can drive every rule below from a fixture list
+# without stubbing a single binary.
+# ---------------------------------------------------------------------------
+def parse_ps(text: str) -> list[Proc]:
+    """Parse `ps -eo <PS_FORMAT>` output. Unparseable lines are skipped."""
+    procs: list[Proc] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(None, PS_FIELDS - 1)
+        if len(parts) < PS_FIELDS - 1:
+            continue
+        if len(parts) == PS_FIELDS - 1:
+            parts.append("")  # a zombie can have an empty args column
+        try:
+            procs.append(
+                Proc(
+                    pid=int(parts[0]),
+                    ppid=int(parts[1]),
+                    user=parts[2],
+                    pcpu=float(parts[3]),
+                    pmem=float(parts[4]),
+                    rss_kb=int(parts[5]),
+                    etimes=int(parts[6]),
+                    stat=parts[7],
+                    args=parts[8],
+                )
+            )
+        except ValueError:
+            continue  # a header row or a torn read, not a process
+    return procs
+
+
+def read_loadavg(proc_root: str = "/proc") -> tuple[float, float, float]:
+    parts = Path(proc_root, "loadavg").read_text().split()
+    return (float(parts[0]), float(parts[1]), float(parts[2]))
+
+
+def read_meminfo(proc_root: str = "/proc") -> dict[str, int]:
+    """Return /proc/meminfo as a dict of KiB values."""
+    out: dict[str, int] = {}
+    for line in Path(proc_root, "meminfo").read_text().splitlines():
+        key, _, rest = line.partition(":")
+        fields = rest.split()
+        if fields:
+            try:
+                out[key] = int(fields[0])
+            except ValueError:
+                continue
+    return out
+
+
+def read_uptime(proc_root: str = "/proc") -> float:
+    return float(Path(proc_root, "uptime").read_text().split()[0])
+
+
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
+def parse_ignore(spec: str) -> list[str]:
+    """Comma- or space-separated, lowercased, blanks dropped."""
+    return [t for t in spec.replace(",", " ").lower().split() if t]
+
+
+def is_ignored(proc: Proc, ignore: list[str]) -> bool:
+    hay = f"{proc.comm} {proc.args}".lower()
+    return any(tok in hay for tok in ignore)
+
+
+def self_pids(procs: list[Proc], mypid: int | None = None) -> set[int]:
+    """This process, anything it spawned, and its ancestor chain.
+
+    Without this the report indicts its own `ps` — see the module docstring.
+    The ancestor walk is bounded by the number of processes so a cycle in a
+    torn `ps` read cannot hang it.
+    """
+    mypid = os.getpid() if mypid is None else mypid
+    by_pid = {p.pid: p for p in procs}
+    out = {mypid}
+    # Descendants: in practice just the `ps` child, but a shell wrapper may add
+    # one more level, so walk until the set stops growing.
+    changed = True
+    while changed:
+        changed = False
+        for p in procs:
+            if p.ppid in out and p.pid not in out:
+                out.add(p.pid)
+                changed = True
+    # Ancestors: the shell and the agent that invoked us are not findings.
+    cur = by_pid.get(mypid)
+    seen = 0
+    while cur is not None and cur.ppid > 1 and seen < len(procs) + 1:
+        out.add(cur.ppid)
+        cur = by_pid.get(cur.ppid)
+        seen += 1
+    return out
+
+
+def eligible(procs: list[Proc], ignore: list[str], min_age: int,
+             mypid: int | None = None) -> list[Proc]:
+    """Processes whose %CPU is old enough to mean anything and that we may flag.
+
+    🔴 The min_age filter is the point of this script; see the module docstring.
+    It applies to the CPU/mem/runaway rules only — zombies are found separately
+    and are never age-gated, because a fresh zombie is still a zombie.
+    """
+    skip = self_pids(procs, mypid)
+    return [
+        p for p in procs
+        if p.pid not in skip
+        and p.etimes >= min_age
+        and not p.is_zombie
+        and not is_ignored(p, ignore)
+    ]
+
+
+def find_zombies(procs: list[Proc], mypid: int | None = None) -> list[dict]:
+    """Zombies, each resolved to its parent — the part `ps aux | awk '/Z/'` omits.
+
+    A zombie is not itself the problem: it is a dead child its PARENT has not
+    reaped. So the actionable identity is the parent's, and whether that parent
+    is still alive decides whether anything can be done at all. A zombie
+    reparented to pid 1 (`parent_alive` true, `parent_comm` systemd) is inert —
+    its real parent already died and init will collect it. A zombie whose
+    parent is a live long-running service is a bug in that service.
+    """
+    skip = self_pids(procs, mypid)
+    by_pid = {p.pid: p for p in procs}
+    out = []
+    for z in procs:
+        if not z.is_zombie or z.pid in skip:
+            continue
+        parent = by_pid.get(z.ppid)
+        out.append({
+            "pid": z.pid,
+            "comm": z.comm,
+            "user": z.user,
+            "age_sec": z.etimes,
+            "ppid": z.ppid,
+            "parent_comm": parent.comm if parent else None,
+            "parent_alive": parent is not None,
+            "parent_is_zombie": bool(parent and parent.is_zombie),
+            "reparented_to_init": z.ppid == 1,
+        })
+    return sorted(out, key=lambda d: -d["age_sec"])
+
+
+def group_zombies(zombies: list[dict],
+                  min_children: int = GROUP_MIN_CHILDREN) -> tuple[list[dict], list[dict]]:
+    """Collapse zombies sharing one un-reaping parent into a single finding.
+
+    Measured on this box 2026-09-04: 21 zombies, 18 of them under pid 2273825
+    (`sleep infinity`, a container's PID 1) and 3 under one other. That is TWO
+    findings, and the ungrouped list of 21 buries them — an earlier manual sweep
+    of the same box read the flat list and concluded the zombies were "children
+    of already-dead services", which is the opposite of true: a dead parent's
+    zombies get reparented and reaped, so a zombie that persists for days proves
+    its parent is ALIVE and not reaping. Grouping puts that parent on one line.
+    """
+    buckets: dict[int, list[dict]] = {}
+    for z in zombies:
+        buckets.setdefault(z["ppid"], []).append(z)
+    groups, single = [], []
+    for ppid, kids in buckets.items():
+        if len(kids) >= min_children:
+            k0 = kids[0]
+            groups.append({
+                "ppid": ppid,
+                "parent_comm": k0["parent_comm"],
+                "parent_alive": k0["parent_alive"],
+                "reparented_to_init": k0["reparented_to_init"],
+                "count": len(kids),
+                "oldest_age_sec": max(z["age_sec"] for z in kids),
+                "comms": sorted({z["comm"] for z in kids}),
+                "pids": sorted(z["pid"] for z in kids),
+            })
+        else:
+            single.extend(kids)
+    groups.sort(key=lambda g: -g["count"])
+    single.sort(key=lambda z: -z["age_sec"])
+    return groups, single
+
+
+def find_cpu_hogs(elig: list[Proc], threshold: float) -> list[Proc]:
+    return sorted([p for p in elig if p.pcpu >= threshold],
+                  key=lambda p: -p.pcpu)
+
+
+def find_mem_hogs(elig: list[Proc], threshold_gib: float) -> list[Proc]:
+    return sorted([p for p in elig if p.rss_gib >= threshold_gib],
+                  key=lambda p: -p.rss_kb)
+
+
+def find_runaways(elig: list[Proc], pct: float, min_age: int) -> list[Proc]:
+    """Sustained high CPU. BOTH conditions are required — see the docstring."""
+    return sorted([p for p in elig if p.pcpu >= pct and p.etimes >= min_age],
+                  key=lambda p: -p.pcpu)
+
+
+def is_critical_runaway(p: Proc) -> bool:
+    return p.pcpu >= CRIT_RUNAWAY_PCT and p.etimes >= CRIT_RUNAWAY_AGE
+
+
+def group_by_parent(flagged: list[Proc], procs: list[Proc],
+                    min_children: int = GROUP_MIN_CHILDREN) -> tuple[list[dict], list[Proc]]:
+    """Collapse siblings under a shared parent into one row.
+
+    Returns (groups, ungrouped). Eight pytest workers under one parent are one
+    finding, not eight; listing them individually pushes the actual culprit off
+    the top of the report. A parent with fewer than `min_children` flagged
+    children is left alone — grouping two rows into one hides more than it
+    reveals.
+    """
+    by_pid = {p.pid: p for p in procs}
+    buckets: dict[int, list[Proc]] = {}
+    for p in flagged:
+        buckets.setdefault(p.ppid, []).append(p)
+
+    groups, ungrouped = [], []
+    for ppid, kids in buckets.items():
+        if len(kids) >= min_children:
+            parent = by_pid.get(ppid)
+            groups.append({
+                "ppid": ppid,
+                "parent_comm": parent.comm if parent else None,
+                "parent_args": parent.args if parent else None,
+                "parent_alive": parent is not None,
+                "count": len(kids),
+                "total_pcpu": round(sum(k.pcpu for k in kids), 1),
+                "total_rss_gib": round(sum(k.rss_gib for k in kids), 2),
+                "pids": sorted(k.pid for k in kids),
+                "sample_comm": kids[0].comm,
+            })
+        else:
+            ungrouped.extend(kids)
+    groups.sort(key=lambda g: -g["total_pcpu"])
+    ungrouped.sort(key=lambda p: -p.pcpu)
+    return groups, ungrouped
+
+
+# ---------------------------------------------------------------------------
+# Optional sections
+# ---------------------------------------------------------------------------
+def failed_units(runner=None) -> dict:
+    """Failed systemd USER units.
+
+    `standup` also reports local systemd health; this is here because a failed
+    unit is a routine cause of the symptoms the rest of the report measures, and
+    making the reader run a second tool to see it defeats the point of a sweep.
+
+    🔴 `list-units --state=failed`, NOT the shorter `--failed`. Identical output
+    (measured), but `list-units` is a POSITIONAL VERB on
+    `testlib/nolaunch.SYSTEMCTL_READ_VERBS` while `--failed` is a flag, and that
+    stub's safe-flag list is only `--version/--help/-h`. Unknown spellings fail
+    CLOSED there by design, so the short form would be blocked in the suite --
+    and, more to the point, the long form is the one whose read-only nature the
+    repo's own guard can actually verify. Do not "simplify" it back.
+    """
+    runner = runner or _run
+    rc, out, err = runner(["systemctl", "--user", "list-units",
+                           "--state=failed", "--no-legend", "--plain",
+                           "--no-pager"])
+    if rc != 0:
+        return {"measured": False, "reason": err.strip() or f"systemctl exit {rc}",
+                "units": []}
+    units = [line.split()[0] for line in out.splitlines() if line.strip()]
+    return {"measured": True, "reason": None, "units": units}
+
+
+def fd_counts(procs: list[Proc], proc_root: str = "/proc",
+              top: int = 10, mypid: int | None = None) -> dict:
+    """Open-FD count per process, descending.
+
+    🔴 Reports `unreadable` alongside the counts, and NEVER folds it into a
+    clean result. Most processes on this box are not ours, so /proc/<pid>/fd is
+    EACCES for them; a report that silently dropped those would show a small
+    tidy list that reads as "no process has many FDs" while never having looked
+    at the one that does. An unreadable count is an unmeasured process, and it
+    is printed as such.
+    """
+    skip = self_pids(procs, mypid)
+    rows, unreadable, vanished = [], 0, 0
+    for p in procs:
+        if p.pid in skip or p.is_zombie:
+            continue
+        try:
+            rows.append({"pid": p.pid, "comm": p.comm, "user": p.user,
+                         "fds": len(os.listdir(Path(proc_root, str(p.pid), "fd")))})
+        except PermissionError:
+            unreadable += 1
+        except (FileNotFoundError, NotADirectoryError):
+            vanished += 1  # exited between the ps read and now
+        except OSError:
+            unreadable += 1
+    rows.sort(key=lambda r: -r["fds"])
+    return {"top": rows[:top], "examined": len(rows),
+            "unreadable": unreadable, "vanished": vanished}
+
+
+def proc_cwd(pid: int, proc_root: str = "/proc") -> str | None:
+    """Resolve a process's cwd, for the sibling-agent check in the kill hint."""
+    try:
+        return os.readlink(Path(proc_root, str(pid), "cwd"))
+    except OSError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Collection
+# ---------------------------------------------------------------------------
+def _run(cmd: list[str]) -> tuple[int, str, str]:
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        return r.returncode, r.stdout, r.stderr
+    except FileNotFoundError:
+        return 127, "", f"{cmd[0]}: not found"
+    except subprocess.TimeoutExpired:
+        return 124, "", f"{cmd[0]}: timed out"
+
+
+def collect_ps(runner=None) -> list[Proc]:
+    runner = runner or _run
+    rc, out, err = runner(["ps", "-eo", PS_FORMAT])
+    if rc != 0:
+        raise RuntimeError(f"ps failed (exit {rc}): {err.strip()}")
+    procs = parse_ps(out)
+    if not procs:
+        # A zero here is never a clean bill of health: this host has processes.
+        raise RuntimeError("ps returned no parseable processes — cannot measure")
+    return procs
+
+
+def build_report(args, procs: list[Proc], loadavg, meminfo, uptime_sec,
+                 proc_root: str = "/proc", mypid: int | None = None,
+                 runner=None) -> dict:
+    ignore = parse_ignore(args.ignore)
+    elig = eligible(procs, ignore, args.min_age, mypid)
+
+    zombies = find_zombies(procs, mypid)
+    zgroups, zsingle = group_zombies(zombies)
+    cpu_hogs = find_cpu_hogs(elig, args.cpu_threshold)
+    mem_hogs = find_mem_hogs(elig, args.mem_threshold)
+    runaways = find_runaways(elig, args.runaway_pct, args.runaway_age)
+
+    cpu_groups, cpu_single = group_by_parent(cpu_hogs, procs)
+    mem_groups, mem_single = group_by_parent(mem_hogs, procs)
+
+    total_kb = meminfo.get("MemTotal", 0)
+    avail_kb = meminfo.get("MemAvailable", 0)
+    swap_total = meminfo.get("SwapTotal", 0)
+    swap_free = meminfo.get("SwapFree", 0)
+    swap_used = swap_total - swap_free
+    swap_pct = (swap_used / swap_total * 100.0) if swap_total else 0.0
+    avail_pct = (avail_kb / total_kb * 100.0) if total_kb else 100.0
+
+    cores = os.cpu_count() or 1
+    load_threshold = args.load_threshold if args.load_threshold is not None else float(cores)
+
+    rep = {
+        "overview": {
+            "load1": loadavg[0], "load5": loadavg[1], "load15": loadavg[2],
+            "cores": cores, "load_threshold": load_threshold,
+            "load_high": loadavg[0] >= load_threshold,
+            "uptime_sec": int(uptime_sec),
+            "mem_total_gib": round(total_kb * KIB / GIB, 1),
+            "mem_avail_gib": round(avail_kb * KIB / GIB, 1),
+            "mem_avail_pct": round(avail_pct, 1),
+            "swap_total_gib": round(swap_total * KIB / GIB, 1),
+            "swap_used_gib": round(swap_used * KIB / GIB, 1),
+            "swap_used_pct": round(swap_pct, 1),
+            "swap_high": swap_pct >= args.swap_warn_pct,
+            "mem_critical": bool(total_kb) and avail_pct < args.avail_crit_pct,
+        },
+        "zombies": {"count": len(zombies), "groups": zgroups, "single": zsingle},
+        "cpu_hogs": {"groups": cpu_groups, "single": [_proc_row(p, proc_root) for p in cpu_single]},
+        "mem_hogs": {"groups": mem_groups, "single": [_proc_row(p, proc_root) for p in mem_single]},
+        "runaways": [
+            dict(_proc_row(p, proc_root), critical=is_critical_runaway(p))
+            for p in runaways
+        ],
+        "thresholds": {
+            "cpu": args.cpu_threshold, "mem_gib": args.mem_threshold,
+            "load": load_threshold, "runaway_pct": args.runaway_pct,
+            "runaway_age_sec": args.runaway_age, "min_age_sec": args.min_age,
+            "ignore": ignore,
+        },
+        "counts": {"processes": len(procs), "eligible": len(elig)},
+    }
+    if args.systemd:
+        rep["systemd"] = failed_units(runner)
+    if args.fds:
+        rep["fds"] = fd_counts(procs, proc_root, mypid=mypid)
+
+    rep["verdict"] = verdict(rep)
+    rep["exit_code"] = rep["verdict"]["exit_code"]
+    return rep
+
+
+def _proc_row(p: Proc, proc_root: str = "/proc") -> dict:
+    return {
+        "pid": p.pid, "ppid": p.ppid, "user": p.user, "comm": p.comm,
+        "pcpu": p.pcpu, "pmem": p.pmem, "rss_gib": round(p.rss_gib, 2),
+        "age_sec": p.etimes, "stat": p.stat, "args": p.args,
+        "cwd": proc_cwd(p.pid, proc_root),
+    }
+
+
+def verdict(rep: dict) -> dict:
+    """Fold the sections into one exit code, naming every reason.
+
+    The reasons are returned, not just the code — a bare 1 tells the reader
+    nothing about which of six conditions fired.
+    """
+    warn: list[str] = []
+    crit: list[str] = []
+    ov = rep["overview"]
+
+    if ov["load_high"]:
+        warn.append(f"load1 {ov['load1']} >= threshold {ov['load_threshold']}")
+    if ov["swap_high"]:
+        warn.append(f"swap {ov['swap_used_pct']}% used")
+    if ov["mem_critical"]:
+        crit.append(f"MemAvailable {ov['mem_avail_pct']}% of total")
+    if rep["zombies"]["count"]:
+        z = rep["zombies"]
+        under = len(z["groups"]) + len(z["single"])
+        warn.append(f"{z['count']} zombie process(es) under {under} parent(s)")
+    for key in ("cpu_hogs", "mem_hogs"):
+        n = len(rep[key]["single"]) + sum(g["count"] for g in rep[key]["groups"])
+        if n:
+            warn.append(f"{n} {key.replace('_', ' ')}")
+    if rep["runaways"]:
+        warn.append(f"{len(rep['runaways'])} runaway(s)")
+    for r in rep["runaways"]:
+        if r["critical"]:
+            crit.append(f"pid {r['pid']} ({r['comm']}) at {r['pcpu']}% "
+                        f"for {fmt_age(r['age_sec'])}")
+    sysd = rep.get("systemd")
+    if sysd and sysd["measured"] and sysd["units"]:
+        warn.append(f"{len(sysd['units'])} failed user unit(s)")
+
+    code = 2 if crit else (1 if warn else 0)
+    return {"exit_code": code, "critical": crit, "warnings": warn}
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+def fmt_age(sec: int) -> str:
+    if sec < 60:
+        return f"{sec}s"
+    if sec < 3600:
+        return f"{sec // 60}m{sec % 60:02d}s"
+    if sec < 86400:
+        return f"{sec // 3600}h{(sec % 3600) // 60:02d}m"
+    return f"{sec // 86400}d{(sec % 86400) // 3600:02d}h"
+
+
+def _trunc(s: str, n: int) -> str:
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def render(rep: dict, out=sys.stdout) -> None:
+    p = lambda *a: print(*a, file=out)  # noqa: E731
+    ov = rep["overview"]
+    th = rep["thresholds"]
+
+    p("OVERVIEW")
+    flag = "  ⚠" if ov["load_high"] else ""
+    p(f"  load    {ov['load1']:.2f} / {ov['load5']:.2f} / {ov['load15']:.2f}"
+      f"   ({ov['cores']} cores, threshold {ov['load_threshold']:.0f}){flag}")
+    p(f"  mem     {ov['mem_total_gib'] - ov['mem_avail_gib']:.1f}G / "
+      f"{ov['mem_total_gib']:.1f}G used   avail {ov['mem_avail_gib']:.1f}G "
+      f"({ov['mem_avail_pct']:.0f}%)" + ("  ⚠ CRITICAL" if ov["mem_critical"] else ""))
+    if ov["swap_total_gib"]:
+        p(f"  swap    {ov['swap_used_gib']:.1f}G / {ov['swap_total_gib']:.1f}G used "
+          f"({ov['swap_used_pct']:.0f}%)" + ("  ⚠" if ov["swap_high"] else ""))
+    else:
+        p("  swap    none configured")
+    p(f"  uptime  {fmt_age(ov['uptime_sec'])}")
+    p(f"  scanned {rep['counts']['processes']} processes, "
+      f"{rep['counts']['eligible']} eligible "
+      f"(younger than {th['min_age_sec']}s excluded — %CPU is a lifetime average)")
+
+    zs = rep["zombies"]
+    p("")
+    p(f"ZOMBIES ({zs['count']} under {len(zs['groups']) + len(zs['single'])} parent(s))")
+    if not zs["count"]:
+        p("  none")
+
+    def parent_note(ppid, comm, alive, to_init, indent="    "):
+        if to_init:
+            p(f"{indent}parent: pid 1 (init) — already reparented; init will reap. Inert.")
+        elif not alive:
+            p(f"{indent}parent: pid {ppid} GONE — will be reparented and reaped")
+        else:
+            p(f"{indent}parent: pid {ppid} {comm} — ALIVE and NOT reaping.")
+            p(f"{indent}        ^ this is the process to fix. A zombie whose parent had")
+            p(f"{indent}          died would already have been reaped, so a persistent")
+            p(f"{indent}          zombie always indicts a LIVE parent.")
+
+    for g in zs["groups"]:
+        p(f"  {g['count']}x zombie under pid {g['ppid']} "
+          f"{_trunc(g['parent_comm'] or '(gone)', 24)}"
+          f"   oldest {fmt_age(g['oldest_age_sec'])}")
+        p(f"    commands: {', '.join(g['comms'][:8])}"
+          + (" …" if len(g["comms"]) > 8 else ""))
+        p(f"    pids: {', '.join(str(i) for i in g['pids'][:10])}"
+          + (" …" if len(g["pids"]) > 10 else ""))
+        parent_note(g["ppid"], g["parent_comm"], g["parent_alive"],
+                    g["reparented_to_init"])
+    for z in zs["single"]:
+        p(f"  pid {z['pid']:<8} {_trunc(z['comm'], 20):<20} {fmt_age(z['age_sec']):>8}"
+          f"  user {z['user']}")
+        note = " (also a zombie)" if z["parent_is_zombie"] else ""
+        parent_note(z["ppid"], (z["parent_comm"] or "") + note, z["parent_alive"],
+                    z["reparented_to_init"])
+
+    for key, label, unit in (("cpu_hogs", "CPU HOGS", f">= {th['cpu']:.0f}%"),
+                             ("mem_hogs", "MEM HOGS", f">= {th['mem_gib']:.1f}G RSS")):
+        sec = rep[key]
+        total = len(sec["single"]) + sum(g["count"] for g in sec["groups"])
+        p("")
+        p(f"{label} ({total}, {unit})")
+        if not total:
+            p("  none")
+        for g in sec["groups"]:
+            parent = g["parent_comm"] or f"pid {g['ppid']} (gone)"
+            p(f"  {g['count']}x {_trunc(g['sample_comm'], 18):<18} under "
+              f"{_trunc(parent, 22):<22} {g['total_pcpu']:>6.1f}% "
+              f"{g['total_rss_gib']:>6.2f}G  combined")
+            p(f"    ppid {g['ppid']}  pids {', '.join(str(i) for i in g['pids'][:8])}"
+              + (" …" if len(g["pids"]) > 8 else ""))
+        for r in sec["single"]:
+            p(f"  pid {r['pid']:<8} {_trunc(r['comm'], 18):<18} {r['pcpu']:>6.1f}% "
+              f"{r['rss_gib']:>6.2f}G {fmt_age(r['age_sec']):>8}  {r['user']}")
+            p(f"    {_trunc(r['args'], 100)}")
+
+    p("")
+    p(f"RUNAWAYS ({len(rep['runaways'])}, >= {th['runaway_pct']:.0f}% for "
+      f">= {fmt_age(th['runaway_age_sec'])})")
+    if not rep["runaways"]:
+        p("  none")
+    for r in rep["runaways"]:
+        mark = "  ⚠ CRITICAL" if r["critical"] else ""
+        p(f"  pid {r['pid']:<8} {r['pcpu']:>6.1f}%  {fmt_age(r['age_sec']):>8}"
+          f"  {r['user']}{mark}")
+        p(f"    cmd:  {_trunc(r['args'], 100)}")
+        p(f"    cwd:  {r['cwd'] or '(unreadable)'}")
+        p(f"    ppid: {r['ppid']}")
+        # 🔴 A hint, never an action. This box runs many agents in parallel and
+        # their test workers look exactly like this; killing one reads as a code
+        # defect in whatever branch that agent was verifying. The cwd and ppid
+        # above are what tells them apart, so they are printed right beside it.
+        p(f"    to kill:  kill {r['pid']}")
+        p("      ^ check cwd/ppid is not a sibling agent's worktree first")
+
+    if "systemd" in rep:
+        s = rep["systemd"]
+        p("")
+        if not s["measured"]:
+            p(f"SYSTEMD — COULD NOT MEASURE: {s['reason']}")
+        else:
+            p(f"SYSTEMD ({len(s['units'])} failed user unit(s))")
+            for u in s["units"] or ["  none"]:
+                p(f"  {u}" if s["units"] else u)
+
+    if "fds" in rep:
+        f = rep["fds"]
+        p("")
+        p(f"OPEN FDS (top {len(f['top'])} of {f['examined']} examined; "
+          f"{f['unreadable']} unreadable, {f['vanished']} exited mid-scan)")
+        for r in f["top"]:
+            p(f"  pid {r['pid']:<8} {_trunc(r['comm'], 20):<20} {r['fds']:>6} fds"
+              f"  {r['user']}")
+        if f["unreadable"]:
+            p(f"  ⚠ {f['unreadable']} process(es) unreadable (not ours) — "
+              "UNMEASURED, not zero")
+
+    v = rep["verdict"]
+    p("")
+    p("VERDICT")
+    for c in v["critical"]:
+        p(f"  CRITICAL  {c}")
+    for w in v["warnings"]:
+        p(f"  warning   {w}")
+    if not v["critical"] and not v["warnings"]:
+        p("  clean")
+    p(f"  exit {v['exit_code']}")
+
+
+# ---------------------------------------------------------------------------
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        prog="syshealth",
+        description="On-demand deep system inspection (report-only).")
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of tables")
+    ap.add_argument("--cpu-threshold", type=float, default=DEF_CPU_THRESHOLD,
+                    metavar="PCT", help=f"%%CPU for a hog (default: {DEF_CPU_THRESHOLD:.0f})")
+    ap.add_argument("--mem-threshold", type=float, default=DEF_MEM_THRESHOLD,
+                    metavar="GIB", help=f"RSS GiB for a hog (default: {DEF_MEM_THRESHOLD})")
+    ap.add_argument("--load-threshold", type=float, default=None, metavar="N",
+                    help="load1 that counts as high (default: core count)")
+    ap.add_argument("--runaway-pct", type=float, default=DEF_RUNAWAY_PCT, metavar="PCT")
+    ap.add_argument("--runaway-age", type=int, default=DEF_RUNAWAY_AGE, metavar="SEC")
+    ap.add_argument("--min-age", type=int, default=DEF_MIN_AGE, metavar="SEC",
+                    help="ignore processes younger than this; their %%CPU is a "
+                         f"lifetime average over ~0 time (default: {DEF_MIN_AGE})")
+    ap.add_argument("--swap-warn-pct", type=float, default=DEF_SWAP_WARN_PCT, metavar="PCT")
+    ap.add_argument("--avail-crit-pct", type=float, default=DEF_AVAIL_CRIT_PCT, metavar="PCT")
+    ap.add_argument("--ignore", default=os.environ.get("SYSHEALTH_IGNORE", DEF_IGNORE),
+                    metavar="LIST",
+                    help=f"comma-separated substrings never to flag (default: {DEF_IGNORE})")
+    ap.add_argument("--systemd", action="store_true", help="add failed user units")
+    ap.add_argument("--fds", action="store_true", help="add open-FD counts (walks /proc)")
+    ap.add_argument("--proc-root", default="/proc", help=argparse.SUPPRESS)
+    return ap
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        procs = collect_ps()
+        loadavg = read_loadavg(args.proc_root)
+        meminfo = read_meminfo(args.proc_root)
+        uptime = read_uptime(args.proc_root)
+    except (RuntimeError, OSError, ValueError, IndexError) as e:
+        print(f"syshealth: COULD NOT MEASURE: {e}", file=sys.stderr)
+        return 3
+
+    rep = build_report(args, procs, loadavg, meminfo, uptime, args.proc_root)
+    if args.json:
+        json.dump(rep, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    else:
+        render(rep)
+    return rep["exit_code"]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_no_real_launchers.py
+++ b/scripts/tests/test_no_real_launchers.py
@@ -244,7 +244,8 @@ def test_the_stubbed_launcher_set_is_pinned():
 ACKNOWLEDGED_UNSTUBBED = {
     "systemctl": (
         {"airvpn-menu", "keylog-spin-capture.sh",
-         "monitor-blackout.sh", "run-tests.sh", "sync-claude-permissions.py"},
+         "monitor-blackout.sh", "run-tests.sh", "sync-claude-permissions.py",
+         "syshealth"},
         "verb-split rather than record-only — see the systemctl tests below. "
         "run-tests.sh is a THIRD case, re-justified rather than absorbed: its "
         "only occurrences of the name are GUARD 7's accounting, which counts "
@@ -257,7 +258,20 @@ ACKNOWLEDGED_UNSTUBBED = {
         "table of permission RULES, and the script spawns no subprocess at all — "
         "it imports none of subprocess / os.system / os.exec* / os.popen, which "
         "test_sync_claude_permissions.py asserts STRUCTURALLY so this "
-        "justification cannot rot into a claim about a file that has changed"),
+        "justification cannot rot into a claim about a file that has changed. "
+        "syshealth (added 2026-09-04) is the ONLY one of the six that genuinely "
+        "INVOKES systemctl, and is acknowledged on a different ground from the "
+        "other five: not unreachability, but the VERB. Its single call site is "
+        "`systemctl --user list-units --state=failed --no-legend --plain "
+        "--no-pager`, and `list-units` is on nolaunch.SYSTEMCTL_READ_VERBS, so "
+        "the verb-splitting stub PASSES IT THROUGH as a read rather than "
+        "blocking it — the call cannot start, stop or restart anything. It was "
+        "written as `--failed` first; that is a FLAG, and the stub's safe-flag "
+        "list is only --version/--help/-h, so the short form would have failed "
+        "closed. `test_syshealth.py::test_failed_units_asks_systemctl_for_a_"
+        "read_verb` pins the argv against SYSTEMCTL_READ_VERBS itself rather "
+        "than against a copied literal, so this justification goes red if the "
+        "call site ever grows a mutating verb"),
     "home-manager": (
         {"bar-status-poll", "drift-check.sh", "keylog-spin-capture.sh",
          "notify-failure.sh", "playwright-nixos", "resume-state.sh",

--- a/scripts/tests/test_skill_descriptions.py
+++ b/scripts/tests/test_skill_descriptions.py
@@ -232,31 +232,45 @@ MIN_LISTING_ENTRIES = 30
 # docstring; plus ux-audit-loops' now-dangling pointer at the first) took
 # it to 12,679 across 36 entries, which is where this ceiling was set.
 #
-# 🔴 THE MEASURE IS NOW 12,861 ACROSS 37 ENTRIES, SO HEADROOM IS 68 -- NOT ~250.
-# `subsystem-index` (#790) arrived at 182 chars as this module measures and slid
-# straight through, because 182 < 250. That is not a bug in this constant; it is
-# the constant's actual contract, and the sentence that used to sit here --
-# "so a NEW skill cannot be added without an eviction in the SAME commit" --
-# CLAIMED COVERAGE THIS CODE DOES NOT PROVIDE. `claude/RULES.md` calls that worse
-# than no guard, because reading as coverage is what stops anyone looking.
+# The 68-char-headroom era ENDED on 2026-09-04. It is recorded because the
+# reasoning still applies: headroom had been set below the MEAN entry (12,679 /
+# 36 = 352), so it forced the eviction conversation for a TYPICAL new skill and
+# let a small one through until the accumulated slack was gone. `subsystem-index`
+# (#790) slid straight through at 182 chars. By 12,861/37 the slack WAS gone and
+# the next addition of any size reddened this gate -- which is exactly what
+# happened when `syshealth` was added, and the conversation it forced is the one
+# below.
 #
-# What it really does: headroom is set below the MEAN entry (12,679 / 36 = 352 at
-# the time), so it forces the eviction conversation for a TYPICAL new skill and
-# lets a small one through until the accumulated slack is gone. At 68 chars the
-# slack IS gone: the next addition of ANY size reds this gate. Do not read that
-# as the guard having tightened -- it is the same guard, at the end of its rope.
+# 🔴 THE MEASURE IS NOW 12,259 ACROSS 38 ENTRIES, AND HEADROOM IS 0 BY CHOICE.
+# `syshealth` (+260) was paid for by shrinking the descriptions of three skills
+# that had NEVER FIRED -- `window-triage` 507->126, `initiatives` 389->128,
+# `standup` 367->116 -- for a net -602 against the old 12,861. Measured
+# 2026-09-04 over the whole retained transcript corpus on BOTH hosts (workbench
+# 900 sessions from 08-04, laptop 170 from 07-12), counting the three real
+# attribution channels `find-session --skill` reads. Zero recorded invocations
+# each: full routing prose was buying no routing. All three keep their bodies and
+# stay /-invocable; only the always-on listing entry shrank.
 #
-# 🔴 DO NOT "re-pin to the current measurement plus 250" -- that would RAISE this
-# number, which is the one thing the paragraph below forbids. Leave it at 12_929.
-# The structural answer to a listing that keeps regrowing is the tier ledger
-# (`claude/skill-tiers.json`, gated by `scripts/tests/test_skill_tiers.py`):
-# demote a skill to `name-only` and its entry stops being charged here at all.
+# 🔴 THE COUNTER CANNOT SEE SERVICE-DRIVEN USE, so it is EVIDENCE, NOT A VERDICT.
+# The same sweep read 0 for `adoption-scan` (20,494 tool-invocation events), 1 for
+# `dl-router` (a live systemd service) and 0 for `repo-cos` (a weekly timer whose
+# output is read as email). A zero here means "no skill invocation in a Claude
+# Code transcript", never "dead" -- shrink on a zero only after asking how else
+# the thing is driven, and never delete on one.
+#
+# 🔴 DO NOT "re-pin to the measurement plus slack" -- that RAISES this number,
+# which the paragraph below forbids. Pinned at exactly the measurement, so the
+# next addition of any size reds this gate on purpose.
+# ⚠ Demoting to tier B does NOT relieve this ceiling, and a comment here used to
+# imply it did. `listing_total_chars` sums EVERY entry and never reads
+# `claude/skill-tiers.json`; the ledger changes what a host is told, not what this
+# repo declares. Only shortening or removing description text moves this number.
 #
 # LOWER it when you cut; do NOT raise it to make a new description fit. A ceiling
 # left at the previous, larger number licenses exactly the regrowth this constant
 # exists to catch, so re-pinning it is part of the cut, not follow-up work. The
 # eviction playbook is printed by the failing assertion below.
-LISTING_TOTAL_CEILING_CHARS = 12_929
+LISTING_TOTAL_CEILING_CHARS = 12_259
 
 # The skills deployed by `mkOutOfStoreSymlink` from `scripts/` instead of by the
 # recursive `claude/skills` mapping (`nix/home.nix`). They are listing entries

--- a/scripts/tests/test_skill_tiers.py
+++ b/scripts/tests/test_skill_tiers.py
@@ -83,20 +83,30 @@ MIN_SKILLS = 30
 # 36-entry total quoted in a 37-entry tree, and one contradicted the number the
 # same change reported to its reviewer.
 # --------------------------------------------------------------------------- #
-MEASURED_ENTRIES = 40
+MEASURED_ENTRIES = 41
 MEASURED_TIER_A_ENTRIES = 24
-MEASURED_TIER_A_CHARS = 8_567
+MEASURED_TIER_A_CHARS = 7_674
 # devrc's whole listing under the ledger (tier A in full, tier B name-only).
-MEASURED_UNDER_LEDGER_CHARS = 8_796
-# ...and what the same 40 entries would cost with every skill tier A. The
-# difference is what the ledger buys: 4,295 chars.
-MEASURED_ALL_TIER_A_CHARS = 13_091
+MEASURED_UNDER_LEDGER_CHARS = 7_915
+# ...and what the same 41 entries would cost with every skill tier A. The
+# difference is what the ledger buys: 4,548 chars.
+MEASURED_ALL_TIER_A_CHARS = 12_463
 
 # 🔴 THE TIER-A RATCHET, in the REAL formula: the tier-A block cost
 # `sum(len(name) + 4 + min(len(desc), 1536)) + (n - 1)`.
 #
 # The ceiling sits 254 chars above MEASURED_TIER_A_CHARS — less than the MEAN
-# tier-A entry, which is 8,567 / 24 = 357.0.
+# tier-A entry, which is 7,674 / 24 = 319.8.
+#
+# 🔴 LOWERED 8_821 -> 7_928 on 2026-09-04. `syshealth` (tier B) was added and
+# paid for by shrinking three tier-A entries that had NEVER FIRED in the whole
+# retained transcript corpus on either host — `window-triage` 507->126,
+# `initiatives` 389->128, `standup` 367->116. They keep their bodies and stay
+# /-invocable; only the always-on listing entry shrank. See the sibling comment
+# in `test_skill_descriptions.py` for the measurement and, more importantly, for
+# why a zero in that sweep is EVIDENCE and never a verdict: the same counter
+# reads 0 for `adoption-scan` (20,494 tool events) and for `repo-cos` (a weekly
+# timer read as email).
 #
 # ⚠ IT WAS LOWERED FROM 9,200 -> 8,935 -> 8,821 WHEN `cairn` LANDED, and the
 # lowering is the point rather than paperwork: `cairn` is tier B and cost this
@@ -135,7 +145,7 @@ MEASURED_ALL_TIER_A_CHARS = 13_091
 # LOWER it when you cut; do NOT raise it to make a new description fit. Demoting
 # one skill to tier B in claude/skill-tiers.json is a ONE-LINE edit and is the
 # intended move. The playbook is printed by the failing assertion below.
-TIER_A_CEILING_CHARS = 8_821
+TIER_A_CEILING_CHARS = 7_928
 
 # 🔴 Skills that must NEVER be tier B, pinned as a RELATIONSHIP rather than left
 # to review. Each one fires from a SYMPTOM Zach describes rather than from its own

--- a/scripts/tests/test_syshealth.py
+++ b/scripts/tests/test_syshealth.py
@@ -1,0 +1,931 @@
+"""Tests for `scripts/syshealth`.
+
+TWO TIERS, on purpose. The rules live in pure functions over a list of `Proc`
+records, so most of this file calls them directly on fixtures — no subprocess,
+no PATH stubs, no dependence on what this host happens to be running. The
+end-to-end tier below then drives the real CLI with a stubbed `ps` and a fake
+`/proc` root, because a pure-function suite is structurally blind to argument
+parsing, the exit-code path and the renderer.
+
+🔴 FIXTURE VALUES ARE PAIRWISE DISTINCT AND DISTINCT FROM THE CONSTANTS THEY
+TEST. A fixture whose %CPU happens to equal the default threshold cannot see a
+mutant that hardcodes that default, so it would survive a fully green suite.
+Where a test pins a boundary it also pins a value on the other side of it.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # scripts/
+from testlib import mockbin  # noqa: E402
+
+SCRIPT = Path(__file__).resolve().parents[1] / "syshealth"
+
+
+def _load():
+    """Import `scripts/syshealth` — it has no .py suffix, so by spec + location.
+
+    🔴 The module must be in `sys.modules` BEFORE exec_module: `@dataclass`
+    resolves annotations through `sys.modules[cls.__module__].__dict__`, and
+    without the registration that lookup returns None and the import dies with
+    a bare AttributeError pointing at dataclasses.py.
+    """
+    loader = importlib.machinery.SourceFileLoader("syshealth", str(SCRIPT))
+    spec = importlib.util.spec_from_loader("syshealth", loader)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["syshealth"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+sh = _load()
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+def P(pid, ppid=1, user="zach", pcpu=0.3, pmem=0.1, rss_kb=4096,
+      etimes=3607, stat="S", args="/usr/bin/thing --flag"):
+    """A Proc with deliberately unround defaults, so a mutant that substitutes a
+    constant cannot coincidentally match one."""
+    return sh.Proc(pid=pid, ppid=ppid, user=user, pcpu=pcpu, pmem=pmem,
+                   rss_kb=rss_kb, etimes=etimes, stat=stat, args=args)
+
+
+def zombie(pid, ppid, comm="find", etimes=90061):
+    return P(pid=pid, ppid=ppid, pcpu=0.0, rss_kb=0, etimes=etimes,
+             stat="Z", args=f"[{comm}] <defunct>")
+
+
+class Args:
+    """Stand-in for the argparse namespace, with the script's real defaults."""
+
+    def __init__(self, **kw):
+        self.cpu_threshold = sh.DEF_CPU_THRESHOLD
+        self.mem_threshold = sh.DEF_MEM_THRESHOLD
+        self.load_threshold = None
+        self.runaway_pct = sh.DEF_RUNAWAY_PCT
+        self.runaway_age = sh.DEF_RUNAWAY_AGE
+        self.min_age = sh.DEF_MIN_AGE
+        self.swap_warn_pct = sh.DEF_SWAP_WARN_PCT
+        self.avail_crit_pct = sh.DEF_AVAIL_CRIT_PCT
+        self.ignore = sh.DEF_IGNORE
+        self.systemd = False
+        self.fds = False
+        self.json = False
+        self.proc_root = "/proc"
+        self.__dict__.update(kw)
+
+
+# ---------------------------------------------------------------------------
+# parse_ps
+# ---------------------------------------------------------------------------
+def test_parse_ps_reads_a_normal_row():
+    procs = sh.parse_ps("  1234  1200 zach  12.5  3.7  918273  4821 Sl+ /bin/thing -a -b\n")
+    assert len(procs) == 1
+    p = procs[0]
+    assert (p.pid, p.ppid, p.user) == (1234, 1200, "zach")
+    assert (p.pcpu, p.pmem, p.rss_kb, p.etimes) == (12.5, 3.7, 918273, 4821)
+    assert p.stat == "Sl+"
+    assert p.args == "/bin/thing -a -b"
+
+
+def test_parse_ps_keeps_spaces_in_args():
+    """`args` is last and takes the whole remainder — the reason `comm=` is not
+    requested from ps at all. A maxsplit off by one truncates the command."""
+    procs = sh.parse_ps("7 1 root 0.0 0.0 100 5 S python3 -u -c import sys; go()\n")
+    assert procs[0].args == "python3 -u -c import sys; go()"
+
+
+def test_parse_ps_handles_a_defunct_row():
+    procs = sh.parse_ps(" 316293 2273825 root  0.1  0.0     0  516852 Z    [find] <defunct>\n")
+    assert procs[0].is_zombie
+    assert procs[0].comm == "find"
+
+
+def test_parse_ps_skips_unparseable_and_short_lines():
+    text = ("PID PPID USER %CPU %MEM RSS ELAPSED STAT COMMAND\n"   # a header
+            "  1 0 root 0.0 0.0 12 99 Ss /sbin/init\n"
+            "garbage\n"
+            "\n")
+    procs = sh.parse_ps(text)
+    assert [p.pid for p in procs] == [1]
+
+
+def test_parse_ps_tolerates_an_empty_args_column():
+    """Some ps builds print nothing at all for a defunct process."""
+    procs = sh.parse_ps(" 42 1 root 0.0 0.0 0 77 Z \n")
+    assert len(procs) == 1 and procs[0].args == ""
+
+
+# ---------------------------------------------------------------------------
+# Proc properties
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("stat,expected", [
+    ("Z", True), ("Zs", True), ("Zl+", True),
+    ("S", False), ("Ss", False), ("R", False), ("D", False), ("Sl+", False),
+    # 🔴 Not a state ps emits today — Z never appears as a trailing flag. It is
+    # here to pin the PREFIX semantics as a deliberate contract: without it,
+    # rewriting the guard as `"Z" in self.stat` passes the whole suite (measured
+    # — that mutant SURVIVED until this row was added). The parametrize claimed
+    # to cover both failure directions while only covering one.
+    ("SZ", False),
+])
+def test_is_zombie_reads_only_the_leading_state_letter(stat, expected):
+    """`Zs` IS a real zombie state on this box (measured: pid 988429), so an
+    equality test against "Z" misses it. The prefix read is pinned in both
+    directions — see the SZ row for why the second direction is synthetic."""
+    assert P(1, stat=stat).is_zombie is expected
+
+
+def test_comm_is_basenamed_and_debracketed():
+    assert P(1, args="/nix/store/abc-k3s/bin/k3s server").comm == "k3s"
+    assert P(1, args="[run_batch.sh] <defunct>").comm == "run_batch.sh"
+    assert P(1, args="").comm == ""
+
+
+def test_rss_gib_converts_from_kib():
+    assert P(1, rss_kb=2 * 1024 * 1024).rss_gib == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# 🔴 The min-age guard — the reason this script exists rather than four ps calls
+# ---------------------------------------------------------------------------
+def test_a_young_process_at_impossible_cpu_is_not_flagged():
+    """THE regression test. Reproduces the exact rows the manual sweep of
+    2026-09-03 misread: `ps` itself at 1100% and a `pgrep` at 240%, both aged
+    0s, both reported as runaways. ps's %CPU is cpu-time/elapsed over the
+    process's whole life, so at ~0 elapsed it is division noise."""
+    young = P(3733669, pcpu=240.0, etimes=0, args="pgrep -o -f find /nix -xdev")
+    elig = sh.eligible([young], ignore=[], min_age=sh.DEF_MIN_AGE, mypid=999999)
+    assert elig == []
+    assert sh.find_cpu_hogs(elig, sh.DEF_CPU_THRESHOLD) == []
+    assert sh.find_runaways(elig, sh.DEF_RUNAWAY_PCT, sh.DEF_RUNAWAY_AGE) == []
+
+
+def test_the_same_process_IS_flagged_once_it_is_old_enough():
+    """The other half of the control pair. Without this, a mutant that drops
+    every process (`return []`) would pass the test above."""
+    old = P(3733669, pcpu=240.0, etimes=4001, args="pgrep -o -f find /nix -xdev")
+    elig = sh.eligible([old], ignore=[], min_age=sh.DEF_MIN_AGE, mypid=999999)
+    assert [p.pid for p in elig] == [3733669]
+    assert [p.pid for p in sh.find_cpu_hogs(elig, sh.DEF_CPU_THRESHOLD)] == [3733669]
+
+
+@pytest.mark.parametrize("etimes,eligible_now", [
+    (sh.DEF_MIN_AGE - 1, False),   # just under
+    (sh.DEF_MIN_AGE, True),        # exactly at the boundary — `>=`, not `>`
+    (sh.DEF_MIN_AGE + 1, True),
+])
+def test_min_age_boundary_is_inclusive(etimes, eligible_now):
+    procs = [P(555, pcpu=61.5, etimes=etimes)]
+    got = sh.eligible(procs, ignore=[], min_age=sh.DEF_MIN_AGE, mypid=999999)
+    assert bool(got) is eligible_now
+
+
+def test_min_age_is_configurable_and_actually_consulted():
+    """Feeds a value the default CANNOT equal, so a mutant hardcoding
+    DEF_MIN_AGE is visible."""
+    procs = [P(556, pcpu=61.5, etimes=sh.DEF_MIN_AGE + 3)]
+    assert sh.eligible(procs, [], min_age=sh.DEF_MIN_AGE, mypid=999999)
+    assert sh.eligible(procs, [], min_age=sh.DEF_MIN_AGE + 900, mypid=999999) == []
+
+
+def test_zombies_are_never_age_gated():
+    """A fresh zombie is still a zombie — the min-age rule is about %CPU being
+    meaningless, which does not apply to a state letter."""
+    z = zombie(77, ppid=42, etimes=1)
+    assert sh.find_zombies([z, P(42, args="/bin/parent")], mypid=999999)
+
+
+# ---------------------------------------------------------------------------
+# Self-exclusion
+# ---------------------------------------------------------------------------
+def test_self_pids_covers_self_children_and_ancestors():
+    procs = [P(100, ppid=1, args="/bin/agent"),      # grandparent
+             P(200, ppid=100, args="/bin/zsh"),      # parent
+             P(300, ppid=200, args="python syshealth"),  # us
+             P(400, ppid=300, args="ps -eo ..."),    # our ps child
+             P(500, ppid=1, args="/bin/unrelated")]
+    assert sh.self_pids(procs, mypid=300) == {100, 200, 300, 400}
+
+
+def test_our_own_ps_child_is_never_reported_as_a_hog():
+    """The 1100% row in the 2026-09-03 sweep WAS the ps that produced it."""
+    procs = [P(300, ppid=1, args="python syshealth", etimes=99),
+             P(400, ppid=300, pcpu=1100.0, etimes=99, args="ps -eo pid=,ppid=")]
+    elig = sh.eligible(procs, [], min_age=sh.DEF_MIN_AGE, mypid=300)
+    assert sh.find_cpu_hogs(elig, sh.DEF_CPU_THRESHOLD) == []
+
+
+def test_self_pids_terminates_on_a_parent_cycle():
+    """A torn `ps` read can produce a cycle; the walk must not hang."""
+    procs = [P(10, ppid=11), P(11, ppid=10)]
+    assert sh.self_pids(procs, mypid=10) == {10, 11}
+
+
+# ---------------------------------------------------------------------------
+# Ignore list
+# ---------------------------------------------------------------------------
+def test_parse_ignore_accepts_commas_or_spaces_and_lowercases():
+    assert sh.parse_ignore("Anno, logd  Foo,") == ["anno", "logd", "foo"]
+    assert sh.parse_ignore("") == []
+
+
+def test_ignore_matches_command_case_insensitively():
+    p = P(1, args="Z:\\steam\\Anno1800.exe -windowed", pcpu=203.0, etimes=2263)
+    assert sh.is_ignored(p, ["anno"])
+    assert not sh.is_ignored(p, ["logd"])
+
+
+def test_an_ignored_process_is_dropped_from_every_cpu_rule():
+    procs = [P(1, args="/games/Anno1800.exe", pcpu=203.0, etimes=2263),
+             P(2, args="/bin/real-hog", pcpu=97.5, etimes=2263)]
+    elig = sh.eligible(procs, ["anno"], min_age=sh.DEF_MIN_AGE, mypid=999999)
+    assert [p.pid for p in elig] == [2]
+
+
+def test_an_empty_ignore_list_drops_nothing():
+    """Positive control for the filter: with no tokens it must not silently
+    match everything (a `not any([])`-shaped mutant would)."""
+    procs = [P(1, args="/games/Anno1800.exe", pcpu=203.0, etimes=2263)]
+    assert len(sh.eligible(procs, [], min_age=sh.DEF_MIN_AGE, mypid=999999)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Zombies + parent tracking
+# ---------------------------------------------------------------------------
+def test_zombie_parent_is_resolved_to_a_live_command():
+    procs = [zombie(316293, ppid=2273825, comm="find"),
+             P(2273825, ppid=2273620, args="sleep infinity", stat="Ss")]
+    z = sh.find_zombies(procs, mypid=999999)[0]
+    assert z["ppid"] == 2273825
+    assert z["parent_comm"] == "sleep"
+    assert z["parent_alive"] is True
+    assert z["reparented_to_init"] is False
+
+
+def test_zombie_with_a_missing_parent_is_reported_as_gone():
+    z = sh.find_zombies([zombie(316293, ppid=999001)], mypid=999999)[0]
+    assert z["parent_alive"] is False and z["parent_comm"] is None
+
+
+def test_zombie_reparented_to_init_is_labelled():
+    procs = [zombie(316293, ppid=1), P(1, ppid=0, args="/sbin/init")]
+    z = sh.find_zombies(procs, mypid=999999)[0]
+    assert z["reparented_to_init"] is True and z["parent_alive"] is True
+
+
+def test_a_zombie_whose_parent_is_also_a_zombie_is_flagged():
+    procs = [zombie(2, ppid=3), zombie(3, ppid=4), P(4, args="/bin/top")]
+    got = {z["pid"]: z for z in sh.find_zombies(procs, mypid=999999)}
+    assert got[2]["parent_is_zombie"] is True
+    assert got[3]["parent_is_zombie"] is False
+
+
+def test_zombies_are_sorted_oldest_first():
+    procs = [zombie(1, ppid=9, etimes=100), zombie(2, ppid=9, etimes=90061),
+             zombie(3, ppid=9, etimes=5000), P(9, args="/bin/p")]
+    assert [z["pid"] for z in sh.find_zombies(procs, mypid=999999)] == [2, 3, 1]
+
+
+def test_group_zombies_collapses_a_shared_un_reaping_parent():
+    """Reproduces the measured shape: 18 under one parent, 3 under another."""
+    procs = [P(2273825, args="sleep infinity"), P(3716907, args="/bin/stash")]
+    procs += [zombie(1000 + i, ppid=2273825, comm="find") for i in range(18)]
+    procs += [zombie(2000 + i, ppid=3716907, comm="python3") for i in range(3)]
+    groups, single = sh.group_zombies(sh.find_zombies(procs, mypid=999999))
+    assert single == []
+    assert [(g["ppid"], g["count"]) for g in groups] == [(2273825, 18), (3716907, 3)]
+    assert groups[0]["parent_comm"] == "sleep"
+
+
+@pytest.mark.parametrize("n,grouped", [
+    (sh.GROUP_MIN_CHILDREN - 1, False),
+    (sh.GROUP_MIN_CHILDREN, True),
+])
+def test_group_zombies_boundary(n, grouped):
+    procs = [P(700, args="/bin/parent")]
+    procs += [zombie(800 + i, ppid=700) for i in range(n)]
+    groups, single = sh.group_zombies(sh.find_zombies(procs, mypid=999999))
+    assert bool(groups) is grouped
+    assert (len(single) == 0) is grouped
+
+
+def test_zombie_group_reports_the_oldest_age_not_the_first():
+    """🔴 Grouped on a list whose FIRST element is not the oldest, on purpose.
+
+    `find_zombies` already returns oldest-first, so feeding its output straight
+    in makes `kids[0]["age_sec"]` and `max(...)` the same value — the mutant is
+    then equivalent and SURVIVES (measured). Reversing the list is the control
+    that makes the two expressions disagree.
+    """
+    procs = [P(700, args="/bin/parent")]
+    procs += [zombie(801, ppid=700, etimes=5), zombie(802, ppid=700, etimes=90061),
+              zombie(803, ppid=700, etimes=77)]
+    zs = list(reversed(sh.find_zombies(procs, mypid=999999)))
+    assert zs[0]["age_sec"] != 90061, "fixture no longer exercises the ordering"
+    groups, _ = sh.group_zombies(zs)
+    assert groups[0]["oldest_age_sec"] == 90061
+
+
+# ---------------------------------------------------------------------------
+# Hogs, runaways, grouping
+# ---------------------------------------------------------------------------
+def test_cpu_hogs_respect_the_threshold_on_both_sides():
+    procs = [P(1, pcpu=61.5, etimes=2263), P(2, pcpu=13.2, etimes=2263)]
+    elig = sh.eligible(procs, [], sh.DEF_MIN_AGE, mypid=999999)
+    assert [p.pid for p in sh.find_cpu_hogs(elig, 50.0)] == [1]
+    assert [p.pid for p in sh.find_cpu_hogs(elig, 70.0)] == []
+    assert [p.pid for p in sh.find_cpu_hogs(elig, 10.0)] == [1, 2]
+
+
+def test_cpu_hogs_are_sorted_hottest_first():
+    procs = [P(1, pcpu=61.5, etimes=2263), P(2, pcpu=97.5, etimes=2263),
+             P(3, pcpu=73.1, etimes=2263)]
+    elig = sh.eligible(procs, [], sh.DEF_MIN_AGE, mypid=999999)
+    assert [p.pid for p in sh.find_cpu_hogs(elig, 50.0)] == [2, 3, 1]
+
+
+def test_mem_hogs_use_gib_not_kib():
+    """1_500_000 KiB is ~1.43 GiB — over a 1.0 threshold, under a 2.0 one.
+    A mutant comparing raw KiB against the GiB threshold flags both."""
+    procs = [P(1, rss_kb=1_500_000, etimes=2263), P(2, rss_kb=700_000, etimes=2263)]
+    elig = sh.eligible(procs, [], sh.DEF_MIN_AGE, mypid=999999)
+    assert [p.pid for p in sh.find_mem_hogs(elig, 1.0)] == [1]
+    assert [p.pid for p in sh.find_mem_hogs(elig, 2.0)] == []
+
+
+def test_runaway_needs_BOTH_the_percentage_and_the_age():
+    hot_young = P(1, pcpu=97.5, etimes=61)        # hot, too new
+    warm_old = P(2, pcpu=13.2, etimes=90061)      # old, not hot
+    hot_old = P(3, pcpu=97.5, etimes=90061)       # both
+    elig = sh.eligible([hot_young, warm_old, hot_old], [], sh.DEF_MIN_AGE,
+                       mypid=999999)
+    got = sh.find_runaways(elig, sh.DEF_RUNAWAY_PCT, sh.DEF_RUNAWAY_AGE)
+    assert [p.pid for p in got] == [3]
+
+
+@pytest.mark.parametrize("pcpu,etimes,crit", [
+    (sh.CRIT_RUNAWAY_PCT + 13, sh.CRIT_RUNAWAY_AGE + 401, True),
+    (sh.CRIT_RUNAWAY_PCT - 13, sh.CRIT_RUNAWAY_AGE + 401, False),
+    (sh.CRIT_RUNAWAY_PCT + 13, sh.CRIT_RUNAWAY_AGE - 401, False),
+    (sh.CRIT_RUNAWAY_PCT, sh.CRIT_RUNAWAY_AGE, True),  # boundary is inclusive
+])
+def test_critical_runaway_needs_both_arms(pcpu, etimes, crit):
+    assert sh.is_critical_runaway(P(1, pcpu=pcpu, etimes=etimes)) is crit
+
+
+def test_group_by_parent_collapses_workers_and_sums_them():
+    parent = P(2992278, args="python -m pytest scripts/tests -n 4")
+    kids = [P(2993230 + i, ppid=2992278, pcpu=25.8, rss_kb=292336, etimes=286)
+            for i in range(4)]
+    elig = sh.eligible([parent] + kids, [], sh.DEF_MIN_AGE, mypid=999999)
+    hogs = sh.find_cpu_hogs(elig, 20.0)
+    groups, single = sh.group_by_parent(hogs, [parent] + kids)
+    assert len(groups) == 1
+    g = groups[0]
+    assert g["ppid"] == 2992278 and g["count"] == 4
+    assert g["parent_comm"] == "python"
+    assert g["total_pcpu"] == pytest.approx(103.2)
+    assert single == []
+
+
+@pytest.mark.parametrize("n,grouped", [
+    (sh.GROUP_MIN_CHILDREN - 1, False),
+    (sh.GROUP_MIN_CHILDREN, True),      # exactly at the bar — `>=`, not `>`
+    (sh.GROUP_MIN_CHILDREN + 1, True),
+])
+def test_group_by_parent_boundary_is_inclusive(n, grouped):
+    """🔴 The `== GROUP_MIN_CHILDREN` row is load-bearing. The sum test below
+    uses four workers, which groups under both `>= 3` and `> 3`, so without a
+    row landing exactly ON the bar a `>` mutant SURVIVES the whole suite
+    (measured)."""
+    kids = [P(10 + i, ppid=9, pcpu=61.5, etimes=2263) for i in range(n)]
+    groups, single = sh.group_by_parent(kids, kids)
+    assert bool(groups) is grouped
+    assert (single == []) is grouped
+    assert len(single) == (0 if grouped else n)
+
+
+def test_group_by_parent_handles_a_dead_parent():
+    kids = [P(10 + i, ppid=999001, pcpu=61.5, etimes=2263) for i in range(4)]
+    groups, _ = sh.group_by_parent(kids, kids)
+    assert groups[0]["parent_alive"] is False
+    assert groups[0]["parent_comm"] is None
+
+
+# ---------------------------------------------------------------------------
+# Overview + verdict
+# ---------------------------------------------------------------------------
+def _meminfo(total=129_000_000, avail=64_000_000, swap_total=90_600_000,
+             swap_free=39_000_000):
+    return {"MemTotal": total, "MemAvailable": avail,
+            "SwapTotal": swap_total, "SwapFree": swap_free}
+
+
+def _report(procs, args=None, load=(9.1, 9.18, 9.28), meminfo=None, **kw):
+    return sh.build_report(args or Args(**kw), procs, load,
+                           meminfo or _meminfo(), 2_680_000,
+                           proc_root="/nonexistent-proc", mypid=999999)
+
+
+def test_a_clean_system_exits_0():
+    rep = _report([P(1, ppid=0, args="/sbin/init"), P(500, args="/bin/idle")],
+                  meminfo=_meminfo(swap_total=0, swap_free=0),
+                  load_threshold=24.0)
+    assert rep["verdict"] == {"exit_code": 0, "critical": [], "warnings": []}
+    assert rep["exit_code"] == 0
+
+
+def test_zombies_alone_produce_exit_1():
+    procs = [P(700, args="/bin/parent"), zombie(801, ppid=700)]
+    rep = _report(procs, meminfo=_meminfo(swap_total=0, swap_free=0),
+                  load_threshold=24.0)
+    assert rep["exit_code"] == 1
+    assert any("zombie" in w for w in rep["verdict"]["warnings"])
+
+
+def test_high_load_produces_exit_1_and_names_the_number():
+    rep = _report([P(1, args="/sbin/init")], load=(55.18, 39.53, 32.08),
+                  meminfo=_meminfo(swap_total=0, swap_free=0), load_threshold=24.0)
+    assert rep["exit_code"] == 1
+    assert rep["overview"]["load_high"] is True
+    assert any("55.18" in w for w in rep["verdict"]["warnings"])
+
+
+def test_load_below_threshold_is_not_a_warning():
+    rep = _report([P(1, args="/sbin/init")], load=(9.1, 9.2, 9.3),
+                  meminfo=_meminfo(swap_total=0, swap_free=0), load_threshold=24.0)
+    assert rep["overview"]["load_high"] is False and rep["exit_code"] == 0
+
+
+def test_load_threshold_defaults_to_the_core_count():
+    rep = _report([P(1, args="/sbin/init")], load=(9.1, 9.2, 9.3),
+                  meminfo=_meminfo(swap_total=0, swap_free=0))
+    assert rep["overview"]["load_threshold"] == float(os.cpu_count() or 1)
+
+
+def test_swap_pressure_warns_and_reports_the_percentage():
+    rep = _report([P(1, args="/sbin/init")], load_threshold=24.0,
+                  meminfo=_meminfo(swap_total=90_600_000, swap_free=39_000_000))
+    assert rep["overview"]["swap_used_pct"] == pytest.approx(56.9, abs=0.2)
+    assert rep["overview"]["swap_high"] is True
+    assert rep["exit_code"] == 1
+
+
+def test_low_swap_use_does_not_warn():
+    rep = _report([P(1, args="/sbin/init")], load_threshold=24.0,
+                  meminfo=_meminfo(swap_total=90_600_000, swap_free=85_000_000))
+    assert rep["overview"]["swap_high"] is False and rep["exit_code"] == 0
+
+
+def test_no_swap_configured_is_not_pressure():
+    """Division-by-zero guard: a box with swap off must read 0%, not crash and
+    not warn."""
+    rep = _report([P(1, args="/sbin/init")], load_threshold=24.0,
+                  meminfo=_meminfo(swap_total=0, swap_free=0))
+    assert rep["overview"]["swap_used_pct"] == 0.0
+    assert rep["overview"]["swap_high"] is False
+
+
+def test_memory_near_exhaustion_is_CRITICAL_exit_2():
+    rep = _report([P(1, args="/sbin/init")], load_threshold=24.0,
+                  meminfo=_meminfo(total=129_000_000, avail=2_400_000,
+                                   swap_total=0, swap_free=0))
+    assert rep["exit_code"] == 2
+    assert rep["verdict"]["critical"]
+
+
+def test_a_sustained_runaway_is_CRITICAL_exit_2():
+    procs = [P(479313, pcpu=213.0, etimes=90061, args="/games/Darktide.exe")]
+    rep = _report(procs, load_threshold=24.0, ignore="",
+                  meminfo=_meminfo(swap_total=0, swap_free=0))
+    assert rep["exit_code"] == 2
+    assert rep["runaways"][0]["critical"] is True
+    assert any("479313" in c for c in rep["verdict"]["critical"])
+
+
+def test_the_same_runaway_is_only_a_warning_when_short_lived():
+    """Control pair for the test above: drops ONLY the age below the critical
+    bar, so a mutant ignoring the age arm is visible."""
+    procs = [P(479313, pcpu=213.0, etimes=sh.CRIT_RUNAWAY_AGE - 401,
+               args="/games/Darktide.exe")]
+    rep = _report(procs, load_threshold=24.0, ignore="",
+                  meminfo=_meminfo(swap_total=0, swap_free=0))
+    assert rep["exit_code"] == 1
+    assert rep["runaways"][0]["critical"] is False
+
+
+def test_critical_outranks_warning_in_the_exit_code():
+    procs = [P(700, args="/bin/parent"), zombie(801, ppid=700),
+             P(479313, pcpu=213.0, etimes=90061, args="/bin/hot")]
+    rep = _report(procs, load=(55.18, 39.5, 32.0), load_threshold=24.0, ignore="",
+                  meminfo=_meminfo(swap_total=0, swap_free=0))
+    assert rep["exit_code"] == 2
+    assert rep["verdict"]["warnings"] and rep["verdict"]["critical"]
+
+
+def test_the_verdict_names_every_reason_not_just_the_code():
+    """A bare 1 tells the reader nothing about which of six rules fired."""
+    procs = [P(700, args="/bin/parent"), zombie(801, ppid=700),
+             P(3, pcpu=97.5, etimes=2263, args="/bin/hog")]
+    rep = _report(procs, load=(55.18, 39.5, 32.0), load_threshold=24.0, ignore="",
+                  meminfo=_meminfo(swap_total=90_600_000, swap_free=39_000_000))
+    joined = " | ".join(rep["verdict"]["warnings"])
+    for expected in ("load1", "swap", "zombie", "cpu hogs"):
+        assert expected in joined, f"{expected!r} missing from {joined!r}"
+
+
+def test_grouped_hogs_are_counted_by_member_not_by_group():
+    """A count of GROUPS would report 1 where 4 processes are hogging."""
+    parent = P(2992278, args="python -m pytest -n 4")
+    kids = [P(2993230 + i, ppid=2992278, pcpu=97.5, etimes=286) for i in range(4)]
+    rep = _report([parent] + kids, load_threshold=24.0, ignore="",
+                  meminfo=_meminfo(swap_total=0, swap_free=0))
+    assert any("4 cpu hogs" in w for w in rep["verdict"]["warnings"])
+
+
+def test_report_counts_processes_and_eligibles_separately():
+    procs = [P(1, args="/sbin/init"), P(2, etimes=0, args="/bin/newborn")]
+    rep = _report(procs, load_threshold=24.0,
+                  meminfo=_meminfo(swap_total=0, swap_free=0))
+    assert rep["counts"]["processes"] == 2
+    assert rep["counts"]["eligible"] == 1
+
+
+def test_thresholds_are_echoed_into_the_report():
+    """The report must carry the scope it was measured at."""
+    rep = _report([P(1, args="/sbin/init")], cpu_threshold=71.0,
+                  mem_threshold=3.5, min_age=45, load_threshold=24.0,
+                  meminfo=_meminfo(swap_total=0, swap_free=0))
+    th = rep["thresholds"]
+    assert (th["cpu"], th["mem_gib"], th["min_age_sec"]) == (71.0, 3.5, 45)
+
+
+# ---------------------------------------------------------------------------
+# Optional sections
+# ---------------------------------------------------------------------------
+def test_failed_units_parses_unit_names():
+    got = sh.failed_units(lambda cmd: (0, "dl-router.service loaded failed failed X\n"
+                                          "mail.service loaded failed failed Y\n", ""))
+    assert got == {"measured": True, "reason": None,
+                   "units": ["dl-router.service", "mail.service"]}
+
+
+def test_failed_units_asks_systemctl_for_a_read_verb():
+    """🔴 The systemctl call site must stay a READ, pinned against the repo's own
+    verb list rather than a literal copied into this file.
+
+    `test_no_real_launchers.py` acknowledges `syshealth` as a systemctl reacher on
+    exactly this ground — it is the only acknowledged file that really invokes the
+    binary — so if the argv ever grows a mutating verb, that justification becomes
+    false. This is the test named there; it fails the moment that happens.
+
+    Note `--failed` is deliberately NOT used: it is a FLAG, and nolaunch's
+    safe-flag list is only --version/--help/-h, so the short spelling would fail
+    closed in the suite while reading identically on a real host.
+    """
+    from testlib import nolaunch  # noqa: PLC0415 — keep module import cheap
+
+    seen = {}
+
+    def runner(cmd):
+        seen["cmd"] = cmd
+        return 0, "", ""
+
+    sh.failed_units(runner)
+    argv = seen["cmd"]
+    assert argv[0] == "systemctl"
+    # The first non-flag token after the binary is the positional verb.
+    verb = next(a for a in argv[1:] if not a.startswith("-"))
+    assert verb in nolaunch.SYSTEMCTL_READ_VERBS, (
+        f"{verb!r} is not a read verb; the nolaunch stub blocks it and the "
+        "acknowledgement in test_no_real_launchers.py is no longer true")
+    assert "--failed" not in argv, "the flag spelling fails closed in the suite"
+
+
+def test_failed_units_reports_COULD_NOT_MEASURE_rather_than_zero():
+    """🔴 A systemctl that could not run must not read as 'no failed units'."""
+    got = sh.failed_units(lambda cmd: (127, "", "systemctl: not found"))
+    assert got["measured"] is False
+    assert got["units"] == []
+    assert "not found" in got["reason"]
+
+
+def test_a_could_not_measure_systemd_section_sets_no_warning():
+    rep = _report([P(1, args="/sbin/init")], systemd=True, load_threshold=24.0,
+                  meminfo=_meminfo(swap_total=0, swap_free=0))
+    rep["systemd"] = {"measured": False, "reason": "boom", "units": []}
+    assert sh.verdict(rep)["exit_code"] == 0
+
+
+def test_failed_units_do_warn_when_measured():
+    rep = _report([P(1, args="/sbin/init")], systemd=True, load_threshold=24.0,
+                  meminfo=_meminfo(swap_total=0, swap_free=0))
+    rep["systemd"] = {"measured": True, "reason": None, "units": ["a.service"]}
+    v = sh.verdict(rep)
+    assert v["exit_code"] == 1 and any("failed user unit" in w for w in v["warnings"])
+
+
+def test_optional_sections_are_absent_unless_asked_for():
+    rep = _report([P(1, args="/sbin/init")], load_threshold=24.0,
+                  meminfo=_meminfo(swap_total=0, swap_free=0))
+    assert "systemd" not in rep and "fds" not in rep
+
+
+def test_fd_counts_reports_unreadable_separately_from_zero(tmp_path):
+    """🔴 The positive control for the FD scan. Most processes are not ours, so
+    /proc/<pid>/fd is EACCES; folding those into the result would print a short
+    tidy list that reads as 'nothing has many FDs' while never having looked."""
+    proc = tmp_path / "proc"
+    (proc / "10" / "fd").mkdir(parents=True)
+    for i in range(7):
+        (proc / "10" / "fd" / str(i)).write_text("")
+    unreadable = proc / "11" / "fd"
+    unreadable.mkdir(parents=True)
+    os.chmod(unreadable, 0o000)
+    try:
+        got = sh.fd_counts([P(10), P(11), P(12)], proc_root=str(proc), mypid=999999)
+    finally:
+        os.chmod(unreadable, 0o755)
+    assert got["top"][0] == {"pid": 10, "comm": "thing", "user": "zach", "fds": 7}
+    assert got["examined"] == 1
+    assert got["vanished"] == 1          # pid 12 has no directory at all
+    if os.geteuid() != 0:                # root can read a 0000 dir
+        assert got["unreadable"] == 1
+
+
+def test_fd_counts_skips_zombies_and_self(tmp_path):
+    proc = tmp_path / "proc"
+    for pid in (10, 20):
+        (proc / str(pid) / "fd").mkdir(parents=True)
+        (proc / str(pid) / "fd" / "0").write_text("")
+    got = sh.fd_counts([P(10), zombie(20, ppid=1)], proc_root=str(proc), mypid=10)
+    assert got["top"] == [] and got["examined"] == 0
+
+
+# ---------------------------------------------------------------------------
+# /proc readers
+# ---------------------------------------------------------------------------
+def test_read_loadavg_and_meminfo_and_uptime(tmp_path):
+    (tmp_path / "loadavg").write_text("55.18 39.53 32.08 12/3456 789\n")
+    (tmp_path / "meminfo").write_text(
+        "MemTotal:       129000000 kB\nMemAvailable:    64000000 kB\n"
+        "SwapTotal:       90600000 kB\nSwapFree:        39000000 kB\n"
+        "HugePages_Total:        0\n")
+    (tmp_path / "uptime").write_text("2680000.41 61000000.00\n")
+    assert sh.read_loadavg(str(tmp_path)) == (55.18, 39.53, 32.08)
+    mi = sh.read_meminfo(str(tmp_path))
+    assert mi["MemTotal"] == 129000000 and mi["SwapFree"] == 39000000
+    assert mi["HugePages_Total"] == 0
+    assert sh.read_uptime(str(tmp_path)) == pytest.approx(2680000.41)
+
+
+def test_collect_ps_refuses_an_empty_result():
+    """🔴 A zero here is never a clean bill of health — this host has processes,
+    so 'ps parsed nothing' is a broken instrument, not a healthy machine."""
+    with pytest.raises(RuntimeError, match="cannot measure"):
+        sh.collect_ps(lambda cmd: (0, "\n", ""))
+
+
+def test_collect_ps_surfaces_a_failing_ps():
+    with pytest.raises(RuntimeError, match="exit 127"):
+        sh.collect_ps(lambda cmd: (127, "", "ps: not found"))
+
+
+def test_collect_ps_asks_for_the_documented_format():
+    seen = {}
+
+    def runner(cmd):
+        seen["cmd"] = cmd
+        return 0, " 1 0 root 0.0 0.0 12 99 Ss /sbin/init\n", ""
+
+    sh.collect_ps(runner)
+    assert seen["cmd"] == ["ps", "-eo", sh.PS_FORMAT]
+    assert sh.PS_FORMAT.count("=") == sh.PS_FIELDS
+    assert sh.PS_FORMAT.split(",")[-1] == "args="   # args MUST stay last
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("sec,text", [
+    (7, "7s"), (61, "1m01s"), (3599, "59m59s"),
+    (3600, "1h00m"), (90061, "1d01h"), (2_680_000, "31d00h"),
+])
+def test_fmt_age(sec, text):
+    assert sh.fmt_age(sec) == text
+
+
+def test_render_emits_every_section_and_the_verdict():
+    import io
+    procs = [P(700, args="/bin/parent"), zombie(801, ppid=700),
+             P(3, pcpu=97.5, etimes=90061, args="/bin/hog --loop")]
+    rep = _report(procs, load_threshold=24.0, ignore="",
+                  meminfo=_meminfo(swap_total=0, swap_free=0))
+    buf = io.StringIO()
+    sh.render(rep, out=buf)
+    text = buf.getvalue()
+    for heading in ("OVERVIEW", "ZOMBIES", "CPU HOGS", "MEM HOGS",
+                    "RUNAWAYS", "VERDICT"):
+        assert heading in text
+    assert "exit 1" in text
+
+
+def test_render_prints_a_kill_hint_with_the_identity_needed_to_check_it():
+    """Report-only by design: the hint must carry cwd and ppid, because this box
+    runs parallel agents whose workers look exactly like a runaway."""
+    import io
+    rep = _report([P(479313, pcpu=97.5, etimes=90061, args="/bin/hot")],
+                  load_threshold=24.0, ignore="",
+                  meminfo=_meminfo(swap_total=0, swap_free=0))
+    buf = io.StringIO()
+    sh.render(rep, out=buf)
+    text = buf.getvalue()
+    assert "to kill:  kill 479313" in text
+    assert "cwd:" in text and "ppid:" in text
+    assert "sibling agent" in text
+
+
+def test_the_script_has_no_kill_flag():
+    """Pins the v1 decision STRUCTURALLY, not in prose: syshealth never signals
+    a process. A future --kill must come with its own guard coverage, and this
+    test failing is the prompt to write it."""
+    parser = sh.build_parser()
+    flags = {a for action in parser._actions for a in action.option_strings}
+    assert "--kill" not in flags
+    src = SCRIPT.read_text()
+    for forbidden in ("os.kill", "SIGTERM", "SIGKILL", "pkill", "killpg"):
+        assert forbidden not in src, f"{forbidden} appeared in a report-only tool"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the real CLI, stubbed ps, fake /proc
+# ---------------------------------------------------------------------------
+PS_ROWS = "\n".join([
+    "      1       0 root  0.0  0.0   12000 2680000 Ss  /sbin/init",
+    " 700       1 root  0.4  0.1   40000  700000 Ss  /bin/parent --serve",
+    " 801     700 root  0.0  0.0       0  400000 Z   [find] <defunct>",
+    " 802     700 root  0.0  0.0       0  400000 Z   [grep] <defunct>",
+    " 803     700 root  0.0  0.0       0  400000 Z   [head] <defunct>",
+    " 900       1 zach 97.5  0.9 1500000   90061 Rl  /bin/hog --loop",
+    " 901       1 zach  1.2  0.0    9000       3 R   ps -eo pid=,ppid=",
+])
+
+
+@pytest.fixture()
+def env(tmp_path):
+    """A stub `ps` on PATH plus a fake /proc; returns a runner."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    mockbin.write_exec(bindir / "ps", f"cat <<'ROWS'\n{PS_ROWS}\nROWS\n")
+    mockbin.write_exec(bindir / "systemctl", "echo 'bad.service x failed failed Z'\n")
+    proc = tmp_path / "proc"
+    proc.mkdir()
+    (proc / "loadavg").write_text("55.18 39.53 32.08 12/3456 789\n")
+    (proc / "meminfo").write_text(
+        "MemTotal:       129000000 kB\nMemAvailable:    64000000 kB\n"
+        "SwapTotal:              0 kB\nSwapFree:               0 kB\n")
+    (proc / "uptime").write_text("2680000.41 61000000.00\n")
+
+    def run(*flags):
+        e = dict(os.environ, PATH=f"{bindir}:{os.environ['PATH']}")
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--proc-root", str(proc),
+             "--load-threshold", "24", *flags],
+            capture_output=True, text=True, env=e, timeout=60)
+
+    return run
+
+
+def test_cli_end_to_end_exits_1_and_finds_the_planted_problems(env):
+    r = env()
+    assert r.returncode == 1, r.stderr
+    assert "3x zombie under pid 700" in r.stdout
+    assert "900" in r.stdout and "hog" in r.stdout
+    assert "55.18" in r.stdout
+
+
+def test_cli_never_reports_its_own_ps(env):
+    """pid 901 is the stub `ps` itself, aged 3s. It must appear in neither the
+    hog list nor the runaway list."""
+    r = env()
+    assert "901" not in r.stdout
+
+
+def test_cli_json_is_valid_and_its_exit_code_matches_the_process(env):
+    r = env("--json")
+    doc = json.loads(r.stdout)
+    assert doc["exit_code"] == r.returncode == 1
+    assert doc["verdict"]["exit_code"] == r.returncode
+    assert doc["zombies"]["count"] == 3
+    assert doc["overview"]["load_high"] is True
+    assert {"overview", "zombies", "cpu_hogs", "mem_hogs", "runaways",
+            "thresholds", "counts", "verdict", "exit_code"} <= set(doc)
+
+
+def test_cli_json_and_human_agree_on_the_verdict(env):
+    """Two renderers, one verdict — a divergence here means one of them is
+    computing its own answer."""
+    assert env("--json").returncode == env().returncode
+
+
+def test_cli_thresholds_change_the_outcome(env):
+    """Raising the bar above the planted hog must clear the CPU section — the
+    positive/negative control pair for flag plumbing."""
+    hot = env("--cpu-threshold", "60", "--json")
+    cool = env("--cpu-threshold", "99", "--json")
+    assert json.loads(hot.stdout)["cpu_hogs"]["single"]
+    assert not json.loads(cool.stdout)["cpu_hogs"]["single"]
+
+
+def test_cli_min_age_flag_reaches_the_rule(env):
+    """Raising min-age past the hog's 90061s age drops it from every CPU rule.
+
+    Asserted as a control PAIR against the default run rather than against an
+    absolute count: `/sbin/init` in the fixture is 2,680,000s old and survives
+    any plausible min-age, so `eligible == 0` would be pinning the fixture's
+    uptime, not the flag.
+    """
+    before = json.loads(env("--json").stdout)
+    after = json.loads(env("--min-age", "999999", "--json").stdout)
+    assert before["cpu_hogs"]["single"] and before["runaways"]
+    assert after["cpu_hogs"]["single"] == [] and after["runaways"] == []
+    assert after["counts"]["eligible"] < before["counts"]["eligible"]
+
+
+def test_cli_ignore_flag_suppresses_a_match(env):
+    doc = json.loads(env("--ignore", "hog", "--json").stdout)
+    assert doc["cpu_hogs"]["single"] == []
+    assert doc["zombies"]["count"] == 3  # zombies are not ignore-filtered
+
+
+def test_cli_opt_in_sections_are_off_by_default(env):
+    doc = json.loads(env("--json").stdout)
+    assert "systemd" not in doc and "fds" not in doc
+    assert "SYSTEMD" not in env().stdout
+
+
+def test_cli_systemd_section_appears_on_request(env):
+    doc = json.loads(env("--systemd", "--json").stdout)
+    assert doc["systemd"] == {"measured": True, "reason": None,
+                              "units": ["bad.service"]}
+    assert any("failed user unit" in w for w in doc["verdict"]["warnings"])
+
+
+def test_cli_fds_section_appears_on_request(env):
+    doc = json.loads(env("--fds", "--json").stdout)
+    assert set(doc["fds"]) == {"top", "examined", "unreadable", "vanished"}
+
+
+def test_cli_could_not_measure_exits_3_not_0(tmp_path):
+    """🔴 An unreadable /proc must not read as a clean system."""
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), "--proc-root", str(tmp_path / "nope")],
+        capture_output=True, text=True, timeout=60)
+    assert r.returncode == 3
+    assert "COULD NOT MEASURE" in r.stderr
+
+
+def test_cli_exits_0_on_a_genuinely_clean_stub(tmp_path):
+    """The negative control for the whole pipeline: same code path, nothing
+    planted, must be silent and green. Without this, a script that always
+    returned 1 would pass every test above."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    rows = ("      1       0 root 0.0 0.0 12000 2680000 Ss /sbin/init\n"
+            " 500       1 zach 0.4 0.1 40000  700000 Sl /bin/idle --wait\n")
+    mockbin.write_exec(bindir / "ps", f"cat <<'ROWS'\n{rows}ROWS\n")
+    proc = tmp_path / "proc"
+    proc.mkdir()
+    (proc / "loadavg").write_text("1.10 1.20 1.30 1/100 2\n")
+    (proc / "meminfo").write_text(
+        "MemTotal:       129000000 kB\nMemAvailable:   100000000 kB\n"
+        "SwapTotal:              0 kB\nSwapFree:               0 kB\n")
+    (proc / "uptime").write_text("2680000.41 61000000.00\n")
+    r = subprocess.run(
+        [sys.executable, str(SCRIPT), "--proc-root", str(proc),
+         "--load-threshold", "24"],
+        capture_output=True, text=True,
+        env=dict(os.environ, PATH=f"{bindir}:{os.environ['PATH']}"), timeout=60)
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "exit 0" in r.stdout and "clean" in r.stdout
+
+
+def test_the_clean_and_dirty_runs_actually_differ(env):
+    """The control pair, asserted as a pair: if these two ever produce the same
+    output the fixtures have stopped exercising anything."""
+    dirty = env().stdout
+    assert "ZOMBIES (3" in dirty
+    assert "ZOMBIES (0" not in dirty


### PR DESCRIPTION
## What

`scripts/syshealth` — an on-demand deep system sweep, plus its skill and tests. Report-only:
zombies grouped by the parent that is not reaping them, CPU/mem hogs with process-tree
grouping, sustained runaways, load, and swap/OOM headroom. `--systemd` and `--fds` are opt-in.

It never signals a process, and that is pinned structurally rather than asserted
(`test_the_script_has_no_kill_flag` fails on a reintroduced `--kill`, `os.kill`, `SIGTERM`,
`pkill` or `killpg`). This box runs parallel agents whose test workers look exactly like a
runaway, so each runaway prints its `cwd` and `ppid` beside a paste-ready `kill` line instead
— the identity you need to tell a sibling agent apart from a real problem.

## Why it is not four `ps` one-liners

🔴 **`ps`'s %CPU is cpu-time ÷ elapsed averaged over the process's WHOLE LIFE**, not an
instantaneous sample. For a process a few milliseconds old the divisor is ~0 and the quotient
is meaningless. The manual sweep this replaces (2026-09-03) read three such rows and reported
a **"runaway nix store scan at 240%"** that was a 20-millisecond `pgrep`, plus an 1100% row
that **was the `ps` producing the report**. Hence `--min-age` (default 10s), and
self-exclusion of this process, its `ps` child and its ancestors.

🔴 **A persistent zombie always indicts a LIVE parent.** A dead parent's zombies are
reparented to init and reaped, so one that survives for days proves its parent is alive and
not calling `wait()`. The earlier session concluded the opposite ("children of already-dead
services"); that is retracted here. Measured on the workbench: **21 zombies under 2 parents**,
18 of them under pid 2273825 `sleep infinity` — a Kubernetes container's PID 1, which is not a
subreaper. Grouping turns 21 lines into 2 findings.

## The systemctl call site

`systemctl --user list-units --state=failed`, deliberately **not** the shorter `--failed`:
`list-units` is a positional verb on `testlib/nolaunch.SYSTEMCTL_READ_VERBS`, so the
verb-splitting stub passes it through as a read, while `--failed` is a flag and that stub's
safe-flag list is only `--version/--help/-h` — the short spelling fails closed. Output is
byte-identical on a real host (measured).

`syshealth` is the only entry in `ACKNOWLEDGED_UNSTUBBED["systemctl"]` that genuinely invokes
the binary; the other five are non-invoking. It is therefore acknowledged on **the verb**
rather than on unreachability, and `test_failed_units_asks_systemctl_for_a_read_verb` pins the
argv against `SYSTEMCTL_READ_VERBS` itself — not a copied literal — so the justification goes
red if the call site ever grows a mutating verb.

## Paying for the listing budget

Adding any skill reddened `test_skill_descriptions.py`: the ratchet sat at 12,861/12,929, and
its own comment says the slack was gone and the next addition of any size would red it.

Paid for by shrinking three descriptions **measured as never having fired** across the whole
retained transcript corpus on **both hosts** — `window-triage` 507→126, `initiatives` 389→128,
`standup` 367→116. Bodies unchanged; all three stay `/name`-invocable. Net **−602 chars**, so
both ratchets are re-pinned **downward**: `LISTING_TOTAL_CEILING_CHARS` 12,929→12,259 and
`TIER_A_CEILING_CHARS` 8,821→7,928, with the four `MEASURED_*` constants.

Method: one walk of the corpus using the three attribution channels `find-session --skill`
reads — not the ClickHouse `skills_used` map, which the `activity` skill measures ~40% low and
whose `IS NOT NULL` predicate matches the whole table.

🔴 **Recorded beside the constants: that sweep is EVIDENCE, NOT A VERDICT.** It reads 0 for
`adoption-scan` (20,494 tool-invocation events) and `repo-cos` (a weekly timer read as email),
and 1 for `dl-router` (a live systemd service) — it cannot see service- or timer-driven use.
Nothing was deleted on a zero.

🔴 **Also corrected in the source: demoting a skill to tier B does NOT relieve that ceiling.**
`listing_total_chars` sums every entry and never reads `claude/skill-tiers.json`; a comment
there implied otherwise. Only shortening or removing description text moves the number.

## Verification

| tier | result |
|---|---|
| `nix …#checks.pytests` (branch base) | **PASS** — 21,468 collected, 21,465 passed, 0 failed |
| `nix …#checks.nodetests` (branch base) | **PASS** — 1449/1449 |
| **`nix …#checks.pytests` (MERGED tree)** | **PASS** — 21,468 collected, 21,465 passed, 0 failed, 0 FAIL targets |
| **`nix …#checks.nodetests` (MERGED tree)** | **PASS** — 1449/1449, 0 FAIL targets |
| dev-host `gate.sh --tier both` | node PASS 1449/1449; `scripts/tests` 12440/12440 |

The merged-tree rows are the load-bearing ones: gated on an integration branch (`ccd5e3f4`)
built off **current `origin/main`**, which had moved 4 commits past this branch's base, since a
green run on the PR branch says nothing about the tree the merge creates. Both merged-tree
derivations rebuilt from scratch (different store hashes from the branch-base builds), so
neither is a cache hit reported as a measurement.

Derivations were built **one at a time** — a combined invocation makes them contend on the
store and produce false failures. Verdicts read from each runner's own `RESULT:` line, not a
piped exit code (a first attempt through `| tail` returned a meaningless 0).

`scripts/tests/test_syshealth.py`: **100 tests**, plus a 22/22 mutation sweep (positive control
green; each mutant killed by its **own named test**, under `PYTHONDONTWRITEBYTECODE=1`). The
sweep found three real gaps a fully green suite had hidden — a substring-vs-prefix `is_zombie`
mutant, a grouping boundary with no fixture landing exactly on it, and an "oldest age"
assertion that was vacuous because its input was already sorted.

## Known-red, and NOT caused by this branch

`scripts/claude-hooks/tests/test_clawgate_task_interview_guard.py::test_a_body_file_written_by_a_heredoc_on_the_same_line_is_read`
fails on the **dev host** and passes **310/310 in the nix sandbox**. It fails identically in a
clean base clone without this branch; both the hook and its test are byte-identical to
`origin/main` here (existence on that ref checked *before* comparing — `git diff --quiet <ref>
-- <path>` reports SAME for a path absent on both sides). That is a two-tier discrepancy that
pre-dates this work and is filed here, not fixed by it.

## Incidental findings about the box (not fixed here)

- 21 unreaped zombies under pid 2273825 (`sleep infinity`, container PID 1) and pid 3716907.
- `analyze-service-index-commit.service` is currently **failed**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oVTv3xdPKJXDcwhNwz8Lg
