### PR TITLE
feat(mentions): attribute a bare #N to its repo, widen detection for TELEMETRY only, and stop the terminal handler dead-ending

### DIFF
--- a/scripts/collector/claude/session-tailer.py
+++ b/scripts/collector/claude/session-tailer.py
@@ -877,7 +877,10 @@ MENTIONS_PER_SESSION_CAP = 200
 
 # Cheap pre-filter before the regex pass: a text block containing none of these
 # literals cannot match any pattern this tailer scans for, and does not need
-# scanning. Measured over one 24h window it skipped 81% of assistant text blocks.
+# scanning. Re-measured 2026-09-04 over the preceding 24h (10,118 assistant text
+# blocks): the OLD two literals skipped 81% of them, this derived telemetry set
+# skips 79%. ⚠ That percentage is a property of the WINDOW, not of the code —
+# `mention_scan.mention_hints`' docstring carries the same caveat and the numbers.
 #
 # 🔴 DERIVED FROM THE SCANNER'S OWN LEDGER, NEVER HAND-MAINTAINED. This used to
 # be the literal `("#", "868")`, and that made it the exact place a widening goes
@@ -926,6 +929,17 @@ def load_mention_repos(path: Path | None = None) -> dict:
     attribution, never the telemetry pass. The value SHAPE rule is
     `mention_scan.clean_repo_map`, shared with the hint handler so the two
     cannot disagree about what a usable entry is.
