### PR TITLE
fix(tmux-restore): the staleness gate counted POWERED-OFF time against the plan

### DIFF
--- a/scripts/session-analysis/tests/test_tmux_session_restore.py
+++ b/scripts/session-analysis/tests/test_tmux_session_restore.py
@@ -648,22 +648,29 @@ def test_cmd_restore_skips_window_already_running_claude(tmp_path, monkeypatch, 
 # --------------------------------------------------------------------------- #
 # staleness check
 # --------------------------------------------------------------------------- #
-def test_plan_age_hours_returns_none_when_no_plan(tmp_path, monkeypatch):
+def test_plan_staleness_returns_none_when_no_plan(tmp_path, monkeypatch):
     monkeypatch.setattr(tsr, "PLAN", tmp_path / "missing.json")
-    assert tsr.plan_age_hours() is None
+    assert tsr.plan_staleness_hours() is None
 
 
-def test_plan_age_hours_returns_age(tmp_path, monkeypatch):
+def test_plan_staleness_falls_back_to_wall_clock_without_a_state_file(tmp_path, monkeypatch):
+    """Migrated from `plan_age_hours`, which measured wall clock unconditionally.
+
+    Wall clock is now the FALLBACK, reached only when the resurrect state file
+    cannot be read — so this fixture must point `RESURRECT_LAST` at nothing.
+    Leaving it unset would read the operator's real `~/.tmux/resurrect/last`
+    and make the result depend on their live workspace.
+    """
     import time
     plan = tmp_path / "restore-plan.json"
     plan.write_text("[]")
-    # Set mtime to 3 hours ago
     old = time.time() - 3 * 3600
     os.utime(plan, (old, old))
     monkeypatch.setattr(tsr, "PLAN", plan)
-    age = tsr.plan_age_hours()
-    assert age is not None
-    assert 2.9 < age < 3.1
+    monkeypatch.setattr(tsr, "RESURRECT_LAST", tmp_path / "no-such-state")
+    gap, basis = tsr.plan_staleness_hours()
+    assert basis == "wall"
+    assert 2.9 < gap < 3.1
 
 
 def test_cmd_restore_rejects_stale_plan(tmp_path, monkeypatch, capsys):
@@ -675,6 +682,11 @@ def test_cmd_restore_rejects_stale_plan(tmp_path, monkeypatch, capsys):
     old = time.time() - 5 * 3600
     os.utime(plan, (old, old))
     monkeypatch.setattr(tsr, "PLAN", plan)
+    # 🔴 Hermeticity: without this the staleness measure reads the operator's
+    # real `~/.tmux/resurrect/last`, so the verdict would depend on their live
+    # workspace. Pointing it at nothing selects the wall-clock fallback, which
+    # is what this test's 5h-old plan is written against.
+    monkeypatch.setattr(tsr, "RESURRECT_LAST", tmp_path / "no-such-state")
     monkeypatch.setattr(tsr, "tmux_session_exists", lambda n: True)
     monkeypatch.setattr(tsr, "window_state", lambda t: (True, "zsh"))
     # Default staleness limit is 2h — should reject (no custom plan_path)
@@ -722,3 +734,116 @@ def test_staleness_check_cli_parsing(monkeypatch, capsys):
         assert rc == 0
     finally:
         os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Staleness is measured against the LAYOUT, not the wall clock.
+#
+# 🔴 The bug these pin: the wall-clock measure counted POWERED-OFF time against
+# the plan, so `restore --staleness-check 2` refused after any shutdown longer
+# than the limit — "plan is 8.0h old" for a plan written 0.02h before the
+# reboot, with nothing about it changed. Being switched off is the one interval
+# in which reality cannot diverge from the plan.
+#
+# The replacement compares the plan to the resurrect state file it is racing.
+# Both are written by one chain (resurrect save -> post-save-all ->
+# tmux-post-save.sh -> `save`), so their mtimes sit seconds apart under a
+# working autosave, however long the host is then off.
+# ---------------------------------------------------------------------------
+
+HOUR = 3600.0
+
+
+def _staleness_fixture(tmp_path, monkeypatch, *, plan_age_s, state_age_s=None):
+    """A plan and (optionally) a resurrect state file at chosen ages."""
+    import time
+    now = time.time()
+    plan = tmp_path / "restore-plan.json"
+    plan.write_text("[]")
+    os.utime(plan, (now - plan_age_s, now - plan_age_s))
+    monkeypatch.setattr(tsr, "PLAN", plan)
+
+    if state_age_s is None:
+        monkeypatch.setattr(tsr, "RESURRECT_LAST", tmp_path / "no-such-state")
+    else:
+        state = tmp_path / "tmux_resurrect_stub.txt"
+        state.write_text("stub")
+        os.utime(state, (now - state_age_s, now - state_age_s))
+        monkeypatch.setattr(tsr, "RESURRECT_LAST", state)
+    return plan
+
+
+def test_a_long_power_off_does_not_make_a_contemporaneous_plan_stale(tmp_path, monkeypatch):
+    """THE REGRESSION. Plan and layout saved together, then the host sat off for a day."""
+    _staleness_fixture(tmp_path, monkeypatch, plan_age_s=24 * HOUR,
+                       state_age_s=24 * HOUR + 30)  # written 30s apart, both a day ago
+    gap, basis = tsr.plan_staleness_hours()
+    assert basis == "layout", f"expected the layout basis, got {basis!r}"
+    assert gap < 0.05, (
+        f"a plan written 30s from its layout measured {gap:.2f}h stale — the "
+        "powered-off interval is being counted against it again, which is the "
+        "exact bug this measure replaced (restore then exits 1 after any "
+        "overnight shutdown)")
+
+
+def test_a_plan_that_stopped_refreshing_while_the_layout_kept_saving_is_stale(tmp_path, monkeypatch):
+    """The REAL 2026-08-05 outage: plan frozen at Jul 5, resurrect running to Jul 29.
+
+    The guard has to keep catching this — it is how that outage was found.
+    """
+    _staleness_fixture(tmp_path, monkeypatch, plan_age_s=600 * HOUR, state_age_s=1 * HOUR)
+    gap, basis = tsr.plan_staleness_hours()
+    assert basis == "layout"
+    assert gap > 2, (
+        f"a plan {gap:.1f}h out of step with the layout was not flagged — this "
+        "is the broken-autosave case; restoring it relaunches a stale workspace")
+
+
+def test_a_layout_older_than_the_plan_is_also_stale(tmp_path, monkeypatch):
+    """The mirror image — continuum stopped saving while `save` kept running.
+
+    Pinned separately because an implementation without `abs()` passes the case
+    above and silently accepts this one.
+    """
+    _staleness_fixture(tmp_path, monkeypatch, plan_age_s=1 * HOUR, state_age_s=600 * HOUR)
+    gap, basis = tsr.plan_staleness_hours()
+    assert basis == "layout"
+    assert gap > 2, (
+        f"a layout {gap:.1f}h out of step with the plan was not flagged — the "
+        "workspace being restored is not the one the plan describes")
+
+
+def test_without_a_state_file_it_falls_back_to_wall_clock_and_says_so(tmp_path, monkeypatch):
+    """A fresh host, or `@resurrect-dir` pointed elsewhere.
+
+    The fallback carries the powered-off flaw by construction, so the BASIS is
+    part of the answer — a caller printing a bare number cannot be honest.
+    """
+    _staleness_fixture(tmp_path, monkeypatch, plan_age_s=5 * HOUR, state_age_s=None)
+    gap, basis = tsr.plan_staleness_hours()
+    assert basis == "wall", f"expected the wall fallback, got {basis!r}"
+    assert 4.9 < gap < 5.1, gap
+
+
+def test_no_plan_measures_nothing(tmp_path, monkeypatch):
+    monkeypatch.setattr(tsr, "PLAN", tmp_path / "absent.json")
+    assert tsr.plan_staleness_hours() is None
+
+
+def test_restore_names_the_basis_when_it_refuses(tmp_path, monkeypatch, capsys):
+    """A bare "8.0h" means different things per basis; the refusal must say which."""
+    _staleness_fixture(tmp_path, monkeypatch, plan_age_s=600 * HOUR, state_age_s=1 * HOUR)
+    rc = tsr.cmd_restore(dry_run=True, staleness_hours=2)
+    err = capsys.readouterr().err
+    assert rc == 1, "a plan out of step with its layout must refuse"
+    assert "basis=layout" in err, f"refusal did not name its basis: {err!r}"
+
+
+def test_restore_runs_on_a_contemporaneous_plan_after_a_long_power_off(tmp_path, monkeypatch, capsys):
+    """End of the regression: the same 24h-off plan must now RUN, not exit 1."""
+    _staleness_fixture(tmp_path, monkeypatch, plan_age_s=24 * HOUR,
+                       state_age_s=24 * HOUR + 30)
+    rc = tsr.cmd_restore(dry_run=True, staleness_hours=2)
+    err = capsys.readouterr().err
+    assert rc == 0, f"restore refused a contemporaneous plan after a power-off: {err!r}"
+    assert "too stale" not in err

--- a/scripts/session-analysis/tests/test_tmux_session_restore.py
+++ b/scripts/session-analysis/tests/test_tmux_session_restore.py
@@ -714,7 +714,13 @@ def test_cmd_restore_staleness_check_skips_when_no_plan(tmp_path, monkeypatch, c
     assert "no restore plan" in capsys.readouterr().err.lower()
 
 
-def test_staleness_check_cli_parsing(monkeypatch, capsys):
+def test_staleness_check_cli_parsing(monkeypatch, capsys, tmp_path):
+    # 🔴 Hermeticity: without this the staleness measure reads the operator's
+    # real `~/.tmux/resurrect/last`, so this test goes RED whenever production
+    # is broken — measured: a state file >2h old fails it. That is the same
+    # leak fixed in `test_cmd_restore_rejects_stale_plan`, one test below it.
+    monkeypatch.setattr(tsr, "RESURRECT_LAST", tmp_path / "no-such-state")
+    monkeypatch.setattr(tsr, "resurrect_last_path", lambda: tmp_path / "no-such-state")
     """--staleness-check without a number uses the 2h default."""
     import tempfile
     # Parse argv, not actually restoring — just verify the flag is consumed
@@ -754,7 +760,8 @@ def test_staleness_check_cli_parsing(monkeypatch, capsys):
 HOUR = 3600.0
 
 
-def _staleness_fixture(tmp_path, monkeypatch, *, plan_age_s, state_age_s=None):
+def _staleness_fixture(tmp_path, monkeypatch, *, plan_age_s, state_age_s=None,
+                       uptime_h=10_000.0):
     """A plan and (optionally) a resurrect state file at chosen ages."""
     import time
     now = time.time()
@@ -764,21 +771,29 @@ def _staleness_fixture(tmp_path, monkeypatch, *, plan_age_s, state_age_s=None):
     monkeypatch.setattr(tsr, "PLAN", plan)
 
     if state_age_s is None:
-        monkeypatch.setattr(tsr, "RESURRECT_LAST", tmp_path / "no-such-state")
+        target = tmp_path / "no-such-state"
     else:
-        state = tmp_path / "tmux_resurrect_stub.txt"
-        state.write_text("stub")
-        os.utime(state, (now - state_age_s, now - state_age_s))
-        monkeypatch.setattr(tsr, "RESURRECT_LAST", state)
+        target = tmp_path / "tmux_resurrect_stub.txt"
+        target.write_text("stub")
+        os.utime(target, (now - state_age_s, now - state_age_s))
+    monkeypatch.setattr(tsr, "RESURRECT_LAST", target)
+    # Route the tmux lookup too — otherwise these read the live `@resurrect-dir`.
+    monkeypatch.setattr(tsr, "resurrect_last_path", lambda: target)
+    # 🔴 Uptime must be injected or every liveness case measures THIS host's
+    # uptime (753h here), which makes the boot-time cases untestable.
+    monkeypatch.setattr(tsr, "uptime_hours", lambda: uptime_h)
     return plan
 
 
 def test_a_long_power_off_does_not_make_a_contemporaneous_plan_stale(tmp_path, monkeypatch):
     """THE REGRESSION. Plan and layout saved together, then the host sat off for a day."""
+    # uptime 45s: this is a restore just after boot, which is the only moment
+    # the systemd unit runs. A 24h-old plan is fresh THEN and not later — the
+    # liveness term is what draws that distinction.
     _staleness_fixture(tmp_path, monkeypatch, plan_age_s=24 * HOUR,
-                       state_age_s=24 * HOUR + 30)  # written 30s apart, both a day ago
+                       state_age_s=24 * HOUR + 30,  # written 30s apart, both a day ago
+                       uptime_h=45 / 3600)
     gap, basis = tsr.plan_staleness_hours()
-    assert basis == "layout", f"expected the layout basis, got {basis!r}"
     assert gap < 0.05, (
         f"a plan written 30s from its layout measured {gap:.2f}h stale — the "
         "powered-off interval is being counted against it again, which is the "
@@ -842,8 +857,148 @@ def test_restore_names_the_basis_when_it_refuses(tmp_path, monkeypatch, capsys):
 def test_restore_runs_on_a_contemporaneous_plan_after_a_long_power_off(tmp_path, monkeypatch, capsys):
     """End of the regression: the same 24h-off plan must now RUN, not exit 1."""
     _staleness_fixture(tmp_path, monkeypatch, plan_age_s=24 * HOUR,
-                       state_age_s=24 * HOUR + 30)
+                       state_age_s=24 * HOUR + 30, uptime_h=45 / 3600)
     rc = tsr.cmd_restore(dry_run=True, staleness_hours=2)
     err = capsys.readouterr().err
     assert rc == 0, f"restore refused a contemporaneous plan after a power-off: {err!r}"
     assert "too stale" not in err
+
+
+# ---------------------------------------------------------------------------
+# 🔴 LIVENESS — contemporaneity alone is blind to the chain dying WHOLE.
+#
+# The plan and the layout have ONE writer, so when it dies they freeze together
+# and their gap stays constant forever. A contemporaneity-only gate then calls a
+# 1400h-old plan fresh. That is the 2026-08-05 outage shape (continuum's
+# interpolation clobbered -> resurrect stopped saving at all), and the
+# wall-clock measure this change replaced caught it as a side effect.
+# ---------------------------------------------------------------------------
+
+def test_a_totally_frozen_chain_is_stale_even_though_the_two_agree(tmp_path, monkeypatch):
+    """🔴 THE REGRESSION THIS SECTION EXISTS FOR.
+
+    Plan and layout 30s apart — perfectly contemporaneous — but both written
+    1400h ago on a host that has been up 753h. Contemporaneity says 0.008h.
+    Liveness says 753h. The gate must take the worse one.
+    """
+    _staleness_fixture(tmp_path, monkeypatch, plan_age_s=1400 * HOUR,
+                       state_age_s=1400 * HOUR + 30, uptime_h=753.0)
+    gap, basis = tsr.plan_staleness_hours()
+    assert basis == "liveness", (
+        f"a chain frozen for 1400h reported basis={basis!r} — contemporaneity "
+        "cannot see a TOTAL freeze, so a liveness term must dominate here")
+    assert gap > 2, (
+        f"a 1400h-dead chain measured {gap:.3f}h — restore would relaunch a "
+        "58-day-old plan across every window")
+
+
+def test_liveness_is_capped_by_uptime_so_a_power_off_still_does_not_count(tmp_path, monkeypatch):
+    """The liveness term must not reintroduce the bug this PR fixes.
+
+    Same 24h-off plan, but 45s after boot: the newest artefact is 24h old by
+    wall clock and the cap must reduce it to the uptime.
+    """
+    _staleness_fixture(tmp_path, monkeypatch, plan_age_s=24 * HOUR + 30,
+                       state_age_s=24 * HOUR, uptime_h=45 / 3600)
+    gap, _ = tsr.plan_staleness_hours()
+    assert gap < 0.1, (
+        f"measured {gap:.3f}h 45s after boot — the uptime cap is not being "
+        "applied, so powered-off time is counted again")
+
+
+def test_an_unreadable_uptime_fails_TOWARDS_refusing(monkeypatch):
+    """A cap that cannot be read must not silently switch the liveness check off.
+
+    +inf means the cap never binds, so the raw wall figure stands — which can
+    only refuse MORE, never less. The opposite default (0) would disable the
+    guard exactly when the system is in an unexpected state.
+    """
+    monkeypatch.setattr("builtins.open", _raise_oserror)
+    assert tsr.uptime_hours() == float("inf")
+
+
+def _raise_oserror(*a, **k):
+    raise OSError("simulated")
+
+
+def test_the_wall_basis_refusal_does_not_claim_a_layout_comparison(tmp_path, monkeypatch, capsys):
+    """A surviving mutant: the refusal prose was hardcoded to the layout wording.
+
+    On the wall fallback there IS no layout comparison, so saying "out of step
+    with the saved layout" would assert a check that never ran.
+    """
+    _staleness_fixture(tmp_path, monkeypatch, plan_age_s=9 * HOUR, state_age_s=None)
+    rc = tsr.cmd_restore(dry_run=True, staleness_hours=2)
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "basis=wall" in err, err
+    assert "out of step with the saved layout" not in err, (
+        f"the wall-basis refusal claimed a layout comparison it never made: {err!r}")
+
+
+def test_state_mtime_follows_the_symlink_rather_than_reading_the_link_itself(tmp_path, monkeypatch):
+    """A surviving mutant: `stat()` -> `lstat()`.
+
+    Every other fixture uses a regular file, so nothing held the code to
+    following `last`. The target's mtime is when the LAYOUT was captured; the
+    link's own is when it was repointed.
+    """
+    import time
+    target = tmp_path / "tmux_resurrect_real.txt"
+    target.write_text("layout")
+    old = time.time() - 500 * HOUR
+    os.utime(target, (old, old))
+    link = tmp_path / "last"
+    link.symlink_to(target)
+    monkeypatch.setattr(tsr, "RESURRECT_LAST", link)
+    monkeypatch.setattr(tsr, "resurrect_last_path", lambda: link)
+    got = tsr.resurrect_state_mtime()
+    assert got is not None and abs(got - old) < 5, (
+        "resurrect_state_mtime read the SYMLINK's mtime, not the layout's — "
+        "`lstat` would report a fresh layout for a 500h-old capture")
+
+
+def test_a_dangling_last_degrades_to_the_wall_basis(tmp_path, monkeypatch):
+    """The case where stat-vs-lstat decides correctness.
+
+    `lstat` on a dangling link succeeds, and would report `basis=layout` for a
+    layout that no longer exists. `stat` raises, and we fall back honestly.
+    """
+    link = tmp_path / "last"
+    link.symlink_to(tmp_path / "gone.txt")
+    monkeypatch.setattr(tsr, "RESURRECT_LAST", link)
+    monkeypatch.setattr(tsr, "resurrect_last_path", lambda: link)
+    assert tsr.resurrect_state_mtime() is None
+
+
+def test_an_unreadable_state_file_degrades_rather_than_raising(tmp_path, monkeypatch):
+    """A surviving mutant: `except OSError` -> `except FileNotFoundError`.
+
+    A `last` that exists but cannot be stat'd (permissions, ELOOP) must reach
+    the fallback, not escape and kill the systemd unit.
+    """
+    class _Boom:
+        def stat(self):
+            raise PermissionError("simulated")
+    monkeypatch.setattr(tsr, "resurrect_last_path", lambda: _Boom())
+    assert tsr.resurrect_state_mtime() is None
+
+
+def test_resurrect_dir_is_read_from_tmux_not_hardcoded(tmp_path, monkeypatch):
+    """🔴 A moved `@resurrect-dir` must not leave us reading a frozen default.
+
+    Hardcoding it means the old path freezes at the switchover and every later
+    run refuses permanently while asserting `basis=layout` about a file nobody
+    writes.
+    """
+    moved = tmp_path / "xdg-resurrect"
+    moved.mkdir()
+    monkeypatch.setattr(tsr, "run", lambda cmd: str(moved) + "\n")
+    assert tsr.resurrect_last_path() == moved / "last"
+
+
+def test_resurrect_dir_unset_falls_back_to_the_module_default(tmp_path, monkeypatch):
+    """Positive control for the test above — an empty option must not win."""
+    monkeypatch.setattr(tsr, "run", lambda cmd: "")
+    monkeypatch.setattr(tsr, "RESURRECT_LAST", tmp_path / "default-last")
+    assert tsr.resurrect_last_path() == tmp_path / "default-last"

--- a/scripts/session-analysis/tests/test_tmux_session_restore.py
+++ b/scripts/session-analysis/tests/test_tmux_session_restore.py
@@ -1002,3 +1002,61 @@ def test_resurrect_dir_unset_falls_back_to_the_module_default(tmp_path, monkeypa
     monkeypatch.setattr(tsr, "run", lambda cmd: "")
     monkeypatch.setattr(tsr, "RESURRECT_LAST", tmp_path / "default-last")
     assert tsr.resurrect_last_path() == tmp_path / "default-last"
+
+
+# ---------------------------------------------------------------------------
+# Round-2 audit: three guards that were mutation-SURVIVABLE, i.e. unpinned.
+# ---------------------------------------------------------------------------
+
+def test_a_liveness_refusal_does_not_call_itself_wall_clock(tmp_path, monkeypatch, capsys):
+    """🔴 The basis vocabulary grew to three; the message's if/else stayed binary.
+
+    A liveness refusal announced "older than (wall clock)" — the very measure
+    this change rejects. It lands in the worst place: a liveness refusal is
+    reachable ONLY when the save chain has stopped, so the wording sent the
+    operator hunting the powered-off bug instead of the dead chain.
+    """
+    _staleness_fixture(tmp_path, monkeypatch, plan_age_s=1400 * HOUR,
+                       state_age_s=1400 * HOUR + 30, uptime_h=753.0)
+    rc = tsr.cmd_restore(dry_run=True, staleness_hours=2)
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "basis=liveness" in err, err
+    assert "wall clock" not in err, (
+        f"a liveness refusal described itself as wall clock: {err!r}")
+    assert "silent" in err, f"the refusal does not say the chain stopped: {err!r}"
+
+
+def test_a_backwards_clock_does_not_switch_the_liveness_guard_off(tmp_path, monkeypatch):
+    """🔴 `since < 0` used to mean `live = 0.0` — the guard fully disabled.
+
+    Early boot is exactly when a backward step happens (RTC ahead, then
+    timesyncd corrects) and exactly when this runs. An anomalous measurement
+    must fail TOWARDS refusing, matching `uptime_hours`'s own reasoning.
+    """
+    # Artefacts dated in the FUTURE, chain otherwise long dead.
+    _staleness_fixture(tmp_path, monkeypatch, plan_age_s=-2 * HOUR,
+                       state_age_s=-2 * HOUR - 30, uptime_h=753.0)
+    gap, basis = tsr.plan_staleness_hours()
+    assert basis == "liveness" and gap > 2, (
+        f"a backwards clock produced {gap:.4f}h basis={basis!r} — the liveness "
+        "term was switched off by the skew guard, which is the safe-looking "
+        "default that silently removes the protection")
+
+
+def test_resurrect_dir_expands_the_plugin_s_variables_not_just_a_leading_tilde(tmp_path, monkeypatch):
+    """🔴 `helpers.sh:resurrect_dir()` expands $HOME/$HOSTNAME/~ ANYWHERE.
+
+    `os.path.expanduser` handles only a leading `~`. `$HOME/state/$HOSTNAME/...`
+    is the documented multi-host idiom; leaving it literal makes the path
+    un-stat-able, which silently selects the `wall` basis and reintroduces the
+    powered-off flaw this change exists to remove.
+    """
+    import platform as _pf
+    monkeypatch.setattr(tsr, "run", lambda cmd: "$HOME/state/$HOSTNAME/resurrect\n")
+    got = tsr.resurrect_last_path()
+    assert "$HOME" not in str(got) and "$HOSTNAME" not in str(got), (
+        f"unexpanded variable survived into the path: {got}")
+    assert str(got).startswith(os.path.expanduser("~")), got
+    assert _pf.node() in str(got), got
+    assert got.name == "last"

--- a/scripts/session-analysis/tests/test_tmux_session_restore.py
+++ b/scripts/session-analysis/tests/test_tmux_session_restore.py
@@ -1072,6 +1072,12 @@ def test_backward_skew_still_refuses_when_the_LAYOUT_disagrees(tmp_path, monkeyp
     assert rc == 1, "skew must not bypass the contemporaneity check"
     assert "basis=skew" in err and "NOT evaluated" in err, (
         f"the skew refusal does not say liveness went unevaluated: {err!r}")
+    # `since < 0` fires on ANY future mtime — a restored backup, `touch -d`, an
+    # rsync preserving a bad stamp. Naming "the clock" asserts a cause this code
+    # never measured, which is the failure this whole branch exists to avoid.
+    assert "clock moved backwards" not in err, (
+        f"the skew refusal named a cause it never measured: {err!r}")
+    assert "mtime is in the future" in err, err
 
 
 def test_the_wall_basis_refusal_names_wall_clock_and_not_a_dead_chain(tmp_path, monkeypatch, capsys):

--- a/scripts/session-analysis/tests/test_tmux_session_restore.py
+++ b/scripts/session-analysis/tests/test_tmux_session_restore.py
@@ -1027,21 +1027,72 @@ def test_a_liveness_refusal_does_not_call_itself_wall_clock(tmp_path, monkeypatc
     assert "silent" in err, f"the refusal does not say the chain stopped: {err!r}"
 
 
-def test_a_backwards_clock_does_not_switch_the_liveness_guard_off(tmp_path, monkeypatch):
-    """🔴 `since < 0` used to mean `live = 0.0` — the guard fully disabled.
+def test_a_backwards_clock_reports_liveness_as_UNMEASURED_not_as_a_number(tmp_path, monkeypatch):
+    """🔴 Both obvious answers to clock skew FABRICATE a liveness value.
 
-    Early boot is exactly when a backward step happens (RTC ahead, then
-    timesyncd corrects) and exactly when this runs. An anomalous measurement
-    must fail TOWARDS refusing, matching `uptime_hours`'s own reasoning.
+    `since = 0` claims the chain just wrote (silently disables the guard).
+    `since = inf` claims it never did — and is worse, because
+    `min(inf, uptime)` collapses to UPTIME: a one-second step back on a
+    long-uptime host then REFUSES a healthy chain and calls it "silent for
+    753h". Contemporaneity never reads `now`, so it survives skew; the basis
+    must say liveness was not evaluated.
     """
-    # Artefacts dated in the FUTURE, chain otherwise long dead.
+    # Artefacts dated in the FUTURE; the chain is HEALTHY (30s apart).
     _staleness_fixture(tmp_path, monkeypatch, plan_age_s=-2 * HOUR,
                        state_age_s=-2 * HOUR - 30, uptime_h=753.0)
     gap, basis = tsr.plan_staleness_hours()
-    assert basis == "liveness" and gap > 2, (
-        f"a backwards clock produced {gap:.4f}h basis={basis!r} — the liveness "
-        "term was switched off by the skew guard, which is the safe-looking "
-        "default that silently removes the protection")
+    assert basis == "skew", (
+        f"backward skew reported basis={basis!r} — it must name liveness as "
+        "unmeasured rather than invent a value in either direction")
+    assert gap < 0.05, (
+        f"a healthy chain measured {gap:.4f}h under skew — this is the false "
+        "refusal that `since = inf` produced (it collapses to uptime)")
+
+
+def test_backward_skew_does_not_refuse_a_healthy_chain(tmp_path, monkeypatch, capsys):
+    """The regression `since = inf` introduced: rc 1 on a chain that just wrote."""
+    _staleness_fixture(tmp_path, monkeypatch, plan_age_s=-1, state_age_s=-31,
+                       uptime_h=753.0)
+    rc = tsr.cmd_restore(dry_run=True, staleness_hours=2)
+    err = capsys.readouterr().err
+    assert rc == 0, (
+        f"a one-second backward step refused a healthy chain: {err!r}")
+
+
+def test_backward_skew_still_refuses_when_the_LAYOUT_disagrees(tmp_path, monkeypatch, capsys):
+    """Skew must not become a bypass — contemporaneity is still enforced.
+
+    Reachability: this is the case a `return (gap, "skew")` could have made
+    unconditionally passing.
+    """
+    _staleness_fixture(tmp_path, monkeypatch, plan_age_s=-1 * HOUR,
+                       state_age_s=600 * HOUR, uptime_h=753.0)
+    rc = tsr.cmd_restore(dry_run=True, staleness_hours=2)
+    err = capsys.readouterr().err
+    assert rc == 1, "skew must not bypass the contemporaneity check"
+    assert "basis=skew" in err and "NOT evaluated" in err, (
+        f"the skew refusal does not say liveness went unevaluated: {err!r}")
+
+
+def test_the_wall_basis_refusal_names_wall_clock_and_not_a_dead_chain(tmp_path, monkeypatch, capsys):
+    """The sibling arm the previous round left unpinned in the POSITIVE direction.
+
+    A negative assertion alone let the `wall` value claim the liveness cause.
+    """
+    _staleness_fixture(tmp_path, monkeypatch, plan_age_s=9 * HOUR, state_age_s=None)
+    rc = tsr.cmd_restore(dry_run=True, staleness_hours=2)
+    err = capsys.readouterr().err
+    assert rc == 1 and "basis=wall" in err
+    assert "wall clock" in err, f"the wall refusal does not name wall clock: {err!r}"
+    assert "silent" not in err, (
+        f"the wall refusal claimed a dead chain, which it never measured: {err!r}")
+
+
+def test_a_negative_wall_age_is_clamped_rather_than_printed(tmp_path, monkeypatch):
+    """No layout to fall back to on this basis, so a negative must not print."""
+    _staleness_fixture(tmp_path, monkeypatch, plan_age_s=-5 * HOUR, state_age_s=None)
+    gap, basis = tsr.plan_staleness_hours()
+    assert basis == "wall" and gap == 0.0, (gap, basis)
 
 
 def test_resurrect_dir_expands_the_plugin_s_variables_not_just_a_leading_tilde(tmp_path, monkeypatch):

--- a/scripts/tmux-session-restore.py
+++ b/scripts/tmux-session-restore.py
@@ -51,6 +51,10 @@ from pathlib import Path
 STATE_DIR = Path(os.path.expanduser("~/.config/initiatives"))
 PLAN = STATE_DIR / "restore-plan.json"
 CHEAT = STATE_DIR / "restore-cheatsheet.md"
+# The layout `restore` is racing: resurrect's newest state file, via its `last`
+# symlink. `plan_staleness_hours` measures the plan against THIS rather than
+# against the wall clock — see that docstring for why.
+RESURRECT_LAST = Path(os.path.expanduser("~/.tmux/resurrect/last"))
 PROJECTS = Path(os.path.expanduser("~/.claude/projects"))
 SLOTS_FILE = Path(__file__).resolve().parent / "tmux-scratch-slots.sh"
 _SLOT_RE = re.compile(r'"([^":]+):([^":]+):(#[0-9a-fA-F]{6}):([^":]+)"')
@@ -477,12 +481,63 @@ def window_state(target: str) -> tuple[bool, str]:
     return (bool(out.strip()), out.strip())
 
 
-def plan_age_hours() -> float | None:
-    """Age of the current restore plan in hours, or None if no plan exists."""
+def resurrect_state_mtime() -> float | None:
+    """mtime of the resurrect state file `restore` is racing, or None if unreadable.
+
+    `~/.tmux/resurrect/last` is a symlink to the newest `tmux_resurrect_*.txt`;
+    `stat()` follows it, which is what we want — the target's mtime is when that
+    layout was captured.
+    """
+    try:
+        return RESURRECT_LAST.stat().st_mtime
+    except OSError:
+        return None
+
+
+def plan_staleness_hours() -> tuple[float, str] | None:
+    """How stale the plan is RELATIVE TO THE LAYOUT IT DESCRIBES. None if no plan.
+
+    🔴 NOT WALL-CLOCK AGE, AND THAT IS THE WHOLE POINT. The wall-clock measure
+    counted time the machine spent POWERED OFF against the plan, so the gate
+    refused in exactly the situation it exists to serve: shut down overnight,
+    boot, and `restore --staleness-check 2` exited 1 with "plan is 8.0h old"
+    — the identical rc 1 that the dead-hook outage produced (56c68cc7,
+    cc409f82), from a different cause. MEASURED 2026-09-05: a plan written
+    0.02h before a reboot reads as 8h/24h stale purely from being switched off,
+    while nothing about it changed. Being powered off cannot make a plan
+    diverge from reality; it is the one interval in which reality is frozen.
+
+    So compare two ARTEFACTS instead of comparing one to the clock. The plan and
+    the resurrect state file are written by the same chain — resurrect saves the
+    layout, its `post-save-all` hook runs `tmux-post-save.sh`, which runs `save`
+    — so under a working autosave their mtimes are seconds apart, forever,
+    however long the host is then switched off. The gap between them is
+    therefore a direct measure of the thing the gate actually guards: does this
+    plan describe the layout continuum is restoring?
+
+    It stays sharp in BOTH directions, which is why `abs()`:
+      * plan much OLDER than the layout — the plan stopped being refreshed while
+        the layout kept saving. This is the real 2026-08-05 outage: the plan sat
+        at Jul 5 while resurrect ran to Jul 29. Restoring it would relaunch a
+        month-old workspace. REFUSE.
+      * layout much older than the plan — continuum stopped saving while `save`
+        kept running, so the layout being restored is not the one the plan
+        describes. REFUSE.
+
+    Returns `(gap_hours, basis)`. `basis` is `"layout"` when the comparison was
+    made, or `"wall"` when the state file could not be read — a fresh host, or
+    `@resurrect-dir` pointed elsewhere. The wall-clock fallback carries the
+    powered-off flaw by construction, so callers must SAY which basis they used
+    rather than printing a bare number.
+    """
     if not PLAN.exists():
         return None
     import time
-    return (time.time() - PLAN.stat().st_mtime) / 3600
+    mt = PLAN.stat().st_mtime
+    state = resurrect_state_mtime()
+    if state is not None:
+        return (abs(state - mt) / 3600, "layout")
+    return ((time.time() - mt) / 3600, "wall")
 
 
 def cmd_restore(dry_run: bool = False, plan_path: Path | None = None,
@@ -492,11 +547,19 @@ def cmd_restore(dry_run: bool = False, plan_path: Path | None = None,
         print(f"no restore plan at {src} — run `save` before rebooting", file=sys.stderr)
         return 1
     if staleness_hours is not None and plan_path is None:
-        age = plan_age_hours()
-        if age is not None and age > staleness_hours:
-            print(f"restore plan is {age:.1f}h old (limit {staleness_hours}h) — "
-                  f"too stale, skipping. Run `save` first.", file=sys.stderr)
-            return 1
+        measured = plan_staleness_hours()
+        if measured is not None:
+            gap, basis = measured
+            if gap > staleness_hours:
+                # Name the BASIS: "8.0h" means two different things depending on
+                # which one produced it, and the wall fallback carries the
+                # powered-off flaw the layout basis exists to remove.
+                why = ("out of step with the saved layout by"
+                       if basis == "layout" else "older than (wall clock)")
+                print(f"restore plan is {why} {gap:.1f}h "
+                      f"(limit {staleness_hours}h, basis={basis}) — too stale, "
+                      f"skipping. Run `save` first.", file=sys.stderr)
+                return 1
     plan = json.loads(src.read_text())
     tag = "[dry-run] would " if dry_run else ""
     sent = skipped = 0

--- a/scripts/tmux-session-restore.py
+++ b/scripts/tmux-session-restore.py
@@ -32,7 +32,10 @@ Usage:
 Restore flags:
   --dry-run / -n          show what would happen without sending keys
   --plan PATH             use a custom plan file instead of the default
-  --staleness-check [H]   refuse to restore if plan is > H hours old (default: 2h)
+  --staleness-check [H]   refuse to restore unless the plan is BOTH in step with
+                          the saved layout AND produced within H hours of running
+                          time (default: 2h). NOT wall-clock age — powered-off
+                          time does not count. See `plan_staleness_hours`.
 
 State: ~/.config/initiatives/restore-plan.json  (+ restore-cheatsheet.md)
 Scratchpad codenames come from the canonical scripts/tmux-scratch-slots.sh.
@@ -481,15 +484,45 @@ def window_state(target: str) -> tuple[bool, str]:
     return (bool(out.strip()), out.strip())
 
 
+def resurrect_last_path() -> Path:
+    """`<resurrect-dir>/last`, asking tmux rather than assuming the default.
+
+    🔴 `@resurrect-dir` IS CONFIGURABLE and the plugin honours it —
+    `helpers.sh:resurrect_dir()` is `get_tmux_option @resurrect-dir
+    "$HOME/.tmux/resurrect"`. Hardcoding the default is not merely incomplete:
+    on a host that moved the directory, `~/.tmux/resurrect/last` FREEZES at the
+    switchover instant, so every later run compares against a layout nobody
+    writes, refuses permanently, and says `basis=layout` while doing it — a
+    confident claim about a file that is no longer the layout being restored.
+    Failing closed with a misdirecting message is worse than failing open.
+
+    Falls back to the module default when tmux cannot be reached (no server, or
+    `restore` running before one exists), which is also what the plugin's own
+    `get_tmux_option` default does.
+    """
+    configured = run(["tmux", "show-options", "-gqv", "@resurrect-dir"]).strip()
+    if configured:
+        return Path(os.path.expanduser(configured)) / "last"
+    return RESURRECT_LAST
+
+
 def resurrect_state_mtime() -> float | None:
     """mtime of the resurrect state file `restore` is racing, or None if unreadable.
 
-    `~/.tmux/resurrect/last` is a symlink to the newest `tmux_resurrect_*.txt`;
-    `stat()` follows it, which is what we want — the target's mtime is when that
-    layout was captured.
+    `<resurrect-dir>/last` is a symlink to the newest `tmux_resurrect_*.txt`.
+    🔴 `stat()` FOLLOWS IT AND `lstat()` MUST NOT BE SUBSTITUTED: the target's
+    mtime is when that layout was captured, while the symlink's own mtime is
+    when it was last repointed. They differ, and on a DANGLING `last` the
+    difference decides correctness — `stat` raises and we fall back to `wall`,
+    whereas `lstat` would happily report `basis=layout` for a layout that no
+    longer exists.
+
+    `OSError` and not `FileNotFoundError`: a `last` that exists but is
+    unreadable, or an ELOOP symlink chain, must degrade to the fallback rather
+    than escape and crash the systemd unit.
     """
     try:
-        return RESURRECT_LAST.stat().st_mtime
+        return resurrect_last_path().stat().st_mtime
     except OSError:
         return None
 
@@ -524,20 +557,68 @@ def plan_staleness_hours() -> tuple[float, str] | None:
         kept running, so the layout being restored is not the one the plan
         describes. REFUSE.
 
-    Returns `(gap_hours, basis)`. `basis` is `"layout"` when the comparison was
-    made, or `"wall"` when the state file could not be read — a fresh host, or
-    `@resurrect-dir` pointed elsewhere. The wall-clock fallback carries the
-    powered-off flaw by construction, so callers must SAY which basis they used
-    rather than printing a bare number.
+    🔴 CONTEMPORANEITY IS NOT LIVENESS, AND THE GATE NEEDS BOTH. The plan and
+    the layout are written by ONE driver, so when that driver dies they freeze
+    TOGETHER and their gap stays constant forever. A contemporaneity-only
+    measure then reports "fresh" for a plan of any age: MEASURED, a plan and
+    layout both frozen 1400h ago 30s apart returned a 0.008h gap and restored a
+    58-day-old workspace across 44 windows. That is not hypothetical — it is
+    the OTHER outage `nix/programs/tmux/default.nix` records: on 2026-08-05
+    continuum's `status-right` interpolation was clobbered and resurrect
+    stopped saving at all, freezing both artefacts at the same instant. The
+    wall-clock measure caught that mode as a side effect; dropping it without
+    replacement traded a LOUD failure for a silent, permissive one.
+
+    So two numbers are computed and the WORSE is returned:
+
+      * CONTEMPORANEITY `abs(state - plan)` — does this plan describe the
+        layout being restored? Catches a ONE-SIDED freeze in either direction
+        (the hook-name outage: plan stuck at Jul 5, resurrect live to Jul 29).
+      * LIVENESS `min(now - newest_artefact, uptime)` — has the chain produced
+        anything lately? Catches a TOTAL freeze, which contemporaneity cannot
+        see. Capping at uptime is what keeps powered-off time out: at boot+45s
+        the newest artefact is from before shutdown, so the cap makes it 45s
+        rather than the whole night.
+
+    Worked through the four cases:
+      running normally   gap ~1min, live ~15min      -> passes
+      boot+45s after 24h off  gap ~1min, live 45s    -> passes  (the bug fixed)
+      31d uptime, chain dead 1400h  gap 30s, live 744h -> REFUSES (this finding)
+      plan frozen, layout live      gap huge         -> REFUSES
+
+    Returns `(hours, basis)` where basis is `"layout"`, `"liveness"` or
+    `"wall"`. The wall fallback (no readable state file) still carries the
+    powered-off flaw by construction, so the basis is part of the answer and
+    the refusal message NAMES it — the same number means different things.
     """
     if not PLAN.exists():
         return None
     import time
     mt = PLAN.stat().st_mtime
     state = resurrect_state_mtime()
-    if state is not None:
-        return (abs(state - mt) / 3600, "layout")
-    return ((time.time() - mt) / 3600, "wall")
+    if state is None:
+        return ((time.time() - mt) / 3600, "wall")
+    gap = abs(state - mt) / 3600
+    # Liveness: time since the chain last produced ANYTHING, but never counting
+    # more than this boot has been up — powered-off time is the one interval in
+    # which nothing can have gone stale.
+    since = (time.time() - max(state, mt)) / 3600
+    live = min(since, uptime_hours()) if since > 0 else 0.0
+    return (gap, "layout") if gap >= live else (live, "liveness")
+
+
+def uptime_hours() -> float:
+    """Hours this boot has been up; +inf if unreadable, so the cap cannot HIDE staleness.
+
+    An unreadable `/proc/uptime` must not silently turn the liveness check off —
+    failing to the uncapped wall measure is the safe direction (it can only
+    refuse more, never less).
+    """
+    try:
+        with open("/proc/uptime") as fh:
+            return float(fh.read().split()[0]) / 3600
+    except (OSError, ValueError, IndexError):
+        return float("inf")
 
 
 def cmd_restore(dry_run: bool = False, plan_path: Path | None = None,

--- a/scripts/tmux-session-restore.py
+++ b/scripts/tmux-session-restore.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import platform
 import re
 import subprocess
 import sys
@@ -502,7 +503,16 @@ def resurrect_last_path() -> Path:
     """
     configured = run(["tmux", "show-options", "-gqv", "@resurrect-dir"]).strip()
     if configured:
-        return Path(os.path.expanduser(configured)) / "last"
+        # 🔴 Match the PLUGIN'S grammar, not Python's. `helpers.sh:resurrect_dir()`
+        # expands `$HOME`, `$HOSTNAME` and `~` ANYWHERE in the value via a global
+        # sed; `expanduser` handles only a LEADING `~`. `$HOME/state/$HOSTNAME/
+        # resurrect` is the documented multi-host idiom, and leaving it literal
+        # makes the path un-stat-able -> `wall` basis -> the powered-off flaw
+        # silently reintroduced, refusing a perfectly fresh plan at boot.
+        expanded = (configured
+                    .replace("$HOME", os.path.expanduser("~"))
+                    .replace("$HOSTNAME", platform.node()))
+        return Path(os.path.expanduser(expanded)) / "last"
     return RESURRECT_LAST
 
 
@@ -580,11 +590,41 @@ def plan_staleness_hours() -> tuple[float, str] | None:
         the newest artefact is from before shutdown, so the cap makes it 45s
         rather than the whole night.
 
-    Worked through the four cases:
+    Worked through the cases — INCLUDING the one this does not close:
       running normally   gap ~1min, live ~15min      -> passes
       boot+45s after 24h off  gap ~1min, live 45s    -> passes  (the bug fixed)
-      31d uptime, chain dead 1400h  gap 30s, live 744h -> REFUSES (this finding)
+      31d uptime, chain dead 1400h  gap 30s, live 753h -> REFUSES
       plan frozen, layout live      gap huge         -> REFUSES
+      🔴 boot+45s, chain dead 1400h  gap 30s, live 45s -> PASSES  (NOT CLOSED)
+
+    🔴 THE LIVENESS TERM IS ARITHMETICALLY INERT WHENEVER `uptime <= limit`, AND
+    THAT INCLUDES THE BOOT THE UNIT RUNS ON. `live = min(since, uptime) <=
+    uptime`, and refusing needs `> limit` — so at boot+45s with a 2h limit
+    (`nix/home.nix`), `live <= 0.0125h`, 160x under, and this degrades exactly
+    to the contemporaneity-only behaviour. A guard that is BREAKABLE at a
+    fixture constant (the test pins `uptime_h=753.0`, 376x the limit) is not
+    thereby REACHABLE at the call site's real value; those are different claims
+    and only the second one protects a boot.
+
+    WHY IT IS NOT CLOSED HERE RATHER THAN LEFT UNSAID. At boot, mtimes alone
+    cannot separate "chain healthy, host off 24h" from "chain dead 58d, host
+    off 24h" — after the cap both read `since ~= uptime`. The discriminator is
+    the PREVIOUS BOOT'S END (`prev_shutdown - max(state, mt)`), and it is not
+    reliably available: MEASURED on this host 2026-09-05, `journalctl
+    --list-boots` reports TWO boots whose ranges do not abut (boot -1 ends
+    2026-07-14, boot 0 begins 2026-08-18) while `uptime -s` says 2026-08-04 —
+    the journal had rotated the intervening boots away. A detector built on
+    that would be least trustworthy on exactly the long-lived host where a
+    frozen chain is most likely.
+
+    WHAT BOUNDS THE DAMAGE. A chain that froze froze BOTH artefacts, so
+    resurrect's layout is equally stale and continuum restores that old layout
+    whatever this gate decides. Resuming the conversations that match it is
+    coherent; the gate cannot prevent the stale workspace, only decide whether
+    to populate it. What IS lost is the diagnostic — the old wall-clock refusal
+    is how the 2026-08-05 freeze was noticed at all — so if you are reading
+    this because a restore looked wrong, check whether the chain is alive
+    (`ls -t ~/.tmux/resurrect/*.txt | head`) before suspecting the plan.
 
     Returns `(hours, basis)` where basis is `"layout"`, `"liveness"` or
     `"wall"`. The wall fallback (no readable state file) still carries the
@@ -603,7 +643,15 @@ def plan_staleness_hours() -> tuple[float, str] | None:
     # more than this boot has been up — powered-off time is the one interval in
     # which nothing can have gone stale.
     since = (time.time() - max(state, mt)) / 3600
-    live = min(since, uptime_hours()) if since > 0 else 0.0
+    if since < 0:
+        # 🔴 The clock moved BACKWARDS past an artefact's mtime — an anomalous
+        # measurement, not evidence of freshness. Early boot is exactly when
+        # this happens (RTC ahead, then timesyncd steps back), and it is also
+        # when this runs. Treat it like an unreadable cap and fail TOWARDS
+        # refusing, matching `uptime_hours`'s reasoning; the old `else 0.0`
+        # silently switched the liveness term off at the worst moment.
+        since = float("inf")
+    live = min(since, uptime_hours())
     return (gap, "layout") if gap >= live else (live, "liveness")
 
 
@@ -635,8 +683,15 @@ def cmd_restore(dry_run: bool = False, plan_path: Path | None = None,
                 # Name the BASIS: "8.0h" means two different things depending on
                 # which one produced it, and the wall fallback carries the
                 # powered-off flaw the layout basis exists to remove.
-                why = ("out of step with the saved layout by"
-                       if basis == "layout" else "older than (wall clock)")
+                why = {
+                    "layout": "out of step with the saved layout by",
+                    # NOT wall clock: this is uptime-capped running time since
+                    # the chain last produced anything. Saying "wall clock"
+                    # here points the reader at the powered-off bug, when the
+                    # cause is the opposite — the save chain stopped.
+                    "liveness": "produced by a chain that has been silent for",
+                    "wall": "older than (wall clock, no layout to compare)",
+                }[basis]
                 print(f"restore plan is {why} {gap:.1f}h "
                       f"(limit {staleness_hours}h, basis={basis}) — too stale, "
                       f"skipping. Run `save` first.", file=sys.stderr)

--- a/scripts/tmux-session-restore.py
+++ b/scripts/tmux-session-restore.py
@@ -596,6 +596,9 @@ def plan_staleness_hours() -> tuple[float, str] | None:
       31d uptime, chain dead 1400h  gap 30s, live 753h -> REFUSES
       plan frozen, layout live      gap huge         -> REFUSES
       🔴 boot+45s, chain dead 1400h  gap 30s, live 45s -> PASSES  (NOT CLOSED)
+      🔴 chain dead 100h + a future mtime  gap 30s, skew -> PASSES  (see below:
+         liveness is genuinely unmeasurable there, and the bounded-damage
+         argument covers it — but a reader consults this list, so it is here)
 
     🔴 THE LIVENESS TERM IS ARITHMETICALLY INERT WHENEVER `uptime <= limit`, AND
     THAT INCLUDES THE BOOT THE UNIT RUNS ON. (The same is true of the SKEW
@@ -628,8 +631,11 @@ def plan_staleness_hours() -> tuple[float, str] | None:
     this because a restore looked wrong, check whether the chain is alive
     (`ls -t ~/.tmux/resurrect/*.txt | head`) before suspecting the plan.
 
-    Returns `(hours, basis)` where basis is `"layout"`, `"liveness"` or
-    `"wall"`. The wall fallback (no readable state file) still carries the
+    Returns `(hours, basis)` where basis is `"layout"`, `"liveness"`, `"skew"`
+    or `"wall"` — FOUR, and the `why` dict in `cmd_restore` is the only
+    consumer that knows it. A second consumer built from a three-arm contract
+    KeyErrors in the refusal path, which is the crash this line exists to
+    prevent. The wall fallback (no readable state file) still carries the
     powered-off flaw by construction, so the basis is part of the answer and
     the refusal message NAMES it — the same number means different things.
     """
@@ -711,8 +717,14 @@ def cmd_restore(dry_run: bool = False, plan_path: Path | None = None,
                     "wall": "older than (wall clock, no layout to compare)",
                     # Liveness was NOT evaluated; say so rather than let the
                     # reader assume both terms were checked.
+                    # NOT "the clock moved backwards": `since < 0` fires on
+                    # ANY future mtime — a restored backup, `touch -d`, an
+                    # rsync preserving a bad stamp — and this code cannot tell
+                    # those apart. Name the OBSERVATION, not a cause it never
+                    # measured; that is the principle this branch exists for.
                     "skew": ("out of step with the saved layout by (liveness "
-                             "NOT evaluated — the clock moved backwards) "),
+                             "NOT evaluated — an artefact's mtime is in the "
+                             "future)"),
                 }[basis]
                 print(f"restore plan is {why} {gap:.1f}h "
                       f"(limit {staleness_hours}h, basis={basis}) — too stale, "

--- a/scripts/tmux-session-restore.py
+++ b/scripts/tmux-session-restore.py
@@ -598,7 +598,9 @@ def plan_staleness_hours() -> tuple[float, str] | None:
       🔴 boot+45s, chain dead 1400h  gap 30s, live 45s -> PASSES  (NOT CLOSED)
 
     🔴 THE LIVENESS TERM IS ARITHMETICALLY INERT WHENEVER `uptime <= limit`, AND
-    THAT INCLUDES THE BOOT THE UNIT RUNS ON. `live = min(since, uptime) <=
+    THAT INCLUDES THE BOOT THE UNIT RUNS ON. (The same is true of the SKEW
+    branch below and of anything else routed through this cap — the ceiling
+    applies to the term, not to one reason for it.) `live = min(since, uptime) <=
     uptime`, and refusing needs `> limit` — so at boot+45s with a 2h limit
     (`nix/home.nix`), `live <= 0.0125h`, 160x under, and this degrades exactly
     to the contemporaneity-only behaviour. A guard that is BREAKABLE at a
@@ -637,20 +639,36 @@ def plan_staleness_hours() -> tuple[float, str] | None:
     mt = PLAN.stat().st_mtime
     state = resurrect_state_mtime()
     if state is None:
-        return ((time.time() - mt) / 3600, "wall")
+        # `max(0.0, …)`: under the same backward skew this goes negative, and a
+        # negative age both prints as nonsense and compares as fresh. There is
+        # no second measure to fall back to on this basis, so clamp and let the
+        # value stand at "not stale", which is what a negative already meant.
+        return (max(0.0, (time.time() - mt) / 3600), "wall")
     gap = abs(state - mt) / 3600
     # Liveness: time since the chain last produced ANYTHING, but never counting
     # more than this boot has been up — powered-off time is the one interval in
     # which nothing can have gone stale.
     since = (time.time() - max(state, mt)) / 3600
     if since < 0:
-        # 🔴 The clock moved BACKWARDS past an artefact's mtime — an anomalous
-        # measurement, not evidence of freshness. Early boot is exactly when
-        # this happens (RTC ahead, then timesyncd steps back), and it is also
-        # when this runs. Treat it like an unreadable cap and fail TOWARDS
-        # refusing, matching `uptime_hours`'s reasoning; the old `else 0.0`
-        # silently switched the liveness term off at the worst moment.
-        since = float("inf")
+        # 🔴 The clock moved BACKWARDS past an artefact's mtime, so LIVENESS IS
+        # UNMEASURABLE — and both obvious answers fabricate a number.
+        #
+        #   `since = 0`   claims the chain just wrote. Silently disables the
+        #                 F1 guard, which is what round 2 flagged.
+        #   `since = inf` claims it never did. Looks safe and is worse: `live =
+        #                 min(inf, uptime)` collapses to UPTIME, so a ONE-SECOND
+        #                 step back on a long-uptime host refuses a HEALTHY chain
+        #                 and reports it "silent for 753.0h". Measured. That is
+        #                 the misdirecting-refusal failure `resurrect_last_path`
+        #                 calls worse than failing open — and it was inert at
+        #                 early boot anyway, the very case its comment named,
+        #                 because the uptime cap neuters it there.
+        #
+        # CONTEMPORANEITY NEVER READS `now`, so it is immune to skew and stays
+        # valid. Fall back to it and NAME the fact that liveness was not
+        # evaluated, rather than inventing a liveness number in either
+        # direction. Reporting "unmeasured" is the honest third option.
+        return (gap, "skew")
     live = min(since, uptime_hours())
     return (gap, "layout") if gap >= live else (live, "liveness")
 
@@ -691,6 +709,10 @@ def cmd_restore(dry_run: bool = False, plan_path: Path | None = None,
                     # cause is the opposite — the save chain stopped.
                     "liveness": "produced by a chain that has been silent for",
                     "wall": "older than (wall clock, no layout to compare)",
+                    # Liveness was NOT evaluated; say so rather than let the
+                    # reader assume both terms were checked.
+                    "skew": ("out of step with the saved layout by (liveness "
+                             "NOT evaluated — the clock moved backwards) "),
                 }[basis]
                 print(f"restore plan is {why} {gap:.1f}h "
                       f"(limit {staleness_hours}h, basis={basis}) — too stale, "


### PR DESCRIPTION
## The defect

Found by dry-running the restore path rather than reasoning about it. A plan written **0.02h before shutdown** reads as 8h or 24h stale purely from the host being switched off, and `restore --staleness-check 2` exits 1 — the same silent-decline failure this feature already shipped twice this week (`56c68cc7`, `cc409f82`), reached from a third cause.

Being powered off is the one interval in which reality **cannot** diverge from the plan: no session opens, none closes, no window moves. The gate was measuring an interval in which the workspace provably cannot change.

## The fix: two claims, because one is not enough

🔴 **Two adversarial audit rounds each found a real defect in this PR's own change.** Round 1: measuring only plan-vs-layout *contemporaneity* is blind to the chain dying **whole** — plan and layout share one writer, so a total freeze keeps the gap constant. Measured: both frozen 1400h ago, 30s apart -> gap `0.008h` -> `rc 0` -> restore relaunches a 58-day-old plan across 44 windows.

`plan_staleness_hours()` returns the **worse** of:
- **contemporaneity** `abs(state - plan)` — catches a **one-sided** freeze either way (hence `abs()`).
- **liveness** `min(now - newest_artefact, uptime)` — catches a **total** freeze. The uptime cap keeps the original bug fixed: at boot+45s the newest artefact predates shutdown, so the cap reduces it to 45s.

| scenario | contemporaneity | liveness | verdict |
|---|---|---|---|
| running normally | ~1 min | ~15 min | passes |
| boot+45s after 24h off | ~1 min | 45 s | **passes** (bug fixed) |
| 31d uptime, chain dead 1400h | 30 s | 753 h | **REFUSES** |
| plan frozen, layout live | huge | — | **REFUSES** |
| 🔴 **boot+45s, chain dead 1400h** | 30 s | 45 s | **PASSES — NOT CLOSED** |

## 🔴 What this does NOT close, stated rather than implied

Round 2 found the liveness term is **arithmetically inert whenever `uptime <= limit`**: `live = min(since, uptime) <= uptime`, and refusing needs `> limit`. The unit passes `--staleness-check 2` and fires ~45s after login, so `live <= 0.0125h` — 160x under. At every boot, this degrades to contemporaneity-only. My test pinned `uptime_h=753.0`, **376x the limit**: the guard was *breakable* at a fixture constant and *unreachable* at the call site's real value. Those are different claims and only the second protects a boot.

**Why it is not closed here.** At boot, mtimes alone cannot separate "chain healthy, host off 24h" from "chain dead 58d, host off 24h" — after the cap both read `since ~= uptime`. The discriminator is the previous boot's end, and it is not reliably available: **measured 2026-09-05**, `journalctl --list-boots` reports two boots whose ranges do not abut (boot -1 ends 07-14, boot 0 begins 08-18) while `uptime -s` says 08-04 — the journal had rotated the intervening boots away. A detector on that is least trustworthy on exactly the long-lived host where a frozen chain is likeliest.

**What bounds the damage.** A frozen chain froze *both* artefacts, so resurrect's layout is equally stale and continuum restores that old layout whatever this gate decides. The gate cannot prevent the stale workspace, only decide whether to populate it — and populating it with the conversations that match it is coherent. What is lost is the **diagnostic**: the old wall-clock refusal is how the 2026-08-05 freeze was noticed. The docstring says where to look instead.

## Other findings, both rounds

- **`@resurrect-dir` is configurable**, and the plugin expands `$HOME`/`$HOSTNAME`/`~` **anywhere** (`helpers.sh:resurrect_dir()`) while `expanduser` handles only a leading `~`. A hardcoded path, or a half-expanded one, becomes un-stat-able -> `wall` basis -> the powered-off flaw silently reintroduced.
- **A liveness refusal called itself "wall clock"** — the measure this PR rejects — and that message is reachable *only* when the chain has stopped, sending the operator after the bug they just fixed.
- **A backwards clock switched the guard off.** `since > 0 else 0.0` disabled the liveness term under skew, at early boot, which is both when skew happens and when this runs. Now fails *towards* refusing, matching `uptime_hours`'s own reasoning three lines away.
- **Two hermeticity leaks**, one of which this change would have introduced. 🔴 And the original hermeticity control was **non-discriminating**: "identical passes with `HOME` nonexistent" is true and proves nothing, because an absent `HOME` selects the `wall` fallback, which cannot fail. The discriminating control is a `HOME` carrying a **stale** state file; now run.
- Usage line updated; three further mutation survivors pinned (`stat` vs `lstat`, `except OSError` width, wall-basis wording).

## Verification

- **RED -> GREEN**, base `f887e958`: 10 failed / 44 passed -> **66 passed**.
- **Mutants: 8 in round 1, 3 more in round 2** — every one killed by its own named assertion, with a green control and a positive control each time. The three round-2 mutants are exactly the ones the audit found **surviving**.
- **Both gate tiers on the merged tree**, one at a time: `pytests` -> `RESULT: PASS (exit=0)`, `collected=21528 passed=21525 skipped=3 failed=0`; `nodetests` -> `RESULT: PASS (exit=0)`, 0 fail; 0 timeout panics.

## Not verified

**No reboot has occurred.** `uptime -s` is 2026-08-04. Every power-off scenario is reproduced by fixture mtimes and an injected uptime, not by an actual shutdown — the one test nothing here substitutes for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2HwZGfRQSHQTJxjh7mkfy