### PR TITLE
docs(handoff): handoff-search-index CLOSE-OUT — the doc said NOT deployed about a live, armed timer

### DIFF
--- a/claudedocs/handoff-handoff-search-index.md
+++ b/claudedocs/handoff-handoff-search-index.md
@@ -15,25 +15,27 @@ Give the handoff corpus a queryable index, because git gave it redundancy but no
 424+ docs / 8.6 MB across four repos were readable only by knowing the slug.
 
 ## State now
-- **Branch / PR:** both MERGED to `main`. No branch outstanding for this effort.
-  - `devrc#1209` → squash `45930d644` — section-grained full-text index (P1)
-  - `devrc#1244` → squash `1b769b64b` — cairn I/O-stall classifier
-  - `homelab-infra` `d2c9c49a` — rescued an untracked handoff doc (below)
-- **Shipped:** `scripts/lib/handoff_index.py` (derive + write), `scripts/lib/handoff_search.py`
-  (query CLI), `scripts/tests/test_handoff_index.py`, `scripts/testlib/hang_mechanism.py`,
-  and a `handoff-index-sync` systemd unit in `nix/home.nix`.
-- **Deploy/verify status — be precise:**
-  - Gate green on the MERGED tree at base `de677683`: dev-host `GATE: RESULT=PASS exit=0`;
-    sandbox `devrc-pytests> RESULT: PASS (exit=0)`; `devrc-nodetests> RESULT: PASS (exit=0)`.
-  - 🔴 **NOT deployed.** No `home-manager switch` was run. The unit exists in the repo only.
-  - 🔴 **The live-Postgres path has NEVER executed.** No test accepts the DDL, computes the
-    generated `tsv`, builds the GIN index, or orders by `ts_rank`. Green means the SQL was
-    constructed, never that a server accepted it.
-  - The timer ships **disarmed** (`enableHandoffIndexSync = false`) for exactly that reason.
-- **Works today with no database at all:** `handoff_search.py --offline` derives from git refs.
-  Measured 439 docs / ~4,008 sections across four repos.
-- **In flight:** an agent is fixing the unreadable-docs delete path (Open investigations below);
-  no PR number yet at time of writing.
+🔴 **THE EFFORT IS COMPLETE AND LIVE. Everything below supersedes the earlier "NOT deployed"
+status, which was true when written and is now false.**
+
+- **Merged:** `devrc#1209` (`45930d644`) index · `#1244` (`1b769b64b`) cairn I/O-stall classifier ·
+  `#1264` (`baa95854`) this doc · `#1267` (`d86b4e45`) incomplete-read delete authority ·
+  `#1295` (`3e7d79a4`) the `/resume` consumer · `#1307` (`bb6e46ee`) ARM the timer.
+  Plus `homelab-infra` `d2c9c49a` — the rescued untracked handoff doc.
+- **Deployed and verified, 2026-09-04.** `ship.sh` converged BOTH hosts at `bb6e46ee`
+  ("converged + verified — 2 hosts compared"). `readlink -f ~/.claude/skills/resume/SKILL.md`
+  resolves into a NEW store path carrying the wiring — merged AND live are separate claims and
+  both were checked.
+- 🔴 **The live-Postgres path is EXERCISED — the gap that stood from the first commit is closed.**
+  `--rebuild --write` → `wrote 4647 section row(s) … (after DELETE of 4 repo label(s) — one
+  transaction)`. The `GENERATED … STORED` `tsv` column was accepted and the GIN index built for
+  the first time; both had only ever been pinned as SQL text.
+- 🔴 **The TIMER has run on its own**, which is the only thing that tests the unit's environment:
+  `Result=success ExecMainStatus=0`, `wrote 4651 section row(s)`, `warnings: none`, 21 s,
+  next fire ~6 h. Not inferred from the flag — read from `journalctl --user -u
+  handoff-index-sync.service`.
+- **Query path live:** `backend=postgres`, `indexed_sections=4651`. 🔴 `backend=` IS the
+  discriminator; a silent fall-back to `memory` renders identically otherwise.
 
 ## Open investigations — live diagnosis state
 
