### PR TITLE
feat(i3): pin workspaces to outputs — stateless, and the only i3-layer gap worth closing

### DIFF
--- a/nix/i3/config.nix
+++ b/nix/i3/config.nix
@@ -35,7 +35,32 @@ let
     else ''
 
       # Dual-monitor layout: 1080p (HDMI-0) left of the ultrawide (DP-0, primary)
-      exec --no-startup-id xrandr --output DP-0 --primary --mode 3440x1440 --rate 143.92 --pos 1920x0 --output HDMI-0 --mode 1920x1080 --pos 0x360'';
+      exec --no-startup-id xrandr --output DP-0 --primary --mode 3440x1440 --rate 143.92 --pos 1920x0 --output HDMI-0 --mode 1920x1080 --pos 0x360
+
+      # Pin workspaces to outputs.  WITHOUT this i3 places a workspace on
+      # whichever output it happens to pick, so the same workspace lands on a
+      # different physical screen run to run — and HDMI-0 is usually absent, so
+      # the mistake only surfaces when the second monitor is plugged in.
+      #
+      # This is deliberately NOT a layout snapshot.  It restores no windows and
+      # keeps no state: i3 re-evaluates these lines on every start, so there is
+      # nothing to go stale and nothing to refresh.  Window/pane state lives in
+      # tmux (resurrect + continuum + scripts/tmux-session-restore.py) and is
+      # already restored there; the i3 layer carries no state worth snapshotting
+      # (measured 2026-09-04: 2 workspaces, 6 windows, 5 of them one terminal).
+      #
+      # `workspace 3 output HDMI-0 DP-0` is a FALLBACK LIST, not a pair: i3 uses
+      # the first CONNECTED output, so workspace 3 lands on DP-0 when HDMI-0 is
+      # unplugged rather than vanishing.
+      #
+      # These live inside monitorLayout on purpose — it is already gated on
+      # `isLaptop`, and pinning to HDMI-0 on a host that has no HDMI-0 would be
+      # wrong.  An output name that matches no output is silently IGNORED by i3,
+      # which is why test_i3_workspace_output_pinning.py pins every name here to
+      # an output the xrandr line above actually configures.
+      workspace 1 output DP-0
+      workspace 2 output DP-0
+      workspace 3 output HDMI-0 DP-0'';
 in
 ''
 set $mod Mod1