+
+    🔴 WHAT COMES BACK NAMES PRIVATE REPOSITORIES — the same file whose committed
+    ancestor disclosed 232 of them into this PUBLIC repo. `scripts/mention-open.py`
+    carries this warning for its rofi window; this reader is the one that matters
+    MORE, because its consumer is a durable ClickHouse table rather than a window
+    that closes. ONE value from this mapping may leave here per mention: the
+    repository that mention was ATTRIBUTED to. Never the mapping, never a second
+    entry, never a count of it. Pinned by
+    `test_session_tailer.py::test_the_repo_mapping_never_reaches_the_SPOOL_beyond_
+    the_ONE_repo_a_mention_was_attributed_to`, which asserts the attributed name
+    IS present (a positive control) before asserting the others are not.
     """
     p = path or mention_repos_path()
     try:
@@ -935,13 +949,43 @@ def load_mention_repos(path: Path | None = None) -> dict:
 
 
 def mention_key(m: dict) -> str:
-    """The dedupe identity of a mention: platform + the exact matched text.
+    """The dedupe identity of a mention: platform + the exact matched text + the
+    ATTRIBUTED repo.
 
     🔴 The RAW text, not the bare id. `devrc#370` and `talos-infra#370` are
     different references that share an id, and keying on the id alone would emit
     only the first of them and silently drop the second for the life of the
-    session."""
-    return f"{m['platform']}:{m['raw']}"
+    session.
+
+    🔴 AND THE REPO, for exactly the same reason one level up. 92% of mentions
+    are a bare `#N`, so the raw text is `#1291` for every one of them: without
+    the repo in the identity, `trowelcast PR #1291` and `plotwidget PR #1291`
+    collapse to ONE row, and the FIRST occurrence wins — which, because the bare
+    unattributed form usually appears first, systematically discards the
+    attribution this whole change exists to compute. Measured on real
+    transcripts before the fix: 34 rows/day shipped `repo=""` although an
+    attribution was available, and 6 rows/day dropped a second repository's
+    reference outright.
+
+    🔴 THE FORMAT IS VERSIONED BY OMISSION, AND THAT IS A DELIBERATE MIGRATION
+    CHOICE, NOT AN ACCIDENT OF STRING BUILDING. An unattributed mention keys
+    EXACTLY as before — `"<platform>:<raw>"`, byte for byte — and only an
+    attributed one takes the `@<owner>/<repo>` suffix. The alternative
+    (`"<platform>:<repo>:<raw>"` unconditionally) would have re-keyed EVERY
+    entry in every host's `session-summary-state.json`, re-emitting every
+    already-shipped mention once on both hosts. The deployed tailer passes NO
+    mapping at all (`collect_mentions(objects)`), so every key on disk today was
+    written with `repo == ""` and every one of them still matches. What DOES
+    re-emit once is precisely the set that newly gains an attribution — a row
+    whose content genuinely changed, which is the row this PR exists to ship.
+
+    ⚠ `@` IS SAFE AS THE SEPARATOR because no pattern in `mention_scan` can put
+    one in `raw`: `_OWNER`, `_REPO` and `_URL_REPO` are all alphanumerics plus
+    `-`, `_` and (for URLs) `.`, and the wordy forms are literal keywords. So a
+    key cannot be spelled two ways.
+    """
+    repo = m.get("repo") or ""
+    return f"{m['platform']}:{m['raw']}@{repo}" if repo else f"{m['platform']}:{m['raw']}"
 
 
 def collect_mentions(objects: list[dict], *, repos: dict | None = None) -> list[dict]:
@@ -1022,6 +1066,14 @@ def build_mention_emit_args(ev: dict, m: dict) -> list[str]:
     `repo_source` rides beside it so a consumer can tell a repo the text stated
     from one resolved through the operator's mapping — an analysis that cannot
     separate those is one measurement pretending to be two.
+
+    🔴 THAT SEPARATION IS `explicit` vs `mapped`, and it did not exist until it
+    was measured. `explicit` means an `owner/repo#N` the operator wrote out;
+    `mapped` means a bare `repo#N` whose OWNER came from
+    `~/.config/mention-open/known_repos.json`. Both used to report `explicit`,
+    so the field promised a distinction it did not carry. `adjacent`, `url`,
+    `flag` and `default` are the block-level routes — see the ATTRIBUTION block
+    in `mention_scan`'s module docstring, which owns the full ladder.
     """
     args = [
         "source=mentions",

--- a/scripts/collector/claude/session-tailer.py
+++ b/scripts/collector/claude/session-tailer.py
@@ -875,11 +875,63 @@ def emit_event(emit: str, ev: dict) -> None:
 # state file grow without limit, not that 200 is a meaningful threshold.
 MENTIONS_PER_SESSION_CAP = 200
 
-# Cheap pre-filter before the regex pass. Every pattern in mention_scan requires
-# a literal '#' or the literal '868', so a text block containing neither cannot
-# possibly match and does not need scanning. This is the same short-circuit the
-# rejected hook design needed, applied where it is nearly free.
-_MENTION_HINTS = ("#", "868")
+# Cheap pre-filter before the regex pass: a text block containing none of these
+# literals cannot match any pattern this tailer scans for, and does not need
+# scanning. Measured over one 24h window it skipped 81% of assistant text blocks.
+#
+# 🔴 DERIVED FROM THE SCANNER'S OWN LEDGER, NEVER HAND-MAINTAINED. This used to
+# be the literal `("#", "868")`, and that made it the exact place a widening goes
+# to die: every telemetry-only shape the scanner learned — `audit-pr 1291`,
+# `gh pr view 1291`, `clawgate task 370` — contains neither literal, so the
+# regexes would have been reachable in a unit test calling `scan_mentions()`
+# directly and DEAD in production, with the whole suite green. Deriving it means
+# a pattern added to `PATTERN_LEDGER` widens the filter in the same commit,
+# because there is nowhere else to put the fact.
+#
+# 🔴 AND IT IS THE TELEMETRY PROFILE, not the default. `mention_hints()` with no
+# argument returns the TERMINAL profile's two literals — the old value — which
+# would look correct, pass a "derived from the ledger" review, and still skip
+# every new shape.
+_MENTION_HINTS = MS.mention_hints(MS.PROFILE_TELEMETRY)
+
+# Where the operator's generated repo mapping lives — the same per-host file
+# `scripts/mention-open.py` reads, and for the same reason: it names PRIVATE
+# repositories, so it lives OUTSIDE every checkout and this repo is public.
+# Nothing breaks when it is absent; a `#N` simply stays unattributed.
+#
+# 🔴 THIS EXPRESSION IS THE THIRD COPY OF ONE PATH — the generator writes it, the
+# hint handler reads it, and now so does this tailer. They agree only by
+# coincidence, so `scripts/tests/test_mention_open.py` imports all three modules
+# and pins the three answers equal. Move one and the mapping is generated into
+# a file nothing loads, or read from a file nothing writes, with every suite green.
+#
+# 🔴 A FUNCTION, NOT A MODULE CONSTANT, and that is not a style choice. A
+# constant is evaluated at IMPORT, so a test setting `MENTION_OPEN_KNOWN_REPOS`
+# afterwards changes nothing and the tailer reads the OPERATOR'S REAL mapping —
+# which names private repositories. `scripts/mention-open.py` records the same
+# defect twice (`load_known_repos`, `discover_repos`): once measured running 91
+# real `git remote` calls from a test that believed it had an empty fixture.
+def mention_repos_path() -> Path:
+    return Path(
+        os.environ.get("MENTION_OPEN_KNOWN_REPOS")
+        or Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+        / "mention-open" / "known_repos.json")
+
+
+def load_mention_repos(path: Path | None = None) -> dict:
+    """{repo name: "owner/repo"} from the operator's generated mapping, or {}.
+
+    🔴 EVERY failure is {} — absent, unreadable, malformed, wrong shape. This
+    runs inside a timer-driven collector: a mapping it cannot read must cost
+    attribution, never the telemetry pass. The value SHAPE rule is
+    `mention_scan.clean_repo_map`, shared with the hint handler so the two
+    cannot disagree about what a usable entry is.
+    """
+    p = path or mention_repos_path()
+    try:
+        return MS.clean_repo_map(json.loads(p.read_text()))
+    except (OSError, ValueError):
+        return {}
 
 
 def mention_key(m: dict) -> str:
@@ -892,8 +944,13 @@ def mention_key(m: dict) -> str:
     return f"{m['platform']}:{m['raw']}"
 
 
-def collect_mentions(objects: list[dict]) -> list[dict]:
+def collect_mentions(objects: list[dict], *, repos: dict | None = None) -> list[dict]:
     """Distinct mentions in this session's ASSISTANT text, in first-seen order.
+
+    `repos` is the caller-measured {name: "owner/repo"} mapping used to attribute
+    a bare `#N` written next to a repo token (`devrc PR #1291`). It is a
+    PARAMETER and not a module read for the same reason the rest of this function
+    is pure: `main()` loads it once per pass, and every test can supply its own.
 
     Assistant TEXT blocks only — not tool inputs, not tool results, not user
     messages. A tool result is usually a file the agent read, so scanning it
@@ -927,12 +984,19 @@ def collect_mentions(objects: list[dict]) -> list[dict]:
                 continue
             if not any(h in text for h in _MENTION_HINTS):
                 continue
-            for span in MS.scan_mention_spans(text):
+            # 🔴 THE WIDER PROFILE. Telemetry is a private row, not an underlined
+            # span on the operator's screen, so this side of the split takes the
+            # enumerated widening (`gh pr view N`, `clawgate task N`, GitHub URLs)
+            # that `scripts/mention-open.py` deliberately does not.
+            for span in MS.scan_mention_spans(text, repos=repos,
+                                              profile=MS.PROFILE_TELEMETRY):
                 m = {
                     "platform": span["platform"],
                     "id": span["id"],
                     "raw": span["raw"],
                     "url": span["url"],
+                    "repo": span["repo"],
+                    "repo_source": span["repo_source"],
                     "context": span["context"],
                     "candidates": ",".join(c["platform"] for c in span["candidates"]),
                     "ts": ts,
@@ -949,8 +1013,16 @@ def collect_mentions(objects: list[dict]) -> list[dict]:
 
 def build_mention_emit_args(ev: dict, m: dict) -> list[str]:
     """The v1 emit line for one mention. Unknown keys (`platform`,
-    `reference_id`, `url`, `context`, `candidates`) land in the collector's
-    `payload` JSON — no schema change, see collector.parse_line."""
+    `reference_id`, `url`, `repo`, `repo_source`, `context`, `candidates`) land
+    in the collector's `payload` JSON — no schema change, see collector.parse_line.
+
+    `repo` is the ATTRIBUTION and it is what makes an ambiguous row useful: 92%
+    of mentions in a measured 24h window were a bare `#N`, and a row that names
+    the repository can be grouped even when the platform is still open.
+    `repo_source` rides beside it so a consumer can tell a repo the text stated
+    from one resolved through the operator's mapping — an analysis that cannot
+    separate those is one measurement pretending to be two.
+    """
     args = [
         "source=mentions",
         "kind=mention-detected",
@@ -960,6 +1032,9 @@ def build_mention_emit_args(ev: dict, m: dict) -> list[str]:
         f"platform={m['platform']}",
         f"b64:reference_id={m['id']}",
         f"b64:url={m['url']}",
+        f"b64:repo={m.get('repo', '')}",
+        # Also a fixed vocabulary (mention_scan's SOURCE_* constants).
+        f"repo_source={m.get('repo_source', '')}",
         f"b64:context={m['context']}",
         f"b64:candidates={m['candidates']}",
         f"b64:project={ev['project']}",
@@ -1195,6 +1270,9 @@ def run(now: float | None = None) -> int:
     sp = state_path()
     prev = load_state(sp)
     emit = emit_path()
+    # ONCE per pass, not once per transcript: the mapping is a property of the
+    # host, and re-reading it per session would be hundreds of identical reads.
+    mention_repos = load_mention_repos()
 
     # Start from the prior state and update a session's entry ONLY after it has
     # been (re-)emitted (or confirmed unchanged/deferred), checkpointing
@@ -1268,7 +1346,7 @@ def run(now: float | None = None) -> int:
                 mentions = []
             else:
                 rollup = build_rollup(objects)
-                mentions = collect_mentions(objects)
+                mentions = collect_mentions(objects, repos=mention_repos)
             ev = build_event(session, rollup)
         except Exception as exc:  # noqa: BLE001 — deliberately broad; see above
             failed += 1

--- a/scripts/collector/claude/tests/test_session_tailer.py
+++ b/scripts/collector/claude/tests/test_session_tailer.py
@@ -1090,7 +1090,8 @@ def test_collect_mentions_dedupes_on_the_RAW_text_not_the_bare_id():
     the second for the life of the session."""
     objs = [assistant_text("devrc#7 and talos-infra#7 and devrc#7 again")]
     got = S.collect_mentions(objs)
-    assert [m["raw"] for m in got] == ["devrc#7", "talos-infra#7"]
+    assert [m["raw"] for m in got] == ["devrc#7", "talos-infra#7"], (
+        "keyed on the id, not the raw text")
 
 
 def test_collect_mentions_is_capped(monkeypatch):
@@ -1207,6 +1208,94 @@ def test_the_ledger_survives_a_restart_through_the_state_file(env):
     ])
     assert S.run() == 0
     assert S.load_state(env["state"])[str(p)]["mentions"] == ["ambiguous:#370"]
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE DEDUPE IDENTITY INCLUDES THE ATTRIBUTION
+#
+# Keying on `platform:raw` alone discards the very thing this stream was widened
+# to compute: 92% of mentions are a bare `#N`, so the raw text is `#1291` for all
+# of them, and the FIRST occurrence in a session wins. Measured on real
+# transcripts before the fix: 34 rows/day shipped `repo=""` although an
+# attribution was available, and 6 rows/day dropped a second repository outright.
+# --------------------------------------------------------------------------- #
+def test_two_repositories_referencing_the_SAME_number_are_two_mentions():
+    """🔴 THE DROPPED-REFERENCE HALF. `mention_key`'s own docstring already
+    argued this class one level down for `devrc#370` vs `talos-infra#370`; the
+    bare form is the same collision with the repo one token to the left instead
+    of glued to the `#`."""
+    got = S.collect_mentions([
+        assistant_text("trowelcast PR #1291 is green"),
+        assistant_text("plotwidget PR #1291 is not"),
+    ], repos=FAKE_REPOS)
+    assert [m["repo"] for m in got] == ["gardenersguild/trowelcast",
+                                        "hobbyist/plotwidget"], (
+        "the dedupe key dropped a second repository's reference")
+    assert {m["raw"] for m in got} == {"#1291"}, (
+        "positive control: both really are the same raw text, so only the "
+        "attribution can be telling them apart")
+
+
+def test_an_ATTRIBUTED_repeat_of_an_unattributed_ref_is_not_swallowed():
+    """🔴 THE LOST-ATTRIBUTION HALF, and the ORDER is the point. The bare form
+    usually appears first, so under a `platform:raw` key the row that ships is
+    the one carrying NO repo and every later attributed occurrence is dropped —
+    a loss biased systematically downward."""
+    got = S.collect_mentions([
+        assistant_text("still looking at #1291"),
+        assistant_text("spadeworks PR #1291 landed"),
+    ], repos=FAKE_REPOS)
+    assert [m["repo"] for m in got] == ["", "rivalorg/spadeworks"]
+
+
+def test_the_same_reference_with_the_same_attribution_is_still_ONE_mention():
+    """The ledger must not become a no-op: adding the repo to the key widens the
+    identity, it does not disable deduplication."""
+    got = S.collect_mentions([
+        assistant_text("trowelcast PR #1291"),
+        assistant_text("trowelcast PR #1291 again"),
+    ], repos=FAKE_REPOS)
+    assert len(got) == 1, got
+
+
+def test_an_UNATTRIBUTED_mention_keys_EXACTLY_as_the_deployed_tailer_did():
+    """🔴 THE MIGRATION DECISION, PINNED — not a formatting preference.
+
+    Every key in every host's `session-summary-state.json` today was written by a
+    tailer whose `collect_mentions` took NO mapping, so all of them have
+    `repo == ""`. Keying unconditionally as `platform:repo:raw` would have
+    re-keyed the lot and re-emitted every already-shipped mention once on both
+    hosts. Suffixing ONLY when there is an attribution keeps those keys byte
+    identical, so the re-emit is confined to the rows whose content genuinely
+    changed. A mutant that "tidies" this into one unconditional format dies here.
+
+    The absent-key case is asserted too: `collect_mentions` always sets `repo`,
+    but `mention_key` is also fed straight from a ledger-shaped dict in `run()`,
+    and a missing key must degrade to the old spelling rather than raise."""
+    old = "ambiguous:#370"
+    assert S.mention_key({"platform": "ambiguous", "raw": "#370", "repo": ""}) == old, (
+        "the unattributed key format MOVED — every host's ledger would re-emit")
+    assert S.mention_key({"platform": "ambiguous", "raw": "#370"}) == old, (
+        "the unattributed key format MOVED — every host's ledger would re-emit")
+    assert S.mention_key({"platform": "ambiguous", "raw": "#370",
+                          "repo": "rivalorg/spadeworks"}) == (
+        "ambiguous:#370@rivalorg/spadeworks")
+
+
+def test_an_already_emitted_unattributed_mention_does_NOT_reemit_after_the_change(env):
+    """The migration claim, end to end rather than as a string assertion: a state
+    file written by the OLD code (the literal keys it produced) must still
+    suppress the same mention under the new one."""
+    p = _write(env["projects"], "-home-zach-workspace-devrc", "s-mig", [
+        user_typed("go"), assistant_text("see #370"),
+    ])
+    t0 = time.time()
+    S.save_state(env["state"], {str(p): {"sig": "nope", "emitted_at": None,
+                                         "mentions": ["ambiguous:#370"]}})
+    assert S.run(now=t0) == 0
+    assert _mentions(env["spool"]) == [], (
+        "a pre-change ledger entry must still match — this is the whole reason "
+        "the suffix is conditional")
 
 
 def test_a_corrupt_mention_ledger_degrades_instead_of_crashing():
@@ -1449,6 +1538,74 @@ def test_an_unusable_mapping_costs_ATTRIBUTION_not_the_telemetry_pass(
 
 def test_an_absent_mapping_is_an_empty_mapping(tmp_path):
     assert S.load_mention_repos(tmp_path / "nope.json") == {}
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE DISCLOSURE GUARD FOR THE TELEMETRY HALF
+#
+# `scripts/mention-open.py` sends the operator's known-repo mapping to a rofi
+# window that closes, and carries a guard saying so. THIS reader sends it into a
+# durable ClickHouse table and, until now, carried none — the asymmetry is
+# backwards. `known_repos.json` is the file whose committed ancestor disclosed
+# 232 private repository names into this PUBLIC repo (#1283).
+#
+# THE RULE: exactly ONE value from the mapping may leave here per mention — the
+# repository that mention was ATTRIBUTED to. Never the mapping, never a second
+# entry, never a count of it.
+# --------------------------------------------------------------------------- #
+def _everything_the_run_wrote(env, capsys) -> str:
+    """Every sink a run can write to, decoded. The spool is read RAW as well as
+    parsed, because a leak that is base64-encoded and one that is not are the
+    same disclosure and only one of the two readings can see each."""
+    cur = env["spool"] / "current.log"
+    raw = cur.read_text(encoding="utf-8") if cur.exists() else ""
+    decoded = json.dumps(_spool_events(env["spool"]), ensure_ascii=False)
+    captured = capsys.readouterr()
+    return "\n".join([raw, decoded, captured.out, captured.err])
+
+
+def test_the_repo_mapping_never_reaches_the_SPOOL_beyond_the_ONE_repo_a_mention_was_attributed_to(
+        env, capsys):
+    """🔴 POSITIVE CONTROL FIRST. The attributed repository MUST be present —
+    otherwise every absence below is satisfied by a run that emitted nothing, and
+    the guard is the silent zero it exists to prevent."""
+    env["repos_path"].write_text(json.dumps(FAKE_REPOS), encoding="utf-8")
+    _write(env["projects"], "-home-zach-workspace-devrc", "sess-DISCLOSE", [
+        user_typed("go"),
+        assistant_text("trowelcast PR #1291 is green", ts="2026-07-11T10:02:00.000Z"),
+    ])
+    assert S.run() == 0
+    everywhere = _everything_the_run_wrote(env, capsys)
+    # POSITIVE CONTROL 1 — a mention really shipped, carrying its attribution.
+    assert "gardenersguild/trowelcast" in everywhere
+    # POSITIVE CONTROL 2 — the mapping the run held really had the other two in
+    # it, so their absence is a decision and not an empty fixture.
+    assert S.load_mention_repos(env["repos_path"]) == FAKE_REPOS
+    for name in ("hobbyist/plotwidget", "rivalorg/spadeworks",
+                 "plotwidget", "spadeworks"):
+        assert name not in everywhere, (
+            f"SPOOL DISCLOSURE (attributed run): {name!r} is in the operator's "
+            "mapping and was NOT the repository this mention was attributed "
+            "to — it must not reach the spool")
+
+
+def test_an_UNATTRIBUTED_mention_ships_NO_repository_name_at_all(env, capsys):
+    """The harder direction: with nothing to attribute, a run that consulted the
+    mapping must leave no trace of ANY entry in it. A leak on the unattributed
+    path has no legitimate value to hide behind, so the absence is total."""
+    env["repos_path"].write_text(json.dumps(FAKE_REPOS), encoding="utf-8")
+    _write(env["projects"], "-home-zach-workspace-devrc", "sess-BARE", [
+        user_typed("go"), assistant_text("fixed in #370"),
+    ])
+    assert S.run() == 0
+    everywhere = _everything_the_run_wrote(env, capsys)
+    # POSITIVE CONTROL — the run DID emit a mention and DID load the mapping.
+    assert "370" in everywhere
+    assert S.load_mention_repos(env["repos_path"]) == FAKE_REPOS
+    for name in FAKE_REPOS:
+        assert name not in everywhere, f"SPOOL DISCLOSURE (unattributed run): {name}"
+    for full in FAKE_REPOS.values():
+        assert full not in everywhere, f"SPOOL DISCLOSURE (unattributed run): {full}"
 
 
 def test_summarize_transcript_still_answers_from_the_shared_reader(tmp_path):

--- a/scripts/collector/claude/tests/test_session_tailer.py
+++ b/scripts/collector/claude/tests/test_session_tailer.py
@@ -31,6 +31,10 @@ _COLLECTOR_DIR = _CLAUDE_DIR.parent                            # scripts/collect
 sys.path.insert(0, str(_CLAUDE_DIR))
 sys.path.insert(0, str(_COLLECTOR_DIR))
 import collector as C   # noqa: E402
+# 🔴 THE SAME module object the tailer imports. Asserting the prefilter against a
+# SEPARATELY loaded copy of mention_scan would compare two independent readings
+# and could not see the tailer reading a stale or different one.
+import mention_scan as MS  # noqa: E402
 
 # session-tailer.py has a hyphen → load via importlib (like test_activity_scan.py).
 _spec = importlib.util.spec_from_file_location("session_tailer", _CLAUDE_DIR / "session-tailer.py")
@@ -313,7 +317,15 @@ def env(tmp_path, monkeypatch):
     monkeypatch.setenv("CLAUDE_SUMMARY_STATE", str(state))
     monkeypatch.setenv("CLAUDE_SOURCE_EMIT", str(EMIT))
     monkeypatch.setenv("CLAUDE_PROJECTS_DIR", str(projects))
-    return {"spool": spool, "state": state, "projects": projects}
+    # 🔴 THE REPO MAPPING IS REDIRECTED TO A PATH THAT DOES NOT EXIST. Without
+    # this, `run()` reads the OPERATOR'S REAL ~/.config/mention-open/known_repos
+    # .json — which names PRIVATE repositories — so every attribution assertion
+    # would be a property of that host's disk, and the nix sandbox tier (HOME is
+    # a fresh empty dir) would evaluate it differently from the dev host. That is
+    # the same two-tier divergence `test_mention_open.py` records for WORKSPACE.
+    monkeypatch.setenv("MENTION_OPEN_KNOWN_REPOS", str(tmp_path / "no-mapping.json"))
+    return {"spool": spool, "state": state, "projects": projects,
+            "repos_path": tmp_path / "no-mapping.json"}
 
 
 def _spool_events(spool: Path) -> list[dict]:
@@ -1228,6 +1240,215 @@ def test_an_unreadable_transcript_emits_no_mentions_and_does_not_crash(env):
     assert S.run() == 0
     assert _mentions(env["spool"]) == []
     assert len(_summaries(env["spool"])) == 1
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE INERT-PREFILTER SEAM
+#
+# `_MENTION_HINTS` short-circuits BEFORE the regex pass and skipped 81% of
+# assistant text blocks in one measured 24h window. Every shape below contains
+# NEITHER '#' NOR '868' — the filter's former contents — so under the old value
+# the scanner would never have run on them and every module-level test calling
+# `scan_mentions()` DIRECTLY would still have passed. These are the only tests in
+# the repo that can see that, because they go through `collect_mentions`.
+# --------------------------------------------------------------------------- #
+# 🔴 EVERY FIXTURE NAME IS SYNTHETIC. This repo is public and the real repo
+# mapping names private repositories; nothing measured from this host may appear
+# here. Values are pairwise distinct AND distinct from every constant asserted.
+FAKE_REPOS = {
+    "trowelcast": "gardenersguild/trowelcast",
+    "plotwidget": "hobbyist/plotwidget",
+    "spadeworks": "rivalorg/spadeworks",
+}
+
+# (label, assistant text, expected (platform, id)) — one row per NEW shape.
+NEW_SHAPES = [
+    ("github pull URL", "merged https://github.com/gardenersguild/trowelcast/pull/7",
+     ("github", "7")),
+    ("github issues URL", "see https://github.com/hobbyist/plotwidget/issues/4213",
+     ("github", "4213")),
+    ("slash audit-pr", "next up: /audit-pr 1291", ("github", "1291")),
+    ("bare audit-pr", "next up: audit-pr 1291", ("github", "1291")),
+    ("gh pr subcommand", "ran gh pr view 1291 to check", ("github", "1291")),
+    ("gh issue subcommand", "ran gh issue close 42 after that", ("github", "42")),
+    ("clawgate task", "picked up clawgate task 370 today", ("clawgate", "370")),
+]
+
+
+@pytest.mark.parametrize("label,text,expected",
+                         NEW_SHAPES, ids=[s[0] for s in NEW_SHAPES])
+def test_each_new_shape_REACHES_the_tailer_through_the_prefilter(label, text, expected):
+    """🔴 THE REACHABILITY TEST. Adding the regex alone ships a dead feature: the
+    prefilter drops the block before `scan_mention_spans` is ever called."""
+    got = S.collect_mentions([assistant_text(text)])
+    assert [(m["platform"], m["id"]) for m in got] == [expected], label
+
+
+@pytest.mark.parametrize("label,text,_expected",
+                         NEW_SHAPES, ids=[s[0] for s in NEW_SHAPES])
+def test_every_new_shape_would_have_been_INVISIBLE_to_the_old_prefilter(
+        label, text, _expected):
+    """🔴 THE CONTROL FOR THE TEST ABOVE. If a shape happened to contain a '#' or
+    an '868' anyway, its reachability test would pass with a prefilter that was
+    never widened — green for the wrong reason, proving nothing. This asserts
+    each fixture really is invisible to the OLD value, so the test above can only
+    pass because the filter moved."""
+    assert not any(h in text for h in ("#", "868")), (
+        f"{label}: this fixture is not a witness to the widening")
+
+
+def test_the_prefilter_is_DERIVED_from_the_scanners_telemetry_ledger():
+    """One rule, one place: a pattern added to the ledger widens the filter in
+    the same commit because there is nowhere else to put the fact.
+
+    🔴 AND IT IS THE TELEMETRY PROFILE. `mention_hints()` with no argument
+    returns the terminal profile's two literals — the OLD value — which would
+    look derived, pass review, and skip every new shape."""
+    assert S._MENTION_HINTS == MS.mention_hints(MS.PROFILE_TELEMETRY)
+    assert S._MENTION_HINTS != MS.mention_hints(MS.PROFILE_TERMINAL)
+
+
+def test_the_prefilter_still_SKIPS_a_block_with_no_hint_at_all():
+    """The widening must not become "scan everything" — the short-circuit is the
+    reason this rides in the tailer instead of a per-tool-call hook."""
+    assert S.collect_mentions([assistant_text("nothing to see in this sentence")]) == []
+
+
+def test_the_tailer_scans_with_the_WIDER_profile_not_the_default():
+    """🔴 The second half of the same seam. A correct prefilter plus a default
+    (terminal) profile is also a dead feature, and the prefilter test above
+    cannot see it."""
+    got = S.collect_mentions([assistant_text("ran gh pr view 1291")])
+    assert [m["id"] for m in got] == ["1291"]
+
+
+# --------------------------------------------------------------------------- #
+# Attribution, end to end through the tailer
+# --------------------------------------------------------------------------- #
+def test_an_adjacent_repo_token_is_ATTRIBUTED_through_collect_mentions():
+    """A.2 — the primary defect. 92% of mentions in one measured 24h window were
+    a bare `#N`, and the repo name two words to its left was thrown away."""
+    (m,) = S.collect_mentions([assistant_text("trowelcast PR #1291 is green")],
+                              repos=FAKE_REPOS)
+    assert m["repo"] == "gardenersguild/trowelcast"
+    assert m["repo_source"] == "adjacent"
+
+
+def test_attribution_names_the_repo_ACTUALLY_written():
+    """Three distinct owners, three distinct expectations — a mutant returning a
+    single hardcoded literal dies on two of the three."""
+    for token, expected in (("trowelcast", "gardenersguild/trowelcast"),
+                            ("plotwidget", "hobbyist/plotwidget"),
+                            ("spadeworks", "rivalorg/spadeworks")):
+        (m,) = S.collect_mentions([assistant_text(f"{token} PR #7")],
+                                  repos=FAKE_REPOS)
+        assert m["repo"] == expected, token
+
+
+def test_a_repo_token_ABSENT_from_the_mapping_stays_unattributed():
+    """🔴 THE NO-GUESSING RULE at the tailer's end of the pipe."""
+    (m,) = S.collect_mentions([assistant_text("zzzunknown PR #1291")],
+                              repos=FAKE_REPOS)
+    assert m["repo"] == ""
+    assert m["repo_source"] == ""
+
+
+def test_collect_mentions_without_a_mapping_attributes_nothing_and_still_scans():
+    (m,) = S.collect_mentions([assistant_text("trowelcast PR #1291")])
+    assert m["id"] == "1291"
+    assert m["repo"] == ""
+
+
+def test_a_url_in_the_same_block_attributes_a_bare_ref_through_the_tailer():
+    """A.3, reachable only because `github.com/` is now a prefilter hint."""
+    got = S.collect_mentions([assistant_text(
+        "https://github.com/rivalorg/spadeworks/pull/8 then also #1291")])
+    bare = [m for m in got if m["id"] == "1291"]
+    assert bare and bare[0]["repo"] == "rivalorg/spadeworks"
+    assert bare[0]["repo_source"] == "url"
+
+
+def test_a_repo_flag_in_the_same_block_attributes_through_the_tailer():
+    """A.4 — the measured `gh pr <sub> N --repo owner/repo` case."""
+    (m,) = S.collect_mentions([assistant_text(
+        "gh pr view 1291 --repo hobbyist/plotwidget")])
+    assert m["repo"] == "hobbyist/plotwidget"
+    assert m["repo_source"] == "flag"
+
+
+def test_the_emitted_event_CARRIES_the_attribution(env):
+    """🔴 A FIELD THAT EXISTS IN A DICT IS NOT A COLUMN. The attribution is only
+    worth anything if it survives `build_mention_emit_args` and the spool
+    round-trip — asserting it on `collect_mentions`' return value alone would
+    pin a value nothing ever ships."""
+    p = env["repos_path"]
+    p.write_text(json.dumps(FAKE_REPOS), encoding="utf-8")
+    _write(env["projects"], "-home-zach-workspace-devrc", "sess-ATTR", [
+        user_typed("go"),
+        assistant_text("spadeworks PR #1291 is green",
+                       ts="2026-07-11T10:02:00.000Z"),
+    ])
+    assert S.run() == 0
+    (ev,) = _mentions(env["spool"])
+    payload = json.loads(ev["payload"])
+    assert payload["repo"] == "rivalorg/spadeworks"
+    assert payload["repo_source"] == "adjacent"
+
+
+def test_an_unattributed_mention_still_emits_with_EMPTY_attribution(env):
+    _write(env["projects"], "-home-zach-workspace-devrc", "sess-NOATTR", [
+        user_typed("go"), assistant_text("fixed in #370"),
+    ])
+    assert S.run() == 0
+    (ev,) = _mentions(env["spool"])
+    payload = json.loads(ev["payload"])
+    assert payload["repo"] == ""
+    assert payload["repo_source"] == ""
+
+
+def test_a_new_shape_reaches_the_SPOOL_not_only_collect_mentions(env):
+    """The whole path: transcript -> prefilter -> scanner -> emit -> spool."""
+    _write(env["projects"], "-home-zach-workspace-devrc", "sess-SHAPE", [
+        user_typed("go"), assistant_text("picked up clawgate task 370"),
+    ])
+    assert S.run() == 0
+    (ev,) = _mentions(env["spool"])
+    payload = json.loads(ev["payload"])
+    assert payload["platform"] == "clawgate"
+    assert payload["reference_id"] == "370"
+    assert payload["url"] == "https://clawgate.zacx.dev/tasks/370"
+
+
+# --------------------------------------------------------------------------- #
+# The repo mapping the tailer loads
+# --------------------------------------------------------------------------- #
+def test_the_repo_mapping_path_is_resolved_at_CALL_time(tmp_path, monkeypatch):
+    """🔴 A module CONSTANT is evaluated at import, so `monkeypatch.setenv` would
+    be inert and every test above would silently read the OPERATOR'S REAL
+    mapping — which names private repositories. `scripts/mention-open.py` records
+    this exact defect twice; this is the guard that stops it recurring here."""
+    p = tmp_path / "m.json"
+    p.write_text(json.dumps({"plotwidget": "hobbyist/plotwidget"}), encoding="utf-8")
+    monkeypatch.setenv("MENTION_OPEN_KNOWN_REPOS", str(p))
+    assert S.mention_repos_path() == p
+    assert S.load_mention_repos() == {"plotwidget": "hobbyist/plotwidget"}
+
+
+@pytest.mark.parametrize("body", [
+    "not json", "[]", '"a string"', '{"widget": "acme/widget/"}',
+    '{"widget": 12}', '{"widget": "acme"}',
+])
+def test_an_unusable_mapping_costs_ATTRIBUTION_not_the_telemetry_pass(
+        tmp_path, body):
+    """Every failure is {} — this runs inside a timer-driven collector, and a
+    mapping it cannot read must never stop mentions being emitted."""
+    p = tmp_path / "m.json"
+    p.write_text(body, encoding="utf-8")
+    assert S.load_mention_repos(p) == {}
+
+
+def test_an_absent_mapping_is_an_empty_mapping(tmp_path):
+    assert S.load_mention_repos(tmp_path / "nope.json") == {}
 
 
 def test_summarize_transcript_still_answers_from_the_shared_reader(tmp_path):

--- a/scripts/collector/mention_scan.py
+++ b/scripts/collector/mention_scan.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 """mention_scan — find cross-platform reference MENTIONS in agent output.
 
-PURE. No I/O, no subprocess, no network, stdlib only. Two consumers, one set of
-regexes:
+PURE. No I/O, no subprocess, no network, stdlib only. Two consumers:
 
   * `scripts/collector/claude/session-tailer.py` — emits one telemetry event per
     detected mention into activity.events (source=mentions).
@@ -10,20 +9,75 @@ regexes:
     the matched text; it re-scans that text with the SAME rules and opens (or
     offers) the resolved URL.
 
-Both call this module, so what the terminal underlines and what the telemetry
-records can never drift apart. That is the whole reason this is a module and not
-two regexes.
+🔴 THE TWO CONSUMERS NO LONGER SHARE ONE PATTERN SET, AND THAT IS DELIBERATE.
+This module used to run exactly one set of regexes so that "what the terminal
+underlines" and "what the telemetry records" could never drift apart. That
+invariant is now RELAXED, on purpose, along one axis only: `profile`.
+
+  profile="terminal"  (the DEFAULT)  — today's narrow, click-safe surface. A
+      match here becomes an underlined, clickable span on the operator's screen,
+      so a false positive is a wrong page opening. Unchanged, byte for byte.
+  profile="telemetry" — a WIDER surface, used only by the tailer. A match here
+      becomes one row in a private ClickHouse table, so a false positive costs a
+      stray row and nothing else.
+
+The relaxation is EXPLICIT rather than implicit: every pattern in this module is
+listed in `PATTERN_LEDGER` with the profiles it is consulted in, and
+`scripts/tests/test_mention_scan.py` pins that ledger TWO-WAY — a pattern with no
+entry fails, an entry naming no pattern fails. The default is `terminal`, so a
+caller that says nothing keeps the narrow behaviour.
 
 WHAT IS DETECTED
 ----------------
+Both profiles:
   clickup   868abc123                 -> https://app.clickup.com/t/868abc123
   github    owner/repo#12             -> https://github.com/owner/repo/issues/12
   github    repo#12                   -> owner resolved by the CALLER (see below)
   ambiguous #12                       -> clawgate task 12 OR a GitHub issue 12
 
-A bare `#N` is genuinely ambiguous and this module does NOT pick a winner. It
-returns a candidate per platform and lets the click-time resolver disambiguate
-with facts it can actually measure (the pane's repo). See `scan_mention_spans`.
+profile="telemetry" only — an ENUMERATED widening, never a generic pattern:
+  github    github.com/owner/repo/pull/12   (and /issues/12)
+  github    /audit-pr 12   audit-pr 12
+  github    gh pr view 12  gh issue close 12   (enumerated subcommands)
+  clawgate  clawgate task 12            (`task 12` ALONE is NOT detected)
+  clawgate  #task-12                    (the legacy anchor form)
+
+🔴 WHAT IS DELIBERATELY NOT DETECTED, measured rather than assumed: a bare
+`task N` (179 occurrences in one 24h window, almost all of them prose), a bare
+`PR N`, and abbreviated git shas — a `[0-9a-f]{7,12}` probe over the same window
+returned 520,000 hits. Each of those is a generic pattern, which is exactly the
+shape the ClickUp `DEV-123` note below refuses.
+
+A bare `#N` is genuinely ambiguous BETWEEN PLATFORMS and this module does NOT
+pick a winner. It returns a candidate per platform and lets the click-time
+resolver disambiguate with facts it can actually measure (the pane's repo). See
+`scan_mention_spans`.
+
+ATTRIBUTION — a separate question from ambiguity
+------------------------------------------------
+"Which platform" and "which repository" are different questions. A bare `#N` can
+be attributed to a repository while still being ambiguous between clawgate and
+GitHub, and 92% of the mentions in a measured 24h window were bare `#N`. So
+every candidate and every span now carries `repo` (an `owner/repo`, or "") and
+`repo_source` naming HOW it was resolved, in this priority order:
+
+  "explicit"  an `owner/repo#N` written out in the text            (both profiles)
+  "adjacent"  a repo token immediately before the ref — `devrc PR #1291` —
+              looked up in the caller-measured `repos` mapping     (telemetry)
+  "url"       a `github.com/owner/repo/(pull|issues)/N` URL in the same text
+                                                                   (telemetry)
+  "flag"      a `--repo owner/repo` in the same text               (telemetry)
+  "default"   the caller-supplied `default_repo`                   (both profiles)
+  ""          not attributed
+
+🔴 "url" and "flag" answer only when the text names EXACTLY ONE distinct
+`owner/repo` by that route. Two different repositories in one block is not a
+tie to be broken by position — it is an absence of an answer, and inventing one
+is the failure this whole module is anchored against.
+
+🔴 AND "adjacent" ANSWERS ONLY THROUGH `repos`. A repo token that the caller has
+not MEASURED yields nothing: the ref stays unattributed. There is no default
+org, no "probably his", and no synthesised owner anywhere on this path.
 
 🔴 NO OWNER IS EVER GUESSED. `scripts/check-clickup-addressed/check-completion.py`
 already paid for this lesson in blood — its `KNOWN_REPOS` header records that a
@@ -43,6 +97,21 @@ negative cases are pinned in `scripts/tests/test_mention_scan.py`. Read
 from __future__ import annotations
 
 import re
+from typing import NamedTuple
+
+# --------------------------------------------------------------------------- #
+# Profiles
+# --------------------------------------------------------------------------- #
+# 🔴 `terminal` IS THE DEFAULT, and that is load-bearing. `scripts/mention-open.py`
+# calls this module with no `profile`, so the click surface can only widen if
+# somebody types the word — it cannot widen as a side effect of a change made for
+# the telemetry.
+PROFILE_TERMINAL = "terminal"
+PROFILE_TELEMETRY = "telemetry"
+PROFILES = (PROFILE_TERMINAL, PROFILE_TELEMETRY)
+
+_BOTH = (PROFILE_TERMINAL, PROFILE_TELEMETRY)
+_TELEMETRY_ONLY = (PROFILE_TELEMETRY,)
 
 # --------------------------------------------------------------------------- #
 # URL templates
@@ -163,6 +232,185 @@ BARE_RE = re.compile(_BARE_BEFORE + rf"#(?P<num>{_NUM})" + _NUM_END)
 # as `[A-Z]{2,5}-\d+`.
 CLICKUP_RE = re.compile(r"(?<![0-9A-Za-z_/#-])(?P<id>868[a-z0-9]{6})(?![0-9A-Za-z_-])")
 
+# --------------------------------------------------------------------------- #
+# Telemetry-only patterns (profile="telemetry")
+# --------------------------------------------------------------------------- #
+# In a URL the number is delimited by `/` on the left, so the colour-literal
+# hazard that forces `_NUM` down to 1-5 digits does not exist here. A repo name
+# may also carry dots here for the same reason: `owner/repo` is delimited by
+# slashes, so `foo.js` cannot be confused with `index.html#12`.
+_URL_NUM = r"\d{1,9}"
+_URL_REPO = r"[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,99})"
+
+# `github.com/owner/repo/pull/12` — with or without a scheme, because agent
+# output writes it both ways. Trailing path segments are fine: `/pull/12/files`
+# still names PR 12, so `_NUM_END` deliberately permits a following `/`.
+#
+# 🔴 THIS PATTERN IS ALSO AN ATTRIBUTION SOURCE, not only a mention: it is the
+# one shape that carries a full `owner/repo` with no lookup at all.
+GITHUB_URL_RE = re.compile(
+    r"(?<![0-9A-Za-z_.-])(?:https?://)?github\.com/"
+    rf"(?P<owner>{_OWNER})/(?P<repo>{_URL_REPO})/(?:pull|issues)/"
+    rf"(?P<num>{_URL_NUM})" + _NUM_END
+)
+
+# `/audit-pr 1291` and `audit-pr 1291` — the devrc skill, always invoked with a
+# PR number. `[ \t]+`, never `\s+`: a number on the NEXT line is not an argument.
+AUDIT_PR_RE = re.compile(
+    r"(?<![0-9A-Za-z_/&#.-])/?audit-pr[ \t]+(?P<num>" + _NUM + r")" + _NUM_END)
+
+# `gh pr view 1291`, `gh issue close 42`. 🔴 THE SUBCOMMAND LIST IS AN EXPLICIT
+# ENUMERATION, never `\w+` — that is the same rule the `DEV-123` note above
+# states, applied to a second wordy form. `gh pr create` and `gh pr list` are
+# absent on purpose: neither takes a number.
+#
+# ⚠ EXACTLY ONE SPACE between `gh` and `pr`/`issue`, and the cost is stated
+# rather than hidden: `gh<TAB>pr view 3` and `gh  pr view 3` are NOT detected.
+# That is what lets the ledger declare the honest literals `gh pr` / `gh issue`
+# as pre-filter hints — a `[ \t]+` here would make the only honest hint `gh`,
+# which occurs inside `through`, `right` and `high` and would defeat the filter
+# entirely. A widening that buys nothing and costs 81% of a short-circuit is not
+# a widening.
+GH_CLI_SUBCOMMANDS = (
+    "view", "diff", "checkout", "merge", "close", "reopen", "edit",
+    "comment", "review", "ready", "lock", "unlock", "status",
+)
+GH_CLI_RE = re.compile(
+    r"(?<![0-9A-Za-z_/&#.-])gh (?P<kind>pr|issue)[ \t]+"
+    rf"(?:{'|'.join(GH_CLI_SUBCOMMANDS)})[ \t]+(?P<num>{_NUM})" + _NUM_END)
+
+# 🔴 `task N` IS DETECTED ONLY BEHIND THE LITERAL `clawgate`. A bare `task 5`
+# occurred 179 times in one measured 24h window and is overwhelmingly prose
+# ("the task 5 lines down", "task 3 of 4"). The literal is the anchor; without
+# it there is no pattern here worth having.
+#
+# NO `#` IS ADMITTED between `task` and the digits: `clawgate task #370` is
+# already a bare `#370` span, and letting this pattern claim an overlapping,
+# longer span would emit the same reference twice.
+CLAWGATE_TASK_RE = re.compile(
+    r"(?<![0-9A-Za-z_/&#.-])[Cc]lawgate[ \t]+[Tt]ask[ \t]+"
+    rf"(?P<num>{_NUM})" + _NUM_END)
+
+# The LEGACY clawgate anchor, `#task-370`. See the URL-templates block: nothing
+# here MINTS one, but old links are out in the world (ClickUp comments, docs,
+# activity.events) and reading one is not the same as writing one.
+#
+# 🔴 ITS LEFT GUARD IS DELIBERATELY LOOSER THAN `_BARE_BEFORE`, and this is the
+# whole reason the pattern is not inert. The form occurs almost exclusively as
+# `https://clawgate.zacx.dev/tasks#task-370`, where the character before `#` is a
+# LETTER — the standard guard rejects every real occurrence. It is safe to relax
+# here and nowhere else because `#` is followed by the literal `task-`: GITHUB_RE
+# needs digits after the `#`, BARE_RE needs digits after the `#`, so no other
+# pattern can claim this span and no colour literal can spell it. Only `&` and
+# `#` are excluded (an HTML entity, and a `##` run).
+TASK_ANCHOR_RE = re.compile(rf"(?<![&#])#task-(?P<num>{_NUM})" + _NUM_END)
+
+# --------------------------------------------------------------------------- #
+# Attribution sources (they resolve a repo; they never emit a mention of their own)
+# --------------------------------------------------------------------------- #
+# The connector words allowed between a repo token and the ref. ENUMERATED for
+# the same reason `GH_CLI_SUBCOMMANDS` is: a generic `\w+` would let ANY word
+# stand between them, so `see the devrc thing about #370` would attribute to
+# `devrc`, which the operator never wrote.
+ATTR_CONNECTORS = ("PR", "PRs", "pr", "prs", "issue", "issues",
+                   "Issue", "Issues", "pull", "Pull")
+
+# `devrc PR #1291`, `devrc #1291`. Anchored at the END of the text BEFORE the
+# ref, so it can only ever match a token that is genuinely adjacent to it.
+# `\Z`, not `$`: `$` matches before a trailing newline, which would let a repo
+# token on the PREVIOUS line attribute a ref on this one.
+REPO_BEFORE_RE = re.compile(
+    r"(?<![0-9A-Za-z_/&#.-])"
+    rf"(?P<repo>{_REPO})"
+    rf"(?:[ \t]+(?:{'|'.join(ATTR_CONNECTORS)}))?"
+    r"[ \t]+\Z"
+)
+
+# `--repo owner/repo` / `-R owner/repo`, as written on a `gh` command line.
+REPO_FLAG_RE = re.compile(
+    r"(?<![0-9A-Za-z_-])(?:--repo[ \t=]|-R[ \t])[ \t]*"
+    rf"(?P<owner>{_OWNER})/(?P<repo>{_URL_REPO})(?![0-9A-Za-z_./-])")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE PATTERN LEDGER — one row per compiled pattern in this module
+# --------------------------------------------------------------------------- #
+class _Pat(NamedTuple):
+    """`profiles` the profiles the pattern is consulted in.
+    `role`     "detect" (emits a mention) or "attribute" (resolves a repo only).
+    `hints`    literals, at least one of which appears in ANY text this pattern
+               can match. This is what `mention_hints()` derives the tailer's
+               cheap pre-filter from — see the note on that function.
+    `sample`   a text the pattern MUST match, used by the suite to prove the
+               hints above are honest rather than decorative."""
+    profiles: tuple[str, ...]
+    role: str
+    hints: tuple[str, ...]
+    sample: str
+
+
+PATTERN_LEDGER: dict[str, _Pat] = {
+    "CLICKUP_RE": _Pat(_BOTH, "detect", ("868",), "please look at 868abc123"),
+    "GITHUB_RE": _Pat(_BOTH, "detect", ("#",), "see devrc#591"),
+    "BARE_RE": _Pat(_BOTH, "detect", ("#",), "fixed in #370"),
+    "GITHUB_URL_RE": _Pat(_TELEMETRY_ONLY, "detect", ("github.com/",),
+                          "https://github.com/gardenersguild/trowelcast/pull/7"),
+    "AUDIT_PR_RE": _Pat(_TELEMETRY_ONLY, "detect", ("audit-pr",), "/audit-pr 1291"),
+    "GH_CLI_RE": _Pat(_TELEMETRY_ONLY, "detect", ("gh pr", "gh issue"),
+                      "gh pr view 1291"),
+    "CLAWGATE_TASK_RE": _Pat(_TELEMETRY_ONLY, "detect", ("lawgate",),
+                             "clawgate task 370"),
+    "TASK_ANCHOR_RE": _Pat(_TELEMETRY_ONLY, "detect", ("#task-",),
+                           "https://clawgate.zacx.dev/tasks#task-370"),
+    # Attribution patterns contribute NO hints: neither can produce a mention on
+    # its own, so a text containing only one of them has nothing to emit and
+    # skipping it costs nothing.
+    "REPO_BEFORE_RE": _Pat(_TELEMETRY_ONLY, "attribute", (), "devrc PR "),
+    "REPO_FLAG_RE": _Pat(_TELEMETRY_ONLY, "attribute", (),
+                         "--repo gardenersguild/trowelcast"),
+}
+
+
+# 🔴 EVERY PUBLIC COMPILED PATTERN IN THIS MODULE IS IN EXACTLY ONE OF TWO
+# PLACES: the ledger above, or this set. A pattern in neither fails the suite.
+# This one is not a SCAN pattern at all — it validates a mapping VALUE the caller
+# already holds, so it has no profile and emits no mention. Naming it explicitly
+# is what stops this from being a hole: an escape hatch nobody has to declare is
+# how the next pattern gets added to no ledger at all and is silently never run.
+NON_SCAN_PATTERNS = frozenset({"OWNER_REPO_VALUE_RE"})
+
+
+def patterns_in(profile: str = PROFILE_TERMINAL) -> frozenset[str]:
+    """The ledger names consulted in `profile`. An unknown profile is TERMINAL —
+    the narrow one — because a typo must never silently widen the click surface.
+    """
+    if profile not in PROFILES:
+        profile = PROFILE_TERMINAL
+    return frozenset(n for n, p in PATTERN_LEDGER.items() if profile in p.profiles)
+
+
+def mention_hints(profile: str = PROFILE_TERMINAL) -> tuple[str, ...]:
+    """Literals for a caller's cheap pre-filter: a text containing NONE of them
+    cannot match any detecting pattern enabled in `profile`.
+
+    🔴 THIS EXISTS BECAUSE THE PRE-FILTER IS WHERE A WIDENING GOES TO DIE.
+    `session-tailer.py` short-circuits on these literals BEFORE the regex pass,
+    and it skipped 81% of assistant text blocks in a measured 24h window. Every
+    telemetry-only shape above — `audit-pr 1291`, `gh pr view 1291`,
+    `clawgate task 370` — contains neither `#` nor `868`, so adding the regex
+    alone would have shipped a completely dead feature that still passed every
+    unit test calling `scan_mentions()` directly. Deriving the list from the same
+    ledger the patterns are declared in is what makes that impossible: ONE rule,
+    ONE place.
+    """
+    hints: set[str] = set()
+    for name in patterns_in(profile):
+        entry = PATTERN_LEDGER[name]
+        if entry.role == "detect":
+            hints.update(entry.hints)
+    return tuple(sorted(hints))
+
+
 # Documented residual false positives — the shapes that DO still match, listed so
 # a future widening starts from what is already known rather than rediscovering
 # it. Pinned as a set by the test suite so this comment cannot silently rot.
@@ -172,6 +420,22 @@ _KNOWN_FALSE_POSITIVES = (
     # lands as AMBIGUOUS, so the click shows a picker rather than opening
     # anything wrong, and the telemetry row is one stray row. Accepted.
     "#123",
+)
+
+# The residuals the WIDER profile adds, kept separate because they are not the
+# click surface's problem — nothing here is ever underlined.
+_KNOWN_FALSE_POSITIVES_TELEMETRY = (
+    # 🔴 AN INSTRUCTIONAL EXAMPLE IS CHARACTER-FOR-CHARACTER A REAL INVOCATION.
+    # A runbook, a skill body or a code fence that TEACHES the command spells it
+    # exactly as a session that RAN it, and no rule separates the two. Accepted:
+    # the cost is a stray row in a private table, and the alternative — dropping
+    # the shape — loses the 370 real occurrences measured alongside them.
+    "gh pr view 12",
+    "/audit-pr 12",
+    # A markdown anchor into a document that DOCUMENTS the legacy form. The
+    # relaxed left guard on TASK_ANCHOR_RE is what makes the real
+    # `…/tasks#task-370` case work at all, and it cannot tell the two apart.
+    "[the old anchor](#task-1)",
 )
 
 
@@ -214,22 +478,124 @@ def _resolve_repo(owner: str | None, repo: str, repos: dict | None) -> str:
 
 
 # --------------------------------------------------------------------------- #
+# Repo-map hygiene — ONE definition, shared by every caller that loads one
+# --------------------------------------------------------------------------- #
+# What a mapping VALUE must look like: exactly two segments, nothing else.
+# 🔴 `\Z`, not `$` — `$` matches BEFORE a final newline, so `acme/widget\n`
+# passed and built `github.com/acme/widget\n/issues/12`.
+OWNER_REPO_VALUE_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+
+
+def clean_repo_map(raw) -> dict:
+    """{name: "owner/repo"} keeping only entries whose value is EXACTLY
+    `owner/repo`. Anything else — a wrong type, a trailing slash, an empty middle
+    segment, an embedded newline — is dropped.
+
+    🔴 ONE RULE, ONE PLACE. Both `scripts/mention-open.py` and
+    `scripts/collector/claude/session-tailer.py` load the operator's generated
+    mapping, and each used to need this filter. Counting non-empty segments —
+    the obvious implementation — accepted `acme/widget/`, `acme//widget`, a
+    trailing space and an embedded newline, each of which builds a URL that 404s
+    while looking authoritative. A predicate open-coded at two sites is wrong at
+    one of them; this is the consolidation.
+    """
+    if not isinstance(raw, dict):
+        return {}
+    return {k: v for k, v in raw.items()
+            if isinstance(k, str) and isinstance(v, str)
+            and OWNER_REPO_VALUE_RE.match(v)}
+
+
+# --------------------------------------------------------------------------- #
+# Attribution (telemetry profile only)
+# --------------------------------------------------------------------------- #
+# The ladder, in priority order. Exposed so a consumer can record HOW a mention
+# was attributed rather than only THAT it was.
+SOURCE_EXPLICIT = "explicit"
+SOURCE_ADJACENT = "adjacent"
+SOURCE_URL = "url"
+SOURCE_FLAG = "flag"
+SOURCE_DEFAULT = "default"
+SOURCE_NONE = ""
+
+
+def _sole(values: list[str]) -> str:
+    """The one distinct value in `values`, or "" when there are none or several.
+
+    🔴 SEVERAL IS AN ABSENCE OF AN ANSWER, NOT A TIE TO BREAK. A block naming two
+    different repositories does not tell you which one a bare `#N` belongs to,
+    and picking the nearest — or the first — is a guess wearing a heuristic's
+    clothes. This is the same rule `mention-open.py` applies when a name has two
+    owners, at a different point in the pipeline.
+    """
+    distinct = set(values)
+    return distinct.pop() if len(distinct) == 1 else ""
+
+
+def _adjacent_repo(text: str, start: int, repos: dict | None) -> str:
+    """`owner/repo` for a repo token written immediately before position
+    `start` — `devrc PR #1291` — or "".
+
+    🔴 IT ANSWERS ONLY THROUGH `repos`. The token is whatever word happens to
+    precede the ref, so `fixed in #370` offers `in` and `PR #12` offers `PR`; the
+    caller-measured mapping is the entire guard, and a token it does not hold
+    yields "". That is why this must never fall back to a default org: without
+    the mapping there is no evidence here at all, only a word.
+    """
+    if not repos:
+        return ""
+    m = REPO_BEFORE_RE.search(text[:start])
+    if not m:
+        return ""
+    return _resolve_repo(None, m.group("repo"), repos)
+
+
+def _sole_repo_named_by(pattern, text: str) -> str:
+    """The SOLE distinct `owner/repo` that `pattern` finds in `text`, or "".
+
+    Used for both block-level routes — the `github.com/owner/repo/…` URL and the
+    `--repo owner/repo` flag. They stay SEPARATE calls rather than one merged
+    set because the ladder ranks a URL above a flag: a URL is a reference the
+    agent actually wrote out, a flag is an argument to a command that may have
+    been about something else entirely.
+    """
+    return _sole([f"{m.group('owner')}/{m.group('repo')}"
+                  for m in pattern.finditer(text)])
+
+
+# --------------------------------------------------------------------------- #
 # Public API
 # --------------------------------------------------------------------------- #
+def _github_candidate(num: str, raw: str, start: int, end: int,
+                      repo: str, source: str, ambiguous: bool) -> dict:
+    return {
+        "platform": PLATFORM_GITHUB, "id": num, "raw": raw,
+        "url": _github_url(repo, num), "repo": repo or "",
+        "repo_source": source if repo else SOURCE_NONE,
+        "start": start, "end": end, "ambiguous": ambiguous,
+    }
+
+
 def scan_mentions(text, *, repos: dict | None = None,
-                  default_repo: str | None = None) -> list[dict]:
+                  default_repo: str | None = None,
+                  profile: str = PROFILE_TERMINAL) -> list[dict]:
     """Every mention CANDIDATE in `text`, ordered by position then platform.
 
-    Each dict is `{platform, id, raw, url, start, end, ambiguous}`:
+    Each dict is `{platform, id, raw, url, repo, repo_source, start, end,
+    ambiguous}`:
 
-        platform   "clawgate" | "github" | "clickup" — always a real platform.
-        id         the reference id ("370", "868abc123").
-        raw        the exact matched text ("#370", "civitai/talos-infra#1065").
-        url        the resolved URL, or "" when it cannot be built without
-                   guessing (a GitHub reference whose repo is unknown).
-        start/end  the match span in `text`.
-        ambiguous  True when this candidate SHARES its span with another
-                   platform's candidate, i.e. a bare `#N`.
+        platform    "clawgate" | "github" | "clickup" — always a real platform.
+        id          the reference id ("370", "868abc123").
+        raw         the exact matched text ("#370", "civitai/talos-infra#1065").
+        url         the resolved URL, or "" when it cannot be built without
+                    guessing (a GitHub reference whose repo is unknown).
+        repo        the attributed "owner/repo", or "". GitHub candidates only.
+        repo_source how `repo` was resolved — see the ATTRIBUTION block in the
+                    module docstring. "" exactly when `repo` is "".
+        start/end   the match span in `text`.
+        ambiguous   True when this candidate SHARES its span with another
+                    platform's candidate, i.e. a bare `#N`.
 
     A bare `#N` yields TWO candidates over ONE span (clawgate + github). Use
     `scan_mention_spans` when you want one record per underlined span.
@@ -237,69 +603,127 @@ def scan_mentions(text, *, repos: dict | None = None,
     `repos`        {bare repo name: "owner/repo"} — measured by the caller.
     `default_repo` "owner/repo" for the surrounding context, used only to give a
                    bare `#N` a GitHub URL. Also measured by the caller.
+    `profile`      "terminal" (default, narrow) or "telemetry" (wider). See the
+                   module docstring; an unknown value is treated as "terminal".
     """
     if not isinstance(text, str) or not text:
         return []
 
+    on = patterns_in(profile)
     out: list[dict] = []
 
-    for m in CLICKUP_RE.finditer(text):
-        ident = m.group("id")
-        out.append({
-            "platform": PLATFORM_CLICKUP, "id": ident, "raw": m.group(0),
-            "url": CLICKUP_TASK_URL.format(id=ident),
-            "start": m.start(), "end": m.end(), "ambiguous": False,
-        })
+    # Block-level attribution context, computed ONCE per text rather than per
+    # match — it is a property of the block, not of the reference.
+    url_repo = _sole_repo_named_by(GITHUB_URL_RE, text) if "GITHUB_URL_RE" in on else ""
+    flag_repo = _sole_repo_named_by(REPO_FLAG_RE, text) if "REPO_FLAG_RE" in on else ""
 
-    for m in GITHUB_RE.finditer(text):
-        num = m.group("num")
-        full = _resolve_repo(m.group("owner"), m.group("repo"), repos)
-        out.append({
-            "platform": PLATFORM_GITHUB, "id": num, "raw": m.group(0),
-            "url": _github_url(full, num), "repo": full,
-            "start": m.start(), "end": m.end(), "ambiguous": False,
-        })
+    def _ladder(start: int) -> tuple[str, str]:
+        """(repo, repo_source) for a reference at `start` that names no repo of
+        its own. The priority order is the module docstring's, in one place."""
+        adjacent = _adjacent_repo(text, start, repos) if "REPO_BEFORE_RE" in on else ""
+        for repo, source in ((adjacent, SOURCE_ADJACENT),
+                             (url_repo, SOURCE_URL),
+                             (flag_repo, SOURCE_FLAG),
+                             (default_repo or "", SOURCE_DEFAULT)):
+            if repo:
+                return repo, source
+        return "", SOURCE_NONE
 
-    for m in BARE_RE.finditer(text):
-        num = m.group("num")
-        span = (m.start(), m.end())
-        # ONE span, TWO candidates. They are emitted adjacently and both carry
-        # ambiguous=True, so no consumer can treat either as settled.
-        out.append({
-            "platform": PLATFORM_CLAWGATE, "id": num, "raw": m.group(0),
-            "url": clawgate_url(num),
-            "start": span[0], "end": span[1], "ambiguous": True,
-        })
-        out.append({
-            "platform": PLATFORM_GITHUB, "id": num, "raw": m.group(0),
-            "url": _github_url(default_repo, num), "repo": default_repo or "",
-            "start": span[0], "end": span[1], "ambiguous": True,
-        })
+    if "CLICKUP_RE" in on:
+        for m in CLICKUP_RE.finditer(text):
+            ident = m.group("id")
+            out.append({
+                "platform": PLATFORM_CLICKUP, "id": ident, "raw": m.group(0),
+                "url": CLICKUP_TASK_URL.format(id=ident),
+                "repo": "", "repo_source": SOURCE_NONE,
+                "start": m.start(), "end": m.end(), "ambiguous": False,
+            })
+
+    if "GITHUB_RE" in on:
+        for m in GITHUB_RE.finditer(text):
+            # 🔴 A ref that NAMES a repo is never re-attributed from the block.
+            # An unknown `repo#N` stays unresolved rather than borrowing the
+            # block's other repository — substituting a different repo for the
+            # one the operator wrote is worse than admitting it is unknown.
+            full = _resolve_repo(m.group("owner"), m.group("repo"), repos)
+            out.append(_github_candidate(m.group("num"), m.group(0), m.start(),
+                                         m.end(), full, SOURCE_EXPLICIT, False))
+
+    if "BARE_RE" in on:
+        for m in BARE_RE.finditer(text):
+            num = m.group("num")
+            repo, source = _ladder(m.start())
+            # ONE span, TWO candidates. They are emitted adjacently and both
+            # carry ambiguous=True, so no consumer can treat either as settled.
+            # 🔴 ATTRIBUTION DOES NOT SETTLE THE PLATFORM. Knowing which repo a
+            # `#N` belongs to says nothing about whether it is a GitHub issue or
+            # a clawgate task, so the clawgate candidate survives attribution.
+            out.append({
+                "platform": PLATFORM_CLAWGATE, "id": num, "raw": m.group(0),
+                "url": clawgate_url(num), "repo": "", "repo_source": SOURCE_NONE,
+                "start": m.start(), "end": m.end(), "ambiguous": True,
+            })
+            out.append(_github_candidate(num, m.group(0), m.start(), m.end(),
+                                         repo, source, True))
+
+    if "GITHUB_URL_RE" in on:
+        for m in GITHUB_URL_RE.finditer(text):
+            full = f"{m.group('owner')}/{m.group('repo')}"
+            out.append(_github_candidate(m.group("num"), m.group(0), m.start(),
+                                         m.end(), full, SOURCE_URL, False))
+
+    for name, pattern in (("AUDIT_PR_RE", AUDIT_PR_RE), ("GH_CLI_RE", GH_CLI_RE)):
+        if name not in on:
+            continue
+        for m in pattern.finditer(text):
+            repo, source = _ladder(m.start())
+            out.append(_github_candidate(m.group("num"), m.group(0), m.start(),
+                                         m.end(), repo, source, False))
+
+    for name, pattern in (("CLAWGATE_TASK_RE", CLAWGATE_TASK_RE),
+                          ("TASK_ANCHOR_RE", TASK_ANCHOR_RE)):
+        if name not in on:
+            continue
+        for m in pattern.finditer(text):
+            num = m.group("num")
+            out.append({
+                "platform": PLATFORM_CLAWGATE, "id": num, "raw": m.group(0),
+                "url": clawgate_url(num), "repo": "", "repo_source": SOURCE_NONE,
+                "start": m.start(), "end": m.end(), "ambiguous": False,
+            })
 
     out.sort(key=lambda c: (c["start"], c["platform"]))
     return out
 
 
 def scan_mention_spans(text, *, repos: dict | None = None,
-                       default_repo: str | None = None) -> list[dict]:
+                       default_repo: str | None = None,
+                       profile: str = PROFILE_TERMINAL) -> list[dict]:
     """One record per underlined SPAN, built from `scan_mentions`.
 
-    `{raw, start, end, platform, id, url, ambiguous, candidates, context}` where
-    `platform` is the single owning platform, or "ambiguous" when the span has
-    more than one candidate. `url` is the single candidate's URL, or "" when
-    ambiguous — an ambiguous span has no answer yet, and inventing one is the
-    failure mode this whole module is anchored against.
+    `{raw, start, end, platform, id, url, repo, repo_source, ambiguous,
+    candidates, context}` where `platform` is the single owning platform, or
+    "ambiguous" when the span has more than one candidate. `url` is the single
+    candidate's URL, or "" when ambiguous — an ambiguous span has no answer yet,
+    and inventing one is the failure mode this whole module is anchored against.
+
+    `repo`/`repo_source` are the span's ATTRIBUTION, taken from whichever
+    candidate carries one. They are reported even on an ambiguous span: which
+    repository a `#N` belongs to and which platform owns it are two different
+    questions, and answering the first is not a claim about the second.
 
     This is the shape the telemetry emitter uses: one row per mention, never one
     row per guess.
     """
     by_span: dict[tuple[int, int], list[dict]] = {}
-    for cand in scan_mentions(text, repos=repos, default_repo=default_repo):
+    for cand in scan_mentions(text, repos=repos, default_repo=default_repo,
+                              profile=profile):
         by_span.setdefault((cand["start"], cand["end"]), []).append(cand)
 
     spans: list[dict] = []
     for (start, end), cands in sorted(by_span.items()):
         ambiguous = len(cands) > 1
+        attributed = next((c for c in cands if c.get("repo")), None)
         spans.append({
             "raw": cands[0]["raw"],
             "start": start,
@@ -307,6 +731,8 @@ def scan_mention_spans(text, *, repos: dict | None = None,
             "platform": PLATFORM_AMBIGUOUS if ambiguous else cands[0]["platform"],
             "id": cands[0]["id"],
             "url": "" if ambiguous else cands[0]["url"],
+            "repo": attributed["repo"] if attributed else "",
+            "repo_source": attributed["repo_source"] if attributed else SOURCE_NONE,
             "ambiguous": ambiguous,
             "candidates": [_candidate(c["platform"], c["id"], c["url"]) for c in cands],
             "context": context_for(text, start, end),

--- a/scripts/collector/mention_scan.py
+++ b/scripts/collector/mention_scan.py
@@ -62,6 +62,9 @@ every candidate and every span now carries `repo` (an `owner/repo`, or "") and
 `repo_source` naming HOW it was resolved, in this priority order:
 
   "explicit"  an `owner/repo#N` written out in the text            (both profiles)
+  "mapped"    a bare `repo#N` — the text named the REPO but not the OWNER, and
+              the owner came from the caller-measured `repos` mapping
+                                                                   (both profiles)
   "adjacent"  a repo token immediately before the ref — `devrc PR #1291` —
               looked up in the caller-measured `repos` mapping     (telemetry)
   "url"       a `github.com/owner/repo/(pull|issues)/N` URL in the same text
@@ -69,6 +72,13 @@ every candidate and every span now carries `repo` (an `owner/repo`, or "") and
   "flag"      a `--repo owner/repo` in the same text               (telemetry)
   "default"   the caller-supplied `default_repo`                   (both profiles)
   ""          not attributed
+
+🔴 `explicit` MEANS THE TEXT WROTE THE OWNER OUT, AND NOTHING ELSE. `repo#N` and
+`owner/repo#N` are different evidence: the first is a name the caller's mapping
+resolved, the second is a repository the operator stated. Reporting both as
+`explicit` — which this module did until the distinction was measured — makes an
+analysis that cannot separate "the text said so" from "our mapping said so", i.e.
+one measurement pretending to be two. `mapped` is the second of them.
 
 🔴 "url" and "flag" answer only when the text names EXACTLY ONE distinct
 `owner/repo` by that route. Two different repositories in one block is not a
@@ -394,8 +404,13 @@ def mention_hints(profile: str = PROFILE_TERMINAL) -> tuple[str, ...]:
     cannot match any detecting pattern enabled in `profile`.
 
     🔴 THIS EXISTS BECAUSE THE PRE-FILTER IS WHERE A WIDENING GOES TO DIE.
-    `session-tailer.py` short-circuits on these literals BEFORE the regex pass,
-    and it skipped 81% of assistant text blocks in a measured 24h window. Every
+    `session-tailer.py` short-circuits on these literals BEFORE the regex pass.
+    Re-measured 2026-09-04 over the preceding 24h (10,118 assistant text blocks,
+    312 transcripts): the OLD two literals skipped 8,169 of them = 81%; the
+    telemetry hint set skips 7,990 = 79%, so the short-circuit survives the
+    widening. ⚠ THE PERCENTAGE IS A PROPERTY OF THE WINDOW, NOT OF THE CODE — an
+    earlier window read 82%/80% on 6,052 blocks. Re-measure rather than quote
+    this; what is stable is that the filter still skips ~4 blocks in 5. Every
     telemetry-only shape above — `audit-pr 1291`, `gh pr view 1291`,
     `clawgate task 370` — contains neither `#` nor `868`, so adding the regex
     alone would have shipped a completely dead feature that still passed every
@@ -513,6 +528,10 @@ def clean_repo_map(raw) -> dict:
 # The ladder, in priority order. Exposed so a consumer can record HOW a mention
 # was attributed rather than only THAT it was.
 SOURCE_EXPLICIT = "explicit"
+# 🔴 NOT A SYNONYM FOR `explicit`. The text named the repo but NOT the owner, so
+# the owner is the caller's mapping speaking, not the operator. See the
+# ATTRIBUTION block in the module docstring for why the two must not collapse.
+SOURCE_MAPPED = "mapped"
 SOURCE_ADJACENT = "adjacent"
 SOURCE_URL = "url"
 SOURCE_FLAG = "flag"
@@ -575,6 +594,20 @@ def _sole_repo_named_by(pattern, text: str) -> str:
 # --------------------------------------------------------------------------- #
 def _github_candidate(num: str, raw: str, start: int, end: int,
                       repo: str, source: str, ambiguous: bool) -> dict:
+    # 🔴 `source if repo else SOURCE_NONE` IS A GUARD, NOT A TIDY-UP. The
+    # `repo#N` path passes `SOURCE_MAPPED` with `repo == ""` whenever the
+    # caller's mapping does not hold that name, and without the ternary the
+    # candidate reads `repo_source="mapped"` beside an empty `repo` — a claim
+    # that a resolution happened, next to the evidence that it did not. The
+    # `scan_mentions` docstring's "`""` exactly when `repo` is `""`" contract
+    # lives here and nowhere else.
+    #
+    # ⚠ HONEST SCOPE: it is observable on a CANDIDATE, not on a SPAN.
+    # `scan_mention_spans` takes its `repo_source` from a candidate that HAS a
+    # repo, so it reports "" for this case with or without the ternary — which
+    # is why a span-level test of it SURVIVED a mutation sweep. Both of this
+    # repo's consumers read spans, so the guard defends the public
+    # `scan_mentions` contract rather than a live row today.
     return {
         "platform": PLATFORM_GITHUB, "id": num, "raw": raw,
         "url": _github_url(repo, num), "repo": repo or "",
@@ -620,6 +653,14 @@ def scan_mentions(text, *, repos: dict | None = None,
 
     # Block-level attribution context, computed ONCE per text rather than per
     # match — it is a property of the block, not of the reference.
+    #
+    # 🔴 THE THREE `in on` GUARDS HERE AND IN `_ladder` ARE THE PROFILE SPLIT
+    # ITSELF, not a micro-optimisation. Each one is what keeps a TELEMETRY-only
+    # attribution route out of the terminal profile, and deleting any of them
+    # silently widens the click surface — the exact drift the "one pattern set"
+    # invariant used to prevent. All three are pinned behaviourally by
+    # `test_mention_scan.py::test_no_TELEMETRY_only_attribution_route_answers_in_
+    # the_terminal_profile`, each with its own case, so a deletion goes red.
     url_repo = _sole_repo_named_by(GITHUB_URL_RE, text) if "GITHUB_URL_RE" in on else ""
     flag_repo = _sole_repo_named_by(REPO_FLAG_RE, text) if "REPO_FLAG_RE" in on else ""
 
@@ -651,9 +692,16 @@ def scan_mentions(text, *, repos: dict | None = None,
             # An unknown `repo#N` stays unresolved rather than borrowing the
             # block's other repository — substituting a different repo for the
             # one the operator wrote is worse than admitting it is unknown.
-            full = _resolve_repo(m.group("owner"), m.group("repo"), repos)
+            owner = m.group("owner")
+            full = _resolve_repo(owner, m.group("repo"), repos)
+            # 🔴 THE SOURCE IS DECIDED BY WHETHER THE TEXT WROTE AN OWNER, never
+            # by whether an owner was FOUND. `_resolve_repo` falls through to the
+            # caller's mapping when none was written, and labelling that
+            # `explicit` reports the operator as the author of an owner our own
+            # mapping supplied.
+            source = SOURCE_EXPLICIT if owner else SOURCE_MAPPED
             out.append(_github_candidate(m.group("num"), m.group(0), m.start(),
-                                         m.end(), full, SOURCE_EXPLICIT, False))
+                                         m.end(), full, source, False))
 
     if "BARE_RE" in on:
         for m in BARE_RE.finditer(text):

--- a/scripts/collector/mention_scan.py
+++ b/scripts/collector/mention_scan.py
@@ -542,6 +542,12 @@ def _adjacent_repo(text: str, start: int, repos: dict | None) -> str:
     caller-measured mapping is the entire guard, and a token it does not hold
     yields "". That is why this must never fall back to a default org: without
     the mapping there is no evidence here at all, only a word.
+
+    ⚠ THE GUARD IS `_resolve_repo`, NOT THE EARLY RETURN BELOW. Deleting that
+    return changes no behaviour — `_resolve_repo(None, …, None)` already answers
+    "" — and a mutation sweep scored it SURVIVED for exactly that reason. It is
+    an optimisation (it skips a regex search on the common no-mapping path) and
+    is labelled as one so nobody reads it as the thing that stops a guess.
     """
     if not repos:
         return ""

--- a/scripts/mention-open.py
+++ b/scripts/mention-open.py
@@ -18,7 +18,8 @@ RESOLUTION
 ----------
   1 openable candidate   -> xdg-open it.
   2+ (a bare `#N`)       -> rofi picker, one row per platform, showing the URL.
-  0                      -> a desktop notification saying why. Never a guess.
+  0                      -> the FUZZY repo picker (below), and only if that
+                            cannot run, a desktop notification saying why.
 
 🔴 NOTHING IS GUESSED. A GitHub reference needs an owner, and an owner that is
 wrong points confidently at a real-but-unrelated issue. An owner is accepted
@@ -32,12 +33,33 @@ only from a source that names THIS repo unambiguously:
      it OVERRIDES 2 — the checkout is authoritative about its own owner);
   4. last resort, a GitHub search restricted to an EXACT name match.
 
-When none of them answers, the candidate has no URL and simply does not appear
-in the picker. 🔴 AND WHEN SEVERAL OWNERS ANSWER, THE OPERATOR CHOOSES: a name
-like `dashboard` or `cli` exists under dozens of owners, so an exact-name search
-hit is not the same as an unambiguous one. Several matches means a picker, never
-the first row — that is the same rule as "no owner means no URL", applied to the
-other end of the range.
+🔴 WHEN SEVERAL OWNERS ANSWER, THE OPERATOR CHOOSES: a name like `dashboard` or
+`cli` exists under dozens of owners, so an exact-name search hit is not the same
+as an unambiguous one. Several matches means a picker, never the first row —
+that is the same rule as "no owner means no URL", applied to the other end of
+the range.
+
+🔴 AND WHEN NONE OF THEM ANSWERS, THE OPERATOR STILL CHOOSES — the handler does
+not dead-end. Every repository this host knows about goes into the same rofi
+picker with `-matching fuzzy`, so `talos-inf#12` is four keystrokes from
+`talos-infra` and `kubernetes#1` is a typed narrowing rather than a refusal.
+🔴 THIS IS NOT A RELAXATION OF THE NO-GUESSING RULE, IT IS ITS EXTENSION. A
+picker is a CHOICE the operator makes; a guess is one this script makes for
+them. Nothing below ever opens a URL the operator did not select, and dismissing
+the picker still opens NOTHING.
+
+⚠ IT DEGRADES, IT DOES NOT DISAPPEAR. When the universe cannot be read at all —
+the mapping absent, unreadable or empty, or `--no-discovery` in force — the
+handler falls back to the ORIGINAL refusal, which still names WHICH empty this
+is ("gh is not on PATH" and "no repo by that name" need opposite next moves).
+A silent empty picker would be the same silent zero one layer up.
+
+🔴 THE UNIVERSE NAMES PRIVATE REPOSITORIES. It is built from
+`known_repos.json`, the file whose committed ancestor disclosed 232 private
+repos into this PUBLIC repository. It may go to the operator's own screen and
+NOWHERE ELSE: never to a log, never to activity.events, never to a test fixture,
+never to stderr. `notify()` prints, so the refusal paths below name only the
+clicked text — never a row from the universe.
 """
 from __future__ import annotations
 
@@ -56,6 +78,8 @@ from mention_scan import (  # noqa: E402
     PLATFORM_CLAWGATE,
     PLATFORM_CLICKUP,
     PLATFORM_GITHUB,
+    OWNER_REPO_VALUE_RE as _OWNER_REPO_RE,
+    clean_repo_map,
     scan_mention_spans,
 )
 
@@ -95,14 +119,25 @@ _HTTP_REMOTE = re.compile(r"^https?://[^/]+/(?P<path>.+?)(?:\.git)?/?$")
 # of a longer string.
 _PASS3_REPO_RE = re.compile(r"^(?P<repo>[A-Za-z0-9][A-Za-z0-9._-]*)#(?P<num>\d+)$")
 
-# Above this many exact namesakes the picker stops being a choice. Measured:
-# `dashboard` and `cli` each return a full page of exact matches.
-PASS3_MAX_CHOICES = 8
+# 🔴 THERE IS NO LONGER A CAP ON HOW MANY NAMESAKES REACH THE PICKER, AND THIS
+# PARAGRAPH REPLACES ONE THAT ARGUED FOR IT. The old rule refused above 8, on the
+# reasoning that "a 100-row list of URLs differing only by owner is not a choice,
+# it is a wall". That reasoning was correct about a list you can only SCROLL and
+# wrong about one you can TYPE AT: `-matching fuzzy` turns the wall into a
+# narrowing, so `kubernetes#1` — which used to refuse outright, naming 65
+# namesakes — is now four keystrokes from the right owner.
+#
+# 🔴 DO NOT RE-ADD THE CAP WITHOUT ALSO REMOVING THE FUZZY MATCHER. A comment
+# left asserting a hazard the code has closed is exactly how the refusal would
+# come back: the next maintainer reads "not a choice, it is a wall", believes it,
+# and restores a limit that now only removes the operator's ability to choose.
+# The residual cost, stated rather than hidden: the picker can be long, and one
+# page of search results is still one page (see `gh_api_repo_search`).
 
-# What a mapping VALUE must look like: exactly two segments, nothing else.
-# 🔴 `\Z`, not `$` — `$` matches BEFORE a final newline, so `acme/widget\n`
-# passed and built `github.com/acme/widget\n/issues/12`.
-_OWNER_REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+# `_OWNER_REPO_RE` is IMPORTED, not re-declared — see the import block. It used
+# to be a second copy of `mention_scan`'s rule, which is exactly the shape that
+# regenerates one bug at two sites; the `\Z`-not-`$` incident is recorded on the
+# surviving definition.
 
 
 def parse_owner_repo(remote_url: str) -> str:
@@ -144,6 +179,35 @@ def picker_rows(candidates: list[dict]) -> list[str]:
         label = PLATFORM_LABEL.get(c["platform"], c["platform"])
         rows.append(f"{label} {c['id']} — {c['url']}")
     return rows
+
+
+def repo_universe(repos: dict | None) -> list[str]:
+    """Every distinct `owner/repo` this host knows about, sorted.
+
+    The input is `discover_repos()`'s mapping — the generated file laid under the
+    real local checkouts — so this is a MEASUREMENT of the host, not a list of
+    plausible names. Values that are not exactly `owner/repo` are dropped for the
+    same reason they are dropped on load: they build a URL that 404s while
+    looking authoritative.
+
+    🔴 THE RETURN VALUE NAMES PRIVATE REPOSITORIES. It may reach the operator's
+    rofi window and nothing else — no log line, no notification body, no
+    telemetry row, no test fixture. See the module docstring.
+    """
+    return sorted({v for v in (repos or {}).values()
+                   if isinstance(v, str) and _OWNER_REPO_RE.match(v)})
+
+
+def universe_candidates(num: str, universe: list[str]) -> list[dict]:
+    """One openable GitHub candidate per repository in `universe`.
+
+    These are what turns a dead end into a choice: the operator types a few
+    characters of the repo name into the fuzzy picker instead of reading a
+    refusal. Nothing here is opened without a selection.
+    """
+    return [{"platform": PLATFORM_GITHUB, "id": num,
+             "url": GITHUB_ISSUE_URL.format(repo=full, id=num)}
+            for full in universe]
 
 
 def row_to_url(row: str, candidates: list[dict]) -> str:
@@ -199,14 +263,11 @@ def load_known_repos(path: Path | None = None) -> dict[str, str]:
         raw = json.loads(path.read_text())
     except (OSError, ValueError):
         return {}
-    if not isinstance(raw, dict):
-        return {}
-    # A value must be EXACTLY `owner/repo` — matched, not counted. Counting
-    # non-empty segments accepted `acme/widget/`, `acme//widget`, a trailing
-    # space and an embedded newline, each of which builds a URL that 404s while
-    # looking authoritative: the very failure the rule exists to prevent.
-    return {k: v for k, v in raw.items()
-            if isinstance(k, str) and isinstance(v, str) and _OWNER_REPO_RE.match(v)}
+    # A value must be EXACTLY `owner/repo` — matched, not counted. That rule now
+    # lives ONCE, in `mention_scan.clean_repo_map`, because the collector's
+    # tailer loads the same mapping and a predicate open-coded at two sites is
+    # wrong at one of them.
+    return clean_repo_map(raw)
 
 
 def discover_repos(workspace: Path | None = None) -> dict:
@@ -353,11 +414,23 @@ def open_url(url: str) -> int:
 
 def pick(candidates: list[dict]) -> str:
     """Ask rofi which candidate to open. Returns the chosen URL, or "" if the
-    operator dismissed the picker (which must open NOTHING)."""
+    operator dismissed the picker (which must open NOTHING).
+
+    🔴 `-matching fuzzy` IS LOAD-BEARING, not a nicety. It is the entire reason
+    the namesake cap could be removed and the reason a hundred-row universe is a
+    narrowing rather than a wall: the operator types `talos-inf` and the list
+    collapses. Removing this flag silently restores the wall the old cap existed
+    to prevent, with every test still green — so it is pinned by the suite.
+
+    🔴 `-no-custom` is equally load-bearing in the other direction: it stops rofi
+    returning free text the operator TYPED as if it were a selection, which
+    `row_to_url` would then fail to match — dismissal-shaped, but by accident.
+    """
     rows = picker_rows(candidates)
     try:
         r = subprocess.run(
-            ["rofi", "-dmenu", "-i", "-p", "mention", "-theme", ROFI_THEME,
+            ["rofi", "-dmenu", "-i", "-matching", "fuzzy",
+             "-p", "mention", "-theme", ROFI_THEME,
              "-format", "s", "-no-custom"],
             input="\n".join(rows), capture_output=True, text=True, timeout=120)
     except (OSError, subprocess.SubprocessError) as exc:
@@ -416,10 +489,15 @@ def main(argv: list[str] | None = None) -> int:
     # of `git remote` calls plus a tmux round-trip, and paying that before
     # opening a link that needed neither is latency the operator feels on every
     # single click.
+    discovered: dict = {}
     needs_measuring = span is not None and (span["ambiguous"] or not candidates)
     if needs_measuring and not args.no_discovery:
         default_repo = args.default_repo or tmux_pane_repo()
-        span, candidates = resolve(text, repos=discover_repos(),
+        # Kept, not recomputed: PASS 4 offers the SAME measurement as a fuzzy
+        # universe, and calling `discover_repos()` twice would run the whole
+        # `git remote` fan-out again for an answer already in hand.
+        discovered = discover_repos()
+        span, candidates = resolve(text, repos=discovered,
                                    default_repo=default_repo or None)
 
     if span is None:
@@ -435,21 +513,65 @@ def main(argv: list[str] | None = None) -> int:
         m = _PASS3_REPO_RE.match(span["raw"])
         if m:
             matches, why = gh_api_repo_search(m.group("repo"))
-            if len(matches) > PASS3_MAX_CHOICES:
-                # A 100-row list of URLs differing only by owner is not a
-                # choice, it is a wall. Refusing names the one thing that does
-                # resolve it, instead of pretending the list is useful.
-                notify(f"cannot resolve {span['raw']}",
-                       f"at least {len(matches)} repositories are named "
-                       f"{m.group('repo')} (one page of results — there may be "
-                       f"many more) — write it as owner/repo#N")
-                return 1
+            # 🔴 EVERY match goes to the picker — there is no cap any more. See
+            # the note where `PASS3_MAX_CHOICES` used to be: a list you can type
+            # at is a choice, so refusing above an arbitrary count now removes
+            # the operator's ability to choose rather than protecting them from
+            # a wall.
             candidates = [
                 {"platform": PLATFORM_GITHUB, "id": m.group("num"),
                  "url": GITHUB_ISSUE_URL.format(repo=full, id=m.group("num")),
                  "raw": span["raw"]}
                 for full in sorted(matches)
             ]
+
+    # PASS 4 — THE FUZZY UNIVERSE. Everything above has failed to name a
+    # repository, and the old behaviour here was a refusal. Offer every repo the
+    # host knows about instead and let the operator type at it.
+    #
+    # 🔴 NOT IN `--print` MODE, and not under `--no-discovery`. `--print` exists
+    # so a script can read the resolved URL; answering it with several hundred
+    # is not an answer, and `--no-discovery` means "resolve only what the text
+    # itself carries", which a host-wide mapping is not.
+    #
+    # ⚠ IT NEEDS A NUMBER. Only a numeric reference can be turned into an issue
+    # URL under a chosen repo; there is no such thing as "this ClickUp id, but in
+    # that repository". A ClickUp span always resolves anyway, so this is a guard
+    # rather than a branch anyone reaches.
+    #
+    # 🔴 A UNIVERSE ROW IS NEVER OPENED WITHOUT A SELECTION, EVEN WHEN IT IS THE
+    # ONLY ONE. `offered_universe` exists solely to suppress the "exactly one
+    # candidate → just open it" shortcut below. Without it, a host that knows
+    # exactly ONE repository would answer `trowelcast#77` by opening issue 77 in
+    # that unrelated repository — a confident wrong page, which is precisely the
+    # failure this whole handler is anchored against. A search hit is evidence
+    # ABOUT THE NAME; a universe row is not evidence about anything, only an
+    # option. Measured during development: the first version of PASS 4 did open
+    # it, and the test that caught it was the one asserting a picker appeared.
+    offered_universe = False
+    may_offer_universe = not args.print_only and not args.no_discovery
+    if may_offer_universe and span["id"].isdigit():
+        universe = universe_candidates(span["id"], repo_universe(discovered))
+        if not candidates and universe:
+            offered_universe = True
+            # Dead end 1 and 2 — a namesake wall, or a search that matched
+            # nothing. Either way the operator now gets a choice.
+            #
+            # 🔴 THE PICKER DOES NOT SWALLOW `why`. A search that could not RUN
+            # ("gh is not on PATH", rate-limited, timed out) is a fact about the
+            # operator's tooling that the picker cannot express, and the whole
+            # "say WHICH empty this is" discipline would be lost if offering a
+            # choice silently replaced it. So the cause is announced AND the
+            # choice is offered — they are answers to different questions.
+            if why:
+                notify("the repository search could not run", why)
+            candidates = universe
+        elif span["ambiguous"] and not any(
+                c["platform"] == PLATFORM_GITHUB for c in candidates):
+            # Dead end 3 — a bare `#N` nothing could attribute. The clawgate
+            # candidate STAYS FIRST so the common case is still one Enter away;
+            # the universe is appended as the way to say "no, GitHub, this repo".
+            candidates = candidates + universe
 
     if not candidates:
         # 🔴 SAY WHICH EMPTY THIS IS. "gh is not on PATH" and "no repo by that
@@ -469,7 +591,12 @@ def main(argv: list[str] | None = None) -> int:
             print(c["url"])
         return 0
 
-    if len(candidates) == 1:
+    # 🔴 `and not offered_universe`: see PASS 4. One candidate is enough to open
+    # only when that candidate is EVIDENCE about the reference — an explicit
+    # owner, a measured checkout, an exact-name search hit. A universe row is an
+    # OPTION, and a host that happens to know exactly one repository must not
+    # have that option opened for it.
+    if len(candidates) == 1 and not offered_universe:
         return open_url(candidates[0]["url"])
 
     url = pick(candidates)

--- a/scripts/mention-open.py
+++ b/scripts/mention-open.py
@@ -467,7 +467,20 @@ def resolve(text: str, *, repos: dict | None = None,
 
     Alacritty's looser regex can hand over text with leading/trailing debris; the
     scanner finds the mention inside it. A text with no mention at all — which is
-    how `#282828` arrives here — returns (None, [])."""
+    how `#282828` arrives here — returns (None, []).
+
+    🔴 NO `profile=` ARGUMENT, AND THAT OMISSION IS THE CLICK SURFACE'S ONLY
+    DEFENCE. `mention_scan`'s default is `terminal` — the narrow, click-safe set
+    — and this is the single call site that decides which surface the operator's
+    terminal underlines. Passing `profile="telemetry"` here would put the WIDE
+    enumerated set (`gh pr view N`, `clawgate task N`, bare GitHub URLs, and the
+    telemetry-only attribution routes) behind a click, where a false positive is
+    a wrong page opening rather than a stray row. Pinned by
+    `test_mention_open.py::test_every_TELEMETRY_only_shape_is_invisible_to_the_
+    click_handler`, which drives each telemetry-only pattern's own ledger sample
+    through here and requires it to resolve to NOTHING — with a positive control
+    proving the same sample IS detected at the telemetry profile, so the test
+    cannot pass by scanning nothing."""
     spans = scan_mention_spans(text, repos=repos, default_repo=default_repo)
     if not spans:
         return (None, [])
@@ -518,6 +531,20 @@ def main(argv: list[str] | None = None) -> int:
             # at is a choice, so refusing above an arbitrary count now removes
             # the operator's ability to choose rather than protecting them from
             # a wall.
+            #
+            # 🔴 AND THIS PASS IS REACHED IN `--print` MODE TOO — DELIBERATE, and
+            # stated because removing the cap CHANGED IT. `--print widget#12`
+            # with nine namesakes used to exit 1 with a named refusal ("more than
+            # 8 owners"); it now prints nine URLs and exits 0. That is the
+            # documented contract of the flag — "print every candidate when
+            # ambiguous" — and a namesake set IS ambiguity of exactly the kind
+            # the picker exists for: every row is an EXACT-name search hit, i.e.
+            # evidence about the name the operator typed. It is not the PASS 4
+            # universe, which is evidence about nothing and stays barred from
+            # `--print`. A consumer wanting a single answer must write
+            # `owner/repo#N`; one line of output was never promised here.
+            # Pinned by `test_print_mode_prints_EVERY_namesake_rather_than_
+            # refusing_above_a_cap`.
             candidates = [
                 {"platform": PLATFORM_GITHUB, "id": m.group("num"),
                  "url": GITHUB_ISSUE_URL.format(repo=full, id=m.group("num")),

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1681,7 +1681,24 @@ TARGET_FLOORS=(
   # HERMETIC_TARGETS entry because scripts/collector/claude/tests is already a
   # directory target, and movement on THIS line is the evidence the gate runs
   # the new file at all.
-  "scripts/collector/claude/tests|164"
+  #
+  # 2026-09-04, the mention-attribution fix round (devrc#1313): 223 -> 230
+  # collected, all seven in test_session_tailer.py — the dedupe key now carries
+  # the attribution (3), and the tailer gains its FIRST mapping-disclosure guard
+  # at the spool (2), plus the migration pins (2).
+  # 🔴 THE GATE FORCED THIS ONE — 230 is above the drift ceiling (floor 164 +
+  # max(60, 164/4) = 224), so the run went RED on the ceiling check with all 230
+  # PASSING, which is exactly what that check exists for: the floor had fallen
+  # 59 behind before this branch touched the target. Number copied VERBATIM from
+  # the line the gate printed on the MERGED tree (this branch merged with
+  # origin/main at f75c92d4):
+  #
+  #   Raise the TARGET_FLOORS entry to "scripts/collector/claude/tests|219"
+  #
+  # — that is the run's own count through the documented rule
+  # (230 - min(50, max(1, 230/20 = 11)) = 219), not arithmetic anyone did by
+  # hand. ⚠ ZERO new skips on this target.
+  "scripts/collector/claude/tests|219"
   "scripts/collector/i3/tests|12"
   "scripts/collector/browser-ext/tests|12"
   "scripts/collector/opencode/tests|162"

--- a/scripts/tests/mutation_battery_mentions.py
+++ b/scripts/tests/mutation_battery_mentions.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Mutation battery for the MENTION pipeline — scanner, tailer and hint handler.
+
+    python3 scripts/tests/mutation_battery_mentions.py
+
+🔴 NOT COLLECTED BY THE GATE, ON PURPOSE — and the filename is the mechanism:
+`scripts/run-tests.sh` collects `test_*.py` only. This is a MANUAL instrument,
+run when the mention pipeline changes: it rewrites tracked source in place, one
+mutant at a time, and runs the three mention suites after each. A gate that edits
+tracked source is a gate nobody can run concurrently.
+
+WHY IT IS COMMITTED. PR #1313's round-1 sweep lived in /tmp, so the auditor could
+not re-run it and built their own — which found four guards the first sweep had
+not imagined, including a `profile="telemetry"` mutant at the click surface that
+the whole 313-test suite tolerated. A mutation result quoted from an instrument
+the reader cannot run is a claim, not evidence. This makes it evidence.
+
+🔴 IT SPANS THREE FILES, which is what this battery adds over its two siblings.
+The defect class it exists for is a SEAM: `mention_scan.py` decides what may be
+detected, `session-tailer.py` decides what is recorded, and `mention-open.py`
+decides what is clicked — and every round-1 survivor lived at one of those joins,
+not inside one file. So `TARGETS` names a file per mutant and
+`scripts/tests/test_mutation_battery_anchors.py` (which IS collected) reads it,
+so a row whose anchor stops occurring exactly once fails the push rather than
+scoring a silent SURVIVED for whoever next runs this by hand.
+
+READ BEFORE TRUSTING A VERDICT:
+
+  * The CONTROL runs first and aborts on a red OR EMPTY baseline. A zero is
+    indistinguishable from a probe wired to nothing until something makes the
+    number move.
+  * `P1` is the POSITIVE CONTROL — a mutant that MUST die, breaking a URL every
+    suite reads. A run in which P1 survives is a broken battery, not a clean
+    sweep, and the final line says so.
+  * Every run sets `PYTHONDONTWRITEBYTECODE=1`. CPython validates a cached module
+    on mtime-in-whole-SECONDS plus size, so a same-length edit landing inside one
+    second of the last import is invisible: the suite would import the ORIGINAL
+    bytecode and the mutant would be scored SURVIVED without ever executing.
+    Several rows here ARE same-length-ish edits.
+  * A mutant whose pattern is NOT FOUND is reported as such and counted as a
+    problem. Silent non-application is how a battery reports a clean sweep of
+    mutations it never made.
+  * SURVIVED does not mean "the code is wrong". It means "no test can see this
+    change" — usually a missing test, occasionally genuinely-equivalent code.
+  * THREE KILL VERDICTS. `KILLED` is "the suite went red". A row carrying an
+    `expected` phrase reports `KILLED(attributed)` only when that phrase appears
+    in pytest's `E ` lines, and `KILLED-WRONG-REASON` otherwise — the latter is a
+    FAILURE of this battery, counted with the survivors, because the row's named
+    assertion is not the one that went red. Nearly every row here carries one:
+    these mutants redden broad swathes of the suite, so a bare kill would not
+    show that the guard the row is about is the guard that fired.
+  * Sources are restored in a `finally` AND the restore is verified by hash, so
+    an abort mid-run cannot leave a mutated tree behind unreported.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+SCAN = ROOT / "scripts/collector/mention_scan.py"
+TAILER = ROOT / "scripts/collector/claude/session-tailer.py"
+OPEN_ = ROOT / "scripts/mention-open.py"
+
+# The primary target, for the shared anchor checker's single-file affordances.
+SCRIPT = SCAN
+
+SUITES = (
+    "scripts/tests/test_mention_scan.py",
+    "scripts/tests/test_mention_open.py",
+    "scripts/collector/claude/tests/test_session_tailer.py",
+)
+
+# (id, shape, description, old, new[, expected]) — `old` must occur EXACTLY once
+# in that row's TARGETS file. Same contract as the two sibling batteries; the
+# only addition is that the file is per-row rather than module-wide.
+MUTANTS: list[tuple] = [
+    # ---- POSITIVE CONTROL --------------------------------------------------
+    ("P1", "control", "break a URL every suite reads — MUST be killed",
+     'CLAWGATE_TASKS_URL = "https://clawgate.zacx.dev/tasks"',
+     'CLAWGATE_TASKS_URL = "https://example.invalid/tasks"'),
+
+    # ---- F1: the dedupe identity discards the attribution -------------------
+    ("K1", "deletion", "the key drops the repo again (the round-1 defect): two "
+                       "repositories referencing one number collapse to one row",
+     '    return f"{m[\'platform\']}:{m[\'raw\']}@{repo}" if repo else f"{m[\'platform\']}:{m[\'raw\']}"\n',
+     '    return f"{m[\'platform\']}:{m[\'raw\']}"\n',
+     "dropped a second repository's reference"),
+    ("K2", "widening", "the suffix becomes UNCONDITIONAL, re-keying every "
+                       "already-emitted mention on both hosts",
+     '    return f"{m[\'platform\']}:{m[\'raw\']}@{repo}" if repo else f"{m[\'platform\']}:{m[\'raw\']}"\n',
+     '    return f"{m[\'platform\']}:{m[\'raw\']}@{repo}"\n',
+     "the unattributed key format MOVED"),
+    ("K3", "operand swap", "the key uses the bare id instead of the raw text",
+     '    return f"{m[\'platform\']}:{m[\'raw\']}@{repo}" if repo else f"{m[\'platform\']}:{m[\'raw\']}"\n',
+     '    return f"{m[\'platform\']}:{m[\'id\']}@{repo}" if repo else f"{m[\'platform\']}:{m[\'id\']}"\n',
+     "keyed on the id, not the raw text"),
+
+    # ---- F2: `explicit` reported for an owner nobody wrote ------------------
+    ("K4", "deletion", "the mapping-resolved path is labelled `explicit` again",
+     "            source = SOURCE_EXPLICIT if owner else SOURCE_MAPPED\n",
+     "            source = SOURCE_EXPLICIT\n",
+     "a MAPPING-resolved repo is reported as if the text stated it"),
+    ("K5", "widening", "`mapped` is spelled `explicit`, so the two collapse "
+                       "again one level down",
+     'SOURCE_MAPPED = "mapped"\n', 'SOURCE_MAPPED = "explicit"\n',
+     "a MAPPING-resolved repo is reported as if the text stated it"),
+    ("K6", "deletion", "drop the `source if repo else SOURCE_NONE` guard, so an "
+                       "UNRESOLVED `repo#N` claims `repo_source=mapped`",
+     '        "repo_source": source if repo else SOURCE_NONE,\n',
+     '        "repo_source": source,\n',
+     "claims a resolution that did not happen"),
+
+    # ---- F3: the profile split, at all four enforcement sites ---------------
+    ("K7", "deletion", "the ADJACENT attribution route runs in the terminal "
+                       "profile too",
+     '        adjacent = _adjacent_repo(text, start, repos) if "REPO_BEFORE_RE" in on else ""\n',
+     "        adjacent = _adjacent_repo(text, start, repos)\n",
+     "the adjacent attribution route answered in the TERMINAL profile"),
+    ("K8", "deletion", "the URL attribution route runs in the terminal profile",
+     '    url_repo = _sole_repo_named_by(GITHUB_URL_RE, text) if "GITHUB_URL_RE" in on else ""\n',
+     "    url_repo = _sole_repo_named_by(GITHUB_URL_RE, text)\n",
+     "the url attribution route answered in the TERMINAL profile"),
+    ("K9", "deletion", "the --repo FLAG attribution route runs in the terminal "
+                       "profile",
+     '    flag_repo = _sole_repo_named_by(REPO_FLAG_RE, text) if "REPO_FLAG_RE" in on else ""\n',
+     "    flag_repo = _sole_repo_named_by(REPO_FLAG_RE, text)\n",
+     "the flag attribution route answered in the TERMINAL profile"),
+    ("K10", "widening", "the CLICK handler scans at the telemetry profile — the "
+                        "wide surface becomes clickable",
+     "    spans = scan_mention_spans(text, repos=repos, default_repo=default_repo)\n",
+     "    spans = scan_mention_spans(text, repos=repos, default_repo=default_repo,\n"
+     '                               profile="telemetry")\n',
+     "reached the CLICK surface"),
+
+    # ---- F4: the disclosure guard's two blind paths -------------------------
+    ("K11", "disclosure", "the REFUSAL notify offers the universe as a hint — "
+                          "the path `--print` reaches and PASS 4 does not",
+     "        notify(f\"cannot resolve {span['raw']}\", detail)\n",
+     "        notify(f\"cannot resolve {span['raw']}\",\n"
+     '               detail + " known: " + ", ".join(repo_universe(discovered)))\n',
+     "REFUSAL-PATH DISCLOSURE"),
+    ("K12", "disclosure", "the picker path logs the universe to stdout",
+     "            candidates = universe\n",
+     '            print("universe:", repo_universe(discovered))\n'
+     "            candidates = universe\n",
+     "PICKER-PATH DISCLOSURE"),
+    ("K13", "disclosure", "the emit line ships the WHOLE mapping beside the one "
+                          "repo the mention was attributed to",
+     "        f\"b64:repo={m.get('repo', '')}\",\n",
+     "        f\"b64:repo={m.get('repo', '')}\",\n"
+     '        f"b64:known_repos={sorted(load_mention_repos().values())}",\n',
+     "SPOOL DISCLOSURE (attributed run)"),
+    ("K14", "disclosure", "the mapping rides along in `context`, on a mention "
+                          "with NO attribution at all",
+     "        f\"b64:context={m['context']}\",\n",
+     "        f\"b64:context={m['context']} {sorted(load_mention_repos())}\",\n",
+     "SPOOL DISCLOSURE (unattributed run)"),
+
+    # ---- the nit list: live, reachable, previously untested ------------------
+    ("K15", "deletion", "TASK_ANCHOR_RE loses its `(?<![&#])` left guard, so an "
+                        "HTML entity and a `##` run both parse as the anchor",
+     'TASK_ANCHOR_RE = re.compile(rf"(?<![&#])#task-(?P<num>{_NUM})" + _NUM_END)\n',
+     'TASK_ANCHOR_RE = re.compile(rf"#task-(?P<num>{_NUM})" + _NUM_END)\n',
+     "the legacy-anchor left guard is gone"),
+]
+
+TARGETS: dict[str, pathlib.Path] = {
+    "P1": SCAN,
+    "K1": TAILER, "K2": TAILER, "K3": TAILER,
+    "K4": SCAN, "K5": SCAN, "K6": SCAN,
+    "K7": SCAN, "K8": SCAN, "K9": SCAN, "K10": OPEN_,
+    "K11": OPEN_, "K12": OPEN_, "K13": TAILER, "K14": TAILER,
+    "K15": SCAN,
+}
+
+
+def _digest(path: pathlib.Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
+
+
+def run_suite(messages: bool = False) -> tuple[int, int, list[str], str]:
+    """Run the three mention suites once. Returns (failed, passed, killers, msgs).
+
+    🔴 ONLY THE `E ` LINES COUNT AS "THE MESSAGE". Under `--tb=short` pytest also
+    echoes the SOURCE of the failing statement, which for an assert carrying an
+    f-string message contains that message's literal text — so matching the whole
+    output would report a right-reason kill for a test that never evaluated the
+    assertion. pytest prefixes rendered assertion lines with `E `.
+    """
+    env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+    r = subprocess.run(
+        [sys.executable, "-m", "pytest", *SUITES, "-p", "no:cacheprovider",
+         "--tb=short" if messages else "--tb=no", "-q"],
+        cwd=ROOT, capture_output=True, text=True, env=env, timeout=1800,
+    )
+    out = r.stdout
+    killers = sorted({ln.split("::")[1].split("[")[0]
+                      for ln in out.splitlines()
+                      if ln.startswith("FAILED") and "::" in ln})
+    nfail = int(m.group(1)) if (m := re.search(r"(\d+) failed", out)) else 0
+    npass = int(m.group(1)) if (m := re.search(r"(\d+) passed", out)) else 0
+    msgs = "\n".join(ln for ln in out.splitlines() if ln.startswith("E "))
+    return nfail, npass, killers, msgs
+
+
+def main() -> int:
+    files = sorted({p for p in TARGETS.values()}, key=str)
+    orig = {p: p.read_text(encoding="utf-8") for p in files}
+    before = {p: _digest(p) for p in files}
+    try:
+        nf, np_, _, _ = run_suite()
+        print(f"CONTROL (pristine): {np_} passed, {nf} failed")
+        # 🔴 BOTH halves. A green-looking zero is what a battery wired to
+        # nothing reports.
+        if nf or np_ < 200:
+            print("ABORT — baseline is red or collected nothing; no verdict "
+                  "below would mean anything")
+            return 1
+
+        problems: list[str] = []
+        for row in MUTANTS:
+            mid, shape, desc, old, new = row[:5]
+            expected = row[5] if len(row) > 5 else None
+            target = TARGETS[mid]
+            text = orig[target]
+            n = text.count(old)
+            if n != 1:
+                print(f"{mid:4} {shape:12} !! PATTERN OCCURS {n}x in "
+                      f"{target.name} — NOT APPLIED — {desc}")
+                problems.append(mid)
+                continue
+            target.write_text(text.replace(old, new), encoding="utf-8")
+            try:
+                nf, _np, killers, msgs = run_suite(messages=expected is not None)
+            finally:
+                target.write_text(text, encoding="utf-8")
+            if not nf:
+                verdict = "SURVIVED"
+                problems.append(mid)
+            elif expected is None:
+                verdict = "KILLED"
+            elif expected in msgs:
+                verdict = "KILLED(attributed)"
+            else:
+                verdict = "KILLED-WRONG-REASON"
+                problems.append(mid)
+            shown = ", ".join(k[:52] for k in killers[:3])
+            extra = f" (+{len(killers) - 3} more)" if len(killers) > 3 else ""
+            print(f"{mid:4} {shape:12} {verdict:19} f={nf:<3} "
+                  f"[{target.name}] {desc}")
+            if verdict == "KILLED-WRONG-REASON":
+                print(f"     expected {expected!r} in the `E ` lines; not found")
+            if killers:
+                print(f"     killers: {shown}{extra}")
+
+        # 🔴 THE POSITIVE CONTROL IS READ AS A VERDICT ON THE BATTERY. A run in
+        # which P1 survives observed nothing, whatever the other rows say.
+        pc_ok = "P1" not in problems
+        print(f"\npositive control P1: {'KILLED — the battery can observe' if pc_ok else 'SURVIVED — THIS BATTERY IS BROKEN'}")
+        print(f"{len(MUTANTS) - len(problems)}/{len(MUTANTS)} killed for the "
+              f"stated reason; problems: {problems or 'none'}")
+        return 0 if (pc_ok and not problems) else 1
+    finally:
+        for p in files:
+            p.write_text(orig[p], encoding="utf-8")
+        after = {p: _digest(p) for p in files}
+        drifted = [p.name for p in files if before[p] != after[p]]
+        print("restore: " + ("OK — " + " ".join(f"{p.name}={before[p]}" for p in files)
+                             if not drifted else f"🔴 DRIFTED: {drifted}"))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/mutation_battery_mentions.py
+++ b/scripts/tests/mutation_battery_mentions.py
@@ -77,8 +77,10 @@ SUITES = (
 )
 
 # (id, shape, description, old, new[, expected]) — `old` must occur EXACTLY once
-# in that row's TARGETS file. Same contract as the two sibling batteries; the
-# only addition is that the file is per-row rather than module-wide.
+# in that row's TARGETS file. Same contract as the two sibling batteries: `old`
+# and `new` may be TUPLES of equal length, applied in order, each half still
+# required to occur exactly once. The only addition here is that the FILE is
+# per-row rather than module-wide (see `TARGETS` below the table).
 MUTANTS: list[tuple] = [
     # ---- POSITIVE CONTROL --------------------------------------------------
     ("P1", "control", "break a URL every suite reads — MUST be killed",
@@ -162,6 +164,24 @@ MUTANTS: list[tuple] = [
      "        f\"b64:context={m['context']} {sorted(load_mention_repos())}\",\n",
      "SPOOL DISCLOSURE (unattributed run)"),
 
+    # ---- F3, the TWO-SITE shape: one pattern, gated in two places -----------
+    #
+    # 🔴 `GITHUB_URL_RE` IS GATED TWICE — once as an ATTRIBUTION source and once
+    # as a DETECT pattern — and K8 removes only the first. A maintainer
+    # "simplifying the profile gating for this one pattern" removes both, and
+    # that is a strictly worse defect than either half: the URL shape becomes
+    # clickable AND starts attributing on the terminal profile. Expressing only
+    # one half would put a narrower label on the row than the hazard deserves.
+    # This is also the battery's multi-site row, which is what lets
+    # `test_the_PAIR_check_goes_RED_on_a_real_battery_COPY` run instead of skip.
+    ("K16", "widening", "BOTH `GITHUB_URL_RE` profile gates are removed, so the "
+                        "URL shape both attributes AND is clickable in terminal",
+     ('    url_repo = _sole_repo_named_by(GITHUB_URL_RE, text) if "GITHUB_URL_RE" in on else ""\n',
+      '    if "GITHUB_URL_RE" in on:\n'),
+     ("    url_repo = _sole_repo_named_by(GITHUB_URL_RE, text)\n",
+      "    if True:\n"),
+     "GITHUB_URL_RE: a telemetry-only shape reached the CLICK surface"),
+
     # ---- the nit list: live, reachable, previously untested ------------------
     ("K15", "deletion", "TASK_ANCHOR_RE loses its `(?<![&#])` left guard, so an "
                         "HTML entity and a `##` run both parse as the anchor",
@@ -176,7 +196,7 @@ TARGETS: dict[str, pathlib.Path] = {
     "K4": SCAN, "K5": SCAN, "K6": SCAN,
     "K7": SCAN, "K8": SCAN, "K9": SCAN, "K10": OPEN_,
     "K11": OPEN_, "K12": OPEN_, "K13": TAILER, "K14": TAILER,
-    "K15": SCAN,
+    "K15": SCAN, "K16": SCAN,
 }
 
 
@@ -229,13 +249,23 @@ def main() -> int:
             expected = row[5] if len(row) > 5 else None
             target = TARGETS[mid]
             text = orig[target]
-            n = text.count(old)
-            if n != 1:
-                print(f"{mid:4} {shape:12} !! PATTERN OCCURS {n}x in "
+            # One edit or several: a tuple means every pair is applied in order,
+            # and EACH is still required to occur exactly once. A multi-site
+            # mutant whose second half silently did not apply would be scored on
+            # the first half alone — a DIFFERENT mutation than the row names,
+            # reported under the row's id.
+            pairs = list(zip(old, new)) if isinstance(old, tuple) else [(old, new)]
+            counts = [text.count(o) for o, _ in pairs]
+            if any(n != 1 for n in counts):
+                shown_n = counts[0] if len(counts) == 1 else counts
+                print(f"{mid:4} {shape:12} !! PATTERN OCCURS {shown_n}x in "
                       f"{target.name} — NOT APPLIED — {desc}")
                 problems.append(mid)
                 continue
-            target.write_text(text.replace(old, new), encoding="utf-8")
+            mutated = text
+            for o, nw in pairs:
+                mutated = mutated.replace(o, nw)
+            target.write_text(mutated, encoding="utf-8")
             try:
                 nf, _np, killers, msgs = run_suite(messages=expected is not None)
             finally:

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -912,6 +912,11 @@ def test_an_EMPTY_universe_degrades_to_the_NAMED_reason_refusal(spy, monkeypatch
     assert MO.main(["zzznosuchrepo#12"]) == 1
     assert "gh is not on PATH" in notices[-1][1]
     assert not [c for c in spy if isinstance(c, tuple) and c[0] == "pick"]
+    # 🔴 EXACTLY ONE NOTIFICATION. The refusal already names the cause, so PASS 4
+    # must not ALSO announce it on the way past — and this is the assertion that
+    # makes the `and universe` guard load-bearing rather than decorative.
+    # Measured: without it, dropping `and universe` SURVIVED the whole file.
+    assert len(notices) == 1, notices
 
 
 def test_an_UNREADABLE_mapping_degrades_the_same_way(tmp_path, monkeypatch):

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -36,6 +36,14 @@ _spec = importlib.util.spec_from_file_location("mention_open_under_test", HANDLE
 MO = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(MO)
 
+# 🔴 THE SAME MODULE OBJECT THE HANDLER IMPORTED, not a second reading of the
+# file. `mention-open.py` puts `scripts/collector` on `sys.path` and does
+# `from mention_scan import …`, so by the line above `mention_scan` is already in
+# `sys.modules`; importing it here binds THAT object. A separately-`exec_module`d
+# copy would let the profile-split assertions below compare two independent
+# readings and agree while the handler used a third.
+import mention_scan as MS  # noqa: E402
+
 
 # --------------------------------------------------------------------------- #
 # Remote URL -> owner/repo
@@ -986,13 +994,53 @@ def test_a_bare_hash_N_that_the_PANE_already_attributes_does_NOT_get_the_univers
     assert ("pick", 2) in spy, spy
 
 
+@pytest.fixture
+def real_notify(monkeypatch):
+    """Let the REAL `MO.notify` run, capturing what it hands `notify-send`.
+
+    🔴 THIS FIXTURE IS THE FIX FOR A GUARD THAT COULD NOT SEE ITS OWN SUBJECT.
+    The disclosure test below used to stub `MO.notify` to a no-op — and `notify`
+    is the ONLY function in the module that writes to stderr or to a desktop
+    notification. So "none of them reached stdout or stderr" was a claim about a
+    path the test had removed: adding the universe to any refusal's `notify` body
+    survived the whole suite. Stubbing `subprocess.run` instead keeps the real
+    formatting, the real `print(..., file=sys.stderr)` and the real argv, while
+    still launching nothing.
+    """
+    sent: list[list[str]] = []
+
+    def fake_run(argv, *a, **k):
+        sent.append(list(argv))
+        raise AssertionError(
+            f"no subprocess may launch from these tests: {argv!r}")
+
+    def capture(argv, *a, **k):
+        sent.append(list(argv))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(MO.subprocess, "run", capture)
+    monkeypatch.setattr(MO.subprocess, "Popen", fake_run)
+    return sent
+
+
+# The universe rows may reach the operator's rofi window and NOWHERE else, so
+# every sink the handler can write to is enumerated here rather than left to
+# whichever one a test happened to think of. A sink missing from this list is a
+# hole; adding one to the module means adding it here.
+def _every_sink(capsys, notify_argv: list[list[str]]) -> str:
+    captured = capsys.readouterr()
+    return "\n".join([captured.out, captured.err,
+                      *(" ".join(a) for a in notify_argv)])
+
+
 def test_the_universe_never_reaches_a_LOG_a_SPOOL_or_stderr(spy, universe,
-                                                            monkeypatch, capsys):
+                                                            monkeypatch, capsys,
+                                                            real_notify):
     """🔴 THE DISCLOSURE GUARD FOR PASS 4. The real universe names private
     repositories; the ONLY place it may go is the operator's rofi window. This
     asserts the rows exist (a positive control — a test that only checked for
     absence would pass against a picker wired to nothing) and that none of them
-    reached stdout or stderr."""
+    reached stdout, stderr or a desktop notification."""
     seen = {}
 
     def spy_pick(cands):
@@ -1000,10 +1048,87 @@ def test_the_universe_never_reaches_a_LOG_a_SPOOL_or_stderr(spy, universe,
         return ""
 
     monkeypatch.setattr(MO, "pick", spy_pick)
-    monkeypatch.setattr(MO, "notify", lambda *a, **k: None)
     assert MO.main(["zzznosuchrepo#12"]) == 0
     assert len(seen["rows"]) == 3, "positive control: the picker got real rows"
-    captured = capsys.readouterr()
+    everywhere = _every_sink(capsys, real_notify)
     for name in FAKE_UNIVERSE.values():
-        assert name not in captured.out, name
-        assert name not in captured.err, name
+        assert name not in everywhere, f"PICKER-PATH DISCLOSURE: {name}"
+
+
+def test_the_REFUSAL_path_names_the_clicked_text_and_never_the_universe(
+        universe, monkeypatch, capsys, real_notify):
+    """🔴 THE SECOND HALF OF THE SAME GUARD, on the path PASS 4 never reaches.
+
+    `--print` skips PASS 4 entirely, so the handler refuses — but `discovered`
+    was already populated by PASS 2 and holds the whole universe. That refusal
+    goes through `notify()`, which prints to stderr AND to `notify-send`. Adding
+    the universe to that body — "no repo by that name; did you mean one of
+    these?" is a natural-looking improvement — leaked every private name, with
+    the previous version of this file green.
+
+    The positive controls come FIRST: the refusal really happened, and the
+    handler really held the universe at that moment. Without them a stubbed-out
+    run that refused for some other reason would satisfy every absence below."""
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
+    assert MO.main(["--print", "zzznosuchrepo#77"]) == 1
+    everywhere = _every_sink(capsys, real_notify)
+    # POSITIVE CONTROL 1 — this IS the refusal path, and it named the click.
+    assert "cannot resolve zzznosuchrepo#77" in everywhere
+    # POSITIVE CONTROL 2 — the universe was in hand and NOT empty at that point,
+    # so its absence below is a decision rather than an accident of the fixture.
+    assert MO.repo_universe(dict(FAKE_UNIVERSE)) == sorted(FAKE_UNIVERSE.values())
+    for name in FAKE_UNIVERSE.values():
+        assert name not in everywhere, f"REFUSAL-PATH DISCLOSURE: {name}"
+
+
+def test_print_mode_prints_EVERY_namesake_rather_than_refusing_above_a_cap(
+        monkeypatch, capsys):
+    """🔴 A DECISION, RECORDED. Removing the namesake cap changed `--print` too:
+    `widget#12` with nine namesakes used to exit 1 with a named refusal and now
+    prints nine URLs and exits 0.
+
+    That is intended. `--print`'s documented contract is "print every candidate
+    when ambiguous", a namesake set IS that ambiguity, and every row is an
+    EXACT-name search hit — evidence about the name the operator typed. It is NOT
+    the PASS 4 universe, which is evidence about nothing and stays barred from
+    `--print` (see the test above). A consumer wanting one answer writes
+    `owner/repo#N`.
+
+    Nine, not eight: the retired cap was 8, so a fixture at or below it could not
+    tell "no cap" from "a cap nobody reached"."""
+    owners = [f"org{i}/widget" for i in range(9)]
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
+    monkeypatch.setattr(MO, "gh_api_repo_search",
+                        lambda name: ({o: o for o in owners}, ""))
+    assert MO.main(["--print", "widget#12"]) == 0
+    printed = capsys.readouterr().out.split()
+    assert printed == [f"https://github.com/{o}/issues/12" for o in sorted(owners)]
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE PROFILE SPLIT, AT THE CONSUMER
+#
+# `mention_scan`'s default profile is `terminal`, and this handler's single
+# `scan_mention_spans` call passes no `profile=` — that omission is the entire
+# reason the wider telemetry surface never becomes clickable. It was pinned at
+# the module and NOWHERE here: an independent mutation sweep added
+# `profile="telemetry"` to `resolve()` and the whole suite stayed green.
+# --------------------------------------------------------------------------- #
+def test_every_TELEMETRY_only_shape_is_invisible_to_the_click_handler():
+    """Driven off `PATTERN_LEDGER`, not a hand-written list, so a telemetry-only
+    pattern added later is covered without anyone remembering this file.
+
+    Each sample carries its own positive control: the SAME text must produce a
+    span at the telemetry profile. Without that half, a sample the scanner had
+    stopped matching entirely would pass as "invisible to the click"."""
+    telemetry_only = {
+        name: pat for name, pat in MS.PATTERN_LEDGER.items()
+        if pat.role == "detect" and MS.PROFILE_TERMINAL not in pat.profiles}
+    assert telemetry_only, "positive control: there ARE telemetry-only patterns"
+    for name, pat in sorted(telemetry_only.items()):
+        assert MS.scan_mention_spans(pat.sample, profile=MS.PROFILE_TELEMETRY), (
+            f"{name}: the ledger sample must match at the telemetry profile")
+        assert MO.resolve(pat.sample) == (None, []), (
+            f"{name}: a telemetry-only shape reached the CLICK surface — "
+            f"resolve() is scanning at the wrong profile")

--- a/scripts/tests/test_mention_open.py
+++ b/scripts/tests/test_mention_open.py
@@ -479,8 +479,14 @@ def test_TWO_owners_with_the_same_repo_name_go_to_the_PICKER(spy, monkeypatch):
     assert "gardenersguild" in urls[0] and "rivalorg" in urls[1]
 
 
-def test_an_unknown_repo_with_no_exact_match_still_refuses(spy, monkeypatch):
-    """PASS 3 must not turn an honest refusal into a confident wrong page."""
+def test_an_unknown_repo_with_no_exact_match_still_refuses_WHEN_THE_UNIVERSE_IS_EMPTY(
+        spy, monkeypatch):
+    """PASS 3 must not turn an honest refusal into a confident wrong page.
+
+    The refusal is now the LAST resort rather than the only one — it survives
+    exactly when PASS 4 has nothing to offer, which is what an empty
+    `discover_repos()` produces."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
     run, _ = _fake_gh(["hobbyist/trowelcast-examples"])
     monkeypatch.setattr(MO.subprocess, "run", run)
     assert MO.main(["trowelcast#77"]) == 1
@@ -599,6 +605,23 @@ def test_the_reader_and_the_writer_agree_on_ONE_path(tmp_path, monkeypatch):
         f"{reader.KNOWN_REPOS_PATH} — the mapping would be generated into a "
         f"file nothing ever loads, with both suites green")
 
+    # 🔴 THREE PARTIES NOW, NOT TWO. `scripts/collector/claude/session-tailer.py`
+    # reads the same mapping to ATTRIBUTE a bare `#N`, and it computes the path
+    # with its own copy of the expression. A tailer pointed at a file nothing
+    # writes attributes nothing — and looks exactly like a host with no mapping,
+    # which is a supported state, so no counter goes red.
+    # The tailer imports its siblings (`_shared`, `tailer`) by bare name, so its
+    # own directory has to be importable — it normally is, because the deployed
+    # copy is executed from there.
+    for extra in ("scripts/collector", "scripts/collector/claude"):
+        monkeypatch.syspath_prepend(str(ROOT / extra))
+    tailer = _fresh("session_tailer_for_seam",
+                    "scripts/collector/claude/session-tailer.py")
+    assert tailer.mention_repos_path() == reader.KNOWN_REPOS_PATH, (
+        f"the tailer reads {tailer.mention_repos_path()} but the handler reads "
+        f"{reader.KNOWN_REPOS_PATH} — telemetry attribution would be silently "
+        f"dead while every suite stays green")
+
 
 def test_the_workspace_is_resolved_at_CALL_time_too(tmp_path, monkeypatch):
     """🔴 THE CLASS, NOT THE INSTANCE. `discover_repos(workspace=WORKSPACE)`
@@ -625,21 +648,29 @@ def test_the_workspace_is_resolved_at_CALL_time_too(tmp_path, monkeypatch):
 
 # PASS 3 — an unusable picker, and an empty result that names its cause
 # --------------------------------------------------------------------------- #
-def test_too_many_namesakes_REFUSES_instead_of_showing_a_wall(spy, monkeypatch):
-    """Measured: `dashboard` and `cli` each return a full page of EXACT matches.
-    A 100-row list of URLs differing only by owner is not a choice."""
-    assert MO.PASS3_MAX_CHOICES == 8, "the fixtures below are literal on purpose"
-    rows = [f"owner{i}/trowelcast" for i in range(9)]
+def test_a_WALL_of_namesakes_now_reaches_the_picker_because_it_can_be_TYPED_at(
+        spy, monkeypatch):
+    """🔴 THE REVERSAL. This used to refuse above 8 namesakes, on the reasoning
+    that "a 100-row list of URLs differing only by owner is not a choice, it is
+    a wall". That is true of a list you can only SCROLL and false of one you can
+    TYPE AT, and `pick()` now runs rofi with `-matching fuzzy`. So the wall is a
+    narrowing, and refusing would remove the operator's ability to choose.
+
+    17 rows, not 9: the old cap was 8, so a fixture of 9 would sit one step past
+    a boundary that no longer exists and could not tell a re-added cap of 16
+    from no cap at all."""
+    rows = [f"owner{i}/trowelcast" for i in range(17)]
     run, _ = _fake_gh(rows)
     monkeypatch.setattr(MO.subprocess, "run", run)
-    assert MO.main(["trowelcast#77"]) == 1
-    assert spy[-1] == ("notify", "cannot resolve trowelcast#77")
-    assert not [c for c in spy if isinstance(c, tuple) and c[0] == "open"]
+    assert MO.main(["trowelcast#77"]) == 0
+    assert ("pick", 17) in spy, spy
+    assert not [c for c in spy if isinstance(c, tuple) and c[0] == "notify"]
 
 
-def test_exactly_the_cap_still_offers_the_picker(spy, monkeypatch):
-    """The boundary, from the other side — a cap that also swallowed the
-    legitimate case would be a refusal dressed as a limit."""
+def test_eight_namesakes_still_offer_the_picker(spy, monkeypatch):
+    """The case that worked under the old cap must keep working under no cap —
+    a reversal that broke the legitimate side would be the same outage wearing
+    the opposite hat."""
     rows = [f"owner{i}/trowelcast" for i in range(8)]
     run, _ = _fake_gh(rows)
     monkeypatch.setattr(MO.subprocess, "run", run)
@@ -647,10 +678,39 @@ def test_exactly_the_cap_still_offers_the_picker(spy, monkeypatch):
     assert ("pick", 8) in spy
 
 
+def test_the_picker_asks_rofi_for_FUZZY_matching(monkeypatch):
+    """🔴 THE SEAM BETWEEN THE DECISION AND THE TOOL. Every other test here
+    stubs `pick`, so none of them notices if the flag that makes a long list
+    usable is missing — and dropping it silently restores the wall the cap used
+    to guard against, with the whole suite green. This is the only test that
+    reads the argv `pick` actually builds.
+
+    NOTHING IS LAUNCHED: `subprocess.run` is replaced, so no window is ever
+    raised. Raising a window takes the operator's screen."""
+    seen = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["cmd"] = cmd
+        seen["input"] = kwargs.get("input", "")
+        return types.SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(MO.subprocess, "run", fake_run)
+    MO.pick([{"platform": "github", "id": "7",
+              "url": "https://github.com/gardenersguild/trowelcast/issues/7"}])
+    assert seen["cmd"][0] == "rofi"
+    assert "-matching" in seen["cmd"]
+    assert seen["cmd"][seen["cmd"].index("-matching") + 1] == "fuzzy"
+    # `-no-custom` stops rofi handing back typed free text as a selection.
+    assert "-no-custom" in seen["cmd"]
+
+
 def test_a_search_that_COULD_NOT_RUN_says_so_instead_of_denying_the_repo(spy, monkeypatch):
     """🔴 An empty result cannot distinguish `gh` missing from no such repo, and
     the two need opposite next moves. The refusal must not assert the stronger
-    claim."""
+    claim. With an EMPTY universe there is nothing to offer, so this is still the
+    refusal path exactly as it was."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
+
     def boom(cmd, **kwargs):
         raise FileNotFoundError(2, "No such file or directory", "gh")
 
@@ -662,7 +722,26 @@ def test_a_search_that_COULD_NOT_RUN_says_so_instead_of_denying_the_repo(spy, mo
     assert "not a claim that no such repo exists" in notices[-1][1]
 
 
+def test_the_picker_does_not_SWALLOW_the_reason_the_search_could_not_run(
+        spy, monkeypatch):
+    """🔴 THE NEW SHAPE OF AN OLD RULE. PASS 4 turns a refusal into a choice, and
+    the easiest way to write that is to drop the refusal entirely — which would
+    silently discard "gh is not on PATH", a fact about the operator's TOOLING
+    that no picker can express. The cause is announced AND the choice is offered:
+    they answer different questions."""
+    def boom(cmd, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory", "gh")
+
+    monkeypatch.setattr(MO.subprocess, "run", boom)
+    notices = []
+    monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
+    assert MO.main(["trowelcast#77"]) == 0
+    assert ("pick", 1) in spy, spy
+    assert any("gh is not on PATH" in n[1] for n in notices), notices
+
+
 def test_a_search_that_RAN_and_matched_nothing_keeps_the_ordinary_refusal(spy, monkeypatch):
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
     run, _ = _fake_gh(["hobbyist/trowelcast-examples"])
     monkeypatch.setattr(MO.subprocess, "run", run)
     notices = []
@@ -676,6 +755,8 @@ def test_the_refusal_keeps_the_ADVICE_when_it_also_names_a_cause(spy, monkeypatc
     """🔴 The case where the search could not run is exactly the case where
     writing `owner/repo#N` is the workaround — so naming the cause must ADD to
     the advice, never replace it. It replaced it once."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
+
     def boom(cmd, **kwargs):
         raise FileNotFoundError(2, "No such file or directory", "gh")
 
@@ -686,19 +767,6 @@ def test_the_refusal_keeps_the_ADVICE_when_it_also_names_a_cause(spy, monkeypatc
     body = notices[-1][1]
     assert "gh is not on PATH" in body
     assert "owner/repo#N" in body, "the actionable advice was dropped"
-
-
-def test_the_namesake_count_is_stated_as_a_FLOOR_not_a_total(spy, monkeypatch):
-    """The count comes from ONE page, so `per_page` caps it by construction.
-    Measured live: `cli` and `api` each report 100 exact matches out of
-    ~1.8M search hits. Stating that as a total is wrong by orders of magnitude."""
-    rows = [f"owner{i}/trowelcast" for i in range(9)]
-    run, _ = _fake_gh(rows)
-    monkeypatch.setattr(MO.subprocess, "run", run)
-    notices = []
-    monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
-    assert MO.main(["trowelcast#77"]) == 1
-    assert "at least 9 repositories" in notices[-1][1]
 
 
 @pytest.mark.parametrize("value", [
@@ -727,3 +795,210 @@ def test_the_search_asks_for_a_FULL_page(monkeypatch):
     monkeypatch.setattr(MO.subprocess, "run", run)
     MO.gh_api_repo_search("trowelcast")
     assert "per_page=100" in seen["cmd"], seen["cmd"]
+
+
+# --------------------------------------------------------------------------- #
+# PASS 4 — THE FUZZY UNIVERSE
+#
+# 🔴 EVERY NAME BELOW IS SYNTHETIC. The real universe is built from
+# `known_repos.json`, the file whose committed ancestor disclosed 232 PRIVATE
+# repositories into this PUBLIC repo. No test may read that file, and no row
+# from it may ever be written to a fixture, a log or a spool. Values are
+# pairwise distinct and distinct from every constant these assertions name.
+#
+# 🔴 NOTHING HERE LAUNCHES ROFI. `pick` is stubbed by the `spy` fixture, or
+# `subprocess.run` is replaced. Raising a window takes the operator's screen.
+# --------------------------------------------------------------------------- #
+FAKE_UNIVERSE = {
+    "trowelcast": "gardenersguild/trowelcast",
+    "plotwidget": "hobbyist/plotwidget",
+    "spadeworks": "rivalorg/spadeworks",
+}
+
+
+@pytest.fixture
+def universe(monkeypatch):
+    """A three-entry synthetic universe, and NO gh — so anything that resolves
+    below did so through PASS 4 and nothing else."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: dict(FAKE_UNIVERSE))
+    # ("", not a reason): the search RAN and matched nothing. A reason here would
+    # make every test below also exercise the "could not run" notice, which has
+    # its own test — a fixture that bundles two conditions cannot tell you which
+    # one an assertion is about.
+    monkeypatch.setattr(MO, "gh_api_repo_search", lambda name: ({}, ""))
+    return FAKE_UNIVERSE
+
+
+def test_repo_universe_is_the_sorted_distinct_owner_repos():
+    assert MO.repo_universe(FAKE_UNIVERSE) == [
+        "gardenersguild/trowelcast", "hobbyist/plotwidget", "rivalorg/spadeworks"]
+
+
+def test_repo_universe_drops_a_value_that_would_404_while_looking_authoritative():
+    assert MO.repo_universe({"a": "acme/widget/", "b": "acme", "c": 3,
+                             "d": "hobbyist/plotwidget"}) == ["hobbyist/plotwidget"]
+
+
+def test_repo_universe_is_total_on_an_absent_mapping():
+    assert MO.repo_universe(None) == []
+    assert MO.repo_universe({}) == []
+
+
+def test_universe_candidates_build_one_openable_row_per_repo():
+    cands = MO.universe_candidates("77", ["gardenersguild/trowelcast",
+                                          "rivalorg/spadeworks"])
+    assert [c["url"] for c in cands] == [
+        "https://github.com/gardenersguild/trowelcast/issues/77",
+        "https://github.com/rivalorg/spadeworks/issues/77"]
+    assert {c["platform"] for c in cands} == {"github"}
+    assert {c["id"] for c in cands} == {"77"}
+
+
+def test_an_UNRESOLVABLE_repo_now_reaches_the_fuzzy_picker(spy, universe):
+    """🔴 DEAD END 2. `talos-inf#12` used to refuse; now the operator types four
+    characters into a fuzzy picker. This is the extension of "several matches
+    means a picker", not a relaxation of "nothing is guessed" — nothing opens
+    without a selection."""
+    assert MO.main(["zzznosuchrepo#12"]) == 0
+    assert ("pick", 3) in spy, spy
+    assert not [c for c in spy if isinstance(c, tuple) and c[0] == "notify"]
+
+
+def test_the_picker_rows_carry_the_REPO_so_fuzzy_typing_can_narrow():
+    """A picker whose rows do not contain the repo name cannot be typed at —
+    `-matching fuzzy` matches on the row TEXT."""
+    rows = MO.picker_rows(MO.universe_candidates("12", MO.repo_universe(FAKE_UNIVERSE)))
+    assert any("trowelcast" in r for r in rows)
+    assert any("spadeworks" in r for r in rows)
+    assert len(rows) == 3
+
+
+def test_a_ONE_ENTRY_universe_is_still_a_CHOICE_and_never_auto_opens(
+        spy, monkeypatch):
+    """🔴 THE DEFECT THIS PINS, found during development: with exactly one repo
+    in the universe the "one candidate → just open it" shortcut fired and
+    `zzznosuchrepo#77` opened issue 77 in a completely unrelated repository — a
+    confident wrong page, the exact failure this handler exists to prevent.
+
+    A search HIT is evidence about the name; a universe row is only an option."""
+    monkeypatch.setattr(MO, "discover_repos",
+                        lambda *a, **k: {"spadeworks": "rivalorg/spadeworks"})
+    monkeypatch.setattr(MO, "gh_api_repo_search", lambda name: ({}, ""))
+    assert MO.main(["zzznosuchrepo#77"]) == 0
+    assert ("pick", 1) in spy, spy
+
+
+def test_dismissing_the_universe_picker_opens_NOTHING(spy, universe, monkeypatch):
+    """`pick()`'s contract, preserved exactly: a dismissal is not an error and it
+    must not open anything. Asserted on the OPENER, not only on the exit code —
+    an exit code cannot tell you a browser was launched."""
+    monkeypatch.setattr(MO, "pick", lambda c: "")
+    assert MO.main(["zzznosuchrepo#12"]) == 0
+    assert not [c for c in spy if isinstance(c, tuple) and c[0] == "open"]
+
+
+def test_an_EMPTY_universe_degrades_to_the_NAMED_reason_refusal(spy, monkeypatch):
+    """🔴 NOT A SILENT EMPTY PICKER. A universe that cannot be read must fall
+    back to the refusal that says WHICH empty this is — "gh is not on PATH" and
+    "no repo by that name" need opposite next moves."""
+    monkeypatch.setattr(MO, "discover_repos", lambda *a, **k: {})
+    notices = []
+    monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
+
+    def boom(cmd, **kwargs):
+        raise FileNotFoundError(2, "No such file or directory", "gh")
+
+    monkeypatch.setattr(MO.subprocess, "run", boom)
+    assert MO.main(["zzznosuchrepo#12"]) == 1
+    assert "gh is not on PATH" in notices[-1][1]
+    assert not [c for c in spy if isinstance(c, tuple) and c[0] == "pick"]
+
+
+def test_an_UNREADABLE_mapping_degrades_the_same_way(tmp_path, monkeypatch):
+    """The universe is built from a file. An unreadable one is an empty one, and
+    an empty one is the refusal above — never a picker with no rows.
+
+    🔴 NO `spy` FIXTURE HERE, deliberately: `spy` stubs `discover_repos`, which
+    is the very code path whose file-reading this test is about. Using it would
+    make the test green against a handler that never opens the file at all."""
+    bad = tmp_path / "known_repos.json"
+    bad.write_text("not json at all")
+    monkeypatch.setattr(MO, "KNOWN_REPOS_PATH", bad)
+    monkeypatch.setattr(MO, "WORKSPACE", tmp_path / "no-such-workspace")
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
+    monkeypatch.setattr(MO, "gh_api_repo_search", lambda name: ({}, ""))
+    picks, opens, notices = [], [], []
+    monkeypatch.setattr(MO, "pick", lambda c: picks.append(len(c)) or "")
+    monkeypatch.setattr(MO, "open_url", lambda url: opens.append(url) or 0)
+    monkeypatch.setattr(MO, "notify", lambda *a, **k: notices.append(a))
+    assert MO.main(["zzznosuchrepo#12"]) == 1
+    assert notices[-1][0] == "cannot resolve zzznosuchrepo#12"
+    assert picks == [] and opens == []
+
+
+def test_no_discovery_still_means_resolve_only_what_the_TEXT_carries(spy, universe):
+    """🔴 The flag's meaning is unchanged by PASS 4. A host-wide mapping is not
+    something the clicked text carries."""
+    assert MO.main(["--no-discovery", "zzznosuchrepo#12"]) == 1
+    assert not [c for c in spy if isinstance(c, tuple) and c[0] == "pick"]
+    assert [c for c in spy if isinstance(c, tuple) and c[0] == "notify"]
+    assert not [c for c in spy if isinstance(c, tuple) and c[0] == "open"]
+
+
+def test_print_mode_never_invokes_the_picker_or_the_universe(spy, universe, capsys):
+    """🔴 `--print` exists so a script can read the resolved URL. Answering it
+    with several hundred is not an answer, and printing them would ALSO write
+    private repository names to stdout."""
+    assert MO.main(["--print", "zzznosuchrepo#12"]) == 1
+    assert not [c for c in spy if isinstance(c, tuple) and c[0] == "pick"]
+    out = capsys.readouterr().out
+    assert "trowelcast" not in out and "spadeworks" not in out
+
+
+def test_print_mode_still_prints_a_resolvable_url(spy, universe, capsys):
+    assert MO.main(["--print", "gardenersguild/trowelcast#1065"]) == 0
+    assert capsys.readouterr().out.strip() == (
+        "https://github.com/gardenersguild/trowelcast/issues/1065")
+
+
+def test_a_bare_hash_N_with_NO_repo_context_offers_the_universe_BELOW_clawgate(
+        spy, universe, monkeypatch):
+    """🔴 DEAD END 3, with the common case protected. The clawgate candidate
+    stays FIRST, so the 92%-of-mentions bare `#N` is still one Enter away; the
+    universe is appended as the way to say "no, GitHub, this repository"."""
+    monkeypatch.setattr(MO, "tmux_pane_repo", lambda: "")
+    assert MO.main(["#370"]) == 0
+    assert ("pick", 4) in spy, spy
+    assert spy[-1] == ("open", "https://clawgate.zacx.dev/tasks/370"), (
+        "the clawgate row must still be the first, default-selected one")
+
+
+def test_a_bare_hash_N_that_the_PANE_already_attributes_does_NOT_get_the_universe(
+        spy, universe):
+    """The universe is the LAST resort. A measured pane repo is evidence, and
+    burying it under 300 options would be a regression dressed as a feature."""
+    assert MO.main(["#370"]) == 0
+    assert ("pick", 2) in spy, spy
+
+
+def test_the_universe_never_reaches_a_LOG_a_SPOOL_or_stderr(spy, universe,
+                                                            monkeypatch, capsys):
+    """🔴 THE DISCLOSURE GUARD FOR PASS 4. The real universe names private
+    repositories; the ONLY place it may go is the operator's rofi window. This
+    asserts the rows exist (a positive control — a test that only checked for
+    absence would pass against a picker wired to nothing) and that none of them
+    reached stdout or stderr."""
+    seen = {}
+
+    def spy_pick(cands):
+        seen["rows"] = MO.picker_rows(cands)
+        return ""
+
+    monkeypatch.setattr(MO, "pick", spy_pick)
+    monkeypatch.setattr(MO, "notify", lambda *a, **k: None)
+    assert MO.main(["zzznosuchrepo#12"]) == 0
+    assert len(seen["rows"]) == 3, "positive control: the picker got real rows"
+    captured = capsys.readouterr()
+    for name in FAKE_UNIVERSE.values():
+        assert name not in captured.out, name
+        assert name not in captured.err, name

--- a/scripts/tests/test_mention_scan.py
+++ b/scripts/tests/test_mention_scan.py
@@ -302,3 +302,474 @@ def test_results_are_ordered_by_position():
     text = "868abc123 then devrc#1 then #2"
     assert [m["start"] for m in MS.scan_mentions(text)] == sorted(
         m["start"] for m in MS.scan_mentions(text))
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE PROFILE SPLIT
+#
+# The module used to run ONE set of regexes so the terminal and the telemetry
+# could never disagree. That invariant is deliberately relaxed along exactly one
+# axis, so the relaxation has to be EXPLICIT: a ledger, pinned two-way, and a
+# default that keeps the click surface where it was.
+# --------------------------------------------------------------------------- #
+def _compiled_pattern_names():
+    """Every module-level compiled regex, read from the module itself rather
+    than restated here — so a pattern added tomorrow is covered without editing
+    this file. Private helpers (leading underscore) are excluded: the ledger is
+    about what the SCAN consults, and `_` marks an implementation detail."""
+    import re as _re
+    return {name for name, val in vars(MS).items()
+            if isinstance(val, _re.Pattern) and not name.startswith("_")}
+
+
+def test_the_pattern_ledger_is_pinned_TWO_WAY():
+    """🔴 BOTH DIRECTIONS, because each one fails differently and silently.
+
+    A pattern with NO ledger entry is never consulted in any profile — it
+    compiles, it looks live, and `scan_mentions` skips it forever.
+    A ledger entry naming NO pattern is a row asserting coverage that does not
+    exist, which is worse than no row because it stops anyone looking."""
+    declared = set(MS.PATTERN_LEDGER)
+    compiled = _compiled_pattern_names()
+    assert declared - compiled == set(), (
+        "ledger entries that name no compiled pattern: "
+        f"{sorted(declared - compiled)}")
+    # `NON_SCAN_PATTERNS` is the ONLY other home a compiled pattern may have,
+    # and it is itself pinned below — so "in neither" is a failure, not a gap.
+    unclassified = compiled - declared - MS.NON_SCAN_PATTERNS
+    assert unclassified == set(), (
+        "compiled patterns in NEITHER the ledger nor NON_SCAN_PATTERNS — they "
+        f"are consulted in NO profile and are dead: {sorted(unclassified)}")
+
+
+def test_the_non_scan_escape_hatch_is_pinned_TOO():
+    """An escape hatch nobody has to justify is how the next pattern lands in no
+    ledger at all. Both directions again: a name here must be a real compiled
+    pattern, and it must not ALSO claim a profile in the ledger."""
+    compiled = _compiled_pattern_names()
+    assert MS.NON_SCAN_PATTERNS <= compiled, (
+        f"names no compiled pattern: {sorted(MS.NON_SCAN_PATTERNS - compiled)}")
+    assert not (MS.NON_SCAN_PATTERNS & set(MS.PATTERN_LEDGER)), (
+        "a pattern cannot be both scanned and not-scanned")
+    assert MS.NON_SCAN_PATTERNS == {"OWNER_REPO_VALUE_RE"}, (
+        "the hatch grew — every addition needs its own reason in the module")
+
+
+def test_every_ledger_entry_names_real_profiles_and_a_real_role():
+    for name, entry in MS.PATTERN_LEDGER.items():
+        assert entry.profiles, f"{name} is enabled in no profile at all"
+        assert set(entry.profiles) <= set(MS.PROFILES), name
+        assert entry.role in ("detect", "attribute"), f"{name}: {entry.role}"
+
+
+def test_every_ledger_SAMPLE_actually_matches_its_pattern():
+    """A sample that does not match makes the hint check below vacuous — it
+    would prove a property of a string nothing ever matched."""
+    for name, entry in MS.PATTERN_LEDGER.items():
+        pattern = getattr(MS, name)
+        assert pattern.search(entry.sample), (
+            f"{name}'s ledger sample {entry.sample!r} does not match it")
+
+
+def test_every_detecting_patterns_HINTS_are_honest_about_its_sample():
+    """🔴 THE HINT IS A CLAIM: "a text without one of these cannot match". A hint
+    that is not present in a text the pattern DOES match is a false claim, and it
+    shows up in production as a shape that is silently never scanned."""
+    for name, entry in MS.PATTERN_LEDGER.items():
+        if entry.role != "detect":
+            continue
+        assert entry.hints, f"{name} declares no hints"
+        assert any(h in entry.sample for h in entry.hints), (
+            f"{name}'s hints {entry.hints} appear in none of its own sample "
+            f"{entry.sample!r} — the pre-filter would skip it")
+
+
+def test_attribution_patterns_contribute_NO_hints():
+    """They cannot produce a mention on their own, so a text carrying only one
+    of them has nothing to emit; letting them widen the pre-filter would cost
+    the short-circuit and buy nothing."""
+    for name, entry in MS.PATTERN_LEDGER.items():
+        if entry.role == "attribute":
+            assert entry.hints == (), f"{name} widened the filter for nothing"
+
+
+def test_the_terminal_profiles_hints_are_still_the_original_two():
+    """🔴 THE CLICK SURFACE DID NOT MOVE. This is the value the tailer used to
+    hardcode, and it is the value `scripts/mention-open.py` still implies."""
+    assert MS.mention_hints() == ("#", "868")
+    assert MS.mention_hints(MS.PROFILE_TERMINAL) == ("#", "868")
+
+
+def test_the_telemetry_profiles_hints_cover_every_new_shape():
+    """🔴 THE INERT-PREFILTER GUARD, at the module end of the seam. Each of these
+    shapes contains NEITHER '#' NOR '868', so under the terminal hints the
+    tailer's short-circuit would skip the block and the regex would never run."""
+    hints = MS.mention_hints(MS.PROFILE_TELEMETRY)
+    for text in ("https://github.com/gardenersguild/trowelcast/pull/7",
+                 "/audit-pr 1291",
+                 "audit-pr 1291",
+                 "gh pr view 1291",
+                 "gh issue close 42",
+                 "clawgate task 370"):
+        assert any(h in text for h in hints), f"{text!r} would be pre-filtered away"
+        assert not any(h in text for h in MS.mention_hints(MS.PROFILE_TERMINAL)), (
+            f"{text!r} was expected to be invisible to the OLD hints — if it is "
+            "not, this test proves nothing about the widening")
+
+
+def test_an_unknown_profile_falls_back_to_the_NARROW_one():
+    """🔴 A typo must never widen the click surface. Falling back to `telemetry`
+    would be the same defect in the direction nobody notices."""
+    assert MS.patterns_in("teleemtry") == MS.patterns_in(MS.PROFILE_TERMINAL)
+    assert MS.scan_mentions("gh pr view 1291", profile="teleemtry") == []
+    assert MS.mention_hints("nonsense") == ("#", "868")
+
+
+def test_the_terminal_profile_is_the_DEFAULT():
+    """Pinned as a behaviour, not only as a default argument: this is what keeps
+    `scripts/mention-open.py` unchanged without it having to say anything."""
+    for text in ("https://github.com/gardenersguild/trowelcast/pull/7",
+                 "/audit-pr 1291", "gh pr view 1291", "clawgate task 370",
+                 "https://clawgate.zacx.dev/tasks#task-370"):
+        assert MS.scan_mentions(text) == [], f"the DEFAULT profile matched {text!r}"
+        assert MS.scan_mention_spans(text) == []
+
+
+# --------------------------------------------------------------------------- #
+# The enumerated widening — one positive per new shape (telemetry profile)
+# --------------------------------------------------------------------------- #
+TELEMETRY = {"profile": MS.PROFILE_TELEMETRY}
+
+
+def test_a_github_pull_url_is_a_mention_and_carries_its_own_owner():
+    (span,) = MS.scan_mention_spans(
+        "landed https://github.com/gardenersguild/trowelcast/pull/7 today", **TELEMETRY)
+    assert span["platform"] == "github"
+    assert span["id"] == "7"
+    assert span["repo"] == "gardenersguild/trowelcast"
+    assert span["repo_source"] == MS.SOURCE_URL
+    assert span["url"] == "https://github.com/gardenersguild/trowelcast/issues/7"
+
+
+def test_a_github_issues_url_too_and_a_scheme_is_optional():
+    for text in ("github.com/hobbyist/plotwidget/issues/4213",
+                 "https://github.com/hobbyist/plotwidget/issues/4213",
+                 "http://github.com/hobbyist/plotwidget/issues/4213"):
+        (span,) = MS.scan_mention_spans(text, **TELEMETRY)
+        assert span["repo"] == "hobbyist/plotwidget", text
+        assert span["id"] == "4213", text
+
+
+def test_a_url_with_trailing_path_segments_still_names_the_same_pr():
+    """`/pull/7/files` is PR 7. `_NUM_END` permits a following `/` on purpose."""
+    (span,) = MS.scan_mention_spans(
+        "https://github.com/gardenersguild/trowelcast/pull/7/files", **TELEMETRY)
+    assert span["id"] == "7"
+
+
+def test_a_dotted_repo_name_IS_detected_in_the_URL_form():
+    """The no-dots rule exists to keep `index.html#12` out of the `repo#N` form.
+    A URL delimits `owner/repo` with slashes, so the hazard is absent and the
+    cost the module documents for `repo#N` is not paid here."""
+    (span,) = MS.scan_mention_spans(
+        "https://github.com/hobbyist/plot.widget.js/pull/9", **TELEMETRY)
+    assert span["repo"] == "hobbyist/plot.widget.js"
+
+
+@pytest.mark.parametrize("text,num", [
+    ("/audit-pr 1291", "1291"),
+    ("audit-pr 1291", "1291"),
+    ("run /audit-pr 1291 next", "1291"),
+])
+def test_the_audit_pr_command_is_a_github_reference(text, num):
+    (span,) = MS.scan_mention_spans(text, **TELEMETRY)
+    assert span["platform"] == "github"
+    assert span["id"] == num
+
+
+@pytest.mark.parametrize("text,num", [
+    ("gh pr view 1291", "1291"),
+    ("gh pr merge 887 --squash", "887"),
+    ("gh issue close 42", "42"),
+    ("gh issue comment 3", "3"),
+])
+def test_the_gh_cli_forms_are_github_references(text, num):
+    spans = MS.scan_mention_spans(text, **TELEMETRY)
+    assert [s["id"] for s in spans] == [num], text
+    assert spans[0]["platform"] == "github"
+
+
+def test_a_gh_subcommand_that_is_NOT_on_the_enumerated_list_is_not_detected():
+    """🔴 THE ENUMERATION IS THE GUARD. `\\w+` there would make `gh pr 12345`,
+    `gh repo clone 3` and any future subcommand a reference."""
+    assert MS.scan_mentions("gh pr rebase 1291", **TELEMETRY) == []
+    assert MS.scan_mentions("gh repo view 1291", **TELEMETRY) == []
+    assert "rebase" not in MS.GH_CLI_SUBCOMMANDS
+
+
+@pytest.mark.parametrize("text", ["clawgate task 370", "Clawgate task 370",
+                                  "the clawgate Task 370 board"])
+def test_clawgate_task_N_is_a_clawgate_reference(text):
+    (span,) = MS.scan_mention_spans(text, **TELEMETRY)
+    assert span["platform"] == "clawgate"
+    assert span["id"] == "370"
+    assert span["url"] == "https://clawgate.zacx.dev/tasks/370"
+
+
+def test_a_BARE_task_N_is_deliberately_NOT_detected():
+    """🔴 179 occurrences in one measured 24h window, overwhelmingly prose. The
+    literal `clawgate` is the entire anchor; without it there is no pattern here
+    worth having."""
+    for text in ("task 5 of 9", "the task 3 lines down", "task 370"):
+        assert MS.scan_mentions(text, **TELEMETRY) == [], text
+
+
+def test_the_legacy_task_anchor_resolves_to_the_task_page():
+    (span,) = MS.scan_mention_spans(
+        "https://clawgate.zacx.dev/tasks#task-370", **TELEMETRY)
+    assert span["platform"] == "clawgate"
+    assert span["url"] == "https://clawgate.zacx.dev/tasks/370"
+    assert "#" not in span["url"], "the constructor must not mint a fragment"
+
+
+def test_the_legacy_anchor_is_reachable_AFTER_A_WORD_CHARACTER():
+    """🔴 THE INERT-GUARD CASE FOR THIS PATTERN. Every real occurrence of the
+    legacy form sits at the end of `.../tasks#task-N`, where the character before
+    `#` is a LETTER — so the module's standard left guard rejects all of them and
+    a pattern carrying it would be dead on arrival. Deleting the relaxed
+    lookbehind turns this red while every other case above stays green."""
+    (span,) = MS.scan_mention_spans("tasks#task-370", **TELEMETRY)
+    assert span["id"] == "370"
+
+
+def test_git_shas_are_NOT_detected_in_either_profile():
+    """🔴 A `[0-9a-f]{7,12}` probe over one 24h window returned ~520,000 hits.
+    Pinned because it is the widening somebody will reach for next."""
+    for text in ("fixed in 099771da", "squash fd68d48c", "at a1adf740 today"):
+        assert MS.scan_mentions(text, **TELEMETRY) == [], text
+        assert MS.scan_mentions(text) == [], text
+
+
+def test_no_two_spans_ever_OVERLAP_in_the_wider_profile():
+    """🔴 The widening's structural hazard: two patterns claiming overlapping
+    text emit the SAME reference twice. `clawgate task #370` is the case that
+    forced `CLAWGATE_TASK_RE` to refuse a `#`."""
+    text = ("clawgate task 370 and clawgate task #371, "
+            "https://github.com/gardenersguild/trowelcast/pull/7 "
+            "plus gh pr view 12 and /audit-pr 13 and tasks#task-14 "
+            "and 868abc123 and hobbyist/plotwidget#15 and #16")
+    spans = MS.scan_mention_spans(text, **TELEMETRY)
+    assert len(spans) >= 9, spans
+    ends = [(s["start"], s["end"]) for s in spans]
+    for (_a_start, a_end), (b_start, _b_end) in zip(ends, ends[1:]):
+        assert a_end <= b_start, f"spans overlap: {ends}"
+
+
+# --------------------------------------------------------------------------- #
+# ATTRIBUTION — each source proved SEPARATELY
+#
+# 🔴 THE FIXTURE VALUES ARE PAIRWISE DISTINCT AND DISTINCT FROM EVERY CONSTANT
+# THE ASSERTIONS NAME, so a mutant that hardcodes any one owner/repo literal
+# cannot survive by landing on the expected value.
+# --------------------------------------------------------------------------- #
+REPOS = {
+    "trowelcast": "gardenersguild/trowelcast",
+    "plotwidget": "hobbyist/plotwidget",
+    "spadeworks": "rivalorg/spadeworks",
+}
+
+
+def test_A2_a_repo_token_immediately_before_the_ref_attributes_it():
+    (span,) = MS.scan_mention_spans("trowelcast PR #1291", repos=REPOS, **TELEMETRY)
+    assert span["repo"] == "gardenersguild/trowelcast"
+    assert span["repo_source"] == MS.SOURCE_ADJACENT
+    assert span["candidates"][1]["url"] == (
+        "https://github.com/gardenersguild/trowelcast/issues/1291")
+
+
+def test_A2_works_without_a_connector_word_too():
+    (span,) = MS.scan_mention_spans("plotwidget #42", repos=REPOS, **TELEMETRY)
+    assert span["repo"] == "hobbyist/plotwidget"
+
+
+def test_A2_picks_the_repo_ACTUALLY_written_not_a_fixed_one():
+    """Three distinct owners in the fixture, three distinct expectations — a
+    mutant returning any single literal dies on two of the three."""
+    for token, expected in (("trowelcast", "gardenersguild/trowelcast"),
+                            ("plotwidget", "hobbyist/plotwidget"),
+                            ("spadeworks", "rivalorg/spadeworks")):
+        (span,) = MS.scan_mention_spans(f"{token} PR #7", repos=REPOS, **TELEMETRY)
+        assert span["repo"] == expected, token
+
+
+def test_A2_STAYS_AMBIGUOUS_when_the_token_is_not_in_the_measured_mapping():
+    """🔴 THE NO-GUESSING RULE, at the new site. `zzzunknown` is a word, not
+    evidence: without a measured mapping entry there is no owner and none is
+    synthesised."""
+    (span,) = MS.scan_mention_spans("zzzunknown PR #1291", repos=REPOS, **TELEMETRY)
+    assert span["repo"] == ""
+    assert span["repo_source"] == ""
+    assert span["url"] == ""
+    assert all(c["url"] == "" or c["platform"] == "clawgate"
+               for c in span["candidates"])
+
+
+def test_A2_does_not_fire_without_a_repos_mapping_at_all():
+    (span,) = MS.scan_mention_spans("trowelcast PR #1291", **TELEMETRY)
+    assert span["repo"] == ""
+
+
+def test_A2_does_not_attribute_across_a_LINE_BREAK():
+    """`\\Z` not `$`: a repo token ending the previous line is not adjacent."""
+    (span,) = MS.scan_mention_spans("trowelcast\n#1291", repos=REPOS, **TELEMETRY)
+    assert span["repo"] == ""
+
+
+def test_A2_a_common_english_word_before_a_ref_attributes_NOTHING():
+    for text in ("fixed in #370", "PR #370", "see #370"):
+        (span,) = MS.scan_mention_spans(text, repos=REPOS, **TELEMETRY)
+        assert span["repo"] == "", text
+
+
+def test_A3_a_github_url_elsewhere_in_the_block_attributes_a_bare_ref():
+    text = ("reviewed https://github.com/rivalorg/spadeworks/pull/8 "
+            "and then fixed #1291")
+    spans = MS.scan_mention_spans(text, **TELEMETRY)
+    bare = [s for s in spans if s["id"] == "1291"]
+    assert len(bare) == 1
+    assert bare[0]["repo"] == "rivalorg/spadeworks"
+    assert bare[0]["repo_source"] == MS.SOURCE_URL
+
+
+def test_A4_a_repo_flag_elsewhere_in_the_block_attributes_a_bare_ref():
+    text = "ran gh pr list --repo hobbyist/plotwidget, then closed #1291"
+    bare = [s for s in MS.scan_mention_spans(text, **TELEMETRY) if s["id"] == "1291"]
+    assert len(bare) == 1
+    assert bare[0]["repo"] == "hobbyist/plotwidget"
+    assert bare[0]["repo_source"] == MS.SOURCE_FLAG
+
+
+def test_A4_attributes_the_gh_cli_reference_beside_it():
+    """The measured 14/14 case: `gh pr <sub> N --repo owner/repo`."""
+    (span,) = MS.scan_mention_spans(
+        "gh pr view 1291 --repo rivalorg/spadeworks", **TELEMETRY)
+    assert span["repo"] == "rivalorg/spadeworks"
+    assert span["url"] == "https://github.com/rivalorg/spadeworks/issues/1291"
+
+
+def test_the_ladder_ranks_ADJACENT_above_URL_above_FLAG_above_DEFAULT():
+    """🔴 ONE ASSERTION PER RUNG, each removing the rung above it. Testing only
+    the top of a priority list proves nothing about the order below it."""
+    url = "https://github.com/rivalorg/spadeworks/pull/8"
+    flag = "--repo hobbyist/plotwidget"
+    default = "gardenersguild/trowelcast"
+
+    def repo_of(text, **kw):
+        return [s for s in MS.scan_mention_spans(text, **kw, **TELEMETRY)
+                if s["id"] == "1291"][0]["repo"]
+
+    assert repo_of(f"{url} {flag} trowelcast PR #1291",
+                   repos=REPOS, default_repo=default) == "gardenersguild/trowelcast"
+    assert repo_of(f"{url} {flag} fixed #1291",
+                   repos=REPOS, default_repo=default) == "rivalorg/spadeworks"
+    assert repo_of(f"{flag} fixed #1291",
+                   repos=REPOS, default_repo=default) == "hobbyist/plotwidget"
+    assert repo_of("fixed #1291", repos=REPOS,
+                   default_repo=default) == "gardenersguild/trowelcast"
+
+
+def test_TWO_different_repos_in_one_block_attribute_NOTHING():
+    """🔴 SEVERAL IS AN ABSENCE OF AN ANSWER, NOT A TIE TO BREAK. Nearest-wins or
+    first-wins would both be a guess wearing a heuristic's clothes."""
+    text = ("https://github.com/rivalorg/spadeworks/pull/8 and "
+            "https://github.com/hobbyist/plotwidget/pull/9 then #1291")
+    bare = [s for s in MS.scan_mention_spans(text, **TELEMETRY) if s["id"] == "1291"]
+    assert bare[0]["repo"] == ""
+    text2 = ("gh pr list --repo rivalorg/spadeworks; "
+             "gh pr list --repo hobbyist/plotwidget; #1291")
+    bare2 = [s for s in MS.scan_mention_spans(text2, **TELEMETRY) if s["id"] == "1291"]
+    assert bare2[0]["repo"] == ""
+
+
+def test_the_SAME_repo_named_twice_still_attributes():
+    """The other side of `_sole`: a boundary that also swallowed the legitimate
+    case would be a refusal dressed as a rule."""
+    text = ("https://github.com/rivalorg/spadeworks/pull/8 and "
+            "https://github.com/rivalorg/spadeworks/pull/9 then #1291")
+    bare = [s for s in MS.scan_mention_spans(text, **TELEMETRY) if s["id"] == "1291"]
+    assert bare[0]["repo"] == "rivalorg/spadeworks"
+
+
+def test_a_ref_that_NAMES_a_repo_is_never_re_attributed_from_the_block():
+    """🔴 Substituting a different repository for the one the operator wrote is
+    strictly worse than admitting the owner is unknown."""
+    text = ("https://github.com/rivalorg/spadeworks/pull/8 "
+            "and separately zzzunknown#1291")
+    named = [s for s in MS.scan_mention_spans(text, **TELEMETRY) if s["id"] == "1291"]
+    assert named[0]["repo"] == ""
+    assert named[0]["url"] == ""
+
+
+def test_attribution_does_not_SETTLE_the_platform():
+    """Which repository and which platform are two questions. A `#N` next to a
+    repo name is still possibly a clawgate task."""
+    (span,) = MS.scan_mention_spans("trowelcast PR #1291", repos=REPOS, **TELEMETRY)
+    assert span["ambiguous"] is True
+    assert span["platform"] == "ambiguous"
+    assert span["url"] == ""
+    assert [c["platform"] for c in span["candidates"]] == ["clawgate", "github"]
+
+
+def test_repo_source_is_EMPTY_exactly_when_repo_is():
+    for text, kw in (("fixed #1", {}),
+                     ("trowelcast PR #1", {"repos": REPOS}),
+                     ("gardenersguild/trowelcast#1", {}),
+                     ("#1", {"default_repo": "rivalorg/spadeworks"})):
+        for span in MS.scan_mention_spans(text, **kw, **TELEMETRY):
+            assert bool(span["repo"]) == bool(span["repo_source"]), (text, span)
+
+
+def test_the_explicit_source_is_reported_for_an_owner_written_out():
+    (span,) = MS.scan_mention_spans("gardenersguild/trowelcast#1065", **TELEMETRY)
+    assert span["repo_source"] == MS.SOURCE_EXPLICIT
+    (span,) = MS.scan_mention_spans("#1065", default_repo="hobbyist/plotwidget",
+                                    **TELEMETRY)
+    assert span["repo_source"] == MS.SOURCE_DEFAULT
+
+
+# --------------------------------------------------------------------------- #
+# The wider profile's own documented residuals
+# --------------------------------------------------------------------------- #
+def test_the_telemetry_residual_false_positives_are_pinned_as_a_set():
+    """Same discipline as `_KNOWN_FALSE_POSITIVES`: the acceptance stays a
+    DECISION rather than becoming a surprise. Each of these DOES match, and each
+    is documented in the module."""
+    assert set(MS._KNOWN_FALSE_POSITIVES_TELEMETRY) == {
+        "gh pr view 12", "/audit-pr 12", "[the old anchor](#task-1)"}
+    for shape in MS._KNOWN_FALSE_POSITIVES_TELEMETRY:
+        assert MS.scan_mentions(shape, **TELEMETRY), (
+            f"{shape!r} was expected to still match in the wider profile")
+
+
+def test_the_original_residual_set_is_UNCHANGED():
+    """The click surface's accepted noise did not move — pinned separately so a
+    telemetry-only addition cannot quietly land on it."""
+    assert set(MS._KNOWN_FALSE_POSITIVES) == {"#123"}
+
+
+# --------------------------------------------------------------------------- #
+# clean_repo_map — ONE definition of the mapping-value rule
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("value", [
+    "acme/widget/", "acme//widget", "acme/widget ", "acme/wid\nget",
+    "acme/widget\n", "/acme/widget", "acme", 12, None,
+])
+def test_clean_repo_map_drops_anything_that_is_not_exactly_owner_slash_repo(value):
+    assert MS.clean_repo_map({"widget": value}) == {}
+
+
+def test_clean_repo_map_keeps_a_good_entry_and_is_total_on_junk():
+    assert MS.clean_repo_map({"a": "gardenersguild/trowelcast", "b": "nope"}) == {
+        "a": "gardenersguild/trowelcast"}
+    for junk in (None, [], "", 3, {1: "a/b"}):
+        assert MS.clean_repo_map(junk) == {}

--- a/scripts/tests/test_mention_scan.py
+++ b/scripts/tests/test_mention_scan.py
@@ -620,15 +620,40 @@ def test_A2_does_not_fire_without_a_repos_mapping_at_all():
 
 
 def test_A2_does_not_attribute_across_a_LINE_BREAK():
-    """`\\Z` not `$`: a repo token ending the previous line is not adjacent."""
+    """`\\Z` not `$`: a repo token ending the previous line is not adjacent.
+
+    🔴 THE SECOND CASE IS THE ONE THAT DISCRIMINATES, and the first alone does
+    not. With no trailing space, `[ \\t]+$` cannot match either — so a `$`
+    mutant SURVIVED the first case, measured. `$` matches immediately BEFORE a
+    final newline, so a line ending in "<repo> " is exactly where the two spell
+    different behaviour."""
     (span,) = MS.scan_mention_spans("trowelcast\n#1291", repos=REPOS, **TELEMETRY)
     assert span["repo"] == ""
+    (span,) = MS.scan_mention_spans("trowelcast \n#1291", repos=REPOS, **TELEMETRY)
+    assert span["repo"] == "", "`$` matched before the trailing newline"
 
 
 def test_A2_a_common_english_word_before_a_ref_attributes_NOTHING():
     for text in ("fixed in #370", "PR #370", "see #370"):
         (span,) = MS.scan_mention_spans(text, repos=REPOS, **TELEMETRY)
         assert span["repo"] == "", text
+
+
+def test_A2_a_NON_connector_word_between_the_repo_and_the_ref_breaks_adjacency():
+    """🔴 WHAT THE ENUMERATED CONNECTOR LIST IS FOR, and the case that
+    discriminates it from `\\w+`. Under a generic word `trowelcast thing #370`
+    attributes to trowelcast — a repository the operator was not referring to.
+    Measured: without this case a `\\w+` mutant SURVIVED, because every other
+    negative here uses a token that is absent from the mapping anyway, so the
+    mapping killed the mutant rather than the enumeration."""
+    for text in ("trowelcast thing #370", "trowelcast unrelated #370",
+                 "trowelcast, #370"):
+        (span,) = MS.scan_mention_spans(text, repos=REPOS, **TELEMETRY)
+        assert span["repo"] == "", text
+    # ...while the enumerated connectors still work, so this is a rule and not
+    # simply a narrower pattern.
+    (span,) = MS.scan_mention_spans("trowelcast issue #370", repos=REPOS, **TELEMETRY)
+    assert span["repo"] == "gardenersguild/trowelcast"
 
 
 def test_A3_a_github_url_elsewhere_in_the_block_attributes_a_bare_ref():

--- a/scripts/tests/test_mention_scan.py
+++ b/scripts/tests/test_mention_scan.py
@@ -746,12 +746,19 @@ def test_attribution_does_not_SETTLE_the_platform():
 
 
 def test_repo_source_is_EMPTY_exactly_when_repo_is():
+    """🔴 BOTH LAYERS. A span builds its `repo_source` from a candidate that has
+    a `repo`, so the span layer cannot observe a candidate that carries a source
+    with no repo — the `zzzunknown#1` row is invisible to a span-only sweep and
+    is the case the guard exists for."""
     for text, kw in (("fixed #1", {}),
                      ("trowelcast PR #1", {"repos": REPOS}),
                      ("gardenersguild/trowelcast#1", {}),
+                     ("zzzunknown#1", {"repos": REPOS}),
                      ("#1", {"default_repo": "rivalorg/spadeworks"})):
         for span in MS.scan_mention_spans(text, **kw, **TELEMETRY):
             assert bool(span["repo"]) == bool(span["repo_source"]), (text, span)
+        for cand in MS.scan_mentions(text, **kw, **TELEMETRY):
+            assert bool(cand["repo"]) == bool(cand["repo_source"]), (text, cand)
 
 
 def test_the_explicit_source_is_reported_for_an_owner_written_out():
@@ -760,6 +767,122 @@ def test_the_explicit_source_is_reported_for_an_owner_written_out():
     (span,) = MS.scan_mention_spans("#1065", default_repo="hobbyist/plotwidget",
                                     **TELEMETRY)
     assert span["repo_source"] == MS.SOURCE_DEFAULT
+
+
+def test_a_bare_repo_hash_N_resolved_through_the_MAPPING_is_not_called_explicit():
+    """🔴 `explicit` MUST MEAN THE TEXT WROTE THE OWNER OUT.
+
+    `trowelcast#591` and `gardenersguild/trowelcast#591` used to report the SAME
+    `repo_source`, because `_resolve_repo` falls through to the caller's mapping
+    when no owner was written and the caller labelled the result `explicit`
+    regardless. The field's whole stated purpose is telling "the text said so"
+    apart from "our mapping said so"; reporting both as `explicit` is one
+    measurement pretending to be two.
+
+    Both halves are asserted TOGETHER, and against the SAME repository, so the
+    only thing that can differ is the source — a mutant that collapses the two
+    dies here rather than on an unrelated fixture difference."""
+    (mapped,) = MS.scan_mention_spans("see trowelcast#591", repos=REPOS, **TELEMETRY)
+    (written,) = MS.scan_mention_spans("see gardenersguild/trowelcast#591",
+                                       repos=REPOS, **TELEMETRY)
+    assert mapped["repo"] == written["repo"] == "gardenersguild/trowelcast"
+    assert mapped["repo_source"] == MS.SOURCE_MAPPED, (
+        "a MAPPING-resolved repo is reported as if the text stated it")
+    assert written["repo_source"] == MS.SOURCE_EXPLICIT
+    assert MS.SOURCE_MAPPED != MS.SOURCE_EXPLICIT, (
+        "a MAPPING-resolved repo is reported as if the text stated it")
+
+
+def test_the_TERMINAL_profile_reports_the_mapped_source_too():
+    """The `repo#N` -> mapping route is in BOTH profiles (it is `GITHUB_RE`), so
+    the new value is not a telemetry-only vocabulary the click surface never
+    emits."""
+    (span,) = MS.scan_mention_spans("see plotwidget#42", repos=REPOS)
+    assert (span["repo"], span["repo_source"]) == ("hobbyist/plotwidget",
+                                                   MS.SOURCE_MAPPED)
+
+
+def test_a_repo_hash_N_the_MAPPING_CANNOT_resolve_reports_NO_source():
+    """🔴 THE `source if repo else SOURCE_NONE` GUARD, AT THE LAYER THAT CAN SEE
+    IT. `zzzunknown#12` takes the `mapped` branch — the text named a repo — but
+    the mapping does not hold it, so there is no owner. Without the guard the
+    CANDIDATE reads `repo="" repo_source="mapped"`: a claim that a resolution
+    happened, beside the evidence that it did not.
+
+    ⚠ ASSERTED ON `scan_mentions`, NOT ON A SPAN, and that is the whole point.
+    `scan_mention_spans` takes its `repo_source` from whichever candidate carries
+    a `repo`, so a span with none reports `""` no matter what its candidates say
+    — a span-level assertion is satisfied by the span builder and never
+    evaluates this guard at all. Measured: a mutant deleting the ternary
+    SURVIVED a span-level version of this test. The candidate layer is public,
+    documented API (`scan_mentions`' docstring pins `""` exactly when `repo` is
+    `""`), so the contract is real even though this repo's two consumers both
+    read spans."""
+    cands = MS.scan_mentions("see zzzunknown#12", repos=REPOS, **TELEMETRY)
+    assert [c["platform"] for c in cands] == ["github"], cands
+    assert cands[0]["repo"] == ""
+    assert cands[0]["repo_source"] == MS.SOURCE_NONE == "", (
+        "repo_source claims a resolution that did not happen")
+    assert cands[0]["url"] == ""
+    # And the span the consumers actually read agrees.
+    (span,) = MS.scan_mention_spans("see zzzunknown#12", repos=REPOS, **TELEMETRY)
+    assert (span["repo"], span["repo_source"], span["url"]) == ("", "", "")
+
+
+# --------------------------------------------------------------------------- #
+# 🔴 THE PROFILE SPLIT, ENFORCED AT THE THREE ATTRIBUTION SITES
+#
+# The PR that introduced `profile` relaxed this module's "one set of regexes,
+# they can never drift apart" invariant on the argument that the DEFAULT stays
+# `terminal`. That default was pinned at the module (`patterns_in`) and nowhere
+# at the three places that CONSULT it, so an independent mutation sweep deleted
+# each `if "<NAME>" in on` in turn with the whole suite green. These are the
+# pins. Each case names ONE route and would still pass with the other two guards
+# deleted, so the file cannot lose coverage of a route by a fixture edit.
+# --------------------------------------------------------------------------- #
+def test_no_TELEMETRY_only_attribution_route_answers_in_the_terminal_profile():
+    cases = {
+        # `REPO_BEFORE_RE` — the adjacent-token route.
+        "adjacent": "trowelcast PR #1291",
+        # `GITHUB_URL_RE` as an ATTRIBUTION source (its DETECT role is guarded
+        # separately). The bare `#1291` is what must stay unattributed.
+        "url": "https://github.com/hobbyist/plotwidget/pull/8 and also #1291",
+        # `REPO_FLAG_RE` — the `--repo owner/repo` route.
+        "flag": "--repo rivalorg/spadeworks then #1291",
+    }
+    for route, text in cases.items():
+        terminal = MS.scan_mention_spans(text, repos=REPOS)
+        bare = [s for s in terminal if s["raw"] == "#1291"]
+        assert len(bare) == 1, (route, terminal)
+        assert bare[0]["repo"] == "", (
+            f"the {route} attribution route answered in the TERMINAL profile")
+        assert bare[0]["repo_source"] == "", (route, bare[0])
+        # POSITIVE CONTROL — the same text DOES attribute at the telemetry
+        # profile. Without this the assertions above would be satisfied by a
+        # fixture that attributes nowhere, which proves nothing about the guard.
+        telemetry = MS.scan_mention_spans(text, repos=REPOS, **TELEMETRY)
+        attributed = [s for s in telemetry if s["raw"] == "#1291"]
+        assert len(attributed) == 1 and attributed[0]["repo"], (route, telemetry)
+
+
+# --------------------------------------------------------------------------- #
+# TASK_ANCHOR_RE's relaxed-but-not-absent left guard
+# --------------------------------------------------------------------------- #
+def test_the_legacy_anchor_left_guard_still_rejects_an_entity_and_a_heading_run():
+    """🔴 `(?<![&#])` IS LIVE, and it was untested — a sweep deleting it survived.
+
+    The guard is deliberately LOOSER than `_BARE_BEFORE` (the real
+    `…/tasks#task-370` case is preceded by a letter), but it is not absent: `&`
+    excludes an HTML entity and `#` excludes a `##` run. The positive control is
+    the third assertion — without it a mutant that broke the pattern entirely
+    would also pass the two negatives."""
+    assert MS.scan_mentions("&#task-1", **TELEMETRY) == [], (
+        "the legacy-anchor left guard is gone")
+    assert MS.scan_mentions("##task-1", **TELEMETRY) == [], (
+        "the legacy-anchor left guard is gone")
+    assert [(m["platform"], m["id"]) for m in
+            MS.scan_mentions("https://clawgate.zacx.dev/tasks#task-370",
+                             **TELEMETRY)] == [("clawgate", "370")]
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/tests/test_mutation_battery_anchors.py
+++ b/scripts/tests/test_mutation_battery_anchors.py
@@ -68,6 +68,7 @@ HERE = Path(__file__).resolve().parent
 BATTERIES = (
     "mutation_battery_resume_state.py",
     "mutation_battery_resume_state_skill.py",
+    "mutation_battery_mentions.py",
 )
 
 # 🔴 PYTHON MUTATION INSTRUMENTS THIS MODULE CANNOT PIN, each with its reason.
@@ -104,7 +105,7 @@ def _load(filename: str | Path):
 def _anchors(mod):
     """`(mutant_id, pattern)` for every anchor in a battery's table.
 
-    `old` is the 4th field in BOTH tables (the skill battery adds a 6th
+    `old` is the 4th field in ALL tables (the skill battery adds a 6th
     `expected` field after it, and nothing before it). It may be a TUPLE of
     patterns applied in order — the skill battery's multi-site mutants — and
     each element is separately required to occur exactly once, which is the
@@ -117,11 +118,39 @@ def _anchors(mod):
             yield mid, pat
 
 
-def _offenders(text: str, mod) -> list[tuple[str, str, int]]:
-    """Anchors that do NOT occur exactly once in `text`."""
-    return [(mid, pat, text.count(pat))
-            for mid, pat in _anchors(mod)
-            if text.count(pat) != 1]
+def _target_of(mod, mid) -> Path:
+    """The file a row's anchor must occur exactly once in.
+
+    🔴 A BATTERY MAY SPAN SEVERAL FILES. `mutation_battery_mentions.py` does,
+    because the defects it exists for live at the SEAMS between the scanner, the
+    tailer and the click handler rather than inside any one of them — a battery
+    restricted to one `SCRIPT` structurally cannot express those. Such a battery
+    declares `TARGETS = {mutant_id: Path}`; a single-file battery declares only
+    `SCRIPT` and every row resolves to it, unchanged.
+    """
+    return getattr(mod, "TARGETS", {}).get(mid, mod.SCRIPT)
+
+
+def _offenders(mod, override: dict | None = None) -> list[tuple[str, str, int]]:
+    """Anchors that do NOT occur exactly once in their own target file.
+
+    `override` maps a Path to text to use INSTEAD of reading that file — the
+    negative control's mechanism, so it can exercise both failure shapes without
+    writing to a battery's target in the tree.
+    """
+    override = override or {}
+    cache: dict[Path, str] = {}
+    bad = []
+    for mid, pat in _anchors(mod):
+        path = _target_of(mod, mid)
+        if path in override:
+            text = override[path]
+        else:
+            text = cache.setdefault(path, path.read_text(encoding="utf-8"))
+        n = text.count(pat)
+        if n != 1:
+            bad.append((mid, pat, n))
+    return bad
 
 
 @pytest.mark.parametrize("battery", BATTERIES)
@@ -129,17 +158,19 @@ def test_every_mutation_anchor_occurs_exactly_once_in_its_target(battery):
     """🔴 THE GUARD. A 0x anchor is a row that tests nothing; a 2x anchor is a
     mutation applied at a site the row does not describe."""
     mod = _load(battery)
-    text = mod.SCRIPT.read_text(encoding="utf-8")
-    bad = _offenders(text, mod)
+    bad = _offenders(mod)
     assert not bad, (
-        f"{battery}: {len(bad)} anchor(s) do not occur EXACTLY ONCE in "
-        f"{mod.SCRIPT.relative_to(HERE.parents[1])}.\n"
+        f"{battery}: {len(bad)} anchor(s) do not occur EXACTLY ONCE in their "
+        "target file.\n"
         "An anchor at 0x makes its row report `!! PATTERN OCCURS 0x — NOT "
         "APPLIED` and score as a SURVIVOR without testing anything; an anchor "
         "at 2x mutates a second site the row's description does not name.\n"
         "FIX THE BATTERY ROW, not this test — re-anchor `old` on the line as it "
         "now reads, and re-run the battery to confirm the row still kills.\n"
-        + "\n".join(f"  {mid}: occurs {n}x — {pat!r}" for mid, pat, n in bad)
+        + "\n".join(
+            f"  {mid}: occurs {n}x in "
+            f"{_target_of(mod, mid).relative_to(HERE.parents[1])} — {pat!r}"
+            for mid, pat, n in bad)
     )
 
 
@@ -157,22 +188,54 @@ def test_the_anchor_check_can_go_RED_in_BOTH_directions(battery):
     Membership, not equality: removing or duplicating one pattern can move the
     count of another anchor that shares text with it, and that is not what this
     control is asserting.
+
+    The copy is fed in through `override` rather than written to disk, and it is
+    keyed on the FIRST ROW'S OWN target — which for a multi-file battery is not
+    necessarily `SCRIPT`.
     """
     mod = _load(battery)
-    text = mod.SCRIPT.read_text(encoding="utf-8")
     mid, pat = next(_anchors(mod))
+    target = _target_of(mod, mid)
+    text = target.read_text(encoding="utf-8")
 
-    gone = _offenders(text.replace(pat, "", 1), mod)
+    gone = _offenders(mod, {target: text.replace(pat, "", 1)})
     assert (mid, pat, 0) in gone, (
         f"deleting {mid}'s anchor did not report it at 0x — the checker cannot "
         f"see the failure it exists for. offenders={gone!r}"
     )
 
-    twice = _offenders(text + pat, mod)
+    twice = _offenders(mod, {target: text + pat})
     assert (mid, pat, 2) in twice, (
         f"duplicating {mid}'s anchor did not report it at 2x. "
         f"offenders={twice!r}"
     )
+
+
+@pytest.mark.parametrize("battery", BATTERIES)
+def test_every_declared_TARGET_exists_and_is_named_by_a_row(battery):
+    """🔴 A `TARGETS` MAP IS A LEDGER, AND AN UNPINNED ROW IS THE FAILURE IT
+    EXISTS TO PREVENT. Two ways it rots, both silent:
+
+      * a row with no entry falls back to `SCRIPT`, so its anchor is checked
+        against the WRONG FILE — where it occurs 0x, which this module would
+        then report as a battery bug rather than as the mapping bug it is;
+      * an entry naming a mutant id no row carries is a stale pointer that
+        reads as coverage.
+
+    A battery with no `TARGETS` is single-file and passes trivially — asserted
+    rather than skipped, so the two families run the same check.
+    """
+    mod = _load(battery)
+    targets = getattr(mod, "TARGETS", {})
+    ids = [row[0] for row in mod.MUTANTS]
+    assert len(ids) == len(set(ids)), f"{battery}: duplicate mutant ids"
+    if targets:
+        missing = [i for i in ids if i not in targets]
+        assert not missing, f"{battery}: rows with no TARGETS entry: {missing}"
+        stale = [k for k in targets if k not in ids]
+        assert not stale, f"{battery}: TARGETS names no such row: {stale}"
+    for path in ({*targets.values()} or {mod.SCRIPT}):
+        assert path.is_file(), f"{battery}: target does not exist: {path}"
 
 
 def test_the_anchor_check_is_not_vacuous_because_the_tables_are_NON_EMPTY():
@@ -182,9 +245,21 @@ def test_the_anchor_check_is_not_vacuous_because_the_tables_are_NON_EMPTY():
     for battery in BATTERIES:
         mod = _load(battery)
         pats = list(_anchors(mod))
-        assert len(pats) >= 20, (
-            f"{battery} yielded {len(pats)} anchors; the tables have dozens. "
-            "The reader is broken, not the batteries."
+        # 🔴 DERIVED FROM THE TABLE, NOT A LITERAL. This used to be `>= 20`,
+        # which is a claim about how big the two original batteries happened to
+        # be — a 16-row battery added later failed it while its reader worked
+        # perfectly. Every row contributes at least one anchor and a multi-site
+        # row contributes more, so `len(pats) >= len(MUTANTS)` is the real
+        # invariant; the small absolute floor only rejects an import that
+        # yielded a stub. What catches a reader pointed at the WRONG FIELD is
+        # the exactly-once check above, where a `new` pattern occurs 0x.
+        assert len(mod.MUTANTS) >= 5, (
+            f"{battery} has {len(mod.MUTANTS)} rows; that is a stub, not a "
+            "battery — or the import yielded the wrong object."
+        )
+        assert len(pats) >= len(mod.MUTANTS), (
+            f"{battery} yielded {len(pats)} anchors for {len(mod.MUTANTS)} "
+            "rows; the reader is broken, not the battery."
         )
         assert mod.SCRIPT.is_file(), f"{battery}: SCRIPT does not exist"
 


### PR DESCRIPTION
## What and why

92% of the mentions detected in a measured 24h window were an ambiguous bare
`#N` — and the commonest shape, `<repo> PR #1291`, threw away the repo name two
words to its left. That **misattribution**, not the genuinely missed references,
is roughly 10x the volume. This PR fixes the attribution first and widens
detection second, and it does the widening for the **telemetry** consumer only.

## 1. Attribution (the primary change)

Every candidate and span now carries `repo` (an `owner/repo`, or `""`) and
`repo_source` naming HOW it was resolved, in a documented priority order:

| source | evidence | profile |
|---|---|---|
| `explicit` | an `owner/repo#N` written out | both |
| `mapped` | a bare `repo#N` — the text named the REPO, the OWNER came from the caller-MEASURED `repos` mapping | both |
| `adjacent` | a repo token immediately before the ref, looked up in the caller-MEASURED `repos` mapping | telemetry |
| `url` | a `github.com/owner/repo/(pull\|issues)/N` in the same text | telemetry |
| `flag` | a `--repo owner/repo` in the same text | telemetry |
| `default` | the caller-supplied `default_repo` | both |

🔴 **`explicit` means the TEXT wrote the owner out, and nothing else.**
`trowelcast#591` and `gardenersguild/trowelcast#591` are different evidence: the
first is a name our mapping resolved, the second is a repository the operator
stated. Reporting both as `explicit` — which round 1 of this PR did — makes an
analysis that cannot separate "the text said so" from "our mapping said so", i.e.
one measurement pretending to be two. `mapped` is the second of them.

🔴 **Nothing is guessed, and the no-guessing rule is *extended*, not relaxed.**
A repo token absent from the mapping leaves the ref unattributed — there is no
default org. A block naming **two different** repositories attributes **nothing**:
several is an absence of an answer, not a tie to break by position. And a ref
that NAMES a repo is never re-attributed from the block, because substituting a
different repository for the one the operator wrote is worse than admitting the
owner is unknown.

Attribution does **not** settle the platform. Which repository a `#N` belongs to
and whether it is a GitHub issue or a clawgate task are different questions;
answering the first is not a claim about the second, so the span stays ambiguous.

### 1b. 🔴 The dedupe key carries the attribution, and the migration is CHOSEN

The tailer keys its per-session ledger on the mention's identity. Keying that on
`platform:raw` alone throws away the very thing this PR computes: 92% of mentions
are a bare `#N`, so `raw` is `#1291` for nearly all of them and the FIRST
occurrence in a session wins. Measured on real transcripts: **34 rows/day shipped
`repo=""` although an attribution was available** (15% of the rows that had one),
and **6 rows/day dropped a second repository's reference outright** —
`trowelcast PR #1291` and `plotwidget PR #1291` collapsing to one row. Because
the bare form usually appears first, the loss was biased systematically downward.

🔴 **THE SUFFIX IS CONDITIONAL, AND THAT IS THE MIGRATION DECISION.** An
unattributed mention keys **byte-identically to before** (`platform:raw`); only
an attributed one takes the `@owner/repo` suffix. The deployed tailer passes NO
mapping (`collect_mentions(objects)`), so **every key in every host's
`session-summary-state.json` today was written with `repo == ""` and still
matches** — nothing already emitted re-emits. The obvious alternative, an
unconditional `platform:repo:raw`, would have re-keyed the lot and re-emitted
every already-shipped mention once on both hosts. What DOES re-emit once under
the chosen format is exactly the set that newly gains an attribution — a row
whose content genuinely changed, which is the row this PR exists to ship.
(`@` is safe as the separator: no pattern in `mention_scan` can put one in `raw`.)

## 2. Detection — telemetry profile only, ENUMERATED

`github.com/owner/repo/(pull|issues)/N` · `/audit-pr N` and `audit-pr N` ·
`gh (pr|issue) <enumerated-subcommand> N` · `task N` **only** behind the literal
`clawgate` · the legacy `#task-N` anchor.

Deliberately **not** added, measured rather than assumed: a bare `task N` (179
occurrences in one 24h window, overwhelmingly prose), a bare `PR N`, and git
shas — a `[0-9a-f]{7,12}` probe over the same window returned ~520,000 hits.
Each of those is a generic pattern, which is the shape the module's own
`DEV-123` note already refuses.

## 3. The profile split is EXPLICIT — and now ENFORCED at the consumer

This deliberately relaxes the module's "one set of regexes, they can never drift
apart" invariant, along one axis only. `PATTERN_LEDGER` names every compiled
pattern with the profiles it is consulted in and is pinned **two-way** by the
suite — a pattern with no entry fails, an entry naming no pattern fails.
`NON_SCAN_PATTERNS` is the only other home a pattern may have and is pinned too,
so "in neither" is a failure rather than a gap. The default is `terminal`, so
`scripts/mention-open.py` keeps today's narrow click-safe surface without saying
anything, and every pre-existing negative case still holds.

🔴 **That default was pinned at the module and NOWHERE at the four sites that
consult it.** An independent mutation sweep deleted each of the three
`if "<NAME>" in on` attribution guards, and added `profile="telemetry"` to
`mention-open.py`'s only `scan_mention_spans` call — putting the WIDE profile on
the terminal click surface — with **all 313 tests green** for each. All four are
now pinned behaviourally, each with a positive control proving the same fixture
DOES attribute (or DOES match) at the telemetry profile, so none of them can pass
by scanning nothing. The click-surface pin is driven off `PATTERN_LEDGER` itself,
so a telemetry-only pattern added later is covered without anyone remembering.

## 4. 🔴 The inert-prefilter trap

`session-tailer.py` had `_MENTION_HINTS = ("#", "868")`, a cheap short-circuit
applied **before** the regex pass that skipped ~4 assistant text blocks in 5.
Every new shape — `audit-pr 1291`, `gh pr view 1291`, `clawgate task 370`, a
github URL — contains **neither** literal, so adding the regexes alone would have
shipped a **completely dead feature** that still passed any unit test calling
`scan_mentions()` directly.

It is now **derived** from the same ledger, at the **telemetry** profile (using
the default would return the old two literals and look correct). The suite proves
each shape reachable through `collect_mentions`, with a control asserting each
fixture really was invisible to the old value — without that control the
reachability test could pass against a prefilter that never moved.

⚠ **The percentage is a property of the WINDOW, not of the code**, and this PR
previously quoted two different windows as if they were one. Re-measured over the
24h to **2026-09-04** (10,118 assistant text blocks across 312 transcripts): the
OLD two literals skip **8,169 = 81%**, the derived telemetry set skips
**7,990 = 79%** — the short-circuit survives the widening. The earlier
development window (6,052 blocks) read 82% → 80%. Both source comments now carry
the counts and the caveat.

## 5. 🔴 Disclosure: BOTH consumers of `known_repos.json` are now guarded

`known_repos.json` names private repositories — the file whose committed ancestor
disclosed 232 of them into this PUBLIC repo (#1283). This PR newly wires the
**tailer** to it, and the asymmetry that shipped in round 1 was backwards: the
hint handler, which sends the mapping to a rofi window that closes, had a guard;
the tailer, which sends it into a **durable ClickHouse table**, had none.

* `mention-open.py`'s guard **stubbed `notify`** — the only function in the module
  that writes to stderr or `notify-send`. MEASURED: with the universe added to the
  **refusal** path's `notify` body (reachable — `--print` skips PASS 4 while
  `discovered` holds every private name), the pre-fix suite reported **92 passed**.
  It now stubs `subprocess.run` instead, keeps the real `notify`, enumerates every
  sink in one helper, and covers the refusal path as well as the picker path.
* `session-tailer.py` gains its first such guard, at the SPOOL: the run's raw
  spool bytes, the decoded events, stdout and stderr, on an attributed run and on
  an unattributed one. MEASURED: the pre-fix suite reported **106 passed** with
  the whole mapping appended to `b64:repo`, and again with it in `context`.

Both guards lead with their positive controls — the attributed repo IS present,
the mapping the run held really did have the other entries in it — so a clean
verdict is never a scan wired to nothing.

## Also: the terminal handler no longer dead-ends (operator request)

Separate axis from the detection split — this is resolution **UX**, not what gets
underlined. Three dead ends now open a rofi picker with `-matching fuzzy` instead
of refusing:

1. **The namesake cap is gone.** It refused above 8, arguing "a 100-row list of
   URLs differing only by owner is not a choice, it is a wall". True of a list you
   can only SCROLL, false of one you can TYPE AT — `kubernetes#1` is now four
   keystrokes from the right owner. That comment is replaced in the same change,
   because a comment left asserting a hazard the code has closed is how the
   refusal comes back.
2. **A search that matched nothing** offers the host's known-repo universe, so
   `talos-inf#12` can still reach `talos-infra`.
3. **A bare `#N` nothing could attribute** appends the universe *below* the
   clawgate row, so the 92% case is still one Enter away.

A picker is a CHOICE, not a guess. 🔴 A universe row is **never opened without a
selection, even when it is the only one** — the first version of this did open it,
and a one-repo host would have answered `zzznosuchrepo#77` by opening issue 77 in
an unrelated repository. Dismissal still opens nothing. `--print` and
`--no-discovery` never reach the universe. An unreadable or empty universe
degrades to the original refusal, which still names WHICH empty it is; and a
search that could not RUN is announced **alongside** the picker rather than being
swallowed by it.

⚠ **Removing the cap changed `--print`, and that is DECLARED rather than
discovered.** `--print widget#12` with nine namesakes used to exit 1 with a named
refusal; it now prints nine URLs and exits 0. **Intended**: `--print`'s documented
contract is "print every candidate when ambiguous", a namesake set is exactly that
ambiguity, and every row is an EXACT-name search hit — evidence about the name the
operator typed. It is **not** the PASS 4 universe, which is evidence about nothing
and stays barred from `--print`. A consumer wanting one answer writes
`owner/repo#N`. Pinned by a test, at nine rather than eight so a fixture cannot
confuse "no cap" with "a cap nobody reached".

## Measured — the development 24h window, counts only

```
assistant text blocks (non-sidechain): 6,052   chars: 3,068,092

spans detected   BEFORE 2,088   ->   AFTER 2,294        (+206, +9.9%)
   ambiguous      1,926              1,926   (unchanged, by design)
   github           151                347   (+196)
   clickup           11                 11
   clawgate           0                 10   (new)

spans carrying an owner/repo   BEFORE 27  ->  AFTER 475   (17.6x)
   by source: url 323 · explicit 103 · adjacent 35 · flag 14
```

⚠ The `by source` split predates the `explicit`/`mapped` separation, so its
`explicit 103` is the MERGED figure the fix above exists to break apart. It has
not been re-measured; the number is left as-is rather than restated with a
distinction it does not carry.

## Deploy note

🔴 **CORRECTED — the earlier version of this note was wrong in the direction that
misleads verification.** It said both runtime files are `home.file` targets, so
nothing changes until a switch. That is true of the telemetry half only.

| half | deployed as | when it changes |
|---|---|---|
| telemetry — `mention_scan.py` + `session-tailer.py` under `~/.config/activity-collector/` | `home.file` **store copies** (verified `readlink -f` → `/nix/store/…`) | only on `home-manager switch` (`scripts/ship.sh`) |
| terminal — the Alacritty hint | a `writeShellScript` wrapper that **execs the working tree**, `nix/programs/alacritty/default.nix:26` | **on `git pull`, no switch** |

And the terminal half drags the scanner with it: `mention-open.py` does
`sys.path.insert(0, <its dir>/collector)`, so a click imports **the repo's**
`scripts/collector/mention_scan.py`, not the store copy. One file, two deploy
lifetimes depending on which consumer reads it — which is why `readlink -f`, and
never a diff, is the arbiter. So the picker, the removed cap, the universe
fallback and the `--print` behaviour go live the moment `main` is pulled on a
host; the ClickHouse rows still need the switch.

## Gate

Run on a TRUE **MERGED** tree — ``7d94c568``, this branch merged with current
`origin/main` `f887e958`. (Round 1 claimed `316ccf74` as "the merged tree"; that
was the branch head and its merge base was `cc409f82`, so that merge was a no-op
and the gate never saw `main`.) The nix derivations were built **one at a time**.

| tier | leg | result |
|---|---|---|
| dev host (`scripts/gate.sh --tier both`) | pytest | PASS — collected 21,642 / passed 21,639 / skipped 3 / failed 0 (floor 18,610) |
| dev host | node | PASS — 1,449 tests, 41 files, 0 fail (floor 1,367) |
| sandbox (`nix build .#checks.x86_64-linux.pytests`) | pytest | PASS — collected 21,642 / passed 21,639 / skipped 3 / failed 0 |
| sandbox (`nix build .#checks.x86_64-linux.nodetests`) | node | PASS — 1,449 tests, 0 fail |

## Test discipline

**Mutation sweep — COMMITTED this time.**
`scripts/tests/mutation_battery_mentions.py` is re-runnable from the tree:

```
python3 scripts/tests/mutation_battery_mentions.py
```

Round 1's sweep lived in `/tmp`, so the auditor could not re-run it and built
their own — which found four guards the first had not imagined. This one spans
**three files**, because the defects it exists for live at the SEAMS between the
scanner, the tailer and the click handler rather than inside any one of them;
`scripts/tests/test_mutation_battery_anchors.py` (which IS collected) gains
per-row `TARGETS` support so a row whose anchor stops occurring exactly once
fails the push instead of silently scoring SURVIVED.

Latest run: **16/16 killed for the stated reason, 0 survived**, positive control
`P1` KILLED, restore verified by hash. Fourteen of the sixteen rows carry an
`expected` phrase and are scored `KILLED(attributed)` — the row's own assertion
went red, not merely "a test failed". Every run sets `PYTHONDONTWRITEBYTECODE=1`.

**One survivor found and closed during this round.** `repo_source: source if repo
else SOURCE_NONE` is observable on a CANDIDATE and **not on a span** —
`scan_mention_spans` takes its `repo_source` from a candidate that HAS a repo, so
it reports `""` for that case with or without the guard. A span-level version of
the test SURVIVED; the assertion moved to `scan_mentions` and the source comment
now states that scope instead of claiming the guard is reachable everywhere.

**Regression matrix, measured against the pre-fix tree rather than asserted:**

| mutant | old suite | new suite |
|---|---|---|
| round-1 `mention_key` (drops the repo) | 106 passed | 3 failed |
| whole mapping → `b64:repo` | 106 passed | 2 failed |
| whole mapping → `context` | 106 passed | 2 failed |
| universe → refusal-path `notify` | 92 passed | 1 failed |
| universe → stdout on the picker path | 1 failed | 1 failed |

The last row is stated because it is the one place the round-1 guard was NOT
blind: a `print()` leak was already caught. It was the `notify` paths — the two
the guard stubbed out — that were invisible.

**Disclosure check:** every token this branch adds that is **new to the tree**
(329) diffed against `gh api user/repos`. Private list asserted **non-empty
first** (233 private / 155 public / 388 total) so a clean verdict is not a scan
wired to nothing; negative control confirms the matcher fires on a planted
private name and full_name. **0 matches against private names, 0 against public
ones.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016A9pA8WLHsvyeaAcuEsdPi
