### PR TITLE
feat(clawgate): host-side feeder for the Claude Code transcript read model (rank 25)

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -105,6 +105,24 @@ let
   # SSHes to the laptop), so running it on the laptop too would have each host pushing
   # a full two-host document and the two would fight over every row.
   enableTmuxSnapshotPush = true;
+  # Claude Code TRANSCRIPT feeder master switch (scripts/transcript-push.sh) — feeds
+  # clawgate's chat view. Gates ONLY whether the timer is wired into timers.target; the
+  # SERVICE definition is always emitted, so `transcript-push` can be started by hand
+  # regardless.
+  #
+  # 🔴 NOT serverMode-GATED, AND THAT ASYMMETRY WITH enableTmuxSnapshotPush ABOVE IS THE
+  # WHOLE POINT. That one is workbench-only as a CORRECTNESS requirement: its collector
+  # already reaches both hosts over ssh, so a second reporter would have the two fighting
+  # over every row. Transcripts are ordinary files on each host's OWN filesystem, readable
+  # from nowhere else, so a workbench-only unit would feed exactly half the fleet and the
+  # laptop's sessions would render as "no transcript stored" for ever. The read model is
+  # keyed on a Claude Code session id, which is globally unique, so two hosts pushing
+  # disjoint session sets cannot collide.
+  #
+  # ON from the start: the write path is a latest-per-session upsert, a bad push is
+  # rejected outright (the server 4xx's and CHANGES NOTHING, leaving the previous tail in
+  # place), and the server sweeps rows older than 7 days.
+  enableTranscriptPush = true;
   # Graphical host = runs X/i3 (both current NixOS hosts do; only a genuinely headless
   # box would not). Approximated as isNixOS, mirroring graphical.nix — deliberately NOT
   # !serverMode, which is true on the graphical workbench.
@@ -3637,6 +3655,96 @@ in
       # correctness requirement, not scoping — two hosts each pushing a full
       # two-host document would fight over every row.
       WantedBy = lib.optionals (serverMode && enableTmuxSnapshotPush) [ "timers.target" ];
+    };
+  };
+
+  # ── CLAWGATE TRANSCRIPT READ-MODEL FEEDER (scripts/transcript-push.sh) ───────
+  # The chat view's supply. Claude Code writes one JSONL transcript per session
+  # under ~/.claude/projects/; clawgate's pod cannot see either host's filesystem
+  # (no hostPath, no hostNetwork, no nodeName), so delivery is outbound from the
+  # host exactly as the tmux read model's is.
+  #
+  # 🔴 ONE UNIT PER HOST — see enableTranscriptPush above for why this is the
+  # opposite of its sibling rather than an inconsistency with it.
+  systemd.user.services.transcript-push = {
+    Unit = {
+      Description = "Push this host's recent Claude Code transcript tails to clawgate";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+      # 🔴 NO OnFailure, DELIBERATELY, and for the reason spelled out at
+      # tmux-snapshot-push: notify-failure@ toasts are wired to DEFEAT
+      # do-not-disturb, that bypass is justified by a measured ~1 firing in 9
+      # days, and a timer this frequent would fire one on EVERY tick through any
+      # sustained outage (clawgate mid-redeploy, the laptop asleep). A
+      # permanently-red alarm trains you to ignore the channel.
+      #
+      # What surfaces a dead feeder instead: this is Type=oneshot with distinct
+      # non-zero exit codes, so a persistent failure lands in the user manager's
+      # failed-unit list, which `/standup` reads. ⚠ That covers the CODES and not
+      # a unit that exits 0 while achieving nothing — which is why "nothing had
+      # changed" is a deliberate rc 0 and every other outcome is not.
+      #
+      # 🔴 AND UNLIKE ITS SIBLING, THIS ONE HAS A CONSUMER THAT SHOWS ITS OWN
+      # STALENESS. clawgate's chat view renders `fed <n> ago` from the server's
+      # received_at beside the session's own last activity, precisely so a dead
+      # feeder is visible on the page rather than only in a unit list.
+    };
+    Service = {
+      Type = "oneshot";
+      # Builder cap (120s) + two curl caps (30s each) + slack. All three inner
+      # bounds live in the script; this only has to exceed their sum, or the
+      # cgroup is killed mid-run and the failure reads as a hang rather than as
+      # whichever leg wedged.
+      TimeoutStartSec = 200;
+      Environment = [
+        # 🔴 EVERY ENTRY IS FOR THE CHILD — under systemd there is no login-shell
+        # PATH to fall back on. The script uses curl, sed (gnused), python3, and
+        # tr/cut/wc/mktemp/rm/readlink/dirname/uname/timeout (coreutils); the
+        # builder is pure stdlib Python.
+        #
+        # ⚠ DELIBERATELY SHORTER THAN THE SIBLING'S LIST. tmux-snapshot-push
+        # needs tmux/openssh/gawk because it runs a collector that reaches the
+        # other host; this reads local files and needs none of them. Copying that
+        # list wholesale would be the "trim a copied list without running the
+        # child" mistake in reverse — carrying binaries to justify later.
+        "PATH=${lib.makeBinPath [ pkgs.bash pkgs.coreutils pkgs.curl pkgs.gnused pkgs.python3 ]}"
+        "HOME=%h"
+      ];
+      ExecStart = "${pkgs.bash}/bin/bash %h/workspace/devrc/scripts/transcript-push.sh";
+      X-Restart-Triggers = [
+        "${../scripts/transcript-push.sh}"
+        # The builder decides which sessions are sent and how much of each — a
+        # change there is a change to what this unit delivers, with no edit to
+        # the shell at all.
+        "${../scripts/lib/build_transcript_push.py}"
+      ];
+    };
+  };
+
+  # Every 5 minutes, which is deliberately SLOWER than the tmux feeder's 2.
+  # The tmux read model backs an at-a-glance "which pane needs me" view, where a
+  # quarter-hour of lag would answer a question nobody asked. A transcript is
+  # read after the fact — the use case is coming back to a session and reading
+  # what it did — so minutes of lag cost nothing, and the run does real work per
+  # tick (hashing up to MAX_CANDIDATES tails).
+  #
+  # The dedupe pre-flight is what makes the cadence affordable: a tick where
+  # nothing changed is one small GET and an exit 0, not a push.
+  #
+  # OnStartupSec gives one prompt run shortly after the user manager starts, so a
+  # rebooted host repopulates before anyone looks. No Persistent: that applies to
+  # OnCalendar timers, not monotonic ones.
+  systemd.user.timers.transcript-push = {
+    Unit = {
+      Description = "Periodic timer for the clawgate transcript read-model feeder";
+    };
+    Timer = {
+      OnStartupSec = "2min";
+      OnUnitActiveSec = "5min";
+    };
+    Install = {
+      # 🔴 NO serverMode GATE — both hosts, on purpose. See enableTranscriptPush.
+      WantedBy = lib.optionals enableTranscriptPush [ "timers.target" ];
     };
   };
 

