### PR TITLE
feat(tmux-restore): bind a window by the per-pane LEDGER, not a 145-file grep

### DIFF
--- a/claude/skills/initiative-scan/SKILL.md
+++ b/claude/skills/initiative-scan/SKILL.md
@@ -59,9 +59,9 @@ skill instead. This skill is the ephemeral scan that feeds it.
 If `$ARGUMENTS` is **`snapshot`** (or `save`), **`restore`** (optionally `restore --dry-run`), or **`show`**, run the workspace snapshot helper instead of the scan — it binds each live claude tmux window to its exact session id (the per-pane agent ledger first — a RECORD; a pane-content grep only for what the ledger cannot answer — a GUESS) so you can bring the whole workspace back after a reboot. tmux-continuum already restores the sessions/windows/cwds; this relaunches the right `claude --resume <id>` in each.
 
 ```bash
-python3 ~/workspace/devrc/scripts/tmux-session-restore.py <snapshot|restore|show> [--dry-run]
+python3 ~/workspace/devrc/scripts/tmux-session-restore.py <save|restore|show> [--dry-run]
 ```
-- **`snapshot`** — run BEFORE rebooting: writes `~/.config/initiatives/restore-plan.json` + a readable `restore-cheatsheet.md` (survives reboot). Present the cheat-sheet. Each entry carries `bind_source` and the sheet prints it per line (`(ledger)` = certain, `(fuzzy)` = a content guess to eyeball); the summary's `bound: N ledger, M pane-content` + `ledger reasons:` tally say why anything is unbound.
+- **`save`** (the script's verb for a snapshot) — run BEFORE rebooting: writes `~/.config/initiatives/restore-plan.json` + a readable `restore-cheatsheet.md` (survives reboot). Present the cheat-sheet. Each entry carries `bind_source` and the sheet prints it per line (`(ledger)` = certain, `(fuzzy)` = a content guess to eyeball); the summary's `bound: N ledger, M pane-content` + `ledger reasons:` tally say why anything is unbound.
 - **`restore`** — run AFTER reboot (once tmux-continuum has restored the shells): relaunches `claude --resume <id>` in each window; windows already running claude are skipped, and windows with no certain match fall back to the interactive picker. Use `--dry-run` first to preview.
 - **⚠ host-local:** run it on the host you're rebooting — it reads that host's live tmux + `~/.claude/projects`. The plan is per-host.
 

--- a/claude/skills/initiative-scan/SKILL.md
+++ b/claude/skills/initiative-scan/SKILL.md
@@ -56,12 +56,12 @@ skill instead. This skill is the ephemeral scan that feeds it.
 
 ## Session snapshot / restore (survive a reboot)
 
-If `$ARGUMENTS` is **`snapshot`** (or `save`), **`restore`** (optionally `restore --dry-run`), or **`show`**, run the workspace snapshot helper instead of the scan — it binds each live claude tmux window to its exact session id (by matching pane content) so you can bring the whole workspace back after a reboot. tmux-continuum already restores the sessions/windows/cwds; this relaunches the right `claude --resume <id>` in each.
+If `$ARGUMENTS` is **`snapshot`** (or `save`), **`restore`** (optionally `restore --dry-run`), or **`show`**, run the workspace snapshot helper instead of the scan — it binds each live claude tmux window to its exact session id (the per-pane agent ledger first — a RECORD; a pane-content grep only for what the ledger cannot answer — a GUESS) so you can bring the whole workspace back after a reboot. tmux-continuum already restores the sessions/windows/cwds; this relaunches the right `claude --resume <id>` in each.
 
 ```bash
 python3 ~/workspace/devrc/scripts/tmux-session-restore.py <snapshot|restore|show> [--dry-run]
 ```
-- **`snapshot`** — run BEFORE rebooting: writes `~/.config/initiatives/restore-plan.json` + a readable `restore-cheatsheet.md` (survives reboot). Present the cheat-sheet.
+- **`snapshot`** — run BEFORE rebooting: writes `~/.config/initiatives/restore-plan.json` + a readable `restore-cheatsheet.md` (survives reboot). Present the cheat-sheet. Each entry carries `bind_source` and the sheet prints it per line (`(ledger)` = certain, `(fuzzy)` = a content guess to eyeball); the summary's `bound: N ledger, M pane-content` + `ledger reasons:` tally say why anything is unbound.
 - **`restore`** — run AFTER reboot (once tmux-continuum has restored the shells): relaunches `claude --resume <id>` in each window; windows already running claude are skipped, and windows with no certain match fall back to the interactive picker. Use `--dry-run` first to preview.
 - **⚠ host-local:** run it on the host you're rebooting — it reads that host's live tmux + `~/.claude/projects`. The plan is per-host.
 

--- a/scripts/lib/agent_ledger.py
+++ b/scripts/lib/agent_ledger.py
@@ -135,10 +135,19 @@ LEDGER_DIR = os.path.join(HOME, LEDGER_SUBPATH)
 SENTINEL = "AGENT_LEDGER_V1"
 
 # fuzzyclaw reached 401 files, ~90% stale, because nothing ever pruned. `write_record`
-# does NOT prune; both writers call `prune` on their SESSION BOUNDARIES only, and a
-# prune sweeps the whole directory — so the ceiling is "records written in the last
-# week" rather than "records ever written", enforced by other sessions' boundaries
-# as much as by a record's own writer.
+# itself does NOT prune, and THE TWO WRITERS DO NOT AGREE ON WHEN THEY DO — say which,
+# because a claim about "the writers" is false of one of them either way:
+#   * writer 1, `scripts/claude-hooks/agent-ledger-hook.py`, prunes on SESSION
+#     BOUNDARIES only — `PRUNE_EVENTS` is `SessionStart`/`Stop`, a subset of the four
+#     events in `WRITE_EVENTS`;
+#   * writer 2, `scripts/opencode/plugin/ledger.js`, has NO session-boundary hook at
+#     all — its one hook is `tool.execute.after`, and it passes `--prune` on EVERY
+#     write it performs, throttled to at most once per session per `THROTTLE_MS` (30 s).
+#     That is deliberate: an opencode-only host fires zero `SessionStart`/`Stop`, so
+#     without it the ledger would grow unbounded. Do not "simplify" it away.
+# A prune sweeps the WHOLE directory whoever triggers it, so the ceiling is "records
+# written in the last week" rather than "records ever written" — enforced by OTHER
+# sessions' prunes as much as by a record's own writer.
 DEFAULT_MAX_AGE = 7 * 86400
 
 # A write costs a stat + a small atomic replace. `PostToolUse` fires on every tool
@@ -786,8 +795,8 @@ def main(argv=None) -> int:
                         "RELIABLE rather than cheap — see DEFAULT_TMUX_TIMEOUT_S."
                         % (DEFAULT_TMUX_TIMEOUT_S, TMUX_TIMEOUT_ENV))
     p.add_argument("--prune", action="store_true",
-                   help="also reap records past the retention window; the "
-                        "caller does this on a session boundary, not per call")
+                   help="also reap records past the retention window; when a "
+                        "caller passes it is CALLER-SPECIFIC — see DEFAULT_MAX_AGE")
     p.add_argument("--directory", default=LEDGER_DIR)
     args = p.parse_args(sys.argv[1:] if argv is None else list(argv))
     # 🔴 FAIL CLOSED on a junk budget rather than falling back to the default.

--- a/scripts/lib/agent_ledger.py
+++ b/scripts/lib/agent_ledger.py
@@ -134,9 +134,11 @@ LEDGER_DIR = os.path.join(HOME, LEDGER_SUBPATH)
 # indistinguishable from a host that did not answer.
 SENTINEL = "AGENT_LEDGER_V1"
 
-# fuzzyclaw reached 401 files, ~90% stale, because nothing ever pruned. Every write
-# prunes, so the ceiling is "records written in the last week" rather than "records
-# ever written".
+# fuzzyclaw reached 401 files, ~90% stale, because nothing ever pruned. `write_record`
+# does NOT prune; both writers call `prune` on their SESSION BOUNDARIES only, and a
+# prune sweeps the whole directory — so the ceiling is "records written in the last
+# week" rather than "records ever written", enforced by other sessions' boundaries
+# as much as by a record's own writer.
 DEFAULT_MAX_AGE = 7 * 86400
 
 # A write costs a stat + a small atomic replace. `PostToolUse` fires on every tool

--- a/scripts/session-analysis/tests/test_tmux_session_restore.py
+++ b/scripts/session-analysis/tests/test_tmux_session_restore.py
@@ -221,14 +221,81 @@ def test_a_ledger_module_without_pane_filename_loads_as_none(tmp_path):
         "`ledger_binding` will then raise AttributeError out of `cmd_save`")
 
 
+_USABLE_STUB = ("LEDGER_DIR = '/nonexistent-ledger'\n"
+                "def pane_filename(runtime, pane_id):\n"
+                "    return 'stub-%s-%s.json' % (runtime, pane_id)\n")
+
+
 def test_a_usable_ledger_module_still_loads(tmp_path):
-    """The positive control: the new guard must not reject a WORKING module."""
+    """The positive control: the guard must not reject a WORKING module.
+
+    Carries EVERY name in `_BORROWED`, so it is the case that proves the loader
+    still says yes — without it, a guard that rejected everything would look as
+    green as a correct one.
+    """
+    mod = _stub_ledger_module(tmp_path, _USABLE_STUB)
+    loaded = tsr._load_agent_ledger(mod)
+    assert loaded is not None, "the guard rejected a module that HAS every symbol"
+    assert loaded.pane_filename("claude", "%7") == "stub-claude-%7.json"
+
+
+def test_a_ledger_module_without_ledger_dir_loads_as_none(tmp_path):
+    """The MIRROR of the `pane_filename` case — `LEDGER_DIR` is borrowed too.
+
+    `pane_filename` is not "the one symbol this file borrows": the module-level
+    `LEDGER_DIR` comes from the same module, and a module carrying one name but
+    not the other is exactly as unusable as a module carrying neither.
+    """
     mod = _stub_ledger_module(
         tmp_path, "def pane_filename(runtime, pane_id):\n"
                   "    return 'stub-%s-%s.json' % (runtime, pane_id)\n")
