### PR TITLE
feat(alacritty): copy on selection — and state why the condition it rests on is inherited, not pinned

### DIFF
--- a/nix/programs/alacritty/default.nix
+++ b/nix/programs/alacritty/default.nix
@@ -43,6 +43,21 @@ in
       osc52 = "OnlyCopy";
     };
 
+    # Selection → clipboard on mouse release, so highlighting text alone copies
+    # it (no Ctrl+Shift+C needed). Tradeoff: every selection, even an accidental
+    # drag, replaces the system clipboard.
+    #
+    # This only matters while ALACRITTY owns the selection. It does today because
+    # tmux's mouse mode is off — but note WHY: `mouse` is off by tmux's OWN
+    # DEFAULT, and this repo does not set it anywhere (`git grep mouse -- '*tmux*'`
+    # finds nothing in `.tmux.conf` or `nix/programs/tmux/`). So the condition is
+    # inherited, not pinned. Turning tmux mouse mode ON hands the selection to
+    # tmux and this setting stops applying inside a tmux pane — which is most of
+    # this terminal's use. Measured 2026-09-05: `tmux show -gv mouse` → `off`.
+    selection = {
+      save_to_clipboard = true;
+    };
+
     # ----------------------------------------------------------------------- #
     # HINTS — clickable text in the terminal grid
     # ----------------------------------------------------------------------- #


### PR DESCRIPTION
Commits `selection.save_to_clipboard = true`, which has been **live on the workbench as an uncommitted working-tree edit** for some time.

## Why this is not just tidying

`nix` reads this file at **eval time**, so the workbench's built generation was `origin/main` **plus** this change while the laptop's was not. `ship.sh` reported exactly that on the last run:

```
🔴 DIRTY AND IN THE ARTIFACT — nix reads 1 path(s) at eval/build time
   - nix/programs/alacritty/default.nix
```

So the two hosts agreed on git sha and **not** on artifact. It was also a latent `ship.sh` rc 7 — it already skipped this host once over this exact file.

## 🔴 Behaviour change on the laptop

The laptop has never had copy-on-select. After this merges and ships, **every selection there — including an accidental drag — replaces the system clipboard.** That tradeoff has been accepted on the workbench; it is new on the other machine.

## The comment now records why the tradeoff is bounded, rather than asserting it

The original comment said "tmux mouse is off, so alacritty always gets the mouse." True — but it reads as though the repo pins it, and it does not. `git grep mouse -- '*tmux*'` finds nothing in `.tmux.conf` or `nix/programs/tmux/`; the `off` is **tmux's own default**, inherited rather than declared. That is load-bearing: turning tmux mouse mode on hands the selection to tmux and silently stops this applying **inside a pane**, which is most of this terminal's use. Measured 2026-09-05: `tmux show -gv mouse` → `off`.

## Verified this is genuine new work, not a stale orphan

- `git log -S save_to_clipboard --all` — no commit ever carried it.
- The working copy is byte-identical to **none** of the file's last 8 commits.

Both checks matter because the file had been called "WIP" on nothing stronger than its dirty status, and "restoring" a stale orphan silently reverts everything since.

## Gate — all four legs, true merged tree

`origin/main` `2f3cb58d` is an ancestor of `26600ec6`, so this **is** the merged tree. Verdicts read from each runner's own `RESULT:` line, never a piped exit code.

| tier | leg | result |
|---|---|---|
| dev host `gate.sh --tier both` | pytest | `RESULT: PASS (exit=0)` |
| dev host | node | `RESULT: PASS (exit=0)` — 1,449 tests, 0 fail (floor 1,367) |
| sandbox `nix build …pytests` | pytest | `RESULT: PASS (exit=0)` — build ran, not a cached silence |
| sandbox `nix build …nodetests` | node | `RESULT: PASS (exit=0)` — 1,449, 0 fail |

Derivations built **one at a time**. `scripts/tests/test_alacritty_hints.py` — the pin that stops an edit here silently deleting URL clicking — passes 16/16.