### PR TITLE
docs(handoff): round 3 of #1304 is NOT clean — two blind lenses, four new gaps, and round 2's claims all held

### DIFF
--- a/claudedocs/handoff-index-store-claims-accuracy.md
+++ b/claudedocs/handoff-index-store-claims-accuracy.md
@@ -22,45 +22,71 @@ reading, and per the protocol no field was written and no task was created.
 
 ## State now
 
-**RANK 1 (the `seed.sh` hard-guard) IS IN FLIGHT AS `devrc#1304`, NOT MERGED.**
-Branch `fix/seed-refuse-pod-overwrite`, head `d7c4c266`. Two audit rounds done; **round 3
-is owed** (round 2 returned findings, so the ladder cannot stop there).
+**RANK 1 (the `seed.sh` hard-guard) IS STILL IN FLIGHT AS `devrc#1304`, NOT MERGED.**
+Branch `fix/seed-refuse-pod-overwrite`, head `d7c4c266`. **Round 3 ran and was NOT CLEAN, so
+the ladder continues and a ROUND 4 delta audit is owed after the fixes below.** No gate tier
+has been run on this branch and no merge was attempted.
 
-- **What it does.** A PRE-FLIGHT before the tar: for exactly the paths in `$staged_list`, ask
-  the pod whether it holds different bytes; refuse **exit 8, pushing nothing**, and name them.
-  `--allow-overwrite` proceeds and still prints what it replaced. The header's
-  `🔴 THE LOCAL STORE IS AUTHORITATIVE` — false since the cutover — is corrected.
-- **Why bytes, not mtime:** two copies cannot be ordered (a local edit not yet pushed and a pod
-  edit not yet pulled both read as "different"). Post-cutover the pod is the authority, so ANY
-  difference means a derivative would overwrite it. No clock needed.
-- **Round 1 (audit) found a 🔴 IN THE GUARD ITSELF.** The pre-flight printed its count only on
-  failure and the probe emitted a line only for files the pod HAS — so "the pod holds none of
-  them" and "the probe never ran" were the same observation (zero lines, rc 0). Driven
-  end-to-end with a silenced probe, the push **destroyed the pod's newer bytes and printed
-  `seed: OK`**. Fixed: every path is answered (hash / `ABSENT` / `UNREADABLE`), a short reply is
-  exit 9, and the counts print on every path.
-- **Round 2 refuted a round-1 claim of mine, in both halves.** `-I{}` does NOT disable xargs's
-  input quote parsing (only `-d`/`-0` does), so a quoted path still aborted rc 1 with no
-  diagnostic — byte-identical to base. And the space case stopped aborting and started LYING:
-  `awk '{print $2" "$1}'` truncated the join key at the first blank, so two BYTE-IDENTICAL
-  entries collapsed to one key, the join became a cross-product, and the guard refused with
-  `differing=2` naming a path that does not exist. Fixed: `-d '\n'` on both sides, TAB-separated
-  key, `join -t <tab>`.
-- **Mutation matrix, all re-run rather than asserted:** local loses `-d` → killed; `awk`
-  truncates the key → killed; `LC_ALL=C join` → `join` → killed (it SURVIVED all 40 base tests
-  before round 1); drop the answered-count gate → killed.
+- **What it does** (unchanged). A PRE-FLIGHT before the tar: for exactly the paths in
+  `$staged_list`, ask the pod whether it holds different bytes; refuse **exit 8, pushing
+  nothing**, and name them. `--allow-overwrite` proceeds and still prints what it replaced.
+  The header's `🔴 THE LOCAL STORE IS AUTHORITATIVE` — false since the cutover — is corrected.
+- **Why bytes, not mtime** (unchanged): two copies cannot be ordered, so ANY difference means a
+  derivative would overwrite the authority. No clock needed.
+- **Round 1 found a 🔴 in the guard itself** — the probe emitted a line only for files the pod
+  HAS, so "the pod holds none of them" and "the probe never ran" were one observation. Fixed:
+  every path is answered (hash / `ABSENT` / `UNREADABLE`), a short reply is exit 9.
+- **Round 2 refuted a round-1 claim in both halves** — `-I{}` does NOT disable xargs's input
+  quote parsing, and `awk '{print $2" "$1}'` truncated the join key at the first blank, turning
+  the guard into a confident FALSE REFUSAL. Fixed: `-d '\n'` both sides, TAB-separated key,
+  `join -t <tab>`.
+- 🔴 **ROUND 3 (this session) IS NOT CLEAN — both lenses reported, both returned findings.**
+  Dispatched blind against `ec16cce8..d7c4c266`. Full evidence in the Open-investigations
+  blocks below.
+- **Lens 1 (shell semantics) — five findings.** Headline: the TAB key round 2 introduced is
+  itself undelimited, and the pod's `/bin/sh` is **dash**, whose `echo` interprets `\t`/`\n`/`\c`
+  while every test runs under bash.
+- 🔴 **Lens 2 (are the new tests real?) — round 2's own claims all held.** All four verified
+  TRUE and re-run, not asserted: all **three** new tests are RED at base (claim 1 *understated*
+  it — it called the DIFFERS test an anti-blindness assertion, and it is also a genuine
+  regression test); the mutation matrix (a)–(d) all **KILLED, each by the named guard's own
+  message**; **723 collected / 723 passed** across two independent runs (357s, 385s);
+  pre-existing coverage intact (7 tests, all four behaviours green). This is the first round
+  whose predecessor's claims survived scrutiny.
+- 🔴 **But lens 2 found TWO SURVIVING MUTANTS — new guards with no test.** `MUTANT F` (make the
+  local hash side silently drop quoted paths while still exiting 0, leaving `answered==staged`)
+  **survived all 46 seed tests**; the QUOTE test asserts only that the run did not crash, so
+  nothing pins that the quoted path was ever in the compared population. `MUTANT H` (revert this
+  delta's `|| [ $? -eq 1 ]` to the exact `|| :` its own comment condemns) **survived all 46**.
+- **Claims measured FALSE this round:** the commit's claim that the key survives any path
+  (false for TAB and for a leading space — reproduced INDEPENDENTLY by both lenses), that
+  `UNREADABLE` always lands in the clobber set (false), and that the `--help` `awk` "cannot
+  drift as the header changes" (false — one blank line truncates it).
+
+**Corrections to this doc, both measured 2026-09-05:**
+- 🔴 **Rank 8 is CLOSED, not open.** `test_a_body_file_written_by_a_heredoc_on_the_same_line_is_read`
+  **passes** on `origin/main` (`1 passed in 0.29s`). `8c27c5cf` (#1303) fixed it — "a stale file
+  at the `--body-file` path shadowed the heredoc about to overwrite it — the verdict was a
+  property of the HOST." The dev-host tier's known-red is gone; it is no longer a reason to
+  discount a red there.
+- **Both Tekton checks are GREEN on `d7c4c266`** — `/repos/.../commits/<sha>/status` reports
+  `state: success` for `tekton/devrc-pytests` and `tekton/devrc-nodetests`. ⚠ `strict` is false,
+  so that is a claim about the PR BRANCH and says nothing about the merged tree.
+- The base clone was **1 commit behind** `origin/main` at session start; fast-forwarded to
+  `f887e958` before any write. `main` has moved 2 commits past the PR's branch point
+  (`d9f0836c` tmux-restore, `f887e958` this doc), both touching files disjoint from the PR —
+  but `d9f0836c` adds a new test file, so the merged tree's per-target floors will move.
 
 🔴 **NOT VERIFIED, and not claimed:**
 - **Neither gate tier has run on `d7c4c266`** — not `scripts/gate.sh --tier both`, not the two
   sandbox derivations, not on the merged tree.
-- The full `test_subsystem_store_api.py` was last run green (**723 passed**) at the round-2 fix
-  commit; since then only targeted subsets (31 passed) have run.
 - **Nothing has touched the LIVE pod.** Every test drives a fake `kubectl` whose `exec` rewrites
-  `/data` to a temp dir and runs the command locally — a harness that structurally cannot tell
-  "works on the pod" from "works on this host". The round-1 auditor closed that gap with a
-  read-only live probe (pod `/bin/sh` = dash, GNU findutils 4.10, the literal command clean over
-  211 real entries); a later auditor's worktree guard refused `kubectl exec` entirely, so that
-  evidence has not been refreshed.
+  `/data` to a temp dir and runs the command locally under **bash** — a harness that
+  structurally cannot tell "works on the pod" from "works on this host", which is exactly the
+  gap round 3 fell into.
+- The round-3 lens-1 auditor measured the pod's toolchain by running `python:3.12-slim` (the
+  `Dockerfile`'s own `FROM`) under local docker. **It did NOT verify the deployed pod's image
+  matches that Dockerfile**; if the tag drifted, the `/bin/sh = dash` finding does not transfer.
 
 ## Open investigations — live diagnosis state
 
@@ -191,59 +217,180 @@ is owed** (round 2 returned findings, so the ladder cannot stop there).
   decide. If P3 is retained, the one-line change is `--allow-overwrite` at
   `cairn-cutover.py:1379-1382` plus a test that exercises P3 against the real `seed.sh`.
 
+### 🔴 The pre-flight's join key can DIVERGE between host and pod — and the pod's `echo` is the reachable route
+- **Symptom + exact repro:** a staged entry whose pod copy DIFFERS is silently treated as a pure
+  addition and pushed, or an IDENTICAL entry is falsely refused naming a path that does not
+  exist. Reproduce the escape half with no cluster:
+  `dash -c 'echo "ABSENT  $1"' _ 'sc/tab\there.md' | cat -A`
+- **Observed (with values):** `scripts/subsystem-store-api/Dockerfile:34` is
+  `FROM python:3.12-slim` → Debian → `/bin/sh` is **dash**. dash's `echo` interprets
+  backslash escapes; bash's does not. Same command, same input:
+
+  | staged path | pod (dash) | tests (bash) |
+  |---|---|---|
+  | `sc/tab\there.md` | `ABSENT  sc/tab<REAL TAB>here.md` | `ABSENT  sc/tab\there.md` |
+  | `sc/new\nline.md` | splits into **TWO** lines | one line |
+  | `sc/cut\chere.md` | truncates AND **swallows the next answer** | one line |
+
+  The `\t` case emits a real TAB on the pod side only, so the local key is
+  `sc/tab\there.md` and the pod key is `sc/tab` — they do not join, the row vanishes, and a
+  differing pod entry reads as a pure addition. `answered == staged` still holds, so exit 9
+  does not fire. `printf 'ABSENT  %s\n' "$1"` produces the bash output under dash in all three
+  cases (measured).
+- **Observed (lens-1 auditor, its fuzzer validated both ways — 0 disagreements in 400 clean
+  trials, and it killed a known-fatal mutant by dropping `join -t <TAB>`):** a literal TAB in a
+  staged path takes base `differing=0 / rc 0` to HEAD `differing=1 / rc 8` naming `sc/a`; two
+  scopes `" sc"` and `"sc"` take base `rc 0` to HEAD `differing=2 / rc 8` naming `sc/e.md`
+  twice. Both are FALSE REFUSALS — fail-safe, but verbatim the shape the delta's own comment
+  claims to have removed.
+- **Observed:** `UNREADABLE` does not always reach the clobber set. For `sc/back\slash.md`
+  differing AND unreadable on the pod, GNU `sha256sum` escapes the local line
+  (`sc/back\\slash.md`) while the hand-written `echo` does not, the keys diverge, `clobber` is
+  empty and `PRE-FLIGHT staged=1 answered=1 differing=0` lets the push proceed.
+- **Ruled out:** "the pod's `xargs` is busybox, so `-d '\n'` fails" — the image carries GNU
+  findutils 4.10.0 and GNU coreutils 9.7, so `-d` works and the HASH branch's escaping is
+  symmetric with the host. The asymmetry is confined to the two hand-written `echo` branches.
+  via: measurement
+- **Ruled out:** "round 2's TAB key removed the truncation class" — it moved the boundary from
+  `0x20` to `0x09`; it did not remove it. via: measurement
+- **Ruled out:** "the existing suite would catch any of this" — the file is fully green
+  (723 passed) and catches none of them, because the fake `kubectl` runs the probe under bash.
+  via: measurement
+- **Leading hypothesis — one root cause, not five:** the key is derived by parsing a path back
+  OUT of hash-output text, on two sides that do not agree on how text is escaped. The
+  consolidating fix is to stop doing that: both sides consume the SAME `$staged_list` in the
+  SAME order through `xargs -I{}`, so pair by POSITION (`paste`) and look the path up from
+  `$staged_list` by line number. That structurally removes the TAB case, the leading-space
+  case, the `UNREADABLE` case AND the whole `sort`/`join`/`LC_ALL` ordering class. Cost: it
+  deletes `TestTheSeedPreFlightJoinIsLocaleSafe`, which pins a real hazard — so removing it
+  needs care, and that is why it was not done unilaterally.
+- **Corroboration:** lens 2 reproduced the TAB false refusal INDEPENDENTLY at unmutated HEAD —
+  two byte-identical `widget-cfg/ta<TAB>bbed.md` files give `differing=1`, exit 8, and a refusal
+  naming `widget-cfg/ta`. Mechanism: `join -t TAB` splits the tab path into extra fields, so
+  `awk -F'\t' '$2 != $3'` compares a filename fragment against a hash and is ALWAYS unequal.
+  Backslash paths pass. Direction is fail-safe (always-refuse, never a silent clobber) for the
+  literal-TAB route — the SILENT-CLOBBER route is the dash `echo` one above, which lens 2 did
+  not test.
+- **Next probe:** decide between the minimal fix (`echo` → `printf` on both pod branches; `awk`
+  skips blank lines in `--help`) and the structural one (pair by position). Either way a ROUND 4
+  delta audit is owed.
+
+### `--help` still drifts, and has ZERO test coverage
+- **Symptom + exact repro:** insert one blank line into `seed.sh`'s leading comment header and
+  run `bash seed.sh --help`.
+- **Observed (with values):** unmodified → **61 lines**, ends on a complete paragraph, contains
+  `allow-overwrite`. One blank line inserted at line 33 → **31 lines**, `allow-overwrite`
+  occurrences **0**. The `awk`'s `{exit}` fires on the first non-`#` line, and a blank line is
+  one. That is verbatim the defect `d7c4c266` exists to fix, silently reintroducible.
+- **Ruled out:** "the line-range rot was the whole bug and the `awk` closes it" — the `awk`
+  closes the GROWTH shape and leaves the BLANK-LINE shape wide open. via: measurement
+- **Ruled out:** "a test guards the fix" — `grep` over `test_subsystem_store_api.py` finds no
+  `seed.sh --help` assertion at all; the only `--help` test belongs to
+  `verify-byte-identity.sh`. The commit's headline claim is unguarded. via: measurement
+- **Leading hypothesis:** `/^#/{...} /^$/{next} {exit}` (or match `^#|^$` and stop only on a
+  real non-comment line), plus the missing test asserting `--help` contains `allow-overwrite`
+  and ends on a terminator.
+- **Next probe:** fold into the same fix commit as the block above, then round 4.
+
+### Two of the delta's NEW guards have no test — both mutants SURVIVED
+- **Symptom + exact repro:** break the guard on purpose and the suite stays green.
+  `MUTANT F`: insert `awk '!index($0,"\047")' |` before the LOCAL `xargs` (drops quoted paths,
+  exits 0, remote probe untouched so `answered==staged` still holds).
+  `MUTANT H`: revert `seed.sh:441`'s `|| [ $? -eq 1 ]` to `|| :`.
+- **Observed (with values):** both survived **all 46 seed tests** (unmutated control 46/46
+  green). Under `MUTANT F` a quoted entry whose pod copy DIFFERS prints
+  `PRE-FLIGHT staged=4 answered=4 present_on_pod=1 differing=0` then
+  `seed: PUSHED … seed: OK all 4 staged entries are present on the pod` — a silent clobber, the
+  exact defect this PR exists to remove, with the suite green. The auditor wrote the missing
+  test (a quoted entry whose pod copy differs); it FAILS under `MUTANT F` and PASSES at
+  unmutated HEAD, so the capability is real and only the test is absent.
+- **Ruled out:** "the SPACE hazard has the same gap" — it does not. `MUTANT G` (exclude spaced
+  paths from the comparison) killed the DIFFERS test while the IDENTICAL test survived, so the
+  SPACE pair is a genuine two-direction control. Only the QUOTE hazard is one-directional.
+  via: measurement
+- **Ruled out:** "`|| [ $? -eq 1 ]` is unreachable, so the surviving mutant is harmless" — GNU
+  grep does exit **2** on a write error (verified against `/dev/full`), and
+  `cmd || [ $? -eq 1 ]` does abort under `set -euo pipefail` (verified). The guard works; it is
+  simply unguarded. ⚠ Its abort emits **no `seed:` line** — the bare-failure-no-diagnostic shape
+  the QUOTE test's own docstring calls unacceptable, one guard over. via: measurement
+- **Leading hypothesis:** three tests are owed, not a code change — a quoted entry whose pod
+  copy differs (kills F), a `grep` I/O-error path (kills H), and a `seed.sh --help` assertion.
+- **Next probe:** add them in the same commit as the fixes above, then round 4.
+
+### What the `fake_cluster` harness structurally CANNOT see
+- **Symptom + exact repro:** read the fixture — its fake `kubectl exec` sed-rewrites
+  `/data`→`$FAKE_DEST` in each argument and runs the command **locally** via `"$@"`. The "pod"
+  is this host.
+- **Observed (with values):** in the devshell `sh` resolves to `bash-interactive-5.3p15/bin/sh`
+  — bash, the most permissive shell available — while the real pod's `/bin/sh` is dash. Also:
+  `xargs -d` is a GNU findutils extension, and **no test pins the `Dockerfile`'s `FROM` line**
+  (`test_the_image_copies_every_module_it_needs` pins `COPY` lines only), so a base-image swap
+  to alpine would break the probe with **zero** test failures. Truncation is simulated only as
+  TOTAL silence (`FAKE_PROBE_SILENT` → 0 lines); PARTIAL truncation and pod-stderr interleaving
+  into probe stdout are never produced.
+- **Ruled out:** "723 green tests cover the probe's behaviour on the pod" — they cover it on
+  this host, under bash, with GNU tools. Every finding in the two blocks above is invisible to
+  all of them. via: measurement
+- **Leading hypothesis:** a cheap two-line test pinning `FROM python:3.12-slim` (so a base-image
+  swap fails loudly) is worth more than widening the fake; a genuinely faithful fake needs the
+  real image.
+- **Next probe:** add the `FROM` pin; decide separately whether a docker-backed test is worth
+  its cost.
+
 ## Next steps (ranked)
 
-1. **Round 3 delta re-audit of `ec16cce8..d7c4c266`** (devrc#1304). Round 2 returned findings, so
-   the ladder cannot stop there — a clean round is the stop condition, not a verdict. Dispatch
-   BLIND: give the diff and round 2's claims block, never the reasoning for why they are correct.
-   forcing: gate — this repo's audit gate is the only pre-merge review, and two of two rounds so
-   far each found a real defect the previous round introduced.
+1. **Fix round 3's findings and run ROUND 4 on `devrc#1304`.** Both lenses reported; both
+   returned findings (blocks above). Round 2's own claims all HELD — the new work is (i) the
+   host/pod escaping divergence, (ii) the TAB/leading-space key, (iii) `--help` blank-line
+   drift, (iv) three missing tests for guards whose mutants survived. Fix once, as one batch,
+   then re-audit the DELTA — a round returning findings cannot end the ladder. Decide
+   minimal-vs-structural using the Leading hypothesis in the first block.
+   forcing: gate — this repo's audit gate is the only pre-merge review, and three of three
+   rounds have each found real defects.
 
 2. **Gate `devrc#1304` and merge.** `scripts/gate.sh --tier both` AND
    `nix build .#checks.x86_64-linux.{pytests,nodetests}` ONE AT A TIME, on the MERGED tree, with
    the base sha named in the claim. ⚠ Read the runners' `RESULT:` lines, never a piped exit
-   code — that trap fired four times in this effort. ⚠ Any red measured above ~load 20 on this
-   box needs a control before it means anything; three failures investigated here were other
-   agents' suites.
+   code. ⚠ Any red measured above ~load 20 on this box needs a control first. Note the
+   dev-host tier's known-red is GONE (#1303), so a red there now means something.
    forcing: gate — nothing else gates a merge in this repo; `main` is protected in name only.
 
-3. **Decide `cairn-cutover.py` P3** (see the open investigation above). Either pass
-   `--allow-overwrite` or declare P3 dead post-cutover.
+3. **Decide `cairn-cutover.py` P3.** Either pass `--allow-overwrite` at
+   `cairn-cutover.py:1379-1382` or declare P3 dead post-cutover. Its shippable set is
+   ADD + SUPERSEDES + MERGED, and SUPERSEDES/MERGED are by definition entries whose pod bytes
+   differ — so the pre-flight refuses and P3 cannot complete.
    forcing: regression — a shipped code path that can never complete, made worse by guidance
    that is false for its only programmatic caller.
 
 4. **Fix the opencode blindness in `scripts/lib/clawgate_handoff.sh`.** Diagnosed and recorded
    (squash `13775144`), NOT fixed. It reads only `CLAUDE_CODE_SESSION_ID`;
    `grep -c OPENCODE_SESSION_ID` is **0**. Detached opencode ⇒ exit 3 forever; NESTED opencode
-   inherits the outer Claude session's id ⇒ exit 0 with **another session's tasks**. The browser
-   bridge already fails closed on exactly this (`X-Session-Origin: opencode-inherited`).
+   inherits the outer Claude session's id ⇒ exit 0 with **another session's tasks**.
    forcing: regression — the nested path silently misattributes today.
 
-5. **Run `scripts/ship.sh`.** Still never run in this effort. The workbench looked current; the
-   **laptop is UNVERIFIED**, so a session there may still be told to write new entries into the
-   dead mirror. Read every per-host line, not the final verdict.
+5. **Run `scripts/ship.sh`.** Still never run in this effort. The **laptop is UNVERIFIED**, so a
+   session there may still be told to write new entries into the dead mirror. Read every
+   per-host line, not the final verdict.
    forcing: regression — a stale prescription on one host reintroduces the defect this effort
    closed.
 
 6. **Decide the token allowlist for the 2 remaining local-only entries**
-   (`civitai-app-requests/app-requests.md`, `civitai-developer-docs/apps.md`). `cairn create`
-   answers `not-found`; `cairn doctor` confirms neither scope is in this token's allowlist.
-   Widening it means editing the k8s secret and deleting the pod (the token file is read ONCE at
-   startup) — an access-control change and a second outage window.
+   (`civitai-app-requests/app-requests.md`, `civitai-developer-docs/apps.md`). Widening it means
+   editing the k8s secret and deleting the pod — an access-control change and an outage window.
    forcing: none
 
-7. **Fix `devrc#1170`'s 🟡5 and 🟡6.** Still never started. Re-measured 2026-09-04: **0**
-   occurrences of `policy:` in `service_recon.py` on `origin/main`, so 🟡5 stands exactly as
-   written. 🟡6: `--template` over an EXISTING entry prints the first-ever-file template and
-   exits 0 silently, destroying an `OPEN:` bullet.
+7. **Fix `devrc#1170`'s 🟡5 and 🟡6.** Still never started. 🟡5: **re-measured 2026-09-04, 0**
+   occurrences of `policy:` in `service_recon.py` on `origin/main`, so it stands exactly as
+   written — `subsystem-index/SKILL.md:148` tells the caller to read a policy nobody names.
+   🟡6: `--template` over an EXISTING entry prints the first-ever-file template and exits 0
+   silently, destroying an `OPEN:` bullet.
    forcing: none
 
-8. **`main` is RED on `scripts/claude-hooks/tests/test_clawgate_task_interview_guard.py`**
-   (`test_a_body_file_written_by_a_heredoc_on_the_same_line_is_read`). PROVEN inherited: fails on
-   `origin/main` with any PR diff absent, deterministically in 0.24s on a quiet box. ⚠ The
-   SANDBOX tier does NOT reproduce it — only the dev-host tier — so it is invisible to the gate a
-   merge is judged on. Unowned.
-   forcing: regression — a red dev-host tier trains everyone to merge through it.
+8. **~~`main` is RED on `test_clawgate_task_interview_guard.py`~~ — CLOSED, do not re-open.**
+   Re-measured 2026-09-05: it PASSES on `origin/main` (`1 passed in 0.29s`). `8c27c5cf` (#1303)
+   fixed it. Kept as a numbered entry only so the ranks above keep their identity for
+   `claim-work --slug-for`.
+   forcing: none
 
 ## Gotchas / decisions / dead-ends
 - 🔴 **The sweep needed THREE widenings and each read as complete.** `no off-machine backup` → 12;
@@ -437,24 +584,75 @@ is owed** (round 2 returned findings, so the ladder cannot stop there).
   verify another agent's claim about it and is definitively not this work, so per the flow no
   field was written and none was created.
 
+- 🔴 **THE TEST HARNESS RUNS THE POD'S COMMAND UNDER BASH, AND THE POD IS DASH.** Every test in
+  `test_subsystem_store_api.py` drives a fake `kubectl` whose `exec` runs the command locally.
+  `echo "ABSENT  $1"` therefore behaves one way in all 723 green tests and a different way on
+  the pod. **Any claim about the probe's OUTPUT TEXT is unproven by that suite.** Measure the
+  pod side with `dash`, or by running the `Dockerfile`'s own base image under docker — both
+  cost seconds and neither needs a cluster.
+- 🔴 **A DELIMITER FIX THAT CHANGES THE DELIMITER IS NOT A FIX.** Round 2 replaced a
+  space-delimited key with a TAB-delimited one and declared the truncation class closed. It
+  moved the boundary from `0x20` to `0x09` — the same bug, one byte lower, and the round-2
+  commit's own comment describes the defect it still has. Ask instead whether the key needs to
+  be parsed out of text AT ALL.
+- 🔴 **`{exit}` on "the first non-comment line" treats a BLANK line as code.** The `--help`
+  rewrite traded a rotting line-range for a rule that a single blank line in the header
+  silently truncates — measured 61 → 31 lines with `allow-overwrite` gone. A rule that "cannot
+  drift" should be tested; there is no `seed.sh --help` test at all.
+- **Two of three round-3 findings I re-measured MYSELF rather than taking the auditor's word,
+  and both held exactly.** The rules require re-verifying a subagent's numbers; here they were
+  right. That is worth recording precisely because the previous two rounds each carried a wrong
+  datum from a subagent.
+- 🔴 **TWO INDEPENDENT LENSES FOUND THE SAME TAB DEFECT BY DIFFERENT ROUTES** — lens 1 by
+  fuzzing the real script, lens 2 by hand at unmutated HEAD. Neither was told what the other was
+  looking for. That agreement is the strongest evidence in this round, and it is also the
+  argument for splitting a round into lenses rather than running one auditor twice.
+- 🔴 **THE FIRST ROUND WHOSE PREDECESSOR'S CLAIMS ALL SURVIVED — and it still found defects.**
+  Rounds 1 and 2 each caught the previous round LYING about what it had fixed. Round 3 verified
+  every round-2 claim as TRUE (and one as *understated*), then found four NEW gaps anyway. So a
+  round is not over when the previous round's claims check out; "the claims are honest" and
+  "the code is right" are different questions, and only the second ends the ladder.
+- 🔴 **A SURVIVING MUTANT IS THE ONLY THING THAT FOUND THE MISSING QUOTE TEST.** The QUOTE test
+  looked like a regression test, IS red at base, and still pins nothing about whether the quoted
+  path was compared — because it asserts an absence (no crash) rather than a presence. The tell
+  is generic: **a test whose every assertion is negative cannot distinguish "handled" from
+  "skipped".** Its SPACE sibling avoids this only because a second test asserts the positive
+  direction.
+- **The handoff doc was 1 commit behind at session start** and `handoff_doc.py` resolves its
+  base from the working tree, so the fast-forward had to happen BEFORE any draft. A stale base
+  would have merged into an out-of-date document and reported success.
+- **No clawgate task recorded, again.** `clawgate_handoff.sh resolve` exited **5** — 0 tasks for
+  this session, positive control confirming the board was reachable (2 links for another
+  session). A wrong session id answers 200/empty exactly like a session that touched nothing,
+  so this is **not** a clean reading; no field was written and none was created.
+- ⚠ **Environment, unchanged:** the shared `devrc` clone still holds another session's
+  uncommitted WIP (`nix/programs/alacritty/default.nix`, `output.txt`,
+  `nix/system/apply-nebula-relay.sh`, `nix/system/check-nebula-relays.sh`,
+  `scripts/diagnose-nix-disk.sh`). Nothing here touched them. This session worked on `main` for
+  reads only and did every write in the worktree `~/workspace/devrc-ho-r3`.
+
 ## How to verify
 
 ```bash
-# the reconciliation is live on the pod, read through the PRESCRIBED reader
-cairn sync
-grep -c 'A GUARD OVER TEXT, OR OVER ONE INSTANCE' ~/.cache/subsystem-store/devrc/tests.md   # 1
-grep -c 'DO NOT RETRY THE NODE UNPIN' ~/.cache/subsystem-store/homelab-talos/devrc-ci.md    # 1
+# the pod is dash and its `echo` eats escapes — no cluster needed
+grep -n '^FROM' ~/workspace/devrc/scripts/subsystem-store-api/Dockerfile      # python:3.12-slim
+dash -c 'echo "ABSENT  $1"' _ 'sc/tab\there.md' | cat -A                      # real TAB
+bash -c 'echo "ABSENT  $1"' _ 'sc/tab\there.md' | cat -A                      # literal \t
+dash -c 'printf "ABSENT  %s\n" "$1"' _ 'sc/tab\there.md' | cat -A             # the fix
 
-# the 5 pod-newer bullets were NOT reverted (each must still say RESOLVED / UPDATED)
-grep -c 'RESOLVED f7557727c' ~/.cache/subsystem-store/datapacket-talos/tekton-builds.md     # 1
-grep -c 'RESOLVED 841d6fc4' ~/.cache/subsystem-store/homelab-talos/tekton-ci.md             # 1
+# --help drifts on a blank line
+S=$(mktemp); git -C ~/workspace/devrc show d7c4c266:scripts/subsystem-store-api/seed.sh > $S
+bash $S --help | wc -l                                     # 61
+awk 'NR==33{print ""} {print}' $S > $S.b
+bash $S.b --help | wc -l                                   # 31
+bash $S.b --help | grep -c 'allow-overwrite'               # 0
 
-# the freeze is inert against the Edit tool (reproduce, don't trust this doc)
-d=$(mktemp -d); printf 'a\nb\n' > $d/f.md; chmod 0444 $d/f.md
-printf 'x\n' >> $d/f.md 2>/dev/null && echo "shell wrote it" || echo "shell EACCES (expected)"
-# then Edit $d/f.md with the Edit tool -> succeeds, and `stat -c %a` still reports 444
+# rank 8 is closed, not open
+nix develop ~/workspace/devrc -c python3 -m pytest \
+  scripts/claude-hooks/tests/test_clawgate_task_interview_guard.py -q \
+  -k test_a_body_file_written_by_a_heredoc_on_the_same_line_is_read   # 1 passed
 
-# the 5 entries still local-only (until item 1 lands)
-comm -23 <(cd ~/.claude/analyze-service-index && find . -name '*.md' ! -name README.md -printf '%P\n' | sort) \
-         <(cd ~/.cache/subsystem-store   && find . -name '*.md' ! -name README.md -printf '%P\n' | sort)
+# the PR head's checks, per-sha (never `gh pr checks`)
+gh api /repos/innovation-upstream/devrc/commits/d7c4c266a20a99ba5e33df08f1fcd34b32122874/status \
+  --jq '.state, [.statuses[].context]'
 ```


### PR DESCRIPTION
## What ran

Round 3 of the `devrc#1304` audit ladder, dispatched **blind** against `ec16cce8..d7c4c266` — two lenses, neither told what the other was looking for: shell semantics of the `xargs -d '\n'` / TAB-key / `join -t` rework, and whether the three new tests are real.

**Round 3 is NOT clean. The ladder continues; the merge is blocked and was not attempted.**

## The result that surprised me

**Round 2's own claims all held.** All four verified and re-run rather than asserted: all *three* new tests are red at base (claim 1 understated it — the DIFFERS test is also a genuine regression test); the mutation matrix (a)–(d) all killed, each by the named guard's own message; 723/723 across two independent runs; pre-existing coverage intact.

Rounds 1 and 2 each caught the previous round lying about what it had fixed. Round 3 found the claims honest — and found four new gaps anyway. "The claims are honest" and "the code is right" are different questions.

## Four new gaps

- 🔴 **The pod's `/bin/sh` is dash, and every test runs under bash.** `Dockerfile:34` is `FROM python:3.12-slim`. dash's `echo` interprets escapes: a staged path containing the two characters `\t` emits a **real TAB** on the pod side only, so the local and pod join keys diverge, the row falls out, and a differing pod entry reads as a pure addition — a **silent clobber**, the exact defect this PR exists to remove. `\n` splits a line; `\c` swallows the next answer. `printf` fixes all three (measured).
- 🔴 **The TAB key is itself undelimited.** Round 2 moved the truncation boundary from `0x20` to `0x09` rather than removing it. **Both lenses reproduced this independently**, by different routes — a literal TAB gives a confident false refusal naming a path that does not exist.
- 🔴 **`--help` still drifts.** The commit claims the `awk` "cannot drift as the header changes." One blank line inserted into the header: **61 → 31 lines**, `allow-overwrite` occurrences **0**. No `seed.sh --help` test exists at all.
- 🔴 **Two mutants SURVIVED all 46 seed tests.** Dropping quoted paths from the local hash side while keeping `answered==staged` produces a silent clobber with the suite green; reverting this delta's `|| [ $? -eq 1 ]` to the `|| :` its own comment condemns is likewise unnoticed.

## Two corrections to the doc

- **Rank 8 is CLOSED, not open.** `test_a_body_file_written_by_a_heredoc_on_the_same_line_is_read` passes on `origin/main` (1 passed, 0.29s) — `8c27c5cf` (#1303) fixed it. The dev-host tier's known-red is gone, so a red there now means something.
- Both Tekton checks are green on `d7c4c266` per the per-sha status API. `strict` is false, so that is a claim about the PR branch only.

## Scope

Docs only — this PR changes no code. The fixes for the four gaps, and round 4, are rank 1 of the updated doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBGF4wQYsMoJH4raCue8vS