-    loaded = tsr._load_agent_ledger(mod)
-    assert loaded is not None, "the guard rejected a module that HAS the symbol"
-    assert loaded.pane_filename("claude", "%7") == "stub-claude-%7.json"
+    assert tsr._load_agent_ledger(mod) is None, (
+        "a ledger module lacking `LEDGER_DIR` was returned as usable — this "
+        "reader then invents a directory the writer does not write to")
+
+
+def test_a_missing_ledger_dir_reports_the_deploy_token_not_no_record(tmp_path,
+                                                                     monkeypatch):
+    """🔴 THE POINT OF THE GUARD: a deploy break must not report as the benign case.
+
+    `cmd_save`'s legend reads `no-ledger-module` as a deploy problem and
+    `no-record` as "nothing to fix". If the reader accepted a module whose
+    directory contract it could not borrow, it would look in a directory of its
+    own invention, EVERY pane would answer `no-record`, and the tally would
+    announce a broken deploy with the one token that tells the operator to ignore
+    it. `LEDGER_DIR` is pointed at an empty scratch dir so the assertion measures
+    the guard rather than the state of the real ledger.
+    """
+    monkeypatch.setattr(
+        tsr, "_AL",
+        tsr._load_agent_ledger(_stub_ledger_module(
+            tmp_path, "def pane_filename(runtime, pane_id):\n"
+                      "    return 'stub-%s-%s.json' % (runtime, pane_id)\n")))
+    empty = tmp_path / "empty-ledger"
+    empty.mkdir()
+    monkeypatch.setattr(tsr, "LEDGER_DIR", empty)
+    got = tsr.ledger_binding("%7", CWD, SERVER_PID)
+    assert got == ("", "no-ledger-module"), (
+        f"a ledger module missing `LEDGER_DIR` reported {got[1]!r}; "
+        f"`no-record` is the token the legend calls 'nothing to fix', so a "
+        f"deploy break would be reported as the benign case")
+
+
+def test_borrowed_lists_every_symbol_this_file_reads_off_the_module():
+    """Two-way pin: `_BORROWED` == the attributes actually read off `_AL`.
+
+    An INVARIANT guard, not regression coverage — it fails when the set GROWS (a
+    third borrowed symbol added without listing it, which re-opens the exact hole
+    `LEDGER_DIR` was) or SHRINKS (a name listed that nothing reads). The check the
+    loader performs is only as wide as this tuple, so the tuple has to be checked
+    against the source rather than trusted.
+    """
+    import re
+    read = set(re.findall(r"\b_AL\.([A-Za-z_]\w*)", SCRIPT.read_text()))
+    assert read == set(tsr._BORROWED), (
+        f"`_BORROWED` is {sorted(tsr._BORROWED)} but this file reads "
+        f"{sorted(read)} off the ledger module — the loader guards only what "
+        f"`_BORROWED` names, so anything missing here loads unguarded")
 
 
 def test_a_ledger_module_missing_pane_filename_degrades_not_raises(tmp_path,

--- a/scripts/session-analysis/tests/test_tmux_session_restore.py
+++ b/scripts/session-analysis/tests/test_tmux_session_restore.py
@@ -1,12 +1,16 @@
 """Unit tests for tmux-session-restore PURE logic (no live tmux / claude / grep).
 
 Run:
-  nix-shell -p 'python3.withPackages(p:[p.pytest])' \
-      --run 'python -m pytest scripts/session-analysis/tests/test_tmux_session_restore.py -q'
+  nix develop ~/workspace/devrc -c python3 -m pytest \
+      scripts/session-analysis/tests/test_tmux_session_restore.py -q
 
 Covers: scratch-slot codename parsing, project-dir encoding, display naming, the
-claim-based unique-session assignment (no two windows share a session, uncertain ->
-picker), and cheat-sheet rendering. tmux/grep/capture-pane I/O is stubbed.
+per-pane LEDGER binding and each of its four validations, the ledger-before-grep
+ordering (both the "the grep never runs" performance claim and the "a guess cannot
+steal a certain id" correctness claim), the claim-based unique-session assignment
+(no two windows share a session, uncertain -> picker), and cheat-sheet rendering.
+tmux/grep/capture-pane I/O and the ledger directory are stubbed; nothing here reads
+the real `~/.cache/agent-ledger` or `~/.claude/projects`.
 """
 import importlib.util
 import json
@@ -14,11 +18,19 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 HERE = Path(__file__).resolve().parent
 SCRIPT = HERE.parent.parent / "tmux-session-restore.py"
 _spec = importlib.util.spec_from_file_location("tmux_session_restore", SCRIPT)
 tsr = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(tsr)
+
+# Synthetic ids — this repo is public, so no fixture ever carries a real one.
+SID_A = "11111111-2222-4333-8444-555555555555"
+SID_B = "66666666-7777-4888-8999-aaaaaaaaaaaa"
+SID_C = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff"
+SERVER_PID = "424242"
 
 
 # --------------------------------------------------------------------------- #
@@ -53,6 +65,119 @@ def test_project_dir_encoding(monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
+# live_claude_panes — the pane_id the ledger is keyed on must survive parsing
+# --------------------------------------------------------------------------- #
+def test_live_claude_panes_carries_pane_id_and_drops_non_claude(monkeypatch):
+    rows = "\n".join([
+        "%7\tscratch4\t2\t/w/repo\tclaude\tfaro work",
+        "%8\tscratch4\t3\t/w/repo\tzsh\tjust a shell",
+        "%9\t8\t1\t/w/other\tclaude\t",           # empty title still parses
+        "%10\t8\t2\t/w/other",                     # short row: ignored
+    ])
+    monkeypatch.setattr(tsr, "run", lambda cmd: rows)
+    panes = tsr.live_claude_panes()
+    assert [p["pane_id"] for p in panes] == ["%7", "%9"]
+    assert panes[0] == {"pane_id": "%7", "session": "scratch4", "window": "2",
+                        "cwd": "/w/repo", "title": "faro work"}
+    assert panes[1]["cwd"] == "/w/other" and panes[1]["title"] == ""
+
+
+# --------------------------------------------------------------------------- #
+# ledger_binding — the deterministic per-pane record and its four validations
+# --------------------------------------------------------------------------- #
+CWD = "/w/repo"
+OTHER_CWD = "/w/other-repo"
+
+
+def _ledger_world(tmp_path, monkeypatch, *, sid=SID_A, cwd=CWD,
+                  transcript_cwd=None, write_transcript=True,
+                  tmux_pid=SERVER_PID, pane="%7", record=True):
+    """A throwaway projects tree + ledger dir; returns (ledger_dir, transcript).
+
+    Every knob here is one of the validations, so a test flips exactly one field
+    and leaves the others in their valid state — that is what makes each guard
+    reachable by a case no EARLIER guard rejects.
+    """
+    projects = tmp_path / "projects"
+    monkeypatch.setattr(tsr, "PROJECTS", projects)
+    tdir = projects / (transcript_cwd or cwd).replace("/", "-")
+    tdir.mkdir(parents=True, exist_ok=True)
+    transcript = tdir / f"{sid or 'none'}.jsonl"
+    if write_transcript:
+        transcript.write_text("")
+    ledger = tmp_path / "agent-ledger"
+    ledger.mkdir(exist_ok=True)
+    if record:
+        (ledger / tsr._AL.pane_filename("claude", pane)).write_text(json.dumps({
+            "schema": 1, "runtime": "claude", "session_id": sid,
+            "last_activity_ts": "2026-09-04T23:47:01Z", "pane_id": pane,
+            "window_id": "@61", "tmux_pid": tmux_pid,
+            "transcript_path": str(transcript),
+        }) + "\n")
+    monkeypatch.setattr(tsr, "LEDGER_DIR", ledger)
+    return ledger, transcript
+
+
+def test_ledger_binding_accepts_a_valid_record(tmp_path, monkeypatch):
+    _ledger_world(tmp_path, monkeypatch)
+    assert tsr.ledger_binding("%7", CWD, SERVER_PID) == (SID_A, "ok")
+
+
+def test_ledger_binding_rejects_a_missing_record_file(tmp_path, monkeypatch):
+    _ledger_world(tmp_path, monkeypatch, record=False)
+    assert tsr.ledger_binding("%7", CWD, SERVER_PID) == ("", "no-record")
+
+
+def test_ledger_binding_rejects_an_unparseable_record(tmp_path, monkeypatch):
+    ledger, _ = _ledger_world(tmp_path, monkeypatch)
+    (ledger / "claude-p7.json").write_text("{not json\n")
+    assert tsr.ledger_binding("%7", CWD, SERVER_PID) == ("", "no-record")
+
+
+def test_ledger_binding_rejects_an_empty_session_id(tmp_path, monkeypatch):
+    # Everything else is valid, so this guard is the ONLY thing that can reject.
+    _ledger_world(tmp_path, monkeypatch, sid="")
+    assert tsr.ledger_binding("%7", CWD, SERVER_PID) == ("", "no-session-id")
+
+
+def test_ledger_binding_rejects_an_absent_transcript(tmp_path, monkeypatch):
+    # The path is spelled correctly (right project dir) — only the FILE is gone,
+    # so deleting this guard would make the record read `ok`, not another reason.
+    _ledger_world(tmp_path, monkeypatch, write_transcript=False)
+    assert tsr.ledger_binding("%7", CWD, SERVER_PID) == ("", "transcript-missing")
+
+
+def test_ledger_binding_rejects_a_different_tmux_generation(tmp_path, monkeypatch):
+    _ledger_world(tmp_path, monkeypatch, tmux_pid="999999")
+    assert tsr.ledger_binding("%7", CWD, SERVER_PID) == ("", "generation-mismatch")
+
+
+def test_ledger_binding_rejects_an_unmeasured_generation(tmp_path, monkeypatch):
+    """Unable to check a generation is NOT the same as having checked it."""
+    _ledger_world(tmp_path, monkeypatch)
+    assert tsr.ledger_binding("%7", CWD, "") == ("", "generation-unmeasured")
+    _ledger_world(tmp_path, monkeypatch, tmux_pid="")
+    assert tsr.ledger_binding("%7", CWD, SERVER_PID) == ("", "generation-unmeasured")
+
+
+def test_ledger_binding_rejects_a_transcript_from_another_repo(tmp_path, monkeypatch):
+    """🔴 The cross-repo mis-bind guard: right pane, right generation, WRONG repo.
+
+    The record is valid in every other respect — a live session id, a transcript
+    that exists on disk, this server's pid — so nothing upstream rejects it. Only
+    the encoded-cwd comparison stands between this pane and resuming another
+    repo's conversation in a window that looks correct.
+    """
+    _ledger_world(tmp_path, monkeypatch, transcript_cwd=OTHER_CWD)
+    assert tsr.ledger_binding("%7", CWD, SERVER_PID) == ("", "project-mismatch")
+
+
+def test_ledger_binding_needs_a_pane_id(tmp_path, monkeypatch):
+    _ledger_world(tmp_path, monkeypatch)
+    assert tsr.ledger_binding("", CWD, SERVER_PID) == ("", "no-pane-id")
+
+
+# --------------------------------------------------------------------------- #
 # build_plan — claim-based unique assignment
 # --------------------------------------------------------------------------- #
 def _panes():
@@ -63,10 +188,118 @@ def _panes():
     ]
 
 
+def _no_grep(target, cwd):
+    raise AssertionError(
+        "unique_match_sids was called for a ledger-bound pane — the whole point "
+        "of the ledger is that the 145-transcript grep never runs for it")
+
+
+def _plan_env(monkeypatch, panes, matcher, server_pid=SERVER_PID):
+    monkeypatch.setattr(tsr, "live_claude_panes", lambda: panes)
+    monkeypatch.setattr(tsr, "codenames", lambda: {"scratch4": "Vapor"})
+    monkeypatch.setattr(tsr, "first_user_line", lambda sid, cwd: "")
+    monkeypatch.setattr(tsr, "tmux_server_pid", lambda: server_pid)
+    monkeypatch.setattr(tsr, "unique_match_sids", matcher)
+
+
+def test_build_plan_binds_from_the_ledger_without_ever_grepping(tmp_path, monkeypatch):
+    """The performance claim, pinned behaviourally rather than asserted in prose."""
+    _ledger_world(tmp_path, monkeypatch)
+    _plan_env(monkeypatch,
+              [{"pane_id": "%7", "session": "scratch4", "window": "2",
+                "cwd": CWD, "title": "faro"}],
+              _no_grep)
+    plan = tsr.build_plan()
+    assert plan[0]["session_id"] == SID_A
+    assert plan[0]["bind_source"] == "ledger"
+
+
+@pytest.mark.parametrize("kw", [
+    {"record": False},                   # no record file
+    {"sid": ""},                         # empty session_id
+    {"write_transcript": False},         # transcript gone
+    {"tmux_pid": "999999"},              # different tmux server generation
+    {"transcript_cwd": OTHER_CWD},       # another repo's project dir
+])
+def test_each_rejected_record_falls_back_to_the_grep(tmp_path, monkeypatch, kw):
+    """Every validation failure independently hands the pane to the fallback."""
+    _ledger_world(tmp_path, monkeypatch, **kw)
+    _plan_env(monkeypatch,
+              [{"pane_id": "%7", "session": "scratch4", "window": "2",
+                "cwd": CWD, "title": "faro"}],
+              lambda target, cwd: [SID_B])
+    plan = tsr.build_plan()
+    assert plan[0]["session_id"] == SID_B
+    assert plan[0]["bind_source"] == "fuzzy"
+
+
+def test_ledger_wins_a_conflict_with_the_grep(tmp_path, monkeypatch):
+    """Same pane, two answers: the RECORD beats the INFERENCE (which never runs)."""
+    _ledger_world(tmp_path, monkeypatch)
+    _plan_env(monkeypatch,
+              [{"pane_id": "%7", "session": "scratch4", "window": "2",
+                "cwd": CWD, "title": "faro"}],
+              lambda target, cwd: [SID_B])   # the grep would say something else
+    plan = tsr.build_plan()
+    assert plan[0]["session_id"] == SID_A and plan[0]["bind_source"] == "ledger"
+
+
+def test_a_guess_cannot_steal_a_session_the_ledger_owns(tmp_path, monkeypatch):
+    """The mixed case: ledger pane and fuzzy pane both want SID_A.
+
+    Pane %7 has a record for SID_A. Pane %8 has none, and its top content match is
+    also SID_A. Ledger claims first, so %8 falls to its second candidate rather
+    than resuming %7's conversation.
+    """
+    _ledger_world(tmp_path, monkeypatch)
+    _plan_env(monkeypatch,
+              [{"pane_id": "%8", "session": "8", "window": "1",
+                "cwd": CWD, "title": "wedge"},         # listed FIRST on purpose
+               {"pane_id": "%7", "session": "scratch4", "window": "2",
+                "cwd": CWD, "title": "faro"}],
+              lambda target, cwd: [SID_A, SID_C])
+    plan = tsr.build_plan()
+    by_win = {(e["codename"], e["window"]): e for e in plan}
+    assert by_win[("Vapor", "2")]["session_id"] == SID_A
+    assert by_win[("Vapor", "2")]["bind_source"] == "ledger"
+    assert by_win[("main:8", "1")]["session_id"] == SID_C
+    assert by_win[("main:8", "1")]["bind_source"] == "fuzzy"
+    sids = [e["session_id"] for e in plan]
+    assert len(sids) == len(set(sids))    # never the same conversation twice
+
+
+def test_two_panes_cannot_share_one_ledger_session(tmp_path, monkeypatch):
+    """Two ledger records naming one session: one binds, the other falls back."""
+    ledger, transcript = _ledger_world(tmp_path, monkeypatch)
+    (ledger / tsr._AL.pane_filename("claude", "%8")).write_text(
+        (ledger / "claude-p7.json").read_text())   # same session_id, other pane
+    _plan_env(monkeypatch,
+              [{"pane_id": "%7", "session": "scratch4", "window": "2",
+                "cwd": CWD, "title": "faro"},
+               {"pane_id": "%8", "session": "8", "window": "1",
+                "cwd": CWD, "title": "wedge"}],
+              lambda target, cwd: [])
+    plan = tsr.build_plan()
+    sids = [e["session_id"] for e in plan if e["session_id"]]
+    assert sids == [SID_A]
+    assert [e["session_id"] for e in plan if not e["session_id"]] == [""]
+
+
+def test_neither_source_yields_the_picker_not_a_guess(tmp_path, monkeypatch):
+    _ledger_world(tmp_path, monkeypatch, record=False)
+    _plan_env(monkeypatch,
+              [{"pane_id": "%7", "session": "scratch4", "window": "2",
+                "cwd": CWD, "title": "faro"}],
+              lambda target, cwd: [])
+    plan = tsr.build_plan()
+    assert plan[0]["session_id"] == "" and plan[0]["bind_source"] == ""
+
+
 def test_build_plan_assigns_unique_sessions(monkeypatch):
     monkeypatch.setattr(tsr, "live_claude_panes", _panes)
     monkeypatch.setattr(tsr, "codenames", lambda: {"scratch4": "Vapor"})
     monkeypatch.setattr(tsr, "first_user_line", lambda sid, cwd: "")
+    monkeypatch.setattr(tsr, "tmux_server_pid", lambda: SERVER_PID)
     # Each pane content-matches its own distinct session.
     cand = {"8:1": ["sidA"], "8:3": ["sidB"], "scratch4:2": ["sidC"]}
     monkeypatch.setattr(tsr, "unique_match_sids", lambda target, cwd: cand[target])
@@ -85,6 +318,7 @@ def test_build_plan_never_double_assigns_a_session(monkeypatch):
     monkeypatch.setattr(tsr, "live_claude_panes", _panes)
     monkeypatch.setattr(tsr, "codenames", lambda: {"scratch4": "Vapor"})
     monkeypatch.setattr(tsr, "first_user_line", lambda sid, cwd: "")
+    monkeypatch.setattr(tsr, "tmux_server_pid", lambda: SERVER_PID)
     cand = {"8:1": ["dup"], "8:3": ["dup"], "scratch4:2": ["dup", "own"]}
     monkeypatch.setattr(tsr, "unique_match_sids", lambda target, cwd: cand[target])
 
@@ -101,6 +335,7 @@ def test_build_plan_empty_when_no_match(monkeypatch):
                         lambda: [{"session": "8", "window": "1", "cwd": "/r", "title": "x"}])
     monkeypatch.setattr(tsr, "codenames", lambda: {})
     monkeypatch.setattr(tsr, "first_user_line", lambda sid, cwd: "")
