### PR TITLE
feat(handoff-index): ARM the sync timer — the live Postgres path is now exercised, not argued

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -62,7 +62,21 @@ let
   # "the full bound scope is printed with the row count below" at rc 4, with the
   # store never opened). Absence of the block on a red run is therefore expected;
   # the exit code is still what you read.
-  enableHandoffIndexSync = false;
+  # ARMED 2026-09-04, after the live path was exercised by hand rather than argued:
+  #   `--rebuild` (dry-run, the default)  -> all 4 repos resolved, `warnings: none`,
+  #      delete scope = all 4 labels, no UNMEASURED and no unreadable.
+  #   `--rebuild --write`                 -> the FIRST time this DDL met a server:
+  #      "wrote 4647 section row(s) ... (after DELETE of 4 repo label(s) ... one
+  #      transaction)". The GENERATED `tsv` column was accepted and the GIN index
+  #      built — neither had ever been executed by Postgres, only pinned as text.
+  #   `handoff_search.py --query fsync`   -> `backend=postgres`, 4647 sections,
+  #      `ts_rank` ordering real hits. 🔴 `backend=` IS the discriminator: a silent
+  #      fall-back to `memory` renders identically otherwise.
+  # 🔴 A HAND-RUN NEEDS `KUBECONFIG=$KC_HOMELAB` — this repo leaves KUBECONFIG unset
+  # on purpose so a bare `kubectl` cannot hit prod, so the DSN read fails loudly
+  # (CalledProcessError on `kubectl -n mailbox get secret`) before touching the
+  # database. The UNIT sets KUBECONFIG itself; only the hand-run path lacks it.
+  enableHandoffIndexSync = true;
   # Drift-deadman master switch (scripts/drift-check.sh) — gates ONLY whether the
   # timer is wired into timers.target. The SERVICE definition is always emitted, so
   # `systemctl --user start drift-check` works by hand on either host regardless.

--- a/scripts/tests/test_resume_handoff_search_wiring.py
+++ b/scripts/tests/test_resume_handoff_search_wiring.py
@@ -137,12 +137,21 @@ def test_the_resume_skill_is_where_it_is_expected():
 def test_the_skill_prescribes_the_offline_command_verbatim():
     """🔴 THE SHAPE PIN, and `--offline` is the load-bearing token in it.
 
-    Without `--offline` the tool falls through to the Postgres backend -- a path
-    NO test has ever exercised, whose sync timer ships disarmed
-    (`enableHandoffIndexSync = false`), and which would turn a working retrieval
-    step into a connection error at the worst moment in a session. A substring
-    check for `handoff_search.py` would not see that edit; a whole-string
-    comparison does.
+    Without `--offline` the tool falls through to the Postgres backend, and that
+    would turn a working retrieval step into a connection error at the worst
+    moment in a session. A substring check for `handoff_search.py` would not see
+    that edit; a whole-string comparison does.
+
+    🔴 THE REASON CHANGED ON 2026-09-04 AND IS NOW SHARPER, NOT WEAKER. The old
+    rationale was "no test has ever exercised that path, and its timer ships
+    disarmed (`enableHandoffIndexSync = false`)". The timer is now ARMED and the
+    live path HAS been exercised by hand (4647 rows written, `backend=postgres`
+    answering), so that half is retired. What replaces it is stronger, because it
+    does not depend on the index being empty: reaching Postgres needs a DSN read
+    via `kubectl`, and this repo leaves `KUBECONFIG` UNSET on purpose so a bare
+    `kubectl` cannot hit prod. A `/resume` session does not export it, so the
+    non-offline path raises `CalledProcessError` before it can answer -- measured,
+    not argued. `--offline` needs no cluster, no port-forward and no secret.
     """
     block = _block()
     normalised = _normalise(block)


### PR DESCRIPTION
Flips `enableHandoffIndexSync` to `true`. The reason it was false is gone: the DDL had never been executed by a server. It has now been, by hand, before this flip.

```
--rebuild (dry-run)   4 repos resolved, warnings: none, delete scope = all 4 labels,
                      no UNMEASURED, no unreadable
--rebuild --write     wrote 4647 section row(s) to initiatives.handoff_section
                      (after DELETE of 4 repo label(s) — one transaction)
handoff_search        backend=postgres, indexed_sections=4647, ts_rank ordering real hits
```

The `GENERATED … STORED` `tsv` column was accepted and the GIN index built for the first time — both were previously pinned only as SQL text. 🔴 `backend=` is the discriminator: a silent fall-back to `memory` renders identically otherwise, so a green write proves nothing on its own.

**Also retires a claim this flip makes false.** `test_the_skill_prescribes_the_offline_command_verbatim` justified `--offline` partly by *"its sync timer ships disarmed (`enableHandoffIndexSync = false`)"*. That half is now untrue. What replaces it is stronger and does not depend on the index being empty: reaching Postgres needs a DSN read via `kubectl`, and this repo leaves `KUBECONFIG` unset on purpose so a bare `kubectl` cannot hit prod — so a `/resume` session raises `CalledProcessError` before it can answer. Measured while arming: the hand-run failed exactly that way until `KUBECONFIG=$KC_HOMELAB`.

**Gate**, sandbox tier (the one Tekton runs), built one at a time:
- `devrc-pytests> RESULT: PASS (exit=0)` — `collected=21366 passed=21363 skipped=3 failed=0`, 0 timeout panics
- `devrc-nodetests` — running; will comment with its `RESULT:` line

`nix eval` confirms the timer is genuinely emitted with the flag armed, rather than reading the flag.

**Still open, unchanged:** the authority-per-derivation vs DELETE-per-label residual, and the empty-label display residual. **Untested until deployed:** the unit's own environment — I will trigger `handoff-index-sync.service` by hand after `ship.sh` and read its journal before trusting the 6h timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)