--- a/scripts/tests/test_i3_workspace_output_pinning.py
+++ b/scripts/tests/test_i3_workspace_output_pinning.py
@@ -1,0 +1,117 @@
+"""🔴 AN i3 `workspace … output <NAME>` IS SILENT WHEN THE OUTPUT NAME IS WRONG.
+
+i3 matches a `workspace … output` directive against the outputs RandR reports.
+A name matching no output is not an error and not a warning — the directive is
+simply inert, i3 falls back to picking an output itself, and the workspace lands
+somewhere arbitrary. The config parses, the session starts, and the only symptom
+is that a workspace shows up on the wrong physical screen, on a host where the
+second monitor is usually unplugged anyway. Nothing fails loudly.
+
+So the hazard is NOT "somebody deleted the pinning". It is that the pinning can
+be PRESENT, well-formed, and bound to a name nothing will ever match — a typo
+(`HDMI0`, `hdmi-0`, `DP0`), or an output renamed in the xrandr line above it
+while these lines were left behind.
+
+WHY THE GUARD IS SHAPED LIKE THIS. Asserting the literal strings `DP-0` and
+`HDMI-0` would be a guard on WORDS: it would pass for a config whose xrandr line
+had been rewritten for different hardware, which is exactly when the pinning goes
+stale. The real invariant is a RELATIONSHIP between two statements that must
+agree — every output named by a `workspace … output` directive must be an output
+the `xrandr` line in the SAME block actually configures. That is what this file
+pins, so re-hardware the machine and the guard follows you; break the agreement
+and it goes red naming the offending output.
+
+It also pins CO-LOCATION: both statements must live inside the `isLaptop`-guarded
+`monitorLayout` branch. Hoisting the pinning out of that branch would send
+`workspace 3 output HDMI-0` to a laptop that has no HDMI-0 — inert in exactly the
+way described above, and invisible.
+
+NOT A SNAPSHOT, deliberately. This mechanism keeps no state: i3 re-evaluates the
+directives on every start, so there is nothing to refresh and nothing to go
+stale. That is the whole reason workspace-output pinning was chosen over an i3
+layout snapshot (`i3-save-tree` / `append_layout`, `i3-resurrect`, `i3-restore`),
+each of which reintroduces a periodic-save-with-no-verifier — the failure class
+that had already cost this repo two silent outages on 2026-09-04 (see
+`56c68cc7` and `cc409f82`). Researched and rejected the same day; the i3 layer
+was measured at 2 workspaces and 6 windows, 5 of them the same terminal, with
+every swallow criterion identical across them.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+CONFIG = REPO / "nix" / "i3" / "config.nix"
+
+# `workspace <n> output <OUT> [<OUT> …]` — the target is a FALLBACK LIST, so every
+# name on the line must resolve, not just the first.
+_WS_OUTPUT = re.compile(r"^\s*workspace\s+(\S+)\s+output\s+(.+?)\s*$", re.MULTILINE)
+# `--output <NAME>` as written by the xrandr invocation.
+_XRANDR_OUTPUT = re.compile(r"--output\s+(\S+)")
+
+
+def _config_text() -> str:
+    assert CONFIG.is_file(), f"{CONFIG} is missing — did nix/i3 move?"
+    return CONFIG.read_text()
+
+
+def _monitor_layout_block(text: str) -> str:
+    """The `else ''…''` body of `monitorLayout`, which both statements must share.
+
+    Sliced rather than parsed: this is a nix string literal, and the guard only
+    needs the region between `monitorLayout =` and the `'';` that closes it.
+    """
+    start = text.index("monitorLayout =")
+    end = text.index("'';", start)
+    return text[start:end]
+
+
+def test_workspace_output_pinning_is_present_and_inside_the_monitor_layout_block():
+    """Deletion, and hoisting it out of the isLaptop guard, both go red here."""
+    block = _monitor_layout_block(_config_text())
+    found = _WS_OUTPUT.findall(block)
+    # Positive control: a regex that matches nothing would make every other
+    # assertion in this file vacuously true.
+    assert found, (
+        "NO `workspace … output` DIRECTIVE inside the monitorLayout block of "
+        f"{CONFIG.relative_to(REPO)}. Either the pinning was removed — i3 will "
+        "then place workspaces on whichever output it picks — or it was moved "
+        "OUT of the `isLaptop`-guarded branch, which would pin a laptop with no "
+        "second monitor to an output that does not exist there. Both are silent "
+        "at runtime; that is why this is a test."
+    )
+
+
+def test_every_pinned_output_is_one_the_xrandr_line_configures():
+    """The seam: the two statements must name the same outputs.
+
+    A name matching no output is inert — i3 neither errors nor warns — so a typo
+    or a rename in the xrandr line leaves a directive that looks correct and does
+    nothing.
+    """
+    block = _monitor_layout_block(_config_text())
+    configured = set(_XRANDR_OUTPUT.findall(block))
+    assert configured, (
+        "NO `--output` FOUND in the monitorLayout block — the xrandr invocation "
+        "this guard compares against is gone or was reworded. Without it the "
+        "comparison below would pass trivially for every possible name."
+    )
+
+    pinned: dict[str, str] = {}
+    for ws, targets in _WS_OUTPUT.findall(block):
+        for out in targets.split():
+            pinned[out] = ws
+
+    unknown = {out: ws for out, ws in pinned.items() if out not in configured}
+    assert not unknown, (
+        "PINNED TO AN OUTPUT THE xrandr LINE DOES NOT CONFIGURE — i3 silently "
+        "IGNORES an output name it cannot match, so the workspace falls back to "
+        "whichever output i3 picks and the pinning is inert:\n"
+        + "\n".join(
+            f"  workspace {ws} output {out}   <- {out!r} is not configured"
+            for out, ws in sorted(unknown.items())
+        )
+        + f"\nOutputs the xrandr line configures: {', '.join(sorted(configured))}"
+    )


### PR DESCRIPTION
## The gap

`nix/i3/` declared a dual-head xrandr layout (DP-0 + HDMI-0) and **zero** `workspace … output` directives, so i3 placed every workspace on whichever output it picked. Latent today — HDMI-0 is disconnected — and it surfaces the moment the second monitor is plugged in.

```
workspace 1 output DP-0
workspace 2 output DP-0
workspace 3 output HDMI-0 DP-0
```

`workspace 3 output HDMI-0 DP-0` is a **fallback list, not a pair**: i3 takes the first *connected* output, so workspace 3 lands on DP-0 when HDMI-0 is unplugged rather than vanishing.

Placed inside `monitorLayout`, which is already gated on `isLaptop` and already owns the output topology — pinning to HDMI-0 on a host without one would be inert.

## Why pinning and not a layout snapshot

i3 layout restore (`i3-save-tree`/`append_layout`, `i3-resurrect`, `i3-restore`) was researched and rejected the same day. It is **structurally unable** to work on this window set. i3 matches swallow criteria on exactly five properties; measured 2026-09-04, all five Alacritty windows share an identical `class`/`instance`, report `window_role=None`, and sit on one `machine` — leaving `title` as the only discriminator, which is agent-generated, changes every session, and already contains duplicates. Placeholders would fill in arbitrary order.

Worse, per i3's own docs swallowing takes precedence over assignment rules, so a stale unfilled placeholder **hijacks an unrelated window opened later** — a failure strictly worse than doing nothing.

The i3 layer also carries almost no state worth restoring: **2 workspaces, 6 windows, 5 of them the same terminal**, against 22 tmux sessions / 52 windows / 44 claude panes already restored by resurrect + continuum + `tmux-session-restore.py`.

And every rejected option is a **periodic snapshot with no verifier** — the exact class that had just cost this repo two silent outages (`56c68cc7`, `cc409f82`), where continuum had not saved in 30 days while looking healthy. This change keeps **no state**: i3 re-evaluates the directives on every start, so there is nothing to refresh and nothing to go stale.

## The guard

An output name matching no output is **silently ignored** by i3 — no error, no warning, the directive is simply inert. So `scripts/tests/test_i3_workspace_output_pinning.py` pins a **relationship**, not the literals `DP-0`/`HDMI-0`: every output named by a `workspace … output` must be one the xrandr line in the *same block* configures. Re-hardware the machine and the guard follows; drift the two apart and it names the offending output. A second case pins co-location inside the `isLaptop`-guarded branch.

## Verification

- `nix-instantiate --parse` clean.
- **RED -> GREEN**, base `cc409f82`: 1 failed / 1 passed before, 2 passed after.
- The seam case passes **vacuously** at base (no directives ⇒ nothing to check) — which is why the presence case exists beside it, and why each carries its own positive control.
- **Mutants — 3, each killed by its own assertion:** output typo (`HDMI-0`->`HDMI0`) -> seam; pinning hoisted out of the guard -> presence; xrandr renamed with the pinning left behind -> seam (rename drift). Control: restored tree green.
- **Gate, branch is current with `main` (0 behind), so the branch tree IS the merged tree**, base `cc409f82`, run one at a time: `pytests` -> `RESULT: PASS (exit=0)`, TOTAL collected=21478 / passed=21475 / skipped=3 / **failed=0**; `nodetests` -> `RESULT: PASS (exit=0)`, 0 fail. `scripts/tests` collected 12447, **+2 vs the prior merged-tree run** — the two new cases ran.

## Not verified

Multi-output behaviour could not be measured: only `DP-0` is connected (`HDMI-0 disconnected`). The pinning is correct per i3's documented semantics but has **not** been exercised against a live second monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2HwZGfRQSHQTJxjh7mkfy