+    monkeypatch.setattr(tsr, "tmux_server_pid", lambda: SERVER_PID)
     monkeypatch.setattr(tsr, "unique_match_sids", lambda target, cwd: [])
     plan = tsr.build_plan()
     assert plan[0]["session_id"] == ""            # uncertain -> picker at restore

--- a/scripts/session-analysis/tests/test_tmux_session_restore.py
+++ b/scripts/session-analysis/tests/test_tmux_session_restore.py
@@ -289,9 +289,34 @@ def test_borrowed_lists_every_symbol_this_file_reads_off_the_module():
     `LEDGER_DIR` was) or SHRINKS (a name listed that nothing reads). The check the
     loader performs is only as wide as this tuple, so the tuple has to be checked
     against the source rather than trusted.
+
+    🔴 READ THE AST, NOT THE TEXT — and the reason is this guard's own history.
+    The first version matched `\\b_AL\\.(\\w+)`, which sees `_AL.LEDGER_DIR` but is
+    BLIND to `getattr(_AL, "LEDGER_DIR", <default>)`. That is not a hypothetical
+    spelling: it is exactly how `LEDGER_DIR` was written at `2eb06a6d`, i.e. the
+    guard could not see the very hole it was introduced to close, while its
+    docstring claimed it could. Measured: a mutant borrowing a third symbol via
+    `getattr` SURVIVED a fully green run. Both spellings are collected here, so
+    the tuple is pinned against what the module actually reads. A comment merely
+    MENTIONING `_AL.SOMETHING` is also no longer counted — the text scan flagged
+    prose as a borrow.
     """
-    import re
-    read = set(re.findall(r"\b_AL\.([A-Za-z_]\w*)", SCRIPT.read_text()))
+    import ast
+
+    read: set[str] = set()
+    for node in ast.walk(ast.parse(SCRIPT.read_text())):
+        # `_AL.NAME`
+        if (isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Name) and node.value.id == "_AL"):
+            read.add(node.attr)
+        # `getattr(_AL, "NAME"[, default])`
+        elif (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name) and node.func.id == "getattr"
+                and len(node.args) >= 2
+                and isinstance(node.args[0], ast.Name) and node.args[0].id == "_AL"
+                and isinstance(node.args[1], ast.Constant)
+                and isinstance(node.args[1].value, str)):
+            read.add(node.args[1].value)
     assert read == set(tsr._BORROWED), (
         f"`_BORROWED` is {sorted(tsr._BORROWED)} but this file reads "
         f"{sorted(read)} off the ledger module — the loader guards only what "

--- a/scripts/session-analysis/tests/test_tmux_session_restore.py
+++ b/scripts/session-analysis/tests/test_tmux_session_restore.py
@@ -8,9 +8,12 @@ Covers: scratch-slot codename parsing, project-dir encoding, display naming, the
 per-pane LEDGER binding and each of its four validations, the ledger-before-grep
 ordering (both the "the grep never runs" performance claim and the "a guess cannot
 steal a certain id" correctness claim), the claim-based unique-session assignment
-(no two windows share a session, uncertain -> picker), and cheat-sheet rendering.
+(no two windows share a session, uncertain -> picker), cheat-sheet rendering and
+its per-entry source badge, the loader's "an unusable module degrades to None"
+promise, and `cmd_save`'s two summary lines.
 tmux/grep/capture-pane I/O and the ledger directory are stubbed; nothing here reads
-the real `~/.cache/agent-ledger` or `~/.claude/projects`.
+or writes the real `~/.cache/agent-ledger`, `~/.claude/projects` or
+`~/.config/initiatives/restore-plan.json`.
 """
 import importlib.util
 import json