@@ -73,21 +75,45 @@ Give the handoff corpus a queryable index, because git gave it redundancy but no
 - **Next probe:** ask whether any single invariant ("never delete a label this run did not
   itself measure and re-insert") would have prevented all four.
 
+### RESOLVED — the four-spelling shape: one invariant does close it, at one level
+- **Answer:** yes for `derive_repo`'s outputs, no for the level above. The shape was named in
+  `#1267`: *DELETE authority was granted by a NEGATIVE predicate — the absence of whichever
+  failure had already been seen — instead of a positive demonstration that the run holds a
+  complete replacement.* A blacklist re-opens the hole for every unmet failure, which is why
+  four rounds never converged. The fix inverts the default in one function.
+- **Observed (with values):** a round-3 blind audit enumerated every way a run can fail to hold a
+  complete replacement — `unmeasured`, `unreadable`, disk incompleteness, zero-row docs, the
+  `errors="replace"` decode — and could construct no fifth spelling through that path.
+- **Ruled out:** that a fifth spelling exists in `derive_repo`'s own outputs — the enumeration
+  above is exhaustive over its return values. via: measurement
+- **Ruled out:** that the label-computation fix widened the residual — collision groups measured
+  byte-identical across 15 input shapes before and after. via: measurement
+- **Residual, still open:** authority is demonstrated per DERIVATION and exercised per LABEL, so
+  two repos sharing a basename let the healthy twin's completeness authorise deleting the broken
+  twin's rows. Pre-existing, measured identical at base, NOT a regression. Pinned by
+  `test_through_main_the_residual_is_recorded_and_the_report_is_true`, a tripwire that FAILS the
+  day it is fixed.
+
+### RESOLVED — the unreadable-docs delete path
+- **Answer:** fixed in `#1267` after five audit/fix rounds. A repo whose docs could not be read no
+  longer obtains delete authority.
+- **Ruled out:** that setting `unmeasured` was the right fix — it would conflate "nothing came
+  back" with "not everything came back" (the conflation this module was burned by three times)
+  and would hide readable docs from `--offline` search over one bad blob. via: code
+
 ## Next steps (ranked)
-1. **Arm the index for real** — supervised `handoff_index.py --rebuild` (dry-run is the
-   default) then `--rebuild --write` against the live Postgres, watching the DDL be accepted,
-   `tsv` computed and `ts_rank` order results. Only then flip `enableHandoffIndexSync = true`
-   in `nix/home.nix` and `home-manager switch`. Nothing in any sandbox can do this step.
+1. **Watch whether `/resume` actually uses it.** The index is live and wired, but nothing yet
+   shows a session's behaviour changed. This is the only real test of whether the effort was
+   worth building; everything else is machinery. Re-read after a few `/resume` runs.
    forcing: none
-2. **Land the unreadable-docs delete fix** (Open investigations block 1). Touches
-   `scripts/lib/handoff_index.py` + `scripts/tests/test_handoff_index.py` in `devrc`.
-   IN FLIGHT: an agent was dispatched for it this session; check `gh pr list` before starting.
+2. **The label/derivation granularity residual** — `scripts/lib/handoff_index.py`,
+   `rebuild_delete_labels`. Its own round, because the fix moves the delete scope. The tripwire
+   test above fails the day someone does it, which is the intended signal.
    forcing: none
-3. **Decide whether one invariant closes the four-spelling shape** (block 2) rather than
-   patching a fifth instance later. `devrc`, same two files.
-   forcing: none
-4. **Wire a consumer.** Nothing calls `handoff_search.py` yet — no skill, no script. Until
-   `/resume` or a subagent queries it, the index is shipped and unused.
+3. **The empty-label display residual** — an empty label renders blank on FOUR surfaces; the
+   operator sees THAT rows were deleted, not WHICH. 🔴 The fix belongs at `main` as an input
+   rejection (`RC_USAGE`), NEVER in the renderers — a `label or "(unnamed)"` there would
+   re-introduce the exact falsy-string shape three audit rounds swept out of the decision path.
    forcing: none
 
 ## Gotchas / decisions / dead-ends
@@ -121,19 +147,41 @@ Give the handoff corpus a queryable index, because git gave it redundancy but no
   blocks a merge and the human is the gate. Run both tiers on the MERGED tree and name the base
   sha in the claim.
 
+- 🔴 **A HAND-RUN NEEDS `KUBECONFIG=$KC_HOMELAB`.** This repo leaves `KUBECONFIG` unset on purpose
+  so a bare `kubectl` cannot hit prod, so the DSN read dies with `CalledProcessError` on
+  `kubectl -n mailbox get secret` — loudly, before touching the database. The UNIT sets it; only
+  the hand-run path lacks it. Measured while arming: the first `--write` failed exactly this way.
+- **`indexed_docs` and the derivation's `docs=` count different things, both correctly.** 464
+  derived vs 381 indexed is NOT slug collisions: sections match EXACTLY at every level, and an
+  overwritten doc would have taken its sections with it. The gap is docs that yield zero sections.
+- **`indexed_*` are GLOBAL totals; `in_scope_*` are the filtered counts.** Reading a truncated
+  line and seeing only the global pair looks exactly like a broken `--repo` filter. It is not.
+- **The audit ladder ran 5 rounds on `#1209` and 3 on `#1267`, and EVERY round's findings were
+  created or half-closed by the previous round's fix.** Both ladders were stopped on the
+  prose-payload criterion, not on a clean round: by the end the payload was ~32 executable lines
+  out of 244 added, and most findings were prose claiming more than the code delivered. When a
+  defect fix and a reword are the same edit the round-over-round gate is structurally inert.
+- **Rejected: S3/MinIO.** 8.6 MB corpus. Object storage adds a fourth copy and key-lookup, not
+  query; git already gives redundancy.
+- **Rejected: adding `.md` to `captured_text_scan.SCANNED_SUFFIXES`.** Its premise is free text
+  where a data field should be; handoff docs are prose throughout, so it would fire on every doc
+  and be disabled.
+
 ## How to verify
 ```bash
-# 1. The search works with no database at all, and reports its own scope:
-python3 ~/workspace/devrc/scripts/lib/handoff_search.py --offline --query "fsync" --limit 3
-#    expect: a recall banner, `indexed_docs=N indexed_sections=M backend=memory`, ranked hits.
-#    A zero beside indexed_docs=0 is a BROKEN INDEX, not an absent answer.
+# 1. The timer's OWN run — the only thing that tests the unit's environment:
+systemctl --user show handoff-index-sync.service -p Result -p ExecMainStatus
+journalctl --user -u handoff-index-sync.service --no-pager -n 20
+#    expect Result=success, ExecMainStatus=0, "wrote N section row(s) … one transaction".
 
-# 2. --repo takes a LABEL, not a path (an unknown value is refused, not silently empty):
-python3 ~/workspace/devrc/scripts/lib/handoff_search.py --offline --repo devrc --query drift-check
+# 2. The DB path answers (backend= is the discriminator, NOT the row count):
+KUBECONFIG=$KC_HOMELAB python3 ~/workspace/devrc/scripts/lib/handoff_search.py --query fsync --limit 3
+#    expect backend=postgres. backend=memory means it silently fell back and you verified nothing.
 
-# 3. Durability holes are reported, never indexed:
-python3 ~/workspace/devrc/scripts/lib/handoff_index.py --repo ~/workspace/devrc   # dry-run is the default
+# 3. The consumer is LIVE, not merely merged (readlink is the arbiter):
+readlink -f ~/.claude/skills/resume/SKILL.md          # must resolve into /nix/store
+grep -c 'handoff_search.py --offline' ~/.claude/skills/resume/SKILL.md   # must be 1
 
-# 4. The shipped code is on main (verify by CONTENT — a squash is never an ancestor):
-git -C ~/workspace/devrc cat-file -e origin/main:scripts/lib/handoff_index.py && echo present
+# 4. No database needed for the offline path:
+python3 ~/workspace/devrc/scripts/lib/handoff_search.py --offline --query "drift-check" --limit 2
 ```


### PR DESCRIPTION
The doc was stale in the one direction that matters: `/resume` reads it first, and it said

> 🔴 **NOT deployed.** No `home-manager switch` was run. The unit exists in the repo only.

against `timer=enabled`, `Result=success`, 4,651 rows live. It also listed 2 of 6 merged PRs and showed all four ranked steps open when all four are done.

Records the close-out:
- **All four ranked steps done.** Arm the index ✅ · unreadable-docs delete fix ✅ (#1267) · decide the four-spelling shape ✅ (answered, below) · wire a consumer ✅ (#1295).
- **The live-Postgres gap is closed** — the `GENERATED … STORED` `tsv` and the GIN index had never been executed by a server, only pinned as SQL text. Now both, plus the timer's own run (`Result=success`, `wrote 4651 section row(s)`), which is the only thing that tests the unit's environment.
- **The four-spelling shape is answered:** DELETE authority was granted by a *negative* predicate — the absence of whichever failure had already been seen — rather than a positive demonstration that the run holds a complete replacement. A blacklist re-opens the hole for every unmet failure, which is why four rounds never converged. Closed at one level; the residual one level up (authority per derivation, DELETE per label) stays open with a tripwire that fails the day it is fixed.
- Both ladders (5 rounds on #1209, 3 on #1267) were stopped on the **prose-payload criterion, not a clean round** — recorded so it doesn't read as convergence.

Status sections replace, findings append, so the earlier diagnosis text survives verbatim beneath the resolutions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)