--- a/scripts/lib/build_transcript_push.py
+++ b/scripts/lib/build_transcript_push.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Build one `POST /api/transcripts` body from this host's Claude Code transcripts.
+
+Called by `scripts/transcript-push.sh`, which owns the credentials, the HTTP and
+the exit-code vocabulary. This half owns exactly one decision — WHICH sessions to
+send and HOW MUCH of each — and it is separate from the shell for two reasons
+that are not tidiness:
+
+  * it is the only part with a testable contract (given a directory and a digest,
+    produce a payload), and a shell heredoc is not directly testable; and
+  * the tail arithmetic is a byte-boundary problem (see `read_tail`), which is
+    exactly the kind of thing that is silently wrong in shell.
+
+🔴 READ-ONLY. This opens transcript files for reading and writes one JSON
+document to stdout. It never writes into the transcript tree, never executes
+anything, and takes nothing from the server but a list of hashes it compares for
+equality.
+
+🔴 IT SENDS A **TAIL**, AND THE PAYLOAD SAYS SO. Measured on this fleet
+2026-09-04: 315 transcript files modified within 24h, 456 MB in total, largest
+single file 23 MB. `truncated` is a first-class field precisely because a
+consumer that cannot tell "the whole session" from "the end of it" will state the
+first while showing the second.
+
+Exit codes, which the caller branches on:
+    0   a payload was written to stdout
+    10  nothing to push — every candidate already matches the server's digest
+    1   anything else (message on stderr)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+# 🔴 THE ONE PLACE THE STORED FORM IS DEFINED, and the server recomputes it
+# rather than trusting what we send (see internal/transcript.NormalizePush). Two
+# implementations of "the hash" is how a dedupe protocol silently degrades into
+# "always push" or, worse, "never push".
+def hash_tail(tail: bytes) -> str:
+    return hashlib.sha256(tail).hexdigest()
+
+
+def read_tail(path: Path, max_bytes: int) -> tuple[str, bool] | None:
+    """Return (tail_text, truncated) for one transcript, or None if unreadable.
+
+    🔴 THE LEADING PARTIAL RECORD IS DROPPED, NOT SHIPPED. Seeking to
+    `size - max_bytes` lands in the middle of a JSON line essentially every time.
+    The server's parser tolerates that (it counts a leading fragment separately
+    from corruption, deliberately), but shipping it wastes the bytes and makes
+    every truncated session look faintly broken. Dropping it costs one `find`.
+
+    🔴 THE FILE IS BEING APPENDED TO AS WE READ IT — that is the normal case, not
+    an edge one, because the sessions worth feeding are the live ones. So: no
+    `size` is re-checked after the read, no consistency is claimed, and the
+    result is explicitly "a tail as of some instant". The read is a single
+    `seek`+`read` so it cannot interleave with itself.
+
+    🔴 DECODED WITH errors="replace", AND THAT IS DELIBERATE RATHER THAN LAZY.
+    The cut point is a byte offset, so it can land inside a multi-byte rune, and
+    the server REJECTS a tail that is not valid UTF-8 (its column is TEXT and
+    Postgres would otherwise fail the whole atomic push, taking every other
+    session in the request down with it). Replacing is what makes one bad byte
+    cost one glyph instead of one session. The dropped-first-line rule above
+    removes almost every instance in practice; this is the backstop.
+    """
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as fh:
+            if size > max_bytes:
+                fh.seek(size - max_bytes)
+                truncated = True
+            else:
+                truncated = False
+            raw = fh.read(max_bytes)
+    except OSError:
+        return None
+
+    if truncated:
+        nl = raw.find(b"\n")
+        if nl == -1:
+            # One record longer than the whole window: there is no boundary to
+            # cut on. Send nothing rather than a fragment that parses to zero
+            # events while claiming to be a conversation.
+            return None
+        raw = raw[nl + 1 :]
+
+    return raw.decode("utf-8", errors="replace"), truncated
+
+
+def project_of(transcript: Path) -> str:
+    """The project label for a transcript.
+
+    Claude Code names the containing directory after a SLUGIFIED cwd
+    (`-home-zach-workspace-devrc`), so the last path segment is the closest thing
+    to a project name available without reading the file.
+
+    ⚠ IT IS A LABEL, NOT AN IDENTIFIER, and it is deliberately not un-slugified.
+    The slug is lossy — a literal `-` in a directory name is indistinguishable
+    from a `/` — so reconstructing a path from it would produce a confident wrong
+    answer. The server prefers the `cwd` the RECORDS carry when it has one; this
+    is the fallback for a tail that has none.
+    """
+    return transcript.parent.name.lstrip("-").split("-")[-1] or transcript.parent.name
+
+
+def candidates(projects_dir: Path, max_age_hours: float, limit: int) -> list[Path]:
+    """Recently-modified transcripts, newest first, bounded.
+
+    🔴 RECENCY IS THE ONLY SELECTOR, ON PURPOSE. The obvious alternative — ask
+    which sessions have a live tmux window — would couple this feeder to the
+    session-manager collector, and that collector runs on ONE host while this
+    runs on both. Worse, it would silently stop feeding a session the moment its
+    window closed, which is exactly when someone wants to read what it did.
+    """
+    cutoff = time.time() - max_age_hours * 3600
+    found: list[tuple[float, Path]] = []
+    # 🔴 A BOUNDED WALK: the transcript tree is `<projects>/<slug>/<uuid>.jsonl`,
+    # one level deep, and globbing it recursively would follow whatever else has
+    # been dropped in there.
+    try:
+        project_dirs = [p for p in projects_dir.iterdir() if p.is_dir()]
+    except OSError as exc:
+        print(f"cannot list {projects_dir}: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
+    for d in project_dirs:
+        try:
+            entries = list(d.glob("*.jsonl"))
+        except OSError:
+            continue
+        for f in entries:
+            try:
+                st = f.stat()
+            except OSError:
+                continue
+            if not os.path.isfile(f):
+                continue
+            if st.st_mtime < cutoff:
+                continue
+            found.append((st.st_mtime, f))
+
+    found.sort(key=lambda pair: pair[0], reverse=True)
+    return [p for _, p in found[:limit]]
+
+
+def load_digest(path: Path) -> dict[str, str]:
+    """The server's `{sessionId: contentHash}`, as it reported it.
+
+    🔴 A DIGEST THIS CANNOT PARSE IS AN ERROR, NEVER AN EMPTY ONE. Treating an
+    unreadable response as "the server has nothing" is the expensive direction —
+    every session re-pushed on every tick — and it would hide a server that had
+    started answering with something else entirely.
+    """
+    with path.open("rb") as fh:
+        doc = json.load(fh)
+    sessions = doc.get("sessions")
+    if sessions is None:
+        raise SystemExit("digest response has no `sessions` key — this is not a clawgate digest")
+    if not isinstance(sessions, list):
+        raise SystemExit(f"digest `sessions` is {type(sessions).__name__}, want a list")
+    out: dict[str, str] = {}
+    for row in sessions:
+        if not isinstance(row, dict):
+            continue
+        sid = row.get("sessionId")
+        h = row.get("contentHash")
+        if isinstance(sid, str) and isinstance(h, str) and sid:
+            out[sid] = h
+    return out
+
+
+def build(args: argparse.Namespace) -> dict:
+    projects_dir = Path(args.projects_dir)
+    known = load_digest(Path(args.digest))
+
+    sessions = []
+    for path in candidates(projects_dir, args.max_age_hours, args.max_candidates):
+        if len(sessions) >= args.max_sessions:
+            break
+        # The session id IS the filename stem — that is how Claude Code writes
+        # them, and it is the same id the attention queue and session-manager's
+        # `claude_session_id` carry, which is what makes the join work at all.
+        session_id = path.stem
+        if not session_id:
+            continue
+
+        result = read_tail(path, args.tail_bytes)
+        if result is None:
+            continue
+        text, truncated = result
+        if not text.strip():
+            continue
+
+        digest = hash_tail(text.encode("utf-8"))
+        # 🔴 THE SKIP. This single comparison is the whole reason the steady-state
+        # push is kilobytes rather than megabytes.
+        if known.get(session_id) == digest:
+            continue
+
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
+
+        sessions.append(
+            {
+                "sessionId": session_id,
+                "project": project_of(path),
+                # `cwd` is left to the server, which reads it out of the records
+                # themselves. Deriving it from the slug here would ship a
+                # confidently wrong path (see project_of).
+                "updatedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(mtime)),
+                "tail": text,
+                "truncated": truncated,
+                "contentHash": digest,
+            }
+        )
+
+    return {"host": args.host, "sessions": sessions}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--projects-dir", required=True)
+    ap.add_argument("--digest", required=True)
+    ap.add_argument("--host", required=True)
+    ap.add_argument("--tail-bytes", type=int, required=True)
+    ap.add_argument("--max-sessions", type=int, required=True)
+    ap.add_argument("--max-age-hours", type=float, required=True)
+    ap.add_argument("--max-candidates", type=int, required=True)
+    args = ap.parse_args()
+
+    if args.tail_bytes <= 0 or args.max_sessions <= 0:
+        print("tail-bytes and max-sessions must be positive", file=sys.stderr)
+        return 1
+
+    payload = build(args)
+    if not payload["sessions"]:
+        # 🔴 SIGNALLED BY A CODE, NOT BY AN EMPTY DOCUMENT. The server REJECTS a
+        # push carrying no sessions (correctly — it is not a transcript push), so
+        # emitting one would turn the ordinary steady state into an HTTP 400 on
+        # every tick, i.e. a feeder that reports failure precisely when it is
+        # working perfectly.
+        return 10
+
+    json.dump(payload, sys.stdout, separators=(",", ":"))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/build_transcript_push.py
+++ b/scripts/lib/build_transcript_push.py
@@ -33,10 +33,28 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
 import sys
 import time
 from pathlib import Path
+
+# 🔴 THE SHARED ENUMERATOR, NOT A HAND-ROLLED WALK. The first version of this file
+# open-coded `projects_dir.iterdir()` + `d.glob("*.jsonl")`, and
+# `scripts/tests/test_transcript_search.py::test_the_jsonl_glob_site_ledger_is_
+# pinned_two_way` caught it — that ledger SCANS the tree for walk sites rather
+# than naming files, precisely so a fourth hand-rolled walk cannot pass unseen.
+#
+# 🔴 AND IT IS A CORRECTNESS FIX, NOT ONLY A HYGIENE ONE. `is_corpus_member`
+# excludes `subagents/`, which holds transcripts that are NOT resumable sessions.
+# Measured on this host 2026-09-04: 4,884 of the 5,788 `.jsonl` files under
+# `~/.claude/projects` — 84% — live there. My walk happened to miss them because
+# it only descended one level, i.e. it was right BY ACCIDENT of its depth rather
+# than by any rule; a later "let's make this recursive" edit would have started
+# feeding clawgate thousands of rows that no attention entry and no tmux window
+# can ever join to, and nothing would have gone red.
+#
+# This module's dir is on sys.path when the file is run as a script, so the
+# import needs no path juggling; `transcript_search` is pure stdlib.
+from transcript_search import iter_transcripts
 
 # 🔴 THE ONE PLACE THE STORED FORM IS DEFINED, and the server recomputes it
 # rather than trusting what we send (see internal/transcript.NormalizePush). Two
@@ -117,33 +135,27 @@ def candidates(projects_dir: Path, max_age_hours: float, limit: int) -> list[Pat
     session-manager collector, and that collector runs on ONE host while this
     runs on both. Worse, it would silently stop feeding a session the moment its
     window closed, which is exactly when someone wants to read what it did.
+
+    The WALK is `transcript_search.iter_transcripts`, never a local glob — see
+    the import for the ledger that enforces that and for the 84%-of-files
+    correctness reason.
     """
-    cutoff = time.time() - max_age_hours * 3600
-    found: list[tuple[float, Path]] = []
-    # 🔴 A BOUNDED WALK: the transcript tree is `<projects>/<slug>/<uuid>.jsonl`,
-    # one level deep, and globbing it recursively would follow whatever else has
-    # been dropped in there.
-    try:
-        project_dirs = [p for p in projects_dir.iterdir() if p.is_dir()]
-    except OSError as exc:
-        print(f"cannot list {projects_dir}: {exc}", file=sys.stderr)
+    if not projects_dir.exists():
+        print(f"cannot list {projects_dir}: no such directory", file=sys.stderr)
         raise SystemExit(1)
 
-    for d in project_dirs:
+    cutoff = time.time() - max_age_hours * 3600
+    found: list[tuple[float, Path]] = []
+    for f in iter_transcripts(projects_dir):
         try:
-            entries = list(d.glob("*.jsonl"))
+            st = f.stat()
         except OSError:
+            # A transcript can vanish between the walk and the stat (a session
+            # cleaned up mid-run). Skipping one file must never fail the push.
             continue
-        for f in entries:
-            try:
-                st = f.stat()
-            except OSError:
-                continue
-            if not os.path.isfile(f):
-                continue
-            if st.st_mtime < cutoff:
-                continue
-            found.append((st.st_mtime, f))
+        if st.st_mtime < cutoff:
+            continue
+        found.append((st.st_mtime, f))
 
     found.sort(key=lambda pair: pair[0], reverse=True)
     return [p for _, p in found[:limit]]

--- a/scripts/tests/test_transcript_push.py
+++ b/scripts/tests/test_transcript_push.py
@@ -1,0 +1,906 @@
+"""Behavioural tests for scripts/transcript-push.sh + scripts/lib/build_transcript_push.py
+— the host-side feeder for clawgate's Claude Code TRANSCRIPT read model.
+
+Everything here runs against a STUB HTTP server bound to loopback on an ephemeral
+port and a SYNTHETIC transcript tree under tmp_path. Nothing touches the real
+clawgate, the real `~/.claude/projects`, or the network.
+
+🔴 EVERY TRANSCRIPT FIXTURE IS SYNTHETIC AND HAND-WRITTEN. devrc is a PUBLIC repo
+and a Claude Code transcript is captured text — real prompts, real model output,
+real paths. What these tests need is the record SHAPE, and the shapes below were
+derived from a measurement of record TYPE COUNTS on the live fleet (2026-09-04:
+of 5,614 records across three sessions, 1,331 attachments, 862 tool_use, 862
+tool_result, 419 thinking, 360 assistant text, 78 human turns), never from copied
+content.
+
+WHAT THIS SUITE IS FOR
+----------------------
+The feeder is a timer-driven pipe, so its failure mode is silence: it can stop
+delivering while the chat view keeps rendering the LAST tail, which reads as a
+quiet session rather than a broken feeder. The load-bearing tests are therefore
+not the happy path:
+
+  1. THE POSITIVE CONTROL. `test_a_changed_session_is_pushed_and_the_server_sees_it`
+     proves the stub server can observe a push at all. Every "nothing was pushed"
+     assertion counts requests and expects zero, and a zero from a harness wired
+     to nothing is indistinguishable from a real one.
+
+  2. THE DEDUPE LOOP, IN BOTH DIRECTIONS. A skip rule that is wrong one way
+     re-pushes megabytes every tick; wrong the other way it never pushes again
+     and the view silently freezes. Both are asserted, and the SECOND is the one
+     a "does it skip?" test alone would miss.
+
+  3. THE TAIL IS A TAIL, AND IT SAYS SO. `truncated` is a first-class field
+     because a consumer that cannot tell "the whole session" from "the end of it"
+     will state the first while showing the second.
+
+  4. rc-PER-CONDITION. A missing token, an absent transcript tree, an unreachable
+     server and a rejecting server need four different fixes. One "something
+     failed" code would tell an operator nothing.
+
+  5. THE TOKEN IS NOT IN argv. Asserted through a stub `curl` that records its
+     own argv — a source-level check would type-check past a second curl
+     invocation added later.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "transcript-push.sh"
+BUILDER = REPO_ROOT / "scripts" / "lib" / "build_transcript_push.py"
+HOME_NIX = REPO_ROOT / "nix" / "home.nix"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+# 🔴 RUNTIME STUBS GO THROUGH `testlib.mockbin.write_exec`, WHICH OWNS THE
+# SHEBANG. Do not hand-write one — the nix check sandbox that gates the merge has
+# no `/usr/bin/env`, so a stub carrying that shebang cannot exec, and the failure
+# presents as production code misbehaving rather than as a fixture fault. See the
+# long note in test_tmux_snapshot_push.py.
+from testlib.mockbin import write_exec  # noqa: E402
+
+
+# --- synthetic transcript records --------------------------------------------
+
+
+def _rec(**fields) -> str:
+    return json.dumps(fields, separators=(",", ":"))
+
+
+def human_turn(text: str, session_id: str = "s") -> str:
+    return _rec(type="user", sessionId=session_id, message={"role": "user", "content": text})
+
+
+def assistant_turn(text: str, session_id: str = "s") -> str:
+    return _rec(
+        type="assistant",
+        sessionId=session_id,
+        message={"role": "assistant", "content": [{"type": "text", "text": text}]},
+    )
+
+
+def attachment(session_id: str = "s") -> str:
+    return _rec(type="attachment", sessionId=session_id)
+
+
+def transcript(session_id: str, *lines: str) -> str:
+    return "\n".join(lines) + "\n"
+
+
+# --- the stub server ----------------------------------------------------------
+
+
+class _Recorder(HTTPServer):
+    """An HTTPServer that records every request and serves a scripted digest."""
+
+    def __init__(self, addr, handler):
+        super().__init__(addr, handler)
+        self.requests = []
+        # What GET /api/transcripts/digest answers with.
+        self.digest_status = 200
+        self.digest_body = json.dumps({"sessions": []}).encode()
+        # What POST /api/transcripts answers with.
+        self.push_status = 200
+        self.push_body = b'{"ok":true}'
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def _record(self, raw):
+        self.server.requests.append(
+            {
+                "method": self.command,
+                "path": self.path,
+                "body": raw,
+                "auth": self.headers.get("Authorization"),
+                "content_type": self.headers.get("Content-Type"),
+            }
+        )
+
+    def _reply(self, status, body):
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):  # noqa: N802 - name fixed by BaseHTTPRequestHandler
+        self._record(b"")
+        self._reply(self.server.digest_status, self.server.digest_body)
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length") or 0)
+        self._record(self.rfile.read(length))
+        self._reply(self.server.push_status, self.server.push_body)
+
+    def log_message(self, format, *args):  # noqa: A002
+        pass  # keep pytest output clean
+
+
+@pytest.fixture
+def server():
+    srv = _Recorder(("127.0.0.1", 0), _Handler)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    yield srv
+    srv.shutdown()
+    srv.server_close()
+
+
+def base_url(server):
+    host, port = server.server_address[0], server.server_address[1]
+    return f"http://{host}:{port}"
+
+
+@pytest.fixture
+def projects(tmp_path):
+    """A synthetic `~/.claude/projects` tree."""
+
+    root = tmp_path / "projects"
+    root.mkdir()
+
+    def _write(session_id: str, body: str, *, project: str = "-home-zach-workspace-devrc"):
+        d = root / project
+        d.mkdir(exist_ok=True)
+        f = d / f"{session_id}.jsonl"
+        f.write_text(body)
+        return f
+
+    _write.root = root
+    return _write
+
+
+def run_push(*, projects_root, tmp_path, env_extra=None, conf_text=None, path_prefix=None):
+    conf = tmp_path / "clawgate.env"
+    conf.write_text(conf_text if conf_text is not None else "")
+    env = dict(os.environ)
+    # Start from a clean slate so an operator's real credentials in the ambient
+    # environment can never leak into a test run and aim it at production.
+    env.pop("CLAWGATE_API_URL", None)
+    env.pop("CLAWGATE_HOOK_TOKEN", None)
+    env["CLAWGATE_CONF_FILE"] = str(conf)
+    env["CLAUDE_PROJECTS_DIR"] = str(projects_root)
+    env["HOME"] = str(tmp_path)
+    env["TRANSCRIPT_PUSH_HOST"] = "testhost"
+    if path_prefix:
+        env["PATH"] = f"{path_prefix}:{env['PATH']}"
+    env.update(env_extra or {})
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180,
+    )
+
+
+def pushes(server):
+    return [r for r in server.requests if r["method"] == "POST"]
+
+
+def digests(server):
+    return [r for r in server.requests if r["method"] == "GET"]
+
+
+# ── 1. the positive control ──────────────────────────────────────────────────
+
+
+def test_a_changed_session_is_pushed_and_the_server_sees_it(server, projects, tmp_path):
+    """🔴 THE POSITIVE CONTROL for this whole file.
+
+    Every "nothing was pushed" assertion below counts requests and expects 0. A
+    0 from a stub server that can never observe anything is indistinguishable
+    from a real 0, so this test exists to show the count CAN move.
+    """
+    projects("sess-a", transcript("sess-a", human_turn("do it"), assistant_turn("done")))
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "tok-abc"},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    assert len(digests(server)) == 1, "the dedupe pre-flight never ran"
+    assert digests(server)[0]["path"] == "/api/transcripts/digest"
+
+    sent = pushes(server)
+    assert len(sent) == 1, "the harness never observed a push"
+    assert sent[0]["path"] == "/api/transcripts"
+    assert sent[0]["auth"] == "Bearer tok-abc"
+    assert sent[0]["content_type"] == "application/json"
+
+    body = json.loads(sent[0]["body"])
+    assert body["host"] == "testhost"
+    assert [s["sessionId"] for s in body["sessions"]] == ["sess-a"]
+    assert "do it" in body["sessions"][0]["tail"]
+
+
+# ── 2. the dedupe loop, in BOTH directions ───────────────────────────────────
+
+
+def test_a_session_the_server_ALREADY_HAS_is_not_pushed(server, projects, tmp_path):
+    """The skip. This one comparison is why the steady-state tick is kilobytes."""
+    body = transcript("sess-a", human_turn("do it"), assistant_turn("done"))
+    projects("sess-a", body)
+
+    # Run once to learn the hash the builder computes, then feed it back as the
+    # server's digest. 🔴 DERIVED FROM THE FEEDER'S OWN OUTPUT, NOT RECOMPUTED
+    # HERE: a test that hashed the file itself would be asserting agreement
+    # between two implementations of the tail rule, and would go green while both
+    # were wrong in the same way.
+    first = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+    sent = json.loads(pushes(server)[0]["body"])["sessions"][0]
+
+    server.digest_body = json.dumps(
+        {"sessions": [{"sessionId": "sess-a", "contentHash": sent["contentHash"],
+                       "updatedAt": "2026-09-04T10:00:00Z", "tailBytes": len(sent["tail"])}]}
+    ).encode()
+    server.requests.clear()
+
+    second = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert second.returncode == 0, second.stdout + second.stderr
+    assert len(digests(server)) == 1, "the pre-flight did not run on the second tick"
+    assert pushes(server) == [], "an UNCHANGED session was pushed again"
+    assert "nothing to push" in second.stdout
+
+
+def test_a_session_that_GREW_is_pushed_again(server, projects, tmp_path):
+    """🔴 THE OTHER DIRECTION, AND THE ONE A SKIP-ONLY TEST MISSES.
+
+    A skip rule that is too eager never pushes again and the chat view silently
+    freezes on whatever it last received — indistinguishable, on screen, from a
+    session that stopped talking. `return` in place of the comparison, or a
+    constant hash, passes the test above and fails this one.
+    """
+    body = transcript("sess-a", human_turn("do it"))
+    f = projects("sess-a", body)
+
+    first = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert first.returncode == 0, first.stdout + first.stderr
+    sent = json.loads(pushes(server)[0]["body"])["sessions"][0]
+
+    server.digest_body = json.dumps(
+        {"sessions": [{"sessionId": "sess-a", "contentHash": sent["contentHash"],
+                       "updatedAt": "2026-09-04T10:00:00Z", "tailBytes": len(sent["tail"])}]}
+    ).encode()
+    server.requests.clear()
+
+    # The session says something more.
+    f.write_text(body + assistant_turn("and now this") + "\n")
+
+    second = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert second.returncode == 0, second.stdout + second.stderr
+    resent = pushes(server)
+    assert len(resent) == 1, "a session that GREW was not re-pushed — the view would freeze"
+    grown = json.loads(resent[0]["body"])["sessions"][0]
+    assert "and now this" in grown["tail"]
+    assert grown["contentHash"] != sent["contentHash"]
+
+
+def test_a_digest_the_feeder_cannot_parse_is_FATAL_not_an_empty_one(server, projects, tmp_path):
+    """🔴 FAIL, NEVER 'ASSUME THE SERVER HAS NOTHING'.
+
+    Treating an unreadable pre-flight as an empty digest is the expensive
+    direction — every recent session re-pushed on every tick — and it fires
+    precisely when the server is least able to absorb it. It would also hide a
+    server that had started answering with something else entirely.
+    """
+    projects("sess-a", transcript("sess-a", human_turn("do it")))
+    server.digest_body = b'{"not_what_you_expected": true}'
+
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert proc.returncode == 3, proc.stdout + proc.stderr
+    assert pushes(server) == [], "a session was pushed against a digest that could not be read"
+
+
+# ── 3. the tail is a TAIL, and it says so ────────────────────────────────────
+
+
+def test_a_short_transcript_is_sent_WHOLE_and_marked_untruncated(server, projects, tmp_path):
+    projects("sess-a", transcript("sess-a", human_turn("short"), assistant_turn("also short")))
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    sess = json.loads(pushes(server)[0]["body"])["sessions"][0]
+    assert sess["truncated"] is False
+    assert "short" in sess["tail"] and "also short" in sess["tail"]
+
+
+def test_a_long_transcript_is_CUT_marked_truncated_and_keeps_the_END(server, projects, tmp_path):
+    """🔴 THE DIRECTION IS THE ASSERTION. Keeping the START is the same one-line
+    slice and produces a payload that answers the opposite of the reader's
+    question ("what has it been doing lately") while looking identical in size.
+    """
+    lines = [assistant_turn(f"filler message number {i:05d}") for i in range(400)]
+    lines.append(assistant_turn("THE-FINAL-MESSAGE"))
+    projects("sess-a", transcript("sess-a", *lines))
+
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={
+            "CLAWGATE_API_URL": base_url(server),
+            "CLAWGATE_HOOK_TOKEN": "t",
+            "TRANSCRIPT_PUSH_TAIL_BYTES": "4096",
+        },
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    sess = json.loads(pushes(server)[0]["body"])["sessions"][0]
+
+    assert sess["truncated"] is True, "a cut tail was not marked truncated"
+    assert len(sess["tail"]) <= 4096
+    assert "THE-FINAL-MESSAGE" in sess["tail"], "the cut kept the START of the session, not the END"
+    assert "filler message number 00000" not in sess["tail"]
+    # 🔴 AND NO LEADING FRAGMENT. Every line the server receives must be a whole
+    # record, or the parser counts a partial one on every truncated session for
+    # ever and the bytes are wasted.
+    first_line = sess["tail"].split("\n", 1)[0]
+    json.loads(first_line)  # raises if the cut left a fragment
+
+
+def test_the_content_hash_matches_the_tail_that_was_sent(server, projects, tmp_path):
+    """The server RECOMPUTES this and REJECTS a mismatch (it is an integrity
+    check, not a value it adopts), so a feeder whose hash describes anything but
+    the bytes it sent fails every push with a 400.
+    """
+    import hashlib
+
+    projects("sess-a", transcript("sess-a", human_turn("do it")))
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    sess = json.loads(pushes(server)[0]["body"])["sessions"][0]
+    assert sess["contentHash"] == hashlib.sha256(sess["tail"].encode("utf-8")).hexdigest()
+
+
+# ── 4. the bounds ────────────────────────────────────────────────────────────
+
+
+def test_no_more_than_max_sessions_are_sent_in_one_push(server, projects, tmp_path):
+    """🔴 THE SERVER REJECTS AN OVER-CAP PUSH OUTRIGHT, so a feeder that ignores
+    this bound fails EVERY tick while looking correctly configured. The rest
+    catch up on the next tick — that is the design, not a shortfall.
+    """
+    for i in range(12):
+        projects(f"sess-{i:02d}", transcript(f"sess-{i:02d}", human_turn(f"session {i}")))
+
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={
+            "CLAWGATE_API_URL": base_url(server),
+            "CLAWGATE_HOOK_TOKEN": "t",
+            "TRANSCRIPT_PUSH_MAX_SESSIONS": "3",
+        },
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    body = json.loads(pushes(server)[0]["body"])
+    assert len(body["sessions"]) == 3, f"sent {len(body['sessions'])} sessions against a cap of 3"
+
+
+def test_a_transcript_older_than_the_age_window_is_not_sent(server, projects, tmp_path):
+    import time
+
+    old = projects("sess-old", transcript("sess-old", human_turn("ages ago")))
+    projects("sess-new", transcript("sess-new", human_turn("just now")))
+    ancient = time.time() - 72 * 3600
+    os.utime(old, (ancient, ancient))
+
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={
+            "CLAWGATE_API_URL": base_url(server),
+            "CLAWGATE_HOOK_TOKEN": "t",
+            "TRANSCRIPT_PUSH_MAX_AGE_HOURS": "24",
+        },
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    ids = [s["sessionId"] for s in json.loads(pushes(server)[0]["body"])["sessions"]]
+    assert ids == ["sess-new"], f"the age window did not exclude the old session: {ids}"
+
+
+def test_the_newest_sessions_win_when_the_cap_bites(server, projects, tmp_path):
+    """🔴 WHICH ones the cap keeps is a decision, not a detail. Dropping the
+    NEWEST would mean the session someone is actively watching is the one that
+    never arrives, on every tick, for as long as the fleet is busy.
+    """
+    import time
+
+    now = time.time()
+    for i in range(6):
+        f = projects(f"sess-{i}", transcript(f"sess-{i}", human_turn(f"session {i}")))
+        # sess-5 newest, sess-0 oldest.
+        stamp = now - (6 - i) * 60
+        os.utime(f, (stamp, stamp))
+
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={
+            "CLAWGATE_API_URL": base_url(server),
+            "CLAWGATE_HOOK_TOKEN": "t",
+            "TRANSCRIPT_PUSH_MAX_SESSIONS": "2",
+        },
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    ids = sorted(s["sessionId"] for s in json.loads(pushes(server)[0]["body"])["sessions"])
+    assert ids == ["sess-4", "sess-5"], f"the cap kept the wrong sessions: {ids}"
+
+
+def test_the_client_bounds_sit_UNDER_the_servers_not_at_them(server, projects, tmp_path):
+    """🔴 A CLIENT TUNED EXACTLY TO THE SERVER'S CAP TURNS ANY ROUNDING
+    DISAGREEMENT INTO A FEEDER THAT FAILS EVERY TICK while looking correctly
+    configured. The server's numbers are read here as LITERALS on purpose — this
+    is a cross-repo contract and the point is to fail loudly when clawgate
+    changes one.
+    """
+    server_max_tail_bytes = 256 * 1024  # transcript.MaxTailBytes
+    server_max_sessions = 8  # transcript.MaxSessionsPerPush
+
+    text = SCRIPT.read_text()
+    tail_default = _shell_default(text, "TAIL_BYTES", "TRANSCRIPT_PUSH_TAIL_BYTES")
+    sess_default = _shell_default(text, "MAX_PER_PUSH", "TRANSCRIPT_PUSH_MAX_SESSIONS")
+
+    assert tail_default < server_max_tail_bytes, (
+        f"the default tail ({tail_default}) is not UNDER the server's cap ({server_max_tail_bytes})"
+    )
+    assert sess_default < server_max_sessions, (
+        f"the default session count ({sess_default}) is not UNDER the server's cap ({server_max_sessions})"
+    )
+
+
+def _shell_default(text: str, var: str, env_name: str) -> int:
+    """Extract `VAR="${ENV:-N}"` from the script source."""
+    import re
+
+    m = re.search(rf'^{var}="\$\{{{env_name}:-(\d+)\}}"', text, re.M)
+    assert m, f"could not find the default for {var} in the script"
+    return int(m.group(1))
+
+
+# ── 5. rc-per-condition ──────────────────────────────────────────────────────
+
+
+def test_no_token_exits_2_and_pushes_nothing(server, projects, tmp_path):
+    projects("sess-a", transcript("sess-a", human_turn("do it")))
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server)},
+    )
+    assert proc.returncode == 2, proc.stdout + proc.stderr
+    assert server.requests == [], "a request was made with no credentials"
+
+
+def test_a_missing_transcript_directory_exits_3(server, tmp_path):
+    """A real state on a host where Claude Code has never run — distinct from
+    every other failure because the fix is 'nothing is wrong'."""
+    proc = run_push(
+        projects_root=tmp_path / "does-not-exist",
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert proc.returncode == 3, proc.stdout + proc.stderr
+    assert server.requests == []
+
+
+def test_an_unreachable_server_exits_4(projects, tmp_path):
+    projects("sess-a", transcript("sess-a", human_turn("do it")))
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        # Port 1 on loopback: nothing listens, so curl fails at the transport.
+        env_extra={"CLAWGATE_API_URL": "http://127.0.0.1:1", "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert proc.returncode == 4, proc.stdout + proc.stderr
+
+
+def test_a_server_that_lacks_the_route_exits_5_and_says_so(server, projects, tmp_path):
+    """A server predating the transcript read model is a DEPLOY-ORDER problem
+    (server first), not a payload problem, and the message must say which."""
+    projects("sess-a", transcript("sess-a", human_turn("do it")))
+    server.digest_status = 404
+    server.digest_body = b"not found"
+
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert proc.returncode == 5, proc.stdout + proc.stderr
+    assert "deploy the server first" in proc.stdout
+    assert pushes(server) == []
+
+
+def test_a_rejected_push_exits_5(server, projects, tmp_path):
+    projects("sess-a", transcript("sess-a", human_turn("do it")))
+    server.push_status = 400
+    server.push_body = b'{"error":"nope"}'
+
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert proc.returncode == 5, proc.stdout + proc.stderr
+
+
+def test_a_REDIRECT_is_a_failure_not_a_success(server, projects, tmp_path):
+    """🔴 THE SIBLING FEEDER'S MEASURED BUG, GUARDED HERE BEFORE IT HAPPENS.
+
+    There is no `-L`, so pointing CLAWGATE_API_URL at any hostname that redirects
+    (an ingress, clawgate.zacx.dev) makes curl return the redirect and store
+    NOTHING. Under an `HTTP < 400` success test that logs "pushed" and exits 0 —
+    invisible for ever at a five-minute cadence.
+    """
+    projects("sess-a", transcript("sess-a", human_turn("do it")))
+    server.digest_status = 302
+
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert proc.returncode == 5, proc.stdout + proc.stderr
+    assert "REDIRECTED" in proc.stdout
+
+
+def test_nothing_recent_exits_0_and_pushes_nothing(server, projects, tmp_path):
+    """🔴 rc 0, NOT AN EMPTY PUSH. The server REJECTS a push carrying no sessions
+    (correctly — it is not a transcript push), so emitting one would turn the
+    ordinary steady state into an HTTP 400 on every tick: a feeder reporting
+    failure precisely when it is working.
+    """
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "t"},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert pushes(server) == []
+    assert "nothing to push" in proc.stdout
+
+
+# ── 6. credentials ───────────────────────────────────────────────────────────
+
+
+def test_the_environment_beats_the_conf_file(server, projects, tmp_path):
+    """🔴 A REGRESSION GUARD, NOT A PREFERENCE.
+
+    `clawgate-stop-hook.sh` sources this same file with `set -a`, which makes the
+    FILE beat the environment there; the measured consequence was a probe aimed
+    at a harmless address silently POSTing to PRODUCTION. If this script ever
+    acquires that behaviour, a test run could write into the real read model.
+    """
+    projects("sess-a", transcript("sess-a", human_turn("do it")))
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        conf_text=(
+            "CLAWGATE_API_URL=http://198.51.100.1:9\n"
+            "CLAWGATE_HOOK_TOKEN=file-token\n"
+        ),
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "env-token"},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert pushes(server)[0]["auth"] == "Bearer env-token"
+
+
+def test_the_conf_file_is_read_when_the_environment_is_silent(server, projects, tmp_path):
+    """The other half — without it, "the environment wins" could be implemented
+    as "the file is never read" and pass."""
+    projects("sess-a", transcript("sess-a", human_turn("do it")))
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        conf_text=(
+            f"export CLAWGATE_API_URL={base_url(server)}\n"
+            "  CLAWGATE_HOOK_TOKEN='file-token'\n"
+        ),
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert pushes(server)[0]["auth"] == "Bearer file-token"
+
+
+def test_the_token_never_appears_in_curl_argv(server, projects, tmp_path):
+    """🔴 EVERYTHING ON THIS BOX CAN READ /proc/<pid>/cmdline.
+
+    Asserted through a stub `curl` that records its OWN argv, not by reading the
+    source — a structural check would type-check past a second curl invocation
+    added later.
+    """
+    projects("sess-a", transcript("sess-a", human_turn("do it")))
+    bindir = tmp_path / "stubbin"
+    bindir.mkdir()
+    argv_log = tmp_path / "curl-argv.log"
+    real_curl = subprocess.run(["bash", "-lc", "command -v curl"], capture_output=True, text=True).stdout.strip()
+    assert real_curl, "no real curl on PATH to delegate to"
+    write_exec(
+        bindir / "curl",
+        f'printf "%s\\n" "$*" >> {argv_log}\n'
+        f'exec {real_curl} "$@"\n',
+    )
+
+    proc = run_push(
+        projects_root=projects.root,
+        tmp_path=tmp_path,
+        path_prefix=str(bindir),
+        env_extra={"CLAWGATE_API_URL": base_url(server), "CLAWGATE_HOOK_TOKEN": "super-secret-token"},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    recorded = argv_log.read_text()
+    # Positive control: the stub really did see the invocations.
+    assert recorded.strip(), "the curl stub recorded nothing — this assertion covers nothing"
+    assert "super-secret-token" not in recorded, f"the token reached curl's argv:\n{recorded}"
+
+
+# ── 7. the builder's own contract ────────────────────────────────────────────
+
+
+def run_builder(projects_root, digest_path, tmp_path, **kw):
+    args = [
+        sys.executable, str(BUILDER),
+        "--projects-dir", str(projects_root),
+        "--digest", str(digest_path),
+        "--host", kw.get("host", "testhost"),
+        "--tail-bytes", str(kw.get("tail_bytes", 196608)),
+        "--max-sessions", str(kw.get("max_sessions", 6)),
+        "--max-age-hours", str(kw.get("max_age_hours", 24)),
+        "--max-candidates", str(kw.get("max_candidates", 200)),
+    ]
+    return subprocess.run(args, capture_output=True, text=True, timeout=120)
+
+
+def empty_digest(tmp_path):
+    p = tmp_path / "digest.json"
+    p.write_text(json.dumps({"sessions": []}))
+    return p
+
+
+def test_the_builder_signals_nothing_to_push_with_rc_10(projects, tmp_path):
+    """🔴 A CODE, NOT AN EMPTY DOCUMENT, so "the builder had nothing to send"
+    cannot be confused with "the builder crashed and produced nothing"."""
+    proc = run_builder(projects.root, empty_digest(tmp_path), tmp_path)
+    assert proc.returncode == 10, proc.stdout + proc.stderr
+    assert proc.stdout.strip() == ""
+
+
+def test_the_builder_skips_a_record_longer_than_the_whole_window(projects, tmp_path):
+    """One record bigger than the tail window has no boundary to cut on. Sending
+    the fragment would parse to zero events while claiming to be a conversation,
+    so the session is skipped instead."""
+    projects("sess-huge", assistant_turn("x" * 5000) + "\n")
+    proc = run_builder(projects.root, empty_digest(tmp_path), tmp_path, tail_bytes=1000)
+    assert proc.returncode == 10, proc.stdout + proc.stderr
+
+
+def test_the_builder_ignores_non_jsonl_files(projects, tmp_path):
+    """The transcript tree is `<projects>/<slug>/<uuid>.jsonl`. Anything else
+    that has been dropped in there is not a transcript."""
+    d = projects.root / "-home-zach-workspace-devrc"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "notes.md").write_text("not a transcript")
+    (d / "sess-a.jsonl.bak").write_text(human_turn("nor this") + "\n")
+    projects("sess-real", transcript("sess-real", human_turn("this one")))
+
+    proc = run_builder(projects.root, empty_digest(tmp_path), tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    ids = [s["sessionId"] for s in json.loads(proc.stdout)["sessions"]]
+    assert ids == ["sess-real"], f"the builder picked up a non-transcript: {ids}"
+
+
+def test_the_builder_never_emits_invalid_utf8(projects, tmp_path):
+    """🔴 THE SERVER'S COLUMN IS TEXT AND POSTGRES REJECTS INVALID UTF-8, which
+    would fail the WHOLE atomic push — one bad byte taking every other session in
+    the request down with it. The cut point is a byte offset, so it CAN land
+    inside a multi-byte rune; replacing is what makes that cost one glyph.
+    """
+    d = projects.root / "-multibyte"
+    d.mkdir(parents=True, exist_ok=True)
+    # 🔴 ensure_ascii=False, SO THE BYTES ON DISK REALLY ARE MULTI-BYTE. The
+    # first version of this fixture used the default json.dumps, which escapes
+    # every non-ASCII rune to `\uXXXX` — six ASCII bytes. The file was then pure
+    # ASCII, no byte offset could land mid-rune, and the test passed while
+    # exercising nothing. A fixture that cannot contain the hazard cannot see it.
+    line = json.dumps(
+        {"type": "assistant", "sessionId": "sess-mb",
+         "message": {"role": "assistant", "content": [{"type": "text", "text": "界" * 40}]}},
+        separators=(",", ":"), ensure_ascii=False,
+    )
+    body = "\n".join(line for _ in range(80)) + "\n"
+    raw = body.encode("utf-8")
+    (d / "sess-mb.jsonl").write_bytes(raw)
+
+    # 🔴 THE FIXTURE'S OWN CONTROL, AND IT ALREADY EARNED ITS KEEP. The first
+    # attempt hard-coded tail_bytes=3000 and every line was the same length, so
+    # the cut landed exactly on a rune boundary and the test would have passed
+    # while exercising nothing. Rather than pick another magic number that could
+    # drift back into alignment when the fixture is edited, SEARCH for an offset
+    # that provably splits a rune, and fail loudly if none exists.
+    tail_bytes = None
+    # The search window must be WIDER than one record: the multi-byte runes sit
+    # inside the `text` field, so a run of consecutive offsets lands in the
+    # surrounding ASCII and splits nothing. Measured on this fixture: offsets
+    # 2910-3022 are all rune-aligned, which is exactly the gap a narrow window
+    # fell into on the first attempt.
+    for candidate in range(2900, 3300):
+        if candidate >= len(raw):
+            continue
+        try:
+            raw[len(raw) - candidate:].decode("utf-8")
+        except UnicodeDecodeError:
+            tail_bytes = candidate
+            break
+    assert tail_bytes is not None, (
+        "no offset in 2900-3300 splits a rune in this fixture — it cannot see the hazard it is "
+        "written for, so a green here would mean nothing"
+    )
+
+    proc = run_builder(projects.root, empty_digest(tmp_path), tmp_path, tail_bytes=tail_bytes)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    payload = json.loads(proc.stdout)
+    tail = payload["sessions"][0]["tail"]
+    tail.encode("utf-8")  # raises on an unencodable surrogate
+
+
+def test_the_builder_is_read_only(projects, tmp_path):
+    """🔴 A SECURITY PROPERTY, NOT A DESCRIPTION. Asserted by snapshotting the
+    whole transcript tree — contents AND mtimes — around a run."""
+    f = projects("sess-a", transcript("sess-a", human_turn("do it")))
+    before = {p: (p.read_bytes(), p.stat().st_mtime_ns) for p in projects.root.rglob("*")
+              if p.is_file()}
+    assert before, "the snapshot is empty — this assertion covers nothing"
+
+    proc = run_builder(projects.root, empty_digest(tmp_path), tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    after = {p: (p.read_bytes(), p.stat().st_mtime_ns) for p in projects.root.rglob("*")
+             if p.is_file()}
+    assert after == before, "the builder modified the transcript tree"
+    assert f.exists()
+
+
+# ── 8. the unit ──────────────────────────────────────────────────────────────
+
+
+def _unit_block() -> str:
+    """The transcript-push SERVICE block from nix/home.nix, service start to timer start."""
+    text = HOME_NIX.read_text()
+    idx = text.index("systemd.user.services.transcript-push")
+    end = text.index("systemd.user.timers.transcript-push")
+    return text[idx:end]
+
+
+def test_the_unit_is_NOT_serverMode_gated():
+    """🔴 THE ASYMMETRY WITH tmux-snapshot-push IS THE POINT, AND IT IS THE ONE
+    THING A COPY-PASTE OF THAT UNIT WOULD GET WRONG.
+
+    That feeder is workbench-only as a CORRECTNESS requirement — its collector
+    already reaches both hosts over ssh, so a second reporter would fight over
+    every row. Transcripts are local files, readable from nowhere else, so a
+    serverMode gate here would feed exactly half the fleet and every laptop
+    session would render "no transcript stored" for ever, silently and for ever.
+    """
+    text = HOME_NIX.read_text()
+    idx = text.index("systemd.user.timers.transcript-push")
+    block = text[idx : idx + 1200]
+    wanted = 'WantedBy = lib.optionals enableTranscriptPush [ "timers.target" ];'
+    assert wanted in block, f"the transcript timer's WantedBy is not the ungated form:\n{block}"
+    # And the sibling's gate really is different, so this is a measured contrast
+    # rather than a claim about a file nobody read.
+    sib = text.index("systemd.user.timers.tmux-snapshot-push")
+    sib_block = text[sib : sib + 1200]
+    assert "serverMode && enableTmuxSnapshotPush" in sib_block, (
+        "the sibling timer is no longer serverMode-gated — this test's contrast is stale"
+    )
+
+
+def test_the_unit_does_not_wire_the_DND_defeating_failure_toast():
+    """🔴 notify-failure@ toasts are wired to DEFEAT do-not-disturb, and that
+    bypass is justified by a MEASURED rate of ~1 firing in 9 days. This timer runs
+    every 5 minutes, so any sustained outage — the laptop asleep, clawgate
+    mid-redeploy — would fire one on EVERY tick and burn down the one alert
+    channel that has to keep its meaning.
+    """
+    block = _unit_block()
+
+    # 🔴 STRIP COMMENTS FIRST, and this is not a refinement — the naive
+    # `"OnFailure" not in block` version of this assertion FAILED against the
+    # very unit it was written to approve, because the block explains at length
+    # WHY there is no OnFailure. Measured here, and measured before in the
+    # sibling suite, which carries the same note. A guard that reads prose is not
+    # a guard on configuration: it would equally have passed a unit that wired
+    # OnFailure while calling it something else in a comment, and it punishes the
+    # documentation that makes the absence deliberate rather than accidental.
+    config = "\n".join(ln for ln in block.splitlines() if not ln.strip().startswith("#"))
+    offenders = [ln for ln in config.splitlines() if "OnFailure" in ln]
+    assert not offenders, (
+        "the transcript feeder wired OnFailure=notify-failure@; at a 5-minute cadence a "
+        f"sustained outage would fire a DND-bypassing toast on every tick. Offenders: {offenders}"
+    )
+    # Positive control for the stripper: it must still be able to SEE a real
+    # setting, or the assertion above is a fact about an empty string.
+    assert "ExecStart" in config and "transcript-push.sh" in config
+
+
+def test_the_unit_PATH_carries_the_binaries_the_script_needs():
+    """🔴 EVERY BINARY IS FOR THE CHILD — under systemd there is no login-shell
+    PATH to fall back on. drift-check.service paid for this lesson: without its
+    binaries the child reported COULD NOT MEASURE on every run for ever, from a
+    unit that looked completely correct.
+    """
+    block = _unit_block()
+    for pkg in ["pkgs.bash", "pkgs.coreutils", "pkgs.curl", "pkgs.gnused", "pkgs.python3"]:
+        assert pkg in block, f"the transcript feeder's PATH is missing {pkg}"
+
+
+def test_the_unit_restart_triggers_name_BOTH_halves():
+    """The builder decides WHICH sessions are sent and HOW MUCH of each. A change
+    there changes what this unit delivers with no edit to the shell at all, so a
+    trigger on the shell alone would leave a deployed unit running the old rule.
+    """
+    block = _unit_block()
+    assert "../scripts/transcript-push.sh" in block
+    assert "../scripts/lib/build_transcript_push.py" in block
+
+
+def test_the_script_and_builder_are_executable():
+    """A NEW file must be `git add`ed AND executable, or the deploy succeeds and
+    the unit fails at exec time."""
+    assert os.access(SCRIPT, os.X_OK), f"{SCRIPT} is not executable"
+    assert os.access(BUILDER, os.X_OK), f"{BUILDER} is not executable"

--- a/scripts/tests/test_transcript_push.py
+++ b/scripts/tests/test_transcript_push.py
@@ -904,3 +904,43 @@ def test_the_script_and_builder_are_executable():
     the unit fails at exec time."""
     assert os.access(SCRIPT, os.X_OK), f"{SCRIPT} is not executable"
     assert os.access(BUILDER, os.X_OK), f"{BUILDER} is not executable"
+
+
+def test_a_SUBAGENT_transcript_is_never_pushed(projects, tmp_path):
+    """🔴 SUBAGENT TRANSCRIPTS ARE NOT RESUMABLE SESSIONS, and they are the BULK
+    of the corpus: measured on this host 2026-09-04, 4,884 of the 5,788 `.jsonl`
+    files under `~/.claude/projects` — 84% — live under a `subagents/` directory.
+
+    Nothing can ever join them to anything the chat view is reached from: no
+    attention entry carries a subagent id, and session-manager's
+    `claude_session_id` is the MAIN session's. Feeding them would fill the read
+    model with thousands of unreachable rows, each up to the tail cap, against a
+    retention sweep sized for real sessions.
+
+    The exclusion comes from `transcript_search.is_corpus_member`, which is the
+    ONE rule the whole repo's transcript readers share. This test exists because
+    the first version of the builder open-coded its own walk and got the right
+    answer BY ACCIDENT — it only descended one level, so it missed them without
+    any rule saying it should. A later "make this recursive" edit would have been
+    silently catastrophic.
+    """
+    d = projects.root / "-home-zach-workspace-devrc"
+    d.mkdir(parents=True, exist_ok=True)
+    sub = d / "subagents"
+    sub.mkdir(exist_ok=True)
+    (sub / "agent-deadbeef.jsonl").write_text(
+        transcript("agent-deadbeef", human_turn("subagent work", "agent-deadbeef"))
+    )
+    projects("sess-main", transcript("sess-main", human_turn("main work", "sess-main")))
+
+    proc = run_builder(projects.root, empty_digest(tmp_path), tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    ids = [s["sessionId"] for s in json.loads(proc.stdout)["sessions"]]
+
+    assert "agent-deadbeef" not in ids, (
+        "a subagent transcript was pushed — it is unreachable from every surface the chat "
+        f"view is linked from, and they are 84% of the corpus. Got: {ids}"
+    )
+    # POSITIVE CONTROL: the walk found the real one, so the absence above is not a
+    # fact about a walk that enumerated nothing.
+    assert ids == ["sess-main"], f"the main session was not picked up either: {ids}"

--- a/scripts/transcript-push.sh
+++ b/scripts/transcript-push.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+#
+# transcript-push.sh — feed clawgate's Claude Code TRANSCRIPT read model.
+#
+# WHAT THIS IS
+# ------------
+# clawgate runs in a pod on the workbench cluster. Claude Code transcripts are
+# ordinary files on each HOST's filesystem (`~/.claude/projects/<slug>/<uuid>.jsonl`).
+# The deployment has no hostPath, no hostNetwork and no nodeName, so the pod
+# structurally cannot read them. Delivery is therefore OUTBOUND from the host,
+# exactly like `tmux-snapshot-push.sh` — which also means no inbound access to
+# either machine and no credential living in a pod on an unauthenticated LAN.
+#
+# 🔴 ONE UNIT PER HOST, WHICH IS THE OPPOSITE OF ITS SIBLING, AND THE REASON IS
+# NOT STYLE. `tmux-snapshot-push.sh` runs on the workbench ONLY because its
+# collector already reaches BOTH machines over ssh, so a second reporter would
+# have the two fighting over every row. Transcripts have no such collector: the
+# files are local, unreadable from the other host, and there is no cross-host
+# enumeration to share. The read model is keyed on a Claude Code SESSION ID,
+# which is globally unique, so two hosts pushing disjoint session sets cannot
+# collide — a session only ever lives on one machine at a time.
+#
+# 🔴 A BOUNDED TAIL, NEVER A TRANSCRIPT. Measured on this fleet 2026-09-04: 315
+# transcript files were modified within 24h, 456 MB in total, the largest single
+# file 23 MB. Shipping whole files is not a size to be tuned down, it is the
+# wrong shape. What is sent is the last TAIL_BYTES of each file with the leading
+# partial record dropped, and the payload SAYS whether it was cut, because a
+# consumer that cannot tell "the whole session" from "the end of it" will state
+# the first while showing the second.
+#
+# 🔴 THE DEDUPE PRE-FLIGHT IS WHAT MAKES THE STEADY STATE CHEAP, AND IT IS
+# SERVER-AUTHORITATIVE ON PURPOSE. Before pushing anything this asks
+# `GET /api/transcripts/digest` what the server already holds and skips every
+# session whose tail hashes to the same value. The alternative considered and
+# REJECTED was a host-side state file of "what I sent last time": it is wrong
+# whenever the two sides disagree, and they disagree in both directions — a
+# database restore or a fresh deploy leaves the server empty while the host
+# believes everything is delivered (silent permanent data loss, invisible), and
+# a wiped host cache re-pushes everything (merely expensive). Asking the server
+# is correct in both directions and needs no state on this machine at all.
+#
+# Exit codes (distinct on purpose — "something went wrong" would not tell an
+# operator whether to look at this host, the network, or the server):
+#   0  pushed, or nothing had changed since the last run
+#   2  no usable credentials
+#   3  the transcript directory is missing/unreadable, or the builder failed
+#   4  a request could not reach the server (transport)
+#   5  the server did not accept a request (any non-2xx)
+#
+# 🔴 A non-zero exit is the ONLY alarm this unit has, by design: it deliberately
+# wires no OnFailure toast (see nix/home.nix), because it runs on a timer and a
+# sustained outage — the laptop asleep, clawgate mid-redeploy — would otherwise
+# fire a do-not-disturb-defeating toast on every tick and burn down the one alert
+# channel that has to keep its meaning. Keep these codes distinct and non-zero.
+#
+# 🔴 READ-ONLY, AND THAT IS A SECURITY PROPERTY RATHER THAN A DESCRIPTION. This
+# script opens transcript files for reading and posts bytes. It executes nothing
+# on any host, writes nothing outside its own mktemp scratch, and takes no input
+# from the server beyond a list of hashes it compares for equality. The clawgate
+# side is symmetric: the ingest stores a document and the chat view renders one.
+
+set -euo pipefail
+
+API_DEFAULT="http://192.168.50.250:30302"
+CONF_FILE="${CLAWGATE_CONF_FILE:-$HOME/.claude/clawgate.env}"
+CURL_TIMEOUT="${TRANSCRIPT_PUSH_CURL_TIMEOUT:-30}"
+BUILD_TIMEOUT="${TRANSCRIPT_PUSH_BUILD_TIMEOUT:-120}"
+
+# Where the transcripts live. Overridable so the tests never touch the real one.
+PROJECTS_DIR="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
+
+# This host's name as the read model will record it. `ACTIVITY_HOST` is the
+# fleet's existing per-host handle (the activity collector sets it on both
+# machines), so reusing it keeps one answer to "which box is this" rather than
+# minting a second.
+HOST_NAME="${TRANSCRIPT_PUSH_HOST:-${ACTIVITY_HOST:-$(uname -n)}}"
+
+# 🔴 THESE THREE BOUNDS MUST STAY UNDER THE SERVER'S OWN, NOT AT THEM. The
+# server enforces MaxTailBytes=262144 and MaxSessionsPerPush=8 and REJECTS a push
+# that exceeds either — a rejection changes nothing server-side, so a client tuned
+# exactly to the limit turns any rounding disagreement into a feeder that fails
+# every single tick while looking correctly configured.
+TAIL_BYTES="${TRANSCRIPT_PUSH_TAIL_BYTES:-196608}"     # 192 KiB; server cap 256 KiB
+MAX_PER_PUSH="${TRANSCRIPT_PUSH_MAX_SESSIONS:-6}"      # server cap 8
+# How far back to consider a transcript at all. 24h keeps a session readable the
+# morning after; older ones are past the server's retention anyway.
+MAX_AGE_HOURS="${TRANSCRIPT_PUSH_MAX_AGE_HOURS:-24}"
+# How many recent files to even HASH per run. Hashing is the only per-file cost
+# in the steady state and it is bounded by TAIL_BYTES, so this is generous.
+MAX_CANDIDATES="${TRANSCRIPT_PUSH_MAX_CANDIDATES:-200}"
+
+log() { printf 'transcript-push: %s\n' "$*"; }
+
+# ── credentials ──────────────────────────────────────────────────────────────
+# 🔴 THE ENVIRONMENT WINS OVER THE FILE, and that direction is load-bearing —
+# the same rule, for the same measured reason, as the sibling feeder.
+# `clawgate-stop-hook.sh` sources this file with `set -a`, which makes the FILE
+# beat the environment; the consequence measured there was a probe aimed at a
+# harmless address silently POSTing to PRODUCTION. Reading the file only for keys
+# the environment has not already set means `CLAWGATE_API_URL=... this script`
+# goes where you told it. `CLAWGATE_CONF_FILE` redirects the file itself.
+read_conf_key() {
+  local key="$1"
+  [ -r "$CONF_FILE" ] || return 0
+  # Last assignment wins, as sourcing would, and the anchor accepts the two
+  # spellings a sourceable file actually carries — a leading `export ` and
+  # leading whitespace.
+  sed -n "s/^[[:space:]]*\(export[[:space:]]\{1,\}\)\{0,1\}${key}=//p" "$CONF_FILE" \
+    | tail -1 \
+    | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'\$/\1/"
+}
+
+API_URL="${CLAWGATE_API_URL:-$(read_conf_key CLAWGATE_API_URL)}"
+API_URL="${API_URL:-$API_DEFAULT}"
+API_URL="${API_URL%/}"
+TOKEN="${CLAWGATE_HOOK_TOKEN:-$(read_conf_key CLAWGATE_HOOK_TOKEN)}"
+
+if [ -z "$TOKEN" ]; then
+  # Not a warning to be ignored: both routes are behind requireHookToken, so with
+  # no token this can only ever 401. Fail loudly rather than push nothing on a
+  # timer for ever.
+  log "no CLAWGATE_HOOK_TOKEN in the environment or $CONF_FILE — refusing to push"
+  exit 2
+fi
+
+if [ ! -d "$PROJECTS_DIR" ]; then
+  # A real state on a host where Claude Code has never run. Distinct from every
+  # other failure because the fix is "nothing is wrong", not "look at the pipe".
+  log "no transcript directory at $PROJECTS_DIR — nothing to feed"
+  exit 3
+fi
+
+# ── scratch ──────────────────────────────────────────────────────────────────
+# 🔴 Per-run mktemp, never a fixed name. Two runs sharing a path is the silent
+# collision that makes one report a result computed against the other's data.
+umask 077
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/transcript-push.XXXXXX")"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT INT TERM
+
+DIGEST="$WORK/digest.json"
+PAYLOAD="$WORK/payload.json"
+CURL_CFG="$WORK/curl.cfg"
+BODY="$WORK/response.json"
+
+# 🔴 The token goes in a 0600 config file, never in argv. Everything on this box
+# can read /proc/<pid>/cmdline.
+printf 'header = "Authorization: Bearer %s"\n' "$TOKEN" >"$CURL_CFG"
+
+# ── 1. the dedupe pre-flight ─────────────────────────────────────────────────
+set +e
+HTTP=$(curl -sS --config "$CURL_CFG" \
+  --max-time "$CURL_TIMEOUT" \
+  -H 'Accept: application/json' \
+  -o "$DIGEST" -w '%{http_code}' \
+  "$API_URL/api/transcripts/digest" 2>"$WORK/curl.err")
+CURL_RC=$?
+set -e
+if [ "$CURL_RC" -ne 0 ]; then
+  log "digest request to $API_URL failed (curl rc=$CURL_RC): $(tr '\n' ' ' <"$WORK/curl.err" | cut -c1-300)"
+  exit 4
+fi
+
+# 🔴 SUCCESS IS 2xx, NOT "anything under 400". The sibling script's header
+# records why, with three measured failures behind it: a 3xx is followed by
+# nothing (there is no `-L`), `000` is curl's no-status-line code, and an EMPTY
+# string makes `[ "" -ge 400 ]` write "integer expected" and evaluate FALSE. A
+# case on the literal covers all three with no numeric comparison.
+#
+# 🔴 AND A FAILED PRE-FLIGHT IS FATAL RATHER THAN "ASSUME NOTHING IS STORED".
+# Treating it as an empty digest would be the expensive direction — every
+# session re-pushed on every tick for as long as the endpoint is unreachable,
+# which is precisely when the server is least able to absorb it.
+case "$HTTP" in
+  2[0-9][0-9]) : ;;
+  404)
+    log "server at $API_URL has no /api/transcripts/digest route (HTTP 404) — it predates the transcript read model; deploy the server first"
+    exit 5
+    ;;
+  30[0-35-9]|3[1-9][0-9])
+    log "server at $API_URL REDIRECTED the digest request (HTTP $HTTP) — this script does not follow redirects; point CLAWGATE_API_URL at the origin, not an ingress"
+    exit 5
+    ;;
+  *)
+    log "digest request not accepted (HTTP '${HTTP}'): $(tr '\n' ' ' <"$DIGEST" | cut -c1-300)"
+    exit 5
+    ;;
+esac
+
+# ── 2. build the payload ─────────────────────────────────────────────────────
+# 🔴 stdout and stderr to SEPARATE files. A merged capture would splice the
+# builder's diagnostics into the JSON document, and the failure would present as
+# a malformed payload rather than as the builder complaining.
+#
+# Exit 10 = nothing to push (every candidate already matches the server's hash).
+# That is the ORDINARY steady-state outcome, not a failure, and it is signalled
+# by a code rather than by an empty file so it cannot be confused with a builder
+# that produced nothing because it crashed.
+BUILDER="${TRANSCRIPT_PUSH_BUILDER:-$(dirname "$(readlink -f "$0")")/lib/build_transcript_push.py}"
+if [ ! -r "$BUILDER" ]; then
+  log "builder not readable: $BUILDER"
+  exit 3
+fi
+
+set +e
+timeout "$BUILD_TIMEOUT" python3 "$BUILDER" \
+  --projects-dir "$PROJECTS_DIR" \
+  --digest "$DIGEST" \
+  --host "$HOST_NAME" \
+  --tail-bytes "$TAIL_BYTES" \
+  --max-sessions "$MAX_PER_PUSH" \
+  --max-age-hours "$MAX_AGE_HOURS" \
+  --max-candidates "$MAX_CANDIDATES" \
+  >"$PAYLOAD" 2>"$WORK/build.err"
+BUILD_RC=$?
+set -e
+if [ "$BUILD_RC" -eq 10 ]; then
+  log "nothing to push — every recent session already matches the server's digest"
+  exit 0
+fi
+if [ "$BUILD_RC" -ne 0 ]; then
+  if [ "$BUILD_RC" -eq 124 ]; then
+    log "builder TIMED OUT after ${BUILD_TIMEOUT}s (rc=124)"
+  else
+    log "builder failed (rc=$BUILD_RC): $(tr '\n' ' ' <"$WORK/build.err" | cut -c1-400)"
+  fi
+  exit 3
+fi
+
+BYTES=$(wc -c <"$PAYLOAD")
+
+# ── 3. push ──────────────────────────────────────────────────────────────────
+set +e
+HTTP=$(curl -sS --config "$CURL_CFG" \
+  --max-time "$CURL_TIMEOUT" \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  --data-binary "@$PAYLOAD" \
+  -o "$BODY" -w '%{http_code}' \
+  "$API_URL/api/transcripts" 2>"$WORK/curl.err")
+CURL_RC=$?
+set -e
+
+if [ "$CURL_RC" -ne 0 ]; then
+  log "push to $API_URL failed (curl rc=$CURL_RC): $(tr '\n' ' ' <"$WORK/curl.err" | cut -c1-300)"
+  exit 4
+fi
+
+case "$HTTP" in
+  2[0-9][0-9]) : ;;
+  404)
+    log "server at $API_URL has no /api/transcripts route (HTTP 404) — it predates the transcript read model; deploy the server first"
+    exit 5
+    ;;
+  30[0-35-9]|3[1-9][0-9])
+    log "server at $API_URL REDIRECTED the push (HTTP $HTTP) and NOTHING was stored — this script does not follow redirects; point CLAWGATE_API_URL at the origin, not an ingress"
+    exit 5
+    ;;
+  *)
+    log "push not accepted (HTTP '${HTTP}'): $(tr '\n' ' ' <"$BODY" | cut -c1-300)"
+    exit 5
+    ;;
+esac
+
+log "pushed ${BYTES}B to $API_URL (HTTP $HTTP): $(tr -d '\n' <"$BODY" | cut -c1-200)"


### PR DESCRIPTION
The host half of rank 25 of the tmux-webapp effort. The server half — the read model, the ingest routes and the chat view — is **ZacxDev/homelab-infra#695**.

🔴 **This is a no-op without #695**, by design: the feeder treats a 404 from either route exactly as it treats an unreachable server, so deploying in either order degrades rather than errors.

## What this adds

- `scripts/transcript-push.sh` — credentials, the two HTTP calls, a distinct exit code per condition.
- `scripts/lib/build_transcript_push.py` — the one decision worth testing: **which** sessions to send and **how much** of each.
- `systemd.user.services.transcript-push` + a 5-minute timer in `nix/home.nix`, behind `enableTranscriptPush`.

## Decisions a reviewer should want to challenge

**1. 🔴 ONE UNIT PER HOST — the opposite of its sibling.** `tmux-snapshot-push` is `serverMode`-gated (workbench only) as a *correctness* requirement: its collector already reaches both machines over ssh, so a second reporter would fight over every row. Transcripts have no such collector — the files are local and unreadable from the other host — so a `serverMode` gate here would feed exactly half the fleet and **every laptop session would render "no transcript stored" for ever, silently**. The read model is keyed on a globally-unique Claude Code session id, so two hosts pushing disjoint sets cannot collide.

This is the single thing a copy-paste of the sibling unit would get wrong, so `test_the_unit_is_NOT_serverMode_gated` pins it — *and* asserts the sibling's gate is still different, so the contrast cannot go stale.

**2. 🔴 The walk is the SHARED enumerator, and that fix is a correctness fix.** The first revision open-coded its own `*.jsonl` walk. `test_transcript_search.py::test_the_jsonl_glob_site_ledger_is_pinned_two_way` caught it — that ledger SCANS the tree for walk sites rather than naming files, precisely so a fourth hand-rolled walk cannot pass unseen.

The fix is not hygiene. `transcript_search.is_corpus_member` excludes `subagents/`, which holds transcripts that are **not resumable sessions**: measured 2026-09-04, **4,884 of the 5,788** `.jsonl` files under `~/.claude/projects` — **84%** — live there, and nothing can ever join them to anything the chat view is reached from. My walk missed them only because it descended one level, i.e. it was right *by accident of its depth*. A later "make this recursive" edit would have fed clawgate thousands of unreachable rows and nothing would have gone red.

**3. A bounded TAIL, never a transcript.** 315 files modified in 24h, 456 MB, largest 23 MB. Client defaults (192 KiB, 6 sessions) sit deliberately **under** the server's caps (256 KiB, 8) — a client tuned exactly to the limit turns any rounding disagreement into a feeder that fails every tick while looking correctly configured. `test_the_client_bounds_sit_UNDER_the_servers_not_at_them` reads the server's numbers as literals, so a clawgate-side change fails loudly here.

**4. Dedupe via a SERVER-AUTHORITATIVE digest.** A host-side "what I sent last time" cache is wrong in both directions: a DB restore leaves the server empty while the host believes everything is delivered (silent, permanent, invisible); a wiped cache re-pushes everything. Asking the server is correct both ways and needs no state on this machine.

**5. A failed pre-flight is FATAL, not "assume the server has nothing".** Treating an unreadable digest as empty is the expensive direction — every recent session re-pushed every tick — and it fires precisely when the server is least able to absorb it.

**6. "Nothing changed" is rc 0, signalled by an exit code, not an empty document.** The server rejects a push carrying no sessions (correctly), so emitting one would make the ordinary steady state an HTTP 400 every tick: a feeder reporting failure exactly when it works.

**7. No `OnFailure` toast.** `notify-failure@` defeats do-not-disturb and is justified by a measured ~1 firing in 9 days; at a 5-minute cadence any sustained outage would fire one every tick. The compensating control is `Type=oneshot` with distinct codes landing in the failed-unit list `/standup` reads — **plus**, unlike the sibling, a consumer that renders its own staleness (`fed <n> ago`).

**8. The `PATH` is deliberately shorter than the sibling's** — no tmux/openssh/gawk, because this reads local files. Pinned.

## Verification matrix

Base: merged with `origin/main` @ **`f75c92d4`**. Tree under test: **`6da75cb1`**.

| tier | command | result |
|---|---|---|
| dev-host, both tiers | `nix develop … scripts/gate.sh --tier both` | **`GATE: RESULT=PASS exit=0`** |
| ↳ pytest | (from the runner's own summary) | **collected=21508, passed=21505, skipped=3, failed=0** (floor 18555) |
| ↳ node | (from the runner's own summary) | **suites=5 files=41 tests=1449 pass=1449 fail=0 skipped=0** (floor 1367) |
| this suite alone | `pytest scripts/tests/test_transcript_push.py` | **32 passed** |
| nix syntax | `nix-instantiate --parse nix/home.nix` | clean |
| sandbox tier | `nix build .#checks.x86_64-linux.pytests` / `.nodetests`, **one at a time** | see the comment below |

🔴 **The sandbox tier is a DIFFERENT tier from `gate.sh`, not a second spelling of it** — it builds from a `cp -r` store copy with no `.git`, and it is what CI runs. Its result is posted as a comment rather than asserted here.

### Three tests were watched to FAIL first — all three were my own bugs

- `test_the_unit_does_not_wire_the_DND_defeating_failure_toast` failed against the very unit it was written to approve, because the block *explains at length why there is no `OnFailure`*. A guard that reads prose is not a guard on configuration — it would equally pass a unit that wired `OnFailure` while calling it something else in a comment. Now strips comment lines, with a positive control that the stripper can still see a real setting.
- `test_the_builder_never_emits_invalid_utf8` used the default `json.dumps`, which escapes non-ASCII to six ASCII bytes — the fixture was pure ASCII, no byte offset could land mid-rune, and it would have passed while exercising nothing. It now writes real multi-byte bytes and **searches** for an offset that provably splits a rune, failing loudly if none exists. Its own control then caught a hardcoded offset that happened to be rune-aligned.
- The glob-site ledger failure above, which was a real defect and not a test bug.

## What is NOT covered

- **Nothing is deployed.** No `home-manager switch`, no `ship.sh`. The timer is armed in config only.
- **The two halves have never run against each other.** This suite drives the real script against a stub HTTP server on loopback; #695's drives real routes against fake stores. Neither exercises the live pod.
- **No measurement of the real steady state.** The dedupe saving is argued from the design and asserted against a stub; the actual bytes/tick on the live fleet are unmeasured.
- **`project_of` is a LABEL, not an identifier.** The directory name is a slugified cwd and the slug is lossy, so it is deliberately not un-slugified; the server prefers the `cwd` the records carry.
- **A session resumed on the other host** flips the row's `host` column. No test covers that transition.
- **`TRANSCRIPT_PUSH_HOST` falls back to `ACTIVITY_HOST` then `uname -n`.** Nothing pins that `ACTIVITY_HOST` is set on both machines.
- **The tail is read while the file is being appended to.** That is the normal case, not an edge one; the code says so and claims no consistency beyond "a tail as of some instant".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBuEtZn6AaCQFy6PjWUrjQ