@@ -130,7 +133,7 @@ def test_ledger_binding_rejects_a_missing_record_file(tmp_path, monkeypatch):
 
 def test_ledger_binding_rejects_an_unparseable_record(tmp_path, monkeypatch):
     ledger, _ = _ledger_world(tmp_path, monkeypatch)
-    (ledger / "claude-p7.json").write_text("{not json\n")
+    (ledger / tsr._AL.pane_filename("claude", "%7")).write_text("{not json\n")
     assert tsr.ledger_binding("%7", CWD, SERVER_PID) == ("", "no-record")
 
 
@@ -175,6 +178,76 @@ def test_ledger_binding_rejects_a_transcript_from_another_repo(tmp_path, monkeyp
 def test_ledger_binding_needs_a_pane_id(tmp_path, monkeypatch):
     _ledger_world(tmp_path, monkeypatch)
     assert tsr.ledger_binding("", CWD, SERVER_PID) == ("", "no-pane-id")
+
+
+def test_ledger_binding_rejects_a_record_that_is_not_an_object(tmp_path, monkeypatch):
+    """A JSON ARRAY parses fine and has no `.get` — only `isinstance` stops it.
+
+    Reachable past every earlier check: the file exists and line 1 is well-formed
+    JSON, so `no-record`'s parse arm cannot fire. Without the type guard this is
+    an `AttributeError` propagating out of `cmd_save`, not a fallback to the grep.
+    """
+    _ledger, transcript = _ledger_world(tmp_path, monkeypatch)
+    (_ledger / tsr._AL.pane_filename("claude", "%7")).write_text(json.dumps(
+        [{"schema": 1, "runtime": "claude", "session_id": SID_A,
+          "tmux_pid": SERVER_PID, "transcript_path": str(transcript)}]) + "\n")
+    try:
+        got = tsr.ledger_binding("%7", CWD, SERVER_PID)
+    except Exception as exc:      # noqa: BLE001 — this IS the failure under test
+        pytest.fail(f"a non-object ledger record raised {exc!r} instead of "
+                    f"returning ('', 'no-record') — the isinstance guard is gone")
+    assert got == ("", "no-record")
+
+
+# --------------------------------------------------------------------------- #
+# the loader's "no fallback spelling" promise — including a module that IMPORTS
+# --------------------------------------------------------------------------- #
+def _stub_ledger_module(tmp_path, body: str) -> Path:
+    p = tmp_path / "stub_agent_ledger.py"
+    p.write_text(body)
+    return p
+
+
+def test_a_ledger_module_without_pane_filename_loads_as_none(tmp_path):
+    """`None` is the promise, not "imported and half-usable".
+
+    This reader borrows exactly one symbol. A module that imports cleanly while
+    lacking it is the SAME case as an absent file, and the loader must say so —
+    otherwise the `_AL is None` arm in `ledger_binding` never runs.
+    """
+    mod = _stub_ledger_module(tmp_path, "LEDGER_DIR = '/nonexistent'\n")
+    assert tsr._load_agent_ledger(mod) is None, (
+        "a ledger module lacking `pane_filename` was returned as usable — "
+        "`ledger_binding` will then raise AttributeError out of `cmd_save`")
+
+
+def test_a_usable_ledger_module_still_loads(tmp_path):
+    """The positive control: the new guard must not reject a WORKING module."""
+    mod = _stub_ledger_module(
+        tmp_path, "def pane_filename(runtime, pane_id):\n"
+                  "    return 'stub-%s-%s.json' % (runtime, pane_id)\n")
+    loaded = tsr._load_agent_ledger(mod)
+    assert loaded is not None, "the guard rejected a module that HAS the symbol"
+    assert loaded.pane_filename("claude", "%7") == "stub-claude-%7.json"
+
+
+def test_a_ledger_module_missing_pane_filename_degrades_not_raises(tmp_path,
+                                                                   monkeypatch):
+    """🔴 `cmd_save` runs unattended every ~15 min from `tmux-post-save.sh` into a
+    log nobody reads. A traceback here freezes the restore plan silently, which is
+    the exact "snapshot nothing refreshes" failure this tool has already had
+    twice — so an unusable module must produce `no-ledger-module`, never an
+    exception.
+    """
+    monkeypatch.setattr(
+        tsr, "_AL",
+        tsr._load_agent_ledger(_stub_ledger_module(tmp_path, "SCHEMA = 1\n")))
+    try:
+        got = tsr.ledger_binding("%7", CWD, SERVER_PID)
+    except Exception as exc:      # noqa: BLE001 — this IS the failure under test
+        pytest.fail(f"ledger_binding raised {exc!r} for a ledger module missing "
+                    f"`pane_filename`; it must degrade to ('', 'no-ledger-module')")
+    assert got == ("", "no-ledger-module")
 
 
 # --------------------------------------------------------------------------- #
@@ -272,7 +345,7 @@ def test_two_panes_cannot_share_one_ledger_session(tmp_path, monkeypatch):
     """Two ledger records naming one session: one binds, the other falls back."""
     ledger, transcript = _ledger_world(tmp_path, monkeypatch)
     (ledger / tsr._AL.pane_filename("claude", "%8")).write_text(
-        (ledger / "claude-p7.json").read_text())   # same session_id, other pane
+        (ledger / tsr._AL.pane_filename("claude", "%7")).read_text())   # same session_id, other pane
     _plan_env(monkeypatch,
               [{"pane_id": "%7", "session": "scratch4", "window": "2",
                 "cwd": CWD, "title": "faro"},
@@ -293,6 +366,26 @@ def test_neither_source_yields_the_picker_not_a_guess(tmp_path, monkeypatch):
               lambda target, cwd: [])
     plan = tsr.build_plan()
     assert plan[0]["session_id"] == "" and plan[0]["bind_source"] == ""
+
+
+def test_build_plan_records_the_ledger_reason_for_every_pane(tmp_path, monkeypatch):
+    """The reason tokens must LEAVE `build_plan`.
+
+    They justify themselves as the distinction between `no-ledger-module` (a
+    deploy problem), `generation-mismatch` (the server restarted) and `no-record`
+    (nothing to fix) — and `cmd_save` can only print what the plan carries. Two
+    panes with DIFFERENT outcomes, so a constant would not satisfy this.
+    """
+    _ledger_world(tmp_path, monkeypatch)          # a valid record for %7 only
+    _plan_env(monkeypatch,
+              [{"pane_id": "%7", "session": "scratch4", "window": "2",
+                "cwd": CWD, "title": "faro"},
+               {"pane_id": "%9", "session": "8", "window": "1",
+                "cwd": CWD, "title": "wedge"}],
+              lambda target, cwd: [])
+    by_win = {e["window"]: e for e in tsr.build_plan()}
+    assert by_win["2"].get("ledger_reason") == "ok"
+    assert by_win["1"].get("ledger_reason") == "no-record"
 
 
 def test_build_plan_assigns_unique_sessions(monkeypatch):
@@ -355,6 +448,84 @@ def test_cheat_sheet_shows_resume_command_and_picker_fallback():
     assert "claude --resume abc" in txt
     assert "Vapor:2" in txt and "main:8:1" in txt
     assert "pick from the list" in txt           # empty id -> picker guidance
+
+
+def test_cheat_sheet_labels_each_binding_with_its_own_source():
+    """The badge must follow the entry, not a single default for the whole sheet."""
+    txt = tsr.cheat_sheet([
+        {"codename": "Vapor", "window": "2", "cwd": "/r", "session_id": SID_A,
+         "bind_source": "ledger", "title": "t", "hint": ""},
+        {"codename": "main:8", "window": "1", "cwd": "/r", "session_id": SID_B,
+         "bind_source": "fuzzy", "title": "u", "hint": ""},
+    ])
+    assert f"claude --resume {SID_A}`  (ledger)" in txt
+    assert f"claude --resume {SID_B}`  (fuzzy)" in txt
+
+
+def test_cheat_sheet_labels_an_unrecorded_source_as_a_guess():
+    """🔴 A plan with NO `bind_source` is a PRE-LEDGER plan — every id in one came
+    from the pane-content grep, so the default has to be `fuzzy`.
+
+    Labelling it `(ledger)` would stamp this PR's certainty badge on exactly the
+    guesses the PR exists to distinguish, and the sheet is what an operator
+    eyeballs before letting `restore` resume 40 conversations. No field in the
+    fixture spells either label, so the rendered word can only come from the
+    default.
+    """
+    txt = tsr.cheat_sheet([{"codename": "Vapor", "window": "2", "cwd": "/r",
+                            "session_id": SID_A, "title": "t", "hint": ""}])
+    assert f"claude --resume {SID_A}`  (fuzzy)" in txt, (
+        "an entry with no recorded bind_source did not render as a guess")
+    assert "(ledger)" not in txt, (
+        "an entry with no recorded bind_source rendered as `(ledger)` — a guess "
+        "must never inherit the ledger's certainty")
+
+
+# --------------------------------------------------------------------------- #
+# cmd_save — the operator-facing summary
+# --------------------------------------------------------------------------- #
+def test_cmd_save_summary_counts_sources_and_ledger_reasons(tmp_path, monkeypatch,
+                                                            capsys):
+    """Both summary lines, on a plan whose three source counts are DISTINCT.
+
+    🔴 Distinctness is the point: at 1/1/1 a summary that counted `fuzzy` as
+    `ledger` would print exactly the correct line and survive. The reason tally is
+    what makes `0 ledger` actionable — `no-ledger-module` and
+    `generation-mismatch` are operator problems, `no-record` is not.
+
+    🔴 Every path is under `tmp_path`; this never touches the real
+    `~/.config/initiatives/restore-plan.json`.
+    """
+    state = tmp_path / "state"
+    monkeypatch.setattr(tsr, "STATE_DIR", state)
+    monkeypatch.setattr(tsr, "PLAN", state / "restore-plan.json")
+    monkeypatch.setattr(tsr, "CHEAT", state / "restore-cheatsheet.md")
+
+    def entry(win, sid, source, reason):
+        return {"session": "8", "window": str(win), "codename": "main:8",
+                "cwd": "/r", "session_id": sid, "bind_source": source,
+                "ledger_reason": reason, "title": f"w{win}", "hint": ""}
+
+    monkeypatch.setattr(tsr, "build_plan", lambda: [
+        entry(1, SID_A, "ledger", "ok"),
+        entry(2, SID_B, "ledger", "ok"),
+        entry(3, SID_C, "fuzzy", "no-record"),
+        entry(4, "", "", "no-record"),
+        entry(5, "", "", "generation-mismatch"),
+        entry(6, "", "", "project-mismatch"),
+    ])
+    rc = tsr.cmd_save()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "bound: 2 ledger, 1 pane-content, 3 unbound" in out, (
+        "the per-source counts do not match the plan — a source is being "
+        "counted under the wrong label")
+    assert ("ledger reasons: generation-mismatch=1, no-record=2, ok=2, "
+            "project-mismatch=1") in out, (
+        "the reason tally is missing or reshaped — `0 ledger` is then "
+        "indistinguishable between a missing module, a restarted server and "
+        "simply no records")
+    assert (state / "restore-plan.json").exists()
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tmux-session-restore.py
+++ b/scripts/tmux-session-restore.py
@@ -57,6 +57,15 @@ _SLOT_RE = re.compile(r'"([^":]+):([^":]+):(#[0-9a-fA-F]{6}):([^":]+)"')
 _ANSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
 
 
+# 🔴 EVERY symbol this file reads off the ledger module — a tuple, not one name,
+# because the half-borrow is the hazard. Both of these are the WRITER's rules (the
+# file key and the directory it writes into), so restating either here is the
+# duplicated predicate that makes this reader look somewhere nobody writes. Add a
+# name the moment this file reads a new attribute off `_AL`; a test pins this
+# tuple two-way against the source, because the loader guards only what it names.
+_BORROWED = ("pane_filename", "LEDGER_DIR")
+
+
 def _load_agent_ledger(path: Path | None = None):
     """`scripts/lib/agent_ledger.py`, imported by path — or None if unusable.
 
@@ -64,20 +73,27 @@ def _load_agent_ledger(path: Path | None = None):
     `tmux-post-save.sh` and by the `tmux-session-restore` user unit), so there is
     no package to import from; the ledger hook reaches its own copy the same way.
 
-    🔴 We borrow `pane_filename` rather than restating it. The file key is the
-    WRITER's rule, and a second spelling of it here is the duplicated predicate
-    that ends up making this reader look at a filename nobody writes. If the
-    module cannot be USED there is deliberately NO fallback spelling — the ledger
-    simply reports nothing and every pane falls through to the grep.
+    🔴 We borrow `_BORROWED` rather than restating any of it. If the module cannot
+    be USED there is deliberately NO fallback spelling — the ledger simply reports
+    nothing and every pane falls through to the grep.
 
-    🔴 "Cannot be used" is TWO cases, and the `hasattr` check is what makes the
+    🔴 "Cannot be used" is TWO cases, and the `_BORROWED` check is what makes the
     promise true for the second. An absent or syntactically broken file raises on
-    import and is caught; a module that imports fine while lacking the one symbol
-    this file borrows would be returned as usable, and the unguarded
-    `_AL.pane_filename(...)` in `ledger_binding` would then raise out of
-    `build_plan` and kill `cmd_save` — which runs unattended every ~15 min from
-    `tmux-post-save.sh` into a log nobody reads, silently freezing the restore
-    plan. Degrading is the whole point; half-degrading is worse than not trying.
+    import and is caught; a module that imports fine while lacking a borrowed
+    symbol would be returned as usable. The two names then fail DIFFERENTLY, and
+    the quieter failure is the one that made this check a tuple:
+
+      * without `pane_filename`, the unguarded `_AL.pane_filename(...)` in
+        `ledger_binding` raises out of `build_plan` and kills `cmd_save` — which
+        runs unattended every ~15 min from `tmux-post-save.sh` into a log nobody
+        reads, silently freezing the restore plan. Loud, once you read the log.
+      * without `LEDGER_DIR`, NOTHING raises. This reader would look in a
+        directory of its own invention, every pane would answer `no-record`, and
+        the `cmd_save` tally would announce a broken deploy using the one token
+        its own legend calls "nothing to fix". Rejecting the module instead makes
+        the tally say `no-ledger-module`, which is a token an operator acts on.
+
+    Degrading is the whole point; half-degrading is worse than not trying.
 
     `path` exists so a test can hand this loader a deliberately-broken module;
     production always takes the default.
@@ -90,14 +106,16 @@ def _load_agent_ledger(path: Path | None = None):
         spec.loader.exec_module(mod)
     except Exception:  # noqa: BLE001 — absent/broken lib: fall back to the grep
         return None
-    if not hasattr(mod, "pane_filename"):
+    if any(not hasattr(mod, sym) for sym in _BORROWED):
         return None
     return mod
 
 
 _AL = _load_agent_ledger()
-LEDGER_DIR = Path(getattr(_AL, "LEDGER_DIR",
-                          os.path.expanduser("~/.cache/agent-ledger")))
+# No `or "<literal>"` default here, deliberately: see `_BORROWED`. `_AL` is None
+# in exactly the cases where the directory cannot be borrowed, and `ledger_binding`
+# returns `no-ledger-module` before it ever reads this.
+LEDGER_DIR = Path(_AL.LEDGER_DIR) if _AL is not None else None
 
 
 def run(cmd: list[str]) -> str:
@@ -154,16 +172,19 @@ def ledger_binding(pane_id: str, cwd: str, server_pid: str,
         `%0` when the SERVER does, so yesterday's `%61` record and today's `%61`
         pane collide after exactly the reboot this tool exists for. `tmux_pid` is
         the server pid, constant across a server's windows, so equality rejects
-        every record written by a server that is not the one answering now.
-        ⚠ That is NOT the same as an exact generation check, and the gap sits in
-        the very event this guard exists for: pids are reused, a reboot resets the
-        counter, and both servers are started at login. MEASURED 2026-09-04 on the
-        workbench: live server pid `4025325` against `pid_max` `4194304` — i.e.
-        near the wrap, so the next boot's server draws a LOW pid, and so did the
-        previous boot's. A collision is unlikely, not astronomical, and a colliding
-        record for the same pane id in the same cwd would pass all four checks.
-        Closing it needs a value the WRITER does not record today (a boot id, or
-        the server's `/proc` start time), so the residual is ACCEPTED, not covered.
+        every record whose recorded pid differs from the live one — which is every
+        record EXCEPT those from a server that drew this same pid.
+        ⚠ That exception is the gap, and it sits in the very event this guard
+        exists for: pids are reused, and a restart resets the pane counter, so a
+        record left by a PREVIOUS server that happened to draw today's pid would
+        pass all four checks and resume the wrong conversation in a window that
+        looks right. How likely that is, is UNMEASURED — and the datum nearest to
+        hand does not answer it. (MEASURED 2026-09-04 on the workbench: the live
+        server's pid was `4025325` of a `pid_max` of `4194304`, but that server
+        started 21.2h AFTER boot, so its pid says nothing about what a server
+        started at login draws.) Closing the gap needs a value the WRITER does not
+        record today (a boot id, or the server's `/proc` start time), so the
+        residual is ACCEPTED — accepted without a rate, not shown to be small.
         🔴 An UNMEASURED live pid rejects too: being unable to check a generation
         is not the same as having checked it.
       * `project-mismatch` — 🔴 THE CROSS-REPO GUARD. The transcript's parent
@@ -182,8 +203,12 @@ def ledger_binding(pane_id: str, cwd: str, server_pid: str,
 
     🔴 But the WRITE side already applies one, so `no-record` has a permanent
     FLOOR rather than shrinking to nothing: `agent_ledger.DEFAULT_MAX_AGE` is 7
-    days and every write prunes, so a live pane idle longer than that has no
-    record at all and reports `no-record` forever. Prune keeps re-opening that set
+    days. `write_record` itself does NOT prune — both writers prune on their
+    SESSION BOUNDARIES only (`agent-ledger-hook.py`'s `PRUNE_EVENTS` is
+    `SessionStart`/`Stop`, a subset of the four events that write) — but a prune
+    sweeps the WHOLE directory, so it is OTHER sessions' boundaries that delete an
+    idle pane's record. Either way a live pane idle longer than that ends up with
+    no record at all and reports `no-record` forever. Prune keeps re-opening that set
     for exactly the long-idle windows a read-side age gate would also have thrown
     away — which is why the argument above still holds, and why "the unbound set
     shrinks on its own" is true only of the panes that predate the hook.
@@ -410,6 +435,16 @@ def cmd_save() -> int:
     # The counts above cannot tell `0 ledger` apart between a missing module, a
     # restarted server and simply no records — and the first two are what an
     # operator would act on. Sorted by token so the line's shape is stable.
+    #
+    # `unrecorded` is UNREACHABLE today and stays on purpose: `build_plan` assigns
+    # every index and `cmd_save` always builds the plan rather than reading one off
+    # disk, so a mutant deleting this default survives. Keeping it costs one `or`
+    # and buys the right failure shape — this runs unattended every ~15 min into a
+    # log nobody reads, so a future refactor that stops assigning reasons must
+    # degrade to a token that is VISIBLY none of `ledger_binding`'s own
+    # (`unrecorded=44` reads as broken) rather than raise a KeyError that freezes
+    # the restore plan, or print `None=44`. The same argument covers
+    # `reasons.get(i, "")` in `build_plan`.
     tally = Counter(e.get("ledger_reason") or "unrecorded" for e in plan)
     print("ledger reasons: "
           + ", ".join(f"{tok}={n}" for tok, n in sorted(tally.items())))

--- a/scripts/tmux-session-restore.py
+++ b/scripts/tmux-session-restore.py
@@ -6,11 +6,22 @@ scratchpad session's windows + working dirs on reboot — but it relaunches a ba
 NOT the `claude` conversation that was in each window. This captures which claude session
 was where and, after reboot, relaunches `claude --resume <id>` in the right window.
 
-Binding a window to its EXACT session id is inherently fuzzy (claude appends-and-closes
-its jsonl, holding no fd; the session summary isn't stored) — so per repo we rank the
-session jsonls by recency and assign the newest ones (the live conversations) to that
-repo's live windows, in window order. The cheat-sheet prints each guess with its summary
-line so you can eyeball / correct before running restore.
+Binding a window to its EXACT session id has TWO sources, and they are not equals:
+
+  1. THE LEDGER (`~/.cache/agent-ledger/claude-p<N>.json`) — a RECORD. Claude Code's
+     `agent-ledger-hook.py` is handed the real `session_id` and `transcript_path` by
+     the harness and keys the file on its own `$TMUX_PANE`, so a validated record is
+     ground truth for that pane: one O(1) file read.
+  2. PANE-CONTENT MATCHING (`unique_match_sids`) — an INFERENCE, and the fallback.
+     It greps a pane's on-screen text across every transcript in that cwd's project
+     dir. Measured on the workbench 2026-09-04: 145 competing transcripts in one
+     project dir, and a 50-window `save` spent essentially all of its 2m15s in that
+     grep while still leaving ~10 of 44 live claude panes unbound.
+
+So the ledger is consulted FIRST and CLAIMS FIRST — a certain binding must never lose
+a session id to a guess — and the grep runs only for panes the ledger cannot answer.
+The cheat-sheet prints each binding with its source and summary line so you can
+eyeball / correct before running restore.
 
 Usage:
   tmux-session-restore.py save      # BEFORE reboot — writes the plan + cheat-sheet
@@ -27,6 +38,7 @@ Scratchpad codenames come from the canonical scripts/tmux-scratch-slots.sh.
 """
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import re
@@ -41,6 +53,34 @@ PROJECTS = Path(os.path.expanduser("~/.claude/projects"))
 SLOTS_FILE = Path(__file__).resolve().parent / "tmux-scratch-slots.sh"
 _SLOT_RE = re.compile(r'"([^":]+):([^":]+):(#[0-9a-fA-F]{6}):([^":]+)"')
 _ANSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+
+def _load_agent_ledger():
+    """`scripts/lib/agent_ledger.py`, imported by path — or None if unavailable.
+
+    This file is a standalone script (run from the working tree by
+    `tmux-post-save.sh` and by the `tmux-session-restore` user unit), so there is
+    no package to import from; the ledger hook reaches its own copy the same way.
+
+    🔴 We borrow `pane_filename` rather than restating it. The file key is the
+    WRITER's rule, and a second spelling of it here is the duplicated predicate
+    that ends up making this reader look at a filename nobody writes. If the
+    module cannot be loaded there is deliberately NO fallback spelling — the
+    ledger simply reports nothing and every pane falls through to the grep.
+    """
+    path = Path(__file__).resolve().parent / "lib" / "agent_ledger.py"
+    try:
+        spec = importlib.util.spec_from_file_location("_tsr_agent_ledger", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    except Exception:  # noqa: BLE001 — absent/broken lib: fall back to the grep
+        return None
+
+
+_AL = _load_agent_ledger()
+LEDGER_DIR = Path(getattr(_AL, "LEDGER_DIR",
+                          os.path.expanduser("~/.cache/agent-ledger")))
 
 
 def run(cmd: list[str]) -> str:
@@ -68,6 +108,74 @@ def display_session(session: str, codes: dict[str, str]) -> str:
 def project_dir_for(cwd: str) -> Path:
     """~/.claude/projects encodes a cwd by replacing every '/' with '-'."""
     return PROJECTS / cwd.replace("/", "-")
+
+
+def tmux_server_pid() -> str:
+    """This tmux server's pid — the ledger's generation key. "" if unmeasured."""
+    return run(["tmux", "display-message", "-p", "#{pid}"]).strip()
+
+
+def ledger_binding(pane_id: str, cwd: str, server_pid: str,
+                   directory: Path | None = None) -> tuple[str, str]:
+    """The session id the LEDGER records for this pane: `(session_id, reason)`.
+
+    `("", <reason>)` whenever no record survives validation, and the reason token
+    names WHICH check rejected it — the tests assert on those tokens, so a broken
+    guard fails with its own name rather than with a generic empty string.
+
+    THE FOUR VALIDATIONS, and what each one is for:
+
+      * `no-session-id` — a record with an empty/absent `session_id` binds nothing.
+      * `transcript-missing` — the transcript named by the record must exist on
+        disk. `claude --resume <id>` against a deleted transcript fails, and a
+        failed resume in the right window is worse than the picker.
+      * `generation-mismatch` / `generation-unmeasured` — tmux pane ids restart at
+        `%0` when the SERVER does, so yesterday's `%61` record and today's `%61`
+        pane collide after exactly the reboot this tool exists for. `tmux_pid` is
+        the server pid, constant across a server's windows, so equality is an exact
+        generation check. 🔴 An UNMEASURED live pid rejects too: being unable to
+        check a generation is not the same as having checked it.
+      * `project-mismatch` — 🔴 THE CROSS-REPO GUARD. The transcript's parent
+        directory is the encoded cwd (`project_dir_for`). A record whose transcript
+        lives under a DIFFERENT repo's project dir would resume the wrong
+        conversation in a window that looks right, which is the single worst
+        outcome available here. Compared as the encoded NAME, because that is what
+        `project_dir_for` derives from the pane's cwd.
+
+    ⚠ `last_activity_ts` deliberately does NOT gate. Within one tmux server pane
+    ids are never reused, and the hook writes on `SessionStart`, so a live claude
+    pane's record names the session running in it however long ago it last spoke;
+    across servers the pid check already rejects. Any age threshold would
+    therefore reject only CORRECT bindings — and it would reject them hardest for
+    long-idle windows, which are precisely the ones worth restoring.
+    """
+    if _AL is None:
+        return "", "no-ledger-module"
+    if not pane_id:
+        return "", "no-pane-id"
+    d = Path(directory) if directory is not None else LEDGER_DIR
+    path = d / _AL.pane_filename("claude", pane_id)
+    try:
+        rec = json.loads(path.read_text().splitlines()[0])
+    except (OSError, ValueError, IndexError):
+        return "", "no-record"
+    if not isinstance(rec, dict):
+        return "", "no-record"
+    sid = str(rec.get("session_id") or "").strip()
+    if not sid:
+        return "", "no-session-id"
+    transcript = str(rec.get("transcript_path") or "").strip()
+    if not transcript or not Path(transcript).exists():
+        return "", "transcript-missing"
+    rec_pid = str(rec.get("tmux_pid") or "").strip()
+    live_pid = str(server_pid or "").strip()
+    if not rec_pid or not live_pid:
+        return "", "generation-unmeasured"
+    if rec_pid != live_pid:
+        return "", "generation-mismatch"
+    if Path(transcript).parent.name != project_dir_for(cwd).name:
+        return "", "project-mismatch"
+    return sid, "ok"
 
 
 def jsonls_by_recency(cwd: str) -> list[Path]:
@@ -139,42 +247,77 @@ def first_user_line(session_id: str, cwd: str) -> str:
 
 
 def live_claude_panes() -> list[dict]:
-    """Live claude panes: [{session, window, cwd, title}] in stable order."""
+    """Live claude panes: [{pane_id, session, window, cwd, title}], stable order.
+
+    `#{pane_id}` leads the format because it is the ledger's file key; `#{pane_title}`
+    stays last because it is the one field whose content is arbitrary.
+    """
     out = run(["tmux", "list-panes", "-a", "-F",
-               "#{session_name}\t#{window_index}\t#{pane_current_path}"
+               "#{pane_id}\t#{session_name}\t#{window_index}\t#{pane_current_path}"
                "\t#{pane_current_command}\t#{pane_title}"])
     panes = []
     for ln in out.splitlines():
         p = ln.split("\t")
-        if len(p) < 5 or p[3] != "claude":
+        if len(p) < 6 or p[4] != "claude":
             continue
-        panes.append({"session": p[0], "window": p[1], "cwd": p[2], "title": p[4]})
+        panes.append({"pane_id": p[0], "session": p[1], "window": p[2],
+                      "cwd": p[3], "title": p[5]})
     return panes
 
 
 def build_plan() -> list[dict]:
-    """Bind each live claude window to the EXACT session it runs (by pane content).
+    """Bind each live claude window to the EXACT session it runs.
 
-    Each pane's session is chosen from its uniquely-matched candidates, and a session
-    once claimed is never reused — so two windows can't collapse onto one conversation.
-    A window with no certain, unclaimed match gets an empty id (interactive picker).
+    TWO PASSES, AND THE ORDER IS THE POINT. Pass 1 takes each pane's ledger record
+    (a RECORD, see `ledger_binding`); pass 2 runs the pane-content grep only for the
+    panes pass 1 could not answer. That ordering buys two things at once:
+
+      * 🔴 CORRECTNESS — a certain binding claims its session id BEFORE any guess
+        can. Interleaved, a fuzzy match on pane B could claim the very id the ledger
+        knows belongs to pane A, and A would then fall through to the picker while B
+        resumed A's conversation. Ledger-first makes that unreachable.
+      * SPEED — the grep is never even called for a ledger-bound pane. That is the
+        whole performance claim, and it is pinned behaviourally by a test that
+        injects a matcher which raises.
+
+    Consequence: for one pane the ledger and the grep can never disagree, because on
+    a valid record the grep does not run. A session once claimed is never reused, so
+    two windows can't collapse onto one conversation; a window with no certain,
+    unclaimed binding gets an empty id and the interactive picker at restore time.
     """
     codes = codenames()
     panes = live_claude_panes()
-    cands = {i: unique_match_sids(f"{p['session']}:{p['window']}", p["cwd"])
-             for i, p in enumerate(panes)}
+    server_pid = tmux_server_pid()
+    bound: dict[int, tuple[str, str]] = {}
     claimed: set[str] = set()
-    plan = []
+
+    # Pass 1 — the ledger. Certain, so it claims first.
     for i, p in enumerate(panes):
-        sid = next((s for s in cands[i] if s not in claimed), "")
+        sid, _reason = ledger_binding(p.get("pane_id", ""), p["cwd"], server_pid)
+        if sid and sid not in claimed:
+            claimed.add(sid)
+            bound[i] = (sid, "ledger")
+
+    # Pass 2 — the grep, for whatever is left.
+    for i, p in enumerate(panes):
+        if i in bound:
+            continue
+        cands = unique_match_sids(f"{p['session']}:{p['window']}", p["cwd"])
+        sid = next((s for s in cands if s not in claimed), "")
         if sid:
             claimed.add(sid)
+            bound[i] = (sid, "fuzzy")
+
+    plan = []
+    for i, p in enumerate(panes):
+        sid, source = bound.get(i, ("", ""))
         plan.append({
             "session": p["session"],
             "window": p["window"],
             "codename": display_session(p["session"], codes),
             "cwd": p["cwd"],
             "session_id": sid,
+            "bind_source": source,
             "title": (p["title"] or "").strip(),
             "hint": first_user_line(sid, p["cwd"]) if sid else "",
         })
@@ -194,7 +337,9 @@ def cheat_sheet(plan: list[dict]) -> str:
         lines.append(f"## {loc}  —  {e['title'] or '(untitled)'}")
         lines.append(f"- cwd: `{e['cwd']}`")
         if e["session_id"]:
-            lines.append(f"- resume: `cd {e['cwd']} && claude --resume {e['session_id']}`")
+            src = e.get("bind_source") or "fuzzy"
+            lines.append(f"- resume: `cd {e['cwd']} && claude --resume {e['session_id']}`"
+                         f"  ({src})")
             if e["hint"]:
                 lines.append(f"- first msg: _{e['hint']}_")
         else:
@@ -211,7 +356,11 @@ def cmd_save() -> int:
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     PLAN.write_text(json.dumps(plan, indent=2))
     CHEAT.write_text(cheat_sheet(plan))
+    n_ledger = sum(1 for e in plan if e.get("bind_source") == "ledger")
+    n_fuzzy = sum(1 for e in plan if e.get("bind_source") == "fuzzy")
     print(f"saved {len(plan)} windows → {PLAN}")
+    print(f"bound: {n_ledger} ledger, {n_fuzzy} pane-content, "
+          f"{len(plan) - n_ledger - n_fuzzy} unbound (picker at restore)")
     print(f"cheat-sheet → {CHEAT}\n")
     print(cheat_sheet(plan))
     return 0

--- a/scripts/tmux-session-restore.py
+++ b/scripts/tmux-session-restore.py
@@ -14,9 +14,10 @@ Binding a window to its EXACT session id has TWO sources, and they are not equal
      ground truth for that pane: one O(1) file read.
   2. PANE-CONTENT MATCHING (`unique_match_sids`) — an INFERENCE, and the fallback.
      It greps a pane's on-screen text across every transcript in that cwd's project
-     dir. Measured on the workbench 2026-09-04: 145 competing transcripts in one
-     project dir, and a 50-window `save` spent essentially all of its 2m15s in that
-     grep while still leaving ~10 of 44 live claude panes unbound.
+     dir. Measured on the workbench 2026-09-04 over ONE snapshot of 44 live claude
+     panes, against 145 competing transcripts in one project dir: the grep took
+     176.6s and bound 34; the ledger took 0.002s and bound 34, agreeing on all 27
+     panes both answered. They miss DIFFERENT panes, so together they bind 41.
 
 So the ledger is consulted FIRST and CLAIMS FIRST — a certain binding must never lose
 a session id to a guess — and the grep runs only for panes the ledger cannot answer.

--- a/scripts/tmux-session-restore.py
+++ b/scripts/tmux-session-restore.py
@@ -45,6 +45,7 @@ import os
 import re
 import subprocess
 import sys
+from collections import Counter
 from pathlib import Path
 
 STATE_DIR = Path(os.path.expanduser("~/.config/initiatives"))
@@ -56,8 +57,8 @@ _SLOT_RE = re.compile(r'"([^":]+):([^":]+):(#[0-9a-fA-F]{6}):([^":]+)"')
 _ANSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
 
 
-def _load_agent_ledger():
-    """`scripts/lib/agent_ledger.py`, imported by path — or None if unavailable.
+def _load_agent_ledger(path: Path | None = None):
+    """`scripts/lib/agent_ledger.py`, imported by path — or None if unusable.
 
     This file is a standalone script (run from the working tree by
     `tmux-post-save.sh` and by the `tmux-session-restore` user unit), so there is
@@ -66,17 +67,32 @@ def _load_agent_ledger():
     🔴 We borrow `pane_filename` rather than restating it. The file key is the
     WRITER's rule, and a second spelling of it here is the duplicated predicate
     that ends up making this reader look at a filename nobody writes. If the
-    module cannot be loaded there is deliberately NO fallback spelling — the
-    ledger simply reports nothing and every pane falls through to the grep.
+    module cannot be USED there is deliberately NO fallback spelling — the ledger
+    simply reports nothing and every pane falls through to the grep.
+
+    🔴 "Cannot be used" is TWO cases, and the `hasattr` check is what makes the
+    promise true for the second. An absent or syntactically broken file raises on
+    import and is caught; a module that imports fine while lacking the one symbol
+    this file borrows would be returned as usable, and the unguarded
+    `_AL.pane_filename(...)` in `ledger_binding` would then raise out of
+    `build_plan` and kill `cmd_save` — which runs unattended every ~15 min from
+    `tmux-post-save.sh` into a log nobody reads, silently freezing the restore
+    plan. Degrading is the whole point; half-degrading is worse than not trying.
+
+    `path` exists so a test can hand this loader a deliberately-broken module;
+    production always takes the default.
     """
-    path = Path(__file__).resolve().parent / "lib" / "agent_ledger.py"
+    p = Path(path) if path is not None else (
+        Path(__file__).resolve().parent / "lib" / "agent_ledger.py")
     try:
-        spec = importlib.util.spec_from_file_location("_tsr_agent_ledger", path)
+        spec = importlib.util.spec_from_file_location("_tsr_agent_ledger", p)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
-        return mod
     except Exception:  # noqa: BLE001 — absent/broken lib: fall back to the grep
         return None
+    if not hasattr(mod, "pane_filename"):
+        return None
+    return mod
 
 
 _AL = _load_agent_ledger()
@@ -122,7 +138,11 @@ def ledger_binding(pane_id: str, cwd: str, server_pid: str,
 
     `("", <reason>)` whenever no record survives validation, and the reason token
     names WHICH check rejected it — the tests assert on those tokens, so a broken
-    guard fails with its own name rather than with a generic empty string.
+    guard fails with its own name rather than with a generic empty string. The
+    token also LEAVES this function: `build_plan` records it per pane and
+    `cmd_save` prints the tally, because `0 ledger` alone cannot tell an operator
+    apart `no-ledger-module` (a deploy problem) from `generation-mismatch` (the
+    server restarted) from `no-record` (nothing to fix).
 
     THE FOUR VALIDATIONS, and what each one is for:
 
@@ -133,9 +153,19 @@ def ledger_binding(pane_id: str, cwd: str, server_pid: str,
       * `generation-mismatch` / `generation-unmeasured` — tmux pane ids restart at
         `%0` when the SERVER does, so yesterday's `%61` record and today's `%61`
         pane collide after exactly the reboot this tool exists for. `tmux_pid` is
-        the server pid, constant across a server's windows, so equality is an exact
-        generation check. 🔴 An UNMEASURED live pid rejects too: being unable to
-        check a generation is not the same as having checked it.
+        the server pid, constant across a server's windows, so equality rejects
+        every record written by a server that is not the one answering now.
+        ⚠ That is NOT the same as an exact generation check, and the gap sits in
+        the very event this guard exists for: pids are reused, a reboot resets the
+        counter, and both servers are started at login. MEASURED 2026-09-04 on the
+        workbench: live server pid `4025325` against `pid_max` `4194304` — i.e.
+        near the wrap, so the next boot's server draws a LOW pid, and so did the
+        previous boot's. A collision is unlikely, not astronomical, and a colliding
+        record for the same pane id in the same cwd would pass all four checks.
+        Closing it needs a value the WRITER does not record today (a boot id, or
+        the server's `/proc` start time), so the residual is ACCEPTED, not covered.
+        🔴 An UNMEASURED live pid rejects too: being unable to check a generation
+        is not the same as having checked it.
       * `project-mismatch` — 🔴 THE CROSS-REPO GUARD. The transcript's parent
         directory is the encoded cwd (`project_dir_for`). A record whose transcript
         lives under a DIFFERENT repo's project dir would resume the wrong
@@ -149,6 +179,14 @@ def ledger_binding(pane_id: str, cwd: str, server_pid: str,
     across servers the pid check already rejects. Any age threshold would
     therefore reject only CORRECT bindings — and it would reject them hardest for
     long-idle windows, which are precisely the ones worth restoring.
+
+    🔴 But the WRITE side already applies one, so `no-record` has a permanent
+    FLOOR rather than shrinking to nothing: `agent_ledger.DEFAULT_MAX_AGE` is 7
+    days and every write prunes, so a live pane idle longer than that has no
+    record at all and reports `no-record` forever. Prune keeps re-opening that set
+    for exactly the long-idle windows a read-side age gate would also have thrown
+    away — which is why the argument above still holds, and why "the unbound set
+    shrinks on its own" is true only of the panes that predate the hook.
     """
     if _AL is None:
         return "", "no-ledger-module"
@@ -290,11 +328,13 @@ def build_plan() -> list[dict]:
     panes = live_claude_panes()
     server_pid = tmux_server_pid()
     bound: dict[int, tuple[str, str]] = {}
+    reasons: dict[int, str] = {}
     claimed: set[str] = set()
 
     # Pass 1 — the ledger. Certain, so it claims first.
     for i, p in enumerate(panes):
-        sid, _reason = ledger_binding(p.get("pane_id", ""), p["cwd"], server_pid)
+        sid, reason = ledger_binding(p.get("pane_id", ""), p["cwd"], server_pid)
+        reasons[i] = reason
         if sid and sid not in claimed:
             claimed.add(sid)
             bound[i] = (sid, "ledger")
@@ -319,6 +359,11 @@ def build_plan() -> list[dict]:
             "cwd": p["cwd"],
             "session_id": sid,
             "bind_source": source,
+            # Why the LEDGER did or did not answer for this pane — carried out so
+            # `cmd_save` can print a tally an operator can act on. Independent of
+            # `bind_source`: a pane can read `ok` here and still be `fuzzy`/unbound
+            # if another pane claimed that session id first.
+            "ledger_reason": reasons.get(i, ""),
             "title": (p["title"] or "").strip(),
             "hint": first_user_line(sid, p["cwd"]) if sid else "",
         })
@@ -362,6 +407,12 @@ def cmd_save() -> int:
     print(f"saved {len(plan)} windows → {PLAN}")
     print(f"bound: {n_ledger} ledger, {n_fuzzy} pane-content, "
           f"{len(plan) - n_ledger - n_fuzzy} unbound (picker at restore)")
+    # The counts above cannot tell `0 ledger` apart between a missing module, a
+    # restarted server and simply no records — and the first two are what an
+    # operator would act on. Sorted by token so the line's shape is stable.
+    tally = Counter(e.get("ledger_reason") or "unrecorded" for e in plan)
+    print("ledger reasons: "
+          + ", ".join(f"{tok}={n}" for tok, n in sorted(tally.items())))
     print(f"cheat-sheet → {CHEAT}\n")
     print(cheat_sheet(plan))
     return 0

--- a/scripts/tmux-session-restore.py
+++ b/scripts/tmux-session-restore.py
@@ -207,7 +207,9 @@ def ledger_binding(pane_id: str, cwd: str, server_pid: str,
     on when they do: `agent-ledger-hook.py` prunes on SESSION BOUNDARIES only
     (`PRUNE_EVENTS` is `SessionStart`/`Stop`, a subset of the four events that
     write), while `opencode/plugin/ledger.js` has no boundary hook at all and
-    passes `--prune` on EVERY write, throttled to once per 30 s. But a prune
+    passes `--prune` on EVERY write, throttled to once per SESSION per 30 s
+    (`ledger.js`'s `lastWrite` is a Map keyed by sessionID, so N concurrent
+    sessions issue up to N prunes in a window, not one). But a prune
     sweeps the WHOLE directory whoever triggers it, so it is OTHER sessions'
     prunes that delete an idle pane's record. Either way a live pane idle
     longer than that ends up with

--- a/scripts/tmux-session-restore.py
+++ b/scripts/tmux-session-restore.py
@@ -203,11 +203,14 @@ def ledger_binding(pane_id: str, cwd: str, server_pid: str,
 
     🔴 But the WRITE side already applies one, so `no-record` has a permanent
     FLOOR rather than shrinking to nothing: `agent_ledger.DEFAULT_MAX_AGE` is 7
-    days. `write_record` itself does NOT prune — both writers prune on their
-    SESSION BOUNDARIES only (`agent-ledger-hook.py`'s `PRUNE_EVENTS` is
-    `SessionStart`/`Stop`, a subset of the four events that write) — but a prune
-    sweeps the WHOLE directory, so it is OTHER sessions' boundaries that delete an
-    idle pane's record. Either way a live pane idle longer than that ends up with
+    days. `write_record` itself does NOT prune, and the two writers do not agree
+    on when they do: `agent-ledger-hook.py` prunes on SESSION BOUNDARIES only
+    (`PRUNE_EVENTS` is `SessionStart`/`Stop`, a subset of the four events that
+    write), while `opencode/plugin/ledger.js` has no boundary hook at all and
+    passes `--prune` on EVERY write, throttled to once per 30 s. But a prune
+    sweeps the WHOLE directory whoever triggers it, so it is OTHER sessions'
+    prunes that delete an idle pane's record. Either way a live pane idle
+    longer than that ends up with
     no record at all and reports `no-record` forever. Prune keeps re-opening that set
     for exactly the long-idle windows a read-side age gate would also have thrown
     away — which is why the argument above still holds, and why "the unbound set


### PR DESCRIPTION
## The problem

`scripts/tmux-session-restore.py` snapshots which claude conversation is in which tmux window so they can be resumed after a reboot. Binding a window to its session id was done by **fuzzy pane-content matching**: capture the last 200 pane lines, keep fragments >=40 chars, and `grep -lF` each across every `*.jsonl` in that cwd's project dir, keeping only fragments that hit exactly one file.

It is slow and it misses. Measured on the workbench 2026-09-04: **145 competing transcripts** in `-home-zach-workspace-devrc` alone, and a `save` over 50 windows took **2m15s**, essentially all of it in that grep.

## The fix

A deterministic per-pane ledger **already existed and was not being read**. `scripts/claude-hooks/agent-ledger-hook.py` is deployed, wired on 4 hook events, and writes one JSON file per pane to `~/.cache/agent-ledger/claude-p<N>.json` carrying `{pane_id, session_id, transcript_path, window_id, tmux_pid, last_activity_ts}`. The hook receives the real `session_id` from Claude Code and reads `TMUX_PANE` from its own environment — a record, not an inference.

`build_plan()` now runs **two passes**: pass 1 reads the ledger; pass 2 runs the existing grep only for panes pass 1 could not answer. Ledger claims first, so a guess can never take an id the ledger owns, and the grep is never *called* for a ledger-bound pane.

**Four validations**, each with its own reason token: `no-session-id`, `transcript-missing`, `generation-mismatch`/`generation-unmeasured`, `project-mismatch` (the cross-repo guard). `last_activity_ts` deliberately does **not** gate — see below.

## Measured, same-instant head-to-head (44 live claude panes, one `tmux list-panes` snapshot)

```
ledger lookup, all 44 panes:      0.002s  ->  34/44
pane-content grep, all 44 panes: 176.606s ->  34/44

both  27  (agree 27, disagree 0)   ledger only 7   fuzzy only 7   neither 3
union 41/44
```

🔴 **The ledger is NOT better at coverage — it ties at 34/44**, and the two miss different panes. Its wins are that it is a record rather than an inference, ~5 orders of magnitude cheaper, and **complementary**: together they bind 41/44 where either alone binds 34. Where both answered they agreed 27/27, an independent cross-check neither gives alone.

`save` wall time, full runs to a scratch plan: **180.5s / 35 bound -> 37.8s / 42 bound** — 4.8x, +7 windows. (Runs minutes apart, so counts differ from the snapshot above by window churn; stated as measured.)

⚠ **The 10 `no-record` panes are pre-hook sessions — but that set does NOT simply "shrink on its own".** `agent_ledger.DEFAULT_MAX_AGE` is 7 days and prune sweeps the whole directory, so it keeps re-opening for exactly the long-idle windows. `no-record` has a permanent floor.

⚠ **`tmux_pid` equality is NOT an exact generation check.** A reboot resets the pid counter, so a colliding record for the same pane id in the same cwd would pass all four validations. Narrow in practice, documented, and **accepted** — closing it needs a writer-side change to `agent_ledger.py`.

**Post-reboot path, exercised rather than reasoned:** with a foreign server pid, `{'generation-mismatch': 33, 'no-record': 10}`. The fallback fires for 100% of panes and the first post-reboot `save` costs the full grep — no regression, no improvement in that window.

## Why `last_activity_ts` does not gate

Any age threshold would reject only *correct* bindings, hardest for the long-idle windows most worth restoring. Corroborated: 18 ledger-bound panes cross-checked against the real grep — **18 agree, 0 disagree**, including the oldest record at 5.3 days, where a 24h gate would have rejected 3 correct bindings.

## Verification

- **RED -> GREEN**: 23 failed/13 passed at `cc409f82` -> **47 passed** at head.
- **Mutation**: every guard killed by its own assertion, under `PYTHONDONTWRITEBYTECODE=1` with a fresh tree per mutant, a green control and a known-fatal positive control.
- **Both gate tiers on the merged tree** (`origin/main` `f75c92d4` is an ancestor, so head IS the merged tree), run one at a time: `pytests` -> `RESULT: PASS (exit=0)`, `collected=21509 passed=21506 skipped=3 failed=0`; `nodetests` -> `RESULT: PASS (exit=0)`, 0 fail; 0 timeout panics in either.

## Four adversarial audit rounds

No 🔴 at any round. Rounds 1-3 each found real defects, none of which a green suite could catch; **round 4 came back clean**, which is what ended the ladder.

1. The loader promised graceful degradation but caught only import *failure* — a module importing without `pane_filename` raised `AttributeError` out of `cmd_save`, **silently freezing the restore plan**. Fixed with a borrowed-symbol guard.
2. The four reason tokens were computed and discarded; `cmd_save` now prints them.
3. `LEDGER_DIR` was a *second* borrowed symbol, unguarded, with a restated literal default — and its failure rendered as `no-record`, the token the legend reserves for the benign case. Now `_BORROWED = ("pane_filename", "LEDGER_DIR")`, read directly off the module, literal default gone.
4. Two prose claims were false about the code they described (a pid-collision inference its own measurement refuted; a prune rule false about one of the two writers). Corrected at all three copies.
5. The `_BORROWED` two-way pin was **blind to `getattr(_AL, "X", …)`** — the exact spelling `LEDGER_DIR` had been written in — while its docstring claimed it closed that hole. Now walks the AST; the surviving mutant is killed and prose is no longer scanned as code.

Payload lines changed across the fix rounds: 75, 67, 34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2HwZGfRQSHQTJxjh7